### PR TITLE
fix(slack): Skip replies directed at other bots

### DIFF
--- a/packages/junior/src/chat/app-runtime.ts
+++ b/packages/junior/src/chat/app-runtime.ts
@@ -1,4 +1,5 @@
 import type { Message, Thread } from "chat";
+import { getSubscribedReplyPreflightDecision } from "@/chat/routing/subscribed-decision";
 import { isRetryableTurnError } from "@/chat/turn/errors";
 import type { ErrorReference } from "@/chat/observability";
 import { getSlackErrorObservabilityAttributes } from "@/chat/runtime/thread-context";
@@ -31,7 +32,11 @@ export interface AppRuntimeReplyHooks {
 }
 
 function isExplicitMentionDecision(reason: string): boolean {
-  return reason === "explicit mention" || reason === "explicit_mention" || reason.startsWith("explicit_mention:");
+  return (
+    reason === "explicit mention" ||
+    reason === "explicit_mention" ||
+    reason.startsWith("explicit_mention:")
+  );
 }
 
 type AppRuntimeLogContext = Record<string, unknown> & {
@@ -47,7 +52,9 @@ type AppRuntimeLogContext = Record<string, unknown> & {
 export interface AppSlackRuntimeDependencies<TPreparedState> {
   assistantUserName: string;
   getChannelId: (thread: Thread, message: Message) => string | undefined;
-  getPreparedConversationContext: (preparedState: TPreparedState) => string | undefined;
+  getPreparedConversationContext: (
+    preparedState: TPreparedState,
+  ) => string | undefined;
   getThreadId: (thread: Thread, message: Message) => string | undefined;
   getRunId: (thread: Thread, message: Message) => string | undefined;
   initializeAssistantThread: (event: {
@@ -61,22 +68,29 @@ export interface AppSlackRuntimeDependencies<TPreparedState> {
     eventName: string,
     context?: Record<string, unknown>,
     attributes?: Record<string, unknown>,
-    body?: string
+    body?: string,
   ) => string | undefined;
   logWarn: (
     eventName: string,
     context?: Record<string, unknown>,
     attributes?: Record<string, unknown>,
-    body?: string
+    body?: string,
   ) => void;
   modelId: string;
   now: () => number;
   getErrorReference: (eventId?: string) => ErrorReference | null;
+  recordSkippedSubscribedMessage: (args: {
+    completedAtMs: number;
+    decision: AppRuntimeReplyDecision;
+    message: Message;
+    thread: Thread;
+    userText: string;
+  }) => Promise<void>;
   onSubscribedMessageSkipped: (args: {
     completedAtMs: number;
     decision: AppRuntimeReplyDecision;
     message: Message;
-    preparedState: TPreparedState;
+    preparedState?: TPreparedState;
     thread: Thread;
   }) => Promise<void>;
   persistPreparedState: (args: {
@@ -97,7 +111,7 @@ export interface AppSlackRuntimeDependencies<TPreparedState> {
       beforeFirstResponsePost?: () => Promise<void>;
       explicitMention?: boolean;
       preparedState?: TPreparedState;
-    }
+    },
   ) => Promise<void>;
   shouldReplyInSubscribedThread: (args: {
     context: AppRuntimeThreadContext;
@@ -111,13 +125,13 @@ export interface AppSlackRuntimeDependencies<TPreparedState> {
     text: string,
     options: {
       stripLeadingSlackMentionToken?: boolean;
-    }
+    },
   ) => string;
   withSpan: (
     name: string,
     op: string,
     context: Record<string, unknown>,
-    callback: () => Promise<void>
+    callback: () => Promise<void>,
   ) => Promise<void>;
 }
 
@@ -133,23 +147,35 @@ function buildFailureMessage(reference: ErrorReference | null): string {
 
 export interface AppSlackRuntime<
   TPreparedState,
-  TAssistantEvent extends AppRuntimeAssistantLifecycleEvent = AppRuntimeAssistantLifecycleEvent
+  TAssistantEvent extends AppRuntimeAssistantLifecycleEvent =
+    AppRuntimeAssistantLifecycleEvent,
 > {
   handleAssistantContextChanged: (event: TAssistantEvent) => Promise<void>;
   handleAssistantThreadStarted: (event: TAssistantEvent) => Promise<void>;
-  handleNewMention: (thread: Thread, message: Message, hooks?: AppRuntimeReplyHooks) => Promise<void>;
-  handleSubscribedMessage: (thread: Thread, message: Message, hooks?: AppRuntimeReplyHooks) => Promise<void>;
+  handleNewMention: (
+    thread: Thread,
+    message: Message,
+    hooks?: AppRuntimeReplyHooks,
+  ) => Promise<void>;
+  handleSubscribedMessage: (
+    thread: Thread,
+    message: Message,
+    hooks?: AppRuntimeReplyHooks,
+  ) => Promise<void>;
 }
 
 function buildLogContext(
-  deps: Pick<AppSlackRuntimeDependencies<unknown>, "assistantUserName" | "modelId">,
+  deps: Pick<
+    AppSlackRuntimeDependencies<unknown>,
+    "assistantUserName" | "modelId"
+  >,
   args: {
     channelId?: string;
     requesterId?: string;
     requesterUserName?: string;
     threadId?: string;
     runId?: string;
-  }
+  },
 ): AppRuntimeLogContext {
   return {
     slackThreadId: args.threadId,
@@ -158,15 +184,16 @@ function buildLogContext(
     slackChannelId: args.channelId,
     runId: args.runId,
     assistantUserName: deps.assistantUserName,
-    modelId: deps.modelId
+    modelId: deps.modelId,
   };
 }
 
 export function createAppSlackRuntime<
   TPreparedState,
-  TAssistantEvent extends AppRuntimeAssistantLifecycleEvent = AppRuntimeAssistantLifecycleEvent
+  TAssistantEvent extends AppRuntimeAssistantLifecycleEvent =
+    AppRuntimeAssistantLifecycleEvent,
 >(
-  deps: AppSlackRuntimeDependencies<TPreparedState>
+  deps: AppSlackRuntimeDependencies<TPreparedState>,
 ): AppSlackRuntime<TPreparedState, TAssistantEvent> {
   const logContext = (args: {
     channelId?: string;
@@ -174,8 +201,7 @@ export function createAppSlackRuntime<
     requesterUserName?: string;
     threadId?: string;
     runId?: string;
-  }): AppRuntimeLogContext =>
-    buildLogContext(deps, args);
+  }): AppRuntimeLogContext => buildLogContext(deps, args);
 
   const postFallbackErrorReplyWithLogging = async (args: {
     thread: Thread;
@@ -194,17 +220,23 @@ export function createAppSlackRuntime<
         args.errorContext,
         {
           "app.slack.reply_stage": "error_fallback_post",
-          ...(args.eventId ? { "app.error.original_event_id": args.eventId } : {}),
-          ...getSlackErrorObservabilityAttributes(postError)
+          ...(args.eventId
+            ? { "app.error.original_event_id": args.eventId }
+            : {}),
+          ...getSlackErrorObservabilityAttributes(postError),
         },
-        args.postFailureBody
+        args.postFailureBody,
       );
       throw postError;
     }
   };
 
   return {
-    async handleNewMention(thread: Thread, message: Message, hooks?: AppRuntimeReplyHooks): Promise<void> {
+    async handleNewMention(
+      thread: Thread,
+      message: Message,
+      hooks?: AppRuntimeReplyHooks,
+    ): Promise<void> {
       try {
         const threadId = deps.getThreadId(thread, message);
         const channelId = deps.getChannelId(thread, message);
@@ -214,28 +246,23 @@ export function createAppSlackRuntime<
           channelId,
           requesterId: message.author.userId,
           requesterUserName: message.author.userName,
-          runId
+          runId,
         });
 
-        await deps.withSpan(
-          "chat.turn",
-          "chat.turn",
-          context,
-          async () => {
-            await thread.subscribe();
-            await deps.replyToThread(thread, message, {
-              explicitMention: true,
-              beforeFirstResponsePost: hooks?.beforeFirstResponsePost
-            });
-          }
-        );
+        await deps.withSpan("chat.turn", "chat.turn", context, async () => {
+          await thread.subscribe();
+          await deps.replyToThread(thread, message, {
+            explicitMention: true,
+            beforeFirstResponsePost: hooks?.beforeFirstResponsePost,
+          });
+        });
       } catch (error) {
         const errorContext = logContext({
           threadId: deps.getThreadId(thread, message),
           requesterId: message.author.userId,
           requesterUserName: message.author.userName,
           channelId: deps.getChannelId(thread, message),
-          runId: deps.getRunId(thread, message)
+          runId: deps.getRunId(thread, message),
         });
         if (isRetryableTurnError(error)) {
           deps.logException(
@@ -243,7 +270,7 @@ export function createAppSlackRuntime<
             "mention_handler_retryable_failure",
             errorContext,
             { "app.turn.retryable_reason": error.reason },
-            "onNewMention failed with retryable error"
+            "onNewMention failed with retryable error",
           );
           throw error;
         }
@@ -252,7 +279,7 @@ export function createAppSlackRuntime<
           "mention_handler_failed",
           errorContext,
           {},
-          "onNewMention failed"
+          "onNewMention failed",
         );
         await hooks?.beforeFirstResponsePost?.();
         const reference = deps.getErrorReference(eventId);
@@ -262,52 +289,102 @@ export function createAppSlackRuntime<
           errorContext,
           eventId,
           postFailureEventName: "mention_handler_failure_reply_post_failed",
-          postFailureBody: "Failed to post fallback error reply for mention handler"
+          postFailureBody:
+            "Failed to post fallback error reply for mention handler",
         });
       }
     },
 
-    async handleSubscribedMessage(thread: Thread, message: Message, hooks?: AppRuntimeReplyHooks): Promise<void> {
+    async handleSubscribedMessage(
+      thread: Thread,
+      message: Message,
+      hooks?: AppRuntimeReplyHooks,
+    ): Promise<void> {
       try {
         const threadId = deps.getThreadId(thread, message);
         const channelId = deps.getChannelId(thread, message);
         const runId = deps.getRunId(thread, message);
         const rawUserText = message.text;
         const userText = deps.stripLeadingBotMention(rawUserText, {
-          stripLeadingSlackMentionToken: Boolean(message.isMention)
+          stripLeadingSlackMentionToken: Boolean(message.isMention),
         });
         const context: AppRuntimeThreadContext = {
           threadId,
           requesterId: message.author.userId,
           channelId,
-          runId
+          runId,
         };
+        const preflightDecision = hooks?.preApprovedReply
+          ? undefined
+          : getSubscribedReplyPreflightDecision({
+              botUserName: deps.assistantUserName,
+              rawText: rawUserText,
+              text: userText,
+              isExplicitMention: Boolean(message.isMention),
+            });
+
+        if (preflightDecision && !preflightDecision.shouldReply) {
+          const completedAtMs = deps.now();
+          const reason = preflightDecision.reasonDetail
+            ? `${preflightDecision.reason}:${preflightDecision.reasonDetail}`
+            : preflightDecision.reason;
+          deps.logWarn(
+            "subscribed_message_reply_skipped",
+            logContext({
+              threadId,
+              requesterId: message.author.userId,
+              requesterUserName: message.author.userName,
+              channelId,
+              runId,
+            }),
+            {
+              "app.decision.reason": reason,
+            },
+            "Skipping subscribed message reply",
+          );
+          await deps.onSubscribedMessageSkipped({
+            thread,
+            message,
+            decision: { shouldReply: false, reason },
+            completedAtMs,
+            preparedState: undefined,
+          });
+          await deps.recordSkippedSubscribedMessage({
+            thread,
+            message,
+            decision: { shouldReply: false, reason },
+            completedAtMs,
+            userText,
+          });
+          return;
+        }
 
         const preparedState = await deps.prepareTurnState({
           thread,
           message,
           userText,
           explicitMention: Boolean(message.isMention),
-          context
+          context,
         });
 
         await deps.persistPreparedState({
           thread,
-          preparedState
+          preparedState,
         });
 
         const decision = hooks?.preApprovedReply
           ? {
               shouldReply: true,
-              reason: "pre_approved_reply"
+              reason: "pre_approved_reply",
             }
           : await deps.shouldReplyInSubscribedThread({
               rawText: rawUserText,
               text: userText,
-              conversationContext: deps.getPreparedConversationContext(preparedState),
+              conversationContext:
+                deps.getPreparedConversationContext(preparedState),
               hasAttachments: message.attachments.length > 0,
               isExplicitMention: Boolean(message.isMention),
-              context
+              context,
             });
 
         if (!decision.shouldReply) {
@@ -318,19 +395,19 @@ export function createAppSlackRuntime<
               requesterId: message.author.userId,
               requesterUserName: message.author.userName,
               channelId,
-              runId
+              runId,
             }),
             {
-              "app.decision.reason": decision.reason
+              "app.decision.reason": decision.reason,
             },
-            "Skipping subscribed message reply"
+            "Skipping subscribed message reply",
           );
           await deps.onSubscribedMessageSkipped({
             thread,
             message,
             preparedState,
             decision,
-            completedAtMs: deps.now()
+            completedAtMs: deps.now(),
           });
           return;
         }
@@ -343,15 +420,15 @@ export function createAppSlackRuntime<
             requesterId: message.author.userId,
             requesterUserName: message.author.userName,
             channelId,
-            runId
+            runId,
           }),
           async () => {
             await deps.replyToThread(thread, message, {
               explicitMention: isExplicitMentionDecision(decision.reason),
               preparedState,
-              beforeFirstResponsePost: hooks?.beforeFirstResponsePost
+              beforeFirstResponsePost: hooks?.beforeFirstResponsePost,
             });
-          }
+          },
         );
       } catch (error) {
         const errorContext = logContext({
@@ -359,7 +436,7 @@ export function createAppSlackRuntime<
           requesterId: message.author.userId,
           requesterUserName: message.author.userName,
           channelId: deps.getChannelId(thread, message),
-          runId: deps.getRunId(thread, message)
+          runId: deps.getRunId(thread, message),
         });
         if (isRetryableTurnError(error)) {
           deps.logException(
@@ -367,7 +444,7 @@ export function createAppSlackRuntime<
             "subscribed_message_handler_retryable_failure",
             errorContext,
             { "app.turn.retryable_reason": error.reason },
-            "onSubscribedMessage failed with retryable error"
+            "onSubscribedMessage failed with retryable error",
           );
           throw error;
         }
@@ -376,7 +453,7 @@ export function createAppSlackRuntime<
           "subscribed_message_handler_failed",
           errorContext,
           {},
-          "onSubscribedMessage failed"
+          "onSubscribedMessage failed",
         );
         await hooks?.beforeFirstResponsePost?.();
         const reference = deps.getErrorReference(eventId);
