### PR TITLE
fix(oauth): Preserve refresh token leases

### DIFF
--- a/packages/junior-dashboard/vitest.config.ts
+++ b/packages/junior-dashboard/vitest.config.ts
@@ -1,5 +1,13 @@
 import path from "node:path";
 import { configDefaults, defineConfig } from "vitest/config";
+import { loadJuniorTestEnvFiles } from "../junior/tests/fixtures/env";
+
+const workspaceRoot = path.resolve(import.meta.dirname, "../..");
+
+loadJuniorTestEnvFiles({
+  packageRoots: [import.meta.dirname],
+  workspaceRoot,
+});
 
 export default defineConfig({
   resolve: {

--- a/packages/junior-github/index.js
+++ b/packages/junior-github/index.js
@@ -606,6 +606,9 @@ async function refreshUserTokensWithLock(tokenSlot, scope, options) {
       };
     }
     const refreshedTokens = {
+      ...(latest.refreshTokenExpiresAt
+        ? { refreshTokenExpiresAt: latest.refreshTokenExpiresAt }
+        : {}),
       ...refreshed,
       ...(latest.account ? { account: latest.account } : {}),
     };

--- a/packages/junior-github/index.js
+++ b/packages/junior-github/index.js
@@ -13,6 +13,7 @@ const GITHUB_AUTH_TOKEN_ENV = "GITHUB_TOKEN";
 const GITHUB_AUTH_TOKEN_PLACEHOLDER = "ghp_host_managed_credential";
 const MAX_LEASE_MS = 60 * 60 * 1000;
 const REFRESH_BUFFER_MS = 5 * 60 * 1000;
+const USER_REFRESH_TIMEOUT_MS = 20_000;
 const GITHUB_GRAPHQL_RESPONSE_BODY_LIMIT_BYTES = 64 * 1024;
 const HTTP_READ_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 const USER_TOKEN_GRANTS = new Set(["user-read", "user-write"]);
@@ -333,20 +334,30 @@ function parseOAuthTokenResponse(data, requestedScope) {
     refreshToken: data.refresh_token,
     ...(scope ? { scope } : {}),
   };
-  if (data.expires_in === undefined) {
-    return result;
+  if (data.expires_in !== undefined) {
+    if (
+      typeof data.expires_in !== "number" ||
+      !Number.isFinite(data.expires_in) ||
+      data.expires_in <= 0
+    ) {
+      throw new Error("OAuth token response returned invalid expires_in");
+    }
+    result.expiresAt = Date.now() + data.expires_in * 1000;
   }
-  if (
-    typeof data.expires_in !== "number" ||
-    !Number.isFinite(data.expires_in) ||
-    data.expires_in <= 0
-  ) {
-    throw new Error("OAuth token response returned invalid expires_in");
+  if (data.refresh_token_expires_in !== undefined) {
+    if (
+      typeof data.refresh_token_expires_in !== "number" ||
+      !Number.isFinite(data.refresh_token_expires_in) ||
+      data.refresh_token_expires_in <= 0
+    ) {
+      throw new Error(
+        "OAuth token response returned invalid refresh_token_expires_in",
+      );
+    }
+    result.refreshTokenExpiresAt =
+      Date.now() + data.refresh_token_expires_in * 1000;
   }
-  return {
-    ...result,
-    expiresAt: Date.now() + data.expires_in * 1000,
-  };
+  return result;
 }
 
 async function refreshUserAccessToken(input) {
@@ -364,6 +375,7 @@ async function refreshUserAccessToken(input) {
     method: "POST",
     headers: request.headers,
     body: request.body,
+    signal: AbortSignal.timeout(USER_REFRESH_TIMEOUT_MS),
   });
   const responseText = await response.text();
   const responseData = parseOAuthResponseJson(responseText);
@@ -528,6 +540,80 @@ async function tokensWithAccount(tokenSlot, stored, scope) {
   return { ok: true, tokens: updated };
 }
 
+function shouldRefreshUserToken(stored, now = Date.now()) {
+  return (
+    stored.expiresAt !== undefined && stored.expiresAt - now < REFRESH_BUFFER_MS
+  );
+}
+
+function canUseStoredUserToken(stored) {
+  return (
+    stored.expiresAt === undefined ||
+    (stored.expiresAt > Date.now() && !shouldRefreshUserToken(stored))
+  );
+}
+
+/** Re-read under the token-slot refresh gate so concurrent callers reuse the winner's rotated tokens. */
+async function refreshUserTokensWithLock(tokenSlot, scope, options) {
+  return await tokenSlot.withRefresh(async () => {
+    const latest = await tokenSlot.get();
+    if (!latest) {
+      return {
+        ok: false,
+        result: credentialNeeded("Connect your GitHub account.", scope),
+      };
+    }
+    if (!hasRequiredOAuthScope(latest.scope, scope)) {
+      return {
+        ok: false,
+        result: credentialNeeded(
+          "Your GitHub authorization needs to be refreshed.",
+          scope,
+        ),
+      };
+    }
+    if (canUseStoredUserToken(latest)) {
+      return { ok: true, tokens: latest };
+    }
+
+    let refreshed;
+    try {
+      refreshed = await refreshUserAccessToken({
+        clientIdEnv: options.clientIdEnv,
+        clientSecretEnv: options.clientSecretEnv,
+        refreshToken: latest.refreshToken,
+        requestedScope: latest.scope ?? scope,
+      });
+    } catch (error) {
+      if (!(error instanceof GitHubUserRefreshRejectedError)) {
+        throw error;
+      }
+      return {
+        ok: false,
+        result: credentialNeeded(
+          "Your GitHub authorization has expired.",
+          scope,
+        ),
+      };
+    }
+    if (!hasRequiredOAuthScope(refreshed.scope, scope)) {
+      return {
+        ok: false,
+        result: credentialNeeded(
+          "Your GitHub authorization needs to be refreshed.",
+          scope,
+        ),
+      };
+    }
+    const refreshedTokens = {
+      ...refreshed,
+      ...(latest.account ? { account: latest.account } : {}),
+    };
+    await tokenSlot.set(refreshedTokens);
+    return { ok: true, tokens: refreshedTokens };
+  });
+}
+
 async function issueUserCredential(ctx, options) {
   const scope = options.userScope;
   const tokenSlot = ctx.tokens.currentUser ?? ctx.tokens.credentialSubject;
@@ -558,34 +644,17 @@ async function issueUserCredential(ctx, options) {
     stored.expiresAt !== undefined &&
     stored.expiresAt - now < REFRESH_BUFFER_MS
   ) {
-    let refreshed;
-    try {
-      refreshed = await refreshUserAccessToken({
-        clientIdEnv: options.clientIdEnv,
-        clientSecretEnv: options.clientSecretEnv,
-        refreshToken: stored.refreshToken,
-        requestedScope: stored.scope ?? scope,
-      });
-    } catch (error) {
-      if (!(error instanceof GitHubUserRefreshRejectedError)) {
-        throw error;
-      }
-      return credentialNeeded("Your GitHub authorization has expired.", scope);
+    const refreshResult = await refreshUserTokensWithLock(
+      tokenSlot,
+      scope,
+      options,
+    );
+    if (!refreshResult.ok) {
+      return refreshResult.result;
     }
-    if (!hasRequiredOAuthScope(refreshed.scope, scope)) {
-      return credentialNeeded(
-        "Your GitHub authorization needs to be refreshed.",
-        scope,
-      );
-    }
-    const refreshedTokens = {
-      ...refreshed,
-      ...(stored.account ? { account: stored.account } : {}),
-    };
-    await tokenSlot.set(refreshedTokens);
     const withAccount = await tokensWithAccount(
       tokenSlot,
-      refreshedTokens,
+      refreshResult.tokens,
       scope,
     );
     if (!withAccount.ok) {

--- a/packages/junior-plugin-api/src/credentials.ts
+++ b/packages/junior-plugin-api/src/credentials.ts
@@ -27,6 +27,18 @@ export const pluginProviderAccountSchema = z
   })
   .strict();
 
+/** Runtime schema for OAuth tokens stored by the host for plugin credentials. */
+export const pluginStoredTokensSchema = z
+  .object({
+    account: pluginProviderAccountSchema.optional(),
+    accessToken: nonBlankStringSchema,
+    expiresAt: z.number().finite().optional(),
+    refreshToken: nonBlankStringSchema,
+    refreshTokenExpiresAt: z.number().finite().optional(),
+    scope: nonBlankStringSchema.optional(),
+  })
+  .strict();
+
 /** Runtime schema for a plugin-defined outbound credential grant. */
 export const pluginGrantSchema = z
   .object({
@@ -169,17 +181,13 @@ export interface PluginResolvedCredentialUser {
   userId: string;
 }
 
-export interface PluginStoredTokens {
-  account?: PluginProviderAccount;
-  accessToken: string;
-  expiresAt?: number;
-  refreshToken: string;
-  scope?: string;
-}
+export type PluginStoredTokens = z.output<typeof pluginStoredTokensSchema>;
 
 export interface PluginUserTokenSlot {
   get(): Promise<PluginStoredTokens | undefined>;
   set(tokens: PluginStoredTokens): Promise<void>;
+  /** Run token refresh work after the host has serialized this user/provider slot, or throw after a bounded wait. */
+  withRefresh<T>(callback: () => Promise<T>): Promise<T>;
   userId: string;
 }
 

--- a/packages/junior/src/chat/config.ts
+++ b/packages/junior/src/chat/config.ts
@@ -236,7 +236,7 @@ function readBotConfig(env: NodeJS.ProcessEnv): BotConfig {
   const maxTurnTimeoutMs = resolveMaxTurnTimeoutMs(functionMaxDurationSeconds);
 
   return {
-    userName: env.JUNIOR_BOT_NAME ?? "junior",
+    userName: toOptionalTrimmed(env.JUNIOR_BOT_NAME) ?? "junior",
     modelId: validateGatewayModelId(env.AI_MODEL) ?? DEFAULT_MODEL_ID,
     modelContextWindowTokens: parseOptionalPositiveInteger(
       "AI_MODEL_CONTEXT_WINDOW_TOKENS",

--- a/packages/junior/src/chat/credentials/state-adapter-token-store.ts
+++ b/packages/junior/src/chat/credentials/state-adapter-token-store.ts
@@ -3,13 +3,25 @@ import type {
   StoredTokens,
   UserTokenStore,
 } from "@/chat/credentials/user-token-store";
+import { storedTokensSchema } from "@/chat/credentials/user-token-store";
 
 const KEY_PREFIX = "oauth-token";
 const BUFFER_MS = 24 * 60 * 60 * 1000; // 24h buffer for refresh token lifetime
 const LONG_LIVED_TTL_MS = 365 * 24 * 60 * 60 * 1000;
+const REFRESH_LOCK_TTL_MS = 30_000;
+const REFRESH_LOCK_WAIT_MS = 30_000;
+const REFRESH_LOCK_RETRY_MS = 100;
 
 function tokenKey(userId: string, provider: string): string {
   return `${KEY_PREFIX}:${userId}:${provider}`;
+}
+
+function refreshLockKey(userId: string, provider: string): string {
+  return `${tokenKey(userId, provider)}:refresh`;
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export class StateAdapterTokenStore implements UserTokenStore {
@@ -23,10 +35,10 @@ export class StateAdapterTokenStore implements UserTokenStore {
     userId: string,
     provider: string,
   ): Promise<StoredTokens | undefined> {
-    const stored = await this.state.get<StoredTokens>(
-      tokenKey(userId, provider),
-    );
-    return stored ?? undefined;
+    const stored = await this.state.get<unknown>(tokenKey(userId, provider));
+    return stored === null || stored === undefined
+      ? undefined
+      : storedTokensSchema.parse(stored);
   }
 
   async set(
@@ -34,13 +46,39 @@ export class StateAdapterTokenStore implements UserTokenStore {
     provider: string,
     tokens: StoredTokens,
   ): Promise<void> {
-    const ttlMs = tokens.expiresAt
-      ? Math.max(tokens.expiresAt - Date.now() + BUFFER_MS, BUFFER_MS)
+    const parsed = storedTokensSchema.parse(tokens);
+    const expiresAt = parsed.refreshTokenExpiresAt ?? parsed.expiresAt;
+    const ttlMs = expiresAt
+      ? Math.max(expiresAt - Date.now() + BUFFER_MS, BUFFER_MS)
       : LONG_LIVED_TTL_MS;
-    await this.state.set(tokenKey(userId, provider), tokens, ttlMs);
+    await this.state.set(tokenKey(userId, provider), parsed, ttlMs);
   }
 
   async delete(userId: string, provider: string): Promise<void> {
     await this.state.delete(tokenKey(userId, provider));
+  }
+
+  /** Wait for the per-slot refresh gate so rotated refresh tokens are used once. */
+  async withRefresh<T>(
+    userId: string,
+    provider: string,
+    callback: () => Promise<T>,
+  ): Promise<T> {
+    const lockKey = refreshLockKey(userId, provider);
+    const deadline = Date.now() + REFRESH_LOCK_WAIT_MS;
+    while (true) {
+      const lock = await this.state.acquireLock(lockKey, REFRESH_LOCK_TTL_MS);
+      if (lock) {
+        try {
+          return await callback();
+        } finally {
+          await this.state.releaseLock(lock);
+        }
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(`Could not acquire OAuth token refresh lock`);
+      }
+      await sleep(REFRESH_LOCK_RETRY_MS);
+    }
   }
 }

--- a/packages/junior/src/chat/credentials/user-token-store.ts
+++ b/packages/junior/src/chat/credentials/user-token-store.ts
@@ -1,19 +1,22 @@
-export interface StoredProviderAccount {
-  id: string;
-  label?: string;
-  url?: string;
-}
+import {
+  pluginStoredTokensSchema,
+  type PluginProviderAccount,
+  type PluginStoredTokens,
+} from "@sentry/junior-plugin-api";
 
-export interface StoredTokens {
-  account?: StoredProviderAccount;
-  accessToken: string;
-  refreshToken: string;
-  expiresAt?: number;
-  scope?: string;
-}
+export const storedTokensSchema = pluginStoredTokensSchema;
+
+export type StoredProviderAccount = PluginProviderAccount;
+export type StoredTokens = PluginStoredTokens;
 
 export interface UserTokenStore {
   get(userId: string, provider: string): Promise<StoredTokens | undefined>;
   set(userId: string, provider: string, tokens: StoredTokens): Promise<void>;
   delete(userId: string, provider: string): Promise<void>;
+  /** Run refresh-token rotation for one user/provider slot, or throw after a bounded wait. */
+  withRefresh<T>(
+    userId: string,
+    provider: string,
+    callback: () => Promise<T>,
+  ): Promise<T>;
 }

--- a/packages/junior/src/chat/plugins/auth/oauth-bearer-broker.ts
+++ b/packages/junior/src/chat/plugins/auth/oauth-bearer-broker.ts
@@ -7,7 +7,10 @@ import { CredentialUnavailableError } from "@/chat/credentials/broker";
 import { credentialUserSubjectId } from "@/chat/credentials/context";
 import { mergeHeaderTransforms } from "@/chat/credentials/header-transforms";
 import { hasRequiredOAuthScope } from "@/chat/credentials/oauth-scope";
-import type { UserTokenStore } from "@/chat/credentials/user-token-store";
+import type {
+  StoredTokens,
+  UserTokenStore,
+} from "@/chat/credentials/user-token-store";
 import { resolvePluginCommandEnv } from "@/chat/plugins/command-env";
 import { resolveAuthTokenPlaceholder } from "./auth-token-placeholder";
 import { resolveApiHeaderTransforms } from "./api-headers-broker";
@@ -52,6 +55,7 @@ async function refreshAccessToken(
   accessToken: string;
   refreshToken: string;
   expiresAt?: number;
+  refreshTokenExpiresAt?: number;
   scope?: string;
 }> {
   const clientId = process.env[oauth.clientIdEnv]?.trim();
@@ -100,6 +104,23 @@ function getLeaseExpiry(expiresAt?: number): number {
   return expiresAt
     ? Math.min(expiresAt, Date.now() + MAX_LEASE_MS)
     : Date.now() + MAX_LEASE_MS;
+}
+
+function canUseStoredToken(
+  stored: StoredTokens | undefined,
+): stored is StoredTokens {
+  return (
+    stored !== undefined &&
+    (stored.expiresAt === undefined || stored.expiresAt > Date.now())
+  );
+}
+
+function shouldRefreshStoredToken(stored: StoredTokens | undefined): boolean {
+  return (
+    stored !== undefined &&
+    stored.expiresAt !== undefined &&
+    stored.expiresAt - Date.now() < REFRESH_BUFFER_MS
+  );
 }
 
 export function createOAuthBearerBroker(
@@ -162,36 +183,68 @@ export function createOAuthBearerBroker(
             );
           }
 
-          const now = Date.now();
-          if (
-            stored.expiresAt !== undefined &&
-            stored.expiresAt - now < REFRESH_BUFFER_MS
-          ) {
+          if (shouldRefreshStoredToken(stored)) {
             try {
-              const refreshed = await refreshAccessToken(
-                stored.refreshToken,
-                oauth,
-                stored.scope ?? oauth.scope,
-              );
-              if (!hasRequiredOAuthScope(refreshed.scope, oauth.scope)) {
-                throw new CredentialUnavailableError(
-                  provider,
-                  `Your ${provider} connection needs to be reauthorized.`,
-                );
-              }
-              const refreshedTokens = {
-                ...refreshed,
-                ...(stored.account ? { account: stored.account } : {}),
-              };
-              await deps.userTokenStore.set(
+              return await deps.userTokenStore.withRefresh(
                 userSubjectId,
                 provider,
-                refreshedTokens,
-              );
-              return buildLease(
-                refreshed.accessToken,
-                getLeaseExpiry(refreshed.expiresAt),
-                input.reason,
+                async () => {
+                  const latest = await deps.userTokenStore.get(
+                    userSubjectId,
+                    provider,
+                  );
+                  if (
+                    latest &&
+                    !hasRequiredOAuthScope(latest.scope, oauth.scope)
+                  ) {
+                    throw new CredentialUnavailableError(
+                      provider,
+                      `Your ${provider} connection needs to be reauthorized.`,
+                    );
+                  }
+                  if (
+                    !shouldRefreshStoredToken(latest) &&
+                    canUseStoredToken(latest)
+                  ) {
+                    return buildLease(
+                      latest.accessToken,
+                      getLeaseExpiry(latest.expiresAt),
+                      input.reason,
+                    );
+                  }
+                  if (!latest) {
+                    throw new CredentialUnavailableError(
+                      provider,
+                      `No ${provider} credentials available.`,
+                    );
+                  }
+
+                  const refreshed = await refreshAccessToken(
+                    latest.refreshToken,
+                    oauth,
+                    latest.scope ?? oauth.scope,
+                  );
+                  if (!hasRequiredOAuthScope(refreshed.scope, oauth.scope)) {
+                    throw new CredentialUnavailableError(
+                      provider,
+                      `Your ${provider} connection needs to be reauthorized.`,
+                    );
+                  }
+                  const refreshedTokens = {
+                    ...refreshed,
+                    ...(latest.account ? { account: latest.account } : {}),
+                  };
+                  await deps.userTokenStore.set(
+                    userSubjectId,
+                    provider,
+                    refreshedTokens,
+                  );
+                  return buildLease(
+                    refreshed.accessToken,
+                    getLeaseExpiry(refreshed.expiresAt),
+                    input.reason,
+                  );
+                },
               );
             } catch (error) {
               if (error instanceof CredentialUnavailableError) {
@@ -207,7 +260,7 @@ export function createOAuthBearerBroker(
             }
           }
 
-          if (stored.expiresAt === undefined || stored.expiresAt > Date.now()) {
+          if (canUseStoredToken(stored)) {
             return buildLease(
               stored.accessToken,
               getLeaseExpiry(stored.expiresAt),

--- a/packages/junior/src/chat/plugins/auth/oauth-bearer-broker.ts
+++ b/packages/junior/src/chat/plugins/auth/oauth-bearer-broker.ts
@@ -231,6 +231,9 @@ export function createOAuthBearerBroker(
                     );
                   }
                   const refreshedTokens = {
+                    ...(latest.refreshTokenExpiresAt
+                      ? { refreshTokenExpiresAt: latest.refreshTokenExpiresAt }
+                      : {}),
                     ...refreshed,
                     ...(latest.account ? { account: latest.account } : {}),
                   };

--- a/packages/junior/src/chat/plugins/auth/oauth-bearer-broker.ts
+++ b/packages/junior/src/chat/plugins/auth/oauth-bearer-broker.ts
@@ -22,6 +22,7 @@ import type { OAuthBearerCredentials, PluginManifest } from "../types";
 
 const MAX_LEASE_MS = 60 * 60 * 1000;
 const REFRESH_BUFFER_MS = 5 * 60 * 1000;
+const TOKEN_REFRESH_TIMEOUT_MS = 20_000;
 
 class OAuthRefreshRejectedError extends Error {
   constructor(message: string) {
@@ -80,6 +81,7 @@ async function refreshAccessToken(
     method: "POST",
     headers: request.headers,
     body: request.body,
+    signal: AbortSignal.timeout(TOKEN_REFRESH_TIMEOUT_MS),
   });
 
   if (!response.ok) {

--- a/packages/junior/src/chat/plugins/auth/oauth-request.ts
+++ b/packages/junior/src/chat/plugins/auth/oauth-request.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { normalizeOAuthScope } from "@/chat/credentials/oauth-scope";
 
 const DEFAULT_TOKEN_CONTENT_TYPE = "application/x-www-form-urlencoded";
@@ -20,6 +21,27 @@ function requireNonEmptyTokenField(
   }
   return value;
 }
+
+function requireTokenResponseObject(data: unknown): Record<string, unknown> {
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    throw new Error("OAuth token response must be an object");
+  }
+  return data as Record<string, unknown>;
+}
+
+const parsedOAuthTokenResponseSchema = z
+  .object({
+    accessToken: z.string().min(1),
+    refreshToken: z.string().min(1),
+    expiresAt: z.number().positive().optional(),
+    refreshTokenExpiresAt: z.number().positive().optional(),
+    scope: z.string().min(1).optional(),
+  })
+  .strict();
+
+export type OAuthTokenResponse = z.output<
+  typeof parsedOAuthTokenResponseSchema
+>;
 
 function contentTypeToBody(
   contentType: string,
@@ -70,19 +92,16 @@ export function buildOAuthTokenRequest(input: OAuthTokenRequestInput): {
 }
 
 export function parseOAuthTokenResponse(
-  data: Record<string, unknown>,
+  data: unknown,
   requestedScope?: string,
   options?: { treatEmptyScopeAsUnreported?: boolean },
-): {
-  accessToken: string;
-  refreshToken: string;
-  expiresAt?: number;
-  scope?: string;
-} {
-  const accessToken = requireNonEmptyTokenField(data, "access_token");
-  const refreshToken = requireNonEmptyTokenField(data, "refresh_token");
-  const expiresIn = data.expires_in;
-  const responseScope = data.scope;
+): OAuthTokenResponse {
+  const response = requireTokenResponseObject(data);
+  const accessToken = requireNonEmptyTokenField(response, "access_token");
+  const refreshToken = requireNonEmptyTokenField(response, "refresh_token");
+  const expiresIn = response.expires_in;
+  const refreshTokenExpiresIn = response.refresh_token_expires_in;
+  const responseScope = response.scope;
   let scope: string | undefined;
 
   if (responseScope !== undefined) {
@@ -101,21 +120,37 @@ export function parseOAuthTokenResponse(
     scope = normalizeOAuthScope(requestedScope);
   }
 
-  if (expiresIn === undefined) {
-    return { accessToken, refreshToken, ...(scope ? { scope } : {}) };
-  }
-  if (
-    typeof expiresIn !== "number" ||
-    !Number.isFinite(expiresIn) ||
-    expiresIn <= 0
-  ) {
-    throw new Error("OAuth token response returned invalid expires_in");
+  const result: {
+    accessToken: string;
+    refreshToken: string;
+    expiresAt?: number;
+    refreshTokenExpiresAt?: number;
+    scope?: string;
+  } = { accessToken, refreshToken, ...(scope ? { scope } : {}) };
+
+  if (expiresIn !== undefined) {
+    if (
+      typeof expiresIn !== "number" ||
+      !Number.isFinite(expiresIn) ||
+      expiresIn <= 0
+    ) {
+      throw new Error("OAuth token response returned invalid expires_in");
+    }
+    result.expiresAt = Date.now() + expiresIn * 1000;
   }
 
-  return {
-    accessToken,
-    refreshToken,
-    expiresAt: Date.now() + expiresIn * 1000,
-    ...(scope ? { scope } : {}),
-  };
+  if (refreshTokenExpiresIn !== undefined) {
+    if (
+      typeof refreshTokenExpiresIn !== "number" ||
+      !Number.isFinite(refreshTokenExpiresIn) ||
+      refreshTokenExpiresIn <= 0
+    ) {
+      throw new Error(
+        "OAuth token response returned invalid refresh_token_expires_in",
+      );
+    }
+    result.refreshTokenExpiresAt = Date.now() + refreshTokenExpiresIn * 1000;
+  }
+
+  return parsedOAuthTokenResponseSchema.parse(result);
 }

--- a/packages/junior/src/chat/plugins/credential-hooks.ts
+++ b/packages/junior/src/chat/plugins/credential-hooks.ts
@@ -262,6 +262,12 @@ export async function issuePluginCredential(
                   tokens,
                 );
               },
+              withRefresh: async (callback) =>
+                await input.userTokenStore.withRefresh(
+                  currentUserId,
+                  plugin.manifest.name,
+                  callback,
+                ),
             },
           }
         : {}),
@@ -281,6 +287,12 @@ export async function issuePluginCredential(
                   tokens,
                 );
               },
+              withRefresh: async (callback) =>
+                await input.userTokenStore.withRefresh(
+                  credentialSubjectUserId,
+                  plugin.manifest.name,
+                  callback,
+                ),
             },
           }
         : {}),

--- a/packages/junior/src/chat/services/subscribed-decision.ts
+++ b/packages/junior/src/chat/services/subscribed-decision.ts
@@ -35,13 +35,6 @@ export interface SubscribedDecisionResult {
   reasonDetail?: string;
 }
 
-interface ClassifierResult {
-  should_reply: boolean;
-  should_unsubscribe?: boolean;
-  confidence: number;
-  reason?: string;
-}
-
 interface TranscriptMessage {
   author: string;
   role: "assistant" | "system" | "user";
@@ -59,23 +52,24 @@ interface RouterSignals {
   recentMessages: TranscriptMessage[];
 }
 
-const replyDecisionSchema = z.object({
-  should_reply: z
-    .boolean()
-    .describe("Whether Junior should respond to this thread message."),
-  should_unsubscribe: z
-    .boolean()
-    .optional()
-    .describe(
-      "Whether Junior should unsubscribe from this thread because the user clearly asked it to stop participating.",
-    ),
-  confidence: z
-    .number()
-    .min(0)
-    .max(1)
-    .describe("Classifier confidence from 0 to 1."),
-  reason: z.string().optional().describe("Short reason for the decision."),
-});
+const replyDecisionSchema = z
+  .object({
+    should_reply: z
+      .boolean()
+      .describe("Whether Junior should respond to this thread message."),
+    should_unsubscribe: z
+      .boolean()
+      .describe(
+        "Whether Junior should unsubscribe from this thread because the user clearly asked it to stop participating.",
+      ),
+    confidence: z
+      .number()
+      .min(0)
+      .max(1)
+      .describe("Classifier confidence from 0 to 1."),
+    reason: z.string().optional().describe("Short reason for the decision."),
+  })
+  .strict();
 
 const ROUTER_CONFIDENCE_THRESHOLD = 0.8;
 const ROUTER_CLASSIFIER_MAX_TOKENS = 240;
@@ -481,7 +475,7 @@ export async function decideSubscribedThreadReply(args: {
       },
     });
 
-    const parsed = replyDecisionSchema.parse(result.object) as ClassifierResult;
+    const parsed = replyDecisionSchema.parse(result.object);
     const reason = parsed.reason?.trim() || "classifier";
     const replyConfidenceThreshold = getReplyConfidenceThreshold(signals);
     if (parsed.should_unsubscribe) {

--- a/packages/junior/src/cli/env.ts
+++ b/packages/junior/src/cli/env.ts
@@ -7,6 +7,7 @@ function envFileNames(nodeEnv: string): string[] {
     ...(nodeEnv === "test" ? [] : [".env.local"]),
     `.env.${nodeEnv}`,
     ".env",
+    ".env.example",
   ];
 }
 

--- a/packages/junior/src/env/files.ts
+++ b/packages/junior/src/env/files.ts
@@ -23,3 +23,18 @@ export function createEnvFileLoader(
     }
   };
 }
+
+/** Create an env-file loader for checked-in defaults that never override. */
+export function createDefaultEnvFileLoader(
+  targetEnv: NodeJS.ProcessEnv = process.env,
+): (absolutePath: string) => void {
+  return (absolutePath: string) => {
+    const values = parseEnv(fs.readFileSync(absolutePath, "utf8"));
+    for (const [name, value] of Object.entries(values)) {
+      if (targetEnv[name] !== undefined) {
+        continue;
+      }
+      targetEnv[name] = value;
+    }
+  };
+}

--- a/packages/junior/tests/component/plugins/plugin-registry-packages.test.ts
+++ b/packages/junior/tests/component/plugins/plugin-registry-packages.test.ts
@@ -674,6 +674,7 @@ describe("plugin registry package discovery", () => {
           get: async () => undefined,
           set: async () => {},
           delete: async () => {},
+          withRefresh: async (_userId, _provider, callback) => callback(),
         },
       }),
     ).toThrow('Provider "demo" has no credentials or API headers configured');

--- a/packages/junior/tests/component/plugins/plugin-registry.test.ts
+++ b/packages/junior/tests/component/plugins/plugin-registry.test.ts
@@ -48,6 +48,7 @@ describe("plugin registry", () => {
           get: async () => undefined,
           set: async () => {},
           delete: async () => {},
+          withRefresh: async (_userId, _provider, callback) => callback(),
         },
       }),
     ).toThrow('Unknown plugin provider: "sentry"');

--- a/packages/junior/tests/fixtures/env.ts
+++ b/packages/junior/tests/fixtures/env.ts
@@ -1,6 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
-import { createEnvFileLoader } from "../../src/env/files";
+import {
+  createDefaultEnvFileLoader,
+  createEnvFileLoader,
+} from "../../src/env/files";
 
 const ENV_FILES = [".env", ".env.local", ".env.test", ".env.test.local"];
 
@@ -13,6 +16,7 @@ export interface JuniorTestEnvOptions {
  * Load Junior's test environment with apps/example defaults before local overrides.
  */
 export function loadJuniorTestEnvFiles(options: JuniorTestEnvOptions): void {
+  const applyDefaultEnvFile = createDefaultEnvFileLoader();
   const applyEnvFile = createEnvFileLoader();
   const roots = [
     path.resolve(options.workspaceRoot, "apps/example"),
@@ -27,6 +31,11 @@ export function loadJuniorTestEnvFiles(options: JuniorTestEnvOptions): void {
       continue;
     }
     seen.add(absoluteRoot);
+
+    const examplePath = path.resolve(absoluteRoot, ".env.example");
+    if (fs.existsSync(examplePath)) {
+      applyDefaultEnvFile(examplePath);
+    }
 
     for (const envFile of ENV_FILES) {
       const absolutePath = path.resolve(absoluteRoot, envFile);

--- a/packages/junior/tests/integration/local-chat-cli.test.ts
+++ b/packages/junior/tests/integration/local-chat-cli.test.ts
@@ -109,5 +109,5 @@ export const plugins = {
       process.chdir(ORIGINAL_CWD);
       rmSync(tempDir, { force: true, recursive: true });
     }
-  });
+  }, 30_000);
 });

--- a/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
+++ b/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
@@ -578,10 +578,11 @@ describe("mcp auth runtime slack integration", () => {
             ({
               object: {
                 should_reply: true,
+                should_unsubscribe: false,
                 confidence: 1,
                 reason: "requires thread follow-up",
               },
-              text: '{"should_reply":true,"confidence":1,"reason":"requires thread follow-up"}',
+              text: '{"should_reply":true,"should_unsubscribe":false,"confidence":1,"reason":"requires thread follow-up"}',
             }) as never,
         },
         visionContext: {

--- a/packages/junior/tests/integration/slack/app-home-webhook.test.ts
+++ b/packages/junior/tests/integration/slack/app-home-webhook.test.ts
@@ -54,6 +54,7 @@ function createTokenStore(
     get: vi.fn(async () => undefined),
     set: vi.fn(async () => undefined),
     delete: vi.fn(async () => undefined),
+    withRefresh: vi.fn(async (_userId, _provider, callback) => callback()),
     ...overrides,
   };
 }

--- a/packages/junior/tests/integration/slack/assistant-thread-contract.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-thread-contract.test.ts
@@ -326,7 +326,17 @@ describe("Slack contract: assistant-thread delivery", () => {
 
     expect(response.status).toBe(200);
     await waitUntil.flush();
-    expect(slackApiOutbox.calls("assistant.threads.setTitle")).toEqual([]);
+    expect(slackApiOutbox.calls("assistant.threads.setTitle")).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          params: expect.objectContaining({
+            channel_id: DM_CHANNEL_ID,
+            thread_ts: DM_THREAD_TS,
+            title: "Debugging Node.js Memory Leaks",
+          }),
+        }),
+      ]),
+    );
 
     resolveTitle!();
     await vi.waitFor(() => {

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -2201,10 +2201,11 @@ describe("bot handlers (integration)", () => {
             ({
               object: {
                 should_reply: true,
+                should_unsubscribe: false,
                 confidence: 1,
                 reason: "follow-up",
               },
-              text: '{"should_reply":true,"confidence":1,"reason":"follow-up"}',
+              text: '{"should_reply":true,"should_unsubscribe":false,"confidence":1,"reason":"follow-up"}',
             }) as any,
         },
         replyExecutor: {

--- a/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
@@ -125,6 +125,7 @@ function createTurnHarness(args: {
           args.completeObject ??
           completeObjectWithDecision(() => ({
             should_reply: true,
+            should_unsubscribe: false,
             confidence: 1,
             reason: "steering follow-up",
           })),
@@ -277,11 +278,13 @@ describe("Slack behavior: durable turn steering", () => {
           prompt.includes("<latest-message>thanks folks</latest-message>")
             ? {
                 should_reply: false,
+                should_unsubscribe: false,
                 confidence: 1,
                 reason: "passive side conversation",
               }
             : {
                 should_reply: true,
+                should_unsubscribe: false,
                 confidence: 1,
                 reason: "active steering follow-up",
               },
@@ -426,6 +429,7 @@ describe("Slack behavior: durable turn steering", () => {
       createTurnHarness({
         completeObject: completeObjectWithDecision(() => ({
           should_reply: false,
+          should_unsubscribe: false,
           confidence: 1,
           reason: "side conversation",
         })),
@@ -518,6 +522,7 @@ describe("Slack behavior: durable turn steering", () => {
             }
           : {
               should_reply: true,
+              should_unsubscribe: false,
               confidence: 1,
               reason: "active steering follow-up",
             },

--- a/packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts
@@ -133,10 +133,11 @@ describe("Slack behavior: processing reaction", () => {
             return {
               object: {
                 should_reply: true,
+                should_unsubscribe: false,
                 confidence: 1,
                 reason: "direct follow-up",
               },
-              text: '{"should_reply":true,"confidence":1,"reason":"direct follow-up"}',
+              text: '{"should_reply":true,"should_unsubscribe":false,"confidence":1,"reason":"direct follow-up"}',
             } as never;
           },
         },

--- a/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
@@ -138,10 +138,11 @@ describe("Slack behavior: subscribed messages", () => {
             return {
               object: {
                 should_reply: true,
+                should_unsubscribe: false,
                 confidence: 1,
                 reason: "explicit ask",
               },
-              text: '{"should_reply":true,"confidence":1,"reason":"explicit ask"}',
+              text: '{"should_reply":true,"should_unsubscribe":false,"confidence":1,"reason":"explicit ask"}',
             } as never;
           },
         },

--- a/packages/junior/tests/unit/cli/env.test.ts
+++ b/packages/junior/tests/unit/cli/env.test.ts
@@ -10,6 +10,7 @@ const TEST_ENV_KEYS = [
   "CLI_ENV_PRIORITY",
   "CLI_ENV_EXISTING",
   "CLI_ENV_MODE",
+  "CLI_ENV_DEFAULT",
 ];
 
 const originalNodeEnv = process.env.NODE_ENV;
@@ -96,5 +97,26 @@ describe("loadCliEnvFiles", () => {
     loadCliEnvFiles(tempRoot);
 
     expect(process.env.CLI_ENV_MODE).toBe("test-local");
+  });
+
+  it("loads example env files as last-resort defaults", () => {
+    clearTestEnv();
+    delete mutableEnv.NODE_ENV;
+
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "junior-cli-env-"));
+    writeFile(path.join(tempRoot, "package.json"), "{}\n");
+    writeFile(
+      path.join(tempRoot, ".env.example"),
+      ["CLI_ENV_DEFAULT=example", "CLI_ENV_PRIORITY=example", ""].join("\n"),
+    );
+    writeFile(
+      path.join(tempRoot, ".env"),
+      ["CLI_ENV_PRIORITY=local", ""].join("\n"),
+    );
+
+    loadCliEnvFiles(tempRoot);
+
+    expect(process.env.CLI_ENV_DEFAULT).toBe("example");
+    expect(process.env.CLI_ENV_PRIORITY).toBe("local");
   });
 });

--- a/packages/junior/tests/unit/config/env-files.test.ts
+++ b/packages/junior/tests/unit/config/env-files.test.ts
@@ -3,8 +3,13 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { createEnvFileLoader } from "@/env/files";
+import { loadJuniorTestEnvFiles } from "../../fixtures/env";
 
-const TEST_ENV_KEYS = ["ENV_FILE_PRECEDENCE", "ENV_FILE_EXISTING"];
+const TEST_ENV_KEYS = [
+  "ENV_FILE_PRECEDENCE",
+  "ENV_FILE_EXISTING",
+  "ENV_FILE_DEFAULT",
+];
 const originalEnv = { ...process.env };
 
 function writeFile(filePath: string, content: string): void {
@@ -50,5 +55,53 @@ describe("createEnvFileLoader", () => {
     applyEnvFile(envFile);
 
     expect(process.env.ENV_FILE_EXISTING).toBe("shell");
+  });
+});
+
+describe("loadJuniorTestEnvFiles", () => {
+  afterEach(() => {
+    clearTestEnv();
+    process.env = { ...originalEnv };
+  });
+
+  it("loads example env files as defaults before local overrides", () => {
+    const workspaceRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "junior-workspace-env-"),
+    );
+    const exampleRoot = path.join(workspaceRoot, "apps/example");
+
+    writeFile(
+      path.join(exampleRoot, ".env.example"),
+      ["ENV_FILE_DEFAULT=example", ""].join("\n"),
+    );
+    writeFile(
+      path.join(exampleRoot, ".env.local"),
+      ["ENV_FILE_DEFAULT=local", ""].join("\n"),
+    );
+
+    loadJuniorTestEnvFiles({ workspaceRoot, packageRoots: [] });
+
+    expect(process.env.ENV_FILE_DEFAULT).toBe("local");
+  });
+
+  it("does not let later example files override existing defaults", () => {
+    const workspaceRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "junior-workspace-env-"),
+    );
+    const exampleRoot = path.join(workspaceRoot, "apps/example");
+    const packageRoot = path.join(workspaceRoot, "packages/junior");
+
+    writeFile(
+      path.join(exampleRoot, ".env.example"),
+      ["ENV_FILE_DEFAULT=example", ""].join("\n"),
+    );
+    writeFile(
+      path.join(packageRoot, ".env.example"),
+      ["ENV_FILE_DEFAULT=", ""].join("\n"),
+    );
+
+    loadJuniorTestEnvFiles({ workspaceRoot, packageRoots: [packageRoot] });
+
+    expect(process.env.ENV_FILE_DEFAULT).toBe("example");
   });
 });

--- a/packages/junior/tests/unit/plugins/github-plugin.test.ts
+++ b/packages/junior/tests/unit/plugins/github-plugin.test.ts
@@ -1,7 +1,12 @@
 import { generateKeyPairSync } from "node:crypto";
-import type { SandboxPrepareHookContext } from "@sentry/junior-plugin-api";
+import { createMemoryState } from "@chat-adapter/state-memory";
+import type {
+  PluginStoredTokens,
+  SandboxPrepareHookContext,
+} from "@sentry/junior-plugin-api";
 import { http, HttpResponse } from "msw";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { StateAdapterTokenStore } from "@/chat/credentials/state-adapter-token-store";
 import { githubPlugin } from "../../../../junior-github/index.js";
 import { mswServer } from "../../msw/server";
 
@@ -180,6 +185,7 @@ function githubIssueCredentialContext(input: {
     accessToken: string;
     expiresAt?: number;
     refreshToken: string;
+    refreshTokenExpiresAt?: number;
     scope?: string;
   };
   grant: { access: "read" | "write"; name: string; reason?: string };
@@ -188,18 +194,37 @@ function githubIssueCredentialContext(input: {
     accessToken: string;
     expiresAt?: number;
     refreshToken: string;
+    refreshTokenExpiresAt?: number;
     scope?: string;
   };
+  currentUserTokenReads?: Array<
+    | {
+        account?: { id: string; label?: string; url?: string };
+        accessToken: string;
+        expiresAt?: number;
+        refreshToken: string;
+        refreshTokenExpiresAt?: number;
+        scope?: string;
+      }
+    | undefined
+  >;
 }) {
+  const currentUserReads = [...(input.currentUserTokenReads ?? [])];
   const currentUser = {
     userId: "U123",
-    get: vi.fn(async () => input.currentUserToken),
+    get: vi.fn(async () =>
+      currentUserReads.length
+        ? currentUserReads.shift()
+        : input.currentUserToken,
+    ),
     set: vi.fn(),
+    withRefresh: vi.fn(async (callback) => await callback()),
   };
   const credentialSubject = {
     userId: "U456",
     get: vi.fn(async () => input.credentialSubjectToken),
     set: vi.fn(),
+    withRefresh: vi.fn(async (callback) => await callback()),
   };
   return {
     actor: input.actor ?? { type: "user" as const, userId: "U123" },
@@ -219,6 +244,7 @@ function githubIssueCredentialContext(input: {
 
 describe("github plugin", () => {
   afterEach(() => {
+    vi.useRealTimers();
     process.env = { ...ORIGINAL_ENV };
   });
 
@@ -874,6 +900,146 @@ describe("github plugin", () => {
         scope: "repo",
       },
     });
+  });
+
+  it("uses tokens refreshed by another request before refreshing a stale token", async () => {
+    process.env.GITHUB_APP_CLIENT_ID = "client-id";
+    process.env.GITHUB_APP_CLIENT_SECRET = "client-secret";
+
+    const staleToken = {
+      accessToken: "stale-token",
+      expiresAt: Date.now() + 60_000,
+      refreshToken: "stale-refresh-token",
+      scope: "repo",
+    };
+    const plugin = githubPlugin({ additionalUserScopes: ["repo"] });
+    const result = await plugin.hooks?.issueCredential?.(
+      githubIssueCredentialContext({
+        grant: {
+          name: "user-write",
+          access: "write",
+          reason: "github.issue-create",
+        },
+        currentUserToken: staleToken,
+        currentUserTokenReads: [
+          staleToken,
+          {
+            account: {
+              id: "12345",
+              label: "requester",
+              url: "https://github.com/requester",
+            },
+            accessToken: "fresh-token",
+            expiresAt: Date.now() + 60 * 60_000,
+            refreshToken: "fresh-refresh-token",
+            scope: "repo",
+          },
+        ],
+      }),
+    );
+
+    expect(result).toMatchObject({
+      type: "lease",
+      lease: {
+        headerTransforms: [
+          {
+            domain: "api.github.com",
+            headers: { Authorization: "Bearer fresh-token" },
+          },
+          {
+            domain: "github.com",
+            headers: {
+              Authorization: expect.stringMatching(/^Basic /),
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it("serializes concurrent refresh requests and reuses the rotated token", async () => {
+    const now = new Date("2026-06-01T12:00:00Z");
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(now);
+    process.env.GITHUB_APP_CLIENT_ID = "client-id";
+    process.env.GITHUB_APP_CLIENT_SECRET = "client-secret";
+    const refreshRequests = mockGitHubRefresh(200, {
+      access_token: "fresh-token",
+      expires_in: 3600,
+      refresh_token: "fresh-refresh-token",
+      refresh_token_expires_in: 7200,
+    });
+    const state = createMemoryState();
+    await state.connect();
+    const store = new StateAdapterTokenStore(state);
+    const storedToken: PluginStoredTokens = {
+      account: {
+        id: "12345",
+        label: "requester",
+        url: "https://github.com/requester",
+      },
+      accessToken: "stale-token",
+      expiresAt: Date.now() + 60_000,
+      refreshToken: "stale-refresh-token",
+      scope: "repo",
+    };
+    await store.set("U123", "github", storedToken);
+    const currentUser = {
+      userId: "U123",
+      get: vi.fn(async () => await store.get("U123", "github")),
+      set: vi.fn(async (tokens) => {
+        await store.set("U123", "github", tokens);
+      }),
+      withRefresh: async <T>(callback: () => Promise<T>) =>
+        await store.withRefresh("U123", "github", callback),
+    };
+    const plugin = githubPlugin({ additionalUserScopes: ["repo"] });
+    const context = {
+      actor: { type: "user" as const, userId: "U123" },
+      grant: {
+        name: "user-write",
+        access: "write" as const,
+        reason: "github.issue-create",
+      },
+      db,
+      log: pluginLog,
+      plugin: { name: "github" },
+      tokens: { currentUser },
+    };
+
+    try {
+      const [first, second] = await Promise.all([
+        plugin.hooks?.issueCredential?.(context),
+        plugin.hooks?.issueCredential?.(context),
+      ]);
+
+      expect(refreshRequests).toHaveLength(1);
+      for (const result of [first, second]) {
+        expect(result).toMatchObject({
+          type: "lease",
+          lease: {
+            headerTransforms: [
+              {
+                domain: "api.github.com",
+                headers: { Authorization: "Bearer fresh-token" },
+              },
+              {
+                domain: "github.com",
+                headers: {
+                  Authorization: expect.stringMatching(/^Basic /),
+                },
+              },
+            ],
+          },
+        });
+      }
+      await expect(store.get("U123", "github")).resolves.toMatchObject({
+        refreshToken: "fresh-refresh-token",
+        refreshTokenExpiresAt: now.getTime() + 7200_000,
+      });
+    } finally {
+      await state.disconnect();
+    }
   });
 
   it.each(["bad_refresh_token", "invalid_grant"])(

--- a/packages/junior/tests/unit/plugins/github-plugin.test.ts
+++ b/packages/junior/tests/unit/plugins/github-plugin.test.ts
@@ -959,6 +959,7 @@ describe("github plugin", () => {
 
   it("serializes concurrent refresh requests and reuses the rotated token", async () => {
     const now = new Date("2026-06-01T12:00:00Z");
+    const refreshTokenExpiresAt = now.getTime() + 30 * 24 * 60 * 60 * 1000;
     vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.setSystemTime(now);
     process.env.GITHUB_APP_CLIENT_ID = "client-id";
@@ -967,7 +968,6 @@ describe("github plugin", () => {
       access_token: "fresh-token",
       expires_in: 3600,
       refresh_token: "fresh-refresh-token",
-      refresh_token_expires_in: 7200,
     });
     const state = createMemoryState();
     await state.connect();
@@ -981,6 +981,7 @@ describe("github plugin", () => {
       accessToken: "stale-token",
       expiresAt: Date.now() + 60_000,
       refreshToken: "stale-refresh-token",
+      refreshTokenExpiresAt,
       scope: "repo",
     };
     await store.set("U123", "github", storedToken);
@@ -1033,6 +1034,70 @@ describe("github plugin", () => {
           },
         });
       }
+      await expect(store.get("U123", "github")).resolves.toMatchObject({
+        refreshToken: "fresh-refresh-token",
+        refreshTokenExpiresAt,
+      });
+    } finally {
+      await state.disconnect();
+    }
+  });
+
+  it("uses the refreshed token expiry when GitHub returns one", async () => {
+    const now = new Date("2026-06-01T12:00:00Z");
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(now);
+    process.env.GITHUB_APP_CLIENT_ID = "client-id";
+    process.env.GITHUB_APP_CLIENT_SECRET = "client-secret";
+    const oldRefreshTokenExpiresAt = now.getTime() + 30 * 24 * 60 * 60 * 1000;
+    mockGitHubRefresh(200, {
+      access_token: "fresh-token",
+      expires_in: 3600,
+      refresh_token: "fresh-refresh-token",
+      refresh_token_expires_in: 7200,
+    });
+
+    const state = createMemoryState();
+    await state.connect();
+    const store = new StateAdapterTokenStore(state);
+    const storedToken: PluginStoredTokens = {
+      account: {
+        id: "12345",
+        label: "requester",
+        url: "https://github.com/requester",
+      },
+      accessToken: "stale-token",
+      expiresAt: Date.now() + 60_000,
+      refreshToken: "stale-refresh-token",
+      refreshTokenExpiresAt: oldRefreshTokenExpiresAt,
+      scope: "repo",
+    };
+    await store.set("U123", "github", storedToken);
+    const currentUser = {
+      userId: "U123",
+      get: vi.fn(async () => await store.get("U123", "github")),
+      set: vi.fn(async (tokens) => {
+        await store.set("U123", "github", tokens);
+      }),
+      withRefresh: async <T>(callback: () => Promise<T>) =>
+        await store.withRefresh("U123", "github", callback),
+    };
+    const plugin = githubPlugin({ additionalUserScopes: ["repo"] });
+    try {
+      const result = await plugin.hooks?.issueCredential?.({
+        actor: { type: "user" as const, userId: "U123" },
+        grant: {
+          name: "user-write",
+          access: "write",
+          reason: "github.issue-create",
+        },
+        db,
+        log: pluginLog,
+        plugin: { name: "github" },
+        tokens: { currentUser },
+      });
+
+      expect(result?.type).toBe("lease");
       await expect(store.get("U123", "github")).resolves.toMatchObject({
         refreshToken: "fresh-refresh-token",
         refreshTokenExpiresAt: now.getTime() + 7200_000,

--- a/packages/junior/tests/unit/plugins/oauth-token-response.test.ts
+++ b/packages/junior/tests/unit/plugins/oauth-token-response.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { parseOAuthTokenResponse } from "@/chat/plugins/auth/oauth-request";
 
 describe("parseOAuthTokenResponse", () => {
@@ -52,5 +52,26 @@ describe("parseOAuthTokenResponse", () => {
       { treatEmptyScopeAsUnreported: true },
     );
     expect(result.scope).toBe("gist repo");
+  });
+
+  it("records refresh token expiry separately from access token expiry", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-24T00:00:00Z"));
+
+    try {
+      const result = parseOAuthTokenResponse({
+        access_token: "access",
+        expires_in: 28_800,
+        refresh_token: "refresh",
+        refresh_token_expires_in: 15_897_600,
+      });
+
+      expect(result.expiresAt).toBe(new Date("2026-06-24T08:00:00Z").getTime());
+      expect(result.refreshTokenExpiresAt).toBe(
+        new Date("2026-12-25T00:00:00Z").getTime(),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/junior/tests/unit/plugins/sentry-broker.test.ts
+++ b/packages/junior/tests/unit/plugins/sentry-broker.test.ts
@@ -188,11 +188,13 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
   it("refreshes tokens that are near expiry", async () => {
     process.env.SENTRY_CLIENT_ID = "client-id";
     process.env.SENTRY_CLIENT_SECRET = "client-secret";
+    const refreshTokenExpiresAt = Date.now() + 30 * 24 * 60 * 60 * 1000;
 
     const tokenStore = createMockTokenStore({
       "U123:sentry": {
         accessToken: "old-access-token",
         refreshToken: "old-refresh-token",
+        refreshTokenExpiresAt,
         expiresAt: Date.now() + 2 * 60 * 1000,
         scope: SENTRY_SCOPE,
       },
@@ -204,7 +206,6 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
         access_token: "new-access-token",
         refresh_token: "new-refresh-token",
         expires_in: 3600,
-        refresh_token_expires_in: 7200,
       }),
     })) as unknown as typeof fetch;
 
@@ -228,7 +229,45 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
     const stored = await tokenStore.get("U123", "sentry");
     expect(stored?.accessToken).toBe("new-access-token");
     expect(stored?.refreshToken).toBe("new-refresh-token");
-    expect(stored?.refreshTokenExpiresAt).toBeGreaterThan(Date.now());
+    expect(stored?.refreshTokenExpiresAt).toBe(refreshTokenExpiresAt);
+  });
+
+  it("uses the refreshed token expiry when the provider returns one", async () => {
+    const now = new Date("2026-06-01T12:00:00Z");
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(now);
+    process.env.SENTRY_CLIENT_ID = "client-id";
+    process.env.SENTRY_CLIENT_SECRET = "client-secret";
+    const oldRefreshTokenExpiresAt = now.getTime() + 30 * 24 * 60 * 60 * 1000;
+
+    const tokenStore = createMockTokenStore({
+      "U123:sentry": {
+        accessToken: "old-access-token",
+        refreshToken: "old-refresh-token",
+        refreshTokenExpiresAt: oldRefreshTokenExpiresAt,
+        expiresAt: Date.now() + 2 * 60 * 1000,
+        scope: SENTRY_SCOPE,
+      },
+    });
+
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        access_token: "new-access-token",
+        refresh_token: "new-refresh-token",
+        expires_in: 3600,
+        refresh_token_expires_in: 7200,
+      }),
+    })) as unknown as typeof fetch;
+
+    const broker = createBroker(tokenStore);
+    await broker.issue({
+      context: USER_CREDENTIAL_CONTEXT,
+      reason: "test:refresh",
+    });
+
+    const stored = await tokenStore.get("U123", "sentry");
+    expect(stored?.refreshTokenExpiresAt).toBe(now.getTime() + 7200_000);
   });
 
   it("uses tokens refreshed by another request before refreshing a stale token", async () => {

--- a/packages/junior/tests/unit/plugins/sentry-broker.test.ts
+++ b/packages/junior/tests/unit/plugins/sentry-broker.test.ts
@@ -58,6 +58,7 @@ function createMockTokenStore(
     delete: async (userId: string, provider: string) => {
       store.delete(`${userId}:${provider}`);
     },
+    withRefresh: async (_userId, _provider, callback) => callback(),
   };
 }
 
@@ -203,6 +204,7 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
         access_token: "new-access-token",
         refresh_token: "new-refresh-token",
         expires_in: 3600,
+        refresh_token_expires_in: 7200,
       }),
     })) as unknown as typeof fetch;
 
@@ -226,6 +228,57 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
     const stored = await tokenStore.get("U123", "sentry");
     expect(stored?.accessToken).toBe("new-access-token");
     expect(stored?.refreshToken).toBe("new-refresh-token");
+    expect(stored?.refreshTokenExpiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it("uses tokens refreshed by another request before refreshing a stale token", async () => {
+    process.env.SENTRY_CLIENT_ID = "client-id";
+    process.env.SENTRY_CLIENT_SECRET = "client-secret";
+    const staleToken: StoredTokens = {
+      accessToken: "old-access-token",
+      refreshToken: "old-refresh-token",
+      expiresAt: Date.now() + 2 * 60 * 1000,
+      scope: SENTRY_SCOPE,
+    };
+    const freshToken: StoredTokens = {
+      accessToken: "new-access-token",
+      refreshToken: "new-refresh-token",
+      expiresAt: Date.now() + 60 * 60 * 1000,
+      scope: SENTRY_SCOPE,
+    };
+    const get = vi
+      .fn<UserTokenStore["get"]>()
+      .mockResolvedValueOnce(staleToken)
+      .mockResolvedValueOnce(freshToken);
+    const withRefresh = vi.fn(async (_userId, _provider, callback) =>
+      callback(),
+    );
+    const tokenStore: UserTokenStore = {
+      get,
+      set: vi.fn(),
+      delete: vi.fn(),
+      withRefresh,
+    };
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+
+    const broker = createBroker(tokenStore);
+    const lease = await broker.issue({
+      context: USER_CREDENTIAL_CONTEXT,
+      reason: "test:refresh-race",
+    });
+
+    expect(withRefresh).toHaveBeenCalledOnce();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(lease.headerTransforms).toEqual([
+      {
+        domain: "us.sentry.io",
+        headers: { Authorization: "Bearer new-access-token" },
+      },
+      {
+        domain: "de.sentry.io",
+        headers: { Authorization: "Bearer new-access-token" },
+      },
+    ]);
   });
 
   it("does not issue a stale lease when token refresh is rejected", async () => {

--- a/packages/junior/tests/unit/plugins/sentry-broker.test.ts
+++ b/packages/junior/tests/unit/plugins/sentry-broker.test.ts
@@ -230,6 +230,12 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
     expect(stored?.accessToken).toBe("new-access-token");
     expect(stored?.refreshToken).toBe("new-refresh-token");
     expect(stored?.refreshTokenExpiresAt).toBe(refreshTokenExpiresAt);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://sentry.io/oauth/token/",
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+      }),
+    );
   });
 
   it("uses the refreshed token expiry when the provider returns one", async () => {

--- a/packages/junior/tests/unit/routing/subscribed-decision.test.ts
+++ b/packages/junior/tests/unit/routing/subscribed-decision.test.ts
@@ -108,6 +108,7 @@ describe("decideSubscribedThreadReply", () => {
     const completeObject = vi.fn(async () => ({
       object: {
         should_reply: false,
+        should_unsubscribe: false,
         confidence: 0.95,
         reason: "attachment acknowledgment",
       },
@@ -281,6 +282,7 @@ describe("decideSubscribedThreadReply", () => {
       completeObject: vi.fn(async () => ({
         object: {
           should_reply: false,
+          should_unsubscribe: false,
           confidence: 0.95,
           reason: "passive attachment",
         },
@@ -355,6 +357,7 @@ describe("decideSubscribedThreadReply", () => {
     const completeObject = vi.fn(async () => ({
       object: {
         should_reply: true,
+        should_unsubscribe: false,
         confidence: 0.95,
         reason: "attachment follow-up",
       },
@@ -428,6 +431,7 @@ describe("decideSubscribedThreadReply", () => {
       completeObject: vi.fn(async () => ({
         object: {
           should_reply: true,
+          should_unsubscribe: false,
           confidence: 0.85,
           reason: "maybe follow-up",
         },
@@ -459,6 +463,7 @@ describe("decideSubscribedThreadReply", () => {
       completeObject: vi.fn(async () => ({
         object: {
           should_reply: true,
+          should_unsubscribe: false,
           confidence: 0.85,
           reason: "maybe follow-up",
         },
@@ -481,6 +486,7 @@ describe("decideSubscribedThreadReply", () => {
       completeObject: vi.fn(async () => ({
         object: {
           should_reply: false,
+          should_unsubscribe: false,
           confidence: 0.95,
           reason: "status chatter",
         },
@@ -530,6 +536,7 @@ describe("decideSubscribedThreadReply", () => {
       completeObject: vi.fn(async () => ({
         object: {
           should_reply: false,
+          should_unsubscribe: false,
           confidence: 0.95,
           reason: longReason,
         },
@@ -550,6 +557,7 @@ describe("decideSubscribedThreadReply", () => {
       completeObject: vi.fn(async () => ({
         object: {
           should_reply: true,
+          should_unsubscribe: false,
           confidence: 0.75,
           reason: "maybe follow-up",
         },
@@ -569,6 +577,7 @@ describe("decideSubscribedThreadReply", () => {
       completeObject: vi.fn(async () => ({
         object: {
           should_reply: true,
+          should_unsubscribe: false,
           confidence: 0.95,
           reason: "direct question",
         },

--- a/packages/junior/tests/unit/runtime/respond-agent-continue.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-agent-continue.test.ts
@@ -173,6 +173,11 @@ vi.mock("@/chat/capabilities/factory", () => ({
     get: async () => undefined,
     set: async () => undefined,
     delete: async () => undefined,
+    withRefresh: async <T>(
+      _userId: string,
+      _provider: string,
+      callback: () => Promise<T>,
+    ) => callback(),
   }),
 }));
 

--- a/packages/junior/tests/unit/runtime/respond-lazy-sandbox.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-lazy-sandbox.test.ts
@@ -289,6 +289,11 @@ vi.mock("@/chat/capabilities/factory", () => ({
     get: async () => undefined,
     set: async () => undefined,
     delete: async () => undefined,
+    withRefresh: async <T>(
+      _userId: string,
+      _provider: string,
+      callback: () => Promise<T>,
+    ) => callback(),
   }),
 }));
 

--- a/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
@@ -466,6 +466,11 @@ vi.mock("@/chat/capabilities/factory", () => ({
     get: async () => undefined,
     set: async () => undefined,
     delete: async () => undefined,
+    withRefresh: async <T>(
+      _userId: string,
+      _provider: string,
+      callback: () => Promise<T>,
+    ) => callback(),
   }),
 }));
 

--- a/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
@@ -183,6 +183,11 @@ vi.mock("@/chat/capabilities/factory", () => ({
     get: async () => undefined,
     set: async () => undefined,
     delete: async () => undefined,
+    withRefresh: async <T>(
+      _userId: string,
+      _provider: string,
+      callback: () => Promise<T>,
+    ) => callback(),
   }),
 }));
 

--- a/packages/junior/tests/unit/services/plugin-auth-orchestration.test.ts
+++ b/packages/junior/tests/unit/services/plugin-auth-orchestration.test.ts
@@ -37,6 +37,7 @@ function tokenStore(): UserTokenStore {
     get: vi.fn(),
     set: vi.fn(),
     delete: vi.fn(),
+    withRefresh: vi.fn(async (_userId, _provider, callback) => callback()),
   };
 }
 

--- a/packages/junior/tests/unit/slack/app-home.test.ts
+++ b/packages/junior/tests/unit/slack/app-home.test.ts
@@ -75,6 +75,7 @@ function createMockTokenStore(
     get: vi.fn(async (_userId: string, provider: string) => tokens[provider]),
     set: vi.fn(async () => {}),
     delete: vi.fn(async () => {}),
+    withRefresh: vi.fn(async (_userId, _provider, callback) => callback()),
   };
 }
 

--- a/packages/junior/tests/unit/state/state-adapter-token-store.test.ts
+++ b/packages/junior/tests/unit/state/state-adapter-token-store.test.ts
@@ -3,11 +3,10 @@ import type { StateAdapter } from "chat";
 import { StateAdapterTokenStore } from "@/chat/credentials/state-adapter-token-store";
 
 describe("StateAdapterTokenStore", () => {
-  it("uses a long-lived ttl for tokens without expiresAt", async () => {
-    const set = vi.fn(async () => {});
-    const adapter = {
+  function createAdapter(overrides: Partial<StateAdapter> = {}) {
+    return {
       get: async () => null,
-      set,
+      set: vi.fn(async () => {}),
       delete: async () => {},
       acquireLock: async () => ({ key: "lock", lockId: "lock-id" }),
       connect: async () => {},
@@ -17,7 +16,14 @@ describe("StateAdapterTokenStore", () => {
       getWithTtl: async () => null,
       releaseLock: async () => {},
       setWithTtl: async () => {},
-    } as unknown as StateAdapter;
+      ...overrides,
+    } as unknown as StateAdapter & {
+      set: ReturnType<typeof vi.fn>;
+    };
+  }
+
+  it("uses a long-lived ttl for tokens without expiresAt", async () => {
+    const adapter = createAdapter();
     const store = new StateAdapterTokenStore(adapter);
 
     await store.set("U123", "notion", {
@@ -25,7 +31,7 @@ describe("StateAdapterTokenStore", () => {
       refreshToken: "refresh-token",
     });
 
-    expect(set).toHaveBeenCalledWith(
+    expect(adapter.set).toHaveBeenCalledWith(
       "oauth-token:U123:notion",
       {
         accessToken: "access-token",
@@ -33,5 +39,58 @@ describe("StateAdapterTokenStore", () => {
       },
       365 * 24 * 60 * 60 * 1000,
     );
+  });
+
+  it("uses refresh token expiry instead of access token expiry for ttl", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-24T00:00:00Z"));
+    const adapter = createAdapter();
+    const store = new StateAdapterTokenStore(adapter);
+
+    try {
+      await store.set("U123", "github", {
+        accessToken: "access-token",
+        refreshToken: "refresh-token",
+        expiresAt: Date.now() + 8 * 60 * 60 * 1000,
+        refreshTokenExpiresAt: Date.now() + 180 * 24 * 60 * 60 * 1000,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(adapter.set).toHaveBeenCalledWith(
+      "oauth-token:U123:github",
+      {
+        accessToken: "access-token",
+        refreshToken: "refresh-token",
+        expiresAt: new Date("2026-06-24T08:00:00Z").getTime(),
+        refreshTokenExpiresAt: new Date("2026-12-21T00:00:00Z").getTime(),
+      },
+      181 * 24 * 60 * 60 * 1000,
+    );
+  });
+
+  it("waits for the refresh lock before running the callback", async () => {
+    const lock = { key: "oauth-token:U123:github:refresh", lockId: "lock-id" };
+    const acquireLock = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(lock);
+    const releaseLock = vi.fn(async () => {});
+    const adapter = createAdapter({ acquireLock, releaseLock });
+    const store = new StateAdapterTokenStore(adapter);
+    const callback = vi.fn(async () => "refreshed");
+
+    await expect(store.withRefresh("U123", "github", callback)).resolves.toBe(
+      "refreshed",
+    );
+
+    expect(acquireLock).toHaveBeenCalledTimes(2);
+    expect(acquireLock).toHaveBeenCalledWith(
+      "oauth-token:U123:github:refresh",
+      30_000,
+    );
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(releaseLock).toHaveBeenCalledWith(lock);
   });
 });

--- a/scripts/lib/load-env-files.mjs
+++ b/scripts/lib/load-env-files.mjs
@@ -18,6 +18,21 @@ export function loadEnvFiles(roots, options = {}) {
   const protectedKeys = new Set(Object.keys(env));
   const loadedKeys = new Set();
 
+  for (const root of roots) {
+    const absolutePath = path.join(root, ".env.example");
+    if (!fs.existsSync(absolutePath)) {
+      continue;
+    }
+
+    const values = parseEnv(fs.readFileSync(absolutePath, "utf8"));
+    for (const [name, value] of Object.entries(values)) {
+      if (env[name] !== undefined) {
+        continue;
+      }
+      env[name] = value;
+    }
+  }
+
   // Shell env wins; later env files override earlier loaded files.
   for (const root of roots) {
     for (const relativePath of envFileNames(nodeEnv)) {

--- a/scripts/lib/load-env-files.test.mjs
+++ b/scripts/lib/load-env-files.test.mjs
@@ -41,3 +41,55 @@ test("app env overrides root env without replacing shell env", () => {
     fs.rmSync(app, { force: true, recursive: true });
   }
 });
+
+test("example env files provide defaults before env overrides", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "junior-env-root-"));
+  try {
+    fs.writeFileSync(
+      path.join(root, ".env.example"),
+      [
+        "DATABASE_URL=postgres://example.example/db",
+        "REDIS_URL=redis://example.example:6379",
+      ].join("\n"),
+    );
+    fs.writeFileSync(
+      path.join(root, ".env"),
+      ["DATABASE_URL=postgres://local.example/db"].join("\n"),
+    );
+
+    const env = {
+      NODE_ENV: "development",
+    };
+    loadEnvFiles([root], { env });
+
+    assert.equal(env.DATABASE_URL, "postgres://local.example/db");
+    assert.equal(env.REDIS_URL, "redis://example.example:6379");
+  } finally {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test("later example env files do not replace earlier defaults", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "junior-env-root-"));
+  const app = fs.mkdtempSync(path.join(os.tmpdir(), "junior-env-app-"));
+  try {
+    fs.writeFileSync(
+      path.join(root, ".env.example"),
+      ["DATABASE_URL=postgres://root.example/db"].join("\n"),
+    );
+    fs.writeFileSync(
+      path.join(app, ".env.example"),
+      ["DATABASE_URL=postgres://app.example/db"].join("\n"),
+    );
+
+    const env = {
+      NODE_ENV: "development",
+    };
+    loadEnvFiles([app, root], { env });
+
+    assert.equal(env.DATABASE_URL, "postgres://app.example/db");
+  } finally {
+    fs.rmSync(root, { force: true, recursive: true });
+    fs.rmSync(app, { force: true, recursive: true });
+  }
+});

--- a/specs/oauth-flows.md
+++ b/specs/oauth-flows.md
@@ -153,8 +153,10 @@ Purpose:
 ### User tokens
 
 - Key pattern: `oauth-token:<userId>:<provider>`
-- Value: `{ accessToken, refreshToken, expiresAt?, scope? }`
-- TTL: derived from expiry when known, otherwise long-lived host storage
+- Value:
+  `{ accessToken, refreshToken, expiresAt?, refreshTokenExpiresAt?, scope? }`
+- TTL: derived from `refreshTokenExpiresAt` when known, otherwise from
+  `expiresAt` when known, otherwise long-lived host storage
 - Storage: `StateAdapterTokenStore`
 
 ### MCP auth sessions and credentials


### PR DESCRIPTION
OAuth refresh now preserves provider refresh-token expiry separately from access-token expiry and serializes refreshes per user/provider for both GitHub and generic OAuth bearer plugins. Concurrent requests re-read the stored token under the refresh gate and reuse the winning rotated token instead of each caller trying to refresh from the same stale token.

The local env loaders now treat checked-in .env.example files as true defaults, so the example app's Docker-backed DATABASE_URL/REDIS_URL are available to CLI, Vitest, and dashboard tests without requiring a copied .env file. This also tightens the model-router and OAuth token response schemas so runtime boundaries match the shapes the providers and token store expect.

Fixes GH-634