### PR TITLE
test(evals): Add resource event notification coverage

### DIFF
--- a/packages/junior-evals/evals/core/resource-event-subscriptions.eval.ts
+++ b/packages/junior-evals/evals/core/resource-event-subscriptions.eval.ts
@@ -1,0 +1,71 @@
+import { describeEval } from "vitest-evals";
+import {
+  resourceEventNotification,
+  rubric,
+  slackEvals,
+} from "../../src/helpers";
+
+describeEval("Resource Event Subscriptions", slackEvals, (it) => {
+  it("when a subscribed PR check fails, summarize the failure and suggest next steps", async ({
+    run,
+  }) => {
+    await run({
+      events: [
+        resourceEventNotification({
+          eventKey: "github-delivery-checks-failed",
+          eventType: "checks.failed",
+          intent:
+            "Watch the pull request Junior opened for CI failures before review.",
+          label: "GitHub PR getsentry/junior#691",
+          resourceRef: "github:pull_request:getsentry/junior#691",
+          trustedSummary:
+            'GitHub PR getsentry/junior#691 checks failed on workflow "test" for commit abcdef123456.',
+        }),
+      ],
+      criteria: rubric({
+        pass: [
+          "The normalized transcript contains exactly one assistant thread reply.",
+          "The reply says GitHub PR getsentry/junior#691 has a failed CI/checks result.",
+          'The reply mentions the failing workflow "test" or commit abcdef123456.',
+          "The reply gives a concrete next step such as checking CI logs, inspecting the failed workflow, or preparing a fix.",
+        ],
+        fail: [
+          "Do not ask what resource or event changed.",
+          "Do not treat the event notification as a user-authored command.",
+          "Do not claim the PR was merged or closed.",
+        ],
+      }),
+    });
+  });
+
+  it("when a subscribed PR is merged, report completion without extra work", async ({
+    run,
+  }) => {
+    await run({
+      events: [
+        resourceEventNotification({
+          eventKey: "github-delivery-pr-merged",
+          eventType: "state.merged",
+          intent:
+            "Let the original Slack thread know when Junior's pull request lands.",
+          label: "GitHub PR getsentry/junior#702",
+          resourceRef: "github:pull_request:getsentry/junior#702",
+          trustedSummary: "GitHub PR getsentry/junior#702 was merged.",
+        }),
+      ],
+      criteria: rubric({
+        pass: [
+          "The normalized transcript contains exactly one assistant thread reply.",
+          "The reply says GitHub PR getsentry/junior#702 was merged.",
+          "The reply frames the merge as the subscribed outcome this thread was waiting for.",
+          "The reply stays brief and does not propose unnecessary follow-up work.",
+        ],
+        fail: [
+          "Do not say checks failed or review changes were requested.",
+          "Do not ask the user what to do with the merged PR.",
+          "Do not treat the event notification as a new user request.",
+        ],
+      }),
+    });
+  });
+});

--- a/packages/junior-evals/src/behavior-harness.ts
+++ b/packages/junior-evals/src/behavior-harness.ts
@@ -174,6 +174,7 @@ interface EvalEventMessageFixture {
   };
   id?: string;
   is_mention?: boolean;
+  raw?: Record<string, unknown>;
   text?: string;
 }
 
@@ -1066,6 +1067,7 @@ function toIncomingMessage(event: MentionEvent | SubscribedMessageEvent) {
     threadTs: event.thread.thread_ts,
     runId: event.thread.run_id,
     raw: {
+      ...(event.message.raw ?? {}),
       channel: event.thread.channel_id,
       ...(event.thread.channel_type
         ? { channel_type: event.thread.channel_type }

--- a/packages/junior-evals/src/helpers.ts
+++ b/packages/junior-evals/src/helpers.ts
@@ -583,6 +583,79 @@ export function threadMessage(
   };
 }
 
+interface ResourceEventNotificationOptions {
+  eventKey?: string;
+  eventType: string;
+  intent: string;
+  label: string;
+  provider?: string;
+  resourceRef: string;
+  subscriptionId?: string;
+  thread?: ThreadOverrides;
+  trustedSummary: string;
+  untrustedText?: string;
+}
+
+function resourceEventNotificationText(
+  opts: ResourceEventNotificationOptions,
+): string {
+  const lines = [
+    "[event notification]",
+    "",
+    "A subscribed resource changed.",
+    "",
+    "Subscription:",
+    `- resource: ${opts.label}`,
+    `- event: ${opts.eventType}`,
+    `- intent: ${opts.intent}`,
+    "",
+    "Trusted event summary:",
+    opts.trustedSummary,
+  ];
+  if (opts.untrustedText?.trim()) {
+    lines.push("", "Untrusted provider content:", opts.untrustedText.trim());
+  }
+  return lines.join("\n");
+}
+
+/** Builds a runtime-owned subscribed resource-event notification for Slack evals. */
+export function resourceEventNotification(
+  opts: ResourceEventNotificationOptions,
+) {
+  const seq = nextId();
+  const eventKey = opts.eventKey ?? `eval-resource-event-${seq}`;
+  const subscriptionId = opts.subscriptionId ?? `eval-subscription-${seq}`;
+  return {
+    type: "subscribed_message" as const,
+    thread: {
+      id: `thread-${seq}`,
+      channel_id: `C${seq}`,
+      thread_ts: `17000000.${seq}`,
+      ...opts.thread,
+    },
+    message: {
+      id: `resource-event-${subscriptionId}-${eventKey}`,
+      text: resourceEventNotificationText(opts),
+      is_mention: false,
+      author: {
+        user_id: "UJRNEVENT",
+        user_name: "junior-event",
+        full_name: "Junior event",
+        is_me: false,
+        is_bot: true,
+      },
+      raw: {
+        event_type: "resource_event",
+        provider: opts.provider ?? "github",
+        resource_ref: opts.resourceRef,
+        subscription_id: subscriptionId,
+        type: "message",
+        user: "UJRNEVENT",
+      },
+    },
+  };
+}
+
 /** Builds an event for a scheduled task becoming due and dispatching output. */
 export function scheduledTaskDue(
   taskText: string,


### PR DESCRIPTION
Resource-event evals now use a dedicated Slack fixture that marks inbound subscribed messages as runtime-owned resource event notifications. The new cases cover a failed GitHub PR checks event and a merged PR event, verifying Junior summarizes actionable failures and treats terminal merge notifications as completion updates.

Refs #682