### PR TITLE
chore: add repository field to all package.json files

### DIFF
--- a/packages/junior-agent-browser/package.json
+++ b/packages/junior-agent-browser/package.json
@@ -6,6 +6,11 @@
     "access": "public"
   },
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getsentry/junior.git",
+    "directory": "packages/junior-agent-browser"
+  },
   "files": [
     "plugin.yaml",
     "skills"

--- a/packages/junior-datadog/package.json
+++ b/packages/junior-datadog/package.json
@@ -6,6 +6,11 @@
     "access": "public"
   },
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getsentry/junior.git",
+    "directory": "packages/junior-datadog"
+  },
   "files": [
     "plugin.yaml",
     "skills"

--- a/packages/junior-github/package.json
+++ b/packages/junior-github/package.json
@@ -6,6 +6,11 @@
     "access": "public"
   },
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getsentry/junior.git",
+    "directory": "packages/junior-github"
+  },
   "exports": {
     ".": {
       "types": "./index.d.ts",

--- a/packages/junior-hex/package.json
+++ b/packages/junior-hex/package.json
@@ -6,6 +6,11 @@
     "access": "public"
   },
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getsentry/junior.git",
+    "directory": "packages/junior-hex"
+  },
   "files": [
     "plugin.yaml",
     "skills"

--- a/packages/junior-linear/package.json
+++ b/packages/junior-linear/package.json
@@ -6,6 +6,11 @@
     "access": "public"
   },
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getsentry/junior.git",
+    "directory": "packages/junior-linear"
+  },
   "files": [
     "plugin.yaml",
     "skills"

--- a/packages/junior-notion/package.json
+++ b/packages/junior-notion/package.json
@@ -6,6 +6,11 @@
     "access": "public"
   },
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getsentry/junior.git",
+    "directory": "packages/junior-notion"
+  },
   "files": [
     "plugin.yaml",
     "skills"

--- a/packages/junior-plugin-api/package.json
+++ b/packages/junior-plugin-api/package.json
@@ -6,6 +6,11 @@
     "access": "public"
   },
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getsentry/junior.git",
+    "directory": "packages/junior-plugin-api"
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/junior-sentry/package.json
+++ b/packages/junior-sentry/package.json
@@ -6,6 +6,11 @@
     "access": "public"
   },
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getsentry/junior.git",
+    "directory": "packages/junior-sentry"
+  },
   "files": [
     "plugin.yaml",
     "skills"

--- a/packages/junior/package.json
+++ b/packages/junior/package.json
@@ -6,6 +6,11 @@
     "access": "public"
   },
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getsentry/junior.git",
+    "directory": "packages/junior"
+  },
   "packageManager": "pnpm@10.30.2",
   "bin": {
     "junior": "bin/junior.mjs"


### PR DESCRIPTION
Adds `repository` to all the package.json files, which allows tools like Renovate to recognize `@sentry/junior*` as a monorepo when suggesting package updates