### PR TITLE
docs: overhaul plugin pages for consistency

### DIFF
--- a/packages/docs/src/content/docs/extend/_plugin-template.md
+++ b/packages/docs/src/content/docs/extend/_plugin-template.md
@@ -1,0 +1,61 @@
+---
+title: Plugin Page Template
+description: Canonical structure for plugin setup pages.
+type: tutorial
+summary: Use this template when writing or updating plugin setup pages so readers get the same install-to-verify flow each time.
+prerequisites:
+  - /extend/
+related:
+  - /extend/
+  - /reference/config-and-env/
+---
+
+Use this template for plugin setup pages so every plugin guide follows the same reader path.
+
+## Install
+
+Install the plugin package alongside `@sentry/junior`:
+
+```bash
+pnpm add @sentry/junior @sentry/junior-example
+```
+
+## Register with `withJunior`
+
+Add the package to `pluginPackages` so build-time tracing and runtime discovery stay aligned:
+
+```ts title="next.config.mjs"
+import { withJunior } from "@sentry/junior/config";
+
+export default withJunior({
+  pluginPackages: ["@sentry/junior-example"],
+});
+```
+
+## Configure environment variables
+
+Use a table even when the answer is "none required":
+
+| Variable        | Required | Purpose                 |
+| --------------- | -------- | ----------------------- |
+| `EXAMPLE_TOKEN` | Yes      | Example API credential. |
+
+If no variables are required, replace the table with a single sentence:
+
+`No environment variables are required for this plugin.`
+
+## Plugin-specific setup
+
+Explain the provider-specific setup after install and environment configuration. Keep this section concrete and action-oriented.
+
+## Verify
+
+Describe one real user workflow that confirms the plugin works end to end.
+
+## Failure modes
+
+List concrete error -> cause -> fix entries so readers can recover quickly.
+
+## Next step
+
+Link to the next page the reader should open after setup succeeds.

--- a/packages/docs/src/content/docs/extend/agent-browser-plugin.md
+++ b/packages/docs/src/content/docs/extend/agent-browser-plugin.md
@@ -2,7 +2,7 @@
 title: Agent Browser Plugin
 description: Configure browser automation workflows with agent-browser in Junior.
 type: tutorial
-summary: Install the agent-browser plugin package, run browser workflows through `/agent-browser`, and verify sandbox execution.
+summary: Install the agent-browser plugin, register it with withJunior, and verify browser automation workflows.
 prerequisites:
   - /extend/
 related:
@@ -13,26 +13,40 @@ related:
 
 The Agent Browser plugin adds a browser automation skill backed by the `agent-browser` CLI.
 
-## Setup
+## Install
 
-### Install the plugin package
+Install the plugin package alongside `@sentry/junior`:
 
 ```bash
 pnpm add @sentry/junior @sentry/junior-agent-browser
 ```
 
-### What this plugin provides
+## Register with `withJunior`
+
+Add the package to `pluginPackages` so runtime discovery includes the browser automation skill:
+
+```ts title="next.config.mjs"
+import { withJunior } from "@sentry/junior/config";
+
+export default withJunior({
+  pluginPackages: ["@sentry/junior-agent-browser"],
+});
+```
+
+## Configure environment variables
+
+No environment variables are required for this plugin.
+
+## Plugin-specific setup
+
+This plugin provisions browser automation as part of the sandbox snapshot:
 
 - Plugin manifest: `agent-browser`
 - Skill: `/agent-browser`
-- Runtime dependency: `agent-browser` npm package installed in the sandbox snapshot
+- Runtime dependency: `agent-browser` npm package installed in the snapshot
 - Runtime postinstall: `agent-browser install` to provision browser binaries in the snapshot
 
