### PR TITLE
fix(github): update footer to "View Junior Session in Sentry" with -- separator

### DIFF
--- a/packages/junior-github/src/tools/create-issue.ts
+++ b/packages/junior-github/src/tools/create-issue.ts
@@ -7,9 +7,7 @@ import {
 } from "@sentry/junior-plugin-api";
 import { Type, type Static } from "@sinclair/typebox";
 import { Value } from "@sinclair/typebox/value";
-
-const GITHUB_ISSUE_FOOTER_START = "<!-- junior-session-footer:start -->";
-const GITHUB_ISSUE_FOOTER_END = "<!-- junior-session-footer:end -->";
+import { appendGitHubFooter } from "./footer.js";
 const GITHUB_ISSUE_CREATE_IDEMPOTENCY_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const GITHUB_ISSUE_CREATE_LOCK_TTL_MS = 60_000;
 
@@ -105,74 +103,6 @@ function parseRepo(value: string): { name: string; owner: string } {
   };
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function sentryConversationUrl(conversationId: string): string | undefined {
-  const dsn = process.env.SENTRY_DSN?.trim();
-  const orgSlug = process.env.SENTRY_ORG_SLUG?.trim();
-  if (!dsn || !orgSlug) {
-    return undefined;
-  }
-
-  let parsed: URL;
-  try {
-    parsed = new URL(dsn);
-  } catch {
-    return undefined;
-  }
-
-  const projectId = parsed.pathname.split("/").filter(Boolean).at(-1);
-  if (!parsed.hostname || !projectId) {
-    return undefined;
-  }
-
-  const encodedConversationId = encodeURIComponent(conversationId);
-  const params = new URLSearchParams({ project: projectId });
-  const path = `explore/conversations/${encodedConversationId}/?${params.toString()}`;
-
-  if (
-    parsed.hostname === "sentry.io" ||
-    parsed.hostname.endsWith(".sentry.io")
-  ) {
-    return `https://${orgSlug}.sentry.io/${path}`;
-  }
-
-  const port = parsed.port ? `:${parsed.port}` : "";
-  return `${parsed.protocol}//${parsed.hostname}${port}/organizations/${orgSlug}/${path}`;
-}
-
-function githubIssueConversationFooter(
-  conversationId: string,
-): string | undefined {
-  const id = nonEmptyString(conversationId, "conversationId");
-  const sessionUrl = sentryConversationUrl(id);
-  if (!sessionUrl) {
-    return undefined;
-  }
-  return `${GITHUB_ISSUE_FOOTER_START}\n\n--\n\n[View Junior Session in Sentry](${sessionUrl})\n\n${GITHUB_ISSUE_FOOTER_END}`;
-}
-
-function appendGitHubIssueFooter(body: string, conversationId: string): string {
-  const footer = githubIssueConversationFooter(conversationId);
-  const normalizedBody = body.trimEnd();
-  const existingFooter = new RegExp(
-    `${escapeRegExp(GITHUB_ISSUE_FOOTER_START)}[\\s\\S]*?${escapeRegExp(
-      GITHUB_ISSUE_FOOTER_END,
-    )}`,
-  );
-  if (existingFooter.test(normalizedBody)) {
-    return footer
-      ? normalizedBody.replace(existingFooter, footer)
-      : normalizedBody.replace(existingFooter, "").trimEnd();
-  }
-  if (!footer) {
-    return normalizedBody;
-  }
-  return normalizedBody ? `${normalizedBody}\n\n${footer}` : footer;
-}
-
 async function readJsonResponse(response: Response): Promise<unknown> {
   const text = await response.text();
   if (!text) {
@@ -237,7 +167,7 @@ function createGitHubIssueRequest(
   );
   const payload = {
     title: nonEmptyString(input.title, "title"),
-    body: appendGitHubIssueFooter(input.body ?? "", conversationId),
+    body: appendGitHubFooter(input.body ?? "", conversationId),
     ...(labels?.length ? { labels } : {}),
   };
   return new Request(

--- a/packages/junior-github/src/tools/create-issue.ts
+++ b/packages/junior-github/src/tools/create-issue.ts
@@ -151,7 +151,7 @@ function githubIssueConversationFooter(
   if (!sessionUrl) {
     return undefined;
   }
-  return `${GITHUB_ISSUE_FOOTER_START}\n\n[View Session in Sentry](${sessionUrl})\n\n${GITHUB_ISSUE_FOOTER_END}`;
+  return `${GITHUB_ISSUE_FOOTER_START}\n\n--\n\n[View Junior Session in Sentry](${sessionUrl})\n\n${GITHUB_ISSUE_FOOTER_END}`;
 }
 
 function appendGitHubIssueFooter(body: string, conversationId: string): string {

--- a/packages/junior-github/src/tools/create-pull-request.ts
+++ b/packages/junior-github/src/tools/create-pull-request.ts
@@ -160,7 +160,7 @@ function githubPullRequestConversationFooter(
   if (!sessionUrl) {
     return undefined;
   }
-  return `${GITHUB_PULL_REQUEST_FOOTER_START}\n\n[View Session in Sentry](${sessionUrl})\n\n${GITHUB_PULL_REQUEST_FOOTER_END}`;
+  return `${GITHUB_PULL_REQUEST_FOOTER_START}\n\n--\n\n[View Junior Session in Sentry](${sessionUrl})\n\n${GITHUB_PULL_REQUEST_FOOTER_END}`;
 }
 
 function appendGitHubPullRequestFooter(

--- a/packages/junior-github/src/tools/create-pull-request.ts
+++ b/packages/junior-github/src/tools/create-pull-request.ts
@@ -7,9 +7,7 @@ import {
 } from "@sentry/junior-plugin-api";
 import { Type, type Static } from "@sinclair/typebox";
 import { Value } from "@sinclair/typebox/value";
-
-const GITHUB_PULL_REQUEST_FOOTER_START = "<!-- junior-session-footer:start -->";
-const GITHUB_PULL_REQUEST_FOOTER_END = "<!-- junior-session-footer:end -->";
+import { appendGitHubFooter } from "./footer.js";
 const GITHUB_PULL_REQUEST_CREATE_IDEMPOTENCY_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const GITHUB_PULL_REQUEST_CREATE_LOCK_TTL_MS = 60_000;
 
@@ -114,77 +112,6 @@ function parseRepo(value: string): { name: string; owner: string } {
   };
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function sentryConversationUrl(conversationId: string): string | undefined {
-  const dsn = process.env.SENTRY_DSN?.trim();
-  const orgSlug = process.env.SENTRY_ORG_SLUG?.trim();
-  if (!dsn || !orgSlug) {
-    return undefined;
-  }
-
-  let parsed: URL;
-  try {
-    parsed = new URL(dsn);
-  } catch {
-    return undefined;
-  }
-
-  const projectId = parsed.pathname.split("/").filter(Boolean).at(-1);
-  if (!parsed.hostname || !projectId) {
-    return undefined;
-  }
-
-  const encodedConversationId = encodeURIComponent(conversationId);
-  const params = new URLSearchParams({ project: projectId });
-  const path = `explore/conversations/${encodedConversationId}/?${params.toString()}`;
-
-  if (
-    parsed.hostname === "sentry.io" ||
-    parsed.hostname.endsWith(".sentry.io")
-  ) {
-    return `https://${orgSlug}.sentry.io/${path}`;
-  }
-
-  const port = parsed.port ? `:${parsed.port}` : "";
-  return `${parsed.protocol}//${parsed.hostname}${port}/organizations/${orgSlug}/${path}`;
-}
-
-function githubPullRequestConversationFooter(
-  conversationId: string,
-): string | undefined {
-  const id = nonEmptyString(conversationId, "conversationId");
-  const sessionUrl = sentryConversationUrl(id);
-  if (!sessionUrl) {
-    return undefined;
-  }
-  return `${GITHUB_PULL_REQUEST_FOOTER_START}\n\n--\n\n[View Junior Session in Sentry](${sessionUrl})\n\n${GITHUB_PULL_REQUEST_FOOTER_END}`;
-}
-
-function appendGitHubPullRequestFooter(
-  body: string,
-  conversationId: string,
-): string {
-  const footer = githubPullRequestConversationFooter(conversationId);
-  const normalizedBody = body.trimEnd();
-  const existingFooter = new RegExp(
-    `${escapeRegExp(GITHUB_PULL_REQUEST_FOOTER_START)}[\\s\\S]*?${escapeRegExp(
-      GITHUB_PULL_REQUEST_FOOTER_END,
-    )}`,
-  );
-  if (existingFooter.test(normalizedBody)) {
-    return footer
-      ? normalizedBody.replace(existingFooter, footer)
-      : normalizedBody.replace(existingFooter, "").trimEnd();
-  }
-  if (!footer) {
-    return normalizedBody;
-  }
-  return normalizedBody ? `${normalizedBody}\n\n${footer}` : footer;
-}
-
 async function readJsonResponse(response: Response): Promise<unknown> {
   const text = await response.text();
   if (!text) {
@@ -251,7 +178,7 @@ function createGitHubPullRequestRequest(
     title: nonEmptyString(input.title, "title"),
     head: nonEmptyString(input.head, "head"),
     base: nonEmptyString(input.base, "base"),
-    body: appendGitHubPullRequestFooter(input.body ?? "", conversationId),
+    body: appendGitHubFooter(input.body ?? "", conversationId),
     ...(input.draft !== undefined ? { draft: input.draft } : {}),
   };
   return new Request(

--- a/packages/junior-github/src/tools/footer.ts
+++ b/packages/junior-github/src/tools/footer.ts
@@ -1,0 +1,90 @@
+import { PluginToolInputError } from "@sentry/junior-plugin-api";
+
+export const GITHUB_SESSION_FOOTER_START = "<!-- junior-session-footer:start -->";
+export const GITHUB_SESSION_FOOTER_END = "<!-- junior-session-footer:end -->";
+
+function nonEmptyString(value: string | undefined, name: string): string {
+  if (!value?.trim()) {
+    throw new PluginToolInputError(`${name} is required`);
+  }
+  return value.trim();
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function sentryConversationUrl(
+  conversationId: string,
+): string | undefined {
+  const dsn = process.env.SENTRY_DSN?.trim();
+  const orgSlug = process.env.SENTRY_ORG_SLUG?.trim();
+  if (!dsn || !orgSlug) {
+    return undefined;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(dsn);
+  } catch {
+    return undefined;
+  }
+
+  const projectId = parsed.pathname.split("/").filter(Boolean).at(-1);
+  if (!parsed.hostname || !projectId) {
+    return undefined;
+  }
+
+  const encodedConversationId = encodeURIComponent(conversationId);
+  const params = new URLSearchParams({ project: projectId });
+  const path = `explore/conversations/${encodedConversationId}/?${params.toString()}`;
+
+  if (
+    parsed.hostname === "sentry.io" ||
+    parsed.hostname.endsWith(".sentry.io")
+  ) {
+    return `https://${orgSlug}.sentry.io/${path}`;
+  }
+
+  const port = parsed.port ? `:${parsed.port}` : "";
+  return `${parsed.protocol}//${parsed.hostname}${port}/organizations/${orgSlug}/${path}`;
+}
+
+/**
+ * Build the Junior session footer block for GitHub issues and pull requests.
+ * Returns undefined when Sentry DSN/org are not configured.
+ */
+export function githubConversationFooter(
+  conversationId: string,
+): string | undefined {
+  const id = nonEmptyString(conversationId, "conversationId");
+  const sessionUrl = sentryConversationUrl(id);
+  if (!sessionUrl) {
+    return undefined;
+  }
+  return `${GITHUB_SESSION_FOOTER_START}\n\n--\n\n[View Junior Session in Sentry](${sessionUrl})\n\n${GITHUB_SESSION_FOOTER_END}`;
+}
+
+/**
+ * Append (or replace an existing) Junior session footer to a GitHub body string.
+ * When Sentry is not configured, returns the body unchanged (existing footer stripped).
+ */
+export function appendGitHubFooter(
+  body: string,
+  conversationId: string,
+): string {
+  const footer = githubConversationFooter(conversationId);
+  const normalizedBody = body.trimEnd();
+  const existingFooter = new RegExp(
+    `${escapeRegExp(GITHUB_SESSION_FOOTER_START)}[\\s\\S]*?${escapeRegExp(GITHUB_SESSION_FOOTER_END)}`,
+  );
+  if (existingFooter.test(normalizedBody)) {
+    return footer
+      ? normalizedBody.replace(existingFooter, footer)
+      : normalizedBody.replace(existingFooter, "").trimEnd();
+  }
+  if (!footer) {
+    return normalizedBody;
+  }
+  return normalizedBody ? `${normalizedBody}\n\n${footer}` : footer;
+}

--- a/packages/junior-github/tests/github-plugin.test.ts
+++ b/packages/junior-github/tests/github-plugin.test.ts
@@ -573,7 +573,9 @@ describe("github plugin", () => {
     await expect(request?.request.json()).resolves.toMatchObject({
       body: `<!-- junior-session-footer:start -->
 
-[View Session in Sentry](https://acme.sentry.io/explore/conversations/slack%3AC123%3A1712345.0001/?project=12345)
+--
+
+[View Junior Session in Sentry](https://acme.sentry.io/explore/conversations/slack%3AC123%3A1712345.0001/?project=12345)
 
 <!-- junior-session-footer:end -->`,
     });
@@ -938,7 +940,9 @@ Conversation: \`local:test:old-conversation\`
 
 <!-- junior-session-footer:start -->
 
-[View Session in Sentry](https://acme.sentry.io/explore/conversations/slack%3AC123%3A1712345.0001/?project=12345)
+--
+
+[View Junior Session in Sentry](https://acme.sentry.io/explore/conversations/slack%3AC123%3A1712345.0001/?project=12345)
 
 <!-- junior-session-footer:end -->`,
     });


### PR DESCRIPTION
Updates the GitHub issue and PR footer link from "View Session in Sentry" to "View Junior Session in Sentry", and adds a `--` separator above it.

**Changed:**
- `packages/junior-github/src/tools/create-issue.ts` — updated footer template
- `packages/junior-github/src/tools/create-pull-request.ts` — updated footer template
- `packages/junior-github/tests/github-plugin.test.ts` — updated test expectations to match new format

<!-- junior-session-footer:start -->

[View Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC0B595QDZLL%3A1782846700.418429/?project=4510944073809921)

<!-- junior-session-footer:end -->