### PR TITLE
Tighten duration schema for dashboard chart

### DIFF
--- a/packages/junior-dashboard/src/client/components/TurnDurationChart.tsx
+++ b/packages/junior-dashboard/src/client/components/TurnDurationChart.tsx
@@ -18,15 +18,13 @@ import {
   conversationRequesterLabel,
   conversationIdForSession,
   conversationPath,
-  formatConversationDuration,
   formatDurationTick,
-  formatTurnDuration,
+  formatMs,
   requesterLabel,
   slackLocationLabel,
   summarizeMessages,
   summarizeToolCalls,
   summarizeUsage,
-  turnElapsedDurationMs,
   visualStatusForSession,
   visualStatusForConversation,
 } from "../format";
@@ -251,13 +249,10 @@ function turnPoint(session: Session, timeZone: string): DurationPoint | null {
     return null;
   }
 
-  const durationMs = turnElapsedDurationMs(session);
-  if (durationMs === undefined) {
-    return null;
-  }
+  const durationMs = session.cumulativeDurationMs;
   return {
     conversationId: conversationIdForSession(session),
-    durationLabel: formatTurnDuration(session),
+    durationLabel: formatMs(durationMs),
     durationMs,
     endedAt: session.completedAt ?? session.lastSeenAt,
     kind: "turns",
@@ -284,16 +279,15 @@ function conversationPoint(
   if (!status) {
     return null;
   }
-  const lastSeenAtMs = Date.parse(conversation.lastSeenAt);
-  if (!Number.isFinite(lastSeenAtMs)) {
-    return null;
-  }
-  const durationMs = Math.max(0, lastSeenAtMs - startedAtMs);
+  const durationMs = conversation.turns.reduce(
+    (sum, turn) => sum + turn.cumulativeDurationMs,
+    0,
+  );
 
   return {
     conversation,
     conversationId: conversation.id,
-    durationLabel: formatConversationDuration(conversation),
+    durationLabel: formatMs(durationMs),
     durationMs,
     endedAt: conversation.lastSeenAt,
     kind: "conversations",

--- a/packages/junior-dashboard/src/client/format.ts
+++ b/packages/junior-dashboard/src/client/format.ts
@@ -118,15 +118,14 @@ export function formatDurationTick(value: number | undefined): string {
   return formatMs(ms);
 }
 
-/** Format aggregate runtime across turn summaries when duration data exists. */
-export function formatDurationTotal(
-  durations: Array<number | undefined>,
-): string {
-  const total = durations.reduce<number | undefined>((sum, value) => {
-    if (typeof value !== "number" || !Number.isFinite(value)) return sum;
-    return (sum ?? 0) + Math.max(0, Math.floor(value));
-  }, undefined);
-  return total === undefined ? "" : formatMs(total);
+/** Format aggregate runtime across turn summaries. */
+export function formatDurationTotal(durations: number[]): string {
+  if (durations.length === 0) return "";
+  const total = durations.reduce(
+    (sum, value) => sum + Math.max(0, Math.floor(value)),
+    0,
+  );
+  return formatMs(total);
 }
 
 /** Format transcript event timestamps independently from turn start offsets. */

--- a/packages/junior-dashboard/tests/dashboard-routes.test.ts
+++ b/packages/junior-dashboard/tests/dashboard-routes.test.ts
@@ -99,6 +99,7 @@ function reporting(): JuniorReporting {
         sessions: [
           {
             conversationId: "slack:C1:123",
+            cumulativeDurationMs: 0,
             id: "turn-1",
             status: "active",
             startedAt: "2026-05-29T00:00:00.000Z",
@@ -120,6 +121,7 @@ function reporting(): JuniorReporting {
         turns: [
           {
             conversationId,
+            cumulativeDurationMs: 0,
             id: "turn-1",
             status: "active",
             startedAt: "2026-05-29T00:00:00.000Z",
@@ -468,6 +470,7 @@ describe("dashboard routes", () => {
       turns: [
         {
           conversationId,
+          cumulativeDurationMs: 1_000,
           id: "turn-1",
           status: "completed",
           startedAt: "2026-05-29T00:00:00.000Z",

--- a/packages/junior-dashboard/tests/format.test.ts
+++ b/packages/junior-dashboard/tests/format.test.ts
@@ -36,8 +36,8 @@ describe("dashboard token formatting", () => {
     ).toBe("205 tokens");
   });
 
-  it("sums turn runtime when duration data exists", () => {
-    expect(formatDurationTotal([1_000, 2_500, undefined])).toBe("3.5s");
+  it("sums turn runtime", () => {
+    expect(formatDurationTotal([1_000, 2_500])).toBe("3.5s");
   });
 
   it("rounds long chart duration ticks to whole minutes", () => {
@@ -235,6 +235,7 @@ describe("dashboard token formatting", () => {
       {
         channel: "C1",
         conversationId: "slack:C1:123",
+        cumulativeDurationMs: 0,
         id: "turn-1",
         lastProgressAt: "2026-06-01T10:05:00.000Z",
         lastSeenAt: "2026-06-01T10:05:00.000Z",
@@ -272,6 +273,7 @@ describe("dashboard token formatting", () => {
         channel: "C1",
         channelName: "engineering",
         conversationId: "slack:C1:123",
+        cumulativeDurationMs: 0,
         id: "turn-1",
         lastProgressAt: "2026-06-01T10:05:00.000Z",
         lastSeenAt: "2026-06-01T10:05:00.000Z",
@@ -292,6 +294,7 @@ describe("dashboard token formatting", () => {
       {
         conversationId: "slack:C1:123",
         conversationTitle: "Older title",
+        cumulativeDurationMs: 0,
         id: "turn-1",
         lastProgressAt: "2026-06-01T10:05:00.000Z",
         lastSeenAt: "2026-06-01T10:05:00.000Z",
@@ -303,6 +306,7 @@ describe("dashboard token formatting", () => {
       {
         conversationId: "slack:C1:123",
         conversationTitle: "Newer title",
+        cumulativeDurationMs: 0,
         id: "turn-2",
         lastProgressAt: "2026-06-01T11:05:00.000Z",
         lastSeenAt: "2026-06-01T11:05:00.000Z",
@@ -323,6 +327,7 @@ describe("dashboard token formatting", () => {
         channelName: "alice",
         conversationId: "slack:C1:123",
         conversationTitle: "Alice",
+        cumulativeDurationMs: 0,
         id: "turn-1",
         lastProgressAt: "2026-06-01T10:05:00.000Z",
         lastSeenAt: "2026-06-01T10:05:00.000Z",
@@ -348,6 +353,7 @@ describe("dashboard token formatting", () => {
     const [conversation] = buildConversations([
       {
         conversationId: "slack:C1:123",
+        cumulativeDurationMs: 0,
         id: "turn-1",
         lastProgressAt: "2026-06-01T10:02:29.000Z",
         lastSeenAt: "2026-06-01T10:02:29.000Z",
@@ -365,6 +371,7 @@ describe("dashboard token formatting", () => {
     const [conversation] = buildConversations([
       {
         conversationId: "slack:C1:123",
+        cumulativeDurationMs: 0,
         id: "turn-1",
         lastProgressAt: "2026-06-01T10:02:29.000Z",
         lastSeenAt: "not-a-date",

--- a/packages/junior-dashboard/tests/markdownExport.test.ts
+++ b/packages/junior-dashboard/tests/markdownExport.test.ts
@@ -106,6 +106,7 @@ describe("dashboard markdown export", () => {
           channelName: "Direct Message",
           conversationId: "slack:D1:222",
           conversationTitle: "Direct Message",
+          cumulativeDurationMs: 7_000,
           id: "turn-private",
           lastProgressAt: "2026-01-01T00:00:07.000Z",
           lastSeenAt: "2026-01-01T00:00:07.000Z",

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -104,6 +104,7 @@ describe("dashboard telemetry components", () => {
   it("keeps the per-turn Sentry trace link in transcript headers", () => {
     const turn = {
       conversationId: "conversation-1",
+      cumulativeDurationMs: 0,
       id: "turn-1",
       lastProgressAt: "2026-01-01T00:00:00.000Z",
       lastSeenAt: "2026-01-01T00:00:00.000Z",
@@ -127,6 +128,7 @@ describe("dashboard telemetry components", () => {
   it("removes residual grid row gap from collapsed system prompts", () => {
     const turn = {
       conversationId: "conversation-1",
+      cumulativeDurationMs: 0,
       id: "turn-1",
       lastProgressAt: "2026-01-01T00:00:00.000Z",
       lastSeenAt: "2026-01-01T00:00:00.000Z",
@@ -155,6 +157,7 @@ describe("dashboard telemetry components", () => {
   it("uses chart mode links as the duration chart title", () => {
     const session = {
       conversationId: "conversation-1",
+      cumulativeDurationMs: 3_000,
       id: "turn-1",
       completedAt: "2026-01-01T00:00:03.000Z",
       lastProgressAt: "2026-01-01T00:00:03.000Z",
@@ -194,6 +197,7 @@ describe("dashboard telemetry components", () => {
   it("omits the conversation tool-call metric slot when the loaded detail has no tool calls", () => {
     const session = {
       conversationId: "conversation-1",
+      cumulativeDurationMs: 0,
       id: "turn-1",
       lastProgressAt: "2026-01-01T00:00:00.000Z",
       lastSeenAt: "not-a-date",

--- a/packages/junior-dashboard/tests/turn-duration-chart.test.tsx
+++ b/packages/junior-dashboard/tests/turn-duration-chart.test.tsx
@@ -1,0 +1,87 @@
+import type { ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { client } from "../src/client/api";
+import { TurnDurationChart } from "../src/client/components/TurnDurationChart";
+import type { Session } from "../src/client/types";
+
+const chartState = vi.hoisted(() => ({
+  scatterData: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("recharts", () => {
+  const passthrough = (props: { children?: ReactNode }) =>
+    props.children ?? null;
+  return {
+    CartesianGrid: () => null,
+    ResponsiveContainer: passthrough,
+    Scatter: (props: { data?: Array<Record<string, unknown>> }) => {
+      chartState.scatterData = props.data ?? [];
+      return null;
+    },
+    ScatterChart: passthrough,
+    Tooltip: () => null,
+    XAxis: () => null,
+    YAxis: () => null,
+  };
+});
+
+afterEach(() => {
+  chartState.scatterData = [];
+  client.clear();
+  vi.useRealTimers();
+});
+
+function renderChart(sessions: Session[]): void {
+  renderToStaticMarkup(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <TurnDurationChart sessions={sessions} timeZone="UTC" />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("turn duration chart", () => {
+  it("plots conversation duration as summed turn runtime", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-02T12:00:00.000Z"));
+
+    renderChart([
+      {
+        completedAt: "2026-06-02T09:05:00.000Z",
+        conversationId: "conversation-1",
+        cumulativeDurationMs: 1_000,
+        id: "turn-1",
+        lastProgressAt: "2026-06-02T09:05:00.000Z",
+        lastSeenAt: "2026-06-02T09:05:00.000Z",
+        startedAt: "2026-06-02T09:00:00.000Z",
+        status: "completed",
+        surface: "slack",
+        title: "Turn turn-1",
+      },
+      {
+        completedAt: "2026-06-02T11:03:00.000Z",
+        conversationId: "conversation-1",
+        cumulativeDurationMs: 2_500,
+        id: "turn-2",
+        lastProgressAt: "2026-06-02T11:03:00.000Z",
+        lastSeenAt: "2026-06-02T11:03:00.000Z",
+        startedAt: "2026-06-02T11:00:00.000Z",
+        status: "completed",
+        surface: "slack",
+        title: "Turn turn-2",
+      },
+    ]);
+
+    expect(chartState.scatterData).toHaveLength(1);
+    expect(chartState.scatterData[0]).toMatchObject({
+      conversationId: "conversation-1",
+      durationLabel: "3.5s",
+      durationMs: 3_500,
+    });
+  });
+});

--- a/packages/junior/src/chat/state/turn-session.ts
+++ b/packages/junior/src/chat/state/turn-session.ts
@@ -39,7 +39,7 @@ export interface AgentTurnSessionRecord {
   conversationTitle?: string;
   version: number;
   conversationId: string;
-  cumulativeDurationMs?: number;
+  cumulativeDurationMs: number;
   cumulativeUsage?: AgentTurnUsage;
   errorMessage?: string;
   lastProgressAtMs: number;
@@ -191,9 +191,8 @@ function parseAgentTurnSessionFields(
   const sliceId = toFiniteNonNegativeNumber(parsed.sliceId);
   const version = toFiniteNonNegativeNumber(parsed.version);
   const updatedAtMs = toFiniteNonNegativeNumber(parsed.updatedAtMs);
-  const cumulativeDurationMs = toFiniteNonNegativeNumber(
-    parsed.cumulativeDurationMs,
-  );
+  const cumulativeDurationMs =
+    toFiniteNonNegativeNumber(parsed.cumulativeDurationMs) ?? 0;
   const cumulativeUsage = parseAgentTurnUsage(parsed.cumulativeUsage);
   const lastProgressAtMs = toFiniteNonNegativeNumber(parsed.lastProgressAtMs);
   const logSessionId =
@@ -221,8 +220,8 @@ function parseAgentTurnSessionFields(
     startedAtMs: startedAtMs ?? updatedAtMs,
     lastProgressAtMs: lastProgressAtMs ?? updatedAtMs,
     updatedAtMs,
+    cumulativeDurationMs,
     ...(logSessionId ? { logSessionId } : {}),
-    ...(cumulativeDurationMs !== undefined ? { cumulativeDurationMs } : {}),
     ...(cumulativeUsage ? { cumulativeUsage } : {}),
     ...(requester ? { requester } : {}),
     ...(Array.isArray(parsed.loadedSkillNames)
@@ -351,9 +350,7 @@ function materializeAgentTurnSessionRecord(
     lastProgressAtMs: stored.lastProgressAtMs,
     updatedAtMs: stored.updatedAtMs,
     piMessages,
-    ...(stored.cumulativeDurationMs !== undefined
-      ? { cumulativeDurationMs: stored.cumulativeDurationMs }
-      : {}),
+    cumulativeDurationMs: stored.cumulativeDurationMs,
     ...(stored.cumulativeUsage
       ? { cumulativeUsage: stored.cumulativeUsage }
       : {}),
@@ -423,7 +420,7 @@ function buildStoredRecord(args: {
   channelName?: string;
   conversationTitle?: string;
   conversationId: string;
-  cumulativeDurationMs?: number;
+  cumulativeDurationMs: number;
   cumulativeUsage?: AgentTurnUsage;
   committedMessageCount: number;
   lastProgressAtMs?: number;
@@ -456,15 +453,7 @@ function buildStoredRecord(args: {
     updatedAtMs: nowMs,
     committedMessageCount: args.committedMessageCount,
     ...(args.logSessionId ? { logSessionId: args.logSessionId } : {}),
-    ...(typeof args.cumulativeDurationMs === "number" &&
-    Number.isFinite(args.cumulativeDurationMs)
-      ? {
-          cumulativeDurationMs: Math.max(
-            0,
-            Math.floor(args.cumulativeDurationMs),
-          ),
-        }
-      : {}),
+    cumulativeDurationMs: args.cumulativeDurationMs,
     ...(args.cumulativeUsage ? { cumulativeUsage: args.cumulativeUsage } : {}),
     ...(args.requester ? { requester: args.requester } : {}),
     ...(Array.isArray(args.loadedSkillNames)
@@ -540,9 +529,7 @@ async function updateAgentTurnSessionState(args: {
       lastProgressAtMs: parsed.lastProgressAtMs,
       previousVersion: parsed.version,
       ...(parsed.logSessionId ? { logSessionId: parsed.logSessionId } : {}),
-      ...(args.existing.cumulativeDurationMs !== undefined
-        ? { cumulativeDurationMs: args.existing.cumulativeDurationMs }
-        : {}),
+      cumulativeDurationMs: args.existing.cumulativeDurationMs,
       ...(args.existing.cumulativeUsage
         ? { cumulativeUsage: args.existing.cumulativeUsage }
         : {}),
@@ -623,9 +610,10 @@ export async function upsertAgentTurnSessionRecord(args: {
       committedMessageCount: args.piMessages.length,
       logSessionId: commit.sessionId,
       previousVersion: existingRecord?.version,
-      ...(args.cumulativeDurationMs !== undefined
-        ? { cumulativeDurationMs: args.cumulativeDurationMs }
-        : {}),
+      cumulativeDurationMs:
+        toFiniteNonNegativeNumber(args.cumulativeDurationMs) ??
+        existingRecord?.cumulativeDurationMs ??
+        0,
       ...(args.cumulativeUsage
         ? { cumulativeUsage: args.cumulativeUsage }
         : {}),
@@ -690,17 +678,10 @@ export async function recordAgentTurnSessionSummary(args: {
       lastProgressAtMs: args.lastProgressAtMs ?? nowMs,
       state: args.state,
       updatedAtMs: nowMs,
-      ...(typeof args.cumulativeDurationMs === "number" &&
-      Number.isFinite(args.cumulativeDurationMs)
-        ? {
-            cumulativeDurationMs: Math.max(
-              0,
-              Math.floor(args.cumulativeDurationMs),
-            ),
-          }
-        : existing?.cumulativeDurationMs !== undefined
-          ? { cumulativeDurationMs: existing.cumulativeDurationMs }
-          : {}),
+      cumulativeDurationMs:
+        toFiniteNonNegativeNumber(args.cumulativeDurationMs) ??
+        existing?.cumulativeDurationMs ??
+        0,
       ...((args.cumulativeUsage ?? existing?.cumulativeUsage)
         ? { cumulativeUsage: args.cumulativeUsage ?? existing?.cumulativeUsage }
         : {}),

--- a/packages/junior/src/reporting.ts
+++ b/packages/junior/src/reporting.ts
@@ -81,7 +81,7 @@ export interface DashboardRequesterIdentity {
 
 export interface DashboardSessionReport {
   conversationTitle?: string;
-  cumulativeDurationMs?: number;
+  cumulativeDurationMs: number;
   cumulativeUsage?: DashboardTurnUsage;
   conversationId: string;
   id: string;
@@ -336,9 +336,7 @@ function sessionReportFromSummary(
     ...(summary.state === "completed"
       ? { completedAt: new Date(summary.updatedAtMs).toISOString() }
       : {}),
-    ...(summary.cumulativeDurationMs !== undefined
-      ? { cumulativeDurationMs: summary.cumulativeDurationMs }
-      : {}),
+    cumulativeDurationMs: summary.cumulativeDurationMs,
     ...(cumulativeUsage ? { cumulativeUsage } : {}),
     surface: surfaceFromConversationId(summary.conversationId),
     title: titleFromSummary(summary),

--- a/packages/junior/tests/integration/dashboard-reporting.test.ts
+++ b/packages/junior/tests/integration/dashboard-reporting.test.ts
@@ -82,6 +82,7 @@ describe("dashboard reporting", () => {
     expect(turn1).not.toHaveProperty("errorMessage");
     expect(turn2).toMatchObject({
       conversationId: "slack:C2:222",
+      cumulativeDurationMs: 0,
       sessionId: "turn-2",
       state: "awaiting_resume",
       resumeReason: "timeout",


### PR DESCRIPTION
## Summary
- Make `cumulativeDurationMs` required in turn-session storage and dashboard reporting.
- Simplify the duration chart to use required turn runtime directly and sum conversation turn durations.
- Tighten `formatDurationTotal` to accept only numeric durations.
- Update tests and fixtures to satisfy the stricter schema, plus add a chart regression test.

## Testing
- `pnpm --filter @sentry/junior typecheck`
- `pnpm --filter @sentry/junior-dashboard typecheck`
- `pnpm --filter @sentry/junior exec vitest run tests/unit/services/turn-session-record.test.ts tests/integration/dashboard-reporting.test.ts`
- `pnpm --filter @sentry/junior-dashboard test`