### PR TITLE
fix(github): Reauth malformed token refreshes

### DIFF
--- a/packages/junior-github/index.js
+++ b/packages/junior-github/index.js
@@ -290,18 +290,25 @@ function buildOAuthTokenRequest(input) {
   };
 }
 
-function parseOAuthError(text) {
-  if (!text.trim()) {
+function parseOAuthResponseJson(responseText) {
+  if (!responseText.trim()) {
     return undefined;
   }
   try {
-    const parsed = JSON.parse(text);
-    return isRecord(parsed) && typeof parsed.error === "string"
-      ? parsed.error
-      : undefined;
+    return JSON.parse(responseText);
   } catch {
     return undefined;
   }
+}
+
+function oauthErrorCode(data) {
+  return isRecord(data) && typeof data.error === "string"
+    ? data.error
+    : undefined;
+}
+
+function isRejectedRefreshError(errorCode) {
+  return errorCode === "bad_refresh_token" || errorCode === "invalid_grant";
 }
 
 function parseOAuthTokenResponse(data, requestedScope) {
@@ -358,18 +365,30 @@ async function refreshUserAccessToken(input) {
     headers: request.headers,
     body: request.body,
   });
-  if (!response.ok) {
-    const errorCode = parseOAuthError(await response.text());
-    if (errorCode === "bad_refresh_token" || errorCode === "invalid_grant") {
-      throw new GitHubUserRefreshRejectedError(
-        `GitHub user token refresh rejected: ${errorCode}`,
-      );
-    }
+  const responseText = await response.text();
+  const responseData = parseOAuthResponseJson(responseText);
+  const errorCode = oauthErrorCode(responseData);
+  if (isRejectedRefreshError(errorCode)) {
+    throw new GitHubUserRefreshRejectedError(
+      `GitHub user token refresh rejected: ${errorCode}`,
+    );
+  }
+  if (!response.ok || errorCode) {
     throw new Error(
       `GitHub user token refresh failed: ${response.status}${errorCode ? ` ${errorCode}` : ""}`,
     );
   }
-  return parseOAuthTokenResponse(await response.json(), input.requestedScope);
+  try {
+    return parseOAuthTokenResponse(responseData, input.requestedScope);
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message === "OAuth token response missing access_token"
+    ) {
+      throw new GitHubUserRefreshRejectedError(error.message);
+    }
+    throw error;
+  }
 }
 
 function leaseExpiry(expiresAt) {

--- a/packages/junior/tests/unit/plugins/github-plugin.test.ts
+++ b/packages/junior/tests/unit/plugins/github-plugin.test.ts
@@ -867,6 +867,73 @@ describe("github plugin", () => {
     });
   });
 
+  it.each(["bad_refresh_token", "invalid_grant"])(
+    "requires reauthorization when GitHub returns %s in a successful refresh response",
+    async (errorCode) => {
+      process.env.GITHUB_APP_CLIENT_ID = "client-id";
+      process.env.GITHUB_APP_CLIENT_SECRET = "client-secret";
+      mockGitHubRefresh(200, { error: errorCode });
+
+      const plugin = githubPlugin({ additionalUserScopes: ["repo"] });
+      const result = await plugin.hooks?.issueCredential?.(
+        githubIssueCredentialContext({
+          grant: {
+            name: "user-write",
+            access: "write",
+            reason: "github.issue-create",
+          },
+          currentUserToken: {
+            accessToken: "stale-token",
+            expiresAt: Date.now() + 60_000,
+            refreshToken: "stale-refresh-token",
+            scope: "repo",
+          },
+        }),
+      );
+
+      expect(result).toMatchObject({
+        type: "needed",
+        authorization: {
+          type: "oauth",
+          provider: "github",
+          scope: "repo",
+        },
+      });
+    },
+  );
+
+  it("requires reauthorization when GitHub returns a malformed successful refresh response", async () => {
+    process.env.GITHUB_APP_CLIENT_ID = "client-id";
+    process.env.GITHUB_APP_CLIENT_SECRET = "client-secret";
+    mockGitHubRefresh(200, { error_description: "refresh token expired" });
+
+    const plugin = githubPlugin({ additionalUserScopes: ["repo"] });
+    const result = await plugin.hooks?.issueCredential?.(
+      githubIssueCredentialContext({
+        grant: {
+          name: "user-write",
+          access: "write",
+          reason: "github.issue-create",
+        },
+        currentUserToken: {
+          accessToken: "stale-token",
+          expiresAt: Date.now() + 60_000,
+          refreshToken: "stale-refresh-token",
+          scope: "repo",
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      type: "needed",
+      authorization: {
+        type: "oauth",
+        provider: "github",
+        scope: "repo",
+      },
+    });
+  });
+
   it("surfaces operational GitHub user token refresh failures", async () => {
     process.env.GITHUB_APP_CLIENT_ID = "client-id";
     process.env.GITHUB_APP_CLIENT_SECRET = "client-secret";
@@ -890,6 +957,56 @@ describe("github plugin", () => {
         }),
       ),
     ).rejects.toThrow("GitHub user token refresh failed: 500 server_error");
+  });
+
+  it("surfaces successful GitHub refresh responses with operational OAuth errors", async () => {
+    process.env.GITHUB_APP_CLIENT_ID = "client-id";
+    process.env.GITHUB_APP_CLIENT_SECRET = "client-secret";
+    mockGitHubRefresh(200, { error: "server_error" });
+
+    const plugin = githubPlugin({ additionalUserScopes: ["repo"] });
+    await expect(
+      plugin.hooks?.issueCredential?.(
+        githubIssueCredentialContext({
+          grant: {
+            name: "user-write",
+            access: "write",
+            reason: "github.issue-create",
+          },
+          currentUserToken: {
+            accessToken: "stale-token",
+            expiresAt: Date.now() + 60_000,
+            refreshToken: "stale-refresh-token",
+            scope: "repo",
+          },
+        }),
+      ),
+    ).rejects.toThrow("GitHub user token refresh failed: 200 server_error");
+  });
+
+  it("surfaces malformed successful GitHub refresh token responses after access token parsing", async () => {
+    process.env.GITHUB_APP_CLIENT_ID = "client-id";
+    process.env.GITHUB_APP_CLIENT_SECRET = "client-secret";
+    mockGitHubRefresh(200, { access_token: "new-access-token" });
+
+    const plugin = githubPlugin({ additionalUserScopes: ["repo"] });
+    await expect(
+      plugin.hooks?.issueCredential?.(
+        githubIssueCredentialContext({
+          grant: {
+            name: "user-write",
+            access: "write",
+            reason: "github.issue-create",
+          },
+          currentUserToken: {
+            accessToken: "stale-token",
+            expiresAt: Date.now() + 60_000,
+            refreshToken: "stale-refresh-token",
+            scope: "repo",
+          },
+        }),
+      ),
+    ).rejects.toThrow("OAuth token response missing refresh_token");
   });
 
   it("prepares git attribution hooks and sandbox git config", async () => {


### PR DESCRIPTION
GitHub user-token refresh now treats refresh-token rejection responses as an auth-expired state even when the OAuth endpoint returns HTTP 200. This prevents sandbox egress from crashing on a successful HTTP response that contains no access token and lets the existing plugin auth pause flow ask the user to reconnect GitHub.

The change keeps non-expiry OAuth errors and malformed token responses after access-token parsing as operational failures, so provider outages or contract drift still surface for investigation. Focused GitHub plugin tests cover the 200 error-body cases and the operational-error boundary.

Fixes JUNIOR-40