### PR TITLE
test(evals): Cover MCP tool argument shape

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Co-Authored-By: (agent model name) <email>
 - Prefer integration tests for most product/runtime changes that need real wiring.
 - Use evals as the integration-style layer for agent/prompt/natural-language behavior. See `packages/junior-evals/README.md`.
 - Run evals from Codex as escalated host commands when they need real Vercel Sandbox/network access; use `pnpm evals` for the full suite.
+- If evals fail from missing or expired Gateway/Vercel credentials, run `pnpm dev:env` to refresh secrets before retrying.
 - Use instrumentation conventions from `specs/logging/index.md`.
 - Use OpenTelemetry semantic keys for logs; when no semantic key exists, use `app.*`.
 - Keep release package lists aligned across `.craft.yml`, `scripts/bump-release-versions.mjs`, `.github/workflows/ci.yml`, `README.md`, and release docs; verify with `pnpm release:check`.

--- a/packages/junior-evals/evals/behavior-harness.ts
+++ b/packages/junior-evals/evals/behavior-harness.ts
@@ -180,6 +180,8 @@ export interface EvalCanvasArtifact {
 export interface EvalToolInvocation {
   tool: string;
   bash_command?: string;
+  mcp_arguments?: Record<string, unknown>;
+  mcp_tool_name?: string;
   skill_name?: string;
 }
 
@@ -221,6 +223,23 @@ function toEvalToolInvocation(input: {
     typeof input.params.skill_name === "string"
   ) {
     invocation.skill_name = input.params.skill_name.trim();
+  }
+
+  if (
+    input.toolName === "callMcpTool" &&
+    typeof input.params.tool_name === "string"
+  ) {
+    invocation.mcp_tool_name = input.params.tool_name.trim();
+    if (
+      input.params.arguments &&
+      typeof input.params.arguments === "object" &&
+      !Array.isArray(input.params.arguments)
+    ) {
+      invocation.mcp_arguments = input.params.arguments as Record<
+        string,
+        unknown
+      >;
+    }
   }
 
   return invocation;
@@ -334,6 +353,16 @@ async function cleanupHarnessThreadState(
   const runtimeThreadIds = new Set(
     events.map((event) => buildRuntimeThreadId(event.thread)),
   );
+  const turnSessionKeys = events
+    .filter(
+      (event): event is MentionEvent | SubscribedMessageEvent =>
+        "message" in event,
+    )
+    .map((event) => {
+      const messageId = event.message.id ?? "";
+      const sessionId = `turn_${messageId.replace(/[^a-zA-Z0-9_-]/g, "_")}`;
+      return `junior:agent_turn_session:${buildRuntimeThreadId(event.thread)}:${sessionId}`;
+    });
   const channelIds = new Set(
     events
       .map((event) => event.thread.channel_id?.trim())
@@ -343,6 +372,9 @@ async function cleanupHarnessThreadState(
   for (const threadId of runtimeThreadIds) {
     await stateAdapter.delete(`thread-state:${threadId}`);
     await stateAdapter.unsubscribe(threadId);
+  }
+  for (const key of turnSessionKeys) {
+    await stateAdapter.delete(key);
   }
   for (const channelId of channelIds) {
     await stateAdapter.delete(`channel-state:${channelId}`);

--- a/packages/junior-evals/evals/core/oauth-workflows.eval.ts
+++ b/packages/junior-evals/evals/core/oauth-workflows.eval.ts
@@ -32,15 +32,15 @@ describe("OAuth Workflows", () => {
       timeout: 300_000,
       criteria: rubric({
         contract:
-          "After MCP authorization completes, the same thread gets a connection notice and a resumed answer that keeps prior context.",
+          "After MCP authorization completes, the same thread gets a resumed answer that keeps prior context.",
         pass: [
-          "The same thread gets a connection or continuation notice that makes it clear the original request is continuing.",
-          "The same thread then gets a resumed answer.",
+          "assistant_posts includes an access-needed message for Eval-auth.",
+          "channel_posts or assistant_posts includes a same-thread resumed answer.",
           "The resumed answer explicitly says the earlier budget deadline was Friday.",
         ],
         allow: [
           "A concise resumed answer that only restates the budget deadline is acceptable.",
-          "A brief connection notice is acceptable before the resumed answer.",
+          "A brief connection or continuation notice is acceptable before the resumed answer.",
         ],
         fail: [
           "Do not ask the user to repeat the deadline.",

--- a/packages/junior-evals/evals/core/skill-infra.eval.ts
+++ b/packages/junior-evals/evals/core/skill-infra.eval.ts
@@ -67,4 +67,39 @@ describe("Skill Infrastructure", () => {
       }),
     },
   );
+
+  slackEval(
+    "when an MCP-backed skill handles a lookup, return the provider-backed answer",
+    {
+      overrides: {
+        plugin_dirs: ["evals/fixtures/plugins"],
+      },
+      events: [
+        mention(
+          "/eval-mcp Ask the handbook what it says about US holidays, then summarize the result.",
+        ),
+      ],
+      taskTimeout: 120_000,
+      timeout: 300_000,
+      criteria: rubric({
+        contract:
+          "An MCP-backed skill can complete a natural lookup by using the provider result instead of surfacing tool validation errors.",
+        pass: [
+          "observed_tool_invocations includes `callMcpTool` with `mcp_tool_name` set to `mcp__eval-mcp__handbook-search`.",
+          "That `callMcpTool` invocation includes `mcp_arguments.query` containing the handbook or US holidays lookup request.",
+          "The visible thread output includes a final answer based on the demo MCP provider result.",
+          "The visible thread output refers to the handbook or US holidays request.",
+          "The visible thread output does not claim the MCP lookup was blocked by missing arguments.",
+        ],
+        allow: [
+          "The final answer may be a concise paraphrase of the eval handbook result.",
+        ],
+        fail: [
+          'Do not include `expected string, received undefined` or `"query"` argument validation errors.',
+          "Do not ask the user to provide a page URL or repeat the request.",
+          "Do not say the MCP runtime is broken or that the lookup cannot be attempted.",
+        ],
+      }),
+    },
+  );
 });

--- a/packages/junior-evals/evals/fixtures/plugins/eval-auth/skills/eval-auth/SKILL.md
+++ b/packages/junior-evals/evals/fixtures/plugins/eval-auth/skills/eval-auth/SKILL.md
@@ -1,15 +1,17 @@
 ---
 name: eval-auth
-description: Use for `/eval-auth` requests in auth-resume evals. Always connect through the eval auth provider before answering, then continue the user's actual request using prior thread context when needed.
+description: Use for `/eval-auth` requests in auth-resume evals. Always connect through the disclosed MCP tool before answering, then continue the user's actual request using prior thread context when needed.
 ---
 
 # Eval Auth Flow
 
-1. Always connect through the eval auth provider once before answering.
+1. Always inspect the disclosed MCP tools and call the exact disclosed tool once before answering.
 
-2. After the provider succeeds, answer the user's real question directly.
+2. When calling the MCP tool, pass the user's lookup request as `query` inside the tool `arguments` object.
+
+3. After the provider succeeds, answer the user's real question directly.
 
 - If the user asks about earlier thread context, use that context plainly.
 - Do not ask the user to repeat facts that were already stated earlier in the thread.
 
-3. Keep the final answer short.
+4. Keep the final answer short.

--- a/packages/junior-evals/evals/fixtures/plugins/eval-mcp/plugin.yaml
+++ b/packages/junior-evals/evals/fixtures/plugins/eval-mcp/plugin.yaml
@@ -1,0 +1,7 @@
+name: eval-mcp
+description: Eval-only MCP lookup fixture
+
+mcp:
+  url: https://eval-mcp.example.test/mcp
+  allowed-tools:
+    - handbook-search

--- a/packages/junior-evals/evals/fixtures/plugins/eval-mcp/skills/eval-mcp/SKILL.md
+++ b/packages/junior-evals/evals/fixtures/plugins/eval-mcp/skills/eval-mcp/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: eval-mcp
+description: Use for `/eval-mcp` requests that need the eval MCP handbook lookup.
+---
+
+# Eval MCP Lookup
+
+1. Always inspect the disclosed MCP tools and call the exact disclosed handbook search tool before answering.
+
+2. Pass the user's lookup request as `query` inside the tool `arguments` object.
+
+3. Answer from the MCP result. Keep the final answer short.

--- a/packages/junior-evals/evals/helpers.ts
+++ b/packages/junior-evals/evals/helpers.ts
@@ -78,6 +78,16 @@ const evalOutputSchema = z.object({
           .string()
           .optional()
           .describe("Skill name when the invoked tool is loadSkill"),
+        mcp_tool_name: z
+          .string()
+          .optional()
+          .describe("MCP tool name when the invoked tool is callMcpTool"),
+        mcp_arguments: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe(
+            "MCP provider arguments nested under callMcpTool.arguments",
+          ),
       }),
     )
     .describe("Sanitized tool invocations observed during the eval"),

--- a/packages/junior/src/chat/tools/skill/call-mcp-tool.ts
+++ b/packages/junior/src/chat/tools/skill/call-mcp-tool.ts
@@ -3,6 +3,32 @@ import type { McpToolManager } from "@/chat/mcp/tool-manager";
 import type { Skill } from "@/chat/skills";
 import { tool } from "@/chat/tools/definition";
 
+function resolveMcpArguments(
+  input: Record<string, unknown>,
+): Record<string, unknown> {
+  const extraKeys = Object.keys(input).filter(
+    (key) => key !== "tool_name" && key !== "arguments",
+  );
+  if (extraKeys.length > 0) {
+    throw new Error(
+      `callMcpTool MCP arguments must be nested under arguments, not top-level fields: ${extraKeys.join(", ")}`,
+    );
+  }
+
+  if ("arguments" in input) {
+    const args = input.arguments;
+    if (args === undefined) {
+      return {};
+    }
+    if (!args || typeof args !== "object" || Array.isArray(args)) {
+      throw new Error("callMcpTool arguments must be an object when provided");
+    }
+    return args as Record<string, unknown>;
+  }
+
+  return {};
+}
+
 /** Create the stable dispatcher for active MCP provider tools. */
 export function createCallMcpToolTool(
   mcpToolManager: McpToolManager,
@@ -25,14 +51,17 @@ export function createCallMcpToolTool(
       },
       { additionalProperties: false },
     ),
-    execute: async ({ tool_name, arguments: args }) => {
+    execute: async (input) => {
+      const { tool_name } = input;
       const mcpTool = mcpToolManager
         .getResolvedActiveTools(getActiveSkills())
         .find((candidate) => candidate.name === tool_name);
       if (!mcpTool) {
         throw new Error(`MCP tool is not active for this turn: ${tool_name}`);
       }
-      return await mcpTool.execute(args ?? {});
+      return await mcpTool.execute(
+        resolveMcpArguments(input as Record<string, unknown>),
+      );
     },
   });
 }

--- a/packages/junior/src/chat/tools/skill/mcp-tool-summary.ts
+++ b/packages/junior/src/chat/tools/skill/mcp-tool-summary.ts
@@ -6,6 +6,11 @@ export interface ExposedToolSummary {
   provider: string;
   title?: string;
   description: string;
+  signature: string;
+  call: {
+    tool_name: string;
+    arguments: Record<string, string>;
+  };
   input_schema: Record<string, unknown>;
   input_schema_summary: string;
   output_schema?: Record<string, unknown>;
@@ -17,19 +22,105 @@ export interface ActiveMcpCatalogSummary {
   available_tool_count: number;
 }
 
-/** Summarize an MCP input schema for quick catalog scanning. */
-export function summarizeInputSchema(schema: Record<string, unknown>): string {
-  const properties =
-    schema.properties && typeof schema.properties === "object"
-      ? (schema.properties as Record<string, unknown>)
-      : {};
-  const required = Array.isArray(schema.required)
+function getSchemaProperties(
+  schema: Record<string, unknown>,
+): Record<string, unknown> {
+  return schema.properties && typeof schema.properties === "object"
+    ? (schema.properties as Record<string, unknown>)
+    : {};
+}
+
+function getRequiredFields(schema: Record<string, unknown>): Set<string> {
+  return Array.isArray(schema.required)
     ? new Set(
         schema.required.filter(
           (value): value is string => typeof value === "string",
         ),
       )
     : new Set<string>();
+}
+
+function formatSchemaType(schema: unknown): string {
+  if (!schema || typeof schema !== "object") {
+    return "unknown";
+  }
+
+  const typed = schema as Record<string, unknown>;
+  const type = typed.type;
+  if (typeof type === "string") {
+    if (type === "array") {
+      return `${formatSchemaType(typed.items)}[]`;
+    }
+    return type;
+  }
+  if (Array.isArray(type)) {
+    return type.filter((value) => typeof value === "string").join(" | ");
+  }
+  if (Array.isArray(typed.enum) && typed.enum.length > 0) {
+    return typed.enum.map((value) => JSON.stringify(value)).join(" | ");
+  }
+  return "unknown";
+}
+
+function formatArgumentPlaceholder(name: string, schema: unknown): string {
+  const type = formatSchemaType(schema);
+  if (type === "string") {
+    return `<${name}>`;
+  }
+  if (type === "number" || type === "integer") {
+    return "<number>";
+  }
+  if (type === "boolean") {
+    return "<boolean>";
+  }
+  if (type.endsWith("[]")) {
+    return "<array>";
+  }
+  if (type === "object") {
+    return "<object>";
+  }
+  return `<${type}>`;
+}
+
+/** Build a stable model-readable MCP tool signature. */
+export function formatMcpToolSignature(
+  toolName: string,
+  schema: Record<string, unknown>,
+): string {
+  const properties = getSchemaProperties(schema);
+  const required = getRequiredFields(schema);
+  const fields = Object.entries(properties).map(([name, propertySchema]) => {
+    const marker = required.has(name) ? "" : "?";
+    return `${name}${marker}: ${formatSchemaType(propertySchema)}`;
+  });
+  if (fields.length === 0) {
+    return `${toolName}()`;
+  }
+  return `${toolName}({ ${fields.join(", ")} })`;
+}
+
+/** Build the exact callMcpTool argument shape agents should use. */
+export function formatMcpToolCallExample(
+  toolName: string,
+  schema: Record<string, unknown>,
+): ExposedToolSummary["call"] {
+  return {
+    tool_name: toolName,
+    arguments: Object.fromEntries(
+      Object.entries(getSchemaProperties(schema)).map(
+        ([name, propertySchema]) => [
+          name,
+          formatArgumentPlaceholder(name, propertySchema),
+        ],
+      ),
+    ),
+  };
+}
+
+/** Summarize an MCP input schema for quick catalog scanning. */
+export function summarizeInputSchema(schema: Record<string, unknown>): string {
+  const properties = getSchemaProperties(schema);
+  const required = getRequiredFields(schema);
   const propertyNames = Object.keys(properties);
   if (propertyNames.length === 0) {
     return "No arguments.";
@@ -50,6 +141,8 @@ export function toExposedToolSummary(
     provider: toolDef.provider,
     ...(toolDef.title ? { title: toolDef.title } : {}),
     description: toolDef.description,
+    signature: formatMcpToolSignature(toolDef.name, toolDef.parameters),
+    call: formatMcpToolCallExample(toolDef.name, toolDef.parameters),
     input_schema: toolDef.parameters,
     input_schema_summary: summarizeInputSchema(toolDef.parameters),
     ...(toolDef.outputSchema ? { output_schema: toolDef.outputSchema } : {}),

--- a/packages/junior/tests/msw/handlers/eval-mcp-auth.ts
+++ b/packages/junior/tests/msw/handlers/eval-mcp-auth.ts
@@ -4,6 +4,8 @@ export const EVAL_MCP_AUTH_PROVIDER = "eval-auth";
 export const EVAL_MCP_AUTH_CODE = "eval-auth-code";
 export const EVAL_MCP_AUTH_ORIGIN = "https://eval-auth.example.test";
 export const EVAL_MCP_SERVER_URL = `${EVAL_MCP_AUTH_ORIGIN}/mcp`;
+const EVAL_MCP_NO_AUTH_ORIGIN = "https://eval-mcp.example.test";
+const EVAL_MCP_NO_AUTH_SERVER_URL = `${EVAL_MCP_NO_AUTH_ORIGIN}/mcp`;
 const EVAL_MCP_RESOURCE_METADATA_URL = `${EVAL_MCP_AUTH_ORIGIN}/.well-known/oauth-protected-resource/mcp`;
 const EVAL_MCP_AUTHORIZATION_ENDPOINT = `${EVAL_MCP_AUTH_ORIGIN}/oauth/authorize`;
 const EVAL_MCP_TOKEN_ENDPOINT = `${EVAL_MCP_AUTH_ORIGIN}/oauth/token`;
@@ -36,6 +38,100 @@ function jsonRpcResult(id: unknown, result: unknown, headers?: HeadersInit) {
 export function resetEvalMcpAuthMockState(): void {}
 
 export const evalMcpAuthHandlers = [
+  http.get(
+    EVAL_MCP_NO_AUTH_SERVER_URL,
+    async () => new HttpResponse(null, { status: 405 }),
+  ),
+  http.post(EVAL_MCP_NO_AUTH_SERVER_URL, async ({ request }) => {
+    const payload = (await request.json()) as
+      | { id?: unknown; method?: unknown; params?: Record<string, unknown> }
+      | Array<{
+          id?: unknown;
+          method?: unknown;
+          params?: Record<string, unknown>;
+        }>;
+    const message = Array.isArray(payload) ? payload[0] : payload;
+    const method =
+      message && typeof message.method === "string"
+        ? message.method
+        : undefined;
+
+    switch (method) {
+      case "initialize":
+        return jsonRpcResult(message?.id ?? null, {
+          protocolVersion: "2025-03-26",
+          capabilities: {
+            tools: {},
+          },
+          serverInfo: {
+            name: "eval-mcp",
+            version: "1.0.0",
+          },
+        });
+      case "tools/list":
+        return jsonRpcResult(message?.id ?? null, {
+          tools: [
+            {
+              name: "handbook-search",
+              title: "Handbook Search",
+              description: "Search the eval handbook fixture.",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  query: { type: "string" },
+                },
+                required: ["query"],
+                additionalProperties: false,
+              },
+            },
+          ],
+        });
+      case "tools/call": {
+        const args =
+          message?.params &&
+          typeof message.params === "object" &&
+          message.params.arguments &&
+          typeof message.params.arguments === "object"
+            ? (message.params.arguments as Record<string, unknown>)
+            : undefined;
+        if (typeof args?.query !== "string") {
+          return jsonRpcResult(message?.id ?? null, {
+            content: [
+              {
+                type: "text",
+                text: 'Input validation error: Invalid arguments for tool handbook-search:\n- "query": expected string, received undefined',
+              },
+            ],
+            isError: true,
+          });
+        }
+
+        return jsonRpcResult(message?.id ?? null, {
+          content: [
+            {
+              type: "text",
+              text: `Handbook result for "${args.query}": US holidays follow the published company holiday calendar.`,
+            },
+          ],
+          isError: false,
+        });
+      }
+      case "notifications/initialized":
+        return new HttpResponse(null, { status: 202 });
+      default:
+        return HttpResponse.json(
+          {
+            jsonrpc: "2.0",
+            id: message?.id ?? null,
+            error: {
+              code: -32601,
+              message: `Unsupported eval MCP method: ${String(method)}`,
+            },
+          },
+          { status: 400 },
+        );
+    }
+  }),
   http.get(
     EVAL_MCP_SERVER_URL,
     async () => new HttpResponse(null, { status: 405 }),
@@ -104,7 +200,19 @@ export const evalMcpAuthHandlers = [
           typeof message.params.arguments === "object"
             ? (message.params.arguments as Record<string, unknown>)
             : undefined;
-        const query = typeof args?.query === "string" ? args.query : "unknown";
+        if (typeof args?.query !== "string") {
+          return jsonRpcResult(message?.id ?? null, {
+            content: [
+              {
+                type: "text",
+                text: 'Input validation error: Invalid arguments for tool budget-echo:\n- "query": expected string, received undefined',
+              },
+            ],
+            isError: true,
+          });
+        }
+
+        const query = args.query;
         return jsonRpcResult(message?.id ?? null, {
           content: [
             {

--- a/packages/junior/tests/unit/tools/call-mcp-tool.test.ts
+++ b/packages/junior/tests/unit/tools/call-mcp-tool.test.ts
@@ -46,6 +46,94 @@ describe("callMcpTool", () => {
     expect(execute).toHaveBeenCalledWith({ query: "hello" });
   });
 
+  it("rejects top-level MCP arguments instead of silently dropping them", async () => {
+    const manager = {
+      getResolvedActiveTools: vi.fn(() => [
+        {
+          name: "mcp__demo__ping",
+          rawName: "ping",
+          provider: "demo",
+          description: "Ping",
+          parameters: {},
+          execute: vi.fn(),
+        },
+      ]),
+    } as unknown as McpToolManager;
+    const callMcpTool = createCallMcpToolTool(manager, () => [activeSkill]);
+
+    await expect(
+      callMcpTool.execute!(
+        {
+          tool_name: "mcp__demo__ping",
+          query: "hello",
+        } as never,
+        {},
+      ),
+    ).rejects.toThrow(
+      "callMcpTool MCP arguments must be nested under arguments",
+    );
+  });
+
+  it("rejects ambiguous mixed top-level and nested MCP arguments", async () => {
+    const execute = vi.fn(async () => ({
+      content: [{ type: "text" as const, text: "pong" }],
+      details: { ok: true },
+    }));
+    const manager = {
+      getResolvedActiveTools: vi.fn(() => [
+        {
+          name: "mcp__demo__ping",
+          rawName: "ping",
+          provider: "demo",
+          description: "Ping",
+          parameters: {},
+          execute,
+        },
+      ]),
+    } as unknown as McpToolManager;
+    const callMcpTool = createCallMcpToolTool(manager, () => [activeSkill]);
+
+    await expect(
+      callMcpTool.execute!(
+        {
+          tool_name: "mcp__demo__ping",
+          query: "ignored",
+          arguments: { query: "hello" },
+        } as never,
+        {},
+      ),
+    ).rejects.toThrow(
+      "callMcpTool MCP arguments must be nested under arguments",
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-object nested MCP arguments", async () => {
+    const manager = {
+      getResolvedActiveTools: vi.fn(() => [
+        {
+          name: "mcp__demo__ping",
+          rawName: "ping",
+          provider: "demo",
+          description: "Ping",
+          parameters: {},
+          execute: vi.fn(),
+        },
+      ]),
+    } as unknown as McpToolManager;
+    const callMcpTool = createCallMcpToolTool(manager, () => [activeSkill]);
+
+    await expect(
+      callMcpTool.execute!(
+        {
+          tool_name: "mcp__demo__ping",
+          arguments: "hello",
+        } as never,
+        {},
+      ),
+    ).rejects.toThrow("callMcpTool arguments must be an object");
+  });
+
   it("rejects tools that are not active for the turn", async () => {
     const manager = {
       getResolvedActiveTools: vi.fn(() => []),

--- a/packages/junior/tests/unit/tools/search-mcp-tools.test.ts
+++ b/packages/junior/tests/unit/tools/search-mcp-tools.test.ts
@@ -25,6 +25,15 @@ describe("searchMcpTools", () => {
               type: "object",
               properties: {
                 title: { type: "string", description: "Issue title" },
+                labels: {
+                  type: "array",
+                  items: { type: "string" },
+                  description: "Issue labels",
+                },
+                metadata: {
+                  type: "object",
+                  description: "Issue metadata",
+                },
               },
               required: ["title"],
             },
@@ -59,7 +68,13 @@ describe("searchMcpTools", () => {
     )) as {
       tools: Array<{
         tool_name: string;
+        signature: string;
+        call: {
+          tool_name: string;
+          arguments: Record<string, string>;
+        };
         input_schema: Record<string, unknown>;
+        input_schema_summary: string;
         output_schema?: Record<string, unknown>;
         annotations?: Record<string, unknown>;
       }>;
@@ -68,6 +83,17 @@ describe("searchMcpTools", () => {
     expect(result.tools).toHaveLength(1);
     expect(result.tools[0]).toMatchObject({
       tool_name: "mcp__demo__create_issue",
+      signature:
+        "mcp__demo__create_issue({ title: string, labels?: string[], metadata?: object })",
+      call: {
+        tool_name: "mcp__demo__create_issue",
+        arguments: {
+          title: "<title>",
+          labels: "<array>",
+          metadata: "<object>",
+        },
+      },
+      input_schema_summary: "title (required), labels, metadata",
       input_schema: {
         properties: {
           title: { type: "string", description: "Issue title" },
@@ -99,8 +125,19 @@ describe("searchMcpTools", () => {
       query: null,
       provider: "demo",
       tools: [
-        { tool_name: "mcp__demo__create_issue" },
-        { tool_name: "mcp__demo__list_projects" },
+        {
+          tool_name: "mcp__demo__create_issue",
+          signature:
+            "mcp__demo__create_issue({ title: string, labels?: string[], metadata?: object })",
+        },
+        {
+          tool_name: "mcp__demo__list_projects",
+          signature: "mcp__demo__list_projects()",
+          call: {
+            tool_name: "mcp__demo__list_projects",
+            arguments: {},
+          },
+        },
       ],
     });
     expect(manager.getActiveToolCatalog).toHaveBeenCalledWith([activeSkill], {


### PR DESCRIPTION
Add eval coverage for MCP-backed skill lookups that proves the agent calls the discovered MCP tool with provider arguments nested under callMcpTool.arguments. The eval output now includes sanitized MCP invocation details, so the judge can verify the actual tool name and arguments instead of only scoring reply prose.

Improve MCP tool disclosure by returning stable model-readable signatures and concrete call examples from searchMcpTools. Agents now see both the concise signature, such as mcp__provider__tool({ query: string }), and the exact callMcpTool shape with nested arguments, while the raw schema remains available for detail.

This also makes callMcpTool reject misplaced top-level provider arguments instead of silently dropping them. The eval MCP handlers now return strict validation errors when query is missing, matching the production failure class we saw.

The eval harness cleanup now removes deterministic turn-session checkpoints so local reruns cannot inherit stale auth-resume state. AGENTS.md also documents pnpm dev:env as the recovery step when evals fail from expired Gateway/Vercel credentials.