### PR TITLE
ref(scheduler): Simplify scheduled task API

### DIFF
--- a/packages/junior-evals/evals/behavior-harness.ts
+++ b/packages/junior-evals/evals/behavior-harness.ts
@@ -335,15 +335,13 @@ function toEvalToolInvocation(input: {
   if (input.toolName.startsWith("slackSchedule")) {
     invocation.arguments = Object.fromEntries(
       [
-        "title",
         "task_id",
-        "objective",
-        "schedule_description",
+        "task",
+        "schedule",
+        "recurring",
         "timezone",
-        "next_run_at_iso",
-        "recurrence_frequency",
-        "recurrence_interval",
-        "recurrence_weekdays",
+        "next_run_at",
+        "recurrence",
         "status",
       ]
         .filter((key) => key in input.params)

--- a/packages/junior-evals/evals/core/scheduler.eval.ts
+++ b/packages/junior-evals/evals/core/scheduler.eval.ts
@@ -12,6 +12,7 @@ describeEval("Scheduler", slackEvals, (it) => {
           "A simple one-off reminder request is scheduled immediately for the active Slack context.",
         pass: [
           "The reply confirms that a one-off reminder to wash hands was scheduled.",
+          "The schedule creation uses recurring=false and does not set recurrence.",
           "The reply does not ask the user to confirm first.",
         ],
         fail: [
@@ -36,7 +37,8 @@ describeEval("Scheduler", slackEvals, (it) => {
         contract:
           "A clear future or recurring task request is normalized and scheduled immediately for the active Slack context.",
         pass: [
-          "The created task title/objective/instructions describe checking scheduler-related GitHub issues, not creating a schedule.",
+          "The created task describes checking scheduler-related GitHub issues, not creating a schedule.",
+          "The schedule creation uses recurring=true and recurrence.frequency=weekly.",
           "The reply confirms the recurring schedule was created for Monday at 9am Pacific.",
         ],
         fail: [

--- a/packages/junior/src/chat/scheduler/prompt.ts
+++ b/packages/junior/src/chat/scheduler/prompt.ts
@@ -9,21 +9,11 @@ const EXECUTION_RULES = [
   "- Execute as the scheduled-task system actor; creator metadata is audit context, not an active user identity.",
   "- Complete the task without asking follow-up questions unless access, approval, or required input is missing.",
   "- Use the available tools and skills that are relevant to the task contract.",
+  "- Do not create, edit, or discuss scheduling during this run; the stored schedule already fired.",
+  "- For reminder tasks, deliver the reminder message now instead of explaining how reminders or delayed posts work.",
   "- If blocked, report the specific missing provider, permission, configuration, or input.",
   "- Keep the final result shaped for the configured destination audience.",
 ];
-
-function renderList(tag: string, values: string[] | undefined): string[] {
-  const entries = (values ?? []).map((value) => value.trim()).filter(Boolean);
-  if (entries.length === 0) {
-    return [`<${tag}>`, "</" + tag + ">"];
-  }
-  return [
-    `<${tag}>`,
-    ...entries.map((value) => `- ${escapeXml(value)}`),
-    `</${tag}>`,
-  ];
-}
 
 function renderOptionalLine(name: string, value: string | undefined): string[] {
   return value?.trim() ? [`- ${name}: ${escapeXml(value.trim())}`] : [];
@@ -39,6 +29,9 @@ export function buildScheduledTaskRunPrompt(args: {
   const destination = task.destination;
   const creator = task.createdBy;
   const executionActor = task.executionActor ?? SCHEDULED_TASK_SYSTEM_ACTOR;
+  if (!task.task.text?.trim()) {
+    throw new Error("Scheduled task text is required");
+  }
 
   return [
     "<scheduled-task-run>",
@@ -46,16 +39,9 @@ export function buildScheduledTaskRunPrompt(args: {
     "",
     "<scheduled-task>",
     `- id: ${escapeXml(task.id)}`,
-    `- title: ${escapeXml(task.task.title)}`,
-    `- objective: ${escapeXml(task.task.objective)}`,
-    ...renderOptionalLine("expected_output", task.task.expectedOutput),
-    "<instructions>",
-    ...task.task.instructions.map(
-      (instruction) => `- ${escapeXml(instruction)}`,
-    ),
-    "</instructions>",
-    ...renderList("constraints", task.task.constraints),
-    ...renderList("source-context", task.task.sourceContext),
+    "<task-text>",
+    escapeXml(task.task.text),
+    "</task-text>",
     "</scheduled-task>",
     "",
     "<run-context>",

--- a/packages/junior/src/chat/scheduler/store.ts
+++ b/packages/junior/src/chat/scheduler/store.ts
@@ -313,10 +313,6 @@ function normalizedText(value: string | undefined): string {
   return value?.trim().replace(/\s+/g, " ").toLowerCase() ?? "";
 }
 
-function normalizedTexts(values: string[] | undefined): string[] {
-  return (values ?? []).map(normalizedText);
-}
-
 function taskDedupeFingerprint(task: ScheduledTask): string {
   return JSON.stringify({
     destination: task.destination,
@@ -336,14 +332,7 @@ function taskDedupeFingerprint(task: ScheduledTask): string {
         : null,
       timezone: task.schedule.timezone,
     },
-    task: {
-      constraints: normalizedTexts(task.task.constraints),
-      expectedOutput: normalizedText(task.task.expectedOutput),
-      instructions: normalizedTexts(task.task.instructions),
-      objective: normalizedText(task.task.objective),
-      sourceContext: normalizedTexts(task.task.sourceContext),
-      title: normalizedText(task.task.title),
-    },
+    task: normalizedText(task.task.text),
   });
 }
 

--- a/packages/junior/src/chat/scheduler/types.ts
+++ b/packages/junior/src/chat/scheduler/types.ts
@@ -70,12 +70,7 @@ export interface ScheduledTaskSchedule {
 }
 
 export interface ScheduledTaskSpec {
-  title: string;
-  objective: string;
-  instructions: string[];
-  expectedOutput?: string;
-  constraints?: string[];
-  sourceContext?: string[];
+  text: string;
 }
 
 export interface ScheduledTask {

--- a/packages/junior/src/chat/tools/slack/schedule-tools.ts
+++ b/packages/junior/src/chat/tools/slack/schedule-tools.ts
@@ -28,6 +28,32 @@ const ACTIVE_DESTINATION_GUIDELINE =
   "Only manage tasks for the active Slack DM or channel; never target an existing thread, another channel, or another user's DM.";
 const ACTIVE_TASK_ID_GUIDELINE =
   "Use only task IDs returned from this active destination.";
+const RECURRING_GUIDELINE =
+  "Set recurring=false for one-time requests like 'in 1 minute', 'tomorrow', or a specific date; set recurring=true only for requests that explicitly repeat.";
+
+const recurrenceInputSchema = Type.Object({
+  frequency: Type.Union([
+    Type.Literal("daily"),
+    Type.Literal("weekly"),
+    Type.Literal("monthly"),
+    Type.Literal("yearly"),
+  ]),
+  interval: Type.Optional(
+    Type.Integer({
+      minimum: 1,
+      maximum: 100,
+      description:
+        "Calendar interval. For example, 2 with weekly means every two weeks.",
+    }),
+  ),
+  weekdays: Type.Optional(
+    Type.Array(Type.Integer({ minimum: 0, maximum: 6 }), {
+      maxItems: 7,
+      description:
+        "For weekly schedules only. Sunday is 0, Monday is 1, Saturday is 6.",
+    }),
+  ),
+});
 
 function requireActiveDestination(
   context: ToolRuntimeContext,
@@ -168,8 +194,7 @@ function compactTask(task: ScheduledTask): Record<string, unknown> {
   return {
     id: task.id,
     status: task.status,
-    title: task.task.title,
-    objective: task.task.objective,
+    task: task.task.text,
     schedule: task.schedule.description,
     timezone: task.schedule.timezone,
     recurrence: task.schedule.recurrence
@@ -233,21 +258,23 @@ function normalizeFrequency(
 function buildRecurrence(args: {
   existing?: ScheduledTaskRecurrence;
   input: {
-    recurrence_frequency?: unknown;
-    recurrence_interval?: number;
-    recurrence_weekdays?: number[];
+    recurrence?: {
+      frequency?: unknown;
+      interval?: number;
+      weekdays?: number[];
+    } | null;
   };
   nextRunAtMs: number | undefined;
   timezone: string;
 }):
   | { ok: true; recurrence?: ScheduledTaskRecurrence }
   | { ok: false; error: string } {
-  if (args.input.recurrence_frequency === null) {
+  if (args.input.recurrence === null) {
     return { ok: true, recurrence: undefined };
   }
 
   const frequency =
-    normalizeFrequency(args.input.recurrence_frequency) ??
+    normalizeFrequency(args.input.recurrence?.frequency) ??
     args.existing?.frequency;
   if (!frequency) {
     return { ok: true, recurrence: undefined };
@@ -255,7 +282,7 @@ function buildRecurrence(args: {
   if (!args.nextRunAtMs) {
     return {
       ok: false,
-      error: "Recurring scheduled tasks require next_run_at_iso.",
+      error: "Recurring scheduled tasks require next_run_at.",
     };
   }
 
@@ -264,12 +291,12 @@ function buildRecurrence(args: {
       ok: true,
       recurrence: buildCalendarRecurrence({
         frequency,
-        interval: args.input.recurrence_interval ?? args.existing?.interval,
+        interval: args.input.recurrence?.interval ?? args.existing?.interval,
         nextRunAtMs: args.nextRunAtMs,
         timezone: args.timezone,
         weekdays:
           frequency === "weekly"
-            ? (args.input.recurrence_weekdays ?? args.existing?.weekdays)
+            ? (args.input.recurrence?.weekdays ?? args.existing?.weekdays)
             : undefined,
       }),
     };
@@ -287,12 +314,13 @@ function buildRecurrence(args: {
 }
 
 function validateRecurringFrequencyLimit(input: {
-  recurrence_frequency?: unknown;
+  recurrence?: {
+    frequency?: unknown;
+  } | null;
 }): { ok: true } | { ok: false; error: string } {
   if (
-    input.recurrence_frequency !== undefined &&
-    input.recurrence_frequency !== null &&
-    !normalizeFrequency(input.recurrence_frequency)
+    input.recurrence?.frequency !== undefined &&
+    !normalizeFrequency(input.recurrence.frequency)
   ) {
     return {
       ok: false,
@@ -303,18 +331,52 @@ function validateRecurringFrequencyLimit(input: {
   return { ok: true };
 }
 
+function validateRecurringIntent(input: {
+  recurring?: unknown;
+  recurrence?: unknown;
+  existingRecurrence?: ScheduledTaskRecurrence;
+}): { ok: true } | { ok: false; error: string } {
+  if (typeof input.recurring !== "boolean") {
+    return {
+      ok: false,
+      error: "recurring must be true or false.",
+    };
+  }
+  if (
+    !input.recurring &&
+    input.recurrence !== undefined &&
+    input.recurrence !== null
+  ) {
+    return {
+      ok: false,
+      error: "One-off scheduled tasks must not include recurrence fields.",
+    };
+  }
+  if (input.recurring && input.recurrence === null) {
+    return {
+      ok: false,
+      error: "Recurring scheduled tasks require recurrence.",
+    };
+  }
+  if (input.recurring && !input.recurrence && !input.existingRecurrence) {
+    return {
+      ok: false,
+      error: "Recurring scheduled tasks require recurrence.",
+    };
+  }
+  return { ok: true };
+}
+
 function shouldRebuildRecurrence(input: {
-  next_run_at_iso?: string;
-  recurrence_frequency?: unknown;
-  recurrence_interval?: number;
-  recurrence_weekdays?: number[];
+  next_run_at?: string;
+  recurring?: unknown;
+  recurrence?: unknown;
   timezone?: string;
 }): boolean {
   return (
-    input.next_run_at_iso !== undefined ||
-    input.recurrence_frequency !== undefined ||
-    input.recurrence_interval !== undefined ||
-    input.recurrence_weekdays !== undefined ||
+    input.next_run_at !== undefined ||
+    input.recurring !== undefined ||
+    input.recurrence !== undefined ||
     input.timezone !== undefined
   );
 }
@@ -354,70 +416,26 @@ export function createSlackScheduleCreateTaskTool(context: ToolRuntimeContext) {
     promptGuidelines: [
       "Use only when the user explicitly asks Junior to do work later or on a recurring cadence.",
       ACTIVE_DESTINATION_GUIDELINE,
+      RECURRING_GUIDELINE,
       "When the user's scheduling intent is clear, create the task immediately without asking for confirmation.",
       "Ask for confirmation only when the task contract, schedule, or active destination is ambiguous.",
       "Recurring tasks can run at most once per day; use only daily, weekly, monthly, or yearly recurrence frequencies.",
-      "Provide next_run_at_iso as an exact ISO timestamp computed from the user's requested schedule.",
-      "Use recurrence_frequency only for recurring schedules.",
+      "Provide next_run_at as an exact ISO timestamp computed from the user's requested schedule.",
+      "Provide recurrence only when recurring=true.",
     ],
     inputSchema: Type.Object({
-      title: Type.String({ minLength: 1, maxLength: 120 }),
-      objective: Type.String({ minLength: 1, maxLength: 1000 }),
-      instructions: Type.Array(Type.String({ minLength: 1, maxLength: 1000 }), {
-        minItems: 1,
-        maxItems: 12,
-      }),
-      expected_output: Type.Optional(
-        Type.String({ minLength: 1, maxLength: 1000 }),
-      ),
-      schedule_description: Type.String({ minLength: 1, maxLength: 300 }),
+      task: Type.String({ minLength: 1, maxLength: 4000 }),
+      schedule: Type.String({ minLength: 1, maxLength: 300 }),
+      recurring: Type.Boolean(),
       timezone: Type.Optional(Type.String({ minLength: 1, maxLength: 80 })),
-      next_run_at_iso: Type.Optional(
+      next_run_at: Type.Optional(
         Type.String({
           minLength: 1,
           description:
             "Exact next run time as an ISO timestamp, computed from the user's requested schedule.",
         }),
       ),
-      recurrence_frequency: Type.Optional(
-        Type.Union(
-          [
-            Type.Literal("daily"),
-            Type.Literal("weekly"),
-            Type.Literal("monthly"),
-            Type.Literal("yearly"),
-          ],
-          {
-            description:
-              "Calendar recurrence for recurring tasks. Omit for exact one-off calendar dates.",
-          },
-        ),
-      ),
-      recurrence_interval: Type.Optional(
-        Type.Integer({
-          minimum: 1,
-          maximum: 100,
-          description:
-            "Calendar interval. For example, 2 with weekly means every two weeks.",
-        }),
-      ),
-      recurrence_weekdays: Type.Optional(
-        Type.Array(Type.Integer({ minimum: 0, maximum: 6 }), {
-          maxItems: 7,
-          description:
-            "For weekly schedules only. Sunday is 0, Monday is 1, Saturday is 6.",
-        }),
-      ),
-      constraints: Type.Optional(
-        Type.Array(Type.String({ minLength: 1, maxLength: 1000 }), {
-          maxItems: 12,
-        }),
-      ),
-      source_context: Type.Optional(
-        Type.Array(Type.String({ minLength: 1, maxLength: 1000 }), {
-          maxItems: 12,
-        }),
-      ),
+      recurrence: Type.Optional(recurrenceInputSchema),
     }),
     execute: async (input) => {
       const destination = requireActiveDestination(context);
@@ -426,6 +444,10 @@ export function createSlackScheduleCreateTaskTool(context: ToolRuntimeContext) {
       if (!requester.ok) return requester;
 
       const nowMs = Date.now();
+      const recurring = validateRecurringIntent(input);
+      if (!recurring.ok) {
+        return recurring;
+      }
       const timezone = input.timezone ?? getDefaultScheduleTimezone();
       const frequencyLimit = validateRecurringFrequencyLimit(input);
       if (!frequencyLimit.ok) {
@@ -437,11 +459,11 @@ export function createSlackScheduleCreateTaskTool(context: ToolRuntimeContext) {
           error: "timezone must be a valid IANA time zone.",
         };
       }
-      const nextRunAtMs = parseNextRunAtMs(input.next_run_at_iso);
+      const nextRunAtMs = parseNextRunAtMs(input.next_run_at);
       if (!nextRunAtMs) {
         return {
           ok: false,
-          error: "Provide next_run_at_iso as a valid ISO timestamp.",
+          error: "Provide next_run_at as a valid ISO timestamp.",
         };
       }
       const recurrence = buildRecurrence({
@@ -470,19 +492,14 @@ export function createSlackScheduleCreateTaskTool(context: ToolRuntimeContext) {
         nextRunAtMs,
         originalRequest: context.userText,
         schedule: {
-          description: input.schedule_description,
+          description: input.schedule,
           timezone,
           kind: recurrence.recurrence ? "recurring" : "one_off",
           recurrence: recurrence.recurrence,
         },
         status: "active",
         task: {
-          title: input.title,
-          objective: input.objective,
-          instructions: input.instructions,
-          expectedOutput: input.expected_output,
-          constraints: input.constraints,
-          sourceContext: input.source_context,
+          text: input.task,
         },
         version: 1,
       };
@@ -537,42 +554,20 @@ export function createSlackScheduleUpdateTaskTool(context: ToolRuntimeContext) {
     promptGuidelines: [
       ACTIVE_TASK_ID_GUIDELINE,
       ACTIVE_DESTINATION_GUIDELINE,
+      RECURRING_GUIDELINE,
       "Do not move scheduled tasks across conversations.",
-      "Provide next_run_at_iso as an exact ISO timestamp when changing the next run.",
+      "Provide next_run_at as an exact ISO timestamp when changing the next run.",
       "Set status to active, paused, or blocked when the user asks to resume, pause, or block a task.",
     ],
     inputSchema: Type.Object({
       task_id: Type.String({ minLength: 1 }),
-      title: Type.Optional(Type.String({ minLength: 1, maxLength: 120 })),
-      objective: Type.Optional(Type.String({ minLength: 1, maxLength: 1000 })),
-      instructions: Type.Optional(
-        Type.Array(Type.String({ minLength: 1, maxLength: 1000 }), {
-          minItems: 1,
-          maxItems: 12,
-        }),
-      ),
-      expected_output: Type.Optional(
-        Type.String({ minLength: 1, maxLength: 1000 }),
-      ),
-      schedule_description: Type.Optional(
-        Type.String({ minLength: 1, maxLength: 300 }),
-      ),
+      task: Type.Optional(Type.String({ minLength: 1, maxLength: 4000 })),
+      schedule: Type.Optional(Type.String({ minLength: 1, maxLength: 300 })),
+      recurring: Type.Optional(Type.Boolean()),
       timezone: Type.Optional(Type.String({ minLength: 1, maxLength: 80 })),
-      next_run_at_iso: Type.Optional(Type.String({ minLength: 1 })),
-      recurrence_frequency: Type.Optional(
-        Type.Union([
-          Type.Literal("daily"),
-          Type.Literal("weekly"),
-          Type.Literal("monthly"),
-          Type.Literal("yearly"),
-          Type.Null(),
-        ]),
-      ),
-      recurrence_interval: Type.Optional(
-        Type.Integer({ minimum: 1, maximum: 100 }),
-      ),
-      recurrence_weekdays: Type.Optional(
-        Type.Array(Type.Integer({ minimum: 0, maximum: 6 }), { maxItems: 7 }),
+      next_run_at: Type.Optional(Type.String({ minLength: 1 })),
+      recurrence: Type.Optional(
+        Type.Union([recurrenceInputSchema, Type.Null()]),
       ),
       status: Type.Optional(
         Type.Union([
@@ -580,16 +575,6 @@ export function createSlackScheduleUpdateTaskTool(context: ToolRuntimeContext) {
           Type.Literal("paused"),
           Type.Literal("blocked"),
         ]),
-      ),
-      constraints: Type.Optional(
-        Type.Array(Type.String({ minLength: 1, maxLength: 1000 }), {
-          maxItems: 12,
-        }),
-      ),
-      source_context: Type.Optional(
-        Type.Array(Type.String({ minLength: 1, maxLength: 1000 }), {
-          maxItems: 12,
-        }),
       ),
     }),
     execute: async (input) => {
@@ -610,14 +595,14 @@ export function createSlackScheduleUpdateTaskTool(context: ToolRuntimeContext) {
           error: "timezone must be a valid IANA time zone.",
         };
       }
-      const parsedNextRunAtMs = parseNextRunAtMs(input.next_run_at_iso);
-      const nextRunAtMs = input.next_run_at_iso
+      const parsedNextRunAtMs = parseNextRunAtMs(input.next_run_at);
+      const nextRunAtMs = input.next_run_at
         ? parsedNextRunAtMs
         : lookup.task.nextRunAtMs;
-      if (input.next_run_at_iso && !nextRunAtMs) {
+      if (input.next_run_at && !nextRunAtMs) {
         return {
           ok: false,
-          error: "Provide next_run_at_iso as a valid ISO timestamp.",
+          error: "Provide next_run_at as a valid ISO timestamp.",
         };
       }
 
@@ -632,13 +617,33 @@ export function createSlackScheduleUpdateTaskTool(context: ToolRuntimeContext) {
         return {
           ok: false,
           error:
-            "Active scheduled tasks require next_run_at_iso when no next run is stored.",
+            "Active scheduled tasks require next_run_at when no next run is stored.",
         };
+      }
+      const recurringInput =
+        input.recurring ??
+        (shouldRebuildRecurrence(input)
+          ? lookup.task.schedule.kind === "recurring"
+          : undefined);
+      const recurring =
+        typeof recurringInput === "boolean"
+          ? validateRecurringIntent({
+              ...input,
+              existingRecurrence: lookup.task.schedule.recurrence,
+              recurring: recurringInput,
+            })
+          : { ok: true as const };
+      if (!recurring.ok) {
+        return recurring;
       }
       const recurrence = shouldRebuildRecurrence(input)
         ? buildRecurrence({
-            existing: lookup.task.schedule.recurrence,
-            input,
+            existing:
+              recurringInput === false
+                ? undefined
+                : lookup.task.schedule.recurrence,
+            input:
+              recurringInput === false ? { ...input, recurrence: null } : input,
             nextRunAtMs,
             timezone,
           })
@@ -659,22 +664,12 @@ export function createSlackScheduleUpdateTaskTool(context: ToolRuntimeContext) {
           nextStatus === "blocked" ? lookup.task.statusReason : undefined,
         schedule: {
           ...lookup.task.schedule,
-          description:
-            input.schedule_description ?? lookup.task.schedule.description,
+          description: input.schedule ?? lookup.task.schedule.description,
           timezone,
           kind: recurrence.recurrence ? "recurring" : "one_off",
           recurrence: recurrence.recurrence,
         },
-        task: {
-          ...lookup.task.task,
-          title: input.title ?? lookup.task.task.title,
-          objective: input.objective ?? lookup.task.task.objective,
-          instructions: input.instructions ?? lookup.task.task.instructions,
-          expectedOutput:
-            input.expected_output ?? lookup.task.task.expectedOutput,
-          constraints: input.constraints ?? lookup.task.task.constraints,
-          sourceContext: input.source_context ?? lookup.task.task.sourceContext,
-        },
+        task: input.task ? { text: input.task } : lookup.task.task,
         version: lookup.task.version + 1,
       };
 

--- a/packages/junior/tests/integration/heartbeat.test.ts
+++ b/packages/junior/tests/integration/heartbeat.test.ts
@@ -51,9 +51,7 @@ function createTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
     },
     status: "active",
     task: {
-      title: "Digest",
-      objective: "Post a digest.",
-      instructions: ["Summarize the latest state."],
+      text: "Post a digest. Summarize the latest state.",
     },
     updatedAtMs: nextRunAtMs,
     version: 1,
@@ -558,9 +556,7 @@ describe("trusted plugin heartbeat", () => {
       ...createTask(),
       id: "sched_plugin_malformed",
       task: {
-        title: "Digest",
-        objective: undefined,
-        instructions: ["Summarize the latest state."],
+        text: undefined,
       } as unknown as ScheduledTask["task"],
     });
 

--- a/packages/junior/tests/integration/slack-schedule-tools.test.ts
+++ b/packages/junior/tests/integration/slack-schedule-tools.test.ts
@@ -51,15 +51,12 @@ async function createTask(
 ) {
   const tool = createSlackScheduleCreateTaskTool(context);
   return await executeTool(tool, {
-    title: "Weekly issue digest",
-    objective: "Summarize open scheduler issues.",
-    instructions: ["Find open scheduler issues", "Post a concise summary"],
-    expected_output: "A short Slack digest",
-    schedule_description: "Every Monday at 9am",
+    task: "Weekly issue digest: Summarize open scheduler issues and post a concise summary.",
+    schedule: "Every Monday at 9am",
+    recurring: true,
     timezone: "America/Los_Angeles",
-    next_run_at_iso: "2026-05-25T16:00:00.000Z",
-    recurrence_frequency: "weekly",
-    recurrence_weekdays: [1],
+    next_run_at: "2026-05-25T16:00:00.000Z",
+    recurrence: { frequency: "weekly", weekdays: [1] },
     ...overrides,
   });
 }
@@ -86,7 +83,7 @@ describe("Slack schedule tools", () => {
         },
         credential_subject: null,
         status: "active",
-        title: "Weekly issue digest",
+        task: "Weekly issue digest: Summarize open scheduler issues and post a concise summary.",
         recurrence: {
           frequency: "weekly",
           interval: 1,
@@ -104,7 +101,7 @@ describe("Slack schedule tools", () => {
       ok: true,
       tasks: [
         {
-          title: "Weekly issue digest",
+          task: "Weekly issue digest: Summarize open scheduler issues and post a concise summary.",
           schedule: "Every Monday at 9am",
         },
       ],
@@ -120,7 +117,7 @@ describe("Slack schedule tools", () => {
       ok: true,
       tasks: [
         {
-          title: "Weekly issue digest",
+          task: "Weekly issue digest: Summarize open scheduler issues and post a concise summary.",
           schedule: "Every Monday at 9am",
         },
       ],
@@ -131,14 +128,12 @@ describe("Slack schedule tools", () => {
     const result = await executeTool(
       createSlackScheduleCreateTaskTool(createContext()),
       {
-        title: "Weekly issue digest",
-        objective: "Summarize open scheduler issues.",
-        instructions: ["Find open scheduler issues", "Post a concise summary"],
-        schedule_description: "Every Monday at 9am",
+        task: "Weekly issue digest: Summarize open scheduler issues and post a concise summary.",
+        schedule: "Every Monday at 9am",
+        recurring: true,
         timezone: "America/Los_Angeles",
-        next_run_at_iso: "2026-05-25T16:00:00.000Z",
-        recurrence_frequency: "weekly",
-        recurrence_weekdays: [1],
+        next_run_at: "2026-05-25T16:00:00.000Z",
+        recurrence: { frequency: "weekly", weekdays: [1] },
       },
     );
 
@@ -147,7 +142,7 @@ describe("Slack schedule tools", () => {
       task: {
         schedule: "Every Monday at 9am",
         status: "active",
-        title: "Weekly issue digest",
+        task: "Weekly issue digest: Summarize open scheduler issues and post a concise summary.",
       },
     });
     await expect(
@@ -164,11 +159,10 @@ describe("Slack schedule tools", () => {
     const result = await executeTool(
       createSlackScheduleCreateTaskTool(createContext({ teamId: "D123" })),
       {
-        title: "Reminder",
-        objective: "Remind David to wash his hands.",
-        instructions: ["Remind David to wash his hands."],
-        schedule_description: "In 1 minute",
-        next_run_at_iso: "2026-05-27T00:25:23.000Z",
+        task: "Reminder: Remind David to wash his hands.",
+        schedule: "In 1 minute",
+        recurring: false,
+        next_run_at: "2026-05-27T00:25:23.000Z",
       },
     );
 
@@ -193,11 +187,10 @@ describe("Slack schedule tools", () => {
         }),
       ),
       {
-        title: "Wash hands reminder",
-        objective: "Remind David to wash his hands.",
-        instructions: ["Remind David to wash his hands."],
-        schedule_description: "In 1 minute",
-        next_run_at_iso: "2026-05-27T00:25:23.000Z",
+        task: "Wash hands reminder: Remind David to wash his hands.",
+        schedule: "In 1 minute",
+        recurring: false,
+        next_run_at: "2026-05-27T00:25:23.000Z",
       },
     );
 
@@ -207,7 +200,7 @@ describe("Slack schedule tools", () => {
         next_run_at: "2026-05-27T00:25:23.000Z",
         schedule: "In 1 minute",
         status: "active",
-        title: "Wash hands reminder",
+        task: "Wash hands reminder: Remind David to wash his hands.",
       },
     });
     await expect(
@@ -241,11 +234,10 @@ describe("Slack schedule tools", () => {
         }),
       ),
       {
-        title: "Drink water reminder",
-        objective: "Remind David to drink water.",
-        instructions: ["Remind David to drink water."],
-        schedule_description: "In 1 minute",
-        next_run_at_iso: "2026-05-27T00:25:23.000Z",
+        task: "Drink water reminder: Remind David to drink water.",
+        schedule: "In 1 minute",
+        recurring: false,
+        next_run_at: "2026-05-27T00:25:23.000Z",
       },
     );
 
@@ -255,7 +247,7 @@ describe("Slack schedule tools", () => {
         next_run_at: "2026-05-27T00:25:23.000Z",
         schedule: "In 1 minute",
         status: "active",
-        title: "Drink water reminder",
+        task: "Drink water reminder: Remind David to drink water.",
       },
     });
     await expect(
@@ -269,14 +261,42 @@ describe("Slack schedule tools", () => {
     ]);
   });
 
+  it("rejects structurally contradictory one-off recurrence arguments", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-28T02:17:48.005Z"));
+
+    const result = await executeTool(
+      createSlackScheduleCreateTaskTool(
+        createContext({
+          userText: "remind greg to drink water in 1m",
+        }),
+      ),
+      {
+        task: "Remind Greg to drink water.",
+        schedule: "In 1 minute",
+        recurring: false,
+        next_run_at: "2026-05-28T02:18:48.005Z",
+        recurrence: { frequency: "daily" },
+      },
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: "One-off scheduled tasks must not include recurrence fields.",
+    });
+    await expect(
+      createStateSchedulerStore().listTasksForTeam(TEST_TEAM_ID),
+    ).resolves.toEqual([]);
+  });
+
   it("rejects parseable non-ISO next run timestamps", async () => {
     const result = await createTask(createContext(), {
-      next_run_at_iso: "05/25/2026 09:00",
+      next_run_at: "05/25/2026 09:00",
     });
 
     expect(result).toMatchObject({
       ok: false,
-      error: "Provide next_run_at_iso as a valid ISO timestamp.",
+      error: "Provide next_run_at as a valid ISO timestamp.",
     });
     await expect(
       createStateSchedulerStore().listTasksForTeam(TEST_TEAM_ID),
@@ -285,12 +305,12 @@ describe("Slack schedule tools", () => {
 
   it("rejects missing next run timestamps with a tool error", async () => {
     const result = await createTask(createContext(), {
-      next_run_at_iso: undefined,
+      next_run_at: undefined,
     });
 
     expect(result).toMatchObject({
       ok: false,
-      error: "Provide next_run_at_iso as a valid ISO timestamp.",
+      error: "Provide next_run_at as a valid ISO timestamp.",
     });
     await expect(
       createStateSchedulerStore().listTasksForTeam(TEST_TEAM_ID),
@@ -299,8 +319,8 @@ describe("Slack schedule tools", () => {
 
   it("rejects recurring schedules that can run more than once per day", async () => {
     const result = await createTask(createContext(), {
-      schedule_description: "Every hour",
-      recurrence_frequency: "hourly",
+      schedule: "Every hour",
+      recurrence: { frequency: "hourly" },
     });
 
     expect(result).toMatchObject({
@@ -323,16 +343,17 @@ describe("Slack schedule tools", () => {
       createSlackScheduleUpdateTaskTool(context),
       {
         task_id: taskId,
-        title: "Daily scheduler digest",
-        schedule_description: "Every day at 9am",
-        recurrence_frequency: "daily",
+        task: "Daily scheduler digest: Summarize open scheduler issues.",
+        schedule: "Every day at 9am",
+        recurring: true,
+        recurrence: { frequency: "daily" },
       },
     );
     expect(updated).toMatchObject({
       ok: true,
       task: {
         id: taskId,
-        title: "Daily scheduler digest",
+        task: "Daily scheduler digest: Summarize open scheduler issues.",
         schedule: "Every day at 9am",
         version: 2,
       },
@@ -369,8 +390,9 @@ describe("Slack schedule tools", () => {
       createSlackScheduleUpdateTaskTool(context),
       {
         task_id: created.task.id,
-        schedule_description: "Every hour",
-        recurrence_frequency: "hourly",
+        schedule: "Every hour",
+        recurring: true,
+        recurrence: { frequency: "hourly" },
       },
     );
 
@@ -398,7 +420,7 @@ describe("Slack schedule tools", () => {
       createSlackScheduleUpdateTaskTool(createContext({ channelId: "C999" })),
       {
         task_id: created.task.id,
-        title: "Wrong channel edit",
+        task: "Wrong channel edit.",
       },
     );
 
@@ -427,7 +449,7 @@ describe("Slack schedule tools", () => {
       createSlackScheduleUpdateTaskTool(otherRequester),
       {
         task_id: created.task.id,
-        title: "Team-owned digest",
+        task: "Team-owned digest: Summarize open scheduler issues.",
       },
     );
     const deleted = await executeTool(
@@ -441,7 +463,7 @@ describe("Slack schedule tools", () => {
       ok: true,
       task: {
         id: created.task.id,
-        title: "Team-owned digest",
+        task: "Team-owned digest: Summarize open scheduler issues.",
         version: 2,
       },
     });
@@ -461,7 +483,7 @@ describe("Slack schedule tools", () => {
         id: "scheduled-task",
       },
       task: {
-        title: "Team-owned digest",
+        text: "Team-owned digest: Summarize open scheduler issues.",
       },
       version: 3,
     });
@@ -499,9 +521,10 @@ describe("Slack schedule tools", () => {
     vi.setSystemTime(new Date("2026-05-25T12:00:00.000Z"));
 
     const created = await createTask(createContext(), {
-      next_run_at_iso: "2026-05-26T16:00:00.000Z",
-      recurrence_frequency: undefined,
-      recurrence_weekdays: undefined,
+      schedule: "On May 26 at 9am",
+      recurring: false,
+      next_run_at: "2026-05-26T16:00:00.000Z",
+      recurrence: undefined,
       timezone: undefined,
     });
 
@@ -521,9 +544,10 @@ describe("Slack schedule tools", () => {
     vi.setSystemTime(new Date("2026-05-25T12:00:00.000Z"));
 
     const created = await createTask(createContext(), {
-      next_run_at_iso: "2026-05-26T13:00:00.000Z",
-      recurrence_frequency: undefined,
-      recurrence_weekdays: undefined,
+      schedule: "On May 26 at 9am",
+      recurring: false,
+      next_run_at: "2026-05-26T13:00:00.000Z",
+      recurrence: undefined,
       timezone: undefined,
     });
 
@@ -556,7 +580,7 @@ describe("Slack schedule tools", () => {
   it("preserves a recurring task calendar anchor on content-only edits", async () => {
     const context = createContext();
     const created = (await createTask(context, {
-      recurrence_interval: 2,
+      recurrence: { frequency: "weekly", interval: 2, weekdays: [1] },
     })) as {
       task: { id: string };
     };
@@ -577,14 +601,14 @@ describe("Slack schedule tools", () => {
       createSlackScheduleUpdateTaskTool(context),
       {
         task_id: created.task.id,
-        title: "Renamed issue digest",
+        task: "Renamed issue digest: Summarize open scheduler issues.",
       },
     );
 
     expect(updated).toMatchObject({
       ok: true,
       task: {
-        title: "Renamed issue digest",
+        task: "Renamed issue digest: Summarize open scheduler issues.",
       },
     });
     await expect(store.getTask(created.task.id)).resolves.toMatchObject({

--- a/specs/scheduler-spec.md
+++ b/specs/scheduler-spec.md
@@ -47,10 +47,7 @@ A scheduled task is not a stored Slack message. It is a normalized task contract
 
 The stored task must include:
 
-- task title
-- objective
-- instructions
-- expected output
+- task text
 - creator metadata
 - execution actor metadata
 - conversation access metadata
@@ -210,13 +207,13 @@ Credential subjects must be explicit and separate from creator metadata.
 Slack authoring creates clear scheduled-work requests immediately for the active destination:
 
 1. User asks Junior to schedule work.
-2. Junior normalizes the task: title, objective, instructions, expected output, cadence, timezone, destination, and next run.
-3. If the task contract, schedule, and active destination are clear, Junior creates the task immediately.
-4. If the task contract, schedule, or active destination is ambiguous, Junior asks for confirmation or clarification before creating the task.
+2. Junior normalizes the task text, cadence, timezone, destination, and next run.
+3. If the task text, schedule, and active destination are clear, Junior creates the task immediately.
+4. If the task text, schedule, or active destination is ambiguous, Junior asks for confirmation or clarification before creating the task.
 5. Junior replies with the task id, destination, schedule, timezone, and next run after creation.
 6. Junior supports list, pause, resume, delete, and run-now commands from the destination conversation.
 
-Confirmation should show the executable task contract, not only echo the user's text.
+Confirmation should show the executable task text, not only echo the user's text.
 Anyone who can post or trigger Junior in the destination Slack conversation window may manage that conversation's scheduled tasks. Creator identity remains audit and notification metadata, but it is not an edit/delete/run-now ownership gate and is not the execution actor.
 Task creation must use the current active Slack conversation as the destination. Users cannot create scheduled tasks for a different channel, and cannot create DMs for other users.
 List output must be scoped to the active destination conversation and must not reveal tasks from other channels or DMs in the same workspace.


### PR DESCRIPTION
Simplify scheduled task creation around one task text field plus schedule metadata. The Slack schedule tools now accept task, schedule, next_run_at, recurring, and optional recurrence instead of asking the model to invent title/objective/instructions fields.

**Task Contract**

Scheduled task storage now keeps task.text as the source of truth, and scheduled run prompts execute that text directly. This removes the over-normalized internal task spec while preserving recurrence and destination metadata.

**One-off Guardrail**

The tool contract makes recurring a required boolean and rejects recurrence details when recurring=false. Relative reminders such as "in 1 minute" now have a structural path to one-off storage instead of relying on prompt wording.