### PR TITLE
Persist Pi transcript eagerly to durable thread state

### DIFF
--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -153,6 +153,15 @@ export interface ReplyRequestContext {
     toolName: string;
     params: Record<string, unknown>;
   }) => void;
+  /**
+   * Called after each safe-boundary checkpoint write succeeds during the
+   * agent loop. The supplied `piMessages` are the latest persisted Pi
+   * transcript with turn-context user-message parts stripped, suitable for
+   * use as durable conversation history. Used to persist mid-turn progress
+   * so a follow-up user message after an ungraceful failure does not start
+   * from stale pre-turn history.
+   */
+  onPiMessagesPersisted?: (piMessages: PiMessage[]) => void | Promise<void>;
 }
 
 let startupDiscoveryLogged = false;
@@ -939,6 +948,30 @@ export async function generateAssistantReply(
     });
     let hasEmittedText = false;
     let needsSeparator = false;
+    const notifyPiMessagesPersisted = async (
+      messages: PiMessage[],
+    ): Promise<void> => {
+      if (!context.onPiMessagesPersisted) {
+        return;
+      }
+      try {
+        await context.onPiMessagesPersisted(
+          stripTurnContextFromMessages(messages, turnContextPrompt),
+        );
+      } catch (error) {
+        // Eager-persistence failures must not interrupt the agent loop. The
+        // turn-session checkpoint already captured the safe boundary.
+        logWarn(
+          "agent_turn_eager_pi_messages_persist_failed",
+          spanContext,
+          {
+            "exception.message":
+              error instanceof Error ? error.message : String(error),
+          },
+          "Failed to persist Pi messages to durable thread state",
+        );
+      }
+    };
     const persistSafeBoundary = async (
       messages: PiMessage[],
     ): Promise<void> => {
@@ -958,10 +991,21 @@ export async function generateAssistantReply(
         loadedSkillNames: loadedSkillNamesForResume,
         logContext: checkpointLogContext,
       });
+      await notifyPiMessagesPersisted(messages);
     };
 
     const unsubscribe = agent.subscribe((event) => {
       if (event.type === "turn_end" && event.toolResults.length > 0) {
+        return persistSafeBoundary([...agent!.state.messages]);
+      }
+      // Also persist after each individual tool-result message is appended.
+      // With sequential tool execution this captures incremental progress
+      // within a multi-tool batch so a function-level interruption mid-batch
+      // does not lose earlier tool results.
+      if (
+        event.type === "message_end" &&
+        (event.message as { role?: unknown }).role === "toolResult"
+      ) {
         return persistSafeBoundary([...agent!.state.messages]);
       }
       if (event.type === "message_start") {

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -154,12 +154,10 @@ export interface ReplyRequestContext {
     params: Record<string, unknown>;
   }) => void;
   /**
-   * Called after each safe-boundary checkpoint write succeeds during the
-   * agent loop. The supplied `piMessages` are the latest persisted Pi
-   * transcript with turn-context user-message parts stripped, suitable for
-   * use as durable conversation history. Used to persist mid-turn progress
-   * so a follow-up user message after an ungraceful failure does not start
-   * from stale pre-turn history.
+   * Called at each safe-boundary checkpoint write during the agent loop so
+   * durable conversation history advances mid-turn. Receives the latest Pi
+   * transcript with turn-context user-message parts stripped. Failures are
+   * treated as hard failures and abort the turn.
    */
   onPiMessagesPersisted?: (piMessages: PiMessage[]) => void | Promise<void>;
 }
@@ -948,30 +946,6 @@ export async function generateAssistantReply(
     });
     let hasEmittedText = false;
     let needsSeparator = false;
