### PR TITLE
fix(runtime): Preserve cooperative yield outcomes

### DIFF
--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -471,7 +471,7 @@ export async function generateAssistantReply(
   let canRecordMcpProviders = false;
   let sandboxExecutor: SandboxExecutor | undefined;
   let timedOut = false;
-  let yielded = false;
+  let cooperativeYieldError: CooperativeTurnYieldError | undefined;
   let inputCommitted = false;
   let turnUsage: AgentTurnUsage | undefined;
   let thinkingSelection: TurnThinkingSelection | undefined;
@@ -1211,13 +1211,13 @@ export async function generateAssistantReply(
         return;
       }
 
-      yielded = true;
       timeoutResumeMessages = getResumeSnapshot();
-      throw new CooperativeTurnYieldError(
+      cooperativeYieldError = new CooperativeTurnYieldError(
         `Agent turn yielded at a safe boundary after ${
           Date.now() - replyStartedAtMs
         }ms`,
       );
+      throw cooperativeYieldError;
     };
 
     agent = new Agent({
@@ -1400,6 +1400,9 @@ export async function generateAssistantReply(
           let retryUsage: AgentTurnUsage | undefined;
           for (let attempt = 0; ; attempt += 1) {
             promptResult = await runAgentStep(run);
+            if (cooperativeYieldError) {
+              throw cooperativeYieldError;
+            }
 
             newMessages = agent.state.messages.slice(beforeMessageCount);
             const outputMessages = newMessages.filter(isAssistantMessage);
@@ -1530,7 +1533,7 @@ export async function generateAssistantReply(
     });
   } catch (error) {
     if (
-      yielded &&
+      cooperativeYieldError &&
       error instanceof CooperativeTurnYieldError &&
       timeoutResumeConversationId &&
       timeoutResumeSessionId

--- a/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
@@ -58,6 +58,19 @@ vi.mock("@earendil-works/pi-agent-core", () => {
       return undefined;
     }
 
+    private recordRunFailure(error: unknown) {
+      this.state.messages.push({
+        role: "assistant",
+        content: [{ type: "text", text: "" }],
+        stopReason: "error",
+        errorMessage: error instanceof Error ? error.message : String(error),
+        usage: {
+          input: 0,
+          output: 0,
+        },
+      });
+    }
+
     async prompt(message: unknown) {
       counters.promptCalls += 1;
       this.state.messages.push(message);
@@ -66,7 +79,12 @@ vi.mock("@earendil-works/pi-agent-core", () => {
         agentMode.value === "steering" ||
         agentMode.value === "steeringSteerThrows"
       ) {
-        await this.prepareNextTurn?.();
+        try {
+          await this.prepareNextTurn?.();
+        } catch (error) {
+          this.recordRunFailure(error);
+          return {};
+        }
         this.state.messages.push(...this.steeringMessages);
         this.state.messages.push({
           role: "assistant",
@@ -323,6 +341,9 @@ describe("generateAssistantReply provider retry", () => {
     expect(sessionRecord).toMatchObject({
       state: "awaiting_resume",
       resumeReason: "yield",
+      errorMessage: expect.stringContaining(
+        "Agent turn yielded at a safe boundary",
+      ),
       sliceId: 1,
     });
     expect(sessionRecord?.piMessages.map((message) => message.role)).toEqual([
@@ -372,6 +393,9 @@ describe("generateAssistantReply provider retry", () => {
     expect(sessionRecord).toMatchObject({
       state: "awaiting_resume",
       resumeReason: "yield",
+      errorMessage: expect.stringContaining(
+        "Agent turn yielded at a safe boundary",
+      ),
       sliceId: 1,
     });
     expect(sessionRecord?.piMessages.map((message) => message.role)).toEqual([


### PR DESCRIPTION
Preserve cooperative yield handling when Pi converts a hook throw into an assistant error message. Junior now rethrows its recorded CooperativeTurnYieldError after the Agent run settles, so the worker persists the yield snapshot and resumes instead of sending a provider-error failure reply.

**Regression Coverage**

The provider retry unit now mirrors Pi's real runWithLifecycle failure behavior by recording a terminal assistant stopReason error when prepareNextTurn throws. The yield tests assert the resumable session keeps the safe Pi snapshot rather than persisting the synthetic failure message.

Fixes JUNIOR-37