### PR TITLE
fix(chat): Use Chat SDK primitives for streaming, status, and file uploads

### DIFF
--- a/evals/behavior-harness.ts
+++ b/evals/behavior-harness.ts
@@ -6,6 +6,7 @@ import {
   type AppRuntimeAssistantLifecycleEvent,
   type AppRuntimeThreadHandle
 } from "@/chat/app-runtime";
+import { parseSlackThreadId } from "@/chat/slack-context";
 import { appSlackRuntime, bot, resetBotDepsForTests, setBotDepsForTests } from "@/chat/bot";
 import { registerLogRecordSink, type EmittedLogRecord } from "@/chat/logging";
 import { generateAssistantReply } from "@/chat/respond";
@@ -247,9 +248,6 @@ class FakeSlackAdapter {
     this.promptCalls.push({ channelId, threadTs, prompts });
   }
 
-  async setAssistantStatus(): Promise<void> {
-    // No-op for eval harness.
-  }
 }
 
 class FakeThread implements AppRuntimeThreadHandle {
@@ -257,6 +255,7 @@ class FakeThread implements AppRuntimeThreadHandle {
     state: Promise<Record<string, unknown>>;
     setState: (state: Record<string, unknown>, options?: { replace?: boolean }) => Promise<void>;
   };
+  readonly channelId?: string;
   readonly id: string;
   readonly posts: unknown[] = [];
   readonly runId?: string;
@@ -273,6 +272,7 @@ class FakeThread implements AppRuntimeThreadHandle {
     threadTs?: string;
   }) {
     this.id = args.id;
+    this.channelId = parseSlackThreadId(args.id)?.channelId;
     this.runId = args.runId;
     this.threadTs = args.threadTs;
     this.stateData = { ...(args.state ?? {}) };
@@ -322,6 +322,10 @@ class FakeThread implements AppRuntimeThreadHandle {
         return newContent;
       }
     };
