### PR TITLE
docs(sentry): Use `npx sentry` instead of `npx @sentry/cli`

### DIFF
--- a/src/plugins/sentry/README.md
+++ b/src/plugins/sentry/README.md
@@ -49,7 +49,7 @@ Set `SENTRY_AUTH_TOKEN` to a static auth token. The broker falls back to this wh
 - If no token exists, the harness auto-starts the OAuth flow, sends an ephemeral authorization link, and auto-resumes the original request after the user authorizes.
 - The broker refreshes tokens within 5 minutes of expiry via `grant_type=refresh_token`.
 - Sandbox does not receive raw tokens via env; host applies scoped Authorization header transforms for Sentry API calls.
-- `SENTRY_AUTH_TOKEN` is injected in the lease env for CLI consumption (`npx @sentry/cli`).
+- `SENTRY_AUTH_TOKEN` is injected in the lease env for CLI consumption (`npx sentry`).
 
 ## 4) CLI usage
 
@@ -57,7 +57,7 @@ Run as a regular sandbox `bash` command while this skill is active:
 
 ```bash
 jr-rpc issue-credential sentry.api
-npx @sentry/cli issues list --org ORG --json
+npx sentry issues list --org ORG --json
 ```
 
 Optional: set org/project once per channel so they don't need to be repeated:

--- a/src/plugins/sentry/skills/sentry/SKILL.md
+++ b/src/plugins/sentry/skills/sentry/SKILL.md
@@ -27,7 +27,7 @@ Use this skill for `/sentry` workflows in the harness.
 - If a Sentry API call returns 401 or 403 after credentials were issued, the user's token may lack access for the requested org. Run `jr-rpc delete-token sentry` to clear the stale token, then run `jr-rpc issue-credential sentry.api` again to trigger a fresh OAuth flow. Do not ask the user to run a command manually — the system handles re-authorization automatically.
 
 3. Execute via CLI:
-- Use `npx @sentry/cli <command>` for structured queries.
+- Use `npx sentry <command>` for structured queries.
 - The CLI reads `SENTRY_AUTH_TOKEN` from env (injected by broker via lease env field).
 - Read [references/cli-commands.md](references/cli-commands.md) for command shapes and flags.
 - Read [references/sandbox-runtime.md](references/sandbox-runtime.md) before relying on sandbox credentials.

--- a/src/plugins/sentry/skills/sentry/references/cli-commands.md
+++ b/src/plugins/sentry/skills/sentry/references/cli-commands.md
@@ -1,13 +1,13 @@
 # Sentry CLI Command Reference
 
-All commands use `npx @sentry/cli` and read `SENTRY_AUTH_TOKEN` from environment.
+All commands use `npx sentry` and read `SENTRY_AUTH_TOKEN` from environment.
 
 ## Issue commands
 
 ### List issues
 
 ```bash
-npx @sentry/cli issues list --org ORG [--project PROJECT] [--query QUERY] [--json]
+npx sentry issues list --org ORG [--project PROJECT] [--query QUERY] [--json]
 ```
 
 - `--org`: Organization slug (required).
@@ -18,7 +18,7 @@ npx @sentry/cli issues list --org ORG [--project PROJECT] [--query QUERY] [--jso
 ### Explain issue
 
 ```bash
-npx @sentry/cli issues explain ISSUE_ID --org ORG [--json]
+npx sentry issues explain ISSUE_ID --org ORG [--json]
 ```
 
 AI-powered root cause analysis for a specific issue.
@@ -26,7 +26,7 @@ AI-powered root cause analysis for a specific issue.
 ### Plan fix
 
 ```bash
-npx @sentry/cli issues plan ISSUE_ID --org ORG [--json]
+npx sentry issues plan ISSUE_ID --org ORG [--json]
 ```
 
 AI-powered remediation guidance for a specific issue.
@@ -36,7 +36,7 @@ AI-powered remediation guidance for a specific issue.
 ### List organizations
 
 ```bash
-npx @sentry/cli organizations list [--json]
+npx sentry organizations list [--json]
 ```
 
 Lists organizations accessible with current token.

--- a/src/plugins/sentry/skills/sentry/references/sandbox-runtime.md
+++ b/src/plugins/sentry/skills/sentry/references/sandbox-runtime.md
@@ -14,7 +14,7 @@ This skill runs in the harness sandbox (`node22`) and commands execute via the `
 1. Enable credentials with `jr-rpc issue-credential sentry.api`.
 2. Runtime injects `Authorization` header transforms for `sentry.io` and regional subdomains (`us.sentry.io`, `de.sentry.io`) — the host proxies the real token at the HTTP layer.
 3. `SENTRY_AUTH_TOKEN` is set to a placeholder so CLI tools don't fail on missing auth. The real token never enters the sandbox.
-4. Run CLI commands: `npx @sentry/cli <command>`.
+4. Run CLI commands: `npx sentry <command>`.
 5. No long-lived token persistence in sandbox files.
 
 ## Important constraint


### PR DESCRIPTION
Update Sentry plugin skill documentation to use the shorter \`npx sentry\` CLI invocation.

The Sentry CLI package has been aliased to allow invocation as \`npx sentry\` instead of \`npx @sentry/cli\`. This updates all references in the Sentry skill documentation to use the new, simpler command.

This change applies to all CLI usage examples in:
- CLI command reference
- Skill workflow documentation
- Runtime guidance
- Setup README