### PR TITLE
fix(scheduler): Use tool errors for schedule validation

### DIFF
--- a/packages/junior-evals/evals/behavior-harness.ts
+++ b/packages/junior-evals/evals/behavior-harness.ts
@@ -338,7 +338,6 @@ function toEvalToolInvocation(input: {
         "task_id",
         "task",
         "schedule",
-        "recurring",
         "timezone",
         "next_run_at",
         "recurrence",

--- a/packages/junior-evals/evals/core/scheduler.eval.ts
+++ b/packages/junior-evals/evals/core/scheduler.eval.ts
@@ -12,12 +12,34 @@ describeEval("Scheduler", slackEvals, (it) => {
           "A simple one-off reminder request is scheduled immediately for the active Slack context.",
         pass: [
           "The reply confirms that a one-off reminder to wash hands was scheduled.",
-          "The schedule creation uses recurring=false and does not set recurrence.",
+          "The schedule creation omits recurrence.",
           "The reply does not ask the user to confirm first.",
         ],
         fail: [
           "Do not ask the user to confirm the reminder before creating it.",
           "Do not ask the user to provide a channel ID.",
+          "Do not describe the reminder as a recurring schedule.",
+        ],
+      }),
+    });
+  });
+
+  it("when asked for a terse one-off reminder, create it without recurrence", async ({
+    run,
+  }) => {
+    await run({
+      events: [mention("@bot remind me to drink water in 1m")],
+      criteria: rubric({
+        contract:
+          "A terse one-off reminder request is scheduled immediately for the active Slack context.",
+        pass: [
+          "The reply confirms that a one-off reminder to drink water was scheduled.",
+          "The schedule creation omits recurrence.",
+          "The reply does not ask the user to retry with a different one-time format.",
+        ],
+        fail: [
+          "Do not reject the request as an invalid one-off task format.",
+          "Do not ask the user to confirm the reminder before creating it.",
           "Do not describe the reminder as a recurring schedule.",
         ],
       }),
@@ -38,7 +60,7 @@ describeEval("Scheduler", slackEvals, (it) => {
           "A clear future or recurring task request is normalized and scheduled immediately for the active Slack context.",
         pass: [
           "The created task describes checking scheduler-related GitHub issues, not creating a schedule.",
-          "The schedule creation uses recurring=true and recurrence.frequency=weekly.",
+          "The schedule creation sets recurrence=weekly.",
           "The reply confirms the recurring schedule was created for Monday at 9am Pacific.",
         ],
         fail: [

--- a/packages/junior/src/chat/tools/slack/schedule-tools.ts
+++ b/packages/junior/src/chat/tools/slack/schedule-tools.ts
@@ -19,6 +19,7 @@ import type {
 import { isDmChannel, normalizeSlackConversationId } from "@/chat/slack/client";
 import { isSlackTeamId } from "@/chat/slack/ids";
 import { tool } from "@/chat/tools/definition";
+import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 import type { ToolRuntimeContext } from "@/chat/tools/types";
 
 const TASK_ID_PREFIX = "sched";
@@ -29,91 +30,54 @@ const ACTIVE_DESTINATION_GUIDELINE =
 const ACTIVE_TASK_ID_GUIDELINE =
   "Use only task IDs returned from this active destination.";
 const RECURRING_GUIDELINE =
-  "Set recurring=false for one-time requests like 'in 1 minute', 'tomorrow', or a specific date; set recurring=true only for requests that explicitly repeat.";
+  "Omit recurrence for one-time requests like 'in 1 minute', 'tomorrow', or a specific date; provide recurrence only for requests that explicitly repeat.";
 
-const recurrenceInputSchema = Type.Object({
-  frequency: Type.Union([
-    Type.Literal("daily"),
-    Type.Literal("weekly"),
-    Type.Literal("monthly"),
-    Type.Literal("yearly"),
-  ]),
-  interval: Type.Optional(
-    Type.Integer({
-      minimum: 1,
-      maximum: 100,
-      description:
-        "Calendar interval. For example, 2 with weekly means every two weeks.",
-    }),
-  ),
-  weekdays: Type.Optional(
-    Type.Array(Type.Integer({ minimum: 0, maximum: 6 }), {
-      maxItems: 7,
-      description:
-        "For weekly schedules only. Sunday is 0, Monday is 1, Saturday is 6.",
-    }),
-  ),
-});
+const recurrenceInputSchema = Type.Union([
+  Type.Literal("daily"),
+  Type.Literal("weekly"),
+  Type.Literal("monthly"),
+  Type.Literal("yearly"),
+]);
+
+function throwToolInputError(error: string): never {
+  throw new ToolInputError(error);
+}
 
 function requireActiveDestination(
   context: ToolRuntimeContext,
-):
-  | { ok: true; destination: ScheduledTaskDestination }
-  | { ok: false; error: string } {
+): ScheduledTaskDestination {
   const channelId = normalizeSlackConversationId(context.channelId);
   if (!channelId) {
-    return {
-      ok: false,
-      error: "No active Slack channel context is available.",
-    };
+    throwToolInputError("No active Slack channel context is available.");
   }
   if (!context.teamId) {
-    return {
-      ok: false,
-      error: "No active Slack workspace context is available.",
-    };
+    throwToolInputError("No active Slack workspace context is available.");
   }
   if (!isSlackTeamId(context.teamId)) {
-    return {
-      ok: false,
-      error: "Active Slack workspace context is invalid.",
-    };
+    throwToolInputError("Active Slack workspace context is invalid.");
   }
 
   return {
-    ok: true,
-    destination: {
-      platform: "slack",
-      teamId: context.teamId,
-      channelId,
-    },
+    platform: "slack",
+    teamId: context.teamId,
+    channelId,
   };
 }
 
-function requireRequester(
-  context: ToolRuntimeContext,
-):
-  | { ok: true; requester: ScheduledTaskPrincipal }
-  | { ok: false; error: string } {
+function requireRequester(context: ToolRuntimeContext): ScheduledTaskPrincipal {
   const userId = context.requester?.userId;
   if (!userId) {
-    return {
-      ok: false,
-      error: "No active Slack requester context is available.",
-    };
+    throwToolInputError("No active Slack requester context is available.");
   }
 
   return {
-    ok: true,
-    requester: {
-      slackUserId: userId,
-      ...(context.requester?.userName
-        ? { userName: context.requester.userName }
-        : {}),
-      ...(context.requester?.fullName
-        ? { fullName: context.requester.fullName }
-        : {}),
-    },
+    slackUserId: userId,
+    ...(context.requester?.userName
+      ? { userName: context.requester.userName }
+      : {}),
+    ...(context.requester?.fullName
+      ? { fullName: context.requester.fullName }
+      : {}),
   };
 }
 
@@ -163,31 +127,22 @@ function sameDestination(
 async function getWritableTask(args: {
   context: ToolRuntimeContext;
   taskId: string;
-}): Promise<{ ok: true; task: ScheduledTask } | { ok: false; error: string }> {
+}): Promise<ScheduledTask> {
   const destination = requireActiveDestination(args.context);
-  if (!destination.ok) {
-    return destination;
-  }
 
   const task = await createStateSchedulerStore().getTask(args.taskId);
   if (!task || task.status === "deleted") {
-    return {
-      ok: false,
-      error: "Scheduled task was not found in the active destination.",
-    };
+    throwToolInputError(
+      "Scheduled task was not found in the active destination.",
+    );
   }
 
-  if (!sameDestination(task, destination.destination)) {
-    return {
-      ok: false,
-      error:
-        "Scheduled task can only be managed from the Slack destination where it was created.",
-    };
+  if (!sameDestination(task, destination)) {
+    throwToolInputError(
+      "Scheduled task can only be managed from the Slack destination where it was created.",
+    );
   }
-  return {
-    ok: true,
-    task,
-  };
+  return task;
 }
 
 function compactTask(task: ScheduledTask): Record<string, unknown> {
@@ -258,124 +213,62 @@ function normalizeFrequency(
 function buildRecurrence(args: {
   existing?: ScheduledTaskRecurrence;
   input: {
-    recurrence?: {
-      frequency?: unknown;
-      interval?: number;
-      weekdays?: number[];
-    } | null;
+    recurrence?: unknown;
   };
   nextRunAtMs: number | undefined;
   timezone: string;
-}):
-  | { ok: true; recurrence?: ScheduledTaskRecurrence }
-  | { ok: false; error: string } {
+}): ScheduledTaskRecurrence | undefined {
   if (args.input.recurrence === null) {
-    return { ok: true, recurrence: undefined };
+    return undefined;
   }
 
   const frequency =
-    normalizeFrequency(args.input.recurrence?.frequency) ??
-    args.existing?.frequency;
+    normalizeFrequency(args.input.recurrence) ?? args.existing?.frequency;
   if (!frequency) {
-    return { ok: true, recurrence: undefined };
+    return undefined;
   }
   if (!args.nextRunAtMs) {
-    return {
-      ok: false,
-      error: "Recurring scheduled tasks require next_run_at.",
-    };
+    throwToolInputError("Recurring scheduled tasks require next_run_at.");
   }
 
   try {
-    return {
-      ok: true,
-      recurrence: buildCalendarRecurrence({
-        frequency,
-        interval: args.input.recurrence?.interval ?? args.existing?.interval,
-        nextRunAtMs: args.nextRunAtMs,
-        timezone: args.timezone,
-        weekdays:
-          frequency === "weekly"
-            ? (args.input.recurrence?.weekdays ?? args.existing?.weekdays)
-            : undefined,
-      }),
-    };
+    return buildCalendarRecurrence({
+      frequency,
+      interval: args.existing?.interval,
+      nextRunAtMs: args.nextRunAtMs,
+      timezone: args.timezone,
+      weekdays: frequency === "weekly" ? args.existing?.weekdays : undefined,
+    });
   } catch (error) {
-    return {
-      ok: false,
-      error:
-        error instanceof RangeError
-          ? "timezone must be a valid IANA time zone."
-          : error instanceof Error
-            ? error.message
-            : String(error),
-    };
+    throwToolInputError(
+      error instanceof RangeError
+        ? "timezone must be a valid IANA time zone."
+        : error instanceof Error
+          ? error.message
+          : String(error),
+    );
   }
 }
 
-function validateRecurringFrequencyLimit(input: {
-  recurrence?: {
-    frequency?: unknown;
-  } | null;
-}): { ok: true } | { ok: false; error: string } {
+function validateRecurringFrequencyLimit(input: { recurrence?: unknown }) {
   if (
-    input.recurrence?.frequency !== undefined &&
-    !normalizeFrequency(input.recurrence.frequency)
-  ) {
-    return {
-      ok: false,
-      error: "Recurring scheduled tasks can run at most once per day.",
-    };
-  }
-
-  return { ok: true };
-}
-
-function validateRecurringIntent(input: {
-  recurring?: unknown;
-  recurrence?: unknown;
-  existingRecurrence?: ScheduledTaskRecurrence;
-}): { ok: true } | { ok: false; error: string } {
-  if (typeof input.recurring !== "boolean") {
-    return {
-      ok: false,
-      error: "recurring must be true or false.",
-    };
-  }
-  if (
-    !input.recurring &&
     input.recurrence !== undefined &&
-    input.recurrence !== null
+    input.recurrence !== null &&
+    !normalizeFrequency(input.recurrence)
   ) {
-    return {
-      ok: false,
-      error: "One-off scheduled tasks must not include recurrence fields.",
-    };
+    throwToolInputError(
+      "Recurring scheduled tasks can run at most once per day.",
+    );
   }
-  if (input.recurring && input.recurrence === null) {
-    return {
-      ok: false,
-      error: "Recurring scheduled tasks require recurrence.",
-    };
-  }
-  if (input.recurring && !input.recurrence && !input.existingRecurrence) {
-    return {
-      ok: false,
-      error: "Recurring scheduled tasks require recurrence.",
-    };
-  }
-  return { ok: true };
 }
 
 function shouldRebuildRecurrence(input: {
   next_run_at?: string;
-  recurring?: unknown;
   recurrence?: unknown;
   timezone?: string;
 }): boolean {
   return (
     input.next_run_at !== undefined ||
-    input.recurring !== undefined ||
     input.recurrence !== undefined ||
     input.timezone !== undefined
   );
@@ -421,12 +314,11 @@ export function createSlackScheduleCreateTaskTool(context: ToolRuntimeContext) {
       "Ask for confirmation only when the task contract, schedule, or active destination is ambiguous.",
       "Recurring tasks can run at most once per day; use only daily, weekly, monthly, or yearly recurrence frequencies.",
       "Provide next_run_at as an exact ISO timestamp computed from the user's requested schedule.",
-      "Provide recurrence only when recurring=true.",
+      "Provide recurrence only for repeating schedules.",
     ],
     inputSchema: Type.Object({
       task: Type.String({ minLength: 1, maxLength: 4000 }),
       schedule: Type.String({ minLength: 1, maxLength: 300 }),
-      recurring: Type.Boolean(),
       timezone: Type.Optional(Type.String({ minLength: 1, maxLength: 80 })),
       next_run_at: Type.Optional(
         Type.String({
@@ -439,63 +331,45 @@ export function createSlackScheduleCreateTaskTool(context: ToolRuntimeContext) {
     }),
     execute: async (input) => {
       const destination = requireActiveDestination(context);
-      if (!destination.ok) return destination;
       const requester = requireRequester(context);
-      if (!requester.ok) return requester;
 
       const nowMs = Date.now();
-      const recurring = validateRecurringIntent(input);
-      if (!recurring.ok) {
-        return recurring;
-      }
       const timezone = input.timezone ?? getDefaultScheduleTimezone();
-      const frequencyLimit = validateRecurringFrequencyLimit(input);
-      if (!frequencyLimit.ok) {
-        return frequencyLimit;
-      }
+      validateRecurringFrequencyLimit(input);
       if (!isValidTimeZone(timezone)) {
-        return {
-          ok: false,
-          error: "timezone must be a valid IANA time zone.",
-        };
+        throwToolInputError("timezone must be a valid IANA time zone.");
       }
       const nextRunAtMs = parseNextRunAtMs(input.next_run_at);
       if (!nextRunAtMs) {
-        return {
-          ok: false,
-          error: "Provide next_run_at as a valid ISO timestamp.",
-        };
+        throwToolInputError("Provide next_run_at as a valid ISO timestamp.");
       }
       const recurrence = buildRecurrence({
         input,
         nextRunAtMs,
         timezone,
       });
-      if (!recurrence.ok) {
-        return recurrence;
-      }
-      const conversationAccess = getConversationAccess(destination.destination);
+      const conversationAccess = getConversationAccess(destination);
       const credentialSubject = getCredentialSubject({
         access: conversationAccess,
-        requester: requester.requester,
+        requester,
       });
 
       const task: ScheduledTask = {
         id: buildTaskId(),
         createdAtMs: nowMs,
         updatedAtMs: nowMs,
-        createdBy: requester.requester,
+        createdBy: requester,
         conversationAccess,
         ...(credentialSubject ? { credentialSubject } : {}),
-        destination: destination.destination,
+        destination,
         executionActor: SCHEDULED_TASK_SYSTEM_ACTOR,
         nextRunAtMs,
         originalRequest: context.userText,
         schedule: {
           description: input.schedule,
           timezone,
-          kind: recurrence.recurrence ? "recurring" : "one_off",
-          recurrence: recurrence.recurrence,
+          kind: recurrence ? "recurring" : "one_off",
+          recurrence,
         },
         status: "active",
         task: {
@@ -527,13 +401,12 @@ export function createSlackScheduleListTasksTool(context: ToolRuntimeContext) {
     inputSchema: Type.Object({}),
     execute: async () => {
       const destination = requireActiveDestination(context);
-      if (!destination.ok) return destination;
 
       const tasks = await createStateSchedulerStore().listTasksForTeam(
-        destination.destination.teamId,
+        destination.teamId,
       );
       const matching = tasks.filter((task) =>
-        sameDestination(task, destination.destination),
+        sameDestination(task, destination),
       );
       const visible = matching.slice(0, MAX_LISTED_TASKS).map(compactTask);
 
@@ -557,13 +430,13 @@ export function createSlackScheduleUpdateTaskTool(context: ToolRuntimeContext) {
       RECURRING_GUIDELINE,
       "Do not move scheduled tasks across conversations.",
       "Provide next_run_at as an exact ISO timestamp when changing the next run.",
+      "Set recurrence to null when converting a recurring task to one-time.",
       "Set status to active, paused, or blocked when the user asks to resume, pause, or block a task.",
     ],
     inputSchema: Type.Object({
       task_id: Type.String({ minLength: 1 }),
       task: Type.Optional(Type.String({ minLength: 1, maxLength: 4000 })),
       schedule: Type.Optional(Type.String({ minLength: 1, maxLength: 300 })),
-      recurring: Type.Optional(Type.Boolean()),
       timezone: Type.Optional(Type.String({ minLength: 1, maxLength: 80 })),
       next_run_at: Type.Optional(Type.String({ minLength: 1 })),
       recurrence: Type.Optional(
@@ -582,95 +455,56 @@ export function createSlackScheduleUpdateTaskTool(context: ToolRuntimeContext) {
         context,
         taskId: input.task_id,
       });
-      if (!lookup.ok) return lookup;
 
-      const timezone = input.timezone ?? lookup.task.schedule.timezone;
-      const frequencyLimit = validateRecurringFrequencyLimit(input);
-      if (!frequencyLimit.ok) {
-        return frequencyLimit;
-      }
+      const timezone = input.timezone ?? lookup.schedule.timezone;
+      validateRecurringFrequencyLimit(input);
       if (!isValidTimeZone(timezone)) {
-        return {
-          ok: false,
-          error: "timezone must be a valid IANA time zone.",
-        };
+        throwToolInputError("timezone must be a valid IANA time zone.");
       }
       const parsedNextRunAtMs = parseNextRunAtMs(input.next_run_at);
       const nextRunAtMs = input.next_run_at
         ? parsedNextRunAtMs
-        : lookup.task.nextRunAtMs;
+        : lookup.nextRunAtMs;
       if (input.next_run_at && !nextRunAtMs) {
-        return {
-          ok: false,
-          error: "Provide next_run_at as a valid ISO timestamp.",
-        };
+        throwToolInputError("Provide next_run_at as a valid ISO timestamp.");
       }
 
       const status = normalizeStatus(input.status);
       if (input.status && !status) {
-        return {
-          ok: false,
-          error: "status must be active, paused, or blocked.",
-        };
+        throwToolInputError("status must be active, paused, or blocked.");
       }
       if (status === "active" && !nextRunAtMs) {
-        return {
-          ok: false,
-          error:
-            "Active scheduled tasks require next_run_at when no next run is stored.",
-        };
-      }
-      const recurringInput =
-        input.recurring ??
-        (shouldRebuildRecurrence(input)
-          ? lookup.task.schedule.kind === "recurring"
-          : undefined);
-      const recurring =
-        typeof recurringInput === "boolean"
-          ? validateRecurringIntent({
-              ...input,
-              existingRecurrence: lookup.task.schedule.recurrence,
-              recurring: recurringInput,
-            })
-          : { ok: true as const };
-      if (!recurring.ok) {
-        return recurring;
+        throwToolInputError(
+          "Active scheduled tasks require next_run_at when no next run is stored.",
+        );
       }
       const recurrence = shouldRebuildRecurrence(input)
         ? buildRecurrence({
-            existing:
-              recurringInput === false
-                ? undefined
-                : lookup.task.schedule.recurrence,
-            input:
-              recurringInput === false ? { ...input, recurrence: null } : input,
+            existing: lookup.schedule.recurrence,
+            input,
             nextRunAtMs,
             timezone,
           })
-        : { ok: true as const, recurrence: lookup.task.schedule.recurrence };
-      if (!recurrence.ok) {
-        return recurrence;
-      }
-      const nextStatus = status ?? lookup.task.status;
+        : lookup.schedule.recurrence;
+      const nextStatus = status ?? lookup.status;
 
       const next: ScheduledTask = {
-        ...lookup.task,
+        ...lookup,
         updatedAtMs: Date.now(),
         nextRunAtMs,
-        runNowAtMs:
-          nextStatus === "active" ? lookup.task.runNowAtMs : undefined,
+        runNowAtMs: nextStatus === "active" ? lookup.runNowAtMs : undefined,
         status: nextStatus,
         statusReason:
-          nextStatus === "blocked" ? lookup.task.statusReason : undefined,
+          nextStatus === "blocked" ? lookup.statusReason : undefined,
         schedule: {
-          ...lookup.task.schedule,
-          description: input.schedule ?? lookup.task.schedule.description,
+          ...lookup.schedule,
+          description: input.schedule ?? lookup.schedule.description,
           timezone,
-          kind: recurrence.recurrence ? "recurring" : "one_off",
-          recurrence: recurrence.recurrence,
+          kind: recurrence ? "recurring" : "one_off",
+          recurrence,
         },
-        task: input.task ? { text: input.task } : lookup.task.task,
-        version: lookup.task.version + 1,
+        task: input.task ? { text: input.task } : lookup.task,
+        version: lookup.version + 1,
       };
 
       await createStateSchedulerStore().saveTask(next);
@@ -694,15 +528,14 @@ export function createSlackScheduleDeleteTaskTool(context: ToolRuntimeContext) {
     }),
     execute: async ({ task_id }) => {
       const lookup = await getWritableTask({ context, taskId: task_id });
-      if (!lookup.ok) return lookup;
 
       const next: ScheduledTask = {
-        ...lookup.task,
+        ...lookup,
         updatedAtMs: Date.now(),
         status: "deleted",
         nextRunAtMs: undefined,
         runNowAtMs: undefined,
-        version: lookup.task.version + 1,
+        version: lookup.version + 1,
       };
 
       await createStateSchedulerStore().saveTask(next);
@@ -730,21 +563,18 @@ export function createSlackScheduleRunTaskNowTool(context: ToolRuntimeContext) {
     }),
     execute: async ({ task_id }) => {
       const lookup = await getWritableTask({ context, taskId: task_id });
-      if (!lookup.ok) return lookup;
-      if (lookup.task.status !== "active") {
-        return {
-          ok: false,
-          error:
-            "Scheduled task must be active before it can be run now. Resume the task first if you want it to run.",
-        };
+      if (lookup.status !== "active") {
+        throwToolInputError(
+          "Scheduled task must be active before it can be run now. Resume the task first if you want it to run.",
+        );
       }
 
       const nowMs = Date.now();
       const next: ScheduledTask = {
-        ...lookup.task,
+        ...lookup,
         updatedAtMs: nowMs,
         runNowAtMs: nowMs,
-        version: lookup.task.version + 1,
+        version: lookup.version + 1,
       };
 
       await createStateSchedulerStore().saveTask(next);

--- a/packages/junior/tests/integration/slack-schedule-tools.test.ts
+++ b/packages/junior/tests/integration/slack-schedule-tools.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import { createStateSchedulerStore } from "@/chat/scheduler/store";
+import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 import {
   createSlackScheduleCreateTaskTool,
   createSlackScheduleDeleteTaskTool,
@@ -53,10 +54,9 @@ async function createTask(
   return await executeTool(tool, {
     task: "Weekly issue digest: Summarize open scheduler issues and post a concise summary.",
     schedule: "Every Monday at 9am",
-    recurring: true,
     timezone: "America/Los_Angeles",
     next_run_at: "2026-05-25T16:00:00.000Z",
-    recurrence: { frequency: "weekly", weekdays: [1] },
+    recurrence: "weekly",
     ...overrides,
   });
 }
@@ -130,10 +130,9 @@ describe("Slack schedule tools", () => {
       {
         task: "Weekly issue digest: Summarize open scheduler issues and post a concise summary.",
         schedule: "Every Monday at 9am",
-        recurring: true,
         timezone: "America/Los_Angeles",
         next_run_at: "2026-05-25T16:00:00.000Z",
-        recurrence: { frequency: "weekly", weekdays: [1] },
+        recurrence: "weekly",
       },
     );
 
@@ -156,20 +155,19 @@ describe("Slack schedule tools", () => {
   });
 
   it("rejects invalid Slack workspace context before creating a task", async () => {
-    const result = await executeTool(
+    const rejected = executeTool(
       createSlackScheduleCreateTaskTool(createContext({ teamId: "D123" })),
       {
         task: "Reminder: Remind David to wash his hands.",
         schedule: "In 1 minute",
-        recurring: false,
         next_run_at: "2026-05-27T00:25:23.000Z",
       },
     );
 
-    expect(result).toMatchObject({
-      ok: false,
-      error: "Active Slack workspace context is invalid.",
-    });
+    await expect(rejected).rejects.toThrow(ToolInputError);
+    await expect(rejected).rejects.toThrow(
+      "Active Slack workspace context is invalid.",
+    );
     await expect(
       createStateSchedulerStore().listTasksForTeam(TEST_TEAM_ID),
     ).resolves.toEqual([]);
@@ -189,7 +187,6 @@ describe("Slack schedule tools", () => {
       {
         task: "Wash hands reminder: Remind David to wash his hands.",
         schedule: "In 1 minute",
-        recurring: false,
         next_run_at: "2026-05-27T00:25:23.000Z",
       },
     );
@@ -236,7 +233,6 @@ describe("Slack schedule tools", () => {
       {
         task: "Drink water reminder: Remind David to drink water.",
         schedule: "In 1 minute",
-        recurring: false,
         next_run_at: "2026-05-27T00:25:23.000Z",
       },
     );
@@ -261,7 +257,7 @@ describe("Slack schedule tools", () => {
     ]);
   });
 
-  it("rejects structurally contradictory one-off recurrence arguments", async () => {
+  it("creates one-off reminders by omitting recurrence", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-28T02:17:48.005Z"));
 
@@ -274,59 +270,65 @@ describe("Slack schedule tools", () => {
       {
         task: "Remind Greg to drink water.",
         schedule: "In 1 minute",
-        recurring: false,
         next_run_at: "2026-05-28T02:18:48.005Z",
-        recurrence: { frequency: "daily" },
       },
     );
 
     expect(result).toMatchObject({
-      ok: false,
-      error: "One-off scheduled tasks must not include recurrence fields.",
+      ok: true,
+      task: {
+        next_run_at: "2026-05-28T02:18:48.005Z",
+        recurrence: null,
+        schedule: "In 1 minute",
+        status: "active",
+        task: "Remind Greg to drink water.",
+      },
     });
     await expect(
       createStateSchedulerStore().listTasksForTeam(TEST_TEAM_ID),
-    ).resolves.toEqual([]);
+    ).resolves.toMatchObject([
+      {
+        nextRunAtMs: Date.parse("2026-05-28T02:18:48.005Z"),
+        schedule: {
+          kind: "one_off",
+          recurrence: undefined,
+        },
+        status: "active",
+      },
+    ]);
   });
 
   it("rejects parseable non-ISO next run timestamps", async () => {
-    const result = await createTask(createContext(), {
-      next_run_at: "05/25/2026 09:00",
-    });
-
-    expect(result).toMatchObject({
-      ok: false,
-      error: "Provide next_run_at as a valid ISO timestamp.",
-    });
+    await expect(
+      createTask(createContext(), {
+        next_run_at: "05/25/2026 09:00",
+      }),
+    ).rejects.toThrow("Provide next_run_at as a valid ISO timestamp.");
     await expect(
       createStateSchedulerStore().listTasksForTeam(TEST_TEAM_ID),
     ).resolves.toEqual([]);
   });
 
   it("rejects missing next run timestamps with a tool error", async () => {
-    const result = await createTask(createContext(), {
-      next_run_at: undefined,
-    });
-
-    expect(result).toMatchObject({
-      ok: false,
-      error: "Provide next_run_at as a valid ISO timestamp.",
-    });
+    await expect(
+      createTask(createContext(), {
+        next_run_at: undefined,
+      }),
+    ).rejects.toThrow("Provide next_run_at as a valid ISO timestamp.");
     await expect(
       createStateSchedulerStore().listTasksForTeam(TEST_TEAM_ID),
     ).resolves.toEqual([]);
   });
 
   it("rejects recurring schedules that can run more than once per day", async () => {
-    const result = await createTask(createContext(), {
-      schedule: "Every hour",
-      recurrence: { frequency: "hourly" },
-    });
-
-    expect(result).toMatchObject({
-      ok: false,
-      error: "Recurring scheduled tasks can run at most once per day.",
-    });
+    await expect(
+      createTask(createContext(), {
+        schedule: "Every hour",
+        recurrence: "hourly",
+      }),
+    ).rejects.toThrow(
+      "Recurring scheduled tasks can run at most once per day.",
+    );
     await expect(
       createStateSchedulerStore().listTasksForTeam(TEST_TEAM_ID),
     ).resolves.toEqual([]);
@@ -345,8 +347,7 @@ describe("Slack schedule tools", () => {
         task_id: taskId,
         task: "Daily scheduler digest: Summarize open scheduler issues.",
         schedule: "Every day at 9am",
-        recurring: true,
-        recurrence: { frequency: "daily" },
+        recurrence: "daily",
       },
     );
     expect(updated).toMatchObject({
@@ -386,20 +387,15 @@ describe("Slack schedule tools", () => {
       task: { id: string };
     };
 
-    const updated = await executeTool(
-      createSlackScheduleUpdateTaskTool(context),
-      {
+    await expect(
+      executeTool(createSlackScheduleUpdateTaskTool(context), {
         task_id: created.task.id,
         schedule: "Every hour",
-        recurring: true,
-        recurrence: { frequency: "hourly" },
-      },
+        recurrence: "hourly",
+      }),
+    ).rejects.toThrow(
+      "Recurring scheduled tasks can run at most once per day.",
     );
-
-    expect(updated).toMatchObject({
-      ok: false,
-      error: "Recurring scheduled tasks can run at most once per day.",
-    });
     await expect(
       createStateSchedulerStore().getTask(created.task.id),
     ).resolves.toMatchObject({
@@ -410,25 +406,58 @@ describe("Slack schedule tools", () => {
     });
   });
 
-  it("rejects edits from another active Slack destination", async () => {
+  it("converts recurring tasks to one-off tasks with recurrence null", async () => {
     const context = createContext();
     const created = (await createTask(context)) as {
       task: { id: string };
     };
 
     const updated = await executeTool(
-      createSlackScheduleUpdateTaskTool(createContext({ channelId: "C999" })),
+      createSlackScheduleUpdateTaskTool(context),
       {
         task_id: created.task.id,
-        task: "Wrong channel edit.",
+        schedule: "On June 1 at 9am",
+        next_run_at: "2026-06-01T16:00:00.000Z",
+        recurrence: null,
       },
     );
 
     expect(updated).toMatchObject({
-      ok: false,
-      error:
-        "Scheduled task can only be managed from the Slack destination where it was created.",
+      ok: true,
+      task: {
+        id: created.task.id,
+        next_run_at: "2026-06-01T16:00:00.000Z",
+        recurrence: null,
+        schedule: "On June 1 at 9am",
+      },
     });
+    await expect(
+      createStateSchedulerStore().getTask(created.task.id),
+    ).resolves.toMatchObject({
+      schedule: {
+        kind: "one_off",
+        recurrence: undefined,
+      },
+    });
+  });
+
+  it("rejects edits from another active Slack destination", async () => {
+    const context = createContext();
+    const created = (await createTask(context)) as {
+      task: { id: string };
+    };
+
+    await expect(
+      executeTool(
+        createSlackScheduleUpdateTaskTool(createContext({ channelId: "C999" })),
+        {
+          task_id: created.task.id,
+          task: "Wrong channel edit.",
+        },
+      ),
+    ).rejects.toThrow(
+      "Scheduled task can only be managed from the Slack destination where it was created.",
+    );
   });
 
   it("allows another requester to manage tasks in the same Slack destination", async () => {
@@ -522,7 +551,6 @@ describe("Slack schedule tools", () => {
 
     const created = await createTask(createContext(), {
       schedule: "On May 26 at 9am",
-      recurring: false,
       next_run_at: "2026-05-26T16:00:00.000Z",
       recurrence: undefined,
       timezone: undefined,
@@ -545,7 +573,6 @@ describe("Slack schedule tools", () => {
 
     const created = await createTask(createContext(), {
       schedule: "On May 26 at 9am",
-      recurring: false,
       next_run_at: "2026-05-26T13:00:00.000Z",
       recurrence: undefined,
       timezone: undefined,
@@ -564,14 +591,11 @@ describe("Slack schedule tools", () => {
   it("rejects invalid default timezones", async () => {
     process.env.JUNIOR_TIMEZONE = "not/a-zone";
 
-    const created = await createTask(createContext(), {
-      timezone: undefined,
-    });
-
-    expect(created).toMatchObject({
-      ok: false,
-      error: "timezone must be a valid IANA time zone.",
-    });
+    await expect(
+      createTask(createContext(), {
+        timezone: undefined,
+      }),
+    ).rejects.toThrow("timezone must be a valid IANA time zone.");
     await expect(
       createStateSchedulerStore().listTasksForTeam(TEST_TEAM_ID),
     ).resolves.toEqual([]);
@@ -580,14 +604,14 @@ describe("Slack schedule tools", () => {
   it("preserves a recurring task calendar anchor on content-only edits", async () => {
     const context = createContext();
     const created = (await createTask(context, {
-      recurrence: { frequency: "weekly", interval: 2, weekdays: [1] },
+      recurrence: "weekly",
     })) as {
       task: { id: string };
     };
     const store = createStateSchedulerStore();
     const task = await store.getTask(created.task.id);
     expect(task?.schedule.recurrence).toMatchObject({
-      interval: 2,
+      interval: 1,
       startDate: "2026-05-25",
     });
     await store.saveTask({
@@ -615,7 +639,7 @@ describe("Slack schedule tools", () => {
       nextRunAtMs: Date.parse("2026-06-08T16:00:00.000Z"),
       schedule: {
         recurrence: {
-          interval: 2,
+          interval: 1,
           startDate: "2026-05-25",
         },
       },
@@ -732,18 +756,13 @@ describe("Slack schedule tools", () => {
       version: task!.version + 1,
     });
 
-    const result = await executeTool(
-      createSlackScheduleRunTaskNowTool(context),
-      {
+    await expect(
+      executeTool(createSlackScheduleRunTaskNowTool(context), {
         task_id: created.task.id,
-      },
+      }),
+    ).rejects.toThrow(
+      "Scheduled task must be active before it can be run now. Resume the task first if you want it to run.",
     );
-
-    expect(result).toMatchObject({
-      ok: false,
-      error:
-        "Scheduled task must be active before it can be run now. Resume the task first if you want it to run.",
-    });
     const paused = await store.getTask(created.task.id);
     expect(paused).toMatchObject({
       status: "paused",

--- a/specs/agent-execution-spec.md
+++ b/specs/agent-execution-spec.md
@@ -3,11 +3,12 @@
 ## Metadata
 
 - Created: 2026-03-04
-- Last Edited: 2026-03-04
+- Last Edited: 2026-05-28
 
 ## Changelog
 
 - 2026-03-04: Initial spec defining the Codex execution rubric and completion gates.
+- 2026-05-28: Added the repository tool-failure contract for Pi agent execution.
 
 ## Status
 
@@ -33,6 +34,7 @@ Define a mandatory execution rubric for coding agents so implementation work is 
 ### 1. Contract-First Start
 
 Before editing code, the agent MUST read the most relevant local contracts:
+
 - Root `AGENTS.md`.
 - Applicable canonical specs under `specs/`.
 - Applicable `SKILL.md` files when a skill-triggered task is in scope.
@@ -42,6 +44,7 @@ The agent MUST derive and preserve explicit invariants from these sources during
 ### 2. Explicit Execution Plan
 
 For non-trivial tasks, the agent MUST maintain a concrete sequence:
+
 1. Discover current behavior and constraints.
 2. Implement minimal end-to-end slice.
 3. Verify with targeted checks.
@@ -60,6 +63,7 @@ Before and during edits, the agent MUST test high-risk assumptions with the narr
 ### 5. Repository Pattern Reuse
 
 The agent MUST prefer established local patterns over novel abstractions when both satisfy requirements:
+
 - Existing architecture seams and naming patterns.
 - Existing logging/tracing semantics (`specs/logging/*`).
 - Existing testing layer boundaries (`specs/testing/*`).
@@ -67,13 +71,21 @@ The agent MUST prefer established local patterns over novel abstractions when bo
 ### 6. Change Legibility
 
 Changes SHOULD optimize for future maintainability and agent reruns:
+
 - Keep diffs localized and intention-revealing.
 - Use concise comments only where reasoning is non-obvious.
 - Update canonical specs/instructions when behavior contracts change.
 
-### 7. Completion Gates
+### 7. Tool Failure Semantics
+
+Agent-facing tool failures must use the Pi tool-error channel. A tool execution that the model can repair, such as invalid arguments, missing active context, unsupported cadence, or missing target state, must throw `ToolInputError` or another expected tool error so the agent loop records a `toolResult` with `isError=true` and continues.
+
+Tools must not invent sentinel success payloads such as `{ ok: false, error }` for model-repairable failures. Such payloads are ordinary successful tool outputs from the Pi loop's perspective and can cause the model to apologize instead of correcting the tool call. Structured `ok` unions are acceptable inside private helper functions or non-agent HTTP handlers, but not as the final result of an agent tool execution when the operation failed.
+
+### 8. Completion Gates
 
 A task is not complete until all applicable gates pass:
+
 1. Build/typecheck gate for changed surface area.
 2. Targeted tests for changed behavior contracts.
 3. Contract drift check (specs/instructions updated if behavior changed).
@@ -82,6 +94,7 @@ A task is not complete until all applicable gates pass:
 ## Failure Model
 
 Common process failures and required correction:
+
 1. Editing before reading contracts:
    - Stop and reconcile implementation against relevant contracts.
 2. Broad refactor without a working vertical slice:
@@ -94,6 +107,7 @@ Common process failures and required correction:
 ## Observability
 
 When agent turn diagnostics are available, execution SHOULD record:
+
 - What contract sources were consulted.
 - What verification commands were run.
 - Whether completion gates passed or were deferred.
@@ -103,6 +117,7 @@ If diagnostics are unavailable, this information MUST be captured in the final h
 ## Verification
 
 Compliance indicators:
+
 1. PR/task summary cites consulted spec/instruction sources when behavior changes are non-trivial.
 2. Verification section lists concrete commands run and outcomes.
 3. Canonical spec references are updated when behavior contracts change.

--- a/specs/chat-architecture-spec.md
+++ b/specs/chat-architecture-spec.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-03-21
-- Last Edited: 2026-05-13
+- Last Edited: 2026-05-28
 
 ## Changelog
 
@@ -18,6 +18,7 @@
 - 2026-05-10: Added the enforced Slack-to-runtime boundary and moved resumed Slack turn orchestration under `runtime/`.
 - 2026-05-13: Added the agent turn data-flow diagram, data ownership table, and spec ownership boundaries for continuation recovery.
 - 2026-05-21: Clarified that Pi execution history is sourced from Redis-backed Pi session state, while thread state stores visible transcript plus session pointers.
+- 2026-05-28: Linked agent-loop tool failure handling to the canonical agent execution contract.
 
 ## Status
 
@@ -97,7 +98,7 @@ Normative rules:
 2. The Chat SDK queue/lock layer handles transport-level concerns such as duplicate inbound delivery, ordering, and lock serialization. It is not the source of truth for agent recovery.
 3. Turn preparation is the only point that converts an inbound Slack message into persisted conversation context for an agent turn.
 4. `respond.ts` is the only owner of Pi agent execution, prompt/continue selection, timeout detection, and safe-boundary checkpoint creation.
-5. Tool calls and tool failures are internal agent-loop data until the assistant produces final turn diagnostics. Tool execution errors must be captured, but they are not automatically terminal user replies.
+5. Tool calls and tool failures are internal agent-loop data until the assistant produces final turn diagnostics. Tool execution errors must be captured, but they are not automatically terminal user replies. Model-repairable failures must use the tool-error semantics from [Agent Execution Discipline Spec](./agent-execution-spec.md).
 6. User-visible assistant text is posted only after the reply is finalized and planned for Slack delivery.
 7. Final turn success is defined by Slack accepting the visible final reply, not by model generation completing.
 8. Agent recovery is session continuation: reload durable thread state plus the latest safe turn checkpoint, then continue the same session. It must not create a second active turn or re-run from transient process memory.

--- a/specs/harness-agent-spec.md
+++ b/specs/harness-agent-spec.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-02-24
-- Last Edited: 2026-05-11
+- Last Edited: 2026-05-28
 
 ## Changelog
 
@@ -14,6 +14,7 @@
 - 2026-04-30: Added the thinking-level routing contract and normal-effort default.
 - 2026-05-06: Clarified that normal turns seed Pi from durable conversation message history instead of flattening prior turns into the current prompt.
 - 2026-05-11: Aligned agent telemetry fields with current OpenTelemetry GenAI and exception semantics.
+- 2026-05-28: Linked tool failure semantics to the canonical agent execution contract.
 
 ## Status
 
@@ -87,6 +88,7 @@ Define the canonical runtime contract for assistant-turn execution and user-visi
 ### Tool semantics
 
 - Tools execute as intermediate actions (`bash`, `readFile`, `webSearch`, Slack tools, skill loading, etc.).
+- Model-repairable tool failures must follow the [Agent Execution Discipline Spec](./agent-execution-spec.md) tool-failure contract so Pi records them as `toolResult.isError=true`.
 - The turn is successful when assistant text resolves to a non-empty, non-escape final response.
 - Slack runtimes refine that further: turn completion is only persisted after the final visible reply is delivered.
 - Context-bound target ownership remains runtime/harness-owned. See [Harness Tool Context Spec](./harness-tool-context-spec.md).
@@ -130,6 +132,7 @@ Define the canonical runtime contract for assistant-turn execution and user-visi
 ## Related Specs
 
 - [Harness Tool Context Spec](./harness-tool-context-spec.md)
+- [Agent Execution Discipline Spec](./agent-execution-spec.md)
 - [Agent Session Resumability Spec](./agent-session-resumability-spec.md)
 - [Security Policy](./security-policy.md)
 - [Tracing Spec](./logging/tracing-spec.md)

--- a/specs/harness-tool-context-spec.md
+++ b/specs/harness-tool-context-spec.md
@@ -3,12 +3,13 @@
 ## Metadata
 
 - Created: 2026-03-03
-- Last Edited: 2026-05-19
+- Last Edited: 2026-05-28
 
 ## Changelog
 
 - 2026-03-03: Standardized metadata headers and reconciled spec references/structure.
 - 2026-05-19: Reframed Slack Canvas follow-up tools as file-like document tools with explicit canvas handles.
+- 2026-05-28: Standardized context-bound tool failures on thrown tool errors instead of `ok: false` sentinel results.
 
 ## Status
 
@@ -48,7 +49,7 @@ Examples:
 ## Security Contract
 
 1. Tool schemas for context-bound tools must not expose destination override fields (for example `channel_id` or `list_id`) unless explicitly approved in a separate spec.
-2. Runtime must validate context before execution and return `ok: false` for missing/invalid context.
+2. Runtime must validate context before execution and throw a model-visible tool input error for missing/invalid context.
 3. Runtime must not silently fall back to broader/private scopes that change visibility semantics.
 4. Canvas creation must stay bound to the active assistant conversation context; runtime must not silently retarget to unrelated/private scopes.
 5. Canvas read/edit/write tools must validate that the handle parses as a Slack Canvas/file ID. Canvas reads must confirm Slack metadata describes a Canvas document before downloading content; writes still depend on Slack `canvases.edit` permission and type checks.
@@ -64,7 +65,7 @@ Examples:
 
 ## Error Behavior
 
-When required context is unavailable, tools should return actionable structured errors (`ok: false`) rather than attempting alternate targets.
+When required context is unavailable, tools must throw an actionable tool input error rather than attempting alternate targets. Tool failures intended for model repair must reach the Pi loop as `toolResult.isError=true`; returning a sentinel object such as `{ ok: false, error }` is not a tool failure.
 
 ## Testing Requirements
 

--- a/specs/index.md
+++ b/specs/index.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-03-03
-- Last Edited: 2026-05-26
+- Last Edited: 2026-05-28
 
 ## Changelog
 
@@ -19,6 +19,7 @@
 - 2026-05-13: Added ownership map for chat, agent session, and Slack delivery specs.
 - 2026-05-18: Added draft scheduler spec for scheduled Junior tasks.
 - 2026-05-26: Added draft trusted plugin heartbeat spec for scheduler packaging.
+- 2026-05-28: Clarified ownership for Pi agent execution and tool failure semantics.
 
 ## Status
 
@@ -72,6 +73,9 @@ Define spec taxonomy, naming conventions, and canonical source-of-truth document
 For chat/agent/Slack turn behavior:
 
 - `specs/chat-architecture-spec.md` owns the end-to-end turn data flow, data authority map, and module boundaries.
+- `specs/agent-execution-spec.md` owns coding-agent execution discipline and the repository-wide model-repairable tool failure contract.
+- `specs/harness-agent-spec.md` owns the Pi agent turn runtime contract, final output resolution, and turn diagnostics.
+- `specs/harness-tool-context-spec.md` owns context-bound tool targeting and missing-context failure behavior.
 - `specs/agent-session-resumability-spec.md` owns checkpoint schema, Pi session continuation, timeout callbacks, and slice lifecycle.
 - `specs/slack-agent-delivery-spec.md` owns Slack entry surfaces, progress UX, continuation acknowledgements, and final reply delivery.
 - `specs/slack-outbound-contract-spec.md` owns Slack API write formatting, file uploads, reactions, retries, and error mapping.

--- a/specs/scheduler-spec.md
+++ b/specs/scheduler-spec.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-05-18
-- Last Edited: 2026-05-27
+- Last Edited: 2026-05-28
 
 ## Changelog
 
@@ -11,6 +11,7 @@
 - 2026-05-27: Added stale missed-run policy: old occurrences are skipped and consumed or advanced, not dispatched late and not blocked for human review.
 - 2026-05-27: Added the recurring schedule frequency limit: at most once per day.
 - 2026-05-27: Changed Slack authoring to auto-create clear scheduled work and reserve confirmation for ambiguous requests.
+- 2026-05-28: Clarified model-facing scheduler tool inputs and standardized rejected schedules as tool errors.
 - 2026-05-26: Reframed scheduled execution around system actors: creator is metadata/contact, scheduled runs execute as a system actor, and user-bound auth must not be borrowed implicitly.
 - 2026-05-18: Clarified V1 calendar model: exact next-run instants plus simple daily/weekly/monthly/yearly recurrence rules.
 - 2026-05-18: Initial draft contract for scheduled Junior tasks, prompt framing, no-SQL storage, run idempotency, and eval-first verification.
@@ -75,6 +76,8 @@ Every active task must have an exact `nextRunAtMs` instant. For one-off tasks, t
 Slack authoring may accept supported relative one-off phrases such as "tomorrow at 9am"; these must be resolved to an exact `nextRunAtMs` before storage. When a user does not provide a timezone, scheduler authoring defaults to `America/Los_Angeles` unless `JUNIOR_TIMEZONE` overrides it.
 Scheduler tools accept exact ISO run timestamps only. Natural-language or relative time belongs in the agent's interpretation step before it calls the tool, not in the storage tool contract.
 
+Model-facing scheduler tools use a small recurrence input: omit recurrence for one-off tasks, pass `daily`, `weekly`, `monthly`, or `yearly` for recurring tasks, and pass `null` only when updating an existing task to one-off. The scheduler derives stored calendar fields such as local start date, local time, weekday, month, and day-of-month from `nextRunAtMs` and timezone.
+
 Recurring tasks must also store a small calendar recurrence rule:
 
 - frequency: `daily`, `weekly`, `monthly`, or `yearly`
@@ -87,7 +90,7 @@ Recurring tasks must also store a small calendar recurrence rule:
 
 V1 recurrence is calendar-based, not fixed-duration. For example, "every Monday at 9am America/Los_Angeles" should continue to run at 9am local time across daylight-saving changes. Monthly and yearly recurrences use exact calendar dates; unsupported dates are skipped rather than converted into "last day" or "business day" behavior.
 
-Recurring tasks must not run more than once per day. Slack authoring must reject hourly, twice-daily, or other sub-daily recurring schedules instead of storing a task contract that cannot execute as requested.
+Recurring tasks must not run more than once per day. Slack authoring must reject hourly, twice-daily, or other sub-daily recurring schedules instead of storing a task contract that cannot execute as requested. Rejected scheduler tool calls must throw a model-visible tool input error so the agent can repair arguments or explain the unsupported request after receiving an `isError=true` tool result.
 
 The scheduler does not need advanced rules such as first business day, nearest weekday, holiday calendars, or arbitrary cron syntax.
 


### PR DESCRIPTION
Scheduler validation now uses the standard Pi tool-error path instead of returning successful `ok:false` payloads. This lets the model repair invalid scheduler tool calls after receiving an `isError=true` tool result.

**Scheduler Tool Contract**

The model-facing recurrence input is now a single cadence value: omit it for one-off tasks, use `daily`, `weekly`, `monthly`, or `yearly` for recurring tasks, and use `null` when updating a task back to one-off.

**Spec Alignment**

The agent execution, harness tool context, and scheduler specs now document that model-repairable tool failures must throw expected tool errors rather than inventing sentinel failure payloads. The spec index, chat architecture spec, and harness agent spec now cross-link that canonical ownership so the rule is easier to find without duplicating it.