### PR TITLE
feat(memory): Boost same-channel recall matches

### DIFF
--- a/packages/junior-memory/src/store.ts
+++ b/packages/junior-memory/src/store.ts
@@ -56,6 +56,7 @@ const MAX_MEMORY_CONTENT_CHARS = 4_000;
 const EMBEDDING_METRIC = "cosine";
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const RELEVANCE_NEAR_TIE_DELTA = 0.01;
+const SOURCE_CHANNEL_BOOST = 0.05;
 const SUPERSESSION_STOP_TERMS = new Set([
   "and",
   "for",
@@ -73,6 +74,7 @@ export type MemoryDb = PgDatabase<PgQueryResultHKT, typeof memorySqlSchema>;
 interface SearchCandidate {
   memory: MemoryRecord;
   score: number;
+  sourceKey: string;
 }
 
 interface MemoryEmbedding {
@@ -343,6 +345,14 @@ function sourceKey(ctx: MemoryRuntimeContext): string {
     );
   }
   return `slack:${ctx.source.teamId}:${ctx.source.channelId}:${threadKey}`;
+}
+
+function sourceChannelPrefix(ctx: MemoryRuntimeContext): string | undefined {
+  if (ctx.source.platform !== "slack") {
+    return undefined;
+  }
+  // TODO(v0.82.0): Replace Slack source-key prefix matching with typed source proximity metadata.
+  return `slack:${ctx.source.teamId}:${ctx.source.channelId}:`;
 }
 
 /** Parse one SQL row into the public memory record projection. */
@@ -961,7 +971,7 @@ async function searchVisibleMemories(args: {
   nowMs: number;
   query: string;
   scopes: ResolvedMemoryScope[];
-}): Promise<MemoryRecord[]> {
+}): Promise<SearchCandidate[]> {
   const terms = searchTerms(args.query);
   if (terms.length === 0) {
     return [];
@@ -983,7 +993,11 @@ async function searchVisibleMemories(args: {
         ),
       ),
     );
-  return rows.map(parseMemoryRow);
+  return rows.map((row) => ({
+    memory: parseMemoryRow(row),
+    score: 0,
+    sourceKey: row.sourceKey,
+  }));
 }
 
 /** Search active visible records with exact pgvector cosine distance. */
@@ -1055,9 +1069,22 @@ async function searchVisibleVectorMemories(args: {
       {
         memory: parseMemoryRow(row.memory),
         score: 1 / (1 + Math.max(0, distanceValue)),
+        sourceKey: row.memory.sourceKey,
       },
     ];
   });
+}
+
+function sourceBoost(
+  candidate: Pick<SearchCandidate, "sourceKey">,
+  currentChannelPrefix: string | undefined,
+): number {
+  if (!currentChannelPrefix) {
+    return 0;
+  }
+  return candidate.sourceKey.startsWith(currentChannelPrefix)
+    ? SOURCE_CHANNEL_BOOST
+    : 0;
 }
 
 /** Score only observation age for near-tie reranking; this is not lifecycle decay. */
