### PR TITLE
docs(readme): clarify junior-github package scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Start here:
 | `@sentry/junior-agent-browser` | Agent Browser plugin package for browser automation                          |
 | `@sentry/junior-dashboard`     | Authenticated dashboard package for Junior runtime diagnostics               |
 | `@sentry/junior-datadog`       | Datadog plugin package for observability workflows through Datadog's Pup CLI |
-| `@sentry/junior-github`        | GitHub plugin package for issue workflows                                    |
+| `@sentry/junior-github`        | GitHub plugin package for repository, code, and issue workflows              |
 | `@sentry/junior-hex`           | Hex plugin package for data warehouse query workflows                        |
 | `@sentry/junior-linear`        | Linear plugin package for issue workflows                                    |
 | `@sentry/junior-notion`        | Notion plugin package for page search workflows                              |


### PR DESCRIPTION
The `@sentry/junior-github` package description only mentioned issue workflows, but the plugin also handles repository inspection, code browsing, and pull request operations.

Updated the packages table to reflect the full scope.

**Verified:** docs-only change, content consistency review done — new description matches the actual plugin capabilities.

Action taken on behalf of immutable dcramer.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AD0AGXRT9XT5%3A1780871254.277129%22)