### PR TITLE
feat(reporting): add aggregate summary field to ConversationReport

### DIFF
--- a/packages/junior/src/reporting/conversations.ts
+++ b/packages/junior/src/reporting/conversations.ts
@@ -221,6 +221,14 @@ export interface ConversationReport {
   displayTitle: string;
   generatedAt: string;
   runs: ConversationRunReport[];
+  /**
+   * Aggregate summary across all runs. Omitted when the conversation has no
+   * run data at all (neither session summaries nor a conversation index entry).
+   * Representative fields (surface, channel, requesterIdentity, sentryConversationUrl,
+   * traceId) come from the newest run; aggregate fields (status, timestamps,
+   * cumulativeDurationMs, cumulativeUsage) are computed across all runs.
+   */
+  summary?: ConversationSummaryReport;
 }
 
 export interface ConversationFeed {
@@ -794,6 +802,117 @@ function newestRun(
       (reportTime(right.lastSeenAt) ?? 0) -
         (reportTime(left.lastSeenAt) ?? 0) || right.id.localeCompare(left.id),
   )[0]!;
+}
+
+function earliestStartedAt(
+  runs: ConversationSummaryReport[],
+): string {
+  return runs.reduce((earliest, run) => {
+    const t = reportTime(run.startedAt);
+    const currentT = reportTime(earliest);
+    return t !== undefined && (currentT === undefined || t < currentT)
+      ? run.startedAt
+      : earliest;
+  }, runs[0]!.startedAt);
+}
+
+function latestIsoField(
+  runs: ConversationSummaryReport[],
+  field: "lastSeenAt" | "lastProgressAt",
+): string {
+  return runs.reduce((latest, run) => {
+    const t = reportTime(run[field]);
+    const currentT = reportTime(latest);
+    return t !== undefined && (currentT === undefined || t > currentT)
+      ? run[field]
+      : latest;
+  }, runs[0]![field]);
+}
+
+/** Aggregate status across runs using the same precedence as the client feed. */
+function conversationAggregateStatus(
+  runs: ConversationSummaryReport[],
+): ConversationSummaryReport["status"] {
+  const signals = statusSignals(runs);
+  if (signals.hung) return "hung";
+  if (signals.active) return "active";
+  if (signals.failed) return "failed";
+  return newestRun(runs).status;
+}
+
+/** Sum ConversationUsage components across independent session runs. */
+function aggregateConversationUsage(
+  runs: ConversationSummaryReport[],
+): ConversationUsage | undefined {
+  let hasAny = false;
+  const result: ConversationUsage = {};
+  const addField = (
+    key: keyof ConversationUsage,
+    value: number | undefined,
+  ) => {
+    if (typeof value !== "number" || !Number.isFinite(value)) return;
+    const clamped = Math.max(0, Math.floor(value));
+    result[key] = ((result[key] ?? 0) as number) + clamped;
+    hasAny = true;
+  };
+  for (const run of runs) {
+    const usage = run.cumulativeUsage;
+    if (!usage) continue;
+    addField("inputTokens", usage.inputTokens);
+    addField("outputTokens", usage.outputTokens);
+    addField("cachedInputTokens", usage.cachedInputTokens);
+    addField("cacheCreationTokens", usage.cacheCreationTokens);
+    addField("totalTokens", usage.totalTokens);
+  }
+  return hasAny ? result : undefined;
+}
+
+/**
+ * Build an aggregate ConversationSummaryReport across all runs.
+ * Representative fields come from the newest run; aggregate fields
+ * (status, timestamps, duration, usage) are computed across all runs.
+ * Returns undefined when the runs array is empty.
+ */
+function conversationSummaryFromRuns(
+  runs: ConversationSummaryReport[],
+  options: {
+    conversationId: string;
+    displayTitle: string;
+  },
+): ConversationSummaryReport | undefined {
+  if (runs.length === 0) return undefined;
+
+  const representative = newestRun(runs);
+  const status = conversationAggregateStatus(runs);
+  const isTerminal =
+    status !== "active" && status !== "hung";
+  const completedAts = isTerminal
+    ? runs.flatMap((run) => (run.completedAt ? [run.completedAt] : []))
+    : [];
+  const completedAt =
+    completedAts.length > 0
+      ? completedAts.reduce((latest, ts) => {
+          const t = reportTime(ts);
+          const currentT = reportTime(latest);
+          return t !== undefined && (currentT === undefined || t > currentT)
+            ? ts
+            : latest;
+        })
+      : undefined;
+  const cumulativeUsage = aggregateConversationUsage(runs);
+
+  return {
+    ...representative,
+    conversationId: options.conversationId,
+    displayTitle: options.displayTitle,
+    status,
+    startedAt: earliestStartedAt(runs),
+    lastSeenAt: latestIsoField(runs, "lastSeenAt"),
+    lastProgressAt: latestIsoField(runs, "lastProgressAt"),
+    ...(completedAt !== undefined ? { completedAt } : { completedAt: undefined }),
+    cumulativeDurationMs: conversationDurationMs(runs),
+    ...(cumulativeUsage !== undefined ? { cumulativeUsage } : {}),
+  };
 }
 
 function recentConversationGroups(args: {
@@ -1602,10 +1721,16 @@ export async function readConversationReport(
     displayTitleFromDetails(conversationId, details) ??
     surfaceFallbackLabel(firstRun?.surface ?? "slack");
 
+  const summary = conversationSummaryFromRuns(effectiveRuns, {
+    conversationId,
+    displayTitle,
+  });
+
   return {
     conversationId,
     displayTitle,
     generatedAt: new Date(nowMs).toISOString(),
     runs: effectiveRuns,
+    ...(summary !== undefined ? { summary } : {}),
   };
 }

--- a/packages/junior/tests/integration/dashboard-reporting.test.ts
+++ b/packages/junior/tests/integration/dashboard-reporting.test.ts
@@ -397,6 +397,138 @@ describe("dashboard reporting", () => {
     });
   });
 
