### PR TITLE
ref(github-skill): Relax templates and add context generalization

### DIFF
--- a/src/plugins/github/skills/github/SKILL.md
+++ b/src/plugins/github/skills/github/SKILL.md
@@ -35,16 +35,18 @@ Use this skill for `/github` workflows in the harness. Issues are the primary su
 - Keep content short and scannable.
 - Do not add acceptance-criteria checklists unless explicitly requested.
 - Include concerns only when material risk, uncertainty, or dependency exists.
+- Generalize conversation context: replace user names, slash-command invocations, channel references, and session-specific fragments with the underlying technical problem. The issue must be actionable without access to the originating conversation.
+- Include code snippets when they clarify the problem pattern or proposed change.
+- Cross-reference related issues and PRs when they provide context.
 
 4. Enforce concise usability limits:
 - Title must be specific and outcome-oriented.
 - Title hard max: 60 characters. Target: 40-60.
 - If user-provided title exceeds 60 characters, rewrite concisely while preserving intent.
-- Body caps:
+- Body guidelines:
   - Summary max 3 sentences.
-  - Max 4 bullets per section.
-  - One sentence per bullet.
-  - Target issue body length: 350 words or fewer.
+  - Prefer concise sections but use as many bullets, steps, or rows as the problem requires.
+  - Include code snippets, tables, or numbered steps when they add clarity.
 
 5. Research and verify factual claims:
 - Follow [references/research-rules.md](references/research-rules.md).

--- a/src/plugins/github/skills/github/references/issue-examples.md
+++ b/src/plugins/github/skills/github/references/issue-examples.md
@@ -1,30 +1,88 @@
-# High-Quality Issue Examples
+# Issue Examples
 
-Use examples to shape structure and clarity, not to copy wording.
+Calibrate structure and depth by comparing good and bad patterns.
 
-## Example links
+## Bug example
 
-- Sentry JavaScript: https://github.com/getsentry/sentry-javascript/issues/19529
+Bad title: "Error in auth"
+Good title: "OAuth token refresh fails during long-running operations"
 
-## What to emulate
+Bad summary:
+> Something is broken with auth tokens. Users are seeing errors.
 
-- Title is specific and scannable.
-- Summary explains the problem or goal in one short paragraph.
-- Analysis is concrete and evidence-backed.
-- Scope/impact is explicit.
-- Unknowns are called out instead of guessed.
-- Sources are linked for factual claims.
-- Concerns are included only when material.
+Good summary:
+> The SDK sets a dedup key before acquiring the per-thread lock. When the lock is contended, the message is permanently lost because the dedup slot is already consumed.
 
-## Negative calibration
+Bad structure — generic catch-all:
+> ## Analysis
+> - There's an auth error
+> - It happens sometimes
+> - We should fix it
 
