### PR TITLE
fix(dashboard): Preserve login return paths

### DIFF
--- a/packages/junior-dashboard/src/app.ts
+++ b/packages/junior-dashboard/src/app.ts
@@ -18,6 +18,7 @@ import { createMockConversationReporting } from "./mock-conversations";
 const DEFAULT_BASE_PATH = "/";
 const DEFAULT_AUTH_PATH = "/api/auth";
 const DASHBOARD_CLIENT_VERSION = Date.now().toString(36);
+const LOGIN_NEXT_PARAM = "next";
 
 export interface JuniorDashboardOptions {
   basePath?: string;
@@ -69,17 +70,69 @@ function isJsonRoute(pathname: string): boolean {
   return pathname.startsWith("/api/");
 }
 
-function dashboardLoginUrl(request: Request): string {
+function isDashboardPagePath(pathname: string, basePath: string): boolean {
+  for (const path of dashboardPagePaths(basePath)) {
+    if (
+      pathname === path ||
+      (path !== "/" && pathname.startsWith(`${path}/`))
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function dashboardReturnPath(url: URL, basePath: string): string | undefined {
+  if (!isDashboardPagePath(url.pathname, basePath)) {
+    return undefined;
+  }
+
+  const path = `${url.pathname}${url.search}`;
+  return path === basePath ? undefined : path;
+}
+
+function requestedReturnPath(url: URL, basePath: string): string | undefined {
+  const next = url.searchParams.get(LOGIN_NEXT_PARAM);
+  if (!next?.startsWith("/") || next.startsWith("//")) {
+    return undefined;
+  }
+
+  const returnUrl = new URL(next, url.origin);
+  if (
+    returnUrl.origin !== url.origin ||
+    !isDashboardPagePath(returnUrl.pathname, basePath)
+  ) {
+    return undefined;
+  }
+
+  return `${returnUrl.pathname}${returnUrl.search}`;
+}
+
+function dashboardLoginUrl(request: Request, basePath: string): string {
+  const requestUrl = new URL(request.url);
   const url = new URL(request.url);
   url.pathname = "/api/dashboard/login";
   url.search = "";
+  const returnPath = dashboardReturnPath(requestUrl, basePath);
+  if (returnPath) {
+    url.searchParams.set(LOGIN_NEXT_PARAM, returnPath);
+  }
   return url.toString();
 }
 
 function callbackUrl(request: Request, basePath: string): string {
+  const requestUrl = new URL(request.url);
+  const returnPath = requestedReturnPath(requestUrl, basePath);
   const url = new URL(request.url);
-  url.pathname = basePath;
-  url.search = "";
+  if (returnPath) {
+    const returnUrl = new URL(returnPath, requestUrl.origin);
+    url.pathname = returnUrl.pathname;
+    url.search = returnUrl.search;
+  } else {
+    url.pathname = basePath;
+    url.search = "";
+  }
   return url.toString();
 }
 
@@ -100,11 +153,11 @@ function isAuthorized(
   );
 }
 
-function unauthorized(request: Request): Response {
+function unauthorized(request: Request, basePath: string): Response {
   if (isJsonRoute(new URL(request.url).pathname)) {
     return Response.json({ error: "unauthenticated" }, { status: 401 });
   }
-  return Response.redirect(dashboardLoginUrl(request), 302);
+  return Response.redirect(dashboardLoginUrl(request, basePath), 302);
 }
 
 function forbidden(request: Request): Response {
@@ -346,10 +399,15 @@ export function createDashboardApp(
   app.get("/favicon.ico", () => renderFavicon());
 
   app.get("/api/dashboard/login", async (c) => {
+    const returnUrl = callbackUrl(c.req.raw, basePath);
     if (!auth) {
-      return Response.redirect(callbackUrl(c.req.raw, basePath), 302);
+      return Response.redirect(returnUrl, 302);
     }
-    return auth.signInWithGoogle(c.req.raw, callbackUrl(c.req.raw, basePath));
+    const session = await auth.getSession(c.req.raw);
+    if (session && isAuthorized(session, allowedDomains, allowedEmails)) {
+      return Response.redirect(returnUrl, 302);
+    }
+    return auth.signInWithGoogle(c.req.raw, returnUrl);
   });
 
   const requireDashboardSession = async (
@@ -363,11 +421,11 @@ export function createDashboardApp(
     }
 
     if (!auth) {
-      return unauthorized(c.req.raw);
+      return unauthorized(c.req.raw, basePath);
     }
     const session = await auth.getSession(c.req.raw);
     if (!session) {
-      return unauthorized(c.req.raw);
+      return unauthorized(c.req.raw, basePath);
     }
     if (!isAuthorized(session, allowedDomains, allowedEmails)) {
       return forbidden(c.req.raw);

--- a/packages/junior-dashboard/src/client/api.ts
+++ b/packages/junior-dashboard/src/client/api.ts
@@ -31,7 +31,17 @@ function restartDashboardSignIn(): void {
 
   const loginPath = "/api/dashboard/login";
   if (window.location.pathname !== loginPath) {
-    window.location.assign(loginPath);
+    const returnPath = `${window.location.pathname}${
+      window.location.search || ""
+    }`;
+    const loginParams = new URLSearchParams();
+    if (returnPath !== "/") {
+      loginParams.set("next", returnPath);
+    }
+    const loginSearch = loginParams.toString();
+    window.location.assign(
+      loginSearch ? `${loginPath}?${loginSearch}` : loginPath,
+    );
   }
 }
 

--- a/packages/junior-dashboard/tests/client-api.test.ts
+++ b/packages/junior-dashboard/tests/client-api.test.ts
@@ -17,6 +17,7 @@ describe("dashboard client API", () => {
       location: {
         assign,
         pathname: "/conversations",
+        search: "?filter=recent",
       },
     });
 
@@ -28,7 +29,9 @@ describe("dashboard client API", () => {
       "/api/dashboard/conversations/slack%3AC1%3A123",
       { credentials: "same-origin" },
     );
-    expect(assign).toHaveBeenCalledWith("/api/dashboard/login");
+    expect(assign).toHaveBeenCalledWith(
+      "/api/dashboard/login?next=%2Fconversations%3Ffilter%3Drecent",
+    );
   });
 
   it("does not redirect for non-auth dashboard API failures", async () => {
@@ -41,6 +44,7 @@ describe("dashboard client API", () => {
       location: {
         assign,
         pathname: "/conversations",
+        search: "",
       },
     });
 

--- a/packages/junior-dashboard/tests/dashboard-routes.test.ts
+++ b/packages/junior-dashboard/tests/dashboard-routes.test.ts
@@ -152,7 +152,10 @@ function reporting(): JuniorReporting {
   };
 }
 
-function auth(session: DashboardSession | null): DashboardAuth {
+function auth(
+  session: DashboardSession | null,
+  onSignIn?: (callbackURL: string) => void,
+): DashboardAuth {
   return {
     async handler() {
       return Response.json({ ok: true });
@@ -160,7 +163,8 @@ function auth(session: DashboardSession | null): DashboardAuth {
     async getSession() {
       return session;
     },
-    async signInWithGoogle() {
+    async signInWithGoogle(_request, callbackURL) {
+      onSignIn?.(callbackURL);
       return Response.redirect(
         "https://accounts.google.com/o/oauth2/v2/auth",
         302,
@@ -207,15 +211,122 @@ describe("dashboard routes", () => {
     for (const path of [
       "/conversations",
       "/conversations/slack%3AC1%3A123",
+      "/conversations/slack%3AC1%3A123?view=tools",
       "/sessions",
       "/sessions/some-session",
     ]) {
       const response = await app.fetch(new Request(`http://localhost${path}`));
       expect(response.status, path).toBe(302);
-      expect(response.headers.get("location"), path).toBe(
-        `http://localhost/api/dashboard/login`,
+      const location = new URL(response.headers.get("location")!);
+      expect(`${location.origin}${location.pathname}`, path).toBe(
+        "http://localhost/api/dashboard/login",
       );
+      expect(location.searchParams.get("next"), path).toBe(path);
     }
+  });
+
+  it("uses the requested dashboard path as the Google sign-in callback", async () => {
+    let callbackURL: string | undefined;
+    const app = createDashboardApp({
+      allowedGoogleDomains: ["sentry.io"],
+      auth: auth(null, (value) => {
+        callbackURL = value;
+      }),
+      reporting: reporting(),
+    });
+
+    const unauthenticated = await app.fetch(
+      new Request("http://localhost/conversations/slack%3AC1%3A123?view=tools"),
+    );
+    const loginUrl = unauthenticated.headers.get("location");
+    expect(loginUrl).toBeTruthy();
+
+    const signIn = await app.fetch(new Request(loginUrl!));
+
+    expect(signIn.status).toBe(302);
+    expect(callbackURL).toBe(
+      "http://localhost/conversations/slack%3AC1%3A123?view=tools",
+    );
+  });
+
+  it("preserves non-root dashboard base paths through Google sign-in", async () => {
+    let callbackURL: string | undefined;
+    const app = createDashboardApp({
+      allowedGoogleDomains: ["sentry.io"],
+      auth: auth(null, (value) => {
+        callbackURL = value;
+      }),
+      basePath: "/ops",
+      reporting: reporting(),
+    });
+
+    const unauthenticated = await app.fetch(
+      new Request("http://localhost/ops/conversations/slack%3AC1%3A123"),
+    );
+    const loginUrl = unauthenticated.headers.get("location");
+    expect(loginUrl).toBeTruthy();
+    expect(new URL(loginUrl!).searchParams.get("next")).toBe(
+      "/ops/conversations/slack%3AC1%3A123",
+    );
+
+    const signIn = await app.fetch(new Request(loginUrl!));
+
+    expect(signIn.status).toBe(302);
+    expect(callbackURL).toBe(
+      "http://localhost/ops/conversations/slack%3AC1%3A123",
+    );
+  });
+
+  it("falls back to the dashboard root for unsafe login return paths", async () => {
+    let callbackURL: string | undefined;
+    const app = createDashboardApp({
+      allowedGoogleDomains: ["sentry.io"],
+      auth: auth(null, (value) => {
+        callbackURL = value;
+      }),
+      reporting: reporting(),
+    });
+
+    const response = await app.fetch(
+      new Request(
+        "http://localhost/api/dashboard/login?next=https%3A%2F%2Fevil.example%2Fconversations",
+      ),
+    );
+
+    expect(response.status).toBe(302);
+    expect(callbackURL).toBe("http://localhost/");
+  });
+
+  it("does not restart Google sign-in for an already authorized session", async () => {
+    let startedGoogleSignIn = false;
+    const app = createDashboardApp({
+      allowedGoogleDomains: ["sentry.io"],
+      auth: auth(
+        {
+          user: {
+            email: "person@sentry.io",
+            emailVerified: true,
+            hostedDomain: "sentry.io",
+          },
+        },
+        () => {
+          startedGoogleSignIn = true;
+        },
+      ),
+      reporting: reporting(),
+    });
+
+    const response = await app.fetch(
+      new Request(
+        "http://localhost/api/dashboard/login?next=%2Fconversations%2Fslack%253AC1%253A123",
+      ),
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost/conversations/slack%3AC1%3A123",
+    );
+    expect(startedGoogleSignIn).toBe(false);
   });
 
   it("can explicitly disable dashboard auth for local development", async () => {


### PR DESCRIPTION
Dashboard page requests now carry their destination through the Google sign-in flow so deep links return to the page the user originally opened. The login route also skips starting a fresh Google OAuth flow when the browser already has an authorized dashboard session.

**Return Path Validation**

The dashboard only accepts same-origin dashboard UI paths as login return targets and falls back to the dashboard root for unsafe or non-dashboard values.

**Session Expiry**

Client-side dashboard API 401s restart sign-in with the current page path attached, preserving conversation and filtered views after re-authentication.