### PR TITLE
fix(auth): Reissue auth links for new sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,7 @@ Co-Authored-By: (agent model name) <email>
 - `specs/security-policy.md` (global runtime/container/token security policy)
 - `specs/data-redaction-policy.md` (conversation privacy classification and raw payload redaction policy)
 - `specs/chat-architecture.md` (chat composition, service, and test-seam architecture contract)
+- `specs/terminology.md` (canonical execution vocabulary and historical turn naming rules)
 - `specs/task-execution.md` (durable conversation mailbox, queue wake-up, lease, and heartbeat execution contract)
 - `specs/local-agent.md` (local CLI/local adapter user flows, identity, state, and delivery contract)
 - `specs/agent-turn-handling.md` (agent user-message response policy: reply/silence, tool use, Slack side effects, resumed runs, and completion)

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -249,7 +249,7 @@ export interface ReplyRequestContext {
   ) => Promise<ReplySteeringMessage[]>;
   /** Return true when the durable worker should pause at the next Pi boundary. */
   shouldYield?: () => boolean;
-  onAuthPending?: (
+  recordPendingAuth?: (
     pendingAuth: ConversationPendingAuthState,
   ) => void | Promise<void>;
   onTextDelta?: (deltaText: string) => void | Promise<void>;
@@ -971,43 +971,39 @@ export async function generateAssistantReply(
         : undefined;
     const slackChannelId = slackDestination?.channelId;
 
-    const mcpAuth = createMcpAuthOrchestration(
-      {
-        conversationId: sessionConversationId,
-        sessionId,
-        requesterId: authRequesterId,
-        channelId: slackChannelId,
-        destination: context.destination,
-        threadTs: context.correlation?.threadTs,
-        toolChannelId: context.toolChannelId,
-        userMessage: userInput,
-        currentPendingAuth: context.pendingAuth,
-        getConfiguration: () => configurationValues,
-        getArtifactState: () => context.artifactState,
-        getMergedArtifactState: () =>
-          mergeArtifactsState(context.artifactState ?? {}, artifactStatePatch),
-        onPendingAuth: context.onAuthPending,
-        authorizationFlowMode: context.authorizationFlowMode,
-      },
-      () => agent?.abort(),
-    );
-    const pluginAuth = createPluginAuthOrchestration(
-      {
-        conversationId: sessionConversationId,
-        sessionId,
-        requesterId: authRequesterId,
-        channelId: slackChannelId,
-        destination: context.destination,
-        threadTs: context.correlation?.threadTs,
-        userMessage: userInput,
-        channelConfiguration: context.channelConfiguration,
-        currentPendingAuth: context.pendingAuth,
-        onPendingAuth: context.onAuthPending,
-        authorizationFlowMode: context.authorizationFlowMode,
-        userTokenStore,
-      },
-      () => agent?.abort(),
-    );
+    const mcpAuth = createMcpAuthOrchestration({
+      abortAgent: () => agent?.abort(),
+      conversationId: sessionConversationId,
+      sessionId,
+      requesterId: authRequesterId,
+      channelId: slackChannelId,
+      destination: context.destination,
+      threadTs: context.correlation?.threadTs,
+      toolChannelId: context.toolChannelId,
+      userMessage: userInput,
+      pendingAuth: context.pendingAuth,
+      getConfiguration: () => configurationValues,
+      getArtifactState: () => context.artifactState,
+      getMergedArtifactState: () =>
+        mergeArtifactsState(context.artifactState ?? {}, artifactStatePatch),
+      recordPendingAuth: context.recordPendingAuth,
+      authorizationFlowMode: context.authorizationFlowMode,
+    });
+    const pluginAuth = createPluginAuthOrchestration({
+      abortAgent: () => agent?.abort(),
+      conversationId: sessionConversationId,
+      sessionId,
+      requesterId: authRequesterId,
+      channelId: slackChannelId,
+      destination: context.destination,
+      threadTs: context.correlation?.threadTs,
+      userMessage: userInput,
+      channelConfiguration: context.channelConfiguration,
+      pendingAuth: context.pendingAuth,
+      recordPendingAuth: context.recordPendingAuth,
+      authorizationFlowMode: context.authorizationFlowMode,
+      userTokenStore,
+    });
 
     mcpToolManager = new McpToolManager(getPluginMcpProviders(), {
       authProviderFactory: mcpAuth.authProviderFactory,

--- a/packages/junior/src/chat/runtime/agent-continue-runner.ts
+++ b/packages/junior/src/chat/runtime/agent-continue-runner.ts
@@ -294,7 +294,7 @@ export async function continueSlackAgentRun(
             channelConfiguration,
             piMessages: conversation.piMessages,
             sandbox,
-            onAuthPending: async (nextPendingAuth) => {
+            recordPendingAuth: async (nextPendingAuth) => {
               await applyPendingAuthUpdate({
                 conversation,
                 conversationId: payload.conversationId,

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -886,7 +886,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                   artifacts: latestArtifacts,
                 });
               },
-              onAuthPending: async (pendingAuth) => {
+              recordPendingAuth: async (pendingAuth) => {
                 await applyPendingAuthUpdate({
                   conversation: preparedState.conversation,
                   conversationId,

--- a/packages/junior/src/chat/services/mcp-auth-orchestration.ts
+++ b/packages/junior/src/chat/services/mcp-auth-orchestration.ts
@@ -37,7 +37,8 @@ export class McpAuthorizationPauseError extends AuthorizationPauseError {
   }
 }
 
-export interface McpAuthOrchestrationDeps {
+export interface McpAuthOrchestrationInput {
+  abortAgent: () => void;
   conversationId?: string;
   sessionId?: string;
   requesterId?: string;
@@ -46,11 +47,11 @@ export interface McpAuthOrchestrationDeps {
   threadTs?: string;
   toolChannelId?: string;
   userMessage: string;
-  currentPendingAuth?: ConversationPendingAuthState;
+  pendingAuth?: ConversationPendingAuthState;
   getConfiguration: () => Record<string, unknown>;
   getArtifactState: () => ThreadArtifactsState | undefined;
   getMergedArtifactState: () => ThreadArtifactsState;
-  onPendingAuth?: (
+  recordPendingAuth?: (
     pendingAuth: ConversationPendingAuthState,
   ) => void | Promise<void>;
   authorizationFlowMode?: AuthorizationFlowMode;
@@ -74,8 +75,7 @@ function authorizationId(args: {
 
 /** Create MCP authorization orchestration for a single agent run. */
 export function createMcpAuthOrchestration(
-  deps: McpAuthOrchestrationDeps,
-  abortAgent: () => void,
+  input: McpAuthOrchestrationInput,
 ): McpAuthOrchestration {
   let pendingPause: McpAuthorizationPauseError | undefined;
   const authSessionIdsByProvider = new Map<string, string>();
@@ -83,22 +83,30 @@ export function createMcpAuthOrchestration(
   const authProviderFactory = async (
     plugin: PluginDefinition,
   ): Promise<OAuthClientProvider | undefined> => {
-    if (!deps.conversationId || !deps.sessionId || !deps.requesterId) {
+    if (!input.conversationId || !input.sessionId || !input.requesterId) {
       return undefined;
+    }
+    if (
+      !input.recordPendingAuth &&
+      input.authorizationFlowMode !== "disabled"
+    ) {
+      throw new Error(
+        `Missing pending auth recorder for MCP authorization pause "${plugin.manifest.name}"`,
+      );
     }
 
     const provider = await createMcpOAuthClientProvider({
       provider: plugin.manifest.name,
-      conversationId: deps.conversationId,
-      destination: deps.destination,
-      sessionId: deps.sessionId,
-      userId: deps.requesterId,
-      userMessage: deps.userMessage,
-      ...(deps.channelId ? { channelId: deps.channelId } : {}),
-      ...(deps.threadTs ? { threadTs: deps.threadTs } : {}),
-      ...(deps.toolChannelId ? { toolChannelId: deps.toolChannelId } : {}),
-      configuration: deps.getConfiguration(),
-      artifactState: deps.getArtifactState(),
+      conversationId: input.conversationId,
+      destination: input.destination,
+      sessionId: input.sessionId,
+      userId: input.requesterId,
+      userMessage: input.userMessage,
+      ...(input.channelId ? { channelId: input.channelId } : {}),
+      ...(input.threadTs ? { threadTs: input.threadTs } : {}),
+      ...(input.toolChannelId ? { toolChannelId: input.toolChannelId } : {}),
+      configuration: input.getConfiguration(),
+      artifactState: input.getArtifactState(),
     });
     authSessionIdsByProvider.set(plugin.manifest.name, provider.authSessionId);
     return provider;
@@ -112,27 +120,33 @@ export function createMcpAuthOrchestration(
     }
 
     const authSessionId = authSessionIdsByProvider.get(provider);
-    const conversationId = deps.conversationId;
-    const sessionId = deps.sessionId;
-    const requesterId = deps.requesterId;
+    const conversationId = input.conversationId;
+    const sessionId = input.sessionId;
+    const requesterId = input.requesterId;
     if (!authSessionId || !conversationId || !sessionId || !requesterId) {
       throw new Error(
         `Missing MCP auth session context for plugin "${provider}"`,
       );
     }
-    if (deps.authorizationFlowMode === "disabled") {
+    if (input.authorizationFlowMode === "disabled") {
       await deleteMcpAuthSession(authSessionId);
       throw new AuthorizationFlowDisabledError("mcp", provider);
     }
+    const recordPendingAuth = input.recordPendingAuth;
+    if (!recordPendingAuth) {
+      throw new Error(
+        `Missing pending auth recorder for MCP authorization pause "${provider}"`,
+      );
+    }
 
-    const latestArtifactState = deps.getMergedArtifactState();
+    const latestArtifactState = input.getMergedArtifactState();
     await patchMcpAuthSession(authSessionId, {
-      configuration: { ...deps.getConfiguration() },
+      configuration: { ...input.getConfiguration() },
       artifactState: latestArtifactState,
       toolChannelId:
-        deps.toolChannelId ??
+        input.toolChannelId ??
         latestArtifactState.assistantContextChannelId ??
-        deps.channelId,
+        input.channelId,
     });
 
     const authSession = await getMcpAuthSession(authSessionId);
@@ -141,7 +155,7 @@ export function createMcpAuthOrchestration(
     }
 
     const reusingPendingLink = canReusePendingAuthLink({
-      pendingAuth: deps.currentPendingAuth,
+      pendingAuth: input.pendingAuth,
       kind: "mcp",
       provider,
       requesterId,
@@ -165,13 +179,13 @@ export function createMcpAuthOrchestration(
       await deleteMcpAuthSession(authSessionId);
     }
 
-    await deps.onPendingAuth?.({
+    await recordPendingAuth({
       kind: "mcp",
       provider,
       requesterId,
       sessionId,
       linkSentAtMs: reusingPendingLink
-        ? deps.currentPendingAuth!.linkSentAtMs
+        ? input.pendingAuth!.linkSentAtMs
         : Date.now(),
     });
     await recordAuthorizationRequested({
@@ -194,7 +208,7 @@ export function createMcpAuthOrchestration(
       providerLabel,
       reusingPendingLink ? "link_already_sent" : "link_sent",
     );
-    abortAgent();
+    input.abortAgent();
     return true;
   };
 

--- a/packages/junior/src/chat/services/mcp-auth-orchestration.ts
+++ b/packages/junior/src/chat/services/mcp-auth-orchestration.ts
@@ -1,7 +1,7 @@
 /**
  * MCP authorization pause orchestration.
  *
- * This module turns an MCP client auth challenge into Junior's paused-turn
+ * This module turns an MCP client auth challenge into Junior's paused-run
  * model: create provider auth state, deliver or reuse a private Slack link,
  * record pending auth, and abort the agent so the OAuth callback can resume the
  * same session.
@@ -72,7 +72,7 @@ function authorizationId(args: {
   return `${args.sessionId}:${args.kind}:${args.provider}`;
 }
 
-/** Create MCP authorization orchestration for a single turn. */
+/** Create MCP authorization orchestration for a single agent run. */
 export function createMcpAuthOrchestration(
   deps: McpAuthOrchestrationDeps,
   abortAgent: () => void,
@@ -112,7 +112,10 @@ export function createMcpAuthOrchestration(
     }
 
     const authSessionId = authSessionIdsByProvider.get(provider);
-    if (!authSessionId || !deps.requesterId) {
+    const conversationId = deps.conversationId;
+    const sessionId = deps.sessionId;
+    const requesterId = deps.requesterId;
+    if (!authSessionId || !conversationId || !sessionId || !requesterId) {
       throw new Error(
         `Missing MCP auth session context for plugin "${provider}"`,
       );
@@ -141,7 +144,8 @@ export function createMcpAuthOrchestration(
       pendingAuth: deps.currentPendingAuth,
       kind: "mcp",
       provider,
-      requesterId: deps.requesterId,
+      requesterId,
+      sessionId,
     });
     const providerLabel = formatProviderLabel(provider);
 
@@ -161,37 +165,30 @@ export function createMcpAuthOrchestration(
       await deleteMcpAuthSession(authSessionId);
     }
 
-    // `sessionId`/`requesterId` are guaranteed here: `onAuthorizationRequired`
-    // only fires for an MCP provider we actually created, and the provider
-    // factory returns undefined unless both are set.
-    if (deps.sessionId && deps.requesterId) {
-      await deps.onPendingAuth?.({
+    await deps.onPendingAuth?.({
+      kind: "mcp",
+      provider,
+      requesterId,
+      sessionId,
+      linkSentAtMs: reusingPendingLink
+        ? deps.currentPendingAuth!.linkSentAtMs
+        : Date.now(),
+    });
+    await recordAuthorizationRequested({
+      conversationId,
+      kind: "mcp",
+      provider,
+      requesterId,
+      authorizationId: authorizationId({
         kind: "mcp",
         provider,
-        requesterId: deps.requesterId,
-        sessionId: deps.sessionId,
-        linkSentAtMs: reusingPendingLink
-          ? deps.currentPendingAuth!.linkSentAtMs
-          : Date.now(),
-      });
-    }
-    if (deps.conversationId && deps.sessionId && deps.requesterId) {
-      await recordAuthorizationRequested({
-        conversationId: deps.conversationId,
-        kind: "mcp",
-        provider,
-        requesterId: deps.requesterId,
-        authorizationId: authorizationId({
-          kind: "mcp",
-          provider,
-          sessionId: deps.sessionId,
-        }),
-        delivery: reusingPendingLink
-          ? "private_link_reused"
-          : "private_link_sent",
-        ttlMs: THREAD_STATE_TTL_MS,
-      });
-    }
+        sessionId,
+      }),
+      delivery: reusingPendingLink
+        ? "private_link_reused"
+        : "private_link_sent",
+      ttlMs: THREAD_STATE_TTL_MS,
+    });
     pendingPause = new McpAuthorizationPauseError(
       provider,
       providerLabel,

--- a/packages/junior/src/chat/services/pending-auth.ts
+++ b/packages/junior/src/chat/services/pending-auth.ts
@@ -13,6 +13,7 @@ import { abandonAgentTurnSessionRecord } from "@/chat/state/turn-session";
 // so the old link is usually still honorable when we reuse it.
 const AUTH_LINK_REUSE_WINDOW_MS = 10 * 60 * 1000;
 
+/** Decide whether the same agent-run session can reuse its fresh auth link. */
 export function canReusePendingAuthLink(args: {
   kind: AuthorizationPauseKind;
   nowMs?: number;
@@ -20,6 +21,7 @@ export function canReusePendingAuthLink(args: {
   provider: string;
   requesterId: string;
   scope?: string;
+  sessionId: string;
 }): boolean {
   const { pendingAuth } = args;
   if (!pendingAuth) {
@@ -31,6 +33,7 @@ export function canReusePendingAuthLink(args: {
     pendingAuth.provider === args.provider &&
     pendingAuth.requesterId === args.requesterId &&
     pendingAuth.scope === args.scope &&
+    pendingAuth.sessionId === args.sessionId &&
     pendingAuth.linkSentAtMs + AUTH_LINK_REUSE_WINDOW_MS >
       (args.nowMs ?? Date.now())
   );

--- a/packages/junior/src/chat/services/plugin-auth-orchestration.ts
+++ b/packages/junior/src/chat/services/plugin-auth-orchestration.ts
@@ -2,7 +2,7 @@
  * Plugin authorization pause orchestration.
  *
  * This module detects plugin credential failures from the sandbox egress layer
- * and maps them onto the same paused-turn contract used by MCP auth. It owns
+ * and maps them onto the same paused-run contract used by MCP auth. It owns
  * provider attribution, private-link delivery/reuse, session-log recording,
  * and credential cleanup.
  *
@@ -68,7 +68,7 @@ export interface PluginAuthOrchestration {
   /**
    * Inspect a sandbox tool result for an `auth_required` signal from the
    * egress proxy. If one is present and an OAuth flow is available, parks the
-   * current turn and sends the user an authorization link. No-ops when the
+   * current run and sends the user an authorization link. No-ops when the
    * result carries no auth signal.
    */
   maybeHandleAuthSignal: (details: unknown) => Promise<void>;
@@ -121,7 +121,7 @@ function authorizationId(args: {
 }
 
 /**
- * Start plugin OAuth from a sandbox egress auth signal and park the turn.
+ * Start plugin OAuth from a sandbox egress auth signal and park the run.
  */
 export function createPluginAuthOrchestration(
   deps: PluginAuthOrchestrationDeps,
@@ -147,13 +147,16 @@ export function createPluginAuthOrchestration(
     }
 
     const providerLabel = formatProviderLabel(provider);
-    const reusingPendingLink = canReusePendingAuthLink({
-      pendingAuth: deps.currentPendingAuth,
-      kind: "plugin",
-      provider,
-      requesterId: deps.requesterId,
-      ...(options?.scope ? { scope: options.scope } : {}),
-    });
+    const reusingPendingLink = deps.sessionId
+      ? canReusePendingAuthLink({
+          pendingAuth: deps.currentPendingAuth,
+          kind: "plugin",
+          provider,
+          requesterId: deps.requesterId,
+          sessionId: deps.sessionId,
+          ...(options?.scope ? { scope: options.scope } : {}),
+        })
+      : false;
 
     if (!reusingPendingLink) {
       const oauthResult = await startOAuthFlow(provider, {

--- a/packages/junior/src/chat/services/plugin-auth-orchestration.ts
+++ b/packages/junior/src/chat/services/plugin-auth-orchestration.ts
@@ -47,7 +47,8 @@ export class PluginCredentialFailureError extends Error {
   }
 }
 
-export interface PluginAuthOrchestrationDeps {
+export interface PluginAuthOrchestrationInput {
+  abortAgent: () => void;
   conversationId?: string;
   sessionId?: string;
   requesterId?: string;
@@ -56,8 +57,8 @@ export interface PluginAuthOrchestrationDeps {
   threadTs?: string;
   userMessage: string;
   channelConfiguration?: ChannelConfigurationService;
-  currentPendingAuth?: ConversationPendingAuthState;
-  onPendingAuth?: (
+  pendingAuth?: ConversationPendingAuthState;
+  recordPendingAuth?: (
     pendingAuth: ConversationPendingAuthState,
   ) => void | Promise<void>;
   authorizationFlowMode?: AuthorizationFlowMode;
@@ -124,8 +125,7 @@ function authorizationId(args: {
  * Start plugin OAuth from a sandbox egress auth signal and park the run.
  */
 export function createPluginAuthOrchestration(
-  deps: PluginAuthOrchestrationDeps,
-  abortAgent: () => void,
+  input: PluginAuthOrchestrationInput,
 ): PluginAuthOrchestration {
   let pendingPause: PluginAuthorizationPauseError | undefined;
 
@@ -139,36 +139,44 @@ export function createPluginAuthOrchestration(
     if (pendingPause) {
       throw pendingPause;
     }
-    if (!deps.requesterId || !getPluginOAuthConfig(provider)) {
+    if (!input.requesterId || !getPluginOAuthConfig(provider)) {
       throw new Error(`Cannot start plugin authorization for ${provider}`);
     }
-    if (deps.authorizationFlowMode === "disabled") {
+    if (input.authorizationFlowMode === "disabled") {
       throw new AuthorizationFlowDisabledError("plugin", provider);
+    }
+    const recordPendingAuth = input.sessionId
+      ? input.recordPendingAuth
+      : undefined;
+    if (input.sessionId && !recordPendingAuth) {
+      throw new Error(
+        `Missing pending auth recorder for plugin authorization pause "${provider}"`,
+      );
     }
 
     const providerLabel = formatProviderLabel(provider);
-    const reusingPendingLink = deps.sessionId
+    const reusingPendingLink = input.sessionId
       ? canReusePendingAuthLink({
-          pendingAuth: deps.currentPendingAuth,
+          pendingAuth: input.pendingAuth,
           kind: "plugin",
           provider,
-          requesterId: deps.requesterId,
-          sessionId: deps.sessionId,
+          requesterId: input.requesterId,
+          sessionId: input.sessionId,
           ...(options?.scope ? { scope: options.scope } : {}),
         })
       : false;
 
     if (!reusingPendingLink) {
       const oauthResult = await startOAuthFlow(provider, {
-        requesterId: deps.requesterId,
-        channelId: deps.channelId,
-        destination: deps.destination,
-        threadTs: deps.threadTs,
-        userMessage: deps.userMessage,
-        channelConfiguration: deps.channelConfiguration,
+        requesterId: input.requesterId,
+        channelId: input.channelId,
+        destination: input.destination,
+        threadTs: input.threadTs,
+        userMessage: input.userMessage,
+        channelConfiguration: input.channelConfiguration,
         ...(options?.scope ? { scope: options.scope } : {}),
-        resumeConversationId: deps.conversationId,
-        resumeSessionId: deps.sessionId,
+        resumeConversationId: input.conversationId,
+        resumeSessionId: input.sessionId,
       });
 
       if (!oauthResult.ok) {
@@ -183,34 +191,34 @@ export function createPluginAuthOrchestration(
 
     if (
       options?.unlinkExistingProvider &&
-      deps.requesterId &&
-      deps.userTokenStore
+      input.requesterId &&
+      input.userTokenStore
     ) {
-      await unlinkProvider(deps.requesterId, provider, deps.userTokenStore);
+      await unlinkProvider(input.requesterId, provider, input.userTokenStore);
     }
 
-    if (deps.sessionId) {
-      await deps.onPendingAuth?.({
+    if (input.sessionId && recordPendingAuth) {
+      await recordPendingAuth({
         kind: "plugin",
         provider,
-        requesterId: deps.requesterId,
+        requesterId: input.requesterId,
         ...(options?.scope ? { scope: options.scope } : {}),
-        sessionId: deps.sessionId,
+        sessionId: input.sessionId,
         linkSentAtMs: reusingPendingLink
-          ? deps.currentPendingAuth!.linkSentAtMs
+          ? input.pendingAuth!.linkSentAtMs
           : Date.now(),
       });
     }
-    if (deps.conversationId && deps.sessionId) {
+    if (input.conversationId && input.sessionId) {
       await recordAuthorizationRequested({
-        conversationId: deps.conversationId,
+        conversationId: input.conversationId,
         kind: "plugin",
         provider,
-        requesterId: deps.requesterId,
+        requesterId: input.requesterId,
         authorizationId: authorizationId({
           kind: "plugin",
           provider,
-          sessionId: deps.sessionId,
+          sessionId: input.sessionId,
         }),
         delivery: reusingPendingLink
           ? "private_link_reused"
@@ -223,7 +231,7 @@ export function createPluginAuthOrchestration(
       providerLabel,
       reusingPendingLink ? "link_already_sent" : "link_sent",
     );
-    abortAgent();
+    input.abortAgent();
     throw pendingPause;
   };
 
@@ -252,8 +260,8 @@ export function createPluginAuthOrchestration(
         );
       }
 
-      if (!deps.requesterId || !deps.userTokenStore) {
-        if (deps.authorizationFlowMode === "disabled") {
+      if (!input.requesterId || !input.userTokenStore) {
+        if (input.authorizationFlowMode === "disabled") {
           throw new AuthorizationFlowDisabledError("plugin", provider);
         }
         throw new PluginCredentialFailureError(

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -364,7 +364,7 @@ async function resumeAuthorizedMcpTurn(args: {
           pendingAuth: lockedPendingAuth,
           channelConfiguration: lockedChannelConfiguration,
           sandbox: getPersistedSandboxState(lockedState),
-          onAuthPending: async (nextPendingAuth) => {
+          recordPendingAuth: async (nextPendingAuth) => {
             await applyPendingAuthUpdate({
               conversation: lockedConversation,
               conversationId: authSession.conversationId,

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -391,7 +391,7 @@ async function resumeOAuthSessionRecordTurn(
           channelConfiguration: lockedChannelConfiguration,
           piMessages: lockedConversation.piMessages,
           sandbox: getPersistedSandboxState(lockedState),
-          onAuthPending: async (nextPendingAuth) => {
+          recordPendingAuth: async (nextPendingAuth) => {
             await applyPendingAuthUpdate({
               conversation: lockedConversation,
               conversationId: stored.resumeConversationId!,

--- a/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PiMessage } from "@/chat/pi/messages";
+import type { ConversationPendingAuthState } from "@/chat/state/conversation";
 
 const {
   DEMO_SKILL,
@@ -15,6 +16,7 @@ const {
   loadSkillExecutionErrorCount,
   loadSkillsByNameMock,
   omitFinalAssistantAfterTool,
+  pendingAuthRecords,
   pushPreToolAssistantMessage,
   promptCallCount,
   promptMessages,
@@ -43,6 +45,7 @@ const {
   loadSkillExecutionErrorCount: { value: 0 },
   loadSkillsByNameMock: vi.fn(),
   omitFinalAssistantAfterTool: { value: false },
+  pendingAuthRecords: [] as ConversationPendingAuthState[],
   promptCallCount: { value: 0 },
   promptMessages: [] as unknown[],
   promptSeedMessages: [] as unknown[][],
@@ -108,6 +111,9 @@ function makeReplyContext(args: {
       channelId: "C123",
     },
     requester: TEST_REQUESTER,
+    recordPendingAuth: async (pendingAuth: ConversationPendingAuthState) => {
+      pendingAuthRecords.push(pendingAuth);
+    },
     correlation: {
       channelId: "C123",
       conversationId: args.conversationId,
@@ -600,6 +606,7 @@ describe("generateAssistantReply progressive MCP loading", () => {
     loadSkillExecutionErrorCount.value = 0;
     loadSkillsByNameMock.mockReset();
     omitFinalAssistantAfterTool.value = false;
+    pendingAuthRecords.length = 0;
     promptCallCount.value = 0;
     promptMessages.length = 0;
     promptSeedMessages.length = 0;
@@ -687,6 +694,14 @@ describe("generateAssistantReply progressive MCP loading", () => {
       toolName: "loadSkill",
     });
     expect(deliverPrivateMessageMock).toHaveBeenCalledTimes(1);
+    expect(pendingAuthRecords).toEqual([
+      expect.objectContaining({
+        kind: "mcp",
+        provider: "demo",
+        requesterId: "U123",
+        sessionId: "turn-1",
+      }),
+    ]);
     expect(loadSkillExecutionErrorCount.value).toBe(0);
 
     const reply = await generateAssistantReply("help me", context);
@@ -1100,6 +1115,9 @@ describe("generateAssistantReply progressive MCP loading", () => {
         channelId: "C123",
       },
       requester: TEST_REQUESTER,
+      recordPendingAuth: async (pendingAuth: ConversationPendingAuthState) => {
+        pendingAuthRecords.push(pendingAuth);
+      },
       correlation: {
         conversationId: "conversation-3",
         turnId: "turn-3",
@@ -1190,6 +1208,9 @@ describe("generateAssistantReply progressive MCP loading", () => {
         channelId: "C123",
       },
       requester: TEST_REQUESTER,
+      recordPendingAuth: async (pendingAuth: ConversationPendingAuthState) => {
+        pendingAuthRecords.push(pendingAuth);
+      },
       correlation: {
         conversationId: "conversation-5",
         turnId: "turn-5",
@@ -1226,6 +1247,9 @@ describe("generateAssistantReply progressive MCP loading", () => {
         channelId: "C123",
       },
       requester: TEST_REQUESTER,
+      recordPendingAuth: async (pendingAuth: ConversationPendingAuthState) => {
+        pendingAuthRecords.push(pendingAuth);
+      },
       correlation: {
         conversationId: "conversation-6",
         turnId: "turn-6",

--- a/packages/junior/tests/unit/services/mcp-auth-orchestration.test.ts
+++ b/packages/junior/tests/unit/services/mcp-auth-orchestration.test.ts
@@ -62,21 +62,19 @@ describe("createMcpAuthOrchestration", () => {
 
   it("returns a deterministic error instead of delivering auth links when authorization is disabled", async () => {
     const abortAgent = vi.fn();
-    const orchestration = createMcpAuthOrchestration(
-      {
-        conversationId: "slack:C123:1700000000.000000",
-        sessionId: "scheduled:sched_1:1000",
-        requesterId: "U123",
-        channelId: "C123",
-        threadTs: "1700000000.000000",
-        userMessage: "<scheduled-task-run />",
-        getConfiguration: () => ({}),
-        getArtifactState: () => undefined,
-        getMergedArtifactState: () => ({}),
-        authorizationFlowMode: "disabled",
-      },
+    const orchestration = createMcpAuthOrchestration({
       abortAgent,
-    );
+      conversationId: "slack:C123:1700000000.000000",
+      sessionId: "scheduled:sched_1:1000",
+      requesterId: "U123",
+      channelId: "C123",
+      threadTs: "1700000000.000000",
+      userMessage: "<scheduled-task-run />",
+      getConfiguration: () => ({}),
+      getArtifactState: () => undefined,
+      getMergedArtifactState: () => ({}),
+      authorizationFlowMode: "disabled",
+    });
 
     await orchestration.authProviderFactory(plugin("github"));
 
@@ -91,9 +89,37 @@ describe("createMcpAuthOrchestration", () => {
     expect(abortAgent).not.toHaveBeenCalled();
   });
 
+  it("fails before preparing and delivering an auth link when pending auth cannot be recorded", async () => {
+    const abortAgent = vi.fn();
+    const orchestration = createMcpAuthOrchestration({
+      abortAgent,
+      conversationId: "slack:C123:1700000000.000000",
+      sessionId: "run_new",
+      requesterId: "U123",
+      channelId: "C123",
+      threadTs: "1700000000.000000",
+      userMessage: "use MCP",
+      getConfiguration: () => ({}),
+      getArtifactState: () => undefined,
+      getMergedArtifactState: () => ({}),
+    });
+
+    await expect(
+      orchestration.authProviderFactory(plugin("github")),
+    ).rejects.toThrow(
+      'Missing pending auth recorder for MCP authorization pause "github"',
+    );
+
+    expect(createMcpOAuthClientProvider).not.toHaveBeenCalled();
+    expect(patchMcpAuthSession).not.toHaveBeenCalled();
+    expect(getMcpAuthSession).not.toHaveBeenCalled();
+    expect(deliverPrivateMessage).not.toHaveBeenCalled();
+    expect(abortAgent).not.toHaveBeenCalled();
+  });
+
   it("sends a fresh link when the pending auth belongs to a previous session", async () => {
     const abortAgent = vi.fn();
-    const onPendingAuth = vi.fn();
+    const recordPendingAuth = vi.fn();
     getMcpAuthSession.mockResolvedValue({
       authorizationUrl: "https://mcp.example/authorize",
       channelId: "C123",
@@ -102,28 +128,26 @@ describe("createMcpAuthOrchestration", () => {
     });
     deliverPrivateMessage.mockResolvedValue({ channelId: "D123" });
 
-    const orchestration = createMcpAuthOrchestration(
-      {
-        conversationId: "slack:C123:1700000000.000000",
-        sessionId: "run_new",
-        requesterId: "U123",
-        channelId: "C123",
-        threadTs: "1700000000.000000",
-        userMessage: "use MCP",
-        currentPendingAuth: {
-          kind: "mcp",
-          provider: "github",
-          requesterId: "U123",
-          sessionId: "run_old",
-          linkSentAtMs: Date.now(),
-        },
-        getConfiguration: () => ({}),
-        getArtifactState: () => undefined,
-        getMergedArtifactState: () => ({}),
-        onPendingAuth,
-      },
+    const orchestration = createMcpAuthOrchestration({
       abortAgent,
-    );
+      conversationId: "slack:C123:1700000000.000000",
+      sessionId: "run_new",
+      requesterId: "U123",
+      channelId: "C123",
+      threadTs: "1700000000.000000",
+      userMessage: "use MCP",
+      pendingAuth: {
+        kind: "mcp",
+        provider: "github",
+        requesterId: "U123",
+        sessionId: "run_old",
+        linkSentAtMs: Date.now(),
+      },
+      getConfiguration: () => ({}),
+      getArtifactState: () => undefined,
+      getMergedArtifactState: () => ({}),
+      recordPendingAuth,
+    });
 
     await orchestration.authProviderFactory(plugin("github"));
 
@@ -137,7 +161,7 @@ describe("createMcpAuthOrchestration", () => {
       }),
     );
     expect(deleteMcpAuthSession).not.toHaveBeenCalled();
-    expect(onPendingAuth).toHaveBeenCalledWith(
+    expect(recordPendingAuth).toHaveBeenCalledWith(
       expect.objectContaining({
         kind: "mcp",
         provider: "github",

--- a/packages/junior/tests/unit/services/mcp-auth-orchestration.test.ts
+++ b/packages/junior/tests/unit/services/mcp-auth-orchestration.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMcpAuthOrchestration } from "@/chat/services/mcp-auth-orchestration";
 import { AuthorizationFlowDisabledError } from "@/chat/services/auth-pause";
+import type { PluginDefinition } from "@/chat/plugins/types";
 
 const {
   createMcpOAuthClientProvider,
@@ -33,6 +34,19 @@ vi.mock("@/chat/oauth-flow", () => ({
   formatProviderLabel,
 }));
 
+function plugin(name: string): PluginDefinition {
+  return {
+    dir: `/plugins/${name}`,
+    manifest: {
+      name,
+      displayName: name,
+      description: `${name} plugin`,
+      capabilities: [],
+      configKeys: [],
+    },
+  };
+}
+
 describe("createMcpAuthOrchestration", () => {
   beforeEach(() => {
     createMcpOAuthClientProvider.mockReset();
@@ -64,11 +78,7 @@ describe("createMcpAuthOrchestration", () => {
       abortAgent,
     );
 
-    await orchestration.authProviderFactory({
-      manifest: {
-        name: "github",
-      },
-    } as any);
+    await orchestration.authProviderFactory(plugin("github"));
 
     await expect(
       orchestration.onAuthorizationRequired("github"),
@@ -79,5 +89,62 @@ describe("createMcpAuthOrchestration", () => {
     expect(getMcpAuthSession).not.toHaveBeenCalled();
     expect(deliverPrivateMessage).not.toHaveBeenCalled();
     expect(abortAgent).not.toHaveBeenCalled();
+  });
+
+  it("sends a fresh link when the pending auth belongs to a previous session", async () => {
+    const abortAgent = vi.fn();
+    const onPendingAuth = vi.fn();
+    getMcpAuthSession.mockResolvedValue({
+      authorizationUrl: "https://mcp.example/authorize",
+      channelId: "C123",
+      threadTs: "1700000000.000000",
+      userId: "U123",
+    });
+    deliverPrivateMessage.mockResolvedValue({ channelId: "D123" });
+
+    const orchestration = createMcpAuthOrchestration(
+      {
+        conversationId: "slack:C123:1700000000.000000",
+        sessionId: "run_new",
+        requesterId: "U123",
+        channelId: "C123",
+        threadTs: "1700000000.000000",
+        userMessage: "use MCP",
+        currentPendingAuth: {
+          kind: "mcp",
+          provider: "github",
+          requesterId: "U123",
+          sessionId: "run_old",
+          linkSentAtMs: Date.now(),
+        },
+        getConfiguration: () => ({}),
+        getArtifactState: () => undefined,
+        getMergedArtifactState: () => ({}),
+        onPendingAuth,
+      },
+      abortAgent,
+    );
+
+    await orchestration.authProviderFactory(plugin("github"));
+
+    await expect(orchestration.onAuthorizationRequired("github")).resolves.toBe(
+      true,
+    );
+
+    expect(deliverPrivateMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "U123",
+      }),
+    );
+    expect(deleteMcpAuthSession).not.toHaveBeenCalled();
+    expect(onPendingAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "mcp",
+        provider: "github",
+        requesterId: "U123",
+        sessionId: "run_new",
+      }),
+    );
+    expect(abortAgent).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/junior/tests/unit/services/pending-auth.test.ts
+++ b/packages/junior/tests/unit/services/pending-auth.test.ts
@@ -17,7 +17,7 @@ function pendingAuth(
     kind: "mcp" as const,
     provider: "eval-auth",
     requesterId: "U123",
-    sessionId: "turn_1",
+    sessionId: "run_1",
     linkSentAtMs: NOW - 60_000,
     ...overrides,
   };
@@ -30,6 +30,7 @@ describe("canReusePendingAuthLink", () => {
         kind: "mcp",
         provider: "eval-auth",
         requesterId: "U123",
+        sessionId: "run_1",
         pendingAuth: pendingAuth({ linkSentAtMs: NOW - 60_000 }),
         nowMs: NOW,
       }),
@@ -42,6 +43,7 @@ describe("canReusePendingAuthLink", () => {
         kind: "mcp",
         provider: "eval-auth",
         requesterId: "U123",
+        sessionId: "run_1",
         pendingAuth: pendingAuth({
           linkSentAtMs: NOW - REUSE_WINDOW_MS + 1,
         }),
@@ -56,6 +58,7 @@ describe("canReusePendingAuthLink", () => {
         kind: "mcp",
         provider: "eval-auth",
         requesterId: "U123",
+        sessionId: "run_1",
         pendingAuth: pendingAuth({ linkSentAtMs: NOW - REUSE_WINDOW_MS }),
         nowMs: NOW,
       }),
@@ -68,6 +71,7 @@ describe("canReusePendingAuthLink", () => {
         kind: "mcp",
         provider: "eval-auth",
         requesterId: "U999",
+        sessionId: "run_1",
         pendingAuth: pendingAuth(),
         nowMs: NOW,
       }),
@@ -78,6 +82,7 @@ describe("canReusePendingAuthLink", () => {
         kind: "mcp",
         provider: "other-provider",
         requesterId: "U123",
+        sessionId: "run_1",
         pendingAuth: pendingAuth(),
         nowMs: NOW,
       }),
@@ -90,7 +95,21 @@ describe("canReusePendingAuthLink", () => {
         kind: "plugin",
         provider: "eval-auth",
         requesterId: "U123",
+        sessionId: "run_1",
         pendingAuth: pendingAuth({ kind: "mcp" }),
+        nowMs: NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not reuse a link from a different session", () => {
+    expect(
+      canReusePendingAuthLink({
+        kind: "mcp",
+        provider: "eval-auth",
+        requesterId: "U123",
+        sessionId: "run_2",
+        pendingAuth: pendingAuth(),
         nowMs: NOW,
       }),
     ).toBe(false);
@@ -102,6 +121,7 @@ describe("canReusePendingAuthLink", () => {
         kind: "mcp",
         provider: "eval-auth",
         requesterId: "U123",
+        sessionId: "run_1",
         nowMs: NOW,
       }),
     ).toBe(false);

--- a/packages/junior/tests/unit/services/plugin-auth-orchestration.test.ts
+++ b/packages/junior/tests/unit/services/plugin-auth-orchestration.test.ts
@@ -263,6 +263,52 @@ describe("createPluginAuthOrchestration", () => {
     expect(unlinkProvider).toHaveBeenCalledWith("U123", "github", tokens);
   });
 
+  it("sends a fresh link when the pending auth belongs to a previous session", async () => {
+    startOAuthFlow.mockResolvedValue({
+      ok: true,
+      delivery: { channelId: "D123" },
+    });
+    const onPendingAuth = vi.fn();
+
+    const orchestration = createPluginAuthOrchestration(
+      {
+        conversationId: "slack:C123:1700000000.000000",
+        sessionId: "run_new",
+        requesterId: "U123",
+        userMessage: "check Sentry",
+        userTokenStore: tokenStore(),
+        currentPendingAuth: {
+          kind: "plugin",
+          provider: "sentry",
+          requesterId: "U123",
+          sessionId: "run_old",
+          linkSentAtMs: Date.now(),
+        },
+        onPendingAuth,
+      },
+      vi.fn(),
+    );
+
+    await expect(
+      orchestration.maybeHandleAuthSignal({ auth_required: sentryAuthSignal }),
+    ).rejects.toBeInstanceOf(PluginAuthorizationPauseError);
+
+    expect(startOAuthFlow).toHaveBeenCalledWith(
+      "sentry",
+      expect.objectContaining({
+        resumeSessionId: "run_new",
+      }),
+    );
+    expect(onPendingAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "plugin",
+        provider: "sentry",
+        requesterId: "U123",
+        sessionId: "run_new",
+      }),
+    );
+  });
+
   it("throws PluginCredentialFailureError for signals without oauth authorization", async () => {
     // Installation-read grant has no authorization field — not user-OAuth-able.
     const orchestration = createPluginAuthOrchestration(

--- a/packages/junior/tests/unit/services/plugin-auth-orchestration.test.ts
+++ b/packages/junior/tests/unit/services/plugin-auth-orchestration.test.ts
@@ -86,14 +86,12 @@ describe("createPluginAuthOrchestration", () => {
     });
 
     const tokens = tokenStore();
-    const orchestration = createPluginAuthOrchestration(
-      {
-        requesterId: "U123",
-        userMessage: "check Sentry",
-        userTokenStore: tokens,
-      },
-      vi.fn(),
-    );
+    const orchestration = createPluginAuthOrchestration({
+      abortAgent: vi.fn(),
+      requesterId: "U123",
+      userMessage: "check Sentry",
+      userTokenStore: tokens,
+    });
 
     await expect(
       orchestration.maybeHandleAuthSignal({
@@ -122,14 +120,12 @@ describe("createPluginAuthOrchestration", () => {
     });
 
     const tokens = tokenStore();
-    const orchestration = createPluginAuthOrchestration(
-      {
-        requesterId: "U123",
-        userMessage: "check Sentry",
-        userTokenStore: tokens,
-      },
-      vi.fn(),
-    );
+    const orchestration = createPluginAuthOrchestration({
+      abortAgent: vi.fn(),
+      requesterId: "U123",
+      userMessage: "check Sentry",
+      userTokenStore: tokens,
+    });
 
     await expect(
       orchestration.maybeHandleAuthSignal({
@@ -145,15 +141,13 @@ describe("createPluginAuthOrchestration", () => {
 
   it("returns AuthorizationFlowDisabledError when flow is disabled", async () => {
     const abortAgent = vi.fn();
-    const orchestration = createPluginAuthOrchestration(
-      {
-        requesterId: "U123",
-        userMessage: "check Sentry",
-        userTokenStore: tokenStore(),
-        authorizationFlowMode: "disabled",
-      },
+    const orchestration = createPluginAuthOrchestration({
       abortAgent,
-    );
+      requesterId: "U123",
+      userMessage: "check Sentry",
+      userTokenStore: tokenStore(),
+      authorizationFlowMode: "disabled",
+    });
 
     await expect(
       orchestration.maybeHandleAuthSignal({ auth_required: sentryAuthSignal }),
@@ -164,13 +158,11 @@ describe("createPluginAuthOrchestration", () => {
   });
 
   it("returns AuthorizationFlowDisabledError when no requester and flow is disabled", async () => {
-    const orchestration = createPluginAuthOrchestration(
-      {
-        userMessage: "<scheduled-task-run />",
-        authorizationFlowMode: "disabled",
-      },
-      vi.fn(),
-    );
+    const orchestration = createPluginAuthOrchestration({
+      abortAgent: vi.fn(),
+      userMessage: "<scheduled-task-run />",
+      authorizationFlowMode: "disabled",
+    });
 
     await expect(
       orchestration.maybeHandleAuthSignal({ auth_required: sentryAuthSignal }),
@@ -192,14 +184,12 @@ describe("createPluginAuthOrchestration", () => {
       order.push("unlink");
     });
 
-    const orchestration = createPluginAuthOrchestration(
-      {
-        requesterId: "U123",
-        userMessage: "check Sentry",
-        userTokenStore: tokens,
-      },
+    const orchestration = createPluginAuthOrchestration({
       abortAgent,
-    );
+      requesterId: "U123",
+      userMessage: "check Sentry",
+      userTokenStore: tokens,
+    });
 
     await expect(
       orchestration.maybeHandleAuthSignal({ auth_required: sentryAuthSignal }),
@@ -210,17 +200,37 @@ describe("createPluginAuthOrchestration", () => {
     expect(abortAgent).toHaveBeenCalledTimes(1);
   });
 
+  it("fails before starting oauth when pending auth cannot be recorded", async () => {
+    const abortAgent = vi.fn();
+    const orchestration = createPluginAuthOrchestration({
+      abortAgent,
+      conversationId: "slack:C123:1700000000.000000",
+      sessionId: "run_new",
+      requesterId: "U123",
+      userMessage: "check Sentry",
+      userTokenStore: tokenStore(),
+    });
+
+    await expect(
+      orchestration.maybeHandleAuthSignal({ auth_required: sentryAuthSignal }),
+    ).rejects.toThrow(
+      'Missing pending auth recorder for plugin authorization pause "sentry"',
+    );
+
+    expect(startOAuthFlow).not.toHaveBeenCalled();
+    expect(unlinkProvider).not.toHaveBeenCalled();
+    expect(abortAgent).not.toHaveBeenCalled();
+  });
+
   it("keeps the stored token when oauth start fails", async () => {
     startOAuthFlow.mockResolvedValue({ ok: false, error: "Missing base URL" });
 
-    const orchestration = createPluginAuthOrchestration(
-      {
-        requesterId: "U123",
-        userMessage: "check Sentry",
-        userTokenStore: tokenStore(),
-      },
-      vi.fn(),
-    );
+    const orchestration = createPluginAuthOrchestration({
+      abortAgent: vi.fn(),
+      requesterId: "U123",
+      userMessage: "check Sentry",
+      userTokenStore: tokenStore(),
+    });
 
     await expect(
       orchestration.maybeHandleAuthSignal({ auth_required: sentryAuthSignal }),
@@ -236,14 +246,12 @@ describe("createPluginAuthOrchestration", () => {
     });
 
     const tokens = tokenStore();
-    const orchestration = createPluginAuthOrchestration(
-      {
-        requesterId: "U123",
-        userMessage: "push the branch",
-        userTokenStore: tokens,
-      },
-      vi.fn(),
-    );
+    const orchestration = createPluginAuthOrchestration({
+      abortAgent: vi.fn(),
+      requesterId: "U123",
+      userMessage: "push the branch",
+      userTokenStore: tokens,
+    });
 
     await expect(
       orchestration.maybeHandleAuthSignal({
@@ -268,26 +276,24 @@ describe("createPluginAuthOrchestration", () => {
       ok: true,
       delivery: { channelId: "D123" },
     });
-    const onPendingAuth = vi.fn();
+    const recordPendingAuth = vi.fn();
 
-    const orchestration = createPluginAuthOrchestration(
-      {
-        conversationId: "slack:C123:1700000000.000000",
-        sessionId: "run_new",
+    const orchestration = createPluginAuthOrchestration({
+      abortAgent: vi.fn(),
+      conversationId: "slack:C123:1700000000.000000",
+      sessionId: "run_new",
+      requesterId: "U123",
+      userMessage: "check Sentry",
+      userTokenStore: tokenStore(),
+      pendingAuth: {
+        kind: "plugin",
+        provider: "sentry",
         requesterId: "U123",
-        userMessage: "check Sentry",
-        userTokenStore: tokenStore(),
-        currentPendingAuth: {
-          kind: "plugin",
-          provider: "sentry",
-          requesterId: "U123",
-          sessionId: "run_old",
-          linkSentAtMs: Date.now(),
-        },
-        onPendingAuth,
+        sessionId: "run_old",
+        linkSentAtMs: Date.now(),
       },
-      vi.fn(),
-    );
+      recordPendingAuth,
+    });
 
     await expect(
       orchestration.maybeHandleAuthSignal({ auth_required: sentryAuthSignal }),
@@ -299,7 +305,7 @@ describe("createPluginAuthOrchestration", () => {
         resumeSessionId: "run_new",
       }),
     );
-    expect(onPendingAuth).toHaveBeenCalledWith(
+    expect(recordPendingAuth).toHaveBeenCalledWith(
       expect.objectContaining({
         kind: "plugin",
         provider: "sentry",
@@ -311,14 +317,12 @@ describe("createPluginAuthOrchestration", () => {
 
   it("throws PluginCredentialFailureError for signals without oauth authorization", async () => {
     // Installation-read grant has no authorization field — not user-OAuth-able.
-    const orchestration = createPluginAuthOrchestration(
-      {
-        requesterId: "U123",
-        userMessage: "inspect a repo",
-        userTokenStore: tokenStore(),
-      },
-      vi.fn(),
-    );
+    const orchestration = createPluginAuthOrchestration({
+      abortAgent: vi.fn(),
+      requesterId: "U123",
+      userMessage: "inspect a repo",
+      userTokenStore: tokenStore(),
+    });
 
     await expectPluginCredentialFailure(
       orchestration.maybeHandleAuthSignal({
@@ -340,14 +344,12 @@ describe("createPluginAuthOrchestration", () => {
   });
 
   it("preserves auth signal messages when no oauth authorization is available", async () => {
-    const orchestration = createPluginAuthOrchestration(
-      {
-        requesterId: "U123",
-        userMessage: "inspect a repo",
-        userTokenStore: tokenStore(),
-      },
-      vi.fn(),
-    );
+    const orchestration = createPluginAuthOrchestration({
+      abortAgent: vi.fn(),
+      requesterId: "U123",
+      userMessage: "inspect a repo",
+      userTokenStore: tokenStore(),
+    });
 
     await expectPluginCredentialFailure(
       orchestration.maybeHandleAuthSignal({
@@ -365,14 +367,12 @@ describe("createPluginAuthOrchestration", () => {
   });
 
   it("preserves unavailable auth signal messages without starting oauth", async () => {
-    const orchestration = createPluginAuthOrchestration(
-      {
-        requesterId: "U123",
-        userMessage: "inspect a repo",
-        userTokenStore: tokenStore(),
-      },
-      vi.fn(),
-    );
+    const orchestration = createPluginAuthOrchestration({
+      abortAgent: vi.fn(),
+      requesterId: "U123",
+      userMessage: "inspect a repo",
+      userTokenStore: tokenStore(),
+    });
 
     await expectPluginCredentialFailure(
       orchestration.maybeHandleAuthSignal({
@@ -391,13 +391,11 @@ describe("createPluginAuthOrchestration", () => {
   });
 
   it("preserves no-oauth auth signal messages when authorization flow is disabled", async () => {
-    const orchestration = createPluginAuthOrchestration(
-      {
-        userMessage: "<scheduled-task-run />",
-        authorizationFlowMode: "disabled",
-      },
-      vi.fn(),
-    );
+    const orchestration = createPluginAuthOrchestration({
+      abortAgent: vi.fn(),
+      userMessage: "<scheduled-task-run />",
+      authorizationFlowMode: "disabled",
+    });
 
     await expectPluginCredentialFailure(
       orchestration.maybeHandleAuthSignal({
@@ -415,14 +413,12 @@ describe("createPluginAuthOrchestration", () => {
   });
 
   it("no-ops when no auth_required field is in the result", async () => {
-    const orchestration = createPluginAuthOrchestration(
-      {
-        requesterId: "U123",
-        userMessage: "check GitHub",
-        userTokenStore: tokenStore(),
-      },
-      vi.fn(),
-    );
+    const orchestration = createPluginAuthOrchestration({
+      abortAgent: vi.fn(),
+      requesterId: "U123",
+      userMessage: "check GitHub",
+      userTokenStore: tokenStore(),
+    });
 
     // exit_code non-zero, auth-like text — but no structured signal
     await expect(
@@ -436,10 +432,10 @@ describe("createPluginAuthOrchestration", () => {
   });
 
   it("no-ops when result is empty", async () => {
-    const orchestration = createPluginAuthOrchestration(
-      { userMessage: "check Sentry" },
-      vi.fn(),
-    );
+    const orchestration = createPluginAuthOrchestration({
+      abortAgent: vi.fn(),
+      userMessage: "check Sentry",
+    });
 
     await expect(
       orchestration.maybeHandleAuthSignal({ exit_code: 0 }),
@@ -468,14 +464,12 @@ describe("createPluginAuthOrchestration", () => {
         },
       },
     ]) {
-      const orchestration = createPluginAuthOrchestration(
-        {
-          requesterId: "U123",
-          userMessage: "do something",
-          userTokenStore: tokenStore(),
-        },
-        vi.fn(),
-      );
+      const orchestration = createPluginAuthOrchestration({
+        abortAgent: vi.fn(),
+        requesterId: "U123",
+        userMessage: "do something",
+        userTokenStore: tokenStore(),
+      });
 
       await expect(
         orchestration.maybeHandleAuthSignal(input),

--- a/specs/index.md
+++ b/specs/index.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-03-03
-- Last Edited: 2026-06-10
+- Last Edited: 2026-06-12
 
 ## Purpose
 
@@ -31,6 +31,7 @@ Define spec taxonomy, naming conventions, and canonical source-of-truth document
 - `specs/security-policy.md`
 - `specs/data-redaction-policy.md`
 - `specs/chat-architecture.md`
+- `specs/terminology.md`
 - `specs/task-execution.md`
 - `specs/local-agent.md`
 - `specs/agent-turn-handling.md`
@@ -67,14 +68,15 @@ Define spec taxonomy, naming conventions, and canonical source-of-truth document
 
 ## Ownership Map
 
-For chat/agent/Slack turn behavior:
+For chat/agent/Slack execution and response behavior:
 
+- `specs/terminology.md` owns canonical execution vocabulary and historical `turn` naming rules.
 - `specs/chat-architecture.md` owns the end-to-end platform-event-to-agent-run data flow, platform adapter boundary, data authority map, and module boundaries.
 - `specs/task-execution.md` owns durable conversation mailbox execution, queue wake-up semantics, conversation leases, cooperative yield, and heartbeat repair.
 - `specs/local-agent.md` owns local CLI/local adapter user flows, identity, state, delivery, and verification contracts.
 - `specs/agent-turn-handling.md` owns user-message response policy: when Junior answers, stays silent, asks, uses tools, satisfies Slack side effects, handles resumed turns, and considers a turn complete.
 - `specs/agent-execution.md` owns coding-agent execution discipline and the repository-wide model-repairable tool failure contract.
-- `specs/harness-agent.md` owns the Pi agent turn runtime contract, final output resolution, and turn diagnostics.
+- `specs/harness-agent.md` owns the Pi agent run runtime contract, final output resolution, and diagnostics.
 - `specs/harness-tool-context.md` owns context-bound tool targeting and missing-context failure behavior.
 - `specs/agent-session-resumability.md` owns session record schema, Pi session continuation, timeout callbacks, and slice lifecycle.
 - `specs/context-compaction.md` owns reusable Pi history compaction, internal context forks, and visible-thread compaction bounds.

--- a/specs/oauth-flows.md
+++ b/specs/oauth-flows.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-03-03
-- Last Edited: 2026-05-19
+- Last Edited: 2026-06-12
 
 ## Related
 
@@ -18,16 +18,16 @@ Define how Junior handles per-user OAuth for third-party providers while keeping
 
 ### Components
 
-| Component                            | Role                                                                                                                                                                   |
-| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `startOAuthFlow(provider, ...)`      | Internal runtime helper that creates state and privately delivers the authorization link                                                                               |
-| `/api/oauth/callback/[provider]`     | Exchanges code for tokens, stores them server-side, and resumes the latest still-relevant blocked thread request                                                       |
-| `/api/oauth/callback/mcp/[provider]` | Completes MCP SDK authorization and resumes the latest still-relevant MCP-blocked thread request                                                                       |
-| `StateAdapterTokenStore`             | Persistent per-user token storage                                                                                                                                      |
-| MCP auth session store               | Stores MCP auth session context and SDK-managed OAuth state across the browser redirect                                                                                |
-| `OAuthBearerBroker`                  | Issues short-lived turn leases from stored user tokens                                                                                                                 |
-| Thread `pendingAuth` state           | Stores the current auth-blocked request for one Slack thread independently from `activeTurnId`                                                                         |
-| `PluginAuthOrchestration`            | Consumes structured egress credential signals, starts OAuth privately for OAuth-backed `auth_required` signals, and turns the current turn into a resumable auth block |
+| Component                            | Role                                                                                                                                                                      |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `startOAuthFlow(provider, ...)`      | Internal runtime helper that creates state and privately delivers the authorization link                                                                                  |
+| `/api/oauth/callback/[provider]`     | Exchanges code for tokens, stores them server-side, and resumes the latest still-relevant blocked thread request                                                          |
+| `/api/oauth/callback/mcp/[provider]` | Completes MCP SDK authorization and resumes the latest still-relevant MCP-blocked thread request                                                                          |
+| `StateAdapterTokenStore`             | Persistent per-user token storage                                                                                                                                         |
+| MCP auth session store               | Stores MCP auth session context and SDK-managed OAuth state across the browser redirect                                                                                   |
+| `OAuthBearerBroker`                  | Issues short-lived run-scoped leases from stored user tokens                                                                                                              |
+| Thread `pendingAuth` state           | Stores the current auth-blocked request for one Slack thread independently from `activeTurnId`                                                                            |
+| `PluginAuthOrchestration`            | Consumes structured egress credential signals, starts OAuth privately for OAuth-backed `auth_required` signals, and parks the current agent run as a resumable auth block |
 
 ### Why authorization code grant
 
@@ -56,12 +56,12 @@ Agent: loads the matching plugin skill and runs the real provider command
   │    • runtime privately delivers the authorization link
   │    • runtime posts a brief visible thread note that authorization is needed
   │    • runtime appends `authorization_requested` to the agent session log
-  │    • runtime writes the turn session record as awaiting auth resume
+  │    • runtime writes the historical turn-session record as awaiting auth resume
   │    • runtime records thread-local `pendingAuth`
   ├─ If credential setup is unavailable or no OAuth authorization metadata is present:
   │    • runtime surfaces the host-provided credential failure message
   │    • runtime does not start a user OAuth flow
-  └─ OAuth-paused turns end cleanly; they are not kept as the active in-flight turn
+  └─ OAuth-paused runs end cleanly; they are not kept as the active in-flight run
   │
   ▼
 User: opens private link and approves
@@ -93,9 +93,9 @@ Agent: calls an MCP tool from the same plugin
   ├─ Runtime privately delivers the authorization link to the requesting user
   ├─ Runtime posts a brief visible thread note that authorization is needed
   ├─ Runtime appends `authorization_requested` to the agent session log
-  ├─ Turn session record is written as awaiting auth resume
+  ├─ Historical turn-session record is written as awaiting auth resume
   ├─ Runtime records thread-local `pendingAuth`
-  └─ Current turn ends cleanly; it is not kept as the active in-flight turn
+  └─ Current run ends cleanly; it is not kept as the active in-flight run
   │
   ▼
 User: opens the private link and approves
@@ -134,15 +134,16 @@ Purpose:
 
 - binds the authorization link to the requesting user
 - carries enough context to resume the blocked Slack thread
-- snapshots configuration relevant to the resumed turn
+- snapshots configuration relevant to the resumed run
 
 ### Thread-local pending auth
 
 - Stored in persisted thread conversation state, not in `activeTurnId`
-- Value: `{ kind, provider, requesterId, sessionId, linkSentAtMs }`
+- Value: `{ kind, provider, requesterId, sessionId, scope?, linkSentAtMs }`
 - Purpose:
   - remembers which blocked request is eligible for auto-resume
-  - deduplicates repeated prompts while a fresh private link is already pending
+  - deduplicates repeated prompts only when `kind`, `provider`, `requesterId`,
+    `scope`, and `sessionId` all match a fresh already-sent private link
   - lets callbacks suppress stale resumes after newer thread activity
 - This state is callback routing and dedupe state only. It must not be rendered
   into the prompt as an auth-completion hint. Model-visible authorization

--- a/specs/task-execution.md
+++ b/specs/task-execution.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-06-01
-- Last Edited: 2026-06-11
+- Last Edited: 2026-06-12
 
 ## Purpose
 
@@ -43,7 +43,8 @@ invocations without turning every tool call into a queue round trip.
 
 ### Terminology
 
-The durable execution model uses these terms precisely:
+The durable execution model uses the canonical terms from
+[`terminology.md`](./terminology.md). In this spec:
 
 - **Conversation**: the thread-level or session-level container identified by
   `conversationId`. For Slack, this is a normalized thread identity such as

--- a/specs/terminology.md
+++ b/specs/terminology.md
@@ -1,0 +1,118 @@
+# Terminology Spec
+
+## Metadata
+
+- Created: 2026-06-12
+- Last Edited: 2026-06-12
+
+## Purpose
+
+Define Junior's canonical runtime terminology so specs, code comments, tests,
+and storage names use the same words for the same execution concepts.
+
+Agent frameworks use `turn` inconsistently. Some use it for one model
+invocation, some for one agent's speaking slot, and some avoid it in favor of
+run/thread concepts. Junior uses explicit execution nouns instead.
+
+## Scope
+
+- Runtime execution names used in specs and new code.
+- Conversation, source, destination, message, run, slice, and step boundaries.
+- Historical names that remain in existing APIs, storage keys, and telemetry.
+
+## Non-Goals
+
+- Renaming every existing `turn` identifier in one migration.
+- Defining product copy for user-facing Slack or local CLI messages.
+- Defining provider-specific terminology for OpenAI, LangGraph, AutoGen, Pi, or
+  other agent frameworks.
+
+## Contracts
+
+### Canonical Terms
+
+- **Conversation**: the thread-level or session-level container identified by
+  `conversationId`. Slack conversations usually map to one normalized thread.
+  Local CLI conversations map to one process-scoped local session.
+- **Source**: where an inbound event came from, such as Slack, local CLI,
+  scheduler, or plugin dispatch.
+- **Destination**: where Junior should send output or side effects.
+- **Inbound message**: one normalized source event that should be made
+  available to the agent.
+- **Agent input**: the batch of inbound message content, context, and runtime
+  metadata selected for an agent run.
+- **Agent run**: one response-producing execution for a conversation. A run may
+  consume multiple inbound messages at safe boundaries, call many tools, and
+  span multiple serverless invocations before final delivery.
+- **Execution slice**: one serverless invocation segment of an agent run.
+- **Agent step**: one model, tool, handoff, action, or other internal event
+  represented inside durable execution history.
+- **Session record**: the persisted read model for one resumable agent run.
+  Existing code may still call this a `turn session` for historical reasons.
+- **Conversation execution**: the mutable operational state for one
+  conversation, including mailbox state, worker lease, checkpoint timestamps,
+  and whether the conversation is idle or active.
+
+### `turn`
+
+Do not use `turn` for new agent-run concepts in specs, comments, test fixture
+ids, storage keys, or public interfaces.
+
+Allowed uses:
+
+- User-message response policy that is already named around turns, such as
+  `agent-turn-handling.md`, until that spec is intentionally renamed.
+- Historical identifiers such as `activeTurnId`, `turn-session`, turn-session
+  storage keys, and existing telemetry names.
+- External framework terminology when quoting or directly describing that
+  framework's API.
+
+When touching historical `turn` names, do not rename them opportunistically.
+Prefer comments that clarify the current meaning:
+
+> historical turn-session name; represents an agent-run session record
+
+### Naming Rules
+
+- Use `run` for response-producing execution.
+- Use `slice` for one resumable serverless invocation segment.
+- Use `step` for model/tool/action events inside a run.
+- Use `message` for source events and transcript entries.
+- Use `conversation` for the durable container that owns visible history and
+  execution state.
+- Use `sessionId` only where it already names the persisted agent-run session
+  key. New APIs should prefer `runId` or `sessionRecordId` when no historical
+  compatibility constraint exists.
+
+## Failure Model
+
+Ambiguous terminology is a design failure, not a runtime failure. Reviewers
+should block new specs or public interfaces that introduce `turn` for agent-run
+concepts unless the change is intentionally preserving a historical name.
+
+## Observability
+
+Existing telemetry names that include `turn` may remain for compatibility.
+New telemetry should prefer:
+
+- `app.ai.run_id`
+- `app.ai.execution_slice_id`
+- `app.ai.step_id`
+
+Use existing OpenTelemetry semantic keys where they apply before adding
+`app.*` keys.
+
+## Verification
+
+- New or edited specs must link to this spec when defining execution terms.
+- New tests should use fixture ids such as `run_1` instead of `turn_1` unless
+  the test targets a historical turn-named API.
+- Broad renames from historical `turn` names require targeted migration tests
+  for storage keys, telemetry, and callback routing.
+
+## Related Specs
+
+- `./task-execution.md`
+- `./agent-session-resumability.md`
+- `./agent-turn-handling.md`
+- `./identity.md`


### PR DESCRIPTION
Pending auth link reuse now requires the current agent-run session to match the stored pending auth record. This keeps the existing 10-minute duplicate-link guard inside one run, but a new inbound message creates a new session and receives a fresh private auth link instead of being suppressed by an older pending auth record.

This also adds a canonical terminology spec for Junior execution terms and updates the OAuth pending-auth contract to document the full dedupe key, including optional scope and sessionId. Historical names like activeTurnId and turn-session remain intentionally unchanged where they name existing APIs or storage.

Validation: targeted auth service tests, @sentry/junior typecheck, Prettier check for touched files, git diff --check, and a supplemental local chat smoke.

Fixes GH-597