-No OAuth or capability setup is required for this plugin.
-
-### Use the skill in a thread
-
-Example invocation:
+Use the skill in a thread:
 
 ```text
 /agent-browser Open https://example.com, capture a screenshot, and summarize what is on the page.
@@ -40,15 +54,16 @@ Example invocation:
 
 ## Verify
 
-1. Run `/agent-browser` with a simple open + snapshot request.
+1. Run `/agent-browser` with a simple open-and-snapshot request.
 2. Confirm the turn can execute `agent-browser` commands successfully.
-3. Confirm output includes concrete page evidence (URL and/or screenshot references).
+3. Confirm the output includes concrete page evidence such as the final URL or screenshot references.
 
-## Failure Modes
+## Failure modes
 
-- `command not found: agent-browser`: runtime dependency install did not complete; retry the turn and check sandbox setup logs.
-- Stale element refs (`@e*`): take a fresh `snapshot -i` after navigation or DOM changes.
-- Page appears incomplete: wait explicitly with `agent-browser wait --load networkidle` before interacting.
+- `command not found: agent-browser`: the runtime dependency install did not complete. Retry the turn and check sandbox snapshot setup logs.
+- Browser launch fails during the turn: browser binaries were not provisioned successfully. Rebuild the snapshot so `agent-browser install` runs again.
+- Stale element references like `@e*`: the DOM changed after the snapshot was taken. Run a fresh `snapshot -i` after navigation or UI updates.
+- Page appears incomplete: the page had not finished loading before the next action. Wait explicitly with `agent-browser wait --load networkidle` before interacting.
 
 ## Next step
 

--- a/packages/docs/src/content/docs/extend/github-plugin.md
+++ b/packages/docs/src/content/docs/extend/github-plugin.md
@@ -2,7 +2,7 @@
 title: GitHub Plugin
 description: Configure GitHub App credentials for issue workflows.
 type: tutorial
-summary: Configure the GitHub plugin with app credentials and verify capability-scoped issue workflows.
+summary: Install the GitHub plugin, register it with withJunior, configure GitHub App credentials, and verify issue workflows.
 prerequisites:
   - /extend/
 related:
@@ -10,15 +10,37 @@ related:
   - /reference/runtime-commands/
 ---
 
-The GitHub plugin uses GitHub App credentials so Junior can run repository workflows with explicit capability scoping.
+The GitHub plugin uses a GitHub App so Junior can create and update issues with explicit capability scoping.
 
-## Setup
+## Install
 
-### Configure host env vars
+Install the plugin package alongside `@sentry/junior`:
 
-- `GITHUB_APP_ID`
-- `GITHUB_APP_PRIVATE_KEY`
-- `GITHUB_INSTALLATION_ID`
+```bash
+pnpm add @sentry/junior @sentry/junior-github
+```
+
+## Register with `withJunior`
+
+Add the package to `pluginPackages` so build-time tracing and runtime discovery use the same explicit plugin list:
+
+```ts title="next.config.mjs"
+import { withJunior } from "@sentry/junior/config";
+
+export default withJunior({
+  pluginPackages: ["@sentry/junior-github"],
+});
+```
+
+## Configure environment variables
+
+Set these values in the host environment:
+
+| Variable                 | Required | Purpose                                         |
+| ------------------------ | -------- | ----------------------------------------------- |
+| `GITHUB_APP_ID`          | Yes      | GitHub App identity.                            |
+| `GITHUB_APP_PRIVATE_KEY` | Yes      | GitHub App signing key.                         |
+| `GITHUB_INSTALLATION_ID` | Yes      | Repository or organization installation target. |
 
 Vercel example:
 
@@ -28,14 +50,16 @@ vercel env add GITHUB_INSTALLATION_ID production
 vercel env add GITHUB_APP_PRIVATE_KEY production --sensitive < ./github-app-private-key.pem
 ```
 
-### Issue capability-scoped credentials at runtime
+## Create the GitHub App
 
-```bash
-jr-rpc issue-credential github.issues.write
-gh issue create --repo owner/repo --title "Example issue" --body "Created from Junior"
-```
+Create and install a GitHub App before you issue credentials at runtime:
 