@@ -385,8 +462,10 @@ export function createAppSlackRuntime<
           reference,
           errorContext,
           eventId,
-          postFailureEventName: "subscribed_message_handler_failure_reply_post_failed",
-          postFailureBody: "Failed to post fallback error reply for subscribed message handler"
+          postFailureEventName:
+            "subscribed_message_handler_failure_reply_post_failed",
+          postFailureBody:
+            "Failed to post fallback error reply for subscribed message handler",
         });
       }
     },
@@ -397,7 +476,7 @@ export function createAppSlackRuntime<
           threadId: event.threadId,
           channelId: event.channelId,
           threadTs: event.threadTs,
-          sourceChannelId: event.context?.channelId
+          sourceChannelId: event.context?.channelId,
         });
       } catch (error) {
         deps.logException(
@@ -408,10 +487,10 @@ export function createAppSlackRuntime<
             slackUserId: event.userId,
             slackChannelId: event.channelId,
             assistantUserName: deps.assistantUserName,
-            modelId: deps.modelId
+            modelId: deps.modelId,
           },
           {},
-          "onAssistantThreadStarted failed"
+          "onAssistantThreadStarted failed",
         );
       }
     },
@@ -422,7 +501,7 @@ export function createAppSlackRuntime<
           threadId: event.threadId,
           channelId: event.channelId,
           threadTs: event.threadTs,
-          sourceChannelId: event.context?.channelId
+          sourceChannelId: event.context?.channelId,
         });
       } catch (error) {
         deps.logException(
@@ -433,12 +512,12 @@ export function createAppSlackRuntime<
             slackUserId: event.userId,
             slackChannelId: event.channelId,
             assistantUserName: deps.assistantUserName,
-            modelId: deps.modelId
+            modelId: deps.modelId,
           },
           {},
-          "onAssistantContextChanged failed"
+          "onAssistantContextChanged failed",
         );
       }
-    }
+    },
   };
 }

--- a/packages/junior/src/chat/bot.ts
+++ b/packages/junior/src/chat/bot.ts
@@ -4,21 +4,46 @@ import { createSlackAdapter } from "@chat-adapter/slack";
 import "@/chat/chat-background-patch";
 import {
   createAppSlackRuntime,
-  type AppRuntimeAssistantLifecycleEvent
+  type AppRuntimeAssistantLifecycleEvent,
 } from "@/chat/app-runtime";
 import { registerBotHandlers } from "@/chat/bootstrap/register-handlers";
-import { botConfig, getSlackBotToken, getSlackClientId, getSlackClientSecret, getSlackSigningSecret } from "@/chat/config";
-import { logException, logWarn, resolveErrorReference, withSpan } from "@/chat/observability";
+import {
+  botConfig,
+  getSlackBotToken,
+  getSlackClientId,
+  getSlackClientSecret,
+  getSlackSigningSecret,
+} from "@/chat/config";
+import {
+  logException,
+  logWarn,
+  resolveErrorReference,
+  withSpan,
+} from "@/chat/observability";
 import { getStateAdapter } from "@/chat/state";
 import { initializeAssistantThread as initializeAssistantThreadImpl } from "@/chat/runtime/assistant-lifecycle";
 import { resetBotDepsForTests, setBotDepsForTests } from "@/chat/runtime/deps";
 import { createReplyToThread } from "@/chat/runtime/reply-executor";
 import { createNormalizingStream } from "@/chat/runtime/streaming";
 import { shouldReplyInSubscribedThread } from "@/chat/runtime/subscribed-routing";
