### PR TITLE
build(chat): Update deps and align SDK integration

### DIFF
--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -15,13 +15,13 @@
     "@sentry/junior-linear": "workspace:*",
     "@sentry/junior-notion": "workspace:*",
     "@sentry/junior-sentry": "workspace:*",
-    "@sentry/node": "^10.46.0",
-    "hono": "^4.12.9"
+    "@sentry/node": "^10.48.0",
+    "hono": "^4.12.14"
   },
   "devDependencies": {
-    "@types/node": "^25.5.0",
+    "@types/node": "^25.6.0",
     "jiti": "^2.6.1",
-    "nitro": "3.0.260311-beta",
+    "nitro": "3.0.260415-beta",
     "typescript": "^5.9.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "agent-browser": "^0.23.3",
     "lint-staged": "^16.4.0",
-    "prettier": "^3.8.1",
+    "prettier": "^3.8.3",
     "simple-git-hooks": "^2.13.1",
     "tsx": "^4.21.0"
   }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -16,7 +16,7 @@
     "@fontsource/ibm-plex-mono": "^5.2.7",
     "astro": "^5.18.1",
     "starlight-typedoc": "^0.21.5",
-    "typedoc": "^0.28.18",
+    "typedoc": "^0.28.19",
     "typedoc-plugin-markdown": "^4.11.0",
     "typescript": "^5.9.3"
   }

--- a/packages/docs/src/content/docs/reference/api/handlers/webhooks/functions/POST.md
+++ b/packages/docs/src/content/docs/reference/api/handlers/webhooks/functions/POST.md
@@ -7,7 +7,7 @@ title: "POST"
 
 > **POST**(`request`, `platform`, `waitUntil`): `Promise`\<`Response`\>
 
