### PR TITLE
docs(readme): add license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ Start here:
 | `@sentry/junior-scheduler`     | Scheduler plugin package for scheduled Junior tasks                          |
 | `@sentry/junior-sentry`        | Sentry plugin package for issue workflows                                    |
 | `@sentry/junior-vercel`        | Vercel plugin package for deployment and log investigation workflows         |
+
+## License
+
+Licensed under the [Apache License 2.0](LICENSE).


### PR DESCRIPTION
Adds a `## License` section to the README pointing to the Apache 2.0 `LICENSE` file. The repo has a license file but the README didn't reference it.

No logic changes; docs-only.

---
Action taken on behalf of immutable dcramer.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AD0AGXRT9XT5%3A1780791310.136119%22)