### PR TITLE
fix(chat): Align OTel GenAI span semantics

### DIFF
--- a/packages/junior/.oxlintrc.json
+++ b/packages/junior/.oxlintrc.json
@@ -11,8 +11,37 @@
   ],
   "ignorePatterns": ["dist/**"],
   "rules": {
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "@mariozechner/pi-ai",
+            "importNames": [
+              "completeSimple",
+              "getEnvApiKey",
+              "getModels",
+              "registerApiProvider"
+            ],
+            "message": "Use @/chat/pi/client so provider calls stay traced and gateway auth stays centralized."
+          },
+          {
+            "name": "@mariozechner/pi-ai/anthropic",
+            "message": "Register anthropic providers only in @/chat/pi/client."
+          }
+        ]
+      }
+    ],
     "unicorn/no-useless-fallback-in-spread": "off",
     "vitest/hoisted-apis-on-top": "off",
     "vitest/require-mock-type-parameters": "off"
-  }
+  },
+  "overrides": [
+    {
+      "files": ["src/chat/pi/client.ts"],
+      "rules": {
+        "no-restricted-imports": "off"
+      }
+    }
+  ]
 }

--- a/packages/junior/src/chat/logging.ts
+++ b/packages/junior/src/chat/logging.ts
@@ -1541,19 +1541,23 @@ export async function withSpan<T>(
     }
   }
 
-  return withLogContext(context, () =>
-    Sentry.startSpan(
+  return withLogContext(context, () => {
+    // Child spans inherit the active log context so nested GenAI spans keep
+    // conversation/session correlation even when callers pass only delta
+    // context such as modelId or tool metadata.
+    const inheritedAttributes = getLogContextAttributes();
+    return Sentry.startSpan(
       {
         name,
         op,
         attributes: {
-          ...toSpanAttributes(context),
+          ...inheritedAttributes,
           ...normalizedAttributes,
         },
       },
       callback,
-    ),
-  );
+    );
+  });
 }
 
 /** Set attributes on the currently active Sentry span. */

