### PR TITLE
feat(telemetry): Add production query map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,8 @@ Co-Authored-By: (agent model name) <email>
 
 ## Known Specs
 
+- `TELEMETRY.md` (root telemetry diagnostic map: query surfaces, pivots, and recipes)
+- `TELEMETRY.spec.md` (format contract for repository-root telemetry maps)
 - `specs/index.md` (spec taxonomy, naming rules, and canonical vs archive guidance)
 - `specs/security-policy.md` (global runtime/container/token security policy)
 - `specs/chat-architecture-spec.md` (chat composition, service, and test-seam architecture contract)

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,215 @@
+---
+spec: ./TELEMETRY.spec.md
+---
+
+# Telemetry
+
+## Goal
+
+Use this when investigating Junior production incidents. Start with a Slack
+thread/message, Sentry event, trace ID, event name, or model/tool symptom, then
+use the query recipes below to find the failing turn and next query.
+
+## Where To Query
+
+- Slack thread/footer: query Sentry Logs and Spans by
+  `gen_ai.conversation.id` or `messaging.message.conversation_id`, then run the
+  conversation recipes.
+- Sentry `event_id`: open the Sentry event, copy `trace_id`, then query the
+  trace and matching logs.
+- `trace_id` / `span_id`: open Sentry Traces/Spans first; use logs only to
+  inspect event names and exception fields around that trace.
+- Stable `event.name`: query Sentry Logs, then use the matching domain below for
+  the next pivot.
+- Tool/model symptom: query spans/logs by `gen_ai.tool.name`,
+  `gen_ai.request.model`, or `gen_ai.operation.name`.
+
+## Investigation Pivots
+
+| Pivot                               | Meaning                       | Found In                  | First Query           |
+| ----------------------------------- | ----------------------------- | ------------------------- | --------------------- |
+| `event_id`                          | captured Sentry error         | failed Slack reply        | open event            |
+| `gen_ai.conversation.id`            | Slack thread/run conversation | Slack footer, logs, spans | query trace/logs      |
+| `trace_id`                          | end-to-end trace              | errors, logs, spans       | open trace            |
+| `span_id`                           | one span in a trace           | logs, spans               | inspect span          |
+| `messaging.message.conversation_id` | Slack thread                  | logs, spans               | thread logs           |
+| `messaging.message.id`              | Slack message timestamp       | logs, spans               | message logs          |
+| `messaging.destination.name`        | Slack channel                 | logs, spans               | channel-scoped search |
+| `gen_ai.tool.name`                  | tool name                     | tool spans/logs           | tool failures         |
+| `app.credential.provider`           | auth provider                 | auth logs                 | auth/resume search    |
+
+## Query Recipes
+
+Conversation timeline from a Slack thread, footer link, or conversation ID.
+
+```text
+dataset=spans query='gen_ai.conversation.id:"<conversation_id>"'
+fields=timestamp,trace,span.op,span.description,span.duration,error.type
+sort=-timestamp
+```
+
+Conversation log history from the same pivot.
+
+```text
+dataset=logs query='gen_ai.conversation.id:"<conversation_id>"'
+fields=timestamp,level,event.name,trace_id,span_id,error.type,exception.message
+sort=timestamp
+```
+
+Trace log history after opening a Sentry event or trace.
+
+```text
+dataset=logs query='trace_id:"<trace_id>"'
+fields=timestamp,level,event.name,span_id,gen_ai.conversation.id,error.type,exception.message
+sort=timestamp
+```
+
+Recent failed or timed-out turns.
+
+```text
+dataset=logs query='event.name:agent_turn_timeout OR event.name:agent_turn_failed OR event.name:agent_turn_provider_error'
+fields=timestamp,event.name,trace_id,span_id,gen_ai.conversation.id,gen_ai.request.model,error.type
+sort=-timestamp
+```
+
+Tool failures or slow tool calls.
+
+```text
+dataset=spans query='span.op:gen_ai.execute_tool gen_ai.tool.name:"<tool_name>"'
+fields=timestamp,trace,span.description,span.duration,gen_ai.conversation.id,error.type
+sort=-timestamp
+```
+
+Slack delivery failures after the agent turn ran.
+
+```text
+dataset=logs query='event.name:slack_thread_post_failed app.slack.error_code:*'
+fields=timestamp,event.name,gen_ai.conversation.id,messaging.destination.name,app.slack.reply_stage,app.slack.error_code,app.slack.api_error,exception.message
+sort=-timestamp
+```
+
+Auth, credential, and resume failures.
+
+```text
+dataset=logs query='app.credential.provider:"<provider>"'
+fields=timestamp,event.name,gen_ai.conversation.id,app.credential.provider,app.ai.retryable_reason,exception.message
+sort=-timestamp
+```
+
+## Domains
+
+### Webhook Ingress
+
+Slack or Vercel webhook delivery/routing failures.
+
+Events: `webhook_platform_unknown`, `webhook_non_success_response`,
+`webhook_handler_failed`, `slack_message_changed_side_channel_failed`
+
+Spans: `http.server.request`
+
+Attributes: `http.request.method`, `http.response.status_code`, `url.path`,
+`app.request.id`
+
+### Slack Delivery
+
+Slack accepted the request but no final reply appeared.
+
+Events: `agent_turn_started`, `agent_turn_completed`, `agent_turn_failed`,
+`slack_thread_post_failed`, `assistant_status_update_failed`,
+`slack_action_failed`, `slack_action_retrying`
+
+Spans: `chat.turn`, `chat.reply`, `chat.slash_command`,
+`chat.app_home_opened`, `chat.app_home_disconnect`
+
+Attributes: `trace_id`, `span_id`, `gen_ai.conversation.id`,
+`messaging.message.conversation_id`, `messaging.destination.name`,
+`app.slack.reply_stage`, `app.slack.error_code`, `app.slack.api_error`
+
+### Agent And Model
+
+The turn timed out, returned no useful answer, or used unexpected reasoning.
+
+Events: `agent_message_in`, `agent_message_out`, `agent_turn_timeout`,
+`agent_turn_provider_error`, `agent_turn_execution_failure`,
+`assistant_reply_generation_failed`
+
+Spans: `ai.generate_assistant_reply`, `ai.chat_completion`,
+`chat.route_thinking`, `ai.invoke_advisor`
+
+Attributes: `gen_ai.operation.name`, `gen_ai.request.model`,
+`gen_ai.response.finish_reasons`, `app.ai.outcome`,
+`app.ai.reasoning_effort`, `gen_ai.usage.input_tokens`,
+`gen_ai.usage.output_tokens`, `gen_ai.usage.cache_read.input_tokens`,
+`gen_ai.usage.cache_creation.input_tokens`
+
+### Tools, MCP, And Sandbox
+
+A tool failed, an MCP call failed, a command exited non-zero, or sandbox startup was slow.
+
+Events: `agent_tool_call_failed`, `mcp_tool_call_failed`,
+`mcp_tool_manager_close_failed`, `sandbox_boot_requested`,
+`sandbox_network_policy_restore_failed`
+
+Spans: `execute_tool <toolName>`, `sandbox.acquire`, `sandbox.create`,
+`sandbox.snapshot.resolve`, `sandbox.sync_skills`, `bash`
+
+Attributes: `gen_ai.tool.name`, `gen_ai.tool.call.id`, `mcp.method.name`,
+`process.executable.name`, `process.exit.code`, `app.sandbox.source`,
+`app.sandbox.snapshot.resolve_outcome`
+
+### Auth And Resume
+
+A turn parked for auth, resumed late, or failed after callback.
+
+Events: `credential_issue_failed`, `credential_issue_request`,
+`credential_issue_success`, `mention_handler_auth_pause`,
+`subscribed_message_handler_auth_pause`, `timeout_resume_handler_failed`,
+`timeout_resume_lock_busy`, `oauth_callback_resume_complete`,
+`mcp_oauth_callback_failed`
+
+Spans: resumed `chat.turn`, `chat.reply`
+
+Attributes: `app.credential.provider`, `app.credential.delivery`,
+`app.ai.retryable_reason`, `app.ai.session_id`,
+`app.ai.resume_checkpoint_version`
+
+### Skills And Plugins
+
+A skill/tool is missing, plugin discovery failed, or capability activation looks wrong.
+
+Events: `startup_discovery_summary`, `plugin_loaded`,
+`capability_catalog_loaded`, `skill_directory_read_failed`,
+`skill_frontmatter_invalid`, `plugin_root_read_failed`
+
+Spans: active turn spans carry plugin/skill attributes
+
+Attributes: `app.skill.name`, `app.skill.count`, `app.plugin.name`,
+`app.plugin.count`, `app.plugin.has_mcp`, `app.capability.names`,
+`file.directory`, `app.file.skill_directory`
+
+### Attachments And Web Search
+
+Screenshots, file attachments, image context, or web search failed.
+
+Events: `attachment_resolution_failed`, `attachment_skipped_size_limit`,
+`image_attachment_processing_failed`, `conversation_image_context_hydrated`,
+`conversation_image_vision_failed`, `web_search_failed`
+
+Spans: model/tool spans around vision or search calls
+
+Attributes: `app.message.attachment_count`,
+`app.message.prompt_attachment_count`, `app.conversation_image.analyzed`,
+`app.web_search.query`, `app.web_search.retryable`, `app.web_search.timeout`,
+`file.name`, `file.size`, `app.file.id`, `app.file.mime_type`
+
+## Configuration
+
+| Setting                     | Controls                 | Default                       |
+| --------------------------- | ------------------------ | ----------------------------- |
+| `SENTRY_DSN`                | Sentry ingestion         | disabled                      |
+| `SENTRY_ENVIRONMENT`        | Sentry environment       | `VERCEL_ENV` or `NODE_ENV`    |
+| `SENTRY_RELEASE`            | Sentry release           | `VERCEL_GIT_COMMIT_SHA`       |
+| `SENTRY_ENABLE_LOGS`        | structured logs          | true when `SENTRY_DSN` is set |
+| `SENTRY_TRACES_SAMPLE_RATE` | traces                   | `1`                           |
+| `SENTRY_ORG_SLUG`           | Slack footer trace links | unset                         |
+| `JUNIOR_LOG_FORMAT`         | console format           | compact unless `structured`   |

