### PR TITLE
Add Vercel plugin to release and docs lists

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -35,3 +35,6 @@ targets:
   - name: npm
     id: "@sentry/junior-sentry"
     includeNames: /^sentry-junior-sentry-\d.*\.tgz$/
+  - name: npm
+    id: "@sentry/junior-vercel"
+    includeNames: /^sentry-junior-vercel-\d.*\.tgz$/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
           pnpm --filter @sentry/junior-notion pack --pack-destination artifacts
           pnpm --filter @sentry/junior-scheduler pack --pack-destination artifacts
           pnpm --filter @sentry/junior-sentry pack --pack-destination artifacts
+          pnpm --filter @sentry/junior-vercel pack --pack-destination artifacts
           ls -la artifacts
 
       - name: Upload release artifacts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,7 @@ This repo uses Craft for manual lockstep npm releases of:
 - `@sentry/junior-notion`
 - `@sentry/junior-scheduler`
 - `@sentry/junior-sentry`
+- `@sentry/junior-vercel`
 
 Run `pnpm release:check` before changing release package lists so `.craft.yml`, CI,
 the bump script, and the release docs stay aligned.

--- a/README.md
+++ b/README.md
@@ -33,3 +33,4 @@ Start here:
 | `@sentry/junior-notion`        | Notion plugin package for page search workflows                              |
 | `@sentry/junior-scheduler`     | Scheduler plugin package for scheduled Junior tasks                          |
 | `@sentry/junior-sentry`        | Sentry plugin package for issue workflows                                    |
+| `@sentry/junior-vercel`        | Vercel plugin package for deployment and log investigation workflows         |

--- a/apps/example/README.md
+++ b/apps/example/README.md
@@ -7,7 +7,7 @@ It demonstrates:
 - one local skill (`/example-local`)
 - one plugin-bundled skill (`/example-bundle-help`)
 - one bundle-only plugin (`app/plugins/example-bundle/plugin.yaml`) with no credential broker config
-- installed plugin packages (`@sentry/junior-agent-browser`, `@sentry/junior-github`, `@sentry/junior-hex`, `@sentry/junior-linear`, `@sentry/junior-notion`, `@sentry/junior-sentry`)
+- installed plugin packages (`@sentry/junior-agent-browser`, `@sentry/junior-github`, `@sentry/junior-hex`, `@sentry/junior-linear`, `@sentry/junior-notion`, `@sentry/junior-sentry`, `@sentry/junior-vercel`)
 
 ## Run
 
@@ -29,8 +29,12 @@ Copy `.env.example` and set:
 - `AI_WEB_SEARCH_MODEL` (optional, overrides the `webSearch` tool model; defaults to a search-tuned model)
 - `JUNIOR_SECRET` (required outside `pnpm dev`; the local wrapper supplies a dev-only secret when unset)
 - `JUNIOR_SCHEDULER_SECRET` or `CRON_SECRET` (optional for `pnpm dev`; the local wrapper supplies a dev-only heartbeat secret when both are unset)
-- `NOTION_TOKEN` (optional, enables the bundled Notion plugin)
 - Dashboard auth is enabled by default. `pnpm dev` disables dashboard auth only for local non-Vercel development.
+
+## Optional plugin env
+
+- `JUNIOR_VERCEL_TOKEN` enables the bundled Vercel plugin's CLI access to deployments and logs.
+- Notion does not use `NOTION_TOKEN`; each user connects their own Notion account through MCP OAuth when Junior first calls a Notion tool.
 
 ## Wiring
 

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -19,6 +19,7 @@
     "@sentry/junior-linear": "workspace:*",
     "@sentry/junior-notion": "workspace:*",
     "@sentry/junior-sentry": "workspace:*",
