### PR TITLE
Gate synthetic system prompts and update duration chart toggle

### DIFF
--- a/packages/junior-dashboard/src/client/components/TranscriptTurn.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptTurn.tsx
@@ -643,7 +643,7 @@ function SystemMessageView(props: {
 
   return (
     <details
-      className={cn(transcriptMessageClass(role), !open && "gap-0")}
+      className={cn(transcriptMessageClass(role), !open && "gap-y-0")}
       onToggle={(event) => {
         if (event.currentTarget !== event.target) return;
         setOpen(event.currentTarget.open);

--- a/packages/junior-dashboard/src/client/components/TurnDurationChart.tsx
+++ b/packages/junior-dashboard/src/client/components/TurnDurationChart.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type ReactNode } from "react";
+import { Fragment, useMemo, useState, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router";
 import {
@@ -41,7 +41,6 @@ import type {
 import { MetricValue } from "./Metric";
 import { Section } from "./Section";
 import { SectionHeader } from "./SectionHeader";
-import { SectionTitle } from "./SectionTitle";
 import {
   DurationMetric,
   MessagesMetric,
@@ -55,7 +54,7 @@ export function TurnDurationChart(props: {
   sessions: Session[];
   timeZone: string;
 }) {
-  const [mode, setMode] = useState<DurationChartMode>("turns");
+  const [mode, setMode] = useState<DurationChartMode>("conversations");
   const navigate = useNavigate();
   const nowMs = Date.now();
   const rangeStartMs = nowMs - 7 * 24 * 60 * 60 * 1000;
@@ -109,10 +108,7 @@ export function TurnDurationChart(props: {
           </div>
         }
       >
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
-          <SectionTitle>Durations</SectionTitle>
-          <ChartModeToggle mode={mode} onChange={setMode} />
-        </div>
+        <ChartModeToggle mode={mode} onChange={setMode} />
       </SectionHeader>
       <div
         className="min-h-48 px-3 pb-2 pt-4"
@@ -206,30 +202,36 @@ function ChartModeToggle(props: {
   onChange(mode: DurationChartMode): void;
 }) {
   const modes: Array<{ label: string; value: DurationChartMode }> = [
-    { label: "Turns", value: "turns" },
     { label: "Conversations", value: "conversations" },
+    { label: "Turns", value: "turns" },
   ];
   return (
     <div
       aria-label="Duration chart mode"
-      className="inline-flex items-center gap-3"
+      className="inline-flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-1"
       role="group"
     >
-      {modes.map((mode) => (
-        <button
-          aria-pressed={props.mode === mode.value}
-          className={cn(
-            "cursor-pointer border-0 border-b-2 bg-transparent px-0.5 pb-1 pt-0.5 text-[0.78rem] font-semibold leading-none transition-colors",
-            props.mode === mode.value
-              ? "border-[#b59cff] text-white"
-              : "border-transparent text-[#888] hover:border-white/25 hover:text-white",
-          )}
-          key={mode.value}
-          onClick={() => props.onChange(mode.value)}
-          type="button"
-        >
-          {mode.label}
-        </button>
+      {modes.map((mode, index) => (
+        <Fragment key={mode.value}>
+          {index > 0 ? (
+            <span className="text-[1.05rem] font-bold leading-tight text-[#666]">
+              /
+            </span>
+          ) : null}
+          <button
+            aria-pressed={props.mode === mode.value}
+            className={cn(
+              "cursor-pointer border-0 bg-transparent p-0 text-[1.05rem] font-bold leading-tight tracking-normal transition-colors",
+              props.mode === mode.value
+                ? "text-white"
+                : "text-[#888] hover:text-white",
+            )}
+            onClick={() => props.onChange(mode.value)}
+            type="button"
+          >
+            {mode.label}
+          </button>
+        </Fragment>
       ))}
     </div>
   );

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { ToolCallsMetric } from "../src/client/components/TelemetryMetrics";
 import { TranscriptToolView } from "../src/client/components/TranscriptToolView";
 import { TurnTranscript } from "../src/client/components/TranscriptTurn";
+import { TurnDurationChart } from "../src/client/components/TurnDurationChart";
 import { client } from "../src/client/api";
 import { ConversationPage } from "../src/client/pages/ConversationPage";
 import type {
@@ -90,6 +91,65 @@ describe("dashboard telemetry components", () => {
 
     expect(html).toContain("View in Sentry");
     expect(html).toContain("https://sentry.example/trace/abc");
+  });
+
+  it("removes residual grid row gap from collapsed system prompts", () => {
+    const turn = {
+      conversationId: "conversation-1",
+      id: "turn-1",
+      lastProgressAt: "2026-01-01T00:00:00.000Z",
+      lastSeenAt: "2026-01-01T00:00:00.000Z",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      status: "completed",
+      surface: "slack",
+      title: "Turn turn-1",
+      transcript: [
+        {
+          role: "system",
+          parts: [{ type: "text", text: "System prompt" }],
+        },
+      ],
+      transcriptAvailable: true,
+    } as ConversationTurn;
+
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={client}>
+        <TurnTranscript number={1} turn={turn} view="rich" />
+      </QueryClientProvider>,
+    );
+
+    expect(html).toContain("gap-y-0");
+  });
+
+  it("uses chart mode links as the duration chart title", () => {
+    const session = {
+      conversationId: "conversation-1",
+      id: "turn-1",
+      completedAt: "2026-01-01T00:00:03.000Z",
+      lastProgressAt: "2026-01-01T00:00:03.000Z",
+      lastSeenAt: "2026-01-01T00:00:03.000Z",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      status: "completed",
+      surface: "slack",
+      title: "Turn turn-1",
+    } satisfies Session;
+
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={client}>
+        <MemoryRouter>
+          <TurnDurationChart sessions={[session]} timeZone="UTC" />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(html).not.toContain("Durations");
+    expect(html).toContain("Turns");
+    expect(html).toContain("Conversations");
+    expect(html.indexOf("Conversations")).toBeLessThan(html.indexOf("Turns"));
+    expect(html).toMatch(/aria-pressed="true"[^>]*>Conversations/);
+    expect(html).toContain(
+      'aria-label="conversations by duration over the last 7 days"',
+    );
   });
 
   it("omits empty tool-call summaries", () => {

--- a/packages/junior/src/reporting.ts
+++ b/packages/junior/src/reporting.ts
@@ -588,7 +588,7 @@ function countConversationMessages(
   return transcript.filter(isConversationMessage).length;
 }
 
-/** Build the synthetic system-prompt message prepended to each exposed turn transcript. */
+/** Build the synthetic system-prompt message shown only at a run boundary. */
 function systemPromptMessage(): DashboardTranscriptMessage {
   return {
     role: "system",
@@ -596,14 +596,25 @@ function systemPromptMessage(): DashboardTranscriptMessage {
   };
 }
 
-function turnScopedMessages(messages: PiMessage[]): PiMessage[] {
+interface ScopedTurnMessages {
+  messages: PiMessage[];
+  startsAtRunBoundary: boolean;
+}
+
+function turnScopedMessages(messages: PiMessage[]): ScopedTurnMessages {
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const record = messages[index] as unknown as Record<string, unknown>;
     if (record.role === "user") {
-      return messages.slice(index);
+      return {
+        messages: messages.slice(index),
+        startsAtRunBoundary: index === 0,
+      };
     }
   }
-  return messages;
+  return {
+    messages,
+    startsAtRunBoundary: messages.length > 0,
+  };
 }
 
 function traceIdFromTranscript(
@@ -658,15 +669,21 @@ async function readConversation(
       );
       const scopedMessages = sessionRecord?.piMessages
         ? turnScopedMessages(sessionRecord.piMessages)
-        : [];
+        : { messages: [], startsAtRunBoundary: false };
       const canExposeTranscript = canExposeConversationTranscript(summary);
-      const normalizedTranscript = scopedMessages.map(
+      const normalizedTranscript = scopedMessages.messages.map(
         normalizeTranscriptMessage,
       );
       const transcriptMessageCount =
         countConversationMessages(normalizedTranscript);
       const transcript = canExposeTranscript
-        ? [systemPromptMessage(), ...normalizedTranscript]
+        ? [
+            ...(scopedMessages.startsAtRunBoundary &&
+            normalizedTranscript.length > 0
+              ? [systemPromptMessage()]
+              : []),
+            ...normalizedTranscript,
+          ]
         : [];
       const transcriptMetadata = canExposeTranscript
         ? undefined

--- a/packages/junior/tests/integration/dashboard-reporting.test.ts
+++ b/packages/junior/tests/integration/dashboard-reporting.test.ts
@@ -149,7 +149,6 @@ describe("dashboard reporting", () => {
       transcriptMessageCount: 2,
     });
     expect(report.turns[0]!.transcript).toEqual([
-      SYSTEM_MESSAGE,
       {
         role: "user",
         timestamp: 3,
@@ -305,7 +304,6 @@ describe("dashboard reporting", () => {
     ]);
     expect(report.turns[1]).toMatchObject({ id: "turn-two" });
     expect(report.turns[1]!.transcript).toEqual([
-      SYSTEM_MESSAGE,
       {
         role: "user",
         timestamp: 3,

--- a/specs/dashboard.md
+++ b/specs/dashboard.md
@@ -144,6 +144,11 @@ Dashboard JSON APIs are split by view concern:
 | `GET /api/dashboard/config`                      | Safe config counts, timezone, and feature signals.  |
 | `GET /api/dashboard/me`                          | Signed-in dashboard identity.                       |
 
+Conversation transcript responses may synthesize the static system prompt only
+when the exposed transcript begins at a model run boundary. Follow-up turn
+transcripts that are scoped to the current user message must not repeat the
+system prompt.
+
 The current public diagnostics surfaces must move behind dashboard auth:
 
 - The HTML diagnostics page stays at `/` when the dashboard package is mounted, but requires dashboard auth.


### PR DESCRIPTION
## Summary
- Only synthesize the static system prompt when a transcript starts at a run boundary, so follow-up turns scoped to the current user message do not repeat it.
- Adjust the collapsed system message spacing to remove the residual row gap.
- Rework the duration chart header so `Conversations` is the default active mode and the toggle renders as `Conversations / Turns`.
- Add coverage for the transcript boundary behavior and the chart header rendering.

## Testing
- Updated dashboard integration and component tests for transcript scoping, collapsed system prompts, and chart mode rendering.
- Verified the dashboard UI locally in the browser and confirmed the duration chart default state and transcript spacing behavior.
- Typecheck and targeted Vitest coverage passed.