### PR TITLE
feat(memory): Add preference supersession

### DIFF
--- a/packages/junior-evals/evals/memory/workflows.eval.ts
+++ b/packages/junior-evals/evals/memory/workflows.eval.ts
@@ -3,11 +3,12 @@ import { assistantMessages, describeEval } from "vitest-evals";
 import { getDb } from "@/chat/db";
 import { completeText, resolveGatewayModel } from "@/chat/pi/client";
 import { createMemoryStore, type MemoryDb } from "@sentry/junior-memory";
-import { createSlackSource } from "@sentry/junior-plugin-api";
+import { createSlackSource, type PluginModel } from "@sentry/junior-plugin-api";
 import {
   juniorMemoryEmbeddings,
   juniorMemoryMemories,
 } from "../../../junior-memory/src/db/schema";
+import { createMemoryAgent } from "../../../junior-memory/src/agent";
 import { mention, rubric, slackEvals } from "../../src/helpers";
 
 const memoryPluginOverrides = {
@@ -27,6 +28,7 @@ interface MemoryThread {
 async function seedMemory(args: {
   content: string;
   idempotencyKey: string;
+  kind?: "knowledge" | "preference" | "procedure";
   scope?: "conversation" | "personal";
   thread: MemoryThread;
 }) {
@@ -47,6 +49,7 @@ async function seedMemory(args: {
   const input = {
     content: args.content,
     idempotencyKey: args.idempotencyKey,
+    kind: args.kind ?? "preference",
   };
   if (args.scope === "conversation") {
     await store.createConversationMemory(input);
@@ -58,6 +61,45 @@ async function seedMemory(args: {
 function memoryDb(): MemoryDb {
   return getDb() as unknown as MemoryDb;
 }
+
+const evalMemoryModel: PluginModel = {
+  async completeObject(input) {
+    const { text } = await completeText({
+      maxTokens: input.maxTokens,
+      modelId: memoryJudgeModelId,
+      system: input.system,
+      messages: [
+        {
+          role: "user",
+          content: [
+            input.prompt,
+            "",
+            "Return only raw JSON in exactly one of these shapes:",
+            '{"decision":"supersedes_old","supersededIds":["existing-memory-id"]}',
+            '{"decision":"distinct"}',
+            '{"decision":"uncertain"}',
+            'Use camelCase keys exactly, including "supersededIds". Do not wrap it in markdown.',
+          ].join("\n"),
+          timestamp: Date.now(),
+        },
+      ],
+      temperature: 0,
+    });
+    const parsed = JSON.parse(text) as unknown;
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      "superseded_ids" in parsed &&
+      !("supersededIds" in parsed)
+    ) {
+      (parsed as Record<string, unknown>).supersededIds = (
+        parsed as Record<string, unknown>
+      ).superseded_ids;
+      delete (parsed as Record<string, unknown>).superseded_ids;
+    }
+    return { object: input.schema.parse(parsed) };
+  },
+};
 
 function memorySourceKey(thread: MemoryThread): string {
   return `slack:${memoryTeamId}:${thread.channel_id}:${thread.thread_ts}`;
@@ -346,6 +388,57 @@ describeEval("Memory Workflows", slackEvals, (it) => {
       userText,
     });
   });
+
+  it("when adjudicating preference supersession, distinguish replacement from additive preferences", async () => {
+    const agent = createMemoryAgent(evalMemoryModel);
+    const runtimeContext = {
+      conversationId: "slack:CMEMORYSUPERSESSION:17000000.memory-supersession",
+      requester: {
+        platform: "slack" as const,
+        teamId: memoryTeamId,
+        userId: requesterUserId,
+      },
+      source: createSlackSource({
+        channelId: "CMEMORYSUPERSESSION",
+        messageTs: "17000000.memory-supersession",
+        teamId: memoryTeamId,
+        threadTs: "17000000.memory-supersession",
+      }),
+    };
+
+    const replacement = await agent.adjudicateSupersession({
+      candidate: {
+        content: "Prefers TypeScript for automation scripts.",
+        kind: "preference",
+      },
+      existingMemories: [
+        {
+          content: "Prefers Python for automation scripts.",
+          id: "memory-old-language",
+        },
+      ],
+      runtimeContext,
+    });
+    expect(replacement).toEqual({
+      decision: "supersedes_old",
+      supersededIds: ["memory-old-language"],
+    });
+
+    const additive = await agent.adjudicateSupersession({
+      candidate: {
+        content: "Prefers Slack updates in the morning.",
+        kind: "preference",
+      },
+      existingMemories: [
+        {
+          content: "Prefers terse PR summaries.",
+          id: "memory-old-summary-style",
+        },
+      ],
+      runtimeContext,
+    });
+    expect(additive.decision).not.toBe("supersedes_old");
+  }, 120_000);
 
   const explicitTaskProcedureThread = {
     channel_type: "channel",

--- a/packages/junior-memory/src/agent.ts
+++ b/packages/junior-memory/src/agent.ts
@@ -1,5 +1,9 @@
 import type { PluginModel } from "@sentry/junior-plugin-api";
 import { z } from "zod";
+import type {
+  MemorySupersessionDecision,
+  MemorySupersessionInput,
+} from "./store";
 import { MEMORY_KINDS, memoryRuntimeContextSchema } from "./types";
 
 const memoryKindSchema = z.enum(MEMORY_KINDS);
@@ -60,6 +64,28 @@ const extractSessionRequestSchema = z
         ]),
       )
       .min(1),
+  })
+  .strict();
+const supersessionRequestSchema = z
+  .object({
+    candidate: z
+      .object({
+        content: z.string().min(1),
+        kind: z.literal("preference"),
+      })
+      .strict(),
+    existingMemories: z
+      .array(
+        z
+          .object({
+            content: z.string().min(1),
+            id: z.string().min(1),
+          })
+          .strict(),
+      )
+      .min(1)
+      .max(10),
+    runtimeContext: memoryRuntimeContextSchema,
   })
   .strict();
 
@@ -140,6 +166,19 @@ const extractMemoriesResponseSchema = z
       ),
   })
   .strict();
