### PR TITLE
fix(dashboard): Keep event timestamps right aligned

### DIFF
--- a/packages/junior-dashboard/src/client/components/TranscriptThinkingView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptThinkingView.tsx
@@ -1,10 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-import {
-  formatMessageOffset,
-  formatMessageTimestamp,
-  stringifyPartValue,
-} from "../format";
+import { formatMessageTimestamp, stringifyPartValue } from "../format";
 import { cn } from "../styles";
 import type { ConversationTurn } from "../types";
 import {
@@ -35,14 +31,10 @@ export function TranscriptThinkingView(props: {
   const contentChangesOnExpand =
     preview !== expandedText || expandedText.includes("\n");
   const shouldMeasurePreview = !contentChangesOnExpand;
-  const offset = props.turn
-    ? formatMessageOffset(props.turn, props.timestamp)
-    : undefined;
   const meta = [
     typeof props.timestamp === "number"
       ? formatMessageTimestamp(props.timestamp)
       : undefined,
-    offset,
   ].filter(isString);
   const metaText = meta.join(" · ");
   const canExpand = contentChangesOnExpand || previewOverflows;

--- a/packages/junior-dashboard/src/client/components/TranscriptThinkingView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptThinkingView.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from "react";
 
 import { formatMessageTimestamp, stringifyPartValue } from "../format";
 import { cn } from "../styles";
-import type { ConversationTurn } from "../types";
 import {
   TranscriptHeadingMeta,
   TranscriptHeadingRow,
@@ -19,7 +18,6 @@ function isString(value: string | undefined): value is string {
 /** Render a thinking transcript event with layout-aware expansion. */
 export function TranscriptThinkingView(props: {
   timestamp?: number;
-  turn?: ConversationTurn;
   value: unknown;
 }) {
   const [open, setOpen] = useState(false);

--- a/packages/junior-dashboard/src/client/components/TranscriptToolView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptToolView.tsx
@@ -38,12 +38,12 @@ export function TranscriptToolView(props: {
       ? formatMs(props.resultTimestamp - props.timestamp)
       : undefined;
   const meta = [
-    typeof props.timestamp === "number"
-      ? formatMessageTimestamp(props.timestamp)
-      : undefined,
     duration,
     props.result ? formatBytes(outputBytes) : undefined,
     props.result ? undefined : "missing result",
+    typeof props.timestamp === "number"
+      ? formatMessageTimestamp(props.timestamp)
+      : undefined,
   ].filter(isString);
   const args = <ToolArgumentsPreview input={input} />;
   const hasExpandableContent = Boolean(props.call || props.result);

--- a/packages/junior-dashboard/src/client/components/TranscriptTurn.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptTurn.tsx
@@ -231,7 +231,6 @@ function TurnEvents(props: {
             <TranscriptThinkingView
               key={`${props.turn.id}:thinking:${index}`}
               timestamp={entry.timestamp}
-              turn={props.turn}
               value={entry.part.output}
             />
           )}
@@ -318,7 +317,6 @@ function RedactedTranscriptView(props: { turn: ConversationTurn }) {
         <RedactedThinkingView
           key={`${props.turn.id}:redacted:thinking:${index}`}
           timestamp={entry.timestamp}
-          turn={props.turn}
         />
       )}
       renderTool={(entry, index) => (
@@ -389,10 +387,7 @@ function RedactedMarker() {
   );
 }
 
-function RedactedThinkingView(props: {
-  timestamp?: number;
-  turn: ConversationTurn;
-}) {
+function RedactedThinkingView(props: { timestamp?: number }) {
   const meta = [
     typeof props.timestamp === "number"
       ? formatMessageTimestamp(props.timestamp)

--- a/packages/junior-dashboard/src/client/components/TranscriptTurn.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptTurn.tsx
@@ -10,7 +10,6 @@ import {
   detectLanguage,
   transcriptRoleKind,
   formatBytes,
-  formatMessageOffset,
   formatMessageTimestamp,
   formatMs,
   formatTurnDuration,
@@ -339,8 +338,7 @@ function RedactedMessageView(props: {
   message: TranscriptMessage;
   turn: ConversationTurn;
 }) {
-  const offset = formatMessageOffset(props.turn, props.message.timestamp);
-  const meta = [formatMessageTimestamp(props.message.timestamp), offset].filter(
+  const meta = [formatMessageTimestamp(props.message.timestamp)].filter(
     isString,
   );
 
@@ -395,12 +393,10 @@ function RedactedThinkingView(props: {
   timestamp?: number;
   turn: ConversationTurn;
 }) {
-  const offset = formatMessageOffset(props.turn, props.timestamp);
   const meta = [
     typeof props.timestamp === "number"
       ? formatMessageTimestamp(props.timestamp)
       : undefined,
-    offset,
   ].filter(isString);
   const metaText = meta.join(" · ");
 
@@ -445,11 +441,11 @@ function RedactedToolView(props: {
       ? formatMs(props.resultTimestamp - props.timestamp)
       : undefined;
   const meta = [
+    duration,
+    props.result ? undefined : "missing result",
     typeof props.timestamp === "number"
       ? formatMessageTimestamp(props.timestamp)
       : undefined,
-    duration,
-    props.result ? undefined : "missing result",
   ].filter(isString);
   const mobileSummaryMeta =
     duration ?? (props.call && !props.result ? "missing result" : undefined);
@@ -627,7 +623,6 @@ function TranscriptMessageView(props: {
     );
   }
 
-  const offset = formatMessageOffset(props.turn, props.message.timestamp);
   const renderedParts = groupTranscriptParts(props.message.parts);
   const rawText = messageRawText(props.message);
   const role = props.message.role;
@@ -647,7 +642,7 @@ function TranscriptMessageView(props: {
       }}
     >
       <TranscriptMessageHeader
-        meta={[formatMessageTimestamp(props.message.timestamp), offset]}
+        meta={[formatMessageTimestamp(props.message.timestamp)]}
         role={props.message.role}
         turn={props.turn}
       />

--- a/packages/junior-dashboard/src/client/format.ts
+++ b/packages/junior-dashboard/src/client/format.ts
@@ -138,23 +138,6 @@ export function formatMessageTimestamp(value: number | undefined): string {
   });
 }
 
-/** Format a transcript event as an offset from the current turn start. */
-export function formatMessageOffset(
-  turn: ConversationTurn,
-  value: number | undefined,
-): string | undefined {
-  const start = parseTime(turn.startedAt);
-  if (
-    start == null ||
-    typeof value !== "number" ||
-    !Number.isFinite(value) ||
-    value < start
-  ) {
-    return undefined;
-  }
-  return `+${formatMs(value - start)}`;
-}
-
 function formatNumber(value: number | undefined): string {
   if (typeof value !== "number" || !Number.isFinite(value)) return "0";
   const number = Math.max(0, Math.floor(value));

--- a/packages/junior-dashboard/tests/dashboard-mock-routes.test.ts
+++ b/packages/junior-dashboard/tests/dashboard-mock-routes.test.ts
@@ -40,6 +40,7 @@ function reporting(): JuniorReporting {
         sessions: [
           {
             conversationId: "slack:C1:123",
+            cumulativeDurationMs: 0,
             id: "turn-1",
             status: "active",
             startedAt: "2026-05-29T00:00:00.000Z",
@@ -59,6 +60,7 @@ function reporting(): JuniorReporting {
         turns: [
           {
             conversationId,
+            cumulativeDurationMs: 0,
             id: "turn-1",
             status: "active",
             startedAt: "2026-05-29T00:00:00.000Z",

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -209,7 +209,7 @@ describe("dashboard telemetry components", () => {
     );
   });
 
-  it("aligns message metadata in a shared heading row", () => {
+  it("keeps message timestamps in a shared heading row without elapsed offsets", () => {
     const turn = {
       conversationId: "conversation-1",
       id: "turn-1",
@@ -237,7 +237,8 @@ describe("dashboard telemetry components", () => {
 
     expect(html).toContain("flex min-w-0 items-center justify-between gap-3");
     expect(html).toContain("font-mono leading-none text-[0.78rem] text-[#888]");
-    expect(html).toContain("· +10s");
+    expect(html).not.toContain("+10s");
+    expect(html).not.toContain("· +");
     expect(html).not.toContain("items-baseline gap-2 text-[0.88rem]");
   });
 
@@ -316,6 +317,7 @@ describe("dashboard telemetry components", () => {
   it("caps dashboard route pages at a readable width", () => {
     const session = {
       conversationId: "conversation-1",
+      cumulativeDurationMs: 0,
       id: "turn-1",
       lastProgressAt: "2026-01-01T00:00:00.000Z",
       lastSeenAt: "2026-01-01T00:00:00.000Z",
@@ -346,6 +348,7 @@ describe("dashboard telemetry components", () => {
   it("renders transcript copy as an icon-only control", () => {
     const session = {
       conversationId: "conversation-1",
+      cumulativeDurationMs: 0,
       id: "turn-1",
       lastProgressAt: "2026-01-01T00:00:00.000Z",
       lastSeenAt: "2026-01-01T00:00:00.000Z",
@@ -401,6 +404,7 @@ describe("dashboard telemetry components", () => {
     );
 
     expect(html.match(/·/g) ?? []).toHaveLength(5);
+    expect(html).toContain("5ms · 2b ·");
     expect(html).toContain("hidden text-[#777] max-md:inline");
     expect(html).toContain(
       'hidden min-w-0 break-words text-[#888] max-md:inline">5ms',


### PR DESCRIPTION
Conversation transcript event headings now show only the absolute timestamp rather than mixing in elapsed `+Ns` offsets. Tool rows keep duration, size, and status metadata, but the timestamp is ordered last so it remains the rightmost visible metadata when present.

**Transcript Metadata**

Message and thinking rows no longer compute turn-start offsets. Tool call rows keep their operational metadata ahead of the timestamp, preserving the right-edge datetime placement across expanded and redacted views.