### PR TITLE
ci: Prevent release workflow input injection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,9 +59,11 @@ jobs:
 
       - name: Calculate version
         id: version
+        env:
+          BUMP: ${{ inputs.bump }}
         run: |
           CURRENT=$(node -p "require('./packages/junior/package.json').version")
-          NEW=$(npx semver -i ${{ inputs.bump }} $CURRENT)
+          NEW=$(npx semver -i "$BUMP" "$CURRENT")
           echo "current=$CURRENT" >> $GITHUB_OUTPUT
           echo "new=$NEW" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Move the release workflow's bump input into step environment before reading it from the shell. This avoids direct workflow_dispatch input interpolation in a run block while keeping the release version calculation behavior unchanged.

Refs https://github.com/getsentry/warden/pull/277