### PR TITLE
fix(sandbox): Propagate trace context through egress

### DIFF
--- a/packages/docs/src/content/docs/reference/api/functions/createApp.md
+++ b/packages/docs/src/content/docs/reference/api/functions/createApp.md
@@ -7,7 +7,7 @@ title: "createApp"
 
 > **createApp**(`options?`): `Promise`\<`Hono`\<`BlankEnv`, `BlankSchema`, `"/"`\>\>
 
-Defined in: [junior/src/app.ts:325](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L325)
+Defined in: [junior/src/app.ts:329](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L329)
 
 Create a Hono app with all Junior routes.
 

--- a/packages/docs/src/content/docs/reference/api/functions/createApp.md
+++ b/packages/docs/src/content/docs/reference/api/functions/createApp.md
@@ -7,7 +7,7 @@ title: "createApp"
 
 > **createApp**(`options?`): `Promise`\<`Hono`\<`BlankEnv`, `BlankSchema`, `"/"`\>\>
 
-Defined in: [junior/src/app.ts:316](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L316)
+Defined in: [junior/src/app.ts:325](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L325)
 
 Create a Hono app with all Junior routes.
 

--- a/packages/docs/src/content/docs/reference/api/interfaces/JuniorAppOptions.md
+++ b/packages/docs/src/content/docs/reference/api/interfaces/JuniorAppOptions.md
@@ -52,6 +52,8 @@ Sandbox execution options.
 > `optional` **egressTracePropagationDomains?**: `string`[]
 
 Egress domains allowed to carry Sentry trace propagation headers.
+Entries may be exact domains or leading wildcard domains such as
+`*.sentry.io`; wildcard entries match subdomains, not the apex domain.
 
 ---
 
@@ -81,4 +83,4 @@ Slack emoji shown while Junior is processing. Defaults to `eyes`.
 
 > `optional` **waitUntil?**: `WaitUntilFn`
 
-Defined in: [junior/src/app.ts:77](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L77)
+Defined in: [junior/src/app.ts:81](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L81)

--- a/packages/docs/src/content/docs/reference/api/interfaces/JuniorAppOptions.md
+++ b/packages/docs/src/content/docs/reference/api/interfaces/JuniorAppOptions.md
@@ -5,7 +5,7 @@ prev: false
 title: "JuniorAppOptions"
 ---
 
-Defined in: [junior/src/app.ts:54](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L54)
+Defined in: [junior/src/app.ts:58](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L58)
 
 ## Properties
 
