### PR TITLE
fix(plugins): make skills directory optional for yaml manifest plugins

### DIFF
--- a/packages/junior/src/chat/plugins/registry.ts
+++ b/packages/junior/src/chat/plugins/registry.ts
@@ -132,12 +132,20 @@ function registerYamlPluginManifest(
   pluginDir: string,
 ): void {
   const manifest = parsePluginManifest(raw, pluginDir, pluginConfig);
+  const candidateSkillsDir = path.join(pluginDir, "skills");
+  const hasSkillsDir = (() => {
+    try {
+      return statSync(candidateSkillsDir).isDirectory();
+    } catch {
+      return false;
+    }
+  })();
   // Declarative manifests are manifest-only; code registrations claim migrations.
   registerPluginManifest(
     state,
     manifest,
     pluginDir,
-    path.join(pluginDir, "skills"),
+    hasSkillsDir ? candidateSkillsDir : undefined,
   );
 }
 

--- a/packages/junior/tests/component/plugins/plugin-registry.test.ts
+++ b/packages/junior/tests/component/plugins/plugin-registry.test.ts
@@ -360,4 +360,45 @@ describe("plugin registry", () => {
       'Plugin "other-plugin" cannot share migrations directory with plugin "code-plugin"',
     );
   });
+
+  it("does not register a skillsDir for local yaml plugins that have no skills directory", async () => {
+    const tempRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "junior-plugin-no-skills-"),
+    );
+    // Create a plugin directory with a plugin.yaml but no skills/ subdirectory
+    const pluginDir = path.join(tempRoot, "rust-toolchain");
+    await fs.mkdir(pluginDir, { recursive: true });
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.yaml"),
+      [
+        "name: rust-toolchain",
+        "display-name: Rust Toolchain",
+        "description: Rust toolchain plugin",
+      ].join("\n"),
+      "utf8",
+    );
+
+    vi.doMock("@/chat/discovery", () => ({
+      pluginRoots: () => [tempRoot],
+    }));
+    vi.doMock("@/chat/plugins/package-discovery", () => ({
+      discoverInstalledPluginPackageContent: () => ({
+        packageNames: [],
+        packages: [],
+        manifestRoots: [],
+        skillRoots: [],
+        tracingIncludes: [],
+      }),
+      normalizePluginPackageNames: (names: string[] | undefined) => names,
+    }));
+
+    const registry = await import("@/chat/plugins/registry");
+
+    expect(registry.getPluginProviders()).toHaveLength(1);
+    expect(registry.getPluginProviders()[0]?.manifest.name).toBe(
+      "rust-toolchain",
+    );
+    // No skills directory exists, so the plugin must not contribute a skill root
+    expect(registry.getPluginSkillRoots()).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Problem

`registerYamlPluginManifest` unconditionally passed `path.join(pluginDir, 'skills')` as the `skillsDir`, even when that directory doesn't exist. This caused a `skill_root_read_failed` warning on every request for any yaml-manifest plugin that doesn't have a `skills/` subdirectory:

```
WRN Failed to read skill root event.name=skill_root_read_failed exception.message="ENOENT: no such file or directory, scandir '/var/task/app/plugins/rust-toolchain/skills'"
```

## Root cause

The inline manifest code path correctly gates on `pkg?.hasSkillsDir` before setting `skillsDir`. The yaml manifest path had no such check — it always registered the `skills/` path regardless of whether the directory exists.

## Fix

Check for directory existence before registering the skills root in `registerYamlPluginManifest`, consistent with the inline manifest path.

## Verification

- TypeScript compiles cleanly (`tsc --noEmit`)
- Added a regression test: a yaml plugin with no `skills/` directory must not contribute to `getPluginSkillRoots()`
- Component tests require Postgres (unavailable in sandbox) — CI will cover them

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC0B595QDZLL%3A1782546862.816199%22)