### PR TITLE
Restore the rainbow dashboard hydration loader

### DIFF
--- a/packages/junior-dashboard/src/app.ts
+++ b/packages/junior-dashboard/src/app.ts
@@ -12,6 +12,7 @@ import {
   type DashboardAuth,
   type DashboardSession,
 } from "./auth";
+import { dashboardRainbowProgressClass } from "./dashboardLoader";
 
 const DEFAULT_BASE_PATH = "/";
 const DEFAULT_AUTH_PATH = "/api/auth";
@@ -216,7 +217,17 @@ function renderDashboard(basePath: string): Response {
   </style>
 </head>
 <body class="m-0 bg-black text-white [color-scheme:dark]">
-  <div id="dashboard-root"></div>
+  <div id="dashboard-root">
+    <main class="grid min-h-screen place-items-center bg-black px-4 py-8 font-sans text-white md:px-8" aria-busy="true">
+      <section class="grid w-full max-w-lg grid-cols-[auto_minmax(0,1fr)] items-center gap-3 border border-white/15 bg-[#0b0b0b] p-4">
+        <div class="grid size-9 shrink-0 select-none place-items-center bg-black text-[0.82rem] font-black leading-none text-white">Jr</div>
+        <div class="min-w-0">
+          <div class="font-bold">Loading Junior</div>
+          <div class="${dashboardRainbowProgressClass} mt-3 h-1.5 w-full" role="progressbar" aria-label="Loading Junior"></div>
+        </div>
+      </section>
+    </main>
+  </div>
   <script>
     window.__JUNIOR_DASHBOARD_BASE_PATH__ = ${JSON.stringify(basePath)};
     (function () {

--- a/packages/junior-dashboard/src/client/components/LoadingView.tsx
+++ b/packages/junior-dashboard/src/client/components/LoadingView.tsx
@@ -1,4 +1,5 @@
 import { JuniorLogo } from "./JuniorLogo";
+import { dashboardRainbowProgressClass } from "../../dashboardLoader";
 
 /** Render the full-page loading treatment before the first dashboard payload lands. */
 export function LoadingView(props: { label: string }) {
@@ -8,7 +9,11 @@ export function LoadingView(props: { label: string }) {
         <JuniorLogo />
         <div>
           <div className="font-bold">{props.label}</div>
-          <div className="mt-3 h-1.5 w-full animate-pulse bg-white/20" />
+          <div
+            aria-label={props.label}
+            className={`${dashboardRainbowProgressClass} mt-3 h-1.5 w-full`}
+            role="progressbar"
+          />
         </div>
       </section>
     </div>

--- a/packages/junior-dashboard/src/dashboardLoader.ts
+++ b/packages/junior-dashboard/src/dashboardLoader.ts
@@ -1,0 +1,12 @@
+export const dashboardRainbowProgressClass = [
+  "relative",
+  "overflow-hidden",
+  "bg-white/15",
+  "before:absolute",
+  "before:inset-0",
+  "before:content-['']",
+  "before:bg-[linear-gradient(90deg,#ff4d6d,#ffb703,#56f39a,#4cc9f0,#9b5de5,#ff4d6d)]",
+  "before:bg-[length:200%_100%]",
+  "before:animate-[junior-rainbow-flow_1.2s_linear_infinite]",
+  "motion-reduce:before:animate-none",
+].join(" ");

--- a/packages/junior-dashboard/src/tailwind.css
+++ b/packages/junior-dashboard/src/tailwind.css
@@ -9,5 +9,16 @@
 }
 
 @source "./app.ts";
+@source "./dashboardLoader.ts";
 @source "./client.tsx";
 @source "./client/**/*.{ts,tsx}";
+
+@keyframes junior-rainbow-flow {
+  0% {
+    background-position: 0% 50%;
+  }
+
+  100% {
+    background-position: 200% 50%;
+  }
+}

--- a/packages/junior-dashboard/tests/dashboard-output.test.ts
+++ b/packages/junior-dashboard/tests/dashboard-output.test.ts
@@ -103,6 +103,7 @@ describe.sequential("dashboard Nitro production output", () => {
       expect(client.headers.get("content-type")).toContain(
         "application/javascript",
       );
+      expect(await client.text()).not.toMatch(/\bfrom\s*["']lucide-react["']/);
 
       const page = await app.fetch(new Request("http://localhost/"), {});
       expect(page.status).toBe(200);

--- a/packages/junior-dashboard/tests/dashboard-routes.test.ts
+++ b/packages/junior-dashboard/tests/dashboard-routes.test.ts
@@ -293,6 +293,8 @@ describe("dashboard routes", () => {
     expect(response.headers.get("content-type")).toContain("text/html");
     const html = await response.text();
     expect(html).toContain("<title>Junior</title>");
+    expect(html).toContain("Loading Junior");
+    expect(html).toContain("junior-rainbow-flow");
     expect(html).toMatch(/\/api\/dashboard\/client\.js\?v=[a-z0-9]+/);
     expect(html).toContain("__JUNIOR_DASHBOARD_BASE_PATH__");
   });

--- a/packages/junior-dashboard/tsup.client.config.ts
+++ b/packages/junior-dashboard/tsup.client.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     "react-dom",
     "react-router",
     "recharts",
+    "lucide-react",
     "shiki",
   ],
 });


### PR DESCRIPTION
## Summary
- Restore the rainbow loading treatment for the initial dashboard hydration shell and reuse the same styling in the React `LoadingView`
- Keep the animation definition in Tailwind while centralizing the shared utility class in one small helper
- Fix the dashboard client bundle to inline `lucide-react` so the standalone browser bundle loads cleanly
- Add coverage for the hydration loader and the bundle regression

## Testing
- `pnpm --filter @sentry/junior-dashboard run build`
- `pnpm --filter @sentry/junior-dashboard test`
- `pnpm --filter @sentry/junior-dashboard run typecheck`
- Verified the loader in a local browser smoke test