### PR TITLE
ref(slack): Share final reply delivery

### DIFF
--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -11,8 +11,8 @@ import {
   withSpan,
 } from "@/chat/logging";
 import {
+  deliverSlackApiFinalReply,
   planSlackReplyPosts,
-  postSlackApiReplyPosts,
   type PlannedSlackReplyStage,
 } from "@/chat/slack/reply";
 import { buildSlackOutputMessage } from "@/chat/slack/output";
@@ -49,7 +49,6 @@ import {
   isVisionEnabled,
 } from "@/chat/services/vision-context";
 import { createSlackAdapterAssistantStatusSession } from "@/chat/slack/assistant-thread/status";
-import { buildSlackReplyFooter } from "@/chat/slack/footer";
 import { maybeUpdateAssistantTitle } from "@/chat/slack/assistant-thread/title";
 import { type ThreadArtifactsState } from "@/chat/state/artifacts";
 import { lookupSlackUser } from "@/chat/slack/user";
@@ -390,89 +389,74 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           const reactionPerformed = reply.diagnostics.toolCalls.includes(
             "slackMessageAddReaction",
           );
-          const plannedPosts = planSlackReplyPosts({ reply });
-          const replyFooter = buildSlackReplyFooter({
-            conversationId,
-            durationMs: reply.diagnostics.durationMs,
-            thinkingLevel: reply.diagnostics.thinkingLevel,
-            usage: reply.diagnostics.usage,
-          });
-          const shouldUseSlackFooter =
-            Boolean(replyFooter) &&
-            Boolean(channelId && threadTs) &&
-            (thread.adapter as { name?: string } | undefined)?.name === "slack";
-
           // Final Slack delivery is part of turn success. We only mark the turn
           // completed after the visible reply has been accepted by Slack.
