### PR TITLE
chore: bump @sentry/node to 10.50.0-alpha.0

### DIFF
--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -17,7 +17,7 @@
     "@sentry/junior-linear": "workspace:*",
     "@sentry/junior-notion": "workspace:*",
     "@sentry/junior-sentry": "workspace:*",
-    "@sentry/node": "^10.51.0",
+    "@sentry/node": "10.50.0-alpha.0",
     "hono": "^4.12.6"
   },
   "devDependencies": {

--- a/packages/junior/package.json
+++ b/packages/junior/package.json
@@ -59,7 +59,7 @@
     "@sentry/node": ">=10.0.0"
   },
   "devDependencies": {
-    "@sentry/node": "^10.51.0",
+    "@sentry/node": "10.50.0-alpha.0",
     "@types/node": "^25.6.0",
     "dependency-cruiser": "^17.4.0",
     "msw": "^2.14.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
     dependencies:
       "@sentry/junior":
         specifier: workspace:*
-        version: file:packages/junior(@aws-sdk/credential-provider-web-identity@3.972.33)(@opentelemetry/api@1.9.1)(@sentry/node@10.51.0)
+        version: file:packages/junior(@aws-sdk/credential-provider-web-identity@3.972.33)(@opentelemetry/api@1.9.1)(@sentry/node@10.50.0-alpha.0)
       "@sentry/junior-agent-browser":
         specifier: workspace:*
         version: link:../../packages/junior-agent-browser
@@ -51,8 +51,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/junior-sentry
       "@sentry/node":
-        specifier: ^10.51.0
-        version: 10.51.0
+        specifier: 10.50.0-alpha.0
+        version: 10.50.0-alpha.0
       hono:
         specifier: ^4.12.6
         version: 4.12.17
@@ -164,8 +164,8 @@ importers:
         version: 4.4.3
     devDependencies:
       "@sentry/node":
-        specifier: ^10.51.0
-        version: 10.51.0
+        specifier: 10.50.0-alpha.0
+        version: 10.50.0-alpha.0
       "@types/node":
         specifier: ^25.6.0
         version: 25.6.0
@@ -2305,6 +2305,15 @@ packages:
     peerDependencies:
       "@opentelemetry/api": ^1.3.0
 
+  "@opentelemetry/instrumentation-undici@0.24.0":
+    resolution:
+      {
+        integrity: sha512-oKzZ3uvqP17sV0EsoQcJgjEfIp0kiZRbYu/eD8p13Cbahumf8lb/xpYeNr/hfAJ4owzEtIDcGIjprfLcYbIKBQ==,
+      }
+    engines: { node: ^18.19.0 || >=20.6.0 }
+    peerDependencies:
+      "@opentelemetry/api": ^1.7.0
+
   "@opentelemetry/instrumentation@0.207.0":
     resolution:
       {
@@ -3594,6 +3603,13 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  "@sentry/core@10.50.0-alpha.0":
+    resolution:
+      {
+        integrity: sha512-ZB+MIIgFVWVYjCqvsAaGN0i69qEuplzIOCsuk9oV8IgcF6uDxVrcshOTK8nGafypDdWbk60pRj2HrhHsGBsuvw==,
+      }
+    engines: { node: ">=18" }
+
   "@sentry/core@10.51.0":
     resolution:
       {
@@ -3606,6 +3622,33 @@ packages:
     hasBin: true
     peerDependencies:
       "@sentry/node": ">=10.0.0"
+
+  "@sentry/node-core@10.50.0-alpha.0":
+    resolution:
+      {
+        integrity: sha512-KMyClwcvnC4FwwWoykWCDBq+lOo2u3w3EXYlOS/kKmyVgoZhO6+iz2OIrYWDzj6iTtMnJHJqY4rRGT6Lky/5gQ==,
+      }
+    engines: { node: ">=18" }
+    peerDependencies:
+      "@opentelemetry/api": ^1.9.0
+      "@opentelemetry/core": ^1.30.1 || ^2.1.0
+      "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1"
+      "@opentelemetry/instrumentation": ">=0.57.1 <1"
+      "@opentelemetry/sdk-trace-base": ^1.30.1 || ^2.1.0
+      "@opentelemetry/semantic-conventions": ^1.39.0
+    peerDependenciesMeta:
+      "@opentelemetry/api":
+        optional: true
+      "@opentelemetry/core":
+        optional: true
+      "@opentelemetry/exporter-trace-otlp-http":
+        optional: true
+      "@opentelemetry/instrumentation":
+        optional: true
+      "@opentelemetry/sdk-trace-base":
+        optional: true
+      "@opentelemetry/semantic-conventions":
+        optional: true
 
   "@sentry/node-core@10.51.0":
     resolution:
@@ -3634,12 +3677,31 @@ packages:
       "@opentelemetry/semantic-conventions":
         optional: true
 
+  "@sentry/node@10.50.0-alpha.0":
+    resolution:
+      {
+        integrity: sha512-H9hUDbuPe3uMyOk6nIvkWUGyHhQUXg7Sw4bE7xWZHQsEiGVXWxynfx5tt2m47GcGaJ/8/u7TzK1EMysGiMZCjw==,
+      }
+    engines: { node: ">=18" }
+
   "@sentry/node@10.51.0":
     resolution:
       {
         integrity: sha512-2yZLRZwS1dKG8/4eOTpGSo/gO/EgmT9aPj6lAzUkRa7bZCTTdW4BraaHU0leX5T94909Qfhbr3W5AVTfDOCKiQ==,
       }
     engines: { node: ">=18" }
+
+  "@sentry/opentelemetry@10.50.0-alpha.0":
+    resolution:
+      {
+        integrity: sha512-fNHI9VDhYdHfAtN49j+m4yI8RFh7AcUWmNtAO/Y6FfS0Up4MVPtzbFlSme8V09EDabKuGFWIvX6846iMc0Ftgg==,
+      }
+    engines: { node: ">=18" }
+    peerDependencies:
+      "@opentelemetry/api": ^1.9.0
+      "@opentelemetry/core": ^1.30.1 || ^2.1.0
+      "@opentelemetry/sdk-trace-base": ^1.30.1 || ^2.1.0
+      "@opentelemetry/semantic-conventions": ^1.39.0
 
   "@sentry/opentelemetry@10.51.0":
     resolution:
@@ -12764,6 +12826,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  "@opentelemetry/instrumentation-undici@0.24.0(@opentelemetry/api@1.9.1)":
+    dependencies:
+      "@opentelemetry/api": 1.9.1
+      "@opentelemetry/core": 2.7.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/semantic-conventions": 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
   "@opentelemetry/instrumentation@0.207.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
@@ -13252,7 +13323,46 @@ snapshots:
   "@rollup/rollup-win32-x64-msvc@4.60.1":
     optional: true
 
+  "@sentry/core@10.50.0-alpha.0": {}
+
   "@sentry/core@10.51.0": {}
+
+  "@sentry/junior@file:packages/junior(@aws-sdk/credential-provider-web-identity@3.972.33)(@opentelemetry/api@1.9.1)(@sentry/node@10.50.0-alpha.0)":
+    dependencies:
+      "@ai-sdk/gateway": 3.0.110(zod@4.4.3)
+      "@chat-adapter/slack": 4.27.0
+      "@chat-adapter/state-memory": 4.27.0
+      "@chat-adapter/state-redis": 4.27.0(@opentelemetry/api@1.9.1)
+      "@logtape/logtape": 2.0.7
+      "@mariozechner/pi-agent-core": 0.73.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)
+      "@mariozechner/pi-ai": 0.73.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)
+      "@modelcontextprotocol/sdk": 1.29.0(zod@4.4.3)
+      "@sentry/node": 10.50.0-alpha.0
+      "@sinclair/typebox": 0.34.49
+      "@slack/web-api": 7.15.2
+      "@vercel/functions": 3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33)
+      "@vercel/sandbox": 1.10.0
+      ai: 6.0.175(zod@4.4.3)
+      bash-tool: 1.3.16(@vercel/sandbox@1.10.0)(ai@6.0.175(zod@4.4.3))(just-bash@2.14.2)
+      chat: 4.27.0
+      hono: 4.12.17
+      just-bash: 2.14.2
+      node-html-markdown: 2.0.0
+      yaml: 2.8.4
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - "@aws-sdk/credential-provider-web-identity"
+      - "@cfworker/json-schema"
+      - "@node-rs/xxhash"
+      - "@opentelemetry/api"
+      - aws-crt
+      - bare-abort-controller
+      - bufferutil
+      - debug
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
+      - ws
 
   "@sentry/junior@file:packages/junior(@aws-sdk/credential-provider-web-identity@3.972.33)(@opentelemetry/api@1.9.1)(@sentry/node@10.51.0)":
     dependencies:
