### PR TITLE
feat(dashboard): Render activity inline in transcripts

### DIFF
--- a/.agents/skills/junior-qa/SKILL.md
+++ b/.agents/skills/junior-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: junior-qa
-description: Validate Junior changes by running the local Junior CLI from apps/example. Use for local client or agent QA, PR readiness, plugin CLI commands, skill/tool/prompt/plugin behavior, and behavior that tests do not cover well but can be exercised with `pnpm cli -- chat ...` or `pnpm cli -- <command> ...`.
+description: Validate Junior changes through local app-facing paths. Use for local client or agent QA, dashboard mock reporting UI QA, PR readiness, plugin CLI commands, skill/tool/prompt/plugin behavior, and behavior that tests do not cover well but can be exercised with `pnpm cli -- chat ...`, `pnpm cli -- <command> ...`, or `JUNIOR_DASHBOARD_MOCK_CONVERSATIONS=true pnpm dev`.
 ---
 
 Use the local Junior CLI to exercise behavior the test suite does not prove well.
@@ -46,6 +46,27 @@ Healthy startup usually logs `SOUL.md`, `WORLD.md`, loaded plugins, and
 discovered skills. Treat those logs as useful evidence that the example app path
 was exercised.
 
+## Dashboard UI QA
+
+For dashboard UI changes that depend on reporting payload shape, use the typed
+mock reporting overlay before relying on ad-hoc local conversations:
+
+```sh
+JUNIOR_DASHBOARD_MOCK_CONVERSATIONS=true pnpm dev
+```
+
+Then open the dashboard in a browser and exercise the relevant conversation,
+transcript, search, or conversation stats surface. The mock overlay returns
+read-only `@sentry/junior/reporting` conversation API-shaped data, including
+dashboard QA edge cases such as activity-only tool rows and inverted tool
+timestamps. Use it when a UI change needs deterministic reporting records that
+are hard to produce through a live local chat. Plugin report data is pass-through
+from the configured reporting provider and needs separate validation.
+
+Do not treat mock dashboard data as proof of runtime ingestion, Slack delivery,
+credential behavior, or model behavior. Pair it with local CLI or integration
+tests when the changed contract crosses those boundaries.
+
 ## Choosing a Probe
 
 Pick the smallest local CLI run that demonstrates the changed behavior:
@@ -54,6 +75,8 @@ Pick the smallest local CLI run that demonstrates the changed behavior:
 - Use natural-language prompts when the behavior is an agent/tool workflow.
 - Use direct plugin commands when the behavior is an operator CLI surface.
 - Use interactive `pnpm cli -- chat` when continuity across turns matters.
+- Use dashboard mock reporting when the behavior is dashboard rendering,
+  filtering, search, or metrics over reporting API payloads.
 - Do not use local CLI to claim Slack-only behavior, such as Slack formatting,
   delivery retries, reactions, files, or OAuth UI.
 
@@ -78,6 +101,8 @@ insufficient and name the runtime surface that still needs manual coverage.
 Report:
 
 - the exact `pnpm cli -- ...` commands run
+- for dashboard mock QA, the dev-server command, URL, mock conversation or page
+  inspected, and the visible UI evidence
 - exit status and the key output that proves the behavior
 - whether `apps/example` loaded the expected app/plugin/skill path
 - whether local QA was sufficient, or what remains unproven locally

--- a/.agents/skills/junior-qa/SKILL.md
+++ b/.agents/skills/junior-qa/SKILL.md
@@ -59,9 +59,12 @@ Then open the dashboard in a browser and exercise the relevant conversation,
 transcript, search, or conversation stats surface. The mock overlay returns
 read-only `@sentry/junior/reporting` conversation API-shaped data, including
 dashboard QA edge cases such as activity-only tool rows and inverted tool
-timestamps. Use it when a UI change needs deterministic reporting records that
-are hard to produce through a live local chat. Plugin report data is pass-through
-from the configured reporting provider and needs separate validation.
+timestamps. It also includes an advisor tool call/result paired with advisor
+subagent activity so transcript rendering can be checked against nested tool
+activity without manufacturing a live agent run. Use it when a UI change needs
+deterministic reporting records that are hard to produce through a live local
+chat. Plugin report data is pass-through from the configured reporting provider
+and needs separate validation.
 
 Do not treat mock dashboard data as proof of runtime ingestion, Slack delivery,
 credential behavior, or model behavior. Pair it with local CLI or integration

--- a/packages/junior-dashboard/src/client/components/TranscriptSubagentView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptSubagentView.tsx
@@ -1,0 +1,67 @@
+import { Bot } from "lucide-react";
+
+import { formatMessageTimestamp, formatMs } from "../format";
+import type { TranscriptViewSubagentPart } from "../types";
+import { ToolFrame } from "./ToolFrame";
+import { HighlightText } from "./transcriptSearch";
+
+/** Render a child-agent lifecycle event inside the transcript stream. */
+export function TranscriptSubagentView(props: {
+  part: TranscriptViewSubagentPart;
+  timestamp?: number;
+}) {
+  const label = `${props.part.subagentKind} subagent`;
+  const endedAt = props.part.endedAt
+    ? Date.parse(props.part.endedAt)
+    : undefined;
+  const duration =
+    typeof props.timestamp === "number" &&
+    typeof endedAt === "number" &&
+    Number.isFinite(endedAt) &&
+    endedAt >= props.timestamp
+      ? formatMs(endedAt - props.timestamp)
+      : undefined;
+  const status = statusLabel(props.part);
+  const meta = [
+    status,
+    duration,
+    props.part.parentToolCallId
+      ? `parent ${props.part.parentToolCallId}`
+      : undefined,
+    typeof props.timestamp === "number"
+      ? formatMessageTimestamp(props.timestamp)
+      : undefined,
+  ].filter(isString);
+
+  return (
+    <ToolFrame
+      meta={meta}
+      mobileSummaryMeta={status}
+      raw
+      signature={
+        <>
+          <Bot
+            aria-hidden="true"
+            className="mt-px shrink-0 text-cyan-300"
+            size={14}
+            strokeWidth={2.25}
+          />
+          <strong className="min-w-0 break-words font-bold text-cyan-100">
+            <HighlightText text={label} />
+          </strong>
+        </>
+      }
+    />
+  );
+}
+
+function statusLabel(part: TranscriptViewSubagentPart): string | undefined {
+  if (part.outcome === "success") return "completed";
+  if (part.outcome === "error") return "error";
+  if (part.outcome === "aborted") return "aborted";
+  return part.status === "running" ? "running" : part.status;
+}
+
+function isString(value: string | undefined): value is string {
+  return typeof value === "string" && value.length > 0;
+}

--- a/packages/junior-dashboard/src/client/components/TranscriptToolView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptToolView.tsx
@@ -8,15 +8,15 @@ import {
   stringifyPartValue,
 } from "../format";
 import { cn } from "../styles";
