### PR TITLE
Preserve transcript whitespace in markdown export and redact tool metadata

### DIFF
--- a/packages/junior-dashboard/package.json
+++ b/packages/junior-dashboard/package.json
@@ -45,6 +45,7 @@
     "@tanstack/react-query": "^5.100.14",
     "better-auth": "^1.3.36",
     "hono": "^4.12.22",
+    "lucide-react": "^1.17.0",
     "nitro": "3.0.260522-beta",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",

--- a/packages/junior-dashboard/src/client/App.tsx
+++ b/packages/junior-dashboard/src/client/App.tsx
@@ -1,3 +1,4 @@
+import { LogOut } from "lucide-react";
 import {
   Link,
   Navigate,
@@ -8,6 +9,7 @@ import {
 } from "react-router";
 
 import { useDashboardData } from "./api";
+import { Button } from "./components/Button";
 import { LoadingView } from "./components/LoadingView";
 import {
   conversationPath,
@@ -80,43 +82,14 @@ export function DashboardShell() {
             </NavLink>
           </nav>
           {loggedIn ? (
-            <button
+            <Button
               aria-label="Log out"
-              className="grid size-9 cursor-pointer place-items-center border border-white/15 bg-[#0b0b0b] p-0 text-[#b8b8b8] transition-colors hover:border-white/30 hover:bg-[#151515] hover:text-white"
-              type="button"
-              title="Log out"
               onClick={() => void signOut()}
+              size="icon"
+              title="Log out"
             >
-              <svg
-                aria-hidden="true"
-                fill="none"
-                height="16"
-                viewBox="0 0 24 24"
-                width="16"
-              >
-                <path
-                  d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"
-                  stroke="currentColor"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                />
-                <path
-                  d="m16 17 5-5-5-5"
-                  stroke="currentColor"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                />
-                <path
-                  d="M21 12H9"
-                  stroke="currentColor"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                />
-              </svg>
-            </button>
+              <LogOut aria-hidden="true" size={16} strokeWidth={2} />
+            </Button>
           ) : null}
         </div>
       </header>

--- a/packages/junior-dashboard/src/client/components/Button.tsx
+++ b/packages/junior-dashboard/src/client/components/Button.tsx
@@ -1,0 +1,75 @@
+import type { ButtonHTMLAttributes } from "react";
+
+import { cn } from "../styles";
+
+type ButtonSize = "default" | "icon";
+type ToggleButtonVariant = "pill" | "text";
+
+export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  size?: ButtonSize;
+};
+
+export type ToggleButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  pressed: boolean;
+  variant: ToggleButtonVariant;
+};
+
+/** Render the dashboard's standard bordered command button surface. */
+export function Button({
+  className,
+  size = "default",
+  type = "button",
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      {...props}
+      className={cn(
+        "border border-white/15 bg-[#0b0b0b] text-[#d6d6d6] transition-colors hover:border-white/30 hover:bg-[#151515] hover:text-white disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-white/15 disabled:hover:bg-[#0b0b0b] disabled:hover:text-[#d6d6d6]",
+        size === "icon"
+          ? "grid size-9 place-items-center p-0"
+          : "inline-flex h-9 max-w-full items-center gap-2 px-3 text-[0.82rem] font-semibold leading-none",
+        props.disabled ? "" : "cursor-pointer",
+        className,
+      )}
+      type={type}
+    />
+  );
+}
+
+/** Render a dashboard toggle button with a consistent pressed-state contract. */
+export function ToggleButton({
+  className,
+  pressed,
+  type = "button",
+  variant,
+  ...props
+}: ToggleButtonProps) {
+  return (
+    <button
+      {...props}
+      aria-pressed={pressed}
+      className={cn(
+        toggleButtonBase[variant],
+        pressed ? toggleButtonPressed[variant] : toggleButtonIdle[variant],
+        className,
+      )}
+      type={type}
+    />
+  );
+}
+
+const toggleButtonBase: Record<ToggleButtonVariant, string> = {
+  pill: "cursor-pointer border px-2 py-1 text-[0.78rem] font-semibold uppercase leading-tight transition-colors focus-visible:outline focus-visible:outline-1 focus-visible:outline-[#beaaff]/55",
+  text: "cursor-pointer border-0 bg-transparent px-1.5 py-1 uppercase tracking-normal underline-offset-4 transition-colors focus-visible:outline focus-visible:outline-1 focus-visible:outline-[#beaaff]/55",
+};
+
+const toggleButtonPressed: Record<ToggleButtonVariant, string> = {
+  pill: "border-white/30 bg-white text-black",
+  text: "text-white underline decoration-white",
+};
+
+const toggleButtonIdle: Record<ToggleButtonVariant, string> = {
+  pill: "border-white/10 bg-[#0b0b0b] text-[#888] hover:border-white/25 hover:bg-[#151515] hover:text-white",
+  text: "text-[#888] hover:text-white",
+};

--- a/packages/junior-dashboard/src/client/components/FilterTabs.tsx
+++ b/packages/junior-dashboard/src/client/components/FilterTabs.tsx
@@ -1,4 +1,4 @@
-import { cn } from "../styles";
+import { ToggleButton } from "./Button";
 import type { SessionFilter } from "../types";
 
 /** Render conversation filters while keeping URL state owned by the page. */
@@ -14,21 +14,20 @@ export function FilterTabs(props: {
     "all",
   ];
   return (
-    <div className="flex flex-wrap items-center justify-end gap-1">
+    <div
+      aria-label="Conversation filter"
+      className="flex flex-wrap items-center justify-end gap-1"
+      role="group"
+    >
       {filters.map((filter) => (
-        <button
-          className={cn(
-            "cursor-pointer border px-2 py-1 text-[0.78rem] font-semibold uppercase leading-tight transition-colors",
-            props.current === filter
-              ? "border-white/30 bg-white text-black"
-              : "border-white/10 bg-[#0b0b0b] text-[#888] hover:border-white/25 hover:bg-[#151515] hover:text-white",
-          )}
+        <ToggleButton
           key={filter}
           onClick={() => props.onChange(filter)}
-          type="button"
+          pressed={props.current === filter}
+          variant="pill"
         >
           {filter}
-        </button>
+        </ToggleButton>
       ))}
     </div>
   );

--- a/packages/junior-dashboard/src/client/components/TranscriptHeader.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptHeader.tsx
@@ -1,3 +1,4 @@
+import { ToggleButton } from "./Button";
 import type { TranscriptViewMode } from "./transcriptRenderModel";
 
 /** Render transcript controls without coupling them to turn rendering. */
@@ -30,22 +31,19 @@ function TranscriptViewToggle(props: {
   const options: TranscriptViewMode[] = ["rich", "raw"];
   return (
     <div
-      className="inline-flex items-center gap-1 text-[0.82rem] font-semibold text-[#888]"
       aria-label="Transcript view"
+      className="inline-flex items-center gap-1 text-[0.82rem] font-semibold text-[#888]"
+      role="group"
     >
       {options.map((option) => (
-        <button
-          className={`cursor-pointer border-0 bg-transparent px-1.5 py-1 uppercase tracking-normal underline-offset-4 ${
-            props.value === option
-              ? "text-white underline decoration-white"
-              : "text-[#888] hover:text-white"
-          }`}
+        <ToggleButton
           key={option}
           onClick={() => props.onChange(option)}
-          type="button"
+          pressed={props.value === option}
+          variant="text"
         >
           {option}
-        </button>
+        </ToggleButton>
       ))}
     </div>
   );

--- a/packages/junior-dashboard/src/client/markdownExport.ts
+++ b/packages/junior-dashboard/src/client/markdownExport.ts
@@ -175,17 +175,27 @@ function appendTool(
   timestamp: number | undefined,
   resultTimestamp: number | undefined,
 ): void {
-  lines.push("", `### Tool: ${headingText(toolName(call, result))}`);
-  addEventMeta(lines, turn, timestamp);
-  addMetaLine(lines, "Result timestamp", eventTimestamp(resultTimestamp));
-  addMetaLine(lines, "Duration", toolDuration(timestamp, resultTimestamp));
-  if (!result) {
-    addMetaLine(lines, "Result", "missing");
-  }
+  appendToolHeader(lines, turn, call, result, timestamp, resultTimestamp);
   lines.push("", fencedBlock(stringifyPartValue({ call, result }), "json"));
 }
 
 function appendRedactedTool(
+  lines: string[],
+  turn: ConversationTurn,
+  call: TranscriptPart | undefined,
+  result: TranscriptPart | undefined,
+  timestamp: number | undefined,
+  resultTimestamp: number | undefined,
+): void {
+  appendToolHeader(lines, turn, call, result, timestamp, resultTimestamp);
+
+  const redactedLines = [call, result]
+    .filter((part): part is TranscriptPart => part !== undefined)
+    .map(redactedPartLabel);
+  lines.push("", ...redactedLines.map((line) => `- ${line}`));
+}
+
+function appendToolHeader(
   lines: string[],
   turn: ConversationTurn,
   call: TranscriptPart | undefined,
@@ -200,11 +210,6 @@ function appendRedactedTool(
   if (!result) {
     addMetaLine(lines, "Result", "missing");
   }
-
-  const redactedLines = [call, result]
-    .filter((part): part is TranscriptPart => part !== undefined)
-    .map(redactedPartLabel);
-  lines.push("", ...redactedLines.map((line) => `- ${line}`));
 }
 
 function addEventMeta(

--- a/packages/junior-dashboard/src/client/markdownExport.ts
+++ b/packages/junior-dashboard/src/client/markdownExport.ts
@@ -1,0 +1,325 @@
+import {
+  conversationDisplayTitle,
+  formatMs,
+  formatTurnDuration,
+  formatUsageTotal,
+  requesterLabel,
+  slackLocationLabel,
+  stringifyPartValue,
+  transcriptRoleKind,
+  unavailableTranscriptLabel,
+} from "./format";
+import {
+  groupTranscriptMessages,
+  messageRawText,
+} from "./components/transcriptRenderModel";
+import type {
+  Conversation,
+  ConversationDetailFeed,
+  ConversationTurn,
+  TranscriptMessage,
+  TranscriptPart,
+} from "./types";
+
+/** Build a clipboard Markdown transcript from the already-authorized dashboard report. */
+export function buildConversationMarkdown(
+  detail: ConversationDetailFeed,
+  conversation?: Conversation,
+): string {
+  const lines: string[] = [];
+  const firstTurn = detail.turns[0];
+
+  lines.push(`# ${headingText(conversationTitle(detail, conversation))}`, "");
+  addMetaLine(lines, "Conversation ID", inlineCode(detail.conversationId));
+  addMetaLine(lines, "Generated", detail.generatedAt);
+  addMetaLine(
+    lines,
+    "Requester",
+    conversationRequester(conversation, firstTurn),
+  );
+  addMetaLine(lines, "Location", conversationLocation(conversation, firstTurn));
+  addMetaLine(lines, "Turns", String(detail.turns.length));
+  addMetaLine(
+    lines,
+    "Sentry conversation",
+    conversation?.sentryConversationUrl ?? firstTurn?.sentryConversationUrl,
+  );
+
+  if (detail.turns.length === 0) {
+    lines.push("", "## Transcript", "", "No transcript is available.");
+    return trimMarkdown(lines);
+  }
+
+  detail.turns.forEach((turn, index) => {
+    lines.push("", `## ${turnHeading(turn, index)}`, "");
+    addMetaLine(lines, "Turn ID", inlineCode(turn.id));
+    addMetaLine(lines, "Status", inlineCode(turn.status));
+    addMetaLine(lines, "Started", turn.startedAt);
+    addMetaLine(lines, "Completed", turn.completedAt);
+    addMetaLine(lines, "Last seen", turn.lastSeenAt);
+    addMetaLine(lines, "Duration", formatTurnDuration(turn));
+    addMetaLine(lines, "Usage", formatUsageTotal([turn.cumulativeUsage]));
+    addMetaLine(
+      lines,
+      "Trace ID",
+      turn.traceId ? inlineCode(turn.traceId) : "",
+    );
+    addMetaLine(lines, "Sentry trace", turn.sentryTraceUrl);
+
+    appendTurnTranscript(lines, turn);
+  });
+
+  return trimMarkdown(lines);
+}
+
+function appendTurnTranscript(lines: string[], turn: ConversationTurn): void {
+  if (turn.transcriptAvailable) {
+    appendTranscriptMessages(lines, turn, turn.transcript, false);
+    return;
+  }
+
+  if (turn.transcriptRedacted && turn.transcriptMetadata?.length) {
+    lines.push(
+      "",
+      "Transcript hidden because this conversation is not public.",
+    );
+    appendTranscriptMessages(lines, turn, turn.transcriptMetadata, true);
+    return;
+  }
+
+  lines.push("", unavailableTranscriptLabel(turn));
+}
+
+function appendTranscriptMessages(
+  lines: string[],
+  turn: ConversationTurn,
+  messages: TranscriptMessage[],
+  redacted: boolean,
+): void {
+  for (const entry of groupTranscriptMessages(messages)) {
+    if (entry.kind === "message") {
+      appendMessage(lines, turn, entry.message, redacted);
+      continue;
+    }
+
+    if (entry.kind === "thinking") {
+      appendThinking(lines, turn, entry.part, entry.timestamp, redacted);
+      continue;
+    }
+
+    appendTool(
+      lines,
+      turn,
+      entry.call,
+      entry.result,
+      entry.timestamp,
+      entry.resultTimestamp,
+    );
+  }
+}
+
+function appendMessage(
+  lines: string[],
+  turn: ConversationTurn,
+  message: TranscriptMessage,
+  redacted: boolean,
+): void {
+  lines.push("", `### ${messageRoleLabel(message, turn)}`);
+  addEventMeta(lines, turn, message.timestamp);
+
+  if (redacted) {
+    const redactedLines = message.parts.map(redactedPartLabel);
+    lines.push("", ...redactedLines.map((line) => `- ${line}`));
+    return;
+  }
+
+  const rawText = messageRawText(message).trim();
+  lines.push("", rawText || "_No content._");
+}
+
+function appendThinking(
+  lines: string[],
+  turn: ConversationTurn,
+  part: TranscriptPart,
+  timestamp: number | undefined,
+  redacted: boolean,
+): void {
+  lines.push("", "### Thinking");
+  addEventMeta(lines, turn, timestamp);
+
+  if (redacted) {
+    lines.push("", `- ${redactedPartLabel(part)}`);
+    return;
+  }
+
+  lines.push("", fencedBlock(stringifyPartValue(part.output), "text"));
+}
+
+function appendTool(
+  lines: string[],
+  turn: ConversationTurn,
+  call: TranscriptPart | undefined,
+  result: TranscriptPart | undefined,
+  timestamp: number | undefined,
+  resultTimestamp: number | undefined,
+): void {
+  lines.push("", `### Tool: ${headingText(toolName(call, result))}`);
+  addEventMeta(lines, turn, timestamp);
+  addMetaLine(lines, "Result timestamp", eventTimestamp(resultTimestamp));
+  addMetaLine(lines, "Duration", toolDuration(timestamp, resultTimestamp));
+  if (!result) {
+    addMetaLine(lines, "Result", "missing");
+  }
+  lines.push("", fencedBlock(stringifyPartValue({ call, result }), "json"));
+}
+
+function addEventMeta(
+  lines: string[],
+  turn: ConversationTurn,
+  timestamp: number | undefined,
+): void {
+  const meta = [eventTimestamp(timestamp), eventOffset(turn, timestamp)].filter(
+    isNonEmptyString,
+  );
+  if (meta.length) {
+    lines.push("", `_${meta.join(" - ")}_`);
+  }
+}
+
+function conversationTitle(
+  detail: ConversationDetailFeed,
+  conversation: Conversation | undefined,
+): string {
+  if (conversation) return conversationDisplayTitle(conversation);
+  const firstTurn = detail.turns[0];
+  return firstTurn?.conversationTitle ?? firstTurn?.title ?? "Conversation";
+}
+
+function conversationRequester(
+  conversation: Conversation | undefined,
+  turn: ConversationTurn | undefined,
+): string {
+  return (
+    requesterLabel(
+      conversation?.requesterIdentity ?? turn?.requesterIdentity,
+    ) ?? ""
+  );
+}
+
+function conversationLocation(
+  conversation: Conversation | undefined,
+  turn: ConversationTurn | undefined,
+): string {
+  if (conversation) return slackLocationLabel(conversation) ?? "";
+  return turn ? (slackLocationLabel(turn) ?? "") : "";
+}
+
+function turnHeading(turn: ConversationTurn, index: number): string {
+  const title = turn.title.trim();
+  const label = `Turn ${index + 1}`;
+  if (!title || title === turn.id || title === `Turn ${turn.id}`) return label;
+  return `${label}: ${headingText(title)}`;
+}
+
+function messageRoleLabel(
+  message: TranscriptMessage,
+  turn: ConversationTurn,
+): string {
+  const kind = transcriptRoleKind(message.role);
+  if (kind === "assistant") return "Junior";
+  if (kind === "user") return requesterLabel(turn.requesterIdentity) ?? "User";
+  if (kind === "system") return "System";
+  if (kind === "tool") return "Tool";
+  return headingText(message.role || "Unknown");
+}
+
+function redactedPartLabel(part: TranscriptPart): string {
+  const meta = [
+    part.type !== "text" ? part.type : "",
+    part.name ? `name: ${inlineCode(part.name)}` : "",
+    part.chars !== undefined ? `${part.chars} chars` : "",
+    part.bytes !== undefined ? `${part.bytes} bytes` : "",
+    part.inputType ? `input: ${part.inputType}` : "",
+    part.outputType ? `output: ${part.outputType}` : "",
+    part.inputKeys?.length ? `input keys: ${part.inputKeys.join(", ")}` : "",
+    part.outputKeys?.length ? `output keys: ${part.outputKeys.join(", ")}` : "",
+  ].filter(isNonEmptyString);
+  return ["<redacted>", ...meta].join(" - ");
+}
+
+function toolName(
+  call: TranscriptPart | undefined,
+  result: TranscriptPart | undefined,
+): string {
+  return call?.name ?? result?.name ?? call?.id ?? result?.id ?? "unknown";
+}
+
+function toolDuration(
+  timestamp: number | undefined,
+  resultTimestamp: number | undefined,
+): string {
+  if (
+    typeof timestamp !== "number" ||
+    typeof resultTimestamp !== "number" ||
+    !Number.isFinite(timestamp) ||
+    !Number.isFinite(resultTimestamp) ||
+    resultTimestamp < timestamp
+  ) {
+    return "";
+  }
+  return formatMs(resultTimestamp - timestamp);
+}
+
+function eventTimestamp(timestamp: number | undefined): string {
+  if (typeof timestamp !== "number" || !Number.isFinite(timestamp)) return "";
+  return new Date(timestamp).toISOString();
+}
+
+function eventOffset(
+  turn: ConversationTurn,
+  timestamp: number | undefined,
+): string {
+  if (typeof timestamp !== "number" || !Number.isFinite(timestamp)) return "";
+  const start = Date.parse(turn.startedAt);
+  if (!Number.isFinite(start) || timestamp < start) return "";
+  return `+${formatMs(timestamp - start)}`;
+}
+
+function addMetaLine(
+  lines: string[],
+  label: string,
+  value: string | undefined,
+): void {
+  if (!value) return;
+  lines.push(`- ${label}: ${value}`);
+}
+
+function headingText(value: string): string {
+  return value.replace(/\s+/g, " ").trim() || "Untitled";
+}
+
+function inlineCode(value: string): string {
+  const fence = value.includes("`") ? "``" : "`";
+  return `${fence}${value}${fence}`;
+}
+
+function fencedBlock(value: string, language: string): string {
+  const code = value.trimEnd();
+  const longestBacktickRun = [...code.matchAll(/`+/g)].reduce(
+    (longest, match) => Math.max(longest, match[0].length),
+    0,
+  );
+  const fence = "`".repeat(Math.max(3, longestBacktickRun + 1));
+  return `${fence}${language}\n${code}\n${fence}`;
+}
+
+function trimMarkdown(lines: string[]): string {
+  return `${lines
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim()}\n`;
+}
+
+function isNonEmptyString(value: string): boolean {
+  return value.length > 0;
+}

--- a/packages/junior-dashboard/src/client/markdownExport.ts
+++ b/packages/junior-dashboard/src/client/markdownExport.ts
@@ -107,6 +107,18 @@ function appendTranscriptMessages(
       continue;
     }
 
+    if (redacted) {
+      appendRedactedTool(
+        lines,
+        turn,
+        entry.call,
+        entry.result,
+        entry.timestamp,
+        entry.resultTimestamp,
+      );
+      continue;
+    }
+
     appendTool(
       lines,
       turn,
@@ -171,6 +183,28 @@ function appendTool(
     addMetaLine(lines, "Result", "missing");
   }
   lines.push("", fencedBlock(stringifyPartValue({ call, result }), "json"));
+}
+
+function appendRedactedTool(
+  lines: string[],
+  turn: ConversationTurn,
+  call: TranscriptPart | undefined,
+  result: TranscriptPart | undefined,
+  timestamp: number | undefined,
+  resultTimestamp: number | undefined,
+): void {
+  lines.push("", `### Tool: ${headingText(toolName(call, result))}`);
+  addEventMeta(lines, turn, timestamp);
+  addMetaLine(lines, "Result timestamp", eventTimestamp(resultTimestamp));
+  addMetaLine(lines, "Duration", toolDuration(timestamp, resultTimestamp));
+  if (!result) {
+    addMetaLine(lines, "Result", "missing");
+  }
+
+  const redactedLines = [call, result]
+    .filter((part): part is TranscriptPart => part !== undefined)
+    .map(redactedPartLabel);
+  lines.push("", ...redactedLines.map((line) => `- ${line}`));
 }
 
 function addEventMeta(
@@ -314,10 +348,7 @@ function fencedBlock(value: string, language: string): string {
 }
 
 function trimMarkdown(lines: string[]): string {
-  return `${lines
-    .join("\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim()}\n`;
+  return `${lines.join("\n").trim()}\n`;
 }
 
 function isNonEmptyString(value: string): boolean {

--- a/packages/junior-dashboard/src/client/markdownExport.ts
+++ b/packages/junior-dashboard/src/client/markdownExport.ts
@@ -47,7 +47,7 @@ export function buildConversationMarkdown(
 
   if (detail.turns.length === 0) {
     lines.push("", "## Transcript", "", "No transcript is available.");
-    return trimMarkdown(lines);
+    return finishMarkdown(lines);
   }
 
   detail.turns.forEach((turn, index) => {
@@ -69,7 +69,7 @@ export function buildConversationMarkdown(
     appendTurnTranscript(lines, turn);
   });
 
-  return trimMarkdown(lines);
+  return finishMarkdown(lines);
 }
 
 function appendTurnTranscript(lines: string[], turn: ConversationTurn): void {
@@ -145,8 +145,8 @@ function appendMessage(
     return;
   }
 
-  const rawText = messageRawText(message).trim();
-  lines.push("", rawText || "_No content._");
+  const rawText = messageRawText(message);
+  lines.push("", rawText.trim().length ? rawText : "_No content._");
 }
 
 function appendThinking(
@@ -338,17 +338,16 @@ function inlineCode(value: string): string {
 }
 
 function fencedBlock(value: string, language: string): string {
-  const code = value.trimEnd();
-  const longestBacktickRun = [...code.matchAll(/`+/g)].reduce(
+  const longestBacktickRun = [...value.matchAll(/`+/g)].reduce(
     (longest, match) => Math.max(longest, match[0].length),
     0,
   );
   const fence = "`".repeat(Math.max(3, longestBacktickRun + 1));
-  return `${fence}${language}\n${code}\n${fence}`;
+  return `${fence}${language}\n${value}\n${fence}`;
 }
 
-function trimMarkdown(lines: string[]): string {
-  return `${lines.join("\n").trim()}\n`;
+function finishMarkdown(lines: string[]): string {
+  return `${lines.join("\n")}\n`;
 }
 
 function isNonEmptyString(value: string): boolean {

--- a/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
@@ -1,6 +1,9 @@
+import { useEffect, useState } from "react";
+import { Check, Copy } from "lucide-react";
 import { useParams } from "react-router";
 
 import { useConversationData } from "../api";
+import { buildConversationMarkdown } from "../markdownExport";
 import { StatusBadge } from "../components/StatusBadge";
 import {
   buildConversations,
@@ -29,6 +32,7 @@ import type {
   ConversationDetailFeed,
   DashboardData,
 } from "../types";
+import { cn } from "../styles";
 
 /** Render one permalinkable conversation transcript route. */
 export function ConversationPage(props: { data?: DashboardData }) {
@@ -62,11 +66,17 @@ export function ConversationPage(props: { data?: DashboardData }) {
               />
             </div>
           </div>
-          <div className="self-start break-words text-[0.82rem] leading-relaxed text-[#b8b8b8] md:text-right">
-            updated{" "}
-            {formatRelativeTime(
-              conversation?.lastSeenAt ?? detail.data?.generatedAt,
-            )}
+          <div className="flex min-w-0 flex-col items-start gap-2 self-start text-[0.82rem] leading-relaxed text-[#b8b8b8] md:items-end md:text-right">
+            <CopyMarkdownButton
+              conversation={conversation}
+              detail={detail.data}
+            />
+            <div className="break-words">
+              updated{" "}
+              {formatRelativeTime(
+                conversation?.lastSeenAt ?? detail.data?.generatedAt,
+              )}
+            </div>
           </div>
           <ConversationStats conversation={conversation} detail={detail.data} />
         </header>
@@ -82,6 +92,57 @@ export function ConversationPage(props: { data?: DashboardData }) {
         )}
       </section>
     </div>
+  );
+}
+
+function CopyMarkdownButton(props: {
+  conversation: Conversation | undefined;
+  detail: ConversationDetailFeed | undefined;
+}) {
+  const [status, setStatus] = useState<"copied" | "failed" | "idle">("idle");
+  const disabled = !props.detail;
+  const label =
+    status === "copied"
+      ? "Copied"
+      : status === "failed"
+        ? "Copy failed"
+        : "Copy as Markdown";
+  const Icon = status === "copied" ? Check : Copy;
+
+  useEffect(() => {
+    setStatus("idle");
+  }, [props.detail?.conversationId, props.detail?.generatedAt]);
+
+  async function copyMarkdown() {
+    if (!props.detail) return;
+
+    try {
+      await navigator.clipboard.writeText(
+        buildConversationMarkdown(props.detail, props.conversation),
+      );
+      setStatus("copied");
+    } catch {
+      setStatus("failed");
+    }
+  }
+
+  return (
+    <button
+      aria-label="Copy conversation as Markdown"
+      className={cn(
+        "inline-flex h-9 max-w-full items-center gap-2 border border-white/15 bg-[#0b0b0b] px-3 text-[0.82rem] font-semibold leading-none text-[#d6d6d6] transition-colors",
+        disabled
+          ? "cursor-not-allowed opacity-50"
+          : "cursor-pointer hover:border-white/30 hover:bg-[#151515] hover:text-white",
+      )}
+      disabled={disabled}
+      onClick={() => void copyMarkdown()}
+      title="Copy conversation as Markdown"
+      type="button"
+    >
+      <Icon aria-hidden="true" size={15} strokeWidth={2} />
+      <span className="truncate">{label}</span>
+    </button>
   );
 }
 

--- a/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
@@ -4,6 +4,7 @@ import { useParams } from "react-router";
 
 import { useConversationData } from "../api";
 import { buildConversationMarkdown } from "../markdownExport";
+import { Button } from "../components/Button";
 import { StatusBadge } from "../components/StatusBadge";
 import {
   buildConversations,
@@ -32,7 +33,6 @@ import type {
   ConversationDetailFeed,
   DashboardData,
 } from "../types";
-import { cn } from "../styles";
 
 /** Render one permalinkable conversation transcript route. */
 export function ConversationPage(props: { data?: DashboardData }) {
@@ -127,22 +127,15 @@ function CopyMarkdownButton(props: {
   }
 
   return (
-    <button
+    <Button
       aria-label="Copy conversation as Markdown"
-      className={cn(
-        "inline-flex h-9 max-w-full items-center gap-2 border border-white/15 bg-[#0b0b0b] px-3 text-[0.82rem] font-semibold leading-none text-[#d6d6d6] transition-colors",
-        disabled
-          ? "cursor-not-allowed opacity-50"
-          : "cursor-pointer hover:border-white/30 hover:bg-[#151515] hover:text-white",
-      )}
       disabled={disabled}
       onClick={() => void copyMarkdown()}
       title="Copy conversation as Markdown"
-      type="button"
     >
       <Icon aria-hidden="true" size={15} strokeWidth={2} />
       <span className="truncate">{label}</span>
-    </button>
+    </Button>
   );
 }
 

--- a/packages/junior-dashboard/tests/markdownExport.test.ts
+++ b/packages/junior-dashboard/tests/markdownExport.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+
+import { buildConversationMarkdown } from "../src/client/markdownExport";
+import type {
+  ConversationDetailFeed,
+  ConversationTurn,
+} from "../src/client/types";
+
+describe("dashboard markdown export", () => {
+  it("serializes visible conversation transcripts as Markdown", () => {
+    const startedAt = "2026-01-01T00:00:00.000Z";
+    const detail = {
+      conversationId: "slack:C1:222",
+      generatedAt: "2026-01-01T00:00:08.000Z",
+      turns: [
+        {
+          channel: "C1",
+          channelName: "eng",
+          conversationId: "slack:C1:222",
+          conversationTitle: "Copy button discussion",
+          id: "turn-1",
+          lastProgressAt: "2026-01-01T00:00:07.000Z",
+          lastSeenAt: "2026-01-01T00:00:07.000Z",
+          requesterIdentity: { fullName: "Alice" },
+          startedAt,
+          status: "completed",
+          surface: "slack",
+          title: "Turn turn-1",
+          transcriptAvailable: true,
+          transcript: [
+            {
+              role: "user",
+              timestamp: Date.parse(startedAt) + 1_000,
+              parts: [{ type: "text", text: "copy this conversation" }],
+            },
+            {
+              role: "assistant",
+              timestamp: Date.parse(startedAt) + 2_000,
+              parts: [
+                { type: "thinking", output: "Need a deterministic export." },
+                {
+                  type: "tool_call",
+                  id: "call-1",
+                  name: "search",
+                  input: { query: "copy markdown" },
+                },
+              ],
+            },
+            {
+              role: "toolResult",
+              timestamp: Date.parse(startedAt) + 3_500,
+              parts: [
+                {
+                  type: "tool_result",
+                  id: "call-1",
+                  name: "search",
+                  output: { ok: true },
+                },
+              ],
+            },
+            {
+              role: "assistant",
+              timestamp: Date.parse(startedAt) + 5_000,
+              parts: [{ type: "text", text: "## Done\n\nCopied as Markdown." }],
+            },
+          ],
+        } as ConversationTurn,
+      ],
+    } satisfies ConversationDetailFeed;
+
+    const markdown = buildConversationMarkdown(detail);
+
+    expect(markdown).toContain("# Copy button discussion");
+    expect(markdown).toContain("- Conversation ID: `slack:C1:222`");
+    expect(markdown).toContain("- Requester: Alice");
+    expect(markdown).toContain("- Location: #eng (C1)");
+    expect(markdown).toContain("### Alice");
+    expect(markdown).toContain("copy this conversation");
+    expect(markdown).toContain("### Thinking");
+    expect(markdown).toContain("Need a deterministic export.");
+    expect(markdown).toContain("### Tool: search");
+    expect(markdown).toContain('"query": "copy markdown"');
+    expect(markdown).toContain("## Done\n\nCopied as Markdown.");
+  });
+
+  it("exports only safe redaction metadata for private transcripts", () => {
+    const detail = {
+      conversationId: "slack:D1:222",
+      generatedAt: "2026-01-01T00:00:08.000Z",
+      turns: [
+        {
+          channel: "D1",
+          channelName: "Direct Message",
+          conversationId: "slack:D1:222",
+          conversationTitle: "Direct Message",
+          id: "turn-private",
+          lastProgressAt: "2026-01-01T00:00:07.000Z",
+          lastSeenAt: "2026-01-01T00:00:07.000Z",
+          requesterIdentity: { email: "alice@example.com" },
+          startedAt: "2026-01-01T00:00:00.000Z",
+          status: "completed",
+          surface: "slack",
+          title: "Direct Message",
+          transcriptAvailable: false,
+          transcriptRedacted: true,
+          transcriptRedactionReason: "non_public_conversation",
+          transcript: [],
+          transcriptMetadata: [
+            {
+              role: "user",
+              timestamp: 1_767_225_601_000,
+              parts: [
+                {
+                  bytes: 24,
+                  chars: 24,
+                  redacted: true,
+                  type: "text",
+                },
+              ],
+            },
+            {
+              role: "assistant",
+              timestamp: 1_767_225_602_000,
+              parts: [
+                {
+                  inputKeys: ["query"],
+                  inputSizeBytes: 42,
+                  inputType: "object",
+                  name: "search",
+                  redacted: true,
+                  type: "tool_call",
+                },
+              ],
+            },
+          ],
+        } as ConversationTurn,
+      ],
+    } satisfies ConversationDetailFeed;
+
+    const markdown = buildConversationMarkdown(detail);
+
+    expect(markdown).toContain("# Direct Message");
+    expect(markdown).toContain(
+      "Transcript hidden because this conversation is not public.",
+    );
+    expect(markdown).toContain("<redacted> - 24 chars - 24 bytes");
+    expect(markdown).toContain('"inputKeys": [\n      "query"\n    ]');
+    expect(markdown).toContain('"name": "search"');
+    expect(markdown).not.toContain("private question");
+    expect(markdown).not.toContain("private answer");
+  });
+});

--- a/packages/junior-dashboard/tests/markdownExport.test.ts
+++ b/packages/junior-dashboard/tests/markdownExport.test.ts
@@ -31,13 +31,21 @@ describe("dashboard markdown export", () => {
             {
               role: "user",
               timestamp: Date.parse(startedAt) + 1_000,
-              parts: [{ type: "text", text: "copy this conversation" }],
+              parts: [
+                {
+                  type: "text",
+                  text: "  copy this conversation  \n",
+                },
+              ],
             },
             {
               role: "assistant",
               timestamp: Date.parse(startedAt) + 2_000,
               parts: [
-                { type: "thinking", output: "Need a deterministic export." },
+                {
+                  type: "thinking",
+                  output: "Need a deterministic export.  \n",
+                },
                 {
                   type: "tool_call",
                   id: "call-1",
@@ -80,9 +88,9 @@ describe("dashboard markdown export", () => {
     expect(markdown).toContain("- Requester: Alice");
     expect(markdown).toContain("- Location: #eng (C1)");
     expect(markdown).toContain("### Alice");
-    expect(markdown).toContain("copy this conversation");
+    expect(markdown).toContain("  copy this conversation  \n");
     expect(markdown).toContain("### Thinking");
-    expect(markdown).toContain("Need a deterministic export.");
+    expect(markdown).toContain("Need a deterministic export.  \n");
     expect(markdown).toContain("### Tool: search");
     expect(markdown).toContain('"query": "copy markdown"');
     expect(markdown).toContain("## Done\n\n\n\nCopied as Markdown.");
@@ -119,6 +127,7 @@ describe("dashboard markdown export", () => {
                   bytes: 24,
                   chars: 24,
                   redacted: true,
+                  text: "private question",
                   type: "text",
                 },
               ],
@@ -127,6 +136,13 @@ describe("dashboard markdown export", () => {
               role: "assistant",
               timestamp: 1_767_225_602_000,
               parts: [
+                {
+                  bytes: 22,
+                  chars: 22,
+                  redacted: true,
+                  text: "private answer",
+                  type: "text",
+                },
                 {
                   id: "call-1",
                   input: { query: "private search value" },
@@ -166,6 +182,7 @@ describe("dashboard markdown export", () => {
       "Transcript hidden because this conversation is not public.",
     );
     expect(markdown).toContain("<redacted> - 24 chars - 24 bytes");
+    expect(markdown).toContain("<redacted> - 22 chars - 22 bytes");
     expect(markdown).toContain(
       "<redacted> - tool_call - name: `search` - input: object - input keys: query",
     );

--- a/packages/junior-dashboard/tests/markdownExport.test.ts
+++ b/packages/junior-dashboard/tests/markdownExport.test.ts
@@ -61,7 +61,12 @@ describe("dashboard markdown export", () => {
             {
               role: "assistant",
               timestamp: Date.parse(startedAt) + 5_000,
-              parts: [{ type: "text", text: "## Done\n\nCopied as Markdown." }],
+              parts: [
+                {
+                  type: "text",
+                  text: "## Done\n\n\n\nCopied as Markdown.",
+                },
+              ],
             },
           ],
         } as ConversationTurn,
@@ -80,7 +85,7 @@ describe("dashboard markdown export", () => {
     expect(markdown).toContain("Need a deterministic export.");
     expect(markdown).toContain("### Tool: search");
     expect(markdown).toContain('"query": "copy markdown"');
-    expect(markdown).toContain("## Done\n\nCopied as Markdown.");
+    expect(markdown).toContain("## Done\n\n\n\nCopied as Markdown.");
   });
 
   it("exports only safe redaction metadata for private transcripts", () => {
@@ -123,12 +128,29 @@ describe("dashboard markdown export", () => {
               timestamp: 1_767_225_602_000,
               parts: [
                 {
+                  id: "call-1",
+                  input: { query: "private search value" },
                   inputKeys: ["query"],
                   inputSizeBytes: 42,
                   inputType: "object",
                   name: "search",
                   redacted: true,
                   type: "tool_call",
+                },
+              ],
+            },
+            {
+              role: "toolResult",
+              timestamp: 1_767_225_603_000,
+              parts: [
+                {
+                  id: "call-1",
+                  name: "search",
+                  output: "private tool result",
+                  outputSizeBytes: 19,
+                  outputType: "string",
+                  redacted: true,
+                  type: "tool_result",
                 },
               ],
             },
@@ -144,9 +166,15 @@ describe("dashboard markdown export", () => {
       "Transcript hidden because this conversation is not public.",
     );
     expect(markdown).toContain("<redacted> - 24 chars - 24 bytes");
-    expect(markdown).toContain('"inputKeys": [\n      "query"\n    ]');
-    expect(markdown).toContain('"name": "search"');
+    expect(markdown).toContain(
+      "<redacted> - tool_call - name: `search` - input: object - input keys: query",
+    );
+    expect(markdown).toContain(
+      "<redacted> - tool_result - name: `search` - output: string",
+    );
     expect(markdown).not.toContain("private question");
     expect(markdown).not.toContain("private answer");
+    expect(markdown).not.toContain("private search value");
+    expect(markdown).not.toContain("private tool result");
   });
 });

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -4,6 +4,9 @@ import { MemoryRouter, Route, Routes } from "react-router";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { ToolCallsMetric } from "../src/client/components/TelemetryMetrics";
+import { Button } from "../src/client/components/Button";
+import { FilterTabs } from "../src/client/components/FilterTabs";
+import { TranscriptHeader } from "../src/client/components/TranscriptHeader";
 import { TranscriptToolView } from "../src/client/components/TranscriptToolView";
 import { TurnTranscript } from "../src/client/components/TranscriptTurn";
 import { TurnDurationChart } from "../src/client/components/TurnDurationChart";
@@ -70,6 +73,34 @@ function renderConversationPage(data: DashboardData): string {
 }
 
 describe("dashboard telemetry components", () => {
+  it("keeps shared command buttons out of form-submit mode", () => {
+    const html = renderToStaticMarkup(<Button>Copy as Markdown</Button>);
+    const iconHtml = renderToStaticMarkup(
+      <Button aria-label="Log out" disabled size="icon" />,
+    );
+
+    expect(html).toContain('type="button"');
+    expect(iconHtml).toContain('disabled=""');
+    expect(iconHtml).toContain("size-9");
+  });
+
+  it("exposes pressed state for dashboard toggle controls", () => {
+    const filters = renderToStaticMarkup(
+      <FilterTabs current="failed" onChange={() => {}} />,
+    );
+    const transcript = renderToStaticMarkup(
+      <TranscriptHeader onChange={() => {}} redacted={false} value="raw" />,
+    );
+
+    expect(filters).toContain('role="group"');
+    expect(filters).toContain('aria-label="Conversation filter"');
+    expect(filters.match(/aria-pressed="true"/g) ?? []).toHaveLength(1);
+    expect(filters.match(/aria-pressed="false"/g) ?? []).toHaveLength(4);
+    expect(transcript).toContain('aria-label="Transcript view"');
+    expect(transcript.match(/aria-pressed="true"/g) ?? []).toHaveLength(1);
+    expect(transcript.match(/aria-pressed="false"/g) ?? []).toHaveLength(1);
+  });
+
   it("keeps the per-turn Sentry trace link in transcript headers", () => {
     const turn = {
       conversationId: "conversation-1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,9 @@ importers:
       hono:
         specifier: ^4.12.22
         version: 4.12.22
+      lucide-react:
+        specifier: ^1.17.0
+        version: 1.17.0(react@19.2.6)
       nitro:
         specifier: 3.0.260522-beta
         version: 3.0.260522-beta(@vercel/blob@2.4.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.43))(chokidar@5.0.0)(jiti@2.7.0)(lru-cache@11.5.0)(rollup@4.60.4)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
@@ -7759,6 +7762,14 @@ packages:
       }
     engines: { node: ">=12" }
 
+  lucide-react@1.17.0:
+    resolution:
+      {
+        integrity: sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==,
+      }
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   lunr@2.3.9:
     resolution:
       {
@@ -13469,6 +13480,7 @@ snapshots:
       "@tanstack/react-query": 5.100.14(react@19.2.6)
       better-auth: 1.6.11(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.7(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0)))
       hono: 4.12.22
+      lucide-react: 1.17.0(react@19.2.6)
       nitro: 3.0.260522-beta(@vercel/blob@2.4.0)(@vercel/functions@3.6.0(@aws-sdk/credential-provider-web-identity@3.972.43))(chokidar@5.0.0)(jiti@2.7.0)(lru-cache@11.5.0)(rollup@4.60.4)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -16322,6 +16334,10 @@ snapshots:
       yallist: 4.0.0
 
   lru-cache@7.18.3: {}
+
+  lucide-react@1.17.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
 
   lunr@2.3.9: {}
 


### PR DESCRIPTION
## Summary
- Add a conversation-level "Copy as Markdown" action to the dashboard conversation detail view.
- Preserve transcript whitespace in the export instead of collapsing blank lines.
- Redact private tool entries using bounded metadata only, matching the dashboard privacy model.
- Add focused tests for visible transcript export and redacted transcript handling.

## Testing
- `pnpm --filter @sentry/junior-dashboard exec vitest run tests/markdownExport.test.ts`
- `pnpm --filter @sentry/junior-dashboard test`
- `pnpm --filter @sentry/junior-dashboard build`