### PR TITLE
fix(chat): Keep short locks from blocking recovery

### DIFF
--- a/packages/junior/src/chat/credentials/state-adapter-token-store.ts
+++ b/packages/junior/src/chat/credentials/state-adapter-token-store.ts
@@ -4,7 +4,7 @@ import type {
   UserTokenStore,
 } from "@/chat/credentials/user-token-store";
 import { storedTokensSchema } from "@/chat/credentials/user-token-store";
-import { ACTIVE_LOCK_TTL_MS } from "@/chat/state/adapter";
+import { ACTIVE_LOCK_TTL_MS } from "@/chat/state/locks";
 
 const KEY_PREFIX = "oauth-token";
 const BUFFER_MS = 24 * 60 * 60 * 1000; // 24h buffer for refresh token lifetime

--- a/packages/junior/src/chat/credentials/state-adapter-token-store.ts
+++ b/packages/junior/src/chat/credentials/state-adapter-token-store.ts
@@ -4,11 +4,12 @@ import type {
   UserTokenStore,
 } from "@/chat/credentials/user-token-store";
 import { storedTokensSchema } from "@/chat/credentials/user-token-store";
+import { ACTIVE_LOCK_TTL_MS } from "@/chat/state/adapter";
 
 const KEY_PREFIX = "oauth-token";
 const BUFFER_MS = 24 * 60 * 60 * 1000; // 24h buffer for refresh token lifetime
 const LONG_LIVED_TTL_MS = 365 * 24 * 60 * 60 * 1000;
-const REFRESH_LOCK_TTL_MS = 30_000;
+const REFRESH_LOCK_TTL_MS = ACTIVE_LOCK_TTL_MS;
 const REFRESH_LOCK_WAIT_MS = 30_000;
 const REFRESH_LOCK_RETRY_MS = 100;
 

--- a/packages/junior/src/chat/credentials/state-adapter-token-store.ts
+++ b/packages/junior/src/chat/credentials/state-adapter-token-store.ts
@@ -4,12 +4,11 @@ import type {
   UserTokenStore,
 } from "@/chat/credentials/user-token-store";
 import { storedTokensSchema } from "@/chat/credentials/user-token-store";
-import { ACTIVE_LOCK_TTL_MS } from "@/chat/state/locks";
+import { acquireActiveLock } from "@/chat/state/locks";
 
 const KEY_PREFIX = "oauth-token";
 const BUFFER_MS = 24 * 60 * 60 * 1000; // 24h buffer for refresh token lifetime
 const LONG_LIVED_TTL_MS = 365 * 24 * 60 * 60 * 1000;
-const REFRESH_LOCK_TTL_MS = ACTIVE_LOCK_TTL_MS;
 const REFRESH_LOCK_WAIT_MS = 30_000;
 const REFRESH_LOCK_RETRY_MS = 100;
 
