### PR TITLE
fix(chat): Preserve DM and mention routing at ingress

### DIFF
--- a/packages/junior/src/chat/chat-background-patch.ts
+++ b/packages/junior/src/chat/chat-background-patch.ts
@@ -182,10 +182,22 @@ export function buildQueueIngressDedupKey(
   return `${normalizedThreadId}:${messageId}`;
 }
 
+function isSlackDirectMessageThreadId(threadId: string): boolean {
+  const parts = threadId.split(":");
+  return (
+    parts.length === 3 && parts[0] === "slack" && parts[1]?.startsWith("D")
+  );
+}
+
 export function determineThreadMessageKind(args: {
+  isDirectMessage: boolean;
   isMention: boolean;
   isSubscribed: boolean;
 }): ThreadMessageKind | undefined {
+  if (args.isDirectMessage) {
+    return "new_mention";
+  }
+
   if (args.isSubscribed) {
     return "subscribed_message";
   }
@@ -403,7 +415,12 @@ export async function routeIncomingMessageToQueue(args: {
       ? "fallback_detector"
       : undefined;
   const isMention = mentionSource !== undefined;
+  if (isMention && !typedMessage.isMention) {
+    typedMessage.isMention = true;
+  }
+  const isDirectMessage = isSlackDirectMessageThreadId(normalizedThreadId);
   const kind = determineThreadMessageKind({
+    isDirectMessage,
     isSubscribed,
     isMention,
   });

--- a/packages/junior/tests/integration/queue/chat-background-enqueue.test.ts
+++ b/packages/junior/tests/integration/queue/chat-background-enqueue.test.ts
@@ -1,5 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Chat } from "chat";
+import {
+  createTestMessage,
+  createTestThread,
+} from "../../fixtures/slack-harness";
+import {
+  TEST_DM_CHANNEL_ID,
+  TEST_THREAD_TS,
+  slackThreadId,
+} from "../../fixtures/slack/factories/ids";
 
 const {
   enqueueThreadMessageMock,
@@ -7,38 +16,38 @@ const {
   claimQueueIngressDedupMock,
   isSubscribedMock,
   addReactionToMessageMock,
-  removeReactionFromMessageMock
+  removeReactionFromMessageMock,
 } = vi.hoisted(() => ({
   enqueueThreadMessageMock: vi.fn(async () => "msg_abc123"),
   hasQueueIngressDedupMock: vi.fn(async () => false),
   claimQueueIngressDedupMock: vi.fn(async () => true),
   isSubscribedMock: vi.fn(async () => true),
   addReactionToMessageMock: vi.fn(async () => ({ ok: true })),
-  removeReactionFromMessageMock: vi.fn(async () => ({ ok: true }))
+  removeReactionFromMessageMock: vi.fn(async () => ({ ok: true })),
 }));
 
 vi.mock("@/chat/queue/client", () => ({
-  enqueueThreadMessage: enqueueThreadMessageMock
+  enqueueThreadMessage: enqueueThreadMessageMock,
 }));
 
 vi.mock("@/chat/state", () => ({
   hasQueueIngressDedup: hasQueueIngressDedupMock,
   claimQueueIngressDedup: claimQueueIngressDedupMock,
   getStateAdapter: () => ({
-    isSubscribed: isSubscribedMock
-  })
+    isSubscribed: isSubscribedMock,
+  }),
 }));
 
 vi.mock("@/chat/slack-actions/channel", () => ({
   addReactionToMessage: addReactionToMessageMock,
-  removeReactionFromMessage: removeReactionFromMessageMock
+  removeReactionFromMessage: removeReactionFromMessageMock,
 }));
 
 vi.mock("@/chat/runtime/subscribed-routing", () => ({
   shouldReplyInSubscribedThread: vi.fn(async () => ({
     shouldReply: true,
-    reason: "explicit_ask"
-  }))
+    reason: "explicit_ask",
+  })),
 }));
 
 import "@/chat/chat-background-patch";
