### PR TITLE
fix(sandbox): Preserve lazy credential egress auth

### DIFF
--- a/packages/docs/src/content/docs/concepts/credentials-and-oauth.md
+++ b/packages/docs/src/content/docs/concepts/credentials-and-oauth.md
@@ -20,7 +20,9 @@ requester-bound lease and injects auth at the host boundary.
 - User-owned provider access is only activated for the author of the current message.
 - Plugin declarations determine which credentials can be injected for matching provider domains.
 - Sandbox receives placeholder env vars and proxied HTTP responses, not raw long-lived tokens.
-- Junior rejects proxied provider requests unless the sandbox command has an active requester-bound egress session and the forwarded host matches a registered provider domain.
+- Credential issuance is lazy: Junior does not mint provider tokens until sandbox traffic actually reaches a declared provider domain, avoiding wasted token work for commands that never need auth.
+- Junior does not guess intent from command text to pre-scope or pre-mint credentials; request-time provider/domain matching is the boundary.
+- Junior rejects proxied provider requests unless the sandbox has a signed requester context for that VM session and the forwarded host matches a registered provider domain.
 
 ## OAuth model
 

--- a/packages/docs/src/content/docs/concepts/execution-model.md
+++ b/packages/docs/src/content/docs/concepts/execution-model.md
@@ -17,7 +17,7 @@ related:
 3. Thread work is enqueued to `junior-thread-message`.
 4. `/api/queue/callback` processes queued work.
 5. Agent turn runs with configured tools, loaded skills, and capability gates.
-6. If an authenticated command reaches a declared provider domain, the sandbox egress proxy fetches command-scoped requester credentials and injects them at the host boundary.
+6. If sandbox traffic reaches a declared provider domain, the sandbox egress proxy lazily fetches requester-bound credentials and injects them at the host boundary.
 7. If OAuth is required, Junior sends the link privately to the requesting user and resumes the blocked request after the callback.
 8. Reply is posted back to the original Slack thread.
 
@@ -30,7 +30,7 @@ related:
 ## Core invariants
 
 - Webhook ingress and queue callback are both required for production.
-- Tool usage is turn-scoped; sandbox credential leases are requester-bound and command-scoped.
+- Tool usage is turn-scoped; sandbox credential leases are requester-bound and minted lazily only after forwarded provider traffic needs them.
 - Registered plugin providers determine which provider credentials can be injected for matching provider domains.
 - Failure states are logged and surfaced for operator recovery.
 

--- a/packages/docs/src/content/docs/operate/security-hardening.md
+++ b/packages/docs/src/content/docs/operate/security-hardening.md
@@ -27,7 +27,9 @@ session-wide sandbox state.
 - Use short-lived scoped credentials.
 - Let registered plugin providers determine which credentials may be injected for matching domains.
 - Fetch credentials from the host when sandbox traffic hits a declared provider domain.
-- Keep sandbox egress authorization bound to the requester and current sandbox command.
+- Keep sandbox egress authorization bound to the requester context, sandbox VM session, and forwarded provider domain.
+- Mint provider credentials lazily at the egress proxy, not when a plugin loads or a command starts.
+- Do not guess provider intent from command text for token scoping; use request-time provider/domain matching.
 - Inject scoped auth at the host proxy boundary instead of exposing raw tokens.
 
 ## OAuth handling

--- a/packages/docs/src/content/docs/reference/config-and-env.md
+++ b/packages/docs/src/content/docs/reference/config-and-env.md
@@ -38,10 +38,10 @@ If enabled plugins use host-managed credentials inside Vercel Sandbox, Junior fo
 
 The egress proxy verifies Vercel-signed Sandbox OIDC tokens per request to authenticate the sandbox VM; requester authorization comes from the signed forwarding-route context bound to that VM session. No separate audience, project, or team env vars are required for the proxy.
 
-| Variable                       | Required    | Purpose                                                                                                                           |
-| ------------------------------ | ----------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `JUNIOR_BASE_URL`              | Conditional | Public URL for the credential egress proxy, unless Vercel URL envs cover it.                                                      |
-| `JUNIOR_SANDBOX_EGRESS_SECRET` | No          | Secret for signed sandbox egress requester-context URLs. Falls back to `JUNIOR_INTERNAL_RESUME_SECRET` or `SLACK_SIGNING_SECRET`. |
+| Variable                       | Required    | Purpose                                                                                                            |
+| ------------------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------ |
+| `JUNIOR_BASE_URL`              | Conditional | Public URL for the credential egress proxy, unless Vercel URL envs cover it.                                       |
+| `JUNIOR_SANDBOX_EGRESS_SECRET` | No          | Secret for signed sandbox egress requester-context URLs. Falls back to `JUNIOR_INTERNAL_RESUME_SECRET` when unset. |
 
 ## GitHub plugin
 

--- a/packages/docs/src/content/docs/reference/config-and-env.md
+++ b/packages/docs/src/content/docs/reference/config-and-env.md
@@ -34,13 +34,14 @@ If your build command runs `junior snapshot create`:
 
 ## Sandbox credential egress
 
-If enabled plugins use host-managed credentials inside Vercel Sandbox, Junior forwards registered provider domains through its credential egress proxy. The proxy verifies each Vercel-signed sandbox request and requires an active egress session before it injects credentials.
+If enabled plugins use host-managed credentials inside Vercel Sandbox, Junior forwards registered provider domains through its credential egress proxy. The proxy verifies each Vercel-signed sandbox request and requires a signed requester context before it injects credentials lazily.
 
-The egress proxy verifies Vercel-signed Sandbox OIDC tokens per request and binds them to the active VM session used in the forwarding route. No separate audience, project, or team env vars are required for the proxy.
+The egress proxy verifies Vercel-signed Sandbox OIDC tokens per request to authenticate the sandbox VM; requester authorization comes from the signed forwarding-route context bound to that VM session. No separate audience, project, or team env vars are required for the proxy.
 
-| Variable          | Required    | Purpose                                                                      |
-| ----------------- | ----------- | ---------------------------------------------------------------------------- |
-| `JUNIOR_BASE_URL` | Conditional | Public URL for the credential egress proxy, unless Vercel URL envs cover it. |
+| Variable                       | Required    | Purpose                                                                                                                           |
+| ------------------------------ | ----------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `JUNIOR_BASE_URL`              | Conditional | Public URL for the credential egress proxy, unless Vercel URL envs cover it.                                                      |
+| `JUNIOR_SANDBOX_EGRESS_SECRET` | No          | Secret for signed sandbox egress requester-context URLs. Falls back to `JUNIOR_INTERNAL_RESUME_SECRET` or `SLACK_SIGNING_SECRET`. |
 
 ## GitHub plugin
 

--- a/packages/junior/src/chat/sandbox/egress-oidc.ts
+++ b/packages/junior/src/chat/sandbox/egress-oidc.ts
@@ -90,7 +90,7 @@ export async function verifyVercelSandboxOidcToken(
     issuer: unverified.iss,
   });
   // The Sandbox proxy token is request identity. Do not compare its audience,
-  // team, or project claims with deployment OIDC; the egress session decides
-  // whether this VM session may activate requester-bound credentials.
+  // team, or project claims with deployment OIDC; the signed requester
+  // context decides which requester credentials may be issued lazily.
   return verified.payload;
 }

--- a/packages/junior/src/chat/sandbox/egress-policy.ts
+++ b/packages/junior/src/chat/sandbox/egress-policy.ts
@@ -1,5 +1,6 @@
 import type { NetworkPolicy, NetworkPolicyRule } from "@vercel/sandbox";
 import { resolveBaseUrl } from "@/chat/oauth-flow";
+import { SANDBOX_EGRESS_PROXY_PATH } from "@/chat/sandbox/egress-session";
 import { resolveAuthTokenPlaceholder } from "@/chat/plugins/auth/auth-token-placeholder";
 import { resolvePluginCommandEnv } from "@/chat/plugins/command-env";
 import { getPluginProviders } from "@/chat/plugins/registry";
@@ -40,18 +41,23 @@ export function resolveSandboxEgressProviderForHost(
   )?.provider;
 }
 
