### PR TITLE
ref(chat): simplify core system prompt; collapse sections

### DIFF
--- a/packages/junior-evals/evals/core/output-contract.eval.ts
+++ b/packages/junior-evals/evals/core/output-contract.eval.ts
@@ -1,0 +1,76 @@
+import { describe } from "vitest";
+import { mention, rubric, slackEval } from "../helpers";
+
+describe("Output Contract", () => {
+  slackEval(
+    "when asked for a structured overview, use bolded section labels instead of markdown headings",
+    {
+      events: [
+        mention(
+          "Give me a short overview of how OAuth 2.0 authorization code flow works. Cover the authorization request, token exchange, and refresh. Keep it to a few short sections.",
+        ),
+      ],
+      requireSandboxReady: false,
+      criteria: rubric({
+        contract:
+          "Structured multi-section replies use Slack-friendly bolded section labels, not markdown heading syntax.",
+        pass: [
+          "The assistant posts one reply that covers the authorization request, token exchange, and refresh.",
+          "Section labels appear as bolded short phrases on their own line, not as markdown headings.",
+        ],
+        fail: [
+          "Do not use markdown heading syntax (lines beginning with `#`, `##`, or `###`) for section labels.",
+          "Do not paste a heading line like `# Authorization Request` at the start of a section.",
+        ],
+      }),
+    },
+  );
+
+  slackEval(
+    "when the reply contains multiple URLs, use plain URLs instead of markdown link syntax",
+    {
+      events: [
+        mention(
+          "Where can I find the official documentation for the Slack Web API, Slack Bolt JS, and Slack Block Kit? Just point me at the three canonical starting pages.",
+        ),
+      ],
+      requireSandboxReady: false,
+      criteria: rubric({
+        contract:
+          "URLs in Slack replies render as plain URLs, not markdown hyperlinks.",
+        pass: [
+          "The assistant posts one reply that names the three documentation starting points.",
+          "Each URL appears as a bare URL in the reply text, not wrapped in markdown link syntax.",
+        ],
+        fail: [
+          "Do not render any URL using `[label](url)` markdown link syntax.",
+          "Do not wrap URLs in Slack `<url|label>` link syntax unless the user explicitly asked for that form.",
+        ],
+      }),
+    },
+  );
+
+  slackEval(
+    "when asked to compare two options, use bullets instead of a markdown table",
+    {
+      events: [
+        mention(
+          "Give me a short comparison of REST and GraphQL across these three dimensions: caching, over-fetching, and tooling maturity. Keep it tight.",
+        ),
+      ],
+      requireSandboxReady: false,
+      criteria: rubric({
+        contract:
+          "Comparative Slack replies present structured data with bullets or bolded labels rather than markdown tables.",
+        pass: [
+          "The assistant posts one reply that compares REST and GraphQL across caching, over-fetching, and tooling maturity.",
+          "The comparison is expressed through bullets or bolded labels with short explanations, not a table.",
+        ],
+        fail: [
+          "Do not render the comparison as a markdown table with pipe (`|`) column separators and dashed header rows.",
+          "Do not include a row like `| REST | GraphQL |` or similar pipe-delimited structures.",
+        ],
+      }),
+    },
+  );
+});

--- a/packages/junior/skills/jr-rpc/SKILL.md
+++ b/packages/junior/skills/jr-rpc/SKILL.md
@@ -12,7 +12,7 @@ Manage low-level config flows for the current agent turn.
 
 `jr-rpc config get|set|unset|list` — read and write channel-scoped configuration values.
 
-- Choose config keys from the runtime provider-config catalog or the active skill's `uses-config` metadata.
+- Choose config keys from the runtime `<providers>` catalog or the active skill's `uses-config` metadata.
 
 Read `${CLAUDE_SKILL_ROOT}/references/commands.md` for full command syntax and response shapes.
 

--- a/packages/junior/skills/jr-rpc/references/capabilities.md
+++ b/packages/junior/skills/jr-rpc/references/capabilities.md
@@ -3,7 +3,7 @@
 Use the exact config-key names exposed by runtime context:
 
 - loaded skill `uses-config`
-- provider-config catalog in the prompt
+- `<providers>` catalog in the prompt
 
 Examples:
 

