### PR TITLE
docs: align health route and Nitro examples

### DIFF
--- a/packages/docs/src/content/docs/cli/init.md
+++ b/packages/docs/src/content/docs/cli/init.md
@@ -73,7 +73,7 @@ After scaffolding:
 1. Run `cd my-bot && pnpm install`.
 2. Fill in the required values from `.env.example`.
 3. Run `pnpm dev`.
-4. Check `http://localhost:3000/api/health`.
+4. Check `http://localhost:3000/health`.
 
 For the complete setup flow, continue with [Quickstart](/start-here/quickstart/).
 

--- a/packages/docs/src/content/docs/extend/index.md
+++ b/packages/docs/src/content/docs/extend/index.md
@@ -72,7 +72,7 @@ export default defineConfig({
     }),
   ],
   routes: {
-    "/api/**": { handler: "./server.ts" },
+    "/**": { handler: "./server.ts" },
   },
 });
 ```

--- a/packages/docs/src/content/docs/reference/handler-surface.md
+++ b/packages/docs/src/content/docs/reference/handler-surface.md
@@ -11,16 +11,19 @@ related:
 
 ## `@sentry/junior` (via `createApp()`)
 
-The Hono app created by `createApp()` mounts all routes under `/api`.
+The Hono app created by `createApp()` mounts a mix of root-level and `/api` routes.
 
 Handled `GET` routes:
 
-- `/api/health`
+- `/`
+- `/health`
+- `/api/info`
 - `/api/oauth/callback/:provider`
 - `/api/oauth/callback/mcp/:provider`
 
 Handled `POST` routes:
 
+- `/api/internal/turn-resume`
 - `/api/webhooks/:platform` (Slack path is `/api/webhooks/slack`)
 
 ## Expected behavior

--- a/packages/docs/src/content/docs/start-here/quickstart.md
+++ b/packages/docs/src/content/docs/start-here/quickstart.md
@@ -70,7 +70,7 @@ This starts the local app on `http://localhost:3000` by default.
 
 Check the health route first, then verify a real Slack thread.
 
-- `GET http://localhost:3000/api/health` returns JSON with `status: "ok"`.
+- `GET http://localhost:3000/health` returns JSON with `status: "ok"`.
 - Set your Slack Event Subscriptions and Interactivity URLs to `http://<your-tunnel-or-dev-host>/api/webhooks/slack`.
 - Mention the bot in Slack and confirm it replies in the same thread.
 
@@ -104,7 +104,7 @@ export default defineConfig({
     }),
   ],
   routes: {
-    "/api/**": { handler: "./server.ts" },
+    "/**": { handler: "./server.ts" },
   },
 });
 ```
@@ -191,7 +191,7 @@ https://<your-domain>/api/webhooks/slack
 
 ### Verify in production
 
-- `GET https://<your-domain>/api/health` succeeds.
+- `GET https://<your-domain>/health` succeeds.
 - A Slack mention produces a thread reply.
 - Queue callback logs show successful processing.
 

--- a/packages/docs/src/content/docs/start-here/verify-and-troubleshoot.md
+++ b/packages/docs/src/content/docs/start-here/verify-and-troubleshoot.md
@@ -12,7 +12,7 @@ related:
 
 ## Verification sequence
 
-1. Health endpoint: `GET /api/health` returns `status: "ok"`.
+1. Health endpoint: `GET /health` returns `status: "ok"`.
 2. Slack ingress: mention bot and confirm thread reply appears.
 3. Queue callback: verify callback route logs include successful processing.
 4. Plugin auth (if enabled): run one real command and confirm expected result.


### PR DESCRIPTION
## Summary
- update quickstart, init, and troubleshooting docs to use `/health` instead of `/api/health`
- change Nitro config examples to use `"/**"` so they match the `junior init` scaffold
- expand the handler surface reference to document the mixed root-level and `/api` route layout exposed by `createApp()`

This corrects the docs based on what I'm seeing in the code and experiencing in my deployed instance. Let me know if you would prefer the reverse fix and update the implementation to match current docs.

## Test plan
- [x] Run `pnpm docs:check`
- [x] Confirm `packages/junior/src/app.ts` mounts `/health`
- [x] Confirm `packages/junior/src/cli/init.ts` scaffolds `"/**": { handler: "./server.ts" }`