--- a/packages/junior/src/chat/mcp/client.ts
+++ b/packages/junior/src/chat/mcp/client.ts
@@ -119,7 +119,6 @@ export class PluginMcpClient {
         setSpanAttributes({
           "mcp.method.name": MCP_TOOLS_CALL_METHOD,
           "gen_ai.operation.name": "execute_tool",
-          "app.mcp.tool.name": name,
           ...(this.transport?.sessionId
             ? { "mcp.session.id": this.transport.sessionId }
             : {}),

--- a/packages/junior/src/chat/mcp/client.ts
+++ b/packages/junior/src/chat/mcp/client.ts
@@ -119,7 +119,7 @@ export class PluginMcpClient {
         setSpanAttributes({
           "mcp.method.name": MCP_TOOLS_CALL_METHOD,
           "gen_ai.operation.name": "execute_tool",
-          "gen_ai.tool.name": name,
+          "app.mcp.tool.name": name,
           ...(this.transport?.sessionId
             ? { "mcp.session.id": this.transport.sessionId }
             : {}),

--- a/packages/junior/src/chat/mcp/tool-manager.ts
+++ b/packages/junior/src/chat/mcp/tool-manager.ts
@@ -331,7 +331,7 @@ export class McpToolManager {
         const resolvedArgs =
           typeof args === "object" && args !== null ? args : {};
         const baseAttributes = {
-          "gen_ai.tool.name": tool.name,
+          "app.mcp.tool.name": tool.name,
           "mcp.method.name": "tools/call",
         };
         setSpanAttributes(baseAttributes);

--- a/packages/junior/src/chat/mcp/tool-manager.ts
+++ b/packages/junior/src/chat/mcp/tool-manager.ts
@@ -331,7 +331,6 @@ export class McpToolManager {
         const resolvedArgs =
           typeof args === "object" && args !== null ? args : {};
         const baseAttributes = {
-          "app.mcp.tool.name": tool.name,
           "mcp.method.name": "tools/call",
         };
         setSpanAttributes(baseAttributes);

--- a/packages/junior/src/chat/pi/client.ts
+++ b/packages/junior/src/chat/pi/client.ts
@@ -26,7 +26,12 @@ import {
   extractGenAiUsageAttributes,
   serializeGenAiAttribute,
 } from "@/chat/logging";
-import { logException, logWarn, setSpanAttributes } from "@/chat/logging";
+import {
+  logException,
+  logWarn,
+  setSpanAttributes,
+  withSpan,
+} from "@/chat/logging";
 import { toOptionalTrimmed } from "@/chat/optional-string";
 
 const GATEWAY_PROVIDER = "vercel-ai-gateway" as const;
@@ -144,6 +149,7 @@ export function resolveGatewayModel(modelId: string): Model<any> {
   return matched;
 }
 
+/** Execute a direct chat completion inside a dedicated `gen_ai.chat` span. */
 export async function completeText(params: {
   modelId: string;
   system?: string;
@@ -175,69 +181,77 @@ export async function completeText(params: {
       ? { "app.ai.reasoning_effort": params.thinkingLevel }
       : {}),
   };
-  setSpanAttributes(startAttributes);
-  const message = await completeSimple(
-    model,
-    {
-      systemPrompt: params.system,
-      messages: params.messages,
-    },
-    {
-      ...(apiKey ? { apiKey } : {}),
-      temperature: params.temperature,
-      maxTokens: params.maxTokens,
-      reasoning: params.thinkingLevel,
-      signal: params.signal,
-      metadata: params.metadata,
-    },
-  );
-  const outputText = extractText(message);
-  const outputMessagesAttribute = serializeGenAiAttribute([
-    {
-      role: "assistant",
-      content: outputText ? [{ type: "text", text: outputText }] : [],
-    },
-  ]);
-  const usageAttributes = extractGenAiUsageAttributes(message);
-  const endAttributes = {
-    "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
-    "gen_ai.operation.name": GEN_AI_OPERATION_CHAT,
-    "gen_ai.request.model": params.modelId,
-    ...(outputMessagesAttribute
-      ? { "gen_ai.output.messages": outputMessagesAttribute }
-      : {}),
-    ...usageAttributes,
-    ...(message.stopReason
-      ? { "gen_ai.response.finish_reasons": [message.stopReason] }
-      : {}),
-    ...(params.thinkingLevel
-      ? { "app.ai.reasoning_effort": params.thinkingLevel }
-      : {}),
-  };
-  setSpanAttributes(endAttributes);
-  if (message.stopReason === "error") {
-    const providerMessage =
-      message.errorMessage?.trim() || "Unknown provider error";
-    logWarn(
-      "ai_completion_provider_error",
-      {},
-      {
+  return withSpan(
+    "ai.chat_completion",
+    "gen_ai.chat",
+    { modelId: params.modelId },
+    async () => {
+      const message = await completeSimple(
+        model,
+        {
+          systemPrompt: params.system,
+          messages: params.messages,
+        },
+        {
+          ...(apiKey ? { apiKey } : {}),
+          temperature: params.temperature,
+          maxTokens: params.maxTokens,
+          reasoning: params.thinkingLevel,
+          signal: params.signal,
+          metadata: params.metadata,
+        },
+      );
+      const outputText = extractText(message);
+      const outputMessagesAttribute = serializeGenAiAttribute([
+        {
+          role: "assistant",
+          content: outputText ? [{ type: "text", text: outputText }] : [],
+        },
+      ]);
+      const usageAttributes = extractGenAiUsageAttributes(message);
+      const endAttributes = {
         "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
         "gen_ai.operation.name": GEN_AI_OPERATION_CHAT,
         "gen_ai.request.model": params.modelId,
-        "error.message": providerMessage,
-      },
-      "AI completion returned provider error",
-    );
-    throw new Error(`AI provider error: ${providerMessage}`);
-  }
+        ...(outputMessagesAttribute
+          ? { "gen_ai.output.messages": outputMessagesAttribute }
+          : {}),
+        ...usageAttributes,
+        ...(message.stopReason
+          ? { "gen_ai.response.finish_reasons": [message.stopReason] }
+          : {}),
+        ...(params.thinkingLevel
+          ? { "app.ai.reasoning_effort": params.thinkingLevel }
+          : {}),
+      };
+      setSpanAttributes(endAttributes);
+      if (message.stopReason === "error") {
+        const providerMessage =
+          message.errorMessage?.trim() || "Unknown provider error";
+        logWarn(
+          "ai_completion_provider_error",
+          {},
+          {
+            "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
+            "gen_ai.operation.name": GEN_AI_OPERATION_CHAT,
+            "gen_ai.request.model": params.modelId,
+            "error.message": providerMessage,
+          },
+          "AI completion returned provider error",
+        );
+        throw new Error(`AI provider error: ${providerMessage}`);
+      }
 
-  return {
-    message,
-    text: outputText,
-  };
+      return {
+        message,
+        text: outputText,
+      };
+    },
+    startAttributes,
+  );
 }
 
+/** Execute a schema-constrained completion using the traced text path above. */
 export async function completeObject<TSchema extends ZodTypeAny>(params: {
   modelId: string;
   schema: TSchema;

--- a/packages/junior/src/chat/pi/client.ts
+++ b/packages/junior/src/chat/pi/client.ts
@@ -166,10 +166,16 @@ export async function completeText(params: {
   const systemInstructionsAttribute = params.system
     ? serializeGenAiAttribute([{ type: "text", content: params.system }])
     : undefined;
-  const startAttributes = {
+  const baseAttributes = {
     "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
     "gen_ai.operation.name": GEN_AI_OPERATION_CHAT,
     "gen_ai.request.model": params.modelId,
+    ...(params.thinkingLevel
+      ? { "app.ai.reasoning_effort": params.thinkingLevel }
+      : {}),
+  };
+  const startAttributes = {
+    ...baseAttributes,
     ...(systemInstructionsAttribute
       ? { "gen_ai.system_instructions": systemInstructionsAttribute }
       : {}),
@@ -177,9 +183,6 @@ export async function completeText(params: {
       ? { "gen_ai.input.messages": requestMessagesAttribute }
       : {}),
     "app.ai.auth_mode": apiKey ? "oidc" : "api_key",
-    ...(params.thinkingLevel
-      ? { "app.ai.reasoning_effort": params.thinkingLevel }
-      : {}),
   };
   return withSpan(
     "ai.chat_completion",
@@ -210,18 +213,13 @@ export async function completeText(params: {
       ]);
       const usageAttributes = extractGenAiUsageAttributes(message);
       const endAttributes = {
-        "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
-        "gen_ai.operation.name": GEN_AI_OPERATION_CHAT,
-        "gen_ai.request.model": params.modelId,
+        ...baseAttributes,
         ...(outputMessagesAttribute
           ? { "gen_ai.output.messages": outputMessagesAttribute }
           : {}),
         ...usageAttributes,
         ...(message.stopReason
           ? { "gen_ai.response.finish_reasons": [message.stopReason] }
-          : {}),
-        ...(params.thinkingLevel
-          ? { "app.ai.reasoning_effort": params.thinkingLevel }
           : {}),
       };
       setSpanAttributes(endAttributes);
@@ -232,9 +230,7 @@ export async function completeText(params: {
           "ai_completion_provider_error",
           {},
           {
-            "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
-            "gen_ai.operation.name": GEN_AI_OPERATION_CHAT,
-            "gen_ai.request.model": params.modelId,
+            ...baseAttributes,
             "error.message": providerMessage,
           },
           "AI completion returned provider error",

--- a/packages/junior/src/chat/runtime/slack-runtime.ts
+++ b/packages/junior/src/chat/runtime/slack-runtime.ts
@@ -45,6 +45,7 @@ async function maybeHandleThreadOptOutDecision(args: {
 
 type RuntimeLogContext = Record<string, unknown> & {
   assistantUserName: string;
+  conversationId?: string;
   modelId: string;
   slackChannelId?: string;
   slackThreadId?: string;
@@ -187,6 +188,7 @@ function buildLogContext(
   },
 ): RuntimeLogContext {
   return {
+    conversationId: args.threadId ?? args.runId,
     slackThreadId: args.threadId,
     slackUserId: args.requesterId,
     slackUserName: args.requesterUserName,
@@ -356,91 +358,6 @@ export function createSlackTurnRuntime<
         const threadId = deps.getThreadId(thread, message);
         const channelId = deps.getChannelId(thread, message);
         const runId = deps.getRunId(thread, message);
-        const rawUserText = message.text;
-        const userText = deps.stripLeadingBotMention(rawUserText, {
-          stripLeadingSlackMentionToken: Boolean(message.isMention),
-        });
-        const context: ThreadContext = {
-          threadId,
-          requesterId: message.author.userId,
-          channelId,
-          runId,
-        };
-
-        const preflightDecision = getSubscribedReplyPreflightDecision({
-          botUserName: deps.assistantUserName,
-          rawText: rawUserText,
-          text: userText,
-          isExplicitMention: Boolean(message.isMention),
-        });
-
-        if (preflightDecision && !preflightDecision.shouldReply) {
-          const reason = preflightDecision.reasonDetail
-            ? `${preflightDecision.reason}:${preflightDecision.reasonDetail}`
-            : preflightDecision.reason;
-          await skipSubscribedMessage({
-            thread,
-            message,
-            decision: { shouldReply: false, reason },
-            context,
-            userText,
-          });
-          return;
-        }
-
-        const preparedState = await deps.prepareTurnState({
-          thread,
-          message,
-          userText,
-          explicitMention: Boolean(message.isMention),
-          context,
-        });
-
-        await deps.persistPreparedState({
-          thread,
-          preparedState,
-        });
-
-        const decision = await deps.decideSubscribedReply({
-          rawText: rawUserText,
-          text: userText,
-          conversationContext:
-            deps.getPreparedConversationContext(preparedState),
-          hasAttachments: message.attachments.length > 0,
-          isExplicitMention: Boolean(message.isMention),
-          context,
-        });
-
-        if (
-          await maybeHandleThreadOptOutDecision({
-            thread,
-            decision,
-            beforeFirstResponsePost: hooks?.beforeFirstResponsePost,
-          })
-        ) {
-          await skipSubscribedMessage({
-            thread,
-            message,
-            decision,
-            context,
-            preparedState,
-            userText,
-          });
-          return;
-        }
-
-        if (!decision.shouldReply) {
-          await skipSubscribedMessage({
-            thread,
-            message,
-            decision,
-            context,
-            preparedState,
-            userText,
-          });
-          return;
-        }
-
         await deps.withSpan(
           "chat.turn",
           "chat.turn",
@@ -452,6 +369,93 @@ export function createSlackTurnRuntime<
             runId,
           }),
           async () => {
+            // This path can compact context and run router/vision model calls
+            // before replyToThread() opens the main reply span.
+            const rawUserText = message.text;
+            const userText = deps.stripLeadingBotMention(rawUserText, {
+              stripLeadingSlackMentionToken: Boolean(message.isMention),
+            });
+            const context: ThreadContext = {
+              threadId,
+              requesterId: message.author.userId,
+              channelId,
+              runId,
+            };
+
+            const preflightDecision = getSubscribedReplyPreflightDecision({
+              botUserName: deps.assistantUserName,
+              rawText: rawUserText,
+              text: userText,
+              isExplicitMention: Boolean(message.isMention),
+            });
+
+            if (preflightDecision && !preflightDecision.shouldReply) {
+              const reason = preflightDecision.reasonDetail
+                ? `${preflightDecision.reason}:${preflightDecision.reasonDetail}`
+                : preflightDecision.reason;
+              await skipSubscribedMessage({
+                thread,
+                message,
+                decision: { shouldReply: false, reason },
+                context,
+                userText,
+              });
+              return;
+            }
+
+            const preparedState = await deps.prepareTurnState({
+              thread,
+              message,
+              userText,
+              explicitMention: Boolean(message.isMention),
+              context,
+            });
+
+            await deps.persistPreparedState({
+              thread,
+              preparedState,
+            });
+
+            const decision = await deps.decideSubscribedReply({
+              rawText: rawUserText,
+              text: userText,
+              conversationContext:
+                deps.getPreparedConversationContext(preparedState),
+              hasAttachments: message.attachments.length > 0,
+              isExplicitMention: Boolean(message.isMention),
+              context,
+            });
+
+            if (
+              await maybeHandleThreadOptOutDecision({
+                thread,
+                decision,
+                beforeFirstResponsePost: hooks?.beforeFirstResponsePost,
+              })
+            ) {
+              await skipSubscribedMessage({
+                thread,
+                message,
+                decision,
+                context,
+                preparedState,
+                userText,
+              });
+              return;
+            }
+
+            if (!decision.shouldReply) {
+              await skipSubscribedMessage({
+                thread,
+                message,
+                decision,
+                context,
+                preparedState,
+                userText,
+              });
+              return;
+            }
+
             await deps.replyToThread(thread, message, {
               explicitMention: Boolean(message.isMention),
               preparedState,

--- a/packages/junior/src/chat/tools/agent-tools.ts
+++ b/packages/junior/src/chat/tools/agent-tools.ts
@@ -16,6 +16,18 @@ import { resolveCredentialInjection } from "@/chat/tools/execution/inject-creden
 import { normalizeToolResult } from "@/chat/tools/execution/normalize-result";
 import { handleToolExecutionError } from "@/chat/tools/execution/tool-error-handler";
 
+function toToolResultAttributeValue(details: unknown): unknown {
+  if (
+    details &&
+    typeof details === "object" &&
+    "rawResult" in details &&
+    (details as { rawResult?: unknown }).rawResult !== undefined
+  ) {
+    return (details as { rawResult: unknown }).rawResult;
+  }
+  return details;
+}
+
 /** Wrap tool definitions into Pi Agent tool objects with logging, validation, and sandbox execution. */
 export function createAgentTools(
   tools: Record<string, ToolDefinition<any>>,
@@ -116,7 +128,7 @@ export function createAgentTools(
               });
             }
             const toolResultAttribute = serializeGenAiAttribute(
-              normalized.details,
+              toToolResultAttributeValue(normalized.details),
             );
             if (toolResultAttribute) {
               setSpanAttributes({

--- a/packages/junior/src/chat/tools/agent-tools.ts
+++ b/packages/junior/src/chat/tools/agent-tools.ts
@@ -16,18 +16,6 @@ import { resolveCredentialInjection } from "@/chat/tools/execution/inject-creden
 import { normalizeToolResult } from "@/chat/tools/execution/normalize-result";
 import { handleToolExecutionError } from "@/chat/tools/execution/tool-error-handler";
 
-function toToolResultAttributeValue(details: unknown): unknown {
-  if (
-    details &&
-    typeof details === "object" &&
-    "rawResult" in details &&
-    (details as { rawResult?: unknown }).rawResult !== undefined
-  ) {
-    return (details as { rawResult: unknown }).rawResult;
-  }
-  return details;
-}
-
 /** Wrap tool definitions into Pi Agent tool objects with logging, validation, and sandbox execution. */
 export function createAgentTools(
   tools: Record<string, ToolDefinition<any>>,
@@ -51,12 +39,6 @@ export function createAgentTools(
           ? toolCallId
           : undefined;
       const toolArgumentsAttribute = serializeGenAiAttribute(params);
-      const traceToolContext = {
-        ...spanContext,
-        conversationId: spanContext.conversationId,
-        turnId: spanContext.turnId,
-        agentId: spanContext.agentId,
-      };
       if (toolName === "reportProgress") {
         const status = buildReportedProgressStatus(params);
         if (status) {
@@ -127,9 +109,16 @@ export function createAgentTools(
                 details: normalized.details,
               });
             }
-            const toolResultAttribute = serializeGenAiAttribute(
-              toToolResultAttributeValue(normalized.details),
-            );
+            const resultAttributeValue =
+              normalized.details &&
+              typeof normalized.details === "object" &&
+              "rawResult" in normalized.details &&
+              (normalized.details as { rawResult?: unknown }).rawResult !==
+                undefined
+                ? (normalized.details as { rawResult: unknown }).rawResult
+                : normalized.details;
+            const toolResultAttribute =
+              serializeGenAiAttribute(resultAttributeValue);
             if (toolResultAttribute) {
               setSpanAttributes({
                 "gen_ai.tool.call.result": toolResultAttribute,
@@ -145,7 +134,7 @@ export function createAgentTools(
               toolName,
               normalizedToolCallId,
               shouldTrace,
-              traceToolContext,
+              spanContext,
             );
           }
         },

--- a/packages/junior/tests/unit/logging/with-span.test.ts
+++ b/packages/junior/tests/unit/logging/with-span.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { startSpan } = vi.hoisted(() => ({
+  startSpan: vi.fn(
+    async (_options: unknown, callback: () => Promise<unknown>) => callback(),
+  ),
+}));
+
+vi.mock("@/chat/sentry", () => ({
+  startSpan,
+}));
+
+describe("withSpan", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("inherits parent log context attributes on child spans", async () => {
+    const { withSpan } = await import("@/chat/logging");
+
+    await withSpan(
+      "chat.reply",
+      "chat.reply",
+      {
+        conversationId: "thread_123",
+        runId: "run_123",
+      },
+      async () => {
+        await withSpan(
+          "chat.route_thinking",
+          "chat.route_thinking",
+          {
+            modelId: "openai/gpt-4o-mini",
+          },
+          async () => {},
+        );
+      },
+    );
+
+    expect(startSpan).toHaveBeenCalledTimes(2);
+
+    const outerSpanOptions = startSpan.mock.calls[0]?.[0] as {
+      attributes: Record<string, unknown>;
+    };
+    const innerSpanOptions = startSpan.mock.calls[1]?.[0] as {
+      attributes: Record<string, unknown>;
+    };
+
+    expect(outerSpanOptions.attributes["gen_ai.conversation.id"]).toBe(
+      "thread_123",
+    );
+    expect(innerSpanOptions.attributes["gen_ai.conversation.id"]).toBe(
+      "thread_123",
+    );
+    expect(innerSpanOptions.attributes["app.run.id"]).toBe("run_123");
+    expect(innerSpanOptions.attributes["gen_ai.request.model"]).toBe(
+      "openai/gpt-4o-mini",
+    );
+  });
+});

--- a/packages/junior/tests/unit/mcp/client.test.ts
+++ b/packages/junior/tests/unit/mcp/client.test.ts
@@ -248,7 +248,7 @@ describe("PluginMcpClient", () => {
     expect(setSpanAttributesMock).toHaveBeenCalledWith({
       "mcp.method.name": "tools/call",
       "gen_ai.operation.name": "execute_tool",
-      "gen_ai.tool.name": "notion-search",
+      "app.mcp.tool.name": "notion-search",
       "mcp.session.id": "server-session",
       "mcp.protocol.version": "2025-11-25",
       "server.address": "mcp.notion.com",

--- a/packages/junior/tests/unit/mcp/client.test.ts
+++ b/packages/junior/tests/unit/mcp/client.test.ts
@@ -248,7 +248,6 @@ describe("PluginMcpClient", () => {
     expect(setSpanAttributesMock).toHaveBeenCalledWith({
       "mcp.method.name": "tools/call",
       "gen_ai.operation.name": "execute_tool",
-      "app.mcp.tool.name": "notion-search",
       "mcp.session.id": "server-session",
       "mcp.protocol.version": "2025-11-25",
       "server.address": "mcp.notion.com",

--- a/packages/junior/tests/unit/mcp/tool-manager.test.ts
+++ b/packages/junior/tests/unit/mcp/tool-manager.test.ts
@@ -171,7 +171,7 @@ describe("McpToolManager", () => {
     expect(manager.getActiveToolCatalog(activeSkills)).toEqual([]);
   });
 
-  it("annotates MCP tool spans with method and tool name", async () => {
+  it("annotates MCP tool spans with the MCP method name", async () => {
     const plugin = buildPlugin();
     const manager = new McpToolManager([plugin]);
     const activeSkills = [{ name: "demo-skill", pluginProvider: "demo" }];
@@ -188,7 +188,6 @@ describe("McpToolManager", () => {
     });
 
     expect(setSpanAttributesMock).toHaveBeenCalledWith({
-      "app.mcp.tool.name": "ping",
       "mcp.method.name": "tools/call",
     });
   });
@@ -214,7 +213,6 @@ describe("McpToolManager", () => {
     );
 
     const expectedAttributes = expect.objectContaining({
-      "app.mcp.tool.name": "ping",
       "mcp.method.name": "tools/call",
       "error.type": "tool_error",
       "error.message":

--- a/packages/junior/tests/unit/mcp/tool-manager.test.ts
+++ b/packages/junior/tests/unit/mcp/tool-manager.test.ts
@@ -188,7 +188,7 @@ describe("McpToolManager", () => {
     });
 
     expect(setSpanAttributesMock).toHaveBeenCalledWith({
-      "gen_ai.tool.name": "ping",
+      "app.mcp.tool.name": "ping",
       "mcp.method.name": "tools/call",
     });
   });
@@ -214,7 +214,7 @@ describe("McpToolManager", () => {
     );
 
     const expectedAttributes = expect.objectContaining({
-      "gen_ai.tool.name": "ping",
+      "app.mcp.tool.name": "ping",
       "mcp.method.name": "tools/call",
       "error.type": "tool_error",
       "error.message":

--- a/packages/junior/tests/unit/pi/client.test.ts
+++ b/packages/junior/tests/unit/pi/client.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  completeSimple: vi.fn(),
+  getEnvApiKey: vi.fn(),
+  getModels: vi.fn(() => [{ id: "openai/gpt-4o-mini" }]),
+  logException: vi.fn(),
+  logWarn: vi.fn(),
+  registerApiProvider: vi.fn(),
+  setSpanAttributes: vi.fn(),
+  streamAnthropic: vi.fn(),
+  streamSimpleAnthropic: vi.fn(),
+  withSpan: vi.fn(
+    async (
+      _name: string,
+      _op: string,
+      _context: Record<string, unknown>,
+      callback: () => Promise<unknown>,
+      _attributes?: Record<string, unknown>,
+    ) => callback(),
+  ),
+}));
+
+vi.mock("@mariozechner/pi-ai", () => ({
+  completeSimple: mocks.completeSimple,
+  getEnvApiKey: mocks.getEnvApiKey,
+  getModels: mocks.getModels,
+  registerApiProvider: mocks.registerApiProvider,
+}));
+
+vi.mock("@mariozechner/pi-ai/anthropic", () => ({
+  streamAnthropic: mocks.streamAnthropic,
+  streamSimpleAnthropic: mocks.streamSimpleAnthropic,
+}));
+
+vi.mock("@/chat/logging", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/chat/logging")>()),
+  logException: mocks.logException,
+  logWarn: mocks.logWarn,
+  setSpanAttributes: mocks.setSpanAttributes,
+  withSpan: mocks.withSpan,
+}));
+
+describe("completeText", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("creates a gen_ai.chat span for provider completions", async () => {
+    mocks.completeSimple.mockResolvedValue({
+      content: [{ type: "text", text: "hello world" }],
+      stopReason: "stop",
+      usage: {
+        input: 12,
+        output: 4,
+        totalTokens: 16,
+      },
+    });
+
+    const { completeText, GEN_AI_PROVIDER_NAME } =
+      await import("@/chat/pi/client");
+
+    const result = await completeText({
+      modelId: "openai/gpt-4o-mini",
+      system: "Be concise.",
+      messages: [{ role: "user", content: "hi", timestamp: 1 }] as any,
+      thinkingLevel: "low",
+    });
+
+    expect(result.text).toBe("hello world");
+    expect(mocks.withSpan).toHaveBeenCalledTimes(1);
+
+    const [name, op, context, _callback, attributes] = mocks.withSpan.mock
+      .calls[0] as [
+      string,
+      string,
+      Record<string, unknown>,
+      () => Promise<unknown>,
+      Record<string, unknown>,
+    ];
+
+    expect(name).toBe("ai.chat_completion");
+    expect(op).toBe("gen_ai.chat");
+    expect(context).toEqual({ modelId: "openai/gpt-4o-mini" });
+    expect(attributes).toEqual(
+      expect.objectContaining({
+        "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
+        "gen_ai.operation.name": "chat",
+        "gen_ai.request.model": "openai/gpt-4o-mini",
+        "app.ai.reasoning_effort": "low",
+      }),
+    );
+    expect(attributes["gen_ai.system_instructions"]).toBeDefined();
+    expect(attributes["gen_ai.input.messages"]).toBeDefined();
+
+    expect(mocks.setSpanAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
+        "gen_ai.operation.name": "chat",
+        "gen_ai.request.model": "openai/gpt-4o-mini",
+        "gen_ai.output.messages": expect.any(String),
+        "gen_ai.response.finish_reasons": ["stop"],
+      }),
+    );
+  });
+});

--- a/packages/junior/tests/unit/runtime/slack-runtime.test.ts
+++ b/packages/junior/tests/unit/runtime/slack-runtime.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSlackTurnRuntime } from "@/chat/runtime/slack-runtime";
+
+describe("createSlackTurnRuntime", () => {
+  it("runs subscribed-thread routing and preparation inside the turn span", async () => {
+    let insideSpan = false;
+
+    const withSpan = vi.fn(
+      async (
+        _name: string,
+        _op: string,
+        _context: Record<string, unknown>,
+        callback: () => Promise<void>,
+      ) => {
+        insideSpan = true;
+        try {
+          await callback();
+        } finally {
+          insideSpan = false;
+        }
+      },
+    );
+
+    const prepareTurnState = vi.fn(async () => {
+      expect(insideSpan).toBe(true);
+      return { prepared: true } as const;
+    });
+    const decideSubscribedReply = vi.fn(async () => {
+      expect(insideSpan).toBe(true);
+      return {
+        shouldReply: false,
+        reason: "side_conversation",
+      };
+    });
+
+    const runtime = createSlackTurnRuntime({
+      assistantUserName: "junior",
+      decideSubscribedReply,
+      getChannelId: () => "C123",
+      getErrorReference: () => null,
+      getPreparedConversationContext: () => "prior thread context",
+      getRunId: () => "run_123",
+      getThreadId: () => "thread_123",
+      initializeAssistantThread: vi.fn(),
+      logException: vi.fn(),
+      logWarn: vi.fn(),
+      modelId: "openai/gpt-4o-mini",
+      now: () => 1,
+      onSubscribedMessageSkipped: vi.fn(async () => {}),
+      persistPreparedState: vi.fn(async () => {}),
+      prepareTurnState,
+      recordSkippedSubscribedMessage: vi.fn(async () => {}),
+      refreshAssistantThreadContext: vi.fn(),
+      replyToThread: vi.fn(async () => {}),
+      stripLeadingBotMention: (text: string) => text,
+      withSpan,
+    });
+
+    await runtime.handleSubscribedMessage(
+      {
+        post: vi.fn(),
+        unsubscribe: vi.fn(),
+      } as any,
+      {
+        attachments: [],
+        author: {
+          userId: "U123",
+          userName: "alice",
+        },
+        isMention: false,
+        text: "can you take a look at this?",
+      } as any,
+    );
+
+    expect(withSpan).toHaveBeenCalledTimes(1);
+    expect(withSpan.mock.calls[0]?.[2]).toEqual(
+      expect.objectContaining({
+        conversationId: "thread_123",
+        slackChannelId: "C123",
+        slackThreadId: "thread_123",
+        slackUserId: "U123",
+        runId: "run_123",
+      }),
+    );
+    expect(prepareTurnState).toHaveBeenCalledTimes(1);
+    expect(decideSubscribedReply).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/junior/tests/unit/tools/agent-tools.test.ts
+++ b/packages/junior/tests/unit/tools/agent-tools.test.ts
@@ -4,10 +4,27 @@ import { SkillSandbox } from "@/chat/sandbox/skill-sandbox";
 import { createAgentTools } from "@/chat/tools/agent-tools";
 import type { Skill } from "@/chat/skills";
 
-const { handleToolExecutionError } = vi.hoisted(() => ({
-  handleToolExecutionError: vi.fn((error: unknown) => {
-    throw error;
-  }),
+const { handleToolExecutionError, setSpanAttributesMock, withSpanMock } =
+  vi.hoisted(() => ({
+    handleToolExecutionError: vi.fn((error: unknown) => {
+      throw error;
+    }),
+    setSpanAttributesMock: vi.fn(),
+    withSpanMock: vi.fn(
+      async (
+        _name: string,
+        _op: string,
+        _context: Record<string, unknown>,
+        callback: () => Promise<unknown>,
+        _attributes?: Record<string, unknown>,
+      ) => callback(),
+    ),
+  }));
+
+vi.mock("@/chat/logging", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/chat/logging")>()),
+  setSpanAttributes: setSpanAttributesMock,
+  withSpan: withSpanMock,
 }));
 
 vi.mock("@/chat/tools/execution/tool-error-handler", () => ({
@@ -26,6 +43,8 @@ const githubSkill: Skill = {
 describe("createAgentTools", () => {
   beforeEach(() => {
     handleToolExecutionError.mockClear();
+    setSpanAttributesMock.mockClear();
+    withSpanMock.mockClear();
   });
 
   it("emits assistant status only for reportProgress", async () => {
@@ -154,6 +173,94 @@ describe("createAgentTools", () => {
     await bashTool!.execute("tool-bash", { command: "which gh" });
 
     expect(onToolCall).toHaveBeenCalledWith("bash", { command: "which gh" });
+  });
+
+  it("records tool call arguments and result on the execute_tool span", async () => {
+    const sandbox = new SkillSandbox([], []);
+    const [bashTool] = createAgentTools(
+      {
+        bash: {
+          description: "bash",
+          inputSchema: {} as any,
+          execute: async () => ({
+            ok: true,
+            stdout: "done",
+          }),
+        },
+      },
+      sandbox,
+      {
+        conversationId: "thread_123",
+      },
+    );
+
+    const result = await bashTool!.execute("tool-bash", {
+      command: "pwd",
+    });
+
+    expect(result.details).toEqual({
+      ok: true,
+      stdout: "done",
+    });
+    expect(withSpanMock).toHaveBeenCalledWith(
+      "execute_tool bash",
+      "gen_ai.execute_tool",
+      {
+        conversationId: "thread_123",
+      },
+      expect.any(Function),
+      expect.objectContaining({
+        "gen_ai.provider.name": "vercel-ai-gateway",
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.tool.name": "bash",
+        "gen_ai.tool.description": "bash",
+        "gen_ai.tool.call.id": "tool-bash",
+        "gen_ai.tool.call.arguments": expect.any(String),
+      }),
+    );
+    expect(setSpanAttributesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "gen_ai.tool.call.result": expect.any(String),
+      }),
+    );
+  });
+
+  it("records the raw tool result instead of the MCP envelope", async () => {
+    const sandbox = new SkillSandbox([], []);
+    const [mcpTool] = createAgentTools(
+      {
+        mcp__demo__ping: {
+          description: "[demo] ping",
+          inputSchema: {} as any,
+          execute: async () => ({
+            content: [{ type: "text", text: "pong" }],
+            details: {
+              provider: "demo",
+              tool: "ping",
+              rawResult: {
+                content: [{ type: "text", text: "pong" }],
+                isError: false,
+              },
+            },
+          }),
+        },
+      },
+      sandbox,
+      {},
+    );
+
+    await mcpTool!.execute("tool-mcp", { query: "hello" });
+
+    const resultCall = setSpanAttributesMock.mock.calls.find(
+      (call) => call[0] && "gen_ai.tool.call.result" in call[0],
+    );
+    expect(resultCall).toBeDefined();
+    const resultAttribute = resultCall?.[0]?.[
+      "gen_ai.tool.call.result"
+    ] as string;
+    expect(resultAttribute).toContain('"isError":false');
+    expect(resultAttribute).not.toContain('"provider":"demo"');
+    expect(resultAttribute).not.toContain('"tool":"ping"');
   });
 
   it("rethrows plugin auth pauses without reporting a tool failure", async () => {

--- a/specs/logging/semantics.md
+++ b/specs/logging/semantics.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-02-25
-- Last Edited: 2026-04-06
+- Last Edited: 2026-05-01
 
 ## Changelog
 
@@ -11,6 +11,7 @@
 - 2026-03-06: Added sandbox snapshot lifecycle attribute mappings.
 - 2026-04-06: Added official GenAI finish-reason, system-instructions, and tool-description semantics.
 - 2026-04-28: Added MCP tool-call semantic attribute mappings.
+- 2026-05-01: Added `gen_ai.conversation.id` to the canonical GenAI semantic map.
 
 ## Status
 
@@ -67,6 +68,7 @@ This file is the canonical attribute and naming map for instrumentation in this 
 
 ## GenAI
 
+- `gen_ai.conversation.id`
 - `gen_ai.provider.name`
 - `gen_ai.operation.name`
 - `gen_ai.request.model`
@@ -102,6 +104,7 @@ This file is the canonical attribute and naming map for instrumentation in this 
 - `network.transport`
 - `server.address`
 - `server.port`
+- `app.mcp.tool.name` for the raw provider-scoped MCP tool name when it differs from the agent-facing `gen_ai.tool.name`
 
 ## Process / CLI Execution
 

--- a/specs/logging/semantics.md
+++ b/specs/logging/semantics.md
@@ -104,7 +104,6 @@ This file is the canonical attribute and naming map for instrumentation in this 
 - `network.transport`
 - `server.address`
 - `server.port`
-- `app.mcp.tool.name` for the raw provider-scoped MCP tool name when it differs from the agent-facing `gen_ai.tool.name`
 
 ## Process / CLI Execution
 

--- a/specs/logging/tracing-spec.md
+++ b/specs/logging/tracing-spec.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-02-25
-- Last Edited: 2026-04-06
+- Last Edited: 2026-05-01
 
 ## Changelog
 
@@ -13,6 +13,7 @@
 - 2026-03-06: Added snapshot lifecycle span requirements and aligned sandbox snapshot attributes.
 - 2026-04-06: Added official GenAI finish-reasons, system-instructions, and tool-description tracing attributes.
 - 2026-04-28: Added MCP tool-call span attributes from the OpenTelemetry MCP semantic conventions.
+- 2026-05-01: Added `gen_ai.conversation.id` as required correlation context for GenAI spans when available.
 
 ## Status
 
@@ -67,6 +68,7 @@ Define the canonical tracing contract for span naming, boundaries, attributes, a
 ### Correlation Context
 
 - `messaging.message.conversation_id` / `app.workflow.run_id` / `enduser.id` when available.
+- `gen_ai.conversation.id` on GenAI spans when the conversation/thread identifier is known.
 - `messaging.destination.name` for channel context when available.
 - `gen_ai.request.model` for model-level tracing.
 - `gen_ai.response.finish_reasons` when available from provider responses.


### PR DESCRIPTION
Align Junior's GenAI tracing with the current OpenTelemetry semantics for conversation, model, and tool spans. This keeps nested provider calls correlated under the active conversation and keeps tool attributes consistent across the outer agent span and inner MCP layers.

**Span Correlation**

Nested GenAI spans now inherit the active log context, and direct `completeText()` calls open their own `gen_ai.chat` span. This covers subscribed-thread routing and other pre-reply model calls that previously ran without stable conversation correlation.

**Tool Semantics**

`execute_tool` spans now keep the agent-facing `gen_ai.tool.name` stable instead of letting inner MCP layers overwrite it. Tool result attributes also serialize the raw tool output rather than Junior's internal MCP envelope.

**Guardrails**

Add an Oxlint restriction that blocks direct provider execution imports outside `pi/client.ts`, and extend focused unit coverage around span inheritance, direct completions, and tool span payloads.

Fixes #280