### PR TITLE
docs(concepts): fix validation command in skills-and-plugins doc

### DIFF
--- a/packages/docs/src/content/docs/concepts/skills-and-plugins.md
+++ b/packages/docs/src/content/docs/concepts/skills-and-plugins.md
@@ -33,7 +33,7 @@ owns the destination domain, the request is not given provider auth.
 ## Validation
 
 ```bash
-pnpm skills:check
+pnpm exec junior check
 ```
 
 Move package installs, CLI bootstraps, MCP server setup, and API-key configuration to `plugin.yaml` so reviewed manifests, not arbitrary skill instructions, control the runtime authority surface.

--- a/packages/docs/src/content/docs/extend/index.md
+++ b/packages/docs/src/content/docs/extend/index.md
@@ -355,5 +355,5 @@ Add the package name to `defineJuniorPlugins(...)`, then point
 ## Validate extensions
 
 ```bash
-pnpm skills:check
+pnpm exec junior check
 ```


### PR DESCRIPTION
Fixes `pnpm skills:check` → `pnpm exec junior check` in two user-app-facing doc pages.

`pnpm skills:check` is a valid monorepo-internal script (root `package.json` delegates to `@sentry/junior skills:check`), but it is not available in scaffolded user apps. The correct command for user apps is `pnpm exec junior check`.

**Files changed:**
- `concepts/skills-and-plugins.md` — Validation section
- `extend/index.md` — Validate extensions section

`contribute/development.md` references the same command but that page targets monorepo contributors where `pnpm skills:check` is valid — left untouched.