### PR TITLE
fix(oauth): normalize malformed refresh responses

### DIFF
--- a/packages/junior/src/chat/plugins/auth/oauth-bearer-broker.ts
+++ b/packages/junior/src/chat/plugins/auth/oauth-bearer-broker.ts
@@ -13,6 +13,7 @@ import { resolveAuthTokenPlaceholder } from "./auth-token-placeholder";
 import { resolveApiHeaderTransforms } from "./api-headers-broker";
 import {
   buildOAuthTokenRequest,
+  OAuthTokenResponseError,
   parseOAuthTokenResponse,
 } from "./oauth-request";
 import type { OAuthBearerCredentials, PluginManifest } from "../types";
@@ -24,6 +25,13 @@ class OAuthRefreshRejectedError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "OAuthRefreshRejectedError";
+  }
+}
+
+class OAuthRefreshInvalidResponseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OAuthRefreshInvalidResponseError";
   }
 }
 
@@ -90,10 +98,30 @@ async function refreshAccessToken(
     );
   }
 
-  const data = (await response.json()) as Record<string, unknown>;
-  return parseOAuthTokenResponse(data, requestedScope, {
-    treatEmptyScopeAsUnreported: oauth.treatEmptyScopeAsUnreported,
-  });
+  let data: unknown;
+  try {
+    data = await response.json();
+  } catch {
+    throw new OAuthRefreshInvalidResponseError(
+      "Token refresh returned invalid JSON",
+    );
+  }
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    throw new OAuthRefreshInvalidResponseError(
+      "Token refresh returned invalid token response",
+    );
+  }
+  const tokenResponse = data as Record<string, unknown>;
+  try {
+    return parseOAuthTokenResponse(tokenResponse, requestedScope, {
+      treatEmptyScopeAsUnreported: oauth.treatEmptyScopeAsUnreported,
+    });
+  } catch (error) {
+    if (error instanceof OAuthTokenResponseError) {
+      throw new OAuthRefreshInvalidResponseError(error.message);
+    }
+    throw error;
+  }
 }
 
 function getLeaseExpiry(expiresAt?: number): number {
@@ -197,7 +225,10 @@ export function createOAuthBearerBroker(
               if (error instanceof CredentialUnavailableError) {
                 throw error;
               }
-              if (error instanceof OAuthRefreshRejectedError) {
+              if (
+                error instanceof OAuthRefreshRejectedError ||
+                error instanceof OAuthRefreshInvalidResponseError
+              ) {
                 throw new CredentialUnavailableError(
                   provider,
                   `Your ${provider} connection has expired.`,

--- a/packages/junior/src/chat/plugins/auth/oauth-request.ts
+++ b/packages/junior/src/chat/plugins/auth/oauth-request.ts
@@ -2,6 +2,13 @@ import { normalizeOAuthScope } from "@/chat/credentials/oauth-scope";
 
 const DEFAULT_TOKEN_CONTENT_TYPE = "application/x-www-form-urlencoded";
 
+export class OAuthTokenResponseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OAuthTokenResponseError";
+  }
+}
+
 type OAuthTokenRequestInput = {
   clientId: string;
   clientSecret: string;
@@ -16,7 +23,9 @@ function requireNonEmptyTokenField(
 ): string {
   const value = data[field];
   if (typeof value !== "string" || !value.trim()) {
-    throw new Error(`OAuth token response missing ${field}`);
+    throw new OAuthTokenResponseError(
+      `OAuth token response missing ${field}`,
+    );
   }
   return value;
 }
@@ -32,7 +41,9 @@ function contentTypeToBody(
   if (mediaType === "application/json" || mediaType.endsWith("+json")) {
     return JSON.stringify(payload);
   }
-  throw new Error(`Unsupported OAuth token Content-Type: ${contentType}`);
+  throw new OAuthTokenResponseError(
+    `Unsupported OAuth token Content-Type: ${contentType}`,
+  );
 }
 
 export function buildOAuthTokenRequest(input: OAuthTokenRequestInput): {
@@ -87,7 +98,9 @@ export function parseOAuthTokenResponse(
 
   if (responseScope !== undefined) {
     if (typeof responseScope !== "string") {
-      throw new Error("OAuth token response returned invalid scope");
+      throw new OAuthTokenResponseError(
+        "OAuth token response returned invalid scope",
+      );
     }
     const normalized = normalizeOAuthScope(responseScope);
     if (normalized !== undefined) {
@@ -95,7 +108,9 @@ export function parseOAuthTokenResponse(
     } else if (options?.treatEmptyScopeAsUnreported) {
       scope = normalizeOAuthScope(requestedScope);
     } else {
-      throw new Error("OAuth token response returned empty scope");
+      throw new OAuthTokenResponseError(
+        "OAuth token response returned empty scope",
+      );
     }
   } else {
     scope = normalizeOAuthScope(requestedScope);
@@ -109,7 +124,9 @@ export function parseOAuthTokenResponse(
     !Number.isFinite(expiresIn) ||
     expiresIn <= 0
   ) {
-    throw new Error("OAuth token response returned invalid expires_in");
+    throw new OAuthTokenResponseError(
+      "OAuth token response returned invalid expires_in",
+    );
   }
 
   return {

--- a/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@sentry/junior-plugin-api";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { StateAdapterTokenStore } from "@/chat/credentials/state-adapter-token-store";
 import {
   createPluginAppFixture,
   type PluginAppFixture,
@@ -382,6 +383,69 @@ describe("sandbox egress proxy integration", () => {
     await expect(response.text()).resolves.toContain(
       "junior-auth-required provider=oauth-broker grant=default access=read",
     );
+    await expect(
+      modules.session.consumeSandboxEgressAuthRequiredSignal(EGRESS_ID),
+    ).resolves.toMatchObject({
+      provider: "oauth-broker",
+      grant: {
+        name: "default",
+        access: "read",
+      },
+      authorization: {
+        type: "oauth",
+        provider: "oauth-broker",
+        scope: "broker.read",
+      },
+    });
+  });
+
+  it("normalizes malformed OAuth refresh responses into auth-required egress responses", async () => {
+    delete process.env.OAUTH_BROKER_ACCESS_TOKEN;
+    process.env.OAUTH_BROKER_CLIENT_ID = "client-id";
+    process.env.OAUTH_BROKER_CLIENT_SECRET = "client-secret";
+    await registerOAuthBrokerPlugin();
+
+    const tokenStore = new StateAdapterTokenStore(modules.state.getStateAdapter());
+    await tokenStore.set(REQUESTER_ID, "oauth-broker", {
+      accessToken: "old-access",
+      refreshToken: "old-refresh",
+      expiresAt: Date.now() + 60_000,
+      scope: "broker.read",
+    });
+
+    mswServer.use(
+      http.post("https://oauth-broker.example.test/token", () =>
+        HttpResponse.json({ error: "bad_refresh_token" }, { status: 200 }),
+      ),
+    );
+
+    const credentialToken = modules.session.createSandboxEgressCredentialToken({
+      credentials: { actor: { type: "user", userId: REQUESTER_ID } },
+      egressId: EGRESS_ID,
+      ttlMs: 60_000,
+    });
+    const networkPolicy = modules.policy.buildSandboxEgressNetworkPolicy({
+      credentialToken,
+    });
+    const forwardURL = forwardUrlFor(networkPolicy, OAUTH_BROKER_PROVIDER_HOST);
+    const upstreamFetch = vi.fn(async () => new Response("unexpected"));
+
+    const response = await modules.proxy.proxySandboxEgressRequest(
+      proxiedRequest({
+        forwardURL,
+        upstreamHost: OAUTH_BROKER_PROVIDER_HOST,
+      }),
+      {
+        fetch: upstreamFetch as typeof fetch,
+        verifyOidc: async () => ({ sandbox_id: EGRESS_ID }),
+      },
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.text()).resolves.toContain(
+      "junior-auth-required provider=oauth-broker grant=default access=read",
+    );
+    expect(upstreamFetch).not.toHaveBeenCalled();
     await expect(
       modules.session.consumeSandboxEgressAuthRequiredSignal(EGRESS_ID),
     ).resolves.toMatchObject({

--- a/packages/junior/tests/unit/plugins/oauth-bearer-broker.test.ts
+++ b/packages/junior/tests/unit/plugins/oauth-bearer-broker.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CredentialUnavailableError } from "@/chat/credentials/broker";
+import { createOAuthBearerBroker } from "@/chat/plugins/auth/oauth-bearer-broker";
+
+const ORIGINAL_ENV = { ...process.env };
+
+function manifest() {
+  return {
+    name: "oauth-broker",
+    displayName: "OAuth Broker",
+    description: "OAuth Broker",
+    capabilities: ["api"],
+    envVars: {},
+    commandEnv: {},
+    credentials: {
+      type: "oauth-bearer" as const,
+      domains: ["oauth-broker.example.test"],
+      authTokenEnv: "OAUTH_BROKER_ACCESS_TOKEN",
+      authTokenPlaceholder: "host_managed_credential",
+    },
+    oauth: {
+      clientIdEnv: "OAUTH_BROKER_CLIENT_ID",
+      clientSecretEnv: "OAUTH_BROKER_CLIENT_SECRET",
+      authorizeEndpoint: "https://oauth-broker.example.test/authorize",
+      tokenEndpoint: "https://oauth-broker.example.test/token",
+      scope: "broker.read",
+    },
+  };
+}
+
+function tokenStore(storedToken: {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt?: number;
+  scope?: string;
+}) {
+  return {
+    get: vi.fn(async () => storedToken),
+    set: vi.fn(async () => undefined),
+    delete: vi.fn(async () => undefined),
+  };
+}
+
+describe("createOAuthBearerBroker refresh normalization", () => {
+  beforeEach(() => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      OAUTH_BROKER_CLIENT_ID: "client-id",
+      OAUTH_BROKER_CLIENT_SECRET: "client-secret",
+    };
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.restoreAllMocks();
+  });
+
+  it("converts malformed successful refresh responses into CredentialUnavailableError", async () => {
+    const store = tokenStore({
+      accessToken: "old-access",
+      refreshToken: "old-refresh",
+      expiresAt: Date.now() + 60_000,
+      scope: "broker.read",
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "bad_refresh_token" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const broker = createOAuthBearerBroker(manifest(), manifest().credentials, {
+      userTokenStore: store,
+    });
+
+    await expect(
+      broker.issue({
+        context: { actor: { type: "user", userId: "U123" } },
+        reason: "sandbox-egress:oauth-broker:default",
+      }),
+    ).rejects.toSatisfy(
+      (error: unknown) =>
+        error instanceof CredentialUnavailableError &&
+        error.message === "Your oauth-broker connection has expired.",
+    );
+    expect(store.set).not.toHaveBeenCalled();
+  });
+
+  it("keeps operational token endpoint failures as raw errors", async () => {
+    const store = tokenStore({
+      accessToken: "old-access",
+      refreshToken: "old-refresh",
+      expiresAt: Date.now() + 60_000,
+      scope: "broker.read",
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("server error", { status: 500 }),
+    );
+
+    const broker = createOAuthBearerBroker(manifest(), manifest().credentials, {
+      userTokenStore: store,
+    });
+
+    await expect(
+      broker.issue({
+        context: { actor: { type: "user", userId: "U123" } },
+        reason: "sandbox-egress:oauth-broker:default",
+      }),
+    ).rejects.toThrow("Token refresh failed: 500");
+  });
+});


### PR DESCRIPTION
## Summary
- normalize malformed successful OAuth refresh responses into credential expiry at the broker boundary
- keep operational token endpoint failures as raw errors instead of misclassifying them as auth-required
- add unit and integration coverage proving sandbox egress returns the structured auth-required response instead of leaking a proxy 500

## Testing
- `cd /vercel/sandbox/junior/packages/junior && pnpm exec vitest run tests/unit/plugins/oauth-token-response.test.ts tests/unit/plugins/oauth-bearer-broker.test.ts tests/integration/sandbox-egress-proxy.test.ts`

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC0B595QDZLL%3A1781805284.352819%22)