-    const notifyPiMessagesPersisted = async (
-      messages: PiMessage[],
-    ): Promise<void> => {
-      if (!context.onPiMessagesPersisted) {
-        return;
-      }
-      try {
-        await context.onPiMessagesPersisted(
-          stripTurnContextFromMessages(messages, turnContextPrompt),
-        );
-      } catch (error) {
-        // Eager-persistence failures must not interrupt the agent loop. The
-        // turn-session checkpoint already captured the safe boundary.
-        logWarn(
-          "agent_turn_eager_pi_messages_persist_failed",
-          spanContext,
-          {
-            "exception.message":
-              error instanceof Error ? error.message : String(error),
-          },
-          "Failed to persist Pi messages to durable thread state",
-        );
-      }
-    };
     const persistSafeBoundary = async (
       messages: PiMessage[],
     ): Promise<void> => {
@@ -991,21 +965,13 @@ export async function generateAssistantReply(
         loadedSkillNames: loadedSkillNamesForResume,
         logContext: checkpointLogContext,
       });
-      await notifyPiMessagesPersisted(messages);
+      await context.onPiMessagesPersisted?.(
+        stripTurnContextFromMessages(messages, turnContextPrompt),
+      );
     };
 
     const unsubscribe = agent.subscribe((event) => {
-      if (event.type === "turn_end" && event.toolResults.length > 0) {
-        return persistSafeBoundary([...agent!.state.messages]);
-      }
-      // Also persist after each individual tool-result message is appended.
-      // With sequential tool execution this captures incremental progress
-      // within a multi-tool batch so a function-level interruption mid-batch
-      // does not lose earlier tool results.
-      if (
-        event.type === "message_end" &&
-        (event.message as { role?: unknown }).role === "toolResult"
-      ) {
+      if (event.type === "turn_end") {
         return persistSafeBoundary([...agent!.state.messages]);
       }
       if (event.type === "message_start") {

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -497,6 +497,16 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               latestArtifacts = artifacts;
               await persistThreadState(thread, { artifacts });
             },
+            onPiMessagesPersisted: async (piMessages) => {
+              // Mid-turn safe-boundary writes feed the durable conversation
+              // transcript so a follow-up user message after an ungraceful
+              // failure resumes from the latest safe boundary instead of the
+              // pre-turn snapshot.
+              preparedState.conversation.piMessages = piMessages;
+              await persistThreadState(thread, {
+                conversation: preparedState.conversation,
+              });
+            },
             onAuthPending: async (pendingAuth) => {
               await applyPendingAuthUpdate({
                 conversation: preparedState.conversation,

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -265,6 +265,10 @@ async function resumeAuthorizedMcpTurn(args: {
         });
         await persistThreadStateById(threadId, { conversation });
       },
+      onPiMessagesPersisted: async (piMessages) => {
+        conversation.piMessages = piMessages;
+        await persistThreadStateById(threadId, { conversation });
+      },
       ...getTurnUserReplyAttachmentContext(userMessage),
     },
     onSuccess: async (reply) => {

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -287,6 +287,12 @@ async function resumeCheckpointedOAuthTurn(
           conversation,
         });
       },
+      onPiMessagesPersisted: async (piMessages) => {
+        conversation.piMessages = piMessages;
+        await persistThreadStateById(stored.resumeConversationId!, {
+          conversation,
+        });
+      },
       ...getTurnUserReplyAttachmentContext(userMessage),
     },
     onSuccess: async (reply) => {

--- a/packages/junior/src/handlers/turn-resume.ts
+++ b/packages/junior/src/handlers/turn-resume.ts
@@ -210,6 +210,12 @@ async function resumeTimedOutTurn(
           conversation,
         });
       },
+      onPiMessagesPersisted: async (piMessages) => {
+        conversation.piMessages = piMessages;
+        await persistThreadStateById(payload.conversationId, {
+          conversation,
+        });
+      },
       ...getTurnUserReplyAttachmentContext(userMessage),
     },
     onSuccess: async (reply) => {

--- a/packages/junior/tests/unit/runtime/respond-eager-pi-persist.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-eager-pi-persist.test.ts
@@ -33,7 +33,6 @@ vi.mock("@mariozechner/pi-agent-core", () => {
     }
 
     subscribe(listener: (event: unknown) => Promise<void> | void) {
-      console.log("DEBUG subscribe called");
       agentEvents.listeners.push(listener);
       return () => {
         const index = agentEvents.listeners.indexOf(listener);
@@ -52,10 +51,6 @@ vi.mock("@mariozechner/pi-agent-core", () => {
     }
 
     async prompt(message: PiMessage) {
-      console.log(
-        "DEBUG prompt called, listener count:",
-        agentEvents.listeners.length,
-      );
       this.state.messages.push(message);
       const toolResultMessage = {
         role: "toolResult",
@@ -74,7 +69,6 @@ vi.mock("@mariozechner/pi-agent-core", () => {
       this.state.messages.push(assistantMessage);
       this.state.messages.push(toolResultMessage);
       for (const listener of agentEvents.listeners) {
-        await listener({ type: "message_end", message: toolResultMessage });
         await listener({
           type: "turn_end",
           message: assistantMessage,
@@ -206,12 +200,9 @@ describe("generateAssistantReply eager Pi message persistence", () => {
       },
     });
 
-    console.log(
-      "DEBUG snapshots:",
-      persistedSnapshots.length,
-      JSON.stringify(persistedSnapshots).slice(0, 2000),
-    );
-    expect(persistedSnapshots.length).toBeGreaterThanOrEqual(2);
+    // One snapshot from the pre-prompt safe-boundary write (durable history
+    // captures the user prompt before any LLM call), one from `turn_end`.
+    expect(persistedSnapshots.length).toBe(2);
 
     const finalSnapshot = persistedSnapshots[persistedSnapshots.length - 1];
     const lastMessage = finalSnapshot.at(-1) as { role?: unknown };
@@ -231,5 +222,22 @@ describe("generateAssistantReply eager Pi message persistence", () => {
       );
       expect(turnContextParts).toHaveLength(0);
     }
+  });
+
+  it("propagates onPiMessagesPersisted failures as turn errors", async () => {
+    const reply = await generateAssistantReply("help me", {
+      requester: { userId: "U123" },
+      correlation: {
+        conversationId: "conversation-2",
+        turnId: "turn-2",
+        channelId: "C123",
+        threadTs: "1712345.0002",
+      },
+      onPiMessagesPersisted: () => {
+        throw new Error("durable store offline");
+      },
+    });
+
+    expect(reply.text).toContain("Error: durable store offline");
   });
 });

--- a/packages/junior/tests/unit/runtime/respond-eager-pi-persist.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-eager-pi-persist.test.ts
@@ -1,0 +1,235 @@
+import { Buffer } from "node:buffer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PiMessage } from "@/chat/pi/messages";
+
+const { agentEvents } = vi.hoisted(() => ({
+  agentEvents: {
+    listeners: [] as Array<(event: unknown) => Promise<void> | void>,
+  },
+}));
+
+vi.mock("@mariozechner/pi-agent-core", () => {
+  class MockAgent {
+    state: {
+      messages: unknown[];
+      model: unknown;
+      systemPrompt: string;
+      tools: unknown[];
+    };
+
+    constructor(input: {
+      initialState: {
+        model: unknown;
+        systemPrompt: string;
+        tools: unknown[];
+      };
+    }) {
+      this.state = {
+        messages: [],
+        model: input.initialState.model,
+        systemPrompt: input.initialState.systemPrompt,
+        tools: input.initialState.tools,
+      };
+    }
+
+    subscribe(listener: (event: unknown) => Promise<void> | void) {
+      console.log("DEBUG subscribe called");
+      agentEvents.listeners.push(listener);
+      return () => {
+        const index = agentEvents.listeners.indexOf(listener);
+        if (index >= 0) agentEvents.listeners.splice(index, 1);
+      };
+    }
+
+    abort() {}
+
+    async replaceMessages(messages: unknown[]) {
+      this.state.messages = [...messages];
+    }
+
+    async continue() {
+      return {};
+    }
+
+    async prompt(message: PiMessage) {
+      console.log(
+        "DEBUG prompt called, listener count:",
+        agentEvents.listeners.length,
+      );
+      this.state.messages.push(message);
+      const toolResultMessage = {
+        role: "toolResult",
+        toolCallId: "call-1",
+        toolName: "echo",
+        content: [{ type: "text", text: "ok" }],
+        timestamp: 2,
+      };
+      const assistantMessage = {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "call-1", name: "echo", arguments: {} },
+        ],
+        timestamp: 3,
+      };
+      this.state.messages.push(assistantMessage);
+      this.state.messages.push(toolResultMessage);
+      for (const listener of agentEvents.listeners) {
+        await listener({ type: "message_end", message: toolResultMessage });
+        await listener({
+          type: "turn_end",
+          message: assistantMessage,
+          toolResults: [toolResultMessage],
+        });
+      }
+      this.state.messages.push({
+        role: "assistant",
+        content: [{ type: "text", text: "done" }],
+        stopReason: "stop",
+      });
+      return {};
+    }
+  }
+  return { Agent: MockAgent };
+});
+
+vi.mock("@/chat/config", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/chat/config")>();
+  const memoryConfig = original.readChatConfig({
+    ...process.env,
+    AGENT_TURN_TIMEOUT_MS: "10000",
+    FUNCTION_MAX_DURATION_SECONDS: "60",
+    JUNIOR_STATE_ADAPTER: "memory",
+  });
+  return {
+    ...original,
+    botConfig: memoryConfig.bot,
+    getChatConfig: () => memoryConfig,
+    getRuntimeMetadata: () => ({ version: "test" }),
+  };
+});
+
+vi.mock("@/chat/capabilities/factory", () => ({
+  createUserTokenStore: () => ({
+    get: async () => undefined,
+    set: async () => undefined,
+    delete: async () => undefined,
+  }),
+}));
+
+vi.mock("@/chat/capabilities/jr-rpc-command", () => ({
+  maybeExecuteJrRpcCustomCommand: async () => ({ handled: false }),
+}));
+
+vi.mock("@/chat/pi/client", () => ({
+  GEN_AI_PROVIDER_NAME: "vercel-ai-gateway",
+  completeObject: async () => ({
+    object: {
+      thinking_level: "medium",
+      confidence: 1,
+      reason: "test-router",
+    },
+  }),
+  getPiGatewayApiKeyOverride: () => "test-gateway-key",
+  resolveGatewayModel: (modelId: string) => modelId,
+}));
+
+vi.mock("@/chat/prompt", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/chat/prompt")>();
+  return {
+    ...actual,
+    buildSystemPrompt: () => "System prompt",
+  };
+});
+
+vi.mock("@/chat/runtime/dev-agent-trace", () => ({
+  shouldEmitDevAgentTrace: () => false,
+}));
+
+vi.mock("@/chat/sandbox/sandbox", () => ({
+  createSandboxExecutor: () => ({
+    configureSkills: () => undefined,
+    configureReferenceFiles: () => undefined,
+    createSandbox: async () => ({
+      readFileToBuffer: async () => Buffer.from("", "utf8"),
+      runCommand: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
+    }),
+    canExecute: () => false,
+    execute: async () => {
+      throw new Error("sandbox executor should not execute in this test");
+    },
+    getSandboxId: () => undefined,
+    getDependencyProfileHash: () => undefined,
+    dispose: async () => undefined,
+  }),
+}));
+
+vi.mock("@/chat/plugins/registry", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/chat/plugins/registry")>()),
+  getPluginMcpProviders: () => [],
+  getPluginProviders: () => [],
+}));
+
+vi.mock("@/chat/skills", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/chat/skills")>()),
+  discoverSkills: async () => [],
+  findSkillByName: () => null,
+  parseSkillInvocation: () => null,
+}));
+
+import { generateAssistantReply } from "@/chat/respond";
+import { disconnectStateAdapter } from "@/chat/state/adapter";
+
+describe("generateAssistantReply eager Pi message persistence", () => {
+  beforeEach(async () => {
+    process.env.JUNIOR_STATE_ADAPTER = "memory";
+    agentEvents.listeners.length = 0;
+    await disconnectStateAdapter();
+  });
+
+  afterEach(async () => {
+    await disconnectStateAdapter();
+    delete process.env.JUNIOR_STATE_ADAPTER;
+  });
+
+  it("notifies onPiMessagesPersisted at each safe-boundary write so durable state can advance mid-turn", async () => {
+    const persistedSnapshots: PiMessage[][] = [];
+    await generateAssistantReply("help me", {
+      requester: { userId: "U123" },
+      correlation: {
+        conversationId: "conversation-1",
+        turnId: "turn-1",
+        channelId: "C123",
+        threadTs: "1712345.0001",
+      },
+      onPiMessagesPersisted: (messages) => {
+        persistedSnapshots.push(messages.map((m) => ({ ...m }) as PiMessage));
+      },
+    });
+
+    console.log(
+      "DEBUG snapshots:",
+      persistedSnapshots.length,
+      JSON.stringify(persistedSnapshots).slice(0, 2000),
+    );
+    expect(persistedSnapshots.length).toBeGreaterThanOrEqual(2);
+
+    const finalSnapshot = persistedSnapshots[persistedSnapshots.length - 1];
+    const lastMessage = finalSnapshot.at(-1) as { role?: unknown };
+    expect(lastMessage?.role).toBe("toolResult");
+
+    const userMessages = finalSnapshot.filter(
+      (m) => (m as { role?: unknown }).role === "user",
+    );
+    expect(userMessages.length).toBeGreaterThan(0);
+    for (const userMessage of userMessages) {
+      const content = (userMessage as { content?: Array<{ text?: unknown }> })
+        .content;
+      const turnContextParts = (content ?? []).filter(
+        (part) =>
+          typeof part?.text === "string" &&
+          part.text.startsWith("Turn context"),
+      );
+      expect(turnContextParts).toHaveLength(0);
+    }
+  });
+});

