### PR TITLE
fix(webSearch): Sentry reporting, multi-step gateway search, longer timeout

### DIFF
--- a/packages/junior/src/chat/tools/web/search.ts
+++ b/packages/junior/src/chat/tools/web/search.ts
@@ -1,13 +1,32 @@
 import { tool } from "@/chat/tools/definition";
-import { generateText } from "ai";
+import { logException } from "@/chat/logging";
+import { generateText, stepCountIs } from "ai";
 import { createGatewayProvider } from "@ai-sdk/gateway";
 import { Type } from "@sinclair/typebox";
 import { withTimeout } from "@/chat/tools/web/network";
 
-const SEARCH_TIMEOUT_MS = 10_000;
+/** Default allows gateway + model time for agentic parallel search; override with AI_WEB_SEARCH_TIMEOUT_MS. */
+const DEFAULT_SEARCH_TIMEOUT_MS = 45_000;
 const MAX_RESULTS = 5;
 const DEFAULT_SEARCH_MODEL = "xai/grok-4-fast-reasoning";
 const SEARCH_TOOL_NAME = "parallelSearch";
+/** Gateway may surface this id on tool parts from some providers. */
+const SEARCH_TOOL_ALIASES = new Set([
+  SEARCH_TOOL_NAME,
+  "gateway.parallel_search",
+]);
+
+function resolveSearchTimeoutMs(): number {
+  const raw = process.env.AI_WEB_SEARCH_TIMEOUT_MS;
+  if (raw === undefined || raw.trim() === "") {
+    return DEFAULT_SEARCH_TIMEOUT_MS;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_SEARCH_TIMEOUT_MS;
+  }
+  return parsed;
+}
 
 function asString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0
@@ -15,47 +34,109 @@ function asString(value: unknown): string | undefined {
     : undefined;
 }
 