-import type { TranscriptPart } from "../types";
+import type { TranscriptViewPart } from "../types";
 import { ToolFrame } from "./ToolFrame";
 import { isPreviewableValue } from "./transcriptPreview";
 import { HighlightText } from "./transcriptSearch";
 
 /** Render a tool call/result pair in rich or raw transcript mode. */
 export function TranscriptToolView(props: {
-  call?: TranscriptPart;
-  result?: TranscriptPart;
+  call?: TranscriptViewPart;
+  result?: TranscriptViewPart;
   resultTimestamp?: number;
   timestamp?: number;
   view?: "raw" | "rich";
@@ -38,10 +38,12 @@ export function TranscriptToolView(props: {
     props.resultTimestamp >= props.timestamp
       ? formatMs(props.resultTimestamp - props.timestamp)
       : undefined;
+  const missingResultLabel =
+    props.call?.status === "running" ? "running" : "missing result";
   const meta = [
     duration,
     props.result ? formatBytes(outputBytes) : undefined,
-    props.result ? undefined : "missing result",
+    props.result ? undefined : missingResultLabel,
     typeof props.timestamp === "number"
       ? formatMessageTimestamp(props.timestamp)
       : undefined,
@@ -49,7 +51,7 @@ export function TranscriptToolView(props: {
   const args = <ToolArgumentsPreview input={input} />;
   const hasExpandableContent = Boolean(props.call || props.result);
   const mobileSummaryMeta =
-    duration ?? (props.call && !props.result ? "missing result" : undefined);
+    duration ?? (props.call && !props.result ? missingResultLabel : undefined);
 
   if (props.view === "raw") {
     return (

--- a/packages/junior-dashboard/src/client/components/TranscriptTurn.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptTurn.tsx
@@ -23,10 +23,11 @@ import {
   visualStatusForSession,
 } from "../format";
 import { cn } from "../styles";
+import { turnTranscriptMessages } from "../transcriptActivity";
 import type {
   ConversationTurn,
-  TranscriptMessage,
-  TranscriptPart,
+  TranscriptViewMessage,
+  TranscriptViewPart,
 } from "../types";
 import { StatusBadge } from "./StatusBadge";
 import { ToolFrame, toolFrameClass } from "./ToolFrame";
@@ -44,6 +45,7 @@ import {
 } from "./TelemetryMetrics";
 import { TranscriptText } from "./TranscriptText";
 import { TranscriptThinkingView } from "./TranscriptThinkingView";
+import { TranscriptSubagentView } from "./TranscriptSubagentView";
 import { TranscriptToolRun } from "./TranscriptToolRun";
 import { TranscriptToolView } from "./TranscriptToolView";
 import { shouldCopyRawTranscript } from "./transcriptCopy";
@@ -60,13 +62,11 @@ import {
   mutedTranscriptMetaClass,
 } from "./transcriptStyles";
 import { previewToolValue } from "./transcriptPreview";
-import {
-  entryMatchesSearch,
-  useTranscriptSearch,
-} from "./transcriptSearch";
+import { entryMatchesSearch, useTranscriptSearch } from "./transcriptSearch";
 
 type TranscriptEntry = ReturnType<typeof groupTranscriptMessages>[number];
 type TranscriptMessageEntry = Extract<TranscriptEntry, { kind: "message" }>;
+type TranscriptSubagentEntry = Extract<TranscriptEntry, { kind: "subagent" }>;
 type TranscriptThinkingEntry = Extract<TranscriptEntry, { kind: "thinking" }>;
 type TranscriptToolEntry = Extract<TranscriptEntry, { kind: "tool" }>;
 
@@ -214,41 +214,24 @@ function SegmentEvents(props: {
   turn: ConversationTurn;
   view: TranscriptViewMode;
 }) {
+  const transcript = turnTranscriptMessages(props.turn);
+
   return (
     <div className="grid min-w-0 grid-cols-[minmax(0,1fr)] gap-2 pt-3">
       {props.turn.transcriptAvailable ? (
-        <TranscriptEntryList
-          entries={groupTranscriptMessages(props.turn.transcript)}
-          keyPrefix={props.turn.id}
-          renderMessage={(entry, index) => (
-            <TranscriptMessageView
-              key={`${props.turn.id}:${index}`}
-              message={entry.message}
-              turn={props.turn}
-              view={props.view}
-            />
-          )}
-          renderThinking={(entry, index) => (
-            <TranscriptThinkingView
-              key={`${props.turn.id}:thinking:${index}`}
-              timestamp={entry.timestamp}
-              value={entry.part.output}
-            />
-          )}
-          renderTool={(entry, index) => (
-            <TranscriptToolView
-              call={entry.call}
-              key={`${props.turn.id}:${index}`}
-              result={entry.result}
-              resultTimestamp={entry.resultTimestamp}
-              timestamp={entry.timestamp}
-              view={props.view}
-            />
-          )}
+        <VisibleTranscriptEntries
+          transcript={transcript}
+          turn={props.turn}
+          view={props.view}
         />
-      ) : props.turn.transcriptRedacted &&
-        props.turn.transcriptMetadata?.length ? (
+      ) : props.turn.transcriptRedacted && transcript.length > 0 ? (
         <RedactedTranscriptView turn={props.turn} />
+      ) : transcript.length > 0 ? (
+        <VisibleTranscriptEntries
+          transcript={transcript}
+          turn={props.turn}
+          view={props.view}
+        />
       ) : (
         <div className={transcriptEmptyClass()}>
           {unavailableTranscriptLabel(props.turn)}
@@ -258,10 +241,56 @@ function SegmentEvents(props: {
   );
 }
 
+function VisibleTranscriptEntries(props: {
+  transcript: TranscriptViewMessage[];
+  turn: ConversationTurn;
+  view: TranscriptViewMode;
+}) {
+  return (
+    <TranscriptEntryList
+      entries={groupTranscriptMessages(props.transcript)}
+      keyPrefix={props.turn.id}
+      renderMessage={(entry, index) => (
+        <TranscriptMessageView
+          key={`${props.turn.id}:${index}`}
+          message={entry.message}
+          turn={props.turn}
+          view={props.view}
+        />
+      )}
+      renderSubagent={(entry, index) => (
+        <TranscriptSubagentView
+          key={`${props.turn.id}:subagent:${index}`}
+          part={entry.part}
+          timestamp={entry.timestamp}
+        />
+      )}
+      renderThinking={(entry, index) => (
+        <TranscriptThinkingView
+          key={`${props.turn.id}:thinking:${index}`}
+          timestamp={entry.timestamp}
+          value={entry.part.output}
+        />
+      )}
+      renderTool={(entry, index) => (
+        <TranscriptToolView
+          call={entry.call}
+          key={`${props.turn.id}:${index}`}
+          result={entry.result}
+          resultTimestamp={entry.resultTimestamp}
+          timestamp={entry.timestamp}
+          view={props.view}
+        />
+      )}
+    />
+  );
+}
+
 function TranscriptEntryList(props: {
   entries: TranscriptEntry[];
   keyPrefix: string;
   renderMessage: (entry: TranscriptMessageEntry, index: number) => ReactNode;
+  renderSubagent: (entry: TranscriptSubagentEntry, index: number) => ReactNode;
   renderThinking: (entry: TranscriptThinkingEntry, index: number) => ReactNode;
   renderTool: (entry: TranscriptToolEntry, index: number) => ReactNode;
 }) {
@@ -304,7 +333,9 @@ function TranscriptEntryList(props: {
         <Fragment key={`${props.keyPrefix}:${entry.kind}:${index}`}>
           {entry.kind === "thinking"
             ? props.renderThinking(entry, index)
-            : props.renderMessage(entry, index)}
+            : entry.kind === "subagent"
+              ? props.renderSubagent(entry, index)
+              : props.renderMessage(entry, index)}
         </Fragment>,
       );
     }
@@ -323,13 +354,20 @@ function TranscriptEntryList(props: {
 function RedactedTranscriptView(props: { turn: ConversationTurn }) {
   return (
     <TranscriptEntryList
-      entries={groupTranscriptMessages(props.turn.transcriptMetadata ?? [])}
+      entries={groupTranscriptMessages(turnTranscriptMessages(props.turn))}
       keyPrefix={`${props.turn.id}:redacted`}
       renderMessage={(entry, index) => (
         <RedactedMessageView
           key={`${props.turn.id}:redacted:${index}`}
           message={entry.message}
           turn={props.turn}
+        />
+      )}
+      renderSubagent={(entry, index) => (
+        <TranscriptSubagentView
+          key={`${props.turn.id}:redacted:subagent:${index}`}
+          part={entry.part}
+          timestamp={entry.timestamp}
         />
       )}
       renderThinking={(entry, index) => (
@@ -352,7 +390,7 @@ function RedactedTranscriptView(props: { turn: ConversationTurn }) {
 }
 
 function RedactedMessageView(props: {
-  message: TranscriptMessage;
+  message: TranscriptViewMessage;
   turn: ConversationTurn;
 }) {
   const meta = [formatMessageTimestamp(props.message.timestamp)].filter(
@@ -375,7 +413,7 @@ function RedactedMessageView(props: {
   );
 }
 
-function RedactedPartLine(props: { part: TranscriptPart }) {
+function RedactedPartLine(props: { part: TranscriptViewPart }) {
   if (props.part.type === "text") {
     return <RedactedMetadataRow meta={redactedMessageSize(props.part)} />;
   }
@@ -437,8 +475,8 @@ function RedactedThinkingView(props: { timestamp?: number }) {
 }
 
 function RedactedToolView(props: {
-  call?: TranscriptPart;
-  result?: TranscriptPart;
+  call?: TranscriptViewPart;
+  result?: TranscriptViewPart;
   resultTimestamp?: number;
   timestamp?: number;
 }) {
@@ -454,15 +492,17 @@ function RedactedToolView(props: {
     props.resultTimestamp >= props.timestamp
       ? formatMs(props.resultTimestamp - props.timestamp)
       : undefined;
+  const missingResultLabel =
+    props.call?.status === "running" ? "running" : "missing result";
   const meta = [
     duration,
-    props.result ? undefined : "missing result",
+    props.result ? undefined : missingResultLabel,
     typeof props.timestamp === "number"
       ? formatMessageTimestamp(props.timestamp)
       : undefined,
   ].filter(isString);
   const mobileSummaryMeta =
-    duration ?? (props.call && !props.result ? "missing result" : undefined);
+    duration ?? (props.call && !props.result ? missingResultLabel : undefined);
 
   return (
     <ToolFrame
@@ -485,7 +525,7 @@ function RedactedToolView(props: {
   );
 }
 
-function redactedMessageSize(part: TranscriptPart): string | undefined {
+function redactedMessageSize(part: TranscriptViewPart): string | undefined {
   if (typeof part.bytes === "number") return formatBytes(part.bytes);
   return typeof part.chars === "number" ? `${part.chars} chars` : undefined;
 }
@@ -565,7 +605,7 @@ function turnMeta(turn: ConversationTurn): MetricListItem[] {
  * block-level XML heuristic in format.ts fires.
  */
 function SystemMessageView(props: {
-  message: TranscriptMessage;
+  message: TranscriptViewMessage;
   turn: ConversationTurn;
   view: TranscriptViewMode;
 }) {
@@ -601,7 +641,10 @@ function SystemMessageView(props: {
           <div className="grid min-w-0 grid-cols-[minmax(0,1fr)] gap-2">
             {renderedParts.map((part, index) => {
               const firstChildIndex = seenRenderedChildren;
-              seenRenderedChildren += countRenderedTranscriptChildren(part, role);
+              seenRenderedChildren += countRenderedTranscriptChildren(
+                part,
+                role,
+              );
               return (
                 <TranscriptPartView
                   firstChildIndex={firstChildIndex}
@@ -661,7 +704,7 @@ function SystemMessageView(props: {
 }
 
 function TranscriptMessageView(props: {
-  message: TranscriptMessage;
+  message: TranscriptViewMessage;
   turn: ConversationTurn;
   view: TranscriptViewMode;
 }) {

--- a/packages/junior-dashboard/src/client/components/transcriptBottomPinning.ts
+++ b/packages/junior-dashboard/src/client/components/transcriptBottomPinning.ts
@@ -9,7 +9,8 @@ import {
   type RefObject,
 } from "react";
 
-import type { ConversationTurn, TranscriptPart } from "../types";
+import type { ConversationTurn, TranscriptViewPart } from "../types";
+import { turnTranscriptMessages } from "../transcriptActivity";
 
 const BOTTOM_PROXIMITY_PX = 96;
 const USER_SCROLL_DELTA_PX = 2;
@@ -51,10 +52,7 @@ export function transcriptBottomVersion(turns: ConversationTurn[]): string {
   const lastTurn = turns.at(-1);
   if (!lastTurn) return "empty";
 
-  const messages =
-    lastTurn.transcript.length > 0
-      ? lastTurn.transcript
-      : (lastTurn.transcriptMetadata ?? []);
+  const messages = turnTranscriptMessages(lastTurn);
   const lastMessage = messages.at(-1);
   const lastPart = lastMessage?.parts.at(-1);
 
@@ -256,13 +254,16 @@ export function usePinnedTranscriptBottom(input: {
   );
 }
 
-function transcriptPartVersion(part: TranscriptPart | undefined): string {
+function transcriptPartVersion(part: TranscriptViewPart | undefined): string {
   if (!part) return "";
 
   return [
     part.type,
     part.id ?? "",
     part.name ?? "",
+    part.subagentKind ?? "",
+    part.status ?? "",
+    part.outcome ?? "",
     part.chars ?? part.text?.length ?? "",
     part.bytes ?? "",
     part.inputSizeChars ?? "",

--- a/packages/junior-dashboard/src/client/components/transcriptRenderModel.ts
+++ b/packages/junior-dashboard/src/client/components/transcriptRenderModel.ts
@@ -133,6 +133,7 @@ function findToolEntry(
 ): RenderedToolCallEntry | undefined {
   for (let index = entries.length - 1; index >= 0; index -= 1) {
     const entry = entries[index]!;
+    if (entry.kind !== "tool") return undefined;
     if (!isRenderedToolCallEntry(entry) || entry.result) continue;
     if (sameToolInvocation(entry.call, result)) {
       return entry;

--- a/packages/junior-dashboard/src/client/components/transcriptRenderModel.ts
+++ b/packages/junior-dashboard/src/client/components/transcriptRenderModel.ts
@@ -5,46 +5,57 @@ import {
   transcriptRoleKind,
 } from "../format";
 import { sameToolInvocation } from "../toolInvocations";
-import type { TranscriptMessage, TranscriptPart } from "../types";
+import type {
+  TranscriptViewMessage,
+  TranscriptViewPart,
+  TranscriptViewSubagentPart,
+} from "../types";
 
 type RenderedToolPart =
-  | { call: TranscriptPart; kind: "tool"; result?: TranscriptPart }
-  | { call?: undefined; kind: "tool"; result: TranscriptPart };
+  | { call: TranscriptViewPart; kind: "tool"; result?: TranscriptViewPart }
+  | { call?: undefined; kind: "tool"; result: TranscriptViewPart };
 
 export type RenderedTranscriptPart =
-  | { kind: "part"; part: TranscriptPart }
+  | { kind: "part"; part: TranscriptViewPart }
   | RenderedToolPart;
 
 export type RenderedTranscriptEntry =
-  | { kind: "message"; message: TranscriptMessage }
+  | { kind: "message"; message: TranscriptViewMessage }
+  | RenderedSubagentEntry
   | RenderedThinkingEntry
   | RenderedToolEntry;
 
 type RenderedThinkingEntry = {
   kind: "thinking";
-  part: TranscriptPart;
+  part: TranscriptViewPart;
+  timestamp?: number;
+};
+
+export type RenderedSubagentEntry = {
+  kind: "subagent";
+  part: TranscriptViewSubagentPart;
   timestamp?: number;
 };
 
 export type RenderedToolEntry =
   | {
-      call: TranscriptPart;
+      call: TranscriptViewPart;
       kind: "tool";
-      result?: TranscriptPart;
+      result?: TranscriptViewPart;
       resultTimestamp?: number;
       timestamp?: number;
     }
   | {
       call?: undefined;
       kind: "tool";
-      result: TranscriptPart;
+      result: TranscriptViewPart;
       resultTimestamp?: number;
       timestamp?: never;
     };
 
 type RenderedToolCallEntry = Extract<
   RenderedToolEntry,
-  { call: TranscriptPart }
+  { call: TranscriptViewPart }
 >;
 
 function isRenderedToolCallEntry(
@@ -55,16 +66,22 @@ function isRenderedToolCallEntry(
 
 export type TranscriptViewMode = "raw" | "rich";
 
-function isToolCall(part: TranscriptPart): boolean {
+function isToolCall(part: TranscriptViewPart): boolean {
   return part.type === "tool_call";
 }
 
-function isToolResult(part: TranscriptPart): boolean {
+function isToolResult(part: TranscriptViewPart): boolean {
   return part.type === "tool_result";
 }
 
-function isThinking(part: TranscriptPart): boolean {
+function isThinking(part: TranscriptViewPart): boolean {
   return part.type === "thinking";
+}
+
+function isSubagent(
+  part: TranscriptViewPart,
+): part is TranscriptViewSubagentPart {
+  return part.type === "subagent";
 }
 
 function isString(value: string | undefined): value is string {
@@ -73,7 +90,7 @@ function isString(value: string | undefined): value is string {
 
 /** Group inline transcript parts so matching tool calls/results render together. */
 export function groupTranscriptParts(
-  parts: TranscriptPart[],
+  parts: TranscriptViewPart[],
 ): RenderedTranscriptPart[] {
   const grouped: RenderedTranscriptPart[] = [];
   const consumed = new Set<number>();
@@ -112,7 +129,7 @@ export function groupTranscriptParts(
 
 function findToolEntry(
   entries: RenderedTranscriptEntry[],
-  result: TranscriptPart,
+  result: TranscriptViewPart,
 ): RenderedToolCallEntry | undefined {
   for (let index = entries.length - 1; index >= 0; index -= 1) {
     const entry = entries[index]!;
@@ -126,12 +143,12 @@ function findToolEntry(
 
 /** Flatten message-local tool parts into turn-level events for scan-friendly rendering. */
 export function groupTranscriptMessages(
-  messages: TranscriptMessage[],
+  messages: TranscriptViewMessage[],
 ): RenderedTranscriptEntry[] {
   const entries: RenderedTranscriptEntry[] = [];
 
   for (const message of messages) {
-    let messageParts: TranscriptPart[] = [];
+    let messageParts: TranscriptViewPart[] = [];
     const flushMessage = () => {
       if (messageParts.length === 0) return;
       entries.push({
@@ -178,6 +195,16 @@ export function groupTranscriptMessages(
         continue;
       }
 
+      if (isSubagent(part)) {
+        flushMessage();
+        entries.push({
+          kind: "subagent",
+          part,
+          timestamp: message.timestamp,
+        });
+        continue;
+      }
+
       messageParts.push(part);
     }
 
@@ -188,7 +215,7 @@ export function groupTranscriptMessages(
 }
 
 /** Build the plain-text clipboard/raw view for one transcript message. */
-export function messageRawText(message: TranscriptMessage): string {
+export function messageRawText(message: TranscriptViewMessage): string {
   return message.parts
     .map((part) => {
       if (part.type === "text") return part.text ?? "";
@@ -205,6 +232,19 @@ export function messageRawText(message: TranscriptMessage): string {
         return [
           `tool_result ${part.name ?? part.id ?? "unknown"}`,
           stringifyPartValue(part.output),
+        ]
+          .filter(isString)
+          .join("\n");
+      }
+      if (part.type === "subagent") {
+        return [
+          `subagent ${part.subagentKind}`,
+          stringifyPartValue({
+            id: part.id,
+            outcome: part.outcome,
+            parentToolCallId: part.parentToolCallId,
+            status: part.status,
+          }),
         ]
           .filter(isString)
           .join("\n");

--- a/packages/junior-dashboard/src/client/components/transcriptSearch.tsx
+++ b/packages/junior-dashboard/src/client/components/transcriptSearch.tsx
@@ -2,6 +2,7 @@ import { type ReactNode, createContext, useContext } from "react";
 import type { DecorationItem } from "shiki/bundle/web";
 
 import { stringifyPartValue } from "../format";
+import { turnTranscriptMessages } from "../transcriptActivity";
 import type { ConversationTurn } from "../types";
 import {
   groupTranscriptMessages,
@@ -137,11 +138,18 @@ export function entryMatchesSearch(
     );
   }
 
-  if (entry.kind === "thinking") {
-    return textContains(
-      stringifyPartValue(entry.part.output),
-      normalizedQuery,
+  if (entry.kind === "subagent") {
+    return (
+      textContains(entry.part.subagentKind, normalizedQuery) ||
+      textContains(entry.part.id, normalizedQuery) ||
+      textContains(entry.part.status, normalizedQuery) ||
+      textContains(entry.part.outcome, normalizedQuery) ||
+      textContains(entry.part.parentToolCallId, normalizedQuery)
     );
+  }
+
+  if (entry.kind === "thinking") {
+    return textContains(stringifyPartValue(entry.part.output), normalizedQuery);
   }
 
   return false;
@@ -153,10 +161,7 @@ export function turnHasMatch(
   normalizedQuery: string,
 ): boolean {
   if (!normalizedQuery) return true;
-  const source = turn.transcriptAvailable
-    ? turn.transcript
-    : (turn.transcriptMetadata ?? []);
-  return groupTranscriptMessages(source).some((entry) =>
+  return groupTranscriptMessages(turnTranscriptMessages(turn)).some((entry) =>
     entryMatchesSearch(entry, normalizedQuery),
   );
 }

--- a/packages/junior-dashboard/src/client/components/transcriptSearch.tsx
+++ b/packages/junior-dashboard/src/client/components/transcriptSearch.tsx
@@ -130,8 +130,13 @@ export function entryMatchesSearch(
   }
 
   if (entry.kind === "tool") {
+    const visibleCallStatus =
+      entry.call?.status === "running" && !entry.result
+        ? entry.call.status
+        : undefined;
     return (
       textContains(entry.call?.name, normalizedQuery) ||
+      textContains(visibleCallStatus, normalizedQuery) ||
       textContains(entry.result?.name, normalizedQuery) ||
       textContains(stringifyPartValue(entry.call?.input), normalizedQuery) ||
       textContains(stringifyPartValue(entry.result?.output), normalizedQuery)

--- a/packages/junior-dashboard/src/client/format.ts
+++ b/packages/junior-dashboard/src/client/format.ts
@@ -225,6 +225,12 @@ function transcriptSource(turn: ConversationTurn) {
   return turnTranscriptMessages(turn);
 }
 
+function rawTranscriptSource(turn: ConversationTurn) {
+  return turn.transcriptAvailable
+    ? turn.transcript
+    : (turn.transcriptMetadata ?? []);
+}
+
 /** Normalized role category for transcript messages. */
 export type TranscriptRoleKind =
   | "assistant"
@@ -264,7 +270,7 @@ function isConversationMessage(
 
 /** Count visible or redacted message records for a turn. */
 export function turnMessageCount(turn: ConversationTurn): number {
-  const source = transcriptSource(turn);
+  const source = rawTranscriptSource(turn);
   if (source.length > 0) {
     return source.filter(isConversationMessage).length;
   }

--- a/packages/junior-dashboard/src/client/format.ts
+++ b/packages/junior-dashboard/src/client/format.ts
@@ -8,12 +8,13 @@ import type {
   RequesterIdentity,
   Session,
   SessionFilter,
-  TranscriptMessage,
-  TranscriptPart,
+  TranscriptViewMessage,
+  TranscriptViewPart,
   TurnUsage,
   VisualStatus,
 } from "./types";
 import { sameToolInvocation } from "./toolInvocations";
+import { turnTranscriptMessages } from "./transcriptActivity";
 
 let dashboardTimeZone = "America/Los_Angeles";
 const RECENT_CONVERSATION_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
@@ -221,9 +222,7 @@ export function formatBytes(value: number | undefined): string {
 }
 
 function transcriptSource(turn: ConversationTurn) {
-  return turn.transcriptAvailable
-    ? turn.transcript
-    : (turn.transcriptMetadata ?? []);
+  return turnTranscriptMessages(turn);
 }
 
 /** Normalized role category for transcript messages. */
@@ -245,7 +244,7 @@ export function transcriptRoleKind(role: string): TranscriptRoleKind {
 }
 
 function hasTextPart(
-  message: Pick<ConversationTurn["transcript"][number], "parts" | "role">,
+  message: Pick<TranscriptViewMessage, "parts" | "role">,
 ): boolean {
   return message.parts.some((part) => {
     if (part.type !== "text") return false;
@@ -255,7 +254,7 @@ function hasTextPart(
 }
 
 function isConversationMessage(
-  message: Pick<ConversationTurn["transcript"][number], "parts" | "role">,
+  message: Pick<TranscriptViewMessage, "parts" | "role">,
 ): boolean {
   const kind = transcriptRoleKind(message.role);
   if (kind !== "user" && kind !== "assistant") return false;
@@ -289,13 +288,13 @@ type PendingToolCall = {
   timestamp?: number;
 };
 
-function toolCallName(part: TranscriptPart): string {
+function toolCallName(part: TranscriptViewPart): string {
   return part.name ?? part.id ?? "unknown";
 }
 
 function findPendingToolCallIndex(
   calls: PendingToolCall[],
-  result: TranscriptPart,
+  result: TranscriptViewPart,
 ): number {
   for (let index = calls.length - 1; index >= 0; index -= 1) {
     if (sameToolInvocation(calls[index]!, result)) {
@@ -377,7 +376,7 @@ export type MessageSummary = {
 
 function transcriptMessageAuthor(
   turn: ConversationTurn,
-  message: TranscriptMessage,
+  message: TranscriptViewMessage,
 ): string {
   const kind = transcriptRoleKind(message.role);
   if (kind === "assistant") return "Junior";
@@ -389,7 +388,7 @@ function transcriptMessageAuthor(
   return message.role || "Unknown";
 }
 
-function transcriptPartBytes(part: TranscriptPart): number {
+function transcriptPartBytes(part: TranscriptViewPart): number {
   if (typeof part.bytes === "number" && Number.isFinite(part.bytes)) {
     return Math.max(0, Math.floor(part.bytes));
   }

--- a/packages/junior-dashboard/src/client/markdownExport.ts
+++ b/packages/junior-dashboard/src/client/markdownExport.ts
@@ -12,12 +12,14 @@ import {
   groupTranscriptMessages,
   messageRawText,
 } from "./components/transcriptRenderModel";
+import { turnTranscriptMessages } from "./transcriptActivity";
 import type {
   Conversation,
   ConversationDetailFeed,
   ConversationTurn,
-  TranscriptMessage,
-  TranscriptPart,
+  TranscriptViewMessage,
+  TranscriptViewPart,
+  TranscriptViewSubagentPart,
 } from "./types";
 
 /** Build a clipboard Markdown transcript from the already-authorized dashboard report. */
@@ -62,17 +64,24 @@ export function buildConversationMarkdown(
 }
 
 function appendTurnTranscript(lines: string[], turn: ConversationTurn): void {
+  const transcript = turnTranscriptMessages(turn);
+
   if (turn.transcriptAvailable) {
-    appendTranscriptMessages(lines, turn, turn.transcript, false);
+    appendTranscriptMessages(lines, turn, transcript, false);
     return;
   }
 
-  if (turn.transcriptRedacted && turn.transcriptMetadata?.length) {
+  if (turn.transcriptRedacted && transcript.length) {
     lines.push(
       "",
       "Transcript hidden because this conversation is not public.",
     );
-    appendTranscriptMessages(lines, turn, turn.transcriptMetadata, true);
+    appendTranscriptMessages(lines, turn, transcript, true);
+    return;
+  }
+
+  if (transcript.length) {
+    appendTranscriptMessages(lines, turn, transcript, false);
     return;
   }
 
@@ -82,7 +91,7 @@ function appendTurnTranscript(lines: string[], turn: ConversationTurn): void {
 function appendTranscriptMessages(
   lines: string[],
   turn: ConversationTurn,
-  messages: TranscriptMessage[],
+  messages: TranscriptViewMessage[],
   redacted: boolean,
 ): void {
   for (const entry of groupTranscriptMessages(messages)) {
@@ -93,6 +102,11 @@ function appendTranscriptMessages(
 
     if (entry.kind === "thinking") {
       appendThinking(lines, turn, entry.part, entry.timestamp, redacted);
+      continue;
+    }
+
+    if (entry.kind === "subagent") {
+      appendSubagent(lines, turn, entry.part, entry.timestamp);
       continue;
     }
 
@@ -122,7 +136,7 @@ function appendTranscriptMessages(
 function appendMessage(
   lines: string[],
   turn: ConversationTurn,
-  message: TranscriptMessage,
+  message: TranscriptViewMessage,
   redacted: boolean,
 ): void {
   lines.push("", `### ${messageRoleLabel(message, turn)}`);
@@ -141,7 +155,7 @@ function appendMessage(
 function appendThinking(
   lines: string[],
   turn: ConversationTurn,
-  part: TranscriptPart,
+  part: TranscriptViewPart,
   timestamp: number | undefined,
   redacted: boolean,
 ): void {
@@ -156,11 +170,23 @@ function appendThinking(
   lines.push("", fencedBlock(stringifyPartValue(part.output), "text"));
 }
 
+function appendSubagent(
+  lines: string[],
+  turn: ConversationTurn,
+  part: TranscriptViewSubagentPart,
+  timestamp: number | undefined,
+): void {
+  lines.push("", `### Subagent: ${headingText(part.subagentKind)}`);
+  addEventMeta(lines, turn, timestamp);
+  addMetaLine(lines, "Status", part.outcome ?? part.status);
+  addMetaLine(lines, "Parent tool call", part.parentToolCallId);
+}
+
 function appendTool(
   lines: string[],
   turn: ConversationTurn,
-  call: TranscriptPart | undefined,
-  result: TranscriptPart | undefined,
+  call: TranscriptViewPart | undefined,
+  result: TranscriptViewPart | undefined,
   timestamp: number | undefined,
   resultTimestamp: number | undefined,
 ): void {
@@ -171,15 +197,15 @@ function appendTool(
 function appendRedactedTool(
   lines: string[],
   turn: ConversationTurn,
-  call: TranscriptPart | undefined,
-  result: TranscriptPart | undefined,
+  call: TranscriptViewPart | undefined,
+  result: TranscriptViewPart | undefined,
   timestamp: number | undefined,
   resultTimestamp: number | undefined,
 ): void {
   appendToolHeader(lines, turn, call, result, timestamp, resultTimestamp);
 
   const redactedLines = [call, result]
-    .filter((part): part is TranscriptPart => part !== undefined)
+    .filter((part): part is TranscriptViewPart => part !== undefined)
     .map(redactedPartLabel);
   lines.push("", ...redactedLines.map((line) => `- ${line}`));
 }
@@ -187,8 +213,8 @@ function appendRedactedTool(
 function appendToolHeader(
   lines: string[],
   turn: ConversationTurn,
-  call: TranscriptPart | undefined,
-  result: TranscriptPart | undefined,
+  call: TranscriptViewPart | undefined,
+  result: TranscriptViewPart | undefined,
   timestamp: number | undefined,
   resultTimestamp: number | undefined,
 ): void {
@@ -197,7 +223,11 @@ function appendToolHeader(
   addMetaLine(lines, "Result timestamp", eventTimestamp(resultTimestamp));
   addMetaLine(lines, "Duration", toolDuration(timestamp, resultTimestamp));
   if (!result) {
-    addMetaLine(lines, "Result", "missing");
+    addMetaLine(
+      lines,
+      "Result",
+      call?.status === "running" ? "running" : "missing",
+    );
   }
 }
 
@@ -243,7 +273,7 @@ function conversationLocation(
 }
 
 function messageRoleLabel(
-  message: TranscriptMessage,
+  message: TranscriptViewMessage,
   turn: ConversationTurn,
 ): string {
   const kind = transcriptRoleKind(message.role);
@@ -254,7 +284,7 @@ function messageRoleLabel(
   return headingText(message.role || "Unknown");
 }
 
-function redactedPartLabel(part: TranscriptPart): string {
+function redactedPartLabel(part: TranscriptViewPart): string {
   const meta = [
     part.type !== "text" ? part.type : "",
     part.name ? `name: ${inlineCode(part.name)}` : "",
@@ -269,8 +299,8 @@ function redactedPartLabel(part: TranscriptPart): string {
 }
 
 function toolName(
-  call: TranscriptPart | undefined,
-  result: TranscriptPart | undefined,
+  call: TranscriptViewPart | undefined,
+  result: TranscriptViewPart | undefined,
 ): string {
   return call?.name ?? result?.name ?? call?.id ?? result?.id ?? "unknown";
 }

--- a/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, type ReactNode } from "react";
-import { Bot, Check, Copy, Wrench } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Check, Copy } from "lucide-react";
 import { useParams } from "react-router";
 
 import { useConversationData } from "../api";
@@ -29,7 +29,6 @@ import {
 import { Transcript } from "../components/Transcript";
 import { TranscriptLoading } from "../components/TranscriptLoading";
 import type {
-  ConversationActivity,
   Conversation,
   ConversationDetailFeed,
   DashboardData,
@@ -85,123 +84,18 @@ export function ConversationPage(props: { data?: DashboardData }) {
             {detail.error.message}
           </div>
         ) : (
-          <>
-            <ActivityTimeline turns={detail.data?.runs ?? []} />
-            <Transcript
-              actions={
-                <CopyMarkdownButton
-                  conversation={conversation}
-                  detail={detail.data}
-                />
-              }
-              live={conversationIsLive(visualStatus, detail.data)}
-              turns={detail.data?.runs ?? []}
-            />
-          </>
+          <Transcript
+            actions={
+              <CopyMarkdownButton
+                conversation={conversation}
+                detail={detail.data}
+              />
+            }
+            live={conversationIsLive(visualStatus, detail.data)}
+            turns={detail.data?.runs ?? []}
+          />
         )}
       </section>
-    </div>
-  );
-}
-
-function ActivityTimeline(props: {
-  turns: NonNullable<ConversationDetailFeed["runs"]>;
-}) {
-  const activity = props.turns.flatMap((turn) =>
-    (turn.activity ?? []).map((item) => ({ ...item, turnId: turn.id })),
-  );
-  if (activity.length === 0) return null;
-
-  return (
-    <section
-      aria-label="Execution activity"
-      className="mb-5 grid min-w-0 gap-2 border border-white/10 bg-white/[0.025] p-3"
-    >
-      <div className="text-[0.82rem] font-bold uppercase tracking-normal text-[#b8b8b8]">
-        Execution Activity
-      </div>
-      <div className="grid min-w-0 gap-2">
-        {activity.map((item) => (
-          <ActivityRow
-            activity={item}
-            key={`${item.turnId}:${item.type}:${item.id}`}
-          />
-        ))}
-      </div>
-    </section>
-  );
-}
-
-function ActivityRow(props: { activity: ConversationActivity }) {
-  if (props.activity.type === "tool_execution") {
-    const meta = [
-      props.activity.status,
-      formatTime(props.activity.createdAt),
-      props.activity.toolCallId,
-    ]
-      .filter(Boolean)
-      .join(" · ");
-
-    return (
-      <ActivityRowShell
-        icon={Wrench}
-        label={props.activity.toolName}
-        meta={meta}
-      >
-        {props.activity.subagents.length > 0 ? (
-          <div className="mt-2 grid min-w-0 gap-1">
-            {props.activity.subagents.map((subagent) => (
-              <ActivityRow activity={subagent} key={subagent.id} />
-            ))}
-          </div>
-        ) : null}
-      </ActivityRowShell>
-    );
-  }
-
-  const meta = [
-    props.activity.status,
-    formatTime(props.activity.createdAt),
-    props.activity.parentToolCallId
-      ? `parent ${props.activity.parentToolCallId}`
-      : undefined,
-  ]
-    .filter(Boolean)
-    .join(" · ");
-
-  return (
-    <ActivityRowShell
-      icon={Bot}
-      label={`${props.activity.subagentKind} subagent`}
-      meta={meta}
-    />
-  );
-}
-
-function ActivityRowShell(props: {
-  children?: ReactNode;
-  icon: typeof Bot;
-  label: string;
-  meta: string;
-}) {
-  const Icon = props.icon;
-  return (
-    <div className="grid min-w-0 grid-cols-[1rem_minmax(0,1fr)] gap-2 border-l-2 border-[#beaaff]/35 py-1 pl-2">
-      <Icon
-        aria-hidden="true"
-        className="mt-0.5 text-[#beaaff]"
-        size={14}
-        strokeWidth={2}
-      />
-      <div className="min-w-0">
-        <div className="break-words text-[0.86rem] font-semibold leading-snug text-[#f4f4f4]">
-          {props.label}
-        </div>
-        <div className="break-words text-[0.75rem] leading-relaxed text-[#888]">
-          {props.meta}
-        </div>
-        {props.children}
-      </div>
     </div>
   );
 }

--- a/packages/junior-dashboard/src/client/transcriptActivity.ts
+++ b/packages/junior-dashboard/src/client/transcriptActivity.ts
@@ -29,6 +29,10 @@ function isToolCall(
   return part.type === "tool_call";
 }
 
+function isToolResult(part: TranscriptViewPart): boolean {
+  return part.type === "tool_result";
+}
+
 function partMatchesToolActivity(
   part: TranscriptViewPart,
   activity: ToolActivity,
@@ -184,19 +188,104 @@ function syntheticMessages(
   return messages;
 }
 
-function compareIndexedMessages(left: IndexedMessage, right: IndexedMessage) {
-  const leftTimestamp = left.message.timestamp;
-  const rightTimestamp = right.message.timestamp;
-  if (
-    typeof leftTimestamp === "number" &&
-    Number.isFinite(leftTimestamp) &&
-    typeof rightTimestamp === "number" &&
-    Number.isFinite(rightTimestamp) &&
-    leftTimestamp !== rightTimestamp
+function messageTimestamp(message: TranscriptViewMessage): number | undefined {
+  return typeof message.timestamp === "number" &&
+    Number.isFinite(message.timestamp)
+    ? message.timestamp
+    : undefined;
+}
+
+function findMatchingToolResultIndex(
+  messages: TranscriptViewMessage[],
+  part: TranscriptViewToolCallPart,
+): number | undefined {
+  const index = messages.findIndex((message) =>
+    message.parts.some(
+      (candidate) =>
+        isToolResult(candidate) && sameToolInvocation(candidate, part),
+    ),
+  );
+  return index >= 0 ? index : undefined;
+}
+
+function findParentToolCallIndex(
+  messages: TranscriptViewMessage[],
+  parentToolCallId: string,
+): number | undefined {
+  const index = messages.findIndex((message) =>
+    message.parts.some(
+      (candidate) => isToolCall(candidate) && candidate.id === parentToolCallId,
+    ),
+  );
+  return index >= 0 ? index : undefined;
+}
+
+function isSubagentForParent(
+  message: TranscriptViewMessage,
+  parentToolCallId: string,
+): boolean {
+  return message.parts.some(
+    (candidate) =>
+      candidate.type === "subagent" &&
+      candidate.parentToolCallId === parentToolCallId,
+  );
+}
+
+function subagentInsertionIndex(
+  messages: TranscriptViewMessage[],
+  parentToolCallId: string,
+): number | undefined {
+  const parentIndex = findParentToolCallIndex(messages, parentToolCallId);
+  if (parentIndex === undefined) return undefined;
+
+  let index = parentIndex + 1;
+  while (
+    index < messages.length &&
+    isSubagentForParent(messages[index]!, parentToolCallId)
   ) {
-    return leftTimestamp - rightTimestamp;
+    index += 1;
   }
-  return left.order - right.order;
+  return index;
+}
+
+function syntheticInsertionIndex(
+  messages: TranscriptViewMessage[],
+  message: TranscriptViewMessage,
+): number {
+  const part = message.parts[0];
+  if (part && isToolCall(part)) {
+    const resultIndex = findMatchingToolResultIndex(messages, part);
+    if (resultIndex !== undefined) return resultIndex;
+  }
+
+  if (part?.type === "subagent" && part.parentToolCallId) {
+    const index = subagentInsertionIndex(messages, part.parentToolCallId);
+    if (index !== undefined) return index;
+  }
+
+  const timestamp = messageTimestamp(message);
+  if (timestamp === undefined) return messages.length;
+
+  const index = messages.findIndex((candidate) => {
+    const candidateTimestamp = messageTimestamp(candidate);
+    return candidateTimestamp !== undefined && candidateTimestamp > timestamp;
+  });
+  return index >= 0 ? index : messages.length;
+}
+
+function mergeMessages(
+  messages: TranscriptViewMessage[],
+  synthetic: IndexedMessage[],
+): TranscriptViewMessage[] {
+  const merged = [...messages];
+  for (const entry of synthetic) {
+    merged.splice(
+      syntheticInsertionIndex(merged, entry.message),
+      0,
+      entry.message,
+    );
+  }
+  return merged;
 }
 
 /** Return the transcript rows that dashboard views should render for a turn. */
@@ -213,15 +302,9 @@ export function turnTranscriptMessages(
   }
 
   const { messages, usedToolCallIds } = upgradeToolCalls(source, activities);
-  const indexedMessages: IndexedMessage[] = messages.map((message, order) => ({
-    message,
-    order,
-  }));
 
-  return [
-    ...indexedMessages,
-    ...syntheticMessages(activities, orphanSubagents, usedToolCallIds),
-  ]
-    .sort(compareIndexedMessages)
-    .map((entry) => entry.message);
+  return mergeMessages(
+    messages,
+    syntheticMessages(activities, orphanSubagents, usedToolCallIds),
+  );
 }

--- a/packages/junior-dashboard/src/client/transcriptActivity.ts
+++ b/packages/junior-dashboard/src/client/transcriptActivity.ts
@@ -148,10 +148,12 @@ function syntheticMessages(
   usedToolCallIds: Set<string>,
 ): IndexedMessage[] {
   const messages: IndexedMessage[] = [];
+  const emittedSubagentKeys = new Set<string>();
+  const emittedToolCallIds = new Set(usedToolCallIds);
   let order = 0;
 
   for (const activity of activities) {
-    if (!usedToolCallIds.has(activity.toolCallId)) {
+    if (!emittedToolCallIds.has(activity.toolCallId)) {
       messages.push({
         message: activityMessage(
           activityTimestamp(activity.createdAt),
@@ -159,9 +161,13 @@ function syntheticMessages(
         ),
         order: order + 0.1,
       });
+      emittedToolCallIds.add(activity.toolCallId);
     }
 
     for (const subagent of activity.subagents) {
+      const key = subagentActivityKey(subagent);
+      if (emittedSubagentKeys.has(key)) continue;
+
       messages.push({
         message: activityMessage(
           activityTimestamp(subagent.createdAt),
@@ -169,12 +175,16 @@ function syntheticMessages(
         ),
         order: order + 0.2,
       });
+      emittedSubagentKeys.add(key);
       order += 1;
     }
     order += 1;
   }
 
   for (const subagent of orphanSubagents) {
+    const key = subagentActivityKey(subagent);
+    if (emittedSubagentKeys.has(key)) continue;
+
     messages.push({
       message: activityMessage(
         activityTimestamp(subagent.createdAt),
@@ -182,10 +192,19 @@ function syntheticMessages(
       ),
       order: order + 0.2,
     });
+    emittedSubagentKeys.add(key);
     order += 1;
   }
 
   return messages;
+}
+
+function subagentActivityKey(activity: SubagentActivity): string {
+  return [
+    activity.parentToolCallId ?? "",
+    activity.id,
+    activity.subagentKind,
+  ].join("\u0000");
 }
 
 function messageTimestamp(message: TranscriptViewMessage): number | undefined {

--- a/packages/junior-dashboard/src/client/transcriptActivity.ts
+++ b/packages/junior-dashboard/src/client/transcriptActivity.ts
@@ -1,0 +1,227 @@
+import { sameToolInvocation } from "./toolInvocations";
+import type {
+  ConversationActivity,
+  ConversationTurn,
+  TranscriptViewMessage,
+  TranscriptViewPart,
+  TranscriptViewSubagentPart,
+  TranscriptViewToolCallPart,
+} from "./types";
+
+type ToolActivity = Extract<ConversationActivity, { type: "tool_execution" }>;
+
+type SubagentActivity = Extract<ConversationActivity, { type: "subagent" }>;
+
+type IndexedMessage = {
+  message: TranscriptViewMessage;
+  order: number;
+};
+
+function activityTimestamp(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : undefined;
+}
+
+function isToolCall(
+  part: TranscriptViewPart,
+): part is TranscriptViewToolCallPart {
+  return part.type === "tool_call";
+}
+
+function partMatchesToolActivity(
+  part: TranscriptViewPart,
+  activity: ToolActivity,
+): boolean {
+  return sameToolInvocation(part, {
+    id: activity.toolCallId,
+    name: activity.toolName,
+  });
+}
+
+function toolCallPart(
+  activity: ToolActivity,
+  existing?: TranscriptViewToolCallPart,
+): TranscriptViewPart {
+  const input = existing?.input ?? activity.args;
+  const part: TranscriptViewPart = {
+    type: "tool_call",
+    id: activity.toolCallId,
+    name: activity.toolName,
+    status: activity.status,
+  };
+  if (activity.redacted) {
+    part.redacted = true;
+    if (activity.inputKeys) part.inputKeys = activity.inputKeys;
+    if (activity.inputSizeBytes !== undefined) {
+      part.inputSizeBytes = activity.inputSizeBytes;
+    }
+    if (activity.inputSizeChars !== undefined) {
+      part.inputSizeChars = activity.inputSizeChars;
+    }
+    if (activity.inputType) part.inputType = activity.inputType;
+    return part;
+  }
+  if (input !== undefined) part.input = input;
+  return part;
+}
+
+function subagentPart(activity: SubagentActivity): TranscriptViewSubagentPart {
+  return {
+    type: "subagent",
+    id: activity.id,
+    subagentKind: activity.subagentKind,
+    status: activity.status,
+    ...(activity.outcome ? { outcome: activity.outcome } : {}),
+    ...(activity.parentToolCallId
+      ? { parentToolCallId: activity.parentToolCallId }
+      : {}),
+    ...(activity.endedAt ? { endedAt: activity.endedAt } : {}),
+  };
+}
+
+function toolActivities(turn: ConversationTurn): ToolActivity[] {
+  return (turn.activity ?? []).filter(
+    (activity): activity is ToolActivity => activity.type === "tool_execution",
+  );
+}
+
+function orphanSubagentActivities(turn: ConversationTurn): SubagentActivity[] {
+  return (turn.activity ?? []).filter(
+    (activity): activity is SubagentActivity => activity.type === "subagent",
+  );
+}
+
+function activityMessage(
+  timestamp: number | undefined,
+  part: TranscriptViewPart,
+): TranscriptViewMessage {
+  return {
+    role: "tool",
+    ...(timestamp !== undefined ? { timestamp } : {}),
+    parts: [part],
+  };
+}
+
+function upgradeToolCalls(
+  messages: TranscriptViewMessage[],
+  activities: ToolActivity[],
+): {
+  messages: TranscriptViewMessage[];
+  usedToolCallIds: Set<string>;
+} {
+  const usedToolCallIds = new Set<string>();
+  if (activities.length === 0) {
+    return { messages, usedToolCallIds };
+  }
+
+  const upgraded = messages.map((message) => {
+    let changed = false;
+    const parts = message.parts.map((part) => {
+      if (!isToolCall(part)) return part;
+
+      const activity = activities.find(
+        (candidate) =>
+          !usedToolCallIds.has(candidate.toolCallId) &&
+          partMatchesToolActivity(part, candidate),
+      );
+      if (!activity) return part;
+
+      usedToolCallIds.add(activity.toolCallId);
+      changed = true;
+      return toolCallPart(activity, part);
+    });
+
+    return changed ? { ...message, parts } : message;
+  });
+
+  return { messages: upgraded, usedToolCallIds };
+}
+
+function syntheticMessages(
+  activities: ToolActivity[],
+  orphanSubagents: SubagentActivity[],
+  usedToolCallIds: Set<string>,
+): IndexedMessage[] {
+  const messages: IndexedMessage[] = [];
+  let order = 0;
+
+  for (const activity of activities) {
+    if (!usedToolCallIds.has(activity.toolCallId)) {
+      messages.push({
+        message: activityMessage(
+          activityTimestamp(activity.createdAt),
+          toolCallPart(activity),
+        ),
+        order: order + 0.1,
+      });
+    }
+
+    for (const subagent of activity.subagents) {
+      messages.push({
+        message: activityMessage(
+          activityTimestamp(subagent.createdAt),
+          subagentPart(subagent),
+        ),
+        order: order + 0.2,
+      });
+      order += 1;
+    }
+    order += 1;
+  }
+
+  for (const subagent of orphanSubagents) {
+    messages.push({
+      message: activityMessage(
+        activityTimestamp(subagent.createdAt),
+        subagentPart(subagent),
+      ),
+      order: order + 0.2,
+    });
+    order += 1;
+  }
+
+  return messages;
+}
+
+function compareIndexedMessages(left: IndexedMessage, right: IndexedMessage) {
+  const leftTimestamp = left.message.timestamp;
+  const rightTimestamp = right.message.timestamp;
+  if (
+    typeof leftTimestamp === "number" &&
+    Number.isFinite(leftTimestamp) &&
+    typeof rightTimestamp === "number" &&
+    Number.isFinite(rightTimestamp) &&
+    leftTimestamp !== rightTimestamp
+  ) {
+    return leftTimestamp - rightTimestamp;
+  }
+  return left.order - right.order;
+}
+
+/** Return the transcript rows that dashboard views should render for a turn. */
+export function turnTranscriptMessages(
+  turn: ConversationTurn,
+): TranscriptViewMessage[] {
+  const source = turn.transcriptAvailable
+    ? turn.transcript
+    : (turn.transcriptMetadata ?? []);
+  const activities = toolActivities(turn);
+  const orphanSubagents = orphanSubagentActivities(turn);
+  if (activities.length === 0 && orphanSubagents.length === 0) {
+    return source;
+  }
+
+  const { messages, usedToolCallIds } = upgradeToolCalls(source, activities);
+  const indexedMessages: IndexedMessage[] = messages.map((message, order) => ({
+    message,
+    order,
+  }));
+
+  return [
+    ...indexedMessages,
+    ...syntheticMessages(activities, orphanSubagents, usedToolCallIds),
+  ]
+    .sort(compareIndexedMessages)
+    .map((entry) => entry.message);
+}

--- a/packages/junior-dashboard/src/client/types.ts
+++ b/packages/junior-dashboard/src/client/types.ts
@@ -47,6 +47,58 @@ export type ConversationActivity = NonNullable<
   ConversationRunReport["activity"]
 >[number];
 
+export type TranscriptActivityStatus = NonNullable<
+  ConversationRunReport["activity"]
+>[number]["status"];
+
+// Dashboard view transcript parts merge reporting transcript payloads with
+// lifecycle activity rows; the backend reporting transcript contract is unchanged.
+type TranscriptViewReportingPart = TranscriptPart & {
+  endedAt?: never;
+  outcome?: never;
+  parentToolCallId?: never;
+  status?: TranscriptActivityStatus;
+  subagentKind?: never;
+};
+
+export type TranscriptViewToolCallPart = TranscriptViewReportingPart & {
+  type: "tool_call";
+};
+
+export type TranscriptViewSubagentPart = {
+  bytes?: never;
+  chars?: never;
+  endedAt?: string;
+  id: string;
+  input?: never;
+  inputKeys?: never;
+  inputSizeBytes?: never;
+  inputSizeChars?: never;
+  inputType?: never;
+  name?: never;
+  outcome?: "success" | "error" | "aborted";
+  output?: never;
+  outputKeys?: never;
+  outputSizeBytes?: never;
+  outputSizeChars?: never;
+  outputType?: never;
+  parentToolCallId?: string;
+  redacted?: boolean;
+  status: TranscriptActivityStatus;
+  subagentKind: string;
+  text?: never;
+  type: "subagent";
+};
+
+export type TranscriptViewPart =
+  | TranscriptViewReportingPart
+  | TranscriptViewSubagentPart
+  | TranscriptViewToolCallPart;
+
+export type TranscriptViewMessage = Omit<TranscriptMessage, "parts"> & {
+  parts: TranscriptViewPart[];
+};
+
 export type ConversationTurn = ConversationRunReport;
 
 export type ConversationDetailFeed = ReportingConversationReport;

--- a/packages/junior-dashboard/src/mock-conversations.ts
+++ b/packages/junior-dashboard/src/mock-conversations.ts
@@ -12,6 +12,13 @@ import type {
 } from "@sentry/junior/reporting";
 
 import { longReleaseConversation } from "./mock-release-conversation";
+import { mockToolActivity } from "./mock-reporting/activity";
+import { mockConversation, mockRun } from "./mock-reporting/conversation";
+import {
+  mockToolCallPart,
+  mockToolResultPart,
+  mockTranscriptMessage,
+} from "./mock-reporting/transcript";
 
 const INCIDENT_CONVERSATION_ID = "slack:CQA123:1770000000.000100";
 const ACTIVE_CONVERSATION_ID = "slack:CQA123:1770003600.000200";
@@ -19,6 +26,7 @@ const PRIVATE_CONVERSATION_ID = "slack:DQA123:1770007200.000300";
 const HUNG_CONVERSATION_ID = "slack:CQA999:1770010800.000400";
 const FAILED_CONVERSATION_ID = "slack:CQA777:1770014400.000500";
 const SCHEDULER_CONVERSATION_ID = "scheduler:daily-ops-digest";
+export const DASHBOARD_QA_CONVERSATION_ID = "internal:dashboard-qa";
 const RECENT_CONVERSATION_STATS_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
 function iso(nowMs: number, offsetMs = 0): string {
@@ -35,6 +43,7 @@ function sentryTraceUrl(traceId: string): string {
 
 function sessionFromRun(run: DashboardRunReport): DashboardSessionReport {
   const {
+    activity,
     transcript,
     transcriptAvailable,
     transcriptMessageCount,
@@ -634,9 +643,98 @@ function schedulerConversation(nowMs: number): DashboardConversationReport {
   };
 }
 
+function dashboardQaConversation(nowMs: number): DashboardConversationReport {
+  const conversationId = DASHBOARD_QA_CONVERSATION_ID;
+  const displayTitle = "Dashboard QA edge cases";
+  const activityStartedAt = iso(nowMs, -11 * 60_000);
+  const transcriptStartedAt = iso(nowMs, -10 * 60_000);
+  const runningToolId = "toolu_mock_dashboard_running";
+  const invertedToolId = "toolu_mock_dashboard_inverted";
+
+  return mockConversation({
+    conversationId,
+    displayTitle,
+    generatedAt: iso(nowMs),
+    runs: [
+      mockRun({
+        conversationId,
+        displayTitle,
+        id: "mock-dashboard-qa-activity-only",
+        status: "active",
+        startedAt: activityStartedAt,
+        lastProgressAt: iso(nowMs, -10 * 60_000),
+        lastSeenAt: iso(nowMs, -10 * 60_000),
+        cumulativeDurationMs: 60_000,
+        surface: "internal",
+        transcriptAvailable: true,
+        transcript: [],
+        transcriptMessageCount: 3,
+        activity: [
+          mockToolActivity({
+            id: runningToolId,
+            toolCallId: runningToolId,
+            toolName: "mock.dashboard_running_tool",
+            createdAt: iso(nowMs, -10 * 60_000),
+            status: "running",
+            args: { query: "activity-only edge case" },
+          }),
+        ],
+      }),
+      mockRun({
+        conversationId,
+        displayTitle,
+        id: "mock-dashboard-qa-inverted-tool",
+        status: "completed",
+        startedAt: transcriptStartedAt,
+        lastProgressAt: iso(nowMs, -9 * 60_000),
+        lastSeenAt: iso(nowMs, -9 * 60_000),
+        completedAt: iso(nowMs, -9 * 60_000),
+        cumulativeDurationMs: 120_000,
+        surface: "internal",
+        transcriptAvailable: true,
+        transcriptMessageCount: 2,
+        transcript: [
+          mockTranscriptMessage({
+            role: "assistant",
+            timestamp: Date.parse(transcriptStartedAt) + 2_000,
+            parts: [
+              mockToolCallPart({
+                id: invertedToolId,
+                name: "mock.inverted_timestamp_tool",
+                input: { order: "call before result" },
+              }),
+            ],
+          }),
+          mockTranscriptMessage({
+            role: "toolResult",
+            timestamp: Date.parse(transcriptStartedAt) + 1_000,
+            parts: [
+              mockToolResultPart({
+                id: invertedToolId,
+                name: "mock.inverted_timestamp_tool",
+                output: { ok: true },
+              }),
+            ],
+          }),
+        ],
+        activity: [
+          mockToolActivity({
+            id: invertedToolId,
+            toolCallId: invertedToolId,
+            toolName: "mock.inverted_timestamp_tool",
+            createdAt: transcriptStartedAt,
+            status: "completed",
+          }),
+        ],
+      }),
+    ],
+  });
+}
+
 function mockConversations(nowMs: number): DashboardConversationReport[] {
   return [
     activeConversation(nowMs),
+    dashboardQaConversation(nowMs),
     longReleaseConversation(nowMs),
     publicIncidentConversation(nowMs),
     privateConversation(nowMs),

--- a/packages/junior-dashboard/src/mock-conversations.ts
+++ b/packages/junior-dashboard/src/mock-conversations.ts
@@ -12,7 +12,10 @@ import type {
 } from "@sentry/junior/reporting";
 
 import { longReleaseConversation } from "./mock-release-conversation";
-import { mockToolActivity } from "./mock-reporting/activity";
+import {
+  mockSubagentActivity,
+  mockToolActivity,
+} from "./mock-reporting/activity";
 import { mockConversation, mockRun } from "./mock-reporting/conversation";
 import {
   mockToolCallPart,
@@ -650,6 +653,8 @@ function dashboardQaConversation(nowMs: number): DashboardConversationReport {
   const transcriptStartedAt = iso(nowMs, -10 * 60_000);
   const runningToolId = "toolu_mock_dashboard_running";
   const invertedToolId = "toolu_mock_dashboard_inverted";
+  const advisorToolId = "toolu_mock_dashboard_advisor";
+  const advisorSubagentId = "subagent_mock_dashboard_advisor";
 
   return mockConversation({
     conversationId,
@@ -724,6 +729,85 @@ function dashboardQaConversation(nowMs: number): DashboardConversationReport {
             toolName: "mock.inverted_timestamp_tool",
             createdAt: transcriptStartedAt,
             status: "completed",
+          }),
+        ],
+      }),
+      mockRun({
+        conversationId,
+        displayTitle,
+        id: "mock-dashboard-qa-advisor-subagent",
+        status: "completed",
+        startedAt: iso(nowMs, -8 * 60_000),
+        lastProgressAt: iso(nowMs, -7 * 60_000),
+        lastSeenAt: iso(nowMs, -7 * 60_000),
+        completedAt: iso(nowMs, -7 * 60_000),
+        cumulativeDurationMs: 90_000,
+        surface: "internal",
+        transcriptAvailable: true,
+        transcriptMessageCount: 3,
+        transcript: [
+          mockTranscriptMessage({
+            role: "user",
+            timestamp: nowMs - 8 * 60_000,
+            parts: [
+              {
+                type: "text",
+                text: "Use an advisor to review the dashboard transcript ordering.",
+              },
+            ],
+          }),
+          mockTranscriptMessage({
+            role: "assistant",
+            timestamp: nowMs - 8 * 60_000 + 4_000,
+            parts: [
+              mockToolCallPart({
+                id: advisorToolId,
+                name: "advisor",
+                input: {
+                  question:
+                    "Check whether tool calls, tool results, and subagent activity render together.",
+                },
+              }),
+            ],
+          }),
+          mockTranscriptMessage({
+            role: "toolResult",
+            timestamp: nowMs - 7 * 60_000,
+            parts: [
+              mockToolResultPart({
+                id: advisorToolId,
+                name: "advisor",
+                output: {
+                  verdict: "ok",
+                  summary:
+                    "Tool call, advisor result, and subagent activity are visible.",
+                },
+              }),
+            ],
+          }),
+        ],
+        activity: [
+          mockToolActivity({
+            id: advisorToolId,
+            toolCallId: advisorToolId,
+            toolName: "advisor",
+            createdAt: iso(nowMs, -8 * 60_000 + 4_000),
+            status: "completed",
+            args: {
+              question:
+                "Check whether tool calls, tool results, and subagent activity render together.",
+            },
+            subagents: [
+              mockSubagentActivity({
+                id: advisorSubagentId,
+                parentToolCallId: advisorToolId,
+                subagentKind: "advisor",
+                createdAt: iso(nowMs, -8 * 60_000 + 6_000),
+                endedAt: iso(nowMs, -7 * 60_000),
+                status: "completed",
+                outcome: "success",
+              }),
+            ],
           }),
         ],
       }),

--- a/packages/junior-dashboard/src/mock-reporting/activity.ts
+++ b/packages/junior-dashboard/src/mock-reporting/activity.ts
@@ -1,0 +1,80 @@
+import type {
+  ConversationActivityStatus,
+  ConversationSubagentActivityReport,
+  ConversationToolActivityReport,
+} from "@sentry/junior/reporting";
+
+import { mockIso } from "./time";
+
+export type MockSubagentActivityOptions = {
+  createdAt?: string;
+  endedAt?: string;
+  id?: string;
+  outcome?: "success" | "error" | "aborted";
+  parentToolCallId?: string;
+  status?: ConversationActivityStatus;
+  subagentKind?: string;
+};
+
+/** Build a subagent activity record constrained to the reporting API shape. */
+export function mockSubagentActivity(
+  options: MockSubagentActivityOptions = {},
+): ConversationSubagentActivityReport {
+  return {
+    type: "subagent",
+    createdAt: options.createdAt ?? mockIso(),
+    id: options.id ?? "mock-subagent",
+    status: options.status ?? "running",
+    subagentKind: options.subagentKind ?? "advisor",
+    ...(options.endedAt !== undefined ? { endedAt: options.endedAt } : {}),
+    ...(options.outcome !== undefined ? { outcome: options.outcome } : {}),
+    ...(options.parentToolCallId !== undefined
+      ? { parentToolCallId: options.parentToolCallId }
+      : {}),
+  } satisfies ConversationSubagentActivityReport;
+}
+
+export type MockToolActivityOptions = {
+  args?: unknown;
+  createdAt?: string;
+  id?: string;
+  inputKeys?: string[];
+  inputSizeBytes?: number;
+  inputSizeChars?: number;
+  inputType?: string;
+  redacted?: boolean;
+  status?: ConversationActivityStatus;
+  subagents?: ConversationSubagentActivityReport[];
+  toolCallId?: string;
+  toolName?: string;
+};
+
+/** Build a tool activity record constrained to the reporting API shape. */
+export function mockToolActivity(
+  options: MockToolActivityOptions = {},
+): ConversationToolActivityReport {
+  const toolCallId = options.toolCallId ?? "toolu_mock_activity";
+  return {
+    type: "tool_execution",
+    createdAt: options.createdAt ?? mockIso(),
+    id: options.id ?? toolCallId,
+    status: options.status ?? "running",
+    subagents: options.subagents ?? [],
+    toolCallId,
+    toolName: options.toolName ?? "mock.tool",
+    ...(options.args !== undefined ? { args: options.args } : {}),
+    ...(options.inputKeys !== undefined
+      ? { inputKeys: options.inputKeys }
+      : {}),
+    ...(options.inputSizeBytes !== undefined
+      ? { inputSizeBytes: options.inputSizeBytes }
+      : {}),
+    ...(options.inputSizeChars !== undefined
+      ? { inputSizeChars: options.inputSizeChars }
+      : {}),
+    ...(options.inputType !== undefined
+      ? { inputType: options.inputType }
+      : {}),
+    ...(options.redacted !== undefined ? { redacted: options.redacted } : {}),
+  } satisfies ConversationToolActivityReport;
+}

--- a/packages/junior-dashboard/src/mock-reporting/conversation.ts
+++ b/packages/junior-dashboard/src/mock-reporting/conversation.ts
@@ -1,0 +1,117 @@
+import type {
+  ConversationActivityReport,
+  ConversationReport,
+  ConversationReportStatus,
+  ConversationRunReport,
+  ConversationSurface,
+  ConversationUsage,
+  RequesterIdentity,
+  TranscriptMessage,
+} from "@sentry/junior/reporting";
+
+import { mockIso } from "./time";
+import { mockTranscriptMessage } from "./transcript";
+
+export type MockRunOptions = {
+  activity?: ConversationActivityReport[];
+  channel?: string;
+  channelName?: string;
+  completedAt?: string;
+  conversationId?: string;
+  cumulativeDurationMs?: number;
+  cumulativeUsage?: ConversationUsage;
+  displayTitle?: string;
+  id?: string;
+  lastProgressAt?: string;
+  lastSeenAt?: string;
+  requesterIdentity?: RequesterIdentity;
+  sentryConversationUrl?: string;
+  sentryTraceUrl?: string;
+  startedAt?: string;
+  status?: ConversationReportStatus;
+  surface?: ConversationSurface;
+  traceId?: string;
+  transcript?: TranscriptMessage[];
+  transcriptAvailable?: boolean;
+  transcriptMessageCount?: number;
+  transcriptMetadata?: TranscriptMessage[];
+  transcriptRedacted?: boolean;
+  transcriptRedactionReason?: "non_public_conversation";
+};
+
+/** Build a conversation run constrained to the reporting API shape. */
+export function mockRun(options: MockRunOptions = {}): ConversationRunReport {
+  const startedAt = options.startedAt ?? mockIso();
+  return {
+    conversationId: options.conversationId ?? "internal:mock-conversation",
+    cumulativeDurationMs: options.cumulativeDurationMs ?? 0,
+    displayTitle: options.displayTitle ?? "Mock conversation",
+    id: options.id ?? "mock-turn-1",
+    lastProgressAt: options.lastProgressAt ?? startedAt,
+    lastSeenAt: options.lastSeenAt ?? startedAt,
+    startedAt,
+    status: options.status ?? "completed",
+    surface: options.surface ?? "internal",
+    transcriptAvailable: options.transcriptAvailable ?? true,
+    transcript: options.transcript ?? [mockTranscriptMessage()],
+    ...(options.activity !== undefined ? { activity: options.activity } : {}),
+    ...(options.channel !== undefined ? { channel: options.channel } : {}),
+    ...(options.channelName !== undefined
+      ? { channelName: options.channelName }
+      : {}),
+    ...(options.completedAt !== undefined
+      ? { completedAt: options.completedAt }
+      : {}),
+    ...(options.cumulativeUsage !== undefined
+      ? { cumulativeUsage: options.cumulativeUsage }
+      : {}),
+    ...(options.requesterIdentity !== undefined
+      ? { requesterIdentity: options.requesterIdentity }
+      : {}),
+    ...(options.sentryConversationUrl !== undefined
+      ? { sentryConversationUrl: options.sentryConversationUrl }
+      : {}),
+    ...(options.sentryTraceUrl !== undefined
+      ? { sentryTraceUrl: options.sentryTraceUrl }
+      : {}),
+    ...(options.traceId !== undefined ? { traceId: options.traceId } : {}),
+    ...(options.transcriptMessageCount !== undefined
+      ? { transcriptMessageCount: options.transcriptMessageCount }
+      : {}),
+    ...(options.transcriptMetadata !== undefined
+      ? { transcriptMetadata: options.transcriptMetadata }
+      : {}),
+    ...(options.transcriptRedacted !== undefined
+      ? { transcriptRedacted: options.transcriptRedacted }
+      : {}),
+    ...(options.transcriptRedactionReason !== undefined
+      ? { transcriptRedactionReason: options.transcriptRedactionReason }
+      : {}),
+  } satisfies ConversationRunReport;
+}
+
+export type MockConversationOptions = {
+  conversationId?: string;
+  displayTitle?: string;
+  generatedAt?: string;
+  runs?: ConversationRunReport[];
+};
+
+/** Build a conversation report constrained to the reporting API shape. */
+export function mockConversation(
+  options: MockConversationOptions = {},
+): ConversationReport {
+  const conversationId = options.conversationId ?? "internal:mock-conversation";
+  const displayTitle = options.displayTitle ?? "Mock conversation";
+  return {
+    conversationId,
+    displayTitle,
+    generatedAt: options.generatedAt ?? mockIso(),
+    runs: options.runs ?? [
+      mockRun({
+        conversationId,
+        displayTitle,
+      }),
+    ],
+  } satisfies ConversationReport;
+}

--- a/packages/junior-dashboard/src/mock-reporting/time.ts
+++ b/packages/junior-dashboard/src/mock-reporting/time.ts
@@ -1,0 +1,6 @@
+export const defaultMockTimeMs = Date.parse("2026-01-01T00:00:00.000Z");
+
+/** Return a stable ISO timestamp for deterministic mock reporting records. */
+export function mockIso(timeMs = defaultMockTimeMs): string {
+  return new Date(timeMs).toISOString();
+}

--- a/packages/junior-dashboard/src/mock-reporting/transcript.ts
+++ b/packages/junior-dashboard/src/mock-reporting/transcript.ts
@@ -1,0 +1,152 @@
+import type {
+  TranscriptMessage,
+  TranscriptPart,
+  TranscriptRole,
+} from "@sentry/junior/reporting";
+
+export type MockTextPartOptions = {
+  bytes?: number;
+  chars?: number;
+  redacted?: boolean;
+  sourceType?: string;
+  text?: string;
+};
+
+/** Build a transcript text part constrained to the reporting API shape. */
+export function mockTextPart(
+  options: MockTextPartOptions = {},
+): TranscriptPart {
+  return {
+    type: "text",
+    text: options.text ?? "Mock transcript text",
+    ...(options.bytes !== undefined ? { bytes: options.bytes } : {}),
+    ...(options.chars !== undefined ? { chars: options.chars } : {}),
+    ...(options.redacted !== undefined ? { redacted: options.redacted } : {}),
+    ...(options.sourceType !== undefined
+      ? { sourceType: options.sourceType }
+      : {}),
+  } satisfies TranscriptPart;
+}
+
+export type MockThinkingPartOptions = {
+  output?: unknown;
+  outputKeys?: string[];
+  outputSizeBytes?: number;
+  outputSizeChars?: number;
+  outputType?: string;
+  redacted?: boolean;
+};
+
+/** Build a transcript thinking part constrained to the reporting API shape. */
+export function mockThinkingPart(
+  options: MockThinkingPartOptions = {},
+): TranscriptPart {
+  return {
+    type: "thinking",
+    output: options.output ?? "Inspect the mock reporting state.",
+    ...(options.outputKeys !== undefined
+      ? { outputKeys: options.outputKeys }
+      : {}),
+    ...(options.outputSizeBytes !== undefined
+      ? { outputSizeBytes: options.outputSizeBytes }
+      : {}),
+    ...(options.outputSizeChars !== undefined
+      ? { outputSizeChars: options.outputSizeChars }
+      : {}),
+    ...(options.outputType !== undefined
+      ? { outputType: options.outputType }
+      : {}),
+    ...(options.redacted !== undefined ? { redacted: options.redacted } : {}),
+  } satisfies TranscriptPart;
+}
+
+export type MockToolCallPartOptions = {
+  id?: string;
+  input?: unknown;
+  inputKeys?: string[];
+  inputSizeBytes?: number;
+  inputSizeChars?: number;
+  inputType?: string;
+  name?: string;
+  redacted?: boolean;
+};
+
+/** Build a transcript tool-call part constrained to the reporting API shape. */
+export function mockToolCallPart(
+  options: MockToolCallPartOptions = {},
+): TranscriptPart {
+  return {
+    type: "tool_call",
+    id: options.id ?? "toolu_mock_call",
+    name: options.name ?? "mock.tool",
+    ...(options.input !== undefined ? { input: options.input } : {}),
+    ...(options.inputKeys !== undefined
+      ? { inputKeys: options.inputKeys }
+      : {}),
+    ...(options.inputSizeBytes !== undefined
+      ? { inputSizeBytes: options.inputSizeBytes }
+      : {}),
+    ...(options.inputSizeChars !== undefined
+      ? { inputSizeChars: options.inputSizeChars }
+      : {}),
+    ...(options.inputType !== undefined
+      ? { inputType: options.inputType }
+      : {}),
+    ...(options.redacted !== undefined ? { redacted: options.redacted } : {}),
+  } satisfies TranscriptPart;
+}
+
+export type MockToolResultPartOptions = {
+  id?: string;
+  name?: string;
+  output?: unknown;
+  outputKeys?: string[];
+  outputSizeBytes?: number;
+  outputSizeChars?: number;
+  outputType?: string;
+  redacted?: boolean;
+};
+
+/** Build a transcript tool-result part constrained to the reporting API shape. */
+export function mockToolResultPart(
+  options: MockToolResultPartOptions = {},
+): TranscriptPart {
+  return {
+    type: "tool_result",
+    id: options.id ?? "toolu_mock_call",
+    name: options.name ?? "mock.tool",
+    ...(options.output !== undefined ? { output: options.output } : {}),
+    ...(options.outputKeys !== undefined
+      ? { outputKeys: options.outputKeys }
+      : {}),
+    ...(options.outputSizeBytes !== undefined
+      ? { outputSizeBytes: options.outputSizeBytes }
+      : {}),
+    ...(options.outputSizeChars !== undefined
+      ? { outputSizeChars: options.outputSizeChars }
+      : {}),
+    ...(options.outputType !== undefined
+      ? { outputType: options.outputType }
+      : {}),
+    ...(options.redacted !== undefined ? { redacted: options.redacted } : {}),
+  } satisfies TranscriptPart;
+}
+
+export type MockTranscriptMessageOptions = {
+  parts?: TranscriptPart[];
+  role?: TranscriptRole;
+  timestamp?: number;
+};
+
+/** Build a transcript message constrained to the reporting API shape. */
+export function mockTranscriptMessage(
+  options: MockTranscriptMessageOptions = {},
+): TranscriptMessage {
+  return {
+    role: options.role ?? "assistant",
+    parts: options.parts ?? [mockTextPart()],
+    ...(options.timestamp !== undefined
+      ? { timestamp: options.timestamp }
+      : {}),
+  } satisfies TranscriptMessage;
+}

--- a/packages/junior-dashboard/tests/dashboard-mock-routes.test.ts
+++ b/packages/junior-dashboard/tests/dashboard-mock-routes.test.ts
@@ -214,10 +214,17 @@ describe("dashboard mock conversation routes", () => {
       runs: Array<{
         activity?: Array<{
           status?: string;
+          subagents?: Array<{
+            parentToolCallId?: string;
+            status?: string;
+            subagentKind?: string;
+            type: string;
+          }>;
           toolCallId?: string;
           toolName?: string;
           type: string;
         }>;
+        id?: string;
         transcript: Array<{
           parts: Array<{ id?: string; name?: string; type: string }>;
           timestamp?: number;
@@ -249,6 +256,28 @@ describe("dashboard mock conversation routes", () => {
     expect(invertedRun?.transcript[1]?.timestamp).toBeLessThan(
       invertedRun?.transcript[0]?.timestamp ?? 0,
     );
+    const advisorRun = qaConversationBody.runs[2];
+    expect(advisorRun?.id).toBe("mock-dashboard-qa-advisor-subagent");
+    expect(
+      advisorRun?.transcript
+        .flatMap((message) => message.parts)
+        .filter((part) => part.name === "advisor")
+        .map((part) => part.type),
+    ).toEqual(["tool_call", "tool_result"]);
+    expect(advisorRun?.activity?.[0]).toMatchObject({
+      type: "tool_execution",
+      status: "completed",
+      toolCallId: "toolu_mock_dashboard_advisor",
+      toolName: "advisor",
+      subagents: [
+        {
+          type: "subagent",
+          status: "completed",
+          subagentKind: "advisor",
+          parentToolCallId: "toolu_mock_dashboard_advisor",
+        },
+      ],
+    });
 
     const longConversation = await app.fetch(
       new Request(

--- a/packages/junior-dashboard/tests/dashboard-mock-routes.test.ts
+++ b/packages/junior-dashboard/tests/dashboard-mock-routes.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { JuniorReporting } from "@sentry/junior/reporting";
 import { createDashboardApp } from "../src/app";
-import { createMockConversationReporting } from "../src/mock-conversations";
+import {
+  createMockConversationReporting,
+  DASHBOARD_QA_CONVERSATION_ID,
+} from "../src/mock-conversations";
 
 function reporting(): JuniorReporting {
   return {
@@ -130,7 +133,12 @@ describe("dashboard mock conversation routes", () => {
     );
     expect(sessions.status).toBe(200);
     const sessionBody = (await sessions.json()) as {
-      sessions: Array<{ conversationId: string; cumulativeDurationMs: number }>;
+      sessions: Array<{
+        activity?: unknown;
+        conversationId: string;
+        cumulativeDurationMs: number;
+        id: string;
+      }>;
     };
     expect(sessionBody.sessions[0]?.conversationId).toBe(
       "slack:CQA123:1770003600.000200",
@@ -141,6 +149,16 @@ describe("dashboard mock conversation routes", () => {
     expect(
       sessionBody.sessions.map((session) => session.conversationId),
     ).toContain("slack:CQA456:1770021600.000600");
+    expect(
+      sessionBody.sessions.map((session) => session.conversationId),
+    ).toContain(DASHBOARD_QA_CONVERSATION_ID);
+    const qaActivityOnlySession = sessionBody.sessions.find(
+      (session) =>
+        session.conversationId === DASHBOARD_QA_CONVERSATION_ID &&
+        session.id === "mock-dashboard-qa-activity-only",
+    );
+    expect(qaActivityOnlySession).toBeDefined();
+    expect(qaActivityOnlySession).not.toHaveProperty("activity");
     const conversationStats = await app.fetch(
       new Request("http://localhost/api/dashboard/conversation-stats"),
     );
@@ -183,6 +201,54 @@ describe("dashboard mock conversation routes", () => {
         .map((part) => part.name)
         .filter(Boolean),
     ).toContain("datacat.search_logs");
+
+    const qaConversation = await app.fetch(
+      new Request(
+        `http://localhost/api/dashboard/conversations/${encodeURIComponent(
+          DASHBOARD_QA_CONVERSATION_ID,
+        )}`,
+      ),
+    );
+    expect(qaConversation.status).toBe(200);
+    const qaConversationBody = (await qaConversation.json()) as {
+      runs: Array<{
+        activity?: Array<{
+          status?: string;
+          toolCallId?: string;
+          toolName?: string;
+          type: string;
+        }>;
+        transcript: Array<{
+          parts: Array<{ id?: string; name?: string; type: string }>;
+          timestamp?: number;
+        }>;
+        transcriptMessageCount?: number;
+      }>;
+    };
+    expect(qaConversationBody.runs[0]).toMatchObject({
+      id: "mock-dashboard-qa-activity-only",
+      transcript: [],
+      transcriptMessageCount: 3,
+      activity: [
+        {
+          type: "tool_execution",
+          status: "running",
+          toolName: "mock.dashboard_running_tool",
+        },
+      ],
+    });
+    const invertedRun = qaConversationBody.runs[1];
+    expect(invertedRun?.transcript[0]?.parts[0]).toMatchObject({
+      type: "tool_call",
+      name: "mock.inverted_timestamp_tool",
+    });
+    expect(invertedRun?.transcript[1]?.parts[0]).toMatchObject({
+      type: "tool_result",
+      name: "mock.inverted_timestamp_tool",
+    });
+    expect(invertedRun?.transcript[1]?.timestamp).toBeLessThan(
+      invertedRun?.transcript[0]?.timestamp ?? 0,
+    );
 
     const longConversation = await app.fetch(
       new Request(

--- a/packages/junior-dashboard/tests/format.test.ts
+++ b/packages/junior-dashboard/tests/format.test.ts
@@ -177,6 +177,40 @@ describe("dashboard token formatting", () => {
     });
   });
 
+  it("uses transcript message count when only activity rows are visible", () => {
+    const turn = {
+      conversationId: "conversation-activity",
+      cumulativeDurationMs: 0,
+      displayTitle: "Activity",
+      id: "turn-activity",
+      lastProgressAt: "2026-01-01T00:00:01.000Z",
+      lastSeenAt: "2026-01-01T00:00:01.000Z",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      status: "active",
+      surface: "internal",
+      transcriptAvailable: true,
+      transcript: [],
+      transcriptMessageCount: 3,
+      activity: [
+        {
+          type: "tool_execution",
+          id: "call-activity",
+          toolCallId: "call-activity",
+          toolName: "advisor",
+          createdAt: "2026-01-01T00:00:01.000Z",
+          status: "running",
+          subagents: [],
+        },
+      ],
+    } as ConversationTurn;
+
+    expect(turnMessageCount(turn)).toBe(3);
+    expect(summarizeToolCalls([turn])).toEqual({
+      items: [{ count: 1, name: "advisor" }],
+      total: 1,
+    });
+  });
+
   it("does not match tool durations across different turns", () => {
     const turns = [
       {

--- a/packages/junior-dashboard/tests/format.test.ts
+++ b/packages/junior-dashboard/tests/format.test.ts
@@ -145,6 +145,38 @@ describe("dashboard token formatting", () => {
     });
   });
 
+  it("counts activity-only tool calls in tool summaries", () => {
+    const turn = {
+      conversationId: "conversation-activity",
+      cumulativeDurationMs: 0,
+      displayTitle: "Activity",
+      id: "turn-activity",
+      lastProgressAt: "2026-01-01T00:00:01.000Z",
+      lastSeenAt: "2026-01-01T00:00:01.000Z",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      status: "active",
+      surface: "internal",
+      transcriptAvailable: true,
+      transcript: [],
+      activity: [
+        {
+          type: "tool_execution",
+          id: "call-activity",
+          toolCallId: "call-activity",
+          toolName: "advisor",
+          createdAt: "2026-01-01T00:00:01.000Z",
+          status: "running",
+          subagents: [],
+        },
+      ],
+    } as ConversationTurn;
+
+    expect(summarizeToolCalls([turn])).toEqual({
+      items: [{ count: 1, name: "advisor" }],
+      total: 1,
+    });
+  });
+
   it("does not match tool durations across different turns", () => {
     const turns = [
       {

--- a/packages/junior-dashboard/tests/markdownExport.test.ts
+++ b/packages/junior-dashboard/tests/markdownExport.test.ts
@@ -128,6 +128,57 @@ describe("dashboard markdown export", () => {
     expect(markdown).not.toContain("# Public Channel");
   });
 
+  it("exports running tool and subagent activity from derived transcript rows", () => {
+    const detail = {
+      conversationId: "conversation-activity",
+      displayTitle: "Activity transcript",
+      generatedAt: "2026-01-01T00:00:08.000Z",
+      runs: [
+        {
+          conversationId: "conversation-activity",
+          cumulativeDurationMs: 0,
+          displayTitle: "Activity transcript",
+          id: "turn-activity",
+          lastProgressAt: "2026-01-01T00:00:02.000Z",
+          lastSeenAt: "2026-01-01T00:00:02.000Z",
+          startedAt: "2026-01-01T00:00:00.000Z",
+          status: "active",
+          surface: "internal",
+          transcriptAvailable: true,
+          transcript: [],
+          activity: [
+            {
+              type: "tool_execution",
+              id: "advisor-call",
+              toolCallId: "advisor-call",
+              toolName: "advisor",
+              createdAt: "2026-01-01T00:00:01.000Z",
+              status: "running",
+              subagents: [
+                {
+                  type: "subagent",
+                  id: "advisor-call",
+                  subagentKind: "advisor",
+                  parentToolCallId: "advisor-call",
+                  createdAt: "2026-01-01T00:00:02.000Z",
+                  status: "running",
+                },
+              ],
+            },
+          ],
+        } as ConversationTurn,
+      ],
+    } satisfies ConversationDetailFeed;
+
+    const markdown = buildConversationMarkdown(detail);
+
+    expect(markdown).toContain("### Tool: advisor");
+    expect(markdown).toContain("- Result: running");
+    expect(markdown).toContain("### Subagent: advisor");
+    expect(markdown).toContain("- Status: running");
+    expect(markdown).toContain("- Parent tool call: advisor-call");
+  });
+
   it("exports only safe redaction metadata for private transcripts", () => {
     const detail = {
       conversationId: "slack:D1:222",

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -443,7 +443,7 @@ describe("dashboard telemetry components", () => {
     expect(html).not.toContain("tool call");
   });
 
-  it("renders execution activity above the transcript", () => {
+  it("renders execution activity inside the transcript", () => {
     const session = {
       conversationId: "conversation-1",
       cumulativeDurationMs: 0,
@@ -469,7 +469,7 @@ describe("dashboard telemetry components", () => {
               toolCallId: "advisor-call-1",
               toolName: "advisor",
               createdAt: "2026-01-01T00:00:01.000Z",
-              status: "completed",
+              status: "running",
               subagents: [
                 {
                   type: "subagent",
@@ -477,9 +477,7 @@ describe("dashboard telemetry components", () => {
                   subagentKind: "advisor",
                   parentToolCallId: "advisor-call-1",
                   createdAt: "2026-01-01T00:00:01.000Z",
-                  endedAt: "2026-01-01T00:00:05.000Z",
-                  outcome: "success",
-                  status: "success",
+                  status: "running",
                 },
               ],
             },
@@ -493,11 +491,12 @@ describe("dashboard telemetry components", () => {
 
     const html = renderConversationPage(dashboardData([session]));
 
-    expect(html).toContain('aria-label="Execution activity"');
-    expect(html).toContain("Execution Activity");
+    expect(html).not.toContain('aria-label="Execution activity"');
+    expect(html).not.toContain("Execution Activity");
     expect(html).toContain("advisor");
     expect(html).toContain("advisor subagent");
-    expect(html.indexOf("Execution Activity")).toBeLessThan(
+    expect(html).toContain("running");
+    expect(html.indexOf("advisor")).toBeGreaterThan(
       html.indexOf('aria-label="Transcript view"'),
     );
   });

--- a/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
+++ b/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
@@ -160,6 +160,50 @@ describe("transcript render model", () => {
     ]);
   });
 
+  it("preserves transcript order when activity rows have inverted tool timestamps", () => {
+    const turn = conversationTurn({
+      activity: [
+        {
+          type: "tool_execution",
+          id: "call-1",
+          toolCallId: "call-1",
+          toolName: "search",
+          createdAt: "2026-01-01T00:00:01.000Z",
+          status: "completed",
+          subagents: [],
+        },
+      ],
+      transcript: [
+        {
+          role: "assistant",
+          timestamp: Date.parse("2026-01-01T00:00:02.000Z"),
+          parts: [{ type: "tool_call", id: "call-1", name: "search" }],
+        },
+        {
+          role: "toolResult",
+          timestamp: Date.parse("2026-01-01T00:00:01.000Z"),
+          parts: [{ type: "tool_result", id: "call-1", name: "search" }],
+        },
+      ],
+      transcriptAvailable: true,
+    });
+
+    expect(groupTranscriptMessages(turnTranscriptMessages(turn))).toEqual([
+      {
+        call: {
+          type: "tool_call",
+          id: "call-1",
+          name: "search",
+          status: "completed",
+        },
+        kind: "tool",
+        result: { type: "tool_result", id: "call-1", name: "search" },
+        resultTimestamp: Date.parse("2026-01-01T00:00:01.000Z"),
+        timestamp: Date.parse("2026-01-01T00:00:02.000Z"),
+      },
+    ]);
+  });
+
   it("adds subagent activity as transcript entries", () => {
     const turn = conversationTurn({
       activity: [
@@ -178,6 +222,15 @@ describe("transcript render model", () => {
               parentToolCallId: "advisor-call",
               createdAt: "2026-01-01T00:00:02.000Z",
               status: "running",
+            },
+            {
+              type: "subagent",
+              id: "advisor-call-2",
+              subagentKind: "advisor",
+              parentToolCallId: "advisor-call",
+              createdAt: "2026-01-01T00:00:03.000Z",
+              status: "completed",
+              outcome: "success",
             },
           ],
         },
@@ -207,6 +260,18 @@ describe("transcript render model", () => {
           status: "running",
         },
         timestamp: Date.parse("2026-01-01T00:00:02.000Z"),
+      },
+      {
+        kind: "subagent",
+        part: {
+          type: "subagent",
+          id: "advisor-call-2",
+          subagentKind: "advisor",
+          parentToolCallId: "advisor-call",
+          status: "completed",
+          outcome: "success",
+        },
+        timestamp: Date.parse("2026-01-01T00:00:03.000Z"),
       },
     ]);
   });

--- a/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
+++ b/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
@@ -4,7 +4,28 @@ import {
   groupTranscriptMessages,
   groupTranscriptParts,
 } from "../src/client/components/transcriptRenderModel";
-import type { TranscriptMessage } from "../src/client/types";
+import { turnHasMatch } from "../src/client/components/transcriptSearch";
+import { turnTranscriptMessages } from "../src/client/transcriptActivity";
+import type { ConversationTurn, TranscriptMessage } from "../src/client/types";
+
+function conversationTurn(
+  overrides: Partial<ConversationTurn>,
+): ConversationTurn {
+  return {
+    conversationId: "conversation-1",
+    cumulativeDurationMs: 0,
+    displayTitle: "Conversation",
+    id: "turn-1",
+    lastProgressAt: "2026-01-01T00:00:00.000Z",
+    lastSeenAt: "2026-01-01T00:00:00.000Z",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    status: "completed",
+    surface: "internal",
+    transcript: [],
+    transcriptAvailable: true,
+    ...overrides,
+  };
+}
 
 describe("transcript render model", () => {
   it("promotes thinking parts to standalone transcript events", () => {
@@ -96,5 +117,128 @@ describe("transcript render model", () => {
         result: { type: "tool_result", id: "call-2", name: "search" },
       },
     ]);
+  });
+
+  it("backfills activity tool calls so result-only transcript entries are paired", () => {
+    const turn = conversationTurn({
+      activity: [
+        {
+          type: "tool_execution",
+          id: "call-1",
+          toolCallId: "call-1",
+          toolName: "search",
+          createdAt: "2026-01-01T00:00:01.000Z",
+          status: "completed",
+          args: { query: "activity" },
+          subagents: [],
+        },
+      ],
+      transcript: [
+        {
+          role: "toolResult",
+          timestamp: Date.parse("2026-01-01T00:00:02.000Z"),
+          parts: [{ type: "tool_result", id: "call-1", name: "search" }],
+        },
+      ],
+      transcriptAvailable: true,
+    });
+
+    expect(groupTranscriptMessages(turnTranscriptMessages(turn))).toEqual([
+      {
+        call: {
+          type: "tool_call",
+          id: "call-1",
+          name: "search",
+          status: "completed",
+          input: { query: "activity" },
+        },
+        kind: "tool",
+        result: { type: "tool_result", id: "call-1", name: "search" },
+        resultTimestamp: Date.parse("2026-01-01T00:00:02.000Z"),
+        timestamp: Date.parse("2026-01-01T00:00:01.000Z"),
+      },
+    ]);
+  });
+
+  it("adds subagent activity as transcript entries", () => {
+    const turn = conversationTurn({
+      activity: [
+        {
+          type: "tool_execution",
+          id: "advisor-call",
+          toolCallId: "advisor-call",
+          toolName: "advisor",
+          createdAt: "2026-01-01T00:00:01.000Z",
+          status: "running",
+          subagents: [
+            {
+              type: "subagent",
+              id: "advisor-call",
+              subagentKind: "advisor",
+              parentToolCallId: "advisor-call",
+              createdAt: "2026-01-01T00:00:02.000Z",
+              status: "running",
+            },
+          ],
+        },
+      ],
+      transcript: [],
+      transcriptAvailable: true,
+    });
+
+    expect(groupTranscriptMessages(turnTranscriptMessages(turn))).toEqual([
+      {
+        call: {
+          type: "tool_call",
+          id: "advisor-call",
+          name: "advisor",
+          status: "running",
+        },
+        kind: "tool",
+        timestamp: Date.parse("2026-01-01T00:00:01.000Z"),
+      },
+      {
+        kind: "subagent",
+        part: {
+          type: "subagent",
+          id: "advisor-call",
+          subagentKind: "advisor",
+          parentToolCallId: "advisor-call",
+          status: "running",
+        },
+        timestamp: Date.parse("2026-01-01T00:00:02.000Z"),
+      },
+    ]);
+  });
+
+  it("matches derived activity rows in transcript search", () => {
+    const turn = conversationTurn({
+      activity: [
+        {
+          type: "tool_execution",
+          id: "advisor-call",
+          toolCallId: "advisor-call",
+          toolName: "advisor",
+          createdAt: "2026-01-01T00:00:01.000Z",
+          status: "running",
+          subagents: [
+            {
+              type: "subagent",
+              id: "advisor-call",
+              subagentKind: "advisor",
+              parentToolCallId: "advisor-call",
+              createdAt: "2026-01-01T00:00:02.000Z",
+              status: "running",
+            },
+          ],
+        },
+      ],
+      transcript: [],
+      transcriptAvailable: true,
+    });
+
+    expect(turnHasMatch(turn, "advisor")).toBe(true);
+    expect(turnHasMatch(turn, "running")).toBe(true);
+    expect(turnHasMatch(turn, "not-present")).toBe(false);
   });
 });

--- a/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
+++ b/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
@@ -276,6 +276,148 @@ describe("transcript render model", () => {
     ]);
   });
 
+  it("does not duplicate subagents from repeated activity snapshots", () => {
+    const turn = conversationTurn({
+      activity: [
+        {
+          type: "tool_execution",
+          id: "advisor-call",
+          toolCallId: "advisor-call",
+          toolName: "advisor",
+          createdAt: "2026-01-01T00:00:01.000Z",
+          status: "running",
+          subagents: [
+            {
+              type: "subagent",
+              id: "advisor-subagent",
+              subagentKind: "advisor",
+              parentToolCallId: "advisor-call",
+              createdAt: "2026-01-01T00:00:02.000Z",
+              status: "running",
+            },
+          ],
+        },
+        {
+          type: "tool_execution",
+          id: "advisor-call",
+          toolCallId: "advisor-call",
+          toolName: "advisor",
+          createdAt: "2026-01-01T00:00:01.000Z",
+          status: "running",
+          subagents: [
+            {
+              type: "subagent",
+              id: "advisor-subagent",
+              subagentKind: "advisor",
+              parentToolCallId: "advisor-call",
+              createdAt: "2026-01-01T00:00:02.000Z",
+              status: "running",
+            },
+          ],
+        },
+      ],
+      transcript: [],
+      transcriptAvailable: true,
+    });
+
+    expect(groupTranscriptMessages(turnTranscriptMessages(turn))).toEqual([
+      {
+        call: {
+          type: "tool_call",
+          id: "advisor-call",
+          name: "advisor",
+          status: "running",
+        },
+        kind: "tool",
+        timestamp: Date.parse("2026-01-01T00:00:01.000Z"),
+      },
+      {
+        kind: "subagent",
+        part: {
+          type: "subagent",
+          id: "advisor-subagent",
+          subagentKind: "advisor",
+          parentToolCallId: "advisor-call",
+          status: "running",
+        },
+        timestamp: Date.parse("2026-01-01T00:00:02.000Z"),
+      },
+    ]);
+  });
+
+  it("keeps subagent activity between an existing tool call and result", () => {
+    const turn = conversationTurn({
+      activity: [
+        {
+          type: "tool_execution",
+          id: "advisor-call",
+          toolCallId: "advisor-call",
+          toolName: "advisor",
+          createdAt: "2026-01-01T00:00:01.000Z",
+          status: "completed",
+          subagents: [
+            {
+              type: "subagent",
+              id: "advisor-subagent",
+              subagentKind: "advisor",
+              parentToolCallId: "advisor-call",
+              createdAt: "2026-01-01T00:00:02.000Z",
+              status: "completed",
+              outcome: "success",
+            },
+          ],
+        },
+      ],
+      transcript: [
+        {
+          role: "assistant",
+          timestamp: Date.parse("2026-01-01T00:00:01.000Z"),
+          parts: [{ type: "tool_call", id: "advisor-call", name: "advisor" }],
+        },
+        {
+          role: "toolResult",
+          timestamp: Date.parse("2026-01-01T00:00:03.000Z"),
+          parts: [{ type: "tool_result", id: "advisor-call", name: "advisor" }],
+        },
+      ],
+      transcriptAvailable: true,
+    });
+
+    expect(groupTranscriptMessages(turnTranscriptMessages(turn))).toEqual([
+      {
+        call: {
+          type: "tool_call",
+          id: "advisor-call",
+          name: "advisor",
+          status: "completed",
+        },
+        kind: "tool",
+        timestamp: Date.parse("2026-01-01T00:00:01.000Z"),
+      },
+      {
+        kind: "subagent",
+        part: {
+          type: "subagent",
+          id: "advisor-subagent",
+          subagentKind: "advisor",
+          parentToolCallId: "advisor-call",
+          status: "completed",
+          outcome: "success",
+        },
+        timestamp: Date.parse("2026-01-01T00:00:02.000Z"),
+      },
+      {
+        kind: "tool",
+        result: {
+          type: "tool_result",
+          id: "advisor-call",
+          name: "advisor",
+        },
+        resultTimestamp: Date.parse("2026-01-01T00:00:03.000Z"),
+      },
+    ]);
+  });
+
   it("matches derived activity rows in transcript search", () => {
     const turn = conversationTurn({
       activity: [

--- a/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
+++ b/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
@@ -306,4 +306,24 @@ describe("transcript render model", () => {
     expect(turnHasMatch(turn, "running")).toBe(true);
     expect(turnHasMatch(turn, "not-present")).toBe(false);
   });
+
+  it("matches tool activity status in transcript search", () => {
+    const turn = conversationTurn({
+      activity: [
+        {
+          type: "tool_execution",
+          id: "call-running",
+          toolCallId: "call-running",
+          toolName: "search",
+          createdAt: "2026-01-01T00:00:01.000Z",
+          status: "running",
+          subagents: [],
+        },
+      ],
+      transcript: [],
+      transcriptAvailable: true,
+    });
+
+    expect(turnHasMatch(turn, "running")).toBe(true);
+  });
 });


### PR DESCRIPTION
Dashboard conversation transcripts now render reporting activity inline with transcript rows. Running tool calls, completed tool results, and advisor subagent activity appear in the same transcript flow, and matching lifecycle activity upgrades into paired call/result rows when transcript data arrives.

The shared transcript projection now feeds rendering, search, bottom pinning, markdown export, and tool summaries, which keeps those dashboard surfaces aligned without changing the backend reporting transcript contract.

A typed mock reporting fixture tree now backs dashboard visual QA. The mock overlay includes activity-only tools, inverted tool timestamps, and an advisor tool call/result with nested advisor subagent activity, so reviewers can exercise the edge cases through the normal dashboard reporting API instead of relying on ad-hoc local conversations.