-function sandboxProxyUrl(): string {
+function sandboxProxyUrl(requesterToken?: string): string {
   const baseUrl = resolveBaseUrl();
   if (!baseUrl) {
     throw new Error(
       "Cannot determine base URL for sandbox credential egress (set JUNIOR_BASE_URL or deploy to Vercel)",
     );
   }
-  return new URL("/", baseUrl).toString();
+  const path = requesterToken
+    ? `${SANDBOX_EGRESS_PROXY_PATH}/${requesterToken}`
+    : SANDBOX_EGRESS_PROXY_PATH;
+  return new URL(path, baseUrl).toString();
 }
 
 /** Build the policy that forwards provider requests back to Junior for credentials. */
-export function buildSandboxEgressNetworkPolicy(): NetworkPolicy {
+export function buildSandboxEgressNetworkPolicy(input?: {
+  requesterToken?: string;
+}): NetworkPolicy {
   const allow: Record<string, NetworkPolicyRule[]> = {
     "*": [],
   };
@@ -60,7 +66,7 @@ export function buildSandboxEgressNetworkPolicy(): NetworkPolicy {
     return { allow };
   }
 
-  const forwardURL = sandboxProxyUrl();
+  const forwardURL = sandboxProxyUrl(input?.requesterToken);
   for (const entry of entries) {
     for (const domain of entry.domains) {
       allow[domain] = [{ forwardURL }];

--- a/packages/junior/src/chat/sandbox/egress-proxy.ts
+++ b/packages/junior/src/chat/sandbox/egress-proxy.ts
@@ -9,10 +9,11 @@ import { verifyVercelSandboxOidcToken } from "@/chat/sandbox/egress-oidc";
 import {
   clearSandboxEgressCredentialLease,
   getSandboxEgressCredentialLease,
-  getSandboxEgressSession,
+  parseSandboxEgressRequesterToken,
+  SANDBOX_EGRESS_PROXY_PATH,
   setSandboxEgressCredentialLease,
   type SandboxEgressCredentialLease,
-  type SandboxEgressSession,
+  type SandboxEgressRequesterContext,
 } from "@/chat/sandbox/egress-session";
 import type { JWTPayload } from "jose";
 
@@ -88,13 +89,37 @@ function egressAttributes(input: {
   };
 }
 
+function requesterTokenFromRequest(request: Request): string | undefined {
+  const pathname = new URL(request.url).pathname;
+  const prefix = `${SANDBOX_EGRESS_PROXY_PATH}/`;
+  if (!pathname.startsWith(prefix)) {
+    return undefined;
+  }
+  const token = pathname.slice(prefix.length).split("/")[0];
+  if (!token) {
+    return undefined;
+  }
+  try {
+    return decodeURIComponent(token);
+  } catch {
+    return undefined;
+  }
+}
+
+function redactedProxyPath(pathname: string): string {
+  if (pathname.startsWith(`${SANDBOX_EGRESS_PROXY_PATH}/`)) {
+    return `${SANDBOX_EGRESS_PROXY_PATH}/<token>`;
+  }
+  return pathname;
+}
+
 function routingAttributes(
   request: Request,
   upstreamUrl?: URL,
 ): Record<string, unknown> {
   const proxyUrl = new URL(request.url);
   const attributes: Record<string, unknown> = {
-    "app.sandbox.egress.proxy_path": proxyUrl.pathname,
+    "app.sandbox.egress.proxy_path": redactedProxyPath(proxyUrl.pathname),
   };
   if (upstreamUrl) {
     attributes["app.sandbox.egress.upstream_path"] = upstreamUrl.pathname;
@@ -167,28 +192,48 @@ function sandboxIdFromPayload(payload: JWTPayload): string | undefined {
     : undefined;
 }
 
+function normalizedForwardedPath(path: string): UpstreamPathResult {
+  if (
+    !path.startsWith("/") ||
+    path.startsWith("//") ||
+    path.includes("#") ||
+    /[\r\n]/.test(path)
+  ) {
+    return { ok: false, error: "Invalid forwarded path" };
+  }
+  try {
+    const url = new URL(path, "https://sandbox-forwarded.local");
+    return { ok: true, path: `${url.pathname}${url.search}` };
+  } catch {
+    return { ok: false, error: "Invalid forwarded path" };
+  }
+}
+
+function upstreamPathFromProxyUrl(url: URL): string | undefined {
+  const prefix = `${SANDBOX_EGRESS_PROXY_PATH}/`;
+  if (!url.pathname.startsWith(prefix)) {
+    return undefined;
+  }
+  const remainder = url.pathname.slice(prefix.length);
+  const upstreamPathStart = remainder.indexOf("/");
+  if (upstreamPathStart === -1) {
+    return undefined;
+  }
+  return `${remainder.slice(upstreamPathStart)}${url.search}`;
+}
+
 function upstreamPath(request: Request): UpstreamPathResult {
   const forwardedPath = request.headers.get(FORWARDED_PATH_HEADER);
   if (forwardedPath?.trim()) {
     // Vercel may normalize request.url; this header carries the original target.
-    const path = forwardedPath.trim();
-    if (
-      !path.startsWith("/") ||
-      path.startsWith("//") ||
-      path.includes("#") ||
-      /[\r\n]/.test(path)
-    ) {
-      return { ok: false, error: "Invalid forwarded path" };
-    }
-    try {
-      const url = new URL(path, "https://sandbox-forwarded.local");
-      return { ok: true, path: `${url.pathname}${url.search}` };
-    } catch {
-      return { ok: false, error: "Invalid forwarded path" };
-    }
+    return normalizedForwardedPath(forwardedPath.trim());
   }
 
   const url = new URL(request.url);
+  const proxyPath = upstreamPathFromProxyUrl(url);
+  if (proxyPath) {
+    return normalizedForwardedPath(proxyPath);
+  }
   return { ok: true, path: `${url.pathname}${url.search}` };
 }
 
@@ -284,22 +329,17 @@ function responseHeaders(upstream: Response): Headers {
 }
 
 async function credentialLease(
-  egressId: string,
   provider: string,
-  session: SandboxEgressSession,
+  context: SandboxEgressRequesterContext,
 ): Promise<SandboxEgressCredentialLease> {
-  const cached = await getSandboxEgressCredentialLease(
-    egressId,
-    provider,
-    session,
-  );
+  const cached = await getSandboxEgressCredentialLease(provider, context);
   if (cached) {
     return cached;
   }
 
   const lease = await issueProviderCredentialLease({
     provider,
-    requesterId: session.requesterId,
+    requesterId: context.requesterId,
     reason: `sandbox-egress:${provider}`,
   });
   const headerTransforms = lease.headerTransforms ?? [];
@@ -314,7 +354,7 @@ async function credentialLease(
     expiresAt: lease.expiresAt,
     headerTransforms,
   };
-  await setSandboxEgressCredentialLease(egressId, session, cachedLease);
+  await setSandboxEgressCredentialLease(context, cachedLease);
   return cachedLease;
 }
 
@@ -336,7 +376,7 @@ export function isSandboxEgressForwardedRequest(request: Request): boolean {
   );
 }
 
-/** Proxy one Vercel Sandbox firewall egress request through Junior credential activation. */
+/** Proxy one Vercel Sandbox firewall egress request through lazy credential injection. */
 export async function proxySandboxEgressRequest(
   request: Request,
   deps: ProxyDeps = {},
@@ -371,7 +411,7 @@ export async function proxySandboxEgressRequest(
       {},
       {
         "http.request.method": request.method,
-        "url.path": new URL(request.url).pathname,
+        "url.path": redactedProxyPath(new URL(request.url).pathname),
       },
       "Sandbox egress OIDC payload did not include a VM session id",
     );
@@ -390,7 +430,7 @@ export async function proxySandboxEgressRequest(
         ...egressAttributes({
           egressId: activeEgressId,
           method: request.method,
-          path: new URL(request.url).pathname,
+          path: redactedProxyPath(new URL(request.url).pathname),
           status: 400,
         }),
         ...routingAttributes(request),
@@ -421,12 +461,15 @@ export async function proxySandboxEgressRequest(
     return jsonError("No provider owns forwarded host", 403);
   }
 
-  // Vercel OIDC authenticates the forwarded VM session; Junior's egress
-  // session authorizes credential activation for the current requester.
-  const session = await getSandboxEgressSession(activeEgressId);
-  if (!session) {
+  // Vercel OIDC authenticates the forwarded VM session; Junior's signed
+  // requester context identifies which user-backed credentials to issue lazily
+  // for that session.
+  const requesterContext = parseSandboxEgressRequesterToken(
+    requesterTokenFromRequest(request),
+  );
+  if (!requesterContext || requesterContext.egressId !== activeEgressId) {
     logWarn(
-      "sandbox_egress_session_unauthorized",
+      "sandbox_egress_requester_context_unauthorized",
       {},
       {
         ...egressAttributes({
@@ -439,14 +482,14 @@ export async function proxySandboxEgressRequest(
         }),
         ...routingAttributes(request, upstreamUrl),
       },
-      "Sandbox egress VM session is not authorized for requester credentials",
+      "Sandbox egress request did not include a valid requester context for the VM session",
     );
-    return jsonError("Sandbox egress session is not authorized", 403);
+    return jsonError("Sandbox egress requester context is not authorized", 403);
   }
 
   let lease: SandboxEgressCredentialLease;
   try {
-    lease = await credentialLease(activeEgressId, provider, session);
+    lease = await credentialLease(provider, requesterContext);
   } catch (error) {
     if (error instanceof CredentialUnavailableError) {
       logWarn(
@@ -551,7 +594,7 @@ export async function proxySandboxEgressRequest(
       },
       "Sandbox egress upstream auth rejected",
     );
-    await clearSandboxEgressCredentialLease(activeEgressId, provider, session);
+    await clearSandboxEgressCredentialLease(provider, requesterContext);
   }
 
   return new Response(upstream.body, {

--- a/packages/junior/src/chat/sandbox/egress-proxy.ts
+++ b/packages/junior/src/chat/sandbox/egress-proxy.ts
@@ -209,32 +209,14 @@ function normalizedForwardedPath(path: string): UpstreamPathResult {
   }
 }
 
-function upstreamPathFromProxyUrl(url: URL): string | undefined {
-  const prefix = `${SANDBOX_EGRESS_PROXY_PATH}/`;
-  if (!url.pathname.startsWith(prefix)) {
-    return undefined;
-  }
-  const remainder = url.pathname.slice(prefix.length);
-  const upstreamPathStart = remainder.indexOf("/");
-  if (upstreamPathStart === -1) {
-    return undefined;
-  }
-  return `${remainder.slice(upstreamPathStart)}${url.search}`;
-}
-
 function upstreamPath(request: Request): UpstreamPathResult {
   const forwardedPath = request.headers.get(FORWARDED_PATH_HEADER);
-  if (forwardedPath?.trim()) {
-    // Vercel may normalize request.url; this header carries the original target.
-    return normalizedForwardedPath(forwardedPath.trim());
+  if (!forwardedPath?.trim()) {
+    return { ok: false, error: "Missing forwarded path" };
   }
 
-  const url = new URL(request.url);
-  const proxyPath = upstreamPathFromProxyUrl(url);
-  if (proxyPath) {
-    return normalizedForwardedPath(proxyPath);
-  }
-  return { ok: true, path: `${url.pathname}${url.search}` };
+  // Vercel may normalize request.url; this header carries the original target.
+  return normalizedForwardedPath(forwardedPath.trim());
 }
 
 function buildUpstreamUrl(request: Request): UpstreamUrlResult {

--- a/packages/junior/src/chat/sandbox/egress-session.ts
+++ b/packages/junior/src/chat/sandbox/egress-session.ts
@@ -1,15 +1,19 @@
-import { randomUUID } from "node:crypto";
+import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
+import { getSlackSigningSecret } from "@/chat/config";
 import type { CredentialHeaderTransform } from "@/chat/credentials/broker";
 import { getStateAdapter } from "@/chat/state/adapter";
 
-const SANDBOX_EGRESS_SESSION_PREFIX = "sandbox-egress-session";
+export const SANDBOX_EGRESS_PROXY_PATH = "/api/internal/sandbox-egress";
+
+const SANDBOX_EGRESS_TOKEN_VERSION = "v1";
 const SANDBOX_EGRESS_LEASE_PREFIX = "sandbox-egress-lease";
 const DEFAULT_SESSION_TTL_MS = 30 * 60 * 1000;
 
-export interface SandboxEgressSession {
+export interface SandboxEgressRequesterContext {
   requesterId: string;
+  egressId: string;
   expiresAtMs: number;
-  activationId: string;
+  contextId: string;
 }
 
 export interface SandboxEgressCredentialLease {
@@ -18,29 +22,70 @@ export interface SandboxEgressCredentialLease {
   headerTransforms: CredentialHeaderTransform[];
 }
 
-function sessionKey(egressId: string): string {
-  return `${SANDBOX_EGRESS_SESSION_PREFIX}:${egressId}`;
-}
-
 function leaseKey(
-  egressId: string,
   provider: string,
-  session: SandboxEgressSession,
+  context: SandboxEgressRequesterContext,
 ): string {
-  return `${SANDBOX_EGRESS_LEASE_PREFIX}:${egressId}:${provider}:${session.requesterId}:${session.activationId}`;
+  return `${SANDBOX_EGRESS_LEASE_PREFIX}:${provider}:${context.requesterId}:${context.egressId}:${context.contextId}`;
 }
 
-function parseSession(value: unknown): SandboxEgressSession | undefined {
+function getSandboxEgressSecret(): string {
+  const explicit = process.env.JUNIOR_SANDBOX_EGRESS_SECRET?.trim();
+  if (explicit) {
+    return explicit;
+  }
+  const sharedInternal = process.env.JUNIOR_INTERNAL_RESUME_SECRET?.trim();
+  if (sharedInternal) {
+    return sharedInternal;
+  }
+  const slackSigningSecret = getSlackSigningSecret();
+  if (slackSigningSecret) {
+    return slackSigningSecret;
+  }
+  throw new Error(
+    "Cannot determine sandbox egress secret (set JUNIOR_SANDBOX_EGRESS_SECRET, JUNIOR_INTERNAL_RESUME_SECRET, or SLACK_SIGNING_SECRET)",
+  );
+}
+
+function base64Url(input: string): string {
+  return Buffer.from(input, "utf8").toString("base64url");
+}
+
+function fromBase64Url(input: string): string {
+  return Buffer.from(input, "base64url").toString("utf8");
+}
+
+function signPayload(payload: string): string {
+  return createHmac("sha256", getSandboxEgressSecret())
+    .update(payload)
+    .digest("base64url");
+}
+
+function timingSafeMatch(expected: string, actual: string): boolean {
+  const expectedBuffer = Buffer.from(expected);
+  const actualBuffer = Buffer.from(actual);
+  if (expectedBuffer.length !== actualBuffer.length) {
+    return false;
+  }
+  return timingSafeEqual(expectedBuffer, actualBuffer);
+}
+
+function parseRequesterContext(
+  value: unknown,
+): SandboxEgressRequesterContext | undefined {
   if (!value || typeof value !== "object") {
     return undefined;
   }
-  const record = value as Partial<SandboxEgressSession>;
+  const record = value as Partial<SandboxEgressRequesterContext>;
   if (
     typeof record.requesterId !== "string" ||
+    !record.requesterId ||
+    typeof record.egressId !== "string" ||
+    !record.egressId ||
     typeof record.expiresAtMs !== "number" ||
     !Number.isFinite(record.expiresAtMs) ||
-    typeof record.activationId !== "string" ||
-    !record.activationId
+    typeof record.contextId !== "string" ||
+    !record.contextId
   ) {
     return undefined;
   }
@@ -49,8 +94,9 @@ function parseSession(value: unknown): SandboxEgressSession | undefined {
   }
   return {
     requesterId: record.requesterId,
+    egressId: record.egressId,
     expiresAtMs: record.expiresAtMs,
-    activationId: record.activationId,
+    contextId: record.contextId,
   };
 }
 
@@ -89,46 +135,56 @@ function parseLease(value: unknown): SandboxEgressCredentialLease | undefined {
   };
 }
 
-/** Persist requester authorization for credential activation by one forwarded VM session. */
-export async function upsertSandboxEgressSession(input: {
-  egressId: string;
+/** Create a signed requester/sandbox context token for lazy sandbox egress auth. */
+export function createSandboxEgressRequesterToken(input: {
   requesterId: string;
+  egressId: string;
   ttlMs?: number;
-}): Promise<void> {
-  const state = getStateAdapter();
-  await state.connect();
+}): string {
   const ttlMs = Math.max(1, input.ttlMs ?? DEFAULT_SESSION_TTL_MS);
   const now = Date.now();
-  const session: SandboxEgressSession = {
+  const context: SandboxEgressRequesterContext = {
     requesterId: input.requesterId,
+    egressId: input.egressId,
     expiresAtMs: now + ttlMs,
-    activationId: randomUUID(),
+    contextId: randomUUID(),
   };
-  await state.set(sessionKey(input.egressId), session, ttlMs);
+  const payload = `${SANDBOX_EGRESS_TOKEN_VERSION}.${base64Url(
+    JSON.stringify(context),
+  )}`;
+  return `${payload}.${signPayload(payload)}`;
 }
 
-/** Clear the active requester-bound authorization context for a forwarded VM session. */
-export async function clearSandboxEgressSession(
-  egressId: string,
-): Promise<void> {
-  const state = getStateAdapter();
-  await state.connect();
-  await state.delete(sessionKey(egressId));
+/** Verify a signed requester/sandbox context token from the proxy URL. */
+export function parseSandboxEgressRequesterToken(
+  token: string | undefined,
+): SandboxEgressRequesterContext | undefined {
+  if (!token) {
+    return undefined;
+  }
+  const parts = token.split(".");
+  if (parts.length !== 3 || parts[0] !== SANDBOX_EGRESS_TOKEN_VERSION) {
+    return undefined;
+  }
+  const encodedSession = parts[1];
+  const signature = parts[2];
+  if (!encodedSession || !signature) {
+    return undefined;
+  }
+  const payload = `${parts[0]}.${encodedSession}`;
+  if (!timingSafeMatch(signPayload(payload), signature)) {
+    return undefined;
+  }
+  try {
+    return parseRequesterContext(JSON.parse(fromBase64Url(encodedSession)));
+  } catch {
+    return undefined;
+  }
 }
 
-/** Load the active egress authorization session for a forwarded VM session. */
-export async function getSandboxEgressSession(
-  egressId: string,
-): Promise<SandboxEgressSession | undefined> {
-  const state = getStateAdapter();
-  await state.connect();
-  return parseSession(await state.get(sessionKey(egressId)));
-}
-
-/** Cache a short-lived credential lease for repeated requests from one forwarded VM session. */
+/** Cache a short-lived credential lease for repeated forwarded requests for one requester/sandbox context. */
 export async function setSandboxEgressCredentialLease(
-  egressId: string,
-  session: SandboxEgressSession,
+  context: SandboxEgressRequesterContext,
   lease: SandboxEgressCredentialLease,
 ): Promise<void> {
   const leaseExpiresAtMs = Date.parse(lease.expiresAt);
@@ -137,31 +193,29 @@ export async function setSandboxEgressCredentialLease(
   }
   const ttlMs = Math.max(
     1,
-    Math.min(leaseExpiresAtMs, session.expiresAtMs) - Date.now(),
+    Math.min(leaseExpiresAtMs, context.expiresAtMs) - Date.now(),
   );
   const state = getStateAdapter();
   await state.connect();
-  await state.set(leaseKey(egressId, lease.provider, session), lease, ttlMs);
+  await state.set(leaseKey(lease.provider, context), lease, ttlMs);
 }
 
-/** Load a cached egress credential lease for a forwarded session/provider pair. */
+/** Load a cached egress credential lease for a requester/sandbox context/provider pair. */
 export async function getSandboxEgressCredentialLease(
-  egressId: string,
   provider: string,
-  session: SandboxEgressSession,
+  context: SandboxEgressRequesterContext,
 ): Promise<SandboxEgressCredentialLease | undefined> {
   const state = getStateAdapter();
   await state.connect();
-  return parseLease(await state.get(leaseKey(egressId, provider, session)));
+  return parseLease(await state.get(leaseKey(provider, context)));
 }
 
 /** Clear a cached egress credential lease after the provider rejects its headers. */
 export async function clearSandboxEgressCredentialLease(
-  egressId: string,
   provider: string,
-  session: SandboxEgressSession,
+  context: SandboxEgressRequesterContext,
 ): Promise<void> {
   const state = getStateAdapter();
   await state.connect();
-  await state.delete(leaseKey(egressId, provider, session));
+  await state.delete(leaseKey(provider, context));
 }

--- a/packages/junior/src/chat/sandbox/egress-session.ts
+++ b/packages/junior/src/chat/sandbox/egress-session.ts
@@ -1,5 +1,4 @@
 import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
-import { getSlackSigningSecret } from "@/chat/config";
 import type { CredentialHeaderTransform } from "@/chat/credentials/broker";
 import { getStateAdapter } from "@/chat/state/adapter";
 
@@ -38,12 +37,8 @@ function getSandboxEgressSecret(): string {
   if (sharedInternal) {
     return sharedInternal;
   }
-  const slackSigningSecret = getSlackSigningSecret();
-  if (slackSigningSecret) {
-    return slackSigningSecret;
-  }
   throw new Error(
-    "Cannot determine sandbox egress secret (set JUNIOR_SANDBOX_EGRESS_SECRET, JUNIOR_INTERNAL_RESUME_SECRET, or SLACK_SIGNING_SECRET)",
+    "Cannot determine sandbox egress secret (set JUNIOR_SANDBOX_EGRESS_SECRET or JUNIOR_INTERNAL_RESUME_SECRET)",
   );
 }
 

--- a/packages/junior/src/chat/sandbox/sandbox.ts
+++ b/packages/junior/src/chat/sandbox/sandbox.ts
@@ -10,10 +10,7 @@ import {
   buildSandboxEgressNetworkPolicy,
   resolveSandboxCommandEnvironment,
 } from "@/chat/sandbox/egress-policy";
-import {
-  clearSandboxEgressSession,
-  upsertSandboxEgressSession,
-} from "@/chat/sandbox/egress-session";
+import { createSandboxEgressRequesterToken } from "@/chat/sandbox/egress-session";
 import { throwSandboxOperationError } from "@/chat/sandbox/errors";
 import { SANDBOX_WORKSPACE_ROOT } from "@/chat/sandbox/paths";
 import { createSandboxSessionManager } from "@/chat/sandbox/session";
@@ -120,20 +117,34 @@ export function createSandboxExecutor(options?: {
   let referenceFiles: string[] = [];
   const traceContext = options?.traceContext ?? {};
   const credentialEgress = options?.credentialEgress;
-  const authorizeSandboxEgressForCommand = credentialEgress
-    ? async (egressId: string): Promise<void> => {
-        await upsertSandboxEgressSession({
-          egressId,
-          requesterId: credentialEgress.requesterId,
-          ttlMs: options?.timeoutMs,
-        });
-      }
-    : undefined;
-  const clearSandboxEgressForCommand = credentialEgress
-    ? async (egressId: string): Promise<void> => {
-        await clearSandboxEgressSession(egressId);
-      }
-    : undefined;
+  const sandboxEgressTokenTtlMs = Math.max(
+    1,
+    options?.timeoutMs ?? 1000 * 60 * 30,
+  );
+  const sandboxEgressRequesterTokens = new Map<
+    string,
+    { expiresAtMs: number; token: string }
+  >();
+  const sandboxEgressRequesterTokenFor = (egressId: string): string => {
+    const cached = sandboxEgressRequesterTokens.get(egressId);
+    if (cached && cached.expiresAtMs > Date.now()) {
+      return cached.token;
+    }
+    if (!credentialEgress) {
+      throw new Error("Sandbox credential egress is not configured");
+    }
+    const now = Date.now();
+    const token = createSandboxEgressRequesterToken({
+      requesterId: credentialEgress.requesterId,
+      egressId,
+      ttlMs: sandboxEgressTokenTtlMs,
+    });
+    sandboxEgressRequesterTokens.set(egressId, {
+      expiresAtMs: now + sandboxEgressTokenTtlMs,
+      token,
+    });
+    return token;
+  };
   const sessionManager = createSandboxSessionManager({
     sandboxId: options?.sandboxId,
     sandboxDependencyProfileHash: options?.sandboxDependencyProfileHash,
@@ -143,10 +154,11 @@ export function createSandboxExecutor(options?: {
       ? async () => await resolveSandboxCommandEnvironment()
       : undefined,
     createNetworkPolicy: credentialEgress
-      ? buildSandboxEgressNetworkPolicy
+      ? (egressId) =>
+          buildSandboxEgressNetworkPolicy({
+            requesterToken: sandboxEgressRequesterTokenFor(egressId),
+          })
       : undefined,
-    beforeCommand: authorizeSandboxEgressForCommand,
-    afterCommand: clearSandboxEgressForCommand,
     onSandboxAcquired: async (sandbox) => {
       await options?.onSandboxAcquired?.(sandbox);
     },

--- a/packages/junior/src/chat/sandbox/session.ts
+++ b/packages/junior/src/chat/sandbox/session.ts
@@ -1,12 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { Sandbox, type NetworkPolicy } from "@vercel/sandbox";
 import { createBashTool } from "bash-tool";
-import {
-  logWarn,
-  setSpanAttributes,
-  withSpan,
-  type LogContext,
-} from "@/chat/logging";
+import { setSpanAttributes, withSpan, type LogContext } from "@/chat/logging";
 import { getVercelSandboxCredentials } from "@/chat/sandbox/credentials";
 import {
   isAlreadyExistsError,
@@ -165,8 +160,6 @@ export function createSandboxSessionManager(options?: {
   traceContext?: LogContext;
   commandEnv?: () => Promise<Record<string, string>>;
   createNetworkPolicy?: (egressId: string) => NetworkPolicy | undefined;
-  beforeCommand?: (egressId: string) => void | Promise<void>;
-  afterCommand?: (egressId: string) => void | Promise<void>;
   onSandboxAcquired?: (sandbox: {
     sandboxId: string;
     sandboxDependencyProfileHash?: string;
@@ -631,7 +624,6 @@ export function createSandboxSessionManager(options?: {
   const buildToolExecutors = async (
     sandboxInstance: SandboxInstance,
   ): Promise<SandboxToolExecutors> => {
-    const activeSandboxId = sandboxInstance.sandboxId;
     const toolkit = await withSandboxSpan(
       "sandbox.bash_tool.init",
       "sandbox.tool.init",
@@ -654,38 +646,9 @@ export function createSandboxSessionManager(options?: {
 
     return {
       bash: async (input) => {
-        const commandEgressId = sandboxInstance.sandboxEgressId;
         let timedOut = false;
         let timeoutId: ReturnType<typeof setTimeout> | undefined;
-        let commandFinished = false;
-        const finishCommand = async (): Promise<void> => {
-          if (commandFinished) {
-            return;
-          }
-          commandFinished = true;
-          await options?.afterCommand?.(commandEgressId);
-          await refreshNetworkPolicy(sandboxInstance);
-        };
-        const finishCommandBestEffort = async (): Promise<void> => {
-          try {
-            await finishCommand();
-          } catch (error) {
-            logWarn(
-              "sandbox_command_cleanup_failed",
-              traceContext,
-              {
-                "app.sandbox.id": activeSandboxId,
-                "error.type":
-                  error instanceof Error
-                    ? error.name
-                    : "sandbox_command_cleanup_error",
-              },
-              "Sandbox command cleanup failed",
-            );
-          }
-        };
         try {
-          await options?.beforeCommand?.(commandEgressId);
           await refreshNetworkPolicy(sandboxInstance);
           const sandboxCommandEnv = await resolveCommandEnv();
           const script = buildNonInteractiveShellScript(input.command, {
@@ -712,7 +675,6 @@ export function createSandboxSessionManager(options?: {
             cwd: SANDBOX_WORKSPACE_ROOT,
             ...(controller ? { signal: controller.signal } : {}),
           });
-          await finishCommandBestEffort();
           return await readCommandOutput(commandResult);
         } catch (error) {
           if (timedOut) {
@@ -733,7 +695,6 @@ export function createSandboxSessionManager(options?: {
           if (timeoutId) {
             clearTimeout(timeoutId);
           }
-          await finishCommandBestEffort();
         }
       },
       readFile: async (input) =>

--- a/packages/junior/tests/fixtures/plugins/sandbox-egress/plugin.yaml
+++ b/packages/junior/tests/fixtures/plugins/sandbox-egress/plugin.yaml
@@ -1,0 +1,16 @@
+name: sandbox-egress-test
+description: Integration fixture for sandbox egress credential proxying
+
+capabilities:
+  - sandbox-egress-test.api
+
+credentials:
+  type: oauth-bearer
+  domains:
+    - sandbox-egress.example.test
+    - git.sandbox-egress.example.test
+  auth-token-env: SANDBOX_EGRESS_TEST_TOKEN
+  auth-token-placeholder: host_managed_credential
+
+command-env:
+  SANDBOX_EGRESS_TEST_READ_ONLY: "1"

--- a/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
@@ -62,6 +62,7 @@ function proxiedRequest(input: {
   return new Request(url, {
     headers: {
       "vercel-forwarded-host": PROVIDER_HOST,
+      "vercel-forwarded-path": upstreamPath,
       "vercel-forwarded-scheme": "https",
       "vercel-sandbox-oidc-token": "signed-vercel-token",
       ...(input.headers ?? {}),

--- a/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
@@ -1,0 +1,162 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ORIGINAL_ENV = { ...process.env };
+const FIXTURE_PLUGIN_ROOT = path.resolve(
+  import.meta.dirname,
+  "../fixtures/plugins/sandbox-egress",
+);
+const BASE_URL = "https://junior.example.com";
+const EGRESS_ID = "sbx_integration_session";
+const REQUESTER_ID = "U123";
+const PROVIDER_HOST = "sandbox-egress.example.test";
+
+type EgressPolicyModule = typeof import("@/chat/sandbox/egress-policy");
+type EgressProxyModule = typeof import("@/chat/sandbox/egress-proxy");
+type EgressSessionModule = typeof import("@/chat/sandbox/egress-session");
+type StateAdapterModule = typeof import("@/chat/state/adapter");
+
+interface LoadedModules {
+  policy: EgressPolicyModule;
+  proxy: EgressProxyModule;
+  session: EgressSessionModule;
+  state: StateAdapterModule;
+}
+
+async function loadModules(): Promise<LoadedModules> {
+  vi.resetModules();
+  const [policy, proxy, session, state] = await Promise.all([
+    import("@/chat/sandbox/egress-policy"),
+    import("@/chat/sandbox/egress-proxy"),
+    import("@/chat/sandbox/egress-session"),
+    import("@/chat/state/adapter"),
+  ]);
+  await state.disconnectStateAdapter();
+  await state.getStateAdapter().connect();
+  return { policy, proxy, session, state };
+}
+
+function forwardUrlFor(policy: unknown, host: string): string {
+  const allow = (
+    policy as { allow?: Record<string, Array<{ forwardURL?: string }>> }
+  ).allow;
+  const forwardURL = allow?.[host]?.[0]?.forwardURL;
+  if (!forwardURL) {
+    throw new Error(`Missing forwardURL for ${host}`);
+  }
+  return forwardURL;
+}
+
+function proxiedRequest(input: {
+  forwardURL: string;
+  headers?: Record<string, string>;
+  upstreamPath?: string;
+}): Request {
+  const url = new URL(input.forwardURL);
+  const upstreamPath = input.upstreamPath ?? "/v1/repos?query=first";
+  url.pathname = `${url.pathname}${upstreamPath.split("?")[0]}`;
+  url.search = upstreamPath.includes("?")
+    ? `?${upstreamPath.split("?").slice(1).join("?")}`
+    : "";
+
+  return new Request(url, {
+    headers: {
+      "vercel-forwarded-host": PROVIDER_HOST,
+      "vercel-forwarded-scheme": "https",
+      "vercel-sandbox-oidc-token": "signed-vercel-token",
+      ...(input.headers ?? {}),
+    },
+  });
+}
+
+describe("sandbox egress proxy integration", () => {
+  let modules: LoadedModules;
+
+  beforeEach(async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      EVAL_ENABLE_TEST_CREDENTIALS: "1",
+      EVAL_TEST_CREDENTIAL_TOKEN: "integration-egress-token",
+      JUNIOR_BASE_URL: BASE_URL,
+      JUNIOR_EXTRA_PLUGIN_ROOTS: JSON.stringify([FIXTURE_PLUGIN_ROOT]),
+      JUNIOR_SANDBOX_EGRESS_SECRET: "integration-egress-secret",
+      JUNIOR_STATE_ADAPTER: "memory",
+    };
+    modules = await loadModules();
+  });
+
+  afterEach(async () => {
+    await modules.state.disconnectStateAdapter();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it("injects provider credentials through real plugin and broker wiring without command session state", async () => {
+    const requesterToken = modules.session.createSandboxEgressRequesterToken({
+      requesterId: REQUESTER_ID,
+      egressId: EGRESS_ID,
+      ttlMs: 60_000,
+    });
+    const networkPolicy = modules.policy.buildSandboxEgressNetworkPolicy({
+      requesterToken,
+    });
+    const forwardURL = forwardUrlFor(networkPolicy, PROVIDER_HOST);
+
+    expect(forwardURL).toBe(
+      `${BASE_URL}/api/internal/sandbox-egress/${requesterToken}`,
+    );
+
+    const upstreamFetch = vi.fn(
+      async (url: URL | string, init?: RequestInit) => {
+        const headers = new Headers(init?.headers);
+        expect(String(url)).toBe(
+          "https://sandbox-egress.example.test/v1/repos?query=first",
+        );
+        expect(headers.get("authorization")).toBe(
+          "Bearer integration-egress-token",
+        );
+        expect(headers.get("vercel-sandbox-oidc-token")).toBeNull();
+        return new Response("ok", { status: 200 });
+      },
+    );
+
+    const response = await modules.proxy.proxySandboxEgressRequest(
+      proxiedRequest({ forwardURL }),
+      {
+        fetch: upstreamFetch as typeof fetch,
+        verifyOidc: async () => ({ sandbox_id: EGRESS_ID }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("ok");
+    expect(upstreamFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects signed requester contexts that do not match the verified sandbox session", async () => {
+    const requesterToken = modules.session.createSandboxEgressRequesterToken({
+      requesterId: REQUESTER_ID,
+      egressId: "different-session",
+      ttlMs: 60_000,
+    });
+    const networkPolicy = modules.policy.buildSandboxEgressNetworkPolicy({
+      requesterToken,
+    });
+    const upstreamFetch = vi.fn(async () => new Response("should not happen"));
+
+    const response = await modules.proxy.proxySandboxEgressRequest(
+      proxiedRequest({
+        forwardURL: forwardUrlFor(networkPolicy, PROVIDER_HOST),
+      }),
+      {
+        fetch: upstreamFetch as typeof fetch,
+        verifyOidc: async () => ({ sandbox_id: EGRESS_ID }),
+      },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "Sandbox egress requester context is not authorized",
+    });
+    expect(upstreamFetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
@@ -131,32 +131,4 @@ describe("sandbox egress proxy integration", () => {
     await expect(response.text()).resolves.toBe("ok");
     expect(upstreamFetch).toHaveBeenCalledTimes(1);
   });
-
-  it("rejects signed requester contexts that do not match the verified sandbox session", async () => {
-    const requesterToken = modules.session.createSandboxEgressRequesterToken({
-      requesterId: REQUESTER_ID,
-      egressId: "different-session",
-      ttlMs: 60_000,
-    });
-    const networkPolicy = modules.policy.buildSandboxEgressNetworkPolicy({
-      requesterToken,
-    });
-    const upstreamFetch = vi.fn(async () => new Response("should not happen"));
-
-    const response = await modules.proxy.proxySandboxEgressRequest(
-      proxiedRequest({
-        forwardURL: forwardUrlFor(networkPolicy, PROVIDER_HOST),
-      }),
-      {
-        fetch: upstreamFetch as typeof fetch,
-        verifyOidc: async () => ({ sandbox_id: EGRESS_ID }),
-      },
-    );
-
-    expect(response.status).toBe(403);
-    await expect(response.json()).resolves.toEqual({
-      error: "Sandbox egress requester context is not authorized",
-    });
-    expect(upstreamFetch).not.toHaveBeenCalled();
-  });
 });

--- a/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
@@ -354,37 +354,6 @@ describe("sandbox egress proxy", () => {
     expect(issueProviderCredentialLeaseMock).toHaveBeenCalledTimes(1);
   });
 
-  it("forwards root-path sandbox proxy requests using the verified OIDC session", async () => {
-    setSandboxEgressRequester();
-    mockSentryLease();
-
-    const fetchMock = vi.fn(async (url: URL | string, init?: RequestInit) => {
-      expect(String(url)).toBe(
-        "https://sentry.io/api/0/issues/?query=forwarded",
-      );
-      expect(new Headers(init?.headers).get("authorization")).toBe(
-        "Bearer sentry-token",
-      );
-      return new Response("ok", { status: 200 });
-    });
-
-    const response = await proxySandboxEgressRequest(
-      egressRequest({ path: "/api/0/issues/?query=forwarded" }),
-      {
-        fetch: fetchMock as typeof fetch,
-        verifyOidc: async () => ({ sandbox_id: EGRESS_ID }),
-      },
-    );
-
-    expect(response.status).toBe(200);
-    await expect(response.text()).resolves.toBe("ok");
-    expect(issueProviderCredentialLeaseMock).toHaveBeenCalledWith({
-      provider: "sentry",
-      requesterId: REQUESTER_ID,
-      reason: "sandbox-egress:sentry",
-    });
-  });
-
   it("prefers Vercel forwarded path over the normalized proxy URL path", async () => {
     setSandboxEgressRequester();
     mockSentryLease();

--- a/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
@@ -161,7 +161,7 @@ function egressRequest(
         ? {}
         : { "vercel-forwarded-scheme": input.scheme ?? "https" }),
       "vercel-sandbox-oidc-token": "signed-token",
-      ...(activeRequesterToken && forwardedPath !== null
+      ...(forwardedPath !== null
         ? { "vercel-forwarded-path": forwardedPath }
         : {}),
       ...(input.port ? { "vercel-forwarded-port": input.port } : {}),
@@ -401,30 +401,24 @@ describe("sandbox egress proxy", () => {
     expect(issueProviderCredentialLeaseMock).toHaveBeenCalledTimes(1);
   });
 
-  it("falls back to the token-prefixed proxy URL path when Vercel omits forwarded path", async () => {
+  it("rejects sandbox egress requests without a forwarded path", async () => {
     setSandboxEgressRequester();
-    mockSentryLease();
 
-    const fetchMock = vi.fn(async (url: URL | string, init?: RequestInit) => {
-      expect(String(url)).toBe("https://sentry.io/api/0/issues/?query=proxy");
-      expect(
-        new Headers(init?.headers).get("vercel-forwarded-path"),
-      ).toBeNull();
-      return new Response("ok", { status: 200 });
-    });
-
+    const fetchMock = vi.fn();
     const response = await proxy(
       egressRequest({
         forwardedPath: null,
-        proxyPath: `${SANDBOX_EGRESS_PROXY_PATH}/${activeRequesterToken}/api/0/issues/?query=proxy`,
+        proxyPath: `${SANDBOX_EGRESS_PROXY_PATH}/${activeRequesterToken}`,
       }),
       fetchMock as typeof fetch,
     );
 
-    expect(response.status).toBe(200);
-    await expect(response.text()).resolves.toBe("ok");
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(issueProviderCredentialLeaseMock).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Missing forwarded path",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(issueProviderCredentialLeaseMock).not.toHaveBeenCalled();
   });
 
   it("recognizes root-path forwarded sandbox proxy requests", () => {

--- a/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
@@ -257,6 +257,22 @@ describe("sandbox egress proxy", () => {
     );
   });
 
+  it("does not reuse Slack signing secret for sandbox egress tokens", () => {
+    delete process.env.JUNIOR_SANDBOX_EGRESS_SECRET;
+    delete process.env.JUNIOR_INTERNAL_RESUME_SECRET;
+    process.env.SLACK_SIGNING_SECRET = "test-slack-signing-secret";
+
+    expect(() =>
+      createSandboxEgressRequesterToken({
+        requesterId: REQUESTER_ID,
+        egressId: EGRESS_ID,
+        ttlMs: 60_000,
+      }),
+    ).toThrow(
+      "Cannot determine sandbox egress secret (set JUNIOR_SANDBOX_EGRESS_SECRET or JUNIOR_INTERNAL_RESUME_SECRET)",
+    );
+  });
+
   it("resolves command env for registered sandbox providers", async () => {
     await expect(resolveSandboxCommandEnvironment()).resolves.toEqual({
       SENTRY_READ_ONLY: "1",

--- a/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
@@ -51,13 +51,18 @@ import {
   isSandboxEgressForwardedRequest,
   proxySandboxEgressRequest,
 } from "@/chat/sandbox/egress-proxy";
-import { upsertSandboxEgressSession } from "@/chat/sandbox/egress-session";
+import {
+  createSandboxEgressRequesterToken,
+  SANDBOX_EGRESS_PROXY_PATH,
+} from "@/chat/sandbox/egress-session";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
 import { CredentialUnavailableError } from "@/chat/credentials/broker";
 import { ALL } from "@/handlers/sandbox-egress-proxy";
 
 const EGRESS_ID = "junior-sbx";
 const REQUESTER_ID = "U123";
+
+let activeRequesterToken: string | undefined;
 
 function sentryPlugin() {
   return {
@@ -104,12 +109,10 @@ function githubPlugin() {
   };
 }
 
-async function authorizeSandboxEgress(
-  requesterId = REQUESTER_ID,
-): Promise<void> {
-  await upsertSandboxEgressSession({
-    egressId: EGRESS_ID,
+function setSandboxEgressRequester(requesterId = REQUESTER_ID): void {
+  activeRequesterToken = createSandboxEgressRequesterToken({
     requesterId,
+    egressId: EGRESS_ID,
     ttlMs: 60_000,
   });
 }
@@ -134,28 +137,38 @@ function egressRequest(
     host?: string;
     method?: string;
     path?: string;
+    proxyPath?: string;
+    forwardedPath?: string | null;
     scheme?: string | null;
     port?: string;
     body?: BodyInit;
     headers?: Record<string, string>;
   } = {},
 ): Request {
-  return new Request(
-    `https://junior.example.com${input.path ?? "/api/0/issues/"}`,
-    {
-      method: input.method ?? "GET",
-      headers: {
-        "vercel-forwarded-host": input.host ?? "sentry.io",
-        ...(input.scheme === null
-          ? {}
-          : { "vercel-forwarded-scheme": input.scheme ?? "https" }),
-        "vercel-sandbox-oidc-token": "signed-token",
-        ...(input.port ? { "vercel-forwarded-port": input.port } : {}),
-        ...(input.headers ?? {}),
-      },
-      ...(input.body === undefined ? {} : { body: input.body }),
+  const upstreamPath = input.path ?? "/api/0/issues/";
+  const proxyPath =
+    input.proxyPath ??
+    (activeRequesterToken
+      ? `${SANDBOX_EGRESS_PROXY_PATH}/${activeRequesterToken}`
+      : upstreamPath);
+  const forwardedPath =
+    input.forwardedPath === undefined ? upstreamPath : input.forwardedPath;
+  return new Request(`https://junior.example.com${proxyPath}`, {
+    method: input.method ?? "GET",
+    headers: {
+      "vercel-forwarded-host": input.host ?? "sentry.io",
+      ...(input.scheme === null
+        ? {}
+        : { "vercel-forwarded-scheme": input.scheme ?? "https" }),
+      "vercel-sandbox-oidc-token": "signed-token",
+      ...(activeRequesterToken && forwardedPath !== null
+        ? { "vercel-forwarded-path": forwardedPath }
+        : {}),
+      ...(input.port ? { "vercel-forwarded-port": input.port } : {}),
+      ...(input.headers ?? {}),
     },
-  );
+    ...(input.body === undefined ? {} : { body: input.body }),
+  });
 }
 
 function proxy(
@@ -174,6 +187,8 @@ describe("sandbox egress proxy", () => {
   beforeEach(async () => {
     process.env.JUNIOR_STATE_ADAPTER = "memory";
     process.env.JUNIOR_BASE_URL = "https://junior.example.com";
+    process.env.JUNIOR_SANDBOX_EGRESS_SECRET = "test-egress-secret";
+    activeRequesterToken = undefined;
     getPluginProvidersMock.mockReturnValue([sentryPlugin()]);
     createRemoteJWKSetMock.mockClear();
     createRemoteJWKSetMock.mockReturnValue(async () => null);
@@ -187,6 +202,7 @@ describe("sandbox egress proxy", () => {
     await disconnectStateAdapter();
     delete process.env.JUNIOR_STATE_ADAPTER;
     delete process.env.JUNIOR_BASE_URL;
+    delete process.env.JUNIOR_SANDBOX_EGRESS_SECRET;
     delete process.env.SENTRY_BOT_EMAIL;
     vi.restoreAllMocks();
   });
@@ -199,12 +215,31 @@ describe("sandbox egress proxy", () => {
         "*": [],
         "sentry.io": [
           {
-            forwardURL: "https://junior.example.com/",
+            forwardURL:
+              "https://junior.example.com/api/internal/sandbox-egress",
           },
         ],
         "us.sentry.io": [
           {
-            forwardURL: "https://junior.example.com/",
+            forwardURL:
+              "https://junior.example.com/api/internal/sandbox-egress",
+          },
+        ],
+      },
+    });
+
+    const token = createSandboxEgressRequesterToken({
+      requesterId: REQUESTER_ID,
+      egressId: EGRESS_ID,
+      ttlMs: 60_000,
+    });
+    expect(
+      buildSandboxEgressNetworkPolicy({ requesterToken: token }),
+    ).toMatchObject({
+      allow: {
+        "sentry.io": [
+          {
+            forwardURL: `https://junior.example.com/api/internal/sandbox-egress/${token}`,
           },
         ],
       },
@@ -213,6 +248,7 @@ describe("sandbox egress proxy", () => {
 
   it("fails sandbox egress policy setup without a public callback URL", () => {
     delete process.env.JUNIOR_BASE_URL;
+    delete process.env.JUNIOR_SANDBOX_EGRESS_SECRET;
     delete process.env.VERCEL_PROJECT_PRODUCTION_URL;
     delete process.env.VERCEL_URL;
 
@@ -261,7 +297,7 @@ describe("sandbox egress proxy", () => {
   });
 
   it("forwards repeated authorized sandbox requests with credential headers", async () => {
-    await authorizeSandboxEgress();
+    setSandboxEgressRequester();
     mockSentryLease();
 
     const fetchMock = vi.fn(async (url: URL | string, init?: RequestInit) => {
@@ -319,7 +355,7 @@ describe("sandbox egress proxy", () => {
   });
 
   it("forwards root-path sandbox proxy requests using the verified OIDC session", async () => {
-    await authorizeSandboxEgress();
+    setSandboxEgressRequester();
     mockSentryLease();
 
     const fetchMock = vi.fn(async (url: URL | string, init?: RequestInit) => {
@@ -350,7 +386,7 @@ describe("sandbox egress proxy", () => {
   });
 
   it("prefers Vercel forwarded path over the normalized proxy URL path", async () => {
-    await authorizeSandboxEgress();
+    setSandboxEgressRequester();
     mockSentryLease();
 
     const fetchMock = vi.fn(async (url: URL | string, init?: RequestInit) => {
@@ -380,6 +416,32 @@ describe("sandbox egress proxy", () => {
     expect(issueProviderCredentialLeaseMock).toHaveBeenCalledTimes(1);
   });
 
+  it("falls back to the token-prefixed proxy URL path when Vercel omits forwarded path", async () => {
+    setSandboxEgressRequester();
+    mockSentryLease();
+
+    const fetchMock = vi.fn(async (url: URL | string, init?: RequestInit) => {
+      expect(String(url)).toBe("https://sentry.io/api/0/issues/?query=proxy");
+      expect(
+        new Headers(init?.headers).get("vercel-forwarded-path"),
+      ).toBeNull();
+      return new Response("ok", { status: 200 });
+    });
+
+    const response = await proxy(
+      egressRequest({
+        forwardedPath: null,
+        proxyPath: `${SANDBOX_EGRESS_PROXY_PATH}/${activeRequesterToken}/api/0/issues/?query=proxy`,
+      }),
+      fetchMock as typeof fetch,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("ok");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(issueProviderCredentialLeaseMock).toHaveBeenCalledTimes(1);
+  });
+
   it("recognizes root-path forwarded sandbox proxy requests", () => {
     expect(isSandboxEgressForwardedRequest(egressRequest())).toBe(true);
     expect(
@@ -395,7 +457,7 @@ describe("sandbox egress proxy", () => {
   });
 
   it("does not synthesize an empty body for bodyless methods", async () => {
-    await authorizeSandboxEgress();
+    setSandboxEgressRequester();
     mockSentryLease();
 
     const fetchMock = vi.fn(async (_url: URL | string, init?: RequestInit) => {
@@ -414,7 +476,7 @@ describe("sandbox egress proxy", () => {
   });
 
   it("scopes cached credential leases to the requester", async () => {
-    await authorizeSandboxEgress();
+    setSandboxEgressRequester();
     issueProviderCredentialLeaseMock
       .mockResolvedValueOnce({
         id: "lease-1",
@@ -451,7 +513,7 @@ describe("sandbox egress proxy", () => {
     );
     await expect(firstResponse.text()).resolves.toBe("Bearer token-u123");
 
-    await authorizeSandboxEgress("U456");
+    setSandboxEgressRequester("U456");
     const secondResponse = await proxy(
       egressRequest({
         path: "/api/0/issues/2",
@@ -473,8 +535,8 @@ describe("sandbox egress proxy", () => {
     });
   });
 
-  it("does not reuse cached credential leases across renewed egress sessions", async () => {
-    await authorizeSandboxEgress();
+  it("does not reuse cached credential leases across renewed requester contexts", async () => {
+    setSandboxEgressRequester();
     issueProviderCredentialLeaseMock
       .mockResolvedValueOnce({
         id: "lease-1",
@@ -513,7 +575,7 @@ describe("sandbox egress proxy", () => {
       "Bearer token-first-session",
     );
 
-    await authorizeSandboxEgress();
+    setSandboxEgressRequester();
     const secondResponse = await proxy(
       egressRequest({ path: "/api/0/issues/2" }),
       fetchMock as typeof fetch,
@@ -526,7 +588,7 @@ describe("sandbox egress proxy", () => {
   });
 
   it("clears cached credential leases after upstream auth rejection", async () => {
-    await authorizeSandboxEgress();
+    setSandboxEgressRequester();
     issueProviderCredentialLeaseMock
       .mockResolvedValueOnce({
         id: "lease-1",
@@ -577,7 +639,7 @@ describe("sandbox egress proxy", () => {
   });
 
   it("applies provider header transforms to matching upstream hosts", async () => {
-    await authorizeSandboxEgress();
+    setSandboxEgressRequester();
     mockSentryLease("us.sentry.io");
 
     const fetchMock = vi.fn(async (_url: URL | string, init?: RequestInit) => {
@@ -597,7 +659,7 @@ describe("sandbox egress proxy", () => {
   });
 
   it("does not apply subdomain transforms to the apex host", async () => {
-    await authorizeSandboxEgress();
+    setSandboxEgressRequester();
     mockSentryLease("us.sentry.io");
 
     const fetchMock = vi.fn();
@@ -612,7 +674,7 @@ describe("sandbox egress proxy", () => {
   });
 
   it("forwards upstream response headers to the sandbox", async () => {
-    await authorizeSandboxEgress();
+    setSandboxEgressRequester();
     mockSentryLease();
 
     const upstreamHeaders = new Headers();
@@ -632,7 +694,7 @@ describe("sandbox egress proxy", () => {
   });
 
   it("drops upstream encoding headers after host fetch decodes the body", async () => {
-    await authorizeSandboxEgress();
+    setSandboxEgressRequester();
     mockSentryLease();
 
     const response = await proxy(
@@ -754,7 +816,7 @@ describe("sandbox egress proxy", () => {
   });
 
   it("returns a command-readable auth marker when provider credentials are missing", async () => {
-    await authorizeSandboxEgress();
+    setSandboxEgressRequester();
     issueProviderCredentialLeaseMock.mockRejectedValue(
       new CredentialUnavailableError(
         "sentry",
@@ -770,7 +832,32 @@ describe("sandbox egress proxy", () => {
     );
   });
 
-  it("requires a requester-bound sandbox egress session", async () => {
+  it("requires a signed requester context", async () => {
+    mockSentryLease();
+
+    const response = await proxy(egressRequest());
+
+    expect(response.status).toBe(403);
+    expect(issueProviderCredentialLeaseMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects requester context tokens from a different sandbox session", async () => {
+    activeRequesterToken = createSandboxEgressRequesterToken({
+      requesterId: REQUESTER_ID,
+      egressId: "different-egress-session",
+      ttlMs: 60_000,
+    });
+    mockSentryLease();
+
+    const response = await proxy(egressRequest());
+
+    expect(response.status).toBe(403);
+    expect(issueProviderCredentialLeaseMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects tampered requester tokens", async () => {
+    setSandboxEgressRequester();
+    activeRequesterToken = `${activeRequesterToken ?? ""}tampered`;
     mockSentryLease();
 
     const response = await proxy(egressRequest());

--- a/packages/junior/tests/unit/misc/sandbox-executor.test.ts
+++ b/packages/junior/tests/unit/misc/sandbox-executor.test.ts
@@ -88,7 +88,10 @@ vi.mock("@/chat/sandbox/runtime-dependency-snapshots", () => ({
 }));
 
 import { createSandboxExecutor } from "@/chat/sandbox/sandbox";
-import { getSandboxEgressSession } from "@/chat/sandbox/egress-session";
+import {
+  parseSandboxEgressRequesterToken,
+  SANDBOX_EGRESS_PROXY_PATH,
+} from "@/chat/sandbox/egress-session";
 import { createSandboxSessionManager } from "@/chat/sandbox/session";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
 import { createBashTool } from "bash-tool";
@@ -149,6 +152,26 @@ function makeSandbox(
     snapshot: vi.fn(async () => ({ snapshotId: "snap_test" })),
     update: vi.fn(async () => {}),
   };
+}
+
+function sentryForwardURLFromPolicy(policy: unknown): string | undefined {
+  const allow = (
+    policy as { allow?: Record<string, Array<{ forwardURL?: string }>> }
+  ).allow;
+  return allow?.["sentry.io"]?.[0]?.forwardURL;
+}
+
+function requesterTokenFromForwardURL(
+  forwardURL: string | undefined,
+): string | undefined {
+  if (!forwardURL) {
+    return undefined;
+  }
+  const pathname = new URL(forwardURL).pathname;
+  const prefix = `${SANDBOX_EGRESS_PROXY_PATH}/`;
+  return pathname.startsWith(prefix)
+    ? pathname.slice(prefix.length)
+    : undefined;
 }
 
 function createApiError(
@@ -232,11 +255,13 @@ describe("createSandboxExecutor", () => {
     delete process.env.JUNIOR_EVAL_FAULT_SANDBOX_BASH_STREAM_INTERRUPTS;
     delete process.env.EVAL_ENABLE_TEST_CREDENTIALS;
     process.env.JUNIOR_BASE_URL = "https://junior.example.com";
+    process.env.JUNIOR_SANDBOX_EGRESS_SECRET = "test-egress-secret";
   });
 
   afterEach(async () => {
     await disconnectStateAdapter();
     delete process.env.JUNIOR_BASE_URL;
+    delete process.env.JUNIOR_SANDBOX_EGRESS_SECRET;
   });
 
   it("recreates a sandbox when sandboxId hint points to a stopped sandbox", async () => {
@@ -622,51 +647,19 @@ describe("createSandboxExecutor", () => {
     );
   });
 
-  it("runs sandbox command hooks around each bash command", async () => {
-    const sandbox = makeSandbox("sbx_command_hooks");
-    sandboxGetMock.mockResolvedValue(sandbox);
-    vi.mocked(createBashTool).mockResolvedValue({
-      tools: {
-        readFile: { execute: vi.fn(async () => ({ content: "" })) },
-        writeFile: { execute: vi.fn(async () => ({ success: true })) },
-      },
-    } as never);
-    const beforeCommand = vi.fn();
-    const afterCommand = vi.fn();
-
-    const manager = createSandboxSessionManager({
-      sandboxId: "sbx_command_hooks",
-      beforeCommand,
-      afterCommand,
-    });
-    const bash = (await manager.ensureToolExecutors()).bash;
-
-    sandbox.currentSession.mockReturnValue({
-      sessionId: "sbx_command_hooks_resumed_session",
-    });
-    await bash({ command: "echo ok" });
-
-    expect(beforeCommand).toHaveBeenCalledWith(
-      "sbx_command_hooks_resumed_session",
-    );
-    expect(afterCommand).toHaveBeenCalledWith(
-      "sbx_command_hooks_resumed_session",
-    );
-    expect(beforeCommand.mock.invocationCallOrder[0]).toBeLessThan(
-      sandbox.runCommand.mock.invocationCallOrder[0] as number,
-    );
-    expect(afterCommand.mock.invocationCallOrder[0]).toBeGreaterThan(
-      sandbox.runCommand.mock.invocationCallOrder[0] as number,
-    );
-  });
-
-  it("authorizes credential egress only while running bash commands", async () => {
+  it("configures lazy requester auth for sandbox egress", async () => {
     const sandbox = makeSandbox("sbx_authorize_credentials");
     sandbox.runCommand.mockImplementationOnce(async () => {
-      await expect(
-        getSandboxEgressSession("sbx_authorize_credentials_session"),
-      ).resolves.toMatchObject({
+      const activePolicy = sandbox.update.mock.calls.at(-1)?.[0].networkPolicy;
+      const activeRequesterToken = requesterTokenFromForwardURL(
+        sentryForwardURLFromPolicy(activePolicy),
+      );
+
+      expect(
+        parseSandboxEgressRequesterToken(activeRequesterToken),
+      ).toMatchObject({
         requesterId: "U123",
+        egressId: "sbx_authorize_credentials_session",
       });
       return {
         exitCode: 0,
@@ -698,26 +691,18 @@ describe("createSandboxExecutor", () => {
     });
 
     expect(sandbox.update).toHaveBeenCalledTimes(1);
-    expect(sandbox.update).toHaveBeenCalledWith({
-      networkPolicy: {
-        allow: {
-          "*": [],
-          "sentry.io": [
-            {
-              forwardURL: "https://junior.example.com/",
-            },
-          ],
-        },
-      },
-    });
+    expect(
+      requesterTokenFromForwardURL(
+        sentryForwardURLFromPolicy(
+          sandbox.update.mock.calls[0]?.[0].networkPolicy,
+        ),
+      ),
+    ).toBeTruthy();
     const invocation = sandbox.runCommand.mock.calls[0]?.[0];
     expect(invocation.args?.[1]).toContain(
       "export SENTRY_AUTH_TOKEN='host_managed_credential'",
     );
     expect(invocation.args?.[1]).toContain("sentry-cli issues list");
-    await expect(
-      getSandboxEgressSession("sbx_authorize_credentials_session"),
-    ).resolves.toBeUndefined();
   });
 
   it("makes registered provider credentials available to sandbox commands", async () => {
@@ -746,87 +731,18 @@ describe("createSandboxExecutor", () => {
     });
 
     expect(sandbox.update).toHaveBeenCalledTimes(1);
-    expect(sandbox.update).toHaveBeenCalledWith({
-      networkPolicy: {
-        allow: {
-          "*": [],
-          "sentry.io": [
-            {
-              forwardURL: "https://junior.example.com/",
-            },
-          ],
-        },
-      },
-    });
+    expect(
+      requesterTokenFromForwardURL(
+        sentryForwardURLFromPolicy(
+          sandbox.update.mock.calls[0]?.[0].networkPolicy,
+        ),
+      ),
+    ).toBeTruthy();
     const invocation = sandbox.runCommand.mock.calls[0]?.[0];
     expect(invocation.args?.[1]).toContain(
       "export SENTRY_AUTH_TOKEN='host_managed_credential'",
     );
     expect(invocation.args?.[1]).toContain("echo local-only");
-  });
-
-  it("clears sandbox command hooks when command env resolution fails", async () => {
-    const sandbox = makeSandbox("sbx_command_env_failure");
-    sandboxGetMock.mockResolvedValue(sandbox);
-    vi.mocked(createBashTool).mockResolvedValue({
-      tools: {
-        readFile: { execute: vi.fn(async () => ({ content: "" })) },
-        writeFile: { execute: vi.fn(async () => ({ success: true })) },
-      },
-    } as never);
-    const afterCommand = vi.fn();
-
-    const manager = createSandboxSessionManager({
-      sandboxId: "sbx_command_env_failure",
-      beforeCommand: vi.fn(),
-      afterCommand,
-      commandEnv: vi.fn(async () => {
-        throw new Error("env failed");
-      }),
-    });
-    const bash = (await manager.ensureToolExecutors()).bash;
-
-    await expect(bash({ command: "echo ok" })).rejects.toThrow("env failed");
-
-    expect(afterCommand).toHaveBeenCalledWith(
-      "sbx_command_env_failure_session",
-    );
-    expect(sandbox.runCommand).not.toHaveBeenCalled();
-  });
-
-  it("does not mask command timeout results when command cleanup fails", async () => {
-    const sandbox = makeSandbox("sbx_timeout_cleanup_failure");
-    sandbox.runCommand.mockImplementation(
-      async (input: { signal?: AbortSignal }) =>
-        await new Promise((_resolve, reject) => {
-          input.signal?.addEventListener("abort", () => {
-            reject(new Error("aborted"));
-          });
-        }),
-    );
-    sandboxGetMock.mockResolvedValue(sandbox);
-    vi.mocked(createBashTool).mockResolvedValue({
-      tools: {
-        readFile: { execute: vi.fn(async () => ({ content: "" })) },
-        writeFile: { execute: vi.fn(async () => ({ success: true })) },
-      },
-    } as never);
-
-    const manager = createSandboxSessionManager({
-      sandboxId: "sbx_timeout_cleanup_failure",
-      afterCommand: vi.fn(async () => {
-        throw new Error("cleanup failed");
-      }),
-    });
-    const bash = (await manager.ensureToolExecutors()).bash;
-
-    await expect(
-      bash({ command: "sleep 10", timeoutMs: 1 }),
-    ).resolves.toMatchObject({
-      exitCode: 124,
-      timedOut: true,
-      stderr: "Command timed out after 1ms",
-    });
   });
 
   it("returns a failed bash result when the command stream ends without a status", async () => {

--- a/specs/oauth-flows-spec.md
+++ b/specs/oauth-flows-spec.md
@@ -202,8 +202,8 @@ Providers define OAuth through plugin manifests:
 - The runtime must not post the authorization URL into the public thread. Slack-thread acknowledgements for auth pauses must stay URL-free and only say that authorization is needed and the private link was sent.
 - Authorization URLs are never returned to the model.
 - Tokens are stored server-side and never appear in sandbox files or model-visible tool arguments.
-- Leases are requester-bound; sandbox egress leases are scoped to one command activation.
-- Target-aware providers may narrow leases to repo/project/org scope when available.
+- Leases are requester-bound; sandbox egress leases are issued lazily when forwarded provider traffic needs them and are scoped to the signed requester/sandbox context plus lease expiry.
+- Target-aware providers may narrow leases only from explicit provider/request context, not guessed command intent.
 
 ## Disconnect behavior
 

--- a/specs/security-policy.md
+++ b/specs/security-policy.md
@@ -32,7 +32,7 @@ This policy applies to:
 
 - Production should use explicit network policy and minimal allowlists.
 - Credential-capable provider domains should route through the Junior sandbox egress proxy instead of receiving long-lived sandbox secrets.
-- Proxied sandbox egress requests must verify the Vercel-signed Sandbox OIDC token, use its sandbox claim as the active VM session id, resolve the provider from the forwarded host, and require a requester-bound sandbox egress session. Egress sessions are command-scoped, and cached provider leases must be scoped to one session activation.
+- Proxied sandbox egress requests must verify the Vercel-signed Sandbox OIDC token, use its sandbox claim as the active VM session id, resolve the provider from the forwarded host, and require a signed requester-bound context token in the forwarding route that matches the OIDC sandbox claim. Cached provider leases must be scoped to one requester/sandbox context and lease expiry.
 - The egress handler must verify Vercel Sandbox OIDC before returning configuration, provider, or session-specific responses.
 - The egress proxy must not reject duplicate method/URL/body requests as replay; duplicate request shapes can be legitimate retries. Requester-bound credential issuance is the security boundary.
 
@@ -55,10 +55,10 @@ This policy applies to:
 ### Issuance and injection
 
 - Runtime issues short-lived provider credentials when sandbox traffic reaches a registered provider domain.
-- Registered plugin provider declarations determine which provider credentials may be injected into a sandbox command.
+- Registered plugin provider declarations determine which provider credentials may be injected for matching forwarded provider domains.
 - A registered provider authorizes its declared domains for sandbox egress; registration must not mint credentials by itself.
 - Credential issuance for user-owned provider access must be requester-bound; runtime paths without requester context must fail instead of issuing reusable credentials.
-- Even for host-managed integrations, sandbox credentials are activated only inside the requesting command and must not carry over to later commands or different message authors.
+- Even for host-managed integrations, sandbox credentials are issued lazily only when a sandbox request reaches a declared provider domain. The runtime must not pre-provision provider credentials merely because a plugin is loaded or a command might need auth.
 - Real provider secrets are delivered exclusively via host-level header transforms — the host proxies auth headers for matching provider domains (e.g. `Authorization` for `api.github.com`/`sentry.io` or provider-specific API key headers). The sandbox never sees real secret values.
 - When CLI tools require tool-native sandbox auth env vars (for example `SENTRY_AUTH_TOKEN`, Pup's `DD_API_KEY`, or Pup's `DD_APP_KEY`), set them to non-secret placeholders so the tool proceeds to make HTTP requests. Placeholder values may be provider-specific via plugin manifest config. The host authenticates those requests via header transforms.
 - Plugin-declared command env may include non-secret placeholders, default-backed deployment values, and explicit non-secret host env bindings needed by the command process. It must not read or expose env vars used by API headers, credential config, OAuth config, or other secret deployment values.

--- a/specs/security-policy.md
+++ b/specs/security-policy.md
@@ -32,7 +32,7 @@ This policy applies to:
 
 - Production should use explicit network policy and minimal allowlists.
 - Credential-capable provider domains should route through the Junior sandbox egress proxy instead of receiving long-lived sandbox secrets.
-- Proxied sandbox egress requests must verify the Vercel-signed Sandbox OIDC token, use its sandbox claim as the active VM session id, resolve the provider from the forwarded host, and require a signed requester-bound context token in the forwarding route that matches the OIDC sandbox claim. Cached provider leases must be scoped to one requester/sandbox context and lease expiry.
+- Proxied sandbox egress requests must verify the Vercel-signed Sandbox OIDC token, use its sandbox claim as the active VM session id, resolve the provider from the Vercel forwarded host/path headers, and require a signed requester-bound context token in the forwarding route that matches the OIDC sandbox claim. Cached provider leases must be scoped to one requester/sandbox context and lease expiry.
 - The egress handler must verify Vercel Sandbox OIDC before returning configuration, provider, or session-specific responses.
 - The egress proxy must not reject duplicate method/URL/body requests as replay; duplicate request shapes can be legitimate retries. Requester-bound credential issuance is the security boundary.
 

--- a/specs/skill-capabilities-spec.md
+++ b/specs/skill-capabilities-spec.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-02-26
-- Last Edited: 2026-05-13
+- Last Edited: 2026-05-21
 
 ## Changelog
 
@@ -15,6 +15,7 @@
 - 2026-05-08: Added plugin-owned `command-env` as a non-secret CLI compatibility surface.
 - 2026-05-12: Added Vercel Sandbox egress proxy activation for request-time credential issuance.
 - 2026-05-13: Removed the old per-turn credential runtime in favor of egress proxy-only credential activation.
+- 2026-05-21: Clarified lazy sandbox egress auth: signed requester/sandbox context in the forwarding URL, request-time provider resolution, and no intent guessing.
 
 ## Status
 
@@ -36,7 +37,7 @@ Define how Junior maps registered plugin provider domains to host-managed creden
 2. Skills do not declare capabilities or config keys.
 3. Registered providers are always available to sandbox commands.
 4. The agent runs the real provider command.
-5. The runtime resolves the provider from the outgoing request host, issues a command-scoped provider lease, and injects credentials for that request only.
+5. The runtime resolves the provider from the outgoing request host, lazily issues a requester-bound provider lease, and injects credentials for that forwarded request.
 6. If auth is missing or stale, the proxy returns a command-readable auth-required response and the command failure path starts a private OAuth flow, then resumes the paused turn after authorization.
 7. Plugin manifests own runtime setup. Skills do not instruct the agent to install packages, bootstrap CLIs, configure provider credentials, command env, or MCP servers.
 
@@ -78,7 +79,7 @@ Rules:
 - Resolve provider from the Vercel Sandbox forwarded host for proxied sandbox egress.
 - Require requester context before issuing provider credentials.
 - Return short-lived leases only.
-- Keep any host-side egress lease cache bounded by the sandbox egress session expiry and lease expiry.
+- Keep any host-side egress lease cache bounded by the signed requester/sandbox context expiry and lease expiry.
 
 ### Injection behavior
 
@@ -87,16 +88,19 @@ Rules:
 - Plugin credentials may define a provider-specific `auth-token-placeholder` for CLI compatibility.
 - Plugin manifests may define non-secret `command-env` values for CLI compatibility. These may include placeholder API keys, deployment defaults, or explicit public host env bindings, but never real secrets.
 - Do not inject long-lived secrets into sandbox files.
+- Credential issuance is intentionally lazy to avoid wasted token minting and provider compute for commands that never touch authenticated domains.
+- Do not infer provider intent from bash commands, skill prose, or planned work to pre-scope tokens. Fine-grained token scopes are desirable, but guessing intent is not a safe authorization boundary; provider/domain matching at request time is the contract.
 
 ### Sandbox egress proxy
 
 - New sandbox sessions use a Vercel Sandbox network policy that forwards declared credential provider domains to Junior's internal egress handler.
-- The internal egress handler must verify the Vercel Sandbox OIDC token before proxying.
+- The runtime configures the forwarding URL with a signed requester context bound to the sandbox VM session so the proxy can mint per-user OAuth leases lazily without a state-store lookup.
+- The internal egress handler must verify the Vercel Sandbox OIDC token and signed requester/sandbox context before proxying.
 - The egress route must reconstruct the upstream URL only from Vercel forwarded host/scheme/port headers and the request path.
 - The egress route must reject forwarded hosts that do not match a registered provider domain.
 - The proxy must not use method/URL/body-only replay fingerprints as an authorization boundary because duplicate request shapes can be legitimate client retries.
 - The proxy must strip hop-by-hop and proxy-control headers before sending the upstream request.
-- Sandbox-supplied request headers and upstream response state may pass through once Vercel OIDC, command-scoped requester session state, and provider-domain ownership have been verified.
+- Sandbox-supplied request headers and upstream response state may pass through once Vercel OIDC, requester context, and provider-domain ownership have been verified.
 
 ### Runtime setup boundary
 

--- a/specs/skill-capabilities-spec.md
+++ b/specs/skill-capabilities-spec.md
@@ -96,7 +96,7 @@ Rules:
 - New sandbox sessions use a Vercel Sandbox network policy that forwards declared credential provider domains to Junior's internal egress handler.
 - The runtime configures the forwarding URL with a signed requester context bound to the sandbox VM session so the proxy can mint per-user OAuth leases lazily without a state-store lookup.
 - The internal egress handler must verify the Vercel Sandbox OIDC token and signed requester/sandbox context before proxying.
-- The egress route must reconstruct the upstream URL only from Vercel forwarded host/scheme/port headers and the request path.
+- The egress route must reconstruct the upstream URL only from Vercel forwarded host/scheme/port/path headers. The proxy route URL contains Junior routing state and must not be used as the upstream path.
 - The egress route must reject forwarded hosts that do not match a registered provider domain.
 - The proxy must not use method/URL/body-only replay fingerprints as an authorization boundary because duplicate request shapes can be legitimate client retries.
 - The proxy must strip hop-by-hop and proxy-control headers before sending the upstream request.


### PR DESCRIPTION
Keep sandbox provider auth lazy while removing the command-scoped state lookup that could deny valid first provider requests. Forwarded provider traffic now carries a signed requester/sandbox context, so the egress proxy can verify Vercel OIDC, resolve the provider from the forwarded host, and mint credentials only when needed.

**Requester/Sandbox Context**

Network policy forward URLs include a short-lived signed context bound to the Vercel OIDC `sandbox_id`. The proxy rejects missing, tampered, or mismatched contexts, redacts context tokens from logs, and caches leases per requester/sandbox context.

**Lazy Proxy Cleanup**

Remove the obsolete command before/after egress hooks and update specs/docs to state that provider tokens are not pre-provisioned or inferred from bash intent.

**Integration Coverage**

Add a sandbox egress integration test that uses real plugin discovery, network policy generation, credential routing, memory-backed state, and proxy header injection. The test substitutes only Vercel OIDC verification and the upstream provider request, which are the external boundaries this local suite cannot own.