### PR TITLE
fix(scheduler): Configure heartbeat cron by default

### DIFF
--- a/apps/example/vercel.json
+++ b/apps/example/vercel.json
@@ -1,4 +1,10 @@
 {
   "framework": "nitro",
-  "buildCommand": "pnpm build"
+  "buildCommand": "pnpm build",
+  "crons": [
+    {
+      "path": "/api/internal/heartbeat",
+      "schedule": "* * * * *"
+    }
+  ]
 }

--- a/packages/docs/src/content/docs/extend/scheduler-plugin.md
+++ b/packages/docs/src/content/docs/extend/scheduler-plugin.md
@@ -26,12 +26,17 @@ const app = await createApp();
 export default app;
 ```
 
-The Vercel helper includes the internal heartbeat route:
+The scaffolded `vercel.json` includes the internal heartbeat route:
 
-```ts title="vercel.config.ts"
-import { juniorVercelConfig } from "@sentry/junior/vercel";
-
-export default juniorVercelConfig();
+```json title="vercel.json"
+{
+  "crons": [
+    {
+      "path": "/api/internal/heartbeat",
+      "schedule": "* * * * *"
+    }
+  ]
+}
 ```
 
 If you manage routes manually, call the heartbeat route on a one-minute cadence:

--- a/packages/docs/src/content/docs/start-here/deploy-to-vercel.md
+++ b/packages/docs/src/content/docs/start-here/deploy-to-vercel.md
@@ -12,7 +12,7 @@ related:
   - /start-here/verify-and-troubleshoot/
 ---
 
-The scaffolded app is already shaped for Vercel. Deployment mainly means linking the project, setting env vars, enabling snapshot warmup support, and pointing Slack at the production URL.
+The scaffolded app is already shaped for Vercel. Deployment mainly means linking the project, setting env vars, enabling the heartbeat cron, enabling snapshot warmup support, and pointing Slack at the production URL.
 
 ## Link the project
 
@@ -41,6 +41,25 @@ The scaffolded `package.json` includes the production build script:
 
 Keep the Vercel build command as `pnpm build`. `junior snapshot create` prepares sandbox runtime dependencies declared by enabled plugins before request handling starts.
 
+## Enable the heartbeat cron
+
+Junior uses a one-minute internal heartbeat to run scheduled tasks and recover stale agent dispatches. The scaffolded `vercel.json` should include this cron:
+
+```json title="vercel.json"
+{
+  "framework": "nitro",
+  "buildCommand": "pnpm build",
+  "crons": [
+    {
+      "path": "/api/internal/heartbeat",
+      "schedule": "* * * * *"
+    }
+  ]
+}
+```
+
+If you maintain `vercel.json` manually, keep the `/api/internal/heartbeat` cron entry. The endpoint returns `401` unless the incoming Vercel Cron request has a bearer token that matches `CRON_SECRET`.
+
 ## Configure production environment
 
 Set the core runtime variables in Vercel:
@@ -51,6 +70,7 @@ Set the core runtime variables in Vercel:
 | `SLACK_BOT_TOKEN` or `SLACK_BOT_USER_TOKEN` | Yes         | Posts replies and calls Slack APIs.                                            |
 | `REDIS_URL`                                 | Yes         | Queue and runtime state storage.                                               |
 | `JUNIOR_SECRET`                             | Yes         | Signs internal callbacks and sandbox requester context.                        |
+| `CRON_SECRET`                               | Yes         | Authenticates Vercel Cron requests to the internal heartbeat route.            |
 | `JUNIOR_BASE_URL`                           | Conditional | Canonical URL for OAuth and callback URLs when Vercel URL envs are not enough. |
 | `JUNIOR_STATE_KEY_PREFIX`                   | No          | Redis key namespace for this deployment when sharing one Redis database.       |
 | `AI_GATEWAY_API_KEY`                        | Optional    | AI Gateway auth when your setup requires it.                                   |
