### PR TITLE
ref(dashboard): Use conversation copy in dashboard

### DIFF
--- a/packages/junior-dashboard/src/client/components/ConversationDurationChart.tsx
+++ b/packages/junior-dashboard/src/client/components/ConversationDurationChart.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useMemo, useState, type ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router";
 import {
@@ -16,23 +16,19 @@ import {
   buildConversations,
   conversationDisplayTitle,
   conversationRequesterLabel,
-  conversationIdForSession,
   conversationPath,
   formatDurationTick,
   formatMs,
-  requesterLabel,
   slackLocationLabel,
   summarizeMessages,
   summarizeToolCalls,
   summarizeUsage,
-  visualStatusForSession,
   visualStatusForConversation,
 } from "../format";
 import { cn } from "../styles";
 import type {
   Conversation,
   ConversationDetailFeed,
-  ConversationTurn,
   Session,
   VisualStatus,
 } from "../types";
@@ -47,12 +43,11 @@ import {
 } from "./TelemetryMetrics";
 import { statusBorderClass } from "./statusStyles";
 
-/** Render recent turns by start time and duration. */
-export function TurnDurationChart(props: {
+/** Render recent conversations by start time and duration. */
+export function ConversationDurationChart(props: {
   sessions: Session[];
   timeZone: string;
 }) {
-  const [mode, setMode] = useState<DurationChartMode>("conversations");
   const navigate = useNavigate();
   const nowMs = Date.now();
   const rangeStartMs = nowMs - 7 * 24 * 60 * 60 * 1000;
@@ -61,16 +56,11 @@ export function TurnDurationChart(props: {
   const chartRangeStartMs = rangeStartMs - chartEdgePaddingMs;
   const chartRangeEndMs = rangeEndMs + chartEdgePaddingMs;
   const conversations = useMemo(
-    () => (mode === "conversations" ? buildConversations(props.sessions) : []),
-    [mode, props.sessions],
+    () => buildConversations(props.sessions),
+    [props.sessions],
   );
-  const points = (
-    mode === "turns"
-      ? props.sessions.map((session) => turnPoint(session, props.timeZone))
-      : conversations.map((conversation) =>
-          conversationPoint(conversation, props.timeZone),
-        )
-  )
+  const points = conversations
+    .map((conversation) => conversationPoint(conversation, props.timeZone))
     .filter((point): point is DurationPoint => Boolean(point))
     .filter((point) => point.x >= rangeStartMs && point.x <= rangeEndMs)
     .sort((left, right) => left.x - right.x);
@@ -93,7 +83,6 @@ export function TurnDurationChart(props: {
   const openPoint = (point: DurationPoint) => {
     navigate(conversationPath(point.conversationId));
   };
-  const modeLabel = mode === "turns" ? "turns" : "conversations";
 
   return (
     <Section>
@@ -106,11 +95,11 @@ export function TurnDurationChart(props: {
           </div>
         }
       >
-        <ChartModeToggle mode={mode} onChange={setMode} />
+        <ChartTitle>Conversations</ChartTitle>
       </SectionHeader>
       <div
         className="min-h-48 px-3 pb-2 pt-4"
-        aria-label={`${modeLabel} by duration over the last 7 days`}
+        aria-label="conversations by duration over the last 7 days"
       >
         <ResponsiveContainer height={190} width="100%">
           <ScatterChart margin={{ bottom: 0, left: 0, right: 4, top: 14 }}>
@@ -149,7 +138,7 @@ export function TurnDurationChart(props: {
               width={48}
             />
             <Tooltip
-              content={<TurnDurationTooltip />}
+              content={<ConversationDurationTooltip />}
               cursor={{ stroke: "rgba(255, 255, 255, 0.22)" }}
             />
             <Scatter
@@ -162,9 +151,18 @@ export function TurnDurationChart(props: {
         </ResponsiveContainer>
       </div>
       <div className="border-t border-white/10 px-4 py-3 text-[0.84rem] leading-tight text-[#888]">
-        {totals.total} {modeLabel} / {totals.hung} hung / {totals.failed} errors
+        {totals.total} conversations / {totals.hung} hung / {totals.failed}{" "}
+        errors
       </div>
     </Section>
+  );
+}
+
+function ChartTitle(props: { children: ReactNode }) {
+  return (
+    <div className="text-[1.05rem] font-bold leading-tight tracking-normal text-white">
+      {props.children}
+    </div>
   );
 }
 
@@ -178,7 +176,6 @@ function ChartLegendItem(props: { className: string; label: string }) {
 }
 
 type PlottedTurnStatus = Exclude<VisualStatus, "active">;
-type DurationChartMode = "conversations" | "turns";
 
 type DurationPoint = {
   conversation?: Conversation;
@@ -186,54 +183,12 @@ type DurationPoint = {
   durationLabel: string;
   durationMs: number;
   endedAt: string;
-  kind: DurationChartMode;
-  session?: Session;
   startedAt: string;
   status: PlottedTurnStatus;
   title: string;
   tooltipLabel: string;
   x: number;
 };
-
-function ChartModeToggle(props: {
-  mode: DurationChartMode;
-  onChange(mode: DurationChartMode): void;
-}) {
-  const modes: Array<{ label: string; value: DurationChartMode }> = [
-    { label: "Conversations", value: "conversations" },
-    { label: "Turns", value: "turns" },
-  ];
-  return (
-    <div
-      aria-label="Duration chart mode"
-      className="inline-flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-1"
-      role="group"
-    >
-      {modes.map((mode, index) => (
-        <Fragment key={mode.value}>
-          {index > 0 ? (
-            <span className="text-[1.05rem] font-bold leading-tight text-[#666]">
-              /
-            </span>
-          ) : null}
-          <button
-            aria-pressed={props.mode === mode.value}
-            className={cn(
-              "cursor-pointer border-0 bg-transparent p-0 text-[1.05rem] font-bold leading-tight tracking-normal transition-colors",
-              props.mode === mode.value
-                ? "text-white"
-                : "text-[#888] hover:text-white",
-            )}
-            onClick={() => props.onChange(mode.value)}
-            type="button"
-          >
-            {mode.label}
-          </button>
-        </Fragment>
-      ))}
-    </div>
-  );
-}
 
 function plottedStatus(status: VisualStatus): PlottedTurnStatus | null {
   return status === "active" ? null : status;
@@ -242,37 +197,6 @@ function plottedStatus(status: VisualStatus): PlottedTurnStatus | null {
 function finiteDurationMs(value: number | undefined): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
   return Math.max(0, Math.floor(value));
-}
-
-function turnPoint(session: Session, timeZone: string): DurationPoint | null {
-  const startedAtMs = Date.parse(session.startedAt);
-  if (!Number.isFinite(startedAtMs)) {
-    return null;
-  }
-  const status = plottedStatus(visualStatusForSession(session));
-  if (!status) {
-    return null;
-  }
-
-  const durationMs = finiteDurationMs(session.cumulativeDurationMs);
-  if (durationMs === undefined) {
-    return null;
-  }
-  return {
-    conversationId: conversationIdForSession(session),
-    durationLabel: formatMs(durationMs),
-    durationMs,
-    endedAt: session.completedAt ?? session.lastSeenAt,
-    kind: "turns",
-    session,
-    startedAt: session.startedAt,
-    status,
-    title: turnTooltipTitle(session),
-    tooltipLabel: new Date(startedAtMs).toLocaleString(undefined, {
-      timeZone,
-    }),
-    x: startedAtMs,
-  };
 }
 
 function conversationPoint(
@@ -301,7 +225,6 @@ function conversationPoint(
     durationLabel: formatMs(durationMs),
     durationMs,
     endedAt: conversation.lastSeenAt,
-    kind: "conversations",
     startedAt: conversation.startedAt,
     status,
     title: conversationDisplayTitle(conversation),
@@ -360,7 +283,7 @@ function durationDotFill(status: PlottedTurnStatus, active: boolean): string {
   return active ? "rgba(250, 250, 250, 0.96)" : "rgba(184, 184, 184, 0.82)";
 }
 
-function TurnDurationTooltip(props: {
+function ConversationDurationTooltip(props: {
   active?: boolean;
   payload?: Array<{ payload: DurationPoint }>;
 }) {
@@ -416,24 +339,18 @@ function chartTooltipRows(
   point: DurationPoint,
   detail: ConversationDetailFeed | undefined,
 ): Array<[string, ReactNode]> {
-  const session = point.session ?? point.conversation;
-  const requester =
-    point.kind === "conversations"
-      ? conversationRequesterLabel(point.conversation)
-      : requesterLabel(session?.requesterIdentity);
+  const session = point.conversation;
+  const requester = conversationRequesterLabel(point.conversation);
   const location = session
     ? slackLocationLabel(session, { includeId: false })
     : undefined;
-  const turns = chartTooltipTurns(point, detail);
   const tokenSummary = summarizeUsage(
-    point.kind === "turns"
-      ? [point.session?.cumulativeUsage]
-      : (detail?.turns ?? point.conversation?.turns ?? []).map(
-          (turn) => turn.cumulativeUsage,
-        ),
+    (detail?.turns ?? point.conversation?.turns ?? []).map(
+      (turn) => turn.cumulativeUsage,
+    ),
   );
-  const messageSummary = detail ? summarizeMessages(turns) : undefined;
-  const toolSummary = detail ? summarizeToolCalls(turns) : undefined;
+  const messageSummary = detail ? summarizeMessages(detail.turns) : undefined;
+  const toolSummary = detail ? summarizeToolCalls(detail.turns) : undefined;
   const rows: Array<[string, ReactNode] | null> = [
     [
       "duration",
@@ -465,21 +382,6 @@ function chartTooltipRows(
     location ? ["surface", location] : null,
   ];
   return rows.filter((row): row is [string, ReactNode] => row !== null);
-}
-
-function chartTooltipTurns(
-  point: DurationPoint,
-  detail: ConversationDetailFeed | undefined,
-): ConversationTurn[] {
-  if (point.kind === "conversations") {
-    return detail?.turns ?? [];
-  }
-  const turn = detail?.turns.find((item) => item.id === point.session?.id);
-  return turn ? [turn] : [];
-}
-
-function turnTooltipTitle(session: Session): string {
-  return session.conversationTitle ?? session.title;
 }
 
 function chartTooltipStatus(status: PlottedTurnStatus): ReactNode {

--- a/packages/junior-dashboard/src/client/components/ConversationRowStats.tsx
+++ b/packages/junior-dashboard/src/client/components/ConversationRowStats.tsx
@@ -16,9 +16,7 @@ export function ConversationRowStats(props: {
   const runtime = formatDurationTotal(
     props.conversation.turns.map((turn) => turn.cumulativeDurationMs),
   );
-  const turnCount = props.conversation.turns.length;
   const primaryStats = [
-    `${turnCount} ${turnCount === 1 ? "turn" : "turns"}`,
     tokens,
     runtime ? `${runtime} runtime` : "",
   ].filter(Boolean);
@@ -29,9 +27,11 @@ export function ConversationRowStats(props: {
 
   return (
     <div className="grid min-w-0 justify-items-end gap-1 text-right max-md:justify-items-start max-md:text-left">
-      <div className="text-[0.84rem] leading-relaxed text-[#b8b8b8]">
-        {primaryStats.join(" · ")}
-      </div>
+      {primaryStats.length > 0 ? (
+        <div className="text-[0.84rem] leading-relaxed text-[#b8b8b8]">
+          {primaryStats.join(" · ")}
+        </div>
+      ) : null}
       {secondaryStats.length > 0 ? (
         <div className="max-w-full break-words text-[0.84rem] leading-relaxed text-[#888] md:truncate">
           {secondaryStats.join(" · ")}

--- a/packages/junior-dashboard/src/client/components/Transcript.tsx
+++ b/packages/junior-dashboard/src/client/components/Transcript.tsx
@@ -2,11 +2,11 @@ import { useState, type ReactNode } from "react";
 
 import type { ConversationTurn } from "../types";
 import { TranscriptHeader } from "./TranscriptHeader";
-import { TurnTranscript } from "./TranscriptTurn";
+import { ConversationTranscriptSegment } from "./TranscriptTurn";
 import type { TranscriptViewMode } from "./transcriptRenderModel";
 import { transcriptEmptyClass } from "./transcriptStyles";
 
-/** Render ordered conversation turns as message, thinking, and tool-call events. */
+/** Render ordered conversation transcript segments as message and tool events. */
 export function Transcript(props: {
   actions?: ReactNode;
   turns: ConversationTurn[];
@@ -30,10 +30,9 @@ export function Transcript(props: {
         value={view}
         onChange={setView}
       />
-      {props.turns.map((turn, index) => (
-        <TurnTranscript
+      {props.turns.map((turn) => (
+        <ConversationTranscriptSegment
           key={turn.id}
-          number={index + 1}
           turn={turn}
           view={view}
         />

--- a/packages/junior-dashboard/src/client/components/TranscriptTurn.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptTurn.tsx
@@ -65,9 +65,8 @@ type TranscriptMessageEntry = Extract<TranscriptEntry, { kind: "message" }>;
 type TranscriptThinkingEntry = Extract<TranscriptEntry, { kind: "thinking" }>;
 type TranscriptToolEntry = Extract<TranscriptEntry, { kind: "tool" }>;
 
-/** Render one conversation turn as actor messages and tool events. */
-export function TurnTranscript(props: {
-  number: number;
+/** Render one conversation transcript segment as actor messages and tool events. */
+export function ConversationTranscriptSegment(props: {
   turn: ConversationTurn;
   view: TranscriptViewMode;
 }) {
@@ -80,8 +79,8 @@ export function TurnTranscript(props: {
         <span className="mt-2 w-px flex-1 bg-[#beaaff]/20" />
       </div>
       <div className="min-w-0">
-        <TurnHeader number={props.number} turn={props.turn} />
-        <TurnEvents turn={props.turn} view={props.view} />
+        <SegmentHeader turn={props.turn} />
+        <SegmentEvents turn={props.turn} view={props.view} />
       </div>
     </section>
   );
@@ -190,17 +189,14 @@ function TranscriptMessageHeader(props: {
   );
 }
 
-function TurnHeader(props: { number: number; turn: ConversationTurn }) {
+function SegmentHeader(props: { turn: ConversationTurn }) {
   const status = visualStatusForSession(props.turn);
 
   return (
     <div className="flex items-start justify-between gap-3 max-md:flex-col">
       <div className="min-w-0">
-        <div className="break-all text-[1.05rem] font-bold leading-tight tracking-normal">
-          Turn {props.number}
-        </div>
         <MetricList
-          className={cn(mutedTranscriptMetaClass(), "mt-1")}
+          className={mutedTranscriptMetaClass()}
           items={turnMeta(props.turn)}
         />
       </div>
@@ -209,7 +205,7 @@ function TurnHeader(props: { number: number; turn: ConversationTurn }) {
   );
 }
 
-function TurnEvents(props: {
+function SegmentEvents(props: {
   turn: ConversationTurn;
   view: TranscriptViewMode;
 }) {

--- a/packages/junior-dashboard/src/client/components/statusStyles.ts
+++ b/packages/junior-dashboard/src/client/components/statusStyles.ts
@@ -1,6 +1,6 @@
 import type { VisualStatus } from "../types";
 
-/** Map turn health to the shared left-border severity accent. */
+/** Map conversation health to the shared left-border severity accent. */
 export function statusBorderClass(status: VisualStatus): string {
   if (status === "active") return "border-l-emerald-400";
   if (status === "hung") return "border-l-amber-400";

--- a/packages/junior-dashboard/src/client/components/transcriptStyles.ts
+++ b/packages/junior-dashboard/src/client/components/transcriptStyles.ts
@@ -1,11 +1,11 @@
 import { cn } from "../styles";
 
-/** Share muted transcript metadata styling between turn and message chrome. */
+/** Share muted transcript metadata styling between segment and message chrome. */
 export function mutedTranscriptMetaClass(size = "text-[0.82rem]"): string {
   return cn("leading-relaxed text-[#b8b8b8]", size);
 }
 
-/** Share the transcript empty/unavailable frame across top-level and turn views. */
+/** Share the transcript empty/unavailable frame across top-level and segment views. */
 export function transcriptEmptyClass(): string {
   return "border border-white/10 bg-[#050505] p-4 text-[0.9rem] leading-relaxed text-[#b8b8b8]";
 }

--- a/packages/junior-dashboard/src/client/format.ts
+++ b/packages/junior-dashboard/src/client/format.ts
@@ -546,10 +546,10 @@ function getConversationTitle(conversation: Conversation): string {
   if (conversation.surface === "slack") {
     return (
       slackLocationLabel(conversation, { includeId: false }) ??
-      conversation.title
+      "Conversation"
     );
   }
-  return conversation.title;
+  return "Conversation";
 }
 
 /** Choose the safe display title already prepared by the reporting API. */
@@ -640,12 +640,12 @@ export function unavailableTranscriptLabel(turn: ConversationTurn): string {
   }
   const status = visualStatusForSession(turn);
   if (status === "active") {
-    return "Transcript pending for this active turn.";
+    return "Transcript pending while this conversation is active.";
   }
   if (status === "hung") {
-    return "Transcript pending for this hung turn.";
+    return "Transcript pending while this conversation is hung.";
   }
-  return "Transcript unavailable for this turn.";
+  return "Transcript unavailable for this conversation.";
 }
 
 /** Build the canonical permalink route for a conversation id. */

--- a/packages/junior-dashboard/src/client/markdownExport.ts
+++ b/packages/junior-dashboard/src/client/markdownExport.ts
@@ -1,7 +1,6 @@
 import {
   conversationDisplayTitle,
   formatMs,
-  formatTurnDuration,
   formatUsageTotal,
   requesterLabel,
   slackLocationLabel,
@@ -38,7 +37,11 @@ export function buildConversationMarkdown(
     conversationRequester(conversation, firstTurn),
   );
   addMetaLine(lines, "Location", conversationLocation(conversation, firstTurn));
-  addMetaLine(lines, "Turns", String(detail.turns.length));
+  addMetaLine(
+    lines,
+    "Usage",
+    formatUsageTotal(detail.turns.map((turn) => turn.cumulativeUsage)),
+  );
   addMetaLine(
     lines,
     "Sentry conversation",
@@ -50,22 +53,8 @@ export function buildConversationMarkdown(
     return finishMarkdown(lines);
   }
 
-  detail.turns.forEach((turn, index) => {
-    lines.push("", `## ${turnHeading(turn, index)}`, "");
-    addMetaLine(lines, "Turn ID", inlineCode(turn.id));
-    addMetaLine(lines, "Status", inlineCode(turn.status));
-    addMetaLine(lines, "Started", turn.startedAt);
-    addMetaLine(lines, "Completed", turn.completedAt);
-    addMetaLine(lines, "Last seen", turn.lastSeenAt);
-    addMetaLine(lines, "Duration", formatTurnDuration(turn));
-    addMetaLine(lines, "Usage", formatUsageTotal([turn.cumulativeUsage]));
-    addMetaLine(
-      lines,
-      "Trace ID",
-      turn.traceId ? inlineCode(turn.traceId) : "",
-    );
-    addMetaLine(lines, "Sentry trace", turn.sentryTraceUrl);
-
+  lines.push("", "## Transcript");
+  detail.turns.forEach((turn) => {
     appendTurnTranscript(lines, turn);
   });
 
@@ -231,7 +220,11 @@ function conversationTitle(
 ): string {
   if (conversation) return conversationDisplayTitle(conversation);
   const firstTurn = detail.turns[0];
-  return firstTurn?.conversationTitle ?? firstTurn?.title ?? "Conversation";
+  return (
+    firstTurn?.conversationTitle ??
+    readableConversationTitle(firstTurn?.title, firstTurn?.id) ??
+    "Conversation"
+  );
 }
 
 function conversationRequester(
@@ -251,13 +244,6 @@ function conversationLocation(
 ): string {
   if (conversation) return slackLocationLabel(conversation) ?? "";
   return turn ? (slackLocationLabel(turn) ?? "") : "";
-}
-
-function turnHeading(turn: ConversationTurn, index: number): string {
-  const title = turn.title.trim();
-  const label = `Turn ${index + 1}`;
-  if (!title || title === turn.id || title === `Turn ${turn.id}`) return label;
-  return `${label}: ${headingText(title)}`;
 }
 
 function messageRoleLabel(
@@ -335,6 +321,20 @@ function addMetaLine(
 
 function headingText(value: string): string {
   return value.replace(/\s+/g, " ").trim() || "Untitled";
+}
+
+function readableConversationTitle(
+  title: string | undefined,
+  id: string | undefined,
+): string | undefined {
+  const normalized = title ? headingText(title) : "";
+  if (!normalized || normalized === id || normalized === `Turn ${id}`) {
+    return undefined;
+  }
+  if (/^Turn\s+\S+$/i.test(normalized)) {
+    return undefined;
+  }
+  return normalized;
 }
 
 function inlineCode(value: string): string {

--- a/packages/junior-dashboard/src/client/pages/CommandCenter.tsx
+++ b/packages/junior-dashboard/src/client/pages/CommandCenter.tsx
@@ -3,7 +3,7 @@ import { ConversationStack } from "../components/ConversationStack";
 import { Section } from "../components/Section";
 import { SectionHeader } from "../components/SectionHeader";
 import { SectionTitle } from "../components/SectionTitle";
-import { TurnDurationChart } from "../components/TurnDurationChart";
+import { ConversationDurationChart } from "../components/ConversationDurationChart";
 import { buildConversations } from "../format";
 import type { DashboardData } from "../types";
 
@@ -20,7 +20,7 @@ export function CommandCenter(props: {
       <CommandRail data={props.data} error={props.queryError} />
 
       <section className="min-w-0">
-        <TurnDurationChart
+        <ConversationDurationChart
           sessions={sessions}
           timeZone={props.data?.config.timeZone ?? "America/Los_Angeles"}
         />

--- a/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
@@ -187,7 +187,6 @@ function ConversationStats(props: {
     includeId: false,
   });
   const durationLabel = formatConversationDuration(props.conversation);
-  const turnCount = props.conversation.turns.length;
   const rawStats: Array<MetricListItem | undefined> = [
     location
       ? {
@@ -195,10 +194,6 @@ function ConversationStats(props: {
           key: "location",
         }
       : undefined,
-    {
-      content: `${turnCount} ${turnCount === 1 ? "turn" : "turns"}`,
-      key: "turns",
-    },
     {
       content: (
         <MessagesMetric loading={!props.detail} summary={messageSummary} />

--- a/packages/junior-dashboard/src/client/pages/ConversationsPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/ConversationsPage.tsx
@@ -23,7 +23,7 @@ export function ConversationsPage(props: { data?: DashboardData }) {
   const search = params.toString();
   const feedMeta =
     props.data?.sessions.source === "turn_session_records"
-      ? `${conversations.length} conversations / ${sessions.length} turns / ${formatTime(props.data.sessions.generatedAt)}`
+      ? `${conversations.length} conversations / ${formatTime(props.data.sessions.generatedAt)}`
       : "waiting for run history feed";
 
   function updateFilter(nextFilter: SessionFilter) {

--- a/packages/junior-dashboard/tests/conversation-duration-chart.test.tsx
+++ b/packages/junior-dashboard/tests/conversation-duration-chart.test.tsx
@@ -5,7 +5,7 @@ import { MemoryRouter } from "react-router";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { client } from "../src/client/api";
-import { TurnDurationChart } from "../src/client/components/TurnDurationChart";
+import { ConversationDurationChart } from "../src/client/components/ConversationDurationChart";
 import type { Session } from "../src/client/types";
 
 const chartState = vi.hoisted(() => ({
@@ -39,13 +39,13 @@ function renderChart(sessions: Session[]): void {
   renderToStaticMarkup(
     <QueryClientProvider client={client}>
       <MemoryRouter>
-        <TurnDurationChart sessions={sessions} timeZone="UTC" />
+        <ConversationDurationChart sessions={sessions} timeZone="UTC" />
       </MemoryRouter>
     </QueryClientProvider>,
   );
 }
 
-describe("turn duration chart", () => {
+describe("conversation duration chart", () => {
   it("plots conversation duration as summed turn runtime", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-02T12:00:00.000Z"));

--- a/packages/junior-dashboard/tests/markdownExport.test.ts
+++ b/packages/junior-dashboard/tests/markdownExport.test.ts
@@ -87,6 +87,10 @@ describe("dashboard markdown export", () => {
     expect(markdown).toContain("- Conversation ID: `slack:C1:222`");
     expect(markdown).toContain("- Requester: Alice");
     expect(markdown).toContain("- Location: #eng (C1)");
+    expect(markdown).toContain("## Transcript");
+    expect(markdown).not.toContain("## Turn");
+    expect(markdown).not.toContain("- Turns:");
+    expect(markdown).not.toContain("- Turn ID:");
     expect(markdown).toContain("### Alice");
     expect(markdown).toContain("  copy this conversation  \n");
     expect(markdown).toContain("### Thinking");
@@ -179,6 +183,8 @@ describe("dashboard markdown export", () => {
     const markdown = buildConversationMarkdown(detail);
 
     expect(markdown).toContain("# Direct Message");
+    expect(markdown).not.toContain("## Turn");
+    expect(markdown).not.toContain("- Turn ID:");
     expect(markdown).toContain(
       "Transcript hidden because this conversation is not public.",
     );

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -10,8 +10,8 @@ import { FilterTabs } from "../src/client/components/FilterTabs";
 import { StatusBadge } from "../src/client/components/StatusBadge";
 import { TranscriptHeader } from "../src/client/components/TranscriptHeader";
 import { TranscriptToolView } from "../src/client/components/TranscriptToolView";
-import { TurnTranscript } from "../src/client/components/TranscriptTurn";
-import { TurnDurationChart } from "../src/client/components/TurnDurationChart";
+import { ConversationTranscriptSegment } from "../src/client/components/TranscriptTurn";
+import { ConversationDurationChart } from "../src/client/components/ConversationDurationChart";
 import { client } from "../src/client/api";
 import { CommandCenter } from "../src/client/pages/CommandCenter";
 import { ConversationPage } from "../src/client/pages/ConversationPage";
@@ -152,7 +152,7 @@ describe("dashboard telemetry components", () => {
     );
   });
 
-  it("keeps the per-turn Sentry trace link in transcript headers", () => {
+  it("keeps the Sentry trace link in transcript headers", () => {
     const turn = {
       conversationId: "conversation-1",
       cumulativeDurationMs: 0,
@@ -169,7 +169,7 @@ describe("dashboard telemetry components", () => {
     } as ConversationTurn;
 
     const html = renderToStaticMarkup(
-      <TurnTranscript number={1} turn={turn} view="rich" />,
+      <ConversationTranscriptSegment turn={turn} view="rich" />,
     );
 
     expect(html).toContain("View in Sentry");
@@ -198,7 +198,7 @@ describe("dashboard telemetry components", () => {
 
     const html = renderToStaticMarkup(
       <QueryClientProvider client={client}>
-        <TurnTranscript number={1} turn={turn} view="rich" />
+        <ConversationTranscriptSegment turn={turn} view="rich" />
       </QueryClientProvider>,
     );
 
@@ -231,7 +231,7 @@ describe("dashboard telemetry components", () => {
 
     const html = renderToStaticMarkup(
       <QueryClientProvider client={client}>
-        <TurnTranscript number={1} turn={turn} view="rich" />
+        <ConversationTranscriptSegment turn={turn} view="rich" />
       </QueryClientProvider>,
     );
 
@@ -242,7 +242,7 @@ describe("dashboard telemetry components", () => {
     expect(html).not.toContain("items-baseline gap-2 text-[0.88rem]");
   });
 
-  it("uses chart mode links as the duration chart title", () => {
+  it("renders the conversation duration chart title", () => {
     const session = {
       conversationId: "conversation-1",
       cumulativeDurationMs: 3_000,
@@ -259,16 +259,15 @@ describe("dashboard telemetry components", () => {
     const html = renderToStaticMarkup(
       <QueryClientProvider client={client}>
         <MemoryRouter>
-          <TurnDurationChart sessions={[session]} timeZone="UTC" />
+          <ConversationDurationChart sessions={[session]} timeZone="UTC" />
         </MemoryRouter>
       </QueryClientProvider>,
     );
 
     expect(html).not.toContain("Durations");
-    expect(html).toContain("Turns");
     expect(html).toContain("Conversations");
-    expect(html.indexOf("Conversations")).toBeLessThan(html.indexOf("Turns"));
-    expect(html).toMatch(/aria-pressed="true"[^>]*>Conversations/);
+    expect(html).not.toContain("Turns");
+    expect(html).not.toContain('aria-label="Duration chart mode"');
     expect(html).toContain(
       'aria-label="conversations by duration over the last 7 days"',
     );
@@ -309,9 +308,8 @@ describe("dashboard telemetry components", () => {
 
     const html = renderConversationPage(dashboardData([session]));
 
-    expect(html).toContain("1 turn");
+    expect(html).not.toContain("turn");
     expect(html).not.toContain("tool call");
-    expect(html.match(/·/g) ?? []).toHaveLength(2);
   });
 
   it("caps dashboard route pages at a readable width", () => {
@@ -378,7 +376,7 @@ describe("dashboard telemetry components", () => {
     const html = renderConversationPage(dashboardData([session]));
     const controls = html.slice(
       html.indexOf('aria-label="Transcript view"'),
-      html.indexOf("Turn 1"),
+      html.indexOf("hello"),
     );
     const pageHeader = html.slice(
       0,
@@ -495,7 +493,7 @@ describe("dashboard telemetry components", () => {
 
     const html = renderToStaticMarkup(
       <QueryClientProvider client={client}>
-        <TurnTranscript number={1} turn={turn} view="raw" />
+        <ConversationTranscriptSegment turn={turn} view="raw" />
       </QueryClientProvider>,
     );
 
@@ -507,7 +505,7 @@ describe("dashboard telemetry components", () => {
   it("collapses four consecutive tool calls to a reveal divider", () => {
     const html = renderToStaticMarkup(
       <QueryClientProvider client={client}>
-        <TurnTranscript number={1} turn={toolRunTurn(4)} view="rich" />
+        <ConversationTranscriptSegment turn={toolRunTurn(4)} view="rich" />
       </QueryClientProvider>,
     );
 
@@ -525,7 +523,7 @@ describe("dashboard telemetry components", () => {
   it("keeps three consecutive tool calls expanded", () => {
     const html = renderToStaticMarkup(
       <QueryClientProvider client={client}>
-        <TurnTranscript number={1} turn={toolRunTurn(3)} view="rich" />
+        <ConversationTranscriptSegment turn={toolRunTurn(3)} view="rich" />
       </QueryClientProvider>,
     );
 
@@ -562,7 +560,7 @@ describe("dashboard telemetry components", () => {
 
     const html = renderToStaticMarkup(
       <QueryClientProvider client={client}>
-        <TurnTranscript number={1} turn={turn} view="rich" />
+        <ConversationTranscriptSegment turn={turn} view="rich" />
       </QueryClientProvider>,
     );
 
@@ -598,7 +596,7 @@ describe("dashboard telemetry components", () => {
 
     const html = renderToStaticMarkup(
       <QueryClientProvider client={client}>
-        <TurnTranscript number={1} turn={turn} view="rich" />
+        <ConversationTranscriptSegment turn={turn} view="rich" />
       </QueryClientProvider>,
     );
 


### PR DESCRIPTION
Dashboard conversation views now avoid turn terminology in user-facing surfaces. Conversation lists, detail transcripts, Markdown export, and the duration chart use conversation-level copy while retaining the internal reporting data shape.

**Transcript Presentation**

Conversation detail pages remove the numbered transcript heading, leaving the status rail, metrics, and message transcript. Markdown copy export now emits a single conversation transcript section instead of per-turn sections.

**Conversation Metrics**

Conversation rows, headers, and the duration chart drop turn-count and toggle wording while keeping tokens, runtime, messages, and tools as the visible summary.
