### PR TITLE
fix(slack): Route assistant progress through loading messages

### DIFF
--- a/packages/junior/src/chat/config.ts
+++ b/packages/junior/src/chat/config.ts
@@ -6,9 +6,24 @@ const DEFAULT_FUNCTION_MAX_DURATION_SECONDS = 800;
 /** Buffer between the Vercel function timeout and the agent turn timeout,
  *  so the agent can abort and post a failure reply before Vercel kills it. */
 const FUNCTION_TIMEOUT_BUFFER_SECONDS = 20;
+const DEFAULT_ASSISTANT_LOADING_MESSAGES = [
+  "Consulting the orb",
+  "Bribing the gremlins",
+  "Shuffling the papers dramatically",
+  "Summoning the right stack trace",
+  "Negotiating with the mutex",
+  "Poking the internet with a stick",
+  "Asking the docs nicely",
+  "Searching for the least cursed path",
+  "Pretending this was obvious",
+  "Waking up the test suite",
+  "Untangling the spaghetti carefully",
+  "Rattling the command line",
+] as const;
 
 export interface BotConfig {
   fastModelId: string;
+  loadingMessages: string[];
   modelId: string;
   visionModelId?: string;
   turnTimeoutMs: number;
@@ -61,6 +76,31 @@ function resolveMaxTurnTimeoutMs(functionMaxDurationSeconds: number): number {
   return Math.max(MIN_AGENT_TURN_TIMEOUT_MS, budgetSeconds * 1000);
 }
 
+function parseLoadingMessages(rawValue: string | undefined): string[] {
+  const trimmed = rawValue?.trim();
+  if (!trimmed) {
+    return [...DEFAULT_ASSISTANT_LOADING_MESSAGES];
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    throw new Error("JUNIOR_LOADING_MESSAGES must be a JSON array of strings");
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error("JUNIOR_LOADING_MESSAGES must be a JSON array of strings");
+  }
+
+  return parsed.map((value, index) => {
+    if (typeof value !== "string") {
+      throw new Error(`JUNIOR_LOADING_MESSAGES[${index}] must be a string`);
+    }
+    return value.trim();
+  });
+}
+
 function readBotConfig(env: NodeJS.ProcessEnv): BotConfig {
   const functionMaxDurationSeconds = resolveFunctionMaxDurationSeconds(env);
   const maxTurnTimeoutMs = resolveMaxTurnTimeoutMs(functionMaxDurationSeconds);
@@ -70,6 +110,7 @@ function readBotConfig(env: NodeJS.ProcessEnv): BotConfig {
     modelId: env.AI_MODEL ?? "anthropic/claude-sonnet-4.6",
     fastModelId:
       env.AI_FAST_MODEL ?? env.AI_MODEL ?? "anthropic/claude-haiku-4.5",
+    loadingMessages: parseLoadingMessages(env.JUNIOR_LOADING_MESSAGES),
     visionModelId: toOptionalTrimmed(env.AI_VISION_MODEL),
     turnTimeoutMs: parseAgentTurnTimeoutMs(
       env.AGENT_TURN_TIMEOUT_MS,

--- a/packages/junior/src/chat/prompt.ts
+++ b/packages/junior/src/chat/prompt.ts
@@ -516,6 +516,7 @@ export function buildSystemPrompt(params: {
       [
         "- For factual or external questions, run tools/skills first, then answer from evidence.",
         "- Use tool descriptions as the source of truth for when each tool should or should not be called.",
+        "- Use `reportProgress` only when you start a major new phase of work, such as researching, reading, executing, reviewing, or drafting. Do not call it for every tool or small substep.",
         "- When using CLI tools through `bash`, prefer deterministic non-interactive flags and avoid commands that wait for prompts or editors.",
         "- Keep routine setup and research steps silent in user-facing replies. Do not narrate duplicate checks, credential issuance, file writes, or similar internal progress unless the result is user-relevant.",
         "- If a routine prerequisite check finds nothing notable, omit it entirely from the final reply and report only the user-relevant outcome.",

--- a/packages/junior/src/chat/runtime/report-progress.ts
+++ b/packages/junior/src/chat/runtime/report-progress.ts
@@ -1,0 +1,41 @@
+import {
+  makeAssistantStatus,
+  type AssistantStatusSpec,
+} from "@/chat/slack/assistant-thread/status-render";
+import { compactStatusText } from "@/chat/runtime/status-format";
+
+/**
+ * Convert a structured major-progress update into internal progress copy for
+ * Slack's assistant loading surface.
+ */
+export function buildReportedProgressStatus(
+  input: unknown,
+): AssistantStatusSpec | undefined {
+  if (!input || typeof input !== "object") {
+    return undefined;
+  }
+
+  const phase = (input as { phase?: unknown }).phase;
+  if (typeof phase !== "string") {
+    return undefined;
+  }
+
+  const detail = compactStatusText((input as { detail?: unknown }).detail, 40);
+
+  switch (phase) {
+    case "thinking":
+      return makeAssistantStatus("thinking", detail, { source: "major" });
+    case "researching":
+      return makeAssistantStatus("searching", detail, { source: "major" });
+    case "reading":
+      return makeAssistantStatus("reading", detail, { source: "major" });
+    case "executing":
+      return makeAssistantStatus("running", detail, { source: "major" });
+    case "reviewing":
+      return makeAssistantStatus("reviewing", detail, { source: "major" });
+    case "drafting":
+      return makeAssistantStatus("drafting", detail, { source: "major" });
+    default:
+      return undefined;
+  }
+}

--- a/packages/junior/src/chat/runtime/tool-status.ts
+++ b/packages/junior/src/chat/runtime/tool-status.ts
@@ -1,5 +1,4 @@
-import type { AssistantStatusSpec } from "@/chat/slack/assistant-thread/status";
-import { makeAssistantStatus } from "@/chat/slack/assistant-thread/status";
+import { buildReportedProgressStatus } from "@/chat/runtime/report-progress";
 import {
   compactStatusCommand,
   compactStatusFilename,
@@ -7,8 +6,17 @@ import {
   compactStatusText,
   extractStatusUrlDomain,
 } from "@/chat/runtime/status-format";
+import {
+  makeAssistantStatus,
+  type AssistantStatusSpec,
+} from "@/chat/slack/assistant-thread/status-render";
 
-/** Build a typed assistant status for a tool call. */
+/**
+ * Build internal progress copy for a tool call.
+ *
+ * For Slack, this ultimately feeds the assistant loading surface rather than
+ * the fixed generic `status` string itself.
+ */
 export function buildToolStatus(
   toolName: string,
   input: unknown,
@@ -26,6 +34,11 @@ export function buildToolStatus(
     ? compactStatusText(obj.skill_name ?? obj.skillName, 40)
     : undefined;
   const provider = obj ? compactStatusText(obj.provider, 20) : undefined;
+  const reportedProgress = buildReportedProgressStatus(obj);
+
+  if (toolName === "reportProgress" && reportedProgress) {
+    return reportedProgress;
+  }
 
   if (command && toolName === "bash") {
     return makeAssistantStatus("running", command);

--- a/packages/junior/src/chat/slack/assistant-thread/status-render.ts
+++ b/packages/junior/src/chat/slack/assistant-thread/status-render.ts
@@ -18,6 +18,10 @@ const STATUS_PATTERNS = {
     defaultContext: "results",
     variants: ["Reviewing", "Checking", "Inspecting", "Auditing"],
   },
+  drafting: {
+    defaultContext: "reply",
+    variants: ["Drafting", "Writing", "Composing", "Shaping"],
+  },
   loading: {
     defaultContext: "task",
     variants: ["Loading", "Priming", "Booting", "Spinning up"],
@@ -53,25 +57,30 @@ const STATUS_PATTERNS = {
 } as const;
 
 export type AssistantStatusKind = keyof typeof STATUS_PATTERNS;
+export type AssistantStatusSource = "fallback" | "major";
 
 export interface AssistantStatusSpec {
   kind: AssistantStatusKind;
   context?: string;
+  source?: AssistantStatusSource;
 }
 
-export interface AssistantStatusPresentation {
+interface AssistantStatusPresentation {
   key: string;
-  hint: string;
   visible: string;
-  suggestions?: string[];
 }
 
 /** Build a typed assistant status from a stable kind and optional context. */
 export function makeAssistantStatus(
   kind: AssistantStatusKind,
   context?: string,
+  options?: { source?: AssistantStatusSource },
 ): AssistantStatusSpec {
-  return { kind, ...(context ? { context } : {}) };
+  return {
+    kind,
+    ...(context ? { context } : {}),
+    ...(options?.source ? { source: options.source } : {}),
+  };
 }
 
 /**
@@ -86,18 +95,46 @@ export function renderAssistantStatus(args: {
 }): AssistantStatusPresentation {
   const random = args.random ?? Math.random;
   const pattern = STATUS_PATTERNS[args.status.kind];
+  const source = args.status.source ?? "fallback";
   const context =
     normalizeSlackStatusText(args.status.context ?? "") ||
     pattern.defaultContext;
   const index = Math.floor(random() * pattern.variants.length);
   const verb = pattern.variants[index] ?? pattern.variants[0];
   const visible = truncateStatusText(`${verb} ${context}`);
-  const hint = truncateStatusText(`${pattern.variants[0]} ${context}`);
 
   return {
-    key: `${args.status.kind}:${context}`,
-    hint,
+    key: `${source}:${args.status.kind}:${context}`,
     visible,
-    suggestions: Array.from(new Set([visible, hint])),
   };
+}
+
+/** Select and normalize the loading messages used for Slack status rotation. */
+export function selectAssistantLoadingMessages(args: {
+  messages: string[];
+  random?: () => number;
+}): string[] | undefined {
+  const random = args.random ?? Math.random;
+  const normalized = Array.from(
+    new Set(
+      args.messages
+        .map((message) => truncateStatusText(normalizeSlackStatusText(message)))
+        .filter((message) => message.length > 0),
+    ),
+  );
+
+  if (normalized.length === 0) {
+    return undefined;
+  }
+
+  const shuffled = [...normalized];
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    const otherIndex = Math.floor(random() * (index + 1));
+    [shuffled[index], shuffled[otherIndex]] = [
+      shuffled[otherIndex] as string,
+      shuffled[index] as string,
+    ];
+  }
+
+  return shuffled.slice(0, 10);
 }

--- a/packages/junior/src/chat/slack/assistant-thread/status-scheduler.ts
+++ b/packages/junior/src/chat/slack/assistant-thread/status-scheduler.ts
@@ -1,6 +1,7 @@
 import {
   makeAssistantStatus,
   renderAssistantStatus,
+  selectAssistantLoadingMessages,
   type AssistantStatusSpec,
 } from "@/chat/slack/assistant-thread/status-render";
 
@@ -17,14 +18,16 @@ export interface AssistantStatusSession {
 }
 
 /**
- * Pace assistant-status writes for a single turn.
+ * Pace assistant loading-state writes for a single turn.
  *
  * This layer owns only local scheduling policy: debounce, minimum visible
- * duration, refresh cadence, and write ordering. It intentionally does not
- * know about Slack channel IDs, tokens, or API clients.
+ * duration, refresh cadence, and write ordering. It deals in user-visible
+ * progress copy; the transport decides how that maps onto Slack's `status`
+ * versus `loading_messages` fields.
  */
 export function createAssistantStatusScheduler(args: {
-  sendStatus: (text: string, suggestions?: string[]) => Promise<void>;
+  sendStatus: (text: string, loadingMessages?: string[]) => Promise<void>;
+  loadingMessages?: string[];
   now?: () => number;
   setTimer?: (callback: () => void, delayMs: number) => TimerHandle;
   clearTimer?: (timer: TimerHandle) => void;
@@ -37,11 +40,17 @@ export function createAssistantStatusScheduler(args: {
   const clearTimer =
     args.clearTimer ?? ((timer: TimerHandle) => clearTimeout(timer));
   const random = args.random ?? Math.random;
+  const loadingMessages = selectAssistantLoadingMessages({
+    messages: args.loadingMessages ?? [],
+    random,
+  });
+  const defaultStatus = makeAssistantStatus("thinking");
 
   let active = false;
   let currentKey = "";
-  let currentStatus: AssistantStatusSpec = makeAssistantStatus("thinking");
+  let currentStatus: AssistantStatusSpec = defaultStatus;
   let currentVisibleStatus = "";
+  let currentLoadingMessages: string[] | undefined;
   let lastStatusAt = 0;
   let pendingStatus: AssistantStatusSpec | null = null;
   let pendingKey = "";
@@ -71,30 +80,68 @@ export function createAssistantStatusScheduler(args: {
       return;
     }
 
-    // Slack removes assistant status automatically after about two minutes if
-    // no reply arrives, so long-running turns must refresh the current status.
+    // Slack removes assistant loading state automatically after about two
+    // minutes if no reply arrives, so long-running turns must refresh the
+    // current visible loading copy.
     rotationTimer = setTimer(() => {
       rotationTimer = null;
       if (!active || !currentVisibleStatus) {
         return;
       }
-      void postRenderedStatus(currentStatus);
+      void postStatus(currentVisibleStatus, currentLoadingMessages);
     }, STATUS_ROTATION_INTERVAL_MS);
+  };
+
+  const getLoadingMessagesForStatus = (
+    _status: AssistantStatusSpec,
+    visible: string,
+  ): string[] | undefined => {
+    if (!visible) {
+      return undefined;
+    }
+
+    // Once we have concrete progress copy, use it as the loading surface.
+    return [visible];
+  };
+
+  const getInitialStatusText = (): string => {
+    if (loadingMessages?.length) {
+      return loadingMessages[0];
+    }
+
+    return renderAssistantStatus({
+      status: defaultStatus,
+      random,
+    }).visible;
+  };
+
+  const haveSameLoadingMessages = (
+    left: string[] | undefined,
+    right: string[] | undefined,
+  ): boolean => {
+    if (left === right) {
+      return true;
+    }
+    if (!left || !right || left.length !== right.length) {
+      return false;
+    }
+    return left.every((message, index) => message === right[index]);
   };
 
   const postStatus = async (
     text: string,
-    suggestions?: string[],
+    nextLoadingMessages?: string[],
   ): Promise<void> => {
     if (!text && !currentVisibleStatus) {
       return;
     }
 
     currentVisibleStatus = text;
+    currentLoadingMessages = nextLoadingMessages;
     lastStatusAt = now();
     scheduleRotation();
     await enqueueStatusUpdate(async () => {
-      await args.sendStatus(text, suggestions);
+      await args.sendStatus(text, nextLoadingMessages);
     });
   };
 
@@ -105,9 +152,13 @@ export function createAssistantStatusScheduler(args: {
       status,
       random,
     });
+    const nextLoadingMessages = getLoadingMessagesForStatus(
+      status,
+      presentation.visible,
+    );
     currentStatus = status;
     currentKey = presentation.key;
-    await postStatus(presentation.visible, presentation.suggestions);
+    await postStatus(presentation.visible, nextLoadingMessages);
   };
 
   const clearPending = () => {
@@ -140,9 +191,9 @@ export function createAssistantStatusScheduler(args: {
     start() {
       active = true;
       clearPending();
-      currentStatus = makeAssistantStatus("thinking");
-      currentKey = "";
-      void postRenderedStatus(currentStatus);
+      currentStatus = defaultStatus;
+      currentKey = "initial";
+      void postStatus(getInitialStatusText(), loadingMessages);
     },
     async stop() {
       active = false;
@@ -165,7 +216,28 @@ export function createAssistantStatusScheduler(args: {
       if (!presentation.visible) {
         return;
       }
+      if (
+        status.source !== "major" &&
+        (currentStatus.source === "major" || pendingStatus?.source === "major")
+      ) {
+        return;
+      }
       if (presentation.key === currentKey || presentation.key === pendingKey) {
+        return;
+      }
+      if (presentation.visible === currentVisibleStatus) {
+        clearPending();
+        currentStatus = status;
+        currentKey = presentation.key;
+        const nextLoadingMessages = getLoadingMessagesForStatus(
+          status,
+          presentation.visible,
+        );
+        if (
+          !haveSameLoadingMessages(currentLoadingMessages, nextLoadingMessages)
+        ) {
+          void postStatus(presentation.visible, nextLoadingMessages);
+        }
         return;
       }
 

--- a/packages/junior/src/chat/slack/assistant-thread/status-send.ts
+++ b/packages/junior/src/chat/slack/assistant-thread/status-send.ts
@@ -5,12 +5,24 @@ import {
   normalizeSlackConversationId,
 } from "@/chat/slack/client";
 
-export type AssistantStatusSender = (
+/**
+ * Slack's assistant loading UI accepts both `status` and `loading_messages`,
+ * but product policy keeps `status` stable and generic. User-visible progress
+ * copy belongs in `loading_messages`.
+ */
+export const SLACK_ASSISTANT_ACTIVE_STATUS = "is working on your request...";
+
+type AssistantStatusSender = (
   text: string,
-  suggestions?: string[],
+  loadingMessages?: string[],
 ) => Promise<void>;
 
-/** Build a best-effort status sender on top of the Slack adapter surface. */
+/**
+ * Build a best-effort sender for Slack's assistant loading state.
+ *
+ * The `text` argument is internal progress copy. This transport maps it onto
+ * Slack's loading surface and keeps the raw Slack `status` field fixed.
+ */
 export function createSlackAdapterStatusSender(args: {
   channelId?: string;
   threadTs?: string;
@@ -28,7 +40,7 @@ export function createSlackAdapterStatusSender(args: {
   // context is gone, so bind the active installation token up front.
   const boundToken = getSlackAdapterRequestToken(adapter);
 
-  return async (text, suggestions) => {
+  return async (text, loadingMessages) => {
     const channelId = args.channelId;
     const threadTs = args.threadTs;
     if (!channelId || !threadTs) {
@@ -40,13 +52,15 @@ export function createSlackAdapterStatusSender(args: {
       return;
     }
 
+    const nextLoadingMessages = text ? (loadingMessages ?? [text]) : undefined;
+
     try {
       await runWithBoundSlackToken(adapter, boundToken, () =>
         adapter.setAssistantStatus(
           normalizedChannelId,
           threadTs,
-          text,
-          suggestions,
+          text ? SLACK_ASSISTANT_ACTIVE_STATUS : "",
+          nextLoadingMessages,
         ),
       );
     } catch (error) {
@@ -61,7 +75,11 @@ export function createSlackAdapterStatusSender(args: {
   };
 }
 
-/** Build a best-effort status sender on top of direct Slack Web API calls. */
+/**
+ * Build a best-effort sender for Slack's assistant loading state over raw Web
+ * API calls. As with the adapter-backed path, the dynamic copy goes to
+ * `loading_messages` while `status` stays fixed and generic.
+ */
 export function createSlackWebApiStatusSender(args: {
   channelId?: string;
   threadTs?: string;
@@ -69,7 +87,7 @@ export function createSlackWebApiStatusSender(args: {
 }): AssistantStatusSender {
   const getClient = args.getSlackClient ?? getSlackClient;
 
-  return async (text, suggestions) => {
+  return async (text, loadingMessages) => {
     const channelId = args.channelId;
     const threadTs = args.threadTs;
     if (!channelId || !threadTs) {
@@ -81,12 +99,16 @@ export function createSlackWebApiStatusSender(args: {
       return;
     }
 
+    const nextLoadingMessages = text ? (loadingMessages ?? [text]) : undefined;
+
     try {
       await getClient().assistant.threads.setStatus({
         channel_id: normalizedChannelId,
         thread_ts: threadTs,
-        status: text,
-        ...(suggestions ? { loading_messages: suggestions } : {}),
+        status: text ? SLACK_ASSISTANT_ACTIVE_STATUS : "",
+        ...(nextLoadingMessages
+          ? { loading_messages: nextLoadingMessages }
+          : {}),
       });
     } catch (error) {
       logAssistantStatusFailure({

--- a/packages/junior/src/chat/slack/assistant-thread/status.ts
+++ b/packages/junior/src/chat/slack/assistant-thread/status.ts
@@ -1,4 +1,5 @@
 import type { SlackAdapter } from "@chat-adapter/slack";
+import { botConfig } from "@/chat/config";
 import { getSlackClient } from "@/chat/slack/client";
 import {
   createAssistantStatusScheduler,
@@ -11,53 +12,22 @@ import {
 } from "@/chat/slack/assistant-thread/status-send";
 export {
   makeAssistantStatus,
-  type AssistantStatusKind,
   type AssistantStatusSpec,
 } from "@/chat/slack/assistant-thread/status-render";
 export type { AssistantStatusSession } from "@/chat/slack/assistant-thread/status-scheduler";
 
 /**
- * Create an assistant-status session for a single turn.
+ * Create a Slack adapter-backed session for Slack's assistant loading state.
  *
- * `start()` and `update()` are intentionally fire-and-forget. Status is a
- * best-effort UX surface, not a turn-execution dependency.
+ * The session accepts internal progress updates and leaves it to the sender to
+ * map them onto Slack's fixed generic `status` field plus dynamic
+ * `loading_messages`.
  */
-export function createSlackAssistantStatusSession(args: {
-  channelId?: string;
-  threadTs?: string;
-  setStatus: (
-    channelId: string,
-    threadTs: string,
-    status: string,
-    suggestions?: string[],
-  ) => Promise<void>;
-  now?: () => number;
-  setTimer?: (callback: () => void, delayMs: number) => TimerHandle;
-  clearTimer?: (timer: TimerHandle) => void;
-  random?: () => number;
-}): AssistantStatusSession {
-  return createAssistantStatusScheduler({
-    sendStatus: (text, suggestions) => {
-      const channelId = args.channelId;
-      const threadTs = args.threadTs;
-      if (!channelId || !threadTs) {
-        return Promise.resolve();
-      }
-
-      return args.setStatus(channelId, threadTs, text, suggestions);
-    },
-    now: args.now,
-    setTimer: args.setTimer,
-    clearTimer: args.clearTimer,
-    random: args.random,
-  });
-}
-
-/** Create a Slack adapter-backed assistant status session for a single turn. */
 export function createSlackAdapterAssistantStatusSession(args: {
   channelId?: string;
   threadTs?: string;
   getSlackAdapter: () => Pick<SlackAdapter, "setAssistantStatus">;
+  loadingMessages?: string[];
   now?: () => number;
   setTimer?: (callback: () => void, delayMs: number) => TimerHandle;
   clearTimer?: (timer: TimerHandle) => void;
@@ -69,6 +39,7 @@ export function createSlackAdapterAssistantStatusSession(args: {
       threadTs: args.threadTs,
       getSlackAdapter: args.getSlackAdapter,
     }),
+    loadingMessages: args.loadingMessages ?? botConfig.loadingMessages,
     now: args.now,
     setTimer: args.setTimer,
     clearTimer: args.clearTimer,
@@ -76,11 +47,15 @@ export function createSlackAdapterAssistantStatusSession(args: {
   });
 }
 
-/** Create a Web API-backed assistant status session for non-adapter flows. */
+/**
+ * Create a Web API-backed session for Slack's assistant loading state in
+ * resume/callback flows that do not use the adapter thread object.
+ */
 export function createSlackWebApiAssistantStatusSession(args: {
   channelId?: string;
   threadTs?: string;
   getSlackClient?: typeof getSlackClient;
+  loadingMessages?: string[];
   now?: () => number;
   setTimer?: (callback: () => void, delayMs: number) => TimerHandle;
   clearTimer?: (timer: TimerHandle) => void;
@@ -92,6 +67,7 @@ export function createSlackWebApiAssistantStatusSession(args: {
       threadTs: args.threadTs,
       getSlackClient: args.getSlackClient,
     }),
+    loadingMessages: args.loadingMessages ?? botConfig.loadingMessages,
     now: args.now,
     setTimer: args.setTimer,
     clearTimer: args.clearTimer,

--- a/packages/junior/src/chat/slack/footer.ts
+++ b/packages/junior/src/chat/slack/footer.ts
@@ -75,7 +75,11 @@ function resolveTotalTokens(
   return usage.totalTokens;
 }
 
-/** Build a compact Slack reply footer so operators can correlate visible replies with backend state. */
+/**
+ * Build a compact footer for the finalized Slack reply.
+ *
+ * This is reply metadata, not part of the in-flight assistant loading state.
+ */
 export function buildSlackReplyFooter(args: {
   conversationId?: string;
   durationMs?: number;
@@ -119,7 +123,7 @@ export function buildSlackReplyFooter(args: {
   return items.length > 0 ? { items } : undefined;
 }
 
-/** Build Slack blocks for a finalized reply plus its optional footer context block. */
+/** Build Slack blocks for a finalized reply plus its optional metadata footer. */
 export function buildSlackReplyBlocks(
   text: string,
   footer: SlackReplyFooter | undefined,

--- a/packages/junior/src/chat/tools/index.ts
+++ b/packages/junior/src/chat/tools/index.ts
@@ -4,6 +4,7 @@ import type { SkillMetadata } from "@/chat/skills";
 import { createImageGenerateTool } from "@/chat/tools/web/image-generate";
 import { createLoadSkillTool } from "@/chat/tools/skill/load-skill";
 import { createReadFileTool } from "@/chat/tools/sandbox/read-file";
+import { createReportProgressTool } from "@/chat/tools/runtime/report-progress";
 import { createSearchToolsTool } from "@/chat/tools/skill/search-tools";
 import { createSlackChannelListMessagesTool } from "@/chat/tools/slack/channel-list-messages";
 import { createSlackChannelPostMessageTool } from "@/chat/tools/slack/channel-post-message";
@@ -83,6 +84,7 @@ export function createTools(
     loadSkill: createLoadSkillTool(availableSkills, {
       onSkillLoaded: hooks.onSkillLoaded,
     }),
+    reportProgress: createReportProgressTool(),
     systemTime: createSystemTimeTool(),
     bash: createBashTool(),
     attachFile: createAttachFileTool(context.sandbox, hooks),

--- a/packages/junior/src/chat/tools/runtime/report-progress.ts
+++ b/packages/junior/src/chat/tools/runtime/report-progress.ts
@@ -1,0 +1,28 @@
+import { Type } from "@sinclair/typebox";
+import { tool } from "@/chat/tools/definition";
+
+/** Create the internal tool the model uses for sparse major-phase updates. */
+export function createReportProgressTool() {
+  return tool({
+    description:
+      "Update assistant status when you start a major new phase of work. Use for sparse phase changes such as researching, reading, executing, reviewing, or drafting. Do not call this for every tool or minor substep.",
+    inputSchema: Type.Object({
+      phase: Type.Union([
+        Type.Literal("thinking"),
+        Type.Literal("researching"),
+        Type.Literal("reading"),
+        Type.Literal("executing"),
+        Type.Literal("reviewing"),
+        Type.Literal("drafting"),
+      ]),
+      detail: Type.Optional(
+        Type.String({
+          minLength: 1,
+          maxLength: 40,
+          description:
+            "Optional short user-facing detail, such as docs, tests, source files, or reply.",
+        }),
+      ),
+    }),
+  });
+}

--- a/packages/junior/tests/fixtures/slack-harness.ts
+++ b/packages/junior/tests/fixtures/slack-harness.ts
@@ -75,7 +75,7 @@ export class FakeSlackAdapter {
     channelId: string;
     threadTs: string;
     text: string;
-    suggestions?: string[];
+    loadingMessages?: string[];
   }> = [];
   readonly promptCalls: Array<{
     channelId: string;
@@ -108,9 +108,9 @@ export class FakeSlackAdapter {
     channelId: string,
     threadTs: string,
     text: string,
-    suggestions?: string[],
+    loadingMessages?: string[],
   ): Promise<void> {
-    this.statusCalls.push({ channelId, threadTs, text, suggestions });
+    this.statusCalls.push({ channelId, threadTs, text, loadingMessages });
   }
 }
 

--- a/packages/junior/tests/integration/slack/assistant-status-auth-contract.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-status-auth-contract.test.ts
@@ -4,6 +4,7 @@ import {
   createSlackAdapterAssistantStatusSession,
   makeAssistantStatus,
 } from "@/chat/slack/assistant-thread/status";
+import { SLACK_ASSISTANT_ACTIVE_STATUS } from "@/chat/slack/assistant-thread/status-send";
 import { createJuniorSlackAdapter } from "@/chat/slack/adapter";
 import {
   getCapturedSlackApiCalls,
@@ -16,6 +17,7 @@ const TEAM_BOT_TOKEN = "xoxb-team";
 const BOT_USER_ID = "U_BOT";
 const DM_CHANNEL_ID = "D12345";
 const THREAD_TS = "1700000000.000001";
+const INITIAL_LOADING_MESSAGE = "Consulting the orb";
 
 interface FakeTimer {
   id: number;
@@ -108,6 +110,7 @@ describe("Slack contract: assistant status auth", () => {
         channelId: DM_CHANNEL_ID,
         threadTs: THREAD_TS,
         getSlackAdapter: () => adapter,
+        loadingMessages: [INITIAL_LOADING_MESSAGE],
         random: () => 0,
       }),
     );
@@ -123,7 +126,8 @@ describe("Slack contract: assistant status auth", () => {
         params: expect.objectContaining({
           channel_id: DM_CHANNEL_ID,
           thread_ts: THREAD_TS,
-          status: "Thinking …",
+          status: SLACK_ASSISTANT_ACTIVE_STATUS,
+          loading_messages: [INITIAL_LOADING_MESSAGE],
         }),
       }),
     ]);
@@ -137,6 +141,7 @@ describe("Slack contract: assistant status auth", () => {
         channelId: DM_CHANNEL_ID,
         threadTs: THREAD_TS,
         getSlackAdapter: () => adapter,
+        loadingMessages: [INITIAL_LOADING_MESSAGE],
         now: scheduler.now,
         setTimer: scheduler.setTimer,
         clearTimer: scheduler.clearTimer,
@@ -160,7 +165,8 @@ describe("Slack contract: assistant status auth", () => {
           params: expect.objectContaining({
             channel_id: DM_CHANNEL_ID,
             thread_ts: THREAD_TS,
-            status: "Thinking …",
+            status: SLACK_ASSISTANT_ACTIVE_STATUS,
+            loading_messages: [INITIAL_LOADING_MESSAGE],
           }),
         }),
         expect.objectContaining({
@@ -170,7 +176,8 @@ describe("Slack contract: assistant status auth", () => {
           params: expect.objectContaining({
             channel_id: DM_CHANNEL_ID,
             thread_ts: THREAD_TS,
-            status: "Searching sources",
+            status: SLACK_ASSISTANT_ACTIVE_STATUS,
+            loading_messages: ["Searching sources"],
           }),
         }),
       ]),

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -600,7 +600,7 @@ describe("bot handlers (integration)", () => {
       channelId: "C_STATUS",
       threadTs: "1700000000.000",
       text: "",
-      suggestions: undefined,
+      loadingMessages: undefined,
     });
   });
 
@@ -674,7 +674,7 @@ describe("bot handlers (integration)", () => {
       channelId,
       threadTs,
       text,
-      suggestions,
+      loadingMessages,
     ) => {
       statusCallCount += 1;
       if (statusCallCount === 1) {
@@ -682,7 +682,12 @@ describe("bot handlers (integration)", () => {
           releaseFirstStatus = resolve;
         });
       }
-      fakeAdapter.statusCalls.push({ channelId, threadTs, text, suggestions });
+      fakeAdapter.statusCalls.push({
+        channelId,
+        threadTs,
+        text,
+        loadingMessages,
+      });
     };
 
     let replyStarted = false;

--- a/packages/junior/tests/integration/slack/new-mention-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/new-mention-behavior.test.ts
@@ -118,7 +118,7 @@ describe("Slack behavior: new mention", () => {
       channelId: "C_STATUS",
       threadTs: "1700002000.000",
       text: "",
-      suggestions: undefined,
+      loadingMessages: undefined,
     });
   });
 
@@ -171,7 +171,7 @@ describe("Slack behavior: new mention", () => {
       channelId: "C_STATUS",
       threadTs: "1700004000.000",
       text: "",
-      suggestions: undefined,
+      loadingMessages: undefined,
     });
   });
 
@@ -206,7 +206,7 @@ describe("Slack behavior: new mention", () => {
       channelId: "C_STATUS",
       threadTs: "1700003000.000",
       text: "",
-      suggestions: undefined,
+      loadingMessages: undefined,
     });
   });
 

--- a/packages/junior/tests/unit/config/chat-config.test.ts
+++ b/packages/junior/tests/unit/config/chat-config.test.ts
@@ -64,6 +64,33 @@ describe("chat config", () => {
     expect(botConfig.visionModelId).toBe("openai/gpt-5.4");
   });
 
+  it("uses the default assistant loading messages when unset", async () => {
+    delete process.env.JUNIOR_LOADING_MESSAGES;
+    const { botConfig } = await loadConfig();
+    expect(botConfig.loadingMessages.length).toBeGreaterThan(0);
+  });
+
+  it("uses JUNIOR_LOADING_MESSAGES when configured", async () => {
+    process.env.JUNIOR_LOADING_MESSAGES = JSON.stringify([
+      "Consulting the orb",
+      "Bribing the gremlins",
+    ]);
+
+    const { botConfig } = await loadConfig();
+    expect(botConfig.loadingMessages).toEqual([
+      "Consulting the orb",
+      "Bribing the gremlins",
+    ]);
+  });
+
+  it("throws when JUNIOR_LOADING_MESSAGES is not a JSON string array", async () => {
+    process.env.JUNIOR_LOADING_MESSAGES = '{"nope":true}';
+
+    await expect(loadConfig()).rejects.toThrow(
+      "JUNIOR_LOADING_MESSAGES must be a JSON array of strings",
+    );
+  });
+
   it("uses default AGENT_TURN_TIMEOUT_MS when env var is unset", async () => {
     delete process.env.AGENT_TURN_TIMEOUT_MS;
     const { botConfig } = await loadConfig();

--- a/packages/junior/tests/unit/progress-reporter.test.ts
+++ b/packages/junior/tests/unit/progress-reporter.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from "vitest";
-import {
-  createSlackAssistantStatusSession,
-  makeAssistantStatus,
-} from "@/chat/slack/assistant-thread/status";
+import { createAssistantStatusScheduler } from "@/chat/slack/assistant-thread/status-scheduler";
+import { makeAssistantStatus } from "@/chat/slack/assistant-thread/status-render";
 
 interface FakeTimer {
   id: number;
@@ -63,7 +61,7 @@ function createFakeScheduler() {
   };
 }
 
-const firstPlayfulStatus = "Thinking …";
+const firstGenericStatus = "Consulting the orb";
 const secondSearchingStatus = "Searching sources";
 const secondReadingStatus = "Reading source files";
 const secondReviewingStatus = "Reviewing results";
@@ -74,16 +72,15 @@ async function flushAsyncWork(): Promise<void> {
   await Promise.resolve();
 }
 
-describe("createSlackAssistantStatusSession", () => {
-  it("posts an initial playful status on start", async () => {
+describe("createAssistantStatusScheduler", () => {
+  it("posts the first generic loading message on start", async () => {
     const scheduler = createFakeScheduler();
     const statuses: string[] = [];
-    const reporter = createSlackAssistantStatusSession({
-      channelId: "C1",
-      threadTs: "123.45",
-      setStatus: async (_channelId, _threadTs, text) => {
+    const reporter = createAssistantStatusScheduler({
+      sendStatus: async (text) => {
         statuses.push(text);
       },
+      loadingMessages: ["Consulting the orb"],
       now: scheduler.now,
       setTimer: scheduler.setTimer,
       clearTimer: scheduler.clearTimer,
@@ -93,18 +90,17 @@ describe("createSlackAssistantStatusSession", () => {
     reporter.start();
     await flushAsyncWork();
 
-    expect(statuses).toEqual([firstPlayfulStatus]);
+    expect(statuses).toEqual([firstGenericStatus]);
   });
 
   it("clears the assistant status when stopped", async () => {
     const scheduler = createFakeScheduler();
     const statuses: string[] = [];
-    const reporter = createSlackAssistantStatusSession({
-      channelId: "C1",
-      threadTs: "123.45",
-      setStatus: async (_channelId, _threadTs, text) => {
+    const reporter = createAssistantStatusScheduler({
+      sendStatus: async (text) => {
         statuses.push(text);
       },
+      loadingMessages: ["Consulting the orb"],
       now: scheduler.now,
       setTimer: scheduler.setTimer,
       clearTimer: scheduler.clearTimer,
@@ -116,23 +112,22 @@ describe("createSlackAssistantStatusSession", () => {
 
     await reporter.stop();
 
-    expect(statuses).toEqual([firstPlayfulStatus, ""]);
+    expect(statuses).toEqual([firstGenericStatus, ""]);
   });
 
   it("does not wait for the initial status request before start() returns", async () => {
     const scheduler = createFakeScheduler();
     let resolveThinking: (() => void) | undefined;
-    const reporter = createSlackAssistantStatusSession({
-      channelId: "C1",
-      threadTs: "123.45",
-      setStatus: async (_channelId, _threadTs, text) => {
-        if (text !== firstPlayfulStatus) {
+    const reporter = createAssistantStatusScheduler({
+      sendStatus: async (text) => {
+        if (text !== firstGenericStatus) {
           return;
         }
         await new Promise<void>((resolve) => {
           resolveThinking = resolve;
         });
       },
+      loadingMessages: ["Consulting the orb"],
       now: scheduler.now,
       setTimer: scheduler.setTimer,
       clearTimer: scheduler.clearTimer,
@@ -150,10 +145,8 @@ describe("createSlackAssistantStatusSession", () => {
   it("does not wait for an immediate replacement status before update() returns", async () => {
     const scheduler = createFakeScheduler();
     let resolveReviewing: (() => void) | undefined;
-    const reporter = createSlackAssistantStatusSession({
-      channelId: "C1",
-      threadTs: "123.45",
-      setStatus: async (_channelId, _threadTs, text) => {
+    const reporter = createAssistantStatusScheduler({
+      sendStatus: async (text) => {
         if (text !== secondReviewingStatus) {
           return;
         }
@@ -161,6 +154,7 @@ describe("createSlackAssistantStatusSession", () => {
           resolveReviewing = resolve;
         });
       },
+      loadingMessages: ["Consulting the orb"],
       now: scheduler.now,
       setTimer: scheduler.setTimer,
       clearTimer: scheduler.clearTimer,
@@ -179,15 +173,14 @@ describe("createSlackAssistantStatusSession", () => {
     await flushAsyncWork();
   });
 
-  it("omits loading suggestions when clearing the assistant status", async () => {
+  it("omits loading messages when clearing the assistant status", async () => {
     const scheduler = createFakeScheduler();
-    const calls: Array<{ text: string; suggestions?: string[] }> = [];
-    const reporter = createSlackAssistantStatusSession({
-      channelId: "C1",
-      threadTs: "123.45",
-      setStatus: async (_channelId, _threadTs, text, suggestions) => {
-        calls.push({ text, suggestions });
+    const calls: Array<{ text: string; loadingMessages?: string[] }> = [];
+    const reporter = createAssistantStatusScheduler({
+      sendStatus: async (text, loadingMessages) => {
+        calls.push({ text, loadingMessages });
       },
+      loadingMessages: ["Consulting the orb", "Bribing the gremlins"],
       now: scheduler.now,
       setTimer: scheduler.setTimer,
       clearTimer: scheduler.clearTimer,
@@ -201,22 +194,24 @@ describe("createSlackAssistantStatusSession", () => {
 
     expect(calls).toEqual([
       {
-        text: firstPlayfulStatus,
-        suggestions: [firstPlayfulStatus],
+        text: expect.any(String),
+        loadingMessages: expect.arrayContaining([
+          "Consulting the orb",
+          "Bribing the gremlins",
+        ]),
       },
-      { text: "", suggestions: undefined },
+      { text: "", loadingMessages: undefined },
     ]);
   });
 
   it("suppresses duplicate pending statuses", async () => {
     const scheduler = createFakeScheduler();
     const statuses: string[] = [];
-    const reporter = createSlackAssistantStatusSession({
-      channelId: "C1",
-      threadTs: "123.45",
-      setStatus: async (_channelId, _threadTs, text) => {
+    const reporter = createAssistantStatusScheduler({
+      sendStatus: async (text) => {
         statuses.push(text);
       },
+      loadingMessages: ["Consulting the orb"],
       now: scheduler.now,
       setTimer: scheduler.setTimer,
       clearTimer: scheduler.clearTimer,
@@ -231,18 +226,17 @@ describe("createSlackAssistantStatusSession", () => {
     scheduler.advance(1200);
     await flushAsyncWork();
 
-    expect(statuses).toEqual([firstPlayfulStatus, secondSearchingStatus]);
+    expect(statuses).toEqual([firstGenericStatus, secondSearchingStatus]);
   });
 
   it("enforces minimum visible duration before replacement", async () => {
     const scheduler = createFakeScheduler();
     const statuses: string[] = [];
-    const reporter = createSlackAssistantStatusSession({
-      channelId: "C1",
-      threadTs: "123.45",
-      setStatus: async (_channelId, _threadTs, text) => {
+    const reporter = createAssistantStatusScheduler({
+      sendStatus: async (text) => {
         statuses.push(text);
       },
+      loadingMessages: ["Consulting the orb"],
       now: scheduler.now,
       setTimer: scheduler.setTimer,
       clearTimer: scheduler.clearTimer,
@@ -255,22 +249,21 @@ describe("createSlackAssistantStatusSession", () => {
     reporter.update(makeAssistantStatus("reading", "source files"));
     scheduler.advance(1000);
     await flushAsyncWork();
-    expect(statuses).toEqual([firstPlayfulStatus]);
+    expect(statuses).toEqual([firstGenericStatus]);
 
     scheduler.advance(200);
     await flushAsyncWork();
-    expect(statuses).toEqual([firstPlayfulStatus, secondReadingStatus]);
+    expect(statuses).toEqual([firstGenericStatus, secondReadingStatus]);
   });
 
   it("keeps the latest status when multiple updates arrive before flush", async () => {
     const scheduler = createFakeScheduler();
     const statuses: string[] = [];
-    const reporter = createSlackAssistantStatusSession({
-      channelId: "C1",
-      threadTs: "123.45",
-      setStatus: async (_channelId, _threadTs, text) => {
+    const reporter = createAssistantStatusScheduler({
+      sendStatus: async (text) => {
         statuses.push(text);
       },
+      loadingMessages: ["Consulting the orb"],
       now: scheduler.now,
       setTimer: scheduler.setTimer,
       clearTimer: scheduler.clearTimer,
@@ -286,24 +279,23 @@ describe("createSlackAssistantStatusSession", () => {
     scheduler.advance(1200);
     await flushAsyncWork();
 
-    expect(statuses).toEqual([firstPlayfulStatus, secondReviewingStatus]);
+    expect(statuses).toEqual([firstGenericStatus, secondReviewingStatus]);
   });
 
   it("serializes status updates so a slow request cannot reorder with the clear", async () => {
     const scheduler = createFakeScheduler();
     const statuses: string[] = [];
     let resolveThinking: (() => void) | undefined;
-    const reporter = createSlackAssistantStatusSession({
-      channelId: "C1",
-      threadTs: "123.45",
-      setStatus: async (_channelId, _threadTs, text) => {
-        if (text === firstPlayfulStatus) {
+    const reporter = createAssistantStatusScheduler({
+      sendStatus: async (text) => {
+        if (text === firstGenericStatus) {
           await new Promise<void>((resolve) => {
             resolveThinking = resolve;
           });
         }
         statuses.push(text);
       },
+      loadingMessages: ["Consulting the orb"],
       now: scheduler.now,
       setTimer: scheduler.setTimer,
       clearTimer: scheduler.clearTimer,
@@ -322,18 +314,17 @@ describe("createSlackAssistantStatusSession", () => {
     await endPromise;
 
     // The clear must always be the last status sent to Slack
-    expect(statuses).toEqual([firstPlayfulStatus, ""]);
+    expect(statuses).toEqual([firstGenericStatus, ""]);
   });
 
   it("clears after the latest visible status when stopping", async () => {
     const scheduler = createFakeScheduler();
     const statuses: string[] = [];
-    const reporter = createSlackAssistantStatusSession({
-      channelId: "C1",
-      threadTs: "123.45",
-      setStatus: async (_channelId, _threadTs, text) => {
+    const reporter = createAssistantStatusScheduler({
+      sendStatus: async (text) => {
         statuses.push(text);
       },
+      loadingMessages: ["Consulting the orb"],
       now: scheduler.now,
       setTimer: scheduler.setTimer,
       clearTimer: scheduler.clearTimer,
@@ -349,18 +340,17 @@ describe("createSlackAssistantStatusSession", () => {
 
     await reporter.stop();
 
-    expect(statuses).toEqual([firstPlayfulStatus, secondReviewingStatus, ""]);
+    expect(statuses).toEqual([firstGenericStatus, secondReviewingStatus, ""]);
   });
 
   it("refreshes the current status during long-running work", async () => {
     const scheduler = createFakeScheduler();
     const statuses: string[] = [];
-    const reporter = createSlackAssistantStatusSession({
-      channelId: "C1",
-      threadTs: "123.45",
-      setStatus: async (_channelId, _threadTs, text) => {
+    const reporter = createAssistantStatusScheduler({
+      sendStatus: async (text) => {
         statuses.push(text);
       },
+      loadingMessages: ["Consulting the orb"],
       now: scheduler.now,
       setTimer: scheduler.setTimer,
       clearTimer: scheduler.clearTimer,
@@ -373,6 +363,111 @@ describe("createSlackAssistantStatusSession", () => {
     scheduler.advance(30_000);
     await flushAsyncWork();
 
-    expect(statuses).toEqual([firstPlayfulStatus, firstPlayfulStatus]);
+    expect(statuses).toEqual([firstGenericStatus, firstGenericStatus]);
+  });
+
+  it("does not let fallback tool statuses replace a major progress phase", async () => {
+    const scheduler = createFakeScheduler();
+    const statuses: string[] = [];
+    const reporter = createAssistantStatusScheduler({
+      sendStatus: async (text) => {
+        statuses.push(text);
+      },
+      loadingMessages: ["Consulting the orb"],
+      now: scheduler.now,
+      setTimer: scheduler.setTimer,
+      clearTimer: scheduler.clearTimer,
+      random: () => 0,
+    });
+
+    reporter.start();
+    await flushAsyncWork();
+
+    scheduler.advance(1200);
+    reporter.update(
+      makeAssistantStatus("reviewing", "results", { source: "major" }),
+    );
+    await flushAsyncWork();
+
+    reporter.update(makeAssistantStatus("running", "pnpm"));
+    scheduler.advance(1200);
+    await flushAsyncWork();
+
+    expect(statuses).toEqual([firstGenericStatus, secondReviewingStatus]);
+  });
+
+  it("omits generic loading messages for major progress updates", async () => {
+    const scheduler = createFakeScheduler();
+    const calls: Array<{ text: string; loadingMessages?: string[] }> = [];
+    const reporter = createAssistantStatusScheduler({
+      sendStatus: async (text, loadingMessages) => {
+        calls.push({ text, loadingMessages });
+      },
+      loadingMessages: ["Consulting the orb"],
+      now: scheduler.now,
+      setTimer: scheduler.setTimer,
+      clearTimer: scheduler.clearTimer,
+      random: () => 0,
+    });
+
+    reporter.start();
+    await flushAsyncWork();
+
+    scheduler.advance(1200);
+    reporter.update(
+      makeAssistantStatus("reviewing", "results", { source: "major" }),
+    );
+    await flushAsyncWork();
+
+    expect(calls).toEqual([
+      {
+        text: firstGenericStatus,
+        loadingMessages: ["Consulting the orb"],
+      },
+      {
+        text: secondReviewingStatus,
+        loadingMessages: [secondReviewingStatus],
+      },
+    ]);
+  });
+
+  it("lets a major progress phase clear generic loading messages without changing the visible text", async () => {
+    const scheduler = createFakeScheduler();
+    const calls: Array<{ text: string; loadingMessages?: string[] }> = [];
+    const reporter = createAssistantStatusScheduler({
+      sendStatus: async (text, loadingMessages) => {
+        calls.push({ text, loadingMessages });
+      },
+      loadingMessages: ["Consulting the orb"],
+      now: scheduler.now,
+      setTimer: scheduler.setTimer,
+      clearTimer: scheduler.clearTimer,
+      random: () => 0,
+    });
+
+    reporter.start();
+    await flushAsyncWork();
+
+    scheduler.advance(1200);
+    reporter.update(makeAssistantStatus("reviewing"));
+    await flushAsyncWork();
+
+    reporter.update(
+      makeAssistantStatus("reviewing", "results", { source: "major" }),
+    );
+    reporter.update(makeAssistantStatus("running", "pnpm"));
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(calls).toEqual([
+      {
+        text: firstGenericStatus,
+        loadingMessages: ["Consulting the orb"],
+      },
+      {
+        text: secondReviewingStatus,
+        loadingMessages: [secondReviewingStatus],
+      },
+    ]);
   });
 });

--- a/packages/junior/tests/unit/runtime/respond-status-formatters.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-status-formatters.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { makeAssistantStatus } from "@/chat/slack/assistant-thread/status";
 import { buildToolStatus } from "@/chat/runtime/tool-status";
+import { makeAssistantStatus } from "@/chat/slack/assistant-thread/status-render";
 
 describe("tool status formatters", () => {
   it("avoids infrastructure language in shell statuses", () => {
@@ -49,5 +49,20 @@ describe("tool status formatters", () => {
     expect(
       buildToolStatus("webSearch", { query: "hottest news story today 2025" }),
     ).toEqual(makeAssistantStatus("searching", "sources"));
+  });
+
+  it("treats reportProgress as a major phase update", () => {
+    expect(
+      buildToolStatus("reportProgress", {
+        phase: "drafting",
+        detail: "reply",
+      }),
+    ).toEqual(makeAssistantStatus("drafting", "reply", { source: "major" }));
+    expect(
+      buildToolStatus("reportProgress", {
+        phase: "reviewing",
+        detail: "results",
+      }),
+    ).toEqual(makeAssistantStatus("reviewing", "results", { source: "major" }));
   });
 });

--- a/specs/slack-agent-delivery-spec.md
+++ b/specs/slack-agent-delivery-spec.md
@@ -105,6 +105,10 @@ Current contract:
 7. Slack `assistant.threads.*` calls must use the current inbound event's live assistant-thread key. For non-DM message events, the first reply may target `thread_ts ?? ts` from the live event. For `message.im`, an explicit `thread_ts` is still required; when Slack omits it, Junior skips assistant status/title updates instead of substituting the message `ts` or a stored root.
 8. Status transports that debounce, rotate, or otherwise defer updates must bind the active Slack bot token when the turn starts instead of relying on later ambient request context. Delayed status updates must keep targeting the same workspace installation as the turn's final reply.
 9. Assistant status is best effort and must not sit on the critical path for model/tool execution. Starting a turn or updating mid-turn status may queue Slack writes, but must not wait for Slack round-trips before assistant work continues.
+10. When Junior has an explicit major-phase progress update, that major-phase status must take precedence over generic tool-derived fallback statuses until another major-phase update arrives or the turn ends.
+11. When Junior shows an explicit major-phase progress update, it must not also send the generic `loading_messages` rotation for that same status update. Major-phase progress owns the loading surface until the turn ends or another status update replaces it.
+12. While a turn is active, Junior uses a stable generic `status` string for Slack's assistant loading state and changes the user-visible progress copy through `loading_messages`.
+13. Final reply footer metadata is not part of the in-flight loading contract. Footer blocks, when present, belong only to the finalized reply artifact.
 
 Status is the only in-flight progress surface required by the contract. Visible assistant reply text is posted only after the turn result is finalized and delivery has been planned.
 
@@ -121,9 +125,13 @@ Design note:
    - Long-running turns refresh the current status before Slack's timeout would remove it.
    - Delayed callbacks bind the active installation token when the turn starts.
 3. Product policy:
+   - Junior keeps Slack's `status` text stable and generic while a turn is active.
    - Junior may randomize phrasing for statuses derived from the same stable status kind.
    - Junior may debounce and minimum-display-time status transitions to avoid unreadable flicker.
-   - Junior may supply `loading_messages` suggestions as part of the Slack status UX.
+   - Junior may supply generic `loading_messages` from core bot configuration and randomize their order per turn.
+   - Junior suppresses the generic `loading_messages` rotation while an explicit progress update is active and uses the current progress message as the loading surface instead.
+   - Junior may expose an internal progress-reporting tool for sparse major-phase updates while keeping tool-derived statuses as fallback behavior.
+   - Footer metadata, when enabled, is a separate finalized-reply affordance and must not be treated as assistant progress.
 
 ### 5. Primary Reply Contract
 
@@ -139,6 +147,7 @@ Current rules:
 6. Reply text must be rendered through the shared Slack output translator before delivery; raw Slack API writers do not own markdown translation rules.
 7. When Junior adds reply footer metadata, it attaches that metadata as a Slack `context` block on the final text chunk only, while keeping the main reply text as the top-level fallback.
 8. Footer metadata is derived from structured reply diagnostics and correlation state. Conversation ID, trace ID, token totals, and turn duration may be shown when available; footer rendering must not scrape logs or spans after the fact.
+9. Footer metadata is not an assistant-status surface and must not be used to convey in-flight progress.
 
 This is intentional. Slack-native text streaming may still exist as an adapter capability, but it is not part of Junior's correctness contract.
 


### PR DESCRIPTION
Align Slack assistant loading UX with Slacks actual loading surfaces.

Slack emphasizes loading_messages more than the raw status string, but our progress pipeline was mutating the status text directly. This changes the runtime to keep Slacks assistant status fixed and generic while routing user-visible progress through loading_messages.

It also deslops the status subsystem a bit: removes the dead generic session wrapper, shrinks internal exports, and rewrites the Slack spec plus inline comments so future edits preserve the same contract.

Footer metadata remains a separate finalized-reply affordance; this change only touches in-flight loading behavior.