### PR TITLE
fix(mcp): Send empty tool arguments

### DIFF
--- a/packages/junior/src/chat/mcp/client.ts
+++ b/packages/junior/src/chat/mcp/client.ts
@@ -7,6 +7,7 @@ import {
   StreamableHTTPClientTransport,
   StreamableHTTPError,
 } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { setSpanAttributes } from "@/chat/logging";
 import type { PluginDefinition } from "@/chat/plugins/types";
 
 type ListedTool = Awaited<ReturnType<Client["listTools"]>>["tools"][number];
@@ -16,6 +17,31 @@ const MCP_CLIENT_INFO = {
   name: "junior-mcp-client",
   version: "1.0.0",
 };
+const MCP_TOOLS_CALL_METHOD = "tools/call";
+
+function getDefaultPort(url: URL): number | undefined {
+  if (url.protocol === "https:") {
+    return 443;
+  }
+  if (url.protocol === "http:") {
+    return 80;
+  }
+  return undefined;
+}
+
+function getMcpNetworkAttributes(url: URL): Record<string, string | number> {
+  const port = url.port ? Number(url.port) : getDefaultPort(url);
+  return {
+    "server.address": url.hostname,
+    ...(port !== undefined ? { "server.port": port } : {}),
+    ...(url.protocol === "http:" || url.protocol === "https:"
+      ? {
+          "network.protocol.name": "http",
+          "network.transport": "tcp",
+        }
+      : {}),
+  };
+}
 
 export class McpAuthorizationRequiredError extends Error {
   readonly provider: string;
@@ -87,10 +113,26 @@ export class PluginMcpClient {
   ): Promise<ToolCallResult> {
     return await this.withSessionRecovery(async () => {
       const client = await this.getClient();
+      const mcp = this.plugin.manifest.mcp;
+      if (mcp) {
+        const url = new URL(mcp.url);
+        setSpanAttributes({
+          "mcp.method.name": MCP_TOOLS_CALL_METHOD,
+          "gen_ai.operation.name": "execute_tool",
+          "gen_ai.tool.name": name,
+          ...(this.transport?.sessionId
+            ? { "mcp.session.id": this.transport.sessionId }
+            : {}),
+          ...(this.transport?.protocolVersion
+            ? { "mcp.protocol.version": this.transport.protocolVersion }
+            : {}),
+          ...getMcpNetworkAttributes(url),
+        });
+      }
       const result = await this.wrapAuth(
         client.callTool({
           name,
-          ...(args && Object.keys(args).length > 0 ? { arguments: args } : {}),
+          arguments: args ?? {},
         }),
       );
       await this.syncTransportSessionId();

--- a/packages/junior/src/chat/mcp/errors.ts
+++ b/packages/junior/src/chat/mcp/errors.ts
@@ -1,0 +1,20 @@
+/** Thrown when an MCP tool returns an error result. */
+export class McpToolError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "McpToolError";
+  }
+}
+
+/** Return the OpenTelemetry error.type value for MCP-aware tool failures. */
+export function getMcpAwareErrorType(error: unknown, fallback: string): string {
+  if (error instanceof McpToolError) {
+    return "tool_error";
+  }
+  return error instanceof Error ? error.name : fallback;
+}
+
+/** Return the display-safe error message for MCP-aware tool failures. */
+export function getMcpAwareErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/junior/src/chat/mcp/tool-manager.ts
+++ b/packages/junior/src/chat/mcp/tool-manager.ts
@@ -1,5 +1,6 @@
 import type { ImageContent, TextContent } from "@mariozechner/pi-ai";
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import { logWarn, setSpanAttributes } from "@/chat/logging";
 import type { SkillMetadata } from "@/chat/skills";
 import type { PluginDefinition } from "@/chat/plugins/types";
 import {
@@ -8,14 +9,11 @@ import {
   type PluginMcpListedTool,
   type PluginMcpToolCallResult,
 } from "./client";
-
-/** Thrown when an MCP tool returns an error result — an expected outcome, not a crash. */
-export class McpToolError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "McpToolError";
-  }
-}
+import {
+  getMcpAwareErrorMessage,
+  getMcpAwareErrorType,
+  McpToolError,
+} from "./errors";
 
 function normalizeMcpToolName(provider: string, toolName: string): string {
   // Raw MCP tool names are only provider-scoped. Prefix the provider for the
@@ -332,6 +330,11 @@ export class McpToolManager {
       execute: async (args) => {
         const resolvedArgs =
           typeof args === "object" && args !== null ? args : {};
+        const baseAttributes = {
+          "gen_ai.tool.name": tool.name,
+          "mcp.method.name": "tools/call",
+        };
+        setSpanAttributes(baseAttributes);
 
         try {
           const result = await client.callTool(tool.name, resolvedArgs);
@@ -371,6 +374,20 @@ export class McpToolManager {
                 },
               },
             };
+          }
+          const errorAttributes = {
+            ...baseAttributes,
+            "error.type": getMcpAwareErrorType(error, "mcp_tool_error"),
+            "error.message": getMcpAwareErrorMessage(error),
+          };
+          setSpanAttributes(errorAttributes);
+          if (error instanceof McpToolError) {
+            logWarn(
+              "mcp_tool_call_failed",
+              {},
+              errorAttributes,
+              "MCP tool call failed",
+            );
           }
           throw error;
         }

--- a/packages/junior/src/chat/tools/execution/tool-error-handler.ts
+++ b/packages/junior/src/chat/tools/execution/tool-error-handler.ts
@@ -5,7 +5,11 @@ import {
   type LogContext,
 } from "@/chat/logging";
 import { GEN_AI_PROVIDER_NAME } from "@/chat/pi/client";
-import { McpToolError } from "@/chat/mcp/tool-manager";
+import {
+  getMcpAwareErrorMessage,
+  getMcpAwareErrorType,
+  McpToolError,
+} from "@/chat/mcp/errors";
 import { SlackActionError } from "@/chat/slack/client";
 
 function getToolErrorAttributes(
@@ -34,8 +38,10 @@ export function handleToolExecutionError(
   shouldTrace: boolean,
   traceContext: LogContext,
 ): never {
+  const errorType = getMcpAwareErrorType(error, "tool_execution_error");
+  const errorMessage = getMcpAwareErrorMessage(error);
   setSpanAttributes({
-    "error.type": error instanceof Error ? error.name : "tool_execution_error",
+    "error.type": errorType,
   });
 
   if (shouldTrace) {
@@ -47,9 +53,8 @@ export function handleToolExecutionError(
         "gen_ai.operation.name": "execute_tool",
         "gen_ai.tool.name": toolName,
         ...(toolCallId ? { "gen_ai.tool.call.id": toolCallId } : {}),
-        "error.type":
-          error instanceof Error ? error.name : "tool_execution_error",
-        "error.message": error instanceof Error ? error.message : String(error),
+        "error.type": errorType,
+        "error.message": errorMessage,
       },
       "Agent tool call failed",
     );

--- a/packages/junior/tests/unit/mcp/client.test.ts
+++ b/packages/junior/tests/unit/mcp/client.test.ts
@@ -1,13 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
 
-const { callToolMock, connectMock, listToolsMock, transportOptions } =
-  vi.hoisted(() => ({
-    callToolMock: vi.fn(),
-    connectMock: vi.fn(),
-    listToolsMock: vi.fn(),
-    transportOptions: [] as Array<Record<string, unknown>>,
-  }));
+const {
+  callToolMock,
+  connectMock,
+  listToolsMock,
+  setSpanAttributesMock,
+  transportOptions,
+} = vi.hoisted(() => ({
+  callToolMock: vi.fn(),
+  connectMock: vi.fn(),
+  listToolsMock: vi.fn(),
+  setSpanAttributesMock: vi.fn(),
+  transportOptions: [] as Array<Record<string, unknown>>,
+}));
 
 vi.mock("@modelcontextprotocol/sdk/client/auth.js", () => {
   class UnauthorizedError extends Error {
@@ -34,6 +40,7 @@ vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => {
   }
 
   class StreamableHTTPClientTransport {
+    protocolVersion?: string;
     sessionId?: string;
 
     constructor(
@@ -47,6 +54,10 @@ vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => {
     }
 
     async close() {}
+
+    setProtocolVersion(version: string) {
+      this.protocolVersion = version;
+    }
   }
 
   return {
@@ -74,6 +85,10 @@ vi.mock("@modelcontextprotocol/sdk/client", () => ({
       return await callToolMock(this.transport, args);
     }
   },
+}));
+
+vi.mock("@/chat/logging", () => ({
+  setSpanAttributes: setSpanAttributesMock,
 }));
 
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
@@ -134,6 +149,7 @@ describe("PluginMcpClient", () => {
     callToolMock.mockReset();
     connectMock.mockReset();
     listToolsMock.mockReset();
+    setSpanAttributesMock.mockReset();
     transportOptions.length = 0;
   });
 
@@ -203,6 +219,43 @@ describe("PluginMcpClient", () => {
     await expect(client.listTools()).rejects.toBeInstanceOf(
       StreamableHTTPError,
     );
+  });
+
+  it("sends an empty arguments object for no-argument MCP tool calls", async () => {
+    const authProvider = buildAuthProvider();
+    authProvider.getMcpServerSessionId.mockResolvedValue(undefined);
+    authProvider.saveMcpServerSessionId.mockResolvedValue(undefined);
+    connectMock.mockImplementation(
+      async (transport: {
+        sessionId?: string;
+        setProtocolVersion: (version: string) => void;
+      }) => {
+        transport.sessionId = "server-session";
+        transport.setProtocolVersion("2025-11-25");
+      },
+    );
+    callToolMock.mockResolvedValue({ content: [{ type: "text", text: "ok" }] });
+
+    const client = new PluginMcpClient(buildPlugin(), { authProvider });
+
+    await expect(client.callTool("notion-search", undefined)).resolves.toEqual({
+      content: [{ type: "text", text: "ok" }],
+    });
+    expect(callToolMock).toHaveBeenCalledWith(expect.anything(), {
+      name: "notion-search",
+      arguments: {},
+    });
+    expect(setSpanAttributesMock).toHaveBeenCalledWith({
+      "mcp.method.name": "tools/call",
+      "gen_ai.operation.name": "execute_tool",
+      "gen_ai.tool.name": "notion-search",
+      "mcp.session.id": "server-session",
+      "mcp.protocol.version": "2025-11-25",
+      "server.address": "mcp.notion.com",
+      "server.port": 443,
+      "network.protocol.name": "http",
+      "network.transport": "tcp",
+    });
   });
 
   it("clears a stale MCP server session and retries once with a fresh transport", async () => {
@@ -276,6 +329,14 @@ describe("PluginMcpClient", () => {
     ]);
     await expect(client.callTool("notion-search", undefined)).resolves.toEqual({
       content: [{ type: "text", text: "ok" }],
+    });
+    expect(callToolMock).toHaveBeenNthCalledWith(1, expect.anything(), {
+      name: "notion-search",
+      arguments: {},
+    });
+    expect(callToolMock).toHaveBeenNthCalledWith(2, expect.anything(), {
+      name: "notion-search",
+      arguments: {},
     });
     await expect(client.listTools()).resolves.toEqual([
       expect.objectContaining({ name: "notion-query" }),

--- a/packages/junior/tests/unit/mcp/tool-manager.test.ts
+++ b/packages/junior/tests/unit/mcp/tool-manager.test.ts
@@ -7,14 +7,18 @@ const {
   clientSetupError,
   closeMock,
   listToolsMock,
+  logWarnMock,
   onAuthorizationRequiredMock,
+  setSpanAttributesMock,
 } = vi.hoisted(() => ({
   callToolMock: vi.fn(),
   clientOptions: [] as unknown[],
   clientSetupError: { value: undefined as unknown },
   closeMock: vi.fn(),
   listToolsMock: vi.fn(),
+  logWarnMock: vi.fn(),
   onAuthorizationRequiredMock: vi.fn(),
+  setSpanAttributesMock: vi.fn(),
 }));
 
 vi.mock("@/chat/mcp/client", () => {
@@ -58,6 +62,11 @@ vi.mock("@/chat/mcp/client", () => {
   };
 });
 
+vi.mock("@/chat/logging", () => ({
+  logWarn: logWarnMock,
+  setSpanAttributes: setSpanAttributesMock,
+}));
+
 import { McpAuthorizationRequiredError } from "@/chat/mcp/client";
 import { McpToolManager } from "@/chat/mcp/tool-manager";
 
@@ -87,7 +96,9 @@ describe("McpToolManager", () => {
     listToolsMock.mockReset();
     callToolMock.mockReset();
     closeMock.mockReset();
+    logWarnMock.mockReset();
     onAuthorizationRequiredMock.mockReset();
+    setSpanAttributesMock.mockReset();
     clientOptions.length = 0;
     clientSetupError.value = undefined;
 
@@ -158,6 +169,64 @@ describe("McpToolManager", () => {
       expect.objectContaining({ sessionId: expect.any(String) }),
     );
     expect(manager.getActiveToolCatalog(activeSkills)).toEqual([]);
+  });
+
+  it("annotates MCP tool spans with method and tool name", async () => {
+    const plugin = buildPlugin();
+    const manager = new McpToolManager([plugin]);
+    const activeSkills = [{ name: "demo-skill", pluginProvider: "demo" }];
+    await manager.activateProvider("demo");
+
+    const resolvedTools = manager.getResolvedActiveTools(activeSkills);
+    await expect(
+      resolvedTools[0]!.execute({ query: "hello" }),
+    ).resolves.toMatchObject({
+      details: {
+        provider: "demo",
+        tool: "ping",
+      },
+    });
+
+    expect(setSpanAttributesMock).toHaveBeenCalledWith({
+      "gen_ai.tool.name": "ping",
+      "mcp.method.name": "tools/call",
+    });
+  });
+
+  it("logs expected MCP tool errors with semantic context", async () => {
+    const plugin = buildPlugin();
+    const manager = new McpToolManager([plugin]);
+    const activeSkills = [{ name: "demo-skill", pluginProvider: "demo" }];
+    await manager.activateProvider("demo");
+    callToolMock.mockResolvedValueOnce({
+      content: [
+        {
+          type: "text",
+          text: "Input validation error: Invalid input: expected object, received undefined",
+        },
+      ],
+      isError: true,
+    });
+
+    const resolvedTools = manager.getResolvedActiveTools(activeSkills);
+    await expect(resolvedTools[0]!.execute({})).rejects.toThrow(
+      "expected object, received undefined",
+    );
+
+    const expectedAttributes = expect.objectContaining({
+      "gen_ai.tool.name": "ping",
+      "mcp.method.name": "tools/call",
+      "error.type": "tool_error",
+      "error.message":
+        "Input validation error: Invalid input: expected object, received undefined",
+    });
+    expect(setSpanAttributesMock).toHaveBeenCalledWith(expectedAttributes);
+    expect(logWarnMock).toHaveBeenCalledWith(
+      "mcp_tool_call_failed",
+      {},
+      expectedAttributes,
+      "MCP tool call failed",
+    );
   });
 
   it("surfaces MCP authorization challenges through the callback hook", async () => {

--- a/packages/junior/tests/unit/tools/call-mcp-tool.test.ts
+++ b/packages/junior/tests/unit/tools/call-mcp-tool.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
-import { createCallMcpToolTool } from "@/chat/tools/skill/call-mcp-tool";
 import type { McpToolManager } from "@/chat/mcp/tool-manager";
 import type { Skill } from "@/chat/skills";
+import { createCallMcpToolTool } from "@/chat/tools/skill/call-mcp-tool";
 
 const activeSkill: Skill = {
   name: "demo",

--- a/packages/junior/tests/unit/tools/tool-error-handler.test.ts
+++ b/packages/junior/tests/unit/tools/tool-error-handler.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { logExceptionMock, logWarnMock, setSpanAttributesMock } = vi.hoisted(
+  () => ({
+    logExceptionMock: vi.fn(),
+    logWarnMock: vi.fn(),
+    setSpanAttributesMock: vi.fn(),
+  }),
+);
+
+vi.mock("@/chat/logging", () => ({
+  logException: logExceptionMock,
+  logWarn: logWarnMock,
+  setSpanAttributes: setSpanAttributesMock,
+}));
+
+import { McpToolError } from "@/chat/mcp/errors";
+import { handleToolExecutionError } from "@/chat/tools/execution/tool-error-handler";
+
+describe("handleToolExecutionError", () => {
+  beforeEach(() => {
+    logExceptionMock.mockReset();
+    logWarnMock.mockReset();
+    setSpanAttributesMock.mockReset();
+  });
+
+  it("uses the MCP semantic error type for MCP tool results", () => {
+    const error = new McpToolError("remote tool failed");
+
+    expect(() =>
+      handleToolExecutionError(error, "callMcpTool", "tool-call-id", true, {}),
+    ).toThrow(error);
+
+    expect(setSpanAttributesMock).toHaveBeenCalledWith({
+      "error.type": "tool_error",
+    });
+    expect(logWarnMock).toHaveBeenCalledWith(
+      "agent_tool_call_failed",
+      {},
+      expect.objectContaining({
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.tool.name": "callMcpTool",
+        "gen_ai.tool.call.id": "tool-call-id",
+        "error.type": "tool_error",
+        "error.message": "remote tool failed",
+      }),
+      "Agent tool call failed",
+    );
+    expect(logExceptionMock).not.toHaveBeenCalled();
+  });
+});

--- a/specs/logging/semantics.md
+++ b/specs/logging/semantics.md
@@ -10,6 +10,7 @@
 - 2026-03-03: Standardized metadata headers and reconciled spec references/structure.
 - 2026-03-06: Added sandbox snapshot lifecycle attribute mappings.
 - 2026-04-06: Added official GenAI finish-reason, system-instructions, and tool-description semantics.
+- 2026-04-28: Added MCP tool-call semantic attribute mappings.
 
 ## Status
 
@@ -82,6 +83,25 @@ This file is the canonical attribute and naming map for instrumentation in this 
 - `gen_ai.tool.call.result` (when captured)
 - Prefer `gen_ai.input.messages` / `gen_ai.output.messages` over legacy names like `gen_ai.request.messages` / `gen_ai.response.text`.
 - Prefer `gen_ai.response.finish_reasons` over custom `app.ai.stop_reason`.
+
+## MCP Tool Calls
+
+- `mcp.method.name`
+- `mcp.protocol.version`
+- `mcp.session.id`
+- `mcp.resource.uri` when applicable under explicit opt-in
+- `jsonrpc.protocol.version`
+- `jsonrpc.request.id`
+- `rpc.response.status_code`
+- `gen_ai.operation.name` (`execute_tool` for tool calls)
+- `gen_ai.tool.name`
+- `gen_ai.tool.call.arguments` only under explicit capture policy
+- `gen_ai.tool.call.result` only under explicit capture policy
+- `network.protocol.name`
+- `network.protocol.version`
+- `network.transport`
+- `server.address`
+- `server.port`
 
 ## Process / CLI Execution
 

--- a/specs/logging/tracing-spec.md
+++ b/specs/logging/tracing-spec.md
@@ -12,6 +12,7 @@
 - 2026-03-04: Normalized section shape with explicit `Status`, `Purpose`, and `Scope`.
 - 2026-03-06: Added snapshot lifecycle span requirements and aligned sandbox snapshot attributes.
 - 2026-04-06: Added official GenAI finish-reasons, system-instructions, and tool-description tracing attributes.
+- 2026-04-28: Added MCP tool-call span attributes from the OpenTelemetry MCP semantic conventions.
 
 ## Status
 
@@ -81,6 +82,26 @@ Define the canonical tracing contract for span naming, boundaries, attributes, a
 - `error.type`
 - `error.message`
 - `exception.stacktrace` (when captured and safe)
+
+### MCP Tool Calls
+
+MCP tool dispatcher and execution spans must follow the draft OpenTelemetry MCP
+semantic conventions:
+
+- `mcp.method.name` (`tools/call` for tool calls)
+- `gen_ai.operation.name` (`execute_tool` for tool calls)
+- `gen_ai.tool.name`
+- `jsonrpc.request.id` when available
+- `rpc.response.status_code` when a JSON-RPC response contains an error code
+- `mcp.protocol.version` when available
+- `mcp.session.id` when available
+- `network.protocol.name`
+- `network.protocol.version` when available
+- `network.transport`
+- `server.address` when applicable
+- `server.port` when `server.address` is set
+- `gen_ai.tool.call.arguments` only under explicit capture policy
+- `gen_ai.tool.call.result` only under explicit capture policy
 
 ## Attribute Policy
 


### PR DESCRIPTION
Always send an `arguments` object for MCP tool calls so providers that validate tool input do not receive `undefined` for no-argument calls. MCP error telemetry now follows the OpenTelemetry MCP draft instead of custom `app.mcp.*` identity fields.

**MCP Telemetry**

Tool calls annotate spans with `mcp.method.name`, `gen_ai.tool.name`, session/protocol, server/network fields, and `tool_error` for MCP `isError` results.

**Validation**

Focused tests cover empty MCP arguments, semantic error typing, and the Notion-style validation failure path.