### PR TITLE
docs(start-here): add Copy agent instructions callout to quickstart

### DIFF
--- a/packages/docs/src/content/docs/start-here/quickstart.md
+++ b/packages/docs/src/content/docs/start-here/quickstart.md
@@ -66,15 +66,15 @@ Goal: Confirm required tools are installed and credentials are ready before
 
   node --version && pnpm --version && vercel --version
   vercel whoami
-  [ "$APP_NAME" != "<replace-me>" ] && echo "APP_NAME is set: $APP_NAME"
+  [ -n "$APP_NAME" ] && [ "$APP_NAME" != "<replace-me>" ] && echo "APP_NAME: $APP_NAME"
 
 Success:
   - All three tools print versions without error.
   - vercel whoami shows an authenticated account.
-  - APP_NAME is set to something other than <replace-me>.
+  - APP_NAME is non-empty and not the literal placeholder <replace-me>.
 
-Stop if: Any tool is missing, Vercel is unauthenticated, or APP_NAME is
-         still <replace-me>.
+Stop if: Any tool is missing, Vercel is unauthenticated, APP_NAME is
+         empty, or APP_NAME is still <replace-me>.
 
 ---
 
@@ -181,7 +181,8 @@ Goal: Deploy to production so the webhook endpoint is publicly reachable before
       the Slack app is created. Slack validates request URLs live on creation.
 Ref:  https://junior.sentry.dev/start-here/deploy-to-vercel/
 
-  vercel --prod $VERCEL_SCOPE | tee /tmp/prod-deploy-url.txt
+  vercel --prod $VERCEL_SCOPE > /tmp/prod-deploy-url.txt
+  cat /tmp/prod-deploy-url.txt
 
   The deployment URL is printed to stdout. The stable production domain is
   usually visible in the Vercel dashboard under the linked project → Domains.
@@ -222,27 +223,37 @@ Stop now and send the human this exact message (fill in STABLE_URL):
   │ Use this as the webhook request URL everywhere the guide asks:
   │   https://<STABLE_URL>/api/webhooks/slack
   │
-  │ When the Slack app is installed, set these in your terminal:
-  │   export SLACK_SIGNING_SECRET="xsec-..."
-  │   export SLACK_BOT_TOKEN="xoxb-..."
-  │
-  │ Then reply: Slack credentials are ready
+  │ When done, reply with both values on separate lines:
+  │   SLACK_SIGNING_SECRET=xsec-...
+  │   SLACK_BOT_TOKEN=xoxb-...
   └───────────────────────────────────────────────────────────────────
 
-Do not run any further commands until the human replies:
-  "Slack credentials are ready"
+Do not run any further commands until the human replies with both values.
 
-After the human confirms, verify:
+When the human replies, extract the two values from their reply and assign:
+
+  SLACK_SIGNING_SECRET="<value from human reply>"
+  SLACK_BOT_TOKEN="<value from human reply>"
+
+Note: Junior verifies Slack request signatures before handling the
+url_verification challenge. If Slack reports URL validation failed, it
+may mean the signing secret was not deployed in time. In that case:
+  1. Upload SLACK_SIGNING_SECRET now (without SLACK_BOT_TOKEN): run Phase 7
+     for SLACK_SIGNING_SECRET only, redeploy, then ask the human to retry
+     configuring Event Subscriptions in the Slack app settings.
+  2. Once URL validation passes, continue with SLACK_BOT_TOKEN upload.
+
+Verify both are assigned:
 
   : "${SLACK_SIGNING_SECRET:?SLACK_SIGNING_SECRET is not set}"
   : "${SLACK_BOT_TOKEN:?SLACK_BOT_TOKEN is not set}"
 
 Success:
-  - Human replied "Slack credentials are ready".
+  - Human provided both values.
   - Both shell variables are non-empty.
 
 Stop if: Either variable is missing, or the human reports that Slack URL
-         validation failed.
+         validation failed and the fallback above did not resolve it.
 
 ---
 