-          if (plannedPosts.length > 0) {
-            let sent: SentMessage | undefined;
-            if (shouldUseSlackFooter) {
-              const slackChannelId = channelId;
-              const slackThreadTs = threadTs;
-              if (!slackChannelId || !slackThreadTs) {
-                throw new Error(
-                  "Slack footer delivery requires a concrete channel and thread timestamp",
-                );
-              }
-
-              const sentMessageTs = await postSlackApiReplyPosts({
-                beforePost: beforeFirstResponsePost,
-                channelId: slackChannelId,
-                threadTs: slackThreadTs,
-                posts: plannedPosts,
-                fileUploadFailureMode: "strict",
-                footer: replyFooter,
-                onPostError: ({ error, messageTs, stage }) => {
-                  logException(
-                    error,
-                    "slack_thread_post_failed",
-                    turnTraceContext,
-                    {
-                      "app.slack.reply_stage": stage,
-                      ...(messageTs
-                        ? { "messaging.message.id": messageTs }
-                        : {}),
-                      ...getSlackErrorObservabilityAttributes(error),
-                    },
-                    "Failed to post Slack thread reply",
-                  );
-                },
-              });
-
-              if (sentMessageTs) {
-                sent = {
-                  id: sentMessageTs,
-                  text: reply.text,
-                  delete: async () => {
-                    await deleteSlackMessage({
-                      channelId: slackChannelId,
-                      timestamp: sentMessageTs,
-                    });
+          let sent: SentMessage | undefined;
+          let plannedPosts: ReturnType<typeof planSlackReplyPosts>;
+          if (
+            channelId &&
+            threadTs &&
+            (thread.adapter as { name?: string } | undefined)?.name === "slack"
+          ) {
+            const delivery = await deliverSlackApiFinalReply({
+              beforePost: beforeFirstResponsePost,
+              channelId,
+              threadTs,
+              reply,
+              conversationId,
+              fileUploadFailureMode: "strict",
+              onPostError: ({ error, messageTs, stage }) => {
+                logException(
+                  error,
+                  "slack_thread_post_failed",
+                  turnTraceContext,
+                  {
+                    "app.slack.reply_stage": stage,
+                    ...(messageTs ? { "messaging.message.id": messageTs } : {}),
+                    ...getSlackErrorObservabilityAttributes(error),
                   },
-                } as SentMessage;
-              }
-            } else {
-              for (const post of plannedPosts) {
-                sent = await postThreadReply(
-                  buildSlackOutputMessage(post.text, post.files),
-                  post.stage,
+                  "Failed to post Slack thread reply",
                 );
-              }
+              },
+            });
+            plannedPosts = delivery.posts;
+
+            const sentMessageTs = delivery.sentMessageTs;
+            if (sentMessageTs) {
+              sent = {
+                id: sentMessageTs,
+                text: reply.text,
+                delete: async () => {
+                  await deleteSlackMessage({
+                    channelId,
+                    timestamp: sentMessageTs,
+                  });
+                },
+              } as SentMessage;
             }
-            const firstPlannedMessageHasFiles =
-              (plannedPosts[0]?.files?.length ?? 0) > 0;
-            // When a reaction already acknowledged the turn, delete the
-            // redundant thread reply. The post itself completes Slack's
-            // assistant response cycle (clearing the typing indicator).
-            if (
-              sent &&
-              reactionPerformed &&
-              plannedPosts.length === 1 &&
-              !firstPlannedMessageHasFiles &&
-              isRedundantReactionAckText(reply.text)
-            ) {
-              await sent.delete();
+          } else {
+            plannedPosts = planSlackReplyPosts({ reply });
+            for (const post of plannedPosts) {
+              sent = await postThreadReply(
+                buildSlackOutputMessage(post.text, post.files),
+                post.stage,
+              );
             }
+          }
+
+          const firstPlannedMessageHasFiles =
+            (plannedPosts[0]?.files?.length ?? 0) > 0;
+          // When a reaction already acknowledged the turn, delete the
+          // redundant thread reply. The post itself completes Slack's
+          // assistant response cycle (clearing the typing indicator).
+          if (
+            sent &&
+            reactionPerformed &&
+            plannedPosts.length === 1 &&
+            !firstPlannedMessageHasFiles &&
+            isRedundantReactionAckText(reply.text)
+          ) {
+            await sent.delete();
           }
 
           const titleUpdateResult = await assistantTitleTask;

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -20,11 +20,7 @@ import {
   createSlackWebApiAssistantStatusSession,
   type AssistantStatusSession,
 } from "@/chat/slack/assistant-thread/status";
-import { buildSlackReplyFooter } from "@/chat/slack/footer";
-import {
-  planSlackReplyPosts,
-  postSlackApiReplyPosts,
-} from "@/chat/slack/reply";
+import { deliverSlackApiFinalReply } from "@/chat/slack/reply";
 import { postSlackMessage as postSlackApiMessage } from "@/chat/slack/outbound";
 import { getStateAdapter } from "@/chat/state/adapter";
 
@@ -297,18 +293,12 @@ export async function resumeSlackTurn(args: ResumeSlackTurnArgs) {
     });
 
     await status.stop();
-    const footer = buildSlackReplyFooter({
-      conversationId: args.replyContext?.correlation?.conversationId ?? lockKey,
-      durationMs: reply.diagnostics.durationMs,
-      thinkingLevel: reply.diagnostics.thinkingLevel,
-      usage: reply.diagnostics.usage,
-    });
-    await postSlackApiReplyPosts({
+    await deliverSlackApiFinalReply({
       channelId: args.channelId,
       threadTs: args.threadTs,
-      posts: planSlackReplyPosts({ reply }),
+      reply,
+      conversationId: args.replyContext?.correlation?.conversationId ?? lockKey,
       fileUploadFailureMode: "best_effort",
-      footer,
     });
     await args.onSuccess?.(reply);
   } catch (error) {

--- a/packages/junior/src/chat/slack/reply.ts
+++ b/packages/junior/src/chat/slack/reply.ts
@@ -4,6 +4,7 @@ import type { AssistantReply } from "@/chat/respond";
 import type { ReplyFileDelivery } from "@/chat/services/reply-delivery-plan";
 import {
   buildSlackReplyBlocks,
+  buildSlackReplyFooter,
   type SlackReplyFooter,
 } from "@/chat/slack/footer";
 import { postSlackMessage, uploadFilesToThread } from "@/chat/slack/outbound";
@@ -178,15 +179,12 @@ export function planSlackReplyPosts(args: {
   return posts;
 }
 
-/**
- * Deliver planned Slack reply posts over raw Slack Web API calls for resume and
- * callback handlers that do not have a Chat SDK thread object.
- */
-export async function postSlackApiReplyPosts(args: {
+/** Send already planned reply posts through the shared Slack outbound boundary. */
+async function postSlackApiReplyPosts(args: {
   beforePost?: () => Promise<void>;
   footer?: SlackReplyFooter;
   channelId: string;
-  fileUploadFailureMode?: "best_effort" | "strict";
+  fileUploadFailureMode: "best_effort" | "strict";
   onPostError?: (context: {
     error: unknown;
     messageTs?: string;
@@ -226,7 +224,7 @@ export async function postSlackApiReplyPosts(args: {
 
       await uploadReplyFiles({
         channelId: args.channelId,
-        failureMode: args.fileUploadFailureMode ?? "best_effort",
+        failureMode: args.fileUploadFailureMode,
         threadTs: args.threadTs,
         files: post.files,
       });
@@ -241,4 +239,44 @@ export async function postSlackApiReplyPosts(args: {
   }
 
   return lastPostedMessageTs;
+}
+
+/** Keep live and resumed turns on the same finalized Slack delivery path. */
+export async function deliverSlackApiFinalReply(args: {
+  beforePost?: () => Promise<void>;
+  channelId: string;
+  conversationId?: string;
+  fileUploadFailureMode: "best_effort" | "strict";
+  onPostError?: (context: {
+    error: unknown;
+    messageTs?: string;
+    stage: PlannedSlackReplyStage;
+  }) => Promise<void> | void;
+  reply: AssistantReply;
+  threadTs: string;
+}): Promise<{
+  posts: PlannedSlackReplyPost[];
+  sentMessageTs?: string;
+}> {
+  const posts = planSlackReplyPosts({ reply: args.reply });
+  const footer = buildSlackReplyFooter({
+    conversationId: args.conversationId,
+    durationMs: args.reply.diagnostics.durationMs,
+    thinkingLevel: args.reply.diagnostics.thinkingLevel,
+    usage: args.reply.diagnostics.usage,
+  });
+  const sentMessageTs = await postSlackApiReplyPosts({
+    beforePost: args.beforePost,
+    channelId: args.channelId,
+    threadTs: args.threadTs,
+    posts,
+    fileUploadFailureMode: args.fileUploadFailureMode,
+    footer,
+    onPostError: args.onPostError,
+  });
+
+  return {
+    posts,
+    ...(sentMessageTs ? { sentMessageTs } : {}),
+  };
 }


### PR DESCRIPTION
Routes live Slack Web API replies and resumed Slack turns through the same finalized reply delivery helper. This keeps reply planning, footer construction, file-delivery mode, and Slack posting semantics together without moving persistence, locking, status, or reaction cleanup out of their existing runtime owners.

**Final Reply Delivery**

`deliverSlackApiFinalReply` now owns the shared Web API reply path in `chat/slack/reply.ts`. The lower-level planned-post sender is private so callers use the finalized-reply contract instead of assembling footer and post arguments themselves.

**Runtime Boundaries**

Live turns still own completion state and reaction-only cleanup. Resume turns still own lock handling and auth/timeout pause callbacks. The shared helper only covers the duplicated Slack-visible final delivery path.