### PR TITLE
fix(chat): Update App Home button label to use Unlink

### DIFF
--- a/src/chat/app-home.ts
+++ b/src/chat/app-home.ts
@@ -29,7 +29,7 @@ export async function buildHomeView(
       },
       accessory: {
         type: "button",
-        text: { type: "plain_text", text: "Disconnect" },
+        text: { type: "plain_text", text: "Unlink" },
         action_id: "app_home_disconnect",
         value: plugin.manifest.name,
         style: "danger"

--- a/tests/app-home.test.ts
+++ b/tests/app-home.test.ts
@@ -24,7 +24,7 @@ const expiredToken: StoredTokens = {
 };
 
 describe("buildHomeView", () => {
-  it("shows connected oauth-bearer provider with Disconnect button", async () => {
+  it("shows connected oauth-bearer provider with Unlink button", async () => {
     const store = createMockTokenStore({ sentry: validToken });
     const view = await buildHomeView("U123", store);
 


### PR DESCRIPTION
Update the provider account disconnection button in the App Home tab to use "Unlink" instead of "Disconnect" for clarity and consistency with terminology used elsewhere in the app.

Also updates the test description to match.