-function parseSearchResults(
-  toolResults: unknown,
+function isParallelSearchToolName(name: unknown): boolean {
+  return typeof name === "string" && SEARCH_TOOL_ALIASES.has(name);
+}
+
+function errorMessageFromUnknown(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+type ParallelSearchSuccessOutput = {
+  results?: Array<Record<string, unknown>>;
+};
+
+type ParallelSearchErrorOutput = {
+  error: string;
+  message: string;
+};
+
+function isParallelSearchErrorOutput(
+  output: unknown,
+): output is ParallelSearchErrorOutput {
+  if (output === null || typeof output !== "object") return false;
+  const o = output as Record<string, unknown>;
+  return typeof o.error === "string" && typeof o.message === "string";
+}
+
+/**
+ * Collects gateway parallel search hits and errors from every `generateText` step.
+ * Provider-executed tools can surface results on non-final steps; the AI SDK also
+ * represents gateway failures as structured `{ error, message }` outputs.
+ */
+function collectParallelSearchOutcome(
+  steps: ReadonlyArray<{ toolResults?: unknown }>,
   maxResults: number,
-): Array<{ title: string; url: string; snippet: string }> {
-  const typedResults = Array.isArray(toolResults)
-    ? (toolResults as Array<Record<string, unknown>>)
-    : [];
+): {
+  results: Array<{ title: string; url: string; snippet: string }>;
+  toolFailureMessage?: string;
+  sawParallelSearchPart: boolean;
+} {
   const parsedResults: Array<{ title: string; url: string; snippet: string }> =
     [];
 
-  for (const toolResult of typedResults) {
-    if (
-      toolResult.type !== "tool-result" ||
-      toolResult.toolName !== SEARCH_TOOL_NAME
-    ) {
-      continue;
-    }
+  let toolFailureMessage: string | undefined;
+  let sawParallelSearchPart = false;
 
-    const output = (toolResult as { output?: unknown }).output as
-      | { results?: unknown }
-      | undefined;
-    const results = Array.isArray(output?.results)
-      ? (output.results as Array<Record<string, unknown>>)
-      : [];
+  for (const step of steps) {
+    const toolResults = step.toolResults;
+    if (!Array.isArray(toolResults)) continue;
 
-    for (const result of results) {
-      const url = asString(result.url);
-      if (!url) continue;
-      parsedResults.push({
-        title: asString(result.title) ?? url,
-        url,
-        snippet: asString(result.excerpt) ?? asString(result.snippet) ?? "",
-      });
+    for (const part of toolResults) {
+      if (part === null || typeof part !== "object") continue;
+      const tr = part as {
+        type?: string;
+        toolName?: string;
+        output?: unknown;
+        error?: unknown;
+      };
 
-      if (parsedResults.length >= maxResults) {
-        return parsedResults;
+      if (!isParallelSearchToolName(tr.toolName)) continue;
+      sawParallelSearchPart = true;
+
+      if (tr.type === "tool-error") {
+        toolFailureMessage = errorMessageFromUnknown(tr.error);
+        continue;
+      }
+
+      if (tr.type !== "tool-result") continue;
+
+      const output = tr.output;
+      if (isParallelSearchErrorOutput(output)) {
+        toolFailureMessage = `${output.error}: ${output.message}`;
+        continue;
+      }
+
+      const success = output as ParallelSearchSuccessOutput;
+      const results = Array.isArray(success.results) ? success.results : [];
+
+      for (const result of results) {
+        const url = asString(result.url);
+        if (!url) continue;
+        parsedResults.push({
+          title: asString(result.title) ?? url,
+          url,
+          snippet: asString(result.excerpt) ?? asString(result.snippet) ?? "",
+        });
+
+        if (parsedResults.length >= maxResults) {
+          return {
+            results: parsedResults,
+            toolFailureMessage,
+            sawParallelSearchPart,
+          };
+        }
       }
     }
   }
 
-  return parsedResults;
+  return { results: parsedResults, toolFailureMessage, sawParallelSearchPart };
 }
 
 function formatSearchFailure(error: unknown): string {
@@ -101,6 +182,7 @@ export function createWebSearchTool() {
     }),
     execute: async ({ query, max_results }) => {
       const maxResults = max_results ?? 3;
+      const searchTimeoutMs = resolveSearchTimeoutMs();
       try {
         const model =
           process.env.AI_WEB_SEARCH_MODEL ??
@@ -127,26 +209,63 @@ export function createWebSearchTool() {
                   type: "tool",
                   toolName: SEARCH_TOOL_NAME,
                 },
+                // Provider-executed parallel search often needs a second model step
+                // after the gateway returns tool results (default stopWhen is one step).
+                stopWhen: stepCountIs(2),
               });
             } catch (error) {
               throw new Error(formatSearchFailure(error));
             }
           })(),
-          SEARCH_TIMEOUT_MS,
+          searchTimeoutMs,
           "webSearch",
         );
 
-        const results = parseSearchResults(response.toolResults, maxResults);
+        const { results, toolFailureMessage, sawParallelSearchPart } =
+          collectParallelSearchOutcome(response.steps, maxResults);
 
+        if (results.length > 0) {
+          return {
+            ok: true,
+            model,
+            query,
+            result_count: results.length,
+            results,
+          };
+        }
+
+        const emptyExplanation = toolFailureMessage
+          ? toolFailureMessage
+          : sawParallelSearchPart
+            ? "parallel search returned no URL results"
+            : "web search did not return parallel search results";
+        const err = new Error(emptyExplanation);
+        logException(
+          err,
+          "web_search_no_results",
+          {},
+          {
+            "app.tool.name": "webSearch",
+          },
+        );
         return {
-          ok: true,
+          ok: false,
           model,
           query,
-          result_count: results.length,
-          results,
+          result_count: 0,
+          results: [],
+          error: formatSearchFailure(err),
+          timeout: false,
+          retryable: !isNonRetryableSearchFailure(emptyExplanation),
         };
       } catch (error) {
         const message = formatSearchFailure(error);
+        logException(
+          error instanceof Error ? error : new Error(message),
+          "web_search_failed",
+          {},
+          { "app.tool.name": "webSearch" },
+        );
         return {
           ok: false,
           query,

--- a/packages/junior/tests/unit/web/web-search.test.ts
+++ b/packages/junior/tests/unit/web/web-search.test.ts
@@ -3,9 +3,13 @@ import { createWebSearchTool } from "@/chat/tools/web/search";
 import { generateText } from "ai";
 import { createGatewayProvider } from "@ai-sdk/gateway";
 
-vi.mock("ai", () => ({
-  generateText: vi.fn(),
-}));
+vi.mock("ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ai")>();
+  return {
+    ...actual,
+    generateText: vi.fn(),
+  };
+});
 
 vi.mock("@ai-sdk/gateway", () => ({
   createGatewayProvider: vi.fn(),
@@ -37,19 +41,23 @@ describe("createWebSearchTool", () => {
   it("uses AI Gateway parallel search and maps tool results", async () => {
     process.env.AI_WEB_SEARCH_MODEL = "xai/grok-4-fast-reasoning";
     vi.mocked(generateText).mockResolvedValueOnce({
-      toolResults: [
+      steps: [
         {
-          type: "tool-result",
-          toolName: "parallelSearch",
-          output: {
-            results: [
-              {
-                title: "Vercel AI Gateway",
-                url: "https://vercel.com/docs/ai-gateway",
-                excerpt: "Gateway docs",
+          toolResults: [
+            {
+              type: "tool-result",
+              toolName: "parallelSearch",
+              output: {
+                results: [
+                  {
+                    title: "Vercel AI Gateway",
+                    url: "https://vercel.com/docs/ai-gateway",
+                    excerpt: "Gateway docs",
+                  },
+                ],
               },
-            ],
-          },
+            },
+          ],
         },
       ],
     } as never);
@@ -116,6 +124,7 @@ describe("createWebSearchTool", () => {
   });
 
   it("returns a retryable timeout error instead of throwing", async () => {
+    process.env.AI_WEB_SEARCH_TIMEOUT_MS = "10000";
     vi.useFakeTimers();
     vi.mocked(generateText).mockImplementation(
       () =>
@@ -141,6 +150,43 @@ describe("createWebSearchTool", () => {
       retryable: true,
     });
     vi.useRealTimers();
+    delete process.env.AI_WEB_SEARCH_TIMEOUT_MS;
+  });
+
+  it("maps gateway.parallel_search tool name and structured error output", async () => {
+    vi.mocked(generateText).mockResolvedValueOnce({
+      steps: [
+        {
+          toolResults: [
+            {
+              type: "tool-result",
+              toolName: "gateway.parallel_search",
+              output: {
+                error: "timeout",
+                message: "upstream search timed out",
+              },
+            },
+          ],
+        },
+      ],
+    } as never);
+
+    const tool = createWebSearchTool();
+    if (typeof tool.execute !== "function") {
+      throw new Error("webSearch execute function missing");
+    }
+
+    await expect(
+      tool.execute({ query: "test" }, {} as never),
+    ).resolves.toMatchObject({
+      ok: false,
+      query: "test",
+      result_count: 0,
+      results: [],
+      error: "web search failed: timeout: upstream search timed out",
+      timeout: false,
+      retryable: true,
+    });
   });
 
   it("marks authentication failures as non-retryable", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigation of `webSearch` timeouts and empty results on the Sentry deployment surfaced two main issues:

1. **AI SDK `generateText` default is one step** (`stopWhen: stepCountIs(1)`). Gateway **provider-executed** parallel search often needs a **second** model round-trip after tool results. With only one step, the call could finish without usable `parallelSearch` hits in the final step—matching “no results” or apparent timeouts.

2. **Result parsing was too narrow**: it only looked at `toolName === "parallelSearch"` and ignored the gateway’s structured error shape `{ error, message }`, alternate tool ids like `gateway.parallel_search`, `tool-error` parts, and results that appear on **non-final** steps.

## Changes

- Set `stopWhen: stepCountIs(2)` for the web search `generateText` call.
- Aggregate hits and errors across **all** `response.steps` via `collectParallelSearchOutcome`.
- Raise default outer timeout to **45s** (configurable with `AI_WEB_SEARCH_TIMEOUT_MS`).
- On failure or empty results after a parallel search part, call `logException` so issues show up in **Sentry** (not only as a tool return value).

## Tests

- Updated unit tests; added coverage for `gateway.parallel_search` + structured error output.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e76e4d65-35d1-4139-b933-bcd16a104490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e76e4d65-35d1-4139-b933-bcd16a104490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

