### PR TITLE
fix(nitro): Emit Vercel deployment wiring

### DIFF
--- a/apps/example/vercel.json
+++ b/apps/example/vercel.json
@@ -1,21 +1,4 @@
 {
   "framework": "nitro",
-  "buildCommand": "pnpm build",
-  "crons": [
-    {
-      "path": "/api/internal/heartbeat",
-      "schedule": "* * * * *"
-    }
-  ],
-  "functions": {
-    "api/internal/agent/continue.ts": {
-      "maxDuration": 300,
-      "experimentalTriggers": [
-        {
-          "type": "queue/v2beta",
-          "topic": "junior_conversation_work"
-        }
-      ]
-    }
-  }
+  "buildCommand": "pnpm build"
 }

--- a/packages/docs/src/content/docs/cli/check.md
+++ b/packages/docs/src/content/docs/cli/check.md
@@ -1,6 +1,6 @@
 ---
 title: "junior check"
-description: "Validate Junior plugin manifests and skill files under app/ before build or deploy."
+description: "Validate Junior content and deployment config before build or deploy."
 type: reference
 prerequisites:
   - /start-here/quickstart/
@@ -11,7 +11,7 @@ related:
   - /cli/snapshot-create/
 ---
 
-`junior check` validates local app content and installed plugin package content before build or deploy. It ignores legacy top-level `plugins/` and `skills/` directories, and it only runs app-file checks when the target already looks like a Junior app.
+`junior check` validates local app content, installed plugin package content, and Junior deployment config before build or deploy. It ignores legacy top-level `plugins/` and `skills/` directories, and it only runs app-file checks when the target already looks like a Junior app.
 
 ## Usage
 