--- a/packages/junior/src/chat/prompt.ts
+++ b/packages/junior/src/chat/prompt.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { botConfig } from "@/chat/config";
+import { botConfig, getRuntimeMetadata } from "@/chat/config";
 import {
   listReferenceFiles,
   soulPathCandidates,
@@ -9,11 +9,9 @@ import {
 import { logInfo, logWarn } from "@/chat/logging";
 import { getPluginProviders } from "@/chat/plugins/registry";
 import { slackOutputPolicy } from "@/chat/slack/output";
-import type { RuntimeMetadata } from "@/chat/config";
 import { SANDBOX_DATA_ROOT, sandboxSkillDir } from "@/chat/sandbox/paths";
 import type { ThreadArtifactsState } from "@/chat/state/artifacts";
 import type { Skill, SkillMetadata, SkillInvocation } from "@/chat/skills";
-import type { ExposedToolSummary } from "@/chat/tools/skill/mcp-tool-summary";
 import { escapeXml } from "@/chat/xml";
 
 const DEFAULT_SOUL = "You are Junior, a practical and concise assistant.";
@@ -129,28 +127,32 @@ function formatConfigurationValue(value: unknown): string {
 function renderIdentityBlock(
   tag: "assistant" | "requester",
   fields: Record<string, string | undefined>,
-): string {
+): string[] {
   const lines = Object.entries(fields)
     .filter(([, value]) => Boolean(value))
     .map(([key, value]) => `- ${key}: ${escapeXml(value as string)}`);
 
   if (lines.length === 0) {
-    return [`<${tag}>`, "none", `</${tag}>`].join("\n");
+    return [`<${tag}>`, "none", `</${tag}>`];
   }
 
-  return [`<${tag}>`, ...lines, `</${tag}>`].join("\n");
+  return [`<${tag}>`, ...lines, `</${tag}>`];
 }
 
-function renderTag(tag: string, content: string): string {
+function renderTag(tag: string, lines: string[]): string[] {
+  return [`<${tag}>`, ...lines, `</${tag}>`];
+}
+
+function renderTagBlock(tag: string, content: string): string {
   return [`<${tag}>`, content, `</${tag}>`].join("\n");
 }
 
 function formatAvailableSkillsForPrompt(skills: SkillMetadata[]): string {
   if (skills.length === 0) {
-    return "<available_skills>\n</available_skills>";
+    return "<available-skills>\n</available-skills>";
   }
 
-  const lines = ["<available_skills>"];
+  const lines = ["<available-skills>"];
   for (const skill of skills) {
     const skillLocation = `${workspaceSkillDir(skill.name)}/SKILL.md`;
     lines.push("  <skill>");
@@ -169,16 +171,16 @@ function formatAvailableSkillsForPrompt(skills: SkillMetadata[]): string {
     }
     lines.push("  </skill>");
   }
-  lines.push("</available_skills>");
+  lines.push("</available-skills>");
   return lines.join("\n");
 }
 
 function formatLoadedSkillsForPrompt(skills: Skill[]): string {
   if (skills.length === 0) {
-    return "<loaded_skills>\n</loaded_skills>";
+    return "<loaded-skills>\n</loaded-skills>";
   }
 
-  const lines = ["<loaded_skills>"];
+  const lines = ["<loaded-skills>"];
   for (const skill of skills) {
     const skillDir = workspaceSkillDir(skill.name);
     lines.push(
@@ -194,17 +196,19 @@ function formatLoadedSkillsForPrompt(skills: Skill[]): string {
     lines.push(skill.body);
     lines.push("  </skill>");
   }
-  lines.push("</loaded_skills>");
+  lines.push("</loaded-skills>");
   return lines.join("\n");
 }
 
-function formatProviderCatalogForPrompt(): string {
+function formatProviderCatalogForPrompt(): string | null {
   const providers = getPluginProviders().map((plugin) => plugin.manifest);
   if (providers.length === 0) {
-    return "- none";
+    return null;
   }
 
-  const lines: string[] = [];
+  const lines = [
+    "Config keys and default targets per provider; use after a skill is loaded.",
+  ];
   for (const provider of providers) {
     lines.push(`- provider: ${escapeXml(provider.name)}`);
     lines.push(
@@ -227,57 +231,225 @@ function formatProviderCatalogForPrompt(): string {
   return lines.join("\n");
 }
 
-function baseSystemPrompt(): string {
-  return [
-    "You are a Slack-based helper assistant.",
-    "Identity, tone, and domain defaults are defined in the personality block.",
-    "",
-    "- Be concise, practical, and specific.",
-    "- Prefer actionable next steps over generic explanations.",
-    "- When the user gives a clear task, execute it immediately in this turn.",
-    "- Do not ask for permission to proceed when the request is already clear.",
-    "- Keep user-visible progress communication concise and useful.",
-    "- In thread follow-ups, answer using prior thread context directly; do not repeat unresolved clarifying questions unless the user asks to refine.",
-    "- If the user asks what you just said or means by the previous answer, summarize your prior assistant reply plainly.",
-    "- Never ask the user to re-tag or re-invoke for a clear task; continue execution in this turn.",
-    "- Never claim you cannot access tools in this turn. If prior results are empty, run tools now.",
-    "- If critical input is missing and cannot be discovered with tools, ask one direct clarifying question.",
-    "- Always gather evidence from available sources (tools or skills) before answering factual questions.",
-    "- When a loaded skill exposes MCP capabilities, those tools are registered as callable tools. Call them directly by name.",
-    "- Use `searchTools` only when you need to rediscover or filter active MCP tools.",
-    "- Never guess. If you cannot verify with available sources, say it is unverified.",
-    "- Never claim a lookup succeeded unless a tool result supports it.",
-    "- Do not give up when unsure how to do something; find a viable path, gather evidence, and provide the best actionable way forward.",
-    "- When active skills are present, follow their instructions before default behavior.",
-  ].join("\n");
-}
-
-function formatReferenceFilesSection(): string[] {
+function formatReferenceFilesLines(): string[] | null {
   const files = listReferenceFiles();
   if (files.length === 0) {
-    return [];
+    return null;
   }
 
-  const fileNames = files.map((filePath) => {
+  return files.map((filePath) => {
     const name = path.basename(filePath);
     return `- ${escapeXml(name)} (${escapeXml(`${SANDBOX_DATA_ROOT}/${name}`)})`;
   });
+}
 
+function formatArtifactsLines(
+  artifactState: ThreadArtifactsState | undefined,
+): string[] | null {
+  if (!artifactState) return null;
+  const lines: string[] = [];
+  if (artifactState.lastCanvasId) {
+    lines.push(`- last_canvas_id: ${escapeXml(artifactState.lastCanvasId)}`);
+  }
+  if (artifactState.lastCanvasUrl) {
+    lines.push(`- last_canvas_url: ${escapeXml(artifactState.lastCanvasUrl)}`);
+  }
+  if (artifactState.recentCanvases && artifactState.recentCanvases.length > 0) {
+    lines.push("- recent_canvases:");
+    for (const canvas of artifactState.recentCanvases) {
+      lines.push(`  - id: ${escapeXml(canvas.id)}`);
+      if (canvas.title) lines.push(`    title: ${escapeXml(canvas.title)}`);
+      if (canvas.url) lines.push(`    url: ${escapeXml(canvas.url)}`);
+      if (canvas.createdAt) {
+        lines.push(`    created_at: ${escapeXml(canvas.createdAt)}`);
+      }
+    }
+  }
+  if (artifactState.lastListId) {
+    lines.push(`- last_list_id: ${escapeXml(artifactState.lastListId)}`);
+  }
+  if (artifactState.lastListUrl) {
+    lines.push(`- last_list_url: ${escapeXml(artifactState.lastListUrl)}`);
+  }
+  return lines.length > 0 ? lines : null;
+}
+
+function formatConfigurationLines(
+  configuration: Record<string, unknown> | undefined,
+): string[] | null {
+  const keys = Object.keys(configuration ?? {}).sort((a, b) =>
+    a.localeCompare(b),
+  );
+  if (keys.length === 0) return null;
+  return keys.map(
+    (key) =>
+      `- ${escapeXml(key)}: ${formatConfigurationValue(configuration?.[key])}`,
+  );
+}
+
+function formatThreadParticipantsLines(
+  participants:
+    | Array<{ userId?: string; userName?: string; fullName?: string }>
+    | undefined,
+): string[] | null {
+  if (!participants || participants.length === 0) return null;
+  return participants.map((p) => {
+    const parts: string[] = [];
+    if (p.userId) {
+      parts.push(`user_id: ${escapeXml(p.userId)}`);
+      parts.push(`slack_mention: <@${p.userId}>`);
+    }
+    if (p.userName) parts.push(`user_name: ${escapeXml(p.userName)}`);
+    if (p.fullName) parts.push(`full_name: ${escapeXml(p.fullName)}`);
+    return `- ${parts.join(", ")}`;
+  });
+}
+
+const HEADER =
+  "You are a Slack-based helper assistant. The behavior and output blocks below are authoritative; the personality block sets voice only.";
+
+const BEHAVIOR_RULES = [
+  "- Load the best-matching skill before applying skill-specific behavior; don't load multiple up front; don't claim a skill was used unless it is in <loaded-skills> or loadSkill succeeded this turn.",
+  "- After loadSkill, resolve referenced paths under skill_dir, and call any MCP tools the skill registers by name; use searchTools only to rediscover registered tools.",
+  "- Gather evidence with tools or skills before answering factual questions; say it is unverified rather than guess.",
+  "- Execute clear tasks this turn; never ask the user to re-tag or re-invoke; never claim tools are unavailable.",
+  "- In thread follow-ups, answer from prior thread context; do not repeat resolved clarifying questions.",
+  "- If the user asks what you just said, summarize your prior reply plainly.",
+  "- Ask one direct clarifying question only when critical input cannot be discovered with tools.",
+  "- Never narrate progress, prerequisite checks, or 'let me check'; never use reactions as progress signals — assistant status covers in-progress UX.",
+  "- Prefer a single result-focused reply; send interim replies only when blocked or waiting on user input.",
+  "- Do not claim an attachment, canvas, or channel post succeeded unless the tool returned success this turn; when it did, include any link the tool returned.",
+  "- Run authenticated provider commands directly; the runtime handles auth pause/resume. Resolve target defaults first, and do not manage auth yourself.",
+  "- jr-rpc config get|set|unset|list is a built-in bash command for conversation-scoped config keys from <providers> or active skill metadata.",
+  "- For explicit channel-post or emoji-reaction requests, skip the text reply.",
+];
+
+function buildOutputSection(): string {
+  const openTag = `<output format="slack-mrkdwn" max_inline_chars="${slackOutputPolicy.maxInlineChars}" max_inline_lines="${slackOutputPolicy.maxInlineLines}">`;
   return [
-    renderTag(
-      "reference-files",
-      [
+    openTag,
+    "- Use Slack-friendly mrkdwn, not full CommonMark; use bolded section labels instead of markdown headings (# / ## / ###).",
+    "- Use bullets and short code blocks when helpful; do not use markdown tables (| column |) or markdown links ([text](url)); prefer plain URLs.",
+    "- Keep responses brief and scannable; for depth, lead with a concise summary and then provide fuller detail.",
+    "- Prefer a single compact thread reply when the answer fits within the inline budget above.",
+    "- When a research or document-style answer would benefit from continuation, multiple sections, or future reference value, create a Slack canvas and keep the thread reply to a short summary plus the canvas link.",
+    "- End every turn with a final user-facing markdown response.",
+    "</output>",
+  ].join("\n");
+}
+
+function buildContextSection(params: {
+  assistant?: { userName?: string; userId?: string };
+  requester?: { userName?: string; fullName?: string; userId?: string };
+  artifactState?: ThreadArtifactsState;
+  configuration?: Record<string, unknown>;
+  threadParticipants?: Array<{
+    userId?: string;
+    userName?: string;
+    fullName?: string;
+  }>;
+  invocation: SkillInvocation | null;
+  turnState?: "fresh" | "resumed";
+}): string {
+  const blocks: string[][] = [];
+
+  if (JUNIOR_WORLD) {
+    blocks.push(renderTag("world", [JUNIOR_WORLD.trim()]));
+  }
+
+  const referenceLines = formatReferenceFilesLines();
+  if (referenceLines) {
+    blocks.push(
+      renderTag("reference-files", [
         "Additional reference documents available in the sandbox. Read them with `readFile` when relevant.",
-        ...fileNames,
-      ].join("\n"),
-    ),
-  ];
+        ...referenceLines,
+      ]),
+    );
+  }
+
+  const runtimeVersion = getRuntimeMetadata().version;
+  if (runtimeVersion) {
+    blocks.push([`<runtime version="${escapeXml(runtimeVersion)}" />`]);
+  }
+
+  blocks.push(
+    renderIdentityBlock("assistant", {
+      user_name: params.assistant?.userName ?? botConfig.userName,
+      user_id: params.assistant?.userId,
+    }),
+  );
+
+  blocks.push(
+    renderIdentityBlock("requester", {
+      full_name: params.requester?.fullName,
+      user_name: params.requester?.userName,
+      user_id: params.requester?.userId,
+    }),
+  );
+
+  const participantLines = formatThreadParticipantsLines(
+    params.threadParticipants,
+  );
+  if (participantLines) {
+    blocks.push(
+      renderTag("thread-participants", [
+        "Known participants. When you mention one of these people, use the provided `<@USERID>` token exactly; do not write a bare `@name`.",
+        ...participantLines,
+      ]),
+    );
+  }
+
+  const artifactLines = formatArtifactsLines(params.artifactState);
+  if (artifactLines) {
+    blocks.push(renderTag("artifacts", artifactLines));
+  }
+
+  const configLines = formatConfigurationLines(params.configuration);
+  if (configLines) {
+    blocks.push(
+      renderTag("configuration", [
+        "Conversation-scoped defaults. Follow explicit user input when it conflicts.",
+        ...configLines,
+      ]),
+    );
+  }
+
+  if (params.turnState === "resumed") {
+    blocks.push([
+      "<turn-state>resumed</turn-state>",
+      "This turn continues from a prior checkpoint (timeout-resume or auth pause). Prior tool results and assistant messages are already in the conversation history.",
+    ]);
+  }
+
+  if (params.invocation) {
+    blocks.push([
+      `<explicit-skill-trigger>/${escapeXml(params.invocation.skillName)}</explicit-skill-trigger>`,
+    ]);
+  }
+
+  const body = blocks.map((block) => block.join("\n")).join("\n\n");
+  return renderTagBlock("context", body);
+}
+
+function buildCapabilitiesSection(params: {
+  availableSkills: SkillMetadata[];
+  activeSkills: Skill[];
+}): string {
+  const blocks: string[] = [];
+  blocks.push(formatAvailableSkillsForPrompt(params.availableSkills));
+  blocks.push(formatLoadedSkillsForPrompt(params.activeSkills));
+
+  const providerCatalog = formatProviderCatalogForPrompt();
+  if (providerCatalog) {
+    blocks.push(renderTagBlock("providers", providerCatalog));
+  }
+
+  return renderTagBlock("capabilities", blocks.join("\n\n"));
 }
 
 export function buildSystemPrompt(params: {
   availableSkills: SkillMetadata[];
   activeSkills: Skill[];
-  activeTools?: ExposedToolSummary[];
   invocation: SkillInvocation | null;
   assistant?: {
     userName?: string;
@@ -290,306 +462,48 @@ export function buildSystemPrompt(params: {
   };
   artifactState?: ThreadArtifactsState;
   configuration?: Record<string, unknown>;
-  relevantConfigurationKeys?: string[];
-  runtimeMetadata?: RuntimeMetadata;
   /**
    * Known thread participants: array of { userId, userName, fullName }.
-   * Injected into <identity-context> so the LLM can write correct <@USERID> mentions
-   * for people already in the conversation without a separate API call.
+   * Injected so the LLM can write correct <@USERID> mentions for people
+   * already in the conversation without a separate API call.
    */
   threadParticipants?: Array<{
     userId?: string;
     userName?: string;
     fullName?: string;
   }>;
+  /**
+   * Whether this turn is a fresh prompt or a resume from a prior checkpoint
+   * (OAuth pause or timeout-resume). Surfaced in <context> so the model knows
+   * it is continuing rather than starting fresh.
+   */
+  turnState?: "fresh" | "resumed";
 }): string {
-  const {
-    availableSkills,
-    activeSkills,
-    activeTools,
-    invocation,
-    requester,
-    assistant,
-    artifactState,
-    configuration,
-    relevantConfigurationKeys,
-    runtimeMetadata,
-    threadParticipants,
-  } = params;
   // Core harness contract:
   // - See specs/harness-agent-spec.md for the canonical agent-loop and terminal-output spec.
-  // - Keep this prompt generic and platform-level (tone, evidence, output constraints).
-  // - Do not encode per-skill behavior here.
-  // - Skill-specific instructions belong in skills/*/SKILL.md and are injected via active skill context.
-  // - Delivery/runtime policies (for example forced attachments) belong in output/runtime code paths.
-
-  const assistantSection = renderIdentityBlock("assistant", {
-    user_name: assistant?.userName ?? botConfig.userName,
-    user_id: assistant?.userId,
-  });
-
-  const requesterSection = renderIdentityBlock("requester", {
-    full_name: requester?.fullName,
-    user_name: requester?.userName,
-    user_id: requester?.userId,
-  });
-
-  const availableSkillsSection = [
-    "The following skills provide specialized instructions for specific tasks.",
-    "Call `loadSkill` when the task matches a skill description.",
-    "When a skill references a relative path, resolve it against `skill_dir` and use that path with `bash`.",
-    "",
-    formatAvailableSkillsForPrompt(availableSkills),
-  ].join("\n");
-
-  const activeSkillsSection = [
-    "Loaded skills for this turn:",
-    formatLoadedSkillsForPrompt(activeSkills),
-  ].join("\n");
-  const activeToolNames = (activeTools ?? []).map((tool) => tool.tool_name);
-  const activeToolsSection =
-    activeToolNames.length > 0
-      ? `Active MCP tools registered for this turn: ${activeToolNames.join(", ")}. Call them directly by name.`
-      : "";
-
-  const configurationKeys = Object.keys(configuration ?? {}).sort((a, b) =>
-    a.localeCompare(b),
-  );
-  const relevantConfigSet = new Set(
-    (relevantConfigurationKeys ?? []).filter((key) =>
-      Object.prototype.hasOwnProperty.call(configuration ?? {}, key),
-    ),
-  );
-  const relevantConfigLines = configurationKeys
-    .filter((key) => relevantConfigSet.has(key))
-    .map(
-      (key) =>
-        `  - ${escapeXml(key)}: ${formatConfigurationValue(configuration?.[key])}`,
-    );
-  const otherConfigLines = configurationKeys
-    .filter((key) => !relevantConfigSet.has(key))
-    .map(
-      (key) =>
-        `  - ${escapeXml(key)}: ${formatConfigurationValue(configuration?.[key])}`,
-    );
-
-  const configurationSection = [
-    "Use these conversation-scoped defaults when the user has not provided explicit values in this turn.",
-    "If explicit user input conflicts with configuration, follow explicit user input.",
-    configurationKeys.length === 0
-      ? "- none"
-      : [
-          ...(relevantConfigLines.length > 0
-            ? ["- relevant_for_active_skills:", ...relevantConfigLines]
-            : []),
-          ...(otherConfigLines.length > 0
-            ? ["- other_available_keys:", ...otherConfigLines]
-            : []),
-        ].join("\n"),
-  ].join("\n");
+  // - Keep this prompt generic and platform-level (behavior, output contract, capability disclosure).
+  // - Platform-level behavior rules must live here, never in SOUL.md (pluggable per deployment).
+  // - Skill-specific instructions belong in skills/*/SKILL.md and are injected via <loaded-skills>.
+  // - Pi-agent discloses tool schemas via the provider-native tool array; do not re-list them here.
 
   const sections = [
-    baseSystemPrompt(),
-    renderTag(
-      "personality",
-      [
-        "Always follow the personality guidance for tone/style unless safety or policy constraints require otherwise.",
-        "",
-        JUNIOR_PERSONALITY.trim(),
-      ].join("\n"),
-    ),
-    ...(JUNIOR_WORLD
-      ? [
-          renderTag(
-            "world",
-            [
-              "Use this as the assistant's operational/domain context.",
-              "",
-              JUNIOR_WORLD.trim(),
-            ].join("\n"),
-          ),
-        ]
-      : []),
-    ...formatReferenceFilesSection(),
-    renderTag(
-      "identity-context",
-      [
-        "Use these blocks as authoritative metadata for identity questions.",
-        assistantSection,
-        requesterSection,
-        ...(threadParticipants && threadParticipants.length > 0
-          ? [
-              renderTag(
-                "thread-participants",
-                [
-                  "Known participants in this thread. When you mention one of these people, use the provided Slack mention token exactly as `<@USERID>` and do not write a bare `@name` form.",
-                  ...threadParticipants.map((p) => {
-                    const parts: string[] = [];
-                    if (p.userId) {
-                      parts.push(`user_id: ${escapeXml(p.userId)}`);
-                      parts.push(`slack_mention: <@${p.userId}>`);
-                    }
-                    if (p.userName)
-                      parts.push(`user_name: ${escapeXml(p.userName)}`);
-                    if (p.fullName)
-                      parts.push(`full_name: ${escapeXml(p.fullName)}`);
-                    return `- ${parts.join(", ")}`;
-                  }),
-                ].join("\n"),
-              ),
-            ]
-          : []),
-      ].join("\n"),
-    ),
-    renderTag(
-      "artifact-context",
-      [
-        "Use this thread-scoped memory for follow-up updates to existing Slack artifacts.",
-        artifactState
-          ? [
-              artifactState.lastCanvasId
-                ? `- last_canvas_id: ${escapeXml(artifactState.lastCanvasId)}`
-                : "- last_canvas_id: none",
-              artifactState.lastCanvasUrl
-                ? `- last_canvas_url: ${escapeXml(artifactState.lastCanvasUrl)}`
-                : "- last_canvas_url: none",
-              artifactState.recentCanvases &&
-              artifactState.recentCanvases.length > 0
-                ? [
-                    "- recent_canvases:",
-                    ...artifactState.recentCanvases.map((canvas) =>
-                      [
-                        `  - id: ${escapeXml(canvas.id)}`,
-                        canvas.title
-                          ? `    title: ${escapeXml(canvas.title)}`
-                          : "    title: [unknown]",
-                        canvas.url
-                          ? `    url: ${escapeXml(canvas.url)}`
-                          : "    url: [unknown]",
-                        canvas.createdAt
-                          ? `    created_at: ${escapeXml(canvas.createdAt)}`
-                          : "    created_at: [unknown]",
-                      ].join("\n"),
-                    ),
-                  ].join("\n")
-                : "- recent_canvases: none",
-              artifactState.lastListId
-                ? `- last_list_id: ${escapeXml(artifactState.lastListId)}`
-                : "- last_list_id: none",
-              artifactState.lastListUrl
-                ? `- last_list_url: ${escapeXml(artifactState.lastListUrl)}`
-                : "- last_list_url: none",
-            ].join("\n")
-          : "- none",
-      ].join("\n"),
-    ),
-    renderTag("configuration-context", configurationSection),
-    renderTag(
-      "runtime-metadata",
-      [
-        "Use this for runtime version questions about the deployed assistant.",
-        `- version: ${escapeXml(runtimeMetadata?.version ?? "unknown")}`,
-      ].join("\n"),
-    ),
-    renderTag(
-      "provider-config",
-      [
-        "Use this catalog to map already-chosen provider work to valid config keys and provider defaults.",
-        "Do not use this catalog by itself to decide which domain skill matches an operational task.",
-        "When user intent is to set a provider default, choose a config key from this catalog and use jr-rpc config set.",
-        "The `jr-rpc` config command is a built-in bash custom command when conversation config is available; do not claim it is missing just because no `jr-rpc` skill is loaded.",
-        formatProviderCatalogForPrompt(),
-      ].join("\n"),
-    ),
-    renderTag(
-      "skill-routing",
-      [
-        "- Choose the skill that matches the requested operation, not incidental nouns, product names, organization names, or channel context.",
-        "- When multiple skills seem adjacent, prefer the one whose description matches the user's requested action most directly.",
-        "- If the task needs evidence from a specialized external system or workflow, load the matching skill before drawing conclusions.",
-        "- The provider-config catalog is for exact config keys and provider defaults after skill selection. It is not a shortcut for choosing a domain.",
-        "- Never start provider auth speculatively. First load the skill that owns the operation, then let runtime-managed credential injection handle authenticated provider commands for that skill.",
-      ].join("\n"),
-    ),
-    renderTag(
-      "tool-usage",
-      [
-        "- For factual or external questions, run tools/skills first, then answer from evidence.",
-        "- Use tool descriptions as the source of truth for when each tool should or should not be called.",
-        "- When using CLI tools through `bash`, prefer deterministic non-interactive flags and avoid commands that wait for prompts or editors.",
-        "- Keep routine setup and research steps silent in user-facing replies. Do not narrate duplicate checks, credential issuance, file writes, or similar internal progress unless the result is user-relevant.",
-        "- If a routine prerequisite check finds nothing notable, omit it entirely from the final reply and report only the user-relevant outcome.",
-        "- Prefer a single result-focused reply after tool work completes. Only send an interim reply when you need user input or have a concrete blocking problem to report.",
-        "- For external/factual research requests that require tools, do not send any preliminary conclusion, 'let me check', or progress narration before the evidence-gathering work is done. Use assistant status for in-progress work and make the first visible reply the researched answer.",
-        "- For evidence-gathering tasks, never state a factual conclusion before you have actually gathered and checked the sources.",
-        "- When the user provides multiple sources, synthesize them explicitly as one combined answer instead of anchoring the reply on a single page or API call.",
-        "- When the user provides explicit URLs or named sources, briefly anchor the answer to those provided sources (for example, 'Across the provided Slack docs...') so the summary reads as researched rather than generic memory.",
-        "- Do not include internal process chatter such as 'let me find', 'fetching now', 'good, I have sources', 'trying smaller limits', or 'I now have sufficient context' in the final user-facing reply.",
-        "- Never claim a screenshot/file is attached unless `attachFile` succeeded in this turn.",
-        "- If `attachFile` fails, explain the failure and do not say the file was shared.",
-        "- When you create or update a Slack artifact in this turn (for example a canvas, list, posted message, or attached file), mention it explicitly in the final reply and include its link when the tool returned one.",
-        "- For explicit in-channel post requests, prefer no thread text reply after a successful channel post. A reaction-only acknowledgment is acceptable when useful.",
-        "- When the user explicitly asks for an emoji reaction instead of text, react and skip the text reply.",
-        "- After the matching plugin-owned skill is loaded, authenticated bash commands for that skill get provider credentials injected automatically for the current turn.",
-        "- Resolve repo/project/org defaults before authenticated provider commands so the runtime can narrow injected credentials correctly.",
-        "- If no loaded skill clearly owns the authenticated command, load the matching skill first instead of guessing from the provider catalog.",
-        "- If provider authorization is required, the runtime sends the private authorization link itself and resumes the paused turn after authorization.",
-        "- Do not try to manage provider auth directly. Run the real provider command and let the runtime handle authorization, reconnect, and resume behavior.",
-        "- Provider-targeted commands may need `--target <value>` or a provider-specific configured default target key when the provider catalog shows one.",
-        "- To persist or read conversation defaults, choose a config key from the provider catalog or active skill metadata and run `jr-rpc config get|set|unset|list ...` as a bash command.",
-        "- `jr-rpc` config commands are built into the bash runtime for conversation-scoped config work; they do not require a separate helper binary in the sandbox.",
-        "- When your work is complete, provide the exact user-facing markdown response.",
-        "- Do not use reaction-based progress signals; Assistants API status already covers in-progress UX.",
-        "- Never call side-effecting tools when the user only asked for analysis or options.",
-        "- When the user asks for their conversation ID, trace ID, or a reference for Sentry lookup, use the IDs from `<session-context>` and `<turn-context>` in the user turn.",
-      ].join("\n"),
-    ),
-    renderTag(
-      "skills",
-      [
-        "- Explicit skill triggers may appear as `/skillname`.",
-        "- If explicitly invoked skill instructions are already present in <loaded_skills>, apply them immediately.",
-        "- If an explicitly invoked skill is present in <loaded_skills>, never say the skill is unavailable, missing, or unsupported in this environment.",
-        "- Otherwise, for an explicitly invoked skill, call `loadSkill` for that exact skill before applying skill-specific behavior.",
-        "- For requests without an explicit trigger where a skill clearly matches, call `loadSkill` before applying skill-specific behavior.",
-        "- When multiple skills appear relevant, prefer the skill whose description best matches the requested action rather than incidental domain nouns in the prompt.",
-        "- For explicit config tasks, you may load the helper skill that owns config commands, but do not use helper skills to choose the provider for unrelated operational work.",
-        "- Do not claim to have used a skill unless it is present in <loaded_skills> or `loadSkill` succeeded in this turn.",
-        "- Never apply skill-specific behavior unless the skill is present in <loaded_skills> or `loadSkill` succeeded in this turn.",
-        "- Load only the best matching skill first; do not load multiple skills upfront.",
-        "- After `loadSkill`, use `skill_dir` as the root for any referenced files you read via `bash`.",
-        "- If a loaded skill exposes MCP tools, they are registered as callable tools after `loadSkill` returns. Call them directly by name (for example `mcp__provider__tool_name`).",
-        "- If no skill is a clear fit, continue with normal tool usage.",
-      ].join("\n"),
-    ),
-    renderTag(
-      "output-contract",
-      [
-        "Always produce output that follows this contract:",
-        `<output format="slack-mrkdwn" max_inline_chars="${slackOutputPolicy.maxInlineChars}" max_inline_lines="${slackOutputPolicy.maxInlineLines}">`,
-        "- Use Slack-friendly markdown, not full CommonMark. Prefer bold section labels over markdown headings, and use bullets and short code blocks when helpful.",
-        "- Keep normal responses brief and scannable.",
-        "- If depth is needed, start with a concise summary and then provide fuller detail.",
-        "- Prefer a single compact thread reply when the full answer comfortably fits within this inline budget.",
-        "- When canvas creation is available and a research or document-style answer would likely need continuation, multiple sections, or future reference value, create a Slack canvas and keep the thread reply to a short summary plus the canvas link.",
-        "- Typical canvas-first cases include long-form research summaries, timelines, bios or profiles, structured notes, plans, comparisons, and other reusable reference documents.",
-        "- Do not create a canvas for short factual answers that fit cleanly in one normal thread reply.",
-        "- For tool-heavy research, discovery, or source-checking requests, do not send an initial acknowledgment. Start the visible reply only once you can present the actual answer.",
-        "- Do not narrate tool execution or repeated status updates in the visible reply.",
-        "- Avoid tables and markdown links like `[label](url)` unless explicitly requested. Prefer plain URLs or Slack-native entities when exact rendering matters.",
-        "- End every turn with a final user-facing markdown response.",
-        "</output>",
-      ].join("\n"),
-    ),
-    availableSkillsSection,
-    activeSkillsSection,
-    ...(activeToolsSection ? [activeToolsSection] : []),
-    renderTag(
-      "invocation-context",
-      invocation
-        ? `Explicit skill trigger detected: /${invocation.skillName}`
-        : "No explicit skill trigger detected.",
-    ),
+    HEADER,
+    renderTagBlock("personality", JUNIOR_PERSONALITY.trim()),
+    buildContextSection({
+      assistant: params.assistant,
+      requester: params.requester,
+      artifactState: params.artifactState,
+      configuration: params.configuration,
+      threadParticipants: params.threadParticipants,
+      invocation: params.invocation,
+      turnState: params.turnState,
+    }),
+    buildCapabilitiesSection({
+      availableSkills: params.availableSkills,
+      activeSkills: params.activeSkills,
+    }),
+    renderTagBlock("behavior", BEHAVIOR_RULES.join("\n")),
+    buildOutputSection(),
   ];
 
   return sections.join("\n\n");

--- a/packages/junior/src/chat/prompt.ts
+++ b/packages/junior/src/chat/prompt.ts
@@ -320,6 +320,7 @@ const BEHAVIOR_RULES = [
   "- Prefer a single result-focused reply; send interim replies only when blocked or waiting on user input.",
   "- Do not claim an attachment, canvas, or channel post succeeded unless the tool returned success this turn; when it did, include any link the tool returned.",
   "- Run authenticated provider commands directly; the runtime handles auth pause/resume. Resolve target defaults first, and do not manage auth yourself.",
+  "- After the runtime resumes a paused turn (auth completion, timeout-resume), post a brief continuation notice (e.g., 'Connected — continuing.') and then the resumed answer as a separate message.",
   "- jr-rpc config get|set|unset|list is a built-in bash command for conversation-scoped config keys from <providers> or active skill metadata.",
   "- For explicit channel-post or emoji-reaction requests, skip the text reply.",
 ];
@@ -417,7 +418,7 @@ function buildContextSection(params: {
   if (params.turnState === "resumed") {
     blocks.push([
       "<turn-state>resumed</turn-state>",
-      "This turn continues from a prior checkpoint (timeout-resume or auth pause). Prior tool results and assistant messages are already in the conversation history.",
+      "This turn continues from a prior checkpoint. Prior tool results and assistant messages are already in the conversation history.",
     ]);
   }
 

--- a/packages/junior/src/chat/respond-helpers.ts
+++ b/packages/junior/src/chat/respond-helpers.ts
@@ -331,23 +331,6 @@ export function upsertActiveSkill(activeSkills: Skill[], next: Skill): void {
   activeSkills.push(next);
 }
 
-/** Collect configuration keys referenced by active and invoked skills. */
-export function collectRelevantConfigurationKeys(
-  activeSkills: Array<{ usesConfig?: string[] }>,
-  explicitSkill?: { usesConfig?: string[] } | null,
-): string[] {
-  const keys = new Set<string>();
-  for (const skill of [
-    ...activeSkills,
-    ...(explicitSkill ? [explicitSkill] : []),
-  ]) {
-    for (const key of skill.usesConfig ?? []) {
-      keys.add(key);
-    }
-  }
-  return [...keys].sort((a, b) => a.localeCompare(b));
-}
-
 /** Remove trailing assistant messages before checkpointing. */
 export function trimTrailingAssistantMessages(
   messages: AgentMessage[],

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -53,7 +53,6 @@ import {
   type SandboxExecutor,
 } from "@/chat/sandbox/sandbox";
 import type { SandboxWorkspace } from "@/chat/sandbox/workspace";
-import { getRuntimeMetadata } from "@/chat/config";
 import { shouldEmitDevAgentTrace } from "@/chat/runtime/dev-agent-trace";
 import type { AssistantStatusSpec } from "@/chat/slack/assistant-thread/status";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
@@ -62,7 +61,6 @@ import { mergeArtifactsState } from "@/chat/runtime/thread-state";
 import { RetryableTurnError, isRetryableTurnError } from "@/chat/runtime/turn";
 import {
   buildUserTurnText,
-  collectRelevantConfigurationKeys,
   encodeNonImageAttachmentForPrompt,
   getSessionIdentifiers,
   isAssistantMessage,
@@ -759,24 +757,16 @@ export async function generateAssistantReply(
     syncResumeState();
 
     // ── System prompt ────────────────────────────────────────────────
-    const activeToolSummaries = turnMcpToolManager
-      .getActiveToolCatalog(activeSkills)
-      .map(toExposedToolSummary);
     baseInstructions = buildSystemPrompt({
       availableSkills,
       activeSkills,
-      activeTools: activeToolSummaries,
       invocation: skillInvocation,
       assistant: context.assistant,
       requester: context.requester,
       artifactState: context.artifactState,
       configuration: configurationValues,
-      relevantConfigurationKeys: collectRelevantConfigurationKeys(
-        activeSkills,
-        invokedSkill,
-      ),
-      runtimeMetadata: getRuntimeMetadata(),
       threadParticipants: context.threadParticipants,
+      turnState: resumedFromCheckpoint ? "resumed" : "fresh",
     });
 
     const inputMessagesAttribute = serializeGenAiAttribute([


### PR DESCRIPTION
Collapse the harness system prompt from ~17 XML-tagged sections (~596 lines) to five top-level blocks grouped by purpose: `<personality>` / `<context>` / `<capabilities>` / `<behavior>` / `<output>`. Rendered prompt for a realistic fixture drops from ~250 lines to ~70.

The prompt had accumulated heavy redundancy — "don't narrate tool execution" appeared in both `<tool-usage>` and `<output-contract>`; "load the matching skill first" appeared in `<skills>`, `<skill-routing>`, `<tool-usage>`, and `<provider-config>`; the 20-bullet `baseSystemPrompt()` preamble re-stated rules that appeared again inside tagged sections. Overlapping rules made the prompt hard to hold in your head and risky to change, because any "redundant" bullet might have been load-bearing somewhere.

### What each block owns

- `<personality>` — voice only. SOUL.md is pluggable per deployment, so platform behavior rules must live in the harness prompt, not in the persona layer.
- `<context>` — every contextual fact, nested by scope: `<world>` (WORLD.md, install-scoped), `<reference-files>`, `<runtime version=…>`, `<assistant>` / `<requester>` / `<thread-participants>`, `<artifacts>`, `<configuration>` (flat alpha-sorted), `<turn-state>resumed</turn-state>` when continuing from a checkpoint, `<explicit-skill-trigger>` when a `/skillname` invocation was parsed. Empty fields and empty subsections are omitted entirely (no more `- none` sentinels).
- `<capabilities>` — `<available-skills>`, `<loaded-skills>`, `<providers>`. Tool schemas are already disclosed via the provider-native tool array (confirmed by reading pi-agent-core), so the prior "Active MCP tools registered for this turn: …" line was pure duplication and has been dropped.
- `<behavior>` — 14 imperative bullets merging `baseSystemPrompt` + `<tool-usage>` + `<skill-routing>` + `<skills>` (down from ~65 scattered conditional-prose bullets across those sections).
- `<output>` — 6 bullets (down from 13) focused on Slack mrkdwn: bold section labels not markdown headings, plain URLs not `[text](url)`, no tables, canvas-for-reusable-docs, inline budget.

### Non-obvious changes to call out in review

- **New `turnState: "fresh" | "resumed"` param** on `buildSystemPrompt`. `respond.ts` passes `resumed` when continuing from a checkpoint so the model has an explicit continuation signal instead of inferring from history. The paired `<behavior>` rule (post a brief continuation notice, then the resumed answer) is what rescued two OAuth eval scenarios that regressed after the initial simplification (see Evaluation).
- **SOUL.md / WORLD.md are treated as deployer-owned content.** Every platform behavior rule lives in the harness prompt and fires even if a deployer ships a minimal persona file. This invariant matters if anyone considers pushing platform rules down into persona content later.
- **Provider-native tool disclosure.** Pi-agent-core passes the `tools` array to Anthropic as native tool schemas, so the prompt does not need to re-list tool names. The dropped "Active MCP tools registered for this turn: …" line was confirmed redundant by reading `node_modules/@mariozechner/pi-agent-core/dist/agent-loop.js`.

### Alternatives considered

- **Lazy skill bodies** (model calls `readFile` on `skill_dir/SKILL.md` instead of inlining loaded skills). Rejected: turns are resumable across OAuth pauses and timeouts, so loaded skills must persist across resumes. Forcing an extra tool roundtrip on every resumed turn hurts latency and contradicts the "never apply skill-specific behavior without `loadSkill` success" rule. If skill-body size becomes a real bottleneck, the right follow-up is compacting `SKILL.md` bodies themselves, not lazy loading.
- **Conservative consolidation** (deduplicate but keep every rule's semantics). Rejected in favor of a bold cutover with eval regression coverage. The old prompt had grown enough that preserving every bullet would re-create the same redundancy it started with.
- **Moving thread participants / artifacts / config to lazy tool calls.** Tempting, but it converts a structural fact ("who's in the room") into an I/O dependency. Out of scope for this pass.

### Evaluation

- Typecheck and unit tests green. (One pre-existing unrelated `resolveGatewayModel` mock failure in `tests/unit/web/image-generate.test.ts`; fails identically on `main`.)
- Core evals: **28/29 passing**. The remaining failure is the `OAuth reconnect` scenario at 0.5, which also scores 0.5 on pre-simplification `main` — pre-existing. The branch is net ahead of `main` on OAuth eval coverage (2/3 vs 1/3 passing); commit 3 rescues the two OAuth scenarios that regressed after the initial simplification.

### Related

Parallel findings from this refactor are filed as issues on `getsentry/skills` (#120, #121, #122), with follow-up reference additions in that repo's `prompt-optimizer` skill.