### PR TITLE
fix(dashboard): Bundle react-is in browser client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,11 @@ jobs:
           cache: "pnpm"
 
       - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install --with-deps chromium
       - run: pnpm release:check
       - run: pnpm lint
       - run: pnpm test:ci
+      - run: pnpm test:e2e:dashboard
       - run: pnpm --filter @sentry/junior-example build
       - run: pnpm docs:check
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 .env
 .env.local
 coverage
+.playwright
 *.tsbuildinfo
 .vercel
 .env*.local

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "release:check": "node scripts/check-release-config.mjs",
     "start": "pnpm --filter @sentry/junior-example dev",
     "test": "pnpm --filter @sentry/junior build && pnpm --filter @sentry/junior-dashboard build && pnpm --filter @sentry/junior test && pnpm --filter @sentry/junior-dashboard test",
+    "test:e2e:dashboard": "pnpm --filter @sentry/junior-dashboard build && playwright test -c packages/junior-dashboard/playwright.config.ts",
     "test:watch": "pnpm --filter @sentry/junior test:watch",
     "evals": "pnpm --filter @sentry/junior-evals evals",
     "evals:record": "pnpm --filter @sentry/junior-evals evals:record",
@@ -56,6 +57,7 @@
     }
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@spotlightjs/spotlight": "4.11.6",
     "agent-browser": "^0.27.0",
     "lint-staged": "^17.0.5",

--- a/packages/junior-dashboard/e2e/dashboard.spec.ts
+++ b/packages/junior-dashboard/e2e/dashboard.spec.ts
@@ -1,0 +1,181 @@
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import type { AddressInfo } from "node:net";
+import { Readable } from "node:stream";
+import { expect, test } from "@playwright/test";
+import type { JuniorReporting } from "@sentry/junior/reporting";
+import { createDashboardApp } from "../dist/app.js";
+
+let server: ReturnType<typeof createServer> | undefined;
+let baseURL = "http://127.0.0.1";
+
+function reporting(): JuniorReporting {
+  return {
+    async getHealth() {
+      return {
+        service: "junior",
+        status: "ok",
+        timestamp: "2026-06-12T00:00:00.000Z",
+      };
+    },
+    async getRuntimeInfo() {
+      return {
+        cwd: "/workspace",
+        descriptionText: "Dashboard e2e",
+        homeDir: "/workspace",
+        packagedContent: {
+          manifestRoots: [],
+          packageNames: [],
+          packages: [],
+          skillRoots: [],
+          tracingIncludes: [],
+        },
+        providers: ["github"],
+        skills: [],
+      };
+    },
+    async getPlugins() {
+      return [{ name: "github" }];
+    },
+    async getSkills() {
+      return [];
+    },
+    async getSessions() {
+      return {
+        generatedAt: "2026-06-12T00:00:00.000Z",
+        sessions: [],
+        source: "conversation_index",
+      };
+    },
+    async getConversationStats() {
+      return {
+        active: 0,
+        conversations: 0,
+        durationMs: 0,
+        failed: 0,
+        generatedAt: "2026-06-12T00:00:00.000Z",
+        hung: 0,
+        locations: [],
+        requesters: [],
+        runs: 0,
+        sampleLimit: 0,
+        sampleSize: 0,
+        source: "conversation_index",
+        truncated: false,
+        windowEnd: "2026-06-12T00:00:00.000Z",
+        windowStart: "2026-06-05T00:00:00.000Z",
+      };
+    },
+    async getPluginOperationalReports() {
+      return {
+        generatedAt: "2026-06-12T00:00:00.000Z",
+        reports: [],
+        source: "plugins",
+      };
+    },
+    async getConversation(conversationId) {
+      return {
+        generatedAt: "2026-06-12T00:00:00.000Z",
+        id: conversationId,
+        runs: [],
+        transcript: [],
+        transcriptAvailable: true,
+      };
+    },
+  };
+}
+
+function requestFromNode(req: IncomingMessage): Request {
+  const url = new URL(req.url ?? "/", baseURL);
+  const headers = new Headers();
+  for (const [name, value] of Object.entries(req.headers)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        headers.append(name, item);
+      }
+    } else if (value !== undefined) {
+      headers.set(name, value);
+    }
+  }
+
+  const method = req.method ?? "GET";
+  return new Request(url, {
+    body:
+      method === "GET" || method === "HEAD"
+        ? undefined
+        : (Readable.toWeb(req) as BodyInit),
+    duplex: method === "GET" || method === "HEAD" ? undefined : "half",
+    headers,
+    method,
+  });
+}
+
+async function writeResponse(res: ServerResponse, response: Response) {
+  res.statusCode = response.status;
+  response.headers.forEach((value, name) => {
+    res.setHeader(name, value);
+  });
+  res.end(Buffer.from(await response.arrayBuffer()));
+}
+
+test.beforeAll(async () => {
+  const app = createDashboardApp({
+    authRequired: false,
+    mockConversations: true,
+    reporting: reporting(),
+  });
+
+  server = createServer((req, res) => {
+    void app
+      .fetch(requestFromNode(req))
+      .then((response) => writeResponse(res, response))
+      .catch((error) => {
+        res.statusCode = 500;
+        res.end(error instanceof Error ? error.stack : String(error));
+      });
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address() as AddressInfo;
+      baseURL = `http://127.0.0.1:${address.port}`;
+      resolve();
+    });
+  });
+});
+
+test.afterAll(async () => {
+  if (!server) {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+test("hydrates the built dashboard client in a real browser", async ({
+  page,
+}) => {
+  const browserErrors: string[] = [];
+  page.on("pageerror", (error) => {
+    browserErrors.push(error.stack ?? error.message);
+  });
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      browserErrors.push(message.text());
+    }
+  });
+
+  await page.goto(baseURL);
+
+  await expect(page.getByRole("heading", { name: "Junior" })).toBeVisible();
+  await expect(page.getByText("Latest Conversations")).toBeVisible();
+  await expect(
+    page.getByLabel("conversations by duration over the last 7 days"),
+  ).toBeVisible();
+  expect(browserErrors).toEqual([]);
+});