@@ -55,11 +64,13 @@ describe("chat background queue enqueue", () => {
 
   it("enqueues subscribed messages through default queue routing", async () => {
     const waitUntilTasks: Array<Promise<unknown>> = [];
-    const processMessage = (Chat.prototype as unknown as { processMessage: Function }).processMessage;
+    const processMessage = (
+      Chat.prototype as unknown as { processMessage: Function }
+    ).processMessage;
 
     const fakeChat = {
       logger: {
-        error: vi.fn()
+        error: vi.fn(),
       },
       createThread: vi.fn(async () => ({
         id: "slack:C123:1700000000.100",
@@ -70,10 +81,10 @@ describe("chat background queue enqueue", () => {
           id: "slack:C123:1700000000.100",
           channelId: "C123",
           adapterName: "slack",
-          isDM: false
-        })
+          isDM: false,
+        }),
       })),
-      detectMention: vi.fn(() => false)
+      detectMention: vi.fn(() => false),
     };
 
     processMessage.call(
@@ -87,7 +98,7 @@ describe("chat background queue enqueue", () => {
         raw: {
           channel: "C123",
           thread_ts: "1700000000.100",
-          ts: "1700000000.200"
+          ts: "1700000000.200",
         },
         toJSON: () => ({
           _type: "chat:Message",
@@ -98,61 +109,205 @@ describe("chat background queue enqueue", () => {
           raw: "hello",
           author: { userId: "U_TEST", isMe: false },
           attachments: [],
-          metadata: { dateSent: new Date().toISOString(), edited: false }
+          metadata: { dateSent: new Date().toISOString(), edited: false },
         }),
         attachments: [],
         author: {
           userId: "U_TEST",
-          isMe: false
-        }
+          isMe: false,
+        },
       },
       {
         waitUntil(taskFactory: () => Promise<unknown>) {
           waitUntilTasks.push(taskFactory());
-        }
-      }
+        },
+      },
     );
 
     expect(waitUntilTasks).toHaveLength(1);
     await expect(waitUntilTasks[0]).resolves.toBeUndefined();
 
     expect(isSubscribedMock).toHaveBeenCalledWith("slack:C123:1700000000.100");
-    expect(hasQueueIngressDedupMock).toHaveBeenCalledWith("slack:C123:1700000000.100:1700000000.200");
+    expect(hasQueueIngressDedupMock).toHaveBeenCalledWith(
+      "slack:C123:1700000000.100:1700000000.200",
+    );
 
     expect(enqueueThreadMessageMock).toHaveBeenCalledTimes(1);
     expect(addReactionToMessageMock).toHaveBeenCalledWith({
       channelId: "C123",
       timestamp: "1700000000.200",
-      emoji: "eyes"
+      emoji: "eyes",
     });
     expect(removeReactionFromMessageMock).not.toHaveBeenCalled();
     expect(enqueueThreadMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({
         dedupKey: "slack:C123:1700000000.100:1700000000.200",
         normalizedThreadId: "slack:C123:1700000000.100",
-        kind: "subscribed_reply"
+        kind: "subscribed_reply",
       }),
       {
-        idempotencyKey: "slack:C123:1700000000.100:1700000000.200"
-      }
+        idempotencyKey: "slack:C123:1700000000.100:1700000000.200",
+      },
     );
 
     expect(claimQueueIngressDedupMock).toHaveBeenCalledWith(
       "slack:C123:1700000000.100:1700000000.200",
-      24 * 60 * 60 * 1000
+      24 * 60 * 60 * 1000,
+    );
+    expect(fakeChat.logger.error).not.toHaveBeenCalled();
+  });
+
+  it("enqueues non-mention DM messages through the new mention path", async () => {
+    const waitUntilTasks: Array<Promise<unknown>> = [];
+    const processMessage = (
+      Chat.prototype as unknown as { processMessage: Function }
+    ).processMessage;
+    const threadId = slackThreadId(TEST_DM_CHANNEL_ID, TEST_THREAD_TS);
+    const message = createTestMessage({
+      id: "1700000000.201",
+      threadId,
+      text: "hello from a DM",
+      isMention: false,
+    });
+
+    isSubscribedMock.mockResolvedValueOnce(false);
+
+    const fakeChat = {
+      logger: {
+        error: vi.fn(),
+      },
+      createThread: vi.fn(async () =>
+        createTestThread({
+          id: threadId,
+          channelId: TEST_DM_CHANNEL_ID,
+        }),
+      ),
+      detectMention: vi.fn(() => false),
+    };
+
+    processMessage.call(fakeChat, {}, threadId, message, {
+      waitUntil(taskFactory: () => Promise<unknown>) {
+        waitUntilTasks.push(taskFactory());
+      },
+    });
+
+    expect(waitUntilTasks).toHaveLength(1);
+    await expect(waitUntilTasks[0]).resolves.toBeUndefined();
+
+    expect(isSubscribedMock).toHaveBeenCalledWith(threadId);
+    expect(hasQueueIngressDedupMock).toHaveBeenCalledWith(
+      `${threadId}:1700000000.201`,
+    );
+    expect(enqueueThreadMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dedupKey: `${threadId}:1700000000.201`,
+        normalizedThreadId: threadId,
+        kind: "new_mention",
+      }),
+      {
+        idempotencyKey: `${threadId}:1700000000.201`,
+      },
+    );
+    expect(addReactionToMessageMock).toHaveBeenCalledWith({
+      channelId: TEST_DM_CHANNEL_ID,
+      timestamp: "1700000000.201",
+      emoji: "eyes",
+    });
+    expect(fakeChat.logger.error).not.toHaveBeenCalled();
+  });
+
+  it("preserves fallback-detected mentions in subscribed thread payloads", async () => {
+    const waitUntilTasks: Array<Promise<unknown>> = [];
+    const processMessage = (
+      Chat.prototype as unknown as { processMessage: Function }
+    ).processMessage;
+    const threadId = "slack:C123:1700000000.300";
+    const message = {
+      id: "1700000000.301",
+      threadId,
+      text: "<@U_APP> quick status?",
+      isMention: false,
+      raw: {
+        channel: "C123",
+        thread_ts: "1700000000.300",
+        ts: "1700000000.301",
+      },
+      toJSON: () => ({
+        _type: "chat:Message",
+        id: message.id,
+        threadId: message.threadId,
+        text: message.text,
+        formatted: { type: "root", children: [] },
+        raw: message.text,
+        author: { userId: "U_TEST", isMe: false },
+        attachments: [],
+        metadata: { dateSent: new Date().toISOString(), edited: false },
+        isMention: message.isMention,
+      }),
+      attachments: [],
+      author: {
+        userId: "U_TEST",
+        isMe: false,
+      },
+    };
+
+    isSubscribedMock.mockResolvedValueOnce(true);
+
+    const fakeChat = {
+      logger: {
+        error: vi.fn(),
+      },
+      createThread: vi.fn(async () => ({
+        id: threadId,
+        channelId: "C123",
+        isDM: false,
+        toJSON: () => ({
+          _type: "chat:Thread",
+          id: threadId,
+          channelId: "C123",
+          adapterName: "slack",
+          isDM: false,
+        }),
+      })),
+      detectMention: vi.fn(() => true),
+    };
+
+    processMessage.call(fakeChat, {}, threadId, message, {
+      waitUntil(taskFactory: () => Promise<unknown>) {
+        waitUntilTasks.push(taskFactory());
+      },
+    });
+
+    expect(waitUntilTasks).toHaveLength(1);
+    await expect(waitUntilTasks[0]).resolves.toBeUndefined();
+
+    expect(enqueueThreadMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "subscribed_message",
+        message: expect.objectContaining({
+          isMention: true,
+        }),
+      }),
+      {
+        idempotencyKey: `${threadId}:1700000000.301`,
+      },
     );
     expect(fakeChat.logger.error).not.toHaveBeenCalled();
   });
 
   it("cleans up :eyes: when enqueue fails", async () => {
     const waitUntilTasks: Array<Promise<unknown>> = [];
-    const processMessage = (Chat.prototype as unknown as { processMessage: Function }).processMessage;
+    const processMessage = (
+      Chat.prototype as unknown as { processMessage: Function }
+    ).processMessage;
 
-    enqueueThreadMessageMock.mockRejectedValueOnce(new Error("queue unavailable"));
+    enqueueThreadMessageMock.mockRejectedValueOnce(
+      new Error("queue unavailable"),
+    );
 
     const fakeChat = {
       logger: {
-        error: vi.fn()
+        error: vi.fn(),
       },
       createThread: vi.fn(async () => ({
         id: "slack:C123:1700000000.100",
@@ -163,10 +318,10 @@ describe("chat background queue enqueue", () => {
           id: "slack:C123:1700000000.100",
           channelId: "C123",
           adapterName: "slack",
-          isDM: false
-        })
+          isDM: false,
+        }),
       })),
-      detectMention: vi.fn(() => true)
+      detectMention: vi.fn(() => true),
     };
 
     processMessage.call(
@@ -180,19 +335,19 @@ describe("chat background queue enqueue", () => {
         raw: {
           channel: "C123",
           thread_ts: "1700000000.100",
-          ts: "1700000000.250"
+          ts: "1700000000.250",
         },
         attachments: [],
         author: {
           userId: "U_TEST",
-          isMe: false
-        }
+          isMe: false,
+        },
       },
       {
         waitUntil(taskFactory: () => Promise<unknown>) {
           waitUntilTasks.push(taskFactory());
-        }
-      }
+        },
+      },
     );
 
     expect(waitUntilTasks).toHaveLength(1);
