### PR TITLE
feat(junior): Add extension authoring skill

### DIFF
--- a/packages/junior/skills/junior/SKILL.md
+++ b/packages/junior/skills/junior/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: junior
+description: Build, review, or update Junior extension skills and plugins. Use when users ask to create a Junior SKILL.md, app skill, plugin, plugin.yaml, packaged plugin, MCP-backed plugin, OAuth or credentialed plugin, or to validate Junior extension files. Do not use for ordinary Junior usage, provider workflows, generic code editing, or non-Junior agent-skill authoring.
+---
+
+# Junior
+
+Create or repair Junior extension files.
+
+## References
+
+| Need                                                                     | Read                                                                                         |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| Choose app skill, app plugin, packaged plugin, or repo-local location    | [references/placement-and-discovery.md](references/placement-and-discovery.md)               |
+| Write or review a `SKILL.md` file                                        | [references/skill-authoring.md](references/skill-authoring.md)                               |
+| Write or review `plugin.yaml`                                            | [references/plugin-manifest.md](references/plugin-manifest.md)                               |
+| Decide where credentials, MCP, packages, OAuth, config, and setup belong | [references/runtime-authority.md](references/runtime-authority.md)                           |
+| Package a reusable plugin for npm or this monorepo                       | [references/packaging.md](references/packaging.md)                                           |
+| Validate files or diagnose check failures                                | [references/validation-and-troubleshooting.md](references/validation-and-troubleshooting.md) |
+| Need concrete templates, robust variants, or anti-pattern corrections    | [references/examples.md](references/examples.md)                                             |
+
+Maintenance: [SPEC.md](SPEC.md). Provenance: [SOURCES.md](SOURCES.md).
+
+## Workflow
+
+1. Classify:
+
+- App-local skill: behavior only, no provider-specific runtime authority.
+- App-local plugin: provider or workflow bundle for one app.
+- Packaged plugin: reusable plugin shipped as an npm package.
+- Monorepo package: new or changed package under `packages/`.
+
+2. Inspect:
+
+- Inspect nearby `SKILL.md` files, `plugin.yaml` manifests, app docs, and package metadata.
+- In this repo, treat `PLUGIN.md`, `specs/plugin-spec.md`, `specs/skill-capabilities-spec.md`, and validators as authoritative.
+- Preserve: placement, manifest authority, credential secrecy, validation, discovery.
+
+3. Choose shape:
+
+- Skill only when no provider runtime setup is needed.
+- Plugin when config, credentials, OAuth, MCP, packages, postinstall, or reuse is needed.
+- References only for optional depth.
+
+4. Author:
+
+- Put skill behavior in `SKILL.md`.
+- Put runtime authority in `plugin.yaml`.
+- Put reusable package metadata in `package.json`.
+- Keep secrets out of all committed files.
+
+5. Validate:
+
+- Run the narrowest structural check first.
+- Fix every validation error before claiming the extension is complete.
+- For runtime dependencies, verify snapshot creation or one real workflow when available.
+
+## Hard rules
+
+- Skill frontmatter owns activation only; plugin manifests own provider authority.
+- Do not use `requires-capabilities` or `uses-config` in skills.
+- Do not hardcode harness dispatcher mechanics in skill prose.
+- Do not print, persist, or ask users to paste secrets into skill files.
+- Do not create top-level `skills/` or `plugins/` in a Junior app unless local tooling explicitly requires that legacy layout.
+- Do not invent manifest fields. If the parser does not support a field, omit it or change the runtime first.
+
+## Reporting
+
+1. Files created or changed.
+2. Placement and discovery path.
+3. Validation commands and result.
+4. Remaining runtime verification: OAuth, MCP, credentials, snapshots, Slack.