--- a/packages/junior-dashboard/playwright.config.ts
+++ b/packages/junior-dashboard/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  outputDir: "../../.playwright/junior-dashboard",
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [["github"], ["list"]] : "list",
+  use: {
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/packages/junior-dashboard/tsup.client.config.ts
+++ b/packages/junior-dashboard/tsup.client.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
     "lucide-react",
     "react",
     "react-dom",
+    "react-is",
     "react-router",
     "recharts",
     "shiki",

--- a/packages/junior-dashboard/vitest.config.ts
+++ b/packages/junior-dashboard/vitest.config.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
@@ -22,6 +22,7 @@ export default defineConfig({
     ],
   },
   test: {
+    exclude: [...configDefaults.exclude, "e2e/**"],
     coverage: {
       provider: "v8",
       reporter: ["json", "lcov"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ overrides:
 importers:
   .:
     devDependencies:
+      "@playwright/test":
+        specifier: ^1.60.0
+        version: 1.60.0
       "@spotlightjs/spotlight":
         specifier: 4.11.6
         version: 4.11.6
@@ -3206,6 +3209,14 @@ packages:
         integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==,
       }
     engines: { node: ">= 10.0.0" }
+
+  "@playwright/test@1.60.0":
+    resolution:
+      {
+        integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
 
   "@prisma/instrumentation@7.6.0":
     resolution:
@@ -6910,6 +6921,14 @@ packages:
       }
     engines: { node: ">=14.14" }
 
+  fsevents@2.3.2:
+    resolution:
+      {
+        integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==,
+      }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution:
       {
@@ -9323,6 +9342,22 @@ packages:
       {
         integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==,
       }
+
+  playwright-core@1.60.0:
+    resolution:
+      {
+        integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution:
+      {
+        integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
 
   postcss-load-config@6.0.1:
     resolution:
@@ -13529,6 +13564,10 @@ snapshots:
       "@parcel/watcher-win32-ia32": 2.5.6
       "@parcel/watcher-win32-x64": 2.5.6
 
+  "@playwright/test@1.60.0":
+    dependencies:
+      playwright: 1.60.0
+
   "@prisma/instrumentation@7.6.0(@opentelemetry/api@1.9.1)":
     dependencies:
       "@opentelemetry/api": 1.9.1
@@ -16168,6 +16207,9 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -17996,6 +18038,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.2
       pathe: 2.0.3
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-load-config@6.0.1(tsx@4.22.3):
     dependencies:


### PR DESCRIPTION
The dashboard client now bundles react-is with the rest of the browser-only React dependencies so Recharts cannot emit a bare module specifier that Chromium cannot resolve in production.

This also adds a Playwright smoke test that builds the dashboard package, serves the built dashboard app, opens it in Chromium, fails on browser errors, and waits for the Recharts-backed command center to hydrate. CI now installs Chromium and runs that e2e check, while the dashboard Vitest config excludes the Playwright e2e directory so coverage and browser tests remain separate.

Validated with `pnpm --store-dir /Users/dcramer/Library/pnpm/store/v10 install --frozen-lockfile`, `pnpm --filter @sentry/junior-dashboard typecheck`, `pnpm --filter @sentry/junior-dashboard test:coverage`, `pnpm test:e2e:dashboard`, and `pnpm --filter @sentry/junior-dashboard exec vitest run tests/dashboard-routes.test.ts tests/dashboard-output.test.ts`. I also verified the Playwright smoke fails when the react-is bundling fix is temporarily removed.