### PR TITLE
feat(chat): Generate dynamic thread titles for Slack assistant history

### DIFF
--- a/src/chat/bot.ts
+++ b/src/chat/bot.ts
@@ -32,7 +32,7 @@ import { lookupSlackUser } from "@/chat/slack-user";
 import { getStateAdapter } from "@/chat/state";
 import { completeObject, completeText, GEN_AI_PROVIDER_NAME } from "@/chat/pi/client";
 import { listThreadReplies } from "@/chat/slack-actions/channel";
-import { downloadPrivateSlackFile, getSlackClient } from "@/chat/slack-actions/client";
+import { downloadPrivateSlackFile, getSlackClient, isDmChannel } from "@/chat/slack-actions/client";
 import { publishAppHomeView } from "@/chat/app-home";
 import { getUserTokenStore } from "@/chat/capabilities/factory";
 
@@ -1602,10 +1602,10 @@ async function replyToThread(
         });
         persistedAtLeastOnce = true;
 
-        const assistantMessageCount = preparedState.conversation.messages.filter(
-          (m) => m.role === "assistant"
-        ).length;
-        if (assistantMessageCount === 1 && channelId && threadTs) {
+        const isFirstAssistantReply =
+          preparedState.conversation.stats.compactedMessageCount === 0 &&
+          preparedState.conversation.messages.filter((m) => m.role === "assistant").length === 1;
+        if (isFirstAssistantReply && channelId && isDmChannel(channelId) && threadTs) {
           void generateThreadTitle(userText, reply.text)
             .then((title) => getSlackAdapter().setAssistantTitle(channelId, threadTs, title))
             .catch((error) => {

--- a/tests/bot-handlers.test.ts
+++ b/tests/bot-handlers.test.ts
@@ -268,14 +268,14 @@ describe("bot handlers (integration)", () => {
       listThreadReplies: async () => []
     });
 
-    const thread = createTestThread({ id: "slack:C_TITLE:1700000000.000" });
+    const thread = createTestThread({ id: "slack:D_TITLE:1700000000.000" });
 
     try {
       await appSlackRuntime.handleNewMention(
         thread,
         createTestMessage({
           id: "msg-title-1",
-          threadId: "slack:C_TITLE:1700000000.000",
+          threadId: "slack:D_TITLE:1700000000.000",
           text: "How do I debug memory leaks in Node?",
           isMention: true
         })
@@ -291,7 +291,7 @@ describe("bot handlers (integration)", () => {
       );
       expect(generatedTitleCall).toBeDefined();
       expect(generatedTitleCall!.title).toBe("Debugging Node.js Memory Leaks");
-      expect(generatedTitleCall!.channelId).toBe("C_TITLE");
+      expect(generatedTitleCall!.channelId).toBe("D_TITLE");
       expect(generatedTitleCall!.threadTs).toBe("1700000000.000");
     } finally {
       (bot as unknown as { getAdapter?: (name: string) => unknown }).getAdapter = originalGetAdapter;
@@ -328,7 +328,7 @@ describe("bot handlers (integration)", () => {
       listThreadReplies: async () => []
     });
 
-    const thread = createTestThread({ id: "slack:C_TITLE2:1700000000.000" });
+    const thread = createTestThread({ id: "slack:D_TITLE2:1700000000.000" });
 
     try {
       // First turn — should trigger title generation
@@ -336,7 +336,7 @@ describe("bot handlers (integration)", () => {
         thread,
         createTestMessage({
           id: "msg-t2-1",
-          threadId: "slack:C_TITLE2:1700000000.000",
+          threadId: "slack:D_TITLE2:1700000000.000",
           text: "first message",
           isMention: true
         })
@@ -351,7 +351,7 @@ describe("bot handlers (integration)", () => {
         thread,
         createTestMessage({
           id: "msg-t2-2",
-          threadId: "slack:C_TITLE2:1700000000.000",
+          threadId: "slack:D_TITLE2:1700000000.000",
           text: "second message",
           isMention: true
         })


### PR DESCRIPTION
Generate contextual titles for DM threads in Slack's Assistants History panel. Previously all threads showed the static title "Junior", giving users no context about past conversations.

After the first assistant reply completes in `replyToThread()`, we count assistant messages in the conversation state. If this is the first one, a fire-and-forget promise calls `generateThreadTitle()` — which uses the fast router model (`botConfig.routerModelId`) to produce a concise 5-8 word title from the user message and assistant response — then updates the thread via `setAssistantTitle`.

The title generation never blocks the main response flow. Failures are caught and warn-logged without affecting the user experience.