### PR TITLE
feat(slack): Add finalized reply footer diagnostics

### DIFF
--- a/packages/junior/src/chat/logging.ts
+++ b/packages/junior/src/chat/logging.ts
@@ -16,6 +16,7 @@ import type {
 } from "chat";
 import { toOptionalNumber, toOptionalString } from "@/chat/coerce";
 import * as Sentry from "@/chat/sentry";
+import type { AgentTurnUsage } from "@/chat/usage";
 
 type Primitive = string | number | boolean;
 type AttributeValue = Primitive | string[];
@@ -1765,12 +1766,6 @@ export function serializeGenAiAttribute(
   return truncateGenAiString(serialized, maxChars);
 }
 
-export interface GenAiUsageSummary {
-  inputTokens?: number;
-  outputTokens?: number;
-  totalTokens?: number;
-}
-
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object"
     ? (value as Record<string, unknown>)
@@ -1839,7 +1834,7 @@ function collectUsageRoots(source: unknown): Record<string, unknown>[] {
 /** Extract a structured token-usage summary from provider metadata roots. */
 export function extractGenAiUsageSummary(
   ...sources: unknown[]
-): GenAiUsageSummary {
+): AgentTurnUsage {
   const roots = sources.flatMap((source) => collectUsageRoots(source));
   if (roots.length === 0) {
     return {};

--- a/packages/junior/src/chat/logging.ts
+++ b/packages/junior/src/chat/logging.ts
@@ -1765,6 +1765,12 @@ export function serializeGenAiAttribute(
   return truncateGenAiString(serialized, maxChars);
 }
 
+export interface GenAiUsageSummary {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+}
+
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object"
     ? (value as Record<string, unknown>)
@@ -1830,12 +1836,10 @@ function collectUsageRoots(source: unknown): Record<string, unknown>[] {
   return roots;
 }
 
-/** Extract input/output token counts from AI provider usage metadata. */
-export function extractGenAiUsageAttributes(
+/** Extract a structured token-usage summary from provider metadata roots. */
+export function extractGenAiUsageSummary(
   ...sources: unknown[]
-): Partial<
-  Record<"gen_ai.usage.input_tokens" | "gen_ai.usage.output_tokens", number>
-> {
+): GenAiUsageSummary {
   const roots = sources.flatMap((source) => collectUsageRoots(source));
   if (roots.length === 0) {
     return {};
@@ -1868,6 +1872,32 @@ export function extractGenAiUsageAttributes(
         ]),
       )
       .find((value) => value !== undefined) ?? undefined;
+
+  const totalTokens =
+    roots
+      .map((root) =>
+        readTokenCount(root, [
+          "total_tokens",
+          "totalTokens",
+          "totalTokenCount",
+        ]),
+      )
+      .find((value) => value !== undefined) ?? undefined;
+
+  return {
+    ...(inputTokens !== undefined ? { inputTokens } : {}),
+    ...(outputTokens !== undefined ? { outputTokens } : {}),
+    ...(totalTokens !== undefined ? { totalTokens } : {}),
+  };
+}
+
+/** Extract input/output token counts from AI provider usage metadata for tracing. */
+export function extractGenAiUsageAttributes(
+  ...sources: unknown[]
+): Partial<
+  Record<"gen_ai.usage.input_tokens" | "gen_ai.usage.output_tokens", number>
+> {
+  const { inputTokens, outputTokens } = extractGenAiUsageSummary(...sources);
 
   return {
     ...(inputTokens !== undefined

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -72,8 +72,8 @@ import {
   buildTurnResult,
   type AssistantReply,
   type AgentTurnDiagnostics,
-  type AgentTurnUsage,
 } from "@/chat/services/turn-result";
+import type { AgentTurnUsage } from "@/chat/usage";
 import {
   loadTurnCheckpoint,
   persistCompletedCheckpoint,

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -2,14 +2,12 @@ import { Agent, type AgentMessage } from "@mariozechner/pi-agent-core";
 import type { FileUpload } from "chat";
 import { botConfig } from "@/chat/config";
 import {
-  extractGenAiUsageAttributes,
-  serializeGenAiAttribute,
-} from "@/chat/logging";
-import {
+  extractGenAiUsageSummary,
   getActiveTraceId,
   logException,
   logInfo,
   logWarn,
+  serializeGenAiAttribute,
   setSpanAttributes,
   setTags,
   withSpan,
@@ -74,6 +72,7 @@ import {
   buildTurnResult,
   type AssistantReply,
   type AgentTurnDiagnostics,
+  type AgentTurnUsage,
 } from "@/chat/services/turn-result";
 import {
   loadTurnCheckpoint,
@@ -185,6 +184,7 @@ export async function generateAssistantReply(
   messageText: string,
   context: ReplyRequestContext = {},
 ): Promise<AssistantReply> {
+  const replyStartedAtMs = Date.now();
   let timeoutResumeConversationId: string | undefined;
   let timeoutResumeSessionId: string | undefined;
   let timeoutResumeSliceId = 1;
@@ -196,6 +196,7 @@ export async function generateAssistantReply(
   let mcpToolManager: McpToolManager | undefined;
   let sandboxExecutor: SandboxExecutor | undefined;
   let timedOut = false;
+  let turnUsage: AgentTurnUsage | undefined;
 
   const getSandboxMetadata = () =>
     sandboxExecutor
@@ -816,16 +817,27 @@ export async function generateAssistantReply(
           const outputMessages = newMessages.filter(isAssistantMessage);
           const outputMessagesAttribute =
             serializeGenAiAttribute(outputMessages);
-          const usageAttributes = extractGenAiUsageAttributes(
+          const usageSummary = extractGenAiUsageSummary(
             promptResult,
             agent.state,
             ...outputMessages,
           );
+          turnUsage =
+            usageSummary.inputTokens !== undefined ||
+            usageSummary.outputTokens !== undefined ||
+            usageSummary.totalTokens !== undefined
+              ? usageSummary
+              : undefined;
           setSpanAttributes({
             ...(outputMessagesAttribute
               ? { "gen_ai.output.messages": outputMessagesAttribute }
               : {}),
-            ...usageAttributes,
+            ...(usageSummary.inputTokens !== undefined
+              ? { "gen_ai.usage.input_tokens": usageSummary.inputTokens }
+              : {}),
+            ...(usageSummary.outputTokens !== undefined
+              ? { "gen_ai.usage.output_tokens": usageSummary.outputTokens }
+              : {}),
           });
         },
         {
@@ -870,9 +882,11 @@ export async function generateAssistantReply(
       sandboxId: currentSandboxExecutor.getSandboxId(),
       sandboxDependencyProfileHash:
         currentSandboxExecutor.getDependencyProfileHash(),
+      durationMs: Date.now() - replyStartedAtMs,
       generatedFileCount: generatedFiles.length,
       shouldTrace,
       spanContext,
+      usage: turnUsage,
       correlation: context.correlation,
       assistantUserName: context.assistant?.userName,
     });
@@ -972,6 +986,7 @@ export async function generateAssistantReply(
         toolResultCount: 0,
         toolErrorCount: 0,
         usedPrimaryText: false,
+        durationMs: Date.now() - replyStartedAtMs,
         errorMessage: message,
         providerError: error,
       },

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -3,6 +3,7 @@ import type { SlackAdapter } from "@chat-adapter/slack";
 import { botConfig } from "@/chat/config";
 import { getSlackMessageTs } from "@/chat/slack/message";
 import {
+  getActiveTraceId,
   logException,
   logInfo,
   logWarn,
@@ -12,6 +13,7 @@ import {
 } from "@/chat/logging";
 import {
   planSlackReplyPosts,
+  postSlackApiReplyPosts,
   type PlannedSlackReplyStage,
 } from "@/chat/slack/reply";
 import { buildSlackOutputMessage } from "@/chat/slack/output";
@@ -48,6 +50,7 @@ import {
   isVisionEnabled,
 } from "@/chat/services/vision-context";
 import { createSlackAdapterAssistantStatusSession } from "@/chat/slack/assistant-thread/status";
+import { buildSlackReplyFooter } from "@/chat/slack/footer";
 import { maybeUpdateAssistantTitle } from "@/chat/slack/assistant-thread/title";
 import { type ThreadArtifactsState } from "@/chat/state/artifacts";
 import { lookupSlackUser } from "@/chat/slack/user";
@@ -58,6 +61,7 @@ import { buildDeterministicTurnId } from "@/chat/runtime/turn";
 import { markTurnCompleted, markTurnFailed } from "@/chat/runtime/turn";
 import { startActiveTurn } from "@/chat/runtime/turn";
 import { isRedundantReactionAckText } from "@/chat/services/reply-delivery-plan";
+import { deleteSlackMessage } from "@/chat/slack/outbound";
 
 export interface ReplyExecutorServices {
   generateAssistantReply: typeof generateAssistantReplyImpl;
@@ -435,16 +439,73 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             "slackMessageAddReaction",
           );
           const plannedPosts = planSlackReplyPosts({ reply });
+          const replyFooter = buildSlackReplyFooter({
+            conversationId,
+            durationMs: reply.diagnostics.durationMs,
+            traceId: getActiveTraceId(),
+            usage: reply.diagnostics.usage,
+          });
+          const shouldUseSlackFooter =
+            Boolean(replyFooter) &&
+            Boolean(channelId && threadTs) &&
+            (thread.adapter as { name?: string } | undefined)?.name === "slack";
 
           // Final Slack delivery is part of turn success. We only mark the turn
           // completed after the visible reply has been accepted by Slack.
           if (plannedPosts.length > 0) {
             let sent: SentMessage | undefined;
-            for (const post of plannedPosts) {
-              sent = await postThreadReply(
-                buildSlackOutputMessage(post.text, post.files),
-                post.stage,
-              );
+            if (shouldUseSlackFooter) {
+              const slackChannelId = channelId;
+              const slackThreadTs = threadTs;
+              if (!slackChannelId || !slackThreadTs) {
+                throw new Error(
+                  "Slack footer delivery requires a concrete channel and thread timestamp",
+                );
+              }
+
+              const sentMessageTs = await postSlackApiReplyPosts({
+                beforePost: beforeFirstResponsePost,
+                channelId: slackChannelId,
+                threadTs: slackThreadTs,
+                posts: plannedPosts,
+                fileUploadFailureMode: "strict",
+                footer: replyFooter,
+                onPostError: ({ error, messageTs, stage }) => {
+                  logException(
+                    error,
+                    "slack_thread_post_failed",
+                    turnTraceContext,
+                    {
+                      "app.slack.reply_stage": stage,
+                      ...(messageTs
+                        ? { "messaging.message.id": messageTs }
+                        : {}),
+                      ...getSlackErrorObservabilityAttributes(error),
+                    },
+                    "Failed to post Slack thread reply",
+                  );
+                },
+              });
+
+              if (sentMessageTs) {
+                sent = {
+                  id: sentMessageTs,
+                  text: reply.text,
+                  delete: async () => {
+                    await deleteSlackMessage({
+                      channelId: slackChannelId,
+                      timestamp: sentMessageTs,
+                    });
+                  },
+                } as SentMessage;
+              }
+            } else {
+              for (const post of plannedPosts) {
+                sent = await postThreadReply(
+                  buildSlackOutputMessage(post.text, post.files),
+                  post.stage,
+                );
+              }
             }
             const firstPlannedMessageHasFiles =
               (plannedPosts[0]?.files?.length ?? 0) > 0;

--- a/packages/junior/src/chat/services/turn-result.ts
+++ b/packages/junior/src/chat/services/turn-result.ts
@@ -23,8 +23,15 @@ import {
   summarizeMessageText,
 } from "@/chat/respond-helpers";
 
+export interface AgentTurnUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+}
+
 export interface AgentTurnDiagnostics {
   assistantMessageCount: number;
+  durationMs?: number;
   errorMessage?: string;
   providerError?: unknown;
   modelId: string;
@@ -33,6 +40,7 @@ export interface AgentTurnDiagnostics {
   toolCalls: string[];
   toolErrorCount: number;
   toolResultCount: number;
+  usage?: AgentTurnUsage;
   usedPrimaryText: boolean;
 }
 
@@ -55,9 +63,11 @@ export interface TurnResultInput {
   toolCalls: string[];
   sandboxId?: string;
   sandboxDependencyProfileHash?: string;
+  durationMs?: number;
   generatedFileCount: number;
   shouldTrace: boolean;
   spanContext: LogContext;
+  usage?: AgentTurnUsage;
   correlation?: {
     threadId?: string;
     requesterId?: string;
@@ -77,8 +87,10 @@ export function buildTurnResult(input: TurnResultInput): AssistantReply {
     toolCalls,
     sandboxId,
     sandboxDependencyProfileHash,
+    durationMs,
     shouldTrace,
     spanContext,
+    usage,
     correlation,
     assistantUserName,
   } = input;
@@ -192,6 +204,8 @@ export function buildTurnResult(input: TurnResultInput): AssistantReply {
     toolResultCount: toolResults.length,
     toolErrorCount,
     usedPrimaryText,
+    durationMs,
+    usage,
     stopReason,
     errorMessage,
     providerError: undefined,

--- a/packages/junior/src/chat/services/turn-result.ts
+++ b/packages/junior/src/chat/services/turn-result.ts
@@ -2,6 +2,7 @@ import type { FileUpload } from "chat";
 import { botConfig } from "@/chat/config";
 import { logInfo, logWarn } from "@/chat/logging";
 import type { LogContext } from "@/chat/logging";
+import type { AgentTurnUsage } from "@/chat/usage";
 import {
   buildReplyDeliveryPlan,
   type ReplyDeliveryPlan,
@@ -22,12 +23,6 @@ import {
   normalizeToolNameFromResult,
   summarizeMessageText,
 } from "@/chat/respond-helpers";
-
-export interface AgentTurnUsage {
-  inputTokens?: number;
-  outputTokens?: number;
-  totalTokens?: number;
-}
 
 export interface AgentTurnDiagnostics {
   assistantMessageCount: number;

--- a/packages/junior/src/chat/slack/footer.ts
+++ b/packages/junior/src/chat/slack/footer.ts
@@ -1,4 +1,4 @@
-import type { AgentTurnUsage } from "@/chat/services/turn-result";
+import type { AgentTurnUsage } from "@/chat/usage";
 
 interface SlackMrkdwnTextObject {
   text: string;

--- a/packages/junior/src/chat/slack/footer.ts
+++ b/packages/junior/src/chat/slack/footer.ts
@@ -1,0 +1,136 @@
+import type { AgentTurnUsage } from "@/chat/services/turn-result";
+
+interface SlackMrkdwnTextObject {
+  text: string;
+  type: "mrkdwn";
+}
+
+interface SlackSectionBlock {
+  text: SlackMrkdwnTextObject;
+  type: "section";
+}
+
+interface SlackContextBlock {
+  elements: SlackMrkdwnTextObject[];
+  type: "context";
+}
+
+export type SlackMessageBlock = SlackSectionBlock | SlackContextBlock;
+
+export interface SlackReplyFooterItem {
+  label: string;
+  value: string;
+}
+
+export interface SlackReplyFooter {
+  items: SlackReplyFooterItem[];
+}
+
+function escapeSlackMrkdwn(text: string): string {
+  return text
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function formatSlackTokenCount(value: number): string {
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+function formatSlackDuration(durationMs: number): string {
+  if (durationMs < 1_000) {
+    return `${durationMs}ms`;
+  }
+
+  const durationSeconds = durationMs / 1_000;
+  if (durationSeconds < 10) {
+    return `${durationSeconds.toFixed(1).replace(/\.0$/, "")}s`;
+  }
+
+  return `${Math.round(durationSeconds)}s`;
+}
+
+function resolveTotalTokens(
+  usage: AgentTurnUsage | undefined,
+): number | undefined {
+  if (usage?.totalTokens !== undefined) {
+    return usage.totalTokens;
+  }
+
+  if (usage?.inputTokens !== undefined && usage.outputTokens !== undefined) {
+    return usage.inputTokens + usage.outputTokens;
+  }
+
+  return undefined;
+}
+
+/** Build a compact Slack reply footer so operators can correlate visible replies with backend state. */
+export function buildSlackReplyFooter(args: {
+  conversationId?: string;
+  durationMs?: number;
+  traceId?: string;
+  usage?: AgentTurnUsage;
+}): SlackReplyFooter | undefined {
+  const items: SlackReplyFooterItem[] = [];
+
+  const conversationId = args.conversationId?.trim();
+  if (conversationId) {
+    items.push({
+      label: "ID",
+      value: conversationId,
+    });
+  }
+
+  const totalTokens = resolveTotalTokens(args.usage);
+  if (totalTokens !== undefined) {
+    items.push({
+      label: "Tokens",
+      value: formatSlackTokenCount(totalTokens),
+    });
+  }
+
+  if (typeof args.durationMs === "number" && Number.isFinite(args.durationMs)) {
+    const durationMs = Math.max(0, Math.floor(args.durationMs));
+    items.push({
+      label: "Time",
+      value: formatSlackDuration(durationMs),
+    });
+  }
+
+  const traceId = args.traceId?.trim();
+  if (traceId) {
+    items.push({
+      label: "Trace",
+      value: traceId,
+    });
+  }
+
+  return items.length > 0 ? { items } : undefined;
+}
+
+/** Build Slack blocks for a finalized reply plus its optional footer context block. */
+export function buildSlackReplyBlocks(
+  text: string,
+  footer: SlackReplyFooter | undefined,
+): SlackMessageBlock[] | undefined {
+  if (!text.trim() || !footer?.items.length) {
+    return undefined;
+  }
+
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text,
+      },
+    },
+    {
+      type: "context",
+      elements: footer.items.map((item) => ({
+        type: "mrkdwn",
+        text: `*${escapeSlackMrkdwn(item.label)}:* ${escapeSlackMrkdwn(item.value)}`,
+      })),
+    },
+  ];
+}

--- a/packages/junior/src/chat/slack/outbound.ts
+++ b/packages/junior/src/chat/slack/outbound.ts
@@ -1,4 +1,5 @@
 import { SlackActionError } from "@/chat/slack/client";
+import type { SlackMessageBlock } from "@/chat/slack/footer";
 import {
   getSlackClient,
   normalizeSlackConversationId,
@@ -69,6 +70,7 @@ async function getPermalinkBestEffort(args: {
 
 /** Post Slack `mrkdwn` text to a conversation or thread via the shared outbound boundary. */
 export async function postSlackMessage(input: {
+  blocks?: SlackMessageBlock[];
   channelId: string;
   text: string;
   threadTs?: string;
@@ -92,6 +94,11 @@ export async function postSlackMessage(input: {
         channel: channelId,
         text,
         mrkdwn: true,
+        ...(input.blocks?.length
+          ? {
+              blocks: input.blocks as unknown as Array<Record<string, unknown>>,
+            }
+          : {}),
         ...(threadTs ? { thread_ts: threadTs } : {}),
       }),
     3,
@@ -113,6 +120,31 @@ export async function postSlackMessage(input: {
         }
       : {}),
   };
+}
+
+/** Delete a previously posted Slack message through the shared outbound boundary. */
+export async function deleteSlackMessage(input: {
+  channelId: string;
+  timestamp: string;
+}): Promise<void> {
+  const channelId = requireSlackConversationId(
+    input.channelId,
+    "Slack message deletion",
+  );
+  const timestamp = requireSlackMessageTimestamp(
+    input.timestamp,
+    "Slack message deletion",
+  );
+
+  await withSlackRetries(
+    () =>
+      getSlackClient().chat.delete({
+        channel: channelId,
+        ts: timestamp,
+      }),
+    3,
+    { action: "chat.delete" },
+  );
 }
 
 /**

--- a/packages/junior/src/chat/slack/reply.ts
+++ b/packages/junior/src/chat/slack/reply.ts
@@ -2,7 +2,11 @@ import { Buffer } from "node:buffer";
 import type { FileUpload } from "chat";
 import type { AssistantReply } from "@/chat/respond";
 import type { ReplyFileDelivery } from "@/chat/services/reply-delivery-plan";
-import { uploadFilesToThread } from "@/chat/slack/outbound";
+import {
+  buildSlackReplyBlocks,
+  type SlackReplyFooter,
+} from "@/chat/slack/footer";
+import { postSlackMessage, uploadFilesToThread } from "@/chat/slack/outbound";
 import {
   buildSlackOutputMessage,
   splitSlackReplyText,
@@ -102,8 +106,19 @@ async function normalizeFileUploads(
   );
 }
 
-async function uploadReplyFilesBestEffort(args: {
+function findLastTextPostIndex(posts: PlannedSlackReplyPost[]): number {
+  for (let index = posts.length - 1; index >= 0; index -= 1) {
+    if (posts[index]?.text.trim().length) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+async function uploadReplyFiles(args: {
   channelId: string;
+  failureMode: "best_effort" | "strict";
   threadTs: string;
   files: FileUpload[];
 }): Promise<void> {
@@ -113,7 +128,11 @@ async function uploadReplyFilesBestEffort(args: {
       threadTs: args.threadTs,
       files: await normalizeFileUploads(args.files),
     });
-  } catch {
+  } catch (error) {
+    if (args.failureMode === "strict") {
+      throw error;
+    }
+
     // File followups should not turn a delivered resume reply into a failed turn.
   }
 }
@@ -173,28 +192,62 @@ export function planSlackReplyPosts(args: {
  * callback handlers that do not have a Chat SDK thread object.
  */
 export async function postSlackApiReplyPosts(args: {
+  beforePost?: () => Promise<void>;
+  footer?: SlackReplyFooter;
   channelId: string;
+  fileUploadFailureMode?: "best_effort" | "strict";
+  onPostError?: (context: {
+    error: unknown;
+    messageTs?: string;
+    stage: PlannedSlackReplyStage;
+  }) => Promise<void> | void;
   threadTs: string;
   posts: PlannedSlackReplyPost[];
-  postMessage: (
-    channelId: string,
-    threadTs: string,
-    text: string,
-  ) => Promise<void>;
-}): Promise<void> {
-  for (const post of args.posts) {
-    if (post.text.trim().length > 0) {
-      await args.postMessage(args.channelId, args.threadTs, post.text);
+}): Promise<string | undefined> {
+  const lastTextPostIndex = findLastTextPostIndex(args.posts);
+  let lastPostedMessageTs: string | undefined;
+
+  for (const [index, post] of args.posts.entries()) {
+    const hasVisibleDelivery =
+      post.text.trim().length > 0 || post.files?.length;
+    if (hasVisibleDelivery) {
+      await args.beforePost?.();
     }
 
-    if (!post.files?.length) {
-      continue;
-    }
+    let messageTs: string | undefined;
+    try {
+      if (post.text.trim().length > 0) {
+        const response = await postSlackMessage({
+          channelId: args.channelId,
+          threadTs: args.threadTs,
+          text: post.text,
+          ...(index === lastTextPostIndex && args.footer
+            ? { blocks: buildSlackReplyBlocks(post.text, args.footer) }
+            : {}),
+        });
+        messageTs = response.ts;
+        lastPostedMessageTs = response.ts;
+      }
 
-    await uploadReplyFilesBestEffort({
-      channelId: args.channelId,
-      threadTs: args.threadTs,
-      files: post.files,
-    });
+      if (!post.files?.length) {
+        continue;
+      }
+
+      await uploadReplyFiles({
+        channelId: args.channelId,
+        failureMode: args.fileUploadFailureMode ?? "best_effort",
+        threadTs: args.threadTs,
+        files: post.files,
+      });
+    } catch (error) {
+      await args.onPostError?.({
+        error,
+        messageTs,
+        stage: post.stage,
+      });
+      throw error;
+    }
   }
+
+  return lastPostedMessageTs;
 }

--- a/packages/junior/src/chat/slack/resume.ts
+++ b/packages/junior/src/chat/slack/resume.ts
@@ -1,5 +1,6 @@
 import { botConfig } from "@/chat/config";
 import type { ChannelConfigurationService } from "@/chat/configuration/types";
+import { getActiveTraceId } from "@/chat/logging";
 import {
   generateAssistantReply,
   type AssistantReply,
@@ -11,6 +12,7 @@ import {
   createSlackWebApiAssistantStatusSession,
   type AssistantStatusSession,
 } from "@/chat/slack/assistant-thread/status";
+import { buildSlackReplyFooter } from "@/chat/slack/footer";
 import {
   planSlackReplyPosts,
   postSlackApiReplyPosts,
@@ -32,29 +34,17 @@ function resolveReplyTimeoutMs(explicitTimeoutMs?: number): number | undefined {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
 
-/**
- * Post the final visible Slack thread reply and surface delivery failures so
- * callers can decide whether the turn actually succeeded.
- */
-export async function postSlackMessage(
-  channelId: string,
-  threadTs: string,
-  text: string,
-): Promise<void> {
-  await postSlackApiMessage({
-    channelId,
-    threadTs,
-    text,
-  });
-}
-
 async function postSlackMessageBestEffort(
   channelId: string,
   threadTs: string,
   text: string,
 ): Promise<void> {
   try {
-    await postSlackMessage(channelId, threadTs, text);
+    await postSlackApiMessage({
+      channelId,
+      threadTs,
+      text,
+    });
   } catch {
     // Best effort.
   }
@@ -233,11 +223,18 @@ export async function resumeSlackTurn(args: ResumeSlackTurnArgs) {
         : await replyPromise;
 
     await status.stop();
+    const footer = buildSlackReplyFooter({
+      conversationId: args.replyContext?.correlation?.conversationId ?? lockKey,
+      durationMs: reply.diagnostics.durationMs,
+      traceId: getActiveTraceId(),
+      usage: reply.diagnostics.usage,
+    });
     await postSlackApiReplyPosts({
       channelId: args.channelId,
       threadTs: args.threadTs,
       posts: planSlackReplyPosts({ reply }),
-      postMessage: postSlackMessage,
+      fileUploadFailureMode: "best_effort",
+      footer,
     });
     await args.onSuccess?.(reply);
   } catch (error) {

--- a/packages/junior/src/chat/usage.ts
+++ b/packages/junior/src/chat/usage.ts
@@ -1,0 +1,5 @@
+export interface AgentTurnUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+}

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -7,7 +7,8 @@ import {
   resolveBaseUrl,
 } from "@/chat/oauth-flow";
 import { buildConversationContext } from "@/chat/services/conversation-memory";
-import { resumeAuthorizedRequest, postSlackMessage } from "@/chat/slack/resume";
+import { postSlackMessage } from "@/chat/slack/outbound";
+import { resumeAuthorizedRequest } from "@/chat/slack/resume";
 import { logException, logInfo } from "@/chat/logging";
 import { htmlCallbackResponse } from "@/handlers/oauth-html";
 import { getPersistedThreadState } from "@/chat/runtime/thread-state";
@@ -260,11 +261,11 @@ export async function GET(
   } else if (stored.channelId && stored.threadTs) {
     const { channelId, threadTs } = stored;
     waitUntil(() =>
-      postSlackMessage(
+      postSlackMessage({
         channelId,
         threadTs,
-        `Your ${providerLabel} account is now connected. You can start using ${providerLabel} commands.`,
-      ),
+        text: `Your ${providerLabel} account is now connected. You can start using ${providerLabel} commands.`,
+      }),
     );
   }
 

--- a/packages/junior/tests/integration/oauth-resume-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-resume-slack.test.ts
@@ -11,7 +11,10 @@ import {
   queueSlackApiError,
 } from "../msw/handlers/slack-api";
 
-function makeDiagnostics(outcome: "success" | "provider_error" = "success") {
+function makeDiagnostics(
+  outcome: "success" | "provider_error" = "success",
+  extras: Record<string, unknown> = {},
+) {
   return {
     assistantMessageCount: 1,
     modelId: "fake-agent-model",
@@ -20,6 +23,7 @@ function makeDiagnostics(outcome: "success" | "provider_error" = "success") {
     toolErrorCount: 0,
     toolResultCount: 0,
     usedPrimaryText: true,
+    ...extras,
   };
 }
 
@@ -51,7 +55,12 @@ describe("oauth resume slack integration", () => {
       generateReply: async () =>
         ({
           text: "The budget deadline you mentioned earlier was Friday.",
-          diagnostics: makeDiagnostics(),
+          diagnostics: makeDiagnostics("success", {
+            durationMs: 842,
+            usage: {
+              totalTokens: 1234,
+            },
+          }),
         }) as any,
     });
 
@@ -83,6 +92,34 @@ describe("oauth resume slack integration", () => {
       }),
       expect.objectContaining({
         params: expect.objectContaining({
+          blocks: [
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: "The budget deadline you mentioned earlier was Friday.",
+              },
+            },
+            {
+              type: "context",
+              elements: expect.arrayContaining([
+                expect.objectContaining({
+                  type: "mrkdwn",
+                  text: expect.stringContaining(
+                    "*ID:* slack:C123:1700000000.001",
+                  ),
+                }),
+                expect.objectContaining({
+                  type: "mrkdwn",
+                  text: "*Tokens:* 1,234",
+                }),
+                expect.objectContaining({
+                  type: "mrkdwn",
+                  text: "*Time:* 842ms",
+                }),
+              ]),
+            },
+          ],
           channel: "C123",
           thread_ts: "1700000000.001",
           text: "The budget deadline you mentioned earlier was Friday.",

--- a/packages/junior/tests/integration/slack/message-changed-reply-contract.test.ts
+++ b/packages/junior/tests/integration/slack/message-changed-reply-contract.test.ts
@@ -148,6 +148,30 @@ describe("Slack contract: edited-message reply delivery", () => {
     expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([
       expect.objectContaining({
         params: expect.objectContaining({
+          blocks: [
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: "Hello world",
+              },
+            },
+            {
+              type: "context",
+              elements: expect.arrayContaining([
+                expect.objectContaining({
+                  type: "mrkdwn",
+                  text: expect.stringContaining(
+                    "*ID:* slack:D12345:1700000100.000100",
+                  ),
+                }),
+                expect.objectContaining({
+                  type: "mrkdwn",
+                  text: expect.stringContaining("*Trace:* "),
+                }),
+              ]),
+            },
+          ],
           channel: "D12345",
           thread_ts: "1700000100.000100",
           text: "Hello world",

--- a/packages/junior/tests/integration/slack/outbound-normalization-contract.test.ts
+++ b/packages/junior/tests/integration/slack/outbound-normalization-contract.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  buildSlackReplyBlocks,
+  buildSlackReplyFooter,
+} from "@/chat/slack/footer";
+import {
   addReactionToMessage,
   postSlackMessage,
   uploadFilesToThread,
@@ -32,6 +36,50 @@ describe("Slack contract: outbound normalization", () => {
         params: expect.objectContaining({
           channel: "C123",
           text: "hello",
+        }),
+      }),
+    ]);
+  });
+
+  it("passes block payloads with a top-level fallback text", async () => {
+    const footer = buildSlackReplyFooter({
+      conversationId: "slack:C123:1700000000.000100",
+      traceId: "trace_123",
+    });
+
+    await postSlackMessage({
+      channelId: "slack:C123",
+      text: "hello",
+      blocks: buildSlackReplyBlocks("hello", footer),
+    });
+
+    expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({
+          channel: "C123",
+          text: "hello",
+          blocks: [
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: "hello",
+              },
+            },
+            {
+              type: "context",
+              elements: [
+                {
+                  type: "mrkdwn",
+                  text: "*ID:* slack:C123:1700000000.000100",
+                },
+                {
+                  type: "mrkdwn",
+                  text: "*Trace:* trace_123",
+                },
+              ],
+            },
+          ],
         }),
       }),
     ]);

--- a/packages/junior/tests/msw/handlers/slack-api.ts
+++ b/packages/junior/tests/msw/handlers/slack-api.ts
@@ -29,6 +29,7 @@ export const SUPPORTED_SLACK_API_METHODS = [
   "assistant.threads.setSuggestedPrompts",
   "assistant.threads.setTitle",
   "chat.postMessage",
+  "chat.delete",
   "chat.postEphemeral",
   "chat.getPermalink",
   "views.publish",
@@ -179,6 +180,8 @@ function defaultSlackApiResponse(
       return { body: slackOk() };
     case "chat.postMessage":
       return { body: chatPostMessageOk() };
+    case "chat.delete":
+      return { body: slackOk() };
     case "chat.postEphemeral":
       return { body: chatPostEphemeralOk() };
     case "chat.getPermalink":

--- a/packages/junior/tests/unit/slack/footer.test.ts
+++ b/packages/junior/tests/unit/slack/footer.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSlackReplyBlocks,
+  buildSlackReplyFooter,
+} from "@/chat/slack/footer";
+
+describe("buildSlackReplyFooter", () => {
+  it("returns compact footer items for available diagnostics", () => {
+    expect(
+      buildSlackReplyFooter({
+        conversationId: "slack:C123:1700000000.000100",
+        durationMs: 842,
+        traceId: "0123456789abcdef0123456789abcdef",
+        usage: {
+          totalTokens: 1234,
+        },
+      }),
+    ).toEqual({
+      items: [
+        {
+          label: "ID",
+          value: "slack:C123:1700000000.000100",
+        },
+        {
+          label: "Tokens",
+          value: "1,234",
+        },
+        {
+          label: "Time",
+          value: "842ms",
+        },
+        {
+          label: "Trace",
+          value: "0123456789abcdef0123456789abcdef",
+        },
+      ],
+    });
+  });
+
+  it("omits the footer when no items are available", () => {
+    expect(buildSlackReplyFooter({})).toBeUndefined();
+  });
+});
+
+describe("buildSlackReplyBlocks", () => {
+  it("renders the reply body plus a Slack context footer block", () => {
+    const footer = buildSlackReplyFooter({
+      conversationId: "slack:C123:1700000000.000100",
+      durationMs: 1250,
+      traceId: "trace_123",
+      usage: {
+        inputTokens: 400,
+        outputTokens: 250,
+      },
+    });
+
+    expect(buildSlackReplyBlocks("Hello world", footer)).toEqual([
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: "Hello world",
+        },
+      },
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: "*ID:* slack:C123:1700000000.000100",
+          },
+          {
+            type: "mrkdwn",
+            text: "*Tokens:* 650",
+          },
+          {
+            type: "mrkdwn",
+            text: "*Time:* 1.3s",
+          },
+          {
+            type: "mrkdwn",
+            text: "*Trace:* trace_123",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("does not emit blocks when the reply has no visible text", () => {
+    const footer = buildSlackReplyFooter({
+      conversationId: "slack:C123:1700000000.000100",
+    });
+
+    expect(buildSlackReplyBlocks("   ", footer)).toBeUndefined();
+  });
+});

--- a/packages/junior/tests/unit/turn-result.test.ts
+++ b/packages/junior/tests/unit/turn-result.test.ts
@@ -110,4 +110,36 @@ describe("buildTurnResult", () => {
     expect(reply.diagnostics.outcome).toBe("success");
     expect(reply.diagnostics.usedPrimaryText).toBe(true);
   });
+
+  it("preserves structured timing and usage diagnostics", () => {
+    const reply = buildTurnResult({
+      newMessages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Done." }],
+          stopReason: "stop",
+        },
+      ],
+      userInput: "Do the thing",
+      replyFiles: [],
+      artifactStatePatch: {},
+      toolCalls: [],
+      durationMs: 1532,
+      generatedFileCount: 0,
+      shouldTrace: false,
+      spanContext: {},
+      usage: {
+        inputTokens: 321,
+        outputTokens: 144,
+        totalTokens: 465,
+      },
+    });
+
+    expect(reply.diagnostics.durationMs).toBe(1532);
+    expect(reply.diagnostics.usage).toEqual({
+      inputTokens: 321,
+      outputTokens: 144,
+      totalTokens: 465,
+    });
+  });
 });

--- a/specs/slack-agent-delivery-spec.md
+++ b/specs/slack-agent-delivery-spec.md
@@ -13,6 +13,7 @@
 - 2026-04-16: Clarified that Chat SDK Slack `thread.channelId` values are adapter-scoped (`slack:<channel>`) and must be normalized before assistant status/title API calls.
 - 2026-04-16: Corrected the assistant-thread context rule to match Slack assistant utilities: `message.im` uses `channel + thread_ts`, lifecycle events use `assistant_thread.channel_id + assistant_thread.thread_ts`, and runtime code does not synthesize a fallback from generic message `ts`.
 - 2026-04-16: Labeled long-running assistant status behavior as Slack-required behavior versus Junior runtime policy versus product policy.
+- 2026-04-16: Added an optional finalized-reply footer contract for Slack context-block metadata.
 
 ## Status
 
@@ -136,6 +137,8 @@ Current rules:
 4. If explicit user intent requested an in-channel post and that post already satisfied the request, Junior may suppress the thread text reply according to the reply-delivery plan.
 5. Persisted assistant conversation state must reflect the same finalized reply content the user saw, not provisional pre-tool text.
 6. Reply text must be rendered through the shared Slack output translator before delivery; raw Slack API writers do not own markdown translation rules.
+7. When Junior adds reply footer metadata, it attaches that metadata as a Slack `context` block on the final text chunk only, while keeping the main reply text as the top-level fallback.
+8. Footer metadata is derived from structured reply diagnostics and correlation state. Conversation ID, trace ID, token totals, and turn duration may be shown when available; footer rendering must not scrape logs or spans after the fact.
 
 This is intentional. Slack-native text streaming may still exist as an adapter capability, but it is not part of Junior's correctness contract.
 

--- a/specs/slack-outbound-contract-spec.md
+++ b/specs/slack-outbound-contract-spec.md
@@ -8,6 +8,7 @@
 ## Changelog
 
 - 2026-04-16: Initial canonical contract for Slack outbound operations and reply-text translation ownership.
+- 2026-04-16: Added support for finalized reply footers rendered as Slack context blocks with top-level text fallbacks.
 
 ## Status
 
@@ -63,6 +64,9 @@ Current rules:
 4. Thread replies pass `thread_ts`; channel posts omit it.
 5. Channel permalink lookup is best effort and must not turn a successful post into a failed action.
 6. Slack message posts use `text` with `mrkdwn` enabled; callers do not switch between competing text fields ad hoc.
+7. When a caller supplies Slack blocks, outbound posting still includes the top-level `text` fallback for notifications and accessibility.
+8. Finalized reply footers that show correlation or diagnostic metadata are rendered as Slack `context` blocks attached through the shared outbound boundary, not assembled ad hoc by callers.
+9. Footer values such as token counts and turn duration are passed as structured reply diagnostics into delivery. Outbound rendering formats those values for Slack; it does not derive them from tracing/logging side effects.
 
 ### 4. Ephemeral Message Contract
 
@@ -105,6 +109,7 @@ Current rules:
 2. Rate-limited Slack writes may be retried.
 3. Non-retryable Slack failures surface as `SlackActionError` values unless the contract explicitly defines them as idempotent success.
 4. Best-effort follow-on work, such as permalink lookup, must not retroactively fail a successful message post.
+5. Message deletion used for post-delivery cleanup goes through the shared outbound boundary.
 
 ## Observability
 
@@ -122,7 +127,7 @@ Required verification coverage for this contract:
 
 1. Unit: outbound-boundary validation and reaction idempotence.
 2. Unit: error mapping for Slack outbound-specific API errors.
-3. Integration: message-post request shape and permalink lookup behavior.
+3. Integration: message-post request shape, footer block shape, and permalink lookup behavior.
 4. Integration: file upload request flow and validation edges.
 5. Integration: reaction request shape and `already_reacted` success semantics.
 6. Runtime behavior tests continue to verify reply planning separately from raw Slack request details.


### PR DESCRIPTION
Add a finalized Slack reply footer that can show conversation metadata, token usage, turn timing, and trace identifiers on the last visible reply chunk.

This threads structured usage and duration through `AssistantReply` diagnostics so footer rendering consumes reply metadata directly instead of inferring it from tracing side effects. It also updates the footer presentation to read as lightweight Slack metadata rather than inline code.

I also collapsed the raw Slack API reply path into the shared Slack reply delivery module so live turns, resumed turns, and OAuth callback flows follow the same outbound footer/file/chunk behavior. That keeps the new footer contract in one place and avoids parallel delivery loops.