### PR TITLE
fix(chat): Improving tool use grounding

### DIFF
--- a/packages/junior-evals/evals/behavior-harness.ts
+++ b/packages/junior-evals/evals/behavior-harness.ts
@@ -110,6 +110,7 @@ interface EvalReplyResultFixture {
   stream_text?: string;
   text: string;
   tool_calls?: string[];
+  tool_invocations?: EvalToolInvocation[];
   tool_error_count?: number;
   tool_result_count?: number;
   used_primary_text?: boolean;
@@ -156,6 +157,7 @@ export interface EvalResult {
     timestamp: string;
   }>;
   slackAdapter: FakeSlackAdapter;
+  toolInvocations: EvalToolInvocation[];
 }
 
 export interface EvalAttachedFile {
@@ -175,6 +177,12 @@ export interface EvalCanvasArtifact {
   title: string;
 }
 
+export interface EvalToolInvocation {
+  tool: string;
+  bash_command?: string;
+  skill_name?: string;
+}
+
 interface EvalSlackThreadReply {
   bot_id?: string;
   text?: string;
@@ -192,6 +200,30 @@ interface QueueDelivery {
   kind: ThreadMessageKind;
   message: Message;
   thread: TestThread;
+}
+
+interface RuntimeObservations {
+  toolInvocations: EvalToolInvocation[];
+}
+
+function toEvalToolInvocation(input: {
+  toolName: string;
+  params: Record<string, unknown>;
+}): EvalToolInvocation {
+  const invocation: EvalToolInvocation = { tool: input.toolName };
+
+  if (input.toolName === "bash" && typeof input.params.command === "string") {
+    invocation.bash_command = input.params.command.trim();
+  }
+
+  if (
+    input.toolName === "loadSkill" &&
+    typeof input.params.skill_name === "string"
+  ) {
+    invocation.skill_name = input.params.skill_name.trim();
+  }
+
+  return invocation;
 }
 
 // ---------------------------------------------------------------------------
@@ -822,6 +854,7 @@ function buildRuntimeServices(
   scenario: EvalScenario,
   env: HarnessEnvironment,
   threadRecordsById: Map<string, EvalThreadRecord>,
+  observations: RuntimeObservations,
 ): JuniorRuntimeServiceOverrides {
   const replyResults = scenario.overrides?.reply_results ?? [];
   const replyTexts = scenario.overrides?.reply_texts ?? [];
@@ -876,6 +909,10 @@ function buildRuntimeServices(
             await context?.onTextDelta?.(replyResult.stream_text);
           }
           replyState.successfulCount += 1;
+          observations.toolInvocations.push(
+            ...(replyResult.tool_invocations ??
+              (replyResult.tool_calls ?? []).map((tool) => ({ tool }))),
+          );
           return {
             text: replyResult.text,
             deliveryMode: "thread",
@@ -937,6 +974,11 @@ function buildRuntimeServices(
           reply = await Promise.race([
             generateAssistantReply(text, {
               ...context,
+              onToolInvocation: (invocation) => {
+                observations.toolInvocations.push(
+                  toEvalToolInvocation(invocation),
+                );
+              },
               ...(env.configuredSkillDirs.length > 0
                 ? { skillDirs: env.configuredSkillDirs }
                 : {}),
@@ -1110,6 +1152,7 @@ function collectResults(
   threadRecordsById: Map<string, EvalThreadRecord>,
   slackAdapter: FakeSlackAdapter,
   logRecords: EmittedLogRecord[],
+  observations: RuntimeObservations,
 ): EvalResult {
   const posts = [...threadRecordsById.values()].flatMap((record) =>
     record.thread.posts.map(toEvalAssistantPost),
@@ -1124,6 +1167,7 @@ function collectResults(
     reactions,
     posts,
     slackAdapter,
+    toolInvocations: observations.toolInvocations,
   };
 }
 
@@ -1141,6 +1185,9 @@ export async function runEvalScenario(
   const slackAdapter = new FakeSlackAdapter();
   const threadRecordsById = new Map<string, EvalThreadRecord>();
   const readyQueueDeliveries: QueueDelivery[] = [];
+  const observations: RuntimeObservations = {
+    toolInvocations: [],
+  };
   const channelStateById = new Map<
     string,
     { value: Record<string, unknown> }
@@ -1176,7 +1223,12 @@ export async function runEvalScenario(
     return record;
   };
 
-  const services = buildRuntimeServices(scenario, env, threadRecordsById);
+  const services = buildRuntimeServices(
+    scenario,
+    env,
+    threadRecordsById,
+    observations,
+  );
 
   const slackRuntime = createSlackRuntime({
     getSlackAdapter: () => slackAdapter as any,
@@ -1197,7 +1249,12 @@ export async function runEvalScenario(
     await teardownHarnessEnvironment(scenario, env);
   }
 
-  return collectResults(threadRecordsById, slackAdapter, logRecords);
+  return collectResults(
+    threadRecordsById,
+    slackAdapter,
+    logRecords,
+    observations,
+  );
 }
 
 // Compile-time guards for Thread and Message fakes are in tests/fixtures/slack-harness.ts.

--- a/packages/junior-evals/evals/github/skill-workflows.eval.ts
+++ b/packages/junior-evals/evals/github/skill-workflows.eval.ts
@@ -149,6 +149,55 @@ describe("GitHub Skill Workflows", () => {
     channel_id: "C-default-repo",
     thread_ts: "17000000.default-repo",
   };
+  const defaultRepoIssueThread = {
+    id: "thread-default-repo-issue",
+    channel_id: "C-default-repo-issue",
+    thread_ts: "17000000.default-repo-issue",
+  };
+
+  slackEval(
+    "when creating an issue after repo setup, use the stored repo without inventing tool failures",
+    {
+      overrides: {
+        enable_test_credentials: true,
+        plugin_packages: ["@sentry/junior-github"],
+        reply_timeout_ms: 75_000,
+        test_credential_token: "eval-default-repo-create-token",
+        skill_dirs: ["../junior/skills"],
+      },
+      events: [
+        mention("Set the default repo to getsentry/junior for this channel.", {
+          thread: defaultRepoIssueThread,
+        }),
+        threadMessage(
+          "Create a GitHub issue for a bug where Slack follow-up replies sometimes blame missing tooling instead of showing the failed command.",
+          {
+            thread: defaultRepoIssueThread,
+            is_mention: true,
+          },
+        ),
+      ],
+      criteria: rubric({
+        contract:
+          "Stored GitHub repo context carries into a later issue-creation workflow, and tool-failure explanations stay grounded in observed command results.",
+        pass: [
+          "The assistant posts exactly two replies in order.",
+          "observed_tool_invocations includes a `loadSkill` invocation with `skill_name` set to `github-issues` before issue creation.",
+          "observed_tool_invocations includes a bash invocation that stores or uses `github.repo` as getsentry/junior.",
+          "observed_tool_invocations includes a bash invocation with `gh issue create` scoped to `--repo getsentry/junior`.",
+          "The first reply confirms default repo setup for getsentry/junior.",
+          "The second reply reports a created GitHub issue in getsentry/junior with an issue URL or issue number.",
+          "The second reply does not ask the user to restate the repository.",
+        ],
+        fail: [
+          "Do not claim that `gh`, the GitHub CLI, or `jr-rpc` is unavailable, missing, or not installed.",
+          "Do not blame issue creation on a missing tool without quoting an observed command failure.",
+          "Do not ask the user to pass --repo or provide the repo again.",
+          "Do not create or report an issue for a repository other than getsentry/junior.",
+        ],
+      }),
+    },
+  );
 
   slackEval(
     "when a default repo is set in one turn, reuse it in the next turn without asking again",

--- a/packages/junior-evals/evals/helpers.ts
+++ b/packages/junior-evals/evals/helpers.ts
@@ -66,6 +66,21 @@ const evalOutputSchema = z.object({
   assistant_posts: z
     .array(assistantPostSchema)
     .describe("Assistant posts sent to the thread, including attached files"),
+  observed_tool_invocations: z
+    .array(
+      z.object({
+        tool: z.string().describe("Tool name the assistant attempted to call"),
+        bash_command: z
+          .string()
+          .optional()
+          .describe("Bash command when the invoked tool is bash"),
+        skill_name: z
+          .string()
+          .optional()
+          .describe("Skill name when the invoked tool is loadSkill"),
+      }),
+    )
+    .describe("Sanitized tool invocations observed during the eval"),
   canvases: z
     .array(canvasSchema)
     .describe("Slack canvases created during the turn"),
@@ -123,6 +138,7 @@ function hasAssistantStatusPending(result: EvalResult): boolean {
 function serializeEvalResult(result: EvalResult): string {
   const output: z.input<typeof evalOutputSchema> = {
     assistant_posts: result.posts,
+    observed_tool_invocations: result.toolInvocations,
     canvases: result.canvases,
     channel_posts: result.channelPosts,
     reactions: result.reactions,

--- a/packages/junior/src/chat/prompt.ts
+++ b/packages/junior/src/chat/prompt.ts
@@ -299,10 +299,10 @@ const HEADER =
   "You are a Slack-based helper assistant. The behavior and output blocks below are authoritative; the personality block sets voice only.";
 
 const BEHAVIOR_RULES = [
-  "- Load the best-matching skill before applying skill-specific behavior; don't load multiple up front; don't claim a skill was used unless it is in <loaded-skills> or loadSkill succeeded this turn.",
+  "- When a request matches an available skill or tool, load the best-matching skill and use the relevant tool or command before answering or acting; don't load multiple up front; don't claim a skill or tool was used unless it was actually called this turn.",
   "- After loadSkill, resolve referenced paths under skill_dir, and call any MCP tools the skill registers by name; use searchTools only to rediscover registered tools.",
   "- Gather evidence with tools or skills before answering factual questions; say it is unverified rather than guess.",
-  "- Execute clear tasks this turn; never ask the user to re-tag or re-invoke; never claim tools are unavailable.",
+  "- Execute clear tasks this turn; never ask the user to re-tag or re-invoke; when diagnosing tool availability or runtime failures, run the named tool or command, or a direct availability check, before reporting on it.",
   "- In thread follow-ups, answer from prior thread context; do not repeat resolved clarifying questions.",
   "- If the user asks what you just said, summarize your prior reply plainly.",
   "- Ask one direct clarifying question only when critical input cannot be discovered with tools.",
@@ -311,7 +311,8 @@ const BEHAVIOR_RULES = [
   "- Do not claim an attachment, canvas, or channel post succeeded unless the tool returned success this turn; when it did, include any link the tool returned.",
   "- Run authenticated provider commands directly; the runtime handles auth pause/resume. Resolve target defaults first, and do not manage auth yourself.",
   "- After the runtime resumes a paused turn (auth completion, timeout-resume), post a brief continuation notice (e.g., 'Connected — continuing.') and then the resumed answer as a separate message.",
-  "- jr-rpc config get|set|unset|list is a built-in bash command for conversation-scoped config keys from <providers> or active skill metadata.",
+  "- If a command or prerequisite fails, report the exact command plus stderr/exit code; do not replace it with an inferred missing-tool or environment diagnosis.",
+  "- Run `jr-rpc config get|set|unset|list` as its own bash command. It is a Junior runtime-intercepted config command for conversation-scoped keys from <providers> or active skill metadata, not a general sandbox binary.",
   "- For explicit channel-post or emoji-reaction requests, skip the text reply.",
 ];
 

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -144,6 +144,10 @@ export interface ReplyRequestContext {
   ) => void | Promise<void>;
   onTextDelta?: (deltaText: string) => void | Promise<void>;
   onAssistantMessageStart?: () => void | Promise<void>;
+  onToolInvocation?: (invocation: {
+    toolName: string;
+    params: Record<string, unknown>;
+  }) => void;
   /**
    * Known thread participants. Injected into the system prompt so the LLM can
    * produce correct <@USERID> mention syntax for people already in the conversation.
@@ -781,8 +785,22 @@ export async function generateAssistantReply(
     ]);
 
     // ── Agent tools ──────────────────────────────────────────────────
-    const onToolCall = (toolName: string) => {
+    const onToolCall = (toolName: string, params: Record<string, unknown>) => {
       toolCalls.push(toolName);
+      try {
+        context.onToolInvocation?.({ toolName, params });
+      } catch (error) {
+        logWarn(
+          "tool_invocation_observer_failed",
+          spanContext,
+          {
+            "gen_ai.tool.name": toolName,
+            "error.message":
+              error instanceof Error ? error.message : String(error),
+          },
+          "Tool invocation observer failed",
+        );
+      }
     };
     const baseAgentTools = createAgentTools(
       tools as Record<string, ToolDefinition<any>>,

--- a/packages/junior/src/chat/tools/agent-tools.ts
+++ b/packages/junior/src/chat/tools/agent-tools.ts
@@ -25,7 +25,7 @@ export function createAgentTools(
   sandboxExecutor?: SandboxExecutor,
   capabilityRuntime?: SkillCapabilityRuntime,
   pluginAuthOrchestration?: PluginAuthOrchestration,
-  onToolCall?: (toolName: string) => void,
+  onToolCall?: (toolName: string, params: Record<string, unknown>) => void,
 ): AgentTool[] {
   const shouldTrace = shouldEmitDevAgentTrace();
   return Object.entries(tools).map(([toolName, toolDef]) => ({
@@ -39,7 +39,6 @@ export function createAgentTools(
           ? toolCallId
           : undefined;
       const toolArgumentsAttribute = serializeGenAiAttribute(params);
-      onToolCall?.(toolName);
       const traceToolContext = {
         ...spanContext,
         conversationId: spanContext.conversationId,
@@ -58,6 +57,7 @@ export function createAgentTools(
         spanContext,
         async () => {
           const parsed = params as Record<string, unknown>;
+          onToolCall?.(toolName, parsed);
 
           try {
             if (typeof toolDef.execute !== "function") {

--- a/packages/junior/tests/unit/tools/agent-tools.test.ts
+++ b/packages/junior/tests/unit/tools/agent-tools.test.ts
@@ -131,6 +131,31 @@ describe("createAgentTools", () => {
     });
   });
 
+  it("reports tool call parameters to the caller", async () => {
+    const sandbox = new SkillSandbox([], []);
+    const onToolCall = vi.fn();
+    const [bashTool] = createAgentTools(
+      {
+        bash: {
+          description: "bash",
+          inputSchema: {} as any,
+          execute: async () => ({ ok: true }),
+        },
+      },
+      sandbox,
+      {},
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      onToolCall,
+    );
+
+    await bashTool!.execute("tool-bash", { command: "which gh" });
+
+    expect(onToolCall).toHaveBeenCalledWith("bash", { command: "which gh" });
+  });
+
   it("rethrows plugin auth pauses without reporting a tool failure", async () => {
     const sandbox = new SkillSandbox([githubSkill], [githubSkill]);
     const capabilityRuntime = {


### PR DESCRIPTION
Make Junior use the relevant skill or tool before it answers, acts, or explains a tool failure.

The regression in #257 was broader than a bad final reply. Junior guessed about unavailable tooling instead of loading the matching skill, using the available command surface, and grounding any failure report in observed command output. This updates the platform prompt so matching skills/tools must be used before claims are made, and tool-availability diagnoses require an observed tool call, command run, or direct availability check.

The GitHub workflow eval now covers the multi-turn path that matters here: set a default repo, then create an issue from stored repo context. It judges the actual invocation trail through sanitized `observed_tool_invocations`, requiring `loadSkill` for `github-issues` and a `gh issue create --repo getsentry/junior` command instead of passing on plausible Slack wording alone.

I kept the new evidence surface scoped to evals. Production turn diagnostics continue to expose the existing tool-call summary, while the eval harness records only the selected fields needed for this behavioral contract: tool name, `bash.command`, and `loadSkill.skill_name`.

Validated with `pnpm --filter @sentry/junior typecheck`, `pnpm --filter @sentry/junior-evals exec tsc --noEmit -p tsconfig.json`, `pnpm --filter @sentry/junior exec vitest run tests/unit/tools/agent-tools.test.ts tests/unit/handlers/jr-rpc-command.test.ts`, and oxlint on the changed Junior files. GitHub PR checks are passing. The focused eval was attempted with host access, but local AI Gateway auth returned 401 for missing or invalid `AI_GATEWAY_API_KEY` before model execution.

Refs #257