--- a/packages/docs/src/content/docs/start-here/quickstart.md
+++ b/packages/docs/src/content/docs/start-here/quickstart.md
@@ -12,6 +12,298 @@ related:
 
 Start here when you want a new Junior app that follows the supported Hono, Nitro, and Vercel shape.
 
+Want an AI coding agent to handle the full deploy workflow? Copy the runbook below into Cursor, Claude, Copilot, or any agent with terminal access. The runbook does two production deploys: the first brings the app live, the Slack app is created against that live URL, then the second deploy adds Slack credentials. One manual step remains at the gate between those two deploys.
+
+<details>
+<summary>Instructions for your Agent <button title="Copy to clipboard" onclick="event.stopPropagation();var c=this.closest('details').querySelector('code');navigator.clipboard.writeText(c.textContent).then(function(){var s=this.querySelector('svg');s.style.stroke='var(--sl-color-green,#16a34a)';setTimeout(function(){s.style.stroke=''},2000)}.bind(this))" style="display:inline-flex;align-items:center;justify-content:center;padding:3px;margin-left:6px;border:none;background:transparent;cursor:pointer;border-radius:4px;vertical-align:middle;opacity:0.75;color:inherit"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" width="16" height="16" aria-hidden="true"><path d="M3 19a2 2 0 0 1-1-2V2a2 2 0 0 1 1-1h13a2 2 0 0 1 2 1"/><rect x="6" y="5" width="16" height="18" rx="1.5" ry="1.5"/></svg></button></summary>
+
+```text
+# Junior deploy runbook — agent instructions
+
+Workflow: scaffold → link → provision storage → generate secrets →
+  first deploy → [HUMAN GATE: create Slack app] → redeploy → verify.
+
+Two production deploys. The Slack gate sits between them because Slack
+validates webhook URLs against a live endpoint the moment the app is saved.
+
+---
+
+## Inputs
+
+Set both values now. Do not proceed until APP_NAME is replaced.
+
+  APP_NAME="<replace-me>"   # Vercel-safe name, e.g. "my-team-bot"
+  VERCEL_SCOPE=""            # Optional. Set to "--scope <team-slug>" if needed.
+
+---
+
+## Rules
+
+- Stop on any non-zero exit code. Report: phase, command, full output, exit code.
+- Complete every Success check before moving to the next phase.
+- Never guess a CLI product slug, flag, or argument. Use --help, then stop and
+  ask if the output is ambiguous.
+- At Phase 6: stop completely and send the listed gate message. Do not execute
+  any further commands until the human explicitly confirms.
+
+---
+
+## References
+
+  Scaffold CLI        https://junior.sentry.dev/cli/init/
+  Deploy to Vercel    https://junior.sentry.dev/start-here/deploy-to-vercel/
+  Storage setup       https://junior.sentry.dev/start-here/deploy-to-vercel/#add-postgres-storage
+  Config & env vars   https://junior.sentry.dev/reference/config-and-env/
+  Slack app setup     https://junior.sentry.dev/start-here/slack-app-setup/
+  Verify & debug      https://junior.sentry.dev/start-here/verify-and-troubleshoot/
+
+---
+
+## Phase 0 — Preflight
+
+Goal: Confirm required tools are installed and credentials are ready before
+      touching any files.
+
+  node --version && pnpm --version && vercel --version
+  vercel whoami
+  [ "$APP_NAME" != "<replace-me>" ] && echo "APP_NAME is set: $APP_NAME"
+
+Success:
+  - All three tools print versions without error.
+  - vercel whoami shows an authenticated account.
+  - APP_NAME is set to something other than <replace-me>.
+
+Stop if: Any tool is missing, Vercel is unauthenticated, or APP_NAME is
+         still <replace-me>.
+
+---
+
+## Phase 1 — Scaffold
+
+Goal: Initialize the Junior app directory and install dependencies.
+Ref:  https://junior.sentry.dev/cli/init/
+
+  pnpm dlx @sentry/junior init "$APP_NAME"
+  cd "$APP_NAME"
+  pnpm install
+
+  ls vercel.json nitro.config.ts server.ts plugins.ts .env.example
+
+Success:
+  - All five files exist in the app directory.
+  - pnpm install completes without errors.
+
+Stop if: Any listed file is missing or pnpm install fails.
+
+---
+
+## Phase 2 — Link to Vercel
+
+Goal: Link the app directory to a new Vercel project. The --yes flag accepts
+      all prompts and uses the directory name as the project name.
+Ref:  https://junior.sentry.dev/start-here/deploy-to-vercel/
+
+  vercel link --yes $VERCEL_SCOPE
+  cat .vercel/project.json
+
+Success:
+  - .vercel/project.json exists.
+  - Project name and org match what was intended.
+
+Stop if: vercel link exits non-zero, .vercel/project.json is missing, or the
+         project is linked to the wrong scope.
+
+---
+
+## Phase 3 — Provision storage
+
+Goal: Provision Postgres (Neon) and Redis (Upstash) and inject their connection
+      URLs into production, preview, and development environments.
+Ref:  https://junior.sentry.dev/start-here/deploy-to-vercel/#add-postgres-storage
+
+Step 3a — Postgres:
+
+  vercel install neon --plan free -e production -e preview -e development $VERCEL_SCOPE
+
+  If this is the first time Neon is used on this Vercel team, the CLI may open
+  a browser for Marketplace terms acceptance. Complete the flow and re-run.
+
+  vercel env ls production $VERCEL_SCOPE | grep DATABASE_URL
+
+  Success: DATABASE_URL is present in production.
+  Stop if: DATABASE_URL is missing after provisioning.
+
+Step 3b — Redis (Upstash):
+
+  Discover the Redis product slug first — do not guess it:
+
+  vercel install upstash --help
+
+  Read the output. Identify the slug for Redis only (not QStash, Search, or
+  Vector). Then provision it. For example, if the slug is upstash-redis:
+
+  vercel install upstash-redis --plan free -e production -e preview -e development $VERCEL_SCOPE
+
+  vercel env ls production $VERCEL_SCOPE | grep REDIS_URL
+
+  Success: REDIS_URL is present in production.
+  Stop if: The Redis product slug is ambiguous in the help output, or REDIS_URL
+           is missing after provisioning.
+
+---
+
+## Phase 4 — Generate secrets
+
+Goal: Create JUNIOR_SECRET and CRON_SECRET in all three Vercel environments.
+      These sign internal callbacks and authenticate the heartbeat cron.
+Ref:  https://junior.sentry.dev/reference/config-and-env/
+
+  JUNIOR_SECRET=$(node -e "console.log(require('node:crypto').randomBytes(32).toString('base64url'))")
+  CRON_SECRET=$(node -e "console.log(require('node:crypto').randomBytes(32).toString('base64url'))")
+
+  for ENV in production preview development; do
+    printf '%s' "$JUNIOR_SECRET" | vercel env add JUNIOR_SECRET "$ENV" $VERCEL_SCOPE
+    printf '%s' "$CRON_SECRET"   | vercel env add CRON_SECRET   "$ENV" $VERCEL_SCOPE
+  done
+
+  vercel env ls production $VERCEL_SCOPE | grep -E "JUNIOR_SECRET|CRON_SECRET"
+
+Success:
+  - Both secrets appear in production, preview, and development.
+
+Stop if: Any env add command fails or reports a conflict.
+
+---
+
+## Phase 5 — First deploy (no Slack credentials yet)
+
+Goal: Deploy to production so the webhook endpoint is publicly reachable before
+      the Slack app is created. Slack validates request URLs live on creation.
+Ref:  https://junior.sentry.dev/start-here/deploy-to-vercel/
+
+  vercel --prod $VERCEL_SCOPE | tee /tmp/prod-deploy-url.txt
+
+  The deployment URL is printed to stdout. The stable production domain is
+  usually visible in the Vercel dashboard under the linked project → Domains.
+  Record it as STABLE_URL.
+
+  curl -sf "https://$STABLE_URL/health"
+
+  Expected response: {"status":"ok",...}
+
+Success:
+  - Deploy exits 0.
+  - /health returns {"status":"ok"}.
+  - The URL is publicly reachable without an auth interstitial.
+
+Stop if: Deploy fails, the stable URL cannot be determined, or /health is
+         unreachable. Check the dashboard if the URL is unclear.
+
+---
+
+## Phase 6 — HUMAN GATE: Create Slack app
+
+Goal: Pause while the human creates the Slack app using the live production URL.
+      Slack validates the webhook URL immediately on app creation, so the first
+      deploy must be healthy before this step.
+Ref:  https://junior.sentry.dev/start-here/slack-app-setup/
+
+Stop now and send the human this exact message (fill in STABLE_URL):
+
+  ┌───────────────────────────────────────────────────────────────────
+  │ Ready for Slack app setup
+  │
+  │ The first production deploy is live.
+  │ Stable URL: https://<STABLE_URL>
+  │
+  │ Please follow this guide to create the Slack app:
+  │ https://junior.sentry.dev/start-here/slack-app-setup/
+  │
+  │ Use this as the webhook request URL everywhere the guide asks:
+  │   https://<STABLE_URL>/api/webhooks/slack
+  │
+  │ When the Slack app is installed, set these in your terminal:
+  │   export SLACK_SIGNING_SECRET="xsec-..."
+  │   export SLACK_BOT_TOKEN="xoxb-..."
+  │
+  │ Then reply: Slack credentials are ready
+  └───────────────────────────────────────────────────────────────────
+
+Do not run any further commands until the human replies:
+  "Slack credentials are ready"
+
+After the human confirms, verify:
+
+  : "${SLACK_SIGNING_SECRET:?SLACK_SIGNING_SECRET is not set}"
+  : "${SLACK_BOT_TOKEN:?SLACK_BOT_TOKEN is not set}"
+
+Success:
+  - Human replied "Slack credentials are ready".
+  - Both shell variables are non-empty.
+
+Stop if: Either variable is missing, or the human reports that Slack URL
+         validation failed.
+
+---
+
+## Phase 7 — Add Slack credentials and redeploy
+
+Goal: Store Slack credentials in Vercel and run the second production deploy.
+
+  for ENV in production preview development; do
+    printf '%s' "$SLACK_SIGNING_SECRET" | vercel env add SLACK_SIGNING_SECRET "$ENV" $VERCEL_SCOPE
+    printf '%s' "$SLACK_BOT_TOKEN"      | vercel env add SLACK_BOT_TOKEN      "$ENV" $VERCEL_SCOPE
+  done
+
+  vercel env ls production $VERCEL_SCOPE | grep -E "SLACK_SIGNING_SECRET|SLACK_BOT_TOKEN"
+
+  vercel --prod $VERCEL_SCOPE
+
+Success:
+  - Both credentials exist in production, preview, and development.
+  - Second production deploy exits 0.
+
+Stop if: Any env add fails, a conflict is reported, or the deploy fails.
+
+---
+
+## Phase 8 — Verify
+
+Goal: Confirm the bot is healthy, reachable from Slack, and replies to a mention.
+Ref:  https://junior.sentry.dev/start-here/verify-and-troubleshoot/
+
+  curl -sf "https://$STABLE_URL/health"
+
+  Expected response: {"status":"ok",...}
+
+Ask the human to run in their Slack workspace:
+  1. /invite @<bot-display-name>
+  2. Mention the bot in that channel.
+
+Success:
+  - /health returns ok after the second deploy.
+  - Bot adds a processing reaction and posts a reply in the same thread.
+
+Stop if: /health fails, Slack events are not reaching Vercel, or Vercel logs
+         show auth, database, or Redis errors.
+         See: https://junior.sentry.dev/start-here/verify-and-troubleshoot/
+
+---
+
+## Done
+
+Report:
+  - App directory: $APP_NAME/
+  - Vercel project: (from .vercel/project.json)
+  - Production URL: https://$STABLE_URL
+  - Storage: Neon Postgres (DATABASE_URL) · Upstash Redis (REDIS_URL)
+  - Secrets: JUNIOR_SECRET · CRON_SECRET · SLACK_SIGNING_SECRET · SLACK_BOT_TOKEN
+  - Health check: pass or fail
+  - Slack test: pass or waiting for human
+```
+
+</details>
+
 ## Prerequisites
 
 Use the same baseline that the scaffolded CI workflow uses:


