### PR TITLE
fix(slack): Defer subscribed processing reaction

### DIFF
--- a/packages/junior/src/chat/runtime/slack-runtime.ts
+++ b/packages/junior/src/chat/runtime/slack-runtime.ts
@@ -394,24 +394,14 @@ export function createSlackTurnRuntime<
         const threadId = deps.getThreadId(thread, message);
         const channelId = deps.getChannelId(thread, message);
         const runId = deps.getRunId(thread, message);
-        const context = logContext({
+        const turnContext = logContext({
           threadId,
           requesterId: message.author.userId,
           requesterUserName: message.author.userName,
           channelId,
           runId,
         });
-        processingReaction = await startSlackProcessingReaction({
-          thread,
-          message,
-          logException: deps.logException,
-          logContext: context,
-        });
-        const toolInvocationHook = createToolInvocationHook(
-          processingReaction,
-          hooks,
-        );
-        await deps.withSpan("chat.turn", "chat.turn", context, async () => {
+        await deps.withSpan("chat.turn", "chat.turn", turnContext, async () => {
           // This path can compact context and run router/vision model calls
           // before replyToThread() opens the main reply span.
           const legacyAttachmentText = renderSlackLegacyAttachmentText(
@@ -428,7 +418,7 @@ export function createSlackTurnRuntime<
             strippedUserText,
             message.raw,
           );
-          const context: ThreadContext = {
+          const threadContext: ThreadContext = {
             threadId,
             requesterId: message.author.userId,
             channelId,
@@ -450,7 +440,7 @@ export function createSlackTurnRuntime<
               thread,
               message,
               decision: { shouldReply: false, reason },
-              context,
+              context: threadContext,
               userText,
             });
             return;
@@ -461,7 +451,7 @@ export function createSlackTurnRuntime<
             message,
             userText,
             explicitMention: Boolean(message.isMention),
-            context,
+            context: threadContext,
           });
 
           await deps.persistPreparedState({
@@ -477,7 +467,7 @@ export function createSlackTurnRuntime<
             hasAttachments:
               message.attachments.length > 0 || legacyAttachmentText !== "",
             isExplicitMention: Boolean(message.isMention),
-            context,
+            context: threadContext,
           });
 
           if (
@@ -491,7 +481,7 @@ export function createSlackTurnRuntime<
               thread,
               message,
               decision,
-              context,
+              context: threadContext,
               preparedState,
               userText,
             });
@@ -503,12 +493,23 @@ export function createSlackTurnRuntime<
               thread,
               message,
               decision,
-              context,
+              context: threadContext,
               preparedState,
               userText,
             });
             return;
           }
+
+          processingReaction = await startSlackProcessingReaction({
+            thread,
+            message,
+            logException: deps.logException,
+            logContext: turnContext,
+          });
+          const toolInvocationHook = createToolInvocationHook(
+            processingReaction,
+            hooks,
+          );
 
           await deps.replyToThread(thread, message, {
             explicitMention: Boolean(message.isMention),

--- a/packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts
@@ -75,19 +75,24 @@ describe("Slack behavior: processing reaction", () => {
     ]);
   });
 
