### PR TITLE
test(evals): Add coding file tool coverage

### DIFF
--- a/packages/junior-evals/evals/core/coding-file-tools.eval.ts
+++ b/packages/junior-evals/evals/core/coding-file-tools.eval.ts
@@ -1,0 +1,73 @@
+import { describeEval } from "vitest-evals";
+import { mention, rubric, slackEvals } from "../helpers";
+
+const codingFixtureOverrides = {
+  skill_dirs: ["evals/fixtures/coding-skills"],
+};
+
+describeEval("Coding File Tools", slackEvals, (it) => {
+  it("when making a targeted source edit, use precise edit tooling and report the changed path", async ({
+    run,
+  }) => {
+    await run({
+      overrides: codingFixtureOverrides,
+      events: [
+        mention(
+          "In the eval coding fixture, change the default retry count from 2 to 3. Keep the reply brief and tell me which file changed.",
+        ),
+      ],
+      taskTimeout: 120_000,
+      criteria: rubric({
+        contract:
+          "A small source edit in the sandbox fixture uses precise file editing instead of full-file rewrites or shell mutation.",
+        pass: [
+          "observed_tool_invocations includes `editFile`.",
+          "observed_tool_invocations includes at least one inspection tool before or alongside the edit, such as `readFile`, `grep`, `findFiles`, or `listDir`.",
+          "observed_tool_invocations does not include `writeFile`.",
+          "A first-class `grep` tool invocation is acceptable; the forbidden case is an invocation with `tool` set to `bash` and `bash_command` containing discovery or edit commands such as `ls`, `find`, `grep`, `cat`, `sed`, `perl`, `python`, `tee`, or shell redirection.",
+          "assistant_posts contains exactly one final reply.",
+          "The reply names the edited config file; acceptable paths include `src/config.ts`, `project/src/config.ts`, or `skills/coding-workspace-fixture/project/src/config.ts`.",
+          "The reply says the default retry count is now 3.",
+        ],
+        fail: [
+          "Do not claim the file was changed without an observed `editFile` invocation.",
+          "Do not use `writeFile` for this targeted edit.",
+          "Do not answer with only a plan or promise to edit later.",
+        ],
+      }),
+    });
+  });
+
+  it("when locating fixture behavior, use structured discovery and leave files unchanged", async ({
+    run,
+  }) => {
+    await run({
+      overrides: codingFixtureOverrides,
+      events: [
+        mention(
+          "In the eval coding fixture, find where emergency mode is handled or documented. Summarize the relevant file paths and what each one says. Do not change any files.",
+        ),
+      ],
+      taskTimeout: 120_000,
+      criteria: rubric({
+        contract:
+          "A sandbox fixture discovery task uses structured file discovery/read tools and returns grounded file-path evidence without modifying files.",
+        pass: [
+          "observed_tool_invocations includes `grep` or `findFiles`.",
+          "observed_tool_invocations includes `readFile` or `listDir`.",
+          "observed_tool_invocations does not include `editFile` or `writeFile`.",
+          "A first-class `grep` tool invocation is acceptable; the forbidden case is an invocation with `tool` set to `bash` and `bash_command` containing discovery commands such as `ls`, `find`, `grep`, or `cat`.",
+          "assistant_posts contains exactly one final reply.",
+          "The reply mentions `project/src/alerts.ts` or `skills/coding-workspace-fixture/project/src/alerts.ts`.",
+          "The reply mentions `project/docs/operations.md` or `skills/coding-workspace-fixture/project/docs/operations.md`.",
+          "The reply accurately summarizes that source code handles emergency alerts while the operations doc describes escalation or operator behavior.",
+        ],
+        fail: [
+          "Do not modify files for this read-only request.",
+          "Do not answer from memory without observed file discovery or reads.",
+          "Do not report unrelated files as the only evidence.",
+        ],
+      }),
+    });
+  });
+});

--- a/packages/junior-evals/evals/fixtures/coding-skills/coding-workspace-fixture/SKILL.md
+++ b/packages/junior-evals/evals/fixtures/coding-skills/coding-workspace-fixture/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: coding-workspace-fixture
+description: Use for eval coding fixture tasks involving the small TypeScript project under skills/coding-workspace-fixture/project.
+---
+
+# Coding Workspace Fixture
+
+The fixture project lives at `skills/coding-workspace-fixture/project`.
+Inspect relevant files before changing them, make only the requested change,
+and answer with the file paths and result.

--- a/packages/junior-evals/evals/fixtures/coding-skills/coding-workspace-fixture/project/docs/operations.md
+++ b/packages/junior-evals/evals/fixtures/coding-skills/coding-workspace-fixture/project/docs/operations.md
@@ -1,0 +1,6 @@
+# Operations
+
+Emergency mode is reserved for incidents that need immediate operator action.
+When emergency mode is active, alerts should be routed to the critical
+operations channel and the incident owner should acknowledge the page before
+routine retry processing continues.

--- a/packages/junior-evals/evals/fixtures/coding-skills/coding-workspace-fixture/project/src/alerts.ts
+++ b/packages/junior-evals/evals/fixtures/coding-skills/coding-workspace-fixture/project/src/alerts.ts
@@ -1,0 +1,14 @@
+type AlertMode = "normal" | "emergency";
+
+export function alertChannelFor(mode: AlertMode): string {
+  if (mode === "emergency") {
+    return "#ops-critical";
+  }
+
+  return "#ops-notices";
+}
+
+export function formatAlert(mode: AlertMode, message: string): string {
+  const prefix = mode === "emergency" ? "[EMERGENCY]" : "[notice]";
+  return `${prefix} ${message}`;
+}

--- a/packages/junior-evals/evals/fixtures/coding-skills/coding-workspace-fixture/project/src/config.ts
+++ b/packages/junior-evals/evals/fixtures/coding-skills/coding-workspace-fixture/project/src/config.ts
@@ -1,0 +1,11 @@
+export const runtimeConfig = {
+  defaultRetryCount: 2,
+  emergencyMode: false,
+  serviceName: "fixture-worker",
+};
+
+export function retryWindowMs(
+  retryCount = runtimeConfig.defaultRetryCount,
+): number {
+  return retryCount * 250;
+}


### PR DESCRIPTION
Add eval coverage for Junior's sandbox file-tool behavior on coding tasks. The new coding fixture gives the model a small TypeScript project so evals can assert that targeted edits use precise edit tooling and read-only discovery uses structured file tools instead of shell discovery or full-file rewrites.

**Coding Fixture**

The fixture lives in its own eval skill root so existing skill-infra evals do not see an extra unrelated skill when they load the shared fixture directory.

Refs GH-312