### PR TITLE
fix(chat): Insert newline separator between streamed assistant messages

### DIFF
--- a/specs/harness-agent-spec.md
+++ b/specs/harness-agent-spec.md
@@ -13,6 +13,12 @@ This document defines how the Junior harness must run agent turns for Slack repl
 - The agent must end each turn with a user-facing assistant markdown response.
 - Reply rendering should use assistant text from the turn's generated assistant message(s).
 
+## Streaming Contract
+
+- When streaming text deltas to the user, the harness must insert a newline separator (`"\n"`) between text from consecutive assistant messages within a single turn.
+- This matches the non-streamed path's `join("\n")` behavior, so the final rendered output is identical regardless of delivery method.
+- The normalizing stream applies `ensureBlockSpacing` to the combined text, expanding single newlines between non-empty paragraphs to double newlines for Slack rendering.
+
 ## Visibility Rules
 
 - Intermediate tool calls/results are internal reasoning artifacts. They are not posted directly to users.

--- a/src/chat/respond.ts
+++ b/src/chat/respond.ts
@@ -760,7 +760,19 @@ export async function generateAssistantReply(
         )
       }
     });
+    let hasEmittedText = false;
+    let needsSeparator = false;
+
     const unsubscribe = agent.subscribe((event) => {
+      // Track message boundaries so text from consecutive assistant messages
+      // is separated by "\n", matching the non-streamed join behavior.
+      if (event.type === "message_start") {
+        if (hasEmittedText) {
+          needsSeparator = true;
+        }
+        return;
+      }
+
       if (event.type !== "message_update") {
         return;
       }
@@ -773,8 +785,18 @@ export async function generateAssistantReply(
       if (!deltaText) {
         return;
       }
-      Promise.resolve(context.onTextDelta?.(deltaText)).catch(() => {
-        // Best effort only.
+
+      const text = needsSeparator ? "\n" + deltaText : deltaText;
+      needsSeparator = false;
+      hasEmittedText = true;
+
+      Promise.resolve(context.onTextDelta?.(text)).catch((error) => {
+        logWarn(
+          "streaming_text_delta_error",
+          {},
+          { "error.message": error instanceof Error ? error.message : String(error) },
+          "Failed to deliver text delta to stream"
+        );
       });
     });
 

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -128,6 +128,15 @@ describe("createNormalizingStream", () => {
     expect(result).toBe(ensureBlockSpacing("text\n```\ncode\n```\nmore"));
   });
 
+  it("separates text from different messages with newline", async () => {
+    // Simulates two assistant messages joined by "\n" separator
+    // (as inserted by respond.ts message boundary detection)
+    const chunks = ["Hello.", "\n", "How are you?"];
+    const stream = createNormalizingStream(chunksToIterable(chunks), ensureBlockSpacing);
+    const result = await collectStream(stream);
+    expect(result).toBe("Hello.\n\nHow are you?");
+  });
+
   it("flushes final incomplete line", async () => {
     const chunks = ["hello"];
     const stream = createNormalizingStream(chunksToIterable(chunks), ensureBlockSpacing);


### PR DESCRIPTION
Fix streaming output concatenating text from different assistant messages without any separator.

When the agent produces multi-turn responses (text → tool call → text), the streamed path pushed raw `text_delta` events directly to the stream bridge with no separator between different assistant messages. This caused output like "Hello.How are you?" instead of properly separated paragraphs.

The non-streamed path already handles this correctly by joining messages with `"\n"` (`respond.ts:857`), but the streaming subscriber had no awareness of message boundaries.

The fix listens for `message_start` events to detect when a new assistant message begins, and prepends `"\n"` to the first delta of the new message. The normalizing stream's `ensureBlockSpacing` then expands this to `"\n\n"` paragraph breaks for Slack rendering — matching the non-streamed path's final output.

Also improved error handling in the streaming callback from a silent catch to `logWarn`, and added a "Streaming Contract" section to the harness spec documenting the multi-message joining requirement.