### PR TITLE
docs(meta): improve homepage meta description

### DIFF
--- a/packages/docs/src/content/docs/index.mdx
+++ b/packages/docs/src/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Junior
-description: Production-ready docs for the Junior Slack bot runtime.
+description: Junior brings your tools into Slack. Ask in a thread and get answers backed by live context from Sentry, GitHub, Linear, and whatever else you've connected.
 template: splash
 hero:
   title: '<span class="jr-home-mega-inline">Junior</span><span class="jr-home-headline">Your company''s tools, <span class="jr-highlight">inside Slack.</span></span>'


### PR DESCRIPTION
The old description was generic filler: `Production-ready docs for the Junior Slack bot runtime.`

Replaced with something that actually communicates what Junior is and does, consistent with the hero tagline already on the page.

**Before:** `Production-ready docs for the Junior Slack bot runtime.`
**After:** `Junior brings your tools into Slack. Ask in a thread and get answers backed by live context from Sentry, GitHub, Linear, and whatever else you've connected.`