### PR TITLE
fix(task-execution): Ack rejected queue messages

### DIFF
--- a/packages/junior/src/chat/task-execution/queue-signing.ts
+++ b/packages/junior/src/chat/task-execution/queue-signing.ts
@@ -5,13 +5,27 @@ import type { ConversationQueueMessage } from "./queue";
 const CONVERSATION_WORK_QUEUE_SIGNATURE_CONTEXT =
   "junior.conversation_work_queue.v1";
 const CONVERSATION_WORK_QUEUE_SIGNATURE_VERSION = "v1";
-const CONVERSATION_WORK_QUEUE_SIGNATURE_MAX_SKEW_MS = 60 * 60 * 1000;
+export const CONVERSATION_WORK_QUEUE_SIGNATURE_MAX_SKEW_MS = 60 * 60 * 1000;
 
 interface SignedConversationQueueMessage extends ConversationQueueMessage {
   signature: string;
   signatureVersion: typeof CONVERSATION_WORK_QUEUE_SIGNATURE_VERSION;
   signedAtMs: number;
 }
+
+export type ConversationQueueMessageVerificationResult =
+  | {
+      message: ConversationQueueMessage;
+      status: "verified";
+    }
+  | {
+      reason: "expired" | "malformed" | "signature_mismatch";
+      status: "rejected";
+    }
+  | {
+      reason: "invalid_clock" | "missing_secret";
+      status: "unavailable";
+    };
 
 function getConversationWorkQueueSecret(): string | undefined {
   return process.env.JUNIOR_SECRET?.trim() || undefined;
@@ -97,30 +111,48 @@ export function signConversationQueueMessage(
   };
 }
 
+/** Explain whether a queue payload is verified, rejected, or temporarily unverifiable. */
+export function verifyConversationQueueMessage(
+  value: unknown,
+  nowMs = Date.now(),
+): ConversationQueueMessageVerificationResult {
+  const message = parseSignedConversationQueueMessage(value);
+  if (!message) {
+    return { status: "rejected", reason: "malformed" };
+  }
+  const secret = getConversationWorkQueueSecret();
+  if (!secret) {
+    return { status: "unavailable", reason: "missing_secret" };
+  }
+  if (!Number.isFinite(nowMs)) {
+    return { status: "unavailable", reason: "invalid_clock" };
+  }
+  if (
+    Math.abs(nowMs - message.signedAtMs) >
+    CONVERSATION_WORK_QUEUE_SIGNATURE_MAX_SKEW_MS
+  ) {
+    return { status: "rejected", reason: "expired" };
+  }
+
+  const expected = signPayload(message, message.signedAtMs, secret);
+  if (!timingSafeMatch(expected, message.signature)) {
+    return { status: "rejected", reason: "signature_mismatch" };
+  }
+
+  return {
+    status: "verified",
+    message: {
+      conversationId: message.conversationId,
+      destination: message.destination,
+    },
+  };
+}
+
 /** Verify a signed conversation queue payload from the Vercel Queue callback. */
 export function verifySignedConversationQueueMessage(
   value: unknown,
   nowMs = Date.now(),
 ): ConversationQueueMessage | undefined {
-  const message = parseSignedConversationQueueMessage(value);
-  const secret = getConversationWorkQueueSecret();
-  if (
-    !message ||
-    !secret ||
-    !Number.isFinite(nowMs) ||
-    Math.abs(nowMs - message.signedAtMs) >
-      CONVERSATION_WORK_QUEUE_SIGNATURE_MAX_SKEW_MS
-  ) {
-    return undefined;
-  }
-
-  const expected = signPayload(message, message.signedAtMs, secret);
-  if (!timingSafeMatch(expected, message.signature)) {
-    return undefined;
-  }
-
-  return {
-    conversationId: message.conversationId,
-    destination: message.destination,
-  };
+  const result = verifyConversationQueueMessage(value, nowMs);
+  return result.status === "verified" ? result.message : undefined;
 }

--- a/packages/junior/src/chat/task-execution/queue.ts
+++ b/packages/junior/src/chat/task-execution/queue.ts
@@ -5,6 +5,36 @@ export interface ConversationQueueMessage {
   destination: Destination;
 }
 