--- a/TELEMETRY.spec.md
+++ b/TELEMETRY.spec.md
@@ -1,0 +1,162 @@
+# Telemetry File Spec
+
+Status: draft
+Spec file: `TELEMETRY.spec.md`
+Target file: repository-root `TELEMETRY.md`
+
+## Purpose
+
+`TELEMETRY.md` is an agent-readable production query map.
+
+It must help an investigator move from:
+
+```text
+debugging scenario -> starting clue -> query surface -> correlation pivot -> query recipe
+```
+
+It is not a telemetry inventory, OTel audit, migration plan, backend tutorial,
+or observability design doc.
+
+## Success Criteria
+
+| Check            | Pass Condition                                                  |
+| ---------------- | --------------------------------------------------------------- |
+| Symptom-first    | A production failure maps to a query path in under a minute.    |
+| Backend-specific | Query surfaces name the actual backend and dataset.             |
+| Pivot-clear      | Trace/span IDs and product-to-telemetry joins are easy to find. |
+| Short            | An agent can scan it before querying telemetry.                 |
+| Not a backlog    | Migrations and cleanup work live elsewhere.                     |
+
+## Required Shape
+
+Start with YAML frontmatter:
+
+```yaml
+---
+spec: ./TELEMETRY.spec.md
+---
+```
+
+Use these sections, in this order:
+
+1. `Goal`
+2. `Where To Query`
+3. `Investigation Pivots`
+4. `Query Recipes`
+5. `Domains`
+6. `Configuration`
+
+Optional:
+
+- `Attribute Notes`: only for cross-cutting or ambiguous attributes.
+- `References`: only canonical standards/backend docs.
+
+## Section Rubric
+
+| Section                | Job                               | Include                                                   | Cut                                                               |
+| ---------------------- | --------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------- |
+| `Goal`                 | State when to use the file.       | Production scope, primary backend, likely starting clues. | Company mission, architecture overview, observability philosophy. |
+| `Where To Query`       | Pick the right telemetry surface. | Starting clue, backend/dataset, pivot, answer, next step. | Signal inventories, emitter lists, setup tutorials.               |
+| `Investigation Pivots` | Join user reports to telemetry.   | 5-10 IDs/tags that cross logs/errors/spans/UI.            | Every ID in the system.                                           |
+| `Query Recipes`        | Give first moves.                 | Copyable queries for top incidents.                       | Dashboards, screenshots, long query language lessons.             |
+| `Domains`              | Map symptoms to handles.          | Critical workflows, one-line descriptions, key handles.   | Exhaustive event lists.                                           |
+| `Configuration`        | Explain telemetry switches.       | Env vars/flags that affect emission or links.             | General app config.                                               |
+| `Attribute Notes`      | Disambiguate key fields.          | Sensitive, overloaded, local, or cross-domain fields.     | OTel migration backlog.                                           |
+| `References`           | Anchor standards.                 | Official OTel/backend docs.                               | Blog posts, general learning links.                               |
+
+## Format Rules
+
+- Use tables only when cells stay short.
+- Use label lists when values are long, especially event/span/attribute
+  handles.
+- Prefer query blocks over prose.
+- Prefer stable handles over exhaustive coverage.
+- Prefer `trace_id` and `span_id` for telemetry joins; use product IDs to get
+  there.
+- Put the spec reference in frontmatter; do not bury it in prose.
+- Bias toward production triage, not instrumentation design.
+- Use real backend names: `Sentry Logs`, `Datadog APM`, `Honeycomb`, etc.
+- Use OpenTelemetry semantic attributes when available.
+- Use `app.*` only for app-owned concepts.
+- Mark local fields as `app` or `local`; do not audit them.
+- Keep example values fake: `<conversation_id>`, `<trace_id>`, `<span_id>`.
+- Do not include raw request bodies, user content, auth headers, tokens, or real
+  IDs.
+
+## Query Surface Template
+
+| Starting Point        | Query Surface       | Pivot               | Answers              | Next Step         |
+| --------------------- | ------------------- | ------------------- | -------------------- | ----------------- |
+| `<thread or user ID>` | `<backend dataset>` | `<correlation key>` | workflow state       | run recipe        |
+| `<event_id>`          | `<backend event>`   | `trace_id`          | exception context    | open trace/logs   |
+| `<event.name>`        | `<backend logs>`    | `<event attribute>` | failure cohort       | inspect domain    |
+| `<trace_id>`          | `<backend traces>`  | `span_id`           | timeline and latency | inspect slow span |
+
+## Pivot Template
+
+| Pivot         | Meaning               | Found In                  | First Query       |
+| ------------- | --------------------- | ------------------------- | ----------------- |
+| `trace_id`    | one distributed trace | errors, logs, spans       | open trace        |
+| `span_id`     | one span in a trace   | logs, spans               | inspect span      |
+| `event_id`    | captured error event  | user-visible error, issue | open event        |
+| `<domain.id>` | product correlation   | product UI, logs, spans   | query logs/traces |
+
+## Query Template
+
+```text
+dataset=<dataset> query='<filter with <placeholder>>'
+fields=<timestamp>,<event/span>,<pivot>,<error>
+sort=<sort>
+```
+
+Every query recipe should answer one concrete production question:
+
+- Did ingress accept the request?
+- Did the user-visible workflow start?
+- Did it fail in model/tool/delivery/auth?
+- Which query should I run next?
+
+## Domain Template
+
+```md
+### <Domain>
+
+<One-line description of the symptom or workflow.>
+
+Events: `event_a`, `event_b`
+
+Spans: `span.name`, `span.op`
+
+Attributes: `pivot.id`, `app.reason`
+```
+
+Domain count guidance:
+
+| Repo Size         | Domain Count                      |
+| ----------------- | --------------------------------- |
+| small service     | 2-4                               |
+| product app       | 4-8                               |
+| platform/monorepo | 6-12, grouped by incident surface |
+
+Split a domain only when it changes the first query or telemetry surface.
+
+## Review Checklist
+
+Before accepting a `TELEMETRY.md`:
+
+- Can an agent start from a user-provided error ID, trace ID, thread URL, order
+  ID, job ID, or request ID?
+- Are the first queries copyable without reading implementation code?
+- Does each domain map to a failure symptom?
+- Are sensitive fields called out or excluded?
+- Is migration or cleanup work absent?
+- Is the file shorter than the docs it points to?
+
+## Example
+
+See `TELEMETRY.md` for this repository's concrete map.
+
+## References
+
+- OpenTelemetry semantic conventions
+- Backend docs for the configured log/error/trace store