-Optional default repo:
+1. Open GitHub App settings and create a new app.
+2. Generate a private key and store the downloaded `.pem` file securely.
+3. Install the app on the repository or organization Junior should access.
+4. Copy the App ID and installation ID into your deployment environment.
+
+If you want a stable default repository for issue creation, set it once:
 
 ```bash
 jr-rpc config set github.repo getsentry/junior
@@ -43,14 +67,22 @@ jr-rpc config set github.repo getsentry/junior
 
 ## Verify
 
-- Create/update/comment/label operations succeed in a test repo.
-- Actions are attributed to the GitHub App identity.
+Issue a capability-scoped credential and create a test issue:
+
+```bash
+jr-rpc issue-credential github.issues.write
+gh issue create --repo owner/repo --title "Example issue" --body "Created from Junior"
+```
+
+Confirm the issue is created successfully and attributed to the GitHub App identity.
 
 ## Failure modes
 
-- Access denied: app not installed on target repo/org.
-- Missing capability: wrong credential scope for operation.
+- `Access denied` from GitHub: the app is not installed on the target repository or organization. Install the app on that target, then retry.
+- `Bad credentials` or signing errors: `GITHUB_APP_PRIVATE_KEY` does not match the App ID. Upload the private key generated for the same app as `GITHUB_APP_ID`.
+- Missing repository context: no repo was provided for the action. Pass `--repo owner/repo` or set `github.repo` with `jr-rpc config set`.
+- Missing capability: the issued credential scope does not cover the requested operation. Re-issue credentials with the required GitHub capability.
 
 ## Next step
 
-Read [Runtime Commands](/reference/runtime-commands/) for credential/config command behavior.
+Read [Runtime Commands](/reference/runtime-commands/) for credential and config command behavior.

--- a/packages/docs/src/content/docs/extend/notion-plugin.md
+++ b/packages/docs/src/content/docs/extend/notion-plugin.md
@@ -2,7 +2,7 @@
 title: Notion Plugin
 description: Configure a shared internal Notion integration for read-only page and data source search workflows.
 type: tutorial
-summary: Set up the Notion plugin with an internal integration token and verify `/notion` page and data source search workflows.
+summary: Install the Notion plugin, register it with withJunior, configure a shared integration token, and verify `/notion` search workflows.
 prerequisites:
   - /extend/
 related:
@@ -14,31 +14,17 @@ The Notion plugin uses a shared internal integration so Slack users can search s
 
 Notion's public search API is more limited than the search experience in the Notion app. Junior uses the stable public API, so `/notion` works best when users search for the exact page or data source title they want to open.
 
-## Setup
+## Install
 
-### Create an internal Notion integration
+Install the plugin package alongside `@sentry/junior`:
 
-Start with Notion's [Authorization guide](https://developers.notion.com/guides/get-started/authorization), then create an internal integration in the Notion integrations dashboard. Notion's docs describe internal integrations as single-workspace integrations that authenticate with one integration token rather than OAuth.
+```bash
+pnpm add @sentry/junior @sentry/junior-notion
+```
 
-After you create the integration:
+## Register with `withJunior`
 
-1. Open the `Configuration` tab.
-2. Copy the integration secret.
-3. Set it in your host environment as `NOTION_TOKEN`.
-
-### Enable the required Notion capability
-
-Open the integration's `Capabilities` tab and enable `Read content`.
-
-Junior's Notion workflow searches pages and data sources, retrieves page markdown, and queries data source rows, so `Read content` is the required content capability. Notion documents capability requirements here:
-
-- [Integration capabilities](https://developers.notion.com/reference/capabilities)
-- [Retrieve a page as markdown](https://developers.notion.com/reference/retrieve-page-markdown)
-- [Query a data source](https://developers.notion.com/reference/query-a-data-source)
-
-### Register the plugin in Junior
-
-Install and register the plugin package:
+Add the package to `pluginPackages` so runtime discovery includes the Notion plugin:
 
 ```ts title="next.config.mjs"
 import { withJunior } from "@sentry/junior/config";
