### PR TITLE
fix(chat): Clear assistant status indicator on progress stop

### DIFF
--- a/src/chat/bot.ts
+++ b/src/chat/bot.ts
@@ -171,6 +171,11 @@ function createProgressReporter(thread: { startTyping?: (status?: string) => Pro
     async stop() {
       active = false;
       clearPending();
+      try {
+        await thread.startTyping?.("");
+      } catch {
+        // Best effort only.
+      }
     },
     async setStatus(text: string) {
       const sanitizedStatus = sanitizeStatus(text);

--- a/src/chat/respond.ts
+++ b/src/chat/respond.ts
@@ -872,7 +872,6 @@ export async function generateAssistantReply(
       unsubscribe();
     }
 
-    await context.onStatus?.("Drafting response...");
     const toolResults = newMessages.filter(isToolResultMessage);
 
     const assistantMessages = newMessages.filter(isAssistantMessage);


### PR DESCRIPTION
The Slack Assistants API status indicator ("Drafting response...") persisted after Junior had already sent its reply. Two issues caused this:

1. `progress.stop()` only cleared pending timers — it never explicitly cleared the `assistant.threads.setStatus` indicator. In the streaming path, `chat.update` calls don't auto-clear the status like `chat.postMessage` does.
2. A "Drafting response..." status was set after the agent loop completed but before the response was finalized, creating a race where the status could fire after the auto-clear from posting.

This fix adds an explicit status clear (`startTyping("")`) in `progress.stop()` and removes the misleading post-loop "Drafting response..." status entirely.

Fixes #29