--- a/packages/junior/skills/junior/SOURCES.md
+++ b/packages/junior/skills/junior/SOURCES.md
@@ -1,0 +1,52 @@
+# Junior Extension Skill Sources
+
+Last updated: 2026-05-07
+
+## Sources
+
+| Source                                                          | Use                                                 |
+| --------------------------------------------------------------- | --------------------------------------------------- |
+| `AGENTS.md`                                                     | repo validation and contribution rules              |
+| `PLUGIN.md`                                                     | plugin layout and examples                          |
+| `specs/plugin-spec.md`                                          | plugin model, manifest, discovery, runtime boundary |
+| `specs/skill-capabilities-spec.md`                              | no skill-owned capabilities/config                  |
+| `packages/docs/src/content/docs/extend/index.md`                | public plugin setup                                 |
+| `packages/docs/src/content/docs/concepts/skills-and-plugins.md` | mental model                                        |
+| `packages/docs/src/content/docs/cli/check.md`                   | app validation                                      |
+| `packages/junior/src/chat/skills.ts`                            | skill parser/discovery/runtime boundary             |
+| `packages/junior/src/chat/plugins/manifest.ts`                  | manifest parser                                     |
+| `packages/junior/src/chat/plugins/package-discovery.ts`         | packaged plugin discovery                           |
+| `packages/junior/src/cli/check.ts`                              | `junior check` behavior                             |
+| `packages/junior/scripts/check-skills.mjs`                      | repo skill validation                               |
+| `packages/junior-*` and `apps/example`                          | working examples                                    |
+
+## Decisions
+
+| Decision                                                                  | Status   |
+| ------------------------------------------------------------------------- | -------- |
+| Skill name/path: `packages/junior/skills/junior`                          | adopted  |
+| Shape: reference-backed router                                            | adopted  |
+| Central rule: `SKILL.md` describes behavior; `plugin.yaml` owns authority | adopted  |
+| Examples stay in a reference, not `SKILL.md`                              | adopted  |
+| No new scripts                                                            | adopted  |
+| Distribution as packaged plugin                                           | deferred |
+
+## Coverage
+
+- provenance: complete
+- placement/discovery: complete
+- skill authoring: complete
+- manifest schema: complete
+- runtime authority: complete
+- packaging: complete
+- validation/troubleshooting: complete
+- examples: happy path, robust variant, anti-pattern
+
+## Gaps
+
+- No standalone public command validates packaged root `plugin.yaml`; use runtime loading or parser tests.
+- Update when parsers, discovery, `junior check`, or packaged plugin loading changes.
+
+## Changelog
+
+- 2026-05-07: Created and renamed to `junior`.

--- a/packages/junior/skills/junior/SPEC.md
+++ b/packages/junior/skills/junior/SPEC.md
@@ -1,0 +1,72 @@
+# Junior Extension Skill Specification
+
+## Intent
+
+Create, review, and repair Junior skills/plugins while preserving the `SKILL.md` vs `plugin.yaml` authority split.
+
+## Scope
+
+In:
+
+- `app/skills/<skill>/SKILL.md`
+- `app/plugins/<plugin>/plugin.yaml`
+- `app/plugins/<plugin>/skills/<skill>/SKILL.md`
+- packaged plugin roots with `plugin.yaml` and `skills/`
+- `packages/junior-*` plugin packages
+- validation and common check failures
+
+Out:
+
+- ordinary provider workflows
+- non-Junior skill authoring
+- core runtime contract changes without specs/tests
+- secrets
+
+## Trigger
+
+Use for: create Junior skill/plugin, add `plugin.yaml`, package plugin, fix `junior check`, move auth/setup out of skill prose, add MCP/OAuth.
+
+Do not use for: existing provider usage, generic code review, docs-only edits.
+
+## Contract
+
+- First: classify placement, inspect nearby conventions, identify manifest-owned authority.
+- Output: files/guidance, discovery path, validation result, remaining runtime checks.
+- Constraints: credentials/setup in `plugin.yaml`; no deprecated skill frontmatter; fix validation errors.
+
+## Sources
+
+Authoritative:
+
+- `PLUGIN.md`
+- `specs/plugin-spec.md`
+- `specs/skill-capabilities-spec.md`
+- `packages/docs/src/content/docs/extend/index.md`
+- `packages/docs/src/content/docs/cli/check.md`
+- `packages/junior/src/chat/skills.ts`
+- `packages/junior/src/chat/plugins/manifest.ts`
+- `packages/junior/src/cli/check.ts`
+- `packages/junior/scripts/check-skills.mjs`
+
+## Files
+
+| File          | Purpose                           |
+| ------------- | --------------------------------- |
+| `SKILL.md`    | trigger, routing, workflow, rules |
+| `references/` | focused runtime guidance          |
+| `SOURCES.md`  | provenance, decisions, gaps       |
+| `SPEC.md`     | maintenance contract              |
+
+## Validation
+
+- Skill: skill-writer validator and `pnpm skills:check`.
+- App: `pnpm exec junior check`.
+- Runtime: one real workflow for OAuth, credentials, MCP, dependencies, or postinstall.
+- Tests: only when parser/discovery/runtime behavior changes.
+
+## Maintenance
+
+- Update `SKILL.md`: triggers, workflow, hard rules.
+- Update `plugin-manifest.md`: manifest parser changes.
+- Update `validation-and-troubleshooting.md`: validator changes.
+- Update `SOURCES.md`: source, decision, or gap changes.