### PR DESCRIPTION
## What

Adds a `:::tip[Copy agent instructions]` Starlight aside to the top of `quickstart.md` with a **runbook-format** agent prompt. Users copy it into Cursor, Claude, Copilot, or any agent with terminal access.

## Why

Setup currently requires reading multiple doc pages and executing steps manually. The callout puts the agent prompt exactly where the reader already is.

## Runbook design

Phase-centric blocks — each phase has `Goal`, optional `Ref`, `Commands`, `Success`, and `Stop if`. No cross-phase step numbering.

| Phase | What | Human? |
| --- | --- | --- |
| 0 — Preflight | Verify tools, auth, APP_NAME | — |
| 1 — Scaffold | `junior init` + `pnpm install` | — |
| 2 — Link to Vercel | `vercel link --yes` | — |
| 3 — Provision storage | Neon Postgres + Upstash Redis (slug discovery via `--help`) | Browser flow for Marketplace terms (first-time only) |
| 4 — Generate secrets | `JUNIOR_SECRET` + `CRON_SECRET` via `printf | vercel env add` loop | — |
| 5 — First deploy | `vercel --prod`, `/health` check | Confirm stable URL from dashboard if needed |
| 6 — HUMAN GATE | Agent sends bordered gate message, waits for confirmation | Create Slack app from Slack App Setup guide |
| 7 — Add Slack creds + redeploy | Upload `SLACK_SIGNING_SECRET` + `SLACK_BOT_TOKEN`, second `vercel --prod` | — |
| 8 — Verify | `/health`, invite bot, Slack mention | Invite + mention the bot |

