### PR TITLE
docs(prompt): Add agent prompt contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ Co-Authored-By: (agent model name) <email>
 - `specs/slack-outbound-contract-spec.md` (Slack outbound boundary, message/file/reaction safety rules, and markdown-to-`mrkdwn` ownership)
 - `specs/skill-capabilities-spec.md` (capability declaration + broker/injection contract)
 - `specs/oauth-flows-spec.md` (OAuth authorization code flow + Slack UX contract)
+- `specs/agent-prompt-spec.md` (core prompt ownership, execution-bias, and bloat-control contract)
 - `specs/harness-agent-spec.md` (agent loop and output contract)
 - `specs/agent-session-resumability-spec.md` (multi-slice turn resumability and timeout recovery contract)
 - `specs/agent-execution-spec.md` (agent execution rubric and completion gates)

--- a/packages/junior/src/chat/prompt.ts
+++ b/packages/junior/src/chat/prompt.ts
@@ -321,20 +321,16 @@ const HEADER =
   "You are a Slack-based helper assistant. The behavior and output blocks below are authoritative; the personality block sets voice only.";
 
 const BEHAVIOR_RULES = [
-  "- When a request matches an available skill or tool, load the best-matching skill and use the relevant tool or command before answering or acting; don't load multiple up front; don't claim a skill or tool was used unless it was actually called this turn.",
-  "- After loadSkill, resolve referenced paths under skill_dir; when loadSkill or <active-mcp-catalogs> shows an MCP provider, use searchMcpTools for descriptors and callMcpTool with exact returned `tool_name` values.",
-  "- Gather evidence with tools or skills before answering factual questions; say it is unverified rather than guess.",
-  "- Execute clear tasks this turn; never ask the user to re-tag or re-invoke; when diagnosing tool availability or runtime failures, run the named tool or command, or a direct availability check, before reporting on it.",
+  "- Load the best-matching skill/tool when relevant, then use it before answering; do not preload multiple skills or claim tool use that did not happen.",
+  "- After `loadSkill`, resolve references under `skill_dir`; for active MCP catalogs, use `searchMcpTools` then `callMcpTool` with exact returned tool names.",
+  "- Default to acting in-turn: use relevant available skills/tools to satisfy the request, continue until done or blocked, and only ask the user when access or required input is missing. If a fact cannot be verified, say so.",
   "- In thread follow-ups, answer from prior thread context; do not repeat resolved clarifying questions.",
-  "- If the user asks what you just said, summarize your prior reply plainly.",
-  "- Ask one direct clarifying question only when critical input cannot be discovered with tools.",
-  "- Never narrate progress, prerequisite checks, or 'let me check'; never use reactions as progress signals — assistant status covers in-progress UX.",
-  "- Prefer a single result-focused reply; send interim replies only when blocked or waiting on user input.",
+  "- Keep work silent and post one result-focused reply unless blocked or waiting on user input; do not use reactions as progress.",
   "- Do not claim an attachment, canvas, or channel post succeeded unless the tool returned success this turn; when it did, include any link the tool returned.",
-  "- Run authenticated provider commands directly; the runtime handles auth pause/resume. Resolve target defaults first, and do not manage auth yourself.",
-  "- After the runtime resumes a paused turn (auth completion, timeout-resume), post a brief continuation notice (e.g., 'Connected — continuing.') and then the resumed answer as a separate message.",
-  "- If a command or prerequisite fails, report the exact command plus stderr/exit code; do not replace it with an inferred missing-tool or environment diagnosis.",
-  "- Run `jr-rpc config get|set|unset|list` as its own bash command. It is a Junior runtime-intercepted config command for conversation-scoped keys from <providers> or active skill metadata, not a general sandbox binary.",
+  "- Run authenticated provider commands directly; resolve target defaults first and let the runtime handle auth pauses/resumes.",
+  "- On resumed turns, post a brief continuation notice, then the resumed answer as a separate message.",
+  "- For tool/runtime failures, run the named check before diagnosing and report the exact failed command plus stderr/exit code.",
+  "- Run `jr-rpc config get|set|unset|list` as standalone bash commands for conversation-scoped provider defaults.",
   "- For explicit channel-post or emoji-reaction requests, skip the text reply.",
 ];
 