--- a/packages/junior-evals/evals/helpers.ts
+++ b/packages/junior-evals/evals/helpers.ts
@@ -184,7 +184,7 @@ function assertGatewayReady(input: SlackEvalInput, result: EvalResult): void {
     if (record.eventName !== "ai_completion_failed") {
       return false;
     }
-    const errorMessage = String(record.attributes["error.message"] ?? "");
+    const errorMessage = String(record.attributes["exception.message"] ?? "");
     return GATEWAY_AUTH_FAILURE_PATTERNS.some((pattern) =>
       errorMessage.includes(pattern),
     );
@@ -194,7 +194,7 @@ function assertGatewayReady(input: SlackEvalInput, result: EvalResult): void {
   }
 
   const message =
-    String(failure.attributes["error.message"] ?? "").trim() ||
+    String(failure.attributes["exception.message"] ?? "").trim() ||
     failure.body ||
     "AI Gateway authentication failed";
   throw new Error(

--- a/packages/junior/src/chat/capabilities/runtime.ts
+++ b/packages/junior/src/chat/capabilities/runtime.ts
@@ -148,7 +148,7 @@ export class SkillCapabilityRuntime {
         {
           "app.skill.name": input.activeSkill?.name,
           "app.credential.provider": provider,
-          "error.message":
+          "exception.message":
             error instanceof Error ? error.message : String(error),
         },
         "Provider credential resolution failed",

--- a/packages/junior/src/chat/logging.ts
+++ b/packages/junior/src/chat/logging.ts
@@ -31,8 +31,6 @@ export interface EmittedLogRecord {
 
 export interface LogContext {
   conversationId?: string;
-  turnId?: string;
-  agentId?: string;
   platform?: string;
   requestId?: string;
   slackThreadId?: string;
@@ -71,14 +69,14 @@ const SECRETS_RE = [
 ];
 
 const LEGACY_KEY_MAP: Record<string, string> = {
-  error: "error.message",
+  error: "exception.message",
   "error.stack": "exception.stacktrace",
   "gen_ai.system": "gen_ai.provider.name",
   "gen_ai.request.messages": "gen_ai.input.messages",
   "gen_ai.response.text": "gen_ai.output.messages",
   "messaging.conversation.id": "messaging.message.conversation_id",
   bytes: "file.size",
-  media_type: "file.mime_type",
+  media_type: "app.file.mime_type",
   skillDir: "file.path",
   root: "file.directory",
   originalLength: "app.output.original_length",
@@ -106,14 +104,12 @@ const LOGTAPE_BODY_KEY = "__logtape_body";
 const ROOT_LOGGER_CATEGORY = ["junior"] as const;
 const CONSOLE_PRIORITY_KEYS = [
   "gen_ai.conversation.id",
-  "app.turn.id",
   "event.name",
   "app.log.source",
-  "error.message",
+  "exception.message",
   "messaging.message.id",
-  "app.trace_id",
-  "app.span_id",
-  "app.agent.id",
+  "trace_id",
+  "span_id",
   "messaging.message.conversation_id",
   "messaging.destination.name",
   "app.run.id",
@@ -126,7 +122,7 @@ const CONSOLE_ALWAYS_HIDDEN_KEYS = new Set([
   "gen_ai.agent.name",
   "app.platform",
   "enduser.id",
-  "enduser.pseudo_id",
+  "enduser.pseudo.id",
   "http.request.method",
   "messaging.system",
   "url.full",
@@ -377,8 +373,6 @@ function sanitizeValue(value: unknown): AttributeValue | undefined {
 function contextToAttributes(context: LogContext): LogAttributes {
   const attributes: Record<string, unknown> = {
     "gen_ai.conversation.id": context.conversationId,
-    "app.turn.id": context.turnId,
-    "app.agent.id": context.agentId,
     "app.platform": context.platform,
     "app.request.id": context.requestId,
     "messaging.system":
@@ -386,7 +380,7 @@ function contextToAttributes(context: LogContext): LogAttributes {
     "messaging.message.conversation_id": context.slackThreadId,
     "messaging.destination.name": context.slackChannelId,
     "enduser.id": context.slackUserId,
-    "enduser.pseudo_id": context.slackUserName,
+    "enduser.pseudo.id": context.slackUserName,
     "app.run.id": context.runId,
     "gen_ai.agent.name": context.assistantUserName,
     "gen_ai.request.model": context.modelId,
@@ -707,9 +701,6 @@ function shouldHideConsoleAttribute(
   if (CONSOLE_DROP_WHEN_COUNTED_KEYS.has(key)) {
     return true;
   }
-  if (key === "app.agent.id" && attributes[key] === attributes["app.turn.id"]) {
-    return true;
-  }
   if (
     key === "messaging.message.conversation_id" &&
     attributes[key] === attributes["gen_ai.conversation.id"]
@@ -902,16 +893,12 @@ function getPrettyConsoleSummaryTokens(
     const conversationId = toOptionalString(
       attributes["gen_ai.conversation.id"],
     );
-    const turnId = toOptionalString(attributes["app.turn.id"]);
     const messageId = toOptionalString(attributes["messaging.message.id"]);
     if (conversationId) {
       pushPrettyConsoleToken(
         tokens,
         `conv=${abbreviateConsoleId(conversationId)}`,
       );
-    }
-    if (turnId) {
-      pushPrettyConsoleToken(tokens, `turn=${abbreviateConsoleId(turnId)}`);
     }
     if (messageId) {
       pushPrettyConsoleToken(tokens, `msg=${abbreviateConsoleId(messageId)}`);
@@ -1167,7 +1154,6 @@ export const log = {
       {
         ...attrs,
         "error.type": normalizedError.name,
-        "error.message": normalizedError.message,
         "exception.type": normalizedError.name,
         "exception.message": normalizedError.message,
         "exception.stacktrace": normalizedError.stack,
@@ -1435,6 +1421,19 @@ function toSpanAttributeValue(value: unknown): SpanAttributeValue | undefined {
   return sanitized.length > 0 ? sanitized : undefined;
 }
 
+function normalizeSpanAttributes(
+  attributes: Record<string, unknown>,
+): Record<string, SpanAttributeValue> {
+  const normalized: Record<string, SpanAttributeValue> = {};
+  for (const [rawKey, value] of Object.entries(attributes)) {
+    const normalizedValue = toSpanAttributeValue(value);
+    if (normalizedValue !== undefined) {
+      normalized[normalizeAttributeKey(rawKey)] = normalizedValue;
+    }
+  }
+  return normalized;
+}
+
 /** Capture an error to Sentry and emit an error log record. */
 export function captureException(
   error: unknown,
@@ -1528,13 +1527,7 @@ export async function withSpan<T>(
   callback: () => Promise<T>,
   attributes: Record<string, unknown> = {},
 ): Promise<T> {
-  const normalizedAttributes: Record<string, SpanAttributeValue> = {};
-  for (const [key, value] of Object.entries(attributes)) {
-    const normalizedValue = toSpanAttributeValue(value);
-    if (normalizedValue !== undefined) {
-      normalizedAttributes[key] = normalizedValue;
-    }
-  }
+  const normalizedAttributes = normalizeSpanAttributes(attributes);
 
   return withLogContext(context, () => {
     // Child spans inherit the active log context so nested GenAI spans keep
@@ -1570,11 +1563,10 @@ export function setSpanAttributes(attributes: Record<string, unknown>): void {
     return;
   }
 
-  for (const [key, value] of Object.entries(attributes)) {
-    const normalizedValue = toSpanAttributeValue(value);
-    if (normalizedValue !== undefined) {
-      setAttribute.call(span, key, normalizedValue);
-    }
+  for (const [key, value] of Object.entries(
+    normalizeSpanAttributes(attributes),
+  )) {
+    setAttribute.call(span, key, value);
   }
 }
 
@@ -1770,6 +1762,21 @@ function toFiniteTokenCount(value: unknown): number | undefined {
   return rounded >= 0 ? rounded : undefined;
 }
 
+function sumTokenCounts(
+  ...values: Array<number | undefined>
+): number | undefined {
+  let total = 0;
+  let hasValue = false;
+  for (const value of values) {
+    if (value === undefined) {
+      continue;
+    }
+    total += value;
+    hasValue = true;
+  }
+  return hasValue ? total : undefined;
+}
+
 // pi-ai `Usage` field name -> our camelCase equivalent. This is the only shape
 // that reaches the extractor today; pi-ai normalizes every provider response
 // into this canonical set before we ever see it.
@@ -1790,7 +1797,8 @@ function readPiUsage(source: unknown): AgentTurnUsage {
   const usage = asRecord(record.usage) ?? record;
   const summary: AgentTurnUsage = {};
   for (const [piKey, ourKey] of PI_USAGE_FIELDS) {
-    const value = toFiniteTokenCount(usage[piKey]);
+    const value =
+      toFiniteTokenCount(usage[piKey]) ?? toFiniteTokenCount(usage[ourKey]);
     if (value !== undefined) {
       summary[ourKey] = value;
     }
@@ -1820,20 +1828,38 @@ export function extractGenAiUsageSummary(
   return summary;
 }
 
-/** Extract input/output token counts from AI provider usage metadata for tracing. */
+/** Extract GenAI token usage attributes from AI provider usage metadata for tracing. */
 export function extractGenAiUsageAttributes(
   ...sources: unknown[]
 ): Partial<
-  Record<"gen_ai.usage.input_tokens" | "gen_ai.usage.output_tokens", number>
+  Record<
+    | "gen_ai.usage.input_tokens"
+    | "gen_ai.usage.output_tokens"
+    | "gen_ai.usage.cache_read.input_tokens"
+    | "gen_ai.usage.cache_creation.input_tokens",
+    number
+  >
 > {
-  const { inputTokens, outputTokens } = extractGenAiUsageSummary(...sources);
+  const { inputTokens, outputTokens, cachedInputTokens, cacheCreationTokens } =
+    extractGenAiUsageSummary(...sources);
+  const semanticInputTokens = sumTokenCounts(
+    inputTokens,
+    cachedInputTokens,
+    cacheCreationTokens,
+  );
 
   return {
-    ...(inputTokens !== undefined
-      ? { "gen_ai.usage.input_tokens": inputTokens }
+    ...(semanticInputTokens !== undefined
+      ? { "gen_ai.usage.input_tokens": semanticInputTokens }
       : {}),
     ...(outputTokens !== undefined
       ? { "gen_ai.usage.output_tokens": outputTokens }
+      : {}),
+    ...(cachedInputTokens !== undefined
+      ? { "gen_ai.usage.cache_read.input_tokens": cachedInputTokens }
+      : {}),
+    ...(cacheCreationTokens !== undefined
+      ? { "gen_ai.usage.cache_creation.input_tokens": cacheCreationTokens }
       : {}),
   };
 }

--- a/packages/junior/src/chat/mcp/tool-manager.ts
+++ b/packages/junior/src/chat/mcp/tool-manager.ts
@@ -377,7 +377,7 @@ export class McpToolManager {
           const errorAttributes = {
             ...baseAttributes,
             "error.type": getMcpAwareErrorType(error, "mcp_tool_error"),
-            "error.message": getMcpAwareErrorMessage(error),
+            "exception.message": getMcpAwareErrorMessage(error),
           };
           setSpanAttributes(errorAttributes);
           if (error instanceof McpToolError) {

--- a/packages/junior/src/chat/pi/client.ts
+++ b/packages/junior/src/chat/pi/client.ts
@@ -231,7 +231,7 @@ export async function completeText(params: {
           {},
           {
             ...baseAttributes,
-            "error.message": providerMessage,
+            "exception.message": providerMessage,
           },
           "AI completion returned provider error",
         );
@@ -259,7 +259,6 @@ export async function completeObject<TSchema extends ZodTypeAny>(params: {
   signal?: AbortSignal;
   metadata?: Record<string, unknown>;
 }): Promise<{ object: z.infer<TSchema>; text: string }> {
-  const startedAt = Date.now();
   let text = "";
   try {
     ({ text } = await completeText({
@@ -287,7 +286,6 @@ export async function completeObject<TSchema extends ZodTypeAny>(params: {
         "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
         "gen_ai.operation.name": GEN_AI_OPERATION_CHAT,
         "gen_ai.request.model": params.modelId,
-        "app.ai.duration_ms": Date.now() - startedAt,
       },
       "AI object completion failed",
     );
@@ -305,7 +303,6 @@ export async function completeObject<TSchema extends ZodTypeAny>(params: {
         "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
         "gen_ai.operation.name": GEN_AI_OPERATION_CHAT,
         "gen_ai.request.model": params.modelId,
-        "app.ai.duration_ms": Date.now() - startedAt,
         "app.ai.response_preview": preview,
       },
       "AI object completion schema parse failed",

--- a/packages/junior/src/chat/plugins/registry.ts
+++ b/packages/junior/src/chat/plugins/registry.ts
@@ -176,7 +176,7 @@ function buildLoadedPluginState(
         {},
         {
           "file.directory": pluginsRoot,
-          "error.message":
+          "exception.message":
             error instanceof Error ? error.message : String(error),
         },
         "Failed to read plugin root",
@@ -205,7 +205,7 @@ function buildLoadedPluginState(
         {},
         {
           "file.directory": pluginsRoot,
-          "error.message":
+          "exception.message":
             error instanceof Error ? error.message : String(error),
         },
         "Failed to read plugin root",
@@ -255,7 +255,7 @@ function logLoadedPlugins(state: LoadedPluginState): void {
         "app.plugin.config_key_count": plugin.manifest.configKeys.length,
         "app.plugin.has_mcp": Boolean(plugin.manifest.mcp),
         "file.directory": plugin.dir,
-        "file.skill_directory": plugin.skillsDir,
+        "app.file.skill_directory": plugin.skillsDir,
       },
       "Loaded plugin",
     );

--- a/packages/junior/src/chat/prompt.ts
+++ b/packages/junior/src/chat/prompt.ts
@@ -70,7 +70,7 @@ function loadSoul(): string {
     "soul_load_fallback",
     {},
     {
-      "file.candidates": soulPathCandidates(),
+      "app.file.candidates": soulPathCandidates(),
     },
     "SOUL.md not found; using built-in default personality",
   );
@@ -89,7 +89,8 @@ export const JUNIOR_PERSONALITY = (() => {
       "soul_load_failed",
       {},
       {
-        "error.message": error instanceof Error ? error.message : String(error),
+        "exception.message":
+          error instanceof Error ? error.message : String(error),
       },
       "Failed to load SOUL.md; using built-in default personality",
     );
@@ -105,7 +106,8 @@ export const JUNIOR_WORLD = (() => {
       "world_load_failed",
       {},
       {
-        "error.message": error instanceof Error ? error.message : String(error),
+        "exception.message":
+          error instanceof Error ? error.message : String(error),
       },
       "Failed to load WORLD.md; omitting world prompt context",
     );

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -2,6 +2,7 @@ import { Agent, type AgentTool } from "@mariozechner/pi-agent-core";
 import type { FileUpload } from "chat";
 import { botConfig } from "@/chat/config";
 import {
+  extractGenAiUsageAttributes,
   extractGenAiUsageSummary,
   getActiveTraceId,
   logException,
@@ -411,8 +412,6 @@ export async function generateAssistantReply(
         context.correlation?.conversationId ??
         context.correlation?.threadId ??
         context.correlation?.runId,
-      turnId: context.correlation?.turnId,
-      agentId: context.correlation?.turnId,
       slackThreadId: context.correlation?.threadId,
       slackUserId: context.correlation?.requesterId,
       slackChannelId: context.correlation?.channelId,
@@ -437,7 +436,7 @@ export async function generateAssistantReply(
         {
           "app.skill.count": availableSkills.length,
           "app.skill.names": availableSkills.map((skill) => skill.name).sort(),
-          "file.directories": roots,
+          "app.file.directories": roots,
           "app.plugin.count": plugins.length,
           "app.plugin.names": plugins
             .map((plugin) => plugin.manifest.name)
@@ -736,8 +735,6 @@ export async function generateAssistantReply(
 
     setTags({
       conversationId: spanContext.conversationId,
-      turnId: spanContext.turnId,
-      agentId: spanContext.agentId,
       slackThreadId: context.correlation?.threadId,
       slackUserId: context.correlation?.requesterId,
       slackChannelId: context.correlation?.channelId,
@@ -899,7 +896,7 @@ export async function generateAssistantReply(
           spanContext,
           {
             "gen_ai.tool.name": toolName,
-            "error.message":
+            "exception.message":
               error instanceof Error ? error.message : String(error),
           },
           "Tool invocation observer failed",
@@ -953,7 +950,7 @@ export async function generateAssistantReply(
             "streaming_message_start_error",
             {},
             {
-              "error.message":
+              "exception.message":
                 error instanceof Error ? error.message : String(error),
             },
             "Failed to deliver assistant message start to stream coordinator",
@@ -978,7 +975,7 @@ export async function generateAssistantReply(
           "streaming_text_delta_error",
           {},
           {
-            "error.message":
+            "exception.message":
               error instanceof Error ? error.message : String(error),
           },
           "Failed to deliver text delta to stream",
@@ -1081,12 +1078,7 @@ export async function generateAssistantReply(
             ...(outputMessagesAttribute
               ? { "gen_ai.output.messages": outputMessagesAttribute }
               : {}),
-            ...(usageSummary.inputTokens !== undefined
-              ? { "gen_ai.usage.input_tokens": usageSummary.inputTokens }
-              : {}),
-            ...(usageSummary.outputTokens !== undefined
-              ? { "gen_ai.usage.output_tokens": usageSummary.outputTokens }
-              : {}),
+            ...extractGenAiUsageAttributes(usageSummary),
           });
           if (getPendingAuthPause()) {
             timeoutResumeMessages = [...agent.state.messages];
@@ -1281,7 +1273,7 @@ export async function generateAssistantReply(
         "mcp_tool_manager_close_failed",
         {},
         {
-          "error.message":
+          "exception.message":
             closeError instanceof Error
               ? closeError.message
               : String(closeError),

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -174,11 +174,8 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           nextTurnId: turnId,
           updateConversationStats,
         });
-        const turnStartedAtMs = Date.now();
         const turnTraceContext = {
           conversationId,
-          turnId,
-          agentId: turnId,
           slackThreadId: threadId,
           slackUserId: message.author.userId,
           slackChannelId: channelId,
@@ -188,8 +185,6 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
         };
         setTags({
           conversationId,
-          turnId,
-          agentId: turnId,
         });
         if (shouldEmitDevAgentTrace()) {
           logInfo(
@@ -507,7 +502,6 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               "agent_turn_completed",
               turnTraceContext,
               {
-                "app.turn.duration_ms": Date.now() - turnStartedAtMs,
                 "app.ai.outcome": reply.diagnostics.outcome,
                 "app.ai.tool_call_count": reply.diagnostics.toolCalls.length,
                 "app.ai.tool_error_results": reply.diagnostics.toolErrorCount,
@@ -609,9 +603,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               logWarn(
                 "agent_turn_failed",
                 turnTraceContext,
-                {
-                  "app.turn.duration_ms": Date.now() - turnStartedAtMs,
-                },
+                {},
                 "Agent turn failed",
               );
             }

--- a/packages/junior/src/chat/runtime/slack-runtime.ts
+++ b/packages/junior/src/chat/runtime/slack-runtime.ts
@@ -309,7 +309,7 @@ export function createSlackTurnRuntime<
             error,
             "mention_handler_auth_pause",
             errorContext,
-            { "app.turn.retryable_reason": error.reason },
+            { "app.ai.retryable_reason": error.reason },
             "onNewMention parked turn for auth resume",
           );
           return;
@@ -468,7 +468,7 @@ export function createSlackTurnRuntime<
             error,
             "subscribed_message_handler_auth_pause",
             errorContext,
-            { "app.turn.retryable_reason": error.reason },
+            { "app.ai.retryable_reason": error.reason },
             "onSubscribedMessage parked turn for auth resume",
           );
           return;

--- a/packages/junior/src/chat/sandbox/http-error-details.ts
+++ b/packages/junior/src/chat/sandbox/http-error-details.ts
@@ -60,7 +60,7 @@ export function extractHttpErrorDetails(
 
   const attributes: Record<string, string | number | boolean | string[]> = {
     "error.type": normalizedError.name || "Error",
-    "error.message":
+    "exception.message":
       toTrimmedString(normalizedError.message, previewLimit) ?? "HTTP error",
   };
 

--- a/packages/junior/src/chat/sandbox/session.ts
+++ b/packages/junior/src/chat/sandbox/session.ts
@@ -249,7 +249,7 @@ export function createSandboxSessionManager(options?: {
       "sandbox_network_policy_restore_failed",
       traceContext,
       {
-        "error.message":
+        "exception.message":
           reason instanceof Error ? reason.message : String(reason),
       },
       "Sandbox network policy restore failed; discarding sandbox instance",

--- a/packages/junior/src/chat/services/conversation-memory.ts
+++ b/packages/junior/src/chat/services/conversation-memory.ts
@@ -287,7 +287,8 @@ async function summarizeConversationChunk(
         modelId: botConfig.fastModelId,
       },
       {
-        "error.message": error instanceof Error ? error.message : String(error),
+        "exception.message":
+          error instanceof Error ? error.message : String(error),
         "app.compaction_messages_covered": messages.length,
       },
       "Compaction summarization failed; using fallback summary",

--- a/packages/junior/src/chat/services/subscribed-reply-policy.ts
+++ b/packages/junior/src/chat/services/subscribed-reply-policy.ts
@@ -48,7 +48,7 @@ export function createSubscribedReplyPolicy(
             modelId: botConfig.fastModelId,
           },
           {
-            "error.message":
+            "exception.message":
               error instanceof Error ? error.message : String(error),
           },
           "Subscribed-message classifier failed; skipping reply",

--- a/packages/junior/src/chat/services/turn-failure-response.ts
+++ b/packages/junior/src/chat/services/turn-failure-response.ts
@@ -97,7 +97,7 @@ export function getAgentTurnDiagnosticsAttributes(
         }
       : {}),
     ...(reply.diagnostics.errorMessage
-      ? { "error.message": reply.diagnostics.errorMessage }
+      ? { "exception.message": reply.diagnostics.errorMessage }
       : {}),
   };
 }

--- a/packages/junior/src/chat/services/vision-context.ts
+++ b/packages/junior/src/chat/services/vision-context.ts
@@ -317,7 +317,7 @@ async function resolveUserAttachmentsWithDeps(
           },
           {
             "file.size": data.byteLength,
-            "file.mime_type": mediaType,
+            "app.file.mime_type": mediaType,
           },
           "Skipping user attachment that exceeds size limit",
         );
@@ -345,9 +345,9 @@ async function resolveUserAttachmentsWithDeps(
             modelId: botConfig.visionModelId ?? botConfig.modelId,
           },
           {
-            "error.message":
+            "exception.message":
               error instanceof Error ? error.message : String(error),
-            "file.mime_type": mediaType,
+            "app.file.mime_type": mediaType,
             ...(attachment.name ? { "file.name": attachment.name } : {}),
           },
           "Image attachment processing failed",
@@ -366,9 +366,9 @@ async function resolveUserAttachmentsWithDeps(
           modelId: botConfig.modelId,
         },
         {
-          "error.message":
+          "exception.message":
             error instanceof Error ? error.message : String(error),
-          "file.mime_type": mediaType,
+          "app.file.mime_type": mediaType,
         },
         "Failed to resolve user attachment",
       );
@@ -433,9 +433,10 @@ async function summarizeConversationImage(
         modelId: visionModelId,
       },
       {
-        "error.message": error instanceof Error ? error.message : String(error),
-        "file.id": args.fileId,
-        "file.mime_type": args.mimeType,
+        "exception.message":
+          error instanceof Error ? error.message : String(error),
+        "app.file.id": args.fileId,
+        "app.file.mime_type": args.mimeType,
       },
       "Image analysis failed while hydrating conversation context",
     );
@@ -498,7 +499,8 @@ async function hydrateConversationVisionContextWithDeps(
         modelId: botConfig.modelId,
       },
       {
-        "error.message": error instanceof Error ? error.message : String(error),
+        "exception.message":
+          error instanceof Error ? error.message : String(error),
       },
       "Failed to fetch thread replies for image context hydration",
     );
@@ -581,9 +583,9 @@ async function hydrateConversationVisionContextWithDeps(
             modelId: botConfig.modelId,
           },
           {
-            "file.id": fileId,
+            "app.file.id": fileId,
             "file.size": fileSize,
-            "file.mime_type": mimeType,
+            "app.file.mime_type": mimeType,
           },
           "Skipping thread image that exceeds size limit",
         );
@@ -612,10 +614,10 @@ async function hydrateConversationVisionContextWithDeps(
             modelId: botConfig.modelId,
           },
           {
-            "error.message":
+            "exception.message":
               error instanceof Error ? error.message : String(error),
-            "file.id": fileId,
-            "file.mime_type": mimeType,
+            "app.file.id": fileId,
+            "app.file.mime_type": mimeType,
           },
           "Failed to download thread image for context hydration",
         );
@@ -634,9 +636,9 @@ async function hydrateConversationVisionContextWithDeps(
             modelId: botConfig.modelId,
           },
           {
-            "file.id": fileId,
+            "app.file.id": fileId,
             "file.size": imageData.byteLength,
-            "file.mime_type": mimeType,
+            "app.file.mime_type": mimeType,
           },
           "Skipping downloaded thread image that exceeds size limit",
         );

--- a/packages/junior/src/chat/skills.ts
+++ b/packages/junior/src/chat/skills.ts
@@ -329,7 +329,7 @@ async function readSkillDirectory(
         {},
         {
           "file.path": skillDir,
-          "error.message": parsed.error,
+          "exception.message": parsed.error,
         },
         "Invalid skill frontmatter",
       );
@@ -352,7 +352,8 @@ async function readSkillDirectory(
       {},
       {
         "file.path": skillDir,
-        "error.message": error instanceof Error ? error.message : String(error),
+        "exception.message":
+          error instanceof Error ? error.message : String(error),
       },
       "Failed to read skill directory",
     );
@@ -399,7 +400,7 @@ export async function discoverSkills(
         {},
         {
           "file.directory": root,
-          "error.message":
+          "exception.message":
             error instanceof Error ? error.message : String(error),
         },
         "Failed to read skill root",

--- a/packages/junior/src/chat/slack/assistant-thread/status-send.ts
+++ b/packages/junior/src/chat/slack/assistant-thread/status-send.ts
@@ -161,7 +161,7 @@ function logAssistantStatusFailure(args: {
       "app.slack.channel_id_raw": args.channelId,
       "app.slack.channel_id": args.normalizedChannelId,
       "app.slack.thread_ts": args.threadTs,
-      "error.message":
+      "exception.message":
         args.error instanceof Error ? args.error.message : String(args.error),
     },
     `Failed to update assistant status channel=${args.normalizedChannelId} raw=${args.channelId} thread=${args.threadTs}`,

--- a/packages/junior/src/chat/slack/assistant-thread/title.ts
+++ b/packages/junior/src/chat/slack/assistant-thread/title.ts
@@ -104,7 +104,7 @@ export function maybeUpdateAssistantTitle(args: {
           modelId: args.modelId,
         },
         {
-          "error.message":
+          "exception.message":
             error instanceof Error ? error.message : String(error),
         },
         "Thread title generation failed",

--- a/packages/junior/src/chat/slack/user.ts
+++ b/packages/junior/src/chat/slack/user.ts
@@ -105,7 +105,8 @@ export async function lookupSlackUser(
       {},
       {
         "enduser.id": userId,
-        "error.message": error instanceof Error ? error.message : String(error),
+        "exception.message":
+          error instanceof Error ? error.message : String(error),
       },
       "Slack user lookup failed with exception",
     );

--- a/packages/junior/src/chat/tools/execution/tool-error-handler.ts
+++ b/packages/junior/src/chat/tools/execution/tool-error-handler.ts
@@ -54,7 +54,7 @@ export function handleToolExecutionError(
         "gen_ai.tool.name": toolName,
         ...(toolCallId ? { "gen_ai.tool.call.id": toolCallId } : {}),
         "error.type": errorType,
-        "error.message": errorMessage,
+        "exception.message": errorMessage,
       },
       "Agent tool call failed",
     );

--- a/packages/junior/src/chat/tools/web/image-generate.ts
+++ b/packages/junior/src/chat/tools/web/image-generate.ts
@@ -42,7 +42,7 @@ async function enrichImagePrompt(rawPrompt: string): Promise<string> {
     logWarn(
       "image_prompt_enrichment_failed",
       {},
-      { "error.message": String(error) },
+      { "exception.message": String(error) },
       "Image prompt enrichment failed, using raw prompt",
     );
     return rawPrompt;

--- a/packages/junior/src/chat/usage.ts
+++ b/packages/junior/src/chat/usage.ts
@@ -7,7 +7,7 @@
  * whether to display a breakdown or a single aggregate.
  */
 export interface AgentTurnUsage {
-  /** Non-cached input tokens (pi-ai subtracts cached tokens from this). */
+  /** Non-cached input tokens; OTel `gen_ai.usage.input_tokens` adds cache counters back in. */
   inputTokens?: number;
   /** Output tokens; pi-ai folds reasoning tokens into this for providers that report them. */
   outputTokens?: number;

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -311,7 +311,7 @@ async function resumeAuthorizedMcpTurn(args: {
         {
           "app.credential.provider": provider,
           ...(isRetryableTurnError(error)
-            ? { "app.turn.retryable_reason": error.reason }
+            ? { "app.ai.retryable_reason": error.reason }
             : {}),
         },
         "Resumed MCP turn requested another authorization flow",

--- a/packages/junior/tests/unit/logging/extract-gen-ai-usage-summary.test.ts
+++ b/packages/junior/tests/unit/logging/extract-gen-ai-usage-summary.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { extractGenAiUsageSummary } from "@/chat/logging";
+import {
+  extractGenAiUsageAttributes,
+  extractGenAiUsageSummary,
+} from "@/chat/logging";
 
 describe("extractGenAiUsageSummary", () => {
   it("returns empty object for sources with no usage metadata", () => {
@@ -94,6 +97,22 @@ describe("extractGenAiUsageSummary", () => {
       cachedInputTokens: 0,
       cacheCreationTokens: 0,
       totalTokens: 12,
+    });
+  });
+
+  it("maps cache token counters to current GenAI semantic attributes", () => {
+    expect(
+      extractGenAiUsageAttributes({
+        inputTokens: 10,
+        outputTokens: 2,
+        cachedInputTokens: 4,
+        cacheCreationTokens: 1,
+      }),
+    ).toEqual({
+      "gen_ai.usage.input_tokens": 15,
+      "gen_ai.usage.output_tokens": 2,
+      "gen_ai.usage.cache_read.input_tokens": 4,
+      "gen_ai.usage.cache_creation.input_tokens": 1,
     });
   });
 });

--- a/packages/junior/tests/unit/mcp/tool-manager.test.ts
+++ b/packages/junior/tests/unit/mcp/tool-manager.test.ts
@@ -215,7 +215,7 @@ describe("McpToolManager", () => {
     const expectedAttributes = expect.objectContaining({
       "mcp.method.name": "tools/call",
       "error.type": "tool_error",
-      "error.message":
+      "exception.message":
         "Input validation error: Invalid input: expected object, received undefined",
     });
     expect(setSpanAttributesMock).toHaveBeenCalledWith(expectedAttributes);

--- a/packages/junior/tests/unit/tools/tool-error-handler.test.ts
+++ b/packages/junior/tests/unit/tools/tool-error-handler.test.ts
@@ -42,7 +42,7 @@ describe("handleToolExecutionError", () => {
         "gen_ai.tool.name": "callMcpTool",
         "gen_ai.tool.call.id": "tool-call-id",
         "error.type": "tool_error",
-        "error.message": "remote tool failed",
+        "exception.message": "remote tool failed",
       }),
       "Agent tool call failed",
     );

--- a/specs/harness-agent-spec.md
+++ b/specs/harness-agent-spec.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-02-24
-- Last Edited: 2026-05-06
+- Last Edited: 2026-05-11
 
 ## Changelog
 
@@ -13,6 +13,7 @@
 - 2026-04-13: Clarified timeout behavior when turn-session checkpoints are available for resumable slices.
 - 2026-04-30: Added the thinking-level routing contract and normal-effort default.
 - 2026-05-06: Clarified that normal turns seed Pi from durable conversation message history instead of flattening prior turns into the current prompt.
+- 2026-05-11: Aligned agent telemetry fields with current OpenTelemetry GenAI and exception semantics.
 
 ## Status
 
@@ -109,13 +110,15 @@ Define the canonical runtime contract for assistant-turn execution and user-visi
   - `gen_ai.output.messages`
   - `gen_ai.usage.input_tokens`
   - `gen_ai.usage.output_tokens`
+  - `gen_ai.usage.cache_read.input_tokens` (when available)
+  - `gen_ai.usage.cache_creation.input_tokens` (when available)
   - `app.ai.outcome` (`success|execution_failure|provider_error`)
   - `app.ai.assistant_messages`
   - `app.ai.tool_results`
   - `app.ai.tool_error_results`
   - `app.ai.used_primary_text`
   - `gen_ai.response.finish_reasons` (when available)
-  - `error.message` (when available)
+  - `exception.message` (when available)
 - Do not emit empty placeholders for absent optional attributes.
 
 ## Verification

--- a/specs/logging/logging-spec.md
+++ b/specs/logging/logging-spec.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-02-24
-- Last Edited: 2026-04-06
+- Last Edited: 2026-05-11
 
 ## Changelog
 
@@ -11,6 +11,7 @@
 - 2026-03-04: Updated code and test file references to repo-root paths under `packages/junior/`.
 - 2026-03-18: Added console rendering policy for compact dev logs and clarified that tool success lifecycle uses spans instead of duplicate start/complete info logs.
 - 2026-04-06: Aligned GenAI semantic keys with official finish-reasons, system-instructions, and tool-description attributes.
+- 2026-05-11: Aligned exception details and GenAI cache token counters with OpenTelemetry 1.41.0.
 
 ## Status
 
@@ -141,8 +142,8 @@ Rules:
 ### Console Rendering Policy
 
 - Structured records remain rich for sinks and Sentry; console rendering may project a smaller view for readability.
-- Default dev console output should keep a small stable core (`event.name`, conversation/turn correlation, trace/span ids, and event-local outcome fields) and suppress low-value ambient fields that are repeated on nearly every line.
-- Default console output should suppress duplicated correlation fields when a stronger equivalent is already present (for example `app.agent.id` when it matches `app.turn.id`).
+- Default dev console output should keep a small stable core (`event.name`, conversation correlation, trace/span ids, and event-local outcome fields) and suppress low-value ambient fields that are repeated on nearly every line.
+- Default console output should suppress duplicated correlation fields when a stronger telemetry pivot is already present.
 - Development console output may render a human-oriented summary line instead of the full key/value projection, as long as structured attributes remain intact for non-console sinks and `JUNIOR_LOG_FORMAT=structured` can force the full projection. This explicitly applies to worker-based dev runtimes that do not expose TTY state to the logging process.
 - Large payload attributes should be compacted for `debug` and `info` console output using short previews plus length metadata. `warn` and `error` console output may retain fuller payload detail subject to normal redaction/truncation rules.
 - Console projection is a presentation concern only; it must not remove the underlying structured attributes from emitted log records.
@@ -205,13 +206,14 @@ Rules:
 - `gen_ai.input.messages` (serialized request messages when captured)
 - `gen_ai.output.messages` (serialized model output messages when captured)
 - `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` (when available)
+- `gen_ai.usage.cache_read.input_tokens` / `gen_ai.usage.cache_creation.input_tokens` (when available)
 - `gen_ai.tool.description` (for tool-call spans when available)
 - `gen_ai.tool.call.arguments` / `gen_ai.tool.call.result` (for tool-call spans when captured)
 
 ### Error
 
 - `error.type`
-- `error.message`
+- `exception.message`
 - `exception.stacktrace` (only on error-level logs/events; truncated)
 
 ### Workflow / App-specific (namespaced)

--- a/specs/logging/semantics.md
+++ b/specs/logging/semantics.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-02-25
-- Last Edited: 2026-05-01
+- Last Edited: 2026-05-11
 
 ## Changelog
 
@@ -12,6 +12,7 @@
 - 2026-04-06: Added official GenAI finish-reason, system-instructions, and tool-description semantics.
 - 2026-04-28: Added MCP tool-call semantic attribute mappings.
 - 2026-05-01: Added `gen_ai.conversation.id` to the canonical GenAI semantic map.
+- 2026-05-11: Aligned error details, cache token usage, and non-standard file fields with OpenTelemetry 1.41.0.
 
 ## Status
 
@@ -78,6 +79,8 @@ This file is the canonical attribute and naming map for instrumentation in this 
 - `gen_ai.output.messages` (when captured)
 - `gen_ai.usage.input_tokens` (when available)
 - `gen_ai.usage.output_tokens` (when available)
+- `gen_ai.usage.cache_read.input_tokens` (when available)
+- `gen_ai.usage.cache_creation.input_tokens` (when available)
 - `gen_ai.tool.description` (when available)
 - `gen_ai.tool.name` (for `execute_tool`)
 - `gen_ai.tool.call.id` (when available)
@@ -126,6 +129,11 @@ This file is the canonical attribute and naming map for instrumentation in this 
 
 Use `app.*` only for data with no current semantic key:
 
+- `app.file.id`
+- `app.file.mime_type`
+- `app.file.skill_directory`
+- `app.file.candidates`
+- `app.file.directories`
 - `app.sandbox.stdout_bytes`
 - `app.sandbox.stderr_bytes`
 - `app.sandbox.sync.files_written`
@@ -142,7 +150,7 @@ Use `app.*` only for data with no current semantic key:
 ## Error Semantics
 
 - `error.type` for low-cardinality error class.
-- `error.message` and `exception.stacktrace` only when needed and safe.
+- `exception.message` and `exception.stacktrace` only when needed and safe.
 
 ## Naming Rules
 

--- a/specs/logging/tracing-spec.md
+++ b/specs/logging/tracing-spec.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-02-25
-- Last Edited: 2026-05-01
+- Last Edited: 2026-05-11
 
 ## Changelog
 
@@ -14,6 +14,7 @@
 - 2026-04-06: Added official GenAI finish-reasons, system-instructions, and tool-description tracing attributes.
 - 2026-04-28: Added MCP tool-call span attributes from the OpenTelemetry MCP semantic conventions.
 - 2026-05-01: Added `gen_ai.conversation.id` as required correlation context for GenAI spans when available.
+- 2026-05-11: Aligned exception details and GenAI cache token counters with OpenTelemetry 1.41.0.
 
 ## Status
 
@@ -75,6 +76,7 @@ Define the canonical tracing contract for span naming, boundaries, attributes, a
 - `gen_ai.system_instructions` when provided separately from chat history and safely captured.
 - `gen_ai.input.messages` / `gen_ai.output.messages` when safely captured.
 - `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` when available from provider responses.
+- `gen_ai.usage.cache_read.input_tokens` / `gen_ai.usage.cache_creation.input_tokens` when available from provider responses.
 - `gen_ai.tool.description` when available on tool execution spans.
 - `gen_ai.tool.call.arguments` / `gen_ai.tool.call.result` on tool execution spans when captured.
 - Keep existing context keys aligned with `packages/junior/src/chat/logging.ts`.
@@ -82,7 +84,7 @@ Define the canonical tracing contract for span naming, boundaries, attributes, a
 ### Error Attributes
 
 - `error.type`
-- `error.message`
+- `exception.message`
 - `exception.stacktrace` (when captured and safe)
 
 ### MCP Tool Calls


### PR DESCRIPTION
Add a root TELEMETRY spec and Junior telemetry map so agents can start from production clues and move directly to Sentry query surfaces, pivots, and first recipes. The map stays symptom-first instead of acting as a source inventory.

**Telemetry Map**

TELEMETRY.md now points agents from Slack threads, Sentry event IDs, trace/span IDs, event names, and tool/model symptoms to concrete Sentry log/span queries and incident domains.

**Semantic Cleanup**

Runtime telemetry now uses current OpenTelemetry keys where available, removes turn-id telemetry pivots, drops redundant duration attributes in favor of span timing, and keeps local fields under app.* only where needed.