### PR TITLE
fix(reporting): Anchor transcript view to primary user message, not last user message

### DIFF
--- a/packages/junior/src/reporting.ts
+++ b/packages/junior/src/reporting.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { isRecord } from "@/chat/coerce";
+import { TURN_CONTEXT_TAG } from "@/chat/turn-context-tag";
 import { homeDir } from "@/chat/discovery";
 import type { PiMessage } from "@/chat/pi/messages";
 import type { AgentTurnUsage } from "@/chat/usage";
@@ -1042,7 +1043,38 @@ interface ScopedTurnMessages {
   startsAtRunBoundary: boolean;
 }
 
+const RUNTIME_TURN_CONTEXT_START = `<${TURN_CONTEXT_TAG}>`;
+
+function messageHasRuntimeTurnContext(
+  record: Record<string, unknown>,
+): boolean {
+  if (record.role !== "user" || !Array.isArray(record.content)) return false;
+  return record.content.some(
+    (part) =>
+      part !== null &&
+      typeof part === "object" &&
+      (part as { type?: unknown }).type === "text" &&
+      typeof (part as { text?: unknown }).text === "string" &&
+      (part as { text: string }).text.startsWith(RUNTIME_TURN_CONTEXT_START),
+  );
+}
+
 function turnScopedMessages(messages: PiMessage[]): ScopedTurnMessages {
+  // Prefer the last user message that carries the runtime turn context marker,
+  // since that is the primary user input for the turn. Steering messages are
+  // also user-role Pi messages but never carry this marker, so they must not
+  // be mistaken for the turn boundary.
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const record = messages[index] as unknown as Record<string, unknown>;
+    if (record.role === "user" && messageHasRuntimeTurnContext(record)) {
+      return {
+        messages: messages.slice(index),
+        startsAtRunBoundary: index === 0,
+      };
+    }
+  }
+  // Fall back to the last user message when no runtime context marker is found
+  // (e.g. very old session records that predate the marker).
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const record = messages[index] as unknown as Record<string, unknown>;
     if (record.role === "user") {


### PR DESCRIPTION
## Problem

When a Slack thread had messages arrive mid-turn (steering messages injected via `agent.steer()`), the dashboard transcript viewer dropped the original `@mention` message and showed only the steering message onward.

**Root cause:** `turnScopedMessages` in `reporting.ts` searched backwards for the last `user`-role Pi message to identify the start of "this turn's work". This assumed one user message per turn. Steering messages injected mid-turn are also `user`-role Pi messages. When present, the function selected the steering message as the turn boundary, slicing the original user input off the front of the transcript.

**What you'd see in the dashboard:** Turn transcript starting at the steered message (e.g. a reply from someone else in the thread that arrived while Junior was processing), with the original `@mention` missing entirely.

## Fix

Search backwards for the last `user` message that carries the `<runtime-turn-context>` marker. This marker is injected only into the primary user input for a turn (via `buildTurnContextPrompt`), never into steering messages. When found, use that as the transcript boundary.

Falls back to the previous last-user-message behavior for old session records that predate the marker.

## Verification

- `typecheck` ✅
- `dashboard-mock-routes.test.ts` (4 tests) ✅

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC0B595QDZLL%3A1781015001.325269%22)