### PR TITLE
feat(scheduler): Add private scheduled credentials

### DIFF
--- a/packages/junior-plugin-api/src/index.ts
+++ b/packages/junior-plugin-api/src/index.ts
@@ -101,6 +101,11 @@ export interface ToolRegistrationHookContext extends AgentPluginContext {
 }
 
 export interface DispatchOptions {
+  credentialSubject?: {
+    type: "user";
+    userId: string;
+    allowedWhen: "private-direct-conversation";
+  };
   destination: {
     platform: "slack";
     teamId: string;

--- a/packages/junior/src/chat/agent-dispatch/runner.ts
+++ b/packages/junior/src/chat/agent-dispatch/runner.ts
@@ -271,6 +271,9 @@ export async function runAgentDispatchSlice(
 
     let reply = await generateAssistantReply(dispatch.input, {
       authorizationFlowMode: "disabled",
+      ...(dispatch.credentialSubject
+        ? { credentialSubject: dispatch.credentialSubject }
+        : {}),
       configuration,
       channelConfiguration,
       conversationContext,

--- a/packages/junior/src/chat/agent-dispatch/store.ts
+++ b/packages/junior/src/chat/agent-dispatch/store.ts
@@ -198,6 +198,9 @@ export async function createOrGetDispatch(args: {
       actor: { type: "system", id: args.plugin },
       attempt: 0,
       createdAtMs: args.nowMs,
+      ...(args.options.credentialSubject
+        ? { credentialSubject: args.options.credentialSubject }
+        : {}),
       destination: args.options.destination,
       id,
       idempotencyKey: args.options.idempotencyKey,

--- a/packages/junior/src/chat/agent-dispatch/types.ts
+++ b/packages/junior/src/chat/agent-dispatch/types.ts
@@ -17,7 +17,14 @@ export interface DispatchDestination {
   channelId: string;
 }
 
+export interface DispatchCredentialSubject {
+  type: "user";
+  userId: string;
+  allowedWhen: "private-direct-conversation";
+}
+
 export interface DispatchOptions {
+  credentialSubject?: DispatchCredentialSubject;
   destination: DispatchDestination;
   idempotencyKey: string;
   input: string;
@@ -28,6 +35,7 @@ export interface DispatchRecord {
   actor: DispatchActor;
   attempt: number;
   createdAtMs: number;
+  credentialSubject?: DispatchCredentialSubject;
   destination: DispatchDestination;
   errorMessage?: string;
   id: string;

--- a/packages/junior/src/chat/agent-dispatch/validation.ts
+++ b/packages/junior/src/chat/agent-dispatch/validation.ts
@@ -1,4 +1,5 @@
 import type { DispatchOptions } from "./types";
+import { isDmChannel } from "@/chat/slack/client";
 import { isSlackConversationId, isSlackTeamId } from "@/chat/slack/ids";
 
 const MAX_DISPATCH_INPUT_LENGTH = 32_000;
@@ -31,6 +32,26 @@ export function validateDispatchOptions(options: DispatchOptions): void {
   }
   if (options.input.length > MAX_DISPATCH_INPUT_LENGTH) {
     throw new Error("Dispatch input exceeds the maximum length");
+  }
+  if (options.credentialSubject) {
+    if (options.credentialSubject.type !== "user") {
+      throw new Error("Dispatch credentialSubject type must be user");
+    }
+    if (!options.credentialSubject.userId.trim()) {
+      throw new Error("Dispatch credentialSubject userId is required");
+    }
+    if (
+      options.credentialSubject.allowedWhen !== "private-direct-conversation"
+    ) {
+      throw new Error(
+        "Dispatch credentialSubject allowedWhen must be private-direct-conversation",
+      );
+    }
+    if (!isDmChannel(options.destination.channelId)) {
+      throw new Error(
+        "Dispatch credentialSubject requires a private direct Slack destination",
+      );
+    }
   }
   const metadata = options.metadata ?? {};
   const entries = Object.entries(metadata);

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -119,6 +119,11 @@ function sleep(ms: number): Promise<void> {
 
 export interface ReplyRequestContext {
   skillDirs?: string[];
+  credentialSubject?: {
+    type: "user";
+    userId: string;
+    allowedWhen: "private-direct-conversation";
+  };
   requester?: {
     userId?: string;
     userName?: string;
@@ -460,7 +465,10 @@ export async function generateAssistantReply(
       ...persistedConfigurationValues,
     };
     // ── Sandbox ──────────────────────────────────────────────────────
-    const requesterId = context.requester?.userId;
+    const credentialRequesterId =
+      context.credentialSubject?.type === "user"
+        ? context.credentialSubject.userId
+        : context.requester?.userId;
     const userTokenStore = createUserTokenStore();
     const agentPluginHooks = createAgentPluginHookRunner({
       requester: context.requester,
@@ -470,9 +478,9 @@ export async function generateAssistantReply(
       sandboxDependencyProfileHash:
         context.sandbox?.sandboxDependencyProfileHash,
       traceContext: spanContext,
-      credentialEgress: requesterId
+      credentialEgress: credentialRequesterId
         ? {
-            requesterId,
+            requesterId: credentialRequesterId,
           }
         : undefined,
       agentHooks: agentPluginHooks,
@@ -633,7 +641,7 @@ export async function generateAssistantReply(
       {
         conversationId: sessionConversationId,
         sessionId,
-        requesterId: context.requester?.userId,
+        requesterId: credentialRequesterId,
         channelId: context.correlation?.channelId,
         threadTs: context.correlation?.threadTs,
         toolChannelId: context.toolChannelId,
@@ -652,7 +660,7 @@ export async function generateAssistantReply(
       {
         conversationId: sessionConversationId,
         sessionId,
-        requesterId: context.requester?.userId,
+        requesterId: credentialRequesterId,
         channelId: context.correlation?.channelId,
         threadTs: context.correlation?.threadTs,
         userMessage: userInput,

--- a/packages/junior/src/chat/scheduler/cadence.ts
+++ b/packages/junior/src/chat/scheduler/cadence.ts
@@ -234,67 +234,6 @@ function buildCandidate(args: {
   });
 }
 
-function parseLocalTime(value: string): ScheduledLocalTime | undefined {
-  const match = /^(\d{1,2})(?::(\d{2}))?\s*(am|pm)$/i.exec(value.trim());
-  if (!match) {
-    return undefined;
-  }
-
-  let hour = Number(match[1]);
-  const minute = match[2] ? Number(match[2]) : 0;
-  const meridiem = match[3].toLowerCase();
-  if (
-    !Number.isInteger(hour) ||
-    !Number.isInteger(minute) ||
-    hour < 1 ||
-    hour > 12 ||
-    minute < 0 ||
-    minute > 59
-  ) {
-    return undefined;
-  }
-  if (meridiem === "am" && hour === 12) {
-    hour = 0;
-  } else if (meridiem === "pm" && hour !== 12) {
-    hour += 12;
-  }
-  return { hour, minute };
-}
-
-/** Parse supported relative one-off schedule text into a UTC timestamp. */
-export function parseRelativeScheduleTimestamp(args: {
-  nowMs: number;
-  text: string;
-  timezone: string;
-}): number | undefined {
-  const text = args.text.trim();
-  const offsetMatch = /^in\s+(\d+)\s+(minute|minutes|hour|hours)$/i.exec(text);
-  if (offsetMatch) {
-    const amount = Number(offsetMatch[1]);
-    if (!Number.isSafeInteger(amount) || amount < 1 || amount > 24 * 60) {
-      return undefined;
-    }
-    const unitMs = offsetMatch[2].toLowerCase().startsWith("hour")
-      ? 60 * 60 * 1000
-      : 60 * 1000;
-    return args.nowMs + amount * unitMs;
-  }
-
-  const tomorrowMatch = /^tomorrow(?:\s+at)?\s+(.+)$/i.exec(text);
-  if (!tomorrowMatch) {
-    return undefined;
-  }
-  const time = parseLocalTime(tomorrowMatch[1]);
-  if (!time) {
-    return undefined;
-  }
-  return localDateTimeToTimestampMs({
-    date: addDays(getLocalDate(args.nowMs, args.timezone), 1),
-    time,
-    timezone: args.timezone,
-  });
-}
-
 function getDailyNextRunAtMs(args: {
   afterMs: number;
   recurrence: ScheduledTaskRecurrence;

--- a/packages/junior/src/chat/scheduler/plugin.ts
+++ b/packages/junior/src/chat/scheduler/plugin.ts
@@ -269,6 +269,9 @@ export function createSchedulerPlugin() {
           try {
             dispatch = await ctx.agent.dispatch({
               idempotencyKey: run.id,
+              ...(task.credentialSubject
+                ? { credentialSubject: task.credentialSubject }
+                : {}),
               destination: task.destination,
               input: prompt,
               metadata: {

--- a/packages/junior/src/chat/scheduler/types.ts
+++ b/packages/junior/src/chat/scheduler/types.ts
@@ -30,6 +30,17 @@ export interface ScheduledTaskDestination {
   channelId: string;
 }
 
+export interface ScheduledTaskConversationAccess {
+  audience: "direct" | "group" | "channel";
+  visibility: "private" | "public" | "unknown";
+}
+
+export interface ScheduledTaskCredentialSubject {
+  type: "user";
+  userId: string;
+  allowedWhen: "private-direct-conversation";
+}
+
 export type ScheduledCalendarFrequency =
   | "daily"
   | "weekly"
@@ -71,6 +82,8 @@ export interface ScheduledTask {
   id: string;
   createdAtMs: number;
   createdBy: ScheduledTaskPrincipal;
+  conversationAccess?: ScheduledTaskConversationAccess;
+  credentialSubject?: ScheduledTaskCredentialSubject;
   destination: ScheduledTaskDestination;
   executionActor?: ScheduledTaskExecutionActor;
   lastRunAtMs?: number;

--- a/packages/junior/src/chat/tools/slack/schedule-tools.ts
+++ b/packages/junior/src/chat/tools/slack/schedule-tools.ts
@@ -2,7 +2,6 @@ import { randomUUID } from "node:crypto";
 import { Type } from "@sinclair/typebox";
 import {
   buildCalendarRecurrence,
-  parseRelativeScheduleTimestamp,
   parseScheduleTimestamp,
 } from "@/chat/scheduler/cadence";
 import { createStateSchedulerStore } from "@/chat/scheduler/store";
@@ -10,12 +9,14 @@ import { SCHEDULED_TASK_SYSTEM_ACTOR } from "@/chat/scheduler/types";
 import type {
   ScheduledCalendarFrequency,
   ScheduledTask,
+  ScheduledTaskConversationAccess,
+  ScheduledTaskCredentialSubject,
   ScheduledTaskDestination,
   ScheduledTaskPrincipal,
   ScheduledTaskRecurrence,
   ScheduledTaskStatus,
 } from "@/chat/scheduler/types";
-import { normalizeSlackConversationId } from "@/chat/slack/client";
+import { isDmChannel, normalizeSlackConversationId } from "@/chat/slack/client";
 import { isSlackTeamId } from "@/chat/slack/ids";
 import { tool } from "@/chat/tools/definition";
 import type { ToolRuntimeContext } from "@/chat/tools/types";
@@ -90,6 +91,38 @@ function requireRequester(
   };
 }
 
+function getConversationAccess(
+  destination: ScheduledTaskDestination,
+): ScheduledTaskConversationAccess {
+  if (isDmChannel(destination.channelId)) {
+    return { audience: "direct", visibility: "private" };
+  }
+  if (destination.channelId.startsWith("G")) {
+    return { audience: "group", visibility: "private" };
+  }
+  if (destination.channelId.startsWith("C")) {
+    return { audience: "channel", visibility: "public" };
+  }
+  return { audience: "channel", visibility: "unknown" };
+}
+
+function getCredentialSubject(args: {
+  access: ScheduledTaskConversationAccess;
+  requester: ScheduledTaskPrincipal;
+}): ScheduledTaskCredentialSubject | undefined {
+  if (
+    args.access.audience !== "direct" ||
+    args.access.visibility !== "private"
+  ) {
+    return undefined;
+  }
+  return {
+    type: "user",
+    userId: args.requester.slackUserId,
+    allowedWhen: "private-direct-conversation",
+  };
+}
+
 function sameDestination(
   task: ScheduledTask,
   destination: ScheduledTaskDestination,
@@ -153,6 +186,13 @@ function compactTask(task: ScheduledTask): Record<string, unknown> {
     next_run_at: task.nextRunAtMs
       ? new Date(task.nextRunAtMs).toISOString()
       : null,
+    conversation_access: task.conversationAccess ?? null,
+    credential_subject: task.credentialSubject
+      ? {
+          type: task.credentialSubject.type,
+          allowed_when: task.credentialSubject.allowedWhen,
+        }
+      : null,
     last_run_at: task.lastRunAtMs
       ? new Date(task.lastRunAtMs).toISOString()
       : null,
@@ -215,8 +255,7 @@ function buildRecurrence(args: {
   if (!args.nextRunAtMs) {
     return {
       ok: false,
-      error:
-        "Recurring scheduled tasks require next_run_at_iso or next_run_at_text.",
+      error: "Recurring scheduled tasks require next_run_at_iso.",
     };
   }
 
@@ -265,7 +304,6 @@ function validateRecurringFrequencyLimit(input: {
 }
 
 function shouldRebuildRecurrence(input: {
-  next_run_at_text?: string;
   next_run_at_iso?: string;
   recurrence_frequency?: unknown;
   recurrence_interval?: number;
@@ -273,7 +311,6 @@ function shouldRebuildRecurrence(input: {
   timezone?: string;
 }): boolean {
   return (
-    input.next_run_at_text !== undefined ||
     input.next_run_at_iso !== undefined ||
     input.recurrence_frequency !== undefined ||
     input.recurrence_interval !== undefined ||
@@ -295,36 +332,17 @@ function isValidTimeZone(timezone: string): boolean {
   }
 }
 
-function parseNextRunAtMs(args: {
-  input: {
-    next_run_at_iso?: string;
-    next_run_at_text?: string;
-  };
-  nowMs: number;
-  timezone: string;
-}): number | undefined {
+function parseNextRunAtMs(
+  nextRunAtIso: string | undefined,
+): number | undefined {
   try {
-    if (args.input.next_run_at_iso) {
-      return parseScheduleTimestamp(args.input.next_run_at_iso);
-    }
-    if (args.input.next_run_at_text) {
-      return parseRelativeScheduleTimestamp({
-        nowMs: args.nowMs,
-        text: args.input.next_run_at_text,
-        timezone: args.timezone,
-      });
+    if (nextRunAtIso) {
+      return parseScheduleTimestamp(nextRunAtIso);
     }
   } catch {
     return undefined;
   }
   return undefined;
-}
-
-function hasConflictingNextRunInputs(input: {
-  next_run_at_iso?: string;
-  next_run_at_text?: string;
-}): boolean {
-  return Boolean(input.next_run_at_iso && input.next_run_at_text);
 }
 
 /** Create a tool that stores a scheduled task for the active Slack context. */
@@ -339,7 +357,7 @@ export function createSlackScheduleCreateTaskTool(context: ToolRuntimeContext) {
       "When the user's scheduling intent is clear, create the task immediately without asking for confirmation.",
       "Ask for confirmation only when the task contract, schedule, or active destination is ambiguous.",
       "Recurring tasks can run at most once per day; use only daily, weekly, monthly, or yearly recurrence frequencies.",
-      "Provide exactly one of next_run_at_iso or next_run_at_text; omit timezone to use the configured default.",
+      "Provide next_run_at_iso as an exact ISO timestamp computed from the user's requested schedule.",
       "Use recurrence_frequency only for recurring schedules.",
     ],
     inputSchema: Type.Object({
@@ -359,14 +377,6 @@ export function createSlackScheduleCreateTaskTool(context: ToolRuntimeContext) {
           minLength: 1,
           description:
             "Exact next run time as an ISO timestamp, computed from the user's requested schedule.",
-        }),
-      ),
-      next_run_at_text: Type.Optional(
-        Type.String({
-          minLength: 1,
-          maxLength: 120,
-          description:
-            'Supported relative one-off text such as "tomorrow at 9am" in the supplied timezone.',
         }),
       ),
       recurrence_frequency: Type.Optional(
@@ -417,12 +427,6 @@ export function createSlackScheduleCreateTaskTool(context: ToolRuntimeContext) {
 
       const nowMs = Date.now();
       const timezone = input.timezone ?? getDefaultScheduleTimezone();
-      if (hasConflictingNextRunInputs(input)) {
-        return {
-          ok: false,
-          error: "Provide only one of next_run_at_iso or next_run_at_text.",
-        };
-      }
       const frequencyLimit = validateRecurringFrequencyLimit(input);
       if (!frequencyLimit.ok) {
         return frequencyLimit;
@@ -433,16 +437,11 @@ export function createSlackScheduleCreateTaskTool(context: ToolRuntimeContext) {
           error: "timezone must be a valid IANA time zone.",
         };
       }
-      const nextRunAtMs = parseNextRunAtMs({
-        input,
-        nowMs,
-        timezone,
-      });
+      const nextRunAtMs = parseNextRunAtMs(input.next_run_at_iso);
       if (!nextRunAtMs) {
         return {
           ok: false,
-          error:
-            'Provide next_run_at_iso as a valid ISO timestamp or next_run_at_text such as "tomorrow at 9am".',
+          error: "Provide next_run_at_iso as a valid ISO timestamp.",
         };
       }
       const recurrence = buildRecurrence({
@@ -453,12 +452,19 @@ export function createSlackScheduleCreateTaskTool(context: ToolRuntimeContext) {
       if (!recurrence.ok) {
         return recurrence;
       }
+      const conversationAccess = getConversationAccess(destination.destination);
+      const credentialSubject = getCredentialSubject({
+        access: conversationAccess,
+        requester: requester.requester,
+      });
 
       const task: ScheduledTask = {
         id: buildTaskId(),
         createdAtMs: nowMs,
         updatedAtMs: nowMs,
         createdBy: requester.requester,
+        conversationAccess,
+        ...(credentialSubject ? { credentialSubject } : {}),
         destination: destination.destination,
         executionActor: SCHEDULED_TASK_SYSTEM_ACTOR,
         nextRunAtMs,
@@ -532,7 +538,7 @@ export function createSlackScheduleUpdateTaskTool(context: ToolRuntimeContext) {
       ACTIVE_TASK_ID_GUIDELINE,
       ACTIVE_DESTINATION_GUIDELINE,
       "Do not move scheduled tasks across conversations.",
-      "Provide exactly one of next_run_at_iso or next_run_at_text when changing the next run.",
+      "Provide next_run_at_iso as an exact ISO timestamp when changing the next run.",
       "Set status to active, paused, or blocked when the user asks to resume, pause, or block a task.",
     ],
     inputSchema: Type.Object({
@@ -553,9 +559,6 @@ export function createSlackScheduleUpdateTaskTool(context: ToolRuntimeContext) {
       ),
       timezone: Type.Optional(Type.String({ minLength: 1, maxLength: 80 })),
       next_run_at_iso: Type.Optional(Type.String({ minLength: 1 })),
-      next_run_at_text: Type.Optional(
-        Type.String({ minLength: 1, maxLength: 120 }),
-      ),
       recurrence_frequency: Type.Optional(
         Type.Union([
           Type.Literal("daily"),
@@ -597,12 +600,6 @@ export function createSlackScheduleUpdateTaskTool(context: ToolRuntimeContext) {
       if (!lookup.ok) return lookup;
 
       const timezone = input.timezone ?? lookup.task.schedule.timezone;
-      if (hasConflictingNextRunInputs(input)) {
-        return {
-          ok: false,
-          error: "Provide only one of next_run_at_iso or next_run_at_text.",
-        };
-      }
       const frequencyLimit = validateRecurringFrequencyLimit(input);
       if (!frequencyLimit.ok) {
         return frequencyLimit;
@@ -613,20 +610,14 @@ export function createSlackScheduleUpdateTaskTool(context: ToolRuntimeContext) {
           error: "timezone must be a valid IANA time zone.",
         };
       }
-      const parsedNextRunAtMs = parseNextRunAtMs({
-        input,
-        nowMs: Date.now(),
-        timezone,
-      });
-      const nextRunAtMs =
-        input.next_run_at_iso || input.next_run_at_text
-          ? parsedNextRunAtMs
-          : lookup.task.nextRunAtMs;
-      if ((input.next_run_at_iso || input.next_run_at_text) && !nextRunAtMs) {
+      const parsedNextRunAtMs = parseNextRunAtMs(input.next_run_at_iso);
+      const nextRunAtMs = input.next_run_at_iso
+        ? parsedNextRunAtMs
+        : lookup.task.nextRunAtMs;
+      if (input.next_run_at_iso && !nextRunAtMs) {
         return {
           ok: false,
-          error:
-            'Provide next_run_at_iso as a valid ISO timestamp or next_run_at_text such as "tomorrow at 9am".',
+          error: "Provide next_run_at_iso as a valid ISO timestamp.",
         };
       }
 
@@ -641,7 +632,7 @@ export function createSlackScheduleUpdateTaskTool(context: ToolRuntimeContext) {
         return {
           ok: false,
           error:
-            "Active scheduled tasks require next_run_at_iso or next_run_at_text when no next run is stored.",
+            "Active scheduled tasks require next_run_at_iso when no next run is stored.",
         };
       }
       const recurrence = shouldRebuildRecurrence(input)

--- a/packages/junior/src/chat/tools/slack/schedule-tools.ts
+++ b/packages/junior/src/chat/tools/slack/schedule-tools.ts
@@ -101,7 +101,7 @@ function getConversationAccess(
     return { audience: "group", visibility: "private" };
   }
   if (destination.channelId.startsWith("C")) {
-    return { audience: "channel", visibility: "public" };
+    return { audience: "channel", visibility: "unknown" };
   }
   return { audience: "channel", visibility: "unknown" };
 }

--- a/packages/junior/tests/integration/agent-dispatch-runner.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-runner.test.ts
@@ -167,6 +167,60 @@ describe("agent dispatch runner", () => {
     });
   });
 
+  it("passes delegated credential subjects without changing the requester actor", async () => {
+    queueSlackApiResponse("chat.postMessage", {
+      body: chatPostMessageOk({
+        channel: "D123",
+        ts: "1700000000.000002",
+      }),
+    });
+    const created = await createOrGetDispatch({
+      plugin: "scheduler",
+      nowMs: Date.parse("2026-05-26T12:00:00.000Z"),
+      options: {
+        idempotencyKey: "run-delegated",
+        credentialSubject: {
+          type: "user",
+          userId: "U123",
+          allowedWhen: "private-direct-conversation",
+        },
+        destination: {
+          platform: "slack",
+          teamId: "T123",
+          channelId: "D123",
+        },
+        input: "Run the scheduled task.",
+      },
+    });
+    const generateAssistantReply = vi.fn(async (_input, context) => {
+      expect(context.requester).toBeUndefined();
+      expect(context.credentialSubject).toEqual({
+        type: "user",
+        userId: "U123",
+        allowedWhen: "private-direct-conversation",
+      });
+      expect(context.authorizationFlowMode).toBe("disabled");
+      expect(context.correlation).toMatchObject({
+        actorType: "system",
+        actorId: "scheduler",
+      });
+      return createReply();
+    });
+
+    await runAgentDispatchSlice(
+      {
+        id: created.record.id,
+        expectedVersion: created.record.version,
+      },
+      { generateAssistantReply },
+    );
+
+    await expect(getDispatchRecord(created.record.id)).resolves.toMatchObject({
+      status: "completed",
+      resultMessageTs: "1700000000.000002",
+    });
+  });
+
   it("does not burn an attempt when the destination conversation is busy", async () => {
     const created = await createOrGetDispatch({
       plugin: "scheduler",

--- a/packages/junior/tests/integration/heartbeat.test.ts
+++ b/packages/junior/tests/integration/heartbeat.test.ts
@@ -455,6 +455,51 @@ describe("trusted plugin heartbeat", () => {
     });
   });
 
+  it("carries scheduled task credential subjects into dispatch records", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response("Accepted", { status: 202 });
+    });
+    global.fetch = fetchMock as typeof fetch;
+    setAgentPlugins([createSchedulerPlugin()]);
+    const store = createStateSchedulerStore();
+    await store.saveTask(
+      createTask({
+        destination: {
+          platform: "slack",
+          teamId: "T123",
+          channelId: "D123",
+        },
+        credentialSubject: {
+          type: "user",
+          userId: "U123",
+          allowedWhen: "private-direct-conversation",
+        },
+      }),
+    );
+
+    const waitUntilTasks: Promise<unknown>[] = [];
+    const response = await heartbeat(
+      new Request("https://example.invalid/api/internal/heartbeat", {
+        headers: { authorization: "Bearer heartbeat-secret" },
+      }),
+      collectWaitUntil(waitUntilTasks),
+    );
+    expect(response.status).toBe(202);
+    await Promise.all(waitUntilTasks);
+
+    const running = await store.getRun(`sched_plugin_1:${TEST_RUN_AT_MS}`);
+    expect(running?.dispatchId).toEqual(expect.any(String));
+    await expect(
+      getDispatchRecord(running!.dispatchId!),
+    ).resolves.toMatchObject({
+      credentialSubject: {
+        type: "user",
+        userId: "U123",
+        allowedWhen: "private-direct-conversation",
+      },
+    });
+  });
+
   it("fails scheduled runs when their dispatch record disappeared", async () => {
     const fetchMock = vi.fn(async () => {
       return new Response("Accepted", { status: 202 });

--- a/packages/junior/tests/integration/slack-schedule-tools.test.ts
+++ b/packages/junior/tests/integration/slack-schedule-tools.test.ts
@@ -82,7 +82,7 @@ describe("Slack schedule tools", () => {
       task: {
         conversation_access: {
           audience: "channel",
-          visibility: "public",
+          visibility: "unknown",
         },
         credential_subject: null,
         status: "active",

--- a/packages/junior/tests/integration/slack-schedule-tools.test.ts
+++ b/packages/junior/tests/integration/slack-schedule-tools.test.ts
@@ -80,6 +80,11 @@ describe("Slack schedule tools", () => {
     expect(created).toMatchObject({
       ok: true,
       task: {
+        conversation_access: {
+          audience: "channel",
+          visibility: "public",
+        },
+        credential_subject: null,
         status: "active",
         title: "Weekly issue digest",
         recurrence: {
@@ -163,7 +168,7 @@ describe("Slack schedule tools", () => {
         objective: "Remind David to wash his hands.",
         instructions: ["Remind David to wash his hands."],
         schedule_description: "In 1 minute",
-        next_run_at_text: "in 1 minute",
+        next_run_at_iso: "2026-05-27T00:25:23.000Z",
       },
     );
 
@@ -192,7 +197,7 @@ describe("Slack schedule tools", () => {
         objective: "Remind David to wash his hands.",
         instructions: ["Remind David to wash his hands."],
         schedule_description: "In 1 minute",
-        next_run_at_text: "in 1 minute",
+        next_run_at_iso: "2026-05-27T00:25:23.000Z",
       },
     );
 
@@ -209,6 +214,15 @@ describe("Slack schedule tools", () => {
       createStateSchedulerStore().listTasksForTeam(TEST_TEAM_ID),
     ).resolves.toMatchObject([
       {
+        conversationAccess: {
+          audience: "direct",
+          visibility: "private",
+        },
+        credentialSubject: {
+          type: "user",
+          userId: "U123",
+          allowedWhen: "private-direct-conversation",
+        },
         destination: { channelId: "D123" },
         nextRunAtMs: Date.parse("2026-05-27T00:25:23.000Z"),
         status: "active",
@@ -231,7 +245,7 @@ describe("Slack schedule tools", () => {
         objective: "Remind David to drink water.",
         instructions: ["Remind David to drink water."],
         schedule_description: "In 1 minute",
-        next_run_at_text: "in 1 minute",
+        next_run_at_iso: "2026-05-27T00:25:23.000Z",
       },
     );
 
@@ -262,23 +276,21 @@ describe("Slack schedule tools", () => {
 
     expect(result).toMatchObject({
       ok: false,
-      error:
-        'Provide next_run_at_iso as a valid ISO timestamp or next_run_at_text such as "tomorrow at 9am".',
+      error: "Provide next_run_at_iso as a valid ISO timestamp.",
     });
     await expect(
       createStateSchedulerStore().listTasksForTeam(TEST_TEAM_ID),
     ).resolves.toEqual([]);
   });
 
-  it("rejects conflicting exact and relative next run inputs", async () => {
+  it("rejects missing next run timestamps with a tool error", async () => {
     const result = await createTask(createContext(), {
-      next_run_at_iso: "2026-05-25T16:00:00.000Z",
-      next_run_at_text: "tomorrow at 9am",
+      next_run_at_iso: undefined,
     });
 
     expect(result).toMatchObject({
       ok: false,
-      error: "Provide only one of next_run_at_iso or next_run_at_text.",
+      error: "Provide next_run_at_iso as a valid ISO timestamp.",
     });
     await expect(
       createStateSchedulerStore().listTasksForTeam(TEST_TEAM_ID),
@@ -455,13 +467,39 @@ describe("Slack schedule tools", () => {
     });
   });
 
-  it("creates one-off tasks from tomorrow text using the default Pacific timezone", async () => {
+  it("does not delegate user credentials in private group conversations", async () => {
+    const result = await createTask(createContext({ channelId: "G123" }));
+
+    expect(result).toMatchObject({
+      ok: true,
+      task: {
+        conversation_access: {
+          audience: "group",
+          visibility: "private",
+        },
+        credential_subject: null,
+      },
+    });
+    const tasks =
+      await createStateSchedulerStore().listTasksForTeam(TEST_TEAM_ID);
+    expect(tasks).toMatchObject([
+      {
+        conversationAccess: {
+          audience: "group",
+          visibility: "private",
+        },
+        destination: { channelId: "G123" },
+      },
+    ]);
+    expect(tasks[0]?.credentialSubject).toBeUndefined();
+  });
+
+  it("creates one-off tasks with an exact timestamp using the default Pacific timezone", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-25T12:00:00.000Z"));
 
     const created = await createTask(createContext(), {
-      next_run_at_iso: undefined,
-      next_run_at_text: "tomorrow at 9am",
+      next_run_at_iso: "2026-05-26T16:00:00.000Z",
       recurrence_frequency: undefined,
       recurrence_weekdays: undefined,
       timezone: undefined,
@@ -483,8 +521,7 @@ describe("Slack schedule tools", () => {
     vi.setSystemTime(new Date("2026-05-25T12:00:00.000Z"));
 
     const created = await createTask(createContext(), {
-      next_run_at_iso: undefined,
-      next_run_at_text: "tomorrow at 9am",
+      next_run_at_iso: "2026-05-26T13:00:00.000Z",
       recurrence_frequency: undefined,
       recurrence_weekdays: undefined,
       timezone: undefined,

--- a/packages/junior/tests/unit/runtime/agent-dispatch-validation.test.ts
+++ b/packages/junior/tests/unit/runtime/agent-dispatch-validation.test.ts
@@ -33,4 +33,34 @@ describe("agent dispatch validation", () => {
       }),
     ).toThrow("Dispatch metadata key exceeds the maximum length");
   });
+
+  it("requires delegated credential subjects to target direct Slack conversations", () => {
+    expect(() =>
+      validateDispatchOptions({
+        ...validOptions,
+        credentialSubject: {
+          type: "user",
+          userId: "U123",
+          allowedWhen: "private-direct-conversation",
+        },
+      }),
+    ).toThrow(
+      "Dispatch credentialSubject requires a private direct Slack destination",
+    );
+
+    expect(() =>
+      validateDispatchOptions({
+        ...validOptions,
+        destination: {
+          ...validOptions.destination,
+          channelId: "D123",
+        },
+        credentialSubject: {
+          type: "user",
+          userId: "U123",
+          allowedWhen: "private-direct-conversation",
+        },
+      }),
+    ).not.toThrow();
+  });
 });

--- a/specs/scheduler-spec.md
+++ b/specs/scheduler-spec.md
@@ -7,6 +7,7 @@
 
 ## Changelog
 
+- 2026-05-27: Added the private direct conversation credential-subject exception for user-authenticated scheduled tools.
 - 2026-05-27: Added stale missed-run policy: old occurrences are skipped and consumed or advanced, not dispatched late and not blocked for human review.
 - 2026-05-27: Added the recurring schedule frequency limit: at most once per day.
 - 2026-05-27: Changed Slack authoring to auto-create clear scheduled work and reserve confirmation for ambiguous requests.
@@ -52,6 +53,8 @@ The stored task must include:
 - expected output
 - creator metadata
 - execution actor metadata
+- conversation access metadata
+- optional credential subject for private direct conversations
 - destination surface
 - schedule and timezone
 - current status
@@ -63,6 +66,8 @@ The original user utterance may be retained for audit/debugging, but it must not
 
 Slack destinations are conversations, not existing threads. A scheduled task may target the active Slack DM or channel, and scheduled output posts as a new message in that conversation.
 
+The scheduler must distinguish conversation audience from visibility. A private direct conversation may use explicit user-delegated credentials for scheduled tools; a private group conversation or private channel is still multi-user and must not implicitly use one user's credentials. Unknown privacy or audience must fail closed for delegated user credentials.
+
 Creator metadata records the user who confirmed the task so Junior can audit changes and privately notify someone when the task needs attention. The creator is not an owner, is not an authorization principal, and is not the actor for future scheduled runs.
 
 Task management is controlled only by access to the destination conversation window. If a user can post or trigger Junior in that Slack DM or channel context, they can manage scheduled tasks for that same context. The scheduler must not add creator-only, owner-only, workspace-admin-only, or channel-admin-only gates for V1 management.
@@ -71,6 +76,7 @@ Task management is controlled only by access to the destination conversation win
 
 Every active task must have an exact `nextRunAtMs` instant. For one-off tasks, that instant is the complete schedule.
 Slack authoring may accept supported relative one-off phrases such as "tomorrow at 9am"; these must be resolved to an exact `nextRunAtMs` before storage. When a user does not provide a timezone, scheduler authoring defaults to `America/Los_Angeles` unless `JUNIOR_TIMEZONE` overrides it.
+Scheduler tools accept exact ISO run timestamps only. Natural-language or relative time belongs in the agent's interpretation step before it calls the tool, not in the storage tool contract.
 
 Recurring tasks must also store a small calendar recurrence rule:
 
@@ -171,25 +177,33 @@ Scheduled tasks must distinguish these V1 identities:
 - **Conversation manager:** any user who can post or trigger Junior in the destination Slack conversation window. This controls who may list, pause, resume, delete, or run-now the task for that same conversation.
 - **Execution actor:** the actor used for the autonomous scheduled run. For scheduled tasks, this is a Junior system actor, not a Slack user.
 
-Scheduled runs must not pass the creator as the runtime requester or treat the creator as if they were present and acting during the run. Audit and correlation metadata should include both the system execution actor and creator metadata, but auth decisions must use the execution actor.
+Scheduled runs must not pass the creator as the runtime requester or treat the creator as if they were present and acting during the run. Audit and correlation metadata should include both the system execution actor and creator metadata. Auth decisions must use the execution actor unless the task stores an explicit credential subject allowed by the private direct conversation exception below.
 
-V1 scheduled execution has no user requester. User OAuth tokens cannot be used merely because that user created the task. Authorization flows are disabled during scheduled runs, and authorization links must not be posted publicly. If no usable non-user credential exists, Junior must block the run and privately notify the creator when possible.
+V1 scheduled execution has no user requester. User OAuth tokens cannot be used merely because that user created the task. Authorization flows are disabled during scheduled runs, and authorization links must not be posted publicly. If no usable system credential or explicit credential subject exists, Junior must block the run and privately notify the creator when possible.
+
+Exception: a scheduled task created in a private direct conversation may store an explicit credential subject for the requester who created the task. This subject is not the execution actor and does not make the creator the requester for the scheduled run. It is only an auth subject that lets credential resolution use that user's already-connected provider credentials during autonomous execution. The exception requires both:
+
+- `conversationAccess.audience = direct`
+- `conversationAccess.visibility = private`
+
+Private group conversations, private channels, public channels, and unknown conversation access must not store or use user credential subjects for scheduled runs.
 
 Future actor-aware auth may add an explicit credential subject: an account, grant, or service principal whose provider credentials may be used by scheduled tools. Future credential subjects may include:
 
 - system-owned credentials available to the scheduled-run actor
-- an explicitly recorded delegated credential grant in the task contract
+- an explicitly recorded delegated credential subject in the task contract
 - a supported service principal named by the task contract
 
-Those future credential subjects must be explicit and separate from creator metadata. Until that support exists, scheduled runs may use only credentials already available to the system execution actor.
+Credential subjects must be explicit and separate from creator metadata.
 
 ### Implementation Plan
 
 1. Introduce a small actor contract shared by runtime, scheduler, and auth boundaries. It should represent user actors, system actors, and future service actors without leaking Slack SDK types.
 2. Keep `createdBy` as creator metadata and add an execution actor field to scheduled tasks. New scheduled tasks should default to a system actor such as `scheduled-task`; existing tasks may be read with that default until migrated.
-3. Update the scheduled runner to enter the agent runtime with the system actor and no user requester. Creator details may remain in run context and notification metadata, but not in the actor slot.
-4. Update auth and credential resolution so V1 scheduled runs cannot use requester-scoped OAuth or start interactive auth flows. Missing non-user credentials should produce a blocked run plus private notification.
-5. Update telemetry, tests, and eval fixtures so scheduled execution assertions refer to creator metadata and execution actor separately.
+3. Add conversation access metadata with separate audience and visibility fields. Slack direct-message destinations populate `direct/private`; private channels or group conversations are not eligible for delegated user credentials.
+4. Update the scheduled runner to enter the agent runtime with the system actor and no user requester. Creator details may remain in run context and notification metadata, but not in the actor slot.
+5. Update auth and credential resolution so scheduled runs can use an explicit private-direct credential subject but cannot start interactive auth flows. Missing credentials should produce a blocked run plus private notification.
+6. Update telemetry, tests, and eval fixtures so scheduled execution assertions refer to creator metadata, execution actor, and credential subject separately.
 
 ### Slack UX
 
@@ -250,6 +264,8 @@ Use integration tests for runtime/storage contracts that do not depend on model 
 - blocked auth path for missing non-user credentials
 - scheduled runner passes a system actor rather than the creator as requester
 - user OAuth tokens are not used implicitly for scheduled tasks
+- private direct scheduled tasks may carry an explicit user credential subject
+- private group/channel scheduled tasks do not carry user credential subjects
 - dispatch to Slack delivery
 - destination-scoped list output
 - conversation-access management for pause, resume, delete, and run-now


### PR DESCRIPTION
Scheduled tasks created in private direct conversations can now carry an explicit user credential subject while still executing as the scheduler system actor. Public channels and private group destinations continue to run without delegated user credentials.

**Credential Subject**

The scheduler stores conversation audience and visibility, passes allowed credential subjects through dispatch, and validates delegated credentials at the dispatch boundary so only direct private Slack destinations can use them.

**Schedule Tool Contract**

The Slack scheduling tool now accepts only exact ISO run timestamps. Natural-language time interpretation stays with the agent before it calls the tool, and missing or invalid timestamps return a clear tool error.

**Scheduler Spec**

The scheduler spec documents the private direct conversation exception, the separation between creator, execution actor, and credential subject, and the ISO-only storage tool contract.