### PR TITLE
fix(slack): Preserve team id for edited mention streaming

### DIFF
--- a/packages/junior/src/chat/ingress/message-changed.ts
+++ b/packages/junior/src/chat/ingress/message-changed.ts
@@ -17,6 +17,7 @@ function getEditedMentionMessageId(messageTs: string): string {
 
 interface SlackMessageChangedEvent {
   type: "event_callback";
+  team_id?: string;
   event: {
     type: "message";
     subtype: "message_changed";
@@ -87,12 +88,14 @@ export function extractMessageChangedMention(
   const threadTs = event.message.thread_ts ?? messageTs;
   const userId = event.message.user ?? "unknown";
   const threadId = `slack:${channelId}:${threadTs}`;
+  const teamId = typeof body.team_id === "string" ? body.team_id : undefined;
 
   const raw: Record<string, unknown> = {
     channel: channelId,
     ts: messageTs,
     thread_ts: threadTs,
     user: userId,
+    ...(teamId ? { team_id: teamId } : {}),
   };
 
   const message = new Message({

--- a/packages/junior/tests/fixtures/slack/factories/api.ts
+++ b/packages/junior/tests/fixtures/slack/factories/api.ts
@@ -43,6 +43,33 @@ export function chatPostMessageOk(
   });
 }
 
+export function chatStartStreamOk(
+  input: { ts?: string; channel?: string } = {},
+): { ok: true; ts: string; channel: string } {
+  return slackOk({
+    ts: input.ts ?? TEST_MESSAGE_TS,
+    channel: input.channel ?? TEST_CHANNEL_ID,
+  });
+}
+
+export function chatAppendStreamOk(
+  input: { ts?: string; channel?: string } = {},
+): { ok: true; ts: string; channel: string } {
+  return slackOk({
+    ts: input.ts ?? TEST_MESSAGE_TS,
+    channel: input.channel ?? TEST_CHANNEL_ID,
+  });
+}
+
+export function chatStopStreamOk(
+  input: { ts?: string; channel?: string } = {},
+): { ok: true; ts: string; channel: string } {
+  return slackOk({
+    ts: input.ts ?? TEST_MESSAGE_TS,
+    channel: input.channel ?? TEST_CHANNEL_ID,
+  });
+}
+
 export function chatPostEphemeralOk(input: { messageTs?: string } = {}): {
   ok: true;
   message_ts: string;

--- a/packages/junior/tests/integration/slack/message-changed-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/message-changed-behavior.test.ts
@@ -2,8 +2,11 @@ import { createHmac } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import { createSlackAdapter } from "@chat-adapter/slack";
 import { createMemoryState } from "@chat-adapter/state-memory";
+import type { SlackAdapter } from "@chat-adapter/slack";
 import type { Message } from "chat";
 import { slackEventsApiEnvelope } from "../../fixtures/slack/factories/events";
+import { getCapturedSlackApiCalls } from "../../msw/handlers/slack-api";
+import { createSlackRuntime } from "@/chat/app/factory";
 import { JuniorChat } from "@/chat/ingress/junior-chat";
 import type { WaitUntilFn } from "@/handlers/types";
 import { handlePlatformWebhook } from "@/handlers/webhooks";
@@ -38,6 +41,18 @@ async function flushWaitUntil(tasks: Array<Promise<unknown>>): Promise<void> {
 function collectWaitUntil(tasks: Array<Promise<unknown>>): WaitUntilFn {
   return (task) => {
     tasks.push(typeof task === "function" ? task() : task);
+  };
+}
+
+function makeDiagnostics() {
+  return {
+    assistantMessageCount: 1,
+    modelId: "fake-agent-model",
+    outcome: "success" as const,
+    toolCalls: [],
+    toolErrorCount: 0,
+    toolResultCount: 0,
+    usedPrimaryText: true,
   };
 }
 
@@ -163,6 +178,114 @@ describe("Slack behavior: message_changed webhook ingress", () => {
     expect((handledMessages[1]?.raw as { ts?: string }).ts).toBe(
       "1700000100.000100",
     );
+  });
+
+  it("streams an edited DM mention with the Slack recipient team metadata", async () => {
+    const state = createMemoryState();
+    await state.connect();
+    const bot = new JuniorChat<{ slack: SlackAdapter }>({
+      userName: "junior",
+      adapters: {
+        slack: createSlackAdapter({
+          botToken: "xoxb-test",
+          botUserId: BOT_USER_ID,
+          signingSecret: SIGNING_SECRET,
+        }),
+      },
+      state,
+    });
+    const slackRuntime = createSlackRuntime({
+      getSlackAdapter: () => bot.getAdapter("slack"),
+      services: {
+        replyExecutor: {
+          generateAssistantReply: async (_prompt, context) => {
+            await context?.onTextDelta?.("Hello world");
+            return {
+              text: "Hello world",
+              diagnostics: makeDiagnostics(),
+            };
+          },
+        },
+      },
+    });
+    const waitUntilTasks: Array<Promise<unknown>> = [];
+
+    bot.onDirectMessage((thread, message) =>
+      slackRuntime.handleNewMention(thread, message),
+    );
+
+    const editedBody = JSON.stringify({
+      ...slackEventsApiEnvelope({
+        eventType: "message",
+        channel: "D12345",
+        ts: "1700000100.000100",
+        text: "hello there",
+      }),
+      event: {
+        type: "message",
+        subtype: "message_changed",
+        channel: "D12345",
+        hidden: true,
+        message: {
+          type: "message",
+          user: "U123",
+          text: `<@${BOT_USER_ID}> hello there`,
+          ts: "1700000100.000100",
+        },
+        previous_message: {
+          type: "message",
+          user: "U123",
+          text: "hello there",
+          ts: "1700000100.000100",
+        },
+      },
+    });
+    const editedTimestamp = String(Math.floor(Date.now() / 1000));
+    const editedRequest = new Request(
+      "https://example.test/api/webhooks/slack",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-slack-request-timestamp": editedTimestamp,
+          "x-slack-signature": signSlackBody(editedBody, editedTimestamp),
+        },
+        body: editedBody,
+      },
+    );
+
+    const response = await handlePlatformWebhook(
+      editedRequest,
+      "slack",
+      collectWaitUntil(waitUntilTasks),
+      bot,
+    );
+    await flushWaitUntil(waitUntilTasks);
+
+    expect(response.status).toBe(200);
+    expect(getCapturedSlackApiCalls("chat.startStream")).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({
+          channel: "D12345",
+          thread_ts: "1700000100.000100",
+          recipient_user_id: "U123",
+          recipient_team_id: "T_TEST",
+        }),
+      }),
+    ]);
+    expect(getCapturedSlackApiCalls("chat.stopStream")).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({
+          channel: "D12345",
+          chunks: [
+            {
+              type: "markdown_text",
+              text: "Hello world",
+            },
+          ],
+        }),
+      }),
+    ]);
   });
 
   it("rejects forged edited mentions before any bot handler runs", async () => {

--- a/packages/junior/tests/msw/handlers/slack-api.ts
+++ b/packages/junior/tests/msw/handlers/slack-api.ts
@@ -5,6 +5,9 @@ import {
   canvasesEditOk,
   canvasesSectionsLookupOk,
   chatGetPermalinkOk,
+  chatStartStreamOk,
+  chatAppendStreamOk,
+  chatStopStreamOk,
   chatPostEphemeralOk,
   chatPostMessageOk,
   conversationsCanvasesCreateOk,
@@ -27,6 +30,9 @@ const EXTERNAL_UPLOAD_KEY = "__files.upload.external__";
 export const SUPPORTED_SLACK_API_METHODS = [
   "assistant.threads.setStatus",
   "chat.postMessage",
+  "chat.startStream",
+  "chat.appendStream",
+  "chat.stopStream",
   "chat.postEphemeral",
   "chat.getPermalink",
   "views.publish",
@@ -175,6 +181,12 @@ function defaultSlackApiResponse(
       return { body: slackOk() };
     case "chat.postMessage":
       return { body: chatPostMessageOk() };
+    case "chat.startStream":
+      return { body: chatStartStreamOk() };
+    case "chat.appendStream":
+      return { body: chatAppendStreamOk() };
+    case "chat.stopStream":
+      return { body: chatStopStreamOk() };
     case "chat.postEphemeral":
       return { body: chatPostEphemeralOk() };
     case "chat.getPermalink":

--- a/packages/junior/tests/unit/slack/message-changed-ingress.test.ts
+++ b/packages/junior/tests/unit/slack/message-changed-ingress.test.ts
@@ -4,6 +4,7 @@ import { extractMessageChangedMention } from "@/chat/ingress/message-changed";
 
 const BOT_USER_ID = "U_BOT_TEST";
 const CHANNEL_ID = "C_CHAN";
+const TEAM_ID = "T_TEAM";
 const MESSAGE_TS = "1700000100.000";
 const THREAD_TS = "1700000000.000";
 const EDITED_MESSAGE_ID = `${MESSAGE_TS}:message_changed_mention`;
@@ -20,6 +21,7 @@ function makeEnvelope(overrides: {
 }): unknown {
   return {
     type: "event_callback",
+    team_id: TEAM_ID,
     event: {
       type: "message",
       subtype: "message_changed",
@@ -84,6 +86,7 @@ describe("extractMessageChangedMention", () => {
       },
       raw: {
         channel: CHANNEL_ID,
+        team_id: TEAM_ID,
         ts: MESSAGE_TS,
         thread_ts: THREAD_TS,
         user: "U_SENDER",


### PR DESCRIPTION
Carry Slack's top-level `team_id` through synthesized `message_changed` mention payloads so native streaming replies can derive `recipient_team_id` when an edited message newly mentions Junior.

The failure in production was not in normal mention routing or model generation; it happened when the edited-mention side path built a synthetic message without the team metadata that Chat SDK's native Slack streaming requires for `chat.startStream`. That let the turn reach the first streamed reply post and then fail with a validation error.

This also extends the shared Slack MSW harness for `chat.startStream`, `chat.appendStream`, and `chat.stopStream`, then adds an integration regression that drives a signed `message_changed` webhook through the real ingress path and asserts the native stream request includes both recipient identifiers.

I considered covering this only with a unit assertion on the synthesized message shape, but the production gap was specifically the combination of webhook ingress plus native streaming, so the regression belongs at that integration seam.

Fixes JUNIOR-1K