### PR TITLE
docs(using-junior): add stop/redirect section and plan-before-acting example

### DIFF
--- a/packages/docs/src/content/docs/start-here/using-junior.md
+++ b/packages/docs/src/content/docs/start-here/using-junior.md
@@ -25,7 +25,12 @@ Vague requests usually produce vague answers. Ask for a specific outcome and inc
 | `@jr make this better`      | `@jr review this onboarding doc for unclear steps. Keep the tone direct and suggest edits, but do not change setup commands.`               |
 | `@jr look at the Slack bug` | `@jr the bot replies in DMs but not channel threads. Check the event path and tell me which Slack config or runtime path is wrong.`         |
 
-If you know a boundary, say it upfront. For example, tell Junior whether to only investigate, whether it can edit files, whether it should avoid committing, or whether it should wait before touching production settings.
+If you know a boundary, say it upfront — tell Junior whether to only investigate, whether it can edit files, whether it should avoid committing, or whether it should wait before touching production settings. For risky or ambiguous work, ask it to lay out the plan before acting:
+
+```
+@jr this migration may touch production data.
+Inspect the code and describe what you would do — do not run commands or open a PR until I say go.
+```
 
 ## Use public threads by default
 
@@ -52,6 +57,17 @@ Start a new thread when the goal changes:
 Mention `@jr` when you want Junior to join a channel thread. After Junior has replied in that thread, follow-up replies in the same thread do not need another mention.
 
 In DMs, send the request directly. In shared channels, prefer a thread over a top-level back-and-forth so the work stays grouped with the original context.
+
+## Steering Junior
+
+Junior reads every message in the thread, so you can course-correct at any point without starting over. Reply with plain language to redirect, narrow scope, stop the current task, or adjust how much detail you want:
+
+- **Redirect:** `@jr focus on the worker path only, not the whole queue`
+- **Stop:** `@jr stop — I meant staging, not prod`
+- **Narrow scope:** `@jr skip the frontend, just fix the query`
+- **Verbosity:** `@jr tl;dr` or `@jr more detail on the error handling`
+
+Junior cannot undo side effects that have already landed — a pushed commit, a filed issue, a sent Slack message. Redirect before the action, not after.
 
 ## Verify important output
 


### PR DESCRIPTION
## What

Two additions to the Using Junior usage guide:

1. **Stop or redirect Junior** — new section explaining how to interrupt a task with plain language (stop, nevermind, wait — redirect to X), the side-effect caveat (can't undo what already landed), and verbosity controls (tl;dr / more detail).

2. **Plan before acting** — expand the boundary-setting paragraph in *Write a concrete request* with a code block example showing how to ask Junior to lay out its plan before running anything, useful for risky migrations or production-adjacent work.

Three fenced code-block conversation examples are now scattered across the page so readers have concrete phrasing to copy.

## Why

The page had no guidance on stopping or redirecting Junior mid-task, and no coverage of asking it to plan before executing. Both come up regularly in practice.