### PR TITLE
fix(slack): Remove turn metrics from reply footers

### DIFF
--- a/packages/junior/src/chat/agent-dispatch/runner.ts
+++ b/packages/junior/src/chat/agent-dispatch/runner.ts
@@ -352,9 +352,6 @@ export async function runAgentDispatchSlice(
       posts: planSlackReplyPosts({ reply: deliveryReply }),
       footer: buildSlackReplyFooter({
         conversationId,
-        durationMs: deliveryReply.diagnostics.durationMs,
-        thinkingLevel: deliveryReply.diagnostics.thinkingLevel,
-        usage: deliveryReply.diagnostics.usage,
       }),
       fileUploadFailureMode: "strict",
     });

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -815,9 +815,6 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           const plannedPosts = planSlackReplyPosts({ reply });
           const replyFooter = buildSlackReplyFooter({
             conversationId,
-            durationMs: reply.diagnostics.durationMs,
-            thinkingLevel: reply.diagnostics.thinkingLevel,
-            usage: reply.diagnostics.usage,
           });
           const shouldUseSlackFooter =
             Boolean(replyFooter) &&

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -27,8 +27,6 @@ import {
 } from "@/chat/slack/reply";
 import { postSlackMessage as postSlackApiMessage } from "@/chat/slack/outbound";
 import { ACTIVE_LOCK_TTL_MS, getStateAdapter } from "@/chat/state/adapter";
