### PR TITLE
fix(chat): Retry transient provider stream failures

### DIFF
--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -79,11 +79,19 @@ import {
   type AgentTurnDiagnostics,
 } from "@/chat/services/turn-result";
 import {
+  isRetryableProviderError,
+  trimRetryableProviderErrorTail,
+} from "@/chat/services/provider-retry";
+import {
   selectTurnThinkingLevel,
   toAgentThinkingLevel,
   type TurnThinkingSelection,
 } from "@/chat/services/turn-thinking-level";
-import { hasAgentTurnUsage, type AgentTurnUsage } from "@/chat/usage";
+import {
+  addAgentTurnUsage,
+  hasAgentTurnUsage,
+  type AgentTurnUsage,
+} from "@/chat/usage";
 import {
   loadTurnCheckpoint,
   persistCompletedCheckpoint,
@@ -97,6 +105,12 @@ import { AuthorizationPauseError } from "@/chat/services/auth-pause";
 
 // Re-export types for backward compatibility with existing consumers.
 export type { AssistantReply, AgentTurnDiagnostics };
+
+const PROVIDER_RETRY_DELAYS_MS = [1_000, 2_000] as const;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 export interface ReplyRequestContext {
   skillDirs?: string[];
@@ -941,81 +955,119 @@ export async function generateAssistantReply(
               freshPromptMessage,
             ]);
           }
-          const promptPromise = resumedFromCheckpoint
+
+          const runAgentStep = async (
+            run: Promise<unknown>,
+          ): Promise<unknown> => {
+            let timeoutId: ReturnType<typeof setTimeout> | undefined;
+            const timeoutPromise = new Promise<never>((_, reject) => {
+              timeoutId = setTimeout(() => {
+                timedOut = true;
+                agent.abort();
+                reject(
+                  new Error(
+                    `Agent turn timed out after ${botConfig.turnTimeoutMs}ms`,
+                  ),
+                );
+              }, botConfig.turnTimeoutMs);
+            });
+
+            try {
+              return await Promise.race([run, timeoutPromise]);
+            } catch (error) {
+              if (timedOut) {
+                logWarn(
+                  "agent_turn_timeout",
+                  {},
+                  {
+                    "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
+                    "gen_ai.operation.name": "invoke_agent",
+                    "gen_ai.request.model": botConfig.modelId,
+                    ...(thinkingSelection
+                      ? {
+                          "app.ai.reasoning_effort":
+                            thinkingSelection.thinkingLevel,
+                        }
+                      : {}),
+                    "app.ai.turn_timeout_ms": botConfig.turnTimeoutMs,
+                  },
+                  "Agent turn timed out and was aborted",
+                );
+                // Wait for the agent call to settle before snapshotting messages
+                // — the agent loop may still be mutating state.
+                await run.catch(() => {});
+                timeoutResumeMessages = [...agent.state.messages];
+              }
+              if (getPendingAuthPause()) {
+                timeoutResumeMessages = [...agent.state.messages];
+                throw getPendingAuthPause()!;
+              }
+              throw error;
+            } finally {
+              if (timeoutId) {
+                clearTimeout(timeoutId);
+              }
+            }
+          };
+
+          let run = resumedFromCheckpoint
             ? agent.continue()
             : agent.prompt(freshPromptMessage);
