### PR TITLE
fix(config): Use GPT web search default

### DIFF
--- a/packages/docs/src/content/docs/reference/config-and-env.md
+++ b/packages/docs/src/content/docs/reference/config-and-env.md
@@ -22,7 +22,7 @@ related:
 | `AI_MODEL`                                  | No          | Primary model selection override for main assistant turns. Defaults to `openai/gpt-5.4`; Junior chooses the reasoning effort per turn automatically.  |
 | `AI_FAST_MODEL`                             | No          | Faster model for lightweight tasks and routing/classification passes before the main turn begins. Defaults to `openai/gpt-5.4-mini`.                  |
 | `AI_VISION_MODEL`                           | No          | Dedicated image-understanding model; unset disables vision features.                                                                                  |
-| `AI_WEB_SEARCH_MODEL`                       | No          | Override for the `webSearch` tool model. Defaults to a search-tuned model; does not fall through to `AI_MODEL`.                                       |
+| `AI_WEB_SEARCH_MODEL`                       | No          | Override for the `webSearch` tool model. Defaults to `openai/gpt-5.4`; does not fall through to `AI_MODEL`.                                           |
 | `JUNIOR_BASE_URL`                           | No          | Canonical base URL for callback/auth URL generation.                                                                                                  |
 | `JUNIOR_STATE_KEY_PREFIX`                   | No          | Optional namespace prepended to all state-adapter keys, locks, and queues. Use separate prefixes when sharing one Redis database across environments. |
 | `CRON_SECRET` or `JUNIOR_SCHEDULER_SECRET`  | Conditional | Bearer token for the internal heartbeat route; use `CRON_SECRET` with Vercel Cron, or `JUNIOR_SCHEDULER_SECRET` for a non-Vercel heartbeat caller.    |

--- a/packages/junior/src/chat/tools/web/search.ts
+++ b/packages/junior/src/chat/tools/web/search.ts
@@ -1,6 +1,7 @@
 import { tool } from "@/chat/tools/definition";
 import { generateText } from "ai";
 import { createGatewayProvider } from "@ai-sdk/gateway";
+import { getModel } from "@earendil-works/pi-ai";
 import { Type } from "@sinclair/typebox";
 import { withTimeout } from "@/chat/tools/web/network";
 import { logException } from "@/chat/logging";
@@ -8,7 +9,7 @@ import type { WebSearchToolDeps } from "@/chat/tools/types";
 
 const SEARCH_TIMEOUT_MS = 60_000;
 const MAX_RESULTS = 5;
-const DEFAULT_SEARCH_MODEL = "xai/grok-4-fast-reasoning";
+const DEFAULT_SEARCH_MODEL = getModel("vercel-ai-gateway", "openai/gpt-5.4").id;
 const SEARCH_TOOL_NAME = "parallelSearch";
 
 function asString(value: unknown): string | undefined {
@@ -102,10 +103,8 @@ export function createWebSearchTool(override?: WebSearchToolDeps) {
       }
 
       const maxResults = max_results ?? 3;
-      // Pinned. General-purpose models (AI_MODEL / AI_FAST_MODEL) aren't
-      // reliable at forced provider-tool calls on AI Gateway; keep the
-      // search tool on a search-tuned model and only allow an explicit
-      // override.
+      // Keep web search pinned to a provider-tool capable model instead of
+      // inheriting the main turn model.
       const model = process.env.AI_WEB_SEARCH_MODEL ?? DEFAULT_SEARCH_MODEL;
       const controller = new AbortController();
 

--- a/packages/junior/tests/unit/web/web-search.test.ts
+++ b/packages/junior/tests/unit/web/web-search.test.ts
@@ -35,7 +35,7 @@ describe("createWebSearchTool", () => {
   });
 
   it("uses AI Gateway parallel search and maps tool results", async () => {
-    process.env.AI_WEB_SEARCH_MODEL = "xai/grok-4-fast-reasoning";
+    process.env.AI_WEB_SEARCH_MODEL = "openai/gpt-5.4";
     vi.mocked(generateText).mockResolvedValueOnce({
       toolResults: [
         {
@@ -71,7 +71,7 @@ describe("createWebSearchTool", () => {
     });
     expect(generateText).toHaveBeenCalledWith(
       expect.objectContaining({
-        model: { model: "xai/grok-4-fast-reasoning" },
+        model: { model: "openai/gpt-5.4" },
         prompt: "vercel ai gateway",
         toolChoice: { type: "tool", toolName: "parallelSearch" },
         abortSignal: expect.any(AbortSignal),
@@ -79,7 +79,7 @@ describe("createWebSearchTool", () => {
     );
     expect(result).toEqual({
       ok: true,
-      model: "xai/grok-4-fast-reasoning",
+      model: "openai/gpt-5.4",
       query: "vercel ai gateway",
       result_count: 1,
       results: [
@@ -105,9 +105,7 @@ describe("createWebSearchTool", () => {
 
     await tool.execute({ query: "anything" }, {} as never);
 
-    expect(gatewayProvider.chat).toHaveBeenCalledWith(
-      "xai/grok-4-fast-reasoning",
-    );
+    expect(gatewayProvider.chat).toHaveBeenCalledWith("openai/gpt-5.4");
   });
 
   it("wraps AI SDK errors in web search error message", async () => {


### PR DESCRIPTION
Default `webSearch` now uses `openai/gpt-5.4` on AI Gateway instead of the stale Grok model ID that can fail at runtime. The existing GPT defaults for main, fast, and advisor model paths stay unchanged.

**Web Search Default**

The search tool remains pinned separately from `AI_MODEL` and `AI_FAST_MODEL`, but its fallback now uses a GPT model with AI Gateway web-search support.

**Default Validation**

The web-search fallback now resolves through the typed Gateway model registry, so stale model IDs are caught by typecheck instead of surfacing as runtime Gateway errors.