### PR TITLE
feat(credentials): Add read-only GitHub credentials for system runs

### DIFF
--- a/packages/junior/src/chat/agent-dispatch/context.ts
+++ b/packages/junior/src/chat/agent-dispatch/context.ts
@@ -8,7 +8,10 @@ import {
 } from "./store";
 import { scheduleDispatchCallback } from "./signing";
 import type { DispatchRecord } from "./types";
-import { validateDispatchOptions } from "./validation";
+import {
+  validateDispatchOptions,
+  verifyDispatchCredentialSubjectAccess,
+} from "./validation";
 
 const MAX_DISPATCHES_PER_HEARTBEAT = 25;
 
@@ -46,6 +49,7 @@ export function createHeartbeatContext(args: {
         if (dispatchCount >= MAX_DISPATCHES_PER_HEARTBEAT) {
           throw new Error("Plugin heartbeat exceeded the dispatch limit");
         }
+        await verifyDispatchCredentialSubjectAccess(options);
         const result = await createOrGetDispatch({
           plugin: args.plugin,
           options,

--- a/packages/junior/src/chat/agent-dispatch/runner.ts
+++ b/packages/junior/src/chat/agent-dispatch/runner.ts
@@ -277,9 +277,12 @@ export async function runAgentDispatchSlice(
 
     let reply = await generateAssistantReply(dispatch.input, {
       authorizationFlowMode: "disabled",
-      ...(dispatch.credentialSubject
-        ? { credentialSubject: dispatch.credentialSubject }
-        : {}),
+      credentialContext: {
+        actor: dispatch.actor,
+        ...(dispatch.credentialSubject
+          ? { subject: dispatch.credentialSubject }
+          : {}),
+      },
       configuration,
       channelConfiguration,
       conversationContext,
@@ -292,8 +295,6 @@ export async function runAgentDispatchSlice(
         runId: dispatch.id,
         channelId: dispatch.destination.channelId,
         teamId: dispatch.destination.teamId,
-        actorType: dispatch.actor.type,
-        actorId: dispatch.actor.id,
       },
       toolChannelId: dispatch.destination.channelId,
       sandbox: {

--- a/packages/junior/src/chat/agent-dispatch/types.ts
+++ b/packages/junior/src/chat/agent-dispatch/types.ts
@@ -1,3 +1,8 @@
+import type {
+  CredentialSubject,
+  CredentialSystemActor,
+} from "@/chat/credentials/context";
+
 export type DispatchStatus =
   | "pending"
   | "running"
@@ -6,25 +11,14 @@ export type DispatchStatus =
   | "failed"
   | "blocked";
 
-export interface DispatchActor {
-  type: "system";
-  id: string;
-}
-
 export interface DispatchDestination {
   platform: "slack";
   teamId: string;
   channelId: string;
 }
 
-export interface DispatchCredentialSubject {
-  type: "user";
-  userId: string;
-  allowedWhen: "private-direct-conversation";
-}
-
 export interface DispatchOptions {
-  credentialSubject?: DispatchCredentialSubject;
+  credentialSubject?: CredentialSubject;
   destination: DispatchDestination;
   idempotencyKey: string;
   input: string;
@@ -32,10 +26,10 @@ export interface DispatchOptions {
 }
 
 export interface DispatchRecord {
-  actor: DispatchActor;
+  actor: CredentialSystemActor;
   attempt: number;
   createdAtMs: number;
-  credentialSubject?: DispatchCredentialSubject;
+  credentialSubject?: CredentialSubject;
   destination: DispatchDestination;
   errorMessage?: string;
   id: string;

--- a/packages/junior/src/chat/agent-dispatch/validation.ts
+++ b/packages/junior/src/chat/agent-dispatch/validation.ts
@@ -1,4 +1,5 @@
 import type { DispatchOptions } from "./types";
+import { isSlackDirectConversationForUser } from "@/chat/slack/channel";
 import { isDmChannel } from "@/chat/slack/client";
 import { isSlackConversationId, isSlackTeamId } from "@/chat/slack/ids";
 
@@ -68,5 +69,24 @@ export function validateDispatchOptions(options: DispatchOptions): void {
     if (value.length > MAX_METADATA_VALUE_LENGTH) {
       throw new Error("Dispatch metadata value exceeds the maximum length");
     }
+  }
+}
+
+/** Verify runtime-owned access requirements for delegated dispatch credentials. */
+export async function verifyDispatchCredentialSubjectAccess(
+  options: DispatchOptions,
+): Promise<void> {
+  if (!options.credentialSubject) {
+    return;
+  }
+
+  const verified = await isSlackDirectConversationForUser({
+    channelId: options.destination.channelId,
+    userId: options.credentialSubject.userId,
+  });
+  if (!verified) {
+    throw new Error(
+      "Dispatch credentialSubject must match the private direct Slack destination",
+    );
   }
 }

--- a/packages/junior/src/chat/capabilities/factory.ts
+++ b/packages/junior/src/chat/capabilities/factory.ts
@@ -5,6 +5,7 @@ import type {
   CredentialBroker,
   CredentialLease,
 } from "@/chat/credentials/broker";
+import type { CredentialContext } from "@/chat/credentials/context";
 import { StateAdapterTokenStore } from "@/chat/credentials/state-adapter-token-store";
 import type { UserTokenStore } from "@/chat/credentials/user-token-store";
 import {
@@ -55,8 +56,8 @@ function getSandboxEgressRouter(): ProviderCredentialRouter {
 
 /** Issue one provider credential lease for host-side sandbox egress proxying. */
 export async function issueProviderCredentialLease(input: {
+  context: CredentialContext;
   provider: string;
-  requesterId: string;
   reason: string;
 }): Promise<CredentialLease> {
   return await getSandboxEgressRouter().issue(input);

--- a/packages/junior/src/chat/capabilities/router.ts
+++ b/packages/junior/src/chat/capabilities/router.ts
@@ -2,12 +2,13 @@ import type {
   CredentialBroker,
   CredentialLease,
 } from "@/chat/credentials/broker";
+import type { CredentialContext } from "@/chat/credentials/context";
 
 export interface CredentialRouter {
   issue(input: {
+    context: CredentialContext;
     provider: string;
     reason: string;
-    requesterId?: string;
   }): Promise<CredentialLease>;
 }
 
@@ -19,9 +20,9 @@ export class ProviderCredentialRouter implements CredentialRouter {
   }
 
   async issue(input: {
+    context: CredentialContext;
     provider: string;
     reason: string;
-    requesterId?: string;
   }): Promise<CredentialLease> {
     const broker = this.brokersByProvider[input.provider];
     if (!broker) {
@@ -31,8 +32,8 @@ export class ProviderCredentialRouter implements CredentialRouter {
     }
 
     return await broker.issue({
+      context: input.context,
       reason: input.reason,
-      requesterId: input.requesterId,
     });
   }
 }

--- a/packages/junior/src/chat/credentials/broker.ts
+++ b/packages/junior/src/chat/credentials/broker.ts
@@ -1,3 +1,5 @@
+import type { CredentialContext } from "@/chat/credentials/context";
+
 export class CredentialUnavailableError extends Error {
   readonly provider: string;
 
@@ -24,7 +26,7 @@ export interface CredentialLease {
 
 export interface CredentialBroker {
   issue(input: {
+    context: CredentialContext;
     reason: string;
-    requesterId?: string;
   }): Promise<CredentialLease>;
 }

--- a/packages/junior/src/chat/credentials/context.ts
+++ b/packages/junior/src/chat/credentials/context.ts
@@ -1,0 +1,106 @@
+export type CredentialSystemActor = {
+  type: "system";
+  id: string;
+};
+
+export type CredentialSubject = {
+  type: "user";
+  userId: string;
+  allowedWhen: "private-direct-conversation";
+};
+
+export type CredentialContext =
+  | {
+      actor: {
+        type: "user";
+        userId: string;
+      };
+      subject?: never;
+    }
+  | {
+      actor: CredentialSystemActor;
+      subject?: CredentialSubject;
+    };
+
+/** Return the user whose OAuth token may satisfy this credential request. */
+export function credentialUserSubjectId(
+  context: CredentialContext,
+): string | undefined {
+  if (context.actor.type === "user") {
+    return context.actor.userId;
+  }
+  return context.subject?.userId;
+}
+
+/** Parse an untrusted credential context payload from sandbox egress state. */
+export function parseCredentialContext(
+  value: unknown,
+): CredentialContext | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const record = value as Partial<CredentialContext>;
+  const actor = parseActor(record.actor);
+  if (!actor) {
+    return undefined;
+  }
+  if (actor.type === "user") {
+    if ("subject" in record && record.subject !== undefined) {
+      return undefined;
+    }
+    return { actor };
+  }
+  if (!("subject" in record) || record.subject === undefined) {
+    return { actor };
+  }
+  const subject = parseSubject(record.subject);
+  if (!subject) {
+    return undefined;
+  }
+  return {
+    actor,
+    subject,
+  };
+}
+
+function parseActor(value: unknown): CredentialContext["actor"] | undefined {
+  if (value && typeof value === "object") {
+    const record = value as Partial<CredentialContext["actor"]>;
+    if (
+      record.type === "user" &&
+      typeof record.userId === "string" &&
+      record.userId
+    ) {
+      return { type: "user", userId: record.userId };
+    }
+    if (
+      record.type === "system" &&
+      typeof record.id === "string" &&
+      record.id
+    ) {
+      return { type: "system", id: record.id };
+    }
+  }
+  return undefined;
+}
+
+function parseSubject(
+  value: unknown,
+): NonNullable<CredentialContext["subject"]> | undefined {
+  if (value && typeof value === "object") {
+    const record = value as Partial<NonNullable<CredentialContext["subject"]>>;
+    if (
+      record.type === "user" &&
+      typeof record.userId === "string" &&
+      record.userId &&
+      record.allowedWhen === "private-direct-conversation"
+    ) {
+      return {
+        type: "user",
+        userId: record.userId,
+        allowedWhen: "private-direct-conversation",
+      };
+    }
+  }
+  return undefined;
+}

--- a/packages/junior/src/chat/plugins/auth/github-app-broker.ts
+++ b/packages/junior/src/chat/plugins/auth/github-app-broker.ts
@@ -5,6 +5,12 @@ import type {
 } from "@/chat/credentials/broker";
 import { mergeHeaderTransforms } from "@/chat/credentials/header-transforms";
 import { resolvePluginCommandEnv } from "@/chat/plugins/command-env";
+import {
+  DEFAULT_GITHUB_SYSTEM_READ_SCOPES,
+  githubCapabilitiesToPermissions,
+  githubInstallationReadPermissions,
+  githubSystemReadPermissionsFromScopes,
+} from "@/chat/plugins/github-permissions";
 import { resolveApiHeaderTransforms } from "./api-headers-broker";
 import { resolveAuthTokenPlaceholder } from "./auth-token-placeholder";
 import type { GitHubAppCredentials, PluginManifest } from "../types";
@@ -161,69 +167,6 @@ function resolveGitHubApiDomain(credentials: GitHubAppCredentials): string {
   return apiDomain;
 }
 
-/**
- * GitHub App permission scopes that plugin manifests may request.
- * Manifest capabilities follow `<plugin>.<scope>.<read|write>` where the
- * scope name uses dashes in capabilities and underscores in the GitHub API.
- */
-const KNOWN_SCOPES = new Set([
-  "actions",
-  "administration",
-  "checks",
-  "codespaces",
-  "contents",
-  "deployments",
-  "environments",
-  "issues",
-  "metadata",
-  "packages",
-  "pages",
-  "pull_requests",
-  "repository_hooks",
-  "repository_projects",
-  "secret_scanning_alerts",
-  "secrets",
-  "security_events",
-  "statuses",
-  "vulnerability_alerts",
-  "workflows",
-]);
-
-function capabilitiesToPermissions(
-  capabilities: string[],
-  pluginName: string,
-): Record<string, "read" | "write"> {
-  const permissions: Record<string, "read" | "write"> = {};
-  const prefix = `${pluginName}.`;
-  for (const capability of capabilities) {
-    if (!capability.startsWith(prefix)) {
-      throw new Error(`Unsupported GitHub capability: ${capability}`);
-    }
-    const suffix = capability.slice(prefix.length);
-
-    const lastDot = suffix.lastIndexOf(".");
-    if (lastDot === -1) {
-      throw new Error(`Unsupported GitHub capability: ${capability}`);
-    }
-    const scopeRaw = suffix.slice(0, lastDot);
-    const level = suffix.slice(lastDot + 1);
-    if (level !== "read" && level !== "write") {
-      throw new Error(`Unsupported GitHub capability: ${capability}`);
-    }
-
-    const scope = scopeRaw.replace(/-/g, "_");
-    if (!KNOWN_SCOPES.has(scope)) {
-      throw new Error(`Unsupported GitHub capability: ${capability}`);
-    }
-
-    const existing = permissions[scope];
-    permissions[scope] =
-      existing === "write" || level === "write" ? "write" : "read";
-  }
-
-  return permissions;
-}
-
 /** Create a broker that keeps GitHub App tokens on the host while authorizing provider traffic. */
 export function createGitHubAppBroker(
   manifest: PluginManifest,
@@ -269,8 +212,34 @@ export function createGitHubAppBroker(
   }
 
   const permissions = manifest.capabilities?.length
-    ? capabilitiesToPermissions(manifest.capabilities, provider)
+    ? githubCapabilitiesToPermissions(manifest.capabilities, provider)
     : undefined;
+  const systemReadPermissions = credentials.systemReadPermissions?.length
+    ? githubSystemReadPermissionsFromScopes(credentials.systemReadPermissions)
+    : undefined;
+
+  async function resolveTokenPermissions(params: {
+    appJwt: string;
+    installationId: number;
+    systemActor: boolean;
+  }) {
+    if (!params.systemActor) {
+      return permissions;
+    }
+    if (systemReadPermissions) {
+      return systemReadPermissions;
+    }
+
+    const installation = await githubRequest<{
+      permissions?: Record<string, string>;
+    }>(apiBase, `/app/installations/${params.installationId}`, {
+      token: params.appJwt,
+    });
+    return githubInstallationReadPermissions(
+      installation.permissions,
+      DEFAULT_GITHUB_SYSTEM_READ_SCOPES,
+    );
+  }
 
   function createLease(params: {
     installationId: number;
@@ -316,14 +285,18 @@ export function createGitHubAppBroker(
   }
 
   return {
-    async issue(input: { reason: string }): Promise<CredentialLease> {
+    async issue(input): Promise<CredentialLease> {
       const installationId = resolveInstallationId();
-      const tokenRequestBody: Record<string, unknown> = permissions
-        ? { permissions }
-        : {};
-
       const appId = resolveAppId(appIdEnv);
       const appJwt = createAppJwt(appId, privateKeyEnv);
+      const tokenPermissions = await resolveTokenPermissions({
+        appJwt,
+        installationId,
+        systemActor: input.context.actor.type === "system",
+      });
+      const tokenRequestBody: Record<string, unknown> = tokenPermissions
+        ? { permissions: tokenPermissions }
+        : {};
 
       const accessTokenResponse = await githubRequest<{
         token: string;

--- a/packages/junior/src/chat/plugins/auth/oauth-bearer-broker.ts
+++ b/packages/junior/src/chat/plugins/auth/oauth-bearer-broker.ts
@@ -4,6 +4,7 @@ import type {
   CredentialLease,
 } from "@/chat/credentials/broker";
 import { CredentialUnavailableError } from "@/chat/credentials/broker";
+import { credentialUserSubjectId } from "@/chat/credentials/context";
 import { mergeHeaderTransforms } from "@/chat/credentials/header-transforms";
 import { hasRequiredOAuthScope } from "@/chat/credentials/oauth-scope";
 import type { UserTokenStore } from "@/chat/credentials/user-token-store";
@@ -105,6 +106,7 @@ export function createOAuthBearerBroker(
     async issue(input) {
       const envToken = process.env[authTokenEnv]?.trim();
       const oauth = manifest.oauth;
+      const userSubjectId = credentialUserSubjectId(input.context);
       if (!oauth) {
         if (envToken) {
           return buildLease(envToken, Date.now() + MAX_LEASE_MS, input.reason);
@@ -116,11 +118,8 @@ export function createOAuthBearerBroker(
         );
       }
 
-      if (input.requesterId) {
-        const stored = await deps.userTokenStore.get(
-          input.requesterId,
-          provider,
-        );
+      if (userSubjectId) {
+        const stored = await deps.userTokenStore.get(userSubjectId, provider);
         if (stored) {
           if (!hasRequiredOAuthScope(stored.scope, oauth.scope)) {
             throw new CredentialUnavailableError(
@@ -146,11 +145,7 @@ export function createOAuthBearerBroker(
                   `Your ${provider} connection needs to be reauthorized.`,
                 );
               }
-              await deps.userTokenStore.set(
-                input.requesterId,
-                provider,
-                refreshed,
-              );
+              await deps.userTokenStore.set(userSubjectId, provider, refreshed);
               return buildLease(
                 refreshed.accessToken,
                 getLeaseExpiry(refreshed.expiresAt),

--- a/packages/junior/src/chat/plugins/github-permissions.ts
+++ b/packages/junior/src/chat/plugins/github-permissions.ts
@@ -1,0 +1,126 @@
+type GitHubPermissionRequest = Record<string, "read" | "write">;
+
+const KNOWN_GITHUB_PERMISSION_SCOPES = new Set([
+  "actions",
+  "administration",
+  "checks",
+  "codespaces",
+  "contents",
+  "deployments",
+  "environments",
+  "issues",
+  "metadata",
+  "packages",
+  "pages",
+  "pull_requests",
+  "repository_hooks",
+  "repository_projects",
+  "secret_scanning_alerts",
+  "secrets",
+  "security_events",
+  "statuses",
+  "vulnerability_alerts",
+  "workflows",
+]);
+
+export const DEFAULT_GITHUB_SYSTEM_READ_SCOPES = new Set([
+  "actions",
+  "checks",
+  "contents",
+  "issues",
+  "metadata",
+  "pull_requests",
+  "statuses",
+]);
+
+function normalizeGitHubPermissionScope(rawScope: string): string {
+  return rawScope.trim().replace(/-/g, "_");
+}
+
+/** Validate and normalize GitHub App read scopes from plugin configuration. */
+export function normalizeGitHubSystemReadPermissionScopes(
+  scopes: string[],
+  context: string,
+): string[] {
+  return scopes.map((rawScope) => {
+    const scope = normalizeGitHubPermissionScope(rawScope);
+    if (!KNOWN_GITHUB_PERMISSION_SCOPES.has(scope)) {
+      throw new Error(`${context} contains unsupported scope "${rawScope}"`);
+    }
+    return scope;
+  });
+}
+
+/** Convert plugin capabilities into the GitHub App installation permission body. */
+export function githubCapabilitiesToPermissions(
+  capabilities: string[],
+  pluginName: string,
+): GitHubPermissionRequest {
+  const permissions: GitHubPermissionRequest = {};
+  const prefix = `${pluginName}.`;
+  for (const capability of capabilities) {
+    if (!capability.startsWith(prefix)) {
+      throw new Error(`Unsupported GitHub capability: ${capability}`);
+    }
+    const suffix = capability.slice(prefix.length);
+
+    const lastDot = suffix.lastIndexOf(".");
+    if (lastDot === -1) {
+      throw new Error(`Unsupported GitHub capability: ${capability}`);
+    }
+    const scopeRaw = suffix.slice(0, lastDot);
+    const level = suffix.slice(lastDot + 1);
+    if (level !== "read" && level !== "write") {
+      throw new Error(`Unsupported GitHub capability: ${capability}`);
+    }
+
+    const scope = normalizeGitHubPermissionScope(scopeRaw);
+    if (!KNOWN_GITHUB_PERMISSION_SCOPES.has(scope)) {
+      throw new Error(`Unsupported GitHub capability: ${capability}`);
+    }
+
+    const existing = permissions[scope];
+    permissions[scope] =
+      existing === "write" || level === "write" ? "write" : "read";
+  }
+
+  return permissions;
+}
+
+/** Convert configured system scopes into read-only GitHub App permissions. */
+export function githubSystemReadPermissionsFromScopes(
+  scopes: string[],
+): GitHubPermissionRequest {
+  const readOnly: GitHubPermissionRequest = {
+    metadata: "read",
+  };
+  for (const scope of normalizeGitHubSystemReadPermissionScopes(
+    scopes,
+    "GitHub system read permissions",
+  )) {
+    readOnly[scope] = "read";
+  }
+  return readOnly;
+}
+
+/** Intersect installation permissions with the allowed system read scope set. */
+export function githubInstallationReadPermissions(
+  permissions: Record<string, string> | undefined,
+  allowedScopes: Set<string>,
+): GitHubPermissionRequest {
+  const readOnly: GitHubPermissionRequest = {
+    metadata: "read",
+  };
+  for (const [scope, level] of Object.entries(permissions ?? {})) {
+    if (
+      !allowedScopes.has(scope) ||
+      !KNOWN_GITHUB_PERMISSION_SCOPES.has(scope)
+    ) {
+      continue;
+    }
+    if (level === "read" || level === "write" || level === "admin") {
+      readOnly[scope] = "read";
+    }
+  }
+  return readOnly;
+}

--- a/packages/junior/src/chat/plugins/inline-manifest-source.ts
+++ b/packages/junior/src/chat/plugins/inline-manifest-source.ts
@@ -55,6 +55,11 @@ function inlineCredentialsSource(
     setDefined(result, "app-id-env", credentials.appIdEnv);
     setDefined(result, "private-key-env", credentials.privateKeyEnv);
     setDefined(result, "installation-id-env", credentials.installationIdEnv);
+    setDefined(
+      result,
+      "system-read-permissions",
+      credentials.systemReadPermissions,
+    );
   }
   return result;
 }

--- a/packages/junior/src/chat/plugins/manifest.ts
+++ b/packages/junior/src/chat/plugins/manifest.ts
@@ -17,6 +17,7 @@ import type {
   PluginSystemRuntimeDependencyFromUrl,
 } from "./types";
 import { inlineManifestSource } from "./inline-manifest-source";
+import { normalizeGitHubSystemReadPermissionScopes } from "./github-permissions";
 
 const PLUGIN_NAME_RE = /^[a-z][a-z0-9-]*$/;
 const SHORT_CAPABILITY_RE = /^[a-z0-9-]+(\.[a-z0-9-]+)*$/;
@@ -186,6 +187,9 @@ const githubAppCredentialsSchema = baseCredentialsSchema.extend({
   "app-id-env": envVarString,
   "private-key-env": envVarString,
   "installation-id-env": envVarString,
+  "system-read-permissions": nonEmptyStringArraySchema(
+    "system-read-permissions",
+  ).optional(),
 });
 
 const runtimeDependencyEntrySchema = z
@@ -363,6 +367,11 @@ function manifestConfigPatch(
         credentials,
         "installation-id-env",
         config.credentials.installationIdEnv,
+      );
+      setDefined(
+        credentials,
+        "system-read-permissions",
+        config.credentials.systemReadPermissions,
       );
       result.credentials = credentials;
     }
@@ -647,9 +656,7 @@ function assertCommandEnvHostRefsAreExplicitlyExposed(
 
   for (const [key, value] of Object.entries(commandEnv)) {
     for (const name of envReferences(value)) {
-      const declaration = envVars[name] as
-        | PluginEnvVarDeclaration
-        | undefined;
+      const declaration = envVars[name] as PluginEnvVarDeclaration | undefined;
       if (
         declaration &&
         declaration.default === undefined &&
@@ -717,6 +724,12 @@ function normalizeCredentials(
         { forbiddenKeys: FORBIDDEN_API_HEADER_NAMES },
       )
     : undefined;
+  const systemReadPermissions = result.data["system-read-permissions"]
+    ? normalizeGitHubSystemReadPermissionScopes(
+        result.data["system-read-permissions"],
+        `Plugin ${name} credentials.system-read-permissions`,
+      )
+    : undefined;
 
   return {
     type: "github-app",
@@ -729,6 +742,7 @@ function normalizeCredentials(
     appIdEnv: result.data["app-id-env"],
     privateKeyEnv: result.data["private-key-env"],
     installationIdEnv: result.data["installation-id-env"],
+    ...(systemReadPermissions ? { systemReadPermissions } : {}),
   } satisfies GitHubAppCredentials;
 }
 

--- a/packages/junior/src/chat/plugins/types.ts
+++ b/packages/junior/src/chat/plugins/types.ts
@@ -32,6 +32,7 @@ export interface GitHubAppCredentials {
   appIdEnv: string;
   privateKeyEnv: string;
   installationIdEnv: string;
+  systemReadPermissions?: string[];
 }
 
 export type PluginCredentials = OAuthBearerCredentials | GitHubAppCredentials;
@@ -141,6 +142,7 @@ export interface PluginManifestConfig {
     appIdEnv?: string;
     privateKeyEnv?: string;
     installationIdEnv?: string;
+    systemReadPermissions?: string[];
   } | null;
   runtimeDependencies?: PluginRuntimeDependencyConfig[] | null;
   runtimePostinstall?: PluginRuntimePostinstallCommand[] | null;

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -120,6 +120,7 @@ import {
   persistTimeoutSessionRecord,
 } from "@/chat/services/turn-session-record";
 import type { AgentTurnRequester } from "@/chat/state/turn-session";
+import type { CredentialContext } from "@/chat/credentials/context";
 import { createMcpAuthOrchestration } from "@/chat/services/mcp-auth-orchestration";
 import { createPluginAuthOrchestration } from "@/chat/services/plugin-auth-orchestration";
 import {
@@ -179,11 +180,7 @@ function waitForAbortSettlement(
 
 export interface ReplyRequestContext {
   skillDirs?: string[];
-  credentialSubject?: {
-    type: "user";
-    userId: string;
-    allowedWhen: "private-direct-conversation";
-  };
+  credentialContext?: CredentialContext;
   requester?: {
     userId?: string;
     userName?: string;
@@ -201,8 +198,6 @@ export interface ReplyRequestContext {
     messageTs?: string;
     threadTs?: string;
     requesterId?: string;
-    actorType?: string;
-    actorId?: string;
   };
   toolChannelId?: string;
   conversationContext?: string;
@@ -432,6 +427,16 @@ export async function generateAssistantReply(
     context.requester,
     context.correlation?.requesterId,
   );
+  const credentialActor = context.credentialContext?.actor;
+  const credentialActorLogContext = credentialActor
+    ? {
+        actorType: credentialActor.type,
+        actorId:
+          credentialActor.type === "user"
+            ? credentialActor.userId
+            : credentialActor.id,
+      }
+    : {};
   const conversationPrivacy = resolveConversationPrivacy({
     channelId: context.correlation?.channelId,
     conversationId:
@@ -444,8 +449,7 @@ export async function generateAssistantReply(
     requesterId: context.correlation?.requesterId,
     channelId: context.correlation?.channelId,
     runId: context.correlation?.runId,
-    actorType: context.correlation?.actorType,
-    actorId: context.correlation?.actorId,
+    ...credentialActorLogContext,
     assistantUserName: botConfig.userName,
     modelId: botConfig.modelId,
   };
@@ -496,8 +500,7 @@ export async function generateAssistantReply(
       slackUserId: context.correlation?.requesterId,
       slackChannelId: context.correlation?.channelId,
       runId: context.correlation?.runId,
-      actorType: context.correlation?.actorType,
-      actorId: context.correlation?.actorId,
+      ...credentialActorLogContext,
       assistantUserName: botConfig.userName,
       modelId: botConfig.modelId,
     };
@@ -583,10 +586,10 @@ export async function generateAssistantReply(
       ...persistedConfigurationValues,
     };
     // ── Sandbox ──────────────────────────────────────────────────────
-    const credentialRequesterId =
-      context.credentialSubject?.type === "user"
-        ? context.credentialSubject.userId
-        : context.requester?.userId;
+    const authRequesterId =
+      context.credentialContext?.actor.type === "user"
+        ? context.credentialContext.actor.userId
+        : undefined;
     const userTokenStore = createUserTokenStore();
     const agentPluginHooks = createAgentPluginHookRunner({
       requester: context.requester,
@@ -596,11 +599,7 @@ export async function generateAssistantReply(
       sandboxDependencyProfileHash:
         context.sandbox?.sandboxDependencyProfileHash,
       traceContext: spanContext,
-      credentialEgress: credentialRequesterId
-        ? {
-            requesterId: credentialRequesterId,
-          }
-        : undefined,
+      credentialEgress: context.credentialContext,
       agentHooks: agentPluginHooks,
       onSandboxAcquired: async (sandbox) => {
         lastKnownSandboxId = sandbox.sandboxId;
@@ -784,7 +783,7 @@ export async function generateAssistantReply(
       {
         conversationId: sessionConversationId,
         sessionId,
-        requesterId: credentialRequesterId,
+        requesterId: authRequesterId,
         channelId: context.correlation?.channelId,
         threadTs: context.correlation?.threadTs,
         toolChannelId: context.toolChannelId,
@@ -803,7 +802,7 @@ export async function generateAssistantReply(
       {
         conversationId: sessionConversationId,
         sessionId,
-        requesterId: credentialRequesterId,
+        requesterId: authRequesterId,
         channelId: context.correlation?.channelId,
         threadTs: context.correlation?.threadTs,
         userMessage: userInput,
@@ -829,8 +828,7 @@ export async function generateAssistantReply(
       slackUserId: context.correlation?.requesterId,
       slackChannelId: context.correlation?.channelId,
       runId: context.correlation?.runId,
-      actorType: context.correlation?.actorType,
-      actorId: context.correlation?.actorId,
+      ...credentialActorLogContext,
       assistantUserName: botConfig.userName,
       modelId: botConfig.modelId,
     });
@@ -1452,8 +1450,7 @@ export async function generateAssistantReply(
         slackUserId: context.correlation?.requesterId,
         slackChannelId: context.correlation?.channelId,
         runId: context.correlation?.runId,
-        actorType: context.correlation?.actorType,
-        actorId: context.correlation?.actorId,
+        ...credentialActorLogContext,
         assistantUserName: botConfig.userName,
         modelId: botConfig.modelId,
       },

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -654,6 +654,9 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           let reply = await deps.services.generateAssistantReply(
             effectiveUserText,
             {
+              credentialContext: {
+                actor: { type: "user", userId: message.author.userId },
+              },
               requester: {
                 userId: message.author.userId,
                 userName: message.author.userName ?? fallbackIdentity?.userName,

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -307,6 +307,18 @@ export async function resumeSlackTurn(args: ResumeSlackTurnArgs) {
     if (!runArgs.replyContext?.requester?.userId) {
       throw new Error("Resumed turn requires replyContext.requester.userId");
     }
+    const credentialContext = runArgs.replyContext.credentialContext;
+    if (!credentialContext) {
+      throw new Error("Resumed turn requires replyContext.credentialContext");
+    }
+    if (
+      credentialContext.actor.type !== "user" ||
+      credentialContext.actor.userId !== runArgs.replyContext.requester.userId
+    ) {
+      throw new Error(
+        "Resumed turn credential actor must match replyContext.requester.userId",
+      );
+    }
 
     if (runArgs.messageTs) {
       processingReaction = await startSlackProcessingReactionForMessage({

--- a/packages/junior/src/chat/sandbox/egress-policy.ts
+++ b/packages/junior/src/chat/sandbox/egress-policy.ts
@@ -41,22 +41,22 @@ export function resolveSandboxEgressProviderForHost(
   )?.provider;
 }
 
-function sandboxProxyUrl(requesterToken?: string): string {
+function sandboxProxyUrl(credentialToken?: string): string {
   const baseUrl = resolveBaseUrl();
   if (!baseUrl) {
     throw new Error(
       "Cannot determine base URL for sandbox credential egress (set JUNIOR_BASE_URL or deploy to Vercel)",
     );
   }
-  const path = requesterToken
-    ? `${SANDBOX_EGRESS_PROXY_PATH}/${requesterToken}`
+  const path = credentialToken
+    ? `${SANDBOX_EGRESS_PROXY_PATH}/${credentialToken}`
     : SANDBOX_EGRESS_PROXY_PATH;
   return new URL(path, baseUrl).toString();
 }
 
 /** Build the policy that forwards provider requests back to Junior for credentials. */
 export function buildSandboxEgressNetworkPolicy(input?: {
-  requesterToken?: string;
+  credentialToken?: string;
 }): NetworkPolicy {
   const allow: Record<string, NetworkPolicyRule[]> = {
     "*": [],
@@ -66,7 +66,7 @@ export function buildSandboxEgressNetworkPolicy(input?: {
     return { allow };
   }
 
-  const forwardURL = sandboxProxyUrl(input?.requesterToken);
+  const forwardURL = sandboxProxyUrl(input?.credentialToken);
   for (const entry of entries) {
     for (const domain of entry.domains) {
       allow[domain] = [{ forwardURL }];

--- a/packages/junior/src/chat/sandbox/egress-proxy.ts
+++ b/packages/junior/src/chat/sandbox/egress-proxy.ts
@@ -9,11 +9,11 @@ import { verifyVercelSandboxOidcToken } from "@/chat/sandbox/egress-oidc";
 import {
   clearSandboxEgressCredentialLease,
   getSandboxEgressCredentialLease,
-  parseSandboxEgressRequesterToken,
+  parseSandboxEgressCredentialToken,
   SANDBOX_EGRESS_PROXY_PATH,
   setSandboxEgressCredentialLease,
   type SandboxEgressCredentialLease,
-  type SandboxEgressRequesterContext,
+  type SandboxEgressCredentialContext,
 } from "@/chat/sandbox/egress-session";
 import type { JWTPayload } from "jose";
 
@@ -98,7 +98,7 @@ function egressAttributes(input: {
   };
 }
 
-function requesterTokenFromRequest(request: Request): string | undefined {
+function credentialTokenFromRequest(request: Request): string | undefined {
   const pathname = new URL(request.url).pathname;
   const prefix = `${SANDBOX_EGRESS_PROXY_PATH}/`;
   if (!pathname.startsWith(prefix)) {
@@ -321,7 +321,7 @@ function responseHeaders(upstream: Response): Headers {
 
 async function credentialLease(
   provider: string,
-  context: SandboxEgressRequesterContext,
+  context: SandboxEgressCredentialContext,
 ): Promise<SandboxEgressCredentialLease> {
   const cached = await getSandboxEgressCredentialLease(provider, context);
   if (cached) {
@@ -329,8 +329,8 @@ async function credentialLease(
   }
 
   const lease = await issueProviderCredentialLease({
+    context: context.credentials,
     provider,
-    requesterId: context.requesterId,
     reason: `sandbox-egress:${provider}`,
   });
   const headerTransforms = lease.headerTransforms ?? [];
@@ -453,14 +453,14 @@ export async function proxySandboxEgressRequest(
   }
 
   // Vercel OIDC authenticates the forwarded VM session; Junior's signed
-  // requester context identifies which user-backed credentials to issue lazily
-  // for that session.
-  const requesterContext = parseSandboxEgressRequesterToken(
-    requesterTokenFromRequest(request),
+  // credential context identifies which provider credentials may be issued
+  // lazily for that session.
+  const credentialContext = parseSandboxEgressCredentialToken(
+    credentialTokenFromRequest(request),
   );
-  if (!requesterContext || requesterContext.egressId !== activeEgressId) {
+  if (!credentialContext || credentialContext.egressId !== activeEgressId) {
     logWarn(
-      "sandbox_egress_requester_context_unauthorized",
+      "sandbox_egress_credential_context_unauthorized",
       {},
       {
         ...egressAttributes({
@@ -473,14 +473,17 @@ export async function proxySandboxEgressRequest(
         }),
         ...routingAttributes(request, upstreamUrl),
       },
-      "Sandbox egress request did not include a valid requester context for the VM session",
+      "Sandbox egress request did not include a valid credential context for the VM session",
     );
-    return jsonError("Sandbox egress requester context is not authorized", 403);
+    return jsonError(
+      "Sandbox egress credential context is not authorized",
+      403,
+    );
   }
 
   let lease: SandboxEgressCredentialLease;
   try {
-    lease = await credentialLease(provider, requesterContext);
+    lease = await credentialLease(provider, credentialContext);
   } catch (error) {
     if (error instanceof CredentialUnavailableError) {
       logWarn(
@@ -598,7 +601,7 @@ export async function proxySandboxEgressRequest(
       },
       "Sandbox egress upstream auth rejected",
     );
-    await clearSandboxEgressCredentialLease(provider, requesterContext);
+    await clearSandboxEgressCredentialLease(provider, credentialContext);
   }
 
   return new Response(upstream.body, {

--- a/packages/junior/src/chat/sandbox/egress-session.ts
+++ b/packages/junior/src/chat/sandbox/egress-session.ts
@@ -1,4 +1,8 @@
 import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
+import {
+  parseCredentialContext,
+  type CredentialContext,
+} from "@/chat/credentials/context";
 import type { CredentialHeaderTransform } from "@/chat/credentials/broker";
 import { getStateAdapter } from "@/chat/state/adapter";
 
@@ -9,8 +13,8 @@ const SANDBOX_EGRESS_HMAC_CONTEXT = "junior.sandbox_egress.v1";
 const SANDBOX_EGRESS_LEASE_PREFIX = "sandbox-egress-lease";
 const DEFAULT_SESSION_TTL_MS = 30 * 60 * 1000;
 
-export interface SandboxEgressRequesterContext {
-  requesterId: string;
+export interface SandboxEgressCredentialContext {
+  credentials: CredentialContext;
   egressId: string;
   expiresAtMs: number;
   contextId: string;
@@ -24,9 +28,12 @@ export interface SandboxEgressCredentialLease {
 
 function leaseKey(
   provider: string,
-  context: SandboxEgressRequesterContext,
+  context: SandboxEgressCredentialContext,
 ): string {
-  return `${SANDBOX_EGRESS_LEASE_PREFIX}:${provider}:${context.requesterId}:${context.egressId}:${context.contextId}`;
+  const actor = context.credentials.actor;
+  const actorKey =
+    actor.type === "user" ? `user:${actor.userId}` : `system:${actor.id}`;
+  return `${SANDBOX_EGRESS_LEASE_PREFIX}:${provider}:${actorKey}:${context.egressId}:${context.contextId}`;
 }
 
 function getSandboxEgressSecret(): string {
@@ -60,16 +67,16 @@ function timingSafeMatch(expected: string, actual: string): boolean {
   return timingSafeEqual(expectedBuffer, actualBuffer);
 }
 
-function parseRequesterContext(
+function parseSandboxEgressContext(
   value: unknown,
-): SandboxEgressRequesterContext | undefined {
+): SandboxEgressCredentialContext | undefined {
   if (!value || typeof value !== "object") {
     return undefined;
   }
-  const record = value as Partial<SandboxEgressRequesterContext>;
+  const record = value as Partial<SandboxEgressCredentialContext>;
+  const credentials = parseCredentialContext(record.credentials);
   if (
-    typeof record.requesterId !== "string" ||
-    !record.requesterId ||
+    !credentials ||
     typeof record.egressId !== "string" ||
     !record.egressId ||
     typeof record.expiresAtMs !== "number" ||
@@ -83,7 +90,7 @@ function parseRequesterContext(
     return undefined;
   }
   return {
-    requesterId: record.requesterId,
+    credentials,
     egressId: record.egressId,
     expiresAtMs: record.expiresAtMs,
     contextId: record.contextId,
@@ -125,16 +132,16 @@ function parseLease(value: unknown): SandboxEgressCredentialLease | undefined {
   };
 }
 
-/** Create a signed requester/sandbox context token for lazy sandbox egress auth. */
-export function createSandboxEgressRequesterToken(input: {
-  requesterId: string;
+/** Create a signed actor/sandbox context token for lazy sandbox egress auth. */
+export function createSandboxEgressCredentialToken(input: {
+  credentials: CredentialContext;
   egressId: string;
   ttlMs?: number;
 }): string {
   const ttlMs = Math.max(1, input.ttlMs ?? DEFAULT_SESSION_TTL_MS);
   const now = Date.now();
-  const context: SandboxEgressRequesterContext = {
-    requesterId: input.requesterId,
+  const context: SandboxEgressCredentialContext = {
+    credentials: input.credentials,
     egressId: input.egressId,
     expiresAtMs: now + ttlMs,
     contextId: randomUUID(),
@@ -145,10 +152,10 @@ export function createSandboxEgressRequesterToken(input: {
   return `${payload}.${signPayload(payload)}`;
 }
 
-/** Verify a signed requester/sandbox context token from the proxy URL. */
-export function parseSandboxEgressRequesterToken(
+/** Verify a signed actor/sandbox context token from the proxy URL. */
+export function parseSandboxEgressCredentialToken(
   token: string | undefined,
-): SandboxEgressRequesterContext | undefined {
+): SandboxEgressCredentialContext | undefined {
   if (!token) {
     return undefined;
   }
@@ -166,15 +173,15 @@ export function parseSandboxEgressRequesterToken(
     return undefined;
   }
   try {
-    return parseRequesterContext(JSON.parse(fromBase64Url(encodedSession)));
+    return parseSandboxEgressContext(JSON.parse(fromBase64Url(encodedSession)));
   } catch {
     return undefined;
   }
 }
 
-/** Cache a short-lived credential lease for repeated forwarded requests for one requester/sandbox context. */
+/** Cache a short-lived credential lease for repeated forwarded requests for one actor/sandbox context. */
 export async function setSandboxEgressCredentialLease(
-  context: SandboxEgressRequesterContext,
+  context: SandboxEgressCredentialContext,
   lease: SandboxEgressCredentialLease,
 ): Promise<void> {
   const leaseExpiresAtMs = Date.parse(lease.expiresAt);
@@ -190,10 +197,10 @@ export async function setSandboxEgressCredentialLease(
   await state.set(leaseKey(lease.provider, context), lease, ttlMs);
 }
 
-/** Load a cached egress credential lease for a requester/sandbox context/provider pair. */
+/** Load a cached egress credential lease for an actor/sandbox context/provider pair. */
 export async function getSandboxEgressCredentialLease(
   provider: string,
-  context: SandboxEgressRequesterContext,
+  context: SandboxEgressCredentialContext,
 ): Promise<SandboxEgressCredentialLease | undefined> {
   const state = getStateAdapter();
   await state.connect();
@@ -203,7 +210,7 @@ export async function getSandboxEgressCredentialLease(
 /** Clear a cached egress credential lease after the provider rejects its headers. */
 export async function clearSandboxEgressCredentialLease(
   provider: string,
-  context: SandboxEgressRequesterContext,
+  context: SandboxEgressCredentialContext,
 ): Promise<void> {
   const state = getStateAdapter();
   await state.connect();

--- a/packages/junior/src/chat/sandbox/sandbox.ts
+++ b/packages/junior/src/chat/sandbox/sandbox.ts
@@ -10,7 +10,8 @@ import {
   buildSandboxEgressNetworkPolicy,
   resolveSandboxCommandEnvironment,
 } from "@/chat/sandbox/egress-policy";
-import { createSandboxEgressRequesterToken } from "@/chat/sandbox/egress-session";
+import { createSandboxEgressCredentialToken } from "@/chat/sandbox/egress-session";
+import type { CredentialContext } from "@/chat/credentials/context";
 import {
   isSandboxCommandStreamInterruptedError,
   throwSandboxOperationError,
@@ -126,9 +127,7 @@ export function createSandboxExecutor(options?: {
   sandboxDependencyProfileHash?: string;
   timeoutMs?: number;
   traceContext?: LogContext;
-  credentialEgress?: {
-    requesterId: string;
-  };
+  credentialEgress?: CredentialContext;
   agentHooks?: AgentPluginHookRunner;
   onSandboxAcquired?: (sandbox: SandboxAcquiredState) => void | Promise<void>;
   runBashCustomCommand?: (
@@ -143,12 +142,12 @@ export function createSandboxExecutor(options?: {
     1,
     options?.timeoutMs ?? 1000 * 60 * 30,
   );
-  const sandboxEgressRequesterTokens = new Map<
+  const sandboxEgressCredentialTokens = new Map<
     string,
     { expiresAtMs: number; token: string }
   >();
-  const sandboxEgressRequesterTokenFor = (egressId: string): string => {
-    const cached = sandboxEgressRequesterTokens.get(egressId);
+  const sandboxEgressCredentialTokenFor = (egressId: string): string => {
+    const cached = sandboxEgressCredentialTokens.get(egressId);
     if (cached && cached.expiresAtMs > Date.now()) {
       return cached.token;
     }
@@ -156,12 +155,12 @@ export function createSandboxExecutor(options?: {
       throw new Error("Sandbox credential egress is not configured");
     }
     const now = Date.now();
-    const token = createSandboxEgressRequesterToken({
-      requesterId: credentialEgress.requesterId,
+    const token = createSandboxEgressCredentialToken({
+      credentials: credentialEgress,
       egressId,
       ttlMs: sandboxEgressTokenTtlMs,
     });
-    sandboxEgressRequesterTokens.set(egressId, {
+    sandboxEgressCredentialTokens.set(egressId, {
       expiresAtMs: now + sandboxEgressTokenTtlMs,
       token,
     });
@@ -178,7 +177,7 @@ export function createSandboxExecutor(options?: {
     createNetworkPolicy: credentialEgress
       ? (egressId) =>
           buildSandboxEgressNetworkPolicy({
-            requesterToken: sandboxEgressRequesterTokenFor(egressId),
+            credentialToken: sandboxEgressCredentialTokenFor(egressId),
           })
       : undefined,
     onSandboxPrepare: async (sandbox) => {

--- a/packages/junior/src/chat/slack/channel.ts
+++ b/packages/junior/src/chat/slack/channel.ts
@@ -36,6 +36,39 @@ export interface SlackThreadReply {
   attachments?: unknown[];
 }
 
+interface SlackConversationInfo {
+  id?: string;
+  is_im?: boolean;
+  is_mpim?: boolean;
+  user?: string;
+}
+
+/** Verify that a Slack conversation is the one-to-one DM owned by a user. */
+export async function isSlackDirectConversationForUser(input: {
+  channelId: string;
+  userId: string;
+}): Promise<boolean> {
+  const client = getSlackClient();
+  const channelId = normalizeSlackConversationId(input.channelId);
+  if (!channelId) {
+    throw new Error("Slack conversation lookup requires a valid channel ID");
+  }
+
+  const response = await withSlackRetries(
+    () => client.conversations.info({ channel: channelId }),
+    3,
+    { action: "conversations.info" },
+  );
+  const channel = (response as { channel?: SlackConversationInfo }).channel;
+
+  return (
+    channel?.id === channelId &&
+    channel.is_im === true &&
+    channel.is_mpim !== true &&
+    channel.user === input.userId
+  );
+}
+
 export async function listChannelMessages(input: {
   channelId: string;
   limit: number;

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -308,6 +308,9 @@ async function resumeAuthorizedMcpTurn(args: {
         messageText: lockedUserMessage.text,
         messageTs: getTurnUserSlackMessageTs(lockedUserMessage),
         replyContext: {
+          credentialContext: {
+            actor: { type: "user", userId: authSession.userId },
+          },
           requester: {
             userId: authSession.userId,
             userName: lockedUserMessage.author?.userName,

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -331,6 +331,12 @@ async function resumeOAuthSessionRecordTurn(
         messageText: stored.pendingMessage ?? lockedUserMessage.text,
         messageTs: getTurnUserSlackMessageTs(lockedUserMessage),
         replyContext: {
+          credentialContext: {
+            actor: {
+              type: "user",
+              userId: lockedUserMessage.author.userId,
+            },
+          },
           requester: {
             userId: lockedUserMessage.author.userId,
             userName: lockedUserMessage.author.userName,
@@ -453,6 +459,9 @@ async function resumePendingOAuthMessage(
     messageTs: getTurnUserSlackMessageTs(latestUserMessage),
     connectedText: "",
     replyContext: {
+      credentialContext: {
+        actor: { type: "user", userId: stored.userId },
+      },
       requester: { userId: stored.userId },
       conversationContext,
       piMessages: conversation.piMessages,

--- a/packages/junior/src/handlers/turn-resume.ts
+++ b/packages/junior/src/handlers/turn-resume.ts
@@ -192,6 +192,12 @@ async function resumeTimedOutTurn(
         messageText: userMessage.text,
         messageTs: getTurnUserSlackMessageTs(userMessage),
         replyContext: {
+          credentialContext: {
+            actor: {
+              type: "user",
+              userId: userMessage.author.userId,
+            },
+          },
           requester: {
             userId: userMessage.author.userId,
             userName: userMessage.author.userName,

--- a/packages/junior/tests/fixtures/slack/factories/api.ts
+++ b/packages/junior/tests/fixtures/slack/factories/api.ts
@@ -309,6 +309,7 @@ export function conversationsInfoOk(
     isIm?: boolean;
     isMpim?: boolean;
     isGroup?: boolean;
+    userId?: string;
   } = {},
 ): {
   ok: true;
@@ -319,6 +320,7 @@ export function conversationsInfoOk(
     is_im: boolean;
     is_mpim: boolean;
     is_group: boolean;
+    user?: string;
   };
 } {
   const isPrivate = input.isPrivate ?? false;
@@ -333,6 +335,7 @@ export function conversationsInfoOk(
       is_im: isIm,
       is_mpim: isMpim,
       is_group: isGroup,
+      ...(input.userId ? { user: input.userId } : {}),
     },
   });
 }

--- a/packages/junior/tests/integration/agent-dispatch-runner.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-runner.test.ts
@@ -85,8 +85,9 @@ describe("agent dispatch runner", () => {
         threadId: dispatchConversationId,
         channelId: "C123",
         teamId: "T123",
-        actorType: "system",
-        actorId: "scheduler",
+      });
+      expect(context.credentialContext).toEqual({
+        actor: { type: "system", id: "scheduler" },
       });
       return createReply();
     });
@@ -279,16 +280,15 @@ describe("agent dispatch runner", () => {
     });
     const generateAssistantReply = vi.fn(async (_input, context) => {
       expect(context.requester).toBeUndefined();
-      expect(context.credentialSubject).toEqual({
-        type: "user",
-        userId: "U123",
-        allowedWhen: "private-direct-conversation",
+      expect(context.credentialContext).toEqual({
+        actor: { type: "system", id: "scheduler" },
+        subject: {
+          type: "user",
+          userId: "U123",
+          allowedWhen: "private-direct-conversation",
+        },
       });
       expect(context.authorizationFlowMode).toBe("disabled");
-      expect(context.correlation).toMatchObject({
-        actorType: "system",
-        actorId: "scheduler",
-      });
       return createReply();
     });
 

--- a/packages/junior/tests/integration/heartbeat.test.ts
+++ b/packages/junior/tests/integration/heartbeat.test.ts
@@ -21,6 +21,11 @@ import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import { setAgentPlugins } from "@/chat/plugins/agent-hooks";
 import { GET as heartbeat } from "@/handlers/heartbeat";
 import type { WaitUntilFn } from "@/handlers/types";
+import { conversationsInfoOk } from "../fixtures/slack/factories/api";
+import {
+  getCapturedSlackApiCalls,
+  queueSlackApiResponse,
+} from "../msw/handlers/slack-api";
 
 vi.hoisted(() => {
   process.env.JUNIOR_STATE_ADAPTER = "memory";
@@ -91,6 +96,24 @@ function createDailyTask(
     updatedAtMs: nextRunAtMs,
     ...overrides,
   });
+}
+
+function mockDispatchCallbackFetch(originalFetch: typeof fetch) {
+  const fetchMock = vi.fn(async (...args: Parameters<typeof fetch>) => {
+    const input = args[0];
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    if (url.startsWith("https://slack.com/api/")) {
+      return await originalFetch(...args);
+    }
+    return new Response("Accepted", { status: 202 });
+  });
+  global.fetch = fetchMock as typeof fetch;
+  return fetchMock;
 }
 
 describe("trusted plugin heartbeat", () => {
@@ -310,6 +333,43 @@ describe("trusted plugin heartbeat", () => {
     ).resolves.toMatchObject({ status: "created" });
   });
 
+  it("rejects delegated credential subjects that do not own the destination DM", async () => {
+    mockDispatchCallbackFetch(originalFetch);
+    queueSlackApiResponse("conversations.info", {
+      body: conversationsInfoOk({
+        channelId: "D123",
+        isIm: true,
+        userId: "U999",
+      }),
+    });
+
+    const ctx = createHeartbeatContext({
+      plugin: "scheduler",
+      nowMs: Date.parse("2026-05-26T12:00:00.000Z"),
+    });
+
+    await expect(
+      ctx.agent.dispatch({
+        idempotencyKey: "run-delegated-mismatch",
+        credentialSubject: {
+          type: "user",
+          userId: "U123",
+          allowedWhen: "private-direct-conversation",
+        },
+        destination: {
+          platform: "slack",
+          teamId: "T123",
+          channelId: "D123",
+        },
+        input: "Run the scheduled task.",
+      }),
+    ).rejects.toThrow(
+      "Dispatch credentialSubject must match the private direct Slack destination",
+    );
+    expect(getCapturedSlackApiCalls("conversations.info")).toHaveLength(1);
+    await expect(listIncompleteDispatchIds()).resolves.toEqual([]);
+  });
+
   it("fails stale dispatches that exceed retry attempts", async () => {
     const created = await createOrGetDispatch({
       plugin: "scheduler",
@@ -488,10 +548,14 @@ describe("trusted plugin heartbeat", () => {
   });
 
   it("carries scheduled task credential subjects into dispatch records", async () => {
-    const fetchMock = vi.fn(async () => {
-      return new Response("Accepted", { status: 202 });
+    mockDispatchCallbackFetch(originalFetch);
+    queueSlackApiResponse("conversations.info", {
+      body: conversationsInfoOk({
+        channelId: "D123",
+        isIm: true,
+        userId: "U123",
+      }),
     });
-    global.fetch = fetchMock as typeof fetch;
     setAgentPlugins([schedulerPlugin()]);
     const store = schedulerStore();
     await store.saveTask(

--- a/packages/junior/tests/integration/oauth-resume-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-resume-slack.test.ts
@@ -49,6 +49,9 @@ describe("oauth resume slack integration", () => {
       connectedText:
         "Your eval-auth MCP access is now connected. Continuing the original request...",
       replyContext: {
+        credentialContext: {
+          actor: { type: "user", userId: "U123" },
+        },
         requester: { userId: "U123" },
       },
       generateReply: async () =>
@@ -149,6 +152,9 @@ describe("oauth resume slack integration", () => {
       threadTs: "1700000000.007",
       connectedText: "",
       replyContext: {
+        credentialContext: {
+          actor: { type: "user", userId: "U123" },
+        },
         requester: { userId: "U123" },
         correlation: {
           conversationId: "conversation-1",
@@ -215,6 +221,9 @@ describe("oauth resume slack integration", () => {
       threadTs: "1700000000.002",
       connectedText: "Connected. Continuing...",
       replyContext: {
+        credentialContext: {
+          actor: { type: "user", userId: "U123" },
+        },
         requester: { userId: "U123" },
       },
       generateReply: async () =>
@@ -250,6 +259,9 @@ describe("oauth resume slack integration", () => {
       threadTs: "1700000000.003",
       connectedText: "Connected. Continuing...",
       replyContext: {
+        credentialContext: {
+          actor: { type: "user", userId: "U123" },
+        },
         requester: { userId: "U123" },
       },
       generateReply: async () =>
@@ -282,6 +294,9 @@ describe("oauth resume slack integration", () => {
       threadTs: "1700000000.006",
       connectedText: "Connected. Continuing...",
       replyContext: {
+        credentialContext: {
+          actor: { type: "user", userId: "U123" },
+        },
         requester: { userId: "U123" },
       },
       generateReply: async () =>
@@ -315,6 +330,9 @@ describe("oauth resume slack integration", () => {
       threadTs: "1700000000.004",
       connectedText: "Connected. Continuing...",
       replyContext: {
+        credentialContext: {
+          actor: { type: "user", userId: "U123" },
+        },
         requester: { userId: "U123" },
       },
       generateReply: async () =>
@@ -369,6 +387,9 @@ describe("oauth resume slack integration", () => {
       threadTs: "1700000000.005",
       connectedText: "Connected. Continuing...",
       replyContext: {
+        credentialContext: {
+          actor: { type: "user", userId: "U123" },
+        },
         requester: { userId: "U123" },
       },
       generateReply: async () =>

--- a/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
@@ -106,18 +106,18 @@ describe("sandbox egress proxy integration", () => {
   });
 
   it("injects provider credentials through real plugin and broker wiring without command session state", async () => {
-    const requesterToken = modules.session.createSandboxEgressRequesterToken({
-      requesterId: REQUESTER_ID,
+    const credentialToken = modules.session.createSandboxEgressCredentialToken({
+      credentials: { actor: { type: "user", userId: REQUESTER_ID } },
       egressId: EGRESS_ID,
       ttlMs: 60_000,
     });
     const networkPolicy = modules.policy.buildSandboxEgressNetworkPolicy({
-      requesterToken,
+      credentialToken,
     });
     const forwardURL = forwardUrlFor(networkPolicy, PROVIDER_HOST);
 
     expect(forwardURL).toBe(
-      `${BASE_URL}/api/internal/sandbox-egress/${requesterToken}`,
+      `${BASE_URL}/api/internal/sandbox-egress/${credentialToken}`,
     );
 
     const upstreamFetch = vi.fn(
@@ -148,13 +148,13 @@ describe("sandbox egress proxy integration", () => {
   });
 
   it("intercepts credential-injected provider traffic before live forwarding", async () => {
-    const requesterToken = modules.session.createSandboxEgressRequesterToken({
-      requesterId: REQUESTER_ID,
+    const credentialToken = modules.session.createSandboxEgressCredentialToken({
+      credentials: { actor: { type: "user", userId: REQUESTER_ID } },
       egressId: EGRESS_ID,
       ttlMs: 60_000,
     });
     const networkPolicy = modules.policy.buildSandboxEgressNetworkPolicy({
-      requesterToken,
+      credentialToken,
     });
     const forwardURL = forwardUrlFor(networkPolicy, PROVIDER_HOST);
     const upstreamFetch = vi.fn();

--- a/packages/junior/tests/unit/capabilities/capability-factory.test.ts
+++ b/packages/junior/tests/unit/capabilities/capability-factory.test.ts
@@ -3,6 +3,9 @@ import type { PluginDefinition } from "@/chat/plugins/types";
 
 const createPluginBrokerMock = vi.fn();
 const getPluginProvidersMock = vi.fn<() => PluginDefinition[]>();
+const USER_CREDENTIAL_CONTEXT = {
+  actor: { type: "user" as const, userId: "U123" },
+};
 
 vi.mock("@/chat/capabilities/catalog", () => ({
   logCapabilityCatalogLoadedOnce: vi.fn(),
@@ -10,10 +13,6 @@ vi.mock("@/chat/capabilities/catalog", () => ({
 
 vi.mock("@/chat/plugins/registry", () => ({
   createPluginBroker: (...args: unknown[]) => createPluginBrokerMock(...args),
-  getPluginDefinition: (provider: string) =>
-    getPluginProvidersMock().find(
-      (plugin) => plugin.manifest.name === provider,
-    ),
   getPluginProviders: () => getPluginProvidersMock(),
 }));
 
@@ -66,8 +65,8 @@ describe("capability factory", () => {
     const { issueProviderCredentialLease } =
       await import("@/chat/capabilities/factory");
     const lease = await issueProviderCredentialLease({
+      context: USER_CREDENTIAL_CONTEXT,
       provider: "example",
-      requesterId: "U123",
       reason: "test:api-headers",
     });
 
@@ -75,7 +74,7 @@ describe("capability factory", () => {
       userTokenStore: expect.any(Object),
     });
     expect(broker.issue).toHaveBeenCalledWith({
-      requesterId: "U123",
+      context: USER_CREDENTIAL_CONTEXT,
       reason: "test:api-headers",
     });
     expect(lease.provider).toBe("example");

--- a/packages/junior/tests/unit/capabilities/capability-router.test.ts
+++ b/packages/junior/tests/unit/capabilities/capability-router.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 import { ProviderCredentialRouter } from "@/chat/capabilities/router";
 import type { CredentialBroker } from "@/chat/credentials/broker";
 
+const USER_CREDENTIAL_CONTEXT = {
+  actor: { type: "user" as const, userId: "U123" },
+};
+
 describe("provider credential router", () => {
   it("routes provider issuance to the matching broker", async () => {
     const broker: CredentialBroker = {
@@ -20,6 +24,7 @@ describe("provider credential router", () => {
 
     await expect(
       router.issue({
+        context: USER_CREDENTIAL_CONTEXT,
         provider: "github",
         reason: "test",
       }),
@@ -27,11 +32,12 @@ describe("provider credential router", () => {
       provider: "github",
     });
     expect(broker.issue).toHaveBeenCalledWith({
+      context: USER_CREDENTIAL_CONTEXT,
       reason: "test",
     });
   });
 
-  it("forwards requester context", async () => {
+  it("forwards credential context", async () => {
     const broker: CredentialBroker = {
       issue: vi.fn(async () => ({
         id: "lease-1",
@@ -47,13 +53,27 @@ describe("provider credential router", () => {
     });
 
     await router.issue({
+      context: {
+        actor: { type: "system", id: "scheduler" },
+        subject: {
+          type: "user",
+          userId: "U123",
+          allowedWhen: "private-direct-conversation",
+        },
+      },
       provider: "github",
-      requesterId: "U123",
       reason: "test",
     });
 
     expect(broker.issue).toHaveBeenCalledWith({
-      requesterId: "U123",
+      context: {
+        actor: { type: "system", id: "scheduler" },
+        subject: {
+          type: "user",
+          userId: "U123",
+          allowedWhen: "private-direct-conversation",
+        },
+      },
       reason: "test",
     });
   });
@@ -65,6 +85,7 @@ describe("provider credential router", () => {
 
     await expect(
       router.issue({
+        context: USER_CREDENTIAL_CONTEXT,
         provider: "github",
         reason: "test",
       }),

--- a/packages/junior/tests/unit/credentials/credential-context.test.ts
+++ b/packages/junior/tests/unit/credentials/credential-context.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  credentialUserSubjectId,
+  parseCredentialContext,
+} from "@/chat/credentials/context";
+
+describe("credential context", () => {
+  const delegatedSubject = {
+    type: "user" as const,
+    userId: "U123",
+    allowedWhen: "private-direct-conversation" as const,
+  };
+
+  it("resolves the user OAuth subject from the current actor or delegated subject", () => {
+    expect(
+      credentialUserSubjectId({
+        actor: { type: "user", userId: "U123" },
+      }),
+    ).toBe("U123");
+    expect(
+      credentialUserSubjectId({
+        actor: { type: "system", id: "scheduler" },
+        subject: delegatedSubject,
+      }),
+    ).toBe("U123");
+    expect(
+      credentialUserSubjectId({
+        actor: { type: "system", id: "scheduler" },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("parses untrusted egress contexts with the same actor rules", () => {
+    expect(
+      parseCredentialContext({
+        actor: { type: "user", userId: "U123" },
+        subject: { type: "user", userId: "U999" },
+      }),
+    ).toBeUndefined();
+    expect(
+      parseCredentialContext({
+        actor: { type: "system", id: "scheduler" },
+        subject: delegatedSubject,
+      }),
+    ).toEqual({
+      actor: { type: "system", id: "scheduler" },
+      subject: delegatedSubject,
+    });
+  });
+
+  it("rejects malformed untrusted credential contexts", () => {
+    expect(parseCredentialContext(undefined)).toBeUndefined();
+    expect(parseCredentialContext({})).toBeUndefined();
+    expect(
+      parseCredentialContext({
+        actor: { type: "system", id: "" },
+      }),
+    ).toBeUndefined();
+    expect(
+      parseCredentialContext({
+        actor: { type: "user", userId: "" },
+      }),
+    ).toBeUndefined();
+    expect(
+      parseCredentialContext({
+        actor: { type: "system", id: "scheduler" },
+        subject: { type: "user", userId: "U123" },
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/junior/tests/unit/handlers/oauth-resume.test.ts
+++ b/packages/junior/tests/unit/handlers/oauth-resume.test.ts
@@ -84,6 +84,9 @@ describe("resumeAuthorizedRequest", () => {
       threadTs: "1700000000.0001",
       connectedText: "connected",
       replyContext: {
+        credentialContext: {
+          actor: { type: "user", userId: "U-test" },
+        },
         requester: { userId: "U-test" },
       },
       generateReply: () => new Promise<never>(() => {}),
@@ -117,6 +120,9 @@ describe("resumeAuthorizedRequest", () => {
         threadTs: "1700000000.0004",
         connectedText: "connected",
         replyContext: {
+          credentialContext: {
+            actor: { type: "user", userId: "U-test" },
+          },
           requester: { userId: "U-test" },
         },
         generateReply: async () => {
@@ -155,6 +161,9 @@ describe("resumeAuthorizedRequest", () => {
         channelId: "C-test",
         threadTs: "1700000000.0005",
         replyContext: {
+          credentialContext: {
+            actor: { type: "user", userId: "U-test" },
+          },
           requester: { userId: "U-test" },
         },
         generateReply: async () => ({
@@ -214,6 +223,9 @@ describe("resumeAuthorizedRequest", () => {
       channelId: "C-test",
       threadTs: "1700000000.0002",
       replyContext: {
+        credentialContext: {
+          actor: { type: "user", userId: "U-test" },
+        },
         requester: { userId: "U-test" },
       },
       generateReply: async () => {
@@ -244,6 +256,9 @@ describe("resumeAuthorizedRequest", () => {
       channelId: "C-test",
       threadTs: "1700000000.0003",
       replyContext: {
+        credentialContext: {
+          actor: { type: "user", userId: "U-test" },
+        },
         requester: { userId: "U-test" },
       },
       generateReply: async () => {

--- a/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
@@ -52,7 +52,7 @@ import {
   proxySandboxEgressRequest,
 } from "@/chat/sandbox/egress-proxy";
 import {
-  createSandboxEgressRequesterToken,
+  createSandboxEgressCredentialToken,
   SANDBOX_EGRESS_PROXY_PATH,
 } from "@/chat/sandbox/egress-session";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
@@ -62,7 +62,7 @@ import { ALL } from "@/handlers/sandbox-egress-proxy";
 const EGRESS_ID = "junior-sbx";
 const REQUESTER_ID = "U123";
 
-let activeRequesterToken: string | undefined;
+let activeCredentialToken: string | undefined;
 
 function sentryPlugin() {
   return {
@@ -109,9 +109,26 @@ function githubPlugin() {
   };
 }
 
-function setSandboxEgressRequester(requesterId = REQUESTER_ID): void {
-  activeRequesterToken = createSandboxEgressRequesterToken({
-    requesterId,
+function setSandboxEgressUserActor(userId = REQUESTER_ID): void {
+  activeCredentialToken = createSandboxEgressCredentialToken({
+    credentials: { actor: { type: "user", userId } },
+    egressId: EGRESS_ID,
+    ttlMs: 60_000,
+  });
+}
+
+function setSandboxEgressSystemActor(input?: {
+  subject?: {
+    type: "user";
+    userId: string;
+    allowedWhen: "private-direct-conversation";
+  };
+}): void {
+  activeCredentialToken = createSandboxEgressCredentialToken({
+    credentials: {
+      actor: { type: "system", id: "scheduler" },
+      ...(input?.subject ? { subject: input.subject } : {}),
+    },
     egressId: EGRESS_ID,
     ttlMs: 60_000,
   });
@@ -125,6 +142,21 @@ function mockSentryLease(domain = "sentry.io", token = "sentry-token"): void {
     headerTransforms: [
       {
         domain,
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    ],
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+  });
+}
+
+function mockGitHubLease(token = "github-token"): void {
+  issueProviderCredentialLeaseMock.mockResolvedValue({
+    id: "lease-github",
+    provider: "github",
+    env: { GITHUB_TOKEN: "ghp_host_managed_credential" },
+    headerTransforms: [
+      {
+        domain: "api.github.com",
         headers: { Authorization: `Bearer ${token}` },
       },
     ],
@@ -148,8 +180,8 @@ function egressRequest(
   const upstreamPath = input.path ?? "/api/0/issues/";
   const proxyPath =
     input.proxyPath ??
-    (activeRequesterToken
-      ? `${SANDBOX_EGRESS_PROXY_PATH}/${activeRequesterToken}`
+    (activeCredentialToken
+      ? `${SANDBOX_EGRESS_PROXY_PATH}/${activeCredentialToken}`
       : upstreamPath);
   const forwardedPath =
     input.forwardedPath === undefined ? upstreamPath : input.forwardedPath;
@@ -188,7 +220,7 @@ describe("sandbox egress proxy", () => {
     process.env.JUNIOR_STATE_ADAPTER = "memory";
     process.env.JUNIOR_BASE_URL = "https://junior.example.com";
     process.env.JUNIOR_SECRET = "test-secret";
-    activeRequesterToken = undefined;
+    activeCredentialToken = undefined;
     getPluginProvidersMock.mockReturnValue([sentryPlugin()]);
     createRemoteJWKSetMock.mockClear();
     createRemoteJWKSetMock.mockReturnValue(async () => null);
@@ -228,13 +260,13 @@ describe("sandbox egress proxy", () => {
       },
     });
 
-    const token = createSandboxEgressRequesterToken({
-      requesterId: REQUESTER_ID,
+    const token = createSandboxEgressCredentialToken({
+      credentials: { actor: { type: "user", userId: REQUESTER_ID } },
       egressId: EGRESS_ID,
       ttlMs: 60_000,
     });
     expect(
-      buildSandboxEgressNetworkPolicy({ requesterToken: token }),
+      buildSandboxEgressNetworkPolicy({ credentialToken: token }),
     ).toMatchObject({
       allow: {
         "sentry.io": [
@@ -262,8 +294,8 @@ describe("sandbox egress proxy", () => {
     process.env.SLACK_SIGNING_SECRET = "test-slack-signing-secret";
 
     expect(() =>
-      createSandboxEgressRequesterToken({
-        requesterId: REQUESTER_ID,
+      createSandboxEgressCredentialToken({
+        credentials: { actor: { type: "user", userId: REQUESTER_ID } },
         egressId: EGRESS_ID,
         ttlMs: 60_000,
       }),
@@ -310,7 +342,7 @@ describe("sandbox egress proxy", () => {
   });
 
   it("forwards repeated authorized sandbox requests with credential headers", async () => {
-    setSandboxEgressRequester();
+    setSandboxEgressUserActor();
     mockSentryLease();
 
     const fetchMock = vi.fn(async (url: URL | string, init?: RequestInit) => {
@@ -348,8 +380,8 @@ describe("sandbox egress proxy", () => {
     expect(response.status).toBe(200);
     await expect(response.text()).resolves.toBe("ok");
     expect(issueProviderCredentialLeaseMock).toHaveBeenCalledWith({
+      context: { actor: { type: "user", userId: REQUESTER_ID } },
       provider: "sentry",
-      requesterId: REQUESTER_ID,
       reason: "sandbox-egress:sentry",
     });
 
@@ -367,8 +399,41 @@ describe("sandbox egress proxy", () => {
     expect(issueProviderCredentialLeaseMock).toHaveBeenCalledTimes(1);
   });
 
+  it("preserves delegated credential subjects under system actor contexts", async () => {
+    getPluginProvidersMock.mockReturnValue([githubPlugin()]);
+    setSandboxEgressSystemActor({
+      subject: {
+        type: "user",
+        userId: REQUESTER_ID,
+        allowedWhen: "private-direct-conversation",
+      },
+    });
+    mockGitHubLease();
+
+    const response = await proxy(
+      egressRequest({
+        host: "api.github.com",
+        path: "/repos/getsentry/junior/issues/449",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(issueProviderCredentialLeaseMock).toHaveBeenCalledWith({
+      context: {
+        actor: { type: "system", id: "scheduler" },
+        subject: {
+          type: "user",
+          userId: REQUESTER_ID,
+          allowedWhen: "private-direct-conversation",
+        },
+      },
+      provider: "github",
+      reason: "sandbox-egress:github",
+    });
+  });
+
   it("prefers Vercel forwarded path over the normalized proxy URL path", async () => {
-    setSandboxEgressRequester();
+    setSandboxEgressUserActor();
     mockSentryLease();
 
     const fetchMock = vi.fn(async (url: URL | string, init?: RequestInit) => {
@@ -399,13 +464,13 @@ describe("sandbox egress proxy", () => {
   });
 
   it("rejects sandbox egress requests without a forwarded path", async () => {
-    setSandboxEgressRequester();
+    setSandboxEgressUserActor();
 
     const fetchMock = vi.fn();
     const response = await proxy(
       egressRequest({
         forwardedPath: null,
-        proxyPath: `${SANDBOX_EGRESS_PROXY_PATH}/${activeRequesterToken}`,
+        proxyPath: `${SANDBOX_EGRESS_PROXY_PATH}/${activeCredentialToken}`,
       }),
       fetchMock as typeof fetch,
     );
@@ -433,7 +498,7 @@ describe("sandbox egress proxy", () => {
   });
 
   it("does not synthesize an empty body for bodyless methods", async () => {
-    setSandboxEgressRequester();
+    setSandboxEgressUserActor();
     mockSentryLease();
 
     const fetchMock = vi.fn(async (_url: URL | string, init?: RequestInit) => {
@@ -451,8 +516,8 @@ describe("sandbox egress proxy", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("scopes cached credential leases to the requester", async () => {
-    setSandboxEgressRequester();
+  it("scopes cached credential leases to the actor", async () => {
+    setSandboxEgressUserActor();
     issueProviderCredentialLeaseMock
       .mockResolvedValueOnce({
         id: "lease-1",
@@ -489,7 +554,7 @@ describe("sandbox egress proxy", () => {
     );
     await expect(firstResponse.text()).resolves.toBe("Bearer token-u123");
 
-    setSandboxEgressRequester("U456");
+    setSandboxEgressUserActor("U456");
     const secondResponse = await proxy(
       egressRequest({
         path: "/api/0/issues/2",
@@ -500,19 +565,19 @@ describe("sandbox egress proxy", () => {
     await expect(secondResponse.text()).resolves.toBe("Bearer token-u456");
 
     expect(issueProviderCredentialLeaseMock).toHaveBeenNthCalledWith(1, {
+      context: { actor: { type: "user", userId: REQUESTER_ID } },
       provider: "sentry",
-      requesterId: REQUESTER_ID,
       reason: "sandbox-egress:sentry",
     });
     expect(issueProviderCredentialLeaseMock).toHaveBeenNthCalledWith(2, {
+      context: { actor: { type: "user", userId: "U456" } },
       provider: "sentry",
-      requesterId: "U456",
       reason: "sandbox-egress:sentry",
     });
   });
 
-  it("does not reuse cached credential leases across renewed requester contexts", async () => {
-    setSandboxEgressRequester();
+  it("does not reuse cached credential leases across renewed credential contexts", async () => {
+    setSandboxEgressUserActor();
     issueProviderCredentialLeaseMock
       .mockResolvedValueOnce({
         id: "lease-1",
@@ -551,7 +616,7 @@ describe("sandbox egress proxy", () => {
       "Bearer token-first-session",
     );
 
-    setSandboxEgressRequester();
+    setSandboxEgressUserActor();
     const secondResponse = await proxy(
       egressRequest({ path: "/api/0/issues/2" }),
       fetchMock as typeof fetch,
@@ -564,7 +629,7 @@ describe("sandbox egress proxy", () => {
   });
 
   it("clears cached credential leases after upstream auth rejection", async () => {
-    setSandboxEgressRequester();
+    setSandboxEgressUserActor();
     issueProviderCredentialLeaseMock
       .mockResolvedValueOnce({
         id: "lease-1",
@@ -615,7 +680,7 @@ describe("sandbox egress proxy", () => {
   });
 
   it("applies provider header transforms to matching upstream hosts", async () => {
-    setSandboxEgressRequester();
+    setSandboxEgressUserActor();
     mockSentryLease("us.sentry.io");
 
     const fetchMock = vi.fn(async (_url: URL | string, init?: RequestInit) => {
@@ -635,7 +700,7 @@ describe("sandbox egress proxy", () => {
   });
 
   it("does not apply subdomain transforms to the apex host", async () => {
-    setSandboxEgressRequester();
+    setSandboxEgressUserActor();
     mockSentryLease("us.sentry.io");
 
     const fetchMock = vi.fn();
@@ -650,7 +715,7 @@ describe("sandbox egress proxy", () => {
   });
 
   it("forwards upstream response headers to the sandbox", async () => {
-    setSandboxEgressRequester();
+    setSandboxEgressUserActor();
     mockSentryLease();
 
     const upstreamHeaders = new Headers();
@@ -670,7 +735,7 @@ describe("sandbox egress proxy", () => {
   });
 
   it("drops upstream encoding headers after host fetch decodes the body", async () => {
-    setSandboxEgressRequester();
+    setSandboxEgressUserActor();
     mockSentryLease();
 
     const response = await proxy(
@@ -792,7 +857,7 @@ describe("sandbox egress proxy", () => {
   });
 
   it("returns a command-readable auth marker when provider credentials are missing", async () => {
-    setSandboxEgressRequester();
+    setSandboxEgressUserActor();
     issueProviderCredentialLeaseMock.mockRejectedValue(
       new CredentialUnavailableError(
         "sentry",
@@ -808,7 +873,7 @@ describe("sandbox egress proxy", () => {
     );
   });
 
-  it("requires a signed requester context", async () => {
+  it("requires a signed credential context", async () => {
     mockSentryLease();
 
     const response = await proxy(egressRequest());
@@ -817,9 +882,9 @@ describe("sandbox egress proxy", () => {
     expect(issueProviderCredentialLeaseMock).not.toHaveBeenCalled();
   });
 
-  it("rejects requester context tokens from a different sandbox session", async () => {
-    activeRequesterToken = createSandboxEgressRequesterToken({
-      requesterId: REQUESTER_ID,
+  it("rejects credential context tokens from a different sandbox session", async () => {
+    activeCredentialToken = createSandboxEgressCredentialToken({
+      credentials: { actor: { type: "user", userId: REQUESTER_ID } },
       egressId: "different-egress-session",
       ttlMs: 60_000,
     });
@@ -831,9 +896,9 @@ describe("sandbox egress proxy", () => {
     expect(issueProviderCredentialLeaseMock).not.toHaveBeenCalled();
   });
 
-  it("rejects tampered requester tokens", async () => {
-    setSandboxEgressRequester();
-    activeRequesterToken = `${activeRequesterToken ?? ""}tampered`;
+  it("rejects tampered credential tokens", async () => {
+    setSandboxEgressUserActor();
+    activeCredentialToken = `${activeCredentialToken ?? ""}tampered`;
     mockSentryLease();
 
     const response = await proxy(egressRequest());

--- a/packages/junior/tests/unit/misc/sandbox-executor.test.ts
+++ b/packages/junior/tests/unit/misc/sandbox-executor.test.ts
@@ -89,7 +89,7 @@ vi.mock("@/chat/sandbox/runtime-dependency-snapshots", () => ({
 
 import { createSandboxExecutor } from "@/chat/sandbox/sandbox";
 import {
-  parseSandboxEgressRequesterToken,
+  parseSandboxEgressCredentialToken,
   SANDBOX_EGRESS_PROXY_PATH,
 } from "@/chat/sandbox/egress-session";
 import { createSandboxSessionManager } from "@/chat/sandbox/session";
@@ -161,7 +161,7 @@ function sentryForwardURLFromPolicy(policy: unknown): string | undefined {
   return allow?.["sentry.io"]?.[0]?.forwardURL;
 }
 
-function requesterTokenFromForwardURL(
+function credentialTokenFromForwardURL(
   forwardURL: string | undefined,
 ): string | undefined {
   if (!forwardURL) {
@@ -799,18 +799,18 @@ describe("createSandboxExecutor", () => {
     );
   });
 
-  it("configures lazy requester auth for sandbox egress", async () => {
+  it("configures lazy user actor auth for sandbox egress", async () => {
     const sandbox = makeSandbox("sbx_authorize_credentials");
     sandbox.runCommand.mockImplementationOnce(async () => {
       const activePolicy = sandbox.update.mock.calls.at(-1)?.[0].networkPolicy;
-      const activeRequesterToken = requesterTokenFromForwardURL(
+      const activeCredentialToken = credentialTokenFromForwardURL(
         sentryForwardURLFromPolicy(activePolicy),
       );
 
       expect(
-        parseSandboxEgressRequesterToken(activeRequesterToken),
+        parseSandboxEgressCredentialToken(activeCredentialToken),
       ).toMatchObject({
-        requesterId: "U123",
+        credentials: { actor: { type: "user", userId: "U123" } },
         egressId: "sbx_authorize_credentials_session",
       });
       return {
@@ -830,7 +830,7 @@ describe("createSandboxExecutor", () => {
     const executor = createSandboxExecutor({
       sandboxId: "sbx_authorize_credentials",
       credentialEgress: {
-        requesterId: "U123",
+        actor: { type: "user", userId: "U123" },
       },
     });
     executor.configureSkills([]);
@@ -844,12 +844,63 @@ describe("createSandboxExecutor", () => {
 
     expect(sandbox.update).toHaveBeenCalledTimes(1);
     expect(
-      requesterTokenFromForwardURL(
+      credentialTokenFromForwardURL(
         sentryForwardURLFromPolicy(
           sandbox.update.mock.calls[0]?.[0].networkPolicy,
         ),
       ),
     ).toBeTruthy();
+    const invocation = sandbox.runCommand.mock.calls[0]?.[0];
+    expect(invocation.args?.[1]).toContain(
+      "export SENTRY_AUTH_TOKEN='host_managed_credential'",
+    );
+    expect(invocation.args?.[1]).toContain("sentry-cli issues list");
+  });
+
+  it("configures lazy system actor credential context for sandbox egress", async () => {
+    const sandbox = makeSandbox("sbx_authorize_system_credentials");
+    sandbox.runCommand.mockImplementationOnce(async () => {
+      const activePolicy = sandbox.update.mock.calls.at(-1)?.[0].networkPolicy;
+      const activeCredentialToken = credentialTokenFromForwardURL(
+        sentryForwardURLFromPolicy(activePolicy),
+      );
+
+      expect(
+        parseSandboxEgressCredentialToken(activeCredentialToken),
+      ).toMatchObject({
+        credentials: { actor: { type: "system", id: "scheduler" } },
+        egressId: "sbx_authorize_system_credentials_session",
+      });
+      return {
+        exitCode: 0,
+        stdout: async () => "",
+        stderr: async () => "",
+      };
+    });
+    sandboxGetMock.mockResolvedValue(sandbox);
+    vi.mocked(createBashTool).mockResolvedValue({
+      tools: {
+        readFile: { execute: vi.fn(async () => ({ content: "" })) },
+        writeFile: { execute: vi.fn(async () => ({ success: true })) },
+      },
+    } as never);
+
+    const executor = createSandboxExecutor({
+      sandboxId: "sbx_authorize_system_credentials",
+      credentialEgress: {
+        actor: { type: "system", id: "scheduler" },
+      },
+    });
+    executor.configureSkills([]);
+
+    await executor.execute({
+      toolName: "bash",
+      input: {
+        command: "sentry-cli issues list",
+      },
+    });
+
+    expect(sandbox.update).toHaveBeenCalledTimes(1);
     const invocation = sandbox.runCommand.mock.calls[0]?.[0];
     expect(invocation.args?.[1]).toContain(
       "export SENTRY_AUTH_TOKEN='host_managed_credential'",
@@ -870,7 +921,7 @@ describe("createSandboxExecutor", () => {
     const executor = createSandboxExecutor({
       sandboxId: "sbx_registered_credentials",
       credentialEgress: {
-        requesterId: "U123",
+        actor: { type: "user", userId: "U123" },
       },
     });
     executor.configureSkills([]);
@@ -884,7 +935,7 @@ describe("createSandboxExecutor", () => {
 
     expect(sandbox.update).toHaveBeenCalledTimes(1);
     expect(
-      requesterTokenFromForwardURL(
+      credentialTokenFromForwardURL(
         sentryForwardURLFromPolicy(
           sandbox.update.mock.calls[0]?.[0].networkPolicy,
         ),

--- a/packages/junior/tests/unit/plugins/api-headers-broker.test.ts
+++ b/packages/junior/tests/unit/plugins/api-headers-broker.test.ts
@@ -3,6 +3,9 @@ import { createApiHeadersBroker } from "@/chat/plugins/auth/api-headers-broker";
 import type { PluginManifest } from "@/chat/plugins/types";
 
 const ORIGINAL_ENV = { ...process.env };
+const SYSTEM_CREDENTIAL_CONTEXT = {
+  actor: { type: "system" as const, id: "scheduler" },
+};
 
 const MANIFEST: PluginManifest = {
   name: "example",
@@ -26,7 +29,10 @@ describe("API headers broker", () => {
     process.env.EXAMPLE_AUTH_HEADER = "Basic abc123";
 
     const broker = createApiHeadersBroker(MANIFEST);
-    const lease = await broker.issue({ reason: "test:api-headers" });
+    const lease = await broker.issue({
+      context: SYSTEM_CREDENTIAL_CONTEXT,
+      reason: "test:api-headers",
+    });
 
     expect(lease.provider).toBe("example");
     expect(lease.env).toEqual({});
@@ -50,7 +56,10 @@ describe("API headers broker", () => {
         EXAMPLE_API_KEY: "host_managed_credential",
       },
     });
-    const lease = await broker.issue({ reason: "test:command-env" });
+    const lease = await broker.issue({
+      context: SYSTEM_CREDENTIAL_CONTEXT,
+      reason: "test:command-env",
+    });
 
     expect(lease.env).toEqual({
       EXAMPLE_API_KEY: "host_managed_credential",
@@ -63,7 +72,10 @@ describe("API headers broker", () => {
     const broker = createApiHeadersBroker(MANIFEST);
 
     await expect(
-      broker.issue({ reason: "test:missing-api-header-env" }),
+      broker.issue({
+        context: SYSTEM_CREDENTIAL_CONTEXT,
+        reason: "test:missing-api-header-env",
+      }),
     ).rejects.toThrow(
       'Missing EXAMPLE_AUTH_HEADER for API header provider "example"',
     );

--- a/packages/junior/tests/unit/plugins/github-app-broker.test.ts
+++ b/packages/junior/tests/unit/plugins/github-app-broker.test.ts
@@ -30,6 +30,12 @@ const TEST_MANIFEST: PluginManifest = {
     commandFlags: ["--repo", "-R"],
   },
 };
+const USER_CREDENTIAL_CONTEXT = {
+  actor: { type: "user" as const, userId: "U123" },
+};
+const SYSTEM_CREDENTIAL_CONTEXT = {
+  actor: { type: "system" as const, id: "scheduler" },
+};
 
 function setupValidEnv() {
   const privateKey = generateKeyPairSync("rsa", { modulusLength: 2048 })
@@ -49,6 +55,7 @@ function mockJsonResponse(body: unknown) {
 }
 
 function mockGitHubApi(options?: {
+  installationPermissions?: Record<string, string>;
   token?: string;
   onRequest?: (url: string, init?: RequestInit) => void;
 }) {
@@ -66,6 +73,16 @@ function mockGitHubApi(options?: {
       return mockJsonResponse({
         token,
         expires_at: "2099-01-01T00:00:00Z",
+      });
+    }
+    if (url.includes("/app/installations/42")) {
+      return mockJsonResponse({
+        permissions: options?.installationPermissions ?? {
+          contents: "write",
+          issues: "write",
+          metadata: "read",
+          pull_requests: "write",
+        },
       });
     }
     throw new Error(`Unexpected fetch request: ${url}`);
@@ -93,6 +110,7 @@ describe("github app credential broker", () => {
 
     const broker = createGitHubAppBroker(TEST_MANIFEST, TEST_CREDENTIALS);
     const lease = await broker.issue({
+      context: USER_CREDENTIAL_CONTEXT,
       reason: "test:lease-shape",
     });
 
@@ -128,6 +146,7 @@ describe("github app credential broker", () => {
       authTokenPlaceholder: "github_host_managed_credential",
     });
     const lease = await broker.issue({
+      context: USER_CREDENTIAL_CONTEXT,
       reason: "test:custom-placeholder",
     });
 
@@ -150,6 +169,7 @@ describe("github app credential broker", () => {
       credentials,
     );
     const lease = await broker.issue({
+      context: USER_CREDENTIAL_CONTEXT,
       reason: "test:configured-domains",
     });
 
@@ -186,6 +206,7 @@ describe("github app credential broker", () => {
       credentials,
     );
     const lease = await broker.issue({
+      context: USER_CREDENTIAL_CONTEXT,
       reason: "test:service-domains",
     });
 
@@ -223,6 +244,7 @@ describe("github app credential broker", () => {
       credentials,
     );
     const lease = await broker.issue({
+      context: USER_CREDENTIAL_CONTEXT,
       reason: "test:reordered-domains",
     });
 
@@ -264,9 +286,11 @@ describe("github app credential broker", () => {
 
     const broker = createGitHubAppBroker(TEST_MANIFEST, TEST_CREDENTIALS);
     const firstLease = await broker.issue({
+      context: USER_CREDENTIAL_CONTEXT,
       reason: "test:first-token",
     });
     const secondLease = await broker.issue({
+      context: USER_CREDENTIAL_CONTEXT,
       reason: "test:second-token",
     });
 
@@ -290,6 +314,7 @@ describe("github app credential broker", () => {
 
     const broker = createGitHubAppBroker(TEST_MANIFEST, TEST_CREDENTIALS);
     await broker.issue({
+      context: USER_CREDENTIAL_CONTEXT,
       reason: "test:permissions",
     });
 
@@ -309,11 +334,119 @@ describe("github app credential broker", () => {
     };
     const broker = createGitHubAppBroker(manifestWithCaps, TEST_CREDENTIALS);
     await broker.issue({
+      context: USER_CREDENTIAL_CONTEXT,
       reason: "test:scoped-permissions",
     });
 
     const fetchCall = findAccessTokenCall();
     const body = JSON.parse(fetchCall[1]?.body as string);
     expect(body.permissions).toEqual({ issues: "write" });
+  });
+
+  it("downgrades GitHub App installation permissions for system actors", async () => {
+    setupValidEnv();
+    mockGitHubApi({
+      installationPermissions: {
+        actions: "write",
+        administration: "write",
+        checks: "write",
+        contents: "write",
+        issues: "write",
+        metadata: "read",
+        pull_requests: "write",
+        secrets: "write",
+        security_events: "write",
+        statuses: "write",
+        unknown_preview_permission: "write",
+      },
+    });
+
+    const broker = createGitHubAppBroker(TEST_MANIFEST, TEST_CREDENTIALS);
+    await broker.issue({
+      context: SYSTEM_CREDENTIAL_CONTEXT,
+      reason: "test:system-read-only",
+    });
+
+    const calls = vi.mocked(globalThis.fetch).mock.calls;
+    expect(String(calls[0]?.[0])).toBe(
+      "https://api.github.com/app/installations/42",
+    );
+    const accessTokenCall = findAccessTokenCall();
+    const body = JSON.parse(accessTokenCall[1]?.body as string);
+    expect(body.permissions).toEqual({
+      actions: "read",
+      checks: "read",
+      contents: "read",
+      issues: "read",
+      metadata: "read",
+      pull_requests: "read",
+      statuses: "read",
+    });
+  });
+
+  it("does not use manifest capabilities as the system permission override", async () => {
+    setupValidEnv();
+    mockGitHubApi({
+      installationPermissions: {
+        contents: "write",
+        deployments: "write",
+        issues: "write",
+        metadata: "read",
+      },
+    });
+
+    const manifestWithCaps: PluginManifest = {
+      ...TEST_MANIFEST,
+      capabilities: ["github.deployments.write"],
+    };
+    const broker = createGitHubAppBroker(manifestWithCaps, TEST_CREDENTIALS);
+    await broker.issue({
+      context: SYSTEM_CREDENTIAL_CONTEXT,
+      reason: "test:system-default-permissions",
+    });
+
+    const calls = vi.mocked(globalThis.fetch).mock.calls;
+    expect(String(calls[0]?.[0])).toBe(
+      "https://api.github.com/app/installations/42",
+    );
+    const fetchCall = findAccessTokenCall();
+    const body = JSON.parse(fetchCall[1]?.body as string);
+    expect(body.permissions).toEqual({
+      contents: "read",
+      issues: "read",
+      metadata: "read",
+    });
+  });
+
+  it("uses configured system read permissions as the system permission override", async () => {
+    setupValidEnv();
+    mockGitHubApi();
+    const credentials: GitHubAppCredentials = {
+      ...TEST_CREDENTIALS,
+      systemReadPermissions: ["deployments", "pull-requests"],
+    };
+    const manifestWithCaps: PluginManifest = {
+      ...TEST_MANIFEST,
+      capabilities: ["github.secrets.write"],
+      credentials,
+    };
+
+    const broker = createGitHubAppBroker(manifestWithCaps, credentials);
+    await broker.issue({
+      context: SYSTEM_CREDENTIAL_CONTEXT,
+      reason: "test:system-configured-permissions",
+    });
+
+    const calls = vi.mocked(globalThis.fetch).mock.calls;
+    expect(calls.map((call) => String(call[0]))).not.toContain(
+      "https://api.github.com/app/installations/42",
+    );
+    const fetchCall = findAccessTokenCall();
+    const body = JSON.parse(fetchCall[1]?.body as string);
+    expect(body.permissions).toEqual({
+      deployments: "read",
+      metadata: "read",
+      pull_requests: "read",
+    });
   });
 });

--- a/packages/junior/tests/unit/plugins/plugin-manifest-config.test.ts
+++ b/packages/junior/tests/unit/plugins/plugin-manifest-config.test.ts
@@ -41,6 +41,63 @@ describe("plugin manifest config", () => {
     expect(manifest.oauth?.scope).toBe("repo read:org workflow");
   });
 
+  it("overrides GitHub App system read permissions through manifest config", () => {
+    const manifest = parsePluginManifest(
+      [
+        "name: github",
+        "description: GitHub",
+        "credentials:",
+        "  type: github-app",
+        "  domains:",
+        "    - api.github.com",
+        "  auth-token-env: GITHUB_TOKEN",
+        "  app-id-env: GITHUB_APP_ID",
+        "  private-key-env: GITHUB_APP_PRIVATE_KEY",
+        "  installation-id-env: GITHUB_INSTALLATION_ID",
+      ].join("\n"),
+      "/plugins/github",
+      {
+        manifests: {
+          github: {
+            credentials: {
+              systemReadPermissions: ["contents", "pull-requests"],
+            },
+          },
+        },
+      },
+    );
+
+    expect(
+      manifest.credentials?.type === "github-app"
+        ? manifest.credentials.systemReadPermissions
+        : undefined,
+    ).toEqual(["contents", "pull_requests"]);
+  });
+
+  it("rejects invalid GitHub App system read permissions during manifest parsing", () => {
+    expect(() =>
+      parsePluginManifest(
+        [
+          "name: github",
+          "description: GitHub",
+          "credentials:",
+          "  type: github-app",
+          "  domains:",
+          "    - api.github.com",
+          "  auth-token-env: GITHUB_TOKEN",
+          "  app-id-env: GITHUB_APP_ID",
+          "  private-key-env: GITHUB_APP_PRIVATE_KEY",
+          "  installation-id-env: GITHUB_INSTALLATION_ID",
+          "  system-read-permissions:",
+          "    - typo-scope",
+        ].join("\n"),
+        "/plugins/github",
+      ),
+    ).toThrow(
+      'Plugin github credentials.system-read-permissions contains unsupported scope "typo-scope"',
+    );
+  });
+
   it("removes optional map entries with null config values", () => {
     const manifest = parsePluginManifest(
       [

--- a/packages/junior/tests/unit/plugins/sentry-broker.test.ts
+++ b/packages/junior/tests/unit/plugins/sentry-broker.test.ts
@@ -13,6 +13,12 @@ import type {
 const ORIGINAL_ENV = { ...process.env };
 const ORIGINAL_FETCH = globalThis.fetch;
 const SENTRY_SCOPE = "event:read org:read project:read team:read";
+const USER_CREDENTIAL_CONTEXT = {
+  actor: { type: "user" as const, userId: "U123" },
+};
+const SYSTEM_CREDENTIAL_CONTEXT = {
+  actor: { type: "system" as const, id: "scheduler" },
+};
 
 const SENTRY_MANIFEST: PluginManifest = {
   name: "sentry",
@@ -81,8 +87,8 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
 
     const broker = createBroker(tokenStore);
     const lease = await broker.issue({
+      context: USER_CREDENTIAL_CONTEXT,
       reason: "test:oauth",
-      requesterId: "U123",
     });
 
     expect(lease.provider).toBe("sentry");
@@ -103,6 +109,7 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
     process.env.SENTRY_AUTH_TOKEN = "static-env-token";
     const broker = createBroker();
     const lease = await broker.issue({
+      context: SYSTEM_CREDENTIAL_CONTEXT,
       reason: "test:env-fallback",
     });
 
@@ -138,6 +145,7 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
       { userTokenStore: createMockTokenStore() },
     );
     const lease = await broker.issue({
+      context: SYSTEM_CREDENTIAL_CONTEXT,
       reason: "test:plugin-api-headers",
     });
 
@@ -169,6 +177,7 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
 
     await expect(
       broker.issue({
+        context: SYSTEM_CREDENTIAL_CONTEXT,
         reason: "test:unavailable",
       }),
     ).rejects.toThrow(CredentialUnavailableError);
@@ -198,8 +207,8 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
 
     const broker = createBroker(tokenStore);
     const lease = await broker.issue({
+      context: USER_CREDENTIAL_CONTEXT,
       reason: "test:refresh",
-      requesterId: "U123",
     });
 
     expect(lease.headerTransforms).toEqual([
@@ -231,9 +240,44 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
     const broker = createBroker(tokenStore);
     await expect(
       broker.issue({
+        context: USER_CREDENTIAL_CONTEXT,
         reason: "test:scope-mismatch",
-        requesterId: "U123",
       }),
     ).rejects.toThrow(CredentialUnavailableError);
+  });
+
+  it("uses a delegated user subject for OAuth lookup under a system actor", async () => {
+    const tokenStore = createMockTokenStore({
+      "U123:sentry": {
+        accessToken: "delegated-access-token",
+        refreshToken: "delegated-refresh-token",
+        expiresAt: Date.now() + 60 * 60 * 1000,
+        scope: SENTRY_SCOPE,
+      },
+    });
+
+    const broker = createBroker(tokenStore);
+    const lease = await broker.issue({
+      context: {
+        actor: { type: "system", id: "scheduler" },
+        subject: {
+          type: "user",
+          userId: "U123",
+          allowedWhen: "private-direct-conversation",
+        },
+      },
+      reason: "test:delegated-subject",
+    });
+
+    expect(lease.headerTransforms).toEqual([
+      {
+        domain: "us.sentry.io",
+        headers: { Authorization: "Bearer delegated-access-token" },
+      },
+      {
+        domain: "de.sentry.io",
+        headers: { Authorization: "Bearer delegated-access-token" },
+      },
+    ]);
   });
 });

--- a/packages/junior/tests/unit/runtime/respond-lazy-sandbox.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-lazy-sandbox.test.ts
@@ -371,68 +371,118 @@ vi.mock("@/chat/sandbox/sandbox", () => ({
       sandboxId: string;
       sandboxDependencyProfileHash?: string;
     }) => void | Promise<void>;
-  }) => ({
-    configureSkills: () => undefined,
-    configureReferenceFiles: () => undefined,
-    createSandbox: async () => {
-      createSandboxCallCount.value += 1;
-      const sandboxVersion = activeSandboxVersion.value;
-      if (
-        agentMode.value === "attachFileBashRaceAttachFile" &&
-        createSandboxCallCount.value === 1
-      ) {
-        await new Promise<void>((resolve) => {
-          pendingWorkspaceRelease.value = resolve;
+  }) => {
+    return {
+      configureSkills: () => undefined,
+      configureReferenceFiles: () => undefined,
+      createSandbox: async () => {
+        createSandboxCallCount.value += 1;
+        const sandboxVersion = activeSandboxVersion.value;
+        if (
+          agentMode.value === "attachFileBashRaceAttachFile" &&
+          createSandboxCallCount.value === 1
+        ) {
+          await new Promise<void>((resolve) => {
+            pendingWorkspaceRelease.value = resolve;
+          });
+          pendingWorkspaceRelease.value = undefined;
+        }
+        await options?.onSandboxAcquired?.({
+          sandboxId:
+            sandboxVersion === 1
+              ? "sandbox-test"
+              : `sandbox-test-${sandboxVersion}`,
+          sandboxDependencyProfileHash: "hash-test",
         });
-        pendingWorkspaceRelease.value = undefined;
-      }
-      await options?.onSandboxAcquired?.({
-        sandboxId:
-          sandboxVersion === 1
-            ? "sandbox-test"
-            : `sandbox-test-${sandboxVersion}`,
-        sandboxDependencyProfileHash: "hash-test",
-      });
-      return {
-        sandboxId:
-          sandboxVersion === 1
-            ? "sandbox-test"
-            : `sandbox-test-${sandboxVersion}`,
-        readFileToBuffer: async () => {
-          attachFileReadVersions.value.push(sandboxVersion);
-          return Buffer.from(
-            [
-              "---",
-              "name: demo-skill",
-              "description: Demo skill",
-              "---",
-              "",
-              "Skill instructions",
-            ].join("\n"),
-            "utf8",
+        return {
+          sandboxId:
+            sandboxVersion === 1
+              ? "sandbox-test"
+              : `sandbox-test-${sandboxVersion}`,
+          readFileToBuffer: async () => {
+            attachFileReadVersions.value.push(sandboxVersion);
+            return Buffer.from(
+              [
+                "---",
+                "name: demo-skill",
+                "description: Demo skill",
+                "---",
+                "",
+                "Skill instructions",
+              ].join("\n"),
+              "utf8",
+            );
+          },
+          runCommand: async () => ({
+            exitCode: 0,
+            stdout: async () => "text/plain\n",
+            stderr: async () => "",
+          }),
+        };
+      },
+      canExecute: (toolName: string) =>
+        (agentMode.value === "bashThenError" ||
+          agentMode.value === "attachFileBashRecoverAttachFile" ||
+          agentMode.value === "attachFileBashRaceAttachFile") &&
+        toolName === "bash",
+      execute: async ({ toolName }: { toolName: string; input: unknown }) => {
+        if (toolName !== "bash") {
+          throw new Error(
+            "sandbox executor should not handle tools in this test",
           );
-        },
-        runCommand: async () => ({
-          exitCode: 0,
-          stdout: async () => "text/plain\n",
-          stderr: async () => "",
-        }),
-      };
-    },
-    canExecute: (toolName: string) =>
-      (agentMode.value === "bashThenError" ||
-        agentMode.value === "attachFileBashRecoverAttachFile" ||
-        agentMode.value === "attachFileBashRaceAttachFile") &&
-      toolName === "bash",
-    execute: async ({ toolName }: { toolName: string; input: unknown }) => {
-      if (toolName !== "bash") {
-        throw new Error(
-          "sandbox executor should not handle tools in this test",
-        );
-      }
+        }
 
-      if (agentMode.value === "attachFileBashRecoverAttachFile") {
-        activeSandboxVersion.value += 1;
+        if (agentMode.value === "attachFileBashRecoverAttachFile") {
+          activeSandboxVersion.value += 1;
+          return {
+            result: {
+              ok: true,
+              command: "pwd",
+              cwd: "/workspace",
+              exit_code: 0,
+              signal: null,
+              timed_out: false,
+              stdout: "/workspace\n",
+              stderr: "",
+              stdout_truncated: false,
+              stderr_truncated: false,
+            },
+          };
+        }
+
+        if (agentMode.value === "attachFileBashRaceAttachFile") {
+          activeSandboxVersion.value += 1;
+          pendingWorkspaceRelease.value?.();
+          return {
+            result: {
+              ok: true,
+              command: "pwd",
+              cwd: "/workspace",
+              exit_code: 0,
+              signal: null,
+              timed_out: false,
+              stdout: "/workspace\n",
+              stderr: "",
+              stdout_truncated: false,
+              stderr_truncated: false,
+            },
+          };
+        }
+
+        if (agentMode.value !== "bashThenError") {
+          throw new Error(
+            "sandbox executor should not handle tools in this test",
+          );
+        }
+
+        createSandboxCallCount.value += 1;
+        await options?.onSandboxAcquired?.({
+          sandboxId:
+            activeSandboxVersion.value === 1
+              ? "sandbox-test"
+              : `sandbox-test-${activeSandboxVersion.value}`,
+          sandboxDependencyProfileHash: "hash-test",
+        });
         return {
           result: {
             ok: true,
@@ -447,65 +497,17 @@ vi.mock("@/chat/sandbox/sandbox", () => ({
             stderr_truncated: false,
           },
         };
-      }
-
-      if (agentMode.value === "attachFileBashRaceAttachFile") {
-        activeSandboxVersion.value += 1;
-        pendingWorkspaceRelease.value?.();
-        return {
-          result: {
-            ok: true,
-            command: "pwd",
-            cwd: "/workspace",
-            exit_code: 0,
-            signal: null,
-            timed_out: false,
-            stdout: "/workspace\n",
-            stderr: "",
-            stdout_truncated: false,
-            stderr_truncated: false,
-          },
-        };
-      }
-
-      if (agentMode.value !== "bashThenError") {
-        throw new Error(
-          "sandbox executor should not handle tools in this test",
-        );
-      }
-
-      createSandboxCallCount.value += 1;
-      await options?.onSandboxAcquired?.({
-        sandboxId:
-          activeSandboxVersion.value === 1
+      },
+      getSandboxId: () =>
+        createSandboxCallCount.value > 0
+          ? activeSandboxVersion.value === 1
             ? "sandbox-test"
-            : `sandbox-test-${activeSandboxVersion.value}`,
-        sandboxDependencyProfileHash: "hash-test",
-      });
-      return {
-        result: {
-          ok: true,
-          command: "pwd",
-          cwd: "/workspace",
-          exit_code: 0,
-          signal: null,
-          timed_out: false,
-          stdout: "/workspace\n",
-          stderr: "",
-          stdout_truncated: false,
-          stderr_truncated: false,
-        },
-      };
-    },
-    getSandboxId: () =>
-      createSandboxCallCount.value > 0
-        ? activeSandboxVersion.value === 1
-          ? "sandbox-test"
-          : `sandbox-test-${activeSandboxVersion.value}`
-        : undefined,
-    getDependencyProfileHash: () => "hash-test",
-    dispose: async () => undefined,
-  }),
+            : `sandbox-test-${activeSandboxVersion.value}`
+          : undefined,
+      getDependencyProfileHash: () => "hash-test",
+      dispose: async () => undefined,
+    };
+  },
 }));
 
 import { generateAssistantReply } from "@/chat/respond";

--- a/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
@@ -93,6 +93,9 @@ function makeReplyContext(args: {
   turnId: string;
 }) {
   return {
+    credentialContext: {
+      actor: { type: "user" as const, userId: "U123" },
+    },
     requester: { userId: "U123" },
     correlation: {
       channelId: "C123",
@@ -1078,6 +1081,9 @@ describe("generateAssistantReply progressive MCP loading", () => {
       });
 
     const context = {
+      credentialContext: {
+        actor: { type: "user" as const, userId: "U123" },
+      },
       requester: { userId: "U123" },
       correlation: {
         conversationId: "conversation-3",
@@ -1160,6 +1166,9 @@ describe("generateAssistantReply progressive MCP loading", () => {
     });
 
     const firstError = await generateAssistantReply("help me", {
+      credentialContext: {
+        actor: { type: "user", userId: "U123" },
+      },
       requester: { userId: "U123" },
       correlation: {
         conversationId: "conversation-5",
@@ -1188,6 +1197,9 @@ describe("generateAssistantReply progressive MCP loading", () => {
     completeEmptyAssistantOnAbort.value = true;
 
     const firstError = await generateAssistantReply("help me", {
+      credentialContext: {
+        actor: { type: "user", userId: "U123" },
+      },
       requester: { userId: "U123" },
       correlation: {
         conversationId: "conversation-6",

--- a/specs/credential-injection.md
+++ b/specs/credential-injection.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-02-26
-- Last Edited: 2026-05-28
+- Last Edited: 2026-06-03
 
 ## Related
 
@@ -20,7 +20,7 @@ Define how Junior maps registered plugin provider domains to host-managed creden
 1. Plugin manifests own provider domains, credentials, command env, OAuth config, and runtime setup. See [Plugin Architecture Spec](./plugin.md).
 2. Skills do not declare capabilities, config keys, credentials, provider domains, or runtime setup.
 3. The agent runs the real provider command. Runtime authentication is implicit and host-owned.
-4. The runtime resolves the provider from the outgoing request host, lazily issues a requester-bound provider lease, and applies credential headers to that forwarded request.
+4. The runtime resolves the provider from the outgoing request host, lazily issues a credential-context-bound provider lease, and applies credential headers to that forwarded request.
 5. If auth is missing or stale, the proxy returns a command-readable auth-required response and the command failure path starts a private OAuth flow, then resumes the paused turn after authorization.
 
 ## Runtime contract
@@ -28,9 +28,13 @@ Define how Junior maps registered plugin provider domains to host-managed creden
 ### Lease issuance
 
 - Resolve provider from the Vercel Sandbox forwarded host for proxied sandbox egress.
-- Require requester context before issuing provider credentials.
+- Require a signed credential context before issuing provider credentials. The context has a current execution actor and may carry an explicit user credential subject.
+- Agent reply callers pass credential context explicitly. Requester and correlation metadata are not credential inputs.
+- The current actor controls provider permission envelopes. A user credential subject only identifies which stored user OAuth token may be used.
+- System actors may carry an explicit user credential subject only from a runtime boundary that verified the subject for that action, such as trusted dispatch verifying Slack one-to-one DM ownership before storing the subject.
+- User-owned OAuth credentials require either a current user actor or an explicit user credential subject. System actors without a user subject may use only provider credentials that are explicitly service-principal or install-owned, such as GitHub App installation credentials or static operator env credentials.
 - Return short-lived leases only.
-- Keep any host-side egress lease cache bounded by the signed requester/sandbox context expiry and lease expiry.
+- Keep any host-side egress lease cache bounded by the signed credential/sandbox context expiry and lease expiry.
 
 ### Injection behavior
 
@@ -45,18 +49,18 @@ Define how Junior maps registered plugin provider domains to host-managed creden
 ### Sandbox egress proxy
 
 - New sandbox sessions use a Vercel Sandbox network policy that forwards declared credential provider domains to Junior's internal egress handler.
-- The runtime configures the forwarding URL with a signed requester context bound to the sandbox VM session so the proxy can mint per-user OAuth leases lazily without a state-store lookup.
-- The internal egress handler must verify the Vercel Sandbox OIDC token and signed requester/sandbox context before proxying.
+- The runtime configures the forwarding URL with a signed credential context bound to the sandbox VM session so the proxy can mint provider leases lazily without a state-store lookup.
+- The internal egress handler must verify the Vercel Sandbox OIDC token and signed credential/sandbox context before proxying.
 - The egress route must reconstruct the upstream URL only from Vercel forwarded host/scheme/port/path headers. The proxy route URL contains Junior routing state and must not be used as the upstream path.
 - The egress route must reject forwarded hosts that do not match a registered provider domain.
 - The proxy must not use method/URL/body-only replay fingerprints as an authorization boundary because duplicate request shapes can be legitimate client retries.
 - The proxy must strip hop-by-hop and proxy-control headers before sending the upstream request.
-- Sandbox-supplied request headers and upstream response state may pass through once Vercel OIDC, requester context, and provider-domain ownership have been verified.
+- Sandbox-supplied request headers and upstream response state may pass through once Vercel OIDC, credential context, and provider-domain ownership have been verified.
 
 ### Security goals
 
 - Secrets are hidden from the model and sandbox filesystem.
-- Credentials are requester-bound.
+- Credentials are credential-context-bound.
 - Leases are valid only for the active turn.
 - Provider defaults may guide command construction, but credential availability is still provider-level and turn-bound.
 
@@ -65,7 +69,8 @@ Define how Junior maps registered plugin provider domains to host-managed creden
 ### Permission model
 
 - Plugin manifest capabilities map to GitHub App installation permissions.
-- Runtime requests the full permission set declared by the GitHub plugin manifest.
+- Runtime requests the full permission set declared by the GitHub plugin manifest for user actors.
+- GitHub App `credentials.system-read-permissions` declares the explicit read-only permission envelope for system actors when configured. These scope names are normalized to GitHub API permission names during plugin load and may use dashes in manifest YAML for readability.
 - Repo context is still important for command correctness, but credential issuance is provider-level and turn-bound.
 
 ### Lease behavior
@@ -75,6 +80,9 @@ Define how Junior maps registered plugin provider domains to host-managed creden
 - The built-in GitHub plugin declares `api.github.com` for REST API calls and
   `github.com` for git smart-HTTP.
 - Runtime may reuse a short-lived sandbox egress lease for repeated GitHub commands in the same turn.
+- When a GitHub App lease is issued for a system actor, runtime must send an explicit read-only permissions body instead of inheriting the installation's default permissions.
+- If GitHub App `credentials.system-read-permissions` is declared, runtime requests only those scopes plus `metadata`, all at `read`.
+- If no system read permissions are declared, runtime reads the installation permission envelope and requests only the safe default read subset that the installation actually has: `metadata`, `contents`, `issues`, `pull_requests`, `checks`, `statuses`, and `actions`.
 - Provider `401`/`403` responses discard the cached sandbox egress lease so resumed auth can mint from current provider state.
 
 ## Sentry profile
@@ -86,7 +94,7 @@ Define how Junior maps registered plugin provider domains to host-managed creden
 
 ### OAuth behavior
 
-- `OAuthBearerBroker` checks for a per-user OAuth token stored by requester ID.
+- `OAuthBearerBroker` checks for a per-user OAuth token stored by the credential user subject ID, which is the current user actor or an explicit delegated user subject.
 - If the token is near expiry, runtime refreshes it server-side.
 - Missing or stale auth triggers the private OAuth resume flow defined in the OAuth Flows Spec.
 

--- a/specs/oauth-flows.md
+++ b/specs/oauth-flows.md
@@ -50,7 +50,7 @@ Agent: loads the matching plugin skill and runs the real provider command
   │
   ├─ Runtime resolves provider from the proxied sandbox request host
   ├─ Runtime keeps any provider defaults (for example a repo config) available for command construction
-  ├─ Broker checks requester-bound stored tokens
+  ├─ Broker checks stored user OAuth tokens
   ├─ If auth is missing or stale:
   │    • runtime creates OAuth state
   │    • runtime privately delivers the authorization link
@@ -112,7 +112,7 @@ After a user has connected their account:
 
 1. Agent runs an authenticated provider command.
 2. Runtime resolves the provider from the proxied sandbox request host.
-3. Broker loads stored requester-bound tokens.
+3. Broker loads stored user OAuth tokens for the credential context.
 4. If the token is near expiry, broker refreshes it server-side.
 5. Broker returns a short-lived `CredentialLease`.
 6. Runtime injects provider headers at the sandbox egress proxy boundary and exposes only declared sandbox command env or placeholder values inside the sandbox.
@@ -196,7 +196,7 @@ Providers define OAuth through plugin manifests:
 - The runtime must not post the authorization URL into the public thread. Slack-thread acknowledgements for auth pauses must stay URL-free and only say that authorization is needed and the private link was sent.
 - Authorization URLs are never returned to the model.
 - Tokens are stored server-side and never appear in sandbox files or model-visible tool arguments.
-- Leases are requester-bound; sandbox egress leases are issued lazily when forwarded provider traffic needs them and are scoped to the signed requester/sandbox context plus lease expiry.
+- Leases are credential-context-bound; sandbox egress leases are issued lazily when forwarded provider traffic needs them and are scoped to the signed credential/sandbox context plus lease expiry.
 - Target-aware providers may narrow leases only from explicit provider/request context, not guessed command intent.
 
 ## Disconnect behavior

--- a/specs/plugin-manifest.md
+++ b/specs/plugin-manifest.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-05-28
-- Last Edited: 2026-05-28
+- Last Edited: 2026-06-03
 
 ## Purpose
 
@@ -74,8 +74,9 @@ target:
 - `api-headers`: headers injected for matching `domains`. Secret values must come from `${NAME}` placeholders declared in `env-vars` without defaults.
 - `credentials.type`: `"oauth-bearer"` or `"github-app"`.
 - `credentials.domains`: domains that receive runtime-managed credential headers. Include every host that needs credentials, such as both `api.github.com` and `github.com` for GitHub App git HTTPS auth.
-- `credentials.auth-token-env`: host env var for static token fallback outside requester-bound turns and for sandbox placeholder naming.
+- `credentials.auth-token-env`: host env var for static token fallback outside credential-context-bound turns and for sandbox placeholder naming.
 - `credentials.auth-token-placeholder`: optional non-secret sandbox env value for CLI compatibility.
+- `credentials.system-read-permissions`: optional GitHub App-only list of read scopes for system actors. Manifest entries may use dashes for readability and are normalized to GitHub API permission names at load. If omitted, the broker derives a safe read-only subset from the installation permissions.
 - `oauth`: required for OAuth bearer providers. Endpoints must be HTTPS.
 - `target.config-key`: must appear in `config-keys`.
 - `runtime-dependencies`: optional sandbox dependencies. `type` is `"npm"` or `"system"`.

--- a/specs/plugin-runtime.md
+++ b/specs/plugin-runtime.md
@@ -54,7 +54,7 @@ createPluginBroker(provider, deps: PluginBrokerDeps): CredentialBroker
 
 `createPluginBroker(provider, deps)` constructs brokers from manifest config:
 
-- `oauth-bearer`: generic OAuth bearer broker for per-user OAuth tokens, refresh, static fallback outside requester-bound turns, command env, and header transforms.
+- `oauth-bearer`: generic OAuth bearer broker for per-user OAuth tokens, refresh, static fallback outside credential-context-bound turns, command env, and header transforms.
 - `github-app`: GitHub App broker that signs JWTs and exchanges them for short-lived installation tokens.
 - plugin-level `api-headers`: API header broker for providers that need header injection without OAuth/App credentials.
 - no credentials/no headers: provider-scoped no-credentials error when authenticated work needs that provider.
@@ -133,7 +133,7 @@ Trusted plugins may also provide `slackConversationLink` to replace the finalize
 ## Security Properties
 
 - Plugin manifests are committed YAML files, not dynamically loaded remote code.
-- Credential delivery uses host-managed headers and requester-bound leases.
+- Credential delivery uses host-managed headers and credential-context-bound leases.
 - Real secret values never enter sandbox env vars, files, command args, skill text, or model-visible tool args.
 - Plugin manifests are parsed once at startup and are not mutated at runtime.
 - Plugin prompt behavior must be local to the loaded skill or trusted tool guidance.

--- a/specs/plugin.md
+++ b/specs/plugin.md
@@ -28,7 +28,7 @@ Define the plugin model for provider integrations. Plugins package declarative r
 2. Plugin discovery is explicit. Runtime must not scan `node_modules`, `package.json` dependencies, or arbitrary filesystem paths to find plugins.
 3. `plugin.yaml` owns runtime setup: provider domains, credentials, API headers, command env, runtime dependencies, postinstall commands, OAuth, MCP endpoints, config keys, and skill roots.
 4. Skills consume plugin-provided runtime surfaces. They must not tell the agent to install CLIs, bootstrap package managers, configure credentials, repair sandbox packages, or create MCP server config.
-5. Credential delivery is host-owned and requester-bound. Real provider secrets never enter sandbox env vars, files, command args, skill text, model-visible tool args, or logs.
+5. Credential delivery is host-owned and credential-context-bound. Real provider secrets never enter sandbox env vars, files, command args, skill text, model-visible tool args, or logs.
 6. Plugin-declared MCP tools are host-managed and activated only after a skill from the same plugin is loaded or the model explicitly requests that provider through the MCP bridge tools.
 7. Trusted runtime behavior is app-code registration, not manifest registration. Apps export one runtime-safe `defineJuniorPlugins(...)` set and point `juniorNitro({ plugins: "./plugins" })` at it; `createApp()` reads the same set from Nitro's virtual module.
 8. A package uses one definition source: `plugin.yaml` for declarative plugins, or a JavaScript factory with an inline manifest for trusted plugins. Do not split one plugin definition across both.
@@ -48,7 +48,7 @@ plugins/sentry/
 
 - [Plugin Manifest Spec](./plugin-manifest.md): `plugin.yaml` fields, env-var expansion, runtime dependency declarations, and validation.
 - [Plugin Runtime Spec](./plugin-runtime.md): discovery/loading, capability catalog integration, MCP activation, plugin skills, and security invariants.
-- [Credential Injection Spec](./credential-injection.md): requester-bound provider leases and sandbox egress auth.
+- [Credential Injection Spec](./credential-injection.md): credential-context-bound provider leases and sandbox egress auth.
 - [OAuth Flows Spec](./oauth-flows.md): OAuth challenge, callback, and turn-resume behavior.
 - [Sandbox Snapshots Spec](./sandbox-snapshots.md): runtime dependency snapshot build/reuse.
 - [Trusted Plugin Heartbeat Spec](./trusted-plugin-heartbeat.md): trusted heartbeat and tool hooks.

--- a/specs/scheduler.md
+++ b/specs/scheduler.md
@@ -50,7 +50,7 @@ The original user utterance may be retained for audit/debugging, but it must not
 Slack destinations are conversations, not existing threads. A scheduled task may target the active Slack DM or channel, and scheduled output posts as a new message in that conversation.
 Each scheduled execution gets fresh dispatch-scoped conversation state. The runner must not load destination-level Slack conversation history as prior thread context for a scheduled run that is creating its own new message.
 
-The scheduler must distinguish conversation audience from visibility. A private direct conversation may use explicit user-delegated credentials for scheduled tools; a private group conversation or private channel is still multi-user and must not implicitly use one user's credentials. Unknown privacy or audience must fail closed for delegated user credentials.
+The scheduler must distinguish conversation audience from visibility. A private direct conversation may attach an explicit user credential subject for scheduled tools; that subject may satisfy stored user OAuth lookup, but the scheduled run still executes as the system actor. A private group conversation or private channel is still multi-user and must not implicitly use one user's credentials. Unknown privacy or audience must fail closed for delegated user credentials.
 
 Creator metadata records the user who confirmed the task so Junior can audit changes and privately notify someone when the task needs attention. The creator is not an owner, is not an authorization principal, and is not the actor for future scheduled runs.
 
@@ -222,6 +222,8 @@ Scheduled tasks must distinguish these V1 identities:
 Scheduled runs must not pass the creator as the runtime requester or treat the creator as if they were present and acting during the run. Audit and correlation metadata should include both the system execution actor and creator metadata. Auth decisions must use the execution actor unless the task stores an explicit credential subject allowed by the private direct conversation exception below.
 
 V1 scheduled execution has no user requester. User OAuth tokens cannot be used merely because that user created the task. Authorization flows are disabled during scheduled runs, and authorization links must not be posted publicly. If no usable system credential or explicit credential subject exists, Junior must block the run and privately notify the creator when possible.
+
+The scheduler chooses the execution actor and forwards explicit credential subjects; it does not encode provider-specific permission policy. Agent runtime and provider brokers own the credential envelope for the current actor, such as safe read-only GitHub App credentials for system actors.
 
 Exception: a scheduled task created in a private direct conversation may store an explicit credential subject for the requester who created the task. This subject is not the execution actor and does not make the creator the requester for the scheduled run. It is only an auth subject that lets credential resolution use that user's already-connected provider credentials during autonomous execution. The exception requires both:
 

--- a/specs/security-policy.md
+++ b/specs/security-policy.md
@@ -28,9 +28,9 @@ This policy applies to:
 
 - Production should use explicit network policy and minimal allowlists.
 - Credential-capable provider domains should route through the Junior sandbox egress proxy instead of receiving long-lived sandbox secrets.
-- Proxied sandbox egress requests must verify the Vercel-signed Sandbox OIDC token, use its sandbox claim as the active VM session id, resolve the provider from the Vercel forwarded host/path headers, and require a signed requester-bound context token in the forwarding route that matches the OIDC sandbox claim. Cached provider leases must be scoped to one requester/sandbox context and lease expiry.
+- Proxied sandbox egress requests must verify the Vercel-signed Sandbox OIDC token, use its sandbox claim as the active VM session id, resolve the provider from the Vercel forwarded host/path headers, and require a signed credential-context token in the forwarding route that matches the OIDC sandbox claim. Cached provider leases must be scoped to one credential/sandbox context and lease expiry.
 - The egress handler must verify Vercel Sandbox OIDC before returning configuration, provider, or session-specific responses.
-- The egress proxy must not reject duplicate method/URL/body requests as replay; duplicate request shapes can be legitimate retries. Requester-bound credential issuance is the security boundary.
+- The egress proxy must not reject duplicate method/URL/body requests as replay; duplicate request shapes can be legitimate retries. Credential-context-bound issuance is the security boundary.
 
 ### Harness-owned tool targeting
 
@@ -53,7 +53,7 @@ This policy applies to:
 - Runtime issues short-lived provider credentials when sandbox traffic reaches a registered provider domain.
 - Registered plugin provider declarations determine which provider credentials may be injected for matching forwarded provider domains.
 - A registered provider authorizes its declared domains for sandbox egress; registration must not mint credentials by itself.
-- Credential issuance for user-owned provider access must be requester-bound; runtime paths without requester context must fail instead of issuing reusable credentials.
+- Credential issuance for user-owned provider access must be bound to a credential context with a user actor or explicit user subject; runtime paths without credential context must fail instead of issuing reusable credentials.
 - Even for host-managed integrations, sandbox credentials are issued lazily only when a sandbox request reaches a declared provider domain. The runtime must not pre-provision provider credentials merely because a plugin is loaded or a command might need auth.
 - Real provider secrets are delivered exclusively via host-level header transforms — the host proxies auth headers for matching provider domains (e.g. `Authorization` for `api.github.com`/`us.sentry.io` or provider-specific API key headers). The sandbox never sees real secret values.
 - When CLI tools require tool-native sandbox auth env vars (for example `SENTRY_AUTH_TOKEN`, Pup's `DD_API_KEY`, or Pup's `DD_APP_KEY`), set them to non-secret placeholders so the tool proceeds to make HTTP requests. Placeholder values may be provider-specific via plugin manifest config. The host authenticates those requests via header transforms.
@@ -66,6 +66,7 @@ This policy applies to:
 - Keep `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY` on host only.
 - Sign App JWT on host, then exchange for installation token.
 - Require `GITHUB_INSTALLATION_ID` for deterministic installation selection.
+- For system actors, request an explicit read-only installation-token permission body. Use GitHub App `credentials.system-read-permissions` when configured, otherwise derive the safe default read subset from the installation permissions.
 - Configure `GITHUB_APP_BOT_NAME` and `GITHUB_APP_BOT_EMAIL` as host env vars.
   They are public git author metadata, not credentials.
 - Declare both `api.github.com` and `github.com` in the GitHub plugin manifest
@@ -94,7 +95,7 @@ This policy applies to:
 - Keep `SENTRY_CLIENT_SECRET` on host only.
 - Token exchange and storage happen server-side in the OAuth callback handler — the agent never sees token values.
 - Refresh tokens on host, deliver short-lived access tokens via header transforms.
-- Fall back to static `SENTRY_AUTH_TOKEN` env var only for local/dev/test paths outside requester-bound turn execution.
+- Fall back to static `SENTRY_AUTH_TOKEN` env var only for local/dev/test paths outside credential-context-bound turn execution.
 - Inject `Authorization` header transforms for Sentry region API domains such as `us.sentry.io` and `de.sentry.io`.
 - Set `SENTRY_AUTH_TOKEN` in lease env to a placeholder — real token never enters the sandbox.
 - See [OAuth Flows Spec](./oauth-flows.md) for full flow details.

--- a/specs/trusted-plugin-dispatch.md
+++ b/specs/trusted-plugin-dispatch.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-05-28
-- Last Edited: 2026-05-31
+- Last Edited: 2026-06-03
 
 ## Purpose
 
@@ -47,6 +47,11 @@ Argument shape:
 ```ts
 type DispatchOptions = {
   idempotencyKey: string;
+  credentialSubject?: {
+    type: "user";
+    userId: string;
+    allowedWhen: "private-direct-conversation";
+  };
   destination: {
     platform: "slack";
     teamId: string;
@@ -101,7 +106,8 @@ type Dispatch = {
 - Destination uses a Slack channel id; it must not accept a user id.
 - Input is plain text inserted as user-role synthetic conversation content.
 - Metadata is correlation-only and must not affect authorization.
-- System dispatches have no requester, no user OAuth token access, and no interactive auth continuation.
+- System dispatches have no requester, no implicit creator-derived user OAuth token access, and no interactive auth continuation. The runtime may expose service-principal or install-owned provider credentials according to the system actor's credential envelope. If a dispatch carries an explicit user credential subject, brokers may use it only for stored user OAuth lookup; provider brokers must not treat creator metadata or credential subjects as the current actor.
+- Explicit user credential subjects are accepted only for Slack one-to-one DM destinations. Before persisting the dispatch record, core must verify through Slack conversation metadata that `destination.channelId` is an IM whose owner is `credentialSubject.userId`; channel-id prefixes and scheduler stored creation context are not sufficient authority.
 - Schedule-management tools are unavailable during system dispatches.
 
 Core derives and enforces system actor identity, auth mode, conversation identity, callback scheduling, timeout continuation, sandbox state persistence, delivery behavior, tool policy, logging, tracing, and redaction.


### PR DESCRIPTION
System-owned Junior runs can now perform normal GitHub lookups through the GitHub App without pretending to be the user who scheduled or created the work. This lets scheduler and trusted-plugin dispatches read repo, code, issue, PR, and check data with an explicitly read-only app token, while writes and commits still require a real current user actor.

**Junior Runtime Impact**

Scheduled and trusted-plugin agent runs now execute as `system` actors and can still receive host-managed GitHub App credentials for read-only lookup. They no longer inherit creator or requester identity for credential decisions, so a scheduled run can inspect GitHub state without gaining user OAuth access or write authority.

**Permission Boundary**

For system actors, GitHub App token creation always sends a read-only permission body. Plugins may set `credentials.system-read-permissions`; otherwise Junior derives a safe read subset from the installation permissions: `metadata`, `contents`, `issues`, `pull_requests`, `checks`, `statuses`, and `actions`. User actor tokens still use manifest capabilities, including write permissions when declared.

**Credential Context Contract**

Agent reply callers now pass `credentialContext` directly. `requester` is still available for prompt and Slack UX, and `correlation` is still telemetry/session metadata, but neither is used to decide credential authority. OAuth-backed providers can use the current user actor or an explicit delegated user subject from a private direct conversation; actorless system runs without that subject cannot borrow user OAuth tokens.

Refs #449