--- a/specs/agent-session-resumability-spec.md
+++ b/specs/agent-session-resumability-spec.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-03-05
-- Last Edited: 2026-05-19
+- Last Edited: 2026-05-21
 
 ## Changelog
 
@@ -16,6 +16,7 @@
 - 2026-05-06: Removed the public Slack auth-pause note; auth pauses complete the live turn after private auth-link delivery.
 - 2026-05-13: Clarified turn continuation as an idempotent checkpoint retry path, including user follow-up rescheduling and bounded lock-busy callback retries.
 - 2026-05-19: Clarified that Slack auth pauses also post a visible URL-free acknowledgement owned by the Slack delivery contract.
+- 2026-05-21: Required durable Pi-transcript persistence at every `turn_end` safe boundary so ungraceful failures resume from the latest completed LLM turn. Persistence failures are hard turn failures, not silently degraded.
 
 ## Status
 
@@ -261,7 +262,7 @@ Required attributes when available:
 6. Integration: a user follow-up or duplicate delivery during an awaiting automatic continuation checkpoint reschedules the existing session instead of starting a new turn.
 7. Unit/integration: auth-driven resume restores the same active skill/MCP tool universe before `continue()`.
 8. Unit/integration: eager sandbox/artifact persistence preserves resumed tool context across slices.
