### PR TITLE
fix(memory): Deduplicate memory writes

### DIFF
--- a/packages/junior-memory/src/store.ts
+++ b/packages/junior-memory/src/store.ts
@@ -696,7 +696,6 @@ async function rememberDuplicateIdempotency(args: {
   content: string;
   db: MemoryDb;
   duplicate: MemoryRecord;
-  expiresAtMs?: number;
   idempotencyKey?: string;
   nowMs: number;
   runtimeContext: MemoryRuntimeContext;
@@ -711,7 +710,7 @@ async function rememberDuplicateIdempotency(args: {
     .values({
       content: args.content,
       createdAtMs: args.nowMs,
-      expiresAtMs: args.expiresAtMs,
+      expiresAtMs: args.duplicate.expiresAtMs,
       id: idempotencyAliasId({
         idempotencyKey: args.idempotencyKey,
         scope: args.scope,
@@ -968,7 +967,6 @@ export function createMemoryStore(
         content,
         db,
         duplicate: exactDuplicate,
-        expiresAtMs: input.expiresAtMs,
         idempotencyKey: input.idempotencyKey,
         nowMs,
         runtimeContext,
@@ -1008,7 +1006,6 @@ export function createMemoryStore(
         content,
         db,
         duplicate: vectorDuplicate,
-        expiresAtMs: input.expiresAtMs,
         idempotencyKey: input.idempotencyKey,
         nowMs,
         runtimeContext,

--- a/packages/junior-memory/src/store.ts
+++ b/packages/junior-memory/src/store.ts
@@ -15,6 +15,7 @@ import {
   ilike,
   inArray,
   isNull,
+  isNotNull,
   like,
   lte,
   or,
@@ -40,6 +41,7 @@ import {
 import {
   deriveMemoryScope,
   deriveMemorySubject,
+  type ResolvedMemorySubject,
   deriveVisibleMemoryScopes,
   type ResolvedMemoryScope,
 } from "./scope";
@@ -47,6 +49,7 @@ import {
 const DEFAULT_LIST_LIMIT = 50;
 const DEFAULT_SEARCH_LIMIT = 10;
 const DEFAULT_EXPIRED_ARCHIVE_LIMIT = 100;
+const HIGH_CONFIDENCE_DUPLICATE_DISTANCE = 0.015;
 const VECTOR_SEARCH_OVERFETCH = 4;
 const MAX_MEMORY_CONTENT_CHARS = 4_000;
 const EMBEDDING_METRIC = "cosine";
@@ -56,6 +59,12 @@ export type MemoryDb = PgDatabase<PgQueryResultHKT, typeof memorySqlSchema>;
 interface SearchCandidate {
   memory: MemoryRecord;
   score: number;
+}
+
+interface MemoryEmbedding {
+  model: string;
+  provider: string;
+  vector: number[];
 }
 
 const nonEmptyStringSchema = z.string().min(1);
@@ -248,6 +257,22 @@ function hashEmbeddedContent(content: string): string {
   return createHash("sha256").update(content, "utf8").digest("hex");
 }
 
+function idempotencyAliasId(args: {
+  idempotencyKey: string;
+  scope: ResolvedMemoryScope;
+  targetId: string;
+}): string {
+  return `alias:${createHash("sha256")
+    .update(args.scope.scope)
+    .update("\0")
+    .update(args.scope.scopeKey)
+    .update("\0")
+    .update(args.idempotencyKey)
+    .update("\0")
+    .update(args.targetId)
+    .digest("hex")}`;
+}
+
 function boundedLimit(value: number | undefined, fallback: number): number {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     return fallback;
@@ -336,7 +361,7 @@ async function findByIdempotencyKey(args: {
   nowMs: number;
   scope: ResolvedMemoryScope;
 }): Promise<MemoryRecord | undefined> {
-  const rows = await args.db
+  const activeRows = await args.db
     .select()
     .from(juniorMemoryMemories)
     .where(
@@ -354,7 +379,58 @@ async function findByIdempotencyKey(args: {
       ),
     )
     .limit(1);
-  return rows[0] ? parseMemoryRow(rows[0]) : undefined;
+  if (activeRows[0]) {
+    return parseMemoryRow(activeRows[0]);
+  }
+
+  const aliasRows = await args.db
+    .select({ supersededById: juniorMemoryMemories.supersededById })
+    .from(juniorMemoryMemories)
+    .where(
+      and(
+        eq(juniorMemoryMemories.scope, args.scope.scope),
+        eq(juniorMemoryMemories.scopeKey, args.scope.scopeKey),
+        eq(juniorMemoryMemories.idempotencyKey, args.idempotencyKey),
+        isNull(juniorMemoryMemories.archivedAtMs),
+        isNotNull(juniorMemoryMemories.supersededAtMs),
+        isNotNull(juniorMemoryMemories.supersededById),
+        or(
+          isNull(juniorMemoryMemories.expiresAtMs),
+          gt(juniorMemoryMemories.expiresAtMs, args.nowMs),
+        ),
+      ),
+    )
+    .orderBy(
+      desc(juniorMemoryMemories.createdAtMs),
+      asc(juniorMemoryMemories.id),
+    );
+  for (const alias of aliasRows) {
+    if (!alias.supersededById) {
+      continue;
+    }
+    const rows = await args.db
+      .select()
+      .from(juniorMemoryMemories)
+      .where(
+        and(
+          eq(juniorMemoryMemories.id, alias.supersededById),
+          eq(juniorMemoryMemories.scope, args.scope.scope),
+          eq(juniorMemoryMemories.scopeKey, args.scope.scopeKey),
+          isNull(juniorMemoryMemories.archivedAtMs),
+          isNull(juniorMemoryMemories.supersededAtMs),
+          isNull(juniorMemoryMemories.supersededById),
+          or(
+            isNull(juniorMemoryMemories.expiresAtMs),
+            gt(juniorMemoryMemories.expiresAtMs, args.nowMs),
+          ),
+        ),
+      )
+      .limit(1);
+    if (rows[0]) {
+      return parseMemoryRow(rows[0]);
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -442,11 +518,7 @@ function searchTerms(query: string): string[] {
 async function embedOne(
   embedder: MemoryEmbeddingProvider,
   text: string,
-): Promise<{
-  model: string;
-  provider: string;
-  vector: number[];
-}> {
+): Promise<MemoryEmbedding> {
   const normalized = normalizeContent(text);
   if (!normalized) {
     throw new Error("Embedding text is required.");
@@ -469,10 +541,11 @@ async function storeEmbedding(args: {
   content: string;
   db: MemoryDb;
   embedder: MemoryEmbeddingProvider | undefined;
+  embedding?: MemoryEmbedding;
   memoryId: string;
   nowMs: number;
 }): Promise<void> {
-  if (!args.embedder) {
+  if (!args.embedder && !args.embedding) {
     return;
   }
   try {
@@ -488,10 +561,18 @@ async function storeEmbedding(args: {
     return;
   }
   let embedding: Awaited<ReturnType<typeof embedOne>>;
-  try {
-    embedding = await embedOne(args.embedder, args.content);
-  } catch {
-    return;
+  if (args.embedding) {
+    embedding = args.embedding;
+  } else {
+    const embedder = args.embedder;
+    if (!embedder) {
+      return;
+    }
+    try {
+      embedding = await embedOne(embedder, args.content);
+    } catch {
+      return;
+    }
   }
   try {
     await args.db
@@ -510,6 +591,145 @@ async function storeEmbedding(args: {
   } catch {
     return;
   }
+}
+
+function activeScopedSubjectPredicate(args: {
+  kind: MemoryRecord["kind"];
+  nowMs: number;
+  scope: ResolvedMemoryScope;
+  subject: ResolvedMemorySubject;
+}): SQL {
+  const predicate = and(
+    eq(juniorMemoryMemories.scope, args.scope.scope),
+    eq(juniorMemoryMemories.scopeKey, args.scope.scopeKey),
+    eq(juniorMemoryMemories.kind, args.kind),
+    eq(juniorMemoryMemories.subjectType, args.subject.subjectType),
+    args.subject.subjectKey === undefined
+      ? isNull(juniorMemoryMemories.subjectKey)
+      : eq(juniorMemoryMemories.subjectKey, args.subject.subjectKey),
+    isNull(juniorMemoryMemories.archivedAtMs),
+    isNull(juniorMemoryMemories.supersededAtMs),
+    isNull(juniorMemoryMemories.supersededById),
+    or(
+      isNull(juniorMemoryMemories.expiresAtMs),
+      gt(juniorMemoryMemories.expiresAtMs, args.nowMs),
+    ),
+  );
+  if (!predicate) {
+    throw new Error("Memory duplicate predicate is empty.");
+  }
+  return predicate;
+}
+
+async function findExactDuplicateMemory(args: {
+  content: string;
+  db: MemoryDb;
+  kind: MemoryRecord["kind"];
+  nowMs: number;
+  scope: ResolvedMemoryScope;
+  subject: ResolvedMemorySubject;
+}): Promise<MemoryRecord | undefined> {
+  const rows = await args.db
+    .select()
+    .from(juniorMemoryMemories)
+    .where(
+      and(
+        activeScopedSubjectPredicate(args),
+        eq(juniorMemoryMemories.content, args.content),
+      ),
+    )
+    .orderBy(
+      desc(juniorMemoryMemories.createdAtMs),
+      asc(juniorMemoryMemories.id),
+    )
+    .limit(1);
+  return rows[0] ? parseMemoryRow(rows[0]) : undefined;
+}
+
+async function findVectorDuplicateMemory(args: {
+  db: MemoryDb;
+  embedding: MemoryEmbedding;
+  kind: MemoryRecord["kind"];
+  nowMs: number;
+  scope: ResolvedMemoryScope;
+  subject: ResolvedMemorySubject;
+}): Promise<MemoryRecord | undefined> {
+  const distance = cosineDistance(
+    juniorMemoryEmbeddings.embedding,
+    args.embedding.vector,
+  );
+  const rows = await args.db
+    .select({
+      contentHash: juniorMemoryEmbeddings.contentHash,
+      distance,
+      memory: juniorMemoryMemories,
+    })
+    .from(juniorMemoryMemories)
+    .innerJoin(
+      juniorMemoryEmbeddings,
+      eq(juniorMemoryEmbeddings.memoryId, juniorMemoryMemories.id),
+    )
+    .where(
+      and(
+        activeScopedSubjectPredicate(args),
+        eq(juniorMemoryEmbeddings.provider, args.embedding.provider),
+        eq(juniorMemoryEmbeddings.model, args.embedding.model),
+        eq(juniorMemoryEmbeddings.dimensions, MEMORY_EMBEDDING_DIMENSIONS),
+        eq(juniorMemoryEmbeddings.metric, EMBEDDING_METRIC),
+        lte(distance, HIGH_CONFIDENCE_DUPLICATE_DISTANCE),
+      ),
+    )
+    .orderBy(
+      distance,
+      desc(juniorMemoryMemories.createdAtMs),
+      asc(juniorMemoryMemories.id),
+    )
+    .limit(1);
+  const row = rows[0];
+  if (!row || hashEmbeddedContent(row.memory.content) !== row.contentHash) {
+    return undefined;
+  }
+  return parseMemoryRow(row.memory);
+}
+
+async function rememberDuplicateIdempotency(args: {
+  content: string;
+  db: MemoryDb;
+  duplicate: MemoryRecord;
+  expiresAtMs?: number;
+  idempotencyKey?: string;
+  nowMs: number;
+  runtimeContext: MemoryRuntimeContext;
+  scope: ResolvedMemoryScope;
+  subject: ResolvedMemorySubject;
+}): Promise<void> {
+  if (args.idempotencyKey === undefined) {
+    return;
+  }
+  await args.db
+    .insert(juniorMemoryMemories)
+    .values({
+      content: args.content,
+      createdAtMs: args.nowMs,
+      expiresAtMs: args.expiresAtMs,
+      id: idempotencyAliasId({
+        idempotencyKey: args.idempotencyKey,
+        scope: args.scope,
+        targetId: args.duplicate.id,
+      }),
+      idempotencyKey: args.idempotencyKey,
+      observedAtMs: args.nowMs,
+      scope: args.scope.scope,
+      scopeKey: args.scope.scopeKey,
+      sourceKey: sourceKey(args.runtimeContext),
+      sourcePlatform: args.runtimeContext.source.platform,
+      subjectKey: args.subject.subjectKey,
+      subjectType: args.subject.subjectType,
+      supersededAtMs: args.nowMs,
+      supersededById: args.duplicate.id,
+      kind: args.duplicate.kind,
+    })
+    .onConflictDoNothing();
 }
 
 /** List active records for the runtime-derived visible scopes. */
@@ -716,6 +936,94 @@ export function createMemoryStore(
       nowMs,
       scopes: [scope],
     });
+    if (input.idempotencyKey !== undefined) {
+      const idempotent = await findByIdempotencyKey({
+        db,
+        idempotencyKey: input.idempotencyKey,
+        nowMs,
+        scope,
+      });
+      if (idempotent) {
+        await storeEmbedding({
+          content: idempotent.content,
+          db,
+          embedder,
+          memoryId: idempotent.id,
+          nowMs,
+        });
+        return { created: false, memory: idempotent };
+      }
+    }
+
+    const exactDuplicate = await findExactDuplicateMemory({
+      content,
+      db,
+      kind: input.kind,
+      nowMs,
+      scope,
+      subject,
+    });
+    if (exactDuplicate) {
+      await rememberDuplicateIdempotency({
+        content,
+        db,
+        duplicate: exactDuplicate,
+        expiresAtMs: input.expiresAtMs,
+        idempotencyKey: input.idempotencyKey,
+        nowMs,
+        runtimeContext,
+        scope,
+        subject,
+      });
+      await storeEmbedding({
+        content: exactDuplicate.content,
+        db,
+        embedder,
+        memoryId: exactDuplicate.id,
+        nowMs,
+      });
+      return { created: false, memory: exactDuplicate };
+    }
+
+    let candidateEmbedding: MemoryEmbedding | undefined;
+    if (embedder) {
+      try {
+        candidateEmbedding = await embedOne(embedder, content);
+      } catch {
+        candidateEmbedding = undefined;
+      }
+    }
+    const vectorDuplicate = candidateEmbedding
+      ? await findVectorDuplicateMemory({
+          db,
+          embedding: candidateEmbedding,
+          kind: input.kind,
+          nowMs,
+          scope,
+          subject,
+        })
+      : undefined;
+    if (vectorDuplicate) {
+      await rememberDuplicateIdempotency({
+        content,
+        db,
+        duplicate: vectorDuplicate,
+        expiresAtMs: input.expiresAtMs,
+        idempotencyKey: input.idempotencyKey,
+        nowMs,
+        runtimeContext,
+        scope,
+        subject,
+      });
+      await storeEmbedding({
+        content: vectorDuplicate.content,
+        db,
+        embedder,
+        memoryId: vectorDuplicate.id,
+        nowMs,
+      });
+      return { created: false, memory: vectorDuplicate };
+    }
 
     const id = randomUUID();
     const rows = await db
@@ -750,6 +1058,7 @@ export function createMemoryStore(
         content: memory.content,
         db,
         embedder,
+        embedding: candidateEmbedding,
         memoryId: memory.id,
         nowMs,
       });

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -1580,6 +1580,164 @@ WHERE id = '${superseded.memory.id}'
     }
   }, 15_000);
 
+  it("returns an existing same-kind memory for exact duplicate content", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      const store = createMemoryStore(memoryDb(fixture), slackContext(), {
+        now: () => TEST_NOW_MS,
+      });
+
+      const created = await store.createMemory({
+        content: "Prefers release notes with risk callouts.",
+        kind: "preference",
+        idempotencyKey: "memory-test:exact-dedup-original",
+      });
+      await expect(
+        store.createMemory({
+          content: "  Prefers release notes\nwith risk callouts.  ",
+          kind: "preference",
+          idempotencyKey: "memory-test:exact-dedup-repeat",
+        }),
+      ).resolves.toMatchObject({
+        created: false,
+        memory: { id: created.memory.id },
+      });
+      await expect(
+        store.createMemory({
+          content: "Changed retry content must not create a duplicate.",
+          kind: "preference",
+          idempotencyKey: "memory-test:exact-dedup-repeat",
+        }),
+      ).resolves.toMatchObject({
+        created: false,
+        memory: { id: created.memory.id },
+      });
+      const otherKind = await store.createMemory({
+        content: "Prefers release notes with risk callouts.",
+        kind: "knowledge",
+        idempotencyKey: "memory-test:exact-dedup-other-kind",
+      });
+      expect(otherKind).toMatchObject({
+        created: true,
+        memory: { content: created.memory.content, kind: "knowledge" },
+      });
+      const otherScope = await store.createConversationMemory({
+        content: "Prefers release notes with risk callouts.",
+        kind: "preference",
+        idempotencyKey: "memory-test:exact-dedup-other-scope",
+      });
+      expect(otherScope).toMatchObject({
+        created: true,
+        memory: { content: created.memory.content, kind: "preference" },
+      });
+
+      await expect(store.listMemories({})).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: otherScope.memory.id }),
+          expect.objectContaining({ id: otherKind.memory.id }),
+          expect.objectContaining({ id: created.memory.id }),
+        ]),
+      );
+      await expect(store.listMemories({})).resolves.toHaveLength(3);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("preserves vector duplicate retry identity", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      const firstContent = "Prefers weekly summaries in bullet form.";
+      const duplicateContent = "Likes weekly updates as bullet lists.";
+      const embedder = createTestEmbedder({
+        [firstContent]: unitEmbedding(1),
+        [duplicateContent]: unitEmbedding(1),
+      });
+      const store = createMemoryStore(memoryDb(fixture), slackContext(), {
+        embedder,
+        now: () => TEST_NOW_MS,
+      });
+
+      const created = await store.createMemory({
+        content: firstContent,
+        kind: "preference",
+        idempotencyKey: "memory-test:vector-dedup-idempotent-original",
+      });
+      await expect(
+        store.createMemory({
+          content: duplicateContent,
+          kind: "preference",
+          idempotencyKey: "memory-test:vector-dedup-idempotent-repeat",
+        }),
+      ).resolves.toMatchObject({
+        created: false,
+        memory: { id: created.memory.id, content: firstContent },
+      });
+      await expect(
+        store.createMemory({
+          content: "Changed retry content should stay deduped.",
+          kind: "preference",
+          idempotencyKey: "memory-test:vector-dedup-idempotent-repeat",
+        }),
+      ).resolves.toMatchObject({
+        created: false,
+        memory: { id: created.memory.id, content: firstContent },
+      });
+
+      await expect(store.listMemories({})).resolves.toEqual([
+        expect.objectContaining({ id: created.memory.id }),
+      ]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("returns an existing same-kind memory for high-confidence vector duplicates", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      const firstContent = "Prefers weekly summaries in bullet form.";
+      const duplicateContent = "Likes weekly updates as bullet lists.";
+      const embedder = createTestEmbedder({
+        [firstContent]: unitEmbedding(1),
+        [duplicateContent]: unitEmbedding(1),
+      });
+      const store = createMemoryStore(memoryDb(fixture), slackContext(), {
+        embedder,
+        now: () => TEST_NOW_MS,
+      });
+
+      const created = await store.createMemory({
+        content: firstContent,
+        kind: "preference",
+        idempotencyKey: "memory-test:vector-dedup-original",
+      });
+      await expect(
+        store.createMemory({
+          content: duplicateContent,
+          kind: "preference",
+          idempotencyKey: "memory-test:vector-dedup-repeat",
+        }),
+      ).resolves.toMatchObject({
+        created: false,
+        memory: { id: created.memory.id, content: firstContent },
+      });
+
+      await expect(store.listMemories({})).resolves.toEqual([
+        expect.objectContaining({ id: created.memory.id }),
+      ]);
+      await expect(
+        memoryDb(fixture).select().from(memorySqlSchema.juniorMemoryEmbeddings),
+      ).resolves.toEqual([
+        expect.objectContaining({ memoryId: created.memory.id }),
+      ]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
   it("backfills missing embeddings on idempotent create retries", async () => {
     const fixture = await createMemoryFixture();
 

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -1584,8 +1584,9 @@ WHERE id = '${superseded.memory.id}'
     const fixture = await createMemoryFixture();
 
     try {
+      let nowMs = TEST_NOW_MS;
       const store = createMemoryStore(memoryDb(fixture), slackContext(), {
-        now: () => TEST_NOW_MS,
+        now: () => nowMs,
       });
 
       const created = await store.createMemory({
@@ -1597,12 +1598,14 @@ WHERE id = '${superseded.memory.id}'
         store.createMemory({
           content: "  Prefers release notes\nwith risk callouts.  ",
           kind: "preference",
+          expiresAtMs: TEST_NOW_MS + 1,
           idempotencyKey: "memory-test:exact-dedup-repeat",
         }),
       ).resolves.toMatchObject({
         created: false,
         memory: { id: created.memory.id },
       });
+      nowMs = TEST_NOW_MS + 2;
       await expect(
         store.createMemory({
           content: "Changed retry content must not create a duplicate.",

--- a/specs/memory-plugin/storage.md
+++ b/specs/memory-plugin/storage.md
@@ -133,9 +133,12 @@ Passive extraction must be idempotent across repeated completed-session task
 scheduling, queue redelivery, and task retry. The store needs a stable source
 marker for a completed session and each extracted fact.
 
-Semantic duplicate suppression needs extractor and retrieval context. It runs
-before insertion in memory creation paths that have memory agent review, but V1
-storage does not use exact-content hashing as memory identity.
+Semantic duplicate suppression needs extractor and retrieval context. V1 store
+writes also enforce a conservative duplicate gate before insertion for active
+memories in the same scope, subject, and kind, using exact normalized-content
+equality and very-high embedding similarity when embeddings are available.
+Exact content remains one suppression signal, not a durable identity for memory
+facts.
 
 ### Lexical Search
 


### PR DESCRIPTION
Memory writes now do a conservative duplicate check before inserting active rows in the same scope, subject, and kind. Exact normalized content and very-high vector similarity return the existing memory instead of adding another active row.

Duplicate-suppressed writes still preserve the incoming idempotency key through a hidden superseded alias row, so retries with the same key resolve to the original memory rather than creating a later duplicate. The storage spec and focused memory-store coverage were updated for that contract.