-import { getChannelId, getThreadId, getRunId, stripLeadingBotMention } from "@/chat/runtime/thread-context";
+import {
+  getChannelId,
+  getThreadId,
+  getRunId,
+  stripLeadingBotMention,
+} from "@/chat/runtime/thread-context";
 import { persistThreadState } from "@/chat/runtime/thread-state";
-import { prepareTurnState, type PreparedTurnState } from "@/chat/runtime/turn-preparation";
-import { markConversationMessage, updateConversationStats } from "@/chat/services/conversation-memory";
+import { coerceThreadConversationState } from "@/chat/conversation-state";
+import {
+  prepareTurnState,
+  type PreparedTurnState,
+} from "@/chat/runtime/turn-preparation";
+import {
+  markConversationMessage,
+  normalizeConversationText,
+  updateConversationStats,
+  upsertConversationMessage,
+} from "@/chat/services/conversation-memory";
 
 const createdBot = new Chat<{ slack: SlackAdapter }>({
   userName: botConfig.userName,
@@ -37,14 +62,16 @@ const createdBot = new Chat<{ slack: SlackAdapter }>({
         signingSecret,
         ...(botToken ? { botToken } : {}),
         ...(clientId ? { clientId } : {}),
-        ...(clientSecret ? { clientSecret } : {})
+        ...(clientSecret ? { clientSecret } : {}),
       });
-    })()
+    })(),
   },
-  state: getStateAdapter()
+  state: getStateAdapter(),
 });
 
-const registerSingleton = (createdBot as unknown as { registerSingleton?: () => unknown }).registerSingleton;
+const registerSingleton = (
+  createdBot as unknown as { registerSingleton?: () => unknown }
+).registerSingleton;
 if (typeof registerSingleton === "function") {
   registerSingleton.call(createdBot);
 }