@@ -201,12 +356,12 @@ describe("chat background queue enqueue", () => {
     expect(addReactionToMessageMock).toHaveBeenCalledWith({
       channelId: "C123",
       timestamp: "1700000000.250",
-      emoji: "eyes"
+      emoji: "eyes",
     });
     expect(removeReactionFromMessageMock).toHaveBeenCalledWith({
       channelId: "C123",
       timestamp: "1700000000.250",
-      emoji: "eyes"
+      emoji: "eyes",
     });
     expect(claimQueueIngressDedupMock).not.toHaveBeenCalled();
     expect(fakeChat.logger.error).toHaveBeenCalled();

--- a/packages/junior/tests/unit/slack/chat-background-patch.test.ts
+++ b/packages/junior/tests/unit/slack/chat-background-patch.test.ts
@@ -2,43 +2,49 @@ import { describe, expect, it } from "vitest";
 import {
   buildQueueIngressDedupKey,
   determineThreadMessageKind,
-  normalizeIncomingSlackThreadId
+  normalizeIncomingSlackThreadId,
 } from "@/chat/chat-background-patch";
 
 describe("normalizeIncomingSlackThreadId", () => {
   it("keeps canonical slack thread ids unchanged", () => {
     expect(
       normalizeIncomingSlackThreadId("slack:C123:1700000000.100", {
-        raw: { channel: "C123", ts: "1700000000.100" }
-      })
+        raw: { channel: "C123", ts: "1700000000.100" },
+      }),
     ).toBe("slack:C123:1700000000.100");
   });
 
   it("repairs slack thread ids missing thread timestamp from raw.ts", () => {
     expect(
       normalizeIncomingSlackThreadId("slack:D123:", {
-        raw: { channel: "D123", ts: "1700000000.200" }
-      })
+        raw: { channel: "D123", ts: "1700000000.200" },
+      }),
     ).toBe("slack:D123:1700000000.200");
   });
 
   it("uses raw.thread_ts when present", () => {
     expect(
       normalizeIncomingSlackThreadId("slack:C123:", {
-        raw: { channel: "C123", thread_ts: "1700000000.300", ts: "1700000000.400" }
-      })
+        raw: {
+          channel: "C123",
+          thread_ts: "1700000000.300",
+          ts: "1700000000.400",
+        },
+      }),
     ).toBe("slack:C123:1700000000.300");
   });
 
   it("returns original thread id when raw slack fields are missing", () => {
-    expect(normalizeIncomingSlackThreadId("slack:D123:", {})).toBe("slack:D123:");
+    expect(normalizeIncomingSlackThreadId("slack:D123:", {})).toBe(
+      "slack:D123:",
+    );
   });
 
   it("ignores adapter thread id parts and uses raw event fields", () => {
     expect(
       normalizeIncomingSlackThreadId("slack:WRONG:WRONG", {
-        raw: { channel: "D123", ts: "1700000000.500" }
-      })
+        raw: { channel: "D123", ts: "1700000000.500" },
+      }),
     ).toBe("slack:D123:1700000000.500");
   });
 