-Defined in: [handlers/webhooks.ts:236](https://github.com/getsentry/junior/blob/main/packages/junior/src/handlers/webhooks.ts#L236)
+Defined in: [handlers/webhooks.ts:238](https://github.com/getsentry/junior/blob/main/packages/junior/src/handlers/webhooks.ts#L238)
 
 ## Parameters
 

--- a/packages/docs/src/content/docs/reference/api/handlers/webhooks/functions/handlePlatformWebhook.md
+++ b/packages/docs/src/content/docs/reference/api/handlers/webhooks/functions/handlePlatformWebhook.md
@@ -7,7 +7,7 @@ title: "handlePlatformWebhook"
 
 > **handlePlatformWebhook**(`request`, `platform`, `waitUntil`, `bot?`): `Promise`\<`Response`\>
 
-Defined in: [handlers/webhooks.ts:117](https://github.com/getsentry/junior/blob/main/packages/junior/src/handlers/webhooks.ts#L117)
+Defined in: [handlers/webhooks.ts:119](https://github.com/getsentry/junior/blob/main/packages/junior/src/handlers/webhooks.ts#L119)
 
 Handles `POST /api/webhooks/:platform`.
 

--- a/packages/junior-evals/package.json
+++ b/packages/junior-evals/package.json
@@ -9,13 +9,13 @@
     "evals": "JUNIOR_STATE_ADAPTER=memory pnpm exec vitest run -c vitest.evals.config.ts"
   },
   "devDependencies": {
-    "@ai-sdk/gateway": "^3.0.83",
+    "@ai-sdk/gateway": "^3.0.99",
     "@sentry/junior": "workspace:*",
     "@sentry/junior-github": "workspace:*",
     "@sentry/junior-sentry": "workspace:*",
-    "chat": "4.23.0",
+    "chat": "4.26.0",
     "typescript": "^5.9.3",
-    "vitest": "^4.1.2",
+    "vitest": "^4.1.4",
     "vitest-evals": "^0.7.0",
     "zod": "^4.3.6"
   }

--- a/packages/junior/package.json
+++ b/packages/junior/package.json
@@ -34,23 +34,23 @@
     "skills:check": "node scripts/check-skills.mjs"
   },
   "dependencies": {
-    "@ai-sdk/gateway": "^3.0.83",
-    "@chat-adapter/slack": "4.23.0",
-    "@chat-adapter/state-memory": "4.23.0",
-    "@chat-adapter/state-redis": "4.23.0",
+    "@ai-sdk/gateway": "^3.0.99",
+    "@chat-adapter/slack": "4.26.0",
+    "@chat-adapter/state-memory": "4.26.0",
+    "@chat-adapter/state-redis": "4.26.0",
     "@logtape/logtape": "^2.0.5",
     "@mariozechner/pi-agent-core": "0.59.0",
     "@mariozechner/pi-ai": "0.59.0",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@sinclair/typebox": "^0.34.49",
-    "@slack/web-api": "^7.15.0",
+    "@slack/web-api": "^7.15.1",
     "@vercel/functions": "^3.4.3",
-    "@vercel/sandbox": "^1.9.3",
-    "ai": "^6.0.141",
-    "bash-tool": "^1.3.15",
-    "chat": "4.23.0",
-    "hono": "^4.12.9",
-    "just-bash": "^2.14.0",
+    "@vercel/sandbox": "^1.10.0",
+    "ai": "^6.0.162",
+    "bash-tool": "^1.3.16",
+    "chat": "4.26.0",
+    "hono": "^4.12.14",
+    "just-bash": "^2.14.2",
     "node-html-markdown": "^2.0.0",
     "yaml": "^2.8.3",
     "zod": "^4.3.6"
@@ -59,15 +59,15 @@
     "@sentry/node": ">=10.0.0"
   },
   "devDependencies": {
-    "@sentry/node": "^10.46.0",
-    "@types/node": "^25.5.0",
+    "@sentry/node": "^10.48.0",
+    "@types/node": "^25.6.0",
     "dependency-cruiser": "^17.3.10",
-    "msw": "^2.12.14",
-    "nitro": "3.0.260311-beta",
-    "oxlint": "^1.58.0",
+    "msw": "^2.13.3",
+    "nitro": "3.0.260415-beta",
+    "oxlint": "^1.60.0",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
-    "vercel": "^50.37.3",
-    "vitest": "^4.1.2"
+    "vercel": "^51.4.0",
+    "vitest": "^4.1.4"
   }
 }

--- a/packages/junior/src/chat/ingress/junior-chat.ts
+++ b/packages/junior/src/chat/ingress/junior-chat.ts
@@ -26,6 +26,7 @@ type ChatInternals = {
     event: Omit<ActionEvent, "thread" | "openModal"> & {
       adapter: Adapter;
     },
+    options: WebhookOptions | undefined,
   ) => Promise<void>;
   retrieveModalContext: (
     adapterName: string,
@@ -40,6 +41,7 @@ type ChatInternals = {
       adapter: Adapter;
       channelId: string;
     },
+    options: WebhookOptions | undefined,
   ) => Promise<void>;
   modalCloseHandlers: Array<{
     callbackIds: string[];
@@ -164,24 +166,23 @@ export class JuniorChat<
     event: Omit<ActionEvent, "thread" | "openModal"> & {
       adapter: Adapter;
     },
-    options?: WebhookOptions,
-  ): void {
+    options: WebhookOptions | undefined,
+  ): Promise<void> {
     const runtime = this as unknown as ChatInternals;
 
-    enqueueBackgroundTask(
-      options,
-      (async (): Promise<void> => {
-        try {
-          await runtime.handleActionEvent(event);
-        } catch (error) {
-          runtime.logger?.error?.("Action processing error", {
-            error,
-            actionId: event.actionId,
-            messageId: event.messageId,
-          });
-        }
-      })(),
-    );
+    const task = (async (): Promise<void> => {
+      try {
+        await runtime.handleActionEvent(event, options);
+      } catch (error) {
+        runtime.logger?.error?.("Action processing error", {
+          error,
+          actionId: event.actionId,
+          messageId: event.messageId,
+        });
+      }
+    })();
+    enqueueBackgroundTask(options, task);
+    return task;
   }
 
   override processModalClose(
@@ -232,7 +233,7 @@ export class JuniorChat<
       adapter: Adapter;
       channelId: string;
     },
-    options?: WebhookOptions,
+    options: WebhookOptions | undefined,
   ): void {
     const runtime = this as unknown as ChatInternals;
 
@@ -240,7 +241,7 @@ export class JuniorChat<
       options,
       (async (): Promise<void> => {
         try {
-          await runtime.handleSlashCommandEvent(event);
+          await runtime.handleSlashCommandEvent(event, options);
         } catch (error) {
           runtime.logger?.error?.("Slash command processing error", {
             error,

--- a/packages/junior/src/chat/sandbox/eval-gh-stub.ts
+++ b/packages/junior/src/chat/sandbox/eval-gh-stub.ts
@@ -115,7 +115,11 @@ function pickFields(record, csv) {
 }
 
 function outputJson(value) {
-  process.stdout.write(JSON.stringify(value, null, 2) + "\\n");
+  fs.writeFileSync(process.stdout.fd, JSON.stringify(value, null, 2) + "\\n");
+}
+
+function outputText(value) {
+  fs.writeFileSync(process.stdout.fd, value);
 }
 
 function fallbackToRealGh() {
@@ -131,12 +135,12 @@ function fallbackToRealGh() {
 }
 
 if (args.length === 0 || args[0] === "--version" || args[0] === "version") {
-  process.stdout.write("gh version 2.0.0 (junior-eval)\\n");
+  outputText("gh version 2.0.0 (junior-eval)\\n");
   process.exit(0);
 }
 
 if (args[0] === "auth" && args[1] === "status") {
-  process.stdout.write("github.com\\n  ✓ Logged in to github.com as junior-eval\\n");
+  outputText("github.com\\n  ✓ Logged in to github.com as junior-eval\\n");
   process.exit(0);
 }
 
@@ -160,7 +164,7 @@ if (args[0] === "repo" && args[1] === "view") {
   if (jsonFields) {
     outputJson(pickFields(record, jsonFields));
   } else {
-    process.stdout.write(record.url + "\\n");
+    outputText(record.url + "\\n");
   }
   process.exit(0);
 }
@@ -212,7 +216,7 @@ if (args[0] === "issue") {
     if (jsonFields) {
       outputJson(pickFields(record, jsonFields));
     } else {
-      process.stdout.write(record.url + "\\n");
+      outputText(record.url + "\\n");
     }
     process.exit(0);
   }
@@ -228,7 +232,7 @@ if (args[0] === "issue") {
     if (jsonFields) {
       outputJson(pickFields(record, jsonFields));
     } else {
-      process.stdout.write(record.url + "\\n");
+      outputText(record.url + "\\n");
     }
     process.exit(0);
   }
@@ -245,7 +249,7 @@ if (args[0] === "issue") {
   }
 
   if (subcommand === "comment") {
-    process.stdout.write(record.url + "#issuecomment-1\\n");
+    outputText(record.url + "#issuecomment-1\\n");
     process.exit(0);
   }
 

--- a/packages/junior/src/chat/slack/adapter.ts
+++ b/packages/junior/src/chat/slack/adapter.ts
@@ -145,7 +145,9 @@ function patchSlackAdapterStream(adapter: SlackAdapter): void {
     let first = true;
     let lastAppended = "";
     let structuredChunksSupported = true;
-    const renderer = new StreamingMarkdownRenderer();
+    const renderer = new StreamingMarkdownRenderer({
+      wrapTablesForAppend: false,
+    });
 
     const flushMarkdownDelta = async (delta: string): Promise<void> => {
       if (delta.length === 0) {
@@ -231,8 +233,9 @@ function patchSlackAdapterStream(adapter: SlackAdapter): void {
  * `buffer_size`, so the SDK waits for 256 characters before it emits the first
  * `chat.startStream`/`chat.appendStream` call. The upstream stream method also
  * withholds plain single-line text until the markdown renderer decides it has a
- * committable prefix. Junior lowers the hidden SDK buffer and eagerly flushes
- * safe plain-text prefixes so Slack threads show visible content sooner.
+ * committable prefix. Junior keeps the upstream table-wrapping setting, lowers
+ * the hidden SDK buffer, and eagerly flushes safe plain-text prefixes so Slack
+ * threads show visible content sooner.
  */
 export function createJuniorSlackAdapter(
   config?: SlackAdapterConfig,

--- a/packages/junior/tests/integration/example-build-discovery.test.ts
+++ b/packages/junior/tests/integration/example-build-discovery.test.ts
@@ -37,8 +37,10 @@ function buildJuniorPackage(): void {
   });
 
   // Re-sync pnpm store so the example app's node_modules/@sentry/junior
-  // points to the freshly built dist, not a stale hardlink.
-  execFileSync("pnpm", ["install"], {
+  // points to the freshly built dist, not a stale hardlink. The relink does
+  // not need workspace prepare hooks, which would rebuild @sentry/junior and
+  // make the full suite timeout-prone.
+  execFileSync("pnpm", ["install", "--ignore-scripts"], {
     cwd: repoRoot,
     env,
     stdio: "pipe",

--- a/packages/junior/tests/integration/oauth-resume-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-resume-slack.test.ts
@@ -89,7 +89,7 @@ describe("oauth resume slack integration", () => {
         }),
       }),
     ]);
-  });
+  }, 10_000);
 
   it("chunks long resumed replies into explicit continuation messages", async () => {
     const { resumeAuthorizedRequest } = await import("@/chat/slack/resume");

--- a/packages/junior/tests/integration/slack/attachment-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/attachment-behavior.test.ts
@@ -15,6 +15,8 @@ async function createRuntime(
   process.env = {
     ...ORIGINAL_ENV,
     AI_VISION_MODEL: "openai/gpt-5.4",
+    SLACK_BOT_TOKEN: "",
+    SLACK_BOT_USER_TOKEN: "",
   };
   vi.resetModules();
   const { createTestChatRuntime } = await import("../../fixtures/chat-runtime");
@@ -107,7 +109,7 @@ describe("Slack behavior: attachment handling", () => {
     expect(capturedAttachmentMediaTypes).toEqual(["image/png"]);
     expect(thread.posts).toHaveLength(1);
     expect(toPostedText(thread.posts[0])).toContain("chart trend is upward");
-  });
+  }, 10_000);
 
   it("posts a fallback error reply when required image analysis fails", async () => {
     const attachmentFetch = vi.fn(async () => Buffer.from("image-bytes"));

--- a/packages/junior/tests/integration/slack/attachment-media-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/attachment-media-behavior.test.ts
@@ -15,6 +15,8 @@ async function createRuntime(
 ) {
   process.env = {
     ...ORIGINAL_ENV,
+    SLACK_BOT_TOKEN: "",
+    SLACK_BOT_USER_TOKEN: "",
     ...env,
   };
   vi.resetModules();
@@ -78,7 +80,9 @@ describe("Slack behavior: mixed attachment media", () => {
       },
     );
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700004010.000" });
+    const thread = createTestThread({
+      id: "slack:C_BEHAVIOR:1700004010.000",
+    });
     const message = createTestMessage({
       id: "m-attachment-mixed-1",
       text: "<@U_APP> summarize these files",
@@ -127,7 +131,7 @@ describe("Slack behavior: mixed attachment media", () => {
       ["image/png", "application/pdf"],
     ]);
     expect(capturedAttachmentNames).toEqual([["chart.png", "incident.pdf"]]);
-  });
+  }, 10_000);
 
   it("drops image attachments when AI_VISION_MODEL is unset", async () => {
     const imageFetch = vi.fn(async () => Buffer.from("image-bytes"));

--- a/packages/junior/tests/integration/slack/bot-image-hydration.test.ts
+++ b/packages/junior/tests/integration/slack/bot-image-hydration.test.ts
@@ -16,6 +16,8 @@ async function createRuntime(
 ) {
   process.env = {
     ...ORIGINAL_ENV,
+    SLACK_BOT_TOKEN: "",
+    SLACK_BOT_USER_TOKEN: "",
     ...env,
   };
   vi.resetModules();

--- a/packages/junior/tests/unit/ingress/junior-chat.test.ts
+++ b/packages/junior/tests/unit/ingress/junior-chat.test.ts
@@ -1,0 +1,62 @@
+import type { Adapter, WebhookOptions } from "chat";
+import { describe, expect, it, vi } from "vitest";
+import { JuniorChat } from "@/chat/ingress/junior-chat";
+
+function createWebhookOptions() {
+  const tasks: Promise<unknown>[] = [];
+  const options: WebhookOptions = {
+    waitUntil(task) {
+      tasks.push(task);
+    },
+  };
+
+  return { options, tasks };
+}
+
+describe("JuniorChat ingress overrides", () => {
+  it("forwards webhook options to action handling", async () => {
+    const handleActionEvent = vi.fn(async () => {});
+    const runtime = {
+      handleActionEvent,
+      logger: { error: vi.fn() },
+    } as unknown as JuniorChat;
+    const { options, tasks } = createWebhookOptions();
+    const event = {
+      actionId: "approve",
+      adapter: { name: "slack" } as Adapter,
+      messageId: "m-action",
+    } as Parameters<JuniorChat["processAction"]>[0];
+
+    const task = JuniorChat.prototype.processAction.call(
+      runtime,
+      event,
+      options,
+    );
+
+    expect(handleActionEvent).toHaveBeenCalledWith(event, options);
+    expect(tasks).toHaveLength(1);
+    await expect(task).resolves.toBeUndefined();
+    await expect(tasks[0]).resolves.toBeUndefined();
+  });
+
+  it("forwards webhook options to slash command handling", async () => {
+    const handleSlashCommandEvent = vi.fn(async () => {});
+    const runtime = {
+      handleSlashCommandEvent,
+      logger: { error: vi.fn() },
+    } as unknown as JuniorChat;
+    const { options, tasks } = createWebhookOptions();
+    const event = {
+      adapter: { name: "slack" } as Adapter,
+      channelId: "C123",
+      command: "/junior",
+      text: "help",
+    } as Parameters<JuniorChat["processSlashCommand"]>[0];
+
+    JuniorChat.prototype.processSlashCommand.call(runtime, event, options);
+
+    expect(handleSlashCommandEvent).toHaveBeenCalledWith(event, options);
+    expect(tasks).toHaveLength(1);
+    await expect(tasks[0]).resolves.toBeUndefined();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^16.4.0
         version: 16.4.0
       prettier:
-        specifier: ^3.8.1
-        version: 3.8.1
+        specifier: ^3.8.3
+        version: 3.8.3
       simple-git-hooks:
         specifier: ^2.13.1
         version: 2.13.1
@@ -28,7 +28,7 @@ importers:
     dependencies:
       "@sentry/junior":
         specifier: workspace:*
-        version: file:packages/junior(@aws-sdk/credential-provider-web-identity@3.972.27)(@sentry/node@10.46.0)
+        version: file:packages/junior(@aws-sdk/credential-provider-web-identity@3.972.27)(@sentry/node@10.48.0)
       "@sentry/junior-agent-browser":
         specifier: workspace:*
         version: link:../../packages/junior-agent-browser
@@ -45,21 +45,21 @@ importers:
         specifier: workspace:*
         version: link:../../packages/junior-sentry
       "@sentry/node":
-        specifier: ^10.46.0
-        version: 10.46.0
+        specifier: ^10.48.0
+        version: 10.48.0
       hono:
-        specifier: ^4.12.9
-        version: 4.12.9
+        specifier: ^4.12.14
+        version: 4.12.14
     devDependencies:
       "@types/node":
-        specifier: ^25.5.0
-        version: 25.5.0
+        specifier: ^25.6.0
+        version: 25.6.0
       jiti:
         specifier: ^2.6.1
         version: 2.6.1
       nitro:
-        specifier: 3.0.260311-beta
-        version: 3.0.260311-beta(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(chokidar@5.0.0)(jiti@2.6.1)(lru-cache@11.2.7)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: 3.0.260415-beta
+        version: 3.0.260415-beta(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(chokidar@5.0.0)(jiti@2.6.1)(lru-cache@11.2.7)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -68,10 +68,10 @@ importers:
     dependencies:
       "@astrojs/check":
         specifier: ^0.9.8
-        version: 0.9.8(prettier@3.8.1)(typescript@5.9.3)
+        version: 0.9.8(prettier@3.8.3)(typescript@5.9.3)
       "@astrojs/starlight":
         specifier: ^0.37.7
-        version: 0.37.7(astro@5.18.1(@types/node@25.5.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
+        version: 0.37.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
       "@fontsource-variable/space-grotesk":
         specifier: ^5.2.10
         version: 5.2.10
@@ -80,16 +80,16 @@ importers:
         version: 5.2.7
       astro:
         specifier: ^5.18.1
-        version: 5.18.1(@types/node@25.5.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       starlight-typedoc:
         specifier: ^0.21.5
-        version: 0.21.5(@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.5.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.18(typescript@5.9.3)))(typedoc@0.28.18(typescript@5.9.3))
+        version: 0.21.5(@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@5.9.3)))(typedoc@0.28.19(typescript@5.9.3))
       typedoc:
-        specifier: ^0.28.18
-        version: 0.28.18(typescript@5.9.3)
+        specifier: ^0.28.19
+        version: 0.28.19(typescript@5.9.3)
       typedoc-plugin-markdown:
         specifier: ^4.11.0
-        version: 4.11.0(typedoc@0.28.18(typescript@5.9.3))
+        version: 4.11.0(typedoc@0.28.19(typescript@5.9.3))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -97,17 +97,17 @@ importers:
   packages/junior:
     dependencies:
       "@ai-sdk/gateway":
-        specifier: ^3.0.83
-        version: 3.0.83(zod@4.3.6)
+        specifier: ^3.0.99
+        version: 3.0.99(zod@4.3.6)
       "@chat-adapter/slack":
-        specifier: 4.23.0
-        version: 4.23.0
+        specifier: 4.26.0
+        version: 4.26.0
       "@chat-adapter/state-memory":
-        specifier: 4.23.0
-        version: 4.23.0
+        specifier: 4.26.0
+        version: 4.26.0
       "@chat-adapter/state-redis":
-        specifier: 4.23.0
-        version: 4.23.0
+        specifier: 4.26.0
+        version: 4.26.0
       "@logtape/logtape":
         specifier: ^2.0.5
         version: 2.0.5
@@ -124,29 +124,29 @@ importers:
         specifier: ^0.34.49
         version: 0.34.49
       "@slack/web-api":
-        specifier: ^7.15.0
-        version: 7.15.0
+        specifier: ^7.15.1
+        version: 7.15.1
       "@vercel/functions":
         specifier: ^3.4.3
         version: 3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27)
       "@vercel/sandbox":
-        specifier: ^1.9.3
-        version: 1.9.3
+        specifier: ^1.10.0
+        version: 1.10.0
       ai:
-        specifier: ^6.0.141
-        version: 6.0.141(zod@4.3.6)
+        specifier: ^6.0.162
+        version: 6.0.162(zod@4.3.6)
       bash-tool:
-        specifier: ^1.3.15
-        version: 1.3.15(@vercel/sandbox@1.9.3)(ai@6.0.141(zod@4.3.6))(just-bash@2.14.0)
+        specifier: ^1.3.16
+        version: 1.3.16(@vercel/sandbox@1.10.0)(ai@6.0.162(zod@4.3.6))(just-bash@2.14.2)
       chat:
-        specifier: 4.23.0
-        version: 4.23.0
+        specifier: 4.26.0
+        version: 4.26.0
       hono:
-        specifier: ^4.12.9
-        version: 4.12.9
+        specifier: ^4.12.14
+        version: 4.12.14
       just-bash:
-        specifier: ^2.14.0
-        version: 2.14.0
+        specifier: ^2.14.2
+        version: 2.14.2
       node-html-markdown:
         specifier: ^2.0.0
         version: 2.0.0
@@ -158,23 +158,23 @@ importers:
         version: 4.3.6
     devDependencies:
       "@sentry/node":
-        specifier: ^10.46.0
-        version: 10.46.0
+        specifier: ^10.48.0
+        version: 10.48.0
       "@types/node":
-        specifier: ^25.5.0
-        version: 25.5.0
+        specifier: ^25.6.0
+        version: 25.6.0
       dependency-cruiser:
         specifier: ^17.3.10
         version: 17.3.10
       msw:
-        specifier: ^2.12.14
-        version: 2.12.14(@types/node@25.5.0)(typescript@5.9.3)
+        specifier: ^2.13.3
+        version: 2.13.3(@types/node@25.6.0)(typescript@5.9.3)
       nitro:
-        specifier: 3.0.260311-beta
-        version: 3.0.260311-beta(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(chokidar@5.0.0)(jiti@2.6.1)(lru-cache@11.2.7)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: 3.0.260415-beta
+        version: 3.0.260415-beta(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(chokidar@5.0.0)(jiti@2.6.1)(lru-cache@11.2.7)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       oxlint:
-        specifier: ^1.58.0
-        version: 1.58.0
+        specifier: ^1.60.0
+        version: 1.60.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@swc/core@1.15.3)(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
@@ -182,22 +182,22 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vercel:
-        specifier: ^50.37.3
-        version: 50.37.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.1)(typescript@5.9.3)
+        specifier: ^51.4.0
+        version: 51.4.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(rollup@4.60.1)(typescript@5.9.3)
       vitest:
-        specifier: ^4.1.2
-        version: 4.1.2(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: ^4.1.4
+        version: 4.1.4(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/junior-agent-browser: {}
 
   packages/junior-evals:
     devDependencies:
       "@ai-sdk/gateway":
-        specifier: ^3.0.83
-        version: 3.0.83(zod@4.3.6)
+        specifier: ^3.0.99
+        version: 3.0.99(zod@4.3.6)
       "@sentry/junior":
         specifier: workspace:*
-        version: file:packages/junior(@aws-sdk/credential-provider-web-identity@3.972.27)(@sentry/node@10.46.0)
+        version: file:packages/junior(@aws-sdk/credential-provider-web-identity@3.972.27)(@sentry/node@10.48.0)
       "@sentry/junior-github":
         specifier: workspace:*
         version: link:../junior-github
@@ -205,17 +205,17 @@ importers:
         specifier: workspace:*
         version: link:../junior-sentry
       chat:
-        specifier: 4.23.0
-        version: 4.23.0
+        specifier: 4.26.0
+        version: 4.26.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: ^4.1.2
-        version: 4.1.2(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: ^4.1.4
+        version: 4.1.4(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       vitest-evals:
         specifier: ^0.7.0
-        version: 0.7.0(ai@6.0.141(zod@4.3.6))(tinyrainbow@3.1.0)(vitest@4.1.2(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(zod@4.3.6)
+        version: 0.7.0(ai@6.0.162(zod@4.3.6))(tinyrainbow@3.1.0)(vitest@4.1.4(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(zod@4.3.6)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -229,19 +229,19 @@ importers:
   packages/junior-sentry: {}
 
 packages:
-  "@ai-sdk/gateway@3.0.83":
+  "@ai-sdk/gateway@3.0.99":
     resolution:
       {
-        integrity: sha512-LvlWujbSdEkTBXBLFtF7GS6riXdHhH0O+DpDrCaNQvXeHmSF2jKsOg7JWXiCgygAHM5cWFAO3JYmZp83DjiuBQ==,
+        integrity: sha512-8/UuzFY8p+T8j4XP/9m841pUb5bhnFt8cecSnJpd2zhBttNZ6GbfjZTmsqnvM/RwJOvzIsdFULZrU+E9QFREsQ==,
       }
     engines: { node: ">=18" }
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  "@ai-sdk/provider-utils@4.0.21":
+  "@ai-sdk/provider-utils@4.0.23":
     resolution:
       {
-        integrity: sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw==,
+        integrity: sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==,
       }
     engines: { node: ">=18" }
     peerDependencies:
@@ -638,28 +638,28 @@ packages:
       }
     engines: { node: ">=18" }
 
-  "@chat-adapter/shared@4.23.0":
+  "@chat-adapter/shared@4.26.0":
     resolution:
       {
-        integrity: sha512-IDHgrAi3Y8Qptl1kd8zmM6jxWX+lu0cq/uZiURv8jONufWHrVwVr19pN0YK52ASnRlLZkcaNYXoa+mLFGQ2tlw==,
+        integrity: sha512-YD0MGktFXrArUqTBsyPfL5vkdD1WBS58PAWO0oVrMQAMmPxpAXfWGjBtZCkf3y8R8Svb0uVuVXiMZSForaEnMQ==,
       }
 
-  "@chat-adapter/slack@4.23.0":
+  "@chat-adapter/slack@4.26.0":
     resolution:
       {
-        integrity: sha512-J5Ml/Ug8Zdb3zVIcbMhkei9U9aTeY+uqpzuuzcHkwdJC6FDFhwj5TSiuocckctqW9tMCqzFl4h4gU5q9f6KSGA==,
+        integrity: sha512-NNN47rURI6qpJf4rRK8xyeumjPTAXr7YSU4/FnViU8cFV/vKYFR4xZTzlFMVWNrYi9SmSwasUjcBmQznigK54Q==,
       }
 
-  "@chat-adapter/state-memory@4.23.0":
+  "@chat-adapter/state-memory@4.26.0":
     resolution:
       {
-        integrity: sha512-IlAVV4MGpjdassiI4haNAzWdFl66xFAfqM5DnWAGZdndkQj0LNMigcxhOgyS++yQUUWWvT1yRKwCswenCvxWVw==,
+        integrity: sha512-FsfyM/A9Bf1yFc1FWmOsK+a4YVwm5FogX25hZxFG6cEvyFb6Cd924SsbtvF06yItY/7J2UFetCsMmBPkdPKshQ==,
       }
 
-  "@chat-adapter/state-redis@4.23.0":
+  "@chat-adapter/state-redis@4.26.0":
     resolution:
       {
-        integrity: sha512-MVOWHz4NjsXc3t7jH5B0juzjCwL7Cn/mz3zblKl6qQxgEIy2rxeP9a+mxvb1KC6zLX1gzKxMOocFEpzjIbotBQ==,
+        integrity: sha512-NSX2E6wkDlg0AMfKFx4LPoV6cBHolL08Ht3cT+S01jss24t9GzlDw/BUsrWOeoTElwEhxZcQw5bUkStUAA7JMg==,
       }
 
   "@ctrl/tinycolor@4.2.0":
@@ -746,10 +746,10 @@ packages:
         integrity: sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==,
       }
 
-  "@emnapi/core@1.9.1":
+  "@emnapi/core@1.9.2":
     resolution:
       {
-        integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==,
+        integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==,
       }
 
   "@emnapi/runtime@1.9.1":
@@ -758,10 +758,16 @@ packages:
         integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==,
       }
 
-  "@emnapi/wasi-threads@1.2.0":
+  "@emnapi/runtime@1.9.2":
     resolution:
       {
-        integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==,
+        integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==,
+      }
+
+  "@emnapi/wasi-threads@1.2.1":
+    resolution:
+      {
+        integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==,
       }
 
   "@esbuild/aix-ppc64@0.25.12":
@@ -1497,10 +1503,10 @@ packages:
       }
     engines: { node: ">=14" }
 
-  "@fastify/otel@0.17.1":
+  "@fastify/otel@0.18.0":
     resolution:
       {
-        integrity: sha512-K4wyxfUZx2ux5o+b6BtTqouYFVILohLZmSbA2tKUueJstNcBnoGPVhllCaOvbQ3ZrXdUxUC/fyrSWSCqHhdOPg==,
+        integrity: sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA==,
       }
     peerDependencies:
       "@opentelemetry/api": ^1.9.0
@@ -1543,12 +1549,6 @@ packages:
     engines: { node: ">=18.14.1" }
     peerDependencies:
       hono: ^4
-
-  "@iarna/toml@2.2.5":
-    resolution:
-      {
-        integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==,
-      }
 
   "@img/colour@1.1.0":
     resolution:
@@ -1993,6 +1993,15 @@ packages:
       "@emnapi/core": ^1.7.1
       "@emnapi/runtime": ^1.7.1
 
+  "@napi-rs/wasm-runtime@1.1.4":
+    resolution:
+      {
+        integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==,
+      }
+    peerDependencies:
+      "@emnapi/core": ^1.7.1
+      "@emnapi/runtime": ^1.7.1
+
   "@nodelib/fs.scandir@2.1.5":
     resolution:
       {
@@ -2046,10 +2055,10 @@ packages:
       }
     engines: { node: ">=8.0.0" }
 
-  "@opentelemetry/api-logs@0.213.0":
+  "@opentelemetry/api-logs@0.214.0":
     resolution:
       {
-        integrity: sha512-zRM5/Qj6G84Ej3F1yt33xBVY/3tnMxtL1fiDIxYbDWYaZ/eudVw3/PBiZ8G7JwUxXxjW8gU4g6LnOyfGKYHYgw==,
+        integrity: sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==,
       }
     engines: { node: ">=8.0.0" }
 
@@ -2076,15 +2085,6 @@ packages:
     peerDependencies:
       "@opentelemetry/api": ">=1.0.0 <1.10.0"
 
-  "@opentelemetry/core@2.6.0":
-    resolution:
-      {
-        integrity: sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==,
-      }
-    engines: { node: ^18.19.0 || >=20.6.0 }
-    peerDependencies:
-      "@opentelemetry/api": ">=1.0.0 <1.10.0"
-
   "@opentelemetry/core@2.6.1":
     resolution:
       {
@@ -2094,199 +2094,190 @@ packages:
     peerDependencies:
       "@opentelemetry/api": ">=1.0.0 <1.10.0"
 
-  "@opentelemetry/instrumentation-amqplib@0.60.0":
+  "@opentelemetry/instrumentation-amqplib@0.61.0":
     resolution:
       {
-        integrity: sha512-q/B2IvoVXRm1M00MvhnzpMN6rKYOszPXVsALi6u0ss4AYHe+TidZEtLW9N1ZhrobI1dSriHnBqqtAOZVAv07sg==,
+        integrity: sha512-mCKoyTGfRNisge4br0NpOFSy2Z1NnEW8hbCJdUDdJFHrPqVzc4IIBPA/vX0U+LUcQqrQvJX+HMIU0dbDRe0i0Q==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
-  "@opentelemetry/instrumentation-connect@0.56.0":
+  "@opentelemetry/instrumentation-connect@0.57.0":
     resolution:
       {
-        integrity: sha512-PKp+sSZ7AfzMvGgO3VCyo1inwNu+q7A1k9X88WK4PQ+S6Hp7eFk8pie+sWHDTaARovmqq5V2osav3lQej2B0nw==,
+        integrity: sha512-FMEBChnI4FLN5TE9DHwfH7QpNir1JzXno1uz/TAucVdLCyrG0jTrKIcNHt/i30A0M2AunNBCkcd8Ei26dIPKdg==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
-  "@opentelemetry/instrumentation-dataloader@0.30.0":
+  "@opentelemetry/instrumentation-dataloader@0.31.0":
     resolution:
       {
-        integrity: sha512-MXHP2Q38cd2OhzEBKAIXUi9uBlPEYzF6BNJbyjUXBQ6kLaf93kRC41vNMIz0Nl5mnuwK7fDvKT+/lpx7BXRwdg==,
+        integrity: sha512-f654tZFQXS5YeLDNb9KySrwtg7SnqZN119FauD7acBoTzuLduaiGTNz88ixcVSOOMGZ+EjJu/RFtx5klObC95g==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
-  "@opentelemetry/instrumentation-express@0.61.0":
+  "@opentelemetry/instrumentation-fs@0.33.0":
     resolution:
       {
-        integrity: sha512-Xdmqo9RZuZlL29Flg8QdwrrX7eW1CZ7wFQPKHyXljNymgKhN1MCsYuqQ/7uxavhSKwAl7WxkTzKhnqpUApLMvQ==,
+        integrity: sha512-sCZWXGalQ01wr3tAhSR9ucqFJ0phidpAle6/17HVjD6gN8FLmZMK/8sKxdXYHy3PbnlV1P4zeiSVFNKpbFMNLA==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
-  "@opentelemetry/instrumentation-fs@0.32.0":
+  "@opentelemetry/instrumentation-generic-pool@0.57.0":
     resolution:
       {
-        integrity: sha512-koR6apx0g0wX6RRiPpjA4AFQUQUbXrK16kq4/SZjVp7u5cffJhNkY4TnITxcGA4acGSPYAfx3NHRIv4Khn1axQ==,
+        integrity: sha512-orhmlaK+ZIW9hKU+nHTbXrCSXZcH83AescTqmpamHRobRmYSQwRbD0a1odc0yAzuzOtxYiHiXAnpnIpaSSY7Ow==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
-  "@opentelemetry/instrumentation-generic-pool@0.56.0":
+  "@opentelemetry/instrumentation-graphql@0.62.0":
     resolution:
       {
-        integrity: sha512-fg+Jffs6fqrf0uQS0hom7qBFKsbtpBiBl8+Vkc63Gx8xh6pVh+FhagmiO6oM0m3vyb683t1lP7yGYq22SiDnqg==,
+        integrity: sha512-3YNuLVPUxafXkH1jBAbGsKNsP3XVzcFDhCDCE3OqBwCwShlqQbLMRMFh1T/d5jaVZiGVmSsfof+ICKD2iOV8xg==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
-  "@opentelemetry/instrumentation-graphql@0.61.0":
+  "@opentelemetry/instrumentation-hapi@0.60.0":
     resolution:
       {
-        integrity: sha512-pUiVASv6nh2XrerTvlbVHh7vKFzscpgwiQ/xvnZuAIzQ5lRjWVdRPUuXbvZJ/Yq79QsE81TZdJ7z9YsXiss1ew==,
+        integrity: sha512-aNljZKYrEa7obLAxd1bCEDxF7kzCLGXTuTJZ8lMR9rIVEjmuKBXN1gfqpm/OB//Zc2zP4iIve1jBp7sr3mQV6w==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
-  "@opentelemetry/instrumentation-hapi@0.59.0":
+  "@opentelemetry/instrumentation-http@0.214.0":
     resolution:
       {
-        integrity: sha512-33wa4mEr+9+ztwdgLor1SeBu4Opz4IsmpcLETXAd3VmBrOjez8uQtrsOhPCa5Vhbm5gzDlMYTgFRLQzf8/YHFA==,
+        integrity: sha512-FlkDhZDRjDJDcO2LcSCtjRpkal1NJ8y0fBqBhTvfAR3JSYY2jAIj1kSS5IjmEBt4c3aWv+u/lqLuoCDrrKCSKg==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
-  "@opentelemetry/instrumentation-http@0.213.0":
+  "@opentelemetry/instrumentation-ioredis@0.62.0":
     resolution:
       {
-        integrity: sha512-B978Xsm5XEPGhm1P07grDoaOFLHapJPkOG9h016cJsyWWxmiLnPu2M/4Nrm7UCkHSiLnkXgC+zVGUAIahy8EEA==,
+        integrity: sha512-ZYt//zcPve8qklaZX+5Z4MkU7UpEkFRrxsf2cnaKYBitqDnsCN69CPAuuMOX6NYdW2rG9sFy7V/QWtBlP5XiNQ==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
-  "@opentelemetry/instrumentation-ioredis@0.61.0":
+  "@opentelemetry/instrumentation-kafkajs@0.23.0":
     resolution:
       {
-        integrity: sha512-hsHDadUtAFbws1YSDc1XW0svGFKiUbqv2td1Cby+UAiwvojm1NyBo/taifH0t8CuFZ0x/2SDm0iuTwrM5pnVOg==,
+        integrity: sha512-4K+nVo+zI+aDz0Z85SObwbdixIbzS9moIuKJaYsdlzcHYnKOPtB7ya8r8Ezivy/GVIBHiKJVq4tv+BEkgOMLaQ==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
-  "@opentelemetry/instrumentation-kafkajs@0.22.0":
+  "@opentelemetry/instrumentation-knex@0.58.0":
     resolution:
       {
-        integrity: sha512-wJU4IBQMUikdJAcTChLFqK5lo+flo7pahqd8DSLv7uMxsdOdAHj6RzKYAm8pPfUS6ItKYutYyuicwKaFwQKsoA==,
+        integrity: sha512-Hc/o8fSsaWxZ8r1Yw4rNDLwTpUopTf4X32y4W6UhlHmW8Wizz8wfhgOKIelSeqFVTKBBPIDUOsQWuIMxBmu8Bw==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
-  "@opentelemetry/instrumentation-knex@0.57.0":
+  "@opentelemetry/instrumentation-koa@0.62.0":
     resolution:
       {
-        integrity: sha512-vMCSh8kolEm5rRsc+FZeTZymWmIJwc40hjIKnXH4O0Dv/gAkJJIRXCsPX5cPbe0c0j/34+PsENd0HqKruwhVYw==,
-      }
-    engines: { node: ^18.19.0 || >=20.6.0 }
-    peerDependencies:
-      "@opentelemetry/api": ^1.3.0
-
-  "@opentelemetry/instrumentation-koa@0.61.0":
-    resolution:
-      {
-        integrity: sha512-lvrfWe9ShK/D2X4brmx8ZqqeWPfRl8xekU0FCn7C1dHm5k6+rTOOi36+4fnaHAP8lig9Ux6XQ1D4RNIpPCt1WQ==,
+        integrity: sha512-uVip0VuGUQXZ+vFxkKxAUNq8qNl+VFlyHDh/U6IQ8COOEDfbEchdaHnpFrMYF3psZRUuoSIgb7xOeXj00RdwDA==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
       "@opentelemetry/api": ^1.9.0
 
-  "@opentelemetry/instrumentation-lru-memoizer@0.57.0":
+  "@opentelemetry/instrumentation-lru-memoizer@0.58.0":
     resolution:
       {
-        integrity: sha512-cEqpUocSKJfwDtLYTTJehRLWzkZ2eoePCxfVIgGkGkb83fMB71O+y4MvRHJPbeV2bdoWdOVrl8uO0+EynWhTEA==,
+        integrity: sha512-6grM3TdMyHzlGY1cUA+mwoPueB1F3dYKgKtZIH6jOFXqfHAByyLTc+6PFjGM9tKh52CFBJaDwodNlL/Td39z7Q==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
-  "@opentelemetry/instrumentation-mongodb@0.66.0":
+  "@opentelemetry/instrumentation-mongodb@0.67.0":
     resolution:
       {
-        integrity: sha512-d7m9QnAY+4TCWI4q1QRkfrc6fo/92VwssaB1DzQfXNRvu51b78P+HJlWP7Qg6N6nkwdb9faMZNBCZJfftmszkw==,
+        integrity: sha512-1WJp5N1lYfHq2IhECOTewFs5Tf2NfUOwQRqs/rZdXKTezArMlucxgzAaqcgp3A3YREXopXTpXHsxZTGHjNhMdQ==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
-  "@opentelemetry/instrumentation-mongoose@0.59.0":
+  "@opentelemetry/instrumentation-mongoose@0.60.0":
     resolution:
       {
-        integrity: sha512-6/jWU+c1NgznkVLDU/2y0bXV2nJo3o9FWZ9mZ9nN6T/JBNRoMnVXZl2FdBmgH+a5MwaWLs5kmRJTP5oUVGIkPw==,
+        integrity: sha512-8BahAZpKsOoc+lrZGb7Ofn4g3z8qtp5IxDfvAVpKXsEheQN7ONMH5djT5ihy6yf8yyeQJGS0gXFfpEAEeEHqQg==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
-  "@opentelemetry/instrumentation-mysql2@0.59.0":
+  "@opentelemetry/instrumentation-mysql2@0.60.0":
     resolution:
       {
-        integrity: sha512-n9/xrVCRBfG9egVbffnlU1uhr+HX0vF4GgtAB/Bvm48wpFgRidqD8msBMiym1kRYzmpWvJqTxNT47u1MkgBEdw==,
+        integrity: sha512-m/5d3bxQALllCzezYDk/6vajh0tj5OijMMvOZGr+qN1NMXm1dzMNwyJ0gNZW7Fo3YFRyj/jJMxIw+W7d525dlw==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
-  "@opentelemetry/instrumentation-mysql@0.59.0":
+  "@opentelemetry/instrumentation-mysql@0.60.0":
     resolution:
       {
-        integrity: sha512-r+V/Fh0sm7Ga8/zk/TI5H5FQRAjwr0RrpfPf8kNIehlsKf12XnvIaZi8ViZkpX0gyPEpLXqzqWD6QHlgObgzZw==,
+        integrity: sha512-08pO8GFPEIz2zquKDGteBZDNmwketdgH8hTe9rVYgW9kCJXq1Psj3wPQGx+VaX4ZJKCfPeoLMYup9+cxHvZyVQ==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
-  "@opentelemetry/instrumentation-pg@0.65.0":
+  "@opentelemetry/instrumentation-pg@0.66.0":
     resolution:
       {
-        integrity: sha512-W0zpHEIEuyZ8zvb3njaX9AAbHgPYOsSWVOoWmv1sjVRSF6ZpBqtlxBWbU+6hhq1TFWBeWJOXZ8nZS/PUFpLJYQ==,
+        integrity: sha512-KxfLGXBb7k2ueaPJfq2GXBDXBly8P+SpR/4Mj410hhNgmQF3sCqwXvUBQxZQkDAmsdBAoenM+yV1LhtsMRamcA==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
-  "@opentelemetry/instrumentation-redis@0.61.0":
+  "@opentelemetry/instrumentation-redis@0.62.0":
     resolution:
       {
-        integrity: sha512-JnPexA034/0UJRsvH96B0erQoNOqKJZjE2ZRSw9hiTSC23LzE0nJE/u6D+xqOhgUhRnhhcPHq4MdYtmUdYTF+Q==,
+        integrity: sha512-y3pPpot7WzR/8JtHcYlTYsyY8g+pbFhAqbwAuG5bLPnR6v6pt1rQc0DpH0OlGP/9CZbWBP+Zhwp9yFoygf/ZXQ==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
-  "@opentelemetry/instrumentation-tedious@0.32.0":
+  "@opentelemetry/instrumentation-tedious@0.33.0":
     resolution:
       {
-        integrity: sha512-BQS6gG8RJ1foEqfEZ+wxoqlwfCAzb1ZVG0ad8Gfe4x8T658HJCLGLd4E4NaoQd8EvPfLqOXgzGaE/2U4ytDSWA==,
+        integrity: sha512-Q6WQwAD01MMTub31GlejoiFACYNw26J426wyjvU7by7fDIr2nZXNW4vhTGs7i7F0TnXBO3xN688g1tdUgYwJ5w==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
-  "@opentelemetry/instrumentation-undici@0.23.0":
+  "@opentelemetry/instrumentation-undici@0.24.0":
     resolution:
       {
-        integrity: sha512-LL0VySzKVR2cJSFVZaTYpZl1XTpBGnfzoQPe2W7McS2267ldsaEIqtQY6VXs2KCXN0poFjze5110PIpxHDaDGg==,
+        integrity: sha512-oKzZ3uvqP17sV0EsoQcJgjEfIp0kiZRbYu/eD8p13Cbahumf8lb/xpYeNr/hfAJ4owzEtIDcGIjprfLcYbIKBQ==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
@@ -2310,10 +2301,10 @@ packages:
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
-  "@opentelemetry/instrumentation@0.213.0":
+  "@opentelemetry/instrumentation@0.214.0":
     resolution:
       {
-        integrity: sha512-3i9NdkET/KvQomeh7UaR/F4r9P25Rx6ooALlWXPIjypcEOUxksCmVu0zA70NBJWlrMW1rPr/LRidFAflLI+s/w==,
+        integrity: sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
@@ -2376,6 +2367,12 @@ packages:
     resolution:
       {
         integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==,
+      }
+
+  "@oxc-project/types@0.124.0":
+    resolution:
+      {
+        integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==,
       }
 
   "@oxc-transform/binding-android-arm-eabi@0.111.0":
@@ -2565,180 +2562,180 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  "@oxlint/binding-android-arm-eabi@1.58.0":
+  "@oxlint/binding-android-arm-eabi@1.60.0":
     resolution:
       {
-        integrity: sha512-1T7UN3SsWWxpWyWGn1cT3ASNJOo+pI3eUkmEl7HgtowapcV8kslYpFQcYn431VuxghXakPNlbjRwhqmR37PFOg==,
+        integrity: sha512-YdeJKaZckDQL1qa62a1aKq/goyq48aX3yOxaaWqWb4sau4Ee4IiLbamftNLU3zbePky6QsDj6thnSSzHRBjDfA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [android]
 
-  "@oxlint/binding-android-arm64@1.58.0":
+  "@oxlint/binding-android-arm64@1.60.0":
     resolution:
       {
-        integrity: sha512-GryzujxuiRv2YFF7bRy8mKcxlbuAN+euVUtGJt9KKbLT8JBUIosamVhcthLh+VEr6KE6cjeVMAQxKAzJcoN7dg==,
+        integrity: sha512-7ANS7PpXCfq84xZQ8E5WPs14gwcuPcl+/8TFNXfpSu0CQBXz3cUo2fDpHT8v8HJN+Ut02eacvMAzTnc9s6X4tw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [android]
 
-  "@oxlint/binding-darwin-arm64@1.58.0":
+  "@oxlint/binding-darwin-arm64@1.60.0":
     resolution:
       {
-        integrity: sha512-7/bRSJIwl4GxeZL9rPZ11anNTyUO9epZrfEJH/ZMla3+/gbQ6xZixh9nOhsZ0QwsTW7/5J2A/fHbD1udC5DQQA==,
+        integrity: sha512-pJsgd9AfplLGBm1fIr25V6V14vMrayhx4uIQvlfH7jWs2SZwSrvi3TfgfJySB8T+hvyEH8K2zXljQiUnkgUnfQ==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [darwin]
 
-  "@oxlint/binding-darwin-x64@1.58.0":
+  "@oxlint/binding-darwin-x64@1.60.0":
     resolution:
       {
-        integrity: sha512-EqdtJSiHweS2vfILNrpyJ6HUwpEq2g7+4Zx1FPi4hu3Hu7tC3znF6ufbXO8Ub2LD4mGgznjI7kSdku9NDD1Mkg==,
+        integrity: sha512-Ue1aXHX49ivwflKqGJc7zcd/LeLgbhaTcDCQStgx5x06AXgjEAZmvrlMuIkWd4AL4FHQe6QJ9f33z04Cg448VQ==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [darwin]
 
-  "@oxlint/binding-freebsd-x64@1.58.0":
+  "@oxlint/binding-freebsd-x64@1.60.0":
     resolution:
       {
-        integrity: sha512-VQt5TH4M42mY20F545G637RKxV/yjwVtKk2vfXuazfReSIiuvWBnv+FVSvIV5fKVTJNjt3GSJibh6JecbhGdBw==,
+        integrity: sha512-YCyQzsQtusQw+gNRW9rRTifSO+Dt/+dtCl2NHoDMZqJlRTEZ/Oht9YnuporI9yiTx7+cB+eqzX3MtHHVHGIWhg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [freebsd]
 
-  "@oxlint/binding-linux-arm-gnueabihf@1.58.0":
+  "@oxlint/binding-linux-arm-gnueabihf@1.60.0":
     resolution:
       {
-        integrity: sha512-fBYcj4ucwpAtjJT3oeBdFBYKvNyjRSK+cyuvBOTQjh0jvKp4yeA4S/D0IsCHus/VPaNG5L48qQkh+Vjy3HL2/Q==,
+        integrity: sha512-c7dxM2Zksa45Qw16i2iGY3Fti2NirJ38FrsBsKw+qcJ0OtqTsBgKJLF0xV+yLG56UH01Z8WRPgsw31e0MoRoGQ==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [linux]
 
-  "@oxlint/binding-linux-arm-musleabihf@1.58.0":
+  "@oxlint/binding-linux-arm-musleabihf@1.60.0":
     resolution:
       {
-        integrity: sha512-0BeuFfwlUHlJ1xpEdSD1YO3vByEFGPg36uLjK1JgFaxFb4W6w17F8ET8sz5cheZ4+x5f2xzdnRrrWv83E3Yd8g==,
+        integrity: sha512-ZWALoA42UYqBEP1Tbw9OWURgFGS1nWj2AAvLdY6ZcGx/Gj93qVCBKjcvwXMupZibYwFbi9s/rzqkZseb/6gVtQ==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [linux]
 
-  "@oxlint/binding-linux-arm64-gnu@1.58.0":
+  "@oxlint/binding-linux-arm64-gnu@1.60.0":
     resolution:
       {
-        integrity: sha512-TXlZgnPTlxrQzxG9ZXU7BNwx1Ilrr17P3GwZY0If2EzrinqRH3zXPc3HrRcBJgcsoZNMuNL5YivtkJYgp467UQ==,
+        integrity: sha512-tpy+1w4p9hN5CicMCxqNy6ymfRtV5ayE573vFNjp1k1TN/qhLFgflveZoE/0++RlkHikBz2vY545NWm/hp7big==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  "@oxlint/binding-linux-arm64-musl@1.58.0":
+  "@oxlint/binding-linux-arm64-musl@1.60.0":
     resolution:
       {
-        integrity: sha512-zSoYRo5dxHLcUx93Stl2hW3hSNjPt99O70eRVWt5A1zwJ+FPjeCCANCD2a9R4JbHsdcl11TIQOjyigcRVOH2mw==,
+        integrity: sha512-eDYDXZGhQAXyn6GwtwiX/qcLS0HlOLPJ/+iiIY8RYr+3P8oKBmgKxADLlniL6FtWfE7pPk7IGN9/xvDEvDvFeg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  "@oxlint/binding-linux-ppc64-gnu@1.58.0":
+  "@oxlint/binding-linux-ppc64-gnu@1.60.0":
     resolution:
       {
-        integrity: sha512-NQ0U/lqxH2/VxBYeAIvMNUK1y0a1bJ3ZicqkF2c6wfakbEciP9jvIE4yNzCFpZaqeIeRYaV7AVGqEO1yrfVPjA==,
+        integrity: sha512-nxehly5XYBHUWI9VJX1bqCf9j/B43DaK/aS/T1fcxCpX3PA4Rm9BB54nPD1CKayT8xg6REN1ao+01hSRNgy8OA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  "@oxlint/binding-linux-riscv64-gnu@1.58.0":
+  "@oxlint/binding-linux-riscv64-gnu@1.60.0":
     resolution:
       {
-        integrity: sha512-X9J+kr3gIC9FT8GuZt0ekzpNUtkBVzMVU4KiKDSlocyQuEgi3gBbXYN8UkQiV77FTusLDPsovjo95YedHr+3yg==,
+        integrity: sha512-j1qf/NaUfOWQutjeoooNG1Q0zsK0XGmSu1uDLq3cctquRF3j7t9Hxqf/76ehCc5GEUAanth2W4Fa+XT1RFg/nw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  "@oxlint/binding-linux-riscv64-musl@1.58.0":
+  "@oxlint/binding-linux-riscv64-musl@1.60.0":
     resolution:
       {
-        integrity: sha512-CDze3pi1OO3Wvb/QsXjmLEY4XPKGM6kIo82ssNOgmcl1IdndF9VSGAE38YLhADWmOac7fjqhBw82LozuUVxD0Q==,
+        integrity: sha512-YELKPRefQ/q/h3RUmeRfPCUhh2wBvgV1RyZ/F9M9u8cDyXsQW2ojv1DeWQTt466yczDITjZnIOg/s05pk7Ve2A==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  "@oxlint/binding-linux-s390x-gnu@1.58.0":
+  "@oxlint/binding-linux-s390x-gnu@1.60.0":
     resolution:
       {
-        integrity: sha512-b/89glbxFaEAcA6Uf1FvCNecBJEgcUTsV1quzrqXM/o4R1M4u+2KCVuyGCayN2UpsRWtGGLb+Ver0tBBpxaPog==,
+        integrity: sha512-JkO3C6Gki7Y6h/MiIkFKvHFOz98/YWvQ4WYbK9DLXACMP2rjULzkeGyAzorJE5S1dzLQGFgeqvN779kSFwoV1g==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  "@oxlint/binding-linux-x64-gnu@1.58.0":
+  "@oxlint/binding-linux-x64-gnu@1.60.0":
     resolution:
       {
-        integrity: sha512-0/yYpkq9VJFCEcuRlrViGj8pJUFFvNS4EkEREaN7CB1EcLXJIaVSSa5eCihwBGXtOZxhnblWgxks9juRdNQI7w==,
+        integrity: sha512-XjKHdFVCpZZZSWBCKyyqCq65s2AKXykMXkjLoKYODrD+f5toLhlwsMESscu8FbgnJQ4Y/dpR/zdazsahmgBJIA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  "@oxlint/binding-linux-x64-musl@1.58.0":
+  "@oxlint/binding-linux-x64-musl@1.60.0":
     resolution:
       {
-        integrity: sha512-hr6FNvmcAXiH+JxSvaJ4SJ1HofkdqEElXICW9sm3/Rd5eC3t7kzvmLyRAB3NngKO2wzXRCAm4Z/mGWfrsS4X8w==,
+        integrity: sha512-js29ZWIuPhNWzY8NC7KoffEMEeWG105vbmm+8EOJsC+T/jHBiKIJEUF78+F/IrgEWMMP9N0kRND4Pp75+xAhKg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  "@oxlint/binding-openharmony-arm64@1.58.0":
+  "@oxlint/binding-openharmony-arm64@1.60.0":
     resolution:
       {
-        integrity: sha512-R+O368VXgRql1K6Xar+FEo7NEwfo13EibPMoTv3sesYQedRXd6m30Dh/7lZMxnrQVFfeo4EOfYIP4FpcgWQNHg==,
+        integrity: sha512-H+PUITKHk04stFpWj3x3Kg08Afp/bcXSBi0EhasR5a0Vw7StXHTzdl655PUI0fB4qdh2Wsu6Dsi+3ACxPoyQnA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [openharmony]
 
-  "@oxlint/binding-win32-arm64-msvc@1.58.0":
+  "@oxlint/binding-win32-arm64-msvc@1.60.0":
     resolution:
       {
-        integrity: sha512-Q0FZiAY/3c4YRj4z3h9K1PgaByrifrfbBoODSeX7gy97UtB7pySPUQfC2B/GbxWU6k7CzQrRy5gME10PltLAFQ==,
+        integrity: sha512-WA/yc7f7ZfCefBXVzNHn1Ztulb1EFwNBb4jMZ6pjML0zz6pHujlF3Q3jySluz3XHl/GNeMTntG1seUBWVMlMag==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [win32]
 
-  "@oxlint/binding-win32-ia32-msvc@1.58.0":
+  "@oxlint/binding-win32-ia32-msvc@1.60.0":
     resolution:
       {
-        integrity: sha512-Y8FKBABrSPp9H0QkRLHDHOSUgM/309a3IvOVgPcVxYcX70wxJrk608CuTg7w+C6vEd724X5wJoNkBcGYfH7nNQ==,
+        integrity: sha512-33YxL1sqwYNZXtn3MD/4dno6s0xeedXOJlT1WohkVD565WvohClZUr7vwKdAk954n4xiEWJkewiCr+zLeq7AeA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ia32]
     os: [win32]
 
-  "@oxlint/binding-win32-x64-msvc@1.58.0":
+  "@oxlint/binding-win32-x64-msvc@1.60.0":
     resolution:
       {
-        integrity: sha512-bCn5rbiz5My+Bj7M09sDcnqW0QJyINRVxdZ65x1/Y2tGrMwherwK/lpk+HRQCKvXa8pcaQdF5KY5j54VGZLwNg==,
+        integrity: sha512-JOro4ZcfBLamJCyfURQmOQByoorgOdx3ZjAkSqnb/CyG/i+lN3KoV5LAgk5ZAW6DPq7/Cx7n23f8DuTWXTWgyQ==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
@@ -2798,10 +2795,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  "@prisma/instrumentation@7.4.2":
+  "@prisma/instrumentation@7.6.0":
     resolution:
       {
-        integrity: sha512-r9JfchJF1Ae6yAxcaLu/V1TGqBhAuSDe3mRNOssBfx1rMzfZ4fdNvrgUBwyb/TNTGXFxlH9AZix5P257x07nrg==,
+        integrity: sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==,
       }
     peerDependencies:
       "@opentelemetry/api": ^1.8
@@ -2939,6 +2936,15 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  "@rolldown/binding-android-arm64@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [android]
+
   "@rolldown/binding-darwin-arm64@1.0.0-rc.1":
     resolution:
       {
@@ -2952,6 +2958,15 @@ packages:
     resolution:
       {
         integrity: sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@rolldown/binding-darwin-arm64@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
@@ -2975,6 +2990,15 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  "@rolldown/binding-darwin-x64@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [darwin]
+
   "@rolldown/binding-freebsd-x64@1.0.0-rc.1":
     resolution:
       {
@@ -2988,6 +3012,15 @@ packages:
     resolution:
       {
         integrity: sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@rolldown/binding-freebsd-x64@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
@@ -3011,6 +3044,15 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [linux]
+
   "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.1":
     resolution:
       {
@@ -3025,6 +3067,16 @@ packages:
     resolution:
       {
         integrity: sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
@@ -3051,6 +3103,16 @@ packages:
     os: [linux]
     libc: [musl]
 
+  "@rolldown/binding-linux-arm64-musl@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12":
     resolution:
       {
@@ -3061,10 +3123,30 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
   "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12":
     resolution:
       {
         integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [s390x]
@@ -3091,6 +3173,16 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  "@rolldown/binding-linux-x64-gnu@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   "@rolldown/binding-linux-x64-musl@1.0.0-rc.1":
     resolution:
       {
@@ -3105,6 +3197,16 @@ packages:
     resolution:
       {
         integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  "@rolldown/binding-linux-x64-musl@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
@@ -3129,6 +3231,15 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  "@rolldown/binding-openharmony-arm64@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [openharmony]
+
   "@rolldown/binding-wasm32-wasi@1.0.0-rc.1":
     resolution:
       {
@@ -3141,6 +3252,14 @@ packages:
     resolution:
       {
         integrity: sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==,
+      }
+    engines: { node: ">=14.0.0" }
+    cpu: [wasm32]
+
+  "@rolldown/binding-wasm32-wasi@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==,
       }
     engines: { node: ">=14.0.0" }
     cpu: [wasm32]
@@ -3158,6 +3277,15 @@ packages:
     resolution:
       {
         integrity: sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [win32]
+
+  "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
@@ -3181,6 +3309,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  "@rolldown/binding-win32-x64-msvc@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [win32]
+
   "@rolldown/pluginutils@1.0.0-rc.1":
     resolution:
       {
@@ -3191,6 +3328,12 @@ packages:
     resolution:
       {
         integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==,
+      }
+
+  "@rolldown/pluginutils@1.0.0-rc.15":
+    resolution:
+      {
+        integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==,
       }
 
   "@rollup/pluginutils@5.3.0":
@@ -3418,10 +3561,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  "@sentry/core@10.46.0":
+  "@sentry/core@10.48.0":
     resolution:
       {
-        integrity: sha512-N3fj4zqBQOhXliS1Ne9euqIKuciHCGOJfPGQLwBoW9DNz03jF+NB8+dUKtrJ79YLoftjVgf8nbgwtADK7NR+2Q==,
+        integrity: sha512-h8F+fXVwYC9ro5ZaO8V+v3vqc0awlXHGblEAuVxSGgh4IV/oFX+QVzXeDTTrFOFS6v/Vn5vAyu240eJrJAS6/g==,
       }
     engines: { node: ">=18" }
 
@@ -3431,16 +3574,17 @@ packages:
     peerDependencies:
       "@sentry/node": ">=10.0.0"
 
-  "@sentry/node-core@10.46.0":
+  "@sentry/node-core@10.48.0":
     resolution:
       {
-        integrity: sha512-gwLGXfkzmiCmUI1VWttyoZBaVp1ItpDKc8AV2mQblWPQGdLSD0c6uKV/FkU291yZA3rXsrLXVwcWoibwnjE2vw==,
+        integrity: sha512-D1TnPhN6vhrRqJ+bN+rdXDM+INibI6lNBm0eGx45zz7DBx9ouq2e9gm/DPx+y/hAkYYq0qTd6x84cGxtVZbKLw==,
       }
     engines: { node: ">=18" }
     peerDependencies:
       "@opentelemetry/api": ^1.9.0
       "@opentelemetry/context-async-hooks": ^1.30.1 || ^2.1.0
       "@opentelemetry/core": ^1.30.1 || ^2.1.0
+      "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1"
       "@opentelemetry/instrumentation": ">=0.57.1 <1"
       "@opentelemetry/resources": ^1.30.1 || ^2.1.0
       "@opentelemetry/sdk-trace-base": ^1.30.1 || ^2.1.0
@@ -3452,6 +3596,8 @@ packages:
         optional: true
       "@opentelemetry/core":
         optional: true
+      "@opentelemetry/exporter-trace-otlp-http":
+        optional: true
       "@opentelemetry/instrumentation":
         optional: true
       "@opentelemetry/resources":
@@ -3461,17 +3607,17 @@ packages:
       "@opentelemetry/semantic-conventions":
         optional: true
 
-  "@sentry/node@10.46.0":
+  "@sentry/node@10.48.0":
     resolution:
       {
-        integrity: sha512-vF+7FrUXEtmYWuVcnvBjlWKeyLw/kwHpwnGj9oUmO/a2uKjDmUr53ZVcapggNxCjivavGYr9uHOY64AGdeUyzA==,
+        integrity: sha512-MzyLJyYmr0Qg60K6NJ2EdwJUX1OuAYXs9tyYxnqVO3nJ8MyYwIcuN4FCYEnXkG6Jiy/4q7OuZgXWnfdQJVcaqw==,
       }
     engines: { node: ">=18" }
 
-  "@sentry/opentelemetry@10.46.0":
+  "@sentry/opentelemetry@10.48.0":
     resolution:
       {
-        integrity: sha512-dzzV2ovruGsx9jzusGGr6cNPvMgYRu2BIrF8aMZ3rkQ1OpPJjPStqtA1l1fw0aoxHOxIjFU7ml4emF+xdmMl3g==,
+        integrity: sha512-Tn6Y0PZjRJ7OW8loK1ntK7wnJnIINnCfSpnwuqow0FMblaDmu5jDVOYq0U1SJBoBcMD5j9aSqrwyj6zqKwjc0A==,
       }
     engines: { node: ">=18" }
     peerDependencies:
@@ -3549,10 +3695,10 @@ packages:
       }
     engines: { node: ">= 12.13.0", npm: ">= 6.12.0" }
 
-  "@slack/web-api@7.15.0":
+  "@slack/web-api@7.15.1":
     resolution:
       {
-        integrity: sha512-va7zYIt3QHG1x9M/jqXXRPFMoOVlVSSRHC5YH+DzKYsrz5xUKOA3lR4THsu/Zxha9N1jOndbKFKLtr0WOPW1Vw==,
+        integrity: sha512-y+TAF7TszcmFzbVtBkFqAdBwKSoD+8shkNxhp4WIfFwXmCKdFje9WD6evROApPa2FTy1v1uc9yBaJs3609PPgg==,
       }
     engines: { node: ">= 18", npm: ">= 8.6.0" }
 
@@ -4143,10 +4289,10 @@ packages:
         integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==,
       }
 
-  "@types/node@25.5.0":
+  "@types/node@25.6.0":
     resolution:
       {
-        integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==,
+        integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==,
       }
 
   "@types/pg-pool@2.0.7":
@@ -4203,10 +4349,10 @@ packages:
         integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==,
       }
 
-  "@vercel/backends@0.0.53":
+  "@vercel/backends@0.0.62":
     resolution:
       {
-        integrity: sha512-f8JK9Jatlco6kT/NsLYVR88iqS7oZxUXzXW8TofLmyTT5o+OEXSY2hzAQSjul6r0qz/9yAhtQkMhcHG8Ne01ZQ==,
+        integrity: sha512-jNaJ4GEQaBapah8XWlGCF2TF8ceEizAk4DunuKVKK2oO3vFx2i6RpHaxZCyOVRAJVgjJQaNqsIS7IYAIVfmGpw==,
       }
     peerDependencies:
       typescript: ^4.0.0 || ^5.0.0
@@ -4218,32 +4364,32 @@ packages:
       }
     engines: { node: ">=20.0.0" }
 
-  "@vercel/build-utils@13.12.0":
+  "@vercel/build-utils@13.17.0":
     resolution:
       {
-        integrity: sha512-GnavaJQPt1tm9qxFdghMsN1Sf2P+Bo3fIG3iEKJBuYTLahWm17AZrH+/Hh1A+R3nRgS3De5BJ2/fDgh0VV2QZA==,
+        integrity: sha512-iF9DLJqfwKSHJIgOXEZG9N7kqO5RL5gN5VLQpXYa0ULPUWP648Rru0ETUaFr+FmUJLRbSorZ0bCyZgzR7yPYDg==,
       }
 
-  "@vercel/cervel@0.0.40":
+  "@vercel/cervel@0.0.49":
     resolution:
       {
-        integrity: sha512-5eY17uPXU6Mhn6lh8HIKyOLkhVr826D7G0CeVIujzsMfiGZjWIYc9udbXLGqikgBucvH9PwkxRQuCXI10jBzIw==,
+        integrity: sha512-3P67TmBFVfBGyDLSJbdJQgswTCVI1aZ6I//ab1XoKsizP2m5v0woNZmi0DfyvOSep4WKq/jtjBFLqP6TmR/Kvw==,
       }
     hasBin: true
     peerDependencies:
       typescript: ^4.0.0 || ^5.0.0
 
-  "@vercel/detect-agent@1.2.1":
+  "@vercel/detect-agent@1.2.2":
     resolution:
       {
-        integrity: sha512-U/BJCltQSTFTHwaiCQQTQG3GonTbRoEewjV+OU2mMjcHLAoPOh6CP1SXA2XNmqiqI3c82nkRNJ7piZ14RqmTXw==,
+        integrity: sha512-bKhhKKPuI37oMUlMA90eplt+QSp8T/t2WDfF+CP9PBA/YTkCADI8D/dECB5sJa9BWxq3+jxO52UsDy0F7Gl51g==,
       }
     engines: { node: ">=14" }
 
-  "@vercel/elysia@0.1.55":
+  "@vercel/elysia@0.1.65":
     resolution:
       {
-        integrity: sha512-LKXOglYMdihN4CKMFZsuf9Oa7ymO1YEWQUdey61fe4qcJzywrEJD70ZFO0bNuRtXMn7Gf0iiGXKmPIPBUklH1g==,
+        integrity: sha512-be8htYrWJS2/4Ac8LbnKnXj/K3b5RES4/UcOx5TtK/DgDSx8xBFpjOz0ae7UKJtGpNo5G67YWu9CEh7ZssX/ZA==,
       }
 
   "@vercel/error-utils@2.0.3":
@@ -4252,16 +4398,16 @@ packages:
         integrity: sha512-CqC01WZxbLUxoiVdh9B/poPbNpY9U+tO1N9oWHwTl5YAZxcqXmmWJ8KNMFItJCUUWdY3J3xv8LvAuQv2KZ5YdQ==,
       }
 
-  "@vercel/express@0.1.65":
+  "@vercel/express@0.1.75":
     resolution:
       {
-        integrity: sha512-hTCTKv7XZJ+SDOpyPBrneX+Qq7tV1WiWmA2sr2/foMb36M4JYexn4OxcGyXQrLEntAVMPg+tp4dHHL/cW/XUeg==,
+        integrity: sha512-QPx3uT9iZUIfJqDygC5v0PaFmMxC4Azq4q9UME1+TfEawBMhwEJxjHaTjVjEiPQbNGO6dYzm08vLcbQrL4O89g==,
       }
 
-  "@vercel/fastify@0.1.58":
+  "@vercel/fastify@0.1.68":
     resolution:
       {
-        integrity: sha512-QRuhhcPneqOvHEUT5He3gGSEkH7JTqNhSIQG298mLEx2fL8OfVJHLHq/50GHVBhRLzIkFA2lfLQbRuwqRSyDvA==,
+        integrity: sha512-p6PT0zI2ewSutMAkcfM1N3x5vI7vk8FrFUfb3kC977So2IvB5l6FKC3b5u3tkTZy119EGPMQn7hqmsdx0gK+Ew==,
       }
 
   "@vercel/fun@1.3.0":
@@ -4289,28 +4435,28 @@ packages:
         integrity: sha512-iTEA0vY6RBPuEzkwUTVzSHDATo1aF6bdLLspI68mQ/BTbi5UQEGjpjyzdKOVcSYApDtFU6M6vypZ1t4vIEnHvw==,
       }
 
-  "@vercel/gatsby-plugin-vercel-builder@2.1.6":
+  "@vercel/gatsby-plugin-vercel-builder@2.1.15":
     resolution:
       {
-        integrity: sha512-Lh0wbhs7WR/h05iBPqaoxVDY5Ut4/GgLlO15H8TUIonZZcAfHD1gm5owdyLIPwOTGvtz3qoxxsgc0hSMo/zCkw==,
+        integrity: sha512-mS8GNNXZ1AxQzHKzMsdh6WRh8ws1nKdAD9pi2FNZnp5ISpifiF4v51nbu9ECEpHGG+Pb/khWMIlcvU2DlPqZDQ==,
       }
 
-  "@vercel/go@3.4.6":
+  "@vercel/go@3.5.0":
     resolution:
       {
-        integrity: sha512-ig91qRY+f4lLXWoRvnhEvu5DcT7LXtALBo/jJqxvlyOsHRBP4mdAvUgg9sygu2NOeMSV/cy249yJqQniP32HWw==,
+        integrity: sha512-xMHQLqQiEfK+YJlC5eJ4S/1E4fBEUAf1u2DwQYsZlS3rLlHVqTOcZ973Z+wZV5pr4/d3vvpgB4/GQ0eqdig0jw==,
       }
 
-  "@vercel/h3@0.1.64":
+  "@vercel/h3@0.1.74":
     resolution:
       {
-        integrity: sha512-zH57M8boAs+YKbT0gtnnq4aBYNKjpXwd1p7h8PlnH3MrQmAAapwb9SCAndRLu8STJSUCsYbT/JLk66rWLTMXNQ==,
+        integrity: sha512-xkj8XkDHudMTPhtlIk5LrfZhq04K0n5wmsGvJOL15BRGwR9JQeUVb4AtoZi476iRgINxhVw0DSsubWMKPHvZSQ==,
       }
 
-  "@vercel/hono@0.2.58":
+  "@vercel/hono@0.2.68":
     resolution:
       {
-        integrity: sha512-yOxq0aGAi5SxFagN/uKgksSv1eNj3NqosZdbhzwd3fRVttGFBloaGuDjNFG1hq/J5O6gm/tRYrLt99amIkINjQ==,
+        integrity: sha512-sit7eUiczfx2a43FGu6FoA2zmNBY17eVC2yQo7GDcAQCzkNpO1dxwCcmiWgj5h5T7Z0VmPkOq89JpGzX6GEiog==,
       }
 
   "@vercel/hydrogen@1.3.6":
@@ -4319,22 +4465,22 @@ packages:
         integrity: sha512-Ec8dKEjGIM4BfThcRLtQs5zaJ4+iJbgLZwkytwi7Blk8VrK6W2F1dtLDmVQYZdVnQcnmHmTx8mxUuMkfP06Mnw==,
       }
 
-  "@vercel/koa@0.1.38":
+  "@vercel/koa@0.1.48":
     resolution:
       {
-        integrity: sha512-Xtnw41TPf84l/tL7eg4ktciBdAJoNZBDZ4lVCZL4/RCVxL4cTr0moC+yRiJ6nC7/eT3leml6ni1eOvG2479kBw==,
+        integrity: sha512-XL0FlLn6oZMObUTMfH7YOn1/up2SXLo9l1L+dK27Sb2VbYFlz6OoLRarS3bOtwvG2+5DdswznrIoeoYUkQT9QA==,
       }
 
-  "@vercel/nestjs@0.2.59":
+  "@vercel/nestjs@0.2.69":
     resolution:
       {
-        integrity: sha512-0LbEeFqMSUPU/2nd1alZYkEpDNq+4WU1G00ROhKAXbfap/s6ChcbBKG9Xi86jUTRJ4ntoIf6PGzlhY03bjlwcA==,
+        integrity: sha512-qYq9VVkEdwwde8e3MlLjRMe5J0HMaZGjIqCtRZprI2SkvmeRXwxVTGVoVVueFztI3X8yEhV2xyAD6srSO8vHrA==,
       }
 
-  "@vercel/next@4.16.3":
+  "@vercel/next@4.16.8":
     resolution:
       {
-        integrity: sha512-yVLrMxMI+Taq47C94lWVUf981WerJ+COrJbgltHcMY8HDdXdgthYe06+na3dni31AL6BYShS8VLpE54QsAdM9Q==,
+        integrity: sha512-buiiOH7t8afdBHcF9vdIZ9z4LwA5hcTS9AUq6UlSY7qbKeeRUIgSVdz8QrYNvHhKMj/CAaTB92C/k25u9U9Muw==,
       }
 
   "@vercel/nft@1.5.0":
@@ -4345,10 +4491,10 @@ packages:
     engines: { node: ">=20" }
     hasBin: true
 
-  "@vercel/node@5.6.22":
+  "@vercel/node@5.7.7":
     resolution:
       {
-        integrity: sha512-Lu6ToUYz8oMdYwN+6OR9KCh2MbkAloBu5YFKlEmIc51Je9Q21W/kqBneA3ZuWlMMpYHstz1E19GL+tqHb7yFdw==,
+        integrity: sha512-pnFB7ja1NJAHhFeArwb9vuYGehNQc9Lip4DjYmDthzRbheuzMwzN3y5H5pu7mDzGgEHTlsS6bs3aiOVbFS4dQw==,
       }
 
   "@vercel/oidc@3.1.0":
@@ -4377,10 +4523,10 @@ packages:
         integrity: sha512-gsoj+nscmNm0xDh+tRhECRhit2VlAVaD7jc9h93sN6rDEBDxPo7eLEgIJFzVDaAItxERZ9Od2IK/04fB9vFy+g==,
       }
 
-  "@vercel/python@6.28.0":
+  "@vercel/python@6.33.0":
     resolution:
       {
-        integrity: sha512-/Ley7HPz/AXhxO7unK5+4hEtsMUxXa02SJ8Tiaz//nEtRQMUcVREIyAUkOOfecjiCpg2hMHSVyCtABFjhzAbgA==,
+        integrity: sha512-n9x0bs1oHFyG/IOcAnuGRhOqZ4M82a0pqzZZOL6RvuCYDwUwjokX2kj4hxTtnAkDjtzgFnXaUzz/kIkoAdguMA==,
       }
 
   "@vercel/redwood@2.4.12":
@@ -4401,22 +4547,28 @@ packages:
         integrity: sha512-okIgMmPEePyDR9TZYaKM4oftcxVHM5Dbdl7V/tIdh3lq8MGLi7HR5vvQglmZUwZOeovE6MVtezxl960EOzeIiQ==,
       }
 
-  "@vercel/rust@1.0.5":
+  "@vercel/rust@1.1.0":
     resolution:
       {
-        integrity: sha512-Y03g59nv1uT6Da+PvB/50WqJSHlaFZ9MSkG00R82dUcTySslMbQdOeaXymZtabrmU8zQYhWDb1/CwBki8sWnaQ==,
+        integrity: sha512-dgiLWA3l+4IFk1jg65aABfmRqO2eJdk6vZsNvONhD8Lkpn8i1WrGJ0ggVjD7I/MR9rNxSs4zyfIgpKYv5FFqWw==,
       }
 
-  "@vercel/sandbox@1.9.3":
+  "@vercel/sandbox@1.10.0":
     resolution:
       {
-        integrity: sha512-G6ef1izdlYftkmv2xxBfks76gm2oxIH3LgiASe8WMw7xoge6zFzyFjY91/dPMT0Pkd4UNX9nsaOedj98ywdk8Q==,
+        integrity: sha512-rGA8KJB5ZwQeygzsndgrbHsys3HGWKHQaRQlmyIEHce2BFuTfQUgivHDj5DCZhWiyjjSEodLHpoJkZBd95K0/Q==,
       }
 
-  "@vercel/static-build@2.9.6":
+  "@vercel/sandbox@1.9.0":
     resolution:
       {
-        integrity: sha512-XBUHUuYNfRi2JVPJF1lx+etTQhfVFVzAW3e8/5Aw/kKtfT1fDLc+uR/fadWlCC+ezXUcyV/h25O5nAk3g3vBaA==,
+        integrity: sha512-zgr1ad0tkT1xZn/8Vxo60wOUOLqMAVGo4WqJQ8/UDcUtWynNJsBjI2tiMdWZrAo9EKH1MIqEzJNkcclF0UT1EQ==,
+      }
+
+  "@vercel/static-build@2.9.15":
+    resolution:
+      {
+        integrity: sha512-fNIjkC3AtLdOCsGezXEbrmXR4KEr2sQnJMA9JpDEofK6qBH8Pvw1RWkAyqizzuMebNNSv1vemCa+r2sCJtpksw==,
       }
 
   "@vercel/static-config@3.2.0":
@@ -4425,16 +4577,16 @@ packages:
         integrity: sha512-UpOEIgWxWx0M+mDe1IMdHS6JuWM/L5nNIJ4ixX8v9JgBAejymo88OkgnmfLCNMem0Wd+b5vcQPWLdZybCndlsA==,
       }
 
-  "@vitest/expect@4.1.2":
+  "@vitest/expect@4.1.4":
     resolution:
       {
-        integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==,
+        integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==,
       }
 
-  "@vitest/mocker@4.1.2":
+  "@vitest/mocker@4.1.4":
     resolution:
       {
-        integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==,
+        integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==,
       }
     peerDependencies:
       msw: ^2.4.9
@@ -4445,34 +4597,34 @@ packages:
       vite:
         optional: true
 
-  "@vitest/pretty-format@4.1.2":
+  "@vitest/pretty-format@4.1.4":
     resolution:
       {
-        integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==,
+        integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==,
       }
 
-  "@vitest/runner@4.1.2":
+  "@vitest/runner@4.1.4":
     resolution:
       {
-        integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==,
+        integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==,
       }
 
-  "@vitest/snapshot@4.1.2":
+  "@vitest/snapshot@4.1.4":
     resolution:
       {
-        integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==,
+        integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==,
       }
 
-  "@vitest/spy@4.1.2":
+  "@vitest/spy@4.1.4":
     resolution:
       {
-        integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==,
+        integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==,
       }
 
-  "@vitest/utils@4.1.2":
+  "@vitest/utils@4.1.4":
     resolution:
       {
-        integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==,
+        integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==,
       }
 
   "@volar/kit@2.4.28":
@@ -4603,10 +4755,10 @@ packages:
       }
     hasBin: true
 
-  ai@6.0.141:
+  ai@6.0.162:
     resolution:
       {
-        integrity: sha512-+GomGQWaId3xN0wcugUW/H7xMMaFkID2PiS7K/Wugj45G3efv0BXhQ3psRZoQVoRbOpdNoUqcK/KTB+FR4h6qg==,
+        integrity: sha512-1PSvNEK1PEbpUXahnFrcey6l7DJXMVWmg0ibQ8h8oMSe9V1Vx5d+R3xNu0hzBtwqfxYj21ddZo+EUYVs6GOEyA==,
       }
     engines: { node: ">=18" }
     peerDependencies:
@@ -4645,13 +4797,6 @@ packages:
       {
         integrity: sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==,
       }
-
-  amdefine@1.0.1:
-    resolution:
-      {
-        integrity: sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==,
-      }
-    engines: { node: ">=0.4.2" }
 
   ansi-align@3.0.1:
     resolution:
@@ -4717,12 +4862,6 @@ packages:
     resolution:
       {
         integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==,
-      }
-
-  argparse@1.0.10:
-    resolution:
-      {
-        integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==,
       }
 
   argparse@2.0.1:
@@ -4820,10 +4959,10 @@ packages:
         integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==,
       }
 
-  axios@1.14.0:
+  axios@1.15.0:
     resolution:
       {
-        integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==,
+        integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==,
       }
 
   axobject-query@4.1.0:
@@ -4886,10 +5025,10 @@ packages:
         integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==,
       }
 
-  bash-tool@1.3.15:
+  bash-tool@1.3.16:
     resolution:
       {
-        integrity: sha512-rsUxbwTO1qU9LxLhsqu7d5MfoJAqWgw0+E1uDEHLxrZRcXXayZspgiqTSXwGM2yuCz6N42duMdbF95o5ZSw8lQ==,
+        integrity: sha512-2xuprVBzUOYw4+QCpeSwvkuXuHkjKRtMzh+nTpEidROsNnglr5xRs3mdeOmwFVkjB4JhE/uZqIXE+tabbJI7QQ==,
       }
     engines: { node: ">=18" }
     peerDependencies:
@@ -5112,10 +5251,10 @@ packages:
         integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==,
       }
 
-  chat@4.23.0:
+  chat@4.26.0:
     resolution:
       {
-        integrity: sha512-Gmw8yyDrrH9Vxs+TfxF7FoTENrCzJV4T0FiAh7APGcQPhMMYAhrpq66PKj8azhkUSEyaen8ujbneogoJWiY8vg==,
+        integrity: sha512-QToDnIEGpyb8yQA6YLMHOSRK30YVk4RtsyFyuWFYyB2c4jQlyIrSWtwVK7qyvmvqzQp9uDwCdJRAhS8GtCHAGQ==,
       }
 
   chokidar@4.0.0:
@@ -5284,17 +5423,17 @@ packages:
         integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==,
       }
 
-  commander@2.8.1:
-    resolution:
-      {
-        integrity: sha512-+pJLBFVk+9ZZdlAOB5WuIElVPPth47hILFkmGym57aq8kwxsowvByvB0DHs1vQAhyMZzdcpTtF0VDKGkSDR4ZQ==,
-      }
-    engines: { node: ">= 0.6.x" }
-
   commander@4.1.1:
     resolution:
       {
         integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==,
+      }
+    engines: { node: ">= 6" }
+
+  commander@6.2.1:
+    resolution:
+      {
+        integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==,
       }
     engines: { node: ">= 6" }
 
@@ -5303,13 +5442,6 @@ packages:
       {
         integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==,
       }
-
-  compressjs@1.0.3:
-    resolution:
-      {
-        integrity: sha512-jpKJjBTretQACTGLNuvnozP1JdP2ZLrjdGdBgk/tz1VfXlUcBhhSZW6vEsuThmeot/yjvSrPQKEgfF3X2Lpi8Q==,
-      }
-    hasBin: true
 
   concat-map@0.0.1:
     resolution:
@@ -5417,13 +5549,13 @@ packages:
         integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==,
       }
 
-  crossws@0.4.4:
+  crossws@0.4.5:
     resolution:
       {
-        integrity: sha512-w6c4OdpRNnudVmcgr7brb/+/HmYjMQvYToO/oTrprTwxRUiom3LYWU1PMWuD006okbUWpII1Ea9/+kwpUfmyRg==,
+        integrity: sha512-wUR89x/Rw7/8t+vn0CmGDYM9TD6VtARGb0LD5jq2wjtMy1vCP4M+sm6N6TigWeTYvnA8MoW29NqqXD0ep0rfBA==,
       }
     peerDependencies:
-      srvx: ">=0.7.1"
+      srvx: ">=0.11.5"
     peerDependenciesMeta:
       srvx:
         optional: true
@@ -6087,13 +6219,6 @@ packages:
         integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==,
       }
 
-  extend-shallow@2.0.1:
-    resolution:
-      {
-        integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==,
-      }
-    engines: { node: ">=0.10.0" }
-
   extend@3.0.2:
     resolution:
       {
@@ -6445,25 +6570,12 @@ packages:
         integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
       }
 
-  graceful-readlink@1.0.1:
-    resolution:
-      {
-        integrity: sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==,
-      }
-
   graphql@16.13.2:
     resolution:
       {
         integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==,
       }
     engines: { node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0 }
-
-  gray-matter@4.0.3:
-    resolution:
-      {
-        integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==,
-      }
-    engines: { node: ">=6.0" }
 
   h3@1.15.10:
     resolution:
@@ -6645,17 +6757,17 @@ packages:
         integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==,
       }
 
-  hono@4.12.9:
+  hono@4.12.14:
     resolution:
       {
-        integrity: sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==,
+        integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==,
       }
     engines: { node: ">=16.9.0" }
 
-  hookable@6.1.0:
+  hookable@6.1.1:
     resolution:
       {
-        integrity: sha512-ZoKZSJgu8voGK2geJS+6YtYjvIzu9AOM/KZXsBxr83uhLL++e9pEv/dlgwgy3dvHg06kTz6JOh1hk3C8Ceiymw==,
+        integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==,
       }
 
   html-escaper@3.0.3:
@@ -6887,13 +6999,6 @@ packages:
         integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==,
       }
 
-  is-extendable@0.1.1:
-    resolution:
-      {
-        integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==,
-      }
-    engines: { node: ">=0.10.0" }
-
   is-extglob@2.1.1:
     resolution:
       {
@@ -7022,13 +7127,6 @@ packages:
       }
     engines: { node: ">=10" }
 
-  js-yaml@3.14.2:
-    resolution:
-      {
-        integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==,
-      }
-    hasBin: true
-
   js-yaml@4.1.1:
     resolution:
       {
@@ -7105,10 +7203,10 @@ packages:
         integrity: sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==,
       }
 
-  just-bash@2.14.0:
+  just-bash@2.14.2:
     resolution:
       {
-        integrity: sha512-hiwsAa7OugRX5/fHhRijpyASioZ/UGjt/fjS15DQmrcFJmsBFabefZogdBJifw0WJUVqUiqATVRbhcwKScrD3w==,
+        integrity: sha512-9Na1rH03Ta5ydHTNotJ7dms1iZwb2kToOnKbnS29AlrCvi1CQ21Fm2lfu4S4rfwDGHYi4E4evgTDC/DcDx8tuQ==,
       }
     hasBin: true
 
@@ -7123,13 +7221,6 @@ packages:
       {
         integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==,
       }
-
-  kind-of@6.0.3:
-    resolution:
-      {
-        integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==,
-      }
-    engines: { node: ">=0.10.0" }
 
   kleur@3.0.3:
     resolution:
@@ -7933,10 +8024,10 @@ packages:
         integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
       }
 
-  msw@2.12.14:
+  msw@2.13.3:
     resolution:
       {
-        integrity: sha512-4KXa4nVBIBjbDbd7vfQNuQ25eFxug0aropCQFoI0JdOBuJWamkT1yLVIWReFI8SiTRc+H1hKzaNk+cLk2N9rtQ==,
+        integrity: sha512-/F49bxavkNGfreMlrKmTxZs6YorjfMbbDLd89Q3pWi+cXGtQQNXXaHt4MkXN7li91xnQJ24HWXqW9QDm5id33w==,
       }
     engines: { node: ">=18" }
     hasBin: true
@@ -8000,28 +8091,31 @@ packages:
       }
     engines: { node: ">= 0.4.0" }
 
-  nf3@0.3.14:
+  nf3@0.3.16:
     resolution:
       {
-        integrity: sha512-MjG9u/IlvSq5txxY0oug1sjrGZ2l37IuhExI1iPuwV4S3RcyRNGoy6xLwznH3ATK6PUAM4fbQVb4Rzy1L1nlzw==,
+        integrity: sha512-Gs0xRPpUm2nDkqbi40NJ9g7qDIcjcJzgExiydnq6LAyqhI2jfno8wG3NKTL+IiJsx799UHOb1CnSd4Wg4SG4Pw==,
       }
 
-  nitro@3.0.260311-beta:
+  nitro@3.0.260415-beta:
     resolution:
       {
-        integrity: sha512-0o0fJ9LUh4WKUqJNX012jyieUOtMCnadkNDWr0mHzdraoHpJP/1CGNefjRyZyMXSpoJfwoWdNEZu2iGf35TUvQ==,
+        integrity: sha512-J0ntJERWtIdvweZdmkCiF8eOFvP9fIAJR2gpeIDrHbAlYavK41WQfADo/YoZ/LF7RMTZBiPaH/pt2s/nPru9Iw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
     peerDependencies:
+      "@vercel/queue": ^0.1.4
       dotenv: "*"
       giget: "*"
       jiti: ^2.6.1
-      rollup: ^4.59.0
-      vite: ^7 || ^8 || >=8.0.0-0
+      rollup: ^4.60.1
+      vite: ^7 || ^8
       xml2js: ^0.6.2
-      zephyr-agent: ^0.1.15
+      zephyr-agent: ^0.2.0
     peerDependenciesMeta:
+      "@vercel/queue":
+        optional: true
       dotenv:
         optional: true
       giget:
@@ -8300,10 +8394,10 @@ packages:
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
 
-  oxlint@1.58.0:
+  oxlint@1.60.0:
     resolution:
       {
-        integrity: sha512-t4s9leczDMqlvOSjnbCQe7gtoLkWgBGZ7sBdCJ9EOj5IXFSG/X7OAzK4yuH4iW+4cAYe8kLFbC8tuYMwWZm+Cg==,
+        integrity: sha512-tnRzTWiWJ9pg3ftRWnD0+Oqh78L6ZSwcEudvCZaER0PIqiAnNyXj5N1dPwjmNpDalkKS9m/WMLN1CTPUBPmsgw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
@@ -8669,10 +8763,10 @@ packages:
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
-  prettier@3.8.1:
+  prettier@3.8.3:
     resolution:
       {
-        integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==,
+        integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==,
       }
     engines: { node: ">=14" }
     hasBin: true
@@ -9113,10 +9207,10 @@ packages:
       }
     engines: { node: ">= 4" }
 
-  rettime@0.10.1:
+  rettime@0.11.7:
     resolution:
       {
-        integrity: sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==,
+        integrity: sha512-DoAm1WjR1eH7z8sHPtvvUMIZh4/CSKkGCz6CxPqOrEAnOGtOuHSnSE9OC+razqxKuf4ub7pAYyl/vZV0vGs5tg==,
       }
 
   reusify@1.1.0:
@@ -9144,6 +9238,14 @@ packages:
     resolution:
       {
         integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    hasBin: true
+
+  rolldown@1.0.0-rc.15:
+    resolution:
+      {
+        integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
@@ -9193,6 +9295,13 @@ packages:
         integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
       }
 
+  sandbox@2.5.6:
+    resolution:
+      {
+        integrity: sha512-tnFr7nyiuEhsAGb+xy60SDbij0790X+FgDljh3J/2HaRM6yQgNJkQKHbDH8ld7mR+PozXGgEfJ2Dc/5OyFnwsg==,
+      }
+    hasBin: true
+
   sax@1.6.0:
     resolution:
       {
@@ -9200,12 +9309,12 @@ packages:
       }
     engines: { node: ">=11.0.0" }
 
-  section-matter@1.0.0:
+  seek-bzip@2.0.0:
     resolution:
       {
-        integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==,
+        integrity: sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg==,
       }
-    engines: { node: ">=4" }
+    hasBin: true
 
   semver@6.3.1:
     resolution:
@@ -9452,12 +9561,6 @@ packages:
         integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==,
       }
 
-  sprintf-js@1.0.3:
-    resolution:
-      {
-        integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==,
-      }
-
   sprintf-js@1.1.3:
     resolution:
       {
@@ -9470,10 +9573,10 @@ packages:
         integrity: sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==,
       }
 
-  srvx@0.11.14:
+  srvx@0.11.15:
     resolution:
       {
-        integrity: sha512-mx+pKrWJCzo5m6uXqyB7n4VA81mpdFRroSWsVTQTYqCZE65hFJ+jtVIeyhtL2/kvtDMrHdbA0hWEUh/vu0+Viw==,
+        integrity: sha512-iXsux0UcOjdvs0LCMa2Ws3WwcDUozA3JN3BquNXkaFPP7TpRqgunKdEgoZ/uwb1J6xaYHfxtz9Twlh6yzwM6Tg==,
       }
     engines: { node: ">=20.16.0" }
     hasBin: true
@@ -9612,13 +9715,6 @@ packages:
         integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==,
       }
     engines: { node: ">=12" }
-
-  strip-bom-string@1.0.0:
-    resolution:
-      {
-        integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==,
-      }
-    engines: { node: ">=0.10.0" }
 
   strip-bom@3.0.0:
     resolution:
@@ -10026,10 +10122,10 @@ packages:
     peerDependencies:
       typedoc: 0.28.x
 
-  typedoc@0.28.18:
+  typedoc@0.28.19:
     resolution:
       {
-        integrity: sha512-NTWTUOFRQ9+SGKKTuWKUioUkjxNwtS3JDRPVKZAXGHZy2wCA8bdv2iJiyeePn0xkmK+TCCqZFT0X7+2+FLjngA==,
+        integrity: sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==,
       }
     engines: { node: ">= 18", pnpm: ">= 10" }
     hasBin: true
@@ -10105,10 +10201,10 @@ packages:
         integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==,
       }
 
-  undici-types@7.18.2:
+  undici-types@7.19.2:
     resolution:
       {
-        integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==,
+        integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==,
       }
 
   undici@5.28.4:
@@ -10391,10 +10487,10 @@ packages:
       }
     engines: { node: ">= 0.8" }
 
-  vercel@50.37.3:
+  vercel@51.4.0:
     resolution:
       {
-        integrity: sha512-ARHoIjLrCsdrXx3uJ3m7CifCE7NizI2mLyQOxH4e5KM4+FruZuTmhzhiMx2rPtJkffkpeH64YimciibwX0YcOg==,
+        integrity: sha512-rwTYp6EkNueLDxmBEfMy8iN5hRZe0tZE7ETrKT4rihIQ5Rj90bIujb4KwtGiEEJ7RBS/Xt9sw0yX/4NraEkklA==,
       }
     engines: { node: ">= 18" }
     hasBin: true
@@ -10533,10 +10629,10 @@ packages:
       zod:
         optional: true
 
-  vitest@4.1.2:
+  vitest@4.1.4:
     resolution:
       {
-        integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==,
+        integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==,
       }
     engines: { node: ^20.0.0 || ^22.0.0 || >=24.0.0 }
     hasBin: true
@@ -10544,10 +10640,12 @@ packages:
       "@edge-runtime/vm": "*"
       "@opentelemetry/api": ^1.9.0
       "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
-      "@vitest/browser-playwright": 4.1.2
-      "@vitest/browser-preview": 4.1.2
-      "@vitest/browser-webdriverio": 4.1.2
-      "@vitest/ui": 4.1.2
+      "@vitest/browser-playwright": 4.1.4
+      "@vitest/browser-preview": 4.1.4
+      "@vitest/browser-webdriverio": 4.1.4
+      "@vitest/coverage-istanbul": 4.1.4
+      "@vitest/coverage-v8": 4.1.4
+      "@vitest/ui": 4.1.4
       happy-dom: "*"
       jsdom: "*"
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -10563,6 +10661,10 @@ packages:
       "@vitest/browser-preview":
         optional: true
       "@vitest/browser-webdriverio":
+        optional: true
+      "@vitest/coverage-istanbul":
+        optional: true
+      "@vitest/coverage-v8":
         optional: true
       "@vitest/ui":
         optional: true
@@ -11005,14 +11107,14 @@ packages:
       }
 
 snapshots:
-  "@ai-sdk/gateway@3.0.83(zod@4.3.6)":
+  "@ai-sdk/gateway@3.0.99(zod@4.3.6)":
     dependencies:
       "@ai-sdk/provider": 3.0.8
-      "@ai-sdk/provider-utils": 4.0.21(zod@4.3.6)
+      "@ai-sdk/provider-utils": 4.0.23(zod@4.3.6)
       "@vercel/oidc": 3.1.0
       zod: 4.3.6
 
-  "@ai-sdk/provider-utils@4.0.21(zod@4.3.6)":
+  "@ai-sdk/provider-utils@4.0.23(zod@4.3.6)":
     dependencies:
       "@ai-sdk/provider": 3.0.8
       "@standard-schema/spec": 1.1.0
@@ -11029,9 +11131,9 @@ snapshots:
     optionalDependencies:
       zod: 4.3.6
 
-  "@astrojs/check@0.9.8(prettier@3.8.1)(typescript@5.9.3)":
+  "@astrojs/check@0.9.8(prettier@3.8.3)(typescript@5.9.3)":
     dependencies:
-      "@astrojs/language-server": 2.16.6(prettier@3.8.1)(typescript@5.9.3)
+      "@astrojs/language-server": 2.16.6(prettier@3.8.3)(typescript@5.9.3)
       chokidar: 4.0.3
       kleur: 4.1.5
       typescript: 5.9.3
@@ -11044,7 +11146,7 @@ snapshots:
 
   "@astrojs/internal-helpers@0.7.6": {}
 
-  "@astrojs/language-server@2.16.6(prettier@3.8.1)(typescript@5.9.3)":
+  "@astrojs/language-server@2.16.6(prettier@3.8.3)(typescript@5.9.3)":
     dependencies:
       "@astrojs/compiler": 2.13.1
       "@astrojs/yaml2ts": 0.2.3
@@ -11058,14 +11160,14 @@ snapshots:
       volar-service-css: 0.0.70(@volar/language-service@2.4.28)
       volar-service-emmet: 0.0.70(@volar/language-service@2.4.28)
       volar-service-html: 0.0.70(@volar/language-service@2.4.28)
-      volar-service-prettier: 0.0.70(@volar/language-service@2.4.28)(prettier@3.8.1)
+      volar-service-prettier: 0.0.70(@volar/language-service@2.4.28)(prettier@3.8.3)
       volar-service-typescript: 0.0.70(@volar/language-service@2.4.28)
       volar-service-typescript-twoslash-queries: 0.0.70(@volar/language-service@2.4.28)
       volar-service-yaml: 0.0.70(@volar/language-service@2.4.28)
       vscode-html-languageservice: 5.6.2
       vscode-uri: 3.1.0
     optionalDependencies:
-      prettier: 3.8.1
+      prettier: 3.8.3
     transitivePeerDependencies:
       - typescript
 
@@ -11095,12 +11197,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@astrojs/mdx@4.3.14(astro@5.18.1(@types/node@25.5.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))":
+  "@astrojs/mdx@4.3.14(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))":
     dependencies:
       "@astrojs/markdown-remark": 6.3.11
       "@mdx-js/mdx": 3.1.1
       acorn: 8.16.0
-      astro: 5.18.1(@types/node@25.5.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      astro: 5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       es-module-lexer: 1.7.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -11124,17 +11226,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.3.6
 
-  "@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.5.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))":
+  "@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))":
     dependencies:
       "@astrojs/markdown-remark": 6.3.11
-      "@astrojs/mdx": 4.3.14(astro@5.18.1(@types/node@25.5.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
+      "@astrojs/mdx": 4.3.14(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
       "@astrojs/sitemap": 3.7.2
       "@pagefind/default-ui": 1.4.0
       "@types/hast": 3.0.4
       "@types/js-yaml": 4.0.9
       "@types/mdast": 4.0.4
-      astro: 5.18.1(@types/node@25.5.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
-      astro-expressive-code: 0.41.7(astro@5.18.1(@types/node@25.5.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
+      astro: 5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      astro-expressive-code: 0.41.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -11573,30 +11675,30 @@ snapshots:
     dependencies:
       fontkitten: 1.0.3
 
-  "@chat-adapter/shared@4.23.0":
+  "@chat-adapter/shared@4.26.0":
     dependencies:
-      chat: 4.23.0
+      chat: 4.26.0
     transitivePeerDependencies:
       - supports-color
 
-  "@chat-adapter/slack@4.23.0":
+  "@chat-adapter/slack@4.26.0":
     dependencies:
-      "@chat-adapter/shared": 4.23.0
-      "@slack/web-api": 7.15.0
-      chat: 4.23.0
+      "@chat-adapter/shared": 4.26.0
+      "@slack/web-api": 7.15.1
+      chat: 4.26.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  "@chat-adapter/state-memory@4.23.0":
+  "@chat-adapter/state-memory@4.26.0":
     dependencies:
-      chat: 4.23.0
+      chat: 4.26.0
     transitivePeerDependencies:
       - supports-color
 
-  "@chat-adapter/state-redis@4.23.0":
+  "@chat-adapter/state-redis@4.26.0":
     dependencies:
-      chat: 4.23.0
+      chat: 4.26.0
       redis: 5.11.0
     transitivePeerDependencies:
       - "@node-rs/xxhash"
@@ -11639,9 +11741,9 @@ snapshots:
 
   "@emmetio/stream-reader@2.2.0": {}
 
-  "@emnapi/core@1.9.1":
+  "@emnapi/core@1.9.2":
     dependencies:
-      "@emnapi/wasi-threads": 1.2.0
+      "@emnapi/wasi-threads": 1.2.1
       tslib: 2.8.1
     optional: true
 
@@ -11650,7 +11752,12 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  "@emnapi/wasi-threads@1.2.0":
+  "@emnapi/runtime@1.9.2":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  "@emnapi/wasi-threads@1.2.1":
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -11916,7 +12023,7 @@ snapshots:
 
   "@fastify/busboy@2.1.1": {}
 
-  "@fastify/otel@0.17.1(@opentelemetry/api@1.9.1)":
+  "@fastify/otel@0.18.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
@@ -11951,11 +12058,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  "@hono/node-server@1.19.12(hono@4.12.9)":
+  "@hono/node-server@1.19.12(hono@4.12.14)":
     dependencies:
-      hono: 4.12.9
-
-  "@iarna/toml@2.2.5": {}
+      hono: 4.12.14
 
   "@img/colour@1.1.0":
     optional: true
@@ -12056,31 +12161,31 @@ snapshots:
 
   "@inquirer/ansi@1.0.2": {}
 
-  "@inquirer/confirm@5.1.21(@types/node@25.5.0)":
+  "@inquirer/confirm@5.1.21(@types/node@25.6.0)":
     dependencies:
-      "@inquirer/core": 10.3.2(@types/node@25.5.0)
-      "@inquirer/type": 3.0.10(@types/node@25.5.0)
+      "@inquirer/core": 10.3.2(@types/node@25.6.0)
+      "@inquirer/type": 3.0.10(@types/node@25.6.0)
     optionalDependencies:
-      "@types/node": 25.5.0
+      "@types/node": 25.6.0
 
-  "@inquirer/core@10.3.2(@types/node@25.5.0)":
+  "@inquirer/core@10.3.2(@types/node@25.6.0)":
     dependencies:
       "@inquirer/ansi": 1.0.2
       "@inquirer/figures": 1.0.15
-      "@inquirer/type": 3.0.10(@types/node@25.5.0)
+      "@inquirer/type": 3.0.10(@types/node@25.6.0)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      "@types/node": 25.5.0
+      "@types/node": 25.6.0
 
   "@inquirer/figures@1.0.15": {}
 
-  "@inquirer/type@3.0.10(@types/node@25.5.0)":
+  "@inquirer/type@3.0.10(@types/node@25.6.0)":
     optionalDependencies:
-      "@types/node": 25.5.0
+      "@types/node": 25.6.0
 
   "@isaacs/balanced-match@4.0.1": {}
 
@@ -12224,7 +12329,7 @@ snapshots:
 
   "@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)":
     dependencies:
-      "@hono/node-server": 1.19.12(hono@4.12.9)
+      "@hono/node-server": 1.19.12(hono@4.12.14)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -12234,7 +12339,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.9
+      hono: 4.12.14
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -12259,10 +12364,17 @@ snapshots:
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
 
-  "@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)":
+  "@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)":
     dependencies:
-      "@emnapi/core": 1.9.1
-      "@emnapi/runtime": 1.9.1
+      "@emnapi/core": 1.9.2
+      "@emnapi/runtime": 1.9.2
+      "@tybys/wasm-util": 0.10.1
+    optional: true
+
+  "@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)":
+    dependencies:
+      "@emnapi/core": 1.9.2
+      "@emnapi/runtime": 1.9.2
       "@tybys/wasm-util": 0.10.1
     optional: true
 
@@ -12295,7 +12407,7 @@ snapshots:
     dependencies:
       "@opentelemetry/api": 1.9.1
 
-  "@opentelemetry/api-logs@0.213.0":
+  "@opentelemetry/api-logs@0.214.0":
     dependencies:
       "@opentelemetry/api": 1.9.1
 
@@ -12307,173 +12419,159 @@ snapshots:
     dependencies:
       "@opentelemetry/api": 1.9.1
 
-  "@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.1)":
-    dependencies:
-      "@opentelemetry/api": 1.9.1
-      "@opentelemetry/semantic-conventions": 1.40.0
-
   "@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/semantic-conventions": 1.40.0
 
-  "@opentelemetry/instrumentation-amqplib@0.60.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-amqplib@0.61.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.213.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-connect@0.56.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-connect@0.57.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.213.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
       "@types/connect": 3.4.38
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-dataloader@0.30.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-dataloader@0.31.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.213.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-express@0.61.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-fs@0.33.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.213.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  "@opentelemetry/instrumentation-generic-pool@0.57.0(@opentelemetry/api@1.9.1)":
+    dependencies:
+      "@opentelemetry/api": 1.9.1
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  "@opentelemetry/instrumentation-graphql@0.62.0(@opentelemetry/api@1.9.1)":
+    dependencies:
+      "@opentelemetry/api": 1.9.1
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  "@opentelemetry/instrumentation-hapi@0.60.0(@opentelemetry/api@1.9.1)":
+    dependencies:
+      "@opentelemetry/api": 1.9.1
+      "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-fs@0.32.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-http@0.214.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.213.0(@opentelemetry/api@1.9.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  "@opentelemetry/instrumentation-generic-pool@0.56.0(@opentelemetry/api@1.9.1)":
-    dependencies:
-      "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.213.0(@opentelemetry/api@1.9.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  "@opentelemetry/instrumentation-graphql@0.61.0(@opentelemetry/api@1.9.1)":
-    dependencies:
-      "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.213.0(@opentelemetry/api@1.9.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  "@opentelemetry/instrumentation-hapi@0.59.0(@opentelemetry/api@1.9.1)":
-    dependencies:
-      "@opentelemetry/api": 1.9.1
-      "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.213.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/semantic-conventions": 1.40.0
-    transitivePeerDependencies:
-      - supports-color
-
-  "@opentelemetry/instrumentation-http@0.213.0(@opentelemetry/api@1.9.1)":
-    dependencies:
-      "@opentelemetry/api": 1.9.1
-      "@opentelemetry/core": 2.6.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.213.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
       forwarded-parse: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-ioredis@0.61.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-ioredis@0.62.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.213.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/redis-common": 0.38.2
       "@opentelemetry/semantic-conventions": 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-kafkajs@0.22.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-kafkajs@0.23.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.213.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-knex@0.57.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-knex@0.58.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.213.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-koa@0.61.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-koa@0.62.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.213.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-lru-memoizer@0.57.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-lru-memoizer@0.58.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.213.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-mongodb@0.66.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-mongodb@0.67.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.213.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-mongoose@0.59.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-mongoose@0.60.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.213.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-mysql2@0.59.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-mysql2@0.60.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.213.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
       "@opentelemetry/sql-common": 0.41.2(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-mysql@0.59.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-mysql@0.60.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.213.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
       "@types/mysql": 2.15.27
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-pg@0.65.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-pg@0.66.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.213.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
       "@opentelemetry/sql-common": 0.41.2(@opentelemetry/api@1.9.1)
       "@types/pg": 8.15.6
@@ -12481,29 +12579,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-redis@0.61.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-redis@0.62.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.213.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/redis-common": 0.38.2
       "@opentelemetry/semantic-conventions": 1.40.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-tedious@0.32.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-tedious@0.33.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.213.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
       "@types/tedious": 4.0.14
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-undici@0.23.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-undici@0.24.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.213.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
     transitivePeerDependencies:
       - supports-color
@@ -12526,10 +12624,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation@0.213.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/api-logs": 0.213.0
+      "@opentelemetry/api-logs": 0.214.0
       import-in-the-middle: 3.0.0
       require-in-the-middle: 8.0.1
     transitivePeerDependencies:
@@ -12562,6 +12660,8 @@ snapshots:
   "@oxc-project/types@0.110.0": {}
 
   "@oxc-project/types@0.122.0": {}
+
+  "@oxc-project/types@0.124.0": {}
 
   "@oxc-transform/binding-android-arm-eabi@0.111.0":
     optional: true
@@ -12611,9 +12711,9 @@ snapshots:
   "@oxc-transform/binding-openharmony-arm64@0.111.0":
     optional: true
 
-  "@oxc-transform/binding-wasm32-wasi@0.111.0(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)":
+  "@oxc-transform/binding-wasm32-wasi@0.111.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)":
     dependencies:
-      "@napi-rs/wasm-runtime": 1.1.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
+      "@napi-rs/wasm-runtime": 1.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
     transitivePeerDependencies:
       - "@emnapi/core"
       - "@emnapi/runtime"
@@ -12628,61 +12728,61 @@ snapshots:
   "@oxc-transform/binding-win32-x64-msvc@0.111.0":
     optional: true
 
-  "@oxlint/binding-android-arm-eabi@1.58.0":
+  "@oxlint/binding-android-arm-eabi@1.60.0":
     optional: true
 
-  "@oxlint/binding-android-arm64@1.58.0":
+  "@oxlint/binding-android-arm64@1.60.0":
     optional: true
 
-  "@oxlint/binding-darwin-arm64@1.58.0":
+  "@oxlint/binding-darwin-arm64@1.60.0":
     optional: true
 
-  "@oxlint/binding-darwin-x64@1.58.0":
+  "@oxlint/binding-darwin-x64@1.60.0":
     optional: true
 
-  "@oxlint/binding-freebsd-x64@1.58.0":
+  "@oxlint/binding-freebsd-x64@1.60.0":
     optional: true
 
-  "@oxlint/binding-linux-arm-gnueabihf@1.58.0":
+  "@oxlint/binding-linux-arm-gnueabihf@1.60.0":
     optional: true
 
-  "@oxlint/binding-linux-arm-musleabihf@1.58.0":
+  "@oxlint/binding-linux-arm-musleabihf@1.60.0":
     optional: true
 
-  "@oxlint/binding-linux-arm64-gnu@1.58.0":
+  "@oxlint/binding-linux-arm64-gnu@1.60.0":
     optional: true
 
-  "@oxlint/binding-linux-arm64-musl@1.58.0":
+  "@oxlint/binding-linux-arm64-musl@1.60.0":
     optional: true
 
-  "@oxlint/binding-linux-ppc64-gnu@1.58.0":
+  "@oxlint/binding-linux-ppc64-gnu@1.60.0":
     optional: true
 
-  "@oxlint/binding-linux-riscv64-gnu@1.58.0":
+  "@oxlint/binding-linux-riscv64-gnu@1.60.0":
     optional: true
 
-  "@oxlint/binding-linux-riscv64-musl@1.58.0":
+  "@oxlint/binding-linux-riscv64-musl@1.60.0":
     optional: true
 
-  "@oxlint/binding-linux-s390x-gnu@1.58.0":
+  "@oxlint/binding-linux-s390x-gnu@1.60.0":
     optional: true
 
-  "@oxlint/binding-linux-x64-gnu@1.58.0":
+  "@oxlint/binding-linux-x64-gnu@1.60.0":
     optional: true
 
-  "@oxlint/binding-linux-x64-musl@1.58.0":
+  "@oxlint/binding-linux-x64-musl@1.60.0":
     optional: true
 
-  "@oxlint/binding-openharmony-arm64@1.58.0":
+  "@oxlint/binding-openharmony-arm64@1.60.0":
     optional: true
 
-  "@oxlint/binding-win32-arm64-msvc@1.58.0":
+  "@oxlint/binding-win32-arm64-msvc@1.60.0":
     optional: true
 
-  "@oxlint/binding-win32-ia32-msvc@1.58.0":
+  "@oxlint/binding-win32-ia32-msvc@1.60.0":
     optional: true
 
-  "@oxlint/binding-win32-x64-msvc@1.58.0":
+  "@oxlint/binding-win32-x64-msvc@1.60.0":
     optional: true
 
   "@pagefind/darwin-arm64@1.4.0":
@@ -12705,7 +12805,7 @@ snapshots:
   "@pagefind/windows-x64@1.4.0":
     optional: true
 
-  "@prisma/instrumentation@7.4.2(@opentelemetry/api@1.9.1)":
+  "@prisma/instrumentation@7.6.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/instrumentation": 0.207.0(@opentelemetry/api@1.9.1)
@@ -12763,10 +12863,16 @@ snapshots:
   "@rolldown/binding-android-arm64@1.0.0-rc.12":
     optional: true
 
+  "@rolldown/binding-android-arm64@1.0.0-rc.15":
+    optional: true
+
   "@rolldown/binding-darwin-arm64@1.0.0-rc.1":
     optional: true
 
   "@rolldown/binding-darwin-arm64@1.0.0-rc.12":
+    optional: true
+
+  "@rolldown/binding-darwin-arm64@1.0.0-rc.15":
     optional: true
 
   "@rolldown/binding-darwin-x64@1.0.0-rc.1":
@@ -12775,10 +12881,16 @@ snapshots:
   "@rolldown/binding-darwin-x64@1.0.0-rc.12":
     optional: true
 
+  "@rolldown/binding-darwin-x64@1.0.0-rc.15":
+    optional: true
+
   "@rolldown/binding-freebsd-x64@1.0.0-rc.1":
     optional: true
 
   "@rolldown/binding-freebsd-x64@1.0.0-rc.12":
+    optional: true
+
+  "@rolldown/binding-freebsd-x64@1.0.0-rc.15":
     optional: true
 
   "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.1":
@@ -12787,10 +12899,16 @@ snapshots:
   "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12":
     optional: true
 
+  "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15":
+    optional: true
+
   "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.1":
     optional: true
 
   "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12":
+    optional: true
+
+  "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15":
     optional: true
 
   "@rolldown/binding-linux-arm64-musl@1.0.0-rc.1":
@@ -12799,10 +12917,19 @@ snapshots:
   "@rolldown/binding-linux-arm64-musl@1.0.0-rc.12":
     optional: true
 
+  "@rolldown/binding-linux-arm64-musl@1.0.0-rc.15":
+    optional: true
+
   "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12":
     optional: true
 
+  "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15":
+    optional: true
+
   "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12":
+    optional: true
+
+  "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15":
     optional: true
 
   "@rolldown/binding-linux-x64-gnu@1.0.0-rc.1":
@@ -12811,10 +12938,16 @@ snapshots:
   "@rolldown/binding-linux-x64-gnu@1.0.0-rc.12":
     optional: true
 
+  "@rolldown/binding-linux-x64-gnu@1.0.0-rc.15":
+    optional: true
+
   "@rolldown/binding-linux-x64-musl@1.0.0-rc.1":
     optional: true
 
   "@rolldown/binding-linux-x64-musl@1.0.0-rc.12":
+    optional: true
+
+  "@rolldown/binding-linux-x64-musl@1.0.0-rc.15":
     optional: true
 
   "@rolldown/binding-openharmony-arm64@1.0.0-rc.1":
@@ -12823,20 +12956,30 @@ snapshots:
   "@rolldown/binding-openharmony-arm64@1.0.0-rc.12":
     optional: true
 
-  "@rolldown/binding-wasm32-wasi@1.0.0-rc.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)":
+  "@rolldown/binding-openharmony-arm64@1.0.0-rc.15":
+    optional: true
+
+  "@rolldown/binding-wasm32-wasi@1.0.0-rc.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)":
     dependencies:
-      "@napi-rs/wasm-runtime": 1.1.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
+      "@napi-rs/wasm-runtime": 1.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
     transitivePeerDependencies:
       - "@emnapi/core"
       - "@emnapi/runtime"
     optional: true
 
-  "@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)":
+  "@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)":
     dependencies:
-      "@napi-rs/wasm-runtime": 1.1.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
+      "@napi-rs/wasm-runtime": 1.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
     transitivePeerDependencies:
       - "@emnapi/core"
       - "@emnapi/runtime"
+    optional: true
+
+  "@rolldown/binding-wasm32-wasi@1.0.0-rc.15":
+    dependencies:
+      "@emnapi/core": 1.9.2
+      "@emnapi/runtime": 1.9.2
+      "@napi-rs/wasm-runtime": 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
     optional: true
 
   "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.1":
@@ -12845,15 +12988,23 @@ snapshots:
   "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12":
     optional: true
 
+  "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15":
+    optional: true
+
   "@rolldown/binding-win32-x64-msvc@1.0.0-rc.1":
     optional: true
 
   "@rolldown/binding-win32-x64-msvc@1.0.0-rc.12":
     optional: true
 
+  "@rolldown/binding-win32-x64-msvc@1.0.0-rc.15":
+    optional: true
+
   "@rolldown/pluginutils@1.0.0-rc.1": {}
 
   "@rolldown/pluginutils@1.0.0-rc.12": {}
+
+  "@rolldown/pluginutils@1.0.0-rc.15": {}
 
   "@rollup/pluginutils@5.3.0(rollup@4.60.1)":
     dependencies:
@@ -12938,28 +13089,28 @@ snapshots:
   "@rollup/rollup-win32-x64-msvc@4.60.1":
     optional: true
 
-  "@sentry/core@10.46.0": {}
+  "@sentry/core@10.48.0": {}
 
-  "@sentry/junior@file:packages/junior(@aws-sdk/credential-provider-web-identity@3.972.27)(@sentry/node@10.46.0)":
+  "@sentry/junior@file:packages/junior(@aws-sdk/credential-provider-web-identity@3.972.27)(@sentry/node@10.48.0)":
     dependencies:
-      "@ai-sdk/gateway": 3.0.83(zod@4.3.6)
-      "@chat-adapter/slack": 4.23.0
-      "@chat-adapter/state-memory": 4.23.0
-      "@chat-adapter/state-redis": 4.23.0
+      "@ai-sdk/gateway": 3.0.99(zod@4.3.6)
+      "@chat-adapter/slack": 4.26.0
+      "@chat-adapter/state-memory": 4.26.0
+      "@chat-adapter/state-redis": 4.26.0
       "@logtape/logtape": 2.0.5
       "@mariozechner/pi-agent-core": 0.59.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
       "@mariozechner/pi-ai": 0.59.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
       "@modelcontextprotocol/sdk": 1.29.0(zod@4.3.6)
-      "@sentry/node": 10.46.0
+      "@sentry/node": 10.48.0
       "@sinclair/typebox": 0.34.49
-      "@slack/web-api": 7.15.0
+      "@slack/web-api": 7.15.1
       "@vercel/functions": 3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27)
-      "@vercel/sandbox": 1.9.3
-      ai: 6.0.141(zod@4.3.6)
-      bash-tool: 1.3.15(@vercel/sandbox@1.9.3)(ai@6.0.141(zod@4.3.6))(just-bash@2.14.0)
-      chat: 4.23.0
-      hono: 4.12.9
-      just-bash: 2.14.0
+      "@vercel/sandbox": 1.10.0
+      ai: 6.0.162(zod@4.3.6)
+      bash-tool: 1.3.16(@vercel/sandbox@1.10.0)(ai@6.0.162(zod@4.3.6))(just-bash@2.14.2)
+      chat: 4.26.0
+      hono: 4.12.14
+      just-bash: 2.14.2
       node-html-markdown: 2.0.0
       yaml: 2.8.3
       zod: 4.3.6
@@ -12976,68 +13127,68 @@ snapshots:
       - utf-8-validate
       - ws
 
-  "@sentry/node-core@10.46.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)":
+  "@sentry/node-core@10.48.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)":
     dependencies:
-      "@sentry/core": 10.46.0
-      "@sentry/opentelemetry": 10.46.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      "@sentry/core": 10.48.0
+      "@sentry/opentelemetry": 10.48.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
       import-in-the-middle: 3.0.0
     optionalDependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/context-async-hooks": 2.6.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.213.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/resources": 2.6.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/sdk-trace-base": 2.6.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
 
-  "@sentry/node@10.46.0":
+  "@sentry/node@10.48.0":
     dependencies:
-      "@fastify/otel": 0.17.1(@opentelemetry/api@1.9.1)
+      "@fastify/otel": 0.18.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/context-async-hooks": 2.6.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.213.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-amqplib": 0.60.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-connect": 0.56.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-dataloader": 0.30.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-express": 0.61.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-fs": 0.32.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-generic-pool": 0.56.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-graphql": 0.61.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-hapi": 0.59.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-http": 0.213.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-ioredis": 0.61.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-kafkajs": 0.22.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-knex": 0.57.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-koa": 0.61.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-lru-memoizer": 0.57.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-mongodb": 0.66.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-mongoose": 0.59.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-mysql": 0.59.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-mysql2": 0.59.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-pg": 0.65.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-redis": 0.61.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-tedious": 0.32.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-undici": 0.23.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-amqplib": 0.61.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-connect": 0.57.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-dataloader": 0.31.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-fs": 0.33.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-generic-pool": 0.57.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-graphql": 0.62.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-hapi": 0.60.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-http": 0.214.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-ioredis": 0.62.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-kafkajs": 0.23.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-knex": 0.58.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-koa": 0.62.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-lru-memoizer": 0.58.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-mongodb": 0.67.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-mongoose": 0.60.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-mysql": 0.60.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-mysql2": 0.60.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-pg": 0.66.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-redis": 0.62.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-tedious": 0.33.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-undici": 0.24.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/resources": 2.6.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/sdk-trace-base": 2.6.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
-      "@prisma/instrumentation": 7.4.2(@opentelemetry/api@1.9.1)
-      "@sentry/core": 10.46.0
-      "@sentry/node-core": 10.46.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
-      "@sentry/opentelemetry": 10.46.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      "@prisma/instrumentation": 7.6.0(@opentelemetry/api@1.9.1)
+      "@sentry/core": 10.48.0
+      "@sentry/node-core": 10.48.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      "@sentry/opentelemetry": 10.48.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
       import-in-the-middle: 3.0.0
     transitivePeerDependencies:
+      - "@opentelemetry/exporter-trace-otlp-http"
       - supports-color
 
-  "@sentry/opentelemetry@10.46.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)":
+  "@sentry/opentelemetry@10.48.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/context-async-hooks": 2.6.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/sdk-trace-base": 2.6.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
-      "@sentry/core": 10.46.0
+      "@sentry/core": 10.48.0
 
   "@shikijs/core@3.23.0":
     dependencies:
@@ -13078,17 +13229,17 @@ snapshots:
 
   "@slack/logger@4.0.1":
     dependencies:
-      "@types/node": 25.5.0
+      "@types/node": 25.6.0
 
   "@slack/types@2.20.1": {}
 
-  "@slack/web-api@7.15.0":
+  "@slack/web-api@7.15.1":
     dependencies:
       "@slack/logger": 4.0.1
       "@slack/types": 2.20.1
-      "@types/node": 25.5.0
+      "@types/node": 25.6.0
       "@types/retry": 0.12.0
-      axios: 1.14.0
+      axios: 1.15.0
       eventemitter3: 5.0.4
       form-data: 4.0.5
       is-electron: 2.2.2
@@ -13487,7 +13638,7 @@ snapshots:
 
   "@types/connect@3.4.38":
     dependencies:
-      "@types/node": 25.5.0
+      "@types/node": 25.6.0
 
   "@types/debug@4.1.13":
     dependencies:
@@ -13519,7 +13670,7 @@ snapshots:
 
   "@types/mysql@2.15.27":
     dependencies:
-      "@types/node": 25.5.0
+      "@types/node": 25.6.0
 
   "@types/nlcst@2.0.3":
     dependencies:
@@ -13533,9 +13684,9 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  "@types/node@25.5.0":
+  "@types/node@25.6.0":
     dependencies:
-      undici-types: 7.18.2
+      undici-types: 7.19.2
 
   "@types/pg-pool@2.0.7":
     dependencies:
@@ -13543,7 +13694,7 @@ snapshots:
 
   "@types/pg@8.15.6":
     dependencies:
-      "@types/node": 25.5.0
+      "@types/node": 25.6.0
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 
@@ -13551,13 +13702,13 @@ snapshots:
 
   "@types/sax@1.2.7":
     dependencies:
-      "@types/node": 24.12.0
+      "@types/node": 25.6.0
 
   "@types/statuses@2.0.6": {}
 
   "@types/tedious@4.0.14":
     dependencies:
-      "@types/node": 25.5.0
+      "@types/node": 25.6.0
 
   "@types/unist@2.0.11": {}
 
@@ -13565,16 +13716,16 @@ snapshots:
 
   "@ungap/structured-clone@1.3.0": {}
 
-  "@vercel/backends@0.0.53(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.1)(typescript@5.9.3)":
+  "@vercel/backends@0.0.62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(rollup@4.60.1)(typescript@5.9.3)":
     dependencies:
-      "@vercel/build-utils": 13.12.0
+      "@vercel/build-utils": 13.17.0
       "@vercel/nft": 1.5.0(rollup@4.60.1)
       execa: 3.2.0
       fs-extra: 11.1.0
-      oxc-transform: 0.111.0(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
+      oxc-transform: 0.111.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
       path-to-regexp: 8.3.0
       resolve.exports: 2.0.3
-      rolldown: 1.0.0-rc.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
+      rolldown: 1.0.0-rc.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
       srvx: 0.8.9
       tsx: 4.21.0
       typescript: 5.9.3
@@ -13594,15 +13745,15 @@ snapshots:
       throttleit: 2.1.0
       undici: 6.24.1
 
-  "@vercel/build-utils@13.12.0":
+  "@vercel/build-utils@13.17.0":
     dependencies:
       "@vercel/python-analysis": 0.11.0
       cjs-module-lexer: 1.2.3
       es-module-lexer: 1.5.0
 
-  "@vercel/cervel@0.0.40(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.1)(typescript@5.9.3)":
+  "@vercel/cervel@0.0.49(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(rollup@4.60.1)(typescript@5.9.3)":
     dependencies:
-      "@vercel/backends": 0.0.53(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.1)(typescript@5.9.3)
+      "@vercel/backends": 0.0.62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(rollup@4.60.1)(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - "@emnapi/core"
@@ -13611,11 +13762,11 @@ snapshots:
       - rollup
       - supports-color
 
-  "@vercel/detect-agent@1.2.1": {}
+  "@vercel/detect-agent@1.2.2": {}
 
-  "@vercel/elysia@0.1.55(rollup@4.60.1)":
+  "@vercel/elysia@0.1.65(rollup@4.60.1)":
     dependencies:
-      "@vercel/node": 5.6.22(rollup@4.60.1)
+      "@vercel/node": 5.7.7(rollup@4.60.1)
       "@vercel/static-config": 3.2.0
     transitivePeerDependencies:
       - encoding
@@ -13624,11 +13775,11 @@ snapshots:
 
   "@vercel/error-utils@2.0.3": {}
 
-  "@vercel/express@0.1.65(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.1)(typescript@5.9.3)":
+  "@vercel/express@0.1.75(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(rollup@4.60.1)(typescript@5.9.3)":
     dependencies:
-      "@vercel/cervel": 0.0.40(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.1)(typescript@5.9.3)
+      "@vercel/cervel": 0.0.49(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(rollup@4.60.1)(typescript@5.9.3)
       "@vercel/nft": 1.5.0(rollup@4.60.1)
-      "@vercel/node": 5.6.22(rollup@4.60.1)
+      "@vercel/node": 5.7.7(rollup@4.60.1)
       "@vercel/static-config": 3.2.0
       fs-extra: 11.1.0
       path-to-regexp: 8.3.0
@@ -13642,9 +13793,9 @@ snapshots:
       - supports-color
       - typescript
 
-  "@vercel/fastify@0.1.58(rollup@4.60.1)":
+  "@vercel/fastify@0.1.68(rollup@4.60.1)":
     dependencies:
-      "@vercel/node": 5.6.22(rollup@4.60.1)
+      "@vercel/node": 5.7.7(rollup@4.60.1)
       "@vercel/static-config": 3.2.0
     transitivePeerDependencies:
       - encoding
@@ -13685,29 +13836,29 @@ snapshots:
     dependencies:
       web-vitals: 0.2.4
 
-  "@vercel/gatsby-plugin-vercel-builder@2.1.6":
+  "@vercel/gatsby-plugin-vercel-builder@2.1.15":
     dependencies:
       "@sinclair/typebox": 0.25.24
-      "@vercel/build-utils": 13.12.0
+      "@vercel/build-utils": 13.17.0
       esbuild: 0.27.0
       etag: 1.8.1
       fs-extra: 11.1.0
 
-  "@vercel/go@3.4.6": {}
+  "@vercel/go@3.5.0": {}
 
-  "@vercel/h3@0.1.64(rollup@4.60.1)":
+  "@vercel/h3@0.1.74(rollup@4.60.1)":
     dependencies:
-      "@vercel/node": 5.6.22(rollup@4.60.1)
+      "@vercel/node": 5.7.7(rollup@4.60.1)
       "@vercel/static-config": 3.2.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  "@vercel/hono@0.2.58(rollup@4.60.1)":
+  "@vercel/hono@0.2.68(rollup@4.60.1)":
     dependencies:
       "@vercel/nft": 1.5.0(rollup@4.60.1)
-      "@vercel/node": 5.6.22(rollup@4.60.1)
+      "@vercel/node": 5.7.7(rollup@4.60.1)
       "@vercel/static-config": 3.2.0
       fs-extra: 11.1.0
       path-to-regexp: 8.3.0
@@ -13723,25 +13874,25 @@ snapshots:
       "@vercel/static-config": 3.2.0
       ts-morph: 12.0.0
 
-  "@vercel/koa@0.1.38(rollup@4.60.1)":
+  "@vercel/koa@0.1.48(rollup@4.60.1)":
     dependencies:
-      "@vercel/node": 5.6.22(rollup@4.60.1)
+      "@vercel/node": 5.7.7(rollup@4.60.1)
       "@vercel/static-config": 3.2.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  "@vercel/nestjs@0.2.59(rollup@4.60.1)":
+  "@vercel/nestjs@0.2.69(rollup@4.60.1)":
     dependencies:
-      "@vercel/node": 5.6.22(rollup@4.60.1)
+      "@vercel/node": 5.7.7(rollup@4.60.1)
       "@vercel/static-config": 3.2.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  "@vercel/next@4.16.3(rollup@4.60.1)":
+  "@vercel/next@4.16.8(rollup@4.60.1)":
     dependencies:
       "@vercel/nft": 1.5.0(rollup@4.60.1)
     transitivePeerDependencies:
@@ -13768,13 +13919,13 @@ snapshots:
       - rollup
       - supports-color
 
-  "@vercel/node@5.6.22(rollup@4.60.1)":
+  "@vercel/node@5.7.7(rollup@4.60.1)":
     dependencies:
       "@edge-runtime/node-utils": 2.3.0
       "@edge-runtime/primitives": 4.1.0
       "@edge-runtime/vm": 3.2.0
       "@types/node": 20.11.0
-      "@vercel/build-utils": 13.12.0
+      "@vercel/build-utils": 13.17.0
       "@vercel/error-utils": 2.0.3
       "@vercel/nft": 1.5.0(rollup@4.60.1)
       "@vercel/static-config": 3.2.0
@@ -13813,7 +13964,7 @@ snapshots:
       smol-toml: 1.5.2
       zod: 3.22.4
 
-  "@vercel/python@6.28.0":
+  "@vercel/python@6.33.0":
     dependencies:
       "@vercel/python-analysis": 0.11.0
 
@@ -13843,12 +13994,12 @@ snapshots:
 
   "@vercel/ruby@2.3.2": {}
 
-  "@vercel/rust@1.0.5":
+  "@vercel/rust@1.1.0":
     dependencies:
-      "@iarna/toml": 2.2.5
       execa: 5.1.1
+      smol-toml: 1.5.2
 
-  "@vercel/sandbox@1.9.3":
+  "@vercel/sandbox@1.10.0":
     dependencies:
       "@vercel/oidc": 3.2.0
       "@workflow/serde": 4.1.0-beta.2
@@ -13864,10 +14015,25 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  "@vercel/static-build@2.9.6":
+  "@vercel/sandbox@1.9.0":
+    dependencies:
+      "@vercel/oidc": 3.2.0
+      async-retry: 1.3.3
+      jsonlines: 0.1.1
+      ms: 2.1.3
+      picocolors: 1.1.1
+      tar-stream: 3.1.7
+      undici: 7.24.6
+      xdg-app-paths: 5.1.0
+      zod: 3.24.4
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  "@vercel/static-build@2.9.15":
     dependencies:
       "@vercel/gatsby-plugin-vercel-analytics": 1.0.11
-      "@vercel/gatsby-plugin-vercel-builder": 2.1.6
+      "@vercel/gatsby-plugin-vercel-builder": 2.1.15
       "@vercel/static-config": 3.2.0
       ts-morph: 12.0.0
 
@@ -13877,45 +14043,45 @@ snapshots:
       json-schema-to-ts: 1.6.4
       ts-morph: 12.0.0
 
-  "@vitest/expect@4.1.2":
+  "@vitest/expect@4.1.4":
     dependencies:
       "@standard-schema/spec": 1.1.0
       "@types/chai": 5.2.3
-      "@vitest/spy": 4.1.2
-      "@vitest/utils": 4.1.2
+      "@vitest/spy": 4.1.4
+      "@vitest/utils": 4.1.4
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  "@vitest/mocker@4.1.2(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))":
+  "@vitest/mocker@4.1.4(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))":
     dependencies:
-      "@vitest/spy": 4.1.2
+      "@vitest/spy": 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.12.14(@types/node@25.5.0)(typescript@5.9.3)
-      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      msw: 2.13.3(@types/node@25.6.0)(typescript@5.9.3)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
-  "@vitest/pretty-format@4.1.2":
+  "@vitest/pretty-format@4.1.4":
     dependencies:
       tinyrainbow: 3.1.0
 
-  "@vitest/runner@4.1.2":
+  "@vitest/runner@4.1.4":
     dependencies:
-      "@vitest/utils": 4.1.2
+      "@vitest/utils": 4.1.4
       pathe: 2.0.3
 
-  "@vitest/snapshot@4.1.2":
+  "@vitest/snapshot@4.1.4":
     dependencies:
-      "@vitest/pretty-format": 4.1.2
-      "@vitest/utils": 4.1.2
+      "@vitest/pretty-format": 4.1.4
+      "@vitest/utils": 4.1.4
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  "@vitest/spy@4.1.2": {}
+  "@vitest/spy@4.1.4": {}
 
-  "@vitest/utils@4.1.2":
+  "@vitest/utils@4.1.4":
     dependencies:
-      "@vitest/pretty-format": 4.1.2
+      "@vitest/pretty-format": 4.1.4
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -14002,11 +14168,11 @@ snapshots:
 
   agent-browser@0.23.3: {}
 
-  ai@6.0.141(zod@4.3.6):
+  ai@6.0.162(zod@4.3.6):
     dependencies:
-      "@ai-sdk/gateway": 3.0.83(zod@4.3.6)
+      "@ai-sdk/gateway": 3.0.99(zod@4.3.6)
       "@ai-sdk/provider": 3.0.8
-      "@ai-sdk/provider-utils": 4.0.21(zod@4.3.6)
+      "@ai-sdk/provider-utils": 4.0.23(zod@4.3.6)
       "@opentelemetry/api": 1.9.0
       zod: 4.3.6
 
@@ -14031,8 +14197,6 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
       uri-js: 4.4.1
-
-  amdefine@1.0.1: {}
 
   ansi-align@3.0.1:
     dependencies:
@@ -14063,10 +14227,6 @@ snapshots:
 
   arg@5.0.2: {}
 
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
-
   argparse@2.0.1: {}
 
   aria-query@5.3.2: {}
@@ -14081,12 +14241,12 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.7(astro@5.18.1(@types/node@25.5.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)):
+  astro-expressive-code@0.41.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)):
     dependencies:
-      astro: 5.18.1(@types/node@25.5.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      astro: 5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       rehype-expressive-code: 0.41.7
 
-  astro@5.18.1(@types/node@25.5.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
+  astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       "@astrojs/compiler": 2.13.1
       "@astrojs/internal-helpers": 0.7.6
@@ -14143,8 +14303,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)
       vfile: 6.0.3
-      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vitefu: 1.1.2(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite: 6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitefu: 1.1.2(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.3
@@ -14202,7 +14362,7 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.14.0:
+  axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5
@@ -14226,15 +14386,15 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  bash-tool@1.3.15(@vercel/sandbox@1.9.3)(ai@6.0.141(zod@4.3.6))(just-bash@2.14.0):
+  bash-tool@1.3.16(@vercel/sandbox@1.10.0)(ai@6.0.162(zod@4.3.6))(just-bash@2.14.2):
     dependencies:
-      ai: 6.0.141(zod@4.3.6)
+      ai: 6.0.162(zod@4.3.6)
       fast-glob: 3.3.3
-      gray-matter: 4.0.3
+      yaml: 2.8.3
       zod: 3.25.76
     optionalDependencies:
-      "@vercel/sandbox": 1.9.3
-      just-bash: 2.14.0
+      "@vercel/sandbox": 1.10.0
+      just-bash: 2.14.2
 
   basic-ftp@5.2.0: {}
 
@@ -14356,7 +14516,7 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
-  chat@4.23.0:
+  chat@4.26.0:
     dependencies:
       "@workflow/serde": 4.1.0-beta.2
       mdast-util-to-string: 4.0.0
@@ -14439,18 +14599,11 @@ snapshots:
   commander@2.20.3:
     optional: true
 
-  commander@2.8.1:
-    dependencies:
-      graceful-readlink: 1.0.1
-
   commander@4.1.1: {}
 
-  common-ancestor-path@1.0.1: {}
+  commander@6.2.1: {}
 
-  compressjs@1.0.3:
-    dependencies:
-      amdefine: 1.0.1
-      commander: 2.8.1
+  common-ancestor-path@1.0.1: {}
 
   concat-map@0.0.1: {}
 
@@ -14493,9 +14646,9 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  crossws@0.4.4(srvx@0.11.14):
+  crossws@0.4.5(srvx@0.11.15):
     optionalDependencies:
-      srvx: 0.11.14
+      srvx: 0.11.15
 
   css-select@5.2.2:
     dependencies:
@@ -14682,10 +14835,10 @@ snapshots:
 
   env-runner@0.1.7:
     dependencies:
-      crossws: 0.4.4(srvx@0.11.14)
+      crossws: 0.4.5(srvx@0.11.15)
       exsolve: 1.0.8
       httpxy: 0.5.0
-      srvx: 0.11.14
+      srvx: 0.11.15
 
   environment@1.1.0: {}
 
@@ -14965,10 +15118,6 @@ snapshots:
 
   exsolve@1.0.8: {}
 
-  extend-shallow@2.0.1:
-    dependencies:
-      is-extendable: 0.1.1
-
   extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
@@ -15194,16 +15343,7 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  graceful-readlink@1.0.1: {}
-
   graphql@16.13.2: {}
-
-  gray-matter@4.0.3:
-    dependencies:
-      js-yaml: 3.14.2
-      kind-of: 6.0.3
-      section-matter: 1.0.0
-      strip-bom-string: 1.0.0
 
   h3@1.15.10:
     dependencies:
@@ -15217,12 +15357,12 @@ snapshots:
       ufo: 1.6.3
       uncrypto: 0.1.3
 
-  h3@2.0.1-rc.20(crossws@0.4.4(srvx@0.11.14)):
+  h3@2.0.1-rc.20(crossws@0.4.5(srvx@0.11.15)):
     dependencies:
       rou3: 0.8.1
-      srvx: 0.11.14
+      srvx: 0.11.15
     optionalDependencies:
-      crossws: 0.4.4(srvx@0.11.14)
+      crossws: 0.4.5(srvx@0.11.15)
 
   has-flag@4.0.0: {}
 
@@ -15429,9 +15569,9 @@ snapshots:
 
   headers-polyfill@4.0.3: {}
 
-  hono@4.12.9: {}
+  hono@4.12.14: {}
 
-  hookable@6.1.0: {}
+  hookable@6.1.1: {}
 
   html-escaper@3.0.3: {}
 
@@ -15547,8 +15687,6 @@ snapshots:
 
   is-electron@2.2.2: {}
 
-  is-extendable@0.1.1: {}
-
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -15598,11 +15736,6 @@ snapshots:
 
   joycon@3.1.1: {}
 
-  js-yaml@3.14.2:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
-
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -15641,9 +15774,8 @@ snapshots:
 
   jsonlines@0.1.1: {}
 
-  just-bash@2.14.0:
+  just-bash@2.14.2:
     dependencies:
-      compressjs: 1.0.3
       diff: 8.0.4
       fast-xml-parser: 5.5.9
       file-type: 21.3.4
@@ -15653,6 +15785,7 @@ snapshots:
       papaparse: 5.5.3
       quickjs-emscripten: 0.32.0
       re2js: 1.2.3
+      seek-bzip: 2.0.0
       smol-toml: 1.6.1
       sprintf-js: 1.1.3
       sql.js: 1.14.1
@@ -15674,8 +15807,6 @@ snapshots:
     dependencies:
       jwa: 2.0.1
       safe-buffer: 5.2.1
-
-  kind-of@6.0.3: {}
 
   kleur@3.0.3: {}
 
@@ -16356,9 +16487,9 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3):
+  msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3):
     dependencies:
-      "@inquirer/confirm": 5.1.21(@types/node@25.5.0)
+      "@inquirer/confirm": 5.1.21(@types/node@25.6.0)
       "@mswjs/interceptors": 0.41.3
       "@open-draft/deferred-promise": 2.2.0
       "@types/statuses": 2.0.6
@@ -16369,7 +16500,7 @@ snapshots:
       outvariant: 1.4.3
       path-to-regexp: 6.3.0
       picocolors: 1.1.1
-      rettime: 0.10.1
+      rettime: 0.11.7
       statuses: 2.0.2
       strict-event-emitter: 0.5.1
       tough-cookie: 6.0.1
@@ -16402,28 +16533,28 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  nf3@0.3.14: {}
+  nf3@0.3.16: {}
 
-  nitro@3.0.260311-beta(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(chokidar@5.0.0)(jiti@2.6.1)(lru-cache@11.2.7)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  nitro@3.0.260415-beta(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(chokidar@5.0.0)(jiti@2.6.1)(lru-cache@11.2.7)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       consola: 3.4.2
-      crossws: 0.4.4(srvx@0.11.14)
+      crossws: 0.4.5(srvx@0.11.15)
       db0: 0.3.4
       env-runner: 0.1.7
-      h3: 2.0.1-rc.20(crossws@0.4.4(srvx@0.11.14))
-      hookable: 6.1.0
-      nf3: 0.3.14
+      h3: 2.0.1-rc.20(crossws@0.4.5(srvx@0.11.15))
+      hookable: 6.1.1
+      nf3: 0.3.16
       ocache: 0.1.4
       ofetch: 2.0.0-alpha.3
       ohash: 2.0.11
-      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
-      srvx: 0.11.14
+      rolldown: 1.0.0-rc.15
+      srvx: 0.11.15
       unenv: 2.0.0-rc.24
       unstorage: 2.0.0-alpha.7(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(chokidar@5.0.0)(db0@0.3.4)(lru-cache@11.2.7)(ofetch@2.0.0-alpha.3)
     optionalDependencies:
       jiti: 2.6.1
       rollup: 4.60.1
-      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - "@azure/app-configuration"
       - "@azure/cosmos"
@@ -16434,8 +16565,6 @@ snapshots:
       - "@capacitor/preferences"
       - "@deno/kv"
       - "@electric-sql/pglite"
-      - "@emnapi/core"
-      - "@emnapi/runtime"
       - "@libsql/client"
       - "@netlify/blobs"
       - "@netlify/runtime"
@@ -16581,7 +16710,7 @@ snapshots:
 
   outvariant@1.4.3: {}
 
-  oxc-transform@0.111.0(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1):
+  oxc-transform@0.111.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
     optionalDependencies:
       "@oxc-transform/binding-android-arm-eabi": 0.111.0
       "@oxc-transform/binding-android-arm64": 0.111.0
@@ -16599,7 +16728,7 @@ snapshots:
       "@oxc-transform/binding-linux-x64-gnu": 0.111.0
       "@oxc-transform/binding-linux-x64-musl": 0.111.0
       "@oxc-transform/binding-openharmony-arm64": 0.111.0
-      "@oxc-transform/binding-wasm32-wasi": 0.111.0(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
+      "@oxc-transform/binding-wasm32-wasi": 0.111.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
       "@oxc-transform/binding-win32-arm64-msvc": 0.111.0
       "@oxc-transform/binding-win32-ia32-msvc": 0.111.0
       "@oxc-transform/binding-win32-x64-msvc": 0.111.0
@@ -16607,27 +16736,27 @@ snapshots:
       - "@emnapi/core"
       - "@emnapi/runtime"
 
-  oxlint@1.58.0:
+  oxlint@1.60.0:
     optionalDependencies:
-      "@oxlint/binding-android-arm-eabi": 1.58.0
-      "@oxlint/binding-android-arm64": 1.58.0
-      "@oxlint/binding-darwin-arm64": 1.58.0
-      "@oxlint/binding-darwin-x64": 1.58.0
-      "@oxlint/binding-freebsd-x64": 1.58.0
-      "@oxlint/binding-linux-arm-gnueabihf": 1.58.0
-      "@oxlint/binding-linux-arm-musleabihf": 1.58.0
-      "@oxlint/binding-linux-arm64-gnu": 1.58.0
-      "@oxlint/binding-linux-arm64-musl": 1.58.0
-      "@oxlint/binding-linux-ppc64-gnu": 1.58.0
-      "@oxlint/binding-linux-riscv64-gnu": 1.58.0
-      "@oxlint/binding-linux-riscv64-musl": 1.58.0
-      "@oxlint/binding-linux-s390x-gnu": 1.58.0
-      "@oxlint/binding-linux-x64-gnu": 1.58.0
-      "@oxlint/binding-linux-x64-musl": 1.58.0
-      "@oxlint/binding-openharmony-arm64": 1.58.0
-      "@oxlint/binding-win32-arm64-msvc": 1.58.0
-      "@oxlint/binding-win32-ia32-msvc": 1.58.0
-      "@oxlint/binding-win32-x64-msvc": 1.58.0
+      "@oxlint/binding-android-arm-eabi": 1.60.0
+      "@oxlint/binding-android-arm64": 1.60.0
+      "@oxlint/binding-darwin-arm64": 1.60.0
+      "@oxlint/binding-darwin-x64": 1.60.0
+      "@oxlint/binding-freebsd-x64": 1.60.0
+      "@oxlint/binding-linux-arm-gnueabihf": 1.60.0
+      "@oxlint/binding-linux-arm-musleabihf": 1.60.0
+      "@oxlint/binding-linux-arm64-gnu": 1.60.0
+      "@oxlint/binding-linux-arm64-musl": 1.60.0
+      "@oxlint/binding-linux-ppc64-gnu": 1.60.0
+      "@oxlint/binding-linux-riscv64-gnu": 1.60.0
+      "@oxlint/binding-linux-riscv64-musl": 1.60.0
+      "@oxlint/binding-linux-s390x-gnu": 1.60.0
+      "@oxlint/binding-linux-x64-gnu": 1.60.0
+      "@oxlint/binding-linux-x64-musl": 1.60.0
+      "@oxlint/binding-openharmony-arm64": 1.60.0
+      "@oxlint/binding-win32-arm64-msvc": 1.60.0
+      "@oxlint/binding-win32-ia32-msvc": 1.60.0
+      "@oxlint/binding-win32-x64-msvc": 1.60.0
 
   p-finally@1.0.0: {}
 
@@ -16828,7 +16957,7 @@ snapshots:
       tunnel-agent: 0.6.0
     optional: true
 
-  prettier@3.8.1: {}
+  prettier@3.8.3: {}
 
   pretty-ms@7.0.1:
     dependencies:
@@ -16857,7 +16986,7 @@ snapshots:
       "@protobufjs/path": 1.1.2
       "@protobufjs/pool": 1.1.0
       "@protobufjs/utf8": 1.1.0
-      "@types/node": 25.5.0
+      "@types/node": 25.6.0
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -17176,13 +17305,13 @@ snapshots:
 
   retry@0.13.1: {}
 
-  rettime@0.10.1: {}
+  rettime@0.11.7: {}
 
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
 
-  rolldown@1.0.0-rc.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1):
+  rolldown@1.0.0-rc.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
     dependencies:
       "@oxc-project/types": 0.110.0
       "@rolldown/pluginutils": 1.0.0-rc.1
@@ -17197,14 +17326,14 @@ snapshots:
       "@rolldown/binding-linux-x64-gnu": 1.0.0-rc.1
       "@rolldown/binding-linux-x64-musl": 1.0.0-rc.1
       "@rolldown/binding-openharmony-arm64": 1.0.0-rc.1
-      "@rolldown/binding-wasm32-wasi": 1.0.0-rc.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
+      "@rolldown/binding-wasm32-wasi": 1.0.0-rc.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
       "@rolldown/binding-win32-arm64-msvc": 1.0.0-rc.1
       "@rolldown/binding-win32-x64-msvc": 1.0.0-rc.1
     transitivePeerDependencies:
       - "@emnapi/core"
       - "@emnapi/runtime"
 
-  rolldown@1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1):
+  rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
     dependencies:
       "@oxc-project/types": 0.122.0
       "@rolldown/pluginutils": 1.0.0-rc.12
@@ -17221,12 +17350,33 @@ snapshots:
       "@rolldown/binding-linux-x64-gnu": 1.0.0-rc.12
       "@rolldown/binding-linux-x64-musl": 1.0.0-rc.12
       "@rolldown/binding-openharmony-arm64": 1.0.0-rc.12
-      "@rolldown/binding-wasm32-wasi": 1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
+      "@rolldown/binding-wasm32-wasi": 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
       "@rolldown/binding-win32-arm64-msvc": 1.0.0-rc.12
       "@rolldown/binding-win32-x64-msvc": 1.0.0-rc.12
     transitivePeerDependencies:
       - "@emnapi/core"
       - "@emnapi/runtime"
+
+  rolldown@1.0.0-rc.15:
+    dependencies:
+      "@oxc-project/types": 0.124.0
+      "@rolldown/pluginutils": 1.0.0-rc.15
+    optionalDependencies:
+      "@rolldown/binding-android-arm64": 1.0.0-rc.15
+      "@rolldown/binding-darwin-arm64": 1.0.0-rc.15
+      "@rolldown/binding-darwin-x64": 1.0.0-rc.15
+      "@rolldown/binding-freebsd-x64": 1.0.0-rc.15
+      "@rolldown/binding-linux-arm-gnueabihf": 1.0.0-rc.15
+      "@rolldown/binding-linux-arm64-gnu": 1.0.0-rc.15
+      "@rolldown/binding-linux-arm64-musl": 1.0.0-rc.15
+      "@rolldown/binding-linux-ppc64-gnu": 1.0.0-rc.15
+      "@rolldown/binding-linux-s390x-gnu": 1.0.0-rc.15
+      "@rolldown/binding-linux-x64-gnu": 1.0.0-rc.15
+      "@rolldown/binding-linux-x64-musl": 1.0.0-rc.15
+      "@rolldown/binding-openharmony-arm64": 1.0.0-rc.15
+      "@rolldown/binding-wasm32-wasi": 1.0.0-rc.15
+      "@rolldown/binding-win32-arm64-msvc": 1.0.0-rc.15
+      "@rolldown/binding-win32-x64-msvc": 1.0.0-rc.15
 
   rollup@4.60.1:
     dependencies:
@@ -17283,12 +17433,21 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  sandbox@2.5.6:
+    dependencies:
+      "@vercel/sandbox": 1.9.0
+      debug: 4.4.3
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+      - supports-color
+
   sax@1.6.0: {}
 
-  section-matter@1.0.0:
+  seek-bzip@2.0.0:
     dependencies:
-      extend-shallow: 2.0.1
-      kind-of: 6.0.3
+      commander: 6.2.1
 
   semver@6.3.1: {}
 
@@ -17477,13 +17636,11 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
-  sprintf-js@1.0.3: {}
-
   sprintf-js@1.1.3: {}
 
   sql.js@1.14.1: {}
 
-  srvx@0.11.14: {}
+  srvx@0.11.15: {}
 
   srvx@0.8.9:
     dependencies:
@@ -17491,12 +17648,12 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  starlight-typedoc@0.21.5(@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.5.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.18(typescript@5.9.3)))(typedoc@0.28.18(typescript@5.9.3)):
+  starlight-typedoc@0.21.5(@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@5.9.3)))(typedoc@0.28.19(typescript@5.9.3)):
     dependencies:
-      "@astrojs/starlight": 0.37.7(astro@5.18.1(@types/node@25.5.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
+      "@astrojs/starlight": 0.37.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.27))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
       github-slugger: 2.0.0
-      typedoc: 0.28.18(typescript@5.9.3)
-      typedoc-plugin-markdown: 4.11.0(typedoc@0.28.18(typescript@5.9.3))
+      typedoc: 0.28.19(typescript@5.9.3)
+      typedoc-plugin-markdown: 4.11.0(typedoc@0.28.19(typescript@5.9.3))
 
   stat-mode@0.3.0: {}
 
@@ -17565,8 +17722,6 @@ snapshots:
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
-
-  strip-bom-string@1.0.0: {}
 
   strip-bom@3.0.0: {}
 
@@ -17823,11 +17978,11 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typedoc-plugin-markdown@4.11.0(typedoc@0.28.18(typescript@5.9.3)):
+  typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@5.9.3)):
     dependencies:
-      typedoc: 0.28.18(typescript@5.9.3)
+      typedoc: 0.28.19(typescript@5.9.3)
 
-  typedoc@0.28.18(typescript@5.9.3):
+  typedoc@0.28.19(typescript@5.9.3):
     dependencies:
       "@gerrit0/mini-shiki": 3.23.0
       lunr: 2.3.9
@@ -17860,7 +18015,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici-types@7.18.2: {}
+  undici-types@7.19.2: {}
 
   undici@5.28.4:
     dependencies:
@@ -17974,41 +18129,45 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vercel@50.37.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.1)(typescript@5.9.3):
+  vercel@51.4.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(rollup@4.60.1)(typescript@5.9.3):
     dependencies:
-      "@vercel/backends": 0.0.53(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.1)(typescript@5.9.3)
+      "@vercel/backends": 0.0.62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(rollup@4.60.1)(typescript@5.9.3)
       "@vercel/blob": 2.3.0
-      "@vercel/build-utils": 13.12.0
-      "@vercel/detect-agent": 1.2.1
-      "@vercel/elysia": 0.1.55(rollup@4.60.1)
-      "@vercel/express": 0.1.65(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.1)(typescript@5.9.3)
-      "@vercel/fastify": 0.1.58(rollup@4.60.1)
+      "@vercel/build-utils": 13.17.0
+      "@vercel/detect-agent": 1.2.2
+      "@vercel/elysia": 0.1.65(rollup@4.60.1)
+      "@vercel/express": 0.1.75(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(rollup@4.60.1)(typescript@5.9.3)
+      "@vercel/fastify": 0.1.68(rollup@4.60.1)
       "@vercel/fun": 1.3.0
-      "@vercel/go": 3.4.6
-      "@vercel/h3": 0.1.64(rollup@4.60.1)
-      "@vercel/hono": 0.2.58(rollup@4.60.1)
+      "@vercel/go": 3.5.0
+      "@vercel/h3": 0.1.74(rollup@4.60.1)
+      "@vercel/hono": 0.2.68(rollup@4.60.1)
       "@vercel/hydrogen": 1.3.6
-      "@vercel/koa": 0.1.38(rollup@4.60.1)
-      "@vercel/nestjs": 0.2.59(rollup@4.60.1)
-      "@vercel/next": 4.16.3(rollup@4.60.1)
-      "@vercel/node": 5.6.22(rollup@4.60.1)
+      "@vercel/koa": 0.1.48(rollup@4.60.1)
+      "@vercel/nestjs": 0.2.69(rollup@4.60.1)
+      "@vercel/next": 4.16.8(rollup@4.60.1)
+      "@vercel/node": 5.7.7(rollup@4.60.1)
       "@vercel/prepare-flags-definitions": 0.2.1
-      "@vercel/python": 6.28.0
+      "@vercel/python": 6.33.0
       "@vercel/redwood": 2.4.12(rollup@4.60.1)
       "@vercel/remix-builder": 5.7.2(rollup@4.60.1)
       "@vercel/ruby": 2.3.2
-      "@vercel/rust": 1.0.5
-      "@vercel/static-build": 2.9.6
+      "@vercel/rust": 1.1.0
+      "@vercel/static-build": 2.9.15
       chokidar: 4.0.0
       esbuild: 0.27.0
       form-data: 4.0.5
       jose: 5.9.6
       luxon: 3.7.2
       proxy-agent: 6.4.0
+      sandbox: 2.5.6
+      smol-toml: 1.5.2
     transitivePeerDependencies:
       - "@emnapi/core"
       - "@emnapi/runtime"
+      - bare-abort-controller
       - encoding
+      - react-native-b4a
       - rollup
       - supports-color
       - typescript
@@ -18028,7 +18187,7 @@ snapshots:
       "@types/unist": 3.0.3
       vfile-message: 4.0.3
 
-  vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
+  vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -18037,7 +18196,7 @@ snapshots:
       rollup: 4.60.1
       tinyglobby: 0.2.15
     optionalDependencies:
-      "@types/node": 25.5.0
+      "@types/node": 25.6.0
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
@@ -18045,15 +18204,15 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
+  vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.8
-      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
+      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
       tinyglobby: 0.2.15
     optionalDependencies:
-      "@types/node": 25.5.0
+      "@types/node": 25.6.0
       esbuild: 0.27.4
       fsevents: 2.3.3
       jiti: 2.6.1
@@ -18064,27 +18223,27 @@ snapshots:
       - "@emnapi/core"
       - "@emnapi/runtime"
 
-  vitefu@1.1.2(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitefu@1.1.2(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
-      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
-  vitest-evals@0.7.0(ai@6.0.141(zod@4.3.6))(tinyrainbow@3.1.0)(vitest@4.1.2(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(zod@4.3.6):
+  vitest-evals@0.7.0(ai@6.0.162(zod@4.3.6))(tinyrainbow@3.1.0)(vitest@4.1.4(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(zod@4.3.6):
     dependencies:
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      ai: 6.0.141(zod@4.3.6)
+      ai: 6.0.162(zod@4.3.6)
       zod: 4.3.6
 
-  vitest@4.1.2(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.4(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
-      "@vitest/expect": 4.1.2
-      "@vitest/mocker": 4.1.2(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-      "@vitest/pretty-format": 4.1.2
-      "@vitest/runner": 4.1.2
-      "@vitest/snapshot": 4.1.2
-      "@vitest/spy": 4.1.2
-      "@vitest/utils": 4.1.2
+      "@vitest/expect": 4.1.4
+      "@vitest/mocker": 4.1.4(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      "@vitest/pretty-format": 4.1.4
+      "@vitest/runner": 4.1.4
+      "@vitest/snapshot": 4.1.4
+      "@vitest/spy": 4.1.4
+      "@vitest/utils": 4.1.4
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -18096,12 +18255,12 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       "@edge-runtime/vm": 3.2.0
       "@opentelemetry/api": 1.9.1
-      "@types/node": 25.5.0
+      "@types/node": 25.6.0
     transitivePeerDependencies:
       - msw
 
@@ -18130,12 +18289,12 @@ snapshots:
     optionalDependencies:
       "@volar/language-service": 2.4.28
 
-  volar-service-prettier@0.0.70(@volar/language-service@2.4.28)(prettier@3.8.1):
+  volar-service-prettier@0.0.70(@volar/language-service@2.4.28)(prettier@3.8.3):
     dependencies:
       vscode-uri: 3.1.0
     optionalDependencies:
       "@volar/language-service": 2.4.28
-      prettier: 3.8.1
+      prettier: 3.8.3
 
   volar-service-typescript-twoslash-queries@0.0.70(@volar/language-service@2.4.28):
     dependencies:
@@ -18277,7 +18436,7 @@ snapshots:
       "@vscode/l10n": 0.0.18
       ajv: 8.18.0
       ajv-draft-04: 1.0.0(ajv@8.18.0)
-      prettier: 3.8.1
+      prettier: 3.8.3
       request-light: 0.5.8
       vscode-json-languageservice: 4.1.8
       vscode-languageserver: 9.0.1


### PR DESCRIPTION
Refreshes the workspace dependency set around Chat SDK 4.26, AI SDK, Nitro, Vitest, and related tooling, and regenerates the lockfile so the runtime, example app, docs, and eval packages stay aligned.

The behavior-sensitive part of the update is the Chat SDK compatibility work. JuniorChat now forwards WebhookOptions into action and slash-command handling so waitUntil and modal flows still work with 4.26, and our Slack stream patch now keeps the upstream renderer table-append setting while preserving the Junior lower buffer and eager plain-text flush.

I also cleaned up a few issues the refresh exposed: the example build-discovery integration now relinks without rerunning workspace prepare hooks, Slack attachment tests clear leaked bot tokens, the oauth resume harness gets enough timeout headroom, and the eval gh stub writes synchronously so execFile does not intermittently lose output.

I reviewed the relevant chat-sdk changes before wiring this so the integration matches upstream behavior instead of carrying another local divergence.

Ran the full root test suite and the full eval suite locally after the update.