### PR TITLE
fix(slack): Add footers to auth pause notices

### DIFF
--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -403,16 +403,29 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
         const postAuthPauseNotice = async (
           providerDisplayName: string,
         ): Promise<void> => {
+          const text = buildAuthPauseResponse(
+            message.author.userId,
+            providerDisplayName,
+          );
+          const footer = buildSlackReplyFooter({ conversationId });
           try {
-            await beforeFirstResponsePost();
-            await thread.post(
-              buildSlackOutputMessage(
-                buildAuthPauseResponse(
-                  message.author.userId,
-                  providerDisplayName,
-                ),
-              ),
-            );
+            if (channelId && threadTs) {
+              await postSlackApiReplyPosts({
+                beforePost: beforeFirstResponsePost,
+                channelId,
+                threadTs,
+                posts: [
+                  {
+                    text,
+                    stage: "thread_reply",
+                  },
+                ],
+                footer,
+              });
+            } else {
+              await beforeFirstResponsePost();
+              await thread.post(buildSlackOutputMessage(text));
+            }
           } catch (error) {
             logException(
               error,

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -1,3 +1,10 @@
+/**
+ * Slack resume execution boundary.
+ *
+ * Resumed turns run from persisted request context under the Slack thread lock.
+ * Status notices are best effort, while final replies and auth-pause notices
+ * reuse the shared Slack reply footer path when they are user-visible.
+ */
 import { botConfig } from "@/chat/config";
 import type { ChannelConfigurationService } from "@/chat/configuration/types";
 import {
@@ -25,7 +32,10 @@ import {
   createSlackWebApiAssistantStatusSession,
   type AssistantStatusSession,
 } from "@/chat/slack/assistant-thread/status";
-import { buildSlackReplyFooter } from "@/chat/slack/footer";
+import {
+  buildSlackReplyFooter,
+  type SlackReplyFooter,
+} from "@/chat/slack/footer";
 import {
   planSlackReplyPosts,
   postSlackApiReplyPosts,
@@ -57,13 +67,25 @@ async function postSlackMessageBestEffort(
   channelId: string,
   threadTs: string,
   text: string,
+  footer?: SlackReplyFooter,
 ): Promise<void> {
   try {
-    await postSlackApiMessage({
-      channelId,
-      threadTs,
-      text,
-    });
+    if (footer) {
+      await postSlackApiReplyPosts({
+        channelId,
+        threadTs,
+        posts: [
+          {
+            text,
+            stage: "thread_reply",
+          },
+        ],
+        footer,
+      });
+      return;
+    }
+
+    await postSlackApiMessage({ channelId, threadTs, text });
   } catch {
     // Resume-side status notices should not decide whether the turn succeeds.
   }
@@ -155,6 +177,14 @@ function getResumeLogContext(
     assistantUserName: botConfig.userName,
     modelId: botConfig.modelId,
   };
+}
+
+/** Resolve the conversation identifier used by resumed-turn logs and Slack footers. */
+function getResumeConversationId(
+  args: ResumeSlackTurnArgs,
+  lockKey: string,
+): string {
+  return args.replyContext?.correlation?.conversationId ?? lockKey;
 }
 
 async function postResumeFailureReply(args: {
@@ -368,8 +398,7 @@ export async function resumeSlackTurn(
 
     await status.stop();
     const footer = buildSlackReplyFooter({
-      conversationId:
-        runArgs.replyContext?.correlation?.conversationId ?? lockKey,
+      conversationId: getResumeConversationId(runArgs, lockKey),
     });
     await postSlackApiReplyPosts({
       channelId: runArgs.channelId,
@@ -476,6 +505,9 @@ export async function resumeSlackTurn(
     try {
       await deferredPauseHandler();
       if (deferredPauseKind === "auth" && deferredAuthInfo) {
+        const footer = buildSlackReplyFooter({
+          conversationId: getResumeConversationId(runArgs, lockKey),
+        });
         await postSlackMessageBestEffort(
           runArgs.channelId,
           runArgs.threadTs,
@@ -483,6 +515,7 @@ export async function resumeSlackTurn(
             deferredAuthInfo.requesterId,
             deferredAuthInfo.providerDisplayName,
           ),
+          footer,
         );
       }
       return true;

--- a/packages/junior/src/chat/slack/footer.ts
+++ b/packages/junior/src/chat/slack/footer.ts
@@ -52,7 +52,7 @@ function escapeSlackLinkUrl(url: string): string {
 }
 
 /**
- * Build the compact conversation footer for the finalized Slack reply.
+ * Build the compact conversation footer for visible Slack reply surfaces.
  *
  * Detailed turn metrics stay in the dashboard instead of Slack-visible copy.
  */

--- a/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
+++ b/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
@@ -76,6 +76,14 @@ function hasPriorBudgetContext(messages: unknown[]): boolean {
   );
 }
 
+function expectBlocksIncludeConversationId(
+  params: Record<string, unknown>,
+  conversationId: string,
+): void {
+  expect(params.blocks).toBeDefined();
+  expect(JSON.stringify(params.blocks)).toContain(conversationId);
+}
+
 vi.mock("@/chat/services/turn-thinking-level", async () => {
   const actual = await vi.importActual<
     typeof import("@/chat/services/turn-thinking-level")
@@ -401,14 +409,20 @@ describe("mcp auth runtime slack integration", () => {
         }),
       }),
     ]);
-    expect(thread.posts).toEqual([
+    expect(thread.posts).toEqual([]);
+    expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([
       expect.objectContaining({
-        markdown: expect.stringContaining(
-          "<@U123> I'll need you to authorize Eval Auth. I sent you a link.",
-        ),
+        params: expect.objectContaining({
+          channel: "C123",
+          thread_ts: "1700000000.001",
+          text: "<@U123> I'll need you to authorize Eval Auth. I sent you a link.",
+        }),
       }),
     ]);
-    expect(getCapturedSlackApiCalls("chat.postMessage")).toHaveLength(0);
+    expectBlocksIncludeConversationId(
+      getCapturedSlackApiCalls("chat.postMessage")[0]!.params,
+      "slack:C123:1700000000.001",
+    );
     expectProcessingReactionLifecycles({
       channel: "C123",
       timestamp: "1700000000.002",
@@ -555,6 +569,13 @@ describe("mcp auth runtime slack integration", () => {
         params: expect.objectContaining({
           channel: "C123",
           thread_ts: "1700000000.001",
+          text: "<@U123> I'll need you to authorize Eval Auth. I sent you a link.",
+        }),
+      }),
+      expect.objectContaining({
+        params: expect.objectContaining({
+          channel: "C123",
+          thread_ts: "1700000000.001",
           text: assistantReplyWithContext,
         }),
       }),
@@ -640,13 +661,20 @@ describe("mcp auth runtime slack integration", () => {
 
     expect(agentProbe.promptCallCount).toBe(1);
     expect(agentProbe.continueCallCount).toBe(0);
-    expect(thread.posts).toEqual([
+    expect(thread.posts).toEqual([]);
+    expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([
       expect.objectContaining({
-        markdown: expect.stringContaining(
-          "<@U123> I'll need you to authorize Eval Auth. I sent you a link.",
-        ),
+        params: expect.objectContaining({
+          channel: "C124",
+          thread_ts: "1700000000.002",
+          text: "<@U123> I'll need you to authorize Eval Auth. I sent you a link.",
+        }),
       }),
     ]);
+    expectBlocksIncludeConversationId(
+      getCapturedSlackApiCalls("chat.postMessage")[0]!.params,
+      "slack:C124:1700000000.002",
+    );
 
     const pendingCheckpoint =
       await turnSessionStoreModule.getAgentTurnSessionRecord(threadId, turnId);
@@ -785,9 +813,20 @@ describe("mcp auth runtime slack integration", () => {
         params: expect.objectContaining({
           channel: "C125",
           thread_ts: "1700000000.003",
+          text: "<@U123> I'll need you to authorize Eval Auth. I sent you a link.",
+        }),
+      }),
+      expect.objectContaining({
+        params: expect.objectContaining({
+          channel: "C125",
+          thread_ts: "1700000000.003",
           text: assistantReplyWithContext,
         }),
       }),
     ]);
+    expectBlocksIncludeConversationId(
+      getCapturedSlackApiCalls("chat.postMessage")[0]!.params,
+      "slack:C125:1700000000.003",
+    );
   });
 });

--- a/packages/junior/tests/integration/oauth-resume-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-resume-slack.test.ts
@@ -42,6 +42,14 @@ function testSlackSource(threadTs: string) {
   });
 }
 
+function expectBlocksIncludeConversationId(
+  params: Record<string, unknown>,
+  conversationId: string,
+): void {
+  expect(params.blocks).toBeDefined();
+  expect(JSON.stringify(params.blocks)).toContain(conversationId);
+}
+
 describe("oauth resume slack integration", () => {
   beforeEach(async () => {
     process.env.JUNIOR_STATE_ADAPTER = "memory";
@@ -209,6 +217,54 @@ describe("oauth resume slack integration", () => {
         }),
       }),
     ]);
+  });
+
+  it("posts resumed auth pause notices with the conversation footer", async () => {
+    const { resumeAuthorizedRequest } =
+      await import("@/chat/runtime/slack-resume");
+    const { RetryableTurnError } = await import("@/chat/runtime/turn");
+
+    await resumeAuthorizedRequest({
+      messageText: "continue this turn",
+      channelId: "C123",
+      threadTs: "1700000000.008",
+      connectedText: "",
+      replyContext: {
+        credentialContext: {
+          actor: { type: "user", userId: "U123" },
+        },
+        destination: TEST_SLACK_DESTINATION,
+        source: testSlackSource("1700000000.008"),
+        requester: { platform: "slack", teamId: "T123", userId: "U123" },
+        correlation: {
+          conversationId: "conversation-auth-pause",
+          turnId: "turn-auth-pause",
+        },
+      },
+      generateReply: async () => {
+        throw new RetryableTurnError("mcp_auth_resume", "auth required", {
+          authDisposition: "link_sent",
+          authKind: "mcp",
+          authProvider: "eval-auth",
+          authProviderDisplayName: "Eval Auth",
+        });
+      },
+      onAuthPause: async () => undefined,
+    });
+
+    expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({
+          channel: "C123",
+          thread_ts: "1700000000.008",
+          text: "<@U123> I'll need you to authorize Eval Auth. I sent you a link.",
+        }),
+      }),
+    ]);
+    expectBlocksIncludeConversationId(
+      getCapturedSlackApiCalls("chat.postMessage")[0]!.params,
+      "conversation-auth-pause",
+    );
   });
 
   it("chunks long resumed replies into explicit continuation messages", async () => {

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -40,6 +40,14 @@ function postIncludes(thread: { posts: unknown[] }, text: string): boolean {
   });
 }
 
+function expectBlocksIncludeConversationId(
+  params: Record<string, unknown>,
+  conversationId: string,
+): void {
+  expect(params.blocks).toBeDefined();
+  expect(JSON.stringify(params.blocks)).toContain(conversationId);
+}
+
 function createRuntime(
   args: {
     services?: JuniorRuntimeServiceOverrides;
@@ -624,13 +632,20 @@ describe("bot handlers (integration)", () => {
       ),
     ).resolves.toBeUndefined();
 
-    expect(thread.posts).toEqual([
+    expect(thread.posts).toEqual([]);
+    expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([
       expect.objectContaining({
-        markdown: expect.stringContaining(
-          "<@U-test> I'll need you to authorize Notion. I sent you a link.",
-        ),
+        params: expect.objectContaining({
+          channel: "C_AUTH",
+          thread_ts: "1700000000.000",
+          text: "<@U-test> I'll need you to authorize Notion. I sent you a link.",
+        }),
       }),
     ]);
+    expectBlocksIncludeConversationId(
+      getCapturedSlackApiCalls("chat.postMessage")[0]!.params,
+      "slack:C_AUTH:1700000000.000",
+    );
     const state = thread.getState();
     const conversation = (
       state as {
@@ -702,13 +717,20 @@ describe("bot handlers (integration)", () => {
       ),
     ).resolves.toBeUndefined();
 
-    expect(thread.posts).toEqual([
+    expect(thread.posts).toEqual([]);
+    expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([
       expect.objectContaining({
-        markdown: expect.stringContaining(
-          "<@U-test> I'll need you to authorize GitHub. I sent you a link.",
-        ),
+        params: expect.objectContaining({
+          channel: "C_PLUGIN_AUTH",
+          thread_ts: "1700000000.000",
+          text: "<@U-test> I'll need you to authorize GitHub. I sent you a link.",
+        }),
       }),
     ]);
+    expectBlocksIncludeConversationId(
+      getCapturedSlackApiCalls("chat.postMessage")[0]!.params,
+      "slack:C_PLUGIN_AUTH:1700000000.000",
+    );
     const state = thread.getState();
     const conversation = (
       state as {

--- a/specs/slack-agent-delivery.md
+++ b/specs/slack-agent-delivery.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-04-15
-- Last Edited: 2026-06-08
+- Last Edited: 2026-06-27
 
 ## Purpose
 
@@ -93,7 +93,7 @@ Current contract:
 9. Assistant status is best effort and must not sit on the critical path for model/tool execution. Starting a turn or updating mid-turn status may queue Slack writes, but must not wait for Slack round-trips before assistant work continues.
 10. When Junior has an explicit `reportProgress` update, it must replace the generic `loading_messages` rotation for that status update. Explicit progress owns the loading surface until another status update replaces it or the turn ends.
 11. While a turn is active, Junior uses a stable generic `status` string for Slack's assistant loading state and changes the user-visible progress copy through `loading_messages`.
-12. Final reply footer metadata is not part of the in-flight loading contract. Footer blocks, when present, belong only to the finalized reply artifact.
+12. Final reply footer metadata is not part of the in-flight loading contract. Footer blocks, when present, belong only to finalized reply artifacts and explicit auth-pause acknowledgements.
 13. If automatic pre-turn compaction is needed, Junior must show explicit compaction progress before the compaction LLM call and return to normal turn status before agent execution begins.
 
 Status is the only in-flight progress surface required by the contract. Visible assistant reply text is posted only after the turn result is finalized and delivery has been planned.
@@ -216,12 +216,12 @@ Current rules:
 3. Continuation success is defined by final visible Slack delivery, not only by successful assistant generation.
 4. Persisted thread state is updated only after the final reply has been delivered to Slack.
 5. Because live turns do not publish provisional assistant text, timeout continuation remains eligible until final reply delivery starts.
-6. When a turn blocks on OAuth/MCP auth, Junior must privately deliver the auth link, post a brief visible thread acknowledgement that authorization is needed, clear `activeTurnId`, and persist thread-local pending-auth state. The visible acknowledgement must not include the auth URL or other secret-bearing state.
+6. When a turn blocks on OAuth/MCP auth, Junior must privately deliver the auth link, post a brief visible thread acknowledgement that authorization is needed, clear `activeTurnId`, and persist thread-local pending-auth state. The visible acknowledgement must not include the auth URL or other secret-bearing state, but it should include the same conversation footer metadata used by finalized Slack replies so users can identify the paused conversation.
 7. Automatic auth resumes must not post a separate public "account connected, continuing..." banner before the real resumed answer. The resumed answer itself is the visible continuation.
 8. If auth completes after a newer thread message already replaced the blocked request, Junior stores the credentials but does not post a stale resumed answer.
 9. Routine cooperative continuation must not post a visible "continuing in the background" thread acknowledgement. User-visible progress belongs to assistant status and `reportProgress`; final answers still use the finalized reply path.
 10. If an active request arrives while a turn is active, Junior should fold it into the active conversation at the next safe execution boundary instead of creating a second visible turn. Explicit mentions, DMs, and active assistant-thread user messages interrupt the active turn through Pi steering. Passive subscribed-thread messages that the reply policy accepts defer until the active turn completes and delivers its answer, then run as ordinary queued subscribed-message work. Passive no-reply messages and opt-out decisions are consumed through existing skipped-message handling without agent injection or automatic processing reactions. Mailbox and worker mechanics belong to `./task-execution.md`.
-11. Any explicit pause acknowledgement that remains for auth or exceptional failure handling is not a final assistant reply. It does not mark the original turn completed, and the final resumed answer must still be delivered through the normal finalized-reply path.
+11. Any explicit pause acknowledgement that remains for auth or exceptional failure handling is not a final assistant reply. It does not mark the original turn completed, and the final resumed answer must still be delivered through the normal finalized-reply path. Footer metadata on an auth-pause acknowledgement is only a conversation identifier affordance, not assistant progress or completion.
 
 ### 12. Testing Contract
 


### PR DESCRIPTION
Auth pause notices now use the shared Slack reply footer path, so visible pause acknowledgements include the conversation ID like other Slack reply surfaces. This covers both the initial auth pause path and the resumed auth pause path without moving Slack block formatting into runtime code.

The Slack delivery spec now calls out auth-pause acknowledgements as footer-bearing but non-final, and regression coverage checks initial, MCP, plugin, and resumed auth pause delivery.