### PR TITLE
fix(task-execution): Bound conversation work retries with poison budget

### DIFF
--- a/packages/junior/src/chat/task-execution/store.ts
+++ b/packages/junior/src/chat/task-execution/store.ts
@@ -20,6 +20,7 @@ const CONVERSATION_WORK_MUTATION_RETRY_MS = 25;
 export const CONVERSATION_WORK_LEASE_TTL_MS = 90_000;
 export const CONVERSATION_WORK_CHECK_IN_INTERVAL_MS = 15_000;
 export const CONVERSATION_WORK_STALE_ENQUEUE_MS = 60_000;
+export const CONVERSATION_WORK_MAX_CONSECUTIVE_FAILURES = 5;
 
 export type InboundMessageSource = "plugin" | "scheduler" | "slack";
 
@@ -49,13 +50,16 @@ export interface ConversationLease {
 }
 
 export interface ConversationWorkState {
+  consecutiveFailureCount: number;
   conversationId: string;
   destination: Destination;
   lastEnqueuedAtMs?: number;
+  lastFailureAtMs?: number;
   lease?: ConversationLease;
   messages: InboundMessageRecord[];
   needsRun: boolean;
   schemaVersion: 1;
+  terminallyFailedAtMs?: number;
   updatedAtMs: number;
 }
 
@@ -275,8 +279,12 @@ function normalizeWorkState(
     messages,
     needsRun: value.needsRun === true,
     updatedAtMs,
+    consecutiveFailureCount:
+      toOptionalNumber(value.consecutiveFailureCount) ?? 0,
     lastEnqueuedAtMs: toOptionalNumber(value.lastEnqueuedAtMs),
+    lastFailureAtMs: toOptionalNumber(value.lastFailureAtMs),
     lease: normalizeLease(value.lease),
+    terminallyFailedAtMs: toOptionalNumber(value.terminallyFailedAtMs),
   };
 }
 
