### PR TITLE
feat: tighten Sentry user attribution and GenAI trace redaction

### DIFF
--- a/packages/junior/src/chat/logging.ts
+++ b/packages/junior/src/chat/logging.ts
@@ -36,6 +36,7 @@ export interface LogContext {
   slackThreadId?: string;
   slackUserId?: string;
   slackUserName?: string;
+  slackUserEmail?: string;
   slackChannelId?: string;
   runId?: string;
   actorType?: string;
@@ -60,6 +61,12 @@ interface SentryLike {
   logger?: SentryLoggerApi;
   getActiveSpan?: () => unknown;
   spanToJSON?: (span: unknown) => { trace_id?: string; span_id?: string };
+}
+
+interface SentryUserIdentity {
+  id: string | number;
+  email?: string;
+  username?: string;
 }
 
 const MAX_STRING_VALUE = 1200;
@@ -158,6 +165,16 @@ const CONSOLE_PREVIEW_KEYS = new Set([
   "gen_ai.output.messages",
   "gen_ai.tool.call.arguments",
   "gen_ai.tool.call.result",
+]);
+const SENTRY_TAG_ATTRIBUTE_KEYS = new Set([
+  "app.platform",
+  "messaging.system",
+  "app.actor.type",
+  "gen_ai.agent.name",
+  "gen_ai.request.model",
+  "app.skill.name",
+  "http.request.method",
+  "url.path",
 ]);
 
 function getSentryEnvironment(): string {
@@ -1178,6 +1195,7 @@ export const log = {
     error: unknown,
     attrs: Record<string, unknown> = {},
     body?: string,
+    context?: LogContext,
   ): string | undefined {
     const normalizedError =
       error instanceof Error ? error : new Error(String(error));
@@ -1211,6 +1229,9 @@ export const log = {
       typeof sentryCaptureException === "function"
     ) {
       sentryWithScope((scope) => {
+        if (context) {
+          setSentryScopeContext(scope, context);
+        }
         for (const [key, value] of Object.entries(
           mergeAttributes(contextStorage.getStore(), attrs),
         )) {
@@ -1222,6 +1243,9 @@ export const log = {
     }
 
     if (typeof sentryCaptureException === "function") {
+      if (context) {
+        setSentryUser(sentryUserIdentityFromContext(context));
+      }
       eventId = sentryCaptureException(normalizedError);
     }
     return eventId;
@@ -1397,33 +1421,64 @@ export function toSpanAttributes(context: LogContext): Record<string, string> {
   ) as Record<string, string>;
 }
 
+/** Attach filterable non-user context tags to Sentry. */
 export function setSentryTagsFromContext(context: LogContext): void {
   const attrs = contextToAttributes(context);
   for (const [key, value] of Object.entries(attrs)) {
+    if (!SENTRY_TAG_ATTRIBUTE_KEYS.has(key)) {
+      continue;
+    }
     if (typeof value === "string" && value.length > 0) {
       Sentry.setTag(key, value);
     }
   }
-  if (context.slackUserId) {
-    Sentry.setUser({
-      id: context.slackUserId,
-      username: context.slackUserName,
-    });
-  }
 }
 
+function sentryUserIdentityFromContext(
+  context: LogContext,
+): SentryUserIdentity | undefined {
+  if (context.slackUserId) {
+    return {
+      id: context.slackUserId,
+      ...(context.slackUserName ? { username: context.slackUserName } : {}),
+      ...(context.slackUserEmail ? { email: context.slackUserEmail } : {}),
+    };
+  }
+  return undefined;
+}
+
+function sentryUserFromIdentity(identity: SentryUserIdentity): Sentry.User {
+  return {
+    id: identity.id,
+    ip_address: null,
+    ...(identity.username ? { username: identity.username } : {}),
+    ...(identity.email ? { email: identity.email } : {}),
+  };
+}
+
+/** Bind requester identity to Sentry's native user fields. */
+export function setSentryUser(identity: SentryUserIdentity | undefined): void {
+  if (!identity) return;
+  Sentry.setUser(sentryUserFromIdentity(identity));
+}
+
+/** Attach scoped Sentry context for isolated exception capture. */
 export function setSentryScopeContext(
   scope: Sentry.Scope,
   context: LogContext,
 ): void {
   const attrs = contextToAttributes(context);
   for (const [key, value] of Object.entries(attrs)) {
+    if (!SENTRY_TAG_ATTRIBUTE_KEYS.has(key)) {
+      continue;
+    }
     if (typeof value === "string" && value.length > 0) {
       scope.setTag(key, value);
     }
   }
-  if (context.slackUserId) {
-    scope.setUser({ id: context.slackUserId, username: context.slackUserName });
+  const identity = sentryUserIdentityFromContext(context);
+  if (identity) {
+    scope.setUser(sentryUserFromIdentity(identity));
   }
   scope.setContext("app", attrs);
 }
@@ -1484,6 +1539,7 @@ export function captureException(
     normalizedError,
     toSpanAttributes(context),
     "Captured exception",
+    context,
   );
 }
 
@@ -1532,13 +1588,15 @@ export function logException(
     normalizedError,
     { ...toSpanAttributes(context), ...attributes },
     body,
+    context,
   );
 }
 
-/** Set log context and Sentry tags for the current scope. */
+/** Set log context and Sentry scope metadata for the current request. */
 export function setTags(context: LogContext = {}): void {
   setLogContext(context);
   setSentryTagsFromContext(context);
+  setSentryUser(sentryUserIdentityFromContext(context));
 }
 
 /** Create a LogContext from an incoming HTTP request. */
@@ -1654,6 +1712,7 @@ export function captureExceptionInScope(
   }
 
   if (typeof sentryCaptureException === "function") {
+    setSentryUser(sentryUserIdentityFromContext(context));
     sentryCaptureException(normalizedError);
   }
 }
@@ -1722,7 +1781,7 @@ function sanitizeGenAiValue(
     if (shouldTreatAsBlob) {
       return `[omitted:${value.length}]`;
     }
-    return truncateGenAiString(value, GEN_AI_MAX_STRING_CHARS);
+    return truncateGenAiString(redactSecrets(value), GEN_AI_MAX_STRING_CHARS);
   }
 
   if (typeof value === "number") {
@@ -1745,7 +1804,7 @@ function sanitizeGenAiValue(
   }
 
   if (typeof value !== "object") {
-    return String(value);
+    return redactSecrets(String(value));
   }
 
   if (seen.has(value)) {
@@ -1783,7 +1842,7 @@ export function serializeGenAiAttribute(
     return undefined;
   }
 
-  return truncateGenAiString(serialized, maxChars);
+  return truncateGenAiString(redactSecrets(serialized), maxChars);
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -15,6 +15,7 @@ import {
   getActiveTraceId,
   logInfo,
   logWarn,
+  setSentryUser,
   setSpanAttributes,
   setTags,
   withSpan,
@@ -535,6 +536,15 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
 
         const resolvedUserName =
           message.author.userName ?? fallbackIdentity?.userName;
+        if (message.author.userId) {
+          setSentryUser({
+            id: message.author.userId,
+            ...(resolvedUserName ? { username: resolvedUserName } : {}),
+            ...(fallbackIdentity?.email
+              ? { email: fallbackIdentity.email }
+              : {}),
+          });
+        }
         if (resolvedUserName) {
           setTags({ slackUserName: resolvedUserName });
         }

--- a/packages/junior/tests/unit/logging/sentry-context.test.ts
+++ b/packages/junior/tests/unit/logging/sentry-context.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const sentry = vi.hoisted(() => {
+  const scope = {
+    setContext: vi.fn(),
+    setExtra: vi.fn(),
+    setTag: vi.fn(),
+    setUser: vi.fn(),
+  };
+  return {
+    captureException: vi.fn(() => "event-id"),
+    scope,
+    setTag: vi.fn(),
+    setUser: vi.fn(),
+    withScope: vi.fn((callback: (scope: unknown) => void) => callback(scope)),
+  };
+});
+
+vi.mock("@/chat/sentry", () => ({
+  captureException: sentry.captureException,
+  getActiveSpan: () => undefined,
+  setTag: sentry.setTag,
+  setUser: sentry.setUser,
+  spanToJSON: () => ({}),
+  withScope: sentry.withScope,
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+});
+
+describe("Sentry context", () => {
+  it("uses native user identity and a small tag allowlist", async () => {
+    const { setTags } = await import("@/chat/logging");
+
+    setTags({
+      conversationId: "thread_123",
+      platform: "slack",
+      slackThreadId: "thread_123",
+      slackUserId: "U123",
+      slackUserName: "alice",
+      slackUserEmail: "alice@example.com",
+      slackChannelId: "C123",
+      runId: "run_123",
+      assistantUserName: "junior",
+      modelId: "openai/gpt-5.4",
+      httpMethod: "POST",
+    });
+
+    expect(sentry.setUser).toHaveBeenCalledWith({
+      id: "U123",
+      ip_address: null,
+      username: "alice",
+      email: "alice@example.com",
+    });
+    expect(sentry.setTag).toHaveBeenCalledWith("messaging.system", "slack");
+    expect(sentry.setTag).toHaveBeenCalledWith("gen_ai.agent.name", "junior");
+    expect(sentry.setTag).toHaveBeenCalledWith(
+      "gen_ai.request.model",
+      "openai/gpt-5.4",
+    );
+    expect(sentry.setTag).toHaveBeenCalledWith("http.request.method", "POST");
+    expect(sentry.setTag).not.toHaveBeenCalledWith(
+      "gen_ai.conversation.id",
+      "thread_123",
+    );
+    expect(sentry.setTag).not.toHaveBeenCalledWith(
+      "messaging.message.conversation_id",
+      "thread_123",
+    );
+    expect(sentry.setTag).not.toHaveBeenCalledWith(
+      "messaging.destination.name",
+      "C123",
+    );
+    expect(sentry.setTag).not.toHaveBeenCalledWith("enduser.id", "U123");
+    expect(sentry.setTag).not.toHaveBeenCalledWith(
+      "enduser.pseudo.id",
+      "alice",
+    );
+    expect(sentry.setTag).not.toHaveBeenCalledWith("app.run.id", "run_123");
+  });
+
+  it("keeps user attributes in scoped context without tagging them", async () => {
+    const logging = await import("@/chat/logging");
+    const scope = {
+      setContext: vi.fn(),
+      setTag: vi.fn(),
+      setUser: vi.fn(),
+    };
+
+    logging.setSentryScopeContext(
+      scope as unknown as Parameters<typeof logging.setSentryScopeContext>[0],
+      {
+        conversationId: "thread_123",
+        slackUserId: "U123",
+        slackUserName: "alice",
+        slackUserEmail: "alice@example.com",
+        modelId: "openai/gpt-5.4",
+      },
+    );
+
+    expect(scope.setUser).toHaveBeenCalledWith({
+      id: "U123",
+      ip_address: null,
+      username: "alice",
+      email: "alice@example.com",
+    });
+    expect(scope.setTag).toHaveBeenCalledWith(
+      "gen_ai.request.model",
+      "openai/gpt-5.4",
+    );
+    expect(scope.setTag).not.toHaveBeenCalledWith(
+      "gen_ai.conversation.id",
+      "thread_123",
+    );
+    expect(scope.setTag).not.toHaveBeenCalledWith("enduser.id", "U123");
+    expect(scope.setTag).not.toHaveBeenCalledWith("enduser.pseudo.id", "alice");
+    expect(scope.setContext).toHaveBeenCalledWith(
+      "app",
+      expect.objectContaining({
+        "enduser.id": "U123",
+        "enduser.pseudo.id": "alice",
+      }),
+    );
+  });
+
+  it("applies native user identity when capturing exceptions with context", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const { logException } = await import("@/chat/logging");
+
+    const eventId = logException(
+      new Error("boom"),
+      "turn_failed",
+      {
+        slackUserId: "U123",
+        slackUserName: "alice",
+        slackUserEmail: "alice@example.com",
+        modelId: "openai/gpt-5.4",
+      },
+      {},
+      "Turn failed",
+    );
+
+    expect(eventId).toBe("event-id");
+    expect(sentry.scope.setUser).toHaveBeenCalledWith({
+      id: "U123",
+      ip_address: null,
+      username: "alice",
+      email: "alice@example.com",
+    });
+    expect(sentry.scope.setTag).toHaveBeenCalledWith(
+      "gen_ai.request.model",
+      "openai/gpt-5.4",
+    );
+    expect(sentry.captureException).toHaveBeenCalledWith(expect.any(Error));
+  });
+});

--- a/packages/junior/tests/unit/logging/serialize-gen-ai-attribute.test.ts
+++ b/packages/junior/tests/unit/logging/serialize-gen-ai-attribute.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { serializeGenAiAttribute } from "@/chat/logging";
+
+describe("serializeGenAiAttribute", () => {
+  it("redacts secret-looking strings before emitting trace attributes", () => {
+    const slackToken = [
+      "xoxb",
+      "1234567890",
+      "abcdefghijklmnopqrstuvwxyz",
+    ].join("-");
+    const serialized = serializeGenAiAttribute({
+      bearer: "Bearer abcdefghijklmnopqrstuvwxyz1234567890",
+      openai: "sk-abcdefghijklmnopqrstuvwxyz1234567890",
+      slack: slackToken,
+      nested: {
+        privateKey: [
+          "-----BEGIN PRIVATE KEY-----",
+          "super-secret-material",
+          "-----END PRIVATE KEY-----",
+        ].join("\n"),
+      },
+    });
+
+    expect(serialized).toContain("Bearer abcd...7890");
+    expect(serialized).toContain("sk-a...7890");
+    expect(serialized).toContain("xoxb...wxyz");
+    expect(serialized).toContain("...redacted...");
+    expect(serialized).not.toContain("abcdefghijklmnopqrstuvwxyz1234567890");
+    expect(serialized).not.toContain("super-secret-material");
+  });
+});


### PR DESCRIPTION
## Summary
- Route Slack requester identity through Sentry's native user context, including email, while clearing inferred IP attribution.
- Restrict Sentry tags to a small low-cardinality allowlist instead of bulk-promoting OTel context fields.
- Apply the existing secret redaction path to GenAI trace payload serialization so public trace attributes do not retain token-like values.
- Ensure exception capture paths carry the same Sentry user/context behavior as the reply flow.

## Testing
- Added targeted unit coverage for Sentry user context, scoped exception capture, and GenAI attribute redaction.
- Verified the logging, GenAI telemetry, typecheck, and lint test suites pass locally.