### PR TITLE
fix(slack): Gate steering reactions on subscribed routing

### DIFF
--- a/packages/junior/src/chat/app/factory.ts
+++ b/packages/junior/src/chat/app/factory.ts
@@ -1,4 +1,5 @@
 import type { SlackAdapter } from "@chat-adapter/slack";
+import type { Message } from "chat";
 import {
   createSlackTurnRuntime,
   type AssistantLifecycleEvent,
@@ -30,6 +31,7 @@ import {
   createPrepareTurnState,
   type PreparedTurnState,
 } from "@/chat/runtime/turn-preparation";
+import type { TurnMessageText } from "@/chat/runtime/turn-input";
 import { buildDeterministicTurnId } from "@/chat/runtime/turn";
 import { toConversationMessage } from "@/chat/runtime/conversation-message";
 import {
@@ -37,6 +39,7 @@ import {
   updateConversationStats,
   upsertConversationMessage,
 } from "@/chat/services/conversation-memory";
+import type { SubscribedReplyDecision } from "@/chat/services/subscribed-reply-policy";
 import { botConfig } from "@/chat/config";
 
 export interface CreateSlackRuntimeOptions {
@@ -69,6 +72,29 @@ function clearSkippedTurnIfActive(
   ) {
     conversation.processing.activeTurnId = undefined;
   }
+}
+
+function upsertSkippedConversationMessage(
+  conversation: PreparedTurnState["conversation"],
+  args: {
+    decision: SubscribedReplyDecision;
+    message: Message;
+    text: TurnMessageText;
+  },
+): void {
+  const conversationMessage = toConversationMessage({
+    entry: args.message,
+    explicitMention: Boolean(args.message.isMention),
+    text: args.text.userText,
+  });
+  upsertConversationMessage(conversation, {
+    ...conversationMessage,
+    meta: {
+      ...conversationMessage.meta,
+      replied: false,
+      skippedReason: args.decision.reason,
+    },
+  });
 }
 
 export function createSlackRuntime(
@@ -112,7 +138,24 @@ export function createSlackRuntime(
     getPreparedConversationContext: (preparedState) =>
       preparedState.conversationContext,
     decideSubscribedReply: services.subscribedReplyPolicy,
-    recordSkippedSubscribedMessage: async ({
+    recordSkippedSteeringMessage: async ({
+      thread,
+      message,
+      decision,
+      text,
+    }) => {
+      const conversation = coerceThreadConversationState(await thread.state);
+      upsertSkippedConversationMessage(conversation, {
+        decision,
+        message,
+        text,
+      });
+      updateConversationStats(conversation);
+      await persistThreadState(thread, {
+        conversation,
+      });
+    },
+    recordSkippedSubscribedTurn: async ({
       thread,
       message,
       decision,
@@ -120,18 +163,10 @@ export function createSlackRuntime(
       text,
     }) => {
       const conversation = coerceThreadConversationState(await thread.state);
-      const conversationMessage = toConversationMessage({
-        entry: message,
-        explicitMention: Boolean(message.isMention),
-        text: text.userText,
-      });
-      upsertConversationMessage(conversation, {
-        ...conversationMessage,
-        meta: {
-          ...conversationMessage.meta,
-          replied: false,
-          skippedReason: decision.reason,
-        },
+      upsertSkippedConversationMessage(conversation, {
+        decision,
+        message,
+        text,
       });
       clearSkippedTurnIfActive(conversation, message.id);
       conversation.processing.lastCompletedAtMs = completedAtMs;
@@ -147,9 +182,6 @@ export function createSlackRuntime(
       decision,
       completedAtMs,
     }) => {
-      if (!preparedState) {
-        return;
-      }
       markConversationMessage(
         preparedState.conversation,
         preparedState.userMessageId,

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -277,6 +277,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
       queuedMessages?: QueuedTurnMessage[];
       drainSteeringMessages?: (
         inject: (messages: QueuedTurnMessage[]) => Promise<void>,
+        context?: { conversationContext?: string },
       ) => Promise<QueuedTurnMessage[]>;
       shouldYield?: () => boolean;
     },
@@ -824,6 +825,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                       await resolveSteeringMessages(queuedMessages);
                     await inject(injectedMessages);
                   },
+                  { conversationContext: preparedState.conversationContext },
                 );
                 return (
                   injectedMessages ?? (await resolveSteeringMessages(drained))

--- a/packages/junior/src/chat/runtime/slack-runtime.ts
+++ b/packages/junior/src/chat/runtime/slack-runtime.ts
@@ -63,6 +63,10 @@ export interface ReplyHooks {
   shouldYield?: () => boolean;
 }
 
+interface SteeringDrainContext {
+  conversationContext?: string;
+}
+
 export interface SlackTurnOptions extends ReplyHooks {
   destination: Destination;
 }
@@ -141,7 +145,13 @@ export interface SlackTurnRuntimeDependencies<TPreparedState> {
   ) => void;
   modelId: string;
   now: () => number;
-  recordSkippedSubscribedMessage: (args: {
+  recordSkippedSteeringMessage: (args: {
+    decision: SubscribedReplyDecision;
+    message: Message;
+    text: TurnMessageText;
+    thread: Thread;
+  }) => Promise<void>;
+  recordSkippedSubscribedTurn: (args: {
     completedAtMs: number;
     decision: SubscribedReplyDecision;
     message: Message;
@@ -152,7 +162,7 @@ export interface SlackTurnRuntimeDependencies<TPreparedState> {
     completedAtMs: number;
     decision: SubscribedReplyDecision;
     message: Message;
-    preparedState?: TPreparedState;
+    preparedState: TPreparedState;
     thread: Thread;
   }) => Promise<void>;
   persistPreparedState: (args: {
@@ -175,6 +185,7 @@ export interface SlackTurnRuntimeDependencies<TPreparedState> {
       queuedMessages?: QueuedTurnMessage[];
       drainSteeringMessages?: (
         inject: (messages: QueuedTurnMessage[]) => Promise<void>,
+        context?: SteeringDrainContext,
       ) => Promise<QueuedTurnMessage[]>;
       shouldYield?: () => boolean;
     },
@@ -233,33 +244,52 @@ function getQueuedMessagesFromSlackMessages(
   );
 }
 
-function createSteeringMessageDrain(
+interface SteeringMessageDecision {
+  context: TurnContext;
+  decision: SubscribedReplyDecision;
+  message: Message;
+  text: TurnMessageText;
+}
+
+interface SteeringMessageSelection {
+  accepted: Message[];
+  skipped: SteeringMessageDecision[];
+}
+
+/** Drain mailbox steering messages only after selecting work Junior will process. */
+function createAcceptedSteeringDrain(
   hooks: ReplyHooks,
   options: {
     explicitMention: boolean;
-    onMessagesAccepted?: (messages: Message[]) => Promise<void>;
+    onAcceptedForProcessing?: (messages: Message[]) => Promise<void>;
+    onSkipped?: (messages: SteeringMessageDecision[]) => Promise<void>;
+    selectMessages: (
+      messages: Message[],
+      context?: SteeringDrainContext,
+    ) => Promise<SteeringMessageSelection>;
     stripLeadingBotMention: SlackTurnRuntimeDependencies<unknown>["stripLeadingBotMention"];
   },
 ):
   | ((
       inject: (messages: QueuedTurnMessage[]) => Promise<void>,
+      context?: SteeringDrainContext,
     ) => Promise<QueuedTurnMessage[]>)
   | undefined {
   if (!hooks.drainSteeringMessages) {
     return undefined;
   }
 
-  return async (inject) => {
+  return async (inject, context) => {
     let acceptedMessages: Message[] | undefined;
-    const drained = await hooks.drainSteeringMessages!(async (messages) => {
-      await inject(getQueuedMessagesFromSlackMessages(messages, options));
-      acceptedMessages = messages;
-      await options.onMessagesAccepted?.(messages);
+    await hooks.drainSteeringMessages!(async (messages) => {
+      const selection = await options.selectMessages(messages, context);
+      const accepted = selection.accepted;
+      await options.onSkipped?.(selection.skipped);
+      await inject(getQueuedMessagesFromSlackMessages(accepted, options));
+      acceptedMessages = accepted;
+      await options.onAcceptedForProcessing?.(accepted);
     });
-    if (!acceptedMessages) {
-      await options.onMessagesAccepted?.(drained);
-    }
-    return getQueuedMessagesFromSlackMessages(drained, options);
+    return getQueuedMessagesFromSlackMessages(acceptedMessages ?? [], options);
   };
 }
 
@@ -416,17 +446,48 @@ export function createSlackTurnRuntime<
     }
   };
 
-  /** Persist the skip decision at the same boundary that a reply would update. */
-  const skipSubscribedMessage = async (args: {
-    thread: Thread;
-    message: Message;
-    decision: SubscribedReplyDecision;
+  const decideSteeringMessage = async (
+    thread: Thread,
+    message: Message,
+    conversationContext: string | undefined,
+  ): Promise<{
     context: TurnContext;
-    onInputCommitted?: () => Promise<void>;
-    preparedState?: TPreparedState;
+    decision: SubscribedReplyDecision;
     text: TurnMessageText;
-  }): Promise<void> => {
-    const completedAtMs = deps.now();
+  }> => {
+    const context: TurnContext = {
+      threadId: deps.getThreadId(thread, message),
+      requesterId: message.author.userId,
+      channelId: deps.getChannelId(thread, message),
+      runId: deps.getRunId(thread, message),
+    };
+    const legacyAttachmentText = renderSlackLegacyAttachmentText(message.raw);
+    const strippedUserText = deps.stripLeadingBotMention(message.text, {
+      stripLeadingSlackMentionToken: Boolean(message.isMention),
+    });
+    const text: TurnMessageText = {
+      rawText: appendSlackLegacyAttachmentText(message.text, message.raw),
+      userText: appendSlackLegacyAttachmentText(strippedUserText, message.raw),
+    };
+    const isExplicitMention = Boolean(message.isMention);
+
+    const decision = await deps.decideSubscribedReply({
+      rawText: text.rawText,
+      text: text.userText,
+      conversationContext,
+      hasAttachments:
+        message.attachments.length > 0 || legacyAttachmentText !== "",
+      isExplicitMention,
+      context,
+    });
+    return { context, decision, text };
+  };
+
+  const logSkippedSubscribedDecision = (args: {
+    context: TurnContext;
+    decision: SubscribedReplyDecision;
+    message: Message;
+  }): void => {
     deps.logWarn(
       "subscribed_message_reply_skipped",
       logContext({
@@ -441,26 +502,135 @@ export function createSlackTurnRuntime<
       },
       "Skipping subscribed message reply",
     );
-    await deps.onSubscribedMessageSkipped({
-      thread: args.thread,
-      message: args.message,
-      preparedState: args.preparedState,
-      decision: args.decision,
-      completedAtMs,
-    });
-    if (!args.preparedState) {
-      await deps.recordSkippedSubscribedMessage({
+  };
+
+  /** Persist the skip decision at the same boundary that a reply would update. */
+  const skipSubscribedMessage = async (args: {
+    thread: Thread;
+    message: Message;
+    decision: SubscribedReplyDecision;
+    context: TurnContext;
+    onInputCommitted?: () => Promise<void>;
+    preparedState?: TPreparedState;
+    text: TurnMessageText;
+  }): Promise<void> => {
+    const completedAtMs = deps.now();
+    logSkippedSubscribedDecision(args);
+    if (args.preparedState) {
+      await deps.onSubscribedMessageSkipped({
         thread: args.thread,
         message: args.message,
         decision: args.decision,
+        preparedState: args.preparedState,
         completedAtMs,
+      });
+    } else {
+      await deps.recordSkippedSubscribedTurn({
+        thread: args.thread,
+        message: args.message,
+        decision: args.decision,
         text: args.text,
+        completedAtMs,
       });
     }
     // Mark the inbound mailbox messages as consumed even though we are not
     // replying. Without this, completeConversationWork sees pendingMessages > 0
     // and re-enqueues indefinitely — an infinite loop for every skipped message.
     await args.onInputCommitted?.();
+  };
+
+  const selectAcceptedSteeringMessages = async (args: {
+    conversationContext: string | undefined;
+    messages: Message[];
+    thread: Thread;
+  }): Promise<SteeringMessageSelection> => {
+    const selected: SteeringMessageDecision[] = [];
+    for (const message of args.messages) {
+      const decision = await decideSteeringMessage(
+        args.thread,
+        message,
+        args.conversationContext,
+      );
+      selected.push({
+        context: decision.context,
+        decision: decision.decision,
+        message,
+        text: decision.text,
+      });
+    }
+    if (selected.some((message) => message.decision.shouldUnsubscribe)) {
+      return {
+        accepted: [],
+        skipped: selected.map((message) =>
+          message.decision.shouldReply
+            ? {
+                ...message,
+                decision: {
+                  shouldReply: false,
+                  reason: "thread_opt_out:batch opt-out",
+                },
+              }
+            : message,
+        ),
+      };
+    }
+    return {
+      accepted: selected
+        .filter((message) => message.decision.shouldReply)
+        .map((message) => message.message),
+      skipped: selected.filter((message) => !message.decision.shouldReply),
+    };
+  };
+
+  /** Persist skipped steering before mailbox commit, without reactions or injection. */
+  const handleSkippedSteeringMessages = async (args: {
+    beforeFirstResponsePost?: () => Promise<void>;
+    pending: SteeringMessageDecision[];
+    skipped: SteeringMessageDecision[];
+    thread: Thread;
+  }): Promise<void> => {
+    for (const skipped of args.skipped) {
+      await maybeHandleThreadOptOutDecision({
+        thread: args.thread,
+        decision: skipped.decision,
+        beforeFirstResponsePost: args.beforeFirstResponsePost,
+      });
+      logSkippedSubscribedDecision(skipped);
+      await deps.recordSkippedSteeringMessage({
+        thread: args.thread,
+        message: skipped.message,
+        decision: skipped.decision,
+        text: skipped.text,
+      });
+      args.pending.push(skipped);
+    }
+  };
+
+  /** Reapply skipped steering after final turn persistence so replayed state keeps skipped context. */
+  const flushSkippedSteeringMessagesBestEffort = async (args: {
+    context: RuntimeLogContext;
+    pending: SteeringMessageDecision[];
+    thread: Thread;
+  }): Promise<void> => {
+    try {
+      while (args.pending.length > 0) {
+        const skipped = args.pending.shift()!;
+        await deps.recordSkippedSteeringMessage({
+          thread: args.thread,
+          message: skipped.message,
+          decision: skipped.decision,
+          text: skipped.text,
+        });
+      }
+    } catch (error) {
+      deps.logException(
+        error,
+        "skipped_steering_flush_failed",
+        args.context,
+        {},
+        "Failed to reapply skipped steering message records",
+      );
+    }
   };
 
   return {
@@ -471,9 +641,21 @@ export function createSlackTurnRuntime<
     ): Promise<void> {
       const processingReactions = createProcessingReactionTracker(thread);
       let processingReaction: ProcessingReactionSession | undefined;
+      const skippedSteeringMessages: SteeringMessageDecision[] = [];
       let completed = false;
       const onTurnCompleted = async (): Promise<void> => {
         completed = true;
+        await flushSkippedSteeringMessagesBestEffort({
+          thread,
+          pending: skippedSteeringMessages,
+          context: logContext({
+            threadId: deps.getThreadId(thread, message),
+            requesterId: message.author.userId,
+            requesterUserName: requesterUserName(message),
+            channelId: deps.getChannelId(thread, message),
+            runId: deps.getRunId(thread, message),
+          }),
+        });
       };
       try {
         const threadId = deps.getThreadId(thread, message);
@@ -514,15 +696,28 @@ export function createSlackTurnRuntime<
             await hooks.onInputCommitted?.();
             await startQueuedProcessingReactions();
           };
-          const drainSteeringMessages = createSteeringMessageDrain(hooks, {
+          const drainSteeringMessages = createAcceptedSteeringDrain(hooks, {
             explicitMention: true,
-            onMessagesAccepted: async (messages) => {
+            onAcceptedForProcessing: async (messages) => {
               await Promise.all(
                 messages.map((drainedMessage) =>
                   processingReactions.start(context, drainedMessage),
                 ),
               );
             },
+            onSkipped: (skipped) =>
+              handleSkippedSteeringMessages({
+                beforeFirstResponsePost: hooks.beforeFirstResponsePost,
+                pending: skippedSteeringMessages,
+                skipped,
+                thread,
+              }),
+            selectMessages: (messages, drainContext) =>
+              selectAcceptedSteeringMessages({
+                conversationContext: drainContext?.conversationContext,
+                messages,
+                thread,
+              }),
             stripLeadingBotMention: deps.stripLeadingBotMention,
           });
           await deps.replyToThread(thread, message, {
@@ -587,6 +782,17 @@ export function createSlackTurnRuntime<
         if (completed) {
           await processingReactions.completeAll();
         } else {
+          await flushSkippedSteeringMessagesBestEffort({
+            thread,
+            pending: skippedSteeringMessages,
+            context: logContext({
+              threadId: deps.getThreadId(thread, message),
+              requesterId: message.author.userId,
+              requesterUserName: requesterUserName(message),
+              channelId: deps.getChannelId(thread, message),
+              runId: deps.getRunId(thread, message),
+            }),
+          });
           await processingReactions.stopAll();
         }
       }
@@ -599,9 +805,21 @@ export function createSlackTurnRuntime<
     ): Promise<void> {
       const processingReactions = createProcessingReactionTracker(thread);
       let processingReaction: ProcessingReactionSession | undefined;
+      const skippedSteeringMessages: SteeringMessageDecision[] = [];
       let completed = false;
       const onTurnCompleted = async (): Promise<void> => {
         completed = true;
+        await flushSkippedSteeringMessagesBestEffort({
+          thread,
+          pending: skippedSteeringMessages,
+          context: logContext({
+            threadId: deps.getThreadId(thread, message),
+            requesterId: message.author.userId,
+            requesterUserName: requesterUserName(message),
+            channelId: deps.getChannelId(thread, message),
+            runId: deps.getRunId(thread, message),
+          }),
+        });
       };
       try {
         const threadId = deps.getThreadId(thread, message);
@@ -638,17 +856,6 @@ export function createSlackTurnRuntime<
           };
           const queuedMessages = getQueuedMessages(hooks.messageContext, {
             explicitMention: Boolean(message.isMention),
-            stripLeadingBotMention: deps.stripLeadingBotMention,
-          });
-          const drainSteeringMessages = createSteeringMessageDrain(hooks, {
-            explicitMention: Boolean(message.isMention),
-            onMessagesAccepted: async (messages) => {
-              await Promise.all(
-                messages.map((drainedMessage) =>
-                  processingReactions.start(turnContext, drainedMessage),
-                ),
-              );
-            },
             stripLeadingBotMention: deps.stripLeadingBotMention,
           });
           const combinedText = combineTurnText(queuedMessages, currentText);
@@ -739,6 +946,33 @@ export function createSlackTurnRuntime<
             return;
           }
 
+          const conversationContext =
+            deps.getPreparedConversationContext(preparedState);
+          const drainSteeringMessages = createAcceptedSteeringDrain(hooks, {
+            explicitMention: Boolean(message.isMention),
+            onAcceptedForProcessing: async (messages) => {
+              await Promise.all(
+                messages.map((drainedMessage) =>
+                  processingReactions.start(turnContext, drainedMessage),
+                ),
+              );
+            },
+            onSkipped: (skipped) =>
+              handleSkippedSteeringMessages({
+                beforeFirstResponsePost: hooks.beforeFirstResponsePost,
+                pending: skippedSteeringMessages,
+                skipped,
+                thread,
+              }),
+            selectMessages: (messages, drainContext) =>
+              selectAcceptedSteeringMessages({
+                conversationContext:
+                  drainContext?.conversationContext ?? conversationContext,
+                messages,
+                thread,
+              }),
+            stripLeadingBotMention: deps.stripLeadingBotMention,
+          });
           processingReaction = await processingReactions.start(
             turnContext,
             message,
@@ -828,6 +1062,17 @@ export function createSlackTurnRuntime<
         if (completed) {
           await processingReactions.completeAll();
         } else {
+          await flushSkippedSteeringMessagesBestEffort({
+            thread,
+            pending: skippedSteeringMessages,
+            context: logContext({
+              threadId: deps.getThreadId(thread, message),
+              requesterId: message.author.userId,
+              requesterUserName: requesterUserName(message),
+              channelId: deps.getChannelId(thread, message),
+              runId: deps.getRunId(thread, message),
+            }),
+          });
           await processingReactions.stopAll();
         }
       }

--- a/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
@@ -12,10 +12,13 @@ import {
 import { slackApiOutbox } from "../../fixtures/slack-api-outbox";
 import { resetSlackApiMockState } from "../../msw/handlers/slack-api";
 import { createSlackRuntime } from "@/chat/app/factory";
+import type { JuniorRuntimeServiceOverrides } from "@/chat/app/services";
 import type { ReplyExecutorServices } from "@/chat/runtime/reply-executor";
 import type { ReplySteeringMessage } from "@/chat/respond";
 import { createJuniorSlackAdapter } from "@/chat/slack/adapter";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
+import { coerceThreadConversationState } from "@/chat/state/conversation";
+import { getPersistedThreadState } from "@/chat/runtime/thread-state";
 import { createSlackConversationWorker } from "@/chat/task-execution/slack-work";
 import {
   countPendingConversationMessages,
@@ -74,7 +77,31 @@ function reactionTargetsByName(name: string) {
   );
 }
 
+type CompleteObjectOverride = NonNullable<
+  JuniorRuntimeServiceOverrides["subscribedReplyPolicy"]
+>["completeObject"];
+
+interface RouterDecision {
+  confidence: number;
+  reason: string;
+  should_unsubscribe?: boolean;
+  should_reply: boolean;
+}
+
+function completeObjectWithDecision(
+  decide: (prompt: string) => RouterDecision,
+): CompleteObjectOverride {
+  return async (args) => {
+    const decision = decide(args.prompt);
+    return {
+      object: args.schema.parse(decision),
+      text: JSON.stringify(decision),
+    };
+  };
+}
+
 function createTurnHarness(args: {
+  completeObject?: CompleteObjectOverride;
   generateAssistantReply: ReplyExecutorServices["generateAssistantReply"];
   services?: Parameters<typeof createSlackRuntime>[0]["services"];
   state: StateAdapter;
@@ -92,6 +119,15 @@ function createTurnHarness(args: {
       replyExecutor: {
         ...(args.services?.replyExecutor ?? {}),
         generateAssistantReply: args.generateAssistantReply,
+      },
+      subscribedReplyPolicy: {
+        completeObject:
+          args.completeObject ??
+          completeObjectWithDecision(() => ({
+            should_reply: true,
+            confidence: 1,
+            reason: "steering follow-up",
+          })),
       },
     },
   });
@@ -233,6 +269,19 @@ describe("Slack behavior: durable turn steering", () => {
       };
     const { conversationId, queue, runNextQueuedWork, services } =
       createTurnHarness({
+        completeObject: completeObjectWithDecision((prompt) =>
+          prompt.includes("thanks folks")
+            ? {
+                should_reply: false,
+                confidence: 1,
+                reason: "passive side conversation",
+              }
+            : {
+                should_reply: true,
+                confidence: 1,
+                reason: "active steering follow-up",
+              },
+        ),
         generateAssistantReply,
         state,
       });
@@ -255,6 +304,7 @@ describe("Slack behavior: durable turn steering", () => {
 
     for (const followUp of [
       { text: "add customer impact", ts: "1712345.000200" },
+      { text: "thanks folks", ts: "1712345.000250" },
       { text: "include the rollback owner", ts: "1712345.000300" },
       { text: "finish with the next action", ts: "1712345.000400" },
     ]) {
@@ -273,7 +323,7 @@ describe("Slack behavior: durable turn steering", () => {
 
     releaseAgent.resolve();
     await expect(activeTurn).resolves.toEqual({ status: "completed" });
-    expect(queue.sentRecords()).toHaveLength(4);
+    expect(queue.sentRecords()).toHaveLength(5);
 
     expect(agentCalls).toEqual([
       {
@@ -307,9 +357,22 @@ describe("Slack behavior: durable turn steering", () => {
       state,
     });
     expect(work?.messages).toEqual([]);
-    expect(work?.execution.inboundMessageIds).toHaveLength(4);
+    expect(work?.execution.inboundMessageIds).toHaveLength(5);
     expect(work ? countPendingConversationMessages(work) : 0).toBe(0);
     expect(work?.needsRun).toBe(false);
+    const persistedState = await getPersistedThreadState(conversationId);
+    const conversation = coerceThreadConversationState(persistedState);
+    expect(conversation.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          text: "thanks folks",
+          meta: expect.objectContaining({
+            replied: false,
+            skippedReason: "side_conversation:passive side conversation",
+          }),
+        }),
+      ]),
+    );
 
     const expectedReactionTargets = (name: string) =>
       [THREAD_TS, "1712345.000200", "1712345.000300", "1712345.000400"].map(
@@ -337,6 +400,11 @@ describe("Slack behavior: durable turn steering", () => {
     const replyCalls: string[] = [];
     const { conversationId, queue, runNextQueuedWork, services } =
       createTurnHarness({
+        completeObject: completeObjectWithDecision(() => ({
+          should_reply: false,
+          confidence: 1,
+          reason: "side conversation",
+        })),
         generateAssistantReply: async (prompt, context) => {
           replyCalls.push(prompt);
           await context?.onInputCommitted?.();
@@ -344,19 +412,6 @@ describe("Slack behavior: durable turn steering", () => {
             text: "Started.",
             diagnostics: makeDiagnostics(),
           };
-        },
-        services: {
-          subscribedReplyPolicy: {
-            completeObject: async () =>
-              ({
-                object: {
-                  should_reply: false,
-                  confidence: 0,
-                  reason: "side conversation",
-                },
-                text: '{"should_reply":false,"confidence":0,"reason":"side conversation"}',
-              }) as never,
-          },
         },
         state,
       });
@@ -403,6 +458,130 @@ describe("Slack behavior: durable turn steering", () => {
     expect(work?.needsRun).toBe(false);
     expect(queue.sentRecords()).toHaveLength(1);
     expect(replyCalls).toEqual(["start the incident summary"]);
+  });
+
+  it("applies opt-out decisions from drained steering messages without reacting to them", async () => {
+    const agentEntered = deferred();
+    const releaseAgent = deferred();
+    const drainedTexts: string[] = [];
+    const state = getStateAdapter();
+    const generateAssistantReply: ReplyExecutorServices["generateAssistantReply"] =
+      async (_prompt, context) => {
+        await context?.onInputCommitted?.();
+        agentEntered.resolve();
+        await releaseAgent.promise;
+        const drained = await context?.drainSteeringMessages?.(
+          async (messages) => {
+            drainedTexts.push(...messages.map((message) => message.text));
+          },
+        );
+        if (drainedTexts.length === 0 && drained) {
+          drainedTexts.push(...drained.map((message) => message.text));
+        }
+        return {
+          text: "Done with the initial request.",
+          diagnostics: makeDiagnostics(),
+        };
+      };
+    const { conversationId, runNextQueuedWork, services } = createTurnHarness({
+      completeObject: completeObjectWithDecision((prompt) =>
+        prompt.includes("stop watching")
+          ? {
+              should_reply: false,
+              should_unsubscribe: true,
+              confidence: 1,
+              reason: "explicit stop instruction",
+            }
+          : {
+              should_reply: true,
+              confidence: 1,
+              reason: "active steering follow-up",
+            },
+      ),
+      generateAssistantReply,
+      state,
+    });
+
+    await expect(
+      handleSlackWebhookAndFlush({
+        request: slackWebhookRequest(
+          makeMessageEvent({
+            eventType: "app_mention",
+            text: `<@${SLACK_BOT_USER_ID}> start the incident summary`,
+            ts: THREAD_TS,
+          }),
+        ),
+        services,
+      }),
+    ).resolves.toMatchObject({ status: 200 });
+
+    const activeTurn = runNextQueuedWork();
+    await agentEntered.promise;
+
+    await expect(
+      handleSlackWebhookAndFlush({
+        request: slackWebhookRequest(
+          makeMessageEvent({
+            eventType: "message",
+            text: "stop watching this thread",
+            ts: "1712345.000500",
+          }),
+        ),
+        services,
+      }),
+    ).resolves.toMatchObject({ status: 200 });
+    await expect(
+      handleSlackWebhookAndFlush({
+        request: slackWebhookRequest(
+          makeMessageEvent({
+            eventType: "message",
+            text: "also add the rollout timeline",
+            ts: "1712345.000600",
+          }),
+        ),
+        services,
+      }),
+    ).resolves.toMatchObject({ status: 200 });
+
+    releaseAgent.resolve();
+    await expect(activeTurn).resolves.toEqual({ status: "completed" });
+    expect(await state.isSubscribed(conversationId)).toBe(false);
+    expect(drainedTexts).toEqual([]);
+
+    expect(reactionTargetsByName("eyes")).toEqual([
+      {
+        channel: CHANNEL_ID,
+        name: "eyes",
+        timestamp: THREAD_TS,
+      },
+    ]);
+    expect(reactionTargetsByName("white_check_mark")).toEqual([
+      {
+        channel: CHANNEL_ID,
+        name: "white_check_mark",
+        timestamp: THREAD_TS,
+      },
+    ]);
+    const persistedState = await getPersistedThreadState(conversationId);
+    const conversation = coerceThreadConversationState(persistedState);
+    expect(conversation.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          text: "stop watching this thread",
+          meta: expect.objectContaining({
+            replied: false,
+            skippedReason: "thread_opt_out:explicit stop instruction",
+          }),
+        }),
+        expect.objectContaining({
+          text: "also add the rollout timeline",
+          meta: expect.objectContaining({
+            replied: false,
+            skippedReason: "thread_opt_out:batch opt-out",
+          }),
+        }),
+      ]),
+    );
   });
 
   it("keeps the mailbox pending when the agent fails before input commit", async () => {

--- a/packages/junior/tests/unit/slack/slack-runtime.test.ts
+++ b/packages/junior/tests/unit/slack/slack-runtime.test.ts
@@ -29,7 +29,8 @@ function createMockDeps(
     logException: vi.fn(() => "evt_test"),
     logWarn: vi.fn(),
     onSubscribedMessageSkipped: vi.fn().mockResolvedValue(undefined),
-    recordSkippedSubscribedMessage: vi.fn().mockResolvedValue(undefined),
+    recordSkippedSteeringMessage: vi.fn().mockResolvedValue(undefined),
+    recordSkippedSubscribedTurn: vi.fn().mockResolvedValue(undefined),
     persistPreparedState: vi.fn().mockResolvedValue(undefined),
     prepareTurnState: vi
       .fn()

--- a/specs/slack-agent-delivery.md
+++ b/specs/slack-agent-delivery.md
@@ -220,7 +220,7 @@ Current rules:
 7. Automatic auth resumes must not post a separate public "account connected, continuing..." banner before the real resumed answer. The resumed answer itself is the visible continuation.
 8. If auth completes after a newer thread message already replaced the blocked request, Junior stores the credentials but does not post a stale resumed answer.
 9. Routine cooperative continuation must not post a visible "continuing in the background" thread acknowledgement. User-visible progress belongs to assistant status and `reportProgress`; final answers still use the finalized reply path.
-10. If a user follow-up or duplicate delivery arrives while a turn is active, Junior should fold it into the active conversation at the next safe execution boundary instead of creating a second visible turn. Mailbox and worker mechanics belong to `./task-execution.md`.
+10. If a user follow-up or duplicate delivery arrives while a turn is active, Junior should fold reply-eligible steering messages into the active conversation at the next safe execution boundary instead of creating a second visible turn. Skipped steering messages, including passive no-reply and opt-out decisions, are consumed and persisted for later context without agent injection or automatic processing reactions. Mailbox and worker mechanics belong to `./task-execution.md`.
 11. Any explicit pause acknowledgement that remains for auth or exceptional failure handling is not a final assistant reply. It does not mark the original turn completed, and the final resumed answer must still be delivered through the normal finalized-reply path.
 
 ### 12. Testing Contract


### PR DESCRIPTION
Drained Slack steering messages now pass through the subscribed-thread routing decision before Junior injects them into an active turn or starts automatic processing reactions. Passive drained messages are consumed without `:eyes:` or completion reactions, while accepted steering messages keep the existing acknowledgement lifecycle.

Rejected steering messages are still recorded as skipped thread context, including opt-out decisions, without completing the active turn. The drain path also receives the prepared conversation context so mention-started turns classify follow-ups with the same routing context as subscribed turns, and rejected records are reapplied after terminal state writes so passive context is not lost.

Fixes GH-564