### PR TITLE
feat(chat): Add local context compaction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,7 @@ Co-Authored-By: (agent model name) <email>
 - `specs/credential-injection.md` (requester-bound provider credential injection contract)
 - `specs/oauth-flows.md` (OAuth authorization code flow + Slack UX contract)
 - `specs/agent-prompt.md` (core prompt ownership, execution-bias, and bloat-control contract)
+- `specs/context-compaction.md` (reusable Pi history compaction, internal context forks, and visible-thread compaction bounds)
 - `specs/advisor-tool.md` (provider-agnostic advisor tool contract)
 - `specs/scheduler.md` (scheduled Junior task contract)
 - `specs/trusted-plugin-heartbeat.md` (trusted plugin heartbeat and tool hook contract)

--- a/packages/junior/src/chat/app/services.ts
+++ b/packages/junior/src/chat/app/services.ts
@@ -53,8 +53,8 @@ export function createJuniorRuntimeServices(
   });
   const contextCompactor = createContextCompactor({
     completeText: overrides.contextCompactor?.completeText ?? completeText,
-    getAutoCompactionTriggerTokens:
-      overrides.contextCompactor?.getAutoCompactionTriggerTokens,
+    autoCompactionTriggerTokens:
+      overrides.contextCompactor?.autoCompactionTriggerTokens,
   });
   const visionContext = createVisionContextService({
     completeText: overrides.visionContext?.completeText ?? completeText,

--- a/packages/junior/src/chat/app/services.ts
+++ b/packages/junior/src/chat/app/services.ts
@@ -9,6 +9,11 @@ import {
   type ConversationMemoryDeps,
   type ConversationMemoryService,
 } from "@/chat/services/conversation-memory";
+import {
+  createContextCompactor,
+  type ContextCompactor,
+  type ContextCompactorDeps,
+} from "@/chat/services/context-compaction";
 import { downloadPrivateSlackFile } from "@/chat/slack/client";
 import { listThreadReplies } from "@/chat/slack/channel";
 import { lookupSlackUser } from "@/chat/slack/user";
@@ -26,6 +31,7 @@ import {
 
 export interface JuniorRuntimeServices {
   conversationMemory: ConversationMemoryService;
+  contextCompactor: ContextCompactor;
   replyExecutor: ReplyExecutorServices;
   subscribedReplyPolicy: SubscribedReplyPolicy;
   visionContext: VisionContextService;
@@ -33,6 +39,7 @@ export interface JuniorRuntimeServices {
 
 export interface JuniorRuntimeServiceOverrides {
   conversationMemory?: Partial<ConversationMemoryDeps>;
+  contextCompactor?: Partial<ContextCompactorDeps>;
   replyExecutor?: Partial<Omit<ReplyExecutorServices, "generateThreadTitle">>;
   subscribedReplyPolicy?: Partial<SubscribedReplyPolicyDeps>;
   visionContext?: Partial<VisionContextDeps>;
@@ -44,6 +51,11 @@ export function createJuniorRuntimeServices(
   const conversationMemory = createConversationMemoryService({
     completeText: overrides.conversationMemory?.completeText ?? completeText,
   });
+  const contextCompactor = createContextCompactor({
+    completeText: overrides.contextCompactor?.completeText ?? completeText,
+    getAutoCompactionTriggerTokens:
+      overrides.contextCompactor?.getAutoCompactionTriggerTokens,
+  });
   const visionContext = createVisionContextService({
     completeText: overrides.visionContext?.completeText ?? completeText,
     listThreadReplies:
@@ -54,7 +66,10 @@ export function createJuniorRuntimeServices(
 
   return {
     conversationMemory,
+    contextCompactor,
     replyExecutor: {
+      contextCompactor:
+        overrides.replyExecutor?.contextCompactor ?? contextCompactor,
       generateAssistantReply:
         overrides.replyExecutor?.generateAssistantReply ??
         generateAssistantReplyImpl,

--- a/packages/junior/src/chat/config.ts
+++ b/packages/junior/src/chat/config.ts
@@ -37,8 +37,10 @@ const DEFAULT_ASSISTANT_LOADING_MESSAGES = [
 export interface BotConfig {
   advisor: AdvisorConfig;
   fastModelId: string;
+  fastModelContextWindowTokens?: number;
   loadingMessages: string[];
   modelId: string;
+  modelContextWindowTokens?: number;
   visionModelId?: string;
   turnTimeoutMs: number;
   userName: string;
@@ -138,6 +140,22 @@ function parseAdvisorThinkingLevel(
   );
 }
 
+function parseOptionalPositiveInteger(
+  envName: string,
+  rawValue: string | undefined,
+): number | undefined {
+  const trimmed = toOptionalTrimmed(rawValue);
+  if (trimmed === undefined) {
+    return undefined;
+  }
+
+  const value = Number.parseInt(trimmed, 10);
+  if (!Number.isSafeInteger(value) || value <= 0 || String(value) !== trimmed) {
+    throw new Error(`${envName} must be a positive integer`);
+  }
+  return value;
+}
+
 // Compile-time assertion: `getModel`'s second generic is constrained to
 // `keyof (typeof MODELS)[TProvider]`, so a stale default becomes a tsc error.
 const DEFAULT_MODEL_ID = getModel("vercel-ai-gateway", "openai/gpt-5.4").id;
@@ -172,9 +190,17 @@ function readBotConfig(env: NodeJS.ProcessEnv): BotConfig {
   return {
     userName: env.JUNIOR_BOT_NAME ?? "junior",
     modelId: validateGatewayModelId(env.AI_MODEL) ?? DEFAULT_MODEL_ID,
+    modelContextWindowTokens: parseOptionalPositiveInteger(
+      "AI_MODEL_CONTEXT_WINDOW_TOKENS",
+      env.AI_MODEL_CONTEXT_WINDOW_TOKENS,
+    ),
     fastModelId:
       validateGatewayModelId(env.AI_FAST_MODEL ?? env.AI_MODEL) ??
       DEFAULT_FAST_MODEL_ID,
+    fastModelContextWindowTokens: parseOptionalPositiveInteger(
+      "AI_FAST_MODEL_CONTEXT_WINDOW_TOKENS",
+      env.AI_FAST_MODEL_CONTEXT_WINDOW_TOKENS,
+    ),
     loadingMessages: parseLoadingMessages(env.JUNIOR_LOADING_MESSAGES),
     visionModelId: validateGatewayModelId(env.AI_VISION_MODEL),
     turnTimeoutMs: parseAgentTurnTimeoutMs(

--- a/packages/junior/src/chat/config.ts
+++ b/packages/junior/src/chat/config.ts
@@ -37,7 +37,6 @@ const DEFAULT_ASSISTANT_LOADING_MESSAGES = [
 export interface BotConfig {
   advisor: AdvisorConfig;
   fastModelId: string;
-  fastModelContextWindowTokens?: number;
   loadingMessages: string[];
   modelId: string;
   modelContextWindowTokens?: number;
@@ -197,10 +196,6 @@ function readBotConfig(env: NodeJS.ProcessEnv): BotConfig {
     fastModelId:
       validateGatewayModelId(env.AI_FAST_MODEL ?? env.AI_MODEL) ??
       DEFAULT_FAST_MODEL_ID,
-    fastModelContextWindowTokens: parseOptionalPositiveInteger(
-      "AI_FAST_MODEL_CONTEXT_WINDOW_TOKENS",
-      env.AI_FAST_MODEL_CONTEXT_WINDOW_TOKENS,
-    ),
     loadingMessages: parseLoadingMessages(env.JUNIOR_LOADING_MESSAGES),
     visionModelId: validateGatewayModelId(env.AI_VISION_MODEL),
     turnTimeoutMs: parseAgentTurnTimeoutMs(

--- a/packages/junior/src/chat/pi/client.ts
+++ b/packages/junior/src/chat/pi/client.ts
@@ -71,6 +71,43 @@ function extractText(message: {
     .trim();
 }
 
+function contentMetadata(content: unknown): unknown {
+  if (typeof content === "string") {
+    return [{ type: "text", chars: content.length }];
+  }
+  if (!Array.isArray(content)) {
+    return { type: typeof content };
+  }
+  return content.map((part) => {
+    if (!part || typeof part !== "object") {
+      return { type: typeof part };
+    }
+    const record = part as Record<string, unknown>;
+    const type = typeof record.type === "string" ? record.type : "unknown";
+    return {
+      type,
+      ...(typeof record.text === "string" ? { chars: record.text.length } : {}),
+      ...(typeof record.mimeType === "string"
+        ? { mimeType: record.mimeType }
+        : {}),
+      ...(typeof record.mediaType === "string"
+        ? { mediaType: record.mediaType }
+        : {}),
+      ...(typeof record.data === "string"
+        ? { dataChars: record.data.length }
+        : {}),
+    };
+  });
+}
+
+function toMessageMetadata(message: Message): Record<string, unknown> {
+  const record = message as unknown as Record<string, unknown>;
+  return {
+    role: record.role,
+    content: contentMetadata(record.content),
+  };
+}
+
 function parseJsonCandidate(text: string): unknown {
   const trimmed = text.trim();
   if (!trimmed) return undefined;
@@ -154,6 +191,7 @@ export async function completeText(params: {
   modelId: string;
   system?: string;
   messages: Message[];
+  messageAttributeMode?: "content" | "metadata";
   thinkingLevel?: ThinkingLevel;
   temperature?: number;
   maxTokens?: number;
@@ -162,9 +200,18 @@ export async function completeText(params: {
 }) {
   const model = resolveGatewayModel(params.modelId);
   const apiKey = getPiGatewayApiKeyOverride();
-  const requestMessagesAttribute = serializeGenAiAttribute(params.messages);
+  const messageAttributeMode = params.messageAttributeMode ?? "content";
+  const requestMessagesAttribute = serializeGenAiAttribute(
+    messageAttributeMode === "metadata"
+      ? params.messages.map(toMessageMetadata)
+      : params.messages,
+  );
   const systemInstructionsAttribute = params.system
-    ? serializeGenAiAttribute([{ type: "text", content: params.system }])
+    ? serializeGenAiAttribute(
+        messageAttributeMode === "metadata"
+          ? [{ type: "text", chars: params.system.length }]
+          : [{ type: "text", content: params.system }],
+      )
     : undefined;
   const baseAttributes = {
     "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
@@ -205,12 +252,23 @@ export async function completeText(params: {
         },
       );
       const outputText = extractText(message);
-      const outputMessagesAttribute = serializeGenAiAttribute([
-        {
-          role: "assistant",
-          content: outputText ? [{ type: "text", text: outputText }] : [],
-        },
-      ]);
+      const outputMessagesAttribute = serializeGenAiAttribute(
+        messageAttributeMode === "metadata"
+          ? [
+              {
+                role: "assistant",
+                content: outputText
+                  ? [{ type: "text", chars: outputText.length }]
+                  : [],
+              },
+            ]
+          : [
+              {
+                role: "assistant",
+                content: outputText ? [{ type: "text", text: outputText }] : [],
+              },
+            ],
+      );
       const usageAttributes = extractGenAiUsageAttributes(message);
       const endAttributes = {
         ...baseAttributes,

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -106,15 +106,20 @@ function buildCanvasRecoveryReply(canvasUrl: string) {
   return `I created the canvas, but the turn was interrupted before I could finish the thread reply: ${canvasUrl}`;
 }
 
+interface LoadedPiMessagesForTurn {
+  compactionSessionId?: string;
+  piMessages?: PiMessage[];
+}
+
 async function loadPiMessagesForTurn(args: {
   conversationId?: string;
   activeTurnId?: string;
   lastSessionId?: string;
   fallback: PiMessage[];
-}): Promise<PiMessage[] | undefined> {
+}): Promise<LoadedPiMessagesForTurn> {
   const fallback = args.fallback.length > 0 ? [...args.fallback] : undefined;
   if (!args.conversationId) {
-    return fallback;
+    return { piMessages: fallback };
   }
 
   if (args.activeTurnId) {
@@ -123,23 +128,30 @@ async function loadPiMessagesForTurn(args: {
       args.activeTurnId,
     );
     if (checkpoint?.piMessages.length) {
-      return stripRuntimeTurnContext(
-        trimTrailingAssistantMessages(checkpoint.piMessages),
-      );
+      return {
+        piMessages: stripRuntimeTurnContext(
+          trimTrailingAssistantMessages(checkpoint.piMessages),
+        ),
+      };
     }
   }
 
   if (!args.lastSessionId) {
-    return fallback;
+    return { piMessages: fallback };
   }
 
   const checkpoint = await getAgentTurnSessionCheckpoint(
     args.conversationId,
     args.lastSessionId,
   );
-  return checkpoint?.state === "completed" && checkpoint.piMessages.length > 0
-    ? stripRuntimeTurnContext(checkpoint.piMessages)
-    : fallback;
+  if (checkpoint?.state === "completed" && checkpoint.piMessages.length > 0) {
+    return {
+      compactionSessionId: args.lastSessionId,
+      piMessages: stripRuntimeTurnContext(checkpoint.piMessages),
+    };
+  }
+
+  return { piMessages: fallback };
 }
 
 export interface ReplyExecutorServices {
@@ -454,13 +466,18 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           !isVisionEnabled() && hasPotentialImageAttachment(message.attachments)
             ? countPotentialImageAttachments(message.attachments)
             : 0;
-        let piMessages = await loadPiMessagesForTurn({
+        const loadedPiMessages = await loadPiMessagesForTurn({
           conversationId,
           activeTurnId,
           lastSessionId: lastSessionIdForHistory,
           fallback: preparedState.conversation.piMessages,
         });
-        if (conversationId && lastSessionIdForHistory && piMessages?.length) {
+        let piMessages = loadedPiMessages.piMessages;
+        if (
+          conversationId &&
+          loadedPiMessages.compactionSessionId &&
+          piMessages?.length
+        ) {
           const compaction = await deps.services.contextCompactor.maybeCompact({
             conversation: preparedState.conversation,
             conversationContext:
@@ -472,7 +489,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               channelId,
               runId,
             },
-            previousSessionId: lastSessionIdForHistory,
+            previousSessionId: loadedPiMessages.compactionSessionId,
           });
           if (compaction.compacted) {
             piMessages = compaction.piMessages;

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -155,7 +155,7 @@ async function loadPiMessagesForTurn(args: {
 }
 
 export interface ReplyExecutorServices {
-  contextCompactor: Pick<ContextCompactor, "maybeCompact">;
+  contextCompactor: ContextCompactor;
   generateAssistantReply: typeof generateAssistantReplyImpl;
   generateThreadTitle: ConversationMemoryService["generateThreadTitle"];
   getAwaitingTurnContinuationRequest: (args: {

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -48,7 +48,10 @@ import {
   hasPotentialImageAttachment,
   isVisionEnabled,
 } from "@/chat/services/vision-context";
-import { createSlackAdapterAssistantStatusSession } from "@/chat/slack/assistant-thread/status";
+import {
+  createSlackAdapterAssistantStatusSession,
+  type AssistantStatusSpec,
+} from "@/chat/slack/assistant-thread/status";
 import { buildSlackReplyFooter } from "@/chat/slack/footer";
 import { maybeUpdateAssistantTitle } from "@/chat/slack/assistant-thread/title";
 import { appendSlackLegacyAttachmentText } from "@/chat/slack/legacy-attachments";
@@ -466,44 +469,14 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           !isVisionEnabled() && hasPotentialImageAttachment(message.attachments)
             ? countPotentialImageAttachments(message.attachments)
             : 0;
-        const loadedPiMessages = await loadPiMessagesForTurn({
-          conversationId,
-          activeTurnId,
-          lastSessionId: lastSessionIdForHistory,
-          fallback: preparedState.conversation.piMessages,
-        });
-        let piMessages = loadedPiMessages.piMessages;
-        if (
-          conversationId &&
-          loadedPiMessages.compactionSessionId &&
-          piMessages?.length
-        ) {
-          const compaction = await deps.services.contextCompactor.maybeCompact({
-            conversation: preparedState.conversation,
-            conversationContext:
-              preparedState.routingContext ?? preparedState.conversationContext,
-            conversationId,
-            metadata: {
-              threadId,
-              requesterId: message.author.userId,
-              channelId,
-              runId,
-            },
-            previousSessionId: loadedPiMessages.compactionSessionId,
-          });
-          if (compaction.compacted) {
-            piMessages = compaction.piMessages;
-            await persistThreadState(thread, {
-              conversation: preparedState.conversation,
-            });
-          }
-        }
-
         const status = createSlackAdapterAssistantStatusSession({
           channelId: assistantThreadContext?.channelId,
           threadTs: assistantThreadContext?.threadTs,
           getSlackAdapter: deps.getSlackAdapter,
         });
+        const compactingStatus: AssistantStatusSpec = {
+          text: "Compacting context",
+        };
         const postThreadReply = async (
           payload: Parameters<typeof thread.post>[0],
           stage: PlannedSlackReplyStage,
@@ -526,25 +499,61 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             throw error;
           }
         };
-        status.start();
-        const assistantTitleTask = maybeUpdateAssistantTitle({
-          assistantThreadContext,
-          assistantUserName: botConfig.userName,
-          artifacts: preparedState.artifacts,
-          channelId,
-          conversation: preparedState.conversation,
-          generateThreadTitle: deps.services.generateThreadTitle,
-          getSlackAdapter: deps.getSlackAdapter,
-          modelId: botConfig.fastModelId,
-          requesterId: message.author.userId,
-          runId,
-          threadId,
-        });
         let persistedAtLeastOnce = false;
         let shouldPersistFailureState = true;
         let latestArtifacts = preparedState.artifacts;
 
         try {
+          const loadedPiMessages = await loadPiMessagesForTurn({
+            conversationId,
+            activeTurnId,
+            lastSessionId: lastSessionIdForHistory,
+            fallback: preparedState.conversation.piMessages,
+          });
+          let piMessages = loadedPiMessages.piMessages;
+          if (
+            conversationId &&
+            loadedPiMessages.compactionSessionId &&
+            piMessages?.length
+          ) {
+            const compaction =
+              await deps.services.contextCompactor.maybeCompact({
+                conversation: preparedState.conversation,
+                conversationContext:
+                  preparedState.routingContext ??
+                  preparedState.conversationContext,
+                conversationId,
+                metadata: {
+                  threadId,
+                  requesterId: message.author.userId,
+                  channelId,
+                  runId,
+                },
+                onCompactionStart: () => status.start(compactingStatus),
+                previousSessionId: loadedPiMessages.compactionSessionId,
+              });
+            if (compaction.compacted) {
+              piMessages = compaction.piMessages;
+              await persistThreadState(thread, {
+                conversation: preparedState.conversation,
+              });
+            }
+          }
+
+          status.start();
+          const assistantTitleTask = maybeUpdateAssistantTitle({
+            assistantThreadContext,
+            assistantUserName: botConfig.userName,
+            artifacts: preparedState.artifacts,
+            channelId,
+            conversation: preparedState.conversation,
+            generateThreadTitle: deps.services.generateThreadTitle,
+            getSlackAdapter: deps.getSlackAdapter,
+            modelId: botConfig.fastModelId,
+            requesterId: message.author.userId,
+            runId,
+            threadId,
+          });
           const toolChannelId =
             preparedState.artifacts.assistantContextChannelId ?? channelId;
           let reply = await deps.services.generateAssistantReply(userText, {

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -41,6 +41,7 @@ import {
   generateConversationId,
   updateConversationStats,
 } from "@/chat/services/conversation-memory";
+import type { ContextCompactor } from "@/chat/services/context-compaction";
 import { applyPendingAuthUpdate } from "@/chat/services/pending-auth";
 import {
   countPotentialImageAttachments,
@@ -142,6 +143,7 @@ async function loadPiMessagesForTurn(args: {
 }
 
 export interface ReplyExecutorServices {
+  contextCompactor: Pick<ContextCompactor, "maybeCompact">;
   generateAssistantReply: typeof generateAssistantReplyImpl;
   generateThreadTitle: ConversationMemoryService["generateThreadTitle"];
   getAwaitingTurnContinuationRequest: (args: {
@@ -452,12 +454,33 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           !isVisionEnabled() && hasPotentialImageAttachment(message.attachments)
             ? countPotentialImageAttachments(message.attachments)
             : 0;
-        const piMessages = await loadPiMessagesForTurn({
+        let piMessages = await loadPiMessagesForTurn({
           conversationId,
           activeTurnId,
           lastSessionId: lastSessionIdForHistory,
           fallback: preparedState.conversation.piMessages,
         });
+        if (conversationId && lastSessionIdForHistory && piMessages?.length) {
+          const compaction = await deps.services.contextCompactor.maybeCompact({
+            conversation: preparedState.conversation,
+            conversationContext:
+              preparedState.routingContext ?? preparedState.conversationContext,
+            conversationId,
+            metadata: {
+              threadId,
+              requesterId: message.author.userId,
+              channelId,
+              runId,
+            },
+            previousSessionId: lastSessionIdForHistory,
+          });
+          if (compaction.compacted) {
+            piMessages = compaction.piMessages;
+            await persistThreadState(thread, {
+              conversation: preparedState.conversation,
+            });
+          }
+        }
 
         const status = createSlackAdapterAssistantStatusSession({
           channelId: assistantThreadContext?.channelId,

--- a/packages/junior/src/chat/services/context-budget.ts
+++ b/packages/junior/src/chat/services/context-budget.ts
@@ -55,12 +55,11 @@ export function getAgentContextCompactionTriggerTokens(): number {
   });
 }
 
-/** Resolve the visible conversation compaction threshold for the fast model. */
+/** Resolve the visible conversation compaction threshold for the auxiliary model. */
 export function getConversationContextCompactionTriggerTokens(): number {
   const model = resolveGatewayModel(botConfig.fastModelId);
   return calculateContextCompactionTriggerTokens({
-    contextWindow:
-      botConfig.fastModelContextWindowTokens ?? model.contextWindow,
+    contextWindow: model.contextWindow,
     maxTokens: model.maxTokens,
   });
 }

--- a/packages/junior/src/chat/services/context-budget.ts
+++ b/packages/junior/src/chat/services/context-budget.ts
@@ -1,0 +1,66 @@
+import { botConfig } from "@/chat/config";
+import { resolveGatewayModel } from "@/chat/pi/client";
+
+const COMPACTION_TRIGGER_INPUT_RATIO = 0.75;
+const COMPACTION_OUTPUT_RESERVE_RATIO = 0.25;
+const COMPACTION_TARGET_RATIO = 0.8;
+const FALLBACK_CONTEXT_WINDOW_TOKENS = 400_000;
+const FALLBACK_MAX_OUTPUT_TOKENS = 128_000;
+
+export interface ModelContextBudget {
+  contextWindow: number;
+  maxTokens: number;
+}
+
+function positiveInteger(value: number, fallback: number): number {
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
+}
+
+/** Derive the automatic compaction threshold from model context capacity. */
+export function calculateContextCompactionTriggerTokens(
+  model: ModelContextBudget,
+): number {
+  const contextWindow = positiveInteger(
+    model.contextWindow,
+    FALLBACK_CONTEXT_WINDOW_TOKENS,
+  );
+  const maxTokens = positiveInteger(
+    model.maxTokens,
+    FALLBACK_MAX_OUTPUT_TOKENS,
+  );
+  const outputReserve = Math.min(
+    maxTokens,
+    Math.floor(contextWindow * COMPACTION_OUTPUT_RESERVE_RATIO),
+  );
+  const usableInputTokens = Math.max(1, contextWindow - outputReserve);
+  return Math.max(
+    1,
+    Math.floor(usableInputTokens * COMPACTION_TRIGGER_INPUT_RATIO),
+  );
+}
+
+/** Derive the post-compaction target from the automatic trigger threshold. */
+export function calculateContextCompactionTargetTokens(
+  triggerTokens: number,
+): number {
+  return Math.max(1, Math.floor(triggerTokens * COMPACTION_TARGET_RATIO));
+}
+
+/** Resolve the automatic compaction threshold for the active agent model. */
+export function getAgentContextCompactionTriggerTokens(): number {
+  const model = resolveGatewayModel(botConfig.modelId);
+  return calculateContextCompactionTriggerTokens({
+    contextWindow: botConfig.modelContextWindowTokens ?? model.contextWindow,
+    maxTokens: model.maxTokens,
+  });
+}
+
+/** Resolve the visible conversation compaction threshold for the fast model. */
+export function getConversationContextCompactionTriggerTokens(): number {
+  const model = resolveGatewayModel(botConfig.fastModelId);
+  return calculateContextCompactionTriggerTokens({
+    contextWindow:
+      botConfig.fastModelContextWindowTokens ?? model.contextWindow,
+    maxTokens: model.maxTokens,
+  });
+}

--- a/packages/junior/src/chat/services/context-budget.ts
+++ b/packages/junior/src/chat/services/context-budget.ts
@@ -16,6 +16,11 @@ function positiveInteger(value: number, fallback: number): number {
   return Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
 }
 
+/** Estimate text tokens with the shared coarse heuristic used for local budgets. */
+export function estimateTextTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
 /** Derive the automatic compaction threshold from model context capacity. */
 export function calculateContextCompactionTriggerTokens(
   model: ModelContextBudget,

--- a/packages/junior/src/chat/services/context-compaction.ts
+++ b/packages/junior/src/chat/services/context-compaction.ts
@@ -40,6 +40,7 @@ export interface CompactContextArgs {
   conversation: ThreadConversationState;
   conversationContext?: string;
   conversationId: string;
+  onCompactionStart?: () => void;
   previousSessionId: string;
   metadata?: {
     channelId?: string;
@@ -342,6 +343,8 @@ async function maybeCompactWithDeps(
   if (source.estimatedTokens <= triggerTokens) {
     return { compacted: false, reason: "below_threshold" };
   }
+
+  args.onCompactionStart?.();
 
   let summary: string;
   try {

--- a/packages/junior/src/chat/services/context-compaction.ts
+++ b/packages/junior/src/chat/services/context-compaction.ts
@@ -29,11 +29,10 @@ const OMITTED_OLDER_CONTEXT_NOTICE = "[older context omitted]";
 
 export interface ContextCompactorDeps {
   completeText: typeof completeText;
-  getAutoCompactionTriggerTokens?: () => number;
+  autoCompactionTriggerTokens?: number;
 }
 
 export interface ContextCompactor {
-  compact: (args: CompactContextArgs) => Promise<CompactContextResult>;
   maybeCompact: (args: CompactContextArgs) => Promise<CompactContextResult>;
 }
 
@@ -59,7 +58,6 @@ export interface CompactContextResult {
     | "not_completed"
     | "summary_failed";
   sessionId?: string;
-  summary?: string;
 }
 
 function estimateTokenCount(text: string): number {
@@ -293,13 +291,19 @@ function createCompactionSessionId(previousSessionId: string): string {
   return `compaction_${previousSessionId}`;
 }
 
-async function loadCompletedHistory(args: {
+type CompactionSource =
+  | {
+      estimatedTokens: number;
+      messages: PiMessage[];
+    }
+  | {
+      reason: "missing_context" | "not_completed";
+    };
+
+async function loadCompactionSource(args: {
   conversationId: string;
   previousSessionId: string;
-}): Promise<{
-  messages?: PiMessage[];
-  reason?: "missing_context" | "not_completed";
-}> {
+}): Promise<CompactionSource> {
   const checkpoint = await getAgentTurnSessionCheckpoint(
     args.conversationId,
     args.previousSessionId,
@@ -312,62 +316,30 @@ async function loadCompletedHistory(args: {
   }
   const messages = checkpoint.piMessages;
   if (messages.length) {
-    return { messages };
+    return {
+      estimatedTokens: estimateHistoryTokens(messages),
+      messages,
+    };
   }
   return { reason: "missing_context" };
-}
-
-async function compactWithDeps(
-  args: CompactContextArgs,
-  deps: ContextCompactorDeps,
-): Promise<CompactContextResult> {
-  const loaded = await loadCompletedHistory({
-    conversationId: args.conversationId,
-    previousSessionId: args.previousSessionId,
-  });
-  if (loaded.reason) {
-    return { compacted: false, reason: loaded.reason };
-  }
-  const sourceMessages = loaded.messages;
-  if (!sourceMessages?.length) {
-    return { compacted: false, reason: "missing_context" };
-  }
-
-  const estimatedTokens = estimateHistoryTokens(sourceMessages);
-  const summary = await summarizeContext(
-    {
-      conversationContext: args.conversationContext,
-      piMessages: sourceMessages,
-      metadata: args.metadata,
-    },
-    deps,
-  );
-  return await writeCompactedThreadContext(args, sourceMessages, summary, {
-    estimatedTokens,
-  });
 }
 
 async function maybeCompactWithDeps(
   args: CompactContextArgs,
   deps: ContextCompactorDeps,
 ): Promise<CompactContextResult> {
-  const loaded = await loadCompletedHistory({
+  const source = await loadCompactionSource({
     conversationId: args.conversationId,
     previousSessionId: args.previousSessionId,
   });
-  if (loaded.reason) {
-    return { compacted: false, reason: loaded.reason };
-  }
-  const sourceMessages = loaded.messages;
-  if (!sourceMessages?.length) {
-    return { compacted: false, reason: "missing_context" };
+  if ("reason" in source) {
+    return { compacted: false, reason: source.reason };
   }
 
-  const estimatedTokens = estimateHistoryTokens(sourceMessages);
   const triggerTokens =
-    deps.getAutoCompactionTriggerTokens?.() ??
+    deps.autoCompactionTriggerTokens ??
     getAgentContextCompactionTriggerTokens();
-  if (estimatedTokens <= triggerTokens) {
+  if (source.estimatedTokens <= triggerTokens) {
     return { compacted: false, reason: "below_threshold" };
   }
 
@@ -376,7 +348,7 @@ async function maybeCompactWithDeps(
     summary = await summarizeContext(
       {
         conversationContext: args.conversationContext,
-        piMessages: sourceMessages,
+        piMessages: source.messages,
         metadata: args.metadata,
       },
       deps,
@@ -401,8 +373,8 @@ async function maybeCompactWithDeps(
     return { compacted: false, reason: "summary_failed" };
   }
 
-  return await writeCompactedThreadContext(args, sourceMessages, summary, {
-    estimatedTokens,
+  return await writeCompactedThreadContext(args, source.messages, summary, {
+    estimatedTokens: source.estimatedTokens,
     triggerTokens,
   });
 }
@@ -447,7 +419,6 @@ async function writeCompactedThreadContext(
     compacted: true,
     piMessages: replacement,
     sessionId: nextSessionId,
-    summary,
   };
 }
 
@@ -456,7 +427,6 @@ export function createContextCompactor(
   deps: ContextCompactorDeps,
 ): ContextCompactor {
   return {
-    compact: async (args) => await compactWithDeps(args, deps),
     maybeCompact: async (args) => await maybeCompactWithDeps(args, deps),
   };
 }

--- a/packages/junior/src/chat/services/context-compaction.ts
+++ b/packages/junior/src/chat/services/context-compaction.ts
@@ -5,7 +5,10 @@ import {
 import { botConfig } from "@/chat/config";
 import type { completeText } from "@/chat/pi/client";
 import type { PiMessage } from "@/chat/pi/messages";
-import { getAgentContextCompactionTriggerTokens } from "@/chat/services/context-budget";
+import {
+  estimateTextTokens,
+  getAgentContextCompactionTriggerTokens,
+} from "@/chat/services/context-budget";
 import {
   getAgentTurnSessionCheckpoint,
   upsertAgentTurnSessionCheckpoint,
@@ -59,10 +62,6 @@ export interface CompactContextResult {
     | "not_completed"
     | "summary_failed";
   sessionId?: string;
-}
-
-function estimateTokenCount(text: string): number {
-  return Math.ceil(text.length / 4);
 }
 
 function textPart(value: unknown): string | undefined {
@@ -144,7 +143,7 @@ export function selectRetainedUserMessages(
       continue;
     }
 
-    const tokens = estimateTokenCount(text);
+    const tokens = estimateTextTokens(text);
     if (tokens <= remaining) {
       selected.push(text);
       remaining -= tokens;

--- a/packages/junior/src/chat/services/context-compaction.ts
+++ b/packages/junior/src/chat/services/context-compaction.ts
@@ -1,0 +1,456 @@
+import { botConfig } from "@/chat/config";
+import type { completeText } from "@/chat/pi/client";
+import type { PiMessage } from "@/chat/pi/messages";
+import { getAgentContextCompactionTriggerTokens } from "@/chat/services/context-budget";
+import {
+  getAgentTurnSessionCheckpoint,
+  upsertAgentTurnSessionCheckpoint,
+} from "@/chat/state/turn-session-store";
+import type { ThreadConversationState } from "@/chat/state/conversation";
+import { logWarn, setSpanAttributes } from "@/chat/logging";
+import {
+  stripRuntimeTurnContext,
+  trimTrailingAssistantMessages,
+} from "@/chat/respond-helpers";
+import { updateConversationStats } from "@/chat/services/conversation-memory";
+
+const RETAINED_USER_MESSAGE_TOKENS = 20_000;
+const MAX_SUMMARY_INPUT_CHARS = 80_000;
+const MAX_VISIBLE_CONTEXT_CHARS = 20_000;
+const MAX_SUMMARY_CHARS = 6_000;
+const MAX_RENDERED_MESSAGE_CHARS = 4_000;
+const COMPACTION_SUMMARY_PREFIX =
+  "Context handoff summary for future Junior turns:";
+const OMITTED_OLDER_CONTEXT_NOTICE = "[older context omitted]";
+
+export interface ContextCompactorDeps {
+  completeText: typeof completeText;
+  getAutoCompactionTriggerTokens?: () => number;
+}
+
+export interface ContextCompactor {
+  compact: (args: CompactContextArgs) => Promise<CompactContextResult>;
+  maybeCompact: (args: CompactContextArgs) => Promise<CompactContextResult>;
+}
+
+export interface CompactContextArgs {
+  conversation: ThreadConversationState;
+  conversationContext?: string;
+  conversationId: string;
+  previousSessionId: string;
+  metadata?: {
+    channelId?: string;
+    requesterId?: string;
+    runId?: string;
+    threadId?: string;
+  };
+}
+
+export interface CompactContextResult {
+  compacted: boolean;
+  piMessages?: PiMessage[];
+  reason?:
+    | "below_threshold"
+    | "missing_context"
+    | "not_completed"
+    | "summary_failed";
+  sessionId?: string;
+  summary?: string;
+}
+
+function estimateTokenCount(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+function textPart(value: unknown): string | undefined {
+  if (
+    value &&
+    typeof value === "object" &&
+    (value as { type?: unknown }).type === "text" &&
+    typeof (value as { text?: unknown }).text === "string"
+  ) {
+    return (value as { text: string }).text;
+  }
+  return undefined;
+}
+
+function messageText(message: PiMessage): string {
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return typeof content === "string" ? content : "";
+  }
+  return content.map(textPart).filter(Boolean).join("\n").trim();
+}
+
+function sanitizeText(text: string): string {
+  return text
+    .replace(
+      /<data_base64>[\s\S]*?<\/data_base64>/g,
+      "<data_base64>[omitted]</data_base64>",
+    )
+    .replace(
+      /data:image\/[a-z0-9.+-]+;base64,[a-z0-9+/=]+/gi,
+      "[image data omitted]",
+    )
+    .replaceAll("\u0000", " ")
+    .trim();
+}
+
+function truncateToTokenBudget(text: string, maxTokens: number): string {
+  const maxChars = Math.max(0, maxTokens * 4);
+  if (text.length <= maxChars) {
+    return text;
+  }
+  return `${text.slice(0, Math.max(0, maxChars - 3)).trimEnd()}...`;
+}
+
+function isCompactionSummary(text: string): boolean {
+  return text.trimStart().startsWith(COMPACTION_SUMMARY_PREFIX);
+}
+
+function isPayloadHeavy(text: string): boolean {
+  return /<data_base64>[\s\S]*?<\/data_base64>|data:image\/[a-z0-9.+-]+;base64,/i.test(
+    text,
+  );
+}
+
+function userMessage(text: string): PiMessage {
+  return {
+    role: "user",
+    content: [{ type: "text", text }],
+    timestamp: Date.now(),
+  } as PiMessage;
+}
+
+/** Build retained user messages for a compacted Pi replacement history. */
+export function selectRetainedUserMessages(
+  messages: PiMessage[],
+  maxTokens = RETAINED_USER_MESSAGE_TOKENS,
+): PiMessage[] {
+  const stripped = stripRuntimeTurnContext(messages);
+  const selected: string[] = [];
+  let remaining = maxTokens;
+
+  for (const message of [...stripped].reverse()) {
+    if ((message as { role?: unknown }).role !== "user" || remaining <= 0) {
+      continue;
+    }
+
+    const text = sanitizeText(messageText(message));
+    if (!text || isCompactionSummary(text) || isPayloadHeavy(text)) {
+      continue;
+    }
+
+    const tokens = estimateTokenCount(text);
+    if (tokens <= remaining) {
+      selected.push(text);
+      remaining -= tokens;
+      continue;
+    }
+
+    const truncated = truncateToTokenBudget(text, remaining);
+    if (truncated) {
+      selected.push(truncated);
+    }
+    break;
+  }
+
+  return selected.reverse().map(userMessage);
+}
+
+function renderMessageForSummary(message: PiMessage): string | undefined {
+  const role = (message as { role?: unknown }).role;
+  if (typeof role !== "string") {
+    return undefined;
+  }
+  const text = sanitizeText(messageText(message));
+  if (!text) {
+    return undefined;
+  }
+  const trimmed =
+    text.length > MAX_RENDERED_MESSAGE_CHARS
+      ? `${text.slice(0, MAX_RENDERED_MESSAGE_CHARS).trimEnd()}...`
+      : text;
+  return `[${role}] ${trimmed}`;
+}
+
+function keepTail(text: string, maxChars: number): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+  const prefix = `${OMITTED_OLDER_CONTEXT_NOTICE}\n`;
+  return `${prefix}${text.slice(Math.max(0, text.length - maxChars + prefix.length))}`;
+}
+
+function renderSummaryInput(
+  piMessages: PiMessage[],
+  conversationContext?: string,
+): string {
+  const lines: string[] = [];
+  const visibleContext = conversationContext?.trim();
+  if (visibleContext) {
+    lines.push(
+      "<visible-thread-context>",
+      keepTail(visibleContext, MAX_VISIBLE_CONTEXT_CHARS),
+      "</visible-thread-context>",
+      "",
+    );
+  }
+
+  const renderedPiMessages = stripRuntimeTurnContext(piMessages)
+    .map(renderMessageForSummary)
+    .filter((line): line is string => Boolean(line));
+
+  if (renderedPiMessages.length > 0) {
+    const piEnvelopeChars = "<pi-history>\n</pi-history>".length + 2;
+    const piHistory = keepTail(
+      renderedPiMessages.join("\n"),
+      Math.max(
+        1,
+        MAX_SUMMARY_INPUT_CHARS - lines.join("\n").length - piEnvelopeChars,
+      ),
+    );
+    lines.push("<pi-history>", piHistory, "</pi-history>");
+  }
+
+  return keepTail(lines.join("\n"), MAX_SUMMARY_INPUT_CHARS);
+}
+
+async function summarizeContext(
+  args: {
+    conversationContext?: string;
+    piMessages: PiMessage[];
+    metadata?: CompactContextArgs["metadata"];
+  },
+  deps: ContextCompactorDeps,
+): Promise<string> {
+  const source = renderSummaryInput(args.piMessages, args.conversationContext);
+  const result = await deps.completeText({
+    modelId: botConfig.fastModelId,
+    messageAttributeMode: "metadata",
+    temperature: 0,
+    messages: [
+      {
+        role: "user",
+        content: [
+          "You are performing a CONTEXT CHECKPOINT COMPACTION for Junior.",
+          "Create a concise handoff summary for another model that will continue this Slack thread.",
+          "",
+          "Include:",
+          "- Current outstanding asks",
+          "- Key decisions, completed work, and outcomes",
+          "- Durable constraints, user preferences, IDs, URLs, artifacts, canvas links, sandbox references, and auth state",
+          "- Clear next steps and unresolved blockers",
+          "",
+          "Do not invent details. Do not include raw secrets or credentials.",
+          "",
+          source,
+        ].join("\n"),
+        timestamp: Date.now(),
+      },
+    ],
+    metadata: {
+      modelId: botConfig.fastModelId,
+      threadId: args.metadata?.threadId ?? "",
+      channelId: args.metadata?.channelId ?? "",
+      requesterId: args.metadata?.requesterId ?? "",
+      runId: args.metadata?.runId ?? "",
+    },
+  });
+
+  const summary = result.text.trim();
+  if (!summary) {
+    throw new Error("Compaction summary was empty");
+  }
+  return summary.slice(0, MAX_SUMMARY_CHARS);
+}
+
+function estimateHistoryTokens(messages: PiMessage[]): number {
+  return stripRuntimeTurnContext(messages).reduce(
+    (total, message) =>
+      total + estimateTokenCount(sanitizeText(messageText(message))),
+    0,
+  );
+}
+
+function buildReplacementHistory(args: {
+  messages: PiMessage[];
+  summary: string;
+}): PiMessage[] {
+  return [
+    ...selectRetainedUserMessages(args.messages),
+    userMessage(`${COMPACTION_SUMMARY_PREFIX}\n${args.summary}`),
+  ];
+}
+
+function createCompactionSessionId(previousSessionId: string): string {
+  return `compaction_${previousSessionId}`;
+}
+
+async function loadCompletedHistory(args: {
+  conversationId: string;
+  previousSessionId: string;
+}): Promise<{
+  messages?: PiMessage[];
+  reason?: "missing_context" | "not_completed";
+}> {
+  const checkpoint = await getAgentTurnSessionCheckpoint(
+    args.conversationId,
+    args.previousSessionId,
+  );
+  if (!checkpoint) {
+    return { reason: "missing_context" };
+  }
+  if (checkpoint.state !== "completed") {
+    return { reason: "not_completed" };
+  }
+  const messages = checkpoint.piMessages;
+  if (messages.length) {
+    return { messages };
+  }
+  return { reason: "missing_context" };
+}
+
+async function compactWithDeps(
+  args: CompactContextArgs,
+  deps: ContextCompactorDeps,
+): Promise<CompactContextResult> {
+  const loaded = await loadCompletedHistory({
+    conversationId: args.conversationId,
+    previousSessionId: args.previousSessionId,
+  });
+  if (loaded.reason) {
+    return { compacted: false, reason: loaded.reason };
+  }
+  const sourceMessages = loaded.messages;
+  if (!sourceMessages?.length) {
+    return { compacted: false, reason: "missing_context" };
+  }
+
+  const estimatedTokens = estimateHistoryTokens(sourceMessages);
+  const summary = await summarizeContext(
+    {
+      conversationContext: args.conversationContext,
+      piMessages: sourceMessages,
+      metadata: args.metadata,
+    },
+    deps,
+  );
+  return await writeCompactedThreadContext(args, sourceMessages, summary, {
+    estimatedTokens,
+  });
+}
+
+async function maybeCompactWithDeps(
+  args: CompactContextArgs,
+  deps: ContextCompactorDeps,
+): Promise<CompactContextResult> {
+  const loaded = await loadCompletedHistory({
+    conversationId: args.conversationId,
+    previousSessionId: args.previousSessionId,
+  });
+  if (loaded.reason) {
+    return { compacted: false, reason: loaded.reason };
+  }
+  const sourceMessages = loaded.messages;
+  if (!sourceMessages?.length) {
+    return { compacted: false, reason: "missing_context" };
+  }
+
+  const estimatedTokens = estimateHistoryTokens(sourceMessages);
+  const triggerTokens =
+    deps.getAutoCompactionTriggerTokens?.() ??
+    getAgentContextCompactionTriggerTokens();
+  if (estimatedTokens <= triggerTokens) {
+    return { compacted: false, reason: "below_threshold" };
+  }
+
+  let summary: string;
+  try {
+    summary = await summarizeContext(
+      {
+        conversationContext: args.conversationContext,
+        piMessages: sourceMessages,
+        metadata: args.metadata,
+      },
+      deps,
+    );
+  } catch (error) {
+    logWarn(
+      "context_compaction_summary_failed",
+      {
+        slackThreadId: args.metadata?.threadId,
+        slackUserId: args.metadata?.requesterId,
+        slackChannelId: args.metadata?.channelId,
+        runId: args.metadata?.runId,
+        assistantUserName: botConfig.userName,
+        modelId: botConfig.fastModelId,
+      },
+      {
+        "exception.message":
+          error instanceof Error ? error.message : String(error),
+      },
+      "Context compaction failed; continuing with prior history",
+    );
+    return { compacted: false, reason: "summary_failed" };
+  }
+
+  return await writeCompactedThreadContext(args, sourceMessages, summary, {
+    estimatedTokens,
+    triggerTokens,
+  });
+}
+
+async function writeCompactedThreadContext(
+  args: CompactContextArgs,
+  sourceMessages: PiMessage[],
+  summary: string,
+  context: {
+    estimatedTokens: number;
+    triggerTokens?: number;
+  },
+): Promise<CompactContextResult> {
+  const replacement = buildReplacementHistory({
+    messages: trimTrailingAssistantMessages(sourceMessages),
+    summary,
+  });
+  const nextSessionId = createCompactionSessionId(args.previousSessionId);
+  await upsertAgentTurnSessionCheckpoint({
+    conversationId: args.conversationId,
+    sessionId: nextSessionId,
+    sliceId: 1,
+    state: "completed",
+    piMessages: replacement,
+  });
+
+  args.conversation.processing.lastSessionId = nextSessionId;
+  updateConversationStats(args.conversation);
+  setSpanAttributes({
+    "app.compaction.input_messages": sourceMessages.length,
+    "app.compaction.retained_messages": replacement.length - 1,
+    "app.compaction.summary_chars": summary.length,
+    "app.compaction.previous_session_id": args.previousSessionId,
+    "app.compaction.next_session_id": nextSessionId,
+    ...(context.triggerTokens !== undefined
+      ? { "app.compaction.trigger_tokens": context.triggerTokens }
+      : {}),
+    "app.context_tokens_estimated": context.estimatedTokens,
+  });
+
+  return {
+    compacted: true,
+    piMessages: replacement,
+    sessionId: nextSessionId,
+    summary,
+  };
+}
+
+/** Build the service that owns local context compaction and checkpoint forks. */
+export function createContextCompactor(
+  deps: ContextCompactorDeps,
+): ContextCompactor {
+  return {
+    compact: async (args) => await compactWithDeps(args, deps),
+    maybeCompact: async (args) => await maybeCompactWithDeps(args, deps),
+  };
+}

--- a/packages/junior/src/chat/services/context-compaction.ts
+++ b/packages/junior/src/chat/services/context-compaction.ts
@@ -1,3 +1,7 @@
+import {
+  estimateContextTokens,
+  estimateTokens,
+} from "@earendil-works/pi-agent-core";
 import { botConfig } from "@/chat/config";
 import type { completeText } from "@/chat/pi/client";
 import type { PiMessage } from "@/chat/pi/messages";
@@ -266,11 +270,13 @@ async function summarizeContext(
 }
 
 function estimateHistoryTokens(messages: PiMessage[]): number {
-  return stripRuntimeTurnContext(messages).reduce(
-    (total, message) =>
-      total + estimateTokenCount(sanitizeText(messageText(message))),
+  const stripped = stripRuntimeTurnContext(messages);
+  const usageEstimate = estimateContextTokens(stripped).tokens;
+  const structuralEstimate = stripped.reduce(
+    (total, message) => total + estimateTokens(message),
     0,
   );
+  return Math.max(usageEstimate, structuralEstimate);
 }
 
 function buildReplacementHistory(args: {

--- a/packages/junior/src/chat/services/conversation-memory.ts
+++ b/packages/junior/src/chat/services/conversation-memory.ts
@@ -7,10 +7,12 @@ import type {
 } from "@/chat/state/conversation";
 import { toOptionalString } from "@/chat/coerce";
 import { logWarn, setSpanAttributes } from "@/chat/logging";
+import {
+  calculateContextCompactionTargetTokens,
+  getConversationContextCompactionTriggerTokens,
+} from "@/chat/services/context-budget";
 import { escapeXml } from "@/chat/xml";
 
-const CONTEXT_COMPACTION_TRIGGER_TOKENS = 9000;
-const CONTEXT_COMPACTION_TARGET_TOKENS = 7000;
 const CONTEXT_MIN_LIVE_MESSAGES = 12;
 const CONTEXT_COMPACTION_BATCH_SIZE = 24;
 const CONTEXT_MAX_COMPACTIONS = 16;
@@ -373,8 +375,10 @@ async function compactConversationIfNeededWithDeps(
     "app.context_tokens_estimated": estimatedTokens,
   });
 
+  const triggerTokens = getConversationContextCompactionTriggerTokens();
+  const targetTokens = calculateContextCompactionTargetTokens(triggerTokens);
   while (
-    estimatedTokens > CONTEXT_COMPACTION_TRIGGER_TOKENS &&
+    estimatedTokens > triggerTokens &&
     conversation.messages.length > CONTEXT_MIN_LIVE_MESSAGES
   ) {
     const compactCount = Math.min(
@@ -406,10 +410,12 @@ async function compactConversationIfNeededWithDeps(
     estimatedTokens = conversation.stats.estimatedContextTokens;
     setSpanAttributes({
       "app.compaction_messages_covered": compactCount,
+      "app.compaction.trigger_tokens": triggerTokens,
+      "app.compaction.target_tokens": targetTokens,
       "app.context_tokens_estimated": estimatedTokens,
     });
 
-    if (estimatedTokens <= CONTEXT_COMPACTION_TARGET_TOKENS) {
+    if (estimatedTokens <= targetTokens) {
       break;
     }
   }

--- a/packages/junior/src/chat/services/conversation-memory.ts
+++ b/packages/junior/src/chat/services/conversation-memory.ts
@@ -9,6 +9,7 @@ import { toOptionalString } from "@/chat/coerce";
 import { logWarn, setSpanAttributes } from "@/chat/logging";
 import {
   calculateContextCompactionTargetTokens,
+  estimateTextTokens,
   getConversationContextCompactionTriggerTokens,
 } from "@/chat/services/context-budget";
 import { escapeXml } from "@/chat/xml";
@@ -43,10 +44,6 @@ export function generateConversationId(
 
 export function normalizeConversationText(text: string): string {
   return text.trim().replace(/\s+/g, " ").slice(0, CONTEXT_MAX_MESSAGE_CHARS);
-}
-
-function estimateTokenCount(text: string): number {
-  return Math.ceil(text.length / 4);
 }
 
 function buildImageContextSuffix(
@@ -97,7 +94,7 @@ export function updateConversationStats(
   conversation: ThreadConversationState,
 ): void {
   const contextText = buildConversationContext(conversation);
-  conversation.stats.estimatedContextTokens = estimateTokenCount(
+  conversation.stats.estimatedContextTokens = estimateTextTokens(
     contextText ?? "",
   );
   conversation.stats.totalMessageCount = conversation.messages.length;

--- a/packages/junior/src/chat/slack/assistant-thread/status-scheduler.ts
+++ b/packages/junior/src/chat/slack/assistant-thread/status-scheduler.ts
@@ -12,7 +12,7 @@ const STATUS_ROTATION_INTERVAL_MS = 30_000;
 export type TimerHandle = ReturnType<typeof setTimeout>;
 
 export interface AssistantStatusSession {
-  start: () => void;
+  start: (status?: AssistantStatusSpec) => void;
   stop: () => Promise<void>;
   update: (status: AssistantStatusSpec) => void;
 }
@@ -172,9 +172,13 @@ export function createAssistantStatusScheduler(args: {
   };
 
   return {
-    start() {
+    start(status?: AssistantStatusSpec) {
       active = true;
       clearPending();
+      if (status) {
+        void postRenderedStatus(status);
+        return;
+      }
       currentKey = "initial";
       void postStatus(getInitialStatusText(), loadingMessages);
     },

--- a/packages/junior/tests/integration/slack/message-content-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/message-content-behavior.test.ts
@@ -411,4 +411,92 @@ describe("Slack behavior: message content", () => {
       "old context is still relevant",
     );
   });
+
+  it("keeps active-turn Pi history instead of compacting older completed history", async () => {
+    const calls: CapturedCall[] = [];
+    const activeMessages: PiMessage[] = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "active checkpoint tool context" }],
+        timestamp: 3,
+      },
+    ] as PiMessage[];
+    const priorMessages: PiMessage[] = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "older context ".repeat(5_000) }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "older answer ".repeat(1_000) }],
+        timestamp: 2,
+      },
+    ] as PiMessage[];
+    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700005006.000" });
+    await upsertAgentTurnSessionCheckpoint({
+      conversationId: thread.id,
+      sessionId: "turn-older-completed",
+      sliceId: 1,
+      state: "completed",
+      piMessages: priorMessages,
+    });
+    await upsertAgentTurnSessionCheckpoint({
+      conversationId: thread.id,
+      sessionId: "turn-active-crashed",
+      sliceId: 1,
+      state: "running",
+      piMessages: activeMessages,
+    });
+    const conversation = coerceThreadConversationState({});
+    conversation.processing.activeTurnId = "turn-active-crashed";
+    conversation.processing.lastSessionId = "turn-older-completed";
+    await persistThreadState(thread, { conversation });
+
+    const { slackRuntime } = createTestChatRuntime({
+      services: {
+        contextCompactor: {
+          completeText: async () => {
+            throw new Error("active checkpoint history should not compact");
+          },
+          getAutoCompactionTriggerTokens: () => 100,
+        },
+        replyExecutor: {
+          generateAssistantReply: async (prompt, context) => {
+            calls.push({
+              prompt,
+              contextConversation: context?.conversationContext,
+              piMessages: context?.piMessages,
+            });
+            return {
+              text: "Done.",
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "fake-agent-model",
+                outcome: "success",
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            };
+          },
+        },
+      },
+    });
+
+    await slackRuntime.handleNewMention(
+      thread,
+      createTestMessage({
+        id: "m-content-active-checkpoint",
+        text: "<@U_APP> continue",
+        isMention: true,
+        threadId: thread.id,
+        author: { userId: "U_TESTER" },
+      }),
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.piMessages).toEqual(activeMessages);
+  });
 });

--- a/packages/junior/tests/integration/slack/message-content-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/message-content-behavior.test.ts
@@ -358,7 +358,7 @@ describe("Slack behavior: message content", () => {
     conversation.processing.lastSessionId = "turn-large-history";
     await persistThreadState(thread, { conversation });
 
-    const { slackRuntime } = createTestChatRuntime({
+    const { slackAdapter, slackRuntime } = createTestChatRuntime({
       services: {
         contextCompactor: {
           completeText: async () =>
@@ -403,6 +403,18 @@ describe("Slack behavior: message content", () => {
     );
 
     expect(calls).toHaveLength(1);
+    const compactingStatusIndex = slackAdapter.statusCalls.findIndex((call) =>
+      call.loadingMessages?.includes("Compacting context"),
+    );
+    expect(compactingStatusIndex).toBeGreaterThanOrEqual(0);
+    expect(
+      slackAdapter.statusCalls.findIndex(
+        (call, index) =>
+          index > compactingStatusIndex &&
+          Boolean(call.text) &&
+          !call.loadingMessages?.includes("Compacting context"),
+      ),
+    ).toBeGreaterThan(compactingStatusIndex);
     expect(calls[0]?.piMessages?.length).toBeLessThan(priorMessages.length + 1);
     expect(JSON.stringify(calls[0]?.piMessages)).toContain(
       "Context handoff summary",

--- a/packages/junior/tests/integration/slack/message-content-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/message-content-behavior.test.ts
@@ -365,7 +365,7 @@ describe("Slack behavior: message content", () => {
             ({
               text: "Compacted summary: old context is still relevant.",
             }) as never,
-          getAutoCompactionTriggerTokens: () => 100,
+          autoCompactionTriggerTokens: 100,
         },
         replyExecutor: {
           generateAssistantReply: async (prompt, context) => {
@@ -459,7 +459,7 @@ describe("Slack behavior: message content", () => {
           completeText: async () => {
             throw new Error("active checkpoint history should not compact");
           },
-          getAutoCompactionTriggerTokens: () => 100,
+          autoCompactionTriggerTokens: 100,
         },
         replyExecutor: {
           generateAssistantReply: async (prompt, context) => {

--- a/packages/junior/tests/integration/slack/message-content-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/message-content-behavior.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { PiMessage } from "@/chat/pi/messages";
 import {
   getPersistedThreadState,
+  persistThreadState,
   persistThreadStateById,
 } from "@/chat/runtime/thread-state";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
@@ -329,5 +330,85 @@ describe("Slack behavior: message content", () => {
     expect(calls).toHaveLength(2);
     expect(calls[1]?.contextConversation ?? "").toContain("budget by Friday");
     expect(calls[1]?.piMessages).toEqual(expectedHistory);
+  });
+
+  it("auto compacts oversized reusable Pi history before the next turn", async () => {
+    const calls: CapturedCall[] = [];
+    const priorMessages: PiMessage[] = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "old context ".repeat(5_000) }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "old answer ".repeat(1_000) }],
+        timestamp: 2,
+      },
+    ] as PiMessage[];
+    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700005005.000" });
+    await upsertAgentTurnSessionCheckpoint({
+      conversationId: thread.id,
+      sessionId: "turn-large-history",
+      sliceId: 1,
+      state: "completed",
+      piMessages: priorMessages,
+    });
+    const conversation = coerceThreadConversationState({});
+    conversation.processing.lastSessionId = "turn-large-history";
+    await persistThreadState(thread, { conversation });
+
+    const { slackRuntime } = createTestChatRuntime({
+      services: {
+        contextCompactor: {
+          completeText: async () =>
+            ({
+              text: "Compacted summary: old context is still relevant.",
+            }) as never,
+          getAutoCompactionTriggerTokens: () => 100,
+        },
+        replyExecutor: {
+          generateAssistantReply: async (prompt, context) => {
+            calls.push({
+              prompt,
+              contextConversation: context?.conversationContext,
+              piMessages: context?.piMessages,
+            });
+            return {
+              text: "Done.",
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "fake-agent-model",
+                outcome: "success",
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            };
+          },
+        },
+      },
+    });
+
+    await slackRuntime.handleNewMention(
+      thread,
+      createTestMessage({
+        id: "m-content-auto-compact",
+        text: "<@U_APP> continue",
+        isMention: true,
+        threadId: thread.id,
+        author: { userId: "U_TESTER" },
+      }),
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.piMessages?.length).toBeLessThan(priorMessages.length + 1);
+    expect(JSON.stringify(calls[0]?.piMessages)).toContain(
+      "Context handoff summary",
+    );
+    expect(JSON.stringify(calls[0]?.piMessages)).toContain(
+      "old context is still relevant",
+    );
   });
 });

--- a/packages/junior/tests/unit/config/chat-config.test.ts
+++ b/packages/junior/tests/unit/config/chat-config.test.ts
@@ -73,11 +73,9 @@ describe("chat config", () => {
 
   it("reads optional model context window overrides", async () => {
     process.env.AI_MODEL_CONTEXT_WINDOW_TOKENS = "200000";
-    process.env.AI_FAST_MODEL_CONTEXT_WINDOW_TOKENS = "100000";
 
     const { botConfig } = await loadConfig();
     expect(botConfig.modelContextWindowTokens).toBe(200000);
-    expect(botConfig.fastModelContextWindowTokens).toBe(100000);
   });
 
   it("throws when model context window overrides are invalid", async () => {

--- a/packages/junior/tests/unit/config/chat-config.test.ts
+++ b/packages/junior/tests/unit/config/chat-config.test.ts
@@ -71,6 +71,23 @@ describe("chat config", () => {
     expect(botConfig.visionModelId).toBe("openai/gpt-5.4");
   });
 
+  it("reads optional model context window overrides", async () => {
+    process.env.AI_MODEL_CONTEXT_WINDOW_TOKENS = "200000";
+    process.env.AI_FAST_MODEL_CONTEXT_WINDOW_TOKENS = "100000";
+
+    const { botConfig } = await loadConfig();
+    expect(botConfig.modelContextWindowTokens).toBe(200000);
+    expect(botConfig.fastModelContextWindowTokens).toBe(100000);
+  });
+
+  it("throws when model context window overrides are invalid", async () => {
+    process.env.AI_MODEL_CONTEXT_WINDOW_TOKENS = "0";
+
+    await expect(loadConfig()).rejects.toThrow(
+      "AI_MODEL_CONTEXT_WINDOW_TOKENS must be a positive integer",
+    );
+  });
+
   it("uses the default advisor config when AI_ADVISOR_MODEL is absent", async () => {
     delete process.env.AI_ADVISOR_MODEL;
 

--- a/packages/junior/tests/unit/services/context-compaction.test.ts
+++ b/packages/junior/tests/unit/services/context-compaction.test.ts
@@ -1,0 +1,289 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PiMessage } from "@/chat/pi/messages";
+
+const ORIGINAL_ENV = { ...process.env };
+
+function user(text: string, timestamp = 1): PiMessage {
+  return {
+    role: "user",
+    content: [{ type: "text", text }],
+    timestamp,
+  } as PiMessage;
+}
+
+function assistant(text: string, timestamp = 1): PiMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    timestamp,
+  } as PiMessage;
+}
+
+function textOf(message: PiMessage): string {
+  return (
+    (message as { content?: Array<{ text?: string }> }).content?.[0]?.text ?? ""
+  );
+}
+
+describe("context compaction retained messages", () => {
+  it("derives automatic trigger size from the model context window", async () => {
+    const {
+      calculateContextCompactionTargetTokens,
+      calculateContextCompactionTriggerTokens,
+    } = await import("@/chat/services/context-budget");
+
+    const miniTrigger = calculateContextCompactionTriggerTokens({
+      contextWindow: 400_000,
+      maxTokens: 128_000,
+    });
+    expect(miniTrigger).toBe(225_000);
+    expect(calculateContextCompactionTargetTokens(miniTrigger)).toBe(180_000);
+    expect(
+      calculateContextCompactionTriggerTokens({
+        contextWindow: 1_050_000,
+        maxTokens: 128_000,
+      }),
+    ).toBe(691_500);
+  });
+
+  it("uses configured model context windows for runtime thresholds", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      AI_MODEL: "openai/gpt-5.4",
+      AI_FAST_MODEL: "openai/gpt-5.4-mini",
+      AI_MODEL_CONTEXT_WINDOW_TOKENS: "200000",
+      AI_FAST_MODEL_CONTEXT_WINDOW_TOKENS: "100000",
+    };
+    vi.resetModules();
+    try {
+      const {
+        getAgentContextCompactionTriggerTokens,
+        getConversationContextCompactionTriggerTokens,
+      } = await import("@/chat/services/context-budget");
+
+      expect(getAgentContextCompactionTriggerTokens()).toBe(112_500);
+      expect(getConversationContextCompactionTriggerTokens()).toBe(56_250);
+    } finally {
+      process.env = { ...ORIGINAL_ENV };
+      vi.resetModules();
+    }
+  });
+
+  it("keeps newest eligible user messages in chronological order", async () => {
+    const { selectRetainedUserMessages } =
+      await import("@/chat/services/context-compaction");
+
+    const retained = selectRetainedUserMessages(
+      [
+        user("older message that should not fit", 1),
+        user("middle", 2),
+        assistant("assistant reply", 3),
+        user("<data_base64>raw-payload</data_base64>", 4),
+        user("recent", 5),
+      ],
+      4,
+    );
+
+    expect(retained.map(textOf)).toEqual(["middle", "recent"]);
+  });
+
+  it("strips stale runtime context before retaining user text", async () => {
+    const { selectRetainedUserMessages } =
+      await import("@/chat/services/context-compaction");
+
+    const retained = selectRetainedUserMessages([
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "<runtime-turn-context>\nstale\n</runtime-turn-context>",
+          },
+          { type: "text", text: "actual user request" },
+        ],
+        timestamp: 1,
+      } as PiMessage,
+    ]);
+
+    expect(retained.map(textOf)).toEqual(["actual user request"]);
+  });
+});
+
+describe("context compaction checkpoint fork", () => {
+  beforeEach(async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      JUNIOR_STATE_ADAPTER: "memory",
+    };
+    vi.resetModules();
+    const { disconnectStateAdapter } = await import("@/chat/state/adapter");
+    await disconnectStateAdapter();
+  });
+
+  afterEach(async () => {
+    const { disconnectStateAdapter } = await import("@/chat/state/adapter");
+    await disconnectStateAdapter();
+    vi.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it("internal compaction command creates a new checkpoint without rewriting the previous one", async () => {
+    const { createContextCompactor } =
+      await import("@/chat/services/context-compaction");
+    const { coerceThreadConversationState } =
+      await import("@/chat/state/conversation");
+    const { getAgentTurnSessionCheckpoint, upsertAgentTurnSessionCheckpoint } =
+      await import("@/chat/state/turn-session-store");
+
+    const priorMessages = [
+      user("Please remember the deploy blocker.", 1),
+      assistant("The blocker is missing migration approval.", 2),
+    ];
+    await upsertAgentTurnSessionCheckpoint({
+      conversationId: "conversation-1",
+      sessionId: "turn-1",
+      sliceId: 1,
+      state: "completed",
+      piMessages: priorMessages,
+    });
+    const conversation = coerceThreadConversationState({});
+    conversation.processing.lastSessionId = "turn-1";
+
+    const compactor = createContextCompactor({
+      completeText: async () =>
+        ({
+          text: "Outstanding ask: continue tracking migration approval.",
+        }) as never,
+    });
+
+    const result = await compactor.compact({
+      conversation,
+      conversationId: "conversation-1",
+      previousSessionId: "turn-1",
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(result.sessionId).toBe("compaction_turn-1");
+    expect(conversation.processing.lastSessionId).toBe(result.sessionId);
+
+    await expect(
+      getAgentTurnSessionCheckpoint("conversation-1", "turn-1"),
+    ).resolves.toMatchObject({
+      state: "completed",
+      piMessages: priorMessages,
+    });
+
+    const fork = await getAgentTurnSessionCheckpoint(
+      "conversation-1",
+      result.sessionId!,
+    );
+    expect(fork).toMatchObject({ state: "completed" });
+    expect(fork?.piMessages.map(textOf).join("\n")).toContain(
+      "Context handoff summary",
+    );
+    expect(fork?.piMessages.map(textOf).join("\n")).toContain(
+      "migration approval",
+    );
+  });
+
+  it("summarizes recent history when compaction input is oversized", async () => {
+    const { createContextCompactor } =
+      await import("@/chat/services/context-compaction");
+    const { coerceThreadConversationState } =
+      await import("@/chat/state/conversation");
+    const { upsertAgentTurnSessionCheckpoint } =
+      await import("@/chat/state/turn-session-store");
+
+    const priorMessages = [
+      ...Array.from({ length: 35 }, (_, index) =>
+        user(`old-${index.toString().padStart(2, "0")} ${"x".repeat(5_000)}`),
+      ),
+      user("recent-critical-marker keep the rollback plan"),
+    ];
+    await upsertAgentTurnSessionCheckpoint({
+      conversationId: "conversation-large",
+      sessionId: "turn-large",
+      sliceId: 1,
+      state: "completed",
+      piMessages: priorMessages,
+    });
+    const conversation = coerceThreadConversationState({});
+    conversation.processing.lastSessionId = "turn-large";
+    let capturedPrompt = "";
+    let capturedMessageAttributeMode: unknown;
+    const compactor = createContextCompactor({
+      completeText: async (params) => {
+        capturedPrompt = String(params.messages[0]?.content ?? "");
+        capturedMessageAttributeMode = params.messageAttributeMode;
+        return { text: "Summary keeps the rollback plan." } as never;
+      },
+    });
+
+    await compactor.compact({
+      conversation,
+      conversationId: "conversation-large",
+      previousSessionId: "turn-large",
+    });
+
+    expect(capturedMessageAttributeMode).toBe("metadata");
+    expect(capturedPrompt).toContain("[older context omitted]");
+    expect(capturedPrompt).not.toContain("old-00");
+    expect(capturedPrompt).toContain("recent-critical-marker");
+  });
+
+  it("does not compact checkpoints that are awaiting resume", async () => {
+    const { createContextCompactor } =
+      await import("@/chat/services/context-compaction");
+    const { coerceThreadConversationState } =
+      await import("@/chat/state/conversation");
+    const { upsertAgentTurnSessionCheckpoint } =
+      await import("@/chat/state/turn-session-store");
+
+    await upsertAgentTurnSessionCheckpoint({
+      conversationId: "conversation-2",
+      sessionId: "turn-awaiting",
+      sliceId: 2,
+      state: "awaiting_resume",
+      resumeReason: "timeout",
+      piMessages: [user("continue me")],
+    });
+    const conversation = coerceThreadConversationState({});
+    conversation.processing.lastSessionId = "turn-awaiting";
+    const compactor = createContextCompactor({
+      completeText: async () => ({ text: "should not run" }) as never,
+    });
+
+    await expect(
+      compactor.compact({
+        conversation,
+        conversationId: "conversation-2",
+        previousSessionId: "turn-awaiting",
+      }),
+    ).resolves.toEqual({ compacted: false, reason: "not_completed" });
+    expect(conversation.processing.lastSessionId).toBe("turn-awaiting");
+  });
+
+  it("does not compact when the checkpoint is missing", async () => {
+    const { createContextCompactor } =
+      await import("@/chat/services/context-compaction");
+    const { coerceThreadConversationState } =
+      await import("@/chat/state/conversation");
+
+    const completeText = vi.fn(async () => ({ text: "should not run" }));
+    const conversation = coerceThreadConversationState({});
+    conversation.processing.lastSessionId = "turn-missing";
+    const compactor = createContextCompactor({
+      completeText: completeText as never,
+    });
+
+    await expect(
+      compactor.compact({
+        conversation,
+        conversationId: "conversation-missing",
+        previousSessionId: "turn-missing",
+      }),
+    ).resolves.toEqual({ compacted: false, reason: "missing_context" });
+    expect(completeText).not.toHaveBeenCalled();
+    expect(conversation.processing.lastSessionId).toBe("turn-missing");
+  });
+});

--- a/packages/junior/tests/unit/services/context-compaction.test.ts
+++ b/packages/junior/tests/unit/services/context-compaction.test.ts
@@ -132,7 +132,7 @@ describe("context compaction checkpoint fork", () => {
     process.env = { ...ORIGINAL_ENV };
   });
 
-  it("internal compaction command creates a new checkpoint without rewriting the previous one", async () => {
+  it("automatic compaction creates a new checkpoint without rewriting the previous one", async () => {
     const { createContextCompactor } =
       await import("@/chat/services/context-compaction");
     const { coerceThreadConversationState } =
@@ -159,9 +159,10 @@ describe("context compaction checkpoint fork", () => {
         ({
           text: "Outstanding ask: continue tracking migration approval.",
         }) as never,
+      autoCompactionTriggerTokens: 0,
     });
 
-    const result = await compactor.compact({
+    const result = await compactor.maybeCompact({
       conversation,
       conversationId: "conversation-1",
       previousSessionId: "turn-1",
@@ -222,9 +223,10 @@ describe("context compaction checkpoint fork", () => {
         capturedMessageAttributeMode = params.messageAttributeMode;
         return { text: "Summary keeps the rollback plan." } as never;
       },
+      autoCompactionTriggerTokens: 0,
     });
 
-    await compactor.compact({
+    await compactor.maybeCompact({
       conversation,
       conversationId: "conversation-large",
       previousSessionId: "turn-large",
@@ -290,7 +292,7 @@ describe("context compaction checkpoint fork", () => {
         summarized = true;
         return { text: "Tool context was compacted." } as never;
       },
-      getAutoCompactionTriggerTokens: () => 1,
+      autoCompactionTriggerTokens: 1,
     });
 
     const result = await compactor.maybeCompact({
@@ -326,7 +328,7 @@ describe("context compaction checkpoint fork", () => {
     });
 
     await expect(
-      compactor.compact({
+      compactor.maybeCompact({
         conversation,
         conversationId: "conversation-2",
         previousSessionId: "turn-awaiting",
@@ -349,7 +351,7 @@ describe("context compaction checkpoint fork", () => {
     });
 
     await expect(
-      compactor.compact({
+      compactor.maybeCompact({
         conversation,
         conversationId: "conversation-missing",
         previousSessionId: "turn-missing",

--- a/packages/junior/tests/unit/services/context-compaction.test.ts
+++ b/packages/junior/tests/unit/services/context-compaction.test.ts
@@ -52,17 +52,22 @@ describe("context compaction retained messages", () => {
       AI_MODEL: "openai/gpt-5.4",
       AI_FAST_MODEL: "openai/gpt-5.4-mini",
       AI_MODEL_CONTEXT_WINDOW_TOKENS: "200000",
-      AI_FAST_MODEL_CONTEXT_WINDOW_TOKENS: "100000",
     };
     vi.resetModules();
     try {
       const {
+        calculateContextCompactionTriggerTokens,
         getAgentContextCompactionTriggerTokens,
         getConversationContextCompactionTriggerTokens,
       } = await import("@/chat/services/context-budget");
+      const { resolveGatewayModel } = await import("@/chat/pi/client");
 
       expect(getAgentContextCompactionTriggerTokens()).toBe(112_500);
-      expect(getConversationContextCompactionTriggerTokens()).toBe(56_250);
+      expect(getConversationContextCompactionTriggerTokens()).toBe(
+        calculateContextCompactionTriggerTokens(
+          resolveGatewayModel("openai/gpt-5.4-mini"),
+        ),
+      );
     } finally {
       process.env = { ...ORIGINAL_ENV };
       vi.resetModules();

--- a/packages/junior/tests/unit/services/context-compaction.test.ts
+++ b/packages/junior/tests/unit/services/context-compaction.test.ts
@@ -236,6 +236,73 @@ describe("context compaction checkpoint fork", () => {
     expect(capturedPrompt).toContain("recent-critical-marker");
   });
 
+  it("counts structured tool context when deciding whether to compact", async () => {
+    const { createContextCompactor } =
+      await import("@/chat/services/context-compaction");
+    const { coerceThreadConversationState } =
+      await import("@/chat/state/conversation");
+    const { upsertAgentTurnSessionCheckpoint } =
+      await import("@/chat/state/turn-session-store");
+
+    await upsertAgentTurnSessionCheckpoint({
+      conversationId: "conversation-tool-context",
+      sessionId: "turn-tool-context",
+      sliceId: 1,
+      state: "completed",
+      piMessages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "tool-call-1",
+              name: "readFile",
+              arguments: { path: "src/large-file.ts", limit: 10_000 },
+            },
+          ],
+          api: "openai-responses",
+          provider: "openai",
+          model: "test-model",
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            cost: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              total: 0,
+            },
+          },
+          stopReason: "toolUse",
+          timestamp: 1,
+        },
+      ] as PiMessage[],
+    });
+    const conversation = coerceThreadConversationState({});
+    conversation.processing.lastSessionId = "turn-tool-context";
+    let summarized = false;
+    const compactor = createContextCompactor({
+      completeText: async () => {
+        summarized = true;
+        return { text: "Tool context was compacted." } as never;
+      },
+      getAutoCompactionTriggerTokens: () => 1,
+    });
+
+    const result = await compactor.maybeCompact({
+      conversation,
+      conversationId: "conversation-tool-context",
+      previousSessionId: "turn-tool-context",
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(summarized).toBe(true);
+  });
+
   it("does not compact checkpoints that are awaiting resume", async () => {
     const { createContextCompactor } =
       await import("@/chat/services/context-compaction");

--- a/specs/context-compaction.md
+++ b/specs/context-compaction.md
@@ -12,7 +12,6 @@ Define how Junior bounds long-running conversation context by replacing reusable
 ## Scope
 
 - Pre-turn compaction of reusable Pi history loaded from completed turn checkpoints.
-- Internal compaction command that can fork reusable completed context for future orchestration flows.
 - Visible Slack conversation-state compaction used for routing, thinking selection, and no-Pi-history prompt background.
 - Summary shape, retained-message selection, persistence boundaries, and verification requirements.
 
@@ -20,6 +19,7 @@ Define how Junior bounds long-running conversation context by replacing reusable
 
 - Remote or server-side compaction endpoints. Junior owns all summarization, retained-message selection, replacement construction, persistence, and triggers locally.
 - User-facing compaction commands, slash commands, or model tools.
+- Manual or forced compaction APIs. Future model-handoff orchestration can add a small internal caller when that flow exists.
 - Mid-turn compaction while an agent turn is actively generating.
 - Compaction of `awaiting_resume` timeout or auth checkpoints.
 - Rewriting partially visible Slack assistant output.
@@ -77,16 +77,11 @@ Eligible retained messages must be user-authored semantic input. They must not i
 - tool results
 - assistant messages
 
-### Internal Context Fork
+### Compaction Checkpoints
 
-The internal compaction command creates a compacted checkpoint whenever an orchestration strategy calls it. No Slack message, slash command, or model tool currently invokes it. It must:
+Compaction persists replacement history as a new synthetic completed session. It must update `conversation.processing.lastSessionId` only after the replacement checkpoint is committed.
 
-1. Load the current reusable completed Pi history and persisted Slack conversation state.
-2. Summarize and compact them into replacement Pi history.
-3. Persist the replacement as a new synthetic completed compaction session.
-4. Update `conversation.processing.lastSessionId` to the new compaction session only after the replacement checkpoint is committed.
-
-The internal compaction command must not destructively rewrite the previous completed checkpoint. Keeping the pre-compaction checkpoint available preserves auditability and avoids corrupting any recovery path.
+Compaction must not destructively rewrite the previous completed checkpoint. Keeping the pre-compaction checkpoint available preserves auditability and avoids corrupting any recovery path.
 
 Compaction checkpoints must use a deterministic synthetic session id derived from the source checkpoint or an explicit idempotency key. Retried automatic compaction must not create an unbounded chain of duplicate compaction checkpoints for the same source session.
 
@@ -119,17 +114,16 @@ Cumulative turn token usage must not be the only trigger input because multi-ste
 
 ### Initial Context
 
-Pre-turn and internal compaction do not store current runtime context in compacted history. The next turn reinjects base instructions and volatile runtime context through the normal prompt path.
+Pre-turn compaction does not store current runtime context in compacted history. The next turn reinjects base instructions and volatile runtime context through the normal prompt path.
 
 If Junior later adds mid-turn compaction, that path must define a separate insertion rule for current runtime context before the last real user message and must prove Pi `continue()` still resumes correctly.
 
 ## Failure Model
 
 1. If summarization fails during automatic pre-turn compaction, Junior must continue with the prior reusable history unless the model provider has already rejected the prompt as too large.
-2. If internal compaction summarization fails, Junior must leave `lastSessionId` unchanged and return the error to the orchestration caller.
-3. If replacement checkpoint persistence fails, Junior must not update `lastSessionId`.
-4. If compaction is requested while `activeTurnId` points at an awaiting resume checkpoint, Junior must refuse or defer compaction rather than compacting the resumable checkpoint.
-5. If retained-message selection cannot parse a message shape, Junior must omit that message from retained verbatim history and rely on the handoff summary.
+2. If replacement checkpoint persistence fails, Junior must not update `lastSessionId`.
+3. If compaction is requested while `activeTurnId` points at an awaiting resume checkpoint, Junior must refuse or defer compaction rather than compacting the resumable checkpoint.
+4. If retained-message selection cannot parse a message shape, Junior must omit that message from retained verbatim history and rely on the handoff summary.
 
 ## Observability
 
@@ -155,7 +149,7 @@ Compaction model calls may send selected history to the model provider, but trac
 
 1. Unit: retained-message selection keeps newest eligible user messages within budget and preserves chronological order.
 2. Unit: replacement history excludes runtime context, assistant messages, tool results, image/base64 payloads, and existing compaction summaries.
-3. Unit: internal compaction creates a new completed checkpoint and does not rewrite the prior completed checkpoint.
+3. Unit: automatic compaction creates a new completed checkpoint and does not rewrite the prior completed checkpoint.
 4. Integration: a long Slack thread with reusable Pi history uses compacted Pi history on the next turn.
 5. Integration: compaction is skipped or rejected while an awaiting timeout/auth resume checkpoint is active.
 6. Eval: long-thread continuity after compaction when the expected outcome depends on model interpretation.

--- a/specs/context-compaction.md
+++ b/specs/context-compaction.md
@@ -1,0 +1,169 @@
+# Context Compaction Spec
+
+## Metadata
+
+- Created: 2026-05-28
+- Last Edited: 2026-05-28
+
+## Purpose
+
+Define how Junior bounds long-running conversation context by replacing reusable model history with a compacted handoff while preserving enough user-authored context for future turns.
+
+## Scope
+
+- Pre-turn compaction of reusable Pi history loaded from completed turn checkpoints.
+- Internal compaction command that can fork reusable completed context for future orchestration flows.
+- Visible Slack conversation-state compaction used for routing, thinking selection, and no-Pi-history prompt background.
+- Summary shape, retained-message selection, persistence boundaries, and verification requirements.
+
+## Non-Goals
+
+- Remote or server-side compaction endpoints. Junior owns all summarization, retained-message selection, replacement construction, persistence, and triggers locally.
+- User-facing compaction commands, slash commands, or model tools.
+- Mid-turn compaction while an agent turn is actively generating.
+- Compaction of `awaiting_resume` timeout or auth checkpoints.
+- Rewriting partially visible Slack assistant output.
+- Replacing the timeout/auth resume contract in `./agent-session-resumability.md`.
+
+## Contracts
+
+### Context Authorities
+
+Junior has two different context authorities:
+
+1. Durable Pi history in turn-session checkpoints. This is the model history reused by fresh turns when `conversation.processing.lastSessionId` points at a completed checkpoint.
+2. Persisted Slack conversation state. This is the visible thread transcript used for routing, thinking selection, assistant titles, and prompt background when no reusable Pi history exists.
+
+Compaction must treat these as separate surfaces. Shrinking Slack conversation state does not shrink model history once fresh turns are seeded from Pi checkpoints.
+
+### Pi History Compaction
+
+Pre-turn Pi compaction runs only for fresh turns and only against reusable completed checkpoint history. It must not compact:
+
+- `awaiting_resume` checkpoints
+- active timeout/auth resume sessions
+- checkpoints that need `continue()` semantics
+- partial assistant-only tails that have not reached final Slack delivery
+
+When compaction is required, Junior creates a replacement Pi history from:
+
+1. recent real user-authored messages up to the retained-message budget
+2. one synthetic user-role handoff summary
+
+The replacement history must exclude stale runtime turn context, old capability catalogs, raw image/base64 payloads, and unbounded tool output. Runtime turn context is injected again on the next actual turn by `buildTurnContextPrompt(...)`.
+
+### Handoff Summary
+
+The summary prompt must produce a concise handoff for another model continuing the same thread. It must ask for:
+
+- current outstanding asks
+- important decisions, outcomes, and completed work
+- durable context, constraints, preferences, identifiers, URLs, artifacts, canvas links, sandbox references, and auth state
+- clear next steps and unresolved blockers
+
+The summary must be stored as one model-visible handoff item, not as an accumulating log of compaction records.
+
+When summary input must be bounded before calling the summarizer, Junior must omit older context before newer context. Recent Pi history is the most important source for continuation, so truncation must preserve the tail of the reusable history rather than blindly taking the first bytes of the checkpoint.
+
+### Retained User Messages
+
+Retained user messages are selected newest-first until the retained-message token budget is exhausted, then restored to chronological order. If the newest eligible user message exceeds the remaining budget, Junior may truncate the text to fit rather than dropping all recent user wording.
+
+Eligible retained messages must be user-authored semantic input. They must not include:
+
+- synthetic runtime context blocks
+- compaction handoff summaries
+- non-text image bytes or attachment base64
+- tool results
+- assistant messages
+
+### Internal Context Fork
+
+The internal compaction command creates a compacted checkpoint whenever an orchestration strategy calls it. No Slack message, slash command, or model tool currently invokes it. It must:
+
+1. Load the current reusable completed Pi history and persisted Slack conversation state.
+2. Summarize and compact them into replacement Pi history.
+3. Persist the replacement as a new synthetic completed compaction session.
+4. Update `conversation.processing.lastSessionId` to the new compaction session only after the replacement checkpoint is committed.
+
+The internal compaction command must not destructively rewrite the previous completed checkpoint. Keeping the pre-compaction checkpoint available preserves auditability and avoids corrupting any recovery path.
+
+Compaction checkpoints must use a deterministic synthetic session id derived from the source checkpoint or an explicit idempotency key. Retried automatic compaction must not create an unbounded chain of duplicate compaction checkpoints for the same source session.
+
+### Automatic Pre-Turn Compaction
+
+Automatic pre-turn compaction may replace an oversized reusable completed checkpoint before the next agent turn starts. It must:
+
+1. Run after reusable Pi history is loaded.
+2. Finish before `generateAssistantReply(...)` receives `piMessages`.
+3. Use the compacted replacement history for the upcoming turn.
+4. Persist the compacted session and update `conversation.processing.lastSessionId` before final thread-state persistence for the turn.
+
+Automatic compaction must not post Slack-visible progress by itself. Normal turn status and final reply delivery remain owned by the Slack runtime.
+
+### Visible Conversation-State Compaction
+
+Slack conversation-state compaction must keep routing and no-Pi-history background bounded. It may retain bounded chunk summaries plus recent visible messages, but it must prune or merge older summaries rather than accumulating an unbounded XML log.
+
+Visible conversation-state compaction must preserve image analysis summaries and message metadata needed for later explicit mentions to reason about earlier attachments.
+
+### Token Accounting
+
+Automatic Pi-history compaction must derive its threshold from the active agent model's advertised context window. Visible Slack conversation-state compaction must use the same budget rule against the fast model because routing and summary calls use that model family. Junior reserves output headroom, then triggers when estimated reusable history exceeds the configured share of the remaining input budget.
+
+Pi model metadata is the default source of `contextWindow` and `maxTokens`. `AI_MODEL_CONTEXT_WINDOW_TOKENS` and `AI_FAST_MODEL_CONTEXT_WINDOW_TOKENS` may override the advertised context windows when provider metadata is missing, stale, or intentionally constrained for operations.
+
+Compaction triggers should prefer server-reported input-token counts for the most recent or largest single model call when available. Character-based estimates are allowed only as a fallback.
+
+Cumulative turn token usage must not be the only trigger input because multi-step/tool-heavy turns can sum multiple model calls and overstate the next prompt size.
+
+### Initial Context
+
+Pre-turn and internal compaction do not store current runtime context in compacted history. The next turn reinjects base instructions and volatile runtime context through the normal prompt path.
+
+If Junior later adds mid-turn compaction, that path must define a separate insertion rule for current runtime context before the last real user message and must prove Pi `continue()` still resumes correctly.
+
+## Failure Model
+
+1. If summarization fails during automatic pre-turn compaction, Junior must continue with the prior reusable history unless the model provider has already rejected the prompt as too large.
+2. If internal compaction summarization fails, Junior must leave `lastSessionId` unchanged and return the error to the orchestration caller.
+3. If replacement checkpoint persistence fails, Junior must not update `lastSessionId`.
+4. If compaction is requested while `activeTurnId` points at an awaiting resume checkpoint, Junior must refuse or defer compaction rather than compacting the resumable checkpoint.
+5. If retained-message selection cannot parse a message shape, Junior must omit that message from retained verbatim history and rely on the handoff summary.
+
+## Observability
+
+Compaction events should emit structured attributes when available:
+
+- `app.compaction.input_messages`
+- `app.compaction.retained_messages`
+- `app.compaction.summary_chars`
+- `app.compaction.previous_session_id`
+- `app.compaction.next_session_id`
+- `app.compaction.trigger_tokens`
+- `app.compaction.target_tokens`
+- `app.context_tokens_estimated`
+- `gen_ai.request.model`
+- `gen_ai.usage.input_tokens`
+- `gen_ai.usage.output_tokens`
+
+Logs and spans must not include raw OAuth tokens, provider credentials, raw private file bytes, raw image base64, or unredacted secret-bearing tool output.
+
+Compaction model calls may send selected history to the model provider, but tracing for those calls must capture message metadata rather than raw prompt or summary text. Model id, duration, finish reason, and token usage remain observable.
+
+## Verification
+
+1. Unit: retained-message selection keeps newest eligible user messages within budget and preserves chronological order.
+2. Unit: replacement history excludes runtime context, assistant messages, tool results, image/base64 payloads, and existing compaction summaries.
+3. Unit: internal compaction creates a new completed checkpoint and does not rewrite the prior completed checkpoint.
+4. Integration: a long Slack thread with reusable Pi history uses compacted Pi history on the next turn.
+5. Integration: compaction is skipped or rejected while an awaiting timeout/auth resume checkpoint is active.
+6. Eval: long-thread continuity after compaction when the expected outcome depends on model interpretation.
+
+## Related Specs
+
+- `./chat-architecture.md`
+- `./agent-session-resumability.md`
+- `./agent-prompt.md`
+- `./slack-agent-delivery.md`
+- `./testing.md`

--- a/specs/context-compaction.md
+++ b/specs/context-compaction.md
@@ -93,8 +93,9 @@ Automatic pre-turn compaction may replace an oversized reusable completed checkp
 2. Finish before `generateAssistantReply(...)` receives `piMessages`.
 3. Use the compacted replacement history for the upcoming turn.
 4. Persist the compacted session and update `conversation.processing.lastSessionId` before final thread-state persistence for the turn.
+5. Start explicit assistant progress after the threshold decision and before summarization when a status surface is available, then return to the normal turn status before agent execution.
 
-Automatic compaction must not post Slack-visible progress by itself. Normal turn status and final reply delivery remain owned by the Slack runtime.
+Automatic compaction must not post Slack thread messages by itself. Assistant status and final reply delivery remain owned by the Slack runtime.
 
 ### Visible Conversation-State Compaction
 

--- a/specs/context-compaction.md
+++ b/specs/context-compaction.md
@@ -109,9 +109,9 @@ Visible conversation-state compaction must preserve image analysis summaries and
 
 ### Token Accounting
 
-Automatic Pi-history compaction must derive its threshold from the active agent model's advertised context window. Visible Slack conversation-state compaction must use the same budget rule against the fast model because routing and summary calls use that model family. Junior reserves output headroom, then triggers when estimated reusable history exceeds the configured share of the remaining input budget.
+Automatic Pi-history compaction must derive its threshold from the active agent model's advertised context window. Visible Slack conversation-state compaction must use the same budget rule against the auxiliary model because routing and summary calls use that model family. Junior reserves output headroom, then triggers when estimated reusable history exceeds the configured share of the remaining input budget.
 
-Pi model metadata is the default source of `contextWindow` and `maxTokens`. `AI_MODEL_CONTEXT_WINDOW_TOKENS` and `AI_FAST_MODEL_CONTEXT_WINDOW_TOKENS` may override the advertised context windows when provider metadata is missing, stale, or intentionally constrained for operations.
+Pi model metadata is the default source of `contextWindow` and `maxTokens`. `AI_MODEL_CONTEXT_WINDOW_TOKENS` may override the active agent model's advertised context window when provider metadata is missing, stale, or intentionally constrained for operations. The auxiliary model context window must come from model metadata.
 
 Compaction triggers should prefer server-reported input-token counts for the most recent or largest single model call when available. Character-based estimates are allowed only as a fallback.
 

--- a/specs/index.md
+++ b/specs/index.md
@@ -35,6 +35,7 @@ Define spec taxonomy, naming conventions, and canonical source-of-truth document
 - `specs/credential-injection.md`
 - `specs/oauth-flows.md`
 - `specs/agent-prompt.md`
+- `specs/context-compaction.md`
 - `specs/advisor-tool.md`
 - `specs/scheduler.md`
 - `specs/trusted-plugin-heartbeat.md`
@@ -66,6 +67,7 @@ For chat/agent/Slack turn behavior:
 - `specs/harness-agent.md` owns the Pi agent turn runtime contract, final output resolution, and turn diagnostics.
 - `specs/harness-tool-context.md` owns context-bound tool targeting and missing-context failure behavior.
 - `specs/agent-session-resumability.md` owns checkpoint schema, Pi session continuation, timeout callbacks, and slice lifecycle.
+- `specs/context-compaction.md` owns reusable Pi history compaction, internal context forks, and visible-thread compaction bounds.
 - `specs/slack-agent-delivery.md` owns Slack entry surfaces, progress UX, continuation acknowledgements, and final reply delivery.
 - `specs/slack-outbound-contract.md` owns Slack API write formatting, file uploads, reactions, retries, and error mapping.
 

--- a/specs/slack-agent-delivery.md
+++ b/specs/slack-agent-delivery.md
@@ -94,6 +94,7 @@ Current contract:
 10. When Junior has an explicit `reportProgress` update, it must replace the generic `loading_messages` rotation for that status update. Explicit progress owns the loading surface until another status update replaces it or the turn ends.
 11. While a turn is active, Junior uses a stable generic `status` string for Slack's assistant loading state and changes the user-visible progress copy through `loading_messages`.
 12. Final reply footer metadata is not part of the in-flight loading contract. Footer blocks, when present, belong only to the finalized reply artifact.
+13. If automatic pre-turn compaction is needed, Junior must show explicit compaction progress before the compaction LLM call and return to normal turn status before agent execution begins.
 
 Status is the only in-flight progress surface required by the contract. Visible assistant reply text is posted only after the turn result is finalized and delivery has been planned.
 


### PR DESCRIPTION
Add local context compaction for completed Pi checkpoints so long Slack threads keep bounded model history without a user-facing or manual compaction command. Junior summarizes reusable history locally, preserves recent user-authored context, and forks a synthetic completed checkpoint before the next turn uses it.

**Before / After**

Before, fresh turns reused raw completed checkpoint history until they approached the provider context limit. Conversation-state compaction used small fixed thresholds, and there was no local LLM pass to replace oversized Pi history with a bounded handoff.

After, fresh turns compact only reusable completed checkpoints when estimated history exceeds a model-window-derived threshold. Junior shows assistant progress while the compaction LLM pass runs, retains recent user messages, stores a deterministic synthetic checkpoint, and passes that replacement Pi history into the agent.

**Compactor Contract**

The current service exposes only `maybeCompact(...)`; there is no manual, forced, slash-command, or tool-exposed compaction path. Test overrides use a plain numeric `autoCompactionTriggerTokens` value, while production thresholds come from active model metadata plus the primary `AI_MODEL_CONTEXT_WINDOW_TOKENS` override when needed. Auxiliary-model visible conversation budgets use model registry metadata directly; there is no auxiliary context-window env override.

**Compaction Safety**

The compactor refuses resumable checkpoints, avoids active crash-recovery history, counts structured Pi content such as tool calls and tool results when estimating trigger size, and captures only metadata attributes for compaction model calls.

Refs #431
