### PR TITLE
feat(chat): Persist Pi session state incrementally

### DIFF
--- a/packages/junior/src/chat/pi/session-state-store.ts
+++ b/packages/junior/src/chat/pi/session-state-store.ts
@@ -1,0 +1,95 @@
+import { isDeepStrictEqual } from "node:util";
+import { isRecord } from "@/chat/coerce";
+import type { PiMessage } from "@/chat/pi/messages";
+import { getStateAdapter } from "@/chat/state/adapter";
+
+const PI_SESSION_MESSAGE_PREFIX = "junior:pi_session_message";
+
+interface PiSessionScope {
+  conversationId: string;
+  sessionId: string;
+}
+
+function piSessionMessageKey(scope: PiSessionScope, index: number): string {
+  return `${PI_SESSION_MESSAGE_PREFIX}:${scope.conversationId}:${scope.sessionId}:${index}`;
+}
+
+function parsePiMessage(value: unknown): PiMessage | undefined {
+  return isRecord(value) ? (value as unknown as PiMessage) : undefined;
+}
+
+function normalizeMessageCount(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+function countMatchingPrefix(left: PiMessage[], right: PiMessage[]): number {
+  const limit = Math.min(left.length, right.length);
+  for (let index = 0; index < limit; index += 1) {
+    if (!isDeepStrictEqual(left[index], right[index])) {
+      return index;
+    }
+  }
+  return limit;
+}
+
+/** Load the exact stable Pi message prefix for a session. */
+export async function loadPiSessionMessages(
+  args: PiSessionScope & {
+    messageCount: number;
+  },
+): Promise<PiMessage[] | undefined> {
+  const stateAdapter = getStateAdapter();
+  await stateAdapter.connect();
+
+  const messageCount = normalizeMessageCount(args.messageCount);
+  if (messageCount === 0) {
+    return [];
+  }
+
+  const values = await Promise.all(
+    Array.from({ length: messageCount }, (_, index) =>
+      stateAdapter.get(piSessionMessageKey(args, index)),
+    ),
+  );
+
+  const messages: PiMessage[] = [];
+  for (const value of values) {
+    const message = parsePiMessage(value);
+    if (!message) {
+      break;
+    }
+    messages.push(message);
+  }
+  return messages.length === messageCount ? messages : undefined;
+}
+
+/** Commit new stable Pi messages before the caller advances its cursor. */
+export async function commitPiSessionMessages(
+  args: PiSessionScope & {
+    messages: PiMessage[];
+    ttlMs: number;
+  },
+): Promise<void> {
+  const stateAdapter = getStateAdapter();
+  await stateAdapter.connect();
+
+  const existingMessages =
+    (await loadPiSessionMessages({
+      conversationId: args.conversationId,
+      sessionId: args.sessionId,
+      messageCount: args.messages.length,
+    })) ?? [];
+  const writeFromIndex = countMatchingPrefix(existingMessages, args.messages);
+
+  await Promise.all(
+    args.messages
+      .slice(writeFromIndex)
+      .map((message, offset) =>
+        stateAdapter.set(
+          piSessionMessageKey(args, writeFromIndex + offset),
+          message,
+          args.ttlMs,
+        ),
+      ),
+  );
+}

--- a/packages/junior/src/chat/prompt.ts
+++ b/packages/junior/src/chat/prompt.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { botConfig, getRuntimeMetadata } from "@/chat/config";
+import { TURN_CONTEXT_TAG } from "@/chat/turn-context-tag";
 import {
   listReferenceFiles,
   soulPathCandidates,
@@ -400,7 +401,6 @@ const HEADER =
 
 const TURN_CONTEXT_HEADER =
   "Per-turn runtime context for this request. Treat these blocks as trusted runtime facts and skill/provider instructions for the current turn; the static system prompt remains authoritative.";
-const TURN_CONTEXT_TAG = "runtime-turn-context";
 
 const TOOL_POLICY_RULES = [
   "- Tool schemas are the source of truth for parameters; tool names are case-sensitive, so call tools exactly by their exposed names and do not invent arguments.",

--- a/packages/junior/src/chat/respond-helpers.ts
+++ b/packages/junior/src/chat/respond-helpers.ts
@@ -7,9 +7,10 @@
 import type { AssistantMessage, ToolResultMessage } from "@mariozechner/pi-ai";
 import type { PiMessage } from "@/chat/pi/messages";
 import type { Skill } from "@/chat/skills";
+import { TURN_CONTEXT_TAG } from "@/chat/turn-context-tag";
 
 const MAX_INLINE_ATTACHMENT_BASE64_CHARS = 120_000;
-const RUNTIME_TURN_CONTEXT_START = "<runtime-turn-context>";
+const RUNTIME_TURN_CONTEXT_START = `<${TURN_CONTEXT_TAG}>`;
 
 /** Extract conversation and session identifiers from correlation context. */
 export function getSessionIdentifiers(context: {

--- a/packages/junior/src/chat/respond-helpers.ts
+++ b/packages/junior/src/chat/respond-helpers.ts
@@ -9,6 +9,7 @@ import type { PiMessage } from "@/chat/pi/messages";
 import type { Skill } from "@/chat/skills";
 
 const MAX_INLINE_ATTACHMENT_BASE64_CHARS = 120_000;
+const RUNTIME_TURN_CONTEXT_START = "<runtime-turn-context>";
 
 /** Extract conversation and session identifiers from correlation context. */
 export function getSessionIdentifiers(context: {
@@ -275,6 +276,101 @@ export function getPiMessageRole(value: unknown): string | undefined {
   }
   const role = (value as { role?: unknown }).role;
   return typeof role === "string" ? role : undefined;
+}
+
+function getUserMessageContent(message: PiMessage): unknown[] | undefined {
+  const record = message as { role?: unknown; content?: unknown };
+  return record.role === "user" && Array.isArray(record.content)
+    ? record.content
+    : undefined;
+}
+
+function isRuntimeTurnContextPart(part: unknown, marker: string): boolean {
+  return (
+    part !== null &&
+    typeof part === "object" &&
+    (part as { type?: unknown }).type === "text" &&
+    typeof (part as { text?: unknown }).text === "string" &&
+    (part as { text: string }).text.startsWith(marker)
+  );
+}
+
+function replaceRuntimeTurnContext(
+  message: PiMessage,
+  turnContextPrompt: string,
+): PiMessage | undefined {
+  const content = getUserMessageContent(message);
+  if (!content) {
+    return undefined;
+  }
+
+  const marker = turnContextPrompt.split("\n", 1)[0];
+  const contextIndex = content.findIndex((part) =>
+    isRuntimeTurnContextPart(part, marker),
+  );
+  if (contextIndex < 0) {
+    return undefined;
+  }
+
+  const nextContent = [...content];
+  nextContent[contextIndex] = {
+    ...(nextContent[contextIndex] as object),
+    text: turnContextPrompt,
+  };
+  return {
+    ...message,
+    content: nextContent,
+  } as PiMessage;
+}
+
+/** Refresh volatile runtime context in a checkpoint before continuing Pi. */
+export function refreshRuntimeTurnContext(
+  messages: PiMessage[],
+  turnContextPrompt: string,
+): PiMessage[] {
+  for (let index = 0; index < messages.length; index += 1) {
+    const updated = replaceRuntimeTurnContext(
+      messages[index],
+      turnContextPrompt,
+    );
+    if (!updated) {
+      continue;
+    }
+
+    const nextMessages = [...messages];
+    nextMessages[index] = updated;
+    return nextMessages;
+  }
+
+  return [
+    ...messages,
+    {
+      role: "user",
+      content: [{ type: "text", text: turnContextPrompt }],
+      timestamp: Date.now(),
+    } as PiMessage,
+  ];
+}
+
+/** Remove volatile runtime context before using checkpoint messages as history. */
+export function stripRuntimeTurnContext(messages: PiMessage[]): PiMessage[] {
+  return messages.flatMap((message) => {
+    const content = getUserMessageContent(message);
+    if (!content) {
+      return [message];
+    }
+
+    const nextContent = content.filter(
+      (part) => !isRuntimeTurnContextPart(part, RUNTIME_TURN_CONTEXT_START),
+    );
+    if (nextContent.length === content.length) {
+      return [message];
+    }
+    if (nextContent.length === 0) {
+      return [];
+    }
+    return [{ ...message, content: nextContent } as PiMessage];
+  });
 }
 
 /** Concatenate text content parts from an assistant message. */

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -341,30 +341,6 @@ function refreshCheckpointTurnContext(
   ];
 }
 
-function stripTurnContextFromMessages(
-  messages: PiMessage[],
-  turnContextPrompt: string,
-): PiMessage[] {
-  const marker = getTurnContextMarker(turnContextPrompt);
-  return messages.flatMap((message) => {
-    const content = getUserMessageContent(message);
-    if (!content) {
-      return [message];
-    }
-
-    const strippedContent = content.filter(
-      (part) => !isTurnContextPart(part, marker),
-    );
-    if (strippedContent.length === content.length) {
-      return [message];
-    }
-    if (strippedContent.length === 0) {
-      return [];
-    }
-    return [{ ...message, content: strippedContent } as PiMessage];
-  });
-}
-
 function getTurnContextMarker(turnContextPrompt: string): string {
   return turnContextPrompt.split("\n", 1)[0];
 }
@@ -1124,7 +1100,6 @@ export async function generateAssistantReply(
       unsubscribe();
     }
 
-    // ── Persist completed checkpoint ─────────────────────────────────
     if (
       checkpointState.canUseTurnSession &&
       sessionConversationId &&
@@ -1145,10 +1120,6 @@ export async function generateAssistantReply(
     // ── Build turn result ────────────────────────────────────────────
     return buildTurnResult({
       newMessages,
-      piMessages: stripTurnContextFromMessages(
-        agent.state.messages,
-        turnContextPrompt,
-      ),
       userInput,
       replyFiles,
       artifactStatePatch,

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -68,6 +68,7 @@ import {
   encodeNonImageAttachmentForPrompt,
   getSessionIdentifiers,
   isAssistantMessage,
+  refreshRuntimeTurnContext,
   summarizeMessageText,
   toObservablePromptPart,
   upsertActiveSkill,
@@ -298,68 +299,6 @@ function buildUserTurnInput(args: {
   }
 
   return { routerBlocks, userContentParts };
-}
-
-function refreshCheckpointTurnContext(
-  messages: PiMessage[],
-  turnContextPrompt: string,
-): PiMessage[] {
-  // Resumes need fresh runtime facts without duplicating the original user turn.
-  const marker = getTurnContextMarker(turnContextPrompt);
-  for (let index = 0; index < messages.length; index += 1) {
-    const content = getUserMessageContent(messages[index]);
-    if (!content) {
-      continue;
-    }
-    const contextIndex = content.findIndex((part) =>
-      isTurnContextPart(part, marker),
-    );
-    if (contextIndex < 0) {
-      continue;
-    }
-
-    const updatedMessages = [...messages];
-    const updatedContent = [...content];
-    updatedContent[contextIndex] = {
-      ...(updatedContent[contextIndex] as object),
-      text: turnContextPrompt,
-    };
-    updatedMessages[index] = {
-      ...messages[index],
-      content: updatedContent,
-    } as PiMessage;
-    return updatedMessages;
-  }
-
-  return [
-    ...messages,
-    {
-      role: "user",
-      content: [{ type: "text", text: turnContextPrompt }],
-      timestamp: Date.now(),
-    } as PiMessage,
-  ];
-}
-
-function getTurnContextMarker(turnContextPrompt: string): string {
-  return turnContextPrompt.split("\n", 1)[0];
-}
-
-function getUserMessageContent(message: PiMessage): unknown[] | undefined {
-  const record = message as { role?: unknown; content?: unknown };
-  return record.role === "user" && Array.isArray(record.content)
-    ? record.content
-    : undefined;
-}
-
-function isTurnContextPart(part: unknown, marker: string): boolean {
-  return (
-    part !== null &&
-    typeof part === "object" &&
-    (part as { type?: unknown }).type === "text" &&
-    typeof (part as { text?: unknown }).text === "string" &&
-    (part as { text: string }).text.startsWith(marker)
-  );
 }
 
 /** Run a full agent turn: discover skills, execute tools, and return the assistant reply. */
@@ -983,7 +922,7 @@ export async function generateAssistantReply(
     beforeMessageCount = agent.state.messages.length;
     try {
       if (resumedFromCheckpoint) {
-        agent.state.messages = refreshCheckpointTurnContext(
+        agent.state.messages = refreshRuntimeTurnContext(
           existingCheckpoint!.piMessages,
           turnContextPrompt,
         );

--- a/packages/junior/src/chat/runtime/auth-pause-state.ts
+++ b/packages/junior/src/chat/runtime/auth-pause-state.ts
@@ -2,7 +2,7 @@ import {
   getPersistedThreadState,
   persistThreadStateById,
 } from "@/chat/runtime/thread-state";
-import { markTurnCompleted } from "@/chat/runtime/turn";
+import { markTurnClosed } from "@/chat/runtime/turn";
 import { getTurnUserMessageId } from "@/chat/runtime/turn-user-message";
 import {
   markConversationMessage,
@@ -26,7 +26,7 @@ export function completeAuthPauseTurn(args: {
       skippedReason: undefined,
     },
   );
-  markTurnCompleted({
+  markTurnClosed({
     conversation: args.conversation,
     nowMs: Date.now(),
     sessionId: args.sessionId,

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -58,7 +58,11 @@ import type { TurnContinuationRequest } from "@/chat/services/timeout-resume";
 import { canScheduleTurnTimeoutResume } from "@/chat/services/timeout-resume";
 import { isRetryableTurnError } from "@/chat/runtime/turn";
 import { buildDeterministicTurnId } from "@/chat/runtime/turn";
-import { markTurnCompleted, markTurnFailed } from "@/chat/runtime/turn";
+import {
+  markTurnClosed,
+  markTurnCompleted,
+  markTurnFailed,
+} from "@/chat/runtime/turn";
 import { startActiveTurn } from "@/chat/runtime/turn";
 import { isRedundantReactionAckText } from "@/chat/services/reply-delivery-plan";
 import { deleteSlackMessage, postSlackMessage } from "@/chat/slack/outbound";
@@ -736,14 +740,10 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           const nextArtifacts = shouldPersistArtifacts
             ? mergeArtifactsState(preparedState.artifacts, artifactStatePatch)
             : undefined;
-          // Live turn owns the in-memory conversation; `sessionId` is omitted
-          // so `activeTurnId` clears unconditionally. Callback paths that
-          // reload thread state fresh must pass `sessionId` to avoid wiping a
-          // concurrent turn's active id.
           markTurnCompleted({
-            completedSessionId: turnId,
             conversation: preparedState.conversation,
             nowMs: Date.now(),
+            sessionId: turnId,
             updateConversationStats,
           });
           await persistThreadState(thread, {
@@ -885,9 +885,10 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                 replied: true,
               },
             });
-            markTurnCompleted({
+            markTurnClosed({
               conversation: preparedState.conversation,
               nowMs: Date.now(),
+              sessionId: turnId,
               updateConversationStats,
             });
             await persistThreadState(thread, {

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -152,11 +152,11 @@ async function loadPiMessagesForTurn(args: {
       args.conversationId,
       args.activeTurnId,
     );
-    return checkpoint && checkpoint.piMessages.length > 0
-      ? stripRuntimeTurnContext(
-          trimTrailingAssistantMessages(checkpoint.piMessages),
-        )
-      : fallback;
+    if (checkpoint?.piMessages.length) {
+      return stripRuntimeTurnContext(
+        trimTrailingAssistantMessages(checkpoint.piMessages),
+      );
+    }
   }
 
   if (!args.lastSessionId) {

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -76,7 +76,7 @@ import { maybeApplyProviderDefaultConfigRequest } from "@/chat/services/provider
 import type { PiMessage } from "@/chat/pi/messages";
 import { getAgentTurnSessionCheckpoint } from "@/chat/state/turn-session-store";
 import {
-  getPiMessageRole,
+  stripRuntimeTurnContext,
   trimTrailingAssistantMessages,
 } from "@/chat/respond-helpers";
 
@@ -105,39 +105,6 @@ function getCurrentTurnCanvasUrl(args: {
 
 function buildCanvasRecoveryReply(canvasUrl: string) {
   return `I created the canvas, but the turn was interrupted before I could finish the thread reply: ${canvasUrl}`;
-}
-
-const RUNTIME_TURN_CONTEXT_START = "<runtime-turn-context>";
-
-function stripRuntimeTurnContext(messages: PiMessage[]): PiMessage[] {
-  return messages.flatMap((message) => {
-    if (getPiMessageRole(message) !== "user") {
-      return [message];
-    }
-
-    const content = (message as { content?: unknown }).content;
-    if (!Array.isArray(content)) {
-      return [message];
-    }
-
-    const nextContent = content.filter(
-      (part) =>
-        !(
-          part !== null &&
-          typeof part === "object" &&
-          (part as { type?: unknown }).type === "text" &&
-          typeof (part as { text?: unknown }).text === "string" &&
-          (part as { text: string }).text.startsWith(RUNTIME_TURN_CONTEXT_START)
-        ),
-    );
-    if (nextContent.length === content.length) {
-      return [message];
-    }
-    if (nextContent.length === 0) {
-      return [];
-    }
-    return [{ ...message, content: nextContent } as PiMessage];
-  });
 }
 
 async function loadPiMessagesForTurn(args: {

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -69,6 +69,12 @@ import {
 import { buildSlackTurnContinuationNotice } from "@/chat/slack/turn-continuation-notice";
 import { buildAuthPauseResponse } from "@/chat/services/auth-pause-response";
 import { maybeApplyProviderDefaultConfigRequest } from "@/chat/services/provider-default-config";
+import type { PiMessage } from "@/chat/pi/messages";
+import { getAgentTurnSessionCheckpoint } from "@/chat/state/turn-session-store";
+import {
+  getPiMessageRole,
+  trimTrailingAssistantMessages,
+} from "@/chat/respond-helpers";
 
 function collectCanvasUrls(artifacts: Partial<ThreadArtifactsState>) {
   return new Set(
@@ -95,6 +101,75 @@ function getCurrentTurnCanvasUrl(args: {
 
 function buildCanvasRecoveryReply(canvasUrl: string) {
   return `I created the canvas, but the turn was interrupted before I could finish the thread reply: ${canvasUrl}`;
+}
+
+const RUNTIME_TURN_CONTEXT_START = "<runtime-turn-context>";
+
+function stripRuntimeTurnContext(messages: PiMessage[]): PiMessage[] {
+  return messages.flatMap((message) => {
+    if (getPiMessageRole(message) !== "user") {
+      return [message];
+    }
+
+    const content = (message as { content?: unknown }).content;
+    if (!Array.isArray(content)) {
+      return [message];
+    }
+
+    const nextContent = content.filter(
+      (part) =>
+        !(
+          part !== null &&
+          typeof part === "object" &&
+          (part as { type?: unknown }).type === "text" &&
+          typeof (part as { text?: unknown }).text === "string" &&
+          (part as { text: string }).text.startsWith(RUNTIME_TURN_CONTEXT_START)
+        ),
+    );
+    if (nextContent.length === content.length) {
+      return [message];
+    }
+    if (nextContent.length === 0) {
+      return [];
+    }
+    return [{ ...message, content: nextContent } as PiMessage];
+  });
+}
+
+async function loadPiMessagesForTurn(args: {
+  conversationId?: string;
+  activeTurnId?: string;
+  lastSessionId?: string;
+  fallback: PiMessage[];
+}): Promise<PiMessage[] | undefined> {
+  const fallback = args.fallback.length > 0 ? [...args.fallback] : undefined;
+  if (!args.conversationId) {
+    return fallback;
+  }
+
+  if (args.activeTurnId) {
+    const checkpoint = await getAgentTurnSessionCheckpoint(
+      args.conversationId,
+      args.activeTurnId,
+    );
+    return checkpoint && checkpoint.piMessages.length > 0
+      ? stripRuntimeTurnContext(
+          trimTrailingAssistantMessages(checkpoint.piMessages),
+        )
+      : fallback;
+  }
+
+  if (!args.lastSessionId) {
+    return fallback;
+  }
+
+  const checkpoint = await getAgentTurnSessionCheckpoint(
+    args.conversationId,
+    args.lastSessionId,
+  );
+  return checkpoint?.state === "completed" && checkpoint.piMessages.length > 0
+    ? stripRuntimeTurnContext(checkpoint.piMessages)
+    : fallback;
 }
 
 export interface ReplyExecutorServices {
@@ -325,6 +400,8 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             return;
           }
         }
+        const lastSessionIdForHistory =
+          preparedState.conversation.processing.lastSessionId;
         const configReply = await maybeApplyProviderDefaultConfigRequest({
           channelConfiguration: preparedState.channelConfiguration,
           requesterId: message.author.userId,
@@ -405,6 +482,12 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           !isVisionEnabled() && hasPotentialImageAttachment(message.attachments)
             ? countPotentialImageAttachments(message.attachments)
             : 0;
+        const piMessages = await loadPiMessagesForTurn({
+          conversationId,
+          activeTurnId,
+          lastSessionId: lastSessionIdForHistory,
+          fallback: preparedState.conversation.piMessages,
+        });
 
         const status = createSlackAdapterAssistantStatusSession({
           channelId: assistantThreadContext?.channelId,
@@ -463,7 +546,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             conversationContext:
               preparedState.routingContext ?? preparedState.conversationContext,
             artifactState: preparedState.artifacts,
-            piMessages: preparedState.conversation.piMessages,
+            piMessages,
             pendingAuth: preparedState.conversation.processing.pendingAuth,
             configuration: preparedState.configuration,
             channelConfiguration: preparedState.channelConfiguration,
@@ -551,10 +634,6 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               replied: true,
             },
           });
-          if (reply.piMessages) {
-            preparedState.conversation.piMessages = reply.piMessages;
-          }
-
           const artifactStatePatch: Partial<ThreadArtifactsState> =
             reply.artifactStatePatch ? { ...reply.artifactStatePatch } : {};
 
@@ -662,6 +741,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           // reload thread state fresh must pass `sessionId` to avoid wiping a
           // concurrent turn's active id.
           markTurnCompleted({
+            completedSessionId: turnId,
             conversation: preparedState.conversation,
             nowMs: Date.now(),
             updateConversationStats,

--- a/packages/junior/src/chat/runtime/turn.ts
+++ b/packages/junior/src/chat/runtime/turn.ts
@@ -83,6 +83,7 @@ export function startActiveTurn(args: {
  * clearing a newer concurrent turn's active id.
  */
 export function markTurnCompleted(args: {
+  completedSessionId?: string;
   conversation: ThreadConversationState;
   nowMs: number;
   sessionId?: string;
@@ -93,6 +94,9 @@ export function markTurnCompleted(args: {
     args.conversation.processing.activeTurnId === args.sessionId
   ) {
     args.conversation.processing.activeTurnId = undefined;
+  }
+  if (args.completedSessionId) {
+    args.conversation.processing.lastSessionId = args.completedSessionId;
   }
   args.conversation.processing.lastCompletedAtMs = args.nowMs;
   args.updateConversationStats(args.conversation);

--- a/packages/junior/src/chat/runtime/turn.ts
+++ b/packages/junior/src/chat/runtime/turn.ts
@@ -75,29 +75,43 @@ export function startActiveTurn(args: {
   args.updateConversationStats(args.conversation);
 }
 
+function clearActiveTurn(
+  conversation: ThreadConversationState,
+  sessionId?: string,
+): void {
+  if (!sessionId || conversation.processing.activeTurnId === sessionId) {
+    conversation.processing.activeTurnId = undefined;
+  }
+}
+
 /**
- * Mark a turn as completed after the runtime has durably accepted the final
- * user-visible reply for delivery. If `sessionId` is provided, `activeTurnId`
- * is only cleared when it still matches the completing turn — this prevents
- * late callback paths (which reload thread state fresh) from accidentally
- * clearing a newer concurrent turn's active id.
+ * Close the active turn without marking a Pi session reusable for future
+ * history. Use this for auth handoffs and recovery replies that end the live
+ * turn but do not produce a completed Pi session.
  */
-export function markTurnCompleted(args: {
-  completedSessionId?: string;
+export function markTurnClosed(args: {
   conversation: ThreadConversationState;
   nowMs: number;
   sessionId?: string;
   updateConversationStats: (conversation: ThreadConversationState) => void;
 }): void {
-  if (
-    !args.sessionId ||
-    args.conversation.processing.activeTurnId === args.sessionId
-  ) {
-    args.conversation.processing.activeTurnId = undefined;
-  }
-  if (args.completedSessionId) {
-    args.conversation.processing.lastSessionId = args.completedSessionId;
-  }
+  clearActiveTurn(args.conversation, args.sessionId);
+  args.conversation.processing.lastCompletedAtMs = args.nowMs;
+  args.updateConversationStats(args.conversation);
+}
+
+/**
+ * Mark a turn as completed after final reply delivery succeeds and make its Pi
+ * session the reusable history source for the next turn.
+ */
+export function markTurnCompleted(args: {
+  conversation: ThreadConversationState;
+  nowMs: number;
+  sessionId: string;
+  updateConversationStats: (conversation: ThreadConversationState) => void;
+}): void {
+  clearActiveTurn(args.conversation, args.sessionId);
+  args.conversation.processing.lastSessionId = args.sessionId;
   args.conversation.processing.lastCompletedAtMs = args.nowMs;
   args.updateConversationStats(args.conversation);
 }
@@ -119,12 +133,7 @@ export function markTurnFailed(args: {
   ) => void;
   updateConversationStats: (conversation: ThreadConversationState) => void;
 }): void {
-  if (
-    !args.sessionId ||
-    args.conversation.processing.activeTurnId === args.sessionId
-  ) {
-    args.conversation.processing.activeTurnId = undefined;
-  }
+  clearActiveTurn(args.conversation, args.sessionId);
   args.conversation.processing.lastCompletedAtMs = args.nowMs;
   args.markConversationMessage(args.conversation, args.userMessageId, {
     replied: false,

--- a/packages/junior/src/chat/services/turn-result.ts
+++ b/packages/junior/src/chat/services/turn-result.ts
@@ -1,7 +1,6 @@
 import type { FileUpload } from "chat";
 import { botConfig } from "@/chat/config";
 import { logInfo, logWarn } from "@/chat/logging";
-import type { PiMessage } from "@/chat/pi/messages";
 import type { LogContext } from "@/chat/logging";
 import type { TurnThinkingSelection } from "@/chat/services/turn-thinking-level";
 import type { AgentTurnUsage } from "@/chat/usage";
@@ -48,7 +47,6 @@ export interface AssistantReply {
   text: string;
   files?: FileUpload[];
   artifactStatePatch?: Partial<ThreadArtifactsState>;
-  piMessages?: PiMessage[];
   deliveryPlan?: ReplyDeliveryPlan;
   deliveryMode?: "thread" | "channel_only";
   sandboxId?: string;
@@ -58,7 +56,6 @@ export interface AssistantReply {
 
 export interface TurnResultInput {
   newMessages: unknown[];
-  piMessages?: PiMessage[];
   userInput: string;
   replyFiles: FileUpload[];
   artifactStatePatch: Partial<ThreadArtifactsState>;
@@ -110,7 +107,6 @@ function buildBriefPostCanvasReply(
 export function buildTurnResult(input: TurnResultInput): AssistantReply {
   const {
     newMessages,
-    piMessages,
     userInput,
     replyFiles,
     artifactStatePatch,
@@ -271,7 +267,6 @@ export function buildTurnResult(input: TurnResultInput): AssistantReply {
       Object.keys(artifactStatePatch).length > 0
         ? artifactStatePatch
         : undefined,
-    piMessages,
     deliveryPlan,
     deliveryMode,
     sandboxId,

--- a/packages/junior/src/chat/state/conversation.ts
+++ b/packages/junior/src/chat/state/conversation.ts
@@ -46,6 +46,7 @@ export interface ConversationBackfillState {
 export interface ConversationProcessingState {
   activeTurnId?: string;
   lastCompletedAtMs?: number;
+  lastSessionId?: string;
   pendingAuth?: ConversationPendingAuthState;
 }
 
@@ -297,6 +298,7 @@ export function coerceThreadConversationState(
   const processing: ConversationProcessingState = {
     activeTurnId: toOptionalString(rawProcessing.activeTurnId),
     lastCompletedAtMs: toOptionalNumber(rawProcessing.lastCompletedAtMs),
+    lastSessionId: toOptionalString(rawProcessing.lastSessionId),
     pendingAuth: coercePendingAuthState(rawProcessing.pendingAuth),
   };
 

--- a/packages/junior/src/chat/state/pi-session-message-store.ts
+++ b/packages/junior/src/chat/state/pi-session-message-store.ts
@@ -1,7 +1,7 @@
 import { isDeepStrictEqual } from "node:util";
 import { isRecord } from "@/chat/coerce";
 import type { PiMessage } from "@/chat/pi/messages";
-import { getStateAdapter } from "@/chat/state/adapter";
+import { getStateAdapter } from "./adapter";
 
 const PI_SESSION_MESSAGE_PREFIX = "junior:pi_session_message";
 

--- a/packages/junior/src/chat/state/pi-session-message-store.ts
+++ b/packages/junior/src/chat/state/pi-session-message-store.ts
@@ -63,6 +63,40 @@ export async function loadPiSessionMessages(
   return messages.length === messageCount ? messages : undefined;
 }
 
+/**
+ * Load as many Pi session messages as are actually present in Redis, stopping at
+ * the first missing slot. Used by the commit path to determine the safe write start
+ * index without requiring an exact count match.
+ */
+async function loadExistingPiSessionMessages(
+  scope: PiSessionScope,
+  maxCount: number,
+): Promise<PiMessage[]> {
+  const count = normalizeMessageCount(maxCount);
+  if (count === 0) {
+    return [];
+  }
+
+  const stateAdapter = getStateAdapter();
+  await stateAdapter.connect();
+
+  const values = await Promise.all(
+    Array.from({ length: count }, (_, index) =>
+      stateAdapter.get(piSessionMessageKey(scope, index)),
+    ),
+  );
+
+  const messages: PiMessage[] = [];
+  for (const value of values) {
+    const message = parsePiMessage(value);
+    if (!message) {
+      break;
+    }
+    messages.push(message);
+  }
+  return messages;
+}
+
 /** Commit new stable Pi messages before the caller advances its cursor. */
 export async function commitPiSessionMessages(
   args: PiSessionScope & {
@@ -73,12 +107,10 @@ export async function commitPiSessionMessages(
   const stateAdapter = getStateAdapter();
   await stateAdapter.connect();
 
-  const existingMessages =
-    (await loadPiSessionMessages({
-      conversationId: args.conversationId,
-      sessionId: args.sessionId,
-      messageCount: args.messages.length,
-    })) ?? [];
+  const existingMessages = await loadExistingPiSessionMessages(
+    { conversationId: args.conversationId, sessionId: args.sessionId },
+    args.messages.length,
+  );
   const writeFromIndex = countMatchingPrefix(existingMessages, args.messages);
 
   await Promise.all(

--- a/packages/junior/src/chat/state/turn-session-store.ts
+++ b/packages/junior/src/chat/state/turn-session-store.ts
@@ -4,7 +4,7 @@ import type { PiMessage } from "@/chat/pi/messages";
 import {
   commitPiSessionMessages,
   loadPiSessionMessages,
-} from "@/chat/pi/session-state-store";
+} from "./pi-session-message-store";
 import type { AgentTurnUsage } from "@/chat/usage";
 import { getStateAdapter } from "./adapter";
 

--- a/packages/junior/src/chat/state/turn-session-store.ts
+++ b/packages/junior/src/chat/state/turn-session-store.ts
@@ -1,10 +1,15 @@
+import { THREAD_STATE_TTL_MS } from "chat";
 import { isRecord } from "@/chat/coerce";
 import type { PiMessage } from "@/chat/pi/messages";
+import {
+  commitPiSessionMessages,
+  loadPiSessionMessages,
+} from "@/chat/pi/session-state-store";
 import type { AgentTurnUsage } from "@/chat/usage";
 import { getStateAdapter } from "./adapter";
 
 const AGENT_TURN_SESSION_PREFIX = "junior:agent_turn_session";
-const AGENT_TURN_SESSION_TTL_MS = 24 * 60 * 60 * 1000;
+const AGENT_TURN_SESSION_TTL_MS = THREAD_STATE_TTL_MS;
 
 export type AgentTurnSessionStatus =
   | "running"
@@ -29,6 +34,13 @@ export interface AgentTurnSessionCheckpoint {
   sliceId: number;
   state: AgentTurnSessionStatus;
   updatedAtMs: number;
+}
+
+interface AgentTurnSessionRecord extends Omit<
+  AgentTurnSessionCheckpoint,
+  "piMessages"
+> {
+  messageCount: number;
 }
 
 function agentTurnSessionKey(
@@ -66,61 +78,83 @@ function parseAgentTurnUsage(value: unknown): AgentTurnUsage | undefined {
   return Object.keys(usage).length > 0 ? usage : undefined;
 }
 
-function parseAgentTurnSessionCheckpoint(
+function parseStoredRecord(
   value: unknown,
-): AgentTurnSessionCheckpoint | undefined {
+): Record<string, unknown> | undefined {
+  if (isRecord(value)) {
+    return value;
+  }
   if (typeof value !== "string") {
     return undefined;
   }
 
   try {
     const parsed = JSON.parse(value) as Record<string, unknown>;
-    if (!isRecord(parsed)) {
-      return undefined;
-    }
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
-    const status = parsed.state;
-    if (
-      status !== "running" &&
-      status !== "awaiting_resume" &&
-      status !== "completed" &&
-      status !== "failed" &&
-      status !== "superseded"
-    ) {
-      return undefined;
+function parseAgentTurnSessionRecord(value: unknown):
+  | {
+      legacyPiMessages: PiMessage[];
+      record: AgentTurnSessionRecord;
     }
+  | undefined {
+  const parsed = parseStoredRecord(value);
+  if (!parsed) {
+    return undefined;
+  }
 
-    const conversationId = parsed.conversationId;
-    const sessionId = parsed.sessionId;
-    const sliceId = parsed.sliceId;
-    const checkpointVersion = parsed.checkpointVersion;
-    const updatedAtMs = parsed.updatedAtMs;
-    const cumulativeDurationMs = toFiniteNonNegativeNumber(
-      parsed.cumulativeDurationMs,
-    );
-    const cumulativeUsage = parseAgentTurnUsage(parsed.cumulativeUsage);
-    if (
-      typeof conversationId !== "string" ||
-      typeof sessionId !== "string" ||
-      typeof sliceId !== "number" ||
-      typeof checkpointVersion !== "number" ||
-      typeof updatedAtMs !== "number"
-    ) {
-      return undefined;
-    }
+  const status = parsed.state;
+  if (
+    status !== "running" &&
+    status !== "awaiting_resume" &&
+    status !== "completed" &&
+    status !== "failed" &&
+    status !== "superseded"
+  ) {
+    return undefined;
+  }
 
-    return {
+  const conversationId = parsed.conversationId;
+  const sessionId = parsed.sessionId;
+  const sliceId = parsed.sliceId;
+  const checkpointVersion = parsed.checkpointVersion;
+  const updatedAtMs = parsed.updatedAtMs;
+  const cumulativeDurationMs = toFiniteNonNegativeNumber(
+    parsed.cumulativeDurationMs,
+  );
+  const cumulativeUsage = parseAgentTurnUsage(parsed.cumulativeUsage);
+  if (
+    typeof conversationId !== "string" ||
+    typeof sessionId !== "string" ||
+    typeof sliceId !== "number" ||
+    typeof checkpointVersion !== "number" ||
+    typeof updatedAtMs !== "number"
+  ) {
+    return undefined;
+  }
+
+  const legacyPiMessages = Array.isArray(parsed.piMessages)
+    ? (parsed.piMessages as PiMessage[])
+    : [];
+  const messageCount =
+    toFiniteNonNegativeNumber(parsed.messageCount) ?? legacyPiMessages.length;
+
+  return {
+    legacyPiMessages,
+    record: {
       checkpointVersion,
       conversationId,
       sessionId,
       sliceId,
       state: status,
       updatedAtMs,
+      messageCount,
       ...(cumulativeDurationMs !== undefined ? { cumulativeDurationMs } : {}),
       ...(cumulativeUsage ? { cumulativeUsage } : {}),
-      piMessages: Array.isArray(parsed.piMessages)
-        ? (parsed.piMessages as PiMessage[])
-        : [],
       ...(Array.isArray(parsed.loadedSkillNames)
         ? {
             loadedSkillNames: parsed.loadedSkillNames.filter(
@@ -137,12 +171,28 @@ function parseAgentTurnSessionCheckpoint(
       ...(typeof parsed.resumedFromSliceId === "number"
         ? { resumedFromSliceId: parsed.resumedFromSliceId }
         : {}),
-    };
-  } catch {
-    return undefined;
-  }
+    },
+  };
 }
 
+function materializePiMessages(
+  legacyPiMessages: PiMessage[],
+  messageCount: number,
+  sessionMessages?: PiMessage[],
+): PiMessage[] | undefined {
+  if (messageCount === 0) {
+    return [];
+  }
+  if (sessionMessages) {
+    return sessionMessages;
+  }
+  if (legacyPiMessages.length >= messageCount) {
+    return legacyPiMessages.slice(0, messageCount);
+  }
+  return undefined;
+}
+
+/** Read a materialized turn-session checkpoint for resume and history loading. */
 export async function getAgentTurnSessionCheckpoint(
   conversationId: string,
   sessionId: string,
@@ -152,9 +202,32 @@ export async function getAgentTurnSessionCheckpoint(
   const value = await stateAdapter.get(
     agentTurnSessionKey(conversationId, sessionId),
   );
-  return parseAgentTurnSessionCheckpoint(value);
+  const parsed = parseAgentTurnSessionRecord(value);
+  if (!parsed) {
+    return undefined;
+  }
+
+  const sessionMessages = await loadPiSessionMessages({
+    conversationId,
+    sessionId,
+    messageCount: parsed.record.messageCount,
+  });
+  const piMessages = materializePiMessages(
+    parsed.legacyPiMessages,
+    parsed.record.messageCount,
+    sessionMessages,
+  );
+  if (!piMessages) {
+    return undefined;
+  }
+
+  return {
+    ...parsed.record,
+    piMessages,
+  };
 }
 
+/** Commit stable Pi session state and advance the turn-session checkpoint cursor. */
 export async function upsertAgentTurnSessionCheckpoint(args: {
   conversationId: string;
   cumulativeDurationMs?: number;
@@ -172,18 +245,27 @@ export async function upsertAgentTurnSessionCheckpoint(args: {
   const stateAdapter = getStateAdapter();
   await stateAdapter.connect();
 
-  const existing = await getAgentTurnSessionCheckpoint(
-    args.conversationId,
-    args.sessionId,
+  const existingValue = await stateAdapter.get(
+    agentTurnSessionKey(args.conversationId, args.sessionId),
   );
-  const checkpoint: AgentTurnSessionCheckpoint = {
-    checkpointVersion: (existing?.checkpointVersion ?? 0) + 1,
+  const existingRecord = parseAgentTurnSessionRecord(existingValue);
+  const ttlMs = Math.max(1, args.ttlMs ?? AGENT_TURN_SESSION_TTL_MS);
+  await commitPiSessionMessages({
+    conversationId: args.conversationId,
+    sessionId: args.sessionId,
+    messages: args.piMessages,
+    ttlMs,
+  });
+  const storedMessageCount = args.piMessages.length;
+
+  const checkpoint: AgentTurnSessionRecord = {
+    checkpointVersion: (existingRecord?.record.checkpointVersion ?? 0) + 1,
     conversationId: args.conversationId,
     sessionId: args.sessionId,
     sliceId: args.sliceId,
     state: args.state,
     updatedAtMs: Date.now(),
-    piMessages: Array.isArray(args.piMessages) ? args.piMessages : [],
+    messageCount: storedMessageCount,
     ...(typeof args.cumulativeDurationMs === "number" &&
     Number.isFinite(args.cumulativeDurationMs)
       ? {
@@ -208,15 +290,18 @@ export async function upsertAgentTurnSessionCheckpoint(args: {
       : {}),
   };
 
-  const ttlMs = Math.max(1, args.ttlMs ?? AGENT_TURN_SESSION_TTL_MS);
   await stateAdapter.set(
     agentTurnSessionKey(args.conversationId, args.sessionId),
-    JSON.stringify(checkpoint),
+    checkpoint,
     ttlMs,
   );
-  return checkpoint;
+  return {
+    ...checkpoint,
+    piMessages: [...args.piMessages],
+  };
 }
 
+/** Mark an unfinished turn-session checkpoint as superseded when a newer turn wins. */
 export async function supersedeAgentTurnSessionCheckpoint(args: {
   conversationId: string;
   sessionId: string;

--- a/packages/junior/src/chat/turn-context-tag.ts
+++ b/packages/junior/src/chat/turn-context-tag.ts
@@ -1,0 +1,6 @@
+/**
+ * Canonical tag name for the runtime turn context block injected into Pi
+ * messages. Shared between prompt assembly and turn context stripping to keep
+ * both in sync without requiring the full prompt module.
+ */
+export const TURN_CONTEXT_TAG = "runtime-turn-context";

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -106,8 +106,6 @@ async function persistCompletedReplyState(
   sessionId: string,
   reply: AssistantReply,
 ): Promise<void> {
-  // OAuth resumes only persist completion after the final visible reply has
-  // already been delivered to Slack.
   const threadId = `slack:${channelId}:${threadTs}`;
   const currentState = await getPersistedThreadState(threadId);
   const conversation = coerceThreadConversationState(currentState);
@@ -115,10 +113,10 @@ async function persistCompletedReplyState(
   const nextArtifacts = reply.artifactStatePatch
     ? mergeArtifactsState(artifacts, reply.artifactStatePatch)
     : undefined;
-  const userMessageId = getTurnUserMessageId(conversation, sessionId);
+  const userMessage = getTurnUserMessage(conversation, sessionId);
   clearPendingAuth(conversation, sessionId);
 
-  markConversationMessage(conversation, userMessageId, {
+  markConversationMessage(conversation, userMessage?.id, {
     replied: true,
     skippedReason: undefined,
   });
@@ -135,10 +133,8 @@ async function persistCompletedReplyState(
       replied: true,
     },
   });
-  if (reply.piMessages) {
-    conversation.piMessages = reply.piMessages;
-  }
   markTurnCompleted({
+    completedSessionId: sessionId,
     conversation,
     nowMs: Date.now(),
     sessionId,

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -134,7 +134,6 @@ async function persistCompletedReplyState(
     },
   });
   markTurnCompleted({
-    completedSessionId: sessionId,
     conversation,
     nowMs: Date.now(),
     sessionId,

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -50,8 +50,10 @@ import { publishAppHomeView } from "@/chat/slack/app-home";
 import { getSlackClient } from "@/chat/slack/client";
 import { getStateAdapter } from "@/chat/state/adapter";
 import { coerceThreadArtifactsState } from "@/chat/state/artifacts";
-import { getAgentTurnSessionCheckpoint } from "@/chat/state/turn-session-store";
-import { supersedeAgentTurnSessionCheckpoint } from "@/chat/state/turn-session-store";
+import {
+  getAgentTurnSessionCheckpoint,
+  supersedeAgentTurnSessionCheckpoint,
+} from "@/chat/state/turn-session-store";
 import {
   applyPendingAuthUpdate,
   clearPendingAuth,
@@ -125,10 +127,8 @@ async function persistCompletedOAuthReplyState(args: {
       replied: true,
     },
   });
-  if (args.reply.piMessages) {
-    conversation.piMessages = args.reply.piMessages;
-  }
   markTurnCompleted({
+    completedSessionId: args.sessionId,
     conversation,
     nowMs: Date.now(),
     sessionId: args.sessionId,

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -128,7 +128,6 @@ async function persistCompletedOAuthReplyState(args: {
     },
   });
   markTurnCompleted({
-    completedSessionId: args.sessionId,
     conversation,
     nowMs: Date.now(),
     sessionId: args.sessionId,

--- a/packages/junior/src/handlers/turn-resume.ts
+++ b/packages/junior/src/handlers/turn-resume.ts
@@ -91,7 +91,6 @@ async function persistCompletedReplyState(args: {
     },
   });
   markTurnCompleted({
-    completedSessionId: args.checkpoint.sessionId,
     conversation,
     nowMs: Date.now(),
     sessionId: args.checkpoint.sessionId,

--- a/packages/junior/src/handlers/turn-resume.ts
+++ b/packages/junior/src/handlers/turn-resume.ts
@@ -59,8 +59,6 @@ async function persistCompletedReplyState(args: {
   checkpoint: AgentTurnSessionCheckpoint;
   reply: AssistantReply;
 }): Promise<void> {
-  // Timeout resumes only persist completion after the final visible reply has
-  // already been delivered to Slack.
   const currentState = await getPersistedThreadState(
     args.checkpoint.conversationId,
   );
@@ -92,10 +90,8 @@ async function persistCompletedReplyState(args: {
       replied: true,
     },
   });
-  if (args.reply.piMessages) {
-    conversation.piMessages = args.reply.piMessages;
-  }
   markTurnCompleted({
+    completedSessionId: args.checkpoint.sessionId,
     conversation,
     nowMs: Date.now(),
     sessionId: args.checkpoint.sessionId,

--- a/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
+++ b/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
@@ -124,10 +124,6 @@ vi.mock("@mariozechner/pi-agent-core", () => {
       this.aborted = true;
     }
 
-    replaceMessages(messages: unknown[]) {
-      this.state.messages = [...messages];
-    }
-
     async prompt(message: unknown) {
       agentProbe.promptCallCount += 1;
       this.aborted = false;

--- a/packages/junior/tests/integration/slack/message-content-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/message-content-behavior.test.ts
@@ -223,10 +223,16 @@ describe("Slack behavior: message content", () => {
 
   it("passes durable Pi history into the next turn", async () => {
     const calls: CapturedCall[] = [];
-    const firstTurnHistory: PiMessage[] = [
+    const storedFirstTurnHistory: PiMessage[] = [
       {
         role: "user",
-        content: [{ type: "text", text: "I need the budget by Friday" }],
+        content: [
+          {
+            type: "text",
+            text: "<runtime-turn-context>\nold runtime facts\n</runtime-turn-context>",
+          },
+          { type: "text", text: "I need the budget by Friday" },
+        ],
         timestamp: 1,
       },
       {
@@ -234,6 +240,14 @@ describe("Slack behavior: message content", () => {
         content: [{ type: "text", text: "First response." }],
         timestamp: 2,
       },
+    ] as PiMessage[];
+    const expectedHistory: PiMessage[] = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "I need the budget by Friday" }],
+        timestamp: 1,
+      },
+      storedFirstTurnHistory[1]!,
     ] as PiMessage[];
 
     const { slackRuntime } = createTestChatRuntime({
@@ -267,7 +281,7 @@ describe("Slack behavior: message content", () => {
                 sessionId: context.correlation.turnId,
                 sliceId: 1,
                 state: "completed",
-                piMessages: firstTurnHistory,
+                piMessages: storedFirstTurnHistory,
               });
             }
             return {
@@ -314,6 +328,6 @@ describe("Slack behavior: message content", () => {
 
     expect(calls).toHaveLength(2);
     expect(calls[1]?.contextConversation ?? "").toContain("budget by Friday");
-    expect(calls[1]?.piMessages).toEqual(firstTurnHistory);
+    expect(calls[1]?.piMessages).toEqual(expectedHistory);
   });
 });

--- a/packages/junior/tests/integration/slack/message-content-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/message-content-behavior.test.ts
@@ -1,4 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import type { PiMessage } from "@/chat/pi/messages";
+import {
+  getPersistedThreadState,
+  persistThreadStateById,
+} from "@/chat/runtime/thread-state";
+import { coerceThreadConversationState } from "@/chat/state/conversation";
+import { disconnectStateAdapter } from "@/chat/state/adapter";
+import { upsertAgentTurnSessionCheckpoint } from "@/chat/state/turn-session-store";
 import { createTestChatRuntime } from "../../fixtures/chat-runtime";
 import {
   createTestMessage,
@@ -7,10 +15,15 @@ import {
 
 interface CapturedCall {
   contextConversation?: string;
+  piMessages?: PiMessage[];
   prompt: string;
 }
 
 describe("Slack behavior: message content", () => {
+  afterEach(async () => {
+    await disconnectStateAdapter();
+  });
+
   it("strips leading Slack mention token before invoking the agent", async () => {
     const calls: CapturedCall[] = [];
 
@@ -210,6 +223,19 @@ describe("Slack behavior: message content", () => {
 
   it("passes durable Pi history into the next turn", async () => {
     const calls: CapturedCall[] = [];
+    const firstTurnHistory: PiMessage[] = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "I need the budget by Friday" }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "First response." }],
+        timestamp: 2,
+      },
+    ] as PiMessage[];
+
     const { slackRuntime } = createTestChatRuntime({
       services: {
         subscribedReplyPolicy: {
@@ -229,7 +255,21 @@ describe("Slack behavior: message content", () => {
             calls.push({
               prompt,
               contextConversation: context?.conversationContext,
+              piMessages: context?.piMessages,
             });
+            if (
+              calls.length === 1 &&
+              context?.correlation?.conversationId &&
+              context.correlation.turnId
+            ) {
+              await upsertAgentTurnSessionCheckpoint({
+                conversationId: context.correlation.conversationId,
+                sessionId: context.correlation.turnId,
+                sliceId: 1,
+                state: "completed",
+                piMessages: firstTurnHistory,
+              });
+            }
             return {
               text: calls.length === 1 ? "First response." : "Second response.",
               diagnostics: {
@@ -264,9 +304,16 @@ describe("Slack behavior: message content", () => {
     });
 
     await slackRuntime.handleNewMention(thread, first);
+
+    const persistedState = await getPersistedThreadState(thread.id);
+    const conversation = coerceThreadConversationState(persistedState);
+    conversation.processing.activeTurnId = "missing-active-turn";
+    await persistThreadStateById(thread.id, { conversation });
+
     await slackRuntime.handleSubscribedMessage(thread, second);
 
     expect(calls).toHaveLength(2);
     expect(calls[1]?.contextConversation ?? "").toContain("budget by Friday");
+    expect(calls[1]?.piMessages).toEqual(firstTurnHistory);
   });
 });

--- a/packages/junior/tests/integration/slack/message-content-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/message-content-behavior.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import type { PiMessage } from "@/chat/pi/messages";
 import { createTestChatRuntime } from "../../fixtures/chat-runtime";
 import {
   createTestMessage,
@@ -8,7 +7,6 @@ import {
 
 interface CapturedCall {
   contextConversation?: string;
-  piMessages?: PiMessage[];
   prompt: string;
 }
 
@@ -212,19 +210,6 @@ describe("Slack behavior: message content", () => {
 
   it("passes durable Pi history into the next turn", async () => {
     const calls: CapturedCall[] = [];
-    const firstTurnHistory: PiMessage[] = [
-      {
-        role: "user",
-        content: [{ type: "text", text: "I need the budget by Friday" }],
-        timestamp: 1,
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "First response." }],
-        timestamp: 2,
-      },
-    ] as PiMessage[];
-
     const { slackRuntime } = createTestChatRuntime({
       services: {
         subscribedReplyPolicy: {
@@ -244,11 +229,9 @@ describe("Slack behavior: message content", () => {
             calls.push({
               prompt,
               contextConversation: context?.conversationContext,
-              piMessages: context?.piMessages,
             });
             return {
               text: calls.length === 1 ? "First response." : "Second response.",
-              piMessages: calls.length === 1 ? firstTurnHistory : undefined,
               diagnostics: {
                 assistantMessageCount: 1,
                 modelId: "fake-agent-model",
@@ -285,6 +268,5 @@ describe("Slack behavior: message content", () => {
 
     expect(calls).toHaveLength(2);
     expect(calls[1]?.contextConversation ?? "").toContain("budget by Friday");
-    expect(calls[1]?.piMessages).toEqual(firstTurnHistory);
   });
 });

--- a/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
@@ -11,7 +11,6 @@ const {
   continueCallCount,
   continueStopsOnAbort,
   deliverPrivateMessageMock,
-  ignoreReplaceMessages,
   listToolsMock,
   loadSkillExecutionErrorCount,
   loadSkillsByNameMock,
@@ -38,7 +37,6 @@ const {
   continueCallCount: { value: 0 },
   continueStopsOnAbort: { value: false },
   deliverPrivateMessageMock: vi.fn(),
-  ignoreReplaceMessages: { value: false },
   listToolsMock: vi.fn(),
   loadSkillExecutionErrorCount: { value: 0 },
   loadSkillsByNameMock: vi.fn(),
@@ -140,13 +138,6 @@ vi.mock("@mariozechner/pi-agent-core", () => {
 
     abort() {
       this.aborted = true;
-    }
-
-    async replaceMessages(messages: unknown[]) {
-      if (ignoreReplaceMessages.value) {
-        return;
-      }
-      this.state.messages = [...messages];
     }
 
     async prompt(message: unknown) {
@@ -567,7 +558,6 @@ describe("generateAssistantReply progressive MCP loading", () => {
     continueCallCount.value = 0;
     continueStopsOnAbort.value = false;
     deliverPrivateMessageMock.mockReset();
-    ignoreReplaceMessages.value = false;
     listToolsMock.mockReset();
     searchMcpToolNames.length = 0;
     loadSkillExecutionErrorCount.value = 0;
@@ -742,7 +732,7 @@ describe("generateAssistantReply progressive MCP loading", () => {
     });
   });
 
-  it("seeds normal turns from persisted Pi history without storing turn context", async () => {
+  it("seeds normal turns from persisted Pi history", async () => {
     listToolsMock.mockReset();
     listToolsMock.mockResolvedValue(makeDemoMcpTools());
     const priorMessages: PiMessage[] = [
@@ -758,7 +748,7 @@ describe("generateAssistantReply progressive MCP loading", () => {
       },
     ] as PiMessage[];
 
-    const reply = await generateAssistantReply("help me", {
+    await generateAssistantReply("help me", {
       ...makeReplyContext({
         conversationId: "conversation-history",
         threadTs: "1712345.0003",
@@ -769,12 +759,6 @@ describe("generateAssistantReply progressive MCP loading", () => {
     });
 
     expect(promptSeedMessages[0]).toEqual(priorMessages);
-    expect(reply.piMessages?.slice(0, 2)).toEqual(priorMessages);
-    expect(JSON.stringify(reply.piMessages)).not.toContain("Turn context");
-    expect(JSON.stringify(reply.piMessages)).not.toContain(
-      "duplicated prior transcript",
-    );
-    expect(JSON.stringify(reply.piMessages)).toContain("help me");
   });
 
   it("parks for auth when MCP auth is requested during a tool call", async () => {
@@ -890,7 +874,6 @@ describe("generateAssistantReply progressive MCP loading", () => {
   });
 
   it("falls back to the latest stored checkpoint when auth pause captures no messages", async () => {
-    ignoreReplaceMessages.value = true;
     continueStopsOnAbort.value = true;
 
     const priorMessages: PiMessage[] = [

--- a/packages/junior/tests/unit/runtime/respond-timeout-resume.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-timeout-resume.test.ts
@@ -39,10 +39,6 @@ vi.mock("@mariozechner/pi-agent-core", () => {
       this.resolveAbort?.();
     }
 
-    async replaceMessages(messages: unknown[]) {
-      this.state.messages = [...messages];
-    }
-
     async continue() {
       this.state.messages.push({
         role: "assistant",

--- a/packages/junior/tests/unit/services/turn-checkpoint.test.ts
+++ b/packages/junior/tests/unit/services/turn-checkpoint.test.ts
@@ -336,4 +336,56 @@ describe("persistAuthPauseCheckpoint", () => {
       piMessages: messages,
     });
   });
+
+  it("branches Pi session state from the recoverable cursor after trimming an unsafe assistant tail", async () => {
+    const { getAgentTurnSessionCheckpoint, upsertAgentTurnSessionCheckpoint } =
+      await import("@/chat/state/turn-session-store");
+    const user: PiMessage = {
+      role: "user",
+      content: [{ type: "text", text: "help me" }],
+      timestamp: 1,
+    };
+    const unsafeAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "not committed" }],
+      timestamp: 2,
+    } as PiMessage;
+    const replacementToolResult = {
+      role: "toolResult",
+      toolCallId: "call-1",
+      toolName: "bash",
+      content: [{ type: "text", text: "safe result" }],
+      timestamp: 3,
+    } as PiMessage;
+
+    await upsertAgentTurnSessionCheckpoint({
+      conversationId: "conversation-branch",
+      sessionId: "turn-branch",
+      sliceId: 1,
+      state: "running",
+      piMessages: [user, unsafeAssistant],
+    });
+    await upsertAgentTurnSessionCheckpoint({
+      conversationId: "conversation-branch",
+      sessionId: "turn-branch",
+      sliceId: 2,
+      state: "awaiting_resume",
+      piMessages: [user],
+      resumeReason: "timeout",
+    });
+    await upsertAgentTurnSessionCheckpoint({
+      conversationId: "conversation-branch",
+      sessionId: "turn-branch",
+      sliceId: 2,
+      state: "running",
+      piMessages: [user, replacementToolResult],
+    });
+
+    await expect(
+      getAgentTurnSessionCheckpoint("conversation-branch", "turn-branch"),
+    ).resolves.toMatchObject({
+      state: "running",
+      piMessages: [user, replacementToolResult],
+    });
+  });
 });

--- a/packages/junior/tests/unit/state/conversation-state.test.ts
+++ b/packages/junior/tests/unit/state/conversation-state.test.ts
@@ -89,6 +89,9 @@ describe("conversation state", () => {
     const conversation = coerceThreadConversationState({
       conversation: {
         messages: [],
+        processing: {
+          lastSessionId: "turn-1",
+        },
         piMessages: [
           {
             role: "user",
@@ -99,6 +102,7 @@ describe("conversation state", () => {
       },
     });
 
+    expect(conversation.processing.lastSessionId).toBe("turn-1");
     expect(conversation.piMessages).toEqual([
       {
         role: "user",

--- a/packages/junior/tests/unit/tools/execution/tool-error-handler.test.ts
+++ b/packages/junior/tests/unit/tools/execution/tool-error-handler.test.ts
@@ -15,6 +15,7 @@ vi.mock("@/chat/logging", () => ({
 
 vi.mock("@/chat/pi/client", () => ({
   GEN_AI_PROVIDER_NAME: "test-provider",
+  resolveGatewayModel: (modelId: string) => modelId,
 }));
 
 import { handleToolExecutionError } from "@/chat/tools/execution/tool-error-handler";

--- a/specs/agent-session-resumability-spec.md
+++ b/specs/agent-session-resumability-spec.md
@@ -16,6 +16,7 @@
 - 2026-05-06: Removed the public Slack auth-pause note; auth pauses complete the live turn after private auth-link delivery.
 - 2026-05-13: Clarified turn continuation as an idempotent checkpoint retry path, including user follow-up rescheduling and bounded lock-busy callback retries.
 - 2026-05-19: Clarified that Slack auth pauses also post a visible URL-free acknowledgement owned by the Slack delivery contract.
+- 2026-05-21: Reframed Pi persistence as an incremental Redis-backed Pi session state store. Checkpoints store metadata and recoverable cursors; materialized `pi_messages` are a read view, not the primary write model.
 
 ## Status
 
@@ -29,7 +30,7 @@ Define how a single assistant turn is split into resumable execution slices so s
 
 - Session/slice lifecycle for one assistant turn.
 - Durable checkpoint schema at safe resume boundaries.
-- Pi replay/continue contract (`replaceMessages` + `continue`) across slices.
+- Pi replay/continue contract (`agent.state.messages = ...` + `continue`) across slices.
 - Signed internal callback contract for timeout continuation.
 - Separation between turn-session checkpoints and durable thread state.
 - Failure recovery and observability requirements.
@@ -61,11 +62,13 @@ A conversation can have multiple sessions over time. Each checkpoint version ide
 
 ### Runtime State Partition
 
-- The turn-session checkpoint store is for Pi transcript state and resume metadata only.
+- The turn-session store is for Pi execution state and resume metadata only.
+- Pi messages are persisted incrementally in the Redis state cache as Pi session message state. Checkpoint metadata stores the recoverable cursor/version, not an independently rewritten transcript blob.
 - Durable thread state is the canonical home for mutable turn-local runtime state that can change mid-slice:
   - artifact state (for example active canvas/list context)
   - sandbox identity and dependency-profile hash
   - conversation/thread state and user/assistant message history
+- Durable thread state may point at the active or last completed agent session. It must not become a second source of truth for mid-turn Pi execution history.
 - Channel configuration is reloaded from the canonical state/configuration services on resume, not copied into the checkpoint payload.
 - Sandbox and artifact state must be persisted eagerly as they change so the next slice can rebuild the same environment without depending on successful turn completion.
 
@@ -74,7 +77,7 @@ A conversation can have multiple sessions over time. Each checkpoint version ide
 - The checkpoint schema supports `running | awaiting_resume | completed | failed | superseded`.
 - The current runtime writes:
   - `awaiting_resume` for timeout/auth safe-boundary checkpoints
-  - `completed` when a turn finishes successfully
+  - `completed` when agent execution finishes successfully
   - `superseded` when a newer thread request replaces an older auth-blocked checkpoint
 - Terminal user-visible failure is currently reflected in conversation/thread state. The timeout-resume implementation does not rely on a `failed` checkpoint write.
 
@@ -94,7 +97,7 @@ A checkpoint is resumable only when all conditions are true:
 
 1. No tool call is currently in flight.
 2. All tool results prior to the boundary are durably recorded.
-3. Pi message history is durably recorded up to the same logical point.
+3. Pi session message state is durably recorded up to the same logical point, and the recoverable cursor points at that boundary.
 4. Side-effect markers/idempotency entries for completed actions are committed.
 
 Forbidden boundary:
@@ -103,13 +106,13 @@ Forbidden boundary:
 
 ### Checkpoint Payload Contract
 
-Each checkpoint must include:
+Each materialized checkpoint read must include:
 
 - `conversation_id`
 - `session_id`
 - `slice_id`
 - `checkpoint_version`
-- `pi_messages`: Canonical message list to replay into Pi.
+- `pi_messages`: Canonical message list to replay into Pi, materialized from Pi session state through the checkpoint cursor.
 - `state`: one of `running|awaiting_resume|completed|failed|superseded`.
 - `updated_at_ms`
 
@@ -120,14 +123,16 @@ Optional checkpoint fields:
 - `resumed_from_slice_id`
 - `error_message`
 
-The checkpoint does not store:
+The checkpoint metadata does not store:
 
 - artifact state
 - sandbox identity
 - channel configuration values
-- a durable tool-call log
+- a second durable tool-call log
 - a separate visible transcript log
 - per-slice deadline metadata
+
+Primary writes persist new stable Pi session messages and then update checkpoint metadata/cursors. Rewriting a whole Pi transcript is a compatibility read shape only.
 
 `inflight_partial` is not part of the checkpoint schema.
 
@@ -138,7 +143,7 @@ For slice `n+1`, runtime must:
 1. Load latest committed checkpoint for `(conversation_id, session_id)`.
 2. Instantiate Pi agent.
 3. Restore any checkpointed dynamic tool state required by the wrapper runtime (for example loaded skills).
-4. Call `replaceMessages(checkpoint.pi_messages)`.
+4. Assign `agent.state.messages = checkpoint.pi_messages`.
 5. Resume generation by calling `continue()` to resume generation/tool loop.
 
 For auth-driven pauses and timeout checkpoints, the checkpoint written at the pause boundary must trim any trailing uncommitted assistant-only messages so the restored Pi history is resumable with `continue()`.
@@ -197,14 +202,14 @@ The callback must:
    - artifact state
    - sandbox identity
    - channel configuration
-7. Restore Pi messages with `replaceMessages(...)` and resume with `continue()`.
+7. Restore Pi messages with `agent.state.messages = ...` and resume with `continue()`.
 8. If the resumed slice times out again before visible output, schedule a new callback carrying the new `checkpoint_version`.
 
 ### Slice Lifecycle
 
 1. User message starts a new `session_id` under `conversation_id`.
 2. Slice `1` runs and eagerly persists sandbox/artifact state as those values change.
-3. If the turn finishes, commit `completed` after the final delivery contract has succeeded.
+3. If agent execution finishes, commit `completed`; thread state only points at that session after the final delivery contract has succeeded.
 4. If MCP auth pauses at a safe boundary, commit `awaiting_resume` with `resume_reason=auth`; the OAuth callback later consults thread-local pending-auth state before resuming.
 5. If timeout is reached before any assistant text is visible, commit `awaiting_resume` with `resume_reason=timeout` and schedule the signed internal timeout-resume callback.
 6. The timeout-resume handler validates `expected_checkpoint_version`, rebuilds durable runtime state, restores Pi messages, and calls `continue()`.
@@ -214,12 +219,13 @@ The callback must:
 
 ## Failure Model
 
-1. Timeout or crash before checkpoint commit: no new boundary exists; the system can only rely on whatever thread state had already been eagerly persisted.
+1. Timeout or crash before a stable Pi session message/cursor commit: no new boundary exists; the system can rely on the previous cursor plus whatever thread state had already been eagerly persisted.
 2. Checkpoint commit succeeds but the timeout-resume callback is never sent or delivered: there is no sweeper today; continuation requires another explicit callback, a later user follow-up that reschedules the existing checkpoint, or operator intervention.
 3. Stale timeout-resume callbacks with an older `expected_checkpoint_version` are dropped without doing work.
 4. Duplicate concurrent callbacks for the same thread are serialized by the shared per-thread state-adapter lock. Lock-busy callbacks retry for a short bounded window, but there is no durable delayed retry queue after that window is exhausted.
 5. Timeout after visible assistant output begins: automatic continuation is skipped to avoid duplicate/corrupt user-visible output.
 6. Repeated resumed timeouts before visible output may produce further `awaiting_resume` checkpoints with incremented `slice_id` and `checkpoint_version`.
+7. A later user message after an ungraceful crash may build its prompt history from the active session's latest recoverable Pi session cursor. If the prior session produced assistant text that was not committed to visible thread state, that trailing assistant text must be trimmed from the fresh-turn history view.
 
 ## Observability
 
@@ -255,13 +261,14 @@ Required attributes when available:
 
 1. Unit: timeout checkpoints trim trailing assistant-only messages and increment `slice_id`/`checkpoint_version`.
 2. Unit: signed timeout-resume callbacks verify successfully and tampered payloads are rejected.
-3. Unit/integration: a timed-out turn resumes with `replaceMessages` + `continue` and reaches a successful terminal reply when no assistant text had been made visible.
+3. Unit/integration: a timed-out turn resumes with restored `agent.state.messages` + `continue` and reaches a successful terminal reply when no assistant text had been made visible.
 4. Unit/integration: a resumed timeout slice can time out again and schedule the next callback with the new `checkpoint_version`.
 5. Unit/integration: a lock-busy timeout callback retries before giving up.
 6. Integration: a user follow-up or duplicate delivery during an awaiting automatic continuation checkpoint reschedules the existing session instead of starting a new turn.
 7. Unit/integration: auth-driven resume restores the same active skill/MCP tool universe before `continue()`.
 8. Unit/integration: eager sandbox/artifact persistence preserves resumed tool context across slices.
-9. Manual/eval: once assistant text is already visible, timeout does not auto-resume or attempt to reconcile partial thread output.
+9. Unit/integration: fresh follow-up turns can recover Pi history from active/last Pi session state without depending on conversation-state Pi transcript mirroring.
+10. Manual/eval: once assistant text is already visible, timeout does not auto-resume or attempt to reconcile partial thread output.
 
 ## Related Specs
 

--- a/specs/chat-architecture-spec.md
+++ b/specs/chat-architecture-spec.md
@@ -17,6 +17,7 @@
 - 2026-05-09: Added the enforced service-to-Slack boundary: domain services depend on injected Slack-backed ports instead of Slack infrastructure modules.
 - 2026-05-10: Added the enforced Slack-to-runtime boundary and moved resumed Slack turn orchestration under `runtime/`.
 - 2026-05-13: Added the agent turn data-flow diagram, data ownership table, and spec ownership boundaries for continuation recovery.
+- 2026-05-21: Clarified that Pi execution history is sourced from Redis-backed Pi session state, while thread state stores visible transcript plus session pointers.
 
 ## Status
 
@@ -105,17 +106,18 @@ Normative rules:
 
 Data authority by stage:
 
-| Data                                     | Authority                                          | Notes                                                                                                     |
-| ---------------------------------------- | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| Slack event shape                        | `ingress/` and Slack adapter payloads              | Normalize IDs and attachments before runtime; do not infer behavior here.                                 |
-| Queue ordering and duplicate suppression | Chat SDK state adapter lock/queue                  | Prevent concurrent handler execution, but do not rely on queue memory for turn recovery.                  |
-| Conversation transcript                  | Persisted thread state                             | Source for future prompt context; assistant messages are added only after final Slack delivery.           |
-| Active turn identity                     | `conversation.processing.activeTurnId`             | Points to the turn session that owns the thread until completion, auth handoff, failure, or supersession. |
-| Pi execution transcript                  | Turn-session checkpoint store                      | Stores resumable Pi messages at safe boundaries; not a replacement for visible Slack transcript.          |
-| Sandbox/artifact state                   | Persisted thread state                             | Persist eagerly as it changes so a resumed slice can rebuild the same runtime world.                      |
-| Pending auth                             | Thread-local processing state plus auth checkpoint | Auth pauses end the live turn after private link delivery and are resumed by callback.                    |
-| Final Slack reply                        | Slack thread post acceptance                       | Completion is persisted only after Slack accepts the final visible reply.                                 |
-| Continuation acknowledgement             | Slack thread post                                  | User-facing status only; does not complete the turn.                                                      |
+| Data                                     | Authority                                          | Notes                                                                                                            |
+| ---------------------------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Slack event shape                        | `ingress/` and Slack adapter payloads              | Normalize IDs and attachments before runtime; do not infer behavior here.                                        |
+| Queue ordering and duplicate suppression | Chat SDK state adapter lock/queue                  | Prevent concurrent handler execution, but do not rely on queue memory for turn recovery.                         |
+| Conversation transcript                  | Persisted thread state                             | Source for visible user/assistant thread history; assistant messages are added only after final Slack delivery.  |
+| Active turn identity                     | `conversation.processing.activeTurnId`             | Points to the turn session that owns the thread until completion, auth handoff, failure, or supersession.        |
+| Last completed session identity          | `conversation.processing.lastSessionId`            | Points fresh turns at the latest completed Pi session when available.                                            |
+| Pi execution transcript                  | Pi session state in the state cache                | Stores stable Pi messages incrementally plus checkpoint cursors; not a replacement for visible Slack transcript. |
+| Sandbox/artifact state                   | Persisted thread state                             | Persist eagerly as it changes so a resumed slice can rebuild the same runtime world.                             |
+| Pending auth                             | Thread-local processing state plus auth checkpoint | Auth pauses end the live turn after private link delivery and are resumed by callback.                           |
+| Final Slack reply                        | Slack thread post acceptance                       | Completion is persisted only after Slack accepts the final visible reply.                                        |
+| Continuation acknowledgement             | Slack thread post                                  | User-facing status only; does not complete the turn.                                                             |
 
 Related contract ownership:
 
@@ -273,8 +275,8 @@ Turn continuation recovery covers any case where Junior has a durable safe resum
 
 Rules:
 
-1. Recovery continues the existing session from durable thread state plus the latest safe checkpoint. It must not start a second active turn for a thread with an awaiting continuation checkpoint.
-2. Chat SDK retry, dedupe, queueing, and per-thread locking protect inbound delivery. They do not replace session continuation because they do not carry Pi transcript state, sandbox/artifact state, pending auth, or final Slack delivery state.
+1. Recovery continues the existing session from durable thread state plus the latest safe agent-session cursor. It must not start a second active turn for a thread with an awaiting continuation checkpoint.
+2. Chat SDK retry, dedupe, queueing, and per-thread locking protect inbound delivery. They do not replace session continuation because they do not carry Pi session state, sandbox/artifact state, pending auth, or final Slack delivery state.
 3. `respond.ts` creates safe checkpoints; `runtime/reply-executor.ts` schedules or reschedules continuation; `handlers/turn-resume.ts` validates callback version and lock ownership; `runtime/slack-resume.ts` reuses the normal final-delivery path.
 4. Continuation acknowledgements are Slack UX only. They do not complete the turn and are not a recovery mechanism.
 5. Lock-busy callback retry is bounded. There is no durable sweeper or delayed retry queue today, so a lost callback after retry exhaustion requires another callback, a later user follow-up that reschedules the checkpoint, or operator intervention.


### PR DESCRIPTION
Pi execution history now persists through session-scoped state cache slots instead of mirrored conversation-state transcripts. Turn checkpoints store metadata and a recoverable cursor, and fresh turns load from active or last completed sessions when available.

**Session State Cursor**

Pi messages are written before checkpoint metadata advances. Redis can contain partial future writes after a crash, but readers only trust the metadata cursor.

**Runtime Recovery**

Fresh follow-ups recover from active crashed sessions with trailing assistant output trimmed, and only use `lastSessionId` when the checkpoint is completed. Final Slack delivery updates the lightweight thread pointer; Pi completion remains owned by agent execution.

**Surface Cleanup**

Delivery code no longer receives or saves `AssistantReply.piMessages`, and tests now use the actual Pi Agent `agent.state.messages = ...` API instead of a fake `replaceMessages` method.