### PR TITLE
fix(task-execution): prevent double wake nudge when continuation already queued

### DIFF
--- a/packages/junior/src/chat/task-execution/state.ts
+++ b/packages/junior/src/chat/task-execution/state.ts
@@ -1586,7 +1586,13 @@ export async function completeConversationWork(args: {
     // may have failed before markConversationWorkEnqueued ran, so a recovery
     // nudge is still correct).
     const hasQueuedWake = current.execution.lastEnqueuedAtMs !== undefined;
-    const shouldNudge = hasPending || (needsRun && !hasQueuedWake);
+    // Use runnable (not hasPending alone) so that any accepted conversation
+    // wake — which is conversation-level and can process both mailbox messages
+    // and continuation resumes — suppresses the extra nudge. Treating pending
+    // mailbox messages as an unconditional nudge reason would allow the same
+    // double-enqueue pattern when hasPending is true alongside needsRun and a
+    // recorded wake.
+    const shouldNudge = runnable && !hasQueuedWake;
     await writeConversation(
       state,
       withExecutionUpdate(

--- a/packages/junior/src/chat/task-execution/state.ts
+++ b/packages/junior/src/chat/task-execution/state.ts
@@ -1572,15 +1572,19 @@ export async function completeConversationWork(args: {
     const hasPending = pendingMessages(current).length > 0;
     const needsRun = current.execution.status === "awaiting_resume";
     const runnable = needsRun || hasPending;
-    // "awaiting_resume" is set by paths (e.g. scheduleAgentContinue) that
-    // already enqueue their own wake nudge via markConversationWorkEnqueued.
-    // Returning "pending" here causes processConversationWork to enqueue a
-    // second distinct nudge (idempotency key includes nowMs), which amplifies
-    // the queue and can produce a runaway loop when continuations repeatedly
-    // fail and reschedule.  Only request a new nudge when actual mailbox
-    // messages need processing, or when no accepted enqueue was recorded
-    // during this lease (the queue.send may have failed before
-    // markConversationWorkEnqueued ran, so a recovery nudge is correct).
+    // When "awaiting_resume" is observed here, it was usually set by a
+    // during-lease continuation request such as scheduleAgentContinue. Those
+    // paths enqueue their own wake and record it with markConversationWorkEnqueued
+    // after queue.send succeeds. Returning "pending" here causes
+    // processConversationWork to enqueue a second distinct wake nudge (the
+    // idempotency key includes nowMs, so it is not deduplicated), which
+    // amplifies the queue. When continuations repeatedly fail and reschedule,
+    // those duplicates produce a runaway loop.
+    //
+    // Only request a new nudge when actual mailbox messages need processing, or
+    // when no accepted enqueue was recorded during this lease (i.e. queue.send
+    // may have failed before markConversationWorkEnqueued ran, so a recovery
+    // nudge is still correct).
     const hasQueuedWake = current.execution.lastEnqueuedAtMs !== undefined;
     const shouldNudge = hasPending || (needsRun && !hasQueuedWake);
     await writeConversation(

--- a/packages/junior/src/chat/task-execution/state.ts
+++ b/packages/junior/src/chat/task-execution/state.ts
@@ -1572,6 +1572,17 @@ export async function completeConversationWork(args: {
     const hasPending = pendingMessages(current).length > 0;
     const needsRun = current.execution.status === "awaiting_resume";
     const runnable = needsRun || hasPending;
+    // "awaiting_resume" is set by paths (e.g. scheduleAgentContinue) that
+    // already enqueue their own wake nudge via markConversationWorkEnqueued.
+    // Returning "pending" here causes processConversationWork to enqueue a
+    // second distinct nudge (idempotency key includes nowMs), which amplifies
+    // the queue and can produce a runaway loop when continuations repeatedly
+    // fail and reschedule.  Only request a new nudge when actual mailbox
+    // messages need processing, or when no accepted enqueue was recorded
+    // during this lease (the queue.send may have failed before
+    // markConversationWorkEnqueued ran, so a recovery nudge is correct).
+    const hasQueuedWake = current.execution.lastEnqueuedAtMs !== undefined;
+    const shouldNudge = hasPending || (needsRun && !hasQueuedWake);
     await writeConversation(
       state,
       withExecutionUpdate(
@@ -1585,7 +1596,7 @@ export async function completeConversationWork(args: {
         nowMs,
       ),
     );
-    return runnable ? "pending" : "completed";
+    return shouldNudge ? "pending" : "completed";
   });
 }
 

--- a/packages/junior/tests/component/task-execution/conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/conversation-work.test.ts
@@ -716,6 +716,57 @@ describe("conversation work execution", () => {
     ]);
   });
 
+  it("does not send extra nudge when pending mailbox + continuation + recorded wake coexist", async () => {
+    // Adversarial case: hasPending=true, needsRun=true, hasQueuedWake=true.
+    // An extra nudge from completeConversationWork would recreate the double-
+    // enqueue loop pattern. Any accepted wake is conversation-level and can
+    // drain the mailbox and process the continuation, so no extra nudge is needed.
+    const queue = createConversationWorkQueueTestAdapter();
+    let currentNowMs = 1_000;
+    await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
+
+    await expect(
+      processConversationWork(conversationQueueMessage(), {
+        nowMs: () => currentNowMs,
+        queue,
+        run: async (context) => {
+          // Drain the initial message.
+          await context.drainMailbox(async () => {});
+          currentNowMs = 2_000;
+          // Schedule a continuation: sets "awaiting_resume" + records wake.
+          await requestConversationWork({
+            conversationId: context.conversationId,
+            destination: context.destination,
+            nowMs: currentNowMs,
+          });
+          await markConversationWorkEnqueued({
+            conversationId: context.conversationId,
+            nowMs: currentNowMs,
+          });
+          // A new inbound message also arrives (pending at completion time).
+          await appendInboundMessage({
+            message: inboundMessage("m2", {
+              createdAtMs: 2_100,
+              receivedAtMs: 2_100,
+            }),
+            nowMs: 2_100,
+          });
+          return { status: "completed" };
+        },
+      }),
+    ).resolves.toEqual({ status: "completed" });
+
+    const state = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+    });
+    expect(state?.lease).toBeUndefined();
+    expect(state?.needsRun).toBe(true);
+    // processConversationWork must NOT have sent its own nudge — the wake
+    // recorded by markConversationWorkEnqueued covers both pending messages
+    // and the continuation.
+    expect(queue.sentRecords()).toHaveLength(0);
+  });
+
   it("uses fresh queue idempotency keys for repeated worker requeues", async () => {
     const queue = createConversationWorkQueueTestAdapter();
     let currentNowMs = 1_000;

--- a/packages/junior/tests/component/task-execution/conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/conversation-work.test.ts
@@ -16,6 +16,7 @@ import {
   listConversationsByActivity,
   markConversationMessagesInjected,
   recordConversationActivity,
+  markConversationWorkEnqueued,
   requestConversationContinuation,
   requestConversationWork,
   releaseConversationWork,
@@ -619,6 +620,89 @@ describe("conversation work execution", () => {
     expect(state?.lease).toBeUndefined();
     expect(state?.needsRun).toBe(true);
     expect(state ? countPendingConversationMessages(state) : 0).toBe(0);
+    expect(queue.sentRecords()).toMatchObject([
+      {
+        conversationId: CONVERSATION_ID,
+        idempotencyKey: `pending:${CONVERSATION_ID}:2000`,
+      },
+    ]);
+  });
+
+  it("does not send extra nudge when continuation wake was already queued via markConversationWorkEnqueued", async () => {
+    // Regression: scheduleAgentContinue calls requestConversationWork (sets
+    // "awaiting_resume") + queue.send + markConversationWorkEnqueued during an
+    // active worker run.  completeConversationWork must not enqueue a second
+    // wake nudge, as the in-flight message already covers the continuation.
+    const queue = createConversationWorkQueueTestAdapter();
+    let currentNowMs = 1_000;
+    await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
+
+    await expect(
+      processConversationWork(conversationQueueMessage(), {
+        nowMs: () => currentNowMs,
+        queue,
+        run: async (context) => {
+          await context.drainMailbox(async () => {});
+          currentNowMs = 2_000;
+          // Simulate the full scheduleAgentContinue call sequence:
+          // requestConversationWork sets "awaiting_resume"; markConversationWorkEnqueued
+          // records that an accepted wake is outstanding.
+          await requestConversationWork({
+            conversationId: context.conversationId,
+            destination: context.destination,
+            nowMs: currentNowMs,
+          });
+          await markConversationWorkEnqueued({
+            conversationId: context.conversationId,
+            nowMs: currentNowMs,
+          });
+          return { status: "completed" };
+        },
+      }),
+    ).resolves.toEqual({ status: "completed" });
+
+    const state = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+    });
+    expect(state?.lease).toBeUndefined();
+    // Status is "pending" so the in-flight queue message from scheduleAgentContinue
+    // will find runnable work when it arrives.
+    expect(state?.needsRun).toBe(true);
+    // processConversationWork must NOT have sent its own nudge.
+    expect(queue.sentRecords()).toHaveLength(0);
+  });
+
+  it("sends recovery nudge when awaiting_resume but no enqueue was recorded", async () => {
+    // If requestConversationWork set "awaiting_resume" but queue.send failed
+    // (markConversationWorkEnqueued never ran), completeConversationWork must
+    // still return "pending" so processConversationWork sends a recovery nudge.
+    const queue = createConversationWorkQueueTestAdapter();
+    let currentNowMs = 1_000;
+    await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
+
+    await expect(
+      processConversationWork(conversationQueueMessage(), {
+        nowMs: () => currentNowMs,
+        queue,
+        run: async (context) => {
+          await context.drainMailbox(async () => {});
+          currentNowMs = 2_000;
+          // Only requestConversationWork — no markConversationWorkEnqueued (queue.send failed).
+          await requestConversationWork({
+            conversationId: context.conversationId,
+            destination: context.destination,
+            nowMs: currentNowMs,
+          });
+          return { status: "completed" };
+        },
+      }),
+    ).resolves.toEqual({ status: "pending_requeued" });
+
+    const state = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+    });
+    expect(state?.lease).toBeUndefined();
+    expect(state?.needsRun).toBe(true);
     expect(queue.sentRecords()).toMatchObject([
       {
         conversationId: CONVERSATION_ID,

--- a/packages/junior/tests/component/task-execution/conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/conversation-work.test.ts
@@ -668,6 +668,9 @@ describe("conversation work execution", () => {
     // Status is "pending" so the in-flight queue message from scheduleAgentContinue
     // will find runnable work when it arrives.
     expect(state?.needsRun).toBe(true);
+    // lastEnqueuedAtMs is still set — the wake recorded by markConversationWorkEnqueued
+    // is preserved so a subsequent heartbeat or worker can see it was queued.
+    expect(state?.lastEnqueuedAtMs).toBe(2_000);
     // processConversationWork must NOT have sent its own nudge.
     expect(queue.sentRecords()).toHaveLength(0);
   });
@@ -703,6 +706,8 @@ describe("conversation work execution", () => {
     });
     expect(state?.lease).toBeUndefined();
     expect(state?.needsRun).toBe(true);
+    // The recovery nudge sets lastEnqueuedAtMs.
+    expect(state?.lastEnqueuedAtMs).toBe(2_000);
     expect(queue.sentRecords()).toMatchObject([
       {
         conversationId: CONVERSATION_ID,


### PR DESCRIPTION
## What

`completeConversationWork` returns `"pending"` whenever `execution.status === "awaiting_resume"`, which causes `processConversationWork` to enqueue an extra wake nudge. The problem: `scheduleAgentContinue` already enqueues its own wake (via `requestConversationWork` → `queue.send` → `markConversationWorkEnqueued`), making the extra nudge a duplicate. Because the queue idempotency key includes `nowMs`, it is never deduplicated.

When continuations repeatedly fail and reschedule (e.g. the continuation lock is consistently busy), each cycle adds one more message. This caused a 29-hour runaway loop on Jun 29–30 2026 where conversation `slack:C0B595QDZLL:1782764912.916989` generated ~2M `/api/internal/agent/continue` requests at ~22 req/sec.

## How

In `completeConversationWork`, check `lastEnqueuedAtMs` before returning `"pending"`:

- `lastEnqueuedAtMs !== undefined` → an accepted wake was recorded during this lease via `markConversationWorkEnqueued`. Skip the extra nudge (`return "completed"`), but still set `status: "pending"` in durable state so the already-queued message finds work when it arrives. Accepted wakes are conversation-level and can handle both pending mailbox messages and continuation resumes.
- `lastEnqueuedAtMs === undefined` → `queue.send` may have failed before `markConversationWorkEnqueued` ran. Send a recovery nudge as before.

The fix uses `runnable && !hasQueuedWake` (stronger than `hasPending || (needsRun && !hasQueuedWake)`) so that any accepted wake suppresses the extra nudge regardless of whether pending mailbox messages also exist at completion time. Treating `hasPending` as an unconditional nudge reason would leave a remaining amplification path when all three conditions coexist.

The key invariant: `startConversationWork` clears `lastEnqueuedAtMs` when acquiring a lease, so any non-`undefined` value seen in `completeConversationWork` was set during the current worker's run.

All `scheduleAgentContinue` call sites are `await`-ed; no fire-and-forget race.

## Tests

Three new cases in `conversation-work.test.ts`:

1. **Full `scheduleAgentContinue` sequence** (`requestConversationWork` + `markConversationWorkEnqueued`): asserts result is `"completed"`, no extra queue message sent, durable status is `"pending"`, `lastEnqueuedAtMs` preserved.
2. **`queue.send` failure** (only `requestConversationWork`, no `markConversationWorkEnqueued`): asserts result is `"pending_requeued"`, recovery nudge sent.
3. **Adversarial: pending mailbox + continuation + recorded wake coexist**: asserts no extra nudge despite `hasPending=true`, `needsRun=true`, `hasQueuedWake=true`.

The existing `"requeues work requested while a lease is running"` test continues to pass unchanged (calls `requestConversationWork` without `markConversationWorkEnqueued`, recovery path fires).

## What this does NOT fix

The underlying cause of why a specific continuation keeps failing indefinitely (e.g. permanent lock contention, tool errors on every retry). A separate circuit-breaker (max `sliceId` for timeout continuations) is worth considering as a follow-up operational guardrail, but is intentionally left out of this PR to keep the scope narrow.