### PR TITLE
fix(chat): Remove misleading follow-up message on /jr link

### DIFF
--- a/src/chat/capabilities/jr-rpc-command.ts
+++ b/src/chat/capabilities/jr-rpc-command.ts
@@ -29,7 +29,7 @@ async function deliverPrivateMessage(input: {
   threadTs?: string;
   userId: string;
   text: string;
-}): Promise<boolean> {
+}): Promise<"in_context" | "fallback_dm" | false> {
   let client: ReturnType<typeof getSlackClient>;
   try {
     client = getSlackClient();
@@ -56,7 +56,7 @@ async function deliverPrivateMessage(input: {
           ...(input.threadTs ? { thread_ts: input.threadTs } : {})
         });
       }
-      return true;
+      return "in_context";
     } catch (error) {
       const slackError = error instanceof Error ? error.message : String(error);
       logWarn(
@@ -78,7 +78,7 @@ async function deliverPrivateMessage(input: {
     }
 
     await client.chat.postMessage({ channel: dmChannelId, text: input.text });
-    return true;
+    return "fallback_dm";
   } catch (error) {
     const slackError = error instanceof Error ? error.message : String(error);
     logWarn(
@@ -211,8 +211,8 @@ async function handleIssueCredentialCommand(
             credential_unavailable: true,
             oauth_started: true,
             provider: error.provider,
-            private_delivery_sent: oauthResult.privateSent,
-            message: oauthResult.privateSent
+            private_delivery_sent: !!oauthResult.delivery,
+            message: oauthResult.delivery
               ? `I need to connect your ${providerLabel} account first. I've sent you a private authorization link.`
               : `I need to connect your ${providerLabel} account first, but I wasn't able to send you a private authorization link. Please send me a direct message and try your command again.`
           },
@@ -471,7 +471,7 @@ export type OAuthFlowInput = {
 export async function startOAuthFlow(
   provider: string,
   input: OAuthFlowInput
-): Promise<{ ok: false; error: string } | { ok: true; privateSent: boolean }> {
+): Promise<{ ok: false; error: string } | { ok: true; delivery: "in_context" | "fallback_dm" | false }> {
   const providerConfig = getOAuthProviderConfig(provider);
   if (!providerConfig) {
     return { ok: false, error: `Provider "${provider}" does not support OAuth authorization` };
@@ -527,14 +527,14 @@ export async function startOAuthFlow(
   );
 
   const providerLabel = provider.charAt(0).toUpperCase() + provider.slice(1);
-  const privateSent = await deliverPrivateMessage({
+  const delivery = await deliverPrivateMessage({
     channelId: input.channelId,
     threadTs: input.threadTs,
     userId: input.requesterId,
     text: `<${authorizeUrl}|Click here to link your ${providerLabel} account>. Once you've authorized, you'll see a confirmation in Slack.`
   });
 
-  return { ok: true, privateSent };
+  return { ok: true, delivery };
 }
 
 async function handleOAuthStartCommand(
@@ -592,7 +592,7 @@ async function handleOAuthStartCommand(
     return commandResult({ stderr: `${result.error}\n`, exitCode: 1 });
   }
 
-  if (!result.privateSent) {
+  if (!result.delivery) {
     return commandResult({
       stdout: {
         ok: true,

--- a/src/chat/slash-command.ts
+++ b/src/chat/slash-command.ts
@@ -38,9 +38,9 @@ async function handleLink(event: SlashCommandEvent, provider: string): Promise<v
     return;
   }
 
-  if (result.privateSent) {
+  if (result.delivery === "fallback_dm") {
     await postEphemeral(event, `Check your DMs for a ${providerLabel(provider)} authorization link.`);
-  } else {
+  } else if (result.delivery === false) {
     await postEphemeral(
       event,
       "I wasn't able to send you a private authorization link. Please try again in a direct message."


### PR DESCRIPTION
Change deliverPrivateMessage to return "in_context" | "fallback_dm" | false instead of boolean, so callers can distinguish how the auth link was delivered. Update handleLink to only show "Check your DMs" when the link was actually sent via fallback DM, and skip the follow-up entirely when the link was delivered in-context (already visible to the user).

Previously, /jr link always posted "Check your DMs for a Sentry authorization link" as a follow-up, even when the link was delivered in the current channel (as ephemeral) or in a DM. This was misleading when the user could already see the link. Now the follow-up only appears when the link was sent via the fallback DM path (Strategy 3 in deliverPrivateMessage).

The delivery method is now propagated through startOAuthFlow, handleOAuthStartCommand, and handleIssueCredentialCommand, so all callers can respond appropriately to different delivery scenarios.