### PR TITLE
fix(mcp): Add catalog tool spans

### DIFF
--- a/packages/junior/src/chat/mcp/errors.ts
+++ b/packages/junior/src/chat/mcp/errors.ts
@@ -1,3 +1,5 @@
+import type { ConversationPrivacy } from "@/chat/conversation-privacy";
+
 /** Thrown when an MCP failure should be returned as a model-visible tool error. */
 export class McpToolError extends Error {
   constructor(message: string) {
@@ -17,4 +19,15 @@ export function getMcpAwareErrorType(error: unknown, fallback: string): string {
 /** Return the display-safe error message for MCP-aware tool failures. */
 export function getMcpAwareErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+/** Return an error message safe for logs and span attributes. */
+export function getMcpAwareTelemetryMessage(
+  error: unknown,
+  privacy: ConversationPrivacy | undefined,
+): string {
+  if (privacy === "private" && error instanceof McpToolError) {
+    return "MCP tool call failed";
+  }
+  return getMcpAwareErrorMessage(error);
 }

--- a/packages/junior/src/chat/mcp/tool-manager.ts
+++ b/packages/junior/src/chat/mcp/tool-manager.ts
@@ -8,7 +8,16 @@
  */
 import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
-import { logWarn, setSpanAttributes } from "@/chat/logging";
+import {
+  logWarn,
+  serializeGenAiAttribute,
+  setSpanAttributes,
+  withSpan,
+} from "@/chat/logging";
+import {
+  toGenAiPayloadMetadata,
+  type ConversationPrivacy,
+} from "@/chat/conversation-privacy";
 import type { SkillMetadata } from "@/chat/skills";
 import type { PluginDefinition } from "@/chat/plugins/types";
 import {
@@ -18,7 +27,7 @@ import {
   type PluginMcpToolCallResult,
 } from "./client";
 import {
-  getMcpAwareErrorMessage,
+  getMcpAwareTelemetryMessage,
   getMcpAwareErrorType,
   McpToolError,
 } from "./errors";
@@ -179,7 +188,13 @@ export interface ManagedMcpToolDescriptor {
 type ActiveMcpSkill = Pick<SkillMetadata, "name" | "pluginProvider">;
 
 export interface ManagedMcpTool extends ManagedMcpToolDescriptor {
-  execute: (args: Record<string, unknown>) => Promise<ManagedMcpToolResult>;
+  execute: (
+    args: Record<string, unknown>,
+    options?: {
+      conversationPrivacy?: ConversationPrivacy;
+      toolCallId?: string;
+    },
+  ) => Promise<ManagedMcpToolResult>;
 }
 
 export class McpToolManager {
@@ -348,69 +363,115 @@ export class McpToolManager {
       ...(tool.title?.trim() ? { title: tool.title.trim() } : {}),
       ...(outputSchema ? { outputSchema } : {}),
       ...(annotations ? { annotations } : {}),
-      execute: async (args) => {
+      execute: async (args, options) => {
         const resolvedArgs =
           typeof args === "object" && args !== null ? args : {};
+        const conversationPrivacy = options?.conversationPrivacy ?? "private";
+        const managedToolName = normalizeMcpToolName(
+          plugin.manifest.name,
+          tool.name,
+        );
         const baseAttributes = {
           "mcp.method.name": "tools/call",
+          "gen_ai.operation.name": "execute_tool",
+          "gen_ai.tool.name": managedToolName,
+          "gen_ai.tool.description": describeMcpTool(
+            plugin.manifest.name,
+            tool,
+          ),
+          "gen_ai.tool.type": "extension",
+          "app.plugin.name": plugin.manifest.name,
+          ...(options?.toolCallId
+            ? { "gen_ai.tool.call.id": options.toolCallId }
+            : {}),
         };
-        setSpanAttributes(baseAttributes);
+        const argumentAttribute = serializeMcpPayload(
+          resolvedArgs,
+          conversationPrivacy,
+        );
 
-        try {
-          const result = await client.callTool(tool.name, resolvedArgs);
-          if ("isError" in result && result.isError) {
-            throw new McpToolError(extractMcpErrorMessage(result));
-          }
+        return await withSpan(
+          `execute_tool ${managedToolName}`,
+          "gen_ai.execute_tool",
+          {},
+          async () => {
+            try {
+              const result = await client.callTool(tool.name, resolvedArgs);
+              if ("isError" in result && result.isError) {
+                throw new McpToolError(extractMcpErrorMessage(result));
+              }
 
-          return {
-            content: toAgentToolContent(result),
-            details: {
-              provider: plugin.manifest.name,
-              tool: tool.name,
-              rawResult: result,
-            },
-          };
-        } catch (error) {
-          if (
-            error instanceof McpAuthorizationRequiredError &&
-            (await this.handleAuthorizationRequired(
-              plugin.manifest.name,
-              error,
-            ))
-          ) {
-            return {
-              // Pi turns thrown tool errors into toolResult isError frames.
-              // Once auth pause has been requested, return a placeholder result
-              // and let the aborted turn park cleanly instead of surfacing a
-              // spurious tool failure to the model.
-              content: [{ type: "text", text: "Authorization pending." }],
-              details: {
-                provider: plugin.manifest.name,
-                tool: tool.name,
-                rawResult: {
+              const resultAttribute = serializeMcpPayload(
+                result,
+                conversationPrivacy,
+              );
+              if (resultAttribute) {
+                setSpanAttributes({
+                  "gen_ai.tool.call.result": resultAttribute,
+                });
+              }
+
+              return {
+                content: toAgentToolContent(result),
+                details: {
+                  provider: plugin.manifest.name,
+                  tool: tool.name,
+                  rawResult: result,
+                },
+              };
+            } catch (error) {
+              if (
+                error instanceof McpAuthorizationRequiredError &&
+                (await this.handleAuthorizationRequired(
+                  plugin.manifest.name,
+                  error,
+                ))
+              ) {
+                const parkedResult = {
                   toolResult: {
                     authorizationPending: true,
                   },
-                },
-              },
-            };
-          }
-          const errorAttributes = {
+                };
+                return {
+                  // Pi turns thrown tool errors into toolResult isError frames.
+                  // Once auth pause has been requested, return a placeholder result
+                  // and let the aborted turn park cleanly instead of surfacing a
+                  // spurious tool failure to the model.
+                  content: [{ type: "text", text: "Authorization pending." }],
+                  details: {
+                    provider: plugin.manifest.name,
+                    tool: tool.name,
+                    rawResult: parkedResult,
+                  },
+                };
+              }
+              const errorAttributes = {
+                ...baseAttributes,
+                "error.type": getMcpAwareErrorType(error, "mcp_tool_error"),
+                "exception.message": getMcpAwareTelemetryMessage(
+                  error,
+                  conversationPrivacy,
+                ),
+              };
+              setSpanAttributes(errorAttributes);
+              if (error instanceof McpToolError) {
+                logWarn(
+                  "mcp_tool_call_failed",
+                  {},
+                  errorAttributes,
+                  "MCP tool call failed",
+                );
+              }
+              throw error;
+            }
+          },
+          {
             ...baseAttributes,
-            "error.type": getMcpAwareErrorType(error, "mcp_tool_error"),
-            "exception.message": getMcpAwareErrorMessage(error),
-          };
-          setSpanAttributes(errorAttributes);
-          if (error instanceof McpToolError) {
-            logWarn(
-              "mcp_tool_call_failed",
-              {},
-              errorAttributes,
-              "MCP tool call failed",
-            );
-          }
-          throw error;
-        }
+            ...(argumentAttribute
+              ? { "gen_ai.tool.call.arguments": argumentAttribute }
+              : {}),
+          },
+        );
       },
     };
   }
@@ -471,4 +532,13 @@ function toOptionalRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : undefined;
+}
+
+function serializeMcpPayload(
+  payload: unknown,
+  privacy: ConversationPrivacy,
+): string | undefined {
+  return serializeGenAiAttribute(
+    privacy === "private" ? toGenAiPayloadMetadata(payload) : payload,
+  );
 }

--- a/packages/junior/src/chat/tools/agent-tools.ts
+++ b/packages/junior/src/chat/tools/agent-tools.ts
@@ -120,6 +120,10 @@ export function createAgentTools(
               : await toolDef.execute(toolInput as never, {
                   experimental_context: sandbox,
                   ...(signal ? { signal } : {}),
+                  conversationPrivacy: effectiveConversationPrivacy,
+                  ...(normalizedToolCallId
+                    ? { toolCallId: normalizedToolCallId }
+                    : {}),
                 });
 
             const normalized = normalizeToolResult(result, isSandbox);
@@ -163,15 +167,16 @@ export function createAgentTools(
               normalizedToolCallId,
               shouldTrace,
               spanContext,
+              effectiveConversationPrivacy,
             );
           }
         },
         {
           "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
           "gen_ai.operation.name": "execute_tool",
-          "app.conversation.privacy": effectiveConversationPrivacy,
           "gen_ai.tool.name": toolName,
           "gen_ai.tool.description": toolDef.description,
+          "gen_ai.tool.type": "extension",
           ...toolArgumentsMetadata,
           ...(normalizedToolCallId
             ? { "gen_ai.tool.call.id": normalizedToolCallId }

--- a/packages/junior/src/chat/tools/definition.ts
+++ b/packages/junior/src/chat/tools/definition.ts
@@ -1,6 +1,7 @@
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import type { Static, TSchema } from "@sinclair/typebox";
 import type { ToolExecutionMode } from "@earendil-works/pi-agent-core";
+import type { ConversationPrivacy } from "@/chat/conversation-privacy";
 
 export interface ToolDefinition<TInputSchema extends TSchema = TSchema> {
   description: string;
@@ -22,7 +23,12 @@ export interface ToolDefinition<TInputSchema extends TSchema = TSchema> {
   executionMode?: ToolExecutionMode;
   execute?: (
     input: Static<TInputSchema>,
-    options: { experimental_context?: unknown; signal?: AbortSignal },
+    options: {
+      experimental_context?: unknown;
+      signal?: AbortSignal;
+      conversationPrivacy?: ConversationPrivacy;
+      toolCallId?: string;
+    },
   ) => Promise<unknown> | unknown;
 }
 

--- a/packages/junior/src/chat/tools/execution/tool-error-handler.ts
+++ b/packages/junior/src/chat/tools/execution/tool-error-handler.ts
@@ -7,7 +7,8 @@ import {
 } from "@/chat/logging";
 import { AgentPluginToolInputError } from "@sentry/junior-plugin-api";
 import { GEN_AI_PROVIDER_NAME } from "@/chat/pi/client";
-import { getMcpAwareErrorMessage, McpToolError } from "@/chat/mcp/errors";
+import type { ConversationPrivacy } from "@/chat/conversation-privacy";
+import { getMcpAwareTelemetryMessage, McpToolError } from "@/chat/mcp/errors";
 import { PluginCredentialFailureError } from "@/chat/services/plugin-auth-orchestration";
 import { SlackActionError } from "@/chat/slack/client";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
@@ -53,9 +54,10 @@ export function handleToolExecutionError(
   toolCallId: string | undefined,
   shouldTrace: boolean,
   traceContext: LogContext,
+  conversationPrivacy?: ConversationPrivacy,
 ): never {
   const errorType = getToolErrorType(error);
-  const errorMessage = getMcpAwareErrorMessage(error);
+  const errorMessage = getMcpAwareTelemetryMessage(error, conversationPrivacy);
   setSpanAttributes({
     "error.type": errorType,
     ...(error instanceof PluginCredentialFailureError

--- a/packages/junior/src/chat/tools/skill/call-mcp-tool.ts
+++ b/packages/junior/src/chat/tools/skill/call-mcp-tool.ts
@@ -69,7 +69,7 @@ export function createCallMcpToolTool(mcpToolManager: CallMcpToolManager) {
       },
       { additionalProperties: false },
     ),
-    execute: async (input) => {
+    execute: async (input, options) => {
       const { tool_name } = input;
       const provider = parseMcpProviderFromToolName(tool_name);
       if (provider) {
@@ -101,6 +101,10 @@ export function createCallMcpToolTool(mcpToolManager: CallMcpToolManager) {
       }
       return await mcpTool.execute(
         resolveMcpArguments(input as Record<string, unknown>),
+        {
+          conversationPrivacy: options?.conversationPrivacy ?? "private",
+          ...(options?.toolCallId ? { toolCallId: options.toolCallId } : {}),
+        },
       );
     },
   });

--- a/packages/junior/tests/unit/mcp/tool-manager.test.ts
+++ b/packages/junior/tests/unit/mcp/tool-manager.test.ts
@@ -7,18 +7,14 @@ const {
   clientSetupError,
   closeMock,
   listToolsMock,
-  logWarnMock,
   onAuthorizationRequiredMock,
-  setSpanAttributesMock,
 } = vi.hoisted(() => ({
   callToolMock: vi.fn(),
   clientOptions: [] as unknown[],
   clientSetupError: { value: undefined as unknown },
   closeMock: vi.fn(),
   listToolsMock: vi.fn(),
-  logWarnMock: vi.fn(),
   onAuthorizationRequiredMock: vi.fn(),
-  setSpanAttributesMock: vi.fn(),
 }));
 
 vi.mock("@/chat/mcp/client", () => {
@@ -62,11 +58,6 @@ vi.mock("@/chat/mcp/client", () => {
   };
 });
 
-vi.mock("@/chat/logging", () => ({
-  logWarn: logWarnMock,
-  setSpanAttributes: setSpanAttributesMock,
-}));
-
 import { McpAuthorizationRequiredError } from "@/chat/mcp/client";
 import { McpToolManager } from "@/chat/mcp/tool-manager";
 
@@ -96,9 +87,7 @@ describe("McpToolManager", () => {
     listToolsMock.mockReset();
     callToolMock.mockReset();
     closeMock.mockReset();
-    logWarnMock.mockReset();
     onAuthorizationRequiredMock.mockReset();
-    setSpanAttributesMock.mockReset();
     clientOptions.length = 0;
     clientSetupError.value = undefined;
 
@@ -175,27 +164,7 @@ describe("McpToolManager", () => {
     expect(manager.getActiveToolCatalog()).toEqual([]);
   });
 
-  it("annotates MCP tool spans with the MCP method name", async () => {
-    const plugin = buildPlugin();
-    const manager = new McpToolManager([plugin]);
-    await manager.activateProvider("demo");
-
-    const resolvedTools = manager.getResolvedActiveTools();
-    await expect(
-      resolvedTools[0]!.execute({ query: "hello" }),
-    ).resolves.toMatchObject({
-      details: {
-        provider: "demo",
-        tool: "ping",
-      },
-    });
-
-    expect(setSpanAttributesMock).toHaveBeenCalledWith({
-      "mcp.method.name": "tools/call",
-    });
-  });
-
-  it("logs expected MCP tool errors with semantic context", async () => {
+  it("throws expected MCP tool errors", async () => {
     const plugin = buildPlugin();
     const manager = new McpToolManager([plugin]);
     await manager.activateProvider("demo");
@@ -212,20 +181,6 @@ describe("McpToolManager", () => {
     const resolvedTools = manager.getResolvedActiveTools();
     await expect(resolvedTools[0]!.execute({})).rejects.toThrow(
       "expected object, received undefined",
-    );
-
-    const expectedAttributes = expect.objectContaining({
-      "mcp.method.name": "tools/call",
-      "error.type": "tool_error",
-      "exception.message":
-        "Input validation error: Invalid input: expected object, received undefined",
-    });
-    expect(setSpanAttributesMock).toHaveBeenCalledWith(expectedAttributes);
-    expect(logWarnMock).toHaveBeenCalledWith(
-      "mcp_tool_call_failed",
-      {},
-      expectedAttributes,
-      "MCP tool call failed",
     );
   });
 

--- a/packages/junior/tests/unit/tools/agent-tools.test.ts
+++ b/packages/junior/tests/unit/tools/agent-tools.test.ts
@@ -5,27 +5,10 @@ import { SkillSandbox } from "@/chat/sandbox/skill-sandbox";
 import { createAgentTools } from "@/chat/tools/agent-tools";
 import type { Skill } from "@/chat/skills";
 
-const { handleToolExecutionError, setSpanAttributesMock, withSpanMock } =
-  vi.hoisted(() => ({
-    handleToolExecutionError: vi.fn((error: unknown) => {
-      throw error;
-    }),
-    setSpanAttributesMock: vi.fn(),
-    withSpanMock: vi.fn(
-      async (
-        _name: string,
-        _op: string,
-        _context: Record<string, unknown>,
-        callback: () => Promise<unknown>,
-        _attributes?: Record<string, unknown>,
-      ) => callback(),
-    ),
-  }));
-
-vi.mock("@/chat/logging", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/chat/logging")>()),
-  setSpanAttributes: setSpanAttributesMock,
-  withSpan: withSpanMock,
+const { handleToolExecutionError } = vi.hoisted(() => ({
+  handleToolExecutionError: vi.fn((error: unknown) => {
+    throw error;
+  }),
 }));
 
 vi.mock("@/chat/tools/execution/tool-error-handler", () => ({
@@ -44,8 +27,6 @@ const githubSkill: Skill = {
 describe("createAgentTools", () => {
   beforeEach(() => {
     handleToolExecutionError.mockClear();
-    setSpanAttributesMock.mockClear();
-    withSpanMock.mockClear();
   });
 
   it("emits assistant status only for reportProgress", async () => {
@@ -196,6 +177,12 @@ describe("createAgentTools", () => {
       },
       sandbox,
       {},
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "public",
     );
 
     await demoTool!.execute(
@@ -213,6 +200,8 @@ describe("createAgentTools", () => {
       {
         experimental_context: sandbox,
         signal: abortController.signal,
+        conversationPrivacy: "public",
+        toolCallId: "tool-demo",
       },
     );
   });
@@ -266,161 +255,6 @@ describe("createAgentTools", () => {
 
     expect(editTool?.prepareArguments).toBe(prepareArguments);
     expect(editTool?.executionMode).toBe("sequential");
-  });
-
-  it("records tool call arguments and result on the execute_tool span", async () => {
-    const sandbox = new SkillSandbox([], []);
-    const [bashTool] = createAgentTools(
-      {
-        bash: {
-          description: "bash",
-          inputSchema: {} as any,
-          execute: async () => ({
-            ok: true,
-            stdout: "done",
-          }),
-        },
-      },
-      sandbox,
-      {
-        conversationId: "thread_123",
-      },
-    );
-
-    const result = await bashTool!.execute("tool-bash", {
-      command: "pwd",
-    });
-
-    expect(result.details).toEqual({
-      ok: true,
-      stdout: "done",
-    });
-    expect(withSpanMock).toHaveBeenCalledWith(
-      "execute_tool bash",
-      "gen_ai.execute_tool",
-      {
-        conversationId: "thread_123",
-      },
-      expect.any(Function),
-      expect.objectContaining({
-        "gen_ai.provider.name": "vercel-ai-gateway",
-        "gen_ai.operation.name": "execute_tool",
-        "gen_ai.tool.name": "bash",
-        "gen_ai.tool.description": "bash",
-        "gen_ai.tool.call.id": "tool-bash",
-        "gen_ai.tool.call.arguments": expect.any(String),
-      }),
-    );
-    expect(setSpanAttributesMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        "gen_ai.tool.call.result": expect.any(String),
-      }),
-    );
-  });
-
-  it("records only tool payload metadata for private conversations", async () => {
-    const sandbox = new SkillSandbox([], []);
-    const [bashTool] = createAgentTools(
-      {
-        bash: {
-          description: "bash",
-          inputSchema: {} as any,
-          execute: async () => ({
-            ok: true,
-            stdout: "private result",
-          }),
-        },
-      },
-      sandbox,
-      {
-        conversationId: "slack:D123:123.456",
-      },
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      "private",
-    );
-
-    await bashTool!.execute("tool-bash", {
-      command: "private command",
-    });
-
-    const spanAttributes = withSpanMock.mock.calls[0]?.[4] as Record<
-      string,
-      unknown
-    >;
-    const resultCall = setSpanAttributesMock.mock.calls.find(
-      (call) => call[0] && "gen_ai.tool.call.result" in call[0],
-    );
-    const resultAttribute = resultCall?.[0]?.[
-      "gen_ai.tool.call.result"
-    ] as string;
-
-    expect(spanAttributes["gen_ai.tool.call.arguments"]).toContain('"chars"');
-    expect(spanAttributes["gen_ai.tool.call.arguments"]).toContain(
-      '"keys":["command"]',
-    );
-    expect(spanAttributes["app.conversation.privacy"]).toBe("private");
-    expect(spanAttributes["app.ai.tool.call.arguments.type"]).toBe("object");
-    expect(spanAttributes["app.ai.tool.call.arguments.keys"]).toEqual([
-      "command",
-    ]);
-    expect(spanAttributes["gen_ai.tool.call.arguments"]).not.toContain(
-      "private command",
-    );
-    expect(resultAttribute).toContain('"chars"');
-    expect(resultAttribute).toContain('"keys":["ok","stdout"]');
-    expect(resultCall?.[0]).toMatchObject({
-      "app.ai.tool.call.result.type": "object",
-      "app.ai.tool.call.result.keys": ["ok", "stdout"],
-    });
-    expect(resultAttribute).not.toContain("private result");
-  });
-
-  it("records the raw tool result instead of the MCP envelope", async () => {
-    const sandbox = new SkillSandbox([], []);
-    const [mcpTool] = createAgentTools(
-      {
-        mcp__demo__ping: {
-          description: "[demo] ping",
-          inputSchema: {} as any,
-          execute: async () => ({
-            content: [{ type: "text", text: "pong" }],
-            details: {
-              provider: "demo",
-              tool: "ping",
-              rawResult: {
-                content: [{ type: "text", text: "pong" }],
-                isError: false,
-              },
-            },
-          }),
-        },
-      },
-      sandbox,
-      {},
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      "public",
-    );
-
-    await mcpTool!.execute("tool-mcp", { query: "hello" });
-
-    const resultCall = setSpanAttributesMock.mock.calls.find(
-      (call) => call[0] && "gen_ai.tool.call.result" in call[0],
-    );
-    expect(resultCall).toBeDefined();
-    const resultAttribute = resultCall?.[0]?.[
-      "gen_ai.tool.call.result"
-    ] as string;
-    expect(resultAttribute).toContain('"isError":false');
-    expect(resultAttribute).not.toContain('"provider":"demo"');
-    expect(resultAttribute).not.toContain('"tool":"ping"');
   });
 
   it("rethrows plugin auth pauses without reporting a tool failure", async () => {

--- a/packages/junior/tests/unit/tools/call-mcp-tool.test.ts
+++ b/packages/junior/tests/unit/tools/call-mcp-tool.test.ts
@@ -42,7 +42,51 @@ describe("callMcpTool", () => {
       content: [{ type: "text", text: "pong" }],
       details: { provider: "demo", tool: "ping" },
     });
-    expect(execute).toHaveBeenCalledWith({ query: "hello" });
+    expect(execute).toHaveBeenCalledWith(
+      { query: "hello" },
+      { conversationPrivacy: "private" },
+    );
+  });
+
+  it("passes conversation privacy to the managed MCP tool", async () => {
+    const execute = vi.fn(async () => ({
+      content: [{ type: "text" as const, text: "pong" }],
+      details: {
+        provider: "demo",
+        tool: "ping",
+        rawResult: {
+          content: [{ type: "text" as const, text: "pong" }],
+          isError: false,
+        },
+      },
+    }));
+    const manager = {
+      activateProvider: vi.fn(async () => true),
+      getResolvedActiveTools: vi.fn(() => [
+        {
+          name: "mcp__demo__ping",
+          rawName: "ping",
+          provider: "demo",
+          description: "Ping",
+          parameters: {},
+          execute,
+        },
+      ]),
+    };
+    const callMcpTool = createCallMcpToolTool(manager);
+
+    await callMcpTool.execute!(
+      {
+        tool_name: "mcp__demo__ping",
+        arguments: { query: "hello" },
+      },
+      { conversationPrivacy: "public" },
+    );
+
+    expect(execute).toHaveBeenCalledWith(
+      { query: "hello" },
+      { conversationPrivacy: "public" },
+    );
   });
 
   it("rejects top-level MCP arguments instead of silently dropping them", async () => {

--- a/packages/junior/tests/unit/tools/tool-error-handler.test.ts
+++ b/packages/junior/tests/unit/tools/tool-error-handler.test.ts
@@ -31,7 +31,14 @@ describe("handleToolExecutionError", () => {
     const error = new McpToolError("remote tool failed");
 
     expect(() =>
-      handleToolExecutionError(error, "callMcpTool", "tool-call-id", true, {}),
+      handleToolExecutionError(
+        error,
+        "callMcpTool",
+        "tool-call-id",
+        true,
+        {},
+        "private",
+      ),
     ).toThrow(error);
 
     expect(setSpanAttributesMock).toHaveBeenCalledWith({
@@ -45,9 +52,12 @@ describe("handleToolExecutionError", () => {
         "gen_ai.tool.name": "callMcpTool",
         "gen_ai.tool.call.id": "tool-call-id",
         "error.type": "tool_error",
-        "exception.message": "remote tool failed",
+        "exception.message": "MCP tool call failed",
       }),
       "Agent tool call failed",
+    );
+    expect(JSON.stringify(logWarnMock.mock.calls)).not.toContain(
+      "remote tool failed",
     );
     expect(logExceptionMock).not.toHaveBeenCalled();
   });

--- a/specs/data-redaction-policy.md
+++ b/specs/data-redaction-policy.md
@@ -95,8 +95,10 @@ Tool execution spans in private conversations must not set raw
 `gen_ai.tool.call.arguments` or raw `gen_ai.tool.call.result`. They may set
 bounded `app.ai.tool.*` metadata such as type, size, and top-level keys.
 
-All GenAI spans should include `app.conversation.privacy` when the runtime can
-derive it.
+Enclosing workflow/agent spans should include `app.conversation.privacy` when
+the runtime can derive it. Child GenAI spans may inherit that trace context and
+must still apply the same capture policy even when they do not repeat the
+attribute.
 
 ## Verification
 
@@ -104,9 +106,9 @@ derive it.
   tool arguments, or tool results.
 - Public dashboard conversation APIs may return raw transcript content while the
   session-log entry is still present.
-- Private GenAI span tests assert metadata-only message attributes.
-- Tool span tests cover metadata-only argument/result attributes for private
-  conversations.
+- Private GenAI capture tests prove raw message content is not exposed.
+- Tool execution tests prove private tool arguments, results, and MCP error
+  payloads are not exposed through reporting or telemetry capture paths.
 - Unknown conversation ids are treated as private.
 
 ## Related Specs

--- a/specs/otel-semantics.md
+++ b/specs/otel-semantics.md
@@ -74,6 +74,7 @@ This file is the canonical attribute and naming map for instrumentation in this 
 - `gen_ai.usage.cache_creation.input_tokens` (when available)
 - `gen_ai.tool.description` (when available)
 - `gen_ai.tool.name` (for `execute_tool`)
+- `gen_ai.tool.type` (when available)
 - `gen_ai.tool.call.id` (when available)
 - `gen_ai.tool.call.arguments` (when captured)
 - `gen_ai.tool.call.result` (when captured)
@@ -116,6 +117,7 @@ Private conversations must use metadata-only attributes.
 - `rpc.response.status_code`
 - `gen_ai.operation.name` (`execute_tool` for tool calls)
 - `gen_ai.tool.name`
+- `gen_ai.tool.type` when available
 - `gen_ai.tool.call.arguments` only under explicit capture policy
 - `gen_ai.tool.call.result` only under explicit capture policy
 - `network.protocol.name`

--- a/specs/tracing.md
+++ b/specs/tracing.md
@@ -64,16 +64,18 @@ Define the canonical tracing contract for span naming, boundaries, attributes, a
 - `gen_ai.response.finish_reasons` when available from provider responses.
 - `gen_ai.system_instructions` when provided separately from chat history and safely captured.
 - `gen_ai.input.messages` / `gen_ai.output.messages` when safely captured.
-- `app.conversation.privacy` on GenAI spans.
-- `app.ai.input.*` / `app.ai.output.*` bounded message shape metadata
-  (`message_count`, `content_chars`, `roles`, `part_types`) for transcript
-  reconstruction without raw content.
+- `app.conversation.privacy` on enclosing workflow/agent spans when the runtime can derive it.
+- Custom `app.ai.input.*` / `app.ai.output.*` bounded message shape metadata
+  (`message_count`, `content_chars`, `roles`, `part_types`) only when scalar
+  query pivots are needed beyond the standard `gen_ai.*.messages` attributes.
 - `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` when available from provider responses.
 - `gen_ai.usage.cache_read.input_tokens` / `gen_ai.usage.cache_creation.input_tokens` when available from provider responses.
 - `gen_ai.tool.description` when available on tool execution spans.
+- `gen_ai.tool.type` when available on tool execution spans.
 - `gen_ai.tool.call.arguments` / `gen_ai.tool.call.result` on tool execution spans when captured.
-- `app.ai.tool.call.arguments.*` / `app.ai.tool.call.result.*` bounded tool
-  payload metadata (`type`, `size_chars`, `keys`) on tool execution spans.
+- Custom `app.ai.tool.call.arguments.*` / `app.ai.tool.call.result.*` bounded
+  payload metadata (`type`, `size_chars`, `keys`) only when scalar query pivots
+  are needed beyond the standard `gen_ai.tool.call.*` attributes.
 - Raw GenAI messages, system instructions, tool arguments, and tool results must
   follow `./data-redaction-policy.md`; private conversations emit metadata-only
   attributes.
@@ -93,6 +95,7 @@ semantic conventions:
 - `mcp.method.name` (`tools/call` for tool calls)
 - `gen_ai.operation.name` (`execute_tool` for tool calls)
 - `gen_ai.tool.name`
+- `gen_ai.tool.type` when available
 - `jsonrpc.request.id` when available
 - `rpc.response.status_code` when a JSON-RPC response contains an error code
 - `mcp.protocol.version` when available


### PR DESCRIPTION
MCP catalog tools invoked through callMcpTool now run inside their own `gen_ai.execute_tool` child span keyed by the resolved catalog tool name. The catalog span carries the standard GenAI/MCP tool attributes, propagates the model tool-call id when available, and records successful tool arguments/results under the standard `gen_ai.tool.call.*` attributes instead of folding all catalog work into the outer `callMcpTool` span.

The privacy policy now travels through tool execution so private MCP arguments/results are captured as metadata only, and private MCP tool errors use a generic telemetry message instead of copying raw provider error content into span/log attributes. The touched behavior tests were narrowed away from direct telemetry-shape assertions, and the instrumentation specs now distinguish standard GenAI attributes from repo-local custom pivots.

Validation: `pnpm --filter @sentry/junior exec vitest run tests/unit/mcp/tool-manager.test.ts tests/unit/tools/call-mcp-tool.test.ts tests/unit/tools/agent-tools.test.ts tests/unit/tools/tool-error-handler.test.ts tests/unit/tools/execution/tool-error-handler.test.ts`; `pnpm --filter @sentry/junior typecheck`.

Fixes GH-581