### PR TITLE
fix(jr-rpc): Remove circular requires-capabilities and uses-config

### DIFF
--- a/src/junior/skills/jr-rpc/SKILL.md
+++ b/src/junior/skills/jr-rpc/SKILL.md
@@ -1,42 +1,46 @@
 ---
 name: jr-rpc
-description: Manage capability credentials and OAuth flows via jr-rpc bash commands.
+description: Issue capability credentials and manage OAuth flows via jr-rpc bash commands. Use when a task needs authenticated API calls, credentials are not enabled, or a user needs to connect or disconnect a provider account.
 allowed-tools: bash
 ---
 
-# jr-rpc Capability Command
+# jr-rpc
 
-Use this skill when a task needs authenticated API calls and credentials are not enabled yet.
+Enable provider credentials and manage OAuth authorization for the current agent turn.
 
 ## Credential issuance
 
+Run before any authenticated API call:
+
 `jr-rpc issue-credential <capability> [--repo <owner/repo>]`
 
-Example:
-
-`jr-rpc issue-credential github.issues.write --repo getsentry/junior`
+- GitHub capabilities require `--repo`. Sentry capabilities are org-scoped (no `--repo`).
+- On success, sandbox header transforms are applied for this turn. Do not pass raw tokens.
+- If credential issuance fails with `credential_unavailable` + `oauth_started`, relay the `message` field to the user and **stop the turn** — the callback auto-resumes the request after authorization.
 
 ## OAuth authorization
 
-`jr-rpc oauth-start <provider>` — initiate authorization code flow, returns `{ ok, authorize_url }`.
+`jr-rpc oauth-start <provider>` — start an OAuth authorization code flow.
+
+- The authorization link is delivered privately (visible only to the requesting user).
+- Returns `{ ok: true, private_delivery_sent: true }` on success.
+- If `private_delivery_sent` is false, tell the user to send a direct message and try again.
+- If the user is already connected, returns `{ ok: true, already_connected: true, message }`.
+- **Never** post or relay authorization URLs — they are security-sensitive.
 
 ## Token management
 
-`jr-rpc delete-token <provider>` — remove stored tokens for current user.
+`jr-rpc delete-token <provider>` — remove stored OAuth tokens for the current user.
 
-## Behavior
+## Configuration
 
-- `jr-rpc` runs as a bash runtime custom command.
-- Runtime lazily issues a short-lived lease for this turn and applies sandbox header transforms.
-- Raw tokens are never written into sandbox env/files.
-- OAuth flows use authorization code grant — the callback handler exchanges the code and stores tokens server-side. The agent never sees token values.
+`jr-rpc config get|set|unset|list` — read and write channel-scoped configuration values.
+
+Read `${CLAUDE_SKILL_ROOT}/references/commands.md` for full command syntax and response shapes.
+
+Read `${CLAUDE_SKILL_ROOT}/references/capabilities.md` for capability naming and scoping rules.
 
 ## Guardrails
 
-- Use provider-qualified capabilities (for example `github.issues.write`).
+- Use provider-qualified capabilities (e.g. `github.issues.write`).
 - Do not print credential values.
-
-## References
-
-- [references/commands.md](references/commands.md)
-- [references/capabilities.md](references/capabilities.md)

--- a/src/junior/skills/jr-rpc/references/capabilities.md
+++ b/src/junior/skills/jr-rpc/references/capabilities.md
@@ -1,6 +1,6 @@
 # Capability guidance
 
-Use capability names declared by active skill policy, for example:
+Use provider-qualified capability names:
 
 - `github.issues.read`
 - `github.issues.write`
@@ -15,6 +15,6 @@ Examples:
 
 Scoping rules:
 
-- Capability should be declared in the active skill frontmatter (`requires-capabilities`).
-- Declarations are currently soft-enforced (warn-only) and will harden later.
-- GitHub capabilities require `--repo <owner/repo>`. Sentry capabilities are org-scoped (no `--repo` needed).
+- GitHub capabilities require `--repo <owner/repo>`.
+- Sentry capabilities are org-scoped (no `--repo` needed).
+- Declare capabilities in the consuming skill's `requires-capabilities` frontmatter. Currently soft-enforced (warn-only).

--- a/src/junior/skills/jr-rpc/references/commands.md
+++ b/src/junior/skills/jr-rpc/references/commands.md
@@ -9,28 +9,33 @@ Enable a capability credential for the current turn.
 - `<capability>` — provider-qualified (e.g. `github.issues.write`, `sentry.api`)
 - `--repo <owner/repo>` — required for GitHub capabilities, not needed for Sentry
 
-## oauth-start
-
-`jr-rpc oauth-start <provider>`
-
-Initiate an OAuth authorization code flow for the given provider. The command sends the authorization link as an ephemeral Slack message (visible only to the requesting user) and returns:
-
-- `{ ok: true, ephemeral_sent: true }` — link was sent privately. Tell the user you've sent them a private link.
-- `{ ok: true, ephemeral_sent: false, authorize_url: "..." }` — ephemeral delivery failed (missing channel context). Post `authorize_url` normally as a fallback.
-
-The user clicks the link, authorizes in browser, and is redirected back to the callback handler which exchanges the code, stores tokens server-side, and posts a confirmation into the thread.
-
-Supported providers: `sentry`
-
-## issue-credential auto-OAuth
+### Auto-OAuth
 
 When `issue-credential` fails because no credentials are available for an OAuth-capable provider, the harness automatically starts the OAuth flow and returns:
 
 ```json
-{ "credential_unavailable": true, "oauth_started": true, "provider": "sentry", "ephemeral_sent": true, "message": "I need to connect your Sentry account first. I've sent you a private authorization link." }
+{ "credential_unavailable": true, "oauth_started": true, "provider": "sentry", "private_delivery_sent": true, "message": "I need to connect your Sentry account first. I've sent you a private authorization link." }
 ```
 
-The `message` field contains the exact text to relay to the user. The callback handler will automatically resume the original user request after authorization completes. The agent should relay `message` and stop the turn.
+Relay the `message` field to the user and stop the turn. The callback handler automatically resumes the original request after authorization completes.
+
+If `private_delivery_sent` is false, the `message` field instructs the user to send a direct message and try again.
+
+## oauth-start
+
+`jr-rpc oauth-start <provider>`
+
+Initiate an OAuth authorization code flow for the given provider. The command sends the authorization link as a private Slack message (visible only to the requesting user).
+
+Responses:
+
+- `{ ok: true, private_delivery_sent: true }` — link was sent privately. Tell the user you've sent them a private authorization link.
+- `{ ok: true, private_delivery_sent: false, message: "..." }` — private delivery failed (missing channel context). Relay the `message` to the user.
+- `{ ok: true, already_connected: true, provider: "...", message: "..." }` — user already has a valid token. Relay the `message`.
+
+**Never** post or relay authorization URLs — they are security-sensitive and are only delivered privately.
+
+Supported providers: `sentry`
 
 ## delete-token
 


### PR DESCRIPTION
Remove `requires-capabilities` and `uses-config` from the jr-rpc skill's YAML frontmatter.

jr-rpc is the primitive that issues credentials and provides config access — declaring these as prerequisites is circular. Both fields are optional per the spec and can be safely removed.

Fixes #41