### PR TITLE
fix(sandbox): Bind egress proxy to VM session

### DIFF
--- a/packages/docs/src/content/docs/reference/config-and-env.md
+++ b/packages/docs/src/content/docs/reference/config-and-env.md
@@ -34,14 +34,13 @@ If your build command runs `junior snapshot create`:
 
 ## Sandbox credential egress
 
-If enabled plugins use host-managed credentials inside Vercel Sandbox, Junior forwards registered provider domains through its credential egress proxy. The deployment must be able to verify that each proxied request came from the expected Vercel project before it injects credentials.
+If enabled plugins use host-managed credentials inside Vercel Sandbox, Junior forwards registered provider domains through its credential egress proxy. The proxy verifies each Vercel-signed sandbox request and requires an active egress session before it injects credentials.
 
-| Variable               | Required    | Purpose                                                                      |
-| ---------------------- | ----------- | ---------------------------------------------------------------------------- |
-| `JUNIOR_BASE_URL`      | Conditional | Public URL for the credential egress proxy, unless Vercel URL envs cover it. |
-| `VERCEL_OIDC_AUDIENCE` | Conditional | Expected Vercel OIDC audience, usually `https://vercel.com/<team-slug>`.     |
-| `VERCEL_PROJECT_ID`    | Conditional | Expected Vercel project ID for sandbox egress proxy requests.                |
-| `VERCEL_TEAM_ID`       | No          | Optional team ID check for sandbox egress proxy requests.                    |
+The egress proxy verifies Vercel-signed Sandbox OIDC tokens per request and binds them to the active VM session used in the forwarding route. No separate audience, project, or team env vars are required for the proxy.
+
+| Variable          | Required    | Purpose                                                                      |
+| ----------------- | ----------- | ---------------------------------------------------------------------------- |
+| `JUNIOR_BASE_URL` | Conditional | Public URL for the credential egress proxy, unless Vercel URL envs cover it. |
 
 ## GitHub plugin
 

--- a/packages/junior/src/app.ts
+++ b/packages/junior/src/app.ts
@@ -91,11 +91,11 @@ export async function createApp(options?: JuniorAppOptions): Promise<Hono> {
     return turnResumePOST(c.req.raw, waitUntil);
   });
 