@@ -13,7 +13,7 @@ Defined in: [junior/src/app.ts:54](https://github.com/getsentry/junior/blob/main
 
 > `optional` **configDefaults?**: `Record`\<`string`, `unknown`\>
 
-Defined in: [junior/src/app.ts:63](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L63)
+Defined in: [junior/src/app.ts:67](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L67)
 
 Install-wide provider defaults (`provider.key` format). Channel overrides take precedence.
 
@@ -23,7 +23,7 @@ Install-wide provider defaults (`provider.key` format). Channel overrides take p
 
 > `optional` **conversationWork?**: `VercelConversationWorkCallbackOptions`
 
-Defined in: [junior/src/app.ts:65](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L65)
+Defined in: [junior/src/app.ts:69](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L69)
 
 Queue consumer wiring for the durable conversation worker.
 
@@ -33,9 +33,25 @@ Queue consumer wiring for the durable conversation worker.
 
 > `optional` **plugins?**: [`JuniorPluginSet`](/reference/api/interfaces/juniorpluginset/)
 
-Defined in: [junior/src/app.ts:67](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L67)
+Defined in: [junior/src/app.ts:71](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L71)
 
 Direct plugin set override. Usually omitted when `juniorNitro()` uses a plugin module.
+
+---
+
+### sandbox?
+
+> `optional` **sandbox?**: `object`
+
+Defined in: [junior/src/app.ts:73](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L73)
+
+Sandbox execution options.
+
+#### egressTracePropagationDomains?
+
+> `optional` **egressTracePropagationDomains?**: `string`[]
+
+Egress domains allowed to carry Sentry trace propagation headers.
 
 ---
 
@@ -43,7 +59,7 @@ Direct plugin set override. Usually omitted when `juniorNitro()` uses a plugin m
 
 > `optional` **slack?**: `object`
 
-Defined in: [junior/src/app.ts:56](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L56)
+Defined in: [junior/src/app.ts:60](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L60)
 
 Slack-specific overrides applied after env parsing.
 
@@ -65,4 +81,4 @@ Slack emoji shown while Junior is processing. Defaults to `eyes`.
 
 > `optional` **waitUntil?**: `WaitUntilFn`
 
-Defined in: [junior/src/app.ts:68](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L68)
+Defined in: [junior/src/app.ts:77](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L77)

--- a/packages/docs/src/content/docs/reference/config-and-env.md
+++ b/packages/docs/src/content/docs/reference/config-and-env.md
@@ -114,6 +114,22 @@ const app = await createApp({
 
 Keys must be registered plugin config keys. Channel-scoped overrides (`jr-rpc config set`) take precedence.
 
+## Sandbox egress trace propagation
+
+Pass `sandbox.egressTracePropagationDomains` to `createApp()` when sandboxed commands should keep Sentry trace context across proxied egress:
+
+```ts
+import { createApp } from "@sentry/junior";
+
+const app = await createApp({
+  sandbox: {
+    egressTracePropagationDomains: ["sentry.io", "*.sentry.io"],
+  },
+});
+```
+
+Entries may be exact domains or leading wildcard domains. The wildcard form matches subdomains, not the apex domain, so include both forms when needed.
+
 ## Verification
 
 - Validate required variables exist in deployment environment.

--- a/packages/docs/src/content/docs/reference/config-and-env.md
+++ b/packages/docs/src/content/docs/reference/config-and-env.md
@@ -116,7 +116,7 @@ Keys must be registered plugin config keys. Channel-scoped overrides (`jr-rpc co
 
 ## Sandbox egress trace propagation
 
-Pass `sandbox.egressTracePropagationDomains` to `createApp()` when sandboxed commands should keep Sentry trace context across proxied egress:
+Pass `sandbox.egressTracePropagationDomains` to `createApp()` when sandboxed commands should keep Sentry trace context across sandbox network egress:
 
 ```ts
 import { createApp } from "@sentry/junior";
@@ -127,6 +127,8 @@ const app = await createApp({
   },
 });
 ```
+
+Configured non-provider domains receive trace-header transforms without requiring credential proxying.
 
 Entries may be exact domains or leading wildcard domains. The wildcard form matches subdomains, not the apex domain, so include both forms when needed.
 

--- a/packages/junior/src/app.ts
+++ b/packages/junior/src/app.ts
@@ -5,6 +5,7 @@ import {
 } from "@/chat/configuration/defaults";
 import { getSlackReactionConfig, setSlackReactionConfig } from "@/chat/config";
 import { logException } from "@/chat/logging";
+import { generateAssistantReply } from "@/chat/respond";
 import { normalizeSandboxEgressTracePropagationDomains } from "@/chat/sandbox/egress-tracing";
 import {
   getPluginCatalogSignature,
@@ -46,6 +47,7 @@ import {
   createProductionConversationWorkOptions,
   createProductionSlackWebhookServices,
 } from "@/chat/app/production";
+import { withSandboxTracePropagation } from "@/chat/app/services";
 import type { WaitUntilFn } from "@/handlers/types";
 
 export { defineJuniorPlugins } from "./plugins";
@@ -382,6 +384,10 @@ export async function createApp(options?: JuniorAppOptions): Promise<Hono> {
   const slackWebhookServices = createProductionSlackWebhookServices({
     services: runtimeServiceOverrides,
   });
+  const generateReplyWithTracePropagation = withSandboxTracePropagation(
+    generateAssistantReply,
+    runtimeServiceOverrides.sandbox.tracePropagation,
+  );
 
   const app = new Hono();
 
@@ -409,11 +415,15 @@ export async function createApp(options?: JuniorAppOptions): Promise<Hono> {
   // MCP callback must be registered before the generic OAuth callback
   // because Hono matches routes top-down and `:provider` would swallow `mcp/`.
   app.get("/api/oauth/callback/mcp/:provider", (c) => {
-    return mcpOauthCallbackGET(c.req.raw, c.req.param("provider"), waitUntil);
+    return mcpOauthCallbackGET(c.req.raw, c.req.param("provider"), waitUntil, {
+      generateReply: generateReplyWithTracePropagation,
+    });
   });
 
   app.get("/api/oauth/callback/:provider", (c) => {
-    return oauthCallbackGET(c.req.raw, c.req.param("provider"), waitUntil);
+    return oauthCallbackGET(c.req.raw, c.req.param("provider"), waitUntil, {
+      generateReply: generateReplyWithTracePropagation,
+    });
   });
 
   app.post("/api/internal/agent-dispatch", (c) => {

--- a/packages/junior/src/app.ts
+++ b/packages/junior/src/app.ts
@@ -347,11 +347,12 @@ export async function createApp(options?: JuniorAppOptions): Promise<Hono> {
   const previousConfigDefaults = getConfigDefaults();
   const previousSlackReactionConfig = getSlackReactionConfig();
   let agentPluginRoutes: AgentPluginRouteRegistration[] = [];
-  const sandboxEgressTracePropagationDomains =
-    normalizeSandboxEgressTracePropagationDomains(
-      options?.sandbox?.egressTracePropagationDomains,
-    );
+  let sandboxEgressTracePropagationDomains: string[] = [];
   try {
+    sandboxEgressTracePropagationDomains =
+      normalizeSandboxEgressTracePropagationDomains(
+        options?.sandbox?.egressTracePropagationDomains,
+      );
     setConfigDefaults(options?.configDefaults);
     if (options?.slack) {
       setSlackReactionConfig(options.slack);

--- a/packages/junior/src/app.ts
+++ b/packages/junior/src/app.ts
@@ -6,6 +6,10 @@ import {
 import { getSlackReactionConfig, setSlackReactionConfig } from "@/chat/config";
 import { logException } from "@/chat/logging";
 import {
+  getSandboxEgressTracePropagationDomains,
+  setSandboxEgressTracePropagationDomains,
+} from "@/chat/sandbox/egress-tracing";
+import {
   getPluginCatalogSignature,
   getPluginProviders,
   setPluginCatalogConfig,
@@ -65,6 +69,11 @@ export interface JuniorAppOptions {
   conversationWork?: VercelConversationWorkCallbackOptions;
   /** Direct plugin set override. Usually omitted when `juniorNitro()` uses a plugin module. */
   plugins?: JuniorPluginSet;
+  /** Sandbox execution options. */
+  sandbox?: {
+    /** Egress domains allowed to carry Sentry trace propagation headers. */
+    egressTracePropagationDomains?: string[];
+  };
   waitUntil?: WaitUntilFn;
 }
 
@@ -332,10 +341,15 @@ export async function createApp(options?: JuniorAppOptions): Promise<Hono> {
   const previousPluginCatalogConfig = setPluginCatalogConfig(pluginConfig);
   const previousAgentPlugins = setAgentPlugins(agentPlugins);
   const previousConfigDefaults = getConfigDefaults();
+  const previousSandboxEgressTracePropagationDomains =
+    getSandboxEgressTracePropagationDomains();
   const previousSlackReactionConfig = getSlackReactionConfig();
   let agentPluginRoutes: AgentPluginRouteRegistration[] = [];
   try {
     setConfigDefaults(options?.configDefaults);
+    setSandboxEgressTracePropagationDomains(
+      options?.sandbox?.egressTracePropagationDomains,
+    );
     if (options?.slack) {
       setSlackReactionConfig(options.slack);
     }
@@ -351,6 +365,9 @@ export async function createApp(options?: JuniorAppOptions): Promise<Hono> {
     setPluginCatalogConfig(previousPluginCatalogConfig);
     setAgentPlugins(previousAgentPlugins);
     setConfigDefaults(previousConfigDefaults);
+    setSandboxEgressTracePropagationDomains(
+      previousSandboxEgressTracePropagationDomains,
+    );
     setSlackReactionConfig(previousSlackReactionConfig);
     throw error;
   }

--- a/packages/junior/src/app.ts
+++ b/packages/junior/src/app.ts
@@ -5,10 +5,7 @@ import {
 } from "@/chat/configuration/defaults";
 import { getSlackReactionConfig, setSlackReactionConfig } from "@/chat/config";
 import { logException } from "@/chat/logging";
-import {
-  getSandboxEgressTracePropagationDomains,
-  setSandboxEgressTracePropagationDomains,
-} from "@/chat/sandbox/egress-tracing";
+import { normalizeSandboxEgressTracePropagationDomains } from "@/chat/sandbox/egress-tracing";
 import {
   getPluginCatalogSignature,
   getPluginProviders,
@@ -44,9 +41,12 @@ import {
   createVercelConversationWorkCallback,
   registerVercelConversationWorkDevConsumer,
   type VercelConversationWorkCallbackOptions,
-} from "./chat/task-execution/vercel-callback";
-import { getProductionConversationWorkOptions } from "@/chat/app/production";
-import type { WaitUntilFn } from "./handlers/types";
+} from "@/chat/task-execution/vercel-callback";
+import {
+  createProductionConversationWorkOptions,
+  createProductionSlackWebhookServices,
+} from "@/chat/app/production";
+import type { WaitUntilFn } from "@/handlers/types";
 
 export { defineJuniorPlugins } from "./plugins";
 export type {
@@ -71,7 +71,11 @@ export interface JuniorAppOptions {
   plugins?: JuniorPluginSet;
   /** Sandbox execution options. */
   sandbox?: {
-    /** Egress domains allowed to carry Sentry trace propagation headers. */
+    /**
+     * Egress domains allowed to carry Sentry trace propagation headers.
+     * Entries may be exact domains or leading wildcard domains such as
+     * `*.sentry.io`; wildcard entries match subdomains, not the apex domain.
+     */
     egressTracePropagationDomains?: string[];
   };
   waitUntil?: WaitUntilFn;
@@ -341,15 +345,14 @@ export async function createApp(options?: JuniorAppOptions): Promise<Hono> {
   const previousPluginCatalogConfig = setPluginCatalogConfig(pluginConfig);
   const previousAgentPlugins = setAgentPlugins(agentPlugins);
   const previousConfigDefaults = getConfigDefaults();
-  const previousSandboxEgressTracePropagationDomains =
-    getSandboxEgressTracePropagationDomains();
   const previousSlackReactionConfig = getSlackReactionConfig();
   let agentPluginRoutes: AgentPluginRouteRegistration[] = [];
-  try {
-    setConfigDefaults(options?.configDefaults);
-    setSandboxEgressTracePropagationDomains(
+  const sandboxEgressTracePropagationDomains =
+    normalizeSandboxEgressTracePropagationDomains(
       options?.sandbox?.egressTracePropagationDomains,
     );
+  try {
+    setConfigDefaults(options?.configDefaults);
     if (options?.slack) {
       setSlackReactionConfig(options.slack);
     }
@@ -365,14 +368,19 @@ export async function createApp(options?: JuniorAppOptions): Promise<Hono> {
     setPluginCatalogConfig(previousPluginCatalogConfig);
     setAgentPlugins(previousAgentPlugins);
     setConfigDefaults(previousConfigDefaults);
-    setSandboxEgressTracePropagationDomains(
-      previousSandboxEgressTracePropagationDomains,
-    );
     setSlackReactionConfig(previousSlackReactionConfig);
     throw error;
   }
 
   const waitUntil = options?.waitUntil ?? (await defaultWaitUntil());
+  const runtimeServiceOverrides = {
+    sandbox: {
+      tracePropagation: { domains: sandboxEgressTracePropagationDomains },
+    },
+  };
+  const slackWebhookServices = createProductionSlackWebhookServices({
+    services: runtimeServiceOverrides,
+  });
 
   const app = new Hono();
 
@@ -385,7 +393,9 @@ export async function createApp(options?: JuniorAppOptions): Promise<Hono> {
     // Vercel Sandbox proxying preserves the original upstream path, so detect
     // authenticated proxy traffic before ordinary application routes claim it.
     if (isSandboxEgressRequest(c.req.raw)) {
-      return await sandboxEgressProxyALL(c.req.raw);
+      return await sandboxEgressProxyALL(c.req.raw, {
+        tracePropagation: { domains: sandboxEgressTracePropagationDomains },
+      });
     }
     await next();
   });
@@ -406,7 +416,9 @@ export async function createApp(options?: JuniorAppOptions): Promise<Hono> {
   });
 
   app.post("/api/internal/agent-dispatch", (c) => {
-    return agentDispatchPOST(c.req.raw, waitUntil);
+    return agentDispatchPOST(c.req.raw, waitUntil, {
+      tracePropagation: { domains: sandboxEgressTracePropagationDomains },
+    });
   });
 
   let agentContinuePOST:
@@ -417,7 +429,10 @@ export async function createApp(options?: JuniorAppOptions): Promise<Hono> {
     | undefined;
   const getConversationWorkOptions = () => {
     conversationWorkOptions ??=
-      options?.conversationWork ?? getProductionConversationWorkOptions();
+      options?.conversationWork ??
+      createProductionConversationWorkOptions({
+        services: runtimeServiceOverrides,
+      });
     return conversationWorkOptions;
   };
   if (process.env.NODE_ENV === "development") {
@@ -435,7 +450,12 @@ export async function createApp(options?: JuniorAppOptions): Promise<Hono> {
   });
 
   app.post("/api/webhooks/:platform", (c) => {
-    return webhooksPOST(c.req.raw, c.req.param("platform"), waitUntil);
+    return webhooksPOST(
+      c.req.raw,
+      c.req.param("platform"),
+      waitUntil,
+      slackWebhookServices,
+    );
   });
 
   return app;

--- a/packages/junior/src/chat/agent-dispatch/runner.ts
+++ b/packages/junior/src/chat/agent-dispatch/runner.ts
@@ -11,6 +11,7 @@ import {
   generateAssistantReply as generateAssistantReplyImpl,
   type AssistantReply,
 } from "@/chat/respond";
+import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress-tracing";
 import { logException } from "@/chat/logging";
 import {
   buildConversationContext,
@@ -61,6 +62,7 @@ const DISPATCH_SLICE_LEASE_MS = 5 * 60 * 1000;
 export interface AgentDispatchRunnerDeps {
   generateAssistantReply?: typeof generateAssistantReplyImpl;
   scheduleCallback?: typeof scheduleDispatchCallback;
+  tracePropagation?: SandboxEgressTracePropagationConfig;
 }
 
 function getUserMessageId(dispatch: DispatchRecord): string {
@@ -304,6 +306,7 @@ export async function runAgentDispatchSlice(
       sandbox: {
         sandboxId,
         sandboxDependencyProfileHash,
+        tracePropagation: deps.tracePropagation,
       },
       onSandboxAcquired: async (sandbox) => {
         sandboxId = sandbox.sandboxId;

--- a/packages/junior/src/chat/app/production.ts
+++ b/packages/junior/src/chat/app/production.ts
@@ -1,5 +1,6 @@
 import type { SlackAdapter } from "@chat-adapter/slack";
 import { createSlackRuntime } from "@/chat/app/factory";
+import { withSandboxTracePropagation } from "@/chat/app/services";
 import { createUserTokenStore } from "@/chat/capabilities/factory";
 import {
   getSlackBotToken,
@@ -15,6 +16,7 @@ import { getVercelConversationWorkQueue } from "@/chat/task-execution/vercel-que
 import type { VercelConversationWorkCallbackOptions } from "@/chat/task-execution/vercel-callback";
 import { resumeAwaitingSlackContinuation } from "@/chat/runtime/agent-continue-runner";
 import type { JuniorRuntimeServiceOverrides } from "@/chat/app/services";
+import { generateAssistantReply } from "@/chat/respond";
 
 let productionSlackAdapter: SlackAdapter | undefined;
 let productionSlackRuntime: ReturnType<typeof createSlackRuntime> | undefined;
@@ -92,7 +94,13 @@ export function createProductionConversationWorkOptions(options?: {
     queue: getVercelConversationWorkQueue(),
     run: createSlackConversationWorker({
       getSlackAdapter: getProductionSlackAdapter,
-      resumeAwaitingContinuation: resumeAwaitingSlackContinuation,
+      resumeAwaitingContinuation: async (conversationId) =>
+        await resumeAwaitingSlackContinuation(conversationId, {
+          generateReply: withSandboxTracePropagation(
+            generateAssistantReply,
+            options?.services?.sandbox?.tracePropagation,
+          ),
+        }),
       runtime,
     }),
   };

--- a/packages/junior/src/chat/app/production.ts
+++ b/packages/junior/src/chat/app/production.ts
@@ -14,6 +14,7 @@ import { createSlackConversationWorker } from "@/chat/task-execution/slack-work"
 import { getVercelConversationWorkQueue } from "@/chat/task-execution/vercel-queue";
 import type { VercelConversationWorkCallbackOptions } from "@/chat/task-execution/vercel-callback";
 import { resumeAwaitingSlackContinuation } from "@/chat/runtime/agent-continue-runner";
+import type { JuniorRuntimeServiceOverrides } from "@/chat/app/services";
 
 let productionSlackAdapter: SlackAdapter | undefined;
 let productionSlackRuntime: ReturnType<typeof createSlackRuntime> | undefined;
@@ -53,6 +54,22 @@ export function getProductionSlackRuntime(): ReturnType<
   return productionSlackRuntime;
 }
 
+/** Create production-backed services for Slack webhook ingress. */
+export function createProductionSlackWebhookServices(options?: {
+  services?: JuniorRuntimeServiceOverrides;
+}): SlackWebhookServices {
+  const runtime = createSlackRuntime({
+    getSlackAdapter: getProductionSlackAdapter,
+    services: options?.services,
+  });
+  return {
+    getSlackAdapter: getProductionSlackAdapter,
+    getUserTokenStore: createUserTokenStore,
+    queue: getVercelConversationWorkQueue(),
+    runtime,
+  };
+}
+
 /** Return production services for Slack webhook ingress. */
 export function getProductionSlackWebhookServices(): SlackWebhookServices {
   return {
@@ -60,6 +77,24 @@ export function getProductionSlackWebhookServices(): SlackWebhookServices {
     getUserTokenStore: createUserTokenStore,
     queue: getVercelConversationWorkQueue(),
     runtime: getProductionSlackRuntime(),
+  };
+}
+
+/** Return the production queue callback options for conversation work. */
+export function createProductionConversationWorkOptions(options?: {
+  services?: JuniorRuntimeServiceOverrides;
+}): VercelConversationWorkCallbackOptions {
+  const runtime = createSlackRuntime({
+    getSlackAdapter: getProductionSlackAdapter,
+    services: options?.services,
+  });
+  return {
+    queue: getVercelConversationWorkQueue(),
+    run: createSlackConversationWorker({
+      getSlackAdapter: getProductionSlackAdapter,
+      resumeAwaitingContinuation: resumeAwaitingSlackContinuation,
+      runtime,
+    }),
   };
 }
 

--- a/packages/junior/src/chat/app/production.ts
+++ b/packages/junior/src/chat/app/production.ts
@@ -105,16 +105,3 @@ export function createProductionConversationWorkOptions(options?: {
     }),
   };
 }
-
-/** Return the production queue callback options for conversation work. */
-export function getProductionConversationWorkOptions(): VercelConversationWorkCallbackOptions {
-  const runtime = getProductionSlackRuntime();
-  return {
-    queue: getVercelConversationWorkQueue(),
-    run: createSlackConversationWorker({
-      getSlackAdapter: getProductionSlackAdapter,
-      resumeAwaitingContinuation: resumeAwaitingSlackContinuation,
-      runtime,
-    }),
-  };
-}

--- a/packages/junior/src/chat/app/services.ts
+++ b/packages/junior/src/chat/app/services.ts
@@ -52,6 +52,22 @@ export interface JuniorRuntimeServiceOverrides {
   visionContext?: Partial<VisionContextDeps>;
 }
 
+/** Apply app-owned sandbox egress trace config unless a turn overrides it. */
+export function withSandboxTracePropagation(
+  generateReply: typeof generateAssistantReplyImpl,
+  tracePropagation?: SandboxEgressTracePropagationConfig,
+): typeof generateAssistantReplyImpl {
+  return async (messageText: string, context?: ReplyRequestContext) =>
+    await generateReply(messageText, {
+      ...context,
+      sandbox: {
+        ...context?.sandbox,
+        tracePropagation:
+          context?.sandbox?.tracePropagation ?? tracePropagation,
+      },
+    });
+}
+
 export function createJuniorRuntimeServices(
   overrides: JuniorRuntimeServiceOverrides = {},
 ): JuniorRuntimeServices {
@@ -79,16 +95,10 @@ export function createJuniorRuntimeServices(
         overrides.replyExecutor?.contextCompactor ?? contextCompactor,
       generateAssistantReply:
         overrides.replyExecutor?.generateAssistantReply ??
-        (async (messageText: string, context?: ReplyRequestContext) =>
-          await generateAssistantReplyImpl(messageText, {
-            ...context,
-            sandbox: {
-              ...context?.sandbox,
-              tracePropagation:
-                context?.sandbox?.tracePropagation ??
-                overrides.sandbox?.tracePropagation,
-            },
-          })),
+        withSandboxTracePropagation(
+          generateAssistantReplyImpl,
+          overrides.sandbox?.tracePropagation,
+        ),
       getAwaitingAgentContinueRequest:
         overrides.replyExecutor?.getAwaitingAgentContinueRequest ??
         getAwaitingAgentContinueRequest,

--- a/packages/junior/src/chat/app/services.ts
+++ b/packages/junior/src/chat/app/services.ts
@@ -1,5 +1,9 @@
 import { completeObject, completeText } from "@/chat/pi/client";
-import { generateAssistantReply as generateAssistantReplyImpl } from "@/chat/respond";
+import {
+  generateAssistantReply as generateAssistantReplyImpl,
+  type ReplyRequestContext,
+} from "@/chat/respond";
+import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress-tracing";
 import {
   getAwaitingAgentContinueRequest,
   scheduleAgentContinue,
@@ -42,6 +46,9 @@ export interface JuniorRuntimeServiceOverrides {
   contextCompactor?: Partial<ContextCompactorDeps>;
   replyExecutor?: Partial<Omit<ReplyExecutorServices, "generateThreadTitle">>;
   subscribedReplyPolicy?: Partial<SubscribedReplyPolicyDeps>;
+  sandbox?: {
+    tracePropagation?: SandboxEgressTracePropagationConfig;
+  };
   visionContext?: Partial<VisionContextDeps>;
 }
 
@@ -72,7 +79,16 @@ export function createJuniorRuntimeServices(
         overrides.replyExecutor?.contextCompactor ?? contextCompactor,
       generateAssistantReply:
         overrides.replyExecutor?.generateAssistantReply ??
-        generateAssistantReplyImpl,
+        (async (messageText: string, context?: ReplyRequestContext) =>
+          await generateAssistantReplyImpl(messageText, {
+            ...context,
+            sandbox: {
+              ...context?.sandbox,
+              tracePropagation:
+                context?.sandbox?.tracePropagation ??
+                overrides.sandbox?.tracePropagation,
+            },
+          })),
       getAwaitingAgentContinueRequest:
         overrides.replyExecutor?.getAwaitingAgentContinueRequest ??
         getAwaitingAgentContinueRequest,

--- a/packages/junior/src/chat/logging.ts
+++ b/packages/junior/src/chat/logging.ts
@@ -50,6 +50,10 @@ export interface LogContext {
   userAgent?: string;
 }
 
+export type TracePropagationHeaders = Partial<
+  Record<"baggage" | "sentry-trace" | "traceparent", string>
+>;
+
 interface SentryLoggerApi {
   debug?: (message: string, attributes?: Record<string, unknown>) => void;
   info?: (message: string, attributes?: Record<string, unknown>) => void;
@@ -1642,6 +1646,28 @@ export async function withSpan<T>(
       callback,
     );
   });
+}
+
+/** Return Sentry-standard trace propagation headers for the active span. */
+export function getTracePropagationHeaders(): TracePropagationHeaders {
+  const sentry = Sentry as unknown as {
+    getTraceData?: (options?: {
+      propagateTraceparent?: boolean;
+    }) => Record<string, unknown>;
+  };
+  const traceData = sentry.getTraceData?.({ propagateTraceparent: true });
+  if (!traceData) {
+    return {};
+  }
+
+  const headers: TracePropagationHeaders = {};
+  for (const key of ["sentry-trace", "baggage", "traceparent"] as const) {
+    const value = traceData[key];
+    if (typeof value === "string" && value.trim()) {
+      headers[key] = value;
+    }
+  }
+  return headers;
 }
 
 /** Set attributes on the currently active Sentry span. */

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -76,6 +76,7 @@ import {
   type SandboxAcquiredState,
   type SandboxExecutor,
 } from "@/chat/sandbox/sandbox";
+import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress-tracing";
 import type { SandboxWorkspace } from "@/chat/sandbox/workspace";
 import { shouldEmitDevAgentTrace } from "@/chat/runtime/dev-agent-trace";
 import type { AssistantStatusSpec } from "@/chat/slack/assistant-thread/status";
@@ -228,6 +229,8 @@ export interface ReplyRequestContext {
   sandbox?: {
     sandboxId?: string;
     sandboxDependencyProfileHash?: string;
+    /** Per-turn override for app-owned sandbox egress trace propagation. */
+    tracePropagation?: SandboxEgressTracePropagationConfig;
   };
   onSandboxAcquired?: (sandbox: SandboxAcquiredState) => void | Promise<void>;
   onArtifactStateUpdated?: (
@@ -684,6 +687,7 @@ export async function generateAssistantReply(
       sandboxDependencyProfileHash:
         context.sandbox?.sandboxDependencyProfileHash,
       traceContext: spanContext,
+      tracePropagation: context.sandbox?.tracePropagation,
       credentialEgress: context.credentialContext,
       agentHooks: agentPluginHooks,
       onSandboxAcquired: async (sandbox) => {

--- a/packages/junior/src/chat/runtime/agent-continue-runner.ts
+++ b/packages/junior/src/chat/runtime/agent-continue-runner.ts
@@ -368,6 +368,7 @@ export async function continueSlackAgentRun(
 /** Resume the first valid paused Slack session for an idle conversation. */
 export async function resumeAwaitingSlackContinuation(
   conversationId: string,
+  options: AgentContinueRunnerOptions = {},
 ): Promise<boolean> {
   const summaries =
     await listAgentTurnSessionSummariesForConversation(conversationId);
@@ -391,7 +392,7 @@ export async function resumeAwaitingSlackContinuation(
       continue;
     }
 
-    if (await continueSlackAgentRunWithLockRetry(request)) {
+    if (await continueSlackAgentRunWithLockRetry(request, options)) {
       return true;
     }
 

--- a/packages/junior/src/chat/sandbox/egress-policy.ts
+++ b/packages/junior/src/chat/sandbox/egress-policy.ts
@@ -2,6 +2,7 @@ import type { NetworkPolicy, NetworkPolicyRule } from "@vercel/sandbox";
 import { resolveBaseUrl } from "@/chat/oauth-flow";
 import type { TracePropagationHeaders } from "@/chat/logging";
 import { SANDBOX_EGRESS_PROXY_PATH } from "@/chat/sandbox/egress-session";
+import { shouldPropagateSandboxEgressTrace } from "@/chat/sandbox/egress-tracing";
 import { resolveAuthTokenPlaceholder } from "@/chat/plugins/auth/auth-token-placeholder";
 import { resolvePluginCommandEnv } from "@/chat/plugins/command-env";
 import { getPluginProviders } from "@/chat/plugins/registry";
@@ -76,9 +77,10 @@ export function buildSandboxEgressNetworkPolicy(input?: {
   );
   for (const entry of entries) {
     for (const domain of entry.domains) {
+      const shouldPropagateTrace = shouldPropagateSandboxEgressTrace(domain);
       allow[domain] = [
         {
-          ...(Object.keys(traceHeaders).length > 0
+          ...(shouldPropagateTrace && Object.keys(traceHeaders).length > 0
             ? { transform: [{ headers: traceHeaders }] }
             : {}),
           forwardURL,

--- a/packages/junior/src/chat/sandbox/egress-policy.ts
+++ b/packages/junior/src/chat/sandbox/egress-policy.ts
@@ -59,7 +59,7 @@ function sandboxProxyUrl(credentialToken?: string): string {
   return new URL(path, baseUrl).toString();
 }
 
-/** Build the policy that forwards provider requests and configured trace headers. */
+/** Build the policy that forwards credentials and configured trace headers. */
 export function buildSandboxEgressNetworkPolicy(input?: {
   credentialToken?: string;
   traceConfig?: SandboxEgressTracePropagationConfig;
@@ -82,14 +82,17 @@ export function buildSandboxEgressNetworkPolicy(input?: {
     return { allow };
   }
 
-  const forwardURL =
-    entries.length > 0 ? sandboxProxyUrl(input?.credentialToken) : undefined;
+  const forwardURL = input?.credentialToken
+    ? sandboxProxyUrl(input.credentialToken)
+    : undefined;
   const domains = new Map<string, { forward: boolean }>();
   // Provider domains are proxied for credentials; configured trace-only domains
   // get transform-only rules so wildcard trace configs are not limited to plugins.
-  for (const entry of entries) {
-    for (const domain of entry.domains) {
-      domains.set(domain, { forward: true });
+  if (forwardURL) {
+    for (const entry of entries) {
+      for (const domain of entry.domains) {
+        domains.set(domain, { forward: true });
+      }
     }
   }
   if (hasTraceHeaders) {

--- a/packages/junior/src/chat/sandbox/egress-policy.ts
+++ b/packages/junior/src/chat/sandbox/egress-policy.ts
@@ -1,5 +1,6 @@
 import type { NetworkPolicy, NetworkPolicyRule } from "@vercel/sandbox";
 import { resolveBaseUrl } from "@/chat/oauth-flow";
+import type { TracePropagationHeaders } from "@/chat/logging";
 import { SANDBOX_EGRESS_PROXY_PATH } from "@/chat/sandbox/egress-session";
 import { resolveAuthTokenPlaceholder } from "@/chat/plugins/auth/auth-token-placeholder";
 import { resolvePluginCommandEnv } from "@/chat/plugins/command-env";
@@ -57,6 +58,7 @@ function sandboxProxyUrl(credentialToken?: string): string {
 /** Build the policy that forwards provider requests back to Junior for credentials. */
 export function buildSandboxEgressNetworkPolicy(input?: {
   credentialToken?: string;
+  traceHeaders?: TracePropagationHeaders;
 }): NetworkPolicy {
   const allow: Record<string, NetworkPolicyRule[]> = {
     "*": [],
@@ -67,9 +69,21 @@ export function buildSandboxEgressNetworkPolicy(input?: {
   }
 
   const forwardURL = sandboxProxyUrl(input?.credentialToken);
+  const traceHeaders = Object.fromEntries(
+    Object.entries(input?.traceHeaders ?? {}).filter(
+      ([, value]) => typeof value === "string" && value.trim(),
+    ),
+  );
   for (const entry of entries) {
     for (const domain of entry.domains) {
-      allow[domain] = [{ forwardURL }];
+      allow[domain] = [
+        {
+          ...(Object.keys(traceHeaders).length > 0
+            ? { transform: [{ headers: traceHeaders }] }
+            : {}),
+          forwardURL,
+        },
+      ];
     }
   }
 

--- a/packages/junior/src/chat/sandbox/egress-policy.ts
+++ b/packages/junior/src/chat/sandbox/egress-policy.ts
@@ -2,7 +2,10 @@ import type { NetworkPolicy, NetworkPolicyRule } from "@vercel/sandbox";
 import { resolveBaseUrl } from "@/chat/oauth-flow";
 import type { TracePropagationHeaders } from "@/chat/logging";
 import { SANDBOX_EGRESS_PROXY_PATH } from "@/chat/sandbox/egress-session";
-import { shouldPropagateSandboxEgressTrace } from "@/chat/sandbox/egress-tracing";
+import {
+  shouldPropagateSandboxEgressTrace,
+  type SandboxEgressTracePropagationConfig,
+} from "@/chat/sandbox/egress-tracing";
 import { resolveAuthTokenPlaceholder } from "@/chat/plugins/auth/auth-token-placeholder";
 import { resolvePluginCommandEnv } from "@/chat/plugins/command-env";
 import { getPluginProviders } from "@/chat/plugins/registry";
@@ -56,9 +59,10 @@ function sandboxProxyUrl(credentialToken?: string): string {
   return new URL(path, baseUrl).toString();
 }
 
-/** Build the policy that forwards provider requests back to Junior for credentials. */
+/** Build the policy that forwards provider requests and configured trace headers. */
 export function buildSandboxEgressNetworkPolicy(input?: {
   credentialToken?: string;
+  traceConfig?: SandboxEgressTracePropagationConfig;
   traceHeaders?: TracePropagationHeaders;
 }): NetworkPolicy {
   const allow: Record<string, NetworkPolicyRule[]> = {
@@ -77,7 +81,10 @@ export function buildSandboxEgressNetworkPolicy(input?: {
   );
   for (const entry of entries) {
     for (const domain of entry.domains) {
-      const shouldPropagateTrace = shouldPropagateSandboxEgressTrace(domain);
+      const shouldPropagateTrace = shouldPropagateSandboxEgressTrace(
+        domain,
+        input?.traceConfig,
+      );
       allow[domain] = [
         {
           ...(shouldPropagateTrace && Object.keys(traceHeaders).length > 0

--- a/packages/junior/src/chat/sandbox/egress-policy.ts
+++ b/packages/junior/src/chat/sandbox/egress-policy.ts
@@ -69,31 +69,50 @@ export function buildSandboxEgressNetworkPolicy(input?: {
     "*": [],
   };
   const entries = providerEntries();
-  if (entries.length === 0) {
-    return { allow };
-  }
-
-  const forwardURL = sandboxProxyUrl(input?.credentialToken);
   const traceHeaders = Object.fromEntries(
     Object.entries(input?.traceHeaders ?? {}).filter(
       ([, value]) => typeof value === "string" && value.trim(),
     ),
   );
+  const hasTraceHeaders = Object.keys(traceHeaders).length > 0;
+  if (
+    entries.length === 0 &&
+    (!hasTraceHeaders || (input?.traceConfig?.domains ?? []).length === 0)
+  ) {
+    return { allow };
+  }
+
+  const forwardURL =
+    entries.length > 0 ? sandboxProxyUrl(input?.credentialToken) : undefined;
+  const domains = new Map<string, { forward: boolean }>();
+  // Provider domains are proxied for credentials; configured trace-only domains
+  // get transform-only rules so wildcard trace configs are not limited to plugins.
   for (const entry of entries) {
     for (const domain of entry.domains) {
-      const shouldPropagateTrace = shouldPropagateSandboxEgressTrace(
-        domain,
-        input?.traceConfig,
-      );
-      allow[domain] = [
-        {
-          ...(shouldPropagateTrace && Object.keys(traceHeaders).length > 0
-            ? { transform: [{ headers: traceHeaders }] }
-            : {}),
-          forwardURL,
-        },
-      ];
+      domains.set(domain, { forward: true });
     }
+  }
+  if (hasTraceHeaders) {
+    for (const domain of input?.traceConfig?.domains ?? []) {
+      domains.set(domain, { forward: domains.get(domain)?.forward ?? false });
+    }
+  }
+
+  for (const [domain, policy] of [...domains.entries()].sort(
+    ([left], [right]) => left.localeCompare(right),
+  )) {
+    const shouldPropagateTrace = shouldPropagateSandboxEgressTrace(
+      domain,
+      input?.traceConfig,
+    );
+    allow[domain] = [
+      {
+        ...(shouldPropagateTrace && hasTraceHeaders
+          ? { transform: [{ headers: traceHeaders }] }
+          : {}),
+        ...(policy.forward && forwardURL ? { forwardURL } : {}),
+      },
+    ];
   }
 
   return { allow };

--- a/packages/junior/src/chat/sandbox/egress-proxy.ts
+++ b/packages/junior/src/chat/sandbox/egress-proxy.ts
@@ -1,5 +1,5 @@
 import { CredentialUnavailableError } from "@/chat/credentials/broker";
-import { logInfo, logWarn } from "@/chat/logging";
+import { logInfo, logWarn, withSpan } from "@/chat/logging";
 import { onPluginEgressResponse } from "@/chat/plugins/credential-hooks";
 import {
   matchesSandboxEgressDomain,
@@ -23,6 +23,7 @@ import {
 } from "@/chat/sandbox/egress-session";
 import { EgressAuthRequired } from "@sentry/junior-plugin-api";
 import type { JWTPayload } from "jose";
+import * as Sentry from "@/chat/sentry";
 
 const OIDC_TOKEN_HEADER = "vercel-sandbox-oidc-token";
 const FORWARDED_HOST_HEADER = "vercel-forwarded-host";
@@ -46,6 +47,11 @@ const PROXY_ONLY_HEADERS = new Set([
   FORWARDED_SCHEME_HEADER,
   FORWARDED_PORT_HEADER,
   FORWARDED_PATH_HEADER,
+]);
+const TRACE_PROPAGATION_HEADERS = new Set([
+  "baggage",
+  "sentry-trace",
+  "traceparent",
 ]);
 const DECODED_RESPONSE_HEADERS = new Set([
   "content-encoding",
@@ -468,6 +474,7 @@ async function responseTextWithinLimit(
 function requestHeaders(
   request: Request,
   lease: SandboxEgressCredentialLease,
+  provider: string,
   upstreamHost: string,
 ): Headers {
   const headers = new Headers();
@@ -477,6 +484,9 @@ function requestHeaders(
       HOP_BY_HOP_HEADERS.has(normalized) ||
       PROXY_ONLY_HEADERS.has(normalized)
     ) {
+      return;
+    }
+    if (TRACE_PROPAGATION_HEADERS.has(normalized) && provider !== "sentry") {
       return;
     }
     headers.append(key, value);
@@ -507,6 +517,23 @@ function responseHeaders(upstream: Response): Headers {
   return headers;
 }
 
+function continueSandboxEgressTrace<T>(
+  request: Request,
+  callback: () => Promise<T>,
+): Promise<T> {
+  const sentryTrace = request.headers.get("sentry-trace") ?? undefined;
+  const baggage = request.headers.get("baggage") ?? undefined;
+  const run = () =>
+    withSpan("sandbox.egress", "http.server", {}, callback, {
+      "http.request.method": request.method,
+      "url.path": redactedProxyPath(new URL(request.url).pathname),
+    });
+  if (!sentryTrace && !baggage) {
+    return run();
+  }
+  return Sentry.continueTrace({ sentryTrace, baggage }, run);
+}
+
 /** Return whether a request appears to be from the Vercel Sandbox egress proxy. */
 export function isSandboxEgressForwardedRequest(request: Request): boolean {
   return Boolean(
@@ -520,6 +547,16 @@ export function isSandboxEgressForwardedRequest(request: Request): boolean {
 export async function proxySandboxEgressRequest(
   request: Request,
   deps: ProxyDeps = {},
+): Promise<Response> {
+  return await continueSandboxEgressTrace(
+    request,
+    async () => await proxySandboxEgressRequestImpl(request, deps),
+  );
+}
+
+async function proxySandboxEgressRequestImpl(
+  request: Request,
+  deps: ProxyDeps,
 ): Promise<Response> {
   const oidcToken = request.headers.get(OIDC_TOKEN_HEADER)?.trim();
   if (!oidcToken) {
@@ -750,7 +787,12 @@ export async function proxySandboxEgressRequest(
   }
 
   const fetchImpl = deps.fetch ?? fetch;
-  const headers = requestHeaders(request, lease, upstreamUrl.hostname);
+  const headers = requestHeaders(
+    request,
+    lease,
+    provider,
+    upstreamUrl.hostname,
+  );
   if (!bodyRead) {
     body = await requestBodyBytes(request);
   }

--- a/packages/junior/src/chat/sandbox/egress-proxy.ts
+++ b/packages/junior/src/chat/sandbox/egress-proxy.ts
@@ -22,7 +22,10 @@ import {
   type SandboxEgressCredentialContext,
   type SandboxEgressCredentialLease,
 } from "@/chat/sandbox/egress-session";
-import { shouldPropagateSandboxEgressTrace } from "@/chat/sandbox/egress-tracing";
+import {
+  shouldPropagateSandboxEgressTrace,
+  type SandboxEgressTracePropagationConfig,
+} from "@/chat/sandbox/egress-tracing";
 import { EgressAuthRequired } from "@sentry/junior-plugin-api";
 import type { JWTPayload } from "jose";
 import * as Sentry from "@/chat/sentry";
@@ -74,6 +77,7 @@ export type SandboxEgressHttpInterceptor = (input: {
 interface ProxyDeps {
   fetch?: typeof fetch;
   interceptHttp?: SandboxEgressHttpInterceptor;
+  tracePropagation?: SandboxEgressTracePropagationConfig;
   verifyOidc?: (token: string) => Promise<JWTPayload>;
 }
 
@@ -473,12 +477,18 @@ async function responseTextWithinLimit(
   return new TextDecoder().decode(combined);
 }
 
+/** Build sanitized upstream headers and preserve trace headers only for configured hosts. */
 function requestHeaders(
   request: Request,
   lease: SandboxEgressCredentialLease,
   upstreamHost: string,
+  tracePropagation: SandboxEgressTracePropagationConfig,
 ): Headers {
   const headers = new Headers();
+  const mayPropagateTrace = shouldPropagateSandboxEgressTrace(
+    upstreamHost,
+    tracePropagation,
+  );
   request.headers.forEach((value, key) => {
     const normalized = key.toLowerCase();
     if (
@@ -487,10 +497,7 @@ function requestHeaders(
     ) {
       return;
     }
-    if (
-      TRACE_PROPAGATION_HEADERS.has(normalized) &&
-      !shouldPropagateSandboxEgressTrace(upstreamHost)
-    ) {
+    if (TRACE_PROPAGATION_HEADERS.has(normalized) && !mayPropagateTrace) {
       return;
     }
     headers.append(key, value);
@@ -501,6 +508,12 @@ function requestHeaders(
       continue;
     }
     for (const [key, value] of Object.entries(transform.headers)) {
+      if (
+        TRACE_PROPAGATION_HEADERS.has(key.toLowerCase()) &&
+        !mayPropagateTrace
+      ) {
+        continue;
+      }
       headers.set(key, value);
     }
   }
@@ -521,9 +534,11 @@ function responseHeaders(upstream: Response): Headers {
   return headers;
 }
 
+/** Continue inbound trace context only after sandbox egress verification succeeds. */
 function continueSandboxEgressTrace<T>(
   request: Request,
   upstreamHost: string,
+  tracePropagation: SandboxEgressTracePropagationConfig,
   callback: () => Promise<T>,
 ): Promise<T> {
   const sentryTrace = request.headers.get("sentry-trace") ?? undefined;
@@ -534,7 +549,7 @@ function continueSandboxEgressTrace<T>(
       "url.path": redactedProxyPath(new URL(request.url).pathname),
     });
   if (
-    !shouldPropagateSandboxEgressTrace(upstreamHost) ||
+    !shouldPropagateSandboxEgressTrace(upstreamHost, tracePropagation) ||
     (!sentryTrace && !baggage)
   ) {
     return run();
@@ -675,6 +690,7 @@ async function proxySandboxEgressRequestImpl(
   return await continueSandboxEgressTrace(
     request,
     upstreamUrl.hostname,
+    deps.tracePropagation ?? {},
     async () =>
       await proxySandboxEgressVerifiedRequest({
         activeEgressId,
@@ -823,7 +839,12 @@ async function proxySandboxEgressVerifiedRequest(input: {
   }
 
   const fetchImpl = deps.fetch ?? fetch;
-  const headers = requestHeaders(request, lease, upstreamUrl.hostname);
+  const headers = requestHeaders(
+    request,
+    lease,
+    upstreamUrl.hostname,
+    deps.tracePropagation ?? {},
+  );
   if (!bodyRead) {
     body = await requestBodyBytes(request);
   }

--- a/packages/junior/src/chat/sandbox/egress-proxy.ts
+++ b/packages/junior/src/chat/sandbox/egress-proxy.ts
@@ -703,6 +703,7 @@ async function proxySandboxEgressRequestImpl(
   );
 }
 
+/** Proxy egress only after sandbox identity and signed credential context pass. */
 async function proxySandboxEgressVerifiedRequest(input: {
   activeEgressId: string;
   credentialContext: SandboxEgressCredentialContext;

--- a/packages/junior/src/chat/sandbox/egress-proxy.ts
+++ b/packages/junior/src/chat/sandbox/egress-proxy.ts
@@ -19,8 +19,10 @@ import {
   SANDBOX_EGRESS_PROXY_PATH,
   setSandboxEgressAuthRequiredSignal,
   setSandboxEgressPermissionDeniedSignal,
+  type SandboxEgressCredentialContext,
   type SandboxEgressCredentialLease,
 } from "@/chat/sandbox/egress-session";
+import { shouldPropagateSandboxEgressTrace } from "@/chat/sandbox/egress-tracing";
 import { EgressAuthRequired } from "@sentry/junior-plugin-api";
 import type { JWTPayload } from "jose";
 import * as Sentry from "@/chat/sentry";
@@ -474,7 +476,6 @@ async function responseTextWithinLimit(
 function requestHeaders(
   request: Request,
   lease: SandboxEgressCredentialLease,
-  provider: string,
   upstreamHost: string,
 ): Headers {
   const headers = new Headers();
@@ -486,7 +487,10 @@ function requestHeaders(
     ) {
       return;
     }
-    if (TRACE_PROPAGATION_HEADERS.has(normalized) && provider !== "sentry") {
+    if (
+      TRACE_PROPAGATION_HEADERS.has(normalized) &&
+      !shouldPropagateSandboxEgressTrace(upstreamHost)
+    ) {
       return;
     }
     headers.append(key, value);
@@ -519,6 +523,7 @@ function responseHeaders(upstream: Response): Headers {
 
 function continueSandboxEgressTrace<T>(
   request: Request,
+  upstreamHost: string,
   callback: () => Promise<T>,
 ): Promise<T> {
   const sentryTrace = request.headers.get("sentry-trace") ?? undefined;
@@ -528,7 +533,10 @@ function continueSandboxEgressTrace<T>(
       "http.request.method": request.method,
       "url.path": redactedProxyPath(new URL(request.url).pathname),
     });
-  if (!sentryTrace && !baggage) {
+  if (
+    !shouldPropagateSandboxEgressTrace(upstreamHost) ||
+    (!sentryTrace && !baggage)
+  ) {
     return run();
   }
   return Sentry.continueTrace({ sentryTrace, baggage }, run);
@@ -548,10 +556,7 @@ export async function proxySandboxEgressRequest(
   request: Request,
   deps: ProxyDeps = {},
 ): Promise<Response> {
-  return await continueSandboxEgressTrace(
-    request,
-    async () => await proxySandboxEgressRequestImpl(request, deps),
-  );
+  return await proxySandboxEgressRequestImpl(request, deps);
 }
 
 async function proxySandboxEgressRequestImpl(
@@ -667,6 +672,37 @@ async function proxySandboxEgressRequestImpl(
     );
   }
 
+  return await continueSandboxEgressTrace(
+    request,
+    upstreamUrl.hostname,
+    async () =>
+      await proxySandboxEgressVerifiedRequest({
+        activeEgressId,
+        credentialContext,
+        deps,
+        provider,
+        request,
+        upstreamUrl,
+      }),
+  );
+}
+
+async function proxySandboxEgressVerifiedRequest(input: {
+  activeEgressId: string;
+  credentialContext: SandboxEgressCredentialContext;
+  deps: ProxyDeps;
+  provider: string;
+  request: Request;
+  upstreamUrl: URL;
+}): Promise<Response> {
+  const {
+    activeEgressId,
+    credentialContext,
+    deps,
+    provider,
+    request,
+    upstreamUrl,
+  } = input;
   let body: ArrayBuffer | undefined;
   let bodyRead = false;
   if (isGrantSelectionBodyVisible({ provider, upstreamUrl })) {
@@ -787,12 +823,7 @@ async function proxySandboxEgressRequestImpl(
   }
 
   const fetchImpl = deps.fetch ?? fetch;
-  const headers = requestHeaders(
-    request,
-    lease,
-    provider,
-    upstreamUrl.hostname,
-  );
+  const headers = requestHeaders(request, lease, upstreamUrl.hostname);
   if (!bodyRead) {
     body = await requestBodyBytes(request);
   }

--- a/packages/junior/src/chat/sandbox/egress-tracing.ts
+++ b/packages/junior/src/chat/sandbox/egress-tracing.ts
@@ -1,4 +1,6 @@
-let tracePropagationDomains: string[] = [];
+export interface SandboxEgressTracePropagationConfig {
+  domains?: string[];
+}
 
 function isValidDomainPattern(domain: string): boolean {
   if (domain.includes("*")) {
@@ -7,7 +9,10 @@ function isValidDomainPattern(domain: string): boolean {
   return true;
 }
 
-function normalizeDomains(domains: string[] | undefined): string[] {
+/** Normalize exact and leading-wildcard sandbox egress trace domains. */
+export function normalizeSandboxEgressTracePropagationDomains(
+  domains: string[] | undefined,
+): string[] {
   if (domains === undefined) {
     return [];
   }
@@ -41,24 +46,13 @@ function normalizeDomains(domains: string[] | undefined): string[] {
   ].sort((left, right) => left.localeCompare(right));
 }
 
-/** Store the sandbox egress domains that may carry trace propagation headers. */
-export function setSandboxEgressTracePropagationDomains(
-  domains: string[] | undefined,
-): string[] {
-  const previous = tracePropagationDomains;
-  tracePropagationDomains = normalizeDomains(domains);
-  return previous;
-}
-
-/** Return sandbox egress domains that may carry trace propagation headers. */
-export function getSandboxEgressTracePropagationDomains(): string[] {
-  return [...tracePropagationDomains];
-}
-
-/** Return whether a sandbox egress host may carry trace propagation headers. */
-export function shouldPropagateSandboxEgressTrace(host: string): boolean {
+/** Return whether a host may carry sandbox egress trace propagation headers. */
+export function shouldPropagateSandboxEgressTrace(
+  host: string,
+  config: SandboxEgressTracePropagationConfig = {},
+): boolean {
   const normalizedHost = host.trim().toLowerCase();
-  return tracePropagationDomains.some((domain) => {
+  return (config.domains ?? []).some((domain) => {
     if (domain.startsWith("*.")) {
       const suffix = domain.slice(1);
       return (

--- a/packages/junior/src/chat/sandbox/egress-tracing.ts
+++ b/packages/junior/src/chat/sandbox/egress-tracing.ts
@@ -1,0 +1,70 @@
+let tracePropagationDomains: string[] = [];
+
+function isValidDomainPattern(domain: string): boolean {
+  if (domain.includes("*")) {
+    return domain.startsWith("*.") && domain.indexOf("*", 1) === -1;
+  }
+  return true;
+}
+
+function normalizeDomains(domains: string[] | undefined): string[] {
+  if (domains === undefined) {
+    return [];
+  }
+
+  if (!Array.isArray(domains)) {
+    throw new Error("sandbox.egressTracePropagationDomains must be an array");
+  }
+
+  return [
+    ...new Set(
+      domains.map((domain) => {
+        if (typeof domain !== "string") {
+          throw new Error(
+            "sandbox.egressTracePropagationDomains entries must be strings",
+          );
+        }
+        const normalized = domain.trim().toLowerCase();
+        if (!normalized) {
+          throw new Error(
+            "sandbox.egressTracePropagationDomains entries must be non-empty",
+          );
+        }
+        if (!isValidDomainPattern(normalized)) {
+          throw new Error(
+            "sandbox.egressTracePropagationDomains entries must be exact domains or leading wildcard domains",
+          );
+        }
+        return normalized;
+      }),
+    ),
+  ].sort((left, right) => left.localeCompare(right));
+}
+
+/** Store the sandbox egress domains that may carry trace propagation headers. */
+export function setSandboxEgressTracePropagationDomains(
+  domains: string[] | undefined,
+): string[] {
+  const previous = tracePropagationDomains;
+  tracePropagationDomains = normalizeDomains(domains);
+  return previous;
+}
+
+/** Return sandbox egress domains that may carry trace propagation headers. */
+export function getSandboxEgressTracePropagationDomains(): string[] {
+  return [...tracePropagationDomains];
+}
+
+/** Return whether a sandbox egress host may carry trace propagation headers. */
+export function shouldPropagateSandboxEgressTrace(host: string): boolean {
+  const normalizedHost = host.trim().toLowerCase();
+  return tracePropagationDomains.some((domain) => {
+    if (domain.startsWith("*.")) {
+      const suffix = domain.slice(1);
+      return (
+        normalizedHost.endsWith(suffix) && normalizedHost !== domain.slice(2)
+      );
+    }
+    return domain === normalizedHost;
+  });
+}

--- a/packages/junior/src/chat/sandbox/sandbox.ts
+++ b/packages/junior/src/chat/sandbox/sandbox.ts
@@ -149,6 +149,9 @@ export function createSandboxExecutor(options?: {
   let availableSkills: SkillMetadata[] = [];
   let referenceFiles: string[] = [];
   const traceContext = options?.traceContext ?? {};
+  const tracePropagation = options?.tracePropagation;
+  const hasTracePropagationDomains =
+    (tracePropagation?.domains?.length ?? 0) > 0;
   const credentialEgress = options?.credentialEgress;
   const sandboxEgressTokenTtlMs = Math.max(
     1,
@@ -186,14 +189,17 @@ export function createSandboxExecutor(options?: {
     commandEnv: credentialEgress
       ? async () => await resolveSandboxCommandEnvironment()
       : undefined,
-    createNetworkPolicy: credentialEgress
-      ? (egressId, traceHeaders) =>
-          buildSandboxEgressNetworkPolicy({
-            credentialToken: sandboxEgressCredentialTokenFor(egressId),
-            traceConfig: options?.tracePropagation,
-            traceHeaders,
-          })
-      : undefined,
+    createNetworkPolicy:
+      credentialEgress || hasTracePropagationDomains
+        ? (egressId, traceHeaders) =>
+            buildSandboxEgressNetworkPolicy({
+              ...(credentialEgress
+                ? { credentialToken: sandboxEgressCredentialTokenFor(egressId) }
+                : {}),
+              traceConfig: tracePropagation,
+              traceHeaders,
+            })
+        : undefined,
     onSandboxPrepare: async (sandbox) => {
       await options?.agentHooks?.prepareSandbox(sandbox);
     },
@@ -209,6 +215,7 @@ export function createSandboxExecutor(options?: {
     callback: () => Promise<T>,
   ): Promise<T> => withSpan(name, op, traceContext, callback, attributes);
 
+  // Network-policy header transforms need the current tool span's trace headers.
   const withSandboxToolSpan = <T>(
     name: string,
     op: string,

--- a/packages/junior/src/chat/sandbox/sandbox.ts
+++ b/packages/junior/src/chat/sandbox/sandbox.ts
@@ -19,6 +19,7 @@ import {
   type SandboxEgressAuthRequiredSignal,
   type SandboxEgressPermissionDeniedSignal,
 } from "@/chat/sandbox/egress-session";
+import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress-tracing";
 import type { CredentialContext } from "@/chat/credentials/context";
 import {
   isSandboxCommandStreamInterruptedError,
@@ -137,6 +138,7 @@ export function createSandboxExecutor(options?: {
   sandboxDependencyProfileHash?: string;
   timeoutMs?: number;
   traceContext?: LogContext;
+  tracePropagation?: SandboxEgressTracePropagationConfig;
   credentialEgress?: CredentialContext;
   agentHooks?: AgentPluginHookRunner;
   onSandboxAcquired?: (sandbox: SandboxAcquiredState) => void | Promise<void>;
@@ -188,6 +190,7 @@ export function createSandboxExecutor(options?: {
       ? (egressId, traceHeaders) =>
           buildSandboxEgressNetworkPolicy({
             credentialToken: sandboxEgressCredentialTokenFor(egressId),
+            traceConfig: options?.tracePropagation,
             traceHeaders,
           })
       : undefined,

--- a/packages/junior/src/chat/sandbox/sandbox.ts
+++ b/packages/junior/src/chat/sandbox/sandbox.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import {
+  getTracePropagationHeaders,
   logInfo,
   setSpanAttributes,
   setSpanStatus,
@@ -184,9 +185,10 @@ export function createSandboxExecutor(options?: {
       ? async () => await resolveSandboxCommandEnvironment()
       : undefined,
     createNetworkPolicy: credentialEgress
-      ? (egressId) =>
+      ? (egressId, traceHeaders) =>
           buildSandboxEgressNetworkPolicy({
             credentialToken: sandboxEgressCredentialTokenFor(egressId),
+            traceHeaders,
           })
       : undefined,
     onSandboxPrepare: async (sandbox) => {
@@ -244,6 +246,9 @@ export function createSandboxExecutor(options?: {
       },
       async () => {
         try {
+          await sessionManager.refreshNetworkPolicy(
+            getTracePropagationHeaders(),
+          );
           const response = await executeBash({
             command,
             ...(env ? { env } : {}),

--- a/packages/junior/src/chat/sandbox/sandbox.ts
+++ b/packages/junior/src/chat/sandbox/sandbox.ts
@@ -209,6 +209,17 @@ export function createSandboxExecutor(options?: {
     callback: () => Promise<T>,
   ): Promise<T> => withSpan(name, op, traceContext, callback, attributes);
 
+  const withSandboxToolSpan = <T>(
+    name: string,
+    op: string,
+    attributes: Record<string, unknown>,
+    callback: () => Promise<T>,
+  ): Promise<T> =>
+    withSandboxSpan(name, op, attributes, async () => {
+      await sessionManager.refreshNetworkPolicy(getTracePropagationHeaders());
+      return await callback();
+    });
+
   const logSandboxBootRequest = (
     trigger: string,
     details: Record<string, string | number> = {},
@@ -241,7 +252,7 @@ export function createSandboxExecutor(options?: {
     const executeBash = (await sessionManager.ensureToolExecutors()).bash;
     const activeEgressId = sessionManager.getSandboxEgressId();
     await clearSandboxEgressSignals(activeEgressId);
-    const result = await withSandboxSpan(
+    const result = await withSandboxToolSpan(
       "bash",
       "process.exec",
       {
@@ -249,9 +260,6 @@ export function createSandboxExecutor(options?: {
       },
       async () => {
         try {
-          await sessionManager.refreshNetworkPolicy(
-            getTracePropagationHeaders(),
-          );
           const response = await executeBash({
             command,
             ...(env ? { env } : {}),
@@ -356,7 +364,7 @@ export function createSandboxExecutor(options?: {
     });
     const executeReadFile = (await sessionManager.ensureToolExecutors())
       .readFile;
-    const result = await withSandboxSpan(
+    const result = await withSandboxToolSpan(
       "sandbox.readFile",
       "sandbox.fs.read",
       {
@@ -407,7 +415,7 @@ export function createSandboxExecutor(options?: {
     });
     const executeWriteFile = (await sessionManager.ensureToolExecutors())
       .writeFile;
-    await withSandboxSpan(
+    await withSandboxToolSpan(
       "sandbox.writeFile",
       "sandbox.fs.write",
       {
@@ -448,7 +456,7 @@ export function createSandboxExecutor(options?: {
       "file.path": filePath,
     });
     const executors = await sessionManager.ensureToolExecutors();
-    const result = await withSandboxSpan(
+    const result = await withSandboxToolSpan(
       "sandbox.editFile",
       "sandbox.fs.edit",
       {
@@ -481,7 +489,7 @@ export function createSandboxExecutor(options?: {
     const contextLines = positiveInteger(rawInput.context);
     const limit = positiveInteger(rawInput.limit);
     const executors = await sessionManager.ensureToolExecutors();
-    const result = await withSandboxSpan(
+    const result = await withSandboxToolSpan(
       "sandbox.grep",
       "sandbox.fs.search",
       {
@@ -521,7 +529,7 @@ export function createSandboxExecutor(options?: {
     logSandboxBootRequest("tool.findFiles");
     const limit = positiveInteger(rawInput.limit);
     const executors = await sessionManager.ensureToolExecutors();
-    const result = await withSandboxSpan(
+    const result = await withSandboxToolSpan(
       "sandbox.findFiles",
       "sandbox.fs.find",
       {
@@ -548,7 +556,7 @@ export function createSandboxExecutor(options?: {
     logSandboxBootRequest("tool.listDir");
     const limit = positiveInteger(rawInput.limit);
     const executors = await sessionManager.ensureToolExecutors();
-    const result = await withSandboxSpan(
+    const result = await withSandboxToolSpan(
       "sandbox.listDir",
       "sandbox.fs.list",
       {},

--- a/packages/junior/src/chat/sandbox/session.ts
+++ b/packages/junior/src/chat/sandbox/session.ts
@@ -7,6 +7,7 @@ import {
   setSpanAttributes,
   withSpan,
   type LogContext,
+  type TracePropagationHeaders,
 } from "@/chat/logging";
 import { getVercelSandboxCredentials } from "@/chat/sandbox/credentials";
 import {
@@ -113,6 +114,7 @@ interface SandboxSessionManager {
   getDependencyProfileHash(): string | undefined;
   createSandbox(): Promise<SandboxInstance>;
   ensureToolExecutors(): Promise<SandboxToolExecutors>;
+  refreshNetworkPolicy(traceHeaders?: TracePropagationHeaders): Promise<void>;
   dispose(): Promise<void>;
 }
 
@@ -186,7 +188,10 @@ export function createSandboxSessionManager(options?: {
   timeoutMs?: number;
   traceContext?: LogContext;
   commandEnv?: () => Promise<Record<string, string>>;
-  createNetworkPolicy?: (egressId: string) => NetworkPolicy | undefined;
+  createNetworkPolicy?: (
+    egressId: string,
+    traceHeaders?: TracePropagationHeaders,
+  ) => NetworkPolicy | undefined;
   onSandboxPrepare?: (sandbox: SandboxInstance) => void | Promise<void>;
   onSandboxAcquired?: (sandbox: {
     sandboxId: string;
@@ -280,9 +285,11 @@ export function createSandboxSessionManager(options?: {
 
   const refreshNetworkPolicy = async (
     targetSandbox: SandboxInstance,
+    traceHeaders?: TracePropagationHeaders,
   ): Promise<void> => {
     const networkPolicy = options?.createNetworkPolicy?.(
       targetSandbox.sandboxEgressId,
+      traceHeaders,
     );
     if (!networkPolicy) {
       return;
@@ -880,6 +887,13 @@ export function createSandboxSessionManager(options?: {
     },
     async ensureToolExecutors() {
       return await loadToolExecutors(await ensureReadySandbox());
+    },
+    async refreshNetworkPolicy(traceHeaders) {
+      const activeSandbox = sandbox;
+      if (!activeSandbox) {
+        return;
+      }
+      await refreshNetworkPolicy(activeSandbox, traceHeaders);
     },
     async dispose() {
       const activeSandbox = sandbox;

--- a/packages/junior/src/chat/sandbox/session.ts
+++ b/packages/junior/src/chat/sandbox/session.ts
@@ -283,7 +283,7 @@ export function createSandboxSessionManager(options?: {
     preparedSandboxId = targetSandbox.sandboxId;
   };
 
-  const refreshNetworkPolicy = async (
+  const applyNetworkPolicy = async (
     targetSandbox: SandboxInstance,
     traceHeaders?: TracePropagationHeaders,
   ): Promise<void> => {
@@ -501,7 +501,7 @@ export function createSandboxSessionManager(options?: {
     }
 
     try {
-      await refreshNetworkPolicy(createdSandbox);
+      await applyNetworkPolicy(createdSandbox);
       await prepareSandbox(createdSandbox);
     } catch (error) {
       return failSetup(error);
@@ -559,7 +559,7 @@ export function createSandboxSessionManager(options?: {
 
     try {
       await ensureSandboxReachable(cachedSandbox, "memory");
-      await refreshNetworkPolicy(cachedSandbox);
+      await applyNetworkPolicy(cachedSandbox);
       await prepareSandbox(cachedSandbox);
       return cachedSandbox;
     } catch (error) {
@@ -609,7 +609,7 @@ export function createSandboxSessionManager(options?: {
     }
 
     try {
-      await refreshNetworkPolicy(hintedSandbox);
+      await applyNetworkPolicy(hintedSandbox);
       await prepareSandbox(hintedSandbox);
       return await rememberSandbox(hintedSandbox);
     } catch (error) {
@@ -893,7 +893,7 @@ export function createSandboxSessionManager(options?: {
       if (!activeSandbox) {
         return;
       }
-      await refreshNetworkPolicy(activeSandbox, traceHeaders);
+      await applyNetworkPolicy(activeSandbox, traceHeaders);
     },
     async dispose() {
       const activeSandbox = sandbox;

--- a/packages/junior/src/handlers/agent-dispatch.ts
+++ b/packages/junior/src/handlers/agent-dispatch.ts
@@ -1,12 +1,18 @@
 import { logException } from "@/chat/logging";
 import { runAgentDispatchSlice } from "@/chat/agent-dispatch/runner";
 import { verifyDispatchCallbackRequest } from "@/chat/agent-dispatch/signing";
+import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress-tracing";
 import type { WaitUntilFn } from "@/handlers/types";
+
+interface AgentDispatchHandlerOptions {
+  tracePropagation?: SandboxEgressTracePropagationConfig;
+}
 
 /** Handle the authenticated internal agent-dispatch callback. */
 export async function POST(
   request: Request,
   waitUntil: WaitUntilFn,
+  options: AgentDispatchHandlerOptions = {},
 ): Promise<Response> {
   const payload = await verifyDispatchCallbackRequest(request);
   if (!payload) {
@@ -14,7 +20,9 @@ export async function POST(
   }
 
   waitUntil(() =>
-    runAgentDispatchSlice(payload).catch((error) => {
+    runAgentDispatchSlice(payload, {
+      tracePropagation: options.tracePropagation,
+    }).catch((error) => {
       logException(
         error,
         "agent_dispatch_handler_failed",

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -14,7 +14,7 @@ import {
 } from "@/chat/mcp/auth-store";
 import { finalizeMcpAuthorization } from "@/chat/mcp/oauth";
 import { logException, logWarn } from "@/chat/logging";
-import type { AssistantReply } from "@/chat/respond";
+import type { AssistantReply, generateAssistantReply } from "@/chat/respond";
 import {
   getChannelConfigurationServiceById,
   getPersistedSandboxState,
@@ -86,6 +86,10 @@ const CALLBACK_PAGES = {
     status: 500,
   },
 } as const;
+
+interface McpOAuthCallbackOptions {
+  generateReply?: typeof generateAssistantReply;
+}
 
 function mcpAuthorizationId(args: {
   provider: string;
@@ -183,9 +187,10 @@ async function persistFailedReplyState(
 
 async function resumeAuthorizedMcpTurn(args: {
   authSession: McpAuthSessionState;
+  generateReply?: typeof generateAssistantReply;
   provider: string;
 }): Promise<void> {
-  const { authSession, provider } = args;
+  const { authSession, generateReply, provider } = args;
   if (
     !authSession.channelId ||
     !authSession.destination ||
@@ -232,6 +237,7 @@ async function resumeAuthorizedMcpTurn(args: {
     messageTs: getTurnUserSlackMessageTs(userMessage),
     lockKey: threadId,
     connectedText: "",
+    generateReply,
     beforeStart: async () => {
       const lockedState = await getPersistedThreadState(threadId);
       const lockedConversation = coerceThreadConversationState(lockedState);
@@ -444,6 +450,7 @@ export async function GET(
   request: Request,
   provider: string,
   waitUntil: WaitUntilFn,
+  options: McpOAuthCallbackOptions = {},
 ): Promise<Response> {
   const url = new URL(request.url);
   const state = url.searchParams.get("state")?.trim();
@@ -477,6 +484,7 @@ export async function GET(
     waitUntil(() =>
       resumeAuthorizedMcpTurn({
         authSession,
+        generateReply: options.generateReply,
         provider,
       }),
     );

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -65,7 +65,11 @@ import {
 import { escapeXml } from "@/chat/xml";
 import type { WaitUntilFn } from "@/handlers/types";
 import { scheduleAgentContinue } from "@/chat/services/agent-continue";
-import type { AssistantReply } from "@/chat/respond";
+import type { AssistantReply, generateAssistantReply } from "@/chat/respond";
+
+interface OAuthCallbackOptions {
+  generateReply?: typeof generateAssistantReply;
+}
 
 /**
  * OAuth callback contract for `@sentry/junior`.
@@ -169,6 +173,7 @@ async function persistFailedOAuthReplyState(args: {
 
 async function resumeOAuthSessionRecordTurn(
   stored: OAuthStatePayload,
+  options: OAuthCallbackOptions,
 ): Promise<boolean> {
   if (
     !stored.resumeConversationId ||
@@ -254,6 +259,7 @@ async function resumeOAuthSessionRecordTurn(
     messageTs: getTurnUserSlackMessageTs(userMessage),
     lockKey: stored.resumeConversationId,
     initialText: "",
+    generateReply: options.generateReply,
     beforeStart: async () => {
       const lockedState = await getPersistedThreadState(
         stored.resumeConversationId!,
@@ -458,6 +464,7 @@ async function resumeOAuthSessionRecordTurn(
 
 async function resumePendingOAuthMessage(
   stored: OAuthStatePayload,
+  options: OAuthCallbackOptions,
 ): Promise<void> {
   if (
     !stored.pendingMessage ||
@@ -488,6 +495,7 @@ async function resumePendingOAuthMessage(
     threadTs: stored.threadTs,
     messageTs: getTurnUserSlackMessageTs(latestUserMessage),
     connectedText: "",
+    generateReply: options.generateReply,
     replyContext: {
       credentialContext: {
         actor: { type: "user", userId: stored.userId },
@@ -523,6 +531,7 @@ export async function GET(
   request: Request,
   provider: string,
   waitUntil: WaitUntilFn,
+  options: OAuthCallbackOptions = {},
 ): Promise<Response> {
   const providerConfig = getPluginOAuthConfig(provider);
   if (!providerConfig) {
@@ -696,9 +705,9 @@ export async function GET(
   if (stored.pendingMessage && stored.channelId && stored.threadTs) {
     waitUntil(async () => {
       try {
-        const resumed = await resumeOAuthSessionRecordTurn(stored);
+        const resumed = await resumeOAuthSessionRecordTurn(stored, options);
         if (!resumed) {
-          await resumePendingOAuthMessage(stored);
+          await resumePendingOAuthMessage(stored, options);
         }
       } catch (error) {
         if (error instanceof ResumeTurnBusyError) {

--- a/packages/junior/src/handlers/sandbox-egress-proxy.ts
+++ b/packages/junior/src/handlers/sandbox-egress-proxy.ts
@@ -3,9 +3,11 @@ import {
   proxySandboxEgressRequest,
   type SandboxEgressHttpInterceptor,
 } from "@/chat/sandbox/egress-proxy";
+import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress-tracing";
 
 interface SandboxEgressProxyOptions {
   interceptHttp?: SandboxEgressHttpInterceptor;
+  tracePropagation?: SandboxEgressTracePropagationConfig;
 }
 
 /** Handles Vercel Sandbox firewall egress proxy requests. */
@@ -15,6 +17,7 @@ export async function ALL(
 ): Promise<Response> {
   return await proxySandboxEgressRequest(request, {
     interceptHttp: options.interceptHttp,
+    tracePropagation: options.tracePropagation,
   });
 }
 

--- a/packages/junior/src/handlers/webhooks.ts
+++ b/packages/junior/src/handlers/webhooks.ts
@@ -1,6 +1,9 @@
 import type { SlackAdapter } from "@chat-adapter/slack";
 import { getProductionSlackWebhookServices } from "@/chat/app/production";
-import { handleSlackWebhook } from "@/chat/ingress/slack-webhook";
+import {
+  handleSlackWebhook,
+  type SlackWebhookServices,
+} from "@/chat/ingress/slack-webhook";
 import { JuniorChat } from "@/chat/ingress/junior-chat";
 import {
   extractMessageChangedMention,
@@ -171,12 +174,14 @@ function parseJson(body: string): unknown {
  * Slack production ingress persists messages into the durable conversation
  * mailbox and wakes the queue worker. The optional `legacyBot` parameter is
  * kept for integration tests that still exercise Chat SDK fixtures directly.
+ * The optional `services` parameter carries app-scoped runtime services.
  */
 export async function handlePlatformWebhook(
   request: Request,
   platform: string,
   waitUntil: WaitUntilFn,
   legacyBot?: LegacyChatSdkBot,
+  services?: SlackWebhookServices,
 ): Promise<Response> {
   const requestContext = createRequestContext(request, { platform });
   const requestUrl = new URL(request.url);
@@ -200,7 +205,7 @@ export async function handlePlatformWebhook(
             } else if (platform === "slack") {
               response = await handleSlackWebhook({
                 request,
-                services: getProductionSlackWebhookServices(),
+                services: services ?? getProductionSlackWebhookServices(),
                 waitUntil,
               });
             } else {
@@ -264,6 +269,13 @@ export async function POST(
   request: Request,
   platform: string,
   waitUntil: WaitUntilFn,
+  services?: SlackWebhookServices,
 ): Promise<Response> {
-  return handlePlatformWebhook(request, platform, waitUntil);
+  return handlePlatformWebhook(
+    request,
+    platform,
+    waitUntil,
+    undefined,
+    services,
+  );
 }

--- a/packages/junior/tests/component/runtime/agent-continue.test.ts
+++ b/packages/junior/tests/component/runtime/agent-continue.test.ts
@@ -133,6 +133,35 @@ describe("agent continuation scheduling", () => {
     });
   });
 
+  it("passes runner options into awaiting continuations", async () => {
+    const { resumeAwaitingSlackContinuation } =
+      await import("@/chat/runtime/agent-continue-runner");
+    const conversationId = "slack:C123:1712345.0005";
+    const generateReply = vi.fn();
+    const resumeTurn = vi.fn(async () => true);
+
+    await upsertAgentTurnSessionRecord({
+      conversationId,
+      sessionId: "turn_msg_5",
+      sliceId: 2,
+      state: "awaiting_resume",
+      destination: SLACK_DESTINATION,
+      resumeReason: "timeout",
+      piMessages: [],
+    });
+
+    await expect(
+      resumeAwaitingSlackContinuation(conversationId, {
+        generateReply,
+        resumeTurn,
+      }),
+    ).resolves.toBe(true);
+
+    expect(resumeTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ generateReply }),
+    );
+  });
+
   it("fails stale continuations skipped during resume startup", async () => {
     const { resumeAwaitingSlackContinuation } =
       await import("@/chat/runtime/agent-continue-runner");

--- a/packages/junior/tests/integration/agent-dispatch-runner.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-runner.test.ts
@@ -115,6 +115,9 @@ describe("agent dispatch runner", () => {
       expect(context.credentialContext).toEqual({
         actor: { type: "system", id: "scheduler" },
       });
+      expect(context.sandbox?.tracePropagation).toEqual({
+        domains: ["*.sentry.io"],
+      });
       return createReply();
     });
 
@@ -123,7 +126,10 @@ describe("agent dispatch runner", () => {
         id: created.record.id,
         expectedVersion: created.record.version,
       },
-      { generateAssistantReply },
+      {
+        generateAssistantReply,
+        tracePropagation: { domains: ["*.sentry.io"] },
+      },
     );
 
     await expect(getDispatchRecord(created.record.id)).resolves.toMatchObject({

--- a/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
@@ -24,6 +24,7 @@ const EGRESS_ID = "sbx_integration_session";
 const REQUESTER_ID = "U123";
 const PROVIDER_HOST = "sandbox-egress.example.test";
 const MANAGED_PROVIDER_HOST = "managed-egress.example.test";
+const MANAGED_PROVIDER_SUBDOMAIN = "api.managed-egress.example.test";
 const GITHUB_API_HOST = "api.github.com";
 
 type EgressPolicyModule = typeof import("@/chat/sandbox/egress-policy");
@@ -62,6 +63,21 @@ function forwardUrlFor(policy: unknown, host: string): string {
   return forwardURL;
 }
 
+function traceHeadersFor(
+  policy: unknown,
+  host: string,
+): Record<string, string> | undefined {
+  const allow = (
+    policy as {
+      allow?: Record<
+        string,
+        Array<{ transform?: Array<{ headers?: Record<string, string> }> }>
+      >;
+    }
+  ).allow;
+  return allow?.[host]?.[0]?.transform?.[0]?.headers;
+}
+
 function proxiedRequest(input: {
   body?: BodyInit;
   forwardURL: string;
@@ -94,6 +110,7 @@ function proxiedRequest(input: {
 }
 
 async function registerManagedEgressPlugin(input?: {
+  egressTracePropagationDomains?: string[];
   issueCredential?: NonNullable<AgentPluginHooks["issueCredential"]>;
   onEgressResponse?: NonNullable<AgentPluginHooks["onEgressResponse"]>;
 }) {
@@ -105,7 +122,7 @@ async function registerManagedEgressPlugin(input?: {
           name: "managed-egress",
           description: "Managed egress integration fixture",
           capabilities: ["api"],
-          domains: [MANAGED_PROVIDER_HOST],
+          domains: [MANAGED_PROVIDER_HOST, MANAGED_PROVIDER_SUBDOMAIN],
         },
         hooks: {
           grantForEgress(ctx) {
@@ -128,13 +145,14 @@ async function registerManagedEgressPlugin(input?: {
               lease: {
                 expiresAt: new Date(Date.now() + 60_000).toISOString(),
                 headerTransforms: [
-                  {
-                    domain: MANAGED_PROVIDER_HOST,
-                    headers: {
-                      Authorization: `Bearer ${ctx.grant.name}`,
-                    },
+                  MANAGED_PROVIDER_HOST,
+                  MANAGED_PROVIDER_SUBDOMAIN,
+                ].map((domain) => ({
+                  domain,
+                  headers: {
+                    Authorization: `Bearer ${ctx.grant.name}`,
                   },
-                ],
+                })),
               },
             })),
           ...(input?.onEgressResponse
@@ -143,6 +161,9 @@ async function registerManagedEgressPlugin(input?: {
         },
       }),
     ]),
+    sandbox: {
+      egressTracePropagationDomains: input?.egressTracePropagationDomains,
+    },
     waitUntil(task) {
       if (typeof task === "function") {
         void task();
@@ -218,6 +239,9 @@ describe("sandbox egress proxy integration", () => {
     await modules?.state.disconnectStateAdapter();
     await pluginApp?.cleanup();
     pluginApp = undefined;
+    const { setSandboxEgressTracePropagationDomains } =
+      await import("@/chat/sandbox/egress-tracing");
+    setSandboxEgressTracePropagationDomains(undefined);
     process.env = { ...ORIGINAL_ENV };
   });
 
@@ -260,6 +284,110 @@ describe("sandbox egress proxy integration", () => {
 
     expect(response.status).toBe(200);
     await expect(response.text()).resolves.toBe("ok");
+    expect(upstreamFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates configured trace headers through real plugin egress wiring", async () => {
+    await registerManagedEgressPlugin({
+      egressTracePropagationDomains: ["*.managed-egress.example.test"],
+    });
+    const credentialToken = modules.session.createSandboxEgressCredentialToken({
+      credentials: { actor: { type: "user", userId: REQUESTER_ID } },
+      egressId: EGRESS_ID,
+      ttlMs: 60_000,
+    });
+    const networkPolicy = modules.policy.buildSandboxEgressNetworkPolicy({
+      credentialToken,
+      traceHeaders: {
+        "sentry-trace": "trace-span-1",
+        baggage: "sentry-release=abc",
+        traceparent: "00-trace-span-01",
+      },
+    });
+    expect(traceHeadersFor(networkPolicy, MANAGED_PROVIDER_SUBDOMAIN)).toEqual({
+      "sentry-trace": "trace-span-1",
+      baggage: "sentry-release=abc",
+      traceparent: "00-trace-span-01",
+    });
+    const forwardURL = forwardUrlFor(networkPolicy, MANAGED_PROVIDER_SUBDOMAIN);
+    const upstreamFetch = vi.fn(
+      async (_url: URL | string, init?: RequestInit) => {
+        const headers = new Headers(init?.headers);
+        expect(headers.get("authorization")).toBe("Bearer installation-read");
+        expect(headers.get("sentry-trace")).toBe("trace-span-1");
+        expect(headers.get("baggage")).toBe("sentry-release=abc");
+        expect(headers.get("traceparent")).toBe("00-trace-span-01");
+        return new Response("ok", { status: 200 });
+      },
+    );
+
+    const response = await modules.proxy.proxySandboxEgressRequest(
+      proxiedRequest({
+        forwardURL,
+        headers: {
+          "sentry-trace": "trace-span-1",
+          baggage: "sentry-release=abc",
+          traceparent: "00-trace-span-01",
+        },
+        upstreamHost: MANAGED_PROVIDER_SUBDOMAIN,
+      }),
+      {
+        fetch: upstreamFetch as typeof fetch,
+        verifyOidc: async () => ({ sandbox_id: EGRESS_ID }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(upstreamFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("strips trace headers from unconfigured real plugin egress wiring", async () => {
+    await registerManagedEgressPlugin();
+    const credentialToken = modules.session.createSandboxEgressCredentialToken({
+      credentials: { actor: { type: "user", userId: REQUESTER_ID } },
+      egressId: EGRESS_ID,
+      ttlMs: 60_000,
+    });
+    const networkPolicy = modules.policy.buildSandboxEgressNetworkPolicy({
+      credentialToken,
+      traceHeaders: {
+        "sentry-trace": "trace-span-1",
+        baggage: "sentry-release=abc",
+        traceparent: "00-trace-span-01",
+      },
+    });
+    expect(
+      traceHeadersFor(networkPolicy, MANAGED_PROVIDER_HOST),
+    ).toBeUndefined();
+    const forwardURL = forwardUrlFor(networkPolicy, MANAGED_PROVIDER_HOST);
+    const upstreamFetch = vi.fn(
+      async (_url: URL | string, init?: RequestInit) => {
+        const headers = new Headers(init?.headers);
+        expect(headers.get("authorization")).toBe("Bearer installation-read");
+        expect(headers.get("sentry-trace")).toBeNull();
+        expect(headers.get("baggage")).toBeNull();
+        expect(headers.get("traceparent")).toBeNull();
+        return new Response("ok", { status: 200 });
+      },
+    );
+
+    const response = await modules.proxy.proxySandboxEgressRequest(
+      proxiedRequest({
+        forwardURL,
+        headers: {
+          "sentry-trace": "trace-span-1",
+          baggage: "sentry-release=abc",
+          traceparent: "00-trace-span-01",
+        },
+        upstreamHost: MANAGED_PROVIDER_HOST,
+      }),
+      {
+        fetch: upstreamFetch as typeof fetch,
+        verifyOidc: async () => ({ sandbox_id: EGRESS_ID }),
+      },
+    );
+
+    expect(response.status).toBe(200);
     expect(upstreamFetch).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
@@ -239,9 +239,6 @@ describe("sandbox egress proxy integration", () => {
     await modules?.state.disconnectStateAdapter();
     await pluginApp?.cleanup();
     pluginApp = undefined;
-    const { setSandboxEgressTracePropagationDomains } =
-      await import("@/chat/sandbox/egress-tracing");
-    setSandboxEgressTracePropagationDomains(undefined);
     process.env = { ...ORIGINAL_ENV };
   });
 
@@ -298,6 +295,7 @@ describe("sandbox egress proxy integration", () => {
     });
     const networkPolicy = modules.policy.buildSandboxEgressNetworkPolicy({
       credentialToken,
+      traceConfig: { domains: ["*.managed-egress.example.test"] },
       traceHeaders: {
         "sentry-trace": "trace-span-1",
         baggage: "sentry-release=abc",
@@ -333,6 +331,7 @@ describe("sandbox egress proxy integration", () => {
       }),
       {
         fetch: upstreamFetch as typeof fetch,
+        tracePropagation: { domains: ["*.managed-egress.example.test"] },
         verifyOidc: async () => ({ sandbox_id: EGRESS_ID }),
       },
     );

--- a/packages/junior/tests/unit/app-config.test.ts
+++ b/packages/junior/tests/unit/app-config.test.ts
@@ -14,10 +14,6 @@ import {
   getPluginProviders,
   setPluginCatalogConfig,
 } from "@/chat/plugins/registry";
-import {
-  getSandboxEgressTracePropagationDomains,
-  setSandboxEgressTracePropagationDomains,
-} from "@/chat/sandbox/egress-tracing";
 
 const originalCwd = process.cwd();
 const originalPluginPackages = process.env.JUNIOR_PLUGIN_PACKAGES;
@@ -61,7 +57,6 @@ afterEach(async () => {
   setAgentPlugins([]);
   setPluginCatalogConfig(undefined);
   setConfigDefaults(undefined);
-  setSandboxEgressTracePropagationDomains(undefined);
   vi.doUnmock("#junior/config");
   if (originalPluginPackages === undefined) {
     delete process.env.JUNIOR_PLUGIN_PACKAGES;
@@ -103,18 +98,17 @@ describe("createApp plugin config", () => {
     expect(getAgentPlugins().map((plugin) => plugin.name)).toEqual([]);
   });
 
-  it("configures sandbox egress trace propagation domains from app options", async () => {
-    await createApp({
-      plugins: defineJuniorPlugins([]),
-      sandbox: {
-        egressTracePropagationDomains: ["SENTRY.IO", " *.sentry.io "],
-      },
-    });
-
-    expect(getSandboxEgressTracePropagationDomains()).toEqual([
-      "*.sentry.io",
-      "sentry.io",
-    ]);
+  it("validates sandbox egress trace propagation domains from app options", async () => {
+    await expect(
+      createApp({
+        plugins: defineJuniorPlugins([]),
+        sandbox: {
+          egressTracePropagationDomains: ["api.*.sentry.io"],
+        },
+      }),
+    ).rejects.toThrow(
+      "sandbox.egressTracePropagationDomains entries must be exact domains or leading wildcard domains",
+    );
   });
 
   it("loads package plugins with runtime hook plugins", async () => {

--- a/packages/junior/tests/unit/app-config.test.ts
+++ b/packages/junior/tests/unit/app-config.test.ts
@@ -99,9 +99,29 @@ describe("createApp plugin config", () => {
   });
 
   it("validates sandbox egress trace propagation domains from app options", async () => {
+    await createApp({
+      plugins: defineJuniorPlugins([
+        defineJuniorPlugin({
+          manifest: {
+            name: "base",
+            description: "Base plugin",
+          },
+          hooks: {},
+        }),
+      ]),
+    });
+
     await expect(
       createApp({
-        plugins: defineJuniorPlugins([]),
+        plugins: defineJuniorPlugins([
+          defineJuniorPlugin({
+            manifest: {
+              name: "next",
+              description: "Next plugin",
+            },
+            hooks: {},
+          }),
+        ]),
         sandbox: {
           egressTracePropagationDomains: ["api.*.sentry.io"],
         },
@@ -109,6 +129,10 @@ describe("createApp plugin config", () => {
     ).rejects.toThrow(
       "sandbox.egressTracePropagationDomains entries must be exact domains or leading wildcard domains",
     );
+    expect(getPluginProviders().map((plugin) => plugin.manifest.name)).toEqual([
+      "base",
+    ]);
+    expect(getAgentPlugins().map((plugin) => plugin.name)).toEqual(["base"]);
   });
 
   it("loads package plugins with runtime hook plugins", async () => {

--- a/packages/junior/tests/unit/app-config.test.ts
+++ b/packages/junior/tests/unit/app-config.test.ts
@@ -14,6 +14,10 @@ import {
   getPluginProviders,
   setPluginCatalogConfig,
 } from "@/chat/plugins/registry";
+import {
+  getSandboxEgressTracePropagationDomains,
+  setSandboxEgressTracePropagationDomains,
+} from "@/chat/sandbox/egress-tracing";
 
 const originalCwd = process.cwd();
 const originalPluginPackages = process.env.JUNIOR_PLUGIN_PACKAGES;
@@ -57,6 +61,7 @@ afterEach(async () => {
   setAgentPlugins([]);
   setPluginCatalogConfig(undefined);
   setConfigDefaults(undefined);
+  setSandboxEgressTracePropagationDomains(undefined);
   vi.doUnmock("#junior/config");
   if (originalPluginPackages === undefined) {
     delete process.env.JUNIOR_PLUGIN_PACKAGES;
@@ -96,6 +101,20 @@ describe("createApp plugin config", () => {
 
     expect(getPluginProviders()).toEqual([]);
     expect(getAgentPlugins().map((plugin) => plugin.name)).toEqual([]);
+  });
+
+  it("configures sandbox egress trace propagation domains from app options", async () => {
+    await createApp({
+      plugins: defineJuniorPlugins([]),
+      sandbox: {
+        egressTracePropagationDomains: ["SENTRY.IO", " *.sentry.io "],
+      },
+    });
+
+    expect(getSandboxEgressTracePropagationDomains()).toEqual([
+      "*.sentry.io",
+      "sentry.io",
+    ]);
   });
 
   it("loads package plugins with runtime hook plugins", async () => {

--- a/packages/junior/tests/unit/app-sandbox-trace-config.test.ts
+++ b/packages/junior/tests/unit/app-sandbox-trace-config.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { sandboxEgressProxyMock } = vi.hoisted(() => ({
+  sandboxEgressProxyMock: vi.fn(async () => new Response("ok")),
+}));
+
+vi.mock("@/handlers/sandbox-egress-proxy", () => ({
+  ALL: sandboxEgressProxyMock,
+  isSandboxEgressRequest: () => true,
+}));
+
+afterEach(() => {
+  sandboxEgressProxyMock.mockClear();
+  vi.resetModules();
+});
+
+describe("createApp sandbox trace config", () => {
+  it("passes configured egress trace domains to sandbox egress routes", async () => {
+    const { createApp, defineJuniorPlugins } = await import("@/app");
+
+    const app = await createApp({
+      plugins: defineJuniorPlugins([]),
+      sandbox: {
+        egressTracePropagationDomains: ["*.SENTRY.IO"],
+      },
+    });
+
+    const response = await app.fetch(
+      new Request("https://junior.example.com/proxied"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(sandboxEgressProxyMock).toHaveBeenCalledWith(expect.any(Request), {
+      tracePropagation: { domains: ["*.sentry.io"] },
+    });
+  });
+});

--- a/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
@@ -45,6 +45,7 @@ import {
   matchesSandboxEgressDomain,
   resolveSandboxCommandEnvironment,
 } from "@/chat/sandbox/egress-policy";
+import { setSandboxEgressTracePropagationDomains } from "@/chat/sandbox/egress-tracing";
 import { setAgentPlugins } from "@/chat/plugins/agent-hooks";
 import {
   isSandboxEgressForwardedRequest,
@@ -226,6 +227,7 @@ describe("sandbox egress proxy", () => {
       provider === "sentry" ? { provider, scope: "project:read" } : undefined,
     );
     issueProviderCredentialLeaseMock.mockReset();
+    setSandboxEgressTracePropagationDomains(undefined);
     await disconnectStateAdapter();
   });
 
@@ -235,6 +237,7 @@ describe("sandbox egress proxy", () => {
     delete process.env.JUNIOR_BASE_URL;
     delete process.env.JUNIOR_SECRET;
     delete process.env.SENTRY_BOT_EMAIL;
+    setSandboxEgressTracePropagationDomains(undefined);
     vi.restoreAllMocks();
   });
 
@@ -264,6 +267,7 @@ describe("sandbox egress proxy", () => {
       egressId: EGRESS_ID,
       ttlMs: 60_000,
     });
+    setSandboxEgressTracePropagationDomains(["sentry.io"]);
     expect(
       buildSandboxEgressNetworkPolicy({
         credentialToken: token,
@@ -287,6 +291,56 @@ describe("sandbox egress proxy", () => {
               },
             ],
             forwardURL: `https://junior.example.com/api/internal/sandbox-egress/${token}`,
+          },
+        ],
+        "us.sentry.io": [
+          {
+            forwardURL: `https://junior.example.com/api/internal/sandbox-egress/${token}`,
+          },
+        ],
+      },
+    });
+  });
+
+  it("adds trace propagation transforms only for configured domains", () => {
+    getPluginProvidersMock.mockReturnValue([sentryPlugin(), githubPlugin()]);
+    setSandboxEgressTracePropagationDomains(["*.sentry.io"]);
+
+    expect(
+      buildSandboxEgressNetworkPolicy({
+        traceHeaders: {
+          "sentry-trace": "trace-span-1",
+          baggage: "sentry-release=abc",
+          traceparent: "00-trace-span-01",
+        },
+      }),
+    ).toMatchObject({
+      allow: {
+        "api.github.com": [
+          {
+            forwardURL:
+              "https://junior.example.com/api/internal/sandbox-egress",
+          },
+        ],
+        "sentry.io": [
+          {
+            forwardURL:
+              "https://junior.example.com/api/internal/sandbox-egress",
+          },
+        ],
+        "us.sentry.io": [
+          {
+            transform: [
+              {
+                headers: {
+                  "sentry-trace": "trace-span-1",
+                  baggage: "sentry-release=abc",
+                  traceparent: "00-trace-span-01",
+                },
+              },
+            ],
+            forwardURL:
+              "https://junior.example.com/api/internal/sandbox-egress",
           },
         ],
       },
@@ -365,6 +419,7 @@ describe("sandbox egress proxy", () => {
   });
 
   it("forwards repeated authorized sandbox requests with credential headers", async () => {
+    setSandboxEgressTracePropagationDomains(["sentry.io"]);
     setSandboxEgressUserActor();
     mockSentryLease();
 

--- a/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
@@ -5,15 +5,25 @@ import {
 } from "@sentry/junior-plugin-api";
 
 const {
+  continueTraceMock,
   getPluginDefinitionMock,
   getPluginOAuthConfigMock,
   getPluginProvidersMock,
   issueProviderCredentialLeaseMock,
+  startSpanMock,
 } = vi.hoisted(() => ({
+  continueTraceMock: vi.fn(
+    async (_context: unknown, callback: () => Promise<unknown>) =>
+      await callback(),
+  ),
   getPluginDefinitionMock: vi.fn(),
   getPluginOAuthConfigMock: vi.fn(),
   getPluginProvidersMock: vi.fn(),
   issueProviderCredentialLeaseMock: vi.fn(),
+  startSpanMock: vi.fn(
+    async (_options: unknown, callback: () => Promise<unknown>) =>
+      await callback(),
+  ),
 }));
 
 vi.mock("@/chat/config", async (importOriginal) => {
@@ -40,12 +50,18 @@ vi.mock("@/chat/capabilities/factory", () => ({
   issueProviderCredentialLease: issueProviderCredentialLeaseMock,
 }));
 
+vi.mock("@/chat/sentry", () => ({
+  continueTrace: continueTraceMock,
+  getActiveSpan: () => undefined,
+  spanToJSON: () => ({}),
+  startSpan: startSpanMock,
+}));
+
 import {
   buildSandboxEgressNetworkPolicy,
   matchesSandboxEgressDomain,
   resolveSandboxCommandEnvironment,
 } from "@/chat/sandbox/egress-policy";
-import { setSandboxEgressTracePropagationDomains } from "@/chat/sandbox/egress-tracing";
 import { setAgentPlugins } from "@/chat/plugins/agent-hooks";
 import {
   isSandboxEgressForwardedRequest,
@@ -58,6 +74,7 @@ import {
 } from "@/chat/sandbox/egress-session";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
 import type { CredentialSubject } from "@/chat/credentials/context";
+import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress-tracing";
 import { ALL } from "@/handlers/sandbox-egress-proxy";
 
 const EGRESS_ID = "junior-sbx";
@@ -202,9 +219,11 @@ function proxy(
   fetchMock: typeof fetch = vi.fn(
     async () => new Response("ok"),
   ) as typeof fetch,
+  tracePropagation: SandboxEgressTracePropagationConfig = {},
 ): Promise<Response> {
   return proxySandboxEgressRequest(request, {
     fetch: fetchMock,
+    tracePropagation,
     verifyOidc: async () => ({ sandbox_id: EGRESS_ID }),
   });
 }
@@ -227,7 +246,16 @@ describe("sandbox egress proxy", () => {
       provider === "sentry" ? { provider, scope: "project:read" } : undefined,
     );
     issueProviderCredentialLeaseMock.mockReset();
-    setSandboxEgressTracePropagationDomains(undefined);
+    continueTraceMock.mockClear();
+    continueTraceMock.mockImplementation(
+      async (_context: unknown, callback: () => Promise<unknown>) =>
+        await callback(),
+    );
+    startSpanMock.mockClear();
+    startSpanMock.mockImplementation(
+      async (_options: unknown, callback: () => Promise<unknown>) =>
+        await callback(),
+    );
     await disconnectStateAdapter();
   });
 
@@ -237,7 +265,6 @@ describe("sandbox egress proxy", () => {
     delete process.env.JUNIOR_BASE_URL;
     delete process.env.JUNIOR_SECRET;
     delete process.env.SENTRY_BOT_EMAIL;
-    setSandboxEgressTracePropagationDomains(undefined);
     vi.restoreAllMocks();
   });
 
@@ -267,10 +294,10 @@ describe("sandbox egress proxy", () => {
       egressId: EGRESS_ID,
       ttlMs: 60_000,
     });
-    setSandboxEgressTracePropagationDomains(["sentry.io"]);
     expect(
       buildSandboxEgressNetworkPolicy({
         credentialToken: token,
+        traceConfig: { domains: ["sentry.io"] },
         traceHeaders: {
           "sentry-trace": "trace-span-1",
           baggage: "sentry-release=abc",
@@ -304,10 +331,10 @@ describe("sandbox egress proxy", () => {
 
   it("adds trace propagation transforms only for configured domains", () => {
     getPluginProvidersMock.mockReturnValue([sentryPlugin(), githubPlugin()]);
-    setSandboxEgressTracePropagationDomains(["*.sentry.io"]);
 
     expect(
       buildSandboxEgressNetworkPolicy({
+        traceConfig: { domains: ["*.sentry.io"] },
         traceHeaders: {
           "sentry-trace": "trace-span-1",
           baggage: "sentry-release=abc",
@@ -419,7 +446,6 @@ describe("sandbox egress proxy", () => {
   });
 
   it("forwards repeated authorized sandbox requests with credential headers", async () => {
-    setSandboxEgressTracePropagationDomains(["sentry.io"]);
     setSandboxEgressUserActor();
     mockSentryLease();
 
@@ -465,7 +491,9 @@ describe("sandbox egress proxy", () => {
       },
     });
 
-    const response = await proxy(request, fetchMock as typeof fetch);
+    const response = await proxy(request, fetchMock as typeof fetch, {
+      domains: ["sentry.io"],
+    });
 
     expect(response.status).toBe(200);
     await expect(response.text()).resolves.toBe("ok");
@@ -481,6 +509,7 @@ describe("sandbox egress proxy", () => {
         headers: request.headers,
       }),
       fetchMock as typeof fetch,
+      { domains: ["sentry.io"] },
     );
 
     expect(repeated.status).toBe(200);
@@ -499,7 +528,10 @@ describe("sandbox egress proxy", () => {
       headerTransforms: [
         {
           domain: "api.github.com",
-          headers: { Authorization: "Bearer github-token" },
+          headers: {
+            Authorization: "Bearer github-token",
+            "sentry-trace": "lease-trace-span",
+          },
         },
       ],
       expiresAt: new Date(Date.now() + 60_000).toISOString(),
@@ -529,6 +561,72 @@ describe("sandbox egress proxy", () => {
 
     expect(response.status).toBe(200);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues trace only for verified configured sandbox egress", async () => {
+    setSandboxEgressUserActor();
+    mockSentryLease();
+    const verifyOidc = vi.fn(async () => ({ sandbox_id: EGRESS_ID }));
+    const fetchMock = vi.fn(async () => new Response("ok", { status: 200 }));
+
+    const response = await proxySandboxEgressRequest(
+      egressRequest({
+        headers: {
+          "sentry-trace": "trace-span-1",
+          baggage: "sentry-release=abc",
+        },
+      }),
+      {
+        fetch: fetchMock as typeof fetch,
+        tracePropagation: { domains: ["sentry.io"] },
+        verifyOidc,
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(continueTraceMock).toHaveBeenCalledWith(
+      { sentryTrace: "trace-span-1", baggage: "sentry-release=abc" },
+      expect.any(Function),
+    );
+    expect(verifyOidc.mock.invocationCallOrder[0]).toBeLessThan(
+      continueTraceMock.mock.invocationCallOrder[0]!,
+    );
+
+    continueTraceMock.mockClear();
+    const unconfiguredResponse = await proxySandboxEgressRequest(
+      egressRequest({
+        headers: {
+          "sentry-trace": "trace-span-1",
+          baggage: "sentry-release=abc",
+        },
+      }),
+      {
+        fetch: fetchMock as typeof fetch,
+        verifyOidc: async () => ({ sandbox_id: EGRESS_ID }),
+      },
+    );
+
+    expect(unconfiguredResponse.status).toBe(200);
+    expect(continueTraceMock).not.toHaveBeenCalled();
+
+    continueTraceMock.mockClear();
+    activeCredentialToken = undefined;
+    const rejectedResponse = await proxySandboxEgressRequest(
+      egressRequest({
+        headers: {
+          "sentry-trace": "trace-span-1",
+          baggage: "sentry-release=abc",
+        },
+      }),
+      {
+        fetch: fetchMock as typeof fetch,
+        tracePropagation: { domains: ["sentry.io"] },
+        verifyOidc: async () => ({ sandbox_id: EGRESS_ID }),
+      },
+    );
+
+    expect(rejectedResponse.status).toBe(403);
+    expect(continueTraceMock).not.toHaveBeenCalled();
   });
 
   it("rejects unbound delegated credential subjects under signed egress contexts", async () => {

--- a/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
@@ -271,29 +271,29 @@ describe("sandbox egress proxy", () => {
   it("builds provider forwarding policy for sandbox egress", () => {
     expect(matchesSandboxEgressDomain("SENTRY.IO", "sentry.io")).toBe(true);
     expect(matchesSandboxEgressDomain("eu.sentry.io", "sentry.io")).toBe(false);
-    expect(buildSandboxEgressNetworkPolicy()).toEqual({
-      allow: {
-        "*": [],
-        "sentry.io": [
-          {
-            forwardURL:
-              "https://junior.example.com/api/internal/sandbox-egress",
-          },
-        ],
-        "us.sentry.io": [
-          {
-            forwardURL:
-              "https://junior.example.com/api/internal/sandbox-egress",
-          },
-        ],
-      },
-    });
-
     const token = createSandboxEgressCredentialToken({
       credentials: { actor: { type: "user", userId: REQUESTER_ID } },
       egressId: EGRESS_ID,
       ttlMs: 60_000,
     });
+    expect(buildSandboxEgressNetworkPolicy({ credentialToken: token })).toEqual(
+      {
+        allow: {
+          "*": [],
+          "sentry.io": [
+            {
+              forwardURL: `https://junior.example.com/api/internal/sandbox-egress/${token}`,
+            },
+          ],
+          "us.sentry.io": [
+            {
+              forwardURL: `https://junior.example.com/api/internal/sandbox-egress/${token}`,
+            },
+          ],
+        },
+      },
+    );
+
     expect(
       buildSandboxEgressNetworkPolicy({
         credentialToken: token,
@@ -356,39 +356,12 @@ describe("sandbox egress proxy", () => {
             ],
           },
         ],
-        "api.github.com": [
-          {
-            forwardURL:
-              "https://junior.example.com/api/internal/sandbox-egress",
-          },
-        ],
-        "sentry.io": [
-          {
-            forwardURL:
-              "https://junior.example.com/api/internal/sandbox-egress",
-          },
-        ],
-        "us.sentry.io": [
-          {
-            transform: [
-              {
-                headers: {
-                  "sentry-trace": "trace-span-1",
-                  baggage: "sentry-release=abc",
-                  traceparent: "00-trace-span-01",
-                },
-              },
-            ],
-            forwardURL:
-              "https://junior.example.com/api/internal/sandbox-egress",
-          },
-        ],
       },
     });
   });
 
   it("adds trace-only domains without provider forwarding", () => {
-    getPluginProvidersMock.mockReturnValue([]);
+    getPluginProvidersMock.mockReturnValue([sentryPlugin()]);
 
     expect(
       buildSandboxEgressNetworkPolicy({
@@ -421,9 +394,9 @@ describe("sandbox egress proxy", () => {
     delete process.env.VERCEL_PROJECT_PRODUCTION_URL;
     delete process.env.VERCEL_URL;
 
-    expect(() => buildSandboxEgressNetworkPolicy()).toThrow(
-      "Cannot determine base URL for sandbox credential egress",
-    );
+    expect(() =>
+      buildSandboxEgressNetworkPolicy({ credentialToken: "signed-token" }),
+    ).toThrow("Cannot determine base URL for sandbox credential egress");
   });
 
   it("does not reuse Slack signing secret for sandbox egress tokens", () => {
@@ -602,72 +575,6 @@ describe("sandbox egress proxy", () => {
 
     expect(response.status).toBe(200);
     expect(fetchMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("continues trace only for verified configured sandbox egress", async () => {
-    setSandboxEgressUserActor();
-    mockSentryLease();
-    const verifyOidc = vi.fn(async () => ({ sandbox_id: EGRESS_ID }));
-    const fetchMock = vi.fn(async () => new Response("ok", { status: 200 }));
-
-    const response = await proxySandboxEgressRequest(
-      egressRequest({
-        headers: {
-          "sentry-trace": "trace-span-1",
-          baggage: "sentry-release=abc",
-        },
-      }),
-      {
-        fetch: fetchMock as typeof fetch,
-        tracePropagation: { domains: ["sentry.io"] },
-        verifyOidc,
-      },
-    );
-
-    expect(response.status).toBe(200);
-    expect(continueTraceMock).toHaveBeenCalledWith(
-      { sentryTrace: "trace-span-1", baggage: "sentry-release=abc" },
-      expect.any(Function),
-    );
-    expect(verifyOidc.mock.invocationCallOrder[0]).toBeLessThan(
-      continueTraceMock.mock.invocationCallOrder[0]!,
-    );
-
-    continueTraceMock.mockClear();
-    const unconfiguredResponse = await proxySandboxEgressRequest(
-      egressRequest({
-        headers: {
-          "sentry-trace": "trace-span-1",
-          baggage: "sentry-release=abc",
-        },
-      }),
-      {
-        fetch: fetchMock as typeof fetch,
-        verifyOidc: async () => ({ sandbox_id: EGRESS_ID }),
-      },
-    );
-
-    expect(unconfiguredResponse.status).toBe(200);
-    expect(continueTraceMock).not.toHaveBeenCalled();
-
-    continueTraceMock.mockClear();
-    activeCredentialToken = undefined;
-    const rejectedResponse = await proxySandboxEgressRequest(
-      egressRequest({
-        headers: {
-          "sentry-trace": "trace-span-1",
-          baggage: "sentry-release=abc",
-        },
-      }),
-      {
-        fetch: fetchMock as typeof fetch,
-        tracePropagation: { domains: ["sentry.io"] },
-        verifyOidc: async () => ({ sandbox_id: EGRESS_ID }),
-      },
-    );
-
-    expect(rejectedResponse.status).toBe(403);
-    expect(continueTraceMock).not.toHaveBeenCalled();
   });
 
   it("rejects unbound delegated credential subjects under signed egress contexts", async () => {

--- a/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
@@ -343,6 +343,19 @@ describe("sandbox egress proxy", () => {
       }),
     ).toMatchObject({
       allow: {
+        "*.sentry.io": [
+          {
+            transform: [
+              {
+                headers: {
+                  "sentry-trace": "trace-span-1",
+                  baggage: "sentry-release=abc",
+                  traceparent: "00-trace-span-01",
+                },
+              },
+            ],
+          },
+        ],
         "api.github.com": [
           {
             forwardURL:
@@ -368,6 +381,34 @@ describe("sandbox egress proxy", () => {
             ],
             forwardURL:
               "https://junior.example.com/api/internal/sandbox-egress",
+          },
+        ],
+      },
+    });
+  });
+
+  it("adds trace-only domains without provider forwarding", () => {
+    getPluginProvidersMock.mockReturnValue([]);
+
+    expect(
+      buildSandboxEgressNetworkPolicy({
+        traceConfig: { domains: ["*.sentry.io"] },
+        traceHeaders: {
+          "sentry-trace": "trace-span-1",
+        },
+      }),
+    ).toEqual({
+      allow: {
+        "*": [],
+        "*.sentry.io": [
+          {
+            transform: [
+              {
+                headers: {
+                  "sentry-trace": "trace-span-1",
+                },
+              },
+            ],
           },
         ],
       },

--- a/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
@@ -265,11 +265,27 @@ describe("sandbox egress proxy", () => {
       ttlMs: 60_000,
     });
     expect(
-      buildSandboxEgressNetworkPolicy({ credentialToken: token }),
+      buildSandboxEgressNetworkPolicy({
+        credentialToken: token,
+        traceHeaders: {
+          "sentry-trace": "trace-span-1",
+          baggage: "sentry-release=abc",
+          traceparent: "00-trace-span-01",
+        },
+      }),
     ).toMatchObject({
       allow: {
         "sentry.io": [
           {
+            transform: [
+              {
+                headers: {
+                  "sentry-trace": "trace-span-1",
+                  baggage: "sentry-release=abc",
+                  traceparent: "00-trace-span-01",
+                },
+              },
+            ],
             forwardURL: `https://junior.example.com/api/internal/sandbox-egress/${token}`,
           },
         ],
@@ -363,6 +379,15 @@ describe("sandbox egress proxy", () => {
       expect(new Headers(init?.headers).get("x-forwarded-for")).toBe(
         "127.0.0.1",
       );
+      expect(new Headers(init?.headers).get("sentry-trace")).toBe(
+        "trace-span-1",
+      );
+      expect(new Headers(init?.headers).get("baggage")).toBe(
+        "sentry-release=abc",
+      );
+      expect(new Headers(init?.headers).get("traceparent")).toBe(
+        "00-trace-span-01",
+      );
       expect(new Headers(init?.headers).get("host")).toBeNull();
       expect(
         new Headers(init?.headers).get("vercel-sandbox-oidc-token"),
@@ -377,6 +402,9 @@ describe("sandbox egress proxy", () => {
         authorization: "Bearer sandbox-token",
         cookie: "session=sandbox",
         host: "junior.example.com",
+        "sentry-trace": "trace-span-1",
+        baggage: "sentry-release=abc",
+        traceparent: "00-trace-span-01",
         "x-api-key": "sandbox-key",
         "x-forwarded-for": "127.0.0.1",
       },
@@ -404,6 +432,48 @@ describe("sandbox egress proxy", () => {
     await expect(repeated.text()).resolves.toBe("ok");
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(issueProviderCredentialLeaseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("strips Sentry trace propagation before forwarding non-Sentry requests", async () => {
+    getPluginProvidersMock.mockReturnValue([githubPlugin()]);
+    setSandboxEgressUserActor();
+    issueProviderCredentialLeaseMock.mockResolvedValue({
+      id: "lease-1",
+      provider: "github",
+      env: {},
+      headerTransforms: [
+        {
+          domain: "api.github.com",
+          headers: { Authorization: "Bearer github-token" },
+        },
+      ],
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    const fetchMock = vi.fn(async (_url: URL | string, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      expect(headers.get("authorization")).toBe("Bearer github-token");
+      expect(headers.get("sentry-trace")).toBeNull();
+      expect(headers.get("baggage")).toBeNull();
+      expect(headers.get("traceparent")).toBeNull();
+      return new Response("ok", { status: 200 });
+    });
+
+    const response = await proxy(
+      egressRequest({
+        host: "api.github.com",
+        path: "/repos/getsentry/junior",
+        headers: {
+          "sentry-trace": "trace-span-1",
+          baggage: "sentry-release=abc",
+          traceparent: "00-trace-span-01",
+        },
+      }),
+      fetchMock as typeof fetch,
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("rejects unbound delegated credential subjects under signed egress contexts", async () => {

--- a/packages/junior/tests/unit/handlers/sandbox-egress-tracing.test.ts
+++ b/packages/junior/tests/unit/handlers/sandbox-egress-tracing.test.ts
@@ -1,35 +1,46 @@
-import { afterEach, describe, expect, it } from "vitest";
 import {
-  getSandboxEgressTracePropagationDomains,
-  setSandboxEgressTracePropagationDomains,
+  normalizeSandboxEgressTracePropagationDomains,
   shouldPropagateSandboxEgressTrace,
 } from "@/chat/sandbox/egress-tracing";
+import { describe, expect, it } from "vitest";
 
 describe("sandbox egress tracing config", () => {
-  afterEach(() => {
-    setSandboxEgressTracePropagationDomains(undefined);
-  });
-
   it("matches exact domains case-insensitively", () => {
-    setSandboxEgressTracePropagationDomains(["SENTRY.IO"]);
+    const domains = normalizeSandboxEgressTracePropagationDomains([
+      "SENTRY.IO",
+    ]);
 
-    expect(getSandboxEgressTracePropagationDomains()).toEqual(["sentry.io"]);
-    expect(shouldPropagateSandboxEgressTrace("sentry.io")).toBe(true);
-    expect(shouldPropagateSandboxEgressTrace("SENTRY.IO")).toBe(true);
-    expect(shouldPropagateSandboxEgressTrace("us.sentry.io")).toBe(false);
+    expect(domains).toEqual(["sentry.io"]);
+    expect(shouldPropagateSandboxEgressTrace("sentry.io", { domains })).toBe(
+      true,
+    );
+    expect(shouldPropagateSandboxEgressTrace("SENTRY.IO", { domains })).toBe(
+      true,
+    );
+    expect(shouldPropagateSandboxEgressTrace("us.sentry.io", { domains })).toBe(
+      false,
+    );
   });
 
   it("matches leading wildcard subdomains without matching the apex", () => {
-    setSandboxEgressTracePropagationDomains(["*.sentry.io"]);
+    const domains = normalizeSandboxEgressTracePropagationDomains([
+      "*.sentry.io",
+    ]);
 
-    expect(shouldPropagateSandboxEgressTrace("us.sentry.io")).toBe(true);
-    expect(shouldPropagateSandboxEgressTrace("api.us.sentry.io")).toBe(true);
-    expect(shouldPropagateSandboxEgressTrace("sentry.io")).toBe(false);
+    expect(shouldPropagateSandboxEgressTrace("us.sentry.io", { domains })).toBe(
+      true,
+    );
+    expect(
+      shouldPropagateSandboxEgressTrace("api.us.sentry.io", { domains }),
+    ).toBe(true);
+    expect(shouldPropagateSandboxEgressTrace("sentry.io", { domains })).toBe(
+      false,
+    );
   });
 
   it("rejects non-leading wildcard patterns", () => {
     expect(() =>
-      setSandboxEgressTracePropagationDomains(["api.*.sentry.io"]),
+      normalizeSandboxEgressTracePropagationDomains(["api.*.sentry.io"]),
     ).toThrow(
       "sandbox.egressTracePropagationDomains entries must be exact domains or leading wildcard domains",
     );

--- a/packages/junior/tests/unit/handlers/sandbox-egress-tracing.test.ts
+++ b/packages/junior/tests/unit/handlers/sandbox-egress-tracing.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getSandboxEgressTracePropagationDomains,
+  setSandboxEgressTracePropagationDomains,
+  shouldPropagateSandboxEgressTrace,
+} from "@/chat/sandbox/egress-tracing";
+
+describe("sandbox egress tracing config", () => {
+  afterEach(() => {
+    setSandboxEgressTracePropagationDomains(undefined);
+  });
+
+  it("matches exact domains case-insensitively", () => {
+    setSandboxEgressTracePropagationDomains(["SENTRY.IO"]);
+
+    expect(getSandboxEgressTracePropagationDomains()).toEqual(["sentry.io"]);
+    expect(shouldPropagateSandboxEgressTrace("sentry.io")).toBe(true);
+    expect(shouldPropagateSandboxEgressTrace("SENTRY.IO")).toBe(true);
+    expect(shouldPropagateSandboxEgressTrace("us.sentry.io")).toBe(false);
+  });
+
+  it("matches leading wildcard subdomains without matching the apex", () => {
+    setSandboxEgressTracePropagationDomains(["*.sentry.io"]);
+
+    expect(shouldPropagateSandboxEgressTrace("us.sentry.io")).toBe(true);
+    expect(shouldPropagateSandboxEgressTrace("api.us.sentry.io")).toBe(true);
+    expect(shouldPropagateSandboxEgressTrace("sentry.io")).toBe(false);
+  });
+
+  it("rejects non-leading wildcard patterns", () => {
+    expect(() =>
+      setSandboxEgressTracePropagationDomains(["api.*.sentry.io"]),
+    ).toThrow(
+      "sandbox.egressTracePropagationDomains entries must be exact domains or leading wildcard domains",
+    );
+  });
+});

--- a/packages/junior/tests/unit/logging/with-span.test.ts
+++ b/packages/junior/tests/unit/logging/with-span.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { activeSpan, startSpan } = vi.hoisted(() => ({
+const { activeSpan, getTraceData, startSpan } = vi.hoisted(() => ({
   activeSpan: {
     setAttribute: vi.fn(),
   },
+  getTraceData: vi.fn(),
   startSpan: vi.fn(
     async (_options: unknown, callback: () => Promise<unknown>) => callback(),
   ),
@@ -11,12 +12,14 @@ const { activeSpan, startSpan } = vi.hoisted(() => ({
 
 vi.mock("@/chat/sentry", () => ({
   getActiveSpan: () => activeSpan,
+  getTraceData,
   startSpan,
 }));
 
 describe("withSpan", () => {
   afterEach(() => {
     vi.clearAllMocks();
+    getTraceData.mockReset();
     vi.resetModules();
   });
 
@@ -81,5 +84,22 @@ describe("withSpan", () => {
       "gen_ai.response.finish_reasons",
       ["tool_use"],
     );
+  });
+
+  it("extracts Sentry trace propagation headers", async () => {
+    getTraceData.mockReturnValue({
+      "sentry-trace": "trace-span-1",
+      baggage: "sentry-release=abc",
+      traceparent: "00-trace-span-01",
+      other: "ignored",
+    });
+    const { getTracePropagationHeaders } = await import("@/chat/logging");
+
+    expect(getTracePropagationHeaders()).toEqual({
+      "sentry-trace": "trace-span-1",
+      baggage: "sentry-release=abc",
+      traceparent: "00-trace-span-01",
+    });
+    expect(getTraceData).toHaveBeenCalledWith({ propagateTraceparent: true });
   });
 });

--- a/packages/junior/tests/unit/misc/sandbox-executor.test.ts
+++ b/packages/junior/tests/unit/misc/sandbox-executor.test.ts
@@ -1912,6 +1912,7 @@ describe("createSandboxExecutor", () => {
     expect(createNetworkPolicy).toHaveBeenNthCalledWith(
       3,
       "sbx_snapshot_policy_ready_session",
+      undefined,
     );
     expect(secondCreate.networkPolicy).toEqual({
       allow: {

--- a/specs/credential-injection.md
+++ b/specs/credential-injection.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-02-26
-- Last Edited: 2026-06-08
+- Last Edited: 2026-06-09
 
 ## Related
 
@@ -59,6 +59,7 @@ Define how Junior maps registered plugin provider domains to host-managed creden
 - The proxy must not use method/URL/body-only replay fingerprints as an authorization boundary because duplicate request shapes can be legitimate client retries.
 - The proxy must strip hop-by-hop and proxy-control headers before sending the upstream request.
 - Sandbox-supplied request headers and upstream response state may pass through once Vercel OIDC, credential context, and provider-domain ownership have been verified.
+- Trace propagation headers (`sentry-trace`, `baggage`, and `traceparent`) are stricter: the sandbox network policy may attach them only for egress domains configured through `createApp({ sandbox: { egressTracePropagationDomains } })`. Config entries may be exact domains or leading wildcard domains such as `*.sentry.io`; the proxy strips trace headers from all other upstream requests.
 - Provider-owned egress response hooks may inspect upstream response metadata after a credentialed request is forwarded. The proxy must not read upstream response bodies by default.
 - Response hooks may inspect a body only through the proxy's bounded lazy reader, which clones the response, enforces a hard byte cap, and leaves the original upstream response body available for pass-through.
 - A response hook that returns normally must preserve the original upstream response. Throwing `EgressAuthRequired` is the only response-hook outcome that rewrites the upstream response to Junior's auth-required sentinel.

--- a/specs/tracing.md
+++ b/specs/tracing.md
@@ -187,6 +187,7 @@ semantic conventions:
 - Sandbox execution spans should be nested under the active tool-call/request span context.
 - Sandbox egress proxy spans must be created only after Vercel OIDC, signed credential context, and provider-domain ownership have been verified.
 - Sandbox egress may continue incoming Sentry trace context only for egress domains configured through `createApp({ sandbox: { egressTracePropagationDomains } })`. Config entries may be exact domains or leading wildcard domains such as `*.sentry.io`; unconfigured domains must start a local `sandbox.egress` span without joining the incoming trace.
+- Each sandbox-backed tool refreshes egress trace headers from its current active tool span before execution. Resumed continuation slices use fresh traces and correlate across slices with `gen_ai.conversation.id`; they do not require carrying the original trace forward.
 
 ### GenAI Span Hierarchy
 

--- a/specs/tracing.md
+++ b/specs/tracing.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-02-25
-- Last Edited: 2026-05-30
+- Last Edited: 2026-06-09
 
 ## Purpose
 
@@ -146,6 +146,7 @@ semantic conventions:
 - `sandbox.sync_skills` with `op: sandbox.sync`
 - `sandbox.bash_tool.init` with `op: sandbox.tool.init`
 - `bash` with `op: process.exec` for sandbox command execution
+- `sandbox.egress` with `op: http.server` for verified sandbox egress proxy forwarding
 - `sandbox.keepalive.extend` with `op: sandbox.keepalive` when keepalive is configured
 - `sandbox.stop` with `op: sandbox.stop` during disposal
 
@@ -184,6 +185,8 @@ semantic conventions:
 
 - Sandbox spans should be nested under `ai.generate_assistant_reply` when invoked during reply generation.
 - Sandbox execution spans should be nested under the active tool-call/request span context.
+- Sandbox egress proxy spans must be created only after Vercel OIDC, signed credential context, and provider-domain ownership have been verified.
+- Sandbox egress may continue incoming Sentry trace context only for egress domains configured through `createApp({ sandbox: { egressTracePropagationDomains } })`. Config entries may be exact domains or leading wildcard domains such as `*.sentry.io`; unconfigured domains must start a local `sandbox.egress` span without joining the incoming trace.
 
 ### GenAI Span Hierarchy
 


### PR DESCRIPTION
Sandbox egress now carries Sentry trace propagation from the active bash command span into the Vercel Sandbox forwarding policy. The egress proxy continues that trace for its own proxy span, keeps the standard propagation headers when forwarding to Sentry upstreams, and strips them before forwarding to other providers.

This uses Sentry-standard `sentry-trace`, `baggage`, and `traceparent` headers rather than adding Junior-specific parentage headers. The sandbox network policy is refreshed inside the active bash span so shell-originated provider traffic can be correlated back to the tool execution that caused it.

Refs GH-557