@@ -47,16 +53,20 @@ describe("normalizeIncomingSlackThreadId", () => {
   });
 
   it("returns original thread id when message is null or undefined", () => {
-    expect(normalizeIncomingSlackThreadId("slack:C123:", null)).toBe("slack:C123:");
-    expect(normalizeIncomingSlackThreadId("slack:C123:", undefined)).toBe("slack:C123:");
+    expect(normalizeIncomingSlackThreadId("slack:C123:", null)).toBe(
+      "slack:C123:",
+    );
+    expect(normalizeIncomingSlackThreadId("slack:C123:", undefined)).toBe(
+      "slack:C123:",
+    );
   });
 });
 
 describe("buildQueueIngressDedupKey", () => {
   it("uses thread and message identifiers", () => {
-    expect(buildQueueIngressDedupKey("slack:C123:1700000000.100", "1700000000.200")).toBe(
-      "slack:C123:1700000000.100:1700000000.200"
-    );
+    expect(
+      buildQueueIngressDedupKey("slack:C123:1700000000.100", "1700000000.200"),
+    ).toBe("slack:C123:1700000000.100:1700000000.200");
   });
 });
 
@@ -64,27 +74,40 @@ describe("determineThreadMessageKind", () => {
   it("routes subscribed messages regardless of mention state", () => {
     expect(
       determineThreadMessageKind({
+        isDirectMessage: false,
         isSubscribed: true,
-        isMention: false
-      })
+        isMention: false,
+      }),
     ).toBe("subscribed_message");
   });
 
   it("routes explicit mentions in unsubscribed threads", () => {
     expect(
       determineThreadMessageKind({
+        isDirectMessage: false,
         isSubscribed: false,
-        isMention: true
-      })
+        isMention: true,
+      }),
+    ).toBe("new_mention");
+  });
+
+  it("routes direct messages without requiring an explicit mention", () => {
+    expect(
+      determineThreadMessageKind({
+        isDirectMessage: true,
+        isSubscribed: false,
+        isMention: false,
+      }),
     ).toBe("new_mention");
   });
 
   it("skips unsubscribed non-mention messages", () => {
     expect(
       determineThreadMessageKind({
+        isDirectMessage: false,
         isSubscribed: false,
-        isMention: false
-      })
+        isMention: false,
+      }),
     ).toBeUndefined();
   });
 });


### PR DESCRIPTION
Fix Slack queue ingress so Junior does not drop fresh DMs or lose explicit mentions in subscribed threads.

The ingress gate previously only routed unsubscribed messages when they were recognized as mentions, which meant a new message in a Slack DM could be discarded before queueing. We also only used fallback mention detection locally for routing, but serialized the original message unchanged, so subscribed-thread handling could later see \`isMention: false\` and treat an explicit mention as passive thread chatter.

This routes direct-message threads through the immediate reply path and persists fallback mention detection onto the queued message. The regression coverage now proves both queue-ingress cases: non-mention DMs still route, and fallback-detected mentions in subscribed threads keep their explicit-mention semantics downstream.