### PR TITLE
docs(self-update): Review Vercel config additions

### DIFF
--- a/packages/junior-maintenance/skills/self-update/SKILL.md
+++ b/packages/junior-maintenance/skills/self-update/SKILL.md
@@ -14,11 +14,11 @@ git branch --show-current
 
 Stop if `package.json`, `pnpm-lock.yaml`, or `pnpm-workspace.yaml` has unrelated uncommitted changes.
 
-### 2. Inventory deps
+### 2. Inventory and target
 
-Collect direct Junior deps from `package.json` — `@sentry/junior` and names starting with `@sentry/junior-`. Record each package's name, current version, and dependency section (`dependencies` / `devDependencies` / `optionalDependencies`). All must be pinned to the same exact version. Do not move packages between sections.
+Inventory direct Junior deps from `package.json`: `@sentry/junior` and `@sentry/junior-*`. Record package, current exact version, and dependency section. Keep all Junior deps on one version and do not move packages between sections.
 
-### 3. Resolve target
+Resolve the target:
 
 ```bash
 pnpm view @sentry/junior dist-tags.latest
@@ -34,36 +34,19 @@ pnpm view <package>@<target> version
 
 Stop if any package lacks the target on npm.
 
-### 3b. Build Junior release context
+### 3. Build release context
 
-Junior does not publish GitHub releases, git tags, or a CHANGELOG. Build a best-effort release summary to guide the update and populate the PR body.
+Junior does not publish GitHub releases, tags, or a changelog. Use npm publish timestamps to summarize merged PRs between `old_version` and `target_version`:
 
-1. Note `old_version` (current `@sentry/junior` from step 2) and `target_version` (from step 3).
+```bash
+pnpm view @sentry/junior time --json
+gh pr list --repo getsentry/junior --state merged \
+  --search "merged:>=<old_published_at> merged:<=<target_published_at>" \
+  --limit 100 \
+  --json number,title,url,mergedAt
+```
 
-2. Fetch npm publish timestamps:
-
-   ```bash
-   pnpm view @sentry/junior time --json
-   ```
-
-   Extract `old_published_at` and `target_published_at` from the result.
-
-3. Query merged PRs in `getsentry/junior` between those timestamps:
-
-   ```bash
-   gh pr list --repo getsentry/junior --state merged \
-     --search "merged:>=<old_published_at> merged:<=<target_published_at>" \
-     --limit 100 \
-     --json number,title,url,mergedAt
-   ```
-
-4. Classify the results:
-   - **Breaking:** PR titles matching `^[a-z]+([^)]*)!:` (conventional-commit `!` marker), or body containing `BREAKING CHANGE`.
-   - **Config-relevant:** titles/scopes mentioning `config`, `plugins`, `nitro`, `createApp`, `runtime`, `credentials`, `egress`, or `example`.
-
-5. Save a compact summary — total PR count, breaking PRs (title + URL), config-relevant PRs — for the PR body. Do not list every fix/chore PR.
-
-6. If breaking PRs are found, flag the update as needing manual review in the PR body and keep the PR draft. Do **not** abort the update — proceed and let checks and the config comparison (step 6c) surface concrete issues.
+Save total PR count, breaking PRs (`!` or `BREAKING CHANGE`), and config-relevant PRs (`config`, `plugins`, `nitro`, `createApp`, `runtime`, `credentials`, `egress`, `example`). If any breaking PR exists, keep the PR draft and call out manual review, but continue the update.
 
 ### 4. Create or reuse branch
 
@@ -77,154 +60,55 @@ If `pnpm-workspace.yaml` has a `minimumReleaseAgeExclude` list, ensure every Jun
 
 Group `pnpm add` by dependency section:
 
-| Section                | Flag    |
-| ---------------------- | ------- |
-| `dependencies`         | `-E`    |
-| `devDependencies`      | `-D -E` |
-| `optionalDependencies` | `-O -E` |
-
 ```bash
 pnpm add -E <deps-packages>@<target> ...
