### PR TITLE
fix(config): warn when setting an unrecognized config key

### DIFF
--- a/packages/junior/src/chat/capabilities/jr-rpc-command.ts
+++ b/packages/junior/src/chat/capabilities/jr-rpc-command.ts
@@ -69,6 +69,27 @@ function parsePrefixFlag(
   };
 }
 
+
+/** Build a stderr warning when a config key is not declared by any installed plugin. */
+function buildUnknownKeyWarning(key: string): string {
+  const knownKeys = pluginCatalogRuntime
+    .getProviders()
+    .flatMap((plugin) => [...plugin.manifest.configKeys]);
+  if (knownKeys.includes(key)) {
+    return "";
+  }
+  // Find suggestions with the same dot-prefix (e.g. "cloudflare." for "cloudflare.worker-id")
+  const prefix = key.includes(".") ? key.slice(0, key.indexOf(".") + 1) : "";
+  const suggestions = prefix
+    ? knownKeys.filter((k) => k.startsWith(prefix))
+    : knownKeys;
+  const hint =
+    suggestions.length > 0
+      ? `Known keys with prefix "${prefix}": ${suggestions.join(", ")}`
+      : `Known config keys: ${knownKeys.join(", ")}`;
+  return `Warning: "${key}" is not a recognized config key. ${hint}\n`;
+}
+
 async function handleConfigCommand(
   args: string[],
   deps: JrRpcDeps,
@@ -150,6 +171,8 @@ async function handleConfigCommand(
       }
     }
 
+    const unknownKeyWarning = buildUnknownKeyWarning(key);
+
     try {
       const entry = await configuration.set({
         key,
@@ -181,6 +204,7 @@ async function handleConfigCommand(
           updatedBy: entry.updatedBy,
           source: entry.source,
         },
+        stderr: unknownKeyWarning,
         exitCode: 0,
       });
     } catch (error) {

--- a/packages/junior/tests/unit/handlers/jr-rpc-command.test.ts
+++ b/packages/junior/tests/unit/handlers/jr-rpc-command.test.ts
@@ -208,4 +208,73 @@ describe("jr-rpc custom command", () => {
       undefined,
     );
   });
+
+  it("warns when setting an unrecognized config key", async () => {
+    const previousConfig = pluginCatalogRuntime.setConfig({
+      inlineManifests: [
+        {
+          manifest: {
+            name: "cloudflare",
+            displayName: "Cloudflare",
+            description: "Cloudflare plugin",
+            capabilities: [],
+            configKeys: ["cloudflare.account.id", "cloudflare.zone.id", "cloudflare.worker.name"],
+          },
+        },
+      ],
+    });
+    try {
+      const configuration = makeChannelConfiguration();
+      const result = await maybeExecuteJrRpcCustomCommand(
+        "jr-rpc config set cloudflare.worker-id sentry-mcp",
+        {
+          activeSkill,
+          channelConfiguration: configuration,
+          requesterId: "U123",
+        },
+      );
+      const handled = expectHandled(result);
+      // Still succeeds
+      expect(handled.result.exit_code).toBe(0);
+      // But warns about the unrecognized key with suggestions
+      expect(handled.result.stderr).toContain(
+        '"cloudflare.worker-id" is not a recognized config key',
+      );
+      expect(handled.result.stderr).toContain("cloudflare.worker.name");
+    } finally {
+      pluginCatalogRuntime.setConfig(previousConfig);
+    }
+  });
+
+  it("does not warn when setting a recognized config key", async () => {
+    const previousConfig = pluginCatalogRuntime.setConfig({
+      inlineManifests: [
+        {
+          manifest: {
+            name: "cloudflare",
+            displayName: "Cloudflare",
+            description: "Cloudflare plugin",
+            capabilities: [],
+            configKeys: ["cloudflare.account.id", "cloudflare.zone.id", "cloudflare.worker.name"],
+          },
+        },
+      ],
+    });
+    try {
+      const configuration = makeChannelConfiguration();
+      const result = await maybeExecuteJrRpcCustomCommand(
+        "jr-rpc config set cloudflare.worker.name sentry-mcp",
+        {
+          activeSkill,
+          channelConfiguration: configuration,
+          requesterId: "U123",
+        },
+      );
+      const handled = expectHandled(result);
+      expect(handled.result.exit_code).toBe(0);
+      expect(handled.result.stderr).toBe("");
+    } finally {
+      pluginCatalogRuntime.setConfig(previousConfig);
+    }
+  });
 });


### PR DESCRIPTION
## What

When `jr-rpc config set` is called with a key not declared in any installed plugin manifest's `configKeys`, the command now emits a stderr warning listing the known keys for the same plugin prefix. The set still succeeds (exit 0) to avoid breaking legitimate non-plugin config uses.

## Why

`jr-rpc config set` previously accepted any key string with no validation. This caused a real failure: `cloudflare.worker-id` was silently stored when the correct key is `cloudflare.worker.name`. The agent had no feedback until the downstream behavior was broken.

Example warning output:
```
Warning: "cloudflare.worker-id" is not a recognized config key. Known keys with prefix "cloudflare.": cloudflare.account.id, cloudflare.zone.id, cloudflare.worker.name
```

The plugin catalog (`pluginCatalogRuntime`) was already imported in this file for `handlePluginsCommand`; the fix just consults it during `config set`.

## Verification

- TypeScript: clean (`tsc --noEmit` passes)
- Two new unit tests added: one for the warning path (unrecognized key), one for the happy path (recognized key produces no warning)
- Unit tests could not be executed in the sandbox due to a pre-existing Postgres global-setup dependency (`connect ECONNREFUSED 127.0.0.1:54322`) — CI will cover this

Refs: https://sentry.slack.com/archives/C08J1NSPU6S/p1782694741000119