### PR TITLE
feat(memory): Add observed freshness to recall

### DIFF
--- a/packages/junior-memory/src/recall.ts
+++ b/packages/junior-memory/src/recall.ts
@@ -32,6 +32,10 @@ function trimContent(content: string, maxLength: number): string {
   return `${trimmed.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
 }
 
+function formatObservedDate(observedAtMs: number): string {
+  return new Date(observedAtMs).toISOString().slice(0, 10);
+}
+
 function renderMemoryPrompt(memories: MemoryRecord[]): string | undefined {
   const header = "Relevant memories for this request:";
   const footer =
@@ -40,7 +44,10 @@ function renderMemoryPrompt(memories: MemoryRecord[]): string | undefined {
   let totalChars = header.length + footer.length + 2;
 
   for (const memory of memories) {
-    const line = `- ${trimContent(memory.content, MAX_MEMORY_LINE_CHARS)}`;
+    const line = `- Observed ${formatObservedDate(memory.observedAtMs)}: ${trimContent(
+      memory.content,
+      MAX_MEMORY_LINE_CHARS,
+    )}`;
     if (totalChars + line.length + 1 > MAX_PROMPT_CHARS) {
       break;
     }

--- a/packages/junior-memory/src/store.ts
+++ b/packages/junior-memory/src/store.ts
@@ -54,6 +54,8 @@ const SUPERSESSION_CANDIDATE_LIMIT = 10;
 const VECTOR_SEARCH_OVERFETCH = 4;
 const MAX_MEMORY_CONTENT_CHARS = 4_000;
 const EMBEDDING_METRIC = "cosine";
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const RELEVANCE_NEAR_TIE_DELTA = 0.01;
 const SUPERSESSION_STOP_TERMS = new Set([
   "and",
   "for",
@@ -1052,8 +1054,26 @@ async function searchVisibleVectorMemories(args: {
   });
 }
 
-/** Fuse higher-is-better retrieval candidates before applying the final limit. */
-function mergeSearchCandidates(candidates: SearchCandidate[]): MemoryRecord[] {
+/** Score only observation age for near-tie reranking; this is not lifecycle decay. */
+function observedAgeBoost(memory: MemoryRecord, nowMs: number): number {
+  const ageMs = Math.max(0, nowMs - memory.observedAtMs);
+  if (ageMs <= 7 * ONE_DAY_MS) {
+    return 0.15;
+  }
+  if (ageMs <= 30 * ONE_DAY_MS) {
+    return 0.1;
+  }
+  if (ageMs <= 90 * ONE_DAY_MS) {
+    return 0.05;
+  }
+  return 0;
+}
+
+/** Fuse retrieval candidates while keeping observed age to near-tie reranking. */
+function mergeSearchCandidates(
+  candidates: SearchCandidate[],
+  nowMs: number,
+): MemoryRecord[] {
   const byId = new Map<
     string,
     {
@@ -1073,12 +1093,18 @@ function mergeSearchCandidates(candidates: SearchCandidate[]): MemoryRecord[] {
     });
   }
   return [...byId.values()]
-    .sort(
-      (left, right) =>
-        right.score - left.score ||
-        right.memory.createdAtMs - left.memory.createdAtMs ||
-        left.memory.id.localeCompare(right.memory.id),
-    )
+    .sort((left, right) => {
+      const scoreDelta = right.score - left.score;
+      if (Math.abs(scoreDelta) > RELEVANCE_NEAR_TIE_DELTA) {
+        return scoreDelta;
+      }
+      return (
+        observedAgeBoost(right.memory, nowMs) -
+          observedAgeBoost(left.memory, nowMs) ||
+        right.memory.observedAtMs - left.memory.observedAtMs ||
+        left.memory.id.localeCompare(right.memory.id)
+      );
+    })
     .map((candidate) => candidate.memory);
 }
 
@@ -1392,10 +1418,10 @@ export function createMemoryStore(
       const lexicalCandidates = candidates
         .map((memory) => ({ memory, score: searchScore(memory, terms) }))
         .filter((item) => item.score > 0);
-      return mergeSearchCandidates([
-        ...vectorCandidates,
-        ...lexicalCandidates,
-      ]).slice(0, limit);
+      return mergeSearchCandidates(
+        [...vectorCandidates, ...lexicalCandidates],
+        nowMs,
+      ).slice(0, limit);
     },
 
     async archiveMemory(input) {

--- a/packages/junior-memory/src/tools.ts
+++ b/packages/junior-memory/src/tools.ts
@@ -1,4 +1,4 @@
-import { Type, type TSchema } from "@sinclair/typebox";
+import { Type, type Static, type TSchema } from "@sinclair/typebox";
 import { Value } from "@sinclair/typebox/value";
 import {
   getSourceKey,
@@ -291,6 +291,18 @@ const searchMemoriesInputSchema = Type.Object(
   { additionalProperties: false },
 );
 
+const memoryToolProjectionSchema = Type.Object(
+  {
+    id: Type.String({ minLength: 1 }),
+    content: Type.String({ minLength: 1 }),
+    createdAtMs: Type.Number(),
+    observedAtMs: Type.Number(),
+    expiresAtMs: Type.Optional(Type.Number()),
+  },
+  { additionalProperties: false },
+);
+type MemoryToolProjection = Static<typeof memoryToolProjectionSchema>;
+
 function parseToolInput<T>(schema: TSchema, input: unknown): T {
   try {
     if (!Value.Check(schema, input)) {
@@ -335,15 +347,16 @@ function targetForKind(kind: MemoryKind): "requester" | "conversation" {
 }
 
 /** Return the model-visible projection without hidden ownership/source fields. */
-function compactMemory(memory: MemoryRecord) {
-  return {
+function compactMemory(memory: MemoryRecord): MemoryToolProjection {
+  return Value.Parse(memoryToolProjectionSchema, {
     id: memory.id,
     content: memory.content,
     createdAtMs: memory.createdAtMs,
+    observedAtMs: memory.observedAtMs,
     ...(memory.expiresAtMs !== undefined
       ? { expiresAtMs: memory.expiresAtMs }
       : {}),
-  };
+  });
 }
 
 /** Create a tool that submits an explicit memory candidate for storage. */

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -189,6 +189,13 @@ function unitEmbedding(index: number): number[] {
   return embedding;
 }
 
+function cosineEmbedding(cosine: number): number[] {
+  const embedding = Array.from({ length: TEST_EMBEDDING_DIMENSIONS }, () => 0);
+  embedding[0] = cosine;
+  embedding[1] = Math.sqrt(1 - cosine * cosine);
+  return embedding;
+}
+
 function createTestEmbedder(
   vectors: Record<string, number[]> = {},
   overrides: { dimensions?: number; model?: string; provider?: string } = {},
@@ -1639,6 +1646,110 @@ WHERE id = '${superseded.memory.id}'
     }
   }, 15_000);
 
+  it("uses observed recency only as a relevance tie-breaker", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      let nowMs = TEST_NOW_MS - 120 * 24 * 60 * 60 * 1000;
+      const store = createMemoryStore(memoryDb(fixture), slackContext(), {
+        now: () => nowMs,
+      });
+      const oldRelevant = await store.createMemory({
+        content:
+          "Deploy checklist ownership escalation requires release approval.",
+        kind: "knowledge",
+        idempotencyKey: "memory-test:recency-old-relevant",
+      });
+      nowMs = TEST_NOW_MS;
+      const newLessRelevant = await store.createMemory({
+        content: "Deploy snacks live near the office checklist.",
+        kind: "knowledge",
+        idempotencyKey: "memory-test:recency-new-less-relevant",
+      });
+
+      await expect(
+        store.searchMemories({
+          limit: 2,
+          query: "deploy checklist ownership escalation approval",
+        }),
+      ).resolves.toEqual([
+        expect.objectContaining({ id: oldRelevant.memory.id }),
+        expect.objectContaining({ id: newLessRelevant.memory.id }),
+      ]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("prefers newer memories when search relevance is otherwise equal", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      let nowMs = TEST_NOW_MS - 120 * 24 * 60 * 60 * 1000;
+      const store = createMemoryStore(memoryDb(fixture), slackContext(), {
+        now: () => nowMs,
+      });
+      const oldMemory = await store.createMemory({
+        content: "Deploy checklist lives in the legacy wiki.",
+        kind: "knowledge",
+        idempotencyKey: "memory-test:recency-old-equal",
+      });
+      nowMs = TEST_NOW_MS;
+      const newMemory = await store.createMemory({
+        content: "Deploy checklist lives in Notion.",
+        kind: "knowledge",
+        idempotencyKey: "memory-test:recency-new-equal",
+      });
+
+      await expect(
+        store.searchMemories({ limit: 2, query: "deploy checklist" }),
+      ).resolves.toEqual([
+        expect.objectContaining({ id: newMemory.memory.id }),
+        expect.objectContaining({ id: oldMemory.memory.id }),
+      ]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("keeps vector relevance ahead of observed recency outside near ties", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      const query = "semantic needle";
+      const oldContent = "Old vector-only memory.";
+      const newContent = "New vector-only memory.";
+      const embedder = createTestEmbedder({
+        [query]: unitEmbedding(0),
+        [oldContent]: cosineEmbedding(0.995),
+        [newContent]: cosineEmbedding(0.9),
+      });
+      let nowMs = TEST_NOW_MS - 120 * 24 * 60 * 60 * 1000;
+      const store = createMemoryStore(memoryDb(fixture), slackContext(), {
+        embedder,
+        now: () => nowMs,
+      });
+      const oldMemory = await store.createMemory({
+        content: oldContent,
+        kind: "knowledge",
+        idempotencyKey: "memory-test:recency-vector-old",
+      });
+      nowMs = TEST_NOW_MS;
+      const newMemory = await store.createMemory({
+        content: newContent,
+        kind: "knowledge",
+        idempotencyKey: "memory-test:recency-vector-new",
+      });
+
+      await expect(store.searchMemories({ limit: 2, query })).resolves.toEqual([
+        expect.objectContaining({ id: oldMemory.memory.id }),
+        expect.objectContaining({ id: newMemory.memory.id }),
+      ]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
   it("does not duplicate embeddings for idempotent create retries", async () => {
     const fixture = await createMemoryFixture();
 
@@ -2324,6 +2435,7 @@ WHERE id = '${superseded.memory.id}'
         },
       ]);
       const text = result?.[0]?.text ?? "";
+      expect(text).toContain(`Observed 2026-06-19: ${personal.memory.content}`);
       expect(text).toContain(conversation.memory.content);
       expect(text).not.toContain(personal.memory.id);
       expect(text).not.toContain(conversation.memory.id);

--- a/specs/memory-plugin/retrieval.md
+++ b/specs/memory-plugin/retrieval.md
@@ -83,7 +83,14 @@ agent, ranker/evaluator, and eval coverage.
 2. Run lexical search against memory content to retrieve candidates.
 3. For automatic injection only, drop memories already injected into the active
    session projection.
-4. Return the top memories within count and character budgets.
+4. Use observed age as a near-tie reranking signal for otherwise similar
+   candidates, without letting age overtake materially stronger relevance.
+5. Return the top memories within count and character budgets.
+
+Observed age is context and a weak ranking signal, not a lifecycle signal.
+Age alone must not archive, expire, or supersede a memory. Hard lifecycle still
+comes only from expiration, supersession, explicit removal, policy/security
+repair, or future admin workflows.
 
 Do not add regexes, keyword lists, stopwords, or text-shape heuristics as a
 semantic relevance gate. If recall relevance is weak, improve the memory agent,
@@ -125,6 +132,7 @@ must:
 - include only active visible memories
 - stay within configured count and character limits
 - avoid raw provenance unless needed for disambiguation
+- include the observation date for each memory when rendering automatic recall
 - avoid ids
 - not include secrets or archived facts
 - not include facts whose scope is no longer visible

--- a/specs/memory-plugin/tools.md
+++ b/specs/memory-plugin/tools.md
@@ -151,6 +151,9 @@ Tool output must be concise and must not reveal hidden private metadata. For
 private conversations, tool output may contain memory content because it is
 model-visible response context, but logs/traces/reporting for that tool must
 redact content according to [`../data-redaction-policy.md`](../data-redaction-policy.md).
+Model-visible memory projections may include the memory id, content,
+`createdAtMs`, `observedAtMs`, and optional `expiresAtMs`. They must not include
+hidden ownership, source, subject, Slack, actor, or provenance fields.
 
 ## Related Specs
 


### PR DESCRIPTION
Memory recall now shows when each injected memory was observed, and explicit memory tool projections include the same observation timestamp. Retrieval uses observed age only as a near-tie reranking signal, so stronger lexical or vector relevance still wins and age never archives, expires, or supersedes a memory.

The memory retrieval and tool specs document that boundary: observation time is model-visible context, while lifecycle remains limited to explicit expiration, supersession, removal, or repair.