@@ -1079,12 +1106,14 @@ function observedAgeBoost(memory: MemoryRecord, nowMs: number): number {
 function mergeSearchCandidates(
   candidates: SearchCandidate[],
   nowMs: number,
+  currentChannelKey?: string,
 ): MemoryRecord[] {
   const byId = new Map<
     string,
     {
       memory: MemoryRecord;
       score: number;
+      sourceKey: string;
     }
   >();
   for (const candidate of candidates) {
@@ -1096,6 +1125,7 @@ function mergeSearchCandidates(
     byId.set(candidate.memory.id, {
       memory: candidate.memory,
       score: candidate.score,
+      sourceKey: candidate.sourceKey,
     });
   }
   return [...byId.values()]
@@ -1103,6 +1133,12 @@ function mergeSearchCandidates(
       const scoreDelta = right.score - left.score;
       if (Math.abs(scoreDelta) > RELEVANCE_NEAR_TIE_DELTA) {
         return scoreDelta;
+      }
+      const sourceDelta =
+        sourceBoost(right, currentChannelKey) -
+        sourceBoost(left, currentChannelKey);
+      if (sourceDelta !== 0) {
+        return sourceDelta;
       }
       return (
         observedAgeBoost(right.memory, nowMs) -
@@ -1411,7 +1447,9 @@ export function createMemoryStore(
         db,
         embedder,
         limit: limit * VECTOR_SEARCH_OVERFETCH,
-        ...(maxVectorDistance !== undefined ? { maxDistance: maxVectorDistance } : {}),
+        ...(maxVectorDistance !== undefined
+          ? { maxDistance: maxVectorDistance }
+          : {}),
         nowMs,
         query: input.query,
         scopes,
@@ -1424,11 +1462,15 @@ export function createMemoryStore(
       });
       const terms = searchTerms(input.query);
       const lexicalCandidates = candidates
-        .map((memory) => ({ memory, score: searchScore(memory, terms) }))
+        .map((candidate) => ({
+          ...candidate,
+          score: searchScore(candidate.memory, terms),
+        }))
         .filter((item) => item.score > 0);
       return mergeSearchCandidates(
         [...vectorCandidates, ...lexicalCandidates],
         nowMs,
+        sourceChannelPrefix(runtimeContext),
       ).slice(0, limit);
     },
 

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -1646,6 +1646,108 @@ WHERE id = '${superseded.memory.id}'
     }
   }, 15_000);
 
+  it("prefers same-channel memories for otherwise close public conversation matches", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      let nowMs = TEST_NOW_MS - 1;
+      const sameChannelStore = createMemoryStore(
+        memoryDb(fixture),
+        slackContext({ channelId: "C123" }),
+        {
+          now: () => nowMs,
+        },
+      );
+      const sameChannel = await sameChannelStore.createConversationMemory({
+        content: "Deploy checklist lives in the release runbook.",
+        kind: "knowledge",
+        idempotencyKey: "memory-test:source-boost-same",
+      });
+
+      nowMs = TEST_NOW_MS;
+      const otherChannelStore = createMemoryStore(
+        memoryDb(fixture),
+        slackContext({ channelId: "C456" }),
+        {
+          now: () => nowMs,
+        },
+      );
+      const otherChannel = await otherChannelStore.createConversationMemory({
+        content: "Deploy checklist lives in the release notes.",
+        kind: "knowledge",
+        idempotencyKey: "memory-test:source-boost-other",
+      });
+
+      await expect(
+        sameChannelStore.searchMemories({
+          limit: 2,
+          query: "deploy checklist lives release",
+        }),
+      ).resolves.toEqual([
+        expect.objectContaining({ id: sameChannel.memory.id }),
+        expect.objectContaining({ id: otherChannel.memory.id }),
+      ]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("keeps stronger vector relevance ahead of same-channel proximity", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      const query = "semantic channel relevance";
+      const sameChannelContent = "Same channel semantic memory.";
+      const otherChannelContent = "Other channel stronger semantic memory.";
+      const embedder = createTestEmbedder({
+        [query]: unitEmbedding(0),
+        [sameChannelContent]: cosineEmbedding(0.9),
+        [otherChannelContent]: cosineEmbedding(0.995),
+      });
+      let nowMs = TEST_NOW_MS;
+      const sameChannelStore = createMemoryStore(
+        memoryDb(fixture),
+        slackContext({ channelId: "C123" }),
+        {
+          embedder,
+          now: () => nowMs,
+        },
+      );
+      const sameChannel = await sameChannelStore.createConversationMemory({
+        content: sameChannelContent,
+        kind: "knowledge",
+        idempotencyKey: "memory-test:source-boost-vector-same",
+      });
+
+      nowMs += 1;
+      const otherChannelStore = createMemoryStore(
+        memoryDb(fixture),
+        slackContext({ channelId: "C456" }),
+        {
+          embedder,
+          now: () => nowMs,
+        },
+      );
+      const otherChannel = await otherChannelStore.createConversationMemory({
+        content: otherChannelContent,
+        kind: "knowledge",
+        idempotencyKey: "memory-test:source-boost-vector-other",
+      });
+
+      await expect(
+        sameChannelStore.searchMemories({
+          limit: 2,
+          query,
+        }),
+      ).resolves.toEqual([
+        expect.objectContaining({ id: otherChannel.memory.id }),
+        expect.objectContaining({ id: sameChannel.memory.id }),
+      ]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
   it("uses observed recency only as a relevance tie-breaker", async () => {
     const fixture = await createMemoryFixture();
 

--- a/specs/memory-plugin/retrieval.md
+++ b/specs/memory-plugin/retrieval.md
@@ -102,7 +102,10 @@ Embedding support may upgrade this to hybrid retrieval:
 1. Run vector search when embeddings are configured and the user text can be
    embedded.
 2. Merge lexical and vector results with reciprocal-rank style fusion.
-3. Apply the same visibility filtering, ranking model, and prompt budgets.
+3. Apply weak same-source proximity reranking after visibility filtering. For
+   Slack sources this is channel-granular, not thread-granular, and must remain
+   small enough that materially stronger semantic or lexical matches still win.
+4. Apply the same visibility filtering, ranking model, and prompt budgets.
 
 Vector results should be overfetched before final filtering and prompt
 formatting. Approximate vector search must be exact-reranked over visible


### PR DESCRIPTION
Memory recall now gives same-channel Slack memories priority when lexical/vector relevance is already a near tie. Stronger cross-channel matches still win, so channel proximity acts as a final rerank signal rather than changing candidate retrieval or embedding input.

This deliberately leaves invocation-context query enrichment out of scope. That path needs more research/eval coverage because changing the embedding query can shift semantic retrieval in less predictable ways.

Refs #684