--- a/packages/junior/skills/junior/references/examples.md
+++ b/packages/junior/skills/junior/references/examples.md
@@ -1,0 +1,194 @@
+# Examples
+
+## App Skill
+
+```text
+app/skills/release-notes/
+└── SKILL.md
+```
+
+```markdown
+---
+name: release-notes
+description: Draft release notes from local project context. Use for changelog bullets and unreleased-change summaries. Do not use for publishing releases or changing version files.
+---
+
+# Release Notes
+
+1. Identify the release range or ask for it.
+2. Inspect local changelog, commits, and issue references.
+3. Draft user-facing bullets grouped by feature, fix, and operational note.
+4. Call out missing validation.
+
+## Guardrails
+
+- Do not change files unless asked.
+- Do not invent issue links or customer impact.
+```
+
+Checks:
+
+- `app/skills`: no provider authority.
+- Description has positive and negative triggers.
+- Validate with `pnpm exec junior check`.
+
+## App Plugin
+
+```text
+app/plugins/acme/
+├── plugin.yaml
+└── skills/
+    └── acme/
+        └── SKILL.md
+```
+
+```yaml
+name: acme
+description: Acme support data lookup
+
+capabilities:
+  - api.read
+
+env-vars:
+  ACME_AUTH_HEADER:
+  ACME_REGION:
+    default: us
+
+api-domains:
+  - api.acme.example
+api-headers:
+  Authorization: ${ACME_AUTH_HEADER}
+
+mcp:
+  url: https://mcp.${ACME_REGION}.acme.example/mcp
+  allowed-tools:
+    - search_customers
+    - fetch_customer
+```
+
+```markdown
+---
+name: acme
+description: Look up Acme support data through the Acme plugin. Use for customer records, account status, or Acme support context. Do not use for writes or non-Acme data.
+---
+
+# Acme Support Lookup
+
+1. Classify as customer search, fetch, or account-status lookup.
+2. Prefer explicit customer IDs, domains, or account names.
+3. Use read-only Acme provider tools.
+4. Summarize only necessary customer data.
+
+## Guardrails
+
+- Read-only only.
+- If runtime surface is unavailable, report an Acme plugin setup failure.
+```
+
+Checks:
+
+- Secrets stay in deployment env.
+- MCP/header setup is manifest-owned.
+- Skill describes behavior only.
+
+## Anti-Pattern
+
+```markdown
+---
+name: acme
+description: Work with Acme.
+requires-capabilities:
+  - acme.api.read
+uses-config:
+  - acme.region
+---
+
+# Acme
+
+Run `pnpm add acme-cli`, export `ACME_TOKEN`, configure MCP, then call `callMcpTool`.
+```
+
+Wrong:
+
+- deprecated frontmatter
+- package/token/config/MCP setup in skill prose
+- secret handling in model-visible workflow
+- hardcoded dispatcher mechanics
+
+Fix:
+
+```yaml
+name: acme
+description: Acme support data lookup
+
+capabilities:
+  - api.read
+
+config-keys:
+  - region
+
+credentials:
+  type: oauth-bearer
+  api-domains:
+    - api.acme.example
+  auth-token-env: ACME_AUTH_TOKEN
+  auth-token-placeholder: host_managed_credential
+
+oauth:
+  client-id-env: ACME_CLIENT_ID
+  client-secret-env: ACME_CLIENT_SECRET
+  authorize-endpoint: https://acme.example/oauth/authorize
+  token-endpoint: https://acme.example/oauth/token
+
+runtime-dependencies:
+  - type: npm
+    package: acme-cli
+
+mcp:
+  url: https://mcp.acme.example/mcp
+  allowed-tools:
+    - search_customers
+    - fetch_customer
+```
+
+```markdown
+---
+name: acme
+description: Look up Acme support data. Use for Acme customer searches and account-status lookups. Do not use for customer mutations or unrelated provider data.
+---
+
+# Acme Lookup
+
+1. Resolve the customer from explicit user input.
+2. Use read-only Acme commands or provider tools.
+3. Return a concise answer with record IDs.
+4. Report Acme plugin setup issues when auth/runtime is unavailable.
+```
+
+## Package
+
+```text
+junior-plugin-acme/
+├── package.json
+├── plugin.yaml
+└── skills/
+    └── acme/
+        └── SKILL.md
+```
+
+```json
+{
+  "name": "@acme/junior-plugin-acme",
+  "private": false,
+  "type": "module",
+  "files": ["plugin.yaml", "skills"]
+}
+```
+
+Validate:
+
+1. Package/repo checks.
+2. Add package to `pluginPackages`.
+3. `pnpm exec junior check` for app-local files.
+4. Runtime load or parser test for packaged `plugin.yaml`.
+5. One real workflow after env is configured.