+const supersessionDecisionResponseSchema = z.discriminatedUnion("decision", [
+  z
+    .object({
+      decision: z.literal("supersedes_old"),
+      supersededIds: z.array(z.string().min(1)).min(1).max(10),
+    })
+    .strict(),
+  z
+    .object({
+      decision: z.enum(["distinct", "uncertain"]),
+    })
+    .strict(),
+]);
 
 type MemoryReviewResponse = z.output<typeof memoryReviewResponseSchema>;
 type ExtractMemoriesResponse = z.output<typeof extractMemoriesResponseSchema>;
@@ -153,6 +192,10 @@ export type ExtractSessionRequest = z.output<
 export type ExtractedMemory = z.output<typeof extractedMemoryResultSchema>;
 
 export interface MemoryAgent {
+  /** Decide whether a new preference safely replaces active old preferences. */
+  adjudicateSupersession(
+    request: MemorySupersessionInput,
+  ): Promise<MemorySupersessionDecision> | MemorySupersessionDecision;
   extractSessionMemories(
     request: ExtractSessionRequest,
   ): Promise<ExtractedMemory[]> | ExtractedMemory[];
@@ -174,6 +217,12 @@ const MEMORY_EXTRACTION_SYSTEM = [
   "Assistant text is context for interpreting the run, not independent evidence for new facts.",
   "Reject secrets, credentials, private or sensitive personal details, gossip, speculative claims about other people, assistant/system implementation details, vague references, and low-durability chatter.",
   "If no public, durable, self-contained memory remains after rewriting, return an empty memories array.",
+].join("\n");
+const MEMORY_SUPERSESSION_SYSTEM = [
+  "You are Junior's memory supersession agent.",
+  "Decide whether a new requester preference clearly replaces existing active requester preferences.",
+  "Return supersedes_old only for obvious changed preferences about the same mutable slot.",
+  "If the facts are additive, different topics, duplicate, broader/narrower without direct replacement, or uncertain, do not supersede.",
 ].join("\n");
 const CANONICAL_CONTENT_RULES = [
   "- Stored memory text must be a rewritten fact, not copied user wording or a sentence about who said it.",
@@ -355,9 +404,52 @@ function sessionExtractionPrompt(request: ExtractSessionRequest): string {
   ].join("\n");
 }
 
+function supersessionPrompt(request: MemorySupersessionInput): string {
+  return [
+    "<memory-supersession-input>",
+    "Decide whether the candidate preference clearly replaces one or more existing active preferences.",
+    "",
+    runtimeDescription({
+      runtimeContext: request.runtimeContext,
+    }),
+    "",
+    "<candidate>",
+    escapeXml(JSON.stringify(request.candidate)),
+    "</candidate>",
+    "",
+    "<existing-memories>",
+    escapeXml(JSON.stringify(request.existingMemories)),
+    "</existing-memories>",
+    "",
+    "<rules>",
+    "- Return supersedes_old only when the candidate and old memory describe the same mutable preference slot and the candidate is the newer value.",
+    "- Examples of same mutable slot: preferred programming language, preferred review style, preferred notification cadence, preferred tool for a task.",
+    "- Do not supersede when the candidate is just more specific, an additional preference, a different task/context, or the same value phrased differently.",
+    "- Do not supersede memories from different topics even if they are both preferences.",
+    "- Only return ids that appear in existing-memories.",
+    "- If unsure, return uncertain.",
+    "</rules>",
+    "</memory-supersession-input>",
+  ].join("\n");
+}
+
 /** Create the memory-owned agent that reviews and extracts memory candidates. */
 export function createMemoryAgent(model: PluginModel): MemoryAgent {
   return {
+    async adjudicateSupersession(rawRequest) {
+      const request = supersessionRequestSchema.parse(
+        rawRequest,
+      ) as MemorySupersessionInput;
+      const result = await model.completeObject({
+        schema: supersessionDecisionResponseSchema,
+        system: MEMORY_SUPERSESSION_SYSTEM,
+        prompt: supersessionPrompt(request),
+        maxTokens: 400,
+      });
+      return supersessionDecisionResponseSchema.parse(
+        result.object,
+      ) as MemorySupersessionDecision;
+    },
     async extractSessionMemories(rawRequest) {
       const request = extractSessionRequestSchema.parse(rawRequest);
       const result = await model.completeObject({

--- a/packages/junior-memory/src/plugin.ts
+++ b/packages/junior-memory/src/plugin.ts
@@ -6,6 +6,7 @@ import {
   createMemoryListTool,
   createMemoryRemoveTool,
   createMemorySearchTool,
+  type MemoryCreateToolContext,
   type MemoryReviewer,
   type MemoryToolContext,
 } from "./tools";
@@ -48,6 +49,22 @@ function memoryToolContext(ctx: {
   };
 }
 
+function memoryCreateToolContext(ctx: {
+  agent: MemoryReviewer;
+  conversationId?: string;
+  db: MemoryCreateToolContext["db"];
+  embedder?: MemoryCreateToolContext["embedder"];
+  requester?: MemoryCreateToolContext["requester"];
+  source: MemoryCreateToolContext["source"];
+  supersessionDecider: MemoryCreateToolContext["supersessionDecider"];
+  userText?: string;
+}): MemoryCreateToolContext {
+  return {
+    ...memoryToolContext(ctx),
+    supersessionDecider: ctx.supersessionDecider,
+  };
+}
+
 /** Create Junior's long-term memory plugin registration. */
 export function createMemoryPlugin(options: MemoryPluginOptions = {}) {
   const modelId = memoryModelId(options);
@@ -73,14 +90,23 @@ export function createMemoryPlugin(options: MemoryPluginOptions = {}) {
     },
     hooks: {
       tools(ctx) {
+        const agent = createMemoryAgent(ctx.model);
         const context = memoryToolContext({
           ...ctx,
-          agent: createMemoryAgent(ctx.model),
+          agent,
           db: ctx.db as MemoryDb,
           embedder: ctx.embedder,
         });
         return {
-          createMemory: createMemoryCreateTool(context),
+          createMemory: createMemoryCreateTool(
+            memoryCreateToolContext({
+              ...ctx,
+              agent,
+              db: ctx.db as MemoryDb,
+              embedder: ctx.embedder,
+              supersessionDecider: agent,
+            }),
+          ),
           removeMemory: createMemoryRemoveTool(context),
           listMemories: createMemoryListTool(context),
           searchMemories: createMemorySearchTool(context),

--- a/packages/junior-memory/src/process-session.ts
+++ b/packages/junior-memory/src/process-session.ts
@@ -135,8 +135,10 @@ export async function processMemorySession(
     ...(run.requester ? { requester: run.requester } : {}),
     source: run.source,
   });
+  const agent = createMemoryAgent(context.model);
   const store = createMemoryStore(context.db as MemoryDb, runtimeContext, {
     embedder: context.embedder,
+    supersessionDecider: agent,
   });
   await store.archiveExpiredMemories();
   const memories = await getTaskMemories(context, async () => {
@@ -144,7 +146,6 @@ export async function processMemorySession(
       limit: 10,
       query: evidenceText,
     });
-    const agent = createMemoryAgent(context.model);
     return await agent.extractSessionMemories({
       existingMemories: existingMemories.map((memory) => ({
         content: memory.content,

--- a/packages/junior-memory/src/store.ts
+++ b/packages/junior-memory/src/store.ts
@@ -50,6 +50,7 @@ const DEFAULT_LIST_LIMIT = 50;
 const DEFAULT_SEARCH_LIMIT = 10;
 const DEFAULT_EXPIRED_ARCHIVE_LIMIT = 100;
 const HIGH_CONFIDENCE_DUPLICATE_DISTANCE = 0.015;
+const SUPERSESSION_CANDIDATE_LIMIT = 10;
 const VECTOR_SEARCH_OVERFETCH = 4;
 const MAX_MEMORY_CONTENT_CHARS = 4_000;
 const EMBEDDING_METRIC = "cosine";
@@ -224,9 +225,44 @@ export interface MemoryEmbeddingProvider {
   }>;
 }
 
+export interface MemorySupersessionInput {
+  candidate: {
+    content: string;
+    kind: "preference";
+  };
+  existingMemories: [
+    {
+      content: string;
+      id: string;
+    },
+    ...Array<{
+      content: string;
+      id: string;
+    }>,
+  ];
+  runtimeContext: MemoryRuntimeContext;
+}
+
+export type MemorySupersessionDecision =
+  | {
+      decision: "supersedes_old";
+      supersededIds: [string, ...string[]];
+    }
+  | {
+      decision: "distinct" | "uncertain";
+    };
+
+export interface MemorySupersessionDecider {
+  /** Decide whether a new preference clearly replaces active old preferences. */
+  adjudicateSupersession(
+    input: MemorySupersessionInput,
+  ): Promise<MemorySupersessionDecision> | MemorySupersessionDecision;
+}
+
 export interface MemoryStoreOptions {
   embedder?: MemoryEmbeddingProvider;
   now?: () => number;
+  supersessionDecider?: MemorySupersessionDecider;
 }
 
 /** Context-bound storage operations for visible long-term memories. */
@@ -731,6 +767,64 @@ async function rememberDuplicateIdempotency(args: {
     .onConflictDoNothing();
 }
 
+async function listSupersessionCandidates(args: {
+  db: MemoryDb;
+  kind: MemoryRecord["kind"];
+  nowMs: number;
+  scope: ResolvedMemoryScope;
+  subject: ResolvedMemorySubject;
+}): Promise<MemoryRecord[]> {
+  const rows = await args.db
+    .select()
+    .from(juniorMemoryMemories)
+    .where(activeScopedSubjectPredicate(args))
+    .orderBy(
+      desc(juniorMemoryMemories.createdAtMs),
+      asc(juniorMemoryMemories.id),
+    )
+    .limit(SUPERSESSION_CANDIDATE_LIMIT);
+  return rows.map(parseMemoryRow);
+}
+
+async function decideSupersededIds(args: {
+  candidates: MemoryRecord[];
+  content: string;
+  decider: MemorySupersessionDecider | undefined;
+  kind: MemoryRecord["kind"];
+  runtimeContext: MemoryRuntimeContext;
+}): Promise<string[]> {
+  // Supersession is conservative: model uncertainty or decider failure leaves
+  // both memories active rather than hiding a possibly valid old preference.
+  if (
+    args.kind !== "preference" ||
+    !args.decider ||
+    args.candidates.length === 0
+  ) {
+    return [];
+  }
+  const existingMemories = args.candidates.map((memory) => ({
+    content: memory.content,
+    id: memory.id,
+  })) as MemorySupersessionInput["existingMemories"];
+  const candidateIds = new Set(args.candidates.map((memory) => memory.id));
+  try {
+    const decision = await args.decider.adjudicateSupersession({
+      candidate: {
+        content: args.content,
+        kind: "preference",
+      },
+      existingMemories,
+      runtimeContext: args.runtimeContext,
+    });
+    if (decision.decision !== "supersedes_old") {
+      return [];
+    }
+    return decision.supersededIds.filter((id) => candidateIds.has(id));
+  } catch {
+    return [];
+  }
+}
+
 /** List active records for the runtime-derived visible scopes. */
 async function listVisibleMemories(args: {
   db: MemoryDb;
@@ -895,6 +989,7 @@ export function createMemoryStore(
   const runtimeContext = memoryRuntimeContextSchema.parse(context);
   const parsedOptions = memoryStoreOptionsSchema.parse({ now: options.now });
   const embedder = options.embedder;
+  const supersessionDecider = options.supersessionDecider;
   const getNowMs = parsedOptions.now ?? Date.now;
 
   async function archiveExpiredVisibleMemories(
@@ -1022,33 +1117,87 @@ export function createMemoryStore(
       return { created: false, memory: vectorDuplicate };
     }
 
-    const id = randomUUID();
-    const rows = await db
-      .insert(juniorMemoryMemories)
-      .values({
-        content,
-        createdAtMs: nowMs,
-        expiresAtMs: input.expiresAtMs,
-        id,
-        idempotencyKey: input.idempotencyKey,
-        observedAtMs: nowMs,
-        scope: scope.scope,
-        scopeKey: scope.scopeKey,
-        sourceKey: sourceKey(runtimeContext),
-        sourcePlatform: runtimeContext.source.platform,
-        subjectKey: subject.subjectKey,
-        subjectType: subject.subjectType,
+    let supersededIds: string[] = [];
+    if (
+      scopeKind === "personal" &&
+      input.kind === "preference" &&
+      supersessionDecider &&
+      (input.expiresAtMs === undefined || input.expiresAtMs > nowMs)
+    ) {
+      const supersessionCandidates = await listSupersessionCandidates({
+        db,
         kind: input.kind,
-      })
-      .onConflictDoNothing({
-        target: [
-          juniorMemoryMemories.scope,
-          juniorMemoryMemories.scopeKey,
-          juniorMemoryMemories.idempotencyKey,
-        ],
-        where: sql`${juniorMemoryMemories.idempotencyKey} IS NOT NULL AND ${juniorMemoryMemories.archivedAtMs} IS NULL AND ${juniorMemoryMemories.supersededAtMs} IS NULL AND ${juniorMemoryMemories.supersededById} IS NULL`,
-      })
-      .returning();
+        nowMs,
+        scope,
+        subject,
+      });
+      supersededIds = await decideSupersededIds({
+        candidates: supersessionCandidates,
+        content,
+        decider: supersessionDecider,
+        kind: input.kind,
+        runtimeContext,
+      });
+    }
+
+    const id = randomUUID();
+    const rows = await db.transaction(async (tx) => {
+      const inserted = await tx
+        .insert(juniorMemoryMemories)
+        .values({
+          content,
+          createdAtMs: nowMs,
+          expiresAtMs: input.expiresAtMs,
+          id,
+          idempotencyKey: input.idempotencyKey,
+          observedAtMs: nowMs,
+          scope: scope.scope,
+          scopeKey: scope.scopeKey,
+          sourceKey: sourceKey(runtimeContext),
+          sourcePlatform: runtimeContext.source.platform,
+          subjectKey: subject.subjectKey,
+          subjectType: subject.subjectType,
+          kind: input.kind,
+        })
+        .onConflictDoNothing({
+          target: [
+            juniorMemoryMemories.scope,
+            juniorMemoryMemories.scopeKey,
+            juniorMemoryMemories.idempotencyKey,
+          ],
+          where: sql`${juniorMemoryMemories.idempotencyKey} IS NOT NULL AND ${juniorMemoryMemories.archivedAtMs} IS NULL AND ${juniorMemoryMemories.supersededAtMs} IS NULL AND ${juniorMemoryMemories.supersededById} IS NULL`,
+        })
+        .returning();
+      const insertedMemory = inserted[0];
+      if (!insertedMemory || supersededIds.length === 0) {
+        return inserted;
+      }
+      const superseded = await tx
+        .update(juniorMemoryMemories)
+        .set({
+          supersededAtMs: nowMs,
+          supersededById: insertedMemory.id,
+        })
+        .where(
+          and(
+            inArray(juniorMemoryMemories.id, supersededIds),
+            activeScopedSubjectPredicate({
+              kind: input.kind,
+              nowMs,
+              scope,
+              subject,
+            }),
+          ),
+        )
+        .returning({ id: juniorMemoryMemories.id });
+      const idsToClean = superseded.map((row) => row.id);
+      if (idsToClean.length > 0) {
+        await tx
+          .delete(juniorMemoryEmbeddings)
+          .where(inArray(juniorMemoryEmbeddings.memoryId, idsToClean));
+      }
+      return inserted;
+    });
     if (rows[0]) {
       const memory = parseMemoryRow(rows[0]);
       await storeEmbedding({

--- a/packages/junior-memory/src/store.ts
+++ b/packages/junior-memory/src/store.ts
@@ -54,6 +54,17 @@ const SUPERSESSION_CANDIDATE_LIMIT = 10;
 const VECTOR_SEARCH_OVERFETCH = 4;
 const MAX_MEMORY_CONTENT_CHARS = 4_000;
 const EMBEDDING_METRIC = "cosine";
+const SUPERSESSION_STOP_TERMS = new Set([
+  "and",
+  "for",
+  "prefer",
+  "prefers",
+  "preference",
+  "the",
+  "use",
+  "uses",
+  "with",
+]);
 
 export type MemoryDb = PgDatabase<PgQueryResultHKT, typeof memorySqlSchema>;
 
@@ -768,22 +779,113 @@ async function rememberDuplicateIdempotency(args: {
 }
 
 async function listSupersessionCandidates(args: {
+  content: string;
   db: MemoryDb;
+  embedding?: MemoryEmbedding;
   kind: MemoryRecord["kind"];
   nowMs: number;
   scope: ResolvedMemoryScope;
   subject: ResolvedMemorySubject;
 }): Promise<MemoryRecord[]> {
+  const predicate = activeScopedSubjectPredicate(args);
+  const terms = searchTerms(args.content).filter(
+    (term) => !SUPERSESSION_STOP_TERMS.has(term),
+  );
+  const lexicalRows =
+    terms.length > 0
+      ? await args.db
+          .select()
+          .from(juniorMemoryMemories)
+          .where(
+            and(
+              predicate,
+              or(
+                ...terms.map((term) =>
+                  ilike(juniorMemoryMemories.content, `%${term}%`),
+                ),
+              ),
+            ),
+          )
+      : [];
+  const lexicalCandidates = lexicalRows
+    .map(parseMemoryRow)
+    .map((memory) => ({
+      memory,
+      score: searchScore(memory, terms),
+    }))
+    .filter((candidate) => candidate.score > 1)
+    .sort(
+      (left, right) =>
+        right.score - left.score ||
+        right.memory.createdAtMs - left.memory.createdAtMs ||
+        left.memory.id.localeCompare(right.memory.id),
+    )
+    .map((candidate) => candidate.memory);
+
+  const vectorCandidates = args.embedding
+    ? await listVectorSupersessionCandidates({
+        db: args.db,
+        embedding: args.embedding,
+        kind: args.kind,
+        nowMs: args.nowMs,
+        scope: args.scope,
+        subject: args.subject,
+      })
+    : [];
+  const byId = new Map<string, MemoryRecord>();
+  for (const memory of [...lexicalCandidates, ...vectorCandidates]) {
+    if (byId.size >= SUPERSESSION_CANDIDATE_LIMIT) {
+      break;
+    }
+    byId.set(memory.id, memory);
+  }
+  return [...byId.values()];
+}
+
+async function listVectorSupersessionCandidates(args: {
+  db: MemoryDb;
+  embedding: MemoryEmbedding;
+  kind: MemoryRecord["kind"];
+  nowMs: number;
+  scope: ResolvedMemoryScope;
+  subject: ResolvedMemorySubject;
+}): Promise<MemoryRecord[]> {
+  const distance = cosineDistance(
+    juniorMemoryEmbeddings.embedding,
+    args.embedding.vector,
+  );
   const rows = await args.db
-    .select()
+    .select({
+      contentHash: juniorMemoryEmbeddings.contentHash,
+      distance,
+      memory: juniorMemoryMemories,
+    })
     .from(juniorMemoryMemories)
-    .where(activeScopedSubjectPredicate(args))
+    .innerJoin(
+      juniorMemoryEmbeddings,
+      eq(juniorMemoryEmbeddings.memoryId, juniorMemoryMemories.id),
+    )
+    .where(
+      and(
+        activeScopedSubjectPredicate(args),
+        eq(juniorMemoryEmbeddings.provider, args.embedding.provider),
+        eq(juniorMemoryEmbeddings.model, args.embedding.model),
+        eq(juniorMemoryEmbeddings.dimensions, MEMORY_EMBEDDING_DIMENSIONS),
+        eq(juniorMemoryEmbeddings.metric, EMBEDDING_METRIC),
+      ),
+    )
     .orderBy(
+      distance,
       desc(juniorMemoryMemories.createdAtMs),
       asc(juniorMemoryMemories.id),
     )
     .limit(SUPERSESSION_CANDIDATE_LIMIT);
-  return rows.map(parseMemoryRow);
+  return rows.flatMap((row) => {
+    if (hashEmbeddedContent(row.memory.content) !== row.contentHash) {
+      return [];
+    }
+    return [parseMemoryRow(row.memory)];
+  });
 }
 
 async function decideSupersededIds(args: {
@@ -1125,7 +1227,9 @@ export function createMemoryStore(
       (input.expiresAtMs === undefined || input.expiresAtMs > nowMs)
     ) {
       const supersessionCandidates = await listSupersessionCandidates({
+        content,
         db,
+        ...(candidateEmbedding ? { embedding: candidateEmbedding } : {}),
         kind: input.kind,
         nowMs,
         scope,

--- a/packages/junior-memory/src/tools.ts
+++ b/packages/junior-memory/src/tools.ts
@@ -13,6 +13,7 @@ import {
   type MemoryEmbeddingProvider,
   type MemoryDb,
   type MemoryRecord,
+  type MemorySupersessionDecider,
 } from "./store";
 import {
   parseCreateMemoryRequest,
@@ -54,6 +55,10 @@ export interface MemoryToolContext {
   userText?: string;
 }
 
+export interface MemoryCreateToolContext extends MemoryToolContext {
+  supersessionDecider?: MemorySupersessionDecider;
+}
+
 function throwToolInputError(message: string): never {
   throw new PluginToolInputError(message);
 }
@@ -83,9 +88,15 @@ function memoryRuntimeContext(
   });
 }
 
-function memoryStore(context: MemoryToolContext) {
+function memoryStore(
+  context: MemoryToolContext,
+  options: { supersessionDecider?: MemorySupersessionDecider } = {},
+) {
   return createMemoryStore(context.db, memoryRuntimeContext(context), {
     embedder: context.embedder,
+    ...(options.supersessionDecider
+      ? { supersessionDecider: options.supersessionDecider }
+      : {}),
   });
 }
 
@@ -336,7 +347,7 @@ function compactMemory(memory: MemoryRecord) {
 }
 
 /** Create a tool that submits an explicit memory candidate for storage. */
-export function createMemoryCreateTool(context: MemoryToolContext) {
+export function createMemoryCreateTool(context: MemoryCreateToolContext) {
   return {
     description:
       "Explicit memory-write tool. Use only when the latest user message directly asks Junior to remember, store, save, or forget-and-replace a public/shareable fact. Do not use for ordinary statements like 'I prefer X', 'I use Y', or 'X goes before Y' unless the user also asks you to remember/store/save it; passive memory learning handles those after the visible reply. Pass one self-contained natural-language candidate preserving the user's explicit memory intent. Do not ask the user to rephrase ordinary first-person facts, and do not rewrite them into display-name or third-person wording. Do not include secrets, private personal details, medical/legal/financial/sensitive facts, or another person's personal preference, opinion, habit, identity, relationship, workflow, or private life. Runtime context derives actor, scope, source, and subject ids; the memory agent decides canonical stored content and memory kind, then the plugin derives storage target from kind.",
@@ -350,7 +361,9 @@ export function createMemoryCreateTool(context: MemoryToolContext) {
       const toolCallId = requireToolCallId(options.toolCallId);
       const requestedExpiresAtMs = parseExpiresAt(parsedInput.expires_at);
       const runtimeContext = memoryRuntimeContext(context);
-      const store = memoryStore(context);
+      const store = memoryStore(context, {
+        supersessionDecider: context.supersessionDecider,
+      });
       const review = await (async () => {
         try {
           return parseMemoryReview(

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -31,6 +31,10 @@ import {
   type MemoryReviewer,
 } from "../src/tools";
 import { createMemoryStore, type MemoryDb } from "../src/store";
+import type {
+  MemorySupersessionDecider,
+  MemorySupersessionInput,
+} from "../src/store";
 
 const TEST_NOW_MS = Date.parse("2026-06-19T12:00:00.000Z");
 const TEST_EMBEDDING_DIMENSIONS = 1536;
@@ -691,6 +695,96 @@ describe("memory plugin storage", () => {
             }),
           ),
         ),
+      );
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("supersedes old preferences from passive completed-session extraction", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      const store = createMemoryStore(memoryDb(fixture), localContext(), {
+        now: () => TEST_NOW_MS,
+      });
+      const oldMemory = await store.createMemory({
+        content: "Prefers Python for automation scripts.",
+        kind: "preference",
+        idempotencyKey: "memory-test:passive-supersession-old",
+      });
+      const model: PluginModel = {
+        async completeObject(input) {
+          if (
+            typeof input.prompt === "string" &&
+            input.prompt.includes("<memory-supersession-input>")
+          ) {
+            return {
+              object: {
+                decision: "supersedes_old",
+                supersededIds: [oldMemory.memory.id],
+              },
+            };
+          }
+          return {
+            object: {
+              memories: [
+                {
+                  canonicalFact: "Prefers TypeScript for automation scripts.",
+                  expiresAtMs: null,
+                  kind: "preference",
+                },
+              ],
+            },
+          };
+        },
+      };
+
+      await processMemorySession(
+        processSessionContext({
+          db: memoryDb(fixture),
+          model,
+          run: {
+            async load() {
+              return completedRun({
+                transcript: [
+                  {
+                    type: "message",
+                    role: "user",
+                    text: "Actually, I prefer TypeScript for automation scripts.",
+                  },
+                  {
+                    type: "message",
+                    role: "assistant",
+                    text: "Noted.",
+                  },
+                ],
+              });
+            },
+          },
+        }),
+      );
+
+      const rows = await memoryDb(fixture)
+        .select()
+        .from(memorySqlSchema.juniorMemoryMemories)
+        .orderBy(memorySqlSchema.juniorMemoryMemories.createdAtMs);
+      const newMemory = rows.find((row) => row.content.includes("TypeScript"));
+      expect(newMemory).toBeDefined();
+      expect(rows).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: oldMemory.memory.id,
+            supersededAtMs: expect.any(Number),
+            supersededById: newMemory!.id,
+          }),
+          expect.objectContaining({
+            content: "Prefers TypeScript for automation scripts.",
+            scope: "personal",
+            supersededAtMs: null,
+            supersededById: null,
+          }),
+        ]),
       );
     } finally {
       await fixture.close();
@@ -2477,6 +2571,265 @@ INSERT INTO junior_memory_memories (
           ],
         ),
       ).rejects.toThrow("duplicate key value violates unique constraint");
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("supersedes old requester preferences when adjudication is confident", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      let nowMs = TEST_NOW_MS;
+      const oldContent = "Prefers Python for automation scripts.";
+      const newContent = "Prefers TypeScript for automation scripts.";
+      const embedder = createTestEmbedder({
+        [oldContent]: unitEmbedding(1),
+        [newContent]: unitEmbedding(2),
+      });
+      const supersessionCalls: MemorySupersessionInput[] = [];
+      const store = createMemoryStore(memoryDb(fixture), slackContext(), {
+        embedder,
+        now: () => nowMs,
+        supersessionDecider: {
+          adjudicateSupersession(input) {
+            supersessionCalls.push(input);
+            return {
+              decision: "supersedes_old",
+              supersededIds: [input.existingMemories[0].id],
+            };
+          },
+        },
+      });
+
+      const oldMemory = await store.createMemory({
+        content: oldContent,
+        kind: "preference",
+        idempotencyKey: "memory-test:supersession-old",
+      });
+
+      nowMs = TEST_NOW_MS + 1;
+      const newMemory = await store.createMemory({
+        content: newContent,
+        kind: "preference",
+        idempotencyKey: "memory-test:supersession-new",
+      });
+
+      expect(supersessionCalls).toEqual([
+        expect.objectContaining({
+          candidate: { content: newContent, kind: "preference" },
+          existingMemories: [{ content: oldContent, id: oldMemory.memory.id }],
+        }),
+      ]);
+      await expect(store.listMemories({})).resolves.toEqual([
+        expect.objectContaining({
+          content: newContent,
+          id: newMemory.memory.id,
+        }),
+      ]);
+      await expect(
+        memoryDb(fixture)
+          .select()
+          .from(memorySqlSchema.juniorMemoryMemories)
+          .where(
+            eq(memorySqlSchema.juniorMemoryMemories.id, oldMemory.memory.id),
+          ),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          supersededAtMs: TEST_NOW_MS + 1,
+          supersededById: newMemory.memory.id,
+        }),
+      ]);
+      await expect(
+        memoryDb(fixture).select().from(memorySqlSchema.juniorMemoryEmbeddings),
+      ).resolves.toEqual([
+        expect.objectContaining({ memoryId: newMemory.memory.id }),
+      ]);
+
+      nowMs = TEST_NOW_MS + 2;
+      await expect(
+        store.createMemory({
+          content: "Different content with the superseding retry key.",
+          kind: "preference",
+          idempotencyKey: "memory-test:supersession-new",
+        }),
+      ).resolves.toMatchObject({
+        created: false,
+        memory: { id: newMemory.memory.id },
+      });
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("keeps old preferences active when supersession is not confident", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      let nowMs = TEST_NOW_MS;
+      const store = createMemoryStore(memoryDb(fixture), slackContext(), {
+        now: () => nowMs,
+        supersessionDecider: {
+          adjudicateSupersession() {
+            return { decision: "distinct" };
+          },
+        },
+      });
+
+      const oldMemory = await store.createMemory({
+        content: "Prefers terse PR summaries.",
+        kind: "preference",
+        idempotencyKey: "memory-test:supersession-distinct-old",
+      });
+
+      nowMs = TEST_NOW_MS + 1;
+      const newMemory = await store.createMemory({
+        content: "Prefers Slack updates in the morning.",
+        kind: "preference",
+        idempotencyKey: "memory-test:supersession-distinct-new",
+      });
+
+      await expect(store.listMemories({})).resolves.toEqual([
+        expect.objectContaining({ id: newMemory.memory.id }),
+        expect.objectContaining({ id: oldMemory.memory.id }),
+      ]);
+      await expect(
+        memoryDb(fixture)
+          .select()
+          .from(memorySqlSchema.juniorMemoryMemories)
+          .where(
+            eq(memorySqlSchema.juniorMemoryMemories.id, oldMemory.memory.id),
+          ),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          supersededAtMs: null,
+          supersededById: null,
+        }),
+      ]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("does not supersede active preferences with immediately expired replacements", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      let nowMs = TEST_NOW_MS;
+      const decider: MemorySupersessionDecider = {
+        adjudicateSupersession() {
+          throw new Error("expired replacement should not use supersession");
+        },
+      };
+      const store = createMemoryStore(memoryDb(fixture), slackContext(), {
+        now: () => nowMs,
+        supersessionDecider: decider,
+      });
+
+      const oldMemory = await store.createMemory({
+        content: "Prefers Python for automation scripts.",
+        kind: "preference",
+        idempotencyKey: "memory-test:supersession-expired-old",
+      });
+
+      nowMs = TEST_NOW_MS + 1;
+      await store.createMemory({
+        content: "Prefers TypeScript for automation scripts.",
+        expiresAtMs: TEST_NOW_MS,
+        kind: "preference",
+        idempotencyKey: "memory-test:supersession-expired-new",
+      });
+
+      await expect(store.listMemories({})).resolves.toEqual([
+        expect.objectContaining({ id: oldMemory.memory.id }),
+      ]);
+      await expect(
+        memoryDb(fixture)
+          .select()
+          .from(memorySqlSchema.juniorMemoryMemories)
+          .where(
+            eq(memorySqlSchema.juniorMemoryMemories.id, oldMemory.memory.id),
+          ),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          supersededAtMs: null,
+          supersededById: null,
+        }),
+      ]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("does not supersede conversation-scoped preference rows", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      let nowMs = TEST_NOW_MS;
+      const store = createMemoryStore(memoryDb(fixture), slackContext(), {
+        now: () => nowMs,
+        supersessionDecider: {
+          adjudicateSupersession() {
+            throw new Error(
+              "conversation-scoped preferences should not use supersession",
+            );
+          },
+        },
+      });
+
+      const oldMemory = await store.createConversationMemory({
+        content: "Prefers Python for automation scripts.",
+        kind: "preference",
+        idempotencyKey: "memory-test:supersession-conversation-old",
+      });
+
+      nowMs = TEST_NOW_MS + 1;
+      const newMemory = await store.createConversationMemory({
+        content: "Prefers TypeScript for automation scripts.",
+        kind: "preference",
+        idempotencyKey: "memory-test:supersession-conversation-new",
+      });
+
+      await expect(store.listMemories({})).resolves.toEqual([
+        expect.objectContaining({ id: newMemory.memory.id }),
+        expect.objectContaining({ id: oldMemory.memory.id }),
+      ]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("does not adjudicate supersession for non-preference memories", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      let nowMs = TEST_NOW_MS;
+      const store = createMemoryStore(memoryDb(fixture), slackContext(), {
+        now: () => nowMs,
+        supersessionDecider: {
+          adjudicateSupersession() {
+            throw new Error("knowledge should not use preference supersession");
+          },
+        },
+      });
+
+      const oldMemory = await store.createMemory({
+        content: "Deploy checks use the release runbook.",
+        kind: "knowledge",
+        idempotencyKey: "memory-test:supersession-knowledge-old",
+      });
+
+      nowMs = TEST_NOW_MS + 1;
+      const newMemory = await store.createMemory({
+        content: "Deploy checks use the release checklist.",
+        kind: "knowledge",
+        idempotencyKey: "memory-test:supersession-knowledge-new",
+      });
+
+      await expect(store.listMemories({})).resolves.toEqual([
+        expect.objectContaining({ id: newMemory.memory.id }),
+        expect.objectContaining({ id: oldMemory.memory.id }),
+      ]);
     } finally {
       await fixture.close();
     }

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -2594,6 +2594,9 @@ INSERT INTO junior_memory_memories (
         supersessionDecider: {
           adjudicateSupersession(input) {
             supersessionCalls.push(input);
+            if (input.candidate.content !== newContent) {
+              return { decision: "distinct" };
+            }
             return {
               decision: "supersedes_old",
               supersededIds: [input.existingMemories[0].id],
@@ -2608,7 +2611,17 @@ INSERT INTO junior_memory_memories (
         idempotencyKey: "memory-test:supersession-old",
       });
 
-      nowMs = TEST_NOW_MS + 1;
+      for (let index = 0; index < 12; index += 1) {
+        nowMs = TEST_NOW_MS + index + 1;
+        await store.createMemory({
+          content: `Prefers unrelated workflow detail ${index}.`,
+          kind: "preference",
+          idempotencyKey: `memory-test:supersession-unrelated-${index}`,
+        });
+      }
+
+      supersessionCalls.length = 0;
+      nowMs = TEST_NOW_MS + 20;
       const newMemory = await store.createMemory({
         content: newContent,
         kind: "preference",
@@ -2618,15 +2631,25 @@ INSERT INTO junior_memory_memories (
       expect(supersessionCalls).toEqual([
         expect.objectContaining({
           candidate: { content: newContent, kind: "preference" },
-          existingMemories: [{ content: oldContent, id: oldMemory.memory.id }],
+          existingMemories: expect.arrayContaining([
+            { content: oldContent, id: oldMemory.memory.id },
+          ]),
         }),
       ]);
-      await expect(store.listMemories({})).resolves.toEqual([
+      expect(supersessionCalls[0]?.existingMemories[0]).toEqual({
+        content: oldContent,
+        id: oldMemory.memory.id,
+      });
+      const activeMemories = await store.listMemories({});
+      expect(activeMemories).toContainEqual(
         expect.objectContaining({
           content: newContent,
           id: newMemory.memory.id,
         }),
-      ]);
+      );
+      expect(activeMemories).not.toContainEqual(
+        expect.objectContaining({ id: oldMemory.memory.id }),
+      );
       await expect(
         memoryDb(fixture)
           .select()
@@ -2636,15 +2659,19 @@ INSERT INTO junior_memory_memories (
           ),
       ).resolves.toEqual([
         expect.objectContaining({
-          supersededAtMs: TEST_NOW_MS + 1,
+          supersededAtMs: TEST_NOW_MS + 20,
           supersededById: newMemory.memory.id,
         }),
       ]);
-      await expect(
-        memoryDb(fixture).select().from(memorySqlSchema.juniorMemoryEmbeddings),
-      ).resolves.toEqual([
+      const embeddingRows = await memoryDb(fixture)
+        .select()
+        .from(memorySqlSchema.juniorMemoryEmbeddings);
+      expect(embeddingRows).toContainEqual(
         expect.objectContaining({ memoryId: newMemory.memory.id }),
-      ]);
+      );
+      expect(embeddingRows).not.toContainEqual(
+        expect.objectContaining({ memoryId: oldMemory.memory.id }),
+      );
 
       nowMs = TEST_NOW_MS + 2;
       await expect(

--- a/specs/memory-plugin/storage.md
+++ b/specs/memory-plugin/storage.md
@@ -140,6 +140,13 @@ equality and very-high embedding similarity when embeddings are available.
 Exact content remains one suppression signal, not a durable identity for memory
 facts.
 
+Conservative supersession may run after duplicate suppression for requester
+preference memories. The store must consider only active memories in the same
+scope, subject, and kind, and must mark old rows superseded only when the memory
+agent confidently decides that the new preference replaces the same mutable
+preference slot. Uncertain, duplicate, additive, or different-topic preferences
+remain active. Procedure and knowledge memories do not use V1 supersession.
+
 ### Lexical Search
 
 Lexical search is required because embeddings are optional operationally and can
@@ -252,10 +259,15 @@ Memory creation follows this order:
    extractor decisions.
 3. Run deterministic structural validation for schemas, authority fields,
    lifecycle bounds, idempotency, and storage constraints.
-4. Insert the memory record transactionally.
-5. After the transaction commits, batch-generate embeddings for inserted records
+4. Resolve idempotent retries and conservative duplicate matches before insert.
+5. For requester preference memories, adjudicate conservative supersession after
+   duplicate suppression and before insert.
+6. Insert the memory record transactionally. When supersession was confidently
+   adjudicated, mark still-active superseded rows and delete their derived
+   vectors in the same transaction.
+7. After the transaction commits, batch-generate embeddings for inserted records
    when an embedding provider is configured.
-6. Store or repair vector data only when provider output matches the configured
+8. Store or repair vector data only when provider output matches the configured
    vector storage.
 
 Provider calls must not run inside the SQL transaction.


### PR DESCRIPTION
Add conservative supersession for requester preference memories.

Memory writes now ask the memory agent whether a new personal preference clearly replaces active old preferences in the same scope and subject. Duplicate and idempotency checks still run first, and supersession only applies to non-expired personal preference replacements. Superseded rows stay in place with supersededAtMs / supersededById, while old derived embeddings are removed in the same transaction.

This wires the same behavior through explicit memory tool writes and passive completed-session processing, keeps list/search/remove tool contexts narrower than create writes, and updates the storage contract plus storage/eval coverage.

Refs GH-658