### PR TITLE
fix(dashboard): Align plugin reports empty state

### DIFF
--- a/packages/junior-dashboard/src/client/components/PluginReports.tsx
+++ b/packages/junior-dashboard/src/client/components/PluginReports.tsx
@@ -20,7 +20,7 @@ export function PluginReports(props: {
         <SectionHeader>
           <SectionTitle>Plugin Reports</SectionTitle>
         </SectionHeader>
-        <div className="px-4 pb-4 text-[0.84rem] leading-relaxed text-[#888]">
+        <div className="px-4 py-4 text-[0.84rem] leading-relaxed text-[#888]">
           {props.emptyText}
         </div>
       </Section>

--- a/packages/junior-dashboard/src/client/pages/PluginsPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/PluginsPage.tsx
@@ -31,7 +31,7 @@ export function PluginsPage(props: { data?: DashboardData }) {
     ? undefined
     : reportsLoading
       ? "Loading trusted plugin stats."
-      : "No trusted plugin stats have been reported yet.";
+      : "No plugins have been reported yet.";
 
   return (
     <div className="mx-auto w-full min-w-0 max-w-screen-xl px-4 py-4 md:px-8">

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -634,7 +634,7 @@ describe("dashboard telemetry components", () => {
 
     expect(html).toContain(">Plugins<");
     expect(html).toContain("github");
-    expect(html).toContain("No trusted plugin stats have been reported yet.");
+    expect(html).toContain("No plugins have been reported yet.");
   });
 
   it("shows plugin reports as loading before the report query returns", () => {
@@ -653,9 +653,7 @@ describe("dashboard telemetry components", () => {
     expect(html).toContain(">...<");
     expect(html).toContain(">loading<");
     expect(html).not.toContain(">none<");
-    expect(html).not.toContain(
-      "No trusted plugin stats have been reported yet.",
-    );
+    expect(html).not.toContain("No plugins have been reported yet.");
   });
 
   it("shows plugin report failures without looking empty", () => {
@@ -669,9 +667,7 @@ describe("dashboard telemetry components", () => {
     );
 
     expect(html).toContain("Trusted plugin stats failed to load.");
-    expect(html).not.toContain(
-      "No trusted plugin stats have been reported yet.",
-    );
+    expect(html).not.toContain("No plugins have been reported yet.");
   });
 
   it("shows plugin report failures while keeping stale reports visible", () => {


### PR DESCRIPTION
Adjust the dashboard plugin reports empty state so it uses generic plugin wording and no longer sits high in the reports box. The empty report row now has balanced vertical padding, and component expectations cover the new copy.