### PR TITLE
feat(cli): Add local agent chat

### DIFF
--- a/.agents/skills/junior-qa/SKILL.md
+++ b/.agents/skills/junior-qa/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: junior-qa
+description: QA Junior changes through the local chat CLI and apps/example without Slack. Use when validating Junior agent behavior, runtime/tool/prompt/plugin changes, local-vs-Slack regressions, or PR readiness with real `junior chat -p` probes.
+---
+
+Use the local Junior chat CLI as a real agent QA surface before relying on Slack. The goal is to prove the shared agent/runtime path works from `apps/example`, then add narrower tests or evals for the exact contract that changed.
+
+## Step 1: Classify the Change
+
+| Change area                                                                 | Local QA probe                                                                     |
+| --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Core reply generation, prompt, source/requester context, or local CLI       | Exact-output `chat -p` smoke plus one targeted scenario prompt                     |
+| Skills or plugin discovery                                                  | `/example-local` and `/example-bundle-help` probes from `apps/example`             |
+| Tool runtime context or provider-neutral tools                              | Targeted natural-language prompt plus focused integration tests                    |
+| Credentialed provider, MCP, sandbox, scheduler, or durable state behavior   | Local CLI as a non-Slack smoke, then targeted integration tests or evals           |
+| Slack-specific formatting, delivery, mentions, files, reactions, or retries | Local CLI is insufficient; use Slack MSW/integration coverage from the Slack specs |
+
+Read `specs/local-agent.md` first, then read the relevant feature spec for the changed behavior. If tests are added or changed, read `specs/testing.md` before choosing the layer.
+
+## Step 2: Run Local Preflight
+
+Use `apps/example` through the repo CLI:
+
+```sh
+pnpm cli -- chat -p "Say exactly: junior qa smoke ok"
+```
+
+For ordinary local QA, expect the CLI to default to memory state. Set `JUNIOR_STATE_ADAPTER=redis` only when durable Redis state is the behavior under test.
+
+Treat startup logs as useful evidence. A healthy `apps/example` run should load `SOUL.md`, `WORLD.md`, the `example-bundle` plugin, and discover both `example-local` and `example-bundle-help`.
+
+## Step 3: Exercise the Example App
+
+Run these probes when validating local agent or plugin/skill behavior:
+
+```sh
+pnpm cli -- chat -p "/example-local confirm local QA discovery"
+```
+
+Expect the answer to follow the `example-local` skill from `apps/example/app/skills` and confirm local skill discovery.
+
+```sh
+pnpm cli -- chat -p "/example-bundle-help"
+```
+
+Expect the answer to explain that the skill is discovered from `app/plugins/example-bundle/skills`, is bundled with `example-bundle`, has no credential configuration, and does not support `jr-rpc issue-credential`.
+
+## Step 4: Add a Targeted Scenario
+
+Craft one small prompt that exercises the changed behavior in user terms. Keep the assertion narrow enough to inspect from the final CLI answer:
+
+```sh
+pnpm cli -- chat -p "<targeted prompt>"
+```
+
+Prefer exact-output prompts for low-level routing or prompt-context checks. Prefer integration tests or evals when the behavior depends on tool wiring, model judgment, continuity, natural-language routing, or provider credentials.
+
+## Step 5: Verify the Contract
+
+Local QA supplements, but does not replace, repo validation:
+
+1. Run package typechecks for code changes, such as `pnpm --filter @sentry/junior typecheck`.
+2. Run focused tests for deterministic product/runtime behavior.
+3. Run evals for model-facing behavior, prompt interpretation, routing, continuity, or reply quality.
+4. Run Slack-specific tests when the change touches Slack-only behavior.
+
+## Failure Handling
+
+If local CLI output shows Redis DNS errors or hangs while connecting to Redis, check whether `JUNIOR_STATE_ADAPTER=redis` was set explicitly. Ordinary local chat should default to memory even when `.env.local` contains `REDIS_URL`.
+
+If the run fails with a model gateway connection error, rerun with host network access when available. If credentials are missing or expired and the check requires real providers, refresh with `pnpm dev:env` before retrying.
+
+If a model answer is too loose to prove the behavior, replace it with an exact-output prompt or move the assertion into an integration test or eval.
+
+## Report Results
+
+Summarize the exact commands run, the final output or assertion that passed, whether local QA was sufficient or only supplemental, and any remaining tests/evals. Do not claim Slack behavior is proven by local CLI unless the changed behavior is platform-neutral and already covered at the shared runtime boundary.

--- a/.agents/skills/junior-qa/SOURCES.md
+++ b/.agents/skills/junior-qa/SOURCES.md
@@ -1,0 +1,69 @@
+# junior-qa Sources
+
+## Repository Sources
+
+| Source                                                                        | Trust | Contribution                                                                                                                                         |
+| ----------------------------------------------------------------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `specs/local-agent.md`                                                        | High  | Canonical contract for local CLI behavior, fresh conversations, source/destination semantics, state adapter expectations, and verification guidance. |
+| `packages/junior/tests/integration/local-agent-runner.test.ts`                | High  | Integration-level proof of local runner wiring and local source behavior.                                                                            |
+| `packages/junior/tests/unit/cli/chat-cli.test.ts`                             | High  | CLI contract coverage for `chat -p` and interactive behavior.                                                                                        |
+| `scripts/cli-with-root-env.mjs`                                               | High  | Confirms `pnpm cli` loads the repo app environment for local runs.                                                                                   |
+| `packages/junior/src/cli/chat.ts`                                             | High  | Shows local CLI state adapter selection and why memory state is the default QA mode.                                                                 |
+| `apps/example/app/SOUL.md`                                                    | High  | Example app soul loaded during local QA.                                                                                                             |
+| `apps/example/app/WORLD.md`                                                   | High  | Example app world context loaded during local QA.                                                                                                    |
+| `apps/example/app/skills/example-local/SKILL.md`                              | High  | Canonical top-level app skill probe.                                                                                                                 |
+| `apps/example/app/plugins/example-bundle/plugin.yaml`                         | High  | Canonical local plugin fixture.                                                                                                                      |
+| `apps/example/app/plugins/example-bundle/skills/example-bundle-help/SKILL.md` | High  | Canonical bundled plugin skill probe.                                                                                                                |
+| `AGENTS.md`                                                                   | High  | Repository validation conventions, pnpm commands, and test/eval layer guidance.                                                                      |
+
+## Verified Commands
+
+These commands were run while authoring the skill:
+
+```sh
+pnpm cli -- chat -p "Say exactly: junior qa smoke ok"
+```
+
+Result: completed successfully and returned `junior qa smoke ok`.
+
+```sh
+pnpm cli -- chat -p "Say exactly: local memory default works"
+```
+
+Result after the default fix: completed successfully without setting `JUNIOR_STATE_ADAPTER=memory`, loaded the example app and bundled plugin, and returned `local memory default works`.
+
+```sh
+pnpm cli -- chat -p "/example-local confirm local QA discovery"
+```
+
+Result: completed successfully and followed the `example-local` skill.
+
+```sh
+pnpm cli -- chat -p "/example-bundle-help list local plugin QA signals"
+```
+
+Result before the default fix: local discovery succeeded, then the run hung with Redis DNS errors because `.env.local` provided `REDIS_URL`. This established that `REDIS_URL` alone must not change local chat away from memory state.
+
+```sh
+env JUNIOR_STATE_ADAPTER=memory pnpm cli -- chat -p "/example-bundle-help"
+```
+
+Historical pre-fix confirmation: completed successfully with host network access after forcing memory. This command remains evidence for the bundled skill behavior, but standard local QA should use the plain command now that memory is the default.
+
+```sh
+pnpm cli -- chat -p "/example-bundle-help"
+```
+
+Expected post-fix command: startup logs should load `SOUL.md`, `WORLD.md`, and `example-bundle`; discovery should find `example-bundle-help` and `example-local`; the final answer should explain the bundled skill source and lack of credential/provider auth support.
+
+## Design Decisions
+
+- Use an inline workflow skill instead of scripts because QA prompts need to vary with the changed behavior.
+- Keep `apps/example` as the canonical fixture because the user stated it should generally be the local setup for testing.
+- Keep memory as the default local chat state adapter so standard QA commands do not depend on Redis.
+- Treat local CLI proof as platform-neutral smoke coverage, not as proof of Slack-specific contracts.
+
+## Open Gaps
+
+- No dedicated scripted assertion wrapper exists yet for parsing final answers out of noisy CLI logs.
+- No local QA fixture currently proves every provider-specific app/plugin path; credentialed providers still need targeted integration tests or evals.

--- a/.agents/skills/junior-qa/SPEC.md
+++ b/.agents/skills/junior-qa/SPEC.md
@@ -1,0 +1,54 @@
+# junior-qa Skill Spec
+
+## Intent
+
+`junior-qa` teaches coding agents working on this repository how to QA Junior through the local chat CLI and `apps/example`. It exists to make local agent verification a normal part of implementation and review, especially for changes that are not Slack-specific.
+
+## Scope
+
+The skill covers:
+
+- Local single-turn QA through `pnpm cli -- chat -p`.
+- `apps/example` SOUL/WORLD loading and skill/plugin discovery checks.
+- When local CLI proof is enough as smoke coverage and when to add integration tests, evals, or Slack-specific tests.
+- Common failure modes for local QA, especially explicit Redis state adapter selection and model gateway network failures.
+
+The skill does not replace:
+
+- Typecheck/build validation.
+- Focused tests for deterministic runtime behavior.
+- Evals for model-facing contracts.
+- Slack MSW/integration coverage for Slack-only contracts.
+
+## Runtime Contract
+
+Agents using the skill should:
+
+1. Read `specs/local-agent.md` and the relevant changed feature spec.
+2. Expect memory state for ordinary local QA unless `JUNIOR_STATE_ADAPTER` is explicitly set.
+3. Use `apps/example` as the canonical local app fixture.
+4. Prove a baseline exact-output CLI turn.
+5. Probe app-level skill discovery with `/example-local`.
+6. Probe plugin-bundled skill discovery with `/example-bundle-help`.
+7. Add one narrow targeted prompt for the changed behavior.
+8. Run the appropriate typecheck, test, or eval layer for the changed contract.
+9. Report commands, final outputs or assertions, and remaining risk.
+
+## Evidence
+
+The workflow is grounded in the repository's local agent spec, CLI tests, integration tests, and verified local CLI runs. The proven QA commands load `apps/example`, discover the top-level example skill and bundled plugin skill, and exercise the shared agent reply path without Slack.
+
+## Limitations
+
+Local CLI QA proves the non-Slack local ingress and shared agent/runtime path. It does not prove Slack formatting, Slack retry delivery, channel/DM routing, file uploads, reactions, mention behavior, or Slack API payload contracts.
+
+Network-dependent local QA can fail when the model gateway is unavailable in the current environment. Redis-dependent local QA can fail when `JUNIOR_STATE_ADAPTER=redis` points at an unavailable Redis service; memory state is the default QA mode unless durable state is under test.
+
+## Maintenance
+
+Update this skill when:
+
+- `specs/local-agent.md` changes the CLI contract.
+- `apps/example` changes its local skill or plugin fixture names.
+- The CLI command shape changes.
+- The repository introduces another canonical local app fixture for QA.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Co-Authored-By: (agent model name) <email>
 - Use `/skill-writer` skill when creating or updating skills.
 - Prefer integration tests for most product/runtime changes that need real wiring.
 - Use evals as the integration-style layer for agent/prompt/natural-language behavior. See `packages/junior-evals/README.md`.
-- For any non-Slack-specific product/runtime/prompt/tool/plugin behavior change, use the local agent as the first manual behavior check. Follow `packages/docs/src/content/docs/contribute/local-agent-validation.md`; from this monorepo, run it with `pnpm cli -- chat ...`.
+- For any non-Slack-specific product/runtime/prompt/tool/plugin behavior change, use the local agent as the first manual behavior check. Follow `packages/docs/src/content/docs/contribute/local-agent-validation.md`; from this monorepo, run it with `pnpm cli -- chat ...`, which uses `apps/example` as the canonical local validation app.
 - Run evals from Codex as escalated host commands when they need real Vercel Sandbox/network access; use `pnpm evals` for the full suite.
 - If evals fail from missing or expired Gateway/Vercel credentials, run `pnpm dev:env` to refresh secrets before retrying.
 - Use instrumentation conventions from `specs/instrumentation.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ Co-Authored-By: (agent model name) <email>
 - Use `/skill-writer` skill when creating or updating skills.
 - Prefer integration tests for most product/runtime changes that need real wiring.
 - Use evals as the integration-style layer for agent/prompt/natural-language behavior. See `packages/junior-evals/README.md`.
+- For any non-Slack-specific product/runtime/prompt/tool/plugin behavior change, use the local agent as the first manual behavior check. Follow `packages/docs/src/content/docs/contribute/local-agent-validation.md`; from this monorepo, run it with `pnpm cli -- chat ...`.
 - Run evals from Codex as escalated host commands when they need real Vercel Sandbox/network access; use `pnpm evals` for the full suite.
 - If evals fail from missing or expired Gateway/Vercel credentials, run `pnpm dev:env` to refresh secrets before retrying.
 - Use instrumentation conventions from `specs/instrumentation.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,7 @@ Co-Authored-By: (agent model name) <email>
 - `specs/data-redaction-policy.md` (conversation privacy classification and raw payload redaction policy)
 - `specs/chat-architecture.md` (chat composition, service, and test-seam architecture contract)
 - `specs/task-execution.md` (durable conversation mailbox, queue wake-up, lease, and heartbeat execution contract)
+- `specs/local-agent.md` (local CLI/local adapter user flows, identity, state, and delivery contract)
 - `specs/agent-turn-handling.md` (agent user-message response policy: reply/silence, tool use, Slack side effects, resumed runs, and completion)
 - `specs/slack-agent-delivery.md` (Slack entry surfaces, reply delivery, continuation, files, images, and resume behavior contract)
 - `specs/slack-outbound-contract.md` (Slack outbound boundary, message/file/reaction safety rules, and markdown-to-`mrkdwn` ownership)

--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -171,6 +171,10 @@ export default defineConfig({
             { label: "Development", link: "/contribute/development/" },
             { label: "Testing", link: "/contribute/testing/" },
             {
+              label: "Local Agent Validation",
+              link: "/contribute/local-agent-validation/",
+            },
+            {
               label: "Documentation Guidelines",
               link: "/contribute/documentation-guidelines/",
             },

--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -138,6 +138,7 @@ export default defineConfig({
           label: "CLI",
           items: [
             { label: "junior init", link: "/cli/init/" },
+            { label: "junior chat", link: "/cli/chat/" },
             { label: "junior check", link: "/cli/check/" },
             {
               label: "junior snapshot create",

--- a/packages/docs/src/content/docs/cli/chat.md
+++ b/packages/docs/src/content/docs/cli/chat.md
@@ -40,7 +40,7 @@ pnpm exec junior chat --conversation docs-review
 | `--once <message>`      | Sends one message, prints the response, and exits.            |
 | `--conversation <name>` | Uses a stable local conversation name. Defaults to `default`. |
 
-Conversation names may contain letters, numbers, dots, underscores, and hyphens. Junior scopes local conversation ids to the current working directory, so the same name in two projects does not collide.
+Conversation names must start with a letter or number, may contain letters, numbers, dots, underscores, and hyphens, and may be at most 64 characters long. Junior lowercases names and normalizes dots to hyphens when building the stored conversation id. Junior scopes local conversation ids to the current working directory, so the same name in two projects does not collide.
 
 ## State and environment
 

--- a/packages/docs/src/content/docs/cli/chat.md
+++ b/packages/docs/src/content/docs/cli/chat.md
@@ -25,36 +25,29 @@ pnpm exec junior chat
 Send one message and exit:
 
 ```bash
-pnpm exec junior chat --once "Summarize this repository"
-```
-
-Name a local conversation when you want to keep separate threads:
-
-```bash
-pnpm exec junior chat --conversation docs-review
+pnpm exec junior chat -p "Summarize this repository"
 ```
 
 ## Options
 
-| Option                  | Purpose                                                       |
-| ----------------------- | ------------------------------------------------------------- |
-| `--once <message>`      | Sends one message, prints the response, and exits.            |
-| `--conversation <name>` | Uses a stable local conversation name. Defaults to `default`. |
+| Option         | Purpose                                            |
+| -------------- | -------------------------------------------------- |
+| `-p <message>` | Sends one message, prints the response, and exits. |
 
-Conversation names must start with a letter or number, may contain letters, numbers, dots, underscores, and hyphens, and may be at most 64 characters long. Junior lowercases names and normalizes dots to hyphens when building the stored conversation id. Junior scopes local conversation ids to the current working directory, so the same name in two projects does not collide.
+Every `junior chat` invocation creates a fresh local conversation. Interactive mode keeps context only while that process is running; `-p` sends one isolated message and exits.
 
 ## State and environment
 
 `junior chat` does not require Slack request signing, Slack tokens, or a Slack channel. It still needs the model and tool environment required by the behavior you are testing, such as `AI_GATEWAY_API_KEY` or plugin provider credentials.
 
-When neither `JUNIOR_STATE_ADAPTER` nor `REDIS_URL` is set, the command uses the in-memory state adapter so a new project can start a local session without Redis. Set `REDIS_URL` when you want conversation state to survive process restarts or match your deployed app state behavior.
+When neither `JUNIOR_STATE_ADAPTER` nor `REDIS_URL` is set, the command uses the in-memory state adapter so a new project can start a local session without Redis. Set `REDIS_URL` when you want local run state stored for diagnostics or to match your deployed app state behavior; the CLI still starts a new conversation on each invocation.
 
 The local actor is the `local-cli` system actor. Provider OAuth prompts are disabled for this local command, so tests that require user-bound provider credentials should use already configured credentials or a deployed Slack flow.
 
 ## Verification
 
 1. Run `pnpm exec junior check` from the app root.
-2. Run `pnpm exec junior chat --once "Say hello in one sentence"`.
+2. Run `pnpm exec junior chat -p "Say hello in one sentence"`.
 3. Confirm the command prints a Junior response and exits with status `0`.
 4. If the command reports missing model or provider credentials, add the required environment variables and retry.
 

--- a/packages/docs/src/content/docs/cli/chat.md
+++ b/packages/docs/src/content/docs/cli/chat.md
@@ -6,12 +6,13 @@ summary: Test Junior agent behavior from a local terminal conversation.
 prerequisites:
   - /start-here/quickstart/
 related:
+  - /contribute/local-agent-validation/
   - /reference/config-and-env/
   - /cli/check/
   - /operate/observability/
 ---
 
-Use `junior chat` when you want to exercise Junior's agent runtime without sending a Slack message. The command runs from a project that already has `@sentry/junior` installed and uses the same app files, skills, plugins, model settings, and sandbox behavior as a normal agent turn.
+Use `junior chat` when you want to exercise Junior's agent runtime without sending a Slack message. The command runs from a project that already has `@sentry/junior` installed and uses the same app files, skills, plugins, model settings, and sandbox behavior as a normal agent turn. For a focused validation workflow, use [Local Agent Validation](/contribute/local-agent-validation/).
 
 ## Usage
 

--- a/packages/docs/src/content/docs/cli/chat.md
+++ b/packages/docs/src/content/docs/cli/chat.md
@@ -1,0 +1,62 @@
+---
+title: "junior chat"
+description: "Run a local Junior conversation without Slack."
+type: reference
+summary: Test Junior agent behavior from a local terminal conversation.
+prerequisites:
+  - /start-here/quickstart/
+related:
+  - /reference/config-and-env/
+  - /cli/check/
+  - /operate/observability/
+---
+
+Use `junior chat` when you want to exercise Junior's agent runtime without sending a Slack message. The command runs from a project that already has `@sentry/junior` installed and uses the same app files, skills, plugins, model settings, and sandbox behavior as a normal agent turn.
+
+## Usage
+
+Start an interactive local conversation:
+
+```bash
+pnpm exec junior chat
+```
+
+Send one message and exit:
+
+```bash
+pnpm exec junior chat --once "Summarize this repository"
+```
+
+Name a local conversation when you want to keep separate threads:
+
+```bash
+pnpm exec junior chat --conversation docs-review
+```
+
+## Options
+
+| Option                  | Purpose                                                       |
+| ----------------------- | ------------------------------------------------------------- |
+| `--once <message>`      | Sends one message, prints the response, and exits.            |
+| `--conversation <name>` | Uses a stable local conversation name. Defaults to `default`. |
+
+Conversation names may contain letters, numbers, dots, underscores, and hyphens. Junior scopes local conversation ids to the current working directory, so the same name in two projects does not collide.
+
+## State and environment
+
+`junior chat` does not require Slack request signing, Slack tokens, or a Slack channel. It still needs the model and tool environment required by the behavior you are testing, such as `AI_GATEWAY_API_KEY` or plugin provider credentials.
+
+When neither `JUNIOR_STATE_ADAPTER` nor `REDIS_URL` is set, the command uses the in-memory state adapter so a new project can start a local session without Redis. Set `REDIS_URL` when you want conversation state to survive process restarts or match your deployed app state behavior.
+
+The local actor is the `local-cli` system actor. Provider OAuth prompts are disabled for this local command, so tests that require user-bound provider credentials should use already configured credentials or a deployed Slack flow.
+
+## Verification
+
+1. Run `pnpm exec junior check` from the app root.
+2. Run `pnpm exec junior chat --once "Say hello in one sentence"`.
+3. Confirm the command prints a Junior response and exits with status `0`.
+4. If the command reports missing model or provider credentials, add the required environment variables and retry.
+
+## Next step
+
+Use [Config & Environment](/reference/config-and-env/) to configure model and provider credentials, then use [Observability](/operate/observability/) when local turns need tracing or log inspection.

--- a/packages/docs/src/content/docs/contribute/local-agent-validation.md
+++ b/packages/docs/src/content/docs/contribute/local-agent-validation.md
@@ -98,7 +98,7 @@ Local validation proves that the shared agent path can run without Slack:
 - the prompt reaches the agent runtime
 - the local destination is not Slack-shaped
 - tools and plugins run with the configured local environment
-- visible conversation context survives within the selected local conversation
+- visible conversation context survives within one interactive local process
 - terminal delivery succeeds for text replies
 
 Keep the usual focused tests for deterministic contracts. Use Slack-specific
@@ -116,7 +116,7 @@ If local validation fails, use the first matching symptom:
 | ------------------------------- | ---------------------------------------------------------------- |
 | Missing model credentials       | Refresh env with `pnpm dev:env`, then rerun the same prompt.     |
 | Missing provider credentials    | Configure the plugin/provider env required by the changed path.  |
-| State does not persist          | Set `REDIS_URL`; memory state is process-local.                  |
+| Context resets between commands | Expected; use one interactive `junior chat` process for context. |
 | Generated files fail delivery   | Expected in the first local adapter; validate file UX elsewhere. |
 | Slack-specific behavior changed | Use the Slack specs and Slack integration tests instead.         |
 

--- a/packages/docs/src/content/docs/contribute/local-agent-validation.md
+++ b/packages/docs/src/content/docs/contribute/local-agent-validation.md
@@ -13,9 +13,9 @@ related:
 ---
 
 Use this runbook for product, runtime, prompt, skill, plugin, tool, sandbox, or
-credential changes that are not specifically about Slack ingress, Slack message
-formatting, Slack retries, or Slack OAuth UI. The local agent should be the
-first manual behavior check for those changes.
+environment-backed credential changes that are not specifically about Slack
+ingress, Slack message formatting, Slack retries, or Slack OAuth UI. The local
+agent should be the first manual behavior check for those changes.
 
 Inside this monorepo, `pnpm cli -- ...` runs Junior from `apps/example`. Treat
 that app as the canonical local validation app: it loads the example SOUL,
@@ -101,6 +101,9 @@ Local validation proves that the shared agent path can run without Slack:
 Keep the usual focused tests for deterministic contracts. Use Slack-specific
 tests only when the change is about Slack event routing, Slack outbound payloads,
 Slack markdown, Slack files, Slack retry behavior, or Slack authorization UI.
+User-bound OAuth and credential issuance flows are not validated by local chat
+because the local agent runs as the `local-cli` system actor with authorization
+prompts disabled.
 
 ## Failure Checks
 

--- a/packages/docs/src/content/docs/contribute/local-agent-validation.md
+++ b/packages/docs/src/content/docs/contribute/local-agent-validation.md
@@ -1,0 +1,97 @@
+---
+title: Local Agent Validation
+description: Use junior chat to validate non-Slack behavior from a terminal.
+type: tutorial
+summary: Verify agent behavior locally before using Slack-specific test paths.
+prerequisites:
+  - /contribute/development/
+  - /cli/chat/
+related:
+  - /contribute/testing/
+  - /cli/check/
+  - /start-here/verify-and-troubleshoot/
+---
+
+Use this runbook for product, runtime, prompt, skill, plugin, tool, sandbox, or
+credential changes that are not specifically about Slack ingress, Slack message
+formatting, Slack retries, or Slack OAuth UI. The local agent should be the
+first manual behavior check for those changes.
+
+## First Check
+
+Confirm the app is configured:
+
+```bash
+pnpm exec junior check
+```
+
+When you are working inside this monorepo, use the source CLI wrapper instead:
+
+```bash
+pnpm cli -- check
+```
+
+Run one local turn:
+
+```bash
+pnpm exec junior chat --once "Describe the behavior I just changed in one sentence."
+```
+
+From this monorepo, run the same check through the source CLI:
+
+```bash
+pnpm cli -- chat --once "Describe the behavior I just changed in one sentence."
+```
+
+The command should print a Junior response and exit with status `0`. If it
+reports missing model or provider credentials, refresh or add the required
+environment variables and rerun the same prompt.
+
+## Conversation Check
+
+Use a named conversation when the change depends on context across turns:
+
+```bash
+pnpm exec junior chat --conversation validation
+```
+
+From this monorepo:
+
+```bash
+pnpm cli -- chat --conversation validation
+```
+
+Send two prompts that exercise the changed behavior, then type `/exit`. The
+second response should use context from the first response without needing a
+Slack channel or thread.
+
+## What This Proves
+
+Local validation proves that the shared agent path can run without Slack:
+
+- the prompt reaches the agent runtime
+- the local destination is not Slack-shaped
+- tools and plugins run with the configured local environment
+- visible conversation context survives within the selected local conversation
+- terminal delivery succeeds for text replies
+
+Keep the usual focused tests for deterministic contracts. Use Slack-specific
+tests only when the change is about Slack event routing, Slack outbound payloads,
+Slack markdown, Slack files, Slack retry behavior, or Slack authorization UI.
+
+## Failure Checks
+
+If local validation fails, use the first matching symptom:
+
+| Symptom                         | First check                                                      |
+| ------------------------------- | ---------------------------------------------------------------- |
+| Missing model credentials       | Refresh env with `pnpm dev:env`, then rerun the same prompt.     |
+| Missing provider credentials    | Configure the plugin/provider env required by the changed path.  |
+| State does not persist          | Set `REDIS_URL`; memory state is process-local.                  |
+| Generated files fail delivery   | Expected in the first local adapter; validate file UX elsewhere. |
+| Slack-specific behavior changed | Use the Slack specs and Slack integration tests instead.         |
+
+## Next Step
+
+After local behavior works, run the focused commands from
+[Testing](/contribute/testing/) for the files you changed.

--- a/packages/docs/src/content/docs/contribute/local-agent-validation.md
+++ b/packages/docs/src/content/docs/contribute/local-agent-validation.md
@@ -17,6 +17,11 @@ credential changes that are not specifically about Slack ingress, Slack message
 formatting, Slack retries, or Slack OAuth UI. The local agent should be the
 first manual behavior check for those changes.
 
+Inside this monorepo, `pnpm cli -- ...` runs Junior from `apps/example`. Treat
+that app as the canonical local validation app: it loads the example SOUL,
+WORLD, local skills, plugin-bundled skills, and normal development env without
+requiring Slack.
+
 ## First Check
 
 Confirm the app is configured:
@@ -46,6 +51,24 @@ pnpm cli -- chat --once "Describe the behavior I just changed in one sentence."
 The command should print a Junior response and exit with status `0`. If it
 reports missing model or provider credentials, refresh or add the required
 environment variables and rerun the same prompt.
+
+## Example App Checks
+
+Use the example app skills when you need to prove local skill and plugin
+discovery, not just a plain model response:
+
+```bash
+pnpm cli -- chat --conversation example-skill-proof --once "/example-local Confirm the example app local skill is available."
+```
+
+```bash
+pnpm cli -- chat --conversation example-plugin-proof --once "/example-bundle-help Explain where this plugin-bundled skill is discovered from and whether it supports jr-rpc issue-credential."
+```
+
+The first command should use the app-local `example-local` skill. The second
+should report that the skill is discovered from
+`app/plugins/example-bundle/skills` and that `example-bundle` is bundle-only
+without credential issuance support.
 
 ## Conversation Check
 

--- a/packages/docs/src/content/docs/contribute/local-agent-validation.md
+++ b/packages/docs/src/content/docs/contribute/local-agent-validation.md
@@ -39,18 +39,21 @@ pnpm cli -- check
 Run one local turn:
 
 ```bash
-pnpm exec junior chat --once "Describe the behavior I just changed in one sentence."
+pnpm exec junior chat -p "Describe the behavior I just changed in one sentence."
 ```
 
 From this monorepo, run the same check through the source CLI:
 
 ```bash
-pnpm cli -- chat --once "Describe the behavior I just changed in one sentence."
+pnpm cli -- chat -p "Describe the behavior I just changed in one sentence."
 ```
 
 The command should print a Junior response and exit with status `0`. If it
 reports missing model or provider credentials, refresh or add the required
 environment variables and rerun the same prompt.
+
+`-p` uses a fresh local conversation for each invocation. Use interactive mode
+when you need to validate multi-turn context.
 
 ## Example App Checks
 
@@ -58,11 +61,11 @@ Use the example app skills when you need to prove local skill and plugin
 discovery, not just a plain model response:
 
 ```bash
-pnpm cli -- chat --conversation example-skill-proof --once "/example-local Confirm the example app local skill is available."
+pnpm cli -- chat -p "/example-local Confirm the example app local skill is available."
 ```
 
 ```bash
-pnpm cli -- chat --conversation example-plugin-proof --once "/example-bundle-help Explain where this plugin-bundled skill is discovered from and whether it supports jr-rpc issue-credential."
+pnpm cli -- chat -p "/example-bundle-help Explain where this plugin-bundled skill is discovered from and whether it supports jr-rpc issue-credential."
 ```
 
 The first command should use the app-local `example-local` skill. The second
@@ -72,16 +75,16 @@ without credential issuance support.
 
 ## Conversation Check
 
-Use a named conversation when the change depends on context across turns:
+Use interactive mode when the change depends on context across turns:
 
 ```bash
-pnpm exec junior chat --conversation validation
+pnpm exec junior chat
 ```
 
 From this monorepo:
 
 ```bash
-pnpm cli -- chat --conversation validation
+pnpm cli -- chat
 ```
 
 Send two prompts that exercise the changed behavior, then type `/exit`. The

--- a/packages/docs/src/content/docs/contribute/testing.md
+++ b/packages/docs/src/content/docs/contribute/testing.md
@@ -5,6 +5,7 @@ type: reference
 prerequisites:
   - /contribute/development/
 related:
+  - /contribute/local-agent-validation/
   - /contribute/releasing/
   - /start-here/verify-and-troubleshoot/
 ---
@@ -39,9 +40,11 @@ pnpm --filter @sentry/junior-evals evals path/to/eval.test.ts
 
 ## Notes
 
+- Use [Local Agent Validation](/contribute/local-agent-validation/) as the
+  first manual behavior check for changes that are not Slack-specific.
 - Evals require real sandbox access and are not always reliable in restricted sandbox environments.
 - Keep layer boundaries strict: behavior quality in evals, protocol details in integration tests, isolated invariants in unit tests.
 
 ## Next step
 
-After adding or changing tests, run the deploy checks in [Releasing](/contribute/releasing/) and validate runtime behavior via [Verify & Troubleshoot](/start-here/verify-and-troubleshoot/).
+After adding or changing tests, run the deploy checks in [Releasing](/contribute/releasing/) and validate runtime behavior with [Local Agent Validation](/contribute/local-agent-validation/) or [Verify & Troubleshoot](/start-here/verify-and-troubleshoot/).

--- a/packages/docs/src/content/docs/reference/api/functions/createApp.md
+++ b/packages/docs/src/content/docs/reference/api/functions/createApp.md
@@ -7,7 +7,7 @@ title: "createApp"
 
 > **createApp**(`options?`): `Promise`\<`Hono`\<`BlankEnv`, `BlankSchema`, `"/"`\>\>
 
-Defined in: [junior/src/app.ts:329](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L329)
+Defined in: [junior/src/app.ts:331](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L331)
 
 Create a Hono app with all Junior routes.
 

--- a/packages/docs/src/content/docs/reference/api/functions/initSentry.md
+++ b/packages/docs/src/content/docs/reference/api/functions/initSentry.md
@@ -7,7 +7,7 @@ title: "initSentry"
 
 > **initSentry**(): `void`
 
-Defined in: [junior/src/instrumentation.ts:18](https://github.com/getsentry/junior/blob/main/packages/junior/src/instrumentation.ts#L18)
+Defined in: [junior/src/instrumentation.ts:22](https://github.com/getsentry/junior/blob/main/packages/junior/src/instrumentation.ts#L22)
 
 Initialize Sentry for the Junior runtime. Call at the top of your entry point.
 

--- a/packages/docs/src/content/docs/reference/api/interfaces/ConversationFeed.md
+++ b/packages/docs/src/content/docs/reference/api/interfaces/ConversationFeed.md
@@ -5,7 +5,7 @@ prev: false
 title: "ConversationFeed"
 ---
 
-Defined in: [junior/src/reporting/conversations.ts:154](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L154)
+Defined in: [junior/src/reporting/conversations.ts:155](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L155)
 
 ## Properties
 
@@ -13,7 +13,7 @@ Defined in: [junior/src/reporting/conversations.ts:154](https://github.com/getse
 
 > **generatedAt**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:157](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L157)
+Defined in: [junior/src/reporting/conversations.ts:158](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L158)
 
 ---
 
@@ -21,7 +21,7 @@ Defined in: [junior/src/reporting/conversations.ts:157](https://github.com/getse
 
 > **sessions**: [`ConversationSummaryReport`](/reference/api/interfaces/conversationsummaryreport/)[]
 
-Defined in: [junior/src/reporting/conversations.ts:155](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L155)
+Defined in: [junior/src/reporting/conversations.ts:156](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L156)
 
 ---
 
@@ -29,4 +29,4 @@ Defined in: [junior/src/reporting/conversations.ts:155](https://github.com/getse
 
 > **source**: `"conversation_index"`
 
-Defined in: [junior/src/reporting/conversations.ts:156](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L156)
+Defined in: [junior/src/reporting/conversations.ts:157](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L157)

--- a/packages/docs/src/content/docs/reference/api/interfaces/ConversationReport.md
+++ b/packages/docs/src/content/docs/reference/api/interfaces/ConversationReport.md
@@ -5,7 +5,7 @@ prev: false
 title: "ConversationReport"
 ---
 
-Defined in: [junior/src/reporting/conversations.ts:146](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L146)
+Defined in: [junior/src/reporting/conversations.ts:147](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L147)
 
 ## Properties
 
@@ -13,7 +13,7 @@ Defined in: [junior/src/reporting/conversations.ts:146](https://github.com/getse
 
 > **conversationId**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:147](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L147)
+Defined in: [junior/src/reporting/conversations.ts:148](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L148)
 
 ---
 
@@ -21,7 +21,7 @@ Defined in: [junior/src/reporting/conversations.ts:147](https://github.com/getse
 
 > **displayTitle**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:149](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L149)
+Defined in: [junior/src/reporting/conversations.ts:150](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L150)
 
 Always-populated display title, computed the same way as per-run reports.
 
@@ -31,7 +31,7 @@ Always-populated display title, computed the same way as per-run reports.
 
 > **generatedAt**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:150](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L150)
+Defined in: [junior/src/reporting/conversations.ts:151](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L151)
 
 ---
 
@@ -39,4 +39,4 @@ Defined in: [junior/src/reporting/conversations.ts:150](https://github.com/getse
 
 > **runs**: [`ConversationRunReport`](/reference/api/interfaces/conversationrunreport/)[]
 
-Defined in: [junior/src/reporting/conversations.ts:151](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L151)
+Defined in: [junior/src/reporting/conversations.ts:152](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L152)

--- a/packages/docs/src/content/docs/reference/api/interfaces/ConversationRunReport.md
+++ b/packages/docs/src/content/docs/reference/api/interfaces/ConversationRunReport.md
@@ -5,7 +5,7 @@ prev: false
 title: "ConversationRunReport"
 ---
 
-Defined in: [junior/src/reporting/conversations.ts:137](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L137)
+Defined in: [junior/src/reporting/conversations.ts:138](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L138)
 
 ## Extends
 
@@ -17,7 +17,7 @@ Defined in: [junior/src/reporting/conversations.ts:137](https://github.com/getse
 
 > `optional` **channel?**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:88](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L88)
+Defined in: [junior/src/reporting/conversations.ts:89](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L89)
 
 #### Inherited from
 
@@ -29,7 +29,7 @@ Defined in: [junior/src/reporting/conversations.ts:88](https://github.com/getsen
 
 > `optional` **channelName?**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:89](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L89)
+Defined in: [junior/src/reporting/conversations.ts:90](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L90)
 
 #### Inherited from
 
@@ -41,7 +41,7 @@ Defined in: [junior/src/reporting/conversations.ts:89](https://github.com/getsen
 
 > `optional` **completedAt?**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:85](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L85)
+Defined in: [junior/src/reporting/conversations.ts:86](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L86)
 
 #### Inherited from
 
@@ -53,7 +53,7 @@ Defined in: [junior/src/reporting/conversations.ts:85](https://github.com/getsen
 
 > **conversationId**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:79](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L79)
+Defined in: [junior/src/reporting/conversations.ts:80](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L80)
 
 #### Inherited from
 
@@ -65,7 +65,7 @@ Defined in: [junior/src/reporting/conversations.ts:79](https://github.com/getsen
 
 > **cumulativeDurationMs**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:77](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L77)
+Defined in: [junior/src/reporting/conversations.ts:78](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L78)
 
 #### Inherited from
 
@@ -77,7 +77,7 @@ Defined in: [junior/src/reporting/conversations.ts:77](https://github.com/getsen
 
 > `optional` **cumulativeUsage?**: [`ConversationUsage`](/reference/api/interfaces/conversationusage/)
 
-Defined in: [junior/src/reporting/conversations.ts:78](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L78)
+Defined in: [junior/src/reporting/conversations.ts:79](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L79)
 
 #### Inherited from
 
@@ -89,7 +89,7 @@ Defined in: [junior/src/reporting/conversations.ts:78](https://github.com/getsen
 
 > **displayTitle**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:76](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L76)
+Defined in: [junior/src/reporting/conversations.ts:77](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L77)
 
 Always-populated display title, with privacy redaction applied first.
 
@@ -103,7 +103,7 @@ Always-populated display title, with privacy redaction applied first.
 
 > **id**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:80](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L80)
+Defined in: [junior/src/reporting/conversations.ts:81](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L81)
 
 #### Inherited from
 
@@ -115,7 +115,7 @@ Defined in: [junior/src/reporting/conversations.ts:80](https://github.com/getsen
 
 > **lastProgressAt**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:84](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L84)
+Defined in: [junior/src/reporting/conversations.ts:85](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L85)
 
 #### Inherited from
 
@@ -127,7 +127,7 @@ Defined in: [junior/src/reporting/conversations.ts:84](https://github.com/getsen
 
 > **lastSeenAt**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:83](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L83)
+Defined in: [junior/src/reporting/conversations.ts:84](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L84)
 
 #### Inherited from
 
@@ -139,7 +139,7 @@ Defined in: [junior/src/reporting/conversations.ts:83](https://github.com/getsen
 
 > `optional` **requesterIdentity?**: [`RequesterIdentity`](/reference/api/interfaces/requesteridentity/)
 
-Defined in: [junior/src/reporting/conversations.ts:87](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L87)
+Defined in: [junior/src/reporting/conversations.ts:88](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L88)
 
 #### Inherited from
 
@@ -151,7 +151,7 @@ Defined in: [junior/src/reporting/conversations.ts:87](https://github.com/getsen
 
 > `optional` **sentryConversationUrl?**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:90](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L90)
+Defined in: [junior/src/reporting/conversations.ts:91](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L91)
 
 #### Inherited from
 
@@ -163,7 +163,7 @@ Defined in: [junior/src/reporting/conversations.ts:90](https://github.com/getsen
 
 > `optional` **sentryTraceUrl?**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:91](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L91)
+Defined in: [junior/src/reporting/conversations.ts:92](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L92)
 
 #### Inherited from
 
@@ -175,7 +175,7 @@ Defined in: [junior/src/reporting/conversations.ts:91](https://github.com/getsen
 
 > **startedAt**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:82](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L82)
+Defined in: [junior/src/reporting/conversations.ts:83](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L83)
 
 #### Inherited from
 
@@ -187,7 +187,7 @@ Defined in: [junior/src/reporting/conversations.ts:82](https://github.com/getsen
 
 > **status**: [`ConversationReportStatus`](/reference/api/type-aliases/conversationreportstatus/)
 
-Defined in: [junior/src/reporting/conversations.ts:81](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L81)
+Defined in: [junior/src/reporting/conversations.ts:82](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L82)
 
 #### Inherited from
 
@@ -199,7 +199,7 @@ Defined in: [junior/src/reporting/conversations.ts:81](https://github.com/getsen
 
 > **surface**: [`ConversationSurface`](/reference/api/type-aliases/conversationsurface/)
 
-Defined in: [junior/src/reporting/conversations.ts:86](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L86)
+Defined in: [junior/src/reporting/conversations.ts:87](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L87)
 
 #### Inherited from
 
@@ -211,7 +211,7 @@ Defined in: [junior/src/reporting/conversations.ts:86](https://github.com/getsen
 
 > `optional` **traceId?**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:92](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L92)
+Defined in: [junior/src/reporting/conversations.ts:93](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L93)
 
 #### Inherited from
 
@@ -223,7 +223,7 @@ Defined in: [junior/src/reporting/conversations.ts:92](https://github.com/getsen
 
 > **transcript**: [`TranscriptMessage`](/reference/api/interfaces/transcriptmessage/)[]
 
-Defined in: [junior/src/reporting/conversations.ts:143](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L143)
+Defined in: [junior/src/reporting/conversations.ts:144](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L144)
 
 ---
 
@@ -231,7 +231,7 @@ Defined in: [junior/src/reporting/conversations.ts:143](https://github.com/getse
 
 > **transcriptAvailable**: `boolean`
 
-Defined in: [junior/src/reporting/conversations.ts:138](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L138)
+Defined in: [junior/src/reporting/conversations.ts:139](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L139)
 
 ---
 
@@ -239,7 +239,7 @@ Defined in: [junior/src/reporting/conversations.ts:138](https://github.com/getse
 
 > `optional` **transcriptMessageCount?**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:140](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L140)
+Defined in: [junior/src/reporting/conversations.ts:141](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L141)
 
 ---
 
@@ -247,7 +247,7 @@ Defined in: [junior/src/reporting/conversations.ts:140](https://github.com/getse
 
 > `optional` **transcriptMetadata?**: [`TranscriptMessage`](/reference/api/interfaces/transcriptmessage/)[]
 
-Defined in: [junior/src/reporting/conversations.ts:139](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L139)
+Defined in: [junior/src/reporting/conversations.ts:140](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L140)
 
 ---
 
@@ -255,7 +255,7 @@ Defined in: [junior/src/reporting/conversations.ts:139](https://github.com/getse
 
 > `optional` **transcriptRedacted?**: `boolean`
 
-Defined in: [junior/src/reporting/conversations.ts:141](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L141)
+Defined in: [junior/src/reporting/conversations.ts:142](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L142)
 
 ---
 
@@ -263,4 +263,4 @@ Defined in: [junior/src/reporting/conversations.ts:141](https://github.com/getse
 
 > `optional` **transcriptRedactionReason?**: `"non_public_conversation"`
 
-Defined in: [junior/src/reporting/conversations.ts:142](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L142)
+Defined in: [junior/src/reporting/conversations.ts:143](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L143)

--- a/packages/docs/src/content/docs/reference/api/interfaces/ConversationStatsItem.md
+++ b/packages/docs/src/content/docs/reference/api/interfaces/ConversationStatsItem.md
@@ -5,7 +5,7 @@ prev: false
 title: "ConversationStatsItem"
 ---
 
-Defined in: [junior/src/reporting/conversations.ts:160](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L160)
+Defined in: [junior/src/reporting/conversations.ts:161](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L161)
 
 ## Properties
 
@@ -13,7 +13,7 @@ Defined in: [junior/src/reporting/conversations.ts:160](https://github.com/getse
 
 > **active**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:161](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L161)
+Defined in: [junior/src/reporting/conversations.ts:162](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L162)
 
 ---
 
@@ -21,7 +21,7 @@ Defined in: [junior/src/reporting/conversations.ts:161](https://github.com/getse
 
 > **conversations**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:162](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L162)
+Defined in: [junior/src/reporting/conversations.ts:163](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L163)
 
 ---
 
@@ -29,7 +29,7 @@ Defined in: [junior/src/reporting/conversations.ts:162](https://github.com/getse
 
 > **durationMs**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:163](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L163)
+Defined in: [junior/src/reporting/conversations.ts:164](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L164)
 
 ---
 
@@ -37,7 +37,7 @@ Defined in: [junior/src/reporting/conversations.ts:163](https://github.com/getse
 
 > **failed**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:164](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L164)
+Defined in: [junior/src/reporting/conversations.ts:165](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L165)
 
 ---
 
@@ -45,7 +45,7 @@ Defined in: [junior/src/reporting/conversations.ts:164](https://github.com/getse
 
 > **hung**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:165](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L165)
+Defined in: [junior/src/reporting/conversations.ts:166](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L166)
 
 ---
 
@@ -53,7 +53,7 @@ Defined in: [junior/src/reporting/conversations.ts:165](https://github.com/getse
 
 > **label**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:166](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L166)
+Defined in: [junior/src/reporting/conversations.ts:167](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L167)
 
 ---
 
@@ -61,7 +61,7 @@ Defined in: [junior/src/reporting/conversations.ts:166](https://github.com/getse
 
 > **runs**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:167](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L167)
+Defined in: [junior/src/reporting/conversations.ts:168](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L168)
 
 ---
 
@@ -69,4 +69,4 @@ Defined in: [junior/src/reporting/conversations.ts:167](https://github.com/getse
 
 > `optional` **tokens?**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:168](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L168)
+Defined in: [junior/src/reporting/conversations.ts:169](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L169)

--- a/packages/docs/src/content/docs/reference/api/interfaces/ConversationStatsReport.md
+++ b/packages/docs/src/content/docs/reference/api/interfaces/ConversationStatsReport.md
@@ -5,7 +5,7 @@ prev: false
 title: "ConversationStatsReport"
 ---
 
-Defined in: [junior/src/reporting/conversations.ts:171](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L171)
+Defined in: [junior/src/reporting/conversations.ts:172](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L172)
 
 ## Properties
 
@@ -13,7 +13,7 @@ Defined in: [junior/src/reporting/conversations.ts:171](https://github.com/getse
 
 > **active**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:172](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L172)
+Defined in: [junior/src/reporting/conversations.ts:173](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L173)
 
 ---
 
@@ -21,7 +21,7 @@ Defined in: [junior/src/reporting/conversations.ts:172](https://github.com/getse
 
 > **conversations**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:173](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L173)
+Defined in: [junior/src/reporting/conversations.ts:174](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L174)
 
 ---
 
@@ -29,7 +29,7 @@ Defined in: [junior/src/reporting/conversations.ts:173](https://github.com/getse
 
 > **durationMs**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:174](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L174)
+Defined in: [junior/src/reporting/conversations.ts:175](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L175)
 
 ---
 
@@ -37,7 +37,7 @@ Defined in: [junior/src/reporting/conversations.ts:174](https://github.com/getse
 
 > **failed**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:175](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L175)
+Defined in: [junior/src/reporting/conversations.ts:176](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L176)
 
 ---
 
@@ -45,7 +45,7 @@ Defined in: [junior/src/reporting/conversations.ts:175](https://github.com/getse
 
 > **generatedAt**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:176](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L176)
+Defined in: [junior/src/reporting/conversations.ts:177](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L177)
 
 ---
 
@@ -53,7 +53,7 @@ Defined in: [junior/src/reporting/conversations.ts:176](https://github.com/getse
 
 > **hung**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:177](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L177)
+Defined in: [junior/src/reporting/conversations.ts:178](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L178)
 
 ---
 
@@ -61,7 +61,7 @@ Defined in: [junior/src/reporting/conversations.ts:177](https://github.com/getse
 
 > **locations**: [`ConversationStatsItem`](/reference/api/interfaces/conversationstatsitem/)[]
 
-Defined in: [junior/src/reporting/conversations.ts:178](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L178)
+Defined in: [junior/src/reporting/conversations.ts:179](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L179)
 
 ---
 
@@ -69,7 +69,7 @@ Defined in: [junior/src/reporting/conversations.ts:178](https://github.com/getse
 
 > **requesters**: [`ConversationStatsItem`](/reference/api/interfaces/conversationstatsitem/)[]
 
-Defined in: [junior/src/reporting/conversations.ts:179](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L179)
+Defined in: [junior/src/reporting/conversations.ts:180](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L180)
 
 ---
 
@@ -77,7 +77,7 @@ Defined in: [junior/src/reporting/conversations.ts:179](https://github.com/getse
 
 > **runs**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:185](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L185)
+Defined in: [junior/src/reporting/conversations.ts:186](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L186)
 
 ---
 
@@ -85,7 +85,7 @@ Defined in: [junior/src/reporting/conversations.ts:185](https://github.com/getse
 
 > **sampleLimit**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:180](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L180)
+Defined in: [junior/src/reporting/conversations.ts:181](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L181)
 
 ---
 
@@ -93,7 +93,7 @@ Defined in: [junior/src/reporting/conversations.ts:180](https://github.com/getse
 
 > **sampleSize**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:181](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L181)
+Defined in: [junior/src/reporting/conversations.ts:182](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L182)
 
 ---
 
@@ -101,7 +101,7 @@ Defined in: [junior/src/reporting/conversations.ts:181](https://github.com/getse
 
 > **source**: `"conversation_index"`
 
-Defined in: [junior/src/reporting/conversations.ts:182](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L182)
+Defined in: [junior/src/reporting/conversations.ts:183](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L183)
 
 ---
 
@@ -109,7 +109,7 @@ Defined in: [junior/src/reporting/conversations.ts:182](https://github.com/getse
 
 > `optional` **tokens?**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:183](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L183)
+Defined in: [junior/src/reporting/conversations.ts:184](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L184)
 
 ---
 
@@ -117,7 +117,7 @@ Defined in: [junior/src/reporting/conversations.ts:183](https://github.com/getse
 
 > **truncated**: `boolean`
 
-Defined in: [junior/src/reporting/conversations.ts:184](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L184)
+Defined in: [junior/src/reporting/conversations.ts:185](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L185)
 
 ---
 
@@ -125,7 +125,7 @@ Defined in: [junior/src/reporting/conversations.ts:184](https://github.com/getse
 
 > **windowEnd**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:186](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L186)
+Defined in: [junior/src/reporting/conversations.ts:187](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L187)
 
 ---
 
@@ -133,4 +133,4 @@ Defined in: [junior/src/reporting/conversations.ts:186](https://github.com/getse
 
 > **windowStart**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:187](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L187)
+Defined in: [junior/src/reporting/conversations.ts:188](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L188)

--- a/packages/docs/src/content/docs/reference/api/interfaces/ConversationSummaryReport.md
+++ b/packages/docs/src/content/docs/reference/api/interfaces/ConversationSummaryReport.md
@@ -5,7 +5,7 @@ prev: false
 title: "ConversationSummaryReport"
 ---
 
-Defined in: [junior/src/reporting/conversations.ts:74](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L74)
+Defined in: [junior/src/reporting/conversations.ts:75](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L75)
 
 ## Extended by
 
@@ -17,7 +17,7 @@ Defined in: [junior/src/reporting/conversations.ts:74](https://github.com/getsen
 
 > `optional` **channel?**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:88](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L88)
+Defined in: [junior/src/reporting/conversations.ts:89](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L89)
 
 ---
 
@@ -25,7 +25,7 @@ Defined in: [junior/src/reporting/conversations.ts:88](https://github.com/getsen
 
 > `optional` **channelName?**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:89](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L89)
+Defined in: [junior/src/reporting/conversations.ts:90](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L90)
 
 ---
 
@@ -33,7 +33,7 @@ Defined in: [junior/src/reporting/conversations.ts:89](https://github.com/getsen
 
 > `optional` **completedAt?**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:85](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L85)
+Defined in: [junior/src/reporting/conversations.ts:86](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L86)
 
 ---
 
@@ -41,7 +41,7 @@ Defined in: [junior/src/reporting/conversations.ts:85](https://github.com/getsen
 
 > **conversationId**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:79](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L79)
+Defined in: [junior/src/reporting/conversations.ts:80](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L80)
 
 ---
 
@@ -49,7 +49,7 @@ Defined in: [junior/src/reporting/conversations.ts:79](https://github.com/getsen
 
 > **cumulativeDurationMs**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:77](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L77)
+Defined in: [junior/src/reporting/conversations.ts:78](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L78)
 
 ---
 
@@ -57,7 +57,7 @@ Defined in: [junior/src/reporting/conversations.ts:77](https://github.com/getsen
 
 > `optional` **cumulativeUsage?**: [`ConversationUsage`](/reference/api/interfaces/conversationusage/)
 
-Defined in: [junior/src/reporting/conversations.ts:78](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L78)
+Defined in: [junior/src/reporting/conversations.ts:79](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L79)
 
 ---
 
@@ -65,7 +65,7 @@ Defined in: [junior/src/reporting/conversations.ts:78](https://github.com/getsen
 
 > **displayTitle**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:76](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L76)
+Defined in: [junior/src/reporting/conversations.ts:77](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L77)
 
 Always-populated display title, with privacy redaction applied first.
 
@@ -75,7 +75,7 @@ Always-populated display title, with privacy redaction applied first.
 
 > **id**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:80](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L80)
+Defined in: [junior/src/reporting/conversations.ts:81](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L81)
 
 ---
 
@@ -83,7 +83,7 @@ Defined in: [junior/src/reporting/conversations.ts:80](https://github.com/getsen
 
 > **lastProgressAt**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:84](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L84)
+Defined in: [junior/src/reporting/conversations.ts:85](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L85)
 
 ---
 
@@ -91,7 +91,7 @@ Defined in: [junior/src/reporting/conversations.ts:84](https://github.com/getsen
 
 > **lastSeenAt**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:83](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L83)
+Defined in: [junior/src/reporting/conversations.ts:84](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L84)
 
 ---
 
@@ -99,7 +99,7 @@ Defined in: [junior/src/reporting/conversations.ts:83](https://github.com/getsen
 
 > `optional` **requesterIdentity?**: [`RequesterIdentity`](/reference/api/interfaces/requesteridentity/)
 
-Defined in: [junior/src/reporting/conversations.ts:87](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L87)
+Defined in: [junior/src/reporting/conversations.ts:88](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L88)
 
 ---
 
@@ -107,7 +107,7 @@ Defined in: [junior/src/reporting/conversations.ts:87](https://github.com/getsen
 
 > `optional` **sentryConversationUrl?**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:90](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L90)
+Defined in: [junior/src/reporting/conversations.ts:91](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L91)
 
 ---
 
@@ -115,7 +115,7 @@ Defined in: [junior/src/reporting/conversations.ts:90](https://github.com/getsen
 
 > `optional` **sentryTraceUrl?**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:91](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L91)
+Defined in: [junior/src/reporting/conversations.ts:92](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L92)
 
 ---
 
@@ -123,7 +123,7 @@ Defined in: [junior/src/reporting/conversations.ts:91](https://github.com/getsen
 
 > **startedAt**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:82](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L82)
+Defined in: [junior/src/reporting/conversations.ts:83](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L83)
 
 ---
 
@@ -131,7 +131,7 @@ Defined in: [junior/src/reporting/conversations.ts:82](https://github.com/getsen
 
 > **status**: [`ConversationReportStatus`](/reference/api/type-aliases/conversationreportstatus/)
 
-Defined in: [junior/src/reporting/conversations.ts:81](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L81)
+Defined in: [junior/src/reporting/conversations.ts:82](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L82)
 
 ---
 
@@ -139,7 +139,7 @@ Defined in: [junior/src/reporting/conversations.ts:81](https://github.com/getsen
 
 > **surface**: [`ConversationSurface`](/reference/api/type-aliases/conversationsurface/)
 
-Defined in: [junior/src/reporting/conversations.ts:86](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L86)
+Defined in: [junior/src/reporting/conversations.ts:87](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L87)
 
 ---
 
@@ -147,4 +147,4 @@ Defined in: [junior/src/reporting/conversations.ts:86](https://github.com/getsen
 
 > `optional` **traceId?**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:92](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L92)
+Defined in: [junior/src/reporting/conversations.ts:93](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L93)

--- a/packages/docs/src/content/docs/reference/api/interfaces/ConversationUsage.md
+++ b/packages/docs/src/content/docs/reference/api/interfaces/ConversationUsage.md
@@ -5,7 +5,7 @@ prev: false
 title: "ConversationUsage"
 ---
 
-Defined in: [junior/src/reporting/conversations.ts:59](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L59)
+Defined in: [junior/src/reporting/conversations.ts:60](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L60)
 
 ## Properties
 
@@ -13,7 +13,7 @@ Defined in: [junior/src/reporting/conversations.ts:59](https://github.com/getsen
 
 > `optional` **cacheCreationTokens?**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:63](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L63)
+Defined in: [junior/src/reporting/conversations.ts:64](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L64)
 
 ---
 
@@ -21,7 +21,7 @@ Defined in: [junior/src/reporting/conversations.ts:63](https://github.com/getsen
 
 > `optional` **cachedInputTokens?**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:62](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L62)
+Defined in: [junior/src/reporting/conversations.ts:63](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L63)
 
 ---
 
@@ -29,7 +29,7 @@ Defined in: [junior/src/reporting/conversations.ts:62](https://github.com/getsen
 
 > `optional` **inputTokens?**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:60](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L60)
+Defined in: [junior/src/reporting/conversations.ts:61](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L61)
 
 ---
 
@@ -37,7 +37,7 @@ Defined in: [junior/src/reporting/conversations.ts:60](https://github.com/getsen
 
 > `optional` **outputTokens?**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:61](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L61)
+Defined in: [junior/src/reporting/conversations.ts:62](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L62)
 
 ---
 
@@ -45,4 +45,4 @@ Defined in: [junior/src/reporting/conversations.ts:61](https://github.com/getsen
 
 > `optional` **totalTokens?**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:64](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L64)
+Defined in: [junior/src/reporting/conversations.ts:65](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L65)

--- a/packages/docs/src/content/docs/reference/api/interfaces/JuniorAppOptions.md
+++ b/packages/docs/src/content/docs/reference/api/interfaces/JuniorAppOptions.md
@@ -5,7 +5,7 @@ prev: false
 title: "JuniorAppOptions"
 ---
 
-Defined in: [junior/src/app.ts:58](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L58)
+Defined in: [junior/src/app.ts:60](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L60)
 
 ## Properties
 
@@ -13,7 +13,7 @@ Defined in: [junior/src/app.ts:58](https://github.com/getsentry/junior/blob/main
 
 > `optional` **configDefaults?**: `Record`\<`string`, `unknown`\>
 
-Defined in: [junior/src/app.ts:67](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L67)
+Defined in: [junior/src/app.ts:69](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L69)
 
 Install-wide provider defaults (`provider.key` format). Channel overrides take precedence.
 
@@ -23,7 +23,7 @@ Install-wide provider defaults (`provider.key` format). Channel overrides take p
 
 > `optional` **conversationWork?**: `VercelConversationWorkCallbackOptions`
 
-Defined in: [junior/src/app.ts:69](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L69)
+Defined in: [junior/src/app.ts:71](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L71)
 
 Queue consumer wiring for the durable conversation worker.
 
@@ -33,7 +33,7 @@ Queue consumer wiring for the durable conversation worker.
 
 > `optional` **plugins?**: [`JuniorPluginSet`](/reference/api/interfaces/juniorpluginset/)
 
-Defined in: [junior/src/app.ts:71](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L71)
+Defined in: [junior/src/app.ts:73](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L73)
 
 Direct plugin set override. Usually omitted when `juniorNitro()` uses a plugin module.
 
@@ -43,7 +43,7 @@ Direct plugin set override. Usually omitted when `juniorNitro()` uses a plugin m
 
 > `optional` **sandbox?**: `object`
 
-Defined in: [junior/src/app.ts:73](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L73)
+Defined in: [junior/src/app.ts:75](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L75)
 
 Sandbox execution options.
 
@@ -61,7 +61,7 @@ Entries may be exact domains or leading wildcard domains such as
 
 > `optional` **slack?**: `object`
 
-Defined in: [junior/src/app.ts:60](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L60)
+Defined in: [junior/src/app.ts:62](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L62)
 
 Slack-specific overrides applied after env parsing.
 
@@ -83,4 +83,4 @@ Slack emoji shown while Junior is processing. Defaults to `eyes`.
 
 > `optional` **waitUntil?**: `WaitUntilFn`
 
-Defined in: [junior/src/app.ts:81](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L81)
+Defined in: [junior/src/app.ts:83](https://github.com/getsentry/junior/blob/main/packages/junior/src/app.ts#L83)

--- a/packages/docs/src/content/docs/reference/api/interfaces/PluginOperationalReport.md
+++ b/packages/docs/src/content/docs/reference/api/interfaces/PluginOperationalReport.md
@@ -5,7 +5,7 @@ prev: false
 title: "PluginOperationalReport"
 ---
 
-Defined in: [junior-plugin-api/src/index.ts:318](https://github.com/getsentry/junior/blob/main/packages/junior-plugin-api/src/index.ts#L318)
+Defined in: [junior-plugin-api/src/index.ts:385](https://github.com/getsentry/junior/blob/main/packages/junior-plugin-api/src/index.ts#L385)
 
 ## Extends
 
@@ -17,7 +17,7 @@ Defined in: [junior-plugin-api/src/index.ts:318](https://github.com/getsentry/ju
 
 > `optional` **generatedAt?**: `string`
 
-Defined in: [junior-plugin-api/src/index.ts:312](https://github.com/getsentry/junior/blob/main/packages/junior-plugin-api/src/index.ts#L312)
+Defined in: [junior-plugin-api/src/index.ts:379](https://github.com/getsentry/junior/blob/main/packages/junior-plugin-api/src/index.ts#L379)
 
 #### Inherited from
 
@@ -29,7 +29,7 @@ Defined in: [junior-plugin-api/src/index.ts:312](https://github.com/getsentry/ju
 
 > `optional` **metrics?**: `PluginOperationalMetric`[]
 
-Defined in: [junior-plugin-api/src/index.ts:313](https://github.com/getsentry/junior/blob/main/packages/junior-plugin-api/src/index.ts#L313)
+Defined in: [junior-plugin-api/src/index.ts:380](https://github.com/getsentry/junior/blob/main/packages/junior-plugin-api/src/index.ts#L380)
 
 #### Inherited from
 
@@ -41,7 +41,7 @@ Defined in: [junior-plugin-api/src/index.ts:313](https://github.com/getsentry/ju
 
 > **pluginName**: `string`
 
-Defined in: [junior-plugin-api/src/index.ts:319](https://github.com/getsentry/junior/blob/main/packages/junior-plugin-api/src/index.ts#L319)
+Defined in: [junior-plugin-api/src/index.ts:386](https://github.com/getsentry/junior/blob/main/packages/junior-plugin-api/src/index.ts#L386)
 
 ---
 
@@ -49,7 +49,7 @@ Defined in: [junior-plugin-api/src/index.ts:319](https://github.com/getsentry/ju
 
 > `optional` **recordSets?**: `PluginOperationalRecordSet`[]
 
-Defined in: [junior-plugin-api/src/index.ts:314](https://github.com/getsentry/junior/blob/main/packages/junior-plugin-api/src/index.ts#L314)
+Defined in: [junior-plugin-api/src/index.ts:381](https://github.com/getsentry/junior/blob/main/packages/junior-plugin-api/src/index.ts#L381)
 
 #### Inherited from
 
@@ -61,7 +61,7 @@ Defined in: [junior-plugin-api/src/index.ts:314](https://github.com/getsentry/ju
 
 > `optional` **title?**: `string`
 
-Defined in: [junior-plugin-api/src/index.ts:315](https://github.com/getsentry/junior/blob/main/packages/junior-plugin-api/src/index.ts#L315)
+Defined in: [junior-plugin-api/src/index.ts:382](https://github.com/getsentry/junior/blob/main/packages/junior-plugin-api/src/index.ts#L382)
 
 #### Inherited from
 

--- a/packages/docs/src/content/docs/reference/api/interfaces/RequesterIdentity.md
+++ b/packages/docs/src/content/docs/reference/api/interfaces/RequesterIdentity.md
@@ -5,7 +5,7 @@ prev: false
 title: "RequesterIdentity"
 ---
 
-Defined in: [junior/src/reporting/conversations.ts:67](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L67)
+Defined in: [junior/src/reporting/conversations.ts:68](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L68)
 
 ## Properties
 
@@ -13,7 +13,7 @@ Defined in: [junior/src/reporting/conversations.ts:67](https://github.com/getsen
 
 > `optional` **email?**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:68](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L68)
+Defined in: [junior/src/reporting/conversations.ts:69](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L69)
 
 ---
 
@@ -21,7 +21,7 @@ Defined in: [junior/src/reporting/conversations.ts:68](https://github.com/getsen
 
 > `optional` **fullName?**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:69](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L69)
+Defined in: [junior/src/reporting/conversations.ts:70](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L70)
 
 ---
 
@@ -29,7 +29,7 @@ Defined in: [junior/src/reporting/conversations.ts:69](https://github.com/getsen
 
 > `optional` **slackUserId?**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:70](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L70)
+Defined in: [junior/src/reporting/conversations.ts:71](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L71)
 
 ---
 
@@ -37,4 +37,4 @@ Defined in: [junior/src/reporting/conversations.ts:70](https://github.com/getsen
 
 > `optional` **slackUserName?**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:71](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L71)
+Defined in: [junior/src/reporting/conversations.ts:72](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L72)

--- a/packages/docs/src/content/docs/reference/api/interfaces/TranscriptMessage.md
+++ b/packages/docs/src/content/docs/reference/api/interfaces/TranscriptMessage.md
@@ -5,7 +5,7 @@ prev: false
 title: "TranscriptMessage"
 ---
 
-Defined in: [junior/src/reporting/conversations.ts:131](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L131)
+Defined in: [junior/src/reporting/conversations.ts:132](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L132)
 
 ## Properties
 
@@ -13,7 +13,7 @@ Defined in: [junior/src/reporting/conversations.ts:131](https://github.com/getse
 
 > **parts**: [`TranscriptPart`](/reference/api/interfaces/transcriptpart/)[]
 
-Defined in: [junior/src/reporting/conversations.ts:132](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L132)
+Defined in: [junior/src/reporting/conversations.ts:133](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L133)
 
 ---
 
@@ -21,7 +21,7 @@ Defined in: [junior/src/reporting/conversations.ts:132](https://github.com/getse
 
 > **role**: [`TranscriptRole`](/reference/api/type-aliases/transcriptrole/)
 
-Defined in: [junior/src/reporting/conversations.ts:133](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L133)
+Defined in: [junior/src/reporting/conversations.ts:134](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L134)
 
 ---
 
@@ -29,4 +29,4 @@ Defined in: [junior/src/reporting/conversations.ts:133](https://github.com/getse
 
 > `optional` **timestamp?**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:134](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L134)
+Defined in: [junior/src/reporting/conversations.ts:135](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L135)

--- a/packages/docs/src/content/docs/reference/api/interfaces/TranscriptPart.md
+++ b/packages/docs/src/content/docs/reference/api/interfaces/TranscriptPart.md
@@ -5,7 +5,7 @@ prev: false
 title: "TranscriptPart"
 ---
 
-Defined in: [junior/src/reporting/conversations.ts:102](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L102)
+Defined in: [junior/src/reporting/conversations.ts:103](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L103)
 
 ## Properties
 
@@ -13,7 +13,7 @@ Defined in: [junior/src/reporting/conversations.ts:102](https://github.com/getse
 
 > `optional` **bytes?**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:103](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L103)
+Defined in: [junior/src/reporting/conversations.ts:104](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L104)
 
 ---
 
@@ -21,7 +21,7 @@ Defined in: [junior/src/reporting/conversations.ts:103](https://github.com/getse
 
 > `optional` **chars?**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:104](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L104)
+Defined in: [junior/src/reporting/conversations.ts:105](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L105)
 
 ---
 
@@ -29,7 +29,7 @@ Defined in: [junior/src/reporting/conversations.ts:104](https://github.com/getse
 
 > `optional` **id?**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:105](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L105)
+Defined in: [junior/src/reporting/conversations.ts:106](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L106)
 
 ---
 
@@ -37,7 +37,7 @@ Defined in: [junior/src/reporting/conversations.ts:105](https://github.com/getse
 
 > `optional` **input?**: `unknown`
 
-Defined in: [junior/src/reporting/conversations.ts:106](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L106)
+Defined in: [junior/src/reporting/conversations.ts:107](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L107)
 
 ---
 
@@ -45,7 +45,7 @@ Defined in: [junior/src/reporting/conversations.ts:106](https://github.com/getse
 
 > `optional` **inputKeys?**: `string`[]
 
-Defined in: [junior/src/reporting/conversations.ts:107](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L107)
+Defined in: [junior/src/reporting/conversations.ts:108](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L108)
 
 ---
 
@@ -53,7 +53,7 @@ Defined in: [junior/src/reporting/conversations.ts:107](https://github.com/getse
 
 > `optional` **inputSizeBytes?**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:108](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L108)
+Defined in: [junior/src/reporting/conversations.ts:109](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L109)
 
 ---
 
@@ -61,7 +61,7 @@ Defined in: [junior/src/reporting/conversations.ts:108](https://github.com/getse
 
 > `optional` **inputSizeChars?**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:109](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L109)
+Defined in: [junior/src/reporting/conversations.ts:110](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L110)
 
 ---
 
@@ -69,7 +69,7 @@ Defined in: [junior/src/reporting/conversations.ts:109](https://github.com/getse
 
 > `optional` **inputType?**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:110](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L110)
+Defined in: [junior/src/reporting/conversations.ts:111](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L111)
 
 ---
 
@@ -77,7 +77,7 @@ Defined in: [junior/src/reporting/conversations.ts:110](https://github.com/getse
 
 > `optional` **name?**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:111](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L111)
+Defined in: [junior/src/reporting/conversations.ts:112](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L112)
 
 ---
 
@@ -85,7 +85,7 @@ Defined in: [junior/src/reporting/conversations.ts:111](https://github.com/getse
 
 > `optional` **output?**: `unknown`
 
-Defined in: [junior/src/reporting/conversations.ts:112](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L112)
+Defined in: [junior/src/reporting/conversations.ts:113](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L113)
 
 ---
 
@@ -93,7 +93,7 @@ Defined in: [junior/src/reporting/conversations.ts:112](https://github.com/getse
 
 > `optional` **outputKeys?**: `string`[]
 
-Defined in: [junior/src/reporting/conversations.ts:113](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L113)
+Defined in: [junior/src/reporting/conversations.ts:114](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L114)
 
 ---
 
@@ -101,7 +101,7 @@ Defined in: [junior/src/reporting/conversations.ts:113](https://github.com/getse
 
 > `optional` **outputSizeBytes?**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:114](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L114)
+Defined in: [junior/src/reporting/conversations.ts:115](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L115)
 
 ---
 
@@ -109,7 +109,7 @@ Defined in: [junior/src/reporting/conversations.ts:114](https://github.com/getse
 
 > `optional` **outputSizeChars?**: `number`
 
-Defined in: [junior/src/reporting/conversations.ts:115](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L115)
+Defined in: [junior/src/reporting/conversations.ts:116](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L116)
 
 ---
 
@@ -117,7 +117,7 @@ Defined in: [junior/src/reporting/conversations.ts:115](https://github.com/getse
 
 > `optional` **outputType?**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:116](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L116)
+Defined in: [junior/src/reporting/conversations.ts:117](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L117)
 
 ---
 
@@ -125,7 +125,7 @@ Defined in: [junior/src/reporting/conversations.ts:116](https://github.com/getse
 
 > `optional` **redacted?**: `boolean`
 
-Defined in: [junior/src/reporting/conversations.ts:117](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L117)
+Defined in: [junior/src/reporting/conversations.ts:118](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L118)
 
 ---
 
@@ -133,7 +133,7 @@ Defined in: [junior/src/reporting/conversations.ts:117](https://github.com/getse
 
 > `optional` **sourceType?**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:118](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L118)
+Defined in: [junior/src/reporting/conversations.ts:119](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L119)
 
 ---
 
@@ -141,7 +141,7 @@ Defined in: [junior/src/reporting/conversations.ts:118](https://github.com/getse
 
 > `optional` **text?**: `string`
 
-Defined in: [junior/src/reporting/conversations.ts:119](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L119)
+Defined in: [junior/src/reporting/conversations.ts:120](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L120)
 
 ---
 
@@ -149,4 +149,4 @@ Defined in: [junior/src/reporting/conversations.ts:119](https://github.com/getse
 
 > **type**: [`TranscriptPartType`](/reference/api/type-aliases/transcriptparttype/)
 
-Defined in: [junior/src/reporting/conversations.ts:120](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L120)
+Defined in: [junior/src/reporting/conversations.ts:121](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L121)

--- a/packages/docs/src/content/docs/reference/api/type-aliases/ConversationReportStatus.md
+++ b/packages/docs/src/content/docs/reference/api/type-aliases/ConversationReportStatus.md
@@ -7,4 +7,4 @@ title: "ConversationReportStatus"
 
 > **ConversationReportStatus** = `"active"` \| `"completed"` \| `"failed"` \| `"hung"` \| `"superseded"`
 
-Defined in: [junior/src/reporting/conversations.ts:50](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L50)
+Defined in: [junior/src/reporting/conversations.ts:51](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L51)

--- a/packages/docs/src/content/docs/reference/api/type-aliases/ConversationSurface.md
+++ b/packages/docs/src/content/docs/reference/api/type-aliases/ConversationSurface.md
@@ -7,4 +7,4 @@ title: "ConversationSurface"
 
 > **ConversationSurface** = `"api"` \| `"internal"` \| `"scheduler"` \| `"slack"`
 
-Defined in: [junior/src/reporting/conversations.ts:57](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L57)
+Defined in: [junior/src/reporting/conversations.ts:58](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L58)

--- a/packages/docs/src/content/docs/reference/api/type-aliases/TranscriptPartType.md
+++ b/packages/docs/src/content/docs/reference/api/type-aliases/TranscriptPartType.md
@@ -7,4 +7,4 @@ title: "TranscriptPartType"
 
 > **TranscriptPartType** = `"text"` \| `"thinking"` \| `"tool_call"` \| `"tool_result"` \| `"unknown"`
 
-Defined in: [junior/src/reporting/conversations.ts:95](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L95)
+Defined in: [junior/src/reporting/conversations.ts:96](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L96)

--- a/packages/docs/src/content/docs/reference/api/type-aliases/TranscriptRole.md
+++ b/packages/docs/src/content/docs/reference/api/type-aliases/TranscriptRole.md
@@ -7,4 +7,4 @@ title: "TranscriptRole"
 
 > **TranscriptRole** = `"assistant"` \| `"system"` \| `"tool"` \| `"toolResult"` \| `"unknown"` \| `"user"`
 
-Defined in: [junior/src/reporting/conversations.ts:123](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L123)
+Defined in: [junior/src/reporting/conversations.ts:124](https://github.com/getsentry/junior/blob/main/packages/junior/src/reporting/conversations.ts#L124)

--- a/packages/junior-plugin-api/src/index.ts
+++ b/packages/junior-plugin-api/src/index.ts
@@ -38,6 +38,26 @@ export const destinationSchema = z.discriminatedUnion("platform", [
   localDestinationSchema,
 ]);
 
+/** Runtime-owned Slack coordinates for the inbound invocation. */
+export const slackSourceSchema = z
+  .object({
+    platform: z.literal("slack"),
+    teamId: slackTeamIdSchema,
+    channelId: slackConversationIdSchema,
+    messageTs: nonBlankStringSchema.optional(),
+    threadTs: nonBlankStringSchema.optional(),
+  })
+  .strict();
+
+/** Runtime-owned local CLI coordinates for the inbound invocation. */
+export const localSourceSchema = localDestinationSchema;
+
+/** Runtime-owned provider-neutral coordinates for the inbound invocation. */
+export const sourceSchema = z.discriminatedUnion("platform", [
+  slackSourceSchema,
+  localSourceSchema,
+]);
+
 /** Stable user credential subject shape accepted from plugins. */
 export const agentPluginCredentialSubjectSchema = z
   .object({
@@ -127,6 +147,9 @@ export const dispatchOptionsSchema = z
 export type Requester = z.output<typeof requesterSchema>;
 export type SlackRequester = z.output<typeof slackRequesterSchema>;
 export type LocalRequester = z.output<typeof localRequesterSchema>;
+export type Source = z.output<typeof sourceSchema>;
+export type SlackSource = Extract<Source, { platform: "slack" }>;
+export type LocalSource = Extract<Source, { platform: "local" }>;
 
 export interface AgentPluginMetadata {
   name: string;
@@ -160,6 +183,32 @@ export interface AgentPluginContext {
   log: AgentPluginLogger;
   plugin: AgentPluginMetadata;
 }
+
+interface BaseInvocationContext {
+  /**
+   * Opaque Junior conversation/session identity for this invocation.
+   * Interactive Slack turns use `slack:{channelId}:{threadTs}`.
+   */
+  conversationId?: string;
+}
+
+export interface SlackInvocationContext extends BaseInvocationContext {
+  /** Runtime-owned default outbound destination for this invocation, if any. */
+  destination?: SlackDestination;
+  requester?: SlackRequester;
+  /** Runtime-owned source where the invocation came from. */
+  source: SlackSource;
+}
+
+export interface LocalInvocationContext extends BaseInvocationContext {
+  /** Runtime-owned default outbound destination for this invocation, if any. */
+  destination?: LocalDestination;
+  requester?: LocalRequester;
+  /** Runtime-owned source where the invocation came from. */
+  source: LocalSource;
+}
+
+export type InvocationContext = LocalInvocationContext | SlackInvocationContext;
 
 export interface AgentPluginSandbox {
   juniorRoot: string;
@@ -228,25 +277,15 @@ export interface AgentPluginToolDefinition<TInput = unknown> {
 
 export interface SlackToolRegistrationHookContext {
   /**
-   * Capabilities of `channelId` — the raw Slack conversation channel exposed to
-   * this plugin. Recomputed from `channelId`, not from `destination`.
+   * Capabilities of the source Slack conversation exposed to this plugin.
+   * Recomputed from `source.channelId`, not from `destination`.
    */
   channelCapabilities: {
     canAddReactions: boolean;
     canCreateCanvas: boolean;
     canPostToChannel: boolean;
   };
-  /**
-   * The raw Slack channel ID for this conversation — the DM or channel where
-   * this turn is happening, without any assistant-context-source override.
-   * Use this as the stable binding key for state scoped to a Slack conversation.
-   * `channelCapabilities` describes this channel.
-   */
-  channelId: string;
   credentialSubject?: AgentPluginCredentialSubject;
-  messageTs?: string;
-  teamId: string;
-  threadTs?: string;
 }
 
 interface BaseToolRegistrationHookContext extends AgentPluginContext {
@@ -261,21 +300,13 @@ interface BaseToolRegistrationHookContext extends AgentPluginContext {
   userText?: string;
 }
 
-interface SlackToolRegistrationContext extends BaseToolRegistrationHookContext {
-  /**
-   * Runtime-owned destination suitable for future autonomous dispatch. For
-   * Slack, this is the raw conversation channel, not a thread timestamp or
-   * assistant-context source channel.
-   */
-  destination: SlackDestination;
-  requester?: SlackRequester;
+interface SlackToolRegistrationContext
+  extends BaseToolRegistrationHookContext, SlackInvocationContext {
   slack: SlackToolRegistrationHookContext;
 }
 
-interface LocalToolRegistrationContext extends BaseToolRegistrationHookContext {
-  /** Runtime-owned local conversation destination. */
-  destination: LocalDestination;
-  requester?: LocalRequester;
+interface LocalToolRegistrationContext
+  extends BaseToolRegistrationHookContext, LocalInvocationContext {
   slack?: never;
 }
 

--- a/packages/junior-plugin-api/src/index.ts
+++ b/packages/junior-plugin-api/src/index.ts
@@ -47,17 +47,34 @@ export const agentPluginCredentialSubjectSchema = z
   })
   .strict();
 
-/** Runtime-provided requester identity visible to plugin hooks. */
-export const requesterSchema = z
+/** Shared exact actor profile fields for platform-scoped requesters. */
+const requesterProfileSchema = {
+  email: nonBlankStringSchema.optional(),
+  fullName: nonBlankStringSchema.optional(),
+  userId: exactActorUserIdSchema,
+  userName: nonBlankStringSchema.optional(),
+};
+
+export const slackRequesterSchema = z
   .object({
+    ...requesterProfileSchema,
     platform: z.literal("slack"),
     teamId: slackTeamIdSchema,
-    userId: exactActorUserIdSchema,
-    userName: nonBlankStringSchema.optional(),
-    fullName: nonBlankStringSchema.optional(),
-    email: nonBlankStringSchema.optional(),
   })
   .strict();
+
+export const localRequesterSchema = z
+  .object({
+    ...requesterProfileSchema,
+    platform: z.literal("local"),
+  })
+  .strict();
+
+/** Runtime-provided requester identity visible to plugin hooks. */
+export const requesterSchema = z.discriminatedUnion("platform", [
+  slackRequesterSchema,
+  localRequesterSchema,
+]);
 
 const dispatchMetadataSchema = z
   .record(z.string(), z.string())
@@ -108,6 +125,8 @@ export const dispatchOptionsSchema = z
   .strict();
 
 export type Requester = z.output<typeof requesterSchema>;
+export type SlackRequester = z.output<typeof slackRequesterSchema>;
+export type LocalRequester = z.output<typeof localRequesterSchema>;
 
 export interface AgentPluginMetadata {
   name: string;
@@ -207,12 +226,12 @@ export interface AgentPluginToolDefinition<TInput = unknown> {
   execute?: AgentPluginToolExecute<TInput>;
 }
 
-export interface ToolRegistrationHookContext extends AgentPluginContext {
+export interface SlackToolRegistrationHookContext {
   /**
-   * Capabilities of `channelId` — the raw conversation channel exposed to
+   * Capabilities of `channelId` — the raw Slack conversation channel exposed to
    * this plugin. Recomputed from `channelId`, not from `destination`.
    */
-  channelCapabilities?: {
+  channelCapabilities: {
     canAddReactions: boolean;
     canCreateCanvas: boolean;
     canPostToChannel: boolean;
@@ -223,7 +242,14 @@ export interface ToolRegistrationHookContext extends AgentPluginContext {
    * Use this as the stable binding key for state scoped to a Slack conversation.
    * `channelCapabilities` describes this channel.
    */
-  channelId?: string;
+  channelId: string;
+  credentialSubject?: AgentPluginCredentialSubject;
+  messageTs?: string;
+  teamId: string;
+  threadTs?: string;
+}
+
+interface BaseToolRegistrationHookContext extends AgentPluginContext {
   /**
    * Opaque Junior conversation/session identity for this turn.
    * Interactive Slack turns use `slack:{channelId}:{threadTs}`.
@@ -231,20 +257,31 @@ export interface ToolRegistrationHookContext extends AgentPluginContext {
    * Do not parse as Slack unless the value starts with `slack:`.
    */
   conversationId?: string;
-  credentialSubject?: AgentPluginCredentialSubject;
+  state: AgentPluginState;
+  userText?: string;
+}
+
+interface SlackToolRegistrationContext extends BaseToolRegistrationHookContext {
   /**
    * Runtime-owned destination suitable for future autonomous dispatch. For
    * Slack, this is the raw conversation channel, not a thread timestamp or
    * assistant-context source channel.
    */
-  destination?: Destination;
-  messageTs?: string;
-  requester?: Requester;
-  state: AgentPluginState;
-  teamId?: string;
-  threadTs?: string;
-  userText?: string;
+  destination: SlackDestination;
+  requester?: SlackRequester;
+  slack: SlackToolRegistrationHookContext;
 }
+
+interface LocalToolRegistrationContext extends BaseToolRegistrationHookContext {
+  /** Runtime-owned local conversation destination. */
+  destination: LocalDestination;
+  requester?: LocalRequester;
+  slack?: never;
+}
+
+export type ToolRegistrationHookContext =
+  | LocalToolRegistrationContext
+  | SlackToolRegistrationContext;
 
 export type AgentPluginCredentialSubject = z.output<
   typeof agentPluginCredentialSubjectSchema

--- a/packages/junior-plugin-api/src/index.ts
+++ b/packages/junior-plugin-api/src/index.ts
@@ -2,6 +2,9 @@ import { z } from "zod";
 
 const slackTeamIdSchema = z.string().regex(/^T[A-Z0-9]+$/);
 const slackConversationIdSchema = z.string().regex(/^(C|G|D)[A-Z0-9]+$/);
+const localConversationIdSchema = z
+  .string()
+  .regex(/^local:[a-z0-9_-]+:[a-z0-9][a-z0-9_-]*$/);
 const exactActorUserIdSchema = z
   .string()
   .min(1)
@@ -12,14 +15,28 @@ const nonBlankStringSchema = z
   .string()
   .refine((value) => value.trim().length > 0);
 
-/** Runtime-owned provider-neutral address for routing future work or side effects. */
-export const destinationSchema = z
+/** Runtime-owned Slack address for routing future work or side effects. */
+export const slackDestinationSchema = z
   .object({
     platform: z.literal("slack"),
     teamId: slackTeamIdSchema,
     channelId: slackConversationIdSchema,
   })
   .strict();
+
+/** Runtime-owned local CLI conversation address. */
+export const localDestinationSchema = z
+  .object({
+    platform: z.literal("local"),
+    conversationId: localConversationIdSchema,
+  })
+  .strict();
+
+/** Runtime-owned provider-neutral address for routing future work or side effects. */
+export const destinationSchema = z.discriminatedUnion("platform", [
+  slackDestinationSchema,
+  localDestinationSchema,
+]);
 
 /** Stable user credential subject shape accepted from plugins. */
 export const agentPluginCredentialSubjectSchema = z
@@ -84,7 +101,7 @@ export const dispatchOptionsSchema = z
   .object({
     idempotencyKey: nonBlankStringSchema.pipe(z.string().max(512)),
     credentialSubject: agentPluginCredentialSubjectSchema.optional(),
-    destination: destinationSchema,
+    destination: slackDestinationSchema,
     input: nonBlankStringSchema.pipe(z.string().max(32_000)),
     metadata: dispatchMetadataSchema.optional(),
   })
@@ -234,6 +251,17 @@ export type AgentPluginCredentialSubject = z.output<
 >;
 
 export type Destination = z.output<typeof destinationSchema>;
+
+export type SlackDestination = Extract<Destination, { platform: "slack" }>;
+
+export type LocalDestination = Extract<Destination, { platform: "local" }>;
+
+/** Narrow a runtime destination to the Slack-specific address shape. */
+export function isSlackDestination(
+  destination: Destination | undefined,
+): destination is SlackDestination {
+  return destination?.platform === "slack";
+}
 
 export type DispatchOptions = z.output<typeof dispatchOptionsSchema>;
 

--- a/packages/junior-scheduler/src/plugin.ts
+++ b/packages/junior-scheduler/src/plugin.ts
@@ -1,9 +1,9 @@
 import {
   defineJuniorPlugin,
-  type Destination,
   type Dispatch,
   type AgentPluginToolDefinition,
   type PluginOperationalReportContent,
+  type SlackDestination,
   type ToolRegistrationHookContext,
 } from "@sentry/junior-plugin-api";
 import { buildScheduledTaskRunPrompt } from "./prompt";
@@ -183,7 +183,7 @@ function formatTimestamp(timestampMs: number | undefined): string {
     : "none";
 }
 
-function destinationLabel(destination: Destination): string {
+function destinationLabel(destination: SlackDestination): string {
   if (destination.channelId.startsWith("D")) {
     return "Direct Message";
   }

--- a/packages/junior-scheduler/src/plugin.ts
+++ b/packages/junior-scheduler/src/plugin.ts
@@ -54,10 +54,10 @@ function createSchedulerToolContext(
   ctx: ToolRegistrationHookContext,
 ): SchedulerToolContext {
   return {
-    credentialSubject: ctx.credentialSubject,
+    credentialSubject: ctx.slack?.credentialSubject,
     destination:
-      ctx.destination?.platform === "slack" ? ctx.destination : undefined,
-    requester: ctx.requester,
+      ctx.destination.platform === "slack" ? ctx.destination : undefined,
+    requester: ctx.requester?.platform === "slack" ? ctx.requester : undefined,
     state: ctx.state,
     userText: ctx.userText,
   };
@@ -365,9 +365,8 @@ export function createSchedulerPlugin() {
     hooks: {
       tools(ctx) {
         if (
-          !ctx.destination ||
           ctx.destination.platform !== "slack" ||
-          !ctx.requester?.userId
+          ctx.requester?.platform !== "slack"
         ) {
           return {} as Record<string, AgentPluginToolDefinition<any>>;
         }

--- a/packages/junior-scheduler/src/plugin.ts
+++ b/packages/junior-scheduler/src/plugin.ts
@@ -55,8 +55,14 @@ function createSchedulerToolContext(
 ): SchedulerToolContext {
   return {
     credentialSubject: ctx.slack?.credentialSubject,
-    destination:
-      ctx.destination.platform === "slack" ? ctx.destination : undefined,
+    source:
+      ctx.source.platform === "slack"
+        ? {
+            platform: "slack",
+            teamId: ctx.source.teamId,
+            channelId: ctx.source.channelId,
+          }
+        : undefined,
     requester: ctx.requester?.platform === "slack" ? ctx.requester : undefined,
     state: ctx.state,
     userText: ctx.userText,
@@ -365,7 +371,7 @@ export function createSchedulerPlugin() {
     hooks: {
       tools(ctx) {
         if (
-          ctx.destination.platform !== "slack" ||
+          ctx.source.platform !== "slack" ||
           ctx.requester?.platform !== "slack"
         ) {
           return {} as Record<string, AgentPluginToolDefinition<any>>;

--- a/packages/junior-scheduler/src/schedule-tools.ts
+++ b/packages/junior-scheduler/src/schedule-tools.ts
@@ -26,8 +26,8 @@ import type {
 
 export interface SchedulerToolContext {
   credentialSubject?: AgentPluginCredentialSubject;
-  destination?: SlackDestination;
   requester?: SlackRequester;
+  source?: SlackDestination;
   state: AgentPluginState;
   userText?: string;
 }
@@ -45,34 +45,32 @@ function throwToolInputError(error: string): never {
   throw new AgentPluginToolInputError(error);
 }
 
-function requireActiveDestination(
+function requireActiveConversation(
   context: SchedulerToolContext,
 ): SlackDestination {
-  const parsed = destinationSchema.safeParse(context.destination);
+  const parsed = destinationSchema.safeParse(context.source);
   if (!parsed.success) {
-    const destination = context.destination as
-      | Partial<SlackDestination>
-      | undefined;
+    const source = context.source as Partial<SlackDestination> | undefined;
     const issues = parsed.error.issues as readonly SchemaIssue[];
-    if (!destination || destination.platform !== "slack") {
-      throwToolInputError("No active Slack destination is available.");
+    if (!source || source.platform !== "slack") {
+      throwToolInputError("No active Slack conversation is available.");
     }
     if (issues.some((issue) => issue.code === "unrecognized_keys")) {
       throwToolInputError(
-        "Active Slack destination must not include unknown fields.",
+        "Active Slack conversation must not include unknown fields.",
       );
     }
     if (issues.some((issue) => issue.path[0] === "channelId")) {
-      throwToolInputError("Active Slack destination channel is invalid.");
+      throwToolInputError("Active Slack conversation channel is invalid.");
     }
     if (issues.some((issue) => issue.path[0] === "teamId")) {
-      throwToolInputError("Active Slack destination workspace is invalid.");
+      throwToolInputError("Active Slack conversation workspace is invalid.");
     }
-    throwToolInputError("No active Slack destination is available.");
+    throwToolInputError("No active Slack conversation is available.");
   }
 
   if (!isSlackDestination(parsed.data)) {
-    throwToolInputError("No active Slack destination is available.");
+    throwToolInputError("No active Slack conversation is available.");
   }
 
   return parsed.data;
@@ -165,14 +163,14 @@ async function getWritableTask(args: {
   context: SchedulerToolContext;
   taskId: string;
 }): Promise<ScheduledTask> {
-  const destination = requireActiveDestination(args.context);
+  const destination = requireActiveConversation(args.context);
 
   const task = await createSchedulerStore(args.context.state).getTask(
     args.taskId,
   );
   if (!task || task.status === "deleted") {
     throwToolInputError(
-      "Scheduled task was not found in the active destination.",
+      "Scheduled task was not found in the active Slack conversation.",
     );
   }
 
@@ -381,7 +379,7 @@ export function createSlackScheduleCreateTaskTool(
       ),
     }),
     execute: async (input) => {
-      const destination = requireActiveDestination(context);
+      const destination = requireActiveConversation(context);
       const requester = requireRequester(context);
 
       const nowMs = Date.now();
@@ -438,7 +436,7 @@ export function createSlackScheduleCreateTaskTool(
   });
 }
 
-/** Create a tool that lists scheduled tasks for the active Slack destination. */
+/** Create a tool that lists scheduled tasks for the active Slack conversation. */
 export function createSlackScheduleListTasksTool(
   context: SchedulerToolContext,
 ) {
@@ -448,7 +446,7 @@ export function createSlackScheduleListTasksTool(
     annotations: { readOnlyHint: true, destructiveHint: false },
     inputSchema: Type.Object({}),
     execute: async () => {
-      const destination = requireActiveDestination(context);
+      const destination = requireActiveConversation(context);
 
       const tasks = await createSchedulerStore(context.state).listTasksForTeam(
         destination.teamId,
@@ -467,19 +465,19 @@ export function createSlackScheduleListTasksTool(
   });
 }
 
-/** Create a tool that edits a scheduled task in the active Slack destination. */
+/** Create a tool that edits a scheduled task in the active Slack conversation. */
 export function createSlackScheduleUpdateTaskTool(
   context: SchedulerToolContext,
 ) {
   return tool({
     description:
-      "Edit, pause, resume, or reschedule an existing Junior scheduled task in the active Slack conversation. Use only task IDs returned for this destination. Do not move scheduled tasks across conversations.",
+      "Edit, pause, resume, or reschedule an existing Junior scheduled task in the active Slack conversation. Use only task IDs returned for this conversation. Do not move scheduled tasks across conversations.",
     executionMode: "sequential",
     inputSchema: Type.Object({
       task_id: Type.String({
         minLength: 1,
         description:
-          "ID of the task to update. Must be from this active Slack destination.",
+          "ID of the task to update. Must be from this active Slack conversation.",
       }),
       task: Type.Optional(Type.String({ minLength: 1, maxLength: 4000 })),
       schedule: Type.Optional(Type.String({ minLength: 1, maxLength: 300 })),
@@ -585,19 +583,19 @@ export function createSlackScheduleUpdateTaskTool(
   });
 }
 
-/** Create a tool that removes a scheduled task from the active Slack destination. */
+/** Create a tool that removes a scheduled task from the active Slack conversation. */
 export function createSlackScheduleDeleteTaskTool(
   context: SchedulerToolContext,
 ) {
   return tool({
     description:
-      "Delete one scheduled Junior task from the active Slack conversation. Use only task IDs returned for this destination. Do not delete schedules from threads, other channels, or another user's DM.",
+      "Delete one scheduled Junior task from the active Slack conversation. Use only task IDs returned for this conversation. Do not delete schedules from threads, other channels, or another user's DM.",
     executionMode: "sequential",
     inputSchema: Type.Object({
       task_id: Type.String({
         minLength: 1,
         description:
-          "ID of the task to delete. Must be from this active Slack destination.",
+          "ID of the task to delete. Must be from this active Slack conversation.",
       }),
     }),
     execute: async ({ task_id }) => {
@@ -627,13 +625,13 @@ export function createSlackScheduleRunTaskNowTool(
 ) {
   return tool({
     description:
-      "Queue an existing active scheduled Junior task to run as soon as possible, without changing its cadence. Use when the user asks to run an existing scheduled task now. Use only task IDs returned for this destination.",
+      "Queue an existing active scheduled Junior task to run as soon as possible, without changing its cadence. Use when the user asks to run an existing scheduled task now. Use only task IDs returned for this conversation.",
     executionMode: "sequential",
     inputSchema: Type.Object({
       task_id: Type.String({
         minLength: 1,
         description:
-          "ID of the active task to run now. Must be from this active Slack destination.",
+          "ID of the active task to run now. Must be from this active Slack conversation.",
       }),
     }),
     execute: async ({ task_id }) => {

--- a/packages/junior-scheduler/src/schedule-tools.ts
+++ b/packages/junior-scheduler/src/schedule-tools.ts
@@ -4,11 +4,12 @@ import {
   AgentPluginToolInputError,
   agentPluginCredentialSubjectSchema,
   destinationSchema,
+  isSlackDestination,
   type AgentPluginCredentialSubject,
-  type Destination,
   type Requester,
   type AgentPluginState,
   type AgentPluginToolDefinition,
+  type SlackDestination,
 } from "@sentry/junior-plugin-api";
 import { buildCalendarRecurrence, parseScheduleTimestamp } from "./cadence";
 import { sanitizeScheduledTaskPrincipal } from "./identity";
@@ -25,7 +26,7 @@ import type {
 
 export interface SchedulerToolContext {
   credentialSubject?: AgentPluginCredentialSubject;
-  destination?: Destination;
+  destination?: SlackDestination;
   requester?: Requester;
   state: AgentPluginState;
   userText?: string;
@@ -44,10 +45,14 @@ function throwToolInputError(error: string): never {
   throw new AgentPluginToolInputError(error);
 }
 
-function requireActiveDestination(context: SchedulerToolContext): Destination {
+function requireActiveDestination(
+  context: SchedulerToolContext,
+): SlackDestination {
   const parsed = destinationSchema.safeParse(context.destination);
   if (!parsed.success) {
-    const destination = context.destination as Partial<Destination> | undefined;
+    const destination = context.destination as
+      | Partial<SlackDestination>
+      | undefined;
     const issues = parsed.error.issues as readonly SchemaIssue[];
     if (!destination || destination.platform !== "slack") {
       throwToolInputError("No active Slack destination is available.");
@@ -63,6 +68,10 @@ function requireActiveDestination(context: SchedulerToolContext): Destination {
     if (issues.some((issue) => issue.path[0] === "teamId")) {
       throwToolInputError("Active Slack destination workspace is invalid.");
     }
+    throwToolInputError("No active Slack destination is available.");
+  }
+
+  if (!isSlackDestination(parsed.data)) {
     throwToolInputError("No active Slack destination is available.");
   }
 
@@ -99,7 +108,7 @@ function isDmChannel(channelId: string): boolean {
 }
 
 function getConversationAccess(
-  destination: Destination,
+  destination: SlackDestination,
 ): ScheduledTaskConversationAccess {
   if (isDmChannel(destination.channelId)) {
     return { audience: "direct", visibility: "private" };
@@ -139,7 +148,7 @@ function getCredentialSubject(args: {
 
 function sameDestination(
   task: ScheduledTask,
-  destination: Destination,
+  destination: SlackDestination,
 ): boolean {
   const taskDestination = task.destination;
   return (

--- a/packages/junior-scheduler/src/schedule-tools.ts
+++ b/packages/junior-scheduler/src/schedule-tools.ts
@@ -6,10 +6,10 @@ import {
   destinationSchema,
   isSlackDestination,
   type AgentPluginCredentialSubject,
-  type Requester,
   type AgentPluginState,
   type AgentPluginToolDefinition,
   type SlackDestination,
+  type SlackRequester,
 } from "@sentry/junior-plugin-api";
 import { buildCalendarRecurrence, parseScheduleTimestamp } from "./cadence";
 import { sanitizeScheduledTaskPrincipal } from "./identity";
@@ -27,7 +27,7 @@ import type {
 export interface SchedulerToolContext {
   credentialSubject?: AgentPluginCredentialSubject;
   destination?: SlackDestination;
-  requester?: Requester;
+  requester?: SlackRequester;
   state: AgentPluginState;
   userText?: string;
 }
@@ -81,6 +81,9 @@ function requireActiveDestination(
 function requireRequester(
   context: SchedulerToolContext,
 ): ScheduledTaskPrincipal {
+  if (context.requester?.platform !== "slack") {
+    throwToolInputError("No active Slack requester context is available.");
+  }
   const userId = context.requester?.userId?.trim();
   if (!userId || userId.toLowerCase() === "unknown") {
     throwToolInputError("No active Slack requester context is available.");

--- a/packages/junior-scheduler/src/store.ts
+++ b/packages/junior-scheduler/src/store.ts
@@ -1,6 +1,7 @@
 import {
   agentPluginCredentialSubjectSchema,
   destinationSchema,
+  isSlackDestination,
   type AgentPluginReadState,
   type AgentPluginState,
 } from "@sentry/junior-plugin-api";
@@ -363,7 +364,7 @@ function parseStoredTask(value: unknown): ScheduledTask | undefined {
   }
   const record = value as Partial<ScheduledTask>;
   const destination = destinationSchema.safeParse(record.destination);
-  if (!destination.success) {
+  if (!destination.success || !isSlackDestination(destination.data)) {
     return undefined;
   }
   const credentialSubject =

--- a/packages/junior-scheduler/src/types.ts
+++ b/packages/junior-scheduler/src/types.ts
@@ -1,6 +1,6 @@
 import type {
   AgentPluginCredentialSubject,
-  Destination,
+  SlackDestination,
 } from "@sentry/junior-plugin-api";
 
 export type ScheduledTaskStatus = "active" | "paused" | "blocked" | "deleted";
@@ -72,7 +72,7 @@ export interface ScheduledTask {
   createdBy: ScheduledTaskPrincipal;
   conversationAccess?: ScheduledTaskConversationAccess;
   credentialSubject?: AgentPluginCredentialSubject;
-  destination: Destination;
+  destination: SlackDestination;
   executionActor?: ScheduledTaskExecutionActor;
   lastRunAtMs?: number;
   nextRunAtMs?: number;

--- a/packages/junior/bin/junior.mjs
+++ b/packages/junior/bin/junior.mjs
@@ -1,13 +1,7 @@
 #!/usr/bin/env node
 
 import path from "node:path";
-import { parseArgs } from "node:util";
 import { fileURLToPath, pathToFileURL } from "node:url";
-
-const { positionals } = parseArgs({
-  allowPositionals: true,
-  strict: false,
-});
 
 async function loadCliFunction(moduleName, exportName, unavailableMessage) {
   const currentFile = fileURLToPath(import.meta.url);
@@ -71,6 +65,15 @@ async function runUpgrade() {
   await runUpgradeFn();
 }
 
+async function runChat(argv) {
+  const runChatFn = await loadCliFunction(
+    "chat",
+    "runChat",
+    "Chat module is unavailable; reinstall @sentry/junior and retry.",
+  );
+  return await runChatFn(argv);
+}
+
 async function main() {
   await loadCliEnvFiles();
   const runCli = await loadCliFunction(
@@ -78,7 +81,8 @@ async function main() {
     "runCli",
     "CLI dispatcher module is unavailable; reinstall @sentry/junior and retry.",
   );
-  const exitCode = await runCli(positionals, {
+  const exitCode = await runCli(process.argv.slice(2), {
+    runChat,
     runInit,
     runSnapshotCreate,
     runCheck,

--- a/packages/junior/bin/junior.mjs
+++ b/packages/junior/bin/junior.mjs
@@ -88,9 +88,7 @@ async function main() {
     runCheck,
     runUpgrade,
   });
-  if (exitCode !== 0) {
-    process.exit(exitCode);
-  }
+  process.exit(exitCode);
 }
 
 main().catch((error) => {

--- a/packages/junior/src/chat/agent-dispatch/context.ts
+++ b/packages/junior/src/chat/agent-dispatch/context.ts
@@ -1,7 +1,4 @@
-import type {
-  DispatchOptions,
-  HeartbeatHookContext,
-} from "@sentry/junior-plugin-api";
+import type { HeartbeatHookContext } from "@sentry/junior-plugin-api";
 import { bindSlackDirectCredentialSubject } from "@/chat/credentials/subject";
 import { createAgentPluginLogger } from "@/chat/plugins/logging";
 import { createPluginState } from "@/chat/plugins/state";
@@ -11,7 +8,11 @@ import {
   isTerminalDispatchStatus,
 } from "./store";
 import { scheduleDispatchCallback } from "./signing";
-import type { BoundDispatchOptions, DispatchRecord } from "./types";
+import type {
+  BoundDispatchOptions,
+  DispatchRecord,
+  SlackDispatchOptions,
+} from "./types";
 import {
   validateDispatchOptions,
   verifyDispatchCredentialSubjectAccess,
@@ -34,7 +35,7 @@ function shouldScheduleDispatch(
 }
 
 function bindDispatchCredentialSubject(
-  options: DispatchOptions,
+  options: SlackDispatchOptions,
 ): BoundDispatchOptions {
   const { credentialSubject, ...baseOptions } = options;
   if (!credentialSubject) {

--- a/packages/junior/src/chat/agent-dispatch/store.ts
+++ b/packages/junior/src/chat/agent-dispatch/store.ts
@@ -3,7 +3,8 @@ import type { Lock, StateAdapter } from "chat";
 import {
   agentPluginCredentialSubjectSchema,
   destinationSchema,
-  type Destination,
+  isSlackDestination,
+  type SlackDestination,
 } from "@sentry/junior-plugin-api";
 import { z } from "zod";
 import { destinationKey } from "@/chat/destination";
@@ -79,6 +80,14 @@ const dispatchRecordSchema = z
   })
   .strict()
   .superRefine((record, ctx) => {
+    if (!isSlackDestination(record.destination)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Dispatch destination platform must be slack",
+        path: ["destination"],
+      });
+      return;
+    }
     const subject = record.credentialSubject;
     if (!subject) {
       return;
@@ -153,7 +162,9 @@ export function parseDispatchRecord(
 }
 
 /** Map a dispatch destination to the lock key that serializes Slack delivery. */
-export function getDispatchDestinationLockId(destination: Destination): string {
+export function getDispatchDestinationLockId(
+  destination: SlackDestination,
+): string {
   return destinationKey(destination);
 }
 

--- a/packages/junior/src/chat/agent-dispatch/types.ts
+++ b/packages/junior/src/chat/agent-dispatch/types.ts
@@ -1,4 +1,7 @@
-import type { Destination, DispatchOptions } from "@sentry/junior-plugin-api";
+import type {
+  DispatchOptions,
+  SlackDestination,
+} from "@sentry/junior-plugin-api";
 import type {
   CredentialSubject,
   CredentialSystemActor,
@@ -12,8 +15,12 @@ export type DispatchStatus =
   | "failed"
   | "blocked";
 
+export type SlackDispatchOptions = Omit<DispatchOptions, "destination"> & {
+  destination: SlackDestination;
+};
+
 export interface BoundDispatchOptions extends Omit<
-  DispatchOptions,
+  SlackDispatchOptions,
   "credentialSubject"
 > {
   credentialSubject?: CredentialSubject;
@@ -24,7 +31,7 @@ export interface DispatchRecord {
   attempt: number;
   createdAtMs: number;
   credentialSubject?: CredentialSubject;
-  destination: Destination;
+  destination: SlackDestination;
   errorMessage?: string;
   id: string;
   idempotencyKey: string;

--- a/packages/junior/src/chat/agent-dispatch/validation.ts
+++ b/packages/junior/src/chat/agent-dispatch/validation.ts
@@ -1,8 +1,8 @@
 import {
   dispatchOptionsSchema,
-  type DispatchOptions,
+  isSlackDestination,
 } from "@sentry/junior-plugin-api";
-import type { BoundDispatchOptions } from "./types";
+import type { BoundDispatchOptions, SlackDispatchOptions } from "./types";
 import { verifySlackDirectCredentialSubject } from "@/chat/credentials/subject";
 import { isDmChannel } from "@/chat/slack/client";
 
@@ -107,13 +107,16 @@ function dispatchOptionsErrorMessage(
 /** Validate plugin-provided dispatch options before core persists them. */
 export function validateDispatchOptions(
   options: unknown,
-): asserts options is DispatchOptions {
+): asserts options is SlackDispatchOptions {
   const parsed = dispatchOptionsSchema.safeParse(options);
   if (!parsed.success) {
     throw new Error(dispatchOptionsErrorMessage(parsed.error.issues));
   }
   const candidate = parsed.data;
   const { credentialSubject, destination } = candidate;
+  if (!isSlackDestination(destination)) {
+    throw new Error("Dispatch destination platform must be slack");
+  }
   if (credentialSubject !== undefined) {
     if (!isDmChannel(destination.channelId)) {
       throw new Error(

--- a/packages/junior/src/chat/app/services.ts
+++ b/packages/junior/src/chat/app/services.ts
@@ -1,7 +1,7 @@
 import { completeObject, completeText } from "@/chat/pi/client";
 import {
   generateAssistantReply as generateAssistantReplyImpl,
-  type ReplyRequestContext,
+  type AssistantReplyRequestContext,
 } from "@/chat/respond";
 import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress-tracing";
 import {
@@ -57,7 +57,7 @@ export function withSandboxTracePropagation(
   generateReply: typeof generateAssistantReplyImpl,
   tracePropagation?: SandboxEgressTracePropagationConfig,
 ): typeof generateAssistantReplyImpl {
-  return async (messageText: string, context?: ReplyRequestContext) =>
+  return async (messageText: string, context: AssistantReplyRequestContext) =>
     await generateReply(messageText, {
       ...context,
       sandbox: {

--- a/packages/junior/src/chat/destination.ts
+++ b/packages/junior/src/chat/destination.ts
@@ -1,4 +1,8 @@
-import { destinationSchema, type Destination } from "@sentry/junior-plugin-api";
+import {
+  destinationSchema,
+  type Destination,
+  type SlackDestination,
+} from "@sentry/junior-plugin-api";
 import { normalizeSlackConversationId } from "@/chat/slack/client";
 import { isSlackConversationId, isSlackTeamId } from "@/chat/slack/ids";
 
@@ -24,19 +28,38 @@ export function parseDestination(value: unknown): Destination | undefined {
   return parsed.success ? parsed.data : undefined;
 }
 
+/** Require a Slack destination at a Slack-only runtime boundary. */
+export function requireSlackDestination(
+  destination: Destination | undefined,
+  action: string,
+): SlackDestination {
+  if (destination?.platform === "slack") {
+    return destination;
+  }
+  throw new Error(`${action} requires a Slack destination`);
+}
+
 /** Compare two destinations without relying on object identity. */
 export function sameDestination(
   left: Destination,
   right: Destination,
 ): boolean {
-  return (
-    left.platform === right.platform &&
-    left.teamId === right.teamId &&
-    left.channelId === right.channelId
-  );
+  if (left.platform !== right.platform) {
+    return false;
+  }
+  if (left.platform === "local" && right.platform === "local") {
+    return left.conversationId === right.conversationId;
+  }
+  if (left.platform === "slack" && right.platform === "slack") {
+    return left.teamId === right.teamId && left.channelId === right.channelId;
+  }
+  return false;
 }
 
 /** Return the lock/index-safe storage key for a destination. */
 export function destinationKey(destination: Destination): string {
+  if (destination.platform === "local") {
+    return destination.conversationId;
+  }
   return `slack:${destination.teamId}:${destination.channelId}`;
 }

--- a/packages/junior/src/chat/local/conversation.ts
+++ b/packages/junior/src/chat/local/conversation.ts
@@ -11,6 +11,7 @@ function slugifyConversationAlias(alias: string): string | undefined {
   return trimmed.toLowerCase().replaceAll(".", "-");
 }
 
+/** Hash the resolved cwd into the stable workspace segment of local conversation ids. */
 function workspaceKey(cwd: string): string {
   return createHash("sha256")
     .update(path.resolve(cwd))

--- a/packages/junior/src/chat/local/conversation.ts
+++ b/packages/junior/src/chat/local/conversation.ts
@@ -1,0 +1,36 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+
+const LOCAL_CONVERSATION_ALIAS_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
+function slugifyConversationAlias(alias: string): string | undefined {
+  const trimmed = alias.trim();
+  if (!LOCAL_CONVERSATION_ALIAS_PATTERN.test(trimmed)) {
+    return undefined;
+  }
+  return trimmed.toLowerCase().replaceAll(".", "-");
+}
+
+function workspaceKey(cwd: string): string {
+  return createHash("sha256")
+    .update(path.resolve(cwd))
+    .digest("hex")
+    .slice(0, 12);
+}
+
+/** Normalize a local CLI conversation alias into the durable conversation id. */
+export function normalizeLocalConversationId(input: {
+  alias?: string;
+  cwd?: string;
+}): string | undefined {
+  const slug = slugifyConversationAlias(input.alias ?? "default");
+  if (!slug) {
+    return undefined;
+  }
+  return `local:${workspaceKey(input.cwd ?? process.cwd())}:${slug}`;
+}
+
+/** Return whether a user-facing local conversation alias is accepted. */
+export function isLocalConversationAlias(value: string): boolean {
+  return Boolean(slugifyConversationAlias(value));
+}

--- a/packages/junior/src/chat/local/conversation.ts
+++ b/packages/junior/src/chat/local/conversation.ts
@@ -21,17 +21,12 @@ function workspaceKey(cwd: string): string {
 
 /** Normalize a local CLI conversation alias into the durable conversation id. */
 export function normalizeLocalConversationId(input: {
-  alias?: string;
+  alias: string;
   cwd?: string;
 }): string | undefined {
-  const slug = slugifyConversationAlias(input.alias ?? "default");
+  const slug = slugifyConversationAlias(input.alias);
   if (!slug) {
     return undefined;
   }
   return `local:${workspaceKey(input.cwd ?? process.cwd())}:${slug}`;
-}
-
-/** Return whether a user-facing local conversation alias is accepted. */
-export function isLocalConversationAlias(value: string): boolean {
-  return Boolean(slugifyConversationAlias(value));
 }

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -36,7 +36,7 @@ export interface LocalAgentTurnInput {
 }
 
 export interface LocalAgentTurnDeps {
-  deliverReply?: (reply: AssistantReply) => Promise<void>;
+  deliverReply: (reply: AssistantReply) => Promise<void>;
   generateAssistantReply?: typeof generateAssistantReplyImpl;
   now?: () => number;
   onStatus?: (status: string) => void | Promise<void>;
@@ -71,11 +71,14 @@ function nextUserMessageSequence(
 /** Run one local CLI message through Junior's shared agent reply boundary. */
 export async function runLocalAgentTurn(
   input: LocalAgentTurnInput,
-  deps: LocalAgentTurnDeps = {},
+  deps: LocalAgentTurnDeps,
 ): Promise<LocalAgentTurnResult> {
   const text = input.message.trim();
   if (!text) {
     throw new Error("Local agent message must not be empty");
+  }
+  if (!deps.deliverReply) {
+    throw new Error("Local reply delivery is required");
   }
 
   const generateAssistantReply =
@@ -161,7 +164,7 @@ export async function runLocalAgentTurn(
       onTextDelta: deps.onTextDelta,
     });
 
-    await deps.deliverReply?.(reply);
+    await deps.deliverReply(reply);
 
     const completedState = buildDeliveredTurnStatePatch({
       artifacts,

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -33,6 +33,8 @@ import { coerceThreadConversationState } from "@/chat/state/conversation";
 import { loadProjection } from "@/chat/state/session-log";
 import type { Destination } from "@sentry/junior-plugin-api";
 
+const DELIVERED_STATE_PERSIST_ATTEMPTS = 3;
+
 export interface LocalAgentTurnInput {
   conversationAlias: string;
   conversationId: string;
@@ -64,6 +66,10 @@ function localTurnId(sequence: number): string {
   return `local-turn-${sequence}`;
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function nextUserMessageSequence(
   conversation: ReturnType<typeof coerceThreadConversationState>,
 ): number {
@@ -85,6 +91,29 @@ async function loadLocalPiMessages(args: {
   }
 
   return args.fallback.length > 0 ? [...args.fallback] : undefined;
+}
+
+async function persistDeliveredLocalTurnState(
+  conversationId: string,
+  patch: Parameters<typeof persistThreadStateById>[1],
+): Promise<void> {
+  let lastError: unknown;
+  for (
+    let attempt = 1;
+    attempt <= DELIVERED_STATE_PERSIST_ATTEMPTS;
+    attempt += 1
+  ) {
+    try {
+      await persistThreadStateById(conversationId, patch);
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt < DELIVERED_STATE_PERSIST_ATTEMPTS) {
+        await sleep(attempt * 100);
+      }
+    }
+  }
+  throw lastError;
 }
 
 /** Run one local CLI message through Junior's shared agent reply boundary. */
@@ -136,6 +165,7 @@ export async function runLocalAgentTurn(
   await persistThreadStateById(input.conversationId, { conversation });
 
   let reply: AssistantReply;
+  let completedState: ReturnType<typeof buildDeliveredTurnStatePatch>;
   try {
     const piMessages = await loadLocalPiMessages({
       conversationId: input.conversationId,
@@ -155,7 +185,6 @@ export async function runLocalAgentTurn(
       surface: "internal",
       correlation: {
         conversationId: input.conversationId,
-        threadId: input.conversationId,
         turnId,
         runId: turnId,
       },
@@ -188,6 +217,13 @@ export async function runLocalAgentTurn(
       onTextDelta: deps.onTextDelta,
     });
 
+    completedState = buildDeliveredTurnStatePatch({
+      artifacts,
+      conversation,
+      reply,
+      sessionId: turnId,
+      userMessageId,
+    });
     await deps.deliverReply(reply);
   } catch (error) {
     markTurnFailed({
@@ -202,14 +238,7 @@ export async function runLocalAgentTurn(
     throw error;
   }
 
-  const completedState = buildDeliveredTurnStatePatch({
-    artifacts,
-    conversation,
-    reply,
-    sessionId: turnId,
-    userMessageId,
-  });
-  await persistThreadStateById(input.conversationId, {
+  await persistDeliveredLocalTurnState(input.conversationId, {
     artifacts: completedState.artifacts ?? artifacts,
     conversation: completedState.conversation,
     sandboxId: reply.sandboxId ?? sandboxId,

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -10,6 +10,7 @@ import {
   generateAssistantReply as generateAssistantReplyImpl,
   type AssistantReply,
 } from "@/chat/respond";
+import { THREAD_STATE_TTL_MS } from "chat";
 import {
   stripRuntimeTurnContext,
   trimTrailingAssistantMessages,
@@ -30,7 +31,7 @@ import {
 } from "@/chat/services/conversation-memory";
 import { coerceThreadArtifactsState } from "@/chat/state/artifacts";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
-import { loadProjection } from "@/chat/state/session-log";
+import { commitMessages, loadProjection } from "@/chat/state/session-log";
 import type { Destination } from "@sentry/junior-plugin-api";
 
 const DELIVERED_STATE_PERSIST_ATTEMPTS = 3;
@@ -164,13 +165,17 @@ export async function runLocalAgentTurn(
   });
   await persistThreadStateById(input.conversationId, { conversation });
 
-  let reply: AssistantReply;
+  let reply: AssistantReply | undefined;
   let completedState: ReturnType<typeof buildDeliveredTurnStatePatch>;
+  let piMessagesBeforeRun:
+    | Awaited<ReturnType<typeof loadLocalPiMessages>>
+    | undefined;
   try {
     const piMessages = await loadLocalPiMessages({
       conversationId: input.conversationId,
       fallback: conversation.piMessages,
     });
+    piMessagesBeforeRun = piMessages;
     reply = await generateAssistantReply(text, {
       authorizationFlowMode: "disabled",
       conversationContext: buildConversationContext(conversation, {
@@ -226,6 +231,13 @@ export async function runLocalAgentTurn(
     });
     await deps.deliverReply(reply);
   } catch (error) {
+    if (reply) {
+      await commitMessages({
+        conversationId: input.conversationId,
+        messages: piMessagesBeforeRun ?? [],
+        ttlMs: THREAD_STATE_TTL_MS,
+      });
+    }
     markTurnFailed({
       conversation,
       nowMs: now(),

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -218,6 +218,12 @@ export async function runLocalAgentTurn(
         actor: { type: "system", id: "local-cli" },
       },
       destination,
+      requester: {
+        fullName: "Local CLI",
+        platform: "local",
+        userId: "local-cli",
+        userName: "local",
+      },
       piMessages,
       surface: "internal",
       correlation: {

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -138,6 +138,9 @@ export async function runLocalAgentTurn(
   let artifacts = coerceThreadArtifactsState(persisted);
   let { sandboxId, sandboxDependencyProfileHash } =
     getPersistedSandboxState(persisted);
+  const initialArtifacts = artifacts;
+  const initialSandboxId = sandboxId;
+  const initialSandboxDependencyProfileHash = sandboxDependencyProfileHash;
 
   const sequence = nextUserMessageSequence(conversation);
   const turnId = localTurnId(sequence);
@@ -246,7 +249,12 @@ export async function runLocalAgentTurn(
       markConversationMessage,
       updateConversationStats,
     });
-    await persistThreadStateById(input.conversationId, { conversation });
+    await persistThreadStateById(input.conversationId, {
+      artifacts: initialArtifacts,
+      conversation,
+      sandboxId: initialSandboxId ?? "",
+      sandboxDependencyProfileHash: initialSandboxDependencyProfileHash ?? "",
+    });
     throw error;
   }
 

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -280,11 +280,23 @@ export async function runLocalAgentTurn(
 
   await persistDeliveredLocalTurnState(input.conversationId, {
     artifacts: completedState.artifacts ?? artifacts,
-    conversation: completedState.conversation,
+    conversation: reply.piMessages
+      ? {
+          ...completedState.conversation,
+          piMessages: reply.piMessages,
+        }
+      : completedState.conversation,
     sandboxId: reply.sandboxId ?? sandboxId,
     sandboxDependencyProfileHash:
       reply.sandboxDependencyProfileHash ?? sandboxDependencyProfileHash,
   });
+  if (reply.piMessages) {
+    await commitMessages({
+      conversationId: input.conversationId,
+      messages: reply.piMessages,
+      ttlMs: THREAD_STATE_TTL_MS,
+    });
+  }
 
   return {
     conversationId: input.conversationId,

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -1,0 +1,197 @@
+/**
+ * Local agent turn runtime.
+ *
+ * This module owns the Slack-free execution boundary for CLI-originated turns:
+ * it persists local conversation state, invokes the shared reply generator with
+ * a local destination, and only commits assistant delivery after the CLI sink
+ * accepts the final output.
+ */
+import {
+  generateAssistantReply as generateAssistantReplyImpl,
+  type AssistantReply,
+} from "@/chat/respond";
+import { buildDeliveredTurnStatePatch } from "@/chat/runtime/delivered-turn-state";
+import {
+  getPersistedSandboxState,
+  getPersistedThreadState,
+  persistThreadStateById,
+} from "@/chat/runtime/thread-state";
+import { startActiveTurn, markTurnFailed } from "@/chat/runtime/turn";
+import {
+  buildConversationContext,
+  markConversationMessage,
+  normalizeConversationText,
+  updateConversationStats,
+  upsertConversationMessage,
+} from "@/chat/services/conversation-memory";
+import { coerceThreadArtifactsState } from "@/chat/state/artifacts";
+import { coerceThreadConversationState } from "@/chat/state/conversation";
+import type { Destination } from "@sentry/junior-plugin-api";
+
+export interface LocalAgentTurnInput {
+  conversationAlias: string;
+  conversationId: string;
+  message: string;
+  mode: "interactive" | "once";
+}
+
+export interface LocalAgentTurnDeps {
+  deliverReply?: (reply: AssistantReply) => Promise<void>;
+  generateAssistantReply?: typeof generateAssistantReplyImpl;
+  now?: () => number;
+  onStatus?: (status: string) => void | Promise<void>;
+  onTextDelta?: (deltaText: string) => void | Promise<void>;
+}
+
+export interface LocalAgentTurnResult {
+  conversationId: string;
+  reply: AssistantReply;
+}
+
+function localDestination(conversationId: string): Destination {
+  return {
+    platform: "local",
+    conversationId,
+  };
+}
+
+function localTurnId(sequence: number): string {
+  return `local-turn-${sequence}`;
+}
+
+function nextUserMessageSequence(
+  conversation: ReturnType<typeof coerceThreadConversationState>,
+): number {
+  return (
+    conversation.messages.filter((message) => message.role === "user").length +
+    1
+  );
+}
+
+/** Run one local CLI message through Junior's shared agent reply boundary. */
+export async function runLocalAgentTurn(
+  input: LocalAgentTurnInput,
+  deps: LocalAgentTurnDeps = {},
+): Promise<LocalAgentTurnResult> {
+  const text = input.message.trim();
+  if (!text) {
+    throw new Error("Local agent message must not be empty");
+  }
+
+  const generateAssistantReply =
+    deps.generateAssistantReply ?? generateAssistantReplyImpl;
+  const now = deps.now ?? (() => Date.now());
+  const persisted = await getPersistedThreadState(input.conversationId);
+  const conversation = coerceThreadConversationState(persisted);
+  let artifacts = coerceThreadArtifactsState(persisted);
+  let { sandboxId, sandboxDependencyProfileHash } =
+    getPersistedSandboxState(persisted);
+
+  const sequence = nextUserMessageSequence(conversation);
+  const turnId = localTurnId(sequence);
+  const userMessageId = `${turnId}:user`;
+  const startedAtMs = now();
+  upsertConversationMessage(conversation, {
+    id: userMessageId,
+    role: "user",
+    text: normalizeConversationText(text),
+    createdAtMs: startedAtMs,
+    author: {
+      fullName: "Local CLI",
+      userId: "local-cli",
+      userName: "local",
+    },
+    meta: {
+      explicitMention: true,
+      replied: false,
+    },
+  });
+  startActiveTurn({
+    conversation,
+    nextTurnId: turnId,
+    updateConversationStats,
+  });
+  await persistThreadStateById(input.conversationId, { conversation });
+
+  try {
+    const reply = await generateAssistantReply(text, {
+      authorizationFlowMode: "disabled",
+      conversationContext: buildConversationContext(conversation, {
+        excludeMessageId: userMessageId,
+      }),
+      artifactState: artifacts,
+      credentialContext: {
+        actor: { type: "system", id: "local-cli" },
+      },
+      destination: localDestination(input.conversationId),
+      piMessages: conversation.piMessages,
+      surface: "internal",
+      correlation: {
+        conversationId: input.conversationId,
+        threadId: input.conversationId,
+        turnId,
+        runId: turnId,
+      },
+      sandbox: {
+        sandboxId,
+        sandboxDependencyProfileHash,
+      },
+      onArtifactStateUpdated: async (nextArtifacts) => {
+        artifacts = nextArtifacts;
+        await persistThreadStateById(input.conversationId, {
+          artifacts,
+          conversation,
+          sandboxId,
+          sandboxDependencyProfileHash,
+        });
+      },
+      onSandboxAcquired: async (sandbox) => {
+        sandboxId = sandbox.sandboxId;
+        sandboxDependencyProfileHash = sandbox.sandboxDependencyProfileHash;
+        await persistThreadStateById(input.conversationId, {
+          artifacts,
+          conversation,
+          sandboxId,
+          sandboxDependencyProfileHash,
+        });
+      },
+      onStatus: async (status) => {
+        await deps.onStatus?.(status.text);
+      },
+      onTextDelta: deps.onTextDelta,
+    });
+
+    await deps.deliverReply?.(reply);
+
+    const completedState = buildDeliveredTurnStatePatch({
+      artifacts,
+      conversation,
+      reply,
+      sessionId: turnId,
+      userMessageId,
+    });
+    await persistThreadStateById(input.conversationId, {
+      artifacts: completedState.artifacts ?? artifacts,
+      conversation: completedState.conversation,
+      sandboxId: reply.sandboxId ?? sandboxId,
+      sandboxDependencyProfileHash:
+        reply.sandboxDependencyProfileHash ?? sandboxDependencyProfileHash,
+    });
+
+    return {
+      conversationId: input.conversationId,
+      reply,
+    };
+  } catch (error) {
+    markTurnFailed({
+      conversation,
+      nowMs: now(),
+      sessionId: turnId,
+      userMessageId,
+      markConversationMessage,
+      updateConversationStats,
+    });
+    await persistThreadStateById(input.conversationId, { conversation });
+    throw error;
+  }
+}

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -32,19 +32,25 @@ import {
 import { coerceThreadArtifactsState } from "@/chat/state/artifacts";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
 import { commitMessages, loadProjection } from "@/chat/state/session-log";
-import type { Destination } from "@sentry/junior-plugin-api";
+import {
+  localDestinationSchema,
+  type LocalDestination,
+} from "@sentry/junior-plugin-api";
 
 const DELIVERED_STATE_PERSIST_ATTEMPTS = 3;
 
 export interface LocalAgentTurnInput {
-  conversationAlias: string;
   conversationId: string;
   message: string;
-  mode: "interactive" | "once";
+}
+
+export interface LocalAgentReply {
+  files?: AssistantReply["files"];
+  text: string;
 }
 
 export interface LocalAgentTurnDeps {
-  deliverReply: (reply: AssistantReply) => Promise<void>;
+  deliverReply: (reply: LocalAgentReply) => Promise<void>;
   generateAssistantReply?: typeof generateAssistantReplyImpl;
   now?: () => number;
   onStatus?: (status: string) => void | Promise<void>;
@@ -53,18 +59,29 @@ export interface LocalAgentTurnDeps {
 
 export interface LocalAgentTurnResult {
   conversationId: string;
-  reply: AssistantReply;
+  outcome: AssistantReply["diagnostics"]["outcome"];
 }
 
-function localDestination(conversationId: string): Destination {
-  return {
+function localDestination(conversationId: string): LocalDestination {
+  const parsed = localDestinationSchema.safeParse({
     platform: "local",
     conversationId,
-  };
+  });
+  if (!parsed.success) {
+    throw new Error("Invalid local conversation id");
+  }
+  return parsed.data;
 }
 
 function localTurnId(sequence: number): string {
   return `local-turn-${sequence}`;
+}
+
+function localReply(reply: AssistantReply): LocalAgentReply {
+  return {
+    ...(reply.files ? { files: reply.files } : {}),
+    text: reply.text,
+  };
 }
 
 function sleep(ms: number): Promise<void> {
@@ -80,6 +97,7 @@ function nextUserMessageSequence(
   );
 }
 
+/** Load durable Pi projection first; fallback only preserves pre-session-log local state. */
 async function loadLocalPiMessages(args: {
   conversationId: string;
   fallback: ReturnType<typeof coerceThreadConversationState>["piMessages"];
@@ -94,6 +112,7 @@ async function loadLocalPiMessages(args: {
   return args.fallback.length > 0 ? [...args.fallback] : undefined;
 }
 
+/** Persist the post-delivery completion state, retrying transient state writes. */
 async function persistDeliveredLocalTurnState(
   conversationId: string,
   patch: Parameters<typeof persistThreadStateById>[1],
@@ -129,6 +148,7 @@ export async function runLocalAgentTurn(
   if (!deps.deliverReply) {
     throw new Error("Local reply delivery is required");
   }
+  const destination = localDestination(input.conversationId);
 
   const generateAssistantReply =
     deps.generateAssistantReply ?? generateAssistantReplyImpl;
@@ -188,7 +208,7 @@ export async function runLocalAgentTurn(
       credentialContext: {
         actor: { type: "system", id: "local-cli" },
       },
-      destination: localDestination(input.conversationId),
+      destination,
       piMessages,
       surface: "internal",
       correlation: {
@@ -232,7 +252,7 @@ export async function runLocalAgentTurn(
       sessionId: turnId,
       userMessageId,
     });
-    await deps.deliverReply(reply);
+    await deps.deliverReply(localReply(reply));
   } catch (error) {
     if (reply) {
       await commitMessages({
@@ -268,6 +288,6 @@ export async function runLocalAgentTurn(
 
   return {
     conversationId: input.conversationId,
-    reply,
+    outcome: reply.diagnostics.outcome,
   };
 }

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -10,6 +10,10 @@ import {
   generateAssistantReply as generateAssistantReplyImpl,
   type AssistantReply,
 } from "@/chat/respond";
+import {
+  stripRuntimeTurnContext,
+  trimTrailingAssistantMessages,
+} from "@/chat/respond-helpers";
 import { buildDeliveredTurnStatePatch } from "@/chat/runtime/delivered-turn-state";
 import {
   getPersistedSandboxState,
@@ -26,6 +30,7 @@ import {
 } from "@/chat/services/conversation-memory";
 import { coerceThreadArtifactsState } from "@/chat/state/artifacts";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
+import { loadProjection } from "@/chat/state/session-log";
 import type { Destination } from "@sentry/junior-plugin-api";
 
 export interface LocalAgentTurnInput {
@@ -66,6 +71,20 @@ function nextUserMessageSequence(
     conversation.messages.filter((message) => message.role === "user").length +
     1
   );
+}
+
+async function loadLocalPiMessages(args: {
+  conversationId: string;
+  fallback: ReturnType<typeof coerceThreadConversationState>["piMessages"];
+}) {
+  const projection = await loadProjection({
+    conversationId: args.conversationId,
+  });
+  if (projection.length > 0) {
+    return stripRuntimeTurnContext(trimTrailingAssistantMessages(projection));
+  }
+
+  return args.fallback.length > 0 ? [...args.fallback] : undefined;
 }
 
 /** Run one local CLI message through Junior's shared agent reply boundary. */
@@ -116,8 +135,13 @@ export async function runLocalAgentTurn(
   });
   await persistThreadStateById(input.conversationId, { conversation });
 
+  let reply: AssistantReply;
   try {
-    const reply = await generateAssistantReply(text, {
+    const piMessages = await loadLocalPiMessages({
+      conversationId: input.conversationId,
+      fallback: conversation.piMessages,
+    });
+    reply = await generateAssistantReply(text, {
       authorizationFlowMode: "disabled",
       conversationContext: buildConversationContext(conversation, {
         excludeMessageId: userMessageId,
@@ -127,7 +151,7 @@ export async function runLocalAgentTurn(
         actor: { type: "system", id: "local-cli" },
       },
       destination: localDestination(input.conversationId),
-      piMessages: conversation.piMessages,
+      piMessages,
       surface: "internal",
       correlation: {
         conversationId: input.conversationId,
@@ -165,26 +189,6 @@ export async function runLocalAgentTurn(
     });
 
     await deps.deliverReply(reply);
-
-    const completedState = buildDeliveredTurnStatePatch({
-      artifacts,
-      conversation,
-      reply,
-      sessionId: turnId,
-      userMessageId,
-    });
-    await persistThreadStateById(input.conversationId, {
-      artifacts: completedState.artifacts ?? artifacts,
-      conversation: completedState.conversation,
-      sandboxId: reply.sandboxId ?? sandboxId,
-      sandboxDependencyProfileHash:
-        reply.sandboxDependencyProfileHash ?? sandboxDependencyProfileHash,
-    });
-
-    return {
-      conversationId: input.conversationId,
-      reply,
-    };
   } catch (error) {
     markTurnFailed({
       conversation,
@@ -197,4 +201,24 @@ export async function runLocalAgentTurn(
     await persistThreadStateById(input.conversationId, { conversation });
     throw error;
   }
+
+  const completedState = buildDeliveredTurnStatePatch({
+    artifacts,
+    conversation,
+    reply,
+    sessionId: turnId,
+    userMessageId,
+  });
+  await persistThreadStateById(input.conversationId, {
+    artifacts: completedState.artifacts ?? artifacts,
+    conversation: completedState.conversation,
+    sandboxId: reply.sandboxId ?? sandboxId,
+    sandboxDependencyProfileHash:
+      reply.sandboxDependencyProfileHash ?? sandboxDependencyProfileHash,
+  });
+
+  return {
+    conversationId: input.conversationId,
+    reply,
+  };
 }

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -97,7 +97,13 @@ function nextUserMessageSequence(
   );
 }
 
-/** Load durable Pi projection first; fallback only preserves pre-session-log local state. */
+function preparedLocalPiMessages(
+  messages: ReturnType<typeof coerceThreadConversationState>["piMessages"],
+) {
+  return stripRuntimeTurnContext(trimTrailingAssistantMessages(messages));
+}
+
+/** Load the newest local Pi state, falling back from stale projection data. */
 async function loadLocalPiMessages(args: {
   conversationId: string;
   fallback: ReturnType<typeof coerceThreadConversationState>["piMessages"];
@@ -105,11 +111,14 @@ async function loadLocalPiMessages(args: {
   const projection = await loadProjection({
     conversationId: args.conversationId,
   });
+  if (args.fallback.length >= projection.length && args.fallback.length > 0) {
+    return preparedLocalPiMessages(args.fallback);
+  }
   if (projection.length > 0) {
-    return stripRuntimeTurnContext(trimTrailingAssistantMessages(projection));
+    return preparedLocalPiMessages(projection);
   }
 
-  return args.fallback.length > 0 ? [...args.fallback] : undefined;
+  return undefined;
 }
 
 /** Persist the post-delivery completion state, retrying transient state writes. */

--- a/packages/junior/src/chat/plugins/agent-hooks.ts
+++ b/packages/junior/src/chat/plugins/agent-hooks.ts
@@ -154,7 +154,7 @@ export function getAgentPluginTools(
     const slackToolContext = getSlackToolContext(context);
     const credentialSubject = slackToolContext
       ? createSlackDirectCredentialSubject({
-          channelId: slackToolContext.channelId,
+          channelId: slackToolContext.sourceChannelId,
           teamId: slackToolContext.teamId,
           userId: slackToolContext.requester?.userId,
         })
@@ -163,21 +163,13 @@ export function getAgentPluginTools(
       slackToolContext
         ? {
             channelCapabilities: resolveChannelCapabilities(
-              slackToolContext.channelId,
+              slackToolContext.sourceChannelId,
             ),
-            channelId: slackToolContext.channelId,
             ...(credentialSubject ? { credentialSubject } : {}),
-            ...(slackToolContext.messageTs
-              ? { messageTs: slackToolContext.messageTs }
-              : {}),
-            teamId: slackToolContext.teamId,
-            ...(slackToolContext.threadTs
-              ? { threadTs: slackToolContext.threadTs }
-              : {}),
           }
         : undefined;
     const pluginContext =
-      destination.platform === "slack"
+      context.source.platform === "slack"
         ? {
             plugin: { name: plugin.name },
             log,
@@ -186,8 +178,10 @@ export function getAgentPluginTools(
                 ? context.requester
                 : undefined,
             conversationId: context.conversationId,
-            destination,
+            destination:
+              destination?.platform === "slack" ? destination : undefined,
             slack: slackContext!,
+            source: context.source,
             userText: context.userText,
             state: createPluginState(plugin.name, {
               legacyStatePrefixes: plugin.legacyStatePrefixes,
@@ -201,7 +195,9 @@ export function getAgentPluginTools(
                 ? context.requester
                 : undefined,
             conversationId: context.conversationId,
-            destination,
+            destination:
+              destination?.platform === "local" ? destination : undefined,
+            source: context.source,
             userText: context.userText,
             state: createPluginState(plugin.name, {
               legacyStatePrefixes: plugin.legacyStatePrefixes,

--- a/packages/junior/src/chat/plugins/agent-hooks.ts
+++ b/packages/junior/src/chat/plugins/agent-hooks.ts
@@ -8,6 +8,7 @@ import type {
   PluginOperationalTone,
   SlackConversationLink,
   JuniorPluginRegistration,
+  SlackToolRegistrationHookContext,
 } from "@sentry/junior-plugin-api";
 import { logInfo } from "@/chat/logging";
 import { createAgentPluginLogger } from "@/chat/plugins/logging";
@@ -148,32 +149,63 @@ export function getAgentPluginTools(
       continue;
     }
     const log = createAgentPluginLogger(plugin.name);
-    // Plugins receive the raw Slack conversation channel. The dispatch
-    // destination is the provider-neutral address for autonomous work.
     const destination = context.destination;
-    const credentialSubject = createSlackDirectCredentialSubject({
-      channelId: context.channelId,
-      teamId: context.teamId,
-      userId: context.requester?.userId,
-    });
-    const pluginCapabilities = resolveChannelCapabilities(context.channelId);
-    const pluginTools = hook({
-      plugin: { name: plugin.name },
-      log,
-      requester: context.requester,
-      channelCapabilities: pluginCapabilities,
-      channelId: context.channelId,
-      conversationId: context.conversationId,
-      ...(credentialSubject ? { credentialSubject } : {}),
-      ...(destination ? { destination } : {}),
-      teamId: context.teamId,
-      messageTs: context.messageTs,
-      threadTs: context.threadTs,
-      userText: context.userText,
-      state: createPluginState(plugin.name, {
-        legacyStatePrefixes: plugin.legacyStatePrefixes,
-      }),
-    });
+    const credentialSubject =
+      destination.platform === "slack"
+        ? createSlackDirectCredentialSubject({
+            channelId: destination.channelId,
+            teamId: destination.teamId,
+            userId:
+              context.requester?.platform === "slack"
+                ? context.requester.userId
+                : undefined,
+          })
+        : undefined;
+    const slackContext: SlackToolRegistrationHookContext | undefined =
+      destination.platform === "slack"
+        ? {
+            channelCapabilities: resolveChannelCapabilities(
+              destination.channelId,
+            ),
+            channelId: destination.channelId,
+            ...(credentialSubject ? { credentialSubject } : {}),
+            ...(context.messageTs ? { messageTs: context.messageTs } : {}),
+            teamId: destination.teamId,
+            ...(context.threadTs ? { threadTs: context.threadTs } : {}),
+          }
+        : undefined;
+    const pluginContext =
+      destination.platform === "slack"
+        ? {
+            plugin: { name: plugin.name },
+            log,
+            requester:
+              context.requester?.platform === "slack"
+                ? context.requester
+                : undefined,
+            conversationId: context.conversationId,
+            destination,
+            slack: slackContext!,
+            userText: context.userText,
+            state: createPluginState(plugin.name, {
+              legacyStatePrefixes: plugin.legacyStatePrefixes,
+            }),
+          }
+        : {
+            plugin: { name: plugin.name },
+            log,
+            requester:
+              context.requester?.platform === "local"
+                ? context.requester
+                : undefined,
+            conversationId: context.conversationId,
+            destination,
+            userText: context.userText,
+            state: createPluginState(plugin.name, {
+              legacyStatePrefixes: plugin.legacyStatePrefixes,
+            }),
+          };
+    const pluginTools = hook(pluginContext);
     for (const [name, tool] of Object.entries(pluginTools)) {
       if (!AGENT_PLUGIN_TOOL_NAME_RE.test(name)) {
         throw new Error(

--- a/packages/junior/src/chat/plugins/agent-hooks.ts
+++ b/packages/junior/src/chat/plugins/agent-hooks.ts
@@ -15,6 +15,7 @@ import { createAgentPluginLogger } from "@/chat/plugins/logging";
 import { createPluginState } from "@/chat/plugins/state";
 import { SANDBOX_WORKSPACE_ROOT } from "@/chat/sandbox/paths";
 import type { ToolDefinition } from "@/chat/tools/definition";
+import { getSlackToolContext } from "@/chat/tools/slack/context";
 import type { ToolRuntimeContext } from "@/chat/tools/types";
 import type {
   SandboxCommandInput,
@@ -150,28 +151,29 @@ export function getAgentPluginTools(
     }
     const log = createAgentPluginLogger(plugin.name);
     const destination = context.destination;
-    const credentialSubject =
-      destination.platform === "slack"
-        ? createSlackDirectCredentialSubject({
-            channelId: destination.channelId,
-            teamId: destination.teamId,
-            userId:
-              context.requester?.platform === "slack"
-                ? context.requester.userId
-                : undefined,
-          })
-        : undefined;
+    const slackToolContext = getSlackToolContext(context);
+    const credentialSubject = slackToolContext
+      ? createSlackDirectCredentialSubject({
+          channelId: slackToolContext.channelId,
+          teamId: slackToolContext.teamId,
+          userId: slackToolContext.requester?.userId,
+        })
+      : undefined;
     const slackContext: SlackToolRegistrationHookContext | undefined =
-      destination.platform === "slack"
+      slackToolContext
         ? {
             channelCapabilities: resolveChannelCapabilities(
-              destination.channelId,
+              slackToolContext.channelId,
             ),
-            channelId: destination.channelId,
+            channelId: slackToolContext.channelId,
             ...(credentialSubject ? { credentialSubject } : {}),
-            ...(context.messageTs ? { messageTs: context.messageTs } : {}),
-            teamId: destination.teamId,
-            ...(context.threadTs ? { threadTs: context.threadTs } : {}),
+            ...(slackToolContext.messageTs
+              ? { messageTs: slackToolContext.messageTs }
+              : {}),
+            teamId: slackToolContext.teamId,
+            ...(slackToolContext.threadTs
+              ? { threadTs: slackToolContext.threadTs }
+              : {}),
           }
         : undefined;
     const pluginContext =

--- a/packages/junior/src/chat/prompt.ts
+++ b/packages/junior/src/chat/prompt.ts
@@ -27,6 +27,7 @@ import type { ThreadArtifactsState } from "@/chat/state/artifacts";
 import type { SkillMetadata, SkillInvocation } from "@/chat/skills";
 import type { ActiveMcpCatalogSummary } from "@/chat/tools/skill/mcp-tool-summary";
 import { escapeXml } from "@/chat/xml";
+import type { Destination } from "@sentry/junior-plugin-api";
 
 const DEFAULT_SOUL = "You are Junior, a practical and concise assistant.";
 
@@ -329,8 +330,12 @@ function formatConfigurationLines(
   );
 }
 
-const HEADER =
+type PromptPlatform = Destination["platform"];
+
+const SLACK_HEADER =
   "You are a Slack-based helper assistant. Follow the personality section for voice and tone in every reply. Platform mechanics and output rules override personality and world context when they conflict.";
+const LOCAL_HEADER =
+  "You are a helper assistant. Follow the personality section for voice and tone in every reply. Platform mechanics and output rules override personality and world context when they conflict.";
 
 const TURN_CONTEXT_HEADER =
   "Runtime context for this request. Treat these blocks as trusted runtime facts; the static system prompt remains authoritative.";
@@ -399,20 +404,37 @@ function renderRuleSection(tag: string, lines: string[]): string {
   return [`<${tag}>`, ...lines, `</${tag}>`].join("\n");
 }
 
-function buildBehaviorSection(): string {
-  return [
+function buildBehaviorSection(platform: PromptPlatform): string {
+  const sections = [
     renderRuleSection("tool-policy", TOOL_POLICY_RULES),
     renderRuleSection("tool-call-style", TOOL_CALL_STYLE_RULES),
     renderRuleSection("skill-policy", SKILL_POLICY_RULES),
     renderRuleSection("execution-contract", EXECUTION_CONTRACT_RULES),
     renderRuleSection("conversation", CONVERSATION_RULES),
-    renderRuleSection("slack-actions", SLACK_ACTION_RULES),
     renderRuleSection("safety", SAFETY_RULES),
     renderRuleSection("failure-handling", FAILURE_RULES),
-  ].join("\n\n");
+  ];
+  if (platform === "slack") {
+    sections.splice(
+      5,
+      0,
+      renderRuleSection("slack-actions", SLACK_ACTION_RULES),
+    );
+  }
+  return sections.join("\n\n");
 }
 
-function buildOutputSection(): string {
+function buildOutputSection(platform: PromptPlatform): string {
+  if (platform === "local") {
+    return [
+      `<output format="markdown">`,
+      "- Start with the answer or result, not internal process narration.",
+      "- Use concise Markdown suitable for terminal output: short paragraphs, bullets, links, and fenced code blocks when helpful.",
+      "- End every turn with a final user-facing response.",
+      "</output>",
+    ].join("\n");
+  }
+
   const openTag = `<output format="slack-markdown" max_inline_chars="${slackOutputPolicy.maxInlineChars}" max_inline_lines="${slackOutputPolicy.maxInlineLines}">`;
   return [
     openTag,
@@ -425,11 +447,12 @@ function buildOutputSection(): string {
   ].join("\n");
 }
 
-function buildIdentitySection(): string {
-  return [
-    "# Identity",
-    `Your Slack username is \`${botConfig.userName}\`.`,
-  ].join("\n");
+function buildIdentitySection(platform: PromptPlatform): string {
+  const name =
+    platform === "slack"
+      ? `Your Slack username is \`${botConfig.userName}\`.`
+      : `Your assistant name is \`${botConfig.userName}\`.`;
+  return ["# Identity", name].join("\n");
 }
 
 function buildPersonalitySection(): string {
@@ -579,20 +602,29 @@ type TurnContextPromptInput = {
   configuration?: Record<string, unknown>;
 };
 
-const STATIC_SYSTEM_PROMPT = [
-  HEADER,
-  buildIdentitySection(),
-  buildPersonalitySection(),
-  buildWorldSection(),
-  buildBehaviorSection(),
-  buildOutputSection(),
-]
-  .filter((section): section is string => Boolean(section))
-  .join("\n\n");
+function buildStaticSystemPrompt(platform: PromptPlatform): string {
+  return [
+    platform === "slack" ? SLACK_HEADER : LOCAL_HEADER,
+    buildIdentitySection(platform),
+    buildPersonalitySection(),
+    buildWorldSection(),
+    buildBehaviorSection(platform),
+    buildOutputSection(platform),
+  ]
+    .filter((section): section is string => Boolean(section))
+    .join("\n\n");
+}
+
+const STATIC_SYSTEM_PROMPTS: Record<PromptPlatform, string> = {
+  local: buildStaticSystemPrompt("local"),
+  slack: buildStaticSystemPrompt("slack"),
+};
 
 /** Return byte-stable platform instructions shared by every conversation and turn. */
-export function buildSystemPrompt(): string {
-  return STATIC_SYSTEM_PROMPT;
+export function buildSystemPrompt(params: {
+  destination: Destination;
+}): string {
+  return STATIC_SYSTEM_PROMPTS[params.destination.platform];
 }
 
 /** Build volatile runtime context that belongs in the user turn, not the system prompt. */

--- a/packages/junior/src/chat/prompt.ts
+++ b/packages/junior/src/chat/prompt.ts
@@ -27,7 +27,7 @@ import type { ThreadArtifactsState } from "@/chat/state/artifacts";
 import type { SkillMetadata, SkillInvocation } from "@/chat/skills";
 import type { ActiveMcpCatalogSummary } from "@/chat/tools/skill/mcp-tool-summary";
 import { escapeXml } from "@/chat/xml";
-import type { Destination } from "@sentry/junior-plugin-api";
+import type { Source } from "@sentry/junior-plugin-api";
 
 const DEFAULT_SOUL = "You are Junior, a practical and concise assistant.";
 
@@ -330,7 +330,7 @@ function formatConfigurationLines(
   );
 }
 
-type PromptPlatform = Destination["platform"];
+type PromptPlatform = Source["platform"];
 
 const SLACK_HEADER =
   "You are a Slack-based helper assistant. Follow the personality section for voice and tone in every reply. Platform mechanics and output rules override personality and world context when they conflict.";
@@ -621,10 +621,8 @@ const STATIC_SYSTEM_PROMPTS: Record<PromptPlatform, string> = {
 };
 
 /** Return byte-stable platform instructions shared by every conversation and turn. */
-export function buildSystemPrompt(params: {
-  destination: Destination;
-}): string {
-  return STATIC_SYSTEM_PROMPTS[params.destination.platform];
+export function buildSystemPrompt(params: { source: Source }): string {
+  return STATIC_SYSTEM_PROMPTS[params.source.platform];
 }
 
 /** Build volatile runtime context that belongs in the user turn, not the system prompt. */

--- a/packages/junior/src/chat/requester.ts
+++ b/packages/junior/src/chat/requester.ts
@@ -1,9 +1,9 @@
 /**
- * Canonical Slack requester identity.
+ * Canonical requester identity.
  *
- * Runtime requesters are always workspace-scoped Slack actors. Stored requester
- * parsing remains explicit so legacy durable records can resume without
- * repairing malformed team or user ids.
+ * Runtime requesters are platform-scoped actors. Stored Slack requester parsing
+ * remains explicit so legacy durable records can resume without repairing
+ * malformed team or user ids.
  */
 import { z } from "zod";
 import { isSlackTeamId } from "@/chat/slack/ids";
@@ -27,14 +27,23 @@ export const storedSlackRequesterSchema = z
   })
   .strict();
 
-export interface Requester {
+interface BaseRequester {
   email?: string;
   fullName?: string;
-  platform: "slack";
-  teamId: string;
   userId: string;
   userName?: string;
 }
+
+export interface SlackRequester extends BaseRequester {
+  platform: "slack";
+  teamId: string;
+}
+
+export interface LocalRequester extends BaseRequester {
+  platform: "local";
+}
+
+export type Requester = SlackRequester | LocalRequester;
 
 export interface SlackRequesterProfile {
   email?: string;
@@ -47,7 +56,7 @@ export type StoredSlackRequester = z.output<typeof storedSlackRequesterSchema>;
 interface RequesterInput {
   email?: string;
   fullName?: string;
-  platform?: "slack";
+  platform?: Requester["platform"];
   teamId?: string;
   userId?: string;
   userName?: string;
@@ -108,14 +117,19 @@ export function isActorUserId(value: string | undefined): value is string {
   return parseActorUserId(value) === value;
 }
 
-/** Build Junior's canonical requester from exact Slack team/user ids and profile data. */
+/** Build Junior's canonical platform requester from exact actor ids and profile data. */
 export function createRequester(
   input: RequesterInput | undefined,
   context: {
+    platform?: Requester["platform"];
     teamId?: string;
     userId?: string;
   },
 ): Requester | undefined {
+  const platform = context.platform ?? input?.platform;
+  if (!platform) {
+    return undefined;
+  }
   const contextUserId = parseActorUserId(context.userId);
   if (context.userId !== undefined && !contextUserId) {
     return undefined;
@@ -124,6 +138,11 @@ export function createRequester(
   if (input?.userId !== undefined && !inputUserId) {
     return undefined;
   }
+  const requesterUserId = contextUserId ?? inputUserId;
+  if (!requesterUserId) {
+    return undefined;
+  }
+
   const contextTeamId = parseSlackTeamId(context.teamId);
   if (context.teamId !== undefined && !contextTeamId) {
     return undefined;
@@ -132,17 +151,18 @@ export function createRequester(
   if (input?.teamId !== undefined && !inputTeamId) {
     return undefined;
   }
-
-  const requesterUserId = contextUserId ?? inputUserId;
   const requesterTeamId = contextTeamId ?? inputTeamId;
-  if (!requesterUserId || !requesterTeamId) {
+  if (platform === "slack" && !requesterTeamId) {
     return undefined;
   }
 
   const canUseInputProfile =
     (!contextUserId || !inputUserId || contextUserId === inputUserId) &&
-    (!contextTeamId || !inputTeamId || contextTeamId === inputTeamId);
-  return {
+    (platform !== "slack" ||
+      !contextTeamId ||
+      !inputTeamId ||
+      contextTeamId === inputTeamId);
+  const requester = {
     ...(canUseInputProfile && cleanRequesterEmail(input?.email)
       ? { email: cleanRequesterEmail(input?.email) }
       : {}),
@@ -152,8 +172,7 @@ export function createRequester(
           fullName: cleanRequesterDisplayName(input?.fullName, requesterUserId),
         }
       : {}),
-    platform: "slack",
-    teamId: requesterTeamId,
+    platform,
     userId: requesterUserId,
     ...(canUseInputProfile &&
     cleanRequesterDisplayName(input?.userName, requesterUserId)
@@ -162,6 +181,10 @@ export function createRequester(
         }
       : {}),
   };
+  if (platform === "slack") {
+    return { ...requester, platform, teamId: requesterTeamId! };
+  }
+  return { ...requester, platform };
 }
 
 /** Build Junior's canonical requester from Slack profile data. */
@@ -169,7 +192,7 @@ export function createSlackRequester(
   teamId: string,
   userId: string,
   profile: SlackRequesterProfile | null | undefined,
-): Requester {
+): SlackRequester {
   const actorUserId = parseActorUserId(userId);
   const actorTeamId = parseSlackTeamId(teamId);
   if (!actorTeamId || !actorUserId) {
@@ -186,7 +209,7 @@ export function createSlackRequester(
     },
     { teamId: actorTeamId, userId: actorUserId },
   );
-  if (!requester) {
+  if (!requester || requester.platform !== "slack") {
     throw new Error("Slack requester requires team and user ids");
   }
   return requester;
@@ -223,7 +246,7 @@ export function parseStoredSlackRequester(
 
 /** Convert a runtime Slack requester into its durable session shape. */
 export function toStoredSlackRequester(
-  requester: Requester,
+  requester: SlackRequester,
 ): StoredSlackRequester {
   return {
     ...(requester.email ? { email: requester.email } : {}),
@@ -240,7 +263,7 @@ export function createRequesterFromStoredSlackRequester(args: {
   requester?: StoredSlackRequester;
   teamId: string;
   userId: string;
-}): Requester {
+}): SlackRequester {
   const actorUserId = parseActorUserId(args.userId);
   const actorTeamId = parseSlackTeamId(args.teamId);
   if (!actorTeamId || !actorUserId) {

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -57,6 +57,7 @@ import type { ToolDefinition } from "@/chat/tools/definition";
 import { toActiveMcpCatalogSummaries } from "@/chat/tools/skill/mcp-tool-summary";
 import type {
   ImageGenerateToolDeps,
+  ToolRuntimeContext,
   WebFetchToolDeps,
   WebSearchToolDeps,
 } from "@/chat/tools/types";
@@ -941,7 +942,6 @@ export async function generateAssistantReply(
         ? context.destination
         : undefined;
     const slackChannelId = slackDestination?.channelId;
-    const slackTeamId = slackDestination?.teamId;
 
     const mcpAuth = createMcpAuthOrchestration(
       {
@@ -1005,6 +1005,47 @@ export async function generateAssistantReply(
         skill.disableModelInvocation !== true ||
         skill.name === invokedSkill?.name,
     );
+    const commonToolRuntimeContext = {
+      conversationId: sessionConversationId,
+      userText: userInput,
+      artifactState: context.artifactState,
+      configuration: configurationValues,
+      mcpToolManager: turnMcpToolManager,
+      sandbox,
+      advisor: {
+        config: botConfig.advisor,
+        conversationId: sessionConversationId,
+        conversationPrivacy,
+        logContext: spanContext,
+        getTools: () => advisorTools,
+        streamFn: createTracedStreamFn({ conversationPrivacy }),
+      },
+    };
+    const toolRuntimeContext: ToolRuntimeContext =
+      context.destination.platform === "slack"
+        ? {
+            ...commonToolRuntimeContext,
+            destination: context.destination,
+            requester:
+              actorRequester?.platform === "slack" ? actorRequester : undefined,
+            slack: {
+              ...(context.toolChannelId
+                ? { deliveryChannelId: context.toolChannelId }
+                : {}),
+              ...(context.correlation?.messageTs
+                ? { messageTs: context.correlation.messageTs }
+                : {}),
+              ...(context.correlation?.threadTs
+                ? { threadTs: context.correlation.threadTs }
+                : {}),
+            },
+          }
+        : {
+            ...commonToolRuntimeContext,
+            destination: context.destination,
+            requester:
+              actorRequester?.platform === "local" ? actorRequester : undefined,
+          };
     const tools = createTools(
       loadableSkills,
       {
@@ -1058,29 +1099,7 @@ export async function generateAssistantReply(
           };
         },
       },
-      {
-        channelId: slackChannelId,
-        conversationId: sessionConversationId,
-        deliveryChannelId: context.toolChannelId,
-        destination: context.destination,
-        requester: actorRequester,
-        teamId: slackTeamId,
-        messageTs: context.correlation?.messageTs,
-        threadTs: context.correlation?.threadTs,
-        userText: userInput,
-        artifactState: context.artifactState,
-        configuration: configurationValues,
-        mcpToolManager: turnMcpToolManager,
-        sandbox,
-        advisor: {
-          config: botConfig.advisor,
-          conversationId: sessionConversationId,
-          conversationPrivacy,
-          logContext: spanContext,
-          getTools: () => advisorTools,
-          streamFn: createTracedStreamFn({ conversationPrivacy }),
-        },
-      },
+      toolRuntimeContext,
     );
 
     const toolGuidance = Object.entries(

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -8,7 +8,7 @@
  * should stay outside this file.
  */
 import { Agent, type AgentTool } from "@earendil-works/pi-agent-core";
-import type { Destination } from "@sentry/junior-plugin-api";
+import type { Destination, Source } from "@sentry/junior-plugin-api";
 import { THREAD_STATE_TTL_MS, type FileUpload } from "chat";
 import { botConfig } from "@/chat/config";
 import {
@@ -388,6 +388,34 @@ function actorRequesterFromContext(
         : undefined),
     userId: context.correlation?.requesterId,
   });
+}
+
+function toolInvocationSource(context: ReplyRequestContext): Source {
+  if (context.destination.platform !== "slack") {
+    return context.destination;
+  }
+  return {
+    platform: "slack",
+    teamId: context.destination.teamId,
+    channelId: context.destination.channelId,
+    ...(context.correlation?.messageTs
+      ? { messageTs: context.correlation.messageTs }
+      : {}),
+    ...(context.correlation?.threadTs
+      ? { threadTs: context.correlation.threadTs }
+      : {}),
+  };
+}
+
+function toolInvocationDestination(context: ReplyRequestContext): Destination {
+  if (context.destination.platform !== "slack" || !context.toolChannelId) {
+    return context.destination;
+  }
+  return {
+    platform: "slack",
+    teamId: context.destination.teamId,
+    channelId: context.toolChannelId,
+  };
 }
 
 function surfaceFromContext(
@@ -1021,31 +1049,30 @@ export async function generateAssistantReply(
         streamFn: createTracedStreamFn({ conversationPrivacy }),
       },
     };
-    const toolRuntimeContext: ToolRuntimeContext =
-      context.destination.platform === "slack"
-        ? {
-            ...commonToolRuntimeContext,
-            destination: context.destination,
-            requester:
-              actorRequester?.platform === "slack" ? actorRequester : undefined,
-            slack: {
-              ...(context.toolChannelId
-                ? { deliveryChannelId: context.toolChannelId }
-                : {}),
-              ...(context.correlation?.messageTs
-                ? { messageTs: context.correlation.messageTs }
-                : {}),
-              ...(context.correlation?.threadTs
-                ? { threadTs: context.correlation.threadTs }
-                : {}),
-            },
-          }
-        : {
-            ...commonToolRuntimeContext,
-            destination: context.destination,
-            requester:
-              actorRequester?.platform === "local" ? actorRequester : undefined,
-          };
+    const toolSource = toolInvocationSource(context);
+    const toolDestination = toolInvocationDestination(context);
+    let toolRuntimeContext: ToolRuntimeContext;
+    if (toolSource.platform === "slack") {
+      toolRuntimeContext = {
+        ...commonToolRuntimeContext,
+        ...(toolDestination.platform === "slack"
+          ? { destination: toolDestination }
+          : {}),
+        requester:
+          actorRequester?.platform === "slack" ? actorRequester : undefined,
+        source: toolSource,
+      };
+    } else {
+      toolRuntimeContext = {
+        ...commonToolRuntimeContext,
+        ...(toolDestination.platform === "local"
+          ? { destination: toolDestination }
+          : {}),
+        requester:
+          actorRequester?.platform === "local" ? actorRequester : undefined,
+        source: toolSource,
+      };
+    }
     const tools = createTools(
       loadableSkills,
       {
@@ -1142,7 +1169,7 @@ export async function generateAssistantReply(
     const activeMcpCatalogs = toActiveMcpCatalogSummaries(
       turnMcpToolManager.getActiveToolCatalog(),
     );
-    baseInstructions = buildSystemPrompt({ destination: context.destination });
+    baseInstructions = buildSystemPrompt({ source: toolSource });
     const needsBootstrapContext = !hasRuntimeTurnContext(priorPiMessages ?? []);
     const turnContextPrompt = needsBootstrapContext
       ? buildTurnContextPrompt({

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -198,7 +198,7 @@ export interface ReplyRequestContext {
   credentialContext?: CredentialContext;
   requester?: Requester;
   slackConversation?: SlackConversationContext;
-  destination?: Destination;
+  destination: Destination;
   surface?: AgentTurnSurface;
   correlation?: {
     conversationId?: string;
@@ -258,6 +258,8 @@ export interface ReplyRequestContext {
     params: Record<string, unknown>;
   }) => void;
 }
+
+export type AssistantReplyRequestContext = ReplyRequestContext;
 
 export interface ReplyRequestAttachment {
   data?: Buffer;
@@ -319,19 +321,70 @@ function requesterFromContext(
   context: ReplyRequestContext,
 ): StoredSlackRequester | undefined {
   const identity = actorRequesterFromContext(context);
-  return identity ? toStoredSlackRequester(identity) : undefined;
+  return identity?.platform === "slack"
+    ? toStoredSlackRequester(identity)
+    : undefined;
+}
+
+/** Reject requester identities that do not belong to the active destination. */
+function assertRequesterDestinationMatch(context: ReplyRequestContext): void {
+  const { destination, requester } = context;
+  if (!requester) {
+    return;
+  }
+  if (requester.platform !== destination.platform) {
+    throw new TypeError(
+      `Requester platform "${requester.platform}" does not match destination platform "${destination.platform}"`,
+    );
+  }
+  if (
+    requester.platform === "slack" &&
+    destination.platform === "slack" &&
+    requester.teamId !== destination.teamId
+  ) {
+    throw new TypeError("Slack requester team does not match destination team");
+  }
+}
+
+/** Reject legacy Slack correlation fields that conflict with the destination. */
+function assertCorrelationDestinationMatch(context: ReplyRequestContext): void {
+  const { correlation, destination } = context;
+  if (destination.platform !== "slack") {
+    return;
+  }
+  if (
+    correlation?.channelId !== undefined &&
+    correlation.channelId !== destination.channelId
+  ) {
+    throw new TypeError(
+      "Slack correlation channel does not match destination channel",
+    );
+  }
+  if (
+    correlation?.teamId !== undefined &&
+    correlation.teamId !== destination.teamId
+  ) {
+    throw new TypeError(
+      "Slack correlation team does not match destination team",
+    );
+  }
 }
 
 function actorRequesterFromContext(
   context: ReplyRequestContext,
 ): Requester | undefined {
   return createRequester(context.requester, {
+    platform:
+      context.requester?.platform ??
+      (context.destination?.platform === "slack" ? "slack" : undefined),
     teamId:
       (context.destination?.platform === "slack"
         ? context.destination.teamId
         : undefined) ??
       context.correlation?.teamId ??
-      context.requester?.teamId,
+      (context.requester?.platform === "slack"
+        ? context.requester.teamId
+        : undefined),
     userId: context.correlation?.requesterId,
   });
 }
@@ -481,8 +534,14 @@ function buildSteeringPiMessage(message: ReplySteeringMessage): PiMessage {
 /** Run a full agent turn: discover skills, execute tools, and return the assistant reply. */
 export async function generateAssistantReply(
   messageText: string,
-  context: ReplyRequestContext = {},
+  context: AssistantReplyRequestContext,
 ): Promise<AssistantReply> {
+  if (!context.destination) {
+    throw new TypeError("Assistant reply generation requires a destination");
+  }
+  assertRequesterDestinationMatch(context);
+  assertCorrelationDestinationMatch(context);
+
   const replyStartedAtMs = Date.now();
   const configuredTurnDeadlineAtMs = replyStartedAtMs + botConfig.turnTimeoutMs;
   const contextTurnDeadlineAtMs =
@@ -877,12 +936,19 @@ export async function generateAssistantReply(
     };
 
     // ── MCP auth orchestration ───────────────────────────────────────
+    const slackDestination =
+      context.destination.platform === "slack"
+        ? context.destination
+        : undefined;
+    const slackChannelId = slackDestination?.channelId;
+    const slackTeamId = slackDestination?.teamId;
+
     const mcpAuth = createMcpAuthOrchestration(
       {
         conversationId: sessionConversationId,
         sessionId,
         requesterId: authRequesterId,
-        channelId: context.correlation?.channelId,
+        channelId: slackChannelId,
         destination: context.destination,
         threadTs: context.correlation?.threadTs,
         toolChannelId: context.toolChannelId,
@@ -902,7 +968,7 @@ export async function generateAssistantReply(
         conversationId: sessionConversationId,
         sessionId,
         requesterId: authRequesterId,
-        channelId: context.correlation?.channelId,
+        channelId: slackChannelId,
         destination: context.destination,
         threadTs: context.correlation?.threadTs,
         userMessage: userInput,
@@ -993,12 +1059,12 @@ export async function generateAssistantReply(
         },
       },
       {
-        channelId: context.correlation?.channelId,
+        channelId: slackChannelId,
         conversationId: sessionConversationId,
         deliveryChannelId: context.toolChannelId,
         destination: context.destination,
         requester: actorRequester,
-        teamId: context.correlation?.teamId,
+        teamId: slackTeamId,
         messageTs: context.correlation?.messageTs,
         threadTs: context.correlation?.threadTs,
         userText: userInput,
@@ -1057,7 +1123,7 @@ export async function generateAssistantReply(
     const activeMcpCatalogs = toActiveMcpCatalogSummaries(
       turnMcpToolManager.getActiveToolCatalog(),
     );
-    baseInstructions = buildSystemPrompt();
+    baseInstructions = buildSystemPrompt({ destination: context.destination });
     const needsBootstrapContext = !hasRuntimeTurnContext(priorPiMessages ?? []);
     const turnContextPrompt = needsBootstrapContext
       ? buildTurnContextPrompt({

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -327,7 +327,9 @@ function actorRequesterFromContext(
 ): Requester | undefined {
   return createRequester(context.requester, {
     teamId:
-      context.destination?.teamId ??
+      (context.destination?.platform === "slack"
+        ? context.destination.teamId
+        : undefined) ??
       context.correlation?.teamId ??
       context.requester?.teamId,
     userId: context.correlation?.requesterId,

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -1570,6 +1570,7 @@ export async function generateAssistantReply(
       sandboxId: currentSandboxExecutor.getSandboxId(),
       sandboxDependencyProfileHash:
         currentSandboxExecutor.getDependencyProfileHash(),
+      piMessages: [...agent.state.messages],
       durationMs: Date.now() - replyStartedAtMs,
       generatedFileCount: generatedFiles.length,
       shouldTrace,

--- a/packages/junior/src/chat/runtime/agent-continue-runner.ts
+++ b/packages/junior/src/chat/runtime/agent-continue-runner.ts
@@ -50,6 +50,7 @@ import {
   applyPendingAuthUpdate,
   clearPendingAuth,
 } from "@/chat/services/pending-auth";
+import { requireSlackDestination } from "@/chat/destination";
 
 const AGENT_CONTINUE_LOCK_RETRY_DELAYS_MS = [250, 1_000, 2_000] as const;
 
@@ -256,9 +257,13 @@ export async function continueSlackAgentRun(
           excludeMessageId: userMessage.id,
         });
         const sandbox = getPersistedSandboxState(currentState);
+        const destination = requireSlackDestination(
+          payload.destination,
+          "Slack continuation",
+        );
         const requester = createRequesterFromStoredSlackRequester({
           requester: activeSessionRecord.requester,
-          teamId: payload.destination.teamId,
+          teamId: destination.teamId,
           userId: userMessage.author.userId,
         });
 

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -120,6 +120,7 @@ import {
   stripRuntimeTurnContext,
   trimTrailingAssistantMessages,
 } from "@/chat/respond-helpers";
+import { requireSlackDestination } from "@/chat/destination";
 
 function collectCanvasUrls(artifacts: Partial<ThreadArtifactsState>) {
   return new Set(
@@ -297,7 +298,10 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
     const threadTs = getThreadTs(threadId);
     const assistantThreadContext = getAssistantThreadContext(message);
     const messageTs = getMessageTs(message);
-    const destination = options.destination;
+    const destination = requireSlackDestination(
+      options.destination,
+      "Slack reply execution",
+    );
     const teamId = destination.teamId;
     const runId = getRunId(thread, message);
     const conversationId = threadId ?? runId;

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -84,7 +84,7 @@ import { type ThreadArtifactsState } from "@/chat/state/artifacts";
 import { lookupSlackUser } from "@/chat/slack/user";
 import {
   toStoredSlackRequester,
-  type Requester,
+  type SlackRequester,
   type StoredSlackRequester,
 } from "@/chat/requester";
 import { ensureSlackMessageActorIdentity } from "@/chat/services/message-actor-identity";
@@ -131,7 +131,7 @@ function collectCanvasUrls(artifacts: Partial<ThreadArtifactsState>) {
   );
 }
 
-function turnRequester(requester: Requester): StoredSlackRequester {
+function turnRequester(requester: SlackRequester): StoredSlackRequester {
   return toStoredSlackRequester(requester);
 }
 

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -3,7 +3,7 @@ import type { ChannelConfigurationService } from "@/chat/configuration/types";
 import {
   generateAssistantReply,
   type AssistantReply,
-  type ReplyRequestContext,
+  type AssistantReplyRequestContext,
 } from "@/chat/respond";
 import {
   buildTurnFailureResponse,
@@ -112,7 +112,7 @@ interface ResumeSlackTurnArgs {
   channelId: string;
   threadTs: string;
   messageTs?: string;
-  replyContext?: ReplyRequestContext;
+  replyContext?: AssistantReplyRequestContext;
   lockKey?: string;
   initialText?: string;
   generateReply?: typeof generateAssistantReply;
@@ -201,8 +201,14 @@ async function handleResumeFailure(args: {
 function createResumeReplyContext(
   args: ResumeSlackTurnArgs,
   statusSession: AssistantStatusSession,
-): ReplyRequestContext {
-  const replyContext = args.replyContext ?? {};
+): AssistantReplyRequestContext {
+  const replyContext = args.replyContext;
+  if (!replyContext) {
+    throw new TypeError("Slack resume requires a reply context");
+  }
+  if (replyContext.destination.platform !== "slack") {
+    throw new TypeError("Slack resume requires a Slack destination");
+  }
   const requestDeadline = getTurnRequestDeadline();
   const threadId =
     args.lockKey ?? getDefaultLockKey(args.channelId, args.threadTs);
@@ -466,7 +472,7 @@ export async function resumeAuthorizedRequest(args: {
   threadTs: string;
   messageTs?: string;
   connectedText: string;
-  replyContext?: ReplyRequestContext;
+  replyContext?: AssistantReplyRequestContext;
   lockKey?: string;
   generateReply?: typeof generateAssistantReply;
   onSuccess?: (reply: AssistantReply) => Promise<void>;

--- a/packages/junior/src/chat/services/message-actor-identity.ts
+++ b/packages/junior/src/chat/services/message-actor-identity.ts
@@ -5,6 +5,7 @@ import {
   isActorUserId,
   parseActorUserId,
   type Requester,
+  type SlackRequester,
   type SlackRequesterProfile,
 } from "@/chat/requester";
 
@@ -51,7 +52,8 @@ export function bindMessageActorIdentity(
 ): Requester {
   const userId = canonicalUserId(message.author, requester);
   const actorRequester = createRequester(requester, {
-    teamId: requester.teamId,
+    platform: requester.platform,
+    ...(requester.platform === "slack" ? { teamId: requester.teamId } : {}),
     userId,
   });
   if (!actorRequester) {
@@ -77,17 +79,26 @@ export async function ensureSlackMessageActorIdentity(
     teamId: string,
     userId: string,
   ) => Promise<SlackRequesterProfile | null | undefined>,
-): Promise<Requester> {
+): Promise<SlackRequester> {
   const existing = messageActors.get(message);
   if (existing) {
+    if (existing.platform !== "slack") {
+      throw new Error(
+        "Slack message actor identity requires a Slack requester",
+      );
+    }
     return existing;
   }
   const userId = parseActorUserId(message.author.userId);
   if (!userId) {
     throw new Error("Slack message actor identity requires a user id");
   }
-  return bindMessageActorIdentity(
+  const requester = bindMessageActorIdentity(
     message,
     createSlackRequester(teamId, userId, await lookupSlackUser(teamId, userId)),
   );
+  if (requester.platform !== "slack") {
+    throw new Error("Slack message actor identity requires a Slack requester");
+  }
+  return requester;
 }

--- a/packages/junior/src/chat/services/turn-result.ts
+++ b/packages/junior/src/chat/services/turn-result.ts
@@ -2,6 +2,7 @@ import type { FileUpload } from "chat";
 import { botConfig } from "@/chat/config";
 import { logInfo, logWarn } from "@/chat/logging";
 import type { LogContext } from "@/chat/logging";
+import type { PiMessage } from "@/chat/pi/messages";
 import type { TurnThinkingSelection } from "@/chat/services/turn-thinking-level";
 import type { AgentTurnUsage } from "@/chat/usage";
 import {
@@ -54,6 +55,7 @@ export interface AssistantReply {
   deliveryMode?: "thread" | "channel_only";
   sandboxId?: string;
   sandboxDependencyProfileHash?: string;
+  piMessages?: PiMessage[];
   diagnostics: AgentTurnDiagnostics;
 }
 
@@ -65,6 +67,7 @@ export interface TurnResultInput {
   toolCalls: string[];
   sandboxId?: string;
   sandboxDependencyProfileHash?: string;
+  piMessages?: PiMessage[];
   durationMs?: number;
   generatedFileCount: number;
   shouldTrace: boolean;
@@ -295,6 +298,7 @@ export function buildTurnResult(input: TurnResultInput): AssistantReply {
     deliveryMode,
     sandboxId,
     sandboxDependencyProfileHash,
+    piMessages: input.piMessages,
     diagnostics: resolvedDiagnostics,
   };
 }

--- a/packages/junior/src/chat/slack/user.ts
+++ b/packages/junior/src/chat/slack/user.ts
@@ -1,6 +1,6 @@
 import { getSlackBotToken } from "@/chat/config";
 import { logWarn } from "@/chat/logging";
-import { createSlackRequester, type Requester } from "@/chat/requester";
+import { createSlackRequester, type SlackRequester } from "@/chat/requester";
 
 interface SlackUserLookupResult {
   userName?: string;
@@ -136,7 +136,7 @@ export async function lookupSlackUser(
 export async function lookupSlackRequester(
   teamId: string,
   userId: string,
-): Promise<Requester> {
+): Promise<SlackRequester> {
   return createSlackRequester(
     teamId,
     userId,

--- a/packages/junior/src/chat/task-execution/slack-work.ts
+++ b/packages/junior/src/chat/task-execution/slack-work.ts
@@ -32,7 +32,10 @@ import {
 import { ensureSlackMessageActorIdentity } from "@/chat/services/message-actor-identity";
 import { lookupSlackUser } from "@/chat/slack/user";
 import { parseActorUserId, type SlackRequesterProfile } from "@/chat/requester";
-import { createSlackDestination } from "@/chat/destination";
+import {
+  createSlackDestination,
+  requireSlackDestination,
+} from "@/chat/destination";
 
 export type SlackConversationRoute = "mention" | "subscribed";
 
@@ -240,10 +243,14 @@ export function createSlackConversationWorker(
         const messages = records.map((record) =>
           restoreMessage({ adapter, record }),
         );
+        const destination = requireSlackDestination(
+          context.destination,
+          "Slack conversation work",
+        );
         await bindSlackActorIdentities({
           lookupSlackUser: actorLookup,
           messages,
-          teamId: context.destination.teamId,
+          teamId: destination.teamId,
         });
         const latestMessage = messages[messages.length - 1];
         if (!latestMessage) {

--- a/packages/junior/src/chat/task-execution/store.ts
+++ b/packages/junior/src/chat/task-execution/store.ts
@@ -46,7 +46,13 @@ export const CONVERSATION_WORK_LEASE_TTL_MS = 90_000;
 export const CONVERSATION_WORK_CHECK_IN_INTERVAL_MS = 15_000;
 export const CONVERSATION_WORK_STALE_ENQUEUE_MS = 60_000;
 
-export type Source = "api" | "internal" | "plugin" | "scheduler" | "slack";
+export type Source =
+  | "api"
+  | "internal"
+  | "local"
+  | "plugin"
+  | "scheduler"
+  | "slack";
 
 export type ExecutionStatus =
   | "awaiting_resume"
@@ -245,6 +251,7 @@ function normalizeSource(value: unknown): Source | undefined {
   if (
     value === "api" ||
     value === "internal" ||
+    value === "local" ||
     value === "plugin" ||
     value === "scheduler" ||
     value === "slack"

--- a/packages/junior/src/chat/tools/index.ts
+++ b/packages/junior/src/chat/tools/index.ts
@@ -107,15 +107,6 @@ export function createTools(
       hooks,
       hooks.toolOverrides?.imageGenerate,
     ),
-    slackCanvasRead: createSlackCanvasReadTool(),
-    slackCanvasEdit: createSlackCanvasEditTool(state),
-    slackCanvasWrite: createSlackCanvasWriteTool(state),
-    slackThreadRead: createSlackThreadReadTool(context),
-    slackUserLookup: createSlackUserLookupTool(),
-    slackListCreate: createSlackListCreateTool(state),
-    slackListAddItems: createSlackListAddItemsTool(state),
-    slackListGetItems: createSlackListGetItemsTool(state),
-    slackListUpdateItem: createSlackListUpdateItemTool(state),
   };
 
   if (context.advisor) {
@@ -127,28 +118,42 @@ export function createTools(
     tools.callMcpTool = createCallMcpToolTool(context.mcpToolManager);
   }
 
-  const outputChannelId = getSlackDeliveryChannelId(context);
-  const outputCapabilities = resolveChannelCapabilities(outputChannelId);
-  const rawChannelCapabilities = resolveChannelCapabilities(context.channelId);
+  if (context.destination.platform === "slack") {
+    tools.slackCanvasRead = createSlackCanvasReadTool();
+    tools.slackCanvasEdit = createSlackCanvasEditTool(state);
+    tools.slackCanvasWrite = createSlackCanvasWriteTool(state);
+    tools.slackThreadRead = createSlackThreadReadTool(context);
+    tools.slackUserLookup = createSlackUserLookupTool();
+    tools.slackListCreate = createSlackListCreateTool(state);
+    tools.slackListAddItems = createSlackListAddItemsTool(state);
+    tools.slackListGetItems = createSlackListGetItemsTool(state);
+    tools.slackListUpdateItem = createSlackListUpdateItemTool(state);
 
-  if (outputCapabilities.canCreateCanvas) {
-    tools.slackCanvasCreate = createSlackCanvasCreateTool(context, state);
-  }
-
-  if (outputCapabilities.canPostToChannel) {
-    tools.slackChannelPostMessage = createSlackChannelPostMessageTool(
-      context,
-      state,
+    const outputChannelId = getSlackDeliveryChannelId(context);
+    const outputCapabilities = resolveChannelCapabilities(outputChannelId);
+    const rawChannelCapabilities = resolveChannelCapabilities(
+      context.destination.channelId,
     );
-    tools.slackChannelListMessages =
-      createSlackChannelListMessagesTool(context);
-  }
 
-  if (rawChannelCapabilities.canAddReactions) {
-    tools.slackMessageAddReaction = createSlackMessageAddReactionTool(
-      context,
-      state,
-    );
+    if (outputCapabilities.canCreateCanvas) {
+      tools.slackCanvasCreate = createSlackCanvasCreateTool(context, state);
+    }
+
+    if (outputCapabilities.canPostToChannel) {
+      tools.slackChannelPostMessage = createSlackChannelPostMessageTool(
+        context,
+        state,
+      );
+      tools.slackChannelListMessages =
+        createSlackChannelListMessagesTool(context);
+    }
+
+    if (rawChannelCapabilities.canAddReactions) {
+      tools.slackMessageAddReaction = createSlackMessageAddReactionTool(
+        context,
+        state,
+      );
+    }
   }
 
   for (const [name, pluginTool] of Object.entries(

--- a/packages/junior/src/chat/tools/index.ts
+++ b/packages/junior/src/chat/tools/index.ts
@@ -14,7 +14,7 @@ import { createReadFileTool } from "@/chat/tools/sandbox/read-file";
 import { createReportProgressTool } from "@/chat/tools/runtime/report-progress";
 import { createSlackChannelListMessagesTool } from "@/chat/tools/slack/channel-list-messages";
 import { createSlackChannelPostMessageTool } from "@/chat/tools/slack/channel-post-message";
-import { getSlackDeliveryChannelId } from "@/chat/tools/slack/context";
+import { getSlackToolContext } from "@/chat/tools/slack/context";
 import { createSlackMessageAddReactionTool } from "@/chat/tools/slack/message-add-reaction";
 import {
   createSlackCanvasCreateTool,
@@ -118,39 +118,43 @@ export function createTools(
     tools.callMcpTool = createCallMcpToolTool(context.mcpToolManager);
   }
 
-  if (context.destination.platform === "slack") {
+  const slackContext = getSlackToolContext(context);
+  if (slackContext) {
     tools.slackCanvasRead = createSlackCanvasReadTool();
     tools.slackCanvasEdit = createSlackCanvasEditTool(state);
     tools.slackCanvasWrite = createSlackCanvasWriteTool(state);
-    tools.slackThreadRead = createSlackThreadReadTool(context);
+    tools.slackThreadRead = createSlackThreadReadTool(slackContext);
     tools.slackUserLookup = createSlackUserLookupTool();
     tools.slackListCreate = createSlackListCreateTool(state);
     tools.slackListAddItems = createSlackListAddItemsTool(state);
     tools.slackListGetItems = createSlackListGetItemsTool(state);
     tools.slackListUpdateItem = createSlackListUpdateItemTool(state);
 
-    const outputChannelId = getSlackDeliveryChannelId(context);
+    const outputChannelId = slackContext.deliveryChannelId;
     const outputCapabilities = resolveChannelCapabilities(outputChannelId);
     const rawChannelCapabilities = resolveChannelCapabilities(
-      context.destination.channelId,
+      slackContext.channelId,
     );
 
     if (outputCapabilities.canCreateCanvas) {
-      tools.slackCanvasCreate = createSlackCanvasCreateTool(context, state);
+      tools.slackCanvasCreate = createSlackCanvasCreateTool(
+        slackContext,
+        state,
+      );
     }
 
     if (outputCapabilities.canPostToChannel) {
       tools.slackChannelPostMessage = createSlackChannelPostMessageTool(
-        context,
+        slackContext,
         state,
       );
       tools.slackChannelListMessages =
-        createSlackChannelListMessagesTool(context);
+        createSlackChannelListMessagesTool(slackContext);
     }
 
     if (rawChannelCapabilities.canAddReactions) {
       tools.slackMessageAddReaction = createSlackMessageAddReactionTool(
-        context,
+        slackContext,
         state,
       );
     }

--- a/packages/junior/src/chat/tools/index.ts
+++ b/packages/junior/src/chat/tools/index.ts
@@ -130,20 +130,22 @@ export function createTools(
     tools.slackListGetItems = createSlackListGetItemsTool(state);
     tools.slackListUpdateItem = createSlackListUpdateItemTool(state);
 
-    const outputChannelId = slackContext.deliveryChannelId;
-    const outputCapabilities = resolveChannelCapabilities(outputChannelId);
+    const outputChannelId = slackContext.destinationChannelId;
+    const outputCapabilities = outputChannelId
+      ? resolveChannelCapabilities(outputChannelId)
+      : undefined;
     const rawChannelCapabilities = resolveChannelCapabilities(
-      slackContext.channelId,
+      slackContext.sourceChannelId,
     );
 
-    if (outputCapabilities.canCreateCanvas) {
+    if (outputCapabilities?.canCreateCanvas) {
       tools.slackCanvasCreate = createSlackCanvasCreateTool(
         slackContext,
         state,
       );
     }
 
-    if (outputCapabilities.canPostToChannel) {
+    if (outputCapabilities?.canPostToChannel) {
       tools.slackChannelPostMessage = createSlackChannelPostMessageTool(
         slackContext,
         state,

--- a/packages/junior/src/chat/tools/slack/canvas-tools.ts
+++ b/packages/junior/src/chat/tools/slack/canvas-tools.ts
@@ -9,7 +9,7 @@ import {
 } from "@/chat/tools/slack/canvases";
 import { isConversationScopedChannel } from "@/chat/slack/client";
 import { createOperationKey } from "@/chat/tools/idempotency";
-import { getSlackDeliveryChannelId } from "@/chat/tools/slack/context";
+import type { SlackToolContext } from "@/chat/tools/slack/context";
 import { logError, logWarn } from "@/chat/logging";
 import { sliceFileContent } from "@/chat/tools/sandbox/read-file";
 import { normalizeToLf } from "@/chat/tools/sandbox/file-utils";
@@ -20,7 +20,7 @@ import {
   type TextReplacement,
 } from "@/chat/tools/sandbox/text-edits";
 import type { CanvasArtifactSummary } from "@/chat/state/artifacts";
-import type { ToolRuntimeContext, ToolState } from "@/chat/tools/types";
+import type { ToolState } from "@/chat/tools/types";
 
 const MAX_RECENT_CANVASES = 5;
 
@@ -95,7 +95,7 @@ const editReplacementSchema = Type.Object(
 
 /** Create a tool that provisions a new Slack canvas in the active channel. */
 export function createSlackCanvasCreateTool(
-  context: ToolRuntimeContext,
+  context: SlackToolContext,
   state: ToolState,
 ) {
   return tool({
@@ -113,7 +113,7 @@ export function createSlackCanvasCreateTool(
       }),
     }),
     execute: async ({ title, markdown }) => {
-      const targetChannelId = getSlackDeliveryChannelId(context);
+      const targetChannelId = context.deliveryChannelId;
       if (!isConversationScopedChannel(targetChannelId)) {
         logError(
           "slack_canvas_create_invalid_context",

--- a/packages/junior/src/chat/tools/slack/canvas-tools.ts
+++ b/packages/junior/src/chat/tools/slack/canvas-tools.ts
@@ -113,7 +113,7 @@ export function createSlackCanvasCreateTool(
       }),
     }),
     execute: async ({ title, markdown }) => {
-      const targetChannelId = context.deliveryChannelId;
+      const targetChannelId = context.destinationChannelId;
       if (!isConversationScopedChannel(targetChannelId)) {
         logError(
           "slack_canvas_create_invalid_context",

--- a/packages/junior/src/chat/tools/slack/channel-list-messages.ts
+++ b/packages/junior/src/chat/tools/slack/channel-list-messages.ts
@@ -2,6 +2,7 @@ import { Type } from "@sinclair/typebox";
 import { SlackActionError } from "@/chat/slack/client";
 import { listChannelMessages } from "@/chat/slack/channel";
 import { tool } from "@/chat/tools/definition";
+import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 import type { SlackToolContext } from "@/chat/tools/slack/context";
 
 export function createSlackChannelListMessagesTool(context: SlackToolContext) {
@@ -59,7 +60,10 @@ export function createSlackChannelListMessagesTool(context: SlackToolContext) {
       inclusive,
       max_pages,
     }) => {
-      const targetChannelId = context.deliveryChannelId;
+      const targetChannelId = context.destinationChannelId;
+      if (!targetChannelId) {
+        throw new ToolInputError("No active Slack destination is available.");
+      }
 
       let result;
       try {

--- a/packages/junior/src/chat/tools/slack/channel-list-messages.ts
+++ b/packages/junior/src/chat/tools/slack/channel-list-messages.ts
@@ -2,12 +2,9 @@ import { Type } from "@sinclair/typebox";
 import { SlackActionError } from "@/chat/slack/client";
 import { listChannelMessages } from "@/chat/slack/channel";
 import { tool } from "@/chat/tools/definition";
-import { getSlackDeliveryChannelId } from "@/chat/tools/slack/context";
-import type { ToolRuntimeContext } from "@/chat/tools/types";
+import type { SlackToolContext } from "@/chat/tools/slack/context";
 
-export function createSlackChannelListMessagesTool(
-  context: ToolRuntimeContext,
-) {
+export function createSlackChannelListMessagesTool(context: SlackToolContext) {
   return tool({
     description:
       "List channel messages from Slack history in the active channel context. Use when the user asks for recent or historical channel context outside this thread. Do not use for live monitoring or when current thread context already answers the question.",
@@ -62,13 +59,7 @@ export function createSlackChannelListMessagesTool(
       inclusive,
       max_pages,
     }) => {
-      const targetChannelId = getSlackDeliveryChannelId(context);
-      if (!targetChannelId) {
-        return {
-          ok: false,
-          error: "No active channel context is available for history lookup",
-        };
-      }
+      const targetChannelId = context.deliveryChannelId;
 
       let result;
       try {

--- a/packages/junior/src/chat/tools/slack/channel-post-message.ts
+++ b/packages/junior/src/chat/tools/slack/channel-post-message.ts
@@ -1,6 +1,7 @@
 import { Type } from "@sinclair/typebox";
 import { postSlackMessage } from "@/chat/slack/outbound";
 import { tool } from "@/chat/tools/definition";
+import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 import { createOperationKey } from "@/chat/tools/idempotency";
 import type { SlackToolContext } from "@/chat/tools/slack/context";
 import type { ToolState } from "@/chat/tools/types";
@@ -20,7 +21,10 @@ export function createSlackChannelPostMessageTool(
       }),
     }),
     execute: async ({ text }) => {
-      const targetChannelId = context.deliveryChannelId;
+      const targetChannelId = context.destinationChannelId;
+      if (!targetChannelId) {
+        throw new ToolInputError("No active Slack destination is available.");
+      }
 
       const operationKey = createOperationKey("slackChannelPostMessage", {
         channel_id: targetChannelId,

--- a/packages/junior/src/chat/tools/slack/channel-post-message.ts
+++ b/packages/junior/src/chat/tools/slack/channel-post-message.ts
@@ -2,11 +2,11 @@ import { Type } from "@sinclair/typebox";
 import { postSlackMessage } from "@/chat/slack/outbound";
 import { tool } from "@/chat/tools/definition";
 import { createOperationKey } from "@/chat/tools/idempotency";
-import { getSlackDeliveryChannelId } from "@/chat/tools/slack/context";
-import type { ToolRuntimeContext, ToolState } from "@/chat/tools/types";
+import type { SlackToolContext } from "@/chat/tools/slack/context";
+import type { ToolState } from "@/chat/tools/types";
 
 export function createSlackChannelPostMessageTool(
-  context: ToolRuntimeContext,
+  context: SlackToolContext,
   state: ToolState,
 ) {
   return tool({
@@ -20,13 +20,7 @@ export function createSlackChannelPostMessageTool(
       }),
     }),
     execute: async ({ text }) => {
-      const targetChannelId = getSlackDeliveryChannelId(context);
-      if (!targetChannelId) {
-        return {
-          ok: false,
-          error: "No active channel context is available for posting",
-        };
-      }
+      const targetChannelId = context.deliveryChannelId;
 
       const operationKey = createOperationKey("slackChannelPostMessage", {
         channel_id: targetChannelId,

--- a/packages/junior/src/chat/tools/slack/context.ts
+++ b/packages/junior/src/chat/tools/slack/context.ts
@@ -1,33 +1,41 @@
 import type { ToolRuntimeContext } from "@/chat/tools/types";
 import type { SlackDestination } from "@sentry/junior-plugin-api";
+import type { SlackSource } from "@sentry/junior-plugin-api";
 import type { SlackRequester } from "@/chat/requester";
 
 export interface SlackToolContext {
-  destination: SlackDestination;
+  destination?: SlackDestination;
+  source: SlackSource;
   requester?: SlackRequester;
-  channelId: string;
-  deliveryChannelId: string;
+  destinationChannelId?: string;
   messageTs?: string;
+  sourceChannelId: string;
   teamId: string;
   threadTs?: string;
 }
 
-/** Resolve Slack-specific tool context from the active destination/requester. */
+/** Resolve Slack-specific tool context from the active source/destination/requester. */
 export function getSlackToolContext(
   context: ToolRuntimeContext,
 ): SlackToolContext | undefined {
-  if (context.destination.platform !== "slack") {
+  if (context.source.platform !== "slack") {
     return undefined;
   }
   return {
-    destination: context.destination,
+    destination:
+      context.destination?.platform === "slack"
+        ? context.destination
+        : undefined,
+    source: context.source,
     requester:
       context.requester?.platform === "slack" ? context.requester : undefined,
-    channelId: context.destination.channelId,
-    deliveryChannelId:
-      context.slack?.deliveryChannelId ?? context.destination.channelId,
-    messageTs: context.slack?.messageTs,
-    teamId: context.destination.teamId,
-    threadTs: context.slack?.threadTs,
+    destinationChannelId:
+      context.destination?.platform === "slack"
+        ? context.destination.channelId
+        : undefined,
+    messageTs: context.source.messageTs,
+    sourceChannelId: context.source.channelId,
+    teamId: context.source.teamId,
+    threadTs: context.source.threadTs,
   };
 }

--- a/packages/junior/src/chat/tools/slack/context.ts
+++ b/packages/junior/src/chat/tools/slack/context.ts
@@ -1,13 +1,33 @@
 import type { ToolRuntimeContext } from "@/chat/tools/types";
+import type { SlackDestination } from "@sentry/junior-plugin-api";
+import type { SlackRequester } from "@/chat/requester";
 
-/** Resolve the Slack channel used by first-class delivery tools. */
-export function getSlackDeliveryChannelId(
+export interface SlackToolContext {
+  destination: SlackDestination;
+  requester?: SlackRequester;
+  channelId: string;
+  deliveryChannelId: string;
+  messageTs?: string;
+  teamId: string;
+  threadTs?: string;
+}
+
+/** Resolve Slack-specific tool context from the active destination/requester. */
+export function getSlackToolContext(
   context: ToolRuntimeContext,
-): string | undefined {
-  if (context.deliveryChannelId) {
-    return context.deliveryChannelId;
+): SlackToolContext | undefined {
+  if (context.destination.platform !== "slack") {
+    return undefined;
   }
-  return context.destination.platform === "slack"
-    ? context.destination.channelId
-    : context.channelId;
+  return {
+    destination: context.destination,
+    requester:
+      context.requester?.platform === "slack" ? context.requester : undefined,
+    channelId: context.destination.channelId,
+    deliveryChannelId:
+      context.slack?.deliveryChannelId ?? context.destination.channelId,
+    messageTs: context.slack?.messageTs,
+    teamId: context.destination.teamId,
+    threadTs: context.slack?.threadTs,
+  };
 }

--- a/packages/junior/src/chat/tools/slack/context.ts
+++ b/packages/junior/src/chat/tools/slack/context.ts
@@ -4,5 +4,10 @@ import type { ToolRuntimeContext } from "@/chat/tools/types";
 export function getSlackDeliveryChannelId(
   context: ToolRuntimeContext,
 ): string | undefined {
-  return context.deliveryChannelId ?? context.channelId;
+  if (context.deliveryChannelId) {
+    return context.deliveryChannelId;
+  }
+  return context.destination.platform === "slack"
+    ? context.destination.channelId
+    : context.channelId;
 }

--- a/packages/junior/src/chat/tools/slack/message-add-reaction.ts
+++ b/packages/junior/src/chat/tools/slack/message-add-reaction.ts
@@ -22,7 +22,7 @@ export function createSlackMessageAddReactionTool(
       }),
     }),
     execute: async ({ emoji }) => {
-      const targetChannelId = context.channelId;
+      const targetChannelId = context.sourceChannelId;
       const targetMessageTs = context.messageTs;
       if (!targetMessageTs) {
         return {

--- a/packages/junior/src/chat/tools/slack/message-add-reaction.ts
+++ b/packages/junior/src/chat/tools/slack/message-add-reaction.ts
@@ -3,10 +3,11 @@ import { normalizeSlackEmojiName } from "@/chat/slack/emoji";
 import { addReactionToMessage } from "@/chat/slack/outbound";
 import { tool } from "@/chat/tools/definition";
 import { createOperationKey } from "@/chat/tools/idempotency";
-import type { ToolRuntimeContext, ToolState } from "@/chat/tools/types";
+import type { SlackToolContext } from "@/chat/tools/slack/context";
+import type { ToolState } from "@/chat/tools/types";
 
 export function createSlackMessageAddReactionTool(
-  context: ToolRuntimeContext,
+  context: SlackToolContext,
   state: ToolState,
 ) {
   return tool({
@@ -22,12 +23,6 @@ export function createSlackMessageAddReactionTool(
     }),
     execute: async ({ emoji }) => {
       const targetChannelId = context.channelId;
-      if (!targetChannelId) {
-        return {
-          ok: false,
-          error: "No active channel context is available for reactions",
-        };
-      }
       const targetMessageTs = context.messageTs;
       if (!targetMessageTs) {
         return {

--- a/packages/junior/src/chat/tools/slack/thread-read.ts
+++ b/packages/junior/src/chat/tools/slack/thread-read.ts
@@ -174,7 +174,10 @@ export function createSlackThreadReadTool(context: SlackToolContext) {
       }
 
       // Restrict private-thread reads to the active Slack delivery context.
-      const access = checkChannelAccess(channelId, context.deliveryChannelId);
+      const access = checkChannelAccess(
+        channelId,
+        context.destinationChannelId,
+      );
       if (!access.allowed) {
         return {
           ok: false,

--- a/packages/junior/src/chat/tools/slack/thread-read.ts
+++ b/packages/junior/src/chat/tools/slack/thread-read.ts
@@ -9,9 +9,8 @@ import {
   SLACK_TS_PATTERN,
   parseSlackMessageReference,
 } from "@/chat/tools/slack/slack-message-url";
-import { getSlackDeliveryChannelId } from "@/chat/tools/slack/context";
+import type { SlackToolContext } from "@/chat/tools/slack/context";
 import type { SlackThreadReply } from "@/chat/slack/channel";
-import type { ToolRuntimeContext } from "@/chat/tools/types";
 import { renderSlackLegacyAttachmentText } from "@/chat/slack/legacy-attachments";
 
 const MAX_THREAD_READ_CHARS = 40_000;
@@ -105,7 +104,7 @@ function checkChannelAccess(
 }
 
 /** Create a tool that reads a Slack thread from a shared message URL or explicit coordinates. */
-export function createSlackThreadReadTool(context: ToolRuntimeContext) {
+export function createSlackThreadReadTool(context: SlackToolContext) {
   return tool({
     description:
       "Read a Slack thread from a shared Slack message archive URL or explicit channel + timestamp. Use when the user shares a Slack message link (https://*.slack.com/archives/...) and you need the referenced message and its thread context. Public channel links can be read if the bot has access; private channels and DMs are only readable when they are the current conversation.",
@@ -175,10 +174,7 @@ export function createSlackThreadReadTool(context: ToolRuntimeContext) {
       }
 
       // Restrict private-thread reads to the active Slack delivery context.
-      const access = checkChannelAccess(
-        channelId,
-        getSlackDeliveryChannelId(context),
-      );
+      const access = checkChannelAccess(channelId, context.deliveryChannelId);
       if (!access.allowed) {
         return {
           ok: false,

--- a/packages/junior/src/chat/tools/types.ts
+++ b/packages/junior/src/chat/tools/types.ts
@@ -2,7 +2,10 @@ import type { FileUpload } from "chat";
 import type {
   Destination,
   LocalDestination,
+  LocalSource,
   SlackDestination,
+  SlackSource,
+  Source,
 } from "@sentry/junior-plugin-api";
 import type { McpToolManager } from "@/chat/mcp/tool-manager";
 import type { SandboxWorkspace } from "@/chat/sandbox/workspace";
@@ -61,10 +64,12 @@ interface BaseToolRuntimeContext {
    */
   conversationId?: string;
 
-  /** Runtime-owned destination for provider-neutral side effects. */
-  destination: Destination;
+  /** Runtime-owned default outbound destination, if this invocation has one. */
+  destination?: Destination;
 
   requester?: Requester;
+  /** Runtime-owned source where this invocation came from. */
+  source: Source;
   userText?: string;
   artifactState?: ThreadArtifactsState;
   configuration?: Record<string, unknown>;
@@ -72,27 +77,16 @@ interface BaseToolRuntimeContext {
   sandbox: SandboxWorkspace;
 }
 
-interface SlackToolRuntimeHints {
-  /**
-   * Slack delivery override when assistant context points at a source channel
-   * different from the raw destination channel.
-   */
-  deliveryChannelId?: string;
-  /** Current inbound Slack message timestamp for reaction tools. */
-  messageTs?: string;
-  /** Current inbound Slack thread timestamp for hook context. */
-  threadTs?: string;
-}
-
 interface SlackToolRuntimeContext extends BaseToolRuntimeContext {
-  destination: SlackDestination;
+  destination?: SlackDestination;
   requester?: SlackRequester;
-  slack?: SlackToolRuntimeHints;
+  source: SlackSource;
 }
 
 interface LocalToolRuntimeContext extends BaseToolRuntimeContext {
-  destination: LocalDestination;
+  destination?: LocalDestination;
   requester?: LocalRequester;
+  source: LocalSource;
   slack?: never;
 }
 

--- a/packages/junior/src/chat/tools/types.ts
+++ b/packages/junior/src/chat/tools/types.ts
@@ -49,7 +49,7 @@ export interface ToolRuntimeContext {
    * Raw Slack channel/conversation container for this turn: `C...`, `D...`,
    * or `G...`. Never overridden by assistant context. Stable binding key for
    * state scoped to a Slack conversation. Passed to plugin hooks as-is via
-   * `ToolRegistrationHookContext.channelId`.
+   * `ToolRegistrationHookContext.slack.channelId`.
    */
   channelId?: string;
 
@@ -68,7 +68,7 @@ export interface ToolRuntimeContext {
   conversationId?: string;
 
   /** Runtime-owned destination for provider-neutral side effects. */
-  destination?: Destination;
+  destination: Destination;
 
   requester?: Requester;
   teamId?: string;

--- a/packages/junior/src/chat/tools/types.ts
+++ b/packages/junior/src/chat/tools/types.ts
@@ -1,12 +1,20 @@
 import type { FileUpload } from "chat";
-import type { Destination } from "@sentry/junior-plugin-api";
+import type {
+  Destination,
+  LocalDestination,
+  SlackDestination,
+} from "@sentry/junior-plugin-api";
 import type { McpToolManager } from "@/chat/mcp/tool-manager";
 import type { SandboxWorkspace } from "@/chat/sandbox/workspace";
 import type { ThreadArtifactsState } from "@/chat/state/artifacts";
 import type { Skill } from "@/chat/skills";
 import type { LoadSkillMetadata } from "@/chat/tools/skill/load-skill";
 import type { AdvisorToolRuntimeContext } from "@/chat/tools/advisor/tool";
-import type { Requester } from "@/chat/requester";
+import type {
+  LocalRequester,
+  Requester,
+  SlackRequester,
+} from "@/chat/requester";
 
 export interface ImageGenerateToolDeps {
   fetch?: typeof fetch;
@@ -43,22 +51,8 @@ export interface ToolHooks {
   };
 }
 
-export interface ToolRuntimeContext {
+interface BaseToolRuntimeContext {
   advisor?: AdvisorToolRuntimeContext;
-  /**
-   * Raw Slack channel/conversation container for this turn: `C...`, `D...`,
-   * or `G...`. Never overridden by assistant context. Stable binding key for
-   * state scoped to a Slack conversation. Passed to plugin hooks as-is via
-   * `ToolRegistrationHookContext.slack.channelId`.
-   */
-  channelId?: string;
-
-  /**
-   * Slack channel used by first-class delivery tools when assistant context
-   * points at a source channel different from the raw conversation channel.
-   */
-  deliveryChannelId?: string;
-
   /**
    * Opaque Junior conversation/session identity for this turn.
    * Interactive Slack turns use `slack:{channelId}:{threadTs}`.
@@ -71,15 +65,40 @@ export interface ToolRuntimeContext {
   destination: Destination;
 
   requester?: Requester;
-  teamId?: string;
-  messageTs?: string;
-  threadTs?: string;
   userText?: string;
   artifactState?: ThreadArtifactsState;
   configuration?: Record<string, unknown>;
   mcpToolManager?: McpToolManager;
   sandbox: SandboxWorkspace;
 }
+
+interface SlackToolRuntimeHints {
+  /**
+   * Slack delivery override when assistant context points at a source channel
+   * different from the raw destination channel.
+   */
+  deliveryChannelId?: string;
+  /** Current inbound Slack message timestamp for reaction tools. */
+  messageTs?: string;
+  /** Current inbound Slack thread timestamp for hook context. */
+  threadTs?: string;
+}
+
+interface SlackToolRuntimeContext extends BaseToolRuntimeContext {
+  destination: SlackDestination;
+  requester?: SlackRequester;
+  slack?: SlackToolRuntimeHints;
+}
+
+interface LocalToolRuntimeContext extends BaseToolRuntimeContext {
+  destination: LocalDestination;
+  requester?: LocalRequester;
+  slack?: never;
+}
+
+export type ToolRuntimeContext =
+  | LocalToolRuntimeContext
+  | SlackToolRuntimeContext;
 
 export interface ToolState {
   artifactState: ThreadArtifactsState;

--- a/packages/junior/src/cli/chat.ts
+++ b/packages/junior/src/cli/chat.ts
@@ -37,6 +37,33 @@ const DEFAULT_IO: ChatIo = {
   write: (text) => writeStream(defaultStdout, text),
 };
 
+class ChatOutputError extends Error {
+  constructor(error: unknown) {
+    super(errorMessage(error));
+    this.name = "ChatOutputError";
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function deliverReply(io: ChatIo, reply: AssistantReply): Promise<void> {
+  try {
+    await io.write(formatReply(reply));
+  } catch (error) {
+    throw new ChatOutputError(error);
+  }
+}
+
+async function reportStatus(io: ChatIo, status: string): Promise<void> {
+  try {
+    await io.error(status);
+  } catch (error) {
+    throw new ChatOutputError(error);
+  }
+}
+
 function writeStream(
   stream: NodeJS.WritableStream,
   text: string,
@@ -136,10 +163,10 @@ async function runOnce(
     },
     {
       deliverReply: async (reply) => {
-        await io.write(formatReply(reply));
+        await deliverReply(io, reply);
       },
       onStatus: async (status) => {
-        await io.error(status);
+        await reportStatus(io, status);
       },
     },
   );
@@ -173,22 +200,29 @@ async function runInteractive(
       if (message === "/exit" || message === "/quit") {
         break;
       }
-      await runLocalAgentTurn(
-        {
-          conversationAlias: options.conversation,
-          conversationId,
-          message,
-          mode: "interactive",
-        },
-        {
-          deliverReply: async (reply) => {
-            await io.write(formatReply(reply));
+      try {
+        await runLocalAgentTurn(
+          {
+            conversationAlias: options.conversation,
+            conversationId,
+            message,
+            mode: "interactive",
           },
-          onStatus: async (status) => {
-            await io.error(status);
+          {
+            deliverReply: async (reply) => {
+              await deliverReply(io, reply);
+            },
+            onStatus: async (status) => {
+              await reportStatus(io, status);
+            },
           },
-        },
-      );
+        );
+      } catch (error) {
+        if (error instanceof ChatOutputError) {
+          throw error;
+        }
+        await reportStatus(io, errorMessage(error));
+      }
     }
   } finally {
     rl.close();
@@ -220,7 +254,7 @@ export async function runChat(
     await runInteractive(options, io);
     return 0;
   } catch (error) {
-    await io.error(error instanceof Error ? error.message : String(error));
+    await io.error(errorMessage(error));
     return 1;
   }
 }

--- a/packages/junior/src/cli/chat.ts
+++ b/packages/junior/src/cli/chat.ts
@@ -50,6 +50,17 @@ function errorMessage(error: unknown): string {
 
 async function deliverReply(io: ChatIo, reply: AssistantReply): Promise<void> {
   try {
+    const files = reply.files ?? [];
+    if (files.length > 0) {
+      const names = files
+        .map((file) =>
+          typeof file.filename === "string" && file.filename.trim()
+            ? file.filename
+            : "generated file",
+        )
+        .join(", ");
+      throw new Error(`Local chat cannot deliver files yet: ${names}`);
+    }
     await io.write(formatReply(reply));
   } catch (error) {
     throw new ChatOutputError(error);
@@ -88,8 +99,8 @@ function defaultStateAdapterForLocalChat(): void {
 
 function parseChatArgs(argv: string[]): ChatCommandOptions | undefined {
   let conversation = "default";
-  let message: string | undefined;
   let mode: ChatCommandOptions["mode"] = "interactive";
+  const messageParts: string[] = [];
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -104,15 +115,26 @@ function parseChatArgs(argv: string[]): ChatCommandOptions | undefined {
     }
 
     if (arg === "--once") {
-      const rest = argv.slice(index + 1);
-      if (rest.length === 0) {
+      if (mode === "once") {
         return undefined;
       }
-      message = rest.join(" ");
       mode = "once";
-      break;
+      continue;
     }
 
+    if (mode === "once") {
+      messageParts.push(arg);
+      continue;
+    }
+
+    return undefined;
+  }
+
+  const message =
+    mode === "once" && messageParts.length > 0
+      ? messageParts.join(" ")
+      : undefined;
+  if (mode === "once" && !message) {
     return undefined;
   }
 
@@ -128,14 +150,6 @@ function formatReply(reply: AssistantReply): string {
   const text = reply.text.trim();
   if (text) {
     lines.push(text);
-  }
-
-  for (const file of reply.files ?? []) {
-    const filename =
-      typeof file.filename === "string" && file.filename.trim()
-        ? file.filename
-        : "generated file";
-    lines.push(`Generated file: ${filename}`);
   }
 
   return `${lines.join("\n") || "[empty response]"}\n`;

--- a/packages/junior/src/cli/chat.ts
+++ b/packages/junior/src/cli/chat.ts
@@ -89,8 +89,9 @@ function writeStream(
   });
 }
 
+/** Keep local chat ephemeral by default; Redis is opt-in via an explicit adapter. */
 function defaultStateAdapterForLocalChat(): void {
-  if (process.env.JUNIOR_STATE_ADAPTER || process.env.REDIS_URL) {
+  if (process.env.JUNIOR_STATE_ADAPTER) {
     return;
   }
   process.env.JUNIOR_STATE_ADAPTER = "memory";

--- a/packages/junior/src/cli/chat.ts
+++ b/packages/junior/src/cli/chat.ts
@@ -10,15 +10,14 @@ import {
   stderr as defaultStderr,
   stdout as defaultStdout,
 } from "node:process";
+import { randomUUID } from "node:crypto";
 import * as readline from "node:readline/promises";
 import { normalizeLocalConversationId } from "@/chat/local/conversation";
 import type { LocalAgentReply } from "@/chat/local/runner";
 
-export const CHAT_USAGE =
-  "usage: junior chat [--conversation <name>]\n       junior chat [--conversation <name>] --once <message>";
+export const CHAT_USAGE = "usage: junior chat\n       junior chat -p <message>";
 
 export interface ChatCommandOptions {
-  conversation: string;
   message?: string;
   mode: "interactive" | "once";
 }
@@ -99,51 +98,20 @@ function defaultStateAdapterForLocalChat(): void {
 }
 
 function parseChatArgs(argv: string[]): ChatCommandOptions | undefined {
-  let conversation = "default";
-  let mode: ChatCommandOptions["mode"] = "interactive";
-  const messageParts: string[] = [];
+  if (argv.length === 0) {
+    return { mode: "interactive" };
+  }
 
-  for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (arg === "--conversation") {
-      const value = argv[index + 1];
-      if (!value || value.startsWith("--")) {
-        return undefined;
-      }
-      conversation = value;
-      index += 1;
-      continue;
-    }
-
-    if (arg === "--once") {
-      if (mode === "once") {
-        return undefined;
-      }
-      mode = "once";
-      continue;
-    }
-
-    if (mode === "once") {
-      messageParts.push(arg);
-      continue;
-    }
-
+  if (argv[0] !== "-p") {
     return undefined;
   }
 
-  const message =
-    mode === "once" && messageParts.length > 0
-      ? messageParts.join(" ")
-      : undefined;
-  if (mode === "once" && !message) {
+  const message = argv.slice(1).join(" ").trim();
+  if (!message) {
     return undefined;
   }
 
-  if (!normalizeLocalConversationId({ alias: conversation })) {
-    return undefined;
-  }
-
-  return { conversation, ...(message ? { message } : {}), mode };
+  return { message, mode: "once" };
 }
 
 function formatReply(reply: LocalAgentReply): string {
@@ -156,17 +124,22 @@ function formatReply(reply: LocalAgentReply): string {
   return `${lines.join("\n") || "[empty response]"}\n`;
 }
 
+function newRunConversationId(): string {
+  const conversationId = normalizeLocalConversationId({
+    alias: `run-${randomUUID()}`,
+  });
+  if (!conversationId) {
+    throw new Error("Invalid local conversation name");
+  }
+  return conversationId;
+}
+
 async function runOnce(
   options: ChatCommandOptions & { message: string },
   io: ChatIo,
 ): Promise<number> {
   defaultStateAdapterForLocalChat();
-  const conversationId = normalizeLocalConversationId({
-    alias: options.conversation,
-  });
-  if (!conversationId) {
-    throw new Error("Invalid local conversation name");
-  }
+  const conversationId = newRunConversationId();
 
   const { runLocalAgentTurn } = await import("@/chat/local/runner");
   const result = await runLocalAgentTurn(
@@ -186,17 +159,9 @@ async function runOnce(
   return result.outcome === "success" ? 0 : 1;
 }
 
-async function runInteractive(
-  options: ChatCommandOptions,
-  io: ChatIo,
-): Promise<void> {
+async function runInteractive(io: ChatIo): Promise<void> {
   defaultStateAdapterForLocalChat();
-  const conversationId = normalizeLocalConversationId({
-    alias: options.conversation,
-  });
-  if (!conversationId) {
-    throw new Error("Invalid local conversation name");
-  }
+  const conversationId = newRunConversationId();
 
   const { runLocalAgentTurn } = await import("@/chat/local/runner");
   const rl = readline.createInterface({
@@ -262,7 +227,7 @@ export async function runChat(
         io,
       );
     }
-    await runInteractive(options, io);
+    await runInteractive(io);
     return 0;
   } catch (error) {
     await io.error(errorMessage(error));

--- a/packages/junior/src/cli/chat.ts
+++ b/packages/junior/src/cli/chat.ts
@@ -105,7 +105,7 @@ function parseChatArgs(argv: string[]): ChatCommandOptions | undefined {
 
     if (arg === "--once") {
       const rest = argv.slice(index + 1);
-      if (rest.length === 0 || rest.some((value) => value.startsWith("--"))) {
+      if (rest.length === 0) {
         return undefined;
       }
       message = rest.join(" ");

--- a/packages/junior/src/cli/chat.ts
+++ b/packages/junior/src/cli/chat.ts
@@ -17,10 +17,9 @@ import type { LocalAgentReply } from "@/chat/local/runner";
 
 export const CHAT_USAGE = "usage: junior chat\n       junior chat -p <message>";
 
-export interface ChatCommandOptions {
-  message?: string;
-  mode: "interactive" | "once";
-}
+export type ChatCommandOptions =
+  | { mode: "interactive" }
+  | { message: string; mode: "prompt" };
 
 export interface ChatIo {
   error: (line: string) => Promise<void> | void;
@@ -111,7 +110,7 @@ function parseChatArgs(argv: string[]): ChatCommandOptions | undefined {
     return undefined;
   }
 
-  return { message, mode: "once" };
+  return { message, mode: "prompt" };
 }
 
 function formatReply(reply: LocalAgentReply): string {
@@ -124,6 +123,7 @@ function formatReply(reply: LocalAgentReply): string {
   return `${lines.join("\n") || "[empty response]"}\n`;
 }
 
+/** Create a fresh local conversation id for one CLI process invocation. */
 function newRunConversationId(): string {
   const conversationId = normalizeLocalConversationId({
     alias: `run-${randomUUID()}`,
@@ -134,8 +134,8 @@ function newRunConversationId(): string {
   return conversationId;
 }
 
-async function runOnce(
-  options: ChatCommandOptions & { message: string },
+async function runPrompt(
+  options: Extract<ChatCommandOptions, { mode: "prompt" }>,
   io: ChatIo,
 ): Promise<number> {
   defaultStateAdapterForLocalChat();
@@ -217,15 +217,8 @@ export async function runChat(
   }
 
   try {
-    if (options.mode === "once") {
-      if (!options.message) {
-        await io.error(CHAT_USAGE);
-        return 1;
-      }
-      return await runOnce(
-        options as ChatCommandOptions & { message: string },
-        io,
-      );
+    if (options.mode === "prompt") {
+      return await runPrompt(options, io);
     }
     await runInteractive(io);
     return 0;

--- a/packages/junior/src/cli/chat.ts
+++ b/packages/junior/src/cli/chat.ts
@@ -11,8 +11,8 @@ import {
   stdout as defaultStdout,
 } from "node:process";
 import * as readline from "node:readline/promises";
-import type { AssistantReply } from "@/chat/respond";
 import { normalizeLocalConversationId } from "@/chat/local/conversation";
+import type { LocalAgentReply } from "@/chat/local/runner";
 
 export const CHAT_USAGE =
   "usage: junior chat [--conversation <name>]\n       junior chat [--conversation <name>] --once <message>";
@@ -48,7 +48,8 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-async function deliverReply(io: ChatIo, reply: AssistantReply): Promise<void> {
+/** Deliver text-only local replies and turn unsupported files/output errors into failed delivery. */
+async function deliverReply(io: ChatIo, reply: LocalAgentReply): Promise<void> {
   try {
     const files = reply.files ?? [];
     if (files.length > 0) {
@@ -145,7 +146,7 @@ function parseChatArgs(argv: string[]): ChatCommandOptions | undefined {
   return { conversation, ...(message ? { message } : {}), mode };
 }
 
-function formatReply(reply: AssistantReply): string {
+function formatReply(reply: LocalAgentReply): string {
   const lines: string[] = [];
   const text = reply.text.trim();
   if (text) {
@@ -170,10 +171,8 @@ async function runOnce(
   const { runLocalAgentTurn } = await import("@/chat/local/runner");
   const result = await runLocalAgentTurn(
     {
-      conversationAlias: options.conversation,
       conversationId,
       message: options.message,
-      mode: "once",
     },
     {
       deliverReply: async (reply) => {
@@ -184,7 +183,7 @@ async function runOnce(
       },
     },
   );
-  return result.reply.diagnostics.outcome === "success" ? 0 : 1;
+  return result.outcome === "success" ? 0 : 1;
 }
 
 async function runInteractive(
@@ -217,10 +216,8 @@ async function runInteractive(
       try {
         await runLocalAgentTurn(
           {
-            conversationAlias: options.conversation,
             conversationId,
             message,
-            mode: "interactive",
           },
           {
             deliverReply: async (reply) => {

--- a/packages/junior/src/cli/chat.ts
+++ b/packages/junior/src/cli/chat.ts
@@ -1,0 +1,226 @@
+/**
+ * Local chat CLI command.
+ *
+ * This module owns terminal argument parsing and output delivery for `junior
+ * chat`; the agent runtime stays behind the local runner, and invalid CLI input
+ * must fail before conversation state is created.
+ */
+import {
+  stdin as defaultStdin,
+  stderr as defaultStderr,
+  stdout as defaultStdout,
+} from "node:process";
+import * as readline from "node:readline/promises";
+import type { AssistantReply } from "@/chat/respond";
+import { normalizeLocalConversationId } from "@/chat/local/conversation";
+
+export const CHAT_USAGE =
+  "usage: junior chat [--conversation <name>]\n       junior chat [--conversation <name>] --once <message>";
+
+export interface ChatCommandOptions {
+  conversation: string;
+  message?: string;
+  mode: "interactive" | "once";
+}
+
+export interface ChatIo {
+  error: (line: string) => Promise<void> | void;
+  input: NodeJS.ReadableStream;
+  output: NodeJS.WritableStream;
+  write: (text: string) => Promise<void> | void;
+}
+
+const DEFAULT_IO: ChatIo = {
+  error: (line) => writeStream(defaultStderr, `${line}\n`),
+  input: defaultStdin,
+  output: defaultStdout,
+  write: (text) => writeStream(defaultStdout, text),
+};
+
+function writeStream(
+  stream: NodeJS.WritableStream,
+  text: string,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    stream.write(text, (error?: Error | null) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+function defaultStateAdapterForLocalChat(): void {
+  if (process.env.JUNIOR_STATE_ADAPTER || process.env.REDIS_URL) {
+    return;
+  }
+  process.env.JUNIOR_STATE_ADAPTER = "memory";
+}
+
+function parseChatArgs(argv: string[]): ChatCommandOptions | undefined {
+  let conversation = "default";
+  let message: string | undefined;
+  let mode: ChatCommandOptions["mode"] = "interactive";
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--conversation") {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) {
+        return undefined;
+      }
+      conversation = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--once") {
+      const rest = argv.slice(index + 1);
+      if (rest.length === 0 || rest.some((value) => value.startsWith("--"))) {
+        return undefined;
+      }
+      message = rest.join(" ");
+      mode = "once";
+      break;
+    }
+
+    return undefined;
+  }
+
+  if (!normalizeLocalConversationId({ alias: conversation })) {
+    return undefined;
+  }
+
+  return { conversation, ...(message ? { message } : {}), mode };
+}
+
+function formatReply(reply: AssistantReply): string {
+  const lines: string[] = [];
+  const text = reply.text.trim();
+  if (text) {
+    lines.push(text);
+  }
+
+  for (const file of reply.files ?? []) {
+    const filename =
+      typeof file.filename === "string" && file.filename.trim()
+        ? file.filename
+        : "generated file";
+    lines.push(`Generated file: ${filename}`);
+  }
+
+  return `${lines.join("\n") || "[empty response]"}\n`;
+}
+
+async function runOnce(
+  options: ChatCommandOptions & { message: string },
+  io: ChatIo,
+): Promise<number> {
+  defaultStateAdapterForLocalChat();
+  const conversationId = normalizeLocalConversationId({
+    alias: options.conversation,
+  });
+  if (!conversationId) {
+    throw new Error("Invalid local conversation name");
+  }
+
+  const { runLocalAgentTurn } = await import("@/chat/local/runner");
+  const result = await runLocalAgentTurn(
+    {
+      conversationAlias: options.conversation,
+      conversationId,
+      message: options.message,
+      mode: "once",
+    },
+    {
+      deliverReply: async (reply) => {
+        await io.write(formatReply(reply));
+      },
+      onStatus: async (status) => {
+        await io.error(status);
+      },
+    },
+  );
+  return result.reply.diagnostics.outcome === "success" ? 0 : 1;
+}
+
+async function runInteractive(
+  options: ChatCommandOptions,
+  io: ChatIo,
+): Promise<void> {
+  defaultStateAdapterForLocalChat();
+  const conversationId = normalizeLocalConversationId({
+    alias: options.conversation,
+  });
+  if (!conversationId) {
+    throw new Error("Invalid local conversation name");
+  }
+
+  const { runLocalAgentTurn } = await import("@/chat/local/runner");
+  const rl = readline.createInterface({
+    input: io.input,
+    output: io.output,
+    terminal: true,
+  });
+  try {
+    while (true) {
+      const message = (await rl.question("junior> ")).trim();
+      if (!message) {
+        continue;
+      }
+      if (message === "/exit" || message === "/quit") {
+        break;
+      }
+      await runLocalAgentTurn(
+        {
+          conversationAlias: options.conversation,
+          conversationId,
+          message,
+          mode: "interactive",
+        },
+        {
+          deliverReply: async (reply) => {
+            await io.write(formatReply(reply));
+          },
+          onStatus: async (status) => {
+            await io.error(status);
+          },
+        },
+      );
+    }
+  } finally {
+    rl.close();
+  }
+}
+
+/** Run the local Junior chat command. */
+export async function runChat(
+  argv: string[],
+  io: ChatIo = DEFAULT_IO,
+): Promise<number> {
+  const options = parseChatArgs(argv);
+  if (!options) {
+    await io.error(CHAT_USAGE);
+    return 1;
+  }
+
+  try {
+    if (options.mode === "once") {
+      if (!options.message) {
+        await io.error(CHAT_USAGE);
+        return 1;
+      }
+      return await runOnce(
+        options as ChatCommandOptions & { message: string },
+        io,
+      );
+    }
+    await runInteractive(options, io);
+    return 0;
+  } catch (error) {
+    await io.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}

--- a/packages/junior/src/cli/main.ts
+++ b/packages/junior/src/cli/main.ts
@@ -21,9 +21,15 @@ async function runUpgrade(): Promise<void> {
   await mod.runUpgrade();
 }
 
+async function runChat(argv: string[]): Promise<number> {
+  const mod = await import("./chat");
+  return await mod.runChat(argv);
+}
+
 async function main(argv: string[]): Promise<void> {
   loadCliEnvFiles();
   const exitCode = await runCli(argv, {
+    runChat,
     runInit,
     runSnapshotCreate,
     runCheck,

--- a/packages/junior/src/cli/main.ts
+++ b/packages/junior/src/cli/main.ts
@@ -35,9 +35,7 @@ async function main(argv: string[]): Promise<void> {
     runCheck,
     runUpgrade,
   });
-  if (exitCode !== 0) {
-    process.exit(exitCode);
-  }
+  process.exit(exitCode);
 }
 
 main(process.argv.slice(2)).catch((error) => {

--- a/packages/junior/src/cli/run.ts
+++ b/packages/junior/src/cli/run.ts
@@ -1,5 +1,5 @@
 export const CLI_USAGE =
-  "usage: junior init <dir>\n       junior snapshot create\n       junior check [dir]\n       junior upgrade\n       junior chat [--conversation <name>]\n       junior chat [--conversation <name>] --once <message>";
+  "usage: junior init <dir>\n       junior snapshot create\n       junior check [dir]\n       junior upgrade\n       junior chat\n       junior chat -p <message>";
 
 interface CliHandlers {
   runChat: (argv: string[]) => Promise<number>;

--- a/packages/junior/src/cli/run.ts
+++ b/packages/junior/src/cli/run.ts
@@ -1,7 +1,8 @@
 export const CLI_USAGE =
-  "usage: junior init <dir>\n       junior snapshot create\n       junior check [dir]\n       junior upgrade";
+  "usage: junior init <dir>\n       junior snapshot create\n       junior check [dir]\n       junior upgrade\n       junior chat [--conversation <name>]\n       junior chat [--conversation <name>] --once <message>";
 
 interface CliHandlers {
+  runChat: (argv: string[]) => Promise<number>;
   runInit: (dir: string) => Promise<void>;
   runSnapshotCreate: () => Promise<void>;
   runCheck: (dir?: string) => Promise<void>;
@@ -23,6 +24,12 @@ export async function runCli(
   io: CliIo = DEFAULT_IO,
 ): Promise<number> {
   const [command, subcommand, ...rest] = argv;
+
+  if (command === "chat") {
+    return await handlers.runChat(
+      subcommand === undefined ? [] : [subcommand, ...rest],
+    );
+  }
 
   if (command === "init") {
     if (!subcommand || rest.length > 0) {

--- a/packages/junior/src/cli/run.ts
+++ b/packages/junior/src/cli/run.ts
@@ -17,13 +17,18 @@ const DEFAULT_IO: CliIo = {
   error: console.error,
 };
 
+/** Strip Node's leading argv separator while preserving command-level flags. */
+function normalizeCliArgv(argv: string[]): string[] {
+  return argv[0] === "--" ? argv.slice(1) : argv;
+}
+
 /** Dispatch CLI arguments to command handlers and return a process exit code. */
 export async function runCli(
   argv: string[],
   handlers: CliHandlers,
   io: CliIo = DEFAULT_IO,
 ): Promise<number> {
-  const [command, subcommand, ...rest] = argv;
+  const [command, subcommand, ...rest] = normalizeCliArgv(argv);
 
   if (command === "chat") {
     return await handlers.runChat(

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -56,6 +56,7 @@ import {
   createRequesterFromStoredSlackRequester,
   type Requester,
 } from "@/chat/requester";
+import { requireSlackDestination } from "@/chat/destination";
 
 const CALLBACK_PAGES = {
   missing_state: {
@@ -198,7 +199,10 @@ async function resumeAuthorizedMcpTurn(args: {
   ) {
     return;
   }
-  const destination = authSession.destination;
+  const destination = requireSlackDestination(
+    authSession.destination,
+    "MCP OAuth resume",
+  );
 
   const threadId = `slack:${authSession.channelId}:${authSession.threadTs}`;
   const currentState = await getPersistedThreadState(threadId);

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -66,6 +66,7 @@ import { escapeXml } from "@/chat/xml";
 import type { WaitUntilFn } from "@/handlers/types";
 import { scheduleAgentContinue } from "@/chat/services/agent-continue";
 import type { AssistantReply, generateAssistantReply } from "@/chat/respond";
+import { requireSlackDestination } from "@/chat/destination";
 
 interface OAuthCallbackOptions {
   generateReply?: typeof generateAssistantReply;
@@ -184,7 +185,10 @@ async function resumeOAuthSessionRecordTurn(
   ) {
     return false;
   }
-  const destination = stored.destination;
+  const destination = requireSlackDestination(
+    stored.destination,
+    "OAuth resume",
+  );
 
   const currentState = await getPersistedThreadState(
     stored.resumeConversationId,
@@ -485,8 +489,12 @@ async function resumePendingOAuthMessage(
   const conversationContext = buildConversationContext(conversation, {
     excludeMessageId: latestUserMessage?.id,
   });
+  const destination = requireSlackDestination(
+    stored.destination,
+    "OAuth pending message resume",
+  );
   const requester = await lookupSlackRequester(
-    stored.destination.teamId,
+    destination.teamId,
     stored.userId,
   );
   await resumeAuthorizedRequest({

--- a/packages/junior/src/reporting/conversations.ts
+++ b/packages/junior/src/reporting/conversations.ts
@@ -1053,7 +1053,7 @@ function countConversationMessages(transcript: TranscriptMessage[]): number {
 function systemPromptMessage(destination: Destination): TranscriptMessage {
   return {
     role: "system",
-    parts: [{ type: "text", text: buildSystemPrompt({ destination }) }],
+    parts: [{ type: "text", text: buildSystemPrompt({ source: destination }) }],
   };
 }
 

--- a/packages/junior/src/reporting/conversations.ts
+++ b/packages/junior/src/reporting/conversations.ts
@@ -12,6 +12,7 @@ import {
 } from "@/chat/conversation-privacy";
 import type { PiMessage } from "@/chat/pi/messages";
 import { buildSystemPrompt } from "@/chat/prompt";
+import type { Destination } from "@sentry/junior-plugin-api";
 import {
   buildSentryConversationUrl,
   buildSentryTraceUrl,
@@ -1049,10 +1050,10 @@ function countConversationMessages(transcript: TranscriptMessage[]): number {
   return transcript.filter(isConversationMessage).length;
 }
 
-function systemPromptMessage(): TranscriptMessage {
+function systemPromptMessage(destination: Destination): TranscriptMessage {
   return {
     role: "system",
-    parts: [{ type: "text", text: buildSystemPrompt() }],
+    parts: [{ type: "text", text: buildSystemPrompt({ destination }) }],
   };
 }
 
@@ -1263,8 +1264,9 @@ export async function readConversationReport(
       const transcript = canExposeTranscript
         ? [
             ...(scopedMessages.startsAtRunBoundary &&
-            normalizedTranscript.length > 0
-              ? [systemPromptMessage()]
+            normalizedTranscript.length > 0 &&
+            sessionRecord?.destination
+              ? [systemPromptMessage(sessionRecord.destination)]
               : []),
             ...normalizedTranscript,
           ]

--- a/packages/junior/tests/integration/advisor/advisor-tool.test.ts
+++ b/packages/junior/tests/integration/advisor/advisor-tool.test.ts
@@ -94,6 +94,7 @@ describe("advisor tool", () => {
   it("is exposed only when advisor runtime context is enabled", () => {
     const baseContext = {
       destination: LOCAL_DESTINATION,
+      source: LOCAL_DESTINATION,
       sandbox: {} as any,
     };
     expect(createTools([], {}, baseContext)).not.toHaveProperty("advisor");
@@ -188,6 +189,7 @@ describe("advisor tool", () => {
         {},
         {
           destination: LOCAL_DESTINATION,
+          source: LOCAL_DESTINATION,
           sandbox: {} as any,
         },
       ),

--- a/packages/junior/tests/integration/advisor/advisor-tool.test.ts
+++ b/packages/junior/tests/integration/advisor/advisor-tool.test.ts
@@ -15,6 +15,11 @@ import { tool } from "@/chat/tools/definition";
 
 type StreamResponse = Awaited<ReturnType<StreamFn>>;
 
+const LOCAL_DESTINATION = {
+  platform: "local",
+  conversationId: "local:test:advisor",
+} as const;
+
 const config: AdvisorConfig = {
   modelId: "openai/gpt-5.5",
   thinkingLevel: "xhigh",
@@ -88,6 +93,7 @@ async function executeAdvisor(
 describe("advisor tool", () => {
   it("is exposed only when advisor runtime context is enabled", () => {
     const baseContext = {
+      destination: LOCAL_DESTINATION,
       sandbox: {} as any,
     };
     expect(createTools([], {}, baseContext)).not.toHaveProperty("advisor");
@@ -181,6 +187,7 @@ describe("advisor tool", () => {
         [],
         {},
         {
+          destination: LOCAL_DESTINATION,
           sandbox: {} as any,
         },
       ),
@@ -191,10 +198,6 @@ describe("advisor tool", () => {
       "grep",
       "listDir",
       "readFile",
-      "slackCanvasRead",
-      "slackListGetItems",
-      "slackThreadRead",
-      "slackUserLookup",
       "systemTime",
       "webFetch",
       "webSearch",

--- a/packages/junior/tests/integration/dashboard-reporting.test.ts
+++ b/packages/junior/tests/integration/dashboard-reporting.test.ts
@@ -709,6 +709,11 @@ describe("dashboard reporting", () => {
 
     await upsertAgentTurnSessionRecord({
       conversationId: "slack:C1:999",
+      destination: {
+        platform: "slack",
+        teamId: "T123",
+        channelId: "C1",
+      },
       sessionId: "target-turn",
       sliceId: 1,
       state: "completed",
@@ -755,6 +760,11 @@ describe("dashboard reporting", () => {
 
     await upsertAgentTurnSessionRecord({
       conversationId: "slack:C1:333",
+      destination: {
+        platform: "slack",
+        teamId: "T123",
+        channelId: "C1",
+      },
       sessionId: "turn-one",
       sliceId: 1,
       state: "completed",
@@ -773,6 +783,11 @@ describe("dashboard reporting", () => {
     });
     await upsertAgentTurnSessionRecord({
       conversationId: "slack:C1:333",
+      destination: {
+        platform: "slack",
+        teamId: "T123",
+        channelId: "C1",
+      },
       sessionId: "turn-two",
       sliceId: 1,
       state: "completed",

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -15,9 +15,13 @@ import { commitMessages, loadProjection } from "@/chat/state/session-log";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
 import { coerceThreadArtifactsState } from "@/chat/state/artifacts";
 
-function successReply(text: string): AssistantReply {
+function successReply(
+  text: string,
+  options: Partial<Pick<AssistantReply, "piMessages">> = {},
+): AssistantReply {
   return {
     text,
+    ...options,
     diagnostics: {
       assistantMessageCount: 1,
       modelId: "fake-local-agent",
@@ -242,6 +246,65 @@ describe("local agent runner", () => {
     );
 
     expect(contexts[0]?.piMessages).toEqual([projectedMessage]);
+  });
+
+  it("commits generated Pi history after successful local delivery", async () => {
+    const conversationId = normalizeLocalConversationId({
+      alias: "pi-history-commit",
+      cwd: "/tmp/local-agent-runner-six",
+    });
+    expect(conversationId).toBeDefined();
+
+    const generatedMessages = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "persisted pi output" }],
+      },
+    ] as PiMessage[];
+    const generateReply = vi.fn<typeof generateAssistantReply>(async () =>
+      successReply("persisted visible output", {
+        piMessages: generatedMessages,
+      }),
+    );
+
+    await runLocalAgentTurn(
+      {
+        conversationId: conversationId!,
+        message: "hello",
+      },
+      {
+        deliverReply: async () => undefined,
+        generateAssistantReply: generateReply,
+      },
+    );
+
+    expect(await loadProjection({ conversationId: conversationId! })).toEqual(
+      generatedMessages,
+    );
+    const state = await getPersistedThreadState(conversationId!);
+    const conversation = coerceThreadConversationState(state);
+    expect(conversation.piMessages).toEqual(generatedMessages);
+
+    const contexts: ReplyRequestContext[] = [];
+    await runLocalAgentTurn(
+      {
+        conversationId: conversationId!,
+        message: "follow up",
+      },
+      {
+        deliverReply: async () => undefined,
+        generateAssistantReply: async (_text, context = {}) => {
+          contexts.push(context);
+          return successReply("follow up reply");
+        },
+      },
+    );
+
+    expect(contexts[0]?.piMessages).toEqual([generatedMessages[0]]);
   });
 
   it("rolls back generated Pi output when local delivery fails", async () => {

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -45,7 +45,7 @@ describe("local agent runner", () => {
 
     const contexts: ReplyRequestContext[] = [];
     const generateReply = vi.fn<typeof generateAssistantReply>(
-      async (_text, context = {}) => {
+      async (_text, context) => {
         contexts.push(context);
         return successReply("hello from local");
       },
@@ -79,9 +79,15 @@ describe("local agent runner", () => {
         surface: "internal",
       }),
     );
-    expect(contexts[0]?.requester).toBeUndefined();
+    expect(contexts[0]?.requester).toEqual({
+      fullName: "Local CLI",
+      platform: "local",
+      userId: "local-cli",
+      userName: "local",
+    });
     expect(contexts[0]?.slackConversation).toBeUndefined();
     expect(contexts[0]?.correlation?.channelId).toBeUndefined();
+    expect(contexts[0]?.correlation?.teamId).toBeUndefined();
     expect(contexts[0]?.correlation?.threadId).toBeUndefined();
     expect(delivered).toEqual(["hello from local"]);
 
@@ -121,7 +127,7 @@ describe("local agent runner", () => {
 
     const contexts: ReplyRequestContext[] = [];
     const generateReply = vi.fn<typeof generateAssistantReply>(
-      async (text, context = {}) => {
+      async (text, context) => {
         contexts.push(context);
         return successReply(`reply to ${text}`);
       },
@@ -229,7 +235,7 @@ describe("local agent runner", () => {
 
     const contexts: ReplyRequestContext[] = [];
     const generateReply = vi.fn<typeof generateAssistantReply>(
-      async (_text, context = {}) => {
+      async (_text, context) => {
         contexts.push(context);
         return successReply("uses projection");
       },
@@ -298,7 +304,7 @@ describe("local agent runner", () => {
       },
       {
         deliverReply: async () => undefined,
-        generateAssistantReply: async (_text, context = {}) => {
+        generateAssistantReply: async (_text, context) => {
           contexts.push(context);
           return successReply("follow up reply");
         },
@@ -347,7 +353,7 @@ describe("local agent runner", () => {
       },
       {
         deliverReply: async () => undefined,
-        generateAssistantReply: async (_text, context = {}) => {
+        generateAssistantReply: async (_text, context) => {
           contexts.push(context);
           return successReply("uses newer fallback");
         },
@@ -369,7 +375,7 @@ describe("local agent runner", () => {
       content: [{ type: "text", text: "undelivered pi output" }],
     } as PiMessage;
     const generateReply = vi.fn<typeof generateAssistantReply>(
-      async (_text, context = {}) => {
+      async (_text, context) => {
         await context.onArtifactStateUpdated?.({
           lastCanvasId: "canvas-undelivered",
           lastCanvasUrl: "https://example.invalid/canvas",

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -8,7 +8,7 @@ import { normalizeLocalConversationId } from "@/chat/local/conversation";
 import { runLocalAgentTurn } from "@/chat/local/runner";
 import type { PiMessage } from "@/chat/pi/messages";
 import { getPersistedThreadState } from "@/chat/runtime/thread-state";
-import { commitMessages } from "@/chat/state/session-log";
+import { commitMessages, loadProjection } from "@/chat/state/session-log";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
 
 function successReply(text: string): AssistantReply {
@@ -229,5 +229,47 @@ describe("local agent runner", () => {
     );
 
     expect(contexts[0]?.piMessages).toEqual([projectedMessage]);
+  });
+
+  it("rolls back generated Pi output when local delivery fails", async () => {
+    const conversationId = normalizeLocalConversationId({
+      alias: "delivery-pi-rollback",
+      cwd: "/tmp/local-agent-runner-five",
+    });
+    expect(conversationId).toBeDefined();
+
+    const assistantMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "undelivered pi output" }],
+    } as PiMessage;
+    const generateReply = vi.fn<typeof generateAssistantReply>(async () => {
+      await commitMessages({
+        conversationId: conversationId!,
+        messages: [assistantMessage],
+        ttlMs: 60_000,
+      });
+      return successReply("not delivered");
+    });
+
+    await expect(
+      runLocalAgentTurn(
+        {
+          conversationAlias: "delivery-pi-rollback",
+          conversationId: conversationId!,
+          message: "hello",
+          mode: "once",
+        },
+        {
+          deliverReply: async () => {
+            throw new Error("stdout closed");
+          },
+          generateAssistantReply: generateReply,
+        },
+      ),
+    ).rejects.toThrow("stdout closed");
+
+    expect(await loadProjection({ conversationId: conversationId! })).toEqual(
+      [],
+    );
   });
 });

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -49,10 +49,8 @@ describe("local agent runner", () => {
 
     await runLocalAgentTurn(
       {
-        conversationAlias: "demo",
         conversationId: conversationId!,
         message: "hello",
-        mode: "once",
       },
       {
         deliverReply: async (reply) => {
@@ -126,10 +124,8 @@ describe("local agent runner", () => {
 
     await runLocalAgentTurn(
       {
-        conversationAlias: "followup",
         conversationId: conversationId!,
         message: "first question",
-        mode: "once",
       },
       {
         deliverReply: async () => undefined,
@@ -138,10 +134,8 @@ describe("local agent runner", () => {
     );
     await runLocalAgentTurn(
       {
-        conversationAlias: "followup",
         conversationId: conversationId!,
         message: "second question",
-        mode: "once",
       },
       {
         deliverReply: async () => undefined,
@@ -178,10 +172,8 @@ describe("local agent runner", () => {
     await expect(
       runLocalAgentTurn(
         {
-          conversationAlias: "missing-delivery",
           conversationId: conversationId!,
           message: "hello",
-          mode: "once",
         },
         {
           generateAssistantReply: generateReply,
@@ -193,6 +185,25 @@ describe("local agent runner", () => {
     const state = await getPersistedThreadState(conversationId!);
     const conversation = coerceThreadConversationState(state);
     expect(conversation.messages).toEqual([]);
+  });
+
+  it("rejects malformed local conversation ids before generation", async () => {
+    const generateReply = vi.fn<typeof generateAssistantReply>(async () => {
+      throw new Error("generation should not run");
+    });
+
+    await expect(
+      runLocalAgentTurn(
+        {
+          conversationId: "slack:C123:123.456",
+          message: "hello",
+        },
+        {
+          deliverReply: async () => undefined,
+          generateAssistantReply: generateReply,
+        },
+      ),
+    ).rejects.toThrow("Invalid local conversation id");
   });
 
   it("uses durable Pi projection for follow-up local turns", async () => {
@@ -221,10 +232,8 @@ describe("local agent runner", () => {
 
     await runLocalAgentTurn(
       {
-        conversationAlias: "pi-history",
         conversationId: conversationId!,
         message: "follow up",
-        mode: "once",
       },
       {
         deliverReply: async () => undefined,
@@ -268,10 +277,8 @@ describe("local agent runner", () => {
     await expect(
       runLocalAgentTurn(
         {
-          conversationAlias: "delivery-pi-rollback",
           conversationId: conversationId!,
           message: "hello",
-          mode: "once",
         },
         {
           deliverReply: async () => {

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  AssistantReply,
+  generateAssistantReply,
+  ReplyRequestContext,
+} from "@/chat/respond";
+import { normalizeLocalConversationId } from "@/chat/local/conversation";
+import { runLocalAgentTurn } from "@/chat/local/runner";
+import { getPersistedThreadState } from "@/chat/runtime/thread-state";
+import { coerceThreadConversationState } from "@/chat/state/conversation";
+
+function successReply(text: string): AssistantReply {
+  return {
+    text,
+    diagnostics: {
+      assistantMessageCount: 1,
+      modelId: "fake-local-agent",
+      outcome: "success",
+      toolCalls: [],
+      toolErrorCount: 0,
+      toolResultCount: 0,
+      usedPrimaryText: true,
+    },
+  };
+}
+
+describe("local agent runner", () => {
+  it("runs a local message without Slack requester or destination state", async () => {
+    const conversationId = normalizeLocalConversationId({
+      alias: "demo",
+      cwd: "/tmp/local-agent-runner-one",
+    });
+    expect(conversationId).toBeDefined();
+
+    const contexts: ReplyRequestContext[] = [];
+    const generateReply = vi.fn<typeof generateAssistantReply>(
+      async (_text, context = {}) => {
+        contexts.push(context);
+        return successReply("hello from local");
+      },
+    );
+    const delivered: string[] = [];
+
+    await runLocalAgentTurn(
+      {
+        conversationAlias: "demo",
+        conversationId: conversationId!,
+        message: "hello",
+        mode: "once",
+      },
+      {
+        deliverReply: async (reply) => {
+          delivered.push(reply.text);
+        },
+        generateAssistantReply: generateReply,
+      },
+    );
+
+    expect(generateReply).toHaveBeenCalledWith(
+      "hello",
+      expect.objectContaining({
+        authorizationFlowMode: "disabled",
+        credentialContext: {
+          actor: { type: "system", id: "local-cli" },
+        },
+        destination: {
+          platform: "local",
+          conversationId,
+        },
+        surface: "internal",
+      }),
+    );
+    expect(contexts[0]?.requester).toBeUndefined();
+    expect(contexts[0]?.slackConversation).toBeUndefined();
+    expect(contexts[0]?.correlation?.channelId).toBeUndefined();
+    expect(delivered).toEqual(["hello from local"]);
+
+    const state = await getPersistedThreadState(conversationId!);
+    const conversation = coerceThreadConversationState(state);
+    expect(conversation.messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+    ]);
+    expect(conversation.messages[0]).toMatchObject({
+      text: "hello",
+      author: {
+        userId: "local-cli",
+        userName: "local",
+      },
+      meta: {
+        replied: true,
+      },
+    });
+    expect(conversation.messages[1]).toMatchObject({
+      text: "hello from local",
+      author: {
+        isBot: true,
+      },
+      meta: {
+        replied: true,
+      },
+    });
+  });
+
+  it("preserves visible local conversation context across messages", async () => {
+    const conversationId = normalizeLocalConversationId({
+      alias: "followup",
+      cwd: "/tmp/local-agent-runner-two",
+    });
+    expect(conversationId).toBeDefined();
+
+    const contexts: ReplyRequestContext[] = [];
+    const generateReply = vi.fn<typeof generateAssistantReply>(
+      async (text, context = {}) => {
+        contexts.push(context);
+        return successReply(`reply to ${text}`);
+      },
+    );
+
+    await runLocalAgentTurn(
+      {
+        conversationAlias: "followup",
+        conversationId: conversationId!,
+        message: "first question",
+        mode: "once",
+      },
+      { generateAssistantReply: generateReply },
+    );
+    await runLocalAgentTurn(
+      {
+        conversationAlias: "followup",
+        conversationId: conversationId!,
+        message: "second question",
+        mode: "once",
+      },
+      { generateAssistantReply: generateReply },
+    );
+
+    expect(contexts[1]?.conversationContext).toContain("first question");
+    expect(contexts[1]?.conversationContext).toContain(
+      "reply to first question",
+    );
+
+    const state = await getPersistedThreadState(conversationId!);
+    const conversation = coerceThreadConversationState(state);
+    expect(conversation.messages.map((message) => message.text)).toEqual([
+      "first question",
+      "reply to first question",
+      "second question",
+      "reply to second question",
+    ]);
+  });
+});

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -75,6 +75,7 @@ describe("local agent runner", () => {
     expect(contexts[0]?.requester).toBeUndefined();
     expect(contexts[0]?.slackConversation).toBeUndefined();
     expect(contexts[0]?.correlation?.channelId).toBeUndefined();
+    expect(contexts[0]?.correlation?.threadId).toBeUndefined();
     expect(delivered).toEqual(["hello from local"]);
 
     const state = await getPersistedThreadState(conversationId!);

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -124,7 +124,10 @@ describe("local agent runner", () => {
         message: "first question",
         mode: "once",
       },
-      { generateAssistantReply: generateReply },
+      {
+        deliverReply: async () => undefined,
+        generateAssistantReply: generateReply,
+      },
     );
     await runLocalAgentTurn(
       {
@@ -133,7 +136,10 @@ describe("local agent runner", () => {
         message: "second question",
         mode: "once",
       },
-      { generateAssistantReply: generateReply },
+      {
+        deliverReply: async () => undefined,
+        generateAssistantReply: generateReply,
+      },
     );
 
     expect(contexts[1]?.conversationContext).toContain("first question");
@@ -149,5 +155,36 @@ describe("local agent runner", () => {
       "second question",
       "reply to second question",
     ]);
+  });
+
+  it("requires local delivery before running a turn", async () => {
+    const conversationId = normalizeLocalConversationId({
+      alias: "missing-delivery",
+      cwd: "/tmp/local-agent-runner-three",
+    });
+    expect(conversationId).toBeDefined();
+
+    const generateReply = vi.fn<typeof generateAssistantReply>(async () =>
+      successReply("not delivered"),
+    );
+
+    await expect(
+      runLocalAgentTurn(
+        {
+          conversationAlias: "missing-delivery",
+          conversationId: conversationId!,
+          message: "hello",
+          mode: "once",
+        },
+        {
+          generateAssistantReply: generateReply,
+        } as unknown as Parameters<typeof runLocalAgentTurn>[1],
+      ),
+    ).rejects.toThrow("Local reply delivery is required");
+    expect(generateReply).not.toHaveBeenCalled();
+
+    const state = await getPersistedThreadState(conversationId!);
+    const conversation = coerceThreadConversationState(state);
+    expect(conversation.messages).toEqual([]);
   });
 });

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -7,9 +7,13 @@ import type {
 import { normalizeLocalConversationId } from "@/chat/local/conversation";
 import { runLocalAgentTurn } from "@/chat/local/runner";
 import type { PiMessage } from "@/chat/pi/messages";
-import { getPersistedThreadState } from "@/chat/runtime/thread-state";
+import {
+  getPersistedSandboxState,
+  getPersistedThreadState,
+} from "@/chat/runtime/thread-state";
 import { commitMessages, loadProjection } from "@/chat/state/session-log";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
+import { coerceThreadArtifactsState } from "@/chat/state/artifacts";
 
 function successReply(text: string): AssistantReply {
   return {
@@ -242,14 +246,24 @@ describe("local agent runner", () => {
       role: "assistant",
       content: [{ type: "text", text: "undelivered pi output" }],
     } as PiMessage;
-    const generateReply = vi.fn<typeof generateAssistantReply>(async () => {
-      await commitMessages({
-        conversationId: conversationId!,
-        messages: [assistantMessage],
-        ttlMs: 60_000,
-      });
-      return successReply("not delivered");
-    });
+    const generateReply = vi.fn<typeof generateAssistantReply>(
+      async (_text, context = {}) => {
+        await context.onArtifactStateUpdated?.({
+          lastCanvasId: "canvas-undelivered",
+          lastCanvasUrl: "https://example.invalid/canvas",
+        });
+        await context.onSandboxAcquired?.({
+          sandboxDependencyProfileHash: "profile-undelivered",
+          sandboxId: "sandbox-undelivered",
+        });
+        await commitMessages({
+          conversationId: conversationId!,
+          messages: [assistantMessage],
+          ttlMs: 60_000,
+        });
+        return successReply("not delivered");
+      },
+    );
 
     await expect(
       runLocalAgentTurn(
@@ -271,5 +285,8 @@ describe("local agent runner", () => {
     expect(await loadProjection({ conversationId: conversationId! })).toEqual(
       [],
     );
+    const state = await getPersistedThreadState(conversationId!);
+    expect(coerceThreadArtifactsState(state).lastCanvasId).toBeUndefined();
+    expect(getPersistedSandboxState(state)).toEqual({});
   });
 });

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -10,6 +10,7 @@ import type { PiMessage } from "@/chat/pi/messages";
 import {
   getPersistedSandboxState,
   getPersistedThreadState,
+  persistThreadStateById,
 } from "@/chat/runtime/thread-state";
 import { commitMessages, loadProjection } from "@/chat/state/session-log";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
@@ -305,6 +306,55 @@ describe("local agent runner", () => {
     );
 
     expect(contexts[0]?.piMessages).toEqual([generatedMessages[0]]);
+  });
+
+  it("uses conversation Pi history when the session projection is stale", async () => {
+    const conversationId = normalizeLocalConversationId({
+      alias: "pi-history-stale-projection",
+      cwd: "/tmp/local-agent-runner-seven",
+    });
+    expect(conversationId).toBeDefined();
+
+    const projectedMessage = {
+      role: "user",
+      content: [{ type: "text", text: "stale projected history" }],
+    } as PiMessage;
+    await commitMessages({
+      conversationId: conversationId!,
+      messages: [projectedMessage],
+      ttlMs: 60_000,
+    });
+
+    const newerMessages = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "newer conversation history" }],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "newer assistant output" }],
+      },
+    ] as PiMessage[];
+    const conversation = coerceThreadConversationState({});
+    conversation.piMessages = newerMessages;
+    await persistThreadStateById(conversationId!, { conversation });
+
+    const contexts: ReplyRequestContext[] = [];
+    await runLocalAgentTurn(
+      {
+        conversationId: conversationId!,
+        message: "follow up",
+      },
+      {
+        deliverReply: async () => undefined,
+        generateAssistantReply: async (_text, context = {}) => {
+          contexts.push(context);
+          return successReply("uses newer fallback");
+        },
+      },
+    );
+
+    expect(contexts[0]?.piMessages).toEqual([newerMessages[0]]);
   });
 
   it("rolls back generated Pi output when local delivery fails", async () => {

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -6,7 +6,9 @@ import type {
 } from "@/chat/respond";
 import { normalizeLocalConversationId } from "@/chat/local/conversation";
 import { runLocalAgentTurn } from "@/chat/local/runner";
+import type { PiMessage } from "@/chat/pi/messages";
 import { getPersistedThreadState } from "@/chat/runtime/thread-state";
+import { commitMessages } from "@/chat/state/session-log";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
 
 function successReply(text: string): AssistantReply {
@@ -186,5 +188,45 @@ describe("local agent runner", () => {
     const state = await getPersistedThreadState(conversationId!);
     const conversation = coerceThreadConversationState(state);
     expect(conversation.messages).toEqual([]);
+  });
+
+  it("uses durable Pi projection for follow-up local turns", async () => {
+    const conversationId = normalizeLocalConversationId({
+      alias: "pi-history",
+      cwd: "/tmp/local-agent-runner-four",
+    });
+    expect(conversationId).toBeDefined();
+    const projectedMessage = {
+      role: "user",
+      content: [{ type: "text", text: "projected history" }],
+    } as PiMessage;
+    await commitMessages({
+      conversationId: conversationId!,
+      messages: [projectedMessage],
+      ttlMs: 60_000,
+    });
+
+    const contexts: ReplyRequestContext[] = [];
+    const generateReply = vi.fn<typeof generateAssistantReply>(
+      async (_text, context = {}) => {
+        contexts.push(context);
+        return successReply("uses projection");
+      },
+    );
+
+    await runLocalAgentTurn(
+      {
+        conversationAlias: "pi-history",
+        conversationId: conversationId!,
+        message: "follow up",
+        mode: "once",
+      },
+      {
+        deliverReply: async () => undefined,
+        generateAssistantReply: generateReply,
+      },
+    );
+
+    expect(contexts[0]?.piMessages).toEqual([projectedMessage]);
   });
 });

--- a/packages/junior/tests/integration/oauth-resume-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-resume-slack.test.ts
@@ -27,6 +27,12 @@ function makeDiagnostics(
   };
 }
 
+const TEST_SLACK_DESTINATION = {
+  platform: "slack",
+  teamId: "T123",
+  channelId: "C123",
+} as const;
+
 describe("oauth resume slack integration", () => {
   beforeEach(async () => {
     process.env.JUNIOR_STATE_ADAPTER = "memory";
@@ -52,6 +58,7 @@ describe("oauth resume slack integration", () => {
         credentialContext: {
           actor: { type: "user", userId: "U123" },
         },
+        destination: TEST_SLACK_DESTINATION,
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       generateReply: async () =>
@@ -147,6 +154,7 @@ describe("oauth resume slack integration", () => {
         credentialContext: {
           actor: { type: "user", userId: "U123" },
         },
+        destination: TEST_SLACK_DESTINATION,
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
         correlation: {
           conversationId: "conversation-1",
@@ -208,6 +216,7 @@ describe("oauth resume slack integration", () => {
         credentialContext: {
           actor: { type: "user", userId: "U123" },
         },
+        destination: TEST_SLACK_DESTINATION,
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       generateReply: async () =>
@@ -246,6 +255,7 @@ describe("oauth resume slack integration", () => {
         credentialContext: {
           actor: { type: "user", userId: "U123" },
         },
+        destination: TEST_SLACK_DESTINATION,
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       generateReply: async () =>
@@ -281,6 +291,7 @@ describe("oauth resume slack integration", () => {
         credentialContext: {
           actor: { type: "user", userId: "U123" },
         },
+        destination: TEST_SLACK_DESTINATION,
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       generateReply: async () =>
@@ -317,6 +328,7 @@ describe("oauth resume slack integration", () => {
         credentialContext: {
           actor: { type: "user", userId: "U123" },
         },
+        destination: TEST_SLACK_DESTINATION,
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       generateReply: async () =>
@@ -374,6 +386,7 @@ describe("oauth resume slack integration", () => {
         credentialContext: {
           actor: { type: "user", userId: "U123" },
         },
+        destination: TEST_SLACK_DESTINATION,
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       generateReply: async () =>

--- a/packages/junior/tests/integration/slack-channel-tools.test.ts
+++ b/packages/junior/tests/integration/slack-channel-tools.test.ts
@@ -39,6 +39,11 @@ function createContext(
 ): ToolRuntimeContext {
   return {
     channelId: "C123",
+    destination: {
+      platform: "slack",
+      teamId: "T123",
+      channelId: "C123",
+    },
     messageTs: "1700000000.321",
     userText,
     sandbox: {} as any,

--- a/packages/junior/tests/integration/slack-channel-tools.test.ts
+++ b/packages/junior/tests/integration/slack-channel-tools.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from "vitest";
 import { createSlackChannelListMessagesTool } from "@/chat/tools/slack/channel-list-messages";
 import { createSlackChannelPostMessageTool } from "@/chat/tools/slack/channel-post-message";
 import { createSlackMessageAddReactionTool } from "@/chat/tools/slack/message-add-reaction";
-import type { ToolRuntimeContext, ToolState } from "@/chat/tools/types";
+import type { SlackToolContext } from "@/chat/tools/slack/context";
+import type { ToolState } from "@/chat/tools/types";
 import {
   chatGetPermalinkOk,
   chatPostMessageOk,
@@ -34,19 +35,20 @@ function createToolState(): ToolState {
 }
 
 function createContext(
-  userText: string,
-  overrides: Partial<ToolRuntimeContext> = {},
-): ToolRuntimeContext {
+  _userText: string,
+  overrides: Partial<SlackToolContext> = {},
+): SlackToolContext {
+  const channelId = overrides.channelId ?? "C123";
   return {
-    channelId: "C123",
     destination: {
       platform: "slack",
       teamId: "T123",
-      channelId: "C123",
+      channelId,
     },
+    channelId,
+    deliveryChannelId: overrides.deliveryChannelId ?? channelId,
     messageTs: "1700000000.321",
-    userText,
-    sandbox: {} as any,
+    teamId: "T123",
     ...overrides,
   };
 }

--- a/packages/junior/tests/integration/slack-channel-tools.test.ts
+++ b/packages/junior/tests/integration/slack-channel-tools.test.ts
@@ -38,16 +38,24 @@ function createContext(
   _userText: string,
   overrides: Partial<SlackToolContext> = {},
 ): SlackToolContext {
-  const channelId = overrides.channelId ?? "C123";
+  const sourceChannelId = overrides.sourceChannelId ?? "C123";
+  const destinationChannelId =
+    overrides.destinationChannelId ?? sourceChannelId;
   return {
     destination: {
       platform: "slack",
       teamId: "T123",
-      channelId,
+      channelId: destinationChannelId,
     },
-    channelId,
-    deliveryChannelId: overrides.deliveryChannelId ?? channelId,
+    source: {
+      platform: "slack",
+      teamId: "T123",
+      channelId: sourceChannelId,
+      messageTs: "1700000000.321",
+    },
+    destinationChannelId,
     messageTs: "1700000000.321",
+    sourceChannelId,
     teamId: "T123",
     ...overrides,
   };
@@ -91,8 +99,8 @@ describe("slack channel tools", () => {
 
   it("uses assistant context channel for channel delivery tools in DM turns", async () => {
     const context = createContext("share this in the current channel", {
-      channelId: "D123",
-      deliveryChannelId: "C_SHARED",
+      sourceChannelId: "D123",
+      destinationChannelId: "C_SHARED",
     });
     queueSlackApiResponse("chat.postMessage", {
       body: chatPostMessageOk({

--- a/packages/junior/tests/integration/slack-schedule-tools.test.ts
+++ b/packages/junior/tests/integration/slack-schedule-tools.test.ts
@@ -1110,13 +1110,11 @@ describe("Slack schedule tool wiring via getAgentPluginTools", () => {
     try {
       const TEAM_ID = `TWIRING${Date.now()}`;
       const tools = getAgentPluginTools({
-        channelId: "DDM",
         destination: {
           platform: "slack",
           teamId: TEAM_ID,
           channelId: "DDM",
         },
-        teamId: TEAM_ID,
         requester: {
           platform: "slack",
           teamId: TEAM_ID,

--- a/packages/junior/tests/integration/slack-schedule-tools.test.ts
+++ b/packages/junior/tests/integration/slack-schedule-tools.test.ts
@@ -40,7 +40,7 @@ function createContext(
   delete contextOverrides.channelId;
   delete contextOverrides.teamId;
   const context: SchedulerToolContext = {
-    destination: {
+    source: {
       platform: "slack",
       teamId,
       channelId,
@@ -59,8 +59,8 @@ function createContext(
   const credentialSubject =
     context.credentialSubject ??
     createSlackDirectCredentialSubject({
-      channelId: context.destination?.channelId,
-      teamId: context.destination?.teamId,
+      channelId: context.source?.channelId,
+      teamId: context.source?.teamId,
       userId: context.requester?.userId,
     });
   return {
@@ -109,7 +109,7 @@ describe("Slack schedule tools", () => {
     await disconnectStateAdapter();
   });
 
-  it("creates and lists tasks only for the active Slack destination", async () => {
+  it("creates and lists tasks only for the active Slack conversation", async () => {
     const created = await createTask();
     expect(created).toMatchObject({
       ok: true,
@@ -233,7 +233,7 @@ describe("Slack schedule tools", () => {
     ).resolves.toEqual([]);
   });
 
-  it("rejects invalid Slack destination before creating a task", async () => {
+  it("rejects invalid Slack source before creating a task", async () => {
     const rejected = executeTool(
       createSlackScheduleCreateTaskTool(createContext({ teamId: "D123" })),
       {
@@ -245,28 +245,28 @@ describe("Slack schedule tools", () => {
 
     await expect(rejected).rejects.toThrow(AgentPluginToolInputError);
     await expect(rejected).rejects.toThrow(
-      "Active Slack destination workspace is invalid.",
+      "Active Slack conversation workspace is invalid.",
     );
     await expect(
       schedulerStore().listTasksForTeam(TEST_TEAM_ID),
     ).resolves.toEqual([]);
   });
 
-  it("rejects non-canonical Slack destination context before creating a task", async () => {
+  it("rejects non-canonical Slack source context before creating a task", async () => {
     const rejected = createTask(
       createContext({
-        destination: {
+        source: {
           platform: "slack",
           teamId: TEST_TEAM_ID,
           channelId: "C123",
           threadTs: "1700000000.000",
-        } as SchedulerToolContext["destination"],
+        } as SchedulerToolContext["source"],
       }),
     );
 
     await expect(rejected).rejects.toThrow(AgentPluginToolInputError);
     await expect(rejected).rejects.toThrow(
-      "Active Slack destination must not include unknown fields.",
+      "Active Slack conversation must not include unknown fields.",
     );
     await expect(
       schedulerStore().listTasksForTeam(TEST_TEAM_ID),
@@ -617,7 +617,7 @@ describe("Slack schedule tools", () => {
     });
   });
 
-  it("rejects edits from another active Slack destination", async () => {
+  it("rejects edits from another active Slack conversation", async () => {
     const context = createContext();
     const created = (await createTask(context)) as {
       task: { id: string };
@@ -637,14 +637,14 @@ describe("Slack schedule tools", () => {
   });
 
   it("binds tasks to the raw conversation channel, not the assistant context channel", async () => {
-    // The scheduler receives an active Destination built from the raw
-    // conversation channel by runtime wiring. Management works from any
-    // context with the same destination.
+    // The scheduler receives an active Source built from the raw conversation
+    // channel by runtime wiring. Management works from any context with the
+    // same source conversation.
     //
     // In practice: a DM opened via Slack’s “Ask Junior” panel from #js-alerts
-    // has getAgentPluginTools build destination.channelId = DDM rather than
-    // CJS (assistant source). Both creation and management from that DM use
-    // DDM, so the destination never drifts.
+    // has getAgentPluginTools build source.channelId = DDM rather than using
+    // the outbound assistant-context channel. Both creation and management
+    // from that DM use DDM, so the stored task destination never drifts.
     const dmCtx = createContext({ channelId: "DDM" });
     const created = (await createTask(dmCtx)) as { task: { id: string } };
     const taskId = created.task.id;
@@ -775,13 +775,13 @@ describe("Slack schedule tools", () => {
     expect(tasks[0]?.credentialSubject).toBeUndefined();
   });
 
-  it("rejects non-canonical Slack destinations before storing tasks", async () => {
+  it("rejects non-canonical Slack sources before storing tasks", async () => {
     const context = createContext({ channelId: "D123" });
     await expect(
       createTask(
         {
           ...context,
-          destination: {
+          source: {
             platform: "slack",
             teamId: TEST_TEAM_ID,
             channelId: "slack:D123:1700000000.000",
@@ -793,7 +793,7 @@ describe("Slack schedule tools", () => {
           recurrence: undefined,
         },
       ),
-    ).rejects.toThrow("Active Slack destination channel is invalid.");
+    ).rejects.toThrow("Active Slack conversation channel is invalid.");
     await expect(
       schedulerStore().listTasksForTeam(TEST_TEAM_ID),
     ).resolves.toEqual([]);
@@ -1001,8 +1001,8 @@ describe("Slack schedule tools", () => {
       status: "active",
       nextRunAtMs: scheduledNextRunAtMs,
       destination: {
-        teamId: context.destination?.teamId,
-        channelId: context.destination?.channelId,
+        teamId: context.source?.teamId,
+        channelId: context.source?.channelId,
       },
       createdBy: {
         slackUserId: context.requester?.userId,
@@ -1103,13 +1103,18 @@ describe("Slack schedule tool wiring via getAgentPluginTools", () => {
     await disconnectStateAdapter();
   });
 
-  it("scheduler tools bind to the runtime-owned destination", async () => {
-    // Verifies that the real getAgentPluginTools wiring passes Destination
-    // through to the scheduler, which stores it as the task destination.
+  it("scheduler tools bind to the runtime-owned source", async () => {
+    // Verifies that real getAgentPluginTools wiring passes Source through to
+    // the scheduler, which stores it as the task destination.
     const previous = setAgentPlugins([schedulerPlugin()]);
     try {
       const TEAM_ID = `TWIRING${Date.now()}`;
       const tools = getAgentPluginTools({
+        source: {
+          platform: "slack",
+          teamId: TEAM_ID,
+          channelId: "DDM",
+        },
         destination: {
           platform: "slack",
           teamId: TEAM_ID,

--- a/packages/junior/tests/integration/slack-thread-read.test.ts
+++ b/packages/junior/tests/integration/slack-thread-read.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createSlackThreadReadTool } from "@/chat/tools/slack/thread-read";
-import type { ToolRuntimeContext } from "@/chat/tools/types";
+import type { SlackToolContext } from "@/chat/tools/slack/context";
 import { conversationsRepliesPage } from "../fixtures/slack/factories/api";
 import {
   getCapturedSlackApiCalls,
@@ -9,8 +9,8 @@ import {
 } from "../msw/handlers/slack-api";
 
 function createContext(
-  overrides: Partial<ToolRuntimeContext> = {},
-): ToolRuntimeContext {
+  overrides: Partial<SlackToolContext> = {},
+): SlackToolContext {
   const channelId = overrides.channelId ?? "C_CURRENT";
   return {
     channelId,
@@ -19,7 +19,8 @@ function createContext(
       teamId: "T123",
       channelId,
     },
-    sandbox: {} as any,
+    deliveryChannelId: overrides.deliveryChannelId ?? channelId,
+    teamId: "T123",
     ...overrides,
   };
 }

--- a/packages/junior/tests/integration/slack-thread-read.test.ts
+++ b/packages/junior/tests/integration/slack-thread-read.test.ts
@@ -11,8 +11,14 @@ import {
 function createContext(
   overrides: Partial<ToolRuntimeContext> = {},
 ): ToolRuntimeContext {
+  const channelId = overrides.channelId ?? "C_CURRENT";
   return {
-    channelId: "C_CURRENT",
+    channelId,
+    destination: overrides.destination ?? {
+      platform: "slack",
+      teamId: "T123",
+      channelId,
+    },
     sandbox: {} as any,
     ...overrides,
   };

--- a/packages/junior/tests/integration/slack-thread-read.test.ts
+++ b/packages/junior/tests/integration/slack-thread-read.test.ts
@@ -11,15 +11,22 @@ import {
 function createContext(
   overrides: Partial<SlackToolContext> = {},
 ): SlackToolContext {
-  const channelId = overrides.channelId ?? "C_CURRENT";
+  const sourceChannelId = overrides.sourceChannelId ?? "C_CURRENT";
+  const destinationChannelId =
+    overrides.destinationChannelId ?? sourceChannelId;
   return {
-    channelId,
     destination: overrides.destination ?? {
       platform: "slack",
       teamId: "T123",
-      channelId,
+      channelId: destinationChannelId,
     },
-    deliveryChannelId: overrides.deliveryChannelId ?? channelId,
+    source: overrides.source ?? {
+      platform: "slack",
+      teamId: "T123",
+      channelId: sourceChannelId,
+    },
+    destinationChannelId,
+    sourceChannelId,
     teamId: "T123",
     ...overrides,
   };
@@ -164,7 +171,7 @@ describe("slackThreadRead", () => {
     });
 
     const tool = createSlackThreadReadTool(
-      createContext({ channelId: "G_PRIVATE" }),
+      createContext({ sourceChannelId: "G_PRIVATE" }),
     );
     const result = await executeTool(tool, {
       channel_id: "G_PRIVATE",
@@ -199,8 +206,8 @@ describe("slackThreadRead", () => {
 
     const tool = createSlackThreadReadTool(
       createContext({
-        channelId: "D_DM",
-        deliveryChannelId: "G_PRIVATE",
+        sourceChannelId: "D_DM",
+        destinationChannelId: "G_PRIVATE",
       }),
     );
     const result = await executeTool(tool, {
@@ -218,7 +225,7 @@ describe("slackThreadRead", () => {
 
   it("blocks reading a private group channel from a DM conversation without assistant context", async () => {
     const tool = createSlackThreadReadTool(
-      createContext({ channelId: "D_DM" }),
+      createContext({ sourceChannelId: "D_DM" }),
     );
     const result = await executeTool(tool, {
       channel_id: "G_PRIVATE",
@@ -235,7 +242,7 @@ describe("slackThreadRead", () => {
 
   it("blocks reading a private channel that is not the current channel", async () => {
     const tool = createSlackThreadReadTool(
-      createContext({ channelId: "C_CURRENT" }),
+      createContext({ sourceChannelId: "C_CURRENT" }),
     );
     const result = await executeTool(tool, {
       url: "https://sentry.slack.com/archives/G0OTHER/p1700000000100000",

--- a/packages/junior/tests/integration/slack-user-lookup.test.ts
+++ b/packages/junior/tests/integration/slack-user-lookup.test.ts
@@ -343,6 +343,11 @@ describe("slackUserLookup", () => {
         {},
         {
           channelId: "C_TEST",
+          destination: {
+            platform: "slack",
+            teamId: "T_TEST",
+            channelId: "C_TEST",
+          },
           sandbox: {} as any,
         },
       );

--- a/packages/junior/tests/integration/slack-user-lookup.test.ts
+++ b/packages/junior/tests/integration/slack-user-lookup.test.ts
@@ -342,6 +342,11 @@ describe("slackUserLookup", () => {
         [],
         {},
         {
+          source: {
+            platform: "slack",
+            teamId: "T_TEST",
+            channelId: "C_TEST",
+          },
           destination: {
             platform: "slack",
             teamId: "T_TEST",

--- a/packages/junior/tests/integration/slack-user-lookup.test.ts
+++ b/packages/junior/tests/integration/slack-user-lookup.test.ts
@@ -342,7 +342,6 @@ describe("slackUserLookup", () => {
         [],
         {},
         {
-          channelId: "C_TEST",
           destination: {
             platform: "slack",
             teamId: "T_TEST",

--- a/packages/junior/tests/integration/tool-idempotency.test.ts
+++ b/packages/junior/tests/integration/tool-idempotency.test.ts
@@ -4,6 +4,7 @@ import { createOperationKey } from "@/chat/tools/idempotency";
 import { createSlackListAddItemsTool } from "@/chat/tools/slack/list-tools";
 import { SlackActionError } from "@/chat/slack/client";
 import type { ToolState } from "@/chat/tools/types";
+import type { SlackToolContext } from "@/chat/tools/slack/context";
 import {
   canvasesAccessSetOk,
   canvasesCreateOk,
@@ -48,7 +49,7 @@ function createToolState(
 
 const noopSandbox = {} as any;
 
-function slackContext(channelId: string) {
+function slackContext(channelId: string): SlackToolContext {
   return {
     channelId,
     destination: {
@@ -56,7 +57,8 @@ function slackContext(channelId: string) {
       teamId: "T123",
       channelId,
     },
-    sandbox: noopSandbox,
+    deliveryChannelId: channelId,
+    teamId: "T123",
   };
 }
 
@@ -218,7 +220,10 @@ describe("tool idempotency", () => {
 
   it("throws when creating a canvas without assistant channel context", async () => {
     const state = createToolState();
-    const tool = createSlackCanvasCreateTool(LOCAL_CONTEXT, state);
+    const tool = createSlackCanvasCreateTool(
+      LOCAL_CONTEXT as unknown as SlackToolContext,
+      state,
+    );
 
     await expect(
       executeTool(tool, {

--- a/packages/junior/tests/integration/tool-idempotency.test.ts
+++ b/packages/junior/tests/integration/tool-idempotency.test.ts
@@ -48,6 +48,26 @@ function createToolState(
 
 const noopSandbox = {} as any;
 
+function slackContext(channelId: string) {
+  return {
+    channelId,
+    destination: {
+      platform: "slack" as const,
+      teamId: "T123",
+      channelId,
+    },
+    sandbox: noopSandbox,
+  };
+}
+
+const LOCAL_CONTEXT = {
+  destination: {
+    platform: "local",
+    conversationId: "local:test:tool-idempotency",
+  },
+  sandbox: noopSandbox,
+} as const;
+
 async function executeTool<TInput>(tool: any, input: TInput) {
   if (typeof tool?.execute !== "function") {
     throw new Error("tool execute function missing");
@@ -85,13 +105,7 @@ describe("tool idempotency", () => {
       }),
     });
     const state = createToolState();
-    const tool = createSlackCanvasCreateTool(
-      {
-        channelId: "C123",
-        sandbox: noopSandbox,
-      },
-      state,
-    );
+    const tool = createSlackCanvasCreateTool(slackContext("C123"), state);
 
     const first = await executeTool(tool, {
       title: "Weekly plan",
@@ -137,13 +151,7 @@ describe("tool idempotency", () => {
     });
 
     const state = createToolState();
-    const tool = createSlackCanvasCreateTool(
-      {
-        channelId: "D123",
-        sandbox: noopSandbox,
-      },
-      state,
-    );
+    const tool = createSlackCanvasCreateTool(slackContext("D123"), state);
 
     const result = await executeTool(tool, {
       title: "DM brief",
@@ -184,9 +192,8 @@ describe("tool idempotency", () => {
 
     const tool = createSlackCanvasCreateTool(
       {
-        channelId: "D123",
+        ...slackContext("D123"),
         deliveryChannelId: "C_SHARED",
-        sandbox: noopSandbox,
       },
       createToolState(),
     );
@@ -211,12 +218,7 @@ describe("tool idempotency", () => {
 
   it("throws when creating a canvas without assistant channel context", async () => {
     const state = createToolState();
-    const tool = createSlackCanvasCreateTool(
-      {
-        sandbox: noopSandbox,
-      },
-      state,
-    );
+    const tool = createSlackCanvasCreateTool(LOCAL_CONTEXT, state);
 
     await expect(
       executeTool(tool, {
@@ -280,13 +282,7 @@ describe("tool idempotency", () => {
       error: "internal_error",
     });
     const state = createToolState();
-    const tool = createSlackCanvasCreateTool(
-      {
-        channelId: "C123",
-        sandbox: noopSandbox,
-      },
-      state,
-    );
+    const tool = createSlackCanvasCreateTool(slackContext("C123"), state);
 
     await expect(
       executeTool(tool, {

--- a/packages/junior/tests/integration/tool-idempotency.test.ts
+++ b/packages/junior/tests/integration/tool-idempotency.test.ts
@@ -51,13 +51,18 @@ const noopSandbox = {} as any;
 
 function slackContext(channelId: string): SlackToolContext {
   return {
-    channelId,
     destination: {
       platform: "slack" as const,
       teamId: "T123",
       channelId,
     },
-    deliveryChannelId: channelId,
+    source: {
+      platform: "slack" as const,
+      teamId: "T123",
+      channelId,
+    },
+    destinationChannelId: channelId,
+    sourceChannelId: channelId,
     teamId: "T123",
   };
 }
@@ -195,7 +200,12 @@ describe("tool idempotency", () => {
     const tool = createSlackCanvasCreateTool(
       {
         ...slackContext("D123"),
-        deliveryChannelId: "C_SHARED",
+        destination: {
+          platform: "slack" as const,
+          teamId: "T123",
+          channelId: "C_SHARED",
+        },
+        destinationChannelId: "C_SHARED",
       },
       createToolState(),
     );

--- a/packages/junior/tests/unit/cli/chat-cli.test.ts
+++ b/packages/junior/tests/unit/cli/chat-cli.test.ts
@@ -44,10 +44,10 @@ describe("chat cli", () => {
       write: () => undefined,
     };
 
-    expect(await runChat(["--conversation"], io)).toBe(1);
     expect(await runChat(["--once"], io)).toBe(1);
+    expect(await runChat(["--conversation"], io)).toBe(1);
+    expect(await runChat(["-p"], io)).toBe(1);
     expect(await runChat(["unexpected"], io)).toBe(1);
-    expect(await runChat(["--conversation", "../bad"], io)).toBe(1);
 
     expect(lines).toEqual([CHAT_USAGE, CHAT_USAGE, CHAT_USAGE, CHAT_USAGE]);
   });
@@ -69,34 +69,18 @@ describe("chat cli", () => {
       },
     };
 
-    expect(await runChat(["--once", "hello"], io)).toBe(0);
+    expect(await runChat(["-p", "hello"], io)).toBe(0);
     expect(output).toEqual(["hello\n"]);
-  });
-
-  it("accepts flag-like tokens as once message text", async () => {
-    runner.runLocalAgentTurn.mockImplementation(async (_input, deps) => {
-      const result = reply("success");
-      await deps.deliverReply(result.reply);
-      return result;
-    });
-
-    const io = {
-      error: vi.fn(),
-      input: process.stdin,
-      output: process.stdout,
-      write: vi.fn(),
-    };
-
-    expect(await runChat(["--once", "explain", "--flag"], io)).toBe(0);
     expect(runner.runLocalAgentTurn).toHaveBeenCalledWith(
       expect.objectContaining({
-        message: "explain --flag",
+        conversationId: expect.stringMatching(/:run-[a-f0-9-]+$/),
+        message: "hello",
       }),
       expect.any(Object),
     );
   });
 
-  it("accepts conversation after the once message", async () => {
+  it("accepts flag-like tokens as prompt message text", async () => {
     runner.runLocalAgentTurn.mockImplementation(async (_input, deps) => {
       const result = reply("success");
       await deps.deliverReply(result.reply);
@@ -110,13 +94,10 @@ describe("chat cli", () => {
       write: vi.fn(),
     };
 
-    expect(
-      await runChat(["--once", "hello", "--conversation", "later"], io),
-    ).toBe(0);
+    expect(await runChat(["-p", "explain", "--flag"], io)).toBe(0);
     expect(runner.runLocalAgentTurn).toHaveBeenCalledWith(
       expect.objectContaining({
-        conversationId: expect.stringMatching(/:later$/),
-        message: "hello",
+        message: "explain --flag",
       }),
       expect.any(Object),
     );
@@ -139,7 +120,7 @@ describe("chat cli", () => {
       },
     };
 
-    expect(await runChat(["--once", "hello"], io)).toBe(1);
+    expect(await runChat(["-p", "hello"], io)).toBe(1);
     expect(output).toEqual(["failed\n"]);
   });
 
@@ -158,7 +139,7 @@ describe("chat cli", () => {
       },
     };
 
-    expect(await runChat(["--once", "hello"], io)).toBe(1);
+    expect(await runChat(["-p", "hello"], io)).toBe(1);
     expect(io.error).toHaveBeenCalledWith("stdout closed");
   });
 
@@ -179,7 +160,7 @@ describe("chat cli", () => {
       write: vi.fn(),
     };
 
-    expect(await runChat(["--once", "hello"], io)).toBe(1);
+    expect(await runChat(["-p", "hello"], io)).toBe(1);
     expect(io.write).not.toHaveBeenCalled();
     expect(io.error).toHaveBeenCalledWith(
       "Local chat cannot deliver files yet: report.txt",
@@ -213,5 +194,12 @@ describe("chat cli", () => {
     expect(code).toBe(0);
     expect(errors).toEqual(["turn failed"]);
     expect(runner.runLocalAgentTurn).toHaveBeenCalledTimes(1);
+    expect(runner.runLocalAgentTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: expect.stringMatching(/:run-[a-f0-9-]+$/),
+        message: "hello",
+      }),
+      expect.any(Object),
+    );
   });
 });

--- a/packages/junior/tests/unit/cli/chat-cli.test.ts
+++ b/packages/junior/tests/unit/cli/chat-cli.test.ts
@@ -20,7 +20,7 @@ function reply(outcome: LocalAgentTurnResult["outcome"]): {
   reply: LocalAgentReply;
 } {
   return {
-    conversationId: "local:test:default",
+    conversationId: "local:test:run-test",
     outcome,
     reply: {
       text: outcome === "success" ? "hello" : "failed",
@@ -52,7 +52,7 @@ describe("chat cli", () => {
     expect(lines).toEqual([CHAT_USAGE, CHAT_USAGE, CHAT_USAGE, CHAT_USAGE]);
   });
 
-  it("returns success for a successful once reply", async () => {
+  it("returns success for a successful prompt reply", async () => {
     const output: string[] = [];
     runner.runLocalAgentTurn.mockImplementation(async (_input, deps) => {
       const result = reply("success");
@@ -80,6 +80,32 @@ describe("chat cli", () => {
     );
   });
 
+  it("uses a fresh local conversation for each prompt invocation", async () => {
+    runner.runLocalAgentTurn.mockImplementation(async (_input, deps) => {
+      const result = reply("success");
+      await deps.deliverReply(result.reply);
+      return result;
+    });
+
+    const io = {
+      error: vi.fn(),
+      input: process.stdin,
+      output: process.stdout,
+      write: vi.fn(),
+    };
+
+    expect(await runChat(["-p", "first"], io)).toBe(0);
+    expect(await runChat(["-p", "second"], io)).toBe(0);
+
+    const firstConversationId =
+      runner.runLocalAgentTurn.mock.calls[0]?.[0].conversationId;
+    const secondConversationId =
+      runner.runLocalAgentTurn.mock.calls[1]?.[0].conversationId;
+    expect(firstConversationId).toMatch(/:run-[a-f0-9-]+$/);
+    expect(secondConversationId).toMatch(/:run-[a-f0-9-]+$/);
+    expect(secondConversationId).not.toBe(firstConversationId);
+  });
+
   it("accepts flag-like tokens as prompt message text", async () => {
     runner.runLocalAgentTurn.mockImplementation(async (_input, deps) => {
       const result = reply("success");
@@ -103,7 +129,7 @@ describe("chat cli", () => {
     );
   });
 
-  it("returns failure for a failed once reply after delivery", async () => {
+  it("returns failure for a failed prompt reply after delivery", async () => {
     const output: string[] = [];
     runner.runLocalAgentTurn.mockImplementation(async (_input, deps) => {
       const result = reply("provider_error");
@@ -124,7 +150,7 @@ describe("chat cli", () => {
     expect(output).toEqual(["failed\n"]);
   });
 
-  it("returns failure when once delivery fails", async () => {
+  it("returns failure when prompt delivery fails", async () => {
     runner.runLocalAgentTurn.mockImplementation(async (_input, deps) => {
       await deps.deliverReply(reply("success").reply);
       return reply("success");
@@ -143,7 +169,7 @@ describe("chat cli", () => {
     expect(io.error).toHaveBeenCalledWith("stdout closed");
   });
 
-  it("returns failure when a once reply contains files", async () => {
+  it("returns failure when a prompt reply contains files", async () => {
     runner.runLocalAgentTurn.mockImplementation(async (_input, deps) => {
       const result = reply("success");
       result.reply.files = [
@@ -176,6 +202,7 @@ describe("chat cli", () => {
       },
     });
     runner.runLocalAgentTurn.mockRejectedValueOnce(new Error("turn failed"));
+    runner.runLocalAgentTurn.mockResolvedValueOnce(reply("success"));
 
     const pending = runChat([], {
       error: (line) => {
@@ -187,19 +214,22 @@ describe("chat cli", () => {
     });
     input.write("hello\n");
     await new Promise((resolve) => setImmediate(resolve));
+    input.write("again\n");
+    await new Promise((resolve) => setImmediate(resolve));
     input.write("/exit\n");
     input.end();
 
     const code = await pending;
     expect(code).toBe(0);
     expect(errors).toEqual(["turn failed"]);
-    expect(runner.runLocalAgentTurn).toHaveBeenCalledTimes(1);
-    expect(runner.runLocalAgentTurn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        conversationId: expect.stringMatching(/:run-[a-f0-9-]+$/),
-        message: "hello",
-      }),
-      expect.any(Object),
-    );
+    expect(runner.runLocalAgentTurn).toHaveBeenCalledTimes(2);
+    const firstConversationId =
+      runner.runLocalAgentTurn.mock.calls[0]?.[0].conversationId;
+    const secondConversationId =
+      runner.runLocalAgentTurn.mock.calls[1]?.[0].conversationId;
+    expect(firstConversationId).toMatch(/:run-[a-f0-9-]+$/);
+    expect(secondConversationId).toBe(firstConversationId);
+    expect(runner.runLocalAgentTurn.mock.calls[0]?.[0].message).toBe("hello");
+    expect(runner.runLocalAgentTurn.mock.calls[1]?.[0].message).toBe("again");
   });
 });

--- a/packages/junior/tests/unit/cli/chat-cli.test.ts
+++ b/packages/junior/tests/unit/cli/chat-cli.test.ts
@@ -1,3 +1,4 @@
+import { PassThrough, Writable } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AssistantReply } from "@/chat/respond";
 import { CHAT_USAGE, runChat } from "@/cli/chat";
@@ -96,7 +97,7 @@ describe("chat cli", () => {
 
   it("returns failure when once delivery fails", async () => {
     runner.runLocalAgentTurn.mockImplementation(async (_input, deps) => {
-      await deps.deliverReply?.(reply("success").reply);
+      await deps.deliverReply(reply("success").reply);
       return reply("success");
     });
 
@@ -111,5 +112,34 @@ describe("chat cli", () => {
 
     expect(await runChat(["--once", "hello"], io)).toBe(1);
     expect(io.error).toHaveBeenCalledWith("stdout closed");
+  });
+
+  it("continues interactive chat after a turn error", async () => {
+    const errors: string[] = [];
+    const input = new PassThrough();
+    const output = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+    });
+    runner.runLocalAgentTurn.mockRejectedValueOnce(new Error("turn failed"));
+
+    const pending = runChat([], {
+      error: (line) => {
+        errors.push(line);
+      },
+      input,
+      output,
+      write: vi.fn(),
+    });
+    input.write("hello\n");
+    await new Promise((resolve) => setImmediate(resolve));
+    input.write("/exit\n");
+    input.end();
+
+    const code = await pending;
+    expect(code).toBe(0);
+    expect(errors).toEqual(["turn failed"]);
+    expect(runner.runLocalAgentTurn).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/junior/tests/unit/cli/chat-cli.test.ts
+++ b/packages/junior/tests/unit/cli/chat-cli.test.ts
@@ -1,7 +1,10 @@
 import { PassThrough, Writable } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { AssistantReply } from "@/chat/respond";
 import { CHAT_USAGE, runChat } from "@/cli/chat";
+import type {
+  LocalAgentReply,
+  LocalAgentTurnResult,
+} from "@/chat/local/runner";
 
 const runner = vi.hoisted(() => ({
   runLocalAgentTurn: vi.fn(),
@@ -11,24 +14,17 @@ vi.mock("@/chat/local/runner", () => ({
   runLocalAgentTurn: runner.runLocalAgentTurn,
 }));
 
-function reply(outcome: AssistantReply["diagnostics"]["outcome"]): {
+function reply(outcome: LocalAgentTurnResult["outcome"]): {
   conversationId: string;
-  reply: AssistantReply;
+  outcome: LocalAgentTurnResult["outcome"];
+  reply: LocalAgentReply;
 } {
   return {
     conversationId: "local:test:default",
+    outcome,
     reply: {
       text: outcome === "success" ? "hello" : "failed",
-      diagnostics: {
-        assistantMessageCount: 1,
-        modelId: "test",
-        outcome,
-        toolCalls: [],
-        toolErrorCount: 0,
-        toolResultCount: 0,
-        usedPrimaryText: true,
-      },
-    } satisfies AssistantReply,
+    },
   };
 }
 

--- a/packages/junior/tests/unit/cli/chat-cli.test.ts
+++ b/packages/junior/tests/unit/cli/chat-cli.test.ts
@@ -11,7 +11,10 @@ vi.mock("@/chat/local/runner", () => ({
   runLocalAgentTurn: runner.runLocalAgentTurn,
 }));
 
-function reply(outcome: AssistantReply["diagnostics"]["outcome"]) {
+function reply(outcome: AssistantReply["diagnostics"]["outcome"]): {
+  conversationId: string;
+  reply: AssistantReply;
+} {
   return {
     conversationId: "local:test:default",
     reply: {
@@ -97,6 +100,32 @@ describe("chat cli", () => {
     );
   });
 
+  it("accepts conversation after the once message", async () => {
+    runner.runLocalAgentTurn.mockImplementation(async (_input, deps) => {
+      const result = reply("success");
+      await deps.deliverReply(result.reply);
+      return result;
+    });
+
+    const io = {
+      error: vi.fn(),
+      input: process.stdin,
+      output: process.stdout,
+      write: vi.fn(),
+    };
+
+    expect(
+      await runChat(["--once", "hello", "--conversation", "later"], io),
+    ).toBe(0);
+    expect(runner.runLocalAgentTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: expect.stringMatching(/:later$/),
+        message: "hello",
+      }),
+      expect.any(Object),
+    );
+  });
+
   it("returns failure for a failed once reply after delivery", async () => {
     const output: string[] = [];
     runner.runLocalAgentTurn.mockImplementation(async (_input, deps) => {
@@ -135,6 +164,30 @@ describe("chat cli", () => {
 
     expect(await runChat(["--once", "hello"], io)).toBe(1);
     expect(io.error).toHaveBeenCalledWith("stdout closed");
+  });
+
+  it("returns failure when a once reply contains files", async () => {
+    runner.runLocalAgentTurn.mockImplementation(async (_input, deps) => {
+      const result = reply("success");
+      result.reply.files = [
+        { data: Buffer.from("report"), filename: "report.txt" },
+      ];
+      await deps.deliverReply(result.reply);
+      return result;
+    });
+
+    const io = {
+      error: vi.fn(),
+      input: process.stdin,
+      output: process.stdout,
+      write: vi.fn(),
+    };
+
+    expect(await runChat(["--once", "hello"], io)).toBe(1);
+    expect(io.write).not.toHaveBeenCalled();
+    expect(io.error).toHaveBeenCalledWith(
+      "Local chat cannot deliver files yet: report.txt",
+    );
   });
 
   it("continues interactive chat after a turn error", async () => {

--- a/packages/junior/tests/unit/cli/chat-cli.test.ts
+++ b/packages/junior/tests/unit/cli/chat-cli.test.ts
@@ -1,5 +1,5 @@
 import { PassThrough, Writable } from "node:stream";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CHAT_USAGE, runChat } from "@/cli/chat";
 import type {
   LocalAgentReply,
@@ -13,6 +13,9 @@ const runner = vi.hoisted(() => ({
 vi.mock("@/chat/local/runner", () => ({
   runLocalAgentTurn: runner.runLocalAgentTurn,
 }));
+
+const ORIGINAL_STATE_ADAPTER = process.env.JUNIOR_STATE_ADAPTER;
+const ORIGINAL_REDIS_URL = process.env.REDIS_URL;
 
 function reply(outcome: LocalAgentTurnResult["outcome"]): {
   conversationId: string;
@@ -31,6 +34,11 @@ function reply(outcome: LocalAgentTurnResult["outcome"]): {
 describe("chat cli", () => {
   beforeEach(() => {
     runner.runLocalAgentTurn.mockReset();
+  });
+
+  afterEach(() => {
+    restoreEnv("JUNIOR_STATE_ADAPTER", ORIGINAL_STATE_ADAPTER);
+    restoreEnv("REDIS_URL", ORIGINAL_REDIS_URL);
   });
 
   it("returns usage for invalid argument forms", async () => {
@@ -78,6 +86,69 @@ describe("chat cli", () => {
       }),
       expect.any(Object),
     );
+  });
+
+  it("defaults prompt local chat to memory even when REDIS_URL is present", async () => {
+    delete process.env.JUNIOR_STATE_ADAPTER;
+    process.env.REDIS_URL = "redis://localhost:6379";
+    runner.runLocalAgentTurn.mockImplementation(async (_input, deps) => {
+      const result = reply("success");
+      await deps.deliverReply(result.reply);
+      return result;
+    });
+
+    const io = {
+      error: vi.fn(),
+      input: process.stdin,
+      output: process.stdout,
+      write: vi.fn(),
+    };
+
+    expect(await runChat(["-p", "hello"], io)).toBe(0);
+    expect(process.env.JUNIOR_STATE_ADAPTER).toBe("memory");
+  });
+
+  it("preserves an explicit prompt local chat state adapter", async () => {
+    process.env.JUNIOR_STATE_ADAPTER = "redis";
+    process.env.REDIS_URL = "redis://localhost:6379";
+    runner.runLocalAgentTurn.mockImplementation(async (_input, deps) => {
+      const result = reply("success");
+      await deps.deliverReply(result.reply);
+      return result;
+    });
+
+    const io = {
+      error: vi.fn(),
+      input: process.stdin,
+      output: process.stdout,
+      write: vi.fn(),
+    };
+
+    expect(await runChat(["-p", "hello"], io)).toBe(0);
+    expect(process.env.JUNIOR_STATE_ADAPTER).toBe("redis");
+  });
+
+  it("defaults interactive local chat to memory even when REDIS_URL is present", async () => {
+    delete process.env.JUNIOR_STATE_ADAPTER;
+    process.env.REDIS_URL = "redis://localhost:6379";
+    const input = new PassThrough();
+    const output = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+    });
+
+    const pending = runChat([], {
+      error: vi.fn(),
+      input,
+      output,
+      write: vi.fn(),
+    });
+    input.write("/exit\n");
+    input.end();
+
+    expect(await pending).toBe(0);
+    expect(process.env.JUNIOR_STATE_ADAPTER).toBe("memory");
   });
 
   it("uses a fresh local conversation for each prompt invocation", async () => {
@@ -233,3 +304,11 @@ describe("chat cli", () => {
     expect(runner.runLocalAgentTurn.mock.calls[1]?.[0].message).toBe("again");
   });
 });
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}

--- a/packages/junior/tests/unit/cli/chat-cli.test.ts
+++ b/packages/junior/tests/unit/cli/chat-cli.test.ts
@@ -57,7 +57,7 @@ describe("chat cli", () => {
     const output: string[] = [];
     runner.runLocalAgentTurn.mockImplementation(async (_input, deps) => {
       const result = reply("success");
-      await deps.deliverReply?.(result.reply);
+      await deps.deliverReply(result.reply);
       return result;
     });
 
@@ -74,11 +74,34 @@ describe("chat cli", () => {
     expect(output).toEqual(["hello\n"]);
   });
 
+  it("accepts flag-like tokens as once message text", async () => {
+    runner.runLocalAgentTurn.mockImplementation(async (_input, deps) => {
+      const result = reply("success");
+      await deps.deliverReply(result.reply);
+      return result;
+    });
+
+    const io = {
+      error: vi.fn(),
+      input: process.stdin,
+      output: process.stdout,
+      write: vi.fn(),
+    };
+
+    expect(await runChat(["--once", "explain", "--flag"], io)).toBe(0);
+    expect(runner.runLocalAgentTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "explain --flag",
+      }),
+      expect.any(Object),
+    );
+  });
+
   it("returns failure for a failed once reply after delivery", async () => {
     const output: string[] = [];
     runner.runLocalAgentTurn.mockImplementation(async (_input, deps) => {
       const result = reply("provider_error");
-      await deps.deliverReply?.(result.reply);
+      await deps.deliverReply(result.reply);
       return result;
     });
 

--- a/packages/junior/tests/unit/cli/chat-cli.test.ts
+++ b/packages/junior/tests/unit/cli/chat-cli.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AssistantReply } from "@/chat/respond";
+import { CHAT_USAGE, runChat } from "@/cli/chat";
+
+const runner = vi.hoisted(() => ({
+  runLocalAgentTurn: vi.fn(),
+}));
+
+vi.mock("@/chat/local/runner", () => ({
+  runLocalAgentTurn: runner.runLocalAgentTurn,
+}));
+
+function reply(outcome: AssistantReply["diagnostics"]["outcome"]) {
+  return {
+    conversationId: "local:test:default",
+    reply: {
+      text: outcome === "success" ? "hello" : "failed",
+      diagnostics: {
+        assistantMessageCount: 1,
+        modelId: "test",
+        outcome,
+        toolCalls: [],
+        toolErrorCount: 0,
+        toolResultCount: 0,
+        usedPrimaryText: true,
+      },
+    } satisfies AssistantReply,
+  };
+}
+
+describe("chat cli", () => {
+  beforeEach(() => {
+    runner.runLocalAgentTurn.mockReset();
+  });
+
+  it("returns usage for invalid argument forms", async () => {
+    const lines: string[] = [];
+    const io = {
+      error: (line: string) => {
+        lines.push(line);
+      },
+      input: process.stdin,
+      output: process.stdout,
+      write: () => undefined,
+    };
+
+    expect(await runChat(["--conversation"], io)).toBe(1);
+    expect(await runChat(["--once"], io)).toBe(1);
+    expect(await runChat(["unexpected"], io)).toBe(1);
+    expect(await runChat(["--conversation", "../bad"], io)).toBe(1);
+
+    expect(lines).toEqual([CHAT_USAGE, CHAT_USAGE, CHAT_USAGE, CHAT_USAGE]);
+  });
+
+  it("returns success for a successful once reply", async () => {
+    const output: string[] = [];
+    runner.runLocalAgentTurn.mockImplementation(async (_input, deps) => {
+      const result = reply("success");
+      await deps.deliverReply?.(result.reply);
+      return result;
+    });
+
+    const io = {
+      error: vi.fn(),
+      input: process.stdin,
+      output: process.stdout,
+      write: async (text: string) => {
+        output.push(text);
+      },
+    };
+
+    expect(await runChat(["--once", "hello"], io)).toBe(0);
+    expect(output).toEqual(["hello\n"]);
+  });
+
+  it("returns failure for a failed once reply after delivery", async () => {
+    const output: string[] = [];
+    runner.runLocalAgentTurn.mockImplementation(async (_input, deps) => {
+      const result = reply("provider_error");
+      await deps.deliverReply?.(result.reply);
+      return result;
+    });
+
+    const io = {
+      error: vi.fn(),
+      input: process.stdin,
+      output: process.stdout,
+      write: async (text: string) => {
+        output.push(text);
+      },
+    };
+
+    expect(await runChat(["--once", "hello"], io)).toBe(1);
+    expect(output).toEqual(["failed\n"]);
+  });
+
+  it("returns failure when once delivery fails", async () => {
+    runner.runLocalAgentTurn.mockImplementation(async (_input, deps) => {
+      await deps.deliverReply?.(reply("success").reply);
+      return reply("success");
+    });
+
+    const io = {
+      error: vi.fn(),
+      input: process.stdin,
+      output: process.stdout,
+      write: async () => {
+        throw new Error("stdout closed");
+      },
+    };
+
+    expect(await runChat(["--once", "hello"], io)).toBe(1);
+    expect(io.error).toHaveBeenCalledWith("stdout closed");
+  });
+});

--- a/packages/junior/tests/unit/cli/cli-run.test.ts
+++ b/packages/junior/tests/unit/cli/cli-run.test.ts
@@ -86,6 +86,27 @@ describe("cli command dispatch", () => {
     expect(cliHandlers.runUpgrade).not.toHaveBeenCalled();
   });
 
+  it("ignores a leading node argv separator before the command", async () => {
+    const cliHandlers = handlers();
+
+    const exitCode = await runCli(
+      ["--", "chat", "--conversation", "demo", "--once", "hello"],
+      cliHandlers,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(cliHandlers.runChat).toHaveBeenCalledWith([
+      "--conversation",
+      "demo",
+      "--once",
+      "hello",
+    ]);
+    expect(cliHandlers.runInit).not.toHaveBeenCalled();
+    expect(cliHandlers.runSnapshotCreate).not.toHaveBeenCalled();
+    expect(cliHandlers.runCheck).not.toHaveBeenCalled();
+    expect(cliHandlers.runUpgrade).not.toHaveBeenCalled();
+  });
+
   it("returns usage for invalid argv forms", async () => {
     const cliHandlers = handlers();
     const lines: string[] = [];

--- a/packages/junior/tests/unit/cli/cli-run.test.ts
+++ b/packages/junior/tests/unit/cli/cli-run.test.ts
@@ -4,6 +4,7 @@ import { CLI_USAGE, runCli } from "@/cli/run";
 describe("cli command dispatch", () => {
   function handlers() {
     return {
+      runChat: vi.fn(async () => 0),
       runInit: vi.fn(async () => undefined),
       runSnapshotCreate: vi.fn(async () => undefined),
       runCheck: vi.fn(async () => undefined),
@@ -63,6 +64,28 @@ describe("cli command dispatch", () => {
     expect(cliHandlers.runCheck).not.toHaveBeenCalled();
   });
 
+  it("runs chat with its remaining arguments", async () => {
+    const cliHandlers = handlers();
+
+    const exitCode = await runCli(
+      ["chat", "--conversation", "demo", "--once", "hello"],
+      cliHandlers,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(cliHandlers.runChat).toHaveBeenCalledTimes(1);
+    expect(cliHandlers.runChat).toHaveBeenCalledWith([
+      "--conversation",
+      "demo",
+      "--once",
+      "hello",
+    ]);
+    expect(cliHandlers.runInit).not.toHaveBeenCalled();
+    expect(cliHandlers.runSnapshotCreate).not.toHaveBeenCalled();
+    expect(cliHandlers.runCheck).not.toHaveBeenCalled();
+    expect(cliHandlers.runUpgrade).not.toHaveBeenCalled();
+  });
+
   it("returns usage for invalid argv forms", async () => {
     const cliHandlers = handlers();
     const lines: string[] = [];
@@ -111,6 +134,7 @@ describe("cli command dispatch", () => {
       CLI_USAGE,
     ]);
     expect(cliHandlers.runInit).not.toHaveBeenCalled();
+    expect(cliHandlers.runChat).not.toHaveBeenCalled();
     expect(cliHandlers.runSnapshotCreate).not.toHaveBeenCalled();
     expect(cliHandlers.runCheck).not.toHaveBeenCalled();
     expect(cliHandlers.runUpgrade).not.toHaveBeenCalled();

--- a/packages/junior/tests/unit/cli/cli-run.test.ts
+++ b/packages/junior/tests/unit/cli/cli-run.test.ts
@@ -67,19 +67,11 @@ describe("cli command dispatch", () => {
   it("runs chat with its remaining arguments", async () => {
     const cliHandlers = handlers();
 
-    const exitCode = await runCli(
-      ["chat", "--conversation", "demo", "--once", "hello"],
-      cliHandlers,
-    );
+    const exitCode = await runCli(["chat", "-p", "hello"], cliHandlers);
 
     expect(exitCode).toBe(0);
     expect(cliHandlers.runChat).toHaveBeenCalledTimes(1);
-    expect(cliHandlers.runChat).toHaveBeenCalledWith([
-      "--conversation",
-      "demo",
-      "--once",
-      "hello",
-    ]);
+    expect(cliHandlers.runChat).toHaveBeenCalledWith(["-p", "hello"]);
     expect(cliHandlers.runInit).not.toHaveBeenCalled();
     expect(cliHandlers.runSnapshotCreate).not.toHaveBeenCalled();
     expect(cliHandlers.runCheck).not.toHaveBeenCalled();
@@ -89,18 +81,10 @@ describe("cli command dispatch", () => {
   it("ignores a leading node argv separator before the command", async () => {
     const cliHandlers = handlers();
 
-    const exitCode = await runCli(
-      ["--", "chat", "--conversation", "demo", "--once", "hello"],
-      cliHandlers,
-    );
+    const exitCode = await runCli(["--", "chat", "-p", "hello"], cliHandlers);
 
     expect(exitCode).toBe(0);
-    expect(cliHandlers.runChat).toHaveBeenCalledWith([
-      "--conversation",
-      "demo",
-      "--once",
-      "hello",
-    ]);
+    expect(cliHandlers.runChat).toHaveBeenCalledWith(["-p", "hello"]);
     expect(cliHandlers.runInit).not.toHaveBeenCalled();
     expect(cliHandlers.runSnapshotCreate).not.toHaveBeenCalled();
     expect(cliHandlers.runCheck).not.toHaveBeenCalled();

--- a/packages/junior/tests/unit/handlers/oauth-resume.test.ts
+++ b/packages/junior/tests/unit/handlers/oauth-resume.test.ts
@@ -58,6 +58,12 @@ import {
   resumeSlackTurn,
 } from "@/chat/runtime/slack-resume";
 
+const TEST_SLACK_DESTINATION = {
+  platform: "slack",
+  teamId: "T-test",
+  channelId: "C-test",
+} as const;
+
 describe("resumeAuthorizedRequest", () => {
   beforeEach(async () => {
     vi.useFakeTimers();
@@ -87,6 +93,7 @@ describe("resumeAuthorizedRequest", () => {
         credentialContext: {
           actor: { type: "user", userId: "U-test" },
         },
+        destination: TEST_SLACK_DESTINATION,
         requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
       },
       generateReply: () => new Promise<never>(() => {}),
@@ -123,6 +130,7 @@ describe("resumeAuthorizedRequest", () => {
           credentialContext: {
             actor: { type: "user", userId: "U-test" },
           },
+          destination: TEST_SLACK_DESTINATION,
           requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
         },
         generateReply: async () => {
@@ -164,6 +172,7 @@ describe("resumeAuthorizedRequest", () => {
           credentialContext: {
             actor: { type: "user", userId: "U-test" },
           },
+          destination: TEST_SLACK_DESTINATION,
           requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
         },
         generateReply: async () => ({
@@ -226,6 +235,7 @@ describe("resumeAuthorizedRequest", () => {
         credentialContext: {
           actor: { type: "user", userId: "U-test" },
         },
+        destination: TEST_SLACK_DESTINATION,
         requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
       },
       generateReply: async () => {
@@ -254,6 +264,7 @@ describe("resumeAuthorizedRequest", () => {
         credentialContext: {
           actor: { type: "user", userId: "U-test" },
         },
+        destination: TEST_SLACK_DESTINATION,
         requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
       },
       generateReply: async () => {

--- a/packages/junior/tests/unit/local/conversation.test.ts
+++ b/packages/junior/tests/unit/local/conversation.test.ts
@@ -1,43 +1,32 @@
 import { describe, expect, it } from "vitest";
-import {
-  isLocalConversationAlias,
-  normalizeLocalConversationId,
-} from "@/chat/local/conversation";
+import { normalizeLocalConversationId } from "@/chat/local/conversation";
 
 describe("local conversation ids", () => {
-  it("normalizes aliases into local conversation ids scoped by cwd", () => {
+  it("normalizes generated run slugs into local conversation ids scoped by cwd", () => {
     expect(
       normalizeLocalConversationId({
-        alias: "Demo.Thread",
+        alias: "run-550e8400-e29b-41d4-a716-446655440000",
         cwd: "/tmp/junior-local-one",
       }),
-    ).toMatch(/^local:[a-f0-9]{12}:demo-thread$/);
+    ).toMatch(/^local:[a-f0-9]{12}:run-550e8400-e29b-41d4-a716-446655440000$/);
     expect(
       normalizeLocalConversationId({
-        alias: "Demo.Thread",
+        alias: "run-550e8400-e29b-41d4-a716-446655440000",
         cwd: "/tmp/junior-local-two",
       }),
     ).not.toBe(
       normalizeLocalConversationId({
-        alias: "Demo.Thread",
+        alias: "run-550e8400-e29b-41d4-a716-446655440000",
         cwd: "/tmp/junior-local-one",
       }),
     );
   });
 
-  it("uses default when no alias is provided", () => {
-    expect(
-      normalizeLocalConversationId({
-        cwd: "/tmp/junior-local-default",
-      }),
-    ).toMatch(/^local:[a-f0-9]{12}:default$/);
-  });
-
-  it("rejects invalid aliases", () => {
-    expect(isLocalConversationAlias("demo")).toBe(true);
-    expect(isLocalConversationAlias("")).toBe(false);
-    expect(isLocalConversationAlias("../demo")).toBe(false);
-    expect(isLocalConversationAlias("demo with spaces")).toBe(false);
+  it("rejects invalid generated slugs", () => {
+    expect(normalizeLocalConversationId({ alias: "" })).toBeUndefined();
     expect(normalizeLocalConversationId({ alias: "../demo" })).toBeUndefined();
+    expect(
+      normalizeLocalConversationId({ alias: "demo with spaces" }),
+    ).toBeUndefined();
   });
 });

--- a/packages/junior/tests/unit/local/conversation.test.ts
+++ b/packages/junior/tests/unit/local/conversation.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  isLocalConversationAlias,
+  normalizeLocalConversationId,
+} from "@/chat/local/conversation";
+
+describe("local conversation ids", () => {
+  it("normalizes aliases into local conversation ids scoped by cwd", () => {
+    expect(
+      normalizeLocalConversationId({
+        alias: "Demo.Thread",
+        cwd: "/tmp/junior-local-one",
+      }),
+    ).toMatch(/^local:[a-f0-9]{12}:demo-thread$/);
+    expect(
+      normalizeLocalConversationId({
+        alias: "Demo.Thread",
+        cwd: "/tmp/junior-local-two",
+      }),
+    ).not.toBe(
+      normalizeLocalConversationId({
+        alias: "Demo.Thread",
+        cwd: "/tmp/junior-local-one",
+      }),
+    );
+  });
+
+  it("uses default when no alias is provided", () => {
+    expect(
+      normalizeLocalConversationId({
+        cwd: "/tmp/junior-local-default",
+      }),
+    ).toMatch(/^local:[a-f0-9]{12}:default$/);
+  });
+
+  it("rejects invalid aliases", () => {
+    expect(isLocalConversationAlias("demo")).toBe(true);
+    expect(isLocalConversationAlias("")).toBe(false);
+    expect(isLocalConversationAlias("../demo")).toBe(false);
+    expect(isLocalConversationAlias("demo with spaces")).toBe(false);
+    expect(normalizeLocalConversationId({ alias: "../demo" })).toBeUndefined();
+  });
+});

--- a/packages/junior/tests/unit/plugins/agent-hooks.test.ts
+++ b/packages/junior/tests/unit/plugins/agent-hooks.test.ts
@@ -111,6 +111,7 @@ describe("agent plugin hooks", () => {
       const tools = getAgentPluginTools({
         destination: SLACK_DESTINATION,
         requester: TEST_REQUESTER,
+        source: SLACK_DESTINATION,
         sandbox: {} as any,
       });
 
@@ -145,6 +146,7 @@ describe("agent plugin hooks", () => {
       expect(() =>
         getAgentPluginTools({
           destination: LOCAL_DESTINATION,
+          source: LOCAL_DESTINATION,
           sandbox: {} as any,
         }),
       ).toThrow("must be a camelCase identifier");
@@ -181,6 +183,7 @@ describe("agent plugin hooks", () => {
           {},
           {
             destination: LOCAL_DESTINATION,
+            source: LOCAL_DESTINATION,
             sandbox: {} as any,
           },
         ),
@@ -525,6 +528,7 @@ describe("getAgentPluginTools channel resolution", () => {
   function capturePluginContext(
     context: ToolRuntimeContext = {
       destination: LOCAL_DESTINATION,
+      source: LOCAL_DESTINATION,
       sandbox: {} as any,
     },
   ) {
@@ -554,28 +558,42 @@ describe("getAgentPluginTools channel resolution", () => {
 
   it("passes runtime-owned destination directly to plugin hooks", () => {
     const ctx = capturePluginContext({
-      destination: {
+      source: {
         platform: "slack",
         teamId: "T123",
         channelId: "DDM",
       },
+      destination: {
+        platform: "slack",
+        teamId: "T123",
+        channelId: "COUT",
+      },
       sandbox: {} as any,
     });
-    expect(ctx.slack?.channelId).toBe("DDM");
-    expect(ctx.destination).toEqual({
+    expect(ctx.source).toEqual({
       platform: "slack",
       teamId: "T123",
       channelId: "DDM",
     });
+    expect(ctx.destination).toEqual({
+      platform: "slack",
+      teamId: "T123",
+      channelId: "COUT",
+    });
   });
 
-  it("computes channelCapabilities from channelId", () => {
+  it("computes channelCapabilities from source channelId", () => {
     // DM channel: canvas and reactions yes, standalone channel-post no
     const ctx = capturePluginContext({
-      destination: {
+      source: {
         platform: "slack",
         teamId: "T123",
         channelId: "DDM",
+      },
+      destination: {
+        platform: "slack",
+        teamId: "T123",
+        channelId: "COUT",
       },
       sandbox: {} as any,
     });
@@ -586,10 +604,15 @@ describe("getAgentPluginTools channel resolution", () => {
 
   it("creates a direct credential subject when channelId is a DM", () => {
     const ctx = capturePluginContext({
-      destination: {
+      source: {
         platform: "slack",
         teamId: "T123",
         channelId: "DDM",
+      },
+      destination: {
+        platform: "slack",
+        teamId: "T123",
+        channelId: "COUT",
       },
       requester: TEST_REQUESTER,
       sandbox: {} as any,
@@ -604,10 +627,15 @@ describe("getAgentPluginTools channel resolution", () => {
 
   it("does not create a credential subject when channelId is not a DM", () => {
     const ctx = capturePluginContext({
-      destination: {
+      source: {
         platform: "slack",
         teamId: "T123",
         channelId: "CSOURCE",
+      },
+      destination: {
+        platform: "slack",
+        teamId: "T123",
+        channelId: "COUT",
       },
       requester: TEST_REQUESTER,
       sandbox: {} as any,
@@ -620,6 +648,7 @@ describe("getAgentPluginTools channel resolution", () => {
     const ctx = capturePluginContext({
       conversationId: "slack:DDM:1780479160.406339",
       destination: SLACK_DESTINATION,
+      source: SLACK_DESTINATION,
       sandbox: {} as any,
     });
 
@@ -629,6 +658,7 @@ describe("getAgentPluginTools channel resolution", () => {
   it("does not synthesize Slack context from local destinations", () => {
     const ctx = capturePluginContext();
     expect(ctx.destination).toEqual(LOCAL_DESTINATION);
+    expect(ctx.source).toEqual(LOCAL_DESTINATION);
     expect(ctx.slack).toBeUndefined();
   });
 });

--- a/packages/junior/tests/unit/plugins/agent-hooks.test.ts
+++ b/packages/junior/tests/unit/plugins/agent-hooks.test.ts
@@ -22,6 +22,17 @@ const TEST_REQUESTER = {
   userId: "U123",
 } as const;
 
+const LOCAL_DESTINATION = {
+  platform: "local",
+  conversationId: "local:test:agent-hooks",
+} as const;
+
+const SLACK_DESTINATION = {
+  platform: "slack",
+  teamId: "T123",
+  channelId: "DDM",
+} as const;
+
 function fakeSandbox(
   writes: Array<{ content: string | Uint8Array; path: string }>,
 ): SandboxInstance {
@@ -97,6 +108,7 @@ describe("agent plugin hooks", () => {
     ]);
     try {
       const tools = getAgentPluginTools({
+        destination: SLACK_DESTINATION,
         requester: TEST_REQUESTER,
         sandbox: {} as any,
       });
@@ -131,6 +143,7 @@ describe("agent plugin hooks", () => {
     try {
       expect(() =>
         getAgentPluginTools({
+          destination: LOCAL_DESTINATION,
           sandbox: {} as any,
         }),
       ).toThrow("must be a camelCase identifier");
@@ -166,6 +179,7 @@ describe("agent plugin hooks", () => {
           [],
           {},
           {
+            destination: LOCAL_DESTINATION,
             sandbox: {} as any,
           },
         ),
@@ -527,7 +541,7 @@ describe("getAgentPluginTools channel resolution", () => {
       }),
     ]);
     getAgentPluginTools({
-      requester: TEST_REQUESTER,
+      destination: LOCAL_DESTINATION,
       sandbox: {} as any,
       ...overrides,
     });
@@ -548,7 +562,7 @@ describe("getAgentPluginTools channel resolution", () => {
       },
       teamId: "T123",
     });
-    expect(ctx.channelId).toBe("slack:DDM");
+    expect(ctx.slack?.channelId).toBe("DDM");
     expect(ctx.destination).toEqual({
       platform: "slack",
       teamId: "T123",
@@ -558,20 +572,33 @@ describe("getAgentPluginTools channel resolution", () => {
 
   it("computes channelCapabilities from channelId", () => {
     // DM channel: canvas and reactions yes, standalone channel-post no
-    const ctx = capturePluginContext({ channelId: "DDM", teamId: "T123" });
-    expect(ctx.channelCapabilities?.canCreateCanvas).toBe(true);
-    expect(ctx.channelCapabilities?.canAddReactions).toBe(true);
-    expect(ctx.channelCapabilities?.canPostToChannel).toBe(false);
+    const ctx = capturePluginContext({
+      channelId: "DDM",
+      destination: {
+        platform: "slack",
+        teamId: "T123",
+        channelId: "DDM",
+      },
+      teamId: "T123",
+    });
+    expect(ctx.slack?.channelCapabilities.canCreateCanvas).toBe(true);
+    expect(ctx.slack?.channelCapabilities.canAddReactions).toBe(true);
+    expect(ctx.slack?.channelCapabilities.canPostToChannel).toBe(false);
   });
 
   it("creates a direct credential subject when channelId is a DM", () => {
     const ctx = capturePluginContext({
       channelId: "DDM",
+      destination: {
+        platform: "slack",
+        teamId: "T123",
+        channelId: "DDM",
+      },
       teamId: "T123",
       requester: TEST_REQUESTER,
     });
 
-    expect(ctx.credentialSubject).toMatchObject({
+    expect(ctx.slack?.credentialSubject).toMatchObject({
       type: "user",
       userId: "U123",
       allowedWhen: "private-direct-conversation",
@@ -581,28 +608,35 @@ describe("getAgentPluginTools channel resolution", () => {
   it("does not create a credential subject when channelId is not a DM", () => {
     const ctx = capturePluginContext({
       channelId: "CSOURCE",
+      destination: {
+        platform: "slack",
+        teamId: "T123",
+        channelId: "CSOURCE",
+      },
       teamId: "T123",
       requester: TEST_REQUESTER,
     });
 
-    expect(ctx.credentialSubject).toBeUndefined();
+    expect(ctx.slack?.credentialSubject).toBeUndefined();
   });
 
   it("exposes conversationId to plugins", () => {
     const ctx = capturePluginContext({
       channelId: "DDM",
       conversationId: "slack:DDM:1780479160.406339",
+      destination: SLACK_DESTINATION,
       teamId: "T123",
     });
 
     expect(ctx.conversationId).toBe("slack:DDM:1780479160.406339");
   });
 
-  it("does not synthesize destination from loose Slack context", () => {
+  it("does not synthesize Slack context from loose Slack fields", () => {
     const ctx = capturePluginContext({
       channelId: "DDM",
       teamId: "T123",
     });
-    expect(ctx.destination).toBeUndefined();
+    expect(ctx.destination).toEqual(LOCAL_DESTINATION);
+    expect(ctx.slack).toBeUndefined();
   });
 });

--- a/packages/junior/tests/unit/plugins/agent-hooks.test.ts
+++ b/packages/junior/tests/unit/plugins/agent-hooks.test.ts
@@ -13,6 +13,7 @@ import {
 } from "@/chat/plugins/agent-hooks";
 import { createTools } from "@/chat/tools";
 import { tool } from "@/chat/tools/definition";
+import type { ToolRuntimeContext } from "@/chat/tools/types";
 import { Type } from "@sinclair/typebox";
 import type { SandboxInstance } from "@/chat/sandbox/workspace";
 
@@ -522,7 +523,10 @@ describe("agent plugin hooks", () => {
 
 describe("getAgentPluginTools channel resolution", () => {
   function capturePluginContext(
-    overrides: Partial<Parameters<typeof getAgentPluginTools>[0]> = {},
+    context: ToolRuntimeContext = {
+      destination: LOCAL_DESTINATION,
+      sandbox: {} as any,
+    },
   ) {
     let captured: ToolRegistrationHookContext | undefined;
     const previous = setAgentPlugins([
@@ -540,11 +544,7 @@ describe("getAgentPluginTools channel resolution", () => {
         },
       }),
     ]);
-    getAgentPluginTools({
-      destination: LOCAL_DESTINATION,
-      sandbox: {} as any,
-      ...overrides,
-    });
+    getAgentPluginTools(context);
     setAgentPlugins(previous);
     if (!captured) {
       throw new Error("capture plugin tools hook was not called");
@@ -554,13 +554,12 @@ describe("getAgentPluginTools channel resolution", () => {
 
   it("passes runtime-owned destination directly to plugin hooks", () => {
     const ctx = capturePluginContext({
-      channelId: "slack:DDM",
       destination: {
         platform: "slack",
         teamId: "T123",
         channelId: "DDM",
       },
-      teamId: "T123",
+      sandbox: {} as any,
     });
     expect(ctx.slack?.channelId).toBe("DDM");
     expect(ctx.destination).toEqual({
@@ -573,13 +572,12 @@ describe("getAgentPluginTools channel resolution", () => {
   it("computes channelCapabilities from channelId", () => {
     // DM channel: canvas and reactions yes, standalone channel-post no
     const ctx = capturePluginContext({
-      channelId: "DDM",
       destination: {
         platform: "slack",
         teamId: "T123",
         channelId: "DDM",
       },
-      teamId: "T123",
+      sandbox: {} as any,
     });
     expect(ctx.slack?.channelCapabilities.canCreateCanvas).toBe(true);
     expect(ctx.slack?.channelCapabilities.canAddReactions).toBe(true);
@@ -588,14 +586,13 @@ describe("getAgentPluginTools channel resolution", () => {
 
   it("creates a direct credential subject when channelId is a DM", () => {
     const ctx = capturePluginContext({
-      channelId: "DDM",
       destination: {
         platform: "slack",
         teamId: "T123",
         channelId: "DDM",
       },
-      teamId: "T123",
       requester: TEST_REQUESTER,
+      sandbox: {} as any,
     });
 
     expect(ctx.slack?.credentialSubject).toMatchObject({
@@ -607,14 +604,13 @@ describe("getAgentPluginTools channel resolution", () => {
 
   it("does not create a credential subject when channelId is not a DM", () => {
     const ctx = capturePluginContext({
-      channelId: "CSOURCE",
       destination: {
         platform: "slack",
         teamId: "T123",
         channelId: "CSOURCE",
       },
-      teamId: "T123",
       requester: TEST_REQUESTER,
+      sandbox: {} as any,
     });
 
     expect(ctx.slack?.credentialSubject).toBeUndefined();
@@ -622,20 +618,16 @@ describe("getAgentPluginTools channel resolution", () => {
 
   it("exposes conversationId to plugins", () => {
     const ctx = capturePluginContext({
-      channelId: "DDM",
       conversationId: "slack:DDM:1780479160.406339",
       destination: SLACK_DESTINATION,
-      teamId: "T123",
+      sandbox: {} as any,
     });
 
     expect(ctx.conversationId).toBe("slack:DDM:1780479160.406339");
   });
 
-  it("does not synthesize Slack context from loose Slack fields", () => {
-    const ctx = capturePluginContext({
-      channelId: "DDM",
-      teamId: "T123",
-    });
+  it("does not synthesize Slack context from local destinations", () => {
+    const ctx = capturePluginContext();
     expect(ctx.destination).toEqual(LOCAL_DESTINATION);
     expect(ctx.slack).toBeUndefined();
   });

--- a/packages/junior/tests/unit/plugins/plugin-api-requester.test.ts
+++ b/packages/junior/tests/unit/plugins/plugin-api-requester.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { requesterSchema } from "@sentry/junior-plugin-api";
 
 describe("requesterSchema", () => {
-  it("requires Slack platform, team id, and user id when requester is present", () => {
+  it("requires Slack team id for Slack requesters", () => {
     expect(
       requesterSchema.safeParse({
         platform: "slack",
@@ -16,6 +16,24 @@ describe("requesterSchema", () => {
       requesterSchema.safeParse({
         platform: "slack",
         userId: "U123",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("accepts local requesters without Slack team state", () => {
+    expect(
+      requesterSchema.safeParse({
+        platform: "local",
+        userId: "local-cli",
+        userName: "local",
+      }).success,
+    ).toBe(true);
+
+    expect(
+      requesterSchema.safeParse({
+        platform: "local",
+        teamId: "T123",
+        userId: "local-cli",
       }).success,
     ).toBe(false);
   });

--- a/packages/junior/tests/unit/prompt.test.ts
+++ b/packages/junior/tests/unit/prompt.test.ts
@@ -3,27 +3,27 @@ import { buildSystemPrompt, buildTurnContextPrompt } from "@/chat/prompt";
 
 describe("prompt builders", () => {
   it("returns a byte-stable static system prompt", () => {
-    const destination = {
+    const source = {
       platform: "slack" as const,
       teamId: "T123",
       channelId: "C123",
     };
-    const systemPrompt = buildSystemPrompt({ destination });
+    const systemPrompt = buildSystemPrompt({ source });
 
-    expect(buildSystemPrompt({ destination })).toBe(systemPrompt);
+    expect(buildSystemPrompt({ source })).toBe(systemPrompt);
   });
 
   it("returns a byte-stable local system prompt variant", () => {
-    const destination = {
+    const source = {
       platform: "local" as const,
       conversationId: "local:test:run-test",
     };
-    const systemPrompt = buildSystemPrompt({ destination });
+    const systemPrompt = buildSystemPrompt({ source });
 
-    expect(buildSystemPrompt({ destination })).toBe(systemPrompt);
+    expect(buildSystemPrompt({ source })).toBe(systemPrompt);
     expect(systemPrompt).not.toBe(
       buildSystemPrompt({
-        destination: {
+        source: {
           platform: "slack",
           teamId: "T123",
           channelId: "C123",

--- a/packages/junior/tests/unit/prompt.test.ts
+++ b/packages/junior/tests/unit/prompt.test.ts
@@ -3,10 +3,33 @@ import { buildSystemPrompt, buildTurnContextPrompt } from "@/chat/prompt";
 
 describe("prompt builders", () => {
   it("returns a byte-stable static system prompt", () => {
-    const systemPrompt = buildSystemPrompt();
+    const destination = {
+      platform: "slack" as const,
+      teamId: "T123",
+      channelId: "C123",
+    };
+    const systemPrompt = buildSystemPrompt({ destination });
 
-    expect(buildSystemPrompt.length).toBe(0);
-    expect(buildSystemPrompt()).toBe(systemPrompt);
+    expect(buildSystemPrompt({ destination })).toBe(systemPrompt);
+  });
+
+  it("returns a byte-stable local system prompt variant", () => {
+    const destination = {
+      platform: "local" as const,
+      conversationId: "local:test:run-test",
+    };
+    const systemPrompt = buildSystemPrompt({ destination });
+
+    expect(buildSystemPrompt({ destination })).toBe(systemPrompt);
+    expect(systemPrompt).not.toBe(
+      buildSystemPrompt({
+        destination: {
+          platform: "slack",
+          teamId: "T123",
+          channelId: "C123",
+        },
+      }),
+    );
   });
 
   it("omits empty runtime context sections", () => {

--- a/packages/junior/tests/unit/runtime/destination.test.ts
+++ b/packages/junior/tests/unit/runtime/destination.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { createSlackDestination, parseDestination } from "@/chat/destination";
+import {
+  createSlackDestination,
+  destinationKey,
+  parseDestination,
+  sameDestination,
+} from "@/chat/destination";
 
 describe("destination context", () => {
   it("normalizes external Slack ids only when creating a destination", () => {
@@ -52,5 +57,24 @@ describe("destination context", () => {
       teamId: "T123",
       channelId: "C123",
     });
+  });
+
+  it("parses local destinations", () => {
+    const destination = parseDestination({
+      platform: "local",
+      conversationId: "local:abc123:demo",
+    });
+
+    expect(destination).toEqual({
+      platform: "local",
+      conversationId: "local:abc123:demo",
+    });
+    expect(destinationKey(destination!)).toBe("local:abc123:demo");
+    expect(
+      sameDestination(destination!, {
+        platform: "local",
+        conversationId: "local:abc123:demo",
+      }),
+    ).toBe(true);
   });
 });

--- a/packages/junior/tests/unit/runtime/respond-agent-continue.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-agent-continue.test.ts
@@ -1,5 +1,6 @@
 import { Buffer } from "node:buffer";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Destination } from "@sentry/junior-plugin-api";
 import type { PiMessage } from "@/chat/pi/messages";
 
 const { promptAborted, promptMode } = vi.hoisted(() => ({
@@ -210,6 +211,18 @@ import {
   upsertAgentTurnSessionRecord,
 } from "@/chat/state/turn-session";
 
+const TEST_DESTINATION = {
+  platform: "slack",
+  teamId: "T123",
+  channelId: "C123",
+} satisfies Destination;
+
+const TEST_REQUESTER = {
+  platform: "slack",
+  teamId: "T123",
+  userId: "U123",
+} as const;
+
 describe("generateAssistantReply agent continuation", () => {
   beforeEach(async () => {
     promptAborted.value = false;
@@ -229,6 +242,7 @@ describe("generateAssistantReply agent continuation", () => {
     const onInputCommitted = vi.fn();
 
     const error = await generateAssistantReply("help me", {
+      destination: TEST_DESTINATION,
       onInputCommitted,
     }).catch((caught) => caught);
 
@@ -238,7 +252,8 @@ describe("generateAssistantReply agent continuation", () => {
 
   it("stores the last safe boundary and throws a retryable timeout error", async () => {
     const replyPromise = generateAssistantReply("help me", {
-      requester: { platform: "slack", teamId: "T123", userId: "U123" },
+      destination: TEST_DESTINATION,
+      requester: TEST_REQUESTER,
       correlation: {
         conversationId: "conversation-1",
         turnId: "turn-1",
@@ -295,7 +310,8 @@ describe("generateAssistantReply agent continuation", () => {
     });
 
     const replyPromise = generateAssistantReply("help me", {
-      requester: { platform: "slack", teamId: "T123", userId: "U123" },
+      destination: TEST_DESTINATION,
+      requester: TEST_REQUESTER,
       correlation: {
         conversationId: "conversation-timeout-cap",
         turnId: "turn-timeout-cap",
@@ -327,7 +343,8 @@ describe("generateAssistantReply agent continuation", () => {
   it("records the effective request deadline timeout budget", async () => {
     const startedAtMs = Date.now();
     const replyPromise = generateAssistantReply("help me", {
-      requester: { platform: "slack", teamId: "T123", userId: "U123" },
+      destination: TEST_DESTINATION,
+      requester: TEST_REQUESTER,
       turnDeadlineAtMs: startedAtMs + 2_500,
       correlation: {
         conversationId: "conversation-short-deadline",
@@ -353,7 +370,8 @@ describe("generateAssistantReply agent continuation", () => {
 
   it("persists omitted-image context in the session-recorded Pi user message", async () => {
     const replyPromise = generateAssistantReply("what is in this image?", {
-      requester: { platform: "slack", teamId: "T123", userId: "U123" },
+      destination: TEST_DESTINATION,
+      requester: TEST_REQUESTER,
       omittedImageAttachmentCount: 1,
       correlation: {
         conversationId: "conversation-2",
@@ -391,7 +409,8 @@ describe("generateAssistantReply agent continuation", () => {
   it("persists agent continuation state when abort does not settle the agent run", async () => {
     promptMode.value = "hangsAfterAbort";
     const replyPromise = generateAssistantReply("help me", {
-      requester: { platform: "slack", teamId: "T123", userId: "U123" },
+      destination: TEST_DESTINATION,
+      requester: TEST_REQUESTER,
       correlation: {
         conversationId: "conversation-hung",
         turnId: "turn-hung",
@@ -432,7 +451,8 @@ describe("generateAssistantReply agent continuation", () => {
   it("uses one wall-clock timeout budget across provider retries", async () => {
     promptMode.value = "providerRetryThenHangs";
     const replyPromise = generateAssistantReply("help me", {
-      requester: { platform: "slack", teamId: "T123", userId: "U123" },
+      destination: TEST_DESTINATION,
+      requester: TEST_REQUESTER,
       correlation: {
         conversationId: "conversation-retry",
         turnId: "turn-retry",

--- a/packages/junior/tests/unit/runtime/respond-error-path.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-error-path.test.ts
@@ -14,6 +14,11 @@ vi.mock("@/chat/skills", () => ({
 
 const { generateAssistantReply } = await import("@/chat/respond");
 
+const LOCAL_DESTINATION = {
+  platform: "local" as const,
+  conversationId: "local:test:respond-error-path",
+};
+
 describe("generateAssistantReply error path", () => {
   afterAll(() => {
     if (originalAiModel === undefined) {
@@ -25,6 +30,7 @@ describe("generateAssistantReply error path", () => {
 
   it("preserves sandbox dependency hash on non-retryable failures", async () => {
     const reply = await generateAssistantReply("hello", {
+      destination: LOCAL_DESTINATION,
       sandbox: {
         sandboxId: "sb-123",
         sandboxDependencyProfileHash: "hash-abc",
@@ -42,10 +48,53 @@ describe("generateAssistantReply error path", () => {
   it("propagates pre-commit failures when durable input commit is required", async () => {
     await expect(
       generateAssistantReply("hello", {
+        destination: LOCAL_DESTINATION,
         onInputCommitted: async () => {
           throw new Error("input should not commit before startup succeeds");
         },
       }),
     ).rejects.toThrow("discover failed");
   }, 10_000);
+
+  it("hard-fails missing destinations", async () => {
+    await expect(
+      generateAssistantReply(
+        "hello",
+        {} as Parameters<typeof generateAssistantReply>[1],
+      ),
+    ).rejects.toThrow("Assistant reply generation requires a destination");
+  });
+
+  it("hard-fails requester and destination platform mismatches", async () => {
+    await expect(
+      generateAssistantReply("hello", {
+        destination: LOCAL_DESTINATION,
+        requester: {
+          platform: "slack",
+          teamId: "T123",
+          userId: "U123",
+        },
+      }),
+    ).rejects.toThrow(
+      'Requester platform "slack" does not match destination platform "local"',
+    );
+  });
+
+  it("hard-fails Slack correlation and destination mismatches", async () => {
+    await expect(
+      generateAssistantReply("hello", {
+        destination: {
+          platform: "slack",
+          teamId: "T123",
+          channelId: "C123",
+        },
+        correlation: {
+          channelId: "C999",
+          teamId: "T123",
+        },
+      }),
+    ).rejects.toThrow(
+      "Slack correlation channel does not match destination channel",
+    );
+  });
 });

--- a/packages/junior/tests/unit/runtime/respond-lazy-sandbox.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-lazy-sandbox.test.ts
@@ -510,7 +510,25 @@ vi.mock("@/chat/sandbox/sandbox", () => ({
   },
 }));
 
-import { generateAssistantReply } from "@/chat/respond";
+import {
+  generateAssistantReply,
+  type ReplyRequestContext,
+} from "@/chat/respond";
+
+const LOCAL_DESTINATION = {
+  platform: "local" as const,
+  conversationId: "local:test:respond-lazy-sandbox",
+};
+
+function generateLocalReply(
+  message: string,
+  context: Omit<ReplyRequestContext, "destination"> = {},
+) {
+  return generateAssistantReply(message, {
+    ...context,
+    destination: LOCAL_DESTINATION,
+  });
+}
 
 describe("generateAssistantReply lazy sandbox boot", () => {
   beforeEach(() => {
@@ -524,7 +542,7 @@ describe("generateAssistantReply lazy sandbox boot", () => {
   });
 
   it("does not create a sandbox for turns that never touch sandbox-backed tools", async () => {
-    const reply = await generateAssistantReply("hello");
+    const reply = await generateLocalReply("hello");
 
     expect(reply.text).toBe("Plain reply.");
     expect(createSandboxCallCount.value).toBe(0);
@@ -536,7 +554,7 @@ describe("generateAssistantReply lazy sandbox boot", () => {
   it("does not create a sandbox when loadSkill only reads host-side skill data", async () => {
     agentMode.value = "loadSkill";
 
-    const reply = await generateAssistantReply("load the demo skill");
+    const reply = await generateLocalReply("load the demo skill");
 
     expect(reply.text).toBe("Loaded demo skill.");
     expect(createSandboxCallCount.value).toBe(0);
@@ -558,7 +576,7 @@ describe("generateAssistantReply lazy sandbox boot", () => {
       },
     ];
 
-    const reply = await generateAssistantReply("hello");
+    const reply = await generateLocalReply("hello");
 
     expect(reply.text).toBe("Plain reply.");
     expect(createSandboxCallCount.value).toBe(0);
@@ -568,7 +586,7 @@ describe("generateAssistantReply lazy sandbox boot", () => {
   it("memoizes the lazy sandbox workspace across multiple workspace calls", async () => {
     agentMode.value = "attachFile";
 
-    const reply = await generateAssistantReply("attach the report");
+    const reply = await generateLocalReply("attach the report");
 
     expect(reply.text).toBe("Attached report.");
     expect(createSandboxCallCount.value).toBe(1);
@@ -577,14 +595,14 @@ describe("generateAssistantReply lazy sandbox boot", () => {
   });
 
   it("uses a high thinking level for explicit code-change asks", async () => {
-    const reply = await generateAssistantReply("fix the failing test in chat");
+    const reply = await generateLocalReply("fix the failing test in chat");
 
     expect(reply.text).toBe("Plain reply.");
     expect(selectedThinkingLevels.value).toEqual(["high"]);
   });
 
   it("uses attachment text when routing the turn thinking level", async () => {
-    const reply = await generateAssistantReply("can you fix this?", {
+    const reply = await generateLocalReply("can you fix this?", {
       userAttachments: [
         {
           data: Buffer.from("TypeError: x is undefined\nat respond.ts:42"),
@@ -599,7 +617,7 @@ describe("generateAssistantReply lazy sandbox boot", () => {
   });
 
   it("uses structured-suffix attachment text when the media type has parameters", async () => {
-    const reply = await generateAssistantReply("can you fix this?", {
+    const reply = await generateLocalReply("can you fix this?", {
       userAttachments: [
         {
           data: Buffer.from("TypeError: x is undefined\nat respond.ts:42"),
@@ -616,7 +634,7 @@ describe("generateAssistantReply lazy sandbox boot", () => {
   it("retains sandbox reuse metadata after lazy boot on error turns", async () => {
     agentMode.value = "attachFileThenError";
 
-    const reply = await generateAssistantReply("attach the report");
+    const reply = await generateLocalReply("attach the report");
 
     expect(reply.text).toContain("Error: agent exploded");
     expect(createSandboxCallCount.value).toBe(1);
@@ -628,7 +646,7 @@ describe("generateAssistantReply lazy sandbox boot", () => {
     agentMode.value = "attachFileThenError";
     const onSandboxAcquired = vi.fn();
 
-    const reply = await generateAssistantReply("attach the report", {
+    const reply = await generateLocalReply("attach the report", {
       onSandboxAcquired,
     });
 
@@ -643,7 +661,7 @@ describe("generateAssistantReply lazy sandbox boot", () => {
   it("retains sandbox reuse metadata after executor-backed boot on error turns", async () => {
     agentMode.value = "bashThenError";
 
-    const reply = await generateAssistantReply("run pwd");
+    const reply = await generateLocalReply("run pwd");
 
     expect(reply.text).toContain("Error: agent exploded");
     expect(createSandboxCallCount.value).toBe(1);
@@ -654,7 +672,7 @@ describe("generateAssistantReply lazy sandbox boot", () => {
   it("refreshes the cached workspace after sandbox replacement", async () => {
     agentMode.value = "attachFileBashRecoverAttachFile";
 
-    const reply = await generateAssistantReply("attach the report twice");
+    const reply = await generateLocalReply("attach the report twice");
 
     expect(reply.text).toBe("Attached report twice.");
     expect(createSandboxCallCount.value).toBe(2);
@@ -670,9 +688,7 @@ describe("generateAssistantReply lazy sandbox boot", () => {
   it("refreshes the cached workspace when sandbox replacement races with lazy boot", async () => {
     agentMode.value = "attachFileBashRaceAttachFile";
 
-    const reply = await generateAssistantReply(
-      "attach the report after a race",
-    );
+    const reply = await generateLocalReply("attach the report after a race");
 
     expect(reply.text).toBe("Attached report after race.");
     expect(createSandboxCallCount.value).toBe(2);

--- a/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
@@ -102,6 +102,11 @@ function makeReplyContext(args: {
     credentialContext: {
       actor: { type: "user" as const, userId: "U123" },
     },
+    destination: {
+      platform: "slack" as const,
+      teamId: "T123",
+      channelId: "C123",
+    },
     requester: TEST_REQUESTER,
     correlation: {
       channelId: "C123",
@@ -1089,6 +1094,11 @@ describe("generateAssistantReply progressive MCP loading", () => {
       credentialContext: {
         actor: { type: "user" as const, userId: "U123" },
       },
+      destination: {
+        platform: "slack" as const,
+        teamId: "T123",
+        channelId: "C123",
+      },
       requester: TEST_REQUESTER,
       correlation: {
         conversationId: "conversation-3",
@@ -1174,6 +1184,11 @@ describe("generateAssistantReply progressive MCP loading", () => {
       credentialContext: {
         actor: { type: "user", userId: "U123" },
       },
+      destination: {
+        platform: "slack",
+        teamId: "T123",
+        channelId: "C123",
+      },
       requester: TEST_REQUESTER,
       correlation: {
         conversationId: "conversation-5",
@@ -1204,6 +1219,11 @@ describe("generateAssistantReply progressive MCP loading", () => {
     const firstError = await generateAssistantReply("help me", {
       credentialContext: {
         actor: { type: "user", userId: "U123" },
+      },
+      destination: {
+        platform: "slack",
+        teamId: "T123",
+        channelId: "C123",
       },
       requester: TEST_REQUESTER,
       correlation: {

--- a/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
@@ -257,6 +257,7 @@ describe("generateAssistantReply provider retry", () => {
 
   it("continues from the last safe boundary after a transient provider stream error", async () => {
     const replyPromise = generateAssistantReply("help me", {
+      destination: TEST_DESTINATION,
       requester: { platform: "slack", teamId: "T123", userId: "U123" },
       correlation: {
         conversationId: "conversation-1",
@@ -326,6 +327,7 @@ describe("generateAssistantReply provider retry", () => {
     ] satisfies PiMessage[];
 
     const reply = await generateAssistantReply("help me", {
+      destination: TEST_DESTINATION,
       piMessages: priorMessages,
       requester: { platform: "slack", teamId: "T123", userId: "U123" },
       correlation: {
@@ -383,6 +385,7 @@ describe("generateAssistantReply provider retry", () => {
     agentMode.value = "cooperativeYield";
 
     const error = await generateAssistantReply("help me", {
+      destination: TEST_DESTINATION,
       requester: { platform: "slack", teamId: "T123", userId: "U123" },
       correlation: {
         conversationId: "conversation-yield",
@@ -390,7 +393,6 @@ describe("generateAssistantReply provider retry", () => {
         channelId: "C123",
         threadTs: "1712345.0003",
       },
-      destination: TEST_DESTINATION,
       shouldYield: () => true,
     }).then(
       () => undefined,
@@ -480,6 +482,7 @@ describe("generateAssistantReply provider retry", () => {
       .mockRejectedValue(new Error("storage unavailable"));
 
     const error = await generateAssistantReply("help me", {
+      destination: TEST_DESTINATION,
       requester: { platform: "slack", teamId: "T123", userId: "U123" },
       correlation: {
         conversationId: "conversation-yield-persist-failure",
@@ -513,6 +516,7 @@ describe("generateAssistantReply provider retry", () => {
     let injectCompleted = false;
 
     await generateAssistantReply("help me", {
+      destination: TEST_DESTINATION,
       requester: { platform: "slack", teamId: "T123", userId: "U123" },
       correlation: {
         conversationId: "conversation-steering-failure",

--- a/packages/junior/tests/unit/services/requester.test.ts
+++ b/packages/junior/tests/unit/services/requester.test.ts
@@ -49,6 +49,25 @@ describe("requester", () => {
     ).toEqual({ platform: "slack", teamId: "T123", userId: "U039RR91S" });
   });
 
+  it("builds local requester identities without Slack team state", () => {
+    expect(
+      createRequester(
+        {
+          fullName: "Local CLI",
+          platform: "local",
+          userId: "local-cli",
+          userName: "local",
+        },
+        { platform: "local", userId: "local-cli" },
+      ),
+    ).toEqual({
+      fullName: "Local CLI",
+      platform: "local",
+      userId: "local-cli",
+      userName: "local",
+    });
+  });
+
   it("does not preserve synthetic unknown actor ids", () => {
     expect(
       createRequester(

--- a/packages/junior/tests/unit/slack/slack-message-add-reaction-tool.test.ts
+++ b/packages/junior/tests/unit/slack/slack-message-add-reaction-tool.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createSlackMessageAddReactionTool } from "@/chat/tools/slack/message-add-reaction";
+import type { SlackToolContext } from "@/chat/tools/slack/context";
 
 const addReactionToMessage = vi.fn();
 
@@ -7,16 +8,17 @@ vi.mock("@/chat/slack/outbound", () => ({
   addReactionToMessage: (...args: unknown[]) => addReactionToMessage(...args),
 }));
 
-const TEST_SLACK_CONTEXT = {
+const TEST_SLACK_CONTEXT: SlackToolContext = {
   channelId: "C123",
   destination: {
     platform: "slack",
     teamId: "T123",
     channelId: "C123",
   },
+  deliveryChannelId: "C123",
   messageTs: "1700000000.100",
-  sandbox: {} as any,
-} as const;
+  teamId: "T123",
+};
 
 function createState() {
   const cache = new Map<string, unknown>();

--- a/packages/junior/tests/unit/slack/slack-message-add-reaction-tool.test.ts
+++ b/packages/junior/tests/unit/slack/slack-message-add-reaction-tool.test.ts
@@ -7,6 +7,17 @@ vi.mock("@/chat/slack/outbound", () => ({
   addReactionToMessage: (...args: unknown[]) => addReactionToMessage(...args),
 }));
 
+const TEST_SLACK_CONTEXT = {
+  channelId: "C123",
+  destination: {
+    platform: "slack",
+    teamId: "T123",
+    channelId: "C123",
+  },
+  messageTs: "1700000000.100",
+  sandbox: {} as any,
+} as const;
+
 function createState() {
   const cache = new Map<string, unknown>();
   return {
@@ -22,11 +33,7 @@ describe("slackMessageAddReaction tool", () => {
   it("rejects non-alias emoji input", async () => {
     addReactionToMessage.mockReset();
     const tool = createSlackMessageAddReactionTool(
-      {
-        channelId: "C123",
-        messageTs: "1700000000.100",
-        sandbox: {} as any,
-      },
+      TEST_SLACK_CONTEXT,
       createState() as any,
     );
     if (!tool.execute) {
@@ -46,11 +53,7 @@ describe("slackMessageAddReaction tool", () => {
     addReactionToMessage.mockReset();
     addReactionToMessage.mockResolvedValue({ ok: true });
     const tool = createSlackMessageAddReactionTool(
-      {
-        channelId: "C123",
-        messageTs: "1700000000.100",
-        sandbox: {} as any,
-      },
+      TEST_SLACK_CONTEXT,
       createState() as any,
     );
     if (!tool.execute) {
@@ -75,11 +78,7 @@ describe("slackMessageAddReaction tool", () => {
     addReactionToMessage.mockReset();
     addReactionToMessage.mockResolvedValue({ ok: true });
     const tool = createSlackMessageAddReactionTool(
-      {
-        channelId: "C123",
-        messageTs: "1700000000.100",
-        sandbox: {} as any,
-      },
+      TEST_SLACK_CONTEXT,
       createState() as any,
     );
     if (!tool.execute) {

--- a/packages/junior/tests/unit/slack/slack-message-add-reaction-tool.test.ts
+++ b/packages/junior/tests/unit/slack/slack-message-add-reaction-tool.test.ts
@@ -9,14 +9,20 @@ vi.mock("@/chat/slack/outbound", () => ({
 }));
 
 const TEST_SLACK_CONTEXT: SlackToolContext = {
-  channelId: "C123",
   destination: {
     platform: "slack",
     teamId: "T123",
     channelId: "C123",
   },
-  deliveryChannelId: "C123",
+  source: {
+    platform: "slack",
+    teamId: "T123",
+    channelId: "C123",
+    messageTs: "1700000000.100",
+  },
+  destinationChannelId: "C123",
   messageTs: "1700000000.100",
+  sourceChannelId: "C123",
   teamId: "T123",
 };
 

--- a/packages/junior/tests/unit/slack/tool-registration.test.ts
+++ b/packages/junior/tests/unit/slack/tool-registration.test.ts
@@ -5,17 +5,18 @@ import { schedulerPlugin } from "@sentry/junior-scheduler";
 import { setAgentPlugins } from "@/chat/plugins/agent-hooks";
 const noopSandbox = {} as any;
 
-function ctx(): Extract<
-  ToolRuntimeContext,
-  { destination: { platform: "local" } }
->;
+function ctx(): Extract<ToolRuntimeContext, { source: { platform: "local" } }>;
 function ctx(
   channelId: string,
-): Extract<ToolRuntimeContext, { destination: { platform: "slack" } }>;
+): Extract<ToolRuntimeContext, { source: { platform: "slack" } }>;
 function ctx(channelId?: string): ToolRuntimeContext {
   if (!channelId) {
     return {
       destination: {
+        platform: "local" as const,
+        conversationId: "local:test:tool-registration",
+      },
+      source: {
         platform: "local" as const,
         conversationId: "local:test:tool-registration",
       },
@@ -25,6 +26,11 @@ function ctx(channelId?: string): ToolRuntimeContext {
 
   return {
     destination: {
+      platform: "slack" as const,
+      teamId: "T123",
+      channelId,
+    },
+    source: {
       platform: "slack" as const,
       teamId: "T123",
       channelId,
@@ -66,8 +72,10 @@ describe("Slack tool registration", () => {
       {},
       {
         ...ctx("D12345"),
-        slack: {
-          deliveryChannelId: "C12345",
+        destination: {
+          platform: "slack",
+          teamId: "T123",
+          channelId: "C12345",
         },
       },
     );
@@ -138,6 +146,10 @@ describe("Slack tool registration", () => {
       {},
       {
         destination: {
+          platform: "local",
+          conversationId: "local:test:run-test",
+        },
+        source: {
           platform: "local",
           conversationId: "local:test:run-test",
         },

--- a/packages/junior/tests/unit/slack/tool-registration.test.ts
+++ b/packages/junior/tests/unit/slack/tool-registration.test.ts
@@ -1,10 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createTools } from "@/chat/tools";
+import type { ToolRuntimeContext } from "@/chat/tools/types";
 import { schedulerPlugin } from "@sentry/junior-scheduler";
 import { setAgentPlugins } from "@/chat/plugins/agent-hooks";
 const noopSandbox = {} as any;
 
-function ctx(channelId?: string) {
+function ctx(): Extract<
+  ToolRuntimeContext,
+  { destination: { platform: "local" } }
+>;
+function ctx(
+  channelId: string,
+): Extract<ToolRuntimeContext, { destination: { platform: "slack" } }>;
+function ctx(channelId?: string): ToolRuntimeContext {
   if (!channelId) {
     return {
       destination: {
@@ -16,13 +24,11 @@ function ctx(channelId?: string) {
   }
 
   return {
-    channelId,
     destination: {
       platform: "slack" as const,
       teamId: "T123",
       channelId,
     },
-    teamId: "T123",
     sandbox: noopSandbox,
   };
 }
@@ -60,7 +66,9 @@ describe("Slack tool registration", () => {
       {},
       {
         ...ctx("D12345"),
-        deliveryChannelId: "C12345",
+        slack: {
+          deliveryChannelId: "C12345",
+        },
       },
     );
 
@@ -82,7 +90,6 @@ describe("Slack tool registration", () => {
           teamId: "T123",
           channelId: "C12345",
         },
-        teamId: "T123",
         requester: {
           platform: "slack",
           teamId: "T123",
@@ -105,7 +112,6 @@ describe("Slack tool registration", () => {
       {},
       {
         ...ctx("C12345"),
-        teamId: "T123",
       },
     );
 

--- a/packages/junior/tests/unit/slack/tool-registration.test.ts
+++ b/packages/junior/tests/unit/slack/tool-registration.test.ts
@@ -5,8 +5,24 @@ import { setAgentPlugins } from "@/chat/plugins/agent-hooks";
 const noopSandbox = {} as any;
 
 function ctx(channelId?: string) {
+  if (!channelId) {
+    return {
+      destination: {
+        platform: "local" as const,
+        conversationId: "local:test:tool-registration",
+      },
+      sandbox: noopSandbox,
+    };
+  }
+
   return {
     channelId,
+    destination: {
+      platform: "slack" as const,
+      teamId: "T123",
+      channelId,
+    },
+    teamId: "T123",
     sandbox: noopSandbox,
   };
 }
@@ -104,8 +120,27 @@ describe("Slack tool registration", () => {
     const tools = createTools([], {}, ctx());
 
     expect(tools).not.toHaveProperty("slackCanvasCreate");
+    expect(tools).not.toHaveProperty("slackCanvasRead");
     expect(tools).not.toHaveProperty("slackChannelPostMessage");
     expect(tools).not.toHaveProperty("slackChannelListMessages");
     expect(tools).not.toHaveProperty("slackMessageAddReaction");
+  });
+
+  it("does not register Slack tools for local destinations", () => {
+    const tools = createTools(
+      [],
+      {},
+      {
+        destination: {
+          platform: "local",
+          conversationId: "local:test:run-test",
+        },
+        sandbox: noopSandbox,
+      },
+    );
+
+    expect(
+      Object.keys(tools).filter((name) => name.startsWith("slack")),
+    ).toEqual([]);
   });
 });

--- a/packages/junior/tsup.config.ts
+++ b/packages/junior/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     "cli/env": "src/cli/env.ts",
     "cli/init": "src/cli/init.ts",
     "cli/run": "src/cli/run.ts",
+    "cli/chat": "src/cli/chat.ts",
     "cli/check": "src/cli/check.ts",
     "cli/upgrade": "src/cli/upgrade.ts",
     "cli/snapshot-warmup": "src/cli/snapshot-warmup.ts",

--- a/specs/agent-prompt.md
+++ b/specs/agent-prompt.md
@@ -11,7 +11,7 @@ Define the canonical contract for Junior's platform-owned agent prompt so prompt
 
 ## Scope
 
-- `buildSystemPrompt({ destination })` in `packages/junior/src/chat/prompt.ts`.
+- `buildSystemPrompt({ source })` in `packages/junior/src/chat/prompt.ts`.
 - `buildTurnContextPrompt(...)` in `packages/junior/src/chat/prompt.ts`.
 - Platform-owned behavior, capability, context, and Slack output instructions.
 - Boundaries between the core harness prompt, deployment personality files, and skill instructions.
@@ -35,7 +35,7 @@ Define the canonical contract for Junior's platform-owned agent prompt so prompt
 
 ### Section boundaries
 
-`buildSystemPrompt({ destination })` must receive the active destination and return the byte-stable static prompt variant for that destination platform. It must not read requester/thread/session/runtime/model/provider/catalog data, and it must not include content that can vary between conversations or turns within the same platform. Deployment-stable assistant identity and deployment-stable world context from `WORLD.md` belong here. Platform-specific mechanics, such as Slack output rules or local terminal output rules, may differ by `destination.platform`. This preserves provider prompt-prefix caching per platform and keeps multi-turn behavior consistent inside each platform.
+`buildSystemPrompt({ source })` must receive the active source and return the byte-stable static prompt variant for that source platform. It must not read requester/thread/session/runtime/model/provider/catalog data, and it must not include content that can vary between conversations or turns within the same platform. Deployment-stable assistant identity and deployment-stable world context from `WORLD.md` belong here. Platform-specific mechanics, such as Slack output rules or local terminal output rules, may differ by `source.platform`. This preserves provider prompt-prefix caching per platform and keeps multi-turn behavior consistent inside each platform.
 
 `buildTurnContextPrompt(...)` owns session bootstrap prompt context. It is attached to the first model-visible user message in a Pi session projection, including requester identity, available capabilities, configuration, artifacts, model-actionable runtime identifiers, and resumed-turn context. Completed turns may store that bootstrap context as part of durable Pi history so later follow-up messages can avoid duplicating it. Compaction replacement history must omit stale bootstrap context; the next user turn after a projection reset receives fresh bootstrap context exactly once.
 

--- a/specs/agent-prompt.md
+++ b/specs/agent-prompt.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-04-28
-- Last Edited: 2026-06-01
+- Last Edited: 2026-06-11
 
 ## Purpose
 
@@ -11,7 +11,7 @@ Define the canonical contract for Junior's platform-owned agent prompt so prompt
 
 ## Scope
 
-- `buildSystemPrompt()` in `packages/junior/src/chat/prompt.ts`.
+- `buildSystemPrompt({ destination })` in `packages/junior/src/chat/prompt.ts`.
 - `buildTurnContextPrompt(...)` in `packages/junior/src/chat/prompt.ts`.
 - Platform-owned behavior, capability, context, and Slack output instructions.
 - Boundaries between the core harness prompt, deployment personality files, and skill instructions.
@@ -35,7 +35,7 @@ Define the canonical contract for Junior's platform-owned agent prompt so prompt
 
 ### Section boundaries
 
-`buildSystemPrompt()` must be static: no parameters, no requester/thread/session/runtime/model/provider/catalog data, and no content that can vary between conversations or turns. Deployment-stable assistant identity, such as the bot Slack username, and deployment-stable world context from `WORLD.md` belong here. This is required for provider prompt-prefix caching and for consistent multi-turn behavior.
+`buildSystemPrompt({ destination })` must receive the active destination and return the byte-stable static prompt variant for that destination platform. It must not read requester/thread/session/runtime/model/provider/catalog data, and it must not include content that can vary between conversations or turns within the same platform. Deployment-stable assistant identity and deployment-stable world context from `WORLD.md` belong here. Platform-specific mechanics, such as Slack output rules or local terminal output rules, may differ by `destination.platform`. This preserves provider prompt-prefix caching per platform and keeps multi-turn behavior consistent inside each platform.
 
 `buildTurnContextPrompt(...)` owns session bootstrap prompt context. It is attached to the first model-visible user message in a Pi session projection, including requester identity, available capabilities, configuration, artifacts, model-actionable runtime identifiers, and resumed-turn context. Completed turns may store that bootstrap context as part of durable Pi history so later follow-up messages can avoid duplicating it. Compaction replacement history must omit stale bootstrap context; the next user turn after a projection reset receives fresh bootstrap context exactly once.
 
@@ -48,7 +48,7 @@ The combined prompt surface must keep these concerns distinct:
 1. Identity/personality.
 2. Deployment-stable world context.
 3. Core operating rules.
-4. Slack output contract.
+4. Platform output contract.
 5. Available and loaded capabilities.
 6. Runtime and thread context.
 
@@ -69,7 +69,7 @@ The core operating rules must be split into fixed sections:
 3. Skill policy.
 4. Execution contract.
 5. Conversation/thread continuity.
-6. Slack side-effect actions.
+6. Platform side-effect actions.
 7. Safety.
 8. Failure handling.
 

--- a/specs/chat-architecture.md
+++ b/specs/chat-architecture.md
@@ -3,16 +3,17 @@
 ## Metadata
 
 - Created: 2026-03-21
-- Last Edited: 2026-06-08
+- Last Edited: 2026-06-10
 
 ## Purpose
 
-Define the normative architecture contract for `packages/junior/src/chat` so new work converges on explicit composition, small service interfaces, and maintainable test seams.
+Define the normative architecture contract for `packages/junior/src/chat` so new work converges on explicit composition, platform adapters, small service interfaces, and maintainable test seams.
 
 ## Scope
 
 - File-tree structure and responsibility boundaries for `packages/junior/src/chat`.
 - Runtime/service/state composition rules.
+- Platform adapter boundaries for Slack, local CLI, and future message sources.
 - Test and eval seams for chat runtime behavior.
 
 ## Non-Goals
@@ -33,13 +34,13 @@ Define the normative architecture contract for `packages/junior/src/chat` so new
 
 ### Agent Run Data Flow
 
-The core architecture is the flow of one Slack event into a durable agent run.
+The core architecture is the flow of one platform event into a durable agent run.
 Module boundaries exist to keep this flow explicit and recoverable; they are not
 the primary architecture by themselves.
 
 ```mermaid
 flowchart TD
-  A[Slack webhook event] --> B[Slack-specific ingress parsing and classification]
+  A[Platform event or local CLI input] --> B[Platform adapter normalization and classification]
   B --> C[Append to durable conversation mailbox]
   C --> D[Send Vercel Queue nudge: conversationId + Destination]
   D --> E[Queue worker acquires conversation lease]
@@ -61,14 +62,14 @@ flowchart TD
   Z -->|yes| E2
   Z -->|no| O
   L --> O{Run outcome}
-  O -->|success/final diagnostics| P[Plan finalized Slack reply]
+  O -->|success/final diagnostics| P[Plan finalized destination reply]
   O -->|auth pause| Q[Append auth pause event and pending auth pointer]
   O -->|cooperative yield| R[Durable session-log boundary already committed]
   O -->|terminal failure| S[Capture failure and build fallback reply]
   R --> YA
   Q --> V[Private auth link plus visible URL-free auth acknowledgement; live run ends]
   V --> AB[OAuth/MCP callback appends mailbox work and enqueues conversation]
-  P --> W[Deliver finalized Slack reply/files]
+  P --> W[Deliver finalized destination reply/files]
   S --> W
   W --> X[Persist assistant message, mark session delivered, release lease]
   AB --> D
@@ -76,32 +77,32 @@ flowchart TD
 
 Normative rules:
 
-1. Ingress parses and classifies source events, appends them to the durable mailbox, and sends a queue nudge. It must not decide agent behavior.
+1. Platform adapters parse and classify source events, append them to the durable mailbox, and send a queue nudge. They must not decide agent behavior beyond source-specific routing such as Slack mention/subscribed classification.
 2. The task execution layer owns queue wake-ups, conversation leases, worker check-ins, and heartbeat recovery. Chat SDK queue/lock semantics are not canonical.
 3. The mailbox worker is the only point that drains inbound messages into persisted agent session context.
 4. `respond.ts` is the only owner of Pi agent execution, prompt/continue selection, timeout detection, and safe-boundary session-log event creation.
 5. Tool calls and tool failures are internal agent-loop data until the assistant produces final run diagnostics. Tool execution errors must be captured, but they are not automatically terminal user replies. Model-repairable failures must use the tool-error semantics from [Agent Execution Discipline Spec](./agent-execution.md).
-6. User-visible assistant text is posted only after the reply is finalized and planned for Slack delivery.
-7. Final run success is defined by Slack accepting the visible final reply, not by model generation completing.
+6. User-visible assistant text is posted only after the reply is finalized and planned for destination delivery.
+7. Final run success is defined by the destination delivery port accepting the visible final reply, not by model generation completing. Slack acceptance is one destination implementation.
 8. Agent recovery is session continuation: reload durable thread state plus the reduced session log, then continue the same session. It must not create a second active run or re-run from transient process memory.
 9. Cooperative yield at safe agent-loop boundaries is the normal accommodation for Vercel execution limits. Platform death is recovered by queue redelivery and heartbeat repair from the latest durable session boundary.
 10. Assistant status and logs are observability/UX surfaces. They never substitute for persisted session recovery or final reply delivery.
 
 Data authority by stage:
 
-| Data                                    | Authority                                              | Notes                                                                                                                       |
-| --------------------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
-| Slack event shape                       | `ingress/` and Slack adapter payloads                  | Parse platform IDs and attachments before runtime; do not infer behavior here.                                              |
-| Queue wake-up and duplicate suppression | Conversation mailbox worker and lease                  | Queue messages are nudges; mailbox state and leases decide whether work exists and who may run it.                          |
-| Conversation API/index rows             | Conversation record + `conversation:by-activity` index | Source for dashboard/API conversation lists; do not rebuild the primary list by grouping agent-run rows.                    |
-| Active execution discovery              | `conversation:active` index + conversation record      | Heartbeat discovers stale active conversations here, then uses the record to decide whether to enqueue a nudge.             |
-| Conversation transcript                 | Persisted thread state                                 | Source for visible user/assistant thread history; assistant messages are added only after final Slack delivery.             |
-| Active work routing                     | Conversation mailbox and lease                         | Pending messages are drained into the active conversation at safe boundaries.                                               |
-| Pi execution transcript                 | Junior agent session log keyed by conversation id      | Append-only model-execution log with a deterministic Pi-message projection; not a replacement for visible Slack transcript. |
-| Sandbox/artifact state                  | Persisted thread state                                 | Persist eagerly as it changes so a resumed slice can rebuild the same runtime world.                                        |
-| Pending auth                            | Auth-owned callback state plus session-log pause event | Auth pauses end the live run after private link delivery and are resumed by callback.                                       |
-| Final Slack reply                       | Slack thread post acceptance                           | Completion is persisted only after Slack accepts the final visible reply.                                                   |
-| Routine continuation progress           | Assistant status and `reportProgress`                  | Cooperative yields do not post filler thread messages.                                                                      |
+| Data                                    | Authority                                              | Notes                                                                                                                              |
+| --------------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Platform event shape                    | Source adapter ingress modules                         | Parse platform IDs and attachments before runtime; do not infer agent behavior here.                                               |
+| Queue wake-up and duplicate suppression | Conversation mailbox worker and lease                  | Queue messages are nudges; mailbox state and leases decide whether work exists and who may run it.                                 |
+| Conversation API/index rows             | Conversation record + `conversation:by-activity` index | Source for dashboard/API conversation lists; do not rebuild the primary list by grouping agent-run rows.                           |
+| Active execution discovery              | `conversation:active` index + conversation record      | Heartbeat discovers stale active conversations here, then uses the record to decide whether to enqueue a nudge.                    |
+| Conversation transcript                 | Persisted thread state                                 | Source for visible user/assistant thread history; assistant messages are added only after final destination delivery.              |
+| Active work routing                     | Conversation mailbox and lease                         | Pending messages are drained into the active conversation at safe boundaries.                                                      |
+| Pi execution transcript                 | Junior agent session log keyed by conversation id      | Append-only model-execution log with a deterministic Pi-message projection; not a replacement for visible conversation transcript. |
+| Sandbox/artifact state                  | Persisted thread state                                 | Persist eagerly as it changes so a resumed slice can rebuild the same runtime world.                                               |
+| Pending auth                            | Auth-owned callback state plus session-log pause event | Auth pauses end the live run after private link delivery and are resumed by callback.                                              |
+| Final destination reply                 | Destination delivery port acceptance                   | Completion is persisted only after the destination accepts the final visible reply.                                                |
+| Routine continuation progress           | Assistant status and `reportProgress`                  | Cooperative yields do not post filler thread messages.                                                                             |
 
 Related contract ownership:
 
@@ -122,6 +123,7 @@ Related contract ownership:
 - `services/`: domain services with injected collaborators.
 - `state/`: adapter selection plus store modules split by concern.
 - `slack/`: Slack-specific client, output formatting, and channel/user helpers.
+- Local CLI adapter code may live under `cli/` or a source-specific runtime module, but it must use the same platform adapter boundary as Slack.
 - `ai/`: provider-facing AI clients.
 - `queue/`: queue transport and queue worker orchestration.
 - `turn/`: agent-run lifecycle state and resumability. The directory name is
@@ -132,7 +134,7 @@ Related contract ownership:
 
 - `app/` may import any chat module needed to assemble the runtime.
 - Non-`app/` modules must not import from `app/`.
-- `runtime/` may depend on `services/`, `state/`, `queue/`, `turn/`, `slack/`, and pure helpers.
+- `runtime/` may depend on `services/`, `state/`, `queue/`, `turn/`, source-specific delivery ports, and pure helpers.
 - `services/` must not depend on `runtime/`.
 - `services/` must not import Slack infrastructure; use small injected ports owned by the service when a domain service needs Slack-backed data or files.
 - `slack/` modules must not import runtime orchestration modules.
@@ -155,7 +157,8 @@ The following boundaries are the canonical interfaces for the chat runtime. New 
 
 #### Runtime Composition Root
 
-- One composition root creates the concrete Slack chat app runtime for production.
+- One composition root creates the shared conversation runtime.
+- Source-specific composition roots wire Slack, local CLI, or another platform adapter into that shared runtime.
 - Production singleton assembly belongs under `app/` rather than worker or runtime modules.
 - One thin test fixture may create local runtime instances for tests and evals.
 - Queue workers, ingress routers, and handlers must depend on a runtime instance or runtime factory, not import the production singleton.
@@ -164,29 +167,44 @@ Target role:
 
 ```ts
 interface ChatRuntimeFactory {
-  create(options?: RuntimeOverrides): ChatTurnRuntime;
+  create(options?: RuntimeOverrides): ConversationRuntime;
+}
+```
+
+#### Platform Adapter Boundary
+
+- A platform adapter owns source-specific normalization and destination delivery only.
+- Slack adapters own Slack-only concerns: signature verification, Slack ID parsing, mention stripping, subscribed-thread routing input, assistant lifecycle events, Slack profile lookup, Slack status, Slack files, Slack reactions, and Slack markdown/output formatting.
+- Local CLI adapters own terminal input/output, local conversation selection, and optional local state configuration.
+- Platform adapters must not call the Pi agent directly. They hand normalized input to the shared conversation runtime or append mailbox work for the shared worker.
+- Platform adapters must not fabricate Slack-shaped requesters, destinations, or thread ids for non-Slack sources.
+
+Target role:
+
+```ts
+interface ConversationPlatformAdapter<RawInput> {
+  normalize(input: RawInput): Promise<NormalizedInboundMessage>;
+  deliver(result: ConversationDeliveryResult): Promise<void>;
 }
 ```
 
 #### Runtime Boundary
 
-- The runtime owns message-handling orchestration for mentions, subscribed-thread messages, and assistant lifecycle events.
-- It may depend on services, state stores, and observability, but must not depend on ingress transport or queue clients.
+- The shared runtime owns normalized message execution, conversation state preparation, Pi execution, safe-boundary continuation, and final result planning.
+- It may depend on services, state stores, destination delivery ports, and observability, but must not depend on source HTTP transports or queue clients.
+- Slack-specific runtime code may remain as a transitional adapter while the shared runtime is extracted, but new non-Slack behavior must not extend Slack runtime interfaces.
 
 Target role:
 
 ```ts
-interface ChatTurnRuntime {
-  handleMention(thread, message, hooks?): Promise<void>;
-  handleSubscribedMessage(thread, message, hooks?): Promise<void>;
-  handleAssistantThreadStarted(event): Promise<void>;
-  handleAssistantContextChanged(event): Promise<void>;
+interface ConversationRuntime {
+  handleMessage(input: NormalizedInboundMessage, hooks?): Promise<void>;
 }
 ```
 
 #### Ingress Router
 
-- Ingress owns event parsing, dedupe, thread-kind classification, mailbox append, and queue handoff.
+- Ingress owns source request verification, event parsing, source-specific classification, mailbox append, and queue handoff.
 - Chat SDK must not own canonical ingress queueing, conversation locks, or long-running handler lifetime.
 - Ingress must not become a second authority for agent-run behavior that already belongs in runtime.
 - Canonical ingress code lives under `chat/ingress/*`. Do not reintroduce legacy patch modules for core ingress behavior.
@@ -260,16 +278,16 @@ interface EvalScenarioRunner {
 ### Agent Run Continuation Recovery
 
 Agent run continuation recovery covers any case where Junior has a durable safe
-resume boundary but does not know whether the active run reached final Slack
-delivery: serverless timeout, lost or duplicate queue nudge, worker death,
-transport retry, or user follow-up while the conversation is active.
+resume boundary but does not know whether the active run reached final
+destination delivery: serverless timeout, lost or duplicate queue nudge, worker
+death, transport retry, or user follow-up while the conversation is active.
 
 Rules:
 
 1. Recovery continues the existing conversation from durable thread state plus the reduced agent-session log keyed by the predictable conversation id. It must not start a second active run for the same conversation.
-2. Conversation mailbox state, queue wake-ups, and leases protect inbound delivery. They do not replace session continuation because they do not carry Junior's canonical agent session log, sandbox/artifact state, pending auth, or final Slack delivery state.
+2. Conversation mailbox state, queue wake-ups, and leases protect inbound delivery. They do not replace session continuation because they do not carry Junior's canonical agent session log, sandbox/artifact state, pending auth, or final destination delivery state.
 3. `respond.ts` appends safe session-log boundaries; the mailbox worker enqueues cooperative continuations; heartbeat re-enqueues expired leases and stranded pending mailbox work.
-4. Routine cooperative continuation does not create a Slack acknowledgement message. Assistant status and `reportProgress` own progress UX.
+4. Routine cooperative continuation does not create a platform acknowledgement message. Assistant status and `reportProgress` own progress UX.
 5. Queue duplicate and active-lease cases are harmless because queue messages are conversation wake-up nudges, not canonical work records.
 
 ### Test And Eval Rules
@@ -291,7 +309,8 @@ Rules:
 
 Current names that should be treated as transitional:
 
-- None in the core runtime path. New runtime naming should follow the `slackRuntime` / `createSlackRuntime` / `SubscribedReplyDecision` / `AssistantLifecycleEvent` vocabulary now in the tree.
+- `slackRuntime` / `createSlackRuntime` are Slack adapter names, not names for the shared conversation runtime.
+- New shared runtime naming should use `conversation`, `platform`, `source`, `destination`, `delivery`, and `adapter` vocabulary rather than Slack-specific nouns.
 
 ## Failure Model
 
@@ -316,6 +335,7 @@ Current names that should be treated as transitional:
 ## Related Specs
 
 - `./task-execution.md`
+- `./local-agent.md`
 - `./agent-session-resumability.md`
 - `./oauth-flows.md`
 - `./plugin.md`

--- a/specs/chat-architecture.md
+++ b/specs/chat-architecture.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-03-21
-- Last Edited: 2026-06-10
+- Last Edited: 2026-06-11
 
 ## Purpose
 
@@ -40,7 +40,7 @@ the primary architecture by themselves.
 
 ```mermaid
 flowchart TD
-  A[Platform event or local CLI input] --> B[Platform adapter normalization and classification]
+  A[Platform event] --> B[Platform adapter normalization and classification]
   B --> C[Append to durable conversation mailbox]
   C --> D[Send Vercel Queue nudge: conversationId + Destination]
   D --> E[Queue worker acquires conversation lease]
@@ -49,6 +49,8 @@ flowchart TD
   E --> E3[Append drained input and attachment metadata to session log]
   E --> F[runtime/reply-executor]
   F --> G[Restore Pi state from reduced session log]
+  LA[Local CLI input] --> LB[Direct local runner: persist local turn and load state]
+  LB --> G
   G --> J[respond.ts generateAssistantReply / continue]
   J --> K[Build prompt context from durable conversation, config, artifacts, sandbox, attachments]
   K --> L[Pi agent continue loop]
@@ -77,16 +79,17 @@ flowchart TD
 
 Normative rules:
 
-1. Platform adapters parse and classify source events, append them to the durable mailbox, and send a queue nudge. They must not decide agent behavior beyond source-specific routing such as Slack mention/subscribed classification.
+1. Mailbox-backed platform adapters parse and classify source events, append them to the durable mailbox, and send a queue nudge. They must not decide agent behavior beyond source-specific routing such as Slack mention/subscribed classification.
 2. The task execution layer owns queue wake-ups, conversation leases, worker check-ins, and heartbeat recovery. Chat SDK queue/lock semantics are not canonical.
-3. The mailbox worker is the only point that drains inbound messages into persisted agent session context.
-4. `respond.ts` is the only owner of Pi agent execution, prompt/continue selection, timeout detection, and safe-boundary session-log event creation.
-5. Tool calls and tool failures are internal agent-loop data until the assistant produces final run diagnostics. Tool execution errors must be captured, but they are not automatically terminal user replies. Model-repairable failures must use the tool-error semantics from [Agent Execution Discipline Spec](./agent-execution.md).
-6. User-visible assistant text is posted only after the reply is finalized and planned for destination delivery.
-7. Final run success is defined by the destination delivery port accepting the visible final reply, not by model generation completing. Slack acceptance is one destination implementation.
-8. Agent recovery is session continuation: reload durable thread state plus the reduced session log, then continue the same session. It must not create a second active run or re-run from transient process memory.
-9. Cooperative yield at safe agent-loop boundaries is the normal accommodation for Vercel execution limits. Platform death is recovered by queue redelivery and heartbeat repair from the latest durable session boundary.
-10. Assistant status and logs are observability/UX surfaces. They never substitute for persisted session recovery or final reply delivery.
+3. The first-pass local CLI adapter uses the direct local runner from [Local Agent Spec](./local-agent.md). It must not claim mailbox-backed local source semantics until a local mailbox ingress contract exists.
+4. The mailbox worker is the only point that drains inbound messages into persisted agent session context for mailbox-backed paths.
+5. `respond.ts` is the only owner of Pi agent execution, prompt/continue selection, timeout detection, and safe-boundary session-log event creation.
+6. Tool calls and tool failures are internal agent-loop data until the assistant produces final run diagnostics. Tool execution errors must be captured, but they are not automatically terminal user replies. Model-repairable failures must use the tool-error semantics from [Agent Execution Discipline Spec](./agent-execution.md).
+7. User-visible assistant text is posted only after the reply is finalized and planned for destination delivery.
+8. Final run success is defined by the destination delivery port accepting the visible final reply, not by model generation completing. Slack acceptance is one destination implementation.
+9. Agent recovery is session continuation: reload durable thread state plus the reduced session log, then continue the same session. It must not create a second active run or re-run from transient process memory.
+10. Cooperative yield at safe agent-loop boundaries is the normal accommodation for Vercel execution limits. Platform death is recovered by queue redelivery and heartbeat repair from the latest durable session boundary.
+11. Assistant status and logs are observability/UX surfaces. They never substitute for persisted session recovery or final reply delivery.
 
 Data authority by stage:
 
@@ -97,7 +100,7 @@ Data authority by stage:
 | Conversation API/index rows             | Conversation record + `conversation:by-activity` index | Source for dashboard/API conversation lists; do not rebuild the primary list by grouping agent-run rows.                           |
 | Active execution discovery              | `conversation:active` index + conversation record      | Heartbeat discovers stale active conversations here, then uses the record to decide whether to enqueue a nudge.                    |
 | Conversation transcript                 | Persisted thread state                                 | Source for visible user/assistant thread history; assistant messages are added only after final destination delivery.              |
-| Active work routing                     | Conversation mailbox and lease                         | Pending messages are drained into the active conversation at safe boundaries.                                                      |
+| Active work routing                     | Conversation mailbox and lease                         | Pending messages are drained into the active conversation at safe boundaries for mailbox-backed paths.                             |
 | Pi execution transcript                 | Junior agent session log keyed by conversation id      | Append-only model-execution log with a deterministic Pi-message projection; not a replacement for visible conversation transcript. |
 | Sandbox/artifact state                  | Persisted thread state                                 | Persist eagerly as it changes so a resumed slice can rebuild the same runtime world.                                               |
 | Pending auth                            | Auth-owned callback state plus session-log pause event | Auth pauses end the live run after private link delivery and are resumed by callback.                                              |

--- a/specs/harness-tool-context.md
+++ b/specs/harness-tool-context.md
@@ -32,7 +32,7 @@ For context-bound side-effect tools, target selection is owned by the harness/ru
 
 Examples:
 
-- First-class Slack delivery tools (channel post, canvas create, list messages, and thread reads) resolve their target channel from `ToolRuntimeContext.deliveryChannelId` when present, otherwise the raw Slack channel in `ToolRuntimeContext.destination.channelId`. Slack message reactions use the raw destination channel because they target the current inbound Slack message.
+- First-class Slack delivery tools (channel post, canvas create, list messages, and thread reads) resolve their target channel from `ToolRuntimeContext.slack.deliveryChannelId` when present, otherwise the raw Slack channel in `ToolRuntimeContext.destination.channelId`. Slack message reactions use the raw destination channel because they target the current inbound Slack message.
 - Plugin tools receive `ToolRegistrationHookContext.destination` as Junior's shared `Destination` contract for provider-neutral side effects. When `destination.platform === "slack"`, plugins also receive Slack-specific context at `ToolRegistrationHookContext.slack`, including `slack.channelId` and `slack.channelCapabilities`. Local hook contexts must not include `slack`.
 - List follow-up operations resolve target artifacts from harness-managed artifact state (`lastListId`, turn-created IDs).
 - Slack Canvas document operations use explicit file-like handles (`canvas`). Canvas IDs and URLs may be attempted directly; Slack file permissions and Canvas metadata decide whether the operation can proceed.
@@ -47,7 +47,7 @@ Examples:
 
 ## Slack-Specific Targeting Rules
 
-1. Channel-scoped Slack delivery tools use `ToolRuntimeContext.deliveryChannelId ?? ToolRuntimeContext.destination.channelId` as the delivery target. The model cannot override this.
+1. Channel-scoped Slack delivery tools use `ToolRuntimeContext.slack.deliveryChannelId ?? ToolRuntimeContext.destination.channelId` as the delivery target. The model cannot override this.
 2. Canvas creation uses the active Slack delivery context (`C*`/`G*`/`D*`) without model-provided destination overrides.
 3. Canvas read/edit/write tools are document tools: `canvas` is analogous to a file path, accepts a Slack canvas/file ID or URL, and must not expose Slack section IDs or section lookup criteria.
 4. Canvas edit uses exact markdown replacements against the current body; Canvas write is explicit full-document replacement. Slack section-scoped mutation APIs are implementation details, not model-facing contracts.

--- a/specs/harness-tool-context.md
+++ b/specs/harness-tool-context.md
@@ -17,7 +17,7 @@ Define how tool execution context is sourced and enforced so model outputs canno
 ## Scope
 
 - Context-bound Slack channel/list targeting and Canvas creation targeting.
-- Runtime-owned destination resolution rules.
+- Runtime-owned source and outbound destination resolution rules.
 - Failure behavior for missing or invalid context.
 - File-like Slack Canvas document handle semantics.
 
@@ -28,12 +28,12 @@ Define how tool execution context is sourced and enforced so model outputs canno
 
 ## Core Rule
 
-For context-bound side-effect tools, target selection is owned by the harness/runtime, not by model-provided tool arguments.
+For context-bound side-effect tools, target selection is owned by the harness/runtime, not by model-provided tool arguments. `source` is the inbound invocation context. `destination` is the default outbound target and is present only for tools or plugin hooks that have an outbound side-effect target.
 
 Examples:
 
-- First-class Slack delivery tools (channel post, canvas create, list messages, and thread reads) resolve their target channel from `ToolRuntimeContext.slack.deliveryChannelId` when present, otherwise the raw Slack channel in `ToolRuntimeContext.destination.channelId`. Slack message reactions use the raw destination channel because they target the current inbound Slack message.
-- Plugin tools receive `ToolRegistrationHookContext.destination` as Junior's shared `Destination` contract for provider-neutral side effects. When `destination.platform === "slack"`, plugins also receive Slack-specific context at `ToolRegistrationHookContext.slack`, including `slack.channelId` and `slack.channelCapabilities`. Local hook contexts must not include `slack`.
+- First-class Slack delivery tools (channel post, canvas create, list messages, and private thread-read context) resolve their target channel from `ToolRuntimeContext.destination.channelId`. Slack message reactions use `ToolRuntimeContext.source.channelId` and `ToolRuntimeContext.source.messageTs` because they target the current inbound Slack message.
+- Plugin tools receive `ToolRegistrationHookContext.source` as Junior's shared inbound context. When an outbound target exists, plugins also receive `ToolRegistrationHookContext.destination`. When `source.platform === "slack"`, plugins receive Slack-specific helper context at `ToolRegistrationHookContext.slack`, including source-channel capabilities and any source-bound credential subject. Local hook contexts must not include `slack`.
 - List follow-up operations resolve target artifacts from harness-managed artifact state (`lastListId`, turn-created IDs).
 - Slack Canvas document operations use explicit file-like handles (`canvas`). Canvas IDs and URLs may be attempted directly; Slack file permissions and Canvas metadata decide whether the operation can proceed.
 
@@ -47,12 +47,13 @@ Examples:
 
 ## Slack-Specific Targeting Rules
 
-1. Channel-scoped Slack delivery tools use `ToolRuntimeContext.slack.deliveryChannelId ?? ToolRuntimeContext.destination.channelId` as the delivery target. The model cannot override this.
-2. Canvas creation uses the active Slack delivery context (`C*`/`G*`/`D*`) without model-provided destination overrides.
-3. Canvas read/edit/write tools are document tools: `canvas` is analogous to a file path, accepts a Slack canvas/file ID or URL, and must not expose Slack section IDs or section lookup criteria.
-4. Canvas edit uses exact markdown replacements against the current body; Canvas write is explicit full-document replacement. Slack section-scoped mutation APIs are implementation details, not model-facing contracts.
-5. List update/read tools use artifact state context, not model-chosen IDs.
-6. `slackListAddItems`, `slackListGetItems`, and `slackListUpdateItem` must not accept `list_id` input; target list resolution is harness-owned via artifact state.
+1. Channel-scoped Slack delivery tools use `ToolRuntimeContext.destination.channelId` as the outbound target. The model cannot override this. If no destination is present, outbound tools must not register or must fail with an actionable tool input error.
+2. Slack reactions use `ToolRuntimeContext.source.channelId` and `ToolRuntimeContext.source.messageTs`.
+3. Canvas creation uses the active Slack outbound destination (`C*`/`G*`/`D*`) without model-provided destination overrides.
+4. Canvas read/edit/write tools are document tools: `canvas` is analogous to a file path, accepts a Slack canvas/file ID or URL, and must not expose Slack section IDs or section lookup criteria.
+5. Canvas edit uses exact markdown replacements against the current body; Canvas write is explicit full-document replacement. Slack section-scoped mutation APIs are implementation details, not model-facing contracts.
+6. List update/read tools use artifact state context, not model-chosen IDs.
+7. `slackListAddItems`, `slackListGetItems`, and `slackListUpdateItem` must not accept `list_id` input; target list resolution is harness-owned via artifact state.
 
 ## Error Behavior
 

--- a/specs/harness-tool-context.md
+++ b/specs/harness-tool-context.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-03-03
-- Last Edited: 2026-06-06
+- Last Edited: 2026-06-11
 
 ## Related Specs
 
@@ -32,8 +32,8 @@ For context-bound side-effect tools, target selection is owned by the harness/ru
 
 Examples:
 
-- First-class Slack delivery tools (channel post, canvas create, list messages, and thread reads) resolve their target channel from `ToolRuntimeContext.deliveryChannelId` when present, otherwise `ToolRuntimeContext.channelId`. Slack message reactions use raw `channelId` because they target the current inbound Slack message.
-- Plugin tools receive `ToolRegistrationHookContext.channelId` for Slack-specific behavior and `ToolRegistrationHookContext.destination` as Junior's shared `Destination` contract for provider-neutral side effects. Scheduler tools consume `destination`, not loose Slack channel/team fields.
+- First-class Slack delivery tools (channel post, canvas create, list messages, and thread reads) resolve their target channel from `ToolRuntimeContext.deliveryChannelId` when present, otherwise the raw Slack channel in `ToolRuntimeContext.destination.channelId`. Slack message reactions use the raw destination channel because they target the current inbound Slack message.
+- Plugin tools receive `ToolRegistrationHookContext.destination` as Junior's shared `Destination` contract for provider-neutral side effects. When `destination.platform === "slack"`, plugins also receive Slack-specific context at `ToolRegistrationHookContext.slack`, including `slack.channelId` and `slack.channelCapabilities`. Local hook contexts must not include `slack`.
 - List follow-up operations resolve target artifacts from harness-managed artifact state (`lastListId`, turn-created IDs).
 - Slack Canvas document operations use explicit file-like handles (`canvas`). Canvas IDs and URLs may be attempted directly; Slack file permissions and Canvas metadata decide whether the operation can proceed.
 
@@ -47,7 +47,7 @@ Examples:
 
 ## Slack-Specific Targeting Rules
 
-1. Channel-scoped Slack delivery tools use `ToolRuntimeContext.deliveryChannelId ?? ToolRuntimeContext.channelId` as the delivery target. The model cannot override this.
+1. Channel-scoped Slack delivery tools use `ToolRuntimeContext.deliveryChannelId ?? ToolRuntimeContext.destination.channelId` as the delivery target. The model cannot override this.
 2. Canvas creation uses the active Slack delivery context (`C*`/`G*`/`D*`) without model-provided destination overrides.
 3. Canvas read/edit/write tools are document tools: `canvas` is analogous to a file path, accepts a Slack canvas/file ID or URL, and must not expose Slack section IDs or section lookup criteria.
 4. Canvas edit uses exact markdown replacements against the current body; Canvas write is explicit full-document replacement. Slack section-scoped mutation APIs are implementation details, not model-facing contracts.

--- a/specs/identity.md
+++ b/specs/identity.md
@@ -129,10 +129,10 @@ resuming.
 
 Canonical stored Slack requesters include `platform: "slack"`, `teamId`,
 `slackUserId`, and optional display/contact fields. Continuation endpoints MUST
-assert stored `teamId` and `slackUserId` against the active destination and
+assert stored `teamId` and `slackUserId` against the active source and
 turn author when those fields are present. Legacy stored requesters without
 `teamId` may reuse display/contact fields only after the stored `slackUserId`
-matches the turn author; the runtime requester still uses the active destination
+matches the turn author; the runtime requester still uses the active source
 team id.
 
 Continuation endpoints MUST NOT call live Slack requester helpers such as

--- a/specs/identity.md
+++ b/specs/identity.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-06-05
-- Last Edited: 2026-06-06
+- Last Edited: 2026-06-10
 
 ## Purpose
 
@@ -15,7 +15,7 @@ Define how Junior carries human, system, delegated, destination, and display ide
 - Service-principal and install-owned credential identities.
 - Slack message authors, requesters, task creators, and conversation managers.
 - Delegated credential subjects for stored user OAuth lookup.
-- Destination identity for Slack conversations, dispatch records, sandbox sessions, and context-bound tools.
+- Destination identity for platform conversations, dispatch records, sandbox sessions, and context-bound tools.
 - Identity context carried through ingress, queue work, callbacks, dispatch records, scheduler tasks, sandbox egress, and conversation state.
 
 ## Non-Goals
@@ -43,7 +43,7 @@ Define how Junior carries human, system, delegated, destination, and display ide
 
 ### Identity Context
 
-Every behavior that can read credentials, perform side effects, send Slack output, run tools, dispatch work, or mutate durable state must have explicit identity context.
+Every behavior that can read credentials, perform side effects, send platform output, run tools, dispatch work, or mutate durable state must have explicit identity context.
 
 The current actor must be a real user actor or a named system actor. Synthetic ids such as `unknown`, empty strings, whitespace-padded ids, previous message authors, task creators, Slack display names, and destination membership are not valid substitutes for actor context.
 
@@ -52,6 +52,7 @@ The current actor must be a real user actor or a named system actor. Synthetic i
 Untrusted external data is parsed once at the boundary that receives it:
 
 - Slack ingress and Slack adapter payloads parse Slack user ids before creating internal work.
+- Local CLI parses local session ids and actor configuration before creating internal work.
 - Plugin APIs parse plugin-provided credential subjects before binding or persisting them.
 - Signed callback and sandbox egress contexts verify signatures and parse actor payloads before issuing credentials.
 
@@ -94,6 +95,24 @@ Scheduled runs execute as a Junior system actor, not as the user who created the
 Plugin dispatch also executes as a system actor unless a future spec defines a different actor model. Plugin metadata and idempotency keys are correlation data, not actor sources.
 
 Scheduled tasks and plugin dispatches may carry an explicit delegated user credential subject only under the Slack private direct conversation exception defined by the scheduler and dispatch specs. That subject is not the actor.
+
+### Local CLI
+
+Local CLI runs must use explicit local identity context and must not fabricate
+Slack identity state.
+
+First implementation rules:
+
+1. Local CLI runs execute as the named Junior system actor `local-cli`.
+2. Local CLI runs do not have a Slack requester unless they are replaying a
+   verified Slack-originated continuation, which ordinary local chat does not do.
+3. Local CLI destination identity uses a local conversation/session id, not a
+   Slack channel id or Slack thread timestamp.
+4. Local CLI must disable interactive OAuth and Slack private auth flows until a
+   separate local user/auth contract exists.
+5. If a future local mode needs user-bound credentials, it must introduce an
+   explicit non-Slack user actor and credential-subject contract instead of
+   reusing Slack requester fields.
 
 ### Turn Continuation Requester Identity
 
@@ -189,6 +208,7 @@ Use evals only when the contract depends on model interpretation, such as preser
 
 - `./chat-architecture.md`
 - `./task-execution.md`
+- `./local-agent.md`
 - `./agent-turn-handling.md`
 - `./slack-agent-delivery.md`
 - `./slack-outbound-contract.md`

--- a/specs/index.md
+++ b/specs/index.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-03-03
-- Last Edited: 2026-06-05
+- Last Edited: 2026-06-10
 
 ## Purpose
 
@@ -32,6 +32,7 @@ Define spec taxonomy, naming conventions, and canonical source-of-truth document
 - `specs/data-redaction-policy.md`
 - `specs/chat-architecture.md`
 - `specs/task-execution.md`
+- `specs/local-agent.md`
 - `specs/agent-turn-handling.md`
 - `specs/slack-agent-delivery.md`
 - `specs/slack-outbound-contract.md`
@@ -68,8 +69,9 @@ Define spec taxonomy, naming conventions, and canonical source-of-truth document
 
 For chat/agent/Slack turn behavior:
 
-- `specs/chat-architecture.md` owns the end-to-end turn data flow, data authority map, and module boundaries.
+- `specs/chat-architecture.md` owns the end-to-end platform-event-to-agent-run data flow, platform adapter boundary, data authority map, and module boundaries.
 - `specs/task-execution.md` owns durable conversation mailbox execution, queue wake-up semantics, conversation leases, cooperative yield, and heartbeat repair.
+- `specs/local-agent.md` owns local CLI/local adapter user flows, identity, state, delivery, and verification contracts.
 - `specs/agent-turn-handling.md` owns user-message response policy: when Junior answers, stays silent, asks, uses tools, satisfies Slack side effects, handles resumed turns, and considers a turn complete.
 - `specs/agent-execution.md` owns coding-agent execution discipline and the repository-wide model-repairable tool failure contract.
 - `specs/harness-agent.md` owns the Pi agent turn runtime contract, final output resolution, and turn diagnostics.

--- a/specs/local-agent.md
+++ b/specs/local-agent.md
@@ -176,8 +176,9 @@ Rules:
 
 1. Users may ask the agent to inspect files by path in the message text.
 2. The local adapter must not synthesize Slack file attachments.
-3. Generated files returned by the agent should be reported with filenames and
-   paths in the terminal output.
+3. Generated files returned by the agent fail delivery in the first local
+   adapter. The runner must not commit assistant state for a reply whose files
+   were not delivered.
 4. A later attachment UX must add explicit local attachment parsing and update
    this spec before implementation.
 

--- a/specs/local-agent.md
+++ b/specs/local-agent.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-06-10
-- Last Edited: 2026-06-10
+- Last Edited: 2026-06-11
 
 ## Purpose
 
@@ -98,19 +98,24 @@ Rules:
 
 ### Source And Destination
 
-Local chat is a first-class source and destination.
+Local chat is a first-class local destination. The first CLI implementation runs
+through a direct local runner rather than the queued inbound-message mailbox.
 
 Rules:
 
-1. Local user input uses `source: "local"`.
+1. Local CLI user input is recorded as a local user turn in the selected local
+   conversation.
 2. Local delivery uses `destination.platform: "local"`.
-3. Local inbound messages use stable idempotency ids scoped to the local
-   conversation id and local prompt sequence.
-4. Local inbound metadata may include CLI command mode and local prompt
+3. Local turn ids are stable within the selected conversation and scoped to the
+   local prompt sequence.
+4. If a later local or non-Slack platform enters through the durable
+   inbound-message mailbox, it must use `source: "local"` or its own
+   platform-specific source and stable idempotency ids scoped to that platform.
+5. Local inbound metadata may include CLI command mode and local prompt
    sequence. It must not include raw terminal control sequences.
-5. Local delivery accepts the finalized reply when stdout/stderr writes have
+6. Local delivery accepts the finalized reply when stdout/stderr writes have
    completed or when the line-oriented output sink confirms delivery.
-6. Local delivery failure is a terminal delivery failure for the local turn.
+7. Local delivery failure is a terminal delivery failure for the local turn.
 
 ### Identity And Credentials
 
@@ -244,8 +249,8 @@ Required checks:
 2. Unit: CLI argument parsing accepts the supported command forms and rejects
    unsupported forms without side effects.
 3. Integration: `junior chat --once "hello"` reaches the shared conversation
-   runtime with `source: "local"`, `destination.platform: "local"`, actor
-   `local-cli`, and no Slack requester.
+   runtime with `destination.platform: "local"`, actor `local-cli`, and no
+   Slack requester.
 4. Integration: local CLI does not construct Slack `Thread`, Slack `Message`, or
    Slack adapter wrappers.
 5. Integration: two messages in the same local conversation preserve visible

--- a/specs/local-agent.md
+++ b/specs/local-agent.md
@@ -69,7 +69,8 @@ Rules:
 1. The prompt reads one user message at a time from stdin.
 2. Empty input is ignored.
 3. `/exit` and `/quit` end the loop without creating an inbound message.
-4. Each non-empty user message is sent to the same selected local conversation.
+4. Each non-empty user message is sent to the same process-scoped local
+   conversation.
 5. The assistant reply may stream to stdout as deltas arrive.
 6. The finalized assistant reply is the delivered output recorded in
    conversation state.
@@ -228,8 +229,7 @@ Required attributes when available:
 - `app.conversation.id`
 - `app.conversation.source` = `local`
 - `app.destination.platform` = `local`
-- `app.local.conversation_alias`
-- `app.local.command_mode` = `interactive|once`
+- `app.local.command_mode` = `interactive|prompt`
 - `app.actor.type` = `system`
 - `app.actor.id` = `local-cli`
 - `gen_ai.request.model`
@@ -244,8 +244,8 @@ Layer choice follows `./testing.md`.
 
 Required checks:
 
-1. Unit: local conversation aliases normalize to `local:<workspace_key>:<slug>`
-   and reject invalid names.
+1. Unit: local conversation ids normalize to `local:<workspace_key>:<slug>`
+   for generated run slugs.
 2. Unit: CLI argument parsing accepts the supported command forms and rejects
    unsupported forms without side effects.
 3. Integration: `junior chat -p "hello"` reaches the shared conversation
@@ -253,8 +253,9 @@ Required checks:
    Slack requester.
 4. Integration: local CLI does not construct Slack `Thread`, Slack `Message`, or
    Slack adapter wrappers.
-5. Integration: two messages in the same local conversation preserve visible
-   conversation context.
+5. Integration: two messages in the same interactive process preserve visible
+   conversation context, while separate CLI invocations start fresh local
+   conversations.
 6. Integration: missing user-bound auth produces a local error and does not
    start Slack OAuth or ephemeral-message delivery.
 7. Integration: invalid arguments print usage and exit non-zero without creating

--- a/specs/local-agent.md
+++ b/specs/local-agent.md
@@ -40,23 +40,23 @@ Supported first-pass forms:
 
 ```bash
 junior chat
-junior chat --once "explain this repository"
-junior chat --conversation demo
-junior chat --conversation demo --once "continue the previous answer"
+junior chat -p "explain this repository"
 ```
 
 Rules:
 
 1. `junior chat` starts an interactive terminal loop.
-2. `junior chat --once <message>` runs one local user message and exits after
+2. `junior chat -p <message>` runs one local user message and exits after
    final delivery.
-3. `--conversation <name>` selects a stable local conversation. If omitted, the
-   CLI uses `default`.
-4. Conversation names are user-facing aliases. They must be normalized into
-   storage-safe conversation ids before crossing into runtime state.
-5. The CLI must load env files through the same env loader as the existing
+3. Each CLI invocation creates a fresh local conversation, so repeated local
+   runs do not inherit prior local context.
+4. Interactive mode preserves multi-turn continuity only inside that running
+   process.
+5. The local conversation slug must be normalized into a storage-safe
+   conversation id before crossing into runtime state.
+6. The CLI must load env files through the same env loader as the existing
    command entrypoint before importing chat runtime modules.
-6. If no durable state adapter is configured for local chat, the command must
+7. If no durable state adapter is configured for local chat, the command must
    select the memory state adapter before importing chat runtime modules. It
    must not require `REDIS_URL` for first-pass local use.
 
@@ -76,22 +76,21 @@ Rules:
 7. Tool invocation progress and non-final status may be printed to stderr, but
    they are not persisted as assistant transcript messages.
 8. A failed turn must print an explicit error and keep the process exit code
-   non-zero for `--once`. Interactive mode may continue after a failed turn
+   non-zero for `-p`. Interactive mode may continue after a failed turn
    unless the failure is a local setup error.
 
 ### Conversation Identity
 
-Local conversation ids must be stable, storage-safe, and distinct from Slack
-thread ids.
+Local conversation ids must be storage-safe, stable for one CLI invocation, and
+distinct from Slack thread ids.
 
 Rules:
 
 1. Local conversation ids use the prefix `local:`.
 2. The normalized shape is `local:<workspace_key>:<conversation_slug>`.
-3. `workspace_key` is derived from the current working directory so separate
-   repositories do not share the same `default` conversation accidentally.
-4. `conversation_slug` is derived from `--conversation`; invalid or empty names
-   are rejected with CLI usage output.
+3. `workspace_key` is derived from the current working directory for local
+   observability and storage grouping.
+4. `conversation_slug` is generated per CLI invocation.
 5. Local conversation ids must never use Slack channel ids, thread timestamps,
    team ids, or message timestamps.
 6. Local conversation ids are the durable Pi/session history key.
@@ -158,20 +157,21 @@ Rules:
 ### Transcript And State
 
 Local chat must preserve conversation continuity across prompts in the same
-process and, when a durable adapter is configured, across processes.
+interactive process. New CLI invocations must start new conversations.
 
 Rules:
 
 1. User messages are appended to visible conversation state before the agent
    turn commits input.
 2. Assistant messages are appended only after final local delivery succeeds.
-3. Pi messages are restored from the durable agent session log or conversation
-   state using the same projection rules as other runtimes.
-4. Memory state is acceptable for first-pass local development. When memory
+3. Pi messages are restored within the run from the durable agent session log or
+   conversation state using the same projection rules as other runtimes.
+4. New CLI invocations do not restore prior visible or Pi conversation history.
+5. Memory state is acceptable for first-pass local development. When memory
    state is used, history is process-local and the CLI must not imply durable
    persistence.
-5. Redis-backed local state may persist history across CLI invocations when
-   configured through normal environment variables.
+6. Redis-backed local state may store local runs for diagnostics, but the CLI
+   must not automatically resume them.
 
 ### Attachments And Files
 
@@ -193,8 +193,8 @@ The local CLI should be predictable and scriptable.
 
 Rules:
 
-1. `--once` writes the assistant final answer to stdout.
-2. `--once` writes setup errors, status, and diagnostics to stderr.
+1. `-p` writes the assistant final answer to stdout.
+2. `-p` writes setup errors, status, and diagnostics to stderr.
 3. Interactive mode clearly separates user prompts from assistant output without
    requiring a full-screen terminal UI.
 4. The CLI must not print raw prompt context, raw provider credentials, raw OAuth
@@ -204,7 +204,7 @@ Rules:
 ## Failure Model
 
 1. Missing model credentials or provider configuration:
-   - Print an explicit setup error and exit non-zero for `--once`.
+   - Print an explicit setup error and exit non-zero for `-p`.
 2. Missing user-bound OAuth:
    - Print an explicit local authorization-unavailable error. Do not start Slack
      auth or local browser auth.
@@ -248,7 +248,7 @@ Required checks:
    and reject invalid names.
 2. Unit: CLI argument parsing accepts the supported command forms and rejects
    unsupported forms without side effects.
-3. Integration: `junior chat --once "hello"` reaches the shared conversation
+3. Integration: `junior chat -p "hello"` reaches the shared conversation
    runtime with `destination.platform: "local"`, actor `local-cli`, and no
    Slack requester.
 4. Integration: local CLI does not construct Slack `Thread`, Slack `Message`, or

--- a/specs/local-agent.md
+++ b/specs/local-agent.md
@@ -56,9 +56,9 @@ Rules:
    conversation id before crossing into runtime state.
 6. The CLI must load env files through the same env loader as the existing
    command entrypoint before importing chat runtime modules.
-7. If no durable state adapter is configured for local chat, the command must
-   select the memory state adapter before importing chat runtime modules. It
-   must not require `REDIS_URL` for first-pass local use.
+7. If no state adapter is explicitly configured for local chat, the command
+   must select the memory state adapter before importing chat runtime modules.
+   `REDIS_URL` alone must not move local chat onto Redis.
 
 ### Interactive Flow
 
@@ -98,24 +98,25 @@ Rules:
 
 ### Source And Destination
 
-Local chat is a first-class local destination. The first CLI implementation runs
+Local chat is a first-class local source. The first CLI implementation runs
 through a direct local runner rather than the queued inbound-message mailbox.
 
 Rules:
 
 1. Local CLI user input is recorded as a local user turn in the selected local
    conversation.
-2. Local delivery uses `destination.platform: "local"`.
-3. Local turn ids are stable within the selected conversation and scoped to the
+2. Local invocation context uses `source.platform: "local"`.
+3. Local delivery may use `destination.platform: "local"` only at outbound delivery boundaries.
+4. Local turn ids are stable within the selected conversation and scoped to the
    local prompt sequence.
-4. If a later local or non-Slack platform enters through the durable
+5. If a later local or non-Slack platform enters through the durable
    inbound-message mailbox, it must use `source: "local"` or its own
    platform-specific source and stable idempotency ids scoped to that platform.
-5. Local inbound metadata may include CLI command mode and local prompt
+6. Local inbound metadata may include CLI command mode and local prompt
    sequence. It must not include raw terminal control sequences.
-6. Local delivery accepts the finalized reply when stdout/stderr writes have
+7. Local delivery accepts the finalized reply when stdout/stderr writes have
    completed or when the line-oriented output sink confirms delivery.
-7. Local delivery failure is a terminal delivery failure for the local turn.
+8. Local delivery failure is a terminal delivery failure for the local turn.
 
 ### Identity And Credentials
 
@@ -230,7 +231,8 @@ Required attributes when available:
 
 - `app.conversation.id`
 - `app.conversation.source` = `local`
-- `app.destination.platform` = `local`
+- `app.source.platform` = `local`
+- `app.destination.platform` = `local` when recording delivery
 - `app.local.command_mode` = `interactive|prompt`
 - `app.actor.type` = `system`
 - `app.actor.id` = `local-cli`
@@ -251,7 +253,7 @@ Required checks:
 2. Unit: CLI argument parsing accepts the supported command forms and rejects
    unsupported forms without side effects.
 3. Integration: `junior chat -p "hello"` reaches the shared conversation
-   runtime with `destination.platform: "local"`, actor `local-cli`, and no
+   runtime with `source.platform: "local"`, actor `local-cli`, and no
    Slack requester.
 4. Integration: local CLI does not construct Slack `Thread`, Slack `Message`, or
    Slack adapter wrappers.

--- a/specs/local-agent.md
+++ b/specs/local-agent.md
@@ -119,20 +119,22 @@ Rules:
 
 ### Identity And Credentials
 
-Local chat does not have a Slack requester.
+Local chat has a local requester identity for runtime/plugin context, but it
+does not have a Slack requester or user-bound credential actor.
 
 Rules:
 
 1. Local chat runs as credential actor `{ type: "system", id: "local-cli" }`.
-2. Local chat must not populate Slack requester fields.
-3. Local chat must not use Slack private auth, Slack ephemeral messages, or Slack
+2. Local chat may populate requester `{ platform: "local", userId: "local-cli" }`.
+3. Local chat must not populate Slack requester fields.
+4. Local chat must not use Slack private auth, Slack ephemeral messages, or Slack
    OAuth continuation notices.
-4. Local chat runs with `authorizationFlowMode: "disabled"` until a local auth
+5. Local chat runs with `authorizationFlowMode: "disabled"` until a local auth
    flow is specified.
-5. Provider credentials available through service-principal, install-owned, or
+6. Provider credentials available through service-principal, install-owned, or
    environment-backed brokers may be used when their broker accepts the
    `local-cli` system actor.
-6. Missing user-bound provider credentials must fail with an explicit local
+7. Missing user-bound provider credentials must fail with an explicit local
    error. The runtime must not silently fall back to a Slack user, task creator,
    last requester, or `unknown` actor.
 

--- a/specs/local-agent.md
+++ b/specs/local-agent.md
@@ -1,0 +1,267 @@
+# Local Agent Spec
+
+## Metadata
+
+- Created: 2026-06-10
+- Last Edited: 2026-06-10
+
+## Purpose
+
+Define the first local, non-Slack way to run and interact with Junior. This spec
+turns local agent testing into a real platform adapter contract instead of a
+fake Slack harness.
+
+## Scope
+
+- Local CLI command shape and user flows.
+- Local source and destination identities.
+- Local conversation ids, state, transcript, and delivery behavior.
+- Local runtime wiring into the shared conversation runtime.
+- First-pass credential and authorization behavior.
+- Verification requirements before implementing or changing local agent
+  behavior.
+
+## Non-Goals
+
+- Replacing Slack ingress, Slack delivery, or Slack-specific side-effect tools.
+- Implementing Telegram, WhatsApp, Discord, or other network platforms.
+- Implementing local OAuth or browser-based authorization flows.
+- Supporting local file upload UX as platform attachments in the first pass.
+- Defining a terminal UI beyond line-oriented CLI interaction.
+- Exposing test-only knobs or fake-agent controls in the product CLI.
+
+## Contracts
+
+### Command Surface
+
+The first local command is `junior chat`.
+
+Supported first-pass forms:
+
+```bash
+junior chat
+junior chat --once "explain this repository"
+junior chat --conversation demo
+junior chat --conversation demo --once "continue the previous answer"
+```
+
+Rules:
+
+1. `junior chat` starts an interactive terminal loop.
+2. `junior chat --once <message>` runs one local user message and exits after
+   final delivery.
+3. `--conversation <name>` selects a stable local conversation. If omitted, the
+   CLI uses `default`.
+4. Conversation names are user-facing aliases. They must be normalized into
+   storage-safe conversation ids before crossing into runtime state.
+5. The CLI must load env files through the same env loader as the existing
+   command entrypoint before importing chat runtime modules.
+6. If no durable state adapter is configured for local chat, the command must
+   select the memory state adapter before importing chat runtime modules. It
+   must not require `REDIS_URL` for first-pass local use.
+
+### Interactive Flow
+
+Interactive local chat is a line-oriented loop.
+
+Rules:
+
+1. The prompt reads one user message at a time from stdin.
+2. Empty input is ignored.
+3. `/exit` and `/quit` end the loop without creating an inbound message.
+4. Each non-empty user message is sent to the same selected local conversation.
+5. The assistant reply may stream to stdout as deltas arrive.
+6. The finalized assistant reply is the delivered output recorded in
+   conversation state.
+7. Tool invocation progress and non-final status may be printed to stderr, but
+   they are not persisted as assistant transcript messages.
+8. A failed turn must print an explicit error and keep the process exit code
+   non-zero for `--once`. Interactive mode may continue after a failed turn
+   unless the failure is a local setup error.
+
+### Conversation Identity
+
+Local conversation ids must be stable, storage-safe, and distinct from Slack
+thread ids.
+
+Rules:
+
+1. Local conversation ids use the prefix `local:`.
+2. The normalized shape is `local:<workspace_key>:<conversation_slug>`.
+3. `workspace_key` is derived from the current working directory so separate
+   repositories do not share the same `default` conversation accidentally.
+4. `conversation_slug` is derived from `--conversation`; invalid or empty names
+   are rejected with CLI usage output.
+5. Local conversation ids must never use Slack channel ids, thread timestamps,
+   team ids, or message timestamps.
+6. Local conversation ids are the durable Pi/session history key.
+
+### Source And Destination
+
+Local chat is a first-class source and destination.
+
+Rules:
+
+1. Local user input uses `source: "local"`.
+2. Local delivery uses `destination.platform: "local"`.
+3. Local inbound messages use stable idempotency ids scoped to the local
+   conversation id and local prompt sequence.
+4. Local inbound metadata may include CLI command mode and local prompt
+   sequence. It must not include raw terminal control sequences.
+5. Local delivery accepts the finalized reply when stdout/stderr writes have
+   completed or when the line-oriented output sink confirms delivery.
+6. Local delivery failure is a terminal delivery failure for the local turn.
+
+### Identity And Credentials
+
+Local chat does not have a Slack requester.
+
+Rules:
+
+1. Local chat runs as credential actor `{ type: "system", id: "local-cli" }`.
+2. Local chat must not populate Slack requester fields.
+3. Local chat must not use Slack private auth, Slack ephemeral messages, or Slack
+   OAuth continuation notices.
+4. Local chat runs with `authorizationFlowMode: "disabled"` until a local auth
+   flow is specified.
+5. Provider credentials available through service-principal, install-owned, or
+   environment-backed brokers may be used when their broker accepts the
+   `local-cli` system actor.
+6. Missing user-bound provider credentials must fail with an explicit local
+   error. The runtime must not silently fall back to a Slack user, task creator,
+   last requester, or `unknown` actor.
+
+### Runtime Wiring
+
+Local chat must exercise the same agent path as other destinations.
+
+Rules:
+
+1. The CLI must call the shared conversation runtime or shared local runner
+   boundary. It must not call Slack runtime methods.
+2. The CLI must not construct Chat SDK `Thread`, `Message`, or Slack adapter
+   wrappers to reach `generateAssistantReply`.
+3. Runtime context must set `surface: "internal"` until a distinct `local`
+   surface is added across reporting and session schemas.
+4. Runtime correlation must include `conversationId`, `runId`, and a local
+   turn/message id. Slack-only correlation fields must be absent.
+5. Local progress callbacks may map assistant status to stderr and text deltas
+   to stdout.
+6. Local artifact and sandbox updates must persist through the same thread-state
+   stores used by the shared runtime.
+
+### Transcript And State
+
+Local chat must preserve conversation continuity across prompts in the same
+process and, when a durable adapter is configured, across processes.
+
+Rules:
+
+1. User messages are appended to visible conversation state before the agent
+   turn commits input.
+2. Assistant messages are appended only after final local delivery succeeds.
+3. Pi messages are restored from the durable agent session log or conversation
+   state using the same projection rules as other runtimes.
+4. Memory state is acceptable for first-pass local development. When memory
+   state is used, history is process-local and the CLI must not imply durable
+   persistence.
+5. Redis-backed local state may persist history across CLI invocations when
+   configured through normal environment variables.
+
+### Attachments And Files
+
+The first local adapter does not define a platform attachment UX.
+
+Rules:
+
+1. Users may ask the agent to inspect files by path in the message text.
+2. The local adapter must not synthesize Slack file attachments.
+3. Generated files returned by the agent should be reported with filenames and
+   paths in the terminal output.
+4. A later attachment UX must add explicit local attachment parsing and update
+   this spec before implementation.
+
+### User Experience
+
+The local CLI should be predictable and scriptable.
+
+Rules:
+
+1. `--once` writes the assistant final answer to stdout.
+2. `--once` writes setup errors, status, and diagnostics to stderr.
+3. Interactive mode clearly separates user prompts from assistant output without
+   requiring a full-screen terminal UI.
+4. The CLI must not print raw prompt context, raw provider credentials, raw OAuth
+   URLs, Slack tokens, or serialized private state.
+5. The CLI must provide concise usage output for invalid arguments.
+
+## Failure Model
+
+1. Missing model credentials or provider configuration:
+   - Print an explicit setup error and exit non-zero for `--once`.
+2. Missing user-bound OAuth:
+   - Print an explicit local authorization-unavailable error. Do not start Slack
+     auth or local browser auth.
+3. State adapter setup failure:
+   - Print the adapter error and exit non-zero before accepting user input.
+4. Agent/provider/tool failure:
+   - Deliver the existing agent failure reply when available; otherwise print a
+     local error and mark the turn failed.
+5. stdout/stderr write failure:
+   - Treat as delivery failure and exit non-zero.
+6. Unsupported CLI arguments:
+   - Print usage and exit non-zero without creating conversation state.
+
+## Observability
+
+Local chat should use existing logging/tracing conventions without creating a
+parallel diagnostics system.
+
+Required attributes when available:
+
+- `app.conversation.id`
+- `app.conversation.source` = `local`
+- `app.destination.platform` = `local`
+- `app.local.conversation_alias`
+- `app.local.command_mode` = `interactive|once`
+- `app.actor.type` = `system`
+- `app.actor.id` = `local-cli`
+- `gen_ai.request.model`
+- `gen_ai.provider.name`
+
+Logs and spans must not include raw terminal input beyond the repository's
+normal redacted message summaries.
+
+## Verification
+
+Layer choice follows `./testing.md`.
+
+Required checks:
+
+1. Unit: local conversation aliases normalize to `local:<workspace_key>:<slug>`
+   and reject invalid names.
+2. Unit: CLI argument parsing accepts the supported command forms and rejects
+   unsupported forms without side effects.
+3. Integration: `junior chat --once "hello"` reaches the shared conversation
+   runtime with `source: "local"`, `destination.platform: "local"`, actor
+   `local-cli`, and no Slack requester.
+4. Integration: local CLI does not construct Slack `Thread`, Slack `Message`, or
+   Slack adapter wrappers.
+5. Integration: two messages in the same local conversation preserve visible
+   conversation context.
+6. Integration: missing user-bound auth produces a local error and does not
+   start Slack OAuth or ephemeral-message delivery.
+7. Integration: invalid arguments print usage and exit non-zero without creating
+   conversation records.
+8. Typecheck and targeted tests must pass before enabling the CLI command in the
+   packaged binary.
+
+## Related Specs
+
+- `./chat-architecture.md`
+- `./task-execution.md`
+- `./identity.md`
+- `./credential-injection.md`
+- `./harness-agent.md`
+- `./agent-session-resumability.md`
+- `./testing.md`

--- a/specs/plugin-dispatch.md
+++ b/specs/plugin-dispatch.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-05-28
-- Last Edited: 2026-06-08
+- Last Edited: 2026-06-11
 
 ## Purpose
 
@@ -48,7 +48,7 @@ type DispatchOptions = {
     userId: string;
     allowedWhen: "private-direct-conversation";
   };
-  destination: Destination;
+  destination: SlackDestination;
   input: string;
   metadata?: Record<string, string>;
 };

--- a/specs/plugin-dispatch.md
+++ b/specs/plugin-dispatch.md
@@ -94,7 +94,7 @@ type Dispatch = {
 - Same plugin + idempotency key must not create two dispatch records.
 - Dispatch options must not include unknown top-level fields.
 - `destination.platform` must be `"slack"`.
-- Destination must match the strict shared `Destination` schema exactly and must not include unknown fields.
+- Destination must match the strict shared Slack destination schema exactly and must not include unknown fields.
 - Destination must be a Slack public channel, private channel, or existing DM channel the bot can post to.
 - Destination must not be an existing Slack thread.
 - Destination uses a Slack channel id; it must not accept a user id.

--- a/specs/plugin-heartbeat.md
+++ b/specs/plugin-heartbeat.md
@@ -60,12 +60,12 @@ interface AgentPluginHooks {
 
 `ToolRegistrationContext` exposes only current turn context needed to decide whether tools are available:
 
-- active conversation destination, when present
+- active source context
+- default outbound destination, when present
 - requester, when present
-- `channelId`: raw Slack conversation channel (`C/D/G`), never assistant-context overridden
 - `conversationId`: opaque Junior session identity (e.g. `slack:{channelId}:{threadTs}` for interactive turns)
-- `destination`: runtime-owned shared `Destination` for future autonomous work; Slack destinations carry raw `teamId` and `channelId`
-- `teamId` and thread/message timestamps, when present
+- `source`: runtime-owned shared `Source`; Slack sources carry raw `teamId`, `channelId`, and optional thread/message timestamps
+- `destination`: runtime-owned shared outbound `Destination`, when an outbound target is available
 - namespaced plugin state
 - current user text
 - schedule-tool suppression for system dispatches

--- a/specs/scheduler.md
+++ b/specs/scheduler.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-05-18
-- Last Edited: 2026-06-08
+- Last Edited: 2026-06-11
 
 ## Purpose
 
@@ -47,8 +47,8 @@ The stored task must include:
 
 The original user utterance may be retained for audit/debugging, but it must not be the sole execution input.
 
-Scheduled task destinations use Junior's shared `Destination` contract, not existing threads. For Slack, a scheduled task targets the raw Slack conversation channel in `ToolRegistrationHookContext.destination` — the DM or channel where the user is interacting with Junior — not the assistant-context source channel, current message timestamp, or thread timestamp. Scheduled output posts as a new message in that destination.
-The scheduler must parse active and stored destinations with the strict shared `Destination` schema from `@sentry/junior-plugin-api`. Unknown destination fields, missing required destination fields, legacy thread-shaped ids, and non-Slack team/channel ids are invalid rather than normalized during scheduler tool execution or store reads.
+Scheduled task destinations use Junior's strict shared Slack destination contract, not existing threads. A scheduled task targets the raw Slack conversation channel in `ToolRegistrationHookContext.destination` — the DM or channel where the user is interacting with Junior — not the assistant-context source channel, current message timestamp, or thread timestamp. Scheduled output posts as a new message in that destination.
+The scheduler must parse active and stored destinations with the strict shared Slack destination schema from `@sentry/junior-plugin-api`. Unknown destination fields, missing required destination fields, legacy thread-shaped ids, and non-Slack team/channel ids are invalid rather than normalized during scheduler tool execution or store reads.
 When the scheduler stores an explicit delegated credential subject, it must parse that subject with the strict shared plugin credential-subject schema. Runtime-owned bindings or signatures must never be stored in scheduler task state.
 Each scheduled execution gets fresh dispatch-scoped conversation state. The runner must not load destination-level Slack conversation history as prior thread context for a scheduled run that is creating its own new message.
 

--- a/specs/scheduler.md
+++ b/specs/scheduler.md
@@ -38,7 +38,8 @@ The stored task must include:
 - execution actor metadata
 - conversation access metadata
 - optional credential subject for private direct conversations
-- destination surface
+- source conversation
+- destination surface for scheduled delivery
 - schedule and timezone
 - current status
 - next-run timestamp when active
@@ -47,7 +48,7 @@ The stored task must include:
 
 The original user utterance may be retained for audit/debugging, but it must not be the sole execution input.
 
-Scheduled task destinations use Junior's strict shared Slack destination contract, not existing threads. A scheduled task targets the raw Slack conversation channel in `ToolRegistrationHookContext.destination` — the DM or channel where the user is interacting with Junior — not the assistant-context source channel, current message timestamp, or thread timestamp. Scheduled output posts as a new message in that destination.
+Scheduled task destinations use Junior's strict shared Slack destination contract, not existing threads. A scheduled task is authored from the raw Slack conversation channel in `ToolRegistrationHookContext.source` — the DM or channel where the user is interacting with Junior — not the outbound assistant-context destination, current message timestamp, or thread timestamp. Scheduled output posts as a new message in that stored task destination.
 The scheduler must parse active and stored destinations with the strict shared Slack destination schema from `@sentry/junior-plugin-api`. Unknown destination fields, missing required destination fields, legacy thread-shaped ids, and non-Slack team/channel ids are invalid rather than normalized during scheduler tool execution or store reads.
 When the scheduler stores an explicit delegated credential subject, it must parse that subject with the strict shared plugin credential-subject schema. Runtime-owned bindings or signatures must never be stored in scheduler task state.
 Each scheduled execution gets fresh dispatch-scoped conversation state. The runner must not load destination-level Slack conversation history as prior thread context for a scheduled run that is creating its own new message.
@@ -56,7 +57,7 @@ The scheduler must distinguish conversation audience from visibility. A private 
 
 Creator metadata records the user who confirmed the task so Junior can audit changes and privately notify someone when the task needs attention. The creator is not an owner, is not an authorization principal, and is not the actor for future scheduled runs.
 
-Task management is controlled only by access to the destination conversation window. If a user can post or trigger Junior in that Slack DM or channel context, they can manage scheduled tasks for that same context. The scheduler must not add creator-only, owner-only, workspace-admin-only, or channel-admin-only gates for V1 management.
+Task management is controlled only by access to the source conversation window. If a user can post or trigger Junior in that Slack DM or channel context, they can manage scheduled tasks for that same context. The scheduler must not add creator-only, owner-only, workspace-admin-only, or channel-admin-only gates for V1 management.
 
 ### Calendar Model
 
@@ -244,19 +245,19 @@ Credential subjects must be explicit and separate from creator metadata.
 
 ### Slack UX
 
-Slack authoring creates clear scheduled-work requests immediately for the active destination:
+Slack authoring creates clear scheduled-work requests immediately for the active source conversation:
 
 1. User asks Junior to schedule work.
 2. Junior normalizes the task text, cadence, timezone, destination, and next run.
-3. If the task text, schedule, and active destination are clear, Junior creates the task immediately.
-4. If the task text, schedule, or active destination is ambiguous, Junior asks for confirmation or clarification before creating the task.
+3. If the task text, schedule, and active source conversation are clear, Junior creates the task immediately.
+4. If the task text, schedule, or active source conversation is ambiguous, Junior asks for confirmation or clarification before creating the task.
 5. Junior replies with the task id, destination, schedule, timezone, and next run after creation.
 6. Junior supports list, pause, resume, delete, and run-now commands from the destination conversation.
 
 Confirmation should show the executable task text, not only echo the user's text.
-Anyone who can post or trigger Junior in the destination Slack conversation window may manage that conversation's scheduled tasks. Creator identity remains audit and notification metadata, but it is not an edit/delete/run-now ownership gate and is not the execution actor.
-Task creation must use the current active `Destination`. For Slack, the destination is always the raw conversation channel carried by `ToolRegistrationHookContext.destination` — never the assistant-context source channel override. Users cannot create scheduled tasks for a different channel, and cannot create DMs for other users.
-List output must be scoped to the active destination conversation and must not reveal tasks from other channels or DMs in the same workspace.
+Anyone who can post or trigger Junior in the source Slack conversation window may manage that conversation's scheduled tasks. Creator identity remains audit and notification metadata, but it is not an edit/delete/run-now ownership gate and is not the execution actor.
+Task creation must use the current active `Source`. For Slack, the stored task destination is derived from the raw conversation channel carried by `ToolRegistrationHookContext.source` — never the outbound assistant-context destination. Users cannot create scheduled tasks for a different channel, and cannot create DMs for other users.
+List output must be scoped to the active source conversation and must not reveal tasks from other channels or DMs in the same workspace.
 Blocked tasks must appear in list output with their blocked reason. After the missing requirement is fixed, a conversation manager can resume the task or run it now from the same destination conversation.
 
 ## Failure Model

--- a/specs/task-execution.md
+++ b/specs/task-execution.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-06-01
-- Last Edited: 2026-06-10
+- Last Edited: 2026-06-11
 
 ## Purpose
 
@@ -545,7 +545,9 @@ Local CLI is the first non-Slack destination implementation.
 
 Rules:
 
-1. Local CLI uses `source: "local"` and `destination.platform: "local"`.
+1. Local CLI uses `destination.platform: "local"`. It may bypass the durable
+   inbound-message mailbox for direct terminal turns; any later mailbox-backed
+   local ingress uses `source: "local"`.
 2. Local CLI conversation ids must be stable across prompts in the same selected
    terminal session.
 3. Local CLI must use the shared conversation runtime and `generateAssistantReply`

--- a/specs/task-execution.md
+++ b/specs/task-execution.md
@@ -541,11 +541,11 @@ Rules:
 
 ### Local Delivery Contract
 
-Local CLI is the first non-Slack destination implementation.
+Local CLI is the first non-Slack source and delivery implementation.
 
 Rules:
 
-1. Local CLI uses `destination.platform: "local"`. It may bypass the durable
+1. Local CLI uses `source.platform: "local"`. It may bypass the durable
    inbound-message mailbox for direct terminal turns; any later mailbox-backed
    local ingress uses `source: "local"`.
 2. Local CLI conversation ids must be stable across prompts in the same selected

--- a/specs/task-execution.md
+++ b/specs/task-execution.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-06-01
-- Last Edited: 2026-06-08
+- Last Edited: 2026-06-10
 
 ## Purpose
 
@@ -22,7 +22,7 @@ invocations without turning every tool call into a queue round trip.
 - Conversation-scoped leases and worker check-ins.
 - Cooperative agent-loop yielding at safe Pi continuation boundaries.
 - Heartbeat repair for expired leases and stranded mailbox work.
-- The boundary between Slack-specific ingress and generic agent execution.
+- The boundary between source-specific adapters and generic agent execution.
 - First-pass migration away from Chat SDK queue, lock, and long-running handler
   ownership.
 
@@ -45,12 +45,13 @@ invocations without turning every tool call into a queue round trip.
 
 The durable execution model uses these terms precisely:
 
-- **Conversation**: the thread-level container identified by `conversationId`.
-  For Slack, this is a normalized thread identity such as
-  `slack:<channel_id>:<thread_ts>`.
-- **Inbound message**: one normalized external source event that should be made
-  available to the agent. Slack messages, scheduler prompts, and plugin dispatch
-  prompts all become inbound messages.
+- **Conversation**: the thread-level or session-level container identified by
+  `conversationId`. For Slack, this is a normalized thread identity such as
+  `slack:<channel_id>:<thread_ts>`. For local CLI, this is a normalized local
+  session identity such as `local:<session_id>`.
+- **Inbound message**: one normalized source event that should be made
+  available to the agent. Slack messages, local CLI prompts, scheduler prompts,
+  and plugin dispatch prompts all become inbound messages.
 - **Agent run**: one response-producing execution for a conversation. A run may
   consume multiple inbound messages at safe boundaries, call many tools, and
   span multiple serverless invocations before final delivery.
@@ -78,7 +79,7 @@ Junior uses a durable conversation mailbox plus a queue wake-up nudge.
 
 ```mermaid
 flowchart TD
-  A[Inbound source event] --> B[Source-specific normalization]
+  A[Inbound source event or local CLI input] --> B[Source-specific normalization]
   B --> C[Append inbound message to conversation mailbox]
   C --> D[Send Vercel Queue nudge: conversationId + Destination]
   D --> E[Queue consumer]
@@ -110,17 +111,21 @@ Normative rules:
    checkpoint or resume position.
 6. Continuation means loading the latest durable conversation/session state and
    calling Pi `continue()`.
-7. Routine continuation must be silent in Slack. The agent-owned
-   `reportProgress` path and assistant status own user-visible progress.
+7. Routine continuation must be silent on platforms where the delivery adapter
+   owns progress UX. The agent-owned `reportProgress` path and destination
+   status/progress port own user-visible progress.
 
 ### Identity Model
 
 `conversationId` is the execution key. For Slack, it must be a stable normalized
-thread identity such as `slack:<channel_id>:<thread_ts>`.
+thread identity such as `slack:<channel_id>:<thread_ts>`. For local CLI, it must
+be a stable normalized session identity such as `local:<session_id>`.
 
 `inboundMessageId` is the idempotency key for one normalized inbound message.
 For Slack, it should be derived from the Slack team, channel, message timestamp,
 event subtype/edit identity when relevant, and source event id when available.
+For local CLI, it should be derived from the local session id and monotonically
+increasing local prompt sequence or another stable per-prompt id.
 
 `runId` identifies one response-producing agent run when a read model or
 callback needs a stable run id. It is not the conversation history key and must
@@ -153,7 +158,18 @@ Conceptual type:
 
 ```ts
 type ExecutionStatus = "idle" | "pending" | "running" | "awaiting_resume";
-type Source = "slack" | "api" | "scheduler" | "plugin" | "internal";
+type Source = "slack" | "local" | "api" | "scheduler" | "plugin" | "internal";
+
+type Destination =
+  | {
+      platform: "slack";
+      teamId: string;
+      channelId: string;
+    }
+  | {
+      platform: "local";
+      conversationId: string;
+    };
 
 // Canonical stored Slack requester from `packages/junior/src/chat/requester.ts`.
 // New records include Slack platform, team, user, and optional display/contact
@@ -275,14 +291,15 @@ only the newest retained conversations for list/reporting APIs, but `active` is
 membership for in-flight work and must keep every non-idle conversation until
 that conversation becomes idle or is explicitly removed after cleanup.
 
-### Ingress Contract
+### Source Adapter Contract
 
 Inbound source handlers are source-specific. Slack parsing, signature
 verification, event subtype handling, assistant lifecycle event handling, and
-attachment normalization may be Slack-specific.
+attachment normalization may be Slack-specific. Local CLI parsing, terminal
+session selection, and stdin/stdout handling may be local-specific.
 
-Ingress must not decide whether an inbound message starts a new agent run,
-steers an active run, or is a stale follow-up. It always performs the same
+Source adapters must not decide whether an inbound message starts a new agent
+run, steers an active run, or is a stale follow-up. They always perform the same
 durable handoff:
 
 1. Verify the source request.
@@ -294,9 +311,11 @@ durable handoff:
 5. Enqueue `{ conversationId, destination }`.
 6. If enqueue succeeds, record `lastEnqueuedAtMs` and refresh
    `execution.updatedAtMs`.
-7. Return the source HTTP acknowledgement quickly.
+7. Return the source acknowledgement quickly. For HTTP sources, this is the
+   HTTP response. For local CLI, this is returning control to the terminal loop
+   after durable handoff or direct local execution setup.
 
-The source HTTP acknowledgement is not the late acknowledgement. Late
+The source acknowledgement is not the late acknowledgement. Late
 acknowledgement applies to the queue delivery consumed by the worker.
 
 If enqueue fails after mailbox append, the heartbeat repair path must later
@@ -467,7 +486,7 @@ Unsafe yield points:
 - after an assistant tool request but before tool execution has produced durable
   results
 - midway through a tool call
-- after final Slack delivery has started but before completion state is
+- after final destination delivery has started but before completion state is
   persisted
 
 If the soft deadline passes during a model or tool call, the worker does not
@@ -480,7 +499,7 @@ When yielding, the worker:
 2. Enqueues `{ conversationId, destination }`.
 3. Releases the lease.
 4. Acknowledges the queue delivery.
-5. Exits without posting a routine continuation message to Slack.
+5. Exits without posting a routine continuation message to the destination.
 
 ### Agent Runtime Boundary
 
@@ -500,6 +519,45 @@ The new implementation must not rely on Chat SDK for queueing, concurrency
 locks, long-running handler lifetime, or conversation work recovery. Any
 transitional compatibility wrapper must be treated as non-canonical and must not
 own execution semantics.
+
+### Destination Delivery Contract
+
+Destination delivery is a small platform-owned port called only after the agent
+has produced a finalized reply and the worker has drained the inbox at the final
+safe boundary.
+
+Rules:
+
+1. The shared worker passes finalized reply text, generated files, delivery
+   plan, and conversation correlation to the destination delivery port.
+2. A destination delivery port may format output for its platform, but it must
+   not re-enter agent execution or mutate source routing decisions.
+3. Completion is persisted only after the destination delivery port accepts the
+   visible final reply or records a terminal delivery failure.
+4. Platform-specific side effects remain platform-specific tools or delivery
+   actions. Non-Slack destinations must not use Slack reply, reaction, or
+   ephemeral-message fallbacks.
+
+### Local Delivery Contract
+
+Local CLI is the first non-Slack destination implementation.
+
+Rules:
+
+1. Local CLI uses `source: "local"` and `destination.platform: "local"`.
+2. Local CLI conversation ids must be stable across prompts in the same selected
+   terminal session.
+3. Local CLI must use the shared conversation runtime and `generateAssistantReply`
+   path. It must not instantiate Slack thread/message wrappers to reach the
+   agent.
+4. Local CLI may stream assistant deltas and status updates to stdout/stderr, but
+   the finalized reply remains the delivery outcome recorded for the
+   conversation.
+5. Local CLI must not fabricate Slack requesters, Slack destinations, Slack
+   thread ids, Slack message timestamps, or Slack assistant lifecycle events.
+6. Local CLI interactive authorization is disabled until a local auth contract
+   exists. Missing provider credentials must surface as an explicit local error
+   instead of creating Slack OAuth or ephemeral-message flows.
 
 ### Slack Delivery Contract
 
@@ -593,9 +651,9 @@ These guardrails must not complicate the first-pass mailbox/lease design.
 8. Worker yields cooperatively and dies after enqueue but before queue
    acknowledgement: redelivery observes released lease or no unsafe work and
    remains harmless.
-9. Worker dies after final delivery starts: Slack post and durable completion
-   are not atomic. First pass accepts best-effort delivery semantics and does
-   not add special reconciliation beyond persisted completion state.
+9. Worker dies after final delivery starts: destination delivery and durable
+   completion are not atomic. First pass accepts best-effort delivery semantics
+   and does not add special reconciliation beyond persisted completion state.
 10. Heartbeat misses one scan: Vercel Queue redelivery or the next heartbeat can
     still recover because leases and mailbox messages are durable.
 
@@ -658,17 +716,20 @@ Required invariants, using the lowest layer that proves the contract:
     not after agent execution.
 13. Integration: a queue-driven Slack worker path reaches the real Slack runtime
     and finalized delivery with deterministic fake-agent output.
-14. Component/integration: recovery after death during model/tool work resumes
+14. Integration: local CLI reaches the shared conversation runtime without
+    constructing Slack message/thread wrappers.
+15. Component/integration: recovery after death during model/tool work resumes
     from the latest durable session-log boundary.
-15. Component: the all-conversation index is sorted by `lastActivityAtMs`; the
+16. Component: the all-conversation index is sorted by `lastActivityAtMs`; the
     active-conversation index contains only non-idle conversations and is sorted
     by `execution.updatedAtMs`.
-16. Evals: realistic multi-message Slack follow-ups during long work are folded
+17. Evals: realistic multi-message Slack follow-ups during long work are folded
     into the active answer without losing user intent.
 
 ## Related Specs
 
 - [Chat Architecture Spec](./chat-architecture.md)
+- [Local Agent Spec](./local-agent.md)
 - [Agent Session Resumability Spec](./agent-session-resumability.md)
 - [Slack Agent Delivery Spec](./slack-agent-delivery.md)
 - [Scheduler Spec](./scheduler.md)

--- a/specs/task-execution.md
+++ b/specs/task-execution.md
@@ -48,7 +48,7 @@ The durable execution model uses these terms precisely:
 - **Conversation**: the thread-level or session-level container identified by
   `conversationId`. For Slack, this is a normalized thread identity such as
   `slack:<channel_id>:<thread_ts>`. For local CLI, this is a normalized local
-  session identity such as `local:<session_id>`.
+  session identity such as `local:<workspace_key>:<conversation_slug>`.
 - **Inbound message**: one normalized source event that should be made
   available to the agent. Slack messages, local CLI prompts, scheduler prompts,
   and plugin dispatch prompts all become inbound messages.
@@ -119,7 +119,8 @@ Normative rules:
 
 `conversationId` is the execution key. For Slack, it must be a stable normalized
 thread identity such as `slack:<channel_id>:<thread_ts>`. For local CLI, it must
-be a stable normalized session identity such as `local:<session_id>`.
+be a stable normalized session identity such as
+`local:<workspace_key>:<conversation_slug>`.
 
 `inboundMessageId` is the idempotency key for one normalized inbound message.
 For Slack, it should be derived from the Slack team, channel, message timestamp,


### PR DESCRIPTION
Junior can now run real agent turns from the terminal with `junior chat`: `-p` exits after one message, interactive mode keeps one process-scoped conversation, and local chat defaults to memory unless `JUNIOR_STATE_ADAPTER` is explicitly selected. That keeps ordinary local QA from inheriting Redis just because `.env.local` contains `REDIS_URL`, while still allowing durable state to be opted into deliberately.

This also tightens platform boundaries for future non-Slack ingress. Source/requestor context is generic through the shared agent path, Slack tool runtime context is derived only inside Slack-specific tools, and scheduler/plugin dispatch records keep Slack-only destinations where the feature is Slack-only. `apps/example` is now documented as the local QA fixture through the new `junior-qa` agent skill, with specs and focused tests covering the local-vs-Slack contracts.