-9. Unit/integration: eager Pi-transcript persistence at safe boundaries means a turn that dies without an `awaiting_resume` checkpoint still leaves durable thread state pointing at the latest safe boundary, so the next user message does not rebuild from pre-turn history.
+9. Unit/integration: every `turn_end` safe boundary advances the durable Pi transcript on the thread, and a durable-store write failure surfaces as a hard turn error (no silent degradation).
 10. Manual/eval: once assistant text is already visible, timeout does not auto-resume or attempt to reconcile partial thread output.
 
 ## Related Specs

--- a/specs/agent-session-resumability-spec.md
+++ b/specs/agent-session-resumability-spec.md
@@ -261,7 +261,8 @@ Required attributes when available:
 6. Integration: a user follow-up or duplicate delivery during an awaiting automatic continuation checkpoint reschedules the existing session instead of starting a new turn.
 7. Unit/integration: auth-driven resume restores the same active skill/MCP tool universe before `continue()`.
 8. Unit/integration: eager sandbox/artifact persistence preserves resumed tool context across slices.
-9. Manual/eval: once assistant text is already visible, timeout does not auto-resume or attempt to reconcile partial thread output.
+9. Unit/integration: eager Pi-transcript persistence at safe boundaries means a turn that dies without an `awaiting_resume` checkpoint still leaves durable thread state pointing at the latest safe boundary, so the next user message does not rebuild from pre-turn history.
+10. Manual/eval: once assistant text is already visible, timeout does not auto-resume or attempt to reconcile partial thread output.
 
 ## Related Specs
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Conversations were dropping mid-turn and follow-up "force resume" messages were starting from stale history because the durable Pi transcript on the thread (`conversation.piMessages`) was only written when a turn completed cleanly.