+    "@sentry/junior-vercel": "workspace:*",
     "hono": "^4.12.22"
   },
   "devDependencies": {

--- a/apps/example/plugin-packages.ts
+++ b/apps/example/plugin-packages.ts
@@ -6,4 +6,5 @@ export const examplePluginPackages = [
   "@sentry/junior-linear",
   "@sentry/junior-notion",
   "@sentry/junior-sentry",
+  "@sentry/junior-vercel",
 ];

--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -30,6 +30,8 @@ export default defineConfig({
     "/plugins/notion": "/extend/notion-plugin",
     "/plugins/scheduler": "/extend/scheduler-plugin",
     "/plugins/sentry": "/extend/sentry-plugin",
+    "/plugins/vercel": "/extend/vercel-plugin",
+    "/extend/vercel": "/extend/vercel-plugin",
     "/operate/telemetry-runbooks": "/operate/reliability-runbooks",
     "/operate/security": "/operate/security-hardening",
     "/operate/reliability": "/operate/reliability-runbooks",
@@ -105,6 +107,7 @@ export default defineConfig({
             { label: "Notion Plugin", link: "/extend/notion-plugin/" },
             { label: "Scheduler Plugin", link: "/extend/scheduler-plugin/" },
             { label: "Sentry Plugin", link: "/extend/sentry-plugin/" },
+            { label: "Vercel Plugin", link: "/extend/vercel-plugin/" },
           ],
         },
         {

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -35,6 +35,7 @@ Junior runs as a Hono app, receives Slack events, processes turns through queue-
 - Linear: https://junior.sentry.dev/extend/linear-plugin/
 - Notion: https://junior.sentry.dev/extend/notion-plugin/
 - Sentry: https://junior.sentry.dev/extend/sentry-plugin/
+- Vercel: https://junior.sentry.dev/extend/vercel-plugin/
 
 ## Operate
 

--- a/packages/docs/src/content/docs/contribute/releasing.md
+++ b/packages/docs/src/content/docs/contribute/releasing.md
@@ -22,6 +22,7 @@ Junior uses lockstep package releases for:
 - `@sentry/junior-notion`
 - `@sentry/junior-scheduler`
 - `@sentry/junior-sentry`
+- `@sentry/junior-vercel`
 
 ## Package release
 

--- a/packages/docs/src/content/docs/extend/index.md
+++ b/packages/docs/src/content/docs/extend/index.md
@@ -15,6 +15,7 @@ related:
   - /extend/notion-plugin/
   - /extend/scheduler-plugin/
   - /extend/sentry-plugin/
+  - /extend/vercel-plugin/
 ---
 
 Junior plugins are manifest-owned provider integrations. A plugin package can also ship skills that use that provider surface, but skills do not define plugin config, credentials, domains, OAuth scopes, MCP endpoints, or runtime dependencies.
@@ -54,7 +55,7 @@ my-junior-plugin/
 For reuse across apps or teams, package plugin manifests and any bundled skills as npm packages and install them next to `@sentry/junior`.
 
 ```bash
-pnpm add @sentry/junior @sentry/junior-agent-browser @sentry/junior-datadog @sentry/junior-github @sentry/junior-hex @sentry/junior-linear @sentry/junior-notion @sentry/junior-scheduler @sentry/junior-sentry
+pnpm add @sentry/junior @sentry/junior-agent-browser @sentry/junior-datadog @sentry/junior-github @sentry/junior-hex @sentry/junior-linear @sentry/junior-notion @sentry/junior-scheduler @sentry/junior-sentry @sentry/junior-vercel
 ```
 
 List the plugin packages in `juniorNitro` so they are bundled at build time and available at runtime:
@@ -77,6 +78,7 @@ export default defineConfig({
           "@sentry/junior-notion",
           "@sentry/junior-scheduler",
           "@sentry/junior-sentry",
+          "@sentry/junior-vercel",
         ],
       },
     }),

--- a/packages/docs/src/content/docs/extend/vercel-plugin.md
+++ b/packages/docs/src/content/docs/extend/vercel-plugin.md
@@ -1,0 +1,94 @@
+---
+title: Vercel Plugin
+description: Configure the Vercel CLI for read-only deployment and log investigations.
+type: tutorial
+summary: Let Junior inspect Vercel deployments, build logs, and runtime logs from Slack.
+prerequisites:
+  - /extend/
+related:
+  - /concepts/credentials-and-oauth/
+  - /operate/security-hardening/
+  - /operate/sandbox-snapshots/
+---
+
+The Vercel plugin installs the Vercel CLI so Slack users can ask Junior to inspect deployments, fetch build logs, search runtime logs, and find deployments by project, environment, status, or commit metadata.
+
+Junior keeps this plugin read-only. The packaged manifest installs the CLI and injects host-managed Vercel API auth, while the bundled skill limits Junior to `vercel logs`, `vercel inspect`, `vercel list`, and CLI help commands.
+
+## Install
+
+Install the plugin package alongside `@sentry/junior`:
+
+```bash
+pnpm add @sentry/junior @sentry/junior-vercel
+```
+
+## Runtime setup
+
+List the plugin in `juniorNitro({ plugins: { packages: [...] } })`:
+
+```ts title="nitro.config.ts"
+juniorNitro({
+  plugins: {
+    packages: ["@sentry/junior-vercel"],
+  },
+});
+```
+
+Set a Vercel token in your Junior deployment environment:
+
+```bash
+JUNIOR_VERCEL_TOKEN=...
+```
+
+Use a Vercel service account or token with the smallest project/team access that covers the deployments users need to inspect. Vercel API permissions are still evolving, so the plugin's read-only boundary comes from the command allowlist plus least-privilege account setup.
+
+## Optional channel defaults
+
+If a Slack channel usually investigates the same Vercel project or team, store that as a conversation-scoped default:
+
+```bash
+jr-rpc config set vercel.project junior-prod
+jr-rpc config set vercel.team sentry
+```
+
+These defaults are optional fallbacks. If a user names a different project, team, deployment, or URL in a request, Junior follows the explicit request instead.
+
+## Auth model
+
+- The plugin uses a deployment-level Vercel token, not per-user OAuth.
+- Junior keeps the real `JUNIOR_VERCEL_TOKEN` value host-side.
+- Matching Vercel API requests from the CLI receive a host-managed `Authorization` header.
+- The sandbox receives only a non-secret placeholder `VERCEL_TOKEN` so the Vercel CLI can perform its normal auth checks before making requests.
+- Users do not connect or disconnect individual Vercel accounts from Junior App Home for this plugin.
+
+## What users can do
+
+- Search recent runtime logs for a project, environment, deployment, status code, level, source, or query string.
+- Inspect production or preview deployment failures.
+- Fetch build logs for a deployment ID or URL.
+- List recent deployments for a project.
+- Find deployments by status, environment, production flag, or Git commit SHA metadata.
+- Stream live logs briefly when a user explicitly asks for live output.
+
+## Verify
+
+Confirm Junior can query Vercel successfully:
+
+1. Ask Junior a Vercel question in a channel, for example: `Show production error logs for junior-prod from the last hour.`
+2. Confirm the thread returns a bounded summary with the project, environment, time window, and filters used.
+3. Confirm Junior does not run mutation commands for requests such as deploys, rollbacks, env changes, cache purges, or domain changes.
+
+## Failure modes
+
+- `JUNIOR_VERCEL_TOKEN` missing: add it to the Junior deployment environment and redeploy.
+- `401 Unauthorized`: the token is invalid, expired, revoked, or not being injected for Vercel API requests.
+- `403 Forbidden` or `permission denied`: the token or service account cannot read the requested project, deployment, or logs.
+- Project not found: confirm the project name, `vercel.project`, and `vercel.team` defaults.
+- Empty logs: confirm the environment, deployment, branch, and time window before widening the search.
+- Long-running live logs: live streaming is only for explicit user requests and should be stopped once enough evidence is captured.
+- Mutation requests: the plugin is read-only and the skill will decline these.
+
+## Next step
+
+Review [Credentials & OAuth](/concepts/credentials-and-oauth/) and [Sandbox Snapshots](/operate/sandbox-snapshots/) to understand how plugin credentials and CLI dependencies are delivered at runtime.

--- a/packages/docs/src/content/docs/start-here/quickstart.md
+++ b/packages/docs/src/content/docs/start-here/quickstart.md
@@ -100,7 +100,7 @@ Packaged plugins must be installed and listed in `juniorNitro` so Nitro bundles 
 Install only the plugins you plan to enable:
 
 ```bash
-pnpm add @sentry/junior-agent-browser @sentry/junior-datadog @sentry/junior-github @sentry/junior-hex @sentry/junior-linear @sentry/junior-notion @sentry/junior-scheduler @sentry/junior-sentry
+pnpm add @sentry/junior-agent-browser @sentry/junior-datadog @sentry/junior-github @sentry/junior-hex @sentry/junior-linear @sentry/junior-notion @sentry/junior-scheduler @sentry/junior-sentry @sentry/junior-vercel
 ```
 
 Then list them in `nitro.config.ts`:
@@ -123,6 +123,7 @@ export default defineConfig({
           "@sentry/junior-notion",
           "@sentry/junior-scheduler",
           "@sentry/junior-sentry",
+          "@sentry/junior-vercel",
         ],
       },
     }),

