### PR TITLE
fix(chat): Avoid Slack no_text error when posting generated images

### DIFF
--- a/src/chat/bot.ts
+++ b/src/chat/bot.ts
@@ -1583,7 +1583,9 @@ async function replyToThread(
         persistedAtLeastOnce = true;
 
         if (streamedReplyPromise && replyFiles) {
-          await thread.post({ markdown: "", files: replyFiles });
+          // Omit text properties so the adapter's file-only early-return
+          // triggers (avoids Slack `no_text` error from empty chat.postMessage)
+          await thread.post({ files: replyFiles } as Parameters<typeof thread.post>[0]);
         }
       } finally {
         textStream.end();

--- a/tests/bot-image-hydration.test.ts
+++ b/tests/bot-image-hydration.test.ts
@@ -395,5 +395,19 @@ describe("bot image hydration", () => {
 
     // Should have at least 2 posts: the streamed reply and the file upload
     expect(postSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+    // The file-only post should omit markdown so the adapter's file-only early-return triggers
+    const filePost = postSpy.mock.calls.find(
+      (call: unknown[]) =>
+        typeof call[0] === "object" &&
+        call[0] !== null &&
+        "files" in (call[0] as Record<string, unknown>) &&
+        Array.isArray((call[0] as { files?: unknown[] }).files) &&
+        ((call[0] as { files: unknown[] }).files).length > 0
+    );
+    expect(filePost).toBeDefined();
+    const filePostArg = filePost![0] as Record<string, unknown>;
+    expect(filePostArg).not.toHaveProperty("markdown");
+    expect((filePostArg.files as Array<{ filename: string }>)[0].filename).toBe("generated.png");
   });
 });


### PR DESCRIPTION
When Jr generates an image during a streamed reply, files are posted
separately after the text stream completes. The previous call passed
`{ markdown: "", files }` — the adapter saw `"markdown" in message`
as truthy (property exists despite empty value), skipped its file-only
early-return, and proceeded to `chat.postMessage` with empty text.
Slack rejected this with `no_text`, surfacing an error to the user.

Fix: omit the text property entirely so the adapter's existing file-only
code path handles the upload without a redundant `chat.postMessage` call.
This avoids a brittle dist-level patch in favor of a one-line caller fix.