### PR TITLE
fix(sandbox): Scope egress and adapt sandbox v2

### DIFF
--- a/packages/docs/src/content/docs/concepts/credentials-and-oauth.md
+++ b/packages/docs/src/content/docs/concepts/credentials-and-oauth.md
@@ -16,11 +16,11 @@ plugin providers are available to sandbox commands, and sandbox HTTP requests to
 declared provider domains are forwarded through Junior. Junior then fetches a
 requester-bound lease and injects auth at the host boundary.
 
-- Credentials are short-lived and scoped to the requester, registered provider, and turn.
+- Credentials are short-lived and scoped to the requester, registered provider, and current sandbox command.
 - User-owned provider access is only activated for the author of the current message.
 - Plugin declarations determine which credentials can be injected for matching provider domains.
 - Sandbox receives placeholder env vars and proxied HTTP responses, not raw long-lived tokens.
-- Junior rejects proxied provider requests unless the sandbox session is requester-bound and the forwarded host matches a registered provider domain.
+- Junior rejects proxied provider requests unless the sandbox command has an active requester-bound egress session and the forwarded host matches a registered provider domain.
 
 ## OAuth model
 

--- a/packages/docs/src/content/docs/concepts/execution-model.md
+++ b/packages/docs/src/content/docs/concepts/execution-model.md
@@ -17,7 +17,7 @@ related:
 3. Thread work is enqueued to `junior-thread-message`.
 4. `/api/queue/callback` processes queued work.
 5. Agent turn runs with configured tools, loaded skills, and capability gates.
-6. If an authenticated command reaches a declared provider domain, the sandbox egress proxy fetches requester-bound credentials and injects them at the host boundary.
+6. If an authenticated command reaches a declared provider domain, the sandbox egress proxy fetches command-scoped requester credentials and injects them at the host boundary.
 7. If OAuth is required, Junior sends the link privately to the requesting user and resumes the blocked request after the callback.
 8. Reply is posted back to the original Slack thread.
 
@@ -30,7 +30,7 @@ related:
 ## Core invariants
 
 - Webhook ingress and queue callback are both required for production.
-- Tool and credential usage is capability-gated, requester-bound, and turn-scoped.
+- Tool usage is turn-scoped; sandbox credential leases are requester-bound and command-scoped.
 - Registered plugin providers determine which provider credentials can be injected for matching provider domains.
 - Failure states are logged and surfaced for operator recovery.
 

--- a/packages/docs/src/content/docs/extend/index.md
+++ b/packages/docs/src/content/docs/extend/index.md
@@ -219,7 +219,7 @@ Use top-level `command-env` when a sandbox CLI needs non-secret env vars. This i
 
 `command-env` values may be literals or `${NAME}` placeholders declared in `env-vars`. References with defaults expand at manifest load. References without defaults are read from host env when sandbox command env is resolved and are skipped when unset.
 
-Only expose non-secret values. For example, GitHub App bot names and noreply emails are safe to expose so git commits can be attributed correctly, but API keys and tokens belong in `api-headers` or credential brokers.
+Only expose non-secret values. `command-env` placeholders cannot reuse env vars that back `api-headers`, credential config, or OAuth config. For example, GitHub App bot names and noreply emails are safe to expose so git commits can be attributed correctly, but API keys and tokens belong in `api-headers` or credential brokers.
 
 Manifests with `command-env` must also declare `credentials` or `api-headers`, so sandbox env exposure stays tied to a credential/header provider.
 

--- a/packages/docs/src/content/docs/operate/security-hardening.md
+++ b/packages/docs/src/content/docs/operate/security-hardening.md
@@ -27,7 +27,7 @@ session-wide sandbox state.
 - Use short-lived scoped credentials.
 - Let registered plugin providers determine which credentials may be injected for matching domains.
 - Fetch credentials from the host when sandbox traffic hits a declared provider domain.
-- Keep sandbox egress authorization bound to the requester and current sandbox session.
+- Keep sandbox egress authorization bound to the requester and current sandbox command.
 - Inject scoped auth at the host proxy boundary instead of exposing raw tokens.
 
 ## OAuth handling
@@ -40,7 +40,7 @@ session-wide sandbox state.
 
 1. Confirm no token values in logs/traces/output.
 2. Confirm OAuth links were not publicly posted and the callback state matched the requesting user.
-3. Confirm credential injection happened only for the expected turn and target.
+3. Confirm credential injection happened only for the expected command and target.
 4. Confirm sandbox session never received raw auth secrets or reusable long-lived tokens.
 
 ## Next step

--- a/packages/junior/skills/junior/references/plugin-manifest.md
+++ b/packages/junior/skills/junior/references/plugin-manifest.md
@@ -90,6 +90,7 @@ mcp:
 - `oauth` requires `credentials.type: oauth-bearer`.
 - `mcp.url` env refs must be declared in `env-vars`.
 - API-header env refs must not declare defaults.
+- `command-env` env refs must not reuse API-header, credential, or OAuth env vars.
 - `Authorization` is reserved inside token-backed `credentials.api-headers`.
 - `target.config-key` must be listed in `config-keys`.
 - System dependencies must not declare `version`.

--- a/packages/junior/skills/junior/references/runtime-authority.md
+++ b/packages/junior/skills/junior/references/runtime-authority.md
@@ -31,7 +31,7 @@ Skills describe behavior. Plugins declare authority.
 
 - Secrets never belong in skill files or committed manifests.
 - Manifest env var names may be committed; secret values stay in deployment configuration.
-- Runtime credential leases are requester-bound and turn-scoped.
+- Runtime credential leases are requester-bound; sandbox command leases are command-scoped.
 - Missing or stale OAuth is handled by Junior's private authorization flow.
 
 ## Dependencies

