### PR TITLE
fix(github): Log sandbox egress auth rejections

### DIFF
--- a/packages/junior-github/SETUP.md
+++ b/packages/junior-github/SETUP.md
@@ -13,6 +13,7 @@ In GitHub:
 - Issues: Read and write
 - Contents: Read and write
 - Pull requests: Read and write
+- Actions: Read and write
 - Metadata: Read
 
 4. Create the app and generate a private key.

--- a/packages/junior/src/chat/sandbox/egress-proxy.ts
+++ b/packages/junior/src/chat/sandbox/egress-proxy.ts
@@ -298,6 +298,17 @@ export async function proxySandboxEgressRequest(
     redirect: "manual",
   });
   if (AUTH_REJECTION_STATUS.has(upstream.status)) {
+    logWarn(
+      "sandbox_egress_upstream_auth_rejected",
+      {},
+      {
+        "app.credential.provider": provider,
+        "http.request.method": request.method,
+        "http.response.status_code": upstream.status,
+        "server.address": upstreamUrl.hostname,
+      },
+      "Sandbox egress upstream auth rejected",
+    );
     await clearSandboxEgressCredentialLease(egressId, provider, session);
   }
 


### PR DESCRIPTION
Sandbox egress now logs sanitized upstream 401 and 403 responses before clearing a provider credential lease. This keeps the existing retry behavior while making production auth failures visible in app logs.

**GitHub App Setup**

Document the Actions read/write permission required by the GitHub plugin manifest so installs request the same capability set the runtime expects.