### PR TITLE
fix(dashboard): Use DB-less Better Auth initializer

### DIFF
--- a/packages/junior-dashboard/src/auth.ts
+++ b/packages/junior-dashboard/src/auth.ts
@@ -1,4 +1,4 @@
-import { betterAuth } from "better-auth";
+import { betterAuth } from "better-auth/minimal";
 
 const DEFAULT_SESSION_MAX_AGE_SECONDS = 60 * 60 * 8;
 

--- a/packages/junior-dashboard/tests/auth-config.test.ts
+++ b/packages/junior-dashboard/tests/auth-config.test.ts
@@ -2,14 +2,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 describe("dashboard auth config", () => {
   afterEach(() => {
-    vi.doUnmock("better-auth");
+    vi.doUnmock("better-auth/minimal");
     vi.resetModules();
   });
 
   it("keeps Google account tokens out of persistent dashboard cookies", async () => {
     let capturedOptions: unknown;
 
-    vi.doMock("better-auth", () => ({
+    vi.doMock("better-auth/minimal", () => ({
       betterAuth(options: unknown) {
         capturedOptions = options;
         return {


### PR DESCRIPTION
Switch the Junior dashboard to Better Auth's minimal initializer so DB-less dashboard auth no longer pulls Kysely adapter and migration code into Nitro production bundles. This matches the existing cookie-backed OAuth state and session cache configuration, and fixes the Rolldown missing-export failure from Better Auth's unused SQLite dialect chunks.

**DB-less Auth Path**

The dashboard still passes no `database` option and continues to store OAuth state and encrypted session cache in cookies. The auth config test now mocks `better-auth/minimal` so that contract stays explicit.

**Bundle Verification**

Verified a packed dashboard tarball in a throwaway Nitro/Vercel app with `@sentry/junior@0.58.0`: `nitro build` succeeds, the output contains `better-auth/dist/context/init-minimal.mjs` and `@better-auth/memory-adapter`, and an output scan found no `@better-auth/kysely-adapter`, `DEFAULT_MIGRATION`, or `from "kysely"` references.

Fixes #455