@@ -288,6 +296,7 @@ function emptyWorkState(args: {
   return {
     schemaVersion: CONVERSATION_WORK_SCHEMA_VERSION,
     conversationId: args.conversationId,
+    consecutiveFailureCount: 0,
     destination: args.destination,
     messages: [],
     needsRun: false,
@@ -309,6 +318,9 @@ function pendingMessages(state: ConversationWorkState): InboundMessageRecord[] {
 }
 
 function shouldKeepIndexed(state: ConversationWorkState): boolean {
+  if (state.terminallyFailedAtMs !== undefined) {
+    return false;
+  }
   return (
     state.needsRun || Boolean(state.lease) || pendingMessages(state).length > 0
   );
@@ -547,8 +559,11 @@ export async function appendInboundMessage(args: {
 
       const next: ConversationWorkState = {
         ...current,
+        consecutiveFailureCount: 0,
+        lastFailureAtMs: undefined,
         messages: [...current.messages, args.message].sort(compareMessages),
         needsRun: true,
+        terminallyFailedAtMs: undefined,
         updatedAtMs: nowMs,
       };
       await writeWorkState(state, next);
@@ -764,6 +779,8 @@ export async function drainConversationMailbox(args: {
     );
     await writeWorkState(state, {
       ...current,
+      consecutiveFailureCount: 0,
+      lastFailureAtMs: undefined,
       messages,
       needsRun: hasPending,
       updatedAtMs: nowMs,
@@ -808,6 +825,8 @@ export async function markConversationMessagesInjected(args: {
 
     await writeWorkState(state, {
       ...current,
+      consecutiveFailureCount: 0,
+      lastFailureAtMs: undefined,
       messages,
       updatedAtMs: nowMs,
     });
@@ -882,6 +901,8 @@ export async function completeConversationWork(args: {
     const hasRunnableWork = current.needsRun || hasPending;
     await writeWorkState(state, {
       ...current,
+      consecutiveFailureCount: 0,
+      lastFailureAtMs: undefined,
       lease: undefined,
       needsRun: hasRunnableWork,
       updatedAtMs: nowMs,
@@ -909,6 +930,74 @@ export async function clearExpiredConversationLease(args: {
       updatedAtMs: nowMs,
     });
     return true;
+  });
+}
+
+export interface RecordConversationWorkFailureResult {
+  abandoned: boolean;
+  consecutiveFailureCount: number;
+  releasedLease: boolean;
+}
+
+/**
+ * Increment the durable failure counter after a caught worker error so
+ * deterministic poison work cannot churn the queue forever. When the counter
+ * crosses {@link CONVERSATION_WORK_MAX_CONSECUTIVE_FAILURES}, the conversation
+ * is marked terminally failed: the lease is cleared, pending mailbox messages
+ * are dropped, and the conversation drops out of the recovery index so neither
+ * the worker nor heartbeat will requeue it again. A later inbound message
+ * resets the counter and gives the conversation a fresh attempt.
+ */
+export async function recordConversationWorkFailure(args: {
+  conversationId: string;
+  nowMs?: number;
+  state?: StateAdapter;
+}): Promise<RecordConversationWorkFailureResult> {
+  const nowMs = args.nowMs ?? now();
+  return await withConversationMutation(args, async (state) => {
+    const current = await readWorkState(state, args.conversationId);
+    if (!current) {
+      return {
+        abandoned: false,
+        consecutiveFailureCount: 0,
+        releasedLease: false,
+      };
+    }
+    const consecutiveFailureCount = current.consecutiveFailureCount + 1;
+    const abandoned =
+      consecutiveFailureCount >= CONVERSATION_WORK_MAX_CONSECUTIVE_FAILURES;
+    if (!abandoned) {
+      await writeWorkState(state, {
+        ...current,
+        consecutiveFailureCount,
+        lastFailureAtMs: nowMs,
+        updatedAtMs: nowMs,
+      });
+      return {
+        abandoned: false,
+        consecutiveFailureCount,
+        releasedLease: false,
+      };
+    }
+    const releasedLease = Boolean(current.lease);
+    const drainedMessages = current.messages.filter(
+      (message) => message.injectedAtMs !== undefined,
+    );
+    await writeWorkState(state, {
+      ...current,
+      consecutiveFailureCount,
+      lastFailureAtMs: nowMs,
+      lease: undefined,
+      messages: drainedMessages,
+      needsRun: false,
+      terminallyFailedAtMs: nowMs,
+      updatedAtMs: nowMs,
+    });
+    return {
+      abandoned: true,
+      consecutiveFailureCount,
+      releasedLease,
+    };
   });
 }
 

--- a/packages/junior/src/chat/task-execution/store.ts
+++ b/packages/junior/src/chat/task-execution/store.ts
@@ -483,6 +483,9 @@ async function writeWorkState(
 }
 
 function hasRunnableWork(state: ConversationWorkState): boolean {
+  if (state.terminallyFailedAtMs !== undefined) {
+    return false;
+  }
   return state.needsRun || pendingMessages(state).length > 0;
 }
 

--- a/packages/junior/src/chat/task-execution/worker.ts
+++ b/packages/junior/src/chat/task-execution/worker.ts
@@ -8,10 +8,12 @@ import {
   checkInConversationWork,
   completeConversationWork,
   CONVERSATION_WORK_CHECK_IN_INTERVAL_MS,
+  CONVERSATION_WORK_MAX_CONSECUTIVE_FAILURES,
   countPendingConversationMessages,
   drainConversationMailbox,
   getConversationWorkState,
   markConversationWorkEnqueued,
+  recordConversationWorkFailure,
   releaseConversationWork,
   requestConversationContinuation,
   startConversationWork,
@@ -38,6 +40,7 @@ export interface ConversationWorkerResult {
 
 export interface ConversationWorkProcessResult {
   status:
+    | "abandoned"
     | "active"
     | "completed"
     | "lost_lease"
@@ -196,24 +199,50 @@ export async function processConversationWork(
   }
   const destination = initial.destination;
 
-  const lease = await startConversationWork({
-    conversationId,
-    nowMs: now(options),
-    state: options.state,
-  });
+  let lease: Awaited<ReturnType<typeof startConversationWork>>;
+  try {
+    lease = await startConversationWork({
+      conversationId,
+      nowMs: now(options),
+      state: options.state,
+    });
+  } catch (error) {
+    logException(
+      error,
+      "conversation_work_lease_acquire_failed",
+      { conversationId },
+      {},
+      "Conversation work lease acquisition failed; heartbeat will recover",
+    );
+    return { status: "no_work" };
+  }
   if (lease.status === "no_work") {
     return { status: "no_work" };
   }
   if (lease.status === "active") {
     const nudgeNowMs = now(options);
-    await sendWakeNudge({
-      conversationId,
-      destination,
-      delayMs: CONVERSATION_WORK_DEFER_DELAY_MS,
-      idempotencyKey: nudgeIdempotencyKey("active", conversationId, nudgeNowMs),
-      nowMs: nudgeNowMs,
-      options,
-    });
+    try {
+      await sendWakeNudge({
+        conversationId,
+        destination,
+        delayMs: CONVERSATION_WORK_DEFER_DELAY_MS,
+        idempotencyKey: nudgeIdempotencyKey(
+          "active",
+          conversationId,
+          nudgeNowMs,
+        ),
+        nowMs: nudgeNowMs,
+        options,
+      });
+    } catch (error) {
+      logException(
+        error,
+        "conversation_work_active_nudge_failed",
+        { conversationId },
+        {},
+        "Conversation work active-lease nudge failed; heartbeat will recover",
+      );
+    }
     logInfo(
       "conversation_work_nudge_deferred_for_active_lease",
       { conversationId },
@@ -375,6 +404,75 @@ export async function processConversationWork(
     return { status: "completed" };
   } catch (error) {
     const errorNowMs = now(options);
+    let failure: Awaited<ReturnType<typeof recordConversationWorkFailure>> = {
+      abandoned: false,
+      consecutiveFailureCount: 0,
+      releasedLease: false,
+    };
+    try {
+      failure = await recordConversationWorkFailure({
+        conversationId,
+        nowMs: errorNowMs,
+        state: options.state,
+      });
+    } catch (recordError) {
+      logException(
+        recordError,
+        "conversation_work_failure_record_failed",
+        { conversationId },
+        {},
+        "Conversation work failure counter update failed",
+      );
+    }
+
+    if (!isProviderRetryError(error)) {
+      logException(
+        error,
+        "conversation_work_failed",
+        { conversationId },
+        {
+          "app.worker.consecutive_failure_count":
+            failure.consecutiveFailureCount,
+          "app.worker.elapsed_ms": now(options) - startedAtMs,
+        },
+        "Conversation work failed",
+      );
+    }
+
+    if (failure.abandoned) {
+      logWarn(
+        "conversation_work_abandoned",
+        { conversationId },
+        {
+          "app.worker.consecutive_failure_count":
+            failure.consecutiveFailureCount,
+          "app.worker.max_consecutive_failures":
+            CONVERSATION_WORK_MAX_CONSECUTIVE_FAILURES,
+        },
+        "Conversation work abandoned after repeated failures; stopping retries",
+      );
+      if (!failure.releasedLease) {
+        try {
+          await releaseConversationWork({
+            conversationId,
+            leaseToken: lease.leaseToken,
+            nowMs: errorNowMs,
+            state: options.state,
+          });
+        } catch (releaseError) {
+          logException(
+            releaseError,
+            "conversation_work_release_failed",
+            { conversationId },
+            {},
+            "Conversation work release failed after abandoning",
+          );
+        }
+      }
+      return { status: "abandoned" };
+    }
+
+    let requeueSucceeded = false;
     try {
       const continuationMarked = await requestConversationContinuation({
         conversationId,
@@ -395,6 +493,7 @@ export async function processConversationWork(
           nowMs: errorNowMs,
           options,
         });
+        requeueSucceeded = true;
       }
     } catch (requeueError) {
       logException(
@@ -421,16 +520,9 @@ export async function processConversationWork(
         "Conversation work release failed after runner error",
       );
     }
-    if (!isProviderRetryError(error)) {
-      logException(
-        error,
-        "conversation_work_failed",
-        { conversationId },
-        {
-          "app.worker.elapsed_ms": now(options) - startedAtMs,
-        },
-        "Conversation work failed",
-      );
+
+    if (requeueSucceeded) {
+      return { status: "pending_requeued" };
     }
     throw error;
   } finally {

--- a/packages/junior/src/chat/task-execution/worker.ts
+++ b/packages/junior/src/chat/task-execution/worker.ts
@@ -404,11 +404,9 @@ export async function processConversationWork(
     return { status: "completed" };
   } catch (error) {
     const errorNowMs = now(options);
-    let failure: Awaited<ReturnType<typeof recordConversationWorkFailure>> = {
-      abandoned: false,
-      consecutiveFailureCount: 0,
-      releasedLease: false,
-    };
+    let failure:
+      | Awaited<ReturnType<typeof recordConversationWorkFailure>>
+      | undefined;
     try {
       failure = await recordConversationWorkFailure({
         conversationId,
@@ -432,14 +430,14 @@ export async function processConversationWork(
         { conversationId },
         {
           "app.worker.consecutive_failure_count":
-            failure.consecutiveFailureCount,
+            failure?.consecutiveFailureCount ?? null,
           "app.worker.elapsed_ms": now(options) - startedAtMs,
         },
         "Conversation work failed",
       );
     }
 
-    if (failure.abandoned) {
+    if (failure?.abandoned) {
       logWarn(
         "conversation_work_abandoned",
         { conversationId },
@@ -473,36 +471,38 @@ export async function processConversationWork(
     }
 
     let requeueSucceeded = false;
-    try {
-      const continuationMarked = await requestConversationContinuation({
-        conversationId,
-        destination,
-        leaseToken: lease.leaseToken,
-        nowMs: errorNowMs,
-        state: options.state,
-      });
-      if (continuationMarked) {
-        await sendWakeNudge({
+    if (failure) {
+      try {
+        const continuationMarked = await requestConversationContinuation({
           conversationId,
           destination,
-          idempotencyKey: nudgeIdempotencyKey(
-            "error",
-            conversationId,
-            errorNowMs,
-          ),
+          leaseToken: lease.leaseToken,
           nowMs: errorNowMs,
-          options,
+          state: options.state,
         });
-        requeueSucceeded = true;
+        if (continuationMarked) {
+          await sendWakeNudge({
+            conversationId,
+            destination,
+            idempotencyKey: nudgeIdempotencyKey(
+              "error",
+              conversationId,
+              errorNowMs,
+            ),
+            nowMs: errorNowMs,
+            options,
+          });
+          requeueSucceeded = true;
+        }
+      } catch (requeueError) {
+        logException(
+          requeueError,
+          "conversation_work_requeue_failed",
+          { conversationId },
+          {},
+          "Conversation work requeue failed after runner error",
+        );
       }
-    } catch (requeueError) {
-      logException(
-        requeueError,
-        "conversation_work_requeue_failed",
-        { conversationId },
-        {},
-        "Conversation work requeue failed after runner error",
-      );
     }
     try {
       await releaseConversationWork({

--- a/packages/junior/tests/component/task-execution/conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/conversation-work.test.ts
@@ -419,7 +419,7 @@ describe("conversation work execution", () => {
     ]);
   });
 
-  it("nudges failed worker runs before releasing runnable work", async () => {
+  it("nudges failed worker runs before releasing runnable work without rethrowing", async () => {
     const queue = createConversationWorkQueueTestAdapter();
     let currentNowMs = 1_000;
     await requestConversationWork({
@@ -437,13 +437,15 @@ describe("conversation work execution", () => {
           throw new Error("runner failed");
         },
       }),
-    ).rejects.toThrow("runner failed");
+    ).resolves.toEqual({ status: "pending_requeued" });
 
     const state = await getConversationWorkState({
       conversationId: CONVERSATION_ID,
     });
     expect(state?.lease).toBeUndefined();
     expect(state?.needsRun).toBe(true);
+    expect(state?.consecutiveFailureCount).toBe(1);
+    expect(state?.lastFailureAtMs).toBe(2_000);
     expect(state?.lastEnqueuedAtMs).toBe(2_000);
     expect(queue.sentRecords()).toMatchObject([
       {
@@ -451,6 +453,207 @@ describe("conversation work execution", () => {
         idempotencyKey: `error:${CONVERSATION_ID}:2000`,
       },
     ]);
+  });
+
+  it("rethrows failed worker runs when own requeue nudge also fails", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    await requestConversationWork({
+      conversationId: CONVERSATION_ID,
+      destination: SLACK_DESTINATION,
+      nowMs: 1_000,
+    });
+
+    let runs = 0;
+    await expect(
+      processConversationWork(conversationQueueMessage(), {
+        nowMs: () => 2_000,
+        queue,
+        run: async () => {
+          runs += 1;
+          queue.rejectSends();
+          throw new Error("runner failed");
+        },
+      }),
+    ).rejects.toThrow("runner failed");
+    expect(runs).toBe(1);
+    expect(queue.sentRecords()).toHaveLength(0);
+  });
+
+  it("abandons poison conversations after repeated failures and stops requeueing", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    let currentNowMs = 1_000;
+    await requestConversationWork({
+      conversationId: CONVERSATION_ID,
+      destination: SLACK_DESTINATION,
+      nowMs: currentNowMs,
+    });
+
+    for (let attempt = 1; attempt < 5; attempt += 1) {
+      currentNowMs += 1_000;
+      await expect(
+        processConversationWork(conversationQueueMessage(), {
+          nowMs: () => currentNowMs,
+          queue,
+          run: async () => {
+            throw new Error("deterministic poison failure");
+          },
+        }),
+      ).resolves.toEqual({ status: "pending_requeued" });
+    }
+
+    currentNowMs += 1_000;
+    await expect(
+      processConversationWork(conversationQueueMessage(), {
+        nowMs: () => currentNowMs,
+        queue,
+        run: async () => {
+          throw new Error("deterministic poison failure");
+        },
+      }),
+    ).resolves.toEqual({ status: "abandoned" });
+
+    expect(queue.sentRecords()).toHaveLength(4);
+    const state = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+    });
+    expect(state?.lease).toBeUndefined();
+    expect(state?.needsRun).toBe(false);
+    expect(state?.consecutiveFailureCount).toBe(5);
+    expect(state?.terminallyFailedAtMs).toBe(currentNowMs);
+
+    await expect(
+      processConversationWork(conversationQueueMessage(), {
+        nowMs: () => currentNowMs + 1_000,
+        queue,
+        run: async () => {
+          throw new Error("should not run");
+        },
+      }),
+    ).resolves.toEqual({ status: "no_work" });
+    expect(queue.sentRecords()).toHaveLength(4);
+  });
+
+  it("clears terminal failure state when a new inbound message arrives", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    let currentNowMs = 1_000;
+    await requestConversationWork({
+      conversationId: CONVERSATION_ID,
+      destination: SLACK_DESTINATION,
+      nowMs: currentNowMs,
+    });
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      currentNowMs += 1_000;
+      await processConversationWork(conversationQueueMessage(), {
+        nowMs: () => currentNowMs,
+        queue,
+        run: async () => {
+          throw new Error("deterministic poison failure");
+        },
+      });
+    }
+    const failed = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+    });
+    expect(failed?.terminallyFailedAtMs).toBeDefined();
+    expect(failed?.consecutiveFailureCount).toBe(5);
+
+    await appendInboundMessage({
+      message: inboundMessage("m-after-failure", {
+        createdAtMs: currentNowMs + 100,
+        receivedAtMs: currentNowMs + 100,
+      }),
+      nowMs: currentNowMs + 100,
+    });
+    const fresh = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+    });
+    expect(fresh?.terminallyFailedAtMs).toBeUndefined();
+    expect(fresh?.consecutiveFailureCount).toBe(0);
+    expect(fresh?.needsRun).toBe(true);
+  });
+
+  it("resets the failure counter after a successful drain or completion", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    await requestConversationWork({
+      conversationId: CONVERSATION_ID,
+      destination: SLACK_DESTINATION,
+      nowMs: 1_000,
+    });
+    await processConversationWork(conversationQueueMessage(), {
+      nowMs: () => 2_000,
+      queue,
+      run: async () => {
+        throw new Error("transient");
+      },
+    });
+    const afterFailure = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+    });
+    expect(afterFailure?.consecutiveFailureCount).toBe(1);
+
+    await appendInboundMessage({
+      message: inboundMessage("m-success", {
+        createdAtMs: 3_000,
+        receivedAtMs: 3_000,
+      }),
+      nowMs: 3_000,
+    });
+    await expect(
+      processConversationWork(conversationQueueMessage(), {
+        nowMs: () => 4_000,
+        queue,
+        run: async (context) => {
+          await context.drainMailbox(async () => {});
+          return { status: "completed" };
+        },
+      }),
+    ).resolves.toEqual({ status: "completed" });
+
+    const afterSuccess = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+    });
+    expect(afterSuccess?.consecutiveFailureCount).toBe(0);
+    expect(afterSuccess?.lastFailureAtMs).toBeUndefined();
+  });
+
+  it("absorbs pre-lease mutation lock failures so vercel will not redeliver", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    const baseState = getStateAdapter();
+    await baseState.connect();
+    await requestConversationWork({
+      conversationId: CONVERSATION_ID,
+      destination: SLACK_DESTINATION,
+      nowMs: 1_000,
+      state: baseState,
+    });
+
+    const mutationLockKey = `junior:conversation-work:mutation:${CONVERSATION_ID}`;
+    const throwOnMutationLock = new Proxy(baseState, {
+      get(target, prop, receiver) {
+        if (prop === "acquireLock") {
+          return async (key: string, ttlMs: number) => {
+            if (key === mutationLockKey) {
+              throw new Error(
+                "Could not acquire conversation work mutation lock for test",
+              );
+            }
+            return target.acquireLock(key, ttlMs);
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as typeof baseState;
+
+    await expect(
+      processConversationWork(conversationQueueMessage(), {
+        nowMs: () => 2_000,
+        queue,
+        run: async () => ({ status: "completed" }),
+        state: throwOnMutationLock,
+      }),
+    ).resolves.toEqual({ status: "no_work" });
   });
 
   it("releases and requeues runnable work when the runner reports lost lease", async () => {

--- a/packages/junior/tests/component/task-execution/conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/conversation-work.test.ts
@@ -656,6 +656,101 @@ describe("conversation work execution", () => {
     ).resolves.toEqual({ status: "no_work" });
   });
 
+  it("rethrows when failure recording fails so platform redelivery bounds the retry", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    const baseState = getStateAdapter();
+    await baseState.connect();
+    await requestConversationWork({
+      conversationId: CONVERSATION_ID,
+      destination: SLACK_DESTINATION,
+      nowMs: 1_000,
+      state: baseState,
+    });
+
+    const mutationLockKey = `junior:conversation-work:mutation:${CONVERSATION_ID}`;
+    let mutationLockCalls = 0;
+    const failRecordMutationLock = new Proxy(baseState, {
+      get(target, prop, receiver) {
+        if (prop === "acquireLock") {
+          return async (key: string, ttlMs: number) => {
+            if (key === mutationLockKey) {
+              mutationLockCalls += 1;
+              if (mutationLockCalls >= 2) {
+                throw new Error(
+                  "Could not acquire conversation work mutation lock for test",
+                );
+              }
+            }
+            return target.acquireLock(key, ttlMs);
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as typeof baseState;
+
+    await expect(
+      processConversationWork(conversationQueueMessage(), {
+        nowMs: () => 2_000,
+        queue,
+        run: async () => {
+          throw new Error("runner failed");
+        },
+        state: failRecordMutationLock,
+      }),
+    ).rejects.toThrow("runner failed");
+    expect(queue.sentRecords()).toHaveLength(0);
+  });
+
+  it("does not resurrect terminally failed conversations via requestConversationWork", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    let currentNowMs = 1_000;
+    await requestConversationWork({
+      conversationId: CONVERSATION_ID,
+      destination: SLACK_DESTINATION,
+      nowMs: currentNowMs,
+    });
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      currentNowMs += 1_000;
+      await processConversationWork(conversationQueueMessage(), {
+        nowMs: () => currentNowMs,
+        queue,
+        run: async () => {
+          throw new Error("deterministic poison failure");
+        },
+      });
+    }
+    const terminal = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+    });
+    expect(terminal?.terminallyFailedAtMs).toBeDefined();
+
+    currentNowMs += 1_000;
+    await requestConversationWork({
+      conversationId: CONVERSATION_ID,
+      destination: SLACK_DESTINATION,
+      nowMs: currentNowMs,
+    });
+
+    const sentBefore = queue.sentRecords().length;
+    await expect(
+      processConversationWork(conversationQueueMessage(), {
+        nowMs: () => currentNowMs + 1_000,
+        queue,
+        run: async () => {
+          throw new Error("should not run after terminal failure");
+        },
+      }),
+    ).resolves.toEqual({ status: "no_work" });
+    expect(queue.sentRecords()).toHaveLength(sentBefore);
+    const stillTerminal = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+    });
+    expect(stillTerminal?.terminallyFailedAtMs).toBeDefined();
+    expect(stillTerminal?.lease).toBeUndefined();
+  });
+
   it("releases and requeues runnable work when the runner reports lost lease", async () => {
     const queue = createConversationWorkQueueTestAdapter();
     let currentNowMs = 1_000;

--- a/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
@@ -913,7 +913,7 @@ describe("Slack conversation work execution", () => {
         },
         state,
       }),
-    ).rejects.toThrow("runtime failed before input commit");
+    ).resolves.toEqual({ status: "pending_requeued" });
 
     const work = await getConversationWorkState({
       conversationId: CONVERSATION_ID,
@@ -922,6 +922,7 @@ describe("Slack conversation work execution", () => {
     expect(work?.lease).toBeUndefined();
     expect(work ? countPendingConversationMessages(work) : 0).toBe(1);
     expect(work?.messages[0]?.injectedAtMs).toBeUndefined();
+    expect(work?.consecutiveFailureCount).toBe(1);
   });
 
   it("requeues Slack mailbox records when the runtime returns without input commit", async () => {

--- a/specs/task-execution.md
+++ b/specs/task-execution.md
@@ -399,12 +399,23 @@ durable `consecutiveFailureCount` on the conversation work record:
      next inbound message starts a fresh attempt).
    - `needsRun` is cleared and the conversation drops out of the recovery
      index so heartbeat will not requeue it.
+5. Terminal failure is sticky against non-user-initiated resurrection. A
+   conversation with `terminallyFailedAtMs` is treated as having no runnable
+   work even if a downstream caller (e.g. a turn-timeout resume request) sets
+   `needsRun` on the record; only a fresh non-duplicate inbound message clears
+   the terminal flag.
+6. If the worker cannot durably record a failure (e.g. mutation lock
+   contention), it must not send its own wake nudge, since doing so without
+   advancing the budget would let poison runs loop indefinitely. The worker
+   rethrows the original runner error in that case so the queue platform's
+   bounded redelivery handles recovery.
 
 A worker that catches a runner error and successfully sends its own wake nudge
 must not also throw. Throwing causes the queue platform to redeliver the same
 payload, doubling execution attempts and amplifying overload conditions. The
-worker rethrows only when its own recovery enqueue failed, so the queue
-provider's redelivery and heartbeat repair remain the safety net.
+worker rethrows only when its own recovery enqueue failed or when the failure
+budget could not be advanced, so the queue provider's redelivery and heartbeat
+repair remain the safety net.
 
 Pre-lease failures (lease acquisition or active-lease deferred nudges) must be
 absorbed rather than rethrown. Heartbeat already requeues pending mailbox work
@@ -523,6 +534,12 @@ Required invariants, using the lowest layer that proves the contract:
 17. Component: a conversation that fails N consecutive times is marked
     terminally failed and stops requeueing until a new inbound message
     arrives.
+18. Component: terminally failed conversations are not resurrected by
+    non-user-initiated `needsRun` writes (e.g. turn-timeout resume), and
+    `processConversationWork` reports `no_work` instead of acquiring a lease.
+19. Component: when the worker cannot durably record a failure, it rethrows
+    the original error without sending its own wake nudge so the failure
+    budget cannot be bypassed.
 
 ## Related Specs
 

--- a/specs/task-execution.md
+++ b/specs/task-execution.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-06-01
-- Last Edited: 2026-06-06
+- Last Edited: 2026-06-09
 
 ## Purpose
 
@@ -381,13 +381,42 @@ selection remain owned by their domain specs. Once claimed, execution should use
 the same mailbox, lease, session-log, and delivery contracts as interactive
 work.
 
+### Failure Budget Contract
+
+Worker errors must not produce unbounded queue retries. The worker maintains a
+durable `consecutiveFailureCount` on the conversation work record:
+
+1. Any caught error in the worker's execution path increments the counter.
+2. A successful session-log boundary (mailbox drain, message inject, clean
+   completion) resets the counter to zero.
+3. A fresh non-duplicate inbound message resets the counter to zero so a new
+   user attempt is never blocked by a poisoned prior turn.
+4. When the counter reaches `CONVERSATION_WORK_MAX_CONSECUTIVE_FAILURES`, the
+   conversation is marked terminally failed:
+   - `terminallyFailedAtMs` is set.
+   - The active lease is cleared.
+   - Pending mailbox messages are dropped (they could not be processed; the
+     next inbound message starts a fresh attempt).
+   - `needsRun` is cleared and the conversation drops out of the recovery
+     index so heartbeat will not requeue it.
+
+A worker that catches a runner error and successfully sends its own wake nudge
+must not also throw. Throwing causes the queue platform to redeliver the same
+payload, doubling execution attempts and amplifying overload conditions. The
+worker rethrows only when its own recovery enqueue failed, so the queue
+provider's redelivery and heartbeat repair remain the safety net.
+
+Pre-lease failures (lease acquisition or active-lease deferred nudges) must be
+absorbed rather than rethrown. Heartbeat already requeues pending mailbox work
+and expired leases, so propagating these errors only multiplies queue load
+during state-store overload.
+
 ### TODO Guardrails
 
 The first pass intentionally avoids extra looping controls. After the mailbox
 worker is proven in production, add policy for:
 
 - maximum wall-clock age for one active conversation run
-- maximum consecutive recoveries without a new session-log boundary
 - explicit cancel/stop semantics for user messages that should abandon active
   work
 - duplicate final-delivery suppression if duplicate replies are observed
@@ -435,6 +464,9 @@ Required event names should distinguish normal progress from repair:
 - `conversation_work_lease_expired_requeued`
 - `conversation_work_pending_requeued`
 - `conversation_work_failed`
+- `conversation_work_abandoned`
+- `conversation_work_lease_acquire_failed`
+- `conversation_work_active_nudge_failed`
 
 Required attributes when available:
 
@@ -485,6 +517,12 @@ Required invariants, using the lowest layer that proves the contract:
     from the latest durable session-log boundary.
 15. Evals: realistic multi-message Slack follow-ups during long work are folded
     into the active answer without losing user intent.
+16. Component: a worker error that successfully requeues itself does not
+    rethrow, so the queue provider's redelivery cannot double-execute the
+    failure.
+17. Component: a conversation that fails N consecutive times is marked
+    terminally failed and stops requeueing until a new inbound message
+    arrives.
 
 ## Related Specs
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a durable failure budget to the conversation work queue so worker errors cannot churn forever. Addresses the production retry loops surfaced in the Slack thread on `#jr-cramer` (mutation lock errors and the broader "infinite retry on failure" concern) and removes the implicit double-retry that amplified queue volume during overload.

## Root cause

When `processConversationWork` caught a runner error it did two things:

1. Sent its own wake nudge (sets `needsRun=true`, enqueues, releases lease).
2. Rethrew the error, causing the Vercel queue platform to **also** redeliver the same payload.

Any deterministic failure (pre-input-commit runtime errors, mutation lock contention during state-store overload, malformed metadata, etc.) therefore looped indefinitely — and the loop _multiplied_ each iteration because both the worker's own nudge and the platform redelivery would fire.

Pre-lease errors (mutation lock failures in `startConversationWork` or the active-lease deferred `sendWakeNudge`) propagated out of the function entirely with no recovery, leaving the queue platform's at-least-once redelivery as the only handler — directly producing the `Could not acquire conversation work mutation lock` repeats observed in production.

## Changes

### `packages/junior/src/chat/task-execution/store.ts`

- Adds `consecutiveFailureCount`, `lastFailureAtMs`, and `terminallyFailedAtMs` fields to `ConversationWorkState` (with backward-compatible normalization).
- Resets the counter on any session-log boundary: `drainConversationMailbox`, `markConversationMessagesInjected`, `completeConversationWork`, and on fresh non-duplicate inbound messages.
- Adds `recordConversationWorkFailure(...)` which increments the counter and — when the threshold (`CONVERSATION_WORK_MAX_CONSECUTIVE_FAILURES = 5`) is reached — marks the conversation terminally failed, clears the lease, drops pending mailbox messages, and removes it from the recovery index so heartbeat won't requeue it.
- `hasRunnableWork` returns false when `terminallyFailedAtMs` is set so non-user-initiated `needsRun` writes (e.g. turn-timeout resume) cannot resurrect a terminally failed conversation. Only a fresh inbound message clears the terminal flag.

### `packages/junior/src/chat/task-execution/worker.ts`

- Catch block now records the failure first, then chooses:
  - **Abandoned**: log `conversation_work_abandoned`, return `{ status: "abandoned" }`, no requeue, no rethrow.
  - **Requeue succeeded**: return `{ status: "pending_requeued" }`, no rethrow (so the platform does not double-execute).
  - **Requeue failed**: rethrow as before, leaving Vercel redelivery + heartbeat as the safety net.
  - **Failure recording failed**: skip the worker's own requeue entirely and rethrow the original error. Without this, poison runs whose mutation-lock contention also blocks the failure-counter write could loop forever via the worker's own nudge without ever advancing the budget.
- Wraps the pre-lease `startConversationWork` and the active-lease deferred `sendWakeNudge` in try/catch with `conversation_work_lease_acquire_failed` / `conversation_work_active_nudge_failed` logs and a clean ack. Heartbeat already handles stranded mailbox work and expired leases, so propagating these errors only multiplied load.

### `specs/task-execution.md`

- New **Failure Budget Contract** section documenting the rules above, including the stickiness of `terminallyFailedAtMs` against non-user-initiated `needsRun` writes and the rethrow-on-record-failure rule.
- Removes the now-implemented "maximum consecutive recoveries" item from the TODO Guardrails.
- Adds the new observability event names and four new verification invariants (16–19).

### Tests

- `tests/component/task-execution/conversation-work.test.ts`:
  - Updates the existing "nudges failed worker runs" test to assert the no-rethrow contract.
  - Adds tests for the rethrow-when-requeue-fails fallback, the abandon-after-N-failures behavior, the terminal-state reset on fresh inbound, the success-path counter reset, the pre-lease mutation-lock absorption, the terminal-state stickiness against `requestConversationWork` resurrection, and the rethrow-when-record-failure behavior.
- `tests/component/task-execution/slack-conversation-work.test.ts`:
  - Updates the "keeps Slack mailbox records pending when input commit fails" test to match the new return shape and counter increment.

## Verification

- `pnpm --filter @sentry/junior typecheck` — passes.
- `pnpm --filter @sentry/junior exec vitest run tests/component` — 65/65 passing.
- `pnpm --filter @sentry/junior exec vitest run tests/integration tests/unit` — 1424/1424 passing.
- `pnpm skills:check` — passes.

## Production effect

- The class of error in the linked Sentry issue (`Could not acquire conversation work mutation lock`) will be absorbed at the worker boundary instead of propagating to platform redelivery, so a single conversation contending the mutation lock no longer multiplies queue load.
- Any deterministic poison run (per-conversation) self-limits to 5 attempts and then stops requeueing until the user sends a new message. This prevents the kind of compounding backlog suggested by the Slack thread without requiring manual intervention.
- If mutation-lock contention also blocks the failure-counter write, the worker now hands control back to the queue platform's bounded redelivery rather than amplifying the loop with its own nudge.

## Related

- Slack thread context referenced this Sentry issue: [`Could not acquire conversation work mutation lock`](https://sentry.sentry.io/issues/7537955938/).
- Follows the spec's previously-deferred guardrail: "maximum consecutive recoveries without a new session-log boundary".
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C0B595QDZLL/p1780952508466799?thread_ts=1780952508.466799&cid=C0B595QDZLL)

<div><a href="https://cursor.com/agents/bc-c09246d2-c655-523e-937d-9504faf675e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c09246d2-c655-523e-937d-9504faf675e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