@@ -62,6 +82,8 @@ node -e "console.log(require('node:crypto').randomBytes(32).toString('base64url'
 ```
 
 Plugin pages list provider-specific env vars such as GitHub App settings or Datadog keys.
+
+Generate `CRON_SECRET` the same way and store it in Vercel for the production environment. Vercel Cron automatically sends it to cron targets as the `Authorization: Bearer <CRON_SECRET>` header.
 
 ## Enable snapshot warmup credentials
 
@@ -90,10 +112,11 @@ Reinstall the Slack app if scopes changed.
 Run these checks after deployment:
 
 1. `GET https://<your-domain>/health` returns `status: "ok"`.
-2. A Slack mention produces a thread reply in the expected workspace.
-3. App Home opens without an error.
-4. Queue callback and turn logs show successful processing.
-5. One enabled plugin workflow succeeds end to end.
+2. The Vercel deployment has a cron entry for `/api/internal/heartbeat`.
+3. A Slack mention produces a thread reply in the expected workspace.
+4. App Home opens without an error.
+5. Queue callback and turn logs show successful processing.
+6. One enabled plugin workflow succeeds end to end.
 
 ## Next step
 

--- a/packages/junior/src/cli/init.ts
+++ b/packages/junior/src/cli/init.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { juniorVercelConfig } from "../vercel";
 
 function writeServerEntry(targetDir: string): void {
   fs.writeFileSync(
@@ -52,7 +53,7 @@ export default defineConfig({
 function writeVercelJson(targetDir: string): void {
   fs.writeFileSync(
     path.join(targetDir, "vercel.json"),
-    `${JSON.stringify({ framework: "nitro", buildCommand: "pnpm build" }, null, 2)}\n`,
+    `${JSON.stringify(juniorVercelConfig(), null, 2)}\n`,
   );
 }
 
@@ -181,6 +182,7 @@ AI_FAST_MODEL=
 AI_VISION_MODEL=
 AI_WEB_SEARCH_MODEL=
 REDIS_URL=
+CRON_SECRET=
 SENTRY_DSN=
 SENTRY_ORG_SLUG=
 `,

--- a/packages/junior/tests/unit/cli/init-cli.test.ts
+++ b/packages/junior/tests/unit/cli/init-cli.test.ts
@@ -51,6 +51,12 @@ describe("init cli", () => {
     );
     expect(vercelConfig.framework).toBe("nitro");
     expect(vercelConfig.buildCommand).toBe("pnpm build");
+    expect(vercelConfig.crons).toEqual([
+      {
+        path: "/api/internal/heartbeat",
+        schedule: "* * * * *",
+      },
+    ]);
     expect(vercelConfig.functions).toBeUndefined();
 
     const pkg = JSON.parse(
@@ -62,6 +68,12 @@ describe("init cli", () => {
     expect(pkg.scripts.dev).toBe("vite dev");
     expect(pkg.scripts.check).toBe("junior check");
     expect(pkg.scripts.build).toBe("junior snapshot create && vite build");
+
+    const envExample = fs.readFileSync(
+      path.join(target, ".env.example"),
+      "utf8",
+    );
+    expect(envExample).toContain("CRON_SECRET=");
   });
 
   it("refuses to initialize a non-empty directory", async () => {


### PR DESCRIPTION
Add the internal heartbeat cron to scaffolded and example Vercel configs so scheduled work runs in production without manual route wiring.

The deploy docs now make the heartbeat setup explicit and document the required CRON_SECRET value that Vercel Cron sends as the bearer token for /api/internal/heartbeat.

**Scaffolded Production Config**

New Junior apps and the repo example now include a one-minute Vercel Cron entry for /api/internal/heartbeat.

**Deployment Docs**

The Vercel deployment guide now lists CRON_SECRET as required for production heartbeat auth and adds verification that the deployment has the heartbeat cron registered.