### PR TITLE
docs: simplify one-eval-file command to use the evals script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,11 +14,11 @@ Co-Authored-By: (agent model name) <email>
 
 ## File-Scoped Commands
 
-| Task                  | Command                                                                                             |
-| --------------------- | --------------------------------------------------------------------------------------------------- |
-| Unit test file        | `pnpm --filter @sentry/junior exec vitest run path/to/file.test.ts`                                 |
-| Integration test file | `pnpm --filter @sentry/junior exec vitest run path/to/file.test.ts`                                 |
-| Eval file             | `pnpm --filter @sentry/junior-evals exec vitest run -c vitest.evals.config.ts path/to/eval.test.ts` |
+| Task                  | Command                                                             |
+| --------------------- | ------------------------------------------------------------------- |
+| Unit test file        | `pnpm --filter @sentry/junior exec vitest run path/to/file.test.ts` |
+| Integration test file | `pnpm --filter @sentry/junior exec vitest run path/to/file.test.ts` |
+| Eval file             | `pnpm --filter @sentry/junior-evals evals path/to/eval.test.ts`     |
 
 ## Key Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ pnpm --filter @sentry/junior exec vitest run path/to/file.test.ts
 Run a single eval file:
 
 ```bash
-pnpm --filter @sentry/junior exec vitest run -c vitest.evals.config.ts path/to/eval.test.ts
+pnpm --filter @sentry/junior-evals evals path/to/eval.test.ts
 ```
 
 ## Evals

--- a/packages/docs/src/content/docs/contribute/testing.md
+++ b/packages/docs/src/content/docs/contribute/testing.md
@@ -34,7 +34,7 @@ pnpm --filter @sentry/junior exec vitest run path/to/file.test.ts
 Run one eval file:
 
 ```bash
-pnpm --filter @sentry/junior exec vitest run -c vitest.evals.config.ts path/to/eval.test.ts
+pnpm --filter @sentry/junior-evals evals path/to/eval.test.ts
 ```
 
 ## Notes


### PR DESCRIPTION
Point the one-eval-file command at the `evals` package script instead of invoking vitest directly.

The prior command ran `pnpm --filter @sentry/junior exec vitest run -c vitest.evals.config.ts ...`, which bypassed the `evals` script's `JUNIOR_STATE_ADAPTER=memory` env. Evals could fail or behave differently than `pnpm evals` depending on the ambient state adapter. Using the script keeps single-file runs consistent with the full suite.

Supersedes #252, which also tried to fix this but bundled unrelated install-path documentation.