### PR TITLE
docs(readme): add example workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Junior is a Slack bot runtime powered by Hono.
 
 Use it to investigate issues, summarize context, and take action from Slack with connected tools.
 
+Example workflow: ask Junior to inspect a repo, open a GitHub issue, or draft a pull request directly from Slack.
+
 ## Documentation
 
 Canonical docs live at **https://junior.sentry.dev/**.


### PR DESCRIPTION
## Summary
- add a small README example showing the kinds of GitHub tasks Junior can handle from Slack

## Verification
- content review only
- `pnpm exec prettier --write README.md` *(failed: `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command "prettier" not found` in this clone)*

Action taken on behalf of immutable dcramer.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AD0AS1V2KPRA%3A1780891965.890639%22)
