### PR TITLE
build(vercel): Run Junior upgrade before scaffold builds

### DIFF
--- a/apps/example/vercel.json
+++ b/apps/example/vercel.json
@@ -1,4 +1,4 @@
 {
   "framework": "nitro",
-  "buildCommand": "pnpm build"
+  "buildCommand": "pnpm exec junior upgrade && pnpm build"
 }

--- a/packages/docs/src/content/docs/reference/api/functions/juniorVercelConfig.md
+++ b/packages/docs/src/content/docs/reference/api/functions/juniorVercelConfig.md
@@ -7,9 +7,12 @@ title: "juniorVercelConfig"
 
 > **juniorVercelConfig**(`options?`): `Record`\<`string`, `unknown`\>
 
-Defined in: [junior/src/vercel.ts:6](https://github.com/getsentry/junior/blob/main/packages/junior/src/vercel.ts#L6)
+Defined in: [junior/src/vercel.ts:11](https://github.com/getsentry/junior/blob/main/packages/junior/src/vercel.ts#L11)
 
 Return the root Vercel project config for scaffolded Junior apps.
+
+New apps run `junior upgrade` before `pnpm build`; older installs without
+Junior SQL configured can override `buildCommand` to keep their prior build.
 
 ## Parameters
 

--- a/packages/docs/src/content/docs/reference/api/interfaces/JuniorVercelConfigOptions.md
+++ b/packages/docs/src/content/docs/reference/api/interfaces/JuniorVercelConfigOptions.md
@@ -13,4 +13,6 @@ Defined in: [junior/src/vercel.ts:1](https://github.com/getsentry/junior/blob/ma
 
 > `optional` **buildCommand?**: `string` \| `null`
 
-Defined in: [junior/src/vercel.ts:2](https://github.com/getsentry/junior/blob/main/packages/junior/src/vercel.ts#L2)
+Defined in: [junior/src/vercel.ts:3](https://github.com/getsentry/junior/blob/main/packages/junior/src/vercel.ts#L3)
+
+Override the Vercel build command, or pass null to omit it.

--- a/packages/docs/src/content/docs/start-here/deploy-to-vercel.md
+++ b/packages/docs/src/content/docs/start-here/deploy-to-vercel.md
@@ -39,13 +39,13 @@ The scaffolded `package.json` includes the production build script:
 }
 ```
 
-If your app uses Junior's SQL database, set the Vercel build command to run upgrades before the normal build:
+New scaffolded apps run Junior upgrades before the normal build:
 
 ```bash
 pnpm exec junior upgrade && pnpm build
 ```
 
-Otherwise, keep the Vercel build command as `pnpm build`. `junior snapshot create` prepares sandbox runtime dependencies declared by enabled plugins before request handling starts. When included in the build command, `junior upgrade` applies schema and state migrations before the new deployment serves traffic.
+Keep that Vercel build command unless you have an older install without Junior's SQL database configured. `junior snapshot create` prepares sandbox runtime dependencies declared by enabled plugins before request handling starts. `junior upgrade` applies schema and state migrations before the new deployment serves traffic.
 
 ## Enable Junior's Nitro deployment module
 

--- a/packages/docs/src/content/docs/start-here/deploy-to-vercel.md
+++ b/packages/docs/src/content/docs/start-here/deploy-to-vercel.md
@@ -25,6 +25,23 @@ pnpm dlx vercel@latest link
 
 If your account requires a team scope, pass the same `--scope <team-slug>` value to Vercel commands.
 
+## Add Postgres storage
+
+New Junior installs expect a SQL database for upgrade migrations and reporting.
+After the project is linked, create one from the Vercel dashboard:
+
+1. Open the Vercel project.
+2. Select **Storage**.
+3. Select **Create Database**.
+4. Choose a Postgres provider such as **Neon**.
+5. Accept the default database settings and connect it to the project.
+
+Vercel Marketplace storage providers inject database credentials into the
+project environment. For Neon and other Postgres providers, confirm the project
+has a `DATABASE_URL` value before the first production deploy. Set
+`JUNIOR_DATABASE_URL` only when Junior should use a different database than the
+project default.
+
 ## Configure build command
 
 The scaffolded `package.json` includes the production build script:

--- a/packages/junior/src/vercel.ts
+++ b/packages/junior/src/vercel.ts
@@ -1,11 +1,18 @@
 export interface JuniorVercelConfigOptions {
+  /** Override the Vercel build command, or pass null to omit it. */
   buildCommand?: string | null;
 }
 
-/** Return the root Vercel project config for scaffolded Junior apps. */
+/** Return the root Vercel project config for scaffolded Junior apps.
+ *
+ * New apps run `junior upgrade` before `pnpm build`; older installs without
+ * Junior SQL configured can override `buildCommand` to keep their prior build.
+ */
 export function juniorVercelConfig(options: JuniorVercelConfigOptions = {}) {
   const buildCommand =
-    options.buildCommand === undefined ? "pnpm build" : options.buildCommand;
+    options.buildCommand === undefined
+      ? "pnpm exec junior upgrade && pnpm build"
+      : options.buildCommand;
 
   const config: Record<string, unknown> = {
     framework: "nitro",

--- a/packages/junior/tests/unit/cli/init-cli.test.ts
+++ b/packages/junior/tests/unit/cli/init-cli.test.ts
@@ -57,7 +57,9 @@ describe("init cli", () => {
       fs.readFileSync(path.join(target, "vercel.json"), "utf8"),
     );
     expect(vercelConfig.framework).toBe("nitro");
-    expect(vercelConfig.buildCommand).toBe("pnpm build");
+    expect(vercelConfig.buildCommand).toBe(
+      "pnpm exec junior upgrade && pnpm build",
+    );
     expect(vercelConfig.crons).toBeUndefined();
     expect(vercelConfig.functions).toBeUndefined();
 

--- a/packages/junior/tests/unit/vercel.test.ts
+++ b/packages/junior/tests/unit/vercel.test.ts
@@ -14,9 +14,18 @@ describe("juniorVercelConfig", () => {
     const config = juniorVercelConfig();
 
     expect(config.framework).toBe("nitro");
-    expect(config.buildCommand).toBe("pnpm build");
+    expect(config.buildCommand).toBe("pnpm exec junior upgrade && pnpm build");
     expect(config.crons).toBeUndefined();
     expect(config.functions).toBeUndefined();
+  });
+
+  it("allows apps to override the build command", () => {
+    const config = juniorVercelConfig({
+      buildCommand: "pnpm build",
+    });
+
+    expect(config.framework).toBe("nitro");
+    expect(config.buildCommand).toBe("pnpm build");
   });
 
   it("omits buildCommand when set to null", () => {


### PR DESCRIPTION
Scaffolded Vercel config now runs `pnpm exec junior upgrade && pnpm build` by default so new Junior installs apply migrations before the deployment serves traffic. The example app and deployment docs now match that default, while `juniorVercelConfig({ buildCommand })` still lets older installs keep a custom command or omit it.

The deploy guide also now walks operators through adding a Vercel Postgres store: open the project Storage tab, create a database, choose a provider such as Neon, accept the defaults, and confirm `DATABASE_URL` before the first production deploy.

The public helper JSDoc and generated API reference document the default and override path. Validated with `pnpm --filter @sentry/junior exec vitest run tests/unit/vercel.test.ts tests/unit/cli/init-cli.test.ts` and `pnpm docs:check`.