+  }
+
+  async startTyping(_status?: string): Promise<void> {
+    // No-op for eval harness.
   }
 
   async subscribe(): Promise<void> {

--- a/src/chat/app-runtime.ts
+++ b/src/chat/app-runtime.ts
@@ -25,8 +25,10 @@ export interface AppRuntimeIncomingMessage {
 
 export interface AppRuntimeThreadHandle {
   id: string;
+  channelId?: string;
   runId?: string;
   post: (message: any) => Promise<unknown>;
+  startTyping?: (status?: string) => Promise<void>;
   refresh?: () => Promise<void>;
   recentMessages?: unknown[];
   setState?: (state: Record<string, unknown>, options?: { replace?: boolean }) => Promise<void>;
@@ -68,7 +70,7 @@ export interface AppSlackRuntimeDependencies<
   TMessage extends AppRuntimeIncomingMessage
 > {
   assistantUserName: string;
-  getChannelId: (message: TMessage) => string | undefined;
+  getChannelId: (thread: TThread, message: TMessage) => string | undefined;
   getPreparedConversationContext: (preparedState: TPreparedState) => string | undefined;
   getThreadId: (thread: TThread, message: TMessage) => string | undefined;
   getWorkflowRunId: (thread: TThread, message: TMessage) => string | undefined;
@@ -193,7 +195,7 @@ export function createAppSlackRuntime<
     async handleNewMention(thread: TThread, message: TMessage): Promise<void> {
       try {
         const threadId = deps.getThreadId(thread, message);
-        const channelId = deps.getChannelId(message);
+        const channelId = deps.getChannelId(thread, message);
         const workflowRunId = deps.getWorkflowRunId(thread, message);
         const context = logContext({
           threadId,
@@ -220,7 +222,7 @@ export function createAppSlackRuntime<
           logContext({
             threadId: deps.getThreadId(thread, message),
             requesterId: message.author.userId,
-            channelId: deps.getChannelId(message),
+            channelId: deps.getChannelId(thread, message),
             workflowRunId: deps.getWorkflowRunId(thread, message)
           }),
           {},
@@ -234,7 +236,7 @@ export function createAppSlackRuntime<
     async handleSubscribedMessage(thread: TThread, message: TMessage): Promise<void> {
       try {
         const threadId = deps.getThreadId(thread, message);
-        const channelId = deps.getChannelId(message);
+        const channelId = deps.getChannelId(thread, message);
         const workflowRunId = deps.getWorkflowRunId(thread, message);
         const rawUserText = message.text ?? "";
         const userText = deps.stripLeadingBotMention(rawUserText, {
@@ -315,7 +317,7 @@ export function createAppSlackRuntime<
           logContext({
             threadId: deps.getThreadId(thread, message),
             requesterId: message.author.userId,
-            channelId: deps.getChannelId(message),
+            channelId: deps.getChannelId(thread, message),
             workflowRunId: deps.getWorkflowRunId(thread, message)
           }),
           {},

--- a/src/chat/bot.ts
+++ b/src/chat/bot.ts
@@ -24,7 +24,7 @@ import {
   coerceThreadArtifactsState,
   type ThreadArtifactsState
 } from "@/chat/slack-actions/types";
-import { resolveSlackChannelIdFromMessage } from "@/chat/slack-context";
+import { parseSlackThreadId, resolveSlackChannelIdFromMessage } from "@/chat/slack-context";
 import { createChannelConfigurationService } from "@/chat/configuration/service";
 import type { ChannelConfigurationService } from "@/chat/configuration/types";
 import { truncateStatusText } from "@/chat/status-format";
@@ -109,13 +109,6 @@ function getThreadId(thread: unknown, _message: unknown): string | undefined {
   return toOptionalString((thread as { id?: unknown }).id);
 }
 
-function getThreadTs(thread: unknown, message: unknown): string | undefined {
-  return (
-    toOptionalString((message as { threadTs?: unknown }).threadTs) ??
-    toOptionalString((thread as { threadTs?: unknown }).threadTs)
-  );
-}
-
 function getWorkflowRunId(thread: unknown, message: unknown): string | undefined {
   return (
     toOptionalString((thread as { runId?: unknown }).runId) ??
@@ -123,78 +116,34 @@ function getWorkflowRunId(thread: unknown, message: unknown): string | undefined
   );
 }
 
-function getChannelId(message: unknown): string | undefined {
-  return resolveSlackChannelIdFromMessage(message);
+function getChannelId(thread: unknown, message: unknown): string | undefined {
+  return (thread as { channelId?: string }).channelId ?? resolveSlackChannelIdFromMessage(message);
 }
 
-interface AssistantThreadMeta {
-  channelId: string;
-  threadTs: string;
-  updatedAtMs: number;
+function getThreadTs(threadId: string | undefined): string | undefined {
+  return parseSlackThreadId(threadId)?.threadTs;
 }
 
 function getSlackAdapter(): SlackAdapter {
   return bot.getAdapter("slack") as SlackAdapter;
 }
 
-const assistantThreadMetaById = new Map<string, AssistantThreadMeta>();
-const ASSISTANT_THREAD_META_MAX = 500;
-const ASSISTANT_THREAD_META_TTL_MS = 1000 * 60 * 60 * 24;
 const STATUS_UPDATE_DEBOUNCE_MS = 1000;
 const SLACK_LOADING_STATUS_MAX_LENGTH = 100;
 
-function pruneAssistantThreadMeta(nowMs: number): void {
-  for (const [threadId, meta] of assistantThreadMetaById) {
-    if (nowMs - meta.updatedAtMs > ASSISTANT_THREAD_META_TTL_MS) {
-      assistantThreadMetaById.delete(threadId);
-    }
-  }
-
-  if (assistantThreadMetaById.size <= ASSISTANT_THREAD_META_MAX) {
-    return;
-  }
-
-  const overflow = assistantThreadMetaById.size - ASSISTANT_THREAD_META_MAX;
-  const oldest = [...assistantThreadMetaById.entries()]
-    .sort((a, b) => a[1].updatedAtMs - b[1].updatedAtMs)
-    .slice(0, overflow);
-
-  for (const [threadId] of oldest) {
-    assistantThreadMetaById.delete(threadId);
-  }
-}
-
-function createProgressReporter(thread: {
-  id: string;
-}) {
+function createProgressReporter(thread: { startTyping?: (status?: string) => Promise<void> }) {
   let active = false;
-  let currentStatus = "Working...";
+  let currentStatus = "";
   let lastStatusAt = 0;
   let pendingStatus: string | null = null;
   let pendingTimer: ReturnType<typeof setTimeout> | null = null;
   const sanitizeStatus = (text: string): string => truncateStatusText(text, SLACK_LOADING_STATUS_MAX_LENGTH);
 
-  const postAssistantStatus = async (text: string): Promise<void> => {
-    const safeText = sanitizeStatus(text);
-    if (!safeText) {
-      return;
-    }
-    currentStatus = safeText;
+  const postStatus = async (text: string): Promise<void> => {
+    currentStatus = text;
     lastStatusAt = Date.now();
-
-    const assistantThread = assistantThreadMetaById.get(thread.id);
-    if (!assistantThread) {
-      return;
-    }
-    assistantThread.updatedAtMs = Date.now();
-
     try {
-      await getSlackAdapter().setAssistantStatus(
-        assistantThread.channelId,
-        assistantThread.threadTs,
-        safeText,
-        [safeText]
-      );
+      await thread.startTyping?.(text);
     } catch {
       // Best effort only.
     }
@@ -217,7 +166,7 @@ function createProgressReporter(thread: {
     const next = pendingStatus;
     clearPending();
     if (next !== currentStatus) {
-      await postAssistantStatus(next);
+      await postStatus(next);
     }
   };
 
@@ -225,7 +174,7 @@ function createProgressReporter(thread: {
     async start() {
       active = true;
       clearPending();
-      await postAssistantStatus("Thinking...");
+      await postStatus("Thinking...");
     },
     async stop() {
       active = false;
@@ -241,7 +190,7 @@ function createProgressReporter(thread: {
       const elapsed = now - lastStatusAt;
       if (elapsed >= STATUS_UPDATE_DEBOUNCE_MS) {
         clearPending();
-        await postAssistantStatus(sanitizedStatus);
+        await postStatus(sanitizedStatus);
         return;
       }
 
@@ -256,19 +205,6 @@ function createProgressReporter(thread: {
       }, Math.max(1, STATUS_UPDATE_DEBOUNCE_MS - elapsed));
     }
   };
-}
-
-interface EditableSentMessage {
-  edit: (newContent: unknown) => Promise<unknown>;
-}
-
-function isEditableSentMessage(value: unknown): value is EditableSentMessage {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-
-  const candidate = value as { edit?: unknown };
-  return typeof candidate.edit === "function";
 }
 
 function createTextStreamBridge() {
@@ -1414,9 +1350,7 @@ async function prepareTurnState(args: {
       channelId: args.context.channelId,
       requesterId: args.context.requesterId,
       workflowRunId: args.context.workflowRunId,
-      threadTs:
-        toOptionalString(args.message.threadTs) ??
-        toOptionalString((args.thread as { threadTs?: unknown }).threadTs)
+      threadTs: getThreadTs(args.context.threadId)
     });
   }
 
@@ -1474,18 +1408,9 @@ async function replyToThread(
   }
 
   const threadId = getThreadId(thread, message);
-  const threadTs = getThreadTs(thread, message);
-  const channelId = getChannelId(message);
+  const channelId = getChannelId(thread, message);
+  const threadTs = getThreadTs(threadId);
   const workflowRunId = getWorkflowRunId(thread, message);
-
-  if (threadId && channelId && threadTs && !assistantThreadMetaById.has(threadId)) {
-    assistantThreadMetaById.set(threadId, {
-      channelId,
-      threadTs,
-      updatedAtMs: Date.now()
-    });
-    pruneAssistantThreadMeta(Date.now());
-  }
 
   await withSpan(
     "workflow.reply",
@@ -1725,14 +1650,6 @@ async function initializeAssistantThread(event: {
   channelId: string;
   threadTs: string;
 }): Promise<void> {
-  const nowMs = Date.now();
-  assistantThreadMetaById.set(event.threadId, {
-    channelId: event.channelId,
-    threadTs: event.threadTs,
-    updatedAtMs: nowMs
-  });
-  pruneAssistantThreadMeta(nowMs);
-
   const slack = getSlackAdapter();
   await slack.setAssistantTitle(event.channelId, event.threadTs, "Junior");
   await slack.setSuggestedPrompts(event.channelId, event.threadTs, [

--- a/src/chat/prompt.ts
+++ b/src/chat/prompt.ts
@@ -137,7 +137,7 @@ function baseSystemPrompt(): string {
     "- Prefer actionable next steps over generic explanations.",
     "- When the user gives a clear task, execute it immediately in this turn.",
     "- Do not ask for permission to proceed when the request is already clear.",
-    "- Do not provide progress promises like 'give me a moment' or 'want me to proceed'.",
+    "- When your response requires significant work (multiple tool calls, sandbox execution), lead with a brief one-line acknowledgment so the user sees immediate feedback. Do not give ongoing status updates or ask permission to proceed.",
     "- Never ask the user to re-tag or re-invoke for a clear task; continue execution in this turn.",
     "- Never claim you cannot access tools in this turn. If prior results are empty, run tools now.",
     "- If critical input is missing and cannot be discovered with tools, ask one direct clarifying question.",
@@ -326,7 +326,7 @@ export function buildSystemPrompt(params: {
         "- Use plain Slack-safe markdown (headings, bullets, short code blocks).",
         "- Keep normal responses brief and scannable.",
         "- If depth is needed, start with a concise summary and then provide fuller detail.",
-        "- Do not include process chatter, preflight confirmations, or status-only updates in the final answer.",
+        "- A brief initial acknowledgment before significant tool work is fine; avoid extended process chatter or repeated status updates.",
         "- Avoid tables unless explicitly requested.",
         "- End every turn with a final user-facing markdown response.",
         "</output>"

--- a/src/chat/slack-context.ts
+++ b/src/chat/slack-context.ts
@@ -2,7 +2,9 @@ function toOptionalString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
-export function resolveSlackChannelIdFromThreadId(threadId: string | undefined): string | undefined {
+export function parseSlackThreadId(
+  threadId: string | undefined
+): { channelId: string; threadTs: string } | undefined {
   const normalizedThreadId = toOptionalString(threadId);
   if (!normalizedThreadId) {
     return undefined;
@@ -13,7 +15,17 @@ export function resolveSlackChannelIdFromThreadId(threadId: string | undefined):
     return undefined;
   }
 
-  return toOptionalString(parts[1]);
+  const channelId = toOptionalString(parts[1]);
+  const threadTs = toOptionalString(parts[2]);
+  if (!channelId || !threadTs) {
+    return undefined;
+  }
+
+  return { channelId, threadTs };
+}
+
+export function resolveSlackChannelIdFromThreadId(threadId: string | undefined): string | undefined {
+  return parseSlackThreadId(threadId)?.channelId;
 }
 
 export function resolveSlackChannelIdFromMessage(message: unknown): string | undefined {

--- a/src/chat/tools/image-generate.ts
+++ b/src/chat/tools/image-generate.ts
@@ -62,7 +62,7 @@ function parseImageGenerationError(status: number, body: string, model: string):
 export function createImageGenerateTool(hooks: ToolHooks) {
   return tool({
     description:
-      "Generate image files from a prompt. Use when the user explicitly asks for image creation. Do not use for text-only tasks.",
+      "Generate images from a prompt. Use when the user wants to visually show or represent something — feelings, concepts, art, humor, or any visual idea. Also use for explicit image creation requests.",
     inputSchema: Type.Object({
       prompt: Type.String({
         minLength: 1,

--- a/tests/behavior-harness.test.ts
+++ b/tests/behavior-harness.test.ts
@@ -51,8 +51,7 @@ describe("behavior harness", () => {
         titleCalls: [],
         promptCalls: [],
         setAssistantTitle: async () => undefined,
-        setSuggestedPrompts: async () => undefined,
-        setAssistantStatus: async () => undefined
+        setSuggestedPrompts: async () => undefined
       },
       toolCalls: []
     };

--- a/tests/bot-image-hydration.test.ts
+++ b/tests/bot-image-hydration.test.ts
@@ -11,7 +11,6 @@ vi.mock("chat", () => {
     onAssistantContextChanged() {}
     getAdapter() {
       return {
-        setAssistantStatus: async () => undefined,
         setAssistantTitle: async () => undefined,
         setSuggestedPrompts: async () => undefined
       };
@@ -46,24 +45,34 @@ vi.mock("@/chat/slack-user", () => ({
 
 interface TestThread {
   id: string;
+  channelId?: string;
   runId?: string;
   readonly state: Promise<Record<string, unknown>>;
   post: (message: unknown) => Promise<unknown>;
+  startTyping: (status?: string) => Promise<void>;
   subscribe: () => Promise<void>;
   setState: (state: Record<string, unknown>, options?: { replace?: boolean }) => Promise<void>;
   getState: () => Record<string, unknown>;
+}
+
+function parseChannelFromThreadId(threadId: string): string | undefined {
+  const parts = threadId.split(":");
+  if (parts.length === 3 && parts[0] === "slack" && parts[1]) return parts[1];
+  return undefined;
 }
 
 function createThread(args: { id: string; state?: Record<string, unknown> }): TestThread {
   let stateData: Record<string, unknown> = { ...(args.state ?? {}) };
   return {
     id: args.id,
+    channelId: parseChannelFromThreadId(args.id),
     get state(): Promise<Record<string, unknown>> {
       return Promise.resolve(stateData);
     },
     async post(message: unknown): Promise<unknown> {
       return message;
     },
+    async startTyping(): Promise<void> {},
     async subscribe(): Promise<void> {},
     async setState(next: Record<string, unknown>, options?: { replace?: boolean }): Promise<void> {
       if (options?.replace) {
@@ -100,7 +109,7 @@ describe("bot image hydration", () => {
       listThreadReplies: listThreadRepliesMock
     });
     const firstThread = createThread({
-      id: "thread-image-hydration",
+      id: "slack:C_IMAGE:1700000000.000",
       state: {
         conversation: {
           schemaVersion: 1,
@@ -142,9 +151,8 @@ describe("bot image hydration", () => {
       id: "1700000000.200",
       text: "/brief on this candidate",
       isMention: true,
-      threadId: "thread-image-hydration",
-      threadTs: "1700000000.000",
-      channelId: "C-image",
+      threadId: "slack:C_IMAGE:1700000000.000",
+      channelId: "C_IMAGE",
       author: {
         userId: "U-user",
         userName: "user",
@@ -155,7 +163,7 @@ describe("bot image hydration", () => {
 
     const persisted = firstThread.getState();
     const secondThread = createThread({
-      id: "thread-image-hydration",
+      id: "slack:C_IMAGE:1700000000.000",
       state: persisted
     });
 
@@ -163,9 +171,8 @@ describe("bot image hydration", () => {
       id: "1700000000.300",
       text: "follow up without new images",
       isMention: true,
-      threadId: "thread-image-hydration",
-      threadTs: "1700000000.000",
-      channelId: "C-image",
+      threadId: "slack:C_IMAGE:1700000000.000",
+      channelId: "C_IMAGE",
       author: {
         userId: "U-user",
         userName: "user",
@@ -207,7 +214,7 @@ describe("bot image hydration", () => {
     });
 
     const thread = createThread({
-      id: "thread-file-upload",
+      id: "slack:C_UPLOAD:1700000000.000",
       state: {}
     });
 
@@ -215,9 +222,8 @@ describe("bot image hydration", () => {
       id: "1700000000.200",
       text: "generate an image",
       isMention: true,
-      threadId: "thread-file-upload",
-      threadTs: "1700000000.000",
-      channelId: "C-upload",
+      threadId: "slack:C_UPLOAD:1700000000.000",
+      channelId: "C_UPLOAD",
       author: {
         userId: "U-user",
         userName: "user",
@@ -229,7 +235,7 @@ describe("bot image hydration", () => {
     expect(uploadFilesToThreadMock).toHaveBeenCalledTimes(1);
     expect(uploadFilesToThreadMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        channelId: "C-upload",
+        channelId: "C_UPLOAD",
         threadTs: "1700000000.000",
         files: [
           expect.objectContaining({
@@ -271,7 +277,7 @@ describe("bot image hydration", () => {
 
     const postSpy = vi.fn().mockResolvedValue(undefined);
     const thread = createThread({
-      id: "thread-upload-fail",
+      id: "slack:C_UPLOADFAIL:1700000000.000",
       state: {}
     });
     thread.post = postSpy;
@@ -280,9 +286,8 @@ describe("bot image hydration", () => {
       id: "1700000000.200",
       text: "generate an image",
       isMention: true,
-      threadId: "thread-upload-fail",
-      threadTs: "1700000000.000",
-      channelId: "C-upload-fail",
+      threadId: "slack:C_UPLOADFAIL:1700000000.000",
+      channelId: "C_UPLOADFAIL",
       author: {
         userId: "U-user",
         userName: "user",

--- a/tests/slack-context.test.ts
+++ b/tests/slack-context.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveSlackChannelIdFromMessage, resolveSlackChannelIdFromThreadId } from "@/chat/slack-context";
+import { parseSlackThreadId, resolveSlackChannelIdFromMessage, resolveSlackChannelIdFromThreadId } from "@/chat/slack-context";
 
 describe("slack context", () => {
   it("prefers message.channelId when available", () => {
@@ -45,5 +45,30 @@ describe("slack context", () => {
     expect(resolveSlackChannelIdFromThreadId("slack::1700000000.900")).toBeUndefined();
     expect(resolveSlackChannelIdFromThreadId("slack:C111")).toBeUndefined();
     expect(resolveSlackChannelIdFromThreadId("not-slack:C111:1700000000.900")).toBeUndefined();
+  });
+});
+
+describe("parseSlackThreadId", () => {
+  it("parses valid slack thread id into channelId and threadTs", () => {
+    expect(parseSlackThreadId("slack:C123:1700000000.100")).toEqual({
+      channelId: "C123",
+      threadTs: "1700000000.100"
+    });
+  });
+
+  it("returns undefined for empty-part thread ids", () => {
+    expect(parseSlackThreadId("slack::1700000000.100")).toBeUndefined();
+    expect(parseSlackThreadId("slack:C123:")).toBeUndefined();
+    expect(parseSlackThreadId("slack: : ")).toBeUndefined();
+  });
+
+  it("returns undefined for malformed thread ids", () => {
+    expect(parseSlackThreadId("slack:C123")).toBeUndefined();
+    expect(parseSlackThreadId("not-slack:C123:1700000000.100")).toBeUndefined();
+    expect(parseSlackThreadId("just-a-string")).toBeUndefined();
+  });
+
+  it("returns undefined for undefined input", () => {
+    expect(parseSlackThreadId(undefined)).toBeUndefined();
   });
 });


### PR DESCRIPTION
Replace the custom `assistantThreadMetaById` cache and direct `setAssistantStatus` adapter bypass with the Chat SDK's built-in `thread.startTyping()` and `thread.channelId`.

The old approach manually called `getSlackAdapter().setAssistantStatus(channelId, threadTs, ...)` which required a global in-memory map to store `{channelId, threadTs}` per thread. This map silently failed when entries weren't populated — which happened because `threadTs` resolution was scattered across four separate helper functions with inconsistent fallback chains. The same missing `threadTs` caused file uploads to be silently skipped.

The Chat SDK already handles all of this: `thread.startTyping(status)` delegates to the Slack adapter's `assistant.threads.setStatus` with proper `decodeThreadId` + `withToken` + error handling. `thread.channelId` is a first-class property. No map needed.

**What changed:**

- Add `parseSlackThreadId` as single canonical parser for the `slack:CHANNEL:TS` format
- Rewrite `createProgressReporter` to use `thread.startTyping()` instead of the adapter bypass
- Derive `channelId` from `thread.channelId` (Chat SDK property) with message fallback
- Derive `threadTs` from `parseSlackThreadId` — single source of truth, no scattered helpers
- Remove ~80 lines: `AssistantThreadMeta` interface, map, pruning, population in two call sites
- Remove dead `EditableSentMessage` / `isEditableSentMessage` code
- Update system prompt to allow brief initial ack before heavy tool work (was "no progress promises")
- Broaden `imageGenerate` tool description to cover visual concepts, not just explicit creation requests

Verified against the actual Chat SDK contracts: `SlackAdapter.startTyping` calls the same `assistant.threads.setStatus` API with identical parameters (`status` + `loading_messages: [status]`).

Fixes #12