If a slice died in any way that did not produce an `awaiting_resume` checkpoint — Vercel function termination, an unexpected JS error, a transient network failure between functions, or a `running` checkpoint that was never promoted — durable thread state still pointed at the pre-turn snapshot. The next user message then rebuilt the agent's Pi history from before any of the dead slice's assistant text or tool results, which surfaced to users as the bot "forgetting things" on follow-up.

The turn-session checkpoint store already wrote a `running` checkpoint at every safe boundary, but `loadTurnCheckpoint` only treats `awaiting_resume` checkpoints as resumable, so the data was effectively dead weight for ungraceful failures. This change makes the same safe-boundary signal also advance durable thread state.

## What

- Added an `onPiMessagesPersisted` hook on `ReplyRequestContext`. It fires from a single `turn_end` subscriber — the natural end-of-LLM-completion safe boundary — with turn-context user-message parts stripped so per-slice runtime context is not captured in durable history.
- Wired the live reply path (`reply-executor.ts`) and all three resume entry points (`turn-resume.ts`, `oauth-callback.ts`, `mcp-oauth-callback.ts`) to push these messages into `conversation.piMessages` and persist thread state.
- Durable-store writes are part of turn correctness: if `onPiMessagesPersisted` throws, the error propagates and the turn fails (the existing `generateAssistantReply` error path logs it and returns a `provider_error` reply). No silent degradation.

## Spec

Updated `specs/agent-session-resumability-spec.md` to require durable Pi-transcript persistence at every `turn_end` safe boundary alongside sandbox/artifact state, and to require that persistence failures are hard turn errors.

## Tests

- `pnpm --filter @sentry/junior typecheck` ✅
- `pnpm --filter @sentry/junior exec vitest run tests/unit` (769 tests) ✅
- `tests/unit/runtime/respond-eager-pi-persist.test.ts` covers the safe-boundary write contract and asserts that a durable-store failure surfaces as a turn error.
- Existing resume integration suites (`turn-resume-slack`, `oauth-callback-slack`, `mcp-oauth-callback-slack`, `oauth-resume-slack`, `mcp-auth-runtime-slack`) continue to pass.
- `pnpm skills:check` and `pnpm --filter @sentry/junior run test:slack-boundary` ✅
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C0AHB7N2JCR/p1779382008376779?thread_ts=1779382008.376779&cid=C0AHB7N2JCR)

<div><a href="https://cursor.com/agents/bc-33fccc3e-bbe6-598b-ba7d-7feeb3b142ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33fccc3e-bbe6-598b-ba7d-7feeb3b142ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

