### PR TITLE
fix(chat): Simplify provider retry policy

### DIFF
--- a/packages/junior/src/chat/pi/client.ts
+++ b/packages/junior/src/chat/pi/client.ts
@@ -40,6 +40,10 @@ import {
   toGenAiMessagesTraceAttributes,
   toGenAiTextMetadata,
 } from "@/chat/conversation-privacy";
+import {
+  createProviderError,
+  isProviderRetryError,
+} from "@/chat/services/provider-retry";
 
 const GATEWAY_PROVIDER = "vercel-ai-gateway" as const;
 export const GEN_AI_PROVIDER_NAME = GATEWAY_PROVIDER;
@@ -231,21 +235,26 @@ export async function completeText(params: {
     "gen_ai.chat",
     logContextFromMetadata(params.modelId, params.metadata),
     async () => {
-      const message = await completeSimple(
-        model,
-        {
-          systemPrompt: params.system,
-          messages: params.messages,
-        },
-        {
-          ...(apiKey ? { apiKey } : {}),
-          temperature: params.temperature,
-          maxTokens: params.maxTokens,
-          reasoning: params.thinkingLevel,
-          signal: params.signal,
-          metadata: params.metadata,
-        },
-      );
+      let message: Awaited<ReturnType<typeof completeSimple>>;
+      try {
+        message = await completeSimple(
+          model,
+          {
+            systemPrompt: params.system,
+            messages: params.messages,
+          },
+          {
+            ...(apiKey ? { apiKey } : {}),
+            temperature: params.temperature,
+            maxTokens: params.maxTokens,
+            reasoning: params.thinkingLevel,
+            signal: params.signal,
+            metadata: params.metadata,
+          },
+        );
+      } catch (error) {
+        throw createProviderError(error);
+      }
       const outputText = extractText(message);
       const outputMessagesAttribute = serializeGenAiAttribute(
         messageAttributeMode === "metadata"
@@ -292,7 +301,7 @@ export async function completeText(params: {
           },
           "AI completion returned provider error",
         );
-        throw new Error(`AI provider error: ${providerMessage}`);
+        throw createProviderError(providerMessage);
       }
 
       return {
@@ -361,6 +370,10 @@ export async function completeObject<TSchema extends ZodTypeAny>(params: {
       ],
     }));
   } catch (error) {
+    if (isProviderRetryError(error)) {
+      throw error;
+    }
+
     logException(
       error,
       "ai_completion_failed",

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -106,8 +106,8 @@ import {
   type AgentTurnDiagnostics,
 } from "@/chat/services/turn-result";
 import {
-  isRetryableProviderError,
-  trimRetryableProviderErrorTail,
+  isProviderRetryError,
+  nextProviderRetry,
 } from "@/chat/services/provider-retry";
 import {
   selectTurnThinkingLevel,
@@ -150,7 +150,6 @@ import {
 // Re-export types for backward compatibility with existing consumers.
 export type { AssistantReply, AgentTurnDiagnostics };
 
-const PROVIDER_RETRY_DELAYS_MS = [1_000, 2_000] as const;
 const AGENT_ABORT_SETTLE_GRACE_MS = 5_000;
 
 function sleep(ms: number): Promise<void> {
@@ -1480,31 +1479,25 @@ export async function generateAssistantReply(
             }
 
             const lastAssistant = outputMessages.at(-1);
-            const retryDelayMs = PROVIDER_RETRY_DELAYS_MS[attempt];
-            if (
-              retryDelayMs === undefined ||
-              !isRetryableProviderError(lastAssistant)
-            ) {
+            const providerRetry = nextProviderRetry({
+              attempt,
+              lastAssistant,
+              messages: agent.state.messages,
+            });
+            if (!providerRetry) {
               break;
             }
 
             retryUsage = turnUsage;
-            const retryMessages = trimRetryableProviderErrorTail(
-              agent.state.messages,
-            );
-            if (!retryMessages) {
-              break;
-            }
-
-            agent.state.messages = retryMessages;
-            await persistSafeBoundary(retryMessages);
+            agent.state.messages = providerRetry.messages;
+            await persistSafeBoundary(providerRetry.messages);
             logWarn(
               "agent_turn_provider_retry",
               spanContext,
               {},
               "Retrying transient provider failure",
             );
-            await sleep(retryDelayMs);
+            await sleep(providerRetry.delayMs);
             run = agent.continue();
           }
         },
@@ -1698,6 +1691,9 @@ export async function generateAssistantReply(
     }
 
     if (isRetryableTurnError(error)) {
+      throw error;
+    }
+    if (isProviderRetryError(error)) {
       throw error;
     }
     if (isTurnInputCommitLostError(error)) {

--- a/packages/junior/src/chat/runtime/slack-runtime.ts
+++ b/packages/junior/src/chat/runtime/slack-runtime.ts
@@ -8,6 +8,7 @@
  */
 import type { Message, MessageContext, Thread } from "chat";
 import { getSubscribedReplyPreflightDecision } from "@/chat/services/subscribed-decision";
+import { isProviderRetryError } from "@/chat/services/provider-retry";
 import {
   isCooperativeTurnYieldError,
   isTurnInputCommitLostError,
@@ -63,6 +64,16 @@ export interface ReplyHooks {
 
 const THREAD_OPTOUT_ACK =
   "Understood. I'll stay out of this thread unless someone @mentions me again.";
+
+/** Preserve retry/yield control flow for the durable worker boundary. */
+function shouldRethrowTurnControlError(error: unknown): boolean {
+  return (
+    isCooperativeTurnYieldError(error) ||
+    isTurnInputCommitLostError(error) ||
+    isProviderRetryError(error)
+  );
+}
+
 /** Apply a subscribed-thread opt-out decision before any agent work runs. */
 async function maybeHandleThreadOptOutDecision(args: {
   beforeFirstResponsePost?: () => Promise<void>;
@@ -516,10 +527,7 @@ export function createSlackTurnRuntime<
           });
         });
       } catch (error) {
-        if (
-          isCooperativeTurnYieldError(error) ||
-          isTurnInputCommitLostError(error)
-        ) {
+        if (shouldRethrowTurnControlError(error)) {
           throw error;
         }
         const errorContext = logContext({
@@ -755,10 +763,7 @@ export function createSlackTurnRuntime<
           });
         });
       } catch (error) {
-        if (
-          isCooperativeTurnYieldError(error) ||
-          isTurnInputCommitLostError(error)
-        ) {
+        if (shouldRethrowTurnControlError(error)) {
           throw error;
         }
         const errorContext = logContext({

--- a/packages/junior/src/chat/services/provider-retry.ts
+++ b/packages/junior/src/chat/services/provider-retry.ts
@@ -5,34 +5,72 @@ import {
   trimTrailingAssistantMessages,
 } from "@/chat/respond-helpers";
 
-const RETRYABLE_PROVIDER_ERROR_PATTERN =
-  /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|websocket.?closed|websocket.?error|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|stream ended before message_stop|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i;
+const PROVIDER_RETRY_DELAYS_MS = [2_000, 4_000, 8_000] as const;
+const PROVIDER_ERROR_PREFIX = "AI provider error:";
+const PROVIDER_RETRY_ERROR_NAME = "ProviderRetryError";
+const NON_RETRYABLE_PROVIDER_ERROR_PATTERNS = [
+  /invalid.?api.?key|no api key|authentication|authorization|permission|forbidden|credential/i,
+  /context.?length|context.?window/i,
+  /content.?policy|validation|bad request|\b(?:400|401|403)\b/i,
+  /unsupported model|invalid model|unknown ai gateway model|unknown model|mismatched api/i,
+  /usage limit|monthly usage limit|available balance|insufficient.?quota|out of budget|quota exceeded|billing/i,
+] as const;
 
-const NON_RETRYABLE_PROVIDER_ERROR_PATTERN =
-  /invalid.?api.?key|authentication|authorization|permission|forbidden|context.?length|context.?window|content.?policy|validation|bad request|400|401|403/i;
-
-/** Detect transient provider failures that are safe to retry from a Pi boundary. */
-export function isRetryableProviderError(
-  message: Pick<AssistantMessage, "stopReason" | "errorMessage"> | undefined,
-): boolean {
-  if (message?.stopReason !== "error" || !message.errorMessage) {
-    return false;
-  }
-  if (NON_RETRYABLE_PROVIDER_ERROR_PATTERN.test(message.errorMessage)) {
-    return false;
-  }
-  return RETRYABLE_PROVIDER_ERROR_PATTERN.test(message.errorMessage);
+function providerMessage(error: unknown): string {
+  return (error instanceof Error ? error.message : String(error)).trim();
 }
 
-/** Remove a failed assistant tail only when the remaining Pi history can continue. */
-export function trimRetryableProviderErrorTail(
-  messages: PiMessage[],
-): PiMessage[] | undefined {
-  const trimmed = trimTrailingAssistantMessages(messages);
-  if (trimmed.length === messages.length) {
+/** Mark failures that cross the AI provider boundary for shared retry handling. */
+export function createProviderError(error: unknown): Error {
+  const message = providerMessage(error);
+  const displayMessage = `${PROVIDER_ERROR_PREFIX} ${message || "Unknown provider error"}`;
+  const providerError = new Error(displayMessage, { cause: error });
+  if (message && isRetryableProviderFailure(message)) {
+    providerError.name = PROVIDER_RETRY_ERROR_NAME;
+  }
+  return providerError;
+}
+
+/** Return whether a provider-boundary error should be retried by the worker. */
+export function isProviderRetryError(error: unknown): boolean {
+  return error instanceof Error && error.name === PROVIDER_RETRY_ERROR_NAME;
+}
+
+/** Classify upstream failures by exclusion so new transient provider errors retry. */
+function isRetryableProviderFailure(errorMessage: string): boolean {
+  return !NON_RETRYABLE_PROVIDER_ERROR_PATTERNS.some((pattern) =>
+    pattern.test(errorMessage),
+  );
+}
+
+/** Build the next provider retry step from Pi history, if the turn can resume. */
+export function nextProviderRetry(args: {
+  attempt: number;
+  lastAssistant:
+    | Pick<AssistantMessage, "stopReason" | "errorMessage">
+    | undefined;
+  messages: PiMessage[];
+}): { delayMs: number; messages: PiMessage[] } | undefined {
+  const delayMs = PROVIDER_RETRY_DELAYS_MS[args.attempt];
+  const errorMessage = args.lastAssistant?.errorMessage?.trim();
+  if (
+    delayMs === undefined ||
+    args.lastAssistant?.stopReason !== "error" ||
+    !errorMessage ||
+    !isRetryableProviderFailure(errorMessage)
+  ) {
     return undefined;
   }
 
-  const tailRole = getPiMessageRole(trimmed.at(-1));
-  return tailRole === "user" || tailRole === "toolResult" ? trimmed : undefined;
+  const messages = trimTrailingAssistantMessages(args.messages);
+  if (messages.length === args.messages.length) {
+    return undefined;
+  }
+
+  const tailRole = getPiMessageRole(messages.at(-1));
+  if (tailRole !== "user" && tailRole !== "toolResult") {
+    return undefined;
+  }
+
+  return { delayMs, messages };
 }

--- a/packages/junior/src/chat/services/subscribed-decision.ts
+++ b/packages/junior/src/chat/services/subscribed-decision.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { escapeXml } from "@/chat/xml";
+import { isProviderRetryError } from "@/chat/services/provider-retry";
 
 export enum SubscribedReplyReason {
   ThreadOptOut = "thread_opt_out",
@@ -522,6 +523,9 @@ export async function decideSubscribedThreadReply(args: {
       reasonDetail: reason,
     };
   } catch (error) {
+    if (isProviderRetryError(error)) {
+      throw error;
+    }
     args.logClassifierFailure(error, args.input);
     return {
       shouldReply: false,

--- a/packages/junior/src/chat/task-execution/worker.ts
+++ b/packages/junior/src/chat/task-execution/worker.ts
@@ -1,5 +1,6 @@
 import type { StateAdapter } from "chat";
 import { logException, logInfo, logWarn } from "@/chat/logging";
+import { isProviderRetryError } from "@/chat/services/provider-retry";
 import type { ConversationWorkQueue } from "./queue";
 import {
   checkInConversationWork,
@@ -394,15 +395,17 @@ export async function processConversationWork(
         "Conversation work release failed after runner error",
       );
     }
-    logException(
-      error,
-      "conversation_work_failed",
-      { conversationId },
-      {
-        "app.worker.elapsed_ms": now(options) - startedAtMs,
-      },
-      "Conversation work failed",
-    );
+    if (!isProviderRetryError(error)) {
+      logException(
+        error,
+        "conversation_work_failed",
+        { conversationId },
+        {
+          "app.worker.elapsed_ms": now(options) - startedAtMs,
+        },
+        "Conversation work failed",
+      );
+    }
     throw error;
   } finally {
     clearInterval(timer);

--- a/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { JuniorRuntimeServiceOverrides } from "@/chat/app/services";
+import { createProviderError } from "@/chat/services/provider-retry";
 import { createTestChatRuntime } from "../../fixtures/chat-runtime";
 import {
   createTestMessage,
@@ -81,6 +82,41 @@ describe("Slack behavior: subscribed messages", () => {
     await slackRuntime.handleSubscribedMessage(thread, message);
 
     expect(classifierCalls).toHaveLength(1);
+    expect(thread.posts).toHaveLength(0);
+  });
+
+  it("rethrows retryable classifier provider errors for durable retry", async () => {
+    const providerError = createProviderError(
+      new Error("Anthropic stream ended before message_stop"),
+    );
+
+    const { slackRuntime } = createTestChatRuntime({
+      services: {
+        subscribedReplyPolicy: {
+          completeObject: async () => {
+            throw providerError;
+          },
+        },
+        replyExecutor: {
+          generateAssistantReply: async () => {
+            throw new Error("generateAssistantReply should not run");
+          },
+        },
+      },
+    });
+
+    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002000.001" });
+    const message = createTestMessage({
+      id: "m-subscribed-provider-retry",
+      text: "can you check this?",
+      isMention: false,
+      threadId: thread.id,
+      author: { userId: "U_TESTER" },
+    });
+
+    await expect(
+      slackRuntime.handleSubscribedMessage(thread, message),
+    ).rejects.toBe(providerError);
     expect(thread.posts).toHaveLength(0);
   });
 

--- a/packages/junior/tests/unit/pi/client.test.ts
+++ b/packages/junior/tests/unit/pi/client.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 
 const mocks = vi.hoisted(() => ({
   completeSimple: vi.fn(),
@@ -170,5 +171,25 @@ describe("completeText", () => {
     expect(endAttributes["gen_ai.output.messages"]).not.toContain(
       "private answer",
     );
+  });
+
+  it("rethrows retryable object provider failures without capturing", async () => {
+    mocks.completeSimple.mockRejectedValue(
+      new Error("Anthropic stream ended before message_stop"),
+    );
+
+    const { completeObject } = await import("@/chat/pi/client");
+
+    await expect(
+      completeObject({
+        modelId: "openai/gpt-4o-mini",
+        schema: z.object({ ok: z.boolean() }),
+        prompt: "return json",
+      }),
+    ).rejects.toThrow(
+      "AI provider error: Anthropic stream ended before message_stop",
+    );
+    expect(mocks.logWarn).not.toHaveBeenCalled();
+    expect(mocks.logException).not.toHaveBeenCalled();
   });
 });

--- a/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
@@ -257,7 +257,7 @@ describe("generateAssistantReply provider retry", () => {
       },
     });
 
-    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.advanceTimersByTimeAsync(2_000);
     const reply = await replyPromise;
 
     expect(reply.text).toBe("Recovered.");

--- a/packages/junior/tests/unit/services/provider-retry.test.ts
+++ b/packages/junior/tests/unit/services/provider-retry.test.ts
@@ -2,12 +2,13 @@ import { describe, expect, it } from "vitest";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import type { PiMessage } from "@/chat/pi/messages";
 import {
-  isRetryableProviderError,
-  trimRetryableProviderErrorTail,
+  nextProviderRetry,
+  createProviderError,
+  isProviderRetryError,
 } from "@/chat/services/provider-retry";
 
 function assistantError(
-  errorMessage: string,
+  errorMessage: string | undefined,
 ): Pick<AssistantMessage, "stopReason" | "errorMessage"> {
   return {
     stopReason: "error",
@@ -16,41 +17,26 @@ function assistantError(
 }
 
 describe("provider retry helpers", () => {
-  it("matches transient provider stream failures", () => {
-    expect(
-      isRetryableProviderError(
-        assistantError("Anthropic stream ended before message_stop"),
-      ),
-    ).toBe(true);
-    expect(
-      isRetryableProviderError(
-        assistantError("Provider finish_reason: network_error"),
-      ),
-    ).toBe(true);
-    expect(isRetryableProviderError(assistantError("overloaded_error"))).toBe(
-      true,
+  it("marks retryable provider-boundary exceptions", () => {
+    const error = createProviderError(
+      new Error("Anthropic stream ended before message_stop"),
     );
-  });
 
-  it("does not match auth or validation failures", () => {
-    expect(isRetryableProviderError(assistantError("invalid_api_key"))).toBe(
+    expect(error.message).toBe(
+      "AI provider error: Anthropic stream ended before message_stop",
+    );
+    expect(isProviderRetryError(error)).toBe(true);
+    expect(isProviderRetryError(createProviderError("invalid_api_key"))).toBe(
       false,
     );
-    expect(isRetryableProviderError(assistantError("400 bad request"))).toBe(
-      false,
-    );
-    expect(isRetryableProviderError({ stopReason: "stop" })).toBe(false);
+    expect(isProviderRetryError(createProviderError(""))).toBe(false);
+    expect(isProviderRetryError(new Error(error.message))).toBe(false);
   });
 
-  it("trims a failed assistant tail only at a continuable boundary", () => {
+  it("builds a retry step from resumable Pi history", () => {
     const user = {
       role: "user",
       content: [{ type: "text", text: "help" }],
-    } as PiMessage;
-    const toolResult = {
-      role: "toolResult",
-      toolName: "bash",
-      content: [{ type: "text", text: "ok" }],
     } as PiMessage;
     const failedAssistant = {
       role: "assistant",
@@ -59,8 +45,52 @@ describe("provider retry helpers", () => {
     } as unknown as PiMessage;
 
     expect(
-      trimRetryableProviderErrorTail([user, toolResult, failedAssistant]),
-    ).toEqual([user, toolResult]);
-    expect(trimRetryableProviderErrorTail([failedAssistant])).toBeUndefined();
+      nextProviderRetry({
+        attempt: 0,
+        lastAssistant: assistantError(
+          "Anthropic stream ended before message_stop",
+        ),
+        messages: [user, failedAssistant],
+      }),
+    ).toEqual({ delayMs: 2_000, messages: [user] });
+  });
+
+  it("does not retry permanent, exhausted, or unresumable Pi failures", () => {
+    const user = {
+      role: "user",
+      content: [{ type: "text", text: "help" }],
+    } as PiMessage;
+    const failedAssistant = {
+      role: "assistant",
+      content: [],
+      stopReason: "error",
+    } as unknown as PiMessage;
+    const retry = (
+      overrides: {
+        attempt?: number;
+        lastAssistant?: Pick<AssistantMessage, "stopReason" | "errorMessage">;
+        messages?: PiMessage[];
+      } = {},
+    ) =>
+      nextProviderRetry({
+        attempt: 0,
+        lastAssistant: assistantError("Anthropic overloaded"),
+        messages: [user, failedAssistant],
+        ...overrides,
+      });
+
+    expect(
+      retry({
+        lastAssistant: assistantError("400 bad request"),
+      }),
+    ).toBeUndefined();
+    expect(
+      retry({
+        lastAssistant: assistantError(undefined),
+      }),
+    ).toBeUndefined();
+    expect(retry({ lastAssistant: { stopReason: "stop" } })).toBeUndefined();
+    expect(retry({ attempt: 3 })).toBeUndefined();
+    expect(retry({ messages: [failedAssistant] })).toBeUndefined();
   });
 });


### PR DESCRIPTION
Provider retry now uses one provider-owned policy: provider-boundary failures with a real provider message retry by default unless they match permanent auth, validation, model, context, quota, or billing exclusions. Pi stop errors use the same bounded 2s/4s/8s retry step, and runtime boundaries rethrow provider retry errors instead of capturing them as failures.

**Provider Boundary**

`createProviderError` wraps thrown Pi completion failures and returned provider stop errors as retryable only for transient-looking failures. Permanent provider or configuration failures stay normal errors and still flow to Sentry capture.

**Agent Retry Step**

`nextProviderRetry` owns the backoff, exclusion classifier, and safe Pi-history trimming so `generateAssistantReply` only asks whether another provider retry is available. Blank provider stop errors are not retried.

**Runtime Retry Flow**

Subscribed-thread classifier errors, Slack handlers, and the durable worker preserve provider retry errors for redelivery and skip `conversation_work_failed` capture for expected upstream failures.

Refs Sentry issue 7506165699