### PR TITLE
feat: Allow standalone command env with explicit exposure

### DIFF
--- a/packages/docs/src/content/docs/extend/index.md
+++ b/packages/docs/src/content/docs/extend/index.md
@@ -120,7 +120,7 @@ export const plugins = defineJuniorPlugins(["@sentry/junior-sentry"], {
   manifests: {
     sentry: {
       credentials: {
-        domains: ["sentry.io", "us.sentry.io"],
+        domains: ["us.sentry.io", "de.sentry.io"],
       },
       oauth: {
         scope: "event:read org:read project:read",
@@ -230,14 +230,14 @@ runtime-postinstall:
 - `capabilities`: provider actions qualified as `<plugin>.<capability>`
 - `config-keys`: provider-specific configuration keys, qualified as `<plugin>.<key>`
 - `domains` and `api-headers`: optional host-managed HTTP headers applied when matching sandbox requests are proxied through Junior; each provider domain can belong to only one plugin
-- `command-env`: optional non-secret sandbox env vars injected for registered credential/header providers; use it for CLI placeholders, deployment defaults, and public install metadata
+- `command-env`: optional sandbox env vars for CLI placeholders, deployment defaults, public install metadata, and host env bindings explicitly marked safe for sandbox exposure
 - `credentials`: how token auth is delivered to tools; current types are `oauth-bearer` and `github-app`
 - `oauth`: user OAuth setup; use it with `credentials.type: oauth-bearer`
 - `target`: optional credential target scope tied to a declared config key
 - `runtime-dependencies`: sandbox dependencies required by the plugin’s tools
 - `runtime-postinstall`: commands that run after dependency install and before snapshot capture
 - `mcp`: optional MCP server configuration for provider-scoped tool sources; `mcp.url` implies hosted HTTP transport, so `mcp.transport: http` is optional
-- `env-vars`: optional map of deployment env vars the manifest may reference from `mcp.url`, `api-headers`, or `command-env`. Each key names an env var (uppercase, `[A-Z_][A-Z0-9_]*`) and may declare a `default` for `mcp.url` and `command-env`. Command-env references without defaults bind from host env when command env is resolved; API header references cannot use defaults.
+- `env-vars`: optional map of deployment env vars the manifest may reference from `mcp.url`, `api-headers`, or `command-env`. Each key names an env var (uppercase, `[A-Z_][A-Z0-9_]*`) and may declare a `default` for `mcp.url` and `command-env`. Command-env references without defaults must set `expose-to-command-env: true` before they bind from host env; API header references cannot use defaults.
 - `mcp.url`: supports `${VAR}` placeholders that must be declared in `env-vars`. This lets region-pinned providers pick the right host at deploy time without a manifest fork.
 - `mcp.allowed-tools`: optional raw MCP tool-name allowlist when a plugin should expose only part of a provider's tool surface
 
@@ -286,13 +286,11 @@ api-headers:
 
 ### Command env
 
-Use top-level `command-env` when a sandbox CLI needs non-secret env vars. This is commonly used for placeholder auth env vars so the CLI proceeds to make HTTP requests while Junior injects the real credentials from the host.
+Use top-level `command-env` when a sandbox CLI needs env vars. This is commonly used for placeholder auth env vars so the CLI proceeds to make HTTP requests while Junior injects the real credentials from the host.
 
-`command-env` values may be literals or `${NAME}` placeholders declared in `env-vars`. References with defaults expand at manifest load. References without defaults are read from host env when sandbox command env is resolved and are skipped when unset.
+`command-env` values may be literals or `${NAME}` placeholders declared in `env-vars`. References with defaults expand at manifest load. References without defaults must set `expose-to-command-env: true`; they are read from host env when sandbox command env is resolved and skipped when unset.
 
-Only expose non-secret values. `command-env` placeholders cannot reuse env vars that back `api-headers`, credential config, or OAuth config. For example, GitHub App bot names and noreply emails are safe to expose so git commits can be attributed correctly, but API keys and tokens belong in `api-headers` or credential brokers.
-
-Manifests with `command-env` must also declare `credentials` or `api-headers`, so sandbox env exposure stays tied to a credential/header provider.
+Only expose values that are safe for sandbox code to read. `command-env` placeholders cannot reuse env vars that back `api-headers`, credential config, or OAuth config. For example, GitHub App bot names and noreply emails are safe to expose so git commits can be attributed correctly, but provider API keys and tokens belong in `api-headers` or credential brokers.
 
 ```yaml
 env-vars:
@@ -300,6 +298,7 @@ env-vars:
   EXAMPLE_SITE:
     default: example.com
   EXAMPLE_BOT_EMAIL:
+    expose-to-command-env: true
 
 domains:
   - api.example.com

--- a/packages/docs/src/content/docs/reference/api/interfaces/JuniorAppOptions.md
+++ b/packages/docs/src/content/docs/reference/api/interfaces/JuniorAppOptions.md
@@ -17,7 +17,7 @@ Defined in: [app.ts:50](https://github.com/getsentry/junior/blob/main/packages/j
 
 Install-wide provider defaults (`provider.key` format). Channel overrides take precedence.
 
----
+***
 
 ### plugins?
 
@@ -27,7 +27,7 @@ Defined in: [app.ts:52](https://github.com/getsentry/junior/blob/main/packages/j
 
 Direct plugin set override. Usually omitted when `juniorNitro()` uses a plugin module.
 
----
+***
 
 ### waitUntil?
 

--- a/packages/docs/src/content/docs/reference/api/interfaces/JuniorPluginSet.md
+++ b/packages/docs/src/content/docs/reference/api/interfaces/JuniorPluginSet.md
@@ -19,7 +19,7 @@ Defined in: [plugins.ts:18](https://github.com/getsentry/junior/blob/main/packag
 
 Install-level manifest overrides applied before validation.
 
----
+***
 
 ### packageNames
 
@@ -29,7 +29,7 @@ Defined in: [plugins.ts:20](https://github.com/getsentry/junior/blob/main/packag
 
 Manifest-only plugin packages included by package name.
 
----
+***
 
 ### registrations
 

--- a/packages/junior-github/index.js
+++ b/packages/junior-github/index.js
@@ -91,8 +91,8 @@ export function githubPlugin(options = {}) {
         "GitHub issue, pull request, and repository workflows via GitHub App",
       configKeys: ["org", "repo"],
       envVars: {
-        GITHUB_APP_BOT_NAME: {},
-        GITHUB_APP_BOT_EMAIL: {},
+        GITHUB_APP_BOT_NAME: { exposeToCommandEnv: true },
+        GITHUB_APP_BOT_EMAIL: { exposeToCommandEnv: true },
       },
       credentials: {
         type: "github-app",

--- a/packages/junior-plugin-api/src/index.ts
+++ b/packages/junior-plugin-api/src/index.ts
@@ -293,6 +293,7 @@ export interface JuniorPluginMcpConfig {
 
 export interface JuniorPluginEnvVarDeclaration {
   default?: string;
+  exposeToCommandEnv?: boolean;
 }
 
 export interface JuniorPluginManifest {

--- a/packages/junior-sentry/plugin.yaml
+++ b/packages/junior-sentry/plugin.yaml
@@ -11,7 +11,6 @@ config-keys:
 credentials:
   type: oauth-bearer
   domains:
-    - sentry.io
     - us.sentry.io
     - de.sentry.io
   auth-token-env: SENTRY_AUTH_TOKEN

--- a/packages/junior/src/chat/plugins/command-env.ts
+++ b/packages/junior/src/chat/plugins/command-env.ts
@@ -23,7 +23,7 @@ function resolveValue(
   return missing ? undefined : resolved;
 }
 
-/** Resolve non-secret sandbox command env declared by a plugin manifest. */
+/** Resolve sandbox command env declared by a plugin manifest. */
 export function resolvePluginCommandEnv(
   manifest: PluginManifest,
 ): Record<string, string> {

--- a/packages/junior/src/chat/plugins/manifest.ts
+++ b/packages/junior/src/chat/plugins/manifest.ts
@@ -636,6 +636,33 @@ function assertCommandEnvDoesNotExposeHostSecretRefs(
   }
 }
 
+function assertCommandEnvHostRefsAreExplicitlyExposed(
+  commandEnv: Record<string, string> | undefined,
+  envVars: Record<string, PluginEnvVarDeclaration>,
+  pluginName: string,
+): void {
+  if (!commandEnv) {
+    return;
+  }
+
+  for (const [key, value] of Object.entries(commandEnv)) {
+    for (const name of envReferences(value)) {
+      const declaration = envVars[name] as
+        | PluginEnvVarDeclaration
+        | undefined;
+      if (
+        declaration &&
+        declaration.default === undefined &&
+        declaration.exposeToCommandEnv !== true
+      ) {
+        throw new Error(
+          `Plugin ${pluginName} command-env.${key} references env var ${name}, but env-vars.${name} must set expose-to-command-env: true before host env can be exposed to sandbox`,
+        );
+      }
+    }
+  }
+}
+
 function normalizeCredentials(
   data: Record<string, unknown>,
   name: string,
@@ -866,6 +893,8 @@ const envVarDeclarationSchema = z.preprocess(
   z
     .object({
       default: z.string().optional(),
+      "expose-to-command-env": z.boolean().optional(),
+      exposeToCommandEnv: z.boolean().optional(),
     })
     .strict(),
 );
@@ -891,6 +920,12 @@ function normalizeEnvVars(
     const decl: PluginEnvVarDeclaration = {};
     if (parsed.data.default !== undefined) {
       decl.default = parsed.data.default;
+    }
+    if (
+      parsed.data["expose-to-command-env"] === true ||
+      parsed.data.exposeToCommandEnv === true
+    ) {
+      decl.exposeToCommandEnv = true;
     }
     normalized[name] = decl;
   }
@@ -1093,11 +1128,6 @@ function parseManifestSource(
   const credentials = data.credentials
     ? normalizeCredentials(data.credentials, data.name)
     : undefined;
-  if (commandEnv && !credentials && !apiHeaders) {
-    throw new Error(
-      `Plugin ${data.name} command-env requires credentials or api-headers`,
-    );
-  }
   const runtimeDependencies = data["runtime-dependencies"]
     ? normalizeRuntimeDependencies(data["runtime-dependencies"], data.name)
     : undefined;
@@ -1174,6 +1204,11 @@ function parseManifestSource(
     apiHeaders,
     credentials,
     manifest.oauth,
+    data.name,
+  );
+  assertCommandEnvHostRefsAreExplicitlyExposed(
+    data["command-env"],
+    envVars,
     data.name,
   );
 

--- a/packages/junior/src/chat/plugins/types.ts
+++ b/packages/junior/src/chat/plugins/types.ts
@@ -75,6 +75,7 @@ export type PluginMcpConfig = PluginMcpHttpConfig;
 
 export interface PluginEnvVarDeclaration {
   default?: string;
+  exposeToCommandEnv?: boolean;
 }
 
 export interface PluginManifest {

--- a/packages/junior/tests/unit/plugins/packaged-sentry-manifest.test.ts
+++ b/packages/junior/tests/unit/plugins/packaged-sentry-manifest.test.ts
@@ -14,5 +14,11 @@ describe("packaged Sentry plugin manifest", () => {
       "us.sentry.io",
       "de.sentry.io",
     ]);
+    expect(manifest.oauth?.authorizeEndpoint).toBe(
+      "https://sentry.io/oauth/authorize/",
+    );
+    expect(manifest.oauth?.tokenEndpoint).toBe(
+      "https://sentry.io/oauth/token/",
+    );
   });
 });

--- a/packages/junior/tests/unit/plugins/packaged-sentry-manifest.test.ts
+++ b/packages/junior/tests/unit/plugins/packaged-sentry-manifest.test.ts
@@ -1,0 +1,18 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { parsePluginManifest } from "@/chat/plugins/manifest";
+
+describe("packaged Sentry plugin manifest", () => {
+  it("binds credentials only to regional API domains", async () => {
+    const pluginDir = path.resolve(process.cwd(), "../junior-sentry");
+    const raw = await fs.readFile(path.join(pluginDir, "plugin.yaml"), "utf8");
+    const manifest = parsePluginManifest(raw, pluginDir);
+
+    expect(manifest.name).toBe("sentry");
+    expect(manifest.credentials?.domains).toEqual([
+      "us.sentry.io",
+      "de.sentry.io",
+    ]);
+  });
+});

--- a/packages/junior/tests/unit/plugins/plugin-inline-manifest.test.ts
+++ b/packages/junior/tests/unit/plugins/plugin-inline-manifest.test.ts
@@ -66,6 +66,26 @@ describe("inline plugin manifests", () => {
           configKey: 123,
         },
       }),
-    ).toThrow("Plugin bad-target-token target.config-key Invalid input");
+      ).toThrow("Plugin bad-target-token target.config-key Invalid input");
+  });
+
+  it("accepts camelCase command env exposure declarations", () => {
+    const manifest = parse({
+      name: "safe-env",
+      description: "Safe sandbox env",
+      envVars: {
+        EXAMPLE_SAFE_TOKEN: { exposeToCommandEnv: true },
+      },
+      commandEnv: {
+        EXAMPLE_SAFE_TOKEN: "${EXAMPLE_SAFE_TOKEN}",
+      },
+    });
+
+    expect(manifest.envVars).toEqual({
+      EXAMPLE_SAFE_TOKEN: { exposeToCommandEnv: true },
+    });
+    expect(manifest.commandEnv).toEqual({
+      EXAMPLE_SAFE_TOKEN: "${EXAMPLE_SAFE_TOKEN}",
+    });
   });
 });

--- a/packages/junior/tests/unit/plugins/plugin-manifest-api-headers.test.ts
+++ b/packages/junior/tests/unit/plugins/plugin-manifest-api-headers.test.ts
@@ -1,8 +1,15 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolvePluginCommandEnv } from "@/chat/plugins/command-env";
 import { parsePluginManifest } from "@/chat/plugins/manifest";
+
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
 
 describe("plugin manifest API headers", () => {
   it("parses plugin-level API headers with literal and env-backed values", () => {
@@ -62,6 +69,7 @@ describe("plugin manifest API headers", () => {
         "description: Example API access",
         "env-vars:",
         "  EXAMPLE_BOT_EMAIL:",
+        "    expose-to-command-env: true",
         "credentials:",
         "  type: oauth-bearer",
         "  domains:",
@@ -73,7 +81,9 @@ describe("plugin manifest API headers", () => {
       "/tmp/example",
     );
 
-    expect(manifest.envVars?.EXAMPLE_BOT_EMAIL).toEqual({});
+    expect(manifest.envVars?.EXAMPLE_BOT_EMAIL).toEqual({
+      exposeToCommandEnv: true,
+    });
     expect(manifest.commandEnv).toEqual({
       GIT_AUTHOR_EMAIL: "${EXAMPLE_BOT_EMAIL}",
     });
@@ -138,9 +148,9 @@ describe("plugin manifest API headers", () => {
     )) as typeof import("../../../../junior-github/index.js");
     const manifest = githubPlugin().manifest!;
 
-    expect(manifest.envVars).toMatchObject({
-      GITHUB_APP_BOT_NAME: {},
-      GITHUB_APP_BOT_EMAIL: {},
+    expect(manifest.envVars).toEqual({
+      GITHUB_APP_BOT_NAME: { exposeToCommandEnv: true },
+      GITHUB_APP_BOT_EMAIL: { exposeToCommandEnv: true },
     });
     expect(manifest.commandEnv).toMatchObject({
       GIT_AUTHOR_NAME: "${GITHUB_APP_BOT_NAME}",
@@ -157,6 +167,7 @@ describe("plugin manifest API headers", () => {
         "description: Example API access",
         "env-vars:",
         "  EXAMPLE_BOT_EMAIL:",
+        "    expose-to-command-env: true",
         "credentials:",
         "  type: oauth-bearer",
         "  domains:",
@@ -181,7 +192,7 @@ describe("plugin manifest API headers", () => {
           "description: Example API access",
           "env-vars:",
           "  EXAMPLE_BOT_EMAIL:",
-          "    expose-to-command-env: true",
+          "    unexpected: true",
           "credentials:",
           "  type: oauth-bearer",
           "  domains:",
@@ -268,18 +279,46 @@ describe("plugin manifest API headers", () => {
     );
   });
 
-  it("rejects command env without credentials or API headers", () => {
+  it("resolves standalone command env from explicitly exposed host env references", () => {
+    process.env.EXAMPLE_SAFE_TOKEN = "safe-token";
+    const manifest = parsePluginManifest(
+      [
+        "name: example",
+        "description: Example CLI access",
+        "env-vars:",
+        "  EXAMPLE_SAFE_TOKEN:",
+        "    expose-to-command-env: true",
+        "command-env:",
+        '  EXAMPLE_SAFE_TOKEN: "${EXAMPLE_SAFE_TOKEN}"',
+        '  EXAMPLE_MODE: "readonly"',
+      ].join("\n"),
+      "/tmp/example",
+    );
+
+    expect(manifest.credentials).toBeUndefined();
+    expect(manifest.apiHeaders).toBeUndefined();
+    expect(resolvePluginCommandEnv(manifest)).toEqual({
+      EXAMPLE_SAFE_TOKEN: "safe-token",
+      EXAMPLE_MODE: "readonly",
+    });
+  });
+
+  it("rejects command env host env references without explicit exposure", () => {
     expect(() =>
       parsePluginManifest(
         [
           "name: example",
           "description: Example CLI access",
+          "env-vars:",
+          "  EXAMPLE_SAFE_TOKEN:",
           "command-env:",
-          "  EXAMPLE_TOKEN: host_managed_credential",
+          '  EXAMPLE_SAFE_TOKEN: "${EXAMPLE_SAFE_TOKEN}"',
         ].join("\n"),
         "/tmp/example",
       ),
-    ).toThrow("Plugin example command-env requires credentials or api-headers");
+    ).toThrow(
+      "Plugin example command-env.EXAMPLE_SAFE_TOKEN references env var EXAMPLE_SAFE_TOKEN, but env-vars.EXAMPLE_SAFE_TOKEN must set expose-to-command-env: true before host env can be exposed to sandbox",
+    );
   });
 
   it("rejects API headers without domains", () => {

--- a/packages/junior/tests/unit/plugins/sentry-broker.test.ts
+++ b/packages/junior/tests/unit/plugins/sentry-broker.test.ts
@@ -21,7 +21,7 @@ const SENTRY_MANIFEST: PluginManifest = {
   configKeys: ["sentry.org", "sentry.project"],
   credentials: {
     type: "oauth-bearer",
-    domains: ["sentry.io", "us.sentry.io", "de.sentry.io"],
+    domains: ["us.sentry.io", "de.sentry.io"],
     authTokenEnv: "SENTRY_AUTH_TOKEN",
   },
   oauth: {
@@ -89,10 +89,6 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
     expect(lease.env).toEqual({ SENTRY_AUTH_TOKEN: "host_managed_credential" });
     expect(lease.headerTransforms).toEqual([
       {
-        domain: "sentry.io",
-        headers: { Authorization: "Bearer user-access-token" },
-      },
-      {
         domain: "us.sentry.io",
         headers: { Authorization: "Bearer user-access-token" },
       },
@@ -114,10 +110,6 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
     expect(lease.env).toEqual({ SENTRY_AUTH_TOKEN: "host_managed_credential" });
     expect(lease.headerTransforms).toEqual([
       {
-        domain: "sentry.io",
-        headers: { Authorization: "Bearer static-env-token" },
-      },
-      {
         domain: "us.sentry.io",
         headers: { Authorization: "Bearer static-env-token" },
       },
@@ -133,7 +125,7 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
     process.env.SENTRY_EXTRA_AUTH = "PluginManaged value";
     const manifest: PluginManifest = {
       ...SENTRY_MANIFEST,
-      domains: ["uploads.sentry.io", "sentry.io"],
+      domains: ["uploads.sentry.io", "us.sentry.io"],
       apiHeaders: {
         Authorization: "${SENTRY_EXTRA_AUTH}",
         "X-Sentry-Mode": "sandbox",
@@ -158,15 +150,11 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
         },
       },
       {
-        domain: "sentry.io",
+        domain: "us.sentry.io",
         headers: {
           Authorization: "Bearer static-env-token",
           "X-Sentry-Mode": "sandbox",
         },
-      },
-      {
-        domain: "us.sentry.io",
-        headers: { Authorization: "Bearer static-env-token" },
       },
       {
         domain: "de.sentry.io",
@@ -215,10 +203,6 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
     });
 
     expect(lease.headerTransforms).toEqual([
-      {
-        domain: "sentry.io",
-        headers: { Authorization: "Bearer new-access-token" },
-      },
       {
         domain: "us.sentry.io",
         headers: { Authorization: "Bearer new-access-token" },

--- a/specs/credential-injection.md
+++ b/specs/credential-injection.md
@@ -37,7 +37,7 @@ Define how Junior maps registered plugin provider domains to host-managed creden
 - Enablement happens when sandbox traffic reaches a registered provider domain, not at skill-load time.
 - Delivery uses the Vercel Sandbox firewall request proxy for provider domains when available, with host-side header injection on the forwarded request.
 - Plugin credentials may define a provider-specific `auth-token-placeholder` for CLI compatibility.
-- Plugin manifests may define non-secret `command-env` values for CLI compatibility. These may include placeholder API keys, deployment defaults, or explicit public host env bindings, but never real secrets.
+- Plugin manifests may define sandbox-visible `command-env` values for CLI compatibility. These may include placeholder API keys, deployment defaults, or host env bindings explicitly marked `expose-to-command-env`; provider auth secrets that should remain host-only belong in credentials or API headers.
 - Do not inject long-lived secrets into sandbox files.
 - Credential issuance is intentionally lazy to avoid wasted token minting and provider compute for commands that never touch authenticated domains.
 - Do not infer provider intent from bash commands, skill prose, or planned work to pre-scope tokens. Fine-grained token scopes are desirable, but guessing intent is not a safe authorization boundary; provider/domain matching at request time is the contract.

--- a/specs/oauth-flows.md
+++ b/specs/oauth-flows.md
@@ -115,7 +115,7 @@ After a user has connected their account:
 3. Broker loads stored requester-bound tokens.
 4. If the token is near expiry, broker refreshes it server-side.
 5. Broker returns a short-lived `CredentialLease`.
-6. Runtime injects provider headers at the sandbox egress proxy boundary and exposes only non-secret command env or placeholder values inside the sandbox.
+6. Runtime injects provider headers at the sandbox egress proxy boundary and exposes only declared sandbox command env or placeholder values inside the sandbox.
 
 ## State management
 

--- a/specs/plugin-manifest.md
+++ b/specs/plugin-manifest.md
@@ -47,7 +47,8 @@ config-keys:
 credentials:
   type: oauth-bearer
   domains:
-    - sentry.io
+    - us.sentry.io
+    - de.sentry.io
   auth-token-env: SENTRY_AUTH_TOKEN
   auth-token-placeholder: host_managed_credential
 
@@ -90,6 +91,8 @@ env-vars:
   EXAMPLE_AUTH_HEADER:
   EXAMPLE_SITE:
     default: example.com
+  EXAMPLE_SAFE_TOKEN:
+    expose-to-command-env: true
 
 api-headers:
   Authorization: ${EXAMPLE_AUTH_HEADER}
@@ -97,6 +100,7 @@ api-headers:
 command-env:
   EXAMPLE_API_KEY: host_managed_credential
   EXAMPLE_SITE: ${EXAMPLE_SITE}
+  EXAMPLE_SAFE_TOKEN: ${EXAMPLE_SAFE_TOKEN}
 ```
 
 Rules:
@@ -106,8 +110,8 @@ Rules:
 3. Placeholders must be declared in `env-vars`.
 4. `api-headers` placeholders must not have defaults.
 5. `mcp.url` and default-backed `command-env` placeholders expand at manifest load.
-6. `command-env` references without defaults bind from host env when sandbox command env is built; unset values are omitted.
-7. Secret-bearing provider values belong in `api-headers`, `oauth`, or `credentials`, not `command-env`.
+6. `command-env` references without defaults require `expose-to-command-env: true`, bind from host env when sandbox command env is built, and are omitted when unset.
+7. Secret-like values may be exposed through `command-env` only when they are intentionally safe for the sandbox. Provider auth values that must stay host-only belong in `api-headers`, `oauth`, or `credentials`.
 
 ## Runtime Dependencies
 
@@ -161,7 +165,7 @@ Rules:
 - No duplicate plugin names.
 - No duplicate qualified capability tokens.
 - No duplicate effective provider egress domains after app-level `PluginCatalogConfig` merges.
-- `command-env` requires credentials or API headers.
+- `command-env` may stand alone and must not force a plugin to claim provider egress domains.
 - `plugin.yaml` is the enforceable runtime authority; skill prose cannot override it.
 
 ## Related Specs

--- a/specs/security-policy.md
+++ b/specs/security-policy.md
@@ -55,9 +55,9 @@ This policy applies to:
 - A registered provider authorizes its declared domains for sandbox egress; registration must not mint credentials by itself.
 - Credential issuance for user-owned provider access must be requester-bound; runtime paths without requester context must fail instead of issuing reusable credentials.
 - Even for host-managed integrations, sandbox credentials are issued lazily only when a sandbox request reaches a declared provider domain. The runtime must not pre-provision provider credentials merely because a plugin is loaded or a command might need auth.
-- Real provider secrets are delivered exclusively via host-level header transforms — the host proxies auth headers for matching provider domains (e.g. `Authorization` for `api.github.com`/`sentry.io` or provider-specific API key headers). The sandbox never sees real secret values.
+- Real provider secrets are delivered exclusively via host-level header transforms — the host proxies auth headers for matching provider domains (e.g. `Authorization` for `api.github.com`/`us.sentry.io` or provider-specific API key headers). The sandbox never sees real secret values.
 - When CLI tools require tool-native sandbox auth env vars (for example `SENTRY_AUTH_TOKEN`, Pup's `DD_API_KEY`, or Pup's `DD_APP_KEY`), set them to non-secret placeholders so the tool proceeds to make HTTP requests. Placeholder values may be provider-specific via plugin manifest config. The host authenticates those requests via header transforms.
-- Plugin-declared command env may include non-secret placeholders, default-backed deployment values, and explicit non-secret host env bindings needed by the command process. It must not read or expose env vars used by API headers, credential config, OAuth config, or other secret deployment values.
+- Plugin-declared command env may include placeholders, default-backed deployment values, and host env bindings explicitly marked safe for sandbox exposure. It must not read or expose env vars used by API headers, credential config, OAuth config, or other host-only secret deployment values.
 - Never inject real provider secrets into sandbox env vars, files, or command arguments.
 
 ### GitHub baseline
@@ -95,7 +95,7 @@ This policy applies to:
 - Token exchange and storage happen server-side in the OAuth callback handler — the agent never sees token values.
 - Refresh tokens on host, deliver short-lived access tokens via header transforms.
 - Fall back to static `SENTRY_AUTH_TOKEN` env var only for local/dev/test paths outside requester-bound turn execution.
-- Inject `Authorization` header transform for `sentry.io` domain.
+- Inject `Authorization` header transforms for Sentry region API domains such as `us.sentry.io` and `de.sentry.io`.
 - Set `SENTRY_AUTH_TOKEN` in lease env to a placeholder — real token never enters the sandbox.
 - See [OAuth Flows Spec](./oauth-flows.md) for full flow details.
 


### PR DESCRIPTION
## Summary
- Let `command-env` stand alone without requiring provider domains or API headers.
- Add an explicit `expose-to-command-env` opt-in for host env bindings that should be visible in the sandbox.
- Keep provider auth values host-only, and update the Sentry/GitHub manifests and docs to match.

## Testing
- Added and updated unit coverage for manifest parsing, inline plugin manifests, packaged Sentry config, and sandbox command-env resolution.
- Ran the affected Vitest suites, plus `pnpm docs:check` and package typecheck for `@sentry/junior` and `@sentry/junior-plugin-api`.