--- a/packages/junior-vercel/README.md
+++ b/packages/junior-vercel/README.md
@@ -1,0 +1,60 @@
+# @sentry/junior-vercel
+
+`@sentry/junior-vercel` adds read-only Vercel deployment and log investigation workflows to Junior through the Vercel CLI.
+
+## Install
+
+```bash
+pnpm add @sentry/junior @sentry/junior-vercel
+```
+
+## Configure
+
+List the plugin in `juniorNitro({ plugins: { packages: [...] } })`:
+
+```ts
+juniorNitro({
+  plugins: {
+    packages: ["@sentry/junior-vercel"],
+  },
+});
+```
+
+Set a Vercel token in the Junior deployment environment:
+
+```bash
+JUNIOR_VERCEL_TOKEN=...
+```
+
+Use a Vercel service account or token with the smallest project/team access that covers the deployments users need to inspect.
+
+## Auth model
+
+- This package uses a deployment-level Vercel token, not per-user OAuth.
+- Junior keeps the real `JUNIOR_VERCEL_TOKEN` host-side.
+- Matching Vercel API requests from the CLI receive a host-managed `Authorization` header.
+- The sandbox receives only a non-secret placeholder `VERCEL_TOKEN` so the Vercel CLI can run normally before making API requests.
+
+## Optional channel defaults
+
+If a Slack channel usually investigates the same Vercel project or team, store that as a conversation-scoped default:
+
+```bash
+jr-rpc config set vercel.project junior-prod
+jr-rpc config set vercel.team sentry
+```
+
+These defaults are optional fallbacks. If a user names a different project, team, deployment, or URL in a request, Junior should follow the explicit request instead.
+
+## Read-only scope
+
+The bundled skill limits Junior to:
+
+- `vercel logs`
+- `vercel inspect`
+- `vercel list` / `vercel ls`
+- Vercel CLI help commands
+
+It is intended for deployment status, build-log, runtime-log, and failed-deployment investigations. It is not for deploys, rollbacks, env vars, domains, caches, storage, aliases, or other Vercel mutations.
+
+Full setup guide: https://junior.sentry.dev/extend/vercel-plugin/

