### PR TITLE
fix(tracing): seed log context before route-thinking to fix gen_ai.conversation.id on gen_ai.chat spans

### DIFF
--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -20,6 +20,7 @@ import {
   serializeGenAiAttribute,
   setSpanAttributes,
   setTags,
+  withLogContext,
   withSpan,
   type LogContext,
 } from "@/chat/logging";
@@ -924,19 +925,21 @@ export async function generateAssistantReply(
         } as PiMessage,
       ];
 
-    thinkingSelection = await selectTurnThinkingLevel({
-      completeObject,
-      conversationContext: context.conversationContext,
-      context: {
-        threadId: context.correlation?.threadId,
-        channelId: context.correlation?.channelId,
-        requesterId: context.correlation?.requesterId,
-        runId: context.correlation?.runId,
-      },
-      currentTurnBlocks: routerBlocks,
-      fastModelId: botConfig.fastModelId,
-      messageText: userInput,
-    });
+    thinkingSelection = await withLogContext(spanContext, () =>
+      selectTurnThinkingLevel({
+        completeObject,
+        conversationContext: context.conversationContext,
+        context: {
+          threadId: context.correlation?.threadId,
+          channelId: context.correlation?.channelId,
+          requesterId: context.correlation?.requesterId,
+          runId: context.correlation?.runId,
+        },
+        currentTurnBlocks: routerBlocks,
+        fastModelId: botConfig.fastModelId,
+        messageText: userInput,
+      }),
+    );
     setSpanAttributes({
       "gen_ai.request.model": botConfig.modelId,
       "app.ai.reasoning_effort": thinkingSelection.thinkingLevel,


### PR DESCRIPTION
## Problem

In the queue-worker path (`POST /api/internal/agent/continue`), `gen_ai.conversation.id` is missing from the `gen_ai.chat` span emitted during thinking-level routing (the Haiku router call).

OTel GenAI semconv marks `gen_ai.conversation.id` as **Conditionally Required** on `gen_ai.chat` and `gen_ai.invoke_agent` spans. All other `gen_ai.*` spans in Junior already carry it — this was the one gap.

### Root cause

`gen_ai.conversation.id` propagates via AsyncLocalStorage. `spanContext` (which has `conversationId`) is computed before `selectTurnThinkingLevel` is called, but hasn't been installed into ALS yet at that point. So the `chat.route_thinking` + its nested `gen_ai.chat` span both miss the attribute in queue-worker turns.

The Slack inline path is unaffected: `slack-runtime.ts` wraps the full turn in `withSpan('chat.turn', ..., context)` which seeds ALS with `conversationId` before `selectTurnThinkingLevel` runs.

### Fix

Wrap the awaited `selectTurnThinkingLevel` call in `withLogContext(spanContext, ...)`. This is a scoped seed — it only covers the route-thinking subtree, leaves everything else unchanged, and works identically in both code paths.

```diff
- thinkingSelection = await selectTurnThinkingLevel({ ... });
+ thinkingSelection = await withLogContext(spanContext, () =>
+   selectTurnThinkingLevel({ ... }),
+ );
```

## Verification

After this change, in queue-worker turns:
- `chat.route_thinking` has `gen_ai.conversation.id` ✓
- `gen_ai.chat` inside route-thinking has `gen_ai.conversation.id` ✓
- All existing spans unaffected ✓

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC0B595QDZLL%3A1781726347.462749%22)