### PR TITLE
feat(cli): Validate packaged plugin content

### DIFF
--- a/packages/docs/src/content/docs/cli/check.md
+++ b/packages/docs/src/content/docs/cli/check.md
@@ -11,7 +11,7 @@ related:
   - /cli/snapshot-create/
 ---
 
-`junior check` validates the same `app/` content layout that the runtime loads. It ignores legacy top-level `plugins/` and `skills/` directories, and it only runs app-file checks when the target already looks like a Junior app.
+`junior check` validates local app content and installed plugin package content before build or deploy. It ignores legacy top-level `plugins/` and `skills/` directories, and it only runs app-file checks when the target already looks like a Junior app.
 
 ## Usage
 
@@ -39,6 +39,12 @@ The command accepts zero or one directory argument.
 - `app/plugins/<plugin>/skills/<skill>/SKILL.md`
 - `app/skills/<skill>/SKILL.md`
 
+It also checks installed package dependencies that contain Junior plugin content:
+
+- `node_modules/<package>/plugin.yaml`
+- `node_modules/<package>/plugins/<plugin>/plugin.yaml`
+- package `skills/` directories
+
 For each file it validates:
 
 - Plugin manifest schema
@@ -46,6 +52,8 @@ For each file it validates:
 - Skill name matches the containing directory
 - Duplicate plugin names
 - Duplicate skill names across app and plugin skill roots
+
+For official `@sentry/junior-*` plugin packages, the command warns when the installed package version differs from `@sentry/junior`. This catches partial updates without requiring migration-specific checks.
 
 When the target already contains Junior app markers such as `app/SOUL.md`, `app/WORLD.md`, `app/DESCRIPTION.md`, `app/skills/`, or `app/plugins/`, the command also checks the app-root Markdown files:
 

--- a/packages/docs/src/content/docs/start-here/quickstart.md
+++ b/packages/docs/src/content/docs/start-here/quickstart.md
@@ -151,11 +151,14 @@ The scaffold includes a build script that runs snapshot warmup:
 ```json title="package.json"
 {
   "scripts": {
+    "check": "junior check",
     "dev": "vite dev",
     "build": "junior snapshot create && vite build"
   }
 }
 ```
+
+Run `pnpm check` after updating Junior or plugin packages to validate local app files and installed plugin content.
 
 ### Configure production environment
 

