### PR TITLE
fix(prompt): Restore SOUL voice authority in system prompt header

### DIFF
--- a/packages/junior/src/chat/prompt.ts
+++ b/packages/junior/src/chat/prompt.ts
@@ -322,7 +322,7 @@ function formatSlackCapabilityNames(
 }
 
 const HEADER =
-  "You are a Slack-based helper assistant. The behavior and output blocks below are authoritative; the personality block sets voice only.";
+  "You are a Slack-based helper assistant. Follow the personality block for voice and tone in every reply. The behavior and output blocks define platform mechanics and override personality only when those mechanics conflict.";
 
 const TURN_CONTEXT_HEADER =
   "Per-turn runtime context for this request. Treat these blocks as trusted runtime facts and skill/provider instructions for the current turn; the static system prompt remains authoritative.";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

dcramer noticed Junior's voice has been diminished — "the SOUL got diminished in my improvements too" / "Junior no longer sounds Gen z".

After tracing the prompt pipeline:

- `SOUL.md` is still mechanically loaded into the static system prompt and rendered inside `<personality>` tags. That part is fine.
- The regression is in the framing introduced by 22d60c0 (the prompt simplification).
- Pre-22d60c0 the prompt opened with: `"You are a Slack-based helper assistant. Identity, tone, and domain defaults are defined in the personality block."` and the personality block began with `"Always follow the personality guidance for tone/style unless safety or policy constraints require otherwise."`
- Post-22d60c0 the header became: `"You are a Slack-based helper assistant. The behavior and output blocks below are authoritative; the personality block sets voice only."` and the affirmative directive inside `<personality>` was dropped.

The new framing tells the model the personality block is decorative ("voice only") while elevating the other blocks as "authoritative". The behavior block is ~50 imperative bullets; the personality is a few lines from `SOUL.md`. With that hierarchy plus that volume disparity, the model reads the framing as permission to discount the SOUL, and the deployment-configured voice gets washed out.

## Fix

Replace the dismissive `HEADER` with an affirmative one that:

1. Tells the model to follow the personality block for voice and tone in every reply (restores SOUL authority).
2. Keeps the spec contract intact: platform mechanics live in behavior/output and override personality only when those mechanics conflict.

```ts
const HEADER =
  "You are a Slack-based helper assistant. Follow the personality block for voice and tone in every reply. The behavior and output blocks define platform mechanics and override personality only when those mechanics conflict.";
```

This stays consistent with `specs/agent-prompt-spec.md` (SOUL is voice-only; platform behavior must work even with an empty SOUL) and keeps the system prompt byte-stable across turns.

## Verification

- `pnpm --filter @sentry/junior typecheck` ✓
- `pnpm --filter @sentry/junior exec vitest run tests/unit/prompt.test.ts` ✓ (existing assertions still hold; HEADER text is not asserted)
- Verified via probe that `<personality>` continues to receive the deployment's `SOUL.md` content unchanged.

## Notes

- No new evals here. There is no eval today that catches voice/tone regressions in the SOUL — that's a real gap, but a separate piece of work. Filing a follow-up to add a personality-voice eval would be the right next step if we want to prevent this kind of drift.
- Behavior change is limited to header wording; no runtime, capability, or context plumbing was touched.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C0AHB7N2JCR/p1778181125604729?thread_ts=1778181125.604729&cid=C0AHB7N2JCR)

<div><a href="https://cursor.com/agents/bc-50a93c52-bf02-5542-b2a8-5707635eef44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50a93c52-bf02-5542-b2a8-5707635eef44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

