### PR TITLE
fix(sandbox): Require OIDC config for egress proxy

### DIFF
--- a/packages/docs/src/content/docs/reference/config-and-env.md
+++ b/packages/docs/src/content/docs/reference/config-and-env.md
@@ -32,6 +32,17 @@ If your build command runs `junior snapshot create`:
 - `REDIS_URL` must be available during build.
 - `VERCEL_OIDC_TOKEN` must be available during build (via Vercel OIDC settings).
 
+## Sandbox credential egress
+
+If enabled plugins use host-managed credentials inside Vercel Sandbox, Junior forwards registered provider domains through its credential egress proxy. The deployment must be able to verify that each proxied request came from the expected Vercel project before it injects credentials.
+
+| Variable               | Required    | Purpose                                                                      |
+| ---------------------- | ----------- | ---------------------------------------------------------------------------- |
+| `JUNIOR_BASE_URL`      | Conditional | Public URL for the credential egress proxy, unless Vercel URL envs cover it. |
+| `VERCEL_OIDC_AUDIENCE` | Conditional | Expected Vercel OIDC audience, usually `https://vercel.com/<team-slug>`.     |
+| `VERCEL_PROJECT_ID`    | Conditional | Expected Vercel project ID for sandbox egress proxy requests.                |
+| `VERCEL_TEAM_ID`       | No          | Optional team ID check for sandbox egress proxy requests.                    |
+
 ## GitHub plugin
 
 | Variable                 | Required | Purpose                                         |

--- a/packages/junior/src/chat/sandbox/egress-oidc.ts
+++ b/packages/junior/src/chat/sandbox/egress-oidc.ts
@@ -83,30 +83,37 @@ interface VercelSandboxOidcConfig {
   teamId?: string;
 }
 
