### PR TITLE
chore: bump @sentry/node to 10.53.1, enable streamGenAISpans

### DIFF
--- a/packages/junior/package.json
+++ b/packages/junior/package.json
@@ -60,7 +60,7 @@
     "@sentry/node": ">=10.0.0"
   },
   "devDependencies": {
-    "@sentry/node": "10.50.0-alpha.0",
+    "@sentry/node": "10.53.1",
     "@types/node": "^25.6.0",
     "dependency-cruiser": "^17.4.0",
     "msw": "^2.14.3",

--- a/packages/junior/src/instrumentation.ts
+++ b/packages/junior/src/instrumentation.ts
@@ -30,7 +30,7 @@ export function initSentry(): void {
     sendDefaultPii: true,
     enabled: Boolean(dsn),
     enableLogs,
-    streamGenAISpans: true,
+    streamGenAiSpans: true,
     integrations: [
       Sentry.vercelAIIntegration({
         recordInputs: true,

--- a/packages/junior/src/instrumentation.ts
+++ b/packages/junior/src/instrumentation.ts
@@ -30,6 +30,7 @@ export function initSentry(): void {
     sendDefaultPii: true,
     enabled: Boolean(dsn),
     enableLogs,
+    streamGenAISpans: true,
     integrations: [
       Sentry.vercelAIIntegration({
         recordInputs: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,8 +167,8 @@ importers:
         version: 4.4.3
     devDependencies:
       "@sentry/node":
-        specifier: 10.50.0-alpha.0
-        version: 10.50.0-alpha.0
+        specifier: 10.53.1
+        version: 10.53.1
       "@types/node":
         specifier: ^25.6.0
         version: 25.6.0
@@ -205,7 +205,7 @@ importers:
     devDependencies:
       "@sentry/junior":
         specifier: workspace:*
-        version: file:packages/junior(@aws-sdk/credential-provider-web-identity@3.972.33)(@opentelemetry/api@1.9.1)(@sentry/node@10.51.0)
+        version: file:packages/junior(@aws-sdk/credential-provider-web-identity@3.972.33)(@opentelemetry/api@1.9.1)(@sentry/node@10.53.1)
       "@sentry/junior-github":
         specifier: workspace:*
         version: link:../junior-github
@@ -3613,10 +3613,10 @@ packages:
       }
     engines: { node: ">=18" }
 
-  "@sentry/core@10.51.0":
+  "@sentry/core@10.53.1":
     resolution:
       {
-        integrity: sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w==,
+        integrity: sha512-XG4ezlkyuAPjBC5+9kXC94rXXuqYTw9NRhfaDHssbTFaGnqBR8vQX2UUgZfY7ucbeelRDGfBu1sywoU+mB04uA==,
       }
     engines: { node: ">=18" }
 
@@ -3653,10 +3653,10 @@ packages:
       "@opentelemetry/semantic-conventions":
         optional: true
 
-  "@sentry/node-core@10.51.0":
+  "@sentry/node-core@10.53.1":
     resolution:
       {
-        integrity: sha512-VP9DMEzBEuauABrfDHYz/pRYa74M09uRJLz0ls3yel3sKhYHMyCB29ZxbKcciUhD4d33dwgi8DbaPZV2H/wnfQ==,
+        integrity: sha512-iH7SMcM/7jPbN+t7+7ussQOiIqI4BMOGt4VYWlV71/z7k0pY+YPaSvlfVkNXfISiDzFAKv0ecCY3BmsLMu1xDQ==,
       }
     engines: { node: ">=18" }
     peerDependencies:
@@ -3687,10 +3687,10 @@ packages:
       }
     engines: { node: ">=18" }
 
-  "@sentry/node@10.51.0":
+  "@sentry/node@10.53.1":
     resolution:
       {
-        integrity: sha512-2yZLRZwS1dKG8/4eOTpGSo/gO/EgmT9aPj6lAzUkRa7bZCTTdW4BraaHU0leX5T94909Qfhbr3W5AVTfDOCKiQ==,
+        integrity: sha512-rxHVil0tJAmz+keFcZCj1LaUdgdkK66E/l0gqh2p1209PNCGoD3lnClFr6vusy1aF3zF8O9JPtuMEJzXOKhs+w==,
       }
     engines: { node: ">=18" }
 
@@ -3706,10 +3706,10 @@ packages:
       "@opentelemetry/sdk-trace-base": ^1.30.1 || ^2.1.0
       "@opentelemetry/semantic-conventions": ^1.39.0
 
-  "@sentry/opentelemetry@10.51.0":
+  "@sentry/opentelemetry@10.53.1":
     resolution:
       {
-        integrity: sha512-Qc7AlCE4uhB+SvHLqah4RgR1WdY7wmmr/hx9g/prDP9R1ocshmUEMrZK9qjuwaklW7/fmkFCXI8ETxo5L1bHIA==,
+        integrity: sha512-Zok6UXla0mFOjd1YnVb1TZtQNOry9v93fXUqx8jmDaygwWM2BwvP8rBQabLz0/OZXo8+35oge+Vmw+QY5aesnA==,
       }
     engines: { node: ">=18" }
     peerDependencies:
@@ -4675,16 +4675,16 @@ packages:
         integrity: sha512-dgiLWA3l+4IFk1jg65aABfmRqO2eJdk6vZsNvONhD8Lkpn8i1WrGJ0ggVjD7I/MR9rNxSs4zyfIgpKYv5FFqWw==,
       }
 
-  "@vercel/sandbox@2.0.0-beta.19":
-    resolution:
-      {
-        integrity: sha512-OH9DkzF3TP1wEBEBy1BHRPQHrUKNjSix8a3gTUOqouKJ0KJxzHNT8PFy+7xMx6MuEZ51cuWtnnesfo0j5TL3LA==,
-      }
-
   "@vercel/sandbox@1.9.0":
     resolution:
       {
         integrity: sha512-zgr1ad0tkT1xZn/8Vxo60wOUOLqMAVGo4WqJQ8/UDcUtWynNJsBjI2tiMdWZrAo9EKH1MIqEzJNkcclF0UT1EQ==,
+      }
+
+  "@vercel/sandbox@2.0.0-beta.19":
+    resolution:
+      {
+        integrity: sha512-OH9DkzF3TP1wEBEBy1BHRPQHrUKNjSix8a3gTUOqouKJ0KJxzHNT8PFy+7xMx6MuEZ51cuWtnnesfo0j5TL3LA==,
       }
 
   "@vercel/static-build@2.9.15":
@@ -13328,7 +13328,7 @@ snapshots:
 
   "@sentry/core@10.50.0-alpha.0": {}
 
-  "@sentry/core@10.51.0": {}
+  "@sentry/core@10.53.1": {}
 
   "@sentry/junior@file:packages/junior(@aws-sdk/credential-provider-web-identity@3.972.33)(@opentelemetry/api@1.9.1)(@sentry/node@10.50.0-alpha.0)":
     dependencies:
@@ -13368,7 +13368,7 @@ snapshots:
       - utf-8-validate
       - ws
 
-  "@sentry/junior@file:packages/junior(@aws-sdk/credential-provider-web-identity@3.972.33)(@opentelemetry/api@1.9.1)(@sentry/node@10.51.0)":
+  "@sentry/junior@file:packages/junior(@aws-sdk/credential-provider-web-identity@3.972.33)(@opentelemetry/api@1.9.1)(@sentry/node@10.53.1)":
     dependencies:
       "@ai-sdk/gateway": 3.0.110(zod@4.4.3)
       "@chat-adapter/slack": 4.28.1
@@ -13378,7 +13378,7 @@ snapshots:
       "@mariozechner/pi-agent-core": 0.73.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)
       "@mariozechner/pi-ai": 0.73.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)
       "@modelcontextprotocol/sdk": 1.29.0(zod@4.4.3)
-      "@sentry/node": 10.51.0
+      "@sentry/node": 10.53.1
       "@sinclair/typebox": 0.34.49
       "@slack/web-api": 7.15.2
       "@vercel/functions": 3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33)
@@ -13418,10 +13418,10 @@ snapshots:
       "@opentelemetry/sdk-trace-base": 2.7.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
 
-  "@sentry/node-core@10.51.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)":
+  "@sentry/node-core@10.53.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)":
     dependencies:
-      "@sentry/core": 10.51.0
-      "@sentry/opentelemetry": 10.51.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      "@sentry/core": 10.53.1
+      "@sentry/opentelemetry": 10.53.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
       import-in-the-middle: 3.0.1
     optionalDependencies:
       "@opentelemetry/api": 1.9.1
@@ -13468,7 +13468,7 @@ snapshots:
       - "@opentelemetry/exporter-trace-otlp-http"
       - supports-color
 
-  "@sentry/node@10.51.0":
+  "@sentry/node@10.53.1":
     dependencies:
       "@fastify/otel": 0.18.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/api": 1.9.1
@@ -13482,7 +13482,6 @@ snapshots:
       "@opentelemetry/instrumentation-graphql": 0.62.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/instrumentation-hapi": 0.60.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/instrumentation-http": 0.214.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-ioredis": 0.62.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/instrumentation-kafkajs": 0.23.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/instrumentation-knex": 0.58.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/instrumentation-koa": 0.62.0(@opentelemetry/api@1.9.1)
@@ -13492,14 +13491,13 @@ snapshots:
       "@opentelemetry/instrumentation-mysql": 0.60.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/instrumentation-mysql2": 0.60.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/instrumentation-pg": 0.66.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-redis": 0.62.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/instrumentation-tedious": 0.33.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/sdk-trace-base": 2.7.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
       "@prisma/instrumentation": 7.6.0(@opentelemetry/api@1.9.1)
-      "@sentry/core": 10.51.0
-      "@sentry/node-core": 10.51.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
-      "@sentry/opentelemetry": 10.51.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      "@sentry/core": 10.53.1
+      "@sentry/node-core": 10.53.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      "@sentry/opentelemetry": 10.53.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
       import-in-the-middle: 3.0.1
     transitivePeerDependencies:
       - "@opentelemetry/exporter-trace-otlp-http"
@@ -13513,13 +13511,13 @@ snapshots:
       "@opentelemetry/semantic-conventions": 1.40.0
       "@sentry/core": 10.50.0-alpha.0
 
-  "@sentry/opentelemetry@10.51.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)":
+  "@sentry/opentelemetry@10.53.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/core": 2.7.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/sdk-trace-base": 2.7.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.40.0
-      "@sentry/core": 10.51.0
+      "@sentry/core": 10.53.1
 
   "@shikijs/core@3.23.0":
     dependencies:
@@ -14054,7 +14052,7 @@ snapshots:
 
   "@types/sax@1.2.7":
     dependencies:
-      "@types/node": 24.12.2
+      "@types/node": 25.6.0
 
   "@types/set-cookie-parser@2.4.10":
     dependencies:
@@ -14359,10 +14357,9 @@ snapshots:
       execa: 5.1.1
       smol-toml: 1.5.2
 
-  "@vercel/sandbox@2.0.0-beta.19":
+  "@vercel/sandbox@1.9.0":
     dependencies:
       "@vercel/oidc": 3.2.0
-      "@workflow/serde": 4.1.0-beta.2
       async-retry: 1.3.3
       jsonlines: 0.1.1
       ms: 2.1.3
@@ -14375,9 +14372,10 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  "@vercel/sandbox@1.9.0":
+  "@vercel/sandbox@2.0.0-beta.19":
     dependencies:
       "@vercel/oidc": 3.2.0
+      "@workflow/serde": 4.1.0-beta.2
       async-retry: 1.3.3
       jsonlines: 0.1.1
       ms: 2.1.3


### PR DESCRIPTION
Bumps `@sentry/node` from `10.50.0-alpha.0` to the stable `10.53.1` release and enables `streamGenAISpans: true` in our Sentry init.

`streamGenAISpans` ensures that Gen AI spans are ingested via span v2 pipeline so they can be up to 1MB in size.
it's experimental opt-in option that will disappear and become a new default after a couple of weeks.