--- a/packages/junior/skills/junior/references/packaging.md
+++ b/packages/junior/skills/junior/references/packaging.md
@@ -1,0 +1,77 @@
+# Packaging
+
+## Generic npm package layout
+
+```text
+my-junior-plugin/
+├── package.json
+├── plugin.yaml
+└── skills/
+    └── my-provider/
+        └── SKILL.md
+```
+
+```json
+{
+  "name": "@acme/junior-my-provider",
+  "private": false,
+  "type": "module",
+  "files": ["plugin.yaml", "skills"]
+}
+```
+
+## Host app wiring
+
+Install next to `@sentry/junior`, then list in `pluginPackages`.
+
+```ts
+import { defineConfig } from "nitro";
+import { juniorNitro } from "@sentry/junior/nitro";
+
+export default defineConfig({
+  preset: "vercel",
+  modules: [
+    juniorNitro({
+      pluginPackages: ["@acme/junior-my-provider"],
+    }),
+  ],
+  routes: {
+    "/**": { handler: "./server.ts" },
+  },
+});
+```
+
+For local dev paths that call `createApp()` directly, pass the same list there unless the app already centralizes it.
+
+```ts
+const app = await createApp({
+  pluginPackages: ["@acme/junior-my-provider"],
+});
+```
+
+## Monorepo package checklist
+
+When adding a new package under this repository's `packages/` directory:
+
+- Match naming such as `@sentry/junior-<provider>`.
+- Include `plugin.yaml` and `skills` in `package.json` `files`.
+- Add a package README if users need setup or verification steps.
+- Keep package version aligned with the monorepo release process.
+- Keep release package lists aligned across `.craft.yml`, `scripts/bump-release-versions.mjs`, `.github/workflows/ci.yml`, `README.md`, and release docs.
+- Run `pnpm release:check` after release-list changes.
+
+## Packaged plugin discovery
+
+- Junior only loads packaged plugin content from package names supplied to the app.
+- A package with root `plugin.yaml` contributes that manifest.
+- A package with root `skills/` contributes those skill roots.
+- A package with `plugins/` contributes each child plugin containing `plugin.yaml`.
+- Nitro copies app content and declared package content into the server bundle.
+
+## Packaging validation
+
+- Run package-local lint/type checks when package code changes.
+- Run `pnpm skills:check` in this repository after changing package skill files.
+- Run `pnpm exec junior check` in a consumer app for app-local files.
+- Validate the packaged root `plugin.yaml` by loading it through a configured host app/runtime or a targeted parser test.
+- Run `junior snapshot create` when runtime dependencies or postinstall steps need sandbox snapshot warmup.