-pnpm add -D -E <devDeps-packages>@<target> ...   # if any
-pnpm add -O -E <optDeps-packages>@<target> ...    # if any
+pnpm add -D -E <devDeps-packages>@<target> ...
+pnpm add -O -E <optDeps-packages>@<target> ...
 ```
 
 Do not manually edit versions in `package.json`. Do not use local `../junior` linking scripts.
 
-### 6b. Sync `nitro.config.ts` plugin packages
+### 7. Sync local config
 
-After updating deps, check whether any **new** `@sentry/junior-*` packages were added (i.e. present in the new `package.json` but absent before the update). For each newly added package, ensure it is also listed in the `plugins.packages` array inside `juniorNitro({...})` in `nitro.config.ts`.
-
-**Packages that are NOT standalone plugins and do NOT need a `plugins.packages` entry:**
-
-- `@sentry/junior` (the base runtime)
-- `@sentry/junior-plugin-api` (plugin development utilities)
-- `@sentry/junior-testing` (test utilities)
-
-For every other newly added `@sentry/junior-*` package, add it to `nitro.config.ts` if missing:
-
-```typescript
-// nitro.config.ts — append the new package to plugins.packages
-juniorNitro({
-  plugins: {
-    packages: [
-      // ... existing entries ...
-      "@sentry/junior-<new-package>", // ← add here
-    ],
-  },
-});
-```
-
-Verify by running:
+If a new standalone `@sentry/junior-*` plugin package was added, list it in `juniorNitro({ plugins.packages })`. Exclude the base/runtime utility packages: `@sentry/junior`, `@sentry/junior-plugin-api`, `@sentry/junior-testing`.
 
 ```bash
 node scripts/check-plugin-packages.mjs
 ```
 
-This must exit 0 before proceeding. If it fails, fix `nitro.config.ts` and rerun.
-
-### 6c. Compare consumer config against the Junior example app
-
-After updating deps, compare this app's configuration files against `apps/example/` in `getsentry/junior` for the target version. Goal: catch config-shape drift before checks run.
-
-1. Clone `getsentry/junior` into a temp directory (skip if already present from a prior run):
-
-   ```bash
-   git clone --filter=blob:none --depth=200 https://github.com/getsentry/junior.git /tmp/junior-upstream
-   cd /tmp/junior-upstream
-   ```
-
-2. Select the best source ref for `target_version` and record it as `target_ref`:
-
-   First try to find the version-bump commit:
-
-   ```bash
-   git log --oneline -S'"version": "<target_version>"' -- packages/junior/package.json
-   ```
-
-   If found, record that commit as `target_ref` and check it out.
-
-   If not found, find the commit just before the npm publish timestamp:
-
-   ```bash
-   git rev-list -n 1 --before="<target_published_at>" origin/main
-   ```
-
-   If found, record that commit as `target_ref` and check it out.
-
-   If neither works, record `origin/main` as `target_ref`, check it out, and mark the comparison as approximate in the PR body.
-
-3. Run focused diffs between example app and consumer app for TypeScript config surfaces:
-
-   ```bash
-   git diff --no-index -- /tmp/junior-upstream/apps/example/nitro.config.ts nitro.config.ts
-   git diff --no-index -- /tmp/junior-upstream/apps/example/plugins.ts plugins.ts
-   git diff --no-index -- /tmp/junior-upstream/apps/example/server.ts server.ts
-   ```
-
-4. Interpret the TypeScript config diffs structurally. Look for changes in:
-   - `juniorNitro()` option shape (new/removed/renamed options)
-   - `defineJuniorPlugins([...])` usage or call convention
-   - Plugin factory call signatures (e.g. `githubPlugin({ ... })`)
-   - `createApp({ ... })` option keys
-   - Required support devDeps (`nitro`, `jiti`, `typescript`)
-
-   **Ignore** app-local differences: env var names, local plugin/skill registrations, custom config defaults, SOUL/WORLD content, Slack personality settings.
-
-5. Inspect `vercel.json` for newly required Junior deployment config. Do not normalize the consumer app's whole Vercel config against the example app.
-
-   If possible, resolve an upstream example-app source ref for `old_version` using the same version-bump commit or publish-timestamp strategy from step 2. Compare upstream `apps/example/vercel.json` between `old_version` and `target_version`:
-
-   ```bash
-   git diff <old_ref>..<target_ref> -- apps/example/vercel.json
-   ```
-
-   If `old_ref` cannot be found, inspect the target example app's `apps/example/vercel.json` directly only as supporting context for release-window PRs or docs that explicitly identify a new Junior deployment requirement. Do not treat target-only entries as newly required just because they exist in the example app. Mark the `vercel.json` review as approximate in the PR body and add a manual review item when no diff-backed or release-window-backed requirement can be proven.
-
-   Identify entries added or changed upstream by the diff, or explicitly documented in release-window PRs or docs, that are Junior-owned deployment requirements. Check especially:
-   - `buildCommand` / `installCommand` changes such as adding `pnpm exec junior upgrade`
-   - `framework` requirements
-   - Junior queue or function wiring
-   - Junior heartbeat or scheduler cron wiring
-   - other entries that release-window PRs or docs describe as required for Junior runtime behavior
-
-   Compare only those Junior-owned entries against the consumer app's `vercel.json`. Ignore app-local deployment choices: env vars, regions, unrelated rewrites/headers, non-Junior functions, non-Junior crons, and project-specific build customization.
-
-   Apply an entry automatically only when it is clearly required, absent locally, and can be added or minimally merged without overwriting app-owned config. Otherwise, add a PR-body action item explaining the missing or changed entry.
-
-6. Apply only obvious, low-risk fixes automatically — e.g. updating a renamed option key, adding a required new argument when the value is inferrable, or adding a missing Junior-owned `vercel.json` entry. For everything else, add a PR-body action item.
-
-7. For `package.json`, compare only the build tooling (`nitro`, `jiti`, `typescript`) — do not copy the example's plugin dep list or version pins.
-
-8. Save findings and any actions taken for the PR body. Include a distinct `vercel.json` note that says whether new Junior-owned deployment entries were found, added, skipped as app-owned, or left for manual review.
-
-### 7. Verify lockfile correctness
-
-1. Check changed files:
-
-   ```bash
-   git diff --name-only
-   ```
-
-   Expected: `package.json`, `pnpm-lock.yaml`, optionally `pnpm-workspace.yaml`, optionally `nitro.config.ts` if plugin registration changed in step 6b, and optionally `vercel.json` if step 6c added or adjusted Junior-owned deployment config. Flag anything else.
-
-2. Confirm every Junior dep in `package.json` shows exact `<target>` — no old versions remain.
-
-3. Prove lockfile agrees with package.json:
-   ```bash
-   pnpm install --frozen-lockfile
-   ```
-   If this fails, repair with `pnpm install --lockfile-only` then rerun. Stop if still broken.
-
-### 8. Run checks
+Compare the consumer config with `apps/example` at `target_ref` to catch shape drift. Choose `target_ref` from the version bump commit, then the publish timestamp, then `origin/main` as approximate:
 
 ```bash
