### PR TITLE
fix(auth): Normalize credential auth handoff

### DIFF
--- a/apps/example/app/plugins/example-bundle/plugin.yaml
+++ b/apps/example/app/plugins/example-bundle/plugin.yaml
@@ -1,2 +1,3 @@
 name: example-bundle
+display-name: Example Bundle
 description: Example bundle-only plugin that contributes skills without credentials.

--- a/packages/junior-agent-browser/plugin.yaml
+++ b/packages/junior-agent-browser/plugin.yaml
@@ -1,4 +1,5 @@
 name: agent-browser
+display-name: Agent Browser
 description: Browser automation workflows powered by agent-browser CLI
 
 runtime-dependencies:

--- a/packages/junior-dashboard/src/index.ts
+++ b/packages/junior-dashboard/src/index.ts
@@ -59,6 +59,7 @@ export function juniorDashboardPlugin(
     name: "dashboard",
     manifest: {
       name: "dashboard",
+      displayName: "Dashboard",
       description: "Junior dashboard routes and Slack footer links",
     },
     hooks: {

--- a/packages/junior-datadog/plugin.yaml
+++ b/packages/junior-datadog/plugin.yaml
@@ -1,4 +1,5 @@
 name: datadog
+display-name: Datadog
 description: Query Datadog telemetry (logs, metrics, traces, monitors, incidents, dashboards) with Datadog's Pup CLI
 
 config-keys:

--- a/packages/junior-evals/evals/fixtures/plugins/eval-auth/plugin.yaml
+++ b/packages/junior-evals/evals/fixtures/plugins/eval-auth/plugin.yaml
@@ -1,4 +1,5 @@
 name: eval-auth
+display-name: Eval Auth
 description: Eval-only MCP auth resume fixture
 
 mcp:

--- a/packages/junior-evals/evals/fixtures/plugins/eval-mcp/plugin.yaml
+++ b/packages/junior-evals/evals/fixtures/plugins/eval-mcp/plugin.yaml
@@ -1,4 +1,5 @@
 name: eval-mcp
+display-name: Eval MCP
 description: Eval-only MCP lookup fixture
 
 mcp:

--- a/packages/junior-evals/evals/fixtures/plugins/eval-oauth/plugin.yaml
+++ b/packages/junior-evals/evals/fixtures/plugins/eval-oauth/plugin.yaml
@@ -1,4 +1,5 @@
 name: eval-oauth
+display-name: Eval OAuth
 description: Eval-only generic OAuth auth-resume fixture
 
 capabilities:

--- a/packages/junior-github/index.js
+++ b/packages/junior-github/index.js
@@ -990,6 +990,7 @@ export function githubPlugin(options = {}) {
     packageName: "@sentry/junior-github",
     manifest: {
       name: "github",
+      displayName: "GitHub",
       description:
         "GitHub issue, pull request, and repository workflows via GitHub App",
       ...(appCapabilities ? { capabilities: appCapabilities } : {}),

--- a/packages/junior-hex/plugin.yaml
+++ b/packages/junior-hex/plugin.yaml
@@ -1,4 +1,5 @@
 name: hex
+display-name: Hex
 description: Hex analytics platform — run data warehouse queries for customer usage data
 
 env-vars:

--- a/packages/junior-linear/plugin.yaml
+++ b/packages/junior-linear/plugin.yaml
@@ -1,4 +1,5 @@
 name: linear
+display-name: Linear
 description: Linear issue tracking via hosted MCP server
 
 config-keys:

--- a/packages/junior-maintenance/plugin.yaml
+++ b/packages/junior-maintenance/plugin.yaml
@@ -1,2 +1,3 @@
 name: maintenance
+display-name: Maintenance
 description: Junior maintenance workflows for updating and improving Junior apps

--- a/packages/junior-notion/plugin.yaml
+++ b/packages/junior-notion/plugin.yaml
@@ -1,4 +1,5 @@
 name: notion
+display-name: Notion
 description: Notion page search and summarization
 
 mcp:

--- a/packages/junior-plugin-api/src/index.ts
+++ b/packages/junior-plugin-api/src/index.ts
@@ -672,6 +672,7 @@ export interface JuniorPluginManifest {
   configKeys?: string[];
   credentials?: JuniorPluginCredentials;
   description: string;
+  displayName: string;
   domains?: string[];
   envVars?: Record<string, JuniorPluginEnvVarDeclaration>;
   mcp?: JuniorPluginMcpConfig;
@@ -724,6 +725,14 @@ export function defineJuniorPlugin(
   if (!PLUGIN_NAME_RE.test(name)) {
     throw new Error(
       `Junior plugin registration name "${name}" must be a lowercase plugin identifier.`,
+    );
+  }
+  if (
+    typeof manifest.displayName !== "string" ||
+    !manifest.displayName.trim()
+  ) {
+    throw new Error(
+      `Junior plugin "${name}" manifest.displayName is required.`,
     );
   }
   if (

--- a/packages/junior-scheduler/src/plugin.ts
+++ b/packages/junior-scheduler/src/plugin.ts
@@ -358,6 +358,7 @@ export function createSchedulerPlugin() {
   return defineJuniorPlugin({
     manifest: {
       name: "scheduler",
+      displayName: "Scheduler",
       description: "Scheduled Junior task management and heartbeat dispatch",
     },
     legacyStatePrefixes: ["junior:scheduler"],

--- a/packages/junior-sentry/plugin.yaml
+++ b/packages/junior-sentry/plugin.yaml
@@ -1,4 +1,5 @@
 name: sentry
+display-name: Sentry
 description: Sentry issue tracking
 
 capabilities:

--- a/packages/junior-vercel/plugin.yaml
+++ b/packages/junior-vercel/plugin.yaml
@@ -1,4 +1,5 @@
 name: vercel
+display-name: Vercel
 description: Query Vercel deployments and logs with the Vercel CLI
 
 config-keys:

--- a/packages/junior/src/chat/oauth-flow.ts
+++ b/packages/junior/src/chat/oauth-flow.ts
@@ -3,7 +3,10 @@ import type { Destination } from "@sentry/junior-plugin-api";
 import type { ChannelConfigurationService } from "@/chat/configuration/types";
 import { parseDestination } from "@/chat/destination";
 import { logInfo, logWarn } from "@/chat/logging";
-import { getPluginOAuthConfig } from "@/chat/plugins/registry";
+import {
+  getPluginDisplayName,
+  getPluginOAuthConfig,
+} from "@/chat/plugins/registry";
 import { getSlackClient, isDmChannel } from "@/chat/slack/client";
 import {
   postSlackEphemeralMessage,
@@ -88,9 +91,13 @@ export function parseOAuthStatePayload(
   };
 }
 
-/** Capitalize the first letter of a provider name for display. */
+/** Return the manifest-owned display label for a provider. */
 export function formatProviderLabel(provider: string): string {
-  return provider.charAt(0).toUpperCase() + provider.slice(1);
+  const displayName = getPluginDisplayName(provider);
+  if (!displayName) {
+    throw new Error(`Unknown plugin provider display name: "${provider}"`);
+  }
+  return displayName;
 }
 
 /** Resolve the public base URL from environment variables (JUNIOR_BASE_URL or Vercel). */

--- a/packages/junior/src/chat/plugins/inline-manifest-source.ts
+++ b/packages/junior/src/chat/plugins/inline-manifest-source.ts
@@ -113,6 +113,7 @@ export function inlineManifestSource(manifest: PluginManifest): ManifestSource {
   const result: ManifestSource = {};
 
   setDefined(result, "name", manifest.name);
+  setDefined(result, "display-name", manifest.displayName);
   setDefined(result, "description", manifest.description);
   setDefined(
     result,

--- a/packages/junior/src/chat/plugins/manifest.ts
+++ b/packages/junior/src/chat/plugins/manifest.ts
@@ -256,6 +256,7 @@ const manifestSourceSchema = z
     name: z.string().refine((value) => PLUGIN_NAME_RE.test(value), {
       error: "invalid",
     }),
+    "display-name": nonEmptyTrimmedString,
     description: nonEmptyTrimmedString,
     capabilities: z
       .array(z.string(), {
@@ -324,6 +325,7 @@ function manifestConfigPatch(
   config: PluginManifestConfig,
 ): Record<string, unknown> {
   const result: Record<string, unknown> = {};
+  setDefined(result, "display-name", config.displayName);
   setDefined(result, "description", config.description);
   setDefined(result, "capabilities", config.capabilities);
   setDefined(result, "config-keys", config.configKeys);
@@ -1100,6 +1102,7 @@ function parseManifestSource(
 
   const manifest: PluginManifest = {
     name: data.name,
+    displayName: data["display-name"],
     description: data.description,
     capabilities,
     configKeys,

--- a/packages/junior/src/chat/plugins/registry.ts
+++ b/packages/junior/src/chat/plugins/registry.ts
@@ -547,6 +547,12 @@ export function getPluginDefinition(
   return ensurePluginsLoaded().pluginsByName.get(provider);
 }
 
+/** Return the human-facing provider label from the plugin manifest. */
+export function getPluginDisplayName(provider: string): string | undefined {
+  return ensurePluginsLoaded().pluginsByName.get(provider)?.manifest
+    .displayName;
+}
+
 export function isPluginProvider(provider: string): boolean {
   return ensurePluginsLoaded().pluginsByName.has(provider);
 }

--- a/packages/junior/src/chat/plugins/types.ts
+++ b/packages/junior/src/chat/plugins/types.ts
@@ -77,6 +77,7 @@ export interface PluginEnvVarDeclaration {
 
 export interface PluginManifest {
   name: string;
+  displayName: string;
   description: string;
   capabilities: string[];
   configKeys: string[];
@@ -133,6 +134,7 @@ type PluginCredentialConfig = PluginCredentialConfigBase & {
 
 /** Install-level changes applied to one plugin manifest before validation. */
 export interface PluginManifestConfig {
+  displayName?: string;
   description?: string;
   capabilities?: string[];
   configKeys?: string[];

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -1691,6 +1691,7 @@ export async function generateAssistantReply(
             authDurationMs: Date.now() - replyStartedAtMs,
             authKind: error.kind,
             authProvider: error.provider,
+            authProviderDisplayName: error.providerDisplayName,
             authThinkingLevel: thinkingSelection?.thinkingLevel,
             authUsage: turnUsage,
             conversationId: timeoutResumeConversationId,

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -90,6 +90,7 @@ import {
 import { ensureSlackMessageActorIdentity } from "@/chat/services/message-actor-identity";
 import type { AgentContinueRequest } from "@/chat/services/agent-continue";
 import {
+  isAuthResumeRetryableTurnError,
   isCooperativeTurnYieldError,
   isRetryableTurnError,
 } from "@/chat/runtime/turn";
@@ -383,11 +384,18 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           beforeFirstResponsePostCalled = true;
           await options.beforeFirstResponsePost?.();
         };
-        const postAuthPauseNotice = async (): Promise<void> => {
+        const postAuthPauseNotice = async (
+          providerDisplayName: string,
+        ): Promise<void> => {
           try {
             await beforeFirstResponsePost();
             await thread.post(
-              buildSlackOutputMessage(buildAuthPauseResponse()),
+              buildSlackOutputMessage(
+                buildAuthPauseResponse(
+                  message.author.userId,
+                  providerDisplayName,
+                ),
+              ),
             );
           } catch (error) {
             logException(
@@ -1061,11 +1069,8 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             throw error;
           }
 
-          if (
-            isRetryableTurnError(error, "mcp_auth_resume") ||
-            isRetryableTurnError(error, "plugin_auth_resume")
-          ) {
-            await postAuthPauseNotice();
+          if (isAuthResumeRetryableTurnError(error)) {
+            await postAuthPauseNotice(error.metadata.authProviderDisplayName);
             completeAuthPauseTurn({
               conversation: preparedState.conversation,
               sessionId: error.metadata?.sessionId ?? turnId,

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -10,7 +10,10 @@ import {
   logException,
   type LogContext,
 } from "@/chat/logging";
-import { isRetryableTurnError } from "@/chat/runtime/turn";
+import {
+  isAuthResumeRetryableTurnError,
+  isRetryableTurnError,
+} from "@/chat/runtime/turn";
 import {
   finalizeFailedTurnReply,
   requireTurnFailureEventId,
@@ -265,6 +268,9 @@ export async function resumeSlackTurn(
   });
   let processingReaction: ProcessingReactionSession | undefined;
   let deferredPauseKind: "auth" | "timeout" | undefined;
+  let deferredAuthInfo:
+    | { providerDisplayName: string; requesterId: string | undefined }
+    | undefined;
   let deferredPauseHandler: (() => Promise<void>) | undefined;
   let deferredFailureHandler: (() => Promise<void>) | undefined;
   let finalReplyDelivered = false;
@@ -371,12 +377,13 @@ export async function resumeSlackTurn(
           "Failed to terminalize resumed turn after post-delivery commit failure",
         );
       }
-    } else if (
-      (isRetryableTurnError(error, "mcp_auth_resume") ||
-        isRetryableTurnError(error, "plugin_auth_resume")) &&
-      onAuthPause
-    ) {
+    } else if (isAuthResumeRetryableTurnError(error) && onAuthPause) {
       deferredPauseKind = "auth";
+      deferredAuthInfo = {
+        providerDisplayName: error.metadata.authProviderDisplayName,
+        // The try body validates requester.userId; catch scope does not retain that narrowing.
+        requesterId: runArgs.replyContext?.requester?.userId,
+      };
       deferredPauseHandler = async () => {
         await onAuthPause(error);
       };
@@ -422,11 +429,14 @@ export async function resumeSlackTurn(
   if (deferredPauseHandler) {
     try {
       await deferredPauseHandler();
-      if (deferredPauseKind === "auth") {
+      if (deferredPauseKind === "auth" && deferredAuthInfo) {
         await postSlackMessageBestEffort(
           runArgs.channelId,
           runArgs.threadTs,
-          buildAuthPauseResponse(),
+          buildAuthPauseResponse(
+            deferredAuthInfo.requesterId,
+            deferredAuthInfo.providerDisplayName,
+          ),
         );
       }
       return true;

--- a/packages/junior/src/chat/runtime/turn.ts
+++ b/packages/junior/src/chat/runtime/turn.ts
@@ -17,11 +17,18 @@ export type RetryableTurnReason =
   | "plugin_auth_resume"
   | "agent_continue";
 
+/** Auth-pause reasons require a known provider before a resume can be parked. */
+export type AuthResumeRetryableTurnReason = Extract<
+  RetryableTurnReason,
+  "mcp_auth_resume" | "plugin_auth_resume"
+>;
+
 export interface RetryableTurnMetadata {
   authDisposition?: AuthorizationPauseDisposition;
   authDurationMs?: number;
   authKind?: AuthorizationPauseKind;
   authProvider?: string;
+  authProviderDisplayName?: string;
   authThinkingLevel?: TurnThinkingSelection["thinkingLevel"];
   authUsage?: AgentTurnUsage;
   version?: number;
@@ -30,12 +37,32 @@ export interface RetryableTurnMetadata {
   sliceId?: number;
 }
 
+export interface AuthResumeRetryableTurnMetadata extends RetryableTurnMetadata {
+  authProvider: string;
+  authProviderDisplayName: string;
+}
+
+export type AuthResumeRetryableTurnError = RetryableTurnError & {
+  readonly reason: AuthResumeRetryableTurnReason;
+  readonly metadata: AuthResumeRetryableTurnMetadata;
+};
+
 /** Error indicating an agent run can continue later after timeout or auth pause. */
 export class RetryableTurnError extends Error {
   readonly code = "retryable_turn";
   readonly metadata?: RetryableTurnMetadata;
   readonly reason: RetryableTurnReason;
 
+  constructor(
+    reason: AuthResumeRetryableTurnReason,
+    message: string,
+    metadata: AuthResumeRetryableTurnMetadata,
+  );
+  constructor(
+    reason: "agent_continue",
+    message: string,
+    metadata?: RetryableTurnMetadata,
+  );
   constructor(
     reason: RetryableTurnReason,
     message: string,
@@ -59,6 +86,19 @@ export function isRetryableTurnError(
     return true;
   }
   return error.reason === reason;
+}
+
+/** Return whether a retryable turn is waiting for provider authorization. */
+export function isAuthResumeRetryableTurnError(
+  error: unknown,
+): error is AuthResumeRetryableTurnError {
+  return (
+    error instanceof RetryableTurnError &&
+    (error.reason === "mcp_auth_resume" ||
+      error.reason === "plugin_auth_resume") &&
+    typeof error.metadata?.authProvider === "string" &&
+    typeof error.metadata.authProviderDisplayName === "string"
+  );
 }
 
 /** Error indicating the turn paused voluntarily at a safe continuation boundary. */

--- a/packages/junior/src/chat/sandbox/egress-credentials.ts
+++ b/packages/junior/src/chat/sandbox/egress-credentials.ts
@@ -197,11 +197,27 @@ export async function sandboxEgressCredentialLease(
     }
     lease = pluginResult.lease;
   } else {
-    lease = await issueProviderCredentialLease({
-      context: context.credentials,
-      provider,
-      reason: grant.reason ?? `sandbox-egress:${provider}:default`,
-    });
+    // Normalize broker credential-needed failures into the canonical egress error
+    // so the proxy handles one auth-required type regardless of credential source.
+    // All CredentialUnavailableError throws in oauth-bearer-broker are user-actionable
+    // (missing token, scope gap, expired connection) and should trigger OAuth re-auth.
+    try {
+      lease = await issueProviderCredentialLease({
+        context: context.credentials,
+        provider,
+        reason: grant.reason ?? `sandbox-egress:${provider}:default`,
+      });
+    } catch (error) {
+      if (error instanceof CredentialUnavailableError) {
+        throw new SandboxEgressCredentialNeededError({
+          provider,
+          grant,
+          authorization: authorizationForSandboxEgressGrant(provider, selection),
+          message: error.message,
+        });
+      }
+      throw error;
+    }
   }
 
   const headerTransforms = lease.headerTransforms ?? [];

--- a/packages/junior/src/chat/sandbox/egress-credentials.ts
+++ b/packages/junior/src/chat/sandbox/egress-credentials.ts
@@ -36,22 +36,27 @@ export type SandboxEgressGrantSelection =
       source: "broker";
     };
 
-/** Signals that a plugin selected a grant but needs user authorization before issuing headers. */
-export class SandboxEgressCredentialNeededError extends Error {
+export type SandboxEgressCredentialErrorKind = "auth_required" | "unavailable";
+
+/** Signals that egress selected a grant but could not issue credential headers. */
+export class SandboxEgressCredentialError extends Error {
   readonly authorization?: AgentPluginAuthorization;
   readonly grant: AgentPluginGrant;
+  readonly kind: SandboxEgressCredentialErrorKind;
   readonly provider: string;
 
   constructor(input: {
     authorization?: AgentPluginAuthorization;
     grant: AgentPluginGrant;
+    kind: SandboxEgressCredentialErrorKind;
     message: string;
     provider: string;
   }) {
     super(input.message);
-    this.name = "SandboxEgressCredentialNeededError";
+    this.name = "SandboxEgressCredentialError";
     this.authorization = input.authorization;
     this.grant = input.grant;
+    this.kind = input.kind;
     this.provider = input.provider;
   }
 }
@@ -185,20 +190,25 @@ export async function sandboxEgressCredentialLease(
       userTokenStore: createUserTokenStore(),
     });
     if (pluginResult.type === "needed") {
-      throw new SandboxEgressCredentialNeededError({
+      throw new SandboxEgressCredentialError({
         provider,
         grant,
+        kind: "auth_required",
         authorization: pluginResult.authorization,
         message: pluginResult.message,
       });
     }
     if (pluginResult.type === "unavailable") {
-      throw new CredentialUnavailableError(provider, pluginResult.message);
+      throw new SandboxEgressCredentialError({
+        provider,
+        grant,
+        kind: "unavailable",
+        message: pluginResult.message,
+      });
     }
     lease = pluginResult.lease;
   } else {
-    // Normalize broker credential-needed failures into the canonical egress error
-    // so the proxy handles one auth-required type regardless of credential source.
+    // Normalize broker credential-needed failures into the egress error shape.
     // All CredentialUnavailableError throws in oauth-bearer-broker are user-actionable
     // (missing token, scope gap, expired connection) and should trigger OAuth re-auth.
     try {
@@ -209,10 +219,14 @@ export async function sandboxEgressCredentialLease(
       });
     } catch (error) {
       if (error instanceof CredentialUnavailableError) {
-        throw new SandboxEgressCredentialNeededError({
+        throw new SandboxEgressCredentialError({
           provider,
           grant,
-          authorization: authorizationForSandboxEgressGrant(provider, selection),
+          kind: "auth_required",
+          authorization: authorizationForSandboxEgressGrant(
+            provider,
+            selection,
+          ),
           message: error.message,
         });
       }

--- a/packages/junior/src/chat/sandbox/egress-proxy.ts
+++ b/packages/junior/src/chat/sandbox/egress-proxy.ts
@@ -773,12 +773,35 @@ async function proxySandboxEgressVerifiedRequest(input: {
         message: error.message,
       });
     }
+    // CredentialUnavailableError should only reach here for plugin { type: "unavailable" }
+    // results (non-OAuth infra/service failures). Broker-sourced CredentialUnavailableError
+    // is normalized to SandboxEgressCredentialNeededError in egress-credentials.ts.
     if (error instanceof CredentialUnavailableError) {
       const failedGrant = grantSelection.grant;
       const authorization = authorizationForSandboxEgressGrant(
         error.provider,
         grantSelection,
       );
+      if (grantSelection.source === "broker") {
+        logWarn(
+          "sandbox_egress_broker_credential_unavailable_unnormalized",
+          {},
+          {
+            ...egressAttributes({
+              egressId: activeEgressId,
+              grantAccess: failedGrant.access,
+              grantName: failedGrant.name,
+              host: upstreamUrl.hostname,
+              method: request.method,
+              path: upstreamUrl.pathname,
+              provider,
+              status: 401,
+            }),
+            ...routingAttributes(request, upstreamUrl),
+          },
+          "Broker CredentialUnavailableError reached proxy without normalization — expected SandboxEgressCredentialNeededError",
+        );
+      }
       await setSandboxEgressAuthRequiredSignal(credentialContext, {
         provider: error.provider,
         grant: failedGrant,

--- a/packages/junior/src/chat/sandbox/egress-proxy.ts
+++ b/packages/junior/src/chat/sandbox/egress-proxy.ts
@@ -743,6 +743,7 @@ async function proxySandboxEgressVerifiedRequest(input: {
       await setSandboxEgressAuthRequiredSignal(credentialContext, {
         provider: error.provider,
         grant: error.grant,
+        kind: error.kind,
         ...(error.authorization ? { authorization: error.authorization } : {}),
         message: error.message,
       });
@@ -892,6 +893,7 @@ async function proxySandboxEgressVerifiedRequest(input: {
     await setSandboxEgressAuthRequiredSignal(credentialContext, {
       provider,
       grant: lease.grant,
+      kind: "auth_required",
       ...((error.authorization ?? lease.authorization)
         ? { authorization: error.authorization ?? lease.authorization }
         : {}),
@@ -998,6 +1000,7 @@ async function proxySandboxEgressVerifiedRequest(input: {
       await setSandboxEgressAuthRequiredSignal(credentialContext, {
         provider,
         grant: lease.grant,
+        kind: "auth_required",
         ...(lease.authorization ? { authorization: lease.authorization } : {}),
         message: `Provider rejected the injected ${provider} credential.`,
       });

--- a/packages/junior/src/chat/sandbox/egress-proxy.ts
+++ b/packages/junior/src/chat/sandbox/egress-proxy.ts
@@ -1,4 +1,3 @@
-import { CredentialUnavailableError } from "@/chat/credentials/broker";
 import { logInfo, logWarn, withSpan } from "@/chat/logging";
 import { onPluginEgressResponse } from "@/chat/plugins/credential-hooks";
 import {
@@ -6,10 +5,9 @@ import {
   resolveSandboxEgressProviderForHost,
 } from "@/chat/sandbox/egress-policy";
 import {
-  authorizationForSandboxEgressGrant,
   hasSandboxEgressLeaseTransformForHost,
   sandboxEgressCredentialLease,
-  SandboxEgressCredentialNeededError,
+  SandboxEgressCredentialError,
   selectSandboxEgressGrant,
 } from "@/chat/sandbox/egress-credentials";
 import { verifyVercelSandboxOidcToken } from "@/chat/sandbox/egress-oidc";
@@ -741,15 +739,18 @@ async function proxySandboxEgressVerifiedRequest(input: {
       credentialContext,
     );
   } catch (error) {
-    if (error instanceof SandboxEgressCredentialNeededError) {
+    if (error instanceof SandboxEgressCredentialError) {
       await setSandboxEgressAuthRequiredSignal(credentialContext, {
         provider: error.provider,
         grant: error.grant,
         ...(error.authorization ? { authorization: error.authorization } : {}),
         message: error.message,
       });
+      const isAuthRequired = error.kind === "auth_required";
       logWarn(
-        "sandbox_egress_credential_needed",
+        isAuthRequired
+          ? "sandbox_egress_credential_needed"
+          : "sandbox_egress_credential_unavailable",
         {},
         {
           ...egressAttributes({
@@ -765,71 +766,13 @@ async function proxySandboxEgressVerifiedRequest(input: {
           }),
           ...routingAttributes(request, upstreamUrl),
         },
-        "Sandbox egress grant needs user authorization before issuing a credential lease",
+        isAuthRequired
+          ? "Sandbox egress grant needs user authorization before issuing a credential lease"
+          : "Sandbox egress credential lease is unavailable for selected grant",
       );
       return authRequiredResponse({
         provider: error.provider,
         grant: error.grant,
-        message: error.message,
-      });
-    }
-    // CredentialUnavailableError should only reach here for plugin { type: "unavailable" }
-    // results (non-OAuth infra/service failures). Broker-sourced CredentialUnavailableError
-    // is normalized to SandboxEgressCredentialNeededError in egress-credentials.ts.
-    if (error instanceof CredentialUnavailableError) {
-      const failedGrant = grantSelection.grant;
-      const authorization = authorizationForSandboxEgressGrant(
-        error.provider,
-        grantSelection,
-      );
-      if (grantSelection.source === "broker") {
-        logWarn(
-          "sandbox_egress_broker_credential_unavailable_unnormalized",
-          {},
-          {
-            ...egressAttributes({
-              egressId: activeEgressId,
-              grantAccess: failedGrant.access,
-              grantName: failedGrant.name,
-              host: upstreamUrl.hostname,
-              method: request.method,
-              path: upstreamUrl.pathname,
-              provider,
-              status: 401,
-            }),
-            ...routingAttributes(request, upstreamUrl),
-          },
-          "Broker CredentialUnavailableError reached proxy without normalization — expected SandboxEgressCredentialNeededError",
-        );
-      }
-      await setSandboxEgressAuthRequiredSignal(credentialContext, {
-        provider: error.provider,
-        grant: failedGrant,
-        ...(authorization ? { authorization } : {}),
-        message: error.message,
-      });
-      logWarn(
-        "sandbox_egress_credential_unavailable",
-        {},
-        {
-          ...egressAttributes({
-            egressId: activeEgressId,
-            grantAccess: failedGrant.access,
-            grantName: failedGrant.name,
-            grantReason: failedGrant.reason,
-            host: upstreamUrl.hostname,
-            method: request.method,
-            path: upstreamUrl.pathname,
-            provider,
-            status: 401,
-          }),
-          ...routingAttributes(request, upstreamUrl),
-        },
-        "Sandbox egress credential lease is unavailable for selected grant",
-      );
-      return authRequiredResponse({
-        provider: error.provider,
-        grant: failedGrant,
         message: error.message,
       });
     }

--- a/packages/junior/src/chat/sandbox/egress-schemas.ts
+++ b/packages/junior/src/chat/sandbox/egress-schemas.ts
@@ -10,6 +10,7 @@ import {
 const finiteNumberSchema = z.number().refine(Number.isFinite);
 const httpStatusSchema = z.number().int().min(100).max(599);
 const providerNameSchema = z.string().regex(/^[a-z][a-z0-9-]*$/);
+const credentialSignalKindSchema = z.enum(["auth_required", "unavailable"]);
 
 export const sandboxEgressGrantSchema = agentPluginGrantSchema;
 
@@ -39,6 +40,7 @@ export const sandboxEgressAuthRequiredSignalSchema = z
   .object({
     authorization: agentPluginAuthorizationSchema.optional(),
     grant: sandboxEgressGrantSchema,
+    kind: credentialSignalKindSchema.default("auth_required"),
     provider: providerNameSchema,
     message: z.string().optional(),
     createdAtMs: finiteNumberSchema,

--- a/packages/junior/src/chat/sandbox/egress-session.ts
+++ b/packages/junior/src/chat/sandbox/egress-session.ts
@@ -204,7 +204,9 @@ export async function clearSandboxEgressCredentialLease(
 /** Record that host-side sandbox egress returned an auth-required response. */
 export async function setSandboxEgressAuthRequiredSignal(
   context: SandboxEgressCredentialContext,
-  signal: Omit<SandboxEgressAuthRequiredSignal, "createdAtMs">,
+  signal: Omit<SandboxEgressAuthRequiredSignal, "createdAtMs" | "kind"> & {
+    kind?: SandboxEgressAuthRequiredSignal["kind"];
+  },
 ): Promise<void> {
   const ttlMs = Math.max(1, context.expiresAtMs - Date.now());
   const state = getStateAdapter();

--- a/packages/junior/src/chat/sandbox/sandbox.ts
+++ b/packages/junior/src/chat/sandbox/sandbox.ts
@@ -299,14 +299,15 @@ export function createSandboxExecutor(options?: {
         }
       },
     );
-    const authRequired =
-      result.exitCode !== 0
-        ? await consumeSandboxEgressAuthRequiredSignal(activeEgressId)
-        : undefined;
-    const permissionDenied =
-      result.exitCode !== 0
-        ? await consumeSandboxEgressPermissionDeniedSignal(activeEgressId)
-        : undefined;
+    // Always consume egress auth/permission signals regardless of exit code.
+    // The exit-code guard was incorrect: piped bash commands (e.g. `cmd | head`)
+    // mask the underlying CLI's non-zero exit with the pipe tail's exit code (0),
+    // preventing the signal from ever being read. The egress signal is a
+    // side-channel from the network layer — not a property of shell exit status —
+    // and `clearSandboxEgressSignals` runs before each execution to prevent
+    // cross-command leakage.
+    const authRequired = await consumeSandboxEgressAuthRequiredSignal(activeEgressId);
+    const permissionDenied = await consumeSandboxEgressPermissionDeniedSignal(activeEgressId);
 
     return {
       result: {

--- a/packages/junior/src/chat/services/auth-pause-response.ts
+++ b/packages/junior/src/chat/services/auth-pause-response.ts
@@ -1,7 +1,8 @@
-const AUTH_PAUSE_RESPONSE =
-  "I need authorization to continue. Check your private link to connect.";
-
 /** Build the visible Slack thread note for an auth-paused turn. */
-export function buildAuthPauseResponse(): string {
-  return AUTH_PAUSE_RESPONSE;
+export function buildAuthPauseResponse(
+  slackUserId: string | undefined,
+  providerDisplayName: string,
+): string {
+  const mention = slackUserId ? `<@${slackUserId}> ` : "";
+  return `${mention}I'll need you to authorize ${providerDisplayName}. I sent you a link.`;
 }

--- a/packages/junior/src/chat/services/auth-pause.ts
+++ b/packages/junior/src/chat/services/auth-pause.ts
@@ -10,10 +10,12 @@ export class AuthorizationPauseError extends Error {
   readonly disposition: AuthorizationPauseDisposition;
   readonly kind: AuthorizationPauseKind;
   readonly provider: string;
+  readonly providerDisplayName: string;
 
   constructor(
     kind: AuthorizationPauseKind,
     provider: string,
+    providerDisplayName: string,
     disposition: AuthorizationPauseDisposition,
   ) {
     super(
@@ -28,6 +30,7 @@ export class AuthorizationPauseError extends Error {
     this.disposition = disposition;
     this.kind = kind;
     this.provider = provider;
+    this.providerDisplayName = providerDisplayName;
   }
 }
 

--- a/packages/junior/src/chat/services/mcp-auth-orchestration.ts
+++ b/packages/junior/src/chat/services/mcp-auth-orchestration.ts
@@ -30,9 +30,10 @@ import type { PluginDefinition } from "@/chat/plugins/types";
 export class McpAuthorizationPauseError extends AuthorizationPauseError {
   constructor(
     provider: string,
+    providerDisplayName: string,
     disposition: "link_already_sent" | "link_sent",
   ) {
-    super("mcp", provider, disposition);
+    super("mcp", provider, providerDisplayName, disposition);
   }
 }
 
@@ -142,13 +143,14 @@ export function createMcpAuthOrchestration(
       provider,
       requesterId: deps.requesterId,
     });
+    const providerLabel = formatProviderLabel(provider);
 
     if (!reusingPendingLink) {
       const delivery = await deliverPrivateMessage({
         channelId: authSession.channelId,
         threadTs: authSession.threadTs,
         userId: authSession.userId,
-        text: `<${authSession.authorizationUrl}|Click here to link your ${formatProviderLabel(provider)} MCP access>. Once you've authorized, this thread will continue automatically.`,
+        text: `<${authSession.authorizationUrl}|Click here to link your ${providerLabel} MCP access>. Once you've authorized, this thread will continue automatically.`,
       });
       if (!delivery) {
         throw new Error(
@@ -192,6 +194,7 @@ export function createMcpAuthOrchestration(
     }
     pendingPause = new McpAuthorizationPauseError(
       provider,
+      providerLabel,
       reusingPendingLink ? "link_already_sent" : "link_sent",
     );
     abortAgent();

--- a/packages/junior/src/chat/services/plugin-auth-orchestration.ts
+++ b/packages/junior/src/chat/services/plugin-auth-orchestration.ts
@@ -87,6 +87,7 @@ function pluginAuthRequiredSignal(details: unknown):
         name: string;
         reason?: string;
       };
+      kind: "auth_required" | "unavailable";
       message?: string;
       provider: string;
     }
@@ -102,6 +103,7 @@ function pluginAuthRequiredSignal(details: unknown):
   return {
     provider: parsedSignal.provider,
     grant: parsedSignal.grant,
+    kind: parsedSignal.kind,
     ...(parsedSignal.message ? { message: parsedSignal.message } : {}),
     ...(parsedSignal.authorization
       ? { authorization: parsedSignal.authorization }
@@ -228,6 +230,14 @@ export function createPluginAuthOrchestration(
       }
 
       const { provider, authorization } = signal;
+
+      if (signal.kind === "unavailable") {
+        throw new PluginCredentialFailureError(
+          provider,
+          signal.message ??
+            `${formatProviderLabel(provider)} credentials are unavailable.`,
+        );
+      }
 
       if (!authorization) {
         throw new PluginCredentialFailureError(

--- a/packages/junior/src/chat/services/plugin-auth-orchestration.ts
+++ b/packages/junior/src/chat/services/plugin-auth-orchestration.ts
@@ -30,9 +30,10 @@ import { parseSandboxEgressAuthRequiredSignal } from "@/chat/sandbox/egress-sche
 export class PluginAuthorizationPauseError extends AuthorizationPauseError {
   constructor(
     provider: string,
+    providerDisplayName: string,
     disposition: "link_already_sent" | "link_sent",
   ) {
-    super("plugin", provider, disposition);
+    super("plugin", provider, providerDisplayName, disposition);
   }
 }
 
@@ -216,6 +217,7 @@ export function createPluginAuthOrchestration(
     }
     pendingPause = new PluginAuthorizationPauseError(
       provider,
+      providerLabel,
       reusingPendingLink ? "link_already_sent" : "link_sent",
     );
     abortAgent();

--- a/packages/junior/src/chat/services/plugin-auth-orchestration.ts
+++ b/packages/junior/src/chat/services/plugin-auth-orchestration.ts
@@ -74,6 +74,7 @@ export interface PluginAuthOrchestration {
   getPendingPause: () => PluginAuthorizationPauseError | undefined;
 }
 
+/** Normalize a sandbox egress auth signal and preserve host failure messages. */
 function pluginAuthRequiredSignal(details: unknown):
   | {
       authorization?: {
@@ -86,6 +87,7 @@ function pluginAuthRequiredSignal(details: unknown):
         name: string;
         reason?: string;
       };
+      message?: string;
       provider: string;
     }
   | undefined {
@@ -100,6 +102,7 @@ function pluginAuthRequiredSignal(details: unknown):
   return {
     provider: parsedSignal.provider,
     grant: parsedSignal.grant,
+    ...(parsedSignal.message ? { message: parsedSignal.message } : {}),
     ...(parsedSignal.authorization
       ? { authorization: parsedSignal.authorization }
       : {}),
@@ -226,27 +229,30 @@ export function createPluginAuthOrchestration(
 
       const { provider, authorization } = signal;
 
+      if (!authorization) {
+        throw new PluginCredentialFailureError(
+          provider,
+          signal.message ??
+            `${formatProviderLabel(provider)} credentials are required but no OAuth flow is available for this provider.`,
+        );
+      }
+
       if (!deps.requesterId || !deps.userTokenStore) {
         if (deps.authorizationFlowMode === "disabled") {
           throw new AuthorizationFlowDisabledError("plugin", provider);
         }
         throw new PluginCredentialFailureError(
           provider,
-          `${formatProviderLabel(provider)} credentials are required. Please connect your ${formatProviderLabel(provider)} account and try again.`,
-        );
-      }
-
-      if (authorization?.type !== "oauth") {
-        throw new PluginCredentialFailureError(
-          provider,
-          `${formatProviderLabel(provider)} credentials are required but no OAuth flow is available for this provider.`,
+          signal.message ??
+            `${formatProviderLabel(provider)} credentials are required. Please connect your ${formatProviderLabel(provider)} account and try again.`,
         );
       }
 
       if (!getPluginOAuthConfig(authorization.provider)) {
         throw new PluginCredentialFailureError(
           provider,
-          `${formatProviderLabel(provider)} credentials are required but the provider is not configured for OAuth.`,
+          signal.message ??
+            `${formatProviderLabel(provider)} credentials are required but the provider is not configured for OAuth.`,
         );
       }
 

--- a/packages/junior/src/chat/services/plugin-auth-orchestration.ts
+++ b/packages/junior/src/chat/services/plugin-auth-orchestration.ts
@@ -1,9 +1,14 @@
 /**
  * Plugin authorization pause orchestration.
  *
- * This module detects plugin command credential failures and maps them onto the
- * same paused-turn contract used by MCP auth. It owns provider attribution,
- * private-link delivery/reuse, session-log recording, and credential cleanup.
+ * This module detects plugin credential failures from the sandbox egress layer
+ * and maps them onto the same paused-turn contract used by MCP auth. It owns
+ * provider attribution, private-link delivery/reuse, session-log recording,
+ * and credential cleanup.
+ *
+ * Auth failures are detected exclusively through the structured `auth_required`
+ * signal emitted by the egress proxy — never inferred from bash command text,
+ * stdout patterns, or exit codes.
  */
 import { THREAD_STATE_TTL_MS } from "chat";
 import type { Destination } from "@sentry/junior-plugin-api";
@@ -19,14 +24,8 @@ import {
 } from "@/chat/services/auth-pause";
 import type { ConversationPendingAuthState } from "@/chat/state/conversation";
 import { recordAuthorizationRequested } from "@/chat/state/session-log";
-import {
-  getPluginDefinition,
-  getPluginProviders,
-  getPluginOAuthConfig,
-} from "@/chat/plugins/registry";
-import { hasEgressCredentialHooks } from "@/chat/plugins/credential-hooks";
+import { getPluginOAuthConfig } from "@/chat/plugins/registry";
 import { parseSandboxEgressAuthRequiredSignal } from "@/chat/sandbox/egress-schemas";
-import type { Skill } from "@/chat/skills";
 
 export class PluginAuthorizationPauseError extends AuthorizationPauseError {
   constructor(
@@ -65,62 +64,14 @@ export interface PluginAuthOrchestrationDeps {
 }
 
 export interface PluginAuthOrchestration {
-  handleCommandFailure: (input: {
-    activeSkill: Skill | null;
-    command: string;
-    details: unknown;
-  }) => Promise<void>;
+  /**
+   * Inspect a sandbox tool result for an `auth_required` signal from the
+   * egress proxy. If one is present and an OAuth flow is available, parks the
+   * current turn and sends the user an authorization link. No-ops when the
+   * result carries no auth signal.
+   */
+  maybeHandleAuthSignal: (details: unknown) => Promise<void>;
   getPendingPause: () => PluginAuthorizationPauseError | undefined;
-}
-
-function isCommandAuthFailure(details: unknown): details is {
-  exit_code: number;
-  stdout?: string;
-  stderr?: string;
-} {
-  if (!details || typeof details !== "object") {
-    return false;
-  }
-
-  const result = details as {
-    exit_code?: unknown;
-    stdout?: unknown;
-    stderr?: unknown;
-  };
-  if (typeof result.exit_code !== "number" || result.exit_code === 0) {
-    return false;
-  }
-
-  const text =
-    `${typeof result.stdout === "string" ? result.stdout : ""}\n${typeof result.stderr === "string" ? result.stderr : ""}`.toLowerCase();
-  if (!text.trim()) {
-    return false;
-  }
-
-  return [
-    /\b401\b/,
-    /\bunauthorized\b/,
-    /\bbad credentials\b/,
-    /\binvalid token\b/,
-    /\bgithub_token\b.*\binvalid\b/,
-    /\btoken (?:expired|revoked)\b/,
-    /\bexpired token\b/,
-    /\bmissing scopes?\b/,
-    /\binsufficient scope\b/,
-    /\binvalid grant\b/,
-    /\breauthoriz/,
-  ].some((pattern) => pattern.test(text));
-}
-
-function commandText(details: unknown): string {
-  if (!details || typeof details !== "object") {
-    return "";
-  }
-  const result = details as {
-    stdout?: unknown;
-    stderr?: unknown;
-  };
-  return `${typeof result.stdout === "string" ? result.stdout : ""}\n${typeof result.stderr === "string" ? result.stderr : ""}`;
 }
 
 function pluginAuthRequiredSignal(details: unknown):
@@ -155,55 +106,6 @@ function pluginAuthRequiredSignal(details: unknown):
   };
 }
 
-function registeredProviderNames(): string[] {
-  const providers = new Set<string>();
-  for (const plugin of getPluginProviders()) {
-    const domains = [
-      ...(plugin.manifest.credentials?.domains ?? []),
-      ...(plugin.manifest.domains ?? []),
-    ];
-    if (domains.length > 0) {
-      providers.add(plugin.manifest.name);
-    }
-  }
-  return [...providers].sort((left, right) => left.localeCompare(right));
-}
-
-function commandTargetsProvider(
-  provider: string,
-  command: string,
-  details: unknown,
-): boolean {
-  const normalizedCommand = command.trim().toLowerCase();
-  if (!normalizedCommand) {
-    return false;
-  }
-
-  const plugin = getPluginDefinition(provider);
-  const candidates = new Set<string>([provider.toLowerCase()]);
-  const manifest = plugin?.manifest;
-  const credentials = manifest?.credentials;
-  if (credentials) {
-    if (credentials.authTokenEnv) {
-      candidates.add(credentials.authTokenEnv.toLowerCase());
-    }
-    for (const domain of credentials.domains) {
-      candidates.add(domain.toLowerCase());
-    }
-  }
-  for (const domain of manifest?.domains ?? []) {
-    candidates.add(domain.toLowerCase());
-  }
-
-  const combinedText = `${normalizedCommand}\n${commandText(details).toLowerCase()}`;
-  return [...candidates].some((candidate) => combinedText.includes(candidate));
-}
-
-function formatCommand(command: string): string {
-  const collapsed = command.replace(/\s+/g, " ").trim();
-  return collapsed.length > 160 ? `${collapsed.slice(0, 157)}...` : collapsed;
-}
-
 function authorizationId(args: {
   kind: "plugin";
   provider: string;
@@ -212,21 +114,8 @@ function authorizationId(args: {
   return `${args.sessionId}:${args.kind}:${args.provider}`;
 }
 
-function buildCredentialFailureError(
-  provider: string,
-  command: string,
-): PluginCredentialFailureError {
-  const providerLabel = formatProviderLabel(provider);
-  const commandSummary = formatCommand(command);
-
-  return new PluginCredentialFailureError(
-    provider,
-    `${providerLabel} credentials were rejected while running \`${commandSummary}\`. Verify the ${providerLabel} provider credentials before retrying.`,
-  );
-}
-
 /**
- * Start plugin OAuth from an authenticated bash command and park the turn.
+ * Start plugin OAuth from a sandbox egress auth signal and park the turn.
  */
 export function createPluginAuthOrchestration(
   deps: PluginAuthOrchestrationDeps,
@@ -236,7 +125,6 @@ export function createPluginAuthOrchestration(
 
   const startAuthorizationPause = async (
     provider: string,
-    activeSkill: Skill | null,
     options?: {
       scope?: string;
       unlinkExistingProvider?: boolean;
@@ -269,7 +157,6 @@ export function createPluginAuthOrchestration(
         threadTs: deps.threadTs,
         userMessage: deps.userMessage,
         channelConfiguration: deps.channelConfiguration,
-        activeSkillName: activeSkill?.name ?? undefined,
         ...(options?.scope ? { scope: options.scope } : {}),
         resumeConversationId: deps.conversationId,
         resumeSessionId: deps.sessionId,
@@ -331,58 +218,39 @@ export function createPluginAuthOrchestration(
   };
 
   return {
-    handleCommandFailure: async (input) => {
-      const providers = registeredProviderNames();
-      const parsedAuthSignal = pluginAuthRequiredSignal(input.details);
-      const authSignal =
-        parsedAuthSignal && providers.includes(parsedAuthSignal.provider)
-          ? parsedAuthSignal
-          : undefined;
-      const provider = authSignal
-        ? authSignal.provider
-        : providers.find((availableProvider) =>
-            commandTargetsProvider(
-              availableProvider,
-              input.command,
-              input.details,
-            ),
-          );
-      if (!provider) {
+    maybeHandleAuthSignal: async (details) => {
+      const signal = pluginAuthRequiredSignal(details);
+      if (!signal) {
         return;
       }
 
-      const authFailure =
-        Boolean(authSignal) || isCommandAuthFailure(input.details);
-      if (!authFailure) {
-        return;
-      }
-
-      const providerOAuth = getPluginOAuthConfig(provider);
-      const authorization =
-        authSignal?.authorization ??
-        (!authSignal && !hasEgressCredentialHooks(provider) && providerOAuth
-          ? {
-              type: "oauth" as const,
-              provider,
-              ...(providerOAuth.scope ? { scope: providerOAuth.scope } : {}),
-            }
-          : undefined);
+      const { provider, authorization } = signal;
 
       if (!deps.requesterId || !deps.userTokenStore) {
         if (deps.authorizationFlowMode === "disabled") {
           throw new AuthorizationFlowDisabledError("plugin", provider);
         }
-        throw buildCredentialFailureError(provider, input.command);
+        throw new PluginCredentialFailureError(
+          provider,
+          `${formatProviderLabel(provider)} credentials are required. Please connect your ${formatProviderLabel(provider)} account and try again.`,
+        );
       }
 
       if (authorization?.type !== "oauth") {
-        throw buildCredentialFailureError(provider, input.command);
-      }
-      if (!getPluginOAuthConfig(authorization.provider)) {
-        throw buildCredentialFailureError(provider, input.command);
+        throw new PluginCredentialFailureError(
+          provider,
+          `${formatProviderLabel(provider)} credentials are required but no OAuth flow is available for this provider.`,
+        );
       }
 
-      await startAuthorizationPause(authorization.provider, input.activeSkill, {
+      if (!getPluginOAuthConfig(authorization.provider)) {
+        throw new PluginCredentialFailureError(
+          provider,
+          `${formatProviderLabel(provider)} credentials are required but the provider is not configured for OAuth.`,
+        );
+      }
+
+      await startAuthorizationPause(authorization.provider, {
         ...(authorization.scope ? { scope: authorization.scope } : {}),
         unlinkExistingProvider: true,
       });

--- a/packages/junior/src/chat/tools/agent-tools.ts
+++ b/packages/junior/src/chat/tools/agent-tools.ts
@@ -104,11 +104,6 @@ export function createAgentTools(
               : { input: parsed, env: {} };
             const toolInput = beforeTool.input;
             onToolCall?.(toolName, toolInput);
-            const bashCommand =
-              toolName === "bash" && typeof toolInput.command === "string"
-                ? toolInput.command.trim()
-                : "";
-
             const sandboxInput = buildSandboxInput(toolName, toolInput);
             const isSandbox = Boolean(sandboxExecutor?.canExecute(toolName));
             const result = isSandbox
@@ -127,12 +122,8 @@ export function createAgentTools(
                 });
 
             const normalized = normalizeToolResult(result, isSandbox);
-            if (bashCommand && pluginAuthOrchestration) {
-              await pluginAuthOrchestration.handleCommandFailure({
-                activeSkill: sandbox.getActiveSkill(),
-                command: bashCommand,
-                details: normalized.details,
-              });
+            if (isSandbox && pluginAuthOrchestration) {
+              await pluginAuthOrchestration.maybeHandleAuthSignal(normalized.details);
             }
             const resultAttributeValue =
               normalized.details &&

--- a/packages/junior/src/chat/tools/sandbox/bash.ts
+++ b/packages/junior/src/chat/tools/sandbox/bash.ts
@@ -22,6 +22,8 @@ export function createBashTool() {
       },
       { additionalProperties: false },
     ),
+    // Bash is sequential so sandbox egress auth signals stay command-scoped.
+    executionMode: "sequential",
     execute: async () => {
       throw new Error("bash can only run when sandbox execution is enabled.");
     },

--- a/packages/junior/tests/fixtures/plugins/eval-auth/plugin.yaml
+++ b/packages/junior/tests/fixtures/plugins/eval-auth/plugin.yaml
@@ -1,4 +1,5 @@
 name: eval-auth
+display-name: Eval Auth
 description: Eval-only MCP OAuth auth-resume fixture
 
 mcp:

--- a/packages/junior/tests/fixtures/plugins/eval-oauth/plugin.yaml
+++ b/packages/junior/tests/fixtures/plugins/eval-oauth/plugin.yaml
@@ -1,4 +1,5 @@
 name: eval-oauth
+display-name: Eval OAuth
 description: Eval-only generic OAuth auth-resume fixture
 
 capabilities:

--- a/packages/junior/tests/fixtures/plugins/sandbox-egress/plugin.yaml
+++ b/packages/junior/tests/fixtures/plugins/sandbox-egress/plugin.yaml
@@ -1,4 +1,5 @@
 name: sandbox-egress-test
+display-name: Sandbox Egress Test
 description: Integration fixture for sandbox egress credential proxying
 
 capabilities:

--- a/packages/junior/tests/integration/heartbeat.test.ts
+++ b/packages/junior/tests/integration/heartbeat.test.ts
@@ -203,6 +203,7 @@ describe("plugin heartbeat", () => {
       defineJuniorPlugin({
         manifest: {
           name: "scheduler",
+          displayName: "Scheduler",
           description: "Scheduler test plugin",
         },
         hooks: {

--- a/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
+++ b/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
@@ -396,14 +396,16 @@ describe("mcp auth runtime slack integration", () => {
           user: "U123",
           thread_ts: "1700000000.001",
           text: expect.stringContaining(
-            "Click here to link your Eval-auth MCP access",
+            "Click here to link your Eval Auth MCP access",
           ),
         }),
       }),
     ]);
     expect(thread.posts).toEqual([
       expect.objectContaining({
-        markdown: expect.stringContaining("private link"),
+        markdown: expect.stringContaining(
+          "<@U123> I'll need you to authorize Eval Auth. I sent you a link.",
+        ),
       }),
     ]);
     expect(getCapturedSlackApiCalls("chat.postMessage")).toHaveLength(0);
@@ -639,7 +641,9 @@ describe("mcp auth runtime slack integration", () => {
     expect(agentProbe.continueCallCount).toBe(0);
     expect(thread.posts).toEqual([
       expect.objectContaining({
-        markdown: expect.stringContaining("private link"),
+        markdown: expect.stringContaining(
+          "<@U123> I'll need you to authorize Eval Auth. I sent you a link.",
+        ),
       }),
     ]);
 

--- a/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
@@ -318,10 +318,10 @@ describe("sandbox egress proxy integration", () => {
     expect(upstreamFetch).toHaveBeenCalledTimes(1);
   });
 
-  it("returns auth-required via canonical SandboxEgressCredentialNeededError when broker has no user token", async () => {
+  it("returns auth-required via canonical egress credential error when broker has no user token", async () => {
     // Broker-backed provider (sandbox-egress-test fixture) with no stored user OAuth token.
     // Since the fixture has no `oauth` section, the broker throws CredentialUnavailableError
-    // for the missing-env-token case. This should be normalized to SandboxEgressCredentialNeededError
+    // for the missing-env-token case. This should be normalized to an egress credential error
     // before reaching the proxy, and the proxy should return the canonical auth-required 401.
     delete process.env.SANDBOX_EGRESS_TEST_TOKEN; // remove env token so broker has no credential
 

--- a/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
@@ -25,6 +25,7 @@ const REQUESTER_ID = "U123";
 const PROVIDER_HOST = "sandbox-egress.example.test";
 const MANAGED_PROVIDER_HOST = "managed-egress.example.test";
 const MANAGED_PROVIDER_SUBDOMAIN = "api.managed-egress.example.test";
+const OAUTH_BROKER_PROVIDER_HOST = "oauth-broker.example.test";
 const GITHUB_API_HOST = "api.github.com";
 
 type EgressPolicyModule = typeof import("@/chat/sandbox/egress-policy");
@@ -164,6 +165,39 @@ async function registerManagedEgressPlugin(input?: {
     sandbox: {
       egressTracePropagationDomains: input?.egressTracePropagationDomains,
     },
+    waitUntil(task) {
+      if (typeof task === "function") {
+        void task();
+      }
+    },
+  });
+}
+
+async function registerOAuthBrokerPlugin() {
+  const { createApp, defineJuniorPlugins } = await import("@/app");
+  await createApp({
+    plugins: defineJuniorPlugins([
+      defineJuniorPlugin({
+        manifest: {
+          name: "oauth-broker",
+          description: "OAuth broker integration fixture",
+          capabilities: ["api"],
+          credentials: {
+            type: "oauth-bearer",
+            domains: [OAUTH_BROKER_PROVIDER_HOST],
+            authTokenEnv: "OAUTH_BROKER_ACCESS_TOKEN",
+            authTokenPlaceholder: "host_managed_credential",
+          },
+          oauth: {
+            clientIdEnv: "OAUTH_BROKER_CLIENT_ID",
+            clientSecretEnv: "OAUTH_BROKER_CLIENT_SECRET",
+            authorizeEndpoint: "https://oauth-broker.example.test/authorize",
+            tokenEndpoint: "https://oauth-broker.example.test/token",
+            scope: "broker.read",
+          },
+        },
+      }),
+    ]),
     waitUntil(task) {
       if (typeof task === "function") {
         void task();
@@ -312,10 +346,53 @@ describe("sandbox egress proxy integration", () => {
     expect(body).toContain("provider=sandbox-egress-test");
 
     // Auth signal should be recorded in state
-    const signal = await modules.session.consumeSandboxEgressAuthRequiredSignal(EGRESS_ID);
+    const signal =
+      await modules.session.consumeSandboxEgressAuthRequiredSignal(EGRESS_ID);
     expect(signal).toMatchObject({
       provider: "sandbox-egress-test",
       grant: expect.objectContaining({ access: "read" }),
+    });
+  });
+
+  it("records OAuth authorization metadata for broker credential gaps", async () => {
+    delete process.env.OAUTH_BROKER_ACCESS_TOKEN;
+    await registerOAuthBrokerPlugin();
+
+    const credentialToken = modules.session.createSandboxEgressCredentialToken({
+      credentials: { actor: { type: "user", userId: REQUESTER_ID } },
+      egressId: EGRESS_ID,
+      ttlMs: 60_000,
+    });
+    const networkPolicy = modules.policy.buildSandboxEgressNetworkPolicy({
+      credentialToken,
+    });
+    const forwardURL = forwardUrlFor(networkPolicy, OAUTH_BROKER_PROVIDER_HOST);
+
+    const response = await modules.proxy.proxySandboxEgressRequest(
+      proxiedRequest({
+        forwardURL,
+        upstreamHost: OAUTH_BROKER_PROVIDER_HOST,
+      }),
+      { verifyOidc: async () => ({ sandbox_id: EGRESS_ID }) },
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.text()).resolves.toContain(
+      "junior-auth-required provider=oauth-broker grant=default access=read",
+    );
+    await expect(
+      modules.session.consumeSandboxEgressAuthRequiredSignal(EGRESS_ID),
+    ).resolves.toMatchObject({
+      provider: "oauth-broker",
+      grant: {
+        name: "default",
+        access: "read",
+      },
+      authorization: {
+        type: "oauth",
+        provider: "oauth-broker",
+        scope: "broker.read",
+      },
     });
   });
 

--- a/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
@@ -121,6 +121,7 @@ async function registerManagedEgressPlugin(input?: {
       defineJuniorPlugin({
         manifest: {
           name: "managed-egress",
+          displayName: "Managed Egress",
           description: "Managed egress integration fixture",
           capabilities: ["api"],
           domains: [MANAGED_PROVIDER_HOST, MANAGED_PROVIDER_SUBDOMAIN],
@@ -180,6 +181,7 @@ async function registerOAuthBrokerPlugin() {
       defineJuniorPlugin({
         manifest: {
           name: "oauth-broker",
+          displayName: "Oauth Broker",
           description: "OAuth broker integration fixture",
           capabilities: ["api"],
           credentials: {

--- a/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
@@ -284,6 +284,41 @@ describe("sandbox egress proxy integration", () => {
     expect(upstreamFetch).toHaveBeenCalledTimes(1);
   });
 
+  it("returns auth-required via canonical SandboxEgressCredentialNeededError when broker has no user token", async () => {
+    // Broker-backed provider (sandbox-egress-test fixture) with no stored user OAuth token.
+    // Since the fixture has no `oauth` section, the broker throws CredentialUnavailableError
+    // for the missing-env-token case. This should be normalized to SandboxEgressCredentialNeededError
+    // before reaching the proxy, and the proxy should return the canonical auth-required 401.
+    delete process.env.SANDBOX_EGRESS_TEST_TOKEN; // remove env token so broker has no credential
+
+    const credentialToken = modules.session.createSandboxEgressCredentialToken({
+      credentials: { actor: { type: "user", userId: REQUESTER_ID } },
+      egressId: EGRESS_ID,
+      ttlMs: 60_000,
+    });
+    const networkPolicy = modules.policy.buildSandboxEgressNetworkPolicy({
+      credentialToken,
+    });
+    const forwardURL = forwardUrlFor(networkPolicy, PROVIDER_HOST);
+
+    const response = await modules.proxy.proxySandboxEgressRequest(
+      proxiedRequest({ forwardURL }),
+      { verifyOidc: async () => ({ sandbox_id: EGRESS_ID }) },
+    );
+
+    expect(response.status).toBe(401);
+    const body = await response.text();
+    expect(body).toContain("junior-auth-required");
+    expect(body).toContain("provider=sandbox-egress-test");
+
+    // Auth signal should be recorded in state
+    const signal = await modules.session.consumeSandboxEgressAuthRequiredSignal(EGRESS_ID);
+    expect(signal).toMatchObject({
+      provider: "sandbox-egress-test",
+      grant: expect.objectContaining({ access: "read" }),
+    });
+  });
+
   it("propagates configured trace headers through real plugin egress wiring", async () => {
     await registerManagedEgressPlugin({
       egressTracePropagationDomains: ["*.managed-egress.example.test"],

--- a/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
@@ -1036,6 +1036,7 @@ describe("sandbox egress proxy integration", () => {
       modules.session.consumeSandboxEgressAuthRequiredSignal(EGRESS_ID),
     ).resolves.toMatchObject({
       provider: "github",
+      kind: "unavailable",
       grant: {
         name: "installation-read",
         access: "read",

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -596,6 +596,7 @@ describe("bot handlers (integration)", () => {
                 authDisposition: "link_sent",
                 authKind: "mcp",
                 authProvider: "notion",
+                authProviderDisplayName: "Notion",
               },
             );
           },
@@ -619,7 +620,9 @@ describe("bot handlers (integration)", () => {
 
     expect(thread.posts).toEqual([
       expect.objectContaining({
-        markdown: expect.stringContaining("private link"),
+        markdown: expect.stringContaining(
+          "<@U-test> I'll need you to authorize Notion. I sent you a link.",
+        ),
       }),
     ]);
     const state = thread.getState();
@@ -641,7 +644,7 @@ describe("bot handlers (integration)", () => {
       expect.arrayContaining([
         expect.objectContaining({
           role: "assistant",
-          text: expect.stringContaining("private link"),
+          text: expect.stringContaining("authorize Notion"),
         }),
       ]),
     );
@@ -669,6 +672,7 @@ describe("bot handlers (integration)", () => {
                 authDisposition: "link_sent",
                 authKind: "plugin",
                 authProvider: "github",
+                authProviderDisplayName: "GitHub",
               },
             );
           },
@@ -694,7 +698,9 @@ describe("bot handlers (integration)", () => {
 
     expect(thread.posts).toEqual([
       expect.objectContaining({
-        markdown: expect.stringContaining("private link"),
+        markdown: expect.stringContaining(
+          "<@U-test> I'll need you to authorize GitHub. I sent you a link.",
+        ),
       }),
     ]);
     const state = thread.getState();
@@ -716,7 +722,7 @@ describe("bot handlers (integration)", () => {
       expect.arrayContaining([
         expect.objectContaining({
           role: "assistant",
-          text: expect.stringContaining("private link"),
+          text: expect.stringContaining("authorize GitHub"),
         }),
       ]),
     );

--- a/packages/junior/tests/integration/slack/outbound-normalization-contract.test.ts
+++ b/packages/junior/tests/integration/slack/outbound-normalization-contract.test.ts
@@ -87,6 +87,7 @@ describe("Slack contract: outbound normalization", () => {
         name: "dashboard",
         manifest: {
           name: "dashboard",
+          displayName: "Dashboard",
           description: "Dashboard",
         },
         hooks: {

--- a/packages/junior/tests/unit/app-config.test.ts
+++ b/packages/junior/tests/unit/app-config.test.ts
@@ -43,6 +43,10 @@ async function writePluginPackage(
     path.join(packageRoot, "plugin.yaml"),
     [
       `name: ${pluginName}`,
+      `display-name: ${pluginName
+        .split("-")
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(" ")}`,
       `description: ${pluginName} plugin`,
       ...extraLines,
       "config-keys:",
@@ -104,6 +108,7 @@ describe("createApp plugin config", () => {
         defineJuniorPlugin({
           manifest: {
             name: "base",
+            displayName: "Base",
             description: "Base plugin",
           },
           hooks: {},
@@ -117,6 +122,7 @@ describe("createApp plugin config", () => {
           defineJuniorPlugin({
             manifest: {
               name: "next",
+              displayName: "Next",
               description: "Next plugin",
             },
             hooks: {},
@@ -157,6 +163,7 @@ describe("createApp plugin config", () => {
         defineJuniorPlugin({
           manifest: {
             name: "dashboard",
+            displayName: "Dashboard",
             description: "Dashboard plugin",
           },
           hooks: {},
@@ -261,6 +268,7 @@ describe("createApp plugin config", () => {
         defineJuniorPlugin({
           manifest: {
             name: "hooked",
+            displayName: "Hooked",
             description: "Runtime plugin",
             configKeys: ["org"],
           },
@@ -287,6 +295,7 @@ describe("createApp plugin config", () => {
           defineJuniorPlugin({
             manifest: {
               name: "example",
+              displayName: "Example",
               description: "Example plugin",
               domains: ["api.example.com"],
             },
@@ -317,6 +326,7 @@ describe("createApp plugin config", () => {
           defineJuniorPlugin({
             manifest: {
               name: "example",
+              displayName: "Example",
               description: "Example plugin",
             },
             hooks: {
@@ -352,6 +362,7 @@ describe("createApp plugin config", () => {
           defineJuniorPlugin({
             manifest: {
               name: "example",
+              displayName: "Example",
               description: "Example plugin",
               oauth: {
                 clientIdEnv: "EXAMPLE_CLIENT_ID",
@@ -378,6 +389,7 @@ describe("createApp plugin config", () => {
         defineJuniorPlugin({
           manifest: {
             name: "example",
+            displayName: "Example",
             description: "Example plugin",
             domains: ["api.example.com"],
           },
@@ -414,6 +426,7 @@ describe("createApp plugin config", () => {
         defineJuniorPlugin({
           manifest: {
             name: "hooked",
+            displayName: "Hooked",
             description: "Runtime plugin",
           },
           hooks: {},
@@ -443,6 +456,7 @@ describe("createApp plugin config", () => {
           packageName: "@acme/hooked-plugin",
           manifest: {
             name: "hooked",
+            displayName: "Hooked",
             description: "Runtime plugin",
           },
           hooks: {},
@@ -469,6 +483,7 @@ describe("createApp plugin config", () => {
           defineJuniorPlugin({
             manifest: {
               name: "hooked",
+              displayName: "Hooked",
               description: "Runtime plugin",
               credentials: {
                 type: "oauth-bearer",
@@ -510,6 +525,7 @@ describe("createApp plugin config", () => {
           defineJuniorPlugin({
             manifest: {
               name: "invalid",
+              displayName: "Invalid",
               description: "Invalid plugin",
               domains: ["api.example.com"],
             },
@@ -531,6 +547,7 @@ describe("createApp plugin config", () => {
         defineJuniorPlugin({
           manifest: {
             name: "hooked",
+            displayName: "Hooked",
             description: "Runtime plugin",
             configKeys: ["org"],
           },
@@ -542,6 +559,7 @@ describe("createApp plugin config", () => {
           {
             manifest: {
               name: "hooked",
+              displayName: "Hooked",
               description: "Runtime plugin",
               capabilities: [],
               configKeys: ["hooked.org"],
@@ -596,10 +614,18 @@ describe("createApp plugin config", () => {
     expect(() =>
       defineJuniorPlugins([
         defineJuniorPlugin({
-          manifest: { name: "dupe", description: "Duplicate plugin" },
+          manifest: {
+            name: "dupe",
+            displayName: "Dupe",
+            description: "Duplicate plugin",
+          },
         }),
         defineJuniorPlugin({
-          manifest: { name: "dupe", description: "Duplicate plugin" },
+          manifest: {
+            name: "dupe",
+            displayName: "Dupe",
+            description: "Duplicate plugin",
+          },
         }),
       ]),
     ).toThrow('Duplicate plugin registration name "dupe"');
@@ -615,7 +641,11 @@ describe("createApp plugin config", () => {
 
     expect(() =>
       defineJuniorPlugin({
-        manifest: { name: "GitHub", description: "Invalid plugin" },
+        manifest: {
+          name: "GitHub",
+          displayName: "GitHub",
+          description: "Invalid plugin",
+        },
         hooks: {},
       }),
     ).toThrow(
@@ -635,7 +665,11 @@ describe("createApp plugin config", () => {
       createApp({
         plugins: defineJuniorPlugins([
           defineJuniorPlugin({
-            manifest: { name: "hooked", description: "Runtime plugin" },
+            manifest: {
+              name: "hooked",
+              displayName: "Hooked",
+              description: "Runtime plugin",
+            },
             legacyStatePrefixes: ["junior:scheduler"],
           }),
         ]),

--- a/packages/junior/tests/unit/build/nitro-plugin-module.test.ts
+++ b/packages/junior/tests/unit/build/nitro-plugin-module.test.ts
@@ -352,6 +352,7 @@ describe("juniorNitro plugin modules", () => {
             name: "hooked",
             manifest: {
               name: "hooked",
+              displayName: "Hooked",
               description: "Runtime plugin",
             },
             hooks: {},

--- a/packages/junior/tests/unit/capabilities/capability-factory.test.ts
+++ b/packages/junior/tests/unit/capabilities/capability-factory.test.ts
@@ -45,6 +45,7 @@ describe("capability factory", () => {
       {
         manifest: {
           name: "example",
+          displayName: "Example",
           description: "Example",
           capabilities: ["example.api"],
           configKeys: [],
@@ -94,6 +95,7 @@ describe("capability factory", () => {
       {
         manifest: {
           name: "github",
+          displayName: "GitHub",
           description: "GitHub",
           capabilities: ["github.api"],
           configKeys: [],
@@ -105,6 +107,7 @@ describe("capability factory", () => {
       {
         manifest: {
           name: "sentry",
+          displayName: "Sentry",
           description: "Sentry",
           capabilities: ["sentry.api"],
           configKeys: [],

--- a/packages/junior/tests/unit/cli/check-cli.test.ts
+++ b/packages/junior/tests/unit/cli/check-cli.test.ts
@@ -39,6 +39,7 @@ describe("check cli", () => {
       path.join(repoRoot, "app", "plugins", "demo", "plugin.yaml"),
       [
         "name: demo",
+        "display-name: Demo",
         "description: Demo plugin",
         "capabilities:",
         "  - issues.read",
@@ -63,6 +64,7 @@ describe("check cli", () => {
       [
         "---",
         "name: demo-helper",
+        "display-name: Demo Helper",
         "description: Help with demo tasks.",
         "---",
         "",
@@ -75,6 +77,7 @@ describe("check cli", () => {
       [
         "---",
         "name: repo-local",
+        "display-name: Repo Local",
         "description: Help with repo-local tasks.",
         "---",
         "",
@@ -149,6 +152,7 @@ describe("check cli", () => {
       path.join(packageRoot, "plugin.yaml"),
       [
         "name: demo",
+        "display-name: Demo",
         "description: Demo packaged plugin",
         "capabilities:",
         "  - issues.read",
@@ -160,6 +164,7 @@ describe("check cli", () => {
       [
         "---",
         "name: demo-helper",
+        "display-name: Demo Helper",
         "description: Help with packaged demo tasks.",
         "---",
         "",
@@ -436,6 +441,7 @@ describe("check cli", () => {
       path.join(packageRoot, "plugin.yaml"),
       [
         "name: demo",
+        "display-name: Demo",
         "description: Demo packaged plugin",
         "config-keys:",
         "  - org",
@@ -514,6 +520,7 @@ describe("check cli", () => {
         '    name: "github",',
         "    manifest: {",
         '      name: "github",',
+        '      displayName: "GitHub",',
         '      description: "GitHub plugin",',
         '      configKeys: ["org", "repo"],',
         "    },",
@@ -538,6 +545,7 @@ describe("check cli", () => {
       path.join(sentryPackageRoot, "plugin.yaml"),
       [
         "name: sentry",
+        "display-name: Sentry",
         "description: Sentry plugin",
         "config-keys:",
         "  - org",
@@ -664,6 +672,7 @@ describe("check cli", () => {
       [
         "---",
         "name: shared-skill",
+        "display-name: Shared Skill",
         "description: Shared skill.",
         "---",
         "",
@@ -673,7 +682,9 @@ describe("check cli", () => {
     );
     writeFile(
       path.join(repoRoot, "app", "plugins", "demo", "plugin.yaml"),
-      ["name: demo", "description: Demo plugin", ""].join("\n"),
+      ["name: demo", "display-name: Demo", "description: Demo plugin", ""].join(
+        "\n",
+      ),
     );
     writeFile(
       path.join(
@@ -688,6 +699,7 @@ describe("check cli", () => {
       [
         "---",
         "name: shared-skill",
+        "display-name: Shared Skill",
         "description: Shared skill again.",
         "---",
         "",
@@ -717,13 +729,16 @@ describe("check cli", () => {
     writeAppFiles(repoRoot);
     writeFile(
       path.join(repoRoot, "app", "plugins", "demo", "plugin.yaml"),
-      ["name: demo", "description: Demo plugin", ""].join("\n"),
+      ["name: demo", "display-name: Demo", "description: Demo plugin", ""].join(
+        "\n",
+      ),
     );
     writeFile(
       path.join(repoRoot, "app", "skills", "repo-local", "SKILL.md"),
       [
         "---",
         "name: repo-local",
+        "display-name: Repo Local",
         "description: Help with repo-local tasks.",
         "uses-config: demo.repo",
         "---",
@@ -751,6 +766,7 @@ describe("check cli", () => {
       path.join(repoRoot, "app", "plugins", "demo", "plugin.yaml"),
       [
         "name: demo",
+        "display-name: Demo",
         "description: Demo plugin",
         "mcp:",
         "  url: https://mcp.example.test/mcp",
@@ -772,6 +788,7 @@ describe("check cli", () => {
       [
         "---",
         "name: demo-helper",
+        "display-name: Demo Helper",
         "description: Help with demo tasks.",
         "---",
         "",
@@ -808,6 +825,7 @@ describe("check cli", () => {
         path.join(repoRoot, "app", "plugins", pluginName, "plugin.yaml"),
         [
           `name: ${pluginName}`,
+          `display-name: ${pluginName === "alpha" ? "Alpha" : "Beta"}`,
           `${pluginName === "alpha" ? "description: Alpha" : "description: Beta"} plugin`,
           "credentials:",
           "  type: oauth-bearer",

--- a/packages/junior/tests/unit/cli/snapshot-warmup-cli.test.ts
+++ b/packages/junior/tests/unit/cli/snapshot-warmup-cli.test.ts
@@ -70,6 +70,7 @@ describe("snapshot create cli", () => {
       {
         manifest: {
           name: "agent-browser",
+          displayName: "Agent Browser",
           runtimeDependencies: [
             { type: "npm", package: "agent-browser", version: "latest" },
             { type: "system", package: "gtk3" },
@@ -80,6 +81,7 @@ describe("snapshot create cli", () => {
       {
         manifest: {
           name: "notion",
+          displayName: "Notion",
         },
       },
     ]);

--- a/packages/junior/tests/unit/handlers/oauth-callback.test.ts
+++ b/packages/junior/tests/unit/handlers/oauth-callback.test.ts
@@ -44,6 +44,18 @@ const {
 }));
 
 vi.mock("@/chat/plugins/registry", () => ({
+  getPluginDisplayName: (provider: string) => {
+    if (provider === "sentry") {
+      return "Sentry";
+    }
+    if (provider === "example") {
+      return "Example";
+    }
+    if (provider === "github") {
+      return "GitHub";
+    }
+    return undefined;
+  },
   getPluginOAuthConfig: (provider: string) => {
     if (provider === "sentry") {
       return SENTRY_OAUTH_CONFIG;

--- a/packages/junior/tests/unit/handlers/sandbox-egress-credentials.test.ts
+++ b/packages/junior/tests/unit/handlers/sandbox-egress-credentials.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from "vitest";
+import { CredentialUnavailableError } from "@/chat/credentials/broker";
+import {
+  SandboxEgressCredentialNeededError,
+  sandboxEgressCredentialLease,
+} from "@/chat/sandbox/egress-credentials";
+
+const {
+  getPluginOAuthConfig,
+  hasEgressCredentialHooks,
+  issuePluginCredential,
+  issueProviderCredentialLease,
+  getStateAdapter,
+} = vi.hoisted(() => ({
+  getPluginOAuthConfig: vi.fn(),
+  hasEgressCredentialHooks: vi.fn(),
+  issuePluginCredential: vi.fn(),
+  issueProviderCredentialLease: vi.fn(),
+  getStateAdapter: vi.fn(),
+}));
+
+vi.mock("@/chat/plugins/registry", () => ({ getPluginOAuthConfig }));
+vi.mock("@/chat/plugins/credential-hooks", () => ({
+  hasEgressCredentialHooks,
+  selectPluginGrant: vi.fn(),
+  issuePluginCredential,
+}));
+vi.mock("@/chat/capabilities/factory", () => ({
+  createUserTokenStore: vi.fn(() => ({})),
+  issueProviderCredentialLease,
+}));
+vi.mock("@/chat/state/adapter", () => ({ getStateAdapter }));
+
+const PROVIDER = "sentry";
+const EGRESS_ID = "test-egress-id";
+
+function brokerGrant() {
+  return {
+    grant: { name: "default", access: "read" as const, reason: "test" },
+    source: "broker" as const,
+  };
+}
+
+function credentialContext() {
+  return {
+    credentials: { actor: { type: "user" as const, userId: "U123" } },
+    egressId: EGRESS_ID,
+    expiresAtMs: Date.now() + 60_000,
+    contextId: "ctx-test",
+  };
+}
+
+describe("sandboxEgressCredentialLease — broker path normalization", () => {
+  it("converts broker CredentialUnavailableError to SandboxEgressCredentialNeededError with OAuth authorization", async () => {
+    hasEgressCredentialHooks.mockReturnValue(false);
+    getPluginOAuthConfig.mockReturnValue({
+      clientIdEnv: "SENTRY_CLIENT_ID",
+      clientSecretEnv: "SENTRY_CLIENT_SECRET",
+      authorizeEndpoint: "https://sentry.io/oauth/authorize/",
+      tokenEndpoint: "https://sentry.io/oauth/token/",
+      scope: "event:read org:read",
+      callbackPath: "/api/oauth/callback/sentry",
+    });
+    issueProviderCredentialLease.mockRejectedValue(
+      new CredentialUnavailableError(PROVIDER, "No sentry credentials available."),
+    );
+    const stateStub = { connect: vi.fn(), get: vi.fn(() => null), set: vi.fn(), delete: vi.fn() };
+    getStateAdapter.mockReturnValue(stateStub);
+
+    const selection = brokerGrant();
+    await expect(
+      sandboxEgressCredentialLease(PROVIDER, selection, credentialContext()),
+    ).rejects.toSatisfy(
+      (e: unknown) =>
+        e instanceof SandboxEgressCredentialNeededError &&
+        e.provider === PROVIDER &&
+        e.grant.name === "default" &&
+        e.authorization?.type === "oauth" &&
+        e.authorization?.provider === PROVIDER &&
+        e.authorization?.scope === "event:read org:read",
+    );
+  });
+
+  it("converts broker CredentialUnavailableError to SandboxEgressCredentialNeededError without authorization when provider has no OAuth config", async () => {
+    hasEgressCredentialHooks.mockReturnValue(false);
+    getPluginOAuthConfig.mockReturnValue(undefined); // no OAuth configured
+    issueProviderCredentialLease.mockRejectedValue(
+      new CredentialUnavailableError(PROVIDER, "No sentry credentials available."),
+    );
+    const stateStub = { connect: vi.fn(), get: vi.fn(() => null), set: vi.fn(), delete: vi.fn() };
+    getStateAdapter.mockReturnValue(stateStub);
+
+    await expect(
+      sandboxEgressCredentialLease(PROVIDER, brokerGrant(), credentialContext()),
+    ).rejects.toSatisfy(
+      (e: unknown) =>
+        e instanceof SandboxEgressCredentialNeededError &&
+        e.provider === PROVIDER &&
+        e.authorization === undefined, // no OAuth → no authorization on the error
+    );
+  });
+
+  it("propagates non-credential broker errors unchanged", async () => {
+    hasEgressCredentialHooks.mockReturnValue(false);
+    getPluginOAuthConfig.mockReturnValue(undefined);
+    const tokenStoreError = new Error("token store unavailable");
+    issueProviderCredentialLease.mockRejectedValue(tokenStoreError);
+    const stateStub = { connect: vi.fn(), get: vi.fn(() => null), set: vi.fn(), delete: vi.fn() };
+    getStateAdapter.mockReturnValue(stateStub);
+
+    await expect(
+      sandboxEgressCredentialLease(PROVIDER, brokerGrant(), credentialContext()),
+    ).rejects.toThrow("token store unavailable");
+  });
+
+  it("does not convert plugin CredentialUnavailableError (unavailable type stays as-is)", async () => {
+    // Plugin "unavailable" results still become CredentialUnavailableError
+    // in the plugin branch — they should NOT be converted to SandboxEgressCredentialNeededError.
+    hasEgressCredentialHooks.mockReturnValue(true);
+    getPluginOAuthConfig.mockReturnValue({ scope: "read" });
+    issuePluginCredential.mockResolvedValue({
+      type: "unavailable",
+      message: "plugin cannot issue credential for this actor",
+    });
+    const stateStub = { connect: vi.fn(), get: vi.fn(() => null), set: vi.fn(), delete: vi.fn() };
+    getStateAdapter.mockReturnValue(stateStub);
+
+    const pluginSelection = {
+      grant: { name: "user-write", access: "write" as const },
+      source: "plugin" as const,
+    };
+    await expect(
+      sandboxEgressCredentialLease(PROVIDER, pluginSelection, credentialContext()),
+    ).rejects.toSatisfy(
+      (e: unknown) =>
+        e instanceof CredentialUnavailableError &&
+        !(e instanceof SandboxEgressCredentialNeededError),
+    );
+  });
+});

--- a/packages/junior/tests/unit/handlers/sandbox-egress-credentials.test.ts
+++ b/packages/junior/tests/unit/handlers/sandbox-egress-credentials.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { CredentialUnavailableError } from "@/chat/credentials/broker";
 import {
-  SandboxEgressCredentialNeededError,
+  SandboxEgressCredentialError,
   sandboxEgressCredentialLease,
 } from "@/chat/sandbox/egress-credentials";
 
@@ -50,8 +50,8 @@ function credentialContext() {
   };
 }
 
-describe("sandboxEgressCredentialLease — broker path normalization", () => {
-  it("converts broker CredentialUnavailableError to SandboxEgressCredentialNeededError with OAuth authorization", async () => {
+describe("sandboxEgressCredentialLease — credential error normalization", () => {
+  it("converts broker CredentialUnavailableError to auth_required with OAuth authorization", async () => {
     hasEgressCredentialHooks.mockReturnValue(false);
     getPluginOAuthConfig.mockReturnValue({
       clientIdEnv: "SENTRY_CLIENT_ID",
@@ -62,9 +62,17 @@ describe("sandboxEgressCredentialLease — broker path normalization", () => {
       callbackPath: "/api/oauth/callback/sentry",
     });
     issueProviderCredentialLease.mockRejectedValue(
-      new CredentialUnavailableError(PROVIDER, "No sentry credentials available."),
+      new CredentialUnavailableError(
+        PROVIDER,
+        "No sentry credentials available.",
+      ),
     );
-    const stateStub = { connect: vi.fn(), get: vi.fn(() => null), set: vi.fn(), delete: vi.fn() };
+    const stateStub = {
+      connect: vi.fn(),
+      get: vi.fn(() => null),
+      set: vi.fn(),
+      delete: vi.fn(),
+    };
     getStateAdapter.mockReturnValue(stateStub);
 
     const selection = brokerGrant();
@@ -72,7 +80,8 @@ describe("sandboxEgressCredentialLease — broker path normalization", () => {
       sandboxEgressCredentialLease(PROVIDER, selection, credentialContext()),
     ).rejects.toSatisfy(
       (e: unknown) =>
-        e instanceof SandboxEgressCredentialNeededError &&
+        e instanceof SandboxEgressCredentialError &&
+        e.kind === "auth_required" &&
         e.provider === PROVIDER &&
         e.grant.name === "default" &&
         e.authorization?.type === "oauth" &&
@@ -81,20 +90,33 @@ describe("sandboxEgressCredentialLease — broker path normalization", () => {
     );
   });
 
-  it("converts broker CredentialUnavailableError to SandboxEgressCredentialNeededError without authorization when provider has no OAuth config", async () => {
+  it("converts broker CredentialUnavailableError to auth_required without authorization when provider has no OAuth config", async () => {
     hasEgressCredentialHooks.mockReturnValue(false);
     getPluginOAuthConfig.mockReturnValue(undefined); // no OAuth configured
     issueProviderCredentialLease.mockRejectedValue(
-      new CredentialUnavailableError(PROVIDER, "No sentry credentials available."),
+      new CredentialUnavailableError(
+        PROVIDER,
+        "No sentry credentials available.",
+      ),
     );
-    const stateStub = { connect: vi.fn(), get: vi.fn(() => null), set: vi.fn(), delete: vi.fn() };
+    const stateStub = {
+      connect: vi.fn(),
+      get: vi.fn(() => null),
+      set: vi.fn(),
+      delete: vi.fn(),
+    };
     getStateAdapter.mockReturnValue(stateStub);
 
     await expect(
-      sandboxEgressCredentialLease(PROVIDER, brokerGrant(), credentialContext()),
+      sandboxEgressCredentialLease(
+        PROVIDER,
+        brokerGrant(),
+        credentialContext(),
+      ),
     ).rejects.toSatisfy(
       (e: unknown) =>
-        e instanceof SandboxEgressCredentialNeededError &&
+        e instanceof SandboxEgressCredentialError &&
+        e.kind === "auth_required" &&
         e.provider === PROVIDER &&
         e.authorization === undefined, // no OAuth → no authorization on the error
     );
@@ -105,24 +127,36 @@ describe("sandboxEgressCredentialLease — broker path normalization", () => {
     getPluginOAuthConfig.mockReturnValue(undefined);
     const tokenStoreError = new Error("token store unavailable");
     issueProviderCredentialLease.mockRejectedValue(tokenStoreError);
-    const stateStub = { connect: vi.fn(), get: vi.fn(() => null), set: vi.fn(), delete: vi.fn() };
+    const stateStub = {
+      connect: vi.fn(),
+      get: vi.fn(() => null),
+      set: vi.fn(),
+      delete: vi.fn(),
+    };
     getStateAdapter.mockReturnValue(stateStub);
 
     await expect(
-      sandboxEgressCredentialLease(PROVIDER, brokerGrant(), credentialContext()),
+      sandboxEgressCredentialLease(
+        PROVIDER,
+        brokerGrant(),
+        credentialContext(),
+      ),
     ).rejects.toThrow("token store unavailable");
   });
 
-  it("does not convert plugin CredentialUnavailableError (unavailable type stays as-is)", async () => {
-    // Plugin "unavailable" results still become CredentialUnavailableError
-    // in the plugin branch — they should NOT be converted to SandboxEgressCredentialNeededError.
+  it("converts plugin unavailable results to unavailable credential errors", async () => {
     hasEgressCredentialHooks.mockReturnValue(true);
     getPluginOAuthConfig.mockReturnValue({ scope: "read" });
     issuePluginCredential.mockResolvedValue({
       type: "unavailable",
       message: "plugin cannot issue credential for this actor",
     });
-    const stateStub = { connect: vi.fn(), get: vi.fn(() => null), set: vi.fn(), delete: vi.fn() };
+    const stateStub = {
+      connect: vi.fn(),
+      get: vi.fn(() => null),
+      set: vi.fn(),
+      delete: vi.fn(),
+    };
     getStateAdapter.mockReturnValue(stateStub);
 
     const pluginSelection = {
@@ -130,11 +164,17 @@ describe("sandboxEgressCredentialLease — broker path normalization", () => {
       source: "plugin" as const,
     };
     await expect(
-      sandboxEgressCredentialLease(PROVIDER, pluginSelection, credentialContext()),
+      sandboxEgressCredentialLease(
+        PROVIDER,
+        pluginSelection,
+        credentialContext(),
+      ),
     ).rejects.toSatisfy(
       (e: unknown) =>
-        e instanceof CredentialUnavailableError &&
-        !(e instanceof SandboxEgressCredentialNeededError),
+        e instanceof SandboxEgressCredentialError &&
+        e.kind === "unavailable" &&
+        e.provider === PROVIDER &&
+        e.grant.name === "user-write",
     );
   });
 });

--- a/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
@@ -10,6 +10,7 @@ const {
   getPluginOAuthConfigMock,
   getPluginProvidersMock,
   issueProviderCredentialLeaseMock,
+  loggerMock,
   startSpanMock,
 } = vi.hoisted(() => ({
   continueTraceMock: vi.fn(
@@ -20,6 +21,14 @@ const {
   getPluginOAuthConfigMock: vi.fn(),
   getPluginProvidersMock: vi.fn(),
   issueProviderCredentialLeaseMock: vi.fn(),
+  loggerMock: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+  },
   startSpanMock: vi.fn(
     async (_options: unknown, callback: () => Promise<unknown>) =>
       await callback(),
@@ -53,6 +62,7 @@ vi.mock("@/chat/capabilities/factory", () => ({
 vi.mock("@/chat/sentry", () => ({
   continueTrace: continueTraceMock,
   getActiveSpan: () => undefined,
+  logger: loggerMock,
   spanToJSON: () => ({}),
   startSpan: startSpanMock,
 }));

--- a/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
@@ -96,6 +96,7 @@ function sentryPlugin() {
   return {
     manifest: {
       name: "sentry",
+      displayName: "Sentry",
       description: "Sentry",
       capabilities: ["sentry.api"],
       configKeys: [],
@@ -120,6 +121,7 @@ function githubPlugin() {
   return {
     manifest: {
       name: "github",
+      displayName: "GitHub",
       description: "GitHub",
       capabilities: ["github.api"],
       configKeys: [],
@@ -137,6 +139,7 @@ function headerOnlyPlugin() {
   return {
     manifest: {
       name: "header-only",
+      displayName: "Header Only",
       description: "Header-only",
       capabilities: ["header-only.api"],
       configKeys: [],

--- a/packages/junior/tests/unit/mcp/client.test.ts
+++ b/packages/junior/tests/unit/mcp/client.test.ts
@@ -104,6 +104,7 @@ function buildPlugin() {
     skillsDir: "/tmp/plugins/notion/skills",
     manifest: {
       name: "notion",
+      displayName: "Notion",
       description: "Notion MCP",
       capabilities: [],
       configKeys: [],

--- a/packages/junior/tests/unit/mcp/oauth.test.ts
+++ b/packages/junior/tests/unit/mcp/oauth.test.ts
@@ -13,6 +13,7 @@ function buildPlugin() {
     skillsDir: "/tmp/plugins/demo/skills",
     manifest: {
       name: "demo",
+      displayName: "Demo",
       description: "Demo plugin",
       capabilities: [],
       configKeys: [],

--- a/packages/junior/tests/unit/mcp/tool-manager.test.ts
+++ b/packages/junior/tests/unit/mcp/tool-manager.test.ts
@@ -70,6 +70,7 @@ function buildPlugin(
     skillsDir: `/tmp/plugins/${name}/skills`,
     manifest: {
       name,
+      displayName: "Demo",
       description: "Demo MCP plugin",
       capabilities: [],
       configKeys: [],

--- a/packages/junior/tests/unit/misc/sandbox-executor.test.ts
+++ b/packages/junior/tests/unit/misc/sandbox-executor.test.ts
@@ -931,7 +931,7 @@ describe("createSandboxExecutor", () => {
     expect(response.result.permission_denied).toBeUndefined();
   });
 
-  it("attaches sandbox egress auth signals to failed bash results", async () => {
+  it("attaches sandbox egress auth signals to bash results regardless of exit code", async () => {
     const sandbox = makeSandbox("sbx_fresh_auth_signal");
     sandbox.runCommand.mockImplementationOnce(async () => {
       await setSandboxEgressAuthRequiredSignal(
@@ -989,7 +989,73 @@ describe("createSandboxExecutor", () => {
     });
   });
 
-  it("attaches sandbox egress permission signals to failed bash results", async () => {
+  it("attaches sandbox egress auth signals to bash results with exit code 0 (pipe-masked failures)", async () => {
+    // Regression test: piped bash commands (e.g. `cmd | head`) mask the
+    // underlying CLI exit code with 0 from the pipe tail. The auth signal must
+    // still be surfaced so the OAuth flow can be triggered.
+    const sandbox = makeSandbox("sbx_pipe_masked_auth_signal");
+    sandbox.runCommand.mockImplementationOnce(async () => {
+      await setSandboxEgressAuthRequiredSignal(
+        {
+          credentials: { actor: { type: "user" as const, userId: "U123" } },
+          egressId: "sbx_pipe_masked_auth_signal_session",
+          expiresAtMs: Date.now() + 60_000,
+          contextId: "ctx-pipe-masked",
+        },
+        {
+          provider: "sentry",
+          grant: {
+            name: "default",
+            access: "read",
+          },
+          authorization: {
+            type: "oauth",
+            provider: "sentry",
+          },
+        },
+      );
+      return {
+        exitCode: 0, // pipe tail (head/grep) always exits 0
+        stdout: async () =>
+          '"junior-auth-required provider=sentry grant=default access=read 401 unauthorized"',
+        stderr: async () => "",
+      };
+    });
+    sandboxGetMock.mockResolvedValue(sandbox);
+    vi.mocked(createBashTool).mockResolvedValue({
+      tools: {
+        readFile: { execute: vi.fn(async () => ({ content: "" })) },
+        writeFile: { execute: vi.fn(async () => ({ success: true })) },
+      },
+    } as never);
+
+    const executor = createSandboxExecutor({
+      sandboxId: "sbx_pipe_masked_auth_signal",
+    });
+    executor.configureSkills([]);
+
+    const response = await executor.execute<{
+      auth_required?: unknown;
+      exit_code: number;
+    }>({
+      toolName: "bash",
+      input: {
+        command: "sentry org list --json 2>&1 | head -20",
+      },
+    });
+
+    expect(response.result.exit_code).toBe(0);
+    // Auth signal must be attached even though exit_code is 0
+    expect(response.result.auth_required).toMatchObject({
+      provider: "sentry",
+      grant: {
+        name: "default",
+        access: "read",
+      },
+    });
+  });
+
+  it("attaches sandbox egress permission signals to bash results regardless of exit code", async () => {
     const sandbox = makeSandbox("sbx_permission_signal");
     sandbox.runCommand.mockImplementationOnce(async () => {
       await setSandboxEgressPermissionDeniedSignal(

--- a/packages/junior/tests/unit/misc/sandbox-executor.test.ts
+++ b/packages/junior/tests/unit/misc/sandbox-executor.test.ts
@@ -1055,6 +1055,59 @@ describe("createSandboxExecutor", () => {
     });
   });
 
+  it("attaches sandbox egress auth signals to bash results with exit code 0 (pipe-masked failures)", async () => {
+    // Regression: piped bash commands (e.g. `cmd | head`) exit 0 from the pipe
+    // tail, masking the CLI's real non-zero exit. Auth signal must still attach.
+    const sandbox = makeSandbox("sbx_pipe_masked_auth_signal");
+    sandbox.runCommand.mockImplementationOnce(async () => {
+      await setSandboxEgressAuthRequiredSignal(
+        {
+          credentials: { actor: { type: "user" as const, userId: "U123" } },
+          egressId: "sbx_pipe_masked_auth_signal_session",
+          expiresAtMs: Date.now() + 60_000,
+          contextId: "ctx-pipe-masked",
+        },
+        {
+          provider: "sentry",
+          grant: { name: "default", access: "read" },
+          authorization: { type: "oauth", provider: "sentry" },
+        },
+      );
+      return {
+        exitCode: 0, // pipe tail (head/grep) always exits 0
+        stdout: async () =>
+          '"junior-auth-required provider=sentry grant=default access=read 401 unauthorized"',
+        stderr: async () => "",
+      };
+    });
+    sandboxGetMock.mockResolvedValue(sandbox);
+    vi.mocked(createBashTool).mockResolvedValue({
+      tools: {
+        readFile: { execute: vi.fn(async () => ({ content: "" })) },
+        writeFile: { execute: vi.fn(async () => ({ success: true })) },
+      },
+    } as never);
+
+    const executor = createSandboxExecutor({
+      sandboxId: "sbx_pipe_masked_auth_signal",
+    });
+    executor.configureSkills([]);
+
+    const response = await executor.execute<{
+      auth_required?: unknown;
+      exit_code: number;
+    }>({
+      toolName: "bash",
+      input: { command: "sentry org list --json 2>&1 | head -20" },
+    });
+
+    expect(response.result.exit_code).toBe(0);
+    expect(response.result.auth_required).toMatchObject({
+      provider: "sentry",
+      grant: { name: "default", access: "read" },
+    });
+  });
+
   it("attaches sandbox egress permission signals to bash results regardless of exit code", async () => {
     const sandbox = makeSandbox("sbx_permission_signal");
     sandbox.runCommand.mockImplementationOnce(async () => {

--- a/packages/junior/tests/unit/misc/sandbox-executor.test.ts
+++ b/packages/junior/tests/unit/misc/sandbox-executor.test.ts
@@ -1055,59 +1055,6 @@ describe("createSandboxExecutor", () => {
     });
   });
 
-  it("attaches sandbox egress auth signals to bash results with exit code 0 (pipe-masked failures)", async () => {
-    // Regression: piped bash commands (e.g. `cmd | head`) exit 0 from the pipe
-    // tail, masking the CLI's real non-zero exit. Auth signal must still attach.
-    const sandbox = makeSandbox("sbx_pipe_masked_auth_signal");
-    sandbox.runCommand.mockImplementationOnce(async () => {
-      await setSandboxEgressAuthRequiredSignal(
-        {
-          credentials: { actor: { type: "user" as const, userId: "U123" } },
-          egressId: "sbx_pipe_masked_auth_signal_session",
-          expiresAtMs: Date.now() + 60_000,
-          contextId: "ctx-pipe-masked",
-        },
-        {
-          provider: "sentry",
-          grant: { name: "default", access: "read" },
-          authorization: { type: "oauth", provider: "sentry" },
-        },
-      );
-      return {
-        exitCode: 0, // pipe tail (head/grep) always exits 0
-        stdout: async () =>
-          '"junior-auth-required provider=sentry grant=default access=read 401 unauthorized"',
-        stderr: async () => "",
-      };
-    });
-    sandboxGetMock.mockResolvedValue(sandbox);
-    vi.mocked(createBashTool).mockResolvedValue({
-      tools: {
-        readFile: { execute: vi.fn(async () => ({ content: "" })) },
-        writeFile: { execute: vi.fn(async () => ({ success: true })) },
-      },
-    } as never);
-
-    const executor = createSandboxExecutor({
-      sandboxId: "sbx_pipe_masked_auth_signal",
-    });
-    executor.configureSkills([]);
-
-    const response = await executor.execute<{
-      auth_required?: unknown;
-      exit_code: number;
-    }>({
-      toolName: "bash",
-      input: { command: "sentry org list --json 2>&1 | head -20" },
-    });
-
-    expect(response.result.exit_code).toBe(0);
-    expect(response.result.auth_required).toMatchObject({
-      provider: "sentry",
-      grant: { name: "default", access: "read" },
-    });
-  });
-
   it("attaches sandbox egress permission signals to bash results regardless of exit code", async () => {
     const sandbox = makeSandbox("sbx_permission_signal");
     sandbox.runCommand.mockImplementationOnce(async () => {

--- a/packages/junior/tests/unit/misc/sandbox-executor.test.ts
+++ b/packages/junior/tests/unit/misc/sandbox-executor.test.ts
@@ -39,6 +39,7 @@ vi.mock("@/chat/plugins/registry", () => ({
     {
       manifest: {
         name: "sentry",
+        displayName: "Sentry",
         description: "Sentry",
         capabilities: ["sentry.api"],
         configKeys: [],

--- a/packages/junior/tests/unit/plugins/agent-hooks.test.ts
+++ b/packages/junior/tests/unit/plugins/agent-hooks.test.ts
@@ -78,6 +78,7 @@ describe("agent plugin hooks", () => {
       defineJuniorPlugin({
         manifest: {
           name: "agent-demo",
+          displayName: "Agent Demo",
           description: "Agent demo",
         },
         hooks: {
@@ -111,6 +112,7 @@ describe("agent plugin hooks", () => {
       defineJuniorPlugin({
         manifest: {
           name: "agent-demo",
+          displayName: "Agent Demo",
           description: "Agent demo",
         },
         hooks: {
@@ -142,6 +144,7 @@ describe("agent plugin hooks", () => {
       defineJuniorPlugin({
         manifest: {
           name: "agent-demo",
+          displayName: "Agent Demo",
           description: "Agent demo",
         },
         hooks: {
@@ -178,6 +181,7 @@ describe("agent plugin hooks", () => {
         name: "agent-demo",
         manifest: {
           name: "agent-demo",
+          displayName: "Agent Demo",
           description: "Agent demo",
         },
         hooks: {
@@ -213,6 +217,7 @@ describe("agent plugin hooks", () => {
         name: "agent-demo",
         manifest: {
           name: "agent-demo",
+          displayName: "Agent Demo",
           description: "Agent demo",
         },
         hooks: {
@@ -243,6 +248,7 @@ describe("agent plugin hooks", () => {
         name: "agent-demo",
         manifest: {
           name: "agent-demo",
+          displayName: "Agent Demo",
           description: "Agent demo",
         },
         hooks: {
@@ -273,6 +279,7 @@ describe("agent plugin hooks", () => {
         name: "agent-demo",
         manifest: {
           name: "agent-demo",
+          displayName: "Agent Demo",
           description: "Agent demo",
         },
         hooks: {
@@ -308,6 +315,7 @@ describe("agent plugin hooks", () => {
         name: "agent-demo",
         manifest: {
           name: "agent-demo",
+          displayName: "Agent Demo",
           description: "Agent demo",
         },
         hooks: {
@@ -332,6 +340,7 @@ describe("agent plugin hooks", () => {
         name: "agent-demo",
         manifest: {
           name: "agent-demo",
+          displayName: "Agent Demo",
           description: "Agent demo",
         },
         hooks: {
@@ -368,6 +377,7 @@ describe("agent plugin hooks", () => {
         name: "agent-demo",
         manifest: {
           name: "agent-demo",
+          displayName: "Agent Demo",
           description: "Agent demo",
         },
         hooks: {
@@ -383,6 +393,7 @@ describe("agent plugin hooks", () => {
         name: "broken-demo",
         manifest: {
           name: "broken-demo",
+          displayName: "Broken Demo",
           description: "Broken demo",
         },
         hooks: {
@@ -423,6 +434,7 @@ describe("agent plugin hooks", () => {
       defineJuniorPlugin({
         manifest: {
           name: "agent-demo",
+          displayName: "Agent Demo",
           description: "Agent demo",
         },
         hooks: {
@@ -501,7 +513,11 @@ describe("getAgentPluginTools channel resolution", () => {
     let captured: ToolRegistrationHookContext | undefined;
     const previous = setAgentPlugins([
       defineJuniorPlugin({
-        manifest: { name: "capture", description: "Capture plugin context" },
+        manifest: {
+          name: "capture",
+          displayName: "Capture",
+          description: "Capture plugin context",
+        },
         hooks: {
           tools(ctx) {
             captured = ctx;

--- a/packages/junior/tests/unit/plugins/api-headers-broker.test.ts
+++ b/packages/junior/tests/unit/plugins/api-headers-broker.test.ts
@@ -9,6 +9,7 @@ const SYSTEM_CREDENTIAL_CONTEXT = {
 
 const MANIFEST: PluginManifest = {
   name: "example",
+  displayName: "Example",
   description: "Example API access",
   capabilities: ["example.query"],
   configKeys: [],

--- a/packages/junior/tests/unit/plugins/plugin-inline-manifest.test.ts
+++ b/packages/junior/tests/unit/plugins/plugin-inline-manifest.test.ts
@@ -40,6 +40,7 @@ describe("inline plugin manifests", () => {
       expect(() =>
         parse({
           name: `bad-${name}`,
+          displayName: `Bad ${name}`,
           description: "Bad inline manifest",
           ...patch,
         }),
@@ -51,6 +52,7 @@ describe("inline plugin manifests", () => {
     expect(() =>
       parse({
         name: "bad-capability-token",
+        displayName: "Bad Capability Token",
         description: "Bad inline manifest",
         capabilities: [123],
       }),
@@ -59,6 +61,7 @@ describe("inline plugin manifests", () => {
     expect(() =>
       parse({
         name: "bad-target-token",
+        displayName: "Bad Target Token",
         description: "Bad inline manifest",
         configKeys: ["repo"],
         target: {
@@ -66,12 +69,13 @@ describe("inline plugin manifests", () => {
           configKey: 123,
         },
       }),
-      ).toThrow("Plugin bad-target-token target.config-key Invalid input");
+    ).toThrow("Plugin bad-target-token target.config-key Invalid input");
   });
 
   it("accepts camelCase command env exposure declarations", () => {
     const manifest = parse({
       name: "safe-env",
+      displayName: "Safe Env",
       description: "Safe sandbox env",
       envVars: {
         EXAMPLE_SAFE_TOKEN: { exposeToCommandEnv: true },

--- a/packages/junior/tests/unit/plugins/plugin-manifest-api-headers.test.ts
+++ b/packages/junior/tests/unit/plugins/plugin-manifest-api-headers.test.ts
@@ -16,6 +16,7 @@ describe("plugin manifest API headers", () => {
     const manifest = parsePluginManifest(
       [
         "name: example",
+        "display-name: Example",
         "description: Example API access",
         "env-vars:",
         "  EXAMPLE_AUTH_HEADER:",
@@ -40,6 +41,7 @@ describe("plugin manifest API headers", () => {
     const manifest = parsePluginManifest(
       [
         "name: example",
+        "display-name: Example",
         "description: Example API access",
         "env-vars:",
         "  EXAMPLE_AUTH_HEADER:",
@@ -66,6 +68,7 @@ describe("plugin manifest API headers", () => {
     const manifest = parsePluginManifest(
       [
         "name: example",
+        "display-name: Example",
         "description: Example API access",
         "env-vars:",
         "  EXAMPLE_BOT_EMAIL:",
@@ -176,6 +179,7 @@ describe("plugin manifest API headers", () => {
     const manifest = parsePluginManifest(
       [
         "name: example",
+        "display-name: Example",
         "description: Example API access",
         "env-vars:",
         "  EXAMPLE_BOT_EMAIL:",
@@ -201,6 +205,7 @@ describe("plugin manifest API headers", () => {
       parsePluginManifest(
         [
           "name: example",
+          "display-name: Example",
           "description: Example API access",
           "env-vars:",
           "  EXAMPLE_BOT_EMAIL:",
@@ -223,6 +228,7 @@ describe("plugin manifest API headers", () => {
       parsePluginManifest(
         [
           "name: example",
+          "display-name: Example",
           "description: Example API access",
           "env-vars:",
           "  EXAMPLE_AUTH_HEADER:",
@@ -245,6 +251,7 @@ describe("plugin manifest API headers", () => {
       parsePluginManifest(
         [
           "name: example",
+          "display-name: Example",
           "description: Example API access",
           "env-vars:",
           "  EXAMPLE_TOKEN:",
@@ -268,6 +275,7 @@ describe("plugin manifest API headers", () => {
       parsePluginManifest(
         [
           "name: example",
+          "display-name: Example",
           "description: Example API access",
           "env-vars:",
           "  EXAMPLE_CLIENT_SECRET:",
@@ -296,6 +304,7 @@ describe("plugin manifest API headers", () => {
     const manifest = parsePluginManifest(
       [
         "name: example",
+        "display-name: Example",
         "description: Example CLI access",
         "env-vars:",
         "  EXAMPLE_SAFE_TOKEN:",
@@ -320,6 +329,7 @@ describe("plugin manifest API headers", () => {
       parsePluginManifest(
         [
           "name: example",
+          "display-name: Example",
           "description: Example CLI access",
           "env-vars:",
           "  EXAMPLE_SAFE_TOKEN:",
@@ -338,6 +348,7 @@ describe("plugin manifest API headers", () => {
       parsePluginManifest(
         [
           "name: example",
+          "display-name: Example",
           "description: Example API access",
           "api-headers:",
           '  Content-Type: "text/plain"',
@@ -351,6 +362,7 @@ describe("plugin manifest API headers", () => {
     const manifest = parsePluginManifest(
       [
         "name: example",
+        "display-name: Example",
         "description: Example API access",
         "domains:",
         "  - uploads.example.com",
@@ -377,6 +389,7 @@ describe("plugin manifest API headers", () => {
       parsePluginManifest(
         [
           "name: example",
+          "display-name: Example",
           "description: Example API access",
           "credentials:",
           "  type: plugin-managed",
@@ -398,6 +411,7 @@ describe("plugin manifest API headers", () => {
       parsePluginManifest(
         [
           "name: example",
+          "display-name: Example",
           "description: Example API access",
           "domains:",
           "  - api.example.com",
@@ -412,6 +426,7 @@ describe("plugin manifest API headers", () => {
       parsePluginManifest(
         [
           "name: example",
+          "display-name: Example",
           "description: Example API access",
           "domains:",
           "  - api.example.com",
@@ -427,6 +442,7 @@ describe("plugin manifest API headers", () => {
       parsePluginManifest(
         [
           "name: example",
+          "display-name: Example",
           "description: Example API access",
           "domains:",
           "  - api.example.com",
@@ -445,6 +461,7 @@ describe("plugin manifest API headers", () => {
       parsePluginManifest(
         [
           "name: example",
+          "display-name: Example",
           "description: Example API access",
           "env-vars:",
           "  EXAMPLE_AUTH_HEADER:",

--- a/packages/junior/tests/unit/plugins/plugin-manifest-config.test.ts
+++ b/packages/junior/tests/unit/plugins/plugin-manifest-config.test.ts
@@ -9,6 +9,7 @@ describe("plugin manifest config", () => {
     const manifest = parsePluginManifest(
       [
         "name: github",
+        "display-name: GitHub",
         "description: GitHub",
         "credentials:",
         "  type: oauth-bearer",
@@ -48,6 +49,7 @@ describe("plugin manifest config", () => {
     const manifest = parsePluginManifest(
       [
         "name: github",
+        "display-name: GitHub",
         "description: GitHub",
         "credentials:",
         "  type: oauth-bearer",
@@ -79,6 +81,7 @@ describe("plugin manifest config", () => {
     const manifest = parsePluginManifest(
       [
         "name: github",
+        "display-name: GitHub",
         "description: GitHub",
         "credentials:",
         "  type: oauth-bearer",
@@ -104,6 +107,7 @@ describe("plugin manifest config", () => {
       parsePluginManifest(
         [
           "name: github",
+          "display-name: GitHub",
           "description: GitHub",
           "credentials:",
           "  type: plugin-managed",
@@ -122,6 +126,7 @@ describe("plugin manifest config", () => {
     const manifest = parseInlinePluginManifest(
       {
         name: "github",
+        displayName: "GitHub",
         description: "GitHub",
         capabilities: [],
         configKeys: [],
@@ -148,6 +153,7 @@ describe("plugin manifest config", () => {
     const manifest = parsePluginManifest(
       [
         "name: sentry",
+        "display-name: Sentry",
         "description: Sentry",
         "env-vars:",
         "  SENTRY_AUTH_HEADER:",
@@ -180,6 +186,7 @@ describe("plugin manifest config", () => {
     const manifest = parsePluginManifest(
       [
         "name: github",
+        "display-name: GitHub",
         "description: GitHub",
         "credentials:",
         "  type: oauth-bearer",
@@ -218,7 +225,9 @@ describe("plugin manifest config", () => {
   it("rejects plugin name changes from manifest config", () => {
     expect(() =>
       parsePluginManifest(
-        ["name: sentry", "description: Sentry"].join("\n"),
+        ["name: sentry", "display-name: Sentry", "description: Sentry"].join(
+          "\n",
+        ),
         "/plugins/sentry",
         {
           manifests: {

--- a/packages/junior/tests/unit/plugins/plugin-registry-packages.test.ts
+++ b/packages/junior/tests/unit/plugins/plugin-registry-packages.test.ts
@@ -42,6 +42,7 @@ async function writePackagedPlugin(tempRoot: string): Promise<void> {
     path.join(packageRoot, "plugin.yaml"),
     [
       "name: demo",
+      "display-name: Demo",
       "description: Demo plugin",
       "capabilities:",
       "  - api",
@@ -72,6 +73,7 @@ async function writePackagedPluginWithImplicitLatest(
     path.join(packageRoot, "plugin.yaml"),
     [
       "name: demo",
+      "display-name: Demo",
       "description: Demo plugin",
       "capabilities:",
       "  - api",
@@ -105,6 +107,7 @@ async function writePackagedPluginWithSystemUrlDependency(
     path.join(packageRoot, "plugin.yaml"),
     [
       "name: demo",
+      "display-name: Demo",
       "description: Demo plugin",
       "runtime-dependencies:",
       "  - type: system",
@@ -130,6 +133,7 @@ async function writePackagedPluginWithRuntimePostinstall(
     path.join(packageRoot, "plugin.yaml"),
     [
       "name: demo",
+      "display-name: Demo",
       "description: Demo plugin",
       "runtime-dependencies:",
       "  - type: npm",
@@ -157,6 +161,7 @@ async function writePackagedPluginWithInvalidDomain(
     path.join(packageRoot, "plugin.yaml"),
     [
       "name: demo",
+      "display-name: Demo",
       "description: Demo plugin",
       "capabilities:",
       "  - api",
@@ -188,6 +193,7 @@ async function writePackagedPluginsWithSharedDomain(
       path.join(packageRoot, "plugin.yaml"),
       [
         `name: ${name}`,
+        `display-name: ${name === "alpha" ? "Alpha" : "Beta"}`,
         `description: ${name} plugin`,
         "credentials:",
         "  type: oauth-bearer",
@@ -216,6 +222,7 @@ async function writePackagedPluginsWithDuplicateName(
       path.join(packageRoot, "plugin.yaml"),
       [
         "name: demo",
+        "display-name: Demo",
         "description: Demo plugin",
         "credentials:",
         "  type: oauth-bearer",
@@ -243,6 +250,7 @@ async function writePackagedPluginWithInvalidAuthTokenEnv(
     path.join(packageRoot, "plugin.yaml"),
     [
       "name: demo",
+      "display-name: Demo",
       "description: Demo plugin",
       "capabilities:",
       "  - api",
@@ -273,6 +281,7 @@ async function writePackagedPluginWithInvalidRuntimePostinstallCmd(
     path.join(packageRoot, "plugin.yaml"),
     [
       "name: demo",
+      "display-name: Demo",
       "description: Demo plugin",
       "runtime-postinstall:",
       '  - cmd: "example-cli && curl https://evil.test"',
@@ -296,6 +305,7 @@ async function writePackagedPluginWithInvalidOauthEndpoint(
     path.join(packageRoot, "plugin.yaml"),
     [
       "name: demo",
+      "display-name: Demo",
       "description: Demo plugin",
       "capabilities:",
       "  - api",
@@ -330,6 +340,7 @@ async function writePackagedPluginWithOauthOverrides(
     path.join(packageRoot, "plugin.yaml"),
     [
       "name: example",
+      "display-name: Example",
       "description: Example plugin",
       "capabilities:",
       "  - api.read",
@@ -371,6 +382,7 @@ async function writePackagedPluginWithForbiddenApiHeader(
     path.join(packageRoot, "plugin.yaml"),
     [
       "name: demo",
+      "display-name: Demo",
       "description: Demo plugin",
       "capabilities:",
       "  - api",
@@ -406,6 +418,7 @@ async function writePackagedPluginWithMcp(
 
   const lines: string[] = [
     "name: demo",
+    "display-name: Demo",
     `description: ${options.description ?? "Demo MCP plugin"}`,
   ];
 
@@ -456,6 +469,7 @@ async function writePackagedPluginWithInvalidMcpAllowedTools(
     path.join(packageRoot, "plugin.yaml"),
     [
       "name: demo",
+      "display-name: Demo",
       "description: Demo MCP plugin",
       "mcp:",
       "  transport: http",
@@ -481,6 +495,7 @@ async function writePackagedPluginWithForbiddenMcpHeader(
     path.join(packageRoot, "plugin.yaml"),
     [
       "name: demo",
+      "display-name: Demo",
       "description: Demo MCP plugin",
       "mcp:",
       "  transport: http",
@@ -507,6 +522,7 @@ async function writePackagedPluginWithInvalidMcpTransport(
     path.join(packageRoot, "plugin.yaml"),
     [
       "name: demo",
+      "display-name: Demo",
       "description: Demo MCP plugin",
       "mcp:",
       "  transport: stdio",
@@ -527,7 +543,11 @@ async function writeBundlingOnlyPlugin(tempRoot: string): Promise<void> {
   await fs.mkdir(skillsDir, { recursive: true });
   await fs.writeFile(
     path.join(packageRoot, "plugin.yaml"),
-    ["name: demo", "description: Demo bundle-only plugin"].join("\n"),
+    [
+      "name: demo",
+      "display-name: Demo",
+      "description: Demo bundle-only plugin",
+    ].join("\n"),
     "utf8",
   );
 }

--- a/packages/junior/tests/unit/plugins/plugin-registry.test.ts
+++ b/packages/junior/tests/unit/plugins/plugin-registry.test.ts
@@ -83,7 +83,9 @@ describe("plugin registry", () => {
     await fs.mkdir(skillsRoot, { recursive: true });
     await fs.writeFile(
       path.join(pluginRoot, "plugin.yaml"),
-      ["name: demo", "description: Demo plugin"].join("\n"),
+      ["name: demo", "display-name: Demo", "description: Demo plugin"].join(
+        "\n",
+      ),
       "utf8",
     );
 

--- a/packages/junior/tests/unit/plugins/sentry-broker.test.ts
+++ b/packages/junior/tests/unit/plugins/sentry-broker.test.ts
@@ -22,6 +22,7 @@ const SYSTEM_CREDENTIAL_CONTEXT = {
 
 const SENTRY_MANIFEST: PluginManifest = {
   name: "sentry",
+  displayName: "Sentry",
   description: "Sentry issue tracking",
   capabilities: ["sentry.api"],
   configKeys: ["sentry.org", "sentry.project"],

--- a/packages/junior/tests/unit/services/plugin-auth-orchestration.test.ts
+++ b/packages/junior/tests/unit/services/plugin-auth-orchestration.test.ts
@@ -65,6 +65,20 @@ describe("createPluginAuthOrchestration", () => {
     unlinkProvider.mockReset();
   });
 
+  async function expectPluginCredentialFailure(
+    promise: Promise<unknown>,
+    expected: { message: string; provider: string },
+  ): Promise<void> {
+    let caught: unknown;
+    try {
+      await promise;
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(PluginCredentialFailureError);
+    expect(caught).toMatchObject(expected);
+  }
+
   it("starts oauth for sentry when auth_required signal is present", async () => {
     startOAuthFlow.mockResolvedValue({
       ok: true,
@@ -260,7 +274,7 @@ describe("createPluginAuthOrchestration", () => {
       vi.fn(),
     );
 
-    await expect(
+    await expectPluginCredentialFailure(
       orchestration.maybeHandleAuthSignal({
         auth_required: {
           provider: "github",
@@ -269,7 +283,61 @@ describe("createPluginAuthOrchestration", () => {
           // no authorization field
         },
       }),
-    ).rejects.toBeInstanceOf(PluginCredentialFailureError);
+      {
+        provider: "github",
+        message:
+          "github credentials are required but no OAuth flow is available for this provider.",
+      },
+    );
+
+    expect(startOAuthFlow).not.toHaveBeenCalled();
+  });
+
+  it("preserves auth signal messages when no oauth authorization is available", async () => {
+    const orchestration = createPluginAuthOrchestration(
+      {
+        requesterId: "U123",
+        userMessage: "inspect a repo",
+        userTokenStore: tokenStore(),
+      },
+      vi.fn(),
+    );
+
+    await expectPluginCredentialFailure(
+      orchestration.maybeHandleAuthSignal({
+        auth_required: {
+          provider: "github",
+          grant: { name: "installation-read", access: "read" as const },
+          createdAtMs: Date.now(),
+          message: "Missing GITHUB_APP_ID",
+        },
+      }),
+      { provider: "github", message: "Missing GITHUB_APP_ID" },
+    );
+
+    expect(startOAuthFlow).not.toHaveBeenCalled();
+  });
+
+  it("preserves no-oauth auth signal messages when authorization flow is disabled", async () => {
+    const orchestration = createPluginAuthOrchestration(
+      {
+        userMessage: "<scheduled-task-run />",
+        authorizationFlowMode: "disabled",
+      },
+      vi.fn(),
+    );
+
+    await expectPluginCredentialFailure(
+      orchestration.maybeHandleAuthSignal({
+        auth_required: {
+          provider: "github",
+          grant: { name: "installation-read", access: "read" as const },
+          createdAtMs: Date.now(),
+          message: "Missing GITHUB_APP_ID",
+        },
+      }),
+      { provider: "github", message: "Missing GITHUB_APP_ID" },
+    );
 
     expect(startOAuthFlow).not.toHaveBeenCalled();
   });

--- a/packages/junior/tests/unit/services/plugin-auth-orchestration.test.ts
+++ b/packages/junior/tests/unit/services/plugin-auth-orchestration.test.ts
@@ -318,6 +318,32 @@ describe("createPluginAuthOrchestration", () => {
     expect(startOAuthFlow).not.toHaveBeenCalled();
   });
 
+  it("preserves unavailable auth signal messages without starting oauth", async () => {
+    const orchestration = createPluginAuthOrchestration(
+      {
+        requesterId: "U123",
+        userMessage: "inspect a repo",
+        userTokenStore: tokenStore(),
+      },
+      vi.fn(),
+    );
+
+    await expectPluginCredentialFailure(
+      orchestration.maybeHandleAuthSignal({
+        auth_required: {
+          provider: "github",
+          grant: { name: "installation-read", access: "read" as const },
+          kind: "unavailable",
+          createdAtMs: Date.now(),
+          message: "Missing GITHUB_APP_ID",
+        },
+      }),
+      { provider: "github", message: "Missing GITHUB_APP_ID" },
+    );
+
+    expect(startOAuthFlow).not.toHaveBeenCalled();
+  });
+
   it("preserves no-oauth auth signal messages when authorization flow is disabled", async () => {
     const orchestration = createPluginAuthOrchestration(
       {

--- a/packages/junior/tests/unit/services/plugin-auth-orchestration.test.ts
+++ b/packages/junior/tests/unit/services/plugin-auth-orchestration.test.ts
@@ -6,22 +6,15 @@ import {
 } from "@/chat/services/plugin-auth-orchestration";
 import { AuthorizationFlowDisabledError } from "@/chat/services/auth-pause";
 import type { UserTokenStore } from "@/chat/credentials/user-token-store";
-import type { Skill } from "@/chat/skills";
 
 const {
   formatProviderLabel,
-  getPluginDefinition,
-  getPluginProviders,
   getPluginOAuthConfig,
-  hasEgressCredentialHooks,
   startOAuthFlow,
   unlinkProvider,
 } = vi.hoisted(() => ({
   formatProviderLabel: vi.fn((provider: string) => provider),
-  getPluginDefinition: vi.fn(),
-  getPluginProviders: vi.fn(),
   getPluginOAuthConfig: vi.fn(),
-  hasEgressCredentialHooks: vi.fn((provider: string) => provider === "github"),
   startOAuthFlow: vi.fn(),
   unlinkProvider: vi.fn(),
 }));
@@ -32,36 +25,12 @@ vi.mock("@/chat/oauth-flow", () => ({
 }));
 
 vi.mock("@/chat/plugins/registry", () => ({
-  getPluginDefinition,
-  getPluginProviders,
   getPluginOAuthConfig,
-}));
-
-vi.mock("@/chat/plugins/credential-hooks", () => ({
-  hasEgressCredentialHooks,
 }));
 
 vi.mock("@/chat/credentials/unlink-provider", () => ({
   unlinkProvider,
 }));
-
-const githubSkill: Skill = {
-  name: "github",
-  description: "GitHub helper",
-  skillPath: "/tmp/github",
-  body: "instructions",
-  pluginProvider: "github",
-  allowedTools: ["bash"],
-};
-
-const sentrySkill: Skill = {
-  name: "sentry",
-  description: "Sentry helper",
-  skillPath: "/tmp/sentry",
-  body: "instructions",
-  pluginProvider: "sentry",
-  allowedTools: ["bash"],
-};
 
 function tokenStore(): UserTokenStore {
   return {
@@ -71,51 +40,32 @@ function tokenStore(): UserTokenStore {
   };
 }
 
+const sentryAuthSignal = {
+  provider: "sentry",
+  grant: { name: "default", access: "read" as const },
+  authorization: { type: "oauth" as const, provider: "sentry" },
+  createdAtMs: Date.now(),
+};
+
+const githubWriteSignal = {
+  provider: "github",
+  grant: { name: "user-write", access: "write" as const },
+  authorization: { type: "oauth" as const, provider: "github" },
+  createdAtMs: Date.now(),
+};
+
 describe("createPluginAuthOrchestration", () => {
   beforeEach(() => {
     formatProviderLabel.mockClear();
-    getPluginDefinition.mockReset();
-    getPluginDefinition.mockImplementation((provider: string) => {
-      if (provider === "github") {
-        return {
-          manifest: {
-            name: "github",
-            domains: ["api.github.com"],
-          },
-        };
-      }
-
-      if (provider === "sentry") {
-        return {
-          manifest: {
-            name: "sentry",
-            credentials: {
-              type: "oauth-bearer",
-              domains: ["sentry.io"],
-              authTokenEnv: "SENTRY_AUTH_TOKEN",
-            },
-          },
-        };
-      }
-
-      return undefined;
-    });
-    getPluginProviders.mockReset();
-    getPluginProviders.mockImplementation(() =>
-      ["github", "sentry"]
-        .map((provider) => getPluginDefinition(provider))
-        .filter(Boolean),
-    );
     getPluginOAuthConfig.mockReset();
     getPluginOAuthConfig.mockImplementation((provider: string) =>
-      provider === "sentry" ? { provider } : undefined,
+      provider === "sentry" || provider === "github" ? { provider } : undefined,
     );
-    hasEgressCredentialHooks.mockClear();
     startOAuthFlow.mockReset();
     unlinkProvider.mockReset();
   });
 
-  it("starts oauth recovery for sentry bash commands through provider matching", async () => {
+  it("starts oauth for sentry when auth_required signal is present", async () => {
     startOAuthFlow.mockResolvedValue({
       ok: true,
       delivery: { channelId: "D123" },
@@ -132,13 +82,10 @@ describe("createPluginAuthOrchestration", () => {
     );
 
     await expect(
-      orchestration.handleCommandFailure({
-        activeSkill: sentrySkill,
-        command: "sentry issue list",
-        details: {
-          exit_code: 1,
-          stderr: "401 unauthorized",
-        },
+      orchestration.maybeHandleAuthSignal({
+        exit_code: 30,
+        stdout: "",
+        auth_required: sentryAuthSignal,
       }),
     ).rejects.toBeInstanceOf(PluginAuthorizationPauseError);
 
@@ -152,40 +99,57 @@ describe("createPluginAuthOrchestration", () => {
     expect(unlinkProvider).toHaveBeenCalledWith("U123", "sentry", tokens);
   });
 
-  it("returns a deterministic error instead of starting oauth when authorization is disabled", async () => {
+  it("starts oauth when exit code is 0 (pipe-masked failure)", async () => {
+    // Regression: `sentry org list | head` exits 0 even though sentry exited 30.
+    // Auth must still trigger based on the structured egress signal alone.
     startOAuthFlow.mockResolvedValue({
       ok: true,
       delivery: { channelId: "D123" },
     });
-    const abortAgent = vi.fn();
+
     const tokens = tokenStore();
     const orchestration = createPluginAuthOrchestration(
       {
         requesterId: "U123",
         userMessage: "check Sentry",
         userTokenStore: tokens,
+      },
+      vi.fn(),
+    );
+
+    await expect(
+      orchestration.maybeHandleAuthSignal({
+        exit_code: 0,
+        stdout:
+          '"junior-auth-required provider=sentry grant=default access=read 401 unauthorized"',
+        auth_required: sentryAuthSignal,
+      }),
+    ).rejects.toBeInstanceOf(PluginAuthorizationPauseError);
+
+    expect(startOAuthFlow).toHaveBeenCalledWith("sentry", expect.anything());
+  });
+
+  it("returns AuthorizationFlowDisabledError when flow is disabled", async () => {
+    const abortAgent = vi.fn();
+    const orchestration = createPluginAuthOrchestration(
+      {
+        requesterId: "U123",
+        userMessage: "check Sentry",
+        userTokenStore: tokenStore(),
         authorizationFlowMode: "disabled",
       },
       abortAgent,
     );
 
     await expect(
-      orchestration.handleCommandFailure({
-        activeSkill: sentrySkill,
-        command: "sentry issue list",
-        details: {
-          exit_code: 1,
-          stderr: "401 unauthorized",
-        },
-      }),
+      orchestration.maybeHandleAuthSignal({ auth_required: sentryAuthSignal }),
     ).rejects.toBeInstanceOf(AuthorizationFlowDisabledError);
 
     expect(startOAuthFlow).not.toHaveBeenCalled();
-    expect(unlinkProvider).not.toHaveBeenCalled();
     expect(abortAgent).not.toHaveBeenCalled();
   });
 
-  it("blocks oauth recovery when authorization is disabled and no requester is present", async () => {
+  it("returns AuthorizationFlowDisabledError when no requester and flow is disabled", async () => {
     const orchestration = createPluginAuthOrchestration(
       {
         userMessage: "<scheduled-task-run />",
@@ -195,18 +159,10 @@ describe("createPluginAuthOrchestration", () => {
     );
 
     await expect(
-      orchestration.handleCommandFailure({
-        activeSkill: sentrySkill,
-        command: "sentry issue list",
-        details: {
-          exit_code: 1,
-          stderr: "401 unauthorized",
-        },
-      }),
+      orchestration.maybeHandleAuthSignal({ auth_required: sentryAuthSignal }),
     ).rejects.toBeInstanceOf(AuthorizationFlowDisabledError);
 
     expect(startOAuthFlow).not.toHaveBeenCalled();
-    expect(unlinkProvider).not.toHaveBeenCalled();
   });
 
   it("unlinks the stored token only after oauth restart is launched", async () => {
@@ -216,10 +172,7 @@ describe("createPluginAuthOrchestration", () => {
 
     startOAuthFlow.mockImplementation(async () => {
       order.push("oauth");
-      return {
-        ok: true,
-        delivery: { channelId: "D123" },
-      };
+      return { ok: true, delivery: { channelId: "D123" } };
     });
     unlinkProvider.mockImplementation(async () => {
       order.push("unlink");
@@ -235,14 +188,7 @@ describe("createPluginAuthOrchestration", () => {
     );
 
     await expect(
-      orchestration.handleCommandFailure({
-        activeSkill: sentrySkill,
-        command: "sentry issue list",
-        details: {
-          exit_code: 1,
-          stderr: "bad credentials",
-        },
-      }),
+      orchestration.maybeHandleAuthSignal({ auth_required: sentryAuthSignal }),
     ).rejects.toBeInstanceOf(PluginAuthorizationPauseError);
 
     expect(order).toEqual(["oauth", "unlink"]);
@@ -250,11 +196,8 @@ describe("createPluginAuthOrchestration", () => {
     expect(abortAgent).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps the stored token when oauth restart cannot be launched", async () => {
-    startOAuthFlow.mockResolvedValue({
-      ok: false,
-      error: "Missing base URL",
-    });
+  it("keeps the stored token when oauth start fails", async () => {
+    startOAuthFlow.mockResolvedValue({ ok: false, error: "Missing base URL" });
 
     const orchestration = createPluginAuthOrchestration(
       {
@@ -266,74 +209,13 @@ describe("createPluginAuthOrchestration", () => {
     );
 
     await expect(
-      orchestration.handleCommandFailure({
-        activeSkill: sentrySkill,
-        command: "sentry issue list",
-        details: {
-          exit_code: 1,
-          stderr: "bad credentials",
-        },
-      }),
+      orchestration.maybeHandleAuthSignal({ auth_required: sentryAuthSignal }),
     ).rejects.toThrow("Missing base URL");
 
     expect(unlinkProvider).not.toHaveBeenCalled();
   });
 
-  it("throws a deterministic credential error for rejected github app commands", async () => {
-    const orchestration = createPluginAuthOrchestration(
-      {
-        requesterId: "U123",
-        userMessage: "clone getsentry/test-internal-repo",
-        userTokenStore: tokenStore(),
-      },
-      vi.fn(),
-    );
-
-    await expect(
-      orchestration.handleCommandFailure({
-        activeSkill: githubSkill,
-        command: "gh auth status",
-        details: {
-          exit_code: 1,
-          stderr:
-            "The value of the GITHUB_TOKEN environment variable is invalid.",
-        },
-      }),
-    ).rejects.toBeInstanceOf(PluginCredentialFailureError);
-
-    expect(startOAuthFlow).not.toHaveBeenCalled();
-    expect(unlinkProvider).not.toHaveBeenCalled();
-  });
-
-  it("ignores GitHub smart-http failures without an egress auth signal", async () => {
-    const orchestration = createPluginAuthOrchestration(
-      {
-        requesterId: "U123",
-        userMessage: "clone getsentry/test-internal-repo",
-        userTokenStore: tokenStore(),
-      },
-      vi.fn(),
-    );
-
-    await expect(
-      orchestration.handleCommandFailure({
-        activeSkill: githubSkill,
-        command: "git clone https://github.com/getsentry/test-internal-repo",
-        details: {
-          exit_code: 128,
-          stderr: "fatal: unable to access repository: gzip: invalid header",
-        },
-      }),
-    ).resolves.toBeUndefined();
-
-    expect(startOAuthFlow).not.toHaveBeenCalled();
-    expect(unlinkProvider).not.toHaveBeenCalled();
-  });
-
-  it("starts oauth recovery for GitHub write grant signals", async () => {
-    getPluginOAuthConfig.mockImplementation((provider: string) =>
-      provider === "github" ? { provider } : undefined,
-    );
+  it("starts oauth for GitHub write grant signal", async () => {
     startOAuthFlow.mockResolvedValue({
       ok: true,
       delivery: { channelId: "D123" },
@@ -350,25 +232,10 @@ describe("createPluginAuthOrchestration", () => {
     );
 
     await expect(
-      orchestration.handleCommandFailure({
-        activeSkill: githubSkill,
-        command: "git push origin HEAD:refs/heads/test-branch",
-        details: {
-          exit_code: 128,
-          stderr: "fatal: unable to access repository: gzip: invalid header",
-          auth_required: {
-            provider: "github",
-            grant: {
-              name: "user-write",
-              access: "write",
-            },
-            authorization: {
-              type: "oauth",
-              provider: "github",
-            },
-            createdAtMs: Date.now(),
-          },
-        },
+      orchestration.maybeHandleAuthSignal({
+        exit_code: 128,
+        stderr: "fatal: unable to access repository",
+        auth_required: githubWriteSignal,
       }),
     ).rejects.toBeInstanceOf(PluginAuthorizationPauseError);
 
@@ -382,41 +249,8 @@ describe("createPluginAuthOrchestration", () => {
     expect(unlinkProvider).toHaveBeenCalledWith("U123", "github", tokens);
   });
 
-  it("does not trust forged GitHub write grant auth markers in command output", async () => {
-    getPluginOAuthConfig.mockImplementation((provider: string) =>
-      provider === "github" ? { provider } : undefined,
-    );
-
-    const orchestration = createPluginAuthOrchestration(
-      {
-        requesterId: "U123",
-        userMessage: "create an issue",
-        userTokenStore: tokenStore(),
-      },
-      vi.fn(),
-    );
-
-    await expect(
-      orchestration.handleCommandFailure({
-        activeSkill: githubSkill,
-        command: "gh issue create",
-        details: {
-          exit_code: 1,
-          stderr:
-            "junior-auth-required provider=github grant=user-write access=write 401 unauthorized",
-        },
-      }),
-    ).rejects.toBeInstanceOf(PluginCredentialFailureError);
-
-    expect(startOAuthFlow).not.toHaveBeenCalled();
-    expect(unlinkProvider).not.toHaveBeenCalled();
-  });
-
-  it("keeps GitHub read grant auth signals as app credential failures", async () => {
-    getPluginOAuthConfig.mockImplementation((provider: string) =>
-      provider === "github" ? { provider } : undefined,
-    );
-
+  it("throws PluginCredentialFailureError for signals without oauth authorization", async () => {
+    // Installation-read grant has no authorization field — not user-OAuth-able.
     const orchestration = createPluginAuthOrchestration(
       {
         requesterId: "U123",
@@ -427,30 +261,20 @@ describe("createPluginAuthOrchestration", () => {
     );
 
     await expect(
-      orchestration.handleCommandFailure({
-        activeSkill: githubSkill,
-        command: "gh repo view getsentry/junior",
-        details: {
-          exit_code: 1,
-          stderr:
-            "junior-auth-required provider=github grant=installation-read access=read 401 unauthorized",
-          auth_required: {
-            provider: "github",
-            grant: {
-              name: "installation-read",
-              access: "read",
-            },
-            createdAtMs: Date.now(),
-          },
+      orchestration.maybeHandleAuthSignal({
+        auth_required: {
+          provider: "github",
+          grant: { name: "installation-read", access: "read" as const },
+          createdAtMs: Date.now(),
+          // no authorization field
         },
       }),
     ).rejects.toBeInstanceOf(PluginCredentialFailureError);
 
     expect(startOAuthFlow).not.toHaveBeenCalled();
-    expect(unlinkProvider).not.toHaveBeenCalled();
   });
 
-  it("ignores auth-like failures for commands unrelated to the provider", async () => {
+  it("no-ops when no auth_required field is in the result", async () => {
     const orchestration = createPluginAuthOrchestration(
       {
         requesterId: "U123",
@@ -460,132 +284,64 @@ describe("createPluginAuthOrchestration", () => {
       vi.fn(),
     );
 
+    // exit_code non-zero, auth-like text — but no structured signal
     await expect(
-      orchestration.handleCommandFailure({
-        activeSkill: githubSkill,
-        command: "curl https://other-api.example.test",
-        details: {
-          exit_code: 1,
-          stderr: "401 unauthorized",
-        },
+      orchestration.maybeHandleAuthSignal({
+        exit_code: 1,
+        stderr: "401 unauthorized bad credentials missing scope",
       }),
     ).resolves.toBeUndefined();
 
     expect(startOAuthFlow).not.toHaveBeenCalled();
-    expect(unlinkProvider).not.toHaveBeenCalled();
   });
 
-  it("ignores invalid structured auth signal objects", async () => {
-    getPluginOAuthConfig.mockImplementation((provider: string) =>
-      provider === "github" ? { provider } : undefined,
+  it("no-ops when result is empty", async () => {
+    const orchestration = createPluginAuthOrchestration(
+      { userMessage: "check Sentry" },
+      vi.fn(),
     );
 
+    await expect(
+      orchestration.maybeHandleAuthSignal({ exit_code: 0 }),
+    ).resolves.toBeUndefined();
+
+    expect(startOAuthFlow).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when auth_required signal fails schema validation", async () => {
+    // provider ≠ authorization.provider → schema superRefine rejects it
     for (const input of [
       {
-        command: "curl https://api.github.com/repos/getsentry/junior/issues",
-        details: {
-          exit_code: 1,
-          stderr: "request failed",
-          auth_required: {
-            provider: "linear",
-            grant: {
-              name: "user-write",
-              access: "write",
-            },
-            authorization: {
-              type: "oauth",
-              provider: "github",
-            },
-            createdAtMs: Date.now(),
-          },
+        auth_required: {
+          provider: "github",
+          grant: { name: "user-write", access: "write" },
+          authorization: { type: "oauth", provider: "sentry" }, // mismatch
+          createdAtMs: Date.now(),
         },
       },
       {
-        command: "git push origin HEAD:refs/heads/test-branch",
-        details: {
-          exit_code: 128,
-          stderr: "fatal: unable to access repository: gzip: invalid header",
-          auth_required: {
-            provider: "github",
-            grant: {
-              name: "user-write",
-              access: "write",
-            },
-            authorization: {
-              type: "oauth",
-              provider: "sentry",
-            },
-            createdAtMs: Date.now(),
-          },
+        auth_required: {
+          provider: "linear",
+          grant: { name: "user-write", access: "write" },
+          authorization: { type: "oauth", provider: "github" }, // mismatch
+          createdAtMs: Date.now(),
         },
       },
     ]) {
       const orchestration = createPluginAuthOrchestration(
         {
           requesterId: "U123",
-          userMessage: "create an issue",
+          userMessage: "do something",
           userTokenStore: tokenStore(),
         },
         vi.fn(),
       );
 
       await expect(
-        orchestration.handleCommandFailure({
-          activeSkill: githubSkill,
-          command: input.command,
-          details: input.details,
-        }),
+        orchestration.maybeHandleAuthSignal(input),
       ).resolves.toBeUndefined();
     }
 
     expect(startOAuthFlow).not.toHaveBeenCalled();
-    expect(unlinkProvider).not.toHaveBeenCalled();
-  });
-
-  it("starts oauth recovery from a provider signal without an active skill", async () => {
-    startOAuthFlow.mockResolvedValue({
-      ok: true,
-      delivery: { channelId: "D123" },
-    });
-
-    const orchestration = createPluginAuthOrchestration(
-      {
-        requesterId: "U123",
-        userMessage: "check Sentry",
-        userTokenStore: tokenStore(),
-      },
-      vi.fn(),
-    );
-
-    await expect(
-      orchestration.handleCommandFailure({
-        activeSkill: null,
-        command: "curl https://sentry.io/api/0/issues/",
-        details: {
-          exit_code: 1,
-          stderr: "junior-auth-required provider=sentry 401 unauthorized",
-          auth_required: {
-            provider: "sentry",
-            grant: {
-              name: "default",
-              access: "read",
-            },
-            authorization: {
-              type: "oauth",
-              provider: "sentry",
-            },
-            createdAtMs: Date.now(),
-          },
-        },
-      }),
-    ).rejects.toBeInstanceOf(PluginAuthorizationPauseError);
-
-    expect(startOAuthFlow).toHaveBeenCalledWith(
-      "sentry",
-      expect.objectContaining({
-        requesterId: "U123",
-        activeSkillName: undefined,
-      }),
-    );
   });
 });

--- a/packages/junior/tests/unit/skills-plugin-provider.test.ts
+++ b/packages/junior/tests/unit/skills-plugin-provider.test.ts
@@ -49,7 +49,9 @@ describe("discoverSkills plugin ownership", () => {
     await fs.mkdir(path.join(pluginRoot, "skills"), { recursive: true });
     await fs.writeFile(
       path.join(pluginRoot, "plugin.yaml"),
-      ["name: demo", "description: Demo plugin"].join("\n"),
+      ["name: demo", "display-name: Demo", "description: Demo plugin"].join(
+        "\n",
+      ),
       "utf8",
     );
     await writeSkill(path.join(pluginRoot, "skills"), "triage", "triage");

--- a/packages/junior/tests/unit/skills/skills.test.ts
+++ b/packages/junior/tests/unit/skills/skills.test.ts
@@ -47,6 +47,7 @@ describe("skills", () => {
     await writeSkillFile(tempRoot, "brief", [
       "---",
       "name: brief",
+      "display-name: Brief",
       "description: Candidate brief",
       "---",
       "",
@@ -55,6 +56,7 @@ describe("skills", () => {
     await writeSkillFile(tempRoot, "sum", [
       "---",
       "name: sum",
+      "display-name: Sum",
       "description: Summarize",
       "---",
       "",
@@ -148,6 +150,7 @@ describe("skills", () => {
       await writeSkillFile(tempRoot, "tmp-valid-metadata", [
         "---",
         "name: tmp-valid-metadata",
+        "display-name: Tmp Valid Metadata",
         "description: Valid metadata skill.",
         "---",
         "",
@@ -156,6 +159,7 @@ describe("skills", () => {
       await writeSkillFile(tempRoot, "tmp-invalid-capability", [
         "---",
         "name: tmp-invalid-capability",
+        "display-name: Tmp Invalid Capability",
         "description: Invalid capability metadata skill.",
         "requires-capabilities: github.unknown.read",
         "---",
@@ -195,6 +199,7 @@ describe("skills", () => {
         path.join(pluginRoot, "plugin.yaml"),
         [
           "name: demo",
+          "display-name: Demo",
           "description: Demo plugin",
           "capabilities:",
           "  - read",
@@ -211,6 +216,7 @@ describe("skills", () => {
         [
           "---",
           "name: demo-connect",
+          "display-name: Demo Connect",
           "description: Demo plugin skill",
           "allowed-tools: bash",
           "---",
@@ -257,6 +263,7 @@ describe("skills", () => {
         path.join(pluginRoot, "plugin.yaml"),
         [
           "name: demo",
+          "display-name: Demo",
           "description: Demo plugin",
           "config-keys:",
           "  - team",
@@ -269,6 +276,7 @@ describe("skills", () => {
         [
           "---",
           "name: demo-defaults",
+          "display-name: Demo Defaults",
           "description: Demo defaults skill",
           "---",
           "",
@@ -310,6 +318,7 @@ describe("skills", () => {
         path.join(pluginRoot, "plugin.yaml"),
         [
           "name: demo",
+          "display-name: Demo",
           "description: Demo plugin",
           "config-keys:",
           "  - repo",
@@ -333,6 +342,7 @@ describe("skills", () => {
         [
           "---",
           "name: demo-tool",
+          "display-name: Demo Tool",
           "description: Demo tool skill",
           "allowed-tools: bash",
           "---",
@@ -386,6 +396,7 @@ describe("skills", () => {
         path.join(pluginRoot, "plugin.yaml"),
         [
           "name: demo",
+          "display-name: Demo",
           "description: Demo plugin",
           "config-keys:",
           "  - repo",
@@ -397,6 +408,7 @@ describe("skills", () => {
         [
           "---",
           "name: demo-tool",
+          "display-name: Demo Tool",
           "description: Demo tool skill",
           "uses-config: demo.repo",
           "---",
@@ -435,6 +447,7 @@ describe("skills", () => {
         path.join(pluginRoot, "plugin.yaml"),
         [
           "name: demo",
+          "display-name: Demo",
           "description: Demo plugin",
           "config-keys:",
           "  - repo",
@@ -446,6 +459,7 @@ describe("skills", () => {
         [
           "---",
           "name: demo-tool",
+          "display-name: Demo Tool",
           "description: Demo tool skill",
           "---",
           "",
@@ -468,6 +482,7 @@ describe("skills", () => {
           [
             "---",
             "name: demo-tool",
+            "display-name: Demo Tool",
             "description: Demo tool skill",
             "uses-config: demo.repo",
             "---",
@@ -499,6 +514,7 @@ describe("skills", () => {
       await writeSkillFile(tempRoot, "demo-tool", [
         "---",
         "name: demo-tool",
+        "display-name: Demo Tool",
         "description: Demo tool skill",
         "---",
         "",

--- a/packages/junior/tests/unit/slack/app-home.test.ts
+++ b/packages/junior/tests/unit/slack/app-home.test.ts
@@ -14,6 +14,7 @@ vi.mock("@/chat/plugins/registry", () => ({
     {
       manifest: {
         name: "sentry",
+        displayName: "Sentry",
         description: "Sentry provider",
         credentials: {
           type: "oauth-bearer",
@@ -23,6 +24,7 @@ vi.mock("@/chat/plugins/registry", () => ({
     {
       manifest: {
         name: "notion",
+        displayName: "Notion",
         description: "Notion provider",
         mcp: {
           transport: "http",
@@ -33,6 +35,7 @@ vi.mock("@/chat/plugins/registry", () => ({
     {
       manifest: {
         name: "github",
+        displayName: "GitHub",
         description: "GitHub provider",
         domains: ["api.github.com", "github.com"],
         oauth: {
@@ -46,6 +49,7 @@ vi.mock("@/chat/plugins/registry", () => ({
     {
       manifest: {
         name: "example-bundle",
+        displayName: "Example Bundle",
         description: "Bundle-only plugin",
       },
     },

--- a/packages/junior/tests/unit/tools/agent-tools.test.ts
+++ b/packages/junior/tests/unit/tools/agent-tools.test.ts
@@ -260,10 +260,24 @@ describe("createAgentTools", () => {
   it("rethrows plugin auth pauses without reporting a tool failure", async () => {
     const sandbox = new SkillSandbox([githubSkill], [githubSkill]);
     const pluginAuthOrchestration = {
-      handleCommandFailure: vi.fn(async () => {
+      maybeHandleAuthSignal: vi.fn(async () => {
         throw new PluginAuthorizationPauseError("github", "link_sent");
       }),
     } as any;
+    const authRequired = {
+      provider: "github",
+      grant: {
+        name: "default",
+        access: "read",
+        reason: "sandbox-egress:github:read",
+      },
+      authorization: {
+        type: "oauth",
+        provider: "github",
+        scope: "repo",
+      },
+      createdAtMs: Date.now(),
+    };
     const sandboxExecutor = {
       canExecute: (toolName: string) => toolName === "bash",
       execute: vi.fn(async () => ({
@@ -278,6 +292,7 @@ describe("createAgentTools", () => {
           stderr: "bad credentials",
           stdout_truncated: false,
           stderr_truncated: false,
+          auth_required: authRequired,
         },
       })),
     } as any;
@@ -301,18 +316,19 @@ describe("createAgentTools", () => {
     await expect(
       bashTool!.execute("tool-2", { command: "gh issue view 123" }),
     ).rejects.toBeInstanceOf(PluginAuthorizationPauseError);
-    expect(pluginAuthOrchestration.handleCommandFailure).toHaveBeenCalledWith({
-      activeSkill: githubSkill,
-      command: "gh issue view 123",
-      details: expect.any(Object),
-    });
+    expect(pluginAuthOrchestration.maybeHandleAuthSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: "gh issue view 123",
+        auth_required: authRequired,
+      }),
+    );
     expect(handleToolExecutionError).not.toHaveBeenCalled();
   });
 
   it("rethrows disabled authorization errors without reporting a tool failure", async () => {
     const sandbox = new SkillSandbox([githubSkill], [githubSkill]);
     const pluginAuthOrchestration = {
-      handleCommandFailure: vi.fn(async () => {
+      maybeHandleAuthSignal: vi.fn(async () => {
         throw new AuthorizationFlowDisabledError("plugin", "github");
       }),
     } as any;

--- a/packages/junior/tests/unit/tools/agent-tools.test.ts
+++ b/packages/junior/tests/unit/tools/agent-tools.test.ts
@@ -275,7 +275,11 @@ describe("createAgentTools", () => {
     const sandbox = new SkillSandbox([githubSkill], [githubSkill]);
     const pluginAuthOrchestration = {
       maybeHandleAuthSignal: vi.fn(async () => {
-        throw new PluginAuthorizationPauseError("github", "link_sent");
+        throw new PluginAuthorizationPauseError(
+          "github",
+          "GitHub",
+          "link_sent",
+        );
       }),
     } as any;
     const authRequired = {

--- a/packages/junior/tests/unit/tools/agent-tools.test.ts
+++ b/packages/junior/tests/unit/tools/agent-tools.test.ts
@@ -3,6 +3,7 @@ import { PluginAuthorizationPauseError } from "@/chat/services/plugin-auth-orche
 import { AuthorizationFlowDisabledError } from "@/chat/services/auth-pause";
 import { SkillSandbox } from "@/chat/sandbox/skill-sandbox";
 import { createAgentTools } from "@/chat/tools/agent-tools";
+import { createBashTool } from "@/chat/tools/sandbox/bash";
 import type { Skill } from "@/chat/skills";
 
 const { handleToolExecutionError } = vi.hoisted(() => ({
@@ -255,6 +256,19 @@ describe("createAgentTools", () => {
 
     expect(editTool?.prepareArguments).toBe(prepareArguments);
     expect(editTool?.executionMode).toBe("sequential");
+  });
+
+  it("marks sandbox bash as sequential", () => {
+    const sandbox = new SkillSandbox([], []);
+    const [bashTool] = createAgentTools(
+      {
+        bash: createBashTool(),
+      },
+      sandbox,
+      {},
+    );
+
+    expect(bashTool?.executionMode).toBe("sequential");
   });
 
   it("rethrows plugin auth pauses without reporting a tool failure", async () => {

--- a/packages/junior/tests/unit/tools/load-skill.test.ts
+++ b/packages/junior/tests/unit/tools/load-skill.test.ts
@@ -43,6 +43,7 @@ describe("loadSkill tool", () => {
       path.join(pluginDir, "plugin.yaml"),
       [
         "name: sentry",
+        "display-name: Sentry",
         "description: Sentry issue tracking",
         "capabilities:",
         "  - api",
@@ -102,6 +103,7 @@ describe("loadSkill tool", () => {
       path.join(pluginDir, "plugin.yaml"),
       [
         "name: linear",
+        "display-name: Linear",
         "description: Linear issues",
         "mcp:",
         "  url: https://mcp.linear.example.test/mcp",

--- a/specs/credential-injection.md
+++ b/specs/credential-injection.md
@@ -22,7 +22,7 @@ Define how Junior maps registered plugin provider domains to host-managed creden
 2. Skills do not declare capabilities, config keys, credentials, provider domains, or runtime setup.
 3. The agent runs the real provider command. Runtime authentication is implicit and host-owned.
 4. The runtime resolves the provider from the outgoing request host, lazily issues a credential-context-bound provider lease, and applies credential headers to that forwarded request.
-5. If auth is missing or stale, the proxy returns a command-readable auth-required response and the command failure path starts a private OAuth flow, then resumes the paused turn after authorization.
+5. If credentials are missing, stale, or unavailable, the proxy records a structured host-side credential signal and returns a command-readable auth response. Plugin auth orchestration starts a private OAuth flow only when that signal is `auth_required` and carries OAuth authorization metadata, then resumes the paused turn after authorization.
 
 ## Runtime contract
 
@@ -98,12 +98,12 @@ Define how Junior maps registered plugin provider domains to host-managed creden
   permission envelope once per process and requests each read-capable
   discovered permission at `read` level.
 - Provider `401` responses discard the cached sandbox egress lease so the next request re-issues from current provider state.
-- When an upstream `401` is received for a request where Junior injected a provider credential, the proxy replaces the raw provider response body with the command-readable `junior-auth-required provider=<name> grant=<grant> access=<read|write> 401 unauthorized` sentinel and records a host-side auth-required signal for the active sandbox egress session. Plugin auth orchestration must trust only the host-side signal for provider grant requirements; raw command stdout/stderr is attacker-influenceable and must not prove GitHub write access or trigger user-token unlink.
+- When an upstream `401` is received for a request where Junior injected a provider credential, the proxy replaces the raw provider response body with the command-readable `junior-auth-required provider=<name> grant=<grant> access=<read|write> 401 unauthorized` sentinel and records a host-side credential signal with `kind: "auth_required"` for the active sandbox egress session. Plugin auth orchestration must trust only the host-side signal for provider grant requirements; raw command stdout/stderr is attacker-influenceable and must not prove GitHub write access or trigger user-token unlink.
 - Upstream `403` responses are permission denials for an issued lease, not missing authorization. They pass through raw, clear the cached lease, and record a host-side `permission_denied` signal on failed bash results with `source: "upstream"`, a message that states the request was forwarded, provider, grant, upstream target, connected provider account when known, plugin-declared requirements when known, and provider permission headers such as GitHub's `X-Accepted-GitHub-Permissions` when present.
 - The GitHub plugin may also record `permission_denied` for GitHub GraphQL HTTP `200` responses whose JSON `errors[]` carry known access-denial semantics, such as repository `NOT_FOUND` or `Resource not accessible by integration`. These responses must pass through unchanged, and the signal status must preserve the real upstream HTTP status.
-- GitHub `user-read` and `user-write` grants require a stored GitHub user-to-server OAuth token. Missing or stale user authorization returns the auth-required sentinel with the selected grant and access, which starts the private OAuth flow and resumes after authorization.
+- GitHub `user-read` and `user-write` grants require a stored GitHub user-to-server OAuth token. Missing or stale user authorization returns the auth-required sentinel with the selected grant, access, `kind: "auth_required"`, and OAuth authorization metadata, which starts the private OAuth flow and resumes after authorization.
 - For GitHub App user-to-server tokens, an empty provider `scope` response is treated as unreported scope information. Junior persists the requested scope string so future broker checks can detect local reauthorization-contract changes. Provider authorization is enforced by GitHub permissions and upstream `401`/`403` responses, not Junior scope checks.
-- GitHub `installation-read` grants continue to use GitHub App installation tokens. Read-grant GitHub credential failures are operational app/installation failures and must not trigger user OAuth.
+- GitHub `installation-read` grants continue to use GitHub App installation tokens. Read-grant GitHub credential failures are operational app/installation failures and must record `kind: "unavailable"` without OAuth authorization metadata; they must not trigger user OAuth.
 
 ## Sentry profile
 

--- a/specs/oauth-flows.md
+++ b/specs/oauth-flows.md
@@ -18,16 +18,16 @@ Define how Junior handles per-user OAuth for third-party providers while keeping
 
 ### Components
 
-| Component                            | Role                                                                                                                |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| `startOAuthFlow(provider, ...)`      | Internal runtime helper that creates state and privately delivers the authorization link                            |
-| `/api/oauth/callback/[provider]`     | Exchanges code for tokens, stores them server-side, and resumes the latest still-relevant blocked thread request    |
-| `/api/oauth/callback/mcp/[provider]` | Completes MCP SDK authorization and resumes the latest still-relevant MCP-blocked thread request                    |
-| `StateAdapterTokenStore`             | Persistent per-user token storage                                                                                   |
-| MCP auth session store               | Stores MCP auth session context and SDK-managed OAuth state across the browser redirect                             |
-| `OAuthBearerBroker`                  | Issues short-lived turn leases from stored user tokens                                                              |
-| Thread `pendingAuth` state           | Stores the current auth-blocked request for one Slack thread independently from `activeTurnId`                      |
-| `PluginAuthOrchestration`            | Detects missing/stale provider auth, starts OAuth privately, and turns the current turn into a resumable auth block |
+| Component                            | Role                                                                                                                                                                   |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `startOAuthFlow(provider, ...)`      | Internal runtime helper that creates state and privately delivers the authorization link                                                                               |
+| `/api/oauth/callback/[provider]`     | Exchanges code for tokens, stores them server-side, and resumes the latest still-relevant blocked thread request                                                       |
+| `/api/oauth/callback/mcp/[provider]` | Completes MCP SDK authorization and resumes the latest still-relevant MCP-blocked thread request                                                                       |
+| `StateAdapterTokenStore`             | Persistent per-user token storage                                                                                                                                      |
+| MCP auth session store               | Stores MCP auth session context and SDK-managed OAuth state across the browser redirect                                                                                |
+| `OAuthBearerBroker`                  | Issues short-lived turn leases from stored user tokens                                                                                                                 |
+| Thread `pendingAuth` state           | Stores the current auth-blocked request for one Slack thread independently from `activeTurnId`                                                                         |
+| `PluginAuthOrchestration`            | Consumes structured egress credential signals, starts OAuth privately for OAuth-backed `auth_required` signals, and turns the current turn into a resumable auth block |
 
 ### Why authorization code grant
 
@@ -51,14 +51,17 @@ Agent: loads the matching plugin skill and runs the real provider command
   ├─ Runtime resolves provider from the proxied sandbox request host
   ├─ Runtime keeps any provider defaults (for example a repo config) available for command construction
   ├─ Broker checks stored user OAuth tokens
-  ├─ If auth is missing or stale:
+  ├─ If auth is missing or stale and the egress signal carries OAuth authorization metadata:
   │    • runtime creates OAuth state
   │    • runtime privately delivers the authorization link
   │    • runtime posts a brief visible thread note that authorization is needed
   │    • runtime appends `authorization_requested` to the agent session log
   │    • runtime writes the turn session record as awaiting auth resume
   │    • runtime records thread-local `pendingAuth`
-  └─ Current turn ends cleanly; it is not kept as the active in-flight turn
+  ├─ If credential setup is unavailable or no OAuth authorization metadata is present:
+  │    • runtime surfaces the host-provided credential failure message
+  │    • runtime does not start a user OAuth flow
+  └─ OAuth-paused turns end cleanly; they are not kept as the active in-flight turn
   │
   ▼
 User: opens private link and approves

--- a/specs/plugin-manifest.md
+++ b/specs/plugin-manifest.md
@@ -26,15 +26,17 @@ Define the `plugin.yaml` contract agents need when adding or reviewing provider 
 
 ```yaml
 name: sentry
+display-name: Sentry
 description: Sentry helper workflows
 ```
 
-`name` must match `^[a-z][a-z0-9-]*$` and be globally unique. `description` must be non-empty.
+`name` must match `^[a-z][a-z0-9-]*$` and be globally unique. `display-name` is the human-facing provider label used in Slack and OAuth copy. `description` must be non-empty.
 
 ## Provider Manifest
 
 ```yaml
 name: sentry
+display-name: Sentry
 description: Sentry issue tracking
 
 capabilities:
@@ -69,6 +71,7 @@ target:
 ## Field Rules
 
 - `capabilities`: short names qualified to `<plugin>.<capability>` by the registry.
+- `display-name`: required provider label for human-facing auth and Slack text, for example `GitHub`, `Notion`, or `Sentry`.
 - `config-keys`: short names qualified to `<plugin>.<key>` by the registry.
 - `domains`: plugin-level domains for API header injection or code-based plugin egress hooks. Required when `api-headers` is set. In `plugin.yaml`, `domains` must pair with `api-headers` or `credentials`.
 - `api-headers`: headers injected for matching `domains`. Secret values must come from `${NAME}` placeholders declared in `env-vars` without defaults.


### PR DESCRIPTION
Credential auth pauses now flow through structured provider metadata instead of derived labels or bash-output heuristics. Sandbox egress consumes auth and permission signals after every execution, broker-backed OAuth and plugin-managed credentials normalize into the same host-side auth signal shape, and auth resume errors now require provider identity plus a human-facing provider label before a turn can be parked.

Plugin manifests now require `display-name`/`displayName`, and Slack/OAuth auth-pause copy reads that manifest-owned label so users see `GitHub`, `Notion`, or `Sentry` instead of machine ids. The branch keeps GitHub credential issuance separate while making the missing, expired, or rejected OAuth intervention point uniform and contained for the rest of the pipeline.

The current branch passes typecheck, lint, build, and the full `@sentry/junior` test suite, including Slack and architecture boundary checks.

Closes #589.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AD0AGRTQ99A7%3A1781118677.966789%22)