@@ -57,7 +84,7 @@ function getSlackAdapter(): SlackAdapter {
 
 const replyToThread = createReplyToThread({
   getSlackAdapter,
-  prepareTurnState
+  prepareTurnState,
 });
 
 export const appSlackRuntime = createAppSlackRuntime<
@@ -78,39 +105,95 @@ export const appSlackRuntime = createAppSlackRuntime<
   prepareTurnState,
   persistPreparedState: async ({ thread, preparedState }) => {
     await persistThreadState(thread, {
-      conversation: preparedState.conversation
+      conversation: preparedState.conversation,
     });
   },
   getPreparedConversationContext: (preparedState) =>
     preparedState.routingContext ?? preparedState.conversationContext,
   shouldReplyInSubscribedThread,
-  onSubscribedMessageSkipped: async ({ thread, preparedState, decision, completedAtMs }) => {
-    markConversationMessage(preparedState.conversation, preparedState.userMessageId, {
-      replied: false,
-      skippedReason: decision.reason
+  recordSkippedSubscribedMessage: async ({
+    thread,
+    message,
+    decision,
+    completedAtMs,
+    userText,
+  }) => {
+    const conversation = coerceThreadConversationState(await thread.state);
+    const normalizedUserText =
+      normalizeConversationText(userText) || "[non-text message]";
+    upsertConversationMessage(conversation, {
+      id: message.id,
+      role: "user",
+      text: normalizedUserText,
+      createdAtMs: message.metadata.dateSent.getTime(),
+      author: {
+        userId: message.author.userId,
+        userName: message.author.userName,
+        fullName: message.author.fullName,
+        isBot:
+          typeof message.author.isBot === "boolean"
+            ? message.author.isBot
+            : undefined,
+      },
+      meta: {
+        explicitMention: Boolean(message.isMention),
+        slackTs: message.id,
+        replied: false,
+        skippedReason: decision.reason,
+        imagesHydrated: true,
+      },
     });
+    conversation.processing.activeTurnId = undefined;
+    conversation.processing.lastCompletedAtMs = completedAtMs;
+    updateConversationStats(conversation);
+    await persistThreadState(thread, {
+      conversation,
+    });
+  },
+  onSubscribedMessageSkipped: async ({
+    thread,
+    preparedState,
+    decision,
+    completedAtMs,
+  }) => {
+    if (!preparedState) {
+      return;
+    }
+    markConversationMessage(
+      preparedState.conversation,
+      preparedState.userMessageId,
+      {
+        replied: false,
+        skippedReason: decision.reason,
+      },
+    );
     preparedState.conversation.processing.activeTurnId = undefined;
     preparedState.conversation.processing.lastCompletedAtMs = completedAtMs;
     updateConversationStats(preparedState.conversation);
     await persistThreadState(thread, {
-      conversation: preparedState.conversation
+      conversation: preparedState.conversation,
     });
   },
   replyToThread,
-  initializeAssistantThread: async ({ threadId, channelId, threadTs, sourceChannelId }) => {
+  initializeAssistantThread: async ({
+    threadId,
+    channelId,
+    threadTs,
+    sourceChannelId,
+  }) => {
     await initializeAssistantThreadImpl({
       threadId,
       channelId,
       threadTs,
       sourceChannelId,
-      getSlackAdapter
+      getSlackAdapter,
     });
-  }
+  },
 });
 
 registerBotHandlers({
   bot,
-  appSlackRuntime
+  appSlackRuntime,
 });
 
 export { createNormalizingStream, resetBotDepsForTests, setBotDepsForTests };

--- a/packages/junior/src/chat/routing/subscribed-decision.ts
+++ b/packages/junior/src/chat/routing/subscribed-decision.ts
@@ -3,6 +3,7 @@ import { escapeXml } from "@/chat/xml";
 
 export enum SubscribedReplyReason {
   ExplicitMention = "explicit_mention",
+  DirectedToOtherParty = "directed_to_other_party",
   EmptyMessage = "empty_message",
   AttachmentOnly = "attachment_only",
   Acknowledgment = "acknowledgment",
@@ -10,7 +11,7 @@ export enum SubscribedReplyReason {
   Classifier = "llm_classifier",
   SideConversation = "side_conversation",
   LowConfidence = "low_confidence",
-  ClassifierError = "classifier_error"
+  ClassifierError = "classifier_error",
 }
 
 export interface SubscribedDecisionInput {
@@ -40,7 +41,9 @@ interface ClassifierResult {
 }
 
 const replyDecisionSchema = z.object({
-  should_reply: z.boolean().describe("Whether Junior should respond to this thread message."),
+  should_reply: z
+    .boolean()
+    .describe("Whether Junior should respond to this thread message."),
   confidence: z
     .number()
     .min(0)
@@ -50,7 +53,7 @@ const replyDecisionSchema = z.object({
     .string()
     .max(160)
     .optional()
-    .describe("Short reason for the decision.")
+    .describe("Short reason for the decision."),
 });
 
 const ROUTER_CONFIDENCE_THRESHOLD = 0.72;
@@ -58,10 +61,18 @@ const ACK_REGEXES: RegExp[] = [
   /^(thanks|thank you|thx|ty|tysm|much appreciated)[!. ]*$/i,
   /^(ok|okay|k|got it|sgtm|lgtm|sounds good|works for me|works|done|resolved|perfect|great|nice|cool)[!. ]*$/i,
   /^(\+1|\+\+|ack|roger|copy that)[!. ]*$/i,
-  /^(:[a-z0-9_+-]+:|[\p{Extended_Pictographic}\uFE0F\u200D])+[!. ]*$/u
+  /^(:[a-z0-9_+-]+:|[\p{Extended_Pictographic}\uFE0F\u200D])+[!. ]*$/u,
 ];
-const QUESTION_PREFIX_RE = /^(what|why|how|when|where|which|who|can|could|would|should|do|does|did|is|are|was|were|will)\b/i;
-const FOLLOW_UP_REF_RE = /\b(you|your|that|this|it|above|previous|earlier|last|just\s+said)\b/i;
+const QUESTION_PREFIX_RE =
+  /^(what|why|how|when|where|which|who|can|could|would|should|do|does|did|is|are|was|were|will)\b/i;
+const FOLLOW_UP_REF_RE =
+  /\b(you|your|that|this|it|above|previous|earlier|last|just\s+said)\b/i;
+const LEADING_SLACK_MENTION_RE = /^\s*<@([A-Z0-9]+)(?:\|([^>]+))?>[\s,:-]*/i;
+const LEADING_NAMED_MENTION_RE = /^\s*@([a-z0-9._-]+)\b[\s,:-]*/i;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
 function tokenizeForOverlap(value: string): string[] {
   return value
@@ -70,7 +81,9 @@ function tokenizeForOverlap(value: string): string[] {
     .filter((token) => token.length >= 4);
 }
 
-function getLastAssistantLine(conversationContext: string | undefined): string | undefined {
+function getLastAssistantLine(
+  conversationContext: string | undefined,
+): string | undefined {
   if (!conversationContext) return undefined;
 
   const lines = conversationContext
@@ -102,7 +115,10 @@ function isLikelyAcknowledgment(text: string): boolean {
   return false;
 }
 
-function isLikelyAssistantDirectedFollowUp(text: string, conversationContext: string | undefined): boolean {
+function isLikelyAssistantDirectedFollowUp(
+  text: string,
+  conversationContext: string | undefined,
+): boolean {
   const trimmed = text.trim();
   if (!trimmed) return false;
 
@@ -131,7 +147,87 @@ function isLikelyAssistantDirectedFollowUp(text: string, conversationContext: st
   return false;
 }
 
-function buildRouterSystemPrompt(botUserName: string, conversationContext: string | undefined): string {
+function containsAssistantInvocation(
+  text: string,
+  botUserName: string,
+): boolean {
+  const escapedUserName = escapeRegExp(botUserName);
+  const plainNameMentionRe = new RegExp(`(^|\\s)@${escapedUserName}\\b`, "i");
+  const labeledEntityMentionRe = new RegExp(
+    `<@[^>|]+\\|${escapedUserName}>`,
+    "i",
+  );
+
+  return plainNameMentionRe.test(text) || labeledEntityMentionRe.test(text);
+}
+
+function detectLeadingOtherPartyAddress(
+  rawText: string,
+  text: string,
+  botUserName: string,
+): string | undefined {
+  if (
+    containsAssistantInvocation(rawText, botUserName) ||
+    containsAssistantInvocation(text, botUserName)
+  ) {
+    return undefined;
+  }
+
+  const leadingSlackMention = rawText.match(LEADING_SLACK_MENTION_RE);
+  if (leadingSlackMention) {
+    const label = leadingSlackMention[2]?.trim();
+    return label ? `slack_mention:${label}` : "slack_mention";
+  }
+
+  const leadingNamedMention = text.match(LEADING_NAMED_MENTION_RE);
+  if (!leadingNamedMention) {
+    return undefined;
+  }
+
+  const directedName = leadingNamedMention[1]?.trim();
+  if (
+    !directedName ||
+    directedName.toLowerCase() === botUserName.toLowerCase()
+  ) {
+    return undefined;
+  }
+
+  return `named_mention:${directedName}`;
+}
+
+export function getSubscribedReplyPreflightDecision(args: {
+  botUserName: string;
+  rawText: string;
+  text: string;
+  isExplicitMention?: boolean;
+}): SubscribedDecisionResult | undefined {
+  const text = args.text.trim();
+  const rawText = args.rawText.trim();
+
+  if (args.isExplicitMention) {
+    return { shouldReply: true, reason: SubscribedReplyReason.ExplicitMention };
+  }
+
+  const leadingOtherPartyAddress = detectLeadingOtherPartyAddress(
+    rawText,
+    text,
+    args.botUserName,
+  );
+  if (!leadingOtherPartyAddress) {
+    return undefined;
+  }
+
+  return {
+    shouldReply: false,
+    reason: SubscribedReplyReason.DirectedToOtherParty,
+    reasonDetail: leadingOtherPartyAddress,
+  };
+}
+
+function buildRouterSystemPrompt(
+  botUserName: string,
+  conversationContext: string | undefined,
+): string {
   return [
     "You are a message router for a Slack assistant named Junior in a subscribed Slack thread.",
     "Decide whether Junior should reply to the latest message.",
@@ -148,7 +244,7 @@ function buildRouterSystemPrompt(botUserName: string, conversationContext: strin
     "Return JSON with should_reply, confidence, and a short reason. Do not return any extra keys.",
     "",
     `<assistant-name>${escapeXml(botUserName)}</assistant-name>`,
-    `<thread-context>${escapeXml(conversationContext?.trim() || "[none]")}</thread-context>`
+    `<thread-context>${escapeXml(conversationContext?.trim() || "[none]")}</thread-context>`,
   ].join("\n");
 }
 
@@ -165,13 +261,21 @@ export async function decideSubscribedThreadReply(args: {
     prompt: string;
     metadata: Record<string, string>;
   }) => Promise<{ object: unknown }>;
-  logClassifierFailure: (error: unknown, input: SubscribedDecisionInput) => void;
+  logClassifierFailure: (
+    error: unknown,
+    input: SubscribedDecisionInput,
+  ) => void;
 }): Promise<SubscribedDecisionResult> {
   const text = args.input.text.trim();
   const rawText = args.input.rawText.trim();
-
-  if (args.input.isExplicitMention) {
-    return { shouldReply: true, reason: SubscribedReplyReason.ExplicitMention };
+  const preflightDecision = getSubscribedReplyPreflightDecision({
+    botUserName: args.botUserName,
+    rawText,
+    text,
+    isExplicitMention: args.input.isExplicitMention,
+  });
+  if (preflightDecision) {
+    return preflightDecision;
   }
   if (!text && !args.input.hasAttachments) {
     return { shouldReply: false, reason: SubscribedReplyReason.EmptyMessage };
@@ -183,7 +287,10 @@ export async function decideSubscribedThreadReply(args: {
     return { shouldReply: false, reason: SubscribedReplyReason.Acknowledgment };
   }
   if (isLikelyAssistantDirectedFollowUp(text, args.input.conversationContext)) {
-    return { shouldReply: true, reason: SubscribedReplyReason.FollowUpQuestion };
+    return {
+      shouldReply: true,
+      reason: SubscribedReplyReason.FollowUpQuestion,
+    };
   }
 
   try {
@@ -192,15 +299,18 @@ export async function decideSubscribedThreadReply(args: {
       schema: replyDecisionSchema,
       maxTokens: 120,
       temperature: 0,
-      system: buildRouterSystemPrompt(args.botUserName, args.input.conversationContext),
+      system: buildRouterSystemPrompt(
+        args.botUserName,
+        args.input.conversationContext,
+      ),
       prompt: rawText,
       metadata: {
         modelId: args.modelId,
         threadId: args.input.context.threadId ?? "",
         channelId: args.input.context.channelId ?? "",
         requesterId: args.input.context.requesterId ?? "",
-        runId: args.input.context.runId ?? ""
-      }
+        runId: args.input.context.runId ?? "",
+      },
     });
 
     const parsed = replyDecisionSchema.parse(result.object) as ClassifierResult;
@@ -209,7 +319,7 @@ export async function decideSubscribedThreadReply(args: {
       return {
         shouldReply: false,
         reason: SubscribedReplyReason.SideConversation,
-        reasonDetail: reason
+        reasonDetail: reason,
       };
     }
 
@@ -217,20 +327,20 @@ export async function decideSubscribedThreadReply(args: {
       return {
         shouldReply: false,
         reason: SubscribedReplyReason.LowConfidence,
-        reasonDetail: `${parsed.confidence.toFixed(2)}: ${reason}`
+        reasonDetail: `${parsed.confidence.toFixed(2)}: ${reason}`,
       };
     }
 
     return {
       shouldReply: true,
       reason: SubscribedReplyReason.Classifier,
-      reasonDetail: reason
+      reasonDetail: reason,
     };
   } catch (error) {
     args.logClassifierFailure(error, args.input);
     return {
       shouldReply: false,
-      reason: SubscribedReplyReason.ClassifierError
+      reason: SubscribedReplyReason.ClassifierError,
     };
   }
 }

--- a/packages/junior/tests/app-runtime.test.ts
+++ b/packages/junior/tests/app-runtime.test.ts
@@ -3,7 +3,7 @@ import type { Attachment } from "chat";
 import {
   createAppSlackRuntime,
   type AppRuntimeReplyDecision,
-  type AppSlackRuntimeDependencies
+  type AppSlackRuntimeDependencies,
 } from "@/chat/app-runtime";
 import { createTestThread, createTestMessage } from "./fixtures/slack-harness";
 
@@ -17,12 +17,12 @@ function createSlackInternalError(requestId: string): Error {
     code: "slack_webapi_platform_error",
     data: { error: "internal_error" },
     statusCode: 500,
-    headers: { "x-slack-req-id": requestId }
+    headers: { "x-slack-req-id": requestId },
   });
 }
 
 function createMockDeps(
-  overrides?: Partial<AppSlackRuntimeDependencies<TestState>>
+  overrides?: Partial<AppSlackRuntimeDependencies<TestState>>,
 ): AppSlackRuntimeDependencies<TestState> {
   return {
     assistantUserName: "test-bot",
@@ -36,17 +36,20 @@ function createMockDeps(
     logException: vi.fn(),
     logWarn: vi.fn(),
     onSubscribedMessageSkipped: vi.fn().mockResolvedValue(undefined),
+    recordSkippedSubscribedMessage: vi.fn().mockResolvedValue(undefined),
     persistPreparedState: vi.fn().mockResolvedValue(undefined),
-    prepareTurnState: vi.fn().mockResolvedValue({ prepared: true } satisfies TestState),
+    prepareTurnState: vi
+      .fn()
+      .mockResolvedValue({ prepared: true } satisfies TestState),
     replyToThread: vi.fn().mockResolvedValue(undefined),
     shouldReplyInSubscribedThread: vi.fn().mockResolvedValue({
       shouldReply: true,
-      reason: "test"
+      reason: "test",
     } satisfies AppRuntimeReplyDecision),
     stripLeadingBotMention: vi.fn((text: string) => text),
     getPreparedConversationContext: vi.fn(() => undefined),
     withSpan: vi.fn(async (_name, _op, _ctx, cb) => cb()),
-    ...overrides
+    ...overrides,
   };
 }
 
@@ -62,7 +65,7 @@ describe("createAppSlackRuntime", () => {
 
       expect(thread.subscribeCalls).toBe(1);
       expect(deps.replyToThread).toHaveBeenCalledWith(thread, message, {
-        explicitMention: true
+        explicitMention: true,
       });
     });
 
@@ -71,7 +74,7 @@ describe("createAppSlackRuntime", () => {
       const runtime = createAppSlackRuntime<TestState>(deps);
       const thread = createTestThread({});
       const message = createTestMessage({
-        author: { userId: "U-caller" }
+        author: { userId: "U-caller" },
       });
 
       await runtime.handleNewMention(thread, message);
@@ -82,9 +85,9 @@ describe("createAppSlackRuntime", () => {
         expect.objectContaining({
           assistantUserName: "test-bot",
           modelId: "test-model",
-          slackUserId: "U-caller"
+          slackUserId: "U-caller",
         }),
-        expect.any(Function)
+        expect.any(Function),
       );
     });
 
@@ -92,7 +95,7 @@ describe("createAppSlackRuntime", () => {
       const replyError = new Error("reply failed");
       const deps = createMockDeps({
         replyToThread: vi.fn().mockRejectedValue(replyError),
-        withSpan: vi.fn(async (_n, _o, _c, cb) => cb())
+        withSpan: vi.fn(async (_n, _o, _c, cb) => cb()),
       });
       const runtime = createAppSlackRuntime<TestState>(deps);
       const thread = createTestThread({});
@@ -105,15 +108,17 @@ describe("createAppSlackRuntime", () => {
         "mention_handler_failed",
         expect.any(Object),
         {},
-        "onNewMention failed"
+        "onNewMention failed",
       );
-      expect(thread.posts).toContain("I ran into an internal error while processing that. Please try again.");
+      expect(thread.posts).toContain(
+        "I ran into an internal error while processing that. Please try again.",
+      );
     });
 
     it("on subscribe failure: posts safe error and calls logException", async () => {
       const subscribeError = new Error("subscribe failed");
       const deps = createMockDeps({
-        withSpan: vi.fn(async (_n, _o, _c, cb) => cb())
+        withSpan: vi.fn(async (_n, _o, _c, cb) => cb()),
       });
       const runtime = createAppSlackRuntime<TestState>(deps);
       const thread = createTestThread({});
@@ -130,9 +135,11 @@ describe("createAppSlackRuntime", () => {
         "mention_handler_failed",
         expect.any(Object),
         {},
-        "onNewMention failed"
+        "onNewMention failed",
       );
-      expect(thread.posts).toContain("I ran into an internal error while processing that. Please try again.");
+      expect(thread.posts).toContain(
+        "I ran into an internal error while processing that. Please try again.",
+      );
     });
 
     it("includes sentry event id when available", async () => {
@@ -141,7 +148,10 @@ describe("createAppSlackRuntime", () => {
         replyToThread: vi.fn().mockRejectedValue(replyError),
         withSpan: vi.fn(async (_n, _o, _c, cb) => cb()),
         logException: vi.fn(() => "evt_123"),
-        getErrorReference: () => ({ eventId: "evt_123", traceId: "trace_ignored" })
+        getErrorReference: () => ({
+          eventId: "evt_123",
+          traceId: "trace_ignored",
+        }),
       });
       const runtime = createAppSlackRuntime<TestState>(deps);
       const thread = createTestThread({});
@@ -150,7 +160,7 @@ describe("createAppSlackRuntime", () => {
       await runtime.handleNewMention(thread, message);
 
       expect(thread.posts).toContain(
-        "I ran into an internal error while processing that. Reference: `event_id=evt_123 trace_id=trace_ignored`."
+        "I ran into an internal error while processing that. Reference: `event_id=evt_123 trace_id=trace_ignored`.",
       );
     });
 
@@ -160,7 +170,7 @@ describe("createAppSlackRuntime", () => {
         replyToThread: vi.fn().mockRejectedValue(replyError),
         withSpan: vi.fn(async (_n, _o, _c, cb) => cb()),
         logException: vi.fn(() => undefined),
-        getErrorReference: () => ({ traceId: "trace_123" })
+        getErrorReference: () => ({ traceId: "trace_123" }),
       });
       const runtime = createAppSlackRuntime<TestState>(deps);
       const thread = createTestThread({});
@@ -169,7 +179,7 @@ describe("createAppSlackRuntime", () => {
       await runtime.handleNewMention(thread, message);
 
       expect(thread.posts).toContain(
-        "I ran into an internal error while processing that. Reference: `trace_id=trace_123`."
+        "I ran into an internal error while processing that. Reference: `trace_id=trace_123`.",
       );
     });
 
@@ -180,14 +190,18 @@ describe("createAppSlackRuntime", () => {
       const deps = createMockDeps({
         replyToThread: vi.fn().mockRejectedValue(replyError),
         withSpan: vi.fn(async (_n, _o, _c, cb) => cb()),
-        logException
+        logException,
       });
       const runtime = createAppSlackRuntime<TestState>(deps);
       const thread = createTestThread({});
-      thread.post = vi.fn().mockRejectedValue(slackPostError) as unknown as typeof thread.post;
+      thread.post = vi
+        .fn()
+        .mockRejectedValue(slackPostError) as unknown as typeof thread.post;
       const message = createTestMessage({});
 
-      await expect(runtime.handleNewMention(thread, message)).rejects.toBe(slackPostError);
+      await expect(runtime.handleNewMention(thread, message)).rejects.toBe(
+        slackPostError,
+      );
 
       expect(logException).toHaveBeenNthCalledWith(
         2,
@@ -200,9 +214,9 @@ describe("createAppSlackRuntime", () => {
           "app.slack.error_code": "slack_webapi_platform_error",
           "app.slack.api_error": "internal_error",
           "app.slack.request_id": "req-123",
-          "http.response.status_code": 500
+          "http.response.status_code": 500,
         }),
-        "Failed to post fallback error reply for mention handler"
+        "Failed to post fallback error reply for mention handler",
       );
     });
   });
@@ -225,7 +239,7 @@ describe("createAppSlackRuntime", () => {
         replyToThread: vi.fn(async () => {
           callOrder.push("replyToThread");
         }),
-        withSpan: vi.fn(async (_n, _o, _c, cb) => cb())
+        withSpan: vi.fn(async (_n, _o, _c, cb) => cb()),
       });
       const runtime = createAppSlackRuntime<TestState>(deps);
       const thread = createTestThread({});
@@ -237,27 +251,30 @@ describe("createAppSlackRuntime", () => {
         "prepareTurnState",
         "persistPreparedState",
         "shouldReply",
-        "replyToThread"
+        "replyToThread",
       ]);
     });
 
     it("passes stripped text via stripLeadingBotMention to prepareTurnState", async () => {
       const deps = createMockDeps({
         stripLeadingBotMention: vi.fn(() => "stripped text"),
-        withSpan: vi.fn(async (_n, _o, _c, cb) => cb())
+        withSpan: vi.fn(async (_n, _o, _c, cb) => cb()),
       });
       const runtime = createAppSlackRuntime<TestState>(deps);
       const thread = createTestThread({});
-      const message = createTestMessage({ text: "<@U123> stripped text", isMention: true });
+      const message = createTestMessage({
+        text: "<@U123> stripped text",
+        isMention: true,
+      });
 
       await runtime.handleSubscribedMessage(thread, message);
 
       expect(deps.stripLeadingBotMention).toHaveBeenCalledWith(
         "<@U123> stripped text",
-        { stripLeadingSlackMentionToken: true }
+        { stripLeadingSlackMentionToken: true },
       );
       expect(deps.prepareTurnState).toHaveBeenCalledWith(
-        expect.objectContaining({ userText: "stripped text" })
+        expect.objectContaining({ userText: "stripped text" }),
       );
     });
 
@@ -265,8 +282,8 @@ describe("createAppSlackRuntime", () => {
       const deps = createMockDeps({
         shouldReplyInSubscribedThread: vi.fn(async () => ({
           shouldReply: false,
-          reason: "passive conversation"
-        }))
+          reason: "passive conversation",
+        })),
       });
       const runtime = createAppSlackRuntime<TestState>(deps);
       const thread = createTestThread({});
@@ -275,26 +292,67 @@ describe("createAppSlackRuntime", () => {
       await runtime.handleSubscribedMessage(thread, message);
 
       expect(deps.replyToThread).not.toHaveBeenCalled();
+      expect(deps.recordSkippedSubscribedMessage).not.toHaveBeenCalled();
       expect(deps.logWarn).toHaveBeenCalledWith(
         "subscribed_message_reply_skipped",
         expect.any(Object),
         { "app.decision.reason": "passive conversation" },
-        "Skipping subscribed message reply"
+        "Skipping subscribed message reply",
       );
       expect(deps.onSubscribedMessageSkipped).toHaveBeenCalledWith(
         expect.objectContaining({
           thread,
           message,
           decision: { shouldReply: false, reason: "passive conversation" },
-          completedAtMs: 1700000000000
-        })
+          completedAtMs: 1700000000000,
+        }),
+      );
+    });
+
+    it("preflight-skips messages addressed to another party before preparing turn state", async () => {
+      const deps = createMockDeps();
+      const runtime = createAppSlackRuntime<TestState>(deps);
+      const thread = createTestThread({});
+      const message = createTestMessage({
+        text: "@Cursor can you take this one?",
+        isMention: false,
+      });
+
+      await runtime.handleSubscribedMessage(thread, message);
+
+      expect(deps.prepareTurnState).not.toHaveBeenCalled();
+      expect(deps.persistPreparedState).not.toHaveBeenCalled();
+      expect(deps.shouldReplyInSubscribedThread).not.toHaveBeenCalled();
+      expect(deps.replyToThread).not.toHaveBeenCalled();
+      expect(deps.onSubscribedMessageSkipped).toHaveBeenCalledWith(
+        expect.objectContaining({
+          thread,
+          message,
+          decision: {
+            shouldReply: false,
+            reason: "directed_to_other_party:named_mention:Cursor",
+          },
+          completedAtMs: 1700000000000,
+        }),
+      );
+      expect(deps.recordSkippedSubscribedMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          thread,
+          message,
+          userText: "@Cursor can you take this one?",
+          decision: {
+            shouldReply: false,
+            reason: "directed_to_other_party:named_mention:Cursor",
+          },
+          completedAtMs: 1700000000000,
+        }),
       );
     });
 
     it("passes conversationContext from getPreparedConversationContext to shouldReply", async () => {
       const deps = createMockDeps({
         getPreparedConversationContext: vi.fn(() => "some context"),
-        withSpan: vi.fn(async (_n, _o, _c, cb) => cb())
+        withSpan: vi.fn(async (_n, _o, _c, cb) => cb()),
       });
       const runtime = createAppSlackRuntime<TestState>(deps);
       const thread = createTestThread({});
@@ -303,7 +361,7 @@ describe("createAppSlackRuntime", () => {
       await runtime.handleSubscribedMessage(thread, message);
 
       expect(deps.shouldReplyInSubscribedThread).toHaveBeenCalledWith(
-        expect.objectContaining({ conversationContext: "some context" })
+        expect.objectContaining({ conversationContext: "some context" }),
       );
     });
 
@@ -311,9 +369,9 @@ describe("createAppSlackRuntime", () => {
       const deps = createMockDeps({
         shouldReplyInSubscribedThread: vi.fn(async () => ({
           shouldReply: true,
-          reason: "explicit mention"
+          reason: "explicit mention",
         })),
-        withSpan: vi.fn(async (_n, _o, _c, cb) => cb())
+        withSpan: vi.fn(async (_n, _o, _c, cb) => cb()),
       });
       const runtime = createAppSlackRuntime<TestState>(deps);
       const thread = createTestThread({});
@@ -323,7 +381,7 @@ describe("createAppSlackRuntime", () => {
 
       expect(deps.replyToThread).toHaveBeenCalledWith(thread, message, {
         explicitMention: true,
-        preparedState: { prepared: true }
+        preparedState: { prepared: true },
       });
     });
 
@@ -331,30 +389,33 @@ describe("createAppSlackRuntime", () => {
       const deps = createMockDeps({
         shouldReplyInSubscribedThread: vi.fn(async (args) => ({
           shouldReply: Boolean(args.hasAttachments),
-          reason: args.hasAttachments ? "attachment" : "empty message"
+          reason: args.hasAttachments ? "attachment" : "empty message",
         })),
-        withSpan: vi.fn(async (_n, _o, _c, cb) => cb())
+        withSpan: vi.fn(async (_n, _o, _c, cb) => cb()),
       });
       const runtime = createAppSlackRuntime<TestState>(deps);
       const thread = createTestThread({});
       const message = createTestMessage({
         text: "",
         attachments: [
-          { type: "image", url: "https://example.com/img.png" } satisfies Attachment
-        ]
+          {
+            type: "image",
+            url: "https://example.com/img.png",
+          } satisfies Attachment,
+        ],
       });
 
       await runtime.handleSubscribedMessage(thread, message);
 
       expect(deps.shouldReplyInSubscribedThread).toHaveBeenCalledWith(
-        expect.objectContaining({ hasAttachments: true })
+        expect.objectContaining({ hasAttachments: true }),
       );
       expect(deps.replyToThread).toHaveBeenCalled();
     });
 
     it("passes hasAttachments: false when message has no attachments", async () => {
       const deps = createMockDeps({
-        withSpan: vi.fn(async (_n, _o, _c, cb) => cb())
+        withSpan: vi.fn(async (_n, _o, _c, cb) => cb()),
       });
       const runtime = createAppSlackRuntime<TestState>(deps);
       const thread = createTestThread({});
@@ -363,14 +424,14 @@ describe("createAppSlackRuntime", () => {
       await runtime.handleSubscribedMessage(thread, message);
 
       expect(deps.shouldReplyInSubscribedThread).toHaveBeenCalledWith(
-        expect.objectContaining({ hasAttachments: false })
+        expect.objectContaining({ hasAttachments: false }),
       );
     });
 
     it("on failure: posts safe error message and calls logException", async () => {
       const err = new Error("handler boom");
       const deps = createMockDeps({
-        prepareTurnState: vi.fn().mockRejectedValue(err)
+        prepareTurnState: vi.fn().mockRejectedValue(err),
       });
       const runtime = createAppSlackRuntime<TestState>(deps);
       const thread = createTestThread({});
@@ -383,9 +444,11 @@ describe("createAppSlackRuntime", () => {
         "subscribed_message_handler_failed",
         expect.any(Object),
         {},
-        "onSubscribedMessage failed"
+        "onSubscribedMessage failed",
       );
-      expect(thread.posts).toContain("I ran into an internal error while processing that. Please try again.");
+      expect(thread.posts).toContain(
+        "I ran into an internal error while processing that. Please try again.",
+      );
     });
 
     it("logs fallback-post failure with Slack attributes when posting subscribed error reply fails", async () => {
@@ -394,14 +457,18 @@ describe("createAppSlackRuntime", () => {
       const logException = vi.fn(() => "evt_subscribed");
       const deps = createMockDeps({
         prepareTurnState: vi.fn().mockRejectedValue(primaryError),
-        logException
+        logException,
       });
       const runtime = createAppSlackRuntime<TestState>(deps);
       const thread = createTestThread({});
-      thread.post = vi.fn().mockRejectedValue(slackPostError) as unknown as typeof thread.post;
+      thread.post = vi
+        .fn()
+        .mockRejectedValue(slackPostError) as unknown as typeof thread.post;
       const message = createTestMessage({});
 
-      await expect(runtime.handleSubscribedMessage(thread, message)).rejects.toBe(slackPostError);
+      await expect(
+        runtime.handleSubscribedMessage(thread, message),
+      ).rejects.toBe(slackPostError);
 
       expect(logException).toHaveBeenNthCalledWith(
         2,
@@ -414,9 +481,9 @@ describe("createAppSlackRuntime", () => {
           "app.slack.error_code": "slack_webapi_platform_error",
           "app.slack.api_error": "internal_error",
           "app.slack.request_id": "req-456",
-          "http.response.status_code": 500
+          "http.response.status_code": 500,
         }),
-        "Failed to post fallback error reply for subscribed message handler"
+        "Failed to post fallback error reply for subscribed message handler",
       );
     });
   });
@@ -430,36 +497,39 @@ describe("createAppSlackRuntime", () => {
         threadId: "T-1",
         channelId: "C-1",
         threadTs: "1700000000.000",
-        userId: "U-1"
+        userId: "U-1",
       });
 
       expect(deps.initializeAssistantThread).toHaveBeenCalledWith({
         threadId: "T-1",
         channelId: "C-1",
         threadTs: "1700000000.000",
-        sourceChannelId: undefined
+        sourceChannelId: undefined,
       });
     });
 
     it("on failure: calls logException without posting error", async () => {
       const err = new Error("init boom");
       const deps = createMockDeps({
-        initializeAssistantThread: vi.fn().mockRejectedValue(err)
+        initializeAssistantThread: vi.fn().mockRejectedValue(err),
       });
       const runtime = createAppSlackRuntime<TestState>(deps);
 
       await runtime.handleAssistantThreadStarted({
         threadId: "T-1",
         channelId: "C-1",
-        threadTs: "1700000000.000"
+        threadTs: "1700000000.000",
       });
 
       expect(deps.logException).toHaveBeenCalledWith(
         err,
         "assistant_thread_started_handler_failed",
-        expect.objectContaining({ slackThreadId: "T-1", slackChannelId: "C-1" }),
+        expect.objectContaining({
+          slackThreadId: "T-1",
+          slackChannelId: "C-1",
+        }),
         {},
-        "onAssistantThreadStarted failed"
+        "onAssistantThreadStarted failed",
       );
     });
   });
@@ -473,14 +543,14 @@ describe("createAppSlackRuntime", () => {
         threadId: "T-2",
         channelId: "C-2",
         threadTs: "1700000000.100",
-        userId: "U-2"
+        userId: "U-2",
       });
 
       expect(deps.initializeAssistantThread).toHaveBeenCalledWith({
         threadId: "T-2",
         channelId: "C-2",
         threadTs: "1700000000.100",
-        sourceChannelId: undefined
+        sourceChannelId: undefined,
       });
     });
 
@@ -494,37 +564,40 @@ describe("createAppSlackRuntime", () => {
         threadTs: "1700000000.100",
         userId: "U-2",
         context: {
-          channelId: "C-source"
-        }
+          channelId: "C-source",
+        },
       });
 
       expect(deps.initializeAssistantThread).toHaveBeenCalledWith({
         threadId: "T-2",
         channelId: "D-assistant",
         threadTs: "1700000000.100",
-        sourceChannelId: "C-source"
+        sourceChannelId: "C-source",
       });
     });
 
     it("on failure: calls logException without posting error", async () => {
       const err = new Error("context boom");
       const deps = createMockDeps({
-        initializeAssistantThread: vi.fn().mockRejectedValue(err)
+        initializeAssistantThread: vi.fn().mockRejectedValue(err),
       });
       const runtime = createAppSlackRuntime<TestState>(deps);
 
       await runtime.handleAssistantContextChanged({
         threadId: "T-2",
         channelId: "C-2",
-        threadTs: "1700000000.100"
+        threadTs: "1700000000.100",
       });
 
       expect(deps.logException).toHaveBeenCalledWith(
         err,
         "assistant_context_changed_handler_failed",
-        expect.objectContaining({ slackThreadId: "T-2", slackChannelId: "C-2" }),
+        expect.objectContaining({
+          slackThreadId: "T-2",
+          slackChannelId: "C-2",
+        }),
         {},
-        "onAssistantContextChanged failed"
+        "onAssistantContextChanged failed",
       );
     });
   });

--- a/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { appSlackRuntime, resetBotDepsForTests, setBotDepsForTests } from "@/chat/bot";
-import { createTestMessage, createTestThread } from "../../fixtures/slack-harness";
+import {
+  appSlackRuntime,
+  resetBotDepsForTests,
+  setBotDepsForTests,
+} from "@/chat/bot";
+import {
+  createTestMessage,
+  createTestThread,
+} from "../../fixtures/slack-harness";
 
 function toPostedText(value: unknown): string {
   if (typeof value === "string") {
@@ -32,14 +39,16 @@ describe("Slack behavior: subscribed messages", () => {
           object: {
             should_reply: false,
             confidence: 0,
-            reason: "side conversation"
+            reason: "side conversation",
           },
-          text: "{\"should_reply\":false,\"confidence\":0,\"reason\":\"side conversation\"}"
+          text: '{"should_reply":false,"confidence":0,"reason":"side conversation"}',
         } as never;
       },
       generateAssistantReply: async () => {
-        throw new Error("generateAssistantReply should not run when classifier skips reply");
-      }
+        throw new Error(
+          "generateAssistantReply should not run when classifier skips reply",
+        );
+      },
     });
 
     const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002000.000" });
@@ -48,7 +57,7 @@ describe("Slack behavior: subscribed messages", () => {
       text: "sounds good thanks everyone",
       isMention: false,
       threadId: thread.id,
-      author: { userId: "U_TESTER" }
+      author: { userId: "U_TESTER" },
     });
 
     await appSlackRuntime.handleSubscribedMessage(thread, message);
@@ -68,9 +77,9 @@ describe("Slack behavior: subscribed messages", () => {
           object: {
             should_reply: true,
             confidence: 1,
-            reason: "explicit ask"
+            reason: "explicit ask",
           },
-          text: "{\"should_reply\":true,\"confidence\":1,\"reason\":\"explicit ask\"}"
+          text: '{"should_reply":true,"confidence":1,"reason":"explicit ask"}',
         } as never;
       },
       generateAssistantReply: async (prompt) => {
@@ -84,10 +93,10 @@ describe("Slack behavior: subscribed messages", () => {
             toolCalls: [],
             toolErrorCount: 0,
             toolResultCount: 0,
-            usedPrimaryText: true
-          }
+            usedPrimaryText: true,
+          },
         };
-      }
+      },
     });
 
     const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002001.000" });
