### PR TITLE
docs(readme): expand intro description with plugin context

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Junior is moving quickly. If you're interested in using it, we'd love to hear your feedback.**
 
-Junior is a Slack bot runtime powered by Hono.
+Junior is a Slack bot runtime powered by Hono. It connects to external tools through plugins, giving teams a single Slack-native interface for investigations, context summaries, and automated actions.
 
 Use it to investigate issues, summarize context, and take action from Slack with connected tools.
 


### PR DESCRIPTION
Adds a brief sentence to the opening paragraph clarifying that Junior connects to external tools via plugins, giving new readers a clearer sense of the architecture before they dive into the docs links.

**What changed:** One sentence added to the intro blurb in `README.md`.

**Verified:** Docs-only change; no automated check needed.

Action taken on behalf of immutable dcramer.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AD0AGXRT9XT5%3A1780871641.078909%22)