+git clone --filter=blob:none --depth=200 https://github.com/getsentry/junior.git /tmp/junior-upstream
+git -C /tmp/junior-upstream log --oneline -S'"version": "<target_version>"' -- packages/junior/package.json
+git -C /tmp/junior-upstream rev-list -n 1 --before="<target_published_at>" origin/main
+git -C /tmp/junior-upstream checkout <target_ref>
+git diff --no-index -- /tmp/junior-upstream/apps/example/nitro.config.ts nitro.config.ts
+git diff --no-index -- /tmp/junior-upstream/apps/example/plugins.ts plugins.ts
+git diff --no-index -- /tmp/junior-upstream/apps/example/server.ts server.ts
+```
+
+Ignore app-local values. Apply only obvious low-risk fixes; put ambiguous drift in the PR body. For `package.json`, compare only build tooling (`nitro`, `jiti`, `typescript`), not plugin dependency lists or pins.
+
+For `vercel.json`, do not normalize the whole file against the example. Use upstream diff-backed changes when possible:
+
+```bash
+git -C /tmp/junior-upstream diff <old_ref>..<target_ref> -- apps/example/vercel.json
+```
+
+Only act on Junior-owned deployment requirements proven by that diff or by release-window PRs/docs. If `old_ref` is unavailable, target-only example entries are context, not proof; mark the review approximate and leave a manual review item when needed.
+
+### 8. Verify
+
+```bash
+git diff --name-only
+pnpm install --frozen-lockfile
 pnpm check
 pnpm typecheck
 pnpm build
 ```
 
-Classify failures: update-related → fix before PR; pre-existing or environment → capture in PR and disclose. Do not silently skip failed checks.
+Expected changed files: `package.json`, `pnpm-lock.yaml`, optional `pnpm-workspace.yaml`, optional `nitro.config.ts`, optional `vercel.json`. Confirm every Junior dep is exactly `<target>`. If the frozen install fails, repair with `pnpm install --lockfile-only` and rerun. Fix update-related check failures; disclose pre-existing or environment failures.
 
 ### 9. Commit
 
@@ -238,22 +122,12 @@ Mention `minimumReleaseAgeExclude` sync if `pnpm-workspace.yaml` changed.
 
 ### 10. Push and open/update draft PR
 
-PR body sections (in order):
-
-1. **Version change** — old → new, package list with sections.
-2. **Junior release window** — total PR count, breaking PRs (title + URL), config-relevant PRs. Sourced from step 3b. Include the disclaimer: _Junior does not publish GitHub releases, tags, or a changelog. This summary is derived from npm publish timestamps and merged PRs._
-3. **Example app config comparison** — source ref used (commit SHA or approximate), files compared, findings, actions taken, and the `vercel.json` Junior-owned deployment-entry review. Sourced from step 6c.
-4. **`minimumReleaseAgeExclude` changes** (if any).
-5. **`nitro.config.ts` plugin registration changes** (if any).
-6. **Check results** — pass/fail per check, pre-existing failures noted.
-7. **Unexpected diffs** — any changed files beyond `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `nitro.config.ts`, and `vercel.json`.
-
-If breaking PRs were found in step 3b, or config comparison found unresolved drift, or checks failed — keep the PR as draft and add a "Manual review required" section at the top summarizing blockers.
+Open a draft PR. Include version change, release-window summary with the no-changelog disclaimer, config comparison findings, optional workspace/plugin/vercel changes, check results, and unexpected diffs. Add **Manual review required** when breaking PRs, unresolved config drift, approximate Vercel review, or failed checks exist.
 
 ## Stop conditions
 
 - Any Junior package lacks the target version on npm.
 - `pnpm install --frozen-lockfile` fails after repair.
