### PR TITLE
ref(logging): Expand gen_ai log attribute limits

### DIFF
--- a/packages/junior/src/chat/logging.ts
+++ b/packages/junior/src/chat/logging.ts
@@ -1753,7 +1753,7 @@ export function buildTurnFailureResponse(eventId: string): string {
 // Gen-AI attribute serialization
 // ---------------------------------------------------------------------------
 
-const GEN_AI_DEFAULT_MAX_ATTRIBUTE_CHARS = 12_000;
+const GEN_AI_DEFAULT_MAX_ATTRIBUTE_CHARS = 100_000;
 const GEN_AI_MAX_ARRAY_ITEMS = 50;
 const GEN_AI_MAX_OBJECT_KEYS = 50;
 

--- a/packages/junior/src/chat/logging.ts
+++ b/packages/junior/src/chat/logging.ts
@@ -1754,7 +1754,6 @@ export function buildTurnFailureResponse(eventId: string): string {
 // ---------------------------------------------------------------------------
 
 const GEN_AI_DEFAULT_MAX_ATTRIBUTE_CHARS = 12_000;
-const GEN_AI_MAX_STRING_CHARS = 2_000;
 const GEN_AI_MAX_ARRAY_ITEMS = 50;
 const GEN_AI_MAX_OBJECT_KEYS = 50;
 
@@ -1781,7 +1780,7 @@ function sanitizeGenAiValue(
     if (shouldTreatAsBlob) {
       return `[omitted:${value.length}]`;
     }
-    return truncateGenAiString(redactSecrets(value), GEN_AI_MAX_STRING_CHARS);
+    return redactSecrets(value);
   }
 
   if (typeof value === "number") {


### PR DESCRIPTION
Loosens two truncation limits on gen_ai span/log attributes so traces retain far more model input/output context.

First, removes the 2,000-character per-string cap applied during sanitization, so individual string values are no longer clipped mid-content. This was especially harmful for user messages formatted with XML-style tags, where truncation cut tags in half and broke the surrounding structure in logs.

Second, raises the whole-attribute cap from 12,000 to 100,000 characters. This is safe now that \`streamGenAiSpans\` is enabled: gen_ai spans are extracted from the transaction event and sent as separate span v2 envelope items (\`extractGenAiSpansFromEvent\`), so large attributes no longer count against transaction event payload size. The SDK's own transport cap (\`maxValueLength\`) does not apply to span attributes, and the SDK's automatic 20KB gen_ai truncation only affects auto-instrumented attributes, not the values we build via \`serializeGenAiAttribute\`. Secret redaction and base64/\`data\` blob omission are unchanged, and output stays bounded by the new 100k limit.