### PR TITLE
fix(skills): Separate issue reporter attribution

### DIFF
--- a/packages/junior-evals/evals/github/skill-workflows.eval.ts
+++ b/packages/junior-evals/evals/github/skill-workflows.eval.ts
@@ -53,6 +53,74 @@ describe("GitHub Skill Workflows", () => {
     },
   );
 
+  const reporterRequesterThread = {
+    id: "thread-reporter-requester",
+    channel_id: "C-reporter-requester",
+    thread_ts: "17000000.reporter-requester",
+  };
+
+  slackEval(
+    "when one user reports and another files an issue, keep attribution roles separate",
+    {
+      overrides: {
+        enable_test_credentials: true,
+        plugin_packages: ["@sentry/junior-github"],
+        reply_timeout_ms: 90_000,
+        subscribed_decisions: [
+          {
+            should_reply: false,
+            reason: "context-setting message only",
+          },
+        ],
+        test_credential_token: "eval-github-attribution-token",
+        skill_dirs: ["../junior/skills"],
+      },
+      events: [
+        threadMessage(
+          "Warden resolved its own review thread on https://github.com/getsentry/ops/pull/20366 even though the warning still applies. The warning was about `SCM_RPC_SHARED_SECRET` not being backported to the cookiecutter template, and the PR still shows `REVIEW_REQUIRED`.",
+          {
+            thread: reporterRequesterThread,
+            author: {
+              user_id: "U_BOJAN",
+              user_name: "bojan",
+              full_name: "Bojan Oro",
+            },
+          },
+        ),
+        mention(
+          "Create a GitHub issue for this in getsentry/warden. Include the issue body you filed in your reply so I can verify attribution.",
+          {
+            thread: reporterRequesterThread,
+            author: {
+              user_id: "U_DCRAMER",
+              user_name: "dcramer",
+              full_name: "David Cramer",
+            },
+          },
+        ),
+      ],
+      criteria: rubric({
+        contract:
+          "GitHub issue creation from a multi-user Slack thread preserves the original reporter separately from the action requester.",
+        pass: [
+          "The assistant posts exactly one reply.",
+          "The reply reports a created GitHub issue in getsentry/warden with an issue URL or issue number.",
+          "The reply includes the filed issue body or enough quoted issue content to verify attribution.",
+          "The shown issue content attributes the report to Bojan Oro.",
+          "The shown issue content ends its delegated-action footer with `Action taken on behalf of David Cramer.`",
+        ],
+        allow: [
+          "Reporter attribution may be phrased as `Reported by Bojan Oro`, `Raised by Bojan Oro`, or equivalent durable issue-body text.",
+        ],
+        fail: [
+          "Do not use `Action taken on behalf of Bojan Oro.`",
+          "Do not describe David Cramer as the reporter.",
+          "Do not omit reporter attribution when showing the filed issue content.",
+        ],
+      }),
+    },
+  );
+
   slackEval(
     "when a GitHub task mentions a Sentry product area, do not prompt for Sentry auth first",
     {

--- a/packages/junior-evals/evals/helpers.ts
+++ b/packages/junior-evals/evals/helpers.ts
@@ -342,6 +342,8 @@ const DEFAULT_AUTHOR = {
   is_bot: false,
 };
 
+type AuthorOverrides = Partial<typeof DEFAULT_AUTHOR>;
+
 interface ThreadOverrides {
   id?: string;
   channel_id?: string;
@@ -349,7 +351,10 @@ interface ThreadOverrides {
 }
 
 /** Builds a first-turn mention event for a harnessed Slack eval. */
-export function mention(text: string, opts?: { thread?: ThreadOverrides }) {
+export function mention(
+  text: string,
+  opts?: { author?: AuthorOverrides; thread?: ThreadOverrides },
+) {
   const seq = nextId();
   return {
     type: "new_mention" as const,
@@ -363,7 +368,7 @@ export function mention(text: string, opts?: { thread?: ThreadOverrides }) {
       id: `m-${seq}`,
       text,
       is_mention: true,
-      author: { ...DEFAULT_AUTHOR },
+      author: { ...DEFAULT_AUTHOR, ...opts?.author },
     },
   };
 }
@@ -371,7 +376,11 @@ export function mention(text: string, opts?: { thread?: ThreadOverrides }) {
 /** Builds a follow-up subscribed-thread message for a harnessed Slack eval. */
 export function threadMessage(
   text: string,
-  opts?: { thread?: ThreadOverrides; is_mention?: boolean },
+  opts?: {
+    author?: AuthorOverrides;
+    thread?: ThreadOverrides;
+    is_mention?: boolean;
+  },
 ) {
   const seq = nextId();
   return {
@@ -386,7 +395,7 @@ export function threadMessage(
       id: `m-${seq}`,
       text,
       is_mention: opts?.is_mention ?? false,
-      author: { ...DEFAULT_AUTHOR },
+      author: { ...DEFAULT_AUTHOR, ...opts?.author },
     },
   };
 }

--- a/packages/junior-github/skills/github-issues/SKILL.md
+++ b/packages/junior-github/skills/github-issues/SKILL.md
@@ -54,11 +54,11 @@ Follow [references/research-rules.md](references/research-rules.md) for cross-ty
 - Generalize session framing — strip channel references, slash commands, Slack thread IDs, user @mentions, and transcript fragments; replace with the underlying technical problem.
 - Compress source material. Research notes, hypotheses, or transcripts become a short summary + scoped bullets — never paste raw investigation into the body.
 - Do not add desired outcome, expected behavior, or acceptance criteria unless the thread explicitly requests them.
-- When the request originated from a Slack thread or any on-behalf-of context, append a final line `Action taken on behalf of <name>.` using the user's real name.
+- When the request originated from a Slack thread or any on-behalf-of context, append a final line `Action taken on behalf of <name>.` using the action requester's real name. The action requester is the current `<requester>` or the person who explicitly asked you to create/update the issue, not necessarily the original reporter.
 
 **Attribution:**
 
-- Mention who raised the issue when clear from the thread.
+- Mention who raised the issue when clear from the thread. If the reporter differs from the action requester, keep them separate with durable body text such as `Reported by Alice.` or `Raised by Alice during incident triage.`
 - Attach screenshots from the thread as image links when present.
 - Include code snippets, related issues, and related PRs only when they materially improve the issue.
 
@@ -67,7 +67,7 @@ Follow [references/research-rules.md](references/research-rules.md) for cross-ty
 Before running the `gh` create/edit command, check each gate. If any fails, revise and re-check before executing:
 
 - Title length ≤ 60 characters.
-- Delegated-action footer is the last line when applicable, using the user's real name.
+- Delegated-action footer is the last line when applicable, using the action requester's real name, not the reporter's name unless they are the same person.
 - No session framing remains (channel refs, slash commands, @mentions, Slack thread IDs).
 - Body structure matches complexity — no empty sections, no restated title, no raw research dump.
 

--- a/packages/junior-github/skills/github-issues/references/issue-examples.md
+++ b/packages/junior-github/skills/github-issues/references/issue-examples.md
@@ -69,6 +69,26 @@ Good scope — quantified and specific:
 >
 > Action taken on behalf of Jane Doe.
 
+## Distinct reporter/requester example
+
+Bad attribution:
+
+> The bot resolved the review thread even though the warning still applies.
+>
+> Action taken on behalf of Bojan Oro.
+
+Good attribution:
+
+> Warden can resolve its own review thread even when the underlying warning still appears valid and the PR remains blocked.
+>
+> Reported by Bojan Oro.
+>
+> - Observed on a PR where Warden left a review comment about a missing backport
+> - The review thread was later marked resolved by the bot
+> - The PR still showed a blocking warning
+>
+> Action taken on behalf of David Cramer.
+
 ## Feature example
 
 Bad framing:
@@ -111,5 +131,6 @@ Good framing — current state, gap, options:
 - Confident fix claims without root-cause evidence
 - Speculative detail mixed into verified facts
 - Dumping a list of URLs without inline context
-- Session-specific content (user names, slash commands, channel references)
+- Session-specific content (slash commands, channel references, raw transcript framing, or unrelated user chatter)
+- Conflating reporter and action requester when they differ
 - Missing delegated attribution footer on user-requested issue creation

--- a/packages/junior-linear/skills/linear/SKILL.md
+++ b/packages/junior-linear/skills/linear/SKILL.md
@@ -46,9 +46,9 @@ Classify the work as `bug`, `feature`, or `task`. Shape the title and body per [
 - Generalize session framing — strip channel references, slash commands, Slack thread IDs, user @mentions, and transcript fragments; replace with the underlying engineering problem.
 - Compress source material. Research notes, hypotheses, or transcripts become a short summary + scoped bullets — never paste raw investigation into the body.
 - Do not add desired outcome, expected behavior, or acceptance criteria unless the thread explicitly requests them.
-- When the request originated from a Slack thread or any on-behalf-of context, append a final line `Action taken on behalf of <name>.` using the user's real name.
+- When the request originated from a Slack thread or any on-behalf-of context, append a final line `Action taken on behalf of <name>.` using the action requester's real name. The action requester is the current `<requester>` or the person who explicitly asked you to create/update the issue, not necessarily the original reporter.
 
-Attribute the reporter by name when clear from the thread (e.g. "Raised by Alice during incident triage") — do not reference Slack channels, threads, or conversation metadata. Attach screenshots from the thread as image links when present. Preserve relevant URLs (Sentry, GitHub, docs, repro links) inline — do not dump a link list.
+Attribute the reporter by name when clear from the thread (e.g. "Raised by Alice during incident triage"). If the reporter differs from the action requester, keep them separate with durable body text such as `Reported by Alice.` — do not reference Slack channels, threads, or conversation metadata. Attach screenshots from the thread as image links when present. Preserve relevant URLs (Sentry, GitHub, docs, repro links) inline — do not dump a link list.
 
 4. Set optional Linear fields literally:
 
@@ -59,7 +59,7 @@ Attribute the reporter by name when clear from the thread (e.g. "Raised by Alice
 5. Verify draft before mutating:
 
 - Title length ≤ 60 characters.
-- Delegated-action footer is the last line when applicable.
+- Delegated-action footer is the last line when applicable, using the action requester's real name, not the reporter's name unless they are the same person.
 - No session framing remains (channel refs, slash commands, @mentions, Slack thread IDs).
 - Body structure matches complexity — no empty sections, no restated title, no raw research dump.
 

--- a/packages/junior-linear/skills/linear/references/issue-examples.md
+++ b/packages/junior-linear/skills/linear/references/issue-examples.md
@@ -65,6 +65,20 @@ Good body:
 >
 > Action taken on behalf of Carol.
 
+## Distinct reporter/requester
+
+Good body:
+
+> The reviewer bot resolved its own warning even though the underlying issue still appeared valid.
+>
+> Reported by Bojan Oro.
+>
+> - Original warning still applied after the thread was resolved
+> - The related PR remained blocked
+> - The bot should not resolve review threads without confirming the condition cleared
+>
+> Action taken on behalf of David Cramer.
+
 ## Anti-patterns
 
 - Adding "Expected behavior" or "Desired outcome" when the thread didn't state one
@@ -72,3 +86,4 @@ Good body:
 - Restating the title as the first sentence of the body
 - Including fix suggestions when the thread only describes the problem
 - Dumping a list of URLs without inline context
+- Conflating the reporter with the action requester when they differ


### PR DESCRIPTION
Clarify issue-writing skills so delegated-action footers use the person who explicitly requested the issue action, while the original reporter is attributed separately in the issue body when they differ.

This adds a GitHub eval regression for a multi-author Slack thread where one person reports the problem and another asks Junior to file the issue. The same role distinction is mirrored in the Linear issue-writing guidance so provider issue creation stays consistent.

Fixes #263