-  it("removes eyes when a subscribed message is skipped", async () => {
+  it("does not add eyes when a subscribed message is skipped", async () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         subscribedReplyPolicy: {
-          completeObject: async () =>
-            ({
+          completeObject: async () => {
+            expect(getCapturedSlackApiCalls("reactions.add")).toHaveLength(0);
+            expect(getCapturedSlackApiCalls("reactions.remove")).toHaveLength(
+              0,
+            );
+            return {
               object: {
                 should_reply: false,
                 confidence: 0,
                 reason: "side conversation",
               },
               text: '{"should_reply":false,"confidence":0,"reason":"side conversation"}',
-            }) as never,
+            } as never;
+          },
         },
         replyExecutor: {
           generateAssistantReply: async () => {
@@ -116,8 +121,80 @@ describe("Slack behavior: processing reaction", () => {
     );
 
     expect(thread.posts).toHaveLength(0);
-    expect(getCapturedSlackApiCalls("reactions.add")).toHaveLength(1);
-    expect(getCapturedSlackApiCalls("reactions.remove")).toHaveLength(1);
+    expect(getCapturedSlackApiCalls("reactions.add")).toHaveLength(0);
+    expect(getCapturedSlackApiCalls("reactions.remove")).toHaveLength(0);
+  });
+
+  it("adds eyes after a subscribed message is approved and removes it after the reply", async () => {
+    const { slackRuntime } = createTestChatRuntime({
+      services: {
+        subscribedReplyPolicy: {
+          completeObject: async () => {
+            expect(getCapturedSlackApiCalls("reactions.add")).toHaveLength(0);
+            expect(getCapturedSlackApiCalls("reactions.remove")).toHaveLength(
+              0,
+            );
+            return {
+              object: {
+                should_reply: true,
+                confidence: 1,
+                reason: "direct follow-up",
+              },
+              text: '{"should_reply":true,"confidence":1,"reason":"direct follow-up"}',
+            } as never;
+          },
+        },
+        replyExecutor: {
+          generateAssistantReply: async () => {
+            expect(getCapturedSlackApiCalls("reactions.add")).toHaveLength(1);
+            expect(getCapturedSlackApiCalls("reactions.remove")).toHaveLength(
+              0,
+            );
+            return {
+              text: "Done.",
+              diagnostics: successDiagnostics(),
+            };
+          },
+        },
+      },
+    });
+
+    const thread = createTestThread({
+      id: "slack:C_PROCESSING:1700007150.000000",
+    });
+    await slackRuntime.handleSubscribedMessage(
+      thread,
+      createTestMessage({
+        id: "1700007151.000000",
+        text: "can you check this next?",
+        isMention: false,
+        threadId: thread.id,
+        raw: {
+          channel: "C_PROCESSING",
+          ts: "1700007151.000000",
+          thread_ts: "1700007150.000000",
+        },
+      }),
+    );
+
+    expect(getCapturedSlackApiCalls("reactions.add")).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({
+          channel: "C_PROCESSING",
+          timestamp: "1700007151.000000",
+          name: "eyes",
+        }),
+      }),
+    ]);
+    expect(getCapturedSlackApiCalls("reactions.remove")).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({
+          channel: "C_PROCESSING",
+          timestamp: "1700007151.000000",
+          name: "eyes",
+        }),
+      }),
+    ]);
   });
 
   it("keeps eyes when the assistant explicitly adds an eyes reaction", async () => {

--- a/specs/slack-agent-delivery-spec.md
+++ b/specs/slack-agent-delivery-spec.md
@@ -24,6 +24,7 @@
 - 2026-05-13: Added the turn-continuation acknowledgement and follow-up retry contract for awaiting continuation checkpoints.
 - 2026-05-16: Added automatic processing reactions for Slack messages Junior is handling or evaluating for handling.
 - 2026-05-19: Restored the visible URL-free auth-pause thread acknowledgement and required processing reaction restoration during auth resumes.
+- 2026-05-19: Deferred subscribed-thread processing reactions until after routing approves a reply.
 
 ## Status
 
@@ -147,16 +148,18 @@ Design note:
 
 ### 5. Processing Reaction Contract
 
-Junior must acknowledge Slack messages it is handling, or evaluating for handling, with an automatic processing reaction.
+Junior must acknowledge Slack messages it is handling with an automatic processing reaction. Explicit mentions acknowledge immediately; passive subscribed-thread messages acknowledge only after routing has committed to a reply.
 
 Current rules:
 
-1. DM, explicit-mention, and subscribed-thread message handlers add `:eyes:` before turn preparation, passive reply classification, or assistant execution.
-2. Junior removes that automatic `:eyes:` reaction when the handler completes, including reply, skip, opt-out, auth-pause, timeout-continuation, and fallback-error paths.
-3. When an OAuth/MCP callback resumes an auth-paused request, Junior re-adds `:eyes:` to the original triggering Slack message while resumed processing runs, then removes it when the resumed handler completes.
-4. Processing-reaction add and remove calls are best effort. Failures are observable but must not fail the turn or change reply routing.
-5. The automatic processing reaction is runtime-owned. It must not be exposed as model progress, and it must not count as a successful user-requested reaction tool call.
-6. If the assistant explicitly uses the Slack reaction tool to add `:eyes:` to the same inbound message, Junior leaves the reaction in place instead of removing the automatic acknowledgement.
+1. DM and explicit-mention handlers add `:eyes:` before turn preparation or assistant execution.
+2. Subscribed-thread handlers add `:eyes:` only after preflight and passive reply routing return `shouldReply: true`, immediately before assistant execution.
+3. Skipped subscribed-thread messages, including passive no-reply and opt-out decisions, do not add or remove the automatic processing reaction.
+4. Junior removes an automatic `:eyes:` reaction when the handler completes after the reaction has started, including reply, auth-pause, timeout-continuation, and fallback-error paths.
+5. When an OAuth/MCP callback resumes an auth-paused request, Junior re-adds `:eyes:` to the original triggering Slack message while resumed processing runs, then removes it when the resumed handler completes.
+6. Processing-reaction add and remove calls are best effort. Failures are observable but must not fail the turn or change reply routing.
+7. The automatic processing reaction is runtime-owned. It must not be exposed as model progress, and it must not count as a successful user-requested reaction tool call.
+8. If the assistant explicitly uses the Slack reaction tool to add `:eyes:` to the same inbound message, Junior leaves the reaction in place instead of removing the automatic acknowledgement.
 
 ### 6. Primary Reply Contract
 


### PR DESCRIPTION
Subscribed-thread messages no longer show the automatic eyes reaction while Junior is still deciding whether to respond. The reaction now starts only after preflight and passive routing approve a reply, avoiding a transient processing flash on skipped messages.

**Processing Reaction Timing**

`handleSubscribedMessage` keeps explicit mention behavior unchanged and starts the subscribed-thread reaction immediately before `replyToThread` on the approved path.

**Contract Coverage**

The Slack delivery spec now documents the deferred subscribed-thread rule, and the reaction integration test covers both skipped and approved subscribed messages.

Fixes #375
