### PR TITLE
fix(slack): Tighten channel post tool steering

### DIFF
--- a/packages/junior-evals/evals/core/routing-and-continuity.eval.ts
+++ b/packages/junior-evals/evals/core/routing-and-continuity.eval.ts
@@ -1,26 +1,5 @@
-import { assistantMessages, describeEval, toolCalls } from "vitest-evals";
-import type { HarnessRun } from "vitest-evals/harness";
-import { expect } from "vitest";
+import { describeEval } from "vitest-evals";
 import { mention, rubric, slackEvals, threadMessage } from "../../src/helpers";
-
-type EvalRun = HarnessRun;
-
-function expectOnlyThreadReplies(result: EvalRun): void {
-  const messages = assistantMessages(result.session);
-  expect(
-    toolCalls(result.session).some(
-      (call) => call.name === "slackChannelPostMessage",
-    ),
-  ).toBe(false);
-  expect(
-    messages.some((message) => message.metadata?.event_type === "channel_post"),
-  ).toBe(false);
-  expect(
-    messages.filter(
-      (message) => message.metadata?.event_type === "thread_post",
-    ),
-  ).toHaveLength(1);
-}
 
 describeEval("Routing and Continuity", slackEvals, (it) => {
   it("when a thread message explicitly mentions Junior, post a direct reply", async ({
@@ -50,37 +29,6 @@ describeEval("Routing and Continuity", slackEvals, (it) => {
         ],
       }),
     });
-  });
-
-  it("when Junior is mentioned mid-sentence, answer in the thread instead of pinging the channel", async ({
-    run,
-  }) => {
-    const thread = {
-      id: "thread-mid-sentence-mention",
-      channel_id: "CMIDSENTENCE",
-      thread_ts: "17000000.mid-sentence",
-    };
-    const result = await run({
-      events: [
-        threadMessage(
-          "This is a good point. Just doing some quick digging: <@U0AGGRG1V0X> what is the largest amount of aggregates we can feasibly get to? context: I'm wondering if we need a lot of server logic to handle exporting many of them at once.",
-          { thread, is_mention: true },
-        ),
-      ],
-      criteria: rubric({
-        pass: [
-          "The assistant posts exactly one thread reply in the original thread.",
-          "The assistant treats the aggregates question as a request for Junior to answer or investigate, not as a request to relay a message to another Slack user.",
-        ],
-        fail: [
-          "Do not create a channel_post message.",
-          "Do not call slackChannelPostMessage.",
-          "Do not paraphrase the user's message back into Slack.",
-        ],
-      }),
-    });
-
-    expectOnlyThreadReplies(result);
   });
 
   it("when asked to post in another named channel, explain the limitation instead", async ({

--- a/packages/junior-evals/evals/core/routing-and-continuity.eval.ts
+++ b/packages/junior-evals/evals/core/routing-and-continuity.eval.ts
@@ -1,5 +1,26 @@
-import { describeEval } from "vitest-evals";
+import { assistantMessages, describeEval, toolCalls } from "vitest-evals";
+import type { HarnessRun } from "vitest-evals/harness";
+import { expect } from "vitest";
 import { mention, rubric, slackEvals, threadMessage } from "../../src/helpers";
+
+type EvalRun = HarnessRun;
+
+function expectOnlyThreadReplies(result: EvalRun): void {
+  const messages = assistantMessages(result.session);
+  expect(
+    toolCalls(result.session).some(
+      (call) => call.name === "slackChannelPostMessage",
+    ),
+  ).toBe(false);
+  expect(
+    messages.some((message) => message.metadata?.event_type === "channel_post"),
+  ).toBe(false);
+  expect(
+    messages.filter(
+      (message) => message.metadata?.event_type === "thread_post",
+    ),
+  ).toHaveLength(1);
+}
 
 describeEval("Routing and Continuity", slackEvals, (it) => {
   it("when a thread message explicitly mentions Junior, post a direct reply", async ({
@@ -29,6 +50,37 @@ describeEval("Routing and Continuity", slackEvals, (it) => {
         ],
       }),
     });
+  });
+
+  it("when Junior is mentioned mid-sentence, answer in the thread instead of pinging the channel", async ({
+    run,
+  }) => {
+    const thread = {
+      id: "thread-mid-sentence-mention",
+      channel_id: "CMIDSENTENCE",
+      thread_ts: "17000000.mid-sentence",
+    };
+    const result = await run({
+      events: [
+        threadMessage(
+          "This is a good point. Just doing some quick digging: <@U0AGGRG1V0X> what is the largest amount of aggregates we can feasibly get to? context: I'm wondering if we need a lot of server logic to handle exporting many of them at once.",
+          { thread, is_mention: true },
+        ),
+      ],
+      criteria: rubric({
+        pass: [
+          "The assistant posts exactly one thread reply in the original thread.",
+          "The assistant treats the aggregates question as a request for Junior to answer or investigate, not as a request to relay a message to another Slack user.",
+        ],
+        fail: [
+          "Do not create a channel_post message.",
+          "Do not call slackChannelPostMessage.",
+          "Do not paraphrase the user's message back into Slack.",
+        ],
+      }),
+    });
+
+    expectOnlyThreadReplies(result);
   });
 
   it("when asked to post in another named channel, explain the limitation instead", async ({

--- a/packages/junior/src/chat/tools/slack/channel-post-message.ts
+++ b/packages/junior/src/chat/tools/slack/channel-post-message.ts
@@ -12,7 +12,7 @@ export function createSlackChannelPostMessageTool(
 ) {
   return tool({
     description:
-      "Post a new top-level message in the active Slack channel, outside the current thread. Use this only when the user's current message explicitly asks you to post/send/share/say/announce/broadcast a message to the current channel. Do not use this for normal answers, thread replies, paraphrasing or forwarding the user's message, speculative broadcasts, or pinging a mentioned user. An inline Slack @mention in the user's message is not by itself a request to relay or ping that user; answer the user in the thread instead. For requests targeting another named channel, explain that limitation instead. Do not claim a channel message was posted unless this tool succeeds in this turn.",
+      "Post a new top-level message to the current Slack channel. Use only when the user explicitly asks to post/send/share/say something to the channel. Do not use for thread replies, inline @mentions, or pinging mentioned users.",
     inputSchema: Type.Object({
       text: Type.String({
         minLength: 1,

--- a/packages/junior/src/chat/tools/slack/channel-post-message.ts
+++ b/packages/junior/src/chat/tools/slack/channel-post-message.ts
@@ -12,7 +12,7 @@ export function createSlackChannelPostMessageTool(
 ) {
   return tool({
     description:
-      "Post a message in the active Slack channel context (outside the thread). Use this only when the user explicitly asks to post/send/share/say something in the current channel. Do not use it for normal thread replies, speculative broadcasts, or requests targeting another named channel; explain that limitation instead. Do not claim a channel message was posted unless this tool succeeds in this turn.",
+      "Post a new top-level message in the active Slack channel, outside the current thread. Use this only when the user's current message explicitly asks you to post/send/share/say/announce/broadcast a message to the current channel. Do not use this for normal answers, thread replies, paraphrasing or forwarding the user's message, speculative broadcasts, or pinging a mentioned user. An inline Slack @mention in the user's message is not by itself a request to relay or ping that user; answer the user in the thread instead. For requests targeting another named channel, explain that limitation instead. Do not claim a channel message was posted unless this tool succeeds in this turn.",
     inputSchema: Type.Object({
       text: Type.String({
         minLength: 1,


### PR DESCRIPTION
The Slack channel-post tool now makes its top-level-channel behavior explicit and steers the model away from using it for thread replies, inline mentions, forwarding user text, or pinging mentioned users. The intended explicit request path for posting to the current channel stays unchanged.

Fixes #672