### PR TITLE
fix(chat): Show assistant status in @-mentioned threads

### DIFF
--- a/src/chat/app-runtime.ts
+++ b/src/chat/app-runtime.ts
@@ -24,7 +24,7 @@ export interface AppRuntimeIncomingMessage {
 }
 
 export interface AppRuntimeThreadHandle {
-  id?: string;
+  id: string;
   runId?: string;
   post: (message: any) => Promise<unknown>;
   refresh?: () => Promise<void>;

--- a/src/chat/bot.ts
+++ b/src/chat/bot.ts
@@ -105,12 +105,8 @@ function escapeXml(value: string): string {
     .replaceAll("'", "&apos;");
 }
 
-function getThreadId(thread: unknown, message: unknown): string | undefined {
-  return (
-    toOptionalString((thread as { id?: unknown }).id) ??
-    toOptionalString((message as { threadId?: unknown }).threadId) ??
-    toOptionalString((message as { threadTs?: unknown }).threadTs)
-  );
+function getThreadId(thread: unknown, _message: unknown): string | undefined {
+  return toOptionalString((thread as { id?: unknown }).id);
 }
 
 function getThreadTs(thread: unknown, message: unknown): string | undefined {
@@ -169,7 +165,7 @@ function pruneAssistantThreadMeta(nowMs: number): void {
 }
 
 function createProgressReporter(thread: {
-  id?: string;
+  id: string;
 }) {
   let active = false;
   let currentStatus = "Working...";
@@ -186,9 +182,8 @@ function createProgressReporter(thread: {
     currentStatus = safeText;
     lastStatusAt = Date.now();
 
-    const threadId = toOptionalString(thread.id);
-    const assistantThread = threadId ? assistantThreadMetaById.get(threadId) : undefined;
-    if (!assistantThread || !threadId) {
+    const assistantThread = assistantThreadMetaById.get(thread.id);
+    if (!assistantThread) {
       return;
     }
     assistantThread.updatedAtMs = Date.now();


### PR DESCRIPTION
When jr is @-mentioned in an existing thread (not an assistant-initiated thread), the Assistants API status text (e.g. "Thinking...", "Searching web...") never appeared — users only saw a basic typing indicator bar.

Two root causes:

1. `setAssistantStatus` is guarded by a lookup in `assistantThreadMetaById`, which is only populated by assistant lifecycle events. @-mention threads never got registered, so status updates were silently dropped.
2. `thread.startTyping(status)` was called redundantly, showing a basic typing bar that added no value when the Assistants API status is the intended UX.

This PR registers thread metadata in `assistantThreadMetaById` during `replyToThread` so status works for all threads, removes the redundant `startTyping` call and its dead code in `AppRuntimeThreadHandle`, and bumps `SLACK_LOADING_STATUS_MAX_LENGTH` from 50 to 100 since the Slack API doesn't document a character limit for this field.

Fixes #13