### PR TITLE
fix(chat): Normalize Slack thread IDs from raw event payload

### DIFF
--- a/src/chat/chat-background-patch.ts
+++ b/src/chat/chat-background-patch.ts
@@ -29,6 +29,37 @@ type ChatLike = {
 
 const PATCH_FLAG = Symbol.for("junior.chat.runInBackgroundPatch");
 
+function nonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+// Derive canonical Slack thread IDs from the raw event payload (channel + thread_ts/ts)
+// rather than trusting adapter-provided thread ID parts which may be incomplete.
+export function normalizeIncomingSlackThreadId(threadId: string, message: unknown): string {
+  if (!threadId.startsWith("slack:")) {
+    return threadId;
+  }
+
+  if (!message || typeof message !== "object") {
+    return threadId;
+  }
+
+  const raw = (message as { raw?: Record<string, unknown> }).raw;
+  if (!raw || typeof raw !== "object") {
+    return threadId;
+  }
+
+  const channelId = nonEmptyString(raw.channel);
+  const threadTs = nonEmptyString(raw.thread_ts) ?? nonEmptyString(raw.ts);
+  if (!channelId || !threadTs) {
+    return threadId;
+  }
+
+  return `slack:${channelId}:${threadTs}`;
+}
+
 function scheduleBackgroundWork(
   instance: ChatLike,
   options: BackgroundWebhookOptions | undefined,
@@ -67,7 +98,11 @@ export function installChatBackgroundPatch(): void {
           typeof messageOrFactory === "function"
             ? await (messageOrFactory as () => Promise<unknown>)()
             : messageOrFactory;
-        await this.handleIncomingMessage(adapter, threadId, message);
+        const normalizedThreadId = normalizeIncomingSlackThreadId(threadId, message);
+        if (message && typeof message === "object" && "threadId" in message) {
+          (message as Record<string, unknown>).threadId = normalizedThreadId;
+        }
+        await this.handleIncomingMessage(adapter, normalizedThreadId, message);
       } catch (err) {
         this.logger?.error?.("Message processing error", { error: err, threadId });
       }

--- a/tests/chat-background-patch.test.ts
+++ b/tests/chat-background-patch.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { normalizeIncomingSlackThreadId } from "@/chat/chat-background-patch";
+
+describe("normalizeIncomingSlackThreadId", () => {
+  it("keeps canonical slack thread ids unchanged", () => {
+    expect(
+      normalizeIncomingSlackThreadId("slack:C123:1700000000.100", {
+        raw: { channel: "C123", ts: "1700000000.100" }
+      })
+    ).toBe("slack:C123:1700000000.100");
+  });
+
+  it("repairs slack thread ids missing thread timestamp from raw.ts", () => {
+    expect(
+      normalizeIncomingSlackThreadId("slack:D123:", {
+        raw: { channel: "D123", ts: "1700000000.200" }
+      })
+    ).toBe("slack:D123:1700000000.200");
+  });
+
+  it("uses raw.thread_ts when present", () => {
+    expect(
+      normalizeIncomingSlackThreadId("slack:C123:", {
+        raw: { channel: "C123", thread_ts: "1700000000.300", ts: "1700000000.400" }
+      })
+    ).toBe("slack:C123:1700000000.300");
+  });
+
+  it("returns original thread id when raw slack fields are missing", () => {
+    expect(normalizeIncomingSlackThreadId("slack:D123:", {})).toBe("slack:D123:");
+  });
+
+  it("ignores adapter thread id parts and uses raw event fields", () => {
+    expect(
+      normalizeIncomingSlackThreadId("slack:WRONG:WRONG", {
+        raw: { channel: "D123", ts: "1700000000.500" }
+      })
+    ).toBe("slack:D123:1700000000.500");
+  });
+
+  it("returns non-slack thread ids as-is", () => {
+    expect(normalizeIncomingSlackThreadId("thread-123", {})).toBe("thread-123");
+  });
+
+  it("returns original thread id when message is null or undefined", () => {
+    expect(normalizeIncomingSlackThreadId("slack:C123:", null)).toBe("slack:C123:");
+    expect(normalizeIncomingSlackThreadId("slack:C123:", undefined)).toBe("slack:C123:");
+  });
+});


### PR DESCRIPTION
Derive canonical Slack thread IDs from the raw event payload fields
(`channel` + `thread_ts`/`ts`) instead of trusting adapter-provided
thread ID parts, which may be incomplete (e.g. `slack:D123:` with a
missing timestamp).

The adapter sometimes constructs thread IDs before all Slack event
fields are available, resulting in broken IDs that prevent thread
lookups. This normalizes them at the `processMessage` boundary using
the raw event as the source of truth, and keeps `message.threadId`
in sync with the corrected value.

Also guards against `null`/`undefined` messages that could cause a
TypeError when accessing `.raw`.