-- Checks fail for non-pre-existing, non-environment reasons and no safe config fix is available from step 6c.
+- Checks fail for non-pre-existing, non-environment reasons and no safe config fix is available from step 7.
 - `package.json` changed but `pnpm-lock.yaml` did not.
 - Example app comparison reveals a breaking plugin signature change whose required values cannot be inferred from the existing consumer config.

--- a/packages/junior-maintenance/skills/self-update/SKILL.md
+++ b/packages/junior-maintenance/skills/self-update/SKILL.md
@@ -77,10 +77,10 @@ If `pnpm-workspace.yaml` has a `minimumReleaseAgeExclude` list, ensure every Jun
 
 Group `pnpm add` by dependency section:
 
-| Section | Flag |
-|---------|------|
-| `dependencies` | `-E` |
-| `devDependencies` | `-D -E` |
+| Section                | Flag    |
+| ---------------------- | ------- |
+| `dependencies`         | `-E`    |
+| `devDependencies`      | `-D -E` |
 | `optionalDependencies` | `-O -E` |
 
 ```bash
@@ -96,6 +96,7 @@ Do not manually edit versions in `package.json`. Do not use local `../junior` li
 After updating deps, check whether any **new** `@sentry/junior-*` packages were added (i.e. present in the new `package.json` but absent before the update). For each newly added package, ensure it is also listed in the `plugins.packages` array inside `juniorNitro({...})` in `nitro.config.ts`.
 
 **Packages that are NOT standalone plugins and do NOT need a `plugins.packages` entry:**
+
 - `@sentry/junior` (the base runtime)
 - `@sentry/junior-plugin-api` (plugin development utilities)
 - `@sentry/junior-testing` (test utilities)
@@ -105,11 +106,13 @@ For every other newly added `@sentry/junior-*` package, add it to `nitro.config.
 ```typescript
 // nitro.config.ts — append the new package to plugins.packages
 juniorNitro({
-  plugins: { packages: [
-    // ... existing entries ...
-    "@sentry/junior-<new-package>",  // ← add here
-  ] },
-})
+  plugins: {
+    packages: [
+      // ... existing entries ...
+      "@sentry/junior-<new-package>", // ← add here
+    ],
+  },
+});
 ```
 
 Verify by running:
