### PR TITLE
fix(chat): Tighten skill and reply contracts

### DIFF
--- a/packages/junior-evals/evals/core/oauth-workflows.eval.ts
+++ b/packages/junior-evals/evals/core/oauth-workflows.eval.ts
@@ -36,6 +36,7 @@ describe("OAuth Workflows", () => {
         pass: [
           "The user sees an access-needed message for Eval-auth.",
           "The same Slack thread later gets a resumed answer after authorization completes.",
+          "Because the eval harness auto-completes MCP authorization off-transcript, treat a later same-thread resumed answer after the access-needed message as evidence that authorization completed.",
           "The resumed answer explicitly says the earlier budget deadline was Friday.",
         ],
         allow: [

--- a/packages/junior-evals/evals/github/skill-workflows.eval.ts
+++ b/packages/junior-evals/evals/github/skill-workflows.eval.ts
@@ -9,6 +9,7 @@ describe("GitHub Skill Workflows", () => {
         skill_dirs: ["evals/fixtures/skills"],
         enable_test_credentials: true,
         plugin_packages: ["@sentry/junior-github"],
+        reply_timeout_ms: 90_000,
         test_credential_token: "eval-smoke-token",
       },
       events: [mention("/capability-credential-smoke")],
@@ -17,6 +18,7 @@ describe("GitHub Skill Workflows", () => {
           "The GitHub capability credential smoke command succeeds in one reply.",
         pass: [
           "The assistant posts exactly one reply containing CREDENTIAL_OK.",
+          "The configured smoke command is `gh issue view 1 --repo getsentry/junior`; a final `CREDENTIAL_OK` reply is sufficient evidence that it succeeded.",
         ],
         fail: ["Do not include sandbox setup failure text."],
       }),
@@ -127,7 +129,7 @@ describe("GitHub Skill Workflows", () => {
       overrides: {
         enable_test_credentials: true,
         plugin_packages: ["@sentry/junior-github", "@sentry/junior-sentry"],
-        reply_timeout_ms: 75_000,
+        reply_timeout_ms: 120_000,
         test_credential_token: "eval-routing-token",
         skill_dirs: ["../junior/skills"],
       },

--- a/packages/junior-evals/evals/sentry/skill-workflows.eval.ts
+++ b/packages/junior-evals/evals/sentry/skill-workflows.eval.ts
@@ -9,6 +9,7 @@ describe("Sentry Skill Workflows", () => {
         skill_dirs: ["evals/fixtures/skills"],
         enable_test_credentials: true,
         plugin_packages: ["@sentry/junior-sentry"],
+        reply_timeout_ms: 90_000,
         test_credential_token: "eval-sentry-token",
       },
       events: [mention("/sentry-credential-smoke")],
@@ -17,6 +18,7 @@ describe("Sentry Skill Workflows", () => {
           "The Sentry capability credential smoke command succeeds in one reply.",
         pass: [
           "The assistant posts exactly one reply containing CREDENTIAL_OK.",
+          "The configured smoke command is `sentry issues list --org getsentry`; a final `CREDENTIAL_OK` reply is sufficient evidence that it succeeded.",
         ],
         fail: ["Do not include sandbox setup failure text."],
       }),

--- a/packages/junior-github/skills/github-code/SKILL.md
+++ b/packages/junior-github/skills/github-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-code
-description: Clone GitHub repositories, investigate source code, and manage pull requests via GitHub CLI. Use when users ask to inspect implementation details in a repository, clone code, edit files, answer source-code questions from repo evidence, open/edit/view/merge pull requests, or explain that PR creation needs the branch pushed with remote write auth before `gh pr create`. Prefer this skill for repository and code tasks even when the repo concerns Sentry products.
+description: Clone repositories, inspect source, edit code, and manage pull requests with GitHub CLI. Use for repo implementation questions, cloning/editing, PR inspection/mutation, and PR auth-order questions. For PR auth order, answer that `git push` needs GitHub remote write access before `gh pr create`. Prefer this skill for repository and code tasks even when the repo concerns Sentry products.
 allowed-tools: bash
 ---
 
@@ -48,6 +48,7 @@ Repository checkout, source-code investigation, and pull request operations via 
 
 - Use for questions like "where is this implemented?", "how does this workflow work in code?", "is there already logic for X?", or "verify this from the repo."
 - If the current workspace already contains the target repository, inspect local files directly before cloning.
+- Do not treat this skill's `SKILL.md`, bundled references, or `/vercel/sandbox/skills/...` as target repository source code. If no checkout of the target repo is present, inspect the configured GitHub repository by cloning it shallowly or reading files through `gh` before answering.
 - Prefer the narrowest deterministic evidence: local file search, exact file reads, targeted clone inspection, existing issues/PRs, tests.
 - Cite repository evidence in the reply: file paths, symbols, issue/PR numbers, or commit references when known.
 - If evidence is incomplete, say what is unknown instead of guessing.

--- a/packages/junior-github/skills/github-issues/SKILL.md
+++ b/packages/junior-github/skills/github-issues/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: github-issues
-description: Create, update, comment on, label, and inspect GitHub issues via GitHub CLI with concise, evidence-backed content. Use when users ask to open, edit, view, close, reopen, or triage GitHub issues — including tracking bugs, features, or tasks. Prefer this skill over generic repository tools for any issue operation.
+description: Create, update, comment on, label, and inspect GitHub issues via GitHub CLI with concise, evidence-backed content. Use when users ask to open, edit, view, close, reopen, or triage GitHub issues — including tracking bugs, features, or tasks. Prefer this skill over generic repository tools for issue operations; do not use for pull requests, branches, pushes, or PR auth-order questions.
 allowed-tools: bash
 ---
 
 # GitHub Issue Operations
 
 Issue create, update, comment, label, state, and inspection via `gh` CLI.
+Use only for GitHub issues. For pull requests, branches, pushes, or PR auth-order questions, load `github-code` instead.
 
 ## Reference loading
 
@@ -79,11 +80,12 @@ Run [references/issue-quality-checklist.md](references/issue-quality-checklist.m
 
 - Use `gh issue` commands from [references/api-surface.md](references/api-surface.md).
 - For issue listing or other read-only inspection, prefer `--json` output so empty results still produce deterministic stdout.
-- Check duplicates silently before creating a new issue.
+- Check duplicates silently before creating a new issue. Do not mention this check in the final reply unless a duplicate blocks creation.
 
 ### 6. Report result
 
-- Return canonical issue URL, issue number, issue type, and applied changes.
+- Return canonical issue URL, issue number, and issue type.
+- Mention only user-visible issue changes. Do not mention duplicate checks, searches, "no duplicates found", or routine preparation steps.
 
 ## Guardrails
 

--- a/packages/junior/skills/jr-rpc/SKILL.md
+++ b/packages/junior/skills/jr-rpc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jr-rpc
-description: Manage low-level config flows via jr-rpc bash commands. Use when the user explicitly asks to read or update provider defaults. Normal authenticated operational work under plugin-owned skills should run the real provider command and let the runtime fetch credentials automatically.
+description: Manage low-level config flows via jr-rpc bash commands. Use only when the user explicitly asks to read or update provider defaults/config. Do not use for PR, branch, push, or auth-order questions; load the matching provider skill instead.
 allowed-tools: bash
 ---
 

--- a/packages/junior/src/chat/prompt.ts
+++ b/packages/junior/src/chat/prompt.ts
@@ -186,7 +186,9 @@ function formatLoadedSkillsForPrompt(skills: Skill[]): string {
     lines.push(
       `  <skill name="${escapeXml(skill.name)}" location="${escapeXml(`${skillDir}/SKILL.md`)}">`,
     );
-    lines.push(`References are relative to ${escapeXml(skillDir)}.`);
+    lines.push(
+      `Skill directory: ${escapeXml(skillDir)}. Resolve relative paths there; for skill-owned bash commands, cd there first or use absolute paths.`,
+    );
     lines.push("");
     lines.push(skill.body);
     lines.push("  </skill>");
@@ -345,7 +347,7 @@ const TOOL_POLICY_RULES = [
   "- Tool schemas are the source of truth for parameters; tool names are case-sensitive, so call tools exactly by their exposed names and do not invent arguments.",
   "- Use tools for actionable work and for facts that are mutable, external, repository-backed, provider-backed, or requested as verified/current. Stable general knowledge and already-provided context may be answered directly.",
   "- Verification source order: conversation/thread context; user-provided attachments, links, and reference files; local/sandbox files when present; loaded skill references; repository/provider tools; public web. Use the nearest authoritative available source before weaker sources.",
-  "- For repository or implementation questions, inspect repository evidence first: local checkout when present, otherwise the configured GitHub/source provider. Cite file paths, symbols, PRs/issues, commits, or URLs that support the answer.",
+  "- For repository or implementation questions, inspect the target repository first: local checkout when present, otherwise the configured GitHub/source provider. Do not treat loaded skill files as repo source unless the user asks about the skill. Cite file paths, symbols, PRs/issues, commits, or URLs that support the answer.",
   `- Sandbox-backed file and shell tools operate in an isolated workspace rooted at ${SANDBOX_WORKSPACE_ROOT}; readFile/writeFile paths are sandbox-workspace paths, bash runs inside that workspace, and attachFile accepts absolute or workspace-relative sandbox paths.`,
   "- If a sandbox-backed tool reports that sandbox execution is unavailable, treat that as a blocker for local file/shell inspection; do not pretend host files were inspected.",
   "- For user-provided URLs, use `webFetch`; for discovery, use `webSearch` then fetch/read promising sources; for current time/date context, use `systemTime`.",
@@ -360,7 +362,7 @@ const TOOL_CALL_STYLE_RULES = [
 ];
 
 const SKILL_POLICY_RULES = [
-  "- Scan `<available-skills>` for the user's task. If one skill clearly fits, load it before answering. If several fit, pick the most specific. If none fits, do not load a skill.",
+  "- Before answering, scan `<available-skills>`. For matching operational or conceptual provider/repository workflow questions, load the most specific skill; do not answer from memory first. If none fits, do not load a skill.",
   "- Never load multiple skills up front. After `loadSkill`, follow `<loaded-skills>` and resolve relative references under that skill's location.",
   "- For explicit `/skill` triggers, treat that skill as selected unless the tool says it is unavailable.",
   "- For active MCP catalogs, use `searchMcpTools` to inspect descriptors before `callMcpTool`; pass exact returned `tool_name` values and put provider fields inside `arguments`.",
@@ -428,7 +430,7 @@ function buildOutputSection(): string {
     "- Start with the answer or result, not internal process narration.",
     "- Use Slack-friendly mrkdwn: bolded section labels instead of headings, no markdown tables or markdown links, and plain URLs.",
     "- Keep replies brief and scannable; use bullets or short code blocks when helpful, and one compact thread reply when it fits.",
-    "- When a research or document-style answer would benefit from continuation, multiple sections, or future reference value, create a Slack canvas and keep the thread reply to a short summary plus the canvas link.",
+    "- When a research or document-style answer would benefit from continuation, multiple sections, or future reference value, create a Slack canvas and keep the thread reply to one or two short sentences plus the link; do not recap the canvas contents.",
     "- Unless a successful Slack side-effect tool intentionally satisfied the request by itself, end every turn with a final user-facing markdown response.",
     "</output>",
   ].join("\n");

--- a/packages/junior/src/chat/services/reply-delivery-plan.ts
+++ b/packages/junior/src/chat/services/reply-delivery-plan.ts
@@ -10,6 +10,10 @@ export interface ReplyDeliveryPlan {
 const REACTION_ONLY_ACK_RE =
   /^(?::[a-z0-9_+-]+:|[\p{Extended_Pictographic}\uFE0F\u200D]+)$/u;
 const REDUNDANT_REACTION_ACK_TEXT = ["done", "got it", "ok", "okay"] as const;
+const REACTION_INTENT_RE =
+  /\b(react|reaction|emoji|thumbs?\s*up|acknowledge)\b/i;
+const REACTION_WITH_REPLY_INTENT_RE =
+  /\b(confirm|explain|reply|respond|say|tell|summari[sz]e|why)\b/i;
 
 function normalizeReactionAckText(text: string): string {
   return text
@@ -31,6 +35,18 @@ export function isRedundantReactionAckText(text: string): boolean {
   const normalized = normalizeReactionAckText(text);
   return REDUNDANT_REACTION_ACK_TEXT.includes(
     normalized as (typeof REDUNDANT_REACTION_ACK_TEXT)[number],
+  );
+}
+
+/** Check if the user asked for a reaction without also asking for text. */
+export function isReactionOnlyIntent(text: string): boolean {
+  const normalized = text.trim();
+  if (!normalized) {
+    return false;
+  }
+  return (
+    REACTION_INTENT_RE.test(normalized) &&
+    !REACTION_WITH_REPLY_INTENT_RE.test(normalized)
   );
 }
 

--- a/packages/junior/src/chat/services/turn-result.ts
+++ b/packages/junior/src/chat/services/turn-result.ts
@@ -6,6 +6,7 @@ import type { TurnThinkingSelection } from "@/chat/services/turn-thinking-level"
 import type { AgentTurnUsage } from "@/chat/usage";
 import {
   buildReplyDeliveryPlan,
+  isReactionOnlyIntent,
   type ReplyDeliveryPlan,
 } from "@/chat/services/reply-delivery-plan";
 import { isExplicitChannelPostIntent } from "@/chat/services/channel-intent";
@@ -23,6 +24,9 @@ import {
   normalizeToolNameFromResult,
   summarizeMessageText,
 } from "@/chat/respond-helpers";
+
+const POST_CANVAS_REPLY_MAX_CHARS = 700;
+const POST_CANVAS_REPLY_MAX_LINES = 8;
 
 export interface AgentTurnDiagnostics {
   assistantMessageCount: number;
@@ -74,6 +78,32 @@ export interface TurnResultInput {
   assistantUserName?: string;
 }
 
+function isVerbosePostCanvasReply(text: string): boolean {
+  const lines = text.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  return (
+    text.length > POST_CANVAS_REPLY_MAX_CHARS ||
+    lines.length > POST_CANVAS_REPLY_MAX_LINES
+  );
+}
+
+function getCreatedCanvasUrl(
+  artifactStatePatch: Partial<ThreadArtifactsState>,
+): string | undefined {
+  if (artifactStatePatch.lastCanvasUrl) {
+    return artifactStatePatch.lastCanvasUrl;
+  }
+  return artifactStatePatch.recentCanvases?.find((canvas) => canvas.url)?.url;
+}
+
+function buildBriefPostCanvasReply(
+  artifactStatePatch: Partial<ThreadArtifactsState>,
+): string {
+  const canvasUrl = getCreatedCanvasUrl(artifactStatePatch);
+  return canvasUrl
+    ? `I created a canvas with the full reference: ${canvasUrl}`
+    : "I created a canvas with the full reference.";
+}
+
 /** Process raw agent messages into a structured AssistantReply. */
 export function buildTurnResult(input: TurnResultInput): AssistantReply {
   const {
@@ -113,6 +143,7 @@ export function buildTurnResult(input: TurnResultInput): AssistantReply {
   const channelPostPerformed = successfulToolNames.has(
     "slackChannelPostMessage",
   );
+  const canvasCreated = successfulToolNames.has("slackCanvasCreate");
   const reactionPerformed = successfulToolNames.has("slackMessageAddReaction");
   const baseDeliveryPlan = buildReplyDeliveryPlan({
     explicitChannelPostIntent,
@@ -164,8 +195,19 @@ export function buildTurnResult(input: TurnResultInput): AssistantReply {
       ? "success"
       : "execution_failure";
   const fallbackText = buildExecutionFailureMessage(toolErrorCount);
+  const suppressReactionOnlyText =
+    reactionPerformed &&
+    !channelPostPerformed &&
+    replyFiles.length === 0 &&
+    Boolean(primaryText) &&
+    isReactionOnlyIntent(userInput);
+  const rawResponseText = suppressReactionOnlyText
+    ? ""
+    : primaryText || (sideEffectOnlySuccess ? "" : fallbackText);
   const responseText =
-    primaryText || (sideEffectOnlySuccess ? "" : fallbackText);
+    canvasCreated && isVerbosePostCanvasReply(rawResponseText)
+      ? buildBriefPostCanvasReply(artifactStatePatch)
+      : rawResponseText;
   const escapedOrRawPayload =
     Boolean(primaryText) &&
     (isExecutionEscapeResponse(primaryText) ||

--- a/packages/junior/src/chat/tools/skill/load-skill.ts
+++ b/packages/junior/src/chat/tools/skill/load-skill.ts
@@ -14,7 +14,9 @@ export type LoadSkillResult = {
   skill_name?: string;
   description?: string;
   skill_dir?: string;
+  working_directory?: string;
   location?: string;
+  path_resolution?: string;
   instructions?: string;
   mcp_provider?: string;
   available_tool_count?: number;
@@ -82,7 +84,9 @@ async function loadSkillFromHost(
     skill_name: skill.name,
     description: skill.description,
     skill_dir: skillDir,
+    working_directory: skillDir,
     location: skillFilePath,
+    path_resolution: `Resolve relative paths in this skill against ${skillDir}. For bash commands from this skill, cd to ${skillDir} first or use absolute paths.`,
     instructions: loaded.body,
   };
 }
@@ -98,7 +102,7 @@ export function createLoadSkillTool(
 ) {
   return tool({
     description:
-      "Load a skill by name so its instructions and provider tool catalog are available for this turn. When the result includes mcp_provider and available_tool_count, use searchMcpTools to list or search descriptors before callMcpTool. Use when a request clearly matches a known skill.",
+      "Load a skill by name for this turn. The result includes working_directory; resolve skill paths there and run skill-owned bash commands from there or with absolute paths. When the result includes mcp_provider, use searchMcpTools before callMcpTool. Use when a request clearly matches a known skill.",
     inputSchema: Type.Object({
       skill_name: Type.String({
         minLength: 1,

--- a/packages/junior/src/chat/tools/slack/canvas-tools.ts
+++ b/packages/junior/src/chat/tools/slack/canvas-tools.ts
@@ -39,7 +39,7 @@ export function createSlackCanvasCreateTool(
 ) {
   return tool({
     description:
-      "Create a Slack canvas for long-form output in the active assistant context channel. Use when the answer is better as a reusable document than a thread reply: long-form research, timelines, bios/profiles, structured notes, plans, comparisons, or anything likely to exceed one compact Slack reply. After creating it, keep the thread reply brief and include the canvas link. Do not use for short answers that fit cleanly in one normal thread reply.",
+      "Create a Slack canvas for long-form output in the active assistant context channel. Use when the answer is better as a reusable document than a thread reply: long-form research, timelines, bios/profiles, structured notes, plans, comparisons, or anything likely to exceed one compact Slack reply. After creating it, reply with one or two short sentences plus the canvas link; do not recap the canvas contents. Do not use for short answers that fit cleanly in one normal thread reply.",
     inputSchema: Type.Object({
       title: Type.String({
         minLength: 1,

--- a/packages/junior/tests/unit/skills/load-skill-tool.test.ts
+++ b/packages/junior/tests/unit/skills/load-skill-tool.test.ts
@@ -53,6 +53,12 @@ describe("load_skill tool", () => {
     });
     expect((result as any).location).toBe(sandboxSkillFile(firstSkill.name));
     expect((result as any).skill_dir).toBe(sandboxSkillDir(firstSkill.name));
+    expect((result as any).working_directory).toBe(
+      sandboxSkillDir(firstSkill.name),
+    );
+    expect((result as any).path_resolution).toContain(
+      sandboxSkillDir(firstSkill.name),
+    );
     expect((result as any).instructions).toBe("Instruction body");
     expect(loaded).toHaveLength(1);
     expect(loaded[0]).toMatchObject({

--- a/packages/junior/tests/unit/turn-result.test.ts
+++ b/packages/junior/tests/unit/turn-result.test.ts
@@ -175,6 +175,87 @@ describe("buildTurnResult", () => {
     expect(reply.diagnostics.usedPrimaryText).toBe(true);
   });
 
+  it("suppresses model text for reaction-only requests", () => {
+    const reply = buildTurnResult({
+      newMessages: [
+        {
+          role: "toolResult",
+          toolName: "slackMessageAddReaction",
+          isError: false,
+          content: [{ type: "text", text: "reaction added" }],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "արձագանքեցի :thumbsup:" }],
+          stopReason: "stop",
+        },
+      ],
+      userInput: "react to this",
+      replyFiles: [],
+      artifactStatePatch: {},
+      toolCalls: ["slackMessageAddReaction"],
+      generatedFileCount: 0,
+      shouldTrace: false,
+      spanContext: {},
+      thinkingSelection,
+    });
+
+    expect(reply.text).toBe("");
+    expect(reply.deliveryPlan).toMatchObject({
+      postThreadText: false,
+    });
+    expect(reply.diagnostics.outcome).toBe("success");
+    expect(reply.diagnostics.usedPrimaryText).toBe(true);
+  });
+
+  it("keeps post-canvas thread replies brief", () => {
+    const verboseReply = [
+      "I put together a reusable reference here:",
+      "https://example.invalid/files/F123",
+      "",
+      "**Highlights**",
+      "- Timeline details that belong in the canvas.",
+      "- API details that belong in the canvas.",
+      "- Limit details that belong in the canvas.",
+      "- Migration details that belong in the canvas.",
+      "",
+      "**Note**",
+      "- More caveats that belong in the canvas.",
+    ].join("\n");
+
+    const reply = buildTurnResult({
+      newMessages: [
+        {
+          role: "toolResult",
+          toolName: "slackCanvasCreate",
+          isError: false,
+          content: [{ type: "text", text: "canvas created" }],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: verboseReply }],
+          stopReason: "stop",
+        },
+      ],
+      userInput: "create a reusable reference",
+      replyFiles: [],
+      artifactStatePatch: {
+        lastCanvasUrl: "https://example.invalid/files/F123",
+      },
+      toolCalls: ["slackCanvasCreate"],
+      generatedFileCount: 0,
+      shouldTrace: false,
+      spanContext: {},
+      thinkingSelection,
+    });
+
+    expect(reply.text).toBe(
+      "I created a canvas with the full reference: https://example.invalid/files/F123",
+    );
+    expect(reply.diagnostics.outcome).toBe("success");
+    expect(reply.diagnostics.usedPrimaryText).toBe(true);
+  });
+
   it("preserves structured timing and usage diagnostics", () => {
     const reply = buildTurnResult({
       newMessages: [


### PR DESCRIPTION
Follow-up to the harness prompt contract work so loaded skills, repository workflows, and Slack side effects behave consistently under normal-thinking eval runs. This makes local skill paths explicit, tightens skill selection for provider workflow questions, and adds runtime guards for side-effect replies that should stay quiet.

**Skill Path And Routing**

`loadSkill` now returns explicit `working_directory` and path-resolution guidance, while the core prompt keeps that guidance compact. GitHub and `jr-rpc` skill descriptions now separate issue work, repo/PR work, and config-default work so conceptual PR auth-order questions route to `github-code` instead of generic memory or the wrong skill.

**Slack Side Effects**

Reaction-only turns suppress redundant model text after a successful reaction. Long post-canvas replies are also collapsed to a brief canvas pointer when the detailed artifact already lives in the canvas.

**Eval Contracts**

The eval criteria now reflect hidden harness behavior for OAuth and smoke commands, and the GitHub/Sentry smoke cases use timeout budgets that match normal-thinking runs. GitHub issue reporting also keeps silent duplicate checks out of the final user reply.