### PR TITLE
fix(auth): mention requester in auth-pause thread reply

### DIFF
--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -387,7 +387,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           try {
             await beforeFirstResponsePost();
             await thread.post(
-              buildSlackOutputMessage(buildAuthPauseResponse()),
+              buildSlackOutputMessage(buildAuthPauseResponse(message.author.userId)),
             );
           } catch (error) {
             logException(

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -90,6 +90,7 @@ import {
 import { ensureSlackMessageActorIdentity } from "@/chat/services/message-actor-identity";
 import type { AgentContinueRequest } from "@/chat/services/agent-continue";
 import {
+  isAuthResumeRetryableTurnError,
   isCooperativeTurnYieldError,
   isRetryableTurnError,
 } from "@/chat/runtime/turn";
@@ -1063,14 +1064,8 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             throw error;
           }
 
-          if (
-            isRetryableTurnError(error, "mcp_auth_resume") ||
-            isRetryableTurnError(error, "plugin_auth_resume")
-          ) {
-            // authProvider is always present for mcp_auth_resume / plugin_auth_resume
-            // (sourced from AuthorizationPauseError.provider, a required constructor arg)
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            await postAuthPauseNotice(error.metadata!.authProvider!);
+          if (isAuthResumeRetryableTurnError(error)) {
+            await postAuthPauseNotice(error.metadata.authProvider);
             completeAuthPauseTurn({
               conversation: preparedState.conversation,
               sessionId: error.metadata?.sessionId ?? turnId,

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -383,11 +383,13 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           beforeFirstResponsePostCalled = true;
           await options.beforeFirstResponsePost?.();
         };
-        const postAuthPauseNotice = async (): Promise<void> => {
+        const postAuthPauseNotice = async (provider?: string): Promise<void> => {
           try {
             await beforeFirstResponsePost();
             await thread.post(
-              buildSlackOutputMessage(buildAuthPauseResponse(message.author.userId)),
+              buildSlackOutputMessage(
+                buildAuthPauseResponse(message.author.userId, provider),
+              ),
             );
           } catch (error) {
             logException(
@@ -1065,7 +1067,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             isRetryableTurnError(error, "mcp_auth_resume") ||
             isRetryableTurnError(error, "plugin_auth_resume")
           ) {
-            await postAuthPauseNotice();
+            await postAuthPauseNotice(error.metadata?.authProvider);
             completeAuthPauseTurn({
               conversation: preparedState.conversation,
               sessionId: error.metadata?.sessionId ?? turnId,

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -383,7 +383,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           beforeFirstResponsePostCalled = true;
           await options.beforeFirstResponsePost?.();
         };
-        const postAuthPauseNotice = async (provider?: string): Promise<void> => {
+        const postAuthPauseNotice = async (provider: string): Promise<void> => {
           try {
             await beforeFirstResponsePost();
             await thread.post(
@@ -1067,7 +1067,10 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             isRetryableTurnError(error, "mcp_auth_resume") ||
             isRetryableTurnError(error, "plugin_auth_resume")
           ) {
-            await postAuthPauseNotice(error.metadata?.authProvider);
+            // authProvider is always present for mcp_auth_resume / plugin_auth_resume
+            // (sourced from AuthorizationPauseError.provider, a required constructor arg)
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            await postAuthPauseNotice(error.metadata!.authProvider!);
             completeAuthPauseTurn({
               conversation: preparedState.conversation,
               sessionId: error.metadata?.sessionId ?? turnId,

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -265,6 +265,7 @@ export async function resumeSlackTurn(
   });
   let processingReaction: ProcessingReactionSession | undefined;
   let deferredPauseKind: "auth" | "timeout" | undefined;
+  let deferredPauseProvider: string | undefined;
   let deferredPauseHandler: (() => Promise<void>) | undefined;
   let deferredFailureHandler: (() => Promise<void>) | undefined;
   let finalReplyDelivered = false;
@@ -377,6 +378,7 @@ export async function resumeSlackTurn(
       onAuthPause
     ) {
       deferredPauseKind = "auth";
+      deferredPauseProvider = error.metadata?.authProvider;
       deferredPauseHandler = async () => {
         await onAuthPause(error);
       };
@@ -426,7 +428,10 @@ export async function resumeSlackTurn(
         await postSlackMessageBestEffort(
           runArgs.channelId,
           runArgs.threadTs,
-          buildAuthPauseResponse(runArgs.replyContext.requester.userId),
+          buildAuthPauseResponse(
+            runArgs.replyContext.requester.userId,
+            deferredPauseProvider,
+          ),
         );
       }
       return true;

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -10,7 +10,10 @@ import {
   logException,
   type LogContext,
 } from "@/chat/logging";
-import { isRetryableTurnError } from "@/chat/runtime/turn";
+import {
+  isAuthResumeRetryableTurnError,
+  isRetryableTurnError,
+} from "@/chat/runtime/turn";
 import {
   finalizeFailedTurnReply,
   requireTurnFailureEventId,
@@ -265,8 +268,9 @@ export async function resumeSlackTurn(
   });
   let processingReaction: ProcessingReactionSession | undefined;
   let deferredPauseKind: "auth" | "timeout" | undefined;
-  let deferredPauseProvider: string | undefined;
-  let deferredPauseRequesterId: string | undefined;
+  let deferredAuthInfo:
+    | { provider: string; requesterId: string | undefined }
+    | undefined;
   let deferredPauseHandler: (() => Promise<void>) | undefined;
   let deferredFailureHandler: (() => Promise<void>) | undefined;
   let finalReplyDelivered = false;
@@ -373,16 +377,14 @@ export async function resumeSlackTurn(
           "Failed to terminalize resumed turn after post-delivery commit failure",
         );
       }
-    } else if (
-      (isRetryableTurnError(error, "mcp_auth_resume") ||
-        isRetryableTurnError(error, "plugin_auth_resume")) &&
-      onAuthPause
-    ) {
+    } else if (isAuthResumeRetryableTurnError(error) && onAuthPause) {
       deferredPauseKind = "auth";
-      deferredPauseProvider = error.metadata?.authProvider;
-      // replyContext.requester.userId is guaranteed by the guard earlier in the try
-      // body; optional-chain here because the catch doesn't inherit that narrowing
-      deferredPauseRequesterId = runArgs.replyContext?.requester?.userId;
+      deferredAuthInfo = {
+        provider: error.metadata.authProvider,
+        // replyContext.requester.userId is guaranteed by the guard earlier in the
+        // try body; optional-chain here because catch doesn't inherit that narrowing
+        requesterId: runArgs.replyContext?.requester?.userId,
+      };
       deferredPauseHandler = async () => {
         await onAuthPause(error);
       };
@@ -428,14 +430,11 @@ export async function resumeSlackTurn(
   if (deferredPauseHandler) {
     try {
       await deferredPauseHandler();
-      if (deferredPauseKind === "auth") {
+      if (deferredPauseKind === "auth" && deferredAuthInfo) {
         await postSlackMessageBestEffort(
           runArgs.channelId,
           runArgs.threadTs,
-          // deferredPauseProvider is always set alongside deferredPauseKind === "auth"
-          // (sourced from AuthorizationPauseError.provider, a required constructor arg)
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          buildAuthPauseResponse(deferredPauseRequesterId, deferredPauseProvider!),
+          buildAuthPauseResponse(deferredAuthInfo.requesterId, deferredAuthInfo.provider),
         );
       }
       return true;

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -266,6 +266,7 @@ export async function resumeSlackTurn(
   let processingReaction: ProcessingReactionSession | undefined;
   let deferredPauseKind: "auth" | "timeout" | undefined;
   let deferredPauseProvider: string | undefined;
+  let deferredPauseRequesterId: string | undefined;
   let deferredPauseHandler: (() => Promise<void>) | undefined;
   let deferredFailureHandler: (() => Promise<void>) | undefined;
   let finalReplyDelivered = false;
@@ -379,6 +380,9 @@ export async function resumeSlackTurn(
     ) {
       deferredPauseKind = "auth";
       deferredPauseProvider = error.metadata?.authProvider;
+      // replyContext.requester.userId is guaranteed by the guard earlier in the try
+      // body; optional-chain here because the catch doesn't inherit that narrowing
+      deferredPauseRequesterId = runArgs.replyContext?.requester?.userId;
       deferredPauseHandler = async () => {
         await onAuthPause(error);
       };
@@ -428,10 +432,10 @@ export async function resumeSlackTurn(
         await postSlackMessageBestEffort(
           runArgs.channelId,
           runArgs.threadTs,
-          buildAuthPauseResponse(
-            runArgs.replyContext.requester.userId,
-            deferredPauseProvider,
-          ),
+          // deferredPauseProvider is always set alongside deferredPauseKind === "auth"
+          // (sourced from AuthorizationPauseError.provider, a required constructor arg)
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          buildAuthPauseResponse(deferredPauseRequesterId, deferredPauseProvider!),
         );
       }
       return true;

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -426,7 +426,7 @@ export async function resumeSlackTurn(
         await postSlackMessageBestEffort(
           runArgs.channelId,
           runArgs.threadTs,
-          buildAuthPauseResponse(),
+          buildAuthPauseResponse(runArgs.replyContext.requester.userId),
         );
       }
       return true;

--- a/packages/junior/src/chat/runtime/turn.ts
+++ b/packages/junior/src/chat/runtime/turn.ts
@@ -17,6 +17,12 @@ export type RetryableTurnReason =
   | "plugin_auth_resume"
   | "agent_continue";
 
+/** Auth-pause reasons — a turn cannot request authorization without a known provider. */
+export type AuthResumeRetryableTurnReason = Extract<
+  RetryableTurnReason,
+  "mcp_auth_resume" | "plugin_auth_resume"
+>;
+
 export interface RetryableTurnMetadata {
   authDisposition?: AuthorizationPauseDisposition;
   authDurationMs?: number;
@@ -30,12 +36,34 @@ export interface RetryableTurnMetadata {
   sliceId?: number;
 }
 
+/** Metadata for auth-pause turns; authProvider is required because auth cannot be
+ * requested without knowing which provider needs authorization. */
+export interface AuthResumeRetryableTurnMetadata extends RetryableTurnMetadata {
+  authProvider: string;
+}
+
+/** Narrowed RetryableTurnError for auth-pause reasons with a guaranteed provider. */
+export type AuthResumeRetryableTurnError = RetryableTurnError & {
+  readonly reason: AuthResumeRetryableTurnReason;
+  readonly metadata: AuthResumeRetryableTurnMetadata;
+};
+
 /** Error indicating an agent run can continue later after timeout or auth pause. */
 export class RetryableTurnError extends Error {
   readonly code = "retryable_turn";
   readonly metadata?: RetryableTurnMetadata;
   readonly reason: RetryableTurnReason;
 
+  constructor(
+    reason: AuthResumeRetryableTurnReason,
+    message: string,
+    metadata: AuthResumeRetryableTurnMetadata,
+  );
+  constructor(
+    reason: "agent_continue",
+    message: string,
+    metadata?: RetryableTurnMetadata,
+  );
   constructor(
     reason: RetryableTurnReason,
     message: string,
@@ -59,6 +87,22 @@ export function isRetryableTurnError(
     return true;
   }
   return error.reason === reason;
+}
+
+/**
+ * Type guard for auth-pause errors. Validates at runtime that authProvider is
+ * present — the type system enforces this at construction but this guard makes
+ * the narrowing safe even across serialization boundaries.
+ */
+export function isAuthResumeRetryableTurnError(
+  error: unknown,
+): error is AuthResumeRetryableTurnError {
+  return (
+    error instanceof RetryableTurnError &&
+    (error.reason === "mcp_auth_resume" ||
+      error.reason === "plugin_auth_resume") &&
+    typeof error.metadata?.authProvider === "string"
+  );
 }
 
 /** Error indicating the turn paused voluntarily at a safe continuation boundary. */

--- a/packages/junior/src/chat/services/auth-pause-response.ts
+++ b/packages/junior/src/chat/services/auth-pause-response.ts
@@ -1,7 +1,12 @@
-const AUTH_PAUSE_RESPONSE =
+const AUTH_PAUSE_RESPONSE_BODY =
   "I need authorization to continue. Check your private link to connect.";
 
-/** Build the visible Slack thread note for an auth-paused turn. */
-export function buildAuthPauseResponse(): string {
-  return AUTH_PAUSE_RESPONSE;
+/**
+ * Build the visible Slack thread note for an auth-paused turn.
+ * When a Slack user ID is supplied the message is prefixed with a mention
+ * so the requester is notified directly in the thread.
+ */
+export function buildAuthPauseResponse(slackUserId?: string): string {
+  const mention = slackUserId ? `<@${slackUserId}> ` : "";
+  return `${mention}${AUTH_PAUSE_RESPONSE_BODY}`;
 }

--- a/packages/junior/src/chat/services/auth-pause-response.ts
+++ b/packages/junior/src/chat/services/auth-pause-response.ts
@@ -4,10 +4,9 @@
  * the provider when known.
  */
 export function buildAuthPauseResponse(
-  slackUserId?: string,
-  provider?: string,
+  slackUserId: string | undefined,
+  provider: string,
 ): string {
   const mention = slackUserId ? `<@${slackUserId}> ` : "";
-  const subject = provider ? `authorize ${provider}` : "connect an account";
-  return `${mention}I'll need you to ${subject}. I sent you a link.`;
+  return `${mention}I'll need you to authorize ${provider}. I sent you a link.`;
 }

--- a/packages/junior/src/chat/services/auth-pause-response.ts
+++ b/packages/junior/src/chat/services/auth-pause-response.ts
@@ -1,5 +1,5 @@
 const AUTH_PAUSE_RESPONSE_BODY =
-  "I need authorization to continue. Check your private link to connect.";
+  "need you to connect an account before I can continue — check your private link.";
 
 /**
  * Build the visible Slack thread note for an auth-paused turn.

--- a/packages/junior/src/chat/services/auth-pause-response.ts
+++ b/packages/junior/src/chat/services/auth-pause-response.ts
@@ -1,12 +1,13 @@
-const AUTH_PAUSE_RESPONSE_BODY =
-  "need you to connect an account before I can continue — check your private link.";
-
 /**
  * Build the visible Slack thread note for an auth-paused turn.
- * When a Slack user ID is supplied the message is prefixed with a mention
- * so the requester is notified directly in the thread.
+ * Mentions the requester when a Slack user ID is supplied, and names
+ * the provider when known.
  */
-export function buildAuthPauseResponse(slackUserId?: string): string {
+export function buildAuthPauseResponse(
+  slackUserId?: string,
+  provider?: string,
+): string {
   const mention = slackUserId ? `<@${slackUserId}> ` : "";
-  return `${mention}${AUTH_PAUSE_RESPONSE_BODY}`;
+  const subject = provider ? `authorize ${provider}` : "connect an account";
+  return `${mention}I'll need you to ${subject}. I sent you a link.`;
 }


### PR DESCRIPTION
## What

When Junior posts an auth-pause notice in a thread, it now prefixes the message with `<@userId>` and names the provider, so the requester knows exactly what to connect.

**Before:** `I need authorization to continue. Check your private link to connect.`
**After:** `<@U039RR91S> I'll need you to authorize GitHub. I sent you a link.`

## Why

The old message was stiff and anonymous. In busy threads users could miss it or not know who it was for or what to do.

## Changes

- `auth-pause-response.ts`: rewrote the message; added `slackUserId` and `provider` params. `provider` is required — it's always set, sourced from `AuthorizationPauseError.provider` (required constructor arg, single throw site in `respond.ts`).
- `reply-executor.ts`: threads `error.metadata.authProvider` through `postAuthPauseNotice`.
- `slack-resume.ts`: captures `deferredPauseProvider` and `deferredPauseRequesterId` at the catch-block assignment, uses them after the try/finally.

## Verification

Typecheck passes clean (`pnpm --filter @sentry/junior typecheck`).

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC0B595QDZLL%3A1781128123.419869%22)