--- a/packages/junior/skills/junior/references/placement-and-discovery.md
+++ b/packages/junior/skills/junior/references/placement-and-discovery.md
@@ -1,0 +1,31 @@
+# Placement And Discovery
+
+Choose placement before writing files.
+
+## Decision table
+
+| Request                                      | Put files here                                                                                          | Use when                                                                                                | Validate with                                                    |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| App-specific behavior with no provider setup | `app/skills/<skill-name>/SKILL.md`                                                                      | The skill only changes how Junior reasons or responds.                                                  | `pnpm exec junior check` from the app root                       |
+| App-specific provider or tool bundle         | `app/plugins/<plugin-name>/plugin.yaml` plus `app/plugins/<plugin-name>/skills/<skill-name>/SKILL.md`   | The workflow needs config keys, credentials, OAuth, MCP, runtime packages, API headers, or postinstall. | `pnpm exec junior check` from the app root                       |
+| Reusable provider or workflow package        | package root `plugin.yaml` plus `skills/<skill-name>/SKILL.md`                                          | Multiple apps should install the same plugin.                                                           | package-local checks plus a configured host-app runtime load     |
+| This monorepo's packaged provider            | `packages/junior-<provider>/plugin.yaml` plus `packages/junior-<provider>/skills/<skill-name>/SKILL.md` | The provider ships as an `@sentry/junior-*` package.                                                    | `pnpm skills:check` and release checks when package lists change |
+| Core repo-only skill                         | `packages/junior/skills/<skill-name>/SKILL.md`                                                          | The skill belongs to core Junior repo workflows rather than a provider package.                         | `pnpm skills:check`                                              |
+
+## Discovery rules
+
+- Junior app validation checks `app/skills` and `app/plugins`.
+- `junior check` ignores legacy top-level `skills/` and `plugins/` in app roots.
+- Runtime app skills come from the resolved app home directory's `skills/` folder.
+- App-local plugin skills come from `app/plugins/<plugin-name>/skills`.
+- Packaged plugin content is discovered only from explicitly configured plugin package names.
+- A package may expose a root `plugin.yaml`, a `plugins/` directory, a `skills/` directory, or a combination supported by package discovery.
+- `junior check` validates app-local plugin manifests; packaged plugin manifests must be exercised through a configured app/runtime or a targeted parser test.
+
+## Placement guardrails
+
+- Use `app/skills` only when the skill does not need manifest-owned authority.
+- Use a plugin as soon as the workflow needs provider-specific runtime setup.
+- Do not copy a packaged plugin into an app unless the user wants an app-local fork.
+- Do not place a user-facing app skill under the repository root `skills/` unless a local non-app tool explicitly loads that legacy location.
+- Keep skill names globally unique across app-local and plugin skill roots in the same app.

