### PR TITLE
docs(cloudflare): Add plugin docs navigation

### DIFF
--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -19,10 +19,12 @@ export default defineConfig({
     "/deploy/vercel": "/start-here/deploy-to-vercel",
     "/extend/custom-plugins": "/extend/build-a-plugin",
     "/extend/plugins-overview": "/extend",
+    "/extend/cloudflare": "/extend/cloudflare-plugin",
     "/extend/datadog": "/extend/datadog-plugin",
     "/extend/hex": "/extend/hex-plugin",
     "/plugins/overview": "/extend",
     "/plugins/agent-browser": "/extend/agent-browser-plugin",
+    "/plugins/cloudflare": "/extend/cloudflare-plugin",
     "/plugins/datadog": "/extend/datadog-plugin",
     "/plugins/github": "/extend/github-plugin",
     "/plugins/hex": "/extend/hex-plugin",
@@ -101,6 +103,10 @@ export default defineConfig({
             {
               label: "Agent Browser Plugin",
               link: "/extend/agent-browser-plugin/",
+            },
+            {
+              label: "Cloudflare Plugin",
+              link: "/extend/cloudflare-plugin/",
             },
             { label: "Datadog Plugin", link: "/extend/datadog-plugin/" },
             { label: "GitHub Plugin", link: "/extend/github-plugin/" },

--- a/packages/docs/src/content/docs/cli/init.md
+++ b/packages/docs/src/content/docs/cli/init.md
@@ -25,8 +25,8 @@ The command requires exactly one argument: the target directory.
 
 The scaffold includes:
 
-- `package.json` with `@sentry/junior`, `@sentry/junior-maintenance`, `hono`, `nitro`, `vite`, `typescript`, and `jiti`
-- `plugins.ts` with `@sentry/junior-maintenance` enabled
+- `package.json` with `@sentry/junior`, `@sentry/junior-maintenance`, `@sentry/junior-memory`, `hono`, `nitro`, `vite`, `typescript`, and `jiti`
+- `plugins.ts` with `@sentry/junior-maintenance` and `createMemoryPlugin()` enabled
 - `server.ts`
 - `nitro.config.ts` pointing at `./plugins`
 - `vite.config.ts`
@@ -41,7 +41,7 @@ The scaffold includes:
 
 `SOUL.md` sets Junior's default voice, `WORLD.md` holds operational context, and `DESCRIPTION.md` powers the user-facing app description. Add other `app/*.md` files only when you want optional reference material available to the agent at runtime. `ABOUT.md` is not part of the scaffold and is not supported.
 
-The generated `plugins.ts` enables `@sentry/junior-maintenance` by default, which provides the `self-update` skill for keeping Junior packages current. It is also the place to add other packaged plugins later.
+The generated `plugins.ts` enables `@sentry/junior-maintenance` and `createMemoryPlugin()` by default. Maintenance provides the `self-update` skill for keeping Junior packages current, and memory provides long-term recall once you configure Postgres with pgvector. `plugins.ts` is also the place to add other packaged plugins later.
 
 This gives you the supported app shape needed to run Junior locally, keep the app updated, and continue with plugin or skill setup.
 

--- a/packages/docs/src/content/docs/extend/cloudflare-plugin.md
+++ b/packages/docs/src/content/docs/extend/cloudflare-plugin.md
@@ -40,14 +40,17 @@ export const plugins = defineJuniorPlugins(["@sentry/junior-cloudflare"]);
 
 ## Optional channel defaults
 
-If a Slack channel consistently works with the same Cloudflare account or zone, store those as conversation-scoped defaults:
+If a Slack channel consistently works with the same Cloudflare account, zone, or Worker, store those as conversation-scoped defaults:
 
 ```bash
 jr-rpc config set cloudflare.account.id <account_id>
 jr-rpc config set cloudflare.zone.id <zone_id>
+jr-rpc config set cloudflare.worker.name sentry-mcp
 ```
 
-These defaults are optional. When not set, Junior discovers the account and zone from the API on first use (requires Account Resources: Read permission). If the user names a different account or zone in a request, Junior follows the explicit request instead.
+These defaults are optional. When not set, Junior discovers the account, zone, or Worker from the API on first use (requires Account Resources: Read permission). If the user names a different account, zone, or Worker in a request, Junior follows the explicit request instead.
+
+Use `cloudflare.worker.name` for the Worker a channel usually investigates. For example, if most operations in a channel are about the `sentry-mcp` Worker, this default lets users ask "check the latest errors" or "show the recent deploy" without repeating the Worker name.
 
 ## What users can do
 

--- a/packages/docs/src/content/docs/extend/index.md
+++ b/packages/docs/src/content/docs/extend/index.md
@@ -59,7 +59,7 @@ my-junior-plugin/
 For reuse across apps or teams, package plugin manifests and any bundled skills as npm packages and install them next to `@sentry/junior`.
 
 ```bash
-pnpm add @sentry/junior @sentry/junior-agent-browser @sentry/junior-cloudflare @sentry/junior-datadog @sentry/junior-github @sentry/junior-hex @sentry/junior-linear @sentry/junior-maintenance @sentry/junior-notion @sentry/junior-scheduler @sentry/junior-sentry @sentry/junior-vercel
+pnpm add @sentry/junior @sentry/junior-agent-browser @sentry/junior-cloudflare @sentry/junior-datadog @sentry/junior-github @sentry/junior-hex @sentry/junior-linear @sentry/junior-maintenance @sentry/junior-memory @sentry/junior-notion @sentry/junior-scheduler @sentry/junior-sentry @sentry/junior-vercel
 ```
 
 Create one runtime-safe plugin set and point `juniorNitro()` at that module.
@@ -70,11 +70,14 @@ runtime.
 
 ```ts title="plugins.ts"
 import { defineJuniorPlugins } from "@sentry/junior";
+import { createMemoryPlugin } from "@sentry/junior-memory";
 import { githubPlugin } from "@sentry/junior-github";
 import { schedulerPlugin } from "@sentry/junior-scheduler";
 
 export const plugins = defineJuniorPlugins([
+  createMemoryPlugin(),
   "@sentry/junior-agent-browser",
+  "@sentry/junior-cloudflare",
   "@sentry/junior-datadog",
   githubPlugin({
     botNameEnv: "GITHUB_APP_BOT_NAME",
@@ -86,6 +89,7 @@ export const plugins = defineJuniorPlugins([
   "@sentry/junior-notion",
   schedulerPlugin(),
   "@sentry/junior-sentry",
+  "@sentry/junior-vercel",
 ]);
 ```
 

--- a/packages/docs/src/content/docs/start-here/quickstart.md
+++ b/packages/docs/src/content/docs/start-here/quickstart.md
@@ -103,22 +103,26 @@ New apps created with `junior init` already have a `plugins.ts` file with mainte
 
 For an existing app created without a `plugins.ts`, create one as shown below.
 
-Install only the plugins you plan to enable:
+Install only the plugins you plan to enable. If you are creating `plugins.ts`
+for an existing app, include the default maintenance and memory packages too:
 
 ```bash
-pnpm add @sentry/junior-agent-browser @sentry/junior-datadog @sentry/junior-github @sentry/junior-hex @sentry/junior-linear @sentry/junior-notion @sentry/junior-scheduler @sentry/junior-sentry @sentry/junior-vercel
+pnpm add @sentry/junior-maintenance @sentry/junior-memory @sentry/junior-agent-browser @sentry/junior-cloudflare @sentry/junior-datadog @sentry/junior-github @sentry/junior-hex @sentry/junior-linear @sentry/junior-notion @sentry/junior-scheduler @sentry/junior-sentry @sentry/junior-vercel
 ```
 
 Add them to the plugin set in `plugins.ts`:
 
 ```ts title="plugins.ts"
 import { defineJuniorPlugins } from "@sentry/junior";
+import { createMemoryPlugin } from "@sentry/junior-memory";
 import { githubPlugin } from "@sentry/junior-github";
 import { schedulerPlugin } from "@sentry/junior-scheduler";
 
 export const plugins = defineJuniorPlugins([
+  createMemoryPlugin(),
   "@sentry/junior-maintenance",
   "@sentry/junior-agent-browser",
+  "@sentry/junior-cloudflare",
   "@sentry/junior-datadog",
   githubPlugin({
     botNameEnv: "GITHUB_APP_BOT_NAME",
@@ -129,6 +133,7 @@ export const plugins = defineJuniorPlugins([
   "@sentry/junior-notion",
   schedulerPlugin(),
   "@sentry/junior-sentry",
+  "@sentry/junior-vercel",
 ]);
 ```
 

--- a/packages/junior-cloudflare/plugin.yaml
+++ b/packages/junior-cloudflare/plugin.yaml
@@ -8,6 +8,7 @@ capabilities:
 config-keys:
   - account.id
   - zone.id
+  - worker.name
 
 mcp:
   url: https://mcp.cloudflare.com/mcp

--- a/packages/junior-cloudflare/skills/cloudflare/SKILL.md
+++ b/packages/junior-cloudflare/skills/cloudflare/SKILL.md
@@ -32,7 +32,7 @@ Load references conditionally based on the request:
 ## Workflow
 
 1. Classify the request as read-only investigation or state-changing work.
-2. Resolve target scope: explicit user account/zone/resource wins; otherwise use `cloudflare.account.id` and `cloudflare.zone.id` config; otherwise discover with MCP and ask one focused question if ambiguous.
+2. Resolve target scope: explicit user account/zone/resource wins; otherwise use `cloudflare.account.id`, `cloudflare.zone.id`, and `cloudflare.worker.name` config where relevant; otherwise discover with MCP and ask one focused question if ambiguous.
 3. For any Cloudflare API call, search the MCP API spec first. Do not call Cloudflare API paths from memory or from bundled docs.
 4. Keep investigation bounded: last 30 minutes for "right now", last 24 hours for retrospective checks, and recent N builds/deployments unless the user asks for more.
 5. Before any state-changing API call, load [references/safety-and-permissions.md](references/safety-and-permissions.md), show current state and the intended change, then wait for explicit approval.
@@ -42,6 +42,7 @@ Load references conditionally based on the request:
 
 - **Read-first.** Default to investigation. Do not execute writes in response to ambiguous requests like "fix this" or "roll it back" — investigate and propose a plan first.
 - **Search owns API selection.** The bundled references give workflows, not API authority.
+- **Respect channel defaults.** When a request mentions "the Worker", "our Worker", deploys, builds, logs, or Worker errors without naming a Worker, use `cloudflare.worker.name` as the default Worker target if it is configured.
 - **Confirm before writes.** No Worker deploy, rollback, DNS create/update/delete, load balancer change, WAF rule change, Access policy change, or R2/KV/D1 destructive action without explicit user approval after showing current state and change summary.
 - **Never delete data by default.** For R2, KV, and D1, support list/inspect/read. Avoid delete/truncate/drop unless the user explicitly asks and confirms.
 - **Redact sensitive data.** Do not paste raw log bodies, Worker source, env var values, token values, or authorization headers.


### PR DESCRIPTION
Expose the Cloudflare plugin from the docs sidebar, quickstart, and plugin overview so users can find and enable it from the main setup path.

This also documents a channel-scoped Cloudflare Worker default via `cloudflare.worker.name`, and registers that key in the plugin manifest so requests like "check the latest errors" can resolve a common Worker such as `sentry-mcp` without users repeating the Worker name.

While touching setup docs, this fixes the `junior init` reference to reflect that new apps include both maintenance and memory by default.

Validated with `pnpm docs:check`.
