### PR TITLE
build(deps): Update Chat SDK and third-party packages

### DIFF
--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -17,13 +17,13 @@
     "@sentry/junior-linear": "workspace:*",
     "@sentry/junior-notion": "workspace:*",
     "@sentry/junior-sentry": "workspace:*",
-    "@sentry/node": "^10.48.0",
-    "hono": "^4.12.14"
+    "@sentry/node": "^10.51.0",
+    "hono": "^4.12.18"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",
-    "jiti": "^2.6.1",
-    "nitro": "3.0.260415-beta",
+    "jiti": "^2.7.0",
+    "nitro": "3.0.260429-beta",
     "typescript": "^5.9.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     }
   },
   "devDependencies": {
-    "agent-browser": "^0.23.3",
+    "agent-browser": "^0.26.0",
     "lint-staged": "^16.4.0",
     "prettier": "^3.8.3",
     "simple-git-hooks": "^2.13.1",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -10,7 +10,7 @@
     "check": "astro check && astro build"
   },
   "dependencies": {
-    "@astrojs/check": "^0.9.8",
+    "@astrojs/check": "^0.9.9",
     "@astrojs/starlight": "^0.37.7",
     "@fontsource-variable/space-grotesk": "^5.2.10",
     "@fontsource/ibm-plex-mono": "^5.2.7",

--- a/packages/docs/src/content/docs/reference/api/handlers/webhooks/functions/POST.md
+++ b/packages/docs/src/content/docs/reference/api/handlers/webhooks/functions/POST.md
@@ -7,7 +7,7 @@ title: "POST"
 
 > **POST**(`request`, `platform`, `waitUntil`): `Promise`\<`Response`\>
 
-Defined in: [handlers/webhooks.ts:238](https://github.com/getsentry/junior/blob/main/packages/junior/src/handlers/webhooks.ts#L238)
+Defined in: [handlers/webhooks.ts:252](https://github.com/getsentry/junior/blob/main/packages/junior/src/handlers/webhooks.ts#L252)
 
 ## Parameters
 

--- a/packages/docs/src/content/docs/reference/api/handlers/webhooks/functions/handlePlatformWebhook.md
+++ b/packages/docs/src/content/docs/reference/api/handlers/webhooks/functions/handlePlatformWebhook.md
@@ -7,7 +7,7 @@ title: "handlePlatformWebhook"
 
 > **handlePlatformWebhook**(`request`, `platform`, `waitUntil`, `bot?`): `Promise`\<`Response`\>
 
-Defined in: [handlers/webhooks.ts:119](https://github.com/getsentry/junior/blob/main/packages/junior/src/handlers/webhooks.ts#L119)
+Defined in: [handlers/webhooks.ts:124](https://github.com/getsentry/junior/blob/main/packages/junior/src/handlers/webhooks.ts#L124)
 
 Handles `POST /api/webhooks/:platform`.
 

--- a/packages/junior-evals/package.json
+++ b/packages/junior-evals/package.json
@@ -12,9 +12,9 @@
     "@sentry/junior": "workspace:*",
     "@sentry/junior-github": "workspace:*",
     "@sentry/junior-sentry": "workspace:*",
-    "chat": "4.26.0",
+    "chat": "4.27.0",
     "typescript": "^5.9.3",
-    "vitest": "^4.1.4",
+    "vitest": "^4.1.5",
     "vitest-evals": "0.9.0-beta.1"
   }
 }

--- a/packages/junior-evals/tests/unit/harness/behavior-harness.test.ts
+++ b/packages/junior-evals/tests/unit/harness/behavior-harness.test.ts
@@ -99,7 +99,14 @@ describe("behavior harness", () => {
     expect(observedRuntimeIds.messageThreadId).toBe(
       "slack:C_AUTH:1700000000.0001",
     );
-    expect(result.posts).toEqual([{ text: "observed", files: [] }]);
+    expect(result.posts).toEqual([
+      {
+        channel: "C_AUTH",
+        files: [],
+        text: "observed",
+        thread_ts: "1700000000.0001",
+      },
+    ]);
   });
 
   it("routes two same-thread mention-shaped events through the queued runtime in order", async () => {
@@ -141,8 +148,18 @@ describe("behavior harness", () => {
     expect(handleNewMentionMock).toHaveBeenCalledTimes(1);
     expect(handleSubscribedMessageMock).toHaveBeenCalledTimes(1);
     expect(result.posts).toEqual([
-      { text: "observed", files: [] },
-      { text: "observed", files: [] },
+      {
+        channel: "C_QUEUE",
+        files: [],
+        text: "observed",
+        thread_ts: "1700000000.0002",
+      },
+      {
+        channel: "C_QUEUE",
+        files: [],
+        text: "observed",
+        thread_ts: "1700000000.0002",
+      },
     ]);
   });
 
@@ -185,7 +202,9 @@ describe("behavior harness", () => {
 
     expect(result.posts).toEqual([
       {
+        channel: "C_MEDIA",
         text: "",
+        thread_ts: "1700000000.0003",
         files: [
           {
             filename: "generated.png",

--- a/packages/junior/package.json
+++ b/packages/junior/package.json
@@ -34,40 +34,40 @@
     "skills:check": "node scripts/check-skills.mjs"
   },
   "dependencies": {
-    "@ai-sdk/gateway": "^3.0.99",
-    "@chat-adapter/slack": "4.26.0",
-    "@chat-adapter/state-memory": "4.26.0",
-    "@chat-adapter/state-redis": "4.26.0",
-    "@logtape/logtape": "^2.0.5",
+    "@ai-sdk/gateway": "^3.0.110",
+    "@chat-adapter/slack": "4.27.0",
+    "@chat-adapter/state-memory": "4.27.0",
+    "@chat-adapter/state-redis": "4.27.0",
+    "@logtape/logtape": "^2.0.7",
     "@mariozechner/pi-agent-core": "0.73.0",
     "@mariozechner/pi-ai": "0.73.0",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@sinclair/typebox": "^0.34.49",
-    "@slack/web-api": "^7.15.1",
-    "@vercel/functions": "^3.4.3",
+    "@slack/web-api": "^7.15.2",
+    "@vercel/functions": "^3.5.0",
     "@vercel/sandbox": "^1.10.0",
-    "ai": "^6.0.162",
+    "ai": "^6.0.175",
     "bash-tool": "^1.3.16",
-    "chat": "4.26.0",
-    "hono": "^4.12.14",
-    "just-bash": "^2.14.2",
+    "chat": "4.27.0",
+    "hono": "^4.12.18",
+    "just-bash": "^2.14.4",
     "node-html-markdown": "^2.0.0",
-    "yaml": "^2.8.3",
-    "zod": "^4.3.6"
+    "yaml": "^2.8.4",
+    "zod": "^4.4.3"
   },
   "peerDependencies": {
     "@sentry/node": ">=10.0.0"
   },
   "devDependencies": {
-    "@sentry/node": "^10.48.0",
+    "@sentry/node": "^10.51.0",
     "@types/node": "^25.6.0",
-    "dependency-cruiser": "^17.3.10",
-    "msw": "^2.13.3",
-    "nitro": "3.0.260415-beta",
-    "oxlint": "^1.60.0",
+    "dependency-cruiser": "^17.4.0",
+    "msw": "^2.14.3",
+    "nitro": "3.0.260429-beta",
+    "oxlint": "^1.63.0",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "vercel": "^51.4.0",
-    "vitest": "^4.1.4"
+    "vitest": "^4.1.5"
   }
 }

--- a/packages/junior/package.json
+++ b/packages/junior/package.json
@@ -50,7 +50,7 @@
     "bash-tool": "^1.3.16",
     "chat": "4.27.0",
     "hono": "^4.12.18",
-    "just-bash": "^2.14.4",
+    "just-bash": "2.14.2",
     "node-html-markdown": "^2.0.0",
     "yaml": "^2.8.4",
     "zod": "^4.4.3"

--- a/packages/junior/src/handlers/webhooks.ts
+++ b/packages/junior/src/handlers/webhooks.ts
@@ -18,7 +18,7 @@ import type { WaitUntilFn } from "@/handlers/types";
 
 interface SlackWebhookAuthAdapter {
   botUserId?: string;
-  defaultBotToken?: string;
+  defaultBotTokenProvider?: () => string | Promise<string>;
   requestContext?: {
     run<T>(context: unknown, fn: () => T): T;
   };
@@ -57,6 +57,10 @@ async function handleAuthenticatedSlackMessageChangedMention(args: {
     return;
   }
 
+  // Chat SDK initializes adapters automatically inside webhook handling. This
+  // side-channel runs before the SDK handler, so it must join that lifecycle.
+  await args.bot.initialize();
+
   const webhookOptions = {
     waitUntil: (task: Promise<unknown>) => args.waitUntil(task),
   };
@@ -85,7 +89,7 @@ async function handleAuthenticatedSlackMessageChangedMention(args: {
     return true;
   };
 
-  if (authAdapter.defaultBotToken) {
+  if (authAdapter.defaultBotTokenProvider) {
     dispatch();
     return;
   }

--- a/packages/junior/tests/fixtures/slack-harness.ts
+++ b/packages/junior/tests/fixtures/slack-harness.ts
@@ -287,6 +287,9 @@ export function createTestThread(args: {
     createSentMessageFromMessage(message: Message): SentMessage {
       return message as unknown as SentMessage;
     },
+    async getParticipants(): Promise<Author[]> {
+      return [];
+    },
     get posts() {
       return posts;
     },

--- a/packages/junior/tests/integration/example-build-discovery.test.ts
+++ b/packages/junior/tests/integration/example-build-discovery.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { cpSync, readFileSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
@@ -9,6 +10,7 @@ const originalCwd = process.cwd();
 const repoRoot = path.resolve(import.meta.dirname, "../../../..");
 const exampleRoot = path.join(repoRoot, "apps/example");
 const exampleEntry = path.join(exampleRoot, "server.ts");
+const exampleRequire = createRequire(exampleEntry);
 
 function getExamplePluginPackages(): string[] {
   const pkg = JSON.parse(
@@ -37,15 +39,18 @@ function buildJuniorPackage(): void {
     stdio: "pipe",
   });
 
-  // Re-sync pnpm store so the example app's node_modules/@sentry/junior
-  // points to the freshly built dist, not a stale hardlink. The relink does
-  // not need workspace prepare hooks, which would rebuild @sentry/junior and
-  // make the full suite timeout-prone.
-  execFileSync("pnpm", ["install", "--ignore-scripts"], {
-    cwd: repoRoot,
-    env,
-    stdio: "pipe",
+  const installedPackageRoot = path.dirname(
+    path.dirname(exampleRequire.resolve("@sentry/junior")),
+  );
+  rmSync(path.join(installedPackageRoot, "dist"), {
+    force: true,
+    recursive: true,
   });
+  cpSync(
+    path.join(repoRoot, "packages/junior/dist"),
+    path.join(installedPackageRoot, "dist"),
+    { recursive: true },
+  );
 }
 
 async function importExampleApp() {

--- a/packages/junior/tests/integration/example-build-discovery.test.ts
+++ b/packages/junior/tests/integration/example-build-discovery.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { cpSync, readFileSync, rmSync } from "node:fs";
+import { cpSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -11,6 +11,14 @@ const repoRoot = path.resolve(import.meta.dirname, "../../../..");
 const exampleRoot = path.join(repoRoot, "apps/example");
 const exampleEntry = path.join(exampleRoot, "server.ts");
 const exampleRequire = createRequire(exampleEntry);
+
+function isSamePath(left: string, right: string): boolean {
+  try {
+    return realpathSync(left) === realpathSync(right);
+  } catch {
+    return false;
+  }
+}
 
 function getExamplePluginPackages(): string[] {
   const pkg = JSON.parse(
@@ -42,15 +50,17 @@ function buildJuniorPackage(): void {
   const installedPackageRoot = path.dirname(
     path.dirname(exampleRequire.resolve("@sentry/junior")),
   );
-  rmSync(path.join(installedPackageRoot, "dist"), {
+  const sourceDist = path.join(repoRoot, "packages/junior/dist");
+  const installedDist = path.join(installedPackageRoot, "dist");
+  if (isSamePath(installedDist, sourceDist)) {
+    return;
+  }
+
+  rmSync(installedDist, {
     force: true,
     recursive: true,
   });
-  cpSync(
-    path.join(repoRoot, "packages/junior/dist"),
-    path.join(installedPackageRoot, "dist"),
-    { recursive: true },
-  );
+  cpSync(sourceDist, installedDist, { recursive: true });
 }
 
 async function importExampleApp() {

--- a/packages/junior/tests/unit/runtime/respond-error-path.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-error-path.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/chat/skills", () => ({
   discoverSkills: vi.fn(async () => {
@@ -8,10 +8,16 @@ vi.mock("@/chat/skills", () => ({
   parseSkillInvocation: vi.fn(),
 }));
 
-import { generateAssistantReply } from "@/chat/respond";
-
 describe("generateAssistantReply error path", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("preserves sandbox dependency hash on non-retryable failures", async () => {
+    vi.resetModules();
+    vi.stubEnv("AI_MODEL", "openai/gpt-5.4");
+    const { generateAssistantReply } = await import("@/chat/respond");
+
     const reply = await generateAssistantReply("hello", {
       sandbox: {
         sandboxId: "sb-123",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,7 +143,7 @@ importers:
         version: 6.0.175(zod@4.4.3)
       bash-tool:
         specifier: ^1.3.16
-        version: 1.3.16(@vercel/sandbox@1.10.0)(ai@6.0.175(zod@4.4.3))(just-bash@2.14.4)
+        version: 1.3.16(@vercel/sandbox@1.10.0)(ai@6.0.175(zod@4.4.3))(just-bash@2.14.2)
       chat:
         specifier: 4.27.0
         version: 4.27.0
@@ -151,8 +151,8 @@ importers:
         specifier: ^4.12.18
         version: 4.12.18
       just-bash:
-        specifier: ^2.14.4
-        version: 2.14.4
+        specifier: 2.14.2
+        version: 2.14.2
       node-html-markdown:
         specifier: ^2.0.0
         version: 2.0.0
@@ -6350,13 +6350,6 @@ packages:
         integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==,
       }
 
-  fast-xml-parser@5.3.3:
-    resolution:
-      {
-        integrity: sha512-2O3dkPAAC6JavuMm8+4+pgTk+5hoAs+CjZ+sWcQLkX9+/tHRuTkQh/Oaifr8qDmZ8iEHb771Ea6G8CdwkrgvYA==,
-      }
-    hasBin: true
-
   fast-xml-parser@5.5.8:
     resolution:
       {
@@ -7304,10 +7297,10 @@ packages:
         integrity: sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==,
       }
 
-  just-bash@2.14.4:
+  just-bash@2.14.2:
     resolution:
       {
-        integrity: sha512-d8PR7XX4e6rRQ9CLWkllotV+5EF/hOGwR7/dQtr8lGHNO/HTjubpBbdoavGUAc70YwxpYjPxdrJ5JCAqEs33jg==,
+        integrity: sha512-9Na1rH03Ta5ydHTNotJ7dms1iZwb2kToOnKbnS29AlrCvi1CQ21Fm2lfu4S4rfwDGHYi4E4evgTDC/DcDx8tuQ==,
       }
     hasBin: true
 
@@ -9858,12 +9851,6 @@ packages:
         integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==,
       }
     engines: { node: ">=0.10.0" }
-
-  strnum@2.2.2:
-    resolution:
-      {
-        integrity: sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==,
-      }
 
   strnum@2.2.3:
     resolution:
@@ -13283,10 +13270,10 @@ snapshots:
       "@vercel/functions": 3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33)
       "@vercel/sandbox": 1.10.0
       ai: 6.0.175(zod@4.4.3)
-      bash-tool: 1.3.16(@vercel/sandbox@1.10.0)(ai@6.0.175(zod@4.4.3))(just-bash@2.14.4)
+      bash-tool: 1.3.16(@vercel/sandbox@1.10.0)(ai@6.0.175(zod@4.4.3))(just-bash@2.14.2)
       chat: 4.27.0
       hono: 4.12.18
-      just-bash: 2.14.4
+      just-bash: 2.14.2
       node-html-markdown: 2.0.0
       yaml: 2.8.4
       zod: 4.4.3
@@ -14593,7 +14580,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  bash-tool@1.3.16(@vercel/sandbox@1.10.0)(ai@6.0.175(zod@4.4.3))(just-bash@2.14.4):
+  bash-tool@1.3.16(@vercel/sandbox@1.10.0)(ai@6.0.175(zod@4.4.3))(just-bash@2.14.2):
     dependencies:
       ai: 6.0.175(zod@4.4.3)
       fast-glob: 3.3.3
@@ -14601,7 +14588,7 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       "@vercel/sandbox": 1.10.0
-      just-bash: 2.14.4
+      just-bash: 2.14.2
 
   basic-ftp@5.2.0: {}
 
@@ -15359,15 +15346,11 @@ snapshots:
     dependencies:
       path-expression-matcher: 1.2.0
 
-  fast-xml-parser@5.3.3:
-    dependencies:
-      strnum: 2.2.3
-
   fast-xml-parser@5.5.8:
     dependencies:
       fast-xml-builder: 1.1.4
       path-expression-matcher: 1.2.0
-      strnum: 2.2.2
+      strnum: 2.2.3
 
   fastq@1.20.1:
     dependencies:
@@ -16000,10 +15983,10 @@ snapshots:
 
   jsonlines@0.1.1: {}
 
-  just-bash@2.14.4:
+  just-bash@2.14.2:
     dependencies:
       diff: 8.0.4
-      fast-xml-parser: 5.3.3
+      fast-xml-parser: 5.5.8
       file-type: 21.3.4
       ini: 6.0.0
       minimatch: 10.2.5
@@ -17967,8 +17950,6 @@ snapshots:
 
   strip-json-comments@2.0.1:
     optional: true
-
-  strnum@2.2.2: {}
 
   strnum@2.2.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       agent-browser:
-        specifier: ^0.23.3
-        version: 0.23.3
+        specifier: ^0.26.0
+        version: 0.26.0
       lint-staged:
         specifier: ^16.4.0
         version: 16.4.0
@@ -28,7 +28,7 @@ importers:
     dependencies:
       "@sentry/junior":
         specifier: workspace:*
-        version: file:packages/junior(@aws-sdk/credential-provider-web-identity@3.972.33)(@sentry/node@10.48.0)
+        version: file:packages/junior(@aws-sdk/credential-provider-web-identity@3.972.33)(@opentelemetry/api@1.9.1)(@sentry/node@10.51.0)
       "@sentry/junior-agent-browser":
         specifier: workspace:*
         version: link:../../packages/junior-agent-browser
@@ -51,21 +51,21 @@ importers:
         specifier: workspace:*
         version: link:../../packages/junior-sentry
       "@sentry/node":
-        specifier: ^10.48.0
-        version: 10.48.0
+        specifier: ^10.51.0
+        version: 10.51.0
       hono:
-        specifier: ^4.12.14
-        version: 4.12.14
+        specifier: ^4.12.18
+        version: 4.12.18
     devDependencies:
       "@types/node":
         specifier: ^25.6.0
         version: 25.6.0
       jiti:
-        specifier: ^2.6.1
-        version: 2.6.1
+        specifier: ^2.7.0
+        version: 2.7.0
       nitro:
-        specifier: 3.0.260415-beta
-        version: 3.0.260415-beta(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33))(chokidar@5.0.0)(jiti@2.6.1)(lru-cache@11.2.7)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: 3.0.260429-beta
+        version: 3.0.260429-beta(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(chokidar@5.0.0)(jiti@2.7.0)(lru-cache@11.2.7)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -73,11 +73,11 @@ importers:
   packages/docs:
     dependencies:
       "@astrojs/check":
-        specifier: ^0.9.8
-        version: 0.9.8(prettier@3.8.3)(typescript@5.9.3)
+        specifier: ^0.9.9
+        version: 0.9.9(prettier@3.8.3)(typescript@5.9.3)
       "@astrojs/starlight":
         specifier: ^0.37.7
-        version: 0.37.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
+        version: 0.37.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4))
       "@fontsource-variable/space-grotesk":
         specifier: ^5.2.10
         version: 5.2.10
@@ -86,10 +86,10 @@ importers:
         version: 5.2.7
       astro:
         specifier: ^5.18.1
-        version: 5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)
       starlight-typedoc:
         specifier: ^0.21.5
-        version: 0.21.5(@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@5.9.3)))(typedoc@0.28.19(typescript@5.9.3))
+        version: 0.21.5(@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@5.9.3)))(typedoc@0.28.19(typescript@5.9.3))
       typedoc:
         specifier: ^0.28.19
         version: 0.28.19(typescript@5.9.3)
@@ -103,96 +103,96 @@ importers:
   packages/junior:
     dependencies:
       "@ai-sdk/gateway":
-        specifier: ^3.0.99
-        version: 3.0.99(zod@4.3.6)
+        specifier: ^3.0.110
+        version: 3.0.110(zod@4.4.3)
       "@chat-adapter/slack":
-        specifier: 4.26.0
-        version: 4.26.0
+        specifier: 4.27.0
+        version: 4.27.0
       "@chat-adapter/state-memory":
-        specifier: 4.26.0
-        version: 4.26.0
+        specifier: 4.27.0
+        version: 4.27.0
       "@chat-adapter/state-redis":
-        specifier: 4.26.0
-        version: 4.26.0
+        specifier: 4.27.0
+        version: 4.27.0(@opentelemetry/api@1.9.1)
       "@logtape/logtape":
-        specifier: ^2.0.5
-        version: 2.0.5
+        specifier: ^2.0.7
+        version: 2.0.7
       "@mariozechner/pi-agent-core":
         specifier: 0.73.0
-        version: 0.73.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+        version: 0.73.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)
       "@mariozechner/pi-ai":
         specifier: 0.73.0
-        version: 0.73.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+        version: 0.73.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)
       "@modelcontextprotocol/sdk":
         specifier: 1.29.0
-        version: 1.29.0(zod@4.3.6)
+        version: 1.29.0(zod@4.4.3)
       "@sinclair/typebox":
         specifier: ^0.34.49
         version: 0.34.49
       "@slack/web-api":
-        specifier: ^7.15.1
-        version: 7.15.1
+        specifier: ^7.15.2
+        version: 7.15.2
       "@vercel/functions":
-        specifier: ^3.4.3
-        version: 3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33)
+        specifier: ^3.5.0
+        version: 3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33)
       "@vercel/sandbox":
         specifier: ^1.10.0
         version: 1.10.0
       ai:
-        specifier: ^6.0.162
-        version: 6.0.162(zod@4.3.6)
+        specifier: ^6.0.175
+        version: 6.0.175(zod@4.4.3)
       bash-tool:
         specifier: ^1.3.16
-        version: 1.3.16(@vercel/sandbox@1.10.0)(ai@6.0.162(zod@4.3.6))(just-bash@2.14.2)
+        version: 1.3.16(@vercel/sandbox@1.10.0)(ai@6.0.175(zod@4.4.3))(just-bash@2.14.4)
       chat:
-        specifier: 4.26.0
-        version: 4.26.0
+        specifier: 4.27.0
+        version: 4.27.0
       hono:
-        specifier: ^4.12.14
-        version: 4.12.14
+        specifier: ^4.12.18
+        version: 4.12.18
       just-bash:
-        specifier: ^2.14.2
-        version: 2.14.2
+        specifier: ^2.14.4
+        version: 2.14.4
       node-html-markdown:
         specifier: ^2.0.0
         version: 2.0.0
       yaml:
-        specifier: ^2.8.3
-        version: 2.8.3
+        specifier: ^2.8.4
+        version: 2.8.4
       zod:
-        specifier: ^4.3.6
-        version: 4.3.6
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       "@sentry/node":
-        specifier: ^10.48.0
-        version: 10.48.0
+        specifier: ^10.51.0
+        version: 10.51.0
       "@types/node":
         specifier: ^25.6.0
         version: 25.6.0
       dependency-cruiser:
-        specifier: ^17.3.10
-        version: 17.3.10
+        specifier: ^17.4.0
+        version: 17.4.0
       msw:
-        specifier: ^2.13.3
-        version: 2.13.3(@types/node@25.6.0)(typescript@5.9.3)
+        specifier: ^2.14.3
+        version: 2.14.3(@types/node@25.6.0)(typescript@5.9.3)
       nitro:
-        specifier: 3.0.260415-beta
-        version: 3.0.260415-beta(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33))(chokidar@5.0.0)(jiti@2.6.1)(lru-cache@11.2.7)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: 3.0.260429-beta
+        version: 3.0.260429-beta(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(chokidar@5.0.0)(jiti@2.7.0)(lru-cache@11.2.7)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
       oxlint:
-        specifier: ^1.60.0
-        version: 1.60.0
+        specifier: ^1.63.0
+        version: 1.63.0
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(@swc/core@1.15.3)(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(@swc/core@1.15.3)(jiti@2.7.0)(postcss@8.5.14)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vercel:
         specifier: ^51.4.0
-        version: 51.4.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(rollup@4.60.1)(typescript@5.9.3)
+        version: 51.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(typescript@5.9.3)
       vitest:
-        specifier: ^4.1.4
-        version: 4.1.4(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: ^4.1.5
+        version: 4.1.5(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(msw@2.14.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
 
   packages/junior-agent-browser: {}
 
@@ -202,7 +202,7 @@ importers:
     devDependencies:
       "@sentry/junior":
         specifier: workspace:*
-        version: file:packages/junior(@aws-sdk/credential-provider-web-identity@3.972.33)(@sentry/node@10.48.0)
+        version: file:packages/junior(@aws-sdk/credential-provider-web-identity@3.972.33)(@opentelemetry/api@1.9.1)(@sentry/node@10.51.0)
       "@sentry/junior-github":
         specifier: workspace:*
         version: link:../junior-github
@@ -210,17 +210,17 @@ importers:
         specifier: workspace:*
         version: link:../junior-sentry
       chat:
-        specifier: 4.26.0
-        version: 4.26.0
+        specifier: 4.27.0
+        version: 4.27.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: ^4.1.4
-        version: 4.1.4(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: ^4.1.5
+        version: 4.1.5(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(msw@2.14.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
       vitest-evals:
         specifier: 0.9.0-beta.1
-        version: 0.9.0-beta.1(ai@6.0.162(zod@4.3.6))(tinyrainbow@3.1.0)(vitest@4.1.4(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(zod@4.3.6)
+        version: 0.9.0-beta.1(ai@6.0.175(zod@4.4.3))(tinyrainbow@3.1.0)(vitest@4.1.5(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(msw@2.14.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)))(zod@4.4.3)
 
   packages/junior-github: {}
 
@@ -233,42 +233,30 @@ importers:
   packages/junior-sentry: {}
 
 packages:
-  "@ai-sdk/gateway@3.0.99":
+  "@ai-sdk/gateway@3.0.110":
     resolution:
       {
-        integrity: sha512-8/UuzFY8p+T8j4XP/9m841pUb5bhnFt8cecSnJpd2zhBttNZ6GbfjZTmsqnvM/RwJOvzIsdFULZrU+E9QFREsQ==,
+        integrity: sha512-sbv8+1L9/BRKydn8dMNwoMQKupA4iLJ9N+yvxgW6wMQ/94UepDf3FeYWMj/dLdzolAHZ6izRUP4s5WqQkmJ2Zg==,
       }
     engines: { node: ">=18" }
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  "@ai-sdk/provider-utils@4.0.23":
+  "@ai-sdk/provider-utils@4.0.26":
     resolution:
       {
-        integrity: sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==,
+        integrity: sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ==,
       }
     engines: { node: ">=18" }
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  "@ai-sdk/provider@3.0.8":
+  "@ai-sdk/provider@3.0.10":
     resolution:
       {
-        integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==,
+        integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==,
       }
     engines: { node: ">=18" }
-
-  "@anthropic-ai/sdk@0.90.0":
-    resolution:
-      {
-        integrity: sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==,
-      }
-    hasBin: true
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
-    peerDependenciesMeta:
-      zod:
-        optional: true
 
   "@anthropic-ai/sdk@0.91.1":
     resolution:
@@ -282,14 +270,14 @@ packages:
       zod:
         optional: true
 
-  "@astrojs/check@0.9.8":
+  "@astrojs/check@0.9.9":
     resolution:
       {
-        integrity: sha512-LDng8446QLS5ToKjRHd3bgUdirvemVVExV7nRyJfW2wV36xuv7vDxwy5NWN9zqeSEDgg0Tv84sP+T3yEq+Zlkw==,
+        integrity: sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg==,
       }
     hasBin: true
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: ^5.0.0 || ^6.0.0
 
   "@astrojs/compiler@2.13.1":
     resolution:
@@ -303,10 +291,10 @@ packages:
         integrity: sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==,
       }
 
-  "@astrojs/language-server@2.16.6":
+  "@astrojs/language-server@2.16.7":
     resolution:
       {
-        integrity: sha512-N990lu+HSFiG57owR0XBkr02BYMgiLCshLf+4QG4v6jjSWkBeQGnzqi+E1L08xFPPJ7eEeXnxPXGLaVv5pa4Ug==,
+        integrity: sha512-b64bWT74Vq/ORcSqW7TdIjjpB6hcl+Ei/lMANIUaAGlLPiYNtPTRI/j2tzvugT+LoVwfJtE2Ukq/t2OGCyEtfQ==,
       }
     hasBin: true
     peerDependencies:
@@ -675,28 +663,28 @@ packages:
       }
     engines: { node: ">=18" }
 
-  "@chat-adapter/shared@4.26.0":
+  "@chat-adapter/shared@4.27.0":
     resolution:
       {
-        integrity: sha512-YD0MGktFXrArUqTBsyPfL5vkdD1WBS58PAWO0oVrMQAMmPxpAXfWGjBtZCkf3y8R8Svb0uVuVXiMZSForaEnMQ==,
+        integrity: sha512-Wz+YZ8Mp2/qcxxJ+rU0ofZQSEtOF/4toEh7wbA+q+uLlPrLue+7hImWluJpQUZqGjSwsUoXhjSNwgFv3hz20aQ==,
       }
 
-  "@chat-adapter/slack@4.26.0":
+  "@chat-adapter/slack@4.27.0":
     resolution:
       {
-        integrity: sha512-NNN47rURI6qpJf4rRK8xyeumjPTAXr7YSU4/FnViU8cFV/vKYFR4xZTzlFMVWNrYi9SmSwasUjcBmQznigK54Q==,
+        integrity: sha512-Hx9tahCY/gA6EDydGdXcaz5r28sJOAAwnUP/j48Wv9U4LylsT4hXtLBoSmxb8gRvom2FypxD9Ry/SwzPnwnpBw==,
       }
 
-  "@chat-adapter/state-memory@4.26.0":
+  "@chat-adapter/state-memory@4.27.0":
     resolution:
       {
-        integrity: sha512-FsfyM/A9Bf1yFc1FWmOsK+a4YVwm5FogX25hZxFG6cEvyFb6Cd924SsbtvF06yItY/7J2UFetCsMmBPkdPKshQ==,
+        integrity: sha512-kl6LilKa6pBGQroIDQy79CPfgkVcUS2Qr13JGvunU/gA1gtLpleoxXHOye9PTRvpv6URCN54Yy5UmgAI9uzXKg==,
       }
 
-  "@chat-adapter/state-redis@4.26.0":
+  "@chat-adapter/state-redis@4.27.0":
     resolution:
       {
-        integrity: sha512-NSX2E6wkDlg0AMfKFx4LPoV6cBHolL08Ht3cT+S01jss24t9GzlDw/BUsrWOeoTElwEhxZcQw5bUkStUAA7JMg==,
+        integrity: sha512-kmfCzNUQOCZ6MxBmd0azdJAmbAbgJ87JkW0/kQWEZ9vmlf8F5VlmRSfvn9jWhh4R90ThpLeflmIaHX8iK4x2dA==,
       }
 
   "@ctrl/tinycolor@4.2.0":
@@ -783,22 +771,22 @@ packages:
         integrity: sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==,
       }
 
-  "@emnapi/core@1.9.2":
+  "@emnapi/core@1.10.0":
     resolution:
       {
-        integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==,
+        integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==,
+      }
+
+  "@emnapi/runtime@1.10.0":
+    resolution:
+      {
+        integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==,
       }
 
   "@emnapi/runtime@1.9.1":
     resolution:
       {
         integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==,
-      }
-
-  "@emnapi/runtime@1.9.2":
-    resolution:
-      {
-        integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==,
       }
 
   "@emnapi/wasi-threads@1.2.1":
@@ -1815,50 +1803,50 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  "@inquirer/ansi@1.0.2":
+  "@inquirer/ansi@2.0.5":
     resolution:
       {
-        integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==,
+        integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==,
       }
-    engines: { node: ">=18" }
+    engines: { node: ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0" }
 
-  "@inquirer/confirm@5.1.21":
+  "@inquirer/confirm@6.0.12":
     resolution:
       {
-        integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==,
+        integrity: sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==,
       }
-    engines: { node: ">=18" }
+    engines: { node: ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0" }
     peerDependencies:
       "@types/node": ">=18"
     peerDependenciesMeta:
       "@types/node":
         optional: true
 
-  "@inquirer/core@10.3.2":
+  "@inquirer/core@11.1.9":
     resolution:
       {
-        integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==,
+        integrity: sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==,
       }
-    engines: { node: ">=18" }
+    engines: { node: ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0" }
     peerDependencies:
       "@types/node": ">=18"
     peerDependenciesMeta:
       "@types/node":
         optional: true
 
-  "@inquirer/figures@1.0.15":
+  "@inquirer/figures@2.0.5":
     resolution:
       {
-        integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==,
+        integrity: sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==,
       }
-    engines: { node: ">=18" }
+    engines: { node: ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0" }
 
-  "@inquirer/type@3.0.10":
+  "@inquirer/type@4.0.5":
     resolution:
       {
-        integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==,
+        integrity: sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==,
       }
-    engines: { node: ">=18" }
+    engines: { node: ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0" }
     peerDependencies:
       "@types/node": ">=18"
     peerDependenciesMeta:
@@ -1947,10 +1935,10 @@ packages:
         integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==,
       }
 
-  "@logtape/logtape@2.0.5":
+  "@logtape/logtape@2.0.7":
     resolution:
       {
-        integrity: sha512-UizDkh20ZPJVOddRxG1F77WhHdlNl/sbQgoO8T534R7XvUBMAJ9En9f35u+meW2tRsNLvjz6R87Zanwf53tspQ==,
+        integrity: sha512-SUkjkEIfQ3zCadlLi8rfGfe4l/JRKNbp248bfLeowyUFs9KZME/k8y+5sugWYZet/gMYnmwCc9xa3J+kjDjSSQ==,
       }
 
   "@mapbox/node-pre-gyp@2.0.3":
@@ -2014,10 +2002,10 @@ packages:
       }
     engines: { node: ">= 20.19.0" }
 
-  "@mswjs/interceptors@0.41.3":
+  "@mswjs/interceptors@0.41.8":
     resolution:
       {
-        integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==,
+        integrity: sha512-pRLMNKTSGRoLq+KnEB/7OY5vijw1XmcheAAOiv6pj7W1FG32kAGqj1C/RK/cqxRGr1Fh+zBi8sDur8kj3EQv6A==,
       }
     engines: { node: ">=18" }
 
@@ -2064,6 +2052,12 @@ packages:
     resolution:
       {
         integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==,
+      }
+
+  "@open-draft/deferred-promise@3.0.0":
+    resolution:
+      {
+        integrity: sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==,
       }
 
   "@open-draft/logger@0.3.0":
@@ -2113,19 +2107,19 @@ packages:
       }
     engines: { node: ">=8.0.0" }
 
-  "@opentelemetry/context-async-hooks@2.6.1":
+  "@opentelemetry/core@2.6.1":
     resolution:
       {
-        integrity: sha512-XHzhwRNkBpeP8Fs/qjGrAf9r9PRv67wkJQ/7ZPaBQQ68DYlTBBx5MF9LvPx7mhuXcDessKK2b+DcxqwpgkcivQ==,
+        integrity: sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
       "@opentelemetry/api": ">=1.0.0 <1.10.0"
 
-  "@opentelemetry/core@2.6.1":
+  "@opentelemetry/core@2.7.1":
     resolution:
       {
-        integrity: sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==,
+        integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
@@ -2311,15 +2305,6 @@ packages:
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
-  "@opentelemetry/instrumentation-undici@0.24.0":
-    resolution:
-      {
-        integrity: sha512-oKzZ3uvqP17sV0EsoQcJgjEfIp0kiZRbYu/eD8p13Cbahumf8lb/xpYeNr/hfAJ4owzEtIDcGIjprfLcYbIKBQ==,
-      }
-    engines: { node: ^18.19.0 || >=20.6.0 }
-    peerDependencies:
-      "@opentelemetry/api": ^1.7.0
-
   "@opentelemetry/instrumentation@0.207.0":
     resolution:
       {
@@ -2347,26 +2332,26 @@ packages:
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
-  "@opentelemetry/redis-common@0.38.2":
+  "@opentelemetry/redis-common@0.38.3":
     resolution:
       {
-        integrity: sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==,
+        integrity: sha512-VCghU1JYs/4gP6Gqf/xro9MEsZ7LrMv2uONVsaESKL38ZOB9BqnI98FfS23wjMnHlpuE+TTaWSoAVNpTwYXzjw==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
 
-  "@opentelemetry/resources@2.6.1":
+  "@opentelemetry/resources@2.7.1":
     resolution:
       {
-        integrity: sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==,
+        integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
       "@opentelemetry/api": ">=1.3.0 <1.10.0"
 
-  "@opentelemetry/sdk-trace-base@2.6.1":
+  "@opentelemetry/sdk-trace-base@2.7.1":
     resolution:
       {
-        integrity: sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==,
+        integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==,
       }
     engines: { node: ^18.19.0 || >=20.6.0 }
     peerDependencies:
@@ -2406,10 +2391,10 @@ packages:
         integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==,
       }
 
-  "@oxc-project/types@0.124.0":
+  "@oxc-project/types@0.128.0":
     resolution:
       {
-        integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==,
+        integrity: sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==,
       }
 
   "@oxc-transform/binding-android-arm-eabi@0.111.0":
@@ -2599,235 +2584,243 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  "@oxlint/binding-android-arm-eabi@1.60.0":
+  "@oxlint/binding-android-arm-eabi@1.63.0":
     resolution:
       {
-        integrity: sha512-YdeJKaZckDQL1qa62a1aKq/goyq48aX3yOxaaWqWb4sau4Ee4IiLbamftNLU3zbePky6QsDj6thnSSzHRBjDfA==,
+        integrity: sha512-A9xLtQt7i0OA1PoB/meog6kikXI9CdwEp7ZwQqmgnpKn3G3b1orvTDy8CQ6T7w1HvDrgWGB78PkFKcWgibcTCg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [android]
 
-  "@oxlint/binding-android-arm64@1.60.0":
+  "@oxlint/binding-android-arm64@1.63.0":
     resolution:
       {
-        integrity: sha512-7ANS7PpXCfq84xZQ8E5WPs14gwcuPcl+/8TFNXfpSu0CQBXz3cUo2fDpHT8v8HJN+Ut02eacvMAzTnc9s6X4tw==,
+        integrity: sha512-SQo+ZMvdR9l3CxZp5W5gFNxSiDxclY6lOzzNpKYLF8asESpm3Pwumx0gER5T7aHLF1/2BAAtLD3DiDkdgy4V1A==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [android]
 
-  "@oxlint/binding-darwin-arm64@1.60.0":
+  "@oxlint/binding-darwin-arm64@1.63.0":
     resolution:
       {
-        integrity: sha512-pJsgd9AfplLGBm1fIr25V6V14vMrayhx4uIQvlfH7jWs2SZwSrvi3TfgfJySB8T+hvyEH8K2zXljQiUnkgUnfQ==,
+        integrity: sha512-6W82XjJDTmMnjg30427l0dufpnyLoq7wEukKdM6/g2VIybRVuQiBVh43EA4b+UxZ3+tLcKm+Or/pXGNgLCEU8g==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [darwin]
 
-  "@oxlint/binding-darwin-x64@1.60.0":
+  "@oxlint/binding-darwin-x64@1.63.0":
     resolution:
       {
-        integrity: sha512-Ue1aXHX49ivwflKqGJc7zcd/LeLgbhaTcDCQStgx5x06AXgjEAZmvrlMuIkWd4AL4FHQe6QJ9f33z04Cg448VQ==,
+        integrity: sha512-CnWd/YCuVG5W1BYkjJEVbJG11o526O9qAwBEQM+nh8K19CRFUkFdROXCyYkGmroHEYQe4vgQ6+lh3550Lp35Xw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [darwin]
 
-  "@oxlint/binding-freebsd-x64@1.60.0":
+  "@oxlint/binding-freebsd-x64@1.63.0":
     resolution:
       {
-        integrity: sha512-YCyQzsQtusQw+gNRW9rRTifSO+Dt/+dtCl2NHoDMZqJlRTEZ/Oht9YnuporI9yiTx7+cB+eqzX3MtHHVHGIWhg==,
+        integrity: sha512-a4eZAqrmtajqcxfdAzC+l7g3PaE3V8hpAYqqeD3fTxLXOMFdK3eNTZrU80n4dDEVm0JXy1aL5PqvqWldBl6zYA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [freebsd]
 
-  "@oxlint/binding-linux-arm-gnueabihf@1.60.0":
+  "@oxlint/binding-linux-arm-gnueabihf@1.63.0":
     resolution:
       {
-        integrity: sha512-c7dxM2Zksa45Qw16i2iGY3Fti2NirJ38FrsBsKw+qcJ0OtqTsBgKJLF0xV+yLG56UH01Z8WRPgsw31e0MoRoGQ==,
+        integrity: sha512-tYUtU9TdbU3uXF5D62g5zXJ13iniFGhXQx5vp9cyEjGdbSAY3VdFBSaldYvyoDmgMZ0ZYuwQP1Y4t2Fhejwa0w==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [linux]
 
-  "@oxlint/binding-linux-arm-musleabihf@1.60.0":
+  "@oxlint/binding-linux-arm-musleabihf@1.63.0":
     resolution:
       {
-        integrity: sha512-ZWALoA42UYqBEP1Tbw9OWURgFGS1nWj2AAvLdY6ZcGx/Gj93qVCBKjcvwXMupZibYwFbi9s/rzqkZseb/6gVtQ==,
+        integrity: sha512-I5r3twFf776UZg9dmRo2xbrKt00tTkORXEVe0ctg4vdTkQvJAjiCHxnbAU2HL1AiJ9cqADA76MAliuilsAWnvg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [linux]
 
-  "@oxlint/binding-linux-arm64-gnu@1.60.0":
+  "@oxlint/binding-linux-arm64-gnu@1.63.0":
     resolution:
       {
-        integrity: sha512-tpy+1w4p9hN5CicMCxqNy6ymfRtV5ayE573vFNjp1k1TN/qhLFgflveZoE/0++RlkHikBz2vY545NWm/hp7big==,
+        integrity: sha512-t7ltUkg6FFh4b564QyGir8xIj/QZbXu8FlcRkcyW9+ztr/mfRHlvUOFd95pJCXi9s/L5DrUeWWgpXRS+V+6igQ==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  "@oxlint/binding-linux-arm64-musl@1.60.0":
+  "@oxlint/binding-linux-arm64-musl@1.63.0":
     resolution:
       {
-        integrity: sha512-eDYDXZGhQAXyn6GwtwiX/qcLS0HlOLPJ/+iiIY8RYr+3P8oKBmgKxADLlniL6FtWfE7pPk7IGN9/xvDEvDvFeg==,
+        integrity: sha512-Q5mmZy/XWjuYFUuQyYjOvZ5U/JkKEwnpir6hGxhh6HcdP0V/BKxLo8dqkfF/t7r7AguB17dfS/8+go5AQDRR6g==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  "@oxlint/binding-linux-ppc64-gnu@1.60.0":
+  "@oxlint/binding-linux-ppc64-gnu@1.63.0":
     resolution:
       {
-        integrity: sha512-nxehly5XYBHUWI9VJX1bqCf9j/B43DaK/aS/T1fcxCpX3PA4Rm9BB54nPD1CKayT8xg6REN1ao+01hSRNgy8OA==,
+        integrity: sha512-uBGtuZ0TzLB4x5wVa82HGNvYqY8buwDhyCnCP0R0gkk9szqVsP0MeTtD5HX7EsEuFIt+aYmYxuxeVxs3nTSwtQ==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  "@oxlint/binding-linux-riscv64-gnu@1.60.0":
+  "@oxlint/binding-linux-riscv64-gnu@1.63.0":
     resolution:
       {
-        integrity: sha512-j1qf/NaUfOWQutjeoooNG1Q0zsK0XGmSu1uDLq3cctquRF3j7t9Hxqf/76ehCc5GEUAanth2W4Fa+XT1RFg/nw==,
+        integrity: sha512-h4s6FwxE+9MeA181o0dnDwHP32Y/bG8EiB/vrD6Ib+AMt6haigDc/0bUtI/sLmQDBMJnUfaCmtSSrEAqjtEVrA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  "@oxlint/binding-linux-riscv64-musl@1.60.0":
+  "@oxlint/binding-linux-riscv64-musl@1.63.0":
     resolution:
       {
-        integrity: sha512-YELKPRefQ/q/h3RUmeRfPCUhh2wBvgV1RyZ/F9M9u8cDyXsQW2ojv1DeWQTt466yczDITjZnIOg/s05pk7Ve2A==,
+        integrity: sha512-2EaNcCBR8Mcjl5ARtuN3BdEpVkX7KpjSjMGZ/mJMIeaXgTtdz5ytg2VwygMSStA/k0ixfvZFoZOfjDEcouV5vQ==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  "@oxlint/binding-linux-s390x-gnu@1.60.0":
+  "@oxlint/binding-linux-s390x-gnu@1.63.0":
     resolution:
       {
-        integrity: sha512-JkO3C6Gki7Y6h/MiIkFKvHFOz98/YWvQ4WYbK9DLXACMP2rjULzkeGyAzorJE5S1dzLQGFgeqvN779kSFwoV1g==,
+        integrity: sha512-p4hlf/fd7TrYYl3QrWWD0GocqJefwMu3cHQhmi2FvEB/YOvFb5DZN3SMBaPi7B1TM5DeypkEtrVib674q1KKPg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  "@oxlint/binding-linux-x64-gnu@1.60.0":
+  "@oxlint/binding-linux-x64-gnu@1.63.0":
     resolution:
       {
-        integrity: sha512-XjKHdFVCpZZZSWBCKyyqCq65s2AKXykMXkjLoKYODrD+f5toLhlwsMESscu8FbgnJQ4Y/dpR/zdazsahmgBJIA==,
+        integrity: sha512-Vgq9rkRVcPcjbcH+ihYTfpeR7vCXfqpd+z5ItTGc0yYUV59L5ceHYN1iV4H9bKGV7Rn5hkVc7x3mSvHegduENA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  "@oxlint/binding-linux-x64-musl@1.60.0":
+  "@oxlint/binding-linux-x64-musl@1.63.0":
     resolution:
       {
-        integrity: sha512-js29ZWIuPhNWzY8NC7KoffEMEeWG105vbmm+8EOJsC+T/jHBiKIJEUF78+F/IrgEWMMP9N0kRND4Pp75+xAhKg==,
+        integrity: sha512-3/Lkq/ncooA61rorrC+ZQed1Bc4VpGj+WnGsp58zmxKgvZ2vhreu+dcVyr3mX8NUpq7mfZ4gDDTou/yrF1Pd7A==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  "@oxlint/binding-openharmony-arm64@1.60.0":
+  "@oxlint/binding-openharmony-arm64@1.63.0":
     resolution:
       {
-        integrity: sha512-H+PUITKHk04stFpWj3x3Kg08Afp/bcXSBi0EhasR5a0Vw7StXHTzdl655PUI0fB4qdh2Wsu6Dsi+3ACxPoyQnA==,
+        integrity: sha512-0/EdD/6hDkx5Mfd769PTjvEM8mZ/6Dfukp1dBCL/2PjlIVGEtYdNZyok6ChqYPsT9JcFnlQnUeQzO0/1L/oC9w==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [openharmony]
 
-  "@oxlint/binding-win32-arm64-msvc@1.60.0":
+  "@oxlint/binding-win32-arm64-msvc@1.63.0":
     resolution:
       {
-        integrity: sha512-WA/yc7f7ZfCefBXVzNHn1Ztulb1EFwNBb4jMZ6pjML0zz6pHujlF3Q3jySluz3XHl/GNeMTntG1seUBWVMlMag==,
+        integrity: sha512-wb0CUkN8ngwPiRQBjD1Cj0LsHeNvm+Xt6YBHDMtj2DVQVD6Oj8Ri7g6BD+KICf6LaBqZlmzOvy6nF9E/8yyGOg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [win32]
 
-  "@oxlint/binding-win32-ia32-msvc@1.60.0":
+  "@oxlint/binding-win32-ia32-msvc@1.63.0":
     resolution:
       {
-        integrity: sha512-33YxL1sqwYNZXtn3MD/4dno6s0xeedXOJlT1WohkVD565WvohClZUr7vwKdAk954n4xiEWJkewiCr+zLeq7AeA==,
+        integrity: sha512-BX5iq+ovdNlVYhSn5qPMUIT0uwAwt2lmEnCnzK+Gkhw4DovIvhGb96OFhV8yzQNUnQxn/xGkOR+X+BLrLDNm8w==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ia32]
     os: [win32]
 
-  "@oxlint/binding-win32-x64-msvc@1.60.0":
+  "@oxlint/binding-win32-x64-msvc@1.63.0":
     resolution:
       {
-        integrity: sha512-JOro4ZcfBLamJCyfURQmOQByoorgOdx3ZjAkSqnb/CyG/i+lN3KoV5LAgk5ZAW6DPq7/Cx7n23f8DuTWXTWgyQ==,
+        integrity: sha512-QeN/WELOfsXMeYwxvfgQrl6CbVftYUCZsGXHjXQd5Trccm8+i4gmtxaOui4xbJQaiDlviF8F3yLSBloQUeFsfA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [win32]
 
-  "@pagefind/darwin-arm64@1.4.0":
+  "@pagefind/darwin-arm64@1.5.2":
     resolution:
       {
-        integrity: sha512-2vMqkbv3lbx1Awea90gTaBsvpzgRs7MuSgKDxW0m9oV1GPZCZbZBJg/qL83GIUEN2BFlY46dtUZi54pwH+/pTQ==,
+        integrity: sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==,
       }
     cpu: [arm64]
     os: [darwin]
 
-  "@pagefind/darwin-x64@1.4.0":
+  "@pagefind/darwin-x64@1.5.2":
     resolution:
       {
-        integrity: sha512-e7JPIS6L9/cJfow+/IAqknsGqEPjJnVXGjpGm25bnq+NPdoD3c/7fAwr1OXkG4Ocjx6ZGSCijXEV4ryMcH2E3A==,
+        integrity: sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==,
       }
     cpu: [x64]
     os: [darwin]
 
-  "@pagefind/default-ui@1.4.0":
+  "@pagefind/default-ui@1.5.2":
     resolution:
       {
-        integrity: sha512-wie82VWn3cnGEdIjh4YwNESyS1G6vRHwL6cNjy9CFgNnWW/PGRjsLq300xjVH5sfPFK3iK36UxvIBymtQIEiSQ==,
+        integrity: sha512-pm1LMnQg8N2B3n2TnjKlhaFihpz6zTiA4HiGQ6/slKO/+8K9CAU5kcjdSSPgpuk1PMuuN4hxLipUIifnrkl3Sg==,
       }
 
-  "@pagefind/freebsd-x64@1.4.0":
+  "@pagefind/freebsd-x64@1.5.2":
     resolution:
       {
-        integrity: sha512-WcJVypXSZ+9HpiqZjFXMUobfFfZZ6NzIYtkhQ9eOhZrQpeY5uQFqNWLCk7w9RkMUwBv1HAMDW3YJQl/8OqsV0Q==,
+        integrity: sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==,
       }
     cpu: [x64]
     os: [freebsd]
 
-  "@pagefind/linux-arm64@1.4.0":
+  "@pagefind/linux-arm64@1.5.2":
     resolution:
       {
-        integrity: sha512-PIt8dkqt4W06KGmQjONw7EZbhDF+uXI7i0XtRLN1vjCUxM9vGPdtJc2mUyVPevjomrGz5M86M8bqTr6cgDp1Uw==,
+        integrity: sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==,
       }
     cpu: [arm64]
     os: [linux]
 
-  "@pagefind/linux-x64@1.4.0":
+  "@pagefind/linux-x64@1.5.2":
     resolution:
       {
-        integrity: sha512-z4oddcWwQ0UHrTHR8psLnVlz6USGJ/eOlDPTDYZ4cI8TK8PgwRUPQZp9D2iJPNIPcS6Qx/E4TebjuGJOyK8Mmg==,
+        integrity: sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==,
       }
     cpu: [x64]
     os: [linux]
 
-  "@pagefind/windows-x64@1.4.0":
+  "@pagefind/windows-arm64@1.5.2":
     resolution:
       {
-        integrity: sha512-NkT+YAdgS2FPCn8mIA9bQhiBs+xmniMGq1LFPDhcFn0+2yIUEiIG06t7bsZlhdjknEQRTSdT7YitP6fC5qwP0g==,
+        integrity: sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==,
+      }
+    cpu: [arm64]
+    os: [win32]
+
+  "@pagefind/windows-x64@1.5.2":
+    resolution:
+      {
+        integrity: sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==,
       }
     cpu: [x64]
     os: [win32]
@@ -2900,53 +2893,56 @@ packages:
         integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==,
       }
 
-  "@redis/bloom@5.11.0":
+  "@redis/bloom@5.12.1":
     resolution:
       {
-        integrity: sha512-KYiVilAhAFN3057afUb/tfYJpsEyTkQB+tQcn5gVVA7DgcNOAj8lLxe4j8ov8BF6I9C1Fe/kwlbuAICcTMX8Lw==,
+        integrity: sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==,
       }
-    engines: { node: ">= 18" }
+    engines: { node: ">= 18.19.0" }
     peerDependencies:
-      "@redis/client": ^5.11.0
+      "@redis/client": ^5.12.1
 
-  "@redis/client@5.11.0":
+  "@redis/client@5.12.1":
     resolution:
       {
-        integrity: sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==,
+        integrity: sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==,
       }
-    engines: { node: ">= 18" }
+    engines: { node: ">= 18.19.0" }
     peerDependencies:
       "@node-rs/xxhash": ^1.1.0
+      "@opentelemetry/api": ">=1 <2"
     peerDependenciesMeta:
       "@node-rs/xxhash":
         optional: true
+      "@opentelemetry/api":
+        optional: true
 
-  "@redis/json@5.11.0":
+  "@redis/json@5.12.1":
     resolution:
       {
-        integrity: sha512-1iAy9kAtcD0quB21RbPTbUqqy+T2Uu2JxucwE+B4A+VaDbIRvpZR6DMqV8Iqaws2YxJYB3GC5JVNzPYio2ErUg==,
+        integrity: sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==,
       }
-    engines: { node: ">= 18" }
+    engines: { node: ">= 18.19.0" }
     peerDependencies:
-      "@redis/client": ^5.11.0
+      "@redis/client": ^5.12.1
 
-  "@redis/search@5.11.0":
+  "@redis/search@5.12.1":
     resolution:
       {
-        integrity: sha512-g1l7f3Rnyk/xI99oGHIgWHSKFl45Re5YTIcO8j/JE8olz389yUFyz2+A6nqVy/Zi031VgPDWscbbgOk8hlhZ3g==,
+        integrity: sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==,
       }
-    engines: { node: ">= 18" }
+    engines: { node: ">= 18.19.0" }
     peerDependencies:
-      "@redis/client": ^5.11.0
+      "@redis/client": ^5.12.1
 
-  "@redis/time-series@5.11.0":
+  "@redis/time-series@5.12.1":
     resolution:
       {
-        integrity: sha512-TWFeOcU4xkj0DkndnOyhtxvX1KWD+78UHT3XX3x3XRBUGWeQrKo3jqzDsZwxbggUgf9yLJr/akFHXru66X5UQA==,
+        integrity: sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==,
       }
-    engines: { node: ">= 18" }
+    engines: { node: ">= 18.19.0" }
     peerDependencies:
-      "@redis/client": ^5.11.0
+      "@redis/client": ^5.12.1
 
   "@renovatebot/pep440@4.2.1":
     resolution:
@@ -2973,10 +2969,10 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  "@rolldown/binding-android-arm64@1.0.0-rc.15":
+  "@rolldown/binding-android-arm64@1.0.0-rc.18":
     resolution:
       {
-        integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==,
+        integrity: sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
@@ -3000,10 +2996,10 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  "@rolldown/binding-darwin-arm64@1.0.0-rc.15":
+  "@rolldown/binding-darwin-arm64@1.0.0-rc.18":
     resolution:
       {
-        integrity: sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==,
+        integrity: sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
@@ -3027,10 +3023,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  "@rolldown/binding-darwin-x64@1.0.0-rc.15":
+  "@rolldown/binding-darwin-x64@1.0.0-rc.18":
     resolution:
       {
-        integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==,
+        integrity: sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
@@ -3054,10 +3050,10 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  "@rolldown/binding-freebsd-x64@1.0.0-rc.15":
+  "@rolldown/binding-freebsd-x64@1.0.0-rc.18":
     resolution:
       {
-        integrity: sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==,
+        integrity: sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
@@ -3081,10 +3077,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15":
+  "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18":
     resolution:
       {
-        integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==,
+        integrity: sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
@@ -3110,10 +3106,10 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15":
+  "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18":
     resolution:
       {
-        integrity: sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==,
+        integrity: sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
@@ -3140,10 +3136,10 @@ packages:
     os: [linux]
     libc: [musl]
 
-  "@rolldown/binding-linux-arm64-musl@1.0.0-rc.15":
+  "@rolldown/binding-linux-arm64-musl@1.0.0-rc.18":
     resolution:
       {
-        integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==,
+        integrity: sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
@@ -3160,10 +3156,10 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15":
+  "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18":
     resolution:
       {
-        integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==,
+        integrity: sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ppc64]
@@ -3180,10 +3176,10 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15":
+  "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18":
     resolution:
       {
-        integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==,
+        integrity: sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [s390x]
@@ -3210,10 +3206,10 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  "@rolldown/binding-linux-x64-gnu@1.0.0-rc.15":
+  "@rolldown/binding-linux-x64-gnu@1.0.0-rc.18":
     resolution:
       {
-        integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==,
+        integrity: sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
@@ -3240,10 +3236,10 @@ packages:
     os: [linux]
     libc: [musl]
 
-  "@rolldown/binding-linux-x64-musl@1.0.0-rc.15":
+  "@rolldown/binding-linux-x64-musl@1.0.0-rc.18":
     resolution:
       {
-        integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==,
+        integrity: sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
@@ -3268,10 +3264,10 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  "@rolldown/binding-openharmony-arm64@1.0.0-rc.15":
+  "@rolldown/binding-openharmony-arm64@1.0.0-rc.18":
     resolution:
       {
-        integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==,
+        integrity: sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
@@ -3293,12 +3289,12 @@ packages:
     engines: { node: ">=14.0.0" }
     cpu: [wasm32]
 
-  "@rolldown/binding-wasm32-wasi@1.0.0-rc.15":
+  "@rolldown/binding-wasm32-wasi@1.0.0-rc.18":
     resolution:
       {
-        integrity: sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==,
+        integrity: sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==,
       }
-    engines: { node: ">=14.0.0" }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [wasm32]
 
   "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.1":
@@ -3319,10 +3315,10 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15":
+  "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18":
     resolution:
       {
-        integrity: sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==,
+        integrity: sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
@@ -3346,10 +3342,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  "@rolldown/binding-win32-x64-msvc@1.0.0-rc.15":
+  "@rolldown/binding-win32-x64-msvc@1.0.0-rc.18":
     resolution:
       {
-        integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==,
+        integrity: sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
@@ -3367,10 +3363,10 @@ packages:
         integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==,
       }
 
-  "@rolldown/pluginutils@1.0.0-rc.15":
+  "@rolldown/pluginutils@1.0.0-rc.18":
     resolution:
       {
-        integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==,
+        integrity: sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==,
       }
 
   "@rollup/pluginutils@5.3.0":
@@ -3598,10 +3594,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  "@sentry/core@10.48.0":
+  "@sentry/core@10.51.0":
     resolution:
       {
-        integrity: sha512-h8F+fXVwYC9ro5ZaO8V+v3vqc0awlXHGblEAuVxSGgh4IV/oFX+QVzXeDTTrFOFS6v/Vn5vAyu240eJrJAS6/g==,
+        integrity: sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w==,
       }
     engines: { node: ">=18" }
 
@@ -3611,25 +3607,21 @@ packages:
     peerDependencies:
       "@sentry/node": ">=10.0.0"
 
-  "@sentry/node-core@10.48.0":
+  "@sentry/node-core@10.51.0":
     resolution:
       {
-        integrity: sha512-D1TnPhN6vhrRqJ+bN+rdXDM+INibI6lNBm0eGx45zz7DBx9ouq2e9gm/DPx+y/hAkYYq0qTd6x84cGxtVZbKLw==,
+        integrity: sha512-VP9DMEzBEuauABrfDHYz/pRYa74M09uRJLz0ls3yel3sKhYHMyCB29ZxbKcciUhD4d33dwgi8DbaPZV2H/wnfQ==,
       }
     engines: { node: ">=18" }
     peerDependencies:
       "@opentelemetry/api": ^1.9.0
-      "@opentelemetry/context-async-hooks": ^1.30.1 || ^2.1.0
       "@opentelemetry/core": ^1.30.1 || ^2.1.0
       "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1"
       "@opentelemetry/instrumentation": ">=0.57.1 <1"
-      "@opentelemetry/resources": ^1.30.1 || ^2.1.0
       "@opentelemetry/sdk-trace-base": ^1.30.1 || ^2.1.0
       "@opentelemetry/semantic-conventions": ^1.39.0
     peerDependenciesMeta:
       "@opentelemetry/api":
-        optional: true
-      "@opentelemetry/context-async-hooks":
         optional: true
       "@opentelemetry/core":
         optional: true
@@ -3637,29 +3629,26 @@ packages:
         optional: true
       "@opentelemetry/instrumentation":
         optional: true
-      "@opentelemetry/resources":
-        optional: true
       "@opentelemetry/sdk-trace-base":
         optional: true
       "@opentelemetry/semantic-conventions":
         optional: true
 
-  "@sentry/node@10.48.0":
+  "@sentry/node@10.51.0":
     resolution:
       {
-        integrity: sha512-MzyLJyYmr0Qg60K6NJ2EdwJUX1OuAYXs9tyYxnqVO3nJ8MyYwIcuN4FCYEnXkG6Jiy/4q7OuZgXWnfdQJVcaqw==,
+        integrity: sha512-2yZLRZwS1dKG8/4eOTpGSo/gO/EgmT9aPj6lAzUkRa7bZCTTdW4BraaHU0leX5T94909Qfhbr3W5AVTfDOCKiQ==,
       }
     engines: { node: ">=18" }
 
-  "@sentry/opentelemetry@10.48.0":
+  "@sentry/opentelemetry@10.51.0":
     resolution:
       {
-        integrity: sha512-Tn6Y0PZjRJ7OW8loK1ntK7wnJnIINnCfSpnwuqow0FMblaDmu5jDVOYq0U1SJBoBcMD5j9aSqrwyj6zqKwjc0A==,
+        integrity: sha512-Qc7AlCE4uhB+SvHLqah4RgR1WdY7wmmr/hx9g/prDP9R1ocshmUEMrZK9qjuwaklW7/fmkFCXI8ETxo5L1bHIA==,
       }
     engines: { node: ">=18" }
     peerDependencies:
       "@opentelemetry/api": ^1.9.0
-      "@opentelemetry/context-async-hooks": ^1.30.1 || ^2.1.0
       "@opentelemetry/core": ^1.30.1 || ^2.1.0
       "@opentelemetry/sdk-trace-base": ^1.30.1 || ^2.1.0
       "@opentelemetry/semantic-conventions": ^1.39.0
@@ -3725,17 +3714,24 @@ packages:
       }
     engines: { node: ">= 18", npm: ">= 8.6.0" }
 
-  "@slack/types@2.20.1":
+  "@slack/socket-mode@2.0.7":
     resolution:
       {
-        integrity: sha512-eWX2mdt1ktpn8+40iiMc404uGrih+2fxiky3zBcPjtXKj6HLRdYlmhrPkJi7JTJm8dpXR6BWVWEDBXtaWMKD6A==,
+        integrity: sha512-qYy07je71WnEHgRwmw12DlAnZLi5HXmdlI2WUzUK2LH/rYXQpP6uEg462S5CwfE8FoCKUdIigHtYnOOfzZH1lQ==,
+      }
+    engines: { node: ">= 18", npm: ">= 8.6.0" }
+
+  "@slack/types@2.21.0":
+    resolution:
+      {
+        integrity: sha512-ZLMsKnD5KLRPmhFEoGoBQUD5Pc2bH3xFc5ygHlioEc0WmLGyZGoGCtMff4rpejrFnptrhfxcKpWxW4r3g39R0A==,
       }
     engines: { node: ">= 12.13.0", npm: ">= 6.12.0" }
 
-  "@slack/web-api@7.15.1":
+  "@slack/web-api@7.15.2":
     resolution:
       {
-        integrity: sha512-y+TAF7TszcmFzbVtBkFqAdBwKSoD+8shkNxhp4WIfFwXmCKdFje9WD6evROApPa2FTy1v1uc9yBaJs3609PPgg==,
+        integrity: sha512-/m9qVFkiq85Oa/FSQwYIRDa/AO4qNYkDh4sRBK1WqEc2+RyG7w4tbU6rBIwUOcc/TmWOIr24Nraquxg7um5mYw==,
       }
     engines: { node: ">= 18", npm: ">= 8.6.0" }
 
@@ -4230,6 +4226,12 @@ packages:
         integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==,
       }
 
+  "@tybys/wasm-util@0.10.2":
+    resolution:
+      {
+        integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==,
+      }
+
   "@types/chai@5.2.3":
     resolution:
       {
@@ -4264,6 +4266,12 @@ packages:
     resolution:
       {
         integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
+      }
+
+  "@types/estree@1.0.9":
+    resolution:
+      {
+        integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==,
       }
 
   "@types/hast@3.0.4":
@@ -4320,10 +4328,10 @@ packages:
         integrity: sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==,
       }
 
-  "@types/node@24.12.0":
+  "@types/node@24.12.2":
     resolution:
       {
-        integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==,
+        integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==,
       }
 
   "@types/node@25.6.0":
@@ -4356,6 +4364,12 @@ packages:
         integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==,
       }
 
+  "@types/set-cookie-parser@2.4.10":
+    resolution:
+      {
+        integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==,
+      }
+
   "@types/statuses@2.0.6":
     resolution:
       {
@@ -4378,6 +4392,12 @@ packages:
     resolution:
       {
         integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==,
+      }
+
+  "@types/ws@8.18.1":
+    resolution:
+      {
+        integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==,
       }
 
   "@ungap/structured-clone@1.3.0":
@@ -4454,10 +4474,10 @@ packages:
       }
     engines: { node: ">= 18" }
 
-  "@vercel/functions@3.4.3":
+  "@vercel/functions@3.5.0":
     resolution:
       {
-        integrity: sha512-kA14KIUVgAY6VXbhZ5jjY+s0883cV3cZqIU3WhrSRxuJ9KvxatMjtmzl0K23HK59oOUjYl7HaE/eYMmhmqpZzw==,
+        integrity: sha512-+RokZ+4gkYyOsKBuJ29cQ8iSZG123LLJbZfPry20kkTgrN9U0277La4feP4DnWVo3sGoYa4plCEKY9XKUYoX9g==,
       }
     engines: { node: ">= 20" }
     peerDependencies:
@@ -4534,17 +4554,17 @@ packages:
         integrity: sha512-pnFB7ja1NJAHhFeArwb9vuYGehNQc9Lip4DjYmDthzRbheuzMwzN3y5H5pu7mDzGgEHTlsS6bs3aiOVbFS4dQw==,
       }
 
-  "@vercel/oidc@3.1.0":
-    resolution:
-      {
-        integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==,
-      }
-    engines: { node: ">= 20" }
-
   "@vercel/oidc@3.2.0":
     resolution:
       {
         integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==,
+      }
+    engines: { node: ">= 20" }
+
+  "@vercel/oidc@3.4.0":
+    resolution:
+      {
+        integrity: sha512-p0sKfHkfRmMaqqDwNL4tjnX9TgRrLMlEtUjIxfrEns8pOxz1R9ztqOVI+ehqiq93/2/HnfPe/UBZkfAZwnx0UA==,
       }
     engines: { node: ">= 20" }
 
@@ -4614,16 +4634,16 @@ packages:
         integrity: sha512-UpOEIgWxWx0M+mDe1IMdHS6JuWM/L5nNIJ4ixX8v9JgBAejymo88OkgnmfLCNMem0Wd+b5vcQPWLdZybCndlsA==,
       }
 
-  "@vitest/expect@4.1.4":
+  "@vitest/expect@4.1.5":
     resolution:
       {
-        integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==,
+        integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==,
       }
 
-  "@vitest/mocker@4.1.4":
+  "@vitest/mocker@4.1.5":
     resolution:
       {
-        integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==,
+        integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==,
       }
     peerDependencies:
       msw: ^2.4.9
@@ -4634,34 +4654,34 @@ packages:
       vite:
         optional: true
 
-  "@vitest/pretty-format@4.1.4":
+  "@vitest/pretty-format@4.1.5":
     resolution:
       {
-        integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==,
+        integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==,
       }
 
-  "@vitest/runner@4.1.4":
+  "@vitest/runner@4.1.5":
     resolution:
       {
-        integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==,
+        integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==,
       }
 
-  "@vitest/snapshot@4.1.4":
+  "@vitest/snapshot@4.1.5":
     resolution:
       {
-        integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==,
+        integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==,
       }
 
-  "@vitest/spy@4.1.4":
+  "@vitest/spy@4.1.5":
     resolution:
       {
-        integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==,
+        integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==,
       }
 
-  "@vitest/utils@4.1.4":
+  "@vitest/utils@4.1.5":
     resolution:
       {
-        integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==,
+        integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==,
       }
 
   "@volar/kit@2.4.28":
@@ -4785,17 +4805,17 @@ packages:
       }
     engines: { node: ">= 14" }
 
-  agent-browser@0.23.3:
+  agent-browser@0.26.0:
     resolution:
       {
-        integrity: sha512-Wmw6O3zJujp7m3D0ExPXZwc6jB2rkeSHR5Wzn/J6EL7nAadlw7fXMbuvut0lJVADLqQw13EL4zUDeeEp942Fng==,
+        integrity: sha512-pdqSfjwbFSp+qnwlb2g23e9wXveIOfMi19xpPA9xZUbzEAUp6W4YBZj6Ybj8z4M7WkcbGDDYc+oDIHDt9R3EDQ==,
       }
     hasBin: true
 
-  ai@6.0.162:
+  ai@6.0.175:
     resolution:
       {
-        integrity: sha512-1PSvNEK1PEbpUXahnFrcey6l7DJXMVWmg0ibQ8h8oMSe9V1Vx5d+R3xNu0hzBtwqfxYj21ddZo+EUYVs6GOEyA==,
+        integrity: sha512-6fFFHzbh6FIZnYc31V6osOxq25ABJYCShfG0O6ajHiA4FB/DgnPi1mP8cO5aAU3HNSbQHiMazdlh9bIsp97mVA==,
       }
     engines: { node: ">=18" }
     peerDependencies:
@@ -4827,6 +4847,12 @@ packages:
     resolution:
       {
         integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==,
+      }
+
+  ajv@8.20.0:
+    resolution:
+      {
+        integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==,
       }
 
   ajv@8.6.3:
@@ -4996,10 +5022,10 @@ packages:
         integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==,
       }
 
-  axios@1.15.0:
+  axios@1.16.0:
     resolution:
       {
-        integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==,
+        integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==,
       }
 
   axobject-query@4.1.0:
@@ -5288,10 +5314,10 @@ packages:
         integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==,
       }
 
-  chat@4.26.0:
+  chat@4.27.0:
     resolution:
       {
-        integrity: sha512-QToDnIEGpyb8yQA6YLMHOSRK30YVk4RtsyFyuWFYyB2c4jQlyIrSWtwVK7qyvmvqzQp9uDwCdJRAhS8GtCHAGQ==,
+        integrity: sha512-PrL4k263DSIlckhX8eHLT84RdTSznOBxCCfaDc5JVJtWaS0lJkCNctm/g3gIrI41AcDHcpc/3WDoUHVrbh0W4w==,
       }
 
   chokidar@4.0.0:
@@ -5763,10 +5789,10 @@ packages:
       }
     engines: { node: ">= 0.8" }
 
-  dependency-cruiser@17.3.10:
+  dependency-cruiser@17.4.0:
     resolution:
       {
-        integrity: sha512-jF5WaIb+O+wLabXrQE7iBY2zYBEW8VlnuuL0+iZPvZHGhTaAYdLk31DI0zkwhcGE8CiHcDwGhMnn3PfOAYnVdQ==,
+        integrity: sha512-+WdFoOb+fT1XNC0iPqOyLpfhLd8xVh7eLXJxPAtiXCS+YmXzGrjqVTte7+L8SZIsnJj0aFhb8LxECIBJY5TTIA==,
       }
     engines: { node: ^20.12||^22||>=24 }
     hasBin: true
@@ -5926,10 +5952,10 @@ packages:
         integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==,
       }
 
-  enhanced-resolve@5.20.1:
+  enhanced-resolve@5.21.0:
     resolution:
       {
-        integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==,
+        integrity: sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==,
       }
     engines: { node: ">=10.13.0" }
 
@@ -6001,10 +6027,10 @@ packages:
         integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==,
       }
 
-  es-module-lexer@2.0.0:
+  es-module-lexer@2.1.0:
     resolution:
       {
-        integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==,
+        integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==,
       }
 
   es-object-atoms@1.1.1:
@@ -6193,6 +6219,13 @@ packages:
       }
     engines: { node: ">=18.0.0" }
 
+  eventsource-parser@3.0.8:
+    resolution:
+      {
+        integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==,
+      }
+    engines: { node: ">=18.0.0" }
+
   eventsource@3.0.7:
     resolution:
       {
@@ -6281,10 +6314,34 @@ packages:
       }
     engines: { node: ">=8.6.0" }
 
+  fast-string-truncated-width@3.0.3:
+    resolution:
+      {
+        integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==,
+      }
+
+  fast-string-width@3.0.2:
+    resolution:
+      {
+        integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==,
+      }
+
   fast-uri@3.1.0:
     resolution:
       {
         integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==,
+      }
+
+  fast-uri@3.1.2:
+    resolution:
+      {
+        integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==,
+      }
+
+  fast-wrap-ansi@0.2.0:
+    resolution:
+      {
+        integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==,
       }
 
   fast-xml-builder@1.1.4:
@@ -6293,17 +6350,17 @@ packages:
         integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==,
       }
 
+  fast-xml-parser@5.3.3:
+    resolution:
+      {
+        integrity: sha512-2O3dkPAAC6JavuMm8+4+pgTk+5hoAs+CjZ+sWcQLkX9+/tHRuTkQh/Oaifr8qDmZ8iEHb771Ea6G8CdwkrgvYA==,
+      }
+    hasBin: true
+
   fast-xml-parser@5.5.8:
     resolution:
       {
         integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==,
-      }
-    hasBin: true
-
-  fast-xml-parser@5.5.9:
-    resolution:
-      {
-        integrity: sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==,
       }
     hasBin: true
 
@@ -6378,10 +6435,10 @@ packages:
       }
     engines: { node: ">=8" }
 
-  follow-redirects@1.15.11:
+  follow-redirects@1.16.0:
     resolution:
       {
-        integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==,
+        integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==,
       }
     engines: { node: ">=4.0" }
     peerDependencies:
@@ -6607,10 +6664,10 @@ packages:
         integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
       }
 
-  graphql@16.13.2:
+  graphql@16.14.0:
     resolution:
       {
-        integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==,
+        integrity: sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==,
       }
     engines: { node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0 }
 
@@ -6620,10 +6677,10 @@ packages:
         integrity: sha512-YzJeWSkDZxAhvmp8dexjRK5hxziRO7I9m0N53WhvYL5NiWfkUkzssVzY9jvGu0HBoLFW6+duYmNSn6MaZBCCtg==,
       }
 
-  h3@2.0.1-rc.20:
+  h3@2.0.1-rc.22:
     resolution:
       {
-        integrity: sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg==,
+        integrity: sha512-Esv0DMIuPkCTSWCA0vO73vcTqwzH1wjSrAO1TXNu/K3up1sZHa9EKMapbmxCDYBeymC3fVTk4qxp7ogQWQ+KgA==,
       }
     engines: { node: ">=20.11.1" }
     hasBin: true
@@ -6658,6 +6715,13 @@ packages:
     resolution:
       {
         integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==,
+      }
+    engines: { node: ">= 0.4" }
+
+  hasown@2.0.3:
+    resolution:
+      {
+        integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==,
       }
     engines: { node: ">= 0.4" }
 
@@ -6788,16 +6852,16 @@ packages:
       }
     hasBin: true
 
-  headers-polyfill@4.0.3:
+  headers-polyfill@5.0.1:
     resolution:
       {
-        integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==,
+        integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==,
       }
 
-  hono@4.12.14:
+  hono@4.12.18:
     resolution:
       {
-        integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==,
+        integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==,
       }
     engines: { node: ">=16.9.0" }
 
@@ -6859,10 +6923,10 @@ packages:
       }
     engines: { node: ">= 14" }
 
-  httpxy@0.5.0:
+  httpxy@0.5.1:
     resolution:
       {
-        integrity: sha512-qwX7QX/rK2visT10/b7bSeZWQOMlSm3svTD0pZpU+vJjNUP0YHtNv4c3z+MO+MSnGuRFWJFdCZiV+7F7dXIOzg==,
+        integrity: sha512-JPhqYiixe1A1I+MXDewWDZqeudBGU8Q9jCHYN8ML+779RQzLjTi78HBvWz4jMxUD6h2/vUL12g4q/mFM0OUw1A==,
       }
 
   human-signals@1.1.1:
@@ -6918,10 +6982,10 @@ packages:
         integrity: sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==,
       }
 
-  import-in-the-middle@3.0.0:
+  import-in-the-middle@3.0.1:
     resolution:
       {
-        integrity: sha512-OnGy+eYT7wVejH2XWgLRgbmzujhhVIATQH0ztIeRilwHBjTeG3pD+XnH3PKX0r9gJ0BuJmJ68q/oh9qgXnNDQg==,
+        integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==,
       }
     engines: { node: ">=18" }
 
@@ -7009,10 +7073,10 @@ packages:
       }
     engines: { node: ">=4" }
 
-  is-core-module@2.16.1:
+  is-core-module@2.16.2:
     resolution:
       {
-        integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==,
+        integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==,
       }
     engines: { node: ">= 0.4" }
 
@@ -7138,10 +7202,10 @@ packages:
         integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
       }
 
-  jiti@2.6.1:
+  jiti@2.7.0:
     resolution:
       {
-        integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==,
+        integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==,
       }
     hasBin: true
 
@@ -7240,10 +7304,10 @@ packages:
         integrity: sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==,
       }
 
-  just-bash@2.14.2:
+  just-bash@2.14.4:
     resolution:
       {
-        integrity: sha512-9Na1rH03Ta5ydHTNotJ7dms1iZwb2kToOnKbnS29AlrCvi1CQ21Fm2lfu4S4rfwDGHYi4E4evgTDC/DcDx8tuQ==,
+        integrity: sha512-d8PR7XX4e6rRQ9CLWkllotV+5EF/hOGwR7/dQtr8lGHNO/HTjubpBbdoavGUAc70YwxpYjPxdrJ5JCAqEs33jg==,
       }
     hasBin: true
 
@@ -8061,10 +8125,10 @@ packages:
         integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
       }
 
-  msw@2.13.3:
+  msw@2.14.3:
     resolution:
       {
-        integrity: sha512-/F49bxavkNGfreMlrKmTxZs6YorjfMbbDLd89Q3pWi+cXGtQQNXXaHt4MkXN7li91xnQJ24HWXqW9QDm5id33w==,
+        integrity: sha512-kk8G5cocVlJ4wsKMGZegn2H6XLOEKjbA+nSJE2354e/SRp4mDicCHUYnMXpymzVcVDCs+GUAsmNqSn+yHv4T2A==,
       }
     engines: { node: ">=18" }
     hasBin: true
@@ -8080,12 +8144,12 @@ packages:
         integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==,
       }
 
-  mute-stream@2.0.0:
+  mute-stream@3.0.0:
     resolution:
       {
-        integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==,
+        integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==,
       }
-    engines: { node: ^18.17.0 || >=20.5.0 }
+    engines: { node: ^20.17.0 || >=22.9.0 }
 
   mz@2.7.0:
     resolution:
@@ -8097,6 +8161,14 @@ packages:
     resolution:
       {
         integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==,
+      }
+    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
+    hasBin: true
+
+  nanoid@3.3.12:
+    resolution:
+      {
+        integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==,
       }
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
@@ -8134,19 +8206,19 @@ packages:
         integrity: sha512-Gs0xRPpUm2nDkqbi40NJ9g7qDIcjcJzgExiydnq6LAyqhI2jfno8wG3NKTL+IiJsx799UHOb1CnSd4Wg4SG4Pw==,
       }
 
-  nitro@3.0.260415-beta:
+  nitro@3.0.260429-beta:
     resolution:
       {
-        integrity: sha512-J0ntJERWtIdvweZdmkCiF8eOFvP9fIAJR2gpeIDrHbAlYavK41WQfADo/YoZ/LF7RMTZBiPaH/pt2s/nPru9Iw==,
+        integrity: sha512-KweLVCUN5X9v9g+4yxAyRcz3FcOlnjmt9FyrAIWDxJETJmNT7I0JV0clgsONjo2nI0U5gwedXYA3RaNtF5XWzg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
     peerDependencies:
-      "@vercel/queue": ^0.1.4
+      "@vercel/queue": ^0.1.6
       dotenv: "*"
       giget: "*"
       jiti: ^2.6.1
-      rollup: ^4.60.1
+      rollup: ^4.60.2
       vite: ^7 || ^8
       xml2js: ^0.6.2
       zephyr-agent: ^0.2.0
@@ -8174,10 +8246,10 @@ packages:
         integrity: sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==,
       }
 
-  node-abi@3.89.0:
+  node-abi@3.92.0:
     resolution:
       {
-        integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==,
+        integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==,
       }
     engines: { node: ">=10" }
 
@@ -8431,15 +8503,15 @@ packages:
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
 
-  oxlint@1.60.0:
+  oxlint@1.63.0:
     resolution:
       {
-        integrity: sha512-tnRzTWiWJ9pg3ftRWnD0+Oqh78L6ZSwcEudvCZaER0PIqiAnNyXj5N1dPwjmNpDalkKS9m/WMLN1CTPUBPmsgw==,
+        integrity: sha512-9TGXetdjgIHOJ9OiReomP7nnrMkV9HxC1xM2ramJSLQpzxjsAJtQwa4wqkJN2f/uCrqZuJseFuSlWDdvcruveg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
     peerDependencies:
-      oxlint-tsgolint: ">=0.18.0"
+      oxlint-tsgolint: ">=0.22.1"
     peerDependenciesMeta:
       oxlint-tsgolint:
         optional: true
@@ -8520,10 +8592,10 @@ packages:
         integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==,
       }
 
-  pagefind@1.4.0:
+  pagefind@1.5.2:
     resolution:
       {
-        integrity: sha512-z2kY1mQlL4J8q5EIsQkLzQjilovKzfNVhX8De6oyE6uHpfFtyBaqUpcl/XzJC/4fjD8vBDyh1zolimIcVrCn9g==,
+        integrity: sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==,
       }
     hasBin: true
 
@@ -8629,10 +8701,10 @@ packages:
         integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==,
       }
 
-  path-to-regexp@8.4.1:
+  path-to-regexp@8.4.2:
     resolution:
       {
-        integrity: sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==,
+        integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==,
       }
 
   pathe@2.0.3:
@@ -8755,6 +8827,13 @@ packages:
         integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==,
       }
     engines: { node: ">=4" }
+
+  postcss@8.5.14:
+    resolution:
+      {
+        integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==,
+      }
+    engines: { node: ^10 || ^12 || >=14 }
 
   postcss@8.5.8:
     resolution:
@@ -8962,10 +9041,10 @@ packages:
       }
     hasBin: true
 
-  re2js@1.2.3:
+  re2js@1.3.3:
     resolution:
       {
-        integrity: sha512-M2/7k8LkP+LmB/muGZXvAHiwhgwqq0Ign2UHCZkea39nHOakeixyMSfb7rql7N/6u5PTS+IpP2MKfRLJ4fed0g==,
+        integrity: sha512-s/I5zEAo79SUK0Qw4dpZKpiMwbQ6Gz0KU2NRr7eaO4x/p2g7Vvmn3hdeXDg8VsaUjfj/ora+e9oi27LX/C9+mw==,
       }
 
   readable-stream@3.6.2:
@@ -9022,12 +9101,12 @@ packages:
         integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==,
       }
 
-  redis@5.11.0:
+  redis@5.12.1:
     resolution:
       {
-        integrity: sha512-YwXjATVDT+AuxcyfOwZn046aml9jMlQPvU1VXIlLDVAExe0u93aTfPYSeRgG4p9Q/Jlkj+LXJ1XEoFV+j2JKcQ==,
+        integrity: sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==,
       }
-    engines: { node: ">= 18" }
+    engines: { node: ">= 18.19.0" }
 
   regex-recursion@6.0.2:
     resolution:
@@ -9198,10 +9277,10 @@ packages:
       }
     engines: { node: ">=10" }
 
-  resolve@1.22.11:
+  resolve@1.22.12:
     resolution:
       {
-        integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==,
+        integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==,
       }
     engines: { node: ">= 0.4" }
     hasBin: true
@@ -9244,10 +9323,10 @@ packages:
       }
     engines: { node: ">= 4" }
 
-  rettime@0.11.7:
+  rettime@0.11.11:
     resolution:
       {
-        integrity: sha512-DoAm1WjR1eH7z8sHPtvvUMIZh4/CSKkGCz6CxPqOrEAnOGtOuHSnSE9OC+razqxKuf4ub7pAYyl/vZV0vGs5tg==,
+        integrity: sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==,
       }
 
   reusify@1.1.0:
@@ -9279,10 +9358,10 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
 
-  rolldown@1.0.0-rc.15:
+  rolldown@1.0.0-rc.18:
     resolution:
       {
-        integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==,
+        integrity: sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
@@ -9389,6 +9468,12 @@ packages:
         integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==,
       }
     engines: { node: ">= 18" }
+
+  set-cookie-parser@3.1.0:
+    resolution:
+      {
+        integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==,
+      }
 
   setprototypeof@1.1.1:
     resolution:
@@ -9663,10 +9748,10 @@ packages:
       }
     engines: { node: ">= 0.8" }
 
-  std-env@4.0.0:
+  std-env@4.1.0:
     resolution:
       {
-        integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==,
+        integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==,
       }
 
   stream-replace-string@2.0.0:
@@ -9780,6 +9865,12 @@ packages:
         integrity: sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==,
       }
 
+  strnum@2.2.3:
+    resolution:
+      {
+        integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==,
+      }
+
   strtok3@10.3.5:
     resolution:
       {
@@ -9836,10 +9927,10 @@ packages:
       }
     engines: { node: ">=20" }
 
-  tapable@2.3.2:
+  tapable@2.3.3:
     resolution:
       {
-        integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==,
+        integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==,
       }
     engines: { node: ">=6" }
 
@@ -9943,10 +10034,24 @@ packages:
       }
     engines: { node: ">=18" }
 
+  tinyexec@1.1.2:
+    resolution:
+      {
+        integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==,
+      }
+    engines: { node: ">=18" }
+
   tinyglobby@0.2.15:
     resolution:
       {
         integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==,
+      }
+    engines: { node: ">=12.0.0" }
+
+  tinyglobby@0.2.16:
+    resolution:
+      {
+        integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==,
       }
     engines: { node: ">=12.0.0" }
 
@@ -9957,16 +10062,16 @@ packages:
       }
     engines: { node: ">=14.0.0" }
 
-  tldts-core@7.0.27:
+  tldts-core@7.0.30:
     resolution:
       {
-        integrity: sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==,
+        integrity: sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==,
       }
 
-  tldts@7.0.27:
+  tldts@7.0.30:
     resolution:
       {
-        integrity: sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==,
+        integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==,
       }
     hasBin: true
 
@@ -10123,11 +10228,12 @@ packages:
         integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==,
       }
 
-  turndown@7.2.2:
+  turndown@7.2.4:
     resolution:
       {
-        integrity: sha512-1F7db8BiExOKxjSMU2b7if62D/XOyQyZbPKq/nUwopfgnHlqXHqQ0lvfUTeUIr1lZJzOPFn43dODyMSIfvWRKQ==,
+        integrity: sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==,
       }
+    engines: { node: ">=18", npm: ">=9" }
 
   type-fest@4.41.0:
     resolution:
@@ -10136,10 +10242,10 @@ packages:
       }
     engines: { node: ">=16" }
 
-  type-fest@5.5.0:
+  type-fest@5.6.0:
     resolution:
       {
-        integrity: sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==,
+        integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==,
       }
     engines: { node: ">=20" }
 
@@ -10149,6 +10255,12 @@ packages:
         integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==,
       }
     engines: { node: ">= 0.6" }
+
+  typebox@1.1.38:
+    resolution:
+      {
+        integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==,
+      }
 
   typedoc-plugin-markdown@4.11.0:
     resolution:
@@ -10188,12 +10300,6 @@ packages:
       }
     engines: { node: ">=14.17" }
     hasBin: true
-
-  typebox@1.1.38:
-    resolution:
-      {
-        integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==,
-      }
 
   uc.micro@2.1.0:
     resolution:
@@ -10672,10 +10778,10 @@ packages:
       zod:
         optional: true
 
-  vitest@4.1.4:
+  vitest@4.1.5:
     resolution:
       {
-        integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==,
+        integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==,
       }
     engines: { node: ^20.0.0 || ^22.0.0 || >=24.0.0 }
     hasBin: true
@@ -10683,12 +10789,12 @@ packages:
       "@edge-runtime/vm": "*"
       "@opentelemetry/api": ^1.9.0
       "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
-      "@vitest/browser-playwright": 4.1.4
-      "@vitest/browser-preview": 4.1.4
-      "@vitest/browser-webdriverio": 4.1.4
-      "@vitest/coverage-istanbul": 4.1.4
-      "@vitest/coverage-v8": 4.1.4
-      "@vitest/ui": 4.1.4
+      "@vitest/browser-playwright": 4.1.5
+      "@vitest/browser-preview": 4.1.5
+      "@vitest/browser-webdriverio": 4.1.5
+      "@vitest/coverage-istanbul": 4.1.5
+      "@vitest/coverage-v8": 4.1.5
+      "@vitest/ui": 4.1.5
       happy-dom: "*"
       jsdom: "*"
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -10928,13 +11034,6 @@ packages:
       }
     engines: { node: ">=18" }
 
-  wrap-ansi@6.2.0:
-    resolution:
-      {
-        integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==,
-      }
-    engines: { node: ">=8" }
-
   wrap-ansi@7.0.0:
     resolution:
       {
@@ -11040,6 +11139,14 @@ packages:
     engines: { node: ">= 14.6" }
     hasBin: true
 
+  yaml@2.8.4:
+    resolution:
+      {
+        integrity: sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==,
+      }
+    engines: { node: ">= 14.6" }
+    hasBin: true
+
   yargs-parser@21.1.1:
     resolution:
       {
@@ -11088,13 +11195,6 @@ packages:
       }
     engines: { node: ">=18.19" }
 
-  yoctocolors-cjs@2.1.3:
-    resolution:
-      {
-        integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==,
-      }
-    engines: { node: ">=18" }
-
   yoctocolors@2.1.2:
     resolution:
       {
@@ -11137,10 +11237,10 @@ packages:
         integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==,
       }
 
-  zod@4.3.6:
+  zod@4.4.3:
     resolution:
       {
-        integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==,
+        integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==,
       }
 
   zwitch@2.0.4:
@@ -11150,39 +11250,33 @@ packages:
       }
 
 snapshots:
-  "@ai-sdk/gateway@3.0.99(zod@4.3.6)":
+  "@ai-sdk/gateway@3.0.110(zod@4.4.3)":
     dependencies:
-      "@ai-sdk/provider": 3.0.8
-      "@ai-sdk/provider-utils": 4.0.23(zod@4.3.6)
-      "@vercel/oidc": 3.1.0
-      zod: 4.3.6
+      "@ai-sdk/provider": 3.0.10
+      "@ai-sdk/provider-utils": 4.0.26(zod@4.4.3)
+      "@vercel/oidc": 3.2.0
+      zod: 4.4.3
 
-  "@ai-sdk/provider-utils@4.0.23(zod@4.3.6)":
+  "@ai-sdk/provider-utils@4.0.26(zod@4.4.3)":
     dependencies:
-      "@ai-sdk/provider": 3.0.8
+      "@ai-sdk/provider": 3.0.10
       "@standard-schema/spec": 1.1.0
-      eventsource-parser: 3.0.6
-      zod: 4.3.6
+      eventsource-parser: 3.0.8
+      zod: 4.4.3
 
-  "@ai-sdk/provider@3.0.8":
+  "@ai-sdk/provider@3.0.10":
     dependencies:
       json-schema: 0.4.0
 
-  "@anthropic-ai/sdk@0.90.0(zod@4.3.6)":
+  "@anthropic-ai/sdk@0.91.1(zod@4.4.3)":
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
-  "@anthropic-ai/sdk@0.91.1(zod@4.3.6)":
+  "@astrojs/check@0.9.9(prettier@3.8.3)(typescript@5.9.3)":
     dependencies:
-      json-schema-to-ts: 3.1.1
-    optionalDependencies:
-      zod: 4.3.6
-
-  "@astrojs/check@0.9.8(prettier@3.8.3)(typescript@5.9.3)":
-    dependencies:
-      "@astrojs/language-server": 2.16.6(prettier@3.8.3)(typescript@5.9.3)
+      "@astrojs/language-server": 2.16.7(prettier@3.8.3)(typescript@5.9.3)
       chokidar: 4.0.3
       kleur: 4.1.5
       typescript: 5.9.3
@@ -11195,7 +11289,7 @@ snapshots:
 
   "@astrojs/internal-helpers@0.7.6": {}
 
-  "@astrojs/language-server@2.16.6(prettier@3.8.3)(typescript@5.9.3)":
+  "@astrojs/language-server@2.16.7(prettier@3.8.3)(typescript@5.9.3)":
     dependencies:
       "@astrojs/compiler": 2.13.1
       "@astrojs/yaml2ts": 0.2.3
@@ -11205,7 +11299,7 @@ snapshots:
       "@volar/language-server": 2.4.28
       "@volar/language-service": 2.4.28
       muggle-string: 0.4.1
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       volar-service-css: 0.0.70(@volar/language-service@2.4.28)
       volar-service-emmet: 0.0.70(@volar/language-service@2.4.28)
       volar-service-html: 0.0.70(@volar/language-service@2.4.28)
@@ -11246,12 +11340,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@astrojs/mdx@4.3.14(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))":
+  "@astrojs/mdx@4.3.14(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4))":
     dependencies:
       "@astrojs/markdown-remark": 6.3.11
       "@mdx-js/mdx": 3.1.1
       acorn: 8.16.0
-      astro: 5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      astro: 5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)
       es-module-lexer: 1.7.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -11273,19 +11367,19 @@ snapshots:
     dependencies:
       sitemap: 9.0.1
       stream-replace-string: 2.0.0
-      zod: 4.3.6
+      zod: 4.4.3
 
-  "@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))":
+  "@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4))":
     dependencies:
       "@astrojs/markdown-remark": 6.3.11
-      "@astrojs/mdx": 4.3.14(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
+      "@astrojs/mdx": 4.3.14(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4))
       "@astrojs/sitemap": 3.7.2
-      "@pagefind/default-ui": 1.4.0
+      "@pagefind/default-ui": 1.5.2
       "@types/hast": 3.0.4
       "@types/js-yaml": 4.0.9
       "@types/mdast": 4.0.4
-      astro: 5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
-      astro-expressive-code: 0.41.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
+      astro: 5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)
+      astro-expressive-code: 0.41.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -11298,7 +11392,7 @@ snapshots:
       mdast-util-directive: 3.1.0
       mdast-util-to-markdown: 2.1.2
       mdast-util-to-string: 4.0.0
-      pagefind: 1.4.0
+      pagefind: 1.5.2
       rehype: 13.0.2
       rehype-format: 5.0.1
       remark-directive: 3.0.1
@@ -11323,7 +11417,7 @@ snapshots:
 
   "@astrojs/yaml2ts@0.2.3":
     dependencies:
-      yaml: 2.8.3
+      yaml: 2.8.4
 
   "@aws-crypto/crc32@5.2.0":
     dependencies:
@@ -11756,33 +11850,37 @@ snapshots:
     dependencies:
       fontkitten: 1.0.3
 
-  "@chat-adapter/shared@4.26.0":
+  "@chat-adapter/shared@4.27.0":
     dependencies:
-      chat: 4.26.0
+      chat: 4.27.0
     transitivePeerDependencies:
       - supports-color
 
-  "@chat-adapter/slack@4.26.0":
+  "@chat-adapter/slack@4.27.0":
     dependencies:
-      "@chat-adapter/shared": 4.26.0
-      "@slack/web-api": 7.15.1
-      chat: 4.26.0
+      "@chat-adapter/shared": 4.27.0
+      "@slack/socket-mode": 2.0.7
+      "@slack/web-api": 7.15.2
+      chat: 4.27.0
     transitivePeerDependencies:
+      - bufferutil
       - debug
       - supports-color
+      - utf-8-validate
 
-  "@chat-adapter/state-memory@4.26.0":
+  "@chat-adapter/state-memory@4.27.0":
     dependencies:
-      chat: 4.26.0
+      chat: 4.27.0
     transitivePeerDependencies:
       - supports-color
 
-  "@chat-adapter/state-redis@4.26.0":
+  "@chat-adapter/state-redis@4.27.0(@opentelemetry/api@1.9.1)":
     dependencies:
-      chat: 4.26.0
-      redis: 5.11.0
+      chat: 4.27.0
+      redis: 5.12.1(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - "@node-rs/xxhash"
+      - "@opentelemetry/api"
       - supports-color
 
   "@ctrl/tinycolor@4.2.0": {}
@@ -11822,18 +11920,18 @@ snapshots:
 
   "@emmetio/stream-reader@2.2.0": {}
 
-  "@emnapi/core@1.9.2":
+  "@emnapi/core@1.10.0":
     dependencies:
       "@emnapi/wasi-threads": 1.2.1
       tslib: 2.8.1
     optional: true
 
-  "@emnapi/runtime@1.9.1":
+  "@emnapi/runtime@1.10.0":
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  "@emnapi/runtime@1.9.2":
+  "@emnapi/runtime@1.9.1":
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -12084,8 +12182,8 @@ snapshots:
       hast-util-to-html: 9.0.5
       hast-util-to-text: 4.0.2
       hastscript: 9.0.1
-      postcss: 8.5.8
-      postcss-nested: 6.2.0(postcss@8.5.8)
+      postcss: 8.5.14
+      postcss-nested: 6.2.0(postcss@8.5.14)
       unist-util-visit: 5.1.0
       unist-util-visit-parents: 6.0.2
 
@@ -12107,7 +12205,7 @@ snapshots:
   "@fastify/otel@0.18.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/core": 2.7.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/instrumentation": 0.212.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
       minimatch: 10.2.5
@@ -12126,22 +12224,22 @@ snapshots:
       "@shikijs/types": 3.23.0
       "@shikijs/vscode-textmate": 10.0.2
 
-  "@google/genai@1.47.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))":
+  "@google/genai@1.47.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))":
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
       protobufjs: 7.5.4
       ws: 8.20.0
     optionalDependencies:
-      "@modelcontextprotocol/sdk": 1.29.0(zod@4.3.6)
+      "@modelcontextprotocol/sdk": 1.29.0(zod@4.4.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  "@hono/node-server@1.19.12(hono@4.12.14)":
+  "@hono/node-server@1.19.12(hono@4.12.18)":
     dependencies:
-      hono: 4.12.14
+      hono: 4.12.18
 
   "@img/colour@1.1.0":
     optional: true
@@ -12240,31 +12338,30 @@ snapshots:
   "@img/sharp-win32-x64@0.34.5":
     optional: true
 
-  "@inquirer/ansi@1.0.2": {}
+  "@inquirer/ansi@2.0.5": {}
 
-  "@inquirer/confirm@5.1.21(@types/node@25.6.0)":
+  "@inquirer/confirm@6.0.12(@types/node@25.6.0)":
     dependencies:
-      "@inquirer/core": 10.3.2(@types/node@25.6.0)
-      "@inquirer/type": 3.0.10(@types/node@25.6.0)
+      "@inquirer/core": 11.1.9(@types/node@25.6.0)
+      "@inquirer/type": 4.0.5(@types/node@25.6.0)
     optionalDependencies:
       "@types/node": 25.6.0
 
-  "@inquirer/core@10.3.2(@types/node@25.6.0)":
+  "@inquirer/core@11.1.9(@types/node@25.6.0)":
     dependencies:
-      "@inquirer/ansi": 1.0.2
-      "@inquirer/figures": 1.0.15
-      "@inquirer/type": 3.0.10(@types/node@25.6.0)
+      "@inquirer/ansi": 2.0.5
+      "@inquirer/figures": 2.0.5
+      "@inquirer/type": 4.0.5(@types/node@25.6.0)
       cli-width: 4.1.0
-      mute-stream: 2.0.0
+      fast-wrap-ansi: 0.2.0
+      mute-stream: 3.0.0
       signal-exit: 4.1.0
-      wrap-ansi: 6.2.0
-      yoctocolors-cjs: 2.1.3
     optionalDependencies:
       "@types/node": 25.6.0
 
-  "@inquirer/figures@1.0.15": {}
+  "@inquirer/figures@2.0.5": {}
 
-  "@inquirer/type@3.0.10(@types/node@25.6.0)":
+  "@inquirer/type@4.0.5(@types/node@25.6.0)":
     optionalDependencies:
       "@types/node": 25.6.0
 
@@ -12316,7 +12413,7 @@ snapshots:
       "@jridgewell/resolve-uri": 3.1.2
       "@jridgewell/sourcemap-codec": 1.5.5
 
-  "@logtape/logtape@2.0.5": {}
+  "@logtape/logtape@2.0.7": {}
 
   "@mapbox/node-pre-gyp@2.0.3":
     dependencies:
@@ -12331,9 +12428,9 @@ snapshots:
       - encoding
       - supports-color
 
-  "@mariozechner/pi-agent-core@0.73.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)":
+  "@mariozechner/pi-agent-core@0.73.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)":
     dependencies:
-      "@mariozechner/pi-ai": 0.73.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      "@mariozechner/pi-ai": 0.73.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)
       typebox: 1.1.38
     transitivePeerDependencies:
       - "@modelcontextprotocol/sdk"
@@ -12344,21 +12441,19 @@ snapshots:
       - ws
       - zod
 
-  "@mariozechner/pi-ai@0.73.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)":
+  "@mariozechner/pi-ai@0.73.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)":
     dependencies:
-      "@anthropic-ai/sdk": 0.91.1(zod@4.3.6)
+      "@anthropic-ai/sdk": 0.91.1(zod@4.4.3)
       "@aws-sdk/client-bedrock-runtime": 3.1034.0
-      "@google/genai": 1.47.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))
+      "@google/genai": 1.47.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
       "@mistralai/mistralai": 2.2.1
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
       chalk: 5.6.2
-      openai: 6.26.0(ws@8.20.0)(zod@4.3.6)
+      openai: 6.26.0(ws@8.20.0)(zod@4.4.3)
       partial-json: 0.1.7
       proxy-agent: 6.5.0
       typebox: 1.1.38
       undici: 7.24.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - "@modelcontextprotocol/sdk"
       - aws-crt
@@ -12370,7 +12465,7 @@ snapshots:
 
   "@mdx-js/mdx@3.1.1":
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       "@types/estree-jsx": 1.0.5
       "@types/hast": 3.0.4
       "@types/mdx": 2.0.13
@@ -12401,17 +12496,17 @@ snapshots:
   "@mistralai/mistralai@2.2.1":
     dependencies:
       ws: 8.20.0
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
   "@mixmark-io/domino@2.2.0": {}
 
-  "@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)":
+  "@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)":
     dependencies:
-      "@hono/node-server": 1.19.12(hono@4.12.14)
+      "@hono/node-server": 1.19.12(hono@4.12.18)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -12421,13 +12516,13 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.14
+      hono: 4.12.18
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -12437,7 +12532,7 @@ snapshots:
       prebuild-install: 7.1.3
     optional: true
 
-  "@mswjs/interceptors@0.41.3":
+  "@mswjs/interceptors@0.41.8":
     dependencies:
       "@open-draft/deferred-promise": 2.2.0
       "@open-draft/logger": 0.3.0
@@ -12446,18 +12541,18 @@ snapshots:
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
 
-  "@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)":
+  "@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)":
     dependencies:
-      "@emnapi/core": 1.9.2
-      "@emnapi/runtime": 1.9.2
+      "@emnapi/core": 1.10.0
+      "@emnapi/runtime": 1.10.0
       "@tybys/wasm-util": 0.10.1
     optional: true
 
-  "@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)":
+  "@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)":
     dependencies:
-      "@emnapi/core": 1.9.2
-      "@emnapi/runtime": 1.9.2
-      "@tybys/wasm-util": 0.10.1
+      "@emnapi/core": 1.10.0
+      "@emnapi/runtime": 1.10.0
+      "@tybys/wasm-util": 0.10.2
     optional: true
 
   "@nodelib/fs.scandir@2.1.5":
@@ -12473,6 +12568,8 @@ snapshots:
       fastq: 1.20.1
 
   "@open-draft/deferred-promise@2.2.0": {}
+
+  "@open-draft/deferred-promise@3.0.0": {}
 
   "@open-draft/logger@0.3.0":
     dependencies:
@@ -12497,11 +12594,12 @@ snapshots:
 
   "@opentelemetry/api@1.9.1": {}
 
-  "@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
+      "@opentelemetry/semantic-conventions": 1.40.0
 
-  "@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/semantic-conventions": 1.40.0
@@ -12509,7 +12607,7 @@ snapshots:
   "@opentelemetry/instrumentation-amqplib@0.61.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/core": 2.7.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
     transitivePeerDependencies:
@@ -12518,7 +12616,7 @@ snapshots:
   "@opentelemetry/instrumentation-connect@0.57.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/core": 2.7.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
       "@types/connect": 3.4.38
@@ -12535,7 +12633,7 @@ snapshots:
   "@opentelemetry/instrumentation-fs@0.33.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/core": 2.7.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
@@ -12557,7 +12655,7 @@ snapshots:
   "@opentelemetry/instrumentation-hapi@0.60.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/core": 2.7.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
     transitivePeerDependencies:
@@ -12577,7 +12675,7 @@ snapshots:
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/redis-common": 0.38.2
+      "@opentelemetry/redis-common": 0.38.3
       "@opentelemetry/semantic-conventions": 1.40.0
     transitivePeerDependencies:
       - supports-color
@@ -12601,7 +12699,7 @@ snapshots:
   "@opentelemetry/instrumentation-koa@0.62.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/core": 2.7.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
     transitivePeerDependencies:
@@ -12625,7 +12723,7 @@ snapshots:
   "@opentelemetry/instrumentation-mongoose@0.60.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/core": 2.7.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
     transitivePeerDependencies:
@@ -12652,7 +12750,7 @@ snapshots:
   "@opentelemetry/instrumentation-pg@0.66.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/core": 2.7.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
       "@opentelemetry/sql-common": 0.41.2(@opentelemetry/api@1.9.1)
@@ -12665,7 +12763,7 @@ snapshots:
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/redis-common": 0.38.2
+      "@opentelemetry/redis-common": 0.38.3
       "@opentelemetry/semantic-conventions": 1.40.0
     transitivePeerDependencies:
       - supports-color
@@ -12676,15 +12774,6 @@ snapshots:
       "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
       "@types/tedious": 4.0.14
-    transitivePeerDependencies:
-      - supports-color
-
-  "@opentelemetry/instrumentation-undici@0.24.0(@opentelemetry/api@1.9.1)":
-    dependencies:
-      "@opentelemetry/api": 1.9.1
-      "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/semantic-conventions": 1.40.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12710,24 +12799,24 @@ snapshots:
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/api-logs": 0.214.0
-      import-in-the-middle: 3.0.0
+      import-in-the-middle: 3.0.1
       require-in-the-middle: 8.0.1
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/redis-common@0.38.2": {}
+  "@opentelemetry/redis-common@0.38.3": {}
 
-  "@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/core": 2.7.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
 
-  "@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/resources": 2.6.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/core": 2.7.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/resources": 2.7.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
 
   "@opentelemetry/semantic-conventions@1.40.0": {}
@@ -12735,7 +12824,7 @@ snapshots:
   "@opentelemetry/sql-common@0.41.2(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/core": 2.7.1(@opentelemetry/api@1.9.1)
 
   "@oslojs/encoding@1.1.0": {}
 
@@ -12743,7 +12832,7 @@ snapshots:
 
   "@oxc-project/types@0.122.0": {}
 
-  "@oxc-project/types@0.124.0": {}
+  "@oxc-project/types@0.128.0": {}
 
   "@oxc-transform/binding-android-arm-eabi@0.111.0":
     optional: true
@@ -12793,9 +12882,9 @@ snapshots:
   "@oxc-transform/binding-openharmony-arm64@0.111.0":
     optional: true
 
-  "@oxc-transform/binding-wasm32-wasi@0.111.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)":
+  "@oxc-transform/binding-wasm32-wasi@0.111.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)":
     dependencies:
-      "@napi-rs/wasm-runtime": 1.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      "@napi-rs/wasm-runtime": 1.1.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - "@emnapi/core"
       - "@emnapi/runtime"
@@ -12810,81 +12899,84 @@ snapshots:
   "@oxc-transform/binding-win32-x64-msvc@0.111.0":
     optional: true
 
-  "@oxlint/binding-android-arm-eabi@1.60.0":
+  "@oxlint/binding-android-arm-eabi@1.63.0":
     optional: true
 
-  "@oxlint/binding-android-arm64@1.60.0":
+  "@oxlint/binding-android-arm64@1.63.0":
     optional: true
 
-  "@oxlint/binding-darwin-arm64@1.60.0":
+  "@oxlint/binding-darwin-arm64@1.63.0":
     optional: true
 
-  "@oxlint/binding-darwin-x64@1.60.0":
+  "@oxlint/binding-darwin-x64@1.63.0":
     optional: true
 
-  "@oxlint/binding-freebsd-x64@1.60.0":
+  "@oxlint/binding-freebsd-x64@1.63.0":
     optional: true
 
-  "@oxlint/binding-linux-arm-gnueabihf@1.60.0":
+  "@oxlint/binding-linux-arm-gnueabihf@1.63.0":
     optional: true
 
-  "@oxlint/binding-linux-arm-musleabihf@1.60.0":
+  "@oxlint/binding-linux-arm-musleabihf@1.63.0":
     optional: true
 
-  "@oxlint/binding-linux-arm64-gnu@1.60.0":
+  "@oxlint/binding-linux-arm64-gnu@1.63.0":
     optional: true
 
-  "@oxlint/binding-linux-arm64-musl@1.60.0":
+  "@oxlint/binding-linux-arm64-musl@1.63.0":
     optional: true
 
-  "@oxlint/binding-linux-ppc64-gnu@1.60.0":
+  "@oxlint/binding-linux-ppc64-gnu@1.63.0":
     optional: true
 
-  "@oxlint/binding-linux-riscv64-gnu@1.60.0":
+  "@oxlint/binding-linux-riscv64-gnu@1.63.0":
     optional: true
 
-  "@oxlint/binding-linux-riscv64-musl@1.60.0":
+  "@oxlint/binding-linux-riscv64-musl@1.63.0":
     optional: true
 
-  "@oxlint/binding-linux-s390x-gnu@1.60.0":
+  "@oxlint/binding-linux-s390x-gnu@1.63.0":
     optional: true
 
-  "@oxlint/binding-linux-x64-gnu@1.60.0":
+  "@oxlint/binding-linux-x64-gnu@1.63.0":
     optional: true
 
-  "@oxlint/binding-linux-x64-musl@1.60.0":
+  "@oxlint/binding-linux-x64-musl@1.63.0":
     optional: true
 
-  "@oxlint/binding-openharmony-arm64@1.60.0":
+  "@oxlint/binding-openharmony-arm64@1.63.0":
     optional: true
 
-  "@oxlint/binding-win32-arm64-msvc@1.60.0":
+  "@oxlint/binding-win32-arm64-msvc@1.63.0":
     optional: true
 
-  "@oxlint/binding-win32-ia32-msvc@1.60.0":
+  "@oxlint/binding-win32-ia32-msvc@1.63.0":
     optional: true
 
-  "@oxlint/binding-win32-x64-msvc@1.60.0":
+  "@oxlint/binding-win32-x64-msvc@1.63.0":
     optional: true
 
-  "@pagefind/darwin-arm64@1.4.0":
+  "@pagefind/darwin-arm64@1.5.2":
     optional: true
 
-  "@pagefind/darwin-x64@1.4.0":
+  "@pagefind/darwin-x64@1.5.2":
     optional: true
 
-  "@pagefind/default-ui@1.4.0": {}
+  "@pagefind/default-ui@1.5.2": {}
 
-  "@pagefind/freebsd-x64@1.4.0":
+  "@pagefind/freebsd-x64@1.5.2":
     optional: true
 
-  "@pagefind/linux-arm64@1.4.0":
+  "@pagefind/linux-arm64@1.5.2":
     optional: true
 
-  "@pagefind/linux-x64@1.4.0":
+  "@pagefind/linux-x64@1.5.2":
     optional: true
 
-  "@pagefind/windows-x64@1.4.0":
+  "@pagefind/windows-arm64@1.5.2":
+    optional: true
+
+  "@pagefind/windows-x64@1.5.2":
     optional: true
 
   "@prisma/instrumentation@7.6.0(@opentelemetry/api@1.9.1)":
@@ -12917,25 +13009,27 @@ snapshots:
 
   "@protobufjs/utf8@1.1.0": {}
 
-  "@redis/bloom@5.11.0(@redis/client@5.11.0)":
+  "@redis/bloom@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))":
     dependencies:
-      "@redis/client": 5.11.0
+      "@redis/client": 5.12.1(@opentelemetry/api@1.9.1)
 
-  "@redis/client@5.11.0":
+  "@redis/client@5.12.1(@opentelemetry/api@1.9.1)":
     dependencies:
       cluster-key-slot: 1.1.2
+    optionalDependencies:
+      "@opentelemetry/api": 1.9.1
 
-  "@redis/json@5.11.0(@redis/client@5.11.0)":
+  "@redis/json@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))":
     dependencies:
-      "@redis/client": 5.11.0
+      "@redis/client": 5.12.1(@opentelemetry/api@1.9.1)
 
-  "@redis/search@5.11.0(@redis/client@5.11.0)":
+  "@redis/search@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))":
     dependencies:
-      "@redis/client": 5.11.0
+      "@redis/client": 5.12.1(@opentelemetry/api@1.9.1)
 
-  "@redis/time-series@5.11.0(@redis/client@5.11.0)":
+  "@redis/time-series@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))":
     dependencies:
-      "@redis/client": 5.11.0
+      "@redis/client": 5.12.1(@opentelemetry/api@1.9.1)
 
   "@renovatebot/pep440@4.2.1": {}
 
@@ -12945,7 +13039,7 @@ snapshots:
   "@rolldown/binding-android-arm64@1.0.0-rc.12":
     optional: true
 
-  "@rolldown/binding-android-arm64@1.0.0-rc.15":
+  "@rolldown/binding-android-arm64@1.0.0-rc.18":
     optional: true
 
   "@rolldown/binding-darwin-arm64@1.0.0-rc.1":
@@ -12954,7 +13048,7 @@ snapshots:
   "@rolldown/binding-darwin-arm64@1.0.0-rc.12":
     optional: true
 
-  "@rolldown/binding-darwin-arm64@1.0.0-rc.15":
+  "@rolldown/binding-darwin-arm64@1.0.0-rc.18":
     optional: true
 
   "@rolldown/binding-darwin-x64@1.0.0-rc.1":
@@ -12963,7 +13057,7 @@ snapshots:
   "@rolldown/binding-darwin-x64@1.0.0-rc.12":
     optional: true
 
-  "@rolldown/binding-darwin-x64@1.0.0-rc.15":
+  "@rolldown/binding-darwin-x64@1.0.0-rc.18":
     optional: true
 
   "@rolldown/binding-freebsd-x64@1.0.0-rc.1":
@@ -12972,7 +13066,7 @@ snapshots:
   "@rolldown/binding-freebsd-x64@1.0.0-rc.12":
     optional: true
 
-  "@rolldown/binding-freebsd-x64@1.0.0-rc.15":
+  "@rolldown/binding-freebsd-x64@1.0.0-rc.18":
     optional: true
 
   "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.1":
@@ -12981,7 +13075,7 @@ snapshots:
   "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12":
     optional: true
 
-  "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15":
+  "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18":
     optional: true
 
   "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.1":
@@ -12990,7 +13084,7 @@ snapshots:
   "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12":
     optional: true
 
-  "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15":
+  "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18":
     optional: true
 
   "@rolldown/binding-linux-arm64-musl@1.0.0-rc.1":
@@ -12999,19 +13093,19 @@ snapshots:
   "@rolldown/binding-linux-arm64-musl@1.0.0-rc.12":
     optional: true
 
-  "@rolldown/binding-linux-arm64-musl@1.0.0-rc.15":
+  "@rolldown/binding-linux-arm64-musl@1.0.0-rc.18":
     optional: true
 
   "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12":
     optional: true
 
-  "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15":
+  "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18":
     optional: true
 
   "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12":
     optional: true
 
-  "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15":
+  "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18":
     optional: true
 
   "@rolldown/binding-linux-x64-gnu@1.0.0-rc.1":
@@ -13020,7 +13114,7 @@ snapshots:
   "@rolldown/binding-linux-x64-gnu@1.0.0-rc.12":
     optional: true
 
-  "@rolldown/binding-linux-x64-gnu@1.0.0-rc.15":
+  "@rolldown/binding-linux-x64-gnu@1.0.0-rc.18":
     optional: true
 
   "@rolldown/binding-linux-x64-musl@1.0.0-rc.1":
@@ -13029,7 +13123,7 @@ snapshots:
   "@rolldown/binding-linux-x64-musl@1.0.0-rc.12":
     optional: true
 
-  "@rolldown/binding-linux-x64-musl@1.0.0-rc.15":
+  "@rolldown/binding-linux-x64-musl@1.0.0-rc.18":
     optional: true
 
   "@rolldown/binding-openharmony-arm64@1.0.0-rc.1":
@@ -13038,30 +13132,30 @@ snapshots:
   "@rolldown/binding-openharmony-arm64@1.0.0-rc.12":
     optional: true
 
-  "@rolldown/binding-openharmony-arm64@1.0.0-rc.15":
+  "@rolldown/binding-openharmony-arm64@1.0.0-rc.18":
     optional: true
 
-  "@rolldown/binding-wasm32-wasi@1.0.0-rc.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)":
+  "@rolldown/binding-wasm32-wasi@1.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)":
     dependencies:
-      "@napi-rs/wasm-runtime": 1.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      "@napi-rs/wasm-runtime": 1.1.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - "@emnapi/core"
       - "@emnapi/runtime"
     optional: true
 
-  "@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)":
+  "@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)":
     dependencies:
-      "@napi-rs/wasm-runtime": 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      "@napi-rs/wasm-runtime": 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - "@emnapi/core"
       - "@emnapi/runtime"
     optional: true
 
-  "@rolldown/binding-wasm32-wasi@1.0.0-rc.15":
+  "@rolldown/binding-wasm32-wasi@1.0.0-rc.18":
     dependencies:
-      "@emnapi/core": 1.9.2
-      "@emnapi/runtime": 1.9.2
-      "@napi-rs/wasm-runtime": 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      "@emnapi/core": 1.10.0
+      "@emnapi/runtime": 1.10.0
+      "@napi-rs/wasm-runtime": 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.1":
@@ -13070,7 +13164,7 @@ snapshots:
   "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12":
     optional: true
 
-  "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15":
+  "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18":
     optional: true
 
   "@rolldown/binding-win32-x64-msvc@1.0.0-rc.1":
@@ -13079,14 +13173,14 @@ snapshots:
   "@rolldown/binding-win32-x64-msvc@1.0.0-rc.12":
     optional: true
 
-  "@rolldown/binding-win32-x64-msvc@1.0.0-rc.15":
+  "@rolldown/binding-win32-x64-msvc@1.0.0-rc.18":
     optional: true
 
   "@rolldown/pluginutils@1.0.0-rc.1": {}
 
   "@rolldown/pluginutils@1.0.0-rc.12": {}
 
-  "@rolldown/pluginutils@1.0.0-rc.15": {}
+  "@rolldown/pluginutils@1.0.0-rc.18": {}
 
   "@rollup/pluginutils@5.3.0(rollup@4.60.1)":
     dependencies:
@@ -13171,35 +13265,36 @@ snapshots:
   "@rollup/rollup-win32-x64-msvc@4.60.1":
     optional: true
 
-  "@sentry/core@10.48.0": {}
+  "@sentry/core@10.51.0": {}
 
-  "@sentry/junior@file:packages/junior(@aws-sdk/credential-provider-web-identity@3.972.33)(@sentry/node@10.48.0)":
+  "@sentry/junior@file:packages/junior(@aws-sdk/credential-provider-web-identity@3.972.33)(@opentelemetry/api@1.9.1)(@sentry/node@10.51.0)":
     dependencies:
-      "@ai-sdk/gateway": 3.0.99(zod@4.3.6)
-      "@chat-adapter/slack": 4.26.0
-      "@chat-adapter/state-memory": 4.26.0
-      "@chat-adapter/state-redis": 4.26.0
-      "@logtape/logtape": 2.0.5
-      "@mariozechner/pi-agent-core": 0.73.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
-      "@mariozechner/pi-ai": 0.73.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
-      "@modelcontextprotocol/sdk": 1.29.0(zod@4.3.6)
-      "@sentry/node": 10.48.0
+      "@ai-sdk/gateway": 3.0.110(zod@4.4.3)
+      "@chat-adapter/slack": 4.27.0
+      "@chat-adapter/state-memory": 4.27.0
+      "@chat-adapter/state-redis": 4.27.0(@opentelemetry/api@1.9.1)
+      "@logtape/logtape": 2.0.7
+      "@mariozechner/pi-agent-core": 0.73.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)
+      "@mariozechner/pi-ai": 0.73.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)
+      "@modelcontextprotocol/sdk": 1.29.0(zod@4.4.3)
+      "@sentry/node": 10.51.0
       "@sinclair/typebox": 0.34.49
-      "@slack/web-api": 7.15.1
-      "@vercel/functions": 3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33)
+      "@slack/web-api": 7.15.2
+      "@vercel/functions": 3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33)
       "@vercel/sandbox": 1.10.0
-      ai: 6.0.162(zod@4.3.6)
-      bash-tool: 1.3.16(@vercel/sandbox@1.10.0)(ai@6.0.162(zod@4.3.6))(just-bash@2.14.2)
-      chat: 4.26.0
-      hono: 4.12.14
-      just-bash: 2.14.2
+      ai: 6.0.175(zod@4.4.3)
+      bash-tool: 1.3.16(@vercel/sandbox@1.10.0)(ai@6.0.175(zod@4.4.3))(just-bash@2.14.4)
+      chat: 4.27.0
+      hono: 4.12.18
+      just-bash: 2.14.4
       node-html-markdown: 2.0.0
-      yaml: 2.8.3
-      zod: 4.3.6
+      yaml: 2.8.4
+      zod: 4.4.3
     transitivePeerDependencies:
       - "@aws-sdk/credential-provider-web-identity"
       - "@cfworker/json-schema"
       - "@node-rs/xxhash"
+      - "@opentelemetry/api"
       - aws-crt
       - bare-abort-controller
       - bufferutil
@@ -13209,26 +13304,23 @@ snapshots:
       - utf-8-validate
       - ws
 
-  "@sentry/node-core@10.48.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)":
+  "@sentry/node-core@10.51.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)":
     dependencies:
-      "@sentry/core": 10.48.0
-      "@sentry/opentelemetry": 10.48.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
-      import-in-the-middle: 3.0.0
+      "@sentry/core": 10.51.0
+      "@sentry/opentelemetry": 10.51.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      import-in-the-middle: 3.0.1
     optionalDependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/context-async-hooks": 2.6.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/core": 2.7.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/resources": 2.6.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/sdk-trace-base": 2.6.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/sdk-trace-base": 2.7.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
 
-  "@sentry/node@10.48.0":
+  "@sentry/node@10.51.0":
     dependencies:
       "@fastify/otel": 0.18.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/context-async-hooks": 2.6.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/core": 2.7.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/instrumentation-amqplib": 0.61.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/instrumentation-connect": 0.57.0(@opentelemetry/api@1.9.1)
@@ -13250,27 +13342,24 @@ snapshots:
       "@opentelemetry/instrumentation-pg": 0.66.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/instrumentation-redis": 0.62.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/instrumentation-tedious": 0.33.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-undici": 0.24.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/resources": 2.6.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/sdk-trace-base": 2.6.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/sdk-trace-base": 2.7.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
       "@prisma/instrumentation": 7.6.0(@opentelemetry/api@1.9.1)
-      "@sentry/core": 10.48.0
-      "@sentry/node-core": 10.48.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
-      "@sentry/opentelemetry": 10.48.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
-      import-in-the-middle: 3.0.0
+      "@sentry/core": 10.51.0
+      "@sentry/node-core": 10.51.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      "@sentry/opentelemetry": 10.51.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      import-in-the-middle: 3.0.1
     transitivePeerDependencies:
       - "@opentelemetry/exporter-trace-otlp-http"
       - supports-color
 
-  "@sentry/opentelemetry@10.48.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)":
+  "@sentry/opentelemetry@10.51.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/context-async-hooks": 2.6.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/core": 2.6.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/sdk-trace-base": 2.6.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/core": 2.7.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/sdk-trace-base": 2.7.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
-      "@sentry/core": 10.48.0
+      "@sentry/core": 10.51.0
 
   "@shikijs/core@3.23.0":
     dependencies:
@@ -13313,15 +13402,28 @@ snapshots:
     dependencies:
       "@types/node": 25.6.0
 
-  "@slack/types@2.20.1": {}
-
-  "@slack/web-api@7.15.1":
+  "@slack/socket-mode@2.0.7":
     dependencies:
       "@slack/logger": 4.0.1
-      "@slack/types": 2.20.1
+      "@slack/web-api": 7.15.2
+      "@types/node": 25.6.0
+      "@types/ws": 8.18.1
+      eventemitter3: 5.0.4
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  "@slack/types@2.21.0": {}
+
+  "@slack/web-api@7.15.2":
+    dependencies:
+      "@slack/logger": 4.0.1
+      "@slack/types": 2.21.0
       "@types/node": 25.6.0
       "@types/retry": 0.12.0
-      axios: 1.15.0
+      axios: 1.16.0
       eventemitter3: 5.0.4
       form-data: 4.0.5
       is-electron: 2.2.2
@@ -13714,6 +13816,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  "@tybys/wasm-util@0.10.2":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   "@types/chai@5.2.3":
     dependencies:
       "@types/deep-eql": 4.0.2
@@ -13731,9 +13838,11 @@ snapshots:
 
   "@types/estree-jsx@1.0.5":
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
 
   "@types/estree@1.0.8": {}
+
+  "@types/estree@1.0.9": {}
 
   "@types/hast@3.0.4":
     dependencies:
@@ -13763,7 +13872,7 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
-  "@types/node@24.12.0":
+  "@types/node@24.12.2":
     dependencies:
       undici-types: 7.16.0
 
@@ -13785,6 +13894,10 @@ snapshots:
 
   "@types/sax@1.2.7":
     dependencies:
+      "@types/node": 24.12.2
+
+  "@types/set-cookie-parser@2.4.10":
+    dependencies:
       "@types/node": 25.6.0
 
   "@types/statuses@2.0.6": {}
@@ -13797,18 +13910,22 @@ snapshots:
 
   "@types/unist@3.0.3": {}
 
+  "@types/ws@8.18.1":
+    dependencies:
+      "@types/node": 25.6.0
+
   "@ungap/structured-clone@1.3.0": {}
 
-  "@vercel/backends@0.0.62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(rollup@4.60.1)(typescript@5.9.3)":
+  "@vercel/backends@0.0.62(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(typescript@5.9.3)":
     dependencies:
       "@vercel/build-utils": 13.17.0
-      "@vercel/nft": 1.5.0(rollup@4.60.1)
+      "@vercel/nft": 1.5.0
       execa: 3.2.0
       fs-extra: 11.1.0
-      oxc-transform: 0.111.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      oxc-transform: 0.111.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       path-to-regexp: 8.3.0
       resolve.exports: 2.0.3
-      rolldown: 1.0.0-rc.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      rolldown: 1.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       srvx: 0.8.9
       tsx: 4.21.0
       typescript: 5.9.3
@@ -13834,9 +13951,9 @@ snapshots:
       cjs-module-lexer: 1.2.3
       es-module-lexer: 1.5.0
 
-  "@vercel/cervel@0.0.49(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(rollup@4.60.1)(typescript@5.9.3)":
+  "@vercel/cervel@0.0.49(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(typescript@5.9.3)":
     dependencies:
-      "@vercel/backends": 0.0.62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(rollup@4.60.1)(typescript@5.9.3)
+      "@vercel/backends": 0.0.62(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - "@emnapi/core"
@@ -13847,9 +13964,9 @@ snapshots:
 
   "@vercel/detect-agent@1.2.2": {}
 
-  "@vercel/elysia@0.1.65(rollup@4.60.1)":
+  "@vercel/elysia@0.1.65":
     dependencies:
-      "@vercel/node": 5.7.7(rollup@4.60.1)
+      "@vercel/node": 5.7.7
       "@vercel/static-config": 3.2.0
     transitivePeerDependencies:
       - encoding
@@ -13858,11 +13975,11 @@ snapshots:
 
   "@vercel/error-utils@2.0.3": {}
 
-  "@vercel/express@0.1.75(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(rollup@4.60.1)(typescript@5.9.3)":
+  "@vercel/express@0.1.75(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(typescript@5.9.3)":
     dependencies:
-      "@vercel/cervel": 0.0.49(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(rollup@4.60.1)(typescript@5.9.3)
-      "@vercel/nft": 1.5.0(rollup@4.60.1)
-      "@vercel/node": 5.7.7(rollup@4.60.1)
+      "@vercel/cervel": 0.0.49(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(typescript@5.9.3)
+      "@vercel/nft": 1.5.0
+      "@vercel/node": 5.7.7
       "@vercel/static-config": 3.2.0
       fs-extra: 11.1.0
       path-to-regexp: 8.3.0
@@ -13876,9 +13993,9 @@ snapshots:
       - supports-color
       - typescript
 
-  "@vercel/fastify@0.1.68(rollup@4.60.1)":
+  "@vercel/fastify@0.1.68":
     dependencies:
-      "@vercel/node": 5.7.7(rollup@4.60.1)
+      "@vercel/node": 5.7.7
       "@vercel/static-config": 3.2.0
     transitivePeerDependencies:
       - encoding
@@ -13909,9 +14026,9 @@ snapshots:
       - encoding
       - supports-color
 
-  "@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33)":
+  "@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33)":
     dependencies:
-      "@vercel/oidc": 3.2.0
+      "@vercel/oidc": 3.4.0
     optionalDependencies:
       "@aws-sdk/credential-provider-web-identity": 3.972.33
 
@@ -13929,19 +14046,19 @@ snapshots:
 
   "@vercel/go@3.5.0": {}
 
-  "@vercel/h3@0.1.74(rollup@4.60.1)":
+  "@vercel/h3@0.1.74":
     dependencies:
-      "@vercel/node": 5.7.7(rollup@4.60.1)
+      "@vercel/node": 5.7.7
       "@vercel/static-config": 3.2.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  "@vercel/hono@0.2.68(rollup@4.60.1)":
+  "@vercel/hono@0.2.68":
     dependencies:
-      "@vercel/nft": 1.5.0(rollup@4.60.1)
-      "@vercel/node": 5.7.7(rollup@4.60.1)
+      "@vercel/nft": 1.5.0
+      "@vercel/node": 5.7.7
       "@vercel/static-config": 3.2.0
       fs-extra: 11.1.0
       path-to-regexp: 8.3.0
@@ -13957,33 +14074,33 @@ snapshots:
       "@vercel/static-config": 3.2.0
       ts-morph: 12.0.0
 
-  "@vercel/koa@0.1.48(rollup@4.60.1)":
+  "@vercel/koa@0.1.48":
     dependencies:
-      "@vercel/node": 5.7.7(rollup@4.60.1)
+      "@vercel/node": 5.7.7
       "@vercel/static-config": 3.2.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  "@vercel/nestjs@0.2.69(rollup@4.60.1)":
+  "@vercel/nestjs@0.2.69":
     dependencies:
-      "@vercel/node": 5.7.7(rollup@4.60.1)
+      "@vercel/node": 5.7.7
       "@vercel/static-config": 3.2.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  "@vercel/next@4.16.8(rollup@4.60.1)":
+  "@vercel/next@4.16.8":
     dependencies:
-      "@vercel/nft": 1.5.0(rollup@4.60.1)
+      "@vercel/nft": 1.5.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  "@vercel/nft@1.5.0(rollup@4.60.1)":
+  "@vercel/nft@1.5.0":
     dependencies:
       "@mapbox/node-pre-gyp": 2.0.3
       "@rollup/pluginutils": 5.3.0(rollup@4.60.1)
@@ -14002,7 +14119,7 @@ snapshots:
       - rollup
       - supports-color
 
-  "@vercel/node@5.7.7(rollup@4.60.1)":
+  "@vercel/node@5.7.7":
     dependencies:
       "@edge-runtime/node-utils": 2.3.0
       "@edge-runtime/primitives": 4.1.0
@@ -14010,7 +14127,7 @@ snapshots:
       "@types/node": 20.11.0
       "@vercel/build-utils": 13.17.0
       "@vercel/error-utils": 2.0.3
-      "@vercel/nft": 1.5.0(rollup@4.60.1)
+      "@vercel/nft": 1.5.0
       "@vercel/static-config": 3.2.0
       async-listen: 3.0.0
       cjs-module-lexer: 1.2.3
@@ -14031,9 +14148,9 @@ snapshots:
       - rollup
       - supports-color
 
-  "@vercel/oidc@3.1.0": {}
-
   "@vercel/oidc@3.2.0": {}
+
+  "@vercel/oidc@3.4.0": {}
 
   "@vercel/prepare-flags-definitions@0.2.1": {}
 
@@ -14051,9 +14168,9 @@ snapshots:
     dependencies:
       "@vercel/python-analysis": 0.11.0
 
-  "@vercel/redwood@2.4.12(rollup@4.60.1)":
+  "@vercel/redwood@2.4.12":
     dependencies:
-      "@vercel/nft": 1.5.0(rollup@4.60.1)
+      "@vercel/nft": 1.5.0
       "@vercel/static-config": 3.2.0
       semver: 6.3.1
       ts-morph: 12.0.0
@@ -14062,10 +14179,10 @@ snapshots:
       - rollup
       - supports-color
 
-  "@vercel/remix-builder@5.7.2(rollup@4.60.1)":
+  "@vercel/remix-builder@5.7.2":
     dependencies:
       "@vercel/error-utils": 2.0.3
-      "@vercel/nft": 1.5.0(rollup@4.60.1)
+      "@vercel/nft": 1.5.0
       "@vercel/static-config": 3.2.0
       path-to-regexp: 6.1.0
       path-to-regexp-updated: path-to-regexp@6.3.0
@@ -14126,45 +14243,45 @@ snapshots:
       json-schema-to-ts: 1.6.4
       ts-morph: 12.0.0
 
-  "@vitest/expect@4.1.4":
+  "@vitest/expect@4.1.5":
     dependencies:
       "@standard-schema/spec": 1.1.0
       "@types/chai": 5.2.3
-      "@vitest/spy": 4.1.4
-      "@vitest/utils": 4.1.4
+      "@vitest/spy": 4.1.5
+      "@vitest/utils": 4.1.5
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  "@vitest/mocker@4.1.4(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))":
+  "@vitest/mocker@4.1.5(msw@2.14.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))":
     dependencies:
-      "@vitest/spy": 4.1.4
+      "@vitest/spy": 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.13.3(@types/node@25.6.0)(typescript@5.9.3)
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      msw: 2.14.3(@types/node@25.6.0)(typescript@5.9.3)
+      vite: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
 
-  "@vitest/pretty-format@4.1.4":
+  "@vitest/pretty-format@4.1.5":
     dependencies:
       tinyrainbow: 3.1.0
 
-  "@vitest/runner@4.1.4":
+  "@vitest/runner@4.1.5":
     dependencies:
-      "@vitest/utils": 4.1.4
+      "@vitest/utils": 4.1.5
       pathe: 2.0.3
 
-  "@vitest/snapshot@4.1.4":
+  "@vitest/snapshot@4.1.5":
     dependencies:
-      "@vitest/pretty-format": 4.1.4
-      "@vitest/utils": 4.1.4
+      "@vitest/pretty-format": 4.1.5
+      "@vitest/utils": 4.1.5
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  "@vitest/spy@4.1.4": {}
+  "@vitest/spy@4.1.5": {}
 
-  "@vitest/utils@4.1.4":
+  "@vitest/utils@4.1.5":
     dependencies:
-      "@vitest/pretty-format": 4.1.4
+      "@vitest/pretty-format": 4.1.5
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -14249,19 +14366,19 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  agent-browser@0.23.3: {}
+  agent-browser@0.26.0: {}
 
-  ai@6.0.162(zod@4.3.6):
+  ai@6.0.175(zod@4.4.3):
     dependencies:
-      "@ai-sdk/gateway": 3.0.99(zod@4.3.6)
-      "@ai-sdk/provider": 3.0.8
-      "@ai-sdk/provider-utils": 4.0.23(zod@4.3.6)
+      "@ai-sdk/gateway": 3.0.110(zod@4.4.3)
+      "@ai-sdk/provider": 3.0.10
+      "@ai-sdk/provider-utils": 4.0.26(zod@4.4.3)
       "@opentelemetry/api": 1.9.0
-      zod: 4.3.6
+      zod: 4.4.3
 
-  ajv-draft-04@1.0.0(ajv@8.18.0):
+  ajv-draft-04@1.0.0(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
 
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
@@ -14271,6 +14388,13 @@ snapshots:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -14324,12 +14448,12 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)):
+  astro-expressive-code@0.41.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)):
     dependencies:
-      astro: 5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      astro: 5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)
       rehype-expressive-code: 0.41.7
 
-  astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
+  astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4):
     dependencies:
       "@astrojs/compiler": 2.13.1
       "@astrojs/internal-helpers": 0.7.6
@@ -14384,10 +14508,10 @@ snapshots:
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unist-util-visit: 5.1.0
-      unstorage: 1.17.5(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)
+      unstorage: 1.17.5(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)
       vfile: 6.0.3
-      vite: 6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vitefu: 1.1.2(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite: 6.4.1(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
+      vitefu: 1.1.2(vite@6.4.1(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.3
@@ -14445,9 +14569,9 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.15.0:
+  axios@1.16.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -14469,15 +14593,15 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  bash-tool@1.3.16(@vercel/sandbox@1.10.0)(ai@6.0.162(zod@4.3.6))(just-bash@2.14.2):
+  bash-tool@1.3.16(@vercel/sandbox@1.10.0)(ai@6.0.175(zod@4.4.3))(just-bash@2.14.4):
     dependencies:
-      ai: 6.0.162(zod@4.3.6)
+      ai: 6.0.175(zod@4.4.3)
       fast-glob: 3.3.3
-      yaml: 2.8.3
+      yaml: 2.8.4
       zod: 3.25.76
     optionalDependencies:
       "@vercel/sandbox": 1.10.0
-      just-bash: 2.14.2
+      just-bash: 2.14.4
 
   basic-ftp@5.2.0: {}
 
@@ -14599,7 +14723,7 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
-  chat@4.26.0:
+  chat@4.27.0:
     dependencies:
       "@workflow/serde": 4.1.0-beta.2
       mdast-util-to-string: 4.0.0
@@ -14801,7 +14925,7 @@ snapshots:
 
   depd@2.0.0: {}
 
-  dependency-cruiser@17.3.10:
+  dependency-cruiser@17.4.0:
     dependencies:
       acorn: 8.16.0
       acorn-jsx: 5.3.2(acorn@8.16.0)
@@ -14809,7 +14933,7 @@ snapshots:
       acorn-loose: 8.5.2
       acorn-walk: 8.3.5
       commander: 14.0.3
-      enhanced-resolve: 5.20.1
+      enhanced-resolve: 5.21.0
       ignore: 7.0.5
       interpret: 3.1.1
       is-installed-globally: 1.0.0
@@ -14907,10 +15031,10 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  enhanced-resolve@5.20.1:
+  enhanced-resolve@5.21.0:
     dependencies:
       graceful-fs: 4.2.11
-      tapable: 2.3.2
+      tapable: 2.3.3
 
   entities@4.5.0: {}
 
@@ -14920,7 +15044,7 @@ snapshots:
     dependencies:
       crossws: 0.4.5(srvx@0.11.15)
       exsolve: 1.0.8
-      httpxy: 0.5.0
+      httpxy: 0.5.1
       srvx: 0.11.15
 
   environment@1.1.0: {}
@@ -14935,7 +15059,7 @@ snapshots:
 
   es-module-lexer@1.7.0: {}
 
-  es-module-lexer@2.0.0: {}
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -15069,7 +15193,7 @@ snapshots:
 
   estree-util-attach-comments@3.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
 
   estree-util-build-jsx@3.0.1:
     dependencies:
@@ -15082,7 +15206,7 @@ snapshots:
 
   estree-util-scope@1.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       devlop: 1.1.0
 
   estree-util-to-js@2.0.0:
@@ -15119,6 +15243,8 @@ snapshots:
       - bare-abort-controller
 
   eventsource-parser@3.0.6: {}
+
+  eventsource-parser@3.0.8: {}
 
   eventsource@3.0.7:
     dependencies:
@@ -15215,19 +15341,29 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.0: {}
+
+  fast-uri@3.1.2: {}
+
+  fast-wrap-ansi@0.2.0:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fast-xml-builder@1.1.4:
     dependencies:
       path-expression-matcher: 1.2.0
 
-  fast-xml-parser@5.5.8:
+  fast-xml-parser@5.3.3:
     dependencies:
-      fast-xml-builder: 1.1.4
-      path-expression-matcher: 1.2.0
-      strnum: 2.2.2
+      strnum: 2.2.3
 
-  fast-xml-parser@5.5.9:
+  fast-xml-parser@5.5.8:
     dependencies:
       fast-xml-builder: 1.1.4
       path-expression-matcher: 1.2.0
@@ -15284,7 +15420,7 @@ snapshots:
 
   flattie@1.1.1: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   fontace@0.4.1:
     dependencies:
@@ -15426,7 +15562,7 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  graphql@16.13.2: {}
+  graphql@16.14.0: {}
 
   h3@1.15.10:
     dependencies:
@@ -15440,7 +15576,7 @@ snapshots:
       ufo: 1.6.3
       uncrypto: 0.1.3
 
-  h3@2.0.1-rc.20(crossws@0.4.5(srvx@0.11.15)):
+  h3@2.0.1-rc.22(crossws@0.4.5(srvx@0.11.15)):
     dependencies:
       rou3: 0.8.1
       srvx: 0.11.15
@@ -15456,6 +15592,10 @@ snapshots:
       has-symbols: 1.1.0
 
   hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
 
@@ -15562,7 +15702,7 @@ snapshots:
 
   hast-util-to-estree@3.1.3:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       "@types/estree-jsx": 1.0.5
       "@types/hast": 3.0.4
       comma-separated-tokens: 2.0.3
@@ -15597,7 +15737,7 @@ snapshots:
 
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       "@types/hast": 3.0.4
       "@types/unist": 3.0.3
       comma-separated-tokens: 2.0.3
@@ -15650,9 +15790,12 @@ snapshots:
 
   he@1.2.0: {}
 
-  headers-polyfill@4.0.3: {}
+  headers-polyfill@5.0.1:
+    dependencies:
+      "@types/set-cookie-parser": 2.4.10
+      set-cookie-parser: 3.1.0
 
-  hono@4.12.14: {}
+  hono@4.12.18: {}
 
   hookable@6.1.1: {}
 
@@ -15694,7 +15837,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  httpxy@0.5.0: {}
+  httpxy@0.5.1: {}
 
   human-signals@1.1.1: {}
 
@@ -15723,7 +15866,7 @@ snapshots:
       cjs-module-lexer: 2.2.0
       module-details-from-path: 1.0.4
 
-  import-in-the-middle@3.0.0:
+  import-in-the-middle@3.0.1:
     dependencies:
       acorn: 8.16.0
       acorn-import-attributes: 1.9.5(acorn@8.16.0)
@@ -15760,9 +15903,9 @@ snapshots:
 
   is-buffer@2.0.5: {}
 
-  is-core-module@2.16.1:
+  is-core-module@2.16.2:
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.3
 
   is-decimal@2.0.1: {}
 
@@ -15811,7 +15954,7 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  jiti@2.6.1: {}
+  jiti@2.7.0: {}
 
   jose@5.9.6: {}
 
@@ -15857,23 +16000,23 @@ snapshots:
 
   jsonlines@0.1.1: {}
 
-  just-bash@2.14.2:
+  just-bash@2.14.4:
     dependencies:
       diff: 8.0.4
-      fast-xml-parser: 5.5.9
+      fast-xml-parser: 5.3.3
       file-type: 21.3.4
       ini: 6.0.0
       minimatch: 10.2.5
       modern-tar: 0.7.6
       papaparse: 5.5.3
       quickjs-emscripten: 0.32.0
-      re2js: 1.2.3
+      re2js: 1.3.3
       seek-bzip: 2.0.0
       smol-toml: 1.6.1
       sprintf-js: 1.1.3
       sql.js: 1.14.1
-      turndown: 7.2.2
-      yaml: 2.8.3
+      turndown: 7.2.4
+      yaml: 2.8.4
     optionalDependencies:
       "@mongodb-js/zstd": 7.0.0
       node-liblzma: 2.2.0
@@ -15961,7 +16104,7 @@ snapshots:
       picomatch: 4.0.4
       string-argv: 0.3.2
       tinyexec: 1.0.4
-      yaml: 2.8.3
+      yaml: 2.8.4
 
   listr2@9.0.5:
     dependencies:
@@ -16315,7 +16458,7 @@ snapshots:
 
   micromark-extension-mdx-expression@3.0.1:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       devlop: 1.1.0
       micromark-factory-mdx-expression: 2.0.3
       micromark-factory-space: 2.0.1
@@ -16326,7 +16469,7 @@ snapshots:
 
   micromark-extension-mdx-jsx@3.0.2:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       micromark-factory-mdx-expression: 2.0.3
@@ -16343,7 +16486,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@3.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
       micromark-util-character: 2.1.1
@@ -16379,7 +16522,7 @@ snapshots:
 
   micromark-factory-mdx-expression@2.0.3:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       devlop: 1.1.0
       micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
@@ -16443,7 +16586,7 @@ snapshots:
 
   micromark-util-events-to-acorn@2.0.3:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       "@types/unist": 3.0.3
       devlop: 1.1.0
       estree-util-visit: 2.0.0
@@ -16570,24 +16713,24 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3):
+  msw@2.14.3(@types/node@25.6.0)(typescript@5.9.3):
     dependencies:
-      "@inquirer/confirm": 5.1.21(@types/node@25.6.0)
-      "@mswjs/interceptors": 0.41.3
-      "@open-draft/deferred-promise": 2.2.0
+      "@inquirer/confirm": 6.0.12(@types/node@25.6.0)
+      "@mswjs/interceptors": 0.41.8
+      "@open-draft/deferred-promise": 3.0.0
       "@types/statuses": 2.0.6
       cookie: 1.1.1
-      graphql: 16.13.2
-      headers-polyfill: 4.0.3
+      graphql: 16.14.0
+      headers-polyfill: 5.0.1
       is-node-process: 1.2.0
       outvariant: 1.4.3
       path-to-regexp: 6.3.0
       picocolors: 1.1.1
-      rettime: 0.11.7
+      rettime: 0.11.11
       statuses: 2.0.2
       strict-event-emitter: 0.5.1
       tough-cookie: 6.0.1
-      type-fest: 5.5.0
+      type-fest: 5.6.0
       until-async: 3.0.2
       yargs: 17.7.2
     optionalDependencies:
@@ -16597,7 +16740,7 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
-  mute-stream@2.0.0: {}
+  mute-stream@3.0.0: {}
 
   mz@2.7.0:
     dependencies:
@@ -16606,6 +16749,8 @@ snapshots:
       thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
+
+  nanoid@3.3.12: {}
 
   napi-build-utils@2.0.0:
     optional: true
@@ -16618,26 +16763,25 @@ snapshots:
 
   nf3@0.3.16: {}
 
-  nitro@3.0.260415-beta(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33))(chokidar@5.0.0)(jiti@2.6.1)(lru-cache@11.2.7)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  nitro@3.0.260429-beta(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(chokidar@5.0.0)(jiti@2.7.0)(lru-cache@11.2.7)(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.5(srvx@0.11.15)
       db0: 0.3.4
       env-runner: 0.1.7
-      h3: 2.0.1-rc.20(crossws@0.4.5(srvx@0.11.15))
+      h3: 2.0.1-rc.22(crossws@0.4.5(srvx@0.11.15))
       hookable: 6.1.1
       nf3: 0.3.16
       ocache: 0.1.4
       ofetch: 2.0.0-alpha.3
       ohash: 2.0.11
-      rolldown: 1.0.0-rc.15
+      rolldown: 1.0.0-rc.18
       srvx: 0.11.15
       unenv: 2.0.0-rc.24
-      unstorage: 2.0.0-alpha.7(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33))(chokidar@5.0.0)(db0@0.3.4)(lru-cache@11.2.7)(ofetch@2.0.0-alpha.3)
+      unstorage: 2.0.0-alpha.7(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(chokidar@5.0.0)(db0@0.3.4)(lru-cache@11.2.7)(ofetch@2.0.0-alpha.3)
     optionalDependencies:
-      jiti: 2.6.1
-      rollup: 4.60.1
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      jiti: 2.7.0
+      vite: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - "@azure/app-configuration"
       - "@azure/cosmos"
@@ -16673,7 +16817,7 @@ snapshots:
     dependencies:
       "@types/nlcst": 2.0.3
 
-  node-abi@3.89.0:
+  node-abi@3.92.0:
     dependencies:
       semver: 7.7.4
     optional: true
@@ -16784,16 +16928,16 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  openai@6.26.0(ws@8.20.0)(zod@4.3.6):
+  openai@6.26.0(ws@8.20.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.20.0
-      zod: 4.3.6
+      zod: 4.4.3
 
   os-paths@4.4.0: {}
 
   outvariant@1.4.3: {}
 
-  oxc-transform@0.111.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
+  oxc-transform@0.111.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     optionalDependencies:
       "@oxc-transform/binding-android-arm-eabi": 0.111.0
       "@oxc-transform/binding-android-arm64": 0.111.0
@@ -16811,7 +16955,7 @@ snapshots:
       "@oxc-transform/binding-linux-x64-gnu": 0.111.0
       "@oxc-transform/binding-linux-x64-musl": 0.111.0
       "@oxc-transform/binding-openharmony-arm64": 0.111.0
-      "@oxc-transform/binding-wasm32-wasi": 0.111.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      "@oxc-transform/binding-wasm32-wasi": 0.111.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       "@oxc-transform/binding-win32-arm64-msvc": 0.111.0
       "@oxc-transform/binding-win32-ia32-msvc": 0.111.0
       "@oxc-transform/binding-win32-x64-msvc": 0.111.0
@@ -16819,27 +16963,27 @@ snapshots:
       - "@emnapi/core"
       - "@emnapi/runtime"
 
-  oxlint@1.60.0:
+  oxlint@1.63.0:
     optionalDependencies:
-      "@oxlint/binding-android-arm-eabi": 1.60.0
-      "@oxlint/binding-android-arm64": 1.60.0
-      "@oxlint/binding-darwin-arm64": 1.60.0
-      "@oxlint/binding-darwin-x64": 1.60.0
-      "@oxlint/binding-freebsd-x64": 1.60.0
-      "@oxlint/binding-linux-arm-gnueabihf": 1.60.0
-      "@oxlint/binding-linux-arm-musleabihf": 1.60.0
-      "@oxlint/binding-linux-arm64-gnu": 1.60.0
-      "@oxlint/binding-linux-arm64-musl": 1.60.0
-      "@oxlint/binding-linux-ppc64-gnu": 1.60.0
-      "@oxlint/binding-linux-riscv64-gnu": 1.60.0
-      "@oxlint/binding-linux-riscv64-musl": 1.60.0
-      "@oxlint/binding-linux-s390x-gnu": 1.60.0
-      "@oxlint/binding-linux-x64-gnu": 1.60.0
-      "@oxlint/binding-linux-x64-musl": 1.60.0
-      "@oxlint/binding-openharmony-arm64": 1.60.0
-      "@oxlint/binding-win32-arm64-msvc": 1.60.0
-      "@oxlint/binding-win32-ia32-msvc": 1.60.0
-      "@oxlint/binding-win32-x64-msvc": 1.60.0
+      "@oxlint/binding-android-arm-eabi": 1.63.0
+      "@oxlint/binding-android-arm64": 1.63.0
+      "@oxlint/binding-darwin-arm64": 1.63.0
+      "@oxlint/binding-darwin-x64": 1.63.0
+      "@oxlint/binding-freebsd-x64": 1.63.0
+      "@oxlint/binding-linux-arm-gnueabihf": 1.63.0
+      "@oxlint/binding-linux-arm-musleabihf": 1.63.0
+      "@oxlint/binding-linux-arm64-gnu": 1.63.0
+      "@oxlint/binding-linux-arm64-musl": 1.63.0
+      "@oxlint/binding-linux-ppc64-gnu": 1.63.0
+      "@oxlint/binding-linux-riscv64-gnu": 1.63.0
+      "@oxlint/binding-linux-riscv64-musl": 1.63.0
+      "@oxlint/binding-linux-s390x-gnu": 1.63.0
+      "@oxlint/binding-linux-x64-gnu": 1.63.0
+      "@oxlint/binding-linux-x64-musl": 1.63.0
+      "@oxlint/binding-openharmony-arm64": 1.63.0
+      "@oxlint/binding-win32-arm64-msvc": 1.63.0
+      "@oxlint/binding-win32-ia32-msvc": 1.63.0
+      "@oxlint/binding-win32-x64-msvc": 1.63.0
 
   p-finally@1.0.0: {}
 
@@ -16890,14 +17034,15 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
-  pagefind@1.4.0:
+  pagefind@1.5.2:
     optionalDependencies:
-      "@pagefind/darwin-arm64": 1.4.0
-      "@pagefind/darwin-x64": 1.4.0
-      "@pagefind/freebsd-x64": 1.4.0
-      "@pagefind/linux-arm64": 1.4.0
-      "@pagefind/linux-x64": 1.4.0
-      "@pagefind/windows-x64": 1.4.0
+      "@pagefind/darwin-arm64": 1.5.2
+      "@pagefind/darwin-x64": 1.5.2
+      "@pagefind/freebsd-x64": 1.5.2
+      "@pagefind/linux-arm64": 1.5.2
+      "@pagefind/linux-x64": 1.5.2
+      "@pagefind/windows-arm64": 1.5.2
+      "@pagefind/windows-x64": 1.5.2
 
   papaparse@5.5.3: {}
 
@@ -16951,7 +17096,7 @@ snapshots:
 
   path-to-regexp@8.3.0: {}
 
-  path-to-regexp@8.4.1: {}
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -16989,24 +17134,30 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(yaml@2.8.3):
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.14)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      jiti: 2.6.1
-      postcss: 8.5.8
+      jiti: 2.7.0
+      postcss: 8.5.14
       tsx: 4.21.0
-      yaml: 2.8.3
+      yaml: 2.8.4
 
-  postcss-nested@6.2.0(postcss@8.5.8):
+  postcss-nested@6.2.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.8
+      postcss: 8.5.14
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.1.2:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
+
+  postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postcss@8.5.8:
     dependencies:
@@ -17032,7 +17183,7 @@ snapshots:
       minimist: 1.2.8
       mkdirp-classic: 0.5.3
       napi-build-utils: 2.0.0
-      node-abi: 3.89.0
+      node-abi: 3.92.0
       pump: 3.0.4
       rc: 1.2.8
       simple-get: 4.0.1
@@ -17160,7 +17311,7 @@ snapshots:
       strip-json-comments: 2.0.1
     optional: true
 
-  re2js@1.2.3: {}
+  re2js@1.3.3: {}
 
   readable-stream@3.6.2:
     dependencies:
@@ -17175,11 +17326,11 @@ snapshots:
 
   rechoir@0.8.0:
     dependencies:
-      resolve: 1.22.11
+      resolve: 1.22.12
 
   recma-build-jsx@1.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
@@ -17194,27 +17345,28 @@ snapshots:
 
   recma-parse@1.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       esast-util-from-js: 2.0.1
       unified: 11.0.5
       vfile: 6.0.3
 
   recma-stringify@1.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       estree-util-to-js: 2.0.0
       unified: 11.0.5
       vfile: 6.0.3
 
-  redis@5.11.0:
+  redis@5.12.1(@opentelemetry/api@1.9.1):
     dependencies:
-      "@redis/bloom": 5.11.0(@redis/client@5.11.0)
-      "@redis/client": 5.11.0
-      "@redis/json": 5.11.0(@redis/client@5.11.0)
-      "@redis/search": 5.11.0(@redis/client@5.11.0)
-      "@redis/time-series": 5.11.0(@redis/client@5.11.0)
+      "@redis/bloom": 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
+      "@redis/client": 5.12.1(@opentelemetry/api@1.9.1)
+      "@redis/json": 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
+      "@redis/search": 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
+      "@redis/time-series": 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
     transitivePeerDependencies:
       - "@node-rs/xxhash"
+      - "@opentelemetry/api"
 
   regex-recursion@6.0.2:
     dependencies:
@@ -17251,7 +17403,7 @@ snapshots:
 
   rehype-recma@1.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       "@types/hast": 3.0.4
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
@@ -17350,9 +17502,10 @@ snapshots:
 
   resolve.exports@2.0.3: {}
 
-  resolve@1.22.11:
+  resolve@1.22.12:
     dependencies:
-      is-core-module: 2.16.1
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
@@ -17388,13 +17541,13 @@ snapshots:
 
   retry@0.13.1: {}
 
-  rettime@0.11.7: {}
+  rettime@0.11.11: {}
 
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
 
-  rolldown@1.0.0-rc.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
+  rolldown@1.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
       "@oxc-project/types": 0.110.0
       "@rolldown/pluginutils": 1.0.0-rc.1
@@ -17409,14 +17562,14 @@ snapshots:
       "@rolldown/binding-linux-x64-gnu": 1.0.0-rc.1
       "@rolldown/binding-linux-x64-musl": 1.0.0-rc.1
       "@rolldown/binding-openharmony-arm64": 1.0.0-rc.1
-      "@rolldown/binding-wasm32-wasi": 1.0.0-rc.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      "@rolldown/binding-wasm32-wasi": 1.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       "@rolldown/binding-win32-arm64-msvc": 1.0.0-rc.1
       "@rolldown/binding-win32-x64-msvc": 1.0.0-rc.1
     transitivePeerDependencies:
       - "@emnapi/core"
       - "@emnapi/runtime"
 
-  rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
+  rolldown@1.0.0-rc.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
       "@oxc-project/types": 0.122.0
       "@rolldown/pluginutils": 1.0.0-rc.12
@@ -17433,33 +17586,33 @@ snapshots:
       "@rolldown/binding-linux-x64-gnu": 1.0.0-rc.12
       "@rolldown/binding-linux-x64-musl": 1.0.0-rc.12
       "@rolldown/binding-openharmony-arm64": 1.0.0-rc.12
-      "@rolldown/binding-wasm32-wasi": 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      "@rolldown/binding-wasm32-wasi": 1.0.0-rc.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       "@rolldown/binding-win32-arm64-msvc": 1.0.0-rc.12
       "@rolldown/binding-win32-x64-msvc": 1.0.0-rc.12
     transitivePeerDependencies:
       - "@emnapi/core"
       - "@emnapi/runtime"
 
-  rolldown@1.0.0-rc.15:
+  rolldown@1.0.0-rc.18:
     dependencies:
-      "@oxc-project/types": 0.124.0
-      "@rolldown/pluginutils": 1.0.0-rc.15
+      "@oxc-project/types": 0.128.0
+      "@rolldown/pluginutils": 1.0.0-rc.18
     optionalDependencies:
-      "@rolldown/binding-android-arm64": 1.0.0-rc.15
-      "@rolldown/binding-darwin-arm64": 1.0.0-rc.15
-      "@rolldown/binding-darwin-x64": 1.0.0-rc.15
-      "@rolldown/binding-freebsd-x64": 1.0.0-rc.15
-      "@rolldown/binding-linux-arm-gnueabihf": 1.0.0-rc.15
-      "@rolldown/binding-linux-arm64-gnu": 1.0.0-rc.15
-      "@rolldown/binding-linux-arm64-musl": 1.0.0-rc.15
-      "@rolldown/binding-linux-ppc64-gnu": 1.0.0-rc.15
-      "@rolldown/binding-linux-s390x-gnu": 1.0.0-rc.15
-      "@rolldown/binding-linux-x64-gnu": 1.0.0-rc.15
-      "@rolldown/binding-linux-x64-musl": 1.0.0-rc.15
-      "@rolldown/binding-openharmony-arm64": 1.0.0-rc.15
-      "@rolldown/binding-wasm32-wasi": 1.0.0-rc.15
-      "@rolldown/binding-win32-arm64-msvc": 1.0.0-rc.15
-      "@rolldown/binding-win32-x64-msvc": 1.0.0-rc.15
+      "@rolldown/binding-android-arm64": 1.0.0-rc.18
+      "@rolldown/binding-darwin-arm64": 1.0.0-rc.18
+      "@rolldown/binding-darwin-x64": 1.0.0-rc.18
+      "@rolldown/binding-freebsd-x64": 1.0.0-rc.18
+      "@rolldown/binding-linux-arm-gnueabihf": 1.0.0-rc.18
+      "@rolldown/binding-linux-arm64-gnu": 1.0.0-rc.18
+      "@rolldown/binding-linux-arm64-musl": 1.0.0-rc.18
+      "@rolldown/binding-linux-ppc64-gnu": 1.0.0-rc.18
+      "@rolldown/binding-linux-s390x-gnu": 1.0.0-rc.18
+      "@rolldown/binding-linux-x64-gnu": 1.0.0-rc.18
+      "@rolldown/binding-linux-x64-musl": 1.0.0-rc.18
+      "@rolldown/binding-openharmony-arm64": 1.0.0-rc.18
+      "@rolldown/binding-wasm32-wasi": 1.0.0-rc.18
+      "@rolldown/binding-win32-arm64-msvc": 1.0.0-rc.18
+      "@rolldown/binding-win32-x64-msvc": 1.0.0-rc.18
 
   rollup@4.60.1:
     dependencies:
@@ -17500,7 +17653,7 @@ snapshots:
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.4.1
+      path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
 
@@ -17520,7 +17673,7 @@ snapshots:
     dependencies:
       "@vercel/sandbox": 1.9.0
       debug: 4.4.3
-      zod: 4.3.6
+      zod: 4.4.3
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
@@ -17564,6 +17717,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  set-cookie-parser@3.1.0: {}
 
   setprototypeof@1.1.1: {}
 
@@ -17670,7 +17825,7 @@ snapshots:
 
   sitemap@9.0.1:
     dependencies:
-      "@types/node": 24.12.0
+      "@types/node": 24.12.2
       "@types/sax": 1.2.7
       arg: 5.0.2
       sax: 1.6.0
@@ -17731,9 +17886,9 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  starlight-typedoc@0.21.5(@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@5.9.3)))(typedoc@0.28.19(typescript@5.9.3)):
+  starlight-typedoc@0.21.5(@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@5.9.3)))(typedoc@0.28.19(typescript@5.9.3)):
     dependencies:
-      "@astrojs/starlight": 0.37.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
+      "@astrojs/starlight": 0.37.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4))
       github-slugger: 2.0.0
       typedoc: 0.28.19(typescript@5.9.3)
       typedoc-plugin-markdown: 4.11.0(typedoc@0.28.19(typescript@5.9.3))
@@ -17744,7 +17899,7 @@ snapshots:
 
   statuses@2.0.2: {}
 
-  std-env@4.0.0: {}
+  std-env@4.1.0: {}
 
   stream-replace-string@2.0.0: {}
 
@@ -17815,6 +17970,8 @@ snapshots:
 
   strnum@2.2.2: {}
 
+  strnum@2.2.3: {}
+
   strtok3@10.3.5:
     dependencies:
       "@tokenizer/token": 0.3.0
@@ -17855,7 +18012,7 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
-  tapable@2.3.2: {}
+  tapable@2.3.3: {}
 
   tar-fs@2.1.4:
     dependencies:
@@ -17935,18 +18092,25 @@ snapshots:
 
   tinyexec@1.0.4: {}
 
+  tinyexec@1.1.2: {}
+
   tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
   tinyrainbow@3.1.0: {}
 
-  tldts-core@7.0.27: {}
+  tldts-core@7.0.30: {}
 
-  tldts@7.0.27:
+  tldts@7.0.30:
     dependencies:
-      tldts-core: 7.0.27
+      tldts-core: 7.0.30
 
   to-regex-range@5.0.1:
     dependencies:
@@ -17964,7 +18128,7 @@ snapshots:
 
   tough-cookie@6.0.1:
     dependencies:
-      tldts: 7.0.27
+      tldts: 7.0.30
 
   tr46@0.0.3: {}
 
@@ -17992,8 +18156,8 @@ snapshots:
   tsconfig-paths-webpack-plugin@4.2.0:
     dependencies:
       chalk: 4.1.2
-      enhanced-resolve: 5.20.1
-      tapable: 2.3.2
+      enhanced-resolve: 5.21.0
+      tapable: 2.3.3
       tsconfig-paths: 4.2.0
 
   tsconfig-paths@4.2.0:
@@ -18004,7 +18168,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(@swc/core@1.15.3)(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
+  tsup@8.5.1(@swc/core@1.15.3)(jiti@2.7.0)(postcss@8.5.14)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.4)
       cac: 6.7.14
@@ -18015,7 +18179,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(yaml@2.8.3)
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.14)(tsx@4.21.0)(yaml@2.8.4)
       resolve-from: 5.0.0
       rollup: 4.60.1
       source-map: 0.7.6
@@ -18025,7 +18189,7 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       "@swc/core": 1.15.3
-      postcss: 8.5.8
+      postcss: 8.5.14
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -18045,13 +18209,13 @@ snapshots:
       safe-buffer: 5.2.1
     optional: true
 
-  turndown@7.2.2:
+  turndown@7.2.4:
     dependencies:
       "@mixmark-io/domino": 2.2.0
 
   type-fest@4.41.0: {}
 
-  type-fest@5.5.0:
+  type-fest@5.6.0:
     dependencies:
       tagged-tag: 1.0.0
 
@@ -18060,6 +18224,8 @@ snapshots:
       content-type: 1.0.5
       media-typer: 1.1.0
       mime-types: 3.0.2
+
+  typebox@1.1.38: {}
 
   typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@5.9.3)):
     dependencies:
@@ -18073,8 +18239,6 @@ snapshots:
       minimatch: 10.2.5
       typescript: 5.9.3
       yaml: 2.8.3
-
-  typebox@1.1.38: {}
 
   typesafe-path@0.2.2: {}
 
@@ -18180,7 +18344,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unstorage@1.17.5(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4):
+  unstorage@1.17.5(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -18192,13 +18356,13 @@ snapshots:
       ufo: 1.6.3
     optionalDependencies:
       "@vercel/blob": 2.3.0
-      "@vercel/functions": 3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33)
+      "@vercel/functions": 3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33)
       db0: 0.3.4
 
-  unstorage@2.0.0-alpha.7(@vercel/blob@2.3.0)(@vercel/functions@3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33))(chokidar@5.0.0)(db0@0.3.4)(lru-cache@11.2.7)(ofetch@2.0.0-alpha.3):
+  unstorage@2.0.0-alpha.7(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(chokidar@5.0.0)(db0@0.3.4)(lru-cache@11.2.7)(ofetch@2.0.0-alpha.3):
     optionalDependencies:
       "@vercel/blob": 2.3.0
-      "@vercel/functions": 3.4.3(@aws-sdk/credential-provider-web-identity@3.972.33)
+      "@vercel/functions": 3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33)
       chokidar: 5.0.0
       db0: 0.3.4
       lru-cache: 11.2.7
@@ -18214,28 +18378,28 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vercel@51.4.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(rollup@4.60.1)(typescript@5.9.3):
+  vercel@51.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(typescript@5.9.3):
     dependencies:
-      "@vercel/backends": 0.0.62(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(rollup@4.60.1)(typescript@5.9.3)
+      "@vercel/backends": 0.0.62(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(typescript@5.9.3)
       "@vercel/blob": 2.3.0
       "@vercel/build-utils": 13.17.0
       "@vercel/detect-agent": 1.2.2
-      "@vercel/elysia": 0.1.65(rollup@4.60.1)
-      "@vercel/express": 0.1.75(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(rollup@4.60.1)(typescript@5.9.3)
-      "@vercel/fastify": 0.1.68(rollup@4.60.1)
+      "@vercel/elysia": 0.1.65
+      "@vercel/express": 0.1.75(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(typescript@5.9.3)
+      "@vercel/fastify": 0.1.68
       "@vercel/fun": 1.3.0
       "@vercel/go": 3.5.0
-      "@vercel/h3": 0.1.74(rollup@4.60.1)
-      "@vercel/hono": 0.2.68(rollup@4.60.1)
+      "@vercel/h3": 0.1.74
+      "@vercel/hono": 0.2.68
       "@vercel/hydrogen": 1.3.6
-      "@vercel/koa": 0.1.48(rollup@4.60.1)
-      "@vercel/nestjs": 0.2.69(rollup@4.60.1)
-      "@vercel/next": 4.16.8(rollup@4.60.1)
-      "@vercel/node": 5.7.7(rollup@4.60.1)
+      "@vercel/koa": 0.1.48
+      "@vercel/nestjs": 0.2.69
+      "@vercel/next": 4.16.8
+      "@vercel/node": 5.7.7
       "@vercel/prepare-flags-definitions": 0.2.1
       "@vercel/python": 6.33.0
-      "@vercel/redwood": 2.4.12(rollup@4.60.1)
-      "@vercel/remix-builder": 5.7.2(rollup@4.60.1)
+      "@vercel/redwood": 2.4.12
+      "@vercel/remix-builder": 5.7.2
       "@vercel/ruby": 2.3.2
       "@vercel/rust": 1.1.0
       "@vercel/static-build": 2.9.15
@@ -18272,7 +18436,7 @@ snapshots:
       "@types/unist": 3.0.3
       vfile-message: 4.0.3
 
-  vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
+  vite@6.4.1(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -18283,64 +18447,64 @@ snapshots:
     optionalDependencies:
       "@types/node": 25.6.0
       fsevents: 2.3.3
-      jiti: 2.6.1
+      jiti: 2.7.0
       lightningcss: 1.32.0
       terser: 5.46.1
       tsx: 4.21.0
-      yaml: 2.8.3
+      yaml: 2.8.4
 
-  vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
+  vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.8
-      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-      tinyglobby: 0.2.15
+      postcss: 8.5.14
+      rolldown: 1.0.0-rc.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      tinyglobby: 0.2.16
     optionalDependencies:
       "@types/node": 25.6.0
       esbuild: 0.27.4
       fsevents: 2.3.3
-      jiti: 2.6.1
+      jiti: 2.7.0
       terser: 5.46.1
       tsx: 4.21.0
-      yaml: 2.8.3
+      yaml: 2.8.4
     transitivePeerDependencies:
       - "@emnapi/core"
       - "@emnapi/runtime"
 
-  vitefu@1.1.2(vite@6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitefu@1.1.2(vite@6.4.1(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)):
     optionalDependencies:
-      vite: 6.4.1(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.1(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
 
-  vitest-evals@0.9.0-beta.1(ai@6.0.162(zod@4.3.6))(tinyrainbow@3.1.0)(vitest@4.1.4(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))(zod@4.3.6):
+  vitest-evals@0.9.0-beta.1(ai@6.0.175(zod@4.4.3))(tinyrainbow@3.1.0)(vitest@4.1.5(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(msw@2.14.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)))(zod@4.4.3):
     dependencies:
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(msw@2.14.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
     optionalDependencies:
-      ai: 6.0.162(zod@4.3.6)
-      zod: 4.3.6
+      ai: 6.0.175(zod@4.4.3)
+      zod: 4.4.3
 
-  vitest@4.1.4(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.5(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(msw@2.14.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)):
     dependencies:
-      "@vitest/expect": 4.1.4
-      "@vitest/mocker": 4.1.4(msw@2.13.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-      "@vitest/pretty-format": 4.1.4
-      "@vitest/runner": 4.1.4
-      "@vitest/snapshot": 4.1.4
-      "@vitest/spy": 4.1.4
-      "@vitest/utils": 4.1.4
-      es-module-lexer: 2.0.0
+      "@vitest/expect": 4.1.5
+      "@vitest/mocker": 4.1.5(msw@2.14.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
+      "@vitest/pretty-format": 4.1.5
+      "@vitest/runner": 4.1.5
+      "@vitest/snapshot": 4.1.5
+      "@vitest/spy": 4.1.5
+      "@vitest/utils": 4.1.5
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.4
-      std-env: 4.0.0
+      std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.15
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       "@edge-runtime/vm": 3.2.0
@@ -18476,12 +18640,6 @@ snapshots:
     dependencies:
       string-width: 7.2.0
 
-  wrap-ansi@6.2.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -18519,8 +18677,8 @@ snapshots:
   yaml-language-server@1.20.0:
     dependencies:
       "@vscode/l10n": 0.0.18
-      ajv: 8.18.0
-      ajv-draft-04: 1.0.0(ajv@8.18.0)
+      ajv: 8.20.0
+      ajv-draft-04: 1.0.0(ajv@8.20.0)
       prettier: 3.8.3
       request-light: 0.5.8
       vscode-json-languageservice: 4.1.8
@@ -18533,6 +18691,8 @@ snapshots:
   yaml@2.7.1: {}
 
   yaml@2.8.3: {}
+
+  yaml@2.8.4: {}
 
   yargs-parser@21.1.1: {}
 
@@ -18566,17 +18726,15 @@ snapshots:
     dependencies:
       yoctocolors: 2.1.2
 
-  yoctocolors-cjs@2.1.3: {}
-
   yoctocolors@2.1.2: {}
 
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
 
-  zod-to-json-schema@3.25.2(zod@4.3.6):
+  zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
   zod-to-ts@1.2.0(typescript@5.9.3)(zod@3.25.76):
     dependencies:
@@ -18589,6 +18747,6 @@ snapshots:
 
   zod@3.25.76: {}
 
-  zod@4.3.6: {}
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
Update Chat SDK and selected non-major third-party packages across the workspace while leaving major framework/tooling upgrades for separate PRs. The update keeps the Slack webhook side-channel aligned with Chat SDK initialization and refreshes tests around the new thread post shape.

**Chat SDK Compatibility**

Slack `message_changed` handling now initializes the bot before using adapter auth, and local test threads implement the new participant lookup contract.

**Harness Stability**

The example build discovery test syncs the built Junior `dist` into the example package instead of running a nested workspace install inside Vitest. Eval harness expectations now include Slack `channel` and `thread_ts` fields preserved by Chat SDK 4.27.

**Dependency Safety**

`just-bash` is intentionally held on the previously safe 2.14.2 release because 2.14.4 pins `fast-xml-parser` to a version flagged by Dependency Review.

**Deferred Majors**

Astro 6, Starlight 0.38, TypeScript 6, Vercel 53, and lint-staged 17 remain intentionally untouched for separate migration work.