-  app.all("/api/internal/sandbox-egress/:sandboxId", (c) => {
-    return sandboxEgressProxyALL(c.req.raw, c.req.param("sandboxId"));
+  app.all("/api/internal/sandbox-egress/:egressId", (c) => {
+    return sandboxEgressProxyALL(c.req.raw, c.req.param("egressId"));
   });
-  app.all("/api/internal/sandbox-egress/:sandboxId/*", (c) => {
-    return sandboxEgressProxyALL(c.req.raw, c.req.param("sandboxId"));
+  app.all("/api/internal/sandbox-egress/:egressId/*", (c) => {
+    return sandboxEgressProxyALL(c.req.raw, c.req.param("egressId"));
   });
 
   app.post("/api/webhooks/:platform", (c) => {

--- a/packages/junior/src/chat/sandbox/egress-oidc.ts
+++ b/packages/junior/src/chat/sandbox/egress-oidc.ts
@@ -77,88 +77,36 @@ async function getJwks(
   return jwks;
 }
 
-interface VercelSandboxOidcConfig {
-  audience: string;
-  projectId: string;
-  teamId?: string;
-}
-
-type VercelSandboxOidcClaimConfig = Omit<VercelSandboxOidcConfig, "audience">;
-
-function requireVercelSandboxOidcClaimConfig(): VercelSandboxOidcClaimConfig {
-  const expectedTeamId = process.env.VERCEL_TEAM_ID?.trim();
-  const expectedProjectId = process.env.VERCEL_PROJECT_ID?.trim();
-  if (!expectedProjectId) {
-    throw new Error("VERCEL_PROJECT_ID is required for sandbox egress OIDC");
-  }
-  return {
-    projectId: expectedProjectId,
-    ...(expectedTeamId ? { teamId: expectedTeamId } : {}),
-  };
-}
-
-/** Require the verifier inputs before enabling host-brokered sandbox egress. */
-export function requireVercelSandboxOidcConfig(): VercelSandboxOidcConfig {
-  const audience = process.env.VERCEL_OIDC_AUDIENCE?.trim();
-  if (!audience) {
-    throw new Error("VERCEL_OIDC_AUDIENCE is required for sandbox egress OIDC");
-  }
-  return {
-    audience,
-    ...requireVercelSandboxOidcClaimConfig(),
-  };
-}
-
-function validateClaimsWithConfig(
-  payload: JWTPayload,
-  sandboxId: string,
-  expected: VercelSandboxOidcClaimConfig,
-): void {
-  if (
-    expected.teamId &&
-    (typeof payload.owner_id !== "string" ||
-      payload.owner_id !== expected.teamId)
-  ) {
-    throw new Error("Vercel OIDC token belongs to a different team");
-  }
-  if (
-    typeof payload.project_id !== "string" ||
-    payload.project_id !== expected.projectId
-  ) {
-    throw new Error("Vercel OIDC token belongs to a different project");
-  }
-  if (payload.sandbox_id !== sandboxId) {
+function validateSandboxClaim(payload: JWTPayload, egressId: string): void {
+  if (payload.sandbox_id !== egressId) {
     throw new Error("Vercel OIDC token belongs to a different sandbox");
   }
 }
 
-/** Validate deployment and sandbox binding claims in a verified Vercel Sandbox OIDC payload. */
+/** Validate that a verified Vercel Sandbox proxy token is bound to this route. */
 export function validateVercelSandboxOidcClaims(
   payload: JWTPayload,
-  sandboxId: string,
+  egressId: string,
 ): void {
-  validateClaimsWithConfig(
-    payload,
-    sandboxId,
-    requireVercelSandboxOidcClaimConfig(),
-  );
+  validateSandboxClaim(payload, egressId);
 }
 
-/** Verify the Vercel-issued OIDC token attached to a sandbox firewall proxy request. */
+/** Verify Vercel signed this Sandbox firewall proxy request for the active VM session. */
 export async function verifyVercelSandboxOidcToken(
   token: string,
-  sandboxId: string,
+  egressId: string,
 ): Promise<JWTPayload> {
   const unverified = decodeJwt(token);
   if (typeof unverified.iss !== "string") {
     throw new Error("Vercel OIDC token did not include an issuer");
   }
-  const expected = requireVercelSandboxOidcConfig();
   const jwks = await getJwks(unverified.iss);
   const verified = await jwtVerify(token, jwks, {
     issuer: unverified.iss,
-    audience: expected.audience,
   });
-  validateClaimsWithConfig(verified.payload, sandboxId, expected);
+  // The Sandbox proxy token is request identity. Do not compare its audience,
+  // team, or project claims with deployment OIDC; the egress session decides
+  // whether this VM session may activate requester-bound credentials.
+  validateSandboxClaim(verified.payload, egressId);
   return verified.payload;
 }

--- a/packages/junior/src/chat/sandbox/egress-policy.ts
+++ b/packages/junior/src/chat/sandbox/egress-policy.ts
@@ -4,7 +4,6 @@ import { resolvePluginCommandEnv } from "@/chat/plugins/command-env";
 import { getPluginProviders } from "@/chat/plugins/registry";
 import type { PluginManifest } from "@/chat/plugins/types";
 import { resolveBaseUrl } from "@/chat/oauth-flow";
-import { requireVercelSandboxOidcConfig } from "@/chat/sandbox/egress-oidc";
 
 const SANDBOX_EGRESS_PROXY_PATH = "/api/internal/sandbox-egress";
 
@@ -43,33 +42,34 @@ export function resolveSandboxEgressProviderForHost(
   )?.provider;
 }
 
-function proxyUrl(sandboxId: string): string | undefined {
+function proxyUrl(egressId: string): string | undefined {
   const baseUrl = resolveBaseUrl();
   if (!baseUrl) {
     return undefined;
   }
   const url = new URL(
-    `${SANDBOX_EGRESS_PROXY_PATH}/${encodeURIComponent(sandboxId)}`,
+    `${SANDBOX_EGRESS_PROXY_PATH}/${encodeURIComponent(egressId)}`,
     baseUrl,
   );
   return url.toString();
 }
 
-/** Build the Vercel Sandbox network policy that forwards credentialed provider domains to Junior. */
+/** Build the forwarding policy that keeps provider credentials outside the sandbox. */
 export function buildSandboxEgressNetworkPolicy(
-  sandboxId: string,
+  egressId: string,
 ): NetworkPolicy | undefined {
   const entries = providerEntries();
   if (entries.length === 0) {
     return undefined;
   }
-  const forwardURL = proxyUrl(sandboxId);
+  const forwardURL = proxyUrl(egressId);
   if (!forwardURL) {
+    // Credential placeholders must not reach real provider domains. If Junior
+    // cannot receive forwarded requests, fail setup before running commands.
     throw new Error(
       "Cannot determine base URL for sandbox credential egress (set JUNIOR_BASE_URL or deploy to Vercel)",
     );
   }
-  requireVercelSandboxOidcConfig();
 
   const allow: Record<string, NetworkPolicyRule[]> = {
     "*": [],

--- a/packages/junior/src/chat/sandbox/egress-proxy.ts
+++ b/packages/junior/src/chat/sandbox/egress-proxy.ts
@@ -40,7 +40,7 @@ const PROXY_ONLY_HEADERS = new Set([
 const AUTH_REJECTION_STATUS = new Set([401, 403]);
 interface ProxyDeps {
   fetch?: typeof fetch;
-  verifyOidc?: (token: string, sandboxId: string) => Promise<unknown>;
+  verifyOidc?: (token: string, egressId: string) => Promise<unknown>;
 }
 
 type UpstreamUrlResult = { ok: true; url: URL } | { ok: false; error: string };
@@ -78,9 +78,9 @@ function normalizePort(value: string | null): string | undefined {
   return port >= 1 && port <= 65_535 ? trimmed : undefined;
 }
 
-function upstreamPath(request: Request, sandboxId: string): string | undefined {
+function upstreamPath(request: Request, egressId: string): string | undefined {
   const url = new URL(request.url);
-  const prefix = `${ROUTE_PREFIX}/${encodeURIComponent(sandboxId)}`;
+  const prefix = `${ROUTE_PREFIX}/${encodeURIComponent(egressId)}`;
   if (url.pathname === prefix) {
     return `/${url.search}`;
   }
@@ -92,7 +92,7 @@ function upstreamPath(request: Request, sandboxId: string): string | undefined {
 
 function buildUpstreamUrl(
   request: Request,
-  sandboxId: string,
+  egressId: string,
 ): UpstreamUrlResult {
   const forwardedHost = request.headers.get(FORWARDED_HOST_HEADER);
   if (!forwardedHost?.trim()) {
@@ -115,7 +115,7 @@ function buildUpstreamUrl(
   if (forwardedPort && !port) {
     return { ok: false, error: "Invalid forwarded port" };
   }
-  const path = upstreamPath(request, sandboxId);
+  const path = upstreamPath(request, egressId);
   if (!path) {
     return { ok: false, error: "Invalid egress route" };
   }
@@ -180,12 +180,12 @@ function responseHeaders(upstream: Response): Headers {
 }
 
 async function credentialLease(
-  sandboxId: string,
+  egressId: string,
   provider: string,
   session: SandboxEgressSession,
 ): Promise<SandboxEgressCredentialLease> {
   const cached = await getSandboxEgressCredentialLease(
-    sandboxId,
+    egressId,
     provider,
     session,
   );
@@ -210,7 +210,7 @@ async function credentialLease(
     expiresAt: lease.expiresAt,
     headerTransforms,
   };
-  await setSandboxEgressCredentialLease(sandboxId, session, cachedLease);
+  await setSandboxEgressCredentialLease(egressId, session, cachedLease);
   return cachedLease;
 }
 
@@ -226,7 +226,7 @@ function hasTransformForHost(
 /** Proxy one Vercel Sandbox firewall egress request through Junior credential activation. */
 export async function proxySandboxEgressRequest(
   request: Request,
-  sandboxId: string,
+  egressId: string,
   deps: ProxyDeps = {},
 ): Promise<Response> {
   const oidcToken = request.headers.get(OIDC_TOKEN_HEADER)?.trim();
@@ -237,7 +237,7 @@ export async function proxySandboxEgressRequest(
   try {
     await (deps.verifyOidc ?? verifyVercelSandboxOidcToken)(
       oidcToken,
-      sandboxId,
+      egressId,
     );
   } catch (error) {
     logWarn(
@@ -252,7 +252,7 @@ export async function proxySandboxEgressRequest(
     return jsonError("Invalid Vercel Sandbox OIDC token", 401);
   }
 
-  const upstreamResult = buildUpstreamUrl(request, sandboxId);
+  const upstreamResult = buildUpstreamUrl(request, egressId);
   if (!upstreamResult.ok) {
     return jsonError(upstreamResult.error, 400);
   }
@@ -263,14 +263,16 @@ export async function proxySandboxEgressRequest(
     return jsonError("No provider owns forwarded host", 403);
   }
 
-  const session = await getSandboxEgressSession(sandboxId);
+  // Vercel OIDC authenticates the forwarded VM session; Junior's egress
+  // session authorizes credential activation for the current requester.
+  const session = await getSandboxEgressSession(egressId);
   if (!session) {
     return jsonError("Sandbox egress session is not authorized", 403);
   }
 
   let lease: SandboxEgressCredentialLease;
   try {
-    lease = await credentialLease(sandboxId, provider, session);
+    lease = await credentialLease(egressId, provider, session);
   } catch (error) {
     if (error instanceof CredentialUnavailableError) {
       return new Response(
@@ -296,7 +298,7 @@ export async function proxySandboxEgressRequest(
     redirect: "manual",
   });
   if (AUTH_REJECTION_STATUS.has(upstream.status)) {
-    await clearSandboxEgressCredentialLease(sandboxId, provider, session);
+    await clearSandboxEgressCredentialLease(egressId, provider, session);
   }
 
   return new Response(upstream.body, {

--- a/packages/junior/src/chat/sandbox/egress-session.ts
+++ b/packages/junior/src/chat/sandbox/egress-session.ts
@@ -18,16 +18,16 @@ export interface SandboxEgressCredentialLease {
   headerTransforms: CredentialHeaderTransform[];
 }
 
-function sessionKey(sandboxId: string): string {
-  return `${SANDBOX_EGRESS_SESSION_PREFIX}:${sandboxId}`;
+function sessionKey(egressId: string): string {
+  return `${SANDBOX_EGRESS_SESSION_PREFIX}:${egressId}`;
 }
 
 function leaseKey(
-  sandboxId: string,
+  egressId: string,
   provider: string,
   session: SandboxEgressSession,
 ): string {
-  return `${SANDBOX_EGRESS_LEASE_PREFIX}:${sandboxId}:${provider}:${session.requesterId}:${session.activationId}`;
+  return `${SANDBOX_EGRESS_LEASE_PREFIX}:${egressId}:${provider}:${session.requesterId}:${session.activationId}`;
 }
 
 function parseSession(value: unknown): SandboxEgressSession | undefined {
@@ -91,7 +91,7 @@ function parseLease(value: unknown): SandboxEgressCredentialLease | undefined {
 
 /** Persist the requester-bound authorization context for sandbox egress credential activation. */
 export async function upsertSandboxEgressSession(input: {
-  sandboxId: string;
+  egressId: string;
   requesterId: string;
   ttlMs?: number;
 }): Promise<void> {
@@ -104,30 +104,30 @@ export async function upsertSandboxEgressSession(input: {
     expiresAtMs: now + ttlMs,
     activationId: randomUUID(),
   };
-  await state.set(sessionKey(input.sandboxId), session, ttlMs);
+  await state.set(sessionKey(input.egressId), session, ttlMs);
 }
 
-/** Clear the active requester-bound authorization context for a sandbox. */
+/** Clear the active requester-bound authorization context for a forwarded VM session. */
 export async function clearSandboxEgressSession(
-  sandboxId: string,
+  egressId: string,
 ): Promise<void> {
   const state = getStateAdapter();
   await state.connect();
-  await state.delete(sessionKey(sandboxId));
+  await state.delete(sessionKey(egressId));
 }
 
-/** Load the active egress authorization session for a sandbox. */
+/** Load the active egress authorization session for a forwarded VM session. */
 export async function getSandboxEgressSession(
-  sandboxId: string,
+  egressId: string,
 ): Promise<SandboxEgressSession | undefined> {
   const state = getStateAdapter();
   await state.connect();
-  return parseSession(await state.get(sessionKey(sandboxId)));
+  return parseSession(await state.get(sessionKey(egressId)));
 }
 
 /** Cache a short-lived credential lease for repeated proxied requests in one sandbox session. */
 export async function setSandboxEgressCredentialLease(
-  sandboxId: string,
+  egressId: string,
   session: SandboxEgressSession,
   lease: SandboxEgressCredentialLease,
 ): Promise<void> {
@@ -141,27 +141,27 @@ export async function setSandboxEgressCredentialLease(
   );
   const state = getStateAdapter();
   await state.connect();
-  await state.set(leaseKey(sandboxId, lease.provider, session), lease, ttlMs);
+  await state.set(leaseKey(egressId, lease.provider, session), lease, ttlMs);
 }
 
-/** Load a cached egress credential lease for a sandbox/provider pair. */
+/** Load a cached egress credential lease for a forwarded session/provider pair. */
 export async function getSandboxEgressCredentialLease(
-  sandboxId: string,
+  egressId: string,
   provider: string,
   session: SandboxEgressSession,
 ): Promise<SandboxEgressCredentialLease | undefined> {
   const state = getStateAdapter();
   await state.connect();
-  return parseLease(await state.get(leaseKey(sandboxId, provider, session)));
+  return parseLease(await state.get(leaseKey(egressId, provider, session)));
 }
 
 /** Clear a cached egress credential lease after the provider rejects its headers. */
 export async function clearSandboxEgressCredentialLease(
-  sandboxId: string,
+  egressId: string,
   provider: string,
   session: SandboxEgressSession,
 ): Promise<void> {
   const state = getStateAdapter();
   await state.connect();
-  await state.delete(leaseKey(sandboxId, provider, session));
+  await state.delete(leaseKey(egressId, provider, session));
 }

--- a/packages/junior/src/chat/sandbox/egress-session.ts
+++ b/packages/junior/src/chat/sandbox/egress-session.ts
@@ -89,7 +89,7 @@ function parseLease(value: unknown): SandboxEgressCredentialLease | undefined {
   };
 }
 
-/** Persist the requester-bound authorization context for sandbox egress credential activation. */
+/** Persist requester authorization for credential activation by one forwarded VM session. */
 export async function upsertSandboxEgressSession(input: {
   egressId: string;
   requesterId: string;
@@ -125,7 +125,7 @@ export async function getSandboxEgressSession(
   return parseSession(await state.get(sessionKey(egressId)));
 }
 
-/** Cache a short-lived credential lease for repeated proxied requests in one sandbox session. */
+/** Cache a short-lived credential lease for repeated requests from one forwarded VM session. */
 export async function setSandboxEgressCredentialLease(
   egressId: string,
   session: SandboxEgressSession,

--- a/packages/junior/src/chat/sandbox/sandbox.ts
+++ b/packages/junior/src/chat/sandbox/sandbox.ts
@@ -114,17 +114,17 @@ export function createSandboxExecutor(options?: {
   const traceContext = options?.traceContext ?? {};
   const credentialEgress = options?.credentialEgress;
   const syncSandboxEgressSession = credentialEgress
-    ? async (sandboxId: string): Promise<void> => {
+    ? async (egressId: string): Promise<void> => {
         await upsertSandboxEgressSession({
-          sandboxId,
+          egressId,
           requesterId: credentialEgress.requesterId,
           ttlMs: options?.timeoutMs,
         });
       }
     : undefined;
   const clearSandboxEgressSessionForCommand = credentialEgress
-    ? async (sandboxId: string): Promise<void> => {
-        await clearSandboxEgressSession(sandboxId);
+    ? async (egressId: string): Promise<void> => {
+        await clearSandboxEgressSession(egressId);
       }
     : undefined;
   const sessionManager = createSandboxSessionManager({

--- a/packages/junior/src/chat/sandbox/session.ts
+++ b/packages/junior/src/chat/sandbox/session.ts
@@ -613,7 +613,6 @@ export function createSandboxSessionManager(options?: {
     sandboxInstance: SandboxInstance,
   ): Promise<SandboxToolExecutors> => {
     const activeSandboxId = sandboxInstance.sandboxId;
-    const activeEgressId = sandboxInstance.sandboxEgressId;
     const toolkit = await withSandboxSpan(
       "sandbox.bash_tool.init",
       "sandbox.tool.init",
@@ -636,7 +635,8 @@ export function createSandboxSessionManager(options?: {
 
     return {
       bash: async (input) => {
-        await options?.beforeCommand?.(activeEgressId);
+        const commandEgressId = sandboxInstance.sandboxEgressId;
+        await options?.beforeCommand?.(commandEgressId);
         let timedOut = false;
         let timeoutId: ReturnType<typeof setTimeout> | undefined;
         let commandFinished = false;
@@ -645,7 +645,7 @@ export function createSandboxSessionManager(options?: {
             return;
           }
           commandFinished = true;
-          await options?.afterCommand?.(activeEgressId);
+          await options?.afterCommand?.(commandEgressId);
         };
         const finishCommandBestEffort = async (): Promise<void> => {
           try {

--- a/packages/junior/src/chat/sandbox/session.ts
+++ b/packages/junior/src/chat/sandbox/session.ts
@@ -145,9 +145,9 @@ export function createSandboxSessionManager(options?: {
   timeoutMs?: number;
   traceContext?: LogContext;
   commandEnv?: () => Promise<Record<string, string>>;
-  createNetworkPolicy?: (sandboxId: string) => NetworkPolicy | undefined;
-  beforeCommand?: (sandboxId: string) => void | Promise<void>;
-  afterCommand?: (sandboxId: string) => void | Promise<void>;
+  createNetworkPolicy?: (egressId: string) => NetworkPolicy | undefined;
+  beforeCommand?: (egressId: string) => void | Promise<void>;
+  afterCommand?: (egressId: string) => void | Promise<void>;
   onSandboxAcquired?: (sandbox: {
     sandboxId: string;
     sandboxDependencyProfileHash?: string;
@@ -184,17 +184,16 @@ export function createSandboxSessionManager(options?: {
   const createSandboxName = (): string =>
     `${SANDBOX_NAME_PREFIX}${randomUUID()}`;
 
-  const rememberNetworkPolicy = (
-    networkPolicy: NetworkPolicy | undefined,
-  ): void => {
-    appliedNetworkPolicyKey = networkPolicy
-      ? JSON.stringify(networkPolicy)
-      : undefined;
+  const preflightNetworkPolicy = (
+    sandboxName: string,
+  ): NetworkPolicy | undefined => {
+    // Build once before boot so missing proxy config fails before sandbox work.
+    // The final route is rebound to the Vercel session id after creation.
+    return options?.createNetworkPolicy?.(sandboxName);
   };
 
   const rememberSandbox = async (
     nextSandbox: SandboxInstance,
-    rememberOptions?: { recordNetworkPolicy?: boolean },
   ): Promise<SandboxInstance> => {
     sandbox = nextSandbox;
     sandboxIdHint = nextSandbox.sandboxId;
@@ -206,11 +205,6 @@ export function createSandboxSessionManager(options?: {
         : {}),
     };
     await options?.onSandboxAcquired?.(acquired);
-    if (rememberOptions?.recordNetworkPolicy) {
-      rememberNetworkPolicy(
-        options?.createNetworkPolicy?.(nextSandbox.sandboxId),
-      );
-    }
     return nextSandbox;
   };
 
@@ -232,7 +226,7 @@ export function createSandboxSessionManager(options?: {
     targetSandbox: SandboxInstance,
   ): Promise<void> => {
     const networkPolicy = options?.createNetworkPolicy?.(
-      targetSandbox.sandboxId,
+      targetSandbox.sandboxEgressId,
     );
     if (!networkPolicy) {
       return;
@@ -302,7 +296,7 @@ export function createSandboxSessionManager(options?: {
     for (let attempt = 0; attempt < SNAPSHOT_BOOT_RETRY_COUNT; attempt += 1) {
       const sandboxName =
         attempt === 0 ? initialSandboxName : createSandboxName();
-      const networkPolicy = options?.createNetworkPolicy?.(sandboxName);
+      const networkPolicy = preflightNetworkPolicy(sandboxName);
       try {
         return createSandboxInstance(
           await Sandbox.create({
@@ -359,7 +353,7 @@ export function createSandboxSessionManager(options?: {
     const { runtime, snapshot, sandboxCredentials, sandboxName } = params;
 
     if (!snapshot.snapshotId) {
-      const networkPolicy = options?.createNetworkPolicy?.(sandboxName);
+      const networkPolicy = preflightNetworkPolicy(sandboxName);
       return createSandboxInstance(
         await Sandbox.create({
           timeout: timeoutMs,
@@ -438,12 +432,13 @@ export function createSandboxSessionManager(options?: {
     }
 
     try {
+      await refreshNetworkPolicy(createdSandbox);
       await syncSkills(createdSandbox);
     } catch (error) {
       return failSetup(error);
     }
 
-    return await rememberSandbox(createdSandbox, { recordNetworkPolicy: true });
+    return await rememberSandbox(createdSandbox);
   };
 
   const discardHintIfProfileChanged = (): void => {
@@ -618,6 +613,7 @@ export function createSandboxSessionManager(options?: {
     sandboxInstance: SandboxInstance,
   ): Promise<SandboxToolExecutors> => {
     const activeSandboxId = sandboxInstance.sandboxId;
+    const activeEgressId = sandboxInstance.sandboxEgressId;
     const toolkit = await withSandboxSpan(
       "sandbox.bash_tool.init",
       "sandbox.tool.init",
@@ -640,7 +636,7 @@ export function createSandboxSessionManager(options?: {
 
     return {
       bash: async (input) => {
-        await options?.beforeCommand?.(activeSandboxId);
+        await options?.beforeCommand?.(activeEgressId);
         let timedOut = false;
         let timeoutId: ReturnType<typeof setTimeout> | undefined;
         let commandFinished = false;
@@ -649,7 +645,7 @@ export function createSandboxSessionManager(options?: {
             return;
           }
           commandFinished = true;
-          await options?.afterCommand?.(activeSandboxId);
+          await options?.afterCommand?.(activeEgressId);
         };
         const finishCommandBestEffort = async (): Promise<void> => {
           try {

--- a/packages/junior/src/chat/sandbox/workspace.ts
+++ b/packages/junior/src/chat/sandbox/workspace.ts
@@ -63,9 +63,11 @@ export interface SandboxInstance extends SandboxWorkspace {
 export function createSandboxInstance(sandbox: VercelSandbox): SandboxInstance {
   return {
     sandboxId: sandbox.name,
-    // Vercel Sandbox v2 names the persistent sandbox separately from the
-    // running VM session identified by firewall proxy OIDC tokens.
-    sandboxEgressId: sandbox.currentSession().sessionId,
+    get sandboxEgressId() {
+      // Vercel Sandbox v2 names the persistent sandbox separately from the
+      // running VM session identified by firewall proxy OIDC tokens.
+      return sandbox.currentSession().sessionId;
+    },
     fs: sandbox.fs as SandboxFileSystem,
     extendTimeout(duration) {
       return sandbox.extendTimeout(duration);

--- a/packages/junior/src/chat/sandbox/workspace.ts
+++ b/packages/junior/src/chat/sandbox/workspace.ts
@@ -43,6 +43,7 @@ export interface SandboxWorkspace {
 
 export interface SandboxInstance extends SandboxWorkspace {
   readonly sandboxId: string;
+  readonly sandboxEgressId: string;
   readonly fs: SandboxFileSystem;
   extendTimeout(duration: number): Promise<void>;
   mkDir(path: string): Promise<void>;
@@ -62,6 +63,9 @@ export interface SandboxInstance extends SandboxWorkspace {
 export function createSandboxInstance(sandbox: VercelSandbox): SandboxInstance {
   return {
     sandboxId: sandbox.name,
+    // Vercel Sandbox v2 names the persistent sandbox separately from the
+    // running VM session identified by firewall proxy OIDC tokens.
+    sandboxEgressId: sandbox.currentSession().sessionId,
     fs: sandbox.fs as SandboxFileSystem,
     extendTimeout(duration) {
       return sandbox.extendTimeout(duration);

--- a/packages/junior/src/handlers/sandbox-egress-proxy.ts
+++ b/packages/junior/src/handlers/sandbox-egress-proxy.ts
@@ -3,7 +3,7 @@ import { proxySandboxEgressRequest } from "@/chat/sandbox/egress-proxy";
 /** Handles Vercel Sandbox firewall egress proxy requests. */
 export async function ALL(
   request: Request,
-  sandboxId: string,
+  egressId: string,
 ): Promise<Response> {
-  return await proxySandboxEgressRequest(request, sandboxId);
+  return await proxySandboxEgressRequest(request, egressId);
 }

--- a/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
@@ -83,7 +83,7 @@ async function authorizeSandboxEgress(
   requesterId = REQUESTER_ID,
 ): Promise<void> {
   await upsertSandboxEgressSession({
-    sandboxId: SANDBOX_ID,
+    egressId: SANDBOX_ID,
     requesterId,
     ttlMs: 60_000,
   });
@@ -161,17 +161,11 @@ describe("sandbox egress proxy", () => {
     await disconnectStateAdapter();
     delete process.env.JUNIOR_STATE_ADAPTER;
     delete process.env.JUNIOR_BASE_URL;
-    delete process.env.VERCEL_OIDC_AUDIENCE;
-    delete process.env.VERCEL_PROJECT_ID;
-    delete process.env.VERCEL_TEAM_ID;
     delete process.env.SENTRY_BOT_EMAIL;
     vi.restoreAllMocks();
   });
 
   it("builds provider forwarding policy for sandbox egress", () => {
-    process.env.VERCEL_OIDC_AUDIENCE = "https://vercel.com/acme";
-    process.env.VERCEL_PROJECT_ID = "prj_123";
-
     expect(matchesSandboxEgressDomain("SENTRY.IO", "sentry.io")).toBe(true);
     expect(matchesSandboxEgressDomain("eu.sentry.io", "sentry.io")).toBe(false);
     expect(buildSandboxEgressNetworkPolicy(SANDBOX_ID)).toEqual({
@@ -193,27 +187,9 @@ describe("sandbox egress proxy", () => {
 
   it("fails sandbox egress policy setup without a public callback URL", () => {
     delete process.env.JUNIOR_BASE_URL;
-    process.env.VERCEL_OIDC_AUDIENCE = "https://vercel.com/acme";
-    process.env.VERCEL_PROJECT_ID = "prj_123";
 
     expect(() => buildSandboxEgressNetworkPolicy(SANDBOX_ID)).toThrow(
       "Cannot determine base URL for sandbox credential egress",
-    );
-  });
-
-  it("fails sandbox egress policy setup without trusted OIDC configuration", () => {
-    process.env.VERCEL_PROJECT_ID = "prj_123";
-
-    expect(() => buildSandboxEgressNetworkPolicy(SANDBOX_ID)).toThrow(
-      "VERCEL_OIDC_AUDIENCE is required for sandbox egress OIDC",
-    );
-  });
-
-  it("fails sandbox egress policy setup without the expected Vercel project", () => {
-    process.env.VERCEL_OIDC_AUDIENCE = "https://vercel.com/acme";
-
-    expect(() => buildSandboxEgressNetworkPolicy(SANDBOX_ID)).toThrow(
-      "VERCEL_PROJECT_ID is required for sandbox egress OIDC",
     );
   });
 
@@ -655,15 +631,10 @@ describe("sandbox egress proxy", () => {
     expect(issueProviderCredentialLeaseMock).not.toHaveBeenCalled();
   });
 
-  it("requires OIDC claims to match the Vercel project and sandbox", () => {
-    process.env.VERCEL_PROJECT_ID = "prj_123";
-    process.env.VERCEL_TEAM_ID = "team_123";
-
+  it("requires OIDC claims to match the sandbox", () => {
     expect(() =>
       validateVercelSandboxOidcClaims(
         {
-          owner_id: "team_123",
-          project_id: "prj_123",
           sandbox_id: SANDBOX_ID,
         },
         SANDBOX_ID,
@@ -673,19 +644,6 @@ describe("sandbox egress proxy", () => {
     expect(() =>
       validateVercelSandboxOidcClaims(
         {
-          owner_id: "team_123",
-          project_id: "prj_other",
-          sandbox_id: SANDBOX_ID,
-        },
-        SANDBOX_ID,
-      ),
-    ).toThrow("different project");
-
-    expect(() =>
-      validateVercelSandboxOidcClaims(
-        {
-          owner_id: "team_123",
-          project_id: "prj_123",
           sandbox_id: "other-sandbox",
         },
         SANDBOX_ID,
@@ -694,15 +652,11 @@ describe("sandbox egress proxy", () => {
   });
 
   it("caches Vercel OIDC discovery metadata by issuer", async () => {
-    process.env.VERCEL_OIDC_AUDIENCE = "https://vercel.com/cache-test";
-    process.env.VERCEL_PROJECT_ID = "prj_123";
     decodeJwtMock.mockReturnValue({
       iss: "https://oidc.vercel.com/cache-test",
-      owner: "cache-test",
     });
     jwtVerifyMock.mockResolvedValue({
       payload: {
-        project_id: "prj_123",
         sandbox_id: SANDBOX_ID,
       },
     });
@@ -721,17 +675,15 @@ describe("sandbox egress proxy", () => {
     expect(createRemoteJWKSetMock).toHaveBeenCalledTimes(1);
   });
 
-  it("verifies Vercel OIDC audience from trusted configuration", async () => {
-    process.env.VERCEL_OIDC_AUDIENCE = "https://vercel.com/acme";
-    process.env.VERCEL_PROJECT_ID = "prj_123";
+  it("verifies sandbox tokens without assuming the deployment OIDC audience", async () => {
     decodeJwtMock.mockReturnValue({
       iss: "https://oidc.vercel.com/acme",
-      owner: "attacker-controlled",
     });
     jwtVerifyMock.mockResolvedValue({
       payload: {
-        owner: "acme",
-        project_id: "prj_123",
+        aud: "sandbox-proxy-audience",
+        owner_id: "different-team",
+        project_id: "different-project",
         sandbox_id: SANDBOX_ID,
       },
     });
@@ -751,30 +703,13 @@ describe("sandbox egress proxy", () => {
       expect.anything(),
       {
         issuer: "https://oidc.vercel.com/acme",
-        audience: "https://vercel.com/acme",
       },
     );
   });
 
-  it("requires trusted Vercel OIDC audience configuration", async () => {
-    process.env.VERCEL_PROJECT_ID = "prj_123";
-    decodeJwtMock.mockReturnValue({
-      iss: "https://oidc.vercel.com/acme",
-    });
-
-    await expect(
-      verifyVercelSandboxOidcToken("signed-token", SANDBOX_ID),
-    ).rejects.toThrow("VERCEL_OIDC_AUDIENCE");
-
-    expect(jwtVerifyMock).not.toHaveBeenCalled();
-  });
-
   it("rejects non-HTTPS Vercel OIDC JWKS metadata", async () => {
-    process.env.VERCEL_OIDC_AUDIENCE = "https://vercel.com/bad-jwks";
-    process.env.VERCEL_PROJECT_ID = "prj_123";
     decodeJwtMock.mockReturnValue({
       iss: "https://oidc.vercel.com/bad-jwks",
-      owner: "bad-jwks",
     });
     const fetchMock = vi.fn(async () =>
       Response.json({

--- a/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
@@ -76,14 +76,14 @@ import { disconnectStateAdapter } from "@/chat/state/adapter";
 import { CredentialUnavailableError } from "@/chat/credentials/broker";
 import { ALL } from "@/handlers/sandbox-egress-proxy";
 
-const SANDBOX_ID = "junior-sbx";
+const EGRESS_ID = "junior-sbx";
 const REQUESTER_ID = "U123";
 
 async function authorizeSandboxEgress(
   requesterId = REQUESTER_ID,
 ): Promise<void> {
   await upsertSandboxEgressSession({
-    egressId: SANDBOX_ID,
+    egressId: EGRESS_ID,
     requesterId,
     ttlMs: 60_000,
   });
@@ -116,7 +116,7 @@ function egressRequest(
   } = {},
 ): Request {
   return new Request(
-    `https://junior.example.com/api/internal/sandbox-egress/${SANDBOX_ID}${input.path ?? "/api/0/issues/"}`,
+    `https://junior.example.com/api/internal/sandbox-egress/${EGRESS_ID}${input.path ?? "/api/0/issues/"}`,
     {
       method: input.method ?? "GET",
       headers: {
@@ -139,7 +139,7 @@ function proxy(
     async () => new Response("ok"),
   ) as typeof fetch,
 ): Promise<Response> {
-  return proxySandboxEgressRequest(request, SANDBOX_ID, {
+  return proxySandboxEgressRequest(request, EGRESS_ID, {
     fetch: fetchMock,
     verifyOidc: async () => ({ sub: "sandbox" }),
   });
@@ -168,17 +168,17 @@ describe("sandbox egress proxy", () => {
   it("builds provider forwarding policy for sandbox egress", () => {
     expect(matchesSandboxEgressDomain("SENTRY.IO", "sentry.io")).toBe(true);
     expect(matchesSandboxEgressDomain("eu.sentry.io", "sentry.io")).toBe(false);
-    expect(buildSandboxEgressNetworkPolicy(SANDBOX_ID)).toEqual({
+    expect(buildSandboxEgressNetworkPolicy(EGRESS_ID)).toEqual({
       allow: {
         "*": [],
         "sentry.io": [
           {
-            forwardURL: `https://junior.example.com/api/internal/sandbox-egress/${SANDBOX_ID}`,
+            forwardURL: `https://junior.example.com/api/internal/sandbox-egress/${EGRESS_ID}`,
           },
         ],
         "us.sentry.io": [
           {
-            forwardURL: `https://junior.example.com/api/internal/sandbox-egress/${SANDBOX_ID}`,
+            forwardURL: `https://junior.example.com/api/internal/sandbox-egress/${EGRESS_ID}`,
           },
         ],
       },
@@ -188,7 +188,7 @@ describe("sandbox egress proxy", () => {
   it("fails sandbox egress policy setup without a public callback URL", () => {
     delete process.env.JUNIOR_BASE_URL;
 
-    expect(() => buildSandboxEgressNetworkPolicy(SANDBOX_ID)).toThrow(
+    expect(() => buildSandboxEgressNetworkPolicy(EGRESS_ID)).toThrow(
       "Cannot determine base URL for sandbox credential egress",
     );
   });
@@ -215,9 +215,9 @@ describe("sandbox egress proxy", () => {
 
     const response = await ALL(
       new Request(
-        `https://junior.example.com/api/internal/sandbox-egress/${SANDBOX_ID}`,
+        `https://junior.example.com/api/internal/sandbox-egress/${EGRESS_ID}`,
       ),
-      SANDBOX_ID,
+      EGRESS_ID,
     );
 
     expect(response.status).toBe(401);
@@ -555,7 +555,7 @@ describe("sandbox egress proxy", () => {
     const fetchMock = vi.fn();
 
     const response = await proxy(
-      new Request(`https://junior.example.com/not-egress/${SANDBOX_ID}`, {
+      new Request(`https://junior.example.com/not-egress/${EGRESS_ID}`, {
         headers: {
           "vercel-forwarded-host": "sentry.io",
           "vercel-forwarded-scheme": "https",
@@ -631,13 +631,13 @@ describe("sandbox egress proxy", () => {
     expect(issueProviderCredentialLeaseMock).not.toHaveBeenCalled();
   });
 
-  it("requires OIDC claims to match the sandbox", () => {
+  it("requires OIDC sandbox claims to match the egress route", () => {
     expect(() =>
       validateVercelSandboxOidcClaims(
         {
-          sandbox_id: SANDBOX_ID,
+          sandbox_id: EGRESS_ID,
         },
-        SANDBOX_ID,
+        EGRESS_ID,
       ),
     ).not.toThrow();
 
@@ -646,7 +646,7 @@ describe("sandbox egress proxy", () => {
         {
           sandbox_id: "other-sandbox",
         },
-        SANDBOX_ID,
+        EGRESS_ID,
       ),
     ).toThrow("different sandbox");
   });
@@ -657,7 +657,7 @@ describe("sandbox egress proxy", () => {
     });
     jwtVerifyMock.mockResolvedValue({
       payload: {
-        sandbox_id: SANDBOX_ID,
+        sandbox_id: EGRESS_ID,
       },
     });
     const fetchMock = vi.fn(async (_url: URL | string, _init?: RequestInit) =>
@@ -667,8 +667,8 @@ describe("sandbox egress proxy", () => {
     );
     vi.stubGlobal("fetch", fetchMock);
 
-    await verifyVercelSandboxOidcToken("signed-token-1", SANDBOX_ID);
-    await verifyVercelSandboxOidcToken("signed-token-2", SANDBOX_ID);
+    await verifyVercelSandboxOidcToken("signed-token-1", EGRESS_ID);
+    await verifyVercelSandboxOidcToken("signed-token-2", EGRESS_ID);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0]?.[1]).toEqual({ redirect: "error" });
@@ -684,7 +684,7 @@ describe("sandbox egress proxy", () => {
         aud: "sandbox-proxy-audience",
         owner_id: "different-team",
         project_id: "different-project",
-        sandbox_id: SANDBOX_ID,
+        sandbox_id: EGRESS_ID,
       },
     });
     vi.stubGlobal(
@@ -696,7 +696,7 @@ describe("sandbox egress proxy", () => {
       ),
     );
 
-    await verifyVercelSandboxOidcToken("signed-token", SANDBOX_ID);
+    await verifyVercelSandboxOidcToken("signed-token", EGRESS_ID);
 
     expect(jwtVerifyMock).toHaveBeenCalledWith(
       "signed-token",
@@ -719,7 +719,7 @@ describe("sandbox egress proxy", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(
-      verifyVercelSandboxOidcToken("signed-token", SANDBOX_ID),
+      verifyVercelSandboxOidcToken("signed-token", EGRESS_ID),
     ).rejects.toThrow("jwks_uri");
 
     expect(createRemoteJWKSetMock).not.toHaveBeenCalled();

--- a/packages/junior/tests/unit/misc/bash-tool-sandbox-adapter.test.ts
+++ b/packages/junior/tests/unit/misc/bash-tool-sandbox-adapter.test.ts
@@ -15,6 +15,9 @@ import { createSandboxSessionManager } from "@/chat/sandbox/session";
 function makeSandbox() {
   return {
     name: "sbx_adapter_contract",
+    currentSession: vi.fn(() => ({
+      sessionId: "sbx_adapter_contract_session",
+    })),
     mkDir: vi.fn(async () => {}),
     writeFiles: vi.fn(async () => {}),
     readFileToBuffer: vi.fn(async () => Buffer.from("file content")),

--- a/packages/junior/tests/unit/misc/sandbox-executor.test.ts
+++ b/packages/junior/tests/unit/misc/sandbox-executor.test.ts
@@ -368,7 +368,9 @@ describe("createSandboxExecutor", () => {
       },
     });
 
-    providerDomain = "api.second.example";
+    sandbox.currentSession.mockReturnValue({
+      sessionId: "sbx_cached_policy_resumed_session",
+    });
     await manager.createSandbox();
 
     expect(sandbox.update).toHaveBeenCalledTimes(2);
@@ -376,10 +378,28 @@ describe("createSandboxExecutor", () => {
       networkPolicy: {
         allow: {
           "*": [],
+          "api.first.example": [
+            {
+              forwardURL:
+                "https://junior.example.com/api/internal/sandbox-egress/sbx_cached_policy_resumed_session",
+            },
+          ],
+        },
+      },
+    });
+
+    providerDomain = "api.second.example";
+    await manager.createSandbox();
+
+    expect(sandbox.update).toHaveBeenCalledTimes(3);
+    expect(sandbox.update).toHaveBeenLastCalledWith({
+      networkPolicy: {
+        allow: {
+          "*": [],
           "api.second.example": [
             {
               forwardURL:
-                "https://junior.example.com/api/internal/sandbox-egress/sbx_cached_policy_session",
+                "https://junior.example.com/api/internal/sandbox-egress/sbx_cached_policy_resumed_session",
             },
           ],
         },
@@ -576,10 +596,17 @@ describe("createSandboxExecutor", () => {
     });
     const bash = (await manager.ensureToolExecutors()).bash;
 
+    sandbox.currentSession.mockReturnValue({
+      sessionId: "sbx_command_hooks_resumed_session",
+    });
     await bash({ command: "echo ok" });
 
-    expect(beforeCommand).toHaveBeenCalledWith("sbx_command_hooks_session");
-    expect(afterCommand).toHaveBeenCalledWith("sbx_command_hooks_session");
+    expect(beforeCommand).toHaveBeenCalledWith(
+      "sbx_command_hooks_resumed_session",
+    );
+    expect(afterCommand).toHaveBeenCalledWith(
+      "sbx_command_hooks_resumed_session",
+    );
     expect(beforeCommand.mock.invocationCallOrder[0]).toBeLessThan(
       sandbox.runCommand.mock.invocationCallOrder[0] as number,
     );

--- a/packages/junior/tests/unit/misc/sandbox-executor.test.ts
+++ b/packages/junior/tests/unit/misc/sandbox-executor.test.ts
@@ -58,6 +58,7 @@ import { createBashTool } from "bash-tool";
 
 interface MockSandbox {
   name: string;
+  currentSession: ReturnType<typeof vi.fn>;
   fs: {
     readFile: ReturnType<typeof vi.fn>;
     writeFile: ReturnType<typeof vi.fn>;
@@ -83,6 +84,7 @@ function makeSandbox(
 ): MockSandbox {
   return {
     name,
+    currentSession: vi.fn(() => ({ sessionId: `${name}_session` })),
     fs: {
       readFile: vi.fn(async () => ""),
       writeFile: vi.fn(async () => {}),
@@ -142,6 +144,7 @@ async function expectWorkspaceToDelegate(
   sandbox: MockSandbox,
 ): Promise<void> {
   expect(workspace.sandboxId).toBe(sandbox.name);
+  expect(workspace.sandboxEgressId).toBe(`${sandbox.name}_session`);
   const fileBuffer = Buffer.from("workspace file");
   const commandResult = {
     exitCode: 0,
@@ -350,20 +353,33 @@ describe("createSandboxExecutor", () => {
 
     await manager.createSandbox();
     await manager.createSandbox();
-    expect(sandbox.update).not.toHaveBeenCalled();
+    expect(sandbox.update).toHaveBeenCalledTimes(1);
+    expect(sandbox.update).toHaveBeenCalledWith({
+      networkPolicy: {
+        allow: {
+          "*": [],
+          "api.first.example": [
+            {
+              forwardURL:
+                "https://junior.example.com/api/internal/sandbox-egress/sbx_cached_policy_session",
+            },
+          ],
+        },
+      },
+    });
 
     providerDomain = "api.second.example";
     await manager.createSandbox();
 
-    expect(sandbox.update).toHaveBeenCalledTimes(1);
-    expect(sandbox.update).toHaveBeenCalledWith({
+    expect(sandbox.update).toHaveBeenCalledTimes(2);
+    expect(sandbox.update).toHaveBeenLastCalledWith({
       networkPolicy: {
         allow: {
           "*": [],
           "api.second.example": [
             {
               forwardURL:
-                "https://junior.example.com/api/internal/sandbox-egress/sbx_cached_policy",
+                "https://junior.example.com/api/internal/sandbox-egress/sbx_cached_policy_session",
             },
           ],
         },
@@ -562,8 +578,8 @@ describe("createSandboxExecutor", () => {
 
     await bash({ command: "echo ok" });
 
-    expect(beforeCommand).toHaveBeenCalledWith("sbx_command_hooks");
-    expect(afterCommand).toHaveBeenCalledWith("sbx_command_hooks");
+    expect(beforeCommand).toHaveBeenCalledWith("sbx_command_hooks_session");
+    expect(afterCommand).toHaveBeenCalledWith("sbx_command_hooks_session");
     expect(beforeCommand.mock.invocationCallOrder[0]).toBeLessThan(
       sandbox.runCommand.mock.invocationCallOrder[0] as number,
     );
@@ -595,7 +611,9 @@ describe("createSandboxExecutor", () => {
 
     await expect(bash({ command: "echo ok" })).rejects.toThrow("env failed");
 
-    expect(afterCommand).toHaveBeenCalledWith("sbx_command_env_failure");
+    expect(afterCommand).toHaveBeenCalledWith(
+      "sbx_command_env_failure_session",
+    );
     expect(sandbox.runCommand).not.toHaveBeenCalled();
   });
 
@@ -1168,6 +1186,10 @@ describe("createSandboxExecutor", () => {
     expect(secondCreate.name).not.toBe(firstCreate.name);
     expect(createNetworkPolicy).toHaveBeenNthCalledWith(1, firstCreate.name);
     expect(createNetworkPolicy).toHaveBeenNthCalledWith(2, secondCreate.name);
+    expect(createNetworkPolicy).toHaveBeenNthCalledWith(
+      3,
+      "sbx_snapshot_policy_ready_session",
+    );
     expect(secondCreate.networkPolicy).toEqual({
       allow: {
         "*": [],
@@ -1176,6 +1198,19 @@ describe("createSandboxExecutor", () => {
             forwardURL: `https://junior.example.com/api/internal/sandbox-egress/${secondCreate.name}`,
           },
         ],
+      },
+    });
+    expect(snapshotSandbox.update).toHaveBeenCalledWith({
+      networkPolicy: {
+        allow: {
+          "*": [],
+          "api.example.com": [
+            {
+              forwardURL:
+                "https://junior.example.com/api/internal/sandbox-egress/sbx_snapshot_policy_ready_session",
+            },
+          ],
+        },
       },
     });
   });

--- a/packages/junior/tests/unit/runtime/runtime-dependency-snapshots.test.ts
+++ b/packages/junior/tests/unit/runtime/runtime-dependency-snapshots.test.ts
@@ -72,6 +72,8 @@ function makeSandbox(
   }>,
 ) {
   return {
+    name: `sbx_${snapshotId}`,
+    currentSession: vi.fn(() => ({ sessionId: `sbx_${snapshotId}_session` })),
     runCommand: vi.fn(
       runCommandImpl ??
         (async () => ({

--- a/specs/security-policy.md
+++ b/specs/security-policy.md
@@ -32,7 +32,7 @@ This policy applies to:
 
 - Production should use explicit network policy and minimal allowlists.
 - Credential-capable provider domains should route through the Junior sandbox egress proxy instead of receiving long-lived sandbox secrets.
-- Proxied sandbox egress requests must verify Vercel Sandbox OIDC audience from trusted deployment configuration, project, and sandbox claims, resolve the provider from the forwarded host, and require a requester-bound sandbox egress session. Egress sessions are command-scoped, and cached provider leases must be scoped to one session activation.
+- Proxied sandbox egress requests must verify the Vercel-signed Sandbox OIDC token, validate its sandbox claim against the active VM session used in the forwarding route, resolve the provider from the forwarded host, and require a requester-bound sandbox egress session. Egress sessions are command-scoped, and cached provider leases must be scoped to one session activation.
 - The public egress route must verify Vercel Sandbox OIDC before returning configuration, provider, or session-specific responses.
 - The egress proxy must not reject duplicate method/URL/body requests as replay; duplicate request shapes can be legitimate retries. Requester-bound credential issuance is the security boundary.
 


### PR DESCRIPTION
Sandbox credential egress now routes through the active Vercel Sandbox VM session id instead of the persistent sandbox name. This matches the Sandbox v2 SDK model where the sandbox name is used for workspace resume while the current session id identifies the running VM that issues forwarded firewall requests.

**Proxy Token Verification**

The egress proxy verifies the Vercel-signed token issuer and signature, then binds the token sandbox claim to the forwarding route id. It does not compare Sandbox proxy token audience, project, or team claims with deployment OIDC because those are separate token contexts and the public Sandbox proxy docs do not define that as the verifier contract.

**Live Session Binding**

Junior reads the egress id from `sandbox.currentSession().sessionId` through a live wrapper getter, so cached named sandboxes that resume into a new VM session refresh their forwarding route and command-scoped authorization with the new session id.

**Credential Activation**

Junior still requires an active command-scoped egress session before issuing requester-bound provider credentials. Missing public callback URL still fails sandbox setup before placeholder credentials can reach provider domains.

Fixes JUNIOR-2F