### PR TITLE
fix(auth): Surface skill auth guidance generically

### DIFF
--- a/packages/junior-github/skills/github/SKILL.md
+++ b/packages/junior-github/skills/github/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github
-description: Manage GitHub issue workflows and repository checkout via GitHub CLI with concise, evidence-backed content. Use when users ask to open, edit, label, comment on, close/reopen, or inspect GitHub issues via /github, or when they need `gh repo clone` guidance, especially shallow-clone defaults and exact CLI commands.
+description: Manage GitHub issue workflows and repository checkout via GitHub CLI with concise, evidence-backed content. Use when users ask to open, edit, label, comment on, close/reopen, or inspect GitHub issues, or when they need `gh repo clone` guidance, especially shallow-clone defaults and exact CLI commands.
 requires-capabilities: github.issues.read github.issues.write github.issues.comment github.labels.write
 uses-config: github.repo
 allowed-tools: bash
@@ -8,11 +8,12 @@ allowed-tools: bash
 
 # GitHub Operations
 
-Use this skill for `/github` workflows in the harness. Issues are the primary surface. Repository checkout is limited to `gh repo clone` guidance and execution when local code context is needed.
+Use this skill for GitHub issue workflows in the harness. Issues are the primary surface. Repository checkout is limited to `gh repo clone` guidance and execution when local code context is needed.
 
 ## Workflow
 
 1. Confirm operation and target:
+
 - Determine `clone`, `create`, `update`, `comment`, `labels`, `state`, or read-only inspection.
 - Resolve repository (`owner/repo`) and issue number for non-create issue operations.
 - If repository is not explicit in args, query channel config:
@@ -21,6 +22,7 @@ Use this skill for `/github` workflows in the harness. Issues are the primary su
 - If repository is still missing, ask the user for `owner/repo`.
 
 2. Handle repository checkout first when operation is `clone`:
+
 - Default to a shallow clone for local inspection or one-off edits:
   - `gh repo clone owner/repo [directory] -- --depth=1`
 - Pass extra `git clone` flags only after `--`.
@@ -32,6 +34,7 @@ Use this skill for `/github` workflows in the harness. Issues are the primary su
 - After checkout, report the local directory and whether the clone is shallow or full. Stop here for clone-only requests.
 
 3. Classify issue type before drafting:
+
 - Use explicit user type when provided (`bug`, `feature`, `task`).
 - Otherwise infer from intent:
   - `bug`: broken behavior, regression, error, failure.
@@ -40,6 +43,7 @@ Use this skill for `/github` workflows in the harness. Issues are the primary su
 - Default to `task` when uncertain.
 
 4. Draft issue content:
+
 - Load the type-specific template:
   - `bug`: [references/issue-template-bug.md](references/issue-template-bug.md)
   - `feature`: [references/issue-template-feature.md](references/issue-template-feature.md)
@@ -57,19 +61,21 @@ Use this skill for `/github` workflows in the harness. Issues are the primary su
 - Use the clearest available user identifier from conversation context. Prefer a human name, then stable handle, and do not omit attribution for delegated mutations.
 
 5. Execute operation:
-- Issue credential for the required capability before API calls:
-  - Read-only (`gh issue view`, comment reads via `gh api`): `jr-rpc issue-credential github.issues.read`
-  - Create/update/state changes: `jr-rpc issue-credential github.issues.write`
-  - Comments: `jr-rpc issue-credential github.issues.comment`
-  - Labels: `jr-rpc issue-credential github.labels.write`
-- Repository checkout does not need an issue credential step. Use `gh repo clone` directly.
+
+- Select the matching declared capability for the operation:
+  - Read-only (`gh issue view`, comment reads via `gh api`): `github.issues.read`
+  - Create/update/state changes: `github.issues.write`
+  - Comments: `github.issues.comment`
+  - Labels: `github.labels.write`
+- Repository checkout does not need a GitHub issue capability. Use `gh repo clone` directly.
 - Resolve command and flags from [references/api-surface.md](references/api-surface.md).
 - Execute using `gh` CLI directly. Use [references/github-issue-api.md](references/github-issue-api.md) for exact command shapes.
 - Use [references/common-use-cases.md](references/common-use-cases.md) for ready-to-run operation patterns.
 - If an operation fails, follow [references/troubleshooting-workarounds.md](references/troubleshooting-workarounds.md) before retrying.
