### PR TITLE
feat(slack): Add processing reactions for inbound messages

### DIFF
--- a/packages/junior/src/chat/runtime/processing-reaction.ts
+++ b/packages/junior/src/chat/runtime/processing-reaction.ts
@@ -1,0 +1,116 @@
+import type { Message, Thread } from "chat";
+import { getSlackErrorObservabilityAttributes } from "@/chat/slack/errors";
+import { normalizeSlackEmojiName } from "@/chat/slack/emoji";
+import {
+  addReactionToMessage,
+  removeReactionFromMessage,
+} from "@/chat/slack/outbound";
+import { getChannelId, getMessageTs } from "@/chat/runtime/thread-context";
+
+const PROCESSING_REACTION_EMOJI = "eyes";
+
+/** Controls the automatic Slack processing reaction lifecycle for one message. */
+export interface ProcessingReactionSession {
+  keep: () => void;
+  stop: () => Promise<void>;
+}
+
+const noProcessingReaction: ProcessingReactionSession = {
+  keep: () => undefined,
+  stop: async () => undefined,
+};
+
+function isProcessingReactionEmoji(value: unknown): boolean {
+  return (
+    typeof value === "string" &&
+    normalizeSlackEmojiName(value) === PROCESSING_REACTION_EMOJI
+  );
+}
+
+/** Return true when a Slack reaction tool call should leave the processing reaction in place. */
+export function shouldKeepProcessingReactionForToolInvocation(input: {
+  params: Record<string, unknown>;
+  toolName: string;
+}): boolean {
+  return (
+    input.toolName === "slackMessageAddReaction" &&
+    isProcessingReactionEmoji(input.params.emoji)
+  );
+}
+
+/** Start Junior's automatic Slack processing reaction for one inbound message. */
+export async function startSlackProcessingReaction(args: {
+  logException: (
+    error: unknown,
+    eventName: string,
+    context?: Record<string, unknown>,
+    attributes?: Record<string, unknown>,
+    body?: string,
+  ) => string | undefined;
+  logContext: Record<string, unknown>;
+  message: Message;
+  thread: Thread;
+}): Promise<ProcessingReactionSession> {
+  if (args.message.author.isMe) {
+    return noProcessingReaction;
+  }
+
+  const channelId = getChannelId(args.thread, args.message);
+  const messageTs = getMessageTs(args.message);
+  if (!channelId || !messageTs) {
+    return noProcessingReaction;
+  }
+
+  try {
+    await addReactionToMessage({
+      channelId,
+      timestamp: messageTs,
+      emoji: PROCESSING_REACTION_EMOJI,
+    });
+  } catch (error) {
+    args.logException(
+      error,
+      "slack_processing_reaction_add_failed",
+      args.logContext,
+      {
+        "app.slack.action": "reactions.add",
+        "messaging.message.id": messageTs,
+        ...getSlackErrorObservabilityAttributes(error),
+      },
+      "Failed to add Slack processing reaction",
+    );
+    return noProcessingReaction;
+  }
+
+  let shouldRemove = true;
+  return {
+    keep: () => {
+      shouldRemove = false;
+    },
+    stop: async () => {
+      if (!shouldRemove) {
+        return;
+      }
+
+      try {
+        await removeReactionFromMessage({
+          channelId,
+          timestamp: messageTs,
+          emoji: PROCESSING_REACTION_EMOJI,
+        });
+      } catch (error) {
+        args.logException(
+          error,
+          "slack_processing_reaction_remove_failed",
+          args.logContext,
+          {
+            "app.slack.action": "reactions.remove",
+            "messaging.message.id": messageTs,
+            ...getSlackErrorObservabilityAttributes(error),
+          },
+          "Failed to remove Slack processing reaction",
+        );
+      }
+    },
+  };
+}

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -123,6 +123,10 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
     options: {
       beforeFirstResponsePost?: () => Promise<void>;
       explicitMention?: boolean;
+      onToolInvocation?: (invocation: {
+        params: Record<string, unknown>;
+        toolName: string;
+      }) => void;
       preparedState?: PreparedTurnState;
     } = {},
   ) {
@@ -406,6 +410,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               });
             },
             onStatus: (nextStatus) => status.update(nextStatus),