+          let retryUsage: AgentTurnUsage | undefined;
+          for (let attempt = 0; ; attempt += 1) {
+            promptResult = await runAgentStep(run);
 
-          let timeoutId: ReturnType<typeof setTimeout> | undefined;
-          const timeoutPromise = new Promise<never>((_, reject) => {
-            timeoutId = setTimeout(() => {
-              timedOut = true;
-              agent.abort();
-              reject(
-                new Error(
-                  `Agent turn timed out after ${botConfig.turnTimeoutMs}ms`,
-                ),
-              );
-            }, botConfig.turnTimeoutMs);
-          });
-
-          try {
-            promptResult = await Promise.race([promptPromise, timeoutPromise]);
-          } catch (error) {
-            if (timedOut) {
-              logWarn(
-                "agent_turn_timeout",
-                {},
-                {
-                  "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
-                  "gen_ai.operation.name": "invoke_agent",
-                  "gen_ai.request.model": botConfig.modelId,
-                  ...(thinkingSelection
-                    ? {
-                        "app.ai.reasoning_effort":
-                          thinkingSelection.thinkingLevel,
-                      }
-                    : {}),
-                  "app.ai.turn_timeout_ms": botConfig.turnTimeoutMs,
-                },
-                "Agent turn timed out and was aborted",
-              );
-              // Wait for promptPromise to settle before snapshotting messages
-              // — the agent loop may still be mutating state.
-              await promptPromise.catch(() => {});
-              timeoutResumeMessages = [...agent.state.messages];
-            }
+            newMessages = agent.state.messages.slice(beforeMessageCount);
+            const outputMessages = newMessages.filter(isAssistantMessage);
+            const outputMessagesAttribute =
+              serializeGenAiAttribute(outputMessages);
+            const usageSummary = extractGenAiUsageSummary(
+              promptResult,
+              agent.state,
+              ...outputMessages,
+            );
+            const currentUsage = hasAgentTurnUsage(usageSummary)
+              ? usageSummary
+              : undefined;
+            turnUsage = addAgentTurnUsage(retryUsage, currentUsage);
+            setSpanAttributes({
+              ...(outputMessagesAttribute
+                ? { "gen_ai.output.messages": outputMessagesAttribute }
+                : {}),
+              ...extractGenAiUsageAttributes(usageSummary),
+            });
             if (getPendingAuthPause()) {
               timeoutResumeMessages = [...agent.state.messages];
               throw getPendingAuthPause()!;
             }
-            throw error;
-          } finally {
-            if (timeoutId) {
-              clearTimeout(timeoutId);
-            }
-          }
 
-          newMessages = agent.state.messages.slice(beforeMessageCount);
-          const outputMessages = newMessages.filter(isAssistantMessage);
-          const outputMessagesAttribute =
-            serializeGenAiAttribute(outputMessages);
-          const usageSummary = extractGenAiUsageSummary(
-            promptResult,
-            agent.state,
-            ...outputMessages,
-          );
-          turnUsage = hasAgentTurnUsage(usageSummary)
-            ? usageSummary
-            : undefined;
-          setSpanAttributes({
-            ...(outputMessagesAttribute
-              ? { "gen_ai.output.messages": outputMessagesAttribute }
-              : {}),
-            ...extractGenAiUsageAttributes(usageSummary),
-          });
-          if (getPendingAuthPause()) {
-            timeoutResumeMessages = [...agent.state.messages];
-            throw getPendingAuthPause()!;
+            const lastAssistant = outputMessages.at(-1);
+            const retryDelayMs = PROVIDER_RETRY_DELAYS_MS[attempt];
+            if (
+              retryDelayMs === undefined ||
+              !isRetryableProviderError(lastAssistant)
+            ) {
+              break;
+            }
+
+            retryUsage = turnUsage;
+            const retryMessages = trimRetryableProviderErrorTail(
+              agent.state.messages,
+            );
+            if (!retryMessages) {
+              break;
+            }
+
+            agent.state.messages = retryMessages;
+            await persistSafeBoundary(retryMessages);
+            logWarn(
+              "agent_turn_provider_retry",
+              spanContext,
+              {},
+              "Retrying transient provider failure",
+            );
+            await sleep(retryDelayMs);
+            run = agent.continue();
           }
         },
         {

--- a/packages/junior/src/chat/services/provider-retry.ts
+++ b/packages/junior/src/chat/services/provider-retry.ts
@@ -1,0 +1,38 @@
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import type { PiMessage } from "@/chat/pi/messages";
+import {
+  getPiMessageRole,
+  trimTrailingAssistantMessages,
+} from "@/chat/respond-helpers";
+
+const RETRYABLE_PROVIDER_ERROR_PATTERN =
+  /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|stream ended before message_stop|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i;
+
+const NON_RETRYABLE_PROVIDER_ERROR_PATTERN =
+  /invalid.?api.?key|authentication|authorization|permission|forbidden|context.?length|context.?window|content.?policy|validation|bad request|400|401|403/i;
+
+/** Detect transient provider failures that are safe to retry from a Pi boundary. */
+export function isRetryableProviderError(
+  message: Pick<AssistantMessage, "stopReason" | "errorMessage"> | undefined,
+): boolean {
+  if (message?.stopReason !== "error" || !message.errorMessage) {
+    return false;
+  }
+  if (NON_RETRYABLE_PROVIDER_ERROR_PATTERN.test(message.errorMessage)) {
+    return false;
+  }
+  return RETRYABLE_PROVIDER_ERROR_PATTERN.test(message.errorMessage);
+}
+
+/** Remove a failed assistant tail only when the remaining Pi history can continue. */
+export function trimRetryableProviderErrorTail(
+  messages: PiMessage[],
+): PiMessage[] | undefined {
+  const trimmed = trimTrailingAssistantMessages(messages);
+  if (trimmed.length === messages.length) {
+    return undefined;
+  }
+
+  const tailRole = getPiMessageRole(trimmed.at(-1));
+  return tailRole === "user" || tailRole === "toolResult" ? trimmed : undefined;
+}

--- a/packages/junior/src/chat/services/turn-result.ts
+++ b/packages/junior/src/chat/services/turn-result.ts
@@ -153,8 +153,20 @@ export function buildTurnResult(input: TurnResultInput): AssistantReply {
     !primaryText &&
     toolErrorCount === 0 &&
     (reactionPerformed || channelPostPerformed || replyFiles.length > 0);
+  const lastAssistant = terminalAssistantMessages.at(-1) as
+    | { stopReason?: unknown; errorMessage?: unknown }
+    | undefined;
+  const stopReason =
+    typeof lastAssistant?.stopReason === "string"
+      ? lastAssistant.stopReason
+      : undefined;
+  const errorMessage =
+    typeof lastAssistant?.errorMessage === "string"
+      ? lastAssistant.errorMessage
+      : undefined;
+  const isProviderError = stopReason === "error";
 
-  if (!primaryText && !sideEffectOnlySuccess) {
+  if (!primaryText && !sideEffectOnlySuccess && !isProviderError) {
     logWarn(
       "ai_model_response_empty",
       {
@@ -174,25 +186,15 @@ export function buildTurnResult(input: TurnResultInput): AssistantReply {
     );
   }
 
-  const lastAssistant = terminalAssistantMessages.at(-1) as
-    | { stopReason?: unknown; errorMessage?: unknown }
-    | undefined;
-  const stopReason =
-    typeof lastAssistant?.stopReason === "string"
-      ? lastAssistant.stopReason
-      : undefined;
-  const errorMessage =
-    typeof lastAssistant?.errorMessage === "string"
-      ? lastAssistant.errorMessage
-      : undefined;
   const usedPrimaryText = Boolean(primaryText);
-  const outcome: AgentTurnDiagnostics["outcome"] = primaryText
-    ? stopReason === "error"
-      ? "provider_error"
-      : "success"
-    : sideEffectOnlySuccess
-      ? "success"
-      : "execution_failure";
+  let outcome: AgentTurnDiagnostics["outcome"];
+  if (isProviderError) {
+    outcome = "provider_error";
+  } else if (primaryText || sideEffectOnlySuccess) {
+    outcome = "success";
+  } else {
+    outcome = "execution_failure";
+  }
   const suppressReactionOnlyText =
     reactionPerformed &&
     !channelPostPerformed &&

--- a/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
@@ -1,0 +1,225 @@
+import { Buffer } from "node:buffer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { counters } = vi.hoisted(() => ({
+  counters: {
+    continueCalls: 0,
+    promptCalls: 0,
+  },
+}));
+
+vi.mock("@earendil-works/pi-agent-core", () => {
+  class MockAgent {
+    state: {
+      messages: unknown[];
+      model: unknown;
+      systemPrompt: string;
+      tools: unknown[];
+    };
+
+    constructor(input: {
+      initialState: {
+        model: unknown;
+        systemPrompt: string;
+        tools: unknown[];
+      };
+    }) {
+      this.state = {
+        messages: [],
+        model: input.initialState.model,
+        systemPrompt: input.initialState.systemPrompt,
+        tools: input.initialState.tools,
+      };
+    }
+
+    subscribe() {
+      return () => undefined;
+    }
+
+    abort() {
+      return undefined;
+    }
+
+    async prompt(message: unknown) {
+      counters.promptCalls += 1;
+      this.state.messages.push(message);
+      this.state.messages.push({
+        role: "toolResult",
+        toolName: "bash",
+        isError: false,
+        content: [{ type: "text", text: "ok" }],
+      });
+      this.state.messages.push({
+        role: "assistant",
+        content: [],
+        stopReason: "error",
+        errorMessage: "Anthropic stream ended before message_stop",
+        usage: {
+          input: 10,
+          output: 1,
+        },
+      });
+      return {};
+    }
+
+    async continue() {
+      counters.continueCalls += 1;
+      this.state.messages.push({
+        role: "assistant",
+        content: [{ type: "text", text: "Recovered." }],
+        stopReason: "stop",
+        usage: {
+          input: 2,
+          output: 2,
+        },
+      });
+      return {};
+    }
+  }
+
+  return { Agent: MockAgent };
+});
+
+vi.mock("@/chat/config", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/chat/config")>();
+  const memoryConfig = original.readChatConfig({
+    ...process.env,
+    AGENT_TURN_TIMEOUT_MS: "10000",
+    FUNCTION_MAX_DURATION_SECONDS: "60",
+    JUNIOR_STATE_ADAPTER: "memory",
+  });
+  return {
+    ...original,
+    botConfig: memoryConfig.bot,
+    getChatConfig: () => memoryConfig,
+    getRuntimeMetadata: () => ({ version: "test" }),
+  };
+});
+
+vi.mock("@/chat/capabilities/factory", () => ({
+  createUserTokenStore: () => ({
+    get: async () => undefined,
+    set: async () => undefined,
+    delete: async () => undefined,
+  }),
+}));
+
+vi.mock("@/chat/capabilities/jr-rpc-command", () => ({
+  maybeExecuteJrRpcCustomCommand: async () => ({ handled: false }),
+}));
+
+vi.mock("@/chat/pi/client", () => ({
+  GEN_AI_PROVIDER_NAME: "vercel-ai-gateway",
+  completeObject: async () => ({
+    object: {
+      thinking_level: "medium",
+      confidence: 1,
+      reason: "test-router",
+    },
+  }),
+  getPiGatewayApiKeyOverride: () => "test-gateway-key",
+  resolveGatewayModel: (modelId: string) => modelId,
+}));
+
+vi.mock("@/chat/prompt", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/chat/prompt")>();
+  return {
+    ...actual,
+    buildSystemPrompt: () => "System prompt",
+  };
+});
+
+vi.mock("@/chat/runtime/dev-agent-trace", () => ({
+  shouldEmitDevAgentTrace: () => false,
+}));
+
+vi.mock("@/chat/sandbox/sandbox", () => ({
+  createSandboxExecutor: () => ({
+    configureSkills: () => undefined,
+    configureReferenceFiles: () => undefined,
+    createSandbox: async () => ({
+      readFileToBuffer: async () => Buffer.from("", "utf8"),
+      runCommand: async () => ({
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+      }),
+    }),
+    canExecute: () => false,
+    execute: async () => {
+      throw new Error("sandbox executor should not execute in this test");
+    },
+    getSandboxId: () => undefined,
+    getDependencyProfileHash: () => undefined,
+    dispose: async () => undefined,
+  }),
+}));
+
+vi.mock("@/chat/plugins/registry", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/chat/plugins/registry")>()),
+  getPluginMcpProviders: () => [],
+  getPluginProviders: () => [],
+}));
+
+vi.mock("@/chat/skills", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/chat/skills")>()),
+  discoverSkills: async () => [],
+  findSkillByName: () => null,
+  parseSkillInvocation: () => null,
+}));
+
+import { generateAssistantReply } from "@/chat/respond";
+import { disconnectStateAdapter } from "@/chat/state/adapter";
+import { getAgentTurnSessionCheckpoint } from "@/chat/state/turn-session-store";
+
+describe("generateAssistantReply provider retry", () => {
+  beforeEach(async () => {
+    counters.continueCalls = 0;
+    counters.promptCalls = 0;
+    process.env.JUNIOR_STATE_ADAPTER = "memory";
+    await disconnectStateAdapter();
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await disconnectStateAdapter();
+    delete process.env.JUNIOR_STATE_ADAPTER;
+  });
+
+  it("continues from the last safe boundary after a transient provider stream error", async () => {
+    const replyPromise = generateAssistantReply("help me", {
+      requester: { userId: "U123" },
+      correlation: {
+        conversationId: "conversation-1",
+        turnId: "turn-1",
+        channelId: "C123",
+        threadTs: "1712345.0001",
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    const reply = await replyPromise;
+
+    expect(reply.text).toBe("Recovered.");
+    expect(reply.diagnostics.outcome).toBe("success");
+    expect(reply.diagnostics.toolResultCount).toBe(1);
+    expect(reply.diagnostics.usage).toMatchObject({
+      inputTokens: 12,
+      outputTokens: 3,
+    });
+    expect(counters.promptCalls).toBe(1);
+    expect(counters.continueCalls).toBe(1);
+
+    const checkpoint = await getAgentTurnSessionCheckpoint(
+      "conversation-1",
+      "turn-1",
+    );
+    expect(checkpoint?.state).toBe("completed");
+    expect(checkpoint?.piMessages.map((message) => message.role)).toEqual([
+      "user",
+      "toolResult",
+      "assistant",
+    ]);
+  });
+});

--- a/packages/junior/tests/unit/services/provider-retry.test.ts
+++ b/packages/junior/tests/unit/services/provider-retry.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import type { PiMessage } from "@/chat/pi/messages";
+import {
+  isRetryableProviderError,
+  trimRetryableProviderErrorTail,
+} from "@/chat/services/provider-retry";
+
+function assistantError(
+  errorMessage: string,
+): Pick<AssistantMessage, "stopReason" | "errorMessage"> {
+  return {
+    stopReason: "error",
+    errorMessage,
+  };
+}
+
+describe("provider retry helpers", () => {
+  it("matches transient provider stream failures", () => {
+    expect(
+      isRetryableProviderError(
+        assistantError("Anthropic stream ended before message_stop"),
+      ),
+    ).toBe(true);
+    expect(
+      isRetryableProviderError(
+        assistantError("Provider finish_reason: network_error"),
+      ),
+    ).toBe(true);
+    expect(isRetryableProviderError(assistantError("overloaded_error"))).toBe(
+      true,
+    );
+  });
+
+  it("does not match auth or validation failures", () => {
+    expect(isRetryableProviderError(assistantError("invalid_api_key"))).toBe(
+      false,
+    );
+    expect(isRetryableProviderError(assistantError("400 bad request"))).toBe(
+      false,
+    );
+    expect(isRetryableProviderError({ stopReason: "stop" })).toBe(false);
+  });
+
+  it("trims a failed assistant tail only at a continuable boundary", () => {
+    const user = {
+      role: "user",
+      content: [{ type: "text", text: "help" }],
+    } as PiMessage;
+    const toolResult = {
+      role: "toolResult",
+      toolName: "bash",
+      content: [{ type: "text", text: "ok" }],
+    } as PiMessage;
+    const failedAssistant = {
+      role: "assistant",
+      content: [],
+      stopReason: "error",
+    } as unknown as PiMessage;
+
+    expect(
+      trimRetryableProviderErrorTail([user, toolResult, failedAssistant]),
+    ).toEqual([user, toolResult]);
+    expect(trimRetryableProviderErrorTail([failedAssistant])).toBeUndefined();
+  });
+});

--- a/packages/junior/tests/unit/turn-result.test.ts
+++ b/packages/junior/tests/unit/turn-result.test.ts
@@ -110,6 +110,40 @@ describe("buildTurnResult", () => {
     expect(reply.diagnostics.usedPrimaryText).toBe(true);
   });
 
+  it("treats terminal provider errors without text as provider errors", () => {
+    const reply = buildTurnResult({
+      newMessages: [
+        {
+          role: "toolResult",
+          toolName: "bash",
+          isError: false,
+          stdout: "ok",
+        },
+        {
+          role: "assistant",
+          content: [],
+          stopReason: "error",
+          errorMessage: "Anthropic stream ended before message_stop",
+        },
+      ],
+      userInput: "Do the thing",
+      replyFiles: [],
+      artifactStatePatch: {},
+      toolCalls: ["bash"],
+      generatedFileCount: 0,
+      shouldTrace: false,
+      spanContext: {},
+      thinkingSelection,
+    });
+
+    expect(reply.text).toBe("");
+    expect(reply.diagnostics.outcome).toBe("provider_error");
+    expect(reply.diagnostics.errorMessage).toBe(
+      "Anthropic stream ended before message_stop",
+    );
+    expect(reply.diagnostics.usedPrimaryText).toBe(false);
+  });
+
   it("treats reaction-only turns as successful without fallback text", () => {
     const reply = buildTurnResult({
       newMessages: [

--- a/specs/agent-session-resumability-spec.md
+++ b/specs/agent-session-resumability-spec.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-03-05
-- Last Edited: 2026-05-19
+- Last Edited: 2026-05-24
 
 ## Changelog
 
@@ -17,6 +17,7 @@
 - 2026-05-13: Clarified turn continuation as an idempotent checkpoint retry path, including user follow-up rescheduling and bounded lock-busy callback retries.
 - 2026-05-19: Clarified that Slack auth pauses also post a visible URL-free acknowledgement owned by the Slack delivery contract.
 - 2026-05-21: Reframed Pi persistence as an incremental Redis-backed Pi session state store. Checkpoints store metadata and recoverable cursors; materialized `pi_messages` are a read view, not the primary write model.
+- 2026-05-24: Added bounded in-process provider retry for transient LLM stream failures before final Slack delivery.
 
 ## Status
 
@@ -177,6 +178,14 @@ If the previous slice timed out after producing uncommitted partial assistant te
 - If a later user message arrives while `activeTurnId` points at an awaiting automatic continuation checkpoint, the live runtime must treat that message as a retry signal for the existing session: reschedule the checkpoint callback, keep `activeTurnId` on the original session, and do not start a new agent turn.
 - In that case, the last safe checkpoint may still exist for inspection or operator-driven recovery, but the user-visible turn is allowed to fail only after automatic continuation is impossible or exhausted.
 
+### In-Process Provider Retry Contract
+
+- Transient provider failures reported as terminal assistant messages with `stopReason=error` may be retried inside the same running slice before final Slack delivery.
+- Provider retry must not replay the original user prompt. It must remove only the trailing failed assistant message(s), verify the remaining Pi history ends at a continuable boundary (`user` or `toolResult`), persist that safe boundary, then call `continue()`.
+- Provider retry is bounded and uses short exponential backoff. If the retry limit is reached, if the error is not classified as transient, or if no safe boundary remains after trimming, the normal provider-failure reply path owns user-visible recovery.
+- Provider retry does not create an `awaiting_resume` checkpoint and does not schedule a signed resume callback. If a retried slice later times out, the timeout continuation contract above applies.
+- Provider retry is only allowed before final Slack reply delivery. The runtime must not retry by rewriting or reconciling text already posted to Slack.
+
 ### Internal Timeout-Resume Callback Contract
 
 The timeout-resume callback payload is:
@@ -236,6 +245,7 @@ Required log events/diagnostics:
 - `agent_turn_timeout_resume_schedule_failed`
 - `agent_turn_continuation_retry_schedule_failed`
 - `agent_turn_timeout_resume_skipped_after_visible_output`
+- `agent_turn_provider_retry`
 - `timeout_resume_failed`
 - `timeout_resume_handler_failed`
 - `timeout_resume_lock_busy`
@@ -269,6 +279,7 @@ Required attributes when available:
 8. Unit/integration: eager sandbox/artifact persistence preserves resumed tool context across slices.
 9. Unit/integration: fresh follow-up turns can recover Pi history from active/last Pi session state without depending on conversation-state Pi transcript mirroring.
 10. Manual/eval: once assistant text is already visible, timeout does not auto-resume or attempt to reconcile partial thread output.
+11. Unit/integration: transient provider failures retry with `continue()` from a safe boundary and do not duplicate prior tool execution.
 
 ## Related Specs
 


### PR DESCRIPTION
Retry transient provider stream errors from the last safe Pi boundary instead of immediately finalizing the turn as failed. This trims only the failed assistant tail, verifies the remaining history can continue, persists the safe boundary, and calls `continue()` so prior tool results are reused rather than replayed.

**Provider Retry**

Transient provider errors such as interrupted Anthropic streams now retry in-process with bounded backoff before final Slack delivery. Retry attempts preserve cumulative usage so diagnostics and reply footers account for failed provider calls.

**Failure Classification**

Empty terminal assistant messages with `stopReason=error` now classify as provider errors instead of execution failures, avoiding misleading empty-response diagnostics when the provider stream itself failed.

**Resumability Contract**

The session resumability spec now documents the in-process provider retry contract and its safety boundaries.

Fixes JUNIOR-2D