### PR TITLE
chore: gitignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 agents.lock
+.claude/scheduled_tasks.lock
 .next
 node_modules
 .env


### PR DESCRIPTION
Add `.claude/scheduled_tasks.lock` to `.gitignore`.

Claude Code writes this lock file into `.claude/` whenever it runs scheduled background tasks. It is a per-runtime artifact, not repository content, and anyone running Claude Code in this repo ends up with an untracked file on every `git status`.

`.claude/settings.local.json` is already covered by most users' global gitignore; `scheduled_tasks.lock` is the only one that routinely leaks into `git status`, so this keeps the change narrow.