-import { getAgentTurnSessionRecord } from "@/chat/state/turn-session";
-import { addAgentTurnUsage } from "@/chat/usage";
 import {
   startSlackProcessingReactionForMessage,
   type ProcessingReactionSession,
@@ -316,14 +314,6 @@ export async function resumeSlackTurn(
 
     const generateReply = runArgs.generateReply ?? generateAssistantReply;
     const replyContext = createResumeReplyContext(runArgs, status);
-    const priorSessionRecord =
-      replyContext.correlation?.conversationId &&
-      replyContext.correlation?.turnId
-        ? await getAgentTurnSessionRecord(
-            replyContext.correlation.conversationId,
-            replyContext.correlation.turnId,
-          )
-        : undefined;
     const replyPromise = generateReply(runArgs.messageText, replyContext);
     const replyTimeoutMs = resolveReplyTimeoutMs(runArgs.replyTimeoutMs);
     let reply =
@@ -353,18 +343,6 @@ export async function resumeSlackTurn(
     const footer = buildSlackReplyFooter({
       conversationId:
         runArgs.replyContext?.correlation?.conversationId ?? lockKey,
-      durationMs:
-        typeof priorSessionRecord?.cumulativeDurationMs === "number" ||
-        typeof reply.diagnostics.durationMs === "number"
-          ? (priorSessionRecord?.cumulativeDurationMs ?? 0) +
-            (reply.diagnostics.durationMs ?? 0)
-          : undefined,
-      thinkingLevel: reply.diagnostics.thinkingLevel,
-      usage:
-        addAgentTurnUsage(
-          priorSessionRecord?.cumulativeUsage,
-          reply.diagnostics.usage,
-        ) ?? reply.diagnostics.usage,
     });
     await postSlackApiReplyPosts({
       channelId: runArgs.channelId,

--- a/packages/junior/src/chat/slack/footer.ts
+++ b/packages/junior/src/chat/slack/footer.ts
@@ -1,7 +1,5 @@
 import { buildSentryConversationUrl } from "@/chat/sentry-links";
 import { getAgentPluginSlackConversationLink } from "@/chat/plugins/agent-hooks";
-import type { TurnThinkingSelection } from "@/chat/services/turn-thinking-level";
-import type { AgentTurnUsage } from "@/chat/usage";
 
 interface SlackMrkdwnTextObject {
   text: string;
@@ -53,78 +51,13 @@ function escapeSlackLinkUrl(url: string): string {
     .replaceAll(">", "%3E");
 }
 
-function formatSlackTokenCount(value: number): string {
-  if (value >= 1_000_000) {
-    const millions = value / 1_000_000;
-    // Show up to 2 decimal places, drop trailing zeros
-    return `${parseFloat(millions.toFixed(2))}m`;
-  }
-  if (value >= 1_000) {
-    const thousands = value / 1_000;
-    return `${parseFloat(thousands.toFixed(1))}k`;
-  }
-  return `${value}`;
-}
-
-function formatSlackDuration(durationMs: number): string {
-  if (durationMs < 1_000) {
-    return `${durationMs}ms`;
-  }
-
-  const totalSeconds = Math.round(durationMs / 1_000);
-
-  if (totalSeconds < 10) {
-    const precise = durationMs / 1_000;
-    return `${precise.toFixed(1).replace(/\.0$/, "")}s`;
-  }
-
-  if (totalSeconds < 60) {
-    return `${totalSeconds}s`;
-  }
-
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  if (seconds === 0) {
-    return `${minutes}m`;
-  }
-  return `${minutes}m${seconds}s`;
-}
-
-function resolveTotalTokens(
-  usage: AgentTurnUsage | undefined,
-): number | undefined {
-  if (!usage) {
-    return undefined;
-  }
-
-  // Sum every individual counter the provider reported so cached + cache
-  // creation tokens are included in the displayed total. Provider `totalTokens`
-  // fields are inconsistent across vendors (some exclude cached tokens, some
-  // include them), so prefer the sum when component counts exist.
-  const components = [
-    usage.inputTokens,
-    usage.outputTokens,
-    usage.cachedInputTokens,
-    usage.cacheCreationTokens,
-  ].filter((value): value is number => value !== undefined);
-
-  if (components.length > 0) {
-    return components.reduce((sum, value) => sum + value, 0);
-  }
-
-  return usage.totalTokens;
-}
-
 /**
- * Build a compact footer for the finalized Slack reply.
+ * Build the compact conversation footer for the finalized Slack reply.
  *
- * This is reply metadata, not part of the in-flight assistant loading state.
+ * Detailed turn metrics stay in the dashboard instead of Slack-visible copy.
  */
 export function buildSlackReplyFooter(args: {
   conversationId?: string;
-  durationMs?: number;
-  thinkingLevel?: TurnThinkingSelection["thinkingLevel"];
-  usage?: AgentTurnUsage;
 }): SlackReplyFooter | undefined {
   const items: SlackReplyFooterItem[] = [];
 
@@ -141,29 +74,6 @@ export function buildSlackReplyFooter(args: {
       idItem.url = conversationUrl;
     }
     items.push(idItem);
-  }
-
-  const totalTokens = resolveTotalTokens(args.usage);
-  if (totalTokens !== undefined) {
-    items.push({
-      label: "Tokens",
-      value: formatSlackTokenCount(totalTokens),
-    });
-  }
-
-  if (typeof args.durationMs === "number" && Number.isFinite(args.durationMs)) {
-    const durationMs = Math.max(0, Math.floor(args.durationMs));
-    items.push({
-      label: "Time",
-      value: formatSlackDuration(durationMs),
-    });
-  }
-
-  if (args.thinkingLevel) {
-    items.push({
-      label: "Thinking",
-      value: args.thinkingLevel,
-    });
   }
 
   return items.length > 0 ? { items } : undefined;

--- a/packages/junior/tests/integration/oauth-resume-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-resume-slack.test.ts
@@ -101,22 +101,14 @@ describe("oauth resume slack integration", () => {
             },
             {
               type: "context",
-              elements: expect.arrayContaining([
+              elements: [
                 expect.objectContaining({
                   type: "mrkdwn",
                   text: expect.stringContaining(
                     "*ID:* slack:C123:1700000000.001",
                   ),
                 }),
-                expect.objectContaining({
-                  type: "mrkdwn",
-                  text: "*Tokens:* 1.2k",
-                }),
-                expect.objectContaining({
-                  type: "mrkdwn",
-                  text: "*Time:* 842ms",
-                }),
-              ]),
+              ],
             },
           ],
           channel: "C123",
@@ -127,7 +119,7 @@ describe("oauth resume slack integration", () => {
     ]);
   }, 10_000);
 
-  it("uses cumulative session diagnostics for resumed reply footers", async () => {
+  it("uses correlation IDs for resumed reply footers", async () => {
     const { resumeAuthorizedRequest } =
       await import("@/chat/runtime/slack-resume");
     const { upsertAgentTurnSessionRecord } =
@@ -186,20 +178,12 @@ describe("oauth resume slack integration", () => {
             },
             {
               type: "context",
-              elements: expect.arrayContaining([
+              elements: [
                 {
                   type: "mrkdwn",
                   text: "*ID:* conversation-1",
                 },
-                {
-                  type: "mrkdwn",
-                  text: "*Tokens:* 1k",
-                },
-                {
-                  type: "mrkdwn",
-                  text: "*Time:* 1.5s",
-                },
-              ]),
+              ],
             },
           ],
         }),

--- a/packages/junior/tests/integration/slack/outbound-normalization-contract.test.ts
+++ b/packages/junior/tests/integration/slack/outbound-normalization-contract.test.ts
@@ -48,7 +48,6 @@ describe("Slack contract: outbound normalization", () => {
   it("passes block payloads with a top-level fallback text", async () => {
     const footer = buildSlackReplyFooter({
       conversationId: "slack:C123:1700000000.000100",
-      thinkingLevel: "low",
     });
 
     await postSlackMessage({
@@ -73,10 +72,6 @@ describe("Slack contract: outbound normalization", () => {
                 {
                   type: "mrkdwn",
                   text: "*ID:* slack:C123:1700000000.000100",
-                },
-                {
-                  type: "mrkdwn",
-                  text: "*Thinking:* low",
                 },
               ],
             },

--- a/packages/junior/tests/unit/slack/footer.test.ts
+++ b/packages/junior/tests/unit/slack/footer.test.ts
@@ -5,33 +5,16 @@ import {
 } from "@/chat/slack/footer";
 
 describe("buildSlackReplyFooter", () => {
-  it("returns compact footer items for available diagnostics", () => {
+  it("returns a compact footer item for the conversation ID", () => {
     expect(
       buildSlackReplyFooter({
-        conversationId: "slack:C123:1700000000.000100",
-        durationMs: 842,
-        thinkingLevel: "medium",
-        usage: {
-          totalTokens: 1234,
-        },
+        conversationId: "  slack:C123:1700000000.000100  ",
       }),
     ).toEqual({
       items: [
         {
           label: "ID",
           value: "slack:C123:1700000000.000100",
-        },
-        {
-          label: "Tokens",
-          value: "1.2k",
-        },
-        {
-          label: "Time",
-          value: "842ms",
-        },
-        {
-          label: "Thinking",
-          value: "medium",
         },
       ],
     });
@@ -55,122 +38,12 @@ describe("buildSlackReplyFooter", () => {
   it("omits the footer when no items are available", () => {
     expect(buildSlackReplyFooter({})).toBeUndefined();
   });
-
-  it("sums individual token counters when rendering the Tokens item", () => {
-    expect(
-      buildSlackReplyFooter({
-        usage: {
-          inputTokens: 100,
-          outputTokens: 50,
-          cachedInputTokens: 200,
-          cacheCreationTokens: 10,
-          totalTokens: 9999,
-        },
-      }),
-    ).toEqual({
-      items: [
-        {
-          label: "Tokens",
-          value: "360",
-        },
-      ],
-    });
-  });
-
-  it("falls back to totalTokens when no component counters are reported", () => {
-    expect(
-      buildSlackReplyFooter({
-        usage: { totalTokens: 1234 },
-      }),
-    ).toEqual({
-      items: [
-        {
-          label: "Tokens",
-          value: "1.2k",
-        },
-      ],
-    });
-  });
-
-  describe("formatSlackTokenCount", () => {
-    it("shows raw number for values under 1000", () => {
-      expect(buildSlackReplyFooter({ usage: { totalTokens: 542 } })).toEqual({
-        items: [{ label: "Tokens", value: "542" }],
-      });
-    });
-
-    it("shows k suffix for thousands", () => {
-      expect(buildSlackReplyFooter({ usage: { totalTokens: 54300 } })).toEqual({
-        items: [{ label: "Tokens", value: "54.3k" }],
-      });
-    });
-
-    it("drops trailing zero in k suffix", () => {
-      expect(buildSlackReplyFooter({ usage: { totalTokens: 2000 } })).toEqual({
-        items: [{ label: "Tokens", value: "2k" }],
-      });
-    });
-
-    it("shows m suffix for millions", () => {
-      expect(
-        buildSlackReplyFooter({ usage: { totalTokens: 1465542 } }),
-      ).toEqual({
-        items: [{ label: "Tokens", value: "1.47m" }],
-      });
-    });
-
-    it("drops trailing zeros in m suffix", () => {
-      expect(
-        buildSlackReplyFooter({ usage: { totalTokens: 2000000 } }),
-      ).toEqual({
-        items: [{ label: "Tokens", value: "2m" }],
-      });
-    });
-  });
-
-  describe("formatSlackDuration", () => {
-    it("shows ms for sub-second durations", () => {
-      expect(buildSlackReplyFooter({ durationMs: 450 })).toEqual({
-        items: [{ label: "Time", value: "450ms" }],
-      });
-    });
-
-    it("shows decimal seconds for 1-9s", () => {
-      expect(buildSlackReplyFooter({ durationMs: 1250 })).toEqual({
-        items: [{ label: "Time", value: "1.3s" }],
-      });
-    });
-
-    it("shows whole seconds for 10-59s", () => {
-      expect(buildSlackReplyFooter({ durationMs: 42000 })).toEqual({
-        items: [{ label: "Time", value: "42s" }],
-      });
-    });
-
-    it("shows minutes and seconds for 60s+", () => {
-      expect(buildSlackReplyFooter({ durationMs: 417000 })).toEqual({
-        items: [{ label: "Time", value: "6m57s" }],
-      });
-    });
-
-    it("shows only minutes when seconds is zero", () => {
-      expect(buildSlackReplyFooter({ durationMs: 120000 })).toEqual({
-        items: [{ label: "Time", value: "2m" }],
-      });
-    });
-  });
 });
 
 describe("buildSlackReplyBlocks", () => {
   it("renders the reply body as a markdown block plus a context footer", () => {
     const footer = buildSlackReplyFooter({
       conversationId: "slack:C123:1700000000.000100",
-      durationMs: 1250,
-      thinkingLevel: "high",
-      usage: {
-        inputTokens: 400,
-        outputTokens: 250,
-      },
     });
 
     expect(buildSlackReplyBlocks("Hello world", footer)).toEqual([
@@ -184,18 +57,6 @@ describe("buildSlackReplyBlocks", () => {
           {
             type: "mrkdwn",
             text: "*ID:* slack:C123:1700000000.000100",
-          },
-          {
-            type: "mrkdwn",
-            text: "*Tokens:* 650",
-          },
-          {
-            type: "mrkdwn",
-            text: "*Time:* 1.3s",
-          },
-          {
-            type: "mrkdwn",
-            text: "*Thinking:* high",
           },
         ],
       },

--- a/specs/slack-agent-delivery.md
+++ b/specs/slack-agent-delivery.md
@@ -152,7 +152,7 @@ Current rules:
 5. Persisted assistant conversation state must reflect the same finalized reply content the user saw, not provisional pre-tool text.
 6. Reply text must be rendered through the shared Slack output translator before delivery; raw Slack API writers do not own markdown translation rules.
 7. When Junior adds finalized reply footer metadata, it attaches that metadata as a Slack `context` block on the final text chunk only, while keeping the main reply text as the top-level fallback.
-8. Footer metadata is derived from structured reply diagnostics and correlation state. Conversation ID, selected thinking level, token totals, and turn duration may be shown when available; footer rendering must not scrape logs or spans after the fact.
+8. Footer metadata is derived from correlation state. Slack footers may show the conversation ID/link; selected thinking level, token totals, and turn duration are available through dashboard reporting instead of Slack-visible footer copy.
 9. Footer metadata is not an assistant-status surface and must not be used to convey in-flight progress.
 
 This is intentional. Slack-native text streaming may still exist as an adapter capability, but it is not part of Junior's correctness contract.

--- a/specs/slack-outbound-contract.md
+++ b/specs/slack-outbound-contract.md
@@ -56,8 +56,8 @@ Current rules:
 5. Channel permalink lookup is best effort and must not turn a successful post into a failed action.
 6. Slack message posts use `text` with `mrkdwn` enabled; callers do not switch between competing text fields ad hoc.
 7. When a caller supplies Slack blocks, outbound posting still includes the top-level `text` fallback for notifications and accessibility.
-8. Finalized reply footers that show correlation or diagnostic metadata are rendered as Slack `context` blocks attached through the shared outbound boundary, not assembled ad hoc by callers.
-9. Footer values such as token counts, turn duration, and the selected thinking-level bucket are passed as structured reply diagnostics into delivery. Outbound rendering formats those values for Slack; it does not derive them from tracing/logging side effects.
+8. Finalized reply footers that show correlation metadata are rendered as Slack `context` blocks attached through the shared outbound boundary, not assembled ad hoc by callers.
+9. Footer rendering may include the conversation ID/link. Token counts, turn duration, and the selected thinking-level bucket stay in dashboard reporting instead of Slack-visible footer copy.
 10. The conversation ID footer item may link through a trusted plugin `slackConversationLink` hook. The hook result must be an absolute HTTP(S) URL. When no trusted plugin supplies a link, Sentry conversation links remain the fallback when Sentry configuration is available.
 
 ### 4. Ephemeral Message Contract


### PR DESCRIPTION
Remove token counts, turn duration, and thinking level from finalized Slack
reply footers now that those diagnostics are available in dashboard reporting.
Slack footer context blocks now keep only the conversation ID/link so replies
stay less noisy.

**Footer Contract**

The Slack footer builder now ignores turn diagnostics and call sites no longer
compute cumulative usage/duration solely for footer rendering. Specs and
transport tests were updated to enforce ID-only footer blocks.