@@ -64,6 +64,10 @@ When the target already contains Junior app markers such as `app/SOUL.md`, `app/
 - Other `app/*.md` files are allowed and stay available at runtime as optional sandbox reference documents.
 
 If a skill file has frontmatter but no instructions after it, the command emits a warning instead of failing.
+
+For Nitro/Vercel apps, the command checks deployment wiring when it sees Junior markers such as `@sentry/junior`, `juniorNitro()`, or app content files. It fails when `nitro.config.ts` omits `juniorNitro()`, because that module emits Junior's heartbeat cron and Vercel Queue trigger into the Nitro build output. It also fails when root `vercel.json` still targets `functions["api/internal/agent/continue.ts"]`; Nitro does not deploy that source file as a Vercel function.
+
+Root `vercel.json` heartbeat crons emit a warning. `juniorNitro()` now emits `/api/internal/heartbeat` into `.vercel/output/config.json`, so keeping the root cron can drift from the deployed Nitro config.
 
 ## Example output
 

--- a/packages/docs/src/content/docs/extend/scheduler-plugin.md
+++ b/packages/docs/src/content/docs/extend/scheduler-plugin.md
@@ -32,20 +32,19 @@ import { schedulerPlugin } from "@sentry/junior-scheduler";
 export const plugins = defineJuniorPlugins([schedulerPlugin()]);
 ```
 
-The scaffolded `vercel.json` includes the internal heartbeat route:
+`juniorNitro()` emits the internal heartbeat route into Nitro's Vercel Build Output config:
 
-```json title="vercel.json"
-{
-  "crons": [
-    {
-      "path": "/api/internal/heartbeat",
-      "schedule": "* * * * *"
-    }
-  ]
-}
+```ts title="nitro.config.ts"
+import { defineConfig } from "nitro";
+import { juniorNitro } from "@sentry/junior/nitro";
+
+export default defineConfig({
+  preset: "vercel",
+  modules: [juniorNitro()],
+});
 ```
 
-If you manage routes manually, call the heartbeat route on a one-minute cadence:
+If you deploy outside Vercel, call the heartbeat route on a one-minute cadence:
 
 | Route                     | Purpose                         |
 | ------------------------- | ------------------------------- |

--- a/packages/docs/src/content/docs/reference/api/functions/createApp.md
+++ b/packages/docs/src/content/docs/reference/api/functions/createApp.md
@@ -7,7 +7,7 @@ title: "createApp"
 
 > **createApp**(`options?`): `Promise`\<`Hono`\<`BlankEnv`, `BlankSchema`, `"/"`\>\>
 
-Defined in: [app.ts:252](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L252)
+Defined in: [app.ts:259](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L259)
 
 Create a Hono app with all Junior routes.
 

--- a/packages/docs/src/content/docs/reference/api/functions/juniorNitro.md
+++ b/packages/docs/src/content/docs/reference/api/functions/juniorNitro.md
@@ -7,9 +7,9 @@ title: "juniorNitro"
 
 > **juniorNitro**(`options?`): `object`
 
-Defined in: [nitro.ts:183](https://github.com/getsentry/junior/blob/main/packages/junior/src/nitro.ts#L183)
+Defined in: [nitro.ts:258](https://github.com/getsentry/junior/blob/main/packages/junior/src/nitro.ts#L258)
 
-Nitro module that copies app and plugin content into the Vercel build output.
+Nitro module that configures deployment wiring and copies app/plugin content into the Vercel build output.
 
 ## Parameters
 

--- a/packages/docs/src/content/docs/reference/api/functions/juniorVercelConfig.md
+++ b/packages/docs/src/content/docs/reference/api/functions/juniorVercelConfig.md
@@ -9,7 +9,7 @@ title: "juniorVercelConfig"
 
 Defined in: [vercel.ts:6](https://github.com/getsentry/junior/blob/main/packages/junior/src/vercel.ts#L6)
 
-Return a minimal Vercel config for scaffolded Junior apps.
+Return the root Vercel project config for scaffolded Junior apps.
 
 ## Parameters
 

--- a/packages/docs/src/content/docs/reference/api/interfaces/JuniorAppOptions.md
+++ b/packages/docs/src/content/docs/reference/api/interfaces/JuniorAppOptions.md
@@ -5,7 +5,7 @@ prev: false
 title: "JuniorAppOptions"
 ---
 
-Defined in: [app.ts:48](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L48)
+Defined in: [app.ts:53](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L53)
 
 ## Properties
 
@@ -13,24 +13,34 @@ Defined in: [app.ts:48](https://github.com/getsentry/junior/blob/main/packages/j
 
 > `optional` **configDefaults?**: `Record`\<`string`, `unknown`\>
 
-Defined in: [app.ts:50](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L50)
+Defined in: [app.ts:55](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L55)
 
 Install-wide provider defaults (`provider.key` format). Channel overrides take precedence.
 
-***
+---
+
+### conversationWork?
+
+> `optional` **conversationWork?**: `VercelConversationWorkCallbackOptions`
+
+Defined in: [app.ts:57](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L57)
+
+Queue consumer wiring for the durable conversation worker.
+
+---
 
 ### plugins?
 
 > `optional` **plugins?**: [`JuniorPluginSet`](/reference/api/interfaces/juniorpluginset/)
 
-Defined in: [app.ts:52](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L52)
+Defined in: [app.ts:59](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L59)
 
 Direct plugin set override. Usually omitted when `juniorNitro()` uses a plugin module.
 
-***
+---
 
 ### waitUntil?
 
 > `optional` **waitUntil?**: `WaitUntilFn`
 
-Defined in: [app.ts:53](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L53)
+Defined in: [app.ts:60](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L60)

--- a/packages/docs/src/content/docs/reference/api/interfaces/JuniorNitroOptions.md
+++ b/packages/docs/src/content/docs/reference/api/interfaces/JuniorNitroOptions.md
@@ -5,43 +5,53 @@ prev: false
 title: "JuniorNitroOptions"
 ---
 
-Defined in: [nitro.ts:33](https://github.com/getsentry/junior/blob/main/packages/junior/src/nitro.ts#L33)
+Defined in: [nitro.ts:39](https://github.com/getsentry/junior/blob/main/packages/junior/src/nitro.ts#L39)
 
 ## Properties
+
+### conversationWorkQueueTopic?
+
+> `optional` **conversationWorkQueueTopic?**: `string`
+
+Defined in: [nitro.ts:43](https://github.com/getsentry/junior/blob/main/packages/junior/src/nitro.ts#L43)
+
+Vercel Queue topic for durable conversation work. Must match the runtime queue producer topic.
+
+---
 
 ### cwd?
 
 > `optional` **cwd?**: `string`
 
-Defined in: [nitro.ts:34](https://github.com/getsentry/junior/blob/main/packages/junior/src/nitro.ts#L34)
+Defined in: [nitro.ts:40](https://github.com/getsentry/junior/blob/main/packages/junior/src/nitro.ts#L40)
 
-***
+---
 
 ### includeFiles?
 
 > `optional` **includeFiles?**: `string`[]
 
-Defined in: [nitro.ts:44](https://github.com/getsentry/junior/blob/main/packages/junior/src/nitro.ts#L44)
+Defined in: [nitro.ts:52](https://github.com/getsentry/junior/blob/main/packages/junior/src/nitro.ts#L52)
 
 Extra file patterns to copy into the server output for files that the
 bundler cannot trace (e.g. dynamically imported providers).
 Each entry is `"<package-name>/<subpath-glob>"`, resolved via Node
 module resolution. Example: `"@earendil-works/pi-ai/dist/providers/*.js"`
 
-***
+---
 
 ### maxDuration?
 
 > `optional` **maxDuration?**: `number`
 
-Defined in: [nitro.ts:35](https://github.com/getsentry/junior/blob/main/packages/junior/src/nitro.ts#L35)
+Defined in: [nitro.ts:41](https://github.com/getsentry/junior/blob/main/packages/junior/src/nitro.ts#L41)
 
-***
+---
 
 ### plugins?
 
 > `optional` **plugins?**: `JuniorNitroPluginSource`
 
-Defined in: [nitro.ts:37](https://github.com/getsentry/junior/blob/main/packages/junior/src/nitro.ts#L37)
+Defined in: [nitro.ts:45](https://github.com/getsentry/junior/blob/main/packages/junior/src/nitro.ts#L45)
 
 Plugin catalog set or runtime-safe plugin module. Direct sets must not include trusted hooks.

--- a/packages/docs/src/content/docs/start-here/deploy-to-vercel.md
+++ b/packages/docs/src/content/docs/start-here/deploy-to-vercel.md
@@ -12,7 +12,7 @@ related:
   - /start-here/verify-and-troubleshoot/
 ---
 
-The scaffolded app is already shaped for Vercel. Deployment mainly means linking the project, setting env vars, enabling the heartbeat cron, enabling snapshot warmup support, and pointing Slack at the production URL.
+The scaffolded app is already shaped for Vercel. Deployment mainly means linking the project, keeping `juniorNitro()` in Nitro config, setting env vars, enabling snapshot warmup support, and pointing Slack at the production URL.
 
 ## Link the project
 
@@ -41,35 +41,26 @@ The scaffolded `package.json` includes the production build script:
 
 Keep the Vercel build command as `pnpm build`. `junior snapshot create` prepares sandbox runtime dependencies declared by enabled plugins before request handling starts.
 
-## Keep Vercel runtime entries
+## Enable Junior's Nitro deployment module
 
-Junior uses a one-minute internal heartbeat to run trusted plugin heartbeats and recover stale agent dispatches. The scheduler plugin uses this heartbeat when scheduled tasks are enabled. The scaffolded `vercel.json` should include these runtime entries:
+Junior uses a one-minute internal heartbeat to run trusted plugin heartbeats and recover stale agent dispatches. Durable agent work is also resumed by a Vercel Queue consumer. Both pieces are emitted by `juniorNitro()` into Nitro's Vercel Build Output config, which is the config Vercel deploys for Nitro apps.
 
-```json title="vercel.json"
-{
-  "framework": "nitro",
-  "buildCommand": "pnpm build",
-  "crons": [
-    {
-      "path": "/api/internal/heartbeat",
-      "schedule": "* * * * *"
-    }
-  ],
-  "functions": {
-    "api/internal/agent/continue.ts": {
-      "maxDuration": 300,
-      "experimentalTriggers": [
-        {
-          "type": "queue/v2beta",
-          "topic": "junior_conversation_work"
-        }
-      ]
-    }
-  }
-}
+Keep `juniorNitro()` installed in `nitro.config.ts`:
+
+```ts title="nitro.config.ts"
+import { defineConfig } from "nitro";
+import { juniorNitro } from "@sentry/junior/nitro";
+
+export default defineConfig({
+  preset: "vercel",
+  modules: [juniorNitro()],
+  routes: {
+    "/**": { handler: "./server.ts" },
+  },
+});
 ```
 
-If you maintain `vercel.json` manually, keep the `/api/internal/heartbeat` cron entry and the queue trigger for `api/internal/agent/continue.ts`. The scaffolded `api/internal/agent/continue.ts` file delegates queue delivery to `server.ts`, and Vercel requires the `functions` key to match a concrete source file.
+Do not configure `functions["api/internal/agent/continue.ts"]` in root `vercel.json`; Nitro does not deploy that source file as a Vercel function. `juniorNitro()` attaches the queue trigger to `/api/internal/agent/continue` with Nitro `vercel.functionRules`, and emits the `/api/internal/heartbeat` cron into `.vercel/output/config.json`.
 
 The heartbeat endpoint returns `401` unless the incoming Vercel Cron request has a bearer token that matches `CRON_SECRET`.
 
@@ -125,11 +116,13 @@ Reinstall the Slack app if scopes changed.
 Run these checks after deployment:
 
 1. `GET https://<your-domain>/health` returns `status: "ok"`.
-2. The Vercel deployment has a cron entry for `/api/internal/heartbeat`.
-3. A Slack mention produces a thread reply in the expected workspace.
-4. App Home opens without an error.
-5. Queue callback and turn logs show successful processing.
-6. One enabled plugin workflow succeeds end to end.
+2. `junior check` passes without deployment config errors.
+3. The Vercel deployment has a cron entry for `/api/internal/heartbeat`.
+4. The Vercel deployment has a Queue trigger for `/api/internal/agent/continue`.
+5. A Slack mention produces a thread reply in the expected workspace.
+6. App Home opens without an error.
+7. Queue callback and turn logs show successful processing.
+8. One enabled plugin workflow succeeds end to end.
 
 ## Next step
 

--- a/packages/junior/src/chat/task-execution/vercel-queue.ts
+++ b/packages/junior/src/chat/task-execution/vercel-queue.ts
@@ -28,8 +28,8 @@ let defaultQueue: ConversationWorkQueue | undefined;
 
 function getTopic(options: VercelConversationWorkQueueOptions): string {
   return (
-    options.topic ??
-    process.env.JUNIOR_CONVERSATION_WORK_QUEUE_TOPIC?.trim() ??
+    options.topic ||
+    process.env.JUNIOR_CONVERSATION_WORK_QUEUE_TOPIC?.trim() ||
     DEFAULT_CONVERSATION_WORK_QUEUE_TOPIC
   );
 }

--- a/packages/junior/src/cli/check.ts
+++ b/packages/junior/src/cli/check.ts
@@ -2,6 +2,11 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { ParsedSkillFile } from "@/chat/skills";
 import { parseSkillFile } from "@/chat/skills";
+import {
+  JUNIOR_CONVERSATION_WORK_CALLBACK_ROUTE,
+  JUNIOR_HEARTBEAT_ROUTE,
+  LEGACY_JUNIOR_CONVERSATION_WORK_FUNCTION,
+} from "@/deployment";
 import { parsePluginManifest } from "@/chat/plugins/manifest";
 import type { PluginManifest } from "@/chat/plugins/types";
 
@@ -106,6 +111,14 @@ async function pathIsFile(targetPath: string): Promise<boolean> {
 async function readJsonFile<T>(targetPath: string): Promise<T | undefined> {
   try {
     return JSON.parse(await fs.readFile(targetPath, "utf8")) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+async function readTextFile(targetPath: string): Promise<string | undefined> {
+  try {
+    return await fs.readFile(targetPath, "utf8");
   } catch {
     return undefined;
   }
@@ -555,6 +568,133 @@ interface AppFileValidationResult {
   warnings: string[];
 }
 
+interface DeploymentConfigValidationResult extends AppFileValidationResult {
+  checked: boolean;
+}
+
+interface VercelProjectConfig {
+  crons?: unknown;
+  functions?: unknown;
+  framework?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+async function hasJuniorDeploymentMarkers(
+  rootDir: string,
+  packages: DeclaredPackage[],
+  nitroConfig: string | undefined,
+): Promise<boolean> {
+  if (
+    packages.some(
+      (declaredPackage) => declaredPackage.name === "@sentry/junior",
+    )
+  ) {
+    return true;
+  }
+
+  for (const source of [
+    nitroConfig,
+    await readTextFile(path.join(rootDir, "server.ts")),
+    await readTextFile(path.join(rootDir, "server.js")),
+  ]) {
+    if (
+      source?.includes("@sentry/junior") ||
+      /\bjuniorNitro\s*\(/.test(source ?? "")
+    ) {
+      return true;
+    }
+  }
+
+  const appDir = path.resolve(rootDir, "app");
+  return (await pathIsDirectory(appDir)) && (await hasJuniorAppMarkers(appDir));
+}
+
+async function validateDeploymentConfig(
+  rootDir: string,
+  packages: DeclaredPackage[],
+): Promise<DeploymentConfigValidationResult> {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  let checked = false;
+
+  const nitroConfigPath = path.join(rootDir, "nitro.config.ts");
+  const nitroConfig = await readTextFile(nitroConfigPath);
+  const hasJuniorMarkers = await hasJuniorDeploymentMarkers(
+    rootDir,
+    packages,
+    nitroConfig,
+  );
+  if (nitroConfig !== undefined && hasJuniorMarkers) {
+    checked = true;
+    if (!/\bjuniorNitro\s*\(/.test(nitroConfig)) {
+      errors.push(
+        `${nitroConfigPath}: missing juniorNitro(). The Nitro module emits Junior's Vercel queue trigger and heartbeat cron into the deployed build output.`,
+      );
+    }
+  }
+
+  const vercelConfigPath = path.join(rootDir, "vercel.json");
+  const vercelConfigText = await readTextFile(vercelConfigPath);
+  if (vercelConfigText === undefined) {
+    return { checked, errors, warnings };
+  }
+  const containsLegacyJuniorQueuePath = vercelConfigText.includes(
+    LEGACY_JUNIOR_CONVERSATION_WORK_FUNCTION,
+  );
+  if (!hasJuniorMarkers && !containsLegacyJuniorQueuePath) {
+    return { checked, errors, warnings };
+  }
+
+  let vercelConfig: VercelProjectConfig;
+  try {
+    vercelConfig = JSON.parse(vercelConfigText) as VercelProjectConfig;
+  } catch (error) {
+    errors.push(
+      `${vercelConfigPath}: invalid JSON (${error instanceof Error ? error.message : String(error)})`,
+    );
+    return { checked, errors, warnings };
+  }
+
+  if (
+    hasJuniorMarkers &&
+    vercelConfig.framework !== undefined &&
+    vercelConfig.framework !== "nitro"
+  ) {
+    checked = true;
+    errors.push(
+      `${vercelConfigPath}: framework must be "nitro" for Junior's Vercel deployment wiring.`,
+    );
+  }
+
+  if (isRecord(vercelConfig.functions)) {
+    const legacyFunctionConfig =
+      vercelConfig.functions[LEGACY_JUNIOR_CONVERSATION_WORK_FUNCTION];
+    if (legacyFunctionConfig !== undefined) {
+      checked = true;
+      errors.push(
+        `${vercelConfigPath}: functions.${LEGACY_JUNIOR_CONVERSATION_WORK_FUNCTION} targets a source file that Nitro does not deploy. Remove it; juniorNitro() emits the ${JUNIOR_CONVERSATION_WORK_CALLBACK_ROUTE} queue trigger through Nitro functionRules.`,
+      );
+    }
+  }
+
+  if (hasJuniorMarkers && Array.isArray(vercelConfig.crons)) {
+    const hasHeartbeatCron = vercelConfig.crons.some(
+      (cron) => isRecord(cron) && cron.path === JUNIOR_HEARTBEAT_ROUTE,
+    );
+    if (hasHeartbeatCron) {
+      checked = true;
+      warnings.push(
+        `${vercelConfigPath}: ${JUNIOR_HEARTBEAT_ROUTE} cron is now emitted by juniorNitro() into Nitro's Vercel Build Output config. Remove the root cron entry to avoid deployment drift.`,
+      );
+    }
+  }
+
+  return { checked, errors, warnings };
+}
+
 async function validateAppSourceFiles(
   rootDir: string,
   registeredConfigKeys: Set<string>,
@@ -721,6 +861,12 @@ export async function runCheck(
   const pluginResults: PluginValidationResult[] = [];
   const skillResultsByDir = new Map<string, SkillValidationResult>();
   warnings.push(...packageWarnings);
+  const deploymentConfigResult = await validateDeploymentConfig(
+    resolvedRoot,
+    packages,
+  );
+  warnings.push(...deploymentConfigResult.warnings);
+  errors.push(...deploymentConfigResult.errors);
 
   for (const { pluginDir, packageName } of pluginDirs) {
     const pluginNameMap = packageName
@@ -824,6 +970,13 @@ export async function runCheck(
       appFileResult.warnings.length,
     );
     io.info(formatHeading(appFileStatus, "app files"));
+  }
+  if (deploymentConfigResult.checked) {
+    const deploymentConfigStatus = formatStatus(
+      deploymentConfigResult.errors.length,
+      deploymentConfigResult.warnings.length,
+    );
+    io.info(formatHeading(deploymentConfigStatus, "deployment config"));
   }
 
   for (const pluginResult of pluginResults) {

--- a/packages/junior/src/deployment.ts
+++ b/packages/junior/src/deployment.ts
@@ -1,0 +1,6 @@
+export const JUNIOR_HEARTBEAT_ROUTE = "/api/internal/heartbeat";
+export const JUNIOR_HEARTBEAT_CRON_SCHEDULE = "* * * * *";
+export const JUNIOR_CONVERSATION_WORK_CALLBACK_ROUTE =
+  "/api/internal/agent/continue";
+export const LEGACY_JUNIOR_CONVERSATION_WORK_FUNCTION =
+  "api/internal/agent/continue.ts";

--- a/packages/junior/src/nitro.ts
+++ b/packages/junior/src/nitro.ts
@@ -232,25 +232,21 @@ function configureVercelDeployment(nitro: Nitro, options: JuniorNitroOptions) {
   const existingTriggers = Array.isArray(existingRule.experimentalTriggers)
     ? existingRule.experimentalTriggers
     : [];
-  const hasConversationWorkTrigger = existingTriggers.some(
-    (trigger) =>
-      trigger.type === VERCEL_QUEUE_TRIGGER_TYPE &&
-      trigger.topic === queueTopic,
+  const otherTriggers = existingTriggers.filter(
+    (trigger) => trigger.type !== VERCEL_QUEUE_TRIGGER_TYPE,
   );
 
   nitro.options.vercel.functionRules[JUNIOR_CONVERSATION_WORK_CALLBACK_ROUTE] =
     {
       maxDuration: callbackMaxDuration,
       ...existingRule,
-      experimentalTriggers: hasConversationWorkTrigger
-        ? existingTriggers
-        : [
-            ...existingTriggers,
-            {
-              type: VERCEL_QUEUE_TRIGGER_TYPE,
-              topic: queueTopic,
-            },
-          ],
+      experimentalTriggers: [
+        ...otherTriggers,
+        {
+          type: VERCEL_QUEUE_TRIGGER_TYPE,
+          topic: queueTopic,
+        },
+      ],
     };
 }
 

--- a/packages/junior/src/nitro.ts
+++ b/packages/junior/src/nitro.ts
@@ -12,6 +12,12 @@ import {
   injectVirtualConfig,
   type RuntimePluginModule,
 } from "@/build/virtual-config";
+import { DEFAULT_CONVERSATION_WORK_QUEUE_TOPIC } from "@/chat/task-execution/vercel-queue";
+import {
+  JUNIOR_CONVERSATION_WORK_CALLBACK_ROUTE,
+  JUNIOR_HEARTBEAT_CRON_SCHEDULE,
+  JUNIOR_HEARTBEAT_ROUTE,
+} from "@/deployment";
 import {
   pluginCatalogConfigFromPluginSet,
   trustedPluginRegistrationsFromPluginSet,
@@ -33,6 +39,8 @@ export type JuniorNitroPluginSource =
 export interface JuniorNitroOptions {
   cwd?: string;
   maxDuration?: number;
+  /** Vercel Queue topic for durable conversation work. Must match the runtime queue producer topic. */
+  conversationWorkQueueTopic?: string;
   /** Plugin catalog set or runtime-safe plugin module. Direct sets must not include trusted hooks. */
   plugins?: JuniorNitroPluginSource;
   /**
@@ -49,6 +57,9 @@ interface ResolvedPluginModuleReference {
   importUrl: string;
   runtimeModule: RuntimePluginModule;
 }
+
+const DEFAULT_FUNCTION_MAX_DURATION_SECONDS = 300;
+const VERCEL_QUEUE_TRIGGER_TYPE = "queue/v2beta";
 
 const PLUGIN_MODULE_EXTENSIONS = [
   "",
@@ -179,7 +190,71 @@ function assertSerializableDirectPluginSet(pluginSet: JuniorPluginSet): void {
   );
 }
 
-/** Nitro module that copies app and plugin content into the Vercel build output. */
+function resolveConversationWorkQueueTopic(
+  options: JuniorNitroOptions,
+): string {
+  return (
+    options.conversationWorkQueueTopic?.trim() ||
+    process.env.JUNIOR_CONVERSATION_WORK_QUEUE_TOPIC?.trim() ||
+    DEFAULT_CONVERSATION_WORK_QUEUE_TOPIC
+  );
+}
+
+function configureVercelDeployment(nitro: Nitro, options: JuniorNitroOptions) {
+  const defaultMaxDuration =
+    options.maxDuration ?? DEFAULT_FUNCTION_MAX_DURATION_SECONDS;
+  const queueTopic = resolveConversationWorkQueueTopic(options);
+
+  nitro.options.vercel ??= {};
+  nitro.options.vercel.config ??= { version: 3 };
+  nitro.options.vercel.config.crons ??= [];
+  if (
+    !nitro.options.vercel.config.crons.some(
+      (cron) => cron.path === JUNIOR_HEARTBEAT_ROUTE,
+    )
+  ) {
+    nitro.options.vercel.config.crons.push({
+      path: JUNIOR_HEARTBEAT_ROUTE,
+      schedule: JUNIOR_HEARTBEAT_CRON_SCHEDULE,
+    });
+  }
+
+  nitro.options.vercel.functions ??= {};
+  nitro.options.vercel.functions.maxDuration ??= defaultMaxDuration;
+  const callbackMaxDuration =
+    nitro.options.vercel.functions.maxDuration ?? defaultMaxDuration;
+
+  nitro.options.vercel.functionRules ??= {};
+  const existingRule =
+    nitro.options.vercel.functionRules[
+      JUNIOR_CONVERSATION_WORK_CALLBACK_ROUTE
+    ] ?? {};
+  const existingTriggers = Array.isArray(existingRule.experimentalTriggers)
+    ? existingRule.experimentalTriggers
+    : [];
+  const hasConversationWorkTrigger = existingTriggers.some(
+    (trigger) =>
+      trigger.type === VERCEL_QUEUE_TRIGGER_TYPE &&
+      trigger.topic === queueTopic,
+  );
+
+  nitro.options.vercel.functionRules[JUNIOR_CONVERSATION_WORK_CALLBACK_ROUTE] =
+    {
+      maxDuration: callbackMaxDuration,
+      ...existingRule,
+      experimentalTriggers: hasConversationWorkTrigger
+        ? existingTriggers
+        : [
+            ...existingTriggers,
+            {
+              type: VERCEL_QUEUE_TRIGGER_TYPE,
+              topic: queueTopic,
+            },
+          ],
+    };
+}
+
+/** Nitro module that configures deployment wiring and copies app/plugin content into the Vercel build output. */
 export function juniorNitro(options: JuniorNitroOptions = {}): {
   nitro: { setup(nitro: unknown): void };
 } {
@@ -190,10 +265,7 @@ export function juniorNitro(options: JuniorNitroOptions = {}): {
           options.cwd ?? nitro.options.rootDir ?? process.cwd(),
         );
 
-        nitro.options.vercel ??= {};
-        nitro.options.vercel.functions ??= {};
-        nitro.options.vercel.functions.maxDuration ??=
-          options.maxDuration ?? 300;
+        configureVercelDeployment(nitro, options);
 
         applyRolldownTreeshakeWorkaround(nitro);
         const pluginSource = options.plugins;

--- a/packages/junior/src/vercel.ts
+++ b/packages/junior/src/vercel.ts
@@ -1,33 +1,14 @@
-import { DEFAULT_CONVERSATION_WORK_QUEUE_TOPIC } from "@/chat/task-execution/vercel-queue";
-
 export interface JuniorVercelConfigOptions {
   buildCommand?: string | null;
 }
 
-/** Return a minimal Vercel config for scaffolded Junior apps. */
+/** Return the root Vercel project config for scaffolded Junior apps. */
 export function juniorVercelConfig(options: JuniorVercelConfigOptions = {}) {
   const buildCommand =
     options.buildCommand === undefined ? "pnpm build" : options.buildCommand;
 
   const config: Record<string, unknown> = {
     framework: "nitro",
-    crons: [
-      {
-        path: "/api/internal/heartbeat",
-        schedule: "* * * * *",
-      },
-    ],
-    functions: {
-      "api/internal/agent/continue.ts": {
-        maxDuration: 300,
-        experimentalTriggers: [
-          {
-            type: "queue/v2beta",
-            topic: DEFAULT_CONVERSATION_WORK_QUEUE_TOPIC,
-          },
-        ],
-      },
-    },
   };
 
   if (buildCommand !== null) {

--- a/packages/junior/tests/unit/build/nitro-plugin-module.test.ts
+++ b/packages/junior/tests/unit/build/nitro-plugin-module.test.ts
@@ -198,6 +198,47 @@ describe("juniorNitro plugin modules", () => {
     ]);
   });
 
+  it("replaces a stale queue trigger when the topic changes", () => {
+    const virtual: Record<string, (() => Promise<string>) | string> = {};
+    const nitro = {
+      hooks: {
+        hook() {},
+      },
+      options: {
+        output: {
+          serverDir: "/tmp/junior-output",
+        },
+        rootDir: "/tmp/junior-app",
+        vercel: {
+          functionRules: {
+            [JUNIOR_CONVERSATION_WORK_CALLBACK_ROUTE]: {
+              experimentalTriggers: [
+                {
+                  type: "queue/v2beta",
+                  topic: "old_topic",
+                },
+              ],
+            },
+          },
+        },
+        virtual,
+      },
+    };
+
+    juniorNitro({ conversationWorkQueueTopic: "new_topic" }).nitro.setup(nitro);
+    const vercel = getVercelOptions(nitro);
+
+    expect(
+      vercel.functionRules?.[JUNIOR_CONVERSATION_WORK_CALLBACK_ROUTE]
+        ?.experimentalTriggers,
+    ).toEqual([
+      {
+        type: "queue/v2beta",
+        topic: "new_topic",
+      },
+    ]);
+  });
+
   it("preserves Vercel max function duration settings", () => {
     const virtual: Record<string, (() => Promise<string>) | string> = {};
     const nitro = {

--- a/packages/junior/tests/unit/build/nitro-plugin-module.test.ts
+++ b/packages/junior/tests/unit/build/nitro-plugin-module.test.ts
@@ -3,10 +3,35 @@ import os from "node:os";
 import path from "node:path";
 import { defineJuniorPlugin } from "@sentry/junior-plugin-api";
 import { afterEach, describe, expect, it } from "vitest";
+import { DEFAULT_CONVERSATION_WORK_QUEUE_TOPIC } from "@/chat/task-execution/vercel-queue";
+import {
+  JUNIOR_CONVERSATION_WORK_CALLBACK_ROUTE,
+  JUNIOR_HEARTBEAT_CRON_SCHEDULE,
+  JUNIOR_HEARTBEAT_ROUTE,
+} from "@/deployment";
 import { juniorNitro } from "@/nitro";
 import { defineJuniorPlugins } from "@/plugins";
 
 const tempDirs: string[] = [];
+
+interface TestFunctionRule {
+  maxDuration?: number | "max";
+  memory?: number;
+  experimentalTriggers?: Array<{
+    type: string;
+    topic: string;
+    consumer?: string;
+  }>;
+}
+
+interface TestVercelOptions {
+  config?: {
+    version: 3;
+    crons?: Array<{ path: string; schedule: string }>;
+  };
+  functions?: Record<string, unknown>;
+  functionRules?: Record<string, TestFunctionRule>;
+}
 
 async function makeTempDir(): Promise<string> {
   const tempDir = await fs.mkdtemp(
@@ -16,6 +41,12 @@ async function makeTempDir(): Promise<string> {
   return tempDir;
 }
 
+function getVercelOptions(nitro: {
+  options: { vercel: unknown };
+}): TestVercelOptions {
+  return nitro.options.vercel as TestVercelOptions;
+}
+
 afterEach(async () => {
   for (const tempDir of tempDirs.splice(0)) {
     await fs.rm(tempDir, { recursive: true, force: true });
@@ -23,6 +54,179 @@ afterEach(async () => {
 });
 
 describe("juniorNitro plugin modules", () => {
+  it("configures Vercel build output for heartbeat and conversation work", () => {
+    const virtual: Record<string, (() => Promise<string>) | string> = {};
+    const nitro = {
+      hooks: {
+        hook() {},
+      },
+      options: {
+        output: {
+          serverDir: "/tmp/junior-output",
+        },
+        rootDir: "/tmp/junior-app",
+        vercel: {},
+        virtual,
+      },
+    };
+
+    juniorNitro().nitro.setup(nitro);
+    const vercel = getVercelOptions(nitro);
+
+    expect(vercel.config).toEqual({
+      version: 3,
+      crons: [
+        {
+          path: JUNIOR_HEARTBEAT_ROUTE,
+          schedule: JUNIOR_HEARTBEAT_CRON_SCHEDULE,
+        },
+      ],
+    });
+    expect(vercel.functions).toEqual({
+      maxDuration: 300,
+    });
+    expect(
+      vercel.functionRules?.[JUNIOR_CONVERSATION_WORK_CALLBACK_ROUTE],
+    ).toEqual({
+      maxDuration: 300,
+      experimentalTriggers: [
+        {
+          type: "queue/v2beta",
+          topic: DEFAULT_CONVERSATION_WORK_QUEUE_TOPIC,
+        },
+      ],
+    });
+  });
+
+  it("preserves existing Vercel route function settings", () => {
+    const virtual: Record<string, (() => Promise<string>) | string> = {};
+    const nitro = {
+      hooks: {
+        hook() {},
+      },
+      options: {
+        output: {
+          serverDir: "/tmp/junior-output",
+        },
+        rootDir: "/tmp/junior-app",
+        vercel: {
+          config: {
+            version: 3,
+            crons: [
+              {
+                path: JUNIOR_HEARTBEAT_ROUTE,
+                schedule: "*/5 * * * *",
+              },
+            ],
+          },
+          functions: {
+            maxDuration: 120,
+            memory: 1024,
+          },
+          functionRules: {
+            [JUNIOR_CONVERSATION_WORK_CALLBACK_ROUTE]: {
+              memory: 2048,
+              experimentalTriggers: [
+                {
+                  type: "queue/v2beta",
+                  topic: DEFAULT_CONVERSATION_WORK_QUEUE_TOPIC,
+                },
+              ],
+            },
+          },
+        },
+        virtual,
+      },
+    };
+
+    juniorNitro({ maxDuration: 300 }).nitro.setup(nitro);
+    const vercel = getVercelOptions(nitro);
+
+    expect(vercel.config?.crons).toEqual([
+      {
+        path: JUNIOR_HEARTBEAT_ROUTE,
+        schedule: "*/5 * * * *",
+      },
+    ]);
+    expect(vercel.functions).toEqual({
+      maxDuration: 120,
+      memory: 1024,
+    });
+    expect(
+      vercel.functionRules?.[JUNIOR_CONVERSATION_WORK_CALLBACK_ROUTE],
+    ).toEqual({
+      maxDuration: 120,
+      memory: 2048,
+      experimentalTriggers: [
+        {
+          type: "queue/v2beta",
+          topic: DEFAULT_CONVERSATION_WORK_QUEUE_TOPIC,
+        },
+      ],
+    });
+  });
+
+  it("uses a custom Vercel conversation work queue topic", () => {
+    const virtual: Record<string, (() => Promise<string>) | string> = {};
+    const nitro = {
+      hooks: {
+        hook() {},
+      },
+      options: {
+        output: {
+          serverDir: "/tmp/junior-output",
+        },
+        rootDir: "/tmp/junior-app",
+        vercel: {},
+        virtual,
+      },
+    };
+
+    juniorNitro({ conversationWorkQueueTopic: "custom_work" }).nitro.setup(
+      nitro,
+    );
+    const vercel = getVercelOptions(nitro);
+
+    expect(
+      vercel.functionRules?.[JUNIOR_CONVERSATION_WORK_CALLBACK_ROUTE]
+        ?.experimentalTriggers,
+    ).toEqual([
+      {
+        type: "queue/v2beta",
+        topic: "custom_work",
+      },
+    ]);
+  });
+
+  it("preserves Vercel max function duration settings", () => {
+    const virtual: Record<string, (() => Promise<string>) | string> = {};
+    const nitro = {
+      hooks: {
+        hook() {},
+      },
+      options: {
+        output: {
+          serverDir: "/tmp/junior-output",
+        },
+        rootDir: "/tmp/junior-app",
+        vercel: {
+          functions: {
+            maxDuration: "max" as const,
+          },
+        },
+        virtual,
+      },
+    };
+
+    juniorNitro().nitro.setup(nitro);
+    const vercel = getVercelOptions(nitro);
+
+    expect(
+      vercel.functionRules?.[JUNIOR_CONVERSATION_WORK_CALLBACK_ROUTE]
+        ?.maxDuration,
+    ).toBe("max");
+  });
+
   it("loads plugin modules lazily when virtual config is rendered", async () => {
     const tempRoot = await makeTempDir();
     await fs.writeFile(

--- a/packages/junior/tests/unit/cli/check-cli.test.ts
+++ b/packages/junior/tests/unit/cli/check-cli.test.ts
@@ -255,6 +255,159 @@ describe("check cli", () => {
     ).toBe(true);
   });
 
+  it("fails when a Junior Nitro app does not install juniorNitro", async () => {
+    const repoRoot = makeTempDir("junior-validate-missing-nitro-module-");
+    writeFile(
+      path.join(repoRoot, "package.json"),
+      JSON.stringify(
+        {
+          dependencies: {
+            "@sentry/junior": "1.0.0",
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    writeFile(
+      path.join(repoRoot, "nitro.config.ts"),
+      [
+        'import { defineConfig } from "nitro";',
+        "",
+        "export default defineConfig({",
+        '  preset: "vercel",',
+        "});",
+        "",
+      ].join("\n"),
+    );
+
+    const lines: string[] = [];
+    await expect(
+      runCheck(repoRoot, {
+        info: (line) => lines.push(line),
+        warn: (line) => lines.push(line),
+        error: (line) => lines.push(line),
+      }),
+    ).rejects.toThrow(
+      "Validation failed (1 error, 0 plugin manifests, 0 skill directories checked).",
+    );
+
+    expect(lines).toContain("✖ deployment config");
+    expect(
+      lines.some((line) =>
+        line.includes(
+          "missing juniorNitro(). The Nitro module emits Junior's Vercel queue trigger and heartbeat cron",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("fails when Vercel config targets the legacy queue source file", async () => {
+    const repoRoot = makeTempDir("junior-validate-legacy-vercel-function-");
+    writeFile(
+      path.join(repoRoot, "vercel.json"),
+      JSON.stringify(
+        {
+          framework: "nitro",
+          functions: {
+            "api/internal/agent/continue.ts": {
+              maxDuration: 300,
+              experimentalTriggers: [
+                {
+                  type: "queue/v2beta",
+                  topic: "junior_conversation_work",
+                },
+              ],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const lines: string[] = [];
+    await expect(
+      runCheck(repoRoot, {
+        info: (line) => lines.push(line),
+        warn: (line) => lines.push(line),
+        error: (line) => lines.push(line),
+      }),
+    ).rejects.toThrow(
+      "Validation failed (1 error, 0 plugin manifests, 0 skill directories checked).",
+    );
+
+    expect(lines).toContain("✖ deployment config");
+    expect(
+      lines.some((line) =>
+        line.includes(
+          "functions.api/internal/agent/continue.ts targets a source file that Nitro does not deploy",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("warns when Vercel config still declares the root heartbeat cron", async () => {
+    const repoRoot = makeTempDir("junior-validate-root-heartbeat-cron-");
+    writeFile(
+      path.join(repoRoot, "package.json"),
+      JSON.stringify(
+        {
+          dependencies: {
+            "@sentry/junior": "1.0.0",
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    writeFile(
+      path.join(repoRoot, "nitro.config.ts"),
+      [
+        'import { defineConfig } from "nitro";',
+        'import { juniorNitro } from "@sentry/junior/nitro";',
+        "",
+        "export default defineConfig({",
+        '  preset: "vercel",',
+        "  modules: [juniorNitro()],",
+        "});",
+        "",
+      ].join("\n"),
+    );
+    writeFile(
+      path.join(repoRoot, "vercel.json"),
+      JSON.stringify(
+        {
+          framework: "nitro",
+          crons: [
+            {
+              path: "/api/internal/heartbeat",
+              schedule: "* * * * *",
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+
+    const lines: string[] = [];
+    await runCheck(repoRoot, {
+      info: (line) => lines.push(line),
+      warn: (line) => lines.push(line),
+      error: (line) => lines.push(line),
+    });
+
+    expect(lines).toContain("⚠ deployment config");
+    expect(
+      lines.some((line) =>
+        line.includes(
+          "/api/internal/heartbeat cron is now emitted by juniorNitro()",
+        ),
+      ),
+    ).toBe(true);
+  });
+
   it("fails when app configDefaults references an unregistered plugin key", async () => {
     const repoRoot = makeTempDir("junior-validate-config-defaults-");
     writeFile(
@@ -374,6 +527,23 @@ describe("check cli", () => {
   it("skips app file validation for unrelated app directories", async () => {
     const repoRoot = makeTempDir("junior-validate-empty-app-");
     fs.mkdirSync(path.join(repoRoot, "app"), { recursive: true });
+
+    const lines: string[] = [];
+    await runCheck(repoRoot, {
+      info: (line) => lines.push(line),
+      warn: (line) => lines.push(line),
+      error: (line) => lines.push(line),
+    });
+
+    expect(lines).toEqual([
+      `Checking ${repoRoot}`,
+      "✓ Validation passed (0 plugin manifests, 0 skill directories checked).",
+    ]);
+  });
+
+  it("skips deployment config validation for unrelated Vercel projects", async () => {
+    const repoRoot = makeTempDir("junior-validate-unrelated-vercel-");
+    writeFile(path.join(repoRoot, "vercel.json"), "{ invalid");
 
     const lines: string[] = [];
     await runCheck(repoRoot, {

--- a/packages/junior/tests/unit/cli/init-cli.test.ts
+++ b/packages/junior/tests/unit/cli/init-cli.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { runCheck } from "@/cli/check";
 import { runInit } from "@/cli/init";
 
 const tempRoots: string[] = [];
@@ -56,23 +57,17 @@ describe("init cli", () => {
     );
     expect(vercelConfig.framework).toBe("nitro");
     expect(vercelConfig.buildCommand).toBe("pnpm build");
-    expect(vercelConfig.crons).toEqual([
-      {
-        path: "/api/internal/heartbeat",
-        schedule: "* * * * *",
-      },
-    ]);
-    expect(vercelConfig.functions).toEqual({
-      "api/internal/agent/continue.ts": {
-        maxDuration: 300,
-        experimentalTriggers: [
-          {
-            type: "queue/v2beta",
-            topic: "junior_conversation_work",
-          },
-        ],
-      },
-    });
+    expect(vercelConfig.crons).toBeUndefined();
+    expect(vercelConfig.functions).toBeUndefined();
+
+    const nitroConfig = fs.readFileSync(
+      path.join(target, "nitro.config.ts"),
+      "utf8",
+    );
+    expect(nitroConfig).toContain(
+      'import { juniorNitro } from "@sentry/junior/nitro";',
+    );
+    expect(nitroConfig).toContain("modules: [juniorNitro()]");
 
     const pkg = JSON.parse(
       fs.readFileSync(path.join(target, "package.json"), "utf8"),
@@ -89,6 +84,14 @@ describe("init cli", () => {
       "utf8",
     );
     expect(envExample).toContain("CRON_SECRET=");
+
+    const checkLines: string[] = [];
+    await runCheck(target, {
+      info: (line) => checkLines.push(line),
+      warn: (line) => checkLines.push(line),
+      error: (line) => checkLines.push(line),
+    });
+    expect(checkLines).toContain("✓ deployment config");
   });
 
   it("refuses to initialize a non-empty directory", async () => {

--- a/packages/junior/tests/unit/vercel.test.ts
+++ b/packages/junior/tests/unit/vercel.test.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { resolveConversationWorkVisibilityTimeoutSeconds } from "@/chat/task-execution/vercel-callback";
-import { DEFAULT_CONVERSATION_WORK_QUEUE_TOPIC } from "@/chat/task-execution/vercel-queue";
 import { juniorVercelConfig } from "@/vercel";
 
 const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -15,23 +14,8 @@ describe("juniorVercelConfig", () => {
 
     expect(config.framework).toBe("nitro");
     expect(config.buildCommand).toBe("pnpm build");
-    expect(config.crons).toEqual([
-      {
-        path: "/api/internal/heartbeat",
-        schedule: "* * * * *",
-      },
-    ]);
-    expect(config.functions).toEqual({
-      "api/internal/agent/continue.ts": {
-        maxDuration: 300,
-        experimentalTriggers: [
-          {
-            type: "queue/v2beta",
-            topic: DEFAULT_CONVERSATION_WORK_QUEUE_TOPIC,
-          },
-        ],
-      },
-    });
+    expect(config.crons).toBeUndefined();
+    expect(config.functions).toBeUndefined();
   });
 
   it("omits buildCommand when set to null", () => {
@@ -40,7 +24,7 @@ describe("juniorVercelConfig", () => {
     expect(config.buildCommand).toBeUndefined();
   });
 
-  it("keeps the example app Vercel config aligned with queue triggers", () => {
+  it("keeps the example app Vercel config aligned with the root project config", () => {
     const config = JSON.parse(
       fs.readFileSync(
         path.join(WORKSPACE_ROOT, "apps/example/vercel.json"),
@@ -51,15 +35,10 @@ describe("juniorVercelConfig", () => {
     expect(config).toEqual(juniorVercelConfig());
   });
 
-  it("keeps the example queue trigger pointed at a concrete function source", () => {
+  it("keeps queue triggers out of the root Vercel source-function config", () => {
     const config = juniorVercelConfig();
-    const functionSources = Object.keys(config.functions as object);
 
-    for (const source of functionSources) {
-      expect(
-        fs.existsSync(path.join(WORKSPACE_ROOT, "apps/example", source)),
-      ).toBe(true);
-    }
+    expect(config.functions).toBeUndefined();
   });
 });
 

--- a/specs/task-execution.md
+++ b/specs/task-execution.md
@@ -203,7 +203,14 @@ internal push endpoint is `/api/internal/agent/continue`, because each queue
 delivery asks Junior to continue the latest durable agent state for that
 conversation. The app must wire the concrete conversation runner before
 registering the queue trigger; otherwise queue messages could be acknowledged
-without advancing agent state.
+without advancing agent state. For Nitro/Vercel deployments, `juniorNitro()`
+must attach that trigger with Nitro `vercel.functionRules`; root
+`vercel.json.functions` entries for source files are not deployable functions
+and must not be used for the conversation work consumer.
+
+`juniorNitro()` must also emit the `/api/internal/heartbeat` one-minute cron
+into Nitro's Vercel Build Output config so trusted plugin heartbeats and stale
+dispatch recovery run in production.
 
 ### Lease And Check-In Contract
 


### PR DESCRIPTION
Move Junior's Vercel cron and queue consumer wiring out of root vercel.json and into juniorNitro() so Nitro emits deployable Build Output config. This fixes deployments where Vercel only saw Nitro's catch-all server function and never registered the conversation work queue trigger.

**Nitro Vercel Output**

juniorNitro() now writes the heartbeat cron and /api/internal/agent/continue functionRule, preserving existing Vercel function settings and supporting custom queue topics.

**Queue Trigger Normalization**

Existing queue triggers on the Junior callback route are normalized to one resolved conversation work topic so stale topics cannot accumulate after config changes.

**CLI Validation**

junior check now reports deployment config status, fails missing juniorNitro() or stale functions["api/internal/agent/continue.ts"], and keeps init scaffolds aligned with the validator.