-- Read [references/sandbox-runtime.md](references/sandbox-runtime.md) for credential delivery details.
+- Read [references/sandbox-runtime.md](references/sandbox-runtime.md) when you need the GitHub CLI credential delivery details.
 
 6. Report result:
+
 - Return canonical issue URL, issue number, issue type, applied changes, and confidence for issue workflows.
 - For clone operations, return the repository, local directory, clone mode (`shallow` or `full`), and any follow-up deepen/unshallow action taken.
 - Include references used for verified claims.

--- a/packages/junior-notion/skills/notion/SKILL.md
+++ b/packages/junior-notion/skills/notion/SKILL.md
@@ -5,14 +5,11 @@ description: Search Notion pages and data sources and summarize the best match. 
 
 # Notion Operations
 
-Use this skill for `/notion` workflows in the harness.
+Use this skill for Notion search and summarization workflows in the harness.
 
 ## Workflow
 
-1. Classify the request:
-
-- `disconnect`: run `jr-rpc delete-token notion` in `bash`, then confirm that the user's Notion connection was removed.
-- otherwise treat the request as a read-only query.
+1. Treat the request as a read-only query.
 
 2. Keep tool work mostly silent:
 
@@ -26,7 +23,6 @@ Use this skill for `/notion` workflows in the harness.
 - `loadSkill` returns `available_tools` for this skill, including the exact `tool_name` values and argument schemas for the Notion tools exposed in this turn.
 - Use `useTool` with those exact `tool_name` values.
 - Use `searchTools` only if you need to rediscover or filter the active Notion tools later in the turn.
-- The first MCP call may trigger a private OAuth link. Do not try to start auth manually. The runtime will pause and resume automatically after the user completes the flow.
 - Decide the actual search phrases first. Notion search is title-biased, so search for the likely page or data source title, not the user's full sentence.
 - Use 1-3 short explicit search phrases.
 - Good: `deployment pipeline`, `launch tracker`, `incident review`

--- a/packages/junior-sentry/skills/sentry/SKILL.md
+++ b/packages/junior-sentry/skills/sentry/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry
-description: Query Sentry telemetry (issues, events, replays, traces) and generate deep links scoped to users or timeframes. This skill should be used when users ask to investigate bugs, search errors, find replays, or look up Sentry data via /sentry.
+description: Query Sentry telemetry (issues, events, replays, traces) and generate deep links scoped to users or timeframes. This skill should be used when users ask to investigate bugs, search errors, find replays, or look up Sentry data.
 requires-capabilities: sentry.api
 uses-config: sentry.org sentry.project
 allowed-tools: bash
@@ -8,49 +8,34 @@ allowed-tools: bash
 
 # Sentry Operations
 
-Use this skill for `/sentry` workflows in the harness.
+Use this skill for Sentry investigation workflows in the harness.
 
 ## Workflow
 
 1. Confirm operation and target:
-- Determine operation: `auth`, `disconnect`, `issue list`, `issue explain`, `issue plan`, `replays`, `deep-link`, or general query.
-- If `auth` or `disconnect`, handle OAuth flow (see below) and stop.
+
+- Determine operation: `issue list`, `issue explain`, `issue plan`, `replays`, `deep-link`, or general query.
 - Resolve org from channel config: `jr-rpc config get sentry.org`
 - Resolve project from channel config: `jr-rpc config get sentry.project` (optional — many queries span multiple projects).
 - If org is missing and needed, ask the user.
 
