### PR TITLE
fix(nitro): Copy app content into Vercel queue functions

### DIFF
--- a/apps/example/dashboard.ts
+++ b/apps/example/dashboard.ts
@@ -9,6 +9,14 @@ function isVercelEnvironment(): boolean {
 
 /** Return whether the example dashboard should require browser auth. */
 export function exampleDashboardAuthRequired(): boolean {
+  const authRequired = process.env.JUNIOR_DASHBOARD_AUTH_REQUIRED?.trim();
+  if (authRequired === "true") {
+    return true;
+  }
+  if (authRequired === "false" && !isVercelEnvironment()) {
+    return false;
+  }
+
   return process.env.NODE_ENV !== "development" || isVercelEnvironment();
 }
 

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "predev": "pnpm --filter @sentry/junior build && pnpm --filter @sentry/junior-dashboard build",
     "dev": "nitro dev",
+    "prebuild": "pnpm --filter @sentry/junior build && pnpm --filter @sentry/junior-dashboard build",
     "build": "junior snapshot create && nitro build",
+    "postbuild": "node scripts/check-vercel-output.mjs",
     "preview": "nitro preview",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/example/scripts/check-vercel-output.mjs
+++ b/apps/example/scripts/check-vercel-output.mjs
@@ -1,0 +1,115 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const appRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const repoRoot = path.resolve(appRoot, "../..");
+const outputRoot = path.join(appRoot, ".vercel", "output");
+const functionsRoot = path.join(outputRoot, "functions");
+const serverFunctionDir = path.join(functionsRoot, "__server.func");
+const queueFunctionDir = path.join(
+  functionsRoot,
+  "api",
+  "internal",
+  "agent",
+  "continue.func",
+);
+
+function fail(message) {
+  throw new Error(`Vercel output check failed: ${message}`);
+}
+
+function requireFile(filePath) {
+  if (!existsSync(filePath) || !statSync(filePath).isFile()) {
+    fail(`missing file ${path.relative(appRoot, filePath)}`);
+  }
+}
+
+function requireDirectory(directoryPath) {
+  if (!existsSync(directoryPath) || !statSync(directoryPath).isDirectory()) {
+    fail(`missing directory ${path.relative(appRoot, directoryPath)}`);
+  }
+}
+
+function readJson(filePath) {
+  requireFile(filePath);
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function packageSourceHasPlugin(packageName) {
+  const sourceDir = path.join(
+    repoRoot,
+    "packages",
+    packageName.replace("@sentry/", ""),
+  );
+  return existsSync(path.join(sourceDir, "plugin.yaml"));
+}
+
+function expectedPluginPackages() {
+  const packageJson = readJson(path.join(appRoot, "package.json"));
+  return Object.keys(packageJson.dependencies ?? {})
+    .filter((packageName) => packageName.startsWith("@sentry/junior-"))
+    .filter((packageName) => packageSourceHasPlugin(packageName))
+    .sort();
+}
+
+function assertQueueTrigger() {
+  const vcConfig = readJson(path.join(queueFunctionDir, ".vc-config.json"));
+  const triggers = Array.isArray(vcConfig.experimentalTriggers)
+    ? vcConfig.experimentalTriggers
+    : [];
+  if (
+    !triggers.some(
+      (trigger) =>
+        trigger?.type === "queue/v2beta" &&
+        trigger?.topic === "junior_conversation_work",
+    )
+  ) {
+    fail(
+      "queue callback function is missing the junior_conversation_work trigger",
+    );
+  }
+}
+
+function assertFunctionHasJuniorContent(functionDir, pluginPackages) {
+  requireFile(path.join(functionDir, "index.mjs"));
+  requireFile(path.join(functionDir, "app", "SOUL.md"));
+  requireFile(
+    path.join(functionDir, "app", "plugins", "example-bundle", "plugin.yaml"),
+  );
+  requireFile(
+    path.join(functionDir, "app", "skills", "example-local", "SKILL.md"),
+  );
+
+  for (const packageName of pluginPackages) {
+    requireFile(
+      path.join(functionDir, "node_modules", packageName, "plugin.yaml"),
+    );
+  }
+}
+
+if (existsSync(path.join(appRoot, "api"))) {
+  fail(
+    "apps/example/api exists; Vercel would route source functions before Nitro",
+  );
+}
+
+requireDirectory(serverFunctionDir);
+requireDirectory(queueFunctionDir);
+assertQueueTrigger();
+
+const pluginPackages = expectedPluginPackages();
+if (pluginPackages.length === 0) {
+  fail("no plugin package fixtures were discovered for output validation");
+}
+
+for (const functionDir of [serverFunctionDir, queueFunctionDir]) {
+  assertFunctionHasJuniorContent(functionDir, pluginPackages);
+}
+
+console.log(
+  `Verified Vercel output for ${pluginPackages.length} plugin package(s) in primary and queue functions.`,
+);

--- a/packages/junior/src/instrumentation.ts
+++ b/packages/junior/src/instrumentation.ts
@@ -34,6 +34,7 @@ export function initSentry(): void {
     sendDefaultPii: true,
     enabled: Boolean(dsn),
     enableLogs,
+    registerEsmLoaderHooks: false,
     streamGenAiSpans: true,
     integrations: [
       Sentry.vercelAIIntegration({

--- a/packages/junior/src/nitro.ts
+++ b/packages/junior/src/nitro.ts
@@ -58,6 +58,10 @@ interface ResolvedPluginModuleReference {
   runtimeModule: RuntimePluginModule;
 }
 
+type RollupLikeConfig = {
+  plugins?: unknown[];
+};
+
 const DEFAULT_FUNCTION_MAX_DURATION_SECONDS = 300;
 const VERCEL_QUEUE_TRIGGER_TYPE = "queue/v2beta";
 
@@ -328,7 +332,7 @@ export function juniorNitro(options: JuniorNitroOptions = {}): {
           trustedPluginRegistrations,
         });
 
-        nitro.hooks.hook("compiled", async () => {
+        const copyBuildContent = async () => {
           const pluginSet = await loadConfiguredPluginSet();
           const compiledPluginCatalogConfig =
             pluginCatalogConfigFromPluginSet(pluginSet);
@@ -342,6 +346,17 @@ export function juniorNitro(options: JuniorNitroOptions = {}): {
             nitro.options.output.serverDir,
             options.includeFiles,
           );
+        };
+
+        nitro.hooks.hook("rollup:before", (_nitro, config) => {
+          const buildConfig = config as RollupLikeConfig;
+          buildConfig.plugins ??= [];
+          buildConfig.plugins.push({
+            name: "junior:copy-build-content",
+            async writeBundle() {
+              await copyBuildContent();
+            },
+          });
         });
       },
     },

--- a/packages/junior/tests/integration/example-build-discovery.test.ts
+++ b/packages/junior/tests/integration/example-build-discovery.test.ts
@@ -1,5 +1,11 @@
 import { execFileSync } from "node:child_process";
-import { cpSync, realpathSync, rmSync } from "node:fs";
+import {
+  cpSync,
+  existsSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+} from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -12,6 +18,7 @@ const exampleRoot = path.join(repoRoot, "apps/example");
 const exampleEntry = path.join(exampleRoot, "server.ts");
 const examplePluginsModule = path.join(exampleRoot, "plugins.ts");
 const exampleDashboardConfig = path.join(exampleRoot, "dashboard.ts");
+const examplePackageJson = path.join(exampleRoot, "package.json");
 const exampleRequire = createRequire(exampleEntry);
 const vercelEnvNames = [
   "VERCEL",
@@ -120,6 +127,28 @@ describe.sequential("example build discovery integration", () => {
     };
     expect(config.exampleDashboardAuthRequired()).toBe(true);
 
+    process.env = {
+      ...originalEnv,
+      JUNIOR_DASHBOARD_AUTH_REQUIRED: "false",
+    };
+    clearVercelEnv();
+    expect(config.exampleDashboardAuthRequired()).toBe(false);
+
+    process.env = {
+      ...originalEnv,
+      JUNIOR_DASHBOARD_AUTH_REQUIRED: "false",
+      VERCEL: "1",
+    };
+    expect(config.exampleDashboardAuthRequired()).toBe(true);
+
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: "development",
+      JUNIOR_DASHBOARD_AUTH_REQUIRED: "true",
+    };
+    clearVercelEnv();
+    expect(config.exampleDashboardAuthRequired()).toBe(true);
+
     process.env = { ...originalEnv, NODE_ENV: "production" };
     clearVercelEnv();
     expect(config.exampleDashboardAuthRequired()).toBe(true);
@@ -128,6 +157,28 @@ describe.sequential("example build discovery integration", () => {
     delete process.env.NODE_ENV;
     clearVercelEnv();
     expect(config.exampleDashboardAuthRequired()).toBe(true);
+  });
+
+  it("does not include top-level Vercel api source files", () => {
+    expect(existsSync(path.join(exampleRoot, "api"))).toBe(false);
+  });
+
+  it("runs deployment build guards around the Vercel app build", () => {
+    const packageJson = JSON.parse(
+      readFileSync(examplePackageJson, "utf8"),
+    ) as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(packageJson.scripts?.prebuild).toContain(
+      "pnpm --filter @sentry/junior build",
+    );
+    expect(packageJson.scripts?.prebuild).toContain(
+      "pnpm --filter @sentry/junior-dashboard build",
+    );
+    expect(packageJson.scripts?.postbuild).toBe(
+      "node scripts/check-vercel-output.mjs",
+    );
   });
 
   it("serves built health and recognizes the sentry oauth callback route", async () => {

--- a/packages/junior/tests/unit/build/nitro-plugin-module.test.ts
+++ b/packages/junior/tests/unit/build/nitro-plugin-module.test.ts
@@ -33,6 +33,20 @@ interface TestVercelOptions {
   functionRules?: Record<string, TestFunctionRule>;
 }
 
+interface TestBuildPlugin {
+  name: string;
+  writeBundle?: () => Promise<void> | void;
+}
+
+interface TestBuildConfig {
+  plugins?: TestBuildPlugin[];
+}
+
+type TestRollupBeforeHook = (
+  nitro: unknown,
+  config: TestBuildConfig,
+) => Promise<void> | void;
+
 async function makeTempDir(): Promise<string> {
   const tempDir = await fs.mkdtemp(
     path.join(os.tmpdir(), "junior-nitro-plugin-module-"),
@@ -316,15 +330,10 @@ describe("juniorNitro plugin modules", () => {
   });
 
   it("rejects direct trusted plugin sets because hooks need a runtime import", () => {
-    const compiledHooks: Array<() => Promise<void> | void> = [];
     const virtual: Record<string, (() => Promise<string>) | string> = {};
     const nitro = {
       hooks: {
-        hook(name: string, callback: () => Promise<void> | void) {
-          if (name === "compiled") {
-            compiledHooks.push(callback);
-          }
-        },
+        hook() {},
       },
       options: {
         output: {
@@ -368,13 +377,13 @@ describe("juniorNitro plugin modules", () => {
       "utf8",
     );
 
-    const compiledHooks: Array<() => Promise<void> | void> = [];
+    const rollupBeforeHooks: TestRollupBeforeHook[] = [];
     const virtual: Record<string, (() => Promise<string>) | string> = {};
     const nitro = {
       hooks: {
-        hook(name: string, callback: () => Promise<void> | void) {
-          if (name === "compiled") {
-            compiledHooks.push(callback);
+        hook(name: string, callback: TestRollupBeforeHook) {
+          if (name === "rollup:before") {
+            rollupBeforeHooks.push(callback);
           }
         },
       },
@@ -400,6 +409,119 @@ describe("juniorNitro plugin modules", () => {
     expect(code).toContain(
       'export const plugins = {"packages":["@acme/junior-demo"]};',
     );
-    expect(compiledHooks).toHaveLength(1);
+    expect(rollupBeforeHooks).toHaveLength(1);
+  });
+
+  it("copies app and plugin content before Vercel route functions are cloned", async () => {
+    const tempRoot = await makeTempDir();
+    const serverDir = path.join(
+      tempRoot,
+      ".vercel",
+      "output",
+      "functions",
+      "__server.func",
+    );
+    const callbackDir = path.join(
+      tempRoot,
+      ".vercel",
+      "output",
+      "functions",
+      "api",
+      "internal",
+      "agent",
+      "continue.func",
+    );
+    const packageDir = path.join(
+      tempRoot,
+      "node_modules",
+      "@acme",
+      "junior-demo",
+    );
+    await fs.mkdir(path.join(tempRoot, "app"), { recursive: true });
+    await fs.writeFile(
+      path.join(tempRoot, "app", "SOUL.md"),
+      "Local soul\n",
+      "utf8",
+    );
+    await fs.mkdir(path.join(packageDir, "skills", "demo"), {
+      recursive: true,
+    });
+    await fs.writeFile(
+      path.join(packageDir, "plugin.yaml"),
+      "name: demo\ndescription: Demo plugin\n",
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(packageDir, "skills", "demo", "SKILL.md"),
+      "---\nname: demo\ndescription: Demo\n---\n",
+      "utf8",
+    );
+    await fs.mkdir(serverDir, { recursive: true });
+
+    const rollupBeforeHooks: TestRollupBeforeHook[] = [];
+    const virtual: Record<string, (() => Promise<string>) | string> = {};
+    const nitro = {
+      hooks: {
+        hook(name: string, callback: TestRollupBeforeHook) {
+          if (name === "rollup:before") {
+            rollupBeforeHooks.push(callback);
+          }
+        },
+      },
+      options: {
+        output: {
+          serverDir,
+        },
+        rootDir: tempRoot,
+        vercel: {},
+        virtual,
+      },
+    };
+
+    juniorNitro({
+      cwd: tempRoot,
+      plugins: defineJuniorPlugins(["@acme/junior-demo"]),
+    }).nitro.setup(nitro);
+    const buildConfig: TestBuildConfig = { plugins: [] };
+    await rollupBeforeHooks[0]?.(nitro, buildConfig);
+    const copyPlugin = buildConfig.plugins?.find(
+      (plugin) => plugin.name === "junior:copy-build-content",
+    );
+    expect(copyPlugin).toBeDefined();
+    await copyPlugin?.writeBundle?.();
+
+    await fs.cp(serverDir, callbackDir, { recursive: true });
+
+    for (const functionDir of [serverDir, callbackDir]) {
+      await expect(
+        fs.readFile(path.join(functionDir, "app", "SOUL.md"), "utf8"),
+      ).resolves.toBe("Local soul\n");
+      await expect(
+        fs.readFile(
+          path.join(
+            functionDir,
+            "node_modules",
+            "@acme",
+            "junior-demo",
+            "plugin.yaml",
+          ),
+          "utf8",
+        ),
+      ).resolves.toContain("name: demo");
+      await expect(
+        fs.readFile(
+          path.join(
+            functionDir,
+            "node_modules",
+            "@acme",
+            "junior-demo",
+            "skills",
+            "demo",
+            "SKILL.md",
+          ),
+          "utf8",
+        ),
+      ).resolves.toContain("description: Demo");
+    }
   });
 });


### PR DESCRIPTION
Copy Junior app and plugin payload into Nitro’s server output during the Rollup/Rolldown `writeBundle` phase. Nitro’s Vercel preset later clones that output for `functionRules` route functions, so the generated queue callback receives the same runtime filesystem content as the primary `__server.func` without walking generated `.func` directories.

**Why This Started Now**

The durable queue work moved Slack turn execution behind a Vercel Queue callback at `/api/internal/agent/continue`. That made Slack processing depend on a second serverless function, while `juniorNitro()` still copied app/plugin runtime content only after Nitro had already built the primary server output. The later source-file workaround was removed because it let Vercel route source functions before Nitro; this PR keeps the Nitro-owned architecture and moves the content copy earlier in Nitro’s build lifecycle.

**Build Lifecycle**

`juniorNitro()` now installs a build plugin from `rollup:before` and copies app/plugin/include content in `writeBundle`. That places Junior’s runtime-discovered files in `output.serverDir` before deployment presets generate derived functions, which lets Nitro/Vercel’s own cloning behavior carry the files into the queue callback.

**Deployment Guard**

The example app runs a postbuild verifier that fails when `apps/example/api` reappears, when the queue callback trigger is missing, or when the primary/queue functions lack app and plugin content. CI already runs the example build, so this guard covers the production failure mode.

**Runtime Startup**

Sentry ESM loader hooks are disabled so startup does not rely on runtime resolution of `import-in-the-middle/hook.mjs` in the serverless bundle.