+            onToolInvocation: options.onToolInvocation,
           });
           const diagnosticsContext = {
             slackThreadId: threadId,

--- a/packages/junior/src/chat/runtime/slack-runtime.ts
+++ b/packages/junior/src/chat/runtime/slack-runtime.ts
@@ -8,6 +8,11 @@ import {
   appendSlackLegacyAttachmentText,
   renderSlackLegacyAttachmentText,
 } from "@/chat/slack/legacy-attachments";
+import {
+  shouldKeepProcessingReactionForToolInvocation,
+  startSlackProcessingReaction,
+  type ProcessingReactionSession,
+} from "@/chat/runtime/processing-reaction";
 
 export interface AssistantLifecycleEvent {
   channelId: string;
@@ -28,6 +33,10 @@ export interface ThreadContext {
 
 export interface ReplyHooks {
   beforeFirstResponsePost?: () => Promise<void>;
+  onToolInvocation?: (invocation: {
+    params: Record<string, unknown>;
+    toolName: string;
+  }) => void;
 }
 
 const THREAD_OPTOUT_ACK =
@@ -124,6 +133,10 @@ export interface SlackTurnRuntimeDependencies<TPreparedState> {
     options?: {
       beforeFirstResponsePost?: () => Promise<void>;
       explicitMention?: boolean;
+      onToolInvocation?: (invocation: {
+        params: Record<string, unknown>;
+        toolName: string;
+      }) => void;
       preparedState?: TPreparedState;
     },
   ) => Promise<void>;
@@ -206,6 +219,21 @@ export function createSlackTurnRuntime<
     runId?: string;
   }): RuntimeLogContext => buildLogContext(deps, args);
 
+  const createToolInvocationHook = (
+    processingReaction: ProcessingReactionSession,
+    hooks: ReplyHooks | undefined,
+  ) => {
+    return (invocation: {
+      params: Record<string, unknown>;
+      toolName: string;
+    }): void => {
+      if (shouldKeepProcessingReactionForToolInvocation(invocation)) {
+        processingReaction.keep();
+      }
+      hooks?.onToolInvocation?.(invocation);
+    };
+  };
+
   const postFallbackErrorReplyWithLogging = async (args: {
     thread: Thread;
     errorContext: RuntimeLogContext;
@@ -278,6 +306,7 @@ export function createSlackTurnRuntime<
       message: Message,
       hooks?: ReplyHooks,
     ): Promise<void> {
+      let processingReaction: ProcessingReactionSession | undefined;
       try {
         const threadId = deps.getThreadId(thread, message);
         const channelId = deps.getChannelId(thread, message);
@@ -289,12 +318,23 @@ export function createSlackTurnRuntime<
           requesterUserName: message.author.userName,
           runId,
         });
+        processingReaction = await startSlackProcessingReaction({
+          thread,
+          message,
+          logException: deps.logException,
+          logContext: context,
+        });
+        const toolInvocationHook = createToolInvocationHook(
+          processingReaction,
+          hooks,
+        );
 
         await deps.withSpan("chat.turn", "chat.turn", context, async () => {
           await thread.subscribe();
           await deps.replyToThread(thread, message, {
             explicitMention: true,
             beforeFirstResponsePost: hooks?.beforeFirstResponsePost,
+            onToolInvocation: toolInvocationHook,
           });
         });
       } catch (error) {
@@ -339,6 +379,8 @@ export function createSlackTurnRuntime<
           postFailureBody:
             "Failed to post fallback error reply for mention handler",
         });
+      } finally {
+        await processingReaction?.stop();
       }
     },
 
