### PR TITLE
Fix highlighted code whitespace in dashboard

### DIFF
--- a/packages/junior-dashboard/src/client/code.tsx
+++ b/packages/junior-dashboard/src/client/code.tsx
@@ -146,7 +146,7 @@ export function HighlightedCode(props: {
 
   return (
     <div
-      className="min-w-0 overflow-hidden [&_.line]:block [&_.line]:max-w-full [&_.line]:whitespace-pre-wrap [&_.line]:break-words [&_.line]:[overflow-wrap:anywhere] [&_code]:block [&_code]:max-w-full [&_code]:whitespace-pre-wrap [&_code]:break-words [&_code]:[overflow-wrap:anywhere] [&_pre]:!m-0 [&_pre]:!max-w-full [&_pre]:!overflow-hidden [&_pre]:!bg-transparent [&_pre]:!p-0 [&_pre]:whitespace-pre-wrap [&_pre]:break-words [&_pre]:font-mono [&_pre]:text-[0.86rem] [&_pre]:leading-relaxed [&_pre]:[overflow-wrap:anywhere] [&_span]:whitespace-pre-wrap [&_span]:break-words [&_span]:[overflow-wrap:anywhere]"
+      className="min-w-0 overflow-hidden [&_.line]:block [&_.line]:max-w-full [&_.line]:whitespace-pre-wrap [&_.line]:break-words [&_.line]:[overflow-wrap:anywhere] [&_code]:block [&_code]:max-w-full [&_code]:whitespace-normal [&_code]:break-words [&_code]:[overflow-wrap:anywhere] [&_pre]:!m-0 [&_pre]:!max-w-full [&_pre]:!overflow-hidden [&_pre]:!bg-transparent [&_pre]:!p-0 [&_pre]:whitespace-normal [&_pre]:break-words [&_pre]:font-mono [&_pre]:text-[0.86rem] [&_pre]:leading-relaxed [&_pre]:[overflow-wrap:anywhere] [&_span]:whitespace-pre-wrap [&_span]:break-words [&_span]:[overflow-wrap:anywhere]"
       dangerouslySetInnerHTML={{ __html: highlighted.data }}
     />
   );

--- a/packages/junior-dashboard/tests/dashboard-mock-routes.test.ts
+++ b/packages/junior-dashboard/tests/dashboard-mock-routes.test.ts
@@ -40,6 +40,7 @@ function reporting(): JuniorReporting {
         sessions: [
           {
             conversationId: "slack:C1:123",
+            cumulativeDurationMs: 0,
             id: "turn-1",
             status: "active",
             startedAt: "2026-05-29T00:00:00.000Z",
@@ -59,6 +60,7 @@ function reporting(): JuniorReporting {
         turns: [
           {
             conversationId,
+            cumulativeDurationMs: 0,
             id: "turn-1",
             status: "active",
             startedAt: "2026-05-29T00:00:00.000Z",

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -316,6 +316,7 @@ describe("dashboard telemetry components", () => {
   it("caps dashboard route pages at a readable width", () => {
     const session = {
       conversationId: "conversation-1",
+      cumulativeDurationMs: 0,
       id: "turn-1",
       lastProgressAt: "2026-01-01T00:00:00.000Z",
       lastSeenAt: "2026-01-01T00:00:00.000Z",
@@ -346,6 +347,7 @@ describe("dashboard telemetry components", () => {
   it("renders transcript copy as an icon-only control", () => {
     const session = {
       conversationId: "conversation-1",
+      cumulativeDurationMs: 0,
       id: "turn-1",
       lastProgressAt: "2026-01-01T00:00:00.000Z",
       lastSeenAt: "2026-01-01T00:00:00.000Z",
@@ -457,6 +459,47 @@ describe("dashboard telemetry components", () => {
     expect(html).toContain("overflow-hidden");
     expect(html).toContain("overflow-wrap:anywhere");
     expect(html).toContain("[&amp;_.line]:block");
+    expect(html).toContain("[&amp;_.line]:whitespace-pre-wrap");
+    expect(html).toContain("[&amp;_code]:whitespace-normal");
+    expect(html).toContain("[&amp;_pre]:whitespace-normal");
+    expect(html).not.toContain("[&amp;_code]:whitespace-pre-wrap");
+  });
+
+  it("uses compact highlighted code spacing for raw XML transcripts", () => {
+    const rawText = "<root>\n  <message>Checking MCP output</message>\n</root>";
+    client.setQueryData(
+      ["highlight", "xml", rawText],
+      '<pre><code><span class="line"><span>&lt;root&gt;</span></span>\n<span class="line"><span>  &lt;message&gt;Checking MCP output&lt;/message&gt;</span></span>\n<span class="line"><span>&lt;/root&gt;</span></span></code></pre>',
+    );
+
+    const turn = {
+      conversationId: "conversation-1",
+      cumulativeDurationMs: 0,
+      id: "turn-1",
+      lastProgressAt: "2026-01-01T00:00:00.000Z",
+      lastSeenAt: "2026-01-01T00:00:00.000Z",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      status: "completed",
+      surface: "internal",
+      title: "Raw XML",
+      transcript: [
+        {
+          parts: [{ text: rawText, type: "text" }],
+          role: "assistant",
+        },
+      ],
+      transcriptAvailable: true,
+    } as ConversationTurn;
+
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={client}>
+        <TurnTranscript number={1} turn={turn} view="raw" />
+      </QueryClientProvider>,
+    );
+
+    expect(html).toContain("[&amp;_code]:whitespace-normal");
+    expect(html).toContain("[&amp;_pre]:whitespace-normal");
+    expect(html).toContain("Checking MCP output");
   });
 
   it("collapses four consecutive tool calls to a reveal divider", () => {


### PR DESCRIPTION
## Summary
- Remove the extra preserved whitespace on Shiki `<pre>`/`<code>` wrappers so highlighted JSON and raw XML render without blank lines between visible rows
- Add regression coverage for highlighted JSON spacing and raw XML transcript rendering
- Fill in missing `cumulativeDurationMs` fields in dashboard test fixtures so the package typecheck stays aligned with the reporting types

## Testing
- `vitest run tests/telemetry-components.test.tsx -c vitest.config.ts`
- `vitest run tests/dashboard-mock-routes.test.ts -c vitest.config.ts`
- `typecheck` for `@sentry/junior-dashboard`