### PR TITLE
fix(sandbox): always consume egress auth signals regardless of exit code

### DIFF
--- a/packages/junior/src/chat/sandbox/sandbox.ts
+++ b/packages/junior/src/chat/sandbox/sandbox.ts
@@ -299,14 +299,15 @@ export function createSandboxExecutor(options?: {
         }
       },
     );
-    const authRequired =
-      result.exitCode !== 0
-        ? await consumeSandboxEgressAuthRequiredSignal(activeEgressId)
-        : undefined;
-    const permissionDenied =
-      result.exitCode !== 0
-        ? await consumeSandboxEgressPermissionDeniedSignal(activeEgressId)
-        : undefined;
+    // Always consume egress auth/permission signals regardless of exit code.
+    // The exit-code guard was incorrect: piped bash commands (e.g. `cmd | head`)
+    // mask the underlying CLI's non-zero exit with the pipe tail's exit code (0),
+    // preventing the signal from ever being read. The egress signal is a
+    // side-channel from the network layer — not a property of shell exit status —
+    // and `clearSandboxEgressSignals` runs before each execution to prevent
+    // cross-command leakage.
+    const authRequired = await consumeSandboxEgressAuthRequiredSignal(activeEgressId);
+    const permissionDenied = await consumeSandboxEgressPermissionDeniedSignal(activeEgressId);
 
     return {
       result: {

--- a/packages/junior/tests/unit/misc/sandbox-executor.test.ts
+++ b/packages/junior/tests/unit/misc/sandbox-executor.test.ts
@@ -931,7 +931,7 @@ describe("createSandboxExecutor", () => {
     expect(response.result.permission_denied).toBeUndefined();
   });
 
-  it("attaches sandbox egress auth signals to failed bash results", async () => {
+  it("attaches sandbox egress auth signals to bash results regardless of exit code", async () => {
     const sandbox = makeSandbox("sbx_fresh_auth_signal");
     sandbox.runCommand.mockImplementationOnce(async () => {
       await setSandboxEgressAuthRequiredSignal(
@@ -989,7 +989,73 @@ describe("createSandboxExecutor", () => {
     });
   });
 
-  it("attaches sandbox egress permission signals to failed bash results", async () => {
+  it("attaches sandbox egress auth signals to bash results with exit code 0 (pipe-masked failures)", async () => {
+    // Regression test: piped bash commands (e.g. `cmd | head`) mask the
+    // underlying CLI exit code with 0 from the pipe tail. The auth signal must
+    // still be surfaced so the OAuth flow can be triggered.
+    const sandbox = makeSandbox("sbx_pipe_masked_auth_signal");
+    sandbox.runCommand.mockImplementationOnce(async () => {
+      await setSandboxEgressAuthRequiredSignal(
+        {
+          credentials: { actor: { type: "user" as const, userId: "U123" } },
+          egressId: "sbx_pipe_masked_auth_signal_session",
+          expiresAtMs: Date.now() + 60_000,
+          contextId: "ctx-pipe-masked",
+        },
+        {
+          provider: "sentry",
+          grant: {
+            name: "default",
+            access: "read",
+          },
+          authorization: {
+            type: "oauth",
+            provider: "sentry",
+          },
+        },
+      );
+      return {
+        exitCode: 0, // pipe tail (head/grep) always exits 0
+        stdout: async () =>
+          '"junior-auth-required provider=sentry grant=default access=read 401 unauthorized"',
+        stderr: async () => "",
+      };
+    });
+    sandboxGetMock.mockResolvedValue(sandbox);
+    vi.mocked(createBashTool).mockResolvedValue({
+      tools: {
+        readFile: { execute: vi.fn(async () => ({ content: "" })) },
+        writeFile: { execute: vi.fn(async () => ({ success: true })) },
+      },
+    } as never);
+
+    const executor = createSandboxExecutor({
+      sandboxId: "sbx_pipe_masked_auth_signal",
+    });
+    executor.configureSkills([]);
+
+    const response = await executor.execute<{
+      auth_required?: unknown;
+      exit_code: number;
+    }>({
+      toolName: "bash",
+      input: {
+        command: "sentry org list --json 2>&1 | head -20",
+      },
+    });
+
+    expect(response.result.exit_code).toBe(0);
+    // Auth signal must be attached even though exit_code is 0
+    expect(response.result.auth_required).toMatchObject({
+      provider: "sentry",
+      grant: {
+        name: "default",
+        access: "read",
+      },
+    });
+  });
+
+  it("attaches sandbox egress permission signals to bash results regardless of exit code", async () => {
     const sandbox = makeSandbox("sbx_permission_signal");
     sandbox.runCommand.mockImplementationOnce(async () => {
       await setSandboxEgressPermissionDeniedSignal(


### PR DESCRIPTION
## What

Remove the `exitCode !== 0` guard when consuming sandbox egress auth/permission signals after a bash execution.

## Why

Piped bash commands like:
```
sentry org list --json 2>&1 | head -20
sentry api /organizations/sentry/projects/ --json 2>&1 | grep -i foo | head -30
```

mask the underlying CLI's non-zero exit code with 0 from the pipe tail (`head`, `grep`, etc.). The previous guard prevented auth/permission signals from ever being consumed when the outer shell returned 0, so the OAuth reconnect flow was never triggered and the user never received an authorization link.

Concretely: `sentry org list` exits **30** on a 401, but `sentry org list ... | head` exits **0**. The egress proxy sets the auth-required signal in Redis, but the old code only consumed that signal when `result.exitCode !== 0`.

## Why it's safe

The egress auth signal is a **side-channel from the network layer**, not a property of shell exit status. Consuming it unconditionally is safe because `clearSandboxEgressSignals(activeEgressId)` runs **before** each bash execution, preventing signals from a previous command bleeding into the current one.

If an auth signal is present after a successful command (exit 0), it means some network request during that command was rejected by the proxy — the OAuth flow should still be triggered.

## Verified

- 43 sandbox executor tests pass
- 35 egress proxy tests pass
- 13 plugin auth orchestration tests pass
- New regression test covers the pipe-masked exit code scenario

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AD0AGRTQ99A7%3A1781118677.966789%22)