### PR TITLE
fix(queue): Preserve conversation recovery progress

### DIFF
--- a/packages/junior/src/chat/task-execution/heartbeat.ts
+++ b/packages/junior/src/chat/task-execution/heartbeat.ts
@@ -7,7 +7,7 @@ import {
   CONVERSATION_WORK_STALE_ENQUEUE_MS,
   getConversationWorkState,
   hasRunnableConversationWork,
-  listConversationWorkIds,
+  claimConversationWorkRecoveryIds,
   markConversationWorkEnqueued,
 } from "./store";
 
@@ -59,7 +59,7 @@ export async function recoverConversationWork(args: {
     expiredLeaseCount: 0,
     pendingCount: 0,
   };
-  const ids = await listConversationWorkIds({
+  const ids = await claimConversationWorkRecoveryIds({
     limit: args.limit ?? DEFAULT_RECOVERY_LIMIT,
     state: args.state,
   });

--- a/packages/junior/src/chat/task-execution/store.ts
+++ b/packages/junior/src/chat/task-execution/store.ts
@@ -1004,14 +1004,25 @@ export async function recordConversationWorkFailure(args: {
   });
 }
 
-/** List bounded conversation ids that may need heartbeat recovery. */
-export async function listConversationWorkIds(
+/** Claim bounded recovery candidates and rotate them behind unscanned ids. */
+export async function claimConversationWorkRecoveryIds(
   args: {
     limit?: number;
     state?: StateAdapter;
   } = {},
 ): Promise<string[]> {
   const state = await getConnectedState(args.state);
-  const ids = uniqueStrings((await state.get<unknown[]>(indexKey())) ?? []);
-  return ids.slice(0, args.limit ?? ids.length);
+  return await withIndexLock(state, async () => {
+    const ids = uniqueStrings((await state.get<unknown[]>(indexKey())) ?? []);
+    const limit = Math.max(0, args.limit ?? ids.length);
+    const selected = ids.slice(0, limit);
+    if (selected.length > 0 && selected.length < ids.length) {
+      await state.set(
+        indexKey(),
+        [...ids.slice(selected.length), ...selected],
+        JUNIOR_THREAD_STATE_TTL_MS,
+      );
+    }
+    return selected;
+  });
 }

--- a/packages/junior/src/chat/task-execution/worker.ts
+++ b/packages/junior/src/chat/task-execution/worker.ts
@@ -148,6 +148,7 @@ async function requestLostLeaseRecovery(args: {
   });
 }
 
+/** Mark uncertain periodic check-ins as lost-lease so runners stop at safe boundaries. */
 function startLeaseCheckIn(args: {
   conversationId: string;
   leaseToken: string;
@@ -174,6 +175,7 @@ function startLeaseCheckIn(args: {
         }
       },
       (error) => {
+        args.onLostLease();
         logException(
           error,
           "conversation_work_check_in_failed",
@@ -333,17 +335,17 @@ export async function processConversationWork(
       });
       return { status: "lost_lease" };
     }
-    if (leaseLost) {
-      await requestLostLeaseRecovery({
-        conversationId,
-        destination,
-        leaseToken: lease.leaseToken,
-        nowMs: now(options),
-        options,
-      });
-      return { status: "lost_lease" };
-    }
     if (result.status === "yielded") {
+      if (leaseLost) {
+        await requestLostLeaseRecovery({
+          conversationId,
+          destination,
+          leaseToken: lease.leaseToken,
+          nowMs: now(options),
+          options,
+        });
+        return { status: "lost_lease" };
+      }
       const yieldNowMs = now(options);
       const continuationMarked = await requestConversationContinuation({
         conversationId,

--- a/packages/junior/tests/component/task-execution/conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/conversation-work.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { recoverConversationWork } from "@/chat/task-execution/heartbeat";
 import { runHeartbeat } from "@/chat/agent-dispatch/heartbeat";
 import { ConversationQueueMessageRejectedError } from "@/chat/task-execution/queue";
+import { commitMessages, loadProjection } from "@/chat/state/session-log";
 import {
   appendAndEnqueueInboundMessage,
   appendInboundMessage,
@@ -11,7 +12,6 @@ import {
   countPendingConversationMessages,
   drainConversationMailbox,
   getConversationWorkState,
-  listConversationWorkIds,
   markConversationMessagesInjected,
   requestConversationContinuation,
   requestConversationWork,
@@ -19,6 +19,8 @@ import {
   startConversationWork,
   type InboundMessageRecord,
 } from "@/chat/task-execution/store";
+import { JUNIOR_THREAD_STATE_TTL_MS } from "@/chat/state/ttl";
+import type { PiMessage } from "@/chat/pi/messages";
 import {
   CONVERSATION_WORK_DEFER_DELAY_MS,
   processConversationWork,
@@ -43,6 +45,7 @@ import {
   delayMutationLockUntil,
   inboundMessage,
   observeConversationMutationLock,
+  readConversationWorkIndex,
 } from "../../fixtures/conversation-work";
 
 const OTHER_SLACK_DESTINATION = {
@@ -250,11 +253,53 @@ describe("conversation work execution", () => {
       state,
     });
 
-    const ids = await listConversationWorkIds({ state });
+    const ids = await readConversationWorkIndex(state);
     expect(ids).toContain(activeConversationId);
     expect(ids).toContain(newConversationId);
     expect(ids).not.toContain("stale-0");
     expect(ids).toHaveLength(10_000);
+  });
+
+  it("rotates bounded heartbeat scans so stale prefixes cannot starve pending work", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    const state = getStateAdapter();
+    await state.connect();
+    await appendInboundMessage({
+      message: inboundMessage("m1"),
+      nowMs: 1_000,
+      state,
+    });
+    await state.set(
+      "junior:conversation-work:index",
+      ["missing-conversation", CONVERSATION_ID],
+      60_000,
+    );
+
+    await expect(
+      recoverConversationWork({
+        limit: 1,
+        nowMs: 62_000,
+        queue,
+        state,
+      }),
+    ).resolves.toEqual({ expiredLeaseCount: 0, pendingCount: 0 });
+    expect(queue.sentRecords()).toEqual([]);
+
+    await expect(
+      recoverConversationWork({
+        limit: 1,
+        nowMs: 63_000,
+        queue,
+        state,
+      }),
+    ).resolves.toEqual({ expiredLeaseCount: 0, pendingCount: 1 });
+    expect(queue.sentRecords()).toEqual([
+      {
+        conversationId: CONVERSATION_ID,
+        destination: SLACK_DESTINATION,
+        idempotencyKey: `heartbeat:pending:${CONVERSATION_ID}:63000`,
+      },
+    ]);
   });
 
   it("defers duplicate queue nudges while a conversation lease is active", async () => {
@@ -1014,6 +1059,127 @@ describe("conversation work execution", () => {
     await expect(running).resolves.toEqual({ status: "lost_lease" });
   });
 
+  it("treats periodic check-in errors as lost lease at the next yield boundary", async () => {
+    vi.useFakeTimers({ now: 1_000 });
+    const queue = createConversationWorkQueueTestAdapter();
+    const baseState = getStateAdapter();
+    await baseState.connect();
+    await appendInboundMessage({
+      message: inboundMessage("m1"),
+      nowMs: 1_000,
+      state: baseState,
+    });
+    const mutationLockKey = `junior:conversation-work:mutation:${CONVERSATION_ID}`;
+    let failCheckIns = false;
+    const state = new Proxy(baseState, {
+      get(target, prop, receiver) {
+        if (prop === "acquireLock") {
+          return async (key: string, ttlMs: number) => {
+            if (key === mutationLockKey && failCheckIns) {
+              throw new Error("state unavailable during check-in");
+            }
+            return target.acquireLock(key, ttlMs);
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as typeof baseState;
+    const entered = deferred<{ shouldYield: () => boolean }>();
+    const finish = deferred<void>();
+
+    const running = processConversationWork(conversationQueueMessage(), {
+      checkInIntervalMs: 15_000,
+      queue,
+      run: async (context) => {
+        await context.drainMailbox(async () => {});
+        entered.resolve({ shouldYield: context.shouldYield });
+        await finish.promise;
+        return { status: context.shouldYield() ? "yielded" : "completed" };
+      },
+      state,
+    });
+    const runningContext = await entered.promise;
+
+    failCheckIns = true;
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(runningContext.shouldYield()).toBe(true);
+
+    failCheckIns = false;
+    finish.resolve();
+    await expect(running).resolves.toEqual({ status: "lost_lease" });
+    expect(queue.sentRecords()).toEqual([
+      expect.objectContaining({
+        conversationId: CONVERSATION_ID,
+        idempotencyKey: `lost_lease:${CONVERSATION_ID}:16000`,
+      }),
+    ]);
+    const work = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+      state,
+    });
+    expect(work?.lease).toBeUndefined();
+    expect(work?.needsRun).toBe(true);
+  });
+
+  it("does not reopen completed work after a transient check-in error", async () => {
+    vi.useFakeTimers({ now: 1_000 });
+    const queue = createConversationWorkQueueTestAdapter();
+    const baseState = getStateAdapter();
+    await baseState.connect();
+    await appendInboundMessage({
+      message: inboundMessage("m1"),
+      nowMs: 1_000,
+      state: baseState,
+    });
+    const mutationLockKey = `junior:conversation-work:mutation:${CONVERSATION_ID}`;
+    let failCheckIns = false;
+    const state = new Proxy(baseState, {
+      get(target, prop, receiver) {
+        if (prop === "acquireLock") {
+          return async (key: string, ttlMs: number) => {
+            if (key === mutationLockKey && failCheckIns) {
+              throw new Error("state unavailable during check-in");
+            }
+            return target.acquireLock(key, ttlMs);
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as typeof baseState;
+    const entered = deferred<{ shouldYield: () => boolean }>();
+    const finish = deferred<void>();
+
+    const running = processConversationWork(conversationQueueMessage(), {
+      checkInIntervalMs: 15_000,
+      queue,
+      run: async (context) => {
+        await context.drainMailbox(async () => {});
+        entered.resolve({ shouldYield: context.shouldYield });
+        await finish.promise;
+        return { status: "completed" };
+      },
+      state,
+    });
+    const runningContext = await entered.promise;
+
+    failCheckIns = true;
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(runningContext.shouldYield()).toBe(true);
+
+    failCheckIns = false;
+    finish.resolve();
+    await expect(running).resolves.toEqual({ status: "completed" });
+    expect(queue.sentRecords()).toEqual([]);
+    const work = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+      state,
+    });
+    expect(work?.lease).toBeUndefined();
+    expect(work?.needsRun).toBe(false);
+  });
+
   it("requeues an expired conversation lease from heartbeat", async () => {
     const queue = createConversationWorkQueueTestAdapter();
     await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
@@ -1286,6 +1452,77 @@ describe("conversation work execution", () => {
         nowMs: 3_000,
       }),
     ).resolves.toBe(false);
+  });
+
+  it("keeps repeated mailbox injection idempotent when marking injected fails", async () => {
+    await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
+    const lease = await startConversationWork({
+      conversationId: CONVERSATION_ID,
+      nowMs: 2_000,
+    });
+    expect(lease.status).toBe("acquired");
+    if (lease.status !== "acquired") {
+      return;
+    }
+    const toPiMessages = (messages: InboundMessageRecord[]): PiMessage[] =>
+      messages.map(
+        (message) =>
+          ({
+            role: "user",
+            content: [{ type: "text", text: message.input.text }],
+            timestamp: message.createdAtMs,
+          }) as PiMessage,
+      );
+
+    await expect(
+      drainConversationMailbox({
+        conversationId: CONVERSATION_ID,
+        leaseToken: lease.leaseToken,
+        nowMs: 3_000,
+        inject: async (messages) => {
+          await commitMessages({
+            conversationId: CONVERSATION_ID,
+            messages: toPiMessages(messages),
+            ttlMs: JUNIOR_THREAD_STATE_TTL_MS,
+          });
+          throw new Error("process died before marking injected");
+        },
+      }),
+    ).rejects.toThrow("process died before marking injected");
+    await expect(
+      getConversationWorkState({ conversationId: CONVERSATION_ID }),
+    ).resolves.toMatchObject({
+      messages: [expect.objectContaining({ injectedAtMs: undefined })],
+    });
+
+    await expect(
+      drainConversationMailbox({
+        conversationId: CONVERSATION_ID,
+        leaseToken: lease.leaseToken,
+        nowMs: 4_000,
+        inject: async (messages) => {
+          await commitMessages({
+            conversationId: CONVERSATION_ID,
+            messages: toPiMessages(messages),
+            ttlMs: JUNIOR_THREAD_STATE_TTL_MS,
+          });
+        },
+      }),
+    ).resolves.toHaveLength(1);
+
+    await expect(
+      loadProjection({ conversationId: CONVERSATION_ID }),
+    ).resolves.toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "message m1" }],
+        timestamp: 1_000,
+      },
+    ]);
+    const state = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+    });
+    expect(state ? countPendingConversationMessages(state) : 0).toBe(0);
   });
 
   it("deduplicates accepted fake queue payloads by idempotency key", async () => {

--- a/packages/junior/tests/fixtures/conversation-work.ts
+++ b/packages/junior/tests/fixtures/conversation-work.ts
@@ -135,6 +135,24 @@ export function createConversationWorkQueueTestAdapter(): ConversationWorkQueueT
   return new ConversationWorkQueueTestAdapter();
 }
 
+/** Read the private conversation work recovery index for store component tests. */
+export async function readConversationWorkIndex(
+  state: StateAdapter,
+): Promise<string[]> {
+  await state.connect();
+  const value = await state.get<unknown[]>("junior:conversation-work:index");
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return [
+    ...new Set(
+      value.filter((item): item is string => {
+        return typeof item === "string" && item.trim().length > 0;
+      }),
+    ),
+  ];
+}
+
 /** Observe whether one conversation's mutation lock is currently held. */
 export function observeConversationMutationLock(args: {
   conversationId: string;


### PR DESCRIPTION
Heartbeat recovery now claims and rotates bounded conversation work scans, so stale recovery index prefixes cannot indefinitely starve later runnable conversations. The queue worker also treats uncertain periodic check-ins as lost lease only at yield boundaries, while allowing completed work to close out the current lease without reopening already-finished work.

The component coverage now exercises scan fairness, lost-lease recovery state, completed-work closure after transient check-in errors, and idempotent mailbox injection after session-log commit. I also moved direct recovery index inspection into the test fixture so the production store surface exposes the mutating recovery claim rather than a test-only list helper.

Validation passed: targeted task-execution component tests, Slack conversation work component tests, Vercel queue unit tests, heartbeat integration tests, typecheck, and diff whitespace checks.