### PR TITLE
fix(task-execution): Centralize conversation wakes

### DIFF
--- a/packages/junior/src/chat/services/agent-continue.ts
+++ b/packages/junior/src/chat/services/agent-continue.ts
@@ -9,7 +9,7 @@ import type { Destination } from "@sentry/junior-plugin-api";
 import { getAgentTurnSessionRecord } from "@/chat/state/turn-session";
 import type { ConversationWorkQueue } from "@/chat/task-execution/queue";
 import {
-  markConversationWorkEnqueued,
+  ensureConversationWake,
   requestConversationWork,
 } from "@/chat/task-execution/store";
 import { getVercelConversationWorkQueue } from "@/chat/task-execution/vercel-queue";
@@ -70,24 +70,17 @@ export async function scheduleAgentContinue(
     state: options.state,
   });
   const queue = options.queue ?? getVercelConversationWorkQueue();
-  await queue.send(
-    {
-      conversationId: request.conversationId,
-      destination: request.destination,
-    },
-    {
-      idempotencyKey: [
-        "agent-continue",
-        request.conversationId,
-        request.sessionId,
-        request.expectedVersion,
-        nowMs,
-      ].join(":"),
-    },
-  );
-  await markConversationWorkEnqueued({
+  await ensureConversationWake({
     conversationId: request.conversationId,
+    idempotencyKey: [
+      "agent-continue",
+      request.conversationId,
+      request.sessionId,
+      request.expectedVersion,
+      nowMs,
+    ].join(":"),
     nowMs,
+    queue,
     state: options.state,
   });
 }

--- a/packages/junior/src/chat/task-execution/heartbeat.ts
+++ b/packages/junior/src/chat/task-execution/heartbeat.ts
@@ -1,14 +1,13 @@
 import type { StateAdapter } from "chat";
-import type { Destination } from "@sentry/junior-plugin-api";
 import { logException, logInfo } from "@/chat/logging";
 import type { ConversationWorkQueue } from "./queue";
 import {
   clearExpiredConversationLease,
   CONVERSATION_WORK_STALE_ENQUEUE_MS,
+  ensureConversationWake,
   getConversationWorkState,
   hasRunnableConversationWork,
   listActiveConversationIds,
-  markConversationWorkEnqueued,
   removeActiveConversation,
 } from "./store";
 
@@ -25,28 +24,6 @@ function heartbeatIdempotencyKey(
   nowMs: number,
 ): string {
   return `heartbeat:${reason}:${conversationId}:${nowMs}`;
-}
-
-async function sendRecoveryNudge(args: {
-  conversationId: string;
-  destination: Destination;
-  idempotencyKey: string;
-  nowMs: number;
-  queue: ConversationWorkQueue;
-  state?: StateAdapter;
-}): Promise<void> {
-  await args.queue.send(
-    {
-      conversationId: args.conversationId,
-      destination: args.destination,
-    },
-    { idempotencyKey: args.idempotencyKey },
-  );
-  await markConversationWorkEnqueued({
-    conversationId: args.conversationId,
-    nowMs: args.nowMs,
-    state: args.state,
-  });
 }
 
 /** Requeue expired leases and stranded mailbox work without running the agent. */
@@ -89,11 +66,6 @@ export async function recoverConversationWork(args: {
         continue;
       }
 
-      const destination = work.destination;
-      if (!destination) {
-        continue;
-      }
-
       if (
         work.execution.lease &&
         work.execution.lease.expiresAtMs <= args.nowMs
@@ -106,9 +78,8 @@ export async function recoverConversationWork(args: {
         if (!cleared) {
           continue;
         }
-        await sendRecoveryNudge({
+        const wake = await ensureConversationWake({
           conversationId,
-          destination,
           idempotencyKey: heartbeatIdempotencyKey(
             "lease",
             conversationId,
@@ -116,32 +87,27 @@ export async function recoverConversationWork(args: {
           ),
           nowMs: args.nowMs,
           queue: args.queue,
+          replaceExistingWake: true,
           state: args.state,
         });
-        result.expiredLeaseCount += 1;
-        logInfo(
-          "conversation_work_lease_expired_requeued",
-          { conversationId },
-          {},
-          "Heartbeat requeued expired conversation work lease",
-        );
+        if (wake.status === "enqueued") {
+          result.expiredLeaseCount += 1;
+          logInfo(
+            "conversation_work_lease_expired_requeued",
+            { conversationId },
+            {},
+            "Heartbeat requeued expired conversation work lease",
+          );
+        }
         continue;
       }
 
       if (work.execution.lease || !hasRunnableConversationWork(work)) {
         continue;
       }
-      if (
-        typeof work.execution.lastEnqueuedAtMs === "number" &&
-        work.execution.lastEnqueuedAtMs + CONVERSATION_WORK_STALE_ENQUEUE_MS >
-          args.nowMs
-      ) {
-        continue;
-      }
 
-      await sendRecoveryNudge({
+      const wake = await ensureConversationWake({
         conversationId,
-        destination,
         idempotencyKey: heartbeatIdempotencyKey(
           "pending",
           conversationId,
@@ -151,13 +117,15 @@ export async function recoverConversationWork(args: {
         queue: args.queue,
         state: args.state,
       });
-      result.pendingCount += 1;
-      logInfo(
-        "conversation_work_pending_requeued",
-        { conversationId },
-        {},
-        "Heartbeat requeued pending conversation work",
-      );
+      if (wake.status === "enqueued") {
+        result.pendingCount += 1;
+        logInfo(
+          "conversation_work_pending_requeued",
+          { conversationId },
+          {},
+          "Heartbeat requeued pending conversation work",
+        );
+      }
     } catch (error) {
       logException(
         error,

--- a/packages/junior/src/chat/task-execution/state.ts
+++ b/packages/junior/src/chat/task-execution/state.ts
@@ -1295,6 +1295,37 @@ export async function markConversationWorkEnqueued(args: {
   });
 }
 
+/** Clear a wake marker after its queue delivery finds no runnable work. */
+export async function clearConsumedConversationWake(args: {
+  conversationId: string;
+  nowMs?: number;
+  state?: StateAdapter;
+}): Promise<boolean> {
+  const nowMs = args.nowMs ?? now();
+  return await withConversationMutation(args, async (state) => {
+    const current = await readConversation(state, args.conversationId);
+    if (
+      !current ||
+      hasRunnableWork(current) ||
+      current.execution.lastEnqueuedAtMs === undefined
+    ) {
+      return false;
+    }
+    await writeConversation(
+      state,
+      withExecutionUpdate(
+        current,
+        {
+          ...current.execution,
+          lastEnqueuedAtMs: undefined,
+        },
+        nowMs,
+      ),
+    );
+    return true;
+  });
+}
+
 /** Try to acquire the durable execution lease for one conversation. */
 export async function startConversationWork(args: {
   conversationId: string;

--- a/packages/junior/src/chat/task-execution/store.ts
+++ b/packages/junior/src/chat/task-execution/store.ts
@@ -39,6 +39,15 @@ interface MetadataOptions {
   state?: StateAdapter;
 }
 
+export type EnsureConversationWakeResult =
+  | {
+      queueMessageId?: string;
+      status: "enqueued";
+    }
+  | {
+      status: "already_enqueued" | "no_work";
+    };
+
 function metadataStore(options: MetadataOptions): ConversationStore {
   return options.conversationStore ?? getConversationStore();
 }
@@ -142,6 +151,59 @@ export function hasRunnableConversationWork(
   );
 }
 
+/**
+ * Ensure runnable conversation work has one accepted queue wake-up nudge.
+ *
+ * Ordinary wakes coalesce on a recent accepted marker. Replacement is only for
+ * consumed or known-stale deliveries where another queue nudge must exist.
+ */
+export async function ensureConversationWake(args: {
+  conversationId: string;
+  conversationStore?: ConversationStore;
+  delayMs?: number;
+  idempotencyKey: string;
+  nowMs?: number;
+  queue: ConversationWorkQueue;
+  replaceExistingWake?: true;
+  state?: StateAdapter;
+}): Promise<EnsureConversationWakeResult> {
+  const nowMs = args.nowMs ?? now();
+  const conversation = await workState.getConversation({
+    conversationId: args.conversationId,
+    state: args.state,
+  });
+  if (!conversation || !hasRunnableConversationWork(conversation)) {
+    return { status: "no_work" };
+  }
+  if (!conversation.destination) {
+    return { status: "no_work" };
+  }
+  if (
+    args.replaceExistingWake !== true &&
+    hasRecentEnqueueMarker(conversation, nowMs)
+  ) {
+    return { status: "already_enqueued" };
+  }
+
+  const queueResult = await args.queue.send(
+    {
+      conversationId: args.conversationId,
+      destination: conversation.destination,
+    },
+    {
+      delayMs: args.delayMs,
+      idempotencyKey: args.idempotencyKey,
+    },
+  );
+  await markConversationWorkEnqueued({
+    conversationId: args.conversationId,
+    conversationStore: args.conversationStore,
+    nowMs,
+    state: args.state,
+  });
+  return { status: "enqueued", queueMessageId: queueResult?.messageId };
+}
+
 /** Persist one inbound message idempotently in its conversation mailbox. */
 export async function appendInboundMessage(args: {
   message: InboundMessage;
@@ -158,7 +220,7 @@ export async function appendInboundMessage(args: {
   return result;
 }
 
-/** Persist inbound work and send the queue nudge that wakes a worker. */
+/** Persist inbound work and ensure a worker wake-up. */
 export async function appendAndEnqueueInboundMessage(args: {
   message: InboundMessage;
   conversationStore?: ConversationStore;
@@ -189,23 +251,41 @@ export async function appendAndEnqueueInboundMessage(args: {
     }
     idempotencyKey = duplicateInboundNudgeIdempotencyKey(args.message, nowMs);
   }
-  const queueResult = await args.queue.send(
-    {
-      conversationId: args.message.conversationId,
-      destination: args.message.destination,
-    },
-    { idempotencyKey },
-  );
-  await markConversationWorkEnqueued({
+  const wake = await ensureConversationWake({
     conversationId: args.message.conversationId,
     conversationStore: args.conversationStore,
+    idempotencyKey,
     nowMs,
+    queue: args.queue,
     state: args.state,
   });
+  if (wake.status !== "enqueued") {
+    await recordExecutionMetadata({
+      conversationId: args.message.conversationId,
+      conversationStore: args.conversationStore,
+      state: args.state,
+    });
+  }
   return {
     ...appendResult,
-    queueMessageId: queueResult?.messageId,
+    ...(wake.status === "enqueued"
+      ? { queueMessageId: wake.queueMessageId }
+      : {}),
   };
+}
+
+/** Clear an accepted wake marker after its delivery finds no runnable work. */
+export async function clearConsumedConversationWake(args: {
+  conversationId: string;
+  conversationStore?: ConversationStore;
+  nowMs?: number;
+  state?: StateAdapter;
+}) {
+  const result = await workState.clearConsumedConversationWake(args);
+  if (result) {
+    await recordExecutionMetadata(args);
+  }
+  return result;
 }
 
 /** Mark a conversation runnable when there is no new mailbox message. */
@@ -241,7 +321,7 @@ export async function recordConversationActivity(
 }
 
 /** Record that a wake-up nudge was accepted for the conversation. */
-export async function markConversationWorkEnqueued(args: {
+async function markConversationWorkEnqueued(args: {
   conversationId: string;
   conversationStore?: ConversationStore;
   nowMs?: number;

--- a/packages/junior/src/chat/task-execution/worker.ts
+++ b/packages/junior/src/chat/task-execution/worker.ts
@@ -11,12 +11,13 @@ import {
 } from "./queue";
 import {
   checkInConversationWork,
+  clearConsumedConversationWake,
   completeConversationWork,
   CONVERSATION_WORK_CHECK_IN_INTERVAL_MS,
   countPendingConversationMessages,
   drainConversationMailbox,
+  ensureConversationWake,
   getConversationWorkState,
-  markConversationWorkEnqueued,
   releaseConversationWork,
   requestConversationContinuation,
   startConversationWork,
@@ -73,32 +74,6 @@ function nudgeIdempotencyKey(
   return `${reason}:${conversationId}:${nowMs}`;
 }
 
-async function sendWakeNudge(args: {
-  conversationId: string;
-  destination: Destination;
-  delayMs?: number;
-  idempotencyKey: string;
-  nowMs: number;
-  options: ProcessConversationWorkOptions;
-}): Promise<void> {
-  await args.options.queue.send(
-    {
-      conversationId: args.conversationId,
-      destination: args.destination,
-    },
-    {
-      delayMs: args.delayMs,
-      idempotencyKey: args.idempotencyKey,
-    },
-  );
-  await markConversationWorkEnqueued({
-    conversationId: args.conversationId,
-    conversationStore: args.options.conversationStore,
-    nowMs: args.nowMs,
-    state: args.options.state,
-  });
-}
-
 async function requestLostLeaseRecovery(args: {
   conversationId: string;
   destination: Destination;
@@ -127,16 +102,18 @@ async function requestLostLeaseRecovery(args: {
   if (!released) {
     return;
   }
-  await sendWakeNudge({
+  await ensureConversationWake({
     conversationId: args.conversationId,
-    destination: args.destination,
+    conversationStore: args.options.conversationStore,
     idempotencyKey: nudgeIdempotencyKey(
       "lost_lease",
       args.conversationId,
       args.nowMs,
     ),
     nowMs: args.nowMs,
-    options: args.options,
+    queue: args.options.queue,
+    replaceExistingWake: true,
+    state: args.options.state,
   });
 }
 
@@ -197,6 +174,14 @@ export async function processConversationWork(
       initial.execution.status === "idle" &&
       !initial.execution.lease)
   ) {
+    if (initial) {
+      await clearConsumedConversationWake({
+        conversationId,
+        conversationStore: options.conversationStore,
+        nowMs: now(options),
+        state: options.state,
+      });
+    }
     return { status: "no_work" };
   }
   if (
@@ -218,17 +203,25 @@ export async function processConversationWork(
     state: options.state,
   });
   if (lease.status === "no_work") {
+    await clearConsumedConversationWake({
+      conversationId,
+      conversationStore: options.conversationStore,
+      nowMs: now(options),
+      state: options.state,
+    });
     return { status: "no_work" };
   }
   if (lease.status === "active") {
     const nudgeNowMs = now(options);
-    await sendWakeNudge({
+    await ensureConversationWake({
       conversationId,
-      destination,
+      conversationStore: options.conversationStore,
       delayMs: CONVERSATION_WORK_DEFER_DELAY_MS,
       idempotencyKey: nudgeIdempotencyKey("active", conversationId, nudgeNowMs),
       nowMs: nudgeNowMs,
-      options,
+      queue: options.queue,
+      replaceExistingWake: true,
+      state: options.state,
     });
     logInfo(
       "conversation_work_nudge_deferred_for_active_lease",
@@ -329,16 +322,17 @@ export async function processConversationWork(
       if (!continuationMarked) {
         return { status: "lost_lease" };
       }
-      await sendWakeNudge({
+      await ensureConversationWake({
         conversationId,
-        destination,
+        conversationStore: options.conversationStore,
         idempotencyKey: nudgeIdempotencyKey(
           "yield",
           conversationId,
           yieldNowMs,
         ),
         nowMs: yieldNowMs,
-        options,
+        queue: options.queue,
+        state: options.state,
       });
       await releaseConversationWork({
         conversationId,
@@ -371,18 +365,21 @@ export async function processConversationWork(
     }
     if (completion === "pending") {
       const nudgeNowMs = now(options);
-      await sendWakeNudge({
+      const wake = await ensureConversationWake({
         conversationId,
-        destination,
+        conversationStore: options.conversationStore,
         idempotencyKey: nudgeIdempotencyKey(
           "pending",
           conversationId,
           nudgeNowMs,
         ),
         nowMs: nudgeNowMs,
-        options,
+        queue: options.queue,
+        state: options.state,
       });
-      return { status: "pending_requeued" };
+      return wake.status === "enqueued"
+        ? { status: "pending_requeued" }
+        : { status: "completed" };
     }
 
     logInfo(
@@ -406,16 +403,17 @@ export async function processConversationWork(
         state: options.state,
       });
       if (continuationMarked) {
-        await sendWakeNudge({
+        await ensureConversationWake({
           conversationId,
-          destination,
+          conversationStore: options.conversationStore,
           idempotencyKey: nudgeIdempotencyKey(
             "error",
             conversationId,
             errorNowMs,
           ),
           nowMs: errorNowMs,
-          options,
+          queue: options.queue,
+          state: options.state,
         });
       }
     } catch (requeueError) {

--- a/packages/junior/tests/component/runtime/agent-continue.test.ts
+++ b/packages/junior/tests/component/runtime/agent-continue.test.ts
@@ -72,6 +72,41 @@ describe("agent continuation scheduling", () => {
     });
   });
 
+  it("coalesces continuation wakes while an accepted nudge is recent", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    const conversationId = "slack:C123:1712345.0001";
+
+    await scheduleAgentContinue(
+      {
+        conversationId,
+        destination: SLACK_DESTINATION,
+        sessionId: "turn_msg_1",
+        expectedVersion: 3,
+      },
+      { queue, nowMs: 1_000 },
+    );
+    queue.clearSentRecords();
+
+    await scheduleAgentContinue(
+      {
+        conversationId,
+        destination: SLACK_DESTINATION,
+        sessionId: "turn_msg_1",
+        expectedVersion: 4,
+      },
+      { queue, nowMs: 2_000 },
+    );
+
+    expect(queue.sentRecords()).toEqual([]);
+    await expect(
+      getConversationWorkState({ conversationId }),
+    ).resolves.toMatchObject({
+      conversationId,
+      needsRun: true,
+      lastEnqueuedAtMs: 1_000,
+    });
+  });
+
   it("reschedules continuation when the Slack resume lock stays busy", async () => {
     vi.useFakeTimers();
     const conversationId = "slack:C123:1712345.0002";

--- a/packages/junior/tests/component/task-execution/conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/conversation-work.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { scheduleAgentContinue } from "@/chat/services/agent-continue";
 import { recoverConversationWork } from "@/chat/task-execution/heartbeat";
 import { runHeartbeat } from "@/chat/agent-dispatch/heartbeat";
 import {
@@ -538,6 +539,69 @@ describe("conversation work execution", () => {
     await expect(first).resolves.toEqual({ status: "completed" });
   });
 
+  it("wakes fresh inbound work after a consumed deferred nudge left a recent marker", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    let currentNowMs = 1_000;
+    await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
+    const entered = deferred<void>();
+    const finish = deferred<void>();
+
+    const first = processConversationWork(conversationQueueMessage(), {
+      nowMs: () => currentNowMs,
+      queue,
+      run: async (context) => {
+        await context.drainMailbox(async () => {});
+        entered.resolve();
+        await finish.promise;
+        return { status: "completed" };
+      },
+    });
+    await entered.promise;
+
+    currentNowMs = 2_000;
+    await expect(
+      processConversationWork(conversationQueueMessage(), {
+        nowMs: () => currentNowMs,
+        queue,
+        run: async () => ({ status: "completed" }),
+      }),
+    ).resolves.toEqual({ status: "active" });
+
+    currentNowMs = 3_000;
+    finish.resolve();
+    await expect(first).resolves.toEqual({ status: "completed" });
+
+    currentNowMs = 4_000;
+    await expect(
+      processConversationWork(queue.takeMessage(), {
+        nowMs: () => currentNowMs,
+        queue,
+        run: async () => ({ status: "completed" }),
+      }),
+    ).resolves.toEqual({ status: "no_work" });
+
+    queue.clearSentRecords();
+    currentNowMs = 5_000;
+    await expect(
+      appendAndEnqueueInboundMessage({
+        message: inboundMessage("m2", {
+          createdAtMs: 5_000,
+          receivedAtMs: 5_000,
+        }),
+        nowMs: currentNowMs,
+        queue,
+      }),
+    ).resolves.toMatchObject({ status: "appended", queueMessageId: "queue-1" });
+
+    expect(queue.sentRecords()).toEqual([
+      {
+        conversationId: CONVERSATION_ID,
+        destination: SLACK_DESTINATION,
+        idempotencyKey: "m2",
+      },
+    ]);
+  });
+
   it("rejects queue messages whose destination does not match persisted work", async () => {
     const queue = createConversationWorkQueueTestAdapter();
     const run = vi.fn(async () => ({ status: "completed" as const }));
@@ -627,6 +691,107 @@ describe("conversation work execution", () => {
     ]);
   });
 
+  it("does not send a second nudge when a continuation wake was already queued during the lease", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    let currentNowMs = 1_000;
+    await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
+
+    await expect(
+      processConversationWork(conversationQueueMessage(), {
+        nowMs: () => currentNowMs,
+        queue,
+        run: async (context) => {
+          await context.drainMailbox(async () => {});
+          currentNowMs = 2_000;
+          await requestConversationWork({
+            conversationId: context.conversationId,
+            destination: context.destination,
+            nowMs: currentNowMs,
+          });
+          await scheduleAgentContinue(
+            {
+              conversationId: context.conversationId,
+              destination: context.destination,
+              expectedVersion: 2,
+              sessionId: "turn-1",
+            },
+            { queue, nowMs: currentNowMs },
+          );
+          return { status: "completed" };
+        },
+      }),
+    ).resolves.toEqual({ status: "completed" });
+
+    const state = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+    });
+    expect(state?.lease).toBeUndefined();
+    expect(state?.needsRun).toBe(true);
+    expect(state?.lastEnqueuedAtMs).toBe(2_000);
+    expect(queue.sentRecords()).toEqual([
+      {
+        conversationId: CONVERSATION_ID,
+        destination: SLACK_DESTINATION,
+        idempotencyKey: `agent-continue:${CONVERSATION_ID}:turn-1:2:2000`,
+      },
+    ]);
+  });
+
+  it("uses an existing conversation wake for pending mailbox and continuation work", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    let currentNowMs = 1_000;
+    await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
+
+    await expect(
+      processConversationWork(conversationQueueMessage(), {
+        nowMs: () => currentNowMs,
+        queue,
+        run: async (context) => {
+          await context.drainMailbox(async () => {});
+          currentNowMs = 2_000;
+          await requestConversationWork({
+            conversationId: context.conversationId,
+            destination: context.destination,
+            nowMs: currentNowMs,
+          });
+          await scheduleAgentContinue(
+            {
+              conversationId: context.conversationId,
+              destination: context.destination,
+              expectedVersion: 2,
+              sessionId: "turn-1",
+            },
+            { queue, nowMs: currentNowMs },
+          );
+          await appendInboundMessage({
+            message: inboundMessage("m2", {
+              createdAtMs: 2_100,
+              receivedAtMs: 2_100,
+            }),
+            nowMs: 2_100,
+          });
+          return { status: "completed" };
+        },
+      }),
+    ).resolves.toEqual({ status: "completed" });
+
+    const state = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+    });
+    expect(state?.lease).toBeUndefined();
+    expect(state?.needsRun).toBe(true);
+    expect(state?.messages.map((message) => message.inboundMessageId)).toEqual([
+      "m2",
+    ]);
+    expect(queue.sentRecords()).toEqual([
+      {
+        conversationId: CONVERSATION_ID,
+        destination: SLACK_DESTINATION,
+        idempotencyKey: `agent-continue:${CONVERSATION_ID}:turn-1:2:2000`,
+      },
+    ]);
+  });
+
   it("uses fresh queue idempotency keys for repeated worker requeues", async () => {
     const queue = createConversationWorkQueueTestAdapter();
     let currentNowMs = 1_000;
@@ -693,6 +858,47 @@ describe("conversation work execution", () => {
       {
         conversationId: CONVERSATION_ID,
         idempotencyKey: `error:${CONVERSATION_ID}:2000`,
+      },
+    ]);
+  });
+
+  it("does not send a second error nudge when a continuation wake already exists", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    let currentNowMs = 1_000;
+    await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
+
+    await expect(
+      processConversationWork(conversationQueueMessage(), {
+        nowMs: () => currentNowMs,
+        queue,
+        run: async (context) => {
+          await context.drainMailbox(async () => {});
+          currentNowMs = 2_000;
+          await scheduleAgentContinue(
+            {
+              conversationId: context.conversationId,
+              destination: context.destination,
+              expectedVersion: 2,
+              sessionId: "turn-1",
+            },
+            { queue, nowMs: currentNowMs },
+          );
+          throw new Error("runner failed");
+        },
+      }),
+    ).rejects.toThrow("runner failed");
+
+    const state = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+    });
+    expect(state?.lease).toBeUndefined();
+    expect(state?.needsRun).toBe(true);
+    expect(state?.lastEnqueuedAtMs).toBe(2_000);
+    expect(queue.sentRecords()).toEqual([
+      {
+        conversationId: CONVERSATION_ID,
+        destination: SLACK_DESTINATION,
+        idempotencyKey: `agent-continue:${CONVERSATION_ID}:turn-1:2:2000`,
       },
     ]);
   });

--- a/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
@@ -333,8 +333,17 @@ describe("Slack behavior: durable turn steering", () => {
     }
 
     releaseAgent.resolve();
-    await expect(activeTurn).resolves.toEqual({ status: "pending_requeued" });
-    expect(queue.sentRecords()).toHaveLength(6);
+    await expect(activeTurn).resolves.toEqual({ status: "completed" });
+    expect(queue.sentRecords()).toEqual([
+      expect.objectContaining({
+        conversationId,
+        idempotencyKey: `slack:T123:${conversationId}:${THREAD_TS}`,
+      }),
+      expect.objectContaining({
+        conversationId,
+        idempotencyKey: `slack:T123:${conversationId}:1712345.000200`,
+      }),
+    ]);
 
     expect(agentCalls).toEqual([
       {

--- a/policies/interface-design.md
+++ b/policies/interface-design.md
@@ -36,6 +36,12 @@ Interfaces should expose the smallest useful capability while keeping ownership,
 - When a term is overloaded in the product or platform, define it once in the
   owning spec and avoid using it for nearby concepts.
 - Add an interface only when it removes real coupling or represents a stable boundary.
+- Avoid one-hop wrappers, renamed aliases, and helper layers that only forward
+  arguments, options, or dependencies. Call the owning capability directly
+  unless the intermediate function enforces an invariant, translates a boundary,
+  or owns a lifecycle transition.
+- If a helper exists only to hide parameter threading, inline it or move the
+  repeated call shape to the owner that actually defines the contract.
 
 ## Exceptions
 

--- a/specs/task-execution.md
+++ b/specs/task-execution.md
@@ -117,6 +117,14 @@ Normative rules:
 7. Routine continuation must be silent on platforms where the delivery adapter
    owns progress UX. The agent-owned `reportProgress` path and destination
    status/progress port own user-visible progress.
+8. Production wake-up sends must go through `ensureConversationWake`. Business
+   paths mark durable runnable work; the wake helper sends the disposable queue
+   nudge and records the accepted enqueue marker.
+9. Ordinary wake requests coalesce while `lastEnqueuedAtMs` is recent. Explicit
+   replacement wakes are reserved for consumed or known-stale deliveries, such as
+   active-lease deferral and expired-lease heartbeat recovery.
+10. When a queue delivery finds no runnable work, it clears the consumed wake
+    marker so future inbound work can request a fresh wake immediately.
 
 ### Identity Model
 
@@ -323,9 +331,10 @@ durable handoff:
 4. Set `execution.status = "pending"`, update `lastActivityAtMs`,
    `execution.updatedAtMs`, `pendingCount`, and upsert both conversation
    indexes.
-5. Enqueue `{ conversationId, destination }`.
-6. If enqueue succeeds, record `lastEnqueuedAtMs` and refresh
-   `execution.updatedAtMs`.
+5. Ensure a conversation wake through `ensureConversationWake`.
+6. If a new queue nudge is accepted, record `lastEnqueuedAtMs` and refresh
+   `execution.updatedAtMs`. If the wake is coalesced with an existing accepted
+   nudge, leave the existing enqueue marker intact.
 7. Return the source acknowledgement quickly. For HTTP sources, this is the
    HTTP response. For local CLI, this is returning control to the terminal loop
    after durable handoff or direct local execution setup.


### PR DESCRIPTION
Centralize conversation wake scheduling behind `ensureConversationWake` so ordinary wake requests coalesce on the durable enqueue marker instead of each business path sending and marking queue nudges directly.

This addresses the duplicate-wake loop risk from #705 without taking on the larger explicit wake-state redesign. The helper derives the queue payload destination from durable conversation state, requires explicit idempotency keys, keeps replacement wakes limited to consumed or known-stale deliveries, and clears consumed no-work wake markers so later inbound messages can wake immediately.

The PR also updates task-execution docs with the centralized wake contract and adds an interface-design policy note discouraging one-hop wrappers and pass-through helper layers, which came up while cleaning up the worker call sites.

Refs #705