--- a/packages/junior/skills/junior/references/plugin-manifest.md
+++ b/packages/junior/skills/junior/references/plugin-manifest.md
@@ -1,0 +1,95 @@
+# Plugin Manifest
+
+## Minimal
+
+```yaml
+name: my-provider
+description: Internal provider workflows
+```
+
+## Required
+
+| Field         | Rule                        |
+| ------------- | --------------------------- |
+| `name`        | `^[a-z][a-z0-9-]*$`, unique |
+| `description` | non-empty string            |
+
+## Optional
+
+| Field                  | Purpose                     | Rules                                              |
+| ---------------------- | --------------------------- | -------------------------------------------------- |
+| `capabilities`         | provider permissions        | short tokens, qualified as `<plugin>.<capability>` |
+| `config-keys`          | defaults/targets            | short tokens, qualified as `<plugin>.<key>`        |
+| `env-vars`             | allowed deployment env refs | keys match `[A-Z_][A-Z0-9_]*`                      |
+| `api-domains`          | header injection domains    | required with `api-headers`                        |
+| `api-headers`          | literal/env-backed headers  | values may use declared `${NAME}`                  |
+| `credentials`          | token delivery              | `oauth-bearer` or `github-app`                     |
+| `oauth`                | user OAuth                  | requires `credentials.type: oauth-bearer`          |
+| `target`               | target/config metadata      | `config-key` must be in `config-keys`              |
+| `runtime-dependencies` | sandbox packages            | `npm` or `system`                                  |
+| `runtime-postinstall`  | setup commands              | `cmd`, optional `args`, optional `sudo`            |
+| `mcp`                  | hosted HTTP MCP             | HTTPS `url`, optional `allowed-tools`              |
+
+## OAuth bearer
+
+```yaml
+credentials:
+  type: oauth-bearer
+  api-domains:
+    - api.example.com
+  auth-token-env: EXAMPLE_AUTH_TOKEN
+  auth-token-placeholder: host_managed_credential
+
+oauth:
+  client-id-env: EXAMPLE_CLIENT_ID
+  client-secret-env: EXAMPLE_CLIENT_SECRET
+  authorize-endpoint: https://example.com/oauth/authorize
+  token-endpoint: https://example.com/oauth/token
+  scope: "read write"
+```
+
+## GitHub App
+
+```yaml
+credentials:
+  type: github-app
+  api-domains:
+    - api.github.com
+  auth-token-env: GITHUB_TOKEN
+  auth-token-placeholder: ghp_host_managed_credential
+  app-id-env: GITHUB_APP_ID
+  private-key-env: GITHUB_APP_PRIVATE_KEY
+  installation-id-env: GITHUB_INSTALLATION_ID
+```
+
+## MCP + headers
+
+```yaml
+env-vars:
+  EXAMPLE_SITE:
+    default: example.com
+  EXAMPLE_AUTH_HEADER:
+
+api-domains:
+  - api.example.com
+api-headers:
+  Authorization: ${EXAMPLE_AUTH_HEADER}
+
+mcp:
+  url: https://mcp.${EXAMPLE_SITE}/mcp
+  allowed-tools:
+    - search
+    - fetch
+```
+
+## Parser traps
+
+- `api-headers` requires `api-domains`.
+- `api-domains` requires `api-headers`.
+- `oauth` requires `credentials.type: oauth-bearer`.
+- `mcp.url` env refs must be declared in `env-vars`.
+- API-header env refs must not declare defaults.
+- `Authorization` is reserved inside token-backed `credentials.api-headers`.
+- `target.config-key` must be listed in `config-keys`.
+- System dependencies must not declare `version`.
+- System URL dependencies require HTTPS `url` plus 64-char hex `sha256`.

--- a/packages/junior/skills/junior/references/runtime-authority.md
+++ b/packages/junior/skills/junior/references/runtime-authority.md
@@ -1,0 +1,57 @@
+# Runtime Authority Boundary
+
+Skills describe behavior. Plugins declare authority.
+
+## Put this in `plugin.yaml`
+
+| Runtime need                             | Manifest owner                                   |
+| ---------------------------------------- | ------------------------------------------------ |
+| Provider permissions                     | `capabilities`                                   |
+| Conversation or install defaults         | `config-keys` plus optional app `configDefaults` |
+| OAuth bearer delivery                    | `credentials` and `oauth`                        |
+| GitHub App delivery                      | `credentials`                                    |
+| Static or deployment-backed HTTP headers | `env-vars`, `api-domains`, `api-headers`         |
+| CLI or npm package availability          | `runtime-dependencies`                           |
+| System packages in the sandbox           | `runtime-dependencies`                           |
+| Postinstall/bootstrap command            | `runtime-postinstall`                            |
+| Hosted MCP endpoint                      | `mcp.url`                                        |
+| MCP tool allowlist                       | `mcp.allowed-tools`                              |
+| Provider target flag defaults            | `target`                                         |
+
+## Put this in `SKILL.md`
+
+- Operation selection and workflow.
+- How to use provider commands or active provider tools once available.
+- How to resolve targets from explicit user input and configured defaults.
+- How to summarize results.
+- How to report access, setup, auth, or permission failures.
+- When to ask a concise follow-up.
+
+## Secrets
+
+- Secrets never belong in skill files or committed manifests.
+- Manifest env var names may be committed; secret values stay in deployment configuration.
+- Runtime credential leases are requester-bound and turn-scoped.
+- Missing or stale OAuth is handled by Junior's private authorization flow.
+
+## Dependencies
+
+- Sandbox OS is Amazon Linux 2023.
+- Runtime packages and postinstall steps are manifest-owned.
+- If a declared CLI is unavailable, report `<plugin> plugin runtime setup failure`.
+
+## MCP
+
+- Declare hosted HTTP MCP servers in `plugin.yaml`.
+- Use `allowed-tools` for least surface.
+- Skills describe provider tasks in domain terms.
+- If MCP auth is required, Junior handles the pause and resume flow.
+
+## Placement test
+
+1. Would this instruction grant access, install software, or configure auth?
+   Put it in `plugin.yaml` or host deployment docs.
+2. Would this instruction help choose or execute a user workflow after the runtime surface exists?
+   Put it in `SKILL.md`.
+3. Would a malicious skill author gain more authority by changing this prose?
+   Move it to the manifest or runtime.

