### PR TITLE
fix(runtime): Bound timeout recovery after agent abort

### DIFF
--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -138,9 +138,44 @@ import {
 export type { AssistantReply, AgentTurnDiagnostics };
 
 const PROVIDER_RETRY_DELAYS_MS = [1_000, 2_000] as const;
+const AGENT_ABORT_SETTLE_GRACE_MS = 5_000;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Bound post-abort waiting so timeout recovery can persist before the host kills the slice. */
+function waitForAbortSettlement(
+  promise: Promise<unknown>,
+  timeoutMs: number,
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    let done = false;
+    const timeoutId = setTimeout(() => {
+      if (!done) {
+        done = true;
+        resolve(false);
+      }
+    }, timeoutMs);
+    timeoutId.unref?.();
+
+    promise.then(
+      () => {
+        if (!done) {
+          done = true;
+          clearTimeout(timeoutId);
+          resolve(true);
+        }
+      },
+      () => {
+        if (!done) {
+          done = true;
+          clearTimeout(timeoutId);
+          resolve(true);
+        }
+      },
+    );
+  });
 }
 
 export interface ReplyRequestContext {
@@ -1163,9 +1198,21 @@ export async function generateAssistantReply(
                   },
                   "Agent turn timed out and was aborted",
                 );
-                // Wait for the agent call to settle before snapshotting messages
-                // — the agent loop may still be mutating state.
-                await run.catch(() => {});
+                const settled = await waitForAbortSettlement(
+                  run,
+                  AGENT_ABORT_SETTLE_GRACE_MS,
+                );
+                if (!settled) {
+                  logWarn(
+                    "agent_turn_abort_settle_timeout",
+                    {},
+                    {
+                      "app.ai.abort_settle_grace_ms":
+                        AGENT_ABORT_SETTLE_GRACE_MS,
+                    },
+                    "Timed-out agent run did not settle after abort before resume snapshot",
+                  );
+                }
                 timeoutResumeMessages = [...agent.state.messages];
               }
               if (getPendingAuthPause()) {

--- a/packages/junior/src/chat/sandbox/sandbox.ts
+++ b/packages/junior/src/chat/sandbox/sandbox.ts
@@ -44,6 +44,7 @@ import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 interface SandboxExecutionInput {
   toolName: string;
   input: unknown;
+  signal?: AbortSignal;
 }
 
 export interface SandboxExecutionEnvelope<T = unknown> {
@@ -217,6 +218,7 @@ export function createSandboxExecutor(options?: {
   const executeBashTool = async <T>(
     rawInput: Record<string, unknown>,
     command: string,
+    signal?: AbortSignal,
   ): Promise<SandboxExecutionEnvelope<T>> => {
     const env = parseEnv(rawInput.env);
     const timeoutMs = positiveInteger(rawInput.timeoutMs);
@@ -236,6 +238,7 @@ export function createSandboxExecutor(options?: {
             command,
             ...(env ? { env } : {}),
             ...(timeoutMs ? { timeoutMs } : {}),
+            ...(signal ? { signal } : {}),
           });
           setSpanAttributes({
             "process.exit.code": response.exitCode,
@@ -554,7 +557,7 @@ export function createSandboxExecutor(options?: {
           return { result: custom.result as T };
         }
       }
-      return await executeBashTool(rawInput, bashCommand);
+      return await executeBashTool(rawInput, bashCommand, params.signal);
     }
 
     try {

--- a/packages/junior/src/chat/sandbox/session.ts
+++ b/packages/junior/src/chat/sandbox/session.ts
@@ -1,7 +1,13 @@
 import { randomUUID } from "node:crypto";
 import { Sandbox, type NetworkPolicy } from "@vercel/sandbox";
 import { createBashTool } from "bash-tool";
-import { logInfo, logWarn, setSpanAttributes, withSpan, type LogContext } from "@/chat/logging";
+import {
+  logInfo,
+  logWarn,
+  setSpanAttributes,
+  withSpan,
+  type LogContext,
+} from "@/chat/logging";
 import { getVercelSandboxCredentials } from "@/chat/sandbox/credentials";
 import {
   isAlreadyExistsError,
@@ -28,6 +34,7 @@ import {
 import type { SkillMetadata } from "@/chat/skills";
 
 const DEFAULT_MAX_OUTPUT_LENGTH = 30_000;
+const DEFAULT_BASH_COMMAND_TIMEOUT_MS = 5 * 60 * 1000;
 const SANDBOX_RUNTIME = "node22";
 const SANDBOX_RUNTIME_BIN_DIR = `${SANDBOX_WORKSPACE_ROOT}/.junior/bin`;
 const SNAPSHOT_BOOT_RETRY_COUNT = 3;
@@ -44,6 +51,7 @@ interface SandboxToolExecutors {
   bash: (input: {
     command: string;
     env?: Record<string, string>;
+    signal?: AbortSignal;
     timeoutMs?: number;
   }) => Promise<{
     stdout: string;
@@ -51,6 +59,7 @@ interface SandboxToolExecutors {
     exitCode: number;
     stdoutTruncated: boolean;
     stderrTruncated: boolean;
+    aborted?: boolean;
     timedOut?: boolean;
   }>;
   readFile: (input: { path: string }) => Promise<{ content: string }>;
@@ -148,6 +157,24 @@ function getCommandStreamInterruptedResult(): {
     exitCode: 125,
     stdoutTruncated: false,
     stderrTruncated: false,
+  };
+}
+
+function getCommandAbortedResult(): {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  stdoutTruncated: boolean;
+  stderrTruncated: boolean;
+  aborted: true;
+} {
+  return {
+    stdout: "",
+    stderr: "Command aborted because the agent turn was cancelled.",
+    exitCode: 130,
+    stdoutTruncated: false,
+    stderrTruncated: false,
+    aborted: true,
   };
 }
 
@@ -502,7 +529,10 @@ export function createSandboxSessionManager(options?: {
       traceContext,
       {
         ...(options?.sandboxDependencyProfileHash
-          ? { "app.sandbox.previous_profile_hash": options.sandboxDependencyProfileHash }
+          ? {
+              "app.sandbox.previous_profile_hash":
+                options.sandboxDependencyProfileHash,
+            }
           : {}),
         ...(dependencyProfileHash
           ? { "app.sandbox.current_profile_hash": dependencyProfileHash }
@@ -562,7 +592,8 @@ export function createSandboxSessionManager(options?: {
         traceContext,
         {
           "app.sandbox.hint_id": sandboxIdHint,
-          "app.sandbox.error": error instanceof Error ? error.message : String(error),
+          "app.sandbox.error":
+            error instanceof Error ? error.message : String(error),
         },
         "Failed to restore sandbox from hint; will create fresh session",
       );
@@ -708,41 +739,69 @@ export function createSandboxSessionManager(options?: {
     return {
       bash: async (input) => {
         let timedOut = false;
+        let aborted = false;
         let timeoutId: ReturnType<typeof setTimeout> | undefined;
+        let onAbort: (() => void) | undefined;
         try {
+          if (input.signal?.aborted) {
+            return getCommandAbortedResult();
+          }
           await refreshNetworkPolicy(sandboxInstance);
+          if (input.signal?.aborted) {
+            return getCommandAbortedResult();
+          }
           const sandboxCommandEnv = await resolveCommandEnv();
+          if (input.signal?.aborted) {
+            return getCommandAbortedResult();
+          }
           const script = buildNonInteractiveShellScript(input.command, {
             env: { ...sandboxCommandEnv, ...(input.env ?? {}) },
             pathPrefix: `${SANDBOX_RUNTIME_BIN_DIR}:$PATH`,
           });
-          const controller =
+          const controller = new AbortController();
+          const timeoutMs =
             input.timeoutMs && input.timeoutMs > 0
-              ? new AbortController()
-              : undefined;
-          timeoutId = controller
-            ? setTimeout(() => {
-                timedOut = true;
-                controller.abort();
-              }, input.timeoutMs)
-            : undefined;
+              ? input.timeoutMs
+              : DEFAULT_BASH_COMMAND_TIMEOUT_MS;
+          onAbort = () => {
+            aborted = true;
+            controller.abort(input.signal?.reason);
+          };
+          if (input.signal) {
+            input.signal.addEventListener("abort", onAbort, { once: true });
+            if (input.signal.aborted) {
+              onAbort();
+            }
+          }
+          timeoutId = setTimeout(() => {
+            timedOut = true;
+            controller.abort();
+          }, timeoutMs);
+          timeoutId.unref?.();
           const commandResult = await sandboxInstance.runCommand({
             cmd: "bash",
             args: ["-c", script],
             cwd: SANDBOX_WORKSPACE_ROOT,
-            ...(controller ? { signal: controller.signal } : {}),
+            signal: controller.signal,
           });
           return await readCommandOutput(commandResult);
         } catch (error) {
           if (timedOut) {
             return {
               stdout: "",
-              stderr: `Command timed out after ${input.timeoutMs}ms`,
+              stderr: `Command timed out after ${
+                input.timeoutMs && input.timeoutMs > 0
+                  ? input.timeoutMs
+                  : DEFAULT_BASH_COMMAND_TIMEOUT_MS
+              }ms`,
               exitCode: 124,
               stdoutTruncated: false,
               stderrTruncated: false,
               timedOut: true,
             };
+          }
+          if (aborted || input.signal?.aborted) {
+            return getCommandAbortedResult();
           }
           if (isSandboxCommandStreamInterruptedError(error)) {
             return getCommandStreamInterruptedResult();
@@ -751,6 +810,9 @@ export function createSandboxSessionManager(options?: {
         } finally {
           if (timeoutId) {
             clearTimeout(timeoutId);
+          }
+          if (input.signal && onAbort) {
+            input.signal.removeEventListener("abort", onAbort);
           }
         }
       },

--- a/packages/junior/src/chat/tools/agent-tools.ts
+++ b/packages/junior/src/chat/tools/agent-tools.ts
@@ -50,7 +50,11 @@ export function createAgentTools(
     parameters: toolDef.inputSchema,
     prepareArguments: toolDef.prepareArguments,
     executionMode: toolDef.executionMode,
-    execute: async (toolCallId: unknown, params: unknown) => {
+    execute: async (
+      toolCallId: unknown,
+      params: unknown,
+      signal?: AbortSignal,
+    ) => {
       const normalizedToolCallId =
         typeof toolCallId === "string" && toolCallId.length > 0
           ? toolCallId
@@ -111,9 +115,11 @@ export function createAgentTools(
               ? await sandboxExecutor!.execute({
                   toolName,
                   input: sandboxInput,
+                  ...(signal ? { signal } : {}),
                 })
               : await toolDef.execute(toolInput as never, {
                   experimental_context: sandbox,
+                  ...(signal ? { signal } : {}),
                 });
 
             const normalized = normalizeToolResult(result, isSandbox);

--- a/packages/junior/src/chat/tools/definition.ts
+++ b/packages/junior/src/chat/tools/definition.ts
@@ -22,7 +22,7 @@ export interface ToolDefinition<TInputSchema extends TSchema = TSchema> {
   executionMode?: ToolExecutionMode;
   execute?: (
     input: Static<TInputSchema>,
-    options: { experimental_context?: unknown },
+    options: { experimental_context?: unknown; signal?: AbortSignal },
   ) => Promise<unknown> | unknown;
 }
 

--- a/packages/junior/tests/unit/misc/sandbox-executor.test.ts
+++ b/packages/junior/tests/unit/misc/sandbox-executor.test.ts
@@ -262,6 +262,7 @@ describe("createSandboxExecutor", () => {
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
     await disconnectStateAdapter();
     delete process.env.JUNIOR_BASE_URL;
     delete process.env.JUNIOR_SECRET;
@@ -678,6 +679,88 @@ describe("createSandboxExecutor", () => {
     expect(invocation.args?.[1]).toContain("export GIT_TERMINAL_PROMPT='0'");
     expect(invocation.args?.[1]).toContain("exec </dev/null");
     expect(invocation.args?.[1]).toContain("echo ok");
+  });
+
+  it("applies a host timeout to bash commands when the model omits one", async () => {
+    vi.useFakeTimers();
+    const sandbox = makeSandbox("sbx_bash_timeout");
+    sandbox.runCommand.mockImplementationOnce(
+      async (input) =>
+        await new Promise((_, reject) => {
+          input.signal?.addEventListener("abort", () => {
+            reject(new Error("aborted"));
+          });
+        }),
+    );
+    sandboxGetMock.mockResolvedValue(sandbox);
+    vi.mocked(createBashTool).mockResolvedValue({
+      tools: {
+        readFile: { execute: vi.fn(async () => ({ content: "" })) },
+        writeFile: { execute: vi.fn(async () => ({ success: true })) },
+      },
+    } as never);
+
+    const executor = createSandboxExecutor({ sandboxId: "sbx_bash_timeout" });
+    executor.configureSkills([]);
+
+    const responsePromise = executor.execute({
+      toolName: "bash",
+      input: {
+        command: "sleep 999",
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    const response = await responsePromise;
+
+    expect(response.result).toMatchObject({
+      ok: false,
+      exit_code: 124,
+      timed_out: true,
+      stderr: "Command timed out after 300000ms",
+    });
+  });
+
+  it("aborts bash commands when the agent turn is cancelled", async () => {
+    const sandbox = makeSandbox("sbx_bash_abort");
+    sandbox.runCommand.mockImplementationOnce(
+      async (input) =>
+        await new Promise((_, reject) => {
+          input.signal?.addEventListener("abort", () => {
+            reject(new Error("aborted"));
+          });
+        }),
+    );
+    sandboxGetMock.mockResolvedValue(sandbox);
+    vi.mocked(createBashTool).mockResolvedValue({
+      tools: {
+        readFile: { execute: vi.fn(async () => ({ content: "" })) },
+        writeFile: { execute: vi.fn(async () => ({ success: true })) },
+      },
+    } as never);
+
+    const executor = createSandboxExecutor({ sandboxId: "sbx_bash_abort" });
+    executor.configureSkills([]);
+    const abortController = new AbortController();
+
+    const responsePromise = executor.execute({
+      toolName: "bash",
+      input: {
+        command: "sleep 999",
+      },
+      signal: abortController.signal,
+    });
+
+    await Promise.resolve();
+    abortController.abort();
+    const response = await responsePromise;
+
+    expect(response.result).toMatchObject({
+      ok: false,
+      exit_code: 130,
+      timed_out: false,
+      stderr: "Command aborted because the agent turn was cancelled.",
+    });
   });
 
   it("resolves sandbox command environment for each bash command", async () => {

--- a/packages/junior/tests/unit/runtime/respond-timeout-resume.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-timeout-resume.test.ts
@@ -1,8 +1,11 @@
 import { Buffer } from "node:buffer";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { promptAborted } = vi.hoisted(() => ({
+const { promptAborted, promptMode } = vi.hoisted(() => ({
   promptAborted: { value: false },
+  promptMode: {
+    value: "settlesAfterAbort" as "settlesAfterAbort" | "hangsAfterAbort",
+  },
 }));
 
 vi.mock("@earendil-works/pi-agent-core", () => {
@@ -50,6 +53,10 @@ vi.mock("@earendil-works/pi-agent-core", () => {
 
     async prompt(message: unknown) {
       this.state.messages.push(message);
+      if (promptMode.value === "hangsAfterAbort") {
+        await new Promise(() => undefined);
+        return {};
+      }
       await new Promise<void>((resolve) => {
         this.resolveAbort = resolve;
       });
@@ -162,6 +169,7 @@ import { getAgentTurnSessionRecord } from "@/chat/state/turn-session";
 describe("generateAssistantReply timeout resume", () => {
   beforeEach(async () => {
     promptAborted.value = false;
+    promptMode.value = "settlesAfterAbort";
     process.env.JUNIOR_STATE_ADAPTER = "memory";
     await disconnectStateAdapter();
     vi.useFakeTimers();
@@ -248,5 +256,46 @@ describe("generateAssistantReply timeout resume", () => {
         }),
       ]),
     );
+  });
+
+  it("persists timeout resume state when abort does not settle the agent run", async () => {
+    promptMode.value = "hangsAfterAbort";
+    const replyPromise = generateAssistantReply("help me", {
+      requester: { userId: "U123" },
+      correlation: {
+        conversationId: "conversation-hung",
+        turnId: "turn-hung",
+        channelId: "C123",
+        threadTs: "1712345.0003",
+      },
+    }).catch((caught) => caught);
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    const error = await replyPromise;
+
+    expect(promptAborted.value).toBe(true);
+    expect(isRetryableTurnError(error, "turn_timeout_resume")).toBe(true);
+    expect(error.metadata).toMatchObject({
+      conversationId: "conversation-hung",
+      sessionId: "turn-hung",
+      version: expect.any(Number),
+      sliceId: 2,
+    });
+
+    const sessionRecord = await getAgentTurnSessionRecord(
+      "conversation-hung",
+      "turn-hung",
+    );
+    expect(sessionRecord).toMatchObject({
+      state: "awaiting_resume",
+      resumeReason: "timeout",
+      resumedFromSliceId: 1,
+      sliceId: 2,
+    });
+    expect(sessionRecord?.piMessages).toEqual([
+      expect.objectContaining({
+        role: "user",
+      }),
+    ]);
   });
 });

--- a/packages/junior/tests/unit/tools/agent-tools.test.ts
+++ b/packages/junior/tests/unit/tools/agent-tools.test.ts
@@ -127,6 +127,96 @@ describe("createAgentTools", () => {
     });
   });
 
+  it("passes Pi abort signals to sandbox execution", async () => {
+    const sandbox = new SkillSandbox([], []);
+    const abortController = new AbortController();
+    const sandboxExecutor = {
+      canExecute: (toolName: string) => toolName === "bash",
+      execute: vi.fn(async () => ({
+        result: {
+          ok: true,
+          command: "sleep 60",
+          cwd: "/vercel/sandbox",
+          exit_code: 0,
+          signal: null,
+          timed_out: false,
+          stdout: "",
+          stderr: "",
+          stdout_truncated: false,
+          stderr_truncated: false,
+        },
+      })),
+    } as any;
+
+    const [bashTool] = createAgentTools(
+      {
+        bash: {
+          description: "bash",
+          inputSchema: {} as any,
+          execute: async () => ({ ok: true }),
+        },
+      },
+      sandbox,
+      {},
+      undefined,
+      sandboxExecutor,
+    );
+
+    await bashTool!.execute(
+      "tool-1",
+      {
+        command: "sleep 60",
+      },
+      abortController.signal,
+    );
+
+    expect(sandboxExecutor.execute).toHaveBeenCalledWith({
+      toolName: "bash",
+      input: {
+        command: "sleep 60",
+      },
+      signal: abortController.signal,
+    });
+  });
+
+  it("passes Pi abort signals to non-sandbox tools", async () => {
+    const sandbox = new SkillSandbox([], []);
+    const abortController = new AbortController();
+    const execute = vi.fn(async () => ({
+      ok: true,
+    }));
+
+    const [demoTool] = createAgentTools(
+      {
+        demo: {
+          description: "demo",
+          inputSchema: {} as any,
+          execute,
+        },
+      },
+      sandbox,
+      {},
+    );
+
+    await demoTool!.execute(
+      "tool-demo",
+      {
+        value: "input",
+      },
+      abortController.signal,
+    );
+
+    expect(execute).toHaveBeenCalledWith(
+      {
+        value: "input",
+      },
+      {
+        experimental_context: sandbox,
+        signal: abortController.signal,
+      },
+    );
+  });
+
   it("reports tool call parameters to the caller", async () => {
     const sandbox = new SkillSandbox([], []);
     const onToolCall = vi.fn();

--- a/specs/agent-session-resumability.md
+++ b/specs/agent-session-resumability.md
@@ -421,7 +421,7 @@ If the previous slice timed out after producing uncommitted partial assistant te
   - `AGENT_TURN_TIMEOUT_MS` inside `generateAssistantReply(...)`
   - the platform/function max duration outside the agent loop
 - On timeout:
-  1. Abort the Pi agent and wait for the in-flight prompt/continue call to settle before snapshotting Pi messages.
+  1. Abort the Pi agent and wait only a short bounded grace period for the in-flight prompt/continue call to settle before snapshotting Pi messages. If the run does not settle, use the best available in-memory Pi state and the last durable boundary rules below; timeout recovery must not wait until the platform/function max duration kills the request.
   2. If session context exists and a safe boundary can be materialized, append a `timeout_paused` event with:
      - `pause_event_id`
      - current `slice_id`


### PR DESCRIPTION
Bound timed-out agent turns so abort recovery can persist a timeout-resume boundary before Vercel kills the function. This prevents stuck sandbox/tool executions from keeping Slack turns silent until the host hard timeout.

**Abort Propagation**

Pi abort signals now flow through Junior tool execution into sandbox bash. Sandbox commands also get a host-side default timeout when the model does not specify one.

**Timeout Recovery**

After `agent.abort()`, Junior waits a bounded grace period before snapshotting the best available Pi state and scheduling continuation. The resumability spec now documents that bounded recovery contract.

Fixes GH-464