+export type ConversationQueueMessageRejectReason =
+  | "destination_mismatch"
+  | "expired"
+  | "malformed"
+  | "signature_mismatch"
+  | "unauthorized";
+
+export class ConversationQueueMessageRejectedError extends Error {
+  conversationId?: string;
+  reason: ConversationQueueMessageRejectReason;
+
+  constructor(
+    reason: ConversationQueueMessageRejectReason,
+    message: string,
+    options: { conversationId?: string } = {},
+  ) {
+    super(message);
+    this.name = "ConversationQueueMessageRejectedError";
+    this.reason = reason;
+    this.conversationId = options.conversationId;
+  }
+}
+
+/** Return whether a queue payload was permanently rejected at the message boundary. */
+export function isConversationQueueMessageRejectedError(
+  error: unknown,
+): error is ConversationQueueMessageRejectedError {
+  return error instanceof ConversationQueueMessageRejectedError;
+}
+
 export interface ConversationQueueSendOptions {
   delayMs?: number;
   idempotencyKey?: string;

--- a/packages/junior/src/chat/task-execution/vercel-callback.ts
+++ b/packages/junior/src/chat/task-execution/vercel-callback.ts
@@ -2,12 +2,20 @@ import {
   handleCallback,
   QueueClient,
   registerDevConsumer,
+  type MessageMetadata,
+  type RetryDirective,
 } from "@vercel/queue";
 import type { StateAdapter } from "chat";
 import { getChatConfig } from "@/chat/config";
 import { parseDestination } from "@/chat/destination";
+import { logWarn } from "@/chat/logging";
 import { runWithTurnRequestDeadline } from "@/chat/runtime/request-deadline";
-import type { ConversationQueueMessage, ConversationWorkQueue } from "./queue";
+import {
+  ConversationQueueMessageRejectedError,
+  isConversationQueueMessageRejectedError,
+  type ConversationQueueMessage,
+  type ConversationWorkQueue,
+} from "./queue";
 import {
   getVercelConversationWorkQueue,
   resolveConversationWorkQueueTopic,
@@ -18,7 +26,7 @@ import {
   type ConversationWorkerResult,
   type ConversationWorkerContext,
 } from "./worker";
-import { verifySignedConversationQueueMessage } from "./queue-signing";
+import { verifyConversationQueueMessage } from "./queue-signing";
 
 export const CONVERSATION_WORK_VISIBILITY_TIMEOUT_BUFFER_SECONDS = 30;
 export const CONVERSATION_WORK_DEV_CONSUMER_GROUP =
@@ -92,13 +100,44 @@ async function handleConversationQueueMessage(
   message: unknown,
   options: VercelConversationWorkCallbackOptions,
 ): Promise<void> {
-  const verified = verifySignedConversationQueueMessage(message);
-  if (!verified) {
-    throw new Error("Unauthorized conversation queue message");
+  const verification = verifyConversationQueueMessage(message);
+  if (verification.status === "rejected") {
+    throw new ConversationQueueMessageRejectedError(
+      verification.reason,
+      "Unauthorized conversation queue message",
+    );
+  }
+  if (verification.status === "unavailable") {
+    throw new Error(
+      `Conversation queue message verification unavailable: ${verification.reason}`,
+    );
   }
   await runWithTurnRequestDeadline(() =>
-    processConversationQueueMessage(verified, options),
+    processConversationQueueMessage(verification.message, options),
   );
+}
+
+/** Acknowledge permanently rejected queue messages while preserving normal retries. */
+function handleConversationQueueRetry(
+  error: unknown,
+  metadata: MessageMetadata,
+): RetryDirective | undefined {
+  if (!isConversationQueueMessageRejectedError(error)) {
+    return undefined;
+  }
+  logWarn(
+    "conversation_queue_message_rejected",
+    error.conversationId ? { conversationId: error.conversationId } : {},
+    {
+      "app.queue.consumer_group": metadata.consumerGroup,
+      "app.queue.delivery_count": metadata.deliveryCount,
+      "app.queue.message_id": metadata.messageId,
+      "app.queue.reject_reason": error.reason,
+      "app.queue.topic_name": metadata.topicName,
+    },
+    "Conversation queue message rejected without retry",
+  );
+  return { acknowledge: true };
 }
 
 /** Create the Vercel Queue push callback for conversation work nudges. */
@@ -108,6 +147,7 @@ export function createVercelConversationWorkCallback(
   return handleCallback(
     (message: unknown) => handleConversationQueueMessage(message, options),
     {
+      retry: handleConversationQueueRetry,
       visibilityTimeoutSeconds:
         options.visibilityTimeoutSeconds ??
         resolveConversationWorkVisibilityTimeoutSeconds(),
@@ -128,6 +168,7 @@ export function registerVercelConversationWorkDevConsumer(
     consumerGroup: CONVERSATION_WORK_DEV_CONSUMER_GROUP,
     handler: (message: unknown) =>
       handleConversationQueueMessage(message, options),
+    retry: handleConversationQueueRetry,
     topic: resolveConversationWorkQueueTopic(options),
     visibilityTimeoutSeconds:
       options.visibilityTimeoutSeconds ??

--- a/packages/junior/src/chat/task-execution/vercel-queue.ts
+++ b/packages/junior/src/chat/task-execution/vercel-queue.ts
@@ -6,9 +6,14 @@ import type {
   ConversationQueueSendResult,
   ConversationWorkQueue,
 } from "./queue";
-import { signConversationQueueMessage } from "./queue-signing";
+import {
+  CONVERSATION_WORK_QUEUE_SIGNATURE_MAX_SKEW_MS,
+  signConversationQueueMessage,
+} from "./queue-signing";
 
 export const DEFAULT_CONVERSATION_WORK_QUEUE_TOPIC = "junior_conversation_work";
+export const CONVERSATION_WORK_QUEUE_RETENTION_SECONDS =
+  CONVERSATION_WORK_QUEUE_SIGNATURE_MAX_SKEW_MS / 1000;
 
 interface QueueSender {
   send<T = unknown>(
@@ -65,7 +70,9 @@ export function createVercelConversationWorkQueue(
         {
           idempotencyKey: sendOptions?.idempotencyKey,
           delaySeconds: toDelaySeconds(sendOptions),
-          retentionSeconds: options.retentionSeconds,
+          retentionSeconds:
+            options.retentionSeconds ??
+            CONVERSATION_WORK_QUEUE_RETENTION_SECONDS,
         },
       );
       return result.messageId ? { messageId: result.messageId } : {};

--- a/packages/junior/src/chat/task-execution/worker.ts
+++ b/packages/junior/src/chat/task-execution/worker.ts
@@ -3,7 +3,11 @@ import type { Destination } from "@sentry/junior-plugin-api";
 import { sameDestination } from "@/chat/destination";
 import { logException, logInfo, logWarn } from "@/chat/logging";
 import { isProviderRetryError } from "@/chat/services/provider-retry";
-import type { ConversationQueueMessage, ConversationWorkQueue } from "./queue";
+import {
+  ConversationQueueMessageRejectedError,
+  type ConversationQueueMessage,
+  type ConversationWorkQueue,
+} from "./queue";
 import {
   checkInConversationWork,
   completeConversationWork,
@@ -193,8 +197,10 @@ export async function processConversationWork(
     return { status: "no_work" };
   }
   if (!sameDestination(initial.destination, message.destination)) {
-    throw new Error(
+    throw new ConversationQueueMessageRejectedError(
+      "destination_mismatch",
       `Conversation work queue destination changed for ${conversationId}`,
+      { conversationId },
     );
   }
   const destination = initial.destination;

--- a/packages/junior/tests/component/task-execution/conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/conversation-work.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { recoverConversationWork } from "@/chat/task-execution/heartbeat";
 import { runHeartbeat } from "@/chat/agent-dispatch/heartbeat";
+import { ConversationQueueMessageRejectedError } from "@/chat/task-execution/queue";
 import {
   appendAndEnqueueInboundMessage,
   appendInboundMessage,
@@ -23,7 +24,10 @@ import {
   processConversationWork,
 } from "@/chat/task-execution/worker";
 import { processConversationQueueMessage } from "@/chat/task-execution/vercel-callback";
-import { createVercelConversationWorkQueue } from "@/chat/task-execution/vercel-queue";
+import {
+  CONVERSATION_WORK_QUEUE_RETENTION_SECONDS,
+  createVercelConversationWorkQueue,
+} from "@/chat/task-execution/vercel-queue";
 import {
   signConversationQueueMessage,
   verifySignedConversationQueueMessage,
@@ -298,15 +302,21 @@ describe("conversation work execution", () => {
     const run = vi.fn(async () => ({ status: "completed" as const }));
     await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
 
-    await expect(
-      processConversationWork(
-        conversationQueueMessage({ destination: OTHER_SLACK_DESTINATION }),
-        {
-          queue,
-          run,
-        },
-      ),
-    ).rejects.toThrow("Conversation work queue destination changed");
+    let error: unknown;
+    await processConversationWork(
+      conversationQueueMessage({ destination: OTHER_SLACK_DESTINATION }),
+      {
+        queue,
+        run,
+      },
+    ).catch((caught: unknown) => {
+      error = caught;
+    });
+    expect(error).toBeInstanceOf(ConversationQueueMessageRejectedError);
+    expect(error).toMatchObject({
+      conversationId: CONVERSATION_ID,
+      reason: "destination_mismatch",
+    });
 
     expect(run).not.toHaveBeenCalled();
     await expect(
@@ -1285,7 +1295,7 @@ describe("conversation work execution", () => {
         options: {
           delaySeconds: 16,
           idempotencyKey: "idem-1",
-          retentionSeconds: undefined,
+          retentionSeconds: CONVERSATION_WORK_QUEUE_RETENTION_SECONDS,
         },
       },
     ]);

--- a/packages/junior/tests/unit/vercel-queue-dev.test.ts
+++ b/packages/junior/tests/unit/vercel-queue-dev.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const originalNodeEnv = process.env.NODE_ENV;
 const originalQueueTopic = process.env.JUNIOR_CONVERSATION_WORK_QUEUE_TOPIC;
+const originalJuniorSecret = process.env.JUNIOR_SECRET;
 
 afterEach(() => {
   process.env.NODE_ENV = originalNodeEnv;
@@ -9,6 +10,11 @@ afterEach(() => {
     delete process.env.JUNIOR_CONVERSATION_WORK_QUEUE_TOPIC;
   } else {
     process.env.JUNIOR_CONVERSATION_WORK_QUEUE_TOPIC = originalQueueTopic;
+  }
+  if (originalJuniorSecret === undefined) {
+    delete process.env.JUNIOR_SECRET;
+  } else {
+    process.env.JUNIOR_SECRET = originalJuniorSecret;
   }
   vi.doUnmock("@vercel/queue");
   vi.resetModules();
@@ -48,9 +54,92 @@ describe("registerVercelConversationWorkDevConsumer", () => {
       client: queueClient,
       consumerGroup: CONVERSATION_WORK_DEV_CONSUMER_GROUP,
       handler: expect.any(Function),
+      retry: expect.any(Function),
       topic: "local_work",
       visibilityTimeoutSeconds: 45,
     });
+  });
+
+  it("acknowledges rejected conversation queue messages only", async () => {
+    const routeHandler = vi.fn();
+    const handleCallback = vi.fn(() => routeHandler);
+
+    vi.doMock("@vercel/queue", () => ({
+      QueueClient: vi.fn(),
+      handleCallback,
+      registerDevConsumer: vi.fn(),
+    }));
+
+    const { createVercelConversationWorkCallback } =
+      await import("@/chat/task-execution/vercel-callback");
+
+    expect(
+      createVercelConversationWorkCallback({
+        run: vi.fn(),
+        visibilityTimeoutSeconds: 45,
+      }),
+    ).toBe(routeHandler);
+
+    type TestQueueMetadata = {
+      consumerGroup: string;
+      createdAt: Date;
+      deliveryCount: number;
+      expiresAt: Date;
+      messageId: string;
+      region: string;
+      topicName: string;
+    };
+    const metadata: TestQueueMetadata = {
+      consumerGroup: "consumer",
+      createdAt: new Date(1_000),
+      deliveryCount: 3,
+      expiresAt: new Date(2_000),
+      messageId: "msg_1",
+      region: "iad1",
+      topicName: "topic",
+    };
+    const call = handleCallback.mock.calls[0] as unknown as
+      | [
+          (message: unknown) => Promise<void>,
+          {
+            retry?: (error: unknown, metadata: TestQueueMetadata) => unknown;
+            visibilityTimeoutSeconds?: number;
+          },
+        ]
+      | undefined;
+    const handler = call?.[0];
+    const retry = call?.[1].retry;
+    expect(handler).toEqual(expect.any(Function));
+    expect(retry).toEqual(expect.any(Function));
+    if (!handler || !retry) {
+      throw new Error("Expected conversation queue handler and retry hook");
+    }
+
+    let rejectedError: unknown;
+    await handler({ conversationId: "slack:C123:1712345.0001" }).catch(
+      (error: unknown) => {
+        rejectedError = error;
+      },
+    );
+    expect(rejectedError).toBeInstanceOf(Error);
+    expect(retry(rejectedError, metadata)).toEqual({ acknowledge: true });
+
+    delete process.env.JUNIOR_SECRET;
+    let unavailableError: unknown;
+    await handler({
+      conversationId: "slack:C123:1712345.0001",
+      destination: { channelId: "C123", platform: "slack", teamId: "T123" },
+      signature: "signature",
+      signatureVersion: "v1",
+      signedAtMs: 1_000,
+    }).catch((error: unknown) => {
+      unavailableError = error;
+    });
+    if (!unavailableError) {
+      throw new Error("Expected unavailable verification error");
+    }
+    expect(retry(unavailableError, metadata)).toBeUndefined();
+    expect(retry(new Error("runner failed"), metadata)).toBeUndefined();
   });
 
   it("does not register outside local development", async () => {


### PR DESCRIPTION
Conversation queue callback deliveries that fail message-level verification are now treated as permanent rejections instead of ordinary worker failures. The Vercel Queue retry hook acknowledges malformed, expired, signature-mismatched, or destination-mismatched messages so one stale delivery cannot redeliver forever and flood callback logs.

Verifier-unavailable cases, such as a missing internal secret, still throw normally so valid queued work is retried instead of dropped. Queue retention now matches the signature validity window, and rejected-message logs include the reason plus Vercel queue metadata for diagnosing whether future failures are old retained messages or newly malformed producers.

Validated with `pnpm --filter @sentry/junior exec vitest run tests/unit/vercel-queue-dev.test.ts`, `pnpm --filter @sentry/junior exec vitest run tests/component/task-execution/conversation-work.test.ts`, and `pnpm --filter @sentry/junior typecheck`.