### PR TITLE
feat(dashboard): Add live transcript bottom pinning

### DIFF
--- a/packages/junior-dashboard/src/client/components/Transcript.tsx
+++ b/packages/junior-dashboard/src/client/components/Transcript.tsx
@@ -1,18 +1,30 @@
 import { useState, type ReactNode } from "react";
+import { ArrowDownToLine } from "lucide-react";
 
 import type { ConversationTurn } from "../types";
+import { cn } from "../styles";
+import { Button } from "./Button";
 import { TranscriptHeader } from "./TranscriptHeader";
 import { ConversationTranscriptSegment } from "./TranscriptTurn";
+import {
+  transcriptBottomVersion,
+  usePinnedTranscriptBottom,
+} from "./transcriptBottomPinning";
 import type { TranscriptViewMode } from "./transcriptRenderModel";
 import { transcriptEmptyClass } from "./transcriptStyles";
 
 /** Render ordered conversation transcript segments as message and tool events. */
 export function Transcript(props: {
   actions?: ReactNode;
+  live?: boolean;
   turns: ConversationTurn[];
 }) {
   const [view, setView] = useState<TranscriptViewMode>("rich");
   const hasRedactedTurns = props.turns.some((turn) => turn.transcriptRedacted);
+  const bottomPinning = usePinnedTranscriptBottom({
+    enabled: props.live ?? false,
+    version: transcriptBottomVersion(props.turns),
+  });
 
   if (props.turns.length === 0) {
     return (
@@ -23,7 +35,10 @@ export function Transcript(props: {
   }
 
   return (
-    <div className="grid min-w-0">
+    <div
+      className={cn("grid min-w-0", props.live && "max-sm:pr-12")}
+      ref={bottomPinning.contentRef}
+    >
       <TranscriptHeader
         actions={props.actions}
         redacted={hasRedactedTurns}
@@ -31,12 +46,46 @@ export function Transcript(props: {
         onChange={setView}
       />
       {props.turns.map((turn) => (
-        <ConversationTranscriptSegment
-          key={turn.id}
-          turn={turn}
-          view={view}
-        />
+        <ConversationTranscriptSegment key={turn.id} turn={turn} view={view} />
       ))}
+      <div aria-hidden="true" className="h-px" ref={bottomPinning.anchorRef} />
+      <JumpToLatestButton
+        hasPendingUpdate={bottomPinning.hasPendingUpdate}
+        onClick={bottomPinning.jumpToBottom}
+        visible={bottomPinning.showJumpToLatest}
+      />
+    </div>
+  );
+}
+
+function JumpToLatestButton(props: {
+  hasPendingUpdate: boolean;
+  onClick: () => void;
+  visible: boolean;
+}) {
+  if (!props.visible) return null;
+
+  const label = props.hasPendingUpdate
+    ? "Jump to latest update"
+    : "Jump to latest";
+
+  return (
+    <div className="fixed bottom-4 right-4 z-20 md:bottom-6 md:right-8">
+      <Button
+        aria-label={label}
+        className="relative border-[#beaaff]/45 bg-[#111] shadow-[0_6px_24px_rgba(0,0,0,0.36)] hover:border-[#d8ccff]/70"
+        onClick={props.onClick}
+        size="icon"
+        title={label}
+      >
+        <ArrowDownToLine aria-hidden="true" size={16} strokeWidth={2} />
+        {props.hasPendingUpdate ? (
+          <span
+            aria-hidden="true"
+            className="absolute right-1.5 top-1.5 size-2 bg-emerald-300"
+          />
+        ) : null}
+      </Button>
     </div>
   );
 }

--- a/packages/junior-dashboard/src/client/components/transcriptBottomPinning.ts
+++ b/packages/junior-dashboard/src/client/components/transcriptBottomPinning.ts
@@ -1,0 +1,279 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
+
+import type { ConversationTurn, TranscriptPart } from "../types";
+
+const BOTTOM_PROXIMITY_PX = 96;
+const USER_SCROLL_DELTA_PX = 2;
+
+type ScrollRoot = HTMLElement | Window;
+
+export type ScrollSnapshot = {
+  clientHeight: number;
+  scrollHeight: number;
+  scrollTop: number;
+};
+
+type BottomPinResult = {
+  anchorRef: RefObject<HTMLDivElement | null>;
+  contentRef: RefObject<HTMLDivElement | null>;
+  hasPendingUpdate: boolean;
+  jumpToBottom: () => void;
+  showJumpToLatest: boolean;
+};
+
+const useBrowserLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+/** Detect proximity with slack so fractional pixels and mobile chrome do not break follow mode. */
+export function isNearScrollBottom(
+  snapshot: ScrollSnapshot,
+  thresholdPx = BOTTOM_PROXIMITY_PX,
+): boolean {
+  const remaining =
+    snapshot.scrollHeight - snapshot.scrollTop - snapshot.clientHeight;
+  return remaining <= thresholdPx;
+}
+
+/** Build a compact transcript-tail key so polling without content changes does not look new. */
+export function transcriptBottomVersion(turns: ConversationTurn[]): string {
+  const lastTurn = turns.at(-1);
+  if (!lastTurn) return "empty";
+
+  const messages =
+    lastTurn.transcript.length > 0
+      ? lastTurn.transcript
+      : (lastTurn.transcriptMetadata ?? []);
+  const lastMessage = messages.at(-1);
+  const lastPart = lastMessage?.parts.at(-1);
+
+  return [
+    turns.length,
+    lastTurn.id,
+    lastTurn.status,
+    messages.length,
+    lastMessage?.role ?? "",
+    lastMessage?.timestamp ?? "",
+    lastMessage?.parts.length ?? 0,
+    transcriptPartVersion(lastPart),
+  ].join("|");
+}
+
+/** Keep live transcript updates visually pinned only while the reader intends to follow them. */
+export function usePinnedTranscriptBottom(input: {
+  enabled: boolean;
+  version: string;
+}): BottomPinResult {
+  const anchorRef = useRef<HTMLDivElement | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const enabledRef = useRef(input.enabled);
+  const everEnabledRef = useRef(input.enabled);
+  const followingRef = useRef(false);
+  const initializedRef = useRef(false);
+  const previousScrollTopRef = useRef<number | null>(null);
+  const [following, setFollowing] = useState(false);
+  const [hasPendingUpdate, setHasPendingUpdate] = useState(false);
+
+  useEffect(() => {
+    enabledRef.current = input.enabled;
+    if (input.enabled) {
+      everEnabledRef.current = true;
+    } else {
+      setHasPendingUpdate(false);
+    }
+  }, [input.enabled]);
+
+  const setFollowingIntent = useCallback((value: boolean) => {
+    followingRef.current = value;
+    setFollowing(value);
+  }, []);
+
+  const measurePosition = useCallback(
+    (source: "measure" | "scroll") => {
+      const root = scrollRootFor(contentRef.current);
+      if (!root) return;
+
+      const snapshot = scrollSnapshot(root);
+      const nearBottom = isNearScrollBottom(snapshot);
+      const previousScrollTop = previousScrollTopRef.current;
+      previousScrollTopRef.current = snapshot.scrollTop;
+
+      if (nearBottom) {
+        setFollowingIntent(true);
+        setHasPendingUpdate(false);
+        return;
+      }
+
+      if (
+        source === "scroll" &&
+        previousScrollTop != null &&
+        snapshot.scrollTop < previousScrollTop - USER_SCROLL_DELTA_PX
+      ) {
+        setFollowingIntent(false);
+      }
+    },
+    [setFollowingIntent],
+  );
+
+  const scrollToBottom = useCallback((behavior: ScrollBehavior) => {
+    anchorRef.current?.scrollIntoView({ behavior, block: "end" });
+  }, []);
+
+  useBrowserLayoutEffect(() => {
+    const wasEnabled = enabledRef.current;
+    const shouldTrack = input.enabled || wasEnabled;
+    enabledRef.current = input.enabled;
+    if (input.enabled) everEnabledRef.current = true;
+    if (!shouldTrack) return;
+
+    const wasInitialized = initializedRef.current;
+    if (!initializedRef.current) {
+      initializedRef.current = true;
+      measurePosition("measure");
+    }
+
+    if (followingRef.current) {
+      scrollToBottom("auto");
+      setHasPendingUpdate(false);
+      return;
+    }
+
+    if (input.enabled && wasInitialized) {
+      setHasPendingUpdate(true);
+    }
+  }, [input.enabled, input.version, measurePosition, scrollToBottom]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const root = scrollRootFor(contentRef.current);
+    if (!root) return;
+
+    const target: HTMLElement | Window = root === window ? window : root;
+    const onScroll = () => measurePosition("scroll");
+    const onResize = () => measurePosition("measure");
+
+    measurePosition("measure");
+    target.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onResize);
+    return () => {
+      target.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onResize);
+    };
+  }, [measurePosition]);
+
+  useEffect(() => {
+    if (typeof ResizeObserver === "undefined") return;
+    const content = contentRef.current;
+    if (!content) return;
+
+    const observer = new ResizeObserver(() => {
+      if (everEnabledRef.current && followingRef.current) {
+        scrollToBottom("auto");
+        return;
+      }
+
+      measurePosition("measure");
+    });
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, [measurePosition, scrollToBottom]);
+
+  const jumpToBottom = useCallback(() => {
+    setFollowingIntent(true);
+    setHasPendingUpdate(false);
+    scrollToBottom(preferredExplicitScrollBehavior());
+  }, [scrollToBottom, setFollowingIntent]);
+
+  return useMemo(
+    () => ({
+      anchorRef,
+      contentRef,
+      hasPendingUpdate,
+      jumpToBottom,
+      showJumpToLatest: input.enabled && !following,
+    }),
+    [following, hasPendingUpdate, input.enabled, jumpToBottom],
+  );
+}
+
+function transcriptPartVersion(part: TranscriptPart | undefined): string {
+  if (!part) return "";
+
+  return [
+    part.type,
+    part.id ?? "",
+    part.name ?? "",
+    part.chars ?? part.text?.length ?? "",
+    part.bytes ?? "",
+    part.inputSizeChars ?? "",
+    part.inputSizeBytes ?? "",
+    part.outputSizeChars ?? outputLength(part.output),
+    part.outputSizeBytes ?? "",
+    part.redacted ? "redacted" : "",
+  ].join(":");
+}
+
+function outputLength(output: unknown): number | string {
+  if (typeof output === "string") return output.length;
+  if (output == null) return "";
+  return "";
+}
+
+function scrollRootFor(element: HTMLElement | null): ScrollRoot | null {
+  if (typeof window === "undefined") return null;
+  if (!element) return window;
+
+  let current = element.parentElement;
+  while (current && current !== document.body) {
+    const style = window.getComputedStyle(current);
+    if (
+      /(auto|scroll|overlay)/.test(style.overflowY) &&
+      current.scrollHeight > current.clientHeight
+    ) {
+      return current;
+    }
+    current = current.parentElement;
+  }
+
+  return window;
+}
+
+function scrollSnapshot(root: ScrollRoot): ScrollSnapshot {
+  if (isWindowRoot(root)) {
+    const element = document.scrollingElement ?? document.documentElement;
+    return {
+      clientHeight: window.innerHeight,
+      scrollHeight: element.scrollHeight,
+      scrollTop: window.scrollY || element.scrollTop,
+    };
+  }
+
+  return {
+    clientHeight: root.clientHeight,
+    scrollHeight: root.scrollHeight,
+    scrollTop: root.scrollTop,
+  };
+}
+
+function isWindowRoot(root: ScrollRoot): root is Window {
+  return root === window;
+}
+
+function preferredExplicitScrollBehavior(): ScrollBehavior {
+  if (typeof window === "undefined") return "auto";
+  if (
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  ) {
+    return "auto";
+  }
+  return "smooth";
+}

--- a/packages/junior-dashboard/src/client/components/transcriptBottomPinning.ts
+++ b/packages/junior-dashboard/src/client/components/transcriptBottomPinning.ts
@@ -5,6 +5,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type RefCallback,
   type RefObject,
 } from "react";
 
@@ -26,7 +27,7 @@ export type ScrollSnapshot = {
 
 type BottomPinResult = {
   anchorRef: RefObject<HTMLDivElement | null>;
-  contentRef: RefObject<HTMLDivElement | null>;
+  contentRef: RefCallback<HTMLDivElement>;
   hasPendingUpdate: boolean;
   jumpToBottom: () => void;
   showJumpToLatest: boolean;
@@ -101,7 +102,7 @@ export function usePinnedTranscriptBottom(input: {
   version: string;
 }): BottomPinResult {
   const anchorRef = useRef<HTMLDivElement | null>(null);
-  const contentRef = useRef<HTMLDivElement | null>(null);
+  const contentElementRef = useRef<HTMLDivElement | null>(null);
   const enabledRef = useRef(input.enabled);
   const everEnabledRef = useRef(input.enabled);
   const followingRef = useRef(false);
@@ -109,6 +110,14 @@ export function usePinnedTranscriptBottom(input: {
   const previousScrollTopRef = useRef<number | null>(null);
   const [following, setFollowing] = useState(false);
   const [hasPendingUpdate, setHasPendingUpdate] = useState(false);
+  const [contentElement, setContentElement] = useState<HTMLDivElement | null>(
+    null,
+  );
+
+  const contentRef = useCallback((node: HTMLDivElement | null) => {
+    contentElementRef.current = node;
+    setContentElement(node);
+  }, []);
 
   useEffect(() => {
     enabledRef.current = input.enabled;
@@ -128,7 +137,7 @@ export function usePinnedTranscriptBottom(input: {
 
   const measurePosition = useCallback(
     (source: PositionMeasureSource) => {
-      const root = scrollRootFor(contentRef.current);
+      const root = scrollRootFor(contentElementRef.current);
       if (!root) return;
 
       const snapshot = scrollSnapshot(root);
@@ -156,6 +165,20 @@ export function usePinnedTranscriptBottom(input: {
   const scrollToBottom = useCallback((behavior: ScrollBehavior) => {
     anchorRef.current?.scrollIntoView({ behavior, block: "end" });
   }, []);
+
+  const syncAfterLayoutChange = useCallback(() => {
+    if (
+      shouldAutoPinTranscriptBottom({
+        enabled: enabledRef.current,
+        following: followingRef.current,
+      })
+    ) {
+      scrollToBottom("auto");
+      return;
+    }
+
+    measurePosition("measure");
+  }, [measurePosition, scrollToBottom]);
 
   useBrowserLayoutEffect(() => {
     const wasEnabled = enabledRef.current;
@@ -189,43 +212,31 @@ export function usePinnedTranscriptBottom(input: {
   useEffect(() => {
     if (typeof window === "undefined") return;
 
-    const root = scrollRootFor(contentRef.current);
+    const root = scrollRootFor(contentElement);
     if (!root) return;
 
     const target: HTMLElement | Window = root === window ? window : root;
     const onScroll = () => measurePosition("scroll");
-    const onResize = () => measurePosition("measure");
 
     measurePosition("measure");
     target.addEventListener("scroll", onScroll, { passive: true });
-    window.addEventListener("resize", onResize);
+    window.addEventListener("resize", syncAfterLayoutChange);
     return () => {
       target.removeEventListener("scroll", onScroll);
-      window.removeEventListener("resize", onResize);
+      window.removeEventListener("resize", syncAfterLayoutChange);
     };
-  }, [measurePosition]);
+  }, [contentElement, measurePosition, syncAfterLayoutChange]);
 
   useEffect(() => {
     if (typeof ResizeObserver === "undefined") return;
-    const content = contentRef.current;
-    if (!content) return;
+    if (!contentElement) return;
 
     const observer = new ResizeObserver(() => {
-      if (
-        shouldAutoPinTranscriptBottom({
-          enabled: enabledRef.current,
-          following: followingRef.current,
-        })
-      ) {
-        scrollToBottom("auto");
-        return;
-      }
-
-      measurePosition("measure");
+      syncAfterLayoutChange();
     });
-    observer.observe(content);
+    observer.observe(contentElement);
     return () => observer.disconnect();
-  }, [measurePosition, scrollToBottom]);
+  }, [contentElement, syncAfterLayoutChange]);
 
   const jumpToBottom = useCallback(() => {
     setFollowingIntent(true);

--- a/packages/junior-dashboard/src/client/components/transcriptBottomPinning.ts
+++ b/packages/junior-dashboard/src/client/components/transcriptBottomPinning.ts
@@ -66,6 +66,14 @@ export function transcriptBottomVersion(turns: ConversationTurn[]): string {
   ].join("|");
 }
 
+/** Require both live mode and reader intent before moving the viewport. */
+export function shouldAutoPinTranscriptBottom(input: {
+  enabled: boolean;
+  following: boolean;
+}): boolean {
+  return input.enabled && input.following;
+}
+
 /** Keep live transcript updates visually pinned only while the reader intends to follow them. */
 export function usePinnedTranscriptBottom(input: {
   enabled: boolean;
@@ -86,6 +94,8 @@ export function usePinnedTranscriptBottom(input: {
     if (input.enabled) {
       everEnabledRef.current = true;
     } else {
+      followingRef.current = false;
+      setFollowing(false);
       setHasPendingUpdate(false);
     }
   }, [input.enabled]);
@@ -139,7 +149,12 @@ export function usePinnedTranscriptBottom(input: {
       measurePosition("measure");
     }
 
-    if (followingRef.current) {
+    if (
+      shouldAutoPinTranscriptBottom({
+        enabled: input.enabled,
+        following: followingRef.current,
+      })
+    ) {
       scrollToBottom("auto");
       setHasPendingUpdate(false);
       return;
@@ -175,7 +190,12 @@ export function usePinnedTranscriptBottom(input: {
     if (!content) return;
 
     const observer = new ResizeObserver(() => {
-      if (everEnabledRef.current && followingRef.current) {
+      if (
+        shouldAutoPinTranscriptBottom({
+          enabled: enabledRef.current,
+          following: followingRef.current,
+        })
+      ) {
         scrollToBottom("auto");
         return;
       }

--- a/packages/junior-dashboard/src/client/components/transcriptBottomPinning.ts
+++ b/packages/junior-dashboard/src/client/components/transcriptBottomPinning.ts
@@ -14,6 +14,9 @@ const BOTTOM_PROXIMITY_PX = 96;
 const USER_SCROLL_DELTA_PX = 2;
 
 type ScrollRoot = HTMLElement | Window;
+type PositionMeasureSource = "measure" | "scroll";
+
+export type TranscriptFollowIntent = "follow" | "pause" | "preserve";
 
 export type ScrollSnapshot = {
   clientHeight: number;
@@ -74,6 +77,24 @@ export function shouldAutoPinTranscriptBottom(input: {
   return input.enabled && input.following;
 }
 
+/** Resolve scroll intent with user upward movement taking precedence over bottom slack. */
+export function transcriptFollowIntent(input: {
+  previousScrollTop: number | null;
+  snapshot: ScrollSnapshot;
+  source: PositionMeasureSource;
+}): TranscriptFollowIntent {
+  if (
+    input.source === "scroll" &&
+    input.previousScrollTop != null &&
+    input.snapshot.scrollTop < input.previousScrollTop - USER_SCROLL_DELTA_PX
+  ) {
+    return "pause";
+  }
+
+  if (isNearScrollBottom(input.snapshot)) return "follow";
+  return "preserve";
+}
+
 /** Keep live transcript updates visually pinned only while the reader intends to follow them. */
 export function usePinnedTranscriptBottom(input: {
   enabled: boolean;
@@ -106,26 +127,26 @@ export function usePinnedTranscriptBottom(input: {
   }, []);
 
   const measurePosition = useCallback(
-    (source: "measure" | "scroll") => {
+    (source: PositionMeasureSource) => {
       const root = scrollRootFor(contentRef.current);
       if (!root) return;
 
       const snapshot = scrollSnapshot(root);
-      const nearBottom = isNearScrollBottom(snapshot);
       const previousScrollTop = previousScrollTopRef.current;
       previousScrollTopRef.current = snapshot.scrollTop;
 
-      if (nearBottom) {
+      const intent = transcriptFollowIntent({
+        previousScrollTop,
+        snapshot,
+        source,
+      });
+      if (intent === "follow") {
         setFollowingIntent(true);
         setHasPendingUpdate(false);
         return;
       }
 
-      if (
-        source === "scroll" &&
-        previousScrollTop != null &&
-        snapshot.scrollTop < previousScrollTop - USER_SCROLL_DELTA_PX
-      ) {
+      if (intent === "pause") {
         setFollowingIntent(false);
       }
     },

--- a/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
@@ -91,12 +91,21 @@ export function ConversationPage(props: { data?: DashboardData }) {
                 detail={detail.data}
               />
             }
+            live={conversationIsLive(visualStatus, detail.data)}
             turns={detail.data?.turns ?? []}
           />
         )}
       </section>
     </div>
   );
+}
+
+function conversationIsLive(
+  visualStatus: ReturnType<typeof visualStatusForConversation> | undefined,
+  detail: ConversationDetailFeed | undefined,
+): boolean {
+  if (detail) return detail.turns.some((turn) => turn.status === "active");
+  return visualStatus === "active";
 }
 
 function CopyMarkdownButton(props: {

--- a/packages/junior-dashboard/tests/transcriptBottomPinning.test.ts
+++ b/packages/junior-dashboard/tests/transcriptBottomPinning.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   isNearScrollBottom,
   shouldAutoPinTranscriptBottom,
+  transcriptFollowIntent,
   transcriptBottomVersion,
 } from "../src/client/components/transcriptBottomPinning";
 import type { ConversationTurn } from "../src/client/types";
@@ -99,5 +100,19 @@ describe("transcript bottom pinning", () => {
     expect(
       shouldAutoPinTranscriptBottom({ enabled: false, following: true }),
     ).toBe(false);
+  });
+
+  it("pauses follow when the reader scrolls up inside bottom slack", () => {
+    expect(
+      transcriptFollowIntent({
+        previousScrollTop: 1_120,
+        snapshot: {
+          clientHeight: 800,
+          scrollHeight: 2_000,
+          scrollTop: 1_112,
+        },
+        source: "scroll",
+      }),
+    ).toBe("pause");
   });
 });

--- a/packages/junior-dashboard/tests/transcriptBottomPinning.test.ts
+++ b/packages/junior-dashboard/tests/transcriptBottomPinning.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isNearScrollBottom,
+  transcriptBottomVersion,
+} from "../src/client/components/transcriptBottomPinning";
+import type { ConversationTurn } from "../src/client/types";
+
+function activeTurn(
+  overrides: Partial<ConversationTurn> = {},
+): ConversationTurn {
+  return {
+    conversationId: "conversation-1",
+    cumulativeDurationMs: 0,
+    id: "turn-1",
+    lastProgressAt: "2026-01-01T00:00:10.000Z",
+    lastSeenAt: "2026-01-01T00:00:10.000Z",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    status: "active",
+    surface: "slack",
+    title: "Turn turn-1",
+    transcript: [
+      {
+        role: "assistant",
+        timestamp: 1_000,
+        parts: [{ type: "text", text: "checking" }],
+      },
+    ],
+    transcriptAvailable: true,
+    ...overrides,
+  } as ConversationTurn;
+}
+
+describe("transcript bottom pinning", () => {
+  it("treats near-bottom scroll positions as followable", () => {
+    expect(
+      isNearScrollBottom({
+        clientHeight: 800,
+        scrollHeight: 2_000,
+        scrollTop: 1_112,
+      }),
+    ).toBe(true);
+
+    expect(
+      isNearScrollBottom({
+        clientHeight: 800,
+        scrollHeight: 2_000,
+        scrollTop: 1_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("changes the tail version when streamed text grows", () => {
+    const before = transcriptBottomVersion([activeTurn()]);
+    const after = transcriptBottomVersion([
+      activeTurn({
+        transcript: [
+          {
+            role: "assistant",
+            timestamp: 1_000,
+            parts: [{ type: "text", text: "checking the deployment" }],
+          },
+        ],
+      }),
+    ]);
+
+    expect(after).not.toBe(before);
+  });
+
+  it("keeps the tail version stable when only polling timestamps change", () => {
+    const before = transcriptBottomVersion([activeTurn()]);
+    const after = transcriptBottomVersion([
+      activeTurn({
+        lastProgressAt: "2026-01-01T00:01:00.000Z",
+        lastSeenAt: "2026-01-01T00:01:00.000Z",
+      }),
+    ]);
+
+    expect(after).toBe(before);
+  });
+
+  it("changes the tail version when the live turn completes", () => {
+    const before = transcriptBottomVersion([activeTurn()]);
+    const after = transcriptBottomVersion([
+      activeTurn({
+        completedAt: "2026-01-01T00:00:12.000Z",
+        status: "completed",
+      }),
+    ]);
+
+    expect(after).not.toBe(before);
+  });
+});

--- a/packages/junior-dashboard/tests/transcriptBottomPinning.test.ts
+++ b/packages/junior-dashboard/tests/transcriptBottomPinning.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   isNearScrollBottom,
+  shouldAutoPinTranscriptBottom,
   transcriptBottomVersion,
 } from "../src/client/components/transcriptBottomPinning";
 import type { ConversationTurn } from "../src/client/types";
@@ -89,5 +90,14 @@ describe("transcript bottom pinning", () => {
     ]);
 
     expect(after).not.toBe(before);
+  });
+
+  it("does not auto-pin after live mode turns off", () => {
+    expect(
+      shouldAutoPinTranscriptBottom({ enabled: true, following: true }),
+    ).toBe(true);
+    expect(
+      shouldAutoPinTranscriptBottom({ enabled: false, following: true }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
Active dashboard conversation transcripts now stay pinned to the live tail only while the reader is already following the bottom. Scrolling up pauses the follow behavior and shows a compact jump-to-latest control, with mobile spacing reserved so the control does not cover wrapped transcript text.

**Bottom-follow behavior**

The transcript uses a bottom sentinel and a content-tail version so polling heartbeats do not look like new transcript content. A resize observer keeps late layout changes pinned when follow mode is active.

Validated with dashboard typecheck, build, the full dashboard Vitest suite, and desktop/mobile browser QA against a growing active transcript fixture.
