### PR TITLE
fix(sandbox): Restore proxied credential egress

### DIFF
--- a/packages/junior/src/chat/sandbox/egress-policy.ts
+++ b/packages/junior/src/chat/sandbox/egress-policy.ts
@@ -1,5 +1,5 @@
 import type { NetworkPolicy, NetworkPolicyRule } from "@vercel/sandbox";
-import type { CredentialHeaderTransform } from "@/chat/credentials/broker";
+import { resolveBaseUrl } from "@/chat/oauth-flow";
 import { resolveAuthTokenPlaceholder } from "@/chat/plugins/auth/auth-token-placeholder";
 import { resolvePluginCommandEnv } from "@/chat/plugins/command-env";
 import { getPluginProviders } from "@/chat/plugins/registry";
@@ -31,10 +31,6 @@ function providerEntries(): Array<{ provider: string; domains: string[] }> {
     .sort((left, right) => left.provider.localeCompare(right.provider));
 }
 
-function normalizeDomain(domain: string): string {
-  return domain.toLowerCase();
-}
-
 /** Resolve the plugin provider responsible for an outbound sandbox host. */
 export function resolveSandboxEgressProviderForHost(
   host: string,
@@ -44,53 +40,30 @@ export function resolveSandboxEgressProviderForHost(
   )?.provider;
 }
 