@@ -347,126 +389,134 @@ export function createSlackTurnRuntime<
       message: Message,
       hooks?: ReplyHooks,
     ): Promise<void> {
+      let processingReaction: ProcessingReactionSession | undefined;
       try {
         const threadId = deps.getThreadId(thread, message);
         const channelId = deps.getChannelId(thread, message);
         const runId = deps.getRunId(thread, message);
-        await deps.withSpan(
-          "chat.turn",
-          "chat.turn",
-          logContext({
+        const context = logContext({
+          threadId,
+          requesterId: message.author.userId,
+          requesterUserName: message.author.userName,
+          channelId,
+          runId,
+        });
+        processingReaction = await startSlackProcessingReaction({
+          thread,
+          message,
+          logException: deps.logException,
+          logContext: context,
+        });
+        const toolInvocationHook = createToolInvocationHook(
+          processingReaction,
+          hooks,
+        );
+        await deps.withSpan("chat.turn", "chat.turn", context, async () => {
+          // This path can compact context and run router/vision model calls
+          // before replyToThread() opens the main reply span.
+          const legacyAttachmentText = renderSlackLegacyAttachmentText(
+            message.raw,
+          );
+          const rawUserText = appendSlackLegacyAttachmentText(
+            message.text,
+            message.raw,
+          );
+          const strippedUserText = deps.stripLeadingBotMention(message.text, {
+            stripLeadingSlackMentionToken: Boolean(message.isMention),
+          });
+          const userText = appendSlackLegacyAttachmentText(
+            strippedUserText,
+            message.raw,
+          );
+          const context: ThreadContext = {
             threadId,
             requesterId: message.author.userId,
-            requesterUserName: message.author.userName,
             channelId,
             runId,
-          }),
-          async () => {
-            // This path can compact context and run router/vision model calls
-            // before replyToThread() opens the main reply span.
-            const legacyAttachmentText = renderSlackLegacyAttachmentText(
-              message.raw,
-            );
-            const rawUserText = appendSlackLegacyAttachmentText(
-              message.text,
-              message.raw,
-            );
-            const strippedUserText = deps.stripLeadingBotMention(message.text, {
-              stripLeadingSlackMentionToken: Boolean(message.isMention),
-            });
-            const userText = appendSlackLegacyAttachmentText(
-              strippedUserText,
-              message.raw,
-            );
-            const context: ThreadContext = {
-              threadId,
-              requesterId: message.author.userId,
-              channelId,
-              runId,
-            };
+          };
 
-            const preflightDecision = getSubscribedReplyPreflightDecision({
-              botUserName: deps.assistantUserName,
-              rawText: rawUserText,
-              text: userText,
-              isExplicitMention: Boolean(message.isMention),
-            });
+          const preflightDecision = getSubscribedReplyPreflightDecision({
+            botUserName: deps.assistantUserName,
+            rawText: rawUserText,
+            text: userText,
+            isExplicitMention: Boolean(message.isMention),
+          });
 
-            if (preflightDecision && !preflightDecision.shouldReply) {
-              const reason = preflightDecision.reasonDetail
-                ? `${preflightDecision.reason}:${preflightDecision.reasonDetail}`
-                : preflightDecision.reason;
-              await skipSubscribedMessage({
-                thread,
-                message,
-                decision: { shouldReply: false, reason },
-                context,
-                userText,
-              });
-              return;
-            }
-
-            const preparedState = await deps.prepareTurnState({
+          if (preflightDecision && !preflightDecision.shouldReply) {
+            const reason = preflightDecision.reasonDetail
+              ? `${preflightDecision.reason}:${preflightDecision.reasonDetail}`
+              : preflightDecision.reason;
+            await skipSubscribedMessage({
               thread,
               message,
+              decision: { shouldReply: false, reason },
+              context,
               userText,
-              explicitMention: Boolean(message.isMention),
-              context,
             });
+            return;
+          }
 
-            await deps.persistPreparedState({
+          const preparedState = await deps.prepareTurnState({
+            thread,
+            message,
+            userText,
+            explicitMention: Boolean(message.isMention),
+            context,
+          });
+
+          await deps.persistPreparedState({
+            thread,
+            preparedState,
+          });
+
+          const decision = await deps.decideSubscribedReply({
+            rawText: rawUserText,
+            text: userText,
+            conversationContext:
+              deps.getPreparedConversationContext(preparedState),
+            hasAttachments:
+              message.attachments.length > 0 || legacyAttachmentText !== "",
+            isExplicitMention: Boolean(message.isMention),
+            context,
+          });
+
+          if (
+            await maybeHandleThreadOptOutDecision({
               thread,
-              preparedState,
-            });
-
-            const decision = await deps.decideSubscribedReply({
-              rawText: rawUserText,
-              text: userText,
-              conversationContext:
-                deps.getPreparedConversationContext(preparedState),
-              hasAttachments:
-                message.attachments.length > 0 || legacyAttachmentText !== "",
-              isExplicitMention: Boolean(message.isMention),
-              context,
-            });
-
-            if (
-              await maybeHandleThreadOptOutDecision({
-                thread,
-                decision,
-                beforeFirstResponsePost: hooks?.beforeFirstResponsePost,
-              })
-            ) {
-              await skipSubscribedMessage({
-                thread,
-                message,
-                decision,
-                context,
-                preparedState,
-                userText,
-              });
-              return;
-            }
-
-            if (!decision.shouldReply) {
-              await skipSubscribedMessage({
-                thread,
-                message,
-                decision,
-                context,
-                preparedState,
-                userText,
-              });
-              return;
-            }
-
-            await deps.replyToThread(thread, message, {
-              explicitMention: Boolean(message.isMention),
-              preparedState,
+              decision,
               beforeFirstResponsePost: hooks?.beforeFirstResponsePost,
+            })
+          ) {
+            await skipSubscribedMessage({
+              thread,
+              message,
+              decision,
+              context,
+              preparedState,
+              userText,
             });
-          },
-        );
+            return;
+          }
+
+          if (!decision.shouldReply) {
+            await skipSubscribedMessage({
+              thread,
+              message,
+              decision,
+              context,
+              preparedState,
+              userText,
+            });
+            return;
+          }
+
+          await deps.replyToThread(thread, message, {
+            explicitMention: Boolean(message.isMention),
+            preparedState,
+            beforeFirstResponsePost: hooks?.beforeFirstResponsePost,
+            onToolInvocation: toolInvocationHook,
+          });
+        });
       } catch (error) {
         const errorContext = logContext({
           threadId: deps.getThreadId(thread, message),
@@ -510,6 +560,8 @@ export function createSlackTurnRuntime<
           postFailureBody:
             "Failed to post fallback error reply for subscribed message handler",
         });
+      } finally {
+        await processingReaction?.stop();
       }
     },
 

--- a/packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import { createTestChatRuntime } from "../../fixtures/chat-runtime";
+import {
+  createTestMessage,
+  createTestThread,
+} from "../../fixtures/slack-harness";
+import { getCapturedSlackApiCalls } from "../../msw/handlers/slack-api";
+
+function successDiagnostics(toolCalls: string[] = []) {
+  return {
+    assistantMessageCount: 1,
+    modelId: "fake-agent-model",
+    outcome: "success" as const,
+    toolCalls,
+    toolErrorCount: 0,
+    toolResultCount: toolCalls.length,
+    usedPrimaryText: true,
+  };
+}
+
+describe("Slack behavior: processing reaction", () => {
+  it("adds eyes before mention work and removes it after the reply", async () => {
+    const { slackRuntime } = createTestChatRuntime({
+      services: {
+        replyExecutor: {
+          generateAssistantReply: async () => {
+            expect(getCapturedSlackApiCalls("reactions.add")).toHaveLength(1);
+            expect(getCapturedSlackApiCalls("reactions.remove")).toHaveLength(
+              0,
+            );
+            return {
+              text: "Done.",
+              diagnostics: successDiagnostics(),
+            };
+          },
+        },
+      },
+    });
+
+    const thread = createTestThread({
+      id: "slack:C_PROCESSING:1700007000.000000",
+    });
+    await slackRuntime.handleNewMention(
+      thread,
+      createTestMessage({
+        id: "1700007001.000000",
+        text: "<@U_APP> handle this",
+        isMention: true,
+        threadId: thread.id,
+        raw: {
+          channel: "C_PROCESSING",
+          ts: "1700007001.000000",
+          thread_ts: "1700007000.000000",
+        },
+      }),
+    );
+
+    expect(getCapturedSlackApiCalls("reactions.add")).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({
+          channel: "C_PROCESSING",
+          timestamp: "1700007001.000000",
+          name: "eyes",
+        }),
+      }),
+    ]);
+    expect(getCapturedSlackApiCalls("reactions.remove")).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({
+          channel: "C_PROCESSING",
+          timestamp: "1700007001.000000",
+          name: "eyes",
+        }),
+      }),
+    ]);
+  });
+
+  it("removes eyes when a subscribed message is skipped", async () => {
+    const { slackRuntime } = createTestChatRuntime({
+      services: {
+        subscribedReplyPolicy: {
+          completeObject: async () =>
+            ({
+              object: {
+                should_reply: false,
+                confidence: 0,
+                reason: "side conversation",
+              },
+              text: '{"should_reply":false,"confidence":0,"reason":"side conversation"}',
+            }) as never,
+        },
+        replyExecutor: {
+          generateAssistantReply: async () => {
+            throw new Error("assistant should not run for skipped message");
+          },
+        },
+      },
+    });
+
+    const thread = createTestThread({
+      id: "slack:C_PROCESSING:1700007100.000000",
+    });
+    await slackRuntime.handleSubscribedMessage(
+      thread,
+      createTestMessage({
+        id: "1700007101.000000",
+        text: "sounds good, thanks",
+        isMention: false,
+        threadId: thread.id,
+        raw: {
+          channel: "C_PROCESSING",
+          ts: "1700007101.000000",
+          thread_ts: "1700007100.000000",
+        },
+      }),
+    );
+
+    expect(thread.posts).toHaveLength(0);
+    expect(getCapturedSlackApiCalls("reactions.add")).toHaveLength(1);
+    expect(getCapturedSlackApiCalls("reactions.remove")).toHaveLength(1);
+  });
+
+  it("keeps eyes when the assistant explicitly adds an eyes reaction", async () => {
+    const { slackRuntime } = createTestChatRuntime({
+      services: {
+        replyExecutor: {
+          generateAssistantReply: async (_prompt, context) => {
+            context?.onToolInvocation?.({
+              toolName: "slackMessageAddReaction",
+              params: { emoji: ":eyes:" },
+            });
+            return {
+              text: "Done.",
+              diagnostics: successDiagnostics(["slackMessageAddReaction"]),
+            };
+          },
+        },
+      },
+    });
+
+    const thread = createTestThread({
+      id: "slack:C_PROCESSING:1700007200.000000",
+    });
+    await slackRuntime.handleNewMention(
+      thread,
+      createTestMessage({
+        id: "1700007201.000000",
+        text: "<@U_APP> add eyes to this",
+        isMention: true,
+        threadId: thread.id,
+        raw: {
+          channel: "C_PROCESSING",
+          ts: "1700007201.000000",
+          thread_ts: "1700007200.000000",
+        },
+      }),
+    );
+
+    expect(getCapturedSlackApiCalls("reactions.add")).toHaveLength(1);
+    expect(getCapturedSlackApiCalls("reactions.remove")).toHaveLength(0);
+  });
+});

