### PR TITLE
fix(mcp): Let unrelated turns bypass pending auth restore

### DIFF
--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -1171,6 +1171,22 @@ export async function generateAssistantReply(
     }));
 
     // ── MCP provider activation ──────────────────────────────────────
+    // If a prior turn left an MCP provider pending user authorization, skip
+    // eager restoration of that provider here. Without this guard, every
+    // subsequent turn in the conversation would attempt to activate the
+    // still-unauthenticated provider, throw McpAuthorizationPauseError, and
+    // abort the agent run before the user's new request is even handled —
+    // even for requests that have nothing to do with that provider.
+    //
+    // Skipping only suppresses the eager-restore path. The agent can still
+    // trigger the auth flow intentionally (via loadSkill + searchMcpTools)
+    // when the user's request genuinely requires that provider.
+    const priorPendingMcpProvider =
+      context.pendingAuth?.kind === "mcp" &&
+      context.pendingAuth.requesterId === authRequesterId
+        ? context.pendingAuth.provider
+        : undefined;
+
     // Restore providers visible in durable Pi session history. In serverless
     // runtimes, later slices and follow-up turns usually run in a fresh
     // process, so in-memory MCP clients cannot be reused.
@@ -1179,6 +1195,9 @@ export async function generateAssistantReply(
       ...inferActiveMcpProvidersFromPiMessages(priorPiMessages),
     ]);
     for (const provider of providersToRestore) {
+      if (provider === priorPendingMcpProvider) {
+        continue; // awaiting user authorization — skip to avoid aborting unrelated turns
+      }
       if (await turnMcpToolManager.activateProvider(provider)) {
         await recordConnectedMcpProvider(provider);
       }
@@ -1189,6 +1208,9 @@ export async function generateAssistantReply(
     }
     // Activate MCP for skills recovered from durable Pi history.
     for (const skill of activeSkills) {
+      if (skill.pluginProvider === priorPendingMcpProvider) {
+        continue; // awaiting user authorization — skip to avoid aborting unrelated turns
+      }
       if (await turnMcpToolManager.activateForSkill(skill)) {
         await recordConnectedMcpProvider(skill.pluginProvider!);
       }

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -1172,18 +1172,16 @@ export async function generateAssistantReply(
 
     // ── MCP provider activation ──────────────────────────────────────
     // If a prior turn left an MCP provider pending user authorization, skip
-    // eager restoration of that provider here. Without this guard, every
-    // subsequent turn in the conversation would attempt to activate the
+    // eager restoration of that provider here. Without this guard, a later
+    // unrelated turn in the same conversation can try to activate the
     // still-unauthenticated provider, throw McpAuthorizationPauseError, and
-    // abort the agent run before the user's new request is even handled —
-    // even for requests that have nothing to do with that provider.
+    // abort before the agent sees the user's request.
     //
     // Skipping only suppresses the eager-restore path. The agent can still
     // trigger the auth flow intentionally (via loadSkill + searchMcpTools)
     // when the user's request genuinely requires that provider.
-    const priorPendingMcpProvider =
-      context.pendingAuth?.kind === "mcp" &&
-      context.pendingAuth.requesterId === authRequesterId
+    const pendingMcpProvider =
+      context.pendingAuth?.kind === "mcp"
         ? context.pendingAuth.provider
         : undefined;
 
@@ -1195,7 +1193,7 @@ export async function generateAssistantReply(
       ...inferActiveMcpProvidersFromPiMessages(priorPiMessages),
     ]);
     for (const provider of providersToRestore) {
-      if (provider === priorPendingMcpProvider) {
+      if (provider === pendingMcpProvider) {
         continue; // awaiting user authorization — skip to avoid aborting unrelated turns
       }
       if (await turnMcpToolManager.activateProvider(provider)) {
@@ -1208,7 +1206,7 @@ export async function generateAssistantReply(
     }
     // Activate MCP for skills recovered from durable Pi history.
     for (const skill of activeSkills) {
-      if (skill.pluginProvider === priorPendingMcpProvider) {
+      if (skill.pluginProvider === pendingMcpProvider) {
         continue; // awaiting user authorization — skip to avoid aborting unrelated turns
       }
       if (await turnMcpToolManager.activateForSkill(skill)) {

--- a/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
+++ b/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
@@ -174,8 +174,20 @@ vi.mock("@earendil-works/pi-agent-core", () => {
         throw new Error("loadSkill tool missing");
       }
 
-      await loadSkillTool.execute("tool-load-skill", {
+      const loadSkillResult = (await loadSkillTool.execute("tool-load-skill", {
         skill_name: SKILL_NAME,
+      })) as {
+        ok?: boolean;
+        skill_name?: string;
+      };
+      this.state.messages.push({
+        role: "toolResult",
+        toolCallId: "tool-load-skill",
+        toolName: "loadSkill",
+        skill_name: loadSkillResult.skill_name,
+        ok: loadSkillResult.ok,
+        details: loadSkillResult,
+        isError: false,
       });
 
       if (this.aborted) {
@@ -242,7 +254,11 @@ vi.mock("@earendil-works/pi-agent-core", () => {
     }
   }
 
-  return { Agent: FakeAgent };
+  return {
+    Agent: FakeAgent,
+    estimateContextTokens: () => ({ tokens: 0 }),
+    estimateTokens: () => 0,
+  };
 });
 
 const ORIGINAL_ENV = { ...process.env };
@@ -806,116 +822,136 @@ describe("mcp auth runtime slack integration", () => {
     ]);
   });
 
-  it("does not abort unrelated turns when MCP auth is already pending from a prior turn", async () => {
-    // Regression: if a user previously triggered an MCP provider's auth
-    // challenge, Junior was restoring the pending-auth skill from Pi history
-    // and calling activateProvider() on EVERY subsequent turn in the
-    // conversation — even for completely unrelated requests. This caused the
-    // pre-agent MCP restoration loop to throw McpAuthorizationPauseError and
-    // abort the turn before the agent ran.
-    agentProbe.shouldBypassSkill = true;
-    const threadId = "slack:C126:1700000000.004";
-    const turnId = "turn_user-4";
-    const { createTestChatRuntime } = chatRuntimeModule;
-    const { slackRuntime } = createTestChatRuntime({
-      services: {
-        visionContext: {
-          listThreadReplies: async () => [],
+  it.each([
+    {
+      label: "same requester",
+      currentRequesterId: "U123",
+      currentRequesterName: "dcramer",
+    },
+    {
+      label: "different requester",
+      currentRequesterId: "U999",
+      currentRequesterName: "paul",
+    },
+  ])(
+    "does not abort unrelated turns for the $label when MCP auth is already pending from a prior turn",
+    async ({ currentRequesterId, currentRequesterName }) => {
+      const threadId = "slack:C126:1700000000.004";
+      const { createTestChatRuntime } = chatRuntimeModule;
+      const { slackRuntime } = createTestChatRuntime({
+        services: {
+          visionContext: {
+            listThreadReplies: async () => [],
+          },
         },
-      },
-    });
+      });
 
-    const destination = {
-      platform: "slack" as const,
-      teamId: "T123",
-      channelId: "C126",
-    };
+      const destination = {
+        platform: "slack" as const,
+        teamId: "T123",
+        channelId: "C126",
+      };
 
-    // Simulate a conversation where a prior turn already triggered MCP auth
-    // for the eval-auth provider. The thread state has pendingAuth set and
-    // the Pi history contains a prior loadSkill("eval-auth") result so that
-    // inferLoadedSkillNamesFromPiMessages will restore the skill.
-    const thread = createTestThread({
-      id: threadId,
-      state: {
-        conversation: {
-          messages: [
-            {
-              id: "assistant-1",
-              role: "assistant",
-              text: "Please authorize via the link I sent you.",
-              createdAtMs: 1,
-              author: {
-                userName: "junior",
-                isBot: true,
+      const thread = createTestThread({
+        id: threadId,
+        state: {
+          conversation: {
+            messages: [
+              {
+                id: "assistant-1",
+                role: "assistant",
+                text: "Please authorize via the link I sent you.",
+                createdAtMs: 1,
+                author: {
+                  userName: "junior",
+                  isBot: true,
+                },
               },
-            },
-          ],
+            ],
+          },
+        },
+      });
+      await mirrorThreadStateToAdapter(thread);
+
+      await slackRuntime.handleNewMention(
+        thread,
+        createTestMessage({
+          id: "user-auth",
+          threadId,
+          text: "what did i say about the budget?",
+          isMention: true,
+          author: {
+            userId: "U123",
+            userName: "dcramer",
+          },
+          raw: {
+            channel: "C126",
+            team_id: "T123",
+            ts: "1700000000.005",
+            thread_ts: "1700000000.004",
+          },
+        }),
+        { destination },
+      );
+
+      expect(agentProbe.promptCallCount).toBe(1);
+      expect(thread.posts).toEqual([
+        expect.objectContaining({
+          markdown: expect.stringContaining(
+            "<@U123> I'll need you to authorize Eval Auth. I sent you a link.",
+          ),
+        }),
+      ]);
+      expect(
+        await threadStateModule.getPersistedThreadState(threadId),
+      ).toMatchObject({
+        conversation: {
           processing: {
             pendingAuth: {
               kind: "mcp",
               provider: EVAL_MCP_AUTH_PROVIDER,
               requesterId: "U123",
-              sessionId: "turn_prior-turn",
-              linkSentAtMs: Date.now() - 5_000,
+              sessionId: "turn_user-auth",
+              linkSentAtMs: expect.any(Number),
             },
           },
         },
-        piMessages: [
-          // Simulate a prior turn's loadSkill("eval-auth") result in history.
-          // inferLoadedSkillNamesFromPiMessages will pick this up and try to
-          // restore the skill's MCP provider on the next turn.
-          {
-            role: "toolResult",
-            toolName: "loadSkill",
-            skill_name: SKILL_NAME,
-            ok: true,
-            details: { skill_name: SKILL_NAME },
-            isError: false,
+      });
+
+      const authLinkCount =
+        getCapturedSlackApiCalls("chat.postEphemeral").length;
+      agentProbe.shouldBypassSkill = true;
+
+      await slackRuntime.handleNewMention(
+        thread,
+        createTestMessage({
+          id: "user-4",
+          threadId,
+          text: "what time is it?", // completely unrelated to eval-auth
+          isMention: true,
+          author: {
+            userId: currentRequesterId,
+            userName: currentRequesterName,
           },
-        ],
-      },
-    });
-    await mirrorThreadStateToAdapter(thread);
-
-    await slackRuntime.handleNewMention(
-      thread,
-      createTestMessage({
-        id: "user-4",
-        threadId,
-        text: "what time is it?", // completely unrelated to eval-auth
-        isMention: true,
-        author: {
-          userId: "U123",
-          userName: "dcramer",
-        },
-        raw: {
-          channel: "C126",
-          team_id: "T123",
-          ts: "1700000000.005",
-          thread_ts: "1700000000.004",
-        },
-      }),
-      { destination },
-    );
-
-    // Agent must have run for the unrelated request, not been blocked by auth.
-    expect(agentProbe.promptCallCount).toBe(1);
-    expect(agentProbe.continueCallCount).toBe(0);
-
-    // No new auth links should have been sent.
-    expect(getCapturedSlackApiCalls("chat.postEphemeral")).toEqual([]);
-
-    // A real reply should have been posted.
-    expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([
-      expect.objectContaining({
-        params: expect.objectContaining({
-          channel: "C126",
-          thread_ts: "1700000000.004",
-          text: unrelatedAuthPendingReply,
+          raw: {
+            channel: "C126",
+            team_id: "T123",
+            ts: "1700000000.006",
+            thread_ts: "1700000000.004",
+          },
         }),
-      }),
-    ]);
-  });
+        { destination },
+      );
 
+      expect(getCapturedSlackApiCalls("chat.postEphemeral")).toHaveLength(
+        authLinkCount,
+      );
+
+      expect(thread.posts.at(-1)).toEqual(
+        expect.objectContaining({
+          markdown: unrelatedAuthPendingReply,
+        }),
+      );
+    },
+  );
 });

--- a/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
+++ b/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
@@ -25,12 +25,14 @@ const {
   assistantReplyWithoutContext,
   assistantReplyWithContext,
   priorBudgetContext,
+  unrelatedAuthPendingReply,
 } = vi.hoisted(() => ({
   agentProbe: {
     continueCallCount: 0,
     directProviderSearch: false,
     promptCallCount: 0,
     searchToolNames: [] as string[][],
+    shouldBypassSkill: false,
   },
   MCP_TOOL_NAME: "mcp__eval-auth__budget-echo",
   SKILL_NAME: "eval-auth",
@@ -38,6 +40,8 @@ const {
   assistantReplyWithContext:
     "The budget deadline you mentioned earlier was Friday.",
   priorBudgetContext: "You need the budget by Friday.",
+  unrelatedAuthPendingReply:
+    "An unrelated answer that does not require Notion or eval-auth.",
 }));
 
 function resetAgentProbe(): void {
@@ -45,6 +49,7 @@ function resetAgentProbe(): void {
   agentProbe.continueCallCount = 0;
   agentProbe.directProviderSearch = false;
   agentProbe.searchToolNames.length = 0;
+  agentProbe.shouldBypassSkill = false;
 }
 
 function extractTextContent(message: unknown): string {
@@ -134,6 +139,16 @@ vi.mock("@earendil-works/pi-agent-core", () => {
       agentProbe.promptCallCount += 1;
       this.aborted = false;
       this.state.messages.push(message);
+
+      if (agentProbe.shouldBypassSkill) {
+        // Simulate an unrelated request that does not need any MCP tools.
+        this.state.messages.push({
+          role: "assistant",
+          content: [{ type: "text", text: unrelatedAuthPendingReply }],
+          stopReason: "stop",
+        });
+        return {};
+      }
 
       if (agentProbe.directProviderSearch) {
         const searchMcpTools = this.state.tools.find(
@@ -790,4 +805,117 @@ describe("mcp auth runtime slack integration", () => {
       }),
     ]);
   });
+
+  it("does not abort unrelated turns when MCP auth is already pending from a prior turn", async () => {
+    // Regression: if a user previously triggered an MCP provider's auth
+    // challenge, Junior was restoring the pending-auth skill from Pi history
+    // and calling activateProvider() on EVERY subsequent turn in the
+    // conversation — even for completely unrelated requests. This caused the
+    // pre-agent MCP restoration loop to throw McpAuthorizationPauseError and
+    // abort the turn before the agent ran.
+    agentProbe.shouldBypassSkill = true;
+    const threadId = "slack:C126:1700000000.004";
+    const turnId = "turn_user-4";
+    const { createTestChatRuntime } = chatRuntimeModule;
+    const { slackRuntime } = createTestChatRuntime({
+      services: {
+        visionContext: {
+          listThreadReplies: async () => [],
+        },
+      },
+    });
+
+    const destination = {
+      platform: "slack" as const,
+      teamId: "T123",
+      channelId: "C126",
+    };
+
+    // Simulate a conversation where a prior turn already triggered MCP auth
+    // for the eval-auth provider. The thread state has pendingAuth set and
+    // the Pi history contains a prior loadSkill("eval-auth") result so that
+    // inferLoadedSkillNamesFromPiMessages will restore the skill.
+    const thread = createTestThread({
+      id: threadId,
+      state: {
+        conversation: {
+          messages: [
+            {
+              id: "assistant-1",
+              role: "assistant",
+              text: "Please authorize via the link I sent you.",
+              createdAtMs: 1,
+              author: {
+                userName: "junior",
+                isBot: true,
+              },
+            },
+          ],
+          processing: {
+            pendingAuth: {
+              kind: "mcp",
+              provider: EVAL_MCP_AUTH_PROVIDER,
+              requesterId: "U123",
+              sessionId: "turn_prior-turn",
+              linkSentAtMs: Date.now() - 5_000,
+            },
+          },
+        },
+        piMessages: [
+          // Simulate a prior turn's loadSkill("eval-auth") result in history.
+          // inferLoadedSkillNamesFromPiMessages will pick this up and try to
+          // restore the skill's MCP provider on the next turn.
+          {
+            role: "toolResult",
+            toolName: "loadSkill",
+            skill_name: SKILL_NAME,
+            ok: true,
+            details: { skill_name: SKILL_NAME },
+            isError: false,
+          },
+        ],
+      },
+    });
+    await mirrorThreadStateToAdapter(thread);
+
+    await slackRuntime.handleNewMention(
+      thread,
+      createTestMessage({
+        id: "user-4",
+        threadId,
+        text: "what time is it?", // completely unrelated to eval-auth
+        isMention: true,
+        author: {
+          userId: "U123",
+          userName: "dcramer",
+        },
+        raw: {
+          channel: "C126",
+          team_id: "T123",
+          ts: "1700000000.005",
+          thread_ts: "1700000000.004",
+        },
+      }),
+      { destination },
+    );
+
+    // Agent must have run for the unrelated request, not been blocked by auth.
+    expect(agentProbe.promptCallCount).toBe(1);
+    expect(agentProbe.continueCallCount).toBe(0);
+
+    // No new auth links should have been sent.
+    expect(getCapturedSlackApiCalls("chat.postEphemeral")).toEqual([]);
+
+    // A real reply should have been posted.
+    expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({
+          channel: "C126",
+          thread_ts: "1700000000.004",
+          text: unrelatedAuthPendingReply,
+        }),
+      }),
+    ]);
+  });
+
 });

--- a/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
+++ b/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
@@ -894,14 +894,6 @@ describe("mcp auth runtime slack integration", () => {
         { destination },
       );
 
-      expect(agentProbe.promptCallCount).toBe(1);
-      expect(thread.posts).toEqual([
-        expect.objectContaining({
-          markdown: expect.stringContaining(
-            "<@U123> I'll need you to authorize Eval Auth. I sent you a link.",
-          ),
-        }),
-      ]);
       expect(
         await threadStateModule.getPersistedThreadState(threadId),
       ).toMatchObject({

--- a/policies/test-adapters.md
+++ b/policies/test-adapters.md
@@ -7,7 +7,7 @@ Tests should be easy to write because the repo provides faithful test adapters f
 ## Policy
 
 - Start from `specs/testing.md` for layer selection; use this policy for the fixture and adapter shape inside that layer.
-- Prefer shared test adapters over one-off mocks when a boundary recurs across tests.
+- Prefer shared test adapters over one-off mocks when a boundary recurs across tests, especially for product behavior that crosses runtime, persistence, ingress, or delivery boundaries.
 - A test adapter should implement the production-facing contract closely enough that tests can inject real payloads and observe resulting effects.
 - Give adapters small, role-specific introspection methods such as `queuedMessages()`, `messages()`, or `fileUploads()`. Do not expose broad mutable internals.
 - Model external side effects as outboxes or captured deliveries that are reset between tests.
@@ -16,6 +16,7 @@ Tests should be easy to write because the repo provides faithful test adapters f
 - Centralize temporary environment or configuration overrides in helpers that restore state automatically.
 - Make isolation explicit. Tests that use shared resources, fake clocks, singleton state, or process-global configuration must reset them locally or opt into an isolated/serial harness.
 - Keep test-only capabilities out of production singletons. Prefer injected ports, local factories, and test adapters over `setForTests` globals or module mocks.
+- Do not add broad adapter hooks only to make a low-level test possible when an existing integration harness can exercise the real path.
 - Add adapter behavior only for a real recurring test need, and keep it named after the user-visible boundary rather than the implementation mechanism.
 - When a suite fails only under order, shuffle, reverse, or parallel load, treat that as a test-isolation bug unless proven otherwise.
 

--- a/specs/testing.md
+++ b/specs/testing.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-03-03
-- Last Edited: 2026-06-02
+- Last Edited: 2026-06-27
 
 ## Purpose
 
@@ -19,7 +19,7 @@ Start from the real product contract, not the easiest seam to mock.
 3. Use component tests for deterministic service/runtime contracts that cross modules but are still best proven through explicit local ports: durable stores, queue wake-up ports, worker state machines, lease/recovery coordination, persistence adapters, and similar orchestration invariants.
 4. Use unit tests only for tightly local deterministic logic: parsing, scoring, routing heuristics, retry math, pure transforms, normalization, and similar algorithmic invariants.
 
-Do not default to unit tests for runtime behavior just because they are easier to write. Do not force deterministic service contracts into broad integration tests when a component test would prove the invariant more directly and with fewer fake layers.
+For runtime/product regressions, reproduce the failure at the highest deterministic boundary that owns the behavior. Prefer one integration or eval that drives real ingress, persistence, routing, and delivery wiring over unit tests that recreate intermediate state. Do not force deterministic service contracts into broad integration tests when a component test proves the invariant with fewer fake layers.
 
 ## Test Layers
 
@@ -51,7 +51,7 @@ Layer selection is mandatory: classify the test contract first and choose `unit`
 6. Keep test names descriptive of outcomes, not implementation mechanics.
 7. Do not over-test: cover representative, high-risk scenarios for each contract, not every theoretical permutation.
 8. Prefer one focused assertion path per behavior contract; add more cases only when they validate a distinct failure mode.
-9. Workflow behavior integration tests should execute real runtime paths and only substitute deterministic fake agent output at the agent boundary.
+9. Workflow and regression integration tests should execute real runtime paths and only substitute deterministic fake agent output at the agent boundary. Construct state by driving the owning path when practical; hand-build persisted state only when the state shape itself is the contract or real setup would require unrelated external systems.
 10. Do not assert internal observability emission (`logInfo`, `logWarn`, spans, trace attributes) in behavior tests unless instrumentation output is itself the contract under test.
 11. Do not assert prompt prose by checking that a string is present in a generated prompt. Prompt wording is not a stable contract; validate the resulting behavior in evals or integration tests instead.
 12. If Slack API call shape or ordering is the external contract under test, keep those assertions in dedicated transport-contract integration suites; general behavior files should stay scenario-readable.
@@ -71,6 +71,8 @@ Use this practical budget:
 
 If a proposed test does not add a new contract guarantee, do not add it.
 
+When higher-level coverage proves the user-visible contract, do not add parallel unit tests for the same workflow. Keep unit tests for deterministic helper logic the higher-level test cannot localize cleanly.
+
 ## Layer Selection Guide
 
 This section is mandatory policy, not guidance.
@@ -89,7 +91,7 @@ Ask these questions in order:
    Use `unit`.
    Examples: retry math, pure transforms, normalization, local scoring, parser behavior, deterministic state transitions.
 
-If a test needs to mock large parts of the runtime just to prove a user-visible flow, that is usually evidence the test belongs in integration or eval instead.
+If a test must mock large parts of runtime, hand-build durable state, or assert private call sequencing to prove a user-visible flow, it belongs in integration or eval instead.
 
 ## Mock Confidence Rules
 


### PR DESCRIPTION
After a user hit an MCP OAuth challenge, later messages in the same Slack thread could abort before the agent ran because startup restoration eagerly reactivated the still-unauthorized provider. The restore guard now skips the pending MCP provider at the conversation level, so unrelated follow-up turns can run normally while explicit provider use still goes through the normal auth flow.

The regression test now drives the real Slack runtime path: first it creates a pending MCP auth pause, then it sends unrelated same-requester and different-requester follow-ups and verifies Junior posts a normal reply without sending another auth link. The testing guidance was tightened to prefer this kind of high-level deterministic coverage for runtime regressions instead of unit tests that recreate intermediate state.