@@ -131,23 +134,27 @@ After updating deps, compare this app's configuration files against `apps/exampl
    cd /tmp/junior-upstream
    ```
 
-2. Select the best source ref for `target_version`:
+2. Select the best source ref for `target_version` and record it as `target_ref`:
 
-   a. Try to find the version-bump commit:
-      ```bash
-      git log --oneline -S'"version": "<target_version>"' -- packages/junior/package.json
-      ```
-      If found, check out that commit.
+   First try to find the version-bump commit:
 
-   b. If not found, find the commit just before the npm publish timestamp:
-      ```bash
-      git rev-list -n 1 --before="<target_published_at>" origin/main
-      ```
-      If found, check out that commit.
+   ```bash
+   git log --oneline -S'"version": "<target_version>"' -- packages/junior/package.json
+   ```
 
-   c. If neither works, use `origin/main` — mark the comparison as approximate in the PR body.
+   If found, record that commit as `target_ref` and check it out.
 
-3. Run focused diffs between example app and consumer app:
+   If not found, find the commit just before the npm publish timestamp:
+
+   ```bash
+   git rev-list -n 1 --before="<target_published_at>" origin/main
+   ```
+
+   If found, record that commit as `target_ref` and check it out.
+
+   If neither works, record `origin/main` as `target_ref`, check it out, and mark the comparison as approximate in the PR body.
+
+3. Run focused diffs between example app and consumer app for TypeScript config surfaces:
 
    ```bash
    git diff --no-index -- /tmp/junior-upstream/apps/example/nitro.config.ts nitro.config.ts
@@ -155,7 +162,7 @@ After updating deps, compare this app's configuration files against `apps/exampl
    git diff --no-index -- /tmp/junior-upstream/apps/example/server.ts server.ts
    ```
 
-4. Interpret the diffs structurally. Look for changes in:
+4. Interpret the TypeScript config diffs structurally. Look for changes in:
    - `juniorNitro()` option shape (new/removed/renamed options)
    - `defineJuniorPlugins([...])` usage or call convention
    - Plugin factory call signatures (e.g. `githubPlugin({ ... })`)
@@ -164,19 +171,42 @@ After updating deps, compare this app's configuration files against `apps/exampl
 
    **Ignore** app-local differences: env var names, local plugin/skill registrations, custom config defaults, SOUL/WORLD content, Slack personality settings.
 
-5. Apply only obvious, low-risk fixes automatically — e.g. updating a renamed option key or adding a required new argument when the value is inferrable. For everything else, add a PR-body action item.
+5. Inspect `vercel.json` for newly required Junior deployment config. Do not normalize the consumer app's whole Vercel config against the example app.
 
-6. For `package.json`, compare only the build tooling (`nitro`, `jiti`, `typescript`) — do not copy the example's plugin dep list or version pins.
+   If possible, resolve an upstream example-app source ref for `old_version` using the same version-bump commit or publish-timestamp strategy from step 2. Compare upstream `apps/example/vercel.json` between `old_version` and `target_version`:
 
-7. Save findings and any actions taken for the PR body.
+   ```bash
+   git diff <old_ref>..<target_ref> -- apps/example/vercel.json
+   ```
+
+   If `old_ref` cannot be found, inspect the target example app's `apps/example/vercel.json` directly and mark the `vercel.json` review as approximate in the PR body.
+
+   Identify entries added or changed upstream that are Junior-owned or Junior-documented deployment requirements. Check especially:
+   - `buildCommand` / `installCommand` changes such as adding `pnpm exec junior upgrade`
+   - `framework` requirements
+   - Junior queue or function wiring
+   - Junior heartbeat or scheduler cron wiring
+   - other entries that release-window PRs or docs describe as required for Junior runtime behavior
+
+   Compare only those Junior-owned entries against the consumer app's `vercel.json`. Ignore app-local deployment choices: env vars, regions, unrelated rewrites/headers, non-Junior functions, non-Junior crons, and project-specific build customization.
+
+   Apply an entry automatically only when it is clearly required, absent locally, and can be added or minimally merged without overwriting app-owned config. Otherwise, add a PR-body action item explaining the missing or changed entry.
+
+6. Apply only obvious, low-risk fixes automatically — e.g. updating a renamed option key, adding a required new argument when the value is inferrable, or adding a missing Junior-owned `vercel.json` entry. For everything else, add a PR-body action item.
+
+7. For `package.json`, compare only the build tooling (`nitro`, `jiti`, `typescript`) — do not copy the example's plugin dep list or version pins.
+
+8. Save findings and any actions taken for the PR body. Include a distinct `vercel.json` note that says whether new Junior-owned deployment entries were found, added, skipped as app-owned, or left for manual review.
 
 ### 7. Verify lockfile correctness
 
 1. Check changed files:
