### PR TITLE
fix(slack): clarify named-channel posting limits

### DIFF
--- a/packages/junior-evals/evals/core/routing-and-continuity.eval.ts
+++ b/packages/junior-evals/evals/core/routing-and-continuity.eval.ts
@@ -37,6 +37,30 @@ describe("Routing and Continuity", () => {
   );
 
   slackEval(
+    "when asked to post in another named channel, explain the limitation instead",
+    {
+      events: [
+        mention(
+          "@bot post this in #discuss-design-engineering instead: Heads up, design review starts in 10 minutes.",
+        ),
+      ],
+      criteria: rubric({
+        contract:
+          "A request for another named channel does not get silently redirected to the current channel.",
+        pass: [
+          "channel_posts is empty.",
+          "assistant_posts contains exactly one reply.",
+          "That reply clearly says the assistant can only post to the current channel or cannot post to #discuss-design-engineering from here.",
+        ],
+        fail: [
+          "Do not send a direct channel post to the current channel.",
+          "Do not claim the message was posted to #discuss-design-engineering.",
+        ],
+      }),
+    },
+  );
+
+  slackEval(
     "when the request is reaction-only, add a reaction without reply clutter",
     {
       events: [mention("react to this")],

--- a/packages/junior/src/chat/tools/slack/channel-post-message.ts
+++ b/packages/junior/src/chat/tools/slack/channel-post-message.ts
@@ -10,7 +10,7 @@ export function createSlackChannelPostMessageTool(
 ) {
   return tool({
     description:
-      "Post a message in the active Slack channel context (outside the thread). Use this when the user explicitly asks to post/send/share/say something in the channel. Do not use for normal thread replies or speculative broadcasts. Do not claim a channel message was posted unless this tool succeeds in this turn.",
+      "Post a message in the active Slack channel context (outside the thread). Use this only when the user explicitly asks to post/send/share/say something in the current channel. Do not use it for normal thread replies, speculative broadcasts, or requests targeting another named channel; explain that limitation instead. Do not claim a channel message was posted unless this tool succeeds in this turn.",
     inputSchema: Type.Object({
       text: Type.String({
         minLength: 1,


### PR DESCRIPTION
Clarify that `slackChannelPostMessage` only applies to the active channel and add a regression eval for cross-channel post requests.

The issue in #231 is model behavior, not deterministic tool routing. The active-channel post tool was being treated as if it could satisfy requests for another named channel, which let Junior post in the wrong place and report success.

This tightens the tool description so the model is told to explain the limitation instead of calling the current-channel post tool, and adds a routing eval that requires an in-thread refusal with no channel post for `#discuss-design-engineering` requests.

Fixes #231