### PR TITLE
fix(sandbox): Report missing file paths as tool results

### DIFF
--- a/packages/junior/src/chat/sandbox/sandbox.ts
+++ b/packages/junior/src/chat/sandbox/sandbox.ts
@@ -26,10 +26,16 @@ import type { SandboxInstance } from "@/chat/sandbox/workspace";
 import type { SkillMetadata } from "@/chat/skills";
 import { editFile } from "@/chat/tools/sandbox/edit-file";
 import { findFiles } from "@/chat/tools/sandbox/find-files";
-import { positiveInteger } from "@/chat/tools/sandbox/file-utils";
+import {
+  isMissingPathError,
+  positiveInteger,
+} from "@/chat/tools/sandbox/file-utils";
 import { grepFiles } from "@/chat/tools/sandbox/grep";
 import { listDir } from "@/chat/tools/sandbox/list-dir";
-import { sliceFileContent } from "@/chat/tools/sandbox/read-file";
+import {
+  missingFileResult,
+  sliceFileContent,
+} from "@/chat/tools/sandbox/read-file";
 
 // Spec: specs/security-policy.md (sandbox isolation, network policy, credential lifecycle)
 // Spec: specs/logging/tracing-spec.md (required sandbox span semantics)
@@ -295,7 +301,16 @@ export function createSandboxExecutor(options?: {
         "app.sandbox.path.length": filePath.length,
       },
       async () => {
-        const response = await executeReadFile({ path: filePath });
+        let response: { content: string };
+        try {
+          response = await executeReadFile({ path: filePath });
+        } catch (error) {
+          if (isMissingPathError(error)) {
+            setSpanStatus("ok");
+            return missingFileResult(filePath);
+          }
+          throw error;
+        }
         const content = String(response.content ?? "");
         setSpanAttributes({
           "app.sandbox.read.bytes": Buffer.byteLength(content, "utf8"),

--- a/packages/junior/src/chat/tools/sandbox/file-utils.ts
+++ b/packages/junior/src/chat/tools/sandbox/file-utils.ts
@@ -7,10 +7,23 @@ export type { SandboxFileSystem };
 export const MAX_TEXT_CHARS = 60_000;
 const SKIPPED_DIRECTORIES = new Set([".git", "node_modules"]);
 
-export interface TextSearchResultDetails {
-  ok: true;
-  path: string;
-  truncated: boolean;
+export type TextSearchResultDetails =
+  | {
+      ok: true;
+      path: string;
+      truncated: boolean;
+    }
+  | {
+      ok: false;
+      error: "not_found";
+      path: string;
+      missing_path?: string;
+      truncated: false;
+    };
+
+export interface TextSearchToolResult {
+  content: [{ type: "text"; text: string }];
+  details: TextSearchResultDetails;
 }
 
 /** Normalize model-supplied numeric knobs before they reach filesystem tools. */
@@ -40,6 +53,40 @@ export function truncateText(
   return {
     content: `${value.slice(0, maxChars)}\n\n[output truncated: ${removed} characters removed]`,
     truncated: true,
+  };
+}
+
+/** Detect model-facing missing paths without swallowing sandbox lifecycle/API failures. */
+export function isMissingPathError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const candidate = error as { code?: unknown; message?: unknown };
+  if (candidate.code === "ENOENT") {
+    return true;
+  }
+  return (
+    typeof candidate.message === "string" &&
+    candidate.message.startsWith("File not found:")
+  );
+}
+
+/** Build the shared model-visible result for expected missing search/list paths. */
+export function missingPathSearchResult(params: {
+  path: string;
+  displayPath?: string;
+  missingPath?: string;
+}): TextSearchToolResult {
+  const textPath = params.displayPath ?? params.missingPath ?? params.path;
+  return {
+    content: [{ type: "text", text: `Path not found: ${textPath}` }],
+    details: {
+      ok: false,
+      error: "not_found",
+      path: params.path,
+      ...(params.missingPath ? { missing_path: params.missingPath } : {}),
+      truncated: false,
+    },
   };
 }
 
@@ -118,17 +165,44 @@ export async function collectFiles(params: {
   root: string;
   limit?: number;
   pattern?: string;
-}): Promise<{ files: string[]; limitReached: boolean }> {
+}): Promise<{
+  files: string[];
+  limitReached: boolean;
+  missingPath?: string;
+  missingRoot: boolean;
+}> {
   const files: string[] = [];
   let limitReached = false;
+  let missingPath: string | undefined;
 
   const visit = async (dirPath: string): Promise<void> => {
-    const entries = (await params.fs.readdir(dirPath)).sort((a, b) =>
-      a.toLowerCase().localeCompare(b.toLowerCase()),
-    );
+    if (missingPath) {
+      return;
+    }
+    let entries: string[];
+    try {
+      entries = (await params.fs.readdir(dirPath)).sort((a, b) =>
+        a.toLowerCase().localeCompare(b.toLowerCase()),
+      );
+    } catch (error) {
+      if (isMissingPathError(error)) {
+        missingPath = dirPath;
+        return;
+      }
+      throw error;
+    }
     for (const entry of entries) {
       const fullPath = path.posix.join(dirPath, entry);
-      const stat = await params.fs.stat(fullPath);
+      let stat: Awaited<ReturnType<SandboxFileSystem["stat"]>>;
+      try {
+        stat = await params.fs.stat(fullPath);
+      } catch (error) {
+        if (isMissingPathError(error)) {
+          missingPath = fullPath;
+          return;
+        }
+        throw error;
+      }
       if (stat.isDirectory()) {
         if (!SKIPPED_DIRECTORIES.has(entry)) {
           await visit(fullPath);
@@ -148,7 +222,20 @@ export async function collectFiles(params: {
     }
   };
 
-  const stat = await params.fs.stat(params.root);
+  let stat: Awaited<ReturnType<SandboxFileSystem["stat"]>>;
+  try {
+    stat = await params.fs.stat(params.root);
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return {
+        files,
+        limitReached: false,
+        missingPath: params.root,
+        missingRoot: true,
+      };
+    }
+    throw error;
+  }
   if (!stat.isDirectory()) {
     const relativePath = path.posix.basename(params.root);
     return {
@@ -157,9 +244,15 @@ export async function collectFiles(params: {
           ? [params.root]
           : [],
       limitReached: false,
+      missingRoot: false,
     };
   }
 
   await visit(params.root);
-  return { files, limitReached };
+  return {
+    files,
+    limitReached,
+    missingPath,
+    missingRoot: missingPath === params.root,
+  };
 }

--- a/packages/junior/src/chat/tools/sandbox/find-files.ts
+++ b/packages/junior/src/chat/tools/sandbox/find-files.ts
@@ -3,6 +3,7 @@ import { Type } from "@sinclair/typebox";
 import {
   MAX_TEXT_CHARS,
   collectFiles,
+  missingPathSearchResult,
   positiveInteger,
   resolveWorkspacePath,
   truncateText,
@@ -33,12 +34,18 @@ export async function findFiles(params: {
 
   const root = resolveWorkspacePath(params.path);
   const limit = positiveInteger(params.limit) ?? DEFAULT_FIND_LIMIT;
-  const { files, limitReached } = await collectFiles({
+  const { files, limitReached, missingPath, missingRoot } = await collectFiles({
     fs: params.fs,
     root,
     pattern: params.pattern,
     limit,
   });
+  if (missingPath) {
+    return missingPathSearchResult({
+      path: params.path ?? ".",
+      ...(missingRoot ? { displayPath: params.path ?? "." } : { missingPath }),
+    });
+  }
   const relativePaths = files.map((filePath) =>
     path.posix.relative(root, filePath),
   );

--- a/packages/junior/src/chat/tools/sandbox/grep.ts
+++ b/packages/junior/src/chat/tools/sandbox/grep.ts
@@ -3,6 +3,8 @@ import { Type } from "@sinclair/typebox";
 import {
   MAX_TEXT_CHARS,
   collectFiles,
+  isMissingPathError,
+  missingPathSearchResult,
   normalizeToLf,
   positiveInteger,
   resolveWorkspacePath,
@@ -71,11 +73,17 @@ export async function grepFiles(params: {
   const regex = params.literal
     ? undefined
     : new RegExp(params.pattern, params.ignoreCase ? "i" : "");
-  const { files } = await collectFiles({
+  const { files, missingPath, missingRoot } = await collectFiles({
     fs: params.fs,
     root,
     pattern: params.glob,
   });
+  if (missingPath) {
+    return missingPathSearchResult({
+      path: params.path ?? ".",
+      ...(missingRoot ? { displayPath: params.path ?? "." } : { missingPath }),
+    });
+  }
   const output: string[] = [];
   let matchCount = 0;
   let matchLimitReached = false;
@@ -86,8 +94,14 @@ export async function grepFiles(params: {
     let content: string;
     try {
       content = await params.fs.readFile(filePath, { encoding: "utf8" });
-    } catch {
-      continue;
+    } catch (error) {
+      if (isMissingPathError(error)) {
+        return missingPathSearchResult({
+          path: params.path ?? ".",
+          missingPath: filePath,
+        });
+      }
+      throw error;
     }
     if (content.includes("\u0000")) {
       continue;

--- a/packages/junior/src/chat/tools/sandbox/list-dir.ts
+++ b/packages/junior/src/chat/tools/sandbox/list-dir.ts
@@ -2,6 +2,8 @@ import path from "node:path";
 import { Type } from "@sinclair/typebox";
 import {
   MAX_TEXT_CHARS,
+  isMissingPathError,
+  missingPathSearchResult,
   positiveInteger,
   resolveWorkspacePath,
   truncateText,
@@ -27,14 +29,30 @@ export async function listDir(params: {
 }): Promise<ListDirResult> {
   const dirPath = resolveWorkspacePath(params.path);
   const limit = positiveInteger(params.limit) ?? DEFAULT_LIST_LIMIT;
-  const stat = await params.fs.stat(dirPath);
+  let stat: Awaited<ReturnType<SandboxFileSystem["stat"]>>;
+  try {
+    stat = await params.fs.stat(dirPath);
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return missingPathSearchResult({ path: params.path ?? "." });
+    }
+    throw error;
+  }
   if (!stat.isDirectory()) {
     throw new Error(`Not a directory: ${params.path ?? "."}`);
   }
 
-  const entries = (await params.fs.readdir(dirPath)).sort((a, b) =>
-    a.toLowerCase().localeCompare(b.toLowerCase()),
-  );
+  let entries: string[];
+  try {
+    entries = (await params.fs.readdir(dirPath)).sort((a, b) =>
+      a.toLowerCase().localeCompare(b.toLowerCase()),
+    );
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return missingPathSearchResult({ path: params.path ?? "." });
+    }
+    throw error;
+  }
   const output: string[] = [];
   let entryLimitReached = false;
   for (const entry of entries) {
@@ -46,8 +64,14 @@ export async function listDir(params: {
     try {
       const entryStat = await params.fs.stat(entryPath);
       output.push(`${entry}${entryStat.isDirectory() ? "/" : ""}`);
-    } catch {
-      continue;
+    } catch (error) {
+      if (isMissingPathError(error)) {
+        return missingPathSearchResult({
+          path: params.path ?? ".",
+          missingPath: entryPath,
+        });
+      }
+      throw error;
     }
   }
 

--- a/packages/junior/src/chat/tools/sandbox/read-file.ts
+++ b/packages/junior/src/chat/tools/sandbox/read-file.ts
@@ -18,6 +18,13 @@ interface TextRangeResult {
   continuation?: string;
 }
 
+interface TextRangeMissingPathResult {
+  content: "";
+  error: "not_found";
+  path: string;
+  success: false;
+}
+
 /** Return a bounded line window so large files can be read incrementally. */
 export function sliceFileContent(params: {
   content: string;
@@ -53,6 +60,16 @@ export function sliceFileContent(params: {
           continuation: `Read more with offset=${endLine + 1} and limit=${maxLines}.`,
         }
       : {}),
+  };
+}
+
+/** Return a model-visible result for expected missing read targets. */
+export function missingFileResult(path: string): TextRangeMissingPathResult {
+  return {
+    content: "",
+    error: "not_found",
+    path,
+    success: false,
   };
 }
 

--- a/packages/junior/tests/unit/misc/sandbox-executor.test.ts
+++ b/packages/junior/tests/unit/misc/sandbox-executor.test.ts
@@ -1114,6 +1114,70 @@ describe("createSandboxExecutor", () => {
     expect(sandboxCreateMock).toHaveBeenCalledTimes(1);
   });
 
+  it("returns a readFile tool result when the sandbox path is missing", async () => {
+    const sandbox = makeSandbox("sbx_missing_read_file");
+    sandboxCreateMock.mockResolvedValue(sandbox);
+    vi.mocked(createBashTool).mockResolvedValue({
+      tools: {
+        readFile: {
+          execute: vi.fn(async () => {
+            throw new Error("File not found: /vercel/sandbox/missing.ts");
+          }),
+        },
+        writeFile: { execute: vi.fn(async () => ({ success: true })) },
+      },
+    } as never);
+
+    const executor = createSandboxExecutor();
+    executor.configureSkills([]);
+
+    const response = await executor.execute({
+      toolName: "readFile",
+      input: {
+        path: "missing.ts",
+      },
+    });
+
+    expect(response.result).toEqual({
+      content: "",
+      error: "not_found",
+      path: "missing.ts",
+      success: false,
+    });
+  });
+
+  it("keeps sandbox API failures as readFile errors", async () => {
+    const sandbox = makeSandbox("sbx_read_file_api_error");
+    sandboxCreateMock.mockResolvedValue(sandbox);
+    vi.mocked(createBashTool).mockResolvedValue({
+      tools: {
+        readFile: {
+          execute: vi.fn(async () => {
+            throw createApiError(
+              410,
+              "Gone",
+              "sandbox_stopped",
+              "Sandbox has stopped execution and is no longer available",
+            );
+          }),
+        },
+        writeFile: { execute: vi.fn(async () => ({ success: true })) },
+      },
+    } as never);
+
+    const executor = createSandboxExecutor();
+    executor.configureSkills([]);
+
+    await expect(
+      executor.execute({
+        toolName: "readFile",
+        input: {
+          path: "missing.ts",
+        },
+      }),
+    ).rejects.toThrow("Status code 410 is not ok");
+  });
+
   it("reads virtual skill files from sandbox when a sandbox id hint exists", async () => {
     const skillRoot = await fs.mkdtemp(
       path.join(os.tmpdir(), "junior-skill-read-hinted-"),

--- a/packages/junior/tests/unit/tools/sandbox/file-tools.test.ts
+++ b/packages/junior/tests/unit/tools/sandbox/file-tools.test.ts
@@ -15,6 +15,10 @@ function workspacePath(filePath: string): string {
   return path.posix.join(SANDBOX_WORKSPACE_ROOT, filePath);
 }
 
+function missingPathError(message: string): Error {
+  return Object.assign(new Error(message), { code: "ENOENT" });
+}
+
 function createMemoryFs(initialFiles: Record<string, string>) {
   const files = new Map(
     Object.entries(initialFiles).map(([filePath, content]) => [
@@ -32,7 +36,7 @@ function createMemoryFs(initialFiles: Record<string, string>) {
     async readFile(filePath) {
       const content = files.get(filePath);
       if (content === undefined) {
-        throw new Error(`missing file: ${filePath}`);
+        throw missingPathError(`missing file: ${filePath}`);
       }
       return content;
     },
@@ -41,7 +45,7 @@ function createMemoryFs(initialFiles: Record<string, string>) {
     },
     async readdir(directoryPath) {
       if (!hasDirectory(directoryPath)) {
-        throw new Error(`missing directory: ${directoryPath}`);
+        throw missingPathError(`missing directory: ${directoryPath}`);
       }
       const entries = new Set<string>();
       for (const filePath of files.keys()) {
@@ -59,7 +63,7 @@ function createMemoryFs(initialFiles: Record<string, string>) {
       if (hasDirectory(filePath)) {
         return { isDirectory: () => true };
       }
-      throw new Error(`missing path: ${filePath}`);
+      throw missingPathError(`missing path: ${filePath}`);
     },
   };
 
@@ -186,6 +190,84 @@ describe("sandbox file tools", () => {
     ).resolves.toEqual({
       content: [{ type: "text", text: "src/app.ts\nsrc/nested/test.ts" }],
       details: { ok: true, path: ".", truncated: false },
+    });
+  });
+
+  it("returns tool results for missing search roots", async () => {
+    const memory = createMemoryFs({
+      "src/app.ts": "const needle = true;\n",
+    });
+
+    await expect(
+      findFiles({ fs: memory.fs, path: "missing", pattern: "*.ts" }),
+    ).resolves.toEqual({
+      content: [{ type: "text", text: "Path not found: missing" }],
+      details: {
+        ok: false,
+        error: "not_found",
+        path: "missing",
+        truncated: false,
+      },
+    });
+    await expect(
+      grepFiles({
+        fs: memory.fs,
+        path: "missing",
+        pattern: "needle",
+        literal: true,
+      }),
+    ).resolves.toEqual({
+      content: [{ type: "text", text: "Path not found: missing" }],
+      details: {
+        ok: false,
+        error: "not_found",
+        path: "missing",
+        truncated: false,
+      },
+    });
+    await expect(listDir({ fs: memory.fs, path: "missing" })).resolves.toEqual({
+      content: [{ type: "text", text: "Path not found: missing" }],
+      details: {
+        ok: false,
+        error: "not_found",
+        path: "missing",
+        truncated: false,
+      },
+    });
+  });
+
+  it("reports files that disappear during traversal", async () => {
+    const memory = createMemoryFs({
+      "src/kept.ts": "needle\n",
+      "src/gone.ts": "needle\n",
+    });
+    let hideGone = false;
+    const originalStat = memory.fs.stat;
+    memory.fs.stat = async (filePath) => {
+      if (hideGone && filePath.endsWith("/gone.ts")) {
+        throw missingPathError(`missing path: ${filePath}`);
+      }
+      return originalStat(filePath);
+    };
+
+    hideGone = true;
+
+    await expect(
+      findFiles({ fs: memory.fs, path: "src", pattern: "*.ts" }),
+    ).resolves.toEqual({
+      content: [
+        {
+          type: "text",
+          text: `Path not found: ${SANDBOX_WORKSPACE_ROOT}/src/gone.ts`,
+        },
+      ],
+      details: {
+        ok: false,
+        error: "not_found",
+        path: "src",
+        missing_path: `${SANDBOX_WORKSPACE_ROOT}/src/gone.ts`,
+        truncated: false,
+      },
     });
   });
 


### PR DESCRIPTION
Sandbox file tools now return structured `not_found` results for missing paths instead of throwing through the agent tool wrapper. This keeps normal model path probing visible to the LLM and removes Sentry noise from expected filesystem misses.

**Missing Path Results**

`readFile`, `findFiles`, `grep`, and `listDir` now report missing roots or disappearing entries as model-visible tool results. Raw sandbox API/session failures still throw so timeout, resume, and sandbox lifecycle issues remain diagnosable.

Fixes JUNIOR-20
Fixes JUNIOR-2N
Fixes JUNIOR-2M
Fixes JUNIOR-2J
Fixes JUNIOR-2C