+
    ```bash
    git diff --name-only
    ```
-   Expected: `package.json`, `pnpm-lock.yaml`, optionally `pnpm-workspace.yaml`, and optionally `nitro.config.ts` if plugin registration changed in step 6b. Flag anything else.
+
+   Expected: `package.json`, `pnpm-lock.yaml`, optionally `pnpm-workspace.yaml`, optionally `nitro.config.ts` if plugin registration changed in step 6b, and optionally `vercel.json` if step 6c added or adjusted Junior-owned deployment config. Flag anything else.
 
 2. Confirm every Junior dep in `package.json` shows exact `<target>` — no old versions remain.
 
@@ -212,11 +242,11 @@ PR body sections (in order):
 
 1. **Version change** — old → new, package list with sections.
 2. **Junior release window** — total PR count, breaking PRs (title + URL), config-relevant PRs. Sourced from step 3b. Include the disclaimer: _Junior does not publish GitHub releases, tags, or a changelog. This summary is derived from npm publish timestamps and merged PRs._
-3. **Example app config comparison** — source ref used (commit SHA or approximate), files compared, findings, actions taken. Sourced from step 6c.
+3. **Example app config comparison** — source ref used (commit SHA or approximate), files compared, findings, actions taken, and the `vercel.json` Junior-owned deployment-entry review. Sourced from step 6c.
 4. **`minimumReleaseAgeExclude` changes** (if any).
 5. **`nitro.config.ts` plugin registration changes** (if any).
 6. **Check results** — pass/fail per check, pre-existing failures noted.
-7. **Unexpected diffs** — any changed files beyond `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `nitro.config.ts`.
+7. **Unexpected diffs** — any changed files beyond `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `nitro.config.ts`, and `vercel.json`.
 
 If breaking PRs were found in step 3b, or config comparison found unresolved drift, or checks failed — keep the PR as draft and add a "Manual review required" section at the top summarizing blockers.
 

--- a/packages/junior-maintenance/skills/self-update/SKILL.md
+++ b/packages/junior-maintenance/skills/self-update/SKILL.md
@@ -179,9 +179,9 @@ After updating deps, compare this app's configuration files against `apps/exampl
    git diff <old_ref>..<target_ref> -- apps/example/vercel.json
    ```
 
-   If `old_ref` cannot be found, inspect the target example app's `apps/example/vercel.json` directly and mark the `vercel.json` review as approximate in the PR body.
+   If `old_ref` cannot be found, inspect the target example app's `apps/example/vercel.json` directly only as supporting context for release-window PRs or docs that explicitly identify a new Junior deployment requirement. Do not treat target-only entries as newly required just because they exist in the example app. Mark the `vercel.json` review as approximate in the PR body and add a manual review item when no diff-backed or release-window-backed requirement can be proven.
 
-   Identify entries added or changed upstream that are Junior-owned or Junior-documented deployment requirements. Check especially:
+   Identify entries added or changed upstream by the diff, or explicitly documented in release-window PRs or docs, that are Junior-owned deployment requirements. Check especially:
    - `buildCommand` / `installCommand` changes such as adding `pnpm exec junior upgrade`
    - `framework` requirements
    - Junior queue or function wiring


### PR DESCRIPTION
The self-update skill now explicitly checks whether a Junior upgrade adds Junior-owned Vercel deployment config that the consumer app may need. The workflow keeps full-file normalization out of scope and instead calls out targeted entries like the Junior upgrade build command, framework requirements, queue/function wiring, and heartbeat or scheduler crons.

This should make self-update PRs report when vercel.json needs an upgrade-related change while preserving app-owned Vercel settings such as regions, rewrites, headers, unrelated crons, and custom build choices.

Validation: pnpm skills:check