-2. Enable credentials:
-- Before any authenticated Sentry operation, run: `jr-rpc issue-credential sentry.api`
-- Sandbox runtime applies scoped Authorization headers for this turn.
-- Do not pass raw tokens into the sandbox.
-- If credential issuance fails with `credential_unavailable` + `oauth_started`, relay the `message` from the result to the user and **stop the turn** — the callback will automatically resume the request after they authorize.
-- If a Sentry API call returns 401 or 403 after credentials were issued, the user's token may lack access for the requested org. Run `jr-rpc delete-token sentry` to clear the stale token, then run `jr-rpc issue-credential sentry.api` again to trigger a fresh OAuth flow. Do not ask the user to run a command manually — the system handles re-authorization automatically.
+2. Execute via CLI:
 
-3. Execute via CLI:
 - Use `sentry <command>` for structured queries.
-- The CLI reads `SENTRY_AUTH_TOKEN` from env (injected by broker via lease env field).
+- The CLI reads `SENTRY_AUTH_TOKEN` from env after the runtime enables the declared Sentry capability for this turn.
 - Read [references/cli-commands.md](references/cli-commands.md) for command shapes and flags.
 - Read [references/sandbox-runtime.md](references/sandbox-runtime.md) before relying on sandbox credentials.
+- If a Sentry API call returns 401 or 403 after credentials were issued, the user's token may lack access for the requested org. Run `jr-rpc delete-token sentry` to clear the stale token, then retry after re-enabling the declared capability. Do not ask the user to run a command manually — the system handles re-authorization automatically.
 
-4. Generate deep links:
+3. Generate deep links:
+
 - For user-scoped or entity-specific views, generate URLs instead of CLI calls.
 - Read [references/deep-link-patterns.md](references/deep-link-patterns.md) for URL templates.
 
-5. Report result:
+4. Report result:
+
 - Return issue details, replay links, deep links, or CLI output inline.
 - Include Sentry web URLs for easy navigation.
-
-## Auth flow
-
-When user runs `/sentry auth`:
-1. Run: `jr-rpc oauth-start sentry`
-   - The command sends the authorization link privately (visible only to the requesting user) and returns `{ ok, private_delivery_sent: true }`.
-   - If `private_delivery_sent` is false, tell the user to send you a direct message and try again. **Never** post or relay authorization URLs — they are security-sensitive.
-2. Tell the user you've sent them a private authorization link.
-3. Stop. The agent turn ends here. When the user completes authorization in their browser, the callback handler stores tokens and posts a confirmation message back into the thread automatically.
-
-When user runs `/sentry disconnect`:
-- Clear stored tokens: `jr-rpc delete-token sentry` and post confirmation.
 
 ## Guardrails
 

--- a/packages/junior/src/chat/capabilities/jr-rpc-command.ts
+++ b/packages/junior/src/chat/capabilities/jr-rpc-command.ts
@@ -421,7 +421,7 @@ async function handleOAuthStartCommand(
   }
 
   // Explicit oauth-start must not store pendingMessage — the auth request
