### PR TITLE
revert: restore version 0.43.0

### DIFF
--- a/packages/junior-agent-browser/package.json
+++ b/packages/junior-agent-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry/junior-agent-browser",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/junior-datadog/package.json
+++ b/packages/junior-datadog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry/junior-datadog",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/junior-github/package.json
+++ b/packages/junior-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry/junior-github",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/junior-hex/package.json
+++ b/packages/junior-hex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry/junior-hex",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/junior-linear/package.json
+++ b/packages/junior-linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry/junior-linear",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/junior-notion/package.json
+++ b/packages/junior-notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry/junior-notion",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/junior-sentry/package.json
+++ b/packages/junior-sentry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry/junior-sentry",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/packages/junior/package.json
+++ b/packages/junior/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry/junior",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "private": false,
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

- Restores the version from 0.42.0 back to 0.43.0 across all 8 packages
- Undoes the rollback from PR #349

## Packages affected

- `@sentry/junior`
- `@sentry/junior-agent-browser`
- `@sentry/junior-datadog`
- `@sentry/junior-github`
- `@sentry/junior-hex`
- `@sentry/junior-linear`
- `@sentry/junior-notion`
- `@sentry/junior-sentry`

## Slack thread

https://sentry.slack.com/archives/C0AHB7N2JCR/p1778822053161979?thread_ts=1778821295.821809&cid=C0AHB7N2JCR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmZZQhTwwrURZ1kPLSZD8B)_