### PR TITLE
fix(web): Fix webSearch parallel_search tool registration and Sentry reporting

### DIFF
--- a/packages/junior/src/chat/tools/web/search.ts
+++ b/packages/junior/src/chat/tools/web/search.ts
@@ -41,98 +41,79 @@ function formatGatewayToolFailure(output: unknown): string | undefined {
   return undefined;
 }
 
-type GenerateTextStepContent = {
+type StepPart = {
   type: string;
   toolName?: string;
   output?: unknown;
   error?: unknown;
 };
 
-/**
- * Provider-executed Parallel Search can surface failures as `tool-error` parts or
- * error-shaped `tool-result` outputs; both must be handled explicitly.
- */
-function findParallelSearchGatewayFailure(
-  content: GenerateTextStepContent[],
+type SearchHit = { title: string; url: string; snippet: string };
+
+/** Failures often appear only on the step `content` array (not duplicated in `toolResults`). */
+function parallelSearchGatewayFailureFromContent(
+  content: StepPart[],
 ): string | undefined {
   for (const part of content) {
     if (part.toolName !== SEARCH_TOOL_NAME) {
       continue;
     }
     if (part.type === "tool-error") {
-      const message = formatGatewayToolFailure(part.error);
-      if (message) {
-        return message;
+      const detail = formatGatewayToolFailure(part.error);
+      if (detail) {
+        return detail;
       }
     }
-    if (part.type === "tool-result") {
-      const message = formatGatewayToolFailure(part.output);
-      if (message && isGatewayParallelSearchErrorOutput(part.output)) {
-        return message;
-      }
+    if (
+      part.type === "tool-result" &&
+      isGatewayParallelSearchErrorOutput(part.output)
+    ) {
+      const o = part.output;
+      return `${o.error}: ${o.message}`;
     }
   }
   return undefined;
 }
 
-function hadParallelSearchToolResult(response: {
-  content: GenerateTextStepContent[];
-  toolResults: GenerateTextStepContent[];
-}): boolean {
-  for (const part of [...response.content, ...response.toolResults]) {
-    if (part.type === "tool-result" && part.toolName === SEARCH_TOOL_NAME) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function parseSearchResults(
-  response: {
-    content: GenerateTextStepContent[];
-    toolResults: GenerateTextStepContent[];
-  },
+function collectParallelSearchHits(
+  content: StepPart[],
+  toolResults: StepPart[],
   maxResults: number,
-): Array<{ title: string; url: string; snippet: string }> {
-  const parsedResults: Array<{ title: string; url: string; snippet: string }> =
-    [];
-
-  const sources = [response.content, response.toolResults];
-  for (const typedResults of sources) {
-    for (const toolResult of typedResults) {
-      if (
-        toolResult.type !== "tool-result" ||
-        toolResult.toolName !== SEARCH_TOOL_NAME
-      ) {
+): { results: SearchHit[]; sawToolResult: boolean } {
+  const results: SearchHit[] = [];
+  let sawToolResult = false;
+  for (const part of [...content, ...toolResults]) {
+    if (part.type !== "tool-result" || part.toolName !== SEARCH_TOOL_NAME) {
+      continue;
+    }
+    sawToolResult = true;
+    const output = part.output;
+    if (isGatewayParallelSearchErrorOutput(output)) {
+      continue;
+    }
+    const rows = Array.isArray(
+      (output as { results?: unknown } | undefined)?.results,
+    )
+      ? ((output as { results: unknown[] }).results as Array<
+          Record<string, unknown>
+        >)
+      : [];
+    for (const row of rows) {
+      const url = asString(row.url);
+      if (!url) {
         continue;
       }
-
-      const output = toolResult.output as { results?: unknown } | undefined;
-      if (isGatewayParallelSearchErrorOutput(output)) {
-        continue;
-      }
-
-      const results = Array.isArray(output?.results)
-        ? (output.results as Array<Record<string, unknown>>)
-        : [];
-
-      for (const result of results) {
-        const url = asString(result.url);
-        if (!url) continue;
-        parsedResults.push({
-          title: asString(result.title) ?? url,
-          url,
-          snippet: asString(result.excerpt) ?? asString(result.snippet) ?? "",
-        });
-
-        if (parsedResults.length >= maxResults) {
-          return parsedResults;
-        }
+      results.push({
+        title: asString(row.title) ?? url,
+        url,
+        snippet: asString(row.excerpt) ?? asString(row.snippet) ?? "",
+      });
+      if (results.length >= maxResults) {
+        return { results, sawToolResult };
       }
     }
   }
-
-  return parsedResults;
+  return { results, sawToolResult };
 }
 
 function formatSearchFailure(error: unknown): string {
@@ -213,7 +194,7 @@ export function createWebSearchTool() {
           "webSearch",
         );
 
-        const gatewayFailureMessage = findParallelSearchGatewayFailure(
+        const gatewayFailureMessage = parallelSearchGatewayFailureFromContent(
           response.content,
         );
         if (gatewayFailureMessage) {
@@ -239,9 +220,13 @@ export function createWebSearchTool() {
           };
         }
 
-        const results = parseSearchResults(response, maxResults);
+        const { results, sawToolResult } = collectParallelSearchHits(
+          response.content,
+          response.toolResults,
+          maxResults,
+        );
 
-        if (results.length === 0 && !hadParallelSearchToolResult(response)) {
+        if (results.length === 0 && !sawToolResult) {
           const message =
             "web search failed: Parallel Search returned no tool result (possible tool name mismatch or gateway issue)";
           logException(

--- a/packages/junior/src/chat/tools/web/search.ts
+++ b/packages/junior/src/chat/tools/web/search.ts
@@ -2,12 +2,14 @@ import { tool } from "@/chat/tools/definition";
 import { generateText } from "ai";
 import { createGatewayProvider } from "@ai-sdk/gateway";
 import { Type } from "@sinclair/typebox";
+import { logException } from "@/chat/logging";
 import { withTimeout } from "@/chat/tools/web/network";
 
 const SEARCH_TIMEOUT_MS = 10_000;
 const MAX_RESULTS = 5;
 const DEFAULT_SEARCH_MODEL = "xai/grok-4-fast-reasoning";
-const SEARCH_TOOL_NAME = "parallelSearch";
+/** Client tool key must match the model/gateway tool name (see AI Gateway `gateway.parallel_search`). */
+const SEARCH_TOOL_NAME = "parallel_search";
 
 function asString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0
@@ -15,42 +17,117 @@ function asString(value: unknown): string | undefined {
     : undefined;
 }
 
+function isGatewayParallelSearchErrorOutput(
+  output: unknown,
+): output is { error: string; message: string } {
+  if (typeof output !== "object" || output === null) {
+    return false;
+  }
+  const record = output as Record<string, unknown>;
+  return (
+    typeof record.error === "string" &&
+    typeof record.message === "string" &&
+    !("results" in record)
+  );
+}
+
+function formatGatewayToolFailure(output: unknown): string | undefined {
+  if (typeof output === "string" && output.trim()) {
+    return output.trim();
+  }
+  if (isGatewayParallelSearchErrorOutput(output)) {
+    return `${output.error}: ${output.message}`;
+  }
+  return undefined;
+}
+
+type GenerateTextStepContent = {
+  type: string;
+  toolName?: string;
+  output?: unknown;
+  error?: unknown;
+};
+
+/**
+ * Provider-executed Parallel Search can surface failures as `tool-error` parts or
+ * error-shaped `tool-result` outputs; both must be handled explicitly.
+ */
+function findParallelSearchGatewayFailure(
+  content: GenerateTextStepContent[],
+): string | undefined {
+  for (const part of content) {
+    if (part.toolName !== SEARCH_TOOL_NAME) {
+      continue;
+    }
+    if (part.type === "tool-error") {
+      const message = formatGatewayToolFailure(part.error);
+      if (message) {
+        return message;
+      }
+    }
+    if (part.type === "tool-result") {
+      const message = formatGatewayToolFailure(part.output);
+      if (message && isGatewayParallelSearchErrorOutput(part.output)) {
+        return message;
+      }
+    }
+  }
+  return undefined;
+}
+
+function hadParallelSearchToolResult(response: {
+  content: GenerateTextStepContent[];
+  toolResults: GenerateTextStepContent[];
+}): boolean {
+  for (const part of [...response.content, ...response.toolResults]) {
+    if (part.type === "tool-result" && part.toolName === SEARCH_TOOL_NAME) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function parseSearchResults(
-  toolResults: unknown,
+  response: {
+    content: GenerateTextStepContent[];
+    toolResults: GenerateTextStepContent[];
+  },
   maxResults: number,
 ): Array<{ title: string; url: string; snippet: string }> {
-  const typedResults = Array.isArray(toolResults)
-    ? (toolResults as Array<Record<string, unknown>>)
-    : [];
   const parsedResults: Array<{ title: string; url: string; snippet: string }> =
     [];
 
-  for (const toolResult of typedResults) {
-    if (
-      toolResult.type !== "tool-result" ||
-      toolResult.toolName !== SEARCH_TOOL_NAME
-    ) {
-      continue;
-    }
+  const sources = [response.content, response.toolResults];
+  for (const typedResults of sources) {
+    for (const toolResult of typedResults) {
+      if (
+        toolResult.type !== "tool-result" ||
+        toolResult.toolName !== SEARCH_TOOL_NAME
+      ) {
+        continue;
+      }
 
-    const output = (toolResult as { output?: unknown }).output as
-      | { results?: unknown }
-      | undefined;
-    const results = Array.isArray(output?.results)
-      ? (output.results as Array<Record<string, unknown>>)
-      : [];
+      const output = toolResult.output as { results?: unknown } | undefined;
+      if (isGatewayParallelSearchErrorOutput(output)) {
+        continue;
+      }
 
-    for (const result of results) {
-      const url = asString(result.url);
-      if (!url) continue;
-      parsedResults.push({
-        title: asString(result.title) ?? url,
-        url,
-        snippet: asString(result.excerpt) ?? asString(result.snippet) ?? "",
-      });
+      const results = Array.isArray(output?.results)
+        ? (output.results as Array<Record<string, unknown>>)
+        : [];
 
-      if (parsedResults.length >= maxResults) {
-        return parsedResults;
+      for (const result of results) {
+        const url = asString(result.url);
+        if (!url) continue;
+        parsedResults.push({
+          title: asString(result.title) ?? url,
+          url,
+          snippet: asString(result.excerpt) ?? asString(result.snippet) ?? "",
+        });
+
+        if (parsedResults.length >= maxResults) {
+          return parsedResults;
+        }
       }
     }
   }
@@ -136,7 +213,57 @@ export function createWebSearchTool() {
           "webSearch",
         );
 
-        const results = parseSearchResults(response.toolResults, maxResults);
+        const gatewayFailureMessage = findParallelSearchGatewayFailure(
+          response.content,
+        );
+        if (gatewayFailureMessage) {
+          const message = `web search failed: ${gatewayFailureMessage}`;
+          logException(
+            new Error(message),
+            "web_search_gateway_failure",
+            {},
+            {
+              "app.web_search.failure_kind": "gateway",
+            },
+            "AI Gateway parallel search returned an error",
+          );
+          return {
+            ok: false,
+            model,
+            query,
+            result_count: 0,
+            results: [],
+            error: message,
+            timeout: false,
+            retryable: !isNonRetryableSearchFailure(message),
+          };
+        }
+
+        const results = parseSearchResults(response, maxResults);
+
+        if (results.length === 0 && !hadParallelSearchToolResult(response)) {
+          const message =
+            "web search failed: Parallel Search returned no tool result (possible tool name mismatch or gateway issue)";
+          logException(
+            new Error(message),
+            "web_search_silent_failure",
+            {},
+            {
+              "app.web_search.failure_kind": "silent",
+            },
+            "Web search completed without a parallel_search tool result",
+          );
+          return {
+            ok: false,
+            model,
+            query,
+            result_count: 0,
+            results: [],
+            error: message,
+            timeout: false,
+            retryable: true,
+          };
+        }
 
         return {
           ok: true,
@@ -147,13 +274,23 @@ export function createWebSearchTool() {
         };
       } catch (error) {
         const message = formatSearchFailure(error);
+        const timeout = isTimeoutSearchFailure(message);
+        logException(
+          error instanceof Error ? error : new Error(message),
+          "web_search_failed",
+          {},
+          {
+            "app.web_search.failure_kind": timeout ? "timeout" : "exception",
+          },
+          "Web search tool failed",
+        );
         return {
           ok: false,
           query,
           result_count: 0,
           results: [],
           error: message,
-          timeout: isTimeoutSearchFailure(message),
+          timeout,
           retryable: !isNonRetryableSearchFailure(message),
         };
       }

--- a/packages/junior/tests/unit/web/web-search.test.ts
+++ b/packages/junior/tests/unit/web/web-search.test.ts
@@ -11,6 +11,10 @@ vi.mock("@ai-sdk/gateway", () => ({
   createGatewayProvider: vi.fn(),
 }));
 
+vi.mock("@/chat/logging", () => ({
+  logException: vi.fn(),
+}));
+
 describe("createWebSearchTool", () => {
   const parallelSearch = { id: "parallel-search-tool" };
   const gatewayProvider = {
@@ -37,10 +41,11 @@ describe("createWebSearchTool", () => {
   it("uses AI Gateway parallel search and maps tool results", async () => {
     process.env.AI_WEB_SEARCH_MODEL = "xai/grok-4-fast-reasoning";
     vi.mocked(generateText).mockResolvedValueOnce({
+      content: [],
       toolResults: [
         {
           type: "tool-result",
-          toolName: "parallelSearch",
+          toolName: "parallel_search",
           output: {
             results: [
               {
@@ -73,7 +78,7 @@ describe("createWebSearchTool", () => {
       expect.objectContaining({
         model: { model: "xai/grok-4-fast-reasoning" },
         prompt: "vercel ai gateway",
-        toolChoice: { type: "tool", toolName: "parallelSearch" },
+        toolChoice: { type: "tool", toolName: "parallel_search" },
       }),
     );
     expect(result).toEqual({
@@ -88,6 +93,82 @@ describe("createWebSearchTool", () => {
           snippet: "Gateway docs",
         },
       ],
+    });
+  });
+
+  it("maps parallel_search results from step content when toolResults is empty", async () => {
+    process.env.AI_WEB_SEARCH_MODEL = "xai/grok-4-fast-reasoning";
+    vi.mocked(generateText).mockResolvedValueOnce({
+      content: [
+        {
+          type: "tool-result",
+          toolName: "parallel_search",
+          output: {
+            results: [
+              {
+                title: "Docs",
+                url: "https://example.com",
+                excerpt: "Hi",
+              },
+            ],
+          },
+        },
+      ],
+      toolResults: [],
+    } as never);
+
+    const tool = createWebSearchTool();
+    if (typeof tool.execute !== "function") {
+      throw new Error("webSearch execute function missing");
+    }
+
+    const result = await tool.execute({ query: "q" }, {} as never);
+    expect(result).toEqual({
+      ok: true,
+      model: "xai/grok-4-fast-reasoning",
+      query: "q",
+      result_count: 1,
+      results: [
+        {
+          title: "Docs",
+          url: "https://example.com",
+          snippet: "Hi",
+        },
+      ],
+    });
+  });
+
+  it("returns failure when gateway embeds a Parallel Search error in the tool output", async () => {
+    process.env.AI_WEB_SEARCH_MODEL = "xai/grok-4-fast-reasoning";
+    vi.mocked(generateText).mockResolvedValueOnce({
+      content: [
+        {
+          type: "tool-result",
+          toolName: "parallel_search",
+          output: {
+            error: "timeout",
+            message: "upstream deadline exceeded",
+          },
+        },
+      ],
+      toolResults: [],
+    } as never);
+
+    const tool = createWebSearchTool();
+    if (typeof tool.execute !== "function") {
+      throw new Error("webSearch execute function missing");
+    }
+
+    const result = await tool.execute({ query: "q" }, {} as never);
+    expect(result).toEqual({
+      ok: false,
+      model: "xai/grok-4-fast-reasoning",
+      query: "q",
+      result_count: 0,
+      results: [],
+      error: "web search failed: timeout: upstream deadline exceeded",
+      timeout: false,
+      retryable: true,
     });
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `webSearch` tool registered the AI Gateway Parallel Search client tool under the wrong key (`parallelSearch` vs `parallel_search`), so tool results were dropped and searches looked empty or timed out.

## Changes

- Register the tool as `parallel_search` and force that name in `toolChoice`.
- Parse both `response.content` and `response.toolResults`; collect hits and whether any `parallel_search` tool result appeared in one pass.
- Detect gateway failures from step `content` (tool-error parts and error-shaped tool outputs).
- `logException` on gateway errors, silent missing-tool-result cases, timeouts, and thrown errors.

## Follow-up

- Refactored result collection to a single `collectParallelSearchHits` pass (smaller diff, same behavior).

## Tests

- `pnpm --filter @sentry/junior exec vitest run tests/unit/web/web-search.test.ts`
- `pnpm typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c710b5e9-7d1a-4dfe-9c8d-6a5c3d1245b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c710b5e9-7d1a-4dfe-9c8d-6a5c3d1245b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

