### PR TITLE
fix(chat): Tighten passive thread reply routing

### DIFF
--- a/packages/junior-evals/README.md
+++ b/packages/junior-evals/README.md
@@ -68,6 +68,7 @@ Harness override knobs (in `EvalOverrides`):
 - `mock_image_generation`: stub the image-generation HTTP response with a valid image payload while still exercising the real attachment path.
 - `plugin_dirs`: load plugin fixtures from eval-local directories without adding workspace packages.
 - `reply_texts`: override returned reply text per call.
+- `reply_timeout_ms`: raise the per-reply harness timeout for a specific slow scenario without changing the suite-wide default.
 - `subscribed_decisions`: controls the subscribed-message reply gate in the harness. If you use it, do not claim that reply-selection behavior is being validated by the eval itself.
 
 These knobs work by overriding services on the eval-local runtime instance. They must not reintroduce mutable global runtime behavior seams.

--- a/packages/junior-evals/evals/behavior-harness.ts
+++ b/packages/junior-evals/evals/behavior-harness.ts
@@ -124,6 +124,7 @@ export interface EvalOverrides {
   plugin_dirs?: string[];
   plugin_packages?: string[];
   reply_results?: EvalReplyResultFixture[];
+  reply_timeout_ms?: number;
   reply_texts?: string[];
   skill_dirs?: string[];
   subscribed_decisions?: SubscribedDecisionFixture[];
@@ -797,10 +798,11 @@ function buildRuntimeServices(
   const replyResults = scenario.overrides?.reply_results ?? [];
   const replyTexts = scenario.overrides?.reply_texts ?? [];
   const subscribedDecisions = scenario.overrides?.subscribed_decisions ?? [];
-  const replyTimeoutMs = Number.parseInt(
-    process.env.EVAL_AGENT_REPLY_TIMEOUT_MS ?? "45000",
-    10,
-  );
+  const replyTimeoutMs =
+    scenario.overrides?.reply_timeout_ms &&
+    scenario.overrides.reply_timeout_ms > 0
+      ? scenario.overrides.reply_timeout_ms
+      : Number.parseInt(process.env.EVAL_AGENT_REPLY_TIMEOUT_MS ?? "45000", 10);
   let replyCallCount = 0;
   let decisionIndex = 0;
   const replyState = { successfulCount: 0 };

--- a/packages/junior-evals/evals/core/passive-behavior.eval.ts
+++ b/packages/junior-evals/evals/core/passive-behavior.eval.ts
@@ -143,6 +143,62 @@ describe("Conversational Evals: Passive Behavior", () => {
       "The assistant posts two replies in order. The second reply provides more detail about the deploy changes because the follow-up explicitly references Junior's last response.",
   });
 
+  const terseFollowUpThread = {
+    id: "thread-passive-terse-follow-up",
+    channel_id: "C-passive-terse-follow-up",
+    thread_ts: "17000000.passive-terse-follow-up",
+  };
+
+  slackEval(
+    "passive: terse clarification right after Junior reply gets a reply",
+    {
+      overrides: {
+        reply_texts: [
+          "The deploy changed billing, auth, and the API gateway.",
+          "The three services were billing, auth, and the API gateway.",
+        ],
+      },
+      events: [
+        mention("What changed in the deploy?", {
+          thread: terseFollowUpThread,
+        }),
+        threadMessage("Which one?", {
+          thread: terseFollowUpThread,
+        }),
+      ],
+      criteria:
+        "The assistant posts two replies in order. The second reply clarifies which services changed because the terse follow-up 'Which one?' came immediately after Junior's answer and is naturally directed at Junior.",
+    },
+  );
+
+  const humansTookFloorThread = {
+    id: "thread-passive-humans-took-floor",
+    channel_id: "C-passive-humans-took-floor",
+    thread_ts: "17000000.passive-humans-took-floor",
+  };
+
+  slackEval(
+    "passive: same-topic question is skipped after humans take the floor",
+    {
+      overrides: {
+        reply_texts: ["The deploy changed billing, auth, and the API gateway."],
+      },
+      events: [
+        mention("What changed in the deploy?", {
+          thread: humansTookFloorThread,
+        }),
+        threadMessage("I think auth should roll back first.", {
+          thread: humansTookFloorThread,
+        }),
+        threadMessage("What about the billing worker timeline?", {
+          thread: humansTookFloorThread,
+        }),
+      ],
+      criteria:
+        "The assistant posts exactly one reply: the initial deploy summary. It does not answer the later same-topic question about the billing worker timeline because humans resumed the thread and the later question does not clearly turn back to Junior.",
+    },
+  );
+
   const optOutThread = {
     id: "thread-opt-out",
     channel_id: "C-opt-out",

--- a/packages/junior-evals/evals/github/skill-workflows.eval.ts
+++ b/packages/junior-evals/evals/github/skill-workflows.eval.ts
@@ -18,6 +18,7 @@ describe("Conversational Evals: GitHub Skill Workflows", () => {
     overrides: {
       enable_test_credentials: true,
       plugin_packages: ["@sentry/junior-github"],
+      reply_timeout_ms: 75000,
       test_credential_token: "eval-github-token",
       skill_dirs: ["../junior/skills"],
     },

--- a/packages/junior/src/chat/services/subscribed-decision.ts
+++ b/packages/junior/src/chat/services/subscribed-decision.ts
@@ -6,7 +6,6 @@ export enum SubscribedReplyReason {
   ExplicitMention = "explicit_mention",
   DirectedToOtherParty = "directed_to_other_party",
   EmptyMessage = "empty_message",
-  AttachmentOnly = "attachment_only",
   Classifier = "llm_classifier",
   SideConversation = "side_conversation",
   LowConfidence = "low_confidence",
@@ -41,6 +40,23 @@ interface ClassifierResult {
   reason?: string;
 }
 
+interface TranscriptMessage {
+  author: string;
+  role: "assistant" | "system" | "user";
+  text: string;
+}
+
+interface RouterSignals {
+  assistantWasLastSpeaker: boolean;
+  currentMessageHasDirectedFollowUpCue: boolean;
+  currentMessageHasAttachments: boolean;
+  currentMessageIsTerseClarification: boolean;
+  humanMessagesSinceLastAssistant?: number;
+  latestPriorAssistantMessage: string;
+  latestPriorMessageRole: string;
+  recentMessages: TranscriptMessage[];
+}
+
 const replyDecisionSchema = z.object({
   should_reply: z
     .boolean()
@@ -63,7 +79,7 @@ const ROUTER_CONFIDENCE_THRESHOLD = 0.8;
 const LEADING_SLACK_MENTION_RE = /^\s*<@([A-Z0-9]+)(?:\|([^>]+))?>[\s,:-]*/i;
 const LEADING_NAMED_MENTION_RE = /^\s*@([a-z0-9._-]+)\b[\s,:-]*/i;
 const TRANSCRIPT_MESSAGE_LINE_RE =
-  /^\[(assistant|system|user)\]\s+[^:]+:\s+([\s\S]+)$/i;
+  /^\[(assistant|system|user)\]\s+([^:]+):\s+([\s\S]+)$/i;
 const THREAD_OPTOUT_PATTERNS = [
   /\bstop (?:watching|replying|participating)\b/i,
   /\bstay out\b/i,
@@ -71,6 +87,15 @@ const THREAD_OPTOUT_PATTERNS = [
   /\bunsubscribe\b/i,
   /\bleave (?:this )?thread\b/i,
 ];
+const ACKNOWLEDGMENT_ONLY_RE =
+  /^(?:thanks(?: you)?|thank you|thx|ty|got it|sounds good|sgtm|lgtm|ok(?:ay)?|cool|nice|perfect|awesome|great|makes sense|understood|roger|yep|yup|kk|on it|will do)(?:[.!]+)?$/i;
+const DIRECTED_FOLLOW_UP_CUE_RE =
+  /\b(?:you said|you just said|your last response|your last answer|what did you just say|what do you mean|what did you mean|explain(?: that| this| it| more)?|clarify(?: that| this| it)?|expand(?: on)?(?: that| this| it)?|elaborate(?: on)?(?: that| this| it)?|say more)\b/i;
+const TERSE_CLARIFICATION_RE =
+  /^(?:which one|which ones|why|how so|what do you mean|what did you mean|say more|explain that|clarify that|expand on that|elaborate on that)\??$/i;
+const GENERIC_IMMEDIATE_SIDE_CONVERSATION_RE =
+  /^(?:is that (?:the )?right (?:approach|call|move)|(?:can|could|would) you check on this)\??$/i;
+const RECENT_THREAD_WINDOW = 6;
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -130,50 +155,167 @@ function isThreadOptOutInstruction(rawText: string, text: string): boolean {
   );
 }
 
-function getTranscriptMessageHints(conversationContext: string | undefined) {
-  if (!conversationContext) {
-    return {
-      latestPriorMessageRole: "[none]",
-      latestPriorAssistantMessage: "[none]",
-    };
+function isAcknowledgmentOnly(text: string): boolean {
+  return ACKNOWLEDGMENT_ONLY_RE.test(text.trim());
+}
+
+function hasDirectedFollowUpCue(text: string): boolean {
+  return DIRECTED_FOLLOW_UP_CUE_RE.test(text.trim());
+}
+
+function isTerseClarification(text: string): boolean {
+  return TERSE_CLARIFICATION_RE.test(text.trim());
+}
+
+function isGenericImmediateSideConversation(text: string): boolean {
+  const trimmed = text.trim();
+  if (GENERIC_IMMEDIATE_SIDE_CONVERSATION_RE.test(trimmed)) {
+    return true;
   }
 
+  if (!trimmed.toLowerCase().startsWith("what about")) {
+    return false;
+  }
+
+  const wordCount = trimmed
+    .split(/\s+/)
+    .map((part) => part.trim())
+    .filter(Boolean).length;
+  return wordCount > 3;
+}
+
+function parseTranscriptMessages(
+  conversationContext: string | undefined,
+): TranscriptMessage[] {
+  if (!conversationContext) {
+    return [];
+  }
+
+  const messages: TranscriptMessage[] = [];
   const lines = conversationContext
     .split("\n")
     .map((line) => line.trim())
     .filter((line) => line.length > 0);
 
-  let latestPriorMessageRole = "[none]";
-  let latestPriorAssistantMessage = "[none]";
-
-  for (let index = lines.length - 1; index >= 0; index -= 1) {
-    const match = lines[index]?.match(TRANSCRIPT_MESSAGE_LINE_RE);
+  for (const line of lines) {
+    const match = line.match(TRANSCRIPT_MESSAGE_LINE_RE);
     if (!match) {
       continue;
     }
 
-    if (latestPriorMessageRole === "[none]") {
-      latestPriorMessageRole = match[1].toLowerCase();
-    }
-    if (
-      latestPriorAssistantMessage === "[none]" &&
-      match[1].toLowerCase() === "assistant"
-    ) {
-      latestPriorAssistantMessage = match[2];
-    }
+    messages.push({
+      role: match[1].toLowerCase() as TranscriptMessage["role"],
+      author: match[2]?.trim() || "unknown",
+      text: match[3]?.trim() || "",
+    });
+  }
 
-    if (
-      latestPriorMessageRole !== "[none]" &&
-      latestPriorAssistantMessage !== "[none]"
-    ) {
+  return messages;
+}
+
+function buildRouterSignals(input: SubscribedDecisionInput): RouterSignals {
+  const transcriptMessages = parseTranscriptMessages(input.conversationContext);
+  const recentMessages = transcriptMessages
+    .filter((message) => message.role !== "system")
+    .slice(-RECENT_THREAD_WINDOW);
+
+  const latestPriorMessage = [...transcriptMessages]
+    .reverse()
+    .find((message) => message.role !== "system");
+  const latestPriorAssistantMessage = [...transcriptMessages]
+    .reverse()
+    .find((message) => message.role === "assistant");
+
+  let humanMessagesSinceLastAssistant: number | undefined;
+  let humanMessageCount = 0;
+  for (let index = transcriptMessages.length - 1; index >= 0; index -= 1) {
+    const message = transcriptMessages[index];
+    if (!message || message.role === "system") {
+      continue;
+    }
+    if (message.role === "assistant") {
+      humanMessagesSinceLastAssistant = humanMessageCount;
       break;
     }
+    humanMessageCount += 1;
   }
 
   return {
-    latestPriorMessageRole,
-    latestPriorAssistantMessage,
+    assistantWasLastSpeaker: latestPriorMessage?.role === "assistant",
+    currentMessageHasDirectedFollowUpCue: hasDirectedFollowUpCue(input.text),
+    currentMessageHasAttachments: Boolean(input.hasAttachments),
+    currentMessageIsTerseClarification: isTerseClarification(input.text),
+    humanMessagesSinceLastAssistant,
+    latestPriorAssistantMessage: latestPriorAssistantMessage?.text || "[none]",
+    latestPriorMessageRole: latestPriorMessage?.role || "[none]",
+    recentMessages,
   };
+}
+
+function buildRouterPrompt(rawText: string, signals: RouterSignals): string {
+  const recentThread =
+    signals.recentMessages.length > 0
+      ? signals.recentMessages
+          .map((message) =>
+            escapeXml(`[${message.role}] ${message.author}: ${message.text}`),
+          )
+          .join("\n")
+      : "[none]";
+
+  return [
+    `<latest-message>${escapeXml(rawText.trim() || "[attachment-only message]")}</latest-message>`,
+    "<routing-signals>",
+    `assistant_was_last_speaker=${signals.assistantWasLastSpeaker ? "true" : "false"}`,
+    `human_messages_since_last_assistant=${
+      signals.humanMessagesSinceLastAssistant ?? "none"
+    }`,
+    `latest_prior_message_role=${escapeXml(signals.latestPriorMessageRole)}`,
+    `current_message_has_directed_follow_up_cue=${
+      signals.currentMessageHasDirectedFollowUpCue ? "true" : "false"
+    }`,
+    `current_message_is_terse_clarification=${
+      signals.currentMessageIsTerseClarification ? "true" : "false"
+    }`,
+    `current_message_has_attachments=${
+      signals.currentMessageHasAttachments ? "true" : "false"
+    }`,
+    "</routing-signals>",
+    `<latest-prior-assistant-message>${escapeXml(
+      signals.latestPriorAssistantMessage,
+    )}</latest-prior-assistant-message>`,
+    "<recent-thread>",
+    recentThread,
+    "</recent-thread>",
+  ].join("\n");
+}
+
+function getReplyConfidenceThreshold(signals: RouterSignals): number {
+  let threshold = ROUTER_CONFIDENCE_THRESHOLD;
+
+  if (
+    signals.assistantWasLastSpeaker &&
+    signals.humanMessagesSinceLastAssistant === 0
+  ) {
+    if (
+      signals.currentMessageHasDirectedFollowUpCue ||
+      signals.currentMessageIsTerseClarification
+    ) {
+      threshold = 0.65;
+    } else {
+      threshold = 0.9;
+    }
+  } else if (
+    signals.assistantWasLastSpeaker &&
+    signals.humanMessagesSinceLastAssistant === 1
+  ) {
+    threshold = signals.currentMessageHasDirectedFollowUpCue ? 0.8 : 0.9;
+  } else if (signals.humanMessagesSinceLastAssistant === undefined) {
+    threshold = 0.85;
+  } else if (signals.humanMessagesSinceLastAssistant >= 2) {
+    threshold = 0.9;
+  }
+
+  return Math.max(0.6, Math.min(0.9, threshold));
 }
 
 /** Fast heuristic check before the LLM classifier — skips messages directed at another party. */
@@ -206,60 +348,27 @@ export function getSubscribedReplyPreflightDecision(args: {
   };
 }
 
-function buildRouterSystemPrompt(
-  botUserName: string,
-  conversationContext: string | undefined,
-  isExplicitMention: boolean | undefined,
-): string {
-  const { latestPriorMessageRole, latestPriorAssistantMessage } =
-    getTranscriptMessageHints(conversationContext);
-
+function buildRouterSystemPrompt(botUserName: string): string {
   return [
     "You are a message router for a Slack assistant named Junior in a subscribed Slack thread.",
     "Decide whether Junior should reply to the latest message.",
     "Subscribed threads are passive by default.",
-    "Default to should_reply=false unless the user is clearly asking Junior for help or follow-up.",
-    "A direct @mention is a strong signal to reply unless the message is clearly telling Junior to stop participating.",
-    "",
-    "Reply should be true only when the user is clearly asking Junior a question, requesting help,",
-    "or when a direct follow-up is contextually aimed at Junior's previous response in the thread context.",
-    "",
-    "Reply should be false for side conversations between humans, acknowledgements,",
-    "status chatter, or messages not seeking assistant input.",
-    "Junior must not participate in casual banter or keep chiming in just because it replied earlier.",
-    "",
-    "Examples of messages Junior should NOT reply to (should_reply=false):",
-    "- Questions between humans: 'Is that the right approach?', 'Can you check on this?', 'Did you deploy that?'",
-    "- Acknowledgments: 'thanks', '+1', 'lgtm', 'ok cool', 'sounds good', 'nice'",
-    "- Status updates: 'I just pushed a fix', 'Deploying now', 'Build is green'",
-    "- General thread discussion: 'What about the billing issue?', 'I think we should revert'",
-    "- Reactions to work: 'That looks wrong', 'Nice catch', 'Hmm interesting'",
-    "",
-    "Examples of messages Junior SHOULD reply to (should_reply=true):",
-    "- Direct follow-ups to Junior's response: 'Can you explain that last point in more detail?'",
-    "- Self-referential follow-ups after Junior just answered: 'What did you just say about the budget?', 'Can you explain your last response in more detail?'",
-    "- Explicit requests for Junior's help: 'Junior, what's causing this error?'",
-    "",
-    "Treat a message as directed at Junior when it explicitly refers to Junior's immediately previous reply",
-    "using language like 'you just said', 'your last response', 'your last answer', or similar self-reference.",
-    "Do not confuse that with general topic continuation. A message like 'What about the billing worker timeline?'",
-    "still should_reply=false unless it clearly asks Junior for help.",
-    "",
-    "When in doubt, should_reply=false. Most messages in a thread are human-to-human conversation.",
-    "",
-    "If the user is clearly telling Junior to stop watching, replying, or participating in the thread,",
-    "set should_unsubscribe=true and should_reply=false.",
-    "Use should_unsubscribe only for clear thread opt-out instructions, not for ordinary side conversation.",
-    "If uncertain, set should_reply=false and use low confidence.",
+    "Reply true only when the latest message is aimed at Junior.",
+    "Use who currently has the conversation floor, not just topic overlap.",
+    "If Junior was the last speaker, only a clear turn back to Junior should count as an implicit follow-up.",
+    "Terse clarifications like 'which one?' or 'why?' right after Junior answers can be should_reply=true.",
+    "Direct self-reference to Junior's prior answer like 'what did you just say?' or 'explain that more' can be should_reply=true.",
+    "If one or more humans spoke after Junior, require a clear turn back to Junior. Shared domain vocabulary alone is not enough.",
+    "Questions like 'what about auth?' or 'can you check on this?' are usually human-to-human unless the thread clearly turns back to Junior.",
+    "A vague question like 'is that the right approach?' is still should_reply=false unless it clearly turns back to Junior.",
+    "Acknowledgments, reactions, status chatter, and team coordination should be should_reply=false.",
+    "If the latest message clearly tells Junior to stop watching, replying, or participating, set should_unsubscribe=true and should_reply=false.",
+    "When uncertain, prefer should_reply=false with low confidence.",
     "",
     "Return JSON with should_reply, should_unsubscribe, confidence, and a short reason.",
     "Do not return any extra keys.",
     "",
     `<assistant-name>${escapeXml(botUserName)}</assistant-name>`,
-    `<explicit-mention>${isExplicitMention ? "true" : "false"}</explicit-mention>`,
-    `<latest-prior-message-role>${escapeXml(latestPriorMessageRole)}</latest-prior-message-role>`,
-    `<latest-prior-assistant-message>${escapeXml(latestPriorAssistantMessage)}</latest-prior-assistant-message>`,
-    `<thread-context>${escapeXml(conversationContext?.trim() || "[none]")}</thread-context>`,
   ].join("\n");
 }
 
@@ -293,11 +402,16 @@ export async function decideSubscribedThreadReply(args: {
   if (preflightDecision) {
     return preflightDecision;
   }
+  const signals = buildRouterSignals(args.input);
   if (!text && !args.input.hasAttachments) {
     return { shouldReply: false, reason: SubscribedReplyReason.EmptyMessage };
   }
-  if (!text && args.input.hasAttachments) {
-    return { shouldReply: true, reason: SubscribedReplyReason.AttachmentOnly };
+  if (!args.input.isExplicitMention && isAcknowledgmentOnly(text)) {
+    return {
+      shouldReply: false,
+      reason: SubscribedReplyReason.SideConversation,
+      reasonDetail: "acknowledgment",
+    };
   }
 
   if (args.input.isExplicitMention) {
@@ -315,18 +429,28 @@ export async function decideSubscribedThreadReply(args: {
     };
   }
 
+  if (
+    signals.assistantWasLastSpeaker &&
+    signals.humanMessagesSinceLastAssistant === 0 &&
+    !signals.currentMessageHasDirectedFollowUpCue &&
+    !signals.currentMessageIsTerseClarification &&
+    isGenericImmediateSideConversation(text)
+  ) {
+    return {
+      shouldReply: false,
+      reason: SubscribedReplyReason.SideConversation,
+      reasonDetail: "generic immediate side conversation",
+    };
+  }
+
   try {
     const result = await args.completeObject({
       modelId: args.modelId,
       schema: replyDecisionSchema,
       maxTokens: 120,
       temperature: 0,
-      system: buildRouterSystemPrompt(
-        args.botUserName,
-        args.input.conversationContext,
-        args.input.isExplicitMention,
-      ),
-      prompt: rawText,
+      system: buildRouterSystemPrompt(args.botUserName),
+      prompt: buildRouterPrompt(rawText, signals),
       metadata: {
         modelId: args.modelId,
         threadId: args.input.context.threadId ?? "",
@@ -338,6 +462,7 @@ export async function decideSubscribedThreadReply(args: {
 
     const parsed = replyDecisionSchema.parse(result.object) as ClassifierResult;
     const reason = parsed.reason?.trim() || "classifier";
+    const replyConfidenceThreshold = getReplyConfidenceThreshold(signals);
     if (parsed.should_unsubscribe) {
       if (parsed.confidence < ROUTER_CONFIDENCE_THRESHOLD) {
         return {
@@ -363,7 +488,7 @@ export async function decideSubscribedThreadReply(args: {
       };
     }
 
-    if (parsed.confidence < ROUTER_CONFIDENCE_THRESHOLD) {
+    if (parsed.confidence < replyConfidenceThreshold) {
       return {
         shouldReply: false,
         reason: SubscribedReplyReason.LowConfidence,

--- a/packages/junior/src/chat/services/subscribed-decision.ts
+++ b/packages/junior/src/chat/services/subscribed-decision.ts
@@ -304,10 +304,7 @@ function getReplyConfidenceThreshold(signals: RouterSignals): number {
     } else {
       threshold = 0.9;
     }
-  } else if (
-    signals.assistantWasLastSpeaker &&
-    signals.humanMessagesSinceLastAssistant === 1
-  ) {
+  } else if (signals.humanMessagesSinceLastAssistant === 1) {
     threshold = signals.currentMessageHasDirectedFollowUpCue ? 0.8 : 0.9;
   } else if (signals.humanMessagesSinceLastAssistant === undefined) {
     threshold = 0.85;
@@ -406,7 +403,11 @@ export async function decideSubscribedThreadReply(args: {
   if (!text && !args.input.hasAttachments) {
     return { shouldReply: false, reason: SubscribedReplyReason.EmptyMessage };
   }
-  if (!args.input.isExplicitMention && isAcknowledgmentOnly(text)) {
+  if (
+    !args.input.isExplicitMention &&
+    !args.input.hasAttachments &&
+    isAcknowledgmentOnly(text)
+  ) {
     return {
       shouldReply: false,
       reason: SubscribedReplyReason.SideConversation,
@@ -432,6 +433,7 @@ export async function decideSubscribedThreadReply(args: {
   if (
     signals.assistantWasLastSpeaker &&
     signals.humanMessagesSinceLastAssistant === 0 &&
+    !signals.currentMessageHasAttachments &&
     !signals.currentMessageHasDirectedFollowUpCue &&
     !signals.currentMessageIsTerseClarification &&
     isGenericImmediateSideConversation(text)

--- a/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
@@ -291,7 +291,7 @@ describe("Slack behavior: subscribed messages", () => {
     );
   });
 
-  it("routes acknowledgment messages through the classifier", async () => {
+  it("short-circuits acknowledgment messages without calling the classifier", async () => {
     let classifierCalled = false;
     let replyCalled = false;
 
@@ -300,14 +300,9 @@ describe("Slack behavior: subscribed messages", () => {
         subscribedReplyPolicy: {
           completeObject: async () => {
             classifierCalled = true;
-            return {
-              object: {
-                should_reply: false,
-                confidence: 0.95,
-                reason: "acknowledgment, not a request for help",
-              },
-              text: '{"should_reply":false,"confidence":0.95,"reason":"acknowledgment, not a request for help"}',
-            } as never;
+            throw new Error(
+              "classifier should be bypassed for acknowledgments",
+            );
           },
         },
         replyExecutor: {
@@ -341,9 +336,133 @@ describe("Slack behavior: subscribed messages", () => {
 
     await slackRuntime.handleSubscribedMessage(thread, message);
 
+    expect(classifierCalled).toBe(false);
+    expect(replyCalled).toBe(false);
+    expect(thread.posts).toHaveLength(0);
+  });
+
+  it("routes attachment-only passive messages through the classifier", async () => {
+    let classifierCalled = false;
+    let replyCalled = false;
+
+    const { slackRuntime } = createRuntime({
+      services: {
+        subscribedReplyPolicy: {
+          completeObject: async () => {
+            classifierCalled = true;
+            return {
+              object: {
+                should_reply: false,
+                confidence: 0.95,
+                reason: "passive attachment",
+              },
+              text: '{"should_reply":false,"confidence":0.95,"reason":"passive attachment"}',
+            } as never;
+          },
+        },
+        replyExecutor: {
+          generateAssistantReply: async () => {
+            replyCalled = true;
+            return {
+              text: "This should never be posted.",
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "fake-agent-model",
+                outcome: "success",
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            };
+          },
+        },
+      },
+    });
+
+    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002003.250" });
+    const message = createTestMessage({
+      id: "m-subscribed-attachment-only",
+      text: "",
+      isMention: false,
+      threadId: thread.id,
+      author: { userId: "U_TESTER" },
+      attachments: [
+        {
+          type: "image",
+          url: "https://example.com/chart.png",
+        },
+      ],
+    });
+
+    await slackRuntime.handleSubscribedMessage(thread, message);
+
     expect(classifierCalled).toBe(true);
     expect(replyCalled).toBe(false);
     expect(thread.posts).toHaveLength(0);
+  });
+
+  it("short-circuits generic immediate side-conversation questions without calling the classifier", async () => {
+    let classifierCalled = false;
+    let replyCalled = false;
+
+    const { slackRuntime } = createRuntime({
+      services: {
+        subscribedReplyPolicy: {
+          completeObject: async () => {
+            classifierCalled = true;
+            throw new Error(
+              "classifier should be bypassed for generic immediate side conversation",
+            );
+          },
+        },
+        replyExecutor: {
+          generateAssistantReply: async () => {
+            replyCalled = true;
+            return {
+              text: "This should never be posted.",
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "fake-agent-model",
+                outcome: "success",
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            };
+          },
+        },
+      },
+    });
+
+    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002003.300" });
+    await slackRuntime.handleNewMention(
+      thread,
+      createTestMessage({
+        id: "m-subscribed-generic-side-1",
+        text: "<@U_APP> summarize the deploy",
+        isMention: true,
+        threadId: thread.id,
+        author: { userId: "U_TESTER" },
+      }),
+    );
+    replyCalled = false;
+
+    await slackRuntime.handleSubscribedMessage(
+      thread,
+      createTestMessage({
+        id: "m-subscribed-generic-side-2",
+        text: "can you check on this?",
+        isMention: false,
+        threadId: thread.id,
+        author: { userId: "U_TESTER" },
+      }),
+    );
+
+    expect(classifierCalled).toBe(false);
+    expect(replyCalled).toBe(false);
+    expect(thread.posts).toHaveLength(1);
   });
 
   it("stays silent when a subscribed message is clearly directed at another bot", async () => {
@@ -486,5 +605,78 @@ describe("Slack behavior: subscribed messages", () => {
     expect(replyCalls).toContain("what did you just say about the budget?");
     expect(thread.posts).toHaveLength(2);
     expect(toPostedText(thread.posts[1])).toContain("budget by Friday");
+  });
+
+  it("accepts a lower-confidence follow-up when junior just spoke", async () => {
+    let classifierCalled = false;
+    const replyCalls: string[] = [];
+
+    const { slackRuntime } = createRuntime({
+      services: {
+        subscribedReplyPolicy: {
+          completeObject: async () => {
+            classifierCalled = true;
+            return {
+              object: {
+                should_reply: true,
+                confidence: 0.65,
+                reason: "brief clarification after assistant reply",
+              },
+              text: '{"should_reply":true,"confidence":0.65,"reason":"brief clarification after assistant reply"}',
+            } as never;
+          },
+        },
+        replyExecutor: {
+          generateAssistantReply: async (prompt) => {
+            replyCalls.push(prompt);
+            return {
+              text:
+                replyCalls.length === 1
+                  ? "The deploy changed billing, auth, and the API gateway."
+                  : "The three services were billing, auth, and the API gateway.",
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "fake-agent-model",
+                outcome: "success",
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            };
+          },
+        },
+      },
+    });
+
+    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002004.500" });
+    await slackRuntime.handleNewMention(
+      thread,
+      createTestMessage({
+        id: "m-subscribed-low-confidence-followup-1",
+        text: "<@U_APP> what changed in the deploy?",
+        isMention: true,
+        threadId: thread.id,
+        author: { userId: "U_TESTER" },
+      }),
+    );
+
+    await slackRuntime.handleSubscribedMessage(
+      thread,
+      createTestMessage({
+        id: "m-subscribed-low-confidence-followup-2",
+        text: "which one?",
+        isMention: false,
+        threadId: thread.id,
+        author: { userId: "U_TESTER" },
+      }),
+    );
+
+    expect(classifierCalled).toBe(true);
+    expect(replyCalls).toContain("which one?");
+    expect(thread.posts).toHaveLength(2);
+    expect(toPostedText(thread.posts[1])).toContain(
+      "billing, auth, and the API gateway",
+    );
   });
 });

--- a/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
@@ -341,6 +341,67 @@ describe("Slack behavior: subscribed messages", () => {
     expect(thread.posts).toHaveLength(0);
   });
 
+  it("routes acknowledgment text with attachments through the classifier", async () => {
+    let classifierCalled = false;
+    let replyCalled = false;
+
+    const { slackRuntime } = createRuntime({
+      services: {
+        subscribedReplyPolicy: {
+          completeObject: async () => {
+            classifierCalled = true;
+            return {
+              object: {
+                should_reply: false,
+                confidence: 0.95,
+                reason: "attachment acknowledgment",
+              },
+              text: '{"should_reply":false,"confidence":0.95,"reason":"attachment acknowledgment"}',
+            } as never;
+          },
+        },
+        replyExecutor: {
+          generateAssistantReply: async () => {
+            replyCalled = true;
+            return {
+              text: "This should never be posted.",
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "fake-agent-model",
+                outcome: "success",
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            };
+          },
+        },
+      },
+    });
+
+    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002003.125" });
+    const message = createTestMessage({
+      id: "m-subscribed-ack-attachment",
+      text: "thanks!",
+      isMention: false,
+      threadId: thread.id,
+      author: { userId: "U_TESTER" },
+      attachments: [
+        {
+          type: "image",
+          url: "https://example.com/chart.png",
+        },
+      ],
+    });
+
+    await slackRuntime.handleSubscribedMessage(thread, message);
+
+    expect(classifierCalled).toBe(true);
+    expect(replyCalled).toBe(false);
+    expect(thread.posts).toHaveLength(0);
+  });
+
   it("routes attachment-only passive messages through the classifier", async () => {
     let classifierCalled = false;
     let replyCalled = false;
@@ -461,6 +522,80 @@ describe("Slack behavior: subscribed messages", () => {
     );
 
     expect(classifierCalled).toBe(false);
+    expect(replyCalled).toBe(false);
+    expect(thread.posts).toHaveLength(1);
+  });
+
+  it("routes generic immediate attachment follow-ups through the classifier", async () => {
+    let classifierCalled = false;
+    let replyCalled = false;
+
+    const { slackRuntime } = createRuntime({
+      services: {
+        subscribedReplyPolicy: {
+          completeObject: async () => {
+            classifierCalled = true;
+            return {
+              object: {
+                should_reply: false,
+                confidence: 0.95,
+                reason: "attachment follow-up",
+              },
+              text: '{"should_reply":false,"confidence":0.95,"reason":"attachment follow-up"}',
+            } as never;
+          },
+        },
+        replyExecutor: {
+          generateAssistantReply: async () => {
+            replyCalled = true;
+            return {
+              text: "This should never be posted.",
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "fake-agent-model",
+                outcome: "success",
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            };
+          },
+        },
+      },
+    });
+
+    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002003.350" });
+    await slackRuntime.handleNewMention(
+      thread,
+      createTestMessage({
+        id: "m-subscribed-generic-side-attachment-1",
+        text: "<@U_APP> summarize the deploy",
+        isMention: true,
+        threadId: thread.id,
+        author: { userId: "U_TESTER" },
+      }),
+    );
+    replyCalled = false;
+
+    await slackRuntime.handleSubscribedMessage(
+      thread,
+      createTestMessage({
+        id: "m-subscribed-generic-side-attachment-2",
+        text: "can you check on this?",
+        isMention: false,
+        threadId: thread.id,
+        author: { userId: "U_TESTER" },
+        attachments: [
+          {
+            type: "image",
+            url: "https://example.com/screenshot.png",
+          },
+        ],
+      }),
+    );
+
+    expect(classifierCalled).toBe(true);
     expect(replyCalled).toBe(false);
     expect(thread.posts).toHaveLength(1);
   });

--- a/packages/junior/tests/unit/routing/subscribed-decision.test.ts
+++ b/packages/junior/tests/unit/routing/subscribed-decision.test.ts
@@ -80,12 +80,12 @@ describe("decideSubscribedThreadReply", () => {
     expect(completeObject).not.toHaveBeenCalled();
   });
 
-  it("sends acknowledgment text to the classifier instead of short-circuiting", async () => {
+  it("short-circuits pure acknowledgment text without calling the classifier", async () => {
     const completeObject = vi.fn(async () => ({
       object: {
-        should_reply: false,
-        confidence: 0.95,
-        reason: "acknowledgment",
+        should_reply: true,
+        confidence: 1,
+        reason: "this should never be used",
       },
     }));
     const decision = await decideSubscribedThreadReply({
@@ -101,7 +101,7 @@ describe("decideSubscribedThreadReply", () => {
       reason: SubscribedReplyReason.SideConversation,
       reasonDetail: "acknowledgment",
     });
-    expect(completeObject).toHaveBeenCalled();
+    expect(completeObject).not.toHaveBeenCalled();
   });
 
   it("sends follow-up questions to the classifier instead of short-circuiting", async () => {
@@ -216,17 +216,143 @@ describe("decideSubscribedThreadReply", () => {
     expect(decision.shouldReply).toBe(false);
   });
 
-  it("replies to attachment-only message", async () => {
+  it("routes attachment-only messages through the classifier instead of auto-replying", async () => {
     const decision = await decideSubscribedThreadReply({
       botUserName: "junior",
       modelId: "router-model",
       input: makeInput({ text: "", rawText: "", hasAttachments: true }),
-      completeObject: vi.fn(),
+      completeObject: vi.fn(async () => ({
+        object: {
+          should_reply: false,
+          confidence: 0.95,
+          reason: "passive attachment",
+        },
+      })),
       logClassifierFailure: vi.fn(),
     });
 
-    expect(decision.reason).toBe(SubscribedReplyReason.AttachmentOnly);
-    expect(decision.shouldReply).toBe(true);
+    expect(decision).toEqual({
+      shouldReply: false,
+      reason: SubscribedReplyReason.SideConversation,
+      reasonDetail: "passive attachment",
+    });
+  });
+
+  it("accepts lower-confidence clarification when junior was the last speaker", async () => {
+    const decision = await decideSubscribedThreadReply({
+      botUserName: "junior",
+      modelId: "router-model",
+      input: makeInput({
+        text: "which one?",
+        rawText: "which one?",
+        conversationContext:
+          "<thread-transcript>\n[assistant] junior: The deploy touched billing, auth, and API gateway.\n</thread-transcript>",
+      }),
+      completeObject: vi.fn(async () => ({
+        object: {
+          should_reply: true,
+          confidence: 0.65,
+          reason: "immediate clarification for assistant",
+        },
+      })),
+      logClassifierFailure: vi.fn(),
+    });
+
+    expect(decision).toEqual({
+      shouldReply: true,
+      reason: SubscribedReplyReason.Classifier,
+      reasonDetail: "immediate clarification for assistant",
+    });
+  });
+
+  it("skips a generic immediate question that does not clearly turn back to junior", async () => {
+    const completeObject = vi.fn(async () => ({
+      object: {
+        should_reply: true,
+        confidence: 1,
+        reason: "this should never be used",
+      },
+    }));
+    const decision = await decideSubscribedThreadReply({
+      botUserName: "junior",
+      modelId: "router-model",
+      input: makeInput({
+        text: "is that the right approach?",
+        rawText: "is that the right approach?",
+        conversationContext:
+          "<thread-transcript>\n[assistant] junior: The deploy changed billing and auth.\n</thread-transcript>",
+      }),
+      completeObject,
+      logClassifierFailure: vi.fn(),
+    });
+
+    expect(decision).toEqual({
+      shouldReply: false,
+      reason: SubscribedReplyReason.SideConversation,
+      reasonDetail: "generic immediate side conversation",
+    });
+    expect(completeObject).not.toHaveBeenCalled();
+  });
+
+  it("skips long 'what about' topic continuation after junior speaks", async () => {
+    const completeObject = vi.fn(async () => ({
+      object: {
+        should_reply: true,
+        confidence: 1,
+        reason: "this should never be used",
+      },
+    }));
+    const decision = await decideSubscribedThreadReply({
+      botUserName: "junior",
+      modelId: "router-model",
+      input: makeInput({
+        text: "what about the billing worker timeline?",
+        rawText: "what about the billing worker timeline?",
+        conversationContext:
+          "<thread-transcript>\n[assistant] junior: The billing worker handles invoice retries.\n</thread-transcript>",
+      }),
+      completeObject,
+      logClassifierFailure: vi.fn(),
+    });
+
+    expect(decision).toEqual({
+      shouldReply: false,
+      reason: SubscribedReplyReason.SideConversation,
+      reasonDetail: "generic immediate side conversation",
+    });
+    expect(completeObject).not.toHaveBeenCalled();
+  });
+
+  it("requires stronger confidence after humans keep talking in the thread", async () => {
+    const decision = await decideSubscribedThreadReply({
+      botUserName: "junior",
+      modelId: "router-model",
+      input: makeInput({
+        text: "what about the billing worker timeline?",
+        rawText: "what about the billing worker timeline?",
+        conversationContext: [
+          "<thread-transcript>",
+          "[assistant] junior: The deploy changed billing, auth, and the API gateway.",
+          "[user] sam: I think we should revert auth first.",
+          "[user] alex: I can take that rollback.",
+          "</thread-transcript>",
+        ].join("\n"),
+      }),
+      completeObject: vi.fn(async () => ({
+        object: {
+          should_reply: true,
+          confidence: 0.85,
+          reason: "maybe follow-up",
+        },
+      })),
+      logClassifierFailure: vi.fn(),
+    });
+
+    expect(decision).toEqual({
+      shouldReply: false,
+      reason: SubscribedReplyReason.LowConfidence,
+      reasonDetail: "0.85: maybe follow-up",
+    });
   });
 
   it("uses classifier and maps false decision to side conversation", async () => {

--- a/packages/junior/tests/unit/routing/subscribed-decision.test.ts
+++ b/packages/junior/tests/unit/routing/subscribed-decision.test.ts
@@ -104,6 +104,34 @@ describe("decideSubscribedThreadReply", () => {
     expect(completeObject).not.toHaveBeenCalled();
   });
 
+  it("routes acknowledgment text with attachments through the classifier", async () => {
+    const completeObject = vi.fn(async () => ({
+      object: {
+        should_reply: false,
+        confidence: 0.95,
+        reason: "attachment acknowledgment",
+      },
+    }));
+    const decision = await decideSubscribedThreadReply({
+      botUserName: "junior",
+      modelId: "router-model",
+      input: makeInput({
+        text: "thanks!",
+        rawText: "thanks!",
+        hasAttachments: true,
+      }),
+      completeObject,
+      logClassifierFailure: vi.fn(),
+    });
+
+    expect(decision).toEqual({
+      shouldReply: false,
+      reason: SubscribedReplyReason.SideConversation,
+      reasonDetail: "attachment acknowledgment",
+    });
+    expect(completeObject).toHaveBeenCalled();
+  });
+
   it("sends follow-up questions to the classifier instead of short-circuiting", async () => {
     const completeObject = vi.fn(async () => ({
       object: {
@@ -294,6 +322,36 @@ describe("decideSubscribedThreadReply", () => {
     expect(completeObject).not.toHaveBeenCalled();
   });
 
+  it("routes generic immediate attachment follow-ups through the classifier", async () => {
+    const completeObject = vi.fn(async () => ({
+      object: {
+        should_reply: true,
+        confidence: 0.95,
+        reason: "attachment follow-up",
+      },
+    }));
+    const decision = await decideSubscribedThreadReply({
+      botUserName: "junior",
+      modelId: "router-model",
+      input: makeInput({
+        text: "can you check on this?",
+        rawText: "can you check on this?",
+        hasAttachments: true,
+        conversationContext:
+          "<thread-transcript>\n[assistant] junior: Please upload a screenshot.\n</thread-transcript>",
+      }),
+      completeObject,
+      logClassifierFailure: vi.fn(),
+    });
+
+    expect(decision).toEqual({
+      shouldReply: true,
+      reason: SubscribedReplyReason.Classifier,
+      reasonDetail: "attachment follow-up",
+    });
+    expect(completeObject).toHaveBeenCalled();
+  });
+
   it("skips long 'what about' topic continuation after junior speaks", async () => {
     const completeObject = vi.fn(async () => ({
       object: {
@@ -335,6 +393,37 @@ describe("decideSubscribedThreadReply", () => {
           "[assistant] junior: The deploy changed billing, auth, and the API gateway.",
           "[user] sam: I think we should revert auth first.",
           "[user] alex: I can take that rollback.",
+          "</thread-transcript>",
+        ].join("\n"),
+      }),
+      completeObject: vi.fn(async () => ({
+        object: {
+          should_reply: true,
+          confidence: 0.85,
+          reason: "maybe follow-up",
+        },
+      })),
+      logClassifierFailure: vi.fn(),
+    });
+
+    expect(decision).toEqual({
+      shouldReply: false,
+      reason: SubscribedReplyReason.LowConfidence,
+      reasonDetail: "0.85: maybe follow-up",
+    });
+  });
+
+  it("requires stronger confidence after one human takes the floor", async () => {
+    const decision = await decideSubscribedThreadReply({
+      botUserName: "junior",
+      modelId: "router-model",
+      input: makeInput({
+        text: "what about the billing worker timeline?",
+        rawText: "what about the billing worker timeline?",
+        conversationContext: [
+          "<thread-transcript>",
+          "[assistant] junior: The deploy changed billing, auth, and the API gateway.",
+          "[user] sam: I think we should revert auth first.",
           "</thread-transcript>",
         ].join("\n"),
       }),


### PR DESCRIPTION
Tighten passive reply routing for subscribed Slack threads.

The passive gate was still keying too much on lexical overlap and direct self-reference, which caused two failure modes in practice: Junior would jump into same-topic human side conversations, and it would miss terse follow-ups that were clearly turning the thread back to Junior.

This changes the subscribed-thread router to rely on thread geometry plus a small set of high-precision guards. It now reasons about who last held the floor, how many human turns have happened since Junior replied, whether a message is just an acknowledgment or opt-out, and whether the latest message clearly turns back to Junior. Attachment-only passive messages now go through the router instead of forcing a reply, and the prompt/tests/evals are updated around those contracts.

I considered broader lexical cues and suite-wide eval serialization, but both were the wrong tool here. The final patch keeps only narrow deterministic guards and adds a per-scenario eval reply-timeout override for the one known slow GitHub issue-creation eval instead of broadening the whole suite budget.