### PR TITLE
feat(github): Add resource event webhook handling

### DIFF
--- a/packages/junior-github/src/tools/create-pull-request.ts
+++ b/packages/junior-github/src/tools/create-pull-request.ts
@@ -85,7 +85,7 @@ interface GitHubPullRequestResult {
 }
 
 interface GitHubPullRequestToolResult extends GitHubPullRequestResult {
-  subscribable: SubscribableResource;
+  subscribable?: SubscribableResource;
 }
 
 function parseCreatePullRequestInput(
@@ -275,6 +275,9 @@ function gitHubPullRequestToolResult(
   input: CreateGitHubPullRequestInput,
   result: GitHubPullRequestResult,
 ): GitHubPullRequestToolResult {
+  if (!process.env.GITHUB_WEBHOOK_SECRET?.trim()) {
+    return result;
+  }
   return {
     ...result,
     subscribable: gitHubPullRequestSubscribable(input, result),

--- a/packages/junior-github/tests/github-plugin.test.ts
+++ b/packages/junior-github/tests/github-plugin.test.ts
@@ -847,6 +847,7 @@ Conversation: \`local:test:old-conversation\`
   });
 
   it("creates pull requests through host egress with a deterministic Junior footer", async () => {
+    process.env.GITHUB_WEBHOOK_SECRET = "test-secret";
     const ctx = githubToolsContext({
       conversationId: "slack:C123:1712345.0001",
       egressFetch: async () =>
@@ -926,6 +927,36 @@ Conversation: \`local:test:old-conversation\`
     });
   });
 
+  it("omits pull request subscription hints when GitHub webhooks are not configured", async () => {
+    const ctx = githubToolsContext({
+      egressFetch: async () =>
+        new Response(
+          JSON.stringify({
+            number: 691,
+            html_url: "https://github.com/getsentry/junior/pull/691",
+          }),
+          { status: 201 },
+        ),
+    });
+    const plugin = githubPlugin();
+    const tool = plugin.hooks?.tools?.(ctx as any)?.createPullRequest;
+
+    await expect(
+      tool?.execute?.(
+        {
+          repo: "getsentry/junior",
+          title: "Typed PR",
+          head: "dcramer/gh-660-pr-create",
+          base: "main",
+        },
+        { toolCallId: "call-create-pull-request-without-webhooks" },
+      ),
+    ).resolves.toEqual({
+      number: 691,
+      url: "https://github.com/getsentry/junior/pull/691",
+    });
+  });
+
   it("adds a Sentry session link to pull request footers when configured", async () => {
     process.env.SENTRY_DSN = "https://public@o450000.ingest.sentry.io/12345";
     process.env.SENTRY_ORG_SLUG = "acme";
@@ -969,6 +1000,7 @@ Conversation: \`local:test:old-conversation\`
   });
 
   it("returns the stored pull request result when a createPullRequest tool call is retried", async () => {
+    process.env.GITHUB_WEBHOOK_SECRET = "test-secret";
     const ctx = githubToolsContext({
       egressFetch: async () =>
         new Response(
@@ -1017,6 +1049,7 @@ Conversation: \`local:test:old-conversation\`
   });
 
   it("returns legacy stored pull request results without stored input", async () => {
+    process.env.GITHUB_WEBHOOK_SECRET = "test-secret";
     const ctx = githubToolsContext();
     const plugin = githubPlugin();
     const tool = plugin.hooks?.tools?.(ctx as any)?.createPullRequest;

--- a/packages/junior/src/app.ts
+++ b/packages/junior/src/app.ts
@@ -41,6 +41,7 @@ import {
 } from "./plugins";
 import { GET as healthGET } from "@/handlers/health";
 import { POST as agentDispatchPOST } from "@/handlers/agent-dispatch";
+import { POST as githubWebhookPOST } from "@/handlers/github-webhook";
 import { GET as heartbeatGET } from "@/handlers/heartbeat";
 import { GET as mcpOauthCallbackGET } from "@/handlers/mcp-oauth-callback";
 import { GET as oauthCallbackGET } from "@/handlers/oauth-callback";
@@ -52,6 +53,8 @@ import {
   registerVercelConversationWorkDevConsumer,
   type VercelConversationWorkCallbackOptions,
 } from "@/chat/task-execution/vercel-callback";
+import type { ConversationWorkQueue } from "@/chat/task-execution/queue";
+import { getVercelConversationWorkQueue } from "@/chat/task-execution/vercel-queue";
 import {
   createVercelPluginTaskCallback,
   registerVercelPluginTaskDevConsumer,
@@ -645,6 +648,8 @@ export async function createApp(options?: JuniorAppOptions): Promise<Hono> {
       });
     return conversationWorkOptions;
   };
+  const getResourceEventQueue = (): ConversationWorkQueue =>
+    getConversationWorkOptions().queue ?? getVercelConversationWorkQueue();
   if (process.env.NODE_ENV === "development") {
     registerVercelConversationWorkDevConsumer(getConversationWorkOptions());
     registerVercelPluginTaskDevConsumer();
@@ -666,6 +671,13 @@ export async function createApp(options?: JuniorAppOptions): Promise<Hono> {
 
   app.post("/api/webhooks/slack", (c) => {
     return slackWebhookPOST(c.req.raw, waitUntil, slackWebhookServices);
+  });
+
+  app.post("/api/webhooks/github", (c) => {
+    return githubWebhookPOST(c.req.raw, {
+      queue: getResourceEventQueue,
+      state: () => getConversationWorkOptions().state,
+    });
   });
 
   app.post("/api/webhooks/:platform", (c) => {

--- a/packages/junior/src/handlers/github-webhook.ts
+++ b/packages/junior/src/handlers/github-webhook.ts
@@ -5,7 +5,7 @@ import {
   type IngestResourceEventInput,
 } from "@/chat/resource-events/ingest";
 import type { ConversationWorkQueue } from "@/chat/task-execution/queue";
-import { normalizeGitHubCheckSuiteEvent } from "@/handlers/github-webhook/check-suite";
+import { normalizeGitHubCheckSuiteEvents } from "@/handlers/github-webhook/check-suite";
 import { normalizeGitHubPullRequestEvent } from "@/handlers/github-webhook/pull-request";
 import { normalizeGitHubPullRequestReviewEvent } from "@/handlers/github-webhook/pull-request-review";
 
@@ -36,21 +36,28 @@ function verifyGitHubSignature(body: string, signature: string): boolean {
   return actual.length === expected.length && timingSafeEqual(actual, expected);
 }
 
-/** Normalize a verified GitHub webhook delivery into a resource event. */
-export function normalizeGitHubResourceEvent(args: {
+/** Normalize a verified GitHub webhook delivery into resource events. */
+export function normalizeGitHubResourceEvents(args: {
   body: unknown;
   deliveryId: string;
   eventName: string;
-}): IngestResourceEventInput | undefined {
+}): IngestResourceEventInput[] {
   switch (args.eventName) {
-    case "pull_request":
-      return normalizeGitHubPullRequestEvent(args.deliveryId, args.body);
-    case "pull_request_review":
-      return normalizeGitHubPullRequestReviewEvent(args.deliveryId, args.body);
+    case "pull_request": {
+      const event = normalizeGitHubPullRequestEvent(args.deliveryId, args.body);
+      return event ? [event] : [];
+    }
+    case "pull_request_review": {
+      const event = normalizeGitHubPullRequestReviewEvent(
+        args.deliveryId,
+        args.body,
+      );
+      return event ? [event] : [];
+    }
     case "check_suite":
-      return normalizeGitHubCheckSuiteEvent(args.deliveryId, args.body);
+      return normalizeGitHubCheckSuiteEvents(args.deliveryId, args.body);
     default:
-      return undefined;
+      return [];
   }
 }
 
@@ -79,22 +86,23 @@ export async function POST(
     return new Response("Malformed GitHub webhook", { status: 400 });
   }
 
-  const event = normalizeGitHubResourceEvent({
+  const events = normalizeGitHubResourceEvents({
     body: parseJson(body),
     deliveryId,
     eventName,
   });
-  if (!event) {
+  if (events.length === 0) {
     return new Response("Ignored", { status: 202 });
   }
 
-  await ingestResourceEvent(
-    { ...event, occurredAtMs: Date.now() },
-    {
-      queue:
-        typeof options.queue === "function" ? options.queue() : options.queue,
-      state: resolveState(options.state),
-    },
-  );
+  const queue =
+    typeof options.queue === "function" ? options.queue() : options.queue;
+  const state = resolveState(options.state);
+  for (const event of events) {
+    await ingestResourceEvent(
+      { ...event, occurredAtMs: Date.now() },
+      { queue, state },
+    );
+  }
   return new Response("Accepted", { status: 202 });
 }

--- a/packages/junior/src/handlers/github-webhook.ts
+++ b/packages/junior/src/handlers/github-webhook.ts
@@ -1,0 +1,100 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import type { StateAdapter } from "chat";
+import {
+  ingestResourceEvent,
+  type IngestResourceEventInput,
+} from "@/chat/resource-events/ingest";
+import type { ConversationWorkQueue } from "@/chat/task-execution/queue";
+import { normalizeGitHubCheckSuiteEvent } from "@/handlers/github-webhook/check-suite";
+import { normalizeGitHubPullRequestEvent } from "@/handlers/github-webhook/pull-request";
+import { normalizeGitHubPullRequestReviewEvent } from "@/handlers/github-webhook/pull-request-review";
+
+export interface GitHubWebhookHandlerOptions {
+  queue: ConversationWorkQueue | (() => ConversationWorkQueue);
+  state?: StateAdapter | (() => StateAdapter | undefined);
+}
+
+function resolveState(
+  state: GitHubWebhookHandlerOptions["state"],
+): StateAdapter | undefined {
+  return typeof state === "function" ? state() : state;
+}
+
+function githubWebhookSecret(): string | undefined {
+  return process.env.GITHUB_WEBHOOK_SECRET?.trim();
+}
+
+function verifyGitHubSignature(body: string, signature: string): boolean {
+  const secret = githubWebhookSecret();
+  if (!secret || !signature.startsWith("sha256=")) {
+    return false;
+  }
+  const actual = Buffer.from(signature);
+  const expected = Buffer.from(
+    `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`,
+  );
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
+}
+
+/** Normalize a verified GitHub webhook delivery into a resource event. */
+export function normalizeGitHubResourceEvent(args: {
+  body: unknown;
+  deliveryId: string;
+  eventName: string;
+}): IngestResourceEventInput | undefined {
+  switch (args.eventName) {
+    case "pull_request":
+      return normalizeGitHubPullRequestEvent(args.deliveryId, args.body);
+    case "pull_request_review":
+      return normalizeGitHubPullRequestReviewEvent(args.deliveryId, args.body);
+    case "check_suite":
+      return normalizeGitHubCheckSuiteEvent(args.deliveryId, args.body);
+    default:
+      return undefined;
+  }
+}
+
+function parseJson(body: string): unknown {
+  try {
+    return JSON.parse(body);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Handle signed GitHub webhooks for resource event subscriptions. */
+export async function POST(
+  request: Request,
+  options: GitHubWebhookHandlerOptions,
+): Promise<Response> {
+  const body = await request.text();
+  const signature = request.headers.get("x-hub-signature-256") ?? "";
+  if (!verifyGitHubSignature(body, signature)) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const deliveryId = request.headers.get("x-github-delivery");
+  const eventName = request.headers.get("x-github-event");
+  if (!deliveryId || !eventName) {
+    return new Response("Malformed GitHub webhook", { status: 400 });
+  }
+
+  const event = normalizeGitHubResourceEvent({
+    body: parseJson(body),
+    deliveryId,
+    eventName,
+  });
+  if (!event) {
+    return new Response("Ignored", { status: 202 });
+  }
+
+  await ingestResourceEvent(
+    { ...event, occurredAtMs: Date.now() },
+    {
+      queue:
+        typeof options.queue === "function" ? options.queue() : options.queue,
+      state: resolveState(options.state),
+    },
+  );
+  return new Response("Accepted", { status: 202 });
+}

--- a/packages/junior/src/handlers/github-webhook/check-suite.ts
+++ b/packages/junior/src/handlers/github-webhook/check-suite.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+import type { IngestResourceEventInput } from "@/chat/resource-events/ingest";
+import {
+  gitHubEventKey,
+  gitHubPullRequestResource,
+} from "@/handlers/github-webhook/resource";
+
+const checkSuiteWebhookSchema = z.object({
+  action: z.string(),
+  check_suite: z.object({
+    conclusion: z.string().optional().nullable(),
+    head_sha: z.string().optional(),
+    pull_requests: z.array(
+      z.object({
+        number: z.number(),
+      }),
+    ),
+  }),
+  repository: z.object({
+    full_name: z.string().min(1),
+  }),
+});
+
+/** Normalize GitHub `check_suite` webhooks for subscribed PR check outcomes. */
+export function normalizeGitHubCheckSuiteEvent(
+  deliveryId: string,
+  body: unknown,
+): IngestResourceEventInput | undefined {
+  const parsed = checkSuiteWebhookSchema.safeParse(body);
+  if (!parsed.success || parsed.data.action !== "completed") {
+    return undefined;
+  }
+  const pullRequest = parsed.data.check_suite.pull_requests[0];
+  if (!pullRequest) {
+    return undefined;
+  }
+  const conclusion = parsed.data.check_suite.conclusion;
+  const eventType =
+    conclusion === "failure" || conclusion === "timed_out"
+      ? "checks.failed"
+      : conclusion === "success"
+        ? "checks.recovered"
+        : undefined;
+  if (!eventType) {
+    return undefined;
+  }
+  const resource = gitHubPullRequestResource({
+    pullRequestNumber: pullRequest.number,
+    repositoryFullName: parsed.data.repository.full_name,
+  });
+  const sha = parsed.data.check_suite.head_sha?.slice(0, 12);
+  return {
+    eventKey: gitHubEventKey(deliveryId, eventType),
+    eventType,
+    occurredAtMs: Date.now(),
+    provider: "github",
+    resourceRef: resource.resourceRef,
+    trustedSummary:
+      eventType === "checks.failed"
+        ? `${resource.label} checks failed${sha ? ` for ${sha}` : ""}.`
+        : `${resource.label} checks recovered${sha ? ` for ${sha}` : ""}.`,
+  };
+}

--- a/packages/junior/src/handlers/github-webhook/check-suite.ts
+++ b/packages/junior/src/handlers/github-webhook/check-suite.ts
@@ -22,17 +22,13 @@ const checkSuiteWebhookSchema = z.object({
 });
 
 /** Normalize GitHub `check_suite` webhooks for subscribed PR check outcomes. */
-export function normalizeGitHubCheckSuiteEvent(
+export function normalizeGitHubCheckSuiteEvents(
   deliveryId: string,
   body: unknown,
-): IngestResourceEventInput | undefined {
+): IngestResourceEventInput[] {
   const parsed = checkSuiteWebhookSchema.safeParse(body);
   if (!parsed.success || parsed.data.action !== "completed") {
-    return undefined;
-  }
-  const pullRequest = parsed.data.check_suite.pull_requests[0];
-  if (!pullRequest) {
-    return undefined;
+    return [];
   }
   const conclusion = parsed.data.check_suite.conclusion;
   const eventType =
@@ -42,22 +38,27 @@ export function normalizeGitHubCheckSuiteEvent(
         ? "checks.recovered"
         : undefined;
   if (!eventType) {
-    return undefined;
+    return [];
   }
-  const resource = gitHubPullRequestResource({
-    pullRequestNumber: pullRequest.number,
-    repositoryFullName: parsed.data.repository.full_name,
-  });
   const sha = parsed.data.check_suite.head_sha?.slice(0, 12);
-  return {
-    eventKey: gitHubEventKey(deliveryId, eventType),
-    eventType,
-    occurredAtMs: Date.now(),
-    provider: "github",
-    resourceRef: resource.resourceRef,
-    trustedSummary:
-      eventType === "checks.failed"
-        ? `${resource.label} checks failed${sha ? ` for ${sha}` : ""}.`
-        : `${resource.label} checks recovered${sha ? ` for ${sha}` : ""}.`,
-  };
+  return parsed.data.check_suite.pull_requests.map((pullRequest) => {
+    const resource = gitHubPullRequestResource({
+      pullRequestNumber: pullRequest.number,
+      repositoryFullName: parsed.data.repository.full_name,
+    });
+    return {
+      eventKey: gitHubEventKey(
+        deliveryId,
+        `${eventType}:${pullRequest.number}`,
+      ),
+      eventType,
+      occurredAtMs: Date.now(),
+      provider: "github",
+      resourceRef: resource.resourceRef,
+      trustedSummary:
+        eventType === "checks.failed"
+          ? `${resource.label} checks failed${sha ? ` for ${sha}` : ""}.`
+          : `${resource.label} checks recovered${sha ? ` for ${sha}` : ""}.`,
+    };
+  });
 }

--- a/packages/junior/src/handlers/github-webhook/pull-request-review.ts
+++ b/packages/junior/src/handlers/github-webhook/pull-request-review.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+import type { IngestResourceEventInput } from "@/chat/resource-events/ingest";
+import {
+  gitHubEventKey,
+  gitHubPullRequestResource,
+} from "@/handlers/github-webhook/resource";
+
+const pullRequestReviewWebhookSchema = z.object({
+  action: z.string(),
+  pull_request: z.object({
+    number: z.number(),
+  }),
+  repository: z.object({
+    full_name: z.string().min(1),
+  }),
+  review: z.object({
+    body: z.string().optional().nullable(),
+    state: z.string(),
+    user: z
+      .object({
+        login: z.string().optional(),
+      })
+      .optional(),
+  }),
+});
+
+/** Normalize GitHub `pull_request_review` webhooks for subscribed review outcomes. */
+export function normalizeGitHubPullRequestReviewEvent(
+  deliveryId: string,
+  body: unknown,
+): IngestResourceEventInput | undefined {
+  const parsed = pullRequestReviewWebhookSchema.safeParse(body);
+  if (!parsed.success || parsed.data.action !== "submitted") {
+    return undefined;
+  }
+  const reviewState = parsed.data.review.state.toUpperCase();
+  const eventType =
+    reviewState === "APPROVED"
+      ? "review.approved"
+      : reviewState === "CHANGES_REQUESTED"
+        ? "review.changes_requested"
+        : undefined;
+  if (!eventType) {
+    return undefined;
+  }
+  const resource = gitHubPullRequestResource({
+    pullRequestNumber: parsed.data.pull_request.number,
+    repositoryFullName: parsed.data.repository.full_name,
+  });
+  const reviewer = parsed.data.review.user?.login;
+  return {
+    eventKey: gitHubEventKey(deliveryId, eventType),
+    eventType,
+    occurredAtMs: Date.now(),
+    provider: "github",
+    resourceRef: resource.resourceRef,
+    trustedSummary:
+      eventType === "review.approved"
+        ? `${resource.label} was approved${reviewer ? ` by ${reviewer}` : ""}.`
+        : `${resource.label} received requested changes${reviewer ? ` from ${reviewer}` : ""}.`,
+    untrustedText: parsed.data.review.body ?? undefined,
+  };
+}

--- a/packages/junior/src/handlers/github-webhook/pull-request.ts
+++ b/packages/junior/src/handlers/github-webhook/pull-request.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import type { IngestResourceEventInput } from "@/chat/resource-events/ingest";
+import {
+  gitHubEventKey,
+  gitHubPullRequestResource,
+} from "@/handlers/github-webhook/resource";
+
+const pullRequestWebhookSchema = z.object({
+  action: z.string(),
+  pull_request: z.object({
+    merged: z.boolean().optional(),
+    number: z.number(),
+  }),
+  repository: z.object({
+    full_name: z.string().min(1),
+  }),
+});
+
+/** Normalize GitHub `pull_request` webhooks for subscribed PR state changes. */
+export function normalizeGitHubPullRequestEvent(
+  deliveryId: string,
+  body: unknown,
+): IngestResourceEventInput | undefined {
+  const parsed = pullRequestWebhookSchema.safeParse(body);
+  if (!parsed.success || parsed.data.action !== "closed") {
+    return undefined;
+  }
+  const eventType = parsed.data.pull_request.merged
+    ? "state.merged"
+    : "state.closed_unmerged";
+  const resource = gitHubPullRequestResource({
+    pullRequestNumber: parsed.data.pull_request.number,
+    repositoryFullName: parsed.data.repository.full_name,
+  });
+  return {
+    eventKey: gitHubEventKey(deliveryId, eventType),
+    eventType,
+    occurredAtMs: Date.now(),
+    provider: "github",
+    resourceRef: resource.resourceRef,
+    terminal: true,
+    trustedSummary:
+      eventType === "state.merged"
+        ? `${resource.label} was merged.`
+        : `${resource.label} was closed without being merged.`,
+  };
+}

--- a/packages/junior/src/handlers/github-webhook/resource.ts
+++ b/packages/junior/src/handlers/github-webhook/resource.ts
@@ -1,0 +1,19 @@
+function resourceRef(repositoryFullName: string, pullRequestNumber: number) {
+  return `github:pull_request:${repositoryFullName}#${pullRequestNumber}`;
+}
+
+/** Build the normalized resource identity for a GitHub pull request. */
+export function gitHubPullRequestResource(input: {
+  pullRequestNumber: number;
+  repositoryFullName: string;
+}) {
+  return {
+    label: `GitHub PR ${input.repositoryFullName}#${input.pullRequestNumber}`,
+    resourceRef: resourceRef(input.repositoryFullName, input.pullRequestNumber),
+  };
+}
+
+/** Build a stable provider retry key for one normalized GitHub event. */
+export function gitHubEventKey(deliveryId: string, eventType: string): string {
+  return `github:${deliveryId}:${eventType}`;
+}

--- a/packages/junior/tests/unit/app-config.test.ts
+++ b/packages/junior/tests/unit/app-config.test.ts
@@ -94,6 +94,22 @@ describe("createApp plugin config", () => {
     });
   });
 
