### PR TITLE
fix(scheduler): Auto-create clear Slack schedules

### DIFF
--- a/packages/junior-evals/evals/behavior-harness.ts
+++ b/packages/junior-evals/evals/behavior-harness.ts
@@ -338,7 +338,6 @@ function toEvalToolInvocation(input: {
         "title",
         "task_id",
         "objective",
-        "confirmed_by_user",
         "schedule_description",
         "timezone",
         "next_run_at_iso",

--- a/packages/junior-evals/evals/core/scheduler.eval.ts
+++ b/packages/junior-evals/evals/core/scheduler.eval.ts
@@ -23,7 +23,7 @@ describeEval("Scheduler", slackEvals, (it) => {
     });
   });
 
-  it("when asked to schedule recurring work, draft the task for confirmation before creating it", async ({
+  it("when asked to schedule clear recurring work, create it without confirmation", async ({
     run,
   }) => {
     await run({
@@ -34,13 +34,13 @@ describeEval("Scheduler", slackEvals, (it) => {
       ],
       criteria: rubric({
         contract:
-          "A future or recurring task request is normalized into a scheduled task draft for the active Slack context before it is persisted.",
+          "A clear future or recurring task request is normalized and scheduled immediately for the active Slack context.",
         pass: [
-          "The draft task title/objective/instructions describe checking scheduler-related GitHub issues, not creating a schedule.",
-          "The reply asks the user to confirm the normalized cadence or next run before creating the schedule.",
+          "The created task title/objective/instructions describe checking scheduler-related GitHub issues, not creating a schedule.",
+          "The reply confirms the recurring schedule was created for Monday at 9am Pacific.",
         ],
         fail: [
-          "Do not persist a scheduled task before user confirmation.",
+          "Do not ask the user to confirm before creating the clear recurring task.",
           "Do not ask the user to provide a channel ID.",
           "Do not only give instructions for how the user can set up an external cron.",
         ],

--- a/packages/junior/src/chat/tools/slack/schedule-tools.ts
+++ b/packages/junior/src/chat/tools/slack/schedule-tools.ts
@@ -247,6 +247,23 @@ function buildRecurrence(args: {
   }
 }
 
+function validateRecurringFrequencyLimit(input: {
+  recurrence_frequency?: unknown;
+}): { ok: true } | { ok: false; error: string } {
+  if (
+    input.recurrence_frequency !== undefined &&
+    input.recurrence_frequency !== null &&
+    !normalizeFrequency(input.recurrence_frequency)
+  ) {
+    return {
+      ok: false,
+      error: "Recurring scheduled tasks can run at most once per day.",
+    };
+  }
+
+  return { ok: true };
+}
+
 function shouldRebuildRecurrence(input: {
   next_run_at_text?: string;
   next_run_at_iso?: string;
@@ -310,38 +327,6 @@ function hasConflictingNextRunInputs(input: {
   return Boolean(input.next_run_at_iso && input.next_run_at_text);
 }
 
-function canCreateUnconfirmedSimpleReminder(args: {
-  context: ToolRuntimeContext;
-  input: {
-    constraints?: string[];
-    next_run_at_iso?: string;
-    next_run_at_text?: string;
-    recurrence_frequency?: unknown;
-    recurrence_interval?: number;
-    recurrence_weekdays?: number[];
-    source_context?: string[];
-  };
-}): boolean {
-  const userText = args.context.userText;
-  if (
-    !userText ||
-    !/\bremind\s+(me|us|this channel|the channel)\b/i.test(userText)
-  ) {
-    return false;
-  }
-  if (/\b(every|daily|weekly|monthly|yearly|each)\b/i.test(userText)) {
-    return false;
-  }
-  return (
-    Boolean(args.input.next_run_at_iso || args.input.next_run_at_text) &&
-    args.input.recurrence_frequency === undefined &&
-    args.input.recurrence_interval === undefined &&
-    args.input.recurrence_weekdays === undefined &&
-    (args.input.constraints?.length ?? 0) === 0 &&
-    (args.input.source_context?.length ?? 0) === 0
-  );
-}
-
 /** Create a tool that stores a scheduled task for the active Slack context. */
 export function createSlackScheduleCreateTaskTool(context: ToolRuntimeContext) {
   return tool({
@@ -351,18 +336,13 @@ export function createSlackScheduleCreateTaskTool(context: ToolRuntimeContext) {
     promptGuidelines: [
       "Use only when the user explicitly asks Junior to do work later or on a recurring cadence.",
       ACTIVE_DESTINATION_GUIDELINE,
-      'For an explicit simple one-off reminder request such as "remind me in 10 minutes to stretch", call immediately without asking for confirmation.',
-      "For recurring schedules or non-reminder scheduled work, show the normalized task, cadence, timezone, destination, and next run; call only after explicit user confirmation.",
+      "When the user's scheduling intent is clear, create the task immediately without asking for confirmation.",
+      "Ask for confirmation only when the task contract, schedule, or active destination is ambiguous.",
+      "Recurring tasks can run at most once per day; use only daily, weekly, monthly, or yearly recurrence frequencies.",
       "Provide exactly one of next_run_at_iso or next_run_at_text; omit timezone to use the configured default.",
       "Use recurrence_frequency only for recurring schedules.",
     ],
     inputSchema: Type.Object({
-      confirmed_by_user: Type.Optional(
-        Type.Boolean({
-          description:
-            "Set true only after the user explicitly confirms the normalized task, cadence, timezone, destination, and next run. Omit or set false for explicit simple one-off reminders.",
-        }),
-      ),
       title: Type.String({ minLength: 1, maxLength: 120 }),
       objective: Type.String({ minLength: 1, maxLength: 1000 }),
       instructions: Type.Array(Type.String({ minLength: 1, maxLength: 1000 }), {
@@ -434,16 +414,6 @@ export function createSlackScheduleCreateTaskTool(context: ToolRuntimeContext) {
       if (!destination.ok) return destination;
       const requester = requireRequester(context);
       if (!requester.ok) return requester;
-      if (
-        input.confirmed_by_user !== true &&
-        !canCreateUnconfirmedSimpleReminder({ context, input })
-      ) {
-        return {
-          ok: false,
-          error:
-            "Scheduled tasks require explicit user confirmation before they are created, except simple one-off reminders requested directly by the user. Draft the task contract for the user to confirm.",
-        };
-      }
 
       const nowMs = Date.now();
       const timezone = input.timezone ?? getDefaultScheduleTimezone();
@@ -452,6 +422,10 @@ export function createSlackScheduleCreateTaskTool(context: ToolRuntimeContext) {
           ok: false,
           error: "Provide only one of next_run_at_iso or next_run_at_text.",
         };
+      }
+      const frequencyLimit = validateRecurringFrequencyLimit(input);
+      if (!frequencyLimit.ok) {
+        return frequencyLimit;
       }
       if (!isValidTimeZone(timezone)) {
         return {
@@ -628,6 +602,10 @@ export function createSlackScheduleUpdateTaskTool(context: ToolRuntimeContext) {
           ok: false,
           error: "Provide only one of next_run_at_iso or next_run_at_text.",
         };
+      }
+      const frequencyLimit = validateRecurringFrequencyLimit(input);
+      if (!frequencyLimit.ok) {
+        return frequencyLimit;
       }
       if (!isValidTimeZone(timezone)) {
         return {

--- a/packages/junior/tests/integration/slack-schedule-tools.test.ts
+++ b/packages/junior/tests/integration/slack-schedule-tools.test.ts
@@ -51,7 +51,6 @@ async function createTask(
 ) {
   const tool = createSlackScheduleCreateTaskTool(context);
   return await executeTool(tool, {
-    confirmed_by_user: true,
     title: "Weekly issue digest",
     objective: "Summarize open scheduler issues.",
     instructions: ["Find open scheduler issues", "Post a concise summary"],
@@ -123,7 +122,7 @@ describe("Slack schedule tools", () => {
     });
   });
 
-  it("requires explicit confirmation before creating a task", async () => {
+  it("creates clear recurring tasks without a second confirmation", async () => {
     const result = await executeTool(
       createSlackScheduleCreateTaskTool(createContext()),
       {
@@ -139,20 +138,27 @@ describe("Slack schedule tools", () => {
     );
 
     expect(result).toMatchObject({
-      ok: false,
-      error:
-        "Scheduled tasks require explicit user confirmation before they are created, except simple one-off reminders requested directly by the user. Draft the task contract for the user to confirm.",
+      ok: true,
+      task: {
+        schedule: "Every Monday at 9am",
+        status: "active",
+        title: "Weekly issue digest",
+      },
     });
     await expect(
       createStateSchedulerStore().listTasksForTeam(TEST_TEAM_ID),
-    ).resolves.toEqual([]);
+    ).resolves.toMatchObject([
+      {
+        destination: { channelId: "C123" },
+        status: "active",
+      },
+    ]);
   });
 
   it("rejects invalid Slack workspace context before creating a task", async () => {
     const result = await executeTool(
       createSlackScheduleCreateTaskTool(createContext({ teamId: "D123" })),
       {
-        confirmed_by_user: true,
         title: "Reminder",
         objective: "Remind David to wash his hands.",
         instructions: ["Remind David to wash his hands."],
@@ -210,6 +216,45 @@ describe("Slack schedule tools", () => {
     ]);
   });
 
+  it("creates short imperative one-off reminders without channel confirmation", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-27T00:24:23.000Z"));
+
+    const result = await executeTool(
+      createSlackScheduleCreateTaskTool(
+        createContext({
+          userText: "drink water in 1 minute in this conversation",
+        }),
+      ),
+      {
+        title: "Drink water reminder",
+        objective: "Remind David to drink water.",
+        instructions: ["Remind David to drink water."],
+        schedule_description: "In 1 minute",
+        next_run_at_text: "in 1 minute",
+      },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      task: {
+        next_run_at: "2026-05-27T00:25:23.000Z",
+        schedule: "In 1 minute",
+        status: "active",
+        title: "Drink water reminder",
+      },
+    });
+    await expect(
+      createStateSchedulerStore().listTasksForTeam(TEST_TEAM_ID),
+    ).resolves.toMatchObject([
+      {
+        destination: { channelId: "C123" },
+        nextRunAtMs: Date.parse("2026-05-27T00:25:23.000Z"),
+        status: "active",
+      },
+    ]);
+  });
+
   it("rejects parseable non-ISO next run timestamps", async () => {
     const result = await createTask(createContext(), {
       next_run_at_iso: "05/25/2026 09:00",
@@ -234,6 +279,21 @@ describe("Slack schedule tools", () => {
     expect(result).toMatchObject({
       ok: false,
       error: "Provide only one of next_run_at_iso or next_run_at_text.",
+    });
+    await expect(
+      createStateSchedulerStore().listTasksForTeam(TEST_TEAM_ID),
+    ).resolves.toEqual([]);
+  });
+
+  it("rejects recurring schedules that can run more than once per day", async () => {
+    const result = await createTask(createContext(), {
+      schedule_description: "Every hour",
+      recurrence_frequency: "hourly",
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: "Recurring scheduled tasks can run at most once per day.",
     });
     await expect(
       createStateSchedulerStore().listTasksForTeam(TEST_TEAM_ID),
@@ -285,6 +345,35 @@ describe("Slack schedule tools", () => {
       {},
     );
     expect(listed).toMatchObject({ ok: true, tasks: [] });
+  });
+
+  it("rejects edits that make a recurring task run more than once per day", async () => {
+    const context = createContext();
+    const created = (await createTask(context)) as {
+      task: { id: string };
+    };
+
+    const updated = await executeTool(
+      createSlackScheduleUpdateTaskTool(context),
+      {
+        task_id: created.task.id,
+        schedule_description: "Every hour",
+        recurrence_frequency: "hourly",
+      },
+    );
+
+    expect(updated).toMatchObject({
+      ok: false,
+      error: "Recurring scheduled tasks can run at most once per day.",
+    });
+    await expect(
+      createStateSchedulerStore().getTask(created.task.id),
+    ).resolves.toMatchObject({
+      schedule: {
+        description: "Every Monday at 9am",
+      },
+      version: 1,
+    });
   });
 
   it("rejects edits from another active Slack destination", async () => {

--- a/specs/scheduler-spec.md
+++ b/specs/scheduler-spec.md
@@ -8,7 +8,8 @@
 ## Changelog
 
 - 2026-05-27: Added stale missed-run policy: old occurrences are skipped and consumed or advanced, not dispatched late and not blocked for human review.
-- 2026-05-27: Added the simple one-off reminder exception to Slack schedule confirmation.
+- 2026-05-27: Added the recurring schedule frequency limit: at most once per day.
+- 2026-05-27: Changed Slack authoring to auto-create clear scheduled work and reserve confirmation for ambiguous requests.
 - 2026-05-26: Reframed scheduled execution around system actors: creator is metadata/contact, scheduled runs execute as a system actor, and user-bound auth must not be borrowed implicitly.
 - 2026-05-18: Clarified V1 calendar model: exact next-run instants plus simple daily/weekly/monthly/yearly recurrence rules.
 - 2026-05-18: Initial draft contract for scheduled Junior tasks, prompt framing, no-SQL storage, run idempotency, and eval-first verification.
@@ -82,6 +83,8 @@ Recurring tasks must also store a small calendar recurrence rule:
 - optional monthly/yearly exact day-of-month and month
 
 V1 recurrence is calendar-based, not fixed-duration. For example, "every Monday at 9am America/Los_Angeles" should continue to run at 9am local time across daylight-saving changes. Monthly and yearly recurrences use exact calendar dates; unsupported dates are skipped rather than converted into "last day" or "business day" behavior.
+
+Recurring tasks must not run more than once per day. Slack authoring must reject hourly, twice-daily, or other sub-daily recurring schedules instead of storing a task contract that cannot execute as requested.
 
 The scheduler does not need advanced rules such as first business day, nearest weekday, holiday calendars, or arbitrary cron syntax.
 
@@ -190,16 +193,16 @@ Those future credential subjects must be explicit and separate from creator meta
 
 ### Slack UX
 
-Slack authoring is confirm-first for recurring schedules and non-reminder scheduled work:
+Slack authoring creates clear scheduled-work requests immediately for the active destination:
 
 1. User asks Junior to schedule work.
-2. Junior drafts the normalized task: title, objective, instructions, expected output, cadence, timezone, destination, and next run.
-3. User confirms before the task becomes active.
-4. Junior creates the task only after confirmation and replies with the task id, destination, schedule, timezone, and next run.
-5. Junior supports list, pause, resume, delete, and run-now commands from the destination conversation.
+2. Junior normalizes the task: title, objective, instructions, expected output, cadence, timezone, destination, and next run.
+3. If the task contract, schedule, and active destination are clear, Junior creates the task immediately.
+4. If the task contract, schedule, or active destination is ambiguous, Junior asks for confirmation or clarification before creating the task.
+5. Junior replies with the task id, destination, schedule, timezone, and next run after creation.
+6. Junior supports list, pause, resume, delete, and run-now commands from the destination conversation.
 
 Confirmation should show the executable task contract, not only echo the user's text.
-Explicit simple one-off reminder requests, such as "remind me in 10 minutes to stretch", may be created immediately without a second confirmation when the request targets the active Slack destination and has no recurrence, extra constraints, or source context.
 Anyone who can post or trigger Junior in the destination Slack conversation window may manage that conversation's scheduled tasks. Creator identity remains audit and notification metadata, but it is not an edit/delete/run-now ownership gate and is not the execution actor.
 Task creation must use the current active Slack conversation as the destination. Users cannot create scheduled tasks for a different channel, and cannot create DMs for other users.
 List output must be scoped to the active destination conversation and must not reveal tasks from other channels or DMs in the same workspace.


### PR DESCRIPTION
Clear Slack scheduling requests now create tasks immediately in the active conversation instead of forcing a second confirmation step. Confirmation remains reserved for ambiguous task details, schedule details, or destination context.

**Scheduler Tool Contract**

The Slack schedule create tool no longer exposes or enforces the obsolete confirmation flag, and its guidance now tells the agent to create clear scheduled work directly.

**Recurrence Limit**

The tool now rejects unsupported structured recurrence frequencies such as `hourly`, preserving the V1 contract that recurring tasks can run at most once per day.

**Coverage**

The integration suite now covers recurring clear-intent creation, short imperative reminders, and invalid sub-daily recurrence parameters. The scheduler eval and spec were updated to match the product contract.