--- a/packages/junior/tests/unit/slack/slack-runtime.test.ts
+++ b/packages/junior/tests/unit/slack/slack-runtime.test.ts
@@ -57,7 +57,9 @@ describe("createSlackTurnRuntime", () => {
 
       expect(thread.subscribeCalls).toBe(1);
       expect(deps.replyToThread).toHaveBeenCalledWith(thread, message, {
+        beforeFirstResponsePost: undefined,
         explicitMention: true,
+        onToolInvocation: expect.any(Function),
       });
     });
   });

--- a/specs/slack-agent-delivery-spec.md
+++ b/specs/slack-agent-delivery-spec.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-04-15
-- Last Edited: 2026-05-13
+- Last Edited: 2026-05-16
 
 ## Changelog
 
@@ -22,6 +22,7 @@
 - 2026-04-22: Reframed auth-blocked requests as completed thread replies plus thread-local pending-auth state, and removed the public OAuth "connected, continuing..." preamble from automatic resumes.
 - 2026-05-06: Removed the public thread-visible auth-pause note; private auth-link delivery is the only immediate user-facing auth handoff before callback resume.
 - 2026-05-13: Added the turn-continuation acknowledgement and follow-up retry contract for awaiting continuation checkpoints.
+- 2026-05-16: Added automatic processing reactions for Slack messages Junior is handling or evaluating for handling.
 
 ## Status
 