@@ -342,10 +338,8 @@ function buildOutputSection(): string {
   const openTag = `<output format="slack-mrkdwn" max_inline_chars="${slackOutputPolicy.maxInlineChars}" max_inline_lines="${slackOutputPolicy.maxInlineLines}">`;
   return [
     openTag,
-    "- Use Slack-friendly mrkdwn, not full CommonMark; use bolded section labels instead of markdown headings (# / ## / ###).",
-    "- Use bullets and short code blocks when helpful; do not use markdown tables (| column |) or markdown links ([text](url)); prefer plain URLs.",
-    "- Keep responses brief and scannable; for depth, lead with a concise summary and then provide fuller detail.",
-    "- Prefer a single compact thread reply when the answer fits within the inline budget above.",
+    "- Use Slack-friendly mrkdwn: bolded section labels instead of headings, no markdown tables or markdown links, and plain URLs.",
+    "- Keep replies brief and scannable; use bullets or short code blocks when helpful, and one compact thread reply when it fits.",
     "- When a research or document-style answer would benefit from continuation, multiple sections, or future reference value, create a Slack canvas and keep the thread reply to a short summary plus the canvas link.",
     "- End every turn with a final user-facing markdown response.",
     "</output>",

--- a/specs/agent-prompt-spec.md
+++ b/specs/agent-prompt-spec.md
@@ -1,0 +1,114 @@
+# Agent Prompt Spec
+
+## Metadata
+
+- Created: 2026-04-28
+- Last Edited: 2026-04-28
+
+## Changelog
+
+- 2026-04-28: Initial spec defining ownership, structure, and bloat controls for the core agent prompt.
+
+## Status
+
+Active
+
+## Purpose
+
+Define the canonical contract for Junior's platform-owned agent prompt so prompt changes stay compact, non-duplicative, and measurable.
+
+## Scope
+
+- `buildSystemPrompt(...)` in `packages/junior/src/chat/prompt.ts`.
+- Platform-owned behavior, capability, context, and Slack output instructions.
+- Boundaries between the core harness prompt, deployment personality files, and skill instructions.
+
+## Non-Goals
+
+- Defining Pi agent loop mechanics or terminal output assembly; see `./harness-agent-spec.md`.
+- Defining Slack delivery transport behavior; see `./slack-agent-delivery-spec.md` and `./slack-outbound-contract-spec.md`.
+- Defining test-layer taxonomy; see `./testing/index.md`.
+- Defining provider-specific prompt overlays unless this repository owns that overlay.
+
+## Contracts
+
+### Prompt ownership
+
+- The core prompt owns platform behavior: tool-use policy, execution bias, context boundaries, Slack output shape, and failure reporting expectations.
+- `SOUL.md` and other deployment-authored personality files are voice-only. Platform behavior must still work if those files are empty or heavily customized.
+- Skill files own domain-specific workflow mechanics. They must not duplicate generic harness behavior such as "use tools before answering" or "ask only when blocked."
+
+### Section boundaries
+
+`buildSystemPrompt(...)` must keep these concerns distinct:
+
+1. Identity/personality.
+2. Runtime and thread context.
+3. Available and loaded capabilities.
+4. Core behavior rules.
+5. Slack output contract.
+
+Context blocks describe facts. Behavior and output blocks carry instructions.
+
+### Execution bias
+
+The core behavior rules must include one compact execution-bias rule:
+
+- Default to acting in-turn.
+- Use relevant available skills/tools to satisfy the request.
+- Continue until done or blocked.
+- Ask the user only when access or required input is missing.
+- State when a fact cannot be verified.
+
+Do not restate this rule in skills or add sibling bullets that say the same thing with different wording.
+
+### Tool and skill policy
+
+- Tool schemas remain the source of truth for tool parameters. The prompt may state when to use tools, not re-document every tool schema.
+- The model should load the best-matching skill when relevant and avoid preloading unrelated skills.
+- After loading a plugin-backed skill, the prompt may describe the generic MCP lookup path, but provider-specific tool strategy belongs in the skill or plugin docs.
+
+### Bloat controls
+
+- Each behavior bullet should own one distinct decision the model must make.
+- Before adding a new prompt rule, first try to replace or sharpen an existing rule with the same owner.
+- Remove or merge rules that differ only by example, tone, or repeated ask/act/verify language.
+- Add examples only when evals show the compact rule is insufficient.
+- Prompt wording is not a behavior contract by itself; validate prompt behavior with evals or integration tests, not static substring assertions.
+
+### Output contract
+
+- The Slack output section owns formatting and delivery shape only.
+- It should stay compact: Slack `mrkdwn` constraints, brevity, canvas handoff rules, and final user-facing response requirements.
+- Behavioral rules such as when to use tools or ask questions do not belong in the output section.
+
+## Failure Model
+
+Prompt changes are rejected or revised when they introduce:
+
+1. Duplicate rules across core prompt, skills, or personality files.
+2. Multiple adjacent bullets that all express the same ask/act/verify policy.
+3. Tool-schema restatement in prompt prose.
+4. Skill instructions that override generic harness behavior without a domain-specific reason.
+5. Static prompt tests that assert wording instead of behavior.
+
+## Observability
+
+No prompt-specific logs are required.
+
+When debugging prompt behavior, use existing turn diagnostics, observed tool invocations, assistant posts, and eval results to identify whether the failure is prompt wording, missing tool access, weak skill guidance, or runtime behavior.
+
+## Verification
+
+- Typecheck must pass after prompt code changes.
+- Prompt behavior changes require eval coverage when the contract depends on model interpretation.
+- Runtime or Slack delivery behavior changes require integration coverage at the appropriate boundary.
+- Prompt prose should be reviewed against this spec for ownership, duplication, and section placement.
+
+## Related Specs
+
+- `./harness-agent-spec.md`
+- `./harness-tool-context-spec.md`
+- `./slack-agent-delivery-spec.md`
+- `./slack-outbound-contract-spec.md`
+- `./testing/index.md`

--- a/specs/index.md
+++ b/specs/index.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-03-03
-- Last Edited: 2026-04-16
+- Last Edited: 2026-04-28
 
 ## Changelog
 
@@ -14,6 +14,7 @@
 - 2026-03-21: Added canonical chat architecture spec.
 - 2026-04-15: Added canonical Slack agent delivery spec.
 - 2026-04-16: Added canonical Slack write contract spec.
+- 2026-04-28: Added canonical agent prompt spec.
 
 ## Status
 
@@ -50,6 +51,7 @@ Define spec taxonomy, naming conventions, and canonical source-of-truth document
 - `specs/slack-outbound-contract-spec.md`
 - `specs/skill-capabilities-spec.md`
 - `specs/oauth-flows-spec.md`
+- `specs/agent-prompt-spec.md`
 - `specs/harness-agent-spec.md`
 - `specs/agent-session-resumability-spec.md`
 - `specs/agent-execution-spec.md`


### PR DESCRIPTION
Adds a canonical agent prompt spec so core prompt changes have one source of truth for ownership, execution bias, and bloat control. The core prompt now collapses overlapping behavior and Slack output guidance into fewer distinct rules while preserving tool-use, auth/resume, and Slack delivery constraints.

**Prompt Contract**

The new spec defines core-vs-skill ownership, section boundaries, and guardrails against duplicated ask/act/verify wording.

**Prompt Cleanup**

The harness prompt now has one execution-bias rule modeled on OpenClaw's compact pattern: act in-turn, use available skills/tools, continue until done or blocked, and ask only when access or required input is missing.