-/** Require the verifier inputs before enabling host-brokered sandbox egress. */
-export function requireVercelSandboxOidcConfig(): VercelSandboxOidcConfig {
-  const audience = process.env.VERCEL_OIDC_AUDIENCE?.trim();
-  if (!audience) {
-    throw new Error("VERCEL_OIDC_AUDIENCE is required for sandbox egress OIDC");
-  }
+type VercelSandboxOidcClaimConfig = Omit<VercelSandboxOidcConfig, "audience">;
+
+function requireVercelSandboxOidcClaimConfig(): VercelSandboxOidcClaimConfig {
   const expectedTeamId = process.env.VERCEL_TEAM_ID?.trim();
   const expectedProjectId = process.env.VERCEL_PROJECT_ID?.trim();
   if (!expectedProjectId) {
     throw new Error("VERCEL_PROJECT_ID is required for sandbox egress OIDC");
   }
   return {
-    audience,
     projectId: expectedProjectId,
     ...(expectedTeamId ? { teamId: expectedTeamId } : {}),
   };
 }
 
-/** Validate deployment and sandbox binding claims in a verified Vercel Sandbox OIDC payload. */
-export function validateVercelSandboxOidcClaims(
+/** Require the verifier inputs before enabling host-brokered sandbox egress. */
+export function requireVercelSandboxOidcConfig(): VercelSandboxOidcConfig {
+  const audience = process.env.VERCEL_OIDC_AUDIENCE?.trim();
+  if (!audience) {
+    throw new Error("VERCEL_OIDC_AUDIENCE is required for sandbox egress OIDC");
+  }
+  return {
+    audience,
+    ...requireVercelSandboxOidcClaimConfig(),
+  };
+}
+
+function validateClaimsWithConfig(
   payload: JWTPayload,
   sandboxId: string,
+  expected: VercelSandboxOidcClaimConfig,
 ): void {
-  const expected = requireVercelSandboxOidcConfig();
   if (
     expected.teamId &&
     (typeof payload.owner_id !== "string" ||
@@ -125,6 +132,18 @@ export function validateVercelSandboxOidcClaims(
   }
 }
 
+/** Validate deployment and sandbox binding claims in a verified Vercel Sandbox OIDC payload. */
+export function validateVercelSandboxOidcClaims(
+  payload: JWTPayload,
+  sandboxId: string,
+): void {
+  validateClaimsWithConfig(
+    payload,
+    sandboxId,
+    requireVercelSandboxOidcClaimConfig(),
+  );
+}
+
 /** Verify the Vercel-issued OIDC token attached to a sandbox firewall proxy request. */
 export async function verifyVercelSandboxOidcToken(
   token: string,
@@ -134,12 +153,12 @@ export async function verifyVercelSandboxOidcToken(
   if (typeof unverified.iss !== "string") {
     throw new Error("Vercel OIDC token did not include an issuer");
   }
-  const { audience } = requireVercelSandboxOidcConfig();
+  const expected = requireVercelSandboxOidcConfig();
   const jwks = await getJwks(unverified.iss);
   const verified = await jwtVerify(token, jwks, {
     issuer: unverified.iss,
-    audience,
+    audience: expected.audience,
   });
-  validateVercelSandboxOidcClaims(verified.payload, sandboxId);
+  validateClaimsWithConfig(verified.payload, sandboxId, expected);
   return verified.payload;
 }

--- a/packages/junior/src/chat/sandbox/egress-oidc.ts
+++ b/packages/junior/src/chat/sandbox/egress-oidc.ts
@@ -77,12 +77,28 @@ async function getJwks(
   return jwks;
 }
 
-function expectedVercelOidcAudience(): string {
+interface VercelSandboxOidcConfig {
+  audience: string;
+  projectId: string;
+  teamId?: string;
+}
+
+/** Require the verifier inputs before enabling host-brokered sandbox egress. */
+export function requireVercelSandboxOidcConfig(): VercelSandboxOidcConfig {
   const audience = process.env.VERCEL_OIDC_AUDIENCE?.trim();
   if (!audience) {
     throw new Error("VERCEL_OIDC_AUDIENCE is required for sandbox egress OIDC");
   }
-  return audience;
+  const expectedTeamId = process.env.VERCEL_TEAM_ID?.trim();
+  const expectedProjectId = process.env.VERCEL_PROJECT_ID?.trim();
+  if (!expectedProjectId) {
+    throw new Error("VERCEL_PROJECT_ID is required for sandbox egress OIDC");
+  }
+  return {
+    audience,
+    projectId: expectedProjectId,
+    ...(expectedTeamId ? { teamId: expectedTeamId } : {}),
+  };
 }
 
 /** Validate deployment and sandbox binding claims in a verified Vercel Sandbox OIDC payload. */
@@ -90,21 +106,17 @@ export function validateVercelSandboxOidcClaims(
   payload: JWTPayload,
   sandboxId: string,
 ): void {
-  const expectedTeamId = process.env.VERCEL_TEAM_ID?.trim();
-  const expectedProjectId = process.env.VERCEL_PROJECT_ID?.trim();
-  if (!expectedProjectId) {
-    throw new Error("VERCEL_PROJECT_ID is required for sandbox egress OIDC");
-  }
+  const expected = requireVercelSandboxOidcConfig();
   if (
-    expectedTeamId &&
+    expected.teamId &&
     (typeof payload.owner_id !== "string" ||
-      payload.owner_id !== expectedTeamId)
+      payload.owner_id !== expected.teamId)
   ) {
     throw new Error("Vercel OIDC token belongs to a different team");
   }
   if (
     typeof payload.project_id !== "string" ||
-    payload.project_id !== expectedProjectId
+    payload.project_id !== expected.projectId
   ) {
     throw new Error("Vercel OIDC token belongs to a different project");
   }
@@ -122,7 +134,7 @@ export async function verifyVercelSandboxOidcToken(
   if (typeof unverified.iss !== "string") {
     throw new Error("Vercel OIDC token did not include an issuer");
   }
-  const audience = expectedVercelOidcAudience();
+  const { audience } = requireVercelSandboxOidcConfig();
   const jwks = await getJwks(unverified.iss);
   const verified = await jwtVerify(token, jwks, {
     issuer: unverified.iss,

--- a/packages/junior/src/chat/sandbox/egress-policy.ts
+++ b/packages/junior/src/chat/sandbox/egress-policy.ts
@@ -4,6 +4,7 @@ import { resolvePluginCommandEnv } from "@/chat/plugins/command-env";
 import { getPluginProviders } from "@/chat/plugins/registry";
 import type { PluginManifest } from "@/chat/plugins/types";
 import { resolveBaseUrl } from "@/chat/oauth-flow";
+import { requireVercelSandboxOidcConfig } from "@/chat/sandbox/egress-oidc";
 
 const SANDBOX_EGRESS_PROXY_PATH = "/api/internal/sandbox-egress";
 
@@ -58,14 +59,17 @@ function proxyUrl(sandboxId: string): string | undefined {
 export function buildSandboxEgressNetworkPolicy(
   sandboxId: string,
 ): NetworkPolicy | undefined {
-  const forwardURL = proxyUrl(sandboxId);
-  if (!forwardURL) {
-    return undefined;
-  }
   const entries = providerEntries();
   if (entries.length === 0) {
     return undefined;
   }
+  const forwardURL = proxyUrl(sandboxId);
+  if (!forwardURL) {
+    throw new Error(
+      "Cannot determine base URL for sandbox credential egress (set JUNIOR_BASE_URL or deploy to Vercel)",
+    );
+  }
+  requireVercelSandboxOidcConfig();
 
   const allow: Record<string, NetworkPolicyRule[]> = {
     "*": [],

--- a/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
@@ -169,6 +169,9 @@ describe("sandbox egress proxy", () => {
   });
 
   it("builds provider forwarding policy for sandbox egress", () => {
+    process.env.VERCEL_OIDC_AUDIENCE = "https://vercel.com/acme";
+    process.env.VERCEL_PROJECT_ID = "prj_123";
+
     expect(matchesSandboxEgressDomain("SENTRY.IO", "sentry.io")).toBe(true);
     expect(matchesSandboxEgressDomain("eu.sentry.io", "sentry.io")).toBe(false);
     expect(buildSandboxEgressNetworkPolicy(SANDBOX_ID)).toEqual({
@@ -186,6 +189,32 @@ describe("sandbox egress proxy", () => {
         ],
       },
     });
+  });
+
+  it("fails sandbox egress policy setup without a public callback URL", () => {
+    delete process.env.JUNIOR_BASE_URL;
+    process.env.VERCEL_OIDC_AUDIENCE = "https://vercel.com/acme";
+    process.env.VERCEL_PROJECT_ID = "prj_123";
+
+    expect(() => buildSandboxEgressNetworkPolicy(SANDBOX_ID)).toThrow(
+      "Cannot determine base URL for sandbox credential egress",
+    );
+  });
+
+  it("fails sandbox egress policy setup without trusted OIDC configuration", () => {
+    process.env.VERCEL_PROJECT_ID = "prj_123";
+
+    expect(() => buildSandboxEgressNetworkPolicy(SANDBOX_ID)).toThrow(
+      "VERCEL_OIDC_AUDIENCE is required for sandbox egress OIDC",
+    );
+  });
+
+  it("fails sandbox egress policy setup without the expected Vercel project", () => {
+    process.env.VERCEL_OIDC_AUDIENCE = "https://vercel.com/acme";
+
+    expect(() => buildSandboxEgressNetworkPolicy(SANDBOX_ID)).toThrow(
+      "VERCEL_PROJECT_ID is required for sandbox egress OIDC",
+    );
   });
 
   it("resolves command env for registered sandbox providers", async () => {
@@ -627,6 +656,7 @@ describe("sandbox egress proxy", () => {
   });
 
   it("requires OIDC claims to match the Vercel project and sandbox", () => {
+    process.env.VERCEL_OIDC_AUDIENCE = "https://vercel.com/acme";
     process.env.VERCEL_PROJECT_ID = "prj_123";
     process.env.VERCEL_TEAM_ID = "team_123";
 

--- a/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
@@ -656,7 +656,6 @@ describe("sandbox egress proxy", () => {
   });
 
   it("requires OIDC claims to match the Vercel project and sandbox", () => {
-    process.env.VERCEL_OIDC_AUDIENCE = "https://vercel.com/acme";
     process.env.VERCEL_PROJECT_ID = "prj_123";
     process.env.VERCEL_TEAM_ID = "team_123";
 


### PR DESCRIPTION
Fail sandbox credential egress setup before sandbox commands run when the deployment lacks the proxy callback URL or Vercel OIDC verifier configuration. This turns the recent egress regression into an explicit setup failure instead of letting GitHub traffic hit the provider with placeholder credentials and surface as 401s.

**Egress Setup Contract**

Credential egress policy construction now requires a public callback URL plus `VERCEL_OIDC_AUDIENCE` and `VERCEL_PROJECT_ID` before provider forwarding is enabled.

**Regression Coverage**

The sandbox egress proxy tests cover missing callback URL, audience, and project ID, and the config reference documents the required deployment environment.