-- `getsentry/sentry-mcp#817` is a calibration anti-pattern only.
-- Do not mirror overlong issue bodies.
-- Do not present speculative fixes as certain.
+Good structure — problem-specific sections:
+> ## Root cause
+> The dedup key is set *before* the lock is attempted. When a second message arrives...
+>
+> ## Reproduction
+> 1. Two users @-mention the bot in the same thread while processing
+> 2. First message acquires the lock
+> 3. Second message sets its dedup key, fails lock acquisition
+>
+> ## Expected behavior
+> Either:
+> - **Option A**: Acquire lock before setting dedup key
+> - **Option B**: Clear dedup key on lock failure
+>
+> ## Workaround
+> Retry wrapper that catches LockError and clears the dedup key (PR #32).
 
-## How to apply in `/github`
+## Task example
 
-1. Build content from the type-specific template selected by `issue-template.md`.
-2. Run `issue-quality-checklist.md` before posting.
-3. If essential content is missing, add it before create/update.
-4. Keep it concise and within title/body caps.
+Bad title: "Clean up some code"
+Good title: "Remove 7 monkey-patches made unnecessary by SDK v2.1"
+
+Bad scope:
+> We have some patches we should clean up.
+
+Good scope — quantified and specific:
+> We maintain patches on **8 of 9 `process*` methods**. 7 exist solely because the SDK lacks `runInBackground` support. The 8th has two additional behavioral fixes.
+>
+> | Method | Patch reason |
+> |--------|-------------|
+> | `processReaction` | scheduling only |
+> | `processAction` | scheduling only |
+> | `processMessage` | scheduling + thread ID normalization + lock retry |
+
+## Feature example
+
+Bad framing:
+> It would be nice to have better config reloading.
+
+Good framing — current state, gap, options:
+> ## Current behavior
+> Workers read config at startup. Changes require a full restart.
+>
+> ## Gap
+> Config changes during incidents require redeploying, adding 2-3 minutes to mitigation.
+>
+> ## Options
+> | Approach | Tradeoff |
+> |----------|----------|
+> | File watch + hot reload | Simple, but no atomicity guarantee |
+> | Config service with polling | Consistent, but adds a dependency |
+
+## Principles
+
+- Use problem-specific headings, not generic labels
+- Include code snippets when they clarify the pattern
+- Quantify scope precisely ("8 of 9", not "many")
+- Cross-reference related issues and PRs
+- Show concrete options with tradeoffs, not vague "should be fixed"
+- Use tables for structured comparisons
+
+## Anti-patterns
+
+- Overlong, sprawling body with no clear sections
+- Confident fix claims without root-cause evidence
+- Speculative detail mixed into verified facts
+- Session-specific content (user names, slash commands, channel references)

--- a/src/plugins/github/skills/github/references/issue-quality-checklist.md
+++ b/src/plugins/github/skills/github/references/issue-quality-checklist.md
@@ -4,7 +4,7 @@ Run this checklist before create/update mutation.
 
 ## External Quality Signals
 
-- Is the issue easy to understand without chat context?
+- Does the issue contain user names, slash commands, or channel references from the originating conversation? If so, generalize.
 - Is the issue concise and still actionable?
 - Are unknowns called out instead of guessed?
 - Are concerns included only when material?

--- a/src/plugins/github/skills/github/references/issue-template-bug.md
+++ b/src/plugins/github/skills/github/references/issue-template-bug.md
@@ -1,18 +1,16 @@
 # Bug Issue Template
 
-Keep concise. Remove empty sections.
+Use as a starting structure. Adapt headings to fit the specific bug.
 
 ## Summary
-Up to 3 sentences describing the user-visible failure.
+Up to 3 sentences describing the failure and its impact.
 
-## Analysis
-- Symptom and affected surface.
-- Evidence (repro details, logs, observed vs expected).
-- Verified facts with source links.
-- Unknowns and root-cause hypotheses with confidence.
+## Suggested sections (use what fits, rename freely)
 
-## Sources
-- URL or repository reference for factual claims.
+- **Root cause** — technical explanation of why the bug occurs, with code snippets if relevant
+- **Reproduction** — numbered steps any developer can follow independently
+- **Expected behavior** — what should happen, with concrete options if multiple fixes exist
+- **Workaround** — current mitigation if one exists, with links to relevant PRs
+- **Versions affected** — specific versions or environments confirmed
 
-## Concerns
-- Risks, uncertainty, or dependency concerns only when material.
+Remove sections that don't apply. Add sections the problem needs.

--- a/src/plugins/github/skills/github/references/issue-template-feature.md
+++ b/src/plugins/github/skills/github/references/issue-template-feature.md
@@ -1,18 +1,15 @@
 # Feature Issue Template
 
-Keep concise. Remove empty sections.
+Use as a starting structure. Adapt headings to fit the specific feature.
 
 ## Summary
 Up to 3 sentences describing the desired improvement and user outcome.
 
-## Analysis
-- Current behavior and constraints.
-- Gap and user/developer impact.
-- Viable options with tradeoffs.
-- Recommended direction with short rationale.
+## Suggested sections (use what fits, rename freely)
 
-## Sources
-- URL or repository reference for factual claims.
+- **Current behavior** — how the system works today, with code snippets if relevant
+- **Gap** — why current behavior is insufficient, with concrete impact
+- **Options** — viable approaches with tradeoffs
+- **Recommendation** — preferred direction with rationale
 
-## Concerns
-- Risks, open questions, or dependencies only when material.
+Remove sections that don't apply. Add sections the feature needs.

--- a/src/plugins/github/skills/github/references/issue-template-task.md
+++ b/src/plugins/github/skills/github/references/issue-template-task.md
@@ -1,18 +1,15 @@
 # Task Issue Template
 
-Keep concise. Remove empty sections.
+Use as a starting structure. Adapt headings to fit the specific task.
 
 ## Summary
 Up to 3 sentences describing the task and intended result.
 
-## Analysis
-- Goal and done-state.
-- Scope boundaries.
-- Concrete implementation steps.
-- Dependencies or risks only when material.
+## Suggested sections (use what fits, rename freely)
 
-## Sources
-- URL or repository reference when relevant.
+- **Background** — why this task exists, with code snippets showing current state
+- **Scope** — what's included and excluded, quantify when possible
+- **Implementation** — concrete steps or approach
+- **Dependencies** — related issues, PRs, or external blockers
 
-## Concerns
-- Risks or blockers only when material.
+Remove sections that don't apply. Add sections the task needs.

--- a/src/plugins/github/skills/github/references/issue-template.md
+++ b/src/plugins/github/skills/github/references/issue-template.md
@@ -8,7 +8,6 @@ Select one template by issue type:
 Shared constraints:
 - Title hard max: 60 characters (target 40-60).
 - Summary max 3 sentences.
-- Max 4 bullets per section.
-- One sentence per bullet.
 - Remove empty sections.
+- Use problem-specific section headings — adapt the template to fit the issue, not the reverse.
 - Do not include acceptance criteria unless explicitly requested.

--- a/src/plugins/github/skills/github/references/issue-type-bug.md
+++ b/src/plugins/github/skills/github/references/issue-type-bug.md
@@ -32,6 +32,16 @@ Produce a high-signal bug issue that drives root-cause discovery, not premature 
 - If root cause is not verified, include next RCA steps before or alongside fix options.
 - Do not present one fix as certain without explicit evidence.
 
+## Context Generalization
+
+When deriving bug content from conversation, generalize to the technical problem.
+
+Before (session-specific):
+> @alice ran `/github create` in #ops-alerts and saw "token refresh failed" when the OAuth token expired mid-thread
+
+After (generalized):
+> OAuth token refresh fails during long-running operations, producing "token refresh failed" errors
+
 ## Completion Bar
 
 A `bug` issue is ready when it has:

--- a/src/plugins/github/skills/github/references/issue-type-feature.md
+++ b/src/plugins/github/skills/github/references/issue-type-feature.md
@@ -22,6 +22,16 @@ Propose an intentional improvement with clear current-state analysis and practic
 - at least one viable path, preferably multiple when tradeoffs are meaningful
 - include implementation and operational tradeoffs
 
+## Context Generalization
+
+When deriving feature content from conversation, generalize to the capability gap.
+
+Before (session-specific):
+> @carol mentioned in the standup thread that she has to manually restart the worker every time the config changes
+
+After (generalized):
+> Workers do not pick up config changes without a restart, requiring manual intervention
+
 ## Completion Bar
 
 A `feature` issue is ready when it has:

--- a/src/plugins/github/skills/github/references/issue-type-task.md
+++ b/src/plugins/github/skills/github/references/issue-type-task.md
@@ -19,6 +19,16 @@ Create a concise execution ticket for maintenance, cleanup, docs, refactors, or 
 - concrete implementation steps
 - dependencies or risks only when material
 
+## Context Generalization
+
+When deriving task content from conversation, generalize to the goal and scope.
+
+Before (session-specific):
+> @bob asked in #eng-chat to clean up the unused `legacyAuth` middleware that he noticed while reviewing PR #312
+
+After (generalized):
+> Remove unused `legacyAuth` middleware to reduce maintenance surface
+
 ## Completion Bar
 
 A `task` issue is ready when it is short, actionable, and testable without extra discovery.

--- a/src/plugins/github/skills/github/references/research-rules.md
+++ b/src/plugins/github/skills/github/references/research-rules.md
@@ -26,7 +26,7 @@ Use this file for cross-type rules. Then apply the matching type-specific file:
 
 ## Output Expectations
 
-- Separate `Verified Facts`, `Likely`, and `Unknowns`.
+- Clearly distinguish verified facts from unknowns. Weave evidence naturally into the issue structure rather than forcing separate sections.
 - Include source links/paths for each verified fact.
 - Use exact dates for timeline claims.
 - Avoid absolute language when confidence is low.


### PR DESCRIPTION
GitHub skill produces generic, flat issues that don't match high-quality ones. Templates are rigid (fixed Summary/Analysis structure), limits are artificial (4 bullets/section, 350 words), and session-specific details get copied verbatim (user names, slash commands).

This refactors templates to be flexible (suggested sections, rename freely), relaxes body limits, and adds active context generalization rules with before/after examples. issue-examples.md now teaches through inline good/bad patterns instead of external links.

Fixes #48