--- a/packages/junior/src/cli/check.ts
+++ b/packages/junior/src/cli/check.ts
@@ -27,9 +27,25 @@ interface SkillValidationResult {
 interface PluginValidationResult {
   pluginDir: string;
   manifestPath: string;
+  packageName?: string;
   manifest?: PluginManifest;
   errors: string[];
   skillResults: SkillValidationResult[];
+}
+
+interface PackagedPluginDirectory {
+  pluginDir: string;
+  packageName: string;
+}
+
+interface PackagedSkillRoot {
+  root: string;
+  packageName: string;
+}
+
+interface DeclaredPackage {
+  name: string;
+  spec: string;
 }
 
 type Status = "ok" | "warn" | "error";
@@ -85,6 +101,119 @@ async function pathIsFile(targetPath: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+async function readJsonFile<T>(targetPath: string): Promise<T | undefined> {
+  try {
+    return JSON.parse(await fs.readFile(targetPath, "utf8")) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+interface PackageJson {
+  dependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  version?: string;
+}
+
+async function readRootPackageJson(
+  rootDir: string,
+): Promise<PackageJson | undefined> {
+  return await readJsonFile<PackageJson>(path.join(rootDir, "package.json"));
+}
+
+function packageInstallDir(rootDir: string, packageName: string): string {
+  return path.join(rootDir, "node_modules", ...packageName.split("/"));
+}
+
+function declaredPackages(pkg: PackageJson | undefined): DeclaredPackage[] {
+  if (!pkg) {
+    return [];
+  }
+  const packages = new Map<string, string>();
+  for (const deps of [
+    pkg.dependencies,
+    pkg.optionalDependencies,
+    pkg.devDependencies,
+  ]) {
+    for (const [name, spec] of Object.entries(deps ?? {})) {
+      if (!packages.has(name)) {
+        packages.set(name, spec);
+      }
+    }
+  }
+  return [...packages.entries()]
+    .map(([name, spec]) => ({ name, spec }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+async function readInstalledPackageVersion(
+  rootDir: string,
+  packageName: string,
+): Promise<string | undefined> {
+  return (
+    await readJsonFile<PackageJson>(
+      path.join(packageInstallDir(rootDir, packageName), "package.json"),
+    )
+  )?.version;
+}
+
+async function packageHasPluginContent(
+  rootDir: string,
+  packageName: string,
+): Promise<boolean> {
+  const packageDir = packageInstallDir(rootDir, packageName);
+  return (
+    (await pathIsFile(path.join(packageDir, "plugin.yaml"))) ||
+    (await pathIsDirectory(path.join(packageDir, "plugins"))) ||
+    (await pathIsDirectory(path.join(packageDir, "skills")))
+  );
+}
+
+function comparableVersion(version: string | undefined): string | undefined {
+  return version?.match(/\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?/)?.[0];
+}
+
+async function collectPackageWarnings(
+  rootDir: string,
+  packages: DeclaredPackage[],
+): Promise<string[]> {
+  const warnings: string[] = [];
+  const packageSpecByName = new Map(
+    packages.map((declaredPackage) => [
+      declaredPackage.name,
+      declaredPackage.spec,
+    ]),
+  );
+  const coreVersion = comparableVersion(
+    (await readInstalledPackageVersion(rootDir, "@sentry/junior")) ??
+      packageSpecByName.get("@sentry/junior"),
+  );
+  if (!coreVersion) {
+    return warnings;
+  }
+
+  for (const declaredPackage of packages) {
+    if (!declaredPackage.name.startsWith("@sentry/junior-")) {
+      continue;
+    }
+    if (!(await packageHasPluginContent(rootDir, declaredPackage.name))) {
+      continue;
+    }
+    const pluginVersion = comparableVersion(
+      (await readInstalledPackageVersion(rootDir, declaredPackage.name)) ??
+        declaredPackage.spec,
+    );
+    if (pluginVersion && pluginVersion !== coreVersion) {
+      warnings.push(
+        `${path.join(rootDir, "package.json")}: ${declaredPackage.name} version ${pluginVersion} does not match @sentry/junior version ${coreVersion}`,
+      );
+    }
+  }
+
+  return warnings;
 }
 
 async function validateSkillDirectory(
@@ -214,6 +343,76 @@ async function collectPluginDirectories(rootDir: string): Promise<string[]> {
   return pluginDirs.sort((left, right) => left.localeCompare(right));
 }
 
+async function collectPackagedContent(
+  rootDir: string,
+  packages: DeclaredPackage[],
+): Promise<{
+  pluginDirs: PackagedPluginDirectory[];
+  skillRoots: PackagedSkillRoot[];
+}> {
+  const pluginDirs: PackagedPluginDirectory[] = [];
+  const skillRoots: PackagedSkillRoot[] = [];
+
+  for (const declaredPackage of packages) {
+    const packageDir = packageInstallDir(rootDir, declaredPackage.name);
+    if (!(await pathIsDirectory(packageDir))) {
+      continue;
+    }
+
+    const rootManifestPath = path.join(packageDir, "plugin.yaml");
+    const hasRootManifest = await pathIsFile(rootManifestPath);
+    const packageSkillsRoot = path.join(packageDir, "skills");
+
+    if (hasRootManifest) {
+      pluginDirs.push({
+        pluginDir: packageDir,
+        packageName: declaredPackage.name,
+      });
+    } else if (await pathIsDirectory(packageSkillsRoot)) {
+      skillRoots.push({
+        root: packageSkillsRoot,
+        packageName: declaredPackage.name,
+      });
+    }
+
+    const nestedPluginsRoot = path.join(packageDir, "plugins");
+    let nestedEntries;
+    try {
+      nestedEntries = await fs.readdir(nestedPluginsRoot, {
+        withFileTypes: true,
+      });
+    } catch {
+      continue;
+    }
+
+    for (const entry of nestedEntries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const pluginDir = path.join(nestedPluginsRoot, entry.name);
+      if (await pathIsFile(path.join(pluginDir, "plugin.yaml"))) {
+        pluginDirs.push({
+          pluginDir,
+          packageName: declaredPackage.name,
+        });
+      }
+    }
+  }
+
+  return {
+    pluginDirs: pluginDirs.sort((left, right) =>
+      `${left.packageName}:${left.pluginDir}`.localeCompare(
+        `${right.packageName}:${right.pluginDir}`,
+      ),
+    ),
+    skillRoots: skillRoots.sort((left, right) =>
+      `${left.packageName}:${left.root}`.localeCompare(
+        `${right.packageName}:${right.root}`,
+      ),
+    ),
+  };
+}
+
 async function collectSkillDirectories(root: string): Promise<string[]> {
   const skillDirs: string[] = [];
 
@@ -308,8 +507,11 @@ function reportPluginResult(
     skillWarningCount,
   );
   const pluginName = result.manifest?.name ?? path.basename(result.pluginDir);
+  const label = result.packageName
+    ? `packaged plugin ${pluginName} (${result.packageName})`
+    : `plugin ${pluginName}`;
 
-  io.info(formatHeading(status, `plugin ${pluginName}`));
+  io.info(formatHeading(status, label));
   for (const [index, skillResult] of result.skillResults.entries()) {
     reportSkillResult(
       skillResult,
@@ -320,7 +522,8 @@ function reportPluginResult(
   }
 }
 
-function reportAppSkills(
+function reportSkillGroup(
+  label: string,
   skillResults: SkillValidationResult[],
   io: ValidationIo,
 ): void {
@@ -334,10 +537,17 @@ function reportAppSkills(
   );
   const status = formatStatus(errorCount, warningCount);
 
-  io.info(formatHeading(status, "app skills"));
+  io.info(formatHeading(status, label));
   for (const [index, skillResult] of skillResults.entries()) {
     reportSkillResult(skillResult, io, "  ", index === skillResults.length - 1);
   }
+}
+
+function reportAppSkills(
+  skillResults: SkillValidationResult[],
+  io: ValidationIo,
+): void {
+  reportSkillGroup("app skills", skillResults, io);
 }
 
 interface AppFileValidationResult {
@@ -406,38 +616,82 @@ export async function runCheck(
     );
   }
 
-  const pluginDirs = await collectPluginDirectories(resolvedRoot);
+  const rootPackageJson = await readRootPackageJson(resolvedRoot);
+  const packages = declaredPackages(rootPackageJson);
+  const packageWarnings = await collectPackageWarnings(resolvedRoot, packages);
+  const packagedContent = await collectPackagedContent(resolvedRoot, packages);
+  const appPluginDirs = await collectPluginDirectories(resolvedRoot);
+  const packagedPluginDirs = packagedContent.pluginDirs;
+  const pluginDirs = [
+    ...appPluginDirs.map((pluginDir) => ({
+      pluginDir,
+      packageName: undefined,
+    })),
+    ...packagedPluginDirs,
+  ];
   const appSkillsRoot = contentRoot(resolvedRoot, "skills");
   const appSkillDirs = await collectSkillDirectories(appSkillsRoot);
   const pluginSkillDirs = new Map<string, string[]>();
-  for (const pluginDir of pluginDirs) {
+  for (const { pluginDir } of pluginDirs) {
     pluginSkillDirs.set(
       pluginDir,
       await collectSkillDirectories(path.join(pluginDir, "skills")),
     );
   }
+  const packagedSkillDirsByPackage = new Map<string, string[]>();
+  for (const skillRoot of packagedContent.skillRoots) {
+    packagedSkillDirsByPackage.set(
+      skillRoot.packageName,
+      await collectSkillDirectories(skillRoot.root),
+    );
+  }
+  const packagedStandaloneSkillDirs = [
+    ...packagedSkillDirsByPackage.values(),
+  ].flat();
 
-  const skillDirs = [
+  const appAndLocalPluginSkillDirs = [
     ...appSkillDirs,
-    ...pluginDirs.flatMap((pluginDir) => pluginSkillDirs.get(pluginDir) ?? []),
+    ...appPluginDirs.flatMap(
+      (pluginDir) => pluginSkillDirs.get(pluginDir) ?? [],
+    ),
   ].sort((left, right) => left.localeCompare(right));
+  const packagedSkillDirs = [
+    ...packagedPluginDirs.flatMap(
+      ({ pluginDir }) => pluginSkillDirs.get(pluginDir) ?? [],
+    ),
+    ...packagedStandaloneSkillDirs,
+  ].sort((left, right) => left.localeCompare(right));
+  const skillDirs = [...appAndLocalPluginSkillDirs, ...packagedSkillDirs].sort(
+    (left, right) => left.localeCompare(right),
+  );
   const duplicateSkillNames = new Map<string, string>();
   const duplicatePluginNames = new Map<string, string>();
   const duplicateProviderDomains = new Map<string, string>();
+  const duplicatePackagedSkillNames = new Map<string, string>();
+  const duplicatePackagedPluginNames = new Map<string, string>();
+  const duplicatePackagedProviderDomains = new Map<string, string>();
   const warnings: string[] = [];
   const errors: string[] = [];
   const pluginResults: PluginValidationResult[] = [];
   const skillResultsByDir = new Map<string, SkillValidationResult>();
+  warnings.push(...packageWarnings);
 
-  for (const pluginDir of pluginDirs) {
+  for (const { pluginDir, packageName } of pluginDirs) {
+    const pluginNameMap = packageName
+      ? duplicatePackagedPluginNames
+      : duplicatePluginNames;
+    const providerDomainMap = packageName
+      ? duplicatePackagedProviderDomains
+      : duplicateProviderDomains;
     const result = await validatePluginDirectory(
       pluginDir,
-      duplicatePluginNames,
-      duplicateProviderDomains,
+      pluginNameMap,
+      providerDomainMap,
     );
     pluginResults.push({
       pluginDir,
       manifestPath: result.manifestPath,
+      ...(packageName ? { packageName } : {}),
       ...(result.manifest ? { manifest: result.manifest } : {}),
       errors: result.errors,
       skillResults: [],
@@ -445,8 +699,17 @@ export async function runCheck(
     errors.push(...result.errors);
   }
 
-  for (const skillDir of skillDirs) {
+  for (const skillDir of appAndLocalPluginSkillDirs) {
     const result = await validateSkillDirectory(skillDir, duplicateSkillNames);
+    skillResultsByDir.set(skillDir, result);
+    warnings.push(...result.warnings);
+    errors.push(...result.errors);
+  }
+  for (const skillDir of packagedSkillDirs) {
+    const result = await validateSkillDirectory(
+      skillDir,
+      duplicatePackagedSkillNames,
+    );
     skillResultsByDir.set(skillDir, result);
     warnings.push(...result.warnings);
     errors.push(...result.errors);
@@ -463,6 +726,21 @@ export async function runCheck(
   const appSkillResults = appSkillDirs
     .map((skillDir) => skillResultsByDir.get(skillDir))
     .filter((result): result is SkillValidationResult => Boolean(result));
+  const packagedStandaloneSkillResultsByPackage = new Map<
+    string,
+    SkillValidationResult[]
+  >();
+  for (const [packageName, packageSkillDirs] of packagedSkillDirsByPackage) {
+    const packageSkillResults = packageSkillDirs
+      .map((skillDir) => skillResultsByDir.get(skillDir))
+      .filter((result): result is SkillValidationResult => Boolean(result));
+    if (packageSkillResults.length > 0) {
+      packagedStandaloneSkillResultsByPackage.set(
+        packageName,
+        packageSkillResults,
+      );
+    }
+  }
 
   const appDir = path.resolve(resolvedRoot, "app");
   let appFileResult: AppFileValidationResult = {
@@ -494,6 +772,16 @@ export async function runCheck(
 
   for (const pluginResult of pluginResults) {
     reportPluginResult(pluginResult, io);
+  }
+  for (const [
+    packageName,
+    packageSkillResults,
+  ] of packagedStandaloneSkillResultsByPackage) {
+    reportSkillGroup(
+      `packaged skills (${packageName})`,
+      packageSkillResults,
+      io,
+    );
   }
   if (appSkillResults.length > 0) {
     reportAppSkills(appSkillResults, io);

--- a/packages/junior/src/cli/init.ts
+++ b/packages/junior/src/cli/init.ts
@@ -86,6 +86,7 @@ export async function runInit(
     type: "module",
     scripts: {
       dev: "vite dev",
+      check: "junior check",
       build: "junior snapshot create && vite build",
     },
     dependencies: {

--- a/packages/junior/tests/unit/cli/check-cli.test.ts
+++ b/packages/junior/tests/unit/cli/check-cli.test.ts
@@ -121,6 +121,116 @@ describe("check cli", () => {
     ]);
   });
 
+  it("validates installed packaged plugin manifests and skills", async () => {
+    const repoRoot = makeTempDir("junior-validate-packaged-plugin-");
+    writeFile(
+      path.join(repoRoot, "package.json"),
+      JSON.stringify(
+        {
+          dependencies: {
+            "@acme/junior-demo": "1.0.0",
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    const packageRoot = path.join(
+      repoRoot,
+      "node_modules",
+      "@acme",
+      "junior-demo",
+    );
+    writeFile(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "@acme/junior-demo", version: "1.0.0" }),
+    );
+    writeFile(
+      path.join(packageRoot, "plugin.yaml"),
+      [
+        "name: demo",
+        "description: Demo packaged plugin",
+        "capabilities:",
+        "  - issues.read",
+        "",
+      ].join("\n"),
+    );
+    writeFile(
+      path.join(packageRoot, "skills", "demo-helper", "SKILL.md"),
+      [
+        "---",
+        "name: demo-helper",
+        "description: Help with packaged demo tasks.",
+        "---",
+        "",
+        "Use this skill.",
+        "",
+      ].join("\n"),
+    );
+
+    const lines: string[] = [];
+    await runCheck(repoRoot, {
+      info: (line) => lines.push(line),
+      warn: (line) => lines.push(line),
+      error: (line) => lines.push(line),
+    });
+
+    expect(lines).toEqual([
+      `Checking ${repoRoot}`,
+      "✓ packaged plugin demo (@acme/junior-demo)",
+      "  └─ ✓ skill demo-helper",
+      "✓ Validation passed (1 plugin manifest, 1 skill directory checked).",
+    ]);
+  });
+
+  it("warns when official plugin package versions differ from core", async () => {
+    const repoRoot = makeTempDir("junior-validate-version-skew-");
+    writeFile(
+      path.join(repoRoot, "package.json"),
+      JSON.stringify(
+        {
+          dependencies: {
+            "@sentry/junior": "^0.43.0",
+            "@sentry/junior-github": "^0.42.0",
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    writeFile(
+      path.join(repoRoot, "node_modules", "@sentry", "junior", "package.json"),
+      JSON.stringify({ name: "@sentry/junior", version: "0.43.0" }),
+    );
+    writeFile(
+      path.join(
+        repoRoot,
+        "node_modules",
+        "@sentry",
+        "junior-github",
+        "package.json",
+      ),
+      JSON.stringify({ name: "@sentry/junior-github", version: "0.42.0" }),
+    );
+    fs.mkdirSync(
+      path.join(repoRoot, "node_modules", "@sentry", "junior-github", "skills"),
+      { recursive: true },
+    );
+
+    const lines: string[] = [];
+    await runCheck(repoRoot, {
+      info: (line) => lines.push(line),
+      warn: (line) => lines.push(line),
+      error: (line) => lines.push(line),
+    });
+
+    expect(lines).toEqual([
+      `Checking ${repoRoot}`,
+      `⚠ warning: ${path.join(repoRoot, "package.json")}: @sentry/junior-github version 0.42.0 does not match @sentry/junior version 0.43.0`,
+      "✓ Validation passed (0 plugin manifests, 0 skill directories checked).",
+    ]);
+  });
+
   it("skips app file validation for unrelated app directories", async () => {
     const repoRoot = makeTempDir("junior-validate-empty-app-");
     fs.mkdirSync(path.join(repoRoot, "app"), { recursive: true });

--- a/packages/junior/tests/unit/cli/init-cli.test.ts
+++ b/packages/junior/tests/unit/cli/init-cli.test.ts
@@ -49,6 +49,7 @@ describe("init cli", () => {
     expect(pkg.devDependencies.vite).toBeDefined();
     expect(pkg.devDependencies.vercel).toBeUndefined();
     expect(pkg.scripts.dev).toBe("vite dev");
+    expect(pkg.scripts.check).toBe("junior check");
     expect(pkg.scripts.build).toBe("junior snapshot create && vite build");
   });
 


### PR DESCRIPTION
Extend `junior check` so the static safety check covers installed dependency packages that contain Junior plugin manifests or skills. This gives users a local post-update check for packaged plugin drift without touching production credentials or maintaining version-specific migration rules.

**Packaged Plugin Validation**

The checker now inspects declared dependencies in `node_modules` for root `plugin.yaml`, nested `plugins/`, and package `skills/` content, then runs the same manifest and skill validation used for app-local content.

**Official Package Skew**

Official `@sentry/junior-*` plugin packages now warn when their installed version differs from `@sentry/junior`, limited to packages that actually contain Junior plugin content.

**Scaffold and Docs**

New apps get a `check` script that runs `junior check`, and the CLI/quickstart docs describe using `pnpm check` after Junior or plugin package updates.