--- a/packages/junior/skills/junior/references/skill-authoring.md
+++ b/packages/junior/skills/junior/references/skill-authoring.md
@@ -1,0 +1,62 @@
+# Skill Authoring
+
+## Required structure
+
+```markdown
+---
+name: release-helper
+description: Prepare release notes from local project context. Use when users ask Junior to draft release notes or summarize unreleased changes.
+---
+
+# Release Helper
+
+1. Inspect the requested release range.
+2. Summarize user-visible changes.
+3. Call out missing validation.
+```
+
+## Frontmatter contract
+
+| Field                   | Rule                                                                                                                                                     |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                  | Required string. Must match the directory name. Use lowercase letters, digits, and hyphens; no leading, trailing, or repeated hyphens. Maximum 64 chars. |
+| `description`           | Required string. Must be non-empty, under 1024 chars, and contain no angle brackets. Include realistic trigger and anti-trigger language.                |
+| `metadata`              | Optional object. Use only when runtime or UI code reads it.                                                                                              |
+| `compatibility`         | Optional string, maximum 500 chars.                                                                                                                      |
+| `license`               | Optional string.                                                                                                                                         |
+| `allowed-tools`         | Optional whitespace-separated string of allowed tool names.                                                                                              |
+| `requires-capabilities` | Forbidden. Plugin capabilities come from `plugin.yaml`.                                                                                                  |
+| `uses-config`           | Forbidden. Plugin config keys come from `plugin.yaml`.                                                                                                   |
+
+## Body
+
+- Start with what the skill does and when to use it.
+- Use ordered workflows, short guardrails, and direct reference links.
+- Keep every instruction actionable.
+- Load optional depth through `references/*.md` instead of expanding `SKILL.md`.
+- Use domain language.
+- Plugin-backed skills describe operations, not setup.
+
+## Description
+
+- Include user phrases likely to appear in requests.
+- Include negative trigger language for adjacent workflows.
+- Mention the target domain, not implementation internals.
+
+## Never in skill prose
+
+- Package-manager installs, binary downloads, or bootstrap scripts.
+- API tokens, OAuth client secrets, user-specific credentials, or credential-file setup.
+- MCP endpoint configuration or server installation.
+- Provider config key declarations.
+- Instructions to repair sandbox package installation from within a normal user workflow.
+- Harness-internal tool dispatcher names or active-tool catalog tags.
+
+## Review checklist
+
+- Directory name equals frontmatter `name`.
+- Description triggers only the intended Junior extension work.
+- Body is compact.
+- Runtime authority belongs to a parent plugin when needed.
+- All linked bundled files exist.
+- The body has instructions after frontmatter.

