### PR TITLE
feat(plugins): Type source context visibility

### DIFF
--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -7,6 +7,8 @@ import {
   type LocalPgliteFixture,
 } from "@sentry/junior-testing/pglite";
 import {
+  createLocalSource,
+  createSlackSource,
   PluginToolInputError,
   type PluginLogger,
   type PluginModel,
@@ -120,13 +122,12 @@ function slackContext(
       teamId,
       userId: overrides.userId ?? "U123",
     },
-    source: {
-      platform: "slack" as const,
+    source: createSlackSource({
       teamId,
       channelId,
       messageTs: threadTs,
       threadTs,
-    },
+    }),
   };
 }
 
@@ -140,10 +141,7 @@ function localContext(
       platform: "local" as const,
       userId: overrides.userId ?? "local-user",
     },
-    source: {
-      platform: "local" as const,
-      conversationId,
-    },
+    source: createLocalSource(conversationId),
   };
 }
 
@@ -609,6 +607,7 @@ ORDER BY created_at_ms ASC
           },
           source: {
             platform: "slack",
+            type: "pub",
             teamId: "T123",
             channelId: "C123",
             messageTs: "1718800000.000000",

--- a/packages/junior-plugin-api/src/context.ts
+++ b/packages/junior-plugin-api/src/context.ts
@@ -17,6 +17,8 @@ export type LocalRequester = z.output<typeof localRequesterSchema>;
 export type Source = z.output<typeof sourceSchema>;
 export type SlackSource = Extract<Source, { platform: "slack" }>;
 export type LocalSource = Extract<Source, { platform: "local" }>;
+export type SourceType = Source["type"];
+export type SlackChannelType = "channel" | "group" | "im" | "mpim";
 
 export type Destination = z.output<typeof destinationSchema>;
 
@@ -86,6 +88,59 @@ export interface LocalInvocationContext extends BaseInvocationContext {
 }
 
 export type InvocationContext = LocalInvocationContext | SlackInvocationContext;
+
+/** Build a normalized Slack source from runtime-owned Slack coordinates. */
+export function createSlackSource(input: {
+  channelId: string;
+  channelType?: SlackChannelType;
+  messageTs?: string;
+  teamId: string;
+  threadTs?: string;
+}): SlackSource {
+  return {
+    platform: "slack",
+    type: slackSourceType(input),
+    teamId: input.teamId,
+    channelId: input.channelId,
+    ...(input.messageTs ? { messageTs: input.messageTs } : {}),
+    ...(input.threadTs ? { threadTs: input.threadTs } : {}),
+  };
+}
+
+function slackSourceType(input: {
+  channelId: string;
+  channelType?: SlackChannelType;
+}): SourceType {
+  if (input.channelType === "channel") return "pub";
+  if (
+    input.channelType === "group" ||
+    input.channelType === "im" ||
+    input.channelType === "mpim"
+  ) {
+    return "priv";
+  }
+  if (input.channelId.startsWith("D") || input.channelId.startsWith("G")) {
+    return "priv";
+  }
+  if (input.channelId.startsWith("C")) {
+    return "priv";
+  }
+  throw new Error(`Unsupported Slack channel ID prefix: ${input.channelId}`);
+}
+
+/** Build a normalized local source from a local conversation id. */
+export function createLocalSource(conversationId: string): LocalSource {
+  return {
+    platform: "local",
+    type: "priv",
+    conversationId,
+  };
+}
+
+/** Return whether a source is private to a person or restricted group. */
+export function isPrivateSource(source: Source): boolean {
+  return source.type === "priv";
+}
 
 /** Narrow a runtime destination to the Slack-specific address shape. */
 export function isSlackDestination(

--- a/packages/junior-plugin-api/src/context.ts
+++ b/packages/junior-plugin-api/src/context.ts
@@ -123,7 +123,7 @@ function slackSourceType(input: {
     return "priv";
   }
   if (input.channelId.startsWith("C")) {
-    return "priv";
+    return "pub";
   }
   throw new Error(`Unsupported Slack channel ID prefix: ${input.channelId}`);
 }

--- a/packages/junior-plugin-api/src/schemas.ts
+++ b/packages/junior-plugin-api/src/schemas.ts
@@ -19,14 +19,19 @@ export const nonBlankStringSchema = z
 /** Runtime platform names supported by plugin public contracts. */
 export const platformSchema = z.enum(["slack", "local"]);
 
-/** Runtime-owned Slack address for routing future work or side effects. */
-export const slackDestinationSchema = z
+/** Runtime source visibility visible to plugins. */
+export const sourceTypeSchema = z.enum(["pub", "priv"]);
+
+const slackAddressSchema = z
   .object({
     platform: z.literal("slack"),
     teamId: slackTeamIdSchema,
     channelId: slackConversationIdSchema,
   })
   .strict();
+
+/** Runtime-owned Slack address for routing future work or side effects. */
+export const slackDestinationSchema = slackAddressSchema;
 
 /** Runtime-owned local CLI conversation address. */
 export const localDestinationSchema = z
@@ -43,18 +48,22 @@ export const destinationSchema = z.discriminatedUnion("platform", [
 ]);
 
 /** Runtime-owned Slack coordinates for the inbound invocation. */
-export const slackSourceSchema = z
-  .object({
-    platform: z.literal("slack"),
-    teamId: slackTeamIdSchema,
-    channelId: slackConversationIdSchema,
+export const slackSourceSchema = slackAddressSchema
+  .extend({
+    type: sourceTypeSchema,
     messageTs: nonBlankStringSchema.optional(),
     threadTs: nonBlankStringSchema.optional(),
   })
   .strict();
 
 /** Runtime-owned local CLI coordinates for the inbound invocation. */
-export const localSourceSchema = localDestinationSchema;
+export const localSourceSchema = z
+  .object({
+    platform: z.literal("local"),
+    type: z.literal("priv"),
+    conversationId: localConversationIdSchema,
+  })
+  .strict();
 
 /** Runtime-owned provider-neutral coordinates for the inbound invocation. */
 export const sourceSchema = z.discriminatedUnion("platform", [

--- a/packages/junior-scheduler/src/plugin.ts
+++ b/packages/junior-scheduler/src/plugin.ts
@@ -1,5 +1,6 @@
 import {
   defineJuniorPlugin,
+  createSlackSource,
   type Dispatch,
   type PluginToolDefinition,
   type PluginOperationalReportContent,
@@ -76,11 +77,10 @@ function buildScheduledTaskDispatchMetadata(args: {
 }
 
 function scheduledTaskDispatchSource(task: ScheduledTask): Source {
-  return {
-    platform: "slack",
+  return createSlackSource({
     teamId: task.destination.teamId,
     channelId: task.destination.channelId,
-  };
+  });
 }
 
 function schedulerStore(ctx: { db: unknown }): SchedulerStore {
@@ -117,14 +117,7 @@ function createSchedulerToolContext(
 ): SchedulerToolContext {
   return {
     credentialSubject: ctx.slack?.credentialSubject,
-    source:
-      ctx.source.platform === "slack"
-        ? {
-            platform: "slack",
-            teamId: ctx.source.teamId,
-            channelId: ctx.source.channelId,
-          }
-        : undefined,
+    source: ctx.source.platform === "slack" ? ctx.source : undefined,
     requester: ctx.requester?.platform === "slack" ? ctx.requester : undefined,
     store: schedulerStore(ctx),
     userText: ctx.userText,

--- a/packages/junior-scheduler/src/schedule-tools.ts
+++ b/packages/junior-scheduler/src/schedule-tools.ts
@@ -3,12 +3,12 @@ import { Type } from "@sinclair/typebox";
 import {
   PluginToolInputError,
   pluginCredentialSubjectSchema,
-  destinationSchema,
-  isSlackDestination,
+  sourceSchema,
   type PluginCredentialSubject,
   type PluginToolDefinition,
   type SlackDestination,
   type SlackRequester,
+  type SlackSource,
 } from "@sentry/junior-plugin-api";
 import { buildCalendarRecurrence, parseScheduleTimestamp } from "./cadence";
 import { sanitizeScheduledTaskPrincipal } from "./identity";
@@ -26,7 +26,7 @@ import type {
 export interface SchedulerToolContext {
   credentialSubject?: PluginCredentialSubject;
   requester?: SlackRequester;
-  source?: SlackDestination;
+  source?: SlackSource;
   store: SchedulerStore;
   userText?: string;
 }
@@ -47,9 +47,9 @@ function throwToolInputError(error: string): never {
 function requireActiveConversation(
   context: SchedulerToolContext,
 ): SlackDestination {
-  const parsed = destinationSchema.safeParse(context.source);
+  const parsed = sourceSchema.safeParse(context.source);
   if (!parsed.success) {
-    const source = context.source as Partial<SlackDestination> | undefined;
+    const source = context.source as Partial<SlackSource> | undefined;
     const issues = parsed.error.issues as readonly SchemaIssue[];
     if (!source || source.platform !== "slack") {
       throwToolInputError("No active Slack conversation is available.");
@@ -68,11 +68,15 @@ function requireActiveConversation(
     throwToolInputError("No active Slack conversation is available.");
   }
 
-  if (!isSlackDestination(parsed.data)) {
+  if (parsed.data.platform !== "slack") {
     throwToolInputError("No active Slack conversation is available.");
   }
 
-  return parsed.data;
+  return {
+    platform: "slack",
+    teamId: parsed.data.teamId,
+    channelId: parsed.data.channelId,
+  };
 }
 
 function requireRequester(

--- a/packages/junior/src/chat/agent-dispatch/store.ts
+++ b/packages/junior/src/chat/agent-dispatch/store.ts
@@ -159,18 +159,7 @@ function buildDispatchId(plugin: string, idempotencyKey: string): string {
 export function parseDispatchRecord(
   value: unknown,
 ): DispatchRecord | undefined {
-  const candidate =
-    value &&
-    typeof value === "object" &&
-    !Array.isArray(value) &&
-    !("source" in value) &&
-    "destination" in value
-      ? {
-          ...(value as Record<string, unknown>),
-          source: (value as { destination: unknown }).destination,
-        }
-      : value;
-  const parsed = dispatchRecordSchema.safeParse(candidate);
+  const parsed = dispatchRecordSchema.safeParse(value);
   return parsed.success ? (parsed.data as DispatchRecord) : undefined;
 }
 

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -10,6 +10,7 @@ import {
   generateAssistantReply as generateAssistantReplyImpl,
   type AssistantReply,
 } from "@/chat/respond";
+import { createLocalSource } from "@sentry/junior-plugin-api";
 import type { ToolExecutionReport } from "@/chat/tools/agent-tools";
 import { THREAD_STATE_TTL_MS } from "chat";
 import {
@@ -228,6 +229,7 @@ export async function runLocalAgentTurn(
         actor: { type: "system", id: "local-cli" },
       },
       destination,
+      source: createLocalSource(destination.conversationId),
       requester: {
         fullName: "Local CLI",
         platform: "local",

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -8,7 +8,12 @@
  * should stay outside this file.
  */
 import { Agent, type AgentTool } from "@earendil-works/pi-agent-core";
-import type { Destination, Source } from "@sentry/junior-plugin-api";
+import {
+  createLocalSource,
+  createSlackSource,
+  type Destination,
+  type Source,
+} from "@sentry/junior-plugin-api";
 import { THREAD_STATE_TTL_MS, type FileUpload } from "chat";
 import { botConfig } from "@/chat/config";
 import {
@@ -412,10 +417,9 @@ function toolInvocationSource(context: ReplyRequestContext): Source {
     return context.source;
   }
   if (context.destination.platform !== "slack") {
-    return context.destination;
+    return createLocalSource(context.destination.conversationId);
   }
-  return {
-    platform: "slack",
+  return createSlackSource({
     teamId: context.destination.teamId,
     channelId: context.destination.channelId,
     ...(context.correlation?.messageTs
@@ -424,7 +428,7 @@ function toolInvocationSource(context: ReplyRequestContext): Source {
     ...(context.correlation?.threadTs
       ? { threadTs: context.correlation.threadTs }
       : {}),
-  };
+  });
 }
 
 function toolInvocationDestination(context: ReplyRequestContext): Destination {

--- a/packages/junior/src/reporting/conversations.ts
+++ b/packages/junior/src/reporting/conversations.ts
@@ -17,6 +17,11 @@ import type {
   PluginConversations,
   PluginConversationSummary,
   Destination,
+  Source,
+} from "@sentry/junior-plugin-api";
+import {
+  createLocalSource,
+  createSlackSource,
 } from "@sentry/junior-plugin-api";
 import {
   buildSentryConversationUrl,
@@ -1093,8 +1098,23 @@ function countConversationMessages(transcript: TranscriptMessage[]): number {
 function systemPromptMessage(destination: Destination): TranscriptMessage {
   return {
     role: "system",
-    parts: [{ type: "text", text: buildSystemPrompt({ source: destination }) }],
+    parts: [
+      {
+        type: "text",
+        text: buildSystemPrompt({ source: sourceFromDestination(destination) }),
+      },
+    ],
   };
+}
+
+function sourceFromDestination(destination: Destination): Source {
+  if (destination.platform === "local") {
+    return createLocalSource(destination.conversationId);
+  }
+  return createSlackSource({
+    teamId: destination.teamId,
+    channelId: destination.channelId,
+  });
 }
 
 interface ScopedTurnMessages {

--- a/packages/junior/tests/component/memory-plugin-storage.test.ts
+++ b/packages/junior/tests/component/memory-plugin-storage.test.ts
@@ -6,7 +6,10 @@ import {
   createMemoryStore,
   type MemoryDb,
 } from "@sentry/junior-memory";
-import { PluginToolInputError } from "@sentry/junior-plugin-api";
+import {
+  createSlackSource,
+  PluginToolInputError,
+} from "@sentry/junior-plugin-api";
 import { defineJuniorPlugins } from "@/plugins";
 import { getPluginTools, setPlugins } from "@/chat/plugins/agent-hooks";
 import { migratePluginSchemas, readPluginMigrations } from "@/chat/plugins/db";
@@ -120,13 +123,13 @@ WHERE table_name = 'junior_memory_memories'
         teamId: "T123",
         userId: "U123",
       };
-      const source = {
-        platform: "slack" as const,
+      const source = createSlackSource({
         teamId: "T123",
         channelId: "C123",
+        channelType: "channel",
         messageTs: "1718800000.000000",
         threadTs: "1718800000.000000",
-      };
+      });
       const store = createMemoryStore(fixture.sql.db() as unknown as MemoryDb, {
         conversationId,
         requester,

--- a/packages/junior/tests/integration/advisor/advisor-tool.test.ts
+++ b/packages/junior/tests/integration/advisor/advisor-tool.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AgentTool, StreamFn } from "@earendil-works/pi-agent-core";
+import { createLocalSource } from "@sentry/junior-plugin-api";
 import { Type } from "@sinclair/typebox";
 import type { AdvisorConfig } from "@/chat/config";
 import type { PiMessage } from "@/chat/pi/messages";
@@ -19,6 +20,7 @@ const LOCAL_DESTINATION = {
   platform: "local",
   conversationId: "local:test:advisor",
 } as const;
+const LOCAL_SOURCE = createLocalSource(LOCAL_DESTINATION.conversationId);
 
 const config: AdvisorConfig = {
   modelId: "openai/gpt-5.5",
@@ -94,7 +96,7 @@ describe("advisor tool", () => {
   it("is exposed only when advisor runtime context is enabled", () => {
     const baseContext = {
       destination: LOCAL_DESTINATION,
-      source: LOCAL_DESTINATION,
+      source: LOCAL_SOURCE,
       sandbox: {} as any,
     };
     expect(createTools([], {}, baseContext)).not.toHaveProperty("advisor");
@@ -189,7 +191,7 @@ describe("advisor tool", () => {
         {},
         {
           destination: LOCAL_DESTINATION,
-          source: LOCAL_DESTINATION,
+          source: LOCAL_SOURCE,
           sandbox: {} as any,
         },
       ),

--- a/packages/junior/tests/integration/agent-dispatch-runner.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-runner.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSlackSource } from "@sentry/junior-plugin-api";
 import {
   createOrGetDispatch,
   getDispatchConversationId,
@@ -78,6 +79,14 @@ function slackAddress(channelId = "C123") {
   };
 }
 
+function slackSource(channelId = "C123") {
+  return createSlackSource({
+    teamId: "T123",
+    channelId,
+    channelType: channelId.startsWith("C") ? "channel" : "im",
+  });
+}
+
 describe("agent dispatch runner", () => {
   beforeEach(async () => {
     process.env.JUNIOR_SECRET = "dispatch-runner-secret";
@@ -104,7 +113,7 @@ describe("agent dispatch runner", () => {
         destination: slackAddress(),
         input: "Run the scheduled task.",
         metadata: { runId: "run-1" },
-        source: slackAddress(),
+        source: slackSource(),
       },
     });
     const dispatchConversationId = getDispatchConversationId(created.record);
@@ -112,7 +121,7 @@ describe("agent dispatch runner", () => {
       expect(context.requester).toBeUndefined();
       expect(context.authorizationFlowMode).toBe("disabled");
       expect(context.surface).toBe("api");
-      expect(context.source).toEqual(slackAddress());
+      expect(context.source).toEqual(slackSource());
       expect(context.dispatch).toEqual({
         actor: { type: "system", id: "scheduler" },
         metadata: { runId: "run-1" },
@@ -214,7 +223,7 @@ describe("agent dispatch runner", () => {
         destination: slackAddress(),
         input: "Run the scheduled task.",
         metadata: { runId: "run-isolated-context" },
-        source: slackAddress(),
+        source: slackSource(),
       },
     });
     const dispatchConversationId = getDispatchConversationId(created.record);
@@ -263,7 +272,7 @@ describe("agent dispatch runner", () => {
         idempotencyKey: "run-timeout",
         destination: slackAddress(),
         input: "Run the scheduled task.",
-        source: slackAddress(),
+        source: slackSource(),
       },
     });
     const scheduleCallback = vi.fn(async () => undefined);
@@ -306,7 +315,7 @@ describe("agent dispatch runner", () => {
         credentialSubject: createCredentialSubject(),
         destination: slackAddress("D123"),
         input: "Run the scheduled task.",
-        source: slackAddress("D123"),
+        source: slackSource("D123"),
       },
     });
     const generateAssistantReply = vi.fn(async (_input, context) => {
@@ -351,7 +360,7 @@ describe("agent dispatch runner", () => {
         idempotencyKey: "run-busy",
         destination: slackAddress(),
         input: "Run the scheduled task.",
-        source: slackAddress(),
+        source: slackSource(),
       },
     });
     const state = getStateAdapter();

--- a/packages/junior/tests/integration/heartbeat.test.ts
+++ b/packages/junior/tests/integration/heartbeat.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  createSlackSource,
   defineJuniorPlugin,
   type Destination,
   type Source,
@@ -46,11 +47,19 @@ const SLACK_DESTINATION = {
   teamId: "T123",
   channelId: "C123",
 } satisfies Destination;
-const SLACK_SOURCE = {
-  platform: "slack",
+const SLACK_SOURCE = createSlackSource({
   teamId: "T123",
   channelId: "C123",
-} satisfies Source;
+  channelType: "channel",
+}) satisfies Source;
+
+function slackDmSource(channelId = "D123"): Source {
+  return createSlackSource({
+    teamId: "T123",
+    channelId,
+    channelType: "im",
+  });
+}
 
 let schedulerDb: SchedulerDb | undefined;
 
@@ -584,11 +593,7 @@ describe("plugin heartbeat", () => {
           channelId: "D123",
         },
         input: "Run the scheduled task.",
-        source: {
-          platform: "slack",
-          teamId: "T123",
-          channelId: "D123",
-        },
+        source: slackDmSource(),
       }),
     ).rejects.toThrow("Dispatch credentialSubject binding is runtime-owned");
     expect(getCapturedSlackApiCalls("conversations.info")).toHaveLength(0);
@@ -611,11 +616,7 @@ describe("plugin heartbeat", () => {
         channelId: "D123",
       },
       input: "Run the scheduled task.",
-      source: {
-        platform: "slack",
-        teamId: "T123",
-        channelId: "D123",
-      },
+      source: slackDmSource(),
     });
 
     await expect(getDispatchRecord(result.id)).resolves.toMatchObject({
@@ -846,7 +847,12 @@ describe("plugin heartbeat", () => {
       "Post a digest. Summarize the latest state.",
     );
     expect(dispatchRecord?.destination).toEqual(SLACK_DESTINATION);
-    expect(dispatchRecord?.source).toEqual(SLACK_SOURCE);
+    expect(dispatchRecord?.source).toEqual(
+      createSlackSource({
+        teamId: "T123",
+        channelId: "C123",
+      }),
+    );
     expect(dispatchRecord?.metadata).toMatchObject({
       creatorSlackUserId: "U039RR91S",
       runId: `sched_plugin_1:${TEST_RUN_AT_MS}`,

--- a/packages/junior/tests/integration/slack-channel-tools.test.ts
+++ b/packages/junior/tests/integration/slack-channel-tools.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { createSlackSource } from "@sentry/junior-plugin-api";
 import { createSlackChannelListMessagesTool } from "@/chat/tools/slack/channel-list-messages";
 import { createSlackChannelPostMessageTool } from "@/chat/tools/slack/channel-post-message";
 import { createSlackMessageAddReactionTool } from "@/chat/tools/slack/message-add-reaction";
@@ -47,12 +48,12 @@ function createContext(
       teamId: "T123",
       channelId: destinationChannelId,
     },
-    source: {
-      platform: "slack",
+    source: createSlackSource({
       teamId: "T123",
       channelId: sourceChannelId,
+      channelType: sourceChannelId.startsWith("C") ? "channel" : "im",
       messageTs: "1700000000.321",
-    },
+    }),
     destinationChannelId,
     messageTs: "1700000000.321",
     sourceChannelId,

--- a/packages/junior/tests/integration/slack-schedule-tools.test.ts
+++ b/packages/junior/tests/integration/slack-schedule-tools.test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSlackSource } from "@sentry/junior-plugin-api";
 import {
   PluginToolInputError,
   type PluginToolDefinition,
@@ -67,11 +68,11 @@ function createContext(
   delete contextOverrides.channelId;
   delete contextOverrides.teamId;
   const context: SchedulerToolContext = {
-    source: {
-      platform: "slack",
+    source: createSlackSource({
       teamId,
       channelId,
-    },
+      channelType: channelId.startsWith("C") ? "channel" : "im",
+    }),
     requester: {
       platform: "slack",
       teamId,
@@ -321,25 +322,26 @@ describe("Slack schedule tools", () => {
     ).resolves.toEqual([]);
   });
 
-  it("rejects non-canonical Slack source context before creating a task", async () => {
-    const rejected = createTask(
+  it("accepts Slack source message context and stores canonical task destinations", async () => {
+    const result = await createTask(
       createContext({
-        source: {
-          platform: "slack",
+        source: createSlackSource({
           teamId: TEST_TEAM_ID,
           channelId: "C123",
+          channelType: "channel",
           threadTs: "1700000000.000",
-        } as SchedulerToolContext["source"],
+        }),
       }),
     );
 
-    await expect(rejected).rejects.toThrow(PluginToolInputError);
-    await expect(rejected).rejects.toThrow(
-      "Active Slack conversation must not include unknown fields.",
-    );
-    await expect(
-      schedulerStore().listTasksForTeam(TEST_TEAM_ID),
-    ).resolves.toEqual([]);
+    const taskId = (result as { task: { id: string } }).task.id;
+    await expect(schedulerStore().getTask(taskId)).resolves.toMatchObject({
+      destination: {
+        platform: "slack",
+        teamId: TEST_TEAM_ID,
+        channelId: "C123",
+      },
+    });
   });
 
   it("rejects invalid Slack credential subject context before creating a task", async () => {
@@ -884,7 +886,11 @@ describe("Slack schedule tools", () => {
         {
           ...context,
           source: {
-            platform: "slack",
+            ...createSlackSource({
+              teamId: TEST_TEAM_ID,
+              channelId: "D123",
+              channelType: "im",
+            }),
             teamId: TEST_TEAM_ID,
             channelId: "slack:D123:1700000000.000",
           },
@@ -1213,11 +1219,11 @@ describe("Slack schedule tool wiring via getPluginTools", () => {
     try {
       const TEAM_ID = `TWIRING${Date.now()}`;
       const tools = getPluginTools({
-        source: {
-          platform: "slack",
+        source: createSlackSource({
           teamId: TEAM_ID,
           channelId: "DDM",
-        },
+          channelType: "im",
+        }),
         destination: {
           platform: "slack",
           teamId: TEAM_ID,

--- a/packages/junior/tests/integration/slack-thread-read.test.ts
+++ b/packages/junior/tests/integration/slack-thread-read.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { createSlackSource } from "@sentry/junior-plugin-api";
 import { createSlackThreadReadTool } from "@/chat/tools/slack/thread-read";
 import type { SlackToolContext } from "@/chat/tools/slack/context";
 import { conversationsRepliesPage } from "../fixtures/slack/factories/api";
@@ -20,11 +21,13 @@ function createContext(
       teamId: "T123",
       channelId: destinationChannelId,
     },
-    source: overrides.source ?? {
-      platform: "slack",
-      teamId: "T123",
-      channelId: sourceChannelId,
-    },
+    source:
+      overrides.source ??
+      createSlackSource({
+        teamId: "T123",
+        channelId: sourceChannelId,
+        channelType: sourceChannelId.startsWith("C") ? "channel" : "im",
+      }),
     destinationChannelId,
     sourceChannelId,
     teamId: "T123",

--- a/packages/junior/tests/integration/slack-user-lookup.test.ts
+++ b/packages/junior/tests/integration/slack-user-lookup.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { createSlackSource } from "@sentry/junior-plugin-api";
 import { createSlackUserLookupTool } from "@/chat/tools/slack/user-lookup";
 import { usersInfoOk, usersListPage } from "../fixtures/slack/factories/api";
 import {
@@ -342,11 +343,11 @@ describe("slackUserLookup", () => {
         [],
         {},
         {
-          source: {
-            platform: "slack",
+          source: createSlackSource({
             teamId: "T_TEST",
             channelId: "C_TEST",
-          },
+            channelType: "channel",
+          }),
           destination: {
             platform: "slack",
             teamId: "T_TEST",

--- a/packages/junior/tests/integration/tool-idempotency.test.ts
+++ b/packages/junior/tests/integration/tool-idempotency.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { createSlackSource } from "@sentry/junior-plugin-api";
 import { createSlackCanvasCreateTool } from "@/chat/tools/slack/canvas-tools";
 import { createOperationKey } from "@/chat/tools/idempotency";
 import { createSlackListAddItemsTool } from "@/chat/tools/slack/list-tools";
@@ -56,11 +57,11 @@ function slackContext(channelId: string): SlackToolContext {
       teamId: "T123",
       channelId,
     },
-    source: {
-      platform: "slack" as const,
+    source: createSlackSource({
       teamId: "T123",
       channelId,
-    },
+      channelType: channelId.startsWith("C") ? "channel" : "im",
+    }),
     destinationChannelId: channelId,
     sourceChannelId: channelId,
     teamId: "T123",

--- a/packages/junior/tests/unit/plugin-api-source.test.ts
+++ b/packages/junior/tests/unit/plugin-api-source.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { createSlackSource } from "@sentry/junior-plugin-api";
+
+describe("plugin source helpers", () => {
+  it("infers Slack source visibility from channel ids when event type is unavailable", () => {
+    expect(
+      createSlackSource({ teamId: "T123", channelId: "C123" }),
+    ).toMatchObject({ type: "pub" });
+    expect(
+      createSlackSource({ teamId: "T123", channelId: "G123" }),
+    ).toMatchObject({ type: "priv" });
+    expect(
+      createSlackSource({ teamId: "T123", channelId: "D123" }),
+    ).toMatchObject({ type: "priv" });
+  });
+});

--- a/packages/junior/tests/unit/plugins/agent-hooks.test.ts
+++ b/packages/junior/tests/unit/plugins/agent-hooks.test.ts
@@ -1,4 +1,6 @@
 import {
+  createLocalSource,
+  createSlackSource,
   defineJuniorPlugin,
   type PluginConversations,
   type ToolRegistrationHookContext,
@@ -30,6 +32,7 @@ const LOCAL_DESTINATION = {
   platform: "local",
   conversationId: "local:test:agent-hooks",
 } as const;
+const LOCAL_SOURCE = createLocalSource(LOCAL_DESTINATION.conversationId);
 
 const EMPTY_CONVERSATIONS: PluginConversations = {
   async listRecent() {
@@ -42,6 +45,19 @@ const SLACK_DESTINATION = {
   teamId: "T123",
   channelId: "DDM",
 } as const;
+const SLACK_SOURCE = createSlackSource({
+  teamId: SLACK_DESTINATION.teamId,
+  channelId: SLACK_DESTINATION.channelId,
+  channelType: "im",
+});
+
+function slackSource(channelId: string) {
+  return createSlackSource({
+    teamId: "T123",
+    channelId,
+    channelType: channelId.startsWith("C") ? "channel" : "im",
+  });
+}
 
 function fakeSandbox(
   writes: Array<{ content: string | Uint8Array; path: string }>,
@@ -125,7 +141,7 @@ describe("agent plugin hooks", () => {
     ]);
     try {
       await expect(
-        getPluginSystemPromptContributions(LOCAL_DESTINATION),
+        getPluginSystemPromptContributions(LOCAL_SOURCE),
       ).resolves.toEqual([
         { id: "systemPrompt:0", pluginName: "a-demo", text: "A contribution" },
         { id: "systemPrompt:0", pluginName: "z-demo", text: "Z contribution" },
@@ -152,7 +168,7 @@ describe("agent plugin hooks", () => {
     ]);
     try {
       await expect(
-        getPluginSystemPromptContributions(LOCAL_DESTINATION),
+        getPluginSystemPromptContributions(LOCAL_SOURCE),
       ).resolves.toEqual([]);
     } finally {
       setPlugins(previous);
@@ -170,7 +186,7 @@ describe("agent plugin hooks", () => {
         hooks: {
           async userPrompt(ctx) {
             expect(ctx.requester).toBeUndefined();
-            expect(ctx.source).toEqual(LOCAL_DESTINATION);
+            expect(ctx.source).toEqual(LOCAL_SOURCE);
             expect(ctx.text).toBe("remember this");
             expect(ctx).toHaveProperty("embedder");
             expect(ctx).not.toHaveProperty("model");
@@ -184,7 +200,7 @@ describe("agent plugin hooks", () => {
         getPluginUserPromptContributions({
           context: {
             conversationId: "conversation-1",
-            source: LOCAL_DESTINATION,
+            source: LOCAL_SOURCE,
             destination: LOCAL_DESTINATION,
             userText: "remember this",
           },
@@ -221,7 +237,7 @@ describe("agent plugin hooks", () => {
         getPluginUserPromptContributions({
           context: {
             conversationId: "conversation-1",
-            source: LOCAL_DESTINATION,
+            source: LOCAL_SOURCE,
             destination: LOCAL_DESTINATION,
             userText: "hello",
           },
@@ -252,7 +268,7 @@ describe("agent plugin hooks", () => {
         getPluginUserPromptContributions({
           context: {
             conversationId: "conversation-1",
-            source: LOCAL_DESTINATION,
+            source: LOCAL_SOURCE,
             destination: LOCAL_DESTINATION,
             userText: "hello",
           },
@@ -295,7 +311,7 @@ describe("agent plugin hooks", () => {
         getPluginUserPromptContributions({
           context: {
             conversationId: "conversation-1",
-            source: LOCAL_DESTINATION,
+            source: LOCAL_SOURCE,
             destination: LOCAL_DESTINATION,
             userText: "hello",
           },
@@ -343,7 +359,7 @@ describe("agent plugin hooks", () => {
       const tools = getPluginTools({
         destination: SLACK_DESTINATION,
         requester: TEST_REQUESTER,
-        source: SLACK_DESTINATION,
+        source: SLACK_SOURCE,
         sandbox: {} as any,
       });
 
@@ -378,7 +394,7 @@ describe("agent plugin hooks", () => {
       expect(() =>
         getPluginTools({
           destination: LOCAL_DESTINATION,
-          source: LOCAL_DESTINATION,
+          source: LOCAL_SOURCE,
           sandbox: {} as any,
         }),
       ).toThrow("must be a camelCase identifier");
@@ -415,7 +431,7 @@ describe("agent plugin hooks", () => {
           {},
           {
             destination: LOCAL_DESTINATION,
-            source: LOCAL_DESTINATION,
+            source: LOCAL_SOURCE,
             sandbox: {} as any,
           },
         ),
@@ -810,7 +826,7 @@ describe("getPluginTools channel resolution", () => {
   function capturePluginContext(
     context: ToolRuntimeContext = {
       destination: LOCAL_DESTINATION,
-      source: LOCAL_DESTINATION,
+      source: LOCAL_SOURCE,
       sandbox: {} as any,
     },
   ) {
@@ -839,12 +855,9 @@ describe("getPluginTools channel resolution", () => {
   }
 
   it("passes runtime-owned destination directly to plugin hooks", () => {
+    const source = slackSource("DDM");
     const ctx = capturePluginContext({
-      source: {
-        platform: "slack",
-        teamId: "T123",
-        channelId: "DDM",
-      },
+      source,
       destination: {
         platform: "slack",
         teamId: "T123",
@@ -852,11 +865,7 @@ describe("getPluginTools channel resolution", () => {
       },
       sandbox: {} as any,
     });
-    expect(ctx.source).toEqual({
-      platform: "slack",
-      teamId: "T123",
-      channelId: "DDM",
-    });
+    expect(ctx.source).toEqual(source);
     expect(ctx.destination).toEqual({
       platform: "slack",
       teamId: "T123",
@@ -867,11 +876,7 @@ describe("getPluginTools channel resolution", () => {
   it("computes channelCapabilities from source channelId", () => {
     // DM channel: canvas and reactions yes, standalone channel-post no
     const ctx = capturePluginContext({
-      source: {
-        platform: "slack",
-        teamId: "T123",
-        channelId: "DDM",
-      },
+      source: slackSource("DDM"),
       destination: {
         platform: "slack",
         teamId: "T123",
@@ -886,11 +891,7 @@ describe("getPluginTools channel resolution", () => {
 
   it("creates a direct credential subject when channelId is a DM", () => {
     const ctx = capturePluginContext({
-      source: {
-        platform: "slack",
-        teamId: "T123",
-        channelId: "DDM",
-      },
+      source: slackSource("DDM"),
       destination: {
         platform: "slack",
         teamId: "T123",
@@ -909,11 +910,7 @@ describe("getPluginTools channel resolution", () => {
 
   it("does not create a credential subject when channelId is not a DM", () => {
     const ctx = capturePluginContext({
-      source: {
-        platform: "slack",
-        teamId: "T123",
-        channelId: "CSOURCE",
-      },
+      source: slackSource("CSOURCE"),
       destination: {
         platform: "slack",
         teamId: "T123",
@@ -930,7 +927,7 @@ describe("getPluginTools channel resolution", () => {
     const ctx = capturePluginContext({
       conversationId: "slack:DDM:1780479160.406339",
       destination: SLACK_DESTINATION,
-      source: SLACK_DESTINATION,
+      source: SLACK_SOURCE,
       sandbox: {} as any,
     });
 
@@ -946,7 +943,7 @@ describe("getPluginTools channel resolution", () => {
   it("does not synthesize Slack context from local destinations", () => {
     const ctx = capturePluginContext();
     expect(ctx.destination).toEqual(LOCAL_DESTINATION);
-    expect(ctx.source).toEqual(LOCAL_DESTINATION);
+    expect(ctx.source).toEqual(LOCAL_SOURCE);
     expect(ctx.slack).toBeUndefined();
   });
 });

--- a/packages/junior/tests/unit/prompt.test.ts
+++ b/packages/junior/tests/unit/prompt.test.ts
@@ -1,33 +1,34 @@
 import { describe, expect, it } from "vitest";
+import {
+  createLocalSource,
+  createSlackSource,
+} from "@sentry/junior-plugin-api";
 import { buildSystemPrompt, buildTurnContextPrompt } from "@/chat/prompt";
 
 describe("prompt builders", () => {
   it("returns a byte-stable static system prompt", () => {
-    const source = {
-      platform: "slack" as const,
+    const source = createSlackSource({
       teamId: "T123",
       channelId: "C123",
-    };
+      channelType: "channel",
+    });
     const systemPrompt = buildSystemPrompt({ source });
 
     expect(buildSystemPrompt({ source })).toBe(systemPrompt);
   });
 
   it("returns a byte-stable local system prompt variant", () => {
-    const source = {
-      platform: "local" as const,
-      conversationId: "local:test:run-test",
-    };
+    const source = createLocalSource("local:test:run-test");
     const systemPrompt = buildSystemPrompt({ source });
 
     expect(buildSystemPrompt({ source })).toBe(systemPrompt);
     expect(systemPrompt).not.toBe(
       buildSystemPrompt({
-        source: {
-          platform: "slack",
+        source: createSlackSource({
           teamId: "T123",
           channelId: "C123",
-        },
+          channelType: "channel",
+        }),
       }),
     );
   });
@@ -73,11 +74,11 @@ describe("prompt builders", () => {
       dispatch: {
         actor: { type: "system", id: "scheduler" },
         plugin: "scheduler",
-        source: {
-          platform: "slack",
+        source: createSlackSource({
           teamId: "T123",
           channelId: "C123",
-        },
+          channelType: "channel",
+        }),
         destination: {
           platform: "slack",
           teamId: "T123",

--- a/packages/junior/tests/unit/runtime/agent-dispatch-validation.test.ts
+++ b/packages/junior/tests/unit/runtime/agent-dispatch-validation.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { createSlackSource } from "@sentry/junior-plugin-api";
 import {
   validateDispatchOptions,
   verifyDispatchCredentialSubjectAccess,
@@ -17,11 +18,11 @@ const validOptions = {
     channelId: "C123",
   },
   input: "Run the scheduled task.",
-  source: {
-    platform: "slack" as const,
+  source: createSlackSource({
     teamId: "T123",
     channelId: "C123",
-  },
+    channelType: "channel",
+  }),
 };
 
 function createPluginCredentialSubject(
@@ -201,7 +202,7 @@ describe("agent dispatch validation", () => {
     ).toBeUndefined();
   });
 
-  it("backfills legacy persisted dispatch source from destination", () => {
+  it("rejects persisted dispatch records without source", () => {
     const legacyRecord = {
       actor: { type: "system", id: "scheduler" },
       attempt: 0,
@@ -217,20 +218,7 @@ describe("agent dispatch validation", () => {
       version: 1,
     };
 
-    expect(parseDispatchRecord(legacyRecord)).toMatchObject({
-      id: "dispatch_legacy",
-      source: validOptions.source,
-    });
-
-    expect(
-      parseDispatchRecord({
-        ...legacyRecord,
-        destination: {
-          ...validOptions.destination,
-          threadTs: "1700000000.000",
-        },
-      }),
-    ).toBeUndefined();
+    expect(parseDispatchRecord(legacyRecord)).toBeUndefined();
   });
 
   it("bounds durable idempotency and metadata keys", () => {

--- a/packages/junior/tests/unit/slack/slack-message-add-reaction-tool.test.ts
+++ b/packages/junior/tests/unit/slack/slack-message-add-reaction-tool.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createSlackSource } from "@sentry/junior-plugin-api";
 import { createSlackMessageAddReactionTool } from "@/chat/tools/slack/message-add-reaction";
 import type { SlackToolContext } from "@/chat/tools/slack/context";
 
@@ -14,12 +15,12 @@ const TEST_SLACK_CONTEXT: SlackToolContext = {
     teamId: "T123",
     channelId: "C123",
   },
-  source: {
-    platform: "slack",
+  source: createSlackSource({
     teamId: "T123",
     channelId: "C123",
+    channelType: "channel",
     messageTs: "1700000000.100",
-  },
+  }),
   destinationChannelId: "C123",
   messageTs: "1700000000.100",
   sourceChannelId: "C123",

--- a/packages/junior/tests/unit/slack/tool-registration.test.ts
+++ b/packages/junior/tests/unit/slack/tool-registration.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createLocalSource,
+  createSlackSource,
+} from "@sentry/junior-plugin-api";
 import { createTools } from "@/chat/tools";
 import type { ToolRuntimeContext } from "@/chat/tools/types";
 import { schedulerPlugin } from "@sentry/junior-scheduler";
@@ -16,10 +20,7 @@ function ctx(channelId?: string): ToolRuntimeContext {
         platform: "local" as const,
         conversationId: "local:test:tool-registration",
       },
-      source: {
-        platform: "local" as const,
-        conversationId: "local:test:tool-registration",
-      },
+      source: createLocalSource("local:test:tool-registration"),
       sandbox: noopSandbox,
     };
   }
@@ -30,11 +31,11 @@ function ctx(channelId?: string): ToolRuntimeContext {
       teamId: "T123",
       channelId,
     },
-    source: {
-      platform: "slack" as const,
+    source: createSlackSource({
       teamId: "T123",
       channelId,
-    },
+      channelType: channelId.startsWith("C") ? "channel" : "im",
+    }),
     sandbox: noopSandbox,
   };
 }
@@ -165,10 +166,7 @@ describe("Slack tool registration", () => {
           platform: "local",
           conversationId: "local:test:run-test",
         },
-        source: {
-          platform: "local",
-          conversationId: "local:test:run-test",
-        },
+        source: createLocalSource("local:test:run-test"),
         sandbox: noopSandbox,
       },
     );


### PR DESCRIPTION
Plugin sources now carry explicit visibility: Slack and local sources include `type: "pub" | "priv"`, and runtime code builds them through `createSlackSource` / `createLocalSource` instead of reusing destination-shaped objects. This gives plugins a small, typed way to tell where an invocation came from and whether that source is public or private, while keeping outbound destinations as routing addresses only.

Scheduler now accepts the full `SlackSource` at the plugin boundary, then stores canonical Slack destinations for scheduled tasks. Dispatch records also hard-cut to the current source contract: persisted dispatches without `source` no longer backfill it from `destination`, so invalid old shapes are skipped instead of silently normalized.

The branch intentionally does not add source persistence to turn-session records; that remains out of scope until a later slice has a concrete runtime consumer for it.