--- a/packages/junior-vercel/package.json
+++ b/packages/junior-vercel/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@sentry/junior-vercel",
+  "version": "0.62.0",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getsentry/junior.git",
+    "directory": "packages/junior-vercel"
+  },
+  "files": [
+    "plugin.yaml",
+    "skills"
+  ]
+}

--- a/packages/junior-vercel/plugin.yaml
+++ b/packages/junior-vercel/plugin.yaml
@@ -1,0 +1,25 @@
+name: vercel
+description: Query Vercel deployments and logs with the Vercel CLI
+
+config-keys:
+  - project
+  - team
+
+capabilities:
+  - api
+
+env-vars:
+  JUNIOR_VERCEL_TOKEN:
+
+domains:
+  - api.vercel.com
+
+api-headers:
+  Authorization: Bearer ${JUNIOR_VERCEL_TOKEN}
+
+command-env:
+  VERCEL_TOKEN: host_managed_credential
+
+runtime-dependencies:
+  - type: npm
+    package: vercel

--- a/packages/junior-vercel/skills/vercel/SKILL.md
+++ b/packages/junior-vercel/skills/vercel/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: vercel
+description: Query Vercel deployments, build logs, runtime logs, and deployment status through the Vercel CLI. Use when users ask to debug Vercel deployments, inspect failed builds, fetch production or preview runtime logs, find a deployment for a project or commit SHA, or investigate Vercel-hosted app errors. Do not use it for deploying, rolling back, changing project settings, domains, env vars, caches, storage, or any other Vercel mutation.
+allowed-tools: bash
+---
+
+# Vercel Operations
+
+Use this skill for read-only Vercel deployment and log investigations.
+
+## Read-only command allowlist
+
+Run only these Vercel CLI commands:
+
+- `vercel logs`
+- `vercel inspect`
+- `vercel list` or `vercel ls`
+- `vercel help`, `vercel --help`, or `vercel <command> --help`
+
+Do not run `deploy`, `rollback`, `promote`, `remove`, `env`, `alias`, `dns`, `project`, `cache`, `blob`, `certs`, `teams`, `domains`, `git`, `link`, `login`, `logout`, `switch`, `pull`, `build`, `dev`, `redeploy`, `bisect`, `api`, or any command that creates, updates, deletes, purges, promotes, deploys, links, authenticates, or changes Vercel state.
+
+## Workflow
+
+1. Resolve the target:
+
+- Determine whether the user needs runtime logs, build logs, deployment status, or deployment discovery.
+- Prefer explicit deployment IDs, deployment URLs, project names, environments, branch names, commit SHAs, status filters, and time windows from the user.
+- When the user did not specify a project or team, treat `vercel.project` and `vercel.team` conversation config as optional defaults. Explicit user input always wins.
+- Only set or change `vercel.project` and `vercel.team` when the user explicitly asks to store a default for this conversation or channel.
+- Ask one concise follow-up only when the request cannot be bounded to a project, deployment, commit, or time window from the thread or config.
+
+2. Run the narrowest safe command:
+
+- The runtime provides Vercel authentication. Do not set, print, echo, write, or ask for `JUNIOR_VERCEL_TOKEN` or `VERCEL_TOKEN`.
+- If a command shape or flag is unclear, inspect `vercel <command> --help` before guessing.
+- Add `--scope <team>` when a team is known.
+- Add `--project <project>` when a project is known and the command supports it.
+- For runtime logs, prefer `vercel logs --project <project> --since <window> --limit 20 --json` plus user-provided filters such as `--environment`, `--level`, `--status-code`, `--source`, `--query`, or `--deployment`.
+- Use `vercel inspect <deployment-id-or-url> --logs` for build logs. Add `--wait` only when the user explicitly wants to wait for an active build; also bound it with `--timeout`.
+- Use `vercel list <project>` or `vercel ls <project>` to find deployments. Prefer filters such as `--status`, `--environment`, `--prod`, or `--meta githubCommitSha=<sha>` when available.
+- Use `--follow` only when the user asks for live logs, and stop once enough evidence is captured. Do not leave a streaming command running indefinitely.
+
+3. Bound and minimize output:
+
+- Always use a time window for log searches. Default to the last hour for "right now" incidents and the last 24 hours for retrospective deployment investigations.
+- Prefer JSON output for `vercel logs` when parsing or summarizing.
+- Keep page sizes small. Start with 20 log lines or fewer unless the user asked for more.
+- Quote only the minimum log text needed as evidence. Vercel logs may contain customer data, secrets, request headers, or other sensitive payloads.
+
+4. Report the result:
+
+- Answer the user first with deployment status, error pattern, top failing route/function, or the absence of matching logs.
+- Include the project, environment, deployment, time window, and filters used.
+- Include Vercel deployment or dashboard URLs when the CLI output provides them. Do not fabricate URLs from incomplete IDs.
+
+## Failure handling
+
+- Missing `JUNIOR_VERCEL_TOKEN`: tell the operator to add `JUNIOR_VERCEL_TOKEN` to the Junior deployment environment and redeploy.
+- `401`, invalid token, expired token, or revoked token: report that the configured Vercel token cannot authenticate.
+- `403` or permission denied: report that the configured Vercel token or service account cannot read the requested project/deployment/logs. Do not guess missing Vercel permission scopes.
+- Project not found: confirm `vercel.project`, `vercel.team`, and the user-provided project name or scope.
+- Rate limiting or transient network failure: retry the same bounded read command once. If it still fails, report the throttle or network failure and stop.
+- Mutation request: decline briefly and explain this skill is limited to read-only Vercel logs, deployment inspection, and deployment listing.

