### PR TITLE
fix(plugins): Infer MCP HTTP transport from url

### DIFF
--- a/packages/docs/src/content/docs/extend/index.md
+++ b/packages/docs/src/content/docs/extend/index.md
@@ -156,7 +156,7 @@ runtime-postinstall:
 - `target`: optional credential target scope tied to a declared config key
 - `runtime-dependencies`: sandbox dependencies required by the plugin’s tools
 - `runtime-postinstall`: commands that run after dependency install and before snapshot capture
-- `mcp`: optional MCP server configuration for provider-scoped tool sources
+- `mcp`: optional MCP server configuration for provider-scoped tool sources; `mcp.url` implies hosted HTTP transport, so `mcp.transport: http` is optional
 - `mcp.allowed-tools`: optional raw MCP tool-name allowlist when a plugin should expose only part of a provider's tool surface
 
 ### Add skills to the plugin

--- a/packages/junior-evals/evals/fixtures/plugins/eval-auth/plugin.yaml
+++ b/packages/junior-evals/evals/fixtures/plugins/eval-auth/plugin.yaml
@@ -2,7 +2,6 @@ name: eval-auth
 description: Eval-only MCP auth resume fixture
 
 mcp:
-  transport: http
   url: https://eval-auth.example.test/mcp
   allowed-tools:
     - budget-echo

--- a/packages/junior-linear/plugin.yaml
+++ b/packages/junior-linear/plugin.yaml
@@ -6,5 +6,4 @@ config-keys:
   - project
 
 mcp:
-  transport: http
   url: https://mcp.linear.app/mcp

--- a/packages/junior-notion/plugin.yaml
+++ b/packages/junior-notion/plugin.yaml
@@ -2,7 +2,6 @@ name: notion
 description: Notion page search and summarization
 
 mcp:
-  transport: http
   url: https://mcp.notion.com/mcp
   allowed-tools:
     - notion-search