+  it("routes GitHub webhooks through the core resource-event handler", async () => {
+    const app = await createApp({
+      plugins: defineJuniorPlugins([]),
+    });
+
+    const response = await app.fetch(
+      new Request("https://example.test/api/webhooks/github", {
+        method: "POST",
+        body: "{}",
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.text()).resolves.toBe("Unauthorized");
+  });
+
   it("fails loudly when the env plugin package fallback is malformed", async () => {
     process.env.JUNIOR_PLUGIN_PACKAGES = "not-json";
 

--- a/packages/junior/tests/unit/handlers/github-webhook.test.ts
+++ b/packages/junior/tests/unit/handlers/github-webhook.test.ts
@@ -1,0 +1,196 @@
+import { createHmac } from "node:crypto";
+import type { StateAdapter } from "chat";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { POST, normalizeGitHubResourceEvent } from "@/handlers/github-webhook";
+
+const originalGithubWebhookSecret = process.env.GITHUB_WEBHOOK_SECRET;
+
+function signedRequest(body: unknown): Request {
+  const rawBody = JSON.stringify(body);
+  const signature = `sha256=${createHmac("sha256", "test-secret")
+    .update(rawBody)
+    .digest("hex")}`;
+  return new Request("https://example.test/api/webhooks/github", {
+    method: "POST",
+    headers: {
+      "x-github-delivery": "delivery-1",
+      "x-github-event": "pull_request",
+      "x-hub-signature-256": signature,
+    },
+    body: rawBody,
+  });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  if (originalGithubWebhookSecret === undefined) {
+    delete process.env.GITHUB_WEBHOOK_SECRET;
+  } else {
+    process.env.GITHUB_WEBHOOK_SECRET = originalGithubWebhookSecret;
+  }
+});
+
+describe("normalizeGitHubResourceEvent", () => {
+  it("normalizes merged pull request events", () => {
+    vi.setSystemTime(1_000);
+
+    expect(
+      normalizeGitHubResourceEvent({
+        deliveryId: "delivery-1",
+        eventName: "pull_request",
+        body: {
+          action: "closed",
+          repository: { full_name: "getsentry/junior" },
+          pull_request: { number: 691, merged: true },
+        },
+      }),
+    ).toEqual({
+      eventKey: "github:delivery-1:state.merged",
+      eventType: "state.merged",
+      occurredAtMs: 1_000,
+      provider: "github",
+      resourceRef: "github:pull_request:getsentry/junior#691",
+      terminal: true,
+      trustedSummary: "GitHub PR getsentry/junior#691 was merged.",
+    });
+  });
+
+  it("normalizes requested-changes review events with untrusted text", () => {
+    vi.setSystemTime(1_000);
+
+    expect(
+      normalizeGitHubResourceEvent({
+        deliveryId: "delivery-2",
+        eventName: "pull_request_review",
+        body: {
+          action: "submitted",
+          repository: { full_name: "getsentry/junior" },
+          pull_request: { number: 691 },
+          review: {
+            body: "please handle the edge case",
+            state: "changes_requested",
+            user: { login: "reviewer" },
+          },
+        },
+      }),
+    ).toEqual({
+      eventKey: "github:delivery-2:review.changes_requested",
+      eventType: "review.changes_requested",
+      occurredAtMs: 1_000,
+      provider: "github",
+      resourceRef: "github:pull_request:getsentry/junior#691",
+      trustedSummary:
+        "GitHub PR getsentry/junior#691 received requested changes from reviewer.",
+      untrustedText: "please handle the edge case",
+    });
+  });
+
+  it("normalizes completed check suite events for pull requests", () => {
+    vi.setSystemTime(1_000);
+
+    expect(
+      normalizeGitHubResourceEvent({
+        deliveryId: "delivery-3",
+        eventName: "check_suite",
+        body: {
+          action: "completed",
+          repository: { full_name: "getsentry/junior" },
+          check_suite: {
+            conclusion: "failure",
+            head_sha: "abcdef1234567890",
+            pull_requests: [{ number: 691 }],
+          },
+        },
+      }),
+    ).toEqual({
+      eventKey: "github:delivery-3:checks.failed",
+      eventType: "checks.failed",
+      occurredAtMs: 1_000,
+      provider: "github",
+      resourceRef: "github:pull_request:getsentry/junior#691",
+      trustedSummary:
+        "GitHub PR getsentry/junior#691 checks failed for abcdef123456.",
+    });
+  });
+
+  it("ignores unsupported GitHub webhook actions", () => {
+    expect(
+      normalizeGitHubResourceEvent({
+        deliveryId: "delivery-4",
+        eventName: "pull_request",
+        body: {
+          action: "synchronize",
+          repository: { full_name: "getsentry/junior" },
+          pull_request: { number: 691, merged: false },
+        },
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("GitHub webhook handler", () => {
+  it("rejects unsigned requests before creating the queue", async () => {
+    const queue = vi.fn(() => {
+      throw new Error("queue should not be created");
+    });
+
+    const response = await POST(
+      new Request("https://example.test/api/webhooks/github", {
+        method: "POST",
+        body: "{}",
+      }),
+      { queue },
+    );
+
+    expect(response.status).toBe(401);
+    expect(queue).not.toHaveBeenCalled();
+  });
+
+  it("ignores signed but unsupported events before creating the queue", async () => {
+    process.env.GITHUB_WEBHOOK_SECRET = "test-secret";
+    const queue = vi.fn(() => {
+      throw new Error("queue should not be created");
+    });
+
+    const response = await POST(
+      signedRequest({
+        action: "synchronize",
+        repository: { full_name: "getsentry/junior" },
+        pull_request: { number: 691, merged: false },
+      }),
+      { queue },
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.text()).resolves.toBe("Ignored");
+    expect(queue).not.toHaveBeenCalled();
+  });
+
+  it("uses the injected state adapter for supported event subscription lookup", async () => {
+    process.env.GITHUB_WEBHOOK_SECRET = "test-secret";
+    const state = {
+      connect: vi.fn(async () => {}),
+      disconnect: vi.fn(async () => {}),
+      get: vi.fn(async () => undefined),
+      set: vi.fn(async () => {}),
+      acquireLock: vi.fn(async () => undefined),
+      releaseLock: vi.fn(async () => {}),
+    } as unknown as StateAdapter;
+
+    const response = await POST(
+      signedRequest({
+        action: "closed",
+        repository: { full_name: "getsentry/junior" },
+        pull_request: { number: 691, merged: true },
+      }),
+      {
+        queue: { send: vi.fn(async () => undefined) },
+        state,
+      },
+    );
+
+    expect(response.status).toBe(202);
+    expect(state.connect).toHaveBeenCalled();
+    expect(state.get).toHaveBeenCalled();
+  });
+});

--- a/packages/junior/tests/unit/handlers/github-webhook.test.ts
+++ b/packages/junior/tests/unit/handlers/github-webhook.test.ts
@@ -1,11 +1,11 @@
 import { createHmac } from "node:crypto";
 import type { StateAdapter } from "chat";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { POST, normalizeGitHubResourceEvent } from "@/handlers/github-webhook";
+import { POST, normalizeGitHubResourceEvents } from "@/handlers/github-webhook";
 
 const originalGithubWebhookSecret = process.env.GITHUB_WEBHOOK_SECRET;
 
-function signedRequest(body: unknown): Request {
+function signedRequest(body: unknown, eventName = "pull_request"): Request {
   const rawBody = JSON.stringify(body);
   const signature = `sha256=${createHmac("sha256", "test-secret")
     .update(rawBody)
@@ -14,7 +14,7 @@ function signedRequest(body: unknown): Request {
     method: "POST",
     headers: {
       "x-github-delivery": "delivery-1",
-      "x-github-event": "pull_request",
+      "x-github-event": eventName,
       "x-hub-signature-256": signature,
     },
     body: rawBody,
@@ -30,12 +30,12 @@ afterEach(() => {
   }
 });
 
-describe("normalizeGitHubResourceEvent", () => {
+describe("normalizeGitHubResourceEvents", () => {
   it("normalizes merged pull request events", () => {
     vi.setSystemTime(1_000);
 
     expect(
-      normalizeGitHubResourceEvent({
+      normalizeGitHubResourceEvents({
         deliveryId: "delivery-1",
         eventName: "pull_request",
         body: {
@@ -44,22 +44,24 @@ describe("normalizeGitHubResourceEvent", () => {
           pull_request: { number: 691, merged: true },
         },
       }),
-    ).toEqual({
-      eventKey: "github:delivery-1:state.merged",
-      eventType: "state.merged",
-      occurredAtMs: 1_000,
-      provider: "github",
-      resourceRef: "github:pull_request:getsentry/junior#691",
-      terminal: true,
-      trustedSummary: "GitHub PR getsentry/junior#691 was merged.",
-    });
+    ).toEqual([
+      {
+        eventKey: "github:delivery-1:state.merged",
+        eventType: "state.merged",
+        occurredAtMs: 1_000,
+        provider: "github",
+        resourceRef: "github:pull_request:getsentry/junior#691",
+        terminal: true,
+        trustedSummary: "GitHub PR getsentry/junior#691 was merged.",
+      },
+    ]);
   });
 
   it("normalizes requested-changes review events with untrusted text", () => {
     vi.setSystemTime(1_000);
 
     expect(
-      normalizeGitHubResourceEvent({
+      normalizeGitHubResourceEvents({
         deliveryId: "delivery-2",
         eventName: "pull_request_review",
         body: {
@@ -73,23 +75,25 @@ describe("normalizeGitHubResourceEvent", () => {
           },
         },
       }),
-    ).toEqual({
-      eventKey: "github:delivery-2:review.changes_requested",
-      eventType: "review.changes_requested",
-      occurredAtMs: 1_000,
-      provider: "github",
-      resourceRef: "github:pull_request:getsentry/junior#691",
-      trustedSummary:
-        "GitHub PR getsentry/junior#691 received requested changes from reviewer.",
-      untrustedText: "please handle the edge case",
-    });
+    ).toEqual([
+      {
+        eventKey: "github:delivery-2:review.changes_requested",
+        eventType: "review.changes_requested",
+        occurredAtMs: 1_000,
+        provider: "github",
+        resourceRef: "github:pull_request:getsentry/junior#691",
+        trustedSummary:
+          "GitHub PR getsentry/junior#691 received requested changes from reviewer.",
+        untrustedText: "please handle the edge case",
+      },
+    ]);
   });
 
   it("normalizes completed check suite events for pull requests", () => {
     vi.setSystemTime(1_000);
 
     expect(
-      normalizeGitHubResourceEvent({
+      normalizeGitHubResourceEvents({
         deliveryId: "delivery-3",
         eventName: "check_suite",
         body: {
@@ -98,24 +102,35 @@ describe("normalizeGitHubResourceEvent", () => {
           check_suite: {
             conclusion: "failure",
             head_sha: "abcdef1234567890",
-            pull_requests: [{ number: 691 }],
+            pull_requests: [{ number: 691 }, { number: 702 }],
           },
         },
       }),
-    ).toEqual({
-      eventKey: "github:delivery-3:checks.failed",
-      eventType: "checks.failed",
-      occurredAtMs: 1_000,
-      provider: "github",
-      resourceRef: "github:pull_request:getsentry/junior#691",
-      trustedSummary:
-        "GitHub PR getsentry/junior#691 checks failed for abcdef123456.",
-    });
+    ).toEqual([
+      {
+        eventKey: "github:delivery-3:checks.failed:691",
+        eventType: "checks.failed",
+        occurredAtMs: 1_000,
+        provider: "github",
+        resourceRef: "github:pull_request:getsentry/junior#691",
+        trustedSummary:
+          "GitHub PR getsentry/junior#691 checks failed for abcdef123456.",
+      },
+      {
+        eventKey: "github:delivery-3:checks.failed:702",
+        eventType: "checks.failed",
+        occurredAtMs: 1_000,
+        provider: "github",
+        resourceRef: "github:pull_request:getsentry/junior#702",
+        trustedSummary:
+          "GitHub PR getsentry/junior#702 checks failed for abcdef123456.",
+      },
+    ]);
   });
 
   it("ignores unsupported GitHub webhook actions", () => {
     expect(
-      normalizeGitHubResourceEvent({
+      normalizeGitHubResourceEvents({
         deliveryId: "delivery-4",
         eventName: "pull_request",
         body: {
@@ -124,7 +139,7 @@ describe("normalizeGitHubResourceEvent", () => {
           pull_request: { number: 691, merged: false },
         },
       }),
-    ).toBeUndefined();
+    ).toEqual([]);
   });
 });
 
@@ -192,5 +207,40 @@ describe("GitHub webhook handler", () => {
     expect(response.status).toBe(202);
     expect(state.connect).toHaveBeenCalled();
     expect(state.get).toHaveBeenCalled();
+  });
+
+  it("runs subscription lookup for every PR in a check suite event", async () => {
+    process.env.GITHUB_WEBHOOK_SECRET = "test-secret";
+    const state = {
+      connect: vi.fn(async () => {}),
+      disconnect: vi.fn(async () => {}),
+      get: vi.fn(async () => undefined),
+      set: vi.fn(async () => {}),
+      acquireLock: vi.fn(async () => undefined),
+      releaseLock: vi.fn(async () => {}),
+    } as unknown as StateAdapter;
+
+    const response = await POST(
+      signedRequest(
+        {
+          action: "completed",
+          repository: { full_name: "getsentry/junior" },
+          check_suite: {
+            conclusion: "success",
+            head_sha: "abcdef1234567890",
+            pull_requests: [{ number: 691 }, { number: 702 }],
+          },
+        },
+        "check_suite",
+      ),
+      {
+        queue: { send: vi.fn(async () => undefined) },
+        state,
+      },
+    );
+
+    expect(response.status).toBe(202);
+    expect(state.connect).toHaveBeenCalledTimes(2);
+    expect(state.get).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
Add host-owned GitHub webhook ingestion for resource event subscriptions. The new core route verifies GitHub webhook signatures, normalizes the MVP pull request events, and hands them to the existing resource-event ingestion path so matching subscriptions enqueue normal conversation work.

The GitHub event handling is split by webhook event type rather than collected into one large handler: pull request state, pull request review, and check suite normalization each live in their own module. The GitHub create-PR tool now only returns subscribable event hints when GITHUB_WEBHOOK_SECRET is configured, so the model only sees subscription affordances when GitHub webhooks are actually available.

Refs #682

Validation run:
- pnpm --filter @sentry/junior-github test -- --runInBand
- pnpm --filter @sentry/junior exec vitest run tests/unit/handlers/github-webhook.test.ts
- pnpm --filter @sentry/junior-github typecheck
- pnpm --filter @sentry/junior typecheck
- pnpm --filter @sentry/junior-github lint
- pnpm --filter @sentry/junior lint