@@ -96,7 +105,7 @@ describe("Slack behavior: subscribed messages", () => {
       text: "can you suggest one concrete next step?",
       isMention: false,
       threadId: thread.id,
-      author: { userId: "U_TESTER" }
+      author: { userId: "U_TESTER" },
     });
 
     await appSlackRuntime.handleSubscribedMessage(thread, message);
@@ -127,10 +136,10 @@ describe("Slack behavior: subscribed messages", () => {
             toolCalls: [],
             toolErrorCount: 0,
             toolResultCount: 0,
-            usedPrimaryText: true
-          }
+            usedPrimaryText: true,
+          },
         };
-      }
+      },
     });
 
     const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002002.000" });
@@ -139,7 +148,7 @@ describe("Slack behavior: subscribed messages", () => {
       text: "<@U_APP> quick status?",
       isMention: true,
       threadId: thread.id,
-      author: { userId: "U_TESTER" }
+      author: { userId: "U_TESTER" },
     });
 
     await appSlackRuntime.handleSubscribedMessage(thread, message);
@@ -170,10 +179,10 @@ describe("Slack behavior: subscribed messages", () => {
             toolCalls: [],
             toolErrorCount: 0,
             toolResultCount: 0,
-            usedPrimaryText: true
-          }
+            usedPrimaryText: true,
+          },
         };