-  // itself is the intent, and auto-resuming "/sentry auth" would loop.
+  // itself is the intent, and auto-resuming an explicit reconnect request would loop.
   const result = await startOAuthFlow(provider, {
     requesterId: deps.requesterId,
     channelId: deps.channelId,

--- a/packages/junior/src/chat/prompt.ts
+++ b/packages/junior/src/chat/prompt.ts
@@ -177,6 +177,11 @@ function formatLoadedSkillsForPrompt(skills: Skill[]): string {
       `  <skill name="${escapeXml(skill.name)}" location="${escapeXml(`${skillDir}/SKILL.md`)}">`,
     );
     lines.push(`References are relative to ${escapeXml(skillDir)}.`);
+    if (skill.requiresCapabilities && skill.requiresCapabilities.length > 0) {
+      lines.push(
+        `Requires capabilities: ${escapeXml(skill.requiresCapabilities.join(", "))}.`,
+      );
+    }
     if (skill.usesConfig && skill.usesConfig.length > 0) {
       lines.push(
         `Uses config keys: ${escapeXml(skill.usesConfig.join(", "))}.`,
@@ -474,7 +479,10 @@ export function buildSystemPrompt(params: {
         "- Use `slackMessageAddReaction` for rare lightweight acknowledgements. It reacts to the current inbound message via runtime context; never pick a target message yourself.",
         "- If the user explicitly asks for an emoji reaction instead of text, use `slackMessageAddReaction` with a Slack emoji alias name (for example `thumbsup`, `white_check_mark`, or `eyes`, not unicode emoji), and avoid redundant acknowledgment text.",
         "- Suggested acknowledgement reactions include `wave`, `white_check_mark`, `thumbsup`, and `eyes`, but choose what best fits the request.",
-        "- To enable provider credentials for this turn, run `jr-rpc issue-credential <capability> [--repo <owner/repo>]` as a bash command before commands that need authenticated API calls. GitHub capabilities need repository context, which can come from `--repo` or a configured `github.repo` default.",
+        "- If a loaded skill or `loadSkill` result declares `requires_capabilities`, run `jr-rpc issue-credential <capability> [--repo <owner/repo>]` as a bash command before authenticated bash/API work for that skill.",
+        "- Use the minimum declared capability needed for the current operation.",
+        "- If `jr-rpc issue-credential` returns `oauth_started`, relay its `message` to the user and stop. The runtime will resume after authorization.",
+        "- GitHub capabilities need repository context, which can come from `--repo` or a configured `github.repo` default.",
         "- To persist or read conversation defaults (for example `github.repo`), run `jr-rpc config get|set|unset|list ...` as a bash command.",
         "- Capabilities are provider-qualified (for example `github.issues.write`).",
         "- When your work is complete, provide the exact user-facing markdown response.",

--- a/packages/junior/src/chat/tools/load-skill.ts
+++ b/packages/junior/src/chat/tools/load-skill.ts
@@ -12,6 +12,7 @@ export type LoadSkillResult = {
   available_skills?: string[];
   skill_name?: string;
   description?: string;
+  requires_capabilities?: string[];
   skill_dir?: string;
   location?: string;
   instructions?: string;
@@ -85,6 +86,9 @@ export async function loadSkillFromSandbox(
     ok: true,
     skill_name: skill.name,
     description: skill.description,
+    ...(skill.requiresCapabilities
+      ? { requires_capabilities: skill.requiresCapabilities }
+      : {}),
     skill_dir: skillDir,
     location: skillFilePath,
     instructions: stripFrontmatter(file.toString("utf8")),
@@ -102,7 +106,7 @@ export function createLoadSkillTool(
 ) {
   return tool({
     description:
-      "Load a skill by name so its instructions are available for this turn. When the skill exposes MCP tools, the result includes `available_tools` with exact tool_name values and argument schemas for this turn. Use when a request clearly matches a known skill. Do not use when no skill is relevant.",
+      "Load a skill by name so its instructions are available for this turn. The result includes `requires_capabilities` when the skill declares authenticated provider access, and `available_tools` when the skill exposes MCP tools for this turn. Use when a request clearly matches a known skill. Do not use when no skill is relevant.",
     inputSchema: Type.Object({
       skill_name: Type.String({
         minLength: 1,

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -151,7 +151,7 @@ export async function GET(
     if (errorParam === "access_denied") {
       return htmlErrorResponse(
         "Authorization declined",
-        `You declined the ${providerLabel} authorization request. Return to Slack and run the auth command again if you change your mind.`,
+        `You declined the ${providerLabel} authorization request. Return to Slack and ask Junior to connect your ${providerLabel} account again if you change your mind.`,
         400,
       );
     }
@@ -176,7 +176,7 @@ export async function GET(
   if (!stored) {
     return htmlErrorResponse(
       "Link expired",
-      `This authorization link has expired (links are valid for 10 minutes). Return to Slack and ask to connect your ${providerLabel} account again, or retry your original command to get a new link.`,
+      `This authorization link has expired (links are valid for 10 minutes). Return to Slack and ask Junior to connect your ${providerLabel} account again to get a new link.`,
       400,
     );
   }

--- a/packages/junior/tests/load-skill-tool.test.ts
+++ b/packages/junior/tests/load-skill-tool.test.ts
@@ -42,6 +42,9 @@ describe("load_skill tool", () => {
     expect(result).toMatchObject({
       ok: true,
       skill_name: firstSkill.name,
+      ...(firstSkill.requiresCapabilities
+        ? { requires_capabilities: firstSkill.requiresCapabilities }
+        : {}),
     });
     expect((result as any).location).toBe(sandboxSkillFile(firstSkill.name));
     expect((result as any).skill_dir).toBe(sandboxSkillDir(firstSkill.name));

--- a/packages/junior/tests/oauth-callback.test.ts
+++ b/packages/junior/tests/oauth-callback.test.ts
@@ -165,6 +165,9 @@ describe("oauth callback handler", () => {
     const body = await response.text();
     expect(body).toContain("<!DOCTYPE html>");
     expect(body).toContain("expired");
+    expect(body).toContain(
+      "ask Junior to connect your Sentry account again to get a new link",
+    );
   });
 
   it("returns styled HTML 400 for provider mismatch", async () => {
@@ -386,6 +389,10 @@ describe("oauth callback handler", () => {
     const body = await response.text();
     expect(body).toContain("<!DOCTYPE html>");
     expect(body).toContain("declined");
+    expect(body).toContain(
+      "ask Junior to connect your Sentry account again if you change your mind",
+    );
+    expect(body).not.toContain("auth command");
     // State should be cleaned up
     expect(mockStateStore.has(stateKey)).toBe(false);
   });

--- a/packages/junior/tests/prompt-skills.test.ts
+++ b/packages/junior/tests/prompt-skills.test.ts
@@ -25,6 +25,7 @@ describe("buildSystemPrompt skill paths", () => {
         name: "brief",
         description: "Create a candidate brief",
         skillPath: "/host/path/skills/brief",
+        requiresCapabilities: ["github.issues.read"],
         usesConfig: ["github.repo"],
       },
     ];
@@ -49,6 +50,7 @@ describe("buildSystemPrompt skill paths", () => {
     expect(prompt).toContain(
       `<skill name="brief" location="${sandboxSkillFile("brief")}">`,
     );
+    expect(prompt).toContain("Requires capabilities: github.issues.read.");
     expect(prompt).toContain("Uses config keys: github.repo.");
     expect(prompt).toContain(
       `References are relative to ${sandboxSkillDir("brief")}.`,
@@ -77,6 +79,9 @@ describe("buildSystemPrompt skill paths", () => {
     expect(prompt).toContain("- provider: github");
     expect(prompt).toContain("  - config_keys: github.repo");
     expect(prompt).toContain("github.issues.read");
+    expect(prompt).toContain(
+      "If a loaded skill or `loadSkill` result declares `requires_capabilities`",
+    );
   });
 
   it("documents harness-owned Slack artifact targeting and explicit channel-post behavior", () => {

--- a/specs/oauth-flows-spec.md
+++ b/specs/oauth-flows-spec.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-03-03
-- Last Edited: 2026-03-18
+- Last Edited: 2026-03-20
 
 ## Changelog
 
@@ -11,6 +11,7 @@
 - 2026-03-09: Added provider-configured token request auth/headers and optional token expiry semantics.
 - 2026-03-13: Documented MCP challenge-driven OAuth, MCP callback routing, and auth-driven turn resume.
 - 2026-03-18: Clarified lazy MCP auth-session creation, host-managed MCP server-session storage, and disconnect cleanup for stored credentials plus pending auth sessions.
+- 2026-03-20: Removed stale slash-command examples in favor of generic connect/disconnect requests and direct jr-rpc initiation.
 
 ## Status
 
@@ -54,7 +55,7 @@ Device code grant (RFC 8628) was rejected because it requires agent-side polling
 ### Authorization (connect)
 
 ```
-User: /sentry auth (in Slack thread)
+User: asks Junior to connect their Sentry account in a Slack thread
   │
   ▼
 Agent: jr-rpc oauth-start sentry
@@ -130,7 +131,7 @@ After a user has connected their account, credential issuance works transparentl
 ### Disconnect
 
 ```
-User: /sentry disconnect
+User: asks Junior to disconnect their Sentry account
   │
   ▼
 Agent: jr-rpc delete-token sentry
@@ -248,11 +249,11 @@ This section describes what the user actually sees in their Slack thread for eac
 What the thread looks like:
 
 ```
-User:     @Junior /sentry auth
+User:     @Junior connect my Sentry account
 Junior:   I've sent you a private link to connect your Sentry account.
           [ephemeral — only this user sees: "Click here to connect your Sentry account" with link]
           ... user clicks link, authorizes in browser, sees "Sentry account connected" page ...
-Junior:   Your Sentry account is now connected. You can start using Sentry commands.
+Junior:   Your Sentry account is now connected. You can continue with Sentry requests.
 ```
 
 Three messages from Junior appear in the thread:
@@ -266,9 +267,9 @@ The user also sees a success page in their browser after authorizing, telling th
 What happens under the hood:
 
 ```
-1. User sends "@Junior /sentry auth"
+1. User asks Junior to connect their Sentry account
 2. Agent turn starts
-   a. Agent loads sentry skill, sees "auth" operation
+   a. Agent detects an explicit Sentry connect request
    b. Runs `jr-rpc oauth-start sentry`
    c. oauth-start: stores { userId, provider, channelId, threadTs } in Redis (10-min TTL)
    d. oauth-start: sends authorize URL privately via SLACK_BOT_TOKEN (ephemeral in channels, DM fallback)
@@ -293,7 +294,7 @@ What happens under the hood:
 What the thread looks like:
 
 ```
-User:     @Junior /sentry issue list
+User:     @Junior show me recent Sentry issues
 Junior:   [responds with issue list — no auth prompts, no delays]
 ```
 
@@ -304,7 +305,7 @@ The auth machinery is invisible. On every turn, the broker looks up stored token
 What the thread looks like:
 
 ```
-User:     @Junior /sentry issue list
+User:     @Junior show me recent Sentry issues
 Junior:   [responds normally — identical to above]
 ```
 
@@ -315,7 +316,7 @@ If the access token is within 5 minutes of expiry, the broker silently refreshes
 What the thread looks like:
 
 ```
-User:     @Junior /sentry issue list
+User:     @Junior show me recent Sentry issues
 Junior:   I need to reconnect your Sentry account. I've sent you a private authorization link.
           [ephemeral — only this user sees: "Click here to connect your Sentry account" with link]
           ... user clicks link, authorizes in browser ...
@@ -330,7 +331,7 @@ This happens when the refresh token itself is revoked or Sentry's token endpoint
 What the thread looks like:
 
 ```
-User:     @Junior /sentry issue list
+User:     @Junior show me recent Sentry issues
 Junior:   I need to connect your Sentry account first. I've sent you a private link.
           [private — only this user sees: "Click here to connect your Sentry account" with link]
           ... user clicks link, authorizes in browser ...
@@ -343,7 +344,7 @@ The broker throws `CredentialUnavailableError`. The harness (`issue-credential` 
 What happens under the hood:
 
 ```
-1. User sends "@Junior /sentry issue list"
+1. User asks Junior to show recent Sentry issues
 2. Agent turn starts
    a. Agent loads sentry skill, runs jr-rpc issue-credential sentry.api
    b. Broker throws CredentialUnavailableError("sentry", ...)
@@ -358,7 +359,7 @@ What happens under the hood:
    a. Exchanges code for tokens, stores in Redis
    b. Returns HTML success page to browser
    c. after(): posts "Your Sentry account is now connected. Processing your request..."
-   d. after(): calls generateAssistantReply("/sentry issue list", { configuration, ... })
+   d. after(): calls generateAssistantReply("show me recent Sentry issues", { configuration, ... })
    e. after(): posts the agent's reply to the Slack thread
 5. User sees results without any additional action
 ```
@@ -368,7 +369,7 @@ What happens under the hood:
 What the thread looks like:
 
 ```
-User:     @Junior /sentry disconnect
+User:     @Junior disconnect my Sentry account
 Junior:   Your Sentry account has been disconnected.
 ```
 
@@ -388,7 +389,7 @@ Under the hood: `jr-rpc delete-token sentry` deletes the stored provider credent
 
 **Harness-driven auto-start.** The agent never passes pending message context. When `issue-credential` fails with `CredentialUnavailableError` for an OAuth-capable provider, the harness automatically starts the OAuth flow with the original user message (from `JrRpcDeps.userMessage`) and channel configuration stored in the OAuth state. The agent only needs to interpret the `credential_unavailable` + `oauth_started` result and inform the user.
 
-**Explicit `/sentry auth` skips auto-resume.** When the user explicitly requests auth via `oauth-start`, no `userMessage` is stored (the auth request itself is the intent), and the callback posts a simple "connected" confirmation without triggering an agent turn.
+**Explicit connect requests via `oauth-start` skip auto-resume.** When the user explicitly requests account connection via `oauth-start`, no `userMessage` is stored (the connect request itself is the intent), and the callback posts a simple "connected" confirmation without triggering an agent turn.
 
 ## Adding a new provider
 

--- a/specs/skill-capabilities-spec.md
+++ b/specs/skill-capabilities-spec.md
@@ -3,13 +3,13 @@
 ## Metadata
 
 - Created: 2026-02-26
-- Last Edited: 2026-03-04
+- Last Edited: 2026-03-20
 
 ## Changelog
 
 - 2026-03-03: Standardized metadata headers and reconciled spec references/structure.
 - 2026-03-04: Updated repo-root file paths and aligned OAuth URL visibility contract with security policy.
-
+- 2026-03-20: Documented prompt exposure of declared capabilities and clarified Sentry OAuth initiation paths.
 
 ## Status
 
@@ -27,7 +27,7 @@ Define a capability model where skills declare required capabilities and runtime
 ## Core model
 
 1. Skill loads normally.
-2. Runtime reads `requires-capabilities` from active skill.
+2. Prompt/runtime expose `requires-capabilities` from the loaded skill for agent guidance.
 3. Agent enables credential with bash custom command `jr-rpc issue-credential <capability>`.
 4. Runtime issues short-lived credentials and applies sandbox header transforms.
 5. Runtime does not persist long-lived secrets in sandbox env/files or skill files.
@@ -56,6 +56,7 @@ Rules:
 ### Capability resolution
 
 - Resolve capabilities from active skill context for guidance and observability.
+- Expose declared capabilities to the agent through loaded-skill prompt context and `loadSkill` results.
 - Declarations are currently soft-enforced (warn-only) when missing/mismatched.
 
 ### Credential issuance
@@ -114,7 +115,7 @@ Rules:
 
 ### OAuth authorization code flow
 
-- Auth initiated by `/sentry auth` command.
+- Auth initiated by `jr-rpc oauth-start sentry` directly or by auto-OAuth during `jr-rpc issue-credential sentry.api`.
 - Uses Authorization Code Grant (RFC 6749 §4.1) via `jr-rpc oauth-start sentry`.
 - Callback handler at `/api/oauth/callback/sentry` exchanges code for tokens server-side.
 - Tokens stored per Slack user ID via `StateAdapterTokenStore` (Redis-backed).


### PR DESCRIPTION
Surface declared skill capabilities through loadSkill and the loaded-skill prompt so authenticated provider work no longer depends on plugin-specific auth prose.

This moves the generic auth guidance into the shared prompt/loadSkill path, trims stale slash-command and duplicated auth-flow guidance from the Sentry, GitHub, and Notion plugin skills, and updates the OAuth/capability specs to match the runtime behavior.

GitHub keeps the operation-to-capability mapping in the skill because the shared metadata now tells the model which capabilities exist, but not yet which operation should pick which one.

Fixes #105