### PR TITLE
fix(queue): Absorb legacy conversation payloads

### DIFF
--- a/packages/junior/src/chat/task-execution/queue.ts
+++ b/packages/junior/src/chat/task-execution/queue.ts
@@ -9,8 +9,7 @@ export type ConversationQueueMessageRejectReason =
   | "destination_mismatch"
   | "expired"
   | "malformed"
-  | "signature_mismatch"
-  | "unauthorized";
+  | "signature_mismatch";
 
 export class ConversationQueueMessageRejectedError extends Error {
   conversationId?: string;

--- a/packages/junior/tests/unit/vercel-queue-dev.test.ts
+++ b/packages/junior/tests/unit/vercel-queue-dev.test.ts
@@ -119,7 +119,13 @@ describe("registerVercelConversationWorkDevConsumer", () => {
     }
 
     await expect(
-      handler({ conversationId: "slack:C123:1712345.0001" }, metadata),
+      handler(
+        {
+          conversationId: "slack:C123:1712345.0001",
+          destination: { channelId: "C123", platform: "slack", teamId: "T123" },
+        },
+        metadata,
+      ),
     ).resolves.toBeUndefined();
 
     const [{ appendInboundMessage }, { signConversationQueueMessage }] =


### PR DESCRIPTION
Legacy unsigned conversation queue deliveries that still include destination context are now covered as permanent callback rejects, so they are acknowledged without invoking the worker. The stale `unauthorized` reject reason is also removed from the queue boundary because current code only emits malformed, expired, signature mismatch, or destination mismatch rejects.

Verified with `pnpm --filter @sentry/junior exec vitest run tests/unit/vercel-queue-dev.test.ts`, queue-adjacent component tests for conversation work and timeout resume, and `pnpm --filter @sentry/junior typecheck`.