--- a/packages/junior/src/chat/plugins/manifest.ts
+++ b/packages/junior/src/chat/plugins/manifest.ts
@@ -225,9 +225,11 @@ const oauthSourceSchema = z
 
 const mcpSourceSchema = z
   .object({
-    transport: nonEmptyTrimmedString.refine((value) => value === "http", {
-      error: 'must be "http"',
-    }),
+    transport: nonEmptyTrimmedString
+      .refine((value) => value === "http", {
+        error: 'must be "http"',
+      })
+      .optional(),
     url: httpsUrlString,
     headers: stringMapSchema.optional(),
     "allowed-tools": nonEmptyStringArraySchema("allowed-tools").optional(),

--- a/packages/junior/tests/fixtures/plugins/eval-auth/plugin.yaml
+++ b/packages/junior/tests/fixtures/plugins/eval-auth/plugin.yaml
@@ -2,7 +2,6 @@ name: eval-auth
 description: Eval-only MCP OAuth auth-resume fixture
 
 mcp:
-  transport: http
   url: https://eval-auth.example.test/mcp
   allowed-tools:
     - budget-echo

--- a/packages/junior/tests/unit/plugins/plugin-registry-packages.test.ts
+++ b/packages/junior/tests/unit/plugins/plugin-registry-packages.test.ts
@@ -336,7 +336,6 @@ async function writePackagedPluginWithMcp(tempRoot: string): Promise<void> {
       "name: demo",
       "description: Demo MCP plugin",
       "mcp:",
-      "  transport: http",
       "  url: https://mcp.example.com",
       "  headers:",
       '    X-Workspace: "acme"',
@@ -842,7 +841,7 @@ describe("plugin registry package discovery", () => {
     );
   });
 
-  it("parses HTTP MCP configuration from packaged plugins", async () => {
+  it("infers HTTP MCP configuration from packaged plugins with a URL", async () => {
     const tempRoot = await fs.mkdtemp(
       path.join(os.tmpdir(), "junior-plugin-package-"),
     );

--- a/specs/oauth-flows-spec.md
+++ b/specs/oauth-flows-spec.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-03-03
-- Last Edited: 2026-03-20
+- Last Edited: 2026-04-13
 
 ## Changelog
 
@@ -12,6 +12,7 @@
 - 2026-03-13: Documented MCP challenge-driven OAuth, MCP callback routing, and auth-driven turn resume.
 - 2026-03-18: Clarified lazy MCP auth-session creation, host-managed MCP server-session storage, and disconnect cleanup for stored credentials plus pending auth sessions.
 - 2026-03-20: Removed stale slash-command examples in favor of generic connect/disconnect requests and direct jr-rpc initiation.
+- 2026-04-13: Clarified that `mcp.url` implies hosted HTTP transport, so explicit `mcp.transport: http` is optional.
 
 ## Status
 
@@ -219,7 +220,7 @@ Providers are configured via plugin manifests (`plugin.yaml`) and exposed throug
 
 ### MCP-backed plugins
 
-- Plugin manifests may also declare `mcp.transport: http` and `mcp.url`.
+- Plugin manifests may also declare `mcp.url`; hosted HTTP transport is inferred when present, so explicit `mcp.transport: http` is optional.
 - MCP headers are optional but may not include `Authorization`.
 - MCP callback path is `/api/oauth/callback/mcp/<plugin>`.
 - MCP OAuth is challenge-driven by the SDK rather than initiated through `jr-rpc oauth-start`.

--- a/specs/plugin-spec.md
+++ b/specs/plugin-spec.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-03-01
-- Last Edited: 2026-03-18
+- Last Edited: 2026-04-13
 
 ## Changelog
 
@@ -16,6 +16,7 @@
 - 2026-03-18: Added provider-scoped MCP tool allowlists for read-only plugin surfaces.
 - 2026-03-18: Replaced per-MCP-tool Pi registration with stable `searchTools`/`useTool` dispatch and plugin-level MCP allowlists.
 - 2026-04-05: Added INV-1 spec invariant: plugin discovery is explicit only.
+- 2026-04-13: Made `mcp.transport` optional when `mcp.url` is present; Junior infers hosted HTTP transport from the URL.
 
 ## Status
 
@@ -124,7 +125,6 @@ runtime-postinstall: # optional — post-install commands executed before snapsh
     args: ["install"]
 
 mcp: # optional — MCP server config for tool sources
-  transport: http
   url: https://mcp.example.com/mcp
   headers:
     X-Workspace: acme
@@ -144,46 +144,46 @@ mcp: # optional — MCP server config for tool sources
 
 ### Optional fields
 
-| Field                                | Type                     | Rules                                                                                                                                            |
-| ------------------------------------ | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `capabilities`                       | `string[]`               | Short names (e.g. `issues.read`). Qualified to `<name>.issues.read` by the registry. No qualified capability may appear in more than one plugin. |
-| `config-keys`                        | `string[]`               | Short names (e.g. `org`). Qualified to `<name>.org` by the registry.                                                                             |
-| `credentials`                        | `object`                 | Credential delivery configuration.                                                                                                               |
-| `credentials.type`                   | `string`                 | `"oauth-bearer"` or `"github-app"`.                                                                                                              |
-| `credentials.api-domains`            | `string[]`               | Domains for `Authorization: Bearer` header transforms. At least one required.                                                                    |
-| `credentials.api-headers`            | `Record<string, string>` | Optional headers applied to matching API domains alongside `Authorization`. `Authorization` itself is reserved.                                  |
-| `credentials.auth-token-env`         | `string`                 | Env var name for static token fallback and sandbox placeholder.                                                                                  |
-| `credentials.auth-token-placeholder` | `string`                 | Optional non-secret placeholder injected into sandbox env for CLI compatibility.                                                                 |
-| `credentials.app-id-env`             | `string`                 | Env var name for GitHub App ID. Required when `credentials.type` is `"github-app"`.                                                              |
-| `credentials.private-key-env`        | `string`                 | Env var name for GitHub App private key (PEM). Required when `credentials.type` is `"github-app"`.                                               |
-| `credentials.installation-id-env`    | `string`                 | Env var name for GitHub App installation ID. Required when `credentials.type` is `"github-app"`.                                                 |
-| `oauth`                              | `object`                 | OAuth provider configuration. Requires `credentials.type` = `"oauth-bearer"`.                                                                    |
-| `oauth.client-id-env`                | `string`                 | Env var name for client ID.                                                                                                                      |
-| `oauth.client-secret-env`            | `string`                 | Env var name for client secret.                                                                                                                  |
-| `oauth.authorize-endpoint`           | `string`                 | Valid HTTPS URL.                                                                                                                                 |
-| `oauth.token-endpoint`               | `string`                 | Valid HTTPS URL.                                                                                                                                 |
-| `oauth.scope`                        | `string`                 | Optional OAuth scope string.                                                                                                                     |
-| `oauth.authorize-params`             | `Record<string, string>` | Optional authorize URL params added alongside core params. Reserved OAuth param names may not be overridden.                                     |
-| `oauth.token-auth-method`            | `string`                 | Optional token client auth method: `"body"` (default) or `"basic"`.                                                                              |
-| `oauth.token-extra-headers`          | `Record<string, string>` | Optional token request headers. `Authorization` is reserved; `Content-Type` controls token body serialization.                                   |
-| `target`                             | `object`                 | Capability target for scoped credentials.                                                                                                        |
-| `target.type`                        | `string`                 | Currently only `"repo"`.                                                                                                                         |
-| `target.config-key`                  | `string`                 | Must appear in `config-keys`.                                                                                                                    |
-| `runtime-dependencies`               | `object[]`               | Optional sandbox dependency declarations used to build reusable snapshots.                                                                       |
-| `runtime-dependencies[].type`        | `string`                 | `"npm"` or `"system"`.                                                                                                                           |
-| `runtime-dependencies[].package`     | `string`                 | Package identifier (npm package name or system package name). Required for `npm`; optional for `system` when `url` is used.                      |
-| `runtime-dependencies[].version`     | `string`                 | Optional for `npm` dependencies. When omitted, runtime uses `latest`. Must be omitted for `system` dependencies.                                 |
-| `runtime-dependencies[].url`         | `string`                 | HTTPS URL for direct system package install (RPM). Allowed only for `system` dependencies.                                                       |
-| `runtime-dependencies[].sha256`      | `string`                 | Required with `url`. Lowercase or uppercase hex SHA-256 checksum used for integrity verification before install.                                 |
-| `runtime-postinstall`                | `object[]`               | Optional post-install command declarations executed after dependency install and before snapshot capture.                                        |
-| `runtime-postinstall[].cmd`          | `string`                 | Non-empty command name.                                                                                                                          |
-| `runtime-postinstall[].args`         | `string[]`               | Optional command arguments.                                                                                                                      |
-| `runtime-postinstall[].sudo`         | `boolean`                | Optional sudo flag for commands requiring elevated privileges.                                                                                   |
-| `mcp`                                | `object`                 | Optional MCP server configuration for host-managed tool discovery.                                                                               |
-| `mcp.transport`                      | `string`                 | Must be `"http"` in v1. Stdio/command transports are not supported.                                                                              |
-| `mcp.url`                            | `string`                 | HTTPS endpoint for the MCP server.                                                                                                               |
-| `mcp.headers`                        | `Record<string, string>` | Optional static non-Authorization headers sent with MCP HTTP requests. `Authorization` is reserved for runtime-managed auth.                     |
-| `mcp.allowed-tools`                  | `string[]`               | Optional non-empty allowlist of raw MCP tool names to expose for this provider. Activation fails if any listed tool is missing from discovery.   |
+| Field                                | Type                     | Rules                                                                                                                                                    |
+| ------------------------------------ | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `capabilities`                       | `string[]`               | Short names (e.g. `issues.read`). Qualified to `<name>.issues.read` by the registry. No qualified capability may appear in more than one plugin.         |
+| `config-keys`                        | `string[]`               | Short names (e.g. `org`). Qualified to `<name>.org` by the registry.                                                                                     |
+| `credentials`                        | `object`                 | Credential delivery configuration.                                                                                                                       |
+| `credentials.type`                   | `string`                 | `"oauth-bearer"` or `"github-app"`.                                                                                                                      |
+| `credentials.api-domains`            | `string[]`               | Domains for `Authorization: Bearer` header transforms. At least one required.                                                                            |
+| `credentials.api-headers`            | `Record<string, string>` | Optional headers applied to matching API domains alongside `Authorization`. `Authorization` itself is reserved.                                          |
+| `credentials.auth-token-env`         | `string`                 | Env var name for static token fallback and sandbox placeholder.                                                                                          |
+| `credentials.auth-token-placeholder` | `string`                 | Optional non-secret placeholder injected into sandbox env for CLI compatibility.                                                                         |
+| `credentials.app-id-env`             | `string`                 | Env var name for GitHub App ID. Required when `credentials.type` is `"github-app"`.                                                                      |
+| `credentials.private-key-env`        | `string`                 | Env var name for GitHub App private key (PEM). Required when `credentials.type` is `"github-app"`.                                                       |
+| `credentials.installation-id-env`    | `string`                 | Env var name for GitHub App installation ID. Required when `credentials.type` is `"github-app"`.                                                         |
+| `oauth`                              | `object`                 | OAuth provider configuration. Requires `credentials.type` = `"oauth-bearer"`.                                                                            |
+| `oauth.client-id-env`                | `string`                 | Env var name for client ID.                                                                                                                              |
+| `oauth.client-secret-env`            | `string`                 | Env var name for client secret.                                                                                                                          |
+| `oauth.authorize-endpoint`           | `string`                 | Valid HTTPS URL.                                                                                                                                         |
+| `oauth.token-endpoint`               | `string`                 | Valid HTTPS URL.                                                                                                                                         |
+| `oauth.scope`                        | `string`                 | Optional OAuth scope string.                                                                                                                             |
+| `oauth.authorize-params`             | `Record<string, string>` | Optional authorize URL params added alongside core params. Reserved OAuth param names may not be overridden.                                             |
+| `oauth.token-auth-method`            | `string`                 | Optional token client auth method: `"body"` (default) or `"basic"`.                                                                                      |
+| `oauth.token-extra-headers`          | `Record<string, string>` | Optional token request headers. `Authorization` is reserved; `Content-Type` controls token body serialization.                                           |
+| `target`                             | `object`                 | Capability target for scoped credentials.                                                                                                                |
+| `target.type`                        | `string`                 | Currently only `"repo"`.                                                                                                                                 |
+| `target.config-key`                  | `string`                 | Must appear in `config-keys`.                                                                                                                            |
+| `runtime-dependencies`               | `object[]`               | Optional sandbox dependency declarations used to build reusable snapshots.                                                                               |
+| `runtime-dependencies[].type`        | `string`                 | `"npm"` or `"system"`.                                                                                                                                   |
+| `runtime-dependencies[].package`     | `string`                 | Package identifier (npm package name or system package name). Required for `npm`; optional for `system` when `url` is used.                              |
+| `runtime-dependencies[].version`     | `string`                 | Optional for `npm` dependencies. When omitted, runtime uses `latest`. Must be omitted for `system` dependencies.                                         |
+| `runtime-dependencies[].url`         | `string`                 | HTTPS URL for direct system package install (RPM). Allowed only for `system` dependencies.                                                               |
+| `runtime-dependencies[].sha256`      | `string`                 | Required with `url`. Lowercase or uppercase hex SHA-256 checksum used for integrity verification before install.                                         |
+| `runtime-postinstall`                | `object[]`               | Optional post-install command declarations executed after dependency install and before snapshot capture.                                                |
+| `runtime-postinstall[].cmd`          | `string`                 | Non-empty command name.                                                                                                                                  |
+| `runtime-postinstall[].args`         | `string[]`               | Optional command arguments.                                                                                                                              |
+| `runtime-postinstall[].sudo`         | `boolean`                | Optional sudo flag for commands requiring elevated privileges.                                                                                           |
+| `mcp`                                | `object`                 | Optional MCP server configuration for host-managed tool discovery.                                                                                       |
+| `mcp.transport`                      | `string`                 | Optional. When omitted and `mcp.url` is present, Junior infers HTTP. If provided in v1, it must be `"http"`. Stdio/command transports are not supported. |
+| `mcp.url`                            | `string`                 | HTTPS endpoint for the MCP server.                                                                                                                       |
+| `mcp.headers`                        | `Record<string, string>` | Optional static non-Authorization headers sent with MCP HTTP requests. `Authorization` is reserved for runtime-managed auth.                             |
+| `mcp.allowed-tools`                  | `string[]`               | Optional non-empty allowlist of raw MCP tool names to expose for this provider. Activation fails if any listed tool is missing from discovery.           |
 
 Snapshot build/reuse and invalidation behavior for `runtime-dependencies` is defined in [Sandbox Snapshots Spec](./sandbox-snapshots-spec.md).
 


### PR DESCRIPTION
Infer hosted MCP transport from mcp.url so plugin manifests no longer need redundant mcp.transport: http boilerplate.

The runtime still only supports HTTP MCP endpoints today. This change makes the manifest ergonomics match that existing behavior by accepting mcp.url alone, normalizing the parsed config to HTTP, and continuing to reject non-HTTP transport values.

The bundled Linear and Notion plugin manifests, eval fixtures, package-registry coverage, and plugin docs/specs all move to the inferred-HTTP shape so the documented contract matches the parser.

Fixes #190