-      }
+      },
     });
 
     const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002003.000" });
@@ -182,7 +191,7 @@ describe("Slack behavior: subscribed messages", () => {
       text: "thanks!",
       isMention: false,
       threadId: thread.id,
-      author: { userId: "U_TESTER" }
+      author: { userId: "U_TESTER" },
     });
 
     await appSlackRuntime.handleSubscribedMessage(thread, message);
@@ -192,6 +201,74 @@ describe("Slack behavior: subscribed messages", () => {
     expect(thread.posts).toHaveLength(0);
   });
 
+  it("stays silent when a subscribed message is clearly directed at another bot", async () => {
+    let classifierCalled = false;
+    let replyCalled = false;
+
+    setBotDepsForTests({
+      completeObject: async () => {
+        classifierCalled = true;
+        throw new Error(
+          "classifier should be bypassed for messages addressed to another bot",
+        );
+      },
+      generateAssistantReply: async () => {
+        replyCalled = true;
+        return {
+          text: "This should never be posted.",
+          diagnostics: {
+            assistantMessageCount: 1,
+            modelId: "fake-agent-model",
+            outcome: "success",
+            toolCalls: [],
+            toolErrorCount: 0,
+            toolResultCount: 0,
+            usedPrimaryText: true,
+          },
+        };
+      },
+    });
+
+    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002003.500" });
+    const message = createTestMessage({
+      id: "m-subscribed-other-bot",
+      text: "@Cursor can you help address issue 87?",
+      isMention: false,
+      threadId: thread.id,
+      author: { userId: "U_TESTER" },
+    });
+
+    await appSlackRuntime.handleSubscribedMessage(thread, message);
+
+    expect(classifierCalled).toBe(false);
+    expect(replyCalled).toBe(false);
+    expect(thread.posts).toHaveLength(0);
+    const state = await thread.state;
+    const conversation = (state.conversation ?? {}) as {
+      messages?: Array<{
+        id: string;
+        text: string;
+        meta?: { replied?: boolean; skippedReason?: string };
+      }>;
+      processing?: { lastCompletedAtMs?: number };
+    };
+    expect(conversation.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "m-subscribed-other-bot",
+          text: "@Cursor can you help address issue 87?",
+          meta: expect.objectContaining({
+            replied: false,
+            skippedReason: "directed_to_other_party:named_mention:Cursor",
+          }),
+        }),
+      ]),
+    );
+    expect(conversation.processing?.lastCompletedAtMs).toEqual(
+      expect.any(Number),
+    );
+  });
+
   it("bypasses classifier for assistant-directed follow-up questions", async () => {
     let classifierCalled = false;
     const replyCalls: string[] = [];
@@ -199,7 +276,9 @@ describe("Slack behavior: subscribed messages", () => {
     setBotDepsForTests({
       completeObject: async () => {
         classifierCalled = true;
-        throw new Error("classifier should be bypassed for follow-up questions");
+        throw new Error(
+          "classifier should be bypassed for follow-up questions",
+        );
       },
       generateAssistantReply: async (prompt) => {
         replyCalls.push(prompt);
@@ -212,10 +291,10 @@ describe("Slack behavior: subscribed messages", () => {
             toolCalls: [],
             toolErrorCount: 0,
             toolResultCount: 0,
-            usedPrimaryText: true
-          }
+            usedPrimaryText: true,
+          },
         };
-      }
+      },
     });
 
     const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002004.000" });
@@ -226,8 +305,8 @@ describe("Slack behavior: subscribed messages", () => {
         text: "<@U_APP> I need the budget by Friday",
         isMention: true,
         threadId: thread.id,
-        author: { userId: "U_TESTER" }
-      })
+        author: { userId: "U_TESTER" },
+      }),
     );
 
     await appSlackRuntime.handleSubscribedMessage(
@@ -237,8 +316,8 @@ describe("Slack behavior: subscribed messages", () => {
         text: "what did you just say about the budget?",
         isMention: false,
         threadId: thread.id,
-        author: { userId: "U_TESTER" }
-      })
+        author: { userId: "U_TESTER" },
+      }),
     );
 
     expect(classifierCalled).toBe(false);

