### PR TITLE
fix(memory): Archive expired memories opportunistically

### DIFF
--- a/packages/junior-memory/src/process-session.ts
+++ b/packages/junior-memory/src/process-session.ts
@@ -119,6 +119,7 @@ export async function processMemorySession(
   const store = createMemoryStore(context.db as MemoryDb, runtimeContext, {
     embedder: context.embedder,
   });
+  await store.archiveExpiredMemories();
   const memories = await getTaskMemories(context, async () => {
     const existingMemories = await store.searchMemories({
       limit: 10,

--- a/packages/junior-memory/src/store.ts
+++ b/packages/junior-memory/src/store.ts
@@ -13,8 +13,10 @@ import {
   eq,
   gt,
   ilike,
+  inArray,
   isNull,
   like,
+  lte,
   or,
   sql,
   type SQL,
@@ -44,6 +46,7 @@ import {
 
 const DEFAULT_LIST_LIMIT = 50;
 const DEFAULT_SEARCH_LIMIT = 10;
+const DEFAULT_EXPIRED_ARCHIVE_LIMIT = 100;
 const VECTOR_SEARCH_OVERFETCH = 4;
 const MAX_MEMORY_CONTENT_CHARS = 4_000;
 const EMBEDDING_METRIC = "cosine";
@@ -84,6 +87,11 @@ const archiveMemoryInputSchema = z
   .object({
     id: nonEmptyStringSchema,
     reason: nonEmptyStringSchema.optional(),
+  })
+  .strict();
+const archiveExpiredMemoriesInputSchema = z
+  .object({
+    limit: numberSchema.optional(),
   })
   .strict();
 const clockSchema = z.function({ input: [], output: numberSchema }).optional();
@@ -188,6 +196,14 @@ export type SearchMemoriesInput = z.output<typeof searchMemoriesInputSchema>;
 
 export type ArchiveMemoryInput = z.output<typeof archiveMemoryInputSchema>;
 
+export type ArchiveExpiredMemoriesInput = z.output<
+  typeof archiveExpiredMemoriesInputSchema
+>;
+
+export interface ArchiveExpiredMemoriesResult {
+  archivedCount: number;
+}
+
 export interface MemoryEmbeddingProvider {
   /** Embed normalized memory text for derived vector retrieval. */
   embedTexts(input: { texts: string[] }): Promise<{
@@ -205,6 +221,10 @@ export interface MemoryStoreOptions {
 
 /** Context-bound storage operations for visible long-term memories. */
 export interface MemoryStore {
+  /** Archive expired memories visible in the current runtime context. */
+  archiveExpiredMemories(
+    input?: ArchiveExpiredMemoriesInput,
+  ): Promise<ArchiveExpiredMemoriesResult>;
   /** Archive a visible memory in the current runtime context. */
   archiveMemory(input: ArchiveMemoryInput): Promise<MemoryRecord>;
   /** Store a personal memory for the current requester. */
@@ -312,6 +332,7 @@ function activeVisiblePredicate(args: {
 async function findByIdempotencyKey(args: {
   db: MemoryDb;
   idempotencyKey: string;
+  nowMs: number;
   scope: ResolvedMemoryScope;
 }): Promise<MemoryRecord | undefined> {
   const rows = await args.db
@@ -325,10 +346,75 @@ async function findByIdempotencyKey(args: {
         isNull(juniorMemoryMemories.archivedAtMs),
         isNull(juniorMemoryMemories.supersededAtMs),
         isNull(juniorMemoryMemories.supersededById),
+        or(
+          isNull(juniorMemoryMemories.expiresAtMs),
+          gt(juniorMemoryMemories.expiresAtMs, args.nowMs),
+        ),
       ),
     )
     .limit(1);
   return rows[0] ? parseMemoryRow(rows[0]) : undefined;
+}
+
+/**
+ * Archive a bounded batch of expired active rows and remove their derived vectors.
+ */
+async function archiveExpiredMemoryBatch(args: {
+  db: MemoryDb;
+  idempotencyKey?: string;
+  limit?: number;
+  nowMs: number;
+  scopes: ResolvedMemoryScope[];
+}): Promise<ArchiveExpiredMemoriesResult> {
+  const scopePredicate = visibleScopePredicate(args.scopes);
+  if (!scopePredicate) {
+    return { archivedCount: 0 };
+  }
+  const predicates: SQL[] = [
+    scopePredicate,
+    isNull(juniorMemoryMemories.archivedAtMs),
+    isNull(juniorMemoryMemories.supersededAtMs),
+    isNull(juniorMemoryMemories.supersededById),
+    lte(juniorMemoryMemories.expiresAtMs, args.nowMs),
+  ];
+  if (args.idempotencyKey !== undefined) {
+    predicates.push(
+      eq(juniorMemoryMemories.idempotencyKey, args.idempotencyKey),
+    );
+  }
+
+  const archivedIds = await args.db.transaction(async (tx) => {
+    const expired = await tx
+      .select({ id: juniorMemoryMemories.id })
+      .from(juniorMemoryMemories)
+      .where(and(...predicates))
+      .orderBy(
+        asc(juniorMemoryMemories.expiresAtMs),
+        asc(juniorMemoryMemories.id),
+      )
+      .limit(boundedLimit(args.limit, DEFAULT_EXPIRED_ARCHIVE_LIMIT));
+    const ids = expired.map((row) => row.id);
+    if (ids.length === 0) {
+      return [];
+    }
+
+    const archived = await tx
+      .update(juniorMemoryMemories)
+      .set({
+        archivedAtMs: args.nowMs,
+        archiveReason: "expired",
+      })
+      .where(and(inArray(juniorMemoryMemories.id, ids), ...predicates))
+      .returning({ id: juniorMemoryMemories.id });
+    const idsToClean = archived.map((row) => row.id);
+    if (idsToClean.length > 0) {
+      await tx
+        .delete(juniorMemoryEmbeddings)
+        .where(inArray(juniorMemoryEmbeddings.memoryId, idsToClean));
+    }
+    return idsToClean;
+  });
+  return { archivedCount: archivedIds.length };
 }
 
 function searchScore(memory: MemoryRecord, terms: string[]): number {
@@ -591,6 +677,19 @@ export function createMemoryStore(
   const embedder = options.embedder;
   const getNowMs = parsedOptions.now ?? Date.now;
 
+  async function archiveExpiredVisibleMemories(
+    input: ArchiveExpiredMemoriesInput | undefined,
+    nowMs: number,
+  ): Promise<ArchiveExpiredMemoriesResult> {
+    input = archiveExpiredMemoriesInputSchema.parse(input ?? {});
+    return await archiveExpiredMemoryBatch({
+      db,
+      limit: input.limit,
+      nowMs,
+      scopes: deriveVisibleMemoryScopes(runtimeContext),
+    });
+  }
+
   /** Persist a memory under the plugin-derived scope and subject. */
   async function createScopedMemory(
     rawInput: CreateMemoryInput,
@@ -604,6 +703,18 @@ export function createMemoryStore(
     if (content.length > MAX_MEMORY_CONTENT_CHARS) {
       throw new Error("Memory content exceeds the maximum length.");
     }
+    await archiveExpiredMemoryBatch({
+      db,
+      nowMs,
+      scopes: [scope],
+    });
+    await archiveExpiredMemoryBatch({
+      db,
+      idempotencyKey: input.idempotencyKey,
+      limit: 1,
+      nowMs,
+      scopes: [scope],
+    });
 
     const id = randomUUID();
     const rows = await db
@@ -647,6 +758,7 @@ export function createMemoryStore(
     const idempotent = await findByIdempotencyKey({
       db,
       idempotencyKey: input.idempotencyKey,
+      nowMs,
       scope,
     });
     if (!idempotent) {
@@ -663,6 +775,10 @@ export function createMemoryStore(
   }
 
   return {
+    async archiveExpiredMemories(input) {
+      return await archiveExpiredVisibleMemories(input, getNowMs());
+    },
+
     async createMemory(input) {
       return await createScopedMemory(input, "personal");
     },
@@ -675,6 +791,11 @@ export function createMemoryStore(
       input = listMemoriesInputSchema.parse(input);
       const nowMs = getNowMs();
       const scopes = deriveVisibleMemoryScopes(runtimeContext);
+      await archiveExpiredMemoryBatch({
+        db,
+        nowMs,
+        scopes,
+      });
       return await listVisibleMemories({
         db,
         limit: input.limit,
@@ -687,6 +808,11 @@ export function createMemoryStore(
       input = searchMemoriesInputSchema.parse(input);
       const nowMs = getNowMs();
       const scopes = deriveVisibleMemoryScopes(runtimeContext);
+      await archiveExpiredMemoryBatch({
+        db,
+        nowMs,
+        scopes,
+      });
       const limit = boundedLimit(input.limit, DEFAULT_SEARCH_LIMIT);
       const vectorCandidates = await searchVisibleVectorMemories({
         db,

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -16,6 +16,7 @@ import {
   type PluginTaskContext,
 } from "@sentry/junior-plugin-api";
 import { Command, CommanderError } from "commander";
+import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import * as memorySqlSchema from "../src/db/schema";
 import { createMemoryAgent, type CreateMemoryRequest } from "../src/agent";
@@ -1541,6 +1542,95 @@ WHERE id = '${superseded.memory.id}'
     }
   }, 15_000);
 
+  it("archives expired visible memories during reads", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      const expiredContent = "Temporary CLI memory should expire cleanly.";
+      const activeContent = "Persistent CLI memory should remain visible.";
+      const supersededContent = "Superseded CLI memory stays superseded.";
+      const embedder = createTestEmbedder({
+        [expiredContent]: unitEmbedding(1),
+        [activeContent]: unitEmbedding(2),
+        [supersededContent]: unitEmbedding(3),
+      });
+      let nowMs = TEST_NOW_MS;
+      const store = createMemoryStore(memoryDb(fixture), slackContext(), {
+        embedder,
+        now: () => nowMs,
+      });
+
+      const expired = await store.createMemory({
+        content: expiredContent,
+        expiresAtMs: TEST_NOW_MS + 10,
+        idempotencyKey: "memory-test:read-expired",
+      });
+      const active = await store.createMemory({
+        content: activeContent,
+        idempotencyKey: "memory-test:read-active",
+      });
+      const superseded = await store.createMemory({
+        content: supersededContent,
+        expiresAtMs: TEST_NOW_MS + 10,
+        idempotencyKey: "memory-test:read-superseded",
+      });
+      await memoryDb(fixture)
+        .update(memorySqlSchema.juniorMemoryMemories)
+        .set({ supersededAtMs: TEST_NOW_MS + 1 })
+        .where(
+          eq(memorySqlSchema.juniorMemoryMemories.id, superseded.memory.id),
+        );
+      await expect(
+        memoryDb(fixture).select().from(memorySqlSchema.juniorMemoryEmbeddings),
+      ).resolves.toHaveLength(3);
+
+      nowMs = TEST_NOW_MS + 11;
+      await expect(store.listMemories({})).resolves.toEqual([
+        expect.objectContaining({ id: active.memory.id }),
+      ]);
+      await expect(
+        memoryDb(fixture)
+          .select()
+          .from(memorySqlSchema.juniorMemoryMemories)
+          .where(
+            eq(memorySqlSchema.juniorMemoryMemories.id, expired.memory.id),
+          ),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          archiveReason: "expired",
+          archivedAtMs: TEST_NOW_MS + 11,
+        }),
+      ]);
+      await expect(
+        memoryDb(fixture).select().from(memorySqlSchema.juniorMemoryEmbeddings),
+      ).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ memoryId: active.memory.id }),
+          expect.objectContaining({ memoryId: superseded.memory.id }),
+        ]),
+      );
+      await expect(
+        memoryDb(fixture).select().from(memorySqlSchema.juniorMemoryEmbeddings),
+      ).resolves.toHaveLength(2);
+      await expect(
+        memoryDb(fixture)
+          .select()
+          .from(memorySqlSchema.juniorMemoryMemories)
+          .where(
+            eq(memorySqlSchema.juniorMemoryMemories.id, superseded.memory.id),
+          ),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          archivedAtMs: null,
+          archiveReason: null,
+          supersededAtMs: TEST_NOW_MS + 1,
+        }),
+      ]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
   it("keeps memories searchable when embeddings have the wrong dimension", async () => {
     const fixture = await createMemoryFixture();
 
@@ -2157,12 +2247,15 @@ INSERT INTO junior_memory_memories (
 
     try {
       let nowMs = TEST_NOW_MS;
+      const content = "Temporarily prefers quiet deploy reminders.";
+      const embedder = createTestEmbedder({ [content]: unitEmbedding(1) });
       const store = createMemoryStore(memoryDb(fixture), slackContext(), {
+        embedder,
         now: () => nowMs,
       });
 
       const expired = await store.createMemory({
-        content: "Temporarily prefers quiet deploy reminders.",
+        content,
         expiresAtMs: TEST_NOW_MS + 10,
         idempotencyKey: "memory-test:expires",
       });
@@ -2171,14 +2264,11 @@ INSERT INTO junior_memory_memories (
       await expect(
         store.archiveMemory({ id: expired.memory.id }),
       ).rejects.toThrow("Memory was not found in the current context.");
-      await expect(store.searchMemories({ query: "quiet" })).resolves.toEqual(
-        [],
-      );
 
       nowMs = TEST_NOW_MS + 12;
       const recreated = await store.createMemory({
-        content: "Temporarily prefers quiet deploy reminders.",
-        idempotencyKey: "memory-test:expires-recreated",
+        content,
+        idempotencyKey: "memory-test:expires",
       });
 
       expect(recreated).toMatchObject({
@@ -2186,6 +2276,24 @@ INSERT INTO junior_memory_memories (
         memory: { content: expired.memory.content },
       });
       expect(recreated.memory.id).not.toBe(expired.memory.id);
+      await expect(
+        memoryDb(fixture)
+          .select()
+          .from(memorySqlSchema.juniorMemoryMemories)
+          .where(
+            eq(memorySqlSchema.juniorMemoryMemories.id, expired.memory.id),
+          ),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          archiveReason: "expired",
+          archivedAtMs: TEST_NOW_MS + 12,
+        }),
+      ]);
+      await expect(
+        memoryDb(fixture).select().from(memorySqlSchema.juniorMemoryEmbeddings),
+      ).resolves.toEqual([
+        expect.objectContaining({ memoryId: recreated.memory.id }),
+      ]);
       await expect(store.searchMemories({ query: "quiet" })).resolves.toEqual([
         expect.objectContaining({ id: recreated.memory.id }),
       ]);


### PR DESCRIPTION
Expired memory rows now archive from scoped memory store entry points instead of only being filtered out at read time. The archive path is bounded to visible scopes, skips already superseded rows, removes derived embeddings in the same transaction, and lets expired idempotency rows be recreated safely.

Passive memory extraction now runs the same cleanup before building existing-memory context, so expired rows do not keep influencing extraction retries. Coverage exercises archival, embedding cleanup, superseded-row preservation, and idempotent recreation after expiry.