### PR TITLE
fix(identity): Require explicit runtime identity context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ Co-Authored-By: (agent model name) <email>
 
 - `policies/README.md` (when to add a policy doc and how policy docs should stay scoped)
 - `policies/code-comments.md` (repo default for code comments, docstrings, and exported-function JSDoc)
+- `policies/context-bound-systems.md` (explicit actor/destination/context propagation across runtime boundaries)
 - `policies/evals.md` (evals as behavior integration tests and rubric authoring boundaries)
 - `policies/frontend-components.md` (Tailwind colocation and component-owned frontend styling)
 - `policies/interface-design.md` (naming, module paths, and minimal interface boundaries)
@@ -85,7 +86,7 @@ Co-Authored-By: (agent model name) <email>
 - Do not leak third-party SDK types across chat subsystem boundaries when a small local interface will do; keep vendor SDKs inside infrastructure modules.
 - Service modules must depend on small injected ports for Slack behavior, not import Slack infrastructure directly.
 - Slack modules must not import runtime modules.
-- `runtime/` orchestrates turns and turn-scoped formatting, `services/` do domain work (reply policy, delivery planning, channel intent, attachment validation), `state/` persists by concern, `ingress/` only normalizes/routes.
+- `runtime/` orchestrates turns and turn-scoped formatting, `services/` do domain work (reply policy, delivery planning, channel intent, attachment validation), `state/` persists by concern, `ingress/` only parses, classifies, and routes source events.
 - **Feature-based colocation**: group files by domain feature, not by technical role. Within a module, create subdirectories for each feature domain (e.g., `tools/slack/`, `tools/web/`, `tools/sandbox/`, `tools/skill/`). Shared contracts and cross-cutting utilities live at the module root. Only extract to a shared location when 2+ features need the same code.
 - Do not use barrel `index.ts` re-exports inside feature subdirectories — import directly from the source file. A module-root `index.ts` is acceptable as a composition root that wires features together.
 - Queue and worker paths must depend on injected runtime interfaces or factories, not import the production singleton from `@/chat/app/production`.
@@ -115,6 +116,7 @@ Co-Authored-By: (agent model name) <email>
 - `specs/agent-turn-handling.md` (agent user-message response policy: reply/silence, tool use, Slack side effects, resumed turns, and completion)
 - `specs/slack-agent-delivery.md` (Slack entry surfaces, reply delivery, continuation, files, images, and resume behavior contract)
 - `specs/slack-outbound-contract.md` (Slack outbound boundary, message/file/reaction safety rules, and markdown-to-`mrkdwn` ownership)
+- `specs/identity.md` (current actor, system actor, requester, author, creator, credential subject, service principal, and display identity contract)
 - `specs/credential-injection.md` (requester-bound provider credential injection contract)
 - `specs/oauth-flows.md` (OAuth authorization code flow + Slack UX contract)
 - `specs/agent-prompt.md` (core prompt ownership, execution-bias, and bloat-control contract)

