### PR TITLE
fix(sentry): Filter private conversation payloads

### DIFF
--- a/packages/junior/src/chat/conversation-privacy.ts
+++ b/packages/junior/src/chat/conversation-privacy.ts
@@ -1,8 +1,10 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { parseSlackThreadId } from "@/chat/slack/context";
 
 export type ConversationPrivacy = "public" | "private";
 type TraceAttributeValue = string | number | boolean | string[];
 const SAFE_METADATA_KEY_LIMIT = 20;
+const conversationPrivacyStorage = new AsyncLocalStorage<ConversationPrivacy>();
 
 function conversationPrivacyFromChannelId(
   channelId: string | undefined,
@@ -40,6 +42,21 @@ export function canExposeConversationPayload(input: {
   conversationId?: string;
 }): boolean {
   return resolveConversationPrivacy(input) === "public";
+}
+
+/** Return the privacy mode bound to the current agent turn. */
+export function getCurrentConversationPrivacy():
+  | ConversationPrivacy
+  | undefined {
+  return conversationPrivacyStorage.getStore();
+}
+
+/** Bind one conversation privacy mode to all async work in a turn. */
+export function runWithConversationPrivacy<T>(
+  privacy: ConversationPrivacy,
+  callback: () => T,
+): T {
+  return conversationPrivacyStorage.run(privacy, callback);
 }
 
 function contentMetadata(content: unknown): unknown {

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -150,8 +150,10 @@ import {
 } from "@/chat/services/auth-pause";
 import {
   resolveConversationPrivacy,
+  runWithConversationPrivacy,
   toGenAiMessageMetadata,
   toGenAiMessagesTraceAttributes,
+  type ConversationPrivacy,
 } from "@/chat/conversation-privacy";
 
 // Re-export types for backward compatibility with existing consumers.
@@ -573,6 +575,27 @@ export async function generateAssistantReply(
   messageText: string,
   context: AssistantReplyRequestContext,
 ): Promise<AssistantReply> {
+  const conversationPrivacy = resolveConversationPrivacy({
+    channelId: context.correlation?.channelId,
+    conversationId:
+      context.correlation?.conversationId ??
+      context.correlation?.threadId ??
+      context.correlation?.runId,
+  });
+  return runWithConversationPrivacy(conversationPrivacy ?? "private", () =>
+    generateAssistantReplyInPrivacyContext(
+      messageText,
+      context,
+      conversationPrivacy,
+    ),
+  );
+}
+
+async function generateAssistantReplyInPrivacyContext(
+  messageText: string,
+  context: AssistantReplyRequestContext,
+  conversationPrivacy: ConversationPrivacy | undefined,
+): Promise<AssistantReply> {
   if (!context.destination) {
     throw new TypeError("Assistant reply generation requires a destination");
   }
@@ -624,13 +647,6 @@ export async function generateAssistantReply(
             : credentialActor.id,
       }
     : {};
-  const conversationPrivacy = resolveConversationPrivacy({
-    channelId: context.correlation?.channelId,
-    conversationId:
-      context.correlation?.conversationId ??
-      context.correlation?.threadId ??
-      context.correlation?.runId,
-  });
   const sessionRecordLogContext = {
     threadId: context.correlation?.threadId,
     requesterId: context.correlation?.requesterId,

--- a/packages/junior/src/chat/sentry-payload-filter.ts
+++ b/packages/junior/src/chat/sentry-payload-filter.ts
@@ -1,0 +1,104 @@
+import { getCurrentConversationPrivacy } from "@/chat/conversation-privacy";
+import type * as Sentry from "@/chat/sentry";
+
+type AttributeMap = Record<string, unknown>;
+type AttributeContainer = {
+  attributes?: AttributeMap;
+  data?: AttributeMap;
+};
+type SentryErrorEvent = Parameters<
+  NonNullable<Sentry.NodeOptions["beforeSend"]>
+>[0];
+type SentryTransactionEvent = Parameters<
+  NonNullable<Sentry.NodeOptions["beforeSendTransaction"]>
+>[0];
+type SentrySpan = Parameters<Parameters<typeof Sentry.withStreamedSpan>[0]>[0];
+type SentryLog = Parameters<
+  NonNullable<Sentry.NodeOptions["beforeSendLog"]>
+>[0];
+
+const PAYLOAD_ATTRIBUTE_KEYS = new Set([
+  "app.message.input",
+  "app.message.output",
+  "gen_ai.input.messages",
+  "gen_ai.output.messages",
+  "gen_ai.system_instructions",
+  "gen_ai.tool.call.arguments",
+  "gen_ai.tool.call.result",
+]);
+
+function hasPayloadAttributes(attributes: AttributeMap): boolean {
+  return Object.keys(attributes).some((key) => PAYLOAD_ATTRIBUTE_KEYS.has(key));
+}
+
+function shouldScrubPayloads(attributes: AttributeMap): boolean {
+  if (!hasPayloadAttributes(attributes)) {
+    return false;
+  }
+  return getCurrentConversationPrivacy() !== "public";
+}
+
+function scrubPayloadAttributes(attributes: AttributeMap | undefined): void {
+  if (!attributes) {
+    return;
+  }
+
+  if (!shouldScrubPayloads(attributes)) {
+    return;
+  }
+
+  for (const key of PAYLOAD_ATTRIBUTE_KEYS) {
+    delete attributes[key];
+  }
+  attributes["app.conversation.payload_redacted"] = true;
+}
+
+function scrubContainer(container: AttributeContainer | undefined): void {
+  if (!container) {
+    return;
+  }
+  scrubPayloadAttributes(container.data);
+  scrubPayloadAttributes(container.attributes);
+}
+
+/** Remove raw private conversation payloads from Sentry error events. */
+export function scrubPrivateSentryEvent(
+  event: SentryErrorEvent,
+): SentryErrorEvent | null {
+  const eventRecord = event as AttributeContainer;
+  scrubContainer(eventRecord);
+  scrubContainer(event.contexts?.trace as AttributeContainer);
+
+  for (const breadcrumb of event.breadcrumbs ?? []) {
+    scrubContainer(breadcrumb as AttributeContainer);
+  }
+
+  return event;
+}
+
+/** Remove raw private conversation payloads from Sentry transaction events. */
+export function scrubPrivateSentryTransaction(
+  event: SentryTransactionEvent,
+): SentryTransactionEvent | null {
+  const eventRecord = event as AttributeContainer;
+  scrubContainer(eventRecord);
+  scrubContainer(event.contexts?.trace as AttributeContainer);
+
+  for (const span of event.spans ?? []) {
+    scrubContainer(span);
+  }
+
+  return event;
+}
+
+/** Remove raw private conversation payloads from streamed Sentry spans. */
+export function scrubPrivateSentrySpan(span: SentrySpan): SentrySpan {
+  scrubContainer(span);
+  return span;
+}
+
+/** Remove raw private conversation payloads from Sentry structured logs. */
+export function scrubPrivateSentryLog(log: SentryLog): SentryLog | null {
+  scrubContainer(log);
+  return log;
+}

--- a/packages/junior/src/chat/sentry.ts
+++ b/packages/junior/src/chat/sentry.ts
@@ -13,5 +13,6 @@ export {
   vercelAIIntegration,
   withActiveSpan,
   withScope,
+  withStreamedSpan,
 } from "@sentry/node";
 export * from "@sentry/node";

--- a/packages/junior/src/instrumentation.ts
+++ b/packages/junior/src/instrumentation.ts
@@ -1,5 +1,11 @@
 import * as Sentry from "@/chat/sentry";
 import {
+  scrubPrivateSentryEvent,
+  scrubPrivateSentryLog,
+  scrubPrivateSentrySpan,
+  scrubPrivateSentryTransaction,
+} from "@/chat/sentry-payload-filter";
+import {
   getDeploymentServiceVersion,
   getDeploymentTelemetryAttributes,
 } from "@/deployment";
@@ -42,6 +48,10 @@ export function initSentry(): void {
     enableLogs,
     registerEsmLoaderHooks: false,
     streamGenAiSpans: true,
+    beforeSend: scrubPrivateSentryEvent,
+    beforeSendLog: scrubPrivateSentryLog,
+    beforeSendSpan: Sentry.withStreamedSpan(scrubPrivateSentrySpan),
+    beforeSendTransaction: scrubPrivateSentryTransaction,
     integrations: [
       Sentry.vercelAIIntegration({
         recordInputs: true,

--- a/packages/junior/tests/unit/instrumentation.test.ts
+++ b/packages/junior/tests/unit/instrumentation.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { runWithConversationPrivacy } from "@/chat/conversation-privacy";
 
 const ORIGINAL_SENTRY_DSN = process.env.SENTRY_DSN;
 const ORIGINAL_SENTRY_RELEASE = process.env.SENTRY_RELEASE;
@@ -36,7 +37,13 @@ async function loadInstrumentationModule() {
     getClient: () => undefined,
     init,
     getGlobalScope: () => globalScope,
-    vercelAIIntegration: () => ({ name: "vercel-ai" }),
+    vercelAIIntegration: vi.fn((options) => ({
+      name: "vercel-ai",
+      options,
+    })),
+    withStreamedSpan: vi.fn((callback) =>
+      Object.assign(callback, { _streamed: true }),
+    ),
   }));
   const instrumentation = await import("@/instrumentation");
   return { init, globalScope, instrumentation };
@@ -63,6 +70,47 @@ describe("initSentry", () => {
     expect(init).toHaveBeenCalledTimes(1);
     const options = init.mock.calls[0]?.[0];
     expect(options?.release).toBe("git-sha");
+    expect(options).toMatchObject({
+      sendDefaultPii: true,
+      streamGenAiSpans: true,
+    });
+    expect(options?.beforeSend).toEqual(expect.any(Function));
+    expect(options?.beforeSendLog).toEqual(expect.any(Function));
+    expect(options?.beforeSendSpan).toEqual(expect.any(Function));
+    expect(options?.beforeSendSpan?._streamed).toBe(true);
+    expect(options?.beforeSendTransaction).toEqual(expect.any(Function));
+    expect(options?.integrations?.[0]).toMatchObject({
+      options: {
+        recordInputs: true,
+        recordOutputs: true,
+      },
+    });
+    const span: {
+      attributes: Record<string, unknown>;
+      end_timestamp: number;
+      is_segment: boolean;
+      name: string;
+      span_id: string;
+      start_timestamp: number;
+      status: "ok";
+      trace_id: string;
+    } = {
+      attributes: {
+        "gen_ai.input.messages": "private input",
+      },
+      end_timestamp: 2,
+      is_segment: false,
+      name: "gen_ai.chat",
+      span_id: "span",
+      start_timestamp: 1,
+      status: "ok",
+      trace_id: "trace",
+    };
+    runWithConversationPrivacy("private", () =>
+      options?.beforeSendSpan?.(span),
+    );
+    expect(span.attributes["gen_ai.input.messages"]).toBeUndefined();
+    expect(span.attributes["app.conversation.payload_redacted"]).toBe(true);
 
     expect(globalScope.setAttributes).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/junior/tests/unit/sentry-payload-filter.test.ts
+++ b/packages/junior/tests/unit/sentry-payload-filter.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { runWithConversationPrivacy } from "@/chat/conversation-privacy";
+import {
+  scrubPrivateSentryLog,
+  scrubPrivateSentrySpan,
+  scrubPrivateSentryTransaction,
+} from "@/chat/sentry-payload-filter";
+
+type SentrySpan = Parameters<typeof scrubPrivateSentrySpan>[0];
+type SentryLog = Parameters<typeof scrubPrivateSentryLog>[0];
+type SentryTransaction = Parameters<typeof scrubPrivateSentryTransaction>[0];
+
+function messageAttribute(text: string): string {
+  return JSON.stringify([{ role: "user", content: text }]);
+}
+
+describe("Sentry private payload filtering", () => {
+  it("removes private span payload attributes", () => {
+    const span = {
+      attributes: {
+        "app.conversation.privacy": "private",
+        "gen_ai.input.messages": messageAttribute("private prompt"),
+        "gen_ai.output.messages": messageAttribute("private answer"),
+        "gen_ai.system_instructions": JSON.stringify([
+          { type: "text", content: "private system" },
+        ]),
+      },
+      end_timestamp: 2,
+      is_segment: false,
+      name: "gen_ai.chat",
+      span_id: "span",
+      start_timestamp: 1,
+      status: "ok",
+      trace_id: "trace",
+    } as SentrySpan;
+
+    runWithConversationPrivacy("private", () => scrubPrivateSentrySpan(span));
+
+    expect(span.attributes?.["gen_ai.input.messages"]).toBeUndefined();
+    expect(span.attributes?.["gen_ai.output.messages"]).toBeUndefined();
+    expect(span.attributes?.["gen_ai.system_instructions"]).toBeUndefined();
+    expect(span.attributes?.["app.conversation.payload_redacted"]).toBe(true);
+  });
+
+  it("preserves public channel payloads", () => {
+    const payload = messageAttribute("public prompt");
+    const span = {
+      attributes: {
+        "gen_ai.input.messages": payload,
+      },
+      end_timestamp: 2,
+      is_segment: false,
+      name: "gen_ai.chat",
+      span_id: "span",
+      start_timestamp: 1,
+      status: "ok",
+      trace_id: "trace",
+    } as SentrySpan;
+
+    runWithConversationPrivacy("public", () => scrubPrivateSentrySpan(span));
+
+    expect(span.attributes?.["gen_ai.input.messages"]).toBe(payload);
+    expect(
+      span.attributes?.["app.conversation.payload_redacted"],
+    ).toBeUndefined();
+  });
+
+  it("fails closed for payload attributes without conversation privacy", () => {
+    const log = {
+      level: "info",
+      message: "ai_call",
+      attributes: {
+        "gen_ai.tool.call.arguments": JSON.stringify({
+          query: "private search",
+        }),
+      },
+    } as SentryLog;
+
+    scrubPrivateSentryLog(log);
+
+    expect(log.attributes?.["gen_ai.tool.call.arguments"]).toBeUndefined();
+    expect(log.attributes?.["app.conversation.payload_redacted"]).toBe(true);
+  });
+
+  it("uses the current conversation privacy for transaction child spans", () => {
+    const payload = messageAttribute("public answer");
+    const transaction = {
+      type: "transaction",
+      spans: [
+        {
+          data: {
+            "gen_ai.output.messages": payload,
+          },
+          span_id: "child",
+          start_timestamp: 1,
+          trace_id: "trace",
+        },
+      ],
+    } as SentryTransaction;
+
+    runWithConversationPrivacy("public", () =>
+      scrubPrivateSentryTransaction(transaction),
+    );
+
+    expect(transaction.spans?.[0]?.data["gen_ai.output.messages"]).toBe(
+      payload,
+    );
+  });
+});


### PR DESCRIPTION
Sentry now strips raw model, message, and tool payload attributes unless the active agent turn is known to be public. The privacy mode is bound to the async turn context, so private and unknown conversations fail closed while public Slack channels keep the existing payload visibility.

The Sentry SDK defaults stay unchanged: PII collection, streamed GenAI spans, and Vercel AI input/output recording remain enabled. The new core hooks filter events, logs, transaction spans, and streamed spans before they leave the process.

Fixes GH-394