--- a/packages/junior/tests/plugin-registry-packages.test.ts
+++ b/packages/junior/tests/plugin-registry-packages.test.ts
@@ -358,12 +358,14 @@ describe("plugin registry package discovery", () => {
     expect(providers[0]?.manifest.name).toBe("demo");
     expect(providers[0]?.manifest.capabilities).toEqual(["demo.api"]);
     expect(registry.getPluginSkillRoots()).toEqual([
-      path.join(
-        tempRoot,
-        "node_modules",
-        "@acme",
-        "junior-plugin-demo",
-        "skills",
+      await fs.realpath(
+        path.join(
+          tempRoot,
+          "node_modules",
+          "@acme",
+          "junior-plugin-demo",
+          "skills",
+        ),
       ),
     ]);
     expect(registry.isPluginProvider("demo")).toBe(true);

--- a/packages/junior/tests/unit/routing/subscribed-decision.test.ts
+++ b/packages/junior/tests/unit/routing/subscribed-decision.test.ts
@@ -1,22 +1,62 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   decideSubscribedThreadReply,
+  getSubscribedReplyPreflightDecision,
   SubscribedReplyReason,
-  type SubscribedDecisionInput
+  type SubscribedDecisionInput,
 } from "@/chat/routing/subscribed-decision";
 
-function makeInput(overrides: Partial<SubscribedDecisionInput> = {}): SubscribedDecisionInput {
+function makeInput(
+  overrides: Partial<SubscribedDecisionInput> = {},
+): SubscribedDecisionInput {
   return {
     rawText: "hello",
     text: "hello",
     hasAttachments: false,
     isExplicitMention: false,
     context: {},
-    ...overrides
+    ...overrides,
   };
 }
 
 describe("decideSubscribedThreadReply", () => {
+  it("preflight-skips a leading mention addressed to another named party", () => {
+    const decision = getSubscribedReplyPreflightDecision({
+      botUserName: "junior",
+      rawText: "@Cursor can you take this one?",
+      text: "@Cursor can you take this one?",
+      isExplicitMention: false,
+    });
+
+    expect(decision).toEqual({
+      shouldReply: false,
+      reason: SubscribedReplyReason.DirectedToOtherParty,
+      reasonDetail: "named_mention:Cursor",
+    });
+  });
+
+  it("does not preflight-skip when junior is also addressed", () => {
+    const decision = getSubscribedReplyPreflightDecision({
+      botUserName: "junior",
+      rawText: "@Cursor and @junior can one of you take this?",
+      text: "@Cursor and @junior can one of you take this?",
+      isExplicitMention: false,
+    });
+
+    expect(decision).toBeUndefined();
+  });
+
+  it("does not preflight-skip non-address mentions in the middle of the sentence", () => {
+    const decision = getSubscribedReplyPreflightDecision({
+      botUserName: "junior",
+      rawText: "please ask @Cursor to look at this later",
+      text: "please ask @Cursor to look at this later",
+      isExplicitMention: false,
+    });
+
+    expect(decision).toBeUndefined();
+  });
+
   it("replies immediately for explicit mention", async () => {
     const completeObject = vi.fn();
     const decision = await decideSubscribedThreadReply({
@@ -24,10 +64,35 @@ describe("decideSubscribedThreadReply", () => {
       modelId: "router-model",
       input: makeInput({ isExplicitMention: true }),
       completeObject,
-      logClassifierFailure: vi.fn()
+      logClassifierFailure: vi.fn(),
     });
 
-    expect(decision).toEqual({ shouldReply: true, reason: SubscribedReplyReason.ExplicitMention });
+    expect(decision).toEqual({
+      shouldReply: true,
+      reason: SubscribedReplyReason.ExplicitMention,
+    });
+    expect(completeObject).not.toHaveBeenCalled();
+  });
+
+  it("skips leading slack mentions addressed to another party before classifier", async () => {
+    const completeObject = vi.fn();
+    const decision = await decideSubscribedThreadReply({
+      botUserName: "junior",
+      modelId: "router-model",
+      input: makeInput({
+        rawText: "<@UCURSOR> can you handle this?",
+        text: "<@UCURSOR> can you handle this?",
+        isExplicitMention: false,
+      }),
+      completeObject,
+      logClassifierFailure: vi.fn(),
+    });
+
+    expect(decision).toEqual({
+      shouldReply: false,
+      reason: SubscribedReplyReason.DirectedToOtherParty,
+      reasonDetail: "slack_mention",
+    });
     expect(completeObject).not.toHaveBeenCalled();
   });
 
@@ -37,7 +102,7 @@ describe("decideSubscribedThreadReply", () => {
       modelId: "router-model",
       input: makeInput({ text: "   ", rawText: "   " }),
       completeObject: vi.fn(),
-      logClassifierFailure: vi.fn()
+      logClassifierFailure: vi.fn(),
     });
 
     expect(decision.reason).toBe(SubscribedReplyReason.EmptyMessage);
@@ -50,7 +115,7 @@ describe("decideSubscribedThreadReply", () => {
       modelId: "router-model",
       input: makeInput({ text: "", rawText: "", hasAttachments: true }),
       completeObject: vi.fn(),
-      logClassifierFailure: vi.fn()
+      logClassifierFailure: vi.fn(),
     });
 
     expect(decision.reason).toBe(SubscribedReplyReason.AttachmentOnly);
@@ -64,7 +129,7 @@ describe("decideSubscribedThreadReply", () => {
       modelId: "router-model",
       input: makeInput({ text: "thanks!", rawText: "thanks!" }),
       completeObject,
-      logClassifierFailure: vi.fn()
+      logClassifierFailure: vi.fn(),
     });
 
     expect(decision.reason).toBe(SubscribedReplyReason.Acknowledgment);
@@ -80,10 +145,11 @@ describe("decideSubscribedThreadReply", () => {
       input: makeInput({
         text: "what did you just say about the budget?",
         rawText: "what did you just say about the budget?",
-        conversationContext: "<thread-transcript>\n[assistant] junior: Budget is due Friday.\n</thread-transcript>"
+        conversationContext:
+          "<thread-transcript>\n[assistant] junior: Budget is due Friday.\n</thread-transcript>",
       }),
       completeObject,
-      logClassifierFailure: vi.fn()
+      logClassifierFailure: vi.fn(),
     });
 
     expect(decision.reason).toBe(SubscribedReplyReason.FollowUpQuestion);
@@ -97,9 +163,13 @@ describe("decideSubscribedThreadReply", () => {
       modelId: "router-model",
       input: makeInput({ text: "some new text", rawText: "some new text" }),
       completeObject: vi.fn(async () => ({
-        object: { should_reply: false, confidence: 0.95, reason: "status chatter" }
+        object: {
+          should_reply: false,
+          confidence: 0.95,
+          reason: "status chatter",
+        },
       })),
-      logClassifierFailure: vi.fn()
+      logClassifierFailure: vi.fn(),
     });
 
     expect(decision.reason).toBe(SubscribedReplyReason.SideConversation);
@@ -113,9 +183,13 @@ describe("decideSubscribedThreadReply", () => {
       modelId: "router-model",
       input: makeInput({ text: "some new text", rawText: "some new text" }),
       completeObject: vi.fn(async () => ({
-        object: { should_reply: true, confidence: 0.6, reason: "maybe follow-up" }
+        object: {
+          should_reply: true,
+          confidence: 0.6,
+          reason: "maybe follow-up",
+        },
       })),
-      logClassifierFailure: vi.fn()
+      logClassifierFailure: vi.fn(),
     });
 
     expect(decision.reason).toBe(SubscribedReplyReason.LowConfidence);
@@ -128,9 +202,13 @@ describe("decideSubscribedThreadReply", () => {
       modelId: "router-model",
       input: makeInput({ text: "some new text", rawText: "some new text" }),
       completeObject: vi.fn(async () => ({
-        object: { should_reply: true, confidence: 0.95, reason: "direct question" }
+        object: {
+          should_reply: true,
+          confidence: 0.95,
+          reason: "direct question",
+        },
       })),
-      logClassifierFailure: vi.fn()
+      logClassifierFailure: vi.fn(),
     });
 
     expect(decision.reason).toBe(SubscribedReplyReason.Classifier);
@@ -140,7 +218,10 @@ describe("decideSubscribedThreadReply", () => {
 
   it("fails closed on classifier errors", async () => {
     const logClassifierFailure = vi.fn();
-    const input = makeInput({ text: "some new text", rawText: "some new text" });
+    const input = makeInput({
+      text: "some new text",
+      rawText: "some new text",
+    });
     const decision = await decideSubscribedThreadReply({
       botUserName: "junior",
       modelId: "router-model",
@@ -148,7 +229,7 @@ describe("decideSubscribedThreadReply", () => {
       completeObject: vi.fn(async () => {
         throw new Error("router failed");
       }),
-      logClassifierFailure
+      logClassifierFailure,
     });
 
     expect(decision.reason).toBe(SubscribedReplyReason.ClassifierError);


### PR DESCRIPTION
Suppress subscribed-thread replies when a message is clearly addressed to another bot and Junior is not part of the invocation.

This adds a deterministic preflight guard before subscribed-thread turn preparation so we do not spend the full preparation cost on messages like `@Cursor can you handle this?`. The skip path still records the user message in thread conversation state so future turns retain the full transcript.

While validating the branch locally, the full `@sentry/junior` suite exposed an environment-sensitive plugin-registry test that compared `/var/...` against `/private/var/...` for temp paths. This PR normalizes that assertion so the suite is stable on this machine without changing the underlying contract.

Fixes #87