+  it("includes aggregate summary on single-run conversation report", async () => {
+    const { recordAgentTurnSessionSummary } =
+      await import("@/chat/state/turn-session");
+    const { createJuniorReporting } = await import("@/reporting");
+
+    await recordAgentTurnSessionSummary({
+      channelName: "proj-alpha",
+      conversationId: "slack:C1:summary-single",
+      cumulativeDurationMs: 2_000,
+      requester: slackRequester("Avery"),
+      sessionId: "turn-s1",
+      sliceId: 1,
+      startedAtMs: Date.parse("2026-06-04T10:00:00.000Z"),
+      state: "completed",
+      surface: "slack",
+    });
+
+    const report = await createJuniorReporting().getConversation(
+      "slack:C1:summary-single",
+    );
+
+    expect(report.summary).toBeDefined();
+    expect(report.summary).toMatchObject({
+      conversationId: "slack:C1:summary-single",
+      displayTitle: report.displayTitle,
+      status: "completed",
+      cumulativeDurationMs: 2_000,
+      surface: "slack",
+    });
+    // id should be the representative run id, not conversationId
+    expect(report.summary?.id).toBe("turn-s1");
+    // timestamps should match the single run
+    expect(report.summary?.startedAt).toBe(report.runs[0]?.startedAt);
+    expect(report.summary?.lastSeenAt).toBe(report.runs[0]?.lastSeenAt);
+  });
+
+  it("includes aggregate summary across multiple runs", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-04T12:00:00.000Z"));
+    const { recordAgentTurnSessionSummary } =
+      await import("@/chat/state/turn-session");
+    const { createJuniorReporting } = await import("@/reporting");
+
+    const earlierMs = Date.parse("2026-06-04T10:00:00.000Z");
+    const laterMs = Date.parse("2026-06-04T11:00:00.000Z");
+
+    await recordAgentTurnSessionSummary({
+      channelName: "proj-alpha",
+      conversationId: "slack:C1:summary-multi",
+      cumulativeDurationMs: 1_000,
+      requester: slackRequester("Avery"),
+      sessionId: "turn-m1",
+      sliceId: 1,
+      startedAtMs: earlierMs,
+      state: "completed",
+      surface: "slack",
+    });
+    await recordAgentTurnSessionSummary({
+      channelName: "proj-alpha",
+      conversationId: "slack:C1:summary-multi",
+      cumulativeDurationMs: 3_000,
+      requester: slackRequester("Avery"),
+      sessionId: "turn-m2",
+      sliceId: 1,
+      startedAtMs: laterMs,
+      state: "failed",
+      surface: "slack",
+    });
+
+    const report = await createJuniorReporting().getConversation(
+      "slack:C1:summary-multi",
+    );
+
+    expect(report.runs).toHaveLength(2);
+    expect(report.summary).toBeDefined();
+    expect(report.summary).toMatchObject({
+      conversationId: "slack:C1:summary-multi",
+      displayTitle: report.displayTitle,
+      status: "failed",
+    });
+    // startedAt should be the earliest run
+    const earlierRun = report.runs.find((r) => r.id === "turn-m1");
+    const laterRun = report.runs.find((r) => r.id === "turn-m2");
+    if (earlierRun && laterRun) {
+      expect(report.summary?.startedAt).toBe(earlierRun.startedAt);
+      // lastSeenAt should be from the latest run
+      expect(report.summary?.lastSeenAt).toBe(laterRun.lastSeenAt);
+    }
+    // cumulativeDurationMs should be the sum across runs (1000 + 3000 = 4000)
+    expect(report.summary?.cumulativeDurationMs).toBe(4_000);
+    // id should be from the representative (newest) run
+    expect(report.summary?.id).toBe("turn-m2");
+  });
+
+  it("omits summary when conversation has no runs", async () => {
+    const { createJuniorReporting } = await import("@/reporting");
+
+    // Conversation with no turn summaries and no index entry:
+    // getConversation returns empty runs, summary should be absent
+    const report = await createJuniorReporting().getConversation(
+      "slack:C1:no-runs-at-all",
+    );
+
+    expect(report.runs).toHaveLength(0);
+    expect(report.summary).toBeUndefined();
+  });
+
+  it("summary displayTitle matches top-level displayTitle", async () => {
+    const { setConversationTitle } =
+      await import("@/chat/state/conversation-details");
+    const { recordAgentTurnSessionSummary } =
+      await import("@/chat/state/turn-session");
+    const { createJuniorReporting } = await import("@/reporting");
+
+    await setConversationTitle("slack:C1:summary-title", {
+      displayTitle: "Custom Title",
+    });
+    await recordAgentTurnSessionSummary({
+      conversationId: "slack:C1:summary-title",
+      sessionId: "turn-t1",
+      sliceId: 1,
+      startedAtMs: Date.parse("2026-06-04T10:00:00.000Z"),
+      state: "completed",
+    });
+
+    const report = await createJuniorReporting().getConversation(
+      "slack:C1:summary-title",
+    );
+
+    expect(report.displayTitle).toBe(report.summary?.displayTitle);
+  });
+
   it("reports aggregate conversation stats beyond the session feed cap", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-04T12:00:00.000Z"));


### PR DESCRIPTION
## What

Adds `summary?: ConversationSummaryReport` to `ConversationReport` (returned by `GET /api/dashboard/conversations/:id`), making the conversation detail endpoint self-sufficient.

Previously the dashboard `ConversationPage` had to look up the conversation in the global sessions feed to get header metadata (title, status, location, duration, Sentry URL). With this field populated the detail endpoint carries everything needed to render the full page without a dependency on the sessions poll.

## How

New `conversationSummaryFromRuns` helper in `conversations.ts` builds the aggregate summary from `effectiveRuns`:

- **Representative fields** come from the newest run: `id`, `surface`, `channel`, `channelName`, `requesterIdentity`, `sentryConversationUrl`, `sentryTraceUrl`, `traceId`
- **Aggregate fields** are computed across all runs:
  - `status`: `hung > active > failed > newest-run status` — same precedence as the client sessions feed
  - `startedAt`: earliest across runs
  - `lastSeenAt` / `lastProgressAt`: latest across runs  
  - `completedAt`: max `completedAt` when all runs are terminal, else omitted
  - `cumulativeDurationMs`: summed via existing `conversationDurationMs` (handles incremental deduplication)
  - `cumulativeUsage`: summed component-by-component across runs

`summary` is omitted (`undefined`) when `effectiveRuns` is empty — this only happens when neither session summaries nor a conversation index entry exist for the given conversation ID.

## Verified

- `tsc --noEmit` clean in both `@sentry/junior` and `@sentry/junior-dashboard`
- All 143 `@sentry/junior-dashboard` tests pass
- 4 new integration test cases added to `dashboard-reporting.test.ts` covering: single run, multiple runs (aggregation), empty runs (summary absent), title consistency

## Part of

This is step 1 of the dashboard API restructure tracked in #704. Subsequent steps:
1. **This PR**: `ConversationReport.summary` — backend only ← you are here
2. Route restructure: `/api/dashboard/*` → `/api/*` with compat redirects
3. `ConversationPage` self-sufficiency: use `detail.data.summary` instead of sessions feed
4. Polling split: `useCoreData` / `useConversationsData`
5. `client.js` → static assets, drop `info` endpoint

<!-- junior-session-footer:start -->

[View Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC0B595QDZLL%3A1782864433.847299/?project=4510944073809921)

<!-- junior-session-footer:end -->