--- a/packages/junior/tests/unit/plugins/plugin-manifest-api-headers.test.ts
+++ b/packages/junior/tests/unit/plugins/plugin-manifest-api-headers.test.ts
@@ -103,6 +103,33 @@ describe("plugin manifest API headers", () => {
     expect(manifest.runtimePostinstall).toHaveLength(1);
   });
 
+  it("parses the packaged Vercel manifest", () => {
+    const manifestPath = path.resolve(
+      process.cwd(),
+      "../junior-vercel/plugin.yaml",
+    );
+    const manifest = parsePluginManifest(
+      readFileSync(manifestPath, "utf8"),
+      path.dirname(manifestPath),
+    );
+
+    expect(manifest.name).toBe("vercel");
+    expect(manifest.domains).toEqual(["api.vercel.com"]);
+    expect(manifest.apiHeaders).toEqual({
+      Authorization: "Bearer ${JUNIOR_VERCEL_TOKEN}",
+    });
+    expect(manifest.commandEnv).toEqual({
+      VERCEL_TOKEN: "host_managed_credential",
+    });
+    expect(manifest.runtimeDependencies).toEqual([
+      {
+        type: "npm",
+        package: "vercel",
+        version: "latest",
+      },
+    ]);
+  });
+
   it("parses the packaged GitHub command env host bindings", () => {
     const manifestPath = path.resolve(
       process.cwd(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       "@sentry/junior-sentry":
         specifier: workspace:*
         version: link:../../packages/junior-sentry
+      "@sentry/junior-vercel":
+        specifier: workspace:*
+        version: link:../../packages/junior-vercel
       hono:
         specifier: ^4.12.22
         version: 4.12.22
@@ -360,6 +363,8 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+
+  packages/junior-vercel: {}
 
 packages:
   "@ai-sdk/gateway@3.0.119":

--- a/scripts/bump-release-versions.mjs
+++ b/scripts/bump-release-versions.mjs
@@ -20,6 +20,7 @@ const files = [
   "packages/junior-notion/package.json",
   "packages/junior-scheduler/package.json",
   "packages/junior-sentry/package.json",
+  "packages/junior-vercel/package.json",
 ];
 
 for (const relativePath of files) {


### PR DESCRIPTION
## Summary
- Add `@sentry/junior-vercel` to release packaging, CI artifact packing, and release documentation
- Update example app docs and package wiring to include the Vercel plugin and token guidance
- Add Vercel plugin docs, README, manifest, and skill for read-only deployment and log investigation

## Testing
- Not run (not requested)