### PR TITLE
fix(skills): from sentry session urls in github issues and PRs

### DIFF
--- a/packages/junior-github/skills/github-code/SKILL.md
+++ b/packages/junior-github/skills/github-code/SKILL.md
@@ -134,7 +134,7 @@ Defaults:
 
 ```
 ---
-[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22<url-encoded conversation id>%22)
+[View Session in Sentry](https://sentry.sentry.io/explore/conversations/<url-encoded conversation id>/?project=4510944073809921)
 ```
 
 **Assignment:** resolve GitHub handles from evidence (`gh api search/users`, org membership, repo history) before assigning requested reviewers or assignees. Skip assignment when the handle cannot be confirmed.

--- a/packages/junior-github/skills/github-code/SKILL.md
+++ b/packages/junior-github/skills/github-code/SKILL.md
@@ -130,12 +130,6 @@ Defaults:
 **Footers** (in order):
 
 1. Issue references (`Fixes #N`, `Refs SENTRY-N`), if any.
-2. Session link — when `gen_ai.conversation.id` is available:
-
-```
----
-[View Session in Sentry](https://sentry.sentry.io/explore/conversations/<url-encoded conversation id>/?project=4510944073809921)
-```
 
 **Assignment:** resolve GitHub handles from evidence (`gh api search/users`, org membership, repo history) before assigning requested reviewers or assignees. Skip assignment when the handle cannot be confirmed.
 

--- a/packages/junior-github/skills/github-issues/SKILL.md
+++ b/packages/junior-github/skills/github-issues/SKILL.md
@@ -67,14 +67,6 @@ Follow [references/research-rules.md](references/research-rules.md) for cross-ty
 - Attach screenshots from the thread as image links when present.
 - Include code snippets, related issues, and related PRs only when they materially improve the issue.
 
-**Body footer:**
-
-- When `gen_ai.conversation.id` is available in runtime context, append a session link as the last line of the issue body:
-
-```
----
-[View Session in Sentry](https://sentry.sentry.io/explore/conversations/<url-encoded conversation id>/?project=4510944073809921)
-```
 
 ### 4. Verify draft
 

--- a/packages/junior-github/skills/github-issues/SKILL.md
+++ b/packages/junior-github/skills/github-issues/SKILL.md
@@ -67,6 +67,15 @@ Follow [references/research-rules.md](references/research-rules.md) for cross-ty
 - Attach screenshots from the thread as image links when present.
 - Include code snippets, related issues, and related PRs only when they materially improve the issue.
 
+**Body footer:**
+
+- When `gen_ai.conversation.id` is available in runtime context, append a session link as the last line of the issue body:
+
+```
+---
+[View Session in Sentry](https://sentry.sentry.io/explore/conversations/<url-encoded conversation id>/?project=4510944073809921)
+```
+
 ### 4. Verify draft
 
 Before running the `gh` create/edit command, check each gate. If any fails, revise and re-check before executing:


### PR DESCRIPTION
## What

Removes hardcoded `sentry.sentry.io` session link templates from github-code and github-issues skill instructions. The hardcoded org URL and project ID (`4510944073809921`) only work for Sentry's internal deployment — any user with their own `SENTRY_DSN` gets a broken link.

The correct fix is dynamic URL generation at the app level (see #660). This PR removes the broken static templates as a stop-gap.

Refs #660

---
[View Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC0AHB7N2JCR%3A1782621382.822239/?project=4510944073809921)