### PR TITLE
fix(dashboard): Improve conversation telemetry

### DIFF
--- a/packages/junior-dashboard/src/client/code.tsx
+++ b/packages/junior-dashboard/src/client/code.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { codeToHtml, type BundledLanguage } from "shiki/bundle/web";
 
@@ -53,8 +54,18 @@ function MarkupNodeView(props: { defaultOpen?: boolean; node: MarkupNode }) {
     );
   }
 
+  return (
+    <MarkupElementView defaultOpen={props.defaultOpen} node={props.node} />
+  );
+}
+
+function MarkupElementView(props: {
+  defaultOpen?: boolean;
+  node: Extract<MarkupNode, { type: "element" }>;
+}) {
   const children = props.node.children;
   const hasChildren = children.length > 0;
+  const [open, setOpen] = useState(props.defaultOpen ?? true);
   const attributes = props.node.attributes.map(([name, value]) => (
     <span className="ml-1.5 text-[#b8b8b8]" key={name}>
       {name}=<span className="text-white">"{value}"</span>
@@ -74,12 +85,15 @@ function MarkupNodeView(props: { defaultOpen?: boolean; node: MarkupNode }) {
 
   return (
     <details
-      className="group min-w-0 break-words"
-      open={props.defaultOpen ?? true}
+      className="min-w-0 break-words"
+      onToggle={(event) => {
+        if (event.currentTarget !== event.target) return;
+        setOpen(event.currentTarget.open);
+      }}
+      open={open}
     >
       <summary className="-ml-1 flex w-full max-w-full cursor-pointer list-none flex-wrap items-baseline px-1 py-0.5 transition-colors hover:bg-white/[0.05] hover:text-white [&::-webkit-details-marker]:hidden">
-        <span className="mr-1 w-2 text-white group-open:hidden">+</span>
-        <span className="mr-1 hidden w-2 text-white group-open:inline">-</span>
+        <span className="mr-1 w-2 text-white">{open ? "-" : "+"}</span>
         <span className="text-[#888]">&lt;</span>
         <span className="font-bold text-white">{props.node.tagName}</span>
         {attributes}

--- a/packages/junior-dashboard/src/client/components/ConversationRowStats.tsx
+++ b/packages/junior-dashboard/src/client/components/ConversationRowStats.tsx
@@ -1,4 +1,8 @@
-import { slackLocationLabel } from "../format";
+import {
+  formatDurationTotal,
+  formatUsageTotal,
+  slackLocationLabel,
+} from "../format";
 import type { Conversation } from "../types";
 
 /** Render compact conversation metadata aligned to row context. */
@@ -6,14 +10,30 @@ export function ConversationRowStats(props: {
   conversation: Conversation;
   timeLabel: string;
 }) {
+  const tokens = formatUsageTotal(
+    props.conversation.turns.map((turn) => turn.cumulativeUsage),
+  );
+  const runtime = formatDurationTotal(
+    props.conversation.turns.map((turn) => turn.cumulativeDurationMs),
+  );
+  const primaryStats = [
+    `${props.conversation.turns.length} turns`,
+    tokens,
+    runtime ? `${runtime} runtime` : undefined,
+  ].filter(Boolean);
+  const secondaryStats = [
+    props.timeLabel,
+    slackLocationLabel(props.conversation, { includeId: false }),
+  ].filter(Boolean);
+
   return (
     <div className="grid min-w-0 justify-items-end gap-1 text-right max-md:justify-items-start max-md:text-left">
       <div className="text-[0.84rem] leading-relaxed text-[#b8b8b8]">
-        {props.conversation.turns.length} turns · {props.timeLabel}
+        {primaryStats.join(" · ")}
       </div>
-      {props.conversation.channel ? (
+      {secondaryStats.length > 0 ? (
         <div className="max-w-full break-words text-[0.84rem] leading-relaxed text-[#888] md:truncate">
-          {slackLocationLabel(props.conversation, { includeId: false })}
+          {secondaryStats.join(" · ")}
         </div>
       ) : null}
     </div>

--- a/packages/junior-dashboard/src/client/components/TranscriptTurn.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptTurn.tsx
@@ -1,4 +1,4 @@
-import type { ClipboardEventHandler, ReactNode } from "react";
+import { useState, type ClipboardEventHandler, type ReactNode } from "react";
 
 import { HighlightedCode } from "../code";
 import {
@@ -450,19 +450,7 @@ function TranscriptPartView(props: {
 
   const value = part.output;
   if (part.type === "thinking") {
-    const rendered = stringifyPartValue(value);
-    return (
-      <details className="border border-[#beaaff]/20 bg-white/[0.03] transition-colors hover:border-[#beaaff]/45 hover:bg-[rgba(190,170,255,0.06)]">
-        <summary className="grid cursor-pointer grid-cols-[auto_minmax(0,1fr)] items-center gap-3 px-3 py-2 font-mono text-[0.8rem] leading-tight text-[#888] hover:bg-[rgba(190,170,255,0.07)] max-md:grid-cols-1 max-md:gap-1">
-          <span className="uppercase text-[#b8b8b8]">thinking</span>
-          <span className="min-w-0 truncate">{previewToolValue(value)}</span>
-        </summary>
-        <HighlightedCode
-          code={rendered || "{}"}
-          language={detectLanguage(rendered)}
-        />
-      </details>
-    );
+    return <ThinkingPartView value={value} />;
   }
 
   const rendered = stringifyPartValue(value);
@@ -478,6 +466,37 @@ function TranscriptPartView(props: {
         </span>
       </summary>
       <HighlightedCode code={rendered || "{}"} language="json" />
+    </details>
+  );
+}
+
+function ThinkingPartView(props: { value: unknown }) {
+  const [open, setOpen] = useState(false);
+  const rendered = stringifyPartValue(props.value);
+
+  return (
+    <details
+      className="border border-[#beaaff]/20 bg-white/[0.03] transition-colors hover:border-[#beaaff]/45 hover:bg-[rgba(190,170,255,0.06)]"
+      onToggle={(event) => {
+        if (event.currentTarget !== event.target) return;
+        setOpen(event.currentTarget.open);
+      }}
+      open={open}
+    >
+      <summary className="grid cursor-pointer grid-cols-[auto_minmax(0,1fr)] items-center gap-3 px-3 py-2 font-mono text-[0.8rem] leading-tight text-[#888] hover:bg-[rgba(190,170,255,0.07)] max-md:grid-cols-1 max-md:gap-1">
+        <span className="uppercase text-[#b8b8b8]">thinking</span>
+        {open ? null : (
+          <span className="min-w-0 truncate">
+            {previewToolValue(props.value)}
+          </span>
+        )}
+      </summary>
+      <div className="border-t border-[#beaaff]/15 px-3 py-3">
+        <HighlightedCode
+          code={rendered || "{}"}
+          language={detectLanguage(rendered)}
+        />
+      </div>
     </details>
   );
 }

--- a/packages/junior-dashboard/src/client/format.ts
+++ b/packages/junior-dashboard/src/client/format.ts
@@ -151,6 +151,25 @@ function formatNumber(value: number | undefined): string {
   return `${formatted}${suffix}`;
 }
 
+function getFiniteTokenCount(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.max(0, Math.floor(value))
+    : undefined;
+}
+
+function getUsageComponentTotal(usage: TurnUsage): number | undefined {
+  return [
+    usage.inputTokens,
+    usage.outputTokens,
+    usage.cachedInputTokens,
+    usage.cacheCreationTokens,
+  ].reduce<number | undefined>((sum, value) => {
+    const count = getFiniteTokenCount(value);
+    if (count === undefined) return sum;
+    return (sum ?? 0) + count;
+  }, undefined);
+}
+
 /** Format byte counts in lowercase compact units for transcript metadata. */
 export function formatBytes(value: number | undefined): string {
   if (typeof value !== "number" || !Number.isFinite(value)) return "0b";
@@ -190,26 +209,24 @@ export function turnToolCallCount(turn: ConversationTurn): number {
 
 function totalUsageTokens(usage: TurnUsage | undefined): number | undefined {
   if (!usage) return undefined;
-  if (
-    typeof usage.totalTokens === "number" &&
-    Number.isFinite(usage.totalTokens)
-  ) {
-    return usage.totalTokens;
-  }
-  return [
-    usage.inputTokens,
-    usage.outputTokens,
-    usage.cachedInputTokens,
-    usage.cacheCreationTokens,
-  ].reduce<number | undefined>((sum, value) => {
-    if (typeof value !== "number" || !Number.isFinite(value)) return sum;
-    return (sum ?? 0) + Math.max(0, Math.floor(value));
-  }, undefined);
+  return (
+    getUsageComponentTotal(usage) ?? getFiniteTokenCount(usage.totalTokens)
+  );
 }
 
 /** Format known token counters without estimating per-message usage. */
 export function formatTokenTotal(usage: TurnUsage | undefined): string {
   const total = totalUsageTokens(usage);
+  return total === undefined ? "" : `${formatNumber(total)} tokens`;
+}
+
+/** Format the aggregate token count across conversation turns. */
+export function formatUsageTotal(usages: Array<TurnUsage | undefined>): string {
+  const total = usages.reduce<number | undefined>((sum, usage) => {
+    const tokens = totalUsageTokens(usage);
+    if (tokens === undefined) return sum;
+    return (sum ?? 0) + tokens;
+  }, undefined);
   return total === undefined ? "" : `${formatNumber(total)} tokens`;
 }
 

--- a/packages/junior-dashboard/src/client/format.ts
+++ b/packages/junior-dashboard/src/client/format.ts
@@ -104,6 +104,17 @@ export function formatMs(value: number | undefined): string {
   return `${minutes}m ${remainingSeconds}s`;
 }
 
+/** Format aggregate runtime across turn summaries when duration data exists. */
+export function formatDurationTotal(
+  durations: Array<number | undefined>,
+): string {
+  const total = durations.reduce<number | undefined>((sum, value) => {
+    if (typeof value !== "number" || !Number.isFinite(value)) return sum;
+    return (sum ?? 0) + Math.max(0, Math.floor(value));
+  }, undefined);
+  return total === undefined ? "" : formatMs(total);
+}
+
 /** Format transcript event timestamps independently from turn start offsets. */
 export function formatMessageTimestamp(value: number | undefined): string {
   if (typeof value !== "number" || !Number.isFinite(value))
@@ -193,9 +204,36 @@ function transcriptSource(turn: ConversationTurn) {
     : (turn.transcriptMetadata ?? []);
 }
 
+function isConversationMessageRole(role: string): boolean {
+  const normalized = role.toLowerCase();
+  return normalized === "user" || normalized === "assistant";
+}
+
+function hasTextPart(
+  message: Pick<ConversationTurn["transcript"][number], "parts" | "role">,
+): boolean {
+  return message.parts.some((part) => {
+    if (part.type !== "text") return false;
+    if (part.redacted) return true;
+    return typeof part.text === "string" && part.text.trim().length > 0;
+  });
+}
+
+function isConversationMessage(
+  message: Pick<ConversationTurn["transcript"][number], "parts" | "role">,
+): boolean {
+  if (!isConversationMessageRole(message.role)) return false;
+  if (message.role.toLowerCase() === "assistant") return hasTextPart(message);
+  return message.parts.length > 0;
+}
+
 /** Count visible or redacted message records for a turn. */
 export function turnMessageCount(turn: ConversationTurn): number {
-  return turn.transcriptMessageCount ?? transcriptSource(turn).length;
+  const source = transcriptSource(turn);
+  if (source.length > 0) {
+    return source.filter(isConversationMessage).length;
+  }
+  return turn.transcriptMessageCount ?? 0;
 }
 
 /** Count tool calls from visible transcripts or safe redacted metadata. */

--- a/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
@@ -8,6 +8,7 @@ import {
   formatConversationDuration,
   formatRelativeTime,
   formatTime,
+  formatUsageTotal,
   slackLocationLabel,
   turnMessageCount,
   turnToolCallCount,
@@ -123,11 +124,17 @@ function ConversationStats(props: {
         0,
       )
     : undefined;
+  const tokens = formatUsageTotal(
+    (props.detail?.turns ?? props.conversation.turns).map(
+      (turn) => turn.cumulativeUsage,
+    ),
+  );
   const stats = [
     slackLocationLabel(props.conversation, { includeId: false }),
     `${props.conversation.turns.length} turns`,
     messages === undefined ? "messages loading" : `${messages} messages`,
     toolCalls === undefined ? "tool calls loading" : `${toolCalls} tool calls`,
+    tokens,
     formatConversationDuration(props.conversation),
     `started ${formatTime(props.conversation.startedAt)}`,
   ].filter(Boolean);

--- a/packages/junior-dashboard/tests/format.test.ts
+++ b/packages/junior-dashboard/tests/format.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { formatTokenTotal, formatUsageTotal } from "../src/client/format";
+import {
+  formatDurationTotal,
+  formatTokenTotal,
+  formatUsageTotal,
+  turnMessageCount,
+} from "../src/client/format";
+import type { ConversationTurn } from "../src/client/types";
 
 describe("dashboard token formatting", () => {
   it("sums turn usage for conversation totals", () => {
@@ -27,5 +33,41 @@ describe("dashboard token formatting", () => {
         totalTokens: 999,
       }),
     ).toBe("60 tokens");
+  });
+
+  it("sums turn runtime when duration data exists", () => {
+    expect(formatDurationTotal([1_000, 2_500, undefined])).toBe("3.5s");
+  });
+
+  it("counts conversational transcript messages instead of tool events", () => {
+    const turn = {
+      id: "turn-1",
+      status: "completed",
+      transcriptAvailable: true,
+      transcript: [
+        {
+          role: "user",
+          parts: [{ type: "text", text: "run the search" }],
+        },
+        {
+          role: "assistant",
+          parts: [{ type: "thinking", output: "I should search first" }],
+        },
+        {
+          role: "assistant",
+          parts: [{ type: "tool_call", name: "search", input: {} }],
+        },
+        {
+          role: "toolResult",
+          parts: [{ type: "tool_result", name: "search", output: [] }],
+        },
+        {
+          role: "assistant",
+          parts: [{ type: "text", text: "done" }],
+        },
+      ],
+    } as ConversationTurn;
+
+    expect(turnMessageCount(turn)).toBe(2);
   });
 });

--- a/packages/junior-dashboard/tests/format.test.ts
+++ b/packages/junior-dashboard/tests/format.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { formatTokenTotal, formatUsageTotal } from "../src/client/format";
+
+describe("dashboard token formatting", () => {
+  it("sums turn usage for conversation totals", () => {
+    expect(
+      formatUsageTotal([
+        { totalTokens: 125 },
+        {
+          cachedInputTokens: 25,
+          cacheCreationTokens: 30,
+          inputTokens: 10,
+          outputTokens: 15,
+          totalTokens: 999,
+        },
+      ]),
+    ).toBe("205 tokens");
+  });
+
+  it("uses component counters for token totals when present", () => {
+    expect(
+      formatTokenTotal({
+        cachedInputTokens: 10,
+        inputTokens: 20,
+        outputTokens: 30,
+        totalTokens: 999,
+      }),
+    ).toBe("60 tokens");
+  });
+});

--- a/packages/junior/src/reporting.ts
+++ b/packages/junior/src/reporting.ts
@@ -485,6 +485,31 @@ function redactTranscriptMessage(
   };
 }
 
+function isConversationMessageRole(role: string): boolean {
+  const normalized = role.toLowerCase();
+  return normalized === "user" || normalized === "assistant";
+}
+
+function hasTextPart(message: DashboardTranscriptMessage): boolean {
+  return message.parts.some((part) => {
+    if (part.type !== "text") return false;
+    if (part.redacted) return true;
+    return typeof part.text === "string" && part.text.trim().length > 0;
+  });
+}
+
+function isConversationMessage(message: DashboardTranscriptMessage): boolean {
+  if (!isConversationMessageRole(message.role)) return false;
+  if (message.role.toLowerCase() === "assistant") return hasTextPart(message);
+  return message.parts.length > 0;
+}
+
+function countConversationMessages(
+  transcript: DashboardTranscriptMessage[],
+): number {
+  return transcript.filter(isConversationMessage).length;
+}
+
 function turnScopedMessages(messages: PiMessage[]): PiMessage[] {
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const record = messages[index] as unknown as Record<string, unknown>;
@@ -552,6 +577,8 @@ async function readConversation(
       const normalizedTranscript = scopedMessages.map(
         normalizeTranscriptMessage,
       );
+      const transcriptMessageCount =
+        countConversationMessages(normalizedTranscript);
       const transcript = canExposeTranscript ? normalizedTranscript : [];
       const transcriptMetadata = canExposeTranscript
         ? undefined
@@ -566,8 +593,8 @@ async function readConversation(
         ...(traceId ? { traceId } : {}),
         ...(sentryTraceUrl ? { sentryTraceUrl } : {}),
         transcriptAvailable: Boolean(sessionRecord) && canExposeTranscript,
-        ...(sessionRecord && scopedMessages.length > 0
-          ? { transcriptMessageCount: scopedMessages.length }
+        ...(sessionRecord && transcriptMessageCount > 0
+          ? { transcriptMessageCount }
           : {}),
         ...(!canExposeTranscript
           ? {

--- a/packages/junior/tests/integration/dashboard-reporting.test.ts
+++ b/packages/junior/tests/integration/dashboard-reporting.test.ts
@@ -104,8 +104,27 @@ describe("dashboard reporting", () => {
         },
         {
           role: "assistant",
-          content: [{ type: "text", text: "current answer" }],
+          content: [
+            { type: "thinking", text: "I should use a tool" },
+            {
+              type: "toolCall",
+              name: "search",
+              arguments: { query: "current question" },
+            },
+          ],
           timestamp: 4,
+        },
+        {
+          role: "toolResult",
+          toolCallId: "search-1",
+          name: "search",
+          content: [{ type: "text", text: "tool result" }],
+          timestamp: 5,
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "current answer" }],
+          timestamp: 6,
         },
       ] as PiMessage[],
     });
@@ -114,6 +133,9 @@ describe("dashboard reporting", () => {
       await createJuniorReporting().getConversation("slack:C1:222");
 
     expect(report.turns).toHaveLength(1);
+    expect(report.turns[0]).toMatchObject({
+      transcriptMessageCount: 2,
+    });
     expect(report.turns[0]!.transcript).toEqual([
       {
         role: "user",
@@ -123,6 +145,30 @@ describe("dashboard reporting", () => {
       {
         role: "assistant",
         timestamp: 4,
+        parts: [
+          { type: "thinking", output: "I should use a tool" },
+          {
+            type: "tool_call",
+            name: "search",
+            input: { query: "current question" },
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        timestamp: 5,
+        parts: [
+          {
+            type: "tool_result",
+            id: "search-1",
+            name: "search",
+            output: "tool result",
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        timestamp: 6,
         parts: [{ type: "text", text: "current answer" }],
       },
     ]);


### PR DESCRIPTION
Improve dashboard conversation telemetry so transcript details and conversation rows expose the metrics people actually need while scanning recent work.

**Transcript Details**

Nested XML tags now track their own open state instead of inheriting marker styling from parent disclosures. Thinking parts keep the compact preview collapsed and move the full content into a padded expanded body.

**Message Counts**

Conversation detail headers now count conversational user/assistant messages instead of every transcript event. Tool results, thinking-only assistant records, and tool-call-only records remain visible in the transcript but no longer inflate the message total.

**Conversation Aggregates**

Conversation rows now show total tokens and summed runtime alongside turn count, making high-usage conversations easier to spot from the list view. Token totals prefer component counters when available so cached and cache-write tokens are included without double-counting provider totals.
