### PR TITLE
fix(sandbox): Handle interrupted file tool streams

### DIFF
--- a/packages/junior/src/chat/sandbox/sandbox.ts
+++ b/packages/junior/src/chat/sandbox/sandbox.ts
@@ -11,7 +11,10 @@ import {
   resolveSandboxCommandEnvironment,
 } from "@/chat/sandbox/egress-policy";
 import { createSandboxEgressRequesterToken } from "@/chat/sandbox/egress-session";
-import { throwSandboxOperationError } from "@/chat/sandbox/errors";
+import {
+  isSandboxCommandStreamInterruptedError,
+  throwSandboxOperationError,
+} from "@/chat/sandbox/errors";
 import { SANDBOX_WORKSPACE_ROOT } from "@/chat/sandbox/paths";
 import { createSandboxSessionManager } from "@/chat/sandbox/session";
 import type { AgentPluginHookRunner } from "@/chat/plugins/agent-hooks";
@@ -98,6 +101,22 @@ function parseEnv(raw: unknown): Record<string, string> | undefined {
       .filter(([, value]) => typeof value === "string")
       .map(([key, value]) => [key, value as string]),
   );
+}
+
+function sandboxStreamInterruptedResult(toolName: string) {
+  return {
+    content: [
+      {
+        type: "text",
+        text: `Sandbox command stream was interrupted during ${toolName}. The operation did not complete reliably. It may have produced side effects; inspect the workspace or retry only if it is safe.`,
+      },
+    ],
+    details: {
+      ok: false,
+      error: "stream_interrupted",
+      tool: toolName,
+    },
+  };
 }
 
 /** Create one sandbox-backed tool executor facade for the current turn. */
@@ -538,28 +557,35 @@ export function createSandboxExecutor(options?: {
       return await executeBashTool(rawInput, bashCommand);
     }
 
-    if (params.toolName === "readFile") {
-      return await executeReadFileTool(rawInput);
-    }
+    try {
+      if (params.toolName === "readFile") {
+        return await executeReadFileTool(rawInput);
+      }
 
-    if (params.toolName === "editFile") {
-      return await executeEditFileTool(rawInput);
-    }
+      if (params.toolName === "editFile") {
+        return await executeEditFileTool(rawInput);
+      }
 
-    if (params.toolName === "grep") {
-      return await executeGrepTool(rawInput);
-    }
+      if (params.toolName === "grep") {
+        return await executeGrepTool(rawInput);
+      }
 
-    if (params.toolName === "findFiles") {
-      return await executeFindFilesTool(rawInput);
-    }
+      if (params.toolName === "findFiles") {
+        return await executeFindFilesTool(rawInput);
+      }
 
-    if (params.toolName === "listDir") {
-      return await executeListDirTool(rawInput);
-    }
+      if (params.toolName === "listDir") {
+        return await executeListDirTool(rawInput);
+      }
 
-    if (params.toolName === "writeFile") {
-      return await executeWriteFileTool(rawInput);
+      if (params.toolName === "writeFile") {
+        return await executeWriteFileTool(rawInput);
+      }
+    } catch (error) {
+      if (!isSandboxCommandStreamInterruptedError(error)) {
+        throw error;
+      }
+      return { result: sandboxStreamInterruptedResult(params.toolName) as T };
     }
 
     throw new Error(`unsupported sandbox tool: ${params.toolName}`);

--- a/packages/junior/tests/unit/misc/sandbox-executor.test.ts
+++ b/packages/junior/tests/unit/misc/sandbox-executor.test.ts
@@ -199,6 +199,12 @@ function createApiError(
   });
 }
 
+function createStreamInterruptedError(): Error {
+  return Object.assign(new Error("Stream ended before command finished"), {
+    name: "StreamError",
+  });
+}
+
 async function expectWorkspaceToDelegate(
   workspace: SandboxInstance,
   sandbox: MockSandbox,
@@ -764,10 +770,7 @@ describe("createSandboxExecutor", () => {
   });
 
   it("returns a failed bash result when the command stream ends without a status", async () => {
-    const streamError = Object.assign(
-      new Error("Stream ended before command finished"),
-      { name: "StreamError" },
-    );
+    const streamError = createStreamInterruptedError();
     const sandbox = makeSandbox("sbx_stream_interrupted");
     sandbox.runCommand.mockRejectedValueOnce(streamError);
     sandboxGetMock.mockResolvedValue(sandbox);
@@ -795,6 +798,72 @@ describe("createSandboxExecutor", () => {
       exit_code: 125,
       stderr:
         "Command stream ended before the command finished. The command may still have produced side effects; inspect the workspace or rerun only if it is safe.",
+    });
+  });
+
+  it("returns structured file-tool results when sandbox command streams end", async () => {
+    const sandbox = makeSandbox("sbx_find_files_interrupted");
+    sandbox.fs.stat.mockRejectedValueOnce(createStreamInterruptedError());
+    sandboxCreateMock.mockResolvedValueOnce(sandbox);
+    vi.mocked(createBashTool).mockResolvedValueOnce({
+      tools: {
+        readFile: { execute: vi.fn(async () => ({ content: "" })) },
+        writeFile: { execute: vi.fn(async () => ({ success: true })) },
+      },
+    } as never);
+
+    const executor = createSandboxExecutor();
+    executor.configureSkills([]);
+
+    const response = await executor.execute({
+      toolName: "findFiles",
+      input: { pattern: "*.ts" },
+    });
+
+    expect(response.result).toMatchObject({
+      content: [
+        {
+          type: "text",
+          text: expect.stringContaining(
+            "Sandbox command stream was interrupted during findFiles",
+          ),
+        },
+      ],
+      details: {
+        ok: false,
+        error: "stream_interrupted",
+        tool: "findFiles",
+      },
+    });
+  });
+
+  it("recognizes stream interruptions wrapped by writeFile errors", async () => {
+    const sandbox = makeSandbox("sbx_write_file_interrupted");
+    const writeFileExecute = vi.fn(async () => {
+      throw createStreamInterruptedError();
+    });
+    sandboxCreateMock.mockResolvedValueOnce(sandbox);
+    vi.mocked(createBashTool).mockResolvedValueOnce({
+      tools: {
+        readFile: { execute: vi.fn(async () => ({ content: "" })) },
+        writeFile: { execute: writeFileExecute },
+      },
+    } as never);
+
+    const executor = createSandboxExecutor();
+    executor.configureSkills([]);
+
+    const response = await executor.execute({
+      toolName: "writeFile",
+      input: { path: "file.ts", content: "new content" },
+    });
+
+    expect(response.result).toMatchObject({
+      details: {
+        ok: false,
+        error: "stream_interrupted",
+        tool: "writeFile",
+      },
     });
   });
 


### PR DESCRIPTION
Sandbox filesystem tools now return a structured failed tool result when Vercel reports a command stream interruption during filesystem-backed work. This keeps the turn alive and gives the model enough context to decide whether a retry is safe.

**Filesystem Tool Recovery**

The sandbox executor catches the known stream interruption around file-tool dispatch only, leaving bash and unrelated failures on their existing paths.

Fixes #434