-/** Return whether a provider can supply host-managed sandbox credential headers. */
-export function hasSandboxCredentialEgress(provider: string): boolean {
-  const plugin = getPluginProviders().find(
-    (candidate) => candidate.manifest.name === provider,
-  );
-  return Boolean(plugin?.manifest.credentials || plugin?.manifest.apiHeaders);
-}
-
-function mergeHeaderTransforms(
-  headerTransforms: CredentialHeaderTransform[],
-): Map<string, Record<string, string>> {
-  const headersByDomain = new Map<string, Record<string, string>>();
-  for (const transform of headerTransforms) {
-    const domain = normalizeDomain(transform.domain);
-    const existing = headersByDomain.get(domain) ?? {};
-    headersByDomain.set(domain, {
-      ...existing,
-      ...transform.headers,
-    });
+function sandboxProxyUrl(): string {
+  const baseUrl = resolveBaseUrl();
+  if (!baseUrl) {
+    throw new Error(
+      "Cannot determine base URL for sandbox credential egress (set JUNIOR_BASE_URL or deploy to Vercel)",
+    );
   }
-  return headersByDomain;
+  return new URL("/", baseUrl).toString();
 }
 
-/** Build the command-scoped policy that injects credential headers without rewriting URLs. */
-export function buildSandboxEgressNetworkPolicy(input?: {
-  headerTransforms?: CredentialHeaderTransform[];
-}): NetworkPolicy {
-  const headerTransforms = input?.headerTransforms ?? [];
-  const headersByDomain = mergeHeaderTransforms(headerTransforms);
+/** Build the policy that forwards provider requests back to Junior for credentials. */
+export function buildSandboxEgressNetworkPolicy(): NetworkPolicy {
   const allow: Record<string, NetworkPolicyRule[]> = {
     "*": [],
   };
-
-  for (const entry of providerEntries()) {
-    for (const domain of entry.domains) {
-      const headers = headersByDomain.get(normalizeDomain(domain));
-      if (headers && Object.keys(headers).length > 0) {
-        allow[domain] = [{ transform: [{ headers }] }];
-      }
-      headersByDomain.delete(normalizeDomain(domain));
-    }
+  const entries = providerEntries();
+  if (entries.length === 0) {
+    return { allow };
   }
-  for (const [domain, headers] of [...headersByDomain.entries()].sort(
-    ([left], [right]) => left.localeCompare(right),
-  )) {
-    if (Object.keys(headers).length > 0) {
-      allow[domain] = [{ transform: [{ headers }] }];
+
+  const forwardURL = sandboxProxyUrl();
+  for (const entry of entries) {
+    for (const domain of entry.domains) {
+      allow[domain] = [{ forwardURL }];
     }
   }
 

--- a/packages/junior/src/chat/sandbox/egress-proxy.ts
+++ b/packages/junior/src/chat/sandbox/egress-proxy.ts
@@ -1,6 +1,6 @@
 import { issueProviderCredentialLease } from "@/chat/capabilities/factory";
 import { CredentialUnavailableError } from "@/chat/credentials/broker";
-import { logWarn } from "@/chat/logging";
+import { logInfo, logWarn } from "@/chat/logging";
 import {
   matchesSandboxEgressDomain,
   resolveSandboxEgressProviderForHost,
@@ -20,6 +20,7 @@ const OIDC_TOKEN_HEADER = "vercel-sandbox-oidc-token";
 const FORWARDED_HOST_HEADER = "vercel-forwarded-host";
 const FORWARDED_SCHEME_HEADER = "vercel-forwarded-scheme";
 const FORWARDED_PORT_HEADER = "vercel-forwarded-port";
+const FORWARDED_PATH_HEADER = "vercel-forwarded-path";
 const HOP_BY_HOP_HEADERS = new Set([
   "connection",
   "host",
@@ -36,6 +37,7 @@ const PROXY_ONLY_HEADERS = new Set([
   FORWARDED_HOST_HEADER,
   FORWARDED_SCHEME_HEADER,
   FORWARDED_PORT_HEADER,
+  FORWARDED_PATH_HEADER,
 ]);
 const DECODED_RESPONSE_HEADERS = new Set([
   "content-encoding",
@@ -48,9 +50,24 @@ interface ProxyDeps {
 }
 
 type UpstreamUrlResult = { ok: true; url: URL } | { ok: false; error: string };
+type UpstreamPathResult =
+  | { ok: true; path: string }
+  | { ok: false; error: string };
 
 function jsonError(message: string, status: number): Response {
   return Response.json({ error: message }, { status });
+}
+
+function shouldLogSandboxEgressInfo(): boolean {
+  const environment = (
+    process.env.SENTRY_ENVIRONMENT ??
+    process.env.VERCEL_ENV ??
+    process.env.NODE_ENV ??
+    ""
+  )
+    .trim()
+    .toLowerCase();
+  return environment !== "production";
 }
 
 function egressAttributes(input: {
@@ -69,6 +86,50 @@ function egressAttributes(input: {
     ...(input.path ? { "url.path": input.path } : {}),
     ...(input.status ? { "http.response.status_code": input.status } : {}),
   };
+}
+
+function routingAttributes(
+  request: Request,
+  upstreamUrl?: URL,
+): Record<string, unknown> {
+  const proxyUrl = new URL(request.url);
+  const attributes: Record<string, unknown> = {
+    "app.sandbox.egress.proxy_path": proxyUrl.pathname,
+  };
+  if (upstreamUrl) {
+    attributes["app.sandbox.egress.upstream_path"] = upstreamUrl.pathname;
+  }
+  return attributes;
+}
+
+function logSandboxEgressUpstreamRequest(input: {
+  egressId: string;
+  provider: string;
+  request: Request;
+  upstream: Response;
+  upstreamUrl: URL;
+}): void {
+  if (!shouldLogSandboxEgressInfo()) {
+    return;
+  }
+
+  logInfo(
+    "sandbox_egress_upstream_request",
+    {},
+    {
+      ...egressAttributes({
+        egressId: input.egressId,
+        host: input.upstreamUrl.hostname,
+        method: input.request.method,
+        path: input.upstreamUrl.pathname,
+        provider: input.provider,
+        status: input.upstream.status,
+      }),
+      ...routingAttributes(input.request, input.upstreamUrl),
+      "app.sandbox.egress.upstream_ok": input.upstream.ok,
+    },
+    `Sandbox egress ${input.request.method} ${input.upstreamUrl.hostname}${input.upstreamUrl.pathname} -> ${input.upstream.status}`,
+  );
 }
 
 function normalizeHost(value: string): string | undefined {
@@ -106,9 +167,29 @@ function sandboxIdFromPayload(payload: JWTPayload): string | undefined {
     : undefined;
 }
 
-function upstreamPath(request: Request): string {
+function upstreamPath(request: Request): UpstreamPathResult {
+  const forwardedPath = request.headers.get(FORWARDED_PATH_HEADER);
+  if (forwardedPath?.trim()) {
+    // Vercel may normalize request.url; this header carries the original target.
+    const path = forwardedPath.trim();
+    if (
+      !path.startsWith("/") ||
+      path.startsWith("//") ||
+      path.includes("#") ||
+      /[\r\n]/.test(path)
+    ) {
+      return { ok: false, error: "Invalid forwarded path" };
+    }
+    try {
+      const url = new URL(path, "https://sandbox-forwarded.local");
+      return { ok: true, path: `${url.pathname}${url.search}` };
+    } catch {
+      return { ok: false, error: "Invalid forwarded path" };
+    }
+  }
+
   const url = new URL(request.url);
-  return `${url.pathname}${url.search}`;
+  return { ok: true, path: `${url.pathname}${url.search}` };
 }
 
 function buildUpstreamUrl(request: Request): UpstreamUrlResult {
@@ -134,8 +215,13 @@ function buildUpstreamUrl(request: Request): UpstreamUrlResult {
     return { ok: false, error: "Invalid forwarded port" };
   }
   const path = upstreamPath(request);
+  if (!path.ok) {
+    return { ok: false, error: path.error };
+  }
   try {
-    const url = new URL(`${scheme}://${host}${port ? `:${port}` : ""}${path}`);
+    const url = new URL(
+      `${scheme}://${host}${port ? `:${port}` : ""}${path.path}`,
+    );
     return { ok: true, url };
   } catch {
     return { ok: false, error: "Invalid forwarded URL" };
@@ -300,12 +386,15 @@ export async function proxySandboxEgressRequest(
     logWarn(
       "sandbox_egress_upstream_url_invalid",
       {},
-      egressAttributes({
-        egressId: activeEgressId,
-        method: request.method,
-        path: new URL(request.url).pathname,
-        status: 400,
-      }),
+      {
+        ...egressAttributes({
+          egressId: activeEgressId,
+          method: request.method,
+          path: new URL(request.url).pathname,
+          status: 400,
+        }),
+        ...routingAttributes(request),
+      },
       "Sandbox egress forwarded request had invalid upstream routing headers",
     );
     return jsonError(upstreamResult.error, 400);
@@ -317,13 +406,16 @@ export async function proxySandboxEgressRequest(
     logWarn(
       "sandbox_egress_provider_unresolved",
       {},
-      egressAttributes({
-        egressId: activeEgressId,
-        host: upstreamUrl.hostname,
-        method: request.method,
-        path: upstreamUrl.pathname,
-        status: 403,
-      }),
+      {
+        ...egressAttributes({
+          egressId: activeEgressId,
+          host: upstreamUrl.hostname,
+          method: request.method,
+          path: upstreamUrl.pathname,
+          status: 403,
+        }),
+        ...routingAttributes(request, upstreamUrl),
+      },
       "Sandbox egress forwarded host is not owned by any credential provider",
     );
     return jsonError("No provider owns forwarded host", 403);
@@ -336,14 +428,17 @@ export async function proxySandboxEgressRequest(
     logWarn(
       "sandbox_egress_session_unauthorized",
       {},
-      egressAttributes({
-        egressId: activeEgressId,
-        host: upstreamUrl.hostname,
-        method: request.method,
-        path: upstreamUrl.pathname,
-        provider,
-        status: 403,
-      }),
+      {
+        ...egressAttributes({
+          egressId: activeEgressId,
+          host: upstreamUrl.hostname,
+          method: request.method,
+          path: upstreamUrl.pathname,
+          provider,
+          status: 403,
+        }),
+        ...routingAttributes(request, upstreamUrl),
+      },
       "Sandbox egress VM session is not authorized for requester credentials",
     );
     return jsonError("Sandbox egress session is not authorized", 403);
@@ -357,14 +452,17 @@ export async function proxySandboxEgressRequest(
       logWarn(
         "sandbox_egress_credential_unavailable",
         {},
-        egressAttributes({
-          egressId: activeEgressId,
-          host: upstreamUrl.hostname,
-          method: request.method,
-          path: upstreamUrl.pathname,
-          provider,
-          status: 401,
-        }),
+        {
+          ...egressAttributes({
+            egressId: activeEgressId,
+            host: upstreamUrl.hostname,
+            method: request.method,
+            path: upstreamUrl.pathname,
+            provider,
+            status: 401,
+          }),
+          ...routingAttributes(request, upstreamUrl),
+        },
         "Sandbox egress provider credential is unavailable",
       );
       return new Response(
@@ -394,6 +492,7 @@ export async function proxySandboxEgressRequest(
         "app.sandbox.egress.transform_domains": lease.headerTransforms.map(
           (transform) => transform.domain,
         ),
+        ...routingAttributes(request, upstreamUrl),
       },
       "Sandbox egress credential lease does not cover forwarded host",
     );
@@ -406,10 +505,17 @@ export async function proxySandboxEgressRequest(
   const upstream = await fetchImpl(upstreamUrl, {
     method: request.method,
     headers,
-    ...(body ? { body } : {}),
+    ...(body !== undefined ? { body } : {}),
     redirect: "manual",
   });
-  if (!upstream.ok) {
+  logSandboxEgressUpstreamRequest({
+    egressId: activeEgressId,
+    provider,
+    request,
+    upstream,
+    upstreamUrl,
+  });
+  if (upstream.status >= 400) {
     logWarn(
       "sandbox_egress_upstream_error_response",
       {},
@@ -422,6 +528,7 @@ export async function proxySandboxEgressRequest(
           provider,
           status: upstream.status,
         }),
+        ...routingAttributes(request, upstreamUrl),
         "error.type": `http_${upstream.status}`,
       },
       `Sandbox egress upstream returned HTTP ${upstream.status}`,
@@ -440,6 +547,7 @@ export async function proxySandboxEgressRequest(
           provider,
           status: upstream.status,
         }),
+        ...routingAttributes(request, upstreamUrl),
       },
       "Sandbox egress upstream auth rejected",
     );

--- a/packages/junior/src/chat/sandbox/noninteractive-command.ts
+++ b/packages/junior/src/chat/sandbox/noninteractive-command.ts
@@ -31,7 +31,7 @@ const NON_INTERACTIVE_ENV: Readonly<Record<string, string>> = {
   GCM_INTERACTIVE: "never",
   DEBIAN_FRONTEND: "noninteractive",
   // Git credential isolation: prevent git from sending its own auth so the
-  // sandbox network proxy's header transforms are the sole credential source.
+  // sandbox egress proxy's header transforms are the sole credential source.
   GIT_ASKPASS: "/bin/true",
   GIT_CONFIG_NOSYSTEM: "1",
   GIT_CONFIG_COUNT: "2",

--- a/packages/junior/src/chat/sandbox/sandbox.ts
+++ b/packages/junior/src/chat/sandbox/sandbox.ts
@@ -1,9 +1,4 @@
 import fs from "node:fs/promises";
-import { issueProviderCredentialLease } from "@/chat/capabilities/factory";
-import {
-  CredentialUnavailableError,
-  type CredentialHeaderTransform,
-} from "@/chat/credentials/broker";
 import {
   logInfo,
   setSpanAttributes,
@@ -13,7 +8,6 @@ import {
 } from "@/chat/logging";
 import {
   buildSandboxEgressNetworkPolicy,
-  hasSandboxCredentialEgress,
   resolveSandboxCommandEnvironment,
 } from "@/chat/sandbox/egress-policy";
 import {
@@ -120,36 +114,17 @@ export function createSandboxExecutor(options?: {
   let referenceFiles: string[] = [];
   const traceContext = options?.traceContext ?? {};
   const credentialEgress = options?.credentialEgress;
-  let commandHeaderTransforms: CredentialHeaderTransform[] = [];
-  const activateSandboxEgressForCommand = credentialEgress
+  const authorizeSandboxEgressForCommand = credentialEgress
     ? async (egressId: string): Promise<void> => {
         await upsertSandboxEgressSession({
           egressId,
           requesterId: credentialEgress.requesterId,
           ttlMs: options?.timeoutMs,
         });
-        commandHeaderTransforms = [];
-        const provider = credentialEgress.activeProvider?.();
-        if (!provider || !hasSandboxCredentialEgress(provider)) {
-          return;
-        }
-        const lease = await issueProviderCredentialLease({
-          provider,
-          requesterId: credentialEgress.requesterId,
-          reason: `sandbox-command:${provider}`,
-        });
-        const headerTransforms = lease.headerTransforms ?? [];
-        if (headerTransforms.length === 0) {
-          throw new Error(
-            `Credential lease for ${provider} did not include header transforms`,
-          );
-        }
-        commandHeaderTransforms = headerTransforms;
       }
     : undefined;
   const clearSandboxEgressForCommand = credentialEgress
     ? async (egressId: string): Promise<void> => {
-        commandHeaderTransforms = [];
         await clearSandboxEgressSession(egressId);
       }
     : undefined;
@@ -167,12 +142,9 @@ export function createSandboxExecutor(options?: {
         }
       : undefined,
     createNetworkPolicy: credentialEgress
-      ? () =>
-          buildSandboxEgressNetworkPolicy({
-            headerTransforms: commandHeaderTransforms,
-          })
+      ? buildSandboxEgressNetworkPolicy
       : undefined,
-    beforeCommand: activateSandboxEgressForCommand,
+    beforeCommand: authorizeSandboxEgressForCommand,
     afterCommand: clearSandboxEgressForCommand,
     onSandboxAcquired: async (sandbox) => {
       await options?.onSandboxAcquired?.(sandbox);
@@ -245,27 +217,6 @@ export function createSandboxExecutor(options?: {
           setSpanStatus(response.exitCode === 0 ? "ok" : "error");
           return response;
         } catch (error) {
-          if (error instanceof CredentialUnavailableError) {
-            const response = {
-              stdout: "",
-              stderr: `junior-auth-required provider=${error.provider} 401 unauthorized\n${error.message}`,
-              exitCode: 1,
-              stdoutTruncated: false,
-              stderrTruncated: false,
-              timedOut: false,
-            };
-            setSpanAttributes({
-              "process.exit.code": response.exitCode,
-              "app.sandbox.stdout_bytes": 0,
-              "app.sandbox.stderr_bytes": Buffer.byteLength(
-                response.stderr,
-                "utf8",
-              ),
-              "error.type": error.name,
-            });
-            setSpanStatus("error");
-            return response;
-          }
           setSpanAttributes({
             "error.type":
               error instanceof Error ? error.name : "sandbox_execute_error",

--- a/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
@@ -63,7 +63,6 @@ vi.mock("@/chat/capabilities/factory", () => ({
 
 import {
   buildSandboxEgressNetworkPolicy,
-  hasSandboxCredentialEgress,
   matchesSandboxEgressDomain,
   resolveSandboxCommandEnvironment,
 } from "@/chat/sandbox/egress-policy";
@@ -149,6 +148,7 @@ function proxy(
 describe("sandbox egress proxy", () => {
   beforeEach(async () => {
     process.env.JUNIOR_STATE_ADAPTER = "memory";
+    process.env.JUNIOR_BASE_URL = "https://junior.example.com";
     createRemoteJWKSetMock.mockClear();
     createRemoteJWKSetMock.mockReturnValue(async () => null);
     decodeJwtMock.mockReset();
@@ -160,39 +160,39 @@ describe("sandbox egress proxy", () => {
   afterEach(async () => {
     await disconnectStateAdapter();
     delete process.env.JUNIOR_STATE_ADAPTER;
+    delete process.env.JUNIOR_BASE_URL;
     delete process.env.SENTRY_BOT_EMAIL;
     vi.restoreAllMocks();
   });
 
-  it("builds provider transform policy for sandbox egress", () => {
+  it("builds provider forwarding policy for sandbox egress", () => {
     expect(matchesSandboxEgressDomain("SENTRY.IO", "sentry.io")).toBe(true);
     expect(matchesSandboxEgressDomain("eu.sentry.io", "sentry.io")).toBe(false);
-    expect(hasSandboxCredentialEgress("sentry")).toBe(true);
-    expect(hasSandboxCredentialEgress("github")).toBe(false);
     expect(buildSandboxEgressNetworkPolicy()).toEqual({
-      allow: {
-        "*": [],
-      },
-    });
-    expect(
-      buildSandboxEgressNetworkPolicy({
-        headerTransforms: [
-          {
-            domain: "sentry.io",
-            headers: { Authorization: "Bearer sentry-token" },
-          },
-        ],
-      }),
-    ).toEqual({
       allow: {
         "*": [],
         "sentry.io": [
           {
-            transform: [{ headers: { Authorization: "Bearer sentry-token" } }],
+            forwardURL: "https://junior.example.com/",
+          },
+        ],
+        "us.sentry.io": [
+          {
+            forwardURL: "https://junior.example.com/",
           },
         ],
       },
     });
+  });
+
+  it("fails sandbox egress policy setup without a public callback URL", () => {
+    delete process.env.JUNIOR_BASE_URL;
+    delete process.env.VERCEL_PROJECT_PRODUCTION_URL;
+    delete process.env.VERCEL_URL;
+
+    expect(() => buildSandboxEgressNetworkPolicy()).toThrow(
+      "Cannot determine base URL for sandbox credential egress",
+    );
   });
 
   it("resolves command env for registered sandbox providers", async () => {
@@ -320,6 +320,37 @@ describe("sandbox egress proxy", () => {
       requesterId: REQUESTER_ID,
       reason: "sandbox-egress:sentry",
     });
+  });
+
+  it("prefers Vercel forwarded path over the normalized proxy URL path", async () => {
+    await authorizeSandboxEgress();
+    mockSentryLease();
+
+    const fetchMock = vi.fn(async (url: URL | string, init?: RequestInit) => {
+      expect(String(url)).toBe(
+        "https://sentry.io/api/0/organizations/sentry/?query=is%3Aunresolved",
+      );
+      expect(
+        new Headers(init?.headers).get("vercel-forwarded-path"),
+      ).toBeNull();
+      return new Response("ok", { status: 200 });
+    });
+
+    const response = await proxy(
+      egressRequest({
+        path: "/api/0/organizations/sentry",
+        headers: {
+          "vercel-forwarded-path":
+            "/api/0/organizations/sentry/?query=is%3Aunresolved",
+        },
+      }),
+      fetchMock as typeof fetch,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("ok");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(issueProviderCredentialLeaseMock).toHaveBeenCalledTimes(1);
   });
 
   it("recognizes root-path forwarded sandbox proxy requests", () => {
@@ -626,6 +657,26 @@ describe("sandbox egress proxy", () => {
       error: "Invalid forwarded port",
     });
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid forwarded paths", async () => {
+    const fetchMock = vi.fn();
+
+    const response = await proxy(
+      egressRequest({
+        headers: {
+          "vercel-forwarded-path": "//evil.example/api/0/issues/",
+        },
+      }),
+      fetchMock as typeof fetch,
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid forwarded path",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(issueProviderCredentialLeaseMock).not.toHaveBeenCalled();
   });
 
   it("requires the verified OIDC token to identify the sandbox session", async () => {

--- a/packages/junior/tests/unit/misc/sandbox-executor.test.ts
+++ b/packages/junior/tests/unit/misc/sandbox-executor.test.ts
@@ -2,16 +2,13 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { CredentialUnavailableError } from "@/chat/credentials/broker";
 import { SANDBOX_WORKSPACE_ROOT, sandboxSkillDir } from "@/chat/sandbox/paths";
 import type { SandboxInstance } from "@/chat/sandbox/workspace";
 
-const { sandboxGetMock, sandboxCreateMock, issueProviderCredentialLeaseMock } =
-  vi.hoisted(() => ({
-    sandboxGetMock: vi.fn(),
-    sandboxCreateMock: vi.fn(),
-    issueProviderCredentialLeaseMock: vi.fn(),
-  }));
+const { sandboxGetMock, sandboxCreateMock } = vi.hoisted(() => ({
+  sandboxGetMock: vi.fn(),
+  sandboxCreateMock: vi.fn(),
+}));
 
 vi.mock("@vercel/sandbox", () => ({
   Sandbox: {
@@ -36,10 +33,6 @@ vi.mock("@/chat/config", async (importOriginal) => {
     getChatConfig: () => memoryConfig,
   };
 });
-
-vi.mock("@/chat/capabilities/factory", () => ({
-  issueProviderCredentialLease: issueProviderCredentialLeaseMock,
-}));
 
 vi.mock("@/chat/plugins/registry", () => ({
   getPluginProviders: () => [
@@ -95,6 +88,7 @@ vi.mock("@/chat/sandbox/runtime-dependency-snapshots", () => ({
 }));
 
 import { createSandboxExecutor } from "@/chat/sandbox/sandbox";
+import { getSandboxEgressSession } from "@/chat/sandbox/egress-session";
 import { createSandboxSessionManager } from "@/chat/sandbox/session";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
 import { createBashTool } from "bash-tool";
@@ -218,7 +212,6 @@ describe("createSandboxExecutor", () => {
   beforeEach(() => {
     sandboxGetMock.mockReset();
     sandboxCreateMock.mockReset();
-    issueProviderCredentialLeaseMock.mockReset();
     vi.mocked(createBashTool).mockReset();
     resolveRuntimeDependencySnapshotMock.mockReset();
     resolveRuntimeDependencySnapshotMock.mockResolvedValue({
@@ -236,10 +229,12 @@ describe("createSandboxExecutor", () => {
     delete process.env.VERCEL_OIDC_TOKEN;
     delete process.env.VERCEL_SANDBOX_KEEPALIVE_MS;
     delete process.env.EVAL_ENABLE_TEST_CREDENTIALS;
+    process.env.JUNIOR_BASE_URL = "https://junior.example.com";
   });
 
   afterEach(async () => {
     await disconnectStateAdapter();
+    delete process.env.JUNIOR_BASE_URL;
   });
 
   it("recreates a sandbox when sandboxId hint points to a stopped sandbox", async () => {
@@ -663,8 +658,20 @@ describe("createSandboxExecutor", () => {
     );
   });
 
-  it("applies credential transforms only while running bash commands", async () => {
-    const sandbox = makeSandbox("sbx_transform_credentials");
+  it("authorizes credential egress only while running bash commands", async () => {
+    const sandbox = makeSandbox("sbx_authorize_credentials");
+    sandbox.runCommand.mockImplementationOnce(async () => {
+      await expect(
+        getSandboxEgressSession("sbx_authorize_credentials_session"),
+      ).resolves.toMatchObject({
+        requesterId: "U123",
+      });
+      return {
+        exitCode: 0,
+        stdout: async () => "",
+        stderr: async () => "",
+      };
+    });
     sandboxGetMock.mockResolvedValue(sandbox);
     vi.mocked(createBashTool).mockResolvedValue({
       tools: {
@@ -672,21 +679,9 @@ describe("createSandboxExecutor", () => {
         writeFile: { execute: vi.fn(async () => ({ success: true })) },
       },
     } as never);
-    issueProviderCredentialLeaseMock.mockResolvedValue({
-      id: "lease-1",
-      provider: "sentry",
-      env: { SENTRY_AUTH_TOKEN: "host_managed_credential" },
-      headerTransforms: [
-        {
-          domain: "sentry.io",
-          headers: { Authorization: "Bearer sentry-token" },
-        },
-      ],
-      expiresAt: new Date(Date.now() + 60_000).toISOString(),
-    });
 
     const executor = createSandboxExecutor({
-      sandboxId: "sbx_transform_credentials",
+      sandboxId: "sbx_authorize_credentials",
       credentialEgress: {
         requesterId: "U123",
         activeProvider: () => "sentry",
@@ -701,36 +696,27 @@ describe("createSandboxExecutor", () => {
       },
     });
 
-    expect(issueProviderCredentialLeaseMock).toHaveBeenCalledWith({
-      provider: "sentry",
-      requesterId: "U123",
-      reason: "sandbox-command:sentry",
-    });
-    expect(sandbox.update).toHaveBeenNthCalledWith(1, {
-      networkPolicy: { allow: { "*": [] } },
-    });
-    expect(sandbox.update).toHaveBeenNthCalledWith(2, {
+    expect(sandbox.update).toHaveBeenCalledTimes(1);
+    expect(sandbox.update).toHaveBeenCalledWith({
       networkPolicy: {
         allow: {
           "*": [],
           "sentry.io": [
             {
-              transform: [
-                { headers: { Authorization: "Bearer sentry-token" } },
-              ],
+              forwardURL: "https://junior.example.com/",
             },
           ],
         },
       },
-    });
-    expect(sandbox.update).toHaveBeenNthCalledWith(3, {
-      networkPolicy: { allow: { "*": [] } },
     });
     const invocation = sandbox.runCommand.mock.calls[0]?.[0];
     expect(invocation.args?.[1]).toContain(
       "export SENTRY_AUTH_TOKEN='host_managed_credential'",
     );
     expect(invocation.args?.[1]).toContain("sentry-cli issues list");
+    await expect(
+      getSandboxEgressSession("sbx_authorize_credentials_session"),
+    ).resolves.toBeUndefined();
   });
 
   it("runs active provider commands without credentials when no credential surface exists", async () => {
@@ -759,61 +745,22 @@ describe("createSandboxExecutor", () => {
       },
     });
 
-    expect(issueProviderCredentialLeaseMock).not.toHaveBeenCalled();
     expect(sandbox.update).toHaveBeenCalledTimes(1);
     expect(sandbox.update).toHaveBeenCalledWith({
-      networkPolicy: { allow: { "*": [] } },
+      networkPolicy: {
+        allow: {
+          "*": [],
+          "sentry.io": [
+            {
+              forwardURL: "https://junior.example.com/",
+            },
+          ],
+        },
+      },
     });
     const invocation = sandbox.runCommand.mock.calls[0]?.[0];
     expect(invocation.args?.[1]).not.toContain("SENTRY_AUTH_TOKEN");
     expect(invocation.args?.[1]).toContain("echo local-only");
-  });
-
-  it("returns an auth marker when command credential activation is unavailable", async () => {
-    const sandbox = makeSandbox("sbx_missing_credentials");
-    sandboxGetMock.mockResolvedValue(sandbox);
-    vi.mocked(createBashTool).mockResolvedValue({
-      tools: {
-        readFile: { execute: vi.fn(async () => ({ content: "" })) },
-        writeFile: { execute: vi.fn(async () => ({ success: true })) },
-      },
-    } as never);
-    issueProviderCredentialLeaseMock.mockRejectedValue(
-      new CredentialUnavailableError(
-        "sentry",
-        "No sentry credentials available.",
-      ),
-    );
-
-    const executor = createSandboxExecutor({
-      sandboxId: "sbx_missing_credentials",
-      credentialEgress: {
-        requesterId: "U123",
-        activeProvider: () => "sentry",
-      },
-    });
-    executor.configureSkills([]);
-
-    const response = await executor.execute({
-      toolName: "bash",
-      input: {
-        command: "sentry-cli issues list",
-      },
-    });
-
-    expect(response.result).toMatchObject({
-      ok: false,
-      exit_code: 1,
-      stdout: "",
-      stderr: expect.stringContaining(
-        "junior-auth-required provider=sentry 401 unauthorized",
-      ),
-    });
-    expect(sandbox.update).toHaveBeenCalledTimes(1);
-    expect(sandbox.update).toHaveBeenCalledWith({
-      networkPolicy: { allow: { "*": [] } },
-    });
-    expect(sandbox.runCommand).not.toHaveBeenCalled();
   });
 
   it("clears sandbox command hooks when command env resolution fails", async () => {


### PR DESCRIPTION
Route sandbox provider egress through Junior again so credentials are provisioned when outbound requests occur, instead of pre-minting command-scoped headers. The proxy now reconstructs upstream URLs from Vercel forwarded routing headers, including `vercel-forwarded-path`, so normalized proxy paths do not drop upstream request details.

**Forwarded Path Routing**

The proxy prefers `vercel-forwarded-path` and validates it before rebuilding the upstream URL. Proxy-only Vercel headers are stripped before the request is sent to the provider.

**Request-Time Credentials**

Sandbox commands now only authorize a requester-bound egress session. Credential leases are issued by the proxy when matching provider traffic arrives.

**Development Diagnostics**

Non-production upstream request logs include method, host, path, status, provider, and proxy/upstream path attributes without adding provider-specific retry behavior.

**Tests**

- `pnpm --filter @sentry/junior run typecheck`
- `pnpm docs:check`
- `pnpm --filter @sentry/junior exec vitest run tests/unit/handlers/sandbox-egress-proxy.test.ts`
- `pnpm --filter @sentry/junior exec vitest run tests/unit/misc/sandbox-executor.test.ts`
- `pnpm --filter @sentry/junior exec vitest run tests/unit/ingress/junior-chat.test.ts`
- `pnpm --filter @sentry/junior exec oxlint --config .oxlintrc.json --deny-warnings src/chat/sandbox/egress-policy.ts src/chat/sandbox/egress-proxy.ts src/chat/sandbox/sandbox.ts src/chat/sandbox/noninteractive-command.ts src/chat/ingress/junior-chat.ts tests/unit/handlers/sandbox-egress-proxy.test.ts tests/unit/misc/sandbox-executor.test.ts tests/unit/ingress/junior-chat.test.ts`
- `git diff --check`