@@ -13291,6 +13401,18 @@ snapshots:
       - utf-8-validate
       - ws
 
+  "@sentry/node-core@10.50.0-alpha.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)":
+    dependencies:
+      "@sentry/core": 10.50.0-alpha.0
+      "@sentry/opentelemetry": 10.50.0-alpha.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      import-in-the-middle: 3.0.1
+    optionalDependencies:
+      "@opentelemetry/api": 1.9.1
+      "@opentelemetry/core": 2.7.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/sdk-trace-base": 2.7.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/semantic-conventions": 1.40.0
+
   "@sentry/node-core@10.51.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)":
     dependencies:
       "@sentry/core": 10.51.0
@@ -13302,6 +13424,44 @@ snapshots:
       "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/sdk-trace-base": 2.7.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
+
+  "@sentry/node@10.50.0-alpha.0":
+    dependencies:
+      "@fastify/otel": 0.18.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/api": 1.9.1
+      "@opentelemetry/core": 2.7.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.214.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-amqplib": 0.61.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-connect": 0.57.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-dataloader": 0.31.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-fs": 0.33.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-generic-pool": 0.57.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-graphql": 0.62.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-hapi": 0.60.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-http": 0.214.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-ioredis": 0.62.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-kafkajs": 0.23.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-knex": 0.58.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-koa": 0.62.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-lru-memoizer": 0.58.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-mongodb": 0.67.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-mongoose": 0.60.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-mysql": 0.60.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-mysql2": 0.60.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-pg": 0.66.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-redis": 0.62.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-tedious": 0.33.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation-undici": 0.24.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/sdk-trace-base": 2.7.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/semantic-conventions": 1.40.0
+      "@prisma/instrumentation": 7.6.0(@opentelemetry/api@1.9.1)
+      "@sentry/core": 10.50.0-alpha.0
+      "@sentry/node-core": 10.50.0-alpha.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      "@sentry/opentelemetry": 10.50.0-alpha.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      import-in-the-middle: 3.0.1
+    transitivePeerDependencies:
+      - "@opentelemetry/exporter-trace-otlp-http"
+      - supports-color
 
   "@sentry/node@10.51.0":
     dependencies:
@@ -13339,6 +13499,14 @@ snapshots:
     transitivePeerDependencies:
       - "@opentelemetry/exporter-trace-otlp-http"
       - supports-color
+
+  "@sentry/opentelemetry@10.50.0-alpha.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)":
+    dependencies:
+      "@opentelemetry/api": 1.9.1
+      "@opentelemetry/core": 2.7.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/sdk-trace-base": 2.7.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/semantic-conventions": 1.40.0
+      "@sentry/core": 10.50.0-alpha.0
 
   "@sentry/opentelemetry@10.51.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)":
     dependencies:


### PR DESCRIPTION
Bumps `@sentry/node` from `^10.51.0` to `10.50.0-alpha.0` in `packages/junior` and `apps/example`