@@ -143,7 +144,19 @@ Design note:
    - Ordinary tool calls must not synthesize progress phases or override the generic loading-message rotation.
    - Footer metadata, when enabled, is a separate finalized-reply affordance and must not be treated as assistant progress.
 
-### 5. Primary Reply Contract
+### 5. Processing Reaction Contract
+
+Junior must acknowledge Slack messages it is handling, or evaluating for handling, with an automatic processing reaction.
+
+Current rules:
+
+1. DM, explicit-mention, and subscribed-thread message handlers add `:eyes:` before turn preparation, passive reply classification, or assistant execution.
+2. Junior removes that automatic `:eyes:` reaction when the handler completes, including reply, skip, opt-out, auth-pause, timeout-continuation, and fallback-error paths.
+3. Processing-reaction add and remove calls are best effort. Failures are observable but must not fail the turn or change reply routing.
+4. The automatic processing reaction is runtime-owned. It must not be exposed as model progress, and it must not count as a successful user-requested reaction tool call.
+5. If the assistant explicitly uses the Slack reaction tool to add `:eyes:` to the same inbound message, Junior leaves the reaction in place instead of removing the automatic acknowledgement.
+
+### 6. Primary Reply Contract
 
 Junior has one primary visible reply surface per turn: finalized Slack thread replies.
 
