### PR TITLE
fix(ai): Pass Gateway credentials to Pi Agent

### DIFF
--- a/packages/junior/src/chat/pi/client.ts
+++ b/packages/junior/src/chat/pi/client.ts
@@ -67,14 +67,9 @@ export function getGatewayApiKey(): string | undefined {
   );
 }
 
-/**
- * Let pi-ai read AI_GATEWAY_API_KEY from env itself and only override the
- * token when auth comes from VERCEL_OIDC_TOKEN.
- */
-export function getPiGatewayApiKeyOverride(): string | undefined {
-  // pi-ai already reads AI_GATEWAY_API_KEY from env, so only pass the token
-  // ourselves when auth comes from VERCEL_OIDC_TOKEN.
-  return toOptionalTrimmed(process.env.VERCEL_OIDC_TOKEN);
+/** Return the Gateway credential shape expected by Pi Agent getApiKey hooks. */
+export function getPiGatewayApiKey(): string | undefined {
+  return getGatewayApiKey();
 }
 
 function extractText(message: {
@@ -115,7 +110,12 @@ export async function completeText(params: {
   metadata?: Record<string, unknown>;
 }) {
   const model = resolveGatewayModel(params.modelId);
-  const apiKey = getPiGatewayApiKeyOverride();
+  const apiKey = getPiGatewayApiKey();
+  const authMode = toOptionalTrimmed(process.env.AI_GATEWAY_API_KEY)
+    ? "api_key"
+    : toOptionalTrimmed(process.env.VERCEL_OIDC_TOKEN)
+      ? "oidc"
+      : "api_key";
   const privacy = resolveConversationPrivacy({
     channelId:
       typeof params.metadata?.channelId === "string"
@@ -168,7 +168,7 @@ export async function completeText(params: {
     ...(requestMessagesAttribute
       ? { "gen_ai.input.messages": requestMessagesAttribute }
       : {}),
-    "app.ai.auth_mode": apiKey ? "oidc" : "api_key",
+    "app.ai.auth_mode": authMode,
   };
   return withSpan(
     `${GEN_AI_OPERATION_CHAT} ${params.modelId}`,

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -75,7 +75,7 @@ import {
   GEN_AI_SERVER_ADDRESS,
   GEN_AI_SERVER_PORT,
   completeObject,
-  getPiGatewayApiKeyOverride,
+  getPiGatewayApiKey,
   resolveGatewayModel,
 } from "@/chat/pi/client";
 import type { PiMessage } from "@/chat/pi/messages";
@@ -1448,8 +1448,9 @@ export async function generateAssistantReply(
       throw cooperativeYieldError;
     };
 
+    const hasGatewayCredential = Boolean(getPiGatewayApiKey());
     agent = new Agent({
-      getApiKey: () => getPiGatewayApiKeyOverride(),
+      ...(hasGatewayCredential ? { getApiKey: getPiGatewayApiKey } : {}),
       streamFn: createTracedStreamFn({ conversationPrivacy }),
       steeringMode: "all",
       prepareNextTurn: async () => {

--- a/packages/junior/src/chat/tools/advisor/tool.ts
+++ b/packages/junior/src/chat/tools/advisor/tool.ts
@@ -22,7 +22,7 @@ import {
   GEN_AI_PROVIDER_NAME,
   GEN_AI_SERVER_ADDRESS,
   GEN_AI_SERVER_PORT,
-  getPiGatewayApiKeyOverride,
+  getPiGatewayApiKey,
   resolveGatewayModel,
 } from "@/chat/pi/client";
 import type { PiMessage } from "@/chat/pi/messages";
@@ -227,8 +227,9 @@ export function createAdvisorTool(context: AdvisorToolRuntimeContext) {
             );
           }
 
+          const hasGatewayCredential = Boolean(getPiGatewayApiKey());
           const advisorAgent = new Agent({
-            getApiKey: () => getPiGatewayApiKeyOverride(),
+            ...(hasGatewayCredential ? { getApiKey: getPiGatewayApiKey } : {}),
             initialState: {
               systemPrompt: ADVISOR_SYSTEM_PROMPT,
               model: resolveGatewayModel(context.config.modelId),

--- a/packages/junior/tests/component/tools/advisor-tool.test.ts
+++ b/packages/junior/tests/component/tools/advisor-tool.test.ts
@@ -44,7 +44,7 @@ vi.mock("@/chat/pi/client", () => ({
   GEN_AI_PROVIDER_NAME: "vercel-ai-gateway",
   GEN_AI_SERVER_ADDRESS: "ai-gateway.vercel.sh",
   GEN_AI_SERVER_PORT: 443,
-  getPiGatewayApiKeyOverride: vi.fn(() => undefined),
+  getPiGatewayApiKey: vi.fn(() => undefined),
   resolveGatewayModel: vi.fn((modelId: string) => ({ id: modelId })),
 }));
 

--- a/packages/junior/tests/integration/plugin-prompt-hooks.test.ts
+++ b/packages/junior/tests/integration/plugin-prompt-hooks.test.ts
@@ -96,7 +96,7 @@ vi.mock("@/chat/pi/client", () => ({
       reason: "test-router",
     },
   }),
-  getPiGatewayApiKeyOverride: () => "test-gateway-key",
+  getPiGatewayApiKey: () => "test-gateway-key",
   resolveGatewayModel: (modelId: string) => modelId,
 }));
 

--- a/packages/junior/tests/unit/misc/pi-client.test.ts
+++ b/packages/junior/tests/unit/misc/pi-client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { getGatewayApiKey, getPiGatewayApiKeyOverride } from "@/chat/pi/client";
+import { getGatewayApiKey, getPiGatewayApiKey } from "@/chat/pi/client";
 
 const ORIGINAL_ENV = {
   AI_GATEWAY_API_KEY: process.env.AI_GATEWAY_API_KEY,
@@ -36,23 +36,30 @@ describe("getGatewayApiKey", () => {
   });
 });
 
-describe("getPiGatewayApiKeyOverride", () => {
+describe("getPiGatewayApiKey", () => {
   afterEach(() => {
     restoreEnvVar("AI_GATEWAY_API_KEY");
     restoreEnvVar("VERCEL_OIDC_TOKEN");
   });
 
-  it("only overrides pi-ai auth when VERCEL_OIDC_TOKEN is present", () => {
+  it("prefers explicit API key when both Gateway credentials are present", () => {
     process.env.AI_GATEWAY_API_KEY = "api-key";
     process.env.VERCEL_OIDC_TOKEN = "oidc-token";
 
-    expect(getPiGatewayApiKeyOverride()).toBe("oidc-token");
+    expect(getPiGatewayApiKey()).toBe("api-key");
   });
 
-  it("returns undefined when pi-ai should keep using its own env lookup", () => {
+  it("returns the Gateway API key for Pi Agent auth hooks", () => {
     process.env.AI_GATEWAY_API_KEY = "api-key";
     delete process.env.VERCEL_OIDC_TOKEN;
 
-    expect(getPiGatewayApiKeyOverride()).toBeUndefined();
+    expect(getPiGatewayApiKey()).toBe("api-key");
+  });
+
+  it("uses Vercel OIDC when no explicit API key is configured", () => {
+    delete process.env.AI_GATEWAY_API_KEY;
+    process.env.VERCEL_OIDC_TOKEN = "oidc-token";
+
+    expect(getPiGatewayApiKey()).toBe("oidc-token");
   });
 });

--- a/packages/junior/tests/unit/runtime/respond-agent-continue.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-agent-continue.test.ts
@@ -196,7 +196,7 @@ vi.mock("@/chat/pi/client", () => ({
       reason: "test-router",
     },
   }),
-  getPiGatewayApiKeyOverride: () => "test-gateway-key",
+  getPiGatewayApiKey: () => "test-gateway-key",
   resolveGatewayModel: (modelId: string) => modelId,
 }));
 

--- a/packages/junior/tests/unit/runtime/respond-lazy-sandbox.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-lazy-sandbox.test.ts
@@ -271,7 +271,7 @@ vi.mock("@/chat/pi/client", () => ({
       },
     };
   },
-  getPiGatewayApiKeyOverride: () => undefined,
+  getPiGatewayApiKey: () => undefined,
   resolveGatewayModel: (modelId: string) => modelId,
 }));
 

--- a/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
@@ -417,7 +417,7 @@ vi.mock("@/chat/pi/client", () => ({
     },
   }),
   getGatewayApiKey: () => "test-gateway-key",
-  getPiGatewayApiKeyOverride: () => "test-gateway-key",
+  getPiGatewayApiKey: () => "test-gateway-key",
   resolveGatewayModel: (modelId: string) => modelId,
 }));
 

--- a/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
@@ -206,7 +206,7 @@ vi.mock("@/chat/pi/client", () => ({
       reason: "test-router",
     },
   }),
-  getPiGatewayApiKeyOverride: () => "test-gateway-key",
+  getPiGatewayApiKey: () => "test-gateway-key",
   resolveGatewayModel: (modelId: string) => modelId,
 }));
 


### PR DESCRIPTION
Pi Agent runs now use Junior's Gateway credential resolver instead of relying on Pi to discover only some env vars itself. This fixes local and hosted runs where `AI_GATEWAY_API_KEY` is configured but the Agent path does not receive usable auth.

The direct completion path already resolves explicit Gateway API keys and Vercel OIDC tokens. This applies the same resolver to the main Agent and advisor Agent paths, while leaving Pi's default auth behavior alone when Junior has no explicit credential.