### PR TITLE
fix(memory): Make public Slack memories workspace-visible

### DIFF
--- a/packages/docs/src/content/docs/extend/memory-plugin.md
+++ b/packages/docs/src/content/docs/extend/memory-plugin.md
@@ -52,12 +52,12 @@ export const plugins = defineJuniorPlugins([
 
 ## Configure environment variables
 
-| Variable                    | Required | Purpose                                                                                      |
-| --------------------------- | -------- | -------------------------------------------------------------------------------------------- |
-| `DATABASE_URL`              | Yes      | Postgres connection string for memory storage.                                               |
-| `JUNIOR_DATABASE_DRIVER`    | No       | SQL client driver: `neon` (default) or `postgres`. Set `postgres` for non-Neon deployments. |
-| `AI_EMBEDDING_MODEL`        | No       | Embedding model for vector search. Defaults to `openai/text-embedding-3-small` (1536 dims). |
-| `AI_MEMORY_MODEL`           | No       | Model for memory classification and consolidation. Defaults to the app's structured model.   |
+| Variable                 | Required | Purpose                                                                                     |
+| ------------------------ | -------- | ------------------------------------------------------------------------------------------- |
+| `DATABASE_URL`           | Yes      | Postgres connection string for memory storage.                                              |
+| `JUNIOR_DATABASE_DRIVER` | No       | SQL client driver: `neon` (default) or `postgres`. Set `postgres` for non-Neon deployments. |
+| `AI_EMBEDDING_MODEL`     | No       | Embedding model for vector search. Defaults to `openai/text-embedding-3-small` (1536 dims). |
+| `AI_MEMORY_MODEL`        | No       | Model for memory classification and consolidation. Defaults to the app's structured model.  |
 
 `AI_EMBEDDING_MODEL` must produce 1536-dimensional vectors. Changing this value after memories exist requires flushing the `junior_memory_embeddings` table and re-running to regenerate vectors with the new model.
 
@@ -94,6 +94,8 @@ What do you remember about my preferences?
 ```
 
 Junior should recall the preference without prompting.
+
+Public Slack channel memories are workspace-visible. A durable fact remembered in a public channel or public-channel thread can be recalled from another public channel in the same Slack workspace. Private Slack and local conversation memories remain scoped to their original conversation.
 
 ## Failure modes
 

--- a/packages/junior-memory/migrations/0003_public_slack_workspace_memory.sql
+++ b/packages/junior-memory/migrations/0003_public_slack_workspace_memory.sql
@@ -1,11 +1,40 @@
+WITH ranked_active_rows AS (
+  SELECT
+    id,
+    is_legacy_public,
+    row_number() OVER (
+      PARTITION BY target_scope_key, idempotency_key
+      ORDER BY CASE WHEN is_legacy_public THEN 1 ELSE 0 END, id
+    ) AS duplicate_rank
+  FROM (
+    SELECT
+      id,
+      idempotency_key,
+      CASE
+        WHEN split_part(scope_key, ':', 1) = 'slack'
+          AND split_part(scope_key, ':', 3) LIKE 'C%'
+          AND split_part(scope_key, ':', 4) <> ''
+          THEN 'slack:' || split_part(scope_key, ':', 2)
+        ELSE scope_key
+      END AS target_scope_key,
+      split_part(scope_key, ':', 1) = 'slack'
+        AND split_part(scope_key, ':', 3) LIKE 'C%'
+        AND split_part(scope_key, ':', 4) <> '' AS is_legacy_public
+    FROM junior_memory_memories
+    WHERE scope = 'conversation'
+      AND source_platform = 'slack'
+      AND idempotency_key IS NOT NULL
+      AND archived_at_ms IS NULL
+      AND superseded_at_ms IS NULL
+      AND superseded_by_id IS NULL
+  ) active_rows
+)
 UPDATE junior_memory_memories
-SET idempotency_key = 'legacy-public-slack:' || id
-WHERE scope = 'conversation'
-  AND source_platform = 'slack'
-  AND idempotency_key IS NOT NULL
-  AND split_part(scope_key, ':', 1) = 'slack'
-  AND split_part(scope_key, ':', 3) LIKE 'C%'
-  AND split_part(scope_key, ':', 4) <> '';
+SET idempotency_key = 'legacy-public-slack:' || junior_memory_memories.id
+FROM ranked_active_rows
+WHERE junior_memory_memories.id = ranked_active_rows.id
+  AND ranked_active_rows.is_legacy_public
+  AND ranked_active_rows.duplicate_rank > 1;
 --> statement-breakpoint
 UPDATE junior_memory_memories
 SET

--- a/packages/junior-memory/migrations/0003_public_slack_workspace_memory.sql
+++ b/packages/junior-memory/migrations/0003_public_slack_workspace_memory.sql
@@ -1,0 +1,26 @@
+UPDATE junior_memory_memories
+SET idempotency_key = 'legacy-public-slack:' || id
+WHERE scope = 'conversation'
+  AND source_platform = 'slack'
+  AND idempotency_key IS NOT NULL
+  AND split_part(scope_key, ':', 1) = 'slack'
+  AND split_part(scope_key, ':', 3) LIKE 'C%'
+  AND split_part(scope_key, ':', 4) <> '';
+--> statement-breakpoint
+UPDATE junior_memory_memories
+SET
+  scope_key = 'slack:' || split_part(scope_key, ':', 2),
+  subject_key = CASE
+    WHEN subject_type = 'conversation'
+      AND subject_key IS NOT NULL
+      AND split_part(subject_key, ':', 1) = 'slack'
+      AND split_part(subject_key, ':', 3) LIKE 'C%'
+      AND split_part(subject_key, ':', 4) <> ''
+      THEN 'slack:' || split_part(subject_key, ':', 2)
+    ELSE subject_key
+  END
+WHERE scope = 'conversation'
+  AND source_platform = 'slack'
+  AND split_part(scope_key, ':', 1) = 'slack'
+  AND split_part(scope_key, ':', 3) LIKE 'C%'
+  AND split_part(scope_key, ':', 4) <> '';

--- a/packages/junior-memory/migrations/meta/0003_snapshot.json
+++ b/packages/junior-memory/migrations/meta/0003_snapshot.json
@@ -1,0 +1,348 @@
+{
+  "id": "2f78c37c-9c80-4f92-92f8-7eaa1951862b",
+  "prevId": "9e9985ce-7ac3-4872-97f3-e4a4d3fe39c9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.junior_memory_embeddings": {
+      "name": "junior_memory_embeddings",
+      "schema": "",
+      "columns": {
+        "memory_id": {
+          "name": "memory_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_ms": {
+          "name": "created_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_memory_embeddings_model_idx": {
+          "name": "junior_memory_embeddings_model_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dimensions",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "junior_memory_embeddings_memory_id_junior_memory_memories_id_fk": {
+          "name": "junior_memory_embeddings_memory_id_junior_memory_memories_id_fk",
+          "tableFrom": "junior_memory_embeddings",
+          "columnsFrom": ["memory_id"],
+          "tableTo": "junior_memory_memories",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "junior_memory_embeddings_metric_check": {
+          "name": "junior_memory_embeddings_metric_check",
+          "value": "\"junior_memory_embeddings\".\"metric\" IN ('cosine')"
+        },
+        "junior_memory_embeddings_dimensions_check": {
+          "name": "junior_memory_embeddings_dimensions_check",
+          "value": "\"junior_memory_embeddings\".\"dimensions\" = 1536"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.junior_memory_memories": {
+      "name": "junior_memory_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_platform": {
+          "name": "source_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at_ms": {
+          "name": "observed_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_ms": {
+          "name": "created_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at_ms": {
+          "name": "expires_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at_ms": {
+          "name": "superseded_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by_id": {
+          "name": "superseded_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at_ms": {
+          "name": "archived_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_reason": {
+          "name": "archive_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_memory_memories_visible_idx": {
+          "name": "junior_memory_memories_visible_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at_ms",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"junior_memory_memories\".\"archived_at_ms\" IS NULL AND \"junior_memory_memories\".\"superseded_at_ms\" IS NULL AND \"junior_memory_memories\".\"superseded_by_id\" IS NULL",
+          "concurrently": false
+        },
+        "junior_memory_memories_expiration_idx": {
+          "name": "junior_memory_memories_expiration_idx",
+          "columns": [
+            {
+              "expression": "expires_at_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"junior_memory_memories\".\"archived_at_ms\" IS NULL AND \"junior_memory_memories\".\"expires_at_ms\" IS NOT NULL",
+          "concurrently": false
+        },
+        "junior_memory_memories_idempotency_idx": {
+          "name": "junior_memory_memories_idempotency_idx",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"junior_memory_memories\".\"idempotency_key\" IS NOT NULL AND \"junior_memory_memories\".\"archived_at_ms\" IS NULL AND \"junior_memory_memories\".\"superseded_at_ms\" IS NULL AND \"junior_memory_memories\".\"superseded_by_id\" IS NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "junior_memory_memories_scope_check": {
+          "name": "junior_memory_memories_scope_check",
+          "value": "\"junior_memory_memories\".\"scope\" IN ('personal', 'conversation')"
+        },
+        "junior_memory_memories_type_check": {
+          "name": "junior_memory_memories_type_check",
+          "value": "\"junior_memory_memories\".\"type\" IN (\n        'preference',\n        'identity',\n        'relationship',\n        'knowledge',\n        'context',\n        'event',\n        'task',\n        'observation'\n      )"
+        },
+        "junior_memory_memories_subject_type_check": {
+          "name": "junior_memory_memories_subject_type_check",
+          "value": "\"junior_memory_memories\".\"subject_type\" IN ('user', 'conversation', 'general')"
+        },
+        "junior_memory_memories_subject_key_check": {
+          "name": "junior_memory_memories_subject_key_check",
+          "value": "(\"junior_memory_memories\".\"subject_type\" = 'general' AND \"junior_memory_memories\".\"subject_key\" IS NULL) OR (\"junior_memory_memories\".\"subject_type\" IN ('user', 'conversation') AND \"junior_memory_memories\".\"subject_key\" IS NOT NULL AND length(\"junior_memory_memories\".\"subject_key\") > 0)"
+        },
+        "junior_memory_memories_source_platform_check": {
+          "name": "junior_memory_memories_source_platform_check",
+          "value": "\"junior_memory_memories\".\"source_platform\" IN ('slack', 'local')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/junior-memory/migrations/meta/_journal.json
+++ b/packages/junior-memory/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1782158974888,
       "tag": "0002_light_silver_centurion",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1782582311997,
+      "tag": "0003_public_slack_workspace_memory",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/junior-memory/src/scope.ts
+++ b/packages/junior-memory/src/scope.ts
@@ -1,3 +1,4 @@
+import { isPrivateSource } from "@sentry/junior-plugin-api";
 import type {
   MemoryRuntimeContext,
   MemoryScope,
@@ -19,6 +20,9 @@ export interface ResolvedMemorySubject {
 function sourceConversationKey(ctx: MemoryRuntimeContext): string | undefined {
   if (ctx.source.platform === "local") {
     return ctx.source.conversationId;
+  }
+  if (!isPrivateSource(ctx.source)) {
+    return `slack:${ctx.source.teamId}`;
   }
   const threadKey = ctx.source.threadTs ?? ctx.source.messageTs;
   if (!threadKey) {

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -1167,7 +1167,7 @@ ORDER BY created_at_ms ASC
         },
         {
           id: conversation.memory.id,
-          subject_key: "slack:T123:C123:1718800000.000000",
+          subject_key: "slack:T123",
           subject_type: "conversation",
         },
       ]);
@@ -1195,9 +1195,9 @@ ORDER BY created_at_ms ASC
         }),
         { now: () => nowMs },
       );
-      await expect(otherConversationStore.listMemories({})).resolves.toEqual(
-        [],
-      );
+      await expect(otherConversationStore.listMemories({})).resolves.toEqual([
+        expect.objectContaining({ id: conversation.memory.id }),
+      ]);
 
       await expect(
         store.searchMemories({ query: "where are runbooks" }),
@@ -1206,17 +1206,19 @@ ORDER BY created_at_ms ASC
       ]);
       await expect(
         otherConversationStore.searchMemories({ query: "runbooks" }),
-      ).resolves.toEqual([]);
+      ).resolves.toEqual([
+        expect.objectContaining({ id: conversation.memory.id }),
+      ]);
       nowMs = TEST_NOW_MS + 4;
-      await expect(
-        otherConversationStore.archiveMemory({ id: conversation.memory.id }),
-      ).rejects.toThrow("Memory was not found in the current context.");
       const otherTeamStore = createMemoryStore(
         memoryDb(fixture),
         slackContext({ teamId: "T999", userId: "U456" }),
         { now: () => nowMs },
       );
       await expect(otherTeamStore.listMemories({})).resolves.toEqual([]);
+      await expect(
+        otherTeamStore.archiveMemory({ id: conversation.memory.id }),
+      ).rejects.toThrow("Memory was not found in the current context.");
 
       const archived = await store.archiveMemory({
         id: personal.memory.id.slice(0, 12),

--- a/specs/memory-plugin/index.md
+++ b/specs/memory-plugin/index.md
@@ -226,10 +226,10 @@ working relationships that pass policy.
 
 V1 supports two visibility scopes:
 
-| Scope          | Stored authority                                 | Visible to                                   |
-| -------------- | ------------------------------------------------ | -------------------------------------------- |
-| `personal`     | current requester actor                          | same requester in compatible runtime context |
-| `conversation` | current source/destination conversation identity | later requests in the same conversation      |
+| Scope          | Stored authority                                | Visible to                                                 |
+| -------------- | ----------------------------------------------- | ---------------------------------------------------------- |
+| `personal`     | current requester actor                         | same requester in compatible runtime context               |
+| `conversation` | source-derived conversation or public workspace | public Slack workspace, or same private/local conversation |
 
 Rules:
 
@@ -245,8 +245,9 @@ is on the billing team` is not a valid personal memory when written by
 3. Conversation memory may be created only when the user explicitly frames the
    fact as shared team/channel/conversation knowledge or the passive extractor
    can prove the fact is about the current conversation rather than a person.
-4. V1 does not recall memories across unrelated conversations, even if display
-   names or Slack users appear to match.
+4. Public Slack conversation memories are visible across the Slack workspace.
+   Private Slack and local conversation memories do not recall across unrelated
+   conversations, even if display names or Slack users appear to match.
 5. Subject fields describe what the memory is about; they do not broaden
    visibility beyond the stored scope.
 6. Stored content must not include ownership, source, or perspective labels
@@ -259,11 +260,11 @@ thread`, or channel labels. Those facts belong in structured scope, subject,
 Scope answers who can see the memory. Subject answers what the memory is about.
 V1 supports a small subject model rather than a graph:
 
-| Subject type   | Meaning                                      | Subject key                                 |
-| -------------- | -------------------------------------------- | ------------------------------------------- |
-| `user`         | public/shareable fact about the current user | current requester actor key                 |
-| `conversation` | norm or fact about the current conversation  | current source/destination conversation key |
-| `general`      | project, product, repository, or domain fact | none                                        |
+| Subject type   | Meaning                                      | Subject key                                       |
+| -------------- | -------------------------------------------- | ------------------------------------------------- |
+| `user`         | public/shareable fact about the current user | current requester actor key                       |
+| `conversation` | norm or fact about the current conversation  | current source-derived conversation/workspace key |
+| `general`      | project, product, repository, or domain fact | none                                              |
 
 Rules:
 

--- a/specs/memory-plugin/security.md
+++ b/specs/memory-plugin/security.md
@@ -58,9 +58,11 @@ authorization is a separate host boundary.
 Personal memory is visible only to the same requester in a compatible runtime
 context.
 
-Conversation memory is visible only in the same conversation identity. V1 does
-not recall conversation memory across related channels, Slack workspaces,
-threads, projects, or rooms.
+Public Slack conversation memory is visible across the same Slack workspace.
+Private Slack and local conversation memory is visible only in the same
+conversation identity. V1 does not recall conversation memory across Slack
+workspaces, private conversations, unrelated local conversations, projects, or
+rooms.
 
 V1 passive extraction stores public/shareable memories only and prefers
 conversation-scoped workplace knowledge by default. Local CLI is a supported

--- a/specs/memory-plugin/storage.md
+++ b/specs/memory-plugin/storage.md
@@ -111,7 +111,8 @@ and model-extracted entity subjects must not become authorization principals.
 The storage model must support these V1 visibility scopes:
 
 - personal memory owned by the current requester identity
-- conversation memory owned by the current source/destination conversation
+- conversation memory owned by the current public Slack workspace or
+  private/local source conversation
 
 The stored scope must be derived from runtime context before write. Model-visible
 tool input cannot provide requester ids, actor ids, workspace ids, channel ids,


### PR DESCRIPTION
Public Slack memory now uses the Slack workspace as the conversation scope, so durable facts captured in public channels or public-channel threads can be recalled from other public channels in the same workspace. Private Slack and local conversation memories keep their narrower conversation scope.

Existing public Slack conversation memory rows are backfilled through a Drizzle-generated custom SQL migration. The migration preserves source attribution fields for channel/thread provenance while moving the authority-bearing scope and conversation subject key to `slack:{teamId}`.