--- a/packages/junior-github/index.js
+++ b/packages/junior-github/index.js
@@ -19,7 +19,11 @@ function isSlackUserId(value) {
 
 function requesterDisplayName(value, requester) {
   const name = cleanIdentityPart(value);
-  if (!name || name === cleanIdentityPart(requester?.userId)) {
+  if (
+    !name ||
+    name.toLowerCase() === "unknown" ||
+    name === cleanIdentityPart(requester?.userId)
+  ) {
     return undefined;
   }
   return isSlackUserId(name) ? undefined : name;

--- a/packages/junior-github/index.js
+++ b/packages/junior-github/index.js
@@ -13,18 +13,29 @@ function cleanIdentityPart(value) {
     .trim();
 }
 
+function isSlackUserId(value) {
+  return /^[UW][A-Z0-9]{5,}$/.test(value);
+}
+
+function requesterDisplayName(value, requester) {
+  const name = cleanIdentityPart(value);
+  if (!name || name === cleanIdentityPart(requester?.userId)) {
+    return undefined;
+  }
+  return isSlackUserId(name) ? undefined : name;
+}
+
 function requesterName(requester) {
   return (
-    cleanIdentityPart(requester?.fullName) ||
-    cleanIdentityPart(requester?.userName) ||
-    cleanIdentityPart(requester?.userId) ||
+    requesterDisplayName(requester?.fullName, requester) ||
+    requesterDisplayName(requester?.userName, requester) ||
     undefined
   );
 }
 
 function requesterEmail(requester) {
   const email = cleanIdentityPart(requester?.email);
-  return email && !/\s/.test(email) ? email : "noreply";
+  return /^[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+$/.test(email) ? email : undefined;
 }
 
 function isGitCommitCommand(command) {
@@ -156,9 +167,10 @@ export function githubPlugin(options = {}) {
           return;
         }
         const coauthorName = requesterName(ctx.requester);
-        if (!coauthorName && isGitCommitCommand(command)) {
+        const coauthorEmail = requesterEmail(ctx.requester);
+        if ((!coauthorName || !coauthorEmail) && isGitCommitCommand(command)) {
           ctx.decision.deny(
-            "Junior GitHub plugin could not determine requester identity for commit attribution. This is an internal request-context error; do not set coauthor env vars manually.",
+            "Junior GitHub plugin could not determine a resolved requester name and email for commit attribution. This is an internal request-context error; do not set coauthor env vars manually.",
           );
           return;
         }
@@ -168,12 +180,9 @@ export function githubPlugin(options = {}) {
         ctx.env.set("GIT_COMMITTER_EMAIL", botEmail);
         ctx.env.set("JUNIOR_GIT_AUTHOR_NAME", botName);
         ctx.env.set("JUNIOR_GIT_AUTHOR_EMAIL", botEmail);
-        if (coauthorName) {
+        if (coauthorName && coauthorEmail) {
           ctx.env.set("JUNIOR_GIT_COAUTHOR_NAME", coauthorName);
-          ctx.env.set(
-            "JUNIOR_GIT_COAUTHOR_EMAIL",
-            requesterEmail(ctx.requester),
-          );
+          ctx.env.set("JUNIOR_GIT_COAUTHOR_EMAIL", coauthorEmail);
         }
       },
     },

--- a/packages/junior-scheduler/src/identity.ts
+++ b/packages/junior-scheduler/src/identity.ts
@@ -7,12 +7,23 @@ function clean(value: string | undefined): string | undefined {
   return normalized ? normalized : undefined;
 }
 
+function cleanSlackUserId(value: string | undefined): string | undefined {
+  const normalized = clean(value);
+  return normalized && normalized.toLowerCase() !== "unknown"
+    ? normalized
+    : undefined;
+}
+
 function cleanDisplay(
   value: string | undefined,
   slackUserId: string,
 ): string | undefined {
   const normalized = clean(value);
-  if (!normalized || normalized === slackUserId) {
+  if (
+    !normalized ||
+    normalized.toLowerCase() === "unknown" ||
+    normalized === slackUserId
+  ) {
     return undefined;
   }
   return SLACK_USER_ID_PATTERN.test(normalized) ? undefined : normalized;
@@ -22,7 +33,7 @@ function cleanDisplay(
 export function sanitizeScheduledTaskPrincipal(
   principal: ScheduledTaskPrincipal,
 ): ScheduledTaskPrincipal {
-  const slackUserId = clean(principal.slackUserId);
+  const slackUserId = cleanSlackUserId(principal.slackUserId);
   if (!slackUserId) {
     throw new Error("Scheduled task principal requires a Slack user id");
   }

--- a/packages/junior-scheduler/src/identity.ts
+++ b/packages/junior-scheduler/src/identity.ts
@@ -1,0 +1,53 @@
+import type { ScheduledTaskPrincipal } from "./types";
+
+const SLACK_USER_ID_PATTERN = /^[UW][A-Z0-9]{5,}$/;
+
+function clean(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+function cleanDisplay(
+  value: string | undefined,
+  slackUserId: string,
+): string | undefined {
+  const normalized = clean(value);
+  if (!normalized || normalized === slackUserId) {
+    return undefined;
+  }
+  return SLACK_USER_ID_PATTERN.test(normalized) ? undefined : normalized;
+}
+
+/** Keep scheduler creator metadata from promoting Slack IDs into display names. */
+export function sanitizeScheduledTaskPrincipal(
+  principal: ScheduledTaskPrincipal,
+): ScheduledTaskPrincipal {
+  const slackUserId = clean(principal.slackUserId);
+  if (!slackUserId) {
+    throw new Error("Scheduled task principal requires a Slack user id");
+  }
+  const fullName = cleanDisplay(principal.fullName, slackUserId);
+  const userName = cleanDisplay(principal.userName, slackUserId);
+  return {
+    slackUserId,
+    ...(fullName ? { fullName } : {}),
+    ...(userName ? { userName } : {}),
+  };
+}
+
+/** Render scheduler creator metadata without inventing human profile fields. */
+export function scheduledTaskPrincipalLabel(
+  principal: ScheduledTaskPrincipal,
+): string {
+  const author = sanitizeScheduledTaskPrincipal(principal);
+  if (author.fullName && author.userName) {
+    return `${author.fullName} (@${author.userName})`;
+  }
+  if (author.fullName) {
+    return author.fullName;
+  }
+  if (author.userName) {
+    return `@${author.userName}`;
+  }
+  return `Slack User ${author.slackUserId}`;
+}

--- a/packages/junior-scheduler/src/plugin.ts
+++ b/packages/junior-scheduler/src/plugin.ts
@@ -13,7 +13,11 @@ import {
   type SchedulerStore,
 } from "./store";
 import { scheduledTaskPrincipalLabel } from "./identity";
-import type { ScheduledRun, ScheduledTask } from "./types";
+import type {
+  ScheduledRun,
+  ScheduledTask,
+  ScheduledTaskPrincipal,
+} from "./types";
 import {
   createSlackScheduleCreateTaskTool,
   createSlackScheduleDeleteTaskTool,
@@ -198,6 +202,14 @@ function destinationLabel(destination: ScheduledTask["destination"]): string {
   return destination.channelId;
 }
 
+function operationalAuthorLabel(author: ScheduledTaskPrincipal): string {
+  try {
+    return scheduledTaskPrincipalLabel(author);
+  } catch {
+    return "Invalid Slack creator metadata";
+  }
+}
+
 function cadenceLabel(task: ScheduledTask): string {
   if (task.schedule.kind === "one_off") {
     return "one-off";
@@ -289,7 +301,7 @@ async function buildSchedulerOperationalReport(args: {
           id: task.id,
           values: {
             task: task.id,
-            author: scheduledTaskPrincipalLabel(task.createdBy),
+            author: operationalAuthorLabel(task.createdBy),
             destination: destinationLabel(task.destination),
             nextRun: formatTimestamp(task.nextRunAtMs),
             cadence: cadenceLabel(task),
@@ -310,7 +322,7 @@ async function buildSchedulerOperationalReport(args: {
           tone: "danger",
           values: {
             task: task.id,
-            author: scheduledTaskPrincipalLabel(task.createdBy),
+            author: operationalAuthorLabel(task.createdBy),
             destination: destinationLabel(task.destination),
             updated: formatTimestamp(task.updatedAtMs),
           },
@@ -335,8 +347,8 @@ async function buildSchedulerOperationalReport(args: {
               run: run.id,
               task: run.taskId,
               author: task
-                ? scheduledTaskPrincipalLabel(task.createdBy)
-                : "unknown",
+                ? operationalAuthorLabel(task.createdBy)
+                : "Missing scheduled task",
               scheduledFor: formatTimestamp(run.scheduledForMs),
               status: run.status,
             },

--- a/packages/junior-scheduler/src/plugin.ts
+++ b/packages/junior-scheduler/src/plugin.ts
@@ -12,6 +12,7 @@ import {
   type SchedulerOperationalStore,
   type SchedulerStore,
 } from "./store";
+import { scheduledTaskPrincipalLabel } from "./identity";
 import type { ScheduledRun, ScheduledTask } from "./types";
 import {
   createSlackScheduleCreateTaskTool,
@@ -197,19 +198,6 @@ function destinationLabel(destination: ScheduledTask["destination"]): string {
   return destination.channelId;
 }
 
-function authorLabel(author: ScheduledTask["createdBy"]): string {
-  if (author.fullName && author.userName) {
-    return `${author.fullName} (@${author.userName})`;
-  }
-  if (author.fullName) {
-    return author.fullName;
-  }
-  if (author.userName) {
-    return `@${author.userName}`;
-  }
-  return `Slack User ${author.slackUserId}`;
-}
-
 function cadenceLabel(task: ScheduledTask): string {
   if (task.schedule.kind === "one_off") {
     return "one-off";
@@ -301,7 +289,7 @@ async function buildSchedulerOperationalReport(args: {
           id: task.id,
           values: {
             task: task.id,
-            author: authorLabel(task.createdBy),
+            author: scheduledTaskPrincipalLabel(task.createdBy),
             destination: destinationLabel(task.destination),
             nextRun: formatTimestamp(task.nextRunAtMs),
             cadence: cadenceLabel(task),
@@ -322,7 +310,7 @@ async function buildSchedulerOperationalReport(args: {
           tone: "danger",
           values: {
             task: task.id,
-            author: authorLabel(task.createdBy),
+            author: scheduledTaskPrincipalLabel(task.createdBy),
             destination: destinationLabel(task.destination),
             updated: formatTimestamp(task.updatedAtMs),
           },
@@ -346,7 +334,9 @@ async function buildSchedulerOperationalReport(args: {
             values: {
               run: run.id,
               task: run.taskId,
-              author: task ? authorLabel(task.createdBy) : "unknown",
+              author: task
+                ? scheduledTaskPrincipalLabel(task.createdBy)
+                : "unknown",
               scheduledFor: formatTimestamp(run.scheduledForMs),
               status: run.status,
             },

--- a/packages/junior-scheduler/src/prompt.ts
+++ b/packages/junior-scheduler/src/prompt.ts
@@ -3,6 +3,7 @@ import {
   type ScheduledRun,
   type ScheduledTask,
 } from "./types";
+import { sanitizeScheduledTaskPrincipal } from "./identity";
 
 function escapeXml(value: string): string {
   return value
@@ -35,7 +36,7 @@ export function buildScheduledTaskRunPrompt(args: {
 }): string {
   const { run, task } = args;
   const destination = task.destination;
-  const creator = task.createdBy;
+  const creator = sanitizeScheduledTaskPrincipal(task.createdBy);
   const executionActor = task.executionActor ?? SCHEDULED_TASK_SYSTEM_ACTOR;
   if (!task.task.text?.trim()) {
     throw new Error("Scheduled task text is required");

--- a/packages/junior-scheduler/src/schedule-tools.ts
+++ b/packages/junior-scheduler/src/schedule-tools.ts
@@ -70,7 +70,7 @@ function requireRequester(
   context: SchedulerToolContext,
 ): ScheduledTaskPrincipal {
   const userId = context.requester?.userId?.trim();
-  if (!userId) {
+  if (!userId || userId.toLowerCase() === "unknown") {
     throwToolInputError("No active Slack requester context is available.");
   }
 

--- a/packages/junior-scheduler/src/schedule-tools.ts
+++ b/packages/junior-scheduler/src/schedule-tools.ts
@@ -7,6 +7,7 @@ import {
   type AgentPluginToolDefinition,
 } from "@sentry/junior-plugin-api";
 import { buildCalendarRecurrence, parseScheduleTimestamp } from "./cadence";
+import { sanitizeScheduledTaskPrincipal } from "./identity";
 import { createSchedulerStore } from "./store";
 import { SCHEDULED_TASK_SYSTEM_ACTOR } from "./types";
 import type {
@@ -68,12 +69,12 @@ function requireActiveDestination(
 function requireRequester(
   context: SchedulerToolContext,
 ): ScheduledTaskPrincipal {
-  const userId = context.requester?.userId;
+  const userId = context.requester?.userId?.trim();
   if (!userId) {
     throwToolInputError("No active Slack requester context is available.");
   }
 
-  return {
+  return sanitizeScheduledTaskPrincipal({
     slackUserId: userId,
     ...(context.requester?.userName
       ? { userName: context.requester.userName }
@@ -81,7 +82,7 @@ function requireRequester(
     ...(context.requester?.fullName
       ? { fullName: context.requester.fullName }
       : {}),
-  };
+  });
 }
 
 function tool<TInput = any>(

--- a/packages/junior/src/chat/agent-dispatch/validation.ts
+++ b/packages/junior/src/chat/agent-dispatch/validation.ts
@@ -2,6 +2,7 @@ import type { BoundDispatchOptions, DispatchOptions } from "./types";
 import { verifySlackDirectCredentialSubject } from "@/chat/credentials/subject";
 import { isDmChannel } from "@/chat/slack/client";
 import { isSlackConversationId, isSlackTeamId } from "@/chat/slack/ids";
+import { normalizeActorUserId } from "@/chat/services/requester-identity";
 
 const MAX_DISPATCH_INPUT_LENGTH = 32_000;
 const MAX_IDEMPOTENCY_KEY_LENGTH = 512;
@@ -38,7 +39,7 @@ export function validateDispatchOptions(options: DispatchOptions): void {
     if (options.credentialSubject.type !== "user") {
       throw new Error("Dispatch credentialSubject type must be user");
     }
-    if (!options.credentialSubject.userId.trim()) {
+    if (!normalizeActorUserId(options.credentialSubject.userId)) {
       throw new Error("Dispatch credentialSubject userId is required");
     }
     if (

--- a/packages/junior/src/chat/agent-dispatch/validation.ts
+++ b/packages/junior/src/chat/agent-dispatch/validation.ts
@@ -2,7 +2,7 @@ import type { BoundDispatchOptions, DispatchOptions } from "./types";
 import { verifySlackDirectCredentialSubject } from "@/chat/credentials/subject";
 import { isDmChannel } from "@/chat/slack/client";
 import { isSlackConversationId, isSlackTeamId } from "@/chat/slack/ids";
-import { normalizeActorUserId } from "@/chat/services/requester-identity";
+import { isActorUserId } from "@/chat/services/requester-identity";
 
 const MAX_DISPATCH_INPUT_LENGTH = 32_000;
 const MAX_IDEMPOTENCY_KEY_LENGTH = 512;
@@ -39,7 +39,7 @@ export function validateDispatchOptions(options: DispatchOptions): void {
     if (options.credentialSubject.type !== "user") {
       throw new Error("Dispatch credentialSubject type must be user");
     }
-    if (!normalizeActorUserId(options.credentialSubject.userId)) {
+    if (!isActorUserId(options.credentialSubject.userId)) {
       throw new Error("Dispatch credentialSubject userId is required");
     }
     if (

--- a/packages/junior/src/chat/credentials/context.ts
+++ b/packages/junior/src/chat/credentials/context.ts
@@ -1,5 +1,5 @@
 import type { AgentPluginCredentialSubject } from "@sentry/junior-plugin-api";
-import { normalizeActorUserId } from "@/chat/services/requester-identity";
+import { parseActorUserId } from "@/chat/services/requester-identity";
 
 export interface CredentialSubjectBinding {
   type: "slack-direct-conversation";
@@ -78,7 +78,7 @@ function parseActor(value: unknown): CredentialContext["actor"] | undefined {
       type?: unknown;
       userId?: unknown;
     };
-    const userId = normalizeActorUserId(
+    const userId = parseActorUserId(
       typeof record.userId === "string" ? record.userId : undefined,
     );
     if (record.type === "user" && userId) {
@@ -86,8 +86,10 @@ function parseActor(value: unknown): CredentialContext["actor"] | undefined {
     }
     const systemId =
       typeof record.id === "string" &&
-      record.id.trim().toLowerCase() !== "unknown"
-        ? record.id.trim()
+      record.id.length > 0 &&
+      record.id === record.id.trim() &&
+      record.id.toLowerCase() !== "unknown"
+        ? record.id
         : undefined;
     if (record.type === "system" && systemId) {
       return { type: "system", id: systemId };
@@ -101,7 +103,7 @@ function parseSubject(
 ): NonNullable<CredentialContext["subject"]> | undefined {
   if (value && typeof value === "object") {
     const record = value as Partial<NonNullable<CredentialContext["subject"]>>;
-    const userId = normalizeActorUserId(
+    const userId = parseActorUserId(
       typeof record.userId === "string" ? record.userId : undefined,
     );
     if (

--- a/packages/junior/src/chat/credentials/context.ts
+++ b/packages/junior/src/chat/credentials/context.ts
@@ -1,4 +1,5 @@
 import type { AgentPluginCredentialSubject } from "@sentry/junior-plugin-api";
+import { normalizeActorUserId } from "@/chat/services/requester-identity";
 
 export interface CredentialSubjectBinding {
   type: "slack-direct-conversation";
@@ -72,20 +73,24 @@ export function parseCredentialContext(
 
 function parseActor(value: unknown): CredentialContext["actor"] | undefined {
   if (value && typeof value === "object") {
-    const record = value as Partial<CredentialContext["actor"]>;
-    if (
-      record.type === "user" &&
-      typeof record.userId === "string" &&
-      record.userId
-    ) {
-      return { type: "user", userId: record.userId };
+    const record = value as {
+      id?: unknown;
+      type?: unknown;
+      userId?: unknown;
+    };
+    const userId = normalizeActorUserId(
+      typeof record.userId === "string" ? record.userId : undefined,
+    );
+    if (record.type === "user" && userId) {
+      return { type: "user", userId };
     }
-    if (
-      record.type === "system" &&
+    const systemId =
       typeof record.id === "string" &&
-      record.id
-    ) {
-      return { type: "system", id: record.id };
+      record.id.trim().toLowerCase() !== "unknown"
+        ? record.id.trim()
+        : undefined;
+    if (record.type === "system" && systemId) {
+      return { type: "system", id: systemId };
     }
   }
   return undefined;
@@ -96,10 +101,12 @@ function parseSubject(
 ): NonNullable<CredentialContext["subject"]> | undefined {
   if (value && typeof value === "object") {
     const record = value as Partial<NonNullable<CredentialContext["subject"]>>;
+    const userId = normalizeActorUserId(
+      typeof record.userId === "string" ? record.userId : undefined,
+    );
     if (
       record.type === "user" &&
-      typeof record.userId === "string" &&
-      record.userId &&
+      userId &&
       record.allowedWhen === "private-direct-conversation"
     ) {
       if (!record.binding || typeof record.binding !== "object") {
@@ -119,7 +126,7 @@ function parseSubject(
       }
       return {
         type: "user",
-        userId: record.userId,
+        userId,
         allowedWhen: "private-direct-conversation",
         binding: {
           type: "slack-direct-conversation",

--- a/packages/junior/src/chat/credentials/subject.ts
+++ b/packages/junior/src/chat/credentials/subject.ts
@@ -2,6 +2,7 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import type { AgentPluginCredentialSubject } from "@sentry/junior-plugin-api";
 import type { CredentialSubject } from "@/chat/credentials/context";
 import { isDmChannel, normalizeSlackConversationId } from "@/chat/slack/client";
+import { normalizeActorUserId } from "@/chat/services/requester-identity";
 
 const CREDENTIAL_SUBJECT_HMAC_CONTEXT = "junior.credential_subject.v1";
 const CREDENTIAL_SUBJECT_SIGNATURE_VERSION = "v1";
@@ -47,7 +48,7 @@ export function createSlackDirectCredentialSubject(input: {
 }): AgentPluginCredentialSubject | undefined {
   const channelId = normalizeSlackConversationId(input.channelId);
   const teamId = input.teamId?.trim();
-  const userId = input.userId?.trim();
+  const userId = normalizeActorUserId(input.userId);
   if (!channelId || !teamId || !userId || !isDmChannel(channelId)) {
     return undefined;
   }
@@ -69,7 +70,7 @@ export function bindSlackDirectCredentialSubject(input: {
   const teamId = input.teamId.trim();
   const secret = getCredentialSubjectSecret();
   const { subject } = input;
-  const userId = subject.userId.trim();
+  const userId = normalizeActorUserId(subject.userId);
   if (
     !channelId ||
     !teamId ||
@@ -116,10 +117,10 @@ export function verifySlackDirectCredentialSubject(input: {
   }
   const { subject } = input;
   const binding = subject.binding;
+  const userId = normalizeActorUserId(subject.userId);
   if (
     subject.type !== "user" ||
-    typeof subject.userId !== "string" ||
-    !subject.userId ||
+    !userId ||
     subject.allowedWhen !== "private-direct-conversation" ||
     !binding ||
     binding.type !== "slack-direct-conversation" ||
@@ -137,7 +138,7 @@ export function verifySlackDirectCredentialSubject(input: {
       allowedWhen: subject.allowedWhen,
       teamId: binding.teamId,
       channelId: binding.channelId,
-      userId: subject.userId,
+      userId,
     }),
   );
   return timingSafeMatch(expected, binding.signature);

--- a/packages/junior/src/chat/credentials/subject.ts
+++ b/packages/junior/src/chat/credentials/subject.ts
@@ -2,7 +2,10 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import type { AgentPluginCredentialSubject } from "@sentry/junior-plugin-api";
 import type { CredentialSubject } from "@/chat/credentials/context";
 import { isDmChannel, normalizeSlackConversationId } from "@/chat/slack/client";
-import { normalizeActorUserId } from "@/chat/services/requester-identity";
+import {
+  isActorUserId,
+  parseActorUserId,
+} from "@/chat/services/requester-identity";
 
 const CREDENTIAL_SUBJECT_HMAC_CONTEXT = "junior.credential_subject.v1";
 const CREDENTIAL_SUBJECT_SIGNATURE_VERSION = "v1";
@@ -48,7 +51,7 @@ export function createSlackDirectCredentialSubject(input: {
 }): AgentPluginCredentialSubject | undefined {
   const channelId = normalizeSlackConversationId(input.channelId);
   const teamId = input.teamId?.trim();
-  const userId = normalizeActorUserId(input.userId);
+  const userId = parseActorUserId(input.userId);
   if (!channelId || !teamId || !userId || !isDmChannel(channelId)) {
     return undefined;
   }
@@ -70,7 +73,7 @@ export function bindSlackDirectCredentialSubject(input: {
   const teamId = input.teamId.trim();
   const secret = getCredentialSubjectSecret();
   const { subject } = input;
-  const userId = normalizeActorUserId(subject.userId);
+  const userId = parseActorUserId(subject.userId);
   if (
     !channelId ||
     !teamId ||
@@ -117,10 +120,9 @@ export function verifySlackDirectCredentialSubject(input: {
   }
   const { subject } = input;
   const binding = subject.binding;
-  const userId = normalizeActorUserId(subject.userId);
   if (
     subject.type !== "user" ||
-    !userId ||
+    !isActorUserId(subject.userId) ||
     subject.allowedWhen !== "private-direct-conversation" ||
     !binding ||
     binding.type !== "slack-direct-conversation" ||
@@ -138,7 +140,7 @@ export function verifySlackDirectCredentialSubject(input: {
       allowedWhen: subject.allowedWhen,
       teamId: binding.teamId,
       channelId: binding.channelId,
-      userId,
+      userId: subject.userId,
     }),
   );
   return timingSafeMatch(expected, binding.signature);

--- a/packages/junior/src/chat/ingress/message-changed.ts
+++ b/packages/junior/src/chat/ingress/message-changed.ts
@@ -1,4 +1,5 @@
 import { Message, type Adapter, type Attachment } from "chat";
+import { normalizeActorUserId } from "@/chat/services/requester-identity";
 
 /**
  * Parsed result from a Slack `message_changed` event that contains a newly
@@ -130,7 +131,7 @@ export function extractMessageChangedMention(
   const channelId = event.channel;
   const messageTs = event.message.ts;
   const threadTs = event.message.thread_ts ?? messageTs;
-  const userId = event.message.user?.trim();
+  const userId = normalizeActorUserId(event.message.user);
   if (!userId) return null;
   const threadId = `slack:${channelId}:${threadTs}`;
   const teamId = typeof body.team_id === "string" ? body.team_id : undefined;

--- a/packages/junior/src/chat/ingress/message-changed.ts
+++ b/packages/junior/src/chat/ingress/message-changed.ts
@@ -1,5 +1,5 @@
 import { Message, type Adapter, type Attachment } from "chat";
-import { normalizeActorUserId } from "@/chat/services/requester-identity";
+import { parseActorUserId } from "@/chat/services/requester-identity";
 
 /**
  * Parsed result from a Slack `message_changed` event that contains a newly
@@ -131,7 +131,7 @@ export function extractMessageChangedMention(
   const channelId = event.channel;
   const messageTs = event.message.ts;
   const threadTs = event.message.thread_ts ?? messageTs;
-  const userId = normalizeActorUserId(event.message.user);
+  const userId = parseActorUserId(event.message.user);
   if (!userId) return null;
   const threadId = `slack:${channelId}:${threadTs}`;
   const teamId = typeof body.team_id === "string" ? body.team_id : undefined;

--- a/packages/junior/src/chat/ingress/message-changed.ts
+++ b/packages/junior/src/chat/ingress/message-changed.ts
@@ -130,7 +130,8 @@ export function extractMessageChangedMention(
   const channelId = event.channel;
   const messageTs = event.message.ts;
   const threadTs = event.message.thread_ts ?? messageTs;
-  const userId = event.message.user ?? "unknown";
+  const userId = event.message.user?.trim();
+  if (!userId) return null;
   const threadId = `slack:${channelId}:${threadTs}`;
   const teamId = typeof body.team_id === "string" ? body.team_id : undefined;
 
@@ -164,8 +165,9 @@ export function extractMessageChangedMention(
     raw,
     author: {
       userId,
-      userName: userId,
-      fullName: userId,
+      // Raw message_changed payloads do not include profile fields.
+      userName: "",
+      fullName: "",
       isBot: false,
       isMe: false,
     },

--- a/packages/junior/src/chat/ingress/slack-webhook.ts
+++ b/packages/junior/src/chat/ingress/slack-webhook.ts
@@ -28,7 +28,7 @@ import { runWithWorkspaceTeamId } from "@/chat/slack/workspace-context";
 import { getStateAdapter } from "@/chat/state/adapter";
 import { handleSlashCommand } from "@/chat/ingress/slash-command";
 import {
-  normalizeActorIdentity,
+  buildActorIdentity,
   parseActorUserId,
 } from "@/chat/services/requester-identity";
 import { createUserTokenStore } from "@/chat/capabilities/factory";
@@ -443,7 +443,7 @@ async function handleSlashCommandForm(args: {
     args.params.get("user_id"),
     "Slack slash command payload",
   );
-  const userIdentity = normalizeActorIdentity(
+  const userIdentity = buildActorIdentity(
     {
       userId,
       userName: args.params.get("user_name") ?? undefined,

--- a/packages/junior/src/chat/ingress/slack-webhook.ts
+++ b/packages/junior/src/chat/ingress/slack-webhook.ts
@@ -27,7 +27,10 @@ import { isExternalSlackUser } from "@/chat/ingress/workspace-membership";
 import { runWithWorkspaceTeamId } from "@/chat/slack/workspace-context";
 import { getStateAdapter } from "@/chat/state/adapter";
 import { handleSlashCommand } from "@/chat/ingress/slash-command";
-import { normalizeActorIdentity } from "@/chat/services/requester-identity";
+import {
+  normalizeActorIdentity,
+  normalizeActorUserId,
+} from "@/chat/services/requester-identity";
 import { createUserTokenStore } from "@/chat/capabilities/factory";
 import { unlinkProvider } from "@/chat/credentials/unlink-provider";
 import type { UserTokenStore } from "@/chat/credentials/user-token-store";
@@ -417,8 +420,8 @@ function requireSlackPayloadUserId(
   value: string | null | undefined,
   source: string,
 ): string {
-  const userId = value?.trim();
-  if (!userId || userId.toLowerCase() === "unknown") {
+  const userId = normalizeActorUserId(value ?? undefined);
+  if (!userId) {
     throw new Error(`${source} is missing a Slack user id`);
   }
   return userId;
@@ -487,10 +490,13 @@ async function handleInteractivePayload(args: {
     (candidate) => candidate.action_id === "app_home_disconnect",
   );
   const provider = action?.selected_option?.value ?? action?.value;
-  const userId = args.payload.user?.id;
-  if (!provider || !userId) {
+  if (!provider) {
     return;
   }
+  const userId = requireSlackPayloadUserId(
+    args.payload.user?.id,
+    "Slack app home disconnect payload",
+  );
 
   await withSpan(
     "chat.app_home_disconnect",

--- a/packages/junior/src/chat/ingress/slack-webhook.ts
+++ b/packages/junior/src/chat/ingress/slack-webhook.ts
@@ -2,7 +2,6 @@ import type { SlackAdapter, SlackEvent } from "@chat-adapter/slack";
 import {
   ChannelImpl,
   ThreadImpl,
-  type Author,
   type Message,
   type SlashCommandEvent,
   type StateAdapter,
@@ -28,6 +27,7 @@ import { isExternalSlackUser } from "@/chat/ingress/workspace-membership";
 import { runWithWorkspaceTeamId } from "@/chat/slack/workspace-context";
 import { getStateAdapter } from "@/chat/state/adapter";
 import { handleSlashCommand } from "@/chat/ingress/slash-command";
+import { normalizeActorIdentity } from "@/chat/services/requester-identity";
 import { createUserTokenStore } from "@/chat/capabilities/factory";
 import { unlinkProvider } from "@/chat/credentials/unlink-provider";
 import type { UserTokenStore } from "@/chat/credentials/user-token-store";
@@ -413,17 +413,15 @@ async function handleSlackEvent(args: {
   );
 }
 
-function buildAuthorFromInteractive(
-  user: SlackInteractivePayload["user"],
-): Author {
-  const userId = user?.id ?? "unknown";
-  return {
-    userId,
-    userName: user?.username ?? user?.name ?? userId,
-    fullName: user?.name ?? user?.username ?? userId,
-    isBot: false,
-    isMe: false,
-  };
+function requireSlackPayloadUserId(
+  value: string | null | undefined,
+  source: string,
+): string {
+  const userId = value?.trim();
+  if (!userId) {
+    throw new Error(`${source} is missing a Slack user id`);
+  }
+  return userId;
 }
 
 async function handleSlashCommandForm(args: {
@@ -438,7 +436,18 @@ async function handleSlashCommandForm(args: {
     adapter: args.adapter,
     stateAdapter: args.state,
   });
-  const userId = args.params.get("user_id") || "unknown";
+  const userId = requireSlackPayloadUserId(
+    args.params.get("user_id"),
+    "Slack slash command payload",
+  );
+  const userIdentity = normalizeActorIdentity(
+    {
+      userId,
+      userName: args.params.get("user_name") ?? undefined,
+      fullName: args.params.get("user_name") ?? undefined,
+    },
+    userId,
+  ) ?? { userId };
   await withSpan(
     "chat.slash_command",
     "chat.slash_command",
@@ -453,8 +462,8 @@ async function handleSlashCommandForm(args: {
         raw,
         user: {
           userId,
-          userName: args.params.get("user_name") || userId,
-          fullName: args.params.get("user_name") || userId,
+          userName: userIdentity.userName ?? "",
+          fullName: userIdentity.fullName ?? "",
           isBot: false,
           isMe: false,
         },
@@ -589,7 +598,7 @@ async function handleSlackForm(args: {
       }),
     ).catch((error) => {
       logException(error, "slack_interactive_payload_failed", {
-        slackUserId: buildAuthorFromInteractive(payload.user).userId,
+        slackUserId: payload.user?.id?.trim() || undefined,
       });
     }),
   );

--- a/packages/junior/src/chat/ingress/slack-webhook.ts
+++ b/packages/junior/src/chat/ingress/slack-webhook.ts
@@ -29,7 +29,7 @@ import { getStateAdapter } from "@/chat/state/adapter";
 import { handleSlashCommand } from "@/chat/ingress/slash-command";
 import {
   normalizeActorIdentity,
-  normalizeActorUserId,
+  parseActorUserId,
 } from "@/chat/services/requester-identity";
 import { createUserTokenStore } from "@/chat/capabilities/factory";
 import { unlinkProvider } from "@/chat/credentials/unlink-provider";
@@ -420,7 +420,7 @@ function requireSlackPayloadUserId(
   value: string | null | undefined,
   source: string,
 ): string {
-  const userId = normalizeActorUserId(value ?? undefined);
+  const userId = parseActorUserId(value);
   if (!userId) {
     throw new Error(`${source} is missing a Slack user id`);
   }

--- a/packages/junior/src/chat/ingress/slack-webhook.ts
+++ b/packages/junior/src/chat/ingress/slack-webhook.ts
@@ -418,7 +418,7 @@ function requireSlackPayloadUserId(
   source: string,
 ): string {
   const userId = value?.trim();
-  if (!userId) {
+  if (!userId || userId.toLowerCase() === "unknown") {
     throw new Error(`${source} is missing a Slack user id`);
   }
   return userId;
@@ -447,7 +447,10 @@ async function handleSlashCommandForm(args: {
       fullName: args.params.get("user_name") ?? undefined,
     },
     userId,
-  ) ?? { userId };
+  );
+  if (!userIdentity?.userId) {
+    throw new Error("Slack slash command payload actor identity is invalid");
+  }
   await withSpan(
     "chat.slash_command",
     "chat.slash_command",

--- a/packages/junior/src/chat/ingress/slash-command.ts
+++ b/packages/junior/src/chat/ingress/slash-command.ts
@@ -5,7 +5,7 @@ import { isPluginProvider } from "@/chat/plugins/registry";
 import { getPluginOAuthConfig } from "@/chat/plugins/registry";
 import { logInfo } from "@/chat/logging";
 import { getChatConfig } from "@/chat/config";
-import { normalizeActorIdentity } from "@/chat/services/requester-identity";
+import { parseActorUserId } from "@/chat/services/requester-identity";
 
 async function postEphemeral(
   event: SlashCommandEvent,
@@ -15,11 +15,11 @@ async function postEphemeral(
 }
 
 function requireRequesterId(event: SlashCommandEvent): string {
-  const identity = normalizeActorIdentity({ userId: event.user.userId });
-  if (!identity?.userId) {
+  const userId = parseActorUserId(event.user.userId);
+  if (!userId) {
     throw new Error("Slack slash command requires a requester user id");
   }
-  return identity.userId;
+  return userId;
 }
 
 function getCommandName(): string {

--- a/packages/junior/src/chat/ingress/slash-command.ts
+++ b/packages/junior/src/chat/ingress/slash-command.ts
@@ -5,6 +5,7 @@ import { isPluginProvider } from "@/chat/plugins/registry";
 import { getPluginOAuthConfig } from "@/chat/plugins/registry";
 import { logInfo } from "@/chat/logging";
 import { getChatConfig } from "@/chat/config";
+import { normalizeActorIdentity } from "@/chat/services/requester-identity";
 
 async function postEphemeral(
   event: SlashCommandEvent,
@@ -14,11 +15,11 @@ async function postEphemeral(
 }
 
 function requireRequesterId(event: SlashCommandEvent): string {
-  const userId = event.user.userId?.trim();
-  if (!userId) {
+  const identity = normalizeActorIdentity({ userId: event.user.userId });
+  if (!identity?.userId) {
     throw new Error("Slack slash command requires a requester user id");
   }
-  return userId;
+  return identity.userId;
 }
 
 function getCommandName(): string {

--- a/packages/junior/src/chat/ingress/slash-command.ts
+++ b/packages/junior/src/chat/ingress/slash-command.ts
@@ -13,12 +13,21 @@ async function postEphemeral(
   await event.channel.postEphemeral(event.user, text, { fallbackToDM: false });
 }
 
+function requireRequesterId(event: SlashCommandEvent): string {
+  const userId = event.user.userId?.trim();
+  if (!userId) {
+    throw new Error("Slack slash command requires a requester user id");
+  }
+  return userId;
+}
+
 function getCommandName(): string {
   return getChatConfig().slack.slashCommand;
 }
 
 async function handleLink(
   event: SlashCommandEvent,
+  requesterId: string,
   provider: string,
 ): Promise<void> {
   if (!isPluginProvider(provider)) {
@@ -36,7 +45,7 @@ async function handleLink(
 
   const raw = event.raw as { channel_id?: string };
   const result = await startOAuthFlow(provider, {
-    requesterId: event.user.userId,
+    requesterId,
     channelId: raw.channel_id,
   });
 
@@ -60,6 +69,7 @@ async function handleLink(
 
 async function handleUnlink(
   event: SlashCommandEvent,
+  requesterId: string,
   provider: string,
 ): Promise<void> {
   if (!isPluginProvider(provider)) {
@@ -76,11 +86,11 @@ async function handleUnlink(
   }
 
   const tokenStore = createUserTokenStore();
-  await tokenStore.delete(event.user.userId, provider);
+  await tokenStore.delete(requesterId, provider);
 
   logInfo(
     "slash_command_unlink",
-    { slackUserId: event.user.userId },
+    { slackUserId: requesterId },
     { "app.credential.provider": provider },
     `Unlinked ${formatProviderLabel(provider)} account via ${getCommandName()} slash command`,
   );
@@ -114,10 +124,11 @@ export async function handleSlashCommand(
   }
 
   const normalized = provider.toLowerCase();
+  const requesterId = requireRequesterId(event);
 
   if (subcommand === "link") {
-    await handleLink(event, normalized);
+    await handleLink(event, requesterId, normalized);
   } else {
-    await handleUnlink(event, normalized);
+    await handleUnlink(event, requesterId, normalized);
   }
 }

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -2,7 +2,7 @@
  * Agent turn orchestration.
  *
  * This module owns the Pi-facing execution boundary for one Junior turn after
- * Slack/runtime code has normalized the request. It assembles prompt context,
+ * Slack/runtime code has parsed and routed the request. It assembles prompt context,
  * restores durable Pi/session state, wires tools/MCP/auth, executes the agent,
  * and persists resumable checkpoints. Slack delivery and thread presentation
  * should stay outside this file.
@@ -135,7 +135,7 @@ import type { CredentialContext } from "@/chat/credentials/context";
 import { parseSlackThreadId } from "@/chat/slack/context";
 import { createMcpAuthOrchestration } from "@/chat/services/mcp-auth-orchestration";
 import { createPluginAuthOrchestration } from "@/chat/services/plugin-auth-orchestration";
-import { normalizeActorIdentity } from "@/chat/services/requester-identity";
+import { buildActorIdentity } from "@/chat/services/requester-identity";
 import {
   AuthorizationFlowDisabledError,
   AuthorizationPauseError,
@@ -333,7 +333,7 @@ function actorRequesterFromContext(
   requester: ReplyRequestContext["requester"],
   requesterId: string | undefined,
 ): ReplyRequestContext["requester"] | undefined {
-  return normalizeActorIdentity(requester, requesterId);
+  return buildActorIdentity(requester, requesterId);
 }
 
 function surfaceFromContext(

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -135,6 +135,7 @@ import type { CredentialContext } from "@/chat/credentials/context";
 import { parseSlackThreadId } from "@/chat/slack/context";
 import { createMcpAuthOrchestration } from "@/chat/services/mcp-auth-orchestration";
 import { createPluginAuthOrchestration } from "@/chat/services/plugin-auth-orchestration";
+import { normalizeActorIdentity } from "@/chat/services/requester-identity";
 import {
   AuthorizationFlowDisabledError,
   AuthorizationPauseError,
@@ -318,15 +319,21 @@ function requesterFromContext(
   requester: ReplyRequestContext["requester"],
   requesterId: string | undefined,
 ): AgentTurnRequester | undefined {
-  const identity: AgentTurnRequester = {
-    ...(requester?.email ? { email: requester.email } : {}),
-    ...(requester?.fullName ? { fullName: requester.fullName } : {}),
-    ...((requesterId ?? requester?.userId)
-      ? { slackUserId: requesterId ?? requester?.userId }
-      : {}),
-    ...(requester?.userName ? { slackUserName: requester.userName } : {}),
+  const identity = actorRequesterFromContext(requester, requesterId);
+  const agentRequester: AgentTurnRequester = {
+    ...(identity?.email ? { email: identity.email } : {}),
+    ...(identity?.fullName ? { fullName: identity.fullName } : {}),
+    ...(identity?.userId ? { slackUserId: identity.userId } : {}),
+    ...(identity?.userName ? { slackUserName: identity.userName } : {}),
   };
-  return Object.keys(identity).length > 0 ? identity : undefined;
+  return Object.keys(agentRequester).length > 0 ? agentRequester : undefined;
+}
+
+function actorRequesterFromContext(
+  requester: ReplyRequestContext["requester"],
+  requesterId: string | undefined,
+): ReplyRequestContext["requester"] | undefined {
+  return normalizeActorIdentity(requester, requesterId);
 }
 
 function surfaceFromContext(
@@ -510,6 +517,10 @@ export async function generateAssistantReply(
     context.requester,
     context.correlation?.requesterId,
   );
+  const actorRequester = actorRequesterFromContext(
+    context.requester,
+    context.correlation?.requesterId,
+  );
   const surface = surfaceFromContext(context);
   const credentialActor = context.credentialContext?.actor;
   const credentialActorLogContext = credentialActor
@@ -676,7 +687,7 @@ export async function generateAssistantReply(
         : undefined;
     const userTokenStore = createUserTokenStore();
     const agentPluginHooks = createAgentPluginHookRunner({
-      requester: context.requester,
+      requester: actorRequester,
     });
     sandboxExecutor = createSandboxExecutor({
       sandboxId: context.sandbox?.sandboxId,
@@ -695,7 +706,7 @@ export async function generateAssistantReply(
         const result = await maybeExecuteJrRpcCustomCommand(command, {
           activeSkill: skillSandbox.getActiveSkill(),
           channelConfiguration: context.channelConfiguration,
-          requesterId: context.requester?.userId,
+          requesterId: actorRequester?.userId,
           onConfigurationValueChanged: (key, value) => {
             if (value === undefined) {
               delete configurationValues[key];
@@ -989,7 +1000,7 @@ export async function generateAssistantReply(
       {
         channelId: toolChannelId,
         channelCapabilities,
-        requester: context.requester,
+        requester: actorRequester,
         teamId: context.correlation?.teamId,
         messageTs: context.correlation?.messageTs,
         threadTs: context.correlation?.threadTs,
@@ -1062,7 +1073,7 @@ export async function generateAssistantReply(
             slackConversation: context.slackConversation,
           },
           invocation: skillInvocation,
-          requester: context.requester,
+          requester: actorRequester,
           artifactState: context.artifactState,
           configuration: configurationValues,
         })

--- a/packages/junior/src/chat/runtime/conversation-message.ts
+++ b/packages/junior/src/chat/runtime/conversation-message.ts
@@ -2,6 +2,7 @@ import type { Message } from "chat";
 import { getSlackMessageTs } from "@/chat/slack/message";
 import type { ConversationMessage } from "@/chat/state/conversation";
 import { normalizeConversationText } from "@/chat/services/conversation-memory";
+import { getMessageActorIdentity } from "@/chat/services/message-actor-identity";
 import {
   countPotentialImageAttachments,
   hasPotentialImageAttachment,
@@ -24,6 +25,7 @@ function resolveMessageText(args: ConversationMessageInput): string {
 export function toConversationMessage(
   args: ConversationMessageInput,
 ): ConversationMessage {
+  const actor = getMessageActorIdentity(args.entry);
   const messageHasPotentialImageAttachment = hasPotentialImageAttachment(
     args.entry.attachments,
   );
@@ -37,9 +39,9 @@ export function toConversationMessage(
     text: resolveMessageText(args),
     createdAtMs: args.entry.metadata.dateSent.getTime(),
     author: {
-      userId: args.entry.author.userId,
-      userName: args.entry.author.userName,
-      fullName: args.entry.author.fullName,
+      ...(actor?.userId ? { userId: actor.userId } : {}),
+      ...(actor?.userName ? { userName: actor.userName } : {}),
+      ...(actor?.fullName ? { fullName: actor.fullName } : {}),
       isBot:
         typeof args.entry.author.isBot === "boolean"
           ? args.entry.author.isBot

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -82,6 +82,10 @@ import {
 import { appendSlackLegacyAttachmentText } from "@/chat/slack/legacy-attachments";
 import { type ThreadArtifactsState } from "@/chat/state/artifacts";
 import { lookupSlackUser } from "@/chat/slack/user";
+import {
+  slackActorIdentity,
+  type ActorIdentityInput,
+} from "@/chat/services/requester-identity";
 import type { TurnContinuationRequest } from "@/chat/services/timeout-resume";
 import {
   isCooperativeTurnYieldError,
@@ -120,19 +124,14 @@ function collectCanvasUrls(artifacts: Partial<ThreadArtifactsState>) {
   );
 }
 
-function turnRequester(args: {
-  email?: string;
-  fullName?: string;
-  userId?: string;
-  userName?: string;
-}): AgentTurnRequester | undefined {
+function turnRequester(identity: ActorIdentityInput): AgentTurnRequester {
   const requester: AgentTurnRequester = {
-    ...(args.email ? { email: args.email } : {}),
-    ...(args.fullName ? { fullName: args.fullName } : {}),
-    ...(args.userId ? { slackUserId: args.userId } : {}),
-    ...(args.userName ? { slackUserName: args.userName } : {}),
+    ...(identity.email ? { email: identity.email } : {}),
+    ...(identity.fullName ? { fullName: identity.fullName } : {}),
+    ...(identity.userId ? { slackUserId: identity.userId } : {}),
+    ...(identity.userName ? { slackUserName: identity.userName } : {}),
   };
-  return Object.keys(requester).length > 0 ? requester : undefined;
+  return requester;
 }
 
 async function resolveChannelName(thread: Thread): Promise<string | undefined> {
@@ -353,15 +352,14 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
 
         const slackMessageTs = getSlackMessageTs(message);
         const turnId = buildDeterministicTurnId(message.id);
-        const fallbackIdentity = await deps.services.lookupSlackUser(
+        const slackProfile = await deps.services.lookupSlackUser(
           message.author.userId,
         );
-        const requester = turnRequester({
-          email: fallbackIdentity?.email,
-          fullName: message.author.fullName ?? fallbackIdentity?.fullName,
-          userId: message.author.userId,
-          userName: message.author.userName ?? fallbackIdentity?.userName,
-        });
+        const requesterIdentity = slackActorIdentity(
+          message.author.userId,
+          slackProfile,
+        );
+        const requester = turnRequester(requesterIdentity);
         const turnTraceContext = {
           conversationId,
           slackThreadId: threadId,
@@ -558,19 +556,19 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
         });
         await options.onTurnStatePersisted?.();
 
-        const resolvedUserName =
-          message.author.userName ?? fallbackIdentity?.userName;
         if (message.author.userId) {
           setSentryUser({
             id: message.author.userId,
-            ...(resolvedUserName ? { username: resolvedUserName } : {}),
-            ...(fallbackIdentity?.email
-              ? { email: fallbackIdentity.email }
+            ...(requesterIdentity.userName
+              ? { username: requesterIdentity.userName }
+              : {}),
+            ...(requesterIdentity.email
+              ? { email: requesterIdentity.email }
               : {}),
           });
         }
-        if (resolvedUserName) {
-          setTags({ slackUserName: resolvedUserName });
+        if (requesterIdentity.userName) {
+          setTags({ slackUserName: requesterIdentity.userName });
         }
         const turnAttachments = collectTurnAttachments(
           message,
@@ -727,12 +725,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               credentialContext: {
                 actor: { type: "user", userId: message.author.userId },
               },
-              requester: {
-                userId: message.author.userId,
-                userName: message.author.userName ?? fallbackIdentity?.userName,
-                fullName: message.author.fullName ?? fallbackIdentity?.fullName,
-                email: fallbackIdentity?.email,
-              },
+              requester: requesterIdentity,
               conversationContext: preparedState.conversationContext,
               artifactState: preparedState.artifacts,
               piMessages,

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -82,10 +82,8 @@ import {
 import { appendSlackLegacyAttachmentText } from "@/chat/slack/legacy-attachments";
 import { type ThreadArtifactsState } from "@/chat/state/artifacts";
 import { lookupSlackUser } from "@/chat/slack/user";
-import {
-  slackActorIdentity,
-  type ActorIdentityInput,
-} from "@/chat/services/requester-identity";
+import type { ActorIdentityInput } from "@/chat/services/requester-identity";
+import { ensureSlackMessageActorIdentity } from "@/chat/services/message-actor-identity";
 import type { TurnContinuationRequest } from "@/chat/services/timeout-resume";
 import {
   isCooperativeTurnYieldError,
@@ -331,6 +329,19 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           options.queuedMessages ?? [],
           currentText,
         ).userText;
+        await Promise.all(
+          (options.queuedMessages ?? []).map((queued) =>
+            ensureSlackMessageActorIdentity(
+              queued.message,
+              deps.services.lookupSlackUser,
+            ),
+          ),
+        );
+        const requesterIdentity = await ensureSlackMessageActorIdentity(
+          message,
+          deps.services.lookupSlackUser,
+        );
+        const requester = turnRequester(requesterIdentity);
 
         const preparedState =
           options.preparedState ??
@@ -352,14 +363,6 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
 
         const slackMessageTs = getSlackMessageTs(message);
         const turnId = buildDeterministicTurnId(message.id);
-        const slackProfile = await deps.services.lookupSlackUser(
-          message.author.userId,
-        );
-        const requesterIdentity = slackActorIdentity(
-          message.author.userId,
-          slackProfile,
-        );
-        const requester = turnRequester(requesterIdentity);
         const turnTraceContext = {
           conversationId,
           slackThreadId: threadId,

--- a/packages/junior/src/chat/runtime/slack-runtime.ts
+++ b/packages/junior/src/chat/runtime/slack-runtime.ts
@@ -37,6 +37,7 @@ import {
   type TurnMessageText,
   type TurnToolInvocation,
 } from "@/chat/runtime/turn-input";
+import { getMessageActorIdentity } from "@/chat/services/message-actor-identity";
 
 export interface AssistantLifecycleEvent {
   channelId: string;
@@ -288,6 +289,10 @@ function buildLogContext(
   };
 }
 
+function requesterUserName(message: Message): string | undefined {
+  return getMessageActorIdentity(message)?.userName;
+}
+
 /** Build the Slack event runtime that routes mentions and subscribed messages. */
 export function createSlackTurnRuntime<
   TPreparedState,
@@ -409,7 +414,7 @@ export function createSlackTurnRuntime<
       logContext({
         threadId: args.context.threadId,
         requesterId: args.context.requesterId,
-        requesterUserName: args.message.author.userName,
+        requesterUserName: requesterUserName(args.message),
         channelId: args.context.channelId,
         runId: args.context.runId,
       }),
@@ -456,7 +461,7 @@ export function createSlackTurnRuntime<
           threadId,
           channelId,
           requesterId: message.author.userId,
-          requesterUserName: message.author.userName,
+          requesterUserName: requesterUserName(message),
           runId,
         });
         processingReaction = await processingReactions.start(context, message);
@@ -520,7 +525,7 @@ export function createSlackTurnRuntime<
         const errorContext = logContext({
           threadId: deps.getThreadId(thread, message),
           requesterId: message.author.userId,
-          requesterUserName: message.author.userName,
+          requesterUserName: requesterUserName(message),
           channelId: deps.getChannelId(thread, message),
           runId: deps.getRunId(thread, message),
         });
@@ -585,7 +590,7 @@ export function createSlackTurnRuntime<
         const turnContext = logContext({
           threadId,
           requesterId: message.author.userId,
-          requesterUserName: message.author.userName,
+          requesterUserName: requesterUserName(message),
           channelId,
           runId,
         });
@@ -759,7 +764,7 @@ export function createSlackTurnRuntime<
         const errorContext = logContext({
           threadId: deps.getThreadId(thread, message),
           requesterId: message.author.userId,
-          requesterUserName: message.author.userName,
+          requesterUserName: requesterUserName(message),
           channelId: deps.getChannelId(thread, message),
           runId: deps.getRunId(thread, message),
         });

--- a/packages/junior/src/chat/runtime/timeout-resume-runner.ts
+++ b/packages/junior/src/chat/runtime/timeout-resume-runner.ts
@@ -33,6 +33,7 @@ import {
   type TurnContinuationRequest,
 } from "@/chat/services/timeout-resume";
 import { parseSlackThreadId } from "@/chat/slack/context";
+import { lookupSlackActorIdentity } from "@/chat/slack/user";
 import type { AssistantReply } from "@/chat/respond";
 import { persistAuthPauseTurnState } from "@/chat/runtime/auth-pause-state";
 import {
@@ -192,6 +193,9 @@ export async function resumeTimedOutTurn(
         excludeMessageId: userMessage.id,
       });
       const sandbox = getPersistedSandboxState(currentState);
+      const requester = await lookupSlackActorIdentity(
+        userMessage.author.userId,
+      );
 
       return {
         messageText: userMessage.text,
@@ -203,11 +207,7 @@ export async function resumeTimedOutTurn(
               userId: userMessage.author.userId,
             },
           },
-          requester: {
-            userId: userMessage.author.userId,
-            userName: userMessage.author.userName,
-            fullName: userMessage.author.fullName,
-          },
+          requester,
           correlation: {
             conversationId: payload.conversationId,
             turnId: payload.sessionId,

--- a/packages/junior/src/chat/services/conversation-memory.ts
+++ b/packages/junior/src/chat/services/conversation-memory.ts
@@ -7,6 +7,8 @@ import type {
 } from "@/chat/state/conversation";
 import { toOptionalString } from "@/chat/coerce";
 import { logWarn, setSpanAttributes } from "@/chat/logging";
+import { normalizeActorIdentity } from "@/chat/services/requester-identity";
+import { actorDisplayLabel } from "@/chat/services/message-actor-identity";
 import {
   calculateContextCompactionTargetTokens,
   estimateTextTokens,
@@ -70,10 +72,11 @@ function renderConversationMessageLine(
   message: ConversationMessage,
   conversation?: ThreadConversationState,
 ): string {
-  const displayName =
-    message.author?.fullName ||
-    message.author?.userName ||
-    (message.role === "assistant" ? botConfig.userName : message.role);
+  const actor = normalizeActorIdentity(message.author, message.author?.userId);
+  const displayName = actorDisplayLabel(
+    actor,
+    message.role === "assistant" ? botConfig.userName : message.role,
+  );
 
   const markers: string[] = [];
   if (message.meta?.replied === false) {
@@ -187,13 +190,23 @@ export function buildConversationContext(
     }
     lines.push("<thread-transcript>");
     for (const [index, message] of messages.entries()) {
-      const author = escapeXml(message.author?.userName ?? message.role);
+      const actor = normalizeActorIdentity(
+        message.author,
+        message.author?.userId,
+      );
+      const author = escapeXml(
+        actor?.userName ??
+          (message.role === "assistant" ? botConfig.userName : message.role),
+      );
+      const actorIdAttr = actor?.userId
+        ? ` actor_id="${escapeXml(actor.userId)}"`
+        : "";
       const ts = new Date(message.createdAtMs).toISOString();
       const slackTsAttr = message.meta?.slackTs
         ? ` slack_ts="${escapeXml(message.meta.slackTs)}"`
         : "";
       lines.push(
-        `  <message index="${index + 1}" ts="${ts}" role="${message.role}" author="${author}"${slackTsAttr}>`,
+        `  <message index="${index + 1}" ts="${ts}" role="${message.role}" author="${author}"${actorIdAttr}${slackTsAttr}>`,
         renderConversationMessageLine(message, conversation),
         "  </message>",
       );

--- a/packages/junior/src/chat/services/conversation-memory.ts
+++ b/packages/junior/src/chat/services/conversation-memory.ts
@@ -7,7 +7,6 @@ import type {
 } from "@/chat/state/conversation";
 import { toOptionalString } from "@/chat/coerce";
 import { logWarn, setSpanAttributes } from "@/chat/logging";
-import { normalizeActorIdentity } from "@/chat/services/requester-identity";
 import {
   calculateContextCompactionTargetTokens,
   estimateTextTokens,
@@ -19,6 +18,7 @@ const CONTEXT_MIN_LIVE_MESSAGES = 12;
 const CONTEXT_COMPACTION_BATCH_SIZE = 24;
 const CONTEXT_MAX_COMPACTIONS = 16;
 const CONTEXT_MAX_MESSAGE_CHARS = 3200;
+const SLACK_USER_ID_DISPLAY_PATTERN = /^[UW][A-Z0-9]{5,}$/;
 
 export interface ConversationMemoryDeps {
   completeText: typeof completeText;
@@ -71,11 +71,7 @@ function renderConversationMessageLine(
   message: ConversationMessage,
   conversation?: ThreadConversationState,
 ): string {
-  const actor = normalizeActorIdentity(message.author, message.author?.userId);
-  const displayName =
-    actor?.fullName ??
-    actor?.userName ??
-    (message.role === "assistant" ? botConfig.userName : message.role);
+  const displayName = conversationAuthorDisplayName(message);
 
   const markers: string[] = [];
   if (message.meta?.replied === false) {
@@ -90,6 +86,27 @@ function renderConversationMessageLine(
   const markerSuffix = markers.length > 0 ? ` (${markers.join("; ")})` : "";
   const imageContext = buildImageContextSuffix(message, conversation);
   return `[${message.role}] ${displayName}: ${message.text}${imageContext}${markerSuffix}`;
+}
+
+function conversationAuthorDisplayName(message: ConversationMessage): string {
+  const author = message.author;
+  const fullName = authorDisplayField(author?.fullName, author?.userId);
+  const userName = authorDisplayField(author?.userName, author?.userId);
+  return (
+    fullName ??
+    userName ??
+    (message.role === "assistant" ? botConfig.userName : message.role)
+  );
+}
+
+function authorDisplayField(
+  value: string | undefined,
+  userId: string | undefined,
+): string | undefined {
+  if (!value || value === userId || SLACK_USER_ID_DISPLAY_PATTERN.test(value)) {
+    return undefined;
+  }
+  return value;
 }
 
 export function updateConversationStats(
@@ -189,16 +206,9 @@ export function buildConversationContext(
     }
     lines.push("<thread-transcript>");
     for (const [index, message] of messages.entries()) {
-      const actor = normalizeActorIdentity(
-        message.author,
-        message.author?.userId,
-      );
-      const author = escapeXml(
-        actor?.userName ??
-          (message.role === "assistant" ? botConfig.userName : message.role),
-      );
-      const actorIdAttr = actor?.userId
-        ? ` actor_id="${escapeXml(actor.userId)}"`
+      const author = escapeXml(conversationAuthorDisplayName(message));
+      const actorIdAttr = message.author?.userId
+        ? ` actor_id="${escapeXml(message.author.userId)}"`
         : "";
       const ts = new Date(message.createdAtMs).toISOString();
       const slackTsAttr = message.meta?.slackTs

--- a/packages/junior/src/chat/services/conversation-memory.ts
+++ b/packages/junior/src/chat/services/conversation-memory.ts
@@ -8,7 +8,6 @@ import type {
 import { toOptionalString } from "@/chat/coerce";
 import { logWarn, setSpanAttributes } from "@/chat/logging";
 import { normalizeActorIdentity } from "@/chat/services/requester-identity";
-import { actorDisplayLabel } from "@/chat/services/message-actor-identity";
 import {
   calculateContextCompactionTargetTokens,
   estimateTextTokens,
@@ -73,10 +72,10 @@ function renderConversationMessageLine(
   conversation?: ThreadConversationState,
 ): string {
   const actor = normalizeActorIdentity(message.author, message.author?.userId);
-  const displayName = actorDisplayLabel(
-    actor,
-    message.role === "assistant" ? botConfig.userName : message.role,
-  );
+  const displayName =
+    actor?.fullName ??
+    actor?.userName ??
+    (message.role === "assistant" ? botConfig.userName : message.role);
 
   const markers: string[] = [];
   if (message.meta?.replied === false) {

--- a/packages/junior/src/chat/services/message-actor-identity.ts
+++ b/packages/junior/src/chat/services/message-actor-identity.ts
@@ -1,6 +1,7 @@
 import type { Author, Message } from "chat";
 import {
   normalizeActorIdentity,
+  normalizeActorUserId,
   slackActorIdentity,
   type ActorIdentityInput,
   type SlackActorProfile,
@@ -8,16 +9,9 @@ import {
 
 const messageActors = new WeakMap<Message, ActorIdentityInput>();
 
-function cleanUserId(value: string | undefined): string | undefined {
-  const normalized = value?.trim();
-  return normalized && normalized.toLowerCase() !== "unknown"
-    ? normalized
-    : undefined;
-}
-
 function canonicalUserId(author: Author, identity: ActorIdentityInput): string {
-  const authorUserId = cleanUserId(author.userId);
-  const identityUserId = cleanUserId(identity.userId);
+  const authorUserId = normalizeActorUserId(author.userId);
+  const identityUserId = normalizeActorUserId(identity.userId);
   if (authorUserId && identityUserId && authorUserId !== identityUserId) {
     throw new Error("Message actor identity user id mismatch");
   }
@@ -31,14 +25,8 @@ function canonicalUserId(author: Author, identity: ActorIdentityInput): string {
 function actorIdentityFromAuthor(
   author: Author,
 ): ActorIdentityInput | undefined {
-  return normalizeActorIdentity(
-    {
-      fullName: author.fullName,
-      userId: cleanUserId(author.userId),
-      userName: author.userName,
-    },
-    cleanUserId(author.userId),
-  );
+  const userId = normalizeActorUserId(author.userId);
+  return userId ? { userId } : undefined;
 }
 
 function applyIdentityToAuthor(
@@ -86,7 +74,7 @@ export async function ensureSlackMessageActorIdentity(
   if (existing) {
     return existing;
   }
-  const userId = cleanUserId(message.author.userId);
+  const userId = normalizeActorUserId(message.author.userId);
   if (!userId) {
     throw new Error("Slack message actor identity requires a user id");
   }

--- a/packages/junior/src/chat/services/message-actor-identity.ts
+++ b/packages/junior/src/chat/services/message-actor-identity.ts
@@ -1,0 +1,105 @@
+import type { Author, Message } from "chat";
+import {
+  normalizeActorIdentity,
+  slackActorIdentity,
+  type ActorIdentityInput,
+  type SlackActorProfile,
+} from "@/chat/services/requester-identity";
+
+const messageActors = new WeakMap<Message, ActorIdentityInput>();
+
+function cleanUserId(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized && normalized.toLowerCase() !== "unknown"
+    ? normalized
+    : undefined;
+}
+
+function canonicalUserId(author: Author, identity: ActorIdentityInput): string {
+  const authorUserId = cleanUserId(author.userId);
+  const identityUserId = cleanUserId(identity.userId);
+  if (authorUserId && identityUserId && authorUserId !== identityUserId) {
+    throw new Error("Message actor identity user id mismatch");
+  }
+  const userId = authorUserId ?? identityUserId;
+  if (!userId) {
+    throw new Error("Message actor identity requires a user id");
+  }
+  return userId;
+}
+
+function actorIdentityFromAuthor(
+  author: Author,
+): ActorIdentityInput | undefined {
+  return normalizeActorIdentity(
+    {
+      fullName: author.fullName,
+      userId: cleanUserId(author.userId),
+      userName: author.userName,
+    },
+    cleanUserId(author.userId),
+  );
+}
+
+function applyIdentityToAuthor(
+  author: Author,
+  identity: ActorIdentityInput,
+): void {
+  if (!identity.userId) {
+    throw new Error("Message actor identity requires a user id");
+  }
+  author.userId = identity.userId;
+  author.userName = identity.userName ?? "";
+  author.fullName = identity.fullName ?? "";
+}
+
+/** Bind canonical actor identity to a Chat SDK message for downstream consumers. */
+export function bindMessageActorIdentity(
+  message: Message,
+  identity: ActorIdentityInput,
+): ActorIdentityInput {
+  const userId = canonicalUserId(message.author, identity);
+  const normalized = normalizeActorIdentity(identity, userId);
+  if (!normalized?.userId) {
+    throw new Error("Message actor identity requires a user id");
+  }
+  messageActors.set(message, normalized);
+  applyIdentityToAuthor(message.author, normalized);
+  return normalized;
+}
+
+/** Return canonical actor identity for a message without trusting adapter display fallbacks. */
+export function getMessageActorIdentity(
+  message: Message,
+): ActorIdentityInput | undefined {
+  return messageActors.get(message) ?? actorIdentityFromAuthor(message.author);
+}
+
+/** Resolve and bind Slack profile-backed actor identity for one message. */
+export async function ensureSlackMessageActorIdentity(
+  message: Message,
+  lookupSlackUser: (
+    userId: string,
+  ) => Promise<SlackActorProfile | null | undefined>,
+): Promise<ActorIdentityInput> {
+  const existing = messageActors.get(message);
+  if (existing) {
+    return existing;
+  }
+  const userId = cleanUserId(message.author.userId);
+  if (!userId) {
+    throw new Error("Slack message actor identity requires a user id");
+  }
+  return bindMessageActorIdentity(
+    message,
+    slackActorIdentity(userId, await lookupSlackUser(userId)),
+  );
+}
+
+/** Render an author label without promoting platform ids into names. */
+export function actorDisplayLabel(
+  identity: ActorIdentityInput | undefined,
+  fallback: string,
+): string {
+  return identity?.fullName ?? identity?.userName ?? fallback;
+}

--- a/packages/junior/src/chat/services/message-actor-identity.ts
+++ b/packages/junior/src/chat/services/message-actor-identity.ts
@@ -1,7 +1,8 @@
 import type { Author, Message } from "chat";
 import {
+  isActorUserId,
   normalizeActorIdentity,
-  normalizeActorUserId,
+  parseActorUserId,
   slackActorIdentity,
   type ActorIdentityInput,
   type SlackActorProfile,
@@ -10,8 +11,8 @@ import {
 const messageActors = new WeakMap<Message, ActorIdentityInput>();
 
 function canonicalUserId(author: Author, identity: ActorIdentityInput): string {
-  const authorUserId = normalizeActorUserId(author.userId);
-  const identityUserId = normalizeActorUserId(identity.userId);
+  const authorUserId = parseActorUserId(author.userId);
+  const identityUserId = parseActorUserId(identity.userId);
   if (authorUserId && identityUserId && authorUserId !== identityUserId) {
     throw new Error("Message actor identity user id mismatch");
   }
@@ -25,7 +26,7 @@ function canonicalUserId(author: Author, identity: ActorIdentityInput): string {
 function actorIdentityFromAuthor(
   author: Author,
 ): ActorIdentityInput | undefined {
-  const userId = normalizeActorUserId(author.userId);
+  const userId = parseActorUserId(author.userId);
   return userId ? { userId } : undefined;
 }
 
@@ -33,7 +34,7 @@ function applyIdentityToAuthor(
   author: Author,
   identity: ActorIdentityInput,
 ): void {
-  if (!identity.userId) {
+  if (!isActorUserId(identity.userId)) {
     throw new Error("Message actor identity requires a user id");
   }
   author.userId = identity.userId;
@@ -74,7 +75,7 @@ export async function ensureSlackMessageActorIdentity(
   if (existing) {
     return existing;
   }
-  const userId = normalizeActorUserId(message.author.userId);
+  const userId = parseActorUserId(message.author.userId);
   if (!userId) {
     throw new Error("Slack message actor identity requires a user id");
   }

--- a/packages/junior/src/chat/services/message-actor-identity.ts
+++ b/packages/junior/src/chat/services/message-actor-identity.ts
@@ -95,11 +95,3 @@ export async function ensureSlackMessageActorIdentity(
     slackActorIdentity(userId, await lookupSlackUser(userId)),
   );
 }
-
-/** Render an author label without promoting platform ids into names. */
-export function actorDisplayLabel(
-  identity: ActorIdentityInput | undefined,
-  fallback: string,
-): string {
-  return identity?.fullName ?? identity?.userName ?? fallback;
-}

--- a/packages/junior/src/chat/services/message-actor-identity.ts
+++ b/packages/junior/src/chat/services/message-actor-identity.ts
@@ -1,7 +1,7 @@
 import type { Author, Message } from "chat";
 import {
+  buildActorIdentity,
   isActorUserId,
-  normalizeActorIdentity,
   parseActorUserId,
   slackActorIdentity,
   type ActorIdentityInput,
@@ -42,29 +42,29 @@ function applyIdentityToAuthor(
   author.fullName = identity.fullName ?? "";
 }
 
-/** Bind canonical actor identity to a Chat SDK message for downstream consumers. */
+/** Preserve runtime-owned identity on Chat SDK messages before persistence. */
 export function bindMessageActorIdentity(
   message: Message,
   identity: ActorIdentityInput,
 ): ActorIdentityInput {
   const userId = canonicalUserId(message.author, identity);
-  const normalized = normalizeActorIdentity(identity, userId);
-  if (!normalized?.userId) {
+  const actorIdentity = buildActorIdentity(identity, userId);
+  if (!actorIdentity?.userId) {
     throw new Error("Message actor identity requires a user id");
   }
-  messageActors.set(message, normalized);
-  applyIdentityToAuthor(message.author, normalized);
-  return normalized;
+  messageActors.set(message, actorIdentity);
+  applyIdentityToAuthor(message.author, actorIdentity);
+  return actorIdentity;
 }
 
-/** Return canonical actor identity for a message without trusting adapter display fallbacks. */
+/** Read message identity without promoting adapter display fallbacks. */
 export function getMessageActorIdentity(
   message: Message,
 ): ActorIdentityInput | undefined {
   return messageActors.get(message) ?? actorIdentityFromAuthor(message.author);
 }
 
-/** Resolve and bind Slack profile-backed actor identity for one message. */
+/** Attach Slack display fields only after the author id is exact. */
 export async function ensureSlackMessageActorIdentity(
   message: Message,
   lookupSlackUser: (

--- a/packages/junior/src/chat/services/requester-identity.ts
+++ b/packages/junior/src/chat/services/requester-identity.ts
@@ -1,0 +1,93 @@
+const SLACK_USER_ID_PATTERN = /^[UW][A-Z0-9]{5,}$/;
+const EMAIL_PATTERN = /^[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+$/;
+
+export interface ActorIdentityInput {
+  email?: string;
+  fullName?: string;
+  userId?: string;
+  userName?: string;
+}
+
+export interface SlackActorProfile {
+  email?: string;
+  fullName?: string;
+  userName?: string;
+}
+
+function clean(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+function isSlackUserId(value: string): boolean {
+  return SLACK_USER_ID_PATTERN.test(value);
+}
+
+function cleanActorDisplayName(
+  value: string | undefined,
+  userId?: string,
+): string | undefined {
+  const normalized = clean(value);
+  if (!normalized) {
+    return undefined;
+  }
+  if (userId && normalized === userId) {
+    return undefined;
+  }
+  return isSlackUserId(normalized) ? undefined : normalized;
+}
+
+function cleanActorEmail(value: string | undefined): string | undefined {
+  const normalized = clean(value);
+  return normalized && EMAIL_PATTERN.test(normalized) ? normalized : undefined;
+}
+
+/** Normalize a requester object without promoting platform IDs into display identity. */
+export function normalizeActorIdentity(
+  requester: ActorIdentityInput | undefined,
+  requesterId?: string,
+): ActorIdentityInput | undefined {
+  const contextUserId = clean(requesterId);
+  const requesterUserId = clean(requester?.userId);
+  const userId = contextUserId ?? requesterUserId;
+  const canUseRequesterIdentity =
+    !contextUserId || !requesterUserId || contextUserId === requesterUserId;
+  const email = canUseRequesterIdentity
+    ? cleanActorEmail(requester?.email)
+    : undefined;
+  const fullName = canUseRequesterIdentity
+    ? cleanActorDisplayName(requester?.fullName, userId)
+    : undefined;
+  const userName = canUseRequesterIdentity
+    ? cleanActorDisplayName(requester?.userName, userId)
+    : undefined;
+  const identity: ActorIdentityInput = {
+    ...(email ? { email } : {}),
+    ...(fullName ? { fullName } : {}),
+    ...(userId ? { userId } : {}),
+    ...(userName ? { userName } : {}),
+  };
+  return Object.keys(identity).length > 0 ? identity : undefined;
+}
+
+/** Build Slack actor identity from the resolved Slack profile source of truth. */
+export function slackActorIdentity(
+  userId: string,
+  profile: SlackActorProfile | null | undefined,
+): ActorIdentityInput {
+  const actorUserId = clean(userId);
+  if (!actorUserId) {
+    throw new Error("Slack actor identity requires a user id");
+  }
+  return (
+    normalizeActorIdentity(
+      {
+        email: profile?.email,
+        fullName: profile?.fullName,
+        userId: actorUserId,
+        userName: profile?.userName,
+      },
+      actorUserId,
+    ) ?? { userId: actorUserId }
+  );
+}

--- a/packages/junior/src/chat/services/requester-identity.ts
+++ b/packages/junior/src/chat/services/requester-identity.ts
@@ -19,14 +19,24 @@ function clean(value: string | undefined): string | undefined {
   return normalized ? normalized : undefined;
 }
 
-/** Normalize a platform actor id, rejecting synthetic sentinel values. */
-export function normalizeActorUserId(
-  value: string | undefined,
-): string | undefined {
-  const normalized = clean(value);
-  return normalized && normalized.toLowerCase() !== "unknown"
-    ? normalized
-    : undefined;
+function isSyntheticActorUserId(value: string): boolean {
+  return value.toLowerCase() === "unknown";
+}
+
+/** Parse actor ids from platform or adapter payloads before they enter owned state. */
+export function parseActorUserId(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.length === 0) {
+    return undefined;
+  }
+  if (value !== value.trim() || isSyntheticActorUserId(value)) {
+    return undefined;
+  }
+  return value;
+}
+
+/** Return whether a value is already an exact actor id accepted by owned state. */
+export function isActorUserId(value: string | undefined): value is string {
+  return parseActorUserId(value) === value;
 }
 
 function isSlackUserId(value: string): boolean {
@@ -60,8 +70,14 @@ export function normalizeActorIdentity(
   requester: ActorIdentityInput | undefined,
   requesterId?: string,
 ): ActorIdentityInput | undefined {
-  const contextUserId = normalizeActorUserId(requesterId);
-  const requesterUserId = normalizeActorUserId(requester?.userId);
+  const contextUserId = parseActorUserId(requesterId);
+  if (requesterId !== undefined && !contextUserId) {
+    return undefined;
+  }
+  const requesterUserId = parseActorUserId(requester?.userId);
+  if (requester?.userId !== undefined && !requesterUserId) {
+    return undefined;
+  }
   const userId = contextUserId ?? requesterUserId;
   const canUseRequesterIdentity =
     !contextUserId || !requesterUserId || contextUserId === requesterUserId;
@@ -88,7 +104,7 @@ export function slackActorIdentity(
   userId: string,
   profile: SlackActorProfile | null | undefined,
 ): ActorIdentityInput {
-  const actorUserId = normalizeActorUserId(userId);
+  const actorUserId = parseActorUserId(userId);
   if (!actorUserId) {
     throw new Error("Slack actor identity requires a user id");
   }

--- a/packages/junior/src/chat/services/requester-identity.ts
+++ b/packages/junior/src/chat/services/requester-identity.ts
@@ -15,15 +15,15 @@ export interface SlackActorProfile {
 }
 
 function clean(value: string | undefined): string | undefined {
-  const normalized = value?.trim();
-  return normalized ? normalized : undefined;
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
 }
 
 function isSyntheticActorUserId(value: string): boolean {
   return value.toLowerCase() === "unknown";
 }
 
-/** Parse actor ids from platform or adapter payloads before they enter owned state. */
+/** Keep actor ids exact at platform boundaries before they enter owned state. */
 export function parseActorUserId(value: unknown): string | undefined {
   if (typeof value !== "string" || value.length === 0) {
     return undefined;
@@ -34,7 +34,7 @@ export function parseActorUserId(value: unknown): string | undefined {
   return value;
 }
 
-/** Return whether a value is already an exact actor id accepted by owned state. */
+/** Assert persisted actor ids without read-side repair. */
 export function isActorUserId(value: string | undefined): value is string {
   return parseActorUserId(value) === value;
 }
@@ -47,26 +47,26 @@ function cleanActorDisplayName(
   value: string | undefined,
   userId?: string,
 ): string | undefined {
-  const normalized = clean(value);
-  if (!normalized) {
+  const displayName = clean(value);
+  if (!displayName) {
     return undefined;
   }
-  if (normalized.toLowerCase() === "unknown") {
+  if (displayName.toLowerCase() === "unknown") {
     return undefined;
   }
-  if (userId && normalized === userId) {
+  if (userId && displayName === userId) {
     return undefined;
   }
-  return isSlackUserId(normalized) ? undefined : normalized;
+  return isSlackUserId(displayName) ? undefined : displayName;
 }
 
 function cleanActorEmail(value: string | undefined): string | undefined {
-  const normalized = clean(value);
-  return normalized && EMAIL_PATTERN.test(normalized) ? normalized : undefined;
+  const email = clean(value);
+  return email && EMAIL_PATTERN.test(email) ? email : undefined;
 }
 
-/** Normalize a requester object without promoting platform IDs into display identity. */
-export function normalizeActorIdentity(
+/** Keep authority ids exact while attaching optional presentation fields. */
+export function buildActorIdentity(
   requester: ActorIdentityInput | undefined,
   requesterId?: string,
 ): ActorIdentityInput | undefined {
@@ -99,7 +99,7 @@ export function normalizeActorIdentity(
   return Object.keys(identity).length > 0 ? identity : undefined;
 }
 
-/** Build Slack actor identity from the resolved Slack profile source of truth. */
+/** Use Slack profile data only as presentation around the exact user id. */
 export function slackActorIdentity(
   userId: string,
   profile: SlackActorProfile | null | undefined,
@@ -108,7 +108,7 @@ export function slackActorIdentity(
   if (!actorUserId) {
     throw new Error("Slack actor identity requires a user id");
   }
-  const identity = normalizeActorIdentity(
+  const identity = buildActorIdentity(
     {
       email: profile?.email,
       fullName: profile?.fullName,

--- a/packages/junior/src/chat/services/requester-identity.ts
+++ b/packages/junior/src/chat/services/requester-identity.ts
@@ -19,7 +19,10 @@ function clean(value: string | undefined): string | undefined {
   return normalized ? normalized : undefined;
 }
 
-function cleanActorUserId(value: string | undefined): string | undefined {
+/** Normalize a platform actor id, rejecting synthetic sentinel values. */
+export function normalizeActorUserId(
+  value: string | undefined,
+): string | undefined {
   const normalized = clean(value);
   return normalized && normalized.toLowerCase() !== "unknown"
     ? normalized
@@ -57,8 +60,8 @@ export function normalizeActorIdentity(
   requester: ActorIdentityInput | undefined,
   requesterId?: string,
 ): ActorIdentityInput | undefined {
-  const contextUserId = cleanActorUserId(requesterId);
-  const requesterUserId = cleanActorUserId(requester?.userId);
+  const contextUserId = normalizeActorUserId(requesterId);
+  const requesterUserId = normalizeActorUserId(requester?.userId);
   const userId = contextUserId ?? requesterUserId;
   const canUseRequesterIdentity =
     !contextUserId || !requesterUserId || contextUserId === requesterUserId;
@@ -85,7 +88,7 @@ export function slackActorIdentity(
   userId: string,
   profile: SlackActorProfile | null | undefined,
 ): ActorIdentityInput {
-  const actorUserId = cleanActorUserId(userId);
+  const actorUserId = normalizeActorUserId(userId);
   if (!actorUserId) {
     throw new Error("Slack actor identity requires a user id");
   }

--- a/packages/junior/src/chat/services/requester-identity.ts
+++ b/packages/junior/src/chat/services/requester-identity.ts
@@ -89,15 +89,17 @@ export function slackActorIdentity(
   if (!actorUserId) {
     throw new Error("Slack actor identity requires a user id");
   }
-  return (
-    normalizeActorIdentity(
-      {
-        email: profile?.email,
-        fullName: profile?.fullName,
-        userId: actorUserId,
-        userName: profile?.userName,
-      },
-      actorUserId,
-    ) ?? { userId: actorUserId }
+  const identity = normalizeActorIdentity(
+    {
+      email: profile?.email,
+      fullName: profile?.fullName,
+      userId: actorUserId,
+      userName: profile?.userName,
+    },
+    actorUserId,
   );
+  if (!identity?.userId) {
+    throw new Error("Slack actor identity requires a user id");
+  }
+  return identity;
 }

--- a/packages/junior/src/chat/services/requester-identity.ts
+++ b/packages/junior/src/chat/services/requester-identity.ts
@@ -19,6 +19,13 @@ function clean(value: string | undefined): string | undefined {
   return normalized ? normalized : undefined;
 }
 
+function cleanActorUserId(value: string | undefined): string | undefined {
+  const normalized = clean(value);
+  return normalized && normalized.toLowerCase() !== "unknown"
+    ? normalized
+    : undefined;
+}
+
 function isSlackUserId(value: string): boolean {
   return SLACK_USER_ID_PATTERN.test(value);
 }
@@ -29,6 +36,9 @@ function cleanActorDisplayName(
 ): string | undefined {
   const normalized = clean(value);
   if (!normalized) {
+    return undefined;
+  }
+  if (normalized.toLowerCase() === "unknown") {
     return undefined;
   }
   if (userId && normalized === userId) {
@@ -47,8 +57,8 @@ export function normalizeActorIdentity(
   requester: ActorIdentityInput | undefined,
   requesterId?: string,
 ): ActorIdentityInput | undefined {
-  const contextUserId = clean(requesterId);
-  const requesterUserId = clean(requester?.userId);
+  const contextUserId = cleanActorUserId(requesterId);
+  const requesterUserId = cleanActorUserId(requester?.userId);
   const userId = contextUserId ?? requesterUserId;
   const canUseRequesterIdentity =
     !contextUserId || !requesterUserId || contextUserId === requesterUserId;
@@ -75,7 +85,7 @@ export function slackActorIdentity(
   userId: string,
   profile: SlackActorProfile | null | undefined,
 ): ActorIdentityInput {
-  const actorUserId = clean(userId);
+  const actorUserId = cleanActorUserId(userId);
   if (!actorUserId) {
     throw new Error("Slack actor identity requires a user id");
   }

--- a/packages/junior/src/chat/slack/outbound.ts
+++ b/packages/junior/src/chat/slack/outbound.ts
@@ -6,7 +6,7 @@ import {
   withSlackRetries,
 } from "@/chat/slack/client";
 import { normalizeSlackEmojiName } from "@/chat/slack/emoji";
-import { normalizeActorUserId } from "@/chat/services/requester-identity";
+import { parseActorUserId } from "@/chat/services/requester-identity";
 
 const MAX_SLACK_MESSAGE_TEXT_CHARS = 40_000;
 
@@ -161,7 +161,7 @@ export async function postSlackEphemeralMessage(input: {
     input.channelId,
     "Slack ephemeral message posting",
   );
-  const userId = normalizeActorUserId(input.userId);
+  const userId = parseActorUserId(input.userId);
   if (!userId) {
     throw new Error("Slack ephemeral message posting requires a user ID");
   }

--- a/packages/junior/src/chat/slack/outbound.ts
+++ b/packages/junior/src/chat/slack/outbound.ts
@@ -6,6 +6,7 @@ import {
   withSlackRetries,
 } from "@/chat/slack/client";
 import { normalizeSlackEmojiName } from "@/chat/slack/emoji";
+import { normalizeActorUserId } from "@/chat/services/requester-identity";
 
 const MAX_SLACK_MESSAGE_TEXT_CHARS = 40_000;
 
@@ -160,7 +161,7 @@ export async function postSlackEphemeralMessage(input: {
     input.channelId,
     "Slack ephemeral message posting",
   );
-  const userId = input.userId.trim();
+  const userId = normalizeActorUserId(input.userId);
   if (!userId) {
     throw new Error("Slack ephemeral message posting requires a user ID");
   }

--- a/packages/junior/src/chat/slack/user.ts
+++ b/packages/junior/src/chat/slack/user.ts
@@ -1,5 +1,9 @@
 import { getSlackBotToken } from "@/chat/config";
 import { logWarn } from "@/chat/logging";
+import {
+  slackActorIdentity,
+  type ActorIdentityInput,
+} from "@/chat/services/requester-identity";
 
 interface SlackUserLookupResult {
   userName?: string;
@@ -115,4 +119,11 @@ export async function lookupSlackUser(
     );
     return null;
   }
+}
+
+/** Resolve the canonical Slack actor identity from Slack profile data. */
+export async function lookupSlackActorIdentity(
+  userId: string,
+): Promise<ActorIdentityInput> {
+  return slackActorIdentity(userId, await lookupSlackUser(userId));
 }

--- a/packages/junior/src/chat/task-execution/slack-work.ts
+++ b/packages/junior/src/chat/task-execution/slack-work.ts
@@ -42,7 +42,7 @@ import {
 import { ensureSlackMessageActorIdentity } from "@/chat/services/message-actor-identity";
 import { lookupSlackUser } from "@/chat/slack/user";
 import {
-  normalizeActorUserId,
+  parseActorUserId,
   type SlackActorProfile,
 } from "@/chat/services/requester-identity";
 
@@ -71,7 +71,7 @@ export interface CreateSlackConversationWorkerOptions {
 }
 
 function requireSlackAuthorId(message: Message): string {
-  const authorId = normalizeActorUserId(message.author.userId);
+  const authorId = parseActorUserId(message.author.userId);
   if (!authorId) {
     throw new Error("Slack message requires an actor user id");
   }

--- a/packages/junior/src/chat/task-execution/slack-work.ts
+++ b/packages/junior/src/chat/task-execution/slack-work.ts
@@ -41,7 +41,10 @@ import {
 } from "@/chat/slack/adapter-context";
 import { ensureSlackMessageActorIdentity } from "@/chat/services/message-actor-identity";
 import { lookupSlackUser } from "@/chat/slack/user";
-import type { SlackActorProfile } from "@/chat/services/requester-identity";
+import {
+  normalizeActorUserId,
+  type SlackActorProfile,
+} from "@/chat/services/requester-identity";
 
 export type SlackConversationRoute = "mention" | "subscribed";
 
@@ -68,8 +71,8 @@ export interface CreateSlackConversationWorkerOptions {
 }
 
 function requireSlackAuthorId(message: Message): string {
-  const authorId = message.author.userId?.trim();
-  if (!authorId || authorId.toLowerCase() === "unknown") {
+  const authorId = normalizeActorUserId(message.author.userId);
+  if (!authorId) {
     throw new Error("Slack message requires an actor user id");
   }
   return authorId;

--- a/packages/junior/src/chat/task-execution/slack-work.ts
+++ b/packages/junior/src/chat/task-execution/slack-work.ts
@@ -39,6 +39,9 @@ import {
   runWithSlackInstallation,
   type SlackInstallationContext,
 } from "@/chat/slack/adapter-context";
+import { ensureSlackMessageActorIdentity } from "@/chat/services/message-actor-identity";
+import { lookupSlackUser } from "@/chat/slack/user";
+import type { SlackActorProfile } from "@/chat/services/requester-identity";
 
 export type SlackConversationRoute = "mention" | "subscribed";
 
@@ -53,12 +56,23 @@ export interface SlackConversationMessageMetadata {
 
 export interface CreateSlackConversationWorkerOptions {
   getSlackAdapter: () => SlackAdapter;
+  lookupSlackUser?: (
+    userId: string,
+  ) => Promise<SlackActorProfile | null | undefined>;
   resumeAwaitingContinuation?: (conversationId: string) => Promise<boolean>;
   runtime: Pick<
     SlackTurnRuntime<unknown>,
     "handleNewMention" | "handleSubscribedMessage"
   >;
   state?: StateAdapter;
+}
+
+function requireSlackAuthorId(message: Message): string {
+  const authorId = message.author.userId?.trim();
+  if (!authorId || authorId.toLowerCase() === "unknown") {
+    throw new Error("Slack message requires an actor user id");
+  }
+  return authorId;
 }
 
 function getConnectedState(stateAdapter?: StateAdapter): StateAdapter {
@@ -111,6 +125,30 @@ function restoreMessage(args: {
   );
   rehydrateAttachmentFetchers(message);
   return message;
+}
+
+async function bindSlackActorIdentities(args: {
+  lookupSlackUser: (
+    userId: string,
+  ) => Promise<SlackActorProfile | null | undefined>;
+  messages: Message[];
+}): Promise<void> {
+  const byAuthorId = new Map<string, Message[]>();
+  for (const message of args.messages) {
+    const authorId = requireSlackAuthorId(message);
+    byAuthorId.set(authorId, [...(byAuthorId.get(authorId) ?? []), message]);
+  }
+
+  await Promise.all(
+    [...byAuthorId].map(async ([authorId, messages]) => {
+      const profile = await args.lookupSlackUser(authorId);
+      await Promise.all(
+        messages.map((message) =>
+          ensureSlackMessageActorIdentity(message, async () => profile),
+        ),
+      );
+    }),
+  );
 }
 
 function restoreThread(args: {
@@ -230,6 +268,7 @@ export function createSlackConversationWorker(
 ): (context: ConversationWorkerContext) => Promise<ConversationWorkerResult> {
   return async (context) => {
     const adapter = options.getSlackAdapter();
+    const actorLookup = options.lookupSlackUser ?? lookupSlackUser;
     const state = getConnectedState(options.state);
     await state.connect();
 
@@ -274,6 +313,10 @@ export function createSlackConversationWorker(
         const messages = records.map((record) =>
           restoreMessage({ adapter, record }),
         );
+        await bindSlackActorIdentities({
+          lookupSlackUser: actorLookup,
+          messages,
+        });
         const latestMessage = messages[messages.length - 1];
         if (!latestMessage) {
           return;
@@ -380,6 +423,7 @@ export function buildSlackInboundMessage(args: {
   route: SlackConversationRoute;
   thread: ThreadImpl;
 }): InboundMessageRecord {
+  const authorId = requireSlackAuthorId(args.message);
   return {
     conversationId: args.conversationId,
     inboundMessageId: [
@@ -393,7 +437,7 @@ export function buildSlackInboundMessage(args: {
     receivedAtMs: args.receivedAtMs,
     input: {
       text: args.message.text || " ",
-      authorId: args.message.author.userId,
+      authorId,
       attachments: args.message.attachments,
       metadata: {
         platform: "slack",

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -52,6 +52,7 @@ import { isRetryableTurnError, markTurnFailed } from "@/chat/runtime/turn";
 import { scheduleTurnTimeoutResume } from "@/chat/services/timeout-resume";
 import { htmlCallbackResponse } from "@/handlers/oauth-html";
 import type { WaitUntilFn } from "@/handlers/types";
+import { lookupSlackActorIdentity } from "@/chat/slack/user";
 
 const CALLBACK_PAGES = {
   missing_state: {
@@ -300,6 +301,7 @@ async function resumeAuthorizedMcpTurn(args: {
         }),
         ttlMs: THREAD_STATE_TTL_MS,
       });
+      const requester = await lookupSlackActorIdentity(authSession.userId);
 
       return {
         messageText: lockedUserMessage.text,
@@ -308,11 +310,7 @@ async function resumeAuthorizedMcpTurn(args: {
           credentialContext: {
             actor: { type: "user", userId: authSession.userId },
           },
-          requester: {
-            userId: authSession.userId,
-            userName: lockedUserMessage.author?.userName,
-            fullName: lockedUserMessage.author?.fullName,
-          },
+          requester,
           correlation: {
             conversationId: authSession.conversationId,
             turnId: lockedSessionId,

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -41,6 +41,7 @@ import {
 import { isRetryableTurnError, markTurnFailed } from "@/chat/runtime/turn";
 import { publishAppHomeView } from "@/chat/slack/app-home";
 import { getSlackClient } from "@/chat/slack/client";
+import { lookupSlackActorIdentity } from "@/chat/slack/user";
 import { getStateAdapter } from "@/chat/state/adapter";
 import { coerceThreadArtifactsState } from "@/chat/state/artifacts";
 import {
@@ -323,6 +324,9 @@ async function resumeOAuthSessionRecordTurn(
         }),
         ttlMs: THREAD_STATE_TTL_MS,
       });
+      const requester = await lookupSlackActorIdentity(
+        lockedUserMessage.author.userId,
+      );
 
       return {
         messageText: stored.pendingMessage ?? lockedUserMessage.text,
@@ -334,11 +338,7 @@ async function resumeOAuthSessionRecordTurn(
               userId: lockedUserMessage.author.userId,
             },
           },
-          requester: {
-            userId: lockedUserMessage.author.userId,
-            userName: lockedUserMessage.author.userName,
-            fullName: lockedUserMessage.author.fullName,
-          },
+          requester,
           correlation: {
             conversationId: stored.resumeConversationId!,
             turnId: lockedSessionId,
@@ -443,6 +443,7 @@ async function resumePendingOAuthMessage(
   const conversationContext = buildConversationContext(conversation, {
     excludeMessageId: latestUserMessage?.id,
   });
+  const requester = await lookupSlackActorIdentity(stored.userId);
   await resumeAuthorizedRequest({
     messageText: stored.pendingMessage,
     channelId: stored.channelId,
@@ -453,7 +454,7 @@ async function resumePendingOAuthMessage(
       credentialContext: {
         actor: { type: "user", userId: stored.userId },
       },
-      requester: { userId: stored.userId },
+      requester,
       conversationContext,
       piMessages: conversation.piMessages,
       configuration: stored.configuration,

--- a/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
@@ -13,6 +13,7 @@ import {
 import { processConversationWork } from "@/chat/task-execution/worker";
 import { processConversationQueueMessage } from "@/chat/task-execution/vercel-callback";
 import { createSlackConversationWorker } from "@/chat/task-execution/slack-work";
+import { getMessageActorIdentity } from "@/chat/services/message-actor-identity";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import {
   getAgentTurnSessionRecord,
@@ -35,6 +36,7 @@ type SlackWorkerOptions = Parameters<typeof createSlackConversationWorker>[0];
 
 interface ProcessQueuedSlackWorkArgs {
   getSlackAdapter: SlackWorkerOptions["getSlackAdapter"];
+  lookupSlackUser?: SlackWorkerOptions["lookupSlackUser"];
   nowMs?: () => number;
   queue: ConversationWorkQueueTestAdapter;
   resumeAwaitingContinuation?: SlackWorkerOptions["resumeAwaitingContinuation"];
@@ -48,6 +50,7 @@ function processNextQueuedSlackWork(args: ProcessQueuedSlackWorkArgs) {
     queue: args.queue,
     run: createSlackConversationWorker({
       getSlackAdapter: args.getSlackAdapter,
+      lookupSlackUser: args.lookupSlackUser,
       resumeAwaitingContinuation: args.resumeAwaitingContinuation,
       runtime: args.runtime,
       state: args.state,
@@ -123,6 +126,40 @@ describe("Slack conversation work execution", () => {
         }),
       }),
     ]);
+  });
+
+  it("does not persist Slack mailbox messages without actor ids", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    const state = getStateAdapter();
+    await state.connect();
+    const slackAdapter = createSlackAdapterFixture();
+
+    const response = await handleSlackWebhookAndFlush({
+      request: slackWebhookRequest({
+        team_id: "T123",
+        type: "event_callback",
+        event: {
+          type: "app_mention",
+          text: `<@${SLACK_BOT_USER_ID}> missing actor`,
+          channel: "C123",
+          ts: "1712345.0099",
+          event_ts: "1712345.0099",
+          channel_type: "channel",
+        },
+      }),
+      services: {
+        getSlackAdapter: () => slackAdapter,
+        queue,
+        runtime: createNoopSlackWebhookRuntime(),
+        state,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(queue.sentRecords()).toEqual([]);
+    await expect(
+      getConversationWorkState({ conversationId: CONVERSATION_ID, state }),
+    ).resolves.toBeUndefined();
   });
 
   it("routes edited Slack mentions through the durable mailbox", async () => {
@@ -280,6 +317,65 @@ describe("Slack conversation work execution", () => {
       queue,
       runtime,
       state,
+    });
+  });
+
+  it("binds resolved Slack actor identity before runtime handling", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    const state = getStateAdapter();
+    await state.connect();
+    const slackAdapter = createSlackAdapterFixture();
+    let capturedMessage: Message | undefined;
+
+    await handleSlackWebhookAndFlush({
+      request: slackWebhookRequest(
+        slackEnvelope({
+          text: `<@${SLACK_BOT_USER_ID}> identify me`,
+          ts: "1712345.0003",
+        }),
+      ),
+      services: {
+        getSlackAdapter: () => slackAdapter,
+        queue,
+        runtime: createNoopSlackWebhookRuntime(),
+        state,
+      },
+    });
+
+    const runtime: SlackWorkerOptions["runtime"] = {
+      handleNewMention: async (_thread, message, hooks) => {
+        capturedMessage = message;
+        await hooks?.onInputCommitted?.();
+      },
+      handleSubscribedMessage: async () => {
+        throw new Error("unexpected subscribed route");
+      },
+    };
+
+    await expect(
+      processNextQueuedSlackWork({
+        getSlackAdapter: () => slackAdapter,
+        lookupSlackUser: async () => ({
+          email: "david@example.com",
+          fullName: "David Cramer",
+          userName: "dcramer",
+        }),
+        queue,
+        runtime,
+        state,
+      }),
+    ).resolves.toEqual({ status: "completed" });
+
+    expect(capturedMessage?.author).toMatchObject({
+      userId: "U123",
+      userName: "dcramer",
+      fullName: "David Cramer",
+    });
+    expect(getMessageActorIdentity(capturedMessage!)).toEqual({
+      email: "david@example.com",
+      fullName: "David Cramer",
+      userId: "U123",
+      userName: "dcramer",
     });
   });
 

--- a/packages/junior/tests/integration/heartbeat.test.ts
+++ b/packages/junior/tests/integration/heartbeat.test.ts
@@ -704,7 +704,15 @@ describe("trusted plugin heartbeat", () => {
     global.fetch = fetchMock as typeof fetch;
     setAgentPlugins([schedulerPlugin()]);
     const store = schedulerStore();
-    await store.saveTask(createTask());
+    await store.saveTask(
+      createTask({
+        createdBy: {
+          slackUserId: "U039RR91S",
+          userName: "U039RR91S",
+          fullName: "W039RR91S",
+        },
+      }),
+    );
 
     const firstWaitUntil = createWaitUntilCollector();
     const firstResponse = await heartbeat(
@@ -722,6 +730,12 @@ describe("trusted plugin heartbeat", () => {
       dispatchId: expect.any(String),
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    const dispatchRecord = await getDispatchRecord(running!.dispatchId!);
+    expect(dispatchRecord?.input).toContain(
+      "- creator_slack_user_id: U039RR91S",
+    );
+    expect(dispatchRecord?.input).not.toContain("creator_user_name");
+    expect(dispatchRecord?.input).not.toContain("creator_full_name");
 
     await withDispatchLock(running!.dispatchId!, async (state) => {
       const record = await state.get<DispatchRecord>(
@@ -776,7 +790,8 @@ describe("trusted plugin heartbeat", () => {
       createTask({
         createdBy: {
           slackUserId: "U456",
-          userName: "bob",
+          fullName: "W039RR91S",
+          userName: "U456",
         },
         id: "sched_plugin_blocked",
         status: "blocked",
@@ -824,7 +839,7 @@ describe("trusted plugin heartbeat", () => {
     expect(
       scheduler?.recordSets?.[1]?.records?.[0]?.values ?? {},
     ).toMatchObject({
-      author: "@bob",
+      author: "Slack User U456",
     });
     expect(JSON.stringify(feed)).not.toContain("Secret");
   });

--- a/packages/junior/tests/integration/heartbeat.test.ts
+++ b/packages/junior/tests/integration/heartbeat.test.ts
@@ -802,6 +802,19 @@ describe("trusted plugin heartbeat", () => {
         updatedAtMs: TEST_NOW_MS,
       }),
     );
+    await store.saveTask(
+      createTask({
+        createdBy: {
+          slackUserId: "unknown",
+        },
+        id: "sched_plugin_corrupt_creator",
+        status: "blocked",
+        task: {
+          text: "Corrupt creator metadata task",
+        },
+        updatedAtMs: TEST_NOW_MS + 1,
+      }),
+    );
 
     const { createJuniorReporting } = await import("@/reporting");
     const feed = await createJuniorReporting().getPluginOperationalReports();
@@ -817,7 +830,7 @@ describe("trusted plugin heartbeat", () => {
     expect(scheduler?.metrics).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ label: "active", value: "1" }),
-        expect.objectContaining({ label: "blocked", value: "1" }),
+        expect.objectContaining({ label: "blocked", value: "2" }),
         expect.objectContaining({ label: "due now", value: "1" }),
       ]),
     );
@@ -836,10 +849,19 @@ describe("trusted plugin heartbeat", () => {
     ).toMatchObject({
       author: "Alice Reviewer (@alice)",
     });
+    const blockedRecords = scheduler?.recordSets?.[1]?.records ?? [];
     expect(
-      scheduler?.recordSets?.[1]?.records?.[0]?.values ?? {},
+      blockedRecords.find((record) => record.id === "sched_plugin_blocked")
+        ?.values ?? {},
     ).toMatchObject({
       author: "Slack User U456",
+    });
+    expect(
+      blockedRecords.find(
+        (record) => record.id === "sched_plugin_corrupt_creator",
+      )?.values ?? {},
+    ).toMatchObject({
+      author: "Invalid Slack creator metadata",
     });
     expect(JSON.stringify(feed)).not.toContain("Secret");
   });

--- a/packages/junior/tests/integration/slack-schedule-tools.test.ts
+++ b/packages/junior/tests/integration/slack-schedule-tools.test.ts
@@ -171,6 +171,26 @@ describe("Slack schedule tools", () => {
     ]);
   });
 
+  it("does not store Slack ids as creator display identity", async () => {
+    const created = (await createTask(
+      createContext({
+        requester: {
+          userId: "U039RR91S",
+          userName: "U039RR91S",
+          fullName: "W039RR91S",
+        },
+      }),
+    )) as { task: { id: string } };
+
+    await expect(schedulerStore().getTask(created.task.id)).resolves.toEqual(
+      expect.objectContaining({
+        createdBy: {
+          slackUserId: "U039RR91S",
+        },
+      }),
+    );
+  });
+
   it("rejects invalid Slack workspace context before creating a task", async () => {
     const rejected = executeTool(
       createSlackScheduleCreateTaskTool(createContext({ teamId: "D123" })),

--- a/packages/junior/tests/integration/slack-schedule-tools.test.ts
+++ b/packages/junior/tests/integration/slack-schedule-tools.test.ts
@@ -176,7 +176,7 @@ describe("Slack schedule tools", () => {
       createContext({
         requester: {
           userId: "U039RR91S",
-          userName: "U039RR91S",
+          userName: "unknown",
           fullName: "W039RR91S",
         },
       }),
@@ -189,6 +189,26 @@ describe("Slack schedule tools", () => {
         },
       }),
     );
+  });
+
+  it("rejects synthetic unknown requester ids before creating a task", async () => {
+    const rejected = createTask(
+      createContext({
+        requester: {
+          userId: "unknown",
+          userName: "unknown",
+          fullName: "unknown",
+        },
+      }),
+    );
+
+    await expect(rejected).rejects.toThrow(AgentPluginToolInputError);
+    await expect(rejected).rejects.toThrow(
+      "No active Slack requester context is available.",
+    );
+    await expect(
+      schedulerStore().listTasksForTeam(TEST_TEAM_ID),
+    ).resolves.toEqual([]);
   });
 
   it("rejects invalid Slack workspace context before creating a task", async () => {

--- a/packages/junior/tests/integration/slack/app-home-webhook.test.ts
+++ b/packages/junior/tests/integration/slack/app-home-webhook.test.ts
@@ -241,4 +241,44 @@ describe("Slack webhook: App Home events", () => {
     expect(workspaceTeamIds).toEqual(["T123"]);
     expect(slackApiOutbox.homeViews()).toHaveLength(1);
   });
+
+  it("does not unlink App Home credentials for synthetic unknown users", async () => {
+    const state = createMemoryState();
+    const client = createSlackWebhookTestClient({
+      signingSecret: SIGNING_SECRET,
+    });
+    const waitUntil = client.waitUntil();
+    const queue = createConversationWorkQueueTestAdapter();
+    const deleteToken = vi.fn(async () => {});
+    const userTokenStore = createTokenStore({ delete: deleteToken });
+    const slackAdapter = createSlackAdapter();
+    const params = new URLSearchParams({
+      payload: JSON.stringify({
+        ...interactiveDisconnectPayload(),
+        user: {
+          id: "unknown",
+          team_id: "T123",
+        },
+      }),
+    });
+
+    const response = await handleSlackWebhook({
+      request: client.form(params),
+      waitUntil: waitUntil.fn,
+      services: {
+        getSlackAdapter: () => slackAdapter,
+        queue,
+        runtime: createNoopSlackWebhookRuntime(),
+        state,
+        getUserTokenStore: () => userTokenStore,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(queue.sentRecords()).toEqual([]);
+    expect(waitUntil.pendingCount()).toBe(1);
+    await waitUntil.flush();
+    expect(deleteToken).not.toHaveBeenCalled();
+    expect(slackApiOutbox.homeViews()).toHaveLength(0);
+  });
 });

--- a/packages/junior/tests/integration/slack/message-changed-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/message-changed-behavior.test.ts
@@ -253,7 +253,18 @@ describe("Slack behavior: message_changed webhook ingress", () => {
       getSlackAdapter: () => bot.getAdapter("slack"),
       services: {
         replyExecutor: {
+          lookupSlackUser: async () => ({
+            email: "david@example.com",
+            fullName: "David Cramer",
+            userName: "dcramer",
+          }),
           generateAssistantReply: async (_prompt, context) => {
+            expect(context?.requester).toEqual({
+              email: "david@example.com",
+              fullName: "David Cramer",
+              userId: "U123",
+              userName: "dcramer",
+            });
             await context?.onTextDelta?.("Hello world");
             return {
               text: "Hello world",

--- a/packages/junior/tests/integration/slack/outbound-normalization-contract.test.ts
+++ b/packages/junior/tests/integration/slack/outbound-normalization-contract.test.ts
@@ -7,6 +7,7 @@ import {
 import { setAgentPlugins } from "@/chat/plugins/agent-hooks";
 import {
   addReactionToMessage,
+  postSlackEphemeralMessage,
   postSlackMessage,
   uploadFilesToThread,
 } from "@/chat/slack/outbound";
@@ -184,5 +185,17 @@ describe("Slack contract: outbound normalization", () => {
         }),
       }),
     ]);
+  });
+
+  it("rejects synthetic unknown users before chat.postEphemeral", async () => {
+    await expect(
+      postSlackEphemeralMessage({
+        channelId: "slack:C123",
+        userId: "unknown",
+        text: "hello",
+      }),
+    ).rejects.toThrow("Slack ephemeral message posting requires a user ID");
+
+    expect(getCapturedSlackApiCalls("chat.postEphemeral")).toEqual([]);
   });
 });

--- a/packages/junior/tests/integration/turn-resume-slack.test.ts
+++ b/packages/junior/tests/integration/turn-resume-slack.test.ts
@@ -179,8 +179,10 @@ describe("turn resume slack integration", () => {
       "resume this request",
       expect.objectContaining({
         requester: expect.objectContaining({
+          email: "testuser@example.com",
+          fullName: "Test User",
           userId: "U123",
-          userName: "alice",
+          userName: "testuser",
         }),
         toolChannelId: "C999",
         inboundAttachmentCount: 2,

--- a/packages/junior/tests/unit/credentials/credential-context.test.ts
+++ b/packages/junior/tests/unit/credentials/credential-context.test.ts
@@ -70,6 +70,11 @@ describe("credential context", () => {
     expect(parseCredentialContext({})).toBeUndefined();
     expect(
       parseCredentialContext({
+        actor: { type: "system", id: "unknown" },
+      }),
+    ).toBeUndefined();
+    expect(
+      parseCredentialContext({
         actor: { type: "system", id: "" },
       }),
     ).toBeUndefined();
@@ -80,8 +85,22 @@ describe("credential context", () => {
     ).toBeUndefined();
     expect(
       parseCredentialContext({
+        actor: { type: "user", userId: "unknown" },
+      }),
+    ).toBeUndefined();
+    expect(
+      parseCredentialContext({
         actor: { type: "system", id: "scheduler" },
         subject: { type: "user", userId: "U123" },
+      }),
+    ).toBeUndefined();
+    expect(
+      parseCredentialContext({
+        actor: { type: "system", id: "scheduler" },
+        subject: {
+          ...delegatedSubject,
+          userId: "unknown",
+        },
       }),
     ).toBeUndefined();
   });

--- a/packages/junior/tests/unit/credentials/credential-context.test.ts
+++ b/packages/junior/tests/unit/credentials/credential-context.test.ts
@@ -80,12 +80,22 @@ describe("credential context", () => {
     ).toBeUndefined();
     expect(
       parseCredentialContext({
+        actor: { type: "system", id: " scheduler " },
+      }),
+    ).toBeUndefined();
+    expect(
+      parseCredentialContext({
         actor: { type: "user", userId: "" },
       }),
     ).toBeUndefined();
     expect(
       parseCredentialContext({
         actor: { type: "user", userId: "unknown" },
+      }),
+    ).toBeUndefined();
+    expect(
+      parseCredentialContext({
+        actor: { type: "user", userId: " U123 " },
       }),
     ).toBeUndefined();
     expect(

--- a/packages/junior/tests/unit/ingress/slash-command.test.ts
+++ b/packages/junior/tests/unit/ingress/slash-command.test.ts
@@ -8,7 +8,10 @@ async function loadHandler() {
   return import("@/chat/ingress/slash-command");
 }
 
-function createSlashEvent(text: string) {
+function createSlashEvent(
+  text: string,
+  userOverrides: Partial<SlashCommandEvent["user"]> = {},
+) {
   const postEphemeral = vi.fn(async () => {});
   const user = {
     userId: "U123",
@@ -16,6 +19,7 @@ function createSlashEvent(text: string) {
     fullName: "User",
     isBot: false,
     isMe: false,
+    ...userOverrides,
   };
   const event = {
     text,
@@ -58,6 +62,15 @@ describe("slash command ingress", () => {
       user,
       "Usage: `/team link <provider>`",
       { fallbackToDM: false },
+    );
+  });
+
+  it("requires a Slack requester id before credential commands", async () => {
+    const { handleSlashCommand } = await loadHandler();
+    const { event } = createSlashEvent("link github", { userId: "" });
+
+    await expect(handleSlashCommand(event)).rejects.toThrow(
+      "Slack slash command requires a requester user id",
     );
   });
 });

--- a/packages/junior/tests/unit/ingress/slash-command.test.ts
+++ b/packages/junior/tests/unit/ingress/slash-command.test.ts
@@ -73,4 +73,13 @@ describe("slash command ingress", () => {
       "Slack slash command requires a requester user id",
     );
   });
+
+  it("rejects synthetic unknown requester ids before credential commands", async () => {
+    const { handleSlashCommand } = await loadHandler();
+    const { event } = createSlashEvent("link github", { userId: "unknown" });
+
+    await expect(handleSlashCommand(event)).rejects.toThrow(
+      "Slack slash command requires a requester user id",
+    );
+  });
 });

--- a/packages/junior/tests/unit/plugins/github-plugin.test.ts
+++ b/packages/junior/tests/unit/plugins/github-plugin.test.ts
@@ -1,8 +1,58 @@
 import type { SandboxPrepareHookContext } from "@sentry/junior-plugin-api";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { githubPlugin } from "../../../../junior-github/index.js";
 
+const ORIGINAL_ENV = { ...process.env };
+
+function beforeToolContext(requester: {
+  email?: string;
+  fullName?: string;
+  userId?: string;
+  userName?: string;
+}) {
+  const env: Record<string, string> = {};
+  let denial: string | undefined;
+
+  return {
+    ctx: {
+      decision: {
+        deny(message: string) {
+          denial = message;
+        },
+        replaceInput() {},
+      },
+      env: {
+        get(key: string) {
+          return env[key];
+        },
+        set(key: string, value: string) {
+          env[key] = value;
+        },
+      },
+      log: {
+        error() {},
+        info() {},
+        warn() {},
+      },
+      plugin: { name: "github" },
+      requester,
+      tool: {
+        input: { command: "git commit -m test" },
+        name: "bash",
+      },
+    },
+    env,
+    get denial() {
+      return denial;
+    },
+  };
+}
+
 describe("github plugin", () => {
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
   it("serializes global git config writes during sandbox preparation", async () => {
     const started: string[] = [];
     const writes: Array<{ content: string | Uint8Array; path: string }> = [];
@@ -54,5 +104,47 @@ describe("github plugin", () => {
       "http.emptyAuth",
     ]);
     expect(maxRunning).toBe(1);
+  });
+
+  it("injects commit coauthor env only for resolved requester identity", () => {
+    process.env.GITHUB_APP_BOT_NAME = "sentry-junior[bot]";
+    process.env.GITHUB_APP_BOT_EMAIL = "bot@example.com";
+
+    const plugin = githubPlugin();
+    const before = beforeToolContext({
+      email: "david@example.com",
+      fullName: "David Cramer",
+      userId: "U039RR91S",
+      userName: "dcramer",
+    });
+
+    plugin.hooks?.beforeToolExecute?.(before.ctx as never);
+
+    expect(before.denial).toBeUndefined();
+    expect(before.env).toMatchObject({
+      GIT_AUTHOR_NAME: "sentry-junior[bot]",
+      GIT_AUTHOR_EMAIL: "bot@example.com",
+      JUNIOR_GIT_AUTHOR_NAME: "sentry-junior[bot]",
+      JUNIOR_GIT_AUTHOR_EMAIL: "bot@example.com",
+      JUNIOR_GIT_COAUTHOR_NAME: "David Cramer",
+      JUNIOR_GIT_COAUTHOR_EMAIL: "david@example.com",
+    });
+  });
+
+  it("denies git commits when requester identity is an unresolved Slack id", () => {
+    process.env.GITHUB_APP_BOT_NAME = "sentry-junior[bot]";
+    process.env.GITHUB_APP_BOT_EMAIL = "bot@example.com";
+
+    const plugin = githubPlugin();
+    const before = beforeToolContext({
+      fullName: "U039RR91S",
+      userId: "U039RR91S",
+      userName: "U039RR91S",
+    });
+
+    plugin.hooks?.beforeToolExecute?.(before.ctx as never);
+
+    expect(before.denial).toContain("resolved requester name and email");
+    expect(before.env).toEqual({});
   });
 });

--- a/packages/junior/tests/unit/plugins/github-plugin.test.ts
+++ b/packages/junior/tests/unit/plugins/github-plugin.test.ts
@@ -147,4 +147,22 @@ describe("github plugin", () => {
     expect(before.denial).toContain("resolved requester name and email");
     expect(before.env).toEqual({});
   });
+
+  it("denies git commits when requester display identity is synthetic unknown", () => {
+    process.env.GITHUB_APP_BOT_NAME = "sentry-junior[bot]";
+    process.env.GITHUB_APP_BOT_EMAIL = "bot@example.com";
+
+    const plugin = githubPlugin();
+    const before = beforeToolContext({
+      email: "david@example.com",
+      fullName: "unknown",
+      userId: "U039RR91S",
+      userName: "unknown",
+    });
+
+    plugin.hooks?.beforeToolExecute?.(before.ctx as never);
+
+    expect(before.denial).toContain("resolved requester name and email");
+    expect(before.env).toEqual({});
+  });
 });

--- a/packages/junior/tests/unit/runtime/agent-dispatch-validation.test.ts
+++ b/packages/junior/tests/unit/runtime/agent-dispatch-validation.test.ts
@@ -107,6 +107,58 @@ describe("agent dispatch validation", () => {
     ).not.toThrow();
   });
 
+  it("rejects delegated credential subjects without real actor ids", async () => {
+    expect(
+      createSlackDirectCredentialSubject({
+        channelId: "D123",
+        teamId: "T123",
+        userId: "unknown",
+      }),
+    ).toBeUndefined();
+    process.env.JUNIOR_SECRET = "dispatch-validation-secret";
+
+    const unboundSubject = {
+      type: "user" as const,
+      userId: "unknown",
+      allowedWhen: "private-direct-conversation" as const,
+    };
+
+    expect(
+      bindSlackDirectCredentialSubject({
+        channelId: "D123",
+        teamId: "T123",
+        subject: unboundSubject,
+      }),
+    ).toBeUndefined();
+
+    expect(() =>
+      validateDispatchOptions({
+        ...validOptions,
+        destination: {
+          ...validOptions.destination,
+          channelId: "D123",
+        },
+        credentialSubject: unboundSubject,
+      }),
+    ).toThrow("Dispatch credentialSubject userId is required");
+
+    await expect(
+      verifyDispatchCredentialSubjectAccess({
+        ...validOptions,
+        destination: {
+          ...validOptions.destination,
+          channelId: "D123",
+        },
+        credentialSubject: {
+          ...createBoundCredentialSubject(),
+          userId: "unknown",
+        },
+      }),
+    ).rejects.toThrow(
+      "Dispatch credentialSubject must match the private direct Slack destination",
+    );
+  });
+
   it("verifies delegated credential subject bindings locally", async () => {
     await expect(
       verifyDispatchCredentialSubjectAccess({

--- a/packages/junior/tests/unit/runtime/conversation-message.test.ts
+++ b/packages/junior/tests/unit/runtime/conversation-message.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { Message } from "chat";
+import { bindMessageActorIdentity } from "@/chat/services/message-actor-identity";
+import { toConversationMessage } from "@/chat/runtime/conversation-message";
+
+function createMessage(authorUserId = "U039RR91S") {
+  return new Message({
+    id: "1712345.0001",
+    threadId: "slack:C123:1712345.0001",
+    text: "hello",
+    formatted: { type: "root", children: [] },
+    raw: {},
+    author: {
+      userId: authorUserId,
+      userName: authorUserId,
+      fullName: authorUserId,
+      isBot: false,
+      isMe: false,
+    },
+    metadata: {
+      dateSent: new Date("2026-06-05T00:00:00.000Z"),
+      edited: false,
+    },
+    attachments: [],
+  });
+}
+
+describe("conversation message actor identity", () => {
+  it("persists the bound actor identity instead of adapter display fallbacks", () => {
+    const message = createMessage();
+    bindMessageActorIdentity(message, {
+      email: "david@example.com",
+      fullName: "David Cramer",
+      userId: "U039RR91S",
+      userName: "dcramer",
+    });
+
+    expect(
+      toConversationMessage({
+        entry: message,
+        explicitMention: true,
+        text: message.text,
+      }).author,
+    ).toEqual({
+      fullName: "David Cramer",
+      isBot: false,
+      userId: "U039RR91S",
+      userName: "dcramer",
+    });
+  });
+
+  it("drops raw Slack ids from conversation author display fields", () => {
+    expect(
+      toConversationMessage({
+        entry: createMessage(),
+        explicitMention: true,
+        text: "hello",
+      }).author,
+    ).toEqual({
+      isBot: false,
+      userId: "U039RR91S",
+    });
+  });
+
+  it("binds resolved identity when the adapter supplied unknown", () => {
+    const message = createMessage("unknown");
+    bindMessageActorIdentity(message, {
+      fullName: "David Cramer",
+      userId: "U039RR91S",
+      userName: "dcramer",
+    });
+
+    expect(
+      toConversationMessage({
+        entry: message,
+        explicitMention: true,
+        text: "hello",
+      }).author,
+    ).toEqual({
+      fullName: "David Cramer",
+      isBot: false,
+      userId: "U039RR91S",
+      userName: "dcramer",
+    });
+  });
+
+  it("rejects actor identity mismatches", () => {
+    expect(() =>
+      bindMessageActorIdentity(createMessage(), {
+        fullName: "Other Person",
+        userId: "U_OTHER",
+        userName: "other",
+      }),
+    ).toThrow("Message actor identity user id mismatch");
+  });
+});

--- a/packages/junior/tests/unit/runtime/conversation-message.test.ts
+++ b/packages/junior/tests/unit/runtime/conversation-message.test.ts
@@ -62,6 +62,23 @@ describe("conversation message actor identity", () => {
     });
   });
 
+  it("does not persist unbound adapter display fields as actor identity", () => {
+    const message = createMessage();
+    message.author.userName = "dcramer";
+    message.author.fullName = "David Cramer";
+
+    expect(
+      toConversationMessage({
+        entry: message,
+        explicitMention: true,
+        text: "hello",
+      }).author,
+    ).toEqual({
+      isBot: false,
+      userId: "U039RR91S",
+    });
+  });
+
   it("binds resolved identity when the adapter supplied unknown", () => {
     const message = createMessage("unknown");
     bindMessageActorIdentity(message, {

--- a/packages/junior/tests/unit/services/conversation-memory.test.ts
+++ b/packages/junior/tests/unit/services/conversation-memory.test.ts
@@ -137,4 +137,29 @@ describe("buildConversationContext", () => {
     expect(context).toContain("Earlier thread summary.");
     expect(context).not.toContain("<thread-transcript>");
   });
+
+  it("does not render raw Slack ids as author display names", () => {
+    const conversation = coerceThreadConversationState({});
+    conversation.messages = [
+      {
+        id: "msg-1",
+        role: "user",
+        text: "hello",
+        createdAtMs: 1000,
+        author: {
+          isBot: false,
+          userId: "U039RR91S",
+          userName: "U039RR91S",
+          fullName: "U039RR91S",
+        },
+      },
+    ];
+
+    const context = buildConversationContext(conversation);
+
+    expect(context).toContain('author="user"');
+    expect(context).toContain('actor_id="U039RR91S"');
+    expect(context).toContain("[user] user: hello");
+    expect(context).not.toContain("@U039RR91S");
+  });
 });

--- a/packages/junior/tests/unit/services/requester-identity.test.ts
+++ b/packages/junior/tests/unit/services/requester-identity.test.ts
@@ -18,6 +18,32 @@ describe("requester identity", () => {
     ).toEqual({ userId: "U039RR91S" });
   });
 
+  it("does not promote synthetic unknown display names", () => {
+    expect(
+      normalizeActorIdentity(
+        {
+          fullName: "unknown",
+          userId: "U039RR91S",
+          userName: "unknown",
+        },
+        "U039RR91S",
+      ),
+    ).toEqual({ userId: "U039RR91S" });
+  });
+
+  it("does not preserve synthetic unknown actor ids", () => {
+    expect(
+      normalizeActorIdentity(
+        {
+          fullName: "unknown",
+          userId: "unknown",
+          userName: "unknown",
+        },
+        "unknown",
+      ),
+    ).toBeUndefined();
+  });
+
   it("builds Slack actor identity from the resolved Slack profile", () => {
     expect(
       slackActorIdentity("U039RR91S", {

--- a/packages/junior/tests/unit/services/requester-identity.test.ts
+++ b/packages/junior/tests/unit/services/requester-identity.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeActorIdentity,
+  slackActorIdentity,
+} from "@/chat/services/requester-identity";
+
+describe("requester identity", () => {
+  it("does not promote Slack ids into actor display names", () => {
+    expect(
+      normalizeActorIdentity(
+        {
+          fullName: "U039RR91S",
+          userId: "U039RR91S",
+          userName: "U039RR91S",
+        },
+        "U039RR91S",
+      ),
+    ).toEqual({ userId: "U039RR91S" });
+  });
+
+  it("builds Slack actor identity from the resolved Slack profile", () => {
+    expect(
+      slackActorIdentity("U039RR91S", {
+        email: "david@example.com",
+        fullName: "David Cramer",
+        userName: "dcramer",
+      }),
+    ).toEqual({
+      email: "david@example.com",
+      fullName: "David Cramer",
+      userId: "U039RR91S",
+      userName: "dcramer",
+    });
+  });
+
+  it("drops profile fields when caller context points at a different user", () => {
+    expect(
+      normalizeActorIdentity(
+        {
+          email: "david@example.com",
+          fullName: "David Cramer",
+          userId: "U039RR91S",
+          userName: "dcramer",
+        },
+        "U_OTHER",
+      ),
+    ).toEqual({ userId: "U_OTHER" });
+  });
+
+  it("omits unresolved Slack profile fields instead of inventing identity", () => {
+    expect(slackActorIdentity("U039RR91S", null)).toEqual({
+      userId: "U039RR91S",
+    });
+    expect(
+      slackActorIdentity("U039RR91S", {
+        email: "noreply",
+      }),
+    ).toEqual({ userId: "U039RR91S" });
+  });
+
+  it("requires a Slack user id when building Slack actor identity", () => {
+    expect(() => slackActorIdentity("", null)).toThrow(
+      "Slack actor identity requires a user id",
+    );
+  });
+});

--- a/packages/junior/tests/unit/services/requester-identity.test.ts
+++ b/packages/junior/tests/unit/services/requester-identity.test.ts
@@ -1,15 +1,19 @@
 import { describe, expect, it } from "vitest";
 import {
-  normalizeActorUserId,
+  isActorUserId,
   normalizeActorIdentity,
+  parseActorUserId,
   slackActorIdentity,
 } from "@/chat/services/requester-identity";
 
 describe("requester identity", () => {
-  it("normalizes actor user ids without preserving synthetic unknown", () => {
-    expect(normalizeActorUserId(" U039RR91S ")).toBe("U039RR91S");
-    expect(normalizeActorUserId("unknown")).toBeUndefined();
-    expect(normalizeActorUserId("")).toBeUndefined();
+  it("parses exact actor user ids without accepting synthetic values", () => {
+    expect(parseActorUserId("U039RR91S")).toBe("U039RR91S");
+    expect(parseActorUserId(" U039RR91S ")).toBeUndefined();
+    expect(parseActorUserId("unknown")).toBeUndefined();
+    expect(parseActorUserId("")).toBeUndefined();
+    expect(isActorUserId("U039RR91S")).toBe(true);
+    expect(isActorUserId(" U039RR91S ")).toBe(false);
   });
 
   it("does not promote Slack ids into actor display names", () => {
@@ -42,9 +46,9 @@ describe("requester identity", () => {
     expect(
       normalizeActorIdentity(
         {
-          fullName: "unknown",
+          fullName: "David Cramer",
           userId: "unknown",
-          userName: "unknown",
+          userName: "dcramer",
         },
         "unknown",
       ),

--- a/packages/junior/tests/unit/services/requester-identity.test.ts
+++ b/packages/junior/tests/unit/services/requester-identity.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildActorIdentity,
   isActorUserId,
-  normalizeActorIdentity,
   parseActorUserId,
   slackActorIdentity,
 } from "@/chat/services/requester-identity";
@@ -18,7 +18,7 @@ describe("requester identity", () => {
 
   it("does not promote Slack ids into actor display names", () => {
     expect(
-      normalizeActorIdentity(
+      buildActorIdentity(
         {
           fullName: "U039RR91S",
           userId: "U039RR91S",
@@ -31,7 +31,7 @@ describe("requester identity", () => {
 
   it("does not promote synthetic unknown display names", () => {
     expect(
-      normalizeActorIdentity(
+      buildActorIdentity(
         {
           fullName: "unknown",
           userId: "U039RR91S",
@@ -44,7 +44,7 @@ describe("requester identity", () => {
 
   it("does not preserve synthetic unknown actor ids", () => {
     expect(
-      normalizeActorIdentity(
+      buildActorIdentity(
         {
           fullName: "David Cramer",
           userId: "unknown",
@@ -72,7 +72,7 @@ describe("requester identity", () => {
 
   it("drops profile fields when caller context points at a different user", () => {
     expect(
-      normalizeActorIdentity(
+      buildActorIdentity(
         {
           email: "david@example.com",
           fullName: "David Cramer",

--- a/packages/junior/tests/unit/services/requester-identity.test.ts
+++ b/packages/junior/tests/unit/services/requester-identity.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from "vitest";
 import {
+  normalizeActorUserId,
   normalizeActorIdentity,
   slackActorIdentity,
 } from "@/chat/services/requester-identity";
 
 describe("requester identity", () => {
+  it("normalizes actor user ids without preserving synthetic unknown", () => {
+    expect(normalizeActorUserId(" U039RR91S ")).toBe("U039RR91S");
+    expect(normalizeActorUserId("unknown")).toBeUndefined();
+    expect(normalizeActorUserId("")).toBeUndefined();
+  });
+
   it("does not promote Slack ids into actor display names", () => {
     expect(
       normalizeActorIdentity(

--- a/packages/junior/tests/unit/slack/message-changed-ingress.test.ts
+++ b/packages/junior/tests/unit/slack/message-changed-ingress.test.ts
@@ -123,6 +123,18 @@ describe("extractMessageChangedMention", () => {
     expect(result).toBeNull();
   });
 
+  it("returns null when the edited message has a synthetic unknown actor id", () => {
+    const body = makeEnvelope({
+      newText: `<@${BOT_USER_ID}> please help`,
+      prevText: "please help",
+      user: "unknown",
+    });
+
+    const result = extractMessageChangedMention(body, BOT_USER_ID, fakeAdapter);
+
+    expect(result).toBeNull();
+  });
+
   it("uses message ts as thread_ts fallback when thread_ts is absent", () => {
     const body = {
       type: "event_callback",

--- a/packages/junior/tests/unit/slack/message-changed-ingress.test.ts
+++ b/packages/junior/tests/unit/slack/message-changed-ingress.test.ts
@@ -68,13 +68,13 @@ describe("extractMessageChangedMention", () => {
 
     const result = extractMessageChangedMention(body, BOT_USER_ID, fakeAdapter);
 
-    expect(result?.message.toJSON()).toEqual({
+    const serialized = result?.message.toJSON();
+
+    expect(serialized).toMatchObject({
       _type: "chat:Message",
       attachments: [],
       author: {
         userId: "U_SENDER",
-        userName: "U_SENDER",
-        fullName: "U_SENDER",
         isBot: false,
         isMe: false,
       },
@@ -97,6 +97,8 @@ describe("extractMessageChangedMention", () => {
       text: `<@${BOT_USER_ID}> please help`,
       threadId: `slack:${CHANNEL_ID}:${THREAD_TS}`,
     });
+    expect(serialized?.author.userName).toBe("");
+    expect(serialized?.author.fullName).toBe("");
   });
 
   it("returns null when bot mention was already in the previous message", () => {
@@ -108,6 +110,19 @@ describe("extractMessageChangedMention", () => {
     const result = extractMessageChangedMention(body, BOT_USER_ID, fakeAdapter);
     expect(result).toBeNull();
   });
+
+  it("returns null when the edited message has no actor user id", () => {
+    const body = makeEnvelope({
+      newText: `<@${BOT_USER_ID}> please help`,
+      prevText: "please help",
+      user: "",
+    });
+
+    const result = extractMessageChangedMention(body, BOT_USER_ID, fakeAdapter);
+
+    expect(result).toBeNull();
+  });
+
   it("uses message ts as thread_ts fallback when thread_ts is absent", () => {
     const body = {
       type: "event_callback",

--- a/policies/context-bound-systems.md
+++ b/policies/context-bound-systems.md
@@ -1,0 +1,20 @@
+# Context-Bound Systems
+
+## Intent
+
+Runtime behavior should receive the authority, destination, and scope it needs as explicit context. Junior should not infer who is acting, where side effects belong, or which credentials apply from nearby metadata after work has crossed an async, durable, or platform boundary.
+
+## Policy
+
+- APIs that cross ingress, queue, callback, plugin, sandbox, scheduler, or durable-state boundaries must carry the identity context needed by the downstream behavior: current actor, destination, optional credential subject, and correlation ids.
+- Keep the current actor separate from author history, creator metadata, service-principal credentials, destination membership, requester-sensitive credential subjects, and display names.
+- Validate untrusted platform or plugin payloads at the boundary that receives them. After Junior signs, persists, or dispatches context it owns, downstream code must assert that context exactly rather than normalize or repair it on read.
+- Missing required context is an error, blocked state, or rejected input. Do not guess from prior messages, Slack channel membership, task creators, profile names, or synthetic sentinel values.
+- Tool and model inputs must not supply privileged runtime context when the runtime can derive it from the active conversation, actor, destination, or artifact state.
+- Display labels are presentation data. They may be sanitized for UX, but they must not become an identity source or overwrite actor ids.
+- Retryable and resumable workflows must preserve the same identity context and idempotency context across retries and continuation slices.
+
+## Exceptions
+
+- Platform adapters may parse external payloads into exact internal identifiers at ingress.
+- One-time migrations may explicitly repair old malformed state, but the migration must be named, bounded, and verified separately from normal runtime reads.

--- a/specs/chat-architecture.md
+++ b/specs/chat-architecture.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-03-21
-- Last Edited: 2026-06-01
+- Last Edited: 2026-06-05
 
 ## Purpose
 
@@ -37,7 +37,7 @@ The core architecture is the flow of one Slack event through a durable agent tur
 
 ```mermaid
 flowchart TD
-  A[Slack webhook event] --> B[Slack-specific ingress normalization]
+  A[Slack webhook event] --> B[Slack-specific ingress parsing and classification]
   B --> C[Append to durable conversation mailbox]
   C --> D[Send Vercel Queue nudge: conversationId]
   D --> E[Queue worker acquires conversation lease]
@@ -74,7 +74,7 @@ flowchart TD
 
 Normative rules:
 
-1. Ingress normalizes events, appends them to the durable mailbox, and sends a queue nudge. It must not decide agent behavior.
+1. Ingress parses and classifies source events, appends them to the durable mailbox, and sends a queue nudge. It must not decide agent behavior.
 2. The task execution layer owns queue wake-ups, conversation leases, worker check-ins, and heartbeat recovery. Chat SDK queue/lock semantics are not canonical.
 3. The mailbox worker is the only point that drains inbound messages into persisted agent session context.
 4. `respond.ts` is the only owner of Pi agent execution, prompt/continue selection, timeout detection, and safe-boundary session-log event creation.
@@ -89,7 +89,7 @@ Data authority by stage:
 
 | Data                                    | Authority                                              | Notes                                                                                                                       |
 | --------------------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
-| Slack event shape                       | `ingress/` and Slack adapter payloads                  | Normalize IDs and attachments before runtime; do not infer behavior here.                                                   |
+| Slack event shape                       | `ingress/` and Slack adapter payloads                  | Parse platform IDs and attachments before runtime; do not infer behavior here.                                              |
 | Queue wake-up and duplicate suppression | Conversation mailbox worker and lease                  | Queue messages are nudges; mailbox state and leases decide whether work exists and who may run it.                          |
 | Conversation transcript                 | Persisted thread state                                 | Source for visible user/assistant thread history; assistant messages are added only after final Slack delivery.             |
 | Active work routing                     | Conversation mailbox and lease                         | Pending messages are drained into the active conversation at safe boundaries.                                               |
@@ -101,18 +101,19 @@ Data authority by stage:
 
 Related contract ownership:
 
-| Spec                              | Owns                                                                                   |
-| --------------------------------- | -------------------------------------------------------------------------------------- |
-| `./chat-architecture.md`          | End-to-end turn data flow, data authority, and module boundaries.                      |
-| `./task-execution.md`             | Conversation mailbox, queue wake-up, lease, cooperative yield, and heartbeat repair.   |
-| `./agent-session-resumability.md` | Session-log schema, Pi `continue()` semantics, and session lifecycle.                  |
-| `./slack-agent-delivery.md`       | Slack entry surfaces, progress UX, pause acknowledgements, and final reply delivery.   |
-| `./slack-outbound-contract.md`    | Slack API write boundary, formatting, file upload, reactions, and Slack error mapping. |
+| Spec                              | Owns                                                                                       |
+| --------------------------------- | ------------------------------------------------------------------------------------------ |
+| `./chat-architecture.md`          | End-to-end turn data flow, data authority, and module boundaries.                          |
+| `./task-execution.md`             | Conversation mailbox, queue wake-up, lease, cooperative yield, and heartbeat repair.       |
+| `./agent-session-resumability.md` | Session-log schema, Pi `continue()` semantics, and session lifecycle.                      |
+| `./identity.md`                   | Actor, system actor, requester, author, creator, subject, and display identity separation. |
+| `./slack-agent-delivery.md`       | Slack entry surfaces, progress UX, pause acknowledgements, and final reply delivery.       |
+| `./slack-outbound-contract.md`    | Slack API write boundary, formatting, file upload, reactions, and Slack error mapping.     |
 
 ### File Tree Responsibilities
 
 - `app/`: composition roots only. Build concrete implementations and assemble runtime instances.
-- `ingress/`: inbound event normalization, classification, and queue handoff only.
+- `ingress/`: inbound event parsing, classification, and queue handoff only.
 - `runtime/`: turn orchestration only.
 - `services/`: domain services with injected collaborators.
 - `state/`: adapter selection plus store modules split by concern.
@@ -180,7 +181,7 @@ interface ChatTurnRuntime {
 
 #### Ingress Router
 
-- Ingress owns event normalization, dedupe, thread-kind classification, mailbox append, and queue handoff.
+- Ingress owns event parsing, dedupe, thread-kind classification, mailbox append, and queue handoff.
 - Chat SDK must not own canonical ingress queueing, conversation locks, or long-running handler lifetime.
 - Ingress must not become a second authority for turn behavior that already belongs in runtime.
 - Canonical ingress code lives under `chat/ingress/*`. Do not reintroduce legacy patch modules for core ingress behavior.

--- a/specs/credential-injection.md
+++ b/specs/credential-injection.md
@@ -29,7 +29,7 @@ Define how Junior maps registered plugin provider domains to host-managed creden
 
 - Resolve provider from the Vercel Sandbox forwarded host for proxied sandbox egress.
 - Require a signed credential context before issuing provider credentials. The context has a current execution actor and may carry an explicit user credential subject.
-- Credential contexts must carry a real, normalized actor id. Synthetic sentinel values such as `unknown` are invalid for user actors, system actors, and delegated user subjects.
+- Credential contexts must carry exact real actor ids. Synthetic sentinel values such as `unknown` are invalid for user actors, system actors, and delegated user subjects.
 - Agent reply callers pass credential context explicitly. Requester and correlation metadata are not credential inputs.
 - The current actor controls provider permission envelopes. A user credential subject only identifies which stored user OAuth token may be used.
 - System actors may carry an explicit user credential subject only from a runtime boundary that bound or verified the subject for that action. Trusted plugin dispatch accepts the plugin-facing unbound Slack DM subject, signs it at dispatch creation, and stores only the bound subject in dispatch and sandbox egress contexts.

--- a/specs/credential-injection.md
+++ b/specs/credential-injection.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-02-26
-- Last Edited: 2026-06-03
+- Last Edited: 2026-06-05
 
 ## Related
 
@@ -29,6 +29,7 @@ Define how Junior maps registered plugin provider domains to host-managed creden
 
 - Resolve provider from the Vercel Sandbox forwarded host for proxied sandbox egress.
 - Require a signed credential context before issuing provider credentials. The context has a current execution actor and may carry an explicit user credential subject.
+- Credential contexts must carry a real, normalized actor id. Synthetic sentinel values such as `unknown` are invalid for user actors, system actors, and delegated user subjects.
 - Agent reply callers pass credential context explicitly. Requester and correlation metadata are not credential inputs.
 - The current actor controls provider permission envelopes. A user credential subject only identifies which stored user OAuth token may be used.
 - System actors may carry an explicit user credential subject only from a runtime boundary that bound or verified the subject for that action. Trusted plugin dispatch accepts the plugin-facing unbound Slack DM subject, signs it at dispatch creation, and stores only the bound subject in dispatch and sandbox egress contexts.

--- a/specs/credential-injection.md
+++ b/specs/credential-injection.md
@@ -10,6 +10,7 @@
 - [Security Policy](./security-policy.md)
 - [OAuth Flows Spec](./oauth-flows.md)
 - [Plugin Architecture Spec](./plugin.md)
+- [Identity Spec](./identity.md)
 
 ## Purpose
 
@@ -30,6 +31,7 @@ Define how Junior maps registered plugin provider domains to host-managed creden
 - Resolve provider from the Vercel Sandbox forwarded host for proxied sandbox egress.
 - Require a signed credential context before issuing provider credentials. The context has a current execution actor and may carry an explicit user credential subject.
 - Credential contexts must carry exact real actor ids. Synthetic sentinel values such as `unknown` are invalid for user actors, system actors, and delegated user subjects.
+- Actor, requester, system actor, service-principal, and delegated credential subject semantics follow the [Identity Spec](./identity.md). Credential brokers must not infer actor identity from requester metadata, creator metadata, destination, or display profile fields.
 - Agent reply callers pass credential context explicitly. Requester and correlation metadata are not credential inputs.
 - The current actor controls provider permission envelopes. A user credential subject only identifies which stored user OAuth token may be used.
 - System actors may carry an explicit user credential subject only from a runtime boundary that bound or verified the subject for that action. Trusted plugin dispatch accepts the plugin-facing unbound Slack DM subject, signs it at dispatch creation, and stores only the bound subject in dispatch and sandbox egress contexts.

--- a/specs/identity.md
+++ b/specs/identity.md
@@ -1,0 +1,160 @@
+# Identity Spec
+
+## Metadata
+
+- Created: 2026-06-05
+- Last Edited: 2026-06-05
+
+## Purpose
+
+Define how Junior carries human, system, delegated, destination, and display identity through chat turns, scheduled work, plugin dispatch, credential resolution, conversation history, and Slack side effects.
+
+## Scope
+
+- Current user actors and system actors.
+- Service-principal and install-owned credential identities.
+- Slack message authors, requesters, task creators, and conversation managers.
+- Delegated credential subjects for stored user OAuth lookup.
+- Destination identity for Slack conversations, dispatch records, sandbox sessions, and context-bound tools.
+- Identity context carried through ingress, queue work, callbacks, dispatch records, scheduler tasks, sandbox egress, and conversation state.
+
+## Non-Goals
+
+- Provider-specific permission envelopes beyond how they receive the current actor and optional credential subject.
+- Slack profile lookup rules beyond the identity data required by runtime behavior.
+- Workspace membership and channel access policy not already owned by Slack runtime specs.
+- Human-facing naming style beyond separating display labels from authority.
+
+## Terms
+
+- **Identity context:** the runtime-owned bundle of current actor, destination, optional credential subject, and correlation ids carried across a behavior boundary.
+- **Actor:** the current authority for behavior. An actor is either a user actor or a system actor.
+- **User actor:** the human currently asking Junior to act.
+- **System actor:** a named Junior-owned execution authority, such as `scheduler` or a trusted plugin dispatch actor.
+- **Requester:** the interactive user actor for a live Slack turn or requester-sensitive side effect.
+- **Author:** the actor metadata persisted with a conversation message for transcript attribution.
+- **Creator:** audit and notification metadata for durable objects such as scheduled tasks. Creator is not automatically the actor for later execution.
+- **Credential subject:** an explicit subject used only to choose a stored user OAuth token. It is not the current actor and does not grant requester semantics.
+- **Service principal:** a provider credential identity owned by the installation, app, or operator environment. It is not a user actor and must be selected by the current actor's credential envelope.
+- **Destination identity:** the Slack conversation, dispatch destination, sandbox session, or artifact scope where behavior executes.
+- **Display identity:** profile fields shown to humans. Display identity is presentation data, not authority.
+
+## Contracts
+
+### Identity Context
+
+Every behavior that can read credentials, perform side effects, send Slack output, run tools, dispatch work, or mutate durable state must have explicit identity context.
+
+The current actor must be a real user actor or a named system actor. Synthetic ids such as `unknown`, empty strings, whitespace-padded ids, previous message authors, task creators, Slack display names, and destination membership are not valid substitutes for actor context.
+
+### Boundary Parsing
+
+Untrusted external data is parsed once at the boundary that receives it:
+
+- Slack ingress and Slack adapter payloads parse Slack user ids before creating internal work.
+- Trusted plugin APIs parse plugin-provided credential subjects before binding or persisting them.
+- Signed callback and sandbox egress contexts verify signatures and parse actor payloads before issuing credentials.
+
+Boundary parsing accepts only exact identifiers. It must not trim, rewrite, or otherwise repair a malformed actor id into a usable one.
+
+### Owned State
+
+After Junior persists, signs, or dispatches identity context, downstream runtime code treats that context as owned state. Owned state must be asserted exactly. Runtime reads must not normalize malformed actor ids into valid ones.
+
+Invalid owned identity state is a broken contract. The correct outcome is fail closed, block, or surface an operational error, not continue with a guessed actor.
+
+### Role Separation
+
+The current actor controls the permission envelope for behavior.
+
+Actor, author, creator, requester, credential subject, service principal, destination, and display identity are separate fields with separate meanings:
+
+- An actor authorizes current behavior.
+- A persisted author attributes a conversation message.
+- A creator explains who made or confirmed a durable object.
+- A credential subject selects a stored user OAuth token only when the current actor contract allows delegated credentials.
+- A service principal supplies install-owned or app-owned provider access when allowed for the current actor.
+- A destination tells Junior where to post or which context-bound tool target to use.
+- A display name is never an authorization principal.
+
+Copying one role into another is allowed only where a spec names that exact transition.
+
+### System Actors
+
+System actors are first-class actors, not absent users. They must have stable names and explicit credential envelopes.
+
+System actors do not imply a human requester, do not start interactive auth flows, and do not inherit creator or channel-member credentials. They may use service-principal or install-owned credentials only when the provider broker explicitly supports that system actor envelope.
+
+If a system actor needs a stored user OAuth token, the run must carry an explicit delegated credential subject allowed by the relevant spec. That subject still does not become the actor.
+
+### Scheduler And Dispatch
+
+Scheduled runs execute as a Junior system actor, not as the user who created the task. Creator metadata may be used for audit and private notification, but not as requester identity.
+
+Trusted plugin dispatch also executes as a system actor unless a future spec defines a different actor model. Plugin metadata and idempotency keys are correlation data, not actor sources.
+
+Scheduled tasks and trusted dispatches may carry an explicit delegated user credential subject only under the Slack private direct conversation exception defined by the scheduler and dispatch specs. That subject is not the actor.
+
+### Conversation History
+
+User-authored conversation messages must carry exact author identity when they are committed to durable state. Conversation rendering may sanitize display labels so platform ids are not shown as names, but it must not repair or reinterpret stored author ids.
+
+Prompt context must preserve who is asking now versus who authored prior messages. A later user in the same Slack thread becomes the current requester for the new turn without changing attribution for earlier messages.
+
+### Slack Side Effects
+
+Requester-sensitive Slack side effects, including ephemeral responses and OAuth continuations, must use the current requester actor id from turn context. They must not fall back to channel id, bot id, last human author, task creator, or display profile fields.
+
+Destination-sensitive Slack side effects must use runtime-owned destination context. Model arguments may not override context-bound destinations unless a separate spec allows it.
+
+## Failure Model
+
+- Missing or malformed actor id at ingress rejects the payload or records a terminal failure for that work item.
+- Missing identity context in an internal call is a programming error.
+- Malformed actor identity in owned state fails closed and should be investigated or migrated explicitly.
+- Missing display identity may degrade presentation only; it must not change the actor id or credential subject.
+- Missing delegated user credentials block the run or start the approved private auth flow only when the current actor model permits it.
+- Missing system-actor credential envelopes block system work rather than falling back to a creator, last author, or requester-shaped user.
+
+## Observability
+
+Logs and spans may include safe identity dimensions needed for debugging:
+
+- actor type and id
+- credential subject type and user id when present
+- service-principal or provider credential class when present
+- destination platform and conversation id
+- creator user id for scheduled-task audit
+
+Logs and spans must keep these roles distinct. They must not include OAuth tokens, provider credentials, raw authorization URLs, Slack tokens, prompt text, private tool payloads, or raw conversation state.
+
+## Verification
+
+Use integration tests for behavior that crosses real runtime boundaries:
+
+- Slack ingress persists the real requester/author identity and rejects synthetic or malformed actor ids.
+- Slack DM and channel paths preserve the current requester through first delivery, retry, and continuation.
+- Scheduler dispatch runs with a system actor and does not use creator identity as requester.
+- Trusted plugin dispatch carries a system actor through callback, retry, continuation, credential context, and Slack delivery.
+- Private direct scheduled tasks may carry an explicit credential subject; group, private channel, public channel, and unknown-audience tasks may not.
+- Sandbox egress and credential injection reject signed contexts with malformed actors or subjects.
+- System actors use only explicit service-principal, install-owned, or delegated credential envelopes.
+- Requester-sensitive Slack side effects use the current actor id.
+
+Use unit tests for small parsing, signing, and assertion helpers.
+
+Use evals only when the contract depends on model interpretation, such as preserving current requester semantics in natural-language follow-up handling.
+
+## Related Specs
+
+- `./chat-architecture.md`
+- `./task-execution.md`
+- `./agent-turn-handling.md`
+- `./slack-agent-delivery.md`
+- `./slack-outbound-contract.md`
+- `./credential-injection.md`
+- `./scheduler.md`
+- `./trusted-plugin-dispatch.md`
+- `./harness-tool-context.md`
+- `./testing.md`
+- `../policies/context-bound-systems.md`

--- a/specs/index.md
+++ b/specs/index.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-03-03
-- Last Edited: 2026-06-01
+- Last Edited: 2026-06-05
 
 ## Purpose
 
@@ -35,6 +35,7 @@ Define spec taxonomy, naming conventions, and canonical source-of-truth document
 - `specs/agent-turn-handling.md`
 - `specs/slack-agent-delivery.md`
 - `specs/slack-outbound-contract.md`
+- `specs/identity.md`
 - `specs/credential-injection.md`
 - `specs/oauth-flows.md`
 - `specs/agent-prompt.md`
@@ -77,6 +78,7 @@ For chat/agent/Slack turn behavior:
 - `specs/context-compaction.md` owns reusable Pi history compaction, internal context forks, and visible-thread compaction bounds.
 - `specs/slack-agent-delivery.md` owns Slack entry surfaces, progress UX, continuation acknowledgements, and final reply delivery.
 - `specs/slack-outbound-contract.md` owns Slack API write formatting, file uploads, reactions, retries, and error mapping.
+- `specs/identity.md` owns current actor, system actor, requester, author, creator, credential subject, service principal, and display identity separation across runtime boundaries.
 
 ## Archived Superseded Specs
 

--- a/specs/scheduler.md
+++ b/specs/scheduler.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-05-18
-- Last Edited: 2026-06-01
+- Last Edited: 2026-06-05
 
 ## Purpose
 
@@ -309,6 +309,7 @@ Use unit tests only for small deterministic helpers when integration or eval cov
 
 ## Related Specs
 
+- `./identity.md`
 - `./chat-architecture.md`
 - `./task-execution.md`
 - `./agent-prompt.md`

--- a/specs/slack-agent-delivery.md
+++ b/specs/slack-agent-delivery.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-04-15
-- Last Edited: 2026-06-01
+- Last Edited: 2026-06-05
 
 ## Purpose
 
@@ -199,7 +199,7 @@ Images passed into Slack threads are part of the thread context contract.
 
 Current rules:
 
-1. Slack file/image attachments on inbound messages must survive ingress normalization, including `message_changed` events.
+1. Slack file/image attachments on inbound messages must survive ingress parsing, including `message_changed` events.
 2. Private-file fetchers must be rehydrated before runtime processing whenever messages are deserialized or side-channeled through webhook handlers.
 3. Passive subscribed-thread messages that include potential image attachments must not be permanently marked as already hydrated before image hydration has actually run.
 4. Later explicit mentions in the same thread may rely on previously skipped screenshots or image uploads still being recoverable from persisted conversation state.

--- a/specs/trusted-plugin-dispatch.md
+++ b/specs/trusted-plugin-dispatch.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-05-28
-- Last Edited: 2026-06-03
+- Last Edited: 2026-06-05
 
 ## Purpose
 
@@ -297,6 +297,7 @@ Use unit tests for:
 
 ## Related Specs
 
+- `./identity.md`
 - `./trusted-plugin-heartbeat.md`
 - `./task-execution.md`
 - `./scheduler.md`


### PR DESCRIPTION
Runtime behavior now carries explicit runtime identity context instead of deriving actors, destinations, or credential subjects from adapter display fallbacks, creator metadata, or placeholder values. Slack turns, queued mailbox processing, edited messages, OAuth/timeout resumes, scheduler dispatch, plugin hooks, credential egress, and Git coauthor attribution now either use resolved identity context or fail closed when a real actor or subject is required.

**Identity Contract**

Adds `specs/identity.md` for the general identity model: user actors, system actors, service-principal credentials, requesters, authors, creators, destination identity, display identity, and delegated credential subjects. Adds `policies/context-bound-systems.md` so async/runtime boundaries carry identity context explicitly rather than guessing.

**Canonical Message Actors**

Slack messages bind an exact Slack user id plus resolved profile data before being persisted or replayed. Conversation memory keeps display fields separate from actor ids; transcript rendering refuses to show platform ids as names without repairing stored actor ids on read.

**Explicit System Actors And Credential Subjects**

Scheduled and plugin dispatch carries `{ actor: { type: "system", id: ... } }` and may delegate user OAuth only through a bound Slack DM credential subject. External Slack/adapter/plugin payloads are parsed once at the boundary; owned credential subjects and signed contexts assert exact actor ids instead of trimming or normalizing malformed data.

Fixes #522