@@ -48,34 +34,42 @@ export default withJunior({
 });
 ```
 
-Set the integration token in your host environment:
+## Configure environment variables
 
-- `NOTION_TOKEN`
+Set these values in the host environment:
 
-### Share pages and data sources with the integration
+| Variable       | Required | Purpose                                                              |
+| -------------- | -------- | -------------------------------------------------------------------- |
+| `NOTION_TOKEN` | Yes      | Internal integration secret used for search and page fetch requests. |
 
-Notion internal integrations only see the pages and data sources that are explicitly shared with them. Notion's docs describe this as a manual sharing step:
+## Create the Notion integration
+
+Start with Notion's [Authorization guide](https://developers.notion.com/guides/get-started/authorization), then create an internal integration in the Notion integrations dashboard.
+
+After you create the integration:
+
+1. Choose the workspace where the integration will live.
+2. Open the `Capabilities` tab and enable `Read content`.
+3. Open the `Configuration` tab and copy the integration secret.
+4. Store that secret in your deployment environment as `NOTION_TOKEN`.
+
+## Share pages and data sources with the integration
+
+Notion internal integrations only see the pages and data sources that are explicitly shared with them:
 
 1. Open the page or data source in Notion.
 2. Click the `•••` menu in the upper right.
 3. Choose `Add connections`.
 4. Select your integration.
 
-This is the most common reason `/notion` returns no matches or a `404`/permission-style error from the Notion API.
-
-### Runtime usage flow
-
-1. Admin configures `NOTION_TOKEN` once.
-2. Admin shares the relevant pages or data sources with the integration in Notion.
-3. Users run `/notion <query>` in Slack.
+This is the most common reason `/notion` returns no matches or a permission-style error.
 
 ## Verify
 
-- `NOTION_TOKEN` is set in the host environment.
-- The target page or data source is shared with the integration in Notion.
-- A real `/notion <query>` request returns a summary and source URL.
+Confirm the token is set, the target content is shared with the integration, and a real search succeeds:
 
-For local debugging, you can also run:
+- Run `/notion <query>` in Slack and confirm the response includes the expected page or data source.
+- If needed, verify the same content through the local helper scripts:
 
 ```bash
 pnpm notion:search -- --query "company holidays"
@@ -84,13 +78,11 @@ pnpm notion:fetch -- --id "<notion-id>" --object page
 
 ## Failure modes
 
-- No search matches: the page or data source may not be shared with the integration yet, or Notion search may still be indexing immediately after content was shared.
-- `403` from Notion: the integration is missing `Read content`.
-- `401` from Notion: `NOTION_TOKEN` is missing or invalid.
-- Retrieval errors: the top matching page or data source could not be fetched for summarization.
-- Search results differ from notion.so: Junior uses Notion's public `v1` API, which is title-biased and does not expose the richer `Best matches` behavior from the Notion UI.
-
-Notion's search docs note that directly shared pages are guaranteed to appear, while newly shared content can still be delayed by search indexing. If a page or data source was just shared and `/notion` still misses it, retry once indexing catches up.
+- No search matches: the target page or data source is not shared with the integration yet, or Notion search is still indexing newly shared content. Share the content directly and retry after indexing catches up.
+- `403` from Notion: the integration is missing `Read content`. Enable that capability in the integration settings.
+- `401` from Notion: `NOTION_TOKEN` is missing or invalid. Update the deployment secret and redeploy.
+- Retrieval errors after a match: the matching page or data source could not be fetched for summarization. Confirm the object is still shared and accessible to the integration.
+- Search results differ from notion.so: Junior uses Notion's public `v1` API, which is title-biased and does not expose the richer `Best matches` behavior from the Notion UI. Search by the exact title when possible.
 
 ## Next step
 

--- a/packages/docs/src/content/docs/extend/sentry-plugin.md
+++ b/packages/docs/src/content/docs/extend/sentry-plugin.md
@@ -2,7 +2,7 @@
 title: Sentry Plugin
 description: Configure Sentry OAuth for per-user investigation workflows.
 type: tutorial