## Design decisions

**Phase-centric blocks over flat steps.** The advisor confirmed this is more reliable for multi-phase terminal workflows — each phase carries its own context, commands, and stop conditions. Failure messages reference the phase, not a global step number.

**Shell variable inputs.** `APP_NAME` and `VERCEL_SCOPE` are declared at the top and guarded in Phase 0 with an executable check. Agents set them once; all subsequent commands reference `$APP_NAME`.

**`printf '%s' | vercel env add` loop** for uploading secrets to all three environments — cleaner than 6 explicit echo lines and avoids bash history exposure.

**Phase 6 HUMAN GATE.** Agent outputs a bordered gate message to the user and blocks on the phrase `Slack credentials are ready`. Human-facing Slack instructions are the message content, not inline agent docs.

**Phase-scoped Ref links.** Each phase with potential ambiguity has one reference URL.

**References table at top** (Scaffold CLI, Deploy, Storage, Config, Slack, Verify) for any phase that needs wider context.

**Prose intro above the callout** explains the two-deploy approach and manual gate in human terms without bloating the copied prompt.

## CLI evidence

| Command | Source |
| --- | --- |
| `vercel link --yes` | vercel.com/docs/cli/link |
| `vercel install neon --plan free -e production -e preview -e development` | vercel.com/docs/marketplace-storage + vercel.com/docs/cli/integration |
| `vercel install upstash --help` (slug discovery) | vercel.com/docs/cli/integration |
| `printf '%s' $VAR | vercel env add NAME env` | vercel.com/docs/cli/env |
| `vercel --prod | tee file` | vercel.com/docs/cli/deploy |

## Pre-ship verification still needed (per #683)

- [ ] Run `vercel install upstash --help` on a real account — confirm Redis slug and free plan ID, then update the example
- [ ] Verify reliable stable URL discovery after `vercel --prod`
- [ ] End-to-end agent test on a fresh Vercel account + Slack workspace

Fixes #683