--- a/packages/junior/skills/junior/references/validation-and-troubleshooting.md
+++ b/packages/junior/skills/junior/references/validation-and-troubleshooting.md
@@ -1,0 +1,64 @@
+# Validation And Troubleshooting
+
+## Validation commands
+
+| Context                                     | Command                                        | Passing state                                                           |
+| ------------------------------------------- | ---------------------------------------------- | ----------------------------------------------------------------------- |
+| Consumer app                                | `pnpm exec junior check`                       | Prints `Validation passed` or only expected warnings.                   |
+| Consumer app from another directory         | `pnpm exec junior check path/to/app`           | Same as above.                                                          |
+| This repo core skill files                  | `pnpm skills:check`                            | Reports skill validation passed.                                        |
+| Packaged plugin manifest                    | configured app startup or targeted parser test | The package `plugin.yaml` is parsed without errors.                     |
+| Runtime code changed                        | `pnpm typecheck` and targeted tests            | Typecheck and tests pass.                                               |
+| Docs changed                                | `pnpm docs:check`                              | Docs checker passes.                                                    |
+| Release package lists changed               | `pnpm release:check`                           | Release config is aligned.                                              |
+| Runtime dependencies or postinstall changed | `junior snapshot create`                       | Snapshot inputs match expected plugin dependencies and warmup succeeds. |
+
+## App validation scope
+
+`junior check` validates:
+
+- `app/plugins/<plugin>/plugin.yaml`
+- `app/plugins/<plugin>/skills/<skill>/SKILL.md`
+- `app/skills/<skill>/SKILL.md`
+- app marker files when the target looks like a Junior app
+
+It does not validate:
+
+- legacy top-level app `skills/` or `plugins/`
+- installed package root `plugin.yaml`
+
+For packaged plugins, load a configured host app or add a parser test.
+
+## Common failures
+
+| Symptom                                                                                   | Likely cause                                                                                   | Fix                                                                |
+| ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `name must match directory`                                                               | Frontmatter `name` differs from folder name.                                                   | Rename the folder or the skill `name`.                             |
+| `duplicate skill name`                                                                    | App and plugin skill roots contain the same skill name.                                        | Rename one skill and adjust trigger language.                      |
+| `requires-capabilities is no longer supported`                                            | Old skill-level auth metadata.                                                                 | Move capabilities to `plugin.yaml`.                                |
+| `uses-config is no longer supported`                                                      | Old skill-level config metadata.                                                               | Move config keys to `plugin.yaml`.                                 |
+| `skill instructions must not hardcode harness tool-discovery or MCP dispatcher mechanics` | Skill prose names internal dispatcher APIs or active catalog tags.                             | Describe provider actions in domain terms instead.                 |
+| `api-headers requires api-domains`                                                        | Manifest declares headers without target domains.                                              | Add valid `api-domains` or remove `api-headers`.                   |
+| `api-domains requires api-headers`                                                        | Manifest declares top-level domains without headers.                                           | Add headers or remove top-level domains.                           |
+| `oauth requires credentials`                                                              | OAuth block has no credential delivery config.                                                 | Add `credentials.type: oauth-bearer`.                              |
+| `oauth requires credentials.type "oauth-bearer"`                                          | OAuth was paired with unsupported credentials.                                                 | Use bearer OAuth credentials or remove `oauth`.                    |
+| `mcp.url references env var ... not declared`                                             | Placeholder is not listed in `env-vars`.                                                       | Declare the env var and optional default where allowed.            |
+| `API header env vars must not declare defaults`                                           | Secret-like header env var has a default.                                                      | Remove the default and set the value in deployment env.            |
+| `target.config-key ... must be listed in config-keys`                                     | Target points at undeclared config.                                                            | Add the short config key to `config-keys`.                         |
+| Plugin does not load in app                                                               | Package installed but not listed in plugin packages, or local files are outside `app/plugins`. | Add package to `pluginPackages` or move files under `app/plugins`. |
+| Skill does not show up                                                                    | Skill is in a legacy root, has invalid frontmatter, or duplicates another skill name.          | Move under `app/skills` or plugin `skills`, then rerun validation. |
+
+## Runtime verification
+
+1. Ask Junior for one realistic workflow that should trigger the new skill.
+2. For credentialed plugins, verify the auth prompt is private and the resumed turn succeeds.
+3. For MCP plugins, verify the relevant provider tools are available only after the plugin skill is loaded.
+4. For runtime dependencies, confirm snapshot warmup includes the expected package and postinstall counts.
+5. For Slack deployments, verify both a direct message and a channel path when the workflow is Slack-facing.
+
+## Failure handling
+
+- If a validator fails, read the exact first error and fix the root cause before retrying.
+- If a runtime workflow fails after validation, separate manifest setup failures from skill behavior failures.
+- If a provider returns permission or scope errors, report the concrete provider message. Do not guess missing scopes.
+- If credentials are missing or stale, let Junior handle reconnect.


### PR DESCRIPTION
Add a core `junior` skill for creating and reviewing Junior extension skills and plugins. The skill keeps the runtime router compact while moving placement, manifest authority, packaging, validation, and examples into focused references.

**Extension Guidance**

The references make the skill/plugin authority boundary explicit: `SKILL.md` describes behavior, while `plugin.yaml` owns credentials, OAuth, MCP, runtime dependencies, config keys, and setup.