### PR TITLE
fix(chat): Only intercept slash commands for registered skills

### DIFF
--- a/src/chat/respond.ts
+++ b/src/chat/respond.ts
@@ -90,14 +90,6 @@ export interface AgentTurnDiagnostics {
 const AGENT_TURN_TIMEOUT_MS = 15 * 60 * 1000;
 const MAX_INLINE_ATTACHMENT_BASE64_CHARS = 120_000;
 
-function formatUnknownSkillMessage(requestedSkill: string, availableSkills: Array<{ name: string }>): string {
-  const available = availableSkills.map((skill) => `/${skill.name}`).join(", ");
-  return [
-    `Unknown skill: /${requestedSkill}`,
-    available ? `Available skills: ${available}` : "No skills are currently available."
-  ].join("\n");
-}
-
 function isExecutionDeferralResponse(text: string): boolean {
   return /\b(want me to proceed|do you want me to proceed|shall i proceed|can i proceed|should i proceed|let me do that now|give me a moment|tag me again|fresh invocation)\b/i.test(
     text
@@ -584,7 +576,7 @@ export async function generateAssistantReply(
       ...(context.configuration ?? {})
     };
     const userInput = messageText;
-    const explicitInvocation = parseSkillInvocation(userInput);
+    const explicitInvocation = parseSkillInvocation(userInput, availableSkills);
     const explicitSkill = explicitInvocation
       ? findSkillByName(explicitInvocation.skillName, availableSkills)
       : null;
@@ -623,22 +615,6 @@ export async function generateAssistantReply(
     });
     sandboxExecutor.configureSkills(availableSkills);
     const sandbox = await sandboxExecutor.createSandbox();
-
-    if (explicitInvocation && !explicitSkill) {
-      return {
-        text: formatUnknownSkillMessage(explicitInvocation.skillName, availableSkills),
-        sandboxId: sandboxExecutor.getSandboxId(),
-        diagnostics: {
-          outcome: "execution_failure",
-          modelId: botConfig.modelId,
-          assistantMessageCount: 0,
-          toolCalls: [],
-          toolResultCount: 0,
-          toolErrorCount: 0,
-          usedPrimaryText: false
-        }
-      };
-    }
 
     if (explicitSkill) {
       const preloaded = await skillSandbox.loadSkill(explicitSkill.name);

--- a/src/chat/skills.ts
+++ b/src/chat/skills.ts
@@ -167,7 +167,10 @@ export async function discoverSkills(): Promise<SkillMetadata[]> {
   return sorted;
 }
 
-export function parseSkillInvocation(messageText: string): SkillInvocation | null {
+export function parseSkillInvocation(
+  messageText: string,
+  availableSkills: SkillMetadata[]
+): SkillInvocation | null {
   const trimmed = messageText.trim();
   const match = /(?:^|\s)\/([a-z0-9]+(?:-[a-z0-9]+)*)(?:\s+([\s\S]*))?/i.exec(trimmed);
   if (!match) {
@@ -175,6 +178,10 @@ export function parseSkillInvocation(messageText: string): SkillInvocation | nul
   }
 
   const skillName = match[1].toLowerCase();
+  if (!availableSkills.some((s) => s.name === skillName)) {
+    return null;
+  }
+
   const args = (match[2] ?? "").trim();
 
   return {
@@ -227,25 +234,6 @@ export function renderSkillMetadataXml(skills: SkillMetadata[]): string {
   return `<available_skills>\n${items}\n</available_skills>`;
 }
 
-export function renderSkillsHarnessXml(skills: SkillMetadata[]): string {
-  return [
-    "<skills>",
-    "  <rules>",
-    "    1. If the message contains /<skill-name> anywhere, treat it as a skill invocation request.",
-    "    2. If a slash-invoked skill exists, apply that skill's instructions first.",
-    "    3. If a slash-invoked skill does not exist, return an unknown-skill error and list available skills.",
-    "    4. Never reinterpret slash skill commands as plain text chat intent.",
-    "  </rules>",
-    "  <usage>",
-    "    Use format: /<skill-name> <optional arguments>",
-    "  </usage>",
-    renderSkillMetadataXml(skills)
-      .split("\n")
-      .map((line) => `  ${line}`)
-      .join("\n"),
-    "</skills>"
-  ].join("\n");
-}
 
 export function renderActiveSkillsXml(skills: Skill[]): string {
   if (skills.length === 0) {

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -7,9 +7,9 @@ import {
   parseSkillInvocation,
   resetSkillDiscoveryCache,
   renderActiveSkillsXml,
-  renderSkillMetadataXml,
-  renderSkillsHarnessXml
+  renderSkillMetadataXml
 } from "@/chat/skills";
+import type { SkillMetadata } from "@/chat/skills";
 import * as observability from "@/chat/observability";
 
 async function writeSkillFile(rootDir: string, name: string, lines: string[]): Promise<void> {
@@ -17,6 +17,11 @@ async function writeSkillFile(rootDir: string, name: string, lines: string[]): P
   await fs.mkdir(skillDir, { recursive: true });
   await fs.writeFile(path.join(skillDir, "SKILL.md"), lines.join("\n"), "utf8");
 }
+
+const stubSkills: SkillMetadata[] = [
+  { name: "brief", description: "Candidate brief", skillPath: "/tmp/brief" },
+  { name: "sum", description: "Summarize", skillPath: "/tmp/sum" }
+];
 
 describe("skills", () => {
   it("discovers valid skills from the default skills directory", async () => {
@@ -30,21 +35,29 @@ describe("skills", () => {
   });
 
   it("parses skill invocation by slash command", () => {
-    expect(parseSkillInvocation("/brief github: octocat")).toEqual({
+    expect(parseSkillInvocation("/brief github: octocat", stubSkills)).toEqual({
       skillName: "brief",
       args: "github: octocat"
     });
   });
 
   it("does not parse invocation without slash command", () => {
-    expect(parseSkillInvocation("please summarize this candidate")).toBeNull();
+    expect(parseSkillInvocation("please summarize this candidate", stubSkills)).toBeNull();
   });
 
   it("parses slash tokens anywhere in the message", () => {
-    expect(parseSkillInvocation("hey /brief github: octocat")).toEqual({
+    expect(parseSkillInvocation("hey /brief github: octocat", stubSkills)).toEqual({
       skillName: "brief",
       args: "github: octocat"
     });
+  });
+
+  it("returns null for unregistered slash command", () => {
+    expect(parseSkillInvocation("/jr link sentry", stubSkills)).toBeNull();
+  });
+
+  it("returns null when no skills are available", () => {
+    expect(parseSkillInvocation("/brief github: octocat", [])).toBeNull();
   });
 
   it("renders available and active skill XML blocks", () => {
@@ -64,20 +77,12 @@ describe("skills", () => {
         body: "# Instructions"
       }
     ]);
-    const harnessXml = renderSkillsHarnessXml([
-      {
-        name: "brief",
-        description: "Candidate brief profiles",
-        skillPath: "/tmp/brief"
-      }
-    ]);
 
     expect(metadataXml).toContain("<available_skills>");
     expect(metadataXml).toContain("&lt;profiles&gt;");
     expect(metadataXml).toContain("&amp; references");
     expect(metadataXml).toContain("<location>/tmp/brief/SKILL.md</location>");
     expect(activeXml).toContain("<active_skills>");
-    expect(harnessXml).toContain("<skills>");
   });
 
   it("skips skills with unknown capability/config metadata and logs warnings", async () => {


### PR DESCRIPTION
Any message containing a `/word` token (e.g. `/jr link sentry`) triggered `parseSkillInvocation()`, which matched regardless of whether the skill existed. When the skill wasn't registered, the bot immediately returned "Unknown skill: /jr" instead of routing the message to normal agent processing.

`parseSkillInvocation` now takes the discovered skills list and returns `null` for tokens that don't match a registered skill name, so unrecognized slash tokens fall through to the agent as ordinary text. The hard-error path and `formatUnknownSkillMessage` helper are removed since they're no longer reachable. `renderSkillsHarnessXml` (dead code, only referenced in tests) is also removed.

Fixes #36