### PR TITLE
ci: add PR risk experiment workflow

### DIFF
--- a/.github/workflows/pr-risk.yml
+++ b/.github/workflows/pr-risk.yml
@@ -1,0 +1,36 @@
+name: PR Risk Experiment
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: pr-risk-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  risk:
+    name: Score PR risk
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+
+    steps:
+      - name: Score current PR
+        uses: getsentry/pr-risk-action@v0
+        with:
+          repo: ${{ github.repository }}
+          pr-number: ${{ github.event.pull_request.number }}
+          result-path: risk-pr-result.json
+          skip-reviews: "true"
+          apply-label: "true"
+
+      - name: Upload risk result
+        uses: actions/upload-artifact@v4
+        with:
+          name: risk-pr-result
+          path: risk-pr-result.json


### PR DESCRIPTION
Adds the PR Risk Action as an advisory workflow for non-draft pull requests. It runs on `pull_request_target` so it can keep the `risk: low|medium|high` label in sync, but it does not checkout or execute PR code.

The Action now has a bundled `getsentry__junior` profile in `getsentry/pr-risk-action@v0`, so this repo does not need to vendor any scorer code or model artifacts.

Validation:
- Workflow YAML parsed locally.
- Verified `getsentry/pr-risk-action@v0` includes the Junior profile and can score `getsentry/junior#675` locally.
