### PR TITLE
fix(chat): Yield pre-newline content immediately in normalizing stream

### DIFF
--- a/src/chat/bot.ts
+++ b/src/chat/bot.ts
@@ -255,11 +255,21 @@ export function createNormalizingStream(
       let emitted = 0;
       for await (const chunk of inner) {
         accumulated += chunk;
-        // Only normalize up to the last complete line to avoid corruption
-        // when a partial line changes meaning as more characters arrive
         const lastNewline = accumulated.lastIndexOf("\n");
-        const stable = lastNewline === -1 ? "" : accumulated.slice(0, lastNewline + 1);
-        if (!stable) continue;
+
+        if (lastNewline === -1) {
+          // No newline yet — yield raw (identical to normalized for single-line content)
+          const delta = accumulated.slice(emitted);
+          if (delta) {
+            yield delta;
+            emitted = accumulated.length;
+          }
+          continue;
+        }
+
+        // Normalize up to the last complete line to avoid corruption
+        // when a partial line changes meaning as more characters arrive
+        const stable = accumulated.slice(0, lastNewline + 1);
         const normalized = normalize(stable);
         const delta = normalized.slice(emitted);
         emitted = normalized.length;

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -99,6 +99,14 @@ async function collectStream(stream: AsyncIterable<string>): Promise<string> {
   return result;
 }
 
+async function collectChunks(stream: AsyncIterable<string>): Promise<string[]> {
+  const chunks: string[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+  return chunks;
+}
+
 async function* chunksToIterable(chunks: string[]): AsyncIterable<string> {
   for (const chunk of chunks) {
     yield chunk;
@@ -142,5 +150,39 @@ describe("createNormalizingStream", () => {
     const stream = createNormalizingStream(chunksToIterable(chunks), ensureBlockSpacing);
     const result = await collectStream(stream);
     expect(result).toBe("hello");
+  });
+
+  it("yields pre-newline content immediately", async () => {
+    const chunks = ["Hello", " world", "!\nNext line"];
+    const stream = createNormalizingStream(chunksToIterable(chunks), ensureBlockSpacing);
+    const yielded = await collectChunks(stream);
+    // First three chunks have no newline yet — content should be yielded incrementally
+    expect(yielded[0]).toBe("Hello");
+    expect(yielded[1]).toBe(" world");
+    // Final output should still match full normalization
+    expect(yielded.join("")).toBe(ensureBlockSpacing("Hello world!\nNext line"));
+  });
+
+  it("transitions correctly from raw to normalized when first newline arrives", async () => {
+    // "intro\n- item" triggers ensureBlockSpacing to insert a blank line
+    const chunks = ["intro", "\n- item"];
+    const stream = createNormalizingStream(chunksToIterable(chunks), ensureBlockSpacing);
+    const yielded = await collectChunks(stream);
+    // "intro" is yielded immediately (pre-newline)
+    expect(yielded[0]).toBe("intro");
+    // When "\n- item" arrives, normalization inserts a blank line between prose and list.
+    // The normalized stable portion is "intro\n\n" but we already emitted "intro" (5 chars).
+    // So the delta from normalization is "\n\n" (chars 5..7), then final flush yields "- item".
+    expect(yielded.join("")).toBe(ensureBlockSpacing("intro\n- item"));
+  });
+
+  it("yields multiple pre-newline chunks then normalizes correctly", async () => {
+    const chunks = ["a", "b", "c", "\nd"];
+    const stream = createNormalizingStream(chunksToIterable(chunks), ensureBlockSpacing);
+    const yielded = await collectChunks(stream);
+    expect(yielded[0]).toBe("a");
+    expect(yielded[1]).toBe("b");
+    expect(yielded[2]).toBe("c");
+    expect(yielded.join("")).toBe(ensureBlockSpacing("abc\nd"));
   });
 });


### PR DESCRIPTION
`createNormalizingStream` buffered ALL content until a `\n` arrived. For typical
LLM responses that start with prose (50+ tokens before the first newline), this
created a multi-second blank message in Slack before flushing everything at once.

The fix yields raw text immediately when no newline has been seen yet. This is
safe because `ensureBlockSpacing` on a single partial line (no `\n`) is a no-op —
the raw text is identical to its normalized form. Once a `\n` arrives, the
existing normalization logic takes over and correctly computes the delta from
the already-emitted prefix.

Fixes #60