@@ -68,7 +67,7 @@ export class StateAdapterTokenStore implements UserTokenStore {
     const lockKey = refreshLockKey(userId, provider);
     const deadline = Date.now() + REFRESH_LOCK_WAIT_MS;
     while (true) {
-      const lock = await this.state.acquireLock(lockKey, REFRESH_LOCK_TTL_MS);
+      const lock = await acquireActiveLock(this.state, lockKey);
       if (lock) {
         try {
           return await callback();

--- a/packages/junior/src/chat/ingress/slack-webhook.ts
+++ b/packages/junior/src/chat/ingress/slack-webhook.ts
@@ -91,6 +91,16 @@ interface SlackInteractivePayload {
   user?: { id?: string; name?: string; team_id?: string; username?: string };
 }
 
+class SlackEventPersistenceError extends Error {
+  readonly cause: unknown;
+
+  constructor(cause: unknown) {
+    super("Slack event durable persistence failed");
+    this.name = "SlackEventPersistenceError";
+    this.cause = cause;
+  }
+}
+
 export interface SlackWebhookServices {
   getUserTokenStore?: () => UserTokenStore;
   getSlackAdapter: () => SlackAdapter;
@@ -178,6 +188,7 @@ async function buildThread(args: {
 function shouldIgnoreMessage(message: Message): boolean {
   return (
     message.author.isMe === true ||
+    !parseActorUserId(message.author.userId) ||
     isExternalSlackUser(message.raw as Record<string, unknown> | undefined)
   );
 }
@@ -210,6 +221,8 @@ async function persistSlackMessage(args: {
     conversationStore: args.conversationStore,
     queue: args.queue,
     state: args.state,
+  }).catch((error: unknown) => {
+    throw new SlackEventPersistenceError(error);
   });
 }
 
@@ -662,9 +675,16 @@ export async function handleSlackWebhook(args: {
       services: args.services,
     });
     if (shouldPersistBeforeAck(parsed)) {
-      await eventTask.catch((error) => {
-        logException(error, "slack_event_persist_failed");
-      });
+      try {
+        await eventTask;
+      } catch (error) {
+        if (!(error instanceof SlackEventPersistenceError)) {
+          logException(error, "slack_event_enqueue_failed");
+          return new Response("ok", { status: 200 });
+        }
+        logException(error.cause, "slack_event_persist_failed");
+        return new Response("Slack event persistence failed", { status: 503 });
+      }
     } else {
       enqueue(
         args.waitUntil,

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -41,7 +41,8 @@ import {
   postSlackApiReplyPosts,
 } from "@/chat/slack/reply";
 import { postSlackMessage as postSlackApiMessage } from "@/chat/slack/outbound";
-import { ACTIVE_LOCK_TTL_MS, getStateAdapter } from "@/chat/state/adapter";
+import { getStateAdapter } from "@/chat/state/adapter";
+import { ACTIVE_LOCK_TTL_MS } from "@/chat/state/locks";
 import {
   startSlackProcessingReactionForMessage,
   type ProcessingReactionSession,

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -42,7 +42,7 @@ import {
 } from "@/chat/slack/reply";
 import { postSlackMessage as postSlackApiMessage } from "@/chat/slack/outbound";
 import { getStateAdapter } from "@/chat/state/adapter";
-import { ACTIVE_LOCK_TTL_MS } from "@/chat/state/locks";
+import { acquireActiveLock } from "@/chat/state/locks";
 import {
   startSlackProcessingReactionForMessage,
   type ProcessingReactionSession,
@@ -309,7 +309,7 @@ export async function resumeSlackTurn(
   await stateAdapter.connect();
   const lockKey =
     args.lockKey ?? getDefaultLockKey(args.channelId, args.threadTs);
-  const lock = await stateAdapter.acquireLock(lockKey, ACTIVE_LOCK_TTL_MS);
+  const lock = await acquireActiveLock(stateAdapter, lockKey);
   if (!lock) {
     throw new ResumeTurnBusyError(lockKey);
   }

--- a/packages/junior/src/chat/state/adapter.ts
+++ b/packages/junior/src/chat/state/adapter.ts
@@ -75,11 +75,8 @@ function createQueuedStateAdapter(
 
   const heartbeats = new Map<string, LockHeartbeat>();
 
-  const effectiveLockTtlMs = (ttlMs: number): number =>
-    Math.max(ttlMs, ACTIVE_LOCK_TTL_MS);
-
   const shouldHeartbeatLock = (ttlMs: number): boolean =>
-    ttlMs <= ACTIVE_LOCK_TTL_MS;
+    ttlMs === ACTIVE_LOCK_TTL_MS;
 
   const heartbeatKey = (lock: Lock): string => `${lock.threadId}:${lock.token}`;
 
@@ -164,10 +161,9 @@ function createQueuedStateAdapter(
     threadId: string,
     ttlMs: number,
   ): Promise<Lock | null> => {
-    const effectiveTtlMs = effectiveLockTtlMs(ttlMs);
-    const lock = await base.acquireLock(threadId, effectiveTtlMs);
+    const lock = await base.acquireLock(threadId, ttlMs);
     if (lock && shouldHeartbeatLock(ttlMs)) {
-      startOrUpdateHeartbeat(lock, effectiveTtlMs);
+      startOrUpdateHeartbeat(lock, ttlMs);
     }
     return lock;
   };
@@ -189,12 +185,11 @@ function createQueuedStateAdapter(
       await base.releaseLock(lock);
     },
     extendLock: async (lock, ttlMs) => {
-      const effectiveTtlMs = effectiveLockTtlMs(ttlMs);
-      const extended = await base.extendLock(lock, effectiveTtlMs);
+      const extended = await base.extendLock(lock, ttlMs);
       if (extended) {
-        lock.expiresAt = Date.now() + effectiveTtlMs;
+        lock.expiresAt = Date.now() + ttlMs;
         if (shouldHeartbeatLock(ttlMs)) {
-          startOrUpdateHeartbeat(lock, effectiveTtlMs);
+          startOrUpdateHeartbeat(lock, ttlMs);
         } else {
           stopHeartbeat(lock);
         }

--- a/packages/junior/src/chat/state/adapter.ts
+++ b/packages/junior/src/chat/state/adapter.ts
@@ -3,8 +3,8 @@ import { createRedisState } from "@chat-adapter/state-redis";
 import type { RedisStateAdapter } from "@chat-adapter/state-redis";
 import type { Lock, QueueEntry, StateAdapter } from "chat";
 import { getChatConfig } from "@/chat/config";
+import { ACTIVE_LOCK_TTL_MS } from "@/chat/state/locks";
 
-export const ACTIVE_LOCK_TTL_MS = 90_000;
 const ACTIVE_LOCK_HEARTBEAT_MS = 30_000;
 
 let stateAdapter: StateAdapter | undefined;

--- a/packages/junior/src/chat/state/adapter.ts
+++ b/packages/junior/src/chat/state/adapter.ts
@@ -75,6 +75,8 @@ function createQueuedStateAdapter(
 
   const heartbeats = new Map<string, LockHeartbeat>();
 
+  // StateAdapter only carries a TTL through acquire/extend calls, so the
+  // active-lock TTL is the explicit opt-in for adapter-owned heartbeats.
   const shouldHeartbeatLock = (ttlMs: number): boolean =>
     ttlMs === ACTIVE_LOCK_TTL_MS;
 

--- a/packages/junior/src/chat/state/locks.ts
+++ b/packages/junior/src/chat/state/locks.ts
@@ -1,0 +1,1 @@
+export const ACTIVE_LOCK_TTL_MS = 90_000;

--- a/packages/junior/src/chat/state/locks.ts
+++ b/packages/junior/src/chat/state/locks.ts
@@ -1,1 +1,14 @@
+import type { Lock, StateAdapter } from "chat";
+
 export const ACTIVE_LOCK_TTL_MS = 90_000;
+
+/**
+ * Acquire a lock for long-running work that the queued state adapter should
+ * keep alive while the owning invocation is still making progress.
+ */
+export async function acquireActiveLock(
+  state: StateAdapter,
+  threadId: string,
+): Promise<Lock | null> {
+  return await state.acquireLock(threadId, ACTIVE_LOCK_TTL_MS);
+}

--- a/packages/junior/tests/component/state/state-adapter-lock.test.ts
+++ b/packages/junior/tests/component/state/state-adapter-lock.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { ACTIVE_LOCK_TTL_MS } from "@/chat/state/locks";
 import { createTestMessage } from "../../fixtures/slack-harness";
 
 const ORIGINAL_ENV = { ...process.env };
@@ -57,8 +58,7 @@ describe("state adapter lock lease", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(0));
 
-    const { ACTIVE_LOCK_TTL_MS, getStateAdapter } =
-      await loadMemoryStateAdapter();
+    const { getStateAdapter } = await loadMemoryStateAdapter();
     const adapter = getStateAdapter();
     await adapter.connect();
 
@@ -77,8 +77,7 @@ describe("state adapter lock lease", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(0));
 
-    const { ACTIVE_LOCK_TTL_MS, getStateAdapter } =
-      await loadMemoryStateAdapter();
+    const { getStateAdapter } = await loadMemoryStateAdapter();
     const adapter = getStateAdapter();
     await adapter.connect();
 
@@ -101,10 +100,9 @@ describe("state adapter lock lease", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(0));
 
-    const { ACTIVE_LOCK_TTL_MS, getStateAdapter } =
-      await loadMemoryStateAdapter({
-        AGENT_TURN_TIMEOUT_MS: "10000",
-      });
+    const { getStateAdapter } = await loadMemoryStateAdapter({
+      AGENT_TURN_TIMEOUT_MS: "10000",
+    });
     const adapter = getStateAdapter();
     await adapter.connect();
 

--- a/packages/junior/tests/component/state/state-adapter-lock.test.ts
+++ b/packages/junior/tests/component/state/state-adapter-lock.test.ts
@@ -29,35 +29,7 @@ describe("state adapter lock lease", () => {
     vi.resetModules();
   });
 
-  it("keeps an active SDK-sized lock leased past the old static ttl", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(0));
-
-    const { disconnectStateAdapter, getStateAdapter } =
-      await loadMemoryStateAdapter();
-    const adapter = getStateAdapter();
-    await adapter.connect();
-
-    const lock = await adapter.acquireLock("thread-1", 30_000);
-    expect(lock).not.toBeNull();
-    if (!lock) {
-      return;
-    }
-
-    await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
-
-    await expect(adapter.acquireLock("thread-1", 30_000)).resolves.toBeNull();
-
-    await adapter.releaseLock(lock);
-    const nextLock = await adapter.acquireLock("thread-1", 30_000);
-    expect(nextLock).not.toBeNull();
-    if (nextLock) {
-      await adapter.releaseLock(nextLock);
-    }
-    await disconnectStateAdapter();
-  });
-
-  it("stops the heartbeat when the lock is released", async () => {
+  it("lets short locks expire at their requested ttl", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(0));
 
@@ -66,6 +38,31 @@ describe("state adapter lock lease", () => {
     await adapter.connect();
 
     const lock = await adapter.acquireLock("thread-1", 30_000);
+    expect(lock).not.toBeNull();
+    expect(vi.getTimerCount()).toBe(0);
+    if (!lock) {
+      return;
+    }
+
+    await vi.advanceTimersByTimeAsync(31_000);
+
+    const nextLock = await adapter.acquireLock("thread-1", 30_000);
+    expect(nextLock).not.toBeNull();
+    if (nextLock) {
+      await adapter.releaseLock(nextLock);
+    }
+  });
+
+  it("stops the active-lock heartbeat when the lock is released", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+
+    const { ACTIVE_LOCK_TTL_MS, getStateAdapter } =
+      await loadMemoryStateAdapter();
+    const adapter = getStateAdapter();
+    await adapter.connect();
+
+    const lock = await adapter.acquireLock("thread-1", ACTIVE_LOCK_TTL_MS);
     expect(lock).not.toBeNull();
     expect(vi.getTimerCount()).toBe(1);
 
@@ -76,17 +73,42 @@ describe("state adapter lock lease", () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  it("keeps an active lock leased past its initial ttl", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+
+    const { ACTIVE_LOCK_TTL_MS, getStateAdapter } =
+      await loadMemoryStateAdapter();
+    const adapter = getStateAdapter();
+    await adapter.connect();
+
+    const lock = await adapter.acquireLock("thread-1", ACTIVE_LOCK_TTL_MS);
+    expect(lock).not.toBeNull();
+    if (!lock) {
+      return;
+    }
+
+    await vi.advanceTimersByTimeAsync(ACTIVE_LOCK_TTL_MS + 1_000);
+
+    await expect(
+      adapter.acquireLock("thread-1", ACTIVE_LOCK_TTL_MS),
+    ).resolves.toBeNull();
+
+    await adapter.releaseLock(lock);
+  });
+
   it("stops heartbeating active locks after the configured turn window", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(0));
 
-    const { getStateAdapter } = await loadMemoryStateAdapter({
-      AGENT_TURN_TIMEOUT_MS: "10000",
-    });
+    const { ACTIVE_LOCK_TTL_MS, getStateAdapter } =
+      await loadMemoryStateAdapter({
+        AGENT_TURN_TIMEOUT_MS: "10000",
+      });
     const adapter = getStateAdapter();
     await adapter.connect();
 
-    const lock = await adapter.acquireLock("thread-1", 30_000);
+    const lock = await adapter.acquireLock("thread-1", ACTIVE_LOCK_TTL_MS);
     expect(lock).not.toBeNull();
     if (!lock) {
       return;
@@ -94,7 +116,7 @@ describe("state adapter lock lease", () => {
 
     await vi.advanceTimersByTimeAsync(181_000);
 
-    const nextLock = await adapter.acquireLock("thread-1", 30_000);
+    const nextLock = await adapter.acquireLock("thread-1", ACTIVE_LOCK_TTL_MS);
     expect(nextLock).not.toBeNull();
     if (nextLock) {
       await adapter.releaseLock(nextLock);

--- a/packages/junior/tests/component/task-execution/conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/conversation-work.test.ts
@@ -39,6 +39,7 @@ import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import {
   CONVERSATION_ID,
   SLACK_DESTINATION,
+  acquireConversationMutationLock,
   conversationQueueMessage,
   createConversationWorkQueueTestAdapter,
   deferred,
@@ -271,6 +272,60 @@ describe("conversation work execution", () => {
       queueMessageId: "queue-1",
     });
     expect(queue.sentRecords()).toHaveLength(1);
+  });
+
+  it("recovers an expired lease after the mutation lock ttl elapses", async () => {
+    vi.useFakeTimers({ now: 1_000 });
+    const queue = createConversationWorkQueueTestAdapter();
+    const state = getStateAdapter();
+    await state.connect();
+
+    await requestConversationWork({
+      conversationId: CONVERSATION_ID,
+      destination: SLACK_DESTINATION,
+      nowMs: 1_000,
+      state,
+    });
+    const lease = await startConversationWork({
+      conversationId: CONVERSATION_ID,
+      nowMs: 1_000,
+      state,
+    });
+    expect(lease.status).toBe("acquired");
+
+    await vi.advanceTimersByTimeAsync(CONVERSATION_WORK_LEASE_TTL_MS + 1);
+
+    const staleMutationLock = await acquireConversationMutationLock({
+      conversationId: CONVERSATION_ID,
+      state,
+    });
+    expect(staleMutationLock).not.toBeNull();
+
+    const recoveryNowMs = Date.now() + 10_001;
+    const recovery = recoverConversationWork({
+      nowMs: recoveryNowMs,
+      queue,
+      state,
+    });
+    await vi.advanceTimersByTimeAsync(10_001);
+
+    await expect(recovery).resolves.toEqual({
+      expiredLeaseCount: 1,
+      pendingCount: 0,
+    });
+    expect(queue.sentRecords()).toEqual([
+      expect.objectContaining({
+        conversationId: CONVERSATION_ID,
+        idempotencyKey: `heartbeat:lease:${CONVERSATION_ID}:${recoveryNowMs}`,
+      }),
+    ]);
+
+    const recovered = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+      state,
+    });
+    expect(recovered?.lease).toBeUndefined();
+    expect(recovered?.needsRun).toBe(true);
   });
 
   it("repairs pending mailbox work when the initial queue send fails", async () => {

--- a/packages/junior/tests/fixtures/conversation-work.ts
+++ b/packages/junior/tests/fixtures/conversation-work.ts
@@ -178,6 +178,18 @@ export function observeConversationMutationLock(args: {
   };
 }
 
+/** Acquire the conversation mutation lock through the shared test fixture. */
+export async function acquireConversationMutationLock(args: {
+  conversationId: string;
+  state: StateAdapter;
+  ttlMs?: number;
+}): Promise<Lock | null> {
+  return await args.state.acquireLock(
+    `junior:conversation:mutation:${args.conversationId}`,
+    args.ttlMs ?? 10_000,
+  );
+}
+
 /** Build a durable mailbox record for component-level conversation work tests. */
 export function inboundMessage(
   inboundMessageId: string,

--- a/packages/junior/tests/integration/slack/webhook-persistence-contract.test.ts
+++ b/packages/junior/tests/integration/slack/webhook-persistence-contract.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
+import {
+  SLACK_BOT_USER_ID,
+  createConversationWorkQueueTestAdapter,
+  createNoopSlackWebhookRuntime,
+  createSlackAdapterFixture,
+  handleSlackWebhookAndFlush,
+  slackEnvelope,
+  slackWebhookRequest,
+} from "../../fixtures/conversation-work";
+
+describe("Slack webhook persistence contract", () => {
+  afterEach(async () => {
+    await disconnectStateAdapter();
+  });
+
+  it.each([
+    {
+      label: "app mention",
+      envelope: slackEnvelope({
+        text: `<@${SLACK_BOT_USER_ID}> deploy status`,
+      }),
+    },
+    {
+      label: "direct message",
+      envelope: slackEnvelope({
+        channel: "D123",
+        eventType: "message",
+        text: "deploy status",
+      }),
+    },
+  ])(
+    "returns retryable response when $label persistence fails",
+    async (args) => {
+      const queue = createConversationWorkQueueTestAdapter();
+      queue.rejectSends();
+      const state = getStateAdapter();
+      await state.connect();
+      const slackAdapter = createSlackAdapterFixture();
+
+      const response = await handleSlackWebhookAndFlush({
+        request: slackWebhookRequest(args.envelope),
+        services: {
+          getSlackAdapter: () => slackAdapter,
+          queue,
+          runtime: createNoopSlackWebhookRuntime(),
+          state,
+        },
+      });
+
+      expect(response.status).toBe(503);
+      expect(queue.queuedMessages()).toEqual([]);
+    },
+  );
+});

--- a/packages/junior/tests/unit/state/state-adapter-token-store.test.ts
+++ b/packages/junior/tests/unit/state/state-adapter-token-store.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { StateAdapter } from "chat";
 import { StateAdapterTokenStore } from "@/chat/credentials/state-adapter-token-store";
-import { ACTIVE_LOCK_TTL_MS } from "@/chat/state/adapter";
+import { ACTIVE_LOCK_TTL_MS } from "@/chat/state/locks";
 
 describe("StateAdapterTokenStore", () => {
   function createAdapter(overrides: Partial<StateAdapter> = {}) {

--- a/packages/junior/tests/unit/state/state-adapter-token-store.test.ts
+++ b/packages/junior/tests/unit/state/state-adapter-token-store.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { StateAdapter } from "chat";
 import { StateAdapterTokenStore } from "@/chat/credentials/state-adapter-token-store";
+import { ACTIVE_LOCK_TTL_MS } from "@/chat/state/adapter";
 
 describe("StateAdapterTokenStore", () => {
   function createAdapter(overrides: Partial<StateAdapter> = {}) {
@@ -88,7 +89,7 @@ describe("StateAdapterTokenStore", () => {
     expect(acquireLock).toHaveBeenCalledTimes(2);
     expect(acquireLock).toHaveBeenCalledWith(
       "oauth-token:U123:github:refresh",
-      30_000,
+      ACTIVE_LOCK_TTL_MS,
     );
     expect(callback).toHaveBeenCalledTimes(1);
     expect(releaseLock).toHaveBeenCalledWith(lock);


### PR DESCRIPTION
Short state-adapter locks now expire at their requested TTL instead of being upgraded into active, heartbeated locks. Explicit `ACTIVE_LOCK_TTL_MS` locks still heartbeat, so active Slack resume ownership is preserved while conversation mutation locks can no longer block heartbeat recovery for minutes.

Slack `message` and `app_mention` webhooks now return a retryable `503` only when durable append/enqueue persistence fails. Ignored or invalid message events still ACK normally, so Slack retries only the inbound work Junior meant to persist.

Refs #651
