### PR TITLE
docs: Migrate docs to Sentry Starlight theme

### DIFF
--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -1,5 +1,8 @@
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
+import sentryStarlightTheme, {
+  monochromeCodeTheme,
+} from "@sentry/starlight-theme";
 import starlightTypedoc from "starlight-typedoc";
 
 const juniorEntryPoints = [
@@ -44,9 +47,6 @@ export default defineConfig({
           href: "https://github.com/getsentry/junior",
         },
       ],
-      components: {
-        ThemeSelect: "./src/components/ThemeSelect.astro",
-      },
       sidebar: [
         {
           label: "Start Here",
@@ -140,6 +140,7 @@ export default defineConfig({
         },
       ],
       plugins: [
+        sentryStarlightTheme(),
         starlightTypedoc({
           entryPoints: juniorEntryPoints,
           tsconfig: "../junior/tsconfig.build.json",
@@ -158,4 +159,9 @@ export default defineConfig({
       ],
     }),
   ],
+  markdown: {
+    shikiConfig: {
+      theme: monochromeCodeTheme,
+    },
+  },
 });

--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -3,6 +3,7 @@ import starlight from "@astrojs/starlight";
 import sentryStarlightTheme, {
   monochromeCodeTheme,
 } from "@sentry/starlight-theme";
+import { sentryAgentMarkdown } from "@sentry/starlight-theme/agent-markdown";
 import starlightTypedoc from "starlight-typedoc";
 
 const juniorEntryPoints = [
@@ -141,6 +142,7 @@ export default defineConfig({
       ],
       plugins: [
         sentryStarlightTheme(),
+        sentryAgentMarkdown(),
         starlightTypedoc({
           entryPoints: juniorEntryPoints,
           tsconfig: "../junior/tsconfig.build.json",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@astrojs/check": "^0.9.9",
     "@astrojs/starlight": "^0.39.2",
-    "@sentry/starlight-theme": "^0.3.0",
+    "@sentry/starlight-theme": "^0.6.0",
     "astro": "^6.3.7",
     "starlight-typedoc": "^0.23.0",
     "typedoc": "^0.28.19",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -11,11 +11,10 @@
   },
   "dependencies": {
     "@astrojs/check": "^0.9.9",
-    "@astrojs/starlight": "^0.37.7",
-    "@fontsource-variable/space-grotesk": "^5.2.10",
-    "@fontsource/ibm-plex-mono": "^5.2.7",
-    "astro": "^5.18.1",
-    "starlight-typedoc": "^0.21.5",
+    "@astrojs/starlight": "^0.39.2",
+    "@sentry/starlight-theme": "^0.3.0",
+    "astro": "^6.3.7",
+    "starlight-typedoc": "^0.23.0",
     "typedoc": "^0.28.19",
     "typedoc-plugin-markdown": "^4.11.0",
     "typescript": "^5.9.3"

--- a/packages/docs/src/components/ThemeSelect.astro
+++ b/packages/docs/src/components/ThemeSelect.astro
@@ -1,3 +1,0 @@
----
-// Intentionally empty: docs theme is locked to a dark visual system.
----

--- a/packages/docs/src/styles/custom.css
+++ b/packages/docs/src/styles/custom.css
@@ -1,2073 +1,289 @@
-/* ============================================================
-   IMPORTS
-   ============================================================ */
-@import '@fontsource-variable/space-grotesk';
-@import '@fontsource/ibm-plex-mono/400.css';
-@import '@fontsource/ibm-plex-mono/600.css';
-@import url('https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600;700&display=swap');
-
-/* ============================================================
-   DESIGN TOKENS
-   ============================================================ */
-:root,
-:root[data-theme='light'],
-:root[data-theme='dark'] {
-  /* Lime accent — used sparingly: active sidebar, CTA buttons, focus ring */
-  --jr-lime:          #39ff14;
-  --jr-lime-dim:      rgba(57, 255, 20, 0.15);
-  --jr-lime-border:   rgba(57, 255, 20, 0.4);
-
-  /* Backgrounds */
-  --jr-bg:            #000000;
-  --jr-bg-raised:     #0a0a0a;
-  --jr-bg-elevated:   #141414;
-
-  /* Text */
-  --jr-text:          #f5f5f5;
-  --jr-text-dim:      #a8a8a8;
-  --jr-text-muted:    #606060;
-
-  /* Borders */
-  --jr-border:        rgba(255, 255, 255, 0.1);
-  --jr-border-strong: rgba(255, 255, 255, 0.2);
-
-  /* Shape */
-  --jr-radius:        6px;
-  --jr-radius-lg:     10px;
-
-  /* Fonts */
-  --jr-font-heading:  'Space Grotesk Variable', 'Space Grotesk', 'Avenir Next', system-ui, sans-serif;
-  --jr-font:          'Sora', 'Avenir Next', system-ui, sans-serif;
-  --jr-font-mono:     'IBM Plex Mono', 'SFMono-Regular', ui-monospace, monospace;
-
-  /* ============================================================
-     STARLIGHT VARIABLE MAPPING
-     ============================================================ */
-  --sl-color-accent-low:  #1a3b0a;
-  --sl-color-accent:      var(--jr-lime);
-  --sl-color-accent-high: #eeffc2;
-
-  --sl-color-white: #f8f8f8;
-  --sl-color-gray-1: #f2f2f2;
-  --sl-color-gray-2: #d3d3d3;
-  --sl-color-gray-3: #aaaaaa;
-  --sl-color-gray-4: #7f7f7f;
-  --sl-color-gray-5: #444444;
-  --sl-color-gray-6: #1b1b1b;
-  --sl-color-black: #090909;
-
-  --sl-color-bg: var(--jr-bg);
-  --sl-color-bg-nav: var(--jr-bg);
-  --sl-color-bg-sidebar: var(--jr-bg);
-  --sl-color-bg-inline-code: var(--jr-bg-elevated);
-  --sl-sidebar-width: 16.75rem;
-  --sl-sidebar-pad-x: 0.9rem;
-
-  --sl-font: var(--jr-font);
-  --sl-font-mono: var(--jr-font-mono);
-
-  /* Legacy aliases (used in ash-home/chat components) */
-  --ash-ink: #f8f8f8;
-  --ash-paper: #080808;
-  --ash-lime: var(--jr-lime);
-  --ash-lime-dark: var(--jr-lime);
-  --ash-line: rgba(245, 245, 245, 0.22);
-  --ash-dark-border: rgba(255, 255, 255, 0.1);
-  --ash-dark-shadow: rgba(180, 180, 180, 0.22);
-  --ash-section-gap: 4.5rem;
-
-  color-scheme: light;
-}
-
-html,
-body {
-  min-height: 100%;
-}
-
-body {
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-  background: #000000;
-  color: #f2f2f2;
-}
-
-
-body::before {
-  content: '';
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  z-index: 1000;
-  opacity: 0.035;
-  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='220' height='220' viewBox='0 0 220 220'%3E%3Cg fill='%23000000'%3E%3Ccircle cx='24' cy='26' r='1'/%3E%3Ccircle cx='84' cy='52' r='1'/%3E%3Ccircle cx='161' cy='90' r='1.2'/%3E%3Ccircle cx='66' cy='154' r='1'/%3E%3Ccircle cx='190' cy='170' r='1'/%3E%3C/g%3E%3C/svg%3E");
-}
-
-header.header {
-  background: rgba(0, 0, 0, 0.88) !important;
-  backdrop-filter: saturate(180%) blur(20px);
-  -webkit-backdrop-filter: saturate(180%) blur(20px);
-  border-bottom: 1px solid var(--jr-border) !important;
-  border-right: 0 !important;
-  border-inline-end: 0 !important;
-  box-shadow: none;
-}
-
-header.header > .header,
-header.header > .header > .sl-flex,
-header.header .title-wrapper,
-header.header .right-group {
-  align-items: center !important;
-}
-
-header.header > .header {
-  min-height: 100%;
-}
-
-header.header::before,
-header.header::after {
-  border-right: 0 !important;
-  border-inline-end: 0 !important;
-}
-
-header.header .right-group,
-header.header .social-icons,
-header.header .social-icons::after {
-  border-right: 0 !important;
-  border-inline-end: 0 !important;
-}
-
-header.header .social-icons::after {
-  content: none !important;
-  display: none !important;
-}
-
-/* Header search should look like the same hard-edged UI language */
-header.header :is(
-  .site-search,
-  .search,
-  .search-field,
-  .starlight-search,
-  [data-pagefind-ui]
-) {
-  border-radius: var(--jr-radius) !important;
-}
-
-@media (min-width: 50rem) {
-  header.header .site-title {
-    margin-right: auto !important;
-  }
-
-  header.header > .header > .sl-flex:nth-child(2) {
-    width: 100%;
-    display: flex;
-    justify-content: flex-end;
-  }
-
-  header.header > .header > .sl-flex:nth-child(2) site-search {
-    width: min(100%, 26rem);
-    margin-left: auto !important;
-  }
-
-  header.header :is(
-    .site-search,
-    .search,
-    .search-field,
-    .starlight-search,
-    [data-pagefind-ui]
-  ) {
-    margin-left: auto !important;
-  }
-}
-
-header.header site-search > button[data-open-modal] {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.55rem;
-  height: 2.4rem;
-  padding: 0 0.75rem;
-  background: rgba(255, 255, 255, 0.06) !important;
-  color: var(--jr-text-dim) !important;
-  border: 1px solid var(--jr-border) !important;
-  border-radius: var(--jr-radius) !important;
-  box-shadow: none;
-  font-family: var(--jr-font) !important;
-  font-weight: 500 !important;
-  min-height: 2.4rem;
-  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease !important;
-}
-
-header.header site-search > button[data-open-modal]:hover {
-  background: rgba(255, 255, 255, 0.1) !important;
-  border-color: var(--jr-border-strong) !important;
-  color: var(--jr-text) !important;
-}
-
-header.header site-search > button[data-open-modal] kbd {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  padding: 0;
-  background: transparent !important;
-  border: 0 !important;
-  box-shadow: none !important;
-}
-
-header.header site-search > button[data-open-modal] kbd kbd {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 1.35rem;
-  height: 1.35rem;
-  padding: 0 0.32rem;
-  background: rgba(255, 255, 255, 0.08) !important;
-  border: 1px solid var(--jr-border-strong) !important;
-  color: var(--jr-text-dim) !important;
-  border-radius: 3px !important;
-  line-height: 1;
-  font-size: 0.72rem;
-  font-weight: 600;
-}
-
-header.header site-search > button[data-open-modal] svg {
-  flex: 0 0 auto;
-}
-
-header.header .social-icons {
-  margin-inline-end: 0 !important;
-  padding-block: 0 !important;
-  gap: 0.4rem;
-  height: 2.6rem;
-  align-items: center !important;
-}
-
-header.header .social-icons a {
-  display: inline-flex !important;
-  align-items: center !important;
-  justify-content: center !important;
-  width: 2.6rem;
-  height: 2.6rem;
-  padding: 0 !important;
-  background: transparent !important;
-  border: 0 !important;
-  box-shadow: none !important;
-  color: #f3f3f3 !important;
-}
-
-header.header .social-icons a:hover {
-  color: #ffffff !important;
-}
-
-header.header .social-icons svg {
-  color: currentColor !important;
-  fill: currentColor !important;
-}
-
-header.header :is(
-  input[type='search'],
-  .search-input,
-  .site-search input,
-  .starlight-search input,
-  [aria-label='Search']
-) {
-  background: rgba(255, 255, 255, 0.05) !important;
-  color: var(--jr-text) !important;
-  border: 1px solid var(--jr-border) !important;
-  border-radius: var(--jr-radius) !important;
-  box-shadow: none;
-  font-weight: 500;
-}
-
-header.header :is(
-  input[type='search'],
-  .search-input,
-  .site-search input,
-  .starlight-search input,
-  [aria-label='Search']
-)::placeholder {
-  color: #adadad !important;
-  opacity: 1;
+:root {
+  --jr-accent: #39ff14;
+  --jr-accent-soft: rgba(57, 255, 20, 0.16);
+  --jr-accent-line: rgba(57, 255, 20, 0.34);
+  --jr-slack-bg: #1a1d21;
+  --jr-slack-line: rgba(255, 255, 255, 0.09);
+  --jr-radius: 8px;
 }
 
 .site-title {
-  font-family: var(--jr-font-heading);
-  font-size: 1.25rem !important;
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  color: #ffffff !important;
-  display: flex !important;
   align-items: center;
-  gap: 0.5rem;
+  display: inline-flex;
+  gap: 0.55rem;
 }
 
 .site-title::before {
-  content: '';
+  aspect-ratio: 1;
+  background: url("/junior-mark.svg") center / contain no-repeat;
+  content: "";
   display: inline-block;
-  width: 36px;
-  height: 36px;
-  background: url('/junior-mark.svg') no-repeat center;
-  background-size: contain;
+  flex: 0 0 auto;
+  width: 2rem;
 }
 
-.site-title > span[translate='no'] {
-  display: none;
+:root:not([data-has-sidebar]) .hero :is(h1, [data-page-title]) {
+  max-width: 46rem;
 }
 
-main,
-main p,
-main li,
-main td {
-  color: #f2f2f2;
-}
-
-main p,
-main li,
-main td,
-main th {
-  line-height: 1.65;
-}
-
-h1,
-.hero .title {
-  font-family: var(--jr-font-heading);
-  letter-spacing: -0.02em;
-  color: var(--ash-ink);
-}
-
-h1 {
-  font-size: clamp(2.05rem, 5.2vw, 3.15rem);
-  font-weight: 700;
-  line-height: 1.15;
-}
-
-h2 {
-  font-family: var(--jr-font-heading);
-  font-size: clamp(1.35rem, 2.6vw, 1.75rem);
-  line-height: 1.25;
-  letter-spacing: -0.02em;
-  font-weight: 600;
-  color: var(--ash-ink);
-  padding-bottom: 0.5rem;
-  border-bottom: 1px solid var(--jr-border);
-}
-
-h3,
-h4,
-h5,
-h6 {
-  font-family: var(--jr-font-heading);
-  line-height: 1.3;
-  letter-spacing: -0.01em;
-  color: var(--ash-ink);
-}
-
-h3 {
-  font-size: clamp(1.1rem, 2vw, 1.3rem);
-  font-weight: 600;
-}
-
-h4 {
-  font-size: clamp(1rem, 1.6vw, 1.1rem);
-  font-weight: 600;
-}
-
-h5,
-h6 {
-  font-size: 1rem;
-  font-weight: 600;
-}
-
-a:not([class]) {
-  color: var(--jr-text-dim);
-  font-weight: 500;
-  text-underline-offset: 0.16em;
-  text-decoration-thickness: 1px;
-  transition: color 0.15s ease;
-}
-
-a:not([class]):hover {
-  color: var(--jr-text);
-}
-
-.sl-link-button {
-  border-radius: var(--jr-radius) !important;
-  font-weight: 700 !important;
-  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease !important;
-}
-
-.sl-link-button[data-variant='primary'] {
-  background: var(--jr-lime) !important;
-  color: #1b1b1b !important;
-  border: 1px solid transparent !important;
-  box-shadow: none;
-}
-
-.sl-link-button[data-variant='primary']:hover {
-  background: #57ff35 !important;
-}
-
-.sl-link-button[data-variant='secondary'] {
-  background: var(--jr-bg-elevated) !important;
-  color: #f4f4f4 !important;
-  border: 1px solid var(--jr-border-strong) !important;
-  box-shadow: none;
-}
-
-.sl-link-button[data-variant='secondary']:hover {
-  border-color: var(--jr-border-strong) !important;
-  background: #1e1e1e !important;
-}
-
-nav.sidebar {
-  border-inline-end: 1px solid var(--jr-border);
-  background: #000000;
-}
-
-#starlight__sidebar,
-.sidebar-pane,
-.sidebar-content,
-.main-frame,
-.main-pane,
-.content-panel,
-main {
-  background: #000000 !important;
-}
-
-nav.sidebar a {
-  border-radius: 4px !important;
-  font-family: var(--jr-font);
-  font-weight: 500;
-  font-size: 0.92rem;
-  line-height: 1.35;
-  color: #a0a0a0 !important;
-  transition: color 0.15s ease !important;
-}
-
-nav.sidebar a:hover {
-  background: transparent !important;
-  color: #e0e0e0 !important;
-}
-
-nav.sidebar a[aria-current='page'],
-nav.sidebar a[aria-current='page']:hover {
-  background: transparent !important;
-  color: #ffffff !important;
-  box-shadow: none;
-  font-weight: 600;
-  border-left: 2px solid var(--jr-lime) !important;
-  padding-left: calc(var(--sl-sidebar-pad-x) - 2px) !important;
-}
-
-.sidebar-content summary,
-.sidebar-content .large {
-  font-family: var(--jr-font);
-  letter-spacing: 0.05em;
-  font-size: 0.72rem !important;
-  font-weight: 600;
-  text-transform: uppercase;
-  color: #666666 !important;
-}
-
-starlight-toc {
-  border-inline-start: 1px solid var(--jr-border) !important;
-}
-
-starlight-toc a {
-  transition: color 0.15s ease !important;
-}
-
-starlight-toc a[aria-current='true'] {
-  color: var(--jr-lime) !important;
-  font-weight: 600;
-}
-
-starlight-toc a:hover {
-  color: var(--jr-text) !important;
-}
-
-.sl-anchor-link {
-  margin-inline-start: 0.4em;
-}
-
-.card {
-  background: var(--jr-bg-elevated) !important;
-  border: 1px solid var(--jr-border) !important;
-  border-radius: var(--jr-radius) !important;
-  box-shadow: none;
-  transition: border-color 0.15s ease !important;
-}
-
-.card:hover {
-  border-color: var(--jr-border-strong) !important;
-}
-
-.card .title {
-  font-family: var(--jr-font-heading);
-  letter-spacing: -0.01em;
-  font-weight: 600;
-  color: var(--ash-ink) !important;
-}
-
-.card .icon {
-  color: var(--jr-text-dim) !important;
-}
-
-table {
-  border: 1px solid var(--jr-border);
-  border-radius: var(--jr-radius);
-  overflow: hidden;
-  width: 100%;
-  border-collapse: separate;
-  border-spacing: 0;
-  table-layout: auto;
-  background: var(--jr-bg-raised);
-  box-shadow: none;
-}
-
-.sl-markdown-content table {
-  display: table !important;
-  width: 100% !important;
-  max-width: 100% !important;
-}
-
-.sl-markdown-content thead {
-  display: table-header-group !important;
-}
-
-.sl-markdown-content tbody {
-  display: table-row-group !important;
-}
-
-.sl-markdown-content tr {
-  display: table-row !important;
-  width: 100% !important;
-}
-
-th {
-  background: var(--jr-bg-raised) !important;
-  color: #f5f5f5 !important;
-  font-family: var(--jr-font);
-  font-weight: 700;
-  font-size: 0.84rem;
-  letter-spacing: 0.01em;
-  text-align: left;
-  padding: 0.78rem 0.92rem !important;
-  vertical-align: top;
-  border-bottom: 1px solid var(--jr-border) !important;
-}
-
-td,
-th {
-  border-color: var(--jr-border) !important;
-  border-right: 1px solid var(--jr-border) !important;
-}
-
-td:last-child,
-th:last-child {
-  border-right: 0 !important;
-}
-
-td {
-  display: table-cell !important;
-  padding: 0.78rem 0.92rem !important;
-  vertical-align: top;
-  color: #ececec;
-  border-top: 1px solid var(--jr-border) !important;
-}
-
-.sl-markdown-content tbody tr:nth-child(even) {
-  background: #080808;
-}
-
-.sl-markdown-content tbody tr:hover {
-  background: rgba(255, 255, 255, 0.03);
-}
-
-.sl-markdown-content td code {
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid var(--jr-border);
-  color: #e5e5e5;
-  font-size: 0.87em;
-  border-radius: 4px;
-}
-
-/* CLI option list (help-style) */
-.ash-help-list {
-  border: 1px solid var(--jr-border);
-  border-radius: var(--jr-radius);
-  background: var(--jr-bg-raised) !important;
-  padding: 0.35rem 0.52rem;
-  margin: 0;
-  box-shadow: none;
-}
-
-.ash-help-row {
+:root:not([data-has-sidebar])
+  .hero
+  :is(h1, [data-page-title])
+  .jr-home-mega-inline {
   display: block;
-  padding: 0.34rem 0.14rem;
+  font-size: 4.8rem;
+  font-weight: 700;
+  line-height: 0.95;
+  margin-bottom: 0.25rem;
 }
 
-.ash-help-row dt,
-.ash-help-row dd {
-  margin: 0;
-}
-
-.ash-help-flag {
+:root:not([data-has-sidebar])
+  .hero
+  :is(h1, [data-page-title])
+  .jr-home-headline {
   display: block;
-  margin: 0;
-  padding: 0.02rem 0;
-  color: #f9f9f9;
-  font-family: var(--sl-font-mono);
-  font-weight: 800;
-  background: transparent !important;
-  border: 0 !important;
-  box-shadow: none;
-  white-space: nowrap;
-  overflow-x: auto;
 }
 
-.ash-help-desc {
-  margin: 0.16rem 0 0;
-  padding-left: 1.1rem;
-  color: #e6e6e6;
-  line-height: 1.45;
+:root:not([data-has-sidebar]) .jr-highlight {
+  color: var(--ve-text);
+  display: inline;
+  position: relative;
+  z-index: 0;
 }
 
-.ash-help-default {
-  font-family: var(--sl-font-mono);
-  font-size: 0.84em;
-  color: #a0a0a0;
-  font-weight: 600;
+:root:not([data-has-sidebar]) .jr-highlight::before {
+  background: var(--ve-heading-accent);
+  bottom: 0.06em;
+  content: "";
+  height: 0.42em;
+  left: -0.08em;
+  pointer-events: none;
+  position: absolute;
+  right: -0.08em;
+  transform: rotate(-3deg);
+  z-index: -1;
 }
 
-starlight-aside {
-  border-width: 1px;
-  border-left-width: 2px;
-  border-radius: var(--jr-radius) !important;
-  background: var(--jr-bg-elevated) !important;
+.jr-home {
+  margin-top: 2rem;
 }
-
-/* Note aside */
-starlight-aside[type='note'],
-starlight-aside[data-type='note'],
-.starlight-aside--note {
-  background: var(--jr-bg-elevated) !important;
-  border: 1px solid var(--jr-border) !important;
-  border-left: 2px solid var(--jr-lime) !important;
-  border-radius: var(--jr-radius) !important;
-  box-shadow: none;
-}
-
-starlight-aside[type='note'] .title,
-starlight-aside[data-type='note'] .title,
-.starlight-aside--note .title {
-  display: inline-block;
-  margin-bottom: 0.35rem;
-  padding: 0;
-  background: transparent;
-  border: 0;
-  color: var(--jr-text) !important;
-  font-family: var(--jr-font-heading);
-  font-weight: 600;
-  font-size: 0.85rem;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
-}
-
-starlight-aside[type='note'],
-starlight-aside[data-type='note'],
-.starlight-aside--note,
-starlight-aside[type='note'] :is(p, li, a, strong, em),
-starlight-aside[data-type='note'] :is(p, li, a, strong, em),
-.starlight-aside--note :is(p, li, a, strong, em) {
-  color: #f3f3f3 !important;
-}
-
-starlight-aside[type='note'] :is(.icon, [slot='icon'], svg),
-starlight-aside[data-type='note'] :is(.icon, [slot='icon'], svg),
-.starlight-aside--note :is(.icon, [slot='icon'], svg) {
-  color: var(--jr-lime) !important;
-  fill: var(--jr-lime) !important;
-  stroke: var(--jr-lime) !important;
-}
-
-/* ============================================================
-   SLACK MOCK — Homepage demo thread (dark theme)
-   Palette matches Slack's dark color scheme.
-   ============================================================ */
 
 .slk-window {
-  margin-top: 2rem;
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: var(--jr-radius-lg);
-  background: #1a1d21;
-  overflow: hidden;
-  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.04), 0 24px 48px -12px rgba(0, 0, 0, 0.7);
-  font-size: 0.9375rem; /* 15px — Slack's body size */
+  background: var(--jr-slack-bg);
+  border: 1px solid var(--ve-line-soft);
+  border-radius: var(--jr-radius);
+  box-shadow: 0 24px 48px -16px rgba(0, 0, 0, 0.68);
+  color: #c9cdd1;
+  font-size: 0.9375rem;
   line-height: 1.46668;
+  margin-top: 0;
+  overflow: hidden;
 }
 
-/* Thread header */
 .slk-header {
-  display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 0.7rem 1rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.09);
+  background: var(--jr-slack-bg);
+  border-bottom: 1px solid var(--jr-slack-line);
+  display: flex;
   gap: 0.5rem;
-  background: #1a1d21;
+  justify-content: space-between;
+  margin: 0;
+  padding: 0.7rem 1rem;
 }
 
 .slk-header-left {
-  display: flex;
   align-items: center;
+  display: flex;
   gap: 0.4rem;
+  margin: 0;
 }
 
 .slk-thread-icon {
-  width: 1rem;
-  height: 1rem;
   color: #c9cdd1;
   flex: 0 0 auto;
+  height: 1rem;
+  width: 1rem;
 }
 
 .slk-header-title {
-  font-weight: 700;
-  font-size: 0.9375rem;
   color: #d9d9d9;
+  font-size: 0.9375rem;
+  font-weight: 700;
 }
 
 .slk-header-channel {
-  font-size: 0.8125rem;
   color: #848d97;
+  font-size: 0.8125rem;
 }
 
-/* Message list */
 .slk-messages {
-  padding: 0.5rem 0 0.5rem;
+  margin: 0;
+  padding: 0.5rem 0;
 }
 
-/* Prevent Starlight cascade from adding margins inside the Slack window */
-.slk-msg-body,
-.slk-msg-meta,
-.slk-text,
-.slk-tool-call,
-.slk-messages,
-.slk-header,
-.slk-header-left {
-  margin-top: 0 !important;
-  margin-bottom: 0 !important;
-}
-
-/* Individual message row */
 .slk-msg {
-  display: flex;
   align-items: flex-start;
+  display: flex;
   gap: 0.625rem;
   padding: 0.35rem 1rem;
-  transition: background 0.08s ease;
+  transition: background 120ms ease;
 }
 
 .slk-msg:hover {
   background: rgba(255, 255, 255, 0.04);
 }
 
-/* Avatars — Slack-style rounded square */
 .slk-avatar {
-  flex: 0 0 auto;
-  width: 2.25rem;
-  height: 2.25rem;
+  align-items: center;
   border-radius: 6px;
   display: flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: 700;
+  flex: 0 0 auto;
   font-size: 0.8125rem;
-  letter-spacing: 0;
+  font-weight: 700;
+  height: 2.25rem;
+  justify-content: center;
+  width: 2.25rem;
 }
 
 .slk-avatar-user {
   background: #4a154b;
-  color: #ffffff;
+  color: #fff;
 }
 
 .slk-avatar-bot {
   background: #1d2a1d;
-  color: var(--jr-lime);
-  border: 1px solid rgba(57, 255, 20, 0.25);
+  border: 1px solid var(--jr-accent-line);
+  color: var(--jr-accent);
 }
 
-/* Message body */
 .slk-msg-body {
   flex: 1;
+  margin: 0;
   min-width: 0;
 }
 
 .slk-msg-meta {
-  display: flex;
   align-items: baseline;
-  gap: 0.35rem;
-  margin-bottom: 0.1rem;
+  display: flex;
   flex-wrap: wrap;
+  gap: 0.35rem;
+  margin: 0 0 0.1rem;
 }
 
 .slk-name {
-  font-weight: 700;
-  font-size: 0.9375rem;
   color: #d9d9d9;
+  font-size: 0.9375rem;
+  font-weight: 700;
   line-height: 1.2;
 }
 
 .slk-app-badge {
-  display: inline-flex;
   align-items: center;
-  padding: 0.05rem 0.3rem;
   background: #383a3d;
+  border-radius: 3px;
   color: #868686;
+  display: inline-flex;
   font-size: 0.6875rem;
   font-weight: 600;
-  border-radius: 3px;
   line-height: 1.4;
-  letter-spacing: 0.01em;
+  padding: 0.05rem 0.3rem;
 }
 
 .slk-time {
-  font-size: 0.75rem;
   color: #848d97;
-  font-weight: 400;
+  font-size: 0.75rem;
 }
 
 .slk-text {
-  margin: 0;
   color: #c9cdd1;
   font-size: 0.9375rem;
   line-height: 1.46668;
+  margin: 0;
 }
 
 .slk-text em {
   color: #a8abb0;
 }
 
-/* Inline code inside Slack messages */
 .slk-code {
-  font-family: var(--jr-font-mono);
-  font-size: 0.875em;
   background: rgba(255, 255, 255, 0.09);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 3px;
-  padding: 0.08em 0.32em;
   color: #c9cdd1;
+  font-family: var(--__sl-font-mono);
+  font-size: 0.875em;
+  padding: 0.08em 0.32em;
 }
 
-/* Channel mention: #channel-name */
 .slk-mention {
-  color: #1d9bd1;
   background: rgba(29, 155, 209, 0.1);
-  padding: 0 0.12em;
   border-radius: 3px;
+  color: #1d9bd1;
   font-weight: 500;
+  padding: 0 0.12em;
 }
 
-/* User / bot mention: @someone */
 .slk-mention-user {
-  color: #e9c26a;
   background: rgba(233, 194, 106, 0.12);
+  color: #e9c26a;
 }
 
-/* Tool call indicator — shown below a message */
 .slk-tool-call {
-  display: flex;
   align-items: center;
-  gap: 0.35rem;
-  padding-top: 0.3rem; /* padding instead of margin — immune to the wildcard reset */
+  color: #8d96a0;
+  display: flex;
   font-size: 0.8125rem;
-  color: #5e6470;
+  gap: 0.35rem;
   line-height: 1.4;
+  margin: 0;
+  padding-top: 0.3rem;
 }
 
 .slk-tool-call svg {
-  width: 0.75rem;
-  height: 0.75rem;
+  color: #8d96a0;
   flex: 0 0 auto;
-  color: #5e6470;
+  height: 0.75rem;
+  width: 0.75rem;
 }
 
-/* "X replies" divider */
 .slk-divider {
-  display: flex;
   align-items: center;
+  display: flex;
   gap: 0.6rem;
   padding: 0.5rem 1rem;
 }
 
 .slk-divider::before,
 .slk-divider::after {
-  content: '';
+  background: var(--jr-slack-line);
+  content: "";
   flex: 1;
   height: 1px;
-  background: rgba(255, 255, 255, 0.09);
 }
 
 .slk-divider-label {
+  color: #1d9bd1;
   font-size: 0.8125rem;
   font-weight: 700;
-  color: #1d9bd1;
   white-space: nowrap;
 }
 
-@media (max-width: 480px) {
+@media (max-width: 44rem) {
+  :root:not([data-has-sidebar])
+    .hero
+    :is(h1, [data-page-title])
+    .jr-home-mega-inline {
+    font-size: 3.2rem;
+  }
+
   .slk-msg {
     gap: 0.5rem;
-    padding: 0.2rem 0.75rem;
+    padding: 0.25rem 0.75rem;
   }
 
   .slk-avatar {
-    width: 1.75rem;
-    height: 1.75rem;
     font-size: 0.7rem;
-  }
-}
-
-.sl-markdown-content :not(pre) > code,
-:not(pre) > code {
-  background: rgba(255, 255, 255, 0.07);
-  border: 1px solid var(--jr-border);
-  color: #f0f0f0;
-  font-family: var(--sl-font-mono);
-  font-size: 0.88em;
-  font-weight: 500 !important;
-  padding: 0.1em 0.38em;
-  box-shadow: none;
-  border-radius: 4px !important;
-}
-
-pre {
-  background: var(--jr-bg-raised) !important;
-  border: 1px solid var(--jr-border) !important;
-  box-shadow: none;
-  font-family: var(--sl-font-mono);
-  padding-inline: 0.35rem;
-  border-radius: var(--jr-radius) !important;
-}
-
-pre code {
-  color: #ffffff !important;
-  font-family: var(--sl-font-mono) !important;
-}
-
-.expressive-code .frame {
-  border-radius: var(--jr-radius) !important;
-  border: 1px solid var(--jr-border) !important;
-  box-shadow: none;
-  background: var(--jr-bg-raised) !important;
-}
-
-/* Use frame border for shape; avoid nested pre borders causing header/body mismatch */
-.expressive-code .frame pre {
-  border: 0 !important;
-  box-shadow: none;
-}
-
-.expressive-code .frame.has-title pre {
-  border-top-left-radius: 0 !important;
-  border-top-right-radius: 0 !important;
-}
-
-.expressive-code .header,
-.expressive-code .frame .header {
-  background: rgba(255, 255, 255, 0.03) !important;
-  border: 0 !important;
-  border-bottom: 1px solid var(--jr-border) !important;
-  color: #f2f2f2 !important;
-  box-shadow: none !important;
-}
-
-.expressive-code figcaption.header {
-  border-bottom: 0 !important;
-}
-
-.expressive-code .frame.is-terminal .header::after {
-  border-bottom: 0 !important;
-}
-
-/* Show 3-dot chrome only on terminal frames WITHOUT a filename/tab */
-.expressive-code .frame.is-terminal:not(.has-title) .header::before {
-  background: none !important;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 60 16' preserveAspectRatio='xMidYMid meet'%3E%3Ccircle cx='8' cy='8' r='6.1' fill='none' stroke='%236d6d6d' stroke-width='2.1'/%3E%3Ccircle cx='30' cy='8' r='6.1' fill='none' stroke='%236d6d6d' stroke-width='2.1'/%3E%3Ccircle cx='52' cy='8' r='6.1' fill='none' stroke='%236d6d6d' stroke-width='2.1'/%3E%3C/svg%3E") !important;
-  background-size: 2.1rem 0.56rem !important;
-  background-position: 0 0 !important;
-  background-repeat: no-repeat !important;
-  -webkit-mask-image: none !important;
-  mask-image: none !important;
-  width: 2.1rem !important;
-  height: 0.56rem !important;
-  content: '' !important;
-}
-
-.expressive-code .header .title,
-.expressive-code .header .filename {
-  color: #f2f2f2 !important;
-  background: inherit !important;
-  border: 0 !important;
-  box-shadow: none;
-  font-weight: 800 !important;
-}
-
-.expressive-code .header .copy {
-  border: 1px solid var(--jr-border-strong) !important;
-  color: var(--jr-text-dim) !important;
-  background: transparent !important;
-  border-radius: 4px !important;
-  transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease !important;
-}
-
-.expressive-code .header .copy:hover {
-  border-color: var(--jr-lime) !important;
-  color: var(--jr-lime) !important;
-  background: rgba(57, 255, 20, 0.08) !important;
-}
-
-/* High-contrast, monochrome-first code palette */
-body .expressive-code {
-  --ec-codeBg: var(--jr-bg-raised) !important;
-  --ec-codeFg: #ffffff !important;
-  --ec-brdCol: var(--jr-border) !important;
-  --ec-frm-edActTabIndTopCol: rgba(255, 255, 255, 0.7) !important;
-  --ec-gtrFg: #919191 !important;
-  --ec-gtrBrdCol: rgba(255, 255, 255, 0.08) !important;
-  --ec-focusBrd: var(--jr-lime) !important;
-  --ec-frm-trmTtbBg: rgba(255, 255, 255, 0.03) !important;
-  --ec-frm-trmBg: var(--jr-bg-raised) !important;
-  --ec-frm-trmTtbFg: #f2f2f2 !important;
-  --ec-frm-trmTtbBrdBtmCol: var(--jr-border) !important;
-  --ec-frm-trmTtbDotsFg: #6d6d6d !important;
-  --ec-frm-trmTtbDotsOpa: 1 !important;
-  --ec-frm-inlBtnFg: var(--jr-text-dim) !important;
-  --ec-frm-inlBtnBrd: var(--jr-border-strong) !important;
-}
-
-/* Dot styling — only for terminal frames without a filename tab */
-.expressive-code .frame.is-terminal:not(.has-title) .header :is([class*='dot'], [class*='Dot']) {
-  background: transparent !important;
-  border: 1px solid #6d6d6d !important;
-  box-shadow: none !important;
-  color: transparent !important;
-  fill: transparent !important;
-  stroke: #6d6d6d !important;
-  opacity: 1 !important;
-}
-
-.expressive-code .frame.is-terminal:not(.has-title) .header :is([class*='dot'], [class*='Dot'])::before,
-.expressive-code .frame.is-terminal:not(.has-title) .header :is([class*='dot'], [class*='Dot'])::after {
-  background: transparent !important;
-  border: 1px solid #6d6d6d !important;
-  box-shadow: none !important;
-  color: transparent !important;
-  fill: transparent !important;
-  stroke: #6d6d6d !important;
-}
-
-.expressive-code .frame.is-terminal:not(.has-title) .header svg :is(circle, ellipse) {
-  fill: transparent !important;
-  stroke: #6d6d6d !important;
-  stroke-width: 1 !important;
-}
-
-/* Hide dots entirely when a filename/tab is present */
-.expressive-code .frame.has-title .header :is([class*='dot'], [class*='Dot']) {
-  display: none !important;
-}
-
-body .expressive-code .ec-line :where(span[style^='--']:not([class])) {
-  color: #ffffff !important;
-}
-
-body .expressive-code,
-body .expressive-code pre,
-body .expressive-code code {
-  font-family: var(--sl-font-mono) !important;
-}
-
-body .expressive-code .ec-line :where(span[style*='--1:#d6d6d6']) {
-  color: #ffffff !important;
-  font-weight: 650 !important;
-}
-
-body .expressive-code .ec-line :where(span[style*='--1:#a5a5a5']) {
-  color: #ffffff !important;
-  font-weight: 600 !important;
-}
-
-body .expressive-code .ec-line :where(span[style*='--1:#111111']) {
-  color: #ffffff !important;
-}
-
-body .expressive-code .ec-line :is(
-  .keyword,
-  .function,
-  .builtin,
-  .constant,
-  .operator,
-  .type,
-  .boolean,
-  [class*='keyword'],
-  [class*='function'],
-  [class*='builtin'],
-  [class*='constant'],
-  [class*='operator'],
-  [class*='type']
-) {
-  color: #ffffff !important;
-  font-weight: 650 !important;
-}
-
-.pagination-links a {
-  border: 1px solid var(--jr-border);
-  border-radius: var(--jr-radius) !important;
-  background: var(--jr-bg-elevated);
-  color: #f3f3f3 !important;
-  box-shadow: none;
-  transition: border-color 0.15s ease, background 0.15s ease !important;
-}
-
-.pagination-links a:hover {
-  border-color: var(--jr-border-strong);
-  background: #1e1e1e;
-}
-
-::selection {
-  background: rgba(57, 255, 20, 0.46);
-}
-
-*:focus-visible {
-  outline: 3px solid #39ff14;
-  outline-offset: 2px;
-}
-
-body:has(.ash-home) .hero {
-  display: none !important;
-}
-
-/* Junior splash homepage customizations */
-:root:not([data-has-sidebar]) .jr-home-brand {
-  margin: 0.45rem 0 1rem;
-}
-
-:root:not([data-has-sidebar]) .jr-home-brand-word {
-  margin: 0;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.7rem;
-  font-family: var(--jr-font-heading);
-  font-size: clamp(3.1rem, 12vw, 8.6rem);
-  letter-spacing: -0.03em;
-  line-height: 0.9;
-  color: #ffffff;
-}
-
-:root:not([data-has-sidebar]) .jr-home-brand-icon {
-  width: clamp(1.9rem, 6.4vw, 4.6rem);
-  height: clamp(1.9rem, 6.4vw, 4.6rem);
-  flex: 0 0 auto;
-}
-
-:root:not([data-has-sidebar]) .jr-highlight {
-  position: relative;
-  z-index: 1;
-  display: inline;
-  color: #f4f4f4;
-}
-
-:root:not([data-has-sidebar]) .hero :is(h1, [data-page-title]) .jr-home-mega-inline {
-  display: flex !important;
-  align-items: center;
-  gap: 0.55rem;
-  margin-bottom: 0.2rem;
-  font-family: var(--jr-font-heading) !important;
-  font-size: clamp(3.4rem, 12vw, 8rem) !important;
-  line-height: 0.88 !important;
-  letter-spacing: -0.03em !important;
-  background: linear-gradient(135deg, #ffffff 0%, #cccccc 100%);
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-}
-
-:root:not([data-has-sidebar]) .hero :is(h1, [data-page-title]) .jr-home-headline {
-  display: block !important;
-}
-
-:root:not([data-has-sidebar]) .jr-highlight::before {
-  content: '';
-  position: absolute;
-  z-index: -1;
-  left: -0.08em;
-  right: -0.08em;
-  bottom: 0.06em;
-  height: 0.5em;
-  background: rgba(58, 58, 58, 0.92);
-  transform: rotate(-1.1deg);
-}
-
-:root:not([data-has-sidebar]) .hero :is(.sl-link-button[data-variant='primary'], .sl-link-button.primary) {
-  background: transparent !important;
-  color: #ffffff !important;
-  border: 1px solid rgba(255, 255, 255, 0.35) !important;
-  box-shadow: none !important;
-  padding: 0.6rem 1.4rem !important;
-  text-transform: none;
-  letter-spacing: -0.01em;
-  font-family: var(--jr-font-heading) !important;
-  font-size: 0.95rem !important;
-  font-weight: 600 !important;
-  line-height: 1.2;
-  text-decoration: none !important;
-  border-radius: var(--jr-radius) !important;
-  position: relative;
-  z-index: 1;
-  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease !important;
-}
-
-:root:not([data-has-sidebar]) .hero :is(.sl-link-button[data-variant='primary'], .sl-link-button.primary):hover {
-  background: #ffffff !important;
-  color: #000000 !important;
-  border-color: #ffffff !important;
-  box-shadow: none !important;
-  outline: none !important;
-  transform: none;
-}
-
-/* Homepage-only landing shell */
-body:has(.ash-home) header.header {
-  display: none !important;
-}
-
-body:has(.ash-home) #starlight__sidebar,
-body:has(.ash-home) .sidebar-pane,
-body:has(.ash-home) .right-sidebar-container,
-body:has(.ash-home) .right-sidebar,
-body:has(.ash-home) starlight-toc {
-  display: none !important;
-}
-
-body:has(.ash-home) .main-pane {
-  width: 100% !important;
-  max-width: 100% !important;
-}
-
-body:has(.ash-home) .main-frame {
-  padding-top: 0 !important;
-}
-
-body:has(.ash-home) .content-panel > .sl-container {
-  max-width: 50rem;
-}
-
-body:has(.ash-home) main {
-  padding-top: 0 !important;
-}
-
-body:has(.ash-home) .content-panel {
-  padding-top: 0 !important;
-}
-
-body:has(.ash-home) .content-panel:first-of-type {
-  padding-bottom: 0 !important;
-}
-
-.ash-home {
-  display: grid;
-  gap: var(--ash-section-gap);
-  padding: 0 0 3.2rem;
-  max-width: 50rem;
-  margin: 0 auto;
-}
-
-.ash-home > section {
-  width: min(100%, 50rem);
-  margin: 0 auto;
-}
-
-.ash-mega {
-  border: 0;
-  background: transparent;
-  color: #f4f4f4;
-  padding: 0.75rem 0;
-  box-shadow: none;
-}
-
-.ash-mega-word {
-  margin: 0;
-  font-family: var(--jr-font-heading);
-  font-size: clamp(4.2rem, 14vw, 11rem);
-  line-height: 0.8;
-  letter-spacing: 0.02em;
-  color: #1b1b1b;
-  display: flex;
-  align-items: center;
-  gap: 0.48rem;
-}
-
-.ash-mega-icon {
-  width: clamp(3.2rem, 9vw, 5.8rem);
-  height: clamp(3.2rem, 9vw, 5.8rem);
-  border: 0;
-  flex: 0 0 auto;
-}
-
-.ash-mega-expansion {
-  margin: 0.35rem 0 0;
-  font-family: 'IBM Plex Mono', var(--sl-font-mono);
-  font-size: clamp(0.76rem, 1.9vw, 1.05rem);
-  line-height: 1.2;
-  text-transform: lowercase;
-  letter-spacing: 0.04em;
-  color: #1b1b1b;
-}
-
-.ash-home-brand {
-  display: flex;
-  align-items: center;
-  gap: 0.9rem;
-  margin-bottom: 0.45rem;
-}
-
-.ash-home-brand-mark {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: auto;
-  height: auto;
-  border: 0;
-  background: transparent;
-  font-family: var(--jr-font-heading);
-  font-size: clamp(3.2rem, 9vw, 5.8rem);
-  line-height: 0.85;
-  letter-spacing: 0.04em;
-  text-transform: lowercase;
-  color: #d9ff6f;
-  box-shadow: none;
-}
-
-.ash-home-brand-name {
-  margin: 0;
-  font-family: var(--jr-font-heading);
-  font-size: clamp(2.3rem, 5vw, 3.8rem);
-  line-height: 0.9;
-  letter-spacing: 0.04em;
-}
-
-.ash-home-brand-sub {
-  margin: 0.12rem 0 0;
-  font-size: 0.78rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #747474;
-}
-
-.ash-home-hero {
-  border: 0;
-  background: transparent;
-  box-shadow: none;
-}
-
-.ash-home-hero-grid {
-  padding: 0.75rem 0;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 1rem;
-  align-items: start;
-}
-
-.ash-home-kicker {
-  display: inline-flex;
-  padding: 0.3rem 0.7rem;
-  border-radius: var(--jr-radius) !important;
-  border: 1px solid var(--jr-border);
-  background: rgba(255, 255, 255, 0.05);
-  color: var(--jr-text-dim);
-  font-family: var(--jr-font-heading);
-  font-size: 0.8rem;
-  letter-spacing: 0.04em;
-  font-weight: 500;
-}
-
-.ash-home-title {
-  margin: 0;
-  font-family: var(--jr-font-heading);
-  font-size: clamp(2.5rem, 8vw, 5.4rem);
-  line-height: 0.88;
-  letter-spacing: 0.02em;
-  max-width: none;
-  color: #1b1b1b;
-}
-
-.ash-highlight {
-  position: relative;
-  z-index: 1;
-  display: inline;
-}
-
-.ash-highlight::before {
-  content: '';
-  position: absolute;
-  z-index: -1;
-  left: -0.04em;
-  right: -0.04em;
-  bottom: 0.06em;
-  height: 0.55em;
-  background: rgba(34, 34, 34, 0.92);
-  transform: rotate(-1.2deg);
-}
-
-.ash-home-subtitle {
-  margin: 0.45rem 0 0;
-  font-size: 1.03rem;
-  max-width: none;
-  line-height: 1.5;
-  color: #565656;
-  font-weight: 500;
-}
-
-.ash-home-cta {
-  margin-top: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.65rem;
-}
-
-.ash-home-cta a {
-  display: inline-flex;
-  align-items: center;
-  text-decoration: none;
-  border-radius: var(--jr-radius) !important;
-  padding: 0.66rem 1.1rem;
-  font-weight: 700;
-  border: 1px solid var(--jr-border);
-  transition: background 0.15s ease, border-color 0.15s ease;
-}
-
-.ash-home-cta-primary {
-  color: #000000;
-  background: var(--jr-lime);
-  border: 0 !important;
-  box-shadow: none;
-}
-
-.ash-home-cta-primary:hover {
-  color: #000000 !important;
-  background: #57ff35;
-}
-
-.ash-home-cta-secondary {
-  color: #2a2a2a;
-  background: #ffffff;
-}
-
-.ash-home-cta-secondary:hover {
-  background: #f0f0f0;
-}
-
-.ash-home-jumps {
-  margin-top: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-  justify-content: flex-end;
-  margin-left: auto;
-}
-
-.ash-home-jumps a,
-.ash-home-search-btn {
-  display: inline-flex;
-  align-items: center;
-  border: 1px solid var(--ash-ink);
-  padding: 0.36rem 0.6rem;
-  background: #ffffff;
-  color: #2a2a2a;
-  text-decoration: none;
-  font-size: 0.8rem;
-  font-weight: 700;
-  text-transform: lowercase;
-  cursor: pointer;
-}
-
-.ash-home-search-btn {
-  background: #39ff14;
-}
-
-.ash-home-jumps a:hover,
-.ash-home-search-btn:hover {
-  background: #d9ff66;
-}
-
-.ash-home-actions {
-  margin-top: 0.75rem;
-  display: flex;
-  align-items: center;
-  gap: 0.8rem;
-}
-
-.ash-home-proof {
-  border: 0;
-  padding: 0.85rem;
-  background: transparent;
-}
-
-.ash-proof-kicker {
-  margin: 0;
-  font-family: var(--jr-font-heading);
-  letter-spacing: 0.08em;
-  font-size: 0.88rem;
-  color: #dadada;
-}
-
-.ash-proof-list {
-  list-style: none;
-  margin: 0.55rem 0 0;
-  padding: 0;
-  display: grid;
-  gap: 0.45rem;
-}
-
-.ash-proof-list li {
-  display: grid;
-  grid-template-columns: 2.1rem 1fr;
-  align-items: baseline;
-  gap: 0.5rem;
-  font-size: 0.93rem;
-  line-height: 1.35;
-  color: #2a2a2a;
-}
-
-.ash-proof-list li span {
-  display: inline-flex;
-  justify-content: center;
-  border: 1px solid var(--jr-border-strong);
-  border-radius: 4px !important;
-  font-family: 'IBM Plex Mono', var(--sl-font-mono);
-  font-size: 0.7rem;
-  font-weight: 600;
-  padding: 0.12rem 0.25rem;
-  background: #000000;
-  color: #f4f4f4;
-}
-
-.ash-proof-foot {
-  margin: 0.65rem 0 0;
-  font-size: 0.76rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: #a9a9a9;
-}
-
-.ash-home-flow {
-  display: grid;
-  gap: var(--ash-section-gap);
-}
-
-.ash-home-band {
-  border: 0;
-  padding: 0;
-  background: transparent;
-  position: relative;
-  box-shadow: none;
-}
-
-.ash-home-band::before {
-  content: none;
-  position: absolute;
-  left: 1rem;
-  right: 1rem;
-  top: 0.72rem;
-  height: 0.18rem;
-  background: transparent;
-}
-
-.ash-home-band::after {
-  content: none;
-  position: absolute;
-  left: 1rem;
-  right: 1.8rem;
-  top: 2.2rem;
-  height: 0.14rem;
-  background: transparent;
-  transform: rotate(-0.5deg);
-  pointer-events: none;
-}
-
-.ash-home-band > * {
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.ash-home-band-acid {
-  background: transparent;
-}
-
-.ash-home-band-slice {
-  border-top-right-radius: 0.9rem;
-  margin-right: 0;
-}
-
-.ash-home-band-slice::before {
-  left: 1.1rem;
-  right: 40%;
-}
-
-.ash-home-band-paper {
-  background: transparent;
-  margin-left: 0;
-}
-
-.ash-home-band-paper::before {
-  left: 1rem;
-  right: 55%;
-  transform: rotate(-0.2deg);
-}
-
-.ash-home-band-tools {
-  background: transparent;
-  margin-right: 0;
-}
-
-.ash-home-band-tools::before {
-  left: 1rem;
-  right: 48%;
-  background: rgba(57, 255, 20, 0.82);
-}
-
-.ash-home-band h2 {
-  margin: 0 0 0.5rem;
-  font-size: 1.8rem;
-}
-
-.ash-scenario-line {
-  margin: 0 0 0.65rem !important;
-  font-size: 0.84rem;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  color: #434343;
-  text-transform: lowercase;
-  border-left: 3px solid var(--jr-lime);
-  padding-left: 0.5rem;
-}
-
-.ash-chat-demo {
-  position: relative;
-  border: 0;
-  background: transparent;
-  padding: 4.9rem 3rem 2rem;
-  display: grid;
-  gap: 0.42rem;
-  box-shadow: none;
-  transform: none;
-  width: 100%;
-  max-width: none;
-  margin: 0;
-  border-radius: 0 0 0.75rem 0.75rem;
-  overflow: hidden;
-}
-
-.ash-chat-demo::after {
-  content: none;
-}
-
-.ash-chat-demo::before {
-  content: attr(data-title);
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 0;
-  height: 2.8rem;
-  display: flex;
-  align-items: center;
-  padding: 0 1rem;
-  font-family: var(--jr-font-heading);
-  font-size: 0.9rem;
-  letter-spacing: -0.01em;
-  text-transform: none;
-  color: var(--jr-text);
-  font-weight: 600;
-  background: var(--jr-bg-elevated);
-  border-bottom: 1px solid var(--jr-border);
-  border-top-left-radius: 0.75rem;
-  border-top-right-radius: 0.75rem;
-}
-
-.ash-chat-demo:not([data-title]) {
-  padding-top: 2rem;
-  border-radius: 0.75rem;
-}
-
-.ash-chat-demo:not([data-title])::before {
-  content: none;
-}
-
-.ash-chat-ops,
-.ash-chat-memory,
-.ash-chat-ship {
-  border-color: #2a2a2a;
-}
-
-.ash-chat-turn {
-  margin: 0;
-  border: 0;
-  padding: 0.74rem 0.96rem 0.68rem;
-  font-size: 0.94rem;
-  line-height: 1.45;
-  max-width: calc(100% - 3rem);
-  box-shadow: none;
-  position: relative;
-  border-radius: var(--jr-radius) !important;
-  white-space: normal;
-  width: fit-content;
-}
-
-.ash-chat-turn::before {
-  content: none;
-}
-
-.ash-chat-speaker {
-  display: block;
-  margin: 0 0 0.24rem;
-  font-weight: 800;
-  font-size: 0.78rem;
-  line-height: 1.1;
-  letter-spacing: 0.01em;
-}
-
-.ash-chat-user {
-  margin-left: 3rem;
-  margin-right: 3rem;
-  background: var(--jr-lime-dim);
-  color: var(--jr-text);
-  border-color: var(--jr-lime-border);
-  text-align: left;
-  justify-self: end;
-  border-radius: var(--jr-radius) !important;
-}
-
-.ash-chat-user::after,
-.ash-chat-ash::after {
-  content: none;
-}
-
-.ash-chat-user::before,
-.ash-chat-ash::before {
-  content: '';
-  position: absolute;
-  bottom: 0;
-  width: 2rem;
-  height: 2rem;
-  border: 1.5px solid #2a2a2a;
-  border-radius: 0.55rem;
-  box-shadow: none;
-}
-
-.ash-chat-user::before {
-  right: -2.6rem;
-  background:
-    radial-gradient(circle at 50% 50%, #ffffff 0 0.5rem, transparent 0.51rem),
-    #1b1b1b;
-}
-
-.ash-chat-ash::before {
-  left: -2.6rem;
-  background: url('/favicon.svg') center / cover no-repeat;
-}
-
-.ash-chat-user .ash-chat-speaker {
-  color: var(--jr-text-dim);
-}
-
-.ash-chat-ash {
-  margin-left: 3rem;
-  margin-right: 3rem;
-  background: var(--jr-bg-elevated);
-  color: #f0f0f0;
-  border-color: var(--jr-border);
-  text-align: left;
-  justify-self: start;
-  border-radius: var(--jr-radius) !important;
-}
-
-.ash-chat-ash .ash-chat-speaker {
-  color: #f0f0f0;
-}
-
-.ash-chat-time {
-  display: inline-block;
-  margin-left: 0.32rem;
-  font-family: 'IBM Plex Mono', var(--sl-font-mono);
-  font-size: 0.72rem;
-  letter-spacing: 0.03em;
-  opacity: 0.88;
-  vertical-align: baseline;
-}
-
-.ash-chat-user .ash-chat-time {
-  color: var(--jr-text-muted);
-}
-
-.ash-chat-user .ash-chat-time::after {
-  content: ' ✓✓';
-  letter-spacing: 0;
-}
-
-.ash-chat-ash .ash-chat-time {
-  color: #747474;
-}
-
-.ash-chat-tool {
-  margin: 0.06rem auto;
-  border: 0;
-  background: transparent;
-  color: #9b9b9b;
-  padding: 0;
-  font-family: 'IBM Plex Mono', var(--sl-font-mono);
-  font-size: 0.82rem;
-  line-height: 1.35;
-  width: fit-content;
-  max-width: calc(100% - 1rem);
-  text-align: left;
-  font-size: 0.78rem;
-  letter-spacing: 0.02em;
-}
-
-.ash-chat-tool span {
-  display: inline;
-  margin-right: 0.3rem;
-  color: #9b9b9b;
-  font-weight: 700;
-  background: transparent;
-  border: 0;
-  padding: 0;
-}
-
-.ash-chat-meta {
-  margin: 0.08rem auto 0;
-  border: 0;
-  background: transparent;
-  padding: 0;
-  font-size: 0.74rem;
-  font-weight: 800;
-  color: #9b9b9b;
-  text-transform: none;
-  letter-spacing: 0.05em;
-  width: auto;
-  max-width: 100%;
-  text-align: left;
-}
-
-.ash-chat-latest {
-  position: relative;
-}
-
-.ash-chat-latest::after {
-  content: none;
-}
-
-@keyframes ash-chat-blink {
-  0%,
-  54% {
-    opacity: 1;
-  }
-  55%,
-  100% {
-    opacity: 0;
-  }
-}
-
-.ash-band-tag {
-  display: block;
-  border: 0;
-  padding: 0;
-  margin-bottom: 0.45rem !important;
-  font-family: 'IBM Plex Mono', var(--sl-font-mono);
-  font-size: 0.68rem;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: #9b9b9b;
-  background: transparent;
-}
-
-.ash-home-band p {
-  margin: 0;
-  color: #272727;
-}
-
-.ash-home-list {
-  margin: 0.75rem 0 0;
-  padding-left: 1.05rem;
-}
-
-.ash-home-list li {
-  margin-top: 0.33rem;
-  color: #434343;
-}
-
-.ash-home-link-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-top: 0.85rem;
-}
-
-.ash-home-link-pill {
-  border: 1px solid var(--jr-border);
-  border-radius: var(--jr-radius) !important;
-  padding: 0.34rem 0.68rem;
-  text-decoration: none;
-  color: #434343;
-  font-size: 0.82rem;
-  font-weight: 600;
-  background: rgba(255, 255, 255, 0.06);
-  transition: background 0.15s ease, border-color 0.15s ease;
-}
-
-.ash-home-link-pill:hover {
-  background: rgba(255, 255, 255, 0.1);
-  border-color: var(--jr-border-strong);
-}
-
-/* Homepage dark-theme overrides */
-body:has(.ash-home) .ash-mega {
-  border: 0;
-  background: transparent;
-  color: #f4f4f4;
-  box-shadow: none;
-}
-
-body:has(.ash-home) :is(.ash-mega-word, .ash-mega-expansion) {
-  color: #f4f4f4;
-}
-
-body:has(.ash-home) :is(.ash-mega-icon, .ash-home-brand-mark) {
-  border-color: var(--ash-dark-border);
-}
-
-body:has(.ash-home) .ash-home-brand-mark {
-  border: 0;
-  background: transparent;
-  color: #d9ff6f;
-  box-shadow: none;
-}
-
-body:has(.ash-home) .ash-home-brand-sub {
-  color: #acacac;
-}
-
-body:has(.ash-home) .ash-home-hero {
-  border: 0;
-  background: transparent;
-  box-shadow: none;
-}
-
-body:has(.ash-home) :is(.ash-home-title, .ash-home-subtitle) {
-  color: #f4f4f4;
-}
-
-body:has(.ash-home) .ash-home-kicker {
-  border-color: var(--jr-border);
-  background: rgba(255, 255, 255, 0.05);
-  color: var(--jr-text-dim);
-}
-
-body:has(.ash-home) :is(.ash-home-cta-secondary, .ash-home-jumps a, .ash-home-search-btn) {
-  background: #1c1c1c;
-  color: #f4f4f4;
-  border-color: var(--ash-dark-border);
-}
-
-body:has(.ash-home) :is(.ash-home-cta-secondary:hover, .ash-home-jumps a:hover, .ash-home-search-btn:hover) {
-  background: #282828;
-}
-
-body:has(.ash-home) .ash-home-proof {
-  border: 0;
-  background: transparent;
-}
-
-body:has(.ash-home) :is(.ash-proof-kicker, .ash-proof-list li, .ash-proof-foot) {
-  color: #e4e4e4;
-}
-
-body:has(.ash-home) .ash-home-band {
-  border: 0;
-}
-
-body:has(.ash-home) :is(.ash-home-band p, .ash-home-list li, .ash-scenario-line) {
-  color: #e9e9e9;
-}
-
-body:has(.ash-home) .ash-home-band .ash-chat-turn.ash-chat-user,
-body:has(.ash-home) .ash-home-band .ash-chat-turn.ash-chat-user :is(span, .ash-chat-time) {
-  color: var(--jr-text) !important;
-}
-
-body:has(.ash-home) .ash-chat-demo {
-  border: 0;
-  background: transparent;
-  box-shadow: none;
-}
-
-body:has(.ash-home) .ash-chat-ash {
-  background: #1c1c1c;
-  color: #f0f0f0;
-  border-color: var(--ash-dark-border);
-}
-
-body:has(.ash-home) :is(.ash-chat-tool, .ash-chat-meta) {
-  border-color: transparent;
-  background: transparent;
-  color: #9b9b9b;
-}
-
-body:has(.ash-home) .ash-chat-tool span {
-  color: #9b9b9b;
-  border-color: transparent;
-  background: transparent;
-}
-
-@media (max-width: 64rem) {
-  .ash-home-hero-grid {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media (max-width: 50rem) {
-  .ash-home {
-    padding-top: 0.8rem;
-  }
-
-  .ash-home-title {
-    font-size: clamp(2.2rem, 12vw, 3.8rem);
-  }
-
-  .ash-home-actions {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.55rem;
-  }
-
-  .ash-home-jumps {
-    justify-content: flex-start;
-    margin-left: 0;
-  }
-
-  .ash-home-band-slice,
-  .ash-home-band-paper,
-  .ash-home-band-tools {
-    margin-left: 0;
-    margin-right: 0;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation: none !important;
-    transition: none !important;
-    scroll-behavior: auto !important;
+    height: 1.75rem;
+    width: 1.75rem;
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,20 +76,17 @@ importers:
         specifier: ^0.9.9
         version: 0.9.9(prettier@3.8.3)(typescript@5.9.3)
       "@astrojs/starlight":
-        specifier: ^0.37.7
-        version: 0.37.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4))
-      "@fontsource-variable/space-grotesk":
-        specifier: ^5.2.10
-        version: 5.2.10
-      "@fontsource/ibm-plex-mono":
-        specifier: ^5.2.7
-        version: 5.2.7
+        specifier: ^0.39.2
+        version: 0.39.2(astro@6.3.7(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3)
+      "@sentry/starlight-theme":
+        specifier: ^0.3.0
+        version: 0.3.0(@astrojs/starlight@0.39.2(astro@6.3.7(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3))
       astro:
-        specifier: ^5.18.1
-        version: 5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)
+        specifier: ^6.3.7
+        version: 6.3.7(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
       starlight-typedoc:
-        specifier: ^0.21.5
-        version: 0.21.5(@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@5.9.3)))(typedoc@0.28.19(typescript@5.9.3))
+        specifier: ^0.23.0
+        version: 0.23.0(@astrojs/starlight@0.39.2(astro@6.3.7(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@5.9.3)))(typedoc@0.28.19(typescript@5.9.3))
       typedoc:
         specifier: ^0.28.19
         version: 0.28.19(typescript@5.9.3)
@@ -288,10 +285,16 @@ packages:
         integrity: sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==,
       }
 
-  "@astrojs/internal-helpers@0.7.6":
+  "@astrojs/compiler@4.0.0":
     resolution:
       {
-        integrity: sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==,
+        integrity: sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==,
+      }
+
+  "@astrojs/internal-helpers@0.9.1":
+    resolution:
+      {
+        integrity: sha512-1pWuARqYom/TzuU3+0ZugsTrKlUydWKuULmDqSMTuonY+9IRDUEGKX/8PXQ1nBxRq3w85uGtd9q9SXfqEldMIQ==,
       }
 
   "@astrojs/language-server@2.16.7":
@@ -309,27 +312,27 @@ packages:
       prettier-plugin-astro:
         optional: true
 
-  "@astrojs/markdown-remark@6.3.11":
+  "@astrojs/markdown-remark@7.1.2":
     resolution:
       {
-        integrity: sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==,
+        integrity: sha512-caXZ4Dc2St2dW8luEg22GlP0gupLdztCTQE4EzZOxW1pqWXz9mbeJEuHUkgDYcKWW8tjIHkydYDhWLVoxJ327Q==,
       }
 
-  "@astrojs/mdx@4.3.14":
+  "@astrojs/mdx@5.0.6":
     resolution:
       {
-        integrity: sha512-FBrqJQORVm+rkRa2TS5CjU9PBA6hkhrwLVBSS9A77gN2+iehvjq1w6yya/d0YKC7osiVorKkr3Qd9wNbl0ZkGA==,
+        integrity: sha512-4dKe0ZMmqujofPNDHahzClkwinn9f8jHPcaXcgdGvPAlboD2mjzkUCofli2cBnxYAkdfhC6d50gBJ8i/cH8gHw==,
       }
-    engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0 }
+    engines: { node: ">=22.12.0" }
     peerDependencies:
-      astro: ^5.0.0
+      astro: ^6.0.0
 
-  "@astrojs/prism@3.3.0":
+  "@astrojs/prism@4.0.2":
     resolution:
       {
-        integrity: sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==,
+        integrity: sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==,
       }
-    engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0 }
+    engines: { node: ">=22.12.0" }
 
   "@astrojs/sitemap@3.7.2":
     resolution:
@@ -337,18 +340,18 @@ packages:
         integrity: sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==,
       }
 
-  "@astrojs/starlight@0.37.7":
+  "@astrojs/starlight@0.39.2":
     resolution:
       {
-        integrity: sha512-KyBnou8aKIlPJUSNx6a1SN7XyH22oj/VAvTGC+Edld4Bnei1A//pmCRTBvSrSeoGrdUjK0ErFUfaEhhO1bPfDg==,
+        integrity: sha512-vlw+bwnjtf5buCTUtLU7JfV6D3knslxqnspr6LKs6hfRuFZiyr5hT44F7GyDqR9FKANUqFxnIzWM81F1k/kOUA==,
       }
     peerDependencies:
-      astro: ^5.5.0
+      astro: ^6.0.0
 
-  "@astrojs/telemetry@3.3.0":
+  "@astrojs/telemetry@3.3.2":
     resolution:
       {
-        integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==,
+        integrity: sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ==,
       }
     engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0 }
 
@@ -690,6 +693,20 @@ packages:
         integrity: sha512-LA2UHXA4prF+ZKGdHjPQ4X/2hAxU2FI1XCCC4jl9LK93YNNOtV76RfyNp2TewvtygfUjAxH5b/Fk6oFuMUcK2Q==,
       }
 
+  "@clack/core@1.3.1":
+    resolution:
+      {
+        integrity: sha512-fT1qHVGAag4IEkrupZ6lRRbNCs1vS9P01KB/sG8zKgvUztbYtFBtQpjSITNwooDZ83tpsPzP0mRNs1/KVszCRA==,
+      }
+    engines: { node: ">= 20.12.0" }
+
+  "@clack/prompts@1.4.0":
+    resolution:
+      {
+        integrity: sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA==,
+      }
+    engines: { node: ">= 20.12.0" }
+
   "@ctrl/tinycolor@4.2.0":
     resolution:
       {
@@ -786,26 +803,11 @@ packages:
         integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==,
       }
 
-  "@emnapi/runtime@1.9.1":
-    resolution:
-      {
-        integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==,
-      }
-
   "@emnapi/wasi-threads@1.2.1":
     resolution:
       {
         integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==,
       }
-
-  "@esbuild/aix-ppc64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ppc64]
-    os: [aix]
 
   "@esbuild/aix-ppc64@0.27.0":
     resolution:
@@ -825,15 +827,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  "@esbuild/android-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [android]
-
   "@esbuild/android-arm64@0.27.0":
     resolution:
       {
@@ -850,15 +843,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [android]
-
-  "@esbuild/android-arm@0.25.12":
-    resolution:
-      {
-        integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm]
     os: [android]
 
   "@esbuild/android-arm@0.27.0":
@@ -879,15 +863,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  "@esbuild/android-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [android]
-
   "@esbuild/android-x64@0.27.0":
     resolution:
       {
@@ -906,15 +881,6 @@ packages:
     cpu: [x64]
     os: [android]
 
-  "@esbuild/darwin-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [darwin]
-
   "@esbuild/darwin-arm64@0.27.0":
     resolution:
       {
@@ -931,15 +897,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [darwin]
-
-  "@esbuild/darwin-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
     os: [darwin]
 
   "@esbuild/darwin-x64@0.27.0":
@@ -960,15 +917,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  "@esbuild/freebsd-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [freebsd]
-
   "@esbuild/freebsd-arm64@0.27.0":
     resolution:
       {
@@ -985,15 +933,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [freebsd]
-
-  "@esbuild/freebsd-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
     os: [freebsd]
 
   "@esbuild/freebsd-x64@0.27.0":
@@ -1014,15 +953,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  "@esbuild/linux-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [linux]
-
   "@esbuild/linux-arm64@0.27.0":
     resolution:
       {
@@ -1039,15 +969,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [linux]
-
-  "@esbuild/linux-arm@0.25.12":
-    resolution:
-      {
-        integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm]
     os: [linux]
 
   "@esbuild/linux-arm@0.27.0":
@@ -1068,15 +989,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  "@esbuild/linux-ia32@0.25.12":
-    resolution:
-      {
-        integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ia32]
-    os: [linux]
-
   "@esbuild/linux-ia32@0.27.0":
     resolution:
       {
@@ -1093,15 +1005,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [ia32]
-    os: [linux]
-
-  "@esbuild/linux-loong64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==,
-      }
-    engines: { node: ">=18" }
-    cpu: [loong64]
     os: [linux]
 
   "@esbuild/linux-loong64@0.27.0":
@@ -1122,15 +1025,6 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  "@esbuild/linux-mips64el@0.25.12":
-    resolution:
-      {
-        integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [mips64el]
-    os: [linux]
-
   "@esbuild/linux-mips64el@0.27.0":
     resolution:
       {
@@ -1147,15 +1041,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [mips64el]
-    os: [linux]
-
-  "@esbuild/linux-ppc64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ppc64]
     os: [linux]
 
   "@esbuild/linux-ppc64@0.27.0":
@@ -1176,15 +1061,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  "@esbuild/linux-riscv64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==,
-      }
-    engines: { node: ">=18" }
-    cpu: [riscv64]
-    os: [linux]
-
   "@esbuild/linux-riscv64@0.27.0":
     resolution:
       {
@@ -1201,15 +1077,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [riscv64]
-    os: [linux]
-
-  "@esbuild/linux-s390x@0.25.12":
-    resolution:
-      {
-        integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [s390x]
     os: [linux]
 
   "@esbuild/linux-s390x@0.27.0":
@@ -1230,15 +1097,6 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  "@esbuild/linux-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [linux]
-
   "@esbuild/linux-x64@0.27.0":
     resolution:
       {
@@ -1257,15 +1115,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  "@esbuild/netbsd-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [netbsd]
-
   "@esbuild/netbsd-arm64@0.27.0":
     resolution:
       {
@@ -1282,15 +1131,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [netbsd]
-
-  "@esbuild/netbsd-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
     os: [netbsd]
 
   "@esbuild/netbsd-x64@0.27.0":
@@ -1311,15 +1151,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  "@esbuild/openbsd-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [openbsd]
-
   "@esbuild/openbsd-arm64@0.27.0":
     resolution:
       {
@@ -1336,15 +1167,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [openbsd]
-
-  "@esbuild/openbsd-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
     os: [openbsd]
 
   "@esbuild/openbsd-x64@0.27.0":
@@ -1365,15 +1187,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  "@esbuild/openharmony-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [openharmony]
-
   "@esbuild/openharmony-arm64@0.27.0":
     resolution:
       {
@@ -1391,15 +1204,6 @@ packages:
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [openharmony]
-
-  "@esbuild/sunos-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [sunos]
 
   "@esbuild/sunos-x64@0.27.0":
     resolution:
@@ -1419,15 +1223,6 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  "@esbuild/win32-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [win32]
-
   "@esbuild/win32-arm64@0.27.0":
     resolution:
       {
@@ -1444,15 +1239,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [win32]
-
-  "@esbuild/win32-ia32@0.25.12":
-    resolution:
-      {
-        integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ia32]
     os: [win32]
 
   "@esbuild/win32-ia32@0.27.0":
@@ -1473,15 +1259,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  "@esbuild/win32-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [win32]
-
   "@esbuild/win32-x64@0.27.0":
     resolution:
       {
@@ -1500,28 +1277,28 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  "@expressive-code/core@0.41.7":
+  "@expressive-code/core@0.42.0":
     resolution:
       {
-        integrity: sha512-ck92uZYZ9Wba2zxkiZLsZGi9N54pMSAVdrI9uW3Oo9AtLglD5RmrdTwbYPCT2S/jC36JGB2i+pnQtBm/Ib2+dg==,
+        integrity: sha512-MN11+9nfmaC7sYu2BZJXAXqwkBRt8t1xTSqP+Ti1NfTEskgl6xUnzDxoaiQkg0BMzpglA0pys4dpDKquP/cyIw==,
       }
 
-  "@expressive-code/plugin-frames@0.41.7":
+  "@expressive-code/plugin-frames@0.42.0":
     resolution:
       {
-        integrity: sha512-diKtxjQw/979cTglRFaMCY/sR6hWF0kSMg8jsKLXaZBSfGS0I/Hoe7Qds3vVEgeoW+GHHQzMcwvgx/MOIXhrTA==,
+        integrity: sha512-XtkPm+941Uta7Y+81Acv+OA/20F1NJmJhCX6UYGKpqEIGqplNh3PTOhcURp6tcruhlzJcWcvpWy6Oigz3SrjqA==,
       }
 
-  "@expressive-code/plugin-shiki@0.41.7":
+  "@expressive-code/plugin-shiki@0.42.0":
     resolution:
       {
-        integrity: sha512-DL605bLrUOgqTdZ0Ot5MlTaWzppRkzzqzeGEu7ODnHF39IkEBbFdsC7pbl3LbUQ1DFtnfx6rD54k/cdofbW6KQ==,
+        integrity: sha512-PMKey/kLmewttAHQezL+Y5Fx3vVssfDi3+FJOYQQS2mXP3tQspFELtKKAfsXfmSXdToZYgwoO69HJndqfE+09g==,
       }
 
-  "@expressive-code/plugin-text-markers@0.41.7":
+  "@expressive-code/plugin-text-markers@0.42.0":
     resolution:
       {
-        integrity: sha512-Ewpwuc5t6eFdZmWlFyeuy3e1PTQC0jFvw2Q+2bpcWXbOZhPLsT7+h8lsSIJxb5mS7wZko7cKyQ2RLYDyK6Fpmw==,
+        integrity: sha512-l59lUx8fq1v5g6SpmbDjiU0+7IdfbiWnAyRmtTVSpfhyq+nZMN4UcmYyu2b9Mynhzt7Gr+O+cXyEPDNb2AVWVQ==,
       }
 
   "@fastify/busboy@2.1.1":
@@ -1538,18 +1315,6 @@ packages:
       }
     peerDependencies:
       "@opentelemetry/api": ^1.9.0
-
-  "@fontsource-variable/space-grotesk@5.2.10":
-    resolution:
-      {
-        integrity: sha512-yJQO/o35/hAP3CFnpdFTwQku2yzJOae2HIpBmqkOVoxhhXJaQP3g+b6Jrz7u+eI7A5ZdCIf88uMWpBJdFiGr5w==,
-      }
-
-  "@fontsource/ibm-plex-mono@5.2.7":
-    resolution:
-      {
-        integrity: sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==,
-      }
 
   "@gerrit0/mini-shiki@3.23.0":
     resolution:
@@ -3718,17 +3483,28 @@ packages:
       "@opentelemetry/sdk-trace-base": ^1.30.1 || ^2.1.0
       "@opentelemetry/semantic-conventions": ^1.39.0
 
-  "@shikijs/core@3.23.0":
+  "@sentry/starlight-theme@0.3.0":
     resolution:
       {
-        integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==,
+        integrity: sha512-/6HZoCd54dQ9lJHcF5C5f9EDM1iZZZkMjDaItMPhC5ExpYgwT82sci77a+lFVx/85U7n1/0fGpekB4aozLQXAA==,
       }
+    engines: { node: ">=22.12.0" }
+    peerDependencies:
+      "@astrojs/starlight": ">=0.39.0"
 
-  "@shikijs/engine-javascript@3.23.0":
+  "@shikijs/core@4.1.0":
     resolution:
       {
-        integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==,
+        integrity: sha512-jLJtSJeuFffqX6/inRE1zqU5aFv2hrszvYgq3OjbAgFRZiWv7abKMDdQzYxuSDfmUPQozZvI/kuy6VMTvnvqTQ==,
       }
+    engines: { node: ">=20" }
+
+  "@shikijs/engine-javascript@4.1.0":
+    resolution:
+      {
+        integrity: sha512-YquhawCUgaBfhsS72e2Y/dI59gCBNPHu3fEO/tvLaXrTssxZrY5ddjtNLTwndrMgPo8b3IscE+xoICDzpTmlFQ==,
+      }
+    engines: { node: ">=20" }
 
   "@shikijs/engine-oniguruma@3.23.0":
     resolution:
@@ -3736,11 +3512,32 @@ packages:
         integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==,
       }
 
+  "@shikijs/engine-oniguruma@4.1.0":
+    resolution:
+      {
+        integrity: sha512-axLpjVs45YBvvINa+dJF+NPW+KtFkNXsFr4SDw2BMj9GdeMnGxVB9PQb2xXlJYovslt/nz6giedAyOANkfc7hg==,
+      }
+    engines: { node: ">=20" }
+
   "@shikijs/langs@3.23.0":
     resolution:
       {
         integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==,
       }
+
+  "@shikijs/langs@4.1.0":
+    resolution:
+      {
+        integrity: sha512-nwOMruEkbgdZfQ/b8CgpNBVOpvG1k0N5tbmgiFeqsan401+x3ILqlzZJowSla4Agmq4hG2Uf2wh5jLTEhR8VSg==,
+      }
+    engines: { node: ">=20" }
+
+  "@shikijs/primitive@4.1.0":
+    resolution:
+      {
+        integrity: sha512-zx2/2Uwj2q9X3KSyYREEhXO23xBw5WUhP4orK2lE4r+t9JGITmEe0JH+wPmJhqHpOT2bRRs6lAL945+LDvOAGw==,
+      }
+    engines: { node: ">=20" }
 
   "@shikijs/themes@3.23.0":
     resolution:
@@ -3748,11 +3545,25 @@ packages:
         integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==,
       }
 
+  "@shikijs/themes@4.1.0":
+    resolution:
+      {
+        integrity: sha512-emCcTnUM7yO2wltYbaxm+yLvcCI4+h8XBKc4KmJ7EZUXoSGjcCHifkI//R4OFit9ewpg7H2/9tjOuXrT2v/Knw==,
+      }
+    engines: { node: ">=20" }
+
   "@shikijs/types@3.23.0":
     resolution:
       {
         integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==,
       }
+
+  "@shikijs/types@4.1.0":
+    resolution:
+      {
+        integrity: sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==,
+      }
+    engines: { node: ">=20" }
 
   "@shikijs/vscode-textmate@10.0.2":
     resolution:
@@ -4470,6 +4281,7 @@ packages:
       {
         integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==,
       }
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   "@vercel/backends@0.0.62":
     resolution:
@@ -4926,12 +4738,6 @@ packages:
         integrity: sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==,
       }
 
-  ansi-align@3.0.1:
-    resolution:
-      {
-        integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==,
-      }
-
   ansi-escapes@7.3.0:
     resolution:
       {
@@ -5032,21 +4838,20 @@ packages:
       }
     hasBin: true
 
-  astro-expressive-code@0.41.7:
+  astro-expressive-code@0.42.0:
     resolution:
       {
-        integrity: sha512-hUpogGc6DdAd+I7pPXsctyYPRBJDK7Q7d06s4cyP0Vz3OcbziP3FNzN0jZci1BpCvLn9675DvS7B9ctKKX64JQ==,
+        integrity: sha512-aiTePi2Cn0mJPYWZSzP1GcxCinX9mNtJyCCshVVPSg1yRwM7ADvFJOx0FnS440M9t65hp8JH//dc2qr22Bm4ag==,
       }
     peerDependencies:
       astro: ^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta
 
-  astro@5.18.1:
+  astro@6.3.7:
     resolution:
       {
-        integrity: sha512-m4VWilWZ+Xt6NPoYzC4CgGZim/zQUO7WFL0RHCH0AiEavF1153iC3+me2atDvXpf/yX4PyGUeD8wZLq1cirT3g==,
+        integrity: sha512-zIeDRrI0qNgN1lcCjNqt6/IVCVej7VwSa326cO8uP9BOk1cg4QuffhLnOn2gCgWQr32/wxpSRFfXiLKHglu1Tw==,
       }
-    engines:
-      { node: 18.20.8 || ^20.3.0 || >=22.0.0, npm: ">=9.6.5", pnpm: ">=7.1.0" }
+    engines: { node: ">=22.12.0", npm: ">=9.6.5", pnpm: ">=7.1.0" }
     hasBin: true
 
   async-listen@1.2.0:
@@ -5141,12 +4946,6 @@ packages:
       bare-abort-controller:
         optional: true
 
-  base-64@1.0.0:
-    resolution:
-      {
-        integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==,
-      }
-
   base64-js@1.5.1:
     resolution:
       {
@@ -5225,13 +5024,6 @@ packages:
       {
         integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==,
       }
-
-  boxen@8.0.1:
-    resolution:
-      {
-        integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==,
-      }
-    engines: { node: ">=18" }
 
   brace-expansion@1.1.13:
     resolution:
@@ -5320,13 +5112,6 @@ packages:
         integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==,
       }
     engines: { node: ">= 0.4" }
-
-  camelcase@8.0.0:
-    resolution:
-      {
-        integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==,
-      }
-    engines: { node: ">=16" }
 
   ccount@2.0.1:
     resolution:
@@ -5437,13 +5222,6 @@ packages:
       {
         integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==,
       }
-
-  cli-boxes@3.0.0:
-    resolution:
-      {
-        integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==,
-      }
-    engines: { node: ">=10" }
 
   cli-cursor@5.0.0:
     resolution:
@@ -5565,11 +5343,12 @@ packages:
       }
     engines: { node: ">= 6" }
 
-  common-ancestor-path@1.0.1:
+  common-ancestor-path@2.0.0:
     resolution:
       {
-        integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==,
+        integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==,
       }
+    engines: { node: ">= 18" }
 
   concat-map@0.0.1:
     resolution:
@@ -5882,13 +5661,6 @@ packages:
       }
     engines: { node: ">=8" }
 
-  deterministic-object-hash@2.0.2:
-    resolution:
-      {
-        integrity: sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==,
-      }
-    engines: { node: ">=18" }
-
   devalue@5.6.4:
     resolution:
       {
@@ -5914,12 +5686,6 @@ packages:
         integrity: sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==,
       }
     hasBin: true
-
-  dlv@1.1.3:
-    resolution:
-      {
-        integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==,
-      }
 
   dom-serializer@2.0.0:
     resolution:
@@ -6086,12 +5852,6 @@ packages:
         integrity: sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw==,
       }
 
-  es-module-lexer@1.7.0:
-    resolution:
-      {
-        integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==,
-      }
-
   es-module-lexer@2.1.0:
     resolution:
       {
@@ -6123,14 +5883,6 @@ packages:
       {
         integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==,
       }
-
-  esbuild@0.25.12:
-    resolution:
-      {
-        integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==,
-      }
-    engines: { node: ">=18" }
-    hasBin: true
 
   esbuild@0.27.0:
     resolution:
@@ -6342,10 +6094,10 @@ packages:
       }
     engines: { node: ">= 18" }
 
-  expressive-code@0.41.7:
+  expressive-code@0.42.0:
     resolution:
       {
-        integrity: sha512-2wZjC8OQ3TaVEMcBtYY4Va3lo6J+Ai9jf3d4dbhURMJcU4Pbqe6EcHe424MIZI0VHUA1bR6xdpoHYi3yxokWqA==,
+        integrity: sha512-V5DtJLEKuj4wf9O6IRtPtRObkMVy2ggR+S0MdjrTw6m58krZnDioyhW1si3Y04c5YPeooP4nd85Yq9NwEVHS4g==,
       }
 
   exsolve@1.0.8:
@@ -6654,6 +6406,13 @@ packages:
       {
         integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==,
       }
+
+  get-tsconfig@5.0.0-beta.4:
+    resolution:
+      {
+        integrity: sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==,
+      }
+    engines: { node: ">=20.20.0" }
 
   get-uri@6.0.5:
     resolution:
@@ -7001,11 +6760,16 @@ packages:
       }
     engines: { node: ">=10.17.0" }
 
-  i18next@23.16.8:
+  i18next@26.2.0:
     resolution:
       {
-        integrity: sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==,
+        integrity: sha512-zwBHldHdTmwN7r6UNc7lC6GWNN+YYg3DrRSeHR5PRRBf5QnJZcYHrQc0uaU26qZeYxR7iFZD+Y315dPnKP47wA==,
       }
+    peerDependencies:
+      typescript: ^5 || ^6
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   iconv-lite@0.4.24:
     resolution:
@@ -7046,12 +6810,6 @@ packages:
         integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==,
       }
     engines: { node: ">=18" }
-
-  import-meta-resolve@4.2.0:
-    resolution:
-      {
-        integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==,
-      }
 
   inherits@2.0.4:
     resolution:
@@ -7150,6 +6908,14 @@ packages:
         integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==,
       }
     engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+    hasBin: true
+
+  is-docker@4.0.0:
+    resolution:
+      {
+        integrity: sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==,
+      }
+    engines: { node: ">=20" }
     hasBin: true
 
   is-electron@2.2.2:
@@ -7812,10 +7578,10 @@ packages:
         integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==,
       }
 
-  micromark-extension-directive@3.0.2:
+  micromark-extension-directive@4.0.0:
     resolution:
       {
-        integrity: sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA==,
+        integrity: sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==,
       }
 
   micromark-extension-gfm-autolink-literal@2.1.0:
@@ -8215,14 +7981,6 @@ packages:
         integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==,
       }
 
-  nanoid@3.3.11:
-    resolution:
-      {
-        integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==,
-      }
-    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
-    hasBin: true
-
   nanoid@3.3.12:
     resolution:
       {
@@ -8514,16 +8272,16 @@ packages:
       }
     engines: { node: ">=18" }
 
-  oniguruma-parser@0.12.1:
+  oniguruma-parser@0.12.2:
     resolution:
       {
-        integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==,
+        integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==,
       }
 
-  oniguruma-to-es@4.3.5:
+  oniguruma-to-es@4.3.6:
     resolution:
       {
-        integrity: sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==,
+        integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==,
       }
 
   openai@6.26.0:
@@ -8588,12 +8346,12 @@ packages:
       }
     engines: { node: ">=8" }
 
-  p-limit@6.2.0:
+  p-limit@7.3.0:
     resolution:
       {
-        integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==,
+        integrity: sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==,
       }
-    engines: { node: ">=18" }
+    engines: { node: ">=20" }
 
   p-queue@6.6.2:
     resolution:
@@ -8602,12 +8360,12 @@ packages:
       }
     engines: { node: ">=8" }
 
-  p-queue@8.1.1:
+  p-queue@9.3.0:
     resolution:
       {
-        integrity: sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==,
+        integrity: sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==,
       }
-    engines: { node: ">=18" }
+    engines: { node: ">=20" }
 
   p-retry@4.6.2:
     resolution:
@@ -8623,12 +8381,12 @@ packages:
       }
     engines: { node: ">=8" }
 
-  p-timeout@6.1.4:
+  p-timeout@7.0.1:
     resolution:
       {
-        integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==,
+        integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==,
       }
-    engines: { node: ">=14.16" }
+    engines: { node: ">=20" }
 
   pac-proxy-agent@7.2.0:
     resolution:
@@ -8890,13 +8648,6 @@ packages:
     resolution:
       {
         integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==,
-      }
-    engines: { node: ^10 || ^12 || >=14 }
-
-  postcss@8.5.8:
-    resolution:
-      {
-        integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==,
       }
     engines: { node: ^10 || ^12 || >=14 }
 
@@ -9191,10 +8942,10 @@ packages:
       }
     hasBin: true
 
-  rehype-expressive-code@0.41.7:
+  rehype-expressive-code@0.42.0:
     resolution:
       {
-        integrity: sha512-25f8ZMSF1d9CMscX7Cft0TSQIqdwjce2gDOvQ+d/w0FovsMwrSt3ODP4P3Z7wO1jsIJ4eYyaDRnIR/27bd/EMQ==,
+        integrity: sha512-8rp/1YMEVVSYbtz+bFBx+uSx3vA4i4T8RwRm5Q/IWbucQnnQqQ0hDqtmKOr8tv+59Cik6cu5aH3WPo0I7csuTA==,
       }
 
   rehype-format@5.0.1:
@@ -9233,10 +8984,10 @@ packages:
         integrity: sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==,
       }
 
-  remark-directive@3.0.1:
+  remark-directive@4.0.0:
     resolution:
       {
-        integrity: sha512-gwglrEQEZcZYgVyG1tQuA+h58EZfq5CSULw7J90AFuCTyib1thgHPoqQ+h9iFvU6R+vnZ5oNFQR5QKgGpk741A==,
+        integrity: sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA==,
       }
 
   remark-gfm@4.0.1:
@@ -9566,11 +9317,12 @@ packages:
       }
     engines: { node: ">=8" }
 
-  shiki@3.23.0:
+  shiki@4.1.0:
     resolution:
       {
-        integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==,
+        integrity: sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q==,
       }
+    engines: { node: ">=20" }
 
   side-channel-list@1.0.0:
     resolution:
@@ -9775,14 +9527,14 @@ packages:
         integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==,
       }
 
-  starlight-typedoc@0.21.5:
+  starlight-typedoc@0.23.0:
     resolution:
       {
-        integrity: sha512-7JGaPHrP+HgX0sYGnafZcPuzMm+3OmHx7kqE0DWTrsuBfoQS02lJ6/PtJF9y0KCDcfsBynyo0G/1ttHcBq5Vww==,
+        integrity: sha512-GB0tB/15nL3l9tt1aGpkV8EixnSXbApZNZaSBRt8KfIsDAJet7pRiyItk5dxBSbDTXilF2whOMXPqqkbm8dNWA==,
       }
-    engines: { node: ">=18.17.1" }
+    engines: { node: ">=22.12.0" }
     peerDependencies:
-      "@astrojs/starlight": ">=0.32.0"
+      "@astrojs/starlight": ">=0.39.0"
       typedoc: ">=0.28.0"
       typedoc-plugin-markdown: ">=4.6.0"
 
@@ -10073,6 +9825,13 @@ packages:
         integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==,
       }
 
+  tinyclip@0.1.12:
+    resolution:
+      {
+        integrity: sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==,
+      }
+    engines: { node: ^16.14.0 || >= 17.3.0 }
+
   tinyexec@0.3.2:
     resolution:
       {
@@ -10211,19 +9970,6 @@ packages:
         integrity: sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==,
       }
 
-  tsconfck@3.1.6:
-    resolution:
-      {
-        integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==,
-      }
-    engines: { node: ^18 || >=20 }
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   tsconfig-paths-webpack-plugin@4.2.0:
     resolution:
       {
@@ -10286,13 +10032,6 @@ packages:
         integrity: sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==,
       }
     engines: { node: ">=18", npm: ">=9" }
-
-  type-fest@4.41.0:
-    resolution:
-      {
-        integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==,
-      }
-    engines: { node: ">=16" }
 
   type-fest@5.6.0:
     resolution:
@@ -10714,22 +10453,22 @@ packages:
         integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==,
       }
 
-  vite@6.4.1:
+  vite@7.3.3:
     resolution:
       {
-        integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==,
+        integrity: sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==,
       }
-    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
     peerDependencies:
-      "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
+      "@types/node": ^20.19.0 || >=22.12.0
       jiti: ">=1.21.0"
-      less: "*"
+      less: ^4.0.0
       lightningcss: ^1.21.0
-      sass: "*"
-      sass-embedded: "*"
-      stylus: "*"
-      sugarss: "*"
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: ">=0.54.8"
+      sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
@@ -11079,13 +10818,6 @@ packages:
     engines: { node: ">=8" }
     hasBin: true
 
-  widest-line@5.0.0:
-    resolution:
-      {
-        integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==,
-      }
-    engines: { node: ">=18" }
-
   wrap-ansi@7.0.0:
     resolution:
       {
@@ -11206,6 +10938,13 @@ packages:
       }
     engines: { node: ">=12" }
 
+  yargs-parser@22.0.0:
+    resolution:
+      {
+        integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==,
+      }
+    engines: { node: ^20.19.0 || ^22.12.0 || >=23 }
+
   yargs@17.7.2:
     resolution:
       {
@@ -11240,20 +10979,6 @@ packages:
       }
     engines: { node: ">=12.20" }
 
-  yocto-spinner@0.2.3:
-    resolution:
-      {
-        integrity: sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==,
-      }
-    engines: { node: ">=18.19" }
-
-  yoctocolors@2.1.2:
-    resolution:
-      {
-        integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==,
-      }
-    engines: { node: ">=18" }
-
   zod-to-json-schema@3.25.2:
     resolution:
       {
@@ -11261,15 +10986,6 @@ packages:
       }
     peerDependencies:
       zod: ^3.25.28 || ^4
-
-  zod-to-ts@1.2.0:
-    resolution:
-      {
-        integrity: sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==,
-      }
-    peerDependencies:
-      typescript: ^4.9.4 || ^5.0.2
-      zod: ^3
 
   zod@3.22.4:
     resolution:
@@ -11339,7 +11055,11 @@ snapshots:
 
   "@astrojs/compiler@2.13.1": {}
 
-  "@astrojs/internal-helpers@0.7.6": {}
+  "@astrojs/compiler@4.0.0": {}
+
+  "@astrojs/internal-helpers@0.9.1":
+    dependencies:
+      picomatch: 4.0.4
 
   "@astrojs/language-server@2.16.7(prettier@3.8.3)(typescript@5.9.3)":
     dependencies:
@@ -11366,14 +11086,13 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  "@astrojs/markdown-remark@6.3.11":
+  "@astrojs/markdown-remark@7.1.2":
     dependencies:
-      "@astrojs/internal-helpers": 0.7.6
-      "@astrojs/prism": 3.3.0
+      "@astrojs/internal-helpers": 0.9.1
+      "@astrojs/prism": 4.0.2
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
       hast-util-to-text: 4.0.2
-      import-meta-resolve: 4.2.0
       js-yaml: 4.1.1
       mdast-util-definitions: 6.0.0
       rehype-raw: 7.0.0
@@ -11382,7 +11101,8 @@ snapshots:
       remark-parse: 11.0.0
       remark-rehype: 11.1.2
       remark-smartypants: 3.0.2
-      shiki: 3.23.0
+      retext-smartypants: 6.2.0
+      shiki: 4.1.0
       smol-toml: 1.6.1
       unified: 11.0.5
       unist-util-remove-position: 5.0.0
@@ -11392,13 +11112,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@astrojs/mdx@4.3.14(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4))":
+  "@astrojs/mdx@5.0.6(astro@6.3.7(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))":
     dependencies:
-      "@astrojs/markdown-remark": 6.3.11
+      "@astrojs/markdown-remark": 7.1.2
       "@mdx-js/mdx": 3.1.1
       acorn: 8.16.0
-      astro: 5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)
-      es-module-lexer: 1.7.0
+      astro: 6.3.7(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
+      es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
       piccolore: 0.1.3
@@ -11411,7 +11131,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@astrojs/prism@3.3.0":
+  "@astrojs/prism@4.0.2":
     dependencies:
       prismjs: 1.30.0
 
@@ -11421,23 +11141,23 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.4.3
 
-  "@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4))":
+  "@astrojs/starlight@0.39.2(astro@6.3.7(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3)":
     dependencies:
-      "@astrojs/markdown-remark": 6.3.11
-      "@astrojs/mdx": 4.3.14(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4))
+      "@astrojs/markdown-remark": 7.1.2
+      "@astrojs/mdx": 5.0.6(astro@6.3.7(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
       "@astrojs/sitemap": 3.7.2
       "@pagefind/default-ui": 1.5.2
       "@types/hast": 3.0.4
       "@types/js-yaml": 4.0.9
       "@types/mdast": 4.0.4
-      astro: 5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)
-      astro-expressive-code: 0.41.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4))
+      astro: 6.3.7(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
+      astro-expressive-code: 0.42.0(astro@6.3.7(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
       hast-util-to-string: 3.0.1
       hastscript: 9.0.1
-      i18next: 23.16.8
+      i18next: 26.2.0(typescript@5.9.3)
       js-yaml: 4.1.1
       klona: 2.0.6
       magic-string: 0.30.21
@@ -11447,25 +11167,22 @@ snapshots:
       pagefind: 1.5.2
       rehype: 13.0.2
       rehype-format: 5.0.1
-      remark-directive: 3.0.1
+      remark-directive: 4.0.0
       ultrahtml: 1.6.0
       unified: 11.0.5
       unist-util-visit: 5.1.0
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+      - typescript
 
-  "@astrojs/telemetry@3.3.0":
+  "@astrojs/telemetry@3.3.2":
     dependencies:
       ci-info: 4.4.0
-      debug: 4.4.3
-      dlv: 1.1.3
       dset: 3.1.4
-      is-docker: 3.0.0
+      is-docker: 4.0.0
       is-wsl: 3.1.1
       which-pm-runs: 1.1.0
-    transitivePeerDependencies:
-      - supports-color
 
   "@astrojs/yaml2ts@0.2.3":
     dependencies:
@@ -11935,6 +11652,18 @@ snapshots:
       - "@opentelemetry/api"
       - supports-color
 
+  "@clack/core@1.3.1":
+    dependencies:
+      fast-wrap-ansi: 0.2.0
+      sisteransi: 1.0.5
+
+  "@clack/prompts@1.4.0":
+    dependencies:
+      "@clack/core": 1.3.1
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.0
+      sisteransi: 1.0.5
+
   "@ctrl/tinycolor@4.2.0": {}
 
   "@edge-runtime/format@2.2.1": {}
@@ -11983,17 +11712,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  "@emnapi/runtime@1.9.1":
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   "@emnapi/wasi-threads@1.2.1":
     dependencies:
       tslib: 2.8.1
-    optional: true
-
-  "@esbuild/aix-ppc64@0.25.12":
     optional: true
 
   "@esbuild/aix-ppc64@0.27.0":
@@ -12002,16 +11723,10 @@ snapshots:
   "@esbuild/aix-ppc64@0.27.4":
     optional: true
 
-  "@esbuild/android-arm64@0.25.12":
-    optional: true
-
   "@esbuild/android-arm64@0.27.0":
     optional: true
 
   "@esbuild/android-arm64@0.27.4":
-    optional: true
-
-  "@esbuild/android-arm@0.25.12":
     optional: true
 
   "@esbuild/android-arm@0.27.0":
@@ -12020,16 +11735,10 @@ snapshots:
   "@esbuild/android-arm@0.27.4":
     optional: true
 
-  "@esbuild/android-x64@0.25.12":
-    optional: true
-
   "@esbuild/android-x64@0.27.0":
     optional: true
 
   "@esbuild/android-x64@0.27.4":
-    optional: true
-
-  "@esbuild/darwin-arm64@0.25.12":
     optional: true
 
   "@esbuild/darwin-arm64@0.27.0":
@@ -12038,16 +11747,10 @@ snapshots:
   "@esbuild/darwin-arm64@0.27.4":
     optional: true
 
-  "@esbuild/darwin-x64@0.25.12":
-    optional: true
-
   "@esbuild/darwin-x64@0.27.0":
     optional: true
 
   "@esbuild/darwin-x64@0.27.4":
-    optional: true
-
-  "@esbuild/freebsd-arm64@0.25.12":
     optional: true
 
   "@esbuild/freebsd-arm64@0.27.0":
@@ -12056,16 +11759,10 @@ snapshots:
   "@esbuild/freebsd-arm64@0.27.4":
     optional: true
 
-  "@esbuild/freebsd-x64@0.25.12":
-    optional: true
-
   "@esbuild/freebsd-x64@0.27.0":
     optional: true
 
   "@esbuild/freebsd-x64@0.27.4":
-    optional: true
-
-  "@esbuild/linux-arm64@0.25.12":
     optional: true
 
   "@esbuild/linux-arm64@0.27.0":
@@ -12074,16 +11771,10 @@ snapshots:
   "@esbuild/linux-arm64@0.27.4":
     optional: true
 
-  "@esbuild/linux-arm@0.25.12":
-    optional: true
-
   "@esbuild/linux-arm@0.27.0":
     optional: true
 
   "@esbuild/linux-arm@0.27.4":
-    optional: true
-
-  "@esbuild/linux-ia32@0.25.12":
     optional: true
 
   "@esbuild/linux-ia32@0.27.0":
@@ -12092,16 +11783,10 @@ snapshots:
   "@esbuild/linux-ia32@0.27.4":
     optional: true
 
-  "@esbuild/linux-loong64@0.25.12":
-    optional: true
-
   "@esbuild/linux-loong64@0.27.0":
     optional: true
 
   "@esbuild/linux-loong64@0.27.4":
-    optional: true
-
-  "@esbuild/linux-mips64el@0.25.12":
     optional: true
 
   "@esbuild/linux-mips64el@0.27.0":
@@ -12110,16 +11795,10 @@ snapshots:
   "@esbuild/linux-mips64el@0.27.4":
     optional: true
 
-  "@esbuild/linux-ppc64@0.25.12":
-    optional: true
-
   "@esbuild/linux-ppc64@0.27.0":
     optional: true
 
   "@esbuild/linux-ppc64@0.27.4":
-    optional: true
-
-  "@esbuild/linux-riscv64@0.25.12":
     optional: true
 
   "@esbuild/linux-riscv64@0.27.0":
@@ -12128,16 +11807,10 @@ snapshots:
   "@esbuild/linux-riscv64@0.27.4":
     optional: true
 
-  "@esbuild/linux-s390x@0.25.12":
-    optional: true
-
   "@esbuild/linux-s390x@0.27.0":
     optional: true
 
   "@esbuild/linux-s390x@0.27.4":
-    optional: true
-
-  "@esbuild/linux-x64@0.25.12":
     optional: true
 
   "@esbuild/linux-x64@0.27.0":
@@ -12146,16 +11819,10 @@ snapshots:
   "@esbuild/linux-x64@0.27.4":
     optional: true
 
-  "@esbuild/netbsd-arm64@0.25.12":
-    optional: true
-
   "@esbuild/netbsd-arm64@0.27.0":
     optional: true
 
   "@esbuild/netbsd-arm64@0.27.4":
-    optional: true
-
-  "@esbuild/netbsd-x64@0.25.12":
     optional: true
 
   "@esbuild/netbsd-x64@0.27.0":
@@ -12164,16 +11831,10 @@ snapshots:
   "@esbuild/netbsd-x64@0.27.4":
     optional: true
 
-  "@esbuild/openbsd-arm64@0.25.12":
-    optional: true
-
   "@esbuild/openbsd-arm64@0.27.0":
     optional: true
 
   "@esbuild/openbsd-arm64@0.27.4":
-    optional: true
-
-  "@esbuild/openbsd-x64@0.25.12":
     optional: true
 
   "@esbuild/openbsd-x64@0.27.0":
@@ -12182,16 +11843,10 @@ snapshots:
   "@esbuild/openbsd-x64@0.27.4":
     optional: true
 
-  "@esbuild/openharmony-arm64@0.25.12":
-    optional: true
-
   "@esbuild/openharmony-arm64@0.27.0":
     optional: true
 
   "@esbuild/openharmony-arm64@0.27.4":
-    optional: true
-
-  "@esbuild/sunos-x64@0.25.12":
     optional: true
 
   "@esbuild/sunos-x64@0.27.0":
@@ -12200,16 +11855,10 @@ snapshots:
   "@esbuild/sunos-x64@0.27.4":
     optional: true
 
-  "@esbuild/win32-arm64@0.25.12":
-    optional: true
-
   "@esbuild/win32-arm64@0.27.0":
     optional: true
 
   "@esbuild/win32-arm64@0.27.4":
-    optional: true
-
-  "@esbuild/win32-ia32@0.25.12":
     optional: true
 
   "@esbuild/win32-ia32@0.27.0":
@@ -12218,16 +11867,13 @@ snapshots:
   "@esbuild/win32-ia32@0.27.4":
     optional: true
 
-  "@esbuild/win32-x64@0.25.12":
-    optional: true
-
   "@esbuild/win32-x64@0.27.0":
     optional: true
 
   "@esbuild/win32-x64@0.27.4":
     optional: true
 
-  "@expressive-code/core@0.41.7":
+  "@expressive-code/core@0.42.0":
     dependencies:
       "@ctrl/tinycolor": 4.2.0
       hast-util-select: 6.0.4
@@ -12239,18 +11885,18 @@ snapshots:
       unist-util-visit: 5.1.0
       unist-util-visit-parents: 6.0.2
 
-  "@expressive-code/plugin-frames@0.41.7":
+  "@expressive-code/plugin-frames@0.42.0":
     dependencies:
-      "@expressive-code/core": 0.41.7
+      "@expressive-code/core": 0.42.0
 
-  "@expressive-code/plugin-shiki@0.41.7":
+  "@expressive-code/plugin-shiki@0.42.0":
     dependencies:
-      "@expressive-code/core": 0.41.7
-      shiki: 3.23.0
+      "@expressive-code/core": 0.42.0
+      shiki: 4.1.0
 
-  "@expressive-code/plugin-text-markers@0.41.7":
+  "@expressive-code/plugin-text-markers@0.42.0":
     dependencies:
-      "@expressive-code/core": 0.41.7
+      "@expressive-code/core": 0.42.0
 
   "@fastify/busboy@2.1.1": {}
 
@@ -12263,10 +11909,6 @@ snapshots:
       minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
-
-  "@fontsource-variable/space-grotesk@5.2.10": {}
-
-  "@fontsource/ibm-plex-mono@5.2.7": {}
 
   "@gerrit0/mini-shiki@3.23.0":
     dependencies:
@@ -12378,7 +12020,7 @@ snapshots:
 
   "@img/sharp-wasm32@0.34.5":
     dependencies:
-      "@emnapi/runtime": 1.9.1
+      "@emnapi/runtime": 1.10.0
     optional: true
 
   "@img/sharp-win32-arm64@0.34.5":
@@ -13245,7 +12887,7 @@ snapshots:
 
   "@rollup/pluginutils@5.3.0(rollup@4.60.1)":
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       estree-walker: 2.0.2
       picomatch: 4.0.4
     optionalDependencies:
@@ -13519,33 +13161,62 @@ snapshots:
       "@opentelemetry/semantic-conventions": 1.40.0
       "@sentry/core": 10.53.1
 
-  "@shikijs/core@3.23.0":
+  "@sentry/starlight-theme@0.3.0(@astrojs/starlight@0.39.2(astro@6.3.7(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3))":
     dependencies:
-      "@shikijs/types": 3.23.0
+      "@astrojs/starlight": 0.39.2(astro@6.3.7(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3)
+
+  "@shikijs/core@4.1.0":
+    dependencies:
+      "@shikijs/primitive": 4.1.0
+      "@shikijs/types": 4.1.0
       "@shikijs/vscode-textmate": 10.0.2
       "@types/hast": 3.0.4
       hast-util-to-html: 9.0.5
 
-  "@shikijs/engine-javascript@3.23.0":
+  "@shikijs/engine-javascript@4.1.0":
     dependencies:
-      "@shikijs/types": 3.23.0
+      "@shikijs/types": 4.1.0
       "@shikijs/vscode-textmate": 10.0.2
-      oniguruma-to-es: 4.3.5
+      oniguruma-to-es: 4.3.6
 
   "@shikijs/engine-oniguruma@3.23.0":
     dependencies:
       "@shikijs/types": 3.23.0
       "@shikijs/vscode-textmate": 10.0.2
 
+  "@shikijs/engine-oniguruma@4.1.0":
+    dependencies:
+      "@shikijs/types": 4.1.0
+      "@shikijs/vscode-textmate": 10.0.2
+
   "@shikijs/langs@3.23.0":
     dependencies:
       "@shikijs/types": 3.23.0
+
+  "@shikijs/langs@4.1.0":
+    dependencies:
+      "@shikijs/types": 4.1.0
+
+  "@shikijs/primitive@4.1.0":
+    dependencies:
+      "@shikijs/types": 4.1.0
+      "@shikijs/vscode-textmate": 10.0.2
+      "@types/hast": 3.0.4
 
   "@shikijs/themes@3.23.0":
     dependencies:
       "@shikijs/types": 3.23.0
 
+  "@shikijs/themes@4.1.0":
+    dependencies:
+      "@shikijs/types": 4.1.0
+
   "@shikijs/types@3.23.0":
+    dependencies:
+      "@shikijs/vscode-textmate": 10.0.2
+      "@types/hast": 3.0.4
+
+  "@shikijs/types@4.1.0":
     dependencies:
       "@shikijs/vscode-textmate": 10.0.2
       "@types/hast": 3.0.4
@@ -14563,10 +14234,6 @@ snapshots:
       require-from-string: 2.0.2
       uri-js: 4.4.1
 
-  ansi-align@3.0.1:
-    dependencies:
-      string-width: 4.2.3
-
   ansi-escapes@7.3.0:
     dependencies:
       environment: 1.1.0
@@ -14606,76 +14273,68 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)):
+  astro-expressive-code@0.42.0(astro@6.3.7(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)):
     dependencies:
-      astro: 5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)
-      rehype-expressive-code: 0.41.7
+      astro: 6.3.7(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
+      rehype-expressive-code: 0.42.0
 
-  astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4):
+  astro@6.3.7(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
-      "@astrojs/compiler": 2.13.1
-      "@astrojs/internal-helpers": 0.7.6
-      "@astrojs/markdown-remark": 6.3.11
-      "@astrojs/telemetry": 3.3.0
+      "@astrojs/compiler": 4.0.0
+      "@astrojs/internal-helpers": 0.9.1
+      "@astrojs/markdown-remark": 7.1.2
+      "@astrojs/telemetry": 3.3.2
       "@capsizecss/unpack": 4.0.0
+      "@clack/prompts": 1.4.0
       "@oslojs/encoding": 1.1.0
       "@rollup/pluginutils": 5.3.0(rollup@4.60.1)
-      acorn: 8.16.0
       aria-query: 5.3.2
       axobject-query: 4.1.0
-      boxen: 8.0.1
       ci-info: 4.4.0
       clsx: 2.1.1
-      common-ancestor-path: 1.0.1
+      common-ancestor-path: 2.0.0
       cookie: 1.1.1
-      cssesc: 3.0.0
-      debug: 4.4.3
-      deterministic-object-hash: 2.0.2
       devalue: 5.6.4
       diff: 8.0.4
-      dlv: 1.1.3
       dset: 3.1.4
-      es-module-lexer: 1.7.0
+      es-module-lexer: 2.1.0
       esbuild: 0.27.4
-      estree-walker: 3.0.3
       flattie: 1.1.1
       fontace: 0.4.1
+      get-tsconfig: 5.0.0-beta.4
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
-      import-meta-resolve: 4.2.0
       js-yaml: 4.1.1
+      jsonc-parser: 3.3.1
       magic-string: 0.30.21
       magicast: 0.5.2
       mrmime: 2.0.1
       neotraverse: 0.6.18
-      p-limit: 6.2.0
-      p-queue: 8.1.1
+      obug: 2.1.1
+      p-limit: 7.3.0
+      p-queue: 9.3.0
       package-manager-detector: 1.6.0
       piccolore: 0.1.3
       picomatch: 4.0.4
-      prompts: 2.4.2
       rehype: 13.0.2
       semver: 7.7.4
-      shiki: 3.23.0
+      shiki: 4.1.0
       smol-toml: 1.6.1
       svgo: 4.0.1
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.15
-      tsconfck: 3.1.6(typescript@5.9.3)
+      tinyclip: 0.1.12
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unist-util-visit: 5.1.0
       unstorage: 1.17.5(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)
       vfile: 6.0.3
-      vite: 6.4.1(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
-      vitefu: 1.1.2(vite@6.4.1(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
+      vite: 7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
+      vitefu: 1.1.2(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
       xxhash-wasm: 1.1.0
-      yargs-parser: 21.1.1
-      yocto-spinner: 0.2.3
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
-      zod-to-ts: 1.2.0(typescript@5.9.3)(zod@3.25.76)
+      yargs-parser: 22.0.0
+      zod: 4.4.3
     optionalDependencies:
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -14709,7 +14368,6 @@ snapshots:
       - supports-color
       - terser
       - tsx
-      - typescript
       - uploadthing
       - yaml
 
@@ -14746,8 +14404,6 @@ snapshots:
   balanced-match@4.0.4: {}
 
   bare-events@2.8.2: {}
-
-  base-64@1.0.0: {}
 
   base64-js@1.5.1: {}
 
@@ -14802,17 +14458,6 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  boxen@8.0.1:
-    dependencies:
-      ansi-align: 3.0.1
-      camelcase: 8.0.0
-      chalk: 5.6.2
-      cli-boxes: 3.0.0
-      string-width: 7.2.0
-      type-fest: 4.41.0
-      widest-line: 5.0.0
-      wrap-ansi: 9.0.2
-
   brace-expansion@1.1.13:
     dependencies:
       balanced-match: 1.0.2
@@ -14859,8 +14504,6 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
-
-  camelcase@8.0.0: {}
 
   ccount@2.0.1: {}
 
@@ -14916,8 +14559,6 @@ snapshots:
 
   cjs-module-lexer@2.2.0: {}
 
-  cli-boxes@3.0.0: {}
-
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
@@ -14968,7 +14609,7 @@ snapshots:
 
   commander@6.2.1: {}
 
-  common-ancestor-path@1.0.1: {}
+  common-ancestor-path@2.0.0: {}
 
   concat-map@0.0.1: {}
 
@@ -15110,10 +14751,6 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  deterministic-object-hash@2.0.2:
-    dependencies:
-      base-64: 1.0.0
-
   devalue@5.6.4: {}
 
   devlop@1.1.0:
@@ -15123,8 +14760,6 @@ snapshots:
   diff@8.0.4: {}
 
   direction@2.0.1: {}
-
-  dlv@1.1.3: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -15215,8 +14850,6 @@ snapshots:
 
   es-module-lexer@1.5.0: {}
 
-  es-module-lexer@1.7.0: {}
-
   es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
@@ -15243,35 +14876,6 @@ snapshots:
       acorn: 8.16.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
-
-  esbuild@0.25.12:
-    optionalDependencies:
-      "@esbuild/aix-ppc64": 0.25.12
-      "@esbuild/android-arm": 0.25.12
-      "@esbuild/android-arm64": 0.25.12
-      "@esbuild/android-x64": 0.25.12
-      "@esbuild/darwin-arm64": 0.25.12
-      "@esbuild/darwin-x64": 0.25.12
-      "@esbuild/freebsd-arm64": 0.25.12
-      "@esbuild/freebsd-x64": 0.25.12
-      "@esbuild/linux-arm": 0.25.12
-      "@esbuild/linux-arm64": 0.25.12
-      "@esbuild/linux-ia32": 0.25.12
-      "@esbuild/linux-loong64": 0.25.12
-      "@esbuild/linux-mips64el": 0.25.12
-      "@esbuild/linux-ppc64": 0.25.12
-      "@esbuild/linux-riscv64": 0.25.12
-      "@esbuild/linux-s390x": 0.25.12
-      "@esbuild/linux-x64": 0.25.12
-      "@esbuild/netbsd-arm64": 0.25.12
-      "@esbuild/netbsd-x64": 0.25.12
-      "@esbuild/openbsd-arm64": 0.25.12
-      "@esbuild/openbsd-x64": 0.25.12
-      "@esbuild/openharmony-arm64": 0.25.12
-      "@esbuild/sunos-x64": 0.25.12
-      "@esbuild/win32-arm64": 0.25.12
-      "@esbuild/win32-ia32": 0.25.12
-      "@esbuild/win32-x64": 0.25.12
 
   esbuild@0.27.0:
     optionalDependencies:
@@ -15476,12 +15080,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  expressive-code@0.41.7:
+  expressive-code@0.42.0:
     dependencies:
-      "@expressive-code/core": 0.41.7
-      "@expressive-code/plugin-frames": 0.41.7
-      "@expressive-code/plugin-shiki": 0.41.7
-      "@expressive-code/plugin-text-markers": 0.41.7
+      "@expressive-code/core": 0.42.0
+      "@expressive-code/plugin-frames": 0.42.0
+      "@expressive-code/plugin-shiki": 0.42.0
+      "@expressive-code/plugin-text-markers": 0.42.0
 
   exsolve@1.0.8: {}
 
@@ -15669,6 +15273,10 @@ snapshots:
   get-stream@6.0.1: {}
 
   get-tsconfig@4.13.7:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  get-tsconfig@5.0.0-beta.4:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
@@ -15997,9 +15605,9 @@ snapshots:
 
   human-signals@2.1.0: {}
 
-  i18next@23.16.8:
-    dependencies:
-      "@babel/runtime": 7.29.2
+  i18next@26.2.0(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
 
   iconv-lite@0.4.24:
     dependencies:
@@ -16026,8 +15634,6 @@ snapshots:
       acorn-import-attributes: 1.9.5(acorn@8.16.0)
       cjs-module-lexer: 2.2.0
       module-details-from-path: 1.0.4
-
-  import-meta-resolve@4.2.0: {}
 
   inherits@2.0.4: {}
 
@@ -16064,6 +15670,8 @@ snapshots:
   is-decimal@2.0.1: {}
 
   is-docker@3.0.0: {}
+
+  is-docker@4.0.0: {}
 
   is-electron@2.2.2: {}
 
@@ -16542,7 +16150,7 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
-  micromark-extension-directive@3.0.2:
+  micromark-extension-directive@4.0.0:
     dependencies:
       devlop: 1.1.0
       micromark-factory-space: 2.0.1
@@ -16902,8 +16510,6 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.11: {}
-
   nanoid@3.3.12: {}
 
   napi-build-utils@2.0.0:
@@ -17074,11 +16680,11 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  oniguruma-parser@0.12.1: {}
+  oniguruma-parser@0.12.2: {}
 
-  oniguruma-to-es@4.3.5:
+  oniguruma-to-es@4.3.6:
     dependencies:
-      oniguruma-parser: 0.12.1
+      oniguruma-parser: 0.12.2
       regex: 6.1.0
       regex-recursion: 6.0.2
 
@@ -17143,7 +16749,7 @@ snapshots:
 
   p-finally@2.0.1: {}
 
-  p-limit@6.2.0:
+  p-limit@7.3.0:
     dependencies:
       yocto-queue: 1.2.2
 
@@ -17152,10 +16758,10 @@ snapshots:
       eventemitter3: 4.0.7
       p-timeout: 3.2.0
 
-  p-queue@8.1.1:
+  p-queue@9.3.0:
     dependencies:
       eventemitter3: 5.0.4
-      p-timeout: 6.1.4
+      p-timeout: 7.0.1
 
   p-retry@4.6.2:
     dependencies:
@@ -17166,7 +16772,7 @@ snapshots:
     dependencies:
       p-finally: 1.0.0
 
-  p-timeout@6.1.4: {}
+  p-timeout@7.0.1: {}
 
   pac-proxy-agent@7.2.0:
     dependencies:
@@ -17310,12 +16916,6 @@ snapshots:
   postcss@8.5.14:
     dependencies:
       nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.8:
-    dependencies:
-      nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -17534,9 +17134,9 @@ snapshots:
 
   regexp-tree@0.1.27: {}
 
-  rehype-expressive-code@0.41.7:
+  rehype-expressive-code@0.42.0:
     dependencies:
-      expressive-code: 0.41.7
+      expressive-code: 0.42.0
 
   rehype-format@5.0.1:
     dependencies:
@@ -17576,11 +17176,11 @@ snapshots:
       rehype-stringify: 10.0.1
       unified: 11.0.5
 
-  remark-directive@3.0.1:
+  remark-directive@4.0.0:
     dependencies:
       "@types/mdast": 4.0.4
       mdast-util-directive: 3.1.0
-      micromark-extension-directive: 3.0.2
+      micromark-extension-directive: 4.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
@@ -17916,14 +17516,14 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shiki@3.23.0:
+  shiki@4.1.0:
     dependencies:
-      "@shikijs/core": 3.23.0
-      "@shikijs/engine-javascript": 3.23.0
-      "@shikijs/engine-oniguruma": 3.23.0
-      "@shikijs/langs": 3.23.0
-      "@shikijs/themes": 3.23.0
-      "@shikijs/types": 3.23.0
+      "@shikijs/core": 4.1.0
+      "@shikijs/engine-javascript": 4.1.0
+      "@shikijs/engine-oniguruma": 4.1.0
+      "@shikijs/langs": 4.1.0
+      "@shikijs/themes": 4.1.0
+      "@shikijs/types": 4.1.0
       "@shikijs/vscode-textmate": 10.0.2
       "@types/hast": 3.0.4
 
@@ -18040,9 +17640,9 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  starlight-typedoc@0.21.5(@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4)))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@5.9.3)))(typedoc@0.28.19(typescript@5.9.3)):
+  starlight-typedoc@0.23.0(@astrojs/starlight@0.39.2(astro@6.3.7(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@5.9.3)))(typedoc@0.28.19(typescript@5.9.3)):
     dependencies:
-      "@astrojs/starlight": 0.37.7(astro@5.18.1(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.4))
+      "@astrojs/starlight": 0.39.2(astro@6.3.7(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3)
       github-slugger: 2.0.0
       typedoc: 0.28.19(typescript@5.9.3)
       typedoc-plugin-markdown: 4.11.0(typedoc@0.28.19(typescript@5.9.3))
@@ -18240,6 +17840,8 @@ snapshots:
 
   tinybench@2.9.0: {}
 
+  tinyclip@0.1.12: {}
+
   tinyexec@0.3.2: {}
 
   tinyexec@1.0.4: {}
@@ -18301,10 +17903,6 @@ snapshots:
 
   ts-toolbelt@6.15.5: {}
 
-  tsconfck@3.1.6(typescript@5.9.3):
-    optionalDependencies:
-      typescript: 5.9.3
-
   tsconfig-paths-webpack-plugin@4.2.0:
     dependencies:
       chalk: 4.1.2
@@ -18364,8 +17962,6 @@ snapshots:
   turndown@7.2.4:
     dependencies:
       "@mixmark-io/domino": 2.2.0
-
-  type-fest@4.41.0: {}
 
   type-fest@5.6.0:
     dependencies:
@@ -18588,14 +18184,14 @@ snapshots:
       "@types/unist": 3.0.3
       vfile-message: 4.0.3
 
-  vite@6.4.1(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4):
+  vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
-      esbuild: 0.25.12
+      esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.8
+      postcss: 8.5.14
       rollup: 4.60.1
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
     optionalDependencies:
       "@types/node": 25.6.0
       fsevents: 2.3.3
@@ -18624,9 +18220,9 @@ snapshots:
       - "@emnapi/core"
       - "@emnapi/runtime"
 
-  vitefu@1.1.2(vite@6.4.1(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)):
+  vitefu@1.1.2(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)):
     optionalDependencies:
-      vite: 6.4.1(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
 
   vitest-evals@0.9.0-beta.1(ai@6.0.175(zod@4.4.3))(tinyrainbow@3.1.0)(vitest@4.1.5(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(msw@2.14.3(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.3(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)))(zod@4.4.3):
     dependencies:
@@ -18788,10 +18384,6 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  widest-line@5.0.0:
-    dependencies:
-      string-width: 7.2.0
-
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -18848,6 +18440,8 @@ snapshots:
 
   yargs-parser@21.1.1: {}
 
+  yargs-parser@22.0.0: {}
+
   yargs@17.7.2:
     dependencies:
       cliui: 8.0.1
@@ -18874,24 +18468,9 @@ snapshots:
 
   yocto-queue@1.2.2: {}
 
-  yocto-spinner@0.2.3:
-    dependencies:
-      yoctocolors: 2.1.2
-
-  yoctocolors@2.1.2: {}
-
-  zod-to-json-schema@3.25.2(zod@3.25.76):
-    dependencies:
-      zod: 3.25.76
-
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
-
-  zod-to-ts@1.2.0(typescript@5.9.3)(zod@3.25.76):
-    dependencies:
-      typescript: 5.9.3
-      zod: 3.25.76
 
   zod@3.22.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ importers:
         specifier: ^0.39.2
         version: 0.39.2(astro@6.3.7(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3)
       "@sentry/starlight-theme":
-        specifier: ^0.3.0
-        version: 0.3.0(@astrojs/starlight@0.39.2(astro@6.3.7(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3))
+        specifier: ^0.6.0
+        version: 0.6.0(@astrojs/starlight@0.39.2(astro@6.3.7(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3))
       astro:
         specifier: ^6.3.7
         version: 6.3.7(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4)
@@ -1315,6 +1315,18 @@ packages:
       }
     peerDependencies:
       "@opentelemetry/api": ^1.9.0
+
+  "@fontsource-variable/rubik@5.2.8":
+    resolution:
+      {
+        integrity: sha512-vGDExLzB4a2Fj9mca5LqNoA2ZKcU9o+x5FEBLte/nxYkCB9hOQwZS6ZlItUv+Ssn7YMzKauGuI/Po+YueFuZbg==,
+      }
+
+  "@fontsource/ibm-plex-mono@5.2.7":
+    resolution:
+      {
+        integrity: sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==,
+      }
 
   "@gerrit0/mini-shiki@3.23.0":
     resolution:
@@ -3483,10 +3495,10 @@ packages:
       "@opentelemetry/sdk-trace-base": ^1.30.1 || ^2.1.0
       "@opentelemetry/semantic-conventions": ^1.39.0
 
-  "@sentry/starlight-theme@0.3.0":
+  "@sentry/starlight-theme@0.6.0":
     resolution:
       {
-        integrity: sha512-/6HZoCd54dQ9lJHcF5C5f9EDM1iZZZkMjDaItMPhC5ExpYgwT82sci77a+lFVx/85U7n1/0fGpekB4aozLQXAA==,
+        integrity: sha512-olQRVtrN9nJWoVVWhxUqk3KVEBCXRF2xLq4Pkd2/eyfpfzJTzfxFbAI4Sg/GV11IK3fFwNviIyFUPQR6aHsfKA==,
       }
     engines: { node: ">=22.12.0" }
     peerDependencies:
@@ -11910,6 +11922,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  "@fontsource-variable/rubik@5.2.8": {}
+
+  "@fontsource/ibm-plex-mono@5.2.7": {}
+
   "@gerrit0/mini-shiki@3.23.0":
     dependencies:
       "@shikijs/engine-oniguruma": 3.23.0
@@ -13161,9 +13177,12 @@ snapshots:
       "@opentelemetry/semantic-conventions": 1.40.0
       "@sentry/core": 10.53.1
 
-  "@sentry/starlight-theme@0.3.0(@astrojs/starlight@0.39.2(astro@6.3.7(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3))":
+  "@sentry/starlight-theme@0.6.0(@astrojs/starlight@0.39.2(astro@6.3.7(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3))":
     dependencies:
       "@astrojs/starlight": 0.39.2(astro@6.3.7(@types/node@25.6.0)(@vercel/blob@2.3.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.33))(db0@0.3.4)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))(typescript@5.9.3)
+      "@fontsource-variable/rubik": 5.2.8
+      "@fontsource/ibm-plex-mono": 5.2.7
+      ultrahtml: 1.6.0
 
   "@shikijs/core@4.1.0":
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,5 @@ packages:
   - "packages/*"
   - "apps/*"
 minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - "@sentry/starlight-theme"


### PR DESCRIPTION
Migrate the Junior docs app to the shared `@sentry/starlight-theme` package and wire in the `sentryAgentMarkdown` plugin.

This replaces the local dark Starlight theme layer with the shared Sentry theme plugin, including its component overrides, dark-only theme selector behavior, and monochrome code theme. The remaining local CSS is scoped to Junior-specific branding and the homepage Slack thread demo.

Also adds the `sentryAgentMarkdown` Starlight plugin, which generates static `.md` routes for every docs page and injects Markdown actions into the right-sidebar table of contents.

The shared theme requires Starlight `>=0.39`, so this also upgrades the docs app to Astro 6, Starlight 0.39, and the compatible `starlight-typedoc` release. Theme bumped to `^0.6.0` to pick up the `agent-markdown` export; `@sentry/starlight-theme` added to `minimumReleaseAgeExclude` since 0.6.0 was published within the 24-hour gate window.

Validated with `pnpm docs:build` and desktop/mobile browser smoke checks. The existing TypeDoc warnings for stale generated API entrypoint globs remain unchanged.