--- a/packages/junior/src/chat/plugins/manifest.ts
+++ b/packages/junior/src/chat/plugins/manifest.ts
@@ -4,6 +4,7 @@ import type {
   GitHubAppCredentials,
   PluginEnvVarDeclaration,
   PluginMcpConfig,
+  PluginOAuthConfig,
   OAuthBearerCredentials,
   PluginCredentials,
   PluginManifest,
@@ -349,13 +350,18 @@ function normalizeStringMap(
   return value;
 }
 
+function envReferences(value: string): string[] {
+  return Array.from(value.matchAll(ENV_PLACEHOLDER_RE), (match) => {
+    return match[1] as string;
+  });
+}
+
 function assertDeclaredEnvReferences(
   value: string,
   envVars: Record<string, PluginEnvVarDeclaration>,
   context: string,
 ): void {
-  for (const match of value.matchAll(ENV_PLACEHOLDER_RE)) {
-    const name = match[1] as string;
+  for (const name of envReferences(value)) {
     if (!Object.prototype.hasOwnProperty.call(envVars, name)) {
       throw new Error(
         `${context} references env var ${name} which is not declared in env-vars`,
@@ -389,8 +395,7 @@ function assertCommandEnvReferencesDeclared(
   envVars: Record<string, PluginEnvVarDeclaration>,
   context: string,
 ): void {
-  for (const match of value.matchAll(ENV_PLACEHOLDER_RE)) {
-    const name = match[1] as string;
+  for (const name of envReferences(value)) {
     if (!Object.prototype.hasOwnProperty.call(envVars, name)) {
       throw new Error(
         `${context} references env var ${name} which is not declared in env-vars`,
@@ -437,6 +442,47 @@ function normalizeCommandEnv(
       expandCommandEnvPlaceholders(envValue, envVars, `${prefix}.${key}`),
     ]),
   );
+}
+
+function assertCommandEnvDoesNotExposeHostSecretRefs(
+  commandEnv: Record<string, string> | undefined,
+  apiHeaders: Record<string, string> | undefined,
+  credentials: PluginCredentials | undefined,
+  oauth: PluginOAuthConfig | undefined,
+  pluginName: string,
+): void {
+  if (!commandEnv) {
+    return;
+  }
+
+  const hostOnlyRefs = new Set<string>();
+  for (const value of Object.values(apiHeaders ?? {})) {
+    for (const name of envReferences(value)) {
+      hostOnlyRefs.add(name);
+    }
+  }
+  if (credentials) {
+    hostOnlyRefs.add(credentials.authTokenEnv);
+    if (credentials.type === "github-app") {
+      hostOnlyRefs.add(credentials.appIdEnv);
+      hostOnlyRefs.add(credentials.privateKeyEnv);
+      hostOnlyRefs.add(credentials.installationIdEnv);
+    }
+  }
+  if (oauth) {
+    hostOnlyRefs.add(oauth.clientIdEnv);
+    hostOnlyRefs.add(oauth.clientSecretEnv);
+  }
+
+  for (const [key, value] of Object.entries(commandEnv)) {
+    for (const name of envReferences(value)) {
+      if (hostOnlyRefs.has(name)) {
+        throw new Error(
+          `Plugin ${pluginName} command-env.${key} references env var ${name}, but credential/API header env vars must stay host-only`,
+        );
+      }
+    }
+  }
 }
 
 function normalizeCredentials(
@@ -670,7 +716,7 @@ const envVarDeclarationSchema = z.preprocess(
     .object({
       default: z.string().optional(),
     })
-    .passthrough(),
+    .strict(),
 );
 
 function normalizeEnvVars(
@@ -985,6 +1031,14 @@ export function parsePluginManifest(raw: string, dir: string): PluginManifest {
       ...(tokenExtraHeaders ? { tokenExtraHeaders } : {}),
     };
   }
+
+  assertCommandEnvDoesNotExposeHostSecretRefs(
+    data["command-env"],
+    apiHeaders,
+    credentials,
+    manifest.oauth,
+    data.name,
+  );
 
   if (data.target) {
     const result = targetSourceSchema.safeParse(data.target);

--- a/packages/junior/src/chat/sandbox/egress-oidc.ts
+++ b/packages/junior/src/chat/sandbox/egress-oidc.ts
@@ -77,29 +77,6 @@ async function getJwks(
   return jwks;
 }
 
-function sandboxClaimMatches(payload: JWTPayload, sandboxId: string): boolean {
-  for (const claim of [
-    "sandbox_id",
-    "sandboxId",
-    "sandbox",
-    "sandbox_name",
-    "sandboxName",
-    "name",
-  ]) {
-    if (payload[claim] === sandboxId) {
-      return true;
-    }
-  }
-
-  if (typeof payload.sub !== "string") {
-    return false;
-  }
-  const parts = payload.sub.split(":");
-  return parts.some(
-    (part, index) => part === "sandbox" && parts[index + 1] === sandboxId,
-  );
-}
-
 function expectedVercelOidcAudience(): string {
   const audience = process.env.VERCEL_OIDC_AUDIENCE?.trim();
   if (!audience) {
@@ -131,7 +108,7 @@ export function validateVercelSandboxOidcClaims(
   ) {
     throw new Error("Vercel OIDC token belongs to a different project");
   }
-  if (!sandboxClaimMatches(payload, sandboxId)) {
+  if (payload.sandbox_id !== sandboxId) {
     throw new Error("Vercel OIDC token belongs to a different sandbox");
   }
 }

--- a/packages/junior/src/chat/sandbox/egress-proxy.ts
+++ b/packages/junior/src/chat/sandbox/egress-proxy.ts
@@ -187,7 +187,7 @@ async function credentialLease(
   const cached = await getSandboxEgressCredentialLease(
     sandboxId,
     provider,
-    session.requesterId,
+    session,
   );
   if (cached) {
     return cached;
@@ -210,12 +210,7 @@ async function credentialLease(
     expiresAt: lease.expiresAt,
     headerTransforms,
   };
-  await setSandboxEgressCredentialLease(
-    sandboxId,
-    session.requesterId,
-    cachedLease,
-    session.expiresAtMs,
-  );
+  await setSandboxEgressCredentialLease(sandboxId, session, cachedLease);
   return cachedLease;
 }
 
@@ -301,11 +296,7 @@ export async function proxySandboxEgressRequest(
     redirect: "manual",
   });
   if (AUTH_REJECTION_STATUS.has(upstream.status)) {
-    await clearSandboxEgressCredentialLease(
-      sandboxId,
-      provider,
-      session.requesterId,
-    );
+    await clearSandboxEgressCredentialLease(sandboxId, provider, session);
   }
 
   return new Response(upstream.body, {

--- a/packages/junior/src/chat/sandbox/egress-session.ts
+++ b/packages/junior/src/chat/sandbox/egress-session.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { CredentialHeaderTransform } from "@/chat/credentials/broker";
 import { getStateAdapter } from "@/chat/state/adapter";
 
@@ -8,6 +9,7 @@ const DEFAULT_SESSION_TTL_MS = 30 * 60 * 1000;
 export interface SandboxEgressSession {
   requesterId: string;
   expiresAtMs: number;
+  activationId: string;
 }
 
 export interface SandboxEgressCredentialLease {
@@ -23,9 +25,9 @@ function sessionKey(sandboxId: string): string {
 function leaseKey(
   sandboxId: string,
   provider: string,
-  requesterId: string,
+  session: SandboxEgressSession,
 ): string {
-  return `${SANDBOX_EGRESS_LEASE_PREFIX}:${sandboxId}:${provider}:${requesterId}`;
+  return `${SANDBOX_EGRESS_LEASE_PREFIX}:${sandboxId}:${provider}:${session.requesterId}:${session.activationId}`;
 }
 
 function parseSession(value: unknown): SandboxEgressSession | undefined {
@@ -36,7 +38,9 @@ function parseSession(value: unknown): SandboxEgressSession | undefined {
   if (
     typeof record.requesterId !== "string" ||
     typeof record.expiresAtMs !== "number" ||
-    !Number.isFinite(record.expiresAtMs)
+    !Number.isFinite(record.expiresAtMs) ||
+    typeof record.activationId !== "string" ||
+    !record.activationId
   ) {
     return undefined;
   }
@@ -46,6 +50,7 @@ function parseSession(value: unknown): SandboxEgressSession | undefined {
   return {
     requesterId: record.requesterId,
     expiresAtMs: record.expiresAtMs,
+    activationId: record.activationId,
   };
 }
 
@@ -97,8 +102,18 @@ export async function upsertSandboxEgressSession(input: {
   const session: SandboxEgressSession = {
     requesterId: input.requesterId,
     expiresAtMs: now + ttlMs,
+    activationId: randomUUID(),
   };
   await state.set(sessionKey(input.sandboxId), session, ttlMs);
+}
+
+/** Clear the active requester-bound authorization context for a sandbox. */
+export async function clearSandboxEgressSession(
+  sandboxId: string,
+): Promise<void> {
+  const state = getStateAdapter();
+  await state.connect();
+  await state.delete(sessionKey(sandboxId));
 }
 
 /** Load the active egress authorization session for a sandbox. */
@@ -113,9 +128,8 @@ export async function getSandboxEgressSession(
 /** Cache a short-lived credential lease for repeated proxied requests in one sandbox session. */
 export async function setSandboxEgressCredentialLease(
   sandboxId: string,
-  requesterId: string,
+  session: SandboxEgressSession,
   lease: SandboxEgressCredentialLease,
-  sessionExpiresAtMs: number,
 ): Promise<void> {
   const leaseExpiresAtMs = Date.parse(lease.expiresAt);
   if (!Number.isFinite(leaseExpiresAtMs) || leaseExpiresAtMs <= Date.now()) {
@@ -123,37 +137,31 @@ export async function setSandboxEgressCredentialLease(
   }
   const ttlMs = Math.max(
     1,
-    Math.min(leaseExpiresAtMs, sessionExpiresAtMs) - Date.now(),
+    Math.min(leaseExpiresAtMs, session.expiresAtMs) - Date.now(),
   );
   const state = getStateAdapter();
   await state.connect();
-  await state.set(
-    leaseKey(sandboxId, lease.provider, requesterId),
-    lease,
-    ttlMs,
-  );
+  await state.set(leaseKey(sandboxId, lease.provider, session), lease, ttlMs);
 }
 
 /** Load a cached egress credential lease for a sandbox/provider pair. */
 export async function getSandboxEgressCredentialLease(
   sandboxId: string,
   provider: string,
-  requesterId: string,
+  session: SandboxEgressSession,
 ): Promise<SandboxEgressCredentialLease | undefined> {
   const state = getStateAdapter();
   await state.connect();
-  return parseLease(
-    await state.get(leaseKey(sandboxId, provider, requesterId)),
-  );
+  return parseLease(await state.get(leaseKey(sandboxId, provider, session)));
 }
 
 /** Clear a cached egress credential lease after the provider rejects its headers. */
 export async function clearSandboxEgressCredentialLease(
   sandboxId: string,
   provider: string,
-  requesterId: string,
+  session: SandboxEgressSession,
 ): Promise<void> {
   const state = getStateAdapter();
   await state.connect();
-  await state.delete(leaseKey(sandboxId, provider, requesterId));
+  await state.delete(leaseKey(sandboxId, provider, session));
 }

--- a/packages/junior/src/chat/sandbox/noninteractive-command.ts
+++ b/packages/junior/src/chat/sandbox/noninteractive-command.ts
@@ -1,3 +1,9 @@
+import type {
+  SandboxCommandInput,
+  SandboxCommandResult,
+  SandboxWorkspace,
+} from "@/chat/sandbox/workspace";
+
 interface NonInteractiveShellOptions {
   env?: Record<string, string>;
   pathPrefix?: string;
@@ -9,14 +15,6 @@ interface NonInteractiveCommandInput extends NonInteractiveShellOptions {
   cwd?: string;
   login?: boolean;
   sudo?: boolean;
-}
-
-interface CommandRunner {
-  runCommand(input: any): Promise<{
-    exitCode: number;
-    stderr(): Promise<string>;
-    stdout(): Promise<string>;
-  }>;
 }
 
 const NON_INTERACTIVE_ENV: Readonly<Record<string, string>> = {
@@ -97,16 +95,13 @@ function buildNonInteractiveCommand(input: NonInteractiveCommandInput): {
 
 /** Run a subprocess through one enforced non-interactive entrypoint. */
 export async function runNonInteractiveCommand(
-  runner: CommandRunner,
+  sandbox: Pick<SandboxWorkspace, "runCommand">,
   input: NonInteractiveCommandInput,
-): Promise<{
-  exitCode: number;
-  stderr(): Promise<string>;
-  stdout(): Promise<string>;
-}> {
-  return await runner.runCommand({
+): Promise<SandboxCommandResult> {
+  const command: SandboxCommandInput = {
     ...buildNonInteractiveCommand(input),
     ...(input.cwd ? { cwd: input.cwd } : {}),
     ...(input.sudo !== undefined ? { sudo: input.sudo } : {}),
-  });
+  };
+  return await sandbox.runCommand(command);
 }

--- a/packages/junior/src/chat/sandbox/runtime-dependency-snapshots.ts
+++ b/packages/junior/src/chat/sandbox/runtime-dependency-snapshots.ts
@@ -7,6 +7,10 @@ import {
 } from "@/chat/plugins/registry";
 import { runNonInteractiveCommand } from "@/chat/sandbox/noninteractive-command";
 import { getVercelSandboxCredentials } from "@/chat/sandbox/credentials";
+import {
+  createSandboxInstance,
+  type SandboxInstance,
+} from "@/chat/sandbox/workspace";
 import type {
   PluginRuntimeDependency,
   PluginRuntimePostinstallCommand,
@@ -206,7 +210,7 @@ async function withSnapshotSpan<T>(
 }
 
 async function runOrThrow(
-  sandbox: Sandbox,
+  sandbox: SandboxInstance,
   params: {
     cmd: string;
     args?: string[];
@@ -226,7 +230,7 @@ async function runOrThrow(
 }
 
 async function tryRun(
-  sandbox: Sandbox,
+  sandbox: SandboxInstance,
   params: {
     cmd: string;
     args?: string[];
@@ -243,7 +247,7 @@ async function tryRun(
   return { ok: false, detail: stderr || stdout || "command failed" };
 }
 
-async function installGhCliViaDnf(sandbox: Sandbox): Promise<void> {
+async function installGhCliViaDnf(sandbox: SandboxInstance): Promise<void> {
   const direct = await tryRun(sandbox, {
     cmd: "dnf",
     args: ["install", "-y", "gh"],
@@ -316,7 +320,7 @@ function runtimeDependencyFilePath(url: string, sha256: string): string {
 }
 
 async function installRuntimeDependencies(
-  sandbox: Sandbox,
+  sandbox: SandboxInstance,
   deps: PluginRuntimeDependency[],
 ): Promise<void> {
   const systemDeps = deps.filter(
@@ -431,7 +435,7 @@ async function installRuntimeDependencies(
 }
 
 async function runRuntimePostinstall(
-  sandbox: Sandbox,
+  sandbox: SandboxInstance,
   commands: PluginRuntimePostinstallCommand[],
 ): Promise<void> {
   if (commands.length === 0) {
@@ -480,11 +484,13 @@ async function createDependencySnapshot(
     },
     async () => {
       const sandboxCredentials = getVercelSandboxCredentials();
-      const sandbox = await Sandbox.create({
-        timeout: timeoutMs,
-        runtime,
-        ...(sandboxCredentials ?? {}),
-      });
+      const sandbox = createSandboxInstance(
+        await Sandbox.create({
+          timeout: timeoutMs,
+          runtime,
+          ...(sandboxCredentials ?? {}),
+        }),
+      );
 
       try {
         await installRuntimeDependencies(sandbox, profile.dependencies);

--- a/packages/junior/src/chat/sandbox/sandbox.ts
+++ b/packages/junior/src/chat/sandbox/sandbox.ts
@@ -11,7 +11,10 @@ import {
   buildSandboxEgressNetworkPolicy,
   resolveSandboxCommandEnvironment,
 } from "@/chat/sandbox/egress-policy";
-import { upsertSandboxEgressSession } from "@/chat/sandbox/egress-session";
+import {
+  clearSandboxEgressSession,
+  upsertSandboxEgressSession,
+} from "@/chat/sandbox/egress-session";
 import { throwSandboxOperationError } from "@/chat/sandbox/errors";
 import { SANDBOX_WORKSPACE_ROOT } from "@/chat/sandbox/paths";
 import { createSandboxSessionManager } from "@/chat/sandbox/session";
@@ -133,6 +136,11 @@ export function createSandboxExecutor(options?: {
         });
       }
     : undefined;
+  const clearSandboxEgressSessionForCommand = credentialEgress
+    ? async (sandboxId: string): Promise<void> => {
+        await clearSandboxEgressSession(sandboxId);
+      }
+    : undefined;
   const sessionManager = createSandboxSessionManager({
     sandboxId: options?.sandboxId,
     sandboxDependencyProfileHash: options?.sandboxDependencyProfileHash,
@@ -145,8 +153,8 @@ export function createSandboxExecutor(options?: {
       ? buildSandboxEgressNetworkPolicy
       : undefined,
     beforeCommand: syncSandboxEgressSession,
+    afterCommand: clearSandboxEgressSessionForCommand,
     onSandboxAcquired: async (sandbox) => {
-      await syncSandboxEgressSession?.(sandbox.sandboxId);
       await options?.onSandboxAcquired?.(sandbox);
     },
   });

--- a/packages/junior/src/chat/sandbox/sandbox.ts
+++ b/packages/junior/src/chat/sandbox/sandbox.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs/promises";
-import type { Sandbox } from "@vercel/sandbox";
 import {
   logInfo,
   setSpanAttributes,
@@ -23,7 +22,7 @@ import {
   resolveHostDataPath,
   resolveHostSkillPath,
 } from "@/chat/sandbox/skill-sync";
-import type { SandboxWorkspace } from "@/chat/sandbox/workspace";
+import type { SandboxInstance } from "@/chat/sandbox/workspace";
 import type { SkillMetadata } from "@/chat/skills";
 import { editFile } from "@/chat/tools/sandbox/edit-file";
 import { findFiles } from "@/chat/tools/sandbox/find-files";
@@ -67,7 +66,7 @@ export interface SandboxExecutor {
   getSandboxId(): string | undefined;
   getDependencyProfileHash(): string | undefined;
   canExecute(toolName: string): boolean;
-  createSandbox(): Promise<SandboxWorkspace>;
+  createSandbox(): Promise<SandboxInstance>;
   execute<T>(
     params: SandboxExecutionInput,
   ): Promise<SandboxExecutionEnvelope<T>>;
@@ -94,19 +93,6 @@ function parseEnv(raw: unknown): Record<string, string> | undefined {
       .filter(([, value]) => typeof value === "string")
       .map(([key, value]) => [key, value as string]),
   );
-}
-
-function createSandboxWorkspace(sandbox: Sandbox): SandboxWorkspace {
-  const sandboxId = sandbox.name;
-  return {
-    sandboxId,
-    readFileToBuffer(input) {
-      return sandbox.readFileToBuffer(input);
-    },
-    runCommand(input) {
-      return sandbox.runCommand(input);
-    },
-  };
 }
 
 /** Create one sandbox-backed tool executor facade for the current turn. */
@@ -565,7 +551,7 @@ export function createSandboxExecutor(options?: {
       return SANDBOX_TOOL_NAMES.has(toolName);
     },
     async createSandbox() {
-      return createSandboxWorkspace(await sessionManager.createSandbox());
+      return await sessionManager.createSandbox();
     },
     execute,
     async dispose() {

--- a/packages/junior/src/chat/sandbox/session.ts
+++ b/packages/junior/src/chat/sandbox/session.ts
@@ -103,6 +103,7 @@ export function createSandboxSessionManager(options?: {
   commandEnv?: () => Promise<Record<string, string>>;
   createNetworkPolicy?: (sandboxId: string) => NetworkPolicy | undefined;
   beforeCommand?: (sandboxId: string) => void | Promise<void>;
+  afterCommand?: (sandboxId: string) => void | Promise<void>;
   onSandboxAcquired?: (sandbox: {
     sandboxId: string;
     sandboxDependencyProfileHash?: string;
@@ -583,29 +584,39 @@ export function createSandboxSessionManager(options?: {
     return {
       bash: async (input) => {
         await options?.beforeCommand?.(sandboxInstance.name);
-        const sandboxCommandEnv = await resolveCommandEnv();
-        const script = buildNonInteractiveShellScript(input.command, {
-          env: { ...sandboxCommandEnv, ...(input.env ?? {}) },
-          pathPrefix: `${SANDBOX_RUNTIME_BIN_DIR}:$PATH`,
-        });
-        const controller =
-          input.timeoutMs && input.timeoutMs > 0
-            ? new AbortController()
-            : undefined;
         let timedOut = false;
-        const timeoutId = controller
-          ? setTimeout(() => {
-              timedOut = true;
-              controller.abort();
-            }, input.timeoutMs)
-          : undefined;
+        let timeoutId: ReturnType<typeof setTimeout> | undefined;
+        let commandFinished = false;
+        const finishCommand = async (): Promise<void> => {
+          if (commandFinished) {
+            return;
+          }
+          commandFinished = true;
+          await options?.afterCommand?.(sandboxInstance.name);
+        };
         try {
+          const sandboxCommandEnv = await resolveCommandEnv();
+          const script = buildNonInteractiveShellScript(input.command, {
+            env: { ...sandboxCommandEnv, ...(input.env ?? {}) },
+            pathPrefix: `${SANDBOX_RUNTIME_BIN_DIR}:$PATH`,
+          });
+          const controller =
+            input.timeoutMs && input.timeoutMs > 0
+              ? new AbortController()
+              : undefined;
+          timeoutId = controller
+            ? setTimeout(() => {
+                timedOut = true;
+                controller.abort();
+              }, input.timeoutMs)
+            : undefined;
           const commandResult = await sandboxInstance.runCommand({
             cmd: "bash",
             args: ["-c", script],
             cwd: SANDBOX_WORKSPACE_ROOT,
             ...(controller ? { signal: controller.signal } : {}),
           });
+          await finishCommand();
           return await readCommandOutput(commandResult);
         } catch (error) {
           if (timedOut) {
@@ -623,6 +634,7 @@ export function createSandboxSessionManager(options?: {
           if (timeoutId) {
             clearTimeout(timeoutId);
           }
+          await finishCommand();
         }
       },
       readFile: async (input) =>

--- a/packages/junior/src/chat/sandbox/session.ts
+++ b/packages/junior/src/chat/sandbox/session.ts
@@ -1,7 +1,12 @@
 import { randomUUID } from "node:crypto";
 import { Sandbox, type NetworkPolicy } from "@vercel/sandbox";
 import { createBashTool } from "bash-tool";
-import { setSpanAttributes, withSpan, type LogContext } from "@/chat/logging";
+import {
+  logWarn,
+  setSpanAttributes,
+  withSpan,
+  type LogContext,
+} from "@/chat/logging";
 import { getVercelSandboxCredentials } from "@/chat/sandbox/credentials";
 import {
   isAlreadyExistsError,
@@ -18,9 +23,13 @@ import {
   type RuntimeDependencySnapshot,
 } from "@/chat/sandbox/runtime-dependency-snapshots";
 import { syncSkillsToSandbox } from "@/chat/sandbox/skill-sync";
-import type { SandboxCommandResult } from "@/chat/sandbox/workspace";
+import {
+  createSandboxInstance,
+  type SandboxCommandResult,
+  type SandboxFileSystem,
+  type SandboxInstance,
+} from "@/chat/sandbox/workspace";
 import type { SkillMetadata } from "@/chat/skills";
-import type { SandboxFileSystem } from "@/chat/tools/sandbox/file-utils";
 
 const DEFAULT_MAX_OUTPUT_LENGTH = 30_000;
 const SANDBOX_RUNTIME = "node22";
@@ -56,12 +65,47 @@ interface SandboxToolExecutors {
   fs: SandboxFileSystem;
 }
 
+function createBashToolSandboxAdapter(sandbox: SandboxInstance) {
+  return {
+    async executeCommand(command: string) {
+      const result = await sandbox.runCommand({
+        cmd: "bash",
+        args: ["-c", command],
+      });
+      const [stdout, stderr] = await Promise.all([
+        result.stdout(),
+        result.stderr(),
+      ]);
+      return {
+        stdout,
+        stderr,
+        exitCode: result.exitCode,
+      };
+    },
+    async readFile(filePath: string) {
+      const content = await sandbox.readFileToBuffer({ path: filePath });
+      if (content == null) {
+        throw new Error(`File not found: ${filePath}`);
+      }
+      return content.toString("utf8");
+    },
+    async writeFiles(files: Array<{ path: string; content: string | Buffer }>) {
+      await sandbox.writeFiles(
+        files.map((file) => ({
+          path: file.path,
+          content: file.content,
+        })),
+      );
+    },
+  };
+}
+
 interface SandboxSessionManager {
   configureSkills(skills: SkillMetadata[]): void;
   configureReferenceFiles(files: string[]): void;
   getSandboxId(): string | undefined;
   getDependencyProfileHash(): string | undefined;
-  createSandbox(): Promise<Sandbox>;
+  createSandbox(): Promise<SandboxInstance>;
   ensureToolExecutors(): Promise<SandboxToolExecutors>;
   dispose(): Promise<void>;
 }
@@ -109,7 +153,7 @@ export function createSandboxSessionManager(options?: {
     sandboxDependencyProfileHash?: string;
   }) => void | Promise<void>;
 }): SandboxSessionManager {
-  let sandbox: Sandbox | null = null;
+  let sandbox: SandboxInstance | null = null;
   let sandboxIdHint = options?.sandboxId;
   let availableSkills: SkillMetadata[] = [];
   let availableReferenceFiles: string[] = [];
@@ -149,11 +193,11 @@ export function createSandboxSessionManager(options?: {
   };
 
   const rememberSandbox = async (
-    nextSandbox: Sandbox,
+    nextSandbox: SandboxInstance,
     rememberOptions?: { recordNetworkPolicy?: boolean },
-  ): Promise<Sandbox> => {
+  ): Promise<SandboxInstance> => {
     sandbox = nextSandbox;
-    sandboxIdHint = nextSandbox.name;
+    sandboxIdHint = nextSandbox.sandboxId;
     toolExecutors = undefined;
     const acquired = {
       sandboxId: sandboxIdHint,
@@ -163,7 +207,9 @@ export function createSandboxSessionManager(options?: {
     };
     await options?.onSandboxAcquired?.(acquired);
     if (rememberOptions?.recordNetworkPolicy) {
-      rememberNetworkPolicy(options?.createNetworkPolicy?.(nextSandbox.name));
+      rememberNetworkPolicy(
+        options?.createNetworkPolicy?.(nextSandbox.sandboxId),
+      );
     }
     return nextSandbox;
   };
@@ -172,7 +218,7 @@ export function createSandboxSessionManager(options?: {
     throw wrapSandboxSetupError(error);
   };
 
-  const syncSkills = async (targetSandbox: Sandbox): Promise<void> => {
+  const syncSkills = async (targetSandbox: SandboxInstance): Promise<void> => {
     await syncSkillsToSandbox({
       sandbox: targetSandbox,
       skills: availableSkills,
@@ -183,9 +229,11 @@ export function createSandboxSessionManager(options?: {
   };
 
   const refreshNetworkPolicy = async (
-    targetSandbox: Sandbox,
+    targetSandbox: SandboxInstance,
   ): Promise<void> => {
-    const networkPolicy = options?.createNetworkPolicy?.(targetSandbox.name);
+    const networkPolicy = options?.createNetworkPolicy?.(
+      targetSandbox.sandboxId,
+    );
     if (!networkPolicy) {
       return;
     }
@@ -209,7 +257,7 @@ export function createSandboxSessionManager(options?: {
   };
 
   const ensureSandboxReachable = async (
-    targetSandbox: Sandbox,
+    targetSandbox: SandboxInstance,
     source: "memory" | "id_hint",
   ): Promise<void> => {
     await withSandboxSpan(
@@ -233,7 +281,7 @@ export function createSandboxSessionManager(options?: {
 
   const recreateUnavailableSandbox = async (
     source: "memory" | "id_hint",
-  ): Promise<Sandbox> => {
+  ): Promise<SandboxInstance> => {
     setSpanAttributes({
       "app.sandbox.recovery.attempted": true,
       "app.sandbox.recovery.source": source,
@@ -250,23 +298,25 @@ export function createSandboxSessionManager(options?: {
     snapshotId: string,
     sandboxCredentials: SandboxCredentials | undefined,
     initialSandboxName: string,
-  ): Promise<Sandbox> => {
+  ): Promise<SandboxInstance> => {
     for (let attempt = 0; attempt < SNAPSHOT_BOOT_RETRY_COUNT; attempt += 1) {
       const sandboxName =
         attempt === 0 ? initialSandboxName : createSandboxName();
       const networkPolicy = options?.createNetworkPolicy?.(sandboxName);
       try {
-        return await Sandbox.create({
-          timeout: timeoutMs,
-          ...(networkPolicy
-            ? { name: sandboxName, persistent: false, networkPolicy }
-            : {}),
-          source: {
-            type: "snapshot",
-            snapshotId,
-          },
-          ...(sandboxCredentials ?? {}),
-        } as Parameters<typeof Sandbox.create>[0]);
+        return createSandboxInstance(
+          await Sandbox.create({
+            timeout: timeoutMs,
+            ...(networkPolicy
+              ? { name: sandboxName, persistent: false, networkPolicy }
+              : {}),
+            source: {
+              type: "snapshot",
+              snapshotId,
+            },
+            ...(sandboxCredentials ?? {}),
+          } as Parameters<typeof Sandbox.create>[0]),
+        );
       } catch (error) {
         if (
           !isSnapshottingError(error) ||
@@ -305,19 +355,21 @@ export function createSandboxSessionManager(options?: {
     snapshot: RuntimeDependencySnapshot;
     sandboxCredentials: SandboxCredentials | undefined;
     sandboxName: string;
-  }): Promise<Sandbox> => {
+  }): Promise<SandboxInstance> => {
     const { runtime, snapshot, sandboxCredentials, sandboxName } = params;
 
     if (!snapshot.snapshotId) {
       const networkPolicy = options?.createNetworkPolicy?.(sandboxName);
-      return await Sandbox.create({
-        timeout: timeoutMs,
-        runtime,
-        ...(networkPolicy
-          ? { name: sandboxName, persistent: false, networkPolicy }
-          : {}),
-        ...(sandboxCredentials ?? {}),
-      } as Parameters<typeof Sandbox.create>[0]);
+      return createSandboxInstance(
+        await Sandbox.create({
+          timeout: timeoutMs,
+          runtime,
+          ...(networkPolicy
+            ? { name: sandboxName, persistent: false, networkPolicy }
+            : {}),
+          ...(sandboxCredentials ?? {}),
+        } as Parameters<typeof Sandbox.create>[0]),
+      );
     }
 
     try {
@@ -352,12 +404,12 @@ export function createSandboxSessionManager(options?: {
     }
   };
 
-  const createFreshSandbox = async (): Promise<Sandbox> => {
+  const createFreshSandbox = async (): Promise<SandboxInstance> => {
     const runtime = SANDBOX_RUNTIME;
     const sandboxCredentials = getVercelSandboxCredentials();
     const sandboxName = createSandboxName();
 
-    let createdSandbox: Sandbox;
+    let createdSandbox: SandboxInstance;
     try {
       createdSandbox = await withSandboxSpan(
         "sandbox.create",
@@ -419,7 +471,7 @@ export function createSandboxSessionManager(options?: {
     sandboxIdHint = undefined;
   };
 
-  const tryReuseCachedSandbox = async (): Promise<Sandbox | null> => {
+  const tryReuseCachedSandbox = async (): Promise<SandboxInstance | null> => {
     const cachedSandbox = sandbox;
     if (!cachedSandbox) {
       return null;
@@ -437,12 +489,12 @@ export function createSandboxSessionManager(options?: {
     }
   };
 
-  const tryRestoreHintedSandbox = async (): Promise<Sandbox | null> => {
+  const tryRestoreHintedSandbox = async (): Promise<SandboxInstance | null> => {
     if (!sandboxIdHint) {
       return null;
     }
 
-    let hintedSandbox: Sandbox | null = null;
+    let hintedSandbox: SandboxInstance | null = null;
     try {
       const sandboxCredentials = getVercelSandboxCredentials();
       hintedSandbox = await withSandboxSpan(
@@ -453,11 +505,13 @@ export function createSandboxSessionManager(options?: {
           "app.sandbox.source": "id_hint",
         },
         async () =>
-          await Sandbox.get({
-            name: sandboxIdHint as string,
-            resume: true,
-            ...(sandboxCredentials ?? {}),
-          } as Parameters<typeof Sandbox.get>[0]),
+          createSandboxInstance(
+            await Sandbox.get({
+              name: sandboxIdHint as string,
+              resume: true,
+              ...(sandboxCredentials ?? {}),
+            } as Parameters<typeof Sandbox.get>[0]),
+          ),
       );
     } catch {
       return null;
@@ -475,7 +529,7 @@ export function createSandboxSessionManager(options?: {
     }
   };
 
-  const acquireSandbox = async (): Promise<Sandbox> => {
+  const acquireSandbox = async (): Promise<SandboxInstance> => {
     return await withSandboxSpan(
       "sandbox.acquire",
       "sandbox.acquire",
@@ -536,7 +590,9 @@ export function createSandboxSessionManager(options?: {
     };
   };
 
-  const extendKeepAlive = async (activeSandbox: Sandbox): Promise<void> => {
+  const extendKeepAlive = async (
+    activeSandbox: SandboxInstance,
+  ): Promise<void> => {
     const keepAliveMs = parseKeepAliveMs();
     if (keepAliveMs === 0) {
       return;
@@ -559,8 +615,9 @@ export function createSandboxSessionManager(options?: {
   };
 
   const buildToolExecutors = async (
-    sandboxInstance: Sandbox,
+    sandboxInstance: SandboxInstance,
   ): Promise<SandboxToolExecutors> => {
+    const activeSandboxId = sandboxInstance.sandboxId;
     const toolkit = await withSandboxSpan(
       "sandbox.bash_tool.init",
       "sandbox.tool.init",
@@ -570,7 +627,7 @@ export function createSandboxSessionManager(options?: {
       },
       async () =>
         await createBashTool({
-          sandbox: sandboxInstance,
+          sandbox: createBashToolSandboxAdapter(sandboxInstance),
           destination: SANDBOX_WORKSPACE_ROOT,
         }),
     );
@@ -583,7 +640,7 @@ export function createSandboxSessionManager(options?: {
 
     return {
       bash: async (input) => {
-        await options?.beforeCommand?.(sandboxInstance.name);
+        await options?.beforeCommand?.(activeSandboxId);
         let timedOut = false;
         let timeoutId: ReturnType<typeof setTimeout> | undefined;
         let commandFinished = false;
@@ -592,7 +649,25 @@ export function createSandboxSessionManager(options?: {
             return;
           }
           commandFinished = true;
-          await options?.afterCommand?.(sandboxInstance.name);
+          await options?.afterCommand?.(activeSandboxId);
+        };
+        const finishCommandBestEffort = async (): Promise<void> => {
+          try {
+            await finishCommand();
+          } catch (error) {
+            logWarn(
+              "sandbox_command_cleanup_failed",
+              traceContext,
+              {
+                "app.sandbox.id": activeSandboxId,
+                "error.type":
+                  error instanceof Error
+                    ? error.name
+                    : "sandbox_command_cleanup_error",
+              },
+              "Sandbox command cleanup failed",
+            );
+          }
         };
         try {
           const sandboxCommandEnv = await resolveCommandEnv();
@@ -616,7 +691,7 @@ export function createSandboxSessionManager(options?: {
             cwd: SANDBOX_WORKSPACE_ROOT,
             ...(controller ? { signal: controller.signal } : {}),
           });
-          await finishCommand();
+          await finishCommandBestEffort();
           return await readCommandOutput(commandResult);
         } catch (error) {
           if (timedOut) {
@@ -634,7 +709,7 @@ export function createSandboxSessionManager(options?: {
           if (timeoutId) {
             clearTimeout(timeoutId);
           }
-          await finishCommand();
+          await finishCommandBestEffort();
         }
       },
       readFile: async (input) =>
@@ -651,14 +726,14 @@ export function createSandboxSessionManager(options?: {
     };
   };
 
-  const ensureReadySandbox = async (): Promise<Sandbox> => {
+  const ensureReadySandbox = async (): Promise<SandboxInstance> => {
     const activeSandbox = await acquireSandbox();
     await extendKeepAlive(activeSandbox);
     return activeSandbox;
   };
 
   const loadToolExecutors = async (
-    activeSandbox: Sandbox,
+    activeSandbox: SandboxInstance,
   ): Promise<SandboxToolExecutors> => {
     if (toolExecutors) {
       return toolExecutors;
@@ -676,7 +751,7 @@ export function createSandboxSessionManager(options?: {
       availableReferenceFiles = [...files];
     },
     getSandboxId() {
-      return sandbox ? sandbox.name : sandboxIdHint;
+      return sandbox ? sandbox.sandboxId : sandboxIdHint;
     },
     getDependencyProfileHash() {
       return dependencyProfileHash;

--- a/packages/junior/src/chat/sandbox/skill-sync.ts
+++ b/packages/junior/src/chat/sandbox/skill-sync.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { Sandbox } from "@vercel/sandbox";
 import { buildEvalGitHubCliStub } from "@/chat/sandbox/eval-gh-stub";
 import { buildEvalOauthCliStub } from "@/chat/sandbox/eval-oauth-stub";
 import { buildEvalSentryCliStub } from "@/chat/sandbox/eval-sentry-stub";
@@ -15,6 +14,7 @@ import {
   isAlreadyExistsError,
   throwSandboxOperationError,
 } from "@/chat/sandbox/errors";
+import type { SandboxInstance } from "@/chat/sandbox/workspace";
 import type { SkillMetadata } from "@/chat/skills";
 
 interface SkillSyncFile {
@@ -220,7 +220,7 @@ export function isHostFileMissingError(error: unknown): boolean {
 
 /** Copy the current skill set and reference files into a sandbox and mark runtime shims executable. */
 export async function syncSkillsToSandbox(params: {
-  sandbox: Sandbox;
+  sandbox: SandboxInstance;
   skills: SkillMetadata[];
   referenceFiles?: string[];
   withSpan: <T>(

--- a/packages/junior/src/chat/sandbox/workspace.ts
+++ b/packages/junior/src/chat/sandbox/workspace.ts
@@ -1,15 +1,92 @@
+import type { NetworkPolicy, Sandbox as VercelSandbox } from "@vercel/sandbox";
+
 export interface SandboxCommandResult {
   exitCode: number;
   stderr(): Promise<string>;
   stdout(): Promise<string>;
 }
 
+export interface SandboxCommandInput {
+  args?: string[];
+  cmd: string;
+  cwd?: string;
+  env?: Record<string, string>;
+  signal?: AbortSignal;
+  sudo?: boolean;
+}
+
+export interface SandboxFileStat {
+  isDirectory(): boolean;
+}
+
+export interface SandboxFileSystem {
+  readFile(
+    filePath: string,
+    options: { encoding: BufferEncoding },
+  ): Promise<string>;
+  writeFile(
+    filePath: string,
+    content: string,
+    options?: { encoding?: BufferEncoding },
+  ): Promise<void>;
+  readdir(filePath: string): Promise<string[]>;
+  stat(filePath: string): Promise<SandboxFileStat>;
+}
+
 export interface SandboxWorkspace {
-  readonly sandboxId?: string;
-  readFileToBuffer(input: { path: string }): Promise<Buffer | null | undefined>;
-  runCommand(input: {
-    args?: string[];
-    cmd: string;
+  readFileToBuffer(input: {
     cwd?: string;
-  }): Promise<SandboxCommandResult>;
+    path: string;
+  }): Promise<Buffer | null | undefined>;
+  runCommand(input: SandboxCommandInput): Promise<SandboxCommandResult>;
+}
+
+export interface SandboxInstance extends SandboxWorkspace {
+  readonly sandboxId: string;
+  readonly fs: SandboxFileSystem;
+  extendTimeout(duration: number): Promise<void>;
+  mkDir(path: string): Promise<void>;
+  snapshot(): Promise<{ snapshotId: string }>;
+  stop(): Promise<unknown>;
+  update(params: { networkPolicy?: NetworkPolicy }): Promise<void>;
+  writeFiles(
+    files: Array<{
+      content: string | Uint8Array;
+      mode?: number;
+      path: string;
+    }>,
+  ): Promise<void>;
+}
+
+/** Adapt the Vercel SDK object once so the rest of Junior sees one sandbox contract. */
+export function createSandboxInstance(sandbox: VercelSandbox): SandboxInstance {
+  return {
+    sandboxId: sandbox.name,
+    fs: sandbox.fs as SandboxFileSystem,
+    extendTimeout(duration) {
+      return sandbox.extendTimeout(duration);
+    },
+    mkDir(path) {
+      return sandbox.mkDir(path);
+    },
+    readFileToBuffer(input) {
+      return sandbox.readFileToBuffer(input);
+    },
+    runCommand(input) {
+      return sandbox.runCommand(input);
+    },
+    async snapshot() {
+      const snapshot = await sandbox.snapshot();
+      return { snapshotId: snapshot.snapshotId };
+    },
+    stop() {
+      return sandbox.stop();
+    },
+    update(params) {
+      return sandbox.update(params);
+    },
+    writeFiles(files) {
+      return sandbox.writeFiles(files);
+    },
+  };
 }

--- a/packages/junior/src/chat/tools/sandbox/file-utils.ts
+++ b/packages/junior/src/chat/tools/sandbox/file-utils.ts
@@ -1,26 +1,11 @@
 import path from "node:path";
 import { SANDBOX_WORKSPACE_ROOT } from "@/chat/sandbox/paths";
+import type { SandboxFileSystem } from "@/chat/sandbox/workspace";
+
+export type { SandboxFileSystem };
 
 export const MAX_TEXT_CHARS = 60_000;
 const SKIPPED_DIRECTORIES = new Set([".git", "node_modules"]);
-
-interface SandboxFileStat {
-  isDirectory(): boolean;
-}
-
-export interface SandboxFileSystem {
-  readFile(
-    filePath: string,
-    options: { encoding: BufferEncoding },
-  ): Promise<string>;
-  writeFile(
-    filePath: string,
-    content: string,
-    options?: { encoding?: BufferEncoding },
-  ): Promise<void>;
-  readdir(filePath: string): Promise<string[]>;
-  stat(filePath: string): Promise<SandboxFileStat>;
-}
 
 export interface TextSearchResultDetails {
   ok: true;

--- a/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
@@ -358,6 +358,58 @@ describe("sandbox egress proxy", () => {
     });
   });
 
+  it("does not reuse cached credential leases across renewed egress sessions", async () => {
+    await authorizeSandboxEgress();
+    issueProviderCredentialLeaseMock
+      .mockResolvedValueOnce({
+        id: "lease-1",
+        provider: "sentry",
+        env: { SENTRY_AUTH_TOKEN: "host_managed_credential" },
+        headerTransforms: [
+          {
+            domain: "sentry.io",
+            headers: { Authorization: "Bearer token-first-session" },
+          },
+        ],
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      })
+      .mockResolvedValueOnce({
+        id: "lease-2",
+        provider: "sentry",
+        env: { SENTRY_AUTH_TOKEN: "host_managed_credential" },
+        headerTransforms: [
+          {
+            domain: "sentry.io",
+            headers: { Authorization: "Bearer token-second-session" },
+          },
+        ],
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      });
+
+    const fetchMock = vi.fn(async (_url: URL | string, init?: RequestInit) => {
+      return new Response(new Headers(init?.headers).get("authorization"));
+    });
+
+    const firstResponse = await proxy(
+      egressRequest({ path: "/api/0/issues/1" }),
+      fetchMock as typeof fetch,
+    );
+    await expect(firstResponse.text()).resolves.toBe(
+      "Bearer token-first-session",
+    );
+
+    await authorizeSandboxEgress();
+    const secondResponse = await proxy(
+      egressRequest({ path: "/api/0/issues/2" }),
+      fetchMock as typeof fetch,
+    );
+    await expect(secondResponse.text()).resolves.toBe(
+      "Bearer token-second-session",
+    );
+
+    expect(issueProviderCredentialLeaseMock).toHaveBeenCalledTimes(2);
+  });
+
   it("clears cached credential leases after upstream auth rejection", async () => {
     await authorizeSandboxEgress();
     issueProviderCredentialLeaseMock

--- a/packages/junior/tests/unit/misc/bash-tool-sandbox-adapter.test.ts
+++ b/packages/junior/tests/unit/misc/bash-tool-sandbox-adapter.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { sandboxGetMock } = vi.hoisted(() => ({
+  sandboxGetMock: vi.fn(),
+}));
+
+vi.mock("@vercel/sandbox", () => ({
+  Sandbox: {
+    get: sandboxGetMock,
+  },
+}));
+
+import { createSandboxSessionManager } from "@/chat/sandbox/session";
+
+function makeSandbox() {
+  return {
+    name: "sbx_adapter_contract",
+    mkDir: vi.fn(async () => {}),
+    writeFiles: vi.fn(async () => {}),
+    readFileToBuffer: vi.fn(async () => Buffer.from("file content")),
+    runCommand: vi.fn(async (params: { cmd: string; args?: string[] }) => ({
+      exitCode: 0,
+      stdout: async () =>
+        params.cmd === "bash" &&
+        params.args?.[0] === "-c" &&
+        params.args[1]?.startsWith("ls /usr/bin")
+          ? "grep\nsed\ncat\n"
+          : "command stdout",
+      stderr: async () => "",
+    })),
+    stop: vi.fn(async () => {}),
+    extendTimeout: vi.fn(async () => {}),
+    snapshot: vi.fn(async () => ({ snapshotId: "snap_adapter_contract" })),
+    update: vi.fn(async () => {}),
+    fs: {},
+  };
+}
+
+describe("bash-tool sandbox adapter", () => {
+  beforeEach(() => {
+    sandboxGetMock.mockReset();
+  });
+
+  it("lets real bash-tool initialize against Vercel Sandbox v2 shape", async () => {
+    const sandbox = makeSandbox();
+    sandboxGetMock.mockResolvedValue(sandbox);
+    const manager = createSandboxSessionManager({
+      sandboxId: "sbx_adapter_contract",
+    });
+
+    const executors = await manager.ensureToolExecutors();
+
+    expect(sandbox.runCommand).toHaveBeenCalledWith({
+      cmd: "bash",
+      args: ["-c", expect.stringContaining("ls /usr/bin")],
+    });
+    await expect(executors.readFile({ path: "file.txt" })).resolves.toEqual({
+      content: "file content",
+    });
+    await expect(
+      executors.writeFile({ path: "out.txt", content: "written" }),
+    ).resolves.toEqual({ success: true });
+
+    expect(sandbox.readFileToBuffer).toHaveBeenCalledWith({
+      path: "/vercel/sandbox/file.txt",
+    });
+    expect(sandbox.writeFiles).toHaveBeenCalledWith([
+      {
+        path: "/vercel/sandbox/out.txt",
+        content: "written",
+      },
+    ]);
+  });
+});

--- a/packages/junior/tests/unit/misc/sandbox-executor.test.ts
+++ b/packages/junior/tests/unit/misc/sandbox-executor.test.ts
@@ -527,6 +527,64 @@ describe("createSandboxExecutor", () => {
     );
   });
 
+  it("runs sandbox command hooks around each bash command", async () => {
+    const sandbox = makeSandbox("sbx_command_hooks");
+    sandboxGetMock.mockResolvedValue(sandbox);
+    vi.mocked(createBashTool).mockResolvedValue({
+      tools: {
+        readFile: { execute: vi.fn(async () => ({ content: "" })) },
+        writeFile: { execute: vi.fn(async () => ({ success: true })) },
+      },
+    } as never);
+    const beforeCommand = vi.fn();
+    const afterCommand = vi.fn();
+
+    const manager = createSandboxSessionManager({
+      sandboxId: "sbx_command_hooks",
+      beforeCommand,
+      afterCommand,
+    });
+    const bash = (await manager.ensureToolExecutors()).bash;
+
+    await bash({ command: "echo ok" });
+
+    expect(beforeCommand).toHaveBeenCalledWith("sbx_command_hooks");
+    expect(afterCommand).toHaveBeenCalledWith("sbx_command_hooks");
+    expect(beforeCommand.mock.invocationCallOrder[0]).toBeLessThan(
+      sandbox.runCommand.mock.invocationCallOrder[0] as number,
+    );
+    expect(afterCommand.mock.invocationCallOrder[0]).toBeGreaterThan(
+      sandbox.runCommand.mock.invocationCallOrder[0] as number,
+    );
+  });
+
+  it("clears sandbox command hooks when command env resolution fails", async () => {
+    const sandbox = makeSandbox("sbx_command_env_failure");
+    sandboxGetMock.mockResolvedValue(sandbox);
+    vi.mocked(createBashTool).mockResolvedValue({
+      tools: {
+        readFile: { execute: vi.fn(async () => ({ content: "" })) },
+        writeFile: { execute: vi.fn(async () => ({ success: true })) },
+      },
+    } as never);
+    const afterCommand = vi.fn();
+
+    const manager = createSandboxSessionManager({
+      sandboxId: "sbx_command_env_failure",
+      beforeCommand: vi.fn(),
+      afterCommand,
+      commandEnv: vi.fn(async () => {
+        throw new Error("env failed");
+      }),
+    });
+    const bash = (await manager.ensureToolExecutors()).bash;
+
+    await expect(bash({ command: "echo ok" })).rejects.toThrow("env failed");
+
+    expect(afterCommand).toHaveBeenCalledWith("sbx_command_env_failure");
+    expect(sandbox.runCommand).not.toHaveBeenCalled();
+  });
+
   it("routes matching bash commands through custom command handler", async () => {
     const sandbox = makeSandbox("sbx_custom");
     sandboxGetMock.mockResolvedValue(sandbox);

--- a/packages/junior/tests/unit/misc/sandbox-executor.test.ts
+++ b/packages/junior/tests/unit/misc/sandbox-executor.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SANDBOX_WORKSPACE_ROOT, sandboxSkillDir } from "@/chat/sandbox/paths";
-import type { SandboxWorkspace } from "@/chat/sandbox/workspace";
+import type { SandboxInstance } from "@/chat/sandbox/workspace";
 
 const { sandboxGetMock, sandboxCreateMock } = vi.hoisted(() => ({
   sandboxGetMock: vi.fn(),
@@ -58,12 +58,19 @@ import { createBashTool } from "bash-tool";
 
 interface MockSandbox {
   name: string;
+  fs: {
+    readFile: ReturnType<typeof vi.fn>;
+    writeFile: ReturnType<typeof vi.fn>;
+    readdir: ReturnType<typeof vi.fn>;
+    stat: ReturnType<typeof vi.fn>;
+  };
   mkDir: ReturnType<typeof vi.fn>;
   writeFiles: ReturnType<typeof vi.fn>;
   readFileToBuffer: ReturnType<typeof vi.fn>;
   runCommand: ReturnType<typeof vi.fn>;
   stop: ReturnType<typeof vi.fn>;
   extendTimeout: ReturnType<typeof vi.fn>;
+  snapshot: ReturnType<typeof vi.fn>;
   update: ReturnType<typeof vi.fn>;
 }
 
@@ -76,6 +83,12 @@ function makeSandbox(
 ): MockSandbox {
   return {
     name,
+    fs: {
+      readFile: vi.fn(async () => ""),
+      writeFile: vi.fn(async () => {}),
+      readdir: vi.fn(async () => []),
+      stat: vi.fn(async () => ({ isDirectory: () => false })),
+    },
     mkDir: vi.fn(async () => {
       if (options.mkDirError) {
         throw options.mkDirError;
@@ -94,6 +107,7 @@ function makeSandbox(
     })),
     stop: vi.fn(async () => {}),
     extendTimeout: vi.fn(async () => {}),
+    snapshot: vi.fn(async () => ({ snapshotId: "snap_test" })),
     update: vi.fn(async () => {}),
   };
 }
@@ -124,7 +138,7 @@ function createApiError(
 }
 
 async function expectWorkspaceToDelegate(
-  workspace: SandboxWorkspace,
+  workspace: SandboxInstance,
   sandbox: MockSandbox,
 ): Promise<void> {
   expect(workspace.sandboxId).toBe(sandbox.name);
@@ -583,6 +597,41 @@ describe("createSandboxExecutor", () => {
 
     expect(afterCommand).toHaveBeenCalledWith("sbx_command_env_failure");
     expect(sandbox.runCommand).not.toHaveBeenCalled();
+  });
+
+  it("does not mask command timeout results when command cleanup fails", async () => {
+    const sandbox = makeSandbox("sbx_timeout_cleanup_failure");
+    sandbox.runCommand.mockImplementation(
+      async (input: { signal?: AbortSignal }) =>
+        await new Promise((_resolve, reject) => {
+          input.signal?.addEventListener("abort", () => {
+            reject(new Error("aborted"));
+          });
+        }),
+    );
+    sandboxGetMock.mockResolvedValue(sandbox);
+    vi.mocked(createBashTool).mockResolvedValue({
+      tools: {
+        readFile: { execute: vi.fn(async () => ({ content: "" })) },
+        writeFile: { execute: vi.fn(async () => ({ success: true })) },
+      },
+    } as never);
+
+    const manager = createSandboxSessionManager({
+      sandboxId: "sbx_timeout_cleanup_failure",
+      afterCommand: vi.fn(async () => {
+        throw new Error("cleanup failed");
+      }),
+    });
+    const bash = (await manager.ensureToolExecutors()).bash;
+
+    await expect(
+      bash({ command: "sleep 10", timeoutMs: 1 }),
+    ).resolves.toMatchObject({
+      exitCode: 124,
+      timedOut: true,
+      stderr: "Command timed out after 1ms",
+    });
   });
 
   it("routes matching bash commands through custom command handler", async () => {

--- a/packages/junior/tests/unit/plugins/plugin-manifest-api-headers.test.ts
+++ b/packages/junior/tests/unit/plugins/plugin-manifest-api-headers.test.ts
@@ -148,6 +148,101 @@ describe("plugin manifest API headers", () => {
     });
   });
 
+  it("rejects unknown env var declaration fields", () => {
+    expect(() =>
+      parsePluginManifest(
+        [
+          "name: example",
+          "description: Example API access",
+          "env-vars:",
+          "  EXAMPLE_BOT_EMAIL:",
+          "    expose-to-command-env: true",
+          "credentials:",
+          "  type: oauth-bearer",
+          "  domains:",
+          "    - api.example.com",
+          "  auth-token-env: EXAMPLE_TOKEN",
+          "command-env:",
+          '  GIT_AUTHOR_EMAIL: "${EXAMPLE_BOT_EMAIL}"',
+        ].join("\n"),
+        "/tmp/example",
+      ),
+    ).toThrow("Plugin example env-vars.EXAMPLE_BOT_EMAIL");
+  });
+
+  it("rejects command env references that reuse API header env vars", () => {
+    expect(() =>
+      parsePluginManifest(
+        [
+          "name: example",
+          "description: Example API access",
+          "env-vars:",
+          "  EXAMPLE_AUTH_HEADER:",
+          "domains:",
+          "  - api.example.com",
+          "api-headers:",
+          '  Authorization: "${EXAMPLE_AUTH_HEADER}"',
+          "command-env:",
+          '  EXAMPLE_TOKEN: "${EXAMPLE_AUTH_HEADER}"',
+        ].join("\n"),
+        "/tmp/example",
+      ),
+    ).toThrow(
+      "Plugin example command-env.EXAMPLE_TOKEN references env var EXAMPLE_AUTH_HEADER, but credential/API header env vars must stay host-only",
+    );
+  });
+
+  it("rejects command env references that reuse credential env vars", () => {
+    expect(() =>
+      parsePluginManifest(
+        [
+          "name: example",
+          "description: Example API access",
+          "env-vars:",
+          "  EXAMPLE_TOKEN:",
+          "credentials:",
+          "  type: oauth-bearer",
+          "  domains:",
+          "    - api.example.com",
+          "  auth-token-env: EXAMPLE_TOKEN",
+          "command-env:",
+          '  EXAMPLE_TOKEN: "${EXAMPLE_TOKEN}"',
+        ].join("\n"),
+        "/tmp/example",
+      ),
+    ).toThrow(
+      "Plugin example command-env.EXAMPLE_TOKEN references env var EXAMPLE_TOKEN, but credential/API header env vars must stay host-only",
+    );
+  });
+
+  it("rejects command env references that reuse OAuth env vars", () => {
+    expect(() =>
+      parsePluginManifest(
+        [
+          "name: example",
+          "description: Example API access",
+          "env-vars:",
+          "  EXAMPLE_CLIENT_SECRET:",
+          "credentials:",
+          "  type: oauth-bearer",
+          "  domains:",
+          "    - api.example.com",
+          "  auth-token-env: EXAMPLE_TOKEN",
+          "oauth:",
+          "  client-id-env: EXAMPLE_CLIENT_ID",
+          "  client-secret-env: EXAMPLE_CLIENT_SECRET",
+          "  authorize-endpoint: https://example.com/oauth/authorize",
+          "  token-endpoint: https://example.com/oauth/token",
+          "command-env:",
+          '  EXAMPLE_SECRET: "${EXAMPLE_CLIENT_SECRET}"',
+        ].join("\n"),
+        "/tmp/example",
+      ),
+    ).toThrow(
+      "Plugin example command-env.EXAMPLE_SECRET references env var EXAMPLE_CLIENT_SECRET, but credential/API header env vars must stay host-only",
+    );
+  });
+
   it("rejects command env without credentials or API headers", () => {
     expect(() =>
       parsePluginManifest(

--- a/specs/oauth-flows-spec.md
+++ b/specs/oauth-flows-spec.md
@@ -199,7 +199,7 @@ Providers define OAuth through plugin manifests:
 - The runtime must not post the authorization URL into the public thread or add a second public thread note just to announce that a private link was sent.
 - Authorization URLs are never returned to the model.
 - Tokens are stored server-side and never appear in sandbox files or model-visible tool arguments.
-- Leases are requester-bound and turn-scoped.
+- Leases are requester-bound; sandbox egress leases are scoped to one command activation.
 - Target-aware providers may narrow leases to repo/project/org scope when available.
 
 ## Disconnect behavior

--- a/specs/plugin-spec.md
+++ b/specs/plugin-spec.md
@@ -298,6 +298,9 @@ Placeholder references without defaults are copied from host env at command-env
 resolution time and are skipped when unset.
 Use `api-headers` for secret-bearing provider values and `command-env` only
 for placeholders, defaults, or public install metadata safe to expose.
+`command-env` placeholders must not reference env vars used by plugin-level
+`api-headers`, credential config, or OAuth config; those env vars stay
+host-only.
 
 ```yaml
 env-vars:

--- a/specs/security-policy.md
+++ b/specs/security-policy.md
@@ -32,7 +32,7 @@ This policy applies to:
 
 - Production should use explicit network policy and minimal allowlists.
 - Credential-capable provider domains should route through the Junior sandbox egress proxy instead of receiving long-lived sandbox secrets.
-- Proxied sandbox egress requests must verify Vercel Sandbox OIDC audience from trusted deployment configuration, project, and sandbox claims, resolve the provider from the forwarded host, and require a requester-bound sandbox egress session.
+- Proxied sandbox egress requests must verify Vercel Sandbox OIDC audience from trusted deployment configuration, project, and sandbox claims, resolve the provider from the forwarded host, and require a requester-bound sandbox egress session. Egress sessions are command-scoped, and cached provider leases must be scoped to one session activation.
 - The public egress route must verify Vercel Sandbox OIDC before returning configuration, provider, or session-specific responses.
 - The egress proxy must not reject duplicate method/URL/body requests as replay; duplicate request shapes can be legitimate retries. Requester-bound credential issuance is the security boundary.
 
@@ -55,13 +55,13 @@ This policy applies to:
 ### Issuance and injection
 
 - Runtime issues short-lived provider credentials when sandbox traffic reaches a registered provider domain.
-- Registered plugin provider declarations determine which provider credentials may be injected into a turn.
+- Registered plugin provider declarations determine which provider credentials may be injected into a sandbox command.
 - A registered provider authorizes its declared domains for sandbox egress; registration must not mint credentials by itself.
 - Credential issuance for user-owned provider access must be requester-bound; runtime paths without requester context must fail instead of issuing reusable credentials.
-- Even for host-managed integrations, credentials are activated only inside the requesting turn and must not carry over to later turns or different message authors.
+- Even for host-managed integrations, sandbox credentials are activated only inside the requesting command and must not carry over to later commands or different message authors.
 - Real provider secrets are delivered exclusively via host-level header transforms — the host proxies auth headers for matching provider domains (e.g. `Authorization` for `api.github.com`/`sentry.io` or provider-specific API key headers). The sandbox never sees real secret values.
 - When CLI tools require tool-native sandbox auth env vars (for example `SENTRY_AUTH_TOKEN`, Pup's `DD_API_KEY`, or Pup's `DD_APP_KEY`), set them to non-secret placeholders so the tool proceeds to make HTTP requests. Placeholder values may be provider-specific via plugin manifest config. The host authenticates those requests via header transforms.
-- Plugin-declared command env may include non-secret placeholders, default-backed deployment values, and explicit non-secret host env bindings needed by the command process. It must not read or expose secret deployment env vars.
+- Plugin-declared command env may include non-secret placeholders, default-backed deployment values, and explicit non-secret host env bindings needed by the command process. It must not read or expose env vars used by API headers, credential config, OAuth config, or other secret deployment values.
 - Never inject real provider secrets into sandbox env vars, files, or command arguments.
 
 ### GitHub baseline

--- a/specs/skill-capabilities-spec.md
+++ b/specs/skill-capabilities-spec.md
@@ -36,7 +36,7 @@ Define how Junior maps registered plugin provider domains to host-managed creden
 2. Skills do not declare capabilities or config keys.
 3. Registered providers are always available to sandbox commands.
 4. The agent runs the real provider command.
-5. The runtime resolves the provider from the outgoing request host, issues a provider lease, and injects credentials for that request only.
+5. The runtime resolves the provider from the outgoing request host, issues a command-scoped provider lease, and injects credentials for that request only.
 6. If auth is missing or stale, the proxy returns a command-readable auth-required response and the command failure path starts a private OAuth flow, then resumes the paused turn after authorization.
 7. Plugin manifests own runtime setup. Skills do not instruct the agent to install packages, bootstrap CLIs, configure provider credentials, command env, or MCP servers.
 
@@ -96,7 +96,7 @@ Rules:
 - The egress route must reject forwarded hosts that do not match a registered provider domain.
 - The proxy must not use method/URL/body-only replay fingerprints as an authorization boundary because duplicate request shapes can be legitimate client retries.
 - The proxy must strip hop-by-hop and proxy-control headers before sending the upstream request.
-- Sandbox-supplied request headers and upstream response state may pass through once Vercel OIDC, requester-bound session state, and provider-domain ownership have been verified.
+- Sandbox-supplied request headers and upstream response state may pass through once Vercel OIDC, command-scoped requester session state, and provider-domain ownership have been verified.
 
 ### Runtime setup boundary
 


### PR DESCRIPTION
Fixes the sandbox egress follow-ups from #338 after staging exposed two issues: egress credentials were wider than command scope, and bash-tool was receiving the Vercel Sandbox v2 SDK object directly. The PR scopes credential activation to one command and adapts Vercel Sandbox behind Junior's internal sandbox contract.

**Sandbox Contract**

Vercel SDK objects are adapted once in `sandbox/workspace.ts`. Session, skill sync, snapshot, and noninteractive command code consume `SandboxInstance`; tool-facing code gets the narrower `SandboxWorkspace`. The bash-tool `executeCommand` bridge is isolated at that package boundary.

**Command-scoped Egress**

Each bash command gets a fresh requester-bound egress activation, cached leases are tied to that activation, and the session is cleared when command execution finishes. Command env bindings cannot reuse API header, credential, or OAuth env vars.

**Cleanup**

Removes the duplicate sandbox wrapper from `sandbox.ts`, deletes the separate `CommandRunner` shape, removes the bash-tool sandbox type import, and keeps the real bash-tool regression test instead of a second mock-only adapter test.

Fixes JUNIOR-2A
Refs #338
Refs #342