### PR TITLE
fix(dashboard): show Sentry link for conversations outside the feed

### DIFF
--- a/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
@@ -63,6 +63,7 @@ export function ConversationPage(props: { data?: DashboardData }) {
               <ConversationIdentity
                 conversation={conversation}
                 conversationId={conversationId}
+                detail={detail.data}
               />
             </div>
           </div>
@@ -155,16 +156,20 @@ function CopyMarkdownButton(props: {
 function ConversationIdentity(props: {
   conversation: Conversation | undefined;
   conversationId: string | undefined;
+  detail: ConversationDetailFeed | undefined;
 }) {
+  const sentryConversationUrl =
+    props.conversation?.sentryConversationUrl ??
+    props.detail?.sentryConversationUrl;
   return (
     <>
       {conversationIdentityMeta(props.conversation, props.conversationId)}
-      {props.conversation?.sentryConversationUrl ? (
+      {sentryConversationUrl ? (
         <>
           {" · "}
           <a
             className="text-white no-underline hover:underline"
-            href={props.conversation.sentryConversationUrl}
+            href={sentryConversationUrl}
             rel="noreferrer"
             target="_blank"
           >

--- a/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
@@ -158,18 +158,15 @@ function ConversationIdentity(props: {
   conversationId: string | undefined;
   detail: ConversationDetailFeed | undefined;
 }) {
-  const sentryConversationUrl =
-    props.conversation?.sentryConversationUrl ??
-    props.detail?.sentryConversationUrl;
   return (
     <>
       {conversationIdentityMeta(props.conversation, props.conversationId)}
-      {sentryConversationUrl ? (
+      {props.detail?.sentryConversationUrl ? (
         <>
           {" · "}
           <a
             className="text-white no-underline hover:underline"
-            href={sentryConversationUrl}
+            href={props.detail.sentryConversationUrl}
             rel="noreferrer"
             target="_blank"
           >

--- a/packages/junior/src/reporting/conversations.ts
+++ b/packages/junior/src/reporting/conversations.ts
@@ -221,6 +221,7 @@ export interface ConversationReport {
   displayTitle: string;
   generatedAt: string;
   runs: ConversationRunReport[];
+  sentryConversationUrl?: string;
 }
 
 export interface ConversationFeed {
@@ -1602,10 +1603,13 @@ export async function readConversationReport(
     displayTitleFromDetails(conversationId, details) ??
     surfaceFallbackLabel(firstRun?.surface ?? "slack");
 
+  const sentryConversationUrl = buildSentryConversationUrl(conversationId);
+
   return {
     conversationId,
     displayTitle,
     generatedAt: new Date(nowMs).toISOString(),
     runs: effectiveRuns,
+    ...(sentryConversationUrl ? { sentryConversationUrl } : {}),
   };
 }


### PR DESCRIPTION
## Problem

`ConversationPage` sourced `sentryConversationUrl` only from the 50-item sessions feed. Conversations that aged out of the feed rendered their transcript fine (via the detail API) but lost the **View in Sentry** header link.

## Fix

- Add `sentryConversationUrl?: string` to `ConversationReport` and compute it in `readConversationReport` using `buildSentryConversationUrl`. The detail endpoint (`/api/dashboard/conversations/:id`) now always includes the link when env config is present.
- Source the link in `ConversationIdentity` from `detail.sentryConversationUrl` instead of the sessions feed entry. No fallback needed — the detail API always has the conversation ID and can construct the URL.

## Verification

- 143 dashboard tests pass
- Dashboard builds clean

<!-- junior-session-footer:start -->

[View Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC0AHB7N2JCR%3A1782864054.706739/?project=4510944073809921)

<!-- junior-session-footer:end -->