### PR TITLE
fix(slack): handle restricted_action_read_only_channel gracefully

### DIFF
--- a/packages/junior/src/chat/runtime/slack-runtime.ts
+++ b/packages/junior/src/chat/runtime/slack-runtime.ts
@@ -11,6 +11,7 @@ import type { Destination } from "@sentry/junior-plugin-api";
 import { getSubscribedReplyPreflightDecision } from "@/chat/services/subscribed-decision";
 import { isProviderRetryError } from "@/chat/services/provider-retry";
 import { AuthorizationFlowDisabledError } from "@/chat/services/auth-pause";
+import { SlackActionError } from "@/chat/slack/client";
 import {
   isCooperativeTurnYieldError,
   isTurnInputCommitLostError,
@@ -812,6 +813,24 @@ export function createSlackTurnRuntime<
         if (error instanceof AuthorizationFlowDisabledError) {
           return;
         }
+        if (
+          error instanceof SlackActionError &&
+          error.code === "read_only_channel"
+        ) {
+          deps.logWarn(
+            "mention_handler_read_only_channel",
+            logContext({
+              threadId: deps.getThreadId(thread, message),
+              requesterId: message.author.userId,
+              requesterUserName: requesterUserName(message),
+              channelId: deps.getChannelId(thread, message),
+              runId: deps.getRunId(thread, message),
+            }),
+            {},
+            "Skipping reply to read-only channel",
+          );
+          return;
+        }
         const eventId = deps.logException(
           error,
           "mention_handler_failed",
@@ -1100,6 +1119,24 @@ export function createSlackTurnRuntime<
           return;
         }
         if (error instanceof AuthorizationFlowDisabledError) {
+          return;
+        }
+        if (
+          error instanceof SlackActionError &&
+          error.code === "read_only_channel"
+        ) {
+          deps.logWarn(
+            "subscribed_message_handler_read_only_channel",
+            logContext({
+              threadId: deps.getThreadId(thread, message),
+              requesterId: message.author.userId,
+              requesterUserName: requesterUserName(message),
+              channelId: deps.getChannelId(thread, message),
+              runId: deps.getRunId(thread, message),
+            }),
+            {},
+            "Skipping reply to read-only channel",
+          );
           return;
         }
         const eventId = deps.logException(

--- a/packages/junior/src/chat/slack/client.ts
+++ b/packages/junior/src/chat/slack/client.ts
@@ -21,6 +21,7 @@ export type SlackActionErrorCode =
   | "not_in_channel"
   | "already_reacted"
   | "no_reaction"
+  | "read_only_channel"
   | "internal_error";
 
 export class SlackActionError extends Error {
@@ -229,6 +230,10 @@ function mapSlackError(error: unknown): SlackActionError {
 
   if (apiError === "not_in_channel") {
     return new SlackActionError(message, "not_in_channel", baseOptions);
+  }
+
+  if (apiError === "restricted_action_read_only_channel") {
+    return new SlackActionError(message, "read_only_channel", baseOptions);
   }
 
   if (apiError === "already_reacted") {

--- a/packages/junior/tests/unit/slack/slack-client-retries.test.ts
+++ b/packages/junior/tests/unit/slack/slack-client-retries.test.ts
@@ -187,3 +187,23 @@ describe("withSlackRetries", () => {
     expect(task).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("mapSlackError - read_only_channel", () => {
+  it("maps restricted_action_read_only_channel as read_only_channel", async () => {
+    const task = vi.fn<() => Promise<string>>().mockRejectedValue({
+      data: {
+        error: "restricted_action_read_only_channel",
+      },
+      message: "An API error occurred: restricted_action_read_only_channel",
+    });
+
+    await expect(withSlackRetries(task, 3)).rejects.toEqual(
+      expect.objectContaining<Partial<SlackActionError>>({
+        name: "SlackActionError",
+        code: "read_only_channel",
+        apiError: "restricted_action_read_only_channel",
+      }),
+    );
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What

When Junior is mentioned in a read-only Slack channel, Slack's API returns `restricted_action_read_only_channel`. Previously `mapSlackError` had no case for this code, so it fell through to `internal_error`, creating an unhandled exception in Sentry. The error then propagated to `handleNewMention` / `handleSubscribedMessage`, which tried to post a fallback error reply — which _also_ failed with the same read-only error — generating two Sentry events per incident.

**Affected issues**: JUNIOR-3C (`SlackActionError: restricted_action_read_only_channel`) and JUNIOR-3D (`Error: restricted_action_read_only_channel`) — 13 occurrences across 3 users.

## Changes

- `packages/junior/src/chat/slack/client.ts`
  - Add `"read_only_channel"` to the `SlackActionErrorCode` union type
  - Map `restricted_action_read_only_channel` → `"read_only_channel"` in `mapSlackError` (previously fell through to `"internal_error"`)

- `packages/junior/src/chat/runtime/slack-runtime.ts`
  - Import `SlackActionError`
  - In `handleNewMention` and `handleSubscribedMessage` catch blocks: detect `read_only_channel` errors and log a warning + return early, bypassing the fallback reply (which would also fail and produce a second Sentry event)

- `packages/junior/tests/unit/slack/slack-client-retries.test.ts`
  - Add test asserting `restricted_action_read_only_channel` maps to `read_only_channel`

## Verification

- `tsc --noEmit` passes cleanly
- Tests couldn't be run in sandbox (requires local postgres), but the pattern matches existing tests for `canvas_creation_failed`, `already_reacted`, etc.

Refs JUNIOR-3C, JUNIOR-3D

<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC0AHB7N2JCR%3A1782882171.769539/?project=4510944073809921)

<!-- junior-session-footer:end -->