### PR TITLE
fix(sandbox): Serialize sandbox setup

### DIFF
--- a/packages/junior-github/index.js
+++ b/packages/junior-github/index.js
@@ -96,12 +96,10 @@ export function githubPlugin(options = {}) {
           mode: 0o755,
           content: prepareCommitMsgHook(),
         });
-        await Promise.all([
-          configureGit(ctx, "core.hooksPath", hooksPath),
-          configureGit(ctx, "commit.gpgsign", "false"),
-          configureGit(ctx, "credential.helper", ""),
-          configureGit(ctx, "http.emptyAuth", "true"),
-        ]);
+        await configureGit(ctx, "core.hooksPath", hooksPath);
+        await configureGit(ctx, "commit.gpgsign", "false");
+        await configureGit(ctx, "credential.helper", "");
+        await configureGit(ctx, "http.emptyAuth", "true");
       },
       beforeToolExecute(ctx) {
         if (ctx.tool.name !== "bash") {

--- a/packages/junior/src/chat/sandbox/session.ts
+++ b/packages/junior/src/chat/sandbox/session.ts
@@ -170,8 +170,10 @@ export function createSandboxSessionManager(options?: {
   let availableSkills: SkillMetadata[] = [];
   let availableReferenceFiles: string[] = [];
   let toolExecutors: SandboxToolExecutors | undefined;
+  let loadingToolExecutors: Promise<SandboxToolExecutors> | undefined;
   let appliedNetworkPolicyKey: string | undefined;
   let preparedSandboxId: string | undefined;
+  let acquiringSandbox: Promise<SandboxInstance> | undefined;
 
   const timeoutMs = options?.timeoutMs ?? 1000 * 60 * 30;
   const traceContext = options?.traceContext ?? {};
@@ -191,6 +193,7 @@ export function createSandboxSessionManager(options?: {
     sandbox = null;
     sandboxIdHint = undefined;
     toolExecutors = undefined;
+    loadingToolExecutors = undefined;
     appliedNetworkPolicyKey = undefined;
     preparedSandboxId = undefined;
   };
@@ -212,6 +215,7 @@ export function createSandboxSessionManager(options?: {
     sandbox = nextSandbox;
     sandboxIdHint = nextSandbox.sandboxId;
     toolExecutors = undefined;
+    loadingToolExecutors = undefined;
     const acquired = {
       sandboxId: sandboxIdHint,
       ...(dependencyProfileHash
@@ -577,6 +581,22 @@ export function createSandboxSessionManager(options?: {
     );
   };
 
+  const getOrAcquireSandbox = async (): Promise<SandboxInstance> => {
+    if (acquiringSandbox) {
+      return await acquiringSandbox;
+    }
+
+    const nextSandbox = acquireSandbox();
+    acquiringSandbox = nextSandbox;
+    try {
+      return await nextSandbox;
+    } finally {
+      if (acquiringSandbox === nextSandbox) {
+        acquiringSandbox = undefined;
+      }
+    }
+  };
+
   const getMaxOutputLength = (): number => {
     const maxOutputLength = Number.parseInt(
       process.env.SANDBOX_BASH_MAX_OUTPUT_CHARS ?? "",
@@ -721,7 +741,7 @@ export function createSandboxSessionManager(options?: {
   };
 
   const ensureReadySandbox = async (): Promise<SandboxInstance> => {
-    const activeSandbox = await acquireSandbox();
+    const activeSandbox = await getOrAcquireSandbox();
     await extendKeepAlive(activeSandbox);
     return activeSandbox;
   };
@@ -732,9 +752,24 @@ export function createSandboxSessionManager(options?: {
     if (toolExecutors) {
       return toolExecutors;
     }
+    if (loadingToolExecutors) {
+      return await loadingToolExecutors;
+    }
 
-    toolExecutors = await buildToolExecutors(activeSandbox);
-    return toolExecutors;
+    const nextToolExecutors = buildToolExecutors(activeSandbox).then(
+      (executors) => {
+        toolExecutors = executors;
+        return executors;
+      },
+    );
+    loadingToolExecutors = nextToolExecutors;
+    try {
+      return await nextToolExecutors;
+    } finally {
+      if (loadingToolExecutors === nextToolExecutors) {
+        loadingToolExecutors = undefined;
+      }
+    }
   };
 
   return {
@@ -751,7 +786,7 @@ export function createSandboxSessionManager(options?: {
       return dependencyProfileHash;
     },
     async createSandbox() {
-      return await acquireSandbox();
+      return await getOrAcquireSandbox();
     },
     async ensureToolExecutors() {
       return await loadToolExecutors(await ensureReadySandbox());
@@ -775,6 +810,7 @@ export function createSandboxSessionManager(options?: {
 
       sandbox = null;
       toolExecutors = undefined;
+      loadingToolExecutors = undefined;
     },
   };
 }

--- a/packages/junior/tests/unit/misc/sandbox-executor.test.ts
+++ b/packages/junior/tests/unit/misc/sandbox-executor.test.ts
@@ -337,6 +337,51 @@ describe("createSandboxExecutor", () => {
     );
   });
 
+  it("shares in-flight sandbox setup across parallel executor initialization", async () => {
+    const freshSandbox = makeSandbox("sbx_parallel_boot");
+    sandboxCreateMock.mockResolvedValue(freshSandbox);
+    vi.mocked(createBashTool).mockResolvedValue({
+      tools: {
+        readFile: { execute: vi.fn(async () => ({ content: "" })) },
+        writeFile: { execute: vi.fn(async () => ({ success: true })) },
+      },
+    } as never);
+
+    let markPrepareStarted: () => void = () => {};
+    let releasePrepare: () => void = () => {};
+    const prepareStarted = new Promise<void>((resolve) => {
+      markPrepareStarted = resolve;
+    });
+    const prepareReleased = new Promise<void>((resolve) => {
+      releasePrepare = resolve;
+    });
+    const onSandboxPrepare = vi.fn(async () => {
+      markPrepareStarted();
+      await prepareReleased;
+    });
+    const manager = createSandboxSessionManager({
+      onSandboxPrepare,
+    });
+    manager.configureSkills([]);
+
+    const first = manager.ensureToolExecutors();
+    await prepareStarted;
+    const second = manager.ensureToolExecutors();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(sandboxCreateMock).toHaveBeenCalledTimes(1);
+    expect(onSandboxPrepare).toHaveBeenCalledTimes(1);
+
+    releasePrepare();
+    const [firstExecutors, secondExecutors] = await Promise.all([
+      first,
+      second,
+    ]);
+
+    expect(firstExecutors).toBe(secondExecutors);
+    expect(vi.mocked(createBashTool)).toHaveBeenCalledTimes(1);
+  });
+
   it("reports acquired sandbox metadata when restoring from a sandbox id hint", async () => {
     const restoredSandbox = makeSandbox("sbx_restored");
     const onSandboxAcquired = vi.fn();

--- a/packages/junior/tests/unit/plugins/github-plugin.test.ts
+++ b/packages/junior/tests/unit/plugins/github-plugin.test.ts
@@ -1,0 +1,58 @@
+import type { SandboxPrepareHookContext } from "@sentry/junior-plugin-api";
+import { describe, expect, it } from "vitest";
+import { githubPlugin } from "../../../../junior-github/index.js";
+
+describe("github plugin", () => {
+  it("serializes global git config writes during sandbox preparation", async () => {
+    const started: string[] = [];
+    const writes: Array<{ content: string | Uint8Array; path: string }> = [];
+    let running = 0;
+    let maxRunning = 0;
+
+    const plugin = githubPlugin();
+    const ctx: SandboxPrepareHookContext = {
+      log: {
+        error() {},
+        info() {},
+        warn() {},
+      },
+      plugin: { name: "github" },
+      sandbox: {
+        juniorRoot: "/vercel/sandbox/.junior",
+        root: "/vercel/sandbox",
+        async readFile() {
+          return null;
+        },
+        async run(input) {
+          expect(input.cmd).toBe("git");
+          expect(input.args?.slice(0, 2)).toEqual(["config", "--global"]);
+
+          started.push(String(input.args?.[2]));
+          running += 1;
+          maxRunning = Math.max(maxRunning, running);
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          running -= 1;
+
+          return { exitCode: 0, stderr: "", stdout: "" };
+        },
+        async writeFile(input) {
+          writes.push({ content: input.content, path: input.path });
+        },
+      },
+    };
+
+    await plugin.hooks?.sandboxPrepare?.(ctx);
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0]?.path).toBe(
+      "/vercel/sandbox/.junior/git-hooks/prepare-commit-msg",
+    );
+    expect(started).toEqual([
+      "core.hooksPath",
+      "commit.gpgsign",
+      "credential.helper",
+      "http.emptyAuth",
+    ]);
+    expect(maxRunning).toBe(1);
+  });
+});


### PR DESCRIPTION
Serialize sandbox setup so first-use tool calls cannot race while preparing a Vercel sandbox. GitHub plugin global Git config writes now run in order, and sandbox acquisition/tool executor construction now share in-flight work across parallel callers.

**Sandbox Preparation**

Git writes global config through a single lock file, so the GitHub plugin no longer starts the four setup writes concurrently.

**Parallel Tool Startup**

Parallel first-use sandbox tools now reuse the same acquisition and bash-tool initialization promise, avoiding duplicate sandbox preparation before the session cache is populated.

Fixes JUNIOR-2Y