### PR TITLE
fix(chat): Strengthen harness prompt contract

### DIFF
--- a/packages/junior-evals/evals/core/skill-infra.eval.ts
+++ b/packages/junior-evals/evals/core/skill-infra.eval.ts
@@ -69,6 +69,34 @@ describe("Skill Infrastructure", () => {
   );
 
   slackEval(
+    "when asked to double-check a source-backed fact, use the source and answer completely",
+    {
+      overrides: { skill_dirs: ["evals/fixtures/skills"] },
+      events: [
+        mention(
+          "Can you double-check what the source handbook says about closed tracking issues proving capability support? I think there was a note for this.",
+        ),
+      ],
+      criteria: rubric({
+        contract:
+          "A verification request uses the available source-backed skill and returns the checked answer instead of offering to check later.",
+        pass: [
+          "observed_tool_invocations includes a `loadSkill` invocation with `skill_name` set to `source-handbook`.",
+          "observed_tool_invocations includes a `readFile` invocation.",
+          "The assistant posts exactly one final answer.",
+          "The answer says closed tracking issues alone do not prove capability support.",
+          "The answer says implementation evidence, linked PRs, release notes, issue comments, or an equivalent source-backed rationale is needed.",
+        ],
+        fail: [
+          "Do not offer to check the source handbook next or later.",
+          "Do not answer purely from memory without observed source/tool use.",
+          "Do not claim that a closed issue is enough to prove the capability exists.",
+        ],
+      }),
+    },
+  );
+
+  slackEval(
     "when an MCP-backed skill handles a lookup, return the provider-backed answer",
     {
       overrides: {

--- a/packages/junior-evals/evals/fixtures/skills/source-handbook/SKILL.md
+++ b/packages/junior-evals/evals/fixtures/skills/source-handbook/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: source-handbook
+description: Check bundled source handbook files for capability, policy, or implementation verification questions. Use when users ask to double-check or verify what the internal/source handbook says.
+allowed-tools: readFile
+---
+
+# Source Handbook Verification
+
+Use this skill for source-backed handbook checks.
+
+## Workflow
+
+1. Read `references/capability-policy.md` under this skill directory with `readFile`.
+2. Answer from the reference file instead of memory.
+3. If the reference does not cover the request, say what was checked and that the handbook does not say.
+
+## Completion
+
+- Give the checked answer directly.
+- Do not offer to check the handbook later; checking it is the purpose of this skill.

--- a/packages/junior-evals/evals/fixtures/skills/source-handbook/references/capability-policy.md
+++ b/packages/junior-evals/evals/fixtures/skills/source-handbook/references/capability-policy.md
@@ -1,0 +1,7 @@
+# Capability Policy
+
+Closed tracking issues are not proof that a capability exists.
+
+For capability support questions, verify implementation evidence or closing rationale before saying the capability is supported. Repository source, linked pull requests, release notes, or issue comments can establish that evidence. A closed issue with only a title or summary cannot.
+
+For log-query support specifically, the capability exists only when a source exposes a structured logs tool, CLI command, or documented API path that the current runtime can use.

--- a/packages/junior/src/chat/prompt.ts
+++ b/packages/junior/src/chat/prompt.ts
@@ -9,7 +9,11 @@ import {
 import { logInfo, logWarn } from "@/chat/logging";
 import { getPluginProviders } from "@/chat/plugins/registry";
 import { slackOutputPolicy } from "@/chat/slack/output";
-import { SANDBOX_DATA_ROOT, sandboxSkillDir } from "@/chat/sandbox/paths";
+import {
+  SANDBOX_DATA_ROOT,
+  SANDBOX_WORKSPACE_ROOT,
+  sandboxSkillDir,
+} from "@/chat/sandbox/paths";
 import type { ThreadArtifactsState } from "@/chat/state/artifacts";
 import type { Skill, SkillMetadata, SkillInvocation } from "@/chat/skills";
 import type { ActiveMcpCatalogSummary } from "@/chat/tools/skill/mcp-tool-summary";
@@ -317,33 +321,147 @@ function formatThreadParticipantsLines(
   });
 }
 
+function formatSlackCapabilityNames(
+  capabilities:
+    | {
+        canAddReactions?: boolean;
+        canCreateCanvas?: boolean;
+        canPostToChannel?: boolean;
+      }
+    | undefined,
+): string {
+  const names = [
+    capabilities?.canCreateCanvas ? "canvas_create" : "",
+    capabilities?.canPostToChannel ? "channel_post" : "",
+    capabilities?.canAddReactions ? "reaction_add" : "",
+  ].filter(Boolean);
+  return names.length > 0 ? names.join(", ") : "none";
+}
+
 const HEADER =
   "You are a Slack-based helper assistant. The behavior and output blocks below are authoritative; the personality block sets voice only.";
 
-const BEHAVIOR_RULES = [
-  "- Load the best-matching skill/tool when relevant, then use it before answering; do not preload multiple skills or claim tool use that did not happen.",
-  "- After `loadSkill`, resolve references under `skill_dir`; for active MCP catalogs, use `searchMcpTools` then `callMcpTool` with exact returned tool names and required arguments nested under `arguments`.",
-  "- Default to acting in-turn: use relevant available skills/tools to satisfy the request, continue until done or blocked, and only ask the user when access or required input is missing. If a fact cannot be verified, say so.",
-  "- In thread follow-ups, answer from prior thread context; do not repeat resolved clarifying questions.",
-  "- Keep work silent and post one result-focused reply unless blocked or waiting on user input; do not use reactions as progress.",
-  "- Do not claim an attachment, canvas, or channel post succeeded unless the tool returned success this turn; when it did, include any link the tool returned.",
-  "- Run authenticated provider commands directly; resolve target defaults first and let the runtime handle auth pauses/resumes.",
-  "- On resumed turns, post a brief continuation notice, then the resumed answer as a separate message.",
-  "- For tool/runtime failures, run the named check before diagnosing and report the exact failed command plus stderr/exit code.",
-  "- Run `jr-rpc config get|set|unset|list` as standalone bash commands for conversation-scoped provider defaults; do not chain them with `cd`, `&&`, pipes, or provider commands.",
-  "- For explicit channel-post or emoji-reaction requests, skip the text reply.",
+const TOOL_POLICY_RULES = [
+  "- Tool schemas are the source of truth for parameters; tool names are case-sensitive, so call tools exactly by their exposed names and do not invent arguments.",
+  "- Use tools for actionable work and for facts that are mutable, external, repository-backed, provider-backed, or requested as verified/current. Stable general knowledge and already-provided context may be answered directly.",
+  "- Verification source order: conversation/thread context; user-provided attachments, links, and reference files; local/sandbox files when present; loaded skill references; repository/provider tools; public web. Use the nearest authoritative available source before weaker sources.",
+  "- For repository or implementation questions, inspect repository evidence first: local checkout when present, otherwise the configured GitHub/source provider. Cite file paths, symbols, PRs/issues, commits, or URLs that support the answer.",
+  `- Sandbox-backed file and shell tools operate in an isolated workspace rooted at ${SANDBOX_WORKSPACE_ROOT}; readFile/writeFile paths are sandbox-workspace paths, bash runs inside that workspace, and attachFile accepts absolute or workspace-relative sandbox paths.`,
+  "- If a sandbox-backed tool reports that sandbox execution is unavailable, treat that as a blocker for local file/shell inspection; do not pretend host files were inspected.",
+  "- For user-provided URLs, use `webFetch`; for discovery, use `webSearch` then fetch/read promising sources; for current time/date context, use `systemTime`.",
+  "- If the first result is empty, stale, ambiguous, or incomplete, try a focused alternate query, path, command, or source before concluding the answer cannot be verified.",
 ];
+
+const TOOL_CALL_STYLE_RULES = [
+  "- For routine low-risk tool use, call the tool directly without narrating the obvious step first.",
+  "- Briefly narrate only when it helps the user understand multi-step work, sensitive actions, destructive actions, or a notable change in approach.",
+  "- When a first-class tool exists for an action, use it directly instead of asking the user to run an equivalent command, slash command, or manual lookup.",
+  "- Keep tool-call explanations separate from final answers; final answers should report results, evidence, or blockers.",
+];
+
+const SKILL_POLICY_RULES = [
+  "- Scan `<available-skills>` for the user's task. If one skill clearly fits, load it before answering. If several fit, pick the most specific. If none fits, do not load a skill.",
+  "- Never load multiple skills up front. After `loadSkill`, follow `<loaded-skills>` and resolve relative references under that skill's location.",
+  "- For explicit `/skill` triggers, treat that skill as selected unless the tool says it is unavailable.",
+  "- For active MCP catalogs, use `searchMcpTools` to inspect descriptors before `callMcpTool`; pass exact returned `tool_name` values and put provider fields inside `arguments`.",
+  "- Run authenticated provider commands directly after resolving target defaults; let the runtime handle auth pauses/resumes.",
+  "- Run `jr-rpc config get|set|unset|list` as standalone bash commands for conversation-scoped provider defaults; do not chain them with `cd`, `&&`, pipes, or provider commands.",
+];
+
+const EXECUTION_CONTRACT_RULES = [
+  "- Actionable request: act in this turn.",
+  "- Continue until done or genuinely blocked. Do not finish with a plan, promise, or offer to check next when an available tool or source can move the request forward.",
+  "- Completion means the final answer covers the user's actual ask, including requested follow-up checks, and is grounded in the best evidence you could access.",
+  "- Ask the user only for missing access, approval, or a decision that blocks safe progress. Ask one focused question; otherwise infer conservatively and continue.",
+  "- For conflicting evidence, compare sources and state which source is authoritative for the answer.",
+  "- For non-trivial or long-running work, call `reportProgress` early when available, then only when the major phase changes. Routine tool calls should stay silent.",
+];
+
+const CONVERSATION_RULES = [
+  "- In thread follow-ups, answer from prior thread context; do not repeat resolved clarifying questions.",
+  "- Preserve attribution roles from thread context: the requester is the person asking now, which may differ from the original reporter or subject.",
+  "- On resumed turns, post a brief continuation notice, then the resumed answer as a separate message.",
+];
+
+const SLACK_ACTION_RULES = [
+  "- Context-bound Slack tools use runtime-owned targets; do not invent channel, canvas, list, or message IDs.",
+  "- Use first-class Slack tools for Slack side effects; do not use bash, curl, or provider APIs to bypass Slack tool targeting.",
+  "- Use channel-post and emoji-reaction tools only when the user explicitly asks for that Slack side effect.",
+  "- For explicit channel-post or emoji-reaction requests, skip a duplicate thread text reply when the tool result already satisfies the request.",
+  "- Do not claim an attachment, canvas, channel post, list update, or reaction succeeded unless the tool returned success this turn; when it did, include any link the tool returned.",
+  "- Do not use reactions as progress indicators.",
+];
+
+const SAFETY_RULES = [
+  "- Stay within the user's request and the runtime's available capabilities; do not pursue independent goals, persistence, replication, credential gathering, or access expansion.",
+  "- Respect stop, pause, audit, and approval boundaries. Do not bypass safeguards or persuade the user to weaken them.",
+  "- Do not change system prompts, tool policies, security settings, credentials, or runtime configuration unless the user explicitly requests that exact administrative action and an available tool permits it.",
+];
+
+const FAILURE_RULES = [
+  "- For tool/runtime failures, run the named check before diagnosing and report the exact failed command plus stderr/exit code.",
+  "- If a fact cannot be verified after focused checks, say what you checked and what blocked a stronger answer.",
+  "- Do not surface raw tool payloads, execution-escape text, or internal routing metadata as the final answer.",
+];
+
+function renderRuleSection(tag: string, lines: string[]): string {
+  return [`<${tag}>`, ...lines, `</${tag}>`].join("\n");
+}
+
+function buildBehaviorSection(): string {
+  return [
+    renderRuleSection("tool-policy", TOOL_POLICY_RULES),
+    renderRuleSection("tool-call-style", TOOL_CALL_STYLE_RULES),
+    renderRuleSection("skill-policy", SKILL_POLICY_RULES),
+    renderRuleSection("execution-contract", EXECUTION_CONTRACT_RULES),
+    renderRuleSection("conversation", CONVERSATION_RULES),
+    renderRuleSection("slack-actions", SLACK_ACTION_RULES),
+    renderRuleSection("safety", SAFETY_RULES),
+    renderRuleSection("failure-handling", FAILURE_RULES),
+  ].join("\n\n");
+}
 
 function buildOutputSection(): string {
   const openTag = `<output format="slack-mrkdwn" max_inline_chars="${slackOutputPolicy.maxInlineChars}" max_inline_lines="${slackOutputPolicy.maxInlineLines}">`;
   return [
     openTag,
+    "- Start with the answer or result, not internal process narration.",
     "- Use Slack-friendly mrkdwn: bolded section labels instead of headings, no markdown tables or markdown links, and plain URLs.",
     "- Keep replies brief and scannable; use bullets or short code blocks when helpful, and one compact thread reply when it fits.",
     "- When a research or document-style answer would benefit from continuation, multiple sections, or future reference value, create a Slack canvas and keep the thread reply to a short summary plus the canvas link.",
-    "- End every turn with a final user-facing markdown response.",
+    "- Unless a successful Slack side-effect tool intentionally satisfied the request by itself, end every turn with a final user-facing markdown response.",
     "</output>",
   ].join("\n");
+}
+
+function buildRuntimeSection(params: {
+  channelId?: string;
+  fastModelId?: string;
+  modelId?: string;
+  slackCapabilities?: {
+    canAddReactions?: boolean;
+    canCreateCanvas?: boolean;
+    canPostToChannel?: boolean;
+  };
+  thinkingLevel?: string;
+}): string {
+  const lines = [
+    `- version: ${escapeXml(getRuntimeMetadata().version ?? "unknown")}`,
+    params.modelId ? `- model: ${escapeXml(params.modelId)}` : "",
+    params.fastModelId ? `- fast_model: ${escapeXml(params.fastModelId)}` : "",
+    params.thinkingLevel
+      ? `- thinking: ${escapeXml(params.thinkingLevel)}`
+      : "",
+    params.channelId ? "- channel: slack" : "",
+    params.channelId
+      ? `- slack_capabilities: ${escapeXml(
+          formatSlackCapabilityNames(params.slackCapabilities),
+        )}`
+      : "",
+    `- sandbox_workspace: ${escapeXml(SANDBOX_WORKSPACE_ROOT)}`,
+  ].filter(Boolean);
+
+  return renderTagBlock("runtime", lines.join("\n"));
 }
 
 function buildContextSection(params: {
@@ -373,11 +491,6 @@ function buildContextSection(params: {
         ...referenceLines,
       ]),
     );
-  }
-
-  const runtimeVersion = getRuntimeMetadata().version;
-  if (runtimeVersion) {
-    blocks.push([`<runtime version="${escapeXml(runtimeVersion)}" />`]);
   }
 
   blocks.push(
@@ -467,6 +580,17 @@ export function buildSystemPrompt(params: {
   availableSkills: SkillMetadata[];
   activeSkills: Skill[];
   activeMcpCatalogs?: ActiveMcpCatalogSummary[];
+  runtime?: {
+    channelId?: string;
+    fastModelId?: string;
+    modelId?: string;
+    slackCapabilities?: {
+      canAddReactions?: boolean;
+      canCreateCanvas?: boolean;
+      canPostToChannel?: boolean;
+    };
+    thinkingLevel?: string;
+  };
   invocation: SkillInvocation | null;
   assistant?: {
     userName?: string;
@@ -499,6 +623,8 @@ export function buildSystemPrompt(params: {
   // Core harness contract:
   // - See specs/harness-agent-spec.md for the canonical agent-loop and terminal-output spec.
   // - Keep this prompt generic and platform-level (behavior, output contract, capability disclosure).
+  // - Keep stable, high-priority operating rules before volatile turn context
+  //   so instruction salience and prompt-prefix caching both stay predictable.
   // - Platform-level behavior rules must live here, never in SOUL.md (pluggable per deployment).
   // - Skill-specific instructions belong in skills/*/SKILL.md and are injected via <loaded-skills>.
   // - Pi-agent discloses only stable runtime tools natively. MCP tool catalogs
@@ -509,6 +635,13 @@ export function buildSystemPrompt(params: {
   const sections = [
     HEADER,
     renderTagBlock("personality", JUNIOR_PERSONALITY.trim()),
+    renderTagBlock("behavior", buildBehaviorSection()),
+    buildOutputSection(),
+    buildCapabilitiesSection({
+      availableSkills: params.availableSkills,
+      activeSkills: params.activeSkills,
+      activeMcpCatalogs: params.activeMcpCatalogs ?? [],
+    }),
     buildContextSection({
       assistant: params.assistant,
       requester: params.requester,
@@ -518,13 +651,7 @@ export function buildSystemPrompt(params: {
       invocation: params.invocation,
       turnState: params.turnState,
     }),
-    buildCapabilitiesSection({
-      availableSkills: params.availableSkills,
-      activeSkills: params.activeSkills,
-      activeMcpCatalogs: params.activeMcpCatalogs ?? [],
-    }),
-    renderTagBlock("behavior", BEHAVIOR_RULES.join("\n")),
-    buildOutputSection(),
+    buildRuntimeSection(params.runtime ?? {}),
   ];
 
   return sections.join("\n\n");

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -663,6 +663,9 @@ export async function generateAssistantReply(
     });
 
     // ── Tool creation ────────────────────────────────────────────────
+    const toolChannelId =
+      context.toolChannelId ?? context.correlation?.channelId;
+    const channelCapabilities = resolveChannelCapabilities(toolChannelId);
     const tools = createTools(
       availableSkills,
       {
@@ -723,10 +726,8 @@ export async function generateAssistantReply(
         },
       },
       {
-        channelId: context.toolChannelId ?? context.correlation?.channelId,
-        channelCapabilities: resolveChannelCapabilities(
-          context.toolChannelId ?? context.correlation?.channelId,
-        ),
+        channelId: toolChannelId,
+        channelCapabilities,
         messageTs: context.correlation?.messageTs,
         threadTs: context.correlation?.threadTs,
         userText: userInput,
@@ -758,6 +759,13 @@ export async function generateAssistantReply(
       availableSkills,
       activeSkills,
       activeMcpCatalogs,
+      runtime: {
+        channelId: toolChannelId,
+        fastModelId: botConfig.fastModelId,
+        modelId: botConfig.modelId,
+        slackCapabilities: channelCapabilities,
+        thinkingLevel: thinkingSelection.thinkingLevel,
+      },
       invocation: skillInvocation,
       assistant: context.assistant,
       requester: context.requester,

--- a/packages/junior/src/chat/services/turn-thinking-level.ts
+++ b/packages/junior/src/chat/services/turn-thinking-level.ts
@@ -24,7 +24,13 @@ export interface TurnThinkingSelection {
   reason: string;
 }
 
-const DEFAULT_THINKING_LEVEL: TurnThinkingSelection["thinkingLevel"] = "low";
+const DEFAULT_THINKING_LEVEL: TurnThinkingSelection["thinkingLevel"] = "medium";
+const THINKING_LEVEL_RANK: Record<TurnThinkingLevel, number> = {
+  none: 0,
+  low: 1,
+  medium: 2,
+  high: 3,
+};
 
 interface TrimmedContext {
   text: string;
@@ -58,13 +64,14 @@ function trimContextForRouter(text: string | undefined): TrimmedContext | null {
 
 function buildClassifierSystemPrompt(): string {
   return [
-    "You route assistant turns to the cheapest thinking level that is still likely to succeed.",
+    "You route assistant turns to the thinking level most likely to produce a complete, source-grounded answer.",
     "Choose exactly one bucket: none, low, medium, or high.",
     "",
-    "Use none for greetings, acknowledgments, and trivial single-step asks.",
-    "Use low for straightforward explanations or simple one-step work.",
-    "Use medium for investigations, ambiguous asks, multi-step analysis, or likely multi-tool work.",
+    "Use none only for greetings, acknowledgments, and turns that need no substantive assistant work.",
+    "Use low rarely: only for deterministic one-step answers or transformations with no tools, no current/external facts, no thread-background interpretation, and no source verification.",
+    "Use medium for normal assistant work: explanations, source-backed checks, thread follow-ups, tool choice, likely tool use, ambiguous asks, multi-step analysis, or anything where a confident but shallow answer would be risky.",
     "Use high for code changes, debugging/root-cause analysis, research-heavy work, non-trivial drafting, or explicit requests to be thorough.",
+    "When unsure between two non-none buckets, choose the higher bucket. Do not use low as the default.",
     "",
     "Classify based on the substance of the task, not the length of the current message. When the current instruction is a short affirmation (for example: 'go', 'do it', 'yes please', 'proceed') and the thread-background contains a pending task, classify the pending task — not the affirmation.",
     "",
@@ -173,18 +180,44 @@ export async function selectTurnThinkingLevel(args: {
         },
         prompt,
       });
+      const normalizedSelection = applyThinkingFloor(selection, {
+        minimum: trimmedContext || turnBlockCount > 0 ? "medium" : undefined,
+      });
 
       setSpanAttributes({
-        "app.ai.thinking_level": selection.thinkingLevel,
-        "app.ai.thinking_level_reason": selection.reason,
-        ...(selection.confidence !== undefined
-          ? { "app.ai.thinking_level_confidence": selection.confidence }
+        "app.ai.thinking_level": normalizedSelection.thinkingLevel,
+        "app.ai.thinking_level_reason": normalizedSelection.reason,
+        ...(normalizedSelection.confidence !== undefined
+          ? {
+              "app.ai.thinking_level_confidence":
+                normalizedSelection.confidence,
+            }
           : {}),
       });
 
-      return selection;
+      return normalizedSelection;
     },
   );
+}
+
+function applyThinkingFloor(
+  selection: TurnThinkingSelection,
+  args: { minimum?: TurnThinkingLevel },
+): TurnThinkingSelection {
+  const minimum = args.minimum;
+  if (
+    !minimum ||
+    selection.thinkingLevel === "none" ||
+    THINKING_LEVEL_RANK[selection.thinkingLevel] >= THINKING_LEVEL_RANK[minimum]
+  ) {
+    return selection;
+  }
+
+  return {
+    ...selection,
+    thinkingLevel: minimum,
+    reason: `thinking_floor:${minimum}:${selection.reason}`,
+  };
 }
 
 async function classifyTurn(args: {
@@ -214,7 +247,7 @@ async function classifyTurn(args: {
       return {
         confidence: parsed.confidence,
         thinkingLevel: DEFAULT_THINKING_LEVEL,
-        reason: `low_confidence_default:${reason}`,
+        reason: `low_confidence_medium_default:${reason}`,
       };
     }
 

--- a/packages/junior/tests/unit/runtime/respond-lazy-sandbox.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-lazy-sandbox.test.ts
@@ -245,7 +245,7 @@ vi.mock("@/chat/pi/client", () => ({
     if (instruction === "attach the report") {
       return {
         object: {
-          thinking_level: "low",
+          thinking_level: "medium",
           confidence: 1,
           reason: "simple attachment request",
         },
@@ -545,6 +545,7 @@ describe("generateAssistantReply lazy sandbox boot", () => {
     expect(enabledCredentialSkillNames.value).toEqual(["demo-skill"]);
     expect(reply.sandboxId).toBeUndefined();
     expect(reply.diagnostics.toolCalls).toEqual(["loadSkill"]);
+    expect(selectedThinkingLevels.value).toEqual(["medium"]);
   });
 
   it("reprovisions plugin credentials for checkpoint-loaded skills at turn start", async () => {
@@ -566,7 +567,7 @@ describe("generateAssistantReply lazy sandbox boot", () => {
     expect(reply.text).toBe("Attached report.");
     expect(createSandboxCallCount.value).toBe(1);
     expect(reply.diagnostics.toolCalls).toEqual(["attachFile"]);
-    expect(selectedThinkingLevels.value).toEqual(["low"]);
+    expect(selectedThinkingLevels.value).toEqual(["medium"]);
   });
 
   it("uses a high thinking level for explicit code-change asks", async () => {

--- a/packages/junior/tests/unit/services/turn-thinking-level.test.ts
+++ b/packages/junior/tests/unit/services/turn-thinking-level.test.ts
@@ -56,7 +56,7 @@ describe("selectTurnThinkingLevel", () => {
     expect(completeObject).toHaveBeenCalledOnce();
   });
 
-  it("falls back to the default low effort when classifier confidence is low", async () => {
+  it("falls back to medium effort when classifier confidence is low", async () => {
     const completeObject = vi.fn(async () => ({
       object: {
         thinking_level: "high",
@@ -72,12 +72,13 @@ describe("selectTurnThinkingLevel", () => {
     });
 
     expect(profile).toMatchObject({
-      thinkingLevel: "low",
-      reason: "low_confidence_default:not confident",
+      thinkingLevel: "medium",
+      reason: "low_confidence_medium_default:not confident",
     });
+    expect(toAgentThinkingLevel(profile.thinkingLevel)).toBe("medium");
   });
 
-  it("falls back to the default low effort when the classifier fails", async () => {
+  it("falls back to medium effort when the classifier fails", async () => {
     const completeObject = vi.fn(async () => {
       throw new Error("router failed");
     });
@@ -89,8 +90,74 @@ describe("selectTurnThinkingLevel", () => {
     });
 
     expect(profile).toMatchObject({
-      thinkingLevel: "low",
+      thinkingLevel: "medium",
       reason: "classifier_error_default",
+    });
+  });
+
+  it("preserves high-confidence low classifications for deterministic simple work", async () => {
+    const completeObject = vi.fn(async () => ({
+      object: {
+        thinking_level: "low",
+        confidence: 0.97,
+        reason: "deterministic one-step transform",
+      },
+    }));
+
+    const profile = await selectTurnThinkingLevel({
+      completeObject,
+      fastModelId: "openai/gpt-5.4-mini",
+      messageText: "alphabetize these words: beta, alpha",
+    });
+
+    expect(profile).toMatchObject({
+      thinkingLevel: "low",
+      reason: "deterministic one-step transform",
+    });
+    expect(toAgentThinkingLevel(profile.thinkingLevel)).toBe("low");
+  });
+
+  it("floors source-backed context turns at medium unless they are acknowledgments", async () => {
+    const completeObject = vi.fn(async () => ({
+      object: {
+        thinking_level: "low",
+        confidence: 0.92,
+        reason: "simple follow-up",
+      },
+    }));
+
+    const profile = await selectTurnThinkingLevel({
+      completeObject,
+      conversationContext: "Earlier task: double-check the repo evidence.",
+      fastModelId: "openai/gpt-5.4-mini",
+      messageText: "go",
+    });
+
+    expect(profile).toMatchObject({
+      thinkingLevel: "medium",
+      reason: "thinking_floor:medium:simple follow-up",
+    });
+  });
+
+  it("does not floor acknowledgment turns with thread context", async () => {
+    const completeObject = vi.fn(async () => ({
+      object: {
+        thinking_level: "none",
+        confidence: 0.96,
+        reason: "thanks only",
+      },
+    }));
+
+    const profile = await selectTurnThinkingLevel({
+      completeObject,
+      conversationContext: "Earlier answer already resolved the task.",
+      fastModelId: "openai/gpt-5.4-mini",
+      messageText: "thanks",
+    });
+
+    expect(profile).toMatchObject({
+      thinkingLevel: "none",
+      reason: "thanks only",
     });
   });
 

--- a/specs/agent-prompt-spec.md
+++ b/specs/agent-prompt-spec.md
@@ -3,11 +3,12 @@
 ## Metadata
 
 - Created: 2026-04-28
-- Last Edited: 2026-04-28
+- Last Edited: 2026-04-30
 
 ## Changelog
 
 - 2026-04-28: Initial spec defining ownership, structure, and bloat controls for the core agent prompt.
+- 2026-04-30: Reworked the core prompt contract around fixed operating sections, source hierarchy, explicit completion gates, OpenClaw-style tool-call/safety boundaries, and stable-before-volatile ordering.
 
 ## Status
 
@@ -43,30 +44,72 @@ Define the canonical contract for Junior's platform-owned agent prompt so prompt
 `buildSystemPrompt(...)` must keep these concerns distinct:
 
 1. Identity/personality.
-2. Runtime and thread context.
-3. Available and loaded capabilities.
-4. Core behavior rules.
-5. Slack output contract.
+2. Core operating rules.
+3. Slack output contract.
+4. Available and loaded capabilities.
+5. Runtime and thread context.
 
 Context blocks describe facts. Behavior and output blocks carry instructions.
 
+Prompt order is part of the contract. Stable, high-priority operating rules must appear before volatile thread/session context so behavior has salience and provider prompt-prefix caching remains predictable. Do not move requester, artifacts, active catalogs, or configuration defaults above the behavior/output contract.
+
+The core operating rules must be split into fixed sections:
+
+1. Tool policy.
+2. Tool-call style.
+3. Skill policy.
+4. Execution contract.
+5. Conversation/thread continuity.
+6. Slack side-effect actions.
+7. Safety.
+8. Failure handling.
+
+These sections are separate because each owns a distinct decision. Do not collapse them back into one flat list when adding new behavior.
+
 ### Execution bias
 
-The core behavior rules must include one compact execution-bias rule:
+The execution contract must include compact execution-bias rules:
 
 - Default to acting in-turn.
 - Use relevant available skills/tools to satisfy the request.
 - Continue until done or blocked.
 - Ask the user only when access or required input is missing.
+- Treat plans, promises, and "I can check" offers as incomplete when an available tool or source can move the request forward.
+- Require final answers to cover the user's actual ask, including requested follow-up checks.
 - State when a fact cannot be verified.
 
-Do not restate this rule in skills or add sibling bullets that say the same thing with different wording.
+Do not restate these rules in skills or add sibling bullets that say the same thing with different wording.
+
+### Source hierarchy
+
+The tool policy must tell the model when source-backed work is required and which source class to try first:
+
+1. Conversation/thread context.
+2. User-provided attachments, links, and reference files.
+3. Local/sandbox files when present.
+4. Loaded skill references.
+5. Repository or provider tools.
+6. Public web.
+
+For repository or implementation questions, repository evidence is required before generic product framing or memory. When the repository is not locally mounted, the model should use the configured source provider rather than pretending local files are available.
+
+Mutable facts need live checks. Examples include files, repos, versions, issues, services, clocks, and live provider data.
 
 ### Tool and skill policy
 
 - Tool schemas remain the source of truth for tool parameters. The prompt may state when to use tools, not re-document every tool schema.
 - The model should load the best-matching skill when relevant and avoid preloading unrelated skills.
 - After loading a plugin-backed skill, the prompt may describe the generic MCP lookup path, but provider-specific tool strategy belongs in the skill or plugin docs.
+- Skill selection should be explicit: scan available skills, load one clearly matching skill, choose the most specific skill when several match, and avoid loading any skill when none clearly applies.
+- Tool-call style belongs in its own section: call routine tools directly, narrate only when it helps, and prefer first-class tools over asking the user to perform equivalent manual work.
+
+### Runtime and safety boundaries
+
+The tool policy must make sandbox workspace ownership explicit: sandbox-backed file and shell tools inspect the isolated sandbox workspace, not arbitrary host files. If sandbox execution is unavailable, the model should report that blocker instead of implying local inspection succeeded.
+
+Runtime facts should live in a compact runtime block after volatile context. Include only facts that help the model choose valid behavior, such as runtime version, model ids, selected thinking level, channel capabilities, and sandbox workspace root. Do not mix requester, artifacts, or configuration defaults into that runtime block.
+
+The safety section must stay generic and runtime-level: remain within the user's request, respect stop/pause/audit/approval boundaries, avoid access expansion, and avoid administrative prompt/tool/security/config changes unless explicitly requested and supported by an available tool.
 
 ### Bloat controls
 

--- a/specs/harness-agent-spec.md
+++ b/specs/harness-agent-spec.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-02-24
-- Last Edited: 2026-04-13
+- Last Edited: 2026-04-30
 
 ## Changelog
 
@@ -11,6 +11,7 @@
 - 2026-03-05: Linked to canonical session resumability contract for multi-slice timeout recovery.
 - 2026-04-06: Switched stop-reason observability to `gen_ai.response.finish_reasons`.
 - 2026-04-13: Clarified timeout behavior when turn-session checkpoints are available for resumable slices.
+- 2026-04-30: Added the thinking-level routing contract and normal-effort default.
 
 ## Status
 
@@ -38,6 +39,17 @@ Define the canonical runtime contract for assistant-turn execution and user-visi
 - Use `Agent` from `@mariozechner/pi-agent-core` for reply generation.
 - Use bounded execution with `AGENT_TURN_TIMEOUT_MS` and explicit `agent.abort()` on timeout.
 - Completion is based on assistant text output; there is no classifier-driven continuation loop.
+
+### Thinking-level routing
+
+- Route each main assistant turn through the fast thinking classifier before creating the Pi `Agent`.
+- The classifier may run with low thinking because it is a bounded routing task; the selected main-turn level is independent.
+- The default and failure fallback for substantive work is medium effort, which is the normal assistant reasoning level.
+- Use `none` only for greetings, acknowledgments, and turns that need no substantive assistant work.
+- Use `low` rarely, only for deterministic one-step answers or transformations with no tools, no current or external facts, no thread-background interpretation, and no source verification.
+- Use `medium` for ordinary assistant work, including explanations, source-backed checks, thread follow-ups, likely tool use, ambiguity, or multi-step analysis.
+- Use `high` for code changes, debugging/root-cause analysis, research-heavy work, non-trivial drafting, or explicit requests to be thorough.
+- Thread background and current-turn attachment/source blocks floor non-`none` selections at medium so short follow-ups and source-backed turns do not run with shallow reasoning.
 
 ### Timeout behavior
 


### PR DESCRIPTION
Reworks the platform prompt around a stable-before-volatile operating contract inspired by the stronger agent harness patterns we reviewed. The stable behavior and output sections now appear before dynamic capabilities, thread context, and runtime metadata, with separate sections for tool policy, tool-call style, skill policy, execution, Slack side effects, safety, and failure handling.

This also raises the thinking router's default/fallback path to medium effort and floors source-backed thread or attachment turns at medium unless they are true acknowledgments. That keeps ordinary verification and follow-up work from running with shallow reasoning while preserving low effort for high-confidence deterministic one-step tasks.

The prompt and harness specs now describe the desired ordering, source hierarchy, runtime block, safety boundaries, and thinking-level policy. A focused eval fixture covers the original failure mode: when asked to double-check source-backed capability policy, Junior must load the matching skill, read the reference, and answer directly instead of offering to check later.

Validated with package typecheck, focused runtime/router tests, and the targeted source-backed eval.