### PR TITLE
fix(sentry): Tighten OAuth setup and dev plugin loading

### DIFF
--- a/apps/example/README.md
+++ b/apps/example/README.md
@@ -29,5 +29,6 @@ Copy `.env.example` and set:
 
 ## Wiring
 
-- `nitro.config.ts` declares `pluginPackages` in `juniorNitro()` — this both copies plugin content at build time and makes the list available to `createApp()` at runtime via a virtual module
-- `server.ts` creates the Hono app via `createApp()` — plugin packages are resolved automatically from the build config
+- `plugin-packages.ts` is the single source of truth for installed plugin packages in this app
+- `nitro.config.ts` passes that list to `juniorNitro()` so plugin content is copied into the build output
+- `server.ts` passes the same list to `createApp()` so local dev does not depend on Nitro's virtual config path for plugin discovery

--- a/apps/example/nitro.config.ts
+++ b/apps/example/nitro.config.ts
@@ -1,17 +1,12 @@
 import { defineConfig } from "nitro";
 import { juniorNitro } from "@sentry/junior/nitro";
+import { examplePluginPackages } from "./plugin-packages";
 
 export default defineConfig({
   preset: "vercel",
   modules: [
     juniorNitro({
-      pluginPackages: [
-        "@sentry/junior-agent-browser",
-        "@sentry/junior-github",
-        "@sentry/junior-linear",
-        "@sentry/junior-notion",
-        "@sentry/junior-sentry",
-      ],
+      pluginPackages: examplePluginPackages,
     }),
   ],
   routes: {

--- a/apps/example/plugin-packages.ts
+++ b/apps/example/plugin-packages.ts
@@ -1,0 +1,7 @@
+export const examplePluginPackages = [
+  "@sentry/junior-agent-browser",
+  "@sentry/junior-github",
+  "@sentry/junior-linear",
+  "@sentry/junior-notion",
+  "@sentry/junior-sentry",
+];

--- a/apps/example/server.ts
+++ b/apps/example/server.ts
@@ -1,8 +1,9 @@
 import { createApp } from "@sentry/junior";
 import { initSentry } from "@sentry/junior/instrumentation";
+import { examplePluginPackages } from "./plugin-packages";
 
 initSentry();
 
-const app = await createApp();
+const app = await createApp({ pluginPackages: examplePluginPackages });
 
 export default app;

--- a/packages/docs/src/content/docs/extend/sentry-plugin.md
+++ b/packages/docs/src/content/docs/extend/sentry-plugin.md
@@ -48,6 +48,14 @@ Create an OAuth application in Sentry and set its redirect URL to:
 
 Then copy the client ID and client secret into your deployment environment as `SENTRY_CLIENT_ID` and `SENTRY_CLIENT_SECRET`.
 
+Junior requests these Sentry OAuth scopes:
+
+- `event:read`
+- `event:write`
+- `org:read`
+- `project:read`
+- `team:read`
+
 ## Verify
 
 Run the auth flow and then make a real Sentry request:

--- a/packages/docs/src/content/docs/extend/sentry-plugin.md
+++ b/packages/docs/src/content/docs/extend/sentry-plugin.md
@@ -51,7 +51,6 @@ Then copy the client ID and client secret into your deployment environment as `S
 Junior requests these Sentry OAuth scopes:
 
 - `event:read`
-- `event:write`
 - `org:read`
 - `project:read`
 - `team:read`
@@ -70,7 +69,9 @@ Confirm the auth flow completes, the query returns expected data, and re-auth wo
 ## Failure modes
 
 - Callback errors after consent: the OAuth redirect URL does not exactly match `<base-url>/api/oauth/callback/sentry`. Update the OAuth app redirect URL and retry.
-- `401` or `403` after authorization: the user token lacks org access or is stale. Ask Junior to reconnect Sentry with an account that can access the target org.
+- `401` after authorization: the stored token is stale or revoked. Reconnect Sentry and retry.
+- Explicit `missing scope` or `insufficient scope` after authorization: reconnect Sentry to refresh the stored grant, then retry.
+- Generic `403` after authorization: the connected account lacks access to the target org or project. Reconnect with an account that can access the target org, or change the request target.
 - Auth link points at the wrong host: `JUNIOR_BASE_URL` is unset or incorrect. Set it to the canonical public base URL used for callbacks.
 - Query still targets the wrong org or project: Junior does not have enough target context for this request. Include the org and project directly in the Sentry request and retry.
 

--- a/packages/junior-sentry/plugin.yaml
+++ b/packages/junior-sentry/plugin.yaml
@@ -22,7 +22,7 @@ oauth:
   client-secret-env: SENTRY_CLIENT_SECRET
   authorize-endpoint: https://sentry.io/oauth/authorize/
   token-endpoint: https://sentry.io/oauth/token/
-  scope: "event:read org:read project:read"
+  scope: "event:read event:write org:read project:read team:read"
 
 runtime-dependencies:
   - type: npm

--- a/packages/junior-sentry/plugin.yaml
+++ b/packages/junior-sentry/plugin.yaml
@@ -22,7 +22,7 @@ oauth:
   client-secret-env: SENTRY_CLIENT_SECRET
   authorize-endpoint: https://sentry.io/oauth/authorize/
   token-endpoint: https://sentry.io/oauth/token/
-  scope: "event:read event:write org:read project:read team:read"
+  scope: "event:read org:read project:read team:read"
 
 runtime-dependencies:
   - type: npm

--- a/packages/junior-sentry/skills/sentry/SKILL.md
+++ b/packages/junior-sentry/skills/sentry/SKILL.md
@@ -14,7 +14,7 @@ Use this skill for Sentry investigation workflows in the harness.
 
 1. Confirm operation and target:
 
-- Determine operation: `issue list`, `issue explain`, `issue plan`, `replays`, `deep-link`, or general query.
+- Determine operation: `issue list`, `deep-link`, or general query.
 - Resolve org from channel config: `jr-rpc config get sentry.org`
 - Resolve project from channel config: `jr-rpc config get sentry.project` (optional — many queries span multiple projects).
 - If org is missing and needed, ask the user.
@@ -25,7 +25,10 @@ Use this skill for Sentry investigation workflows in the harness.
 - The CLI reads `SENTRY_AUTH_TOKEN` from env after the runtime enables the declared Sentry capability for this turn.
 - Read [references/cli-commands.md](references/cli-commands.md) for command shapes and flags.
 - Read [references/sandbox-runtime.md](references/sandbox-runtime.md) before relying on sandbox credentials.
-- If a Sentry API call returns 401 or 403 after credentials were issued, the user's token may lack access for the requested org. Run `jr-rpc delete-token sentry` to clear the stale token, then retry after re-enabling the declared capability. Do not ask the user to run a command manually — the system handles re-authorization automatically.
+- If a Sentry API call returns `401`, or clearly says the token is invalid, expired, revoked, or unauthorized, run `jr-rpc delete-token sentry` to clear the stale token, then retry after re-enabling the declared capability.
+- If a Sentry API call returns `403`, `missing scope`, `missing scopes`, `insufficient scope`, `permission denied`, or otherwise indicates missing org/project access, stop and tell the user the current Sentry connection could not access the requested Sentry data.
+- Only mention a specific missing scope when the CLI or API error explicitly names that scope. Do not guess scope names from a generic `403`.
+- Do not call `jr-rpc delete-token sentry`, do not retry, and do not start OAuth again for scope/permission failures. Reauth with the same app scopes will not fix that class of error.
 
 3. Generate deep links:
 
@@ -40,6 +43,7 @@ Use this skill for Sentry investigation workflows in the harness.
 ## Guardrails
 
 - Read-only operations only (MVP scope).
+- Avoid speculative or experimental Sentry CLI subcommands that are not listed in the bundled references.
 - Do not print credential values.
 - If org is missing and needed, ask the user.
 - Prefer deep links over raw data dumps when linking to Sentry web UI.

--- a/packages/junior-sentry/skills/sentry/SKILL.md
+++ b/packages/junior-sentry/skills/sentry/SKILL.md
@@ -26,9 +26,9 @@ Use this skill for Sentry investigation workflows in the harness.
 - Read [references/cli-commands.md](references/cli-commands.md) for command shapes and flags.
 - Read [references/sandbox-runtime.md](references/sandbox-runtime.md) before relying on sandbox credentials.
 - If a Sentry API call returns `401`, or clearly says the token is invalid, expired, revoked, or unauthorized, run `jr-rpc delete-token sentry` to clear the stale token, then retry after re-enabling the declared capability.
-- If a Sentry API call returns `403`, `missing scope`, `missing scopes`, `insufficient scope`, `permission denied`, or otherwise indicates missing org/project access, stop and tell the user the current Sentry connection could not access the requested Sentry data.
+- If a Sentry API call explicitly says `missing scope`, `missing scopes`, or `insufficient scope`, run `jr-rpc delete-token sentry` to clear the outdated grant, then retry after re-enabling the declared capability.
+- If a Sentry API call returns a generic `403`, `permission denied`, or otherwise indicates missing org/project access without naming missing scopes, stop and tell the user the current Sentry connection could not access the requested Sentry data.
 - Only mention a specific missing scope when the CLI or API error explicitly names that scope. Do not guess scope names from a generic `403`.
-- Do not call `jr-rpc delete-token sentry`, do not retry, and do not start OAuth again for scope/permission failures. Reauth with the same app scopes will not fix that class of error.
 
 3. Generate deep links:
 

--- a/packages/junior-sentry/skills/sentry/references/cli-commands.md
+++ b/packages/junior-sentry/skills/sentry/references/cli-commands.md
@@ -15,22 +15,6 @@ sentry issues list --org ORG [--project PROJECT] [--query QUERY] [--json]
 - `--query`: Sentry search query (e.g., `user.email:alice@example.com`, `is:unresolved`).
 - `--json`: Output as JSON for structured parsing.
 
-### Explain issue
-
-```bash
-sentry issues explain ISSUE_ID --org ORG [--json]
-```
-
-AI-powered root cause analysis for a specific issue.
-
-### Plan fix
-
-```bash
-sentry issues plan ISSUE_ID --org ORG [--json]
-```
-
-AI-powered remediation guidance for a specific issue.
-
 ## Organization commands
 
 ### List organizations
@@ -47,3 +31,5 @@ Lists organizations accessible with current token.
 - `--org ORG`: Organization slug.
 - `--project PROJECT`: Project slug.
 - `--log-level`: `debug`, `info`, `warn`, `error`.
+
+Only use commands listed in this reference during normal skill execution. If a command reports missing scopes or permission errors, treat that as an access problem rather than a retryable auth refresh problem.

--- a/packages/junior-sentry/skills/sentry/references/cli-commands.md
+++ b/packages/junior-sentry/skills/sentry/references/cli-commands.md
@@ -32,4 +32,4 @@ Lists organizations accessible with current token.
 - `--project PROJECT`: Project slug.
 - `--log-level`: `debug`, `info`, `warn`, `error`.
 
-Only use commands listed in this reference during normal skill execution. If a command reports missing scopes or permission errors, treat that as an access problem rather than a retryable auth refresh problem.
+Only use commands listed in this reference during normal skill execution. If a command reports explicit missing scopes, reconnect the Sentry account to refresh the grant. Treat generic permission or org/project access errors as access problems rather than retryable auth refresh problems.

--- a/packages/junior/src/chat/capabilities/jr-rpc-command.ts
+++ b/packages/junior/src/chat/capabilities/jr-rpc-command.ts
@@ -3,6 +3,7 @@ import { listCapabilityProviders } from "@/chat/capabilities/catalog";
 import type { SkillCapabilityRuntime } from "@/chat/capabilities/runtime";
 import { parseRepoTarget } from "@/chat/capabilities/target";
 import type { ChannelConfigurationService } from "@/chat/configuration/types";
+import { hasRequiredOAuthScope } from "@/chat/credentials/oauth-scope";
 import type { UserTokenStore } from "@/chat/credentials/user-token-store";
 import { CredentialUnavailableError } from "@/chat/credentials/broker";
 import { unlinkProvider } from "@/chat/credentials/unlink-provider";
@@ -470,9 +471,11 @@ async function handleOAuthStartCommand(
   // Check if user already has valid tokens for this provider
   if (deps.requesterId && deps.userTokenStore) {
     const stored = await deps.userTokenStore.get(deps.requesterId, provider);
+    const providerConfig = getPluginOAuthConfig(provider);
     if (
       stored &&
-      (stored.expiresAt === undefined || stored.expiresAt > Date.now())
+      (stored.expiresAt === undefined || stored.expiresAt > Date.now()) &&
+      hasRequiredOAuthScope(stored.scope, providerConfig?.scope)
     ) {
       const providerLabel = formatProviderLabel(provider);
       return commandResult({

--- a/packages/junior/src/chat/credentials/oauth-scope.ts
+++ b/packages/junior/src/chat/credentials/oauth-scope.ts
@@ -1,0 +1,31 @@
+function parseScope(scope?: string): string[] {
+  if (!scope) {
+    return [];
+  }
+
+  return [...new Set(scope.split(/\s+/).filter(Boolean))].sort();
+}
+
+/** Normalize OAuth scope strings so persisted grants can be compared reliably. */
+export function normalizeOAuthScope(scope?: string): string | undefined {
+  const parsed = parseScope(scope);
+  return parsed.length > 0 ? parsed.join(" ") : undefined;
+}
+
+/** Return whether the stored grant still satisfies the provider's current scope contract. */
+export function hasRequiredOAuthScope(
+  storedScope?: string,
+  requiredScope?: string,
+): boolean {
+  const required = parseScope(requiredScope);
+  if (required.length === 0) {
+    return true;
+  }
+
+  const stored = new Set(parseScope(storedScope));
+  if (stored.size === 0) {
+    return false;
+  }
+
+  return required.every((scope) => stored.has(scope));
+}

--- a/packages/junior/src/chat/credentials/user-token-store.ts
+++ b/packages/junior/src/chat/credentials/user-token-store.ts
@@ -2,6 +2,7 @@ export interface StoredTokens {
   accessToken: string;
   refreshToken: string;
   expiresAt?: number;
+  scope?: string;
 }
 
 export interface UserTokenStore {

--- a/packages/junior/src/chat/plugins/auth/oauth-bearer-broker.ts
+++ b/packages/junior/src/chat/plugins/auth/oauth-bearer-broker.ts
@@ -4,6 +4,7 @@ import type {
   CredentialLease,
 } from "@/chat/credentials/broker";
 import { CredentialUnavailableError } from "@/chat/credentials/broker";
+import { hasRequiredOAuthScope } from "@/chat/credentials/oauth-scope";
 import type { UserTokenStore } from "@/chat/credentials/user-token-store";
 import { resolveAuthTokenPlaceholder } from "./auth-token-placeholder";
 import {
@@ -18,10 +19,12 @@ const REFRESH_BUFFER_MS = 5 * 60 * 1000;
 async function refreshAccessToken(
   refreshToken: string,
   oauth: NonNullable<PluginManifest["oauth"]>,
+  fallbackScope?: string,
 ): Promise<{
   accessToken: string;
   refreshToken: string;
   expiresAt?: number;
+  scope?: string;
 }> {
   const clientId = process.env[oauth.clientIdEnv]?.trim();
   const clientSecret = process.env[oauth.clientSecretEnv]?.trim();
@@ -52,7 +55,7 @@ async function refreshAccessToken(
   }
 
   const data = (await response.json()) as Record<string, unknown>;
-  return parseOAuthTokenResponse(data);
+  return parseOAuthTokenResponse(data, fallbackScope);
 }
 
 function getLeaseExpiry(expiresAt?: number): number {
@@ -123,6 +126,13 @@ export function createOAuthBearerBroker(
           provider,
         );
         if (stored) {
+          if (!hasRequiredOAuthScope(stored.scope, oauth.scope)) {
+            throw new CredentialUnavailableError(
+              provider,
+              `Your ${provider} connection needs to be reauthorized.`,
+            );
+          }
+
           const now = Date.now();
           if (
             stored.expiresAt !== undefined &&
@@ -132,7 +142,14 @@ export function createOAuthBearerBroker(
               const refreshed = await refreshAccessToken(
                 stored.refreshToken,
                 oauth,
+                stored.scope ?? oauth.scope,
               );
+              if (!hasRequiredOAuthScope(refreshed.scope, oauth.scope)) {
+                throw new CredentialUnavailableError(
+                  provider,
+                  `Your ${provider} connection needs to be reauthorized.`,
+                );
+              }
               await deps.userTokenStore.set(
                 input.requesterId,
                 provider,
@@ -144,7 +161,10 @@ export function createOAuthBearerBroker(
                 getLeaseExpiry(refreshed.expiresAt),
                 input.reason,
               );
-            } catch {
+            } catch (error) {
+              if (error instanceof CredentialUnavailableError) {
+                throw error;
+              }
               if (stored.expiresAt > Date.now()) {
                 return buildLease(
                   stored.accessToken,

--- a/packages/junior/src/chat/plugins/auth/oauth-request.ts
+++ b/packages/junior/src/chat/plugins/auth/oauth-request.ts
@@ -1,3 +1,5 @@
+import { normalizeOAuthScope } from "@/chat/credentials/oauth-scope";
+
 const DEFAULT_TOKEN_CONTENT_TYPE = "application/x-www-form-urlencoded";
 
 type OAuthTokenRequestInput = {
@@ -67,17 +69,32 @@ export function buildOAuthTokenRequest(input: OAuthTokenRequestInput): {
   };
 }
 
-export function parseOAuthTokenResponse(data: Record<string, unknown>): {
+export function parseOAuthTokenResponse(
+  data: Record<string, unknown>,
+  fallbackScope?: string,
+): {
   accessToken: string;
   refreshToken: string;
   expiresAt?: number;
+  scope?: string;
 } {
   const accessToken = requireNonEmptyTokenField(data, "access_token");
   const refreshToken = requireNonEmptyTokenField(data, "refresh_token");
   const expiresIn = data.expires_in;
+  const responseScope = data.scope;
+  let scope: string | undefined;
+
+  if (responseScope !== undefined) {
+    if (typeof responseScope !== "string" || !responseScope.trim()) {
+      throw new Error("OAuth token response returned invalid scope");
+    }
+    scope = normalizeOAuthScope(responseScope);
+  } else {
+    scope = normalizeOAuthScope(fallbackScope);
+  }
 
   if (expiresIn === undefined) {
-    return { accessToken, refreshToken };
+    return { accessToken, refreshToken, ...(scope ? { scope } : {}) };
   }
   if (
     typeof expiresIn !== "number" ||
@@ -91,5 +108,6 @@ export function parseOAuthTokenResponse(data: Record<string, unknown>): {
     accessToken,
     refreshToken,
     expiresAt: Date.now() + expiresIn * 1000,
+    ...(scope ? { scope } : {}),
   };
 }

--- a/packages/junior/src/chat/slack/app-home.ts
+++ b/packages/junior/src/chat/slack/app-home.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { WebClient, KnownBlock, SectionBlock } from "@slack/web-api";
+import { hasRequiredOAuthScope } from "@/chat/credentials/oauth-scope";
 import { homeDir } from "@/chat/discovery";
 import { getMcpStoredOAuthCredentials } from "@/chat/mcp/auth-store";
 import { getPluginProviders } from "@/chat/plugins/registry";
@@ -64,7 +65,11 @@ async function hasConnectedAccount(
   userTokenStore: UserTokenStore,
 ): Promise<boolean> {
   if (plugin.manifest.credentials?.type === "oauth-bearer") {
-    return Boolean(await userTokenStore.get(userId, plugin.manifest.name));
+    const stored = await userTokenStore.get(userId, plugin.manifest.name);
+    return Boolean(
+      stored &&
+      hasRequiredOAuthScope(stored.scope, plugin.manifest.oauth?.scope),
+    );
   }
 
   if (plugin.manifest.mcp) {

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -1,4 +1,5 @@
 import { createUserTokenStore } from "@/chat/capabilities/factory";
+import { hasRequiredOAuthScope } from "@/chat/credentials/oauth-scope";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
 import {
   formatProviderLabel,
@@ -225,12 +226,23 @@ export async function GET(
   const tokenData = (await tokenResponse.json()) as Record<string, unknown>;
   let parsedTokenResponse;
   try {
-    parsedTokenResponse = parseOAuthTokenResponse(tokenData);
+    parsedTokenResponse = parseOAuthTokenResponse(
+      tokenData,
+      providerConfig.scope,
+    );
   } catch {
     return htmlErrorResponse(
       "Connection failed",
       "The provider returned an incomplete token response. Please try again.",
       500,
+    );
+  }
+
+  if (!hasRequiredOAuthScope(parsedTokenResponse.scope, providerConfig.scope)) {
+    return htmlErrorResponse(
+      "Connection failed",
+      `The ${providerLabel} authorization did not grant the access Junior requires. Return to Slack and ask Junior to connect your ${providerLabel} account again.`,
+      400,
     );
   }
 

--- a/packages/junior/tests/integration/jr-rpc-oauth-start.test.ts
+++ b/packages/junior/tests/integration/jr-rpc-oauth-start.test.ts
@@ -121,6 +121,7 @@ describe("jr-rpc oauth-start integration", () => {
     );
     expect(authorizeUrl.searchParams.get("response_type")).toBe("code");
     expect(authorizeUrl.searchParams.get("scope")).toContain("event:read");
+    expect(authorizeUrl.searchParams.get("scope")).not.toContain("event:write");
 
     const state = authorizeUrl.searchParams.get("state");
     expect(state).toBeTruthy();

--- a/packages/junior/tests/unit/handlers/jr-rpc-command.test.ts
+++ b/packages/junior/tests/unit/handlers/jr-rpc-command.test.ts
@@ -40,6 +40,7 @@ vi.mock("@/chat/plugins/registry", () => ({
           clientSecretEnv: "GITHUB_CLIENT_SECRET",
           authorizeEndpoint: "https://github.example.test/oauth/authorize",
           tokenEndpoint: "https://github.example.test/oauth/token",
+          scope: "read:org repo",
           callbackPath: "/api/oauth/callback/github",
         }
       : undefined,
@@ -671,6 +672,46 @@ describe("jr-rpc custom command", () => {
     expect(handled.result.exit_code).toBe(1);
     expect(handled.result.stderr).toContain(
       'Provider "notion" does not support OAuth authorization',
+    );
+  });
+
+  it("does not treat scope-incompatible stored tokens as already connected", async () => {
+    startOAuthFlowMock.mockResolvedValue({
+      ok: true,
+      delivery: "in_context",
+    });
+    const userTokenStore = {
+      get: vi.fn(async () => ({
+        accessToken: "token",
+        refreshToken: "refresh",
+        expiresAt: Date.now() + 60_000,
+        scope: "repo",
+      })),
+      set: vi.fn(async () => undefined),
+      delete: vi.fn(async () => undefined),
+    };
+
+    const result = await maybeExecuteJrRpcCustomCommand(
+      "jr-rpc oauth-start github",
+      {
+        capabilityRuntime: makeRuntime(),
+        activeSkill,
+        requesterId: "U123",
+        userTokenStore,
+      },
+    );
+
+    const handled = expectHandled(result);
+    expect(handled.result.exit_code).toBe(0);
+    expect(JSON.parse(handled.result.stdout)).toMatchObject({
+      ok: true,
+      private_delivery_sent: true,
+    });
+    expect(startOAuthFlowMock).toHaveBeenCalledWith(
+      "github",
+      expect.objectContaining({
+        requesterId: "U123",
+      }),
     );
   });
 });

--- a/packages/junior/tests/unit/handlers/oauth-callback.test.ts
+++ b/packages/junior/tests/unit/handlers/oauth-callback.test.ts
@@ -49,7 +49,7 @@ vi.mock("@/chat/plugins/registry", () => ({
         clientSecretEnv: "SENTRY_CLIENT_SECRET",
         authorizeEndpoint: "https://sentry.io/oauth/authorize/",
         tokenEndpoint: "https://sentry.io/oauth/token/",
-        scope: "event:read event:write org:read project:read team:read",
+        scope: "event:read org:read project:read team:read",
         callbackPath: "/api/oauth/callback/sentry",
       };
     }
@@ -283,10 +283,12 @@ describe("oauth callback handler", () => {
     const stored = mockTokenStore.get("U456:sentry") as {
       accessToken: string;
       refreshToken: string;
+      scope?: string;
     };
     expect(stored).toBeDefined();
     expect(stored.accessToken).toBe("new-access-token");
     expect(stored.refreshToken).toBe("new-refresh-token");
+    expect(stored.scope).toBe("event:read org:read project:read team:read");
   });
 
   it("uses basic auth and json body for token exchange without expires_in", async () => {
@@ -345,6 +347,44 @@ describe("oauth callback handler", () => {
       refreshToken: "example-refresh-token",
     });
     expect(stored.expiresAt).toBeUndefined();
+  });
+
+  it("rejects callback grants whose explicit scope is missing required access", async () => {
+    const stateKey = "oauth-state:missing-scope";
+    mockStateStore.set(stateKey, {
+      userId: "U456",
+      provider: "sentry",
+      channelId: "C123",
+      threadTs: "123.456",
+    });
+
+    process.env.SENTRY_CLIENT_ID = "client-id";
+    process.env.SENTRY_CLIENT_SECRET = "client-secret";
+    process.env.JUNIOR_BASE_URL = "https://example.com";
+
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        access_token: "new-access-token",
+        refresh_token: "new-refresh-token",
+        expires_in: 7200,
+        scope: "event:read org:read project:read",
+      }),
+    })) as unknown as typeof fetch;
+
+    const response = await GET(
+      makeRequest(
+        "https://example.com/api/oauth/callback/sentry?code=valid-code&state=missing-scope",
+      ),
+      "sentry",
+      testWaitUntil,
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.text();
+    expect(body).toContain("did not grant the access Junior requires");
+    expect(mockTokenStore.get("U456:sentry")).toBeUndefined();
+    expect(waitUntilCallbacks).toHaveLength(0);
   });
 
   it("returns styled HTML 500 when token exchange fails", async () => {

--- a/packages/junior/tests/unit/handlers/oauth-callback.test.ts
+++ b/packages/junior/tests/unit/handlers/oauth-callback.test.ts
@@ -49,7 +49,7 @@ vi.mock("@/chat/plugins/registry", () => ({
         clientSecretEnv: "SENTRY_CLIENT_SECRET",
         authorizeEndpoint: "https://sentry.io/oauth/authorize/",
         tokenEndpoint: "https://sentry.io/oauth/token/",
-        scope: "event:read org:read project:read",
+        scope: "event:read event:write org:read project:read team:read",
         callbackPath: "/api/oauth/callback/sentry",
       };
     }

--- a/packages/junior/tests/unit/plugins/sentry-broker.test.ts
+++ b/packages/junior/tests/unit/plugins/sentry-broker.test.ts
@@ -28,7 +28,7 @@ const SENTRY_MANIFEST: PluginManifest = {
     clientSecretEnv: "SENTRY_CLIENT_SECRET",
     authorizeEndpoint: "https://sentry.io/oauth/authorize/",
     tokenEndpoint: "https://sentry.io/oauth/token/",
-    scope: "event:read org:read project:read",
+    scope: "event:read event:write org:read project:read team:read",
   },
 };
 

--- a/packages/junior/tests/unit/plugins/sentry-broker.test.ts
+++ b/packages/junior/tests/unit/plugins/sentry-broker.test.ts
@@ -12,6 +12,7 @@ import type {
 
 const ORIGINAL_ENV = { ...process.env };
 const ORIGINAL_FETCH = globalThis.fetch;
+const SENTRY_SCOPE = "event:read org:read project:read team:read";
 
 const SENTRY_MANIFEST: PluginManifest = {
   name: "sentry",
@@ -28,7 +29,7 @@ const SENTRY_MANIFEST: PluginManifest = {
     clientSecretEnv: "SENTRY_CLIENT_SECRET",
     authorizeEndpoint: "https://sentry.io/oauth/authorize/",
     tokenEndpoint: "https://sentry.io/oauth/token/",
-    scope: "event:read event:write org:read project:read team:read",
+    scope: SENTRY_SCOPE,
   },
 };
 
@@ -89,6 +90,7 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
         accessToken: "user-access-token",
         refreshToken: "user-refresh-token",
         expiresAt: Date.now() + 60 * 60 * 1000,
+        scope: SENTRY_SCOPE,
       },
     });
 
@@ -177,6 +179,7 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
         accessToken: "old-access-token",
         refreshToken: "old-refresh-token",
         expiresAt: Date.now() + 2 * 60 * 1000, // 2 min from now, within 5 min buffer
+        scope: SENTRY_SCOPE,
       },
     });
 
@@ -215,6 +218,7 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
     const stored = await tokenStore.get("U123", "sentry");
     expect(stored?.accessToken).toBe("new-access-token");
     expect(stored?.refreshToken).toBe("new-refresh-token");
+    expect(stored?.scope).toBe(SENTRY_SCOPE);
   });
 
   it("uses current token when refresh fails and token is still valid", async () => {
@@ -226,6 +230,7 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
         accessToken: "still-valid-token",
         refreshToken: "bad-refresh-token",
         expiresAt: Date.now() + 2 * 60 * 1000,
+        scope: SENTRY_SCOPE,
       },
     });
 
@@ -257,6 +262,47 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
     ]);
   });
 
+  it("rejects refreshed tokens whose scope no longer satisfies the provider requirement", async () => {
+    process.env.SENTRY_CLIENT_ID = "client-id";
+    process.env.SENTRY_CLIENT_SECRET = "client-secret";
+
+    const tokenStore = createMockTokenStore({
+      "U123:sentry": {
+        accessToken: "still-valid-token",
+        refreshToken: "refresh-token",
+        expiresAt: Date.now() + 2 * 60 * 1000,
+        scope: SENTRY_SCOPE,
+      },
+    });
+
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        access_token: "new-access-token",
+        refresh_token: "new-refresh-token",
+        expires_in: 3600,
+        scope: "event:read org:read project:read",
+      }),
+    })) as unknown as typeof fetch;
+
+    const broker = createBroker(tokenStore);
+
+    await expect(
+      broker.issue({
+        capability: "sentry.api",
+        reason: "test:refresh-scope-downgrade",
+        requesterId: "U123",
+      }),
+    ).rejects.toThrow(CredentialUnavailableError);
+
+    const stored = await tokenStore.get("U123", "sentry");
+    expect(stored).toMatchObject({
+      accessToken: "still-valid-token",
+      refreshToken: "refresh-token",
+      scope: SENTRY_SCOPE,
+    });
+  });
+
   it("throws CredentialUnavailableError when refresh fails and token is expired", async () => {
     process.env.SENTRY_CLIENT_ID = "client-id";
     process.env.SENTRY_CLIENT_SECRET = "client-secret";
@@ -266,6 +312,7 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
         accessToken: "expired-token",
         refreshToken: "bad-refresh-token",
         expiresAt: Date.now() - 1000, // already expired
+        scope: SENTRY_SCOPE,
       },
     });
 
@@ -291,6 +338,7 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
         accessToken: "expired-token",
         refreshToken: "refresh-token",
         expiresAt: Date.now() - 1000,
+        scope: SENTRY_SCOPE,
       },
     });
 
@@ -316,6 +364,47 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
         capability: "sentry.api",
         reason: "test:requester-no-token",
         requesterId: "U999",
+      }),
+    ).rejects.toThrow(CredentialUnavailableError);
+  });
+
+  it("throws CredentialUnavailableError when stored scope is missing required access", async () => {
+    const tokenStore = createMockTokenStore({
+      "U123:sentry": {
+        accessToken: "user-access-token",
+        refreshToken: "user-refresh-token",
+        expiresAt: Date.now() + 60 * 60 * 1000,
+        scope: "event:read org:read",
+      },
+    });
+
+    const broker = createBroker(tokenStore);
+
+    await expect(
+      broker.issue({
+        capability: "sentry.api",
+        reason: "test:scope-mismatch",
+        requesterId: "U123",
+      }),
+    ).rejects.toThrow(CredentialUnavailableError);
+  });
+
+  it("throws CredentialUnavailableError for legacy tokens without stored scope metadata", async () => {
+    const tokenStore = createMockTokenStore({
+      "U123:sentry": {
+        accessToken: "legacy-access-token",
+        refreshToken: "legacy-refresh-token",
+        expiresAt: Date.now() + 60 * 60 * 1000,
+      },
+    });
+
+    const broker = createBroker(tokenStore);
+
+    await expect(
+      broker.issue({
+        capability: "sentry.api",
+        reason: "test:legacy-scope",
+        requesterId: "U123",
       }),
     ).rejects.toThrow(CredentialUnavailableError);
   });

--- a/specs/oauth-flows-spec.md
+++ b/specs/oauth-flows-spec.md
@@ -212,7 +212,7 @@ Providers are configured via plugin manifests (`plugin.yaml`) and exposed throug
 - `clientSecretEnv`: `SENTRY_CLIENT_SECRET`
 - Authorize: `https://sentry.io/oauth/authorize/`
 - Token: `https://sentry.io/oauth/token/`
-- Scope: `event:read org:read project:read`
+- Scope: `event:read event:write org:read project:read team:read`
 - Callback: `/api/oauth/callback/sentry`
 
 ### MCP-backed plugins

--- a/specs/oauth-flows-spec.md
+++ b/specs/oauth-flows-spec.md
@@ -83,6 +83,7 @@ Provider: Redirects to /api/oauth/callback/<provider>?code=...&state=...
   ├─ Validate provider matches
   ├─ Delete state key (one-time use)
   ├─ POST to token endpoint using provider-configured auth method and headers
+  ├─ If provider returns an explicit scope, verify it still satisfies the plugin's required scope
   ├─ Store tokens via UserTokenStore (Redis key `oauth-token:<userId>:<provider>`)
   ├─ If pendingMessage: after() triggers generateAssistantReply and posts result to thread
   ├─ Else: post confirmation message into Slack thread (best effort, via SLACK_BOT_TOKEN)
@@ -158,9 +159,10 @@ Agent: jr-rpc delete-token sentry
 ### User tokens (persistent)
 
 - Key pattern: `oauth-token:<userId>:<provider>`
-- Value: `{ accessToken, refreshToken, expiresAt? }`
+- Value: `{ accessToken, refreshToken, expiresAt?, scope? }`
 - TTL: `expiresAt - now + 24h` buffer when expiry is known, otherwise 365 days
 - Storage: `StateAdapterTokenStore` wrapping `StateAdapter` (Redis)
+- `scope` stores the normalized granted/requested OAuth scope so scope changes can force reauthorization instead of silently reusing stale grants
 
 ### MCP auth sessions and credentials
 
@@ -212,7 +214,7 @@ Providers are configured via plugin manifests (`plugin.yaml`) and exposed throug
 - `clientSecretEnv`: `SENTRY_CLIENT_SECRET`
 - Authorize: `https://sentry.io/oauth/authorize/`
 - Token: `https://sentry.io/oauth/token/`
-- Scope: `event:read event:write org:read project:read team:read`
+- Scope: `event:read org:read project:read team:read`
 - Callback: `/api/oauth/callback/sentry`
 
 ### MCP-backed plugins

--- a/specs/plugin-spec.md
+++ b/specs/plugin-spec.md
@@ -98,7 +98,7 @@ oauth: # optional — omit for non-OAuth providers
   client-secret-env: SENTRY_CLIENT_SECRET
   authorize-endpoint: https://sentry.io/oauth/authorize/
   token-endpoint: https://sentry.io/oauth/token/
-  scope: "event:read org:read project:read" # optional
+  scope: "event:read event:write org:read project:read team:read" # optional
   authorize-params: # optional extra authorize query params
     audience: workspace
   token-auth-method: basic # optional; default body

--- a/specs/plugin-spec.md
+++ b/specs/plugin-spec.md
@@ -98,7 +98,7 @@ oauth: # optional — omit for non-OAuth providers
   client-secret-env: SENTRY_CLIENT_SECRET
   authorize-endpoint: https://sentry.io/oauth/authorize/
   token-endpoint: https://sentry.io/oauth/token/
-  scope: "event:read event:write org:read project:read team:read" # optional
+  scope: "event:read org:read project:read team:read" # optional
   authorize-params: # optional extra authorize query params
     audience: workspace
   token-auth-method: basic # optional; default body


### PR DESCRIPTION
Make the example app load the same plugin package set in local dev that production builds use, and tighten OAuth scope handling for stored user grants.

The example app was splitting plugin package configuration between Nitro and `createApp`, which meant local dev could start with a different plugin set than the production runtime. Separately, stored OAuth tokens were keyed only by user and provider, so pre-existing Sentry connections could keep stale scopes and fail later with missing-scope errors after a seemingly successful reconnect.

This shares the example app plugin package list between Nitro and `createApp`, keeps the Sentry plugin read-only, persists normalized granted OAuth scopes with stored tokens, and validates callback, refresh, and reuse paths against each plugin's required scope. Under-scoped grants now fail fast and go back through reauthorization instead of rendering a successful connect flow and failing on the next tool call.

I considered keeping the reconnect logic only in the Sentry skill, but that would leave the actual grant validation in the wrong layer and would still accept obviously insufficient callback or refresh responses. Validating granted scopes in the OAuth callback and broker keeps the behavior generic across OAuth-bearer providers while preserving the Sentry plugin's documented read-only contract.

Split out of the broader `wip/slack-cards-oauth-spike` branch on purpose. This PR keeps the OAuth and dev-loading fixes separate from the Slack card experiment.