-summary: Set up Sentry OAuth for per-user access and verify re-auth behavior for investigation workflows.
+summary: Install the Sentry plugin, register it with withJunior, configure OAuth, and verify per-user investigation workflows.
 prerequisites:
   - /extend/
 related:
@@ -10,30 +10,48 @@ related:
   - /operate/security-hardening/
 ---
 
-The Sentry plugin enables per-user OAuth so Slack users can run Sentry investigations through capability-scoped access.
+The Sentry plugin enables per-user OAuth so Slack users can run Sentry investigations with their own access.
 
-## Setup
+## Install
 
-### Configure OAuth application
+Install the plugin package alongside `@sentry/junior`:
 
-Set redirect URL to:
+```bash
+pnpm add @sentry/junior @sentry/junior-sentry
+```
+
+## Register with `withJunior`
+
+Add the package to `pluginPackages` so runtime discovery includes the Sentry plugin:
+
+```ts title="next.config.mjs"
+import { withJunior } from "@sentry/junior/config";
+
+export default withJunior({
+  pluginPackages: ["@sentry/junior-sentry"],
+});
+```
+
+## Configure environment variables
+
+Set these values in the host environment:
+
+| Variable               | Required | Purpose              |
+| ---------------------- | -------- | -------------------- |
+| `SENTRY_CLIENT_ID`     | Yes      | OAuth client ID.     |
+| `SENTRY_CLIENT_SECRET` | Yes      | OAuth client secret. |
+
+## Create the Sentry OAuth application
+
+Create an OAuth application in Sentry and set its redirect URL to:
 
 ```text
 <base-url>/api/oauth/callback/sentry
 ```
 
-Set host env vars:
+Then copy the client ID and client secret into your deployment environment as `SENTRY_CLIENT_ID` and `SENTRY_CLIENT_SECRET`.
 
-- `SENTRY_CLIENT_ID`
-- `SENTRY_CLIENT_SECRET`
-
-### Runtime auth flow
-
-1. User runs `/sentry auth`.
-2. Runtime sends private authorization link.
-3. OAuth callback stores token and can resume the original request.
-
-### Optional defaults
+If your workspace usually targets the same org or project, set defaults once:
 
 ```bash
 jr-rpc config set sentry.org getsentry
@@ -42,14 +60,21 @@ jr-rpc config set sentry.project my-project
 
 ## Verify
 
-- `/sentry auth` completes successfully.
-- A real query returns expected data.
-- Re-auth flow works after token invalidation.
+Run the auth flow and then make a real Sentry request:
+
+1. User runs `/sentry auth`.
+2. Junior sends the private authorization link.
+3. The OAuth callback stores the token and resumes the original request.
+4. User runs a real Sentry query in Slack.
+
+Confirm the auth flow completes, the query returns expected data, and re-auth works after token invalidation.
 
 ## Failure modes
 
-- 401/403 after issuance: token lacks org access or stale token.
-- Callback errors: redirect URL mismatch or invalid base URL.
+- Callback errors after consent: the OAuth redirect URL does not exactly match `<base-url>/api/oauth/callback/sentry`. Update the OAuth app redirect URL and retry.
+- `401` or `403` after authorization: the user token lacks org access or is stale. Re-run `/sentry auth` with an account that can access the target org.
+- Auth link points at the wrong host: `JUNIOR_BASE_URL` is unset or incorrect. Set it to the canonical public base URL used for callbacks.
+- Query still targets the wrong project: no default config was set for the workspace. Set `sentry.org` and `sentry.project`, or provide the target explicitly in the request.
 
 ## Next step
 


### PR DESCRIPTION
Restructure the plugin setup docs so each page follows the same reader flow: install the package, register it with `withJunior`, configure environment variables, complete provider-specific setup, verify the integration, and recover from common failures.

The previous pages covered the same material in different orders, which made it harder to compare plugins or scan for the next required step. This rewrite puts the setup contract in the same place on each page and adds a hidden `_plugin-template.md` so future plugin pages start from the same structure.

This also recreates the missing branch work captured in issue #88 after the original draft content could not be pushed directly from the GitHub App.

Fixes GH-88