### PR TITLE
fix(queue): Consume rejected conversation callbacks

### DIFF
--- a/packages/junior/src/chat/task-execution/vercel-callback.ts
+++ b/packages/junior/src/chat/task-execution/vercel-callback.ts
@@ -96,24 +96,53 @@ export async function processConversationQueueMessage(
   });
 }
 
+/** Consume queue messages, acking permanent rejects while preserving transient retries. */
 async function handleConversationQueueMessage(
   message: unknown,
+  metadata: MessageMetadata,
   options: VercelConversationWorkCallbackOptions,
 ): Promise<void> {
   const verification = verifyConversationQueueMessage(message);
   if (verification.status === "rejected") {
-    throw new ConversationQueueMessageRejectedError(
-      verification.reason,
-      "Unauthorized conversation queue message",
-    );
+    logConversationQueueMessageRejected(verification.reason, metadata);
+    return;
   }
   if (verification.status === "unavailable") {
     throw new Error(
       `Conversation queue message verification unavailable: ${verification.reason}`,
     );
   }
-  await runWithTurnRequestDeadline(() =>
-    processConversationQueueMessage(verification.message, options),
+  try {
+    await runWithTurnRequestDeadline(() =>
+      processConversationQueueMessage(verification.message, options),
+    );
+  } catch (error) {
+    if (isConversationQueueMessageRejectedError(error)) {
+      logConversationQueueMessageRejected(error.reason, metadata, {
+        conversationId: error.conversationId,
+      });
+      return;
+    }
+    throw error;
+  }
+}
+
+function logConversationQueueMessageRejected(
+  reason: ConversationQueueMessageRejectedError["reason"],
+  metadata: MessageMetadata,
+  context: { conversationId?: string } = {},
+): void {
+  logWarn(
+    "conversation_queue_message_rejected",
+    context.conversationId ? { conversationId: context.conversationId } : {},
+    {
+      "app.queue.consumer_group": metadata.consumerGroup,
+      "app.queue.delivery_count": metadata.deliveryCount,
+      "app.queue.message_id": metadata.messageId,
+      "app.queue.reject_reason": reason,
+      "app.queue.topic_name": metadata.topicName,
+    },
+    "Conversation queue message rejected without retry",
   );
 }
 
@@ -125,18 +154,9 @@ function handleConversationQueueRetry(
   if (!isConversationQueueMessageRejectedError(error)) {
     return undefined;
   }
-  logWarn(
-    "conversation_queue_message_rejected",
-    error.conversationId ? { conversationId: error.conversationId } : {},
-    {
-      "app.queue.consumer_group": metadata.consumerGroup,
-      "app.queue.delivery_count": metadata.deliveryCount,
-      "app.queue.message_id": metadata.messageId,
-      "app.queue.reject_reason": error.reason,
-      "app.queue.topic_name": metadata.topicName,
-    },
-    "Conversation queue message rejected without retry",
-  );
+  logConversationQueueMessageRejected(error.reason, metadata, {
+    conversationId: error.conversationId,
+  });
   return { acknowledge: true };
 }
 
@@ -145,7 +165,8 @@ export function createVercelConversationWorkCallback(
   options: VercelConversationWorkCallbackOptions,
 ): (request: Request) => Promise<Response> {
   return handleCallback(
-    (message: unknown) => handleConversationQueueMessage(message, options),
+    (message: unknown, metadata: MessageMetadata) =>
+      handleConversationQueueMessage(message, metadata, options),
     {
       retry: handleConversationQueueRetry,
       visibilityTimeoutSeconds:
@@ -166,8 +187,8 @@ export function registerVercelConversationWorkDevConsumer(
   return registerDevConsumer({
     client: new QueueClient(),
     consumerGroup: CONVERSATION_WORK_DEV_CONSUMER_GROUP,
-    handler: (message: unknown) =>
-      handleConversationQueueMessage(message, options),
+    handler: (message: unknown, metadata: MessageMetadata) =>
+      handleConversationQueueMessage(message, metadata, options),
     retry: handleConversationQueueRetry,
     topic: resolveConversationWorkQueueTopic(options),
     visibilityTimeoutSeconds:

--- a/packages/junior/tests/unit/vercel-queue-dev.test.ts
+++ b/packages/junior/tests/unit/vercel-queue-dev.test.ts
@@ -4,7 +4,9 @@ const originalNodeEnv = process.env.NODE_ENV;
 const originalQueueTopic = process.env.JUNIOR_CONVERSATION_WORK_QUEUE_TOPIC;
 const originalJuniorSecret = process.env.JUNIOR_SECRET;
 
-afterEach(() => {
+afterEach(async () => {
+  const { disconnectStateAdapter } = await import("@/chat/state/adapter");
+  await disconnectStateAdapter();
   process.env.NODE_ENV = originalNodeEnv;
   if (originalQueueTopic === undefined) {
     delete process.env.JUNIOR_CONVERSATION_WORK_QUEUE_TOPIC;
@@ -60,7 +62,7 @@ describe("registerVercelConversationWorkDevConsumer", () => {
     });
   });
 
-  it("acknowledges rejected conversation queue messages only", async () => {
+  it("absorbs rejected conversation queue messages before retry", async () => {
     const routeHandler = vi.fn();
     const handleCallback = vi.fn(() => routeHandler);
 
@@ -73,9 +75,10 @@ describe("registerVercelConversationWorkDevConsumer", () => {
     const { createVercelConversationWorkCallback } =
       await import("@/chat/task-execution/vercel-callback");
 
+    const run = vi.fn(async () => ({ status: "completed" as const }));
     expect(
       createVercelConversationWorkCallback({
-        run: vi.fn(),
+        run,
         visibilityTimeoutSeconds: 45,
       }),
     ).toBe(routeHandler);
@@ -100,7 +103,7 @@ describe("registerVercelConversationWorkDevConsumer", () => {
     };
     const call = handleCallback.mock.calls[0] as unknown as
       | [
-          (message: unknown) => Promise<void>,
+          (message: unknown, metadata: TestQueueMetadata) => Promise<void>,
           {
             retry?: (error: unknown, metadata: TestQueueMetadata) => unknown;
             visibilityTimeoutSeconds?: number;
@@ -115,30 +118,69 @@ describe("registerVercelConversationWorkDevConsumer", () => {
       throw new Error("Expected conversation queue handler and retry hook");
     }
 
-    let rejectedError: unknown;
-    await handler({ conversationId: "slack:C123:1712345.0001" }).catch(
-      (error: unknown) => {
-        rejectedError = error;
+    await expect(
+      handler({ conversationId: "slack:C123:1712345.0001" }, metadata),
+    ).resolves.toBeUndefined();
+
+    const [{ appendInboundMessage }, { signConversationQueueMessage }] =
+      await Promise.all([
+        import("@/chat/task-execution/store"),
+        import("@/chat/task-execution/queue-signing"),
+      ]);
+    process.env.JUNIOR_SECRET = "conversation-work-secret";
+    await appendInboundMessage({
+      message: {
+        conversationId: "slack:C123:1712345.0001",
+        inboundMessageId: "m1",
+        destination: {
+          channelId: "C123",
+          platform: "slack",
+          teamId: "T123",
+        },
+        source: "slack",
+        createdAtMs: 1_000,
+        receivedAtMs: 1_100,
+        input: {
+          authorId: "U123",
+          text: "message m1",
+        },
       },
-    );
-    expect(rejectedError).toBeInstanceOf(Error);
-    expect(retry(rejectedError, metadata)).toEqual({ acknowledge: true });
+      nowMs: 1_200,
+    });
+    await expect(
+      handler(
+        signConversationQueueMessage({
+          conversationId: "slack:C123:1712345.0001",
+          destination: {
+            channelId: "C456",
+            platform: "slack",
+            teamId: "T123",
+          },
+        }),
+        metadata,
+      ),
+    ).resolves.toBeUndefined();
+    expect(run).not.toHaveBeenCalled();
 
     delete process.env.JUNIOR_SECRET;
-    let unavailableError: unknown;
-    await handler({
-      conversationId: "slack:C123:1712345.0001",
-      destination: { channelId: "C123", platform: "slack", teamId: "T123" },
-      signature: "signature",
-      signatureVersion: "v1",
-      signedAtMs: 1_000,
-    }).catch((error: unknown) => {
-      unavailableError = error;
+    let missingSecretError: unknown;
+    await handler(
+      {
+        conversationId: "slack:C123:1712345.0001",
+        destination: { channelId: "C123", platform: "slack", teamId: "T123" },
+        signature: "signature",
+        signatureVersion: "v1",
+        signedAtMs: 1_000,
+      },
+      metadata,
+    ).catch((error: unknown) => {
+      missingSecretError = error;
     });
-    if (!unavailableError) {
-      throw new Error("Expected unavailable verification error");
-    }
-    expect(retry(unavailableError, metadata)).toBeUndefined();
+    expect(missingSecretError).toMatchObject({
+      message:
+        "Conversation queue message verification unavailable: missing_secret",
+    });
+    expect(retry(missingSecretError, metadata)).toBeUndefined();
     expect(retry(new Error("runner failed"), metadata)).toBeUndefined();
   });
 

--- a/specs/task-execution.md
+++ b/specs/task-execution.md
@@ -189,6 +189,10 @@ Queue consumer rules:
 5. Acknowledge the queue delivery only after durable state is safe: final
    delivery recorded, lease released after cooperative yield, no work found, or
    unrecoverable failure recorded.
+6. Permanently invalid queue messages (malformed, expired,
+   signature-mismatched, or destination-mismatched) are acknowledged at the
+   consumer boundary after logging the reject reason. They must not rely on
+   queue retention expiry for cleanup.
 
 The queue is not the state authority. A successful queue acknowledgement only
 means that one wake-up delivery has been handled.


### PR DESCRIPTION
Permanent conversation queue rejects now resolve at the Vercel Queue callback boundary so malformed, expired, signature-mismatched, or destination-mismatched deliveries are acknowledged instead of retrying and flooding callback logs.

Verifier-unavailable cases such as a missing internal secret still throw so valid queued work is not dropped. The task execution spec now documents that invalid queue messages must be acknowledged on delivery, and the queue callback test covers malformed payloads, worker-side destination mismatches, and missing-secret retry behavior.