@@ -161,7 +174,7 @@ Current rules:
 
 This is intentional. Slack-native text streaming may still exist as an adapter capability, but it is not part of Junior's correctness contract.
 
-### 6. Continuation Contract
+### 7. Continuation Contract
 
 Slack continuation posts are part of the user-visible delivery contract.
 
@@ -175,7 +188,7 @@ Current rules:
 6. If a visible reply ended because the provider failed mid-turn, the final visible chunk ends with `[Response interrupted before completion]`.
 7. Continuation markers are delivery-time formatting, not model-authored text.
 
-### 7. Code Fence Continuation Contract
+### 8. Code Fence Continuation Contract
 
 Continuation behavior must preserve readable fenced markdown/code in Slack.
 
@@ -186,7 +199,7 @@ Current rules:
 
 This is required for readable Slack rendering, not an optional formatting nicety.
 
-### 8. File Delivery Contract
+### 9. File Delivery Contract
 
 Files are part of the same finalized reply-delivery plan as text.
 
@@ -197,7 +210,7 @@ Current rules:
 3. If thread text is intentionally suppressed, files may still be delivered through the thread reply planner when the reply contract requires visible artifacts.
 4. Resume and OAuth callback flows must use the same file-delivery semantics as the main runtime path.
 
-### 9. Image Ingress Contract
+### 10. Image Ingress Contract
 
 Images passed into Slack threads are part of the thread context contract.
 
@@ -209,7 +222,7 @@ Current rules:
 4. Later explicit mentions in the same thread may rely on previously skipped screenshots or image uploads still being recoverable from persisted conversation state.
 5. If Slack delivered an image attachment but the current Junior runtime cannot analyze images, replies must say that the image was received but cannot be analyzed; they must not claim that no image was attached.
 
-### 10. Resume Delivery Contract
+### 11. Resume Delivery Contract
 
 Paused turns resumed by timeout or OAuth must follow the same final Slack delivery contract as live turns.
 
@@ -227,7 +240,7 @@ Current rules:
 10. If a user follow-up or duplicate delivery hits the same awaiting continuation, Junior should acknowledge the existing continuation instead of creating a second visible turn. Checkpoint rescheduling mechanics belong to `./agent-session-resumability-spec.md`.
 11. Turn-continuation acknowledgements are not final assistant replies. They do not mark the original turn completed, and the final resumed answer must still be delivered through the normal finalized-reply path.
 
-### 11. Testing Contract
+### 12. Testing Contract
 
 Slack integration coverage must be behavior-first while still protecting real Slack transport contracts.
 


### PR DESCRIPTION
Add automatic Slack `:eyes:` reactions while Junior handles or evaluates inbound Slack messages. This gives users immediate feedback before subscribed-message classification or agent execution, then removes the reaction when handling completes.

**Processing Reaction Lifecycle**

DM, mention, and subscribed-thread handlers add the reaction at the runtime boundary and clean it up in `finally` across replies, skips, auth pauses, and fallback errors. Reaction API calls remain best effort through the shared Slack outbound boundary.

**Explicit Eyes Reactions**

When the assistant explicitly invokes the Slack reaction tool with `:eyes:`, the runtime leaves the reaction in place instead of removing it as automatic progress.