### PR TITLE
ref(chat): simplify thinking router and instrument classifier

### DIFF
--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -564,8 +564,6 @@ export async function generateAssistantReply(
     });
 
     thinkingSelection = await selectTurnThinkingLevel({
-      activeSkillNames: activeSkills.map((skill) => skill.name),
-      attachmentCount: context.userAttachments?.length,
       completeObject,
       conversationContext: context.conversationContext,
       context: {

--- a/packages/junior/src/chat/services/turn-thinking-level.ts
+++ b/packages/junior/src/chat/services/turn-thinking-level.ts
@@ -47,8 +47,6 @@ function buildClassifierSystemPrompt(): string {
 }
 
 function buildClassifierPrompt(args: {
-  activeSkillNames: string[];
-  attachmentCount: number;
   conversationContext?: string;
   currentTurnBlocks?: string[];
   messageText: string;
@@ -61,12 +59,7 @@ function buildClassifierPrompt(args: {
   }
 
   sections.push(
-    "<turn-context>",
-    `- active_skills: ${args.activeSkillNames.join(", ") || "none"}`,
-    `- attachment_count: ${args.attachmentCount}`,
-    "</turn-context>",
-    "",
-    '<current-instruction priority="highest">',
+    "<current-instruction>",
     args.messageText.trim() || "[empty]",
     "</current-instruction>",
   );
@@ -84,8 +77,6 @@ function buildClassifierPrompt(args: {
 
 /** Choose the thinking level for the upcoming assistant turn. */
 export async function selectTurnThinkingLevel(args: {
-  activeSkillNames?: string[];
-  attachmentCount?: number;
   completeObject: (args: {
     modelId: string;
     schema: typeof turnExecutionProfileSchema;
@@ -107,8 +98,6 @@ export async function selectTurnThinkingLevel(args: {
   fastModelId: string;
   messageText: string;
 }): Promise<TurnThinkingSelection> {
-  const activeSkillNames = [...new Set(args.activeSkillNames ?? [])].sort();
-
   try {
     const result = await args.completeObject({
       modelId: args.fastModelId,
@@ -122,8 +111,6 @@ export async function selectTurnThinkingLevel(args: {
         runId: args.context?.runId ?? "",
       },
       prompt: buildClassifierPrompt({
-        activeSkillNames,
-        attachmentCount: args.attachmentCount ?? 0,
         conversationContext: args.conversationContext,
         currentTurnBlocks: args.currentTurnBlocks,
         messageText: args.messageText,

--- a/packages/junior/src/chat/services/turn-thinking-level.ts
+++ b/packages/junior/src/chat/services/turn-thinking-level.ts
@@ -1,9 +1,14 @@
 import type { ThinkingLevel as AgentThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { ThinkingLevel as ProviderThinkingLevel } from "@mariozechner/pi-ai";
 import { z } from "zod";
+import { setSpanAttributes, withSpan, type LogContext } from "@/chat/logging";
 
 const CLASSIFIER_CONFIDENCE_THRESHOLD = 0.75;
-const MAX_ROUTER_CONTEXT_CHARS = 1_200;
+const MAX_ROUTER_CONTEXT_CHARS = 8_000;
+const ROUTER_CONTEXT_HEAD_CHARS = 3_000;
+const ROUTER_CONTEXT_TAIL_CHARS = 5_000;
+const SHORT_INSTRUCTION_CHAR_THRESHOLD = 30;
+const TRUNCATION_MARKER = "\n…[truncated]…\n";
 const TURN_THINKING_LEVELS = ["none", "low", "medium", "high"] as const;
 
 const turnExecutionProfileSchema = z.object({
@@ -22,14 +27,34 @@ export interface TurnThinkingSelection {
 
 const DEFAULT_THINKING_LEVEL: TurnThinkingSelection["thinkingLevel"] = "low";
 
-function trimContextForRouter(text: string | undefined): string | undefined {
+interface TrimmedContext {
+  text: string;
+  truncated: boolean;
+  originalCharCount: number;
+}
+
+function trimContextForRouter(text: string | undefined): TrimmedContext | null {
   const trimmed = text?.trim();
   if (!trimmed) {
-    return undefined;
+    return null;
   }
-  return trimmed.length <= MAX_ROUTER_CONTEXT_CHARS
-    ? trimmed
-    : trimmed.slice(-MAX_ROUTER_CONTEXT_CHARS);
+  if (trimmed.length <= MAX_ROUTER_CONTEXT_CHARS) {
+    return {
+      text: trimmed,
+      truncated: false,
+      originalCharCount: trimmed.length,
+    };
+  }
+  // Keep both ends of the thread: head preserves the original task framing,
+  // tail preserves the most recent turn. Short follow-ups like "go" are often
+  // preceded by the bot's clarifying question, so tail alone is misleading.
+  const head = trimmed.slice(0, ROUTER_CONTEXT_HEAD_CHARS).trimEnd();
+  const tail = trimmed.slice(-ROUTER_CONTEXT_TAIL_CHARS).trimStart();
+  return {
+    text: `${head}${TRUNCATION_MARKER}${tail}`,
+    truncated: true,
+    originalCharCount: trimmed.length,
+  };
 }
 
 function buildClassifierSystemPrompt(): string {
@@ -42,20 +67,26 @@ function buildClassifierSystemPrompt(): string {
     "Use medium for investigations, ambiguous asks, multi-step analysis, or likely multi-tool work.",
     "Use high for code changes, debugging/root-cause analysis, research-heavy work, non-trivial drafting, or explicit requests to be thorough.",
     "",
+    "Classify based on the substance of the task, not the length of the current message. When the current instruction is a short affirmation (for example: 'go', 'do it', 'yes please', 'proceed') and the thread-background contains a pending task, classify the pending task — not the affirmation.",
+    "",
     "Return JSON only with thinking_level, confidence, and reason.",
   ].join("\n");
 }
 
 function buildClassifierPrompt(args: {
-  conversationContext?: string;
+  conversationContext?: TrimmedContext | null;
   currentTurnBlocks?: string[];
   messageText: string;
 }): string {
   const sections: string[] = [];
 
-  const context = trimContextForRouter(args.conversationContext);
-  if (context) {
-    sections.push("<thread-background>", context, "</thread-background>", "");
+  if (args.conversationContext) {
+    sections.push(
+      "<thread-background>",
+      args.conversationContext.text,
+      "</thread-background>",
+      "",
+    );
   }
 
   sections.push(
@@ -98,41 +129,119 @@ export async function selectTurnThinkingLevel(args: {
   fastModelId: string;
   messageText: string;
 }): Promise<TurnThinkingSelection> {
+  const trimmedContext = trimContextForRouter(args.conversationContext);
+  const instructionLength = args.messageText.trim().length;
+  const turnBlockCount = (args.currentTurnBlocks ?? []).filter(
+    (block) => block.trim().length > 0,
+  ).length;
+  const prompt = buildClassifierPrompt({
+    conversationContext: trimmedContext,
+    currentTurnBlocks: args.currentTurnBlocks,
+    messageText: args.messageText,
+  });
+
+  const logContext: LogContext = {
+    slackThreadId: args.context?.threadId,
+    slackChannelId: args.context?.channelId,
+    slackUserId: args.context?.requesterId,
+    runId: args.context?.runId,
+    modelId: args.fastModelId,
+  };
+
+  return withSpan(
+    "chat.route_thinking",
+    "chat.route_thinking",
+    logContext,
+    async () => {
+      setSpanAttributes({
+        "app.ai.router.prompt_char_count": prompt.length,
+        "app.ai.router.instruction_char_count": instructionLength,
+        "app.ai.router.context_char_count":
+          trimmedContext?.originalCharCount ?? 0,
+        "app.ai.router.context_trimmed": trimmedContext?.truncated ?? false,
+        "app.ai.router.turn_block_count": turnBlockCount,
+      });
+
+      const selection = await classifyTurn({
+        completeObject: args.completeObject,
+        fastModelId: args.fastModelId,
+        hasThreadBackground: trimmedContext !== null,
+        instructionLength,
+        metadata: {
+          modelId: args.fastModelId,
+          threadId: args.context?.threadId ?? "",
+          channelId: args.context?.channelId ?? "",
+          requesterId: args.context?.requesterId ?? "",
+          runId: args.context?.runId ?? "",
+        },
+        prompt,
+      });
+
+      setSpanAttributes({
+        "app.ai.thinking_level": selection.thinkingLevel,
+        "app.ai.thinking_level_reason": selection.reason,
+        ...(selection.confidence !== undefined
+          ? { "app.ai.thinking_level_confidence": selection.confidence }
+          : {}),
+      });
+
+      return selection;
+    },
+  );
+}
+
+async function classifyTurn(args: {
+  completeObject: Parameters<
+    typeof selectTurnThinkingLevel
+  >[0]["completeObject"];
+  fastModelId: string;
+  hasThreadBackground: boolean;
+  instructionLength: number;
+  metadata: Record<string, string>;
+  prompt: string;
+}): Promise<TurnThinkingSelection> {
   try {
     const result = await args.completeObject({
       modelId: args.fastModelId,
       schema: turnExecutionProfileSchema,
       maxTokens: 120,
-      metadata: {
-        modelId: args.fastModelId,
-        threadId: args.context?.threadId ?? "",
-        channelId: args.context?.channelId ?? "",
-        requesterId: args.context?.requesterId ?? "",
-        runId: args.context?.runId ?? "",
-      },
-      prompt: buildClassifierPrompt({
-        conversationContext: args.conversationContext,
-        currentTurnBlocks: args.currentTurnBlocks,
-        messageText: args.messageText,
-      }),
+      metadata: args.metadata,
+      prompt: args.prompt,
       thinkingLevel: "low",
       system: buildClassifierSystemPrompt(),
       temperature: 0,
     });
 
     const parsed = turnExecutionProfileSchema.parse(result.object);
+    const reason = parsed.reason.trim();
+
     if (parsed.confidence < CLASSIFIER_CONFIDENCE_THRESHOLD) {
       return {
         confidence: parsed.confidence,
         thinkingLevel: DEFAULT_THINKING_LEVEL,
-        reason: `low_confidence_default:${parsed.reason.trim()}`,
+        reason: `low_confidence_default:${reason}`,
+      };
+    }
+
+    // Short follow-ups like "go" or "yes please" in a thread with prior
+    // context are authorizations of the pending task — never standalone
+    // trivial asks. If the classifier still picked "none", promote to "low".
+    if (
+      parsed.thinking_level === "none" &&
+      args.hasThreadBackground &&
+      args.instructionLength < SHORT_INSTRUCTION_CHAR_THRESHOLD
+    ) {
+      return {
+        confidence: parsed.confidence,
+        thinkingLevel: "low",
+        reason: `short_followup_no_none:${reason}`,
       };
     }
 
     return {
       confidence: parsed.confidence,
       thinkingLevel: parsed.thinking_level,
-      reason: parsed.reason.trim(),
+      reason,
     };
   } catch {
     return {

--- a/packages/junior/src/chat/services/turn-thinking-level.ts
+++ b/packages/junior/src/chat/services/turn-thinking-level.ts
@@ -7,7 +7,6 @@ const CLASSIFIER_CONFIDENCE_THRESHOLD = 0.75;
 const MAX_ROUTER_CONTEXT_CHARS = 8_000;
 const ROUTER_CONTEXT_HEAD_CHARS = 3_000;
 const ROUTER_CONTEXT_TAIL_CHARS = 5_000;
-const SHORT_INSTRUCTION_CHAR_THRESHOLD = 30;
 const TRUNCATION_MARKER = "\n…[truncated]…\n";
 const TURN_THINKING_LEVELS = ["none", "low", "medium", "high"] as const;
 
@@ -165,8 +164,6 @@ export async function selectTurnThinkingLevel(args: {
       const selection = await classifyTurn({
         completeObject: args.completeObject,
         fastModelId: args.fastModelId,
-        hasThreadBackground: trimmedContext !== null,
-        instructionLength,
         metadata: {
           modelId: args.fastModelId,
           threadId: args.context?.threadId ?? "",
@@ -195,8 +192,6 @@ async function classifyTurn(args: {
     typeof selectTurnThinkingLevel
   >[0]["completeObject"];
   fastModelId: string;
-  hasThreadBackground: boolean;
-  instructionLength: number;
   metadata: Record<string, string>;
   prompt: string;
 }): Promise<TurnThinkingSelection> {
@@ -220,21 +215,6 @@ async function classifyTurn(args: {
         confidence: parsed.confidence,
         thinkingLevel: DEFAULT_THINKING_LEVEL,
         reason: `low_confidence_default:${reason}`,
-      };
-    }
-
-    // Short follow-ups like "go" or "yes please" in a thread with prior
-    // context are authorizations of the pending task — never standalone
-    // trivial asks. If the classifier still picked "none", promote to "low".
-    if (
-      parsed.thinking_level === "none" &&
-      args.hasThreadBackground &&
-      args.instructionLength < SHORT_INSTRUCTION_CHAR_THRESHOLD
-    ) {
-      return {
-        confidence: parsed.confidence,
-        thinkingLevel: "low",
-        reason: `short_followup_no_none:${reason}`,
       };
     }
 

--- a/packages/junior/tests/unit/runtime/respond-lazy-sandbox.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-lazy-sandbox.test.ts
@@ -220,7 +220,7 @@ vi.mock("@/chat/pi/client", () => ({
   GEN_AI_PROVIDER_NAME: "test-provider",
   completeObject: async ({ prompt }: { prompt: string }) => {
     const instructionMatch = prompt.match(
-      /<current-instruction priority="highest">\n([\s\S]*?)\n<\/current-instruction>/,
+      /<current-instruction>\n([\s\S]*?)\n<\/current-instruction>/,
     );
     const instruction = instructionMatch?.[1] ?? "";
 

--- a/packages/junior/tests/unit/services/turn-thinking-level.test.ts
+++ b/packages/junior/tests/unit/services/turn-thinking-level.test.ts
@@ -93,4 +93,78 @@ describe("selectTurnThinkingLevel", () => {
       reason: "classifier_error_default",
     });
   });
+
+  it("promotes 'none' to 'low' for a short follow-up in a thread with prior context", async () => {
+    const completeObject = vi.fn(async () => ({
+      object: {
+        thinking_level: "none",
+        confidence: 0.95,
+        reason: "short message",
+      },
+    }));
+
+    const profile = await selectTurnThinkingLevel({
+      completeObject,
+      fastModelId: "openai/gpt-5.4-mini",
+      messageText: "go",
+      conversationContext:
+        "user: investigate the signup 500s and draft a github issue\nbot: want me to start now?",
+    });
+
+    expect(profile).toMatchObject({
+      thinkingLevel: "low",
+      reason: "short_followup_no_none:short message",
+    });
+  });
+
+  it("leaves 'none' in place for a short message with no thread context", async () => {
+    const completeObject = vi.fn(async () => ({
+      object: {
+        thinking_level: "none",
+        confidence: 0.95,
+        reason: "greeting",
+      },
+    }));
+
+    const profile = await selectTurnThinkingLevel({
+      completeObject,
+      fastModelId: "openai/gpt-5.4-mini",
+      messageText: "hello",
+    });
+
+    expect(profile).toMatchObject({
+      thinkingLevel: "none",
+      reason: "greeting",
+    });
+  });
+
+  it("truncates very long thread context with head + tail slices", async () => {
+    let capturedPrompt = "";
+    const completeObject = async ({ prompt }: { prompt: string }) => {
+      capturedPrompt = prompt;
+      return {
+        object: {
+          thinking_level: "medium",
+          confidence: 0.9,
+          reason: "ok",
+        },
+      };
+    };
+
+    const headMarker = "ORIGINAL_TASK_FRAMING_HEAD";
+    const tailMarker = "MOST_RECENT_TURN_TAIL";
+    const filler = "filler text. ".repeat(2_000);
+    const longContext = `${headMarker} ${filler} ${tailMarker}`;
+
+    await selectTurnThinkingLevel({
+      completeObject,
+      fastModelId: "openai/gpt-5.4-mini",
+      messageText: "go",
+      conversationContext: longContext,
+    });
+
+    expect(capturedPrompt).toContain(headMarker);
+    expect(capturedPrompt).toContain(tailMarker);
+    expect(capturedPrompt).toContain("…[truncated]…");
+  });
 });

--- a/packages/junior/tests/unit/services/turn-thinking-level.test.ts
+++ b/packages/junior/tests/unit/services/turn-thinking-level.test.ts
@@ -94,50 +94,6 @@ describe("selectTurnThinkingLevel", () => {
     });
   });
 
-  it("promotes 'none' to 'low' for a short follow-up in a thread with prior context", async () => {
-    const completeObject = vi.fn(async () => ({
-      object: {
-        thinking_level: "none",
-        confidence: 0.95,
-        reason: "short message",
-      },
-    }));
-
-    const profile = await selectTurnThinkingLevel({
-      completeObject,
-      fastModelId: "openai/gpt-5.4-mini",
-      messageText: "go",
-      conversationContext:
-        "user: investigate the signup 500s and draft a github issue\nbot: want me to start now?",
-    });
-
-    expect(profile).toMatchObject({
-      thinkingLevel: "low",
-      reason: "short_followup_no_none:short message",
-    });
-  });
-
-  it("leaves 'none' in place for a short message with no thread context", async () => {
-    const completeObject = vi.fn(async () => ({
-      object: {
-        thinking_level: "none",
-        confidence: 0.95,
-        reason: "greeting",
-      },
-    }));
-
-    const profile = await selectTurnThinkingLevel({
-      completeObject,
-      fastModelId: "openai/gpt-5.4-mini",
-      messageText: "hello",
-    });
-
-    expect(profile).toMatchObject({
-      thinkingLevel: "none",
-      reason: "greeting",
-    });
-  });
-
   it("truncates very long thread context with head + tail slices", async () => {
     let capturedPrompt = "";
     const completeObject = async ({ prompt }: { prompt: string }) => {


### PR DESCRIPTION
Reworks the thinking-level classifier to make it more likely to read thread context correctly, and to make the classifier's inputs observable.

**Prompt.** Drop the `<current-instruction priority="highest">` directive and the `<turn-context>` metadata block (`active_skills`, `attachment_count`). Thread background and current instruction are now peer sections. A system-prompt line tells the classifier to route on the substance of the pending task, not the length of the current message.

The `priority="highest"` label was actively misleading for short follow-up messages: when a user says "go" or "yes please" after the bot asks "want me to start?", the classifier was told to weight the ack hardest and ignore the complex task sitting in thread history. Removing it lets context and ask stand on equal footing.

**Context budget.** Raised from 1,200 → 8,000 chars, split into a 3,000-char head + 5,000-char tail with a `…[truncated]…` marker. Tail-only slicing was adversarially wrong for the short-follow-up pattern — the tail is typically the bot's own clarifying question, which makes "go" look even more like a pure ack. Keeping the head preserves the original task framing.

**Instrumentation.** Router now runs inside a `chat.route_thinking` span capturing `app.ai.router.*` input sizes (prompt char count, context char count, instruction char count, turn block count, trimmed flag) alongside output bucket, confidence, and reason. Until now the classifier call was invisible in traces — only its output leaked onto `chat.reply` — so regressions were undebuggable. Existing `chat.reply` attributes are unchanged for dashboard/query continuity.

An earlier revision of this PR included a hardcoded guardrail that promoted `none` to `low` for short messages (<30 chars) in threads with prior context. Removed: it encoded an unvalidated hypothesis, had false positives (genuine acks like "thanks, perfect" forced to `low`), and duplicated what the prompt + context changes are meant to achieve. The span makes it possible to validate whether the failure mode occurs in real traffic before adding any rules.

Motivated by #247. The specific run cited there didn't actually under-classify when we pulled telemetry (the hypothesis/GitHub turn was already `medium`, not `none`) — but the prompt-level design flaws around short follow-ups are real and this addresses them.

Refs #247