### PR TITLE
feat(dashboard): Add people profiles and transcript drilldowns

### DIFF
--- a/apps/example/dashboard.ts
+++ b/apps/example/dashboard.ts
@@ -1,7 +1,4 @@
 function isVercelEnvironment(): boolean {
-  if (process.env.NODE_ENV === "development") {
-    return false;
-  }
   return Boolean(
     process.env.VERCEL?.trim() ||
     process.env.VERCEL_ENV?.trim() ||

--- a/apps/example/dashboard.ts
+++ b/apps/example/dashboard.ts
@@ -1,4 +1,7 @@
 function isVercelEnvironment(): boolean {
+  if (process.env.NODE_ENV === "development") {
+    return false;
+  }
   return Boolean(
     process.env.VERCEL?.trim() ||
     process.env.VERCEL_ENV?.trim() ||

--- a/packages/junior-dashboard/e2e/dashboard.spec.ts
+++ b/packages/junior-dashboard/e2e/dashboard.spec.ts
@@ -85,6 +85,22 @@ function reporting(): JuniorReporting {
         transcriptAvailable: true,
       };
     },
+    async getConversationSubagentTranscript(
+      _conversationId,
+      _runId,
+      subagentId,
+    ) {
+      return {
+        type: "subagent",
+        createdAt: "2026-06-12T00:00:00.000Z",
+        id: subagentId,
+        status: "error",
+        subagentKind: "unknown",
+        transcript: [],
+        transcriptAvailable: false,
+        unavailableReason: "not_found",
+      };
+    },
   };
 }
 

--- a/packages/junior-dashboard/src/app.ts
+++ b/packages/junior-dashboard/src/app.ts
@@ -5,6 +5,8 @@ import type {
   ConversationStatsReport,
   PluginOperationalReportFeed,
   JuniorReporting,
+  RequesterDirectoryReport,
+  RequesterProfileReport,
 } from "@sentry/junior/reporting";
 import { createJuniorReporting } from "@sentry/junior/reporting";
 import { initSentry } from "@sentry/junior/instrumentation";
@@ -233,6 +235,48 @@ function emptyConversationStatsReport(): ConversationStatsReport {
   };
 }
 
+function emptyRequesterDirectoryReport(): RequesterDirectoryReport {
+  return {
+    generatedAt: new Date().toISOString(),
+    people: [],
+    sampleLimit: 0,
+    sampleSize: 0,
+    source: "conversation_index",
+    truncated: false,
+  };
+}
+
+function emptyRequesterProfileReport(email: string): RequesterProfileReport {
+  const nowMs = Date.now();
+  const end = new Date(nowMs);
+  end.setUTCHours(0, 0, 0, 0);
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - 365);
+  return {
+    activityDays: [],
+    generatedAt: new Date(nowMs).toISOString(),
+    locations: [],
+    recentConversations: [],
+    requester: { email },
+    sampleLimit: 0,
+    sampleSize: 0,
+    source: "conversation_index",
+    surfaces: [],
+    totals: {
+      active: 0,
+      activeDays: 0,
+      conversations: 0,
+      durationMs: 0,
+      failed: 0,
+      hung: 0,
+      runs: 0,
+    },
+    truncated: false,
+    windowEnd: end.toISOString(),
+    windowStart: start.toISOString(),
+  };
+}
+
 async function readConversationStats(
   reporting: JuniorReporting,
 ): Promise<ConversationStatsReport> {
@@ -249,6 +293,25 @@ async function readPluginReports(
     return emptyPluginReportFeed();
   }
   return await reporting.getPluginOperationalReports();
+}
+
+async function readRequesterDirectory(
+  reporting: JuniorReporting,
+): Promise<RequesterDirectoryReport> {
+  if (!reporting.listRequesters) {
+    return emptyRequesterDirectoryReport();
+  }
+  return await reporting.listRequesters();
+}
+
+async function readRequesterProfile(
+  reporting: JuniorReporting,
+  email: string,
+): Promise<RequesterProfileReport> {
+  if (!reporting.getRequesterProfile) {
+    return emptyRequesterProfileReport(email);
+  }
+  return await reporting.getRequesterProfile(email);
 }
 
 function callbackUrl(request: Request, basePath: string): string {
@@ -385,6 +448,7 @@ function dashboardPagePaths(basePath: string): string[] {
   return [
     basePath,
     basePath === "/" ? "/conversations" : `${basePath}/conversations`,
+    basePath === "/" ? "/people" : `${basePath}/people`,
     basePath === "/" ? "/plugins" : `${basePath}/plugins`,
   ];
 }
@@ -648,6 +712,31 @@ export function createDashboardApp(
       );
     }
   });
+  app.get("/api/people", async () => {
+    try {
+      return Response.json(await readRequesterDirectory(reporting));
+    } catch {
+      return Response.json(
+        { error: "People failed to load." },
+        { status: 500 },
+      );
+    }
+  });
+  app.get("/api/people/:email", async (c) => {
+    try {
+      return Response.json(
+        await readRequesterProfile(
+          reporting,
+          decodeURIComponent(c.req.param("email")),
+        ),
+      );
+    } catch {
+      return Response.json(
+        { error: "Profile failed to load." },
+        { status: 500 },
+      );
+    }
+  });
   app.get("/api/plugin-reports", async () => {
     try {
       return Response.json(await readPluginReports(reporting));
@@ -665,6 +754,18 @@ export function createDashboardApp(
       ),
     );
   });
+  app.get(
+    "/api/conversations/:conversationId/runs/:runId/subagents/:subagentId",
+    async (c) => {
+      return Response.json(
+        await reporting.getConversationSubagentTranscript(
+          decodeURIComponent(c.req.param("conversationId")),
+          decodeURIComponent(c.req.param("runId")),
+          decodeURIComponent(c.req.param("subagentId")),
+        ),
+      );
+    },
+  );
   app.get("/api/config", () => {
     return Response.json({
       allowedEmailCount: allowedEmails.length,

--- a/packages/junior-dashboard/src/client/App.tsx
+++ b/packages/junior-dashboard/src/client/App.tsx
@@ -9,6 +9,7 @@ import { setDashboardTimeZone } from "./format";
 import { CommandCenter } from "./pages/CommandCenter";
 import { ConversationPage } from "./pages/ConversationPage";
 import { ConversationsPage } from "./pages/ConversationsPage";
+import { PeoplePage, PersonProfilePage } from "./pages/PeoplePage";
 import { PluginsPage } from "./pages/PluginsPage";
 import { cn } from "./styles";
 import type { DashboardData } from "./types";
@@ -60,6 +61,9 @@ export function DashboardShell() {
               </NavLink>
               <NavLink className={navLinkClass} to="/conversations">
                 Conversations
+              </NavLink>
+              <NavLink className={navLinkClass} to="/people">
+                People
               </NavLink>
               <NavLink className={navLinkClass} to="/plugins">
                 Plugins
@@ -122,6 +126,22 @@ export function DashboardShell() {
             )
           }
           path="/plugins"
+        />
+        <Route
+          element={
+            loading ? <LoadingView label="Loading people" /> : <PeoplePage />
+          }
+          path="/people"
+        />
+        <Route
+          element={
+            loading ? (
+              <LoadingView label="Loading profile" />
+            ) : (
+              <PersonProfilePage />
+            )
+          }
+          path="/people/:email"
         />
         <Route
           element={

--- a/packages/junior-dashboard/src/client/api.ts
+++ b/packages/junior-dashboard/src/client/api.ts
@@ -2,6 +2,7 @@ import { QueryClient, useQuery } from "@tanstack/react-query";
 
 import type {
   ConversationStatsReport,
+  ConversationSubagentTranscript,
   ConversationDetailFeed,
   ConversationFeed,
   DashboardConfig,
@@ -10,6 +11,8 @@ import type {
   Identity,
   Plugin,
   PluginReportFeed,
+  RequesterDirectory,
+  RequesterProfile,
   Runtime,
   Skill,
 } from "./types";
@@ -117,6 +120,10 @@ async function readPluginReports(): Promise<PluginReportFeed> {
   return await read<PluginReportFeed>("/api/plugin-reports");
 }
 
+async function readRequesterDirectory(): Promise<RequesterDirectory> {
+  return await read<RequesterDirectory>("/api/people");
+}
+
 /** Fetch dashboard shell data shared across browser routes. */
 export function useDashboardCoreData() {
   return useQuery({
@@ -148,6 +155,26 @@ export function useConversationsData() {
   return useQuery({
     queryKey: ["dashboard", "conversations"],
     queryFn: readConversationFeed,
+    retry: false,
+  });
+}
+
+/** Fetch the requester directory used by the People dashboard route. */
+export function useRequesterDirectoryData() {
+  return useQuery({
+    queryKey: ["dashboard", "people"],
+    queryFn: readRequesterDirectory,
+    retry: false,
+  });
+}
+
+/** Fetch one requester profile for the People detail dashboard route. */
+export function useRequesterProfileData(email: string | undefined) {
+  return useQuery({
+    enabled: Boolean(email),
+    queryKey: ["dashboard", "people", email],
+    queryFn: async (): Promise<RequesterProfile> =>
+      read<RequesterProfile>(`/api/people/${encodeURIComponent(email!)}`),
     retry: false,
   });
 }
@@ -205,4 +232,36 @@ export function readConversationData(
   return read<ConversationDetailFeed>(
     `/api/conversations/${encodeURIComponent(conversationId)}`,
   );
+}
+
+/** Fetch one child-agent transcript for the conversation detail drawer. */
+export function useConversationSubagentTranscriptData(
+  params:
+    | {
+        conversationId: string;
+        runId: string;
+        subagentId: string;
+      }
+    | undefined,
+) {
+  return useQuery({
+    enabled: Boolean(params),
+    queryKey: [
+      "conversation-subagent",
+      params?.conversationId,
+      params?.runId,
+      params?.subagentId,
+    ],
+    queryFn: async (): Promise<ConversationSubagentTranscript> => {
+      const active = params!;
+      return await read<ConversationSubagentTranscript>(
+        `/api/conversations/${encodeURIComponent(
+          active.conversationId,
+        )}/runs/${encodeURIComponent(active.runId)}/subagents/${encodeURIComponent(
+          active.subagentId,
+        )}`,
+      );
+    },
+    retry: false,
+  });
 }

--- a/packages/junior-dashboard/src/client/components/ConversationList.tsx
+++ b/packages/junior-dashboard/src/client/components/ConversationList.tsx
@@ -15,13 +15,16 @@ import { statusBorderClass } from "./statusStyles";
 /** Render the full conversation table used by the conversations page. */
 export function ConversationList(props: {
   conversations: Conversation[];
+  emptyLabel?: string;
   selectedId?: string;
   search?: string;
 }) {
   if (props.conversations.length === 0) {
     return (
       <div className="grid gap-2 p-3">
-        <EmptyTelemetry>No matching conversation telemetry.</EmptyTelemetry>
+        <EmptyTelemetry>
+          {props.emptyLabel ?? "No conversations to show."}
+        </EmptyTelemetry>
       </div>
     );
   }

--- a/packages/junior-dashboard/src/client/components/ConversationListControls.tsx
+++ b/packages/junior-dashboard/src/client/components/ConversationListControls.tsx
@@ -1,0 +1,114 @@
+import { Search } from "lucide-react";
+
+import type { ConversationListFilterOption } from "../format";
+import { cn } from "../styles";
+import { Button } from "./Button";
+
+/** Render the dashboard's compact conversation search input. */
+export function ConversationSearchInput(props: {
+  className?: string;
+  label: string;
+  onChange(value: string): void;
+  placeholder: string;
+  value: string;
+}) {
+  return (
+    <div className={cn("relative min-w-0", props.className)}>
+      <Search
+        aria-hidden="true"
+        className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-[#555]"
+        size={13}
+        strokeWidth={2.5}
+      />
+      <input
+        aria-label={props.label}
+        className="h-9 w-full rounded-md border border-white/15 bg-[#0b0b0b] pl-8 pr-3 text-[0.82rem] text-[#d6d6d6] outline-none transition-colors placeholder:text-[#555] hover:border-white/30 focus:border-[#beaaff]/45 focus:ring-1 focus:ring-[#beaaff]/20"
+        placeholder={props.placeholder}
+        type="search"
+        value={props.value}
+        onChange={(event) => props.onChange(event.currentTarget.value)}
+      />
+    </div>
+  );
+}
+
+/** Render a compact inline select for conversation list facets. */
+export function ConversationFilterSelect(props: {
+  allLabel: string;
+  label: string;
+  onChange(value: string): void;
+  options: ConversationListFilterOption[];
+  value: string;
+}) {
+  return (
+    <label className="grid h-9 min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center overflow-hidden rounded-md border border-white/15 bg-[#0b0b0b] transition-colors hover:border-white/30 focus-within:border-[#beaaff]/45 focus-within:ring-1 focus-within:ring-[#beaaff]/20">
+      <span className="flex h-full items-center border-r border-white/10 px-2 text-[0.68rem] font-semibold uppercase leading-none text-[#777]">
+        {props.label}
+      </span>
+      <select
+        aria-label={props.label}
+        className="h-full min-w-0 bg-transparent px-2 text-[0.82rem] font-semibold text-[#d6d6d6] outline-none"
+        value={props.value}
+        onChange={(event) => props.onChange(event.currentTarget.value)}
+      >
+        <option value="">{props.allLabel}</option>
+        {props.options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+/** Render the conversation list search and facet controls as one compact toolbar. */
+export function ConversationListToolbar(props: {
+  query: string;
+  requester: string;
+  requesterOptions: ConversationListFilterOption[];
+  source: string;
+  sourceOptions: ConversationListFilterOption[];
+  onQueryChange(value: string): void;
+  onRequesterChange(value: string): void;
+  onSourceChange(value: string): void;
+  onClear?(): void;
+}) {
+  const filtered = Boolean(
+    props.query.trim() || props.requester || props.source,
+  );
+  return (
+    <div className="border-b border-white/10 bg-[#050505] px-3 py-3">
+      <div className="grid min-w-0 gap-2 md:grid-cols-[minmax(14rem,1fr)_minmax(9rem,13rem)_minmax(11rem,16rem)_auto]">
+        <ConversationSearchInput
+          label="Search conversations"
+          placeholder="Search title, email, channel, id..."
+          value={props.query}
+          onChange={props.onQueryChange}
+        />
+        <ConversationFilterSelect
+          allLabel="All sources"
+          label="Source"
+          options={props.sourceOptions}
+          value={props.source}
+          onChange={props.onSourceChange}
+        />
+        <ConversationFilterSelect
+          allLabel="All requesters"
+          label="Requester"
+          options={props.requesterOptions}
+          value={props.requester}
+          onChange={props.onRequesterChange}
+        />
+        {filtered && props.onClear ? (
+          <Button
+            className="h-9 justify-center md:w-auto"
+            onClick={props.onClear}
+          >
+            Clear
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/packages/junior-dashboard/src/client/components/ConversationStack.tsx
+++ b/packages/junior-dashboard/src/client/components/ConversationStack.tsx
@@ -12,9 +12,18 @@ import { ConversationSummary } from "./ConversationSummary";
 import { EmptyTelemetry } from "./EmptyTelemetry";
 
 /** Render the compact latest-conversation stack on the command center. */
-export function ConversationStack(props: { conversations: Conversation[] }) {
+export function ConversationStack(props: {
+  conversations: Conversation[];
+  emptyLabel?: string;
+}) {
   if (props.conversations.length === 0) {
-    return <EmptyTelemetry>No conversation telemetry yet.</EmptyTelemetry>;
+    return (
+      <div className="p-3">
+        <EmptyTelemetry>
+          {props.emptyLabel ?? "No conversation telemetry yet."}
+        </EmptyTelemetry>
+      </div>
+    );
   }
 
   return (

--- a/packages/junior-dashboard/src/client/components/ConversationStats.tsx
+++ b/packages/junior-dashboard/src/client/components/ConversationStats.tsx
@@ -1,5 +1,5 @@
 import { formatCompactNumber, formatMs } from "../format";
-import type { ConversationStatsItem, ConversationStatsReport } from "../types";
+import type { ConversationStatsReport } from "../types";
 import { Section } from "./Section";
 import { SectionHeader } from "./SectionHeader";
 import { SectionTitle } from "./SectionTitle";
@@ -10,24 +10,13 @@ function plural(label: string, count: number): string {
 
 const EMPTY_STATS: Pick<
   ConversationStatsReport,
-  | "active"
-  | "conversations"
-  | "durationMs"
-  | "failed"
-  | "hung"
-  | "locations"
-  | "requesters"
-  | "runs"
-  | "tokens"
+  "active" | "conversations" | "durationMs" | "failed" | "hung" | "tokens"
 > = {
   active: 0,
   conversations: 0,
   durationMs: 0,
   failed: 0,
   hung: 0,
-  locations: [],
-  requesters: [],
-  runs: 0,
 };
 
 /** Render aggregate conversation stats returned by the reporting API. */
@@ -58,28 +47,15 @@ export function ConversationStats(props: {
       >
         <SectionTitle>Stats</SectionTitle>
       </SectionHeader>
-      <div className="grid border-b border-white/10 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid border-b border-white/10 sm:grid-cols-3">
         <SummaryMetric
           label="conversations"
           value={formatCompactNumber(stats.conversations)}
         />
-        <SummaryMetric label="runs" value={formatCompactNumber(stats.runs)} />
         <SummaryMetric label="runtime" value={formatMs(stats.durationMs)} />
         <SummaryMetric
           label="tokens"
           value={stats.tokens ? formatCompactNumber(stats.tokens) : "0"}
-        />
-      </div>
-      <div className="grid min-w-0 lg:grid-cols-2">
-        <Leaderboard
-          empty="No requester activity yet."
-          items={stats.requesters}
-          title="People"
-        />
-        <Leaderboard
-          empty="No Slack destinations yet."
-          items={stats.locations}
-          title="Places"
         />
       </div>
       <div className="border-t border-white/10 px-4 py-3 text-[0.84rem] leading-tight text-[#888]">
@@ -100,65 +76,5 @@ function SummaryMetric(props: { label: string; value: string }) {
         {props.label}
       </div>
     </div>
-  );
-}
-
-function Leaderboard(props: {
-  empty: string;
-  items: ConversationStatsItem[];
-  title: string;
-}) {
-  const items = props.items.slice(0, 5);
-  return (
-    <div className="min-w-0 border-r border-white/10 last:border-r-0 max-lg:border-t">
-      <div className="border-b border-white/10 px-4 py-2.5 text-[0.76rem] font-bold uppercase leading-none text-[#888]">
-        {props.title}
-      </div>
-      {items.length === 0 ? (
-        <div className="px-4 py-4 text-[0.84rem] leading-relaxed text-[#888]">
-          {props.empty}
-        </div>
-      ) : (
-        <ol className="m-0 list-none p-0">
-          {items.map((item, index) => (
-            <LeaderboardRow index={index} item={item} key={item.label} />
-          ))}
-        </ol>
-      )}
-    </div>
-  );
-}
-
-function LeaderboardRow(props: { index: number; item: ConversationStatsItem }) {
-  const detail = [
-    props.item.durationMs > 0 ? formatMs(props.item.durationMs) : undefined,
-    props.item.tokens
-      ? `${formatCompactNumber(props.item.tokens)} tokens`
-      : undefined,
-    props.item.failed > 0 ? plural("error", props.item.failed) : undefined,
-    props.item.hung > 0
-      ? `${formatCompactNumber(props.item.hung)} hung`
-      : undefined,
-  ]
-    .filter(Boolean)
-    .join(" / ");
-
-  return (
-    <li className="grid min-w-0 grid-cols-[2rem_minmax(0,1fr)_auto] items-center gap-3 border-b border-white/10 px-4 py-3 last:border-b-0">
-      <div className="font-mono text-[0.74rem] font-semibold leading-none text-[#666]">
-        {props.index + 1}
-      </div>
-      <div className="min-w-0">
-        <div className="truncate text-[0.92rem] font-semibold leading-tight text-white">
-          {props.item.label}
-        </div>
-        <div className="mt-1 truncate text-[0.76rem] leading-tight text-[#888]">
-          {detail || "No activity details"}
-        </div>
-      </div>
-      <div className="text-right text-xl font-extrabold leading-none text-white">
-        {formatCompactNumber(props.item.conversations)}
-      </div>
-    </li>
   );
 }

--- a/packages/junior-dashboard/src/client/components/ConversationSummary.tsx
+++ b/packages/junior-dashboard/src/client/components/ConversationSummary.tsx
@@ -1,6 +1,9 @@
+import { Link } from "react-router";
+
 import {
   conversationDisplayTitle,
-  conversationIdentityMeta,
+  conversationRequesterLabel,
+  peoplePath,
   visualStatusForConversation,
 } from "../format";
 import type { Conversation } from "../types";
@@ -19,8 +22,35 @@ export function ConversationSummary(props: { conversation: Conversation }) {
         <StatusBadge status={visualStatus} />
       </div>
       <div className="mt-1 break-words text-[0.86rem] leading-relaxed text-[#b8b8b8] md:truncate">
-        {conversationIdentityMeta(props.conversation, props.conversation.id)}
+        <ConversationIdentity conversation={props.conversation} />
       </div>
     </div>
+  );
+}
+
+function ConversationIdentity(props: { conversation: Conversation }) {
+  const email = props.conversation.requesterIdentity?.email?.trim();
+  const owner = conversationRequesterLabel(props.conversation);
+  const id = props.conversation.id;
+
+  if (!owner) return id;
+
+  return (
+    <>
+      {email ? (
+        <Link
+          className="font-semibold text-[#d6d6d6] underline decoration-white/20 underline-offset-2 transition-colors hover:text-white hover:decoration-white/60"
+          onClick={(event) => event.stopPropagation()}
+          onKeyDown={(event) => event.stopPropagation()}
+          to={peoplePath(email)}
+        >
+          {owner}
+        </Link>
+      ) : (
+        owner
+      )}
+      {" · "}
+      {id}
+    </>
   );
 }

--- a/packages/junior-dashboard/src/client/components/SubagentTranscriptDrawer.tsx
+++ b/packages/junior-dashboard/src/client/components/SubagentTranscriptDrawer.tsx
@@ -1,0 +1,279 @@
+import { useEffect } from "react";
+import { Bot, ExternalLink, X } from "lucide-react";
+
+import { useConversationSubagentTranscriptData } from "../api";
+import { formatMessageTimestamp, formatMs } from "../format";
+import { cn } from "../styles";
+import type {
+  ConversationSubagentTranscript,
+  ConversationTurn,
+  TranscriptViewSubagentPart,
+} from "../types";
+import { Button } from "./Button";
+import { Transcript } from "./Transcript";
+import { TranscriptLoading } from "./TranscriptLoading";
+import { transcriptEmptyClass } from "./transcriptStyles";
+
+export interface SubagentTranscriptTarget {
+  conversationId: string;
+  part: TranscriptViewSubagentPart;
+  turn: ConversationTurn;
+}
+
+/** Show a lazily loaded child-agent transcript without leaving the parent run. */
+export function SubagentTranscriptDrawer(props: {
+  onClose: () => void;
+  target: SubagentTranscriptTarget | undefined;
+}) {
+  const query = useConversationSubagentTranscriptData(
+    props.target
+      ? {
+          conversationId: props.target.conversationId,
+          runId: props.target.turn.id,
+          subagentId: props.target.part.id,
+        }
+      : undefined,
+  );
+
+  useEffect(() => {
+    if (!props.target) return undefined;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        props.onClose();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [props.onClose, props.target]);
+
+  if (!props.target) return null;
+
+  const report = query.data;
+  const visible = report ?? subagentFallback(props.target);
+  const label = visible.subagentKind;
+  const duration = subagentDuration(visible);
+  const meta = [
+    statusLabel(visible),
+    duration,
+    formatMessageTimestamp(Date.parse(visible.createdAt)),
+  ].filter(isString);
+
+  return (
+    <div className="fixed inset-0 z-50" role="dialog" aria-modal="true">
+      <button
+        aria-label="Close subagent transcript"
+        className="absolute inset-0 cursor-default bg-black/55"
+        onClick={props.onClose}
+        type="button"
+      />
+      <aside className="absolute right-0 top-0 grid h-full w-[min(760px,94vw)] grid-rows-[auto_minmax(0,1fr)] border-l border-white/12 bg-[#070707] shadow-[-20px_0_60px_rgba(0,0,0,0.45)]">
+        <header className="border-b border-white/10 bg-[#0b0b0b] px-4 py-3 md:px-5">
+          <div className="flex min-w-0 items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="flex min-w-0 items-center gap-2">
+                <Bot
+                  aria-hidden="true"
+                  className="shrink-0 text-cyan-300"
+                  size={16}
+                  strokeWidth={2.25}
+                />
+                <h2 className="m-0 min-w-0 break-words text-lg font-bold leading-tight tracking-normal text-white">
+                  {label}
+                </h2>
+              </div>
+              <DrawerConversationIdentity report={visible} />
+              {meta.length > 0 ? (
+                <div className="mt-1 break-words font-mono text-[0.78rem] leading-snug text-[#888]">
+                  {meta.join(" · ")}
+                </div>
+              ) : null}
+            </div>
+            <Button
+              aria-label="Close subagent transcript"
+              onClick={props.onClose}
+              size="icon"
+              title="Close"
+            >
+              <X aria-hidden="true" size={15} strokeWidth={2.25} />
+            </Button>
+          </div>
+        </header>
+        <div className="min-h-0 overflow-auto px-4 py-4 md:px-5">
+          {query.isPending ? (
+            <TranscriptLoading />
+          ) : query.error ? (
+            <DrawerEmptyState tone="error">
+              Transcript failed to load.
+            </DrawerEmptyState>
+          ) : report?.transcriptAvailable ? (
+            <Transcript turns={[subagentTurn(props.target, report)]} />
+          ) : (
+            <DrawerEmptyState>
+              {subagentUnavailableLabel(report)}
+            </DrawerEmptyState>
+          )}
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+function DrawerConversationIdentity(props: {
+  report: ConversationSubagentTranscript;
+}) {
+  if (
+    !props.report.subagentConversationId &&
+    !props.report.subagentSentryConversationUrl
+  ) {
+    return null;
+  }
+
+  return (
+    <div className="mt-2 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-[0.78rem] leading-snug">
+      {props.report.subagentConversationId ? (
+        <span className="inline-flex min-w-0 items-baseline gap-1.5">
+          <span className="shrink-0 text-[#777]">Conversation ID</span>
+          <code className="min-w-0 break-all font-mono text-[#d6d6d6]">
+            {props.report.subagentConversationId}
+          </code>
+        </span>
+      ) : null}
+      {props.report.subagentSentryConversationUrl ? (
+        <a
+          className="inline-flex shrink-0 items-center gap-1 font-semibold text-white no-underline hover:underline"
+          href={props.report.subagentSentryConversationUrl}
+          rel="noreferrer"
+          target="_blank"
+        >
+          View in Sentry
+          <ExternalLink aria-hidden="true" size={12} strokeWidth={2.25} />
+        </a>
+      ) : null}
+    </div>
+  );
+}
+
+function subagentFallback(
+  target: SubagentTranscriptTarget,
+): ConversationSubagentTranscript {
+  return {
+    type: "subagent",
+    createdAt: new Date(target.turn.startedAt).toISOString(),
+    id: target.part.id,
+    status: target.part.status,
+    subagentKind: target.part.subagentKind,
+    transcript: [],
+    transcriptAvailable: false,
+    ...(target.part.endedAt ? { endedAt: target.part.endedAt } : {}),
+    ...(target.part.outcome ? { outcome: target.part.outcome } : {}),
+    ...(target.part.parentToolCallId
+      ? { parentToolCallId: target.part.parentToolCallId }
+      : {}),
+  };
+}
+
+function subagentTurn(
+  target: SubagentTranscriptTarget,
+  report: ConversationSubagentTranscript,
+): ConversationTurn {
+  const status =
+    report.status === "running"
+      ? "active"
+      : report.status === "error" || report.status === "aborted"
+        ? "failed"
+        : "completed";
+
+  return {
+    conversationId: target.conversationId,
+    assistantLabel: report.subagentKind,
+    cumulativeDurationMs: subagentDurationMs(report) ?? 0,
+    displayTitle: report.subagentKind,
+    id: report.id,
+    lastProgressAt: report.endedAt ?? report.createdAt,
+    lastSeenAt: report.endedAt ?? report.createdAt,
+    startedAt: report.createdAt,
+    status,
+    surface: "internal",
+    transcript: report.transcript,
+    transcriptAvailable: report.transcriptAvailable,
+    ...(report.endedAt ? { completedAt: report.endedAt } : {}),
+    ...(report.transcriptMessageCount !== undefined
+      ? { transcriptMessageCount: report.transcriptMessageCount }
+      : {}),
+    ...(report.transcriptRedacted
+      ? { transcriptRedacted: report.transcriptRedacted }
+      : {}),
+    ...(report.transcriptRedactionReason
+      ? { transcriptRedactionReason: report.transcriptRedactionReason }
+      : {}),
+  };
+}
+
+function subagentDurationMs(
+  report: Pick<ConversationSubagentTranscript, "createdAt" | "endedAt">,
+): number | undefined {
+  if (!report.endedAt) return undefined;
+  const startedAt = Date.parse(report.createdAt);
+  const endedAt = Date.parse(report.endedAt);
+  if (!Number.isFinite(startedAt) || !Number.isFinite(endedAt)) {
+    return undefined;
+  }
+  return endedAt >= startedAt ? endedAt - startedAt : undefined;
+}
+
+function subagentDuration(
+  report: Pick<ConversationSubagentTranscript, "createdAt" | "endedAt">,
+): string | undefined {
+  const durationMs = subagentDurationMs(report);
+  return durationMs === undefined ? undefined : formatMs(durationMs);
+}
+
+function statusLabel(
+  report: ConversationSubagentTranscript,
+): string | undefined {
+  if (report.outcome === "error") return "error";
+  if (report.outcome === "aborted") return "aborted";
+  if (report.status === "error" || report.status === "aborted") {
+    return report.status;
+  }
+  return undefined;
+}
+
+function subagentUnavailableLabel(
+  report: ConversationSubagentTranscript | undefined,
+): string {
+  if (report?.transcriptRedacted) {
+    return "Transcript hidden because this conversation is not public.";
+  }
+
+  if (report?.unavailableReason === "missing_transcript_range") {
+    return "This subagent was recorded before per-invocation transcripts were available.";
+  }
+
+  if (report?.unavailableReason === "missing_transcript_ref") {
+    return "The referenced subagent transcript is no longer available.";
+  }
+
+  return "No subagent transcript is available.";
+}
+
+function DrawerEmptyState(props: {
+  children: string;
+  tone?: "error" | "muted";
+}) {
+  return (
+    <div
+      className={cn(
+        transcriptEmptyClass(),
+        props.tone === "error" && "border-rose-300/25 text-rose-100",
+      )}
+    >
+      {props.children}
+    </div>
+  );
+}
+
+function isString(value: string | undefined): value is string {
+  return typeof value === "string" && value.length > 0;
+}

--- a/packages/junior-dashboard/src/client/components/ToolValueInspector.tsx
+++ b/packages/junior-dashboard/src/client/components/ToolValueInspector.tsx
@@ -1,0 +1,372 @@
+import { useState, type ReactNode } from "react";
+
+import { stringifyPartValue } from "../format";
+import { cn } from "../styles";
+import { HighlightText, useTranscriptSearch } from "./transcriptSearch";
+
+const LONG_STRING_LENGTH = 260;
+const TABLE_KEY_LIMIT = 6;
+
+/** Render tool payloads as dense key/value rows instead of raw JSON blobs. */
+export function ToolValueInspector(props: {
+  emptyLabel?: string;
+  value: unknown;
+}) {
+  if (props.value === undefined) {
+    return <EmptyValue label={props.emptyLabel ?? "No payload"} />;
+  }
+
+  if (isRecord(props.value)) {
+    const entries = Object.entries(props.value);
+    if (entries.length === 0) {
+      return <EmptyValue label={props.emptyLabel ?? "Empty object"} />;
+    }
+    return <KeyValueRows depth={0} entries={entries} />;
+  }
+
+  return (
+    <KeyValueRows
+      depth={0}
+      entries={[[Array.isArray(props.value) ? "items" : "value", props.value]]}
+    />
+  );
+}
+
+function KeyValueRows(props: {
+  depth: number;
+  entries: Array<[string, unknown]>;
+}) {
+  return (
+    <div
+      className={cn(
+        "grid min-w-0 overflow-hidden border border-white/10",
+        props.depth === 0 ? "bg-white/[0.015]" : "bg-black/15",
+      )}
+    >
+      {props.entries.map(([key, value]) => (
+        <KeyValueRow depth={props.depth} key={key} name={key} value={value} />
+      ))}
+    </div>
+  );
+}
+
+function KeyValueRow(props: { depth: number; name: string; value: unknown }) {
+  return (
+    <div
+      className={cn(
+        "grid min-w-0 border-t border-white/8 first:border-t-0 max-sm:grid-cols-1",
+        props.depth === 0
+          ? "grid-cols-[8rem_minmax(0,1fr)]"
+          : "grid-cols-[7rem_minmax(0,1fr)]",
+      )}
+    >
+      <div
+        className={cn(
+          "min-w-0 break-words border-r border-white/8 bg-black/20 font-mono leading-snug text-[#777] max-sm:border-b max-sm:border-r-0 max-sm:pb-1",
+          props.depth === 0
+            ? "px-2 py-2 text-[0.72rem]"
+            : "px-2 py-1.5 text-[0.7rem]",
+        )}
+      >
+        <HighlightText text={props.name} />
+      </div>
+      <div
+        className={cn(
+          "min-w-0 text-[0.86rem] leading-relaxed text-[#d6d6d6] max-sm:px-2 max-sm:pt-1",
+          props.depth === 0 ? "px-3 py-2" : "px-2.5 py-1.5",
+        )}
+      >
+        <StructuredValue
+          depth={props.depth}
+          name={props.name}
+          value={props.value}
+        />
+      </div>
+    </div>
+  );
+}
+
+function StructuredValue(props: {
+  depth: number;
+  name?: string;
+  value: unknown;
+}) {
+  const value = props.value;
+
+  if (value == null) {
+    return <span className="font-mono text-[#777]">null</span>;
+  }
+
+  if (typeof value === "string") {
+    return <StringValue text={value} />;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return <span className="font-mono text-white">{String(value)}</span>;
+  }
+
+  if (Array.isArray(value)) {
+    return <ArrayValue depth={props.depth} name={props.name} value={value} />;
+  }
+
+  if (isRecord(value)) {
+    return <ObjectValue depth={props.depth} name={props.name} value={value} />;
+  }
+
+  return <StringValue text={stringifyPartValue(value)} />;
+}
+
+function StringValue(props: { text: string }) {
+  const text = props.text;
+  if (text.length === 0) {
+    return <span className="font-mono text-[#777]">empty string</span>;
+  }
+
+  const multiline = text.includes("\n");
+  if (text.length > LONG_STRING_LENGTH || multiline) {
+    const preview = multiline
+      ? firstLine(text)
+      : text.slice(0, LONG_STRING_LENGTH).trimEnd();
+    return (
+      <details className="min-w-0">
+        <summary className="cursor-pointer list-none break-words font-mono text-white transition-colors hover:text-[#d8ccff] [&::-webkit-details-marker]:hidden">
+          <HighlightText
+            text={`${preview}${preview.length < text.length ? "..." : ""}`}
+          />
+        </summary>
+        <pre className="mt-2 max-h-72 min-w-0 overflow-auto whitespace-pre-wrap break-words border-l border-white/12 pl-3 font-mono text-[0.82rem] leading-relaxed text-white">
+          <HighlightText text={text} />
+        </pre>
+      </details>
+    );
+  }
+
+  return (
+    <span className="break-words font-mono text-white">
+      <HighlightText text={text} />
+    </span>
+  );
+}
+
+function ArrayValue(props: { depth: number; name?: string; value: unknown[] }) {
+  const value = props.value;
+  if (value.length === 0) {
+    return <span className="font-mono text-[#777]">empty array</span>;
+  }
+
+  if (canRenderPrimitiveChips(value)) {
+    return (
+      <div className="flex min-w-0 flex-wrap gap-1.5">
+        {value.map((item, index) => (
+          <span
+            className="max-w-full break-words border border-white/10 bg-black/20 px-1.5 py-0.5 font-mono text-[0.78rem] text-white"
+            key={index}
+          >
+            <HighlightText text={String(item)} />
+          </span>
+        ))}
+      </div>
+    );
+  }
+
+  if (canRenderObjectTable(value)) {
+    return <ObjectTable rows={value as Record<string, unknown>[]} />;
+  }
+
+  return (
+    <NestedDetails
+      count={`${value.length} item${value.length === 1 ? "" : "s"}`}
+      depth={props.depth}
+      label={props.name ?? "array"}
+    >
+      <div className="grid min-w-0">
+        {value.map((item, index) => (
+          <KeyValueRow
+            depth={props.depth + 1}
+            key={index}
+            name={String(index)}
+            value={item}
+          />
+        ))}
+      </div>
+    </NestedDetails>
+  );
+}
+
+function ObjectValue(props: {
+  depth: number;
+  name?: string;
+  value: Record<string, unknown>;
+}) {
+  const entries = Object.entries(props.value);
+  if (entries.length === 0) {
+    return <span className="font-mono text-[#777]">empty object</span>;
+  }
+
+  return (
+    <NestedDetails
+      count={`${entries.length} key${entries.length === 1 ? "" : "s"}`}
+      depth={props.depth}
+      label={props.depth === 0 ? undefined : (props.name ?? "object")}
+    >
+      <KeyValueRows depth={props.depth + 1} entries={entries} />
+    </NestedDetails>
+  );
+}
+
+function NestedDetails(props: {
+  children: ReactNode;
+  count: string;
+  depth: number;
+  label?: string;
+}) {
+  const search = useTranscriptSearch();
+  const [open, setOpen] = useState(search.active || props.depth === 0);
+
+  return (
+    <details
+      className="min-w-0"
+      onToggle={(event) => {
+        if (event.currentTarget !== event.target) return;
+        setOpen(event.currentTarget.open);
+      }}
+      open={search.active || open}
+    >
+      <summary className="flex cursor-pointer list-none flex-wrap items-center gap-2 font-mono text-[0.8rem] text-[#b8b8b8] transition-colors hover:text-white [&::-webkit-details-marker]:hidden">
+        <span className="border border-white/10 bg-black/20 px-1.5 py-0.5 text-[#d6d6d6]">
+          <HighlightText text={props.count} />
+        </span>
+        {props.label ? (
+          <span className="text-[#777]">
+            <HighlightText text={props.label} />
+          </span>
+        ) : null}
+      </summary>
+      <div
+        className={cn(
+          "mt-2 min-w-0",
+          props.depth > 0 && "ml-1 border-l border-[#beaaff]/18 pl-3",
+        )}
+      >
+        {props.children}
+      </div>
+    </details>
+  );
+}
+
+function ObjectTable(props: { rows: Array<Record<string, unknown>> }) {
+  const keys = tableKeys(props.rows);
+
+  return (
+    <div className="min-w-0 overflow-auto border border-white/10 bg-black/20">
+      <table className="w-full min-w-[32rem] border-collapse text-left font-mono text-[0.78rem] leading-snug">
+        <thead className="bg-[#121118] text-[#9a8fd0]">
+          <tr>
+            {keys.map((key) => (
+              <th
+                className="border-b border-white/10 px-2 py-1.5 font-bold"
+                key={key}
+              >
+                <HighlightText text={key} />
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-white/8">
+          {props.rows.map((row, rowIndex) => (
+            <tr key={rowIndex}>
+              {keys.map((key) => (
+                <td
+                  className="max-w-[18rem] px-2 py-1.5 align-top text-[#d6d6d6]"
+                  key={key}
+                >
+                  <CompactValue value={row[key]} />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function CompactValue(props: { value: unknown }) {
+  const value = props.value;
+  if (value == null) return <span className="text-[#777]">null</span>;
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return (
+      <span className="break-words text-white">
+        <HighlightText text={truncate(String(value), 96)} />
+      </span>
+    );
+  }
+  return (
+    <span className="break-words text-[#b8b8b8]">
+      <HighlightText
+        text={truncate(stringifyPartValue(value).replace(/\s+/g, " "), 96)}
+      />
+    </span>
+  );
+}
+
+function EmptyValue(props: { label: string }) {
+  return (
+    <div className="border-y border-white/8 py-2 font-mono text-[0.82rem] text-[#777]">
+      {props.label}
+    </div>
+  );
+}
+
+function canRenderPrimitiveChips(value: unknown[]): boolean {
+  return (
+    value.length <= 12 &&
+    value.every(
+      (item) =>
+        item == null ||
+        typeof item === "string" ||
+        typeof item === "number" ||
+        typeof item === "boolean",
+    )
+  );
+}
+
+function canRenderObjectTable(value: unknown[]): boolean {
+  return (
+    value.length > 0 &&
+    value.length <= 25 &&
+    value.every((item) => isRecord(item)) &&
+    tableKeys(value as Record<string, unknown>[]).length > 0
+  );
+}
+
+function tableKeys(rows: Array<Record<string, unknown>>): string[] {
+  const keys: string[] = [];
+  for (const row of rows) {
+    for (const key of Object.keys(row)) {
+      if (!keys.includes(key)) keys.push(key);
+      if (keys.length >= TABLE_KEY_LIMIT) return keys;
+    }
+  }
+  return keys;
+}
+
+function firstLine(text: string): string {
+  return (
+    text.split(/\r?\n/, 1)[0]?.slice(0, LONG_STRING_LENGTH).trimEnd() ?? ""
+  );
+}
+
+function truncate(text: string, maxLength: number): string {
+  return text.length > maxLength
+    ? `${text.slice(0, Math.max(0, maxLength - 3))}...`
+    : text;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/junior-dashboard/src/client/components/Transcript.tsx
+++ b/packages/junior-dashboard/src/client/components/Transcript.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState, type ReactNode } from "react";
 import { ArrowDownToLine, Search } from "lucide-react";
 
-import type { ConversationTurn } from "../types";
+import type { ConversationTurn, TranscriptViewSubagentPart } from "../types";
 import { cn } from "../styles";
 import { Button } from "./Button";
 import { TranscriptHeader } from "./TranscriptHeader";
@@ -12,15 +12,16 @@ import {
 } from "./transcriptBottomPinning";
 import type { TranscriptViewMode } from "./transcriptRenderModel";
 import { transcriptEmptyClass } from "./transcriptStyles";
-import {
-  TranscriptSearchProvider,
-  turnHasMatch,
-} from "./transcriptSearch";
+import { TranscriptSearchProvider, turnHasMatch } from "./transcriptSearch";
 
 /** Render ordered conversation transcript segments as message and tool events. */
 export function Transcript(props: {
   actions?: ReactNode;
   live?: boolean;
+  onOpenSubagentTranscript?: (args: {
+    part: TranscriptViewSubagentPart;
+    turn: ConversationTurn;
+  }) => void;
   turns: ConversationTurn[];
 }) {
   const [view, setView] = useState<TranscriptViewMode>("rich");
@@ -81,6 +82,7 @@ export function Transcript(props: {
           visibleTurns.map((turn) => (
             <ConversationTranscriptSegment
               key={turn.id}
+              onOpenSubagentTranscript={props.onOpenSubagentTranscript}
               turn={turn}
               view={view}
             />
@@ -90,7 +92,11 @@ export function Transcript(props: {
             No events match your search.
           </div>
         ) : null}
-        <div aria-hidden="true" className="h-px" ref={bottomPinning.anchorRef} />
+        <div
+          aria-hidden="true"
+          className="h-px"
+          ref={bottomPinning.anchorRef}
+        />
         <JumpToLatestButton
           hasPendingUpdate={bottomPinning.hasPendingUpdate}
           onClick={bottomPinning.jumpToBottom}

--- a/packages/junior-dashboard/src/client/components/TranscriptHeader.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptHeader.tsx
@@ -11,7 +11,7 @@ export function TranscriptHeader(props: {
   value: TranscriptViewMode;
 }) {
   return (
-    <div className="mb-1 flex min-w-0 items-start justify-between gap-3 border-b border-[#beaaff]/20 pb-3 leading-none max-md:flex-col max-md:items-start">
+    <div className="mb-1 flex min-w-0 items-start justify-between gap-3 border-b border-[#beaaff]/20 pb-2 leading-none max-md:flex-col max-md:items-start">
       {props.redacted ? (
         <div className="min-w-0 break-words text-[0.88rem] leading-relaxed text-[#b8b8b8]">
           Hidden because this conversation is not public.

--- a/packages/junior-dashboard/src/client/components/TranscriptSubagentView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptSubagentView.tsx
@@ -7,10 +7,11 @@ import { HighlightText } from "./transcriptSearch";
 
 /** Render a child-agent lifecycle event inside the transcript stream. */
 export function TranscriptSubagentView(props: {
+  onOpenTranscript?: (part: TranscriptViewSubagentPart) => void;
   part: TranscriptViewSubagentPart;
   timestamp?: number;
 }) {
-  const label = `${props.part.subagentKind} subagent`;
+  const label = props.part.subagentKind;
   const endedAt = props.part.endedAt
     ? Date.parse(props.part.endedAt)
     : undefined;
@@ -25,15 +26,12 @@ export function TranscriptSubagentView(props: {
   const meta = [
     status,
     duration,
-    props.part.parentToolCallId
-      ? `parent ${props.part.parentToolCallId}`
-      : undefined,
     typeof props.timestamp === "number"
       ? formatMessageTimestamp(props.timestamp)
       : undefined,
   ].filter(isString);
 
-  return (
+  const frame = (
     <ToolFrame
       meta={meta}
       mobileSummaryMeta={status}
@@ -49,17 +47,40 @@ export function TranscriptSubagentView(props: {
           <strong className="min-w-0 break-words font-bold text-cyan-100">
             <HighlightText text={label} />
           </strong>
+          {props.part.status === "running" ? (
+            <span
+              aria-hidden="true"
+              className="mt-px size-1.5 shrink-0 animate-pulse rounded-full bg-cyan-300"
+            />
+          ) : null}
         </>
       }
     />
   );
+
+  if (!props.onOpenTranscript || props.part.status === "running") {
+    return frame;
+  }
+
+  return (
+    <button
+      aria-label={`Open ${props.part.subagentKind} transcript`}
+      className="block w-full min-w-0 text-left transition-colors hover:bg-white/[0.035] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[#beaaff]/55"
+      onClick={() => props.onOpenTranscript?.(props.part)}
+      type="button"
+    >
+      {frame}
+    </button>
+  );
 }
 
 function statusLabel(part: TranscriptViewSubagentPart): string | undefined {
-  if (part.outcome === "success") return "completed";
   if (part.outcome === "error") return "error";
   if (part.outcome === "aborted") return "aborted";
-  return part.status === "running" ? "running" : part.status;
+  if (part.status === "error" || part.status === "aborted") {
+    return part.status;
+  }
+  return undefined;
 }
 
 function isString(value: string | undefined): value is string {

--- a/packages/junior-dashboard/src/client/components/TranscriptToolRun.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptToolRun.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState, type ReactNode } from "react";
+import { Fragment, type ReactNode } from "react";
 
 import type { RenderedToolEntry } from "./transcriptRenderModel";
 import { useTranscriptSearch } from "./transcriptSearch";
@@ -12,10 +12,9 @@ export function TranscriptToolRun(props: {
   renderTool: (entry: RenderedToolEntry, index: number) => ReactNode;
   startIndex: number;
 }) {
-  const [revealed, setRevealed] = useState(false);
   const { active: searchActive } = useTranscriptSearch();
 
-  if (props.entries.length < TOOL_RUN_REVEAL_THRESHOLD || revealed || searchActive) {
+  if (props.entries.length < TOOL_RUN_REVEAL_THRESHOLD || searchActive) {
     return (
       <>
         {renderToolEntries(
@@ -29,10 +28,17 @@ export function TranscriptToolRun(props: {
   }
 
   return (
-    <ToolRunReveal
-      hiddenCount={props.entries.length}
-      onClick={() => setRevealed(true)}
-    />
+    <details className="min-w-0">
+      <ToolRunReveal hiddenCount={props.entries.length} />
+      <div className="mt-2 grid min-w-0 grid-cols-[minmax(0,1fr)] gap-2">
+        {renderToolEntries(
+          props.entries,
+          props.startIndex,
+          props.keyPrefix,
+          props.renderTool,
+        )}
+      </div>
+    </details>
   );
 }
 
@@ -52,17 +58,12 @@ function renderToolEntries(
   });
 }
 
-function ToolRunReveal(props: { hiddenCount: number; onClick: () => void }) {
+function ToolRunReveal(props: { hiddenCount: number }) {
   return (
-    <button
-      aria-expanded={false}
-      className="group flex w-full cursor-pointer items-center gap-2 py-1.5 text-left font-mono text-[0.78rem] leading-tight text-[#888] transition-colors hover:text-[#d6d6d6] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[#beaaff]/55"
-      onClick={props.onClick}
-      type="button"
-    >
+    <summary className="group flex w-full cursor-pointer list-none items-center gap-2 py-1.5 text-left font-mono text-[0.78rem] leading-tight text-[#888] transition-colors hover:text-[#d6d6d6] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[#beaaff]/55 [&::-webkit-details-marker]:hidden">
       <span className="h-px min-w-4 flex-1 bg-white/10 transition-colors group-hover:bg-white/20" />
       <span className="shrink-0">show {props.hiddenCount} tool calls</span>
       <span className="h-px min-w-4 flex-1 bg-white/10 transition-colors group-hover:bg-white/20" />
-    </button>
+    </summary>
   );
 }

--- a/packages/junior-dashboard/src/client/components/TranscriptToolView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptToolView.tsx
@@ -10,6 +10,7 @@ import {
 import { cn } from "../styles";
 import type { TranscriptViewPart } from "../types";
 import { ToolFrame } from "./ToolFrame";
+import { ToolValueInspector } from "./ToolValueInspector";
 import { isPreviewableValue } from "./transcriptPreview";
 import { HighlightText } from "./transcriptSearch";
 
@@ -27,8 +28,8 @@ export function TranscriptToolView(props: {
     props.call?.id ??
     props.result?.id ??
     "unknown";
-  const input = props.call?.input;
-  const output = props.result?.output;
+  const input = toolInputPayload(props.call);
+  const output = toolOutputPayload(props.result);
   const outputBytes = props.result
     ? new TextEncoder().encode(stringifyPartValue(output)).length
     : undefined;
@@ -98,22 +99,57 @@ export function TranscriptToolView(props: {
     >
       {props.call ? (
         <ToolBodySection label="arguments">
-          <HighlightedCode
-            code={stringifyPartValue(input) || "{}"}
-            language="json"
-          />
+          <ToolValueInspector emptyLabel="No arguments" value={input} />
         </ToolBodySection>
       ) : null}
       {props.result ? (
         <ToolBodySection label="result">
-          <HighlightedCode
-            code={stringifyPartValue(output) || "{}"}
-            language="json"
-          />
+          <ToolValueInspector emptyLabel="No result payload" value={output} />
         </ToolBodySection>
       ) : null}
     </ToolFrame>
   );
+}
+
+function toolInputPayload(part: TranscriptViewPart | undefined): unknown {
+  if (!part) return undefined;
+  if (part.redacted) {
+    return redactedPayload("input", part);
+  }
+  return part.input;
+}
+
+function toolOutputPayload(part: TranscriptViewPart | undefined): unknown {
+  if (!part) return undefined;
+  if (part.redacted) {
+    return redactedPayload("output", part);
+  }
+  return part.output;
+}
+
+function redactedPayload(
+  kind: "input" | "output",
+  part: TranscriptViewPart,
+): Record<string, unknown> {
+  return {
+    redacted: true,
+    ...(kind === "input" && part.inputKeys ? { keys: part.inputKeys } : {}),
+    ...(kind === "output" && part.outputKeys ? { keys: part.outputKeys } : {}),
+    ...(kind === "input" && part.inputType ? { type: part.inputType } : {}),
+    ...(kind === "output" && part.outputType ? { type: part.outputType } : {}),
+    ...(kind === "input" && part.inputSizeBytes !== undefined
+      ? { sizeBytes: part.inputSizeBytes }
+      : {}),
+    ...(kind === "output" && part.outputSizeBytes !== undefined
+      ? { sizeBytes: part.outputSizeBytes }
+      : {}),
+    ...(kind === "input" && part.inputSizeChars !== undefined
+      ? { sizeChars: part.inputSizeChars }
+      : {}),
+    ...(kind === "output" && part.outputSizeChars !== undefined
+      ? { sizeChars: part.outputSizeChars }
+      : {}),
+  };
 }
 
 function ToolBodySection(props: {
@@ -129,7 +165,7 @@ function ToolBodySection(props: {
       )}
     >
       {props.label ? (
-        <div className="pb-2 font-mono text-[0.78rem] leading-none text-[#888]">
+        <div className="pb-2 font-mono text-[0.68rem] font-bold uppercase leading-none text-[#9a8fd0]">
           {props.label}
         </div>
       ) : null}

--- a/packages/junior-dashboard/src/client/components/TranscriptTurn.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptTurn.tsx
@@ -28,6 +28,7 @@ import type {
   ConversationTurn,
   TranscriptViewMessage,
   TranscriptViewPart,
+  TranscriptViewSubagentPart,
 } from "../types";
 import { StatusBadge } from "./StatusBadge";
 import { ToolFrame, toolFrameClass } from "./ToolFrame";
@@ -72,6 +73,10 @@ type TranscriptToolEntry = Extract<TranscriptEntry, { kind: "tool" }>;
 
 /** Render one conversation transcript segment as actor messages and tool events. */
 export function ConversationTranscriptSegment(props: {
+  onOpenSubagentTranscript?: (args: {
+    part: TranscriptViewSubagentPart;
+    turn: ConversationTurn;
+  }) => void;
   turn: ConversationTurn;
   view: TranscriptViewMode;
 }) {
@@ -85,7 +90,11 @@ export function ConversationTranscriptSegment(props: {
       </div>
       <div className="min-w-0">
         <SegmentHeader turn={props.turn} />
-        <SegmentEvents turn={props.turn} view={props.view} />
+        <SegmentEvents
+          onOpenSubagentTranscript={props.onOpenSubagentTranscript}
+          turn={props.turn}
+          view={props.view}
+        />
       </div>
     </section>
   );
@@ -105,7 +114,7 @@ function turnMarkerClass(
 
 function transcriptRoleLabel(role: string, turn: ConversationTurn): string {
   const kind = transcriptRoleKind(role);
-  if (kind === "assistant") return "Junior";
+  if (kind === "assistant") return turn.assistantLabel ?? "Junior";
   if (kind === "user") return turnActorLabel(turn);
   if (kind === "system") return "System";
   if (kind === "tool") return "Tool";
@@ -211,6 +220,10 @@ function SegmentHeader(props: { turn: ConversationTurn }) {
 }
 
 function SegmentEvents(props: {
+  onOpenSubagentTranscript?: (args: {
+    part: TranscriptViewSubagentPart;
+    turn: ConversationTurn;
+  }) => void;
   turn: ConversationTurn;
   view: TranscriptViewMode;
 }) {
@@ -220,14 +233,19 @@ function SegmentEvents(props: {
     <div className="grid min-w-0 grid-cols-[minmax(0,1fr)] gap-2 pt-3">
       {props.turn.transcriptAvailable ? (
         <VisibleTranscriptEntries
+          onOpenSubagentTranscript={props.onOpenSubagentTranscript}
           transcript={transcript}
           turn={props.turn}
           view={props.view}
         />
       ) : props.turn.transcriptRedacted && transcript.length > 0 ? (
-        <RedactedTranscriptView turn={props.turn} />
+        <RedactedTranscriptView
+          onOpenSubagentTranscript={props.onOpenSubagentTranscript}
+          turn={props.turn}
+        />
       ) : transcript.length > 0 ? (
         <VisibleTranscriptEntries
+          onOpenSubagentTranscript={props.onOpenSubagentTranscript}
           transcript={transcript}
           turn={props.turn}
           view={props.view}
@@ -242,6 +260,10 @@ function SegmentEvents(props: {
 }
 
 function VisibleTranscriptEntries(props: {
+  onOpenSubagentTranscript?: (args: {
+    part: TranscriptViewSubagentPart;
+    turn: ConversationTurn;
+  }) => void;
   transcript: TranscriptViewMessage[];
   turn: ConversationTurn;
   view: TranscriptViewMode;
@@ -261,6 +283,9 @@ function VisibleTranscriptEntries(props: {
       renderSubagent={(entry, index) => (
         <TranscriptSubagentView
           key={`${props.turn.id}:subagent:${index}`}
+          onOpenTranscript={(part) =>
+            props.onOpenSubagentTranscript?.({ part, turn: props.turn })
+          }
           part={entry.part}
           timestamp={entry.timestamp}
         />
@@ -351,7 +376,13 @@ function TranscriptEntryList(props: {
   return <>{rows}</>;
 }
 
-function RedactedTranscriptView(props: { turn: ConversationTurn }) {
+function RedactedTranscriptView(props: {
+  onOpenSubagentTranscript?: (args: {
+    part: TranscriptViewSubagentPart;
+    turn: ConversationTurn;
+  }) => void;
+  turn: ConversationTurn;
+}) {
   return (
     <TranscriptEntryList
       entries={groupTranscriptMessages(turnTranscriptMessages(props.turn))}
@@ -366,6 +397,9 @@ function RedactedTranscriptView(props: { turn: ConversationTurn }) {
       renderSubagent={(entry, index) => (
         <TranscriptSubagentView
           key={`${props.turn.id}:redacted:subagent:${index}`}
+          onOpenTranscript={(part) =>
+            props.onOpenSubagentTranscript?.({ part, turn: props.turn })
+          }
           part={entry.part}
           timestamp={entry.timestamp}
         />

--- a/packages/junior-dashboard/src/client/format.ts
+++ b/packages/junior-dashboard/src/client/format.ts
@@ -589,6 +589,16 @@ export function conversationRequesterLabel(
   return requesterLabel(conversation?.requesterIdentity);
 }
 
+/** Return the stable requester key used by dashboard list filters. */
+export function conversationRequesterKey(
+  conversation: Conversation | undefined,
+): string | undefined {
+  return (
+    conversation?.requesterIdentity?.email?.trim() ||
+    conversationRequesterLabel(conversation)
+  );
+}
+
 /** Format the owner and permalink id line shared by conversation rows and headers. */
 export function conversationIdentityMeta(
   conversation: Conversation | undefined,
@@ -665,6 +675,11 @@ export function unavailableTranscriptLabel(turn: ConversationTurn): string {
 /** Build the canonical permalink route for a conversation id. */
 export function conversationPath(conversationId: string): string {
   return `/conversations/${encodeURIComponent(conversationId)}`;
+}
+
+/** Build the canonical requester profile route for a trusted email address. */
+export function peoplePath(email: string): string {
+  return `/people/${encodeURIComponent(email)}`;
 }
 
 function normalizeLanguage(language: string | undefined): BundledLanguage {
@@ -994,6 +1009,99 @@ export function filterConversations(
   if (filter === "hung") return conversations.filter(isHungConversation);
   if (filter === "failed") return conversations.filter(isFailedConversation);
   return conversations;
+}
+
+export type ConversationListFilters = {
+  query?: string;
+  requester?: string;
+  source?: string;
+};
+
+export type ConversationListFilterOption = {
+  label: string;
+  value: string;
+};
+
+function uniqueConversationOptions(
+  conversations: Conversation[],
+  valueForConversation: (conversation: Conversation) => string | undefined,
+  labelForConversation: (conversation: Conversation, value: string) => string,
+): ConversationListFilterOption[] {
+  const options = new Map<string, string>();
+  for (const conversation of conversations) {
+    const value = valueForConversation(conversation)?.trim();
+    if (!value || options.has(value)) continue;
+    options.set(value, labelForConversation(conversation, value));
+  }
+  return [...options.entries()]
+    .map(([value, label]) => ({ label, value }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+function conversationSearchHaystack(conversation: Conversation): string {
+  const requester = conversation.requesterIdentity;
+  return [
+    conversation.displayTitle,
+    conversation.id,
+    conversation.channel,
+    conversation.channelName,
+    conversation.status,
+    conversation.surface,
+    requester?.email,
+    requester?.fullName,
+    requester?.slackUserId,
+    requester?.slackUserName,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+/** Return source filter options present in the loaded conversation rows. */
+export function conversationSourceOptions(
+  conversations: Conversation[],
+): ConversationListFilterOption[] {
+  return uniqueConversationOptions(
+    conversations,
+    (conversation) => conversation.surface,
+    (_conversation, value) => value,
+  );
+}
+
+/** Return requester filter options present in the loaded conversation rows. */
+export function conversationRequesterOptions(
+  conversations: Conversation[],
+): ConversationListFilterOption[] {
+  return uniqueConversationOptions(
+    conversations,
+    conversationRequesterKey,
+    (conversation, value) =>
+      conversation.requesterIdentity?.fullName?.trim() ||
+      conversation.requesterIdentity?.email?.trim() ||
+      conversation.requesterIdentity?.slackUserName?.trim() ||
+      value,
+  );
+}
+
+/** Apply lightweight client-side search and facet filters to conversations. */
+export function filterConversationList(
+  conversations: Conversation[],
+  filters: ConversationListFilters,
+): Conversation[] {
+  const query = filters.query?.trim().toLowerCase();
+  const source = filters.source?.trim();
+  const requester = filters.requester?.trim();
+
+  return conversations.filter((conversation) => {
+    if (source && conversation.surface !== source) return false;
+    if (requester && conversationRequesterKey(conversation) !== requester) {
+      return false;
+    }
+    if (query && !conversationSearchHaystack(conversation).includes(query)) {
+      return false;
+    }
+    return true;
+  });
 }
 
 /** Normalize URL filter params to the supported dashboard filter set. */

--- a/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Check, Copy } from "lucide-react";
-import { useParams } from "react-router";
+import { Link, useParams } from "react-router";
 
 import { useConversationData } from "../api";
 import { buildConversationMarkdown } from "../markdownExport";
@@ -8,12 +8,13 @@ import { Button } from "../components/Button";
 import { StatusBadge } from "../components/StatusBadge";
 import {
   buildConversations,
-  conversationIdentityMeta,
   conversationDisplayTitle,
   conversationFromDetail,
+  conversationRequesterLabel,
   formatConversationDuration,
   formatRelativeTime,
   formatTime,
+  peoplePath,
   slackLocationLabel,
   summarizeMessages,
   summarizeToolCalls,
@@ -176,9 +177,28 @@ function ConversationIdentity(props: {
   conversationId: string | undefined;
   detail: ConversationDetailFeed | undefined;
 }) {
+  const email = props.conversation?.requesterIdentity?.email?.trim();
+  const owner = conversationRequesterLabel(props.conversation);
+  const id = props.conversationId ?? props.conversation?.id;
+
   return (
     <>
-      {conversationIdentityMeta(props.conversation, props.conversationId)}
+      {owner ? (
+        <>
+          {email ? (
+            <Link
+              className="font-semibold text-[#d6d6d6] underline decoration-white/20 underline-offset-2 transition-colors hover:text-white hover:decoration-white/60"
+              to={peoplePath(email)}
+            >
+              {owner}
+            </Link>
+          ) : (
+            owner
+          )}
+          {id ? <>{" · "}</> : null}
+        </>
+      ) : null}
+      {id ?? null}
       {props.detail?.sentryConversationUrl ? (
         <>
           {" · "}

--- a/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
@@ -29,6 +29,10 @@ import {
 } from "../components/TelemetryMetrics";
 import { Transcript } from "../components/Transcript";
 import { TranscriptLoading } from "../components/TranscriptLoading";
+import {
+  SubagentTranscriptDrawer,
+  type SubagentTranscriptTarget,
+} from "../components/SubagentTranscriptDrawer";
 import type {
   Conversation,
   ConversationDetailFeed,
@@ -37,6 +41,8 @@ import type {
 
 /** Render one permalinkable conversation transcript route. */
 export function ConversationPage(props: { data?: DashboardData }) {
+  const [subagentTarget, setSubagentTarget] =
+    useState<SubagentTranscriptTarget>();
   const routeParams = useParams();
   const conversationId = routeParams.conversationId
     ? decodeURIComponent(routeParams.conversationId)
@@ -53,9 +59,9 @@ export function ConversationPage(props: { data?: DashboardData }) {
     : undefined;
 
   return (
-    <div className="mx-auto w-full min-w-0 max-w-screen-xl px-4 py-5 md:px-8">
+    <div className="mx-auto w-full min-w-0 max-w-screen-xl px-4 py-4 md:px-8">
       <section className="min-w-0">
-        <header className="mb-6 grid gap-3 border-l-4 border-[#beaaff]/70 pl-4 md:grid-cols-[minmax(0,1fr)_auto]">
+        <header className="mb-3 grid gap-2 border-l-4 border-[#beaaff]/70 pl-4 md:grid-cols-[minmax(0,1fr)_auto]">
           <div className="min-w-0">
             <div className="flex min-w-0 flex-wrap items-center gap-2">
               <h2 className="m-0 text-2xl font-bold leading-tight tracking-normal">
@@ -63,7 +69,7 @@ export function ConversationPage(props: { data?: DashboardData }) {
               </h2>
               <StatusBadge status={visualStatus} />
             </div>
-            <div className="mt-1 break-words text-[0.88rem] leading-relaxed text-[#b8b8b8]">
+            <div className="mt-1 break-words text-[0.86rem] leading-snug text-[#b8b8b8]">
               <ConversationIdentity
                 conversation={conversation}
                 conversationId={conversationId}
@@ -71,7 +77,7 @@ export function ConversationPage(props: { data?: DashboardData }) {
               />
             </div>
           </div>
-          <div className="flex min-w-0 flex-col items-start gap-2 self-start text-[0.82rem] leading-relaxed text-[#b8b8b8] md:items-end md:text-right">
+          <div className="flex min-w-0 flex-col items-start gap-2 self-start text-[0.8rem] leading-snug text-[#b8b8b8] md:items-end md:text-right">
             <div className="break-words">
               updated{" "}
               {formatRelativeTime(
@@ -97,10 +103,18 @@ export function ConversationPage(props: { data?: DashboardData }) {
               />
             }
             live={conversationIsLive(visualStatus, detail.data)}
+            onOpenSubagentTranscript={({ part, turn }) => {
+              if (!conversationId) return;
+              setSubagentTarget({ conversationId, part, turn });
+            }}
             turns={detail.data?.runs ?? []}
           />
         )}
       </section>
+      <SubagentTranscriptDrawer
+        onClose={() => setSubagentTarget(undefined)}
+        target={subagentTarget}
+      />
     </div>
   );
 }

--- a/packages/junior-dashboard/src/client/pages/ConversationsPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/ConversationsPage.tsx
@@ -1,5 +1,6 @@
 import { useSearchParams } from "react-router";
 
+import { ConversationListToolbar } from "../components/ConversationListControls";
 import { ConversationList } from "../components/ConversationList";
 import { FilterTabs } from "../components/FilterTabs";
 import { Section } from "../components/Section";
@@ -7,6 +8,9 @@ import { SectionHeader } from "../components/SectionHeader";
 import { SectionTitle } from "../components/SectionTitle";
 import {
   buildConversations,
+  conversationRequesterOptions,
+  conversationSourceOptions,
+  filterConversationList,
   filterConversations,
   formatTime,
   getFilter,
@@ -17,18 +21,47 @@ import type { ConversationFilter, DashboardData } from "../types";
 export function ConversationsPage(props: { data?: DashboardData }) {
   const [params, setParams] = useSearchParams();
   const filter = getFilter(params.get("filter"));
+  const query = params.get("q") ?? "";
+  const requester = params.get("requester") ?? "";
+  const source = params.get("source") ?? "";
   const summaries = props.data?.conversations.conversations ?? [];
   const conversations = buildConversations(summaries);
-  const visibleConversations = filterConversations(conversations, filter);
+  const sourceOptions = conversationSourceOptions(conversations);
+  const requesterOptions = conversationRequesterOptions(conversations);
+  const statusConversations = filterConversations(conversations, filter);
+  const visibleConversations = filterConversationList(statusConversations, {
+    query,
+    requester,
+    source,
+  });
   const search = params.toString();
   const feedMeta = props.data?.conversations
-    ? `${conversations.length} conversations / ${formatTime(props.data.conversations.generatedAt)}`
+    ? `${visibleConversations.length} of ${conversations.length} conversations / ${formatTime(props.data.conversations.generatedAt)}`
     : "waiting for conversation feed";
 
   function updateFilter(nextFilter: ConversationFilter) {
     const next = new URLSearchParams(params);
     next.set("filter", nextFilter);
     setParams(next);
+  }
+
+  function updateParam(name: "q" | "requester" | "source", value: string) {
+    const next = new URLSearchParams(params);
+    const nextValue = name === "q" ? value : value.trim();
+    if (nextValue.trim()) {
+      next.set(name, nextValue);
+    } else {
+      next.delete(name);
+    }
+    setParams(next, { replace: true });
+  }
+
+  function clearListFilters() {
+    const next = new URLSearchParams(params);
+    next.delete("q");
+    next.delete("requester");
+    next.delete("source");
+    setParams(next, { replace: true });
   }
 
   return (
@@ -45,9 +78,21 @@ export function ConversationsPage(props: { data?: DashboardData }) {
               </div>
             </div>
           </SectionHeader>
+          <ConversationListToolbar
+            query={query}
+            requester={requester}
+            requesterOptions={requesterOptions}
+            source={source}
+            sourceOptions={sourceOptions}
+            onQueryChange={(value) => updateParam("q", value)}
+            onRequesterChange={(value) => updateParam("requester", value)}
+            onSourceChange={(value) => updateParam("source", value)}
+            onClear={clearListFilters}
+          />
           <div>
             <ConversationList
               conversations={visibleConversations}
+              emptyLabel="No conversations match these filters."
               search={search ? `?${search}` : ""}
             />
           </div>

--- a/packages/junior-dashboard/src/client/pages/PeoplePage.tsx
+++ b/packages/junior-dashboard/src/client/pages/PeoplePage.tsx
@@ -398,8 +398,16 @@ function ProfileMetrics(props: { totals: RequesterTotals }) {
 function ContributionGrid(props: { days: RequesterActivityDay[] }) {
   const max = Math.max(1, ...props.days.map((day) => day.conversations));
   const weeks: Array<Array<RequesterActivityDay | null>> = [];
-  for (let index = 0; index < props.days.length; index += 7) {
-    const week: Array<RequesterActivityDay | null> = props.days.slice(
+  const leadingDays = props.days[0]
+    ? new Date(`${props.days[0].date}T00:00:00Z`).getUTCDay()
+    : 0;
+  const cells: Array<RequesterActivityDay | null> = [
+    ...Array.from({ length: leadingDays }, () => null),
+    ...props.days,
+  ];
+  while (cells.length > 0 && cells.length % 7 !== 0) cells.push(null);
+  for (let index = 0; index < cells.length; index += 7) {
+    const week: Array<RequesterActivityDay | null> = cells.slice(
       index,
       index + 7,
     );

--- a/packages/junior-dashboard/src/client/pages/PeoplePage.tsx
+++ b/packages/junior-dashboard/src/client/pages/PeoplePage.tsx
@@ -1,0 +1,542 @@
+import { useState } from "react";
+import { Link, useParams } from "react-router";
+import { Mail, UserRound } from "lucide-react";
+
+import { useRequesterDirectoryData, useRequesterProfileData } from "../api";
+import { Button } from "../components/Button";
+import { ConversationList } from "../components/ConversationList";
+import { ConversationSearchInput } from "../components/ConversationListControls";
+import { EmptyTelemetry } from "../components/EmptyTelemetry";
+import { LoadingView } from "../components/LoadingView";
+import { Section } from "../components/Section";
+import { SectionHeader } from "../components/SectionHeader";
+import { SectionTitle } from "../components/SectionTitle";
+import {
+  buildConversations,
+  filterConversationList,
+  formatCompactNumber,
+  formatMs,
+  peoplePath,
+  formatRelativeTime,
+  formatTime,
+} from "../format";
+import { cn } from "../styles";
+import type {
+  ConversationStatsItem,
+  RequesterActivityDay,
+  RequesterDirectory,
+  RequesterProfile,
+  RequesterSummary,
+  RequesterTotals,
+} from "../types";
+
+type PeopleSort = "activeDays" | "conversations" | "recent" | "runtime";
+
+function requesterName(person: Pick<RequesterSummary, "requester">): string {
+  return (
+    person.requester.fullName ??
+    person.requester.slackUserName ??
+    person.requester.email
+  );
+}
+
+function personMeta(person: RequesterSummary): string {
+  const pieces = [
+    person.requester.email,
+    person.requester.slackUserName
+      ? `@${person.requester.slackUserName}`
+      : undefined,
+    `last ${formatRelativeTime(person.lastSeenAt)}`,
+  ];
+  return pieces.filter(Boolean).join(" / ");
+}
+
+function sampleLabel(
+  data: Pick<RequesterDirectory, "sampleSize" | "truncated">,
+) {
+  return `${formatCompactNumber(data.sampleSize)} sampled conversations${
+    data.truncated ? " / limited sample" : ""
+  }`;
+}
+
+function runtimeLabel(durationMs: number, conversations: number): string {
+  if (durationMs <= 0 && conversations > 0) return "unknown";
+  return formatMs(durationMs);
+}
+
+/** Render the requester directory from dashboard reporting data. */
+export function PeoplePage() {
+  const query = useRequesterDirectoryData();
+  const [peopleSearch, setPeopleSearch] = useState("");
+  const [sort, setSort] = useState<PeopleSort>("recent");
+  if (!query.data && !query.error) {
+    return <LoadingView label="Loading people" />;
+  }
+  const data = query.data;
+  const people = data ? filterPeople(data.people, peopleSearch, sort) : [];
+  return (
+    <div className="mx-auto w-full min-w-0 max-w-screen-xl px-4 py-4 md:px-8">
+      <Section>
+        <SectionHeader>
+          <div>
+            <SectionTitle>People</SectionTitle>
+            <div className="mt-1 break-words text-[0.82rem] leading-relaxed text-[#b8b8b8]">
+              {data
+                ? `${people.length} of ${data.people.length} requesters / ${sampleLabel(data)}`
+                : "People failed to load"}
+            </div>
+          </div>
+        </SectionHeader>
+        {data?.people.length ? (
+          <>
+            <PeopleToolbar
+              query={peopleSearch}
+              sort={sort}
+              onQueryChange={setPeopleSearch}
+              onSortChange={setSort}
+            />
+            <PeopleDirectory people={people} />
+          </>
+        ) : (
+          <div className="p-3">
+            <EmptyTelemetry>
+              No requester telemetry with trusted email.
+            </EmptyTelemetry>
+          </div>
+        )}
+      </Section>
+    </div>
+  );
+}
+
+function filterPeople(
+  people: RequesterSummary[],
+  query: string,
+  sort: PeopleSort,
+): RequesterSummary[] {
+  const normalized = query.trim().toLowerCase();
+  const filtered = normalized
+    ? people.filter((person) =>
+        [
+          person.requester.email,
+          person.requester.fullName,
+          person.requester.slackUserId,
+          person.requester.slackUserName,
+        ]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase()
+          .includes(normalized),
+      )
+    : people;
+
+  return [...filtered].sort((left, right) => {
+    if (sort === "conversations") {
+      return right.conversations - left.conversations;
+    }
+    if (sort === "activeDays") {
+      return right.activeDays - left.activeDays;
+    }
+    if (sort === "runtime") {
+      return right.durationMs - left.durationMs;
+    }
+    return Date.parse(right.lastSeenAt) - Date.parse(left.lastSeenAt);
+  });
+}
+
+function PeopleToolbar(props: {
+  query: string;
+  sort: PeopleSort;
+  onQueryChange(value: string): void;
+  onSortChange(value: PeopleSort): void;
+}) {
+  return (
+    <div className="grid min-w-0 gap-2 border-b border-white/10 bg-[#050505] px-3 py-3 md:grid-cols-[minmax(14rem,1fr)_minmax(10rem,14rem)]">
+      <ConversationSearchInput
+        label="Search people"
+        placeholder="Search name, email, Slack handle..."
+        value={props.query}
+        onChange={props.onQueryChange}
+      />
+      <label className="grid h-9 min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center overflow-hidden rounded-md border border-white/15 bg-[#0b0b0b] transition-colors hover:border-white/30 focus-within:border-[#beaaff]/45 focus-within:ring-1 focus-within:ring-[#beaaff]/20">
+        <span className="flex h-full items-center border-r border-white/10 px-2 text-[0.68rem] font-semibold uppercase leading-none text-[#777]">
+          Sort
+        </span>
+        <select
+          aria-label="Sort people"
+          className="h-full min-w-0 bg-transparent px-2 text-[0.82rem] font-semibold text-[#d6d6d6] outline-none"
+          value={props.sort}
+          onChange={(event) =>
+            props.onSortChange(event.currentTarget.value as PeopleSort)
+          }
+        >
+          <option value="recent">Recently active</option>
+          <option value="conversations">Most conversations</option>
+          <option value="activeDays">Most active days</option>
+          <option value="runtime">Most runtime</option>
+        </select>
+      </label>
+    </div>
+  );
+}
+
+function PeopleDirectory(props: { people: RequesterSummary[] }) {
+  if (props.people.length === 0) {
+    return (
+      <div className="p-3">
+        <EmptyTelemetry>No people match this search.</EmptyTelemetry>
+      </div>
+    );
+  }
+  return (
+    <div className="min-w-0" role="table">
+      <div
+        className="sticky top-0 z-[1] grid grid-cols-[minmax(14rem,1fr)_repeat(3,minmax(5rem,auto))] items-center gap-3 border-b border-white/10 bg-[#050505] px-3 py-2 text-[0.76rem] font-semibold uppercase leading-none text-[#888] max-md:hidden"
+        role="row"
+      >
+        <div>Requester</div>
+        <div className="justify-self-end">Conversations</div>
+        <div className="justify-self-end">Active days</div>
+        <div className="justify-self-end">Runtime</div>
+      </div>
+      {props.people.map((person) => (
+        <Link
+          className="grid min-w-0 grid-cols-[minmax(14rem,1fr)_repeat(3,minmax(5rem,auto))] items-center gap-3 border-b border-l-4 border-b-white/10 border-l-[#22a06b] bg-[#0b0b0b] px-3 py-3 text-inherit no-underline transition-colors hover:bg-[#151515] max-md:grid-cols-1 max-md:px-4 max-md:py-4"
+          key={person.requester.email}
+          to={peoplePath(person.requester.email)}
+        >
+          <div className="min-w-0">
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="grid size-8 shrink-0 place-items-center border border-white/10 bg-[#101412] text-[#8bdc97]">
+                <UserRound aria-hidden="true" size={16} strokeWidth={2} />
+              </span>
+              <div className="min-w-0">
+                <div className="truncate text-[1.02rem] font-bold leading-tight text-white">
+                  {requesterName(person)}
+                </div>
+                <div className="mt-1 truncate text-[0.82rem] leading-tight text-[#b8b8b8]">
+                  {personMeta(person)}
+                </div>
+              </div>
+            </div>
+          </div>
+          <DirectoryNumber value={person.conversations} />
+          <DirectoryNumber value={person.activeDays} />
+          <div className="justify-self-end text-right text-[0.92rem] font-semibold leading-tight text-white max-md:justify-self-start">
+            {runtimeLabel(person.durationMs, person.conversations)}
+          </div>
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+function DirectoryNumber(props: { value: number }) {
+  return (
+    <div className="justify-self-end text-right text-xl font-extrabold leading-none text-white max-md:justify-self-start">
+      {formatCompactNumber(props.value)}
+    </div>
+  );
+}
+
+/** Render one requester's profile and recent conversation history. */
+export function PersonProfilePage() {
+  const params = useParams();
+  const email = params.email ? decodeURIComponent(params.email) : undefined;
+  const query = useRequesterProfileData(email);
+  if (!query.data && !query.error) {
+    return <LoadingView label="Loading profile" />;
+  }
+  const profile = query.data;
+  return (
+    <div className="mx-auto w-full min-w-0 max-w-screen-xl px-4 py-4 md:px-8">
+      {profile ? (
+        <Profile profile={profile} />
+      ) : (
+        <Section>
+          <div className="p-3">
+            <EmptyTelemetry>Profile failed to load.</EmptyTelemetry>
+          </div>
+        </Section>
+      )}
+    </div>
+  );
+}
+
+export function Profile(props: { profile: RequesterProfile }) {
+  const profile = props.profile;
+  const [recentSearch, setRecentSearch] = useState("");
+  const conversations = buildConversations(profile.recentConversations);
+  const visibleConversations = filterConversationList(conversations, {
+    query: recentSearch,
+  });
+  return (
+    <>
+      <Section>
+        <div className="border-b border-white/10 px-4 py-4">
+          <div className="min-w-0">
+            <div className="flex min-w-0 items-center gap-3">
+              <span className="grid size-11 shrink-0 place-items-center border border-white/10 bg-[#101412] text-[#8bdc97]">
+                <Mail aria-hidden="true" size={20} strokeWidth={2} />
+              </span>
+              <div className="min-w-0">
+                <h2 className="m-0 truncate text-2xl font-extrabold leading-tight tracking-normal text-white">
+                  {profile.requester.fullName ??
+                    profile.requester.slackUserName ??
+                    profile.requester.email}
+                </h2>
+                <div className="mt-1 break-words text-[0.88rem] leading-relaxed text-[#b8b8b8]">
+                  {profile.requester.email}
+                  {profile.requester.slackUserName
+                    ? ` / @${profile.requester.slackUserName}`
+                    : ""}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <ProfileMetrics totals={profile.totals} />
+      </Section>
+
+      <Section>
+        <SectionHeader
+          actions={
+            <div className="text-right text-[0.76rem] font-semibold uppercase leading-tight text-[#888]">
+              {profile.truncated ? "limited sample" : "12 months"}
+            </div>
+          }
+        >
+          <SectionTitle>Activity</SectionTitle>
+        </SectionHeader>
+        <ContributionGrid days={profile.activityDays} />
+      </Section>
+
+      <div className="grid min-w-0 gap-4 lg:grid-cols-2">
+        <LeaderboardSection items={profile.locations} title="Places" />
+        <LeaderboardSection items={profile.surfaces} title="Surfaces" />
+      </div>
+
+      <Section>
+        <SectionHeader>
+          <div>
+            <SectionTitle>Recent</SectionTitle>
+            <div className="mt-1 break-words text-[0.82rem] leading-relaxed text-[#b8b8b8]">
+              {formatCompactNumber(visibleConversations.length)} of{" "}
+              {formatCompactNumber(profile.recentConversations.length)}{" "}
+              conversations / generated {formatTime(profile.generatedAt)}
+            </div>
+          </div>
+        </SectionHeader>
+        <div className="grid gap-2 border-b border-white/10 bg-[#050505] px-3 py-3 md:grid-cols-[minmax(12rem,36rem)_auto]">
+          <ConversationSearchInput
+            label="Search recent conversations"
+            placeholder="Search title, email, channel, id..."
+            value={recentSearch}
+            onChange={setRecentSearch}
+          />
+          {recentSearch.trim() ? (
+            <Button
+              className="h-9 justify-center"
+              onClick={() => setRecentSearch("")}
+            >
+              Clear
+            </Button>
+          ) : null}
+        </div>
+        <ConversationList
+          conversations={visibleConversations}
+          emptyLabel="No recent conversations match this search."
+        />
+      </Section>
+    </>
+  );
+}
+
+function ProfileMetrics(props: { totals: RequesterTotals }) {
+  const totals = props.totals;
+  const metrics = [
+    ["conversations", formatCompactNumber(totals.conversations)],
+    ["runtime", formatMs(totals.durationMs)],
+    ["tokens", totals.tokens ? formatCompactNumber(totals.tokens) : "0"],
+  ] as const;
+
+  return (
+    <div className="grid border-b border-white/10 sm:grid-cols-2 lg:grid-cols-3">
+      {metrics.map(([label, value]) => (
+        <div
+          className="min-w-0 border-r border-t border-white/10 bg-[#050505] px-4 py-3 first:border-t-0 sm:[&:nth-child(-n+2)]:border-t-0 lg:[&:nth-child(-n+3)]:border-t-0"
+          key={label}
+        >
+          <div className="truncate text-2xl font-extrabold leading-none text-white">
+            {value}
+          </div>
+          <div className="mt-1 text-[0.72rem] font-semibold uppercase leading-tight text-[#888]">
+            {label}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ContributionGrid(props: { days: RequesterActivityDay[] }) {
+  const max = Math.max(1, ...props.days.map((day) => day.conversations));
+  const weeks: Array<Array<RequesterActivityDay | null>> = [];
+  for (let index = 0; index < props.days.length; index += 7) {
+    const week: Array<RequesterActivityDay | null> = props.days.slice(
+      index,
+      index + 7,
+    );
+    while (week.length < 7) week.push(null);
+    weeks.push(week);
+  }
+  if (weeks.length === 0) {
+    weeks.push([null, null, null, null, null, null, null]);
+  }
+  const monthLabels = weeks.map((week, index) => {
+    const firstDay = week.find(Boolean);
+    if (!firstDay) return "";
+    const previousWeek = index > 0 ? weeks[index - 1] : undefined;
+    const previousDay = previousWeek
+      ? [...previousWeek].reverse().find(Boolean)
+      : undefined;
+    if (
+      previousDay &&
+      previousDay.date.slice(0, 7) === firstDay.date.slice(0, 7)
+    ) {
+      return "";
+    }
+    return new Date(`${firstDay.date}T00:00:00Z`).toLocaleString(undefined, {
+      month: "short",
+      timeZone: "UTC",
+    });
+  });
+
+  return (
+    <div className="overflow-x-auto px-4 py-4">
+      <div className="w-max">
+        <div
+          aria-hidden="true"
+          className="mb-1 grid gap-1 text-[0.64rem] font-semibold leading-none text-[#666]"
+          style={{
+            gridTemplateColumns: `repeat(${weeks.length}, 0.75rem)`,
+          }}
+        >
+          {monthLabels.map((label, index) => (
+            <div className="h-3 overflow-visible" key={`${label}-${index}`}>
+              {label}
+            </div>
+          ))}
+        </div>
+        <div
+          aria-label="Daily Junior conversation activity"
+          className="grid w-max grid-flow-col grid-rows-7 gap-1"
+          role="list"
+          style={{
+            gridTemplateColumns: `repeat(${weeks.length}, 0.75rem)`,
+          }}
+        >
+          {weeks.flatMap((week, weekIndex) =>
+            week.map((day, dayIndex) =>
+              day ? (
+                <span
+                  aria-label={`${day.date}: ${day.conversations} conversations`}
+                  className={cn(
+                    "size-3 border border-black/40",
+                    activityClass(day.conversations, max),
+                  )}
+                  key={day.date}
+                  role="listitem"
+                  title={`${day.date}: ${day.conversations} conversations, ${runtimeLabel(day.durationMs, day.conversations)}`}
+                />
+              ) : (
+                <span
+                  aria-hidden="true"
+                  className="size-3 border border-black/40 bg-[#101010]"
+                  key={`empty-${weekIndex}-${dayIndex}`}
+                />
+              ),
+            ),
+          )}
+        </div>
+        <div className="mt-3 flex items-center gap-1 text-[0.7rem] font-semibold uppercase leading-none text-[#666]">
+          <span>Less</span>
+          {[0, 1, 2, 3, 4].map((level) => (
+            <span
+              aria-hidden="true"
+              className={cn(
+                "size-3 border border-black/40",
+                level === 0 && "bg-[#151515]",
+                level === 1 && "bg-[#133225]",
+                level === 2 && "bg-[#176a4a]",
+                level === 3 && "bg-[#22a06b]",
+                level === 4 && "bg-[#8bdc97]",
+              )}
+              key={level}
+            />
+          ))}
+          <span>More</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function activityClass(count: number, max: number): string {
+  if (count <= 0) return "bg-[#151515]";
+  const ratio = count / max;
+  if (ratio >= 0.75) return "bg-[#8bdc97]";
+  if (ratio >= 0.45) return "bg-[#22a06b]";
+  if (ratio >= 0.2) return "bg-[#176a4a]";
+  return "bg-[#133225]";
+}
+
+function LeaderboardSection(props: {
+  items: ConversationStatsItem[];
+  title: string;
+}) {
+  if (props.items.length <= 1) return null;
+  return (
+    <Section>
+      <SectionHeader>
+        <SectionTitle>{props.title}</SectionTitle>
+      </SectionHeader>
+      {props.items.length ? (
+        <ol className="m-0 list-none p-0">
+          {props.items.slice(0, 6).map((item, index) => (
+            <li
+              className="grid min-w-0 grid-cols-[2rem_minmax(0,1fr)_auto] items-center gap-3 border-b border-white/10 px-4 py-3 last:border-b-0"
+              key={item.label}
+            >
+              <div className="font-mono text-[0.74rem] font-semibold leading-none text-[#666]">
+                {index + 1}
+              </div>
+              <div className="min-w-0">
+                <div className="truncate text-[0.92rem] font-semibold leading-tight text-white">
+                  {item.label}
+                </div>
+                <div className="mt-1 truncate text-[0.76rem] leading-tight text-[#888]">
+                  {runtimeLabel(item.durationMs, item.conversations)}
+                  {item.tokens
+                    ? ` / ${formatCompactNumber(item.tokens)} tokens`
+                    : ""}
+                  {item.failed
+                    ? ` / ${formatCompactNumber(item.failed)} errors`
+                    : ""}
+                  {item.hung ? ` / ${formatCompactNumber(item.hung)} hung` : ""}
+                </div>
+              </div>
+              <div className="text-right text-xl font-extrabold leading-none text-white">
+                {formatCompactNumber(item.conversations)}
+              </div>
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <div className="p-3">
+          <EmptyTelemetry>No telemetry.</EmptyTelemetry>
+        </div>
+      )}
+    </Section>
+  );
+}

--- a/packages/junior-dashboard/src/client/pages/PeoplePage.tsx
+++ b/packages/junior-dashboard/src/client/pages/PeoplePage.tsx
@@ -67,12 +67,22 @@ function runtimeLabel(durationMs: number, conversations: number): string {
 /** Render the requester directory from dashboard reporting data. */
 export function PeoplePage() {
   const query = useRequesterDirectoryData();
+  return <PeoplePageContent data={query.data} error={query.error} />;
+}
+
+/** Render loaded, failed, and empty requester directory states. */
+export function PeoplePageContent({
+  data,
+  error,
+}: {
+  data: RequesterDirectory | undefined;
+  error: unknown;
+}) {
   const [peopleSearch, setPeopleSearch] = useState("");
   const [sort, setSort] = useState<PeopleSort>("recent");
-  if (!query.data && !query.error) {
+  if (!data && !error) {
     return <LoadingView label="Loading people" />;
   }
-  const data = query.data;
   const people = data ? filterPeople(data.people, peopleSearch, sort) : [];
   return (
     <div className="mx-auto w-full min-w-0 max-w-screen-xl px-4 py-4 md:px-8">
@@ -87,7 +97,13 @@ export function PeoplePage() {
             </div>
           </div>
         </SectionHeader>
-        {data?.people.length ? (
+        {error ? (
+          <div className="p-3">
+            <EmptyTelemetry>
+              People telemetry is unavailable. Try refreshing the dashboard.
+            </EmptyTelemetry>
+          </div>
+        ) : data?.people.length ? (
           <>
             <PeopleToolbar
               query={peopleSearch}

--- a/packages/junior-dashboard/src/client/transcriptActivity.ts
+++ b/packages/junior-dashboard/src/client/transcriptActivity.ts
@@ -81,6 +81,9 @@ function subagentPart(activity: SubagentActivity): TranscriptViewSubagentPart {
       ? { parentToolCallId: activity.parentToolCallId }
       : {}),
     ...(activity.endedAt ? { endedAt: activity.endedAt } : {}),
+    ...(activity.transcriptAvailable !== undefined
+      ? { transcriptAvailable: activity.transcriptAvailable }
+      : {}),
   };
 }
 

--- a/packages/junior-dashboard/src/client/types.ts
+++ b/packages/junior-dashboard/src/client/types.ts
@@ -3,9 +3,15 @@ import type {
   ConversationStatsItem as ReportingConversationStatsItem,
   ConversationStatsReport as ReportingConversationStatsReport,
   ConversationReport as ReportingConversationReport,
+  ConversationSubagentTranscriptReport as ReportingConversationSubagentTranscriptReport,
   PluginOperationalReportFeed,
   PluginOperationalReport,
+  RequesterActivityDayReport,
+  RequesterDirectoryReport,
   RequesterIdentity as ReportingRequesterIdentity,
+  RequesterProfileReport,
+  RequesterSummaryReport,
+  RequesterTotalsReport,
   ConversationFeed as ReportingConversationFeed,
   ConversationSummaryReport,
   ConversationRunReport,
@@ -30,9 +36,22 @@ export type PluginReportFeed = PluginOperationalReportFeed;
 
 export type ConversationStatsReport = ReportingConversationStatsReport;
 
+export type ConversationSubagentTranscript =
+  ReportingConversationSubagentTranscriptReport;
+
 export type ConversationStatsItem = ReportingConversationStatsItem;
 
 export type RequesterIdentity = ReportingRequesterIdentity;
+
+export type RequesterActivityDay = RequesterActivityDayReport;
+
+export type RequesterDirectory = RequesterDirectoryReport;
+
+export type RequesterProfile = RequesterProfileReport;
+
+export type RequesterSummary = RequesterSummaryReport;
+
+export type RequesterTotals = RequesterTotalsReport;
 
 export type TurnUsage = ConversationUsage;
 
@@ -86,6 +105,7 @@ export type TranscriptViewSubagentPart = {
   redacted?: boolean;
   status: TranscriptActivityStatus;
   subagentKind: string;
+  transcriptAvailable?: boolean;
   text?: never;
   type: "subagent";
 };
@@ -99,7 +119,9 @@ export type TranscriptViewMessage = Omit<TranscriptMessage, "parts"> & {
   parts: TranscriptViewPart[];
 };
 
-export type ConversationTurn = ConversationRunReport;
+export type ConversationTurn = ConversationRunReport & {
+  assistantLabel?: string;
+};
 
 export type ConversationDetailFeed = ReportingConversationReport;
 

--- a/packages/junior-dashboard/src/mock-conversations.ts
+++ b/packages/junior-dashboard/src/mock-conversations.ts
@@ -1537,7 +1537,8 @@ function requesterDirectoryFromFeed(
   feed: DashboardConversationFeed,
 ): DashboardRequesterDirectoryReport {
   const people = new Map<string, MockRequesterAccumulator>();
-  for (const runs of summaryGroups(feed.conversations)) {
+  const groups = summaryGroups(feed.conversations);
+  for (const runs of groups) {
     const newest = newestRun(runs);
     const requester = identityWithEmail(newest.requesterIdentity);
     if (!requester) continue;
@@ -1578,8 +1579,8 @@ function requesterDirectoryFromFeed(
             (reportTime(left.lastSeenAt) ?? 0) ||
           left.requester.email.localeCompare(right.requester.email),
       ),
-    sampleLimit: feed.conversations.length,
-    sampleSize: feed.conversations.length,
+    sampleLimit: groups.length,
+    sampleSize: groups.length,
     source: "conversation_index",
     truncated: false,
   };
@@ -1623,7 +1624,8 @@ function requesterProfileFromFeed(
   feed: DashboardConversationFeed,
 ): DashboardRequesterProfileReport {
   const normalized = normalizeEmail(email) ?? email;
-  const matchingGroups = summaryGroups(feed.conversations).filter((runs) =>
+  const groups = summaryGroups(feed.conversations);
+  const matchingGroups = groups.filter((runs) =>
     runs.some(
       (run) => normalizeEmail(run.requesterIdentity?.email) === normalized,
     ),
@@ -1709,8 +1711,8 @@ function requesterProfileFromFeed(
       )
       .slice(0, 25),
     requester: requester ?? { email: normalized },
-    sampleLimit: feed.conversations.length,
-    sampleSize: feed.conversations.length,
+    sampleLimit: groups.length,
+    sampleSize: groups.length,
     source: "conversation_index",
     surfaces: statsItems(surfaces),
     totals,

--- a/packages/junior-dashboard/src/mock-conversations.ts
+++ b/packages/junior-dashboard/src/mock-conversations.ts
@@ -1724,19 +1724,48 @@ function mergeRequesterDirectories(
   mockDirectory: DashboardRequesterDirectoryReport,
   realDirectory: DashboardRequesterDirectoryReport,
 ): DashboardRequesterDirectoryReport {
-  const emails = new Set(
-    mockDirectory.people.map((person) => person.requester.email),
+  const people = new Map(
+    mockDirectory.people.map((person) => [person.requester.email, person]),
   );
+  for (const person of realDirectory.people) {
+    const existing = people.get(person.requester.email);
+    if (!existing) {
+      people.set(person.requester.email, person);
+      continue;
+    }
+    people.set(person.requester.email, {
+      active: existing.active + person.active,
+      activeDays: Math.max(existing.activeDays, person.activeDays),
+      conversations: existing.conversations + person.conversations,
+      durationMs: existing.durationMs + person.durationMs,
+      failed: existing.failed + person.failed,
+      firstSeenAt:
+        (reportTime(existing.firstSeenAt) ?? 0) <=
+        (reportTime(person.firstSeenAt) ?? 0)
+          ? existing.firstSeenAt
+          : person.firstSeenAt,
+      hung: existing.hung + person.hung,
+      lastSeenAt:
+        (reportTime(existing.lastSeenAt) ?? 0) >=
+        (reportTime(person.lastSeenAt) ?? 0)
+          ? existing.lastSeenAt
+          : person.lastSeenAt,
+      requester: mergeIdentity(existing.requester, person.requester),
+      runs: existing.runs + person.runs,
+      ...(existing.tokens !== undefined || person.tokens !== undefined
+        ? { tokens: (existing.tokens ?? 0) + (person.tokens ?? 0) }
+        : {}),
+    });
+  }
+  const mergedPeople = [...people.values()];
   return {
     ...realDirectory,
     generatedAt: realDirectory.generatedAt,
-    people: [
-      ...mockDirectory.people,
-      ...realDirectory.people.filter(
-        (person) => !emails.has(person.requester.email),
-      ),
-    ],
-    sampleSize: mockDirectory.sampleSize + realDirectory.sampleSize,
+    people: mergedPeople,
+    sampleSize: mergedPeople.reduce(
+      (total, person) => total + person.conversations,
+      0,
+    ),
     truncated: mockDirectory.truncated || realDirectory.truncated,
   };
 }

--- a/packages/junior-dashboard/src/mock-conversations.ts
+++ b/packages/junior-dashboard/src/mock-conversations.ts
@@ -2,7 +2,13 @@ import type {
   ConversationReport as DashboardConversationReport,
   ConversationStatsItem as DashboardConversationStatsItem,
   ConversationStatsReport as DashboardConversationStatsReport,
+  ConversationSubagentTranscriptReport as DashboardConversationSubagentTranscriptReport,
+  RequesterActivityDayReport as DashboardRequesterActivityDayReport,
+  RequesterDirectoryReport as DashboardRequesterDirectoryReport,
   RequesterIdentity as DashboardRequesterIdentity,
+  RequesterProfileReport as DashboardRequesterProfileReport,
+  RequesterSummaryReport as DashboardRequesterSummaryReport,
+  RequesterTotalsReport as DashboardRequesterTotalsReport,
   ConversationFeed as DashboardConversationFeed,
   ConversationSummaryReport as DashboardConversationSummary,
   ConversationUsage as DashboardRunUsage,
@@ -30,6 +36,7 @@ const HUNG_CONVERSATION_ID = "slack:CQA999:1770010800.000400";
 const FAILED_CONVERSATION_ID = "slack:CQA777:1770014400.000500";
 const SCHEDULER_CONVERSATION_ID = "scheduler:daily-ops-digest";
 export const DASHBOARD_QA_CONVERSATION_ID = "internal:dashboard-qa";
+const DASHBOARD_QA_ADVISOR_CONVERSATION_ID = `junior:${DASHBOARD_QA_CONVERSATION_ID}:advisor_session`;
 const RECENT_CONVERSATION_STATS_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
 function iso(nowMs: number, offsetMs = 0): string {
@@ -89,6 +96,7 @@ function publicIncidentConversation(
         },
         surface: "slack",
         requesterIdentity: {
+          email: "avery@sentry.io",
           fullName: "Avery Stone",
           slackUserId: "UQA111",
           slackUserName: "avery",
@@ -187,6 +195,7 @@ function publicIncidentConversation(
         },
         surface: "slack",
         requesterIdentity: {
+          email: "morgan@sentry.io",
           fullName: "Morgan Lee",
           slackUserId: "UQA222",
           slackUserName: "morgan",
@@ -281,6 +290,7 @@ function activeConversation(nowMs: number): DashboardConversationReport {
         },
         surface: "slack",
         requesterIdentity: {
+          email: "sam@sentry.io",
           fullName: "Sam Rivera",
           slackUserId: "UQA333",
           slackUserName: "sam",
@@ -351,6 +361,7 @@ function privateConversation(nowMs: number): DashboardConversationReport {
         },
         surface: "slack",
         requesterIdentity: {
+          email: "private-user@sentry.io",
           slackUserId: "UQA444",
           slackUserName: "private-user",
         },
@@ -457,6 +468,7 @@ function hungConversation(nowMs: number): DashboardConversationReport {
         },
         surface: "slack",
         requesterIdentity: {
+          email: "dana@sentry.io",
           fullName: "Dana Chen",
           slackUserId: "UQA555",
           slackUserName: "dana",
@@ -534,6 +546,7 @@ function failedConversation(nowMs: number): DashboardConversationReport {
         },
         surface: "slack",
         requesterIdentity: {
+          email: "riley@sentry.io",
           fullName: "Riley Patel",
           slackUserId: "UQA666",
           slackUserName: "riley",
@@ -652,8 +665,10 @@ function dashboardQaConversation(nowMs: number): DashboardConversationReport {
   const transcriptStartedAt = iso(nowMs, -10 * 60_000);
   const runningToolId = "toolu_mock_dashboard_running";
   const invertedToolId = "toolu_mock_dashboard_inverted";
-  const advisorToolId = "toolu_mock_dashboard_advisor";
-  const advisorSubagentId = "subagent_mock_dashboard_advisor";
+  const advisorPlanToolId = "toolu_mock_dashboard_advisor_plan";
+  const advisorReviewToolId = "toolu_mock_dashboard_advisor_review";
+  const readFileToolId = "toolu_mock_dashboard_read_file";
+  const editFileToolId = "toolu_mock_dashboard_edit_file";
 
   return mockConversation({
     conversationId,
@@ -734,16 +749,16 @@ function dashboardQaConversation(nowMs: number): DashboardConversationReport {
       mockRun({
         conversationId,
         displayTitle,
-        id: "mock-dashboard-qa-advisor-subagent",
+        id: "mock-dashboard-qa-advisor-code-change",
         status: "completed",
         startedAt: iso(nowMs, -8 * 60_000),
-        lastProgressAt: iso(nowMs, -7 * 60_000),
-        lastSeenAt: iso(nowMs, -7 * 60_000),
-        completedAt: iso(nowMs, -7 * 60_000),
-        cumulativeDurationMs: 90_000,
+        lastProgressAt: iso(nowMs, -5 * 60_000),
+        lastSeenAt: iso(nowMs, -5 * 60_000),
+        completedAt: iso(nowMs, -5 * 60_000),
+        cumulativeDurationMs: 180_000,
         surface: "internal",
         transcriptAvailable: true,
-        transcriptMessageCount: 3,
+        transcriptMessageCount: 7,
         transcript: [
           mockTranscriptMessage({
             role: "user",
@@ -751,7 +766,7 @@ function dashboardQaConversation(nowMs: number): DashboardConversationReport {
             parts: [
               {
                 type: "text",
-                text: "Use an advisor to review the dashboard transcript ordering.",
+                text: "Add a people profile page to the dashboard and make conversation emails link to the profile. Be careful with privacy and keep the UI practical.",
               },
             ],
           }),
@@ -760,51 +775,216 @@ function dashboardQaConversation(nowMs: number): DashboardConversationReport {
             timestamp: nowMs - 8 * 60_000 + 4_000,
             parts: [
               mockToolCallPart({
-                id: advisorToolId,
+                id: advisorPlanToolId,
                 name: "advisor",
                 input: {
                   question:
-                    "Check whether tool calls, tool results, and subagent activity render together.",
+                    "Review the dashboard plan before editing. Focus on whether requester email can be trusted, what profile metrics are useful, and what UI risks to avoid.",
                 },
               }),
             ],
           }),
           mockTranscriptMessage({
             role: "toolResult",
-            timestamp: nowMs - 7 * 60_000,
+            timestamp: nowMs - 8 * 60_000 + 35_000,
             parts: [
               mockToolResultPart({
-                id: advisorToolId,
+                id: advisorPlanToolId,
                 name: "advisor",
                 output: {
-                  verdict: "ok",
+                  verdict: "proceed",
                   summary:
-                    "Tool call, advisor result, and subagent activity are visible.",
+                    "Use trusted requesterIdentity.email, keep metrics to conversations/runtime/tokens, and make profile activity scannable before adding heavier analytics.",
                 },
               }),
+            ],
+          }),
+          mockTranscriptMessage({
+            role: "assistant",
+            timestamp: nowMs - 7 * 60_000 + 5_000,
+            parts: [
+              mockToolCallPart({
+                id: readFileToolId,
+                name: "readFile",
+                input: {
+                  path: "packages/junior-dashboard/src/client/pages/ConversationPage.tsx",
+                },
+              }),
+              mockToolCallPart({
+                id: editFileToolId,
+                name: "editFile",
+                input: {
+                  path: "packages/junior-dashboard/src/client/pages/PeoplePage.tsx",
+                  operations: [
+                    {
+                      action: "insert",
+                      anchor: "ProfileMetrics",
+                      lines: 42,
+                    },
+                    {
+                      action: "replace",
+                      anchor: "RecentConversationList",
+                      lines: 18,
+                    },
+                  ],
+                  summary:
+                    "Add requester activity grid, recent conversations, and email profile links.",
+                },
+              }),
+            ],
+          }),
+          mockTranscriptMessage({
+            role: "toolResult",
+            timestamp: nowMs - 6 * 60_000 + 10_000,
+            parts: [
+              mockToolResultPart({
+                id: readFileToolId,
+                name: "readFile",
+                output: {
+                  lines: 260,
+                  result: "Conversation detail component inspected.",
+                  imports: [
+                    "Transcript",
+                    "ConversationStats",
+                    "ConversationIdentity",
+                  ],
+                  risks: {
+                    auth: "dashboard routes remain authenticated",
+                    privacy:
+                      "requester emails are trusted from normalized reporting identity",
+                  },
+                },
+              }),
+              mockToolResultPart({
+                id: editFileToolId,
+                name: "editFile",
+                output: {
+                  filesChanged: [
+                    {
+                      path: "packages/junior-dashboard/src/client/pages/PeoplePage.tsx",
+                      added: 216,
+                      removed: 0,
+                    },
+                    {
+                      path: "packages/junior-dashboard/src/client/components/ConversationSummary.tsx",
+                      added: 18,
+                      removed: 4,
+                    },
+                  ],
+                  checks: {
+                    typecheck: "passed",
+                    visualQa: "needs browser review",
+                  },
+                  notes:
+                    "The profile page uses a contribution-style activity grid, compact stat row, and searchable recent conversations. Keep the grid cell size stable so long month labels do not shift the layout.",
+                },
+              }),
+            ],
+          }),
+          mockTranscriptMessage({
+            role: "assistant",
+            timestamp: nowMs - 6 * 60_000 + 20_000,
+            parts: [
+              mockToolCallPart({
+                id: advisorReviewToolId,
+                name: "advisor",
+                input: {
+                  question:
+                    "Review the implementation after the first advisor pass. Check whether the UI is too noisy and whether any data shape assumptions are weak.",
+                },
+              }),
+            ],
+          }),
+          mockTranscriptMessage({
+            role: "toolResult",
+            timestamp: nowMs - 5 * 60_000 + 20_000,
+            parts: [
+              mockToolResultPart({
+                id: advisorReviewToolId,
+                name: "advisor",
+                output: {
+                  verdict: "revise",
+                  summary:
+                    "Remove low-signal attention widgets, add list search/filtering, and verify the activity grid fills the available width.",
+                },
+              }),
+            ],
+          }),
+          mockTranscriptMessage({
+            role: "assistant",
+            timestamp: nowMs - 5 * 60_000 + 30_000,
+            parts: [
+              {
+                type: "text",
+                text: "Implemented the people profile route, linked requester emails, and tightened the dashboard widgets based on the advisor review.",
+              },
             ],
           }),
         ],
         activity: [
           mockToolActivity({
-            id: advisorToolId,
-            toolCallId: advisorToolId,
+            id: advisorPlanToolId,
+            toolCallId: advisorPlanToolId,
             toolName: "advisor",
             createdAt: iso(nowMs, -8 * 60_000 + 4_000),
             status: "completed",
             args: {
               question:
-                "Check whether tool calls, tool results, and subagent activity render together.",
+                "Review the dashboard plan before editing. Focus on whether requester email can be trusted, what profile metrics are useful, and what UI risks to avoid.",
             },
             subagents: [
               mockSubagentActivity({
-                id: advisorSubagentId,
-                parentToolCallId: advisorToolId,
+                id: advisorPlanToolId,
+                parentToolCallId: advisorPlanToolId,
                 subagentKind: "advisor",
                 createdAt: iso(nowMs, -8 * 60_000 + 6_000),
-                endedAt: iso(nowMs, -7 * 60_000),
+                endedAt: iso(nowMs, -8 * 60_000 + 35_000),
                 status: "completed",
                 outcome: "success",
+                transcriptAvailable: true,
+              }),
+            ],
+          }),
+          mockToolActivity({
+            id: readFileToolId,
+            toolCallId: readFileToolId,
+            toolName: "readFile",
+            createdAt: iso(nowMs, -7 * 60_000 + 5_000),
+            status: "completed",
+            args: {
+              path: "packages/junior-dashboard/src/client/pages/ConversationPage.tsx",
+            },
+          }),
+          mockToolActivity({
+            id: editFileToolId,
+            toolCallId: editFileToolId,
+            toolName: "editFile",
+            createdAt: iso(nowMs, -7 * 60_000 + 20_000),
+            status: "completed",
+            args: {
+              path: "packages/junior-dashboard/src/client/pages/PeoplePage.tsx",
+            },
+          }),
+          mockToolActivity({
+            id: advisorReviewToolId,
+            toolCallId: advisorReviewToolId,
+            toolName: "advisor",
+            createdAt: iso(nowMs, -6 * 60_000 + 20_000),
+            status: "completed",
+            args: {
+              question:
+                "Review the implementation after the first advisor pass. Check whether the UI is too noisy and whether any data shape assumptions are weak.",
+            },
+            subagents: [
+              mockSubagentActivity({
+                id: advisorReviewToolId,
+                parentToolCallId: advisorReviewToolId,
+                subagentKind: "advisor",
+                createdAt: iso(nowMs, -6 * 60_000 + 25_000),
+                endedAt: iso(nowMs, -5 * 60_000 + 20_000),
+                status: "completed",
+                outcome: "success",
+                transcriptAvailable: true,
               }),
             ],
           }),
@@ -812,6 +992,90 @@ function dashboardQaConversation(nowMs: number): DashboardConversationReport {
       }),
     ],
   });
+}
+
+function dashboardQaAdvisorTranscript(
+  nowMs: number,
+  subagentId: string,
+): DashboardConversationSubagentTranscriptReport | undefined {
+  const createdAt =
+    subagentId === "toolu_mock_dashboard_advisor_plan"
+      ? iso(nowMs, -8 * 60_000 + 6_000)
+      : subagentId === "toolu_mock_dashboard_advisor_review"
+        ? iso(nowMs, -6 * 60_000 + 25_000)
+        : undefined;
+  const endedAt =
+    subagentId === "toolu_mock_dashboard_advisor_plan"
+      ? iso(nowMs, -8 * 60_000 + 35_000)
+      : subagentId === "toolu_mock_dashboard_advisor_review"
+        ? iso(nowMs, -5 * 60_000 + 20_000)
+        : undefined;
+  if (!createdAt || !endedAt) return undefined;
+
+  const sharedAdvisorSession: DashboardTranscriptMessage[] = [
+    mockTranscriptMessage({
+      role: "user",
+      timestamp: Date.parse(createdAt),
+      parts: [
+        {
+          type: "text",
+          text: "Review the dashboard plan before editing. Focus on whether requester email can be trusted, what profile metrics are useful, and what UI risks to avoid.",
+        },
+      ],
+    }),
+    mockTranscriptMessage({
+      role: "assistant",
+      timestamp: Date.parse(createdAt) + 23_000,
+      parts: [
+        {
+          type: "text",
+          text: "Requester identity email is a reasonable profile key because reporting already normalizes trusted identities. Keep the first cut narrow: total conversations, runtime, token volume, recent conversations, and a contribution-style activity grid. Avoid attention widgets until there is an explicit operator workflow.",
+        },
+      ],
+    }),
+    mockTranscriptMessage({
+      role: "user",
+      timestamp: Date.parse(iso(nowMs, -6 * 60_000 + 25_000)),
+      parts: [
+        {
+          type: "text",
+          text: "Review the implementation after the first advisor pass. Check whether the UI is too noisy and whether any data shape assumptions are weak.",
+        },
+      ],
+    }),
+    mockTranscriptMessage({
+      role: "assistant",
+      timestamp: Date.parse(endedAt),
+      parts: [
+        {
+          type: "text",
+          text: "The implementation is directionally right, but it should be more aggressive about removing weak dashboard widgets. Conversation and profile search are more useful than top-N summaries. The activity grid should use smaller fixed cells and fill the row without sparse-looking gaps.",
+        },
+      ],
+    }),
+  ];
+  const slice =
+    subagentId === "toolu_mock_dashboard_advisor_plan"
+      ? sharedAdvisorSession.slice(0, 2)
+      : sharedAdvisorSession.slice(0, 4);
+
+  return {
+    type: "subagent",
+    createdAt,
+    endedAt,
+    id: subagentId,
+    outcome: "success",
+    parentToolCallId: subagentId,
+    status: "success",
+    subagentConversationId: DASHBOARD_QA_ADVISOR_CONVERSATION_ID,
+    subagentKind: "advisor",
+    subagentSentryConversationUrl: sentryConversationUrl(
+      DASHBOARD_QA_ADVISOR_CONVERSATION_ID,
+    ),
+    transcript: slice,
+    transcriptAvailable: true,
+    transcriptMessageCount: 2,
+  };
 }
 
 function mockConversations(nowMs: number): DashboardConversationReport[] {
@@ -1143,6 +1407,340 @@ function statsItems(map: Map<string, DashboardConversationStatsItem>) {
   );
 }
 
+function surfaceLabel(turn: DashboardConversationSummary): string {
+  if (turn.surface === "scheduler") return "Scheduler";
+  if (turn.surface === "api") return "API";
+  if (turn.surface === "internal") return "Internal";
+  return "Conversation";
+}
+
+function normalizeEmail(email: string | undefined): string | undefined {
+  const normalized = email?.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+function identityWithEmail(
+  requester: DashboardRequesterIdentity | undefined,
+): (DashboardRequesterIdentity & { email: string }) | undefined {
+  const email = normalizeEmail(requester?.email);
+  if (!email) return undefined;
+  return {
+    email,
+    ...(requester?.fullName ? { fullName: requester.fullName } : {}),
+    ...(requester?.slackUserId ? { slackUserId: requester.slackUserId } : {}),
+    ...(requester?.slackUserName
+      ? { slackUserName: requester.slackUserName }
+      : {}),
+  };
+}
+
+function mergeIdentity(
+  current: DashboardRequesterIdentity & { email: string },
+  next: DashboardRequesterIdentity & { email: string },
+): DashboardRequesterIdentity & { email: string } {
+  return {
+    email: current.email,
+    ...((current.fullName ?? next.fullName)
+      ? { fullName: current.fullName ?? next.fullName }
+      : {}),
+    ...((current.slackUserId ?? next.slackUserId)
+      ? { slackUserId: current.slackUserId ?? next.slackUserId }
+      : {}),
+    ...((current.slackUserName ?? next.slackUserName)
+      ? { slackUserName: current.slackUserName ?? next.slackUserName }
+      : {}),
+  };
+}
+
+function reportDate(value: string): string | undefined {
+  const time = reportTime(value);
+  if (time === undefined) return undefined;
+  return new Date(time).toISOString().slice(0, 10);
+}
+
+function emptyRequesterTotals(): DashboardRequesterTotalsReport {
+  return {
+    active: 0,
+    activeDays: 0,
+    conversations: 0,
+    durationMs: 0,
+    failed: 0,
+    hung: 0,
+    runs: 0,
+  };
+}
+
+function addRequesterTokens(
+  target: Pick<DashboardRequesterTotalsReport, "tokens">,
+  tokens: number | undefined,
+): void {
+  if (tokens !== undefined) {
+    target.tokens = (target.tokens ?? 0) + tokens;
+  }
+}
+
+function addSignals(
+  target: Pick<DashboardRequesterTotalsReport, "active" | "failed" | "hung">,
+  signals: ReturnType<typeof statusSignals>,
+): void {
+  target.active += signals.active ? 1 : 0;
+  target.failed += signals.failed ? 1 : 0;
+  target.hung += signals.hung ? 1 : 0;
+}
+
+type MockRequesterAccumulator = DashboardRequesterTotalsReport & {
+  activeDates: Set<string>;
+  firstSeenMs: number;
+  lastSeenMs: number;
+  requester: DashboardRequesterIdentity & { email: string };
+};
+
+function summaryGroups(
+  summaries: DashboardConversationSummary[],
+): DashboardConversationSummary[][] {
+  const groups = new Map<string, DashboardConversationSummary[]>();
+  for (const summary of summaries) {
+    groups.set(summary.conversationId, [
+      ...(groups.get(summary.conversationId) ?? []),
+      summary,
+    ]);
+  }
+  return [...groups.values()].map((runs) =>
+    [...runs].sort(
+      (left, right) =>
+        (reportTime(left.startedAt) ?? 0) -
+          (reportTime(right.startedAt) ?? 0) || left.id.localeCompare(right.id),
+    ),
+  );
+}
+
+function directoryItem(
+  accumulator: MockRequesterAccumulator,
+): DashboardRequesterSummaryReport {
+  return {
+    active: accumulator.active,
+    activeDays: accumulator.activeDates.size,
+    conversations: accumulator.conversations,
+    durationMs: accumulator.durationMs,
+    failed: accumulator.failed,
+    firstSeenAt: new Date(accumulator.firstSeenMs).toISOString(),
+    hung: accumulator.hung,
+    lastSeenAt: new Date(accumulator.lastSeenMs).toISOString(),
+    requester: accumulator.requester,
+    runs: accumulator.runs,
+    ...(accumulator.tokens !== undefined ? { tokens: accumulator.tokens } : {}),
+  };
+}
+
+function requesterDirectoryFromFeed(
+  nowMs: number,
+  feed: DashboardConversationFeed,
+): DashboardRequesterDirectoryReport {
+  const people = new Map<string, MockRequesterAccumulator>();
+  for (const runs of summaryGroups(feed.conversations)) {
+    const newest = newestRun(runs);
+    const requester = identityWithEmail(newest.requesterIdentity);
+    if (!requester) continue;
+    const contributions = runContributions(runs);
+    const signals = statusSignals(runs);
+    const date = reportDate(newest.lastSeenAt);
+    const firstSeenMs =
+      reportTime(runs[0]?.startedAt ?? newest.startedAt) ?? nowMs;
+    const lastSeenMs = reportTime(newest.lastSeenAt) ?? nowMs;
+    const accumulator =
+      people.get(requester.email) ??
+      ({
+        ...emptyRequesterTotals(),
+        activeDates: new Set<string>(),
+        firstSeenMs,
+        lastSeenMs,
+        requester,
+      } satisfies MockRequesterAccumulator);
+    accumulator.requester = mergeIdentity(accumulator.requester, requester);
+    accumulator.conversations += 1;
+    accumulator.runs += runs.length;
+    accumulator.durationMs += contributionDurationTotal(contributions);
+    addRequesterTokens(accumulator, contributionTokenTotal(contributions));
+    addSignals(accumulator, signals);
+    accumulator.firstSeenMs = Math.min(accumulator.firstSeenMs, firstSeenMs);
+    accumulator.lastSeenMs = Math.max(accumulator.lastSeenMs, lastSeenMs);
+    if (date) accumulator.activeDates.add(date);
+    people.set(requester.email, accumulator);
+  }
+
+  return {
+    generatedAt: feed.generatedAt,
+    people: [...people.values()]
+      .map(directoryItem)
+      .sort(
+        (left, right) =>
+          (reportTime(right.lastSeenAt) ?? 0) -
+            (reportTime(left.lastSeenAt) ?? 0) ||
+          left.requester.email.localeCompare(right.requester.email),
+      ),
+    sampleLimit: feed.conversations.length,
+    sampleSize: feed.conversations.length,
+    source: "conversation_index",
+    truncated: false,
+  };
+}
+
+function emptyActivityDay(date: string): DashboardRequesterActivityDayReport {
+  return {
+    active: 0,
+    conversations: 0,
+    date,
+    durationMs: 0,
+    failed: 0,
+    hung: 0,
+    runs: 0,
+  };
+}
+
+function profileActivityDays(
+  nowMs: number,
+  days: Map<string, DashboardRequesterActivityDayReport>,
+): DashboardRequesterActivityDayReport[] {
+  const end = new Date(nowMs);
+  end.setUTCHours(0, 0, 0, 0);
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - 365);
+  const items: DashboardRequesterActivityDayReport[] = [];
+  for (
+    const cursor = new Date(start);
+    cursor.getTime() <= end.getTime();
+    cursor.setUTCDate(cursor.getUTCDate() + 1)
+  ) {
+    const date = cursor.toISOString().slice(0, 10);
+    items.push(days.get(date) ?? emptyActivityDay(date));
+  }
+  return items;
+}
+
+function requesterProfileFromFeed(
+  nowMs: number,
+  email: string,
+  feed: DashboardConversationFeed,
+): DashboardRequesterProfileReport {
+  const normalized = normalizeEmail(email) ?? email;
+  const matchingGroups = summaryGroups(feed.conversations).filter((runs) =>
+    runs.some(
+      (run) => normalizeEmail(run.requesterIdentity?.email) === normalized,
+    ),
+  );
+  let requester: (DashboardRequesterIdentity & { email: string }) | undefined;
+  const totals = emptyRequesterTotals();
+  const activeDates = new Set<string>();
+  const activityDays = new Map<string, DashboardRequesterActivityDayReport>();
+  const locations = new Map<string, DashboardConversationStatsItem>();
+  const surfaces = new Map<string, DashboardConversationStatsItem>();
+  const recentConversations: DashboardConversationSummary[] = [];
+
+  for (const runs of matchingGroups) {
+    const newest = newestRun(runs);
+    const identity = identityWithEmail(newest.requesterIdentity);
+    if (identity) {
+      requester = requester ? mergeIdentity(requester, identity) : identity;
+    }
+    recentConversations.push(newest);
+
+    const contributions = runContributions(runs);
+    const signals = statusSignals(runs);
+    const durationMs = contributionDurationTotal(contributions);
+    const tokens = contributionTokenTotal(contributions);
+    const date = reportDate(newest.lastSeenAt);
+
+    totals.conversations += 1;
+    totals.runs += runs.length;
+    totals.durationMs += durationMs;
+    addRequesterTokens(totals, tokens);
+    addSignals(totals, signals);
+
+    if (date) {
+      activeDates.add(date);
+      const day = activityDays.get(date) ?? emptyActivityDay(date);
+      day.conversations += 1;
+      day.runs += runs.length;
+      day.durationMs += durationMs;
+      addRequesterTokens(day, tokens);
+      addSignals(day, signals);
+      activityDays.set(date, day);
+    }
+
+    const location = locationLabel(newest);
+    const locationItem = locations.get(location) ?? emptyStatsItem(location);
+    locationItem.conversations += 1;
+    locationItem.runs += runs.length;
+    locationItem.durationMs += durationMs;
+    addItemTokens(locationItem, tokens);
+    locationItem.active += signals.active ? 1 : 0;
+    locationItem.failed += signals.failed ? 1 : 0;
+    locationItem.hung += signals.hung ? 1 : 0;
+    locations.set(location, locationItem);
+
+    const surface = surfaceLabel(newest);
+    const surfaceItem = surfaces.get(surface) ?? emptyStatsItem(surface);
+    surfaceItem.conversations += 1;
+    surfaceItem.runs += runs.length;
+    surfaceItem.durationMs += durationMs;
+    addItemTokens(surfaceItem, tokens);
+    surfaceItem.active += signals.active ? 1 : 0;
+    surfaceItem.failed += signals.failed ? 1 : 0;
+    surfaceItem.hung += signals.hung ? 1 : 0;
+    surfaces.set(surface, surfaceItem);
+  }
+
+  totals.activeDays = activeDates.size;
+  const end = new Date(nowMs);
+  end.setUTCHours(0, 0, 0, 0);
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - 365);
+
+  return {
+    activityDays: profileActivityDays(nowMs, activityDays),
+    generatedAt: feed.generatedAt,
+    locations: statsItems(locations),
+    recentConversations: recentConversations
+      .sort(
+        (left, right) =>
+          (reportTime(right.lastSeenAt) ?? 0) -
+            (reportTime(left.lastSeenAt) ?? 0) ||
+          right.conversationId.localeCompare(left.conversationId),
+      )
+      .slice(0, 25),
+    requester: requester ?? { email: normalized },
+    sampleLimit: feed.conversations.length,
+    sampleSize: feed.conversations.length,
+    source: "conversation_index",
+    surfaces: statsItems(surfaces),
+    totals,
+    truncated: false,
+    windowEnd: end.toISOString(),
+    windowStart: start.toISOString(),
+  };
+}
+
+function mergeRequesterDirectories(
+  mockDirectory: DashboardRequesterDirectoryReport,
+  realDirectory: DashboardRequesterDirectoryReport,
+): DashboardRequesterDirectoryReport {
+  const emails = new Set(
+    mockDirectory.people.map((person) => person.requester.email),
+  );
+  return {
+    ...realDirectory,
+    generatedAt: realDirectory.generatedAt,
+    people: [
+      ...mockDirectory.people,
+      ...realDirectory.people.filter(
+        (person) => !emails.has(person.requester.email),
+      ),
+    ],
+    sampleSize: mockDirectory.sampleSize + realDirectory.sampleSize,
+    truncated: mockDirectory.truncated || realDirectory.truncated,
+  };
+}
+
 function isLocalPersistenceUnavailable(error: unknown): boolean {
   return (
     error instanceof Error &&
@@ -1198,12 +1796,63 @@ export function createMockConversationReporting(
         );
       }
     },
+    async listRequesters() {
+      const nowMs = Date.now();
+      const mockDirectory = requesterDirectoryFromFeed(
+        nowMs,
+        mockConversationFeed(nowMs),
+      );
+      try {
+        if (!reporting.listRequesters) {
+          return mockDirectory;
+        }
+        return mergeRequesterDirectories(
+          mockDirectory,
+          await reporting.listRequesters(),
+        );
+      } catch (error) {
+        if (!isLocalPersistenceUnavailable(error)) {
+          throw error;
+        }
+        return mockDirectory;
+      }
+    },
+    async getRequesterProfile(email: string) {
+      const nowMs = Date.now();
+      const mockProfile = requesterProfileFromFeed(
+        nowMs,
+        email,
+        mockConversationFeed(nowMs),
+      );
+      if (mockProfile.totals.conversations > 0) {
+        return mockProfile;
+      }
+      if (reporting.getRequesterProfile) {
+        return await reporting.getRequesterProfile(email);
+      }
+      return mockProfile;
+    },
     async getConversation(conversationId: string) {
       const conversation = mockConversationMap(Date.now()).get(conversationId);
       if (conversation) {
         return conversation;
       }
       return reporting.getConversation(conversationId);
+    },
+    async getConversationSubagentTranscript(
+      conversationId: string,
+      _runId: string,
+      subagentId: string,
+    ) {
+      if (conversationId === DASHBOARD_QA_CONVERSATION_ID) {
+        const transcript = dashboardQaAdvisorTranscript(Date.now(), subagentId);
+        if (transcript) return transcript;
+      }
+      return reporting.getConversationSubagentTranscript(
+        conversationId,
+        _runId,
+        subagentId,
+      );
     },
   };
   if (reporting.getPluginOperationalReports) {

--- a/packages/junior-dashboard/src/mock-conversations.ts
+++ b/packages/junior-dashboard/src/mock-conversations.ts
@@ -1735,7 +1735,10 @@ function mergeRequesterDirectories(
     }
     people.set(person.requester.email, {
       active: existing.active + person.active,
-      activeDays: Math.max(existing.activeDays, person.activeDays),
+      activeDays: Math.min(
+        existing.activeDays + person.activeDays,
+        existing.conversations + person.conversations,
+      ),
       conversations: existing.conversations + person.conversations,
       durationMs: existing.durationMs + person.durationMs,
       failed: existing.failed + person.failed,

--- a/packages/junior-dashboard/src/mock-reporting/activity.ts
+++ b/packages/junior-dashboard/src/mock-reporting/activity.ts
@@ -14,6 +14,7 @@ export type MockSubagentActivityOptions = {
   parentToolCallId?: string;
   status?: ConversationActivityStatus;
   subagentKind?: string;
+  transcriptAvailable?: boolean;
 };
 
 /** Build a subagent activity record constrained to the reporting API shape. */
@@ -30,6 +31,9 @@ export function mockSubagentActivity(
     ...(options.outcome !== undefined ? { outcome: options.outcome } : {}),
     ...(options.parentToolCallId !== undefined
       ? { parentToolCallId: options.parentToolCallId }
+      : {}),
+    ...(options.transcriptAvailable !== undefined
+      ? { transcriptAvailable: options.transcriptAvailable }
       : {}),
   } satisfies ConversationSubagentActivityReport;
 }

--- a/packages/junior-dashboard/tests/dashboard-mock-routes.test.ts
+++ b/packages/junior-dashboard/tests/dashboard-mock-routes.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { JuniorReporting } from "@sentry/junior/reporting";
+import type {
+  ConversationSubagentTranscriptReport as DashboardConversationSubagentTranscript,
+  JuniorReporting,
+} from "@sentry/junior/reporting";
 import { createDashboardApp } from "../src/app";
 import {
   createMockConversationReporting,
@@ -107,6 +110,22 @@ function reporting(): JuniorReporting {
             transcript: [],
           },
         ],
+      };
+    },
+    async getConversationSubagentTranscript(
+      _conversationId,
+      _runId,
+      subagentId,
+    ) {
+      return {
+        type: "subagent",
+        createdAt: "2026-05-29T00:00:00.000Z",
+        id: subagentId,
+        status: "error",
+        subagentKind: "unknown",
+        transcript: [],
+        transcriptAvailable: false,
+        unavailableReason: "not_found",
       };
     },
   };
@@ -265,27 +284,84 @@ describe("dashboard mock conversation routes", () => {
       invertedRun?.transcript[0]?.timestamp ?? 0,
     );
     const advisorRun = qaConversationBody.runs[2];
-    expect(advisorRun?.id).toBe("mock-dashboard-qa-advisor-subagent");
+    expect(advisorRun?.id).toBe("mock-dashboard-qa-advisor-code-change");
     expect(
       advisorRun?.transcript
         .flatMap((message) => message.parts)
         .filter((part) => part.name === "advisor")
         .map((part) => part.type),
-    ).toEqual(["tool_call", "tool_result"]);
+    ).toEqual(["tool_call", "tool_result", "tool_call", "tool_result"]);
     expect(advisorRun?.activity?.[0]).toMatchObject({
       type: "tool_execution",
       status: "completed",
-      toolCallId: "toolu_mock_dashboard_advisor",
+      toolCallId: "toolu_mock_dashboard_advisor_plan",
       toolName: "advisor",
       subagents: [
         {
           type: "subagent",
           status: "completed",
           subagentKind: "advisor",
-          parentToolCallId: "toolu_mock_dashboard_advisor",
+          parentToolCallId: "toolu_mock_dashboard_advisor_plan",
+          transcriptAvailable: true,
         },
       ],
     });
+    expect(advisorRun?.activity?.[3]).toMatchObject({
+      type: "tool_execution",
+      status: "completed",
+      toolCallId: "toolu_mock_dashboard_advisor_review",
+      toolName: "advisor",
+      subagents: [
+        {
+          type: "subagent",
+          status: "completed",
+          subagentKind: "advisor",
+          parentToolCallId: "toolu_mock_dashboard_advisor_review",
+          transcriptAvailable: true,
+        },
+      ],
+    });
+
+    const firstAdvisorTranscript = await app.fetch(
+      new Request(
+        `http://localhost/api/conversations/${encodeURIComponent(
+          DASHBOARD_QA_CONVERSATION_ID,
+        )}/runs/mock-dashboard-qa-advisor-code-change/subagents/toolu_mock_dashboard_advisor_plan`,
+      ),
+    );
+    expect(firstAdvisorTranscript.status).toBe(200);
+    const firstAdvisorBody =
+      (await firstAdvisorTranscript.json()) as DashboardConversationSubagentTranscript;
+    expect(firstAdvisorBody.subagentConversationId).toBe(
+      "junior:internal:dashboard-qa:advisor_session",
+    );
+    expect(firstAdvisorBody.subagentSentryConversationUrl).toContain(
+      encodeURIComponent("junior:internal:dashboard-qa:advisor_session"),
+    );
+    expect(firstAdvisorBody.transcriptAvailable).toBe(true);
+    expect(JSON.stringify(firstAdvisorBody.transcript)).toContain(
+      "Review the dashboard plan before editing",
+    );
+    expect(JSON.stringify(firstAdvisorBody.transcript)).not.toContain(
+      "Review the implementation after the first advisor pass",
+    );
+
+    const secondAdvisorTranscript = await app.fetch(
+      new Request(
+        `http://localhost/api/conversations/${encodeURIComponent(
+          DASHBOARD_QA_CONVERSATION_ID,
+        )}/runs/mock-dashboard-qa-advisor-code-change/subagents/toolu_mock_dashboard_advisor_review`,
+      ),
+    );
+    expect(secondAdvisorTranscript.status).toBe(200);
+    const secondAdvisorBody =
+      (await secondAdvisorTranscript.json()) as DashboardConversationSubagentTranscript;
+    expect(JSON.stringify(secondAdvisorBody.transcript)).toContain(
+      "Review the dashboard plan before editing",
+    );
+    expect(JSON.stringify(secondAdvisorBody.transcript)).toContain(
+      "Review the implementation after the first advisor pass",
+    );
 
     const longConversation = await app.fetch(
       new Request(

--- a/packages/junior-dashboard/tests/dashboard-mock-routes.test.ts
+++ b/packages/junior-dashboard/tests/dashboard-mock-routes.test.ts
@@ -209,6 +209,22 @@ describe("dashboard mock conversation routes", () => {
     );
     expect(statsBody.durationMs).toBeLessThan(rawDurationMs);
 
+    const people = await app.fetch(new Request("http://localhost/api/people"));
+    expect(people.status).toBe(200);
+    const peopleBody = (await people.json()) as {
+      sampleSize: number;
+    };
+    expect(peopleBody.sampleSize).toBe(
+      new Set(
+        conversationBody.conversations.map(
+          (conversation) => conversation.conversationId,
+        ),
+      ).size - 1,
+    );
+    expect(peopleBody.sampleSize).toBeLessThan(
+      conversationBody.conversations.length,
+    );
+
     const activeConversation = await app.fetch(
       new Request(
         "http://localhost/api/conversations/slack%3ACQA123%3A1770003600.000200",

--- a/packages/junior-dashboard/tests/dashboard-routes.test.ts
+++ b/packages/junior-dashboard/tests/dashboard-routes.test.ts
@@ -77,6 +77,10 @@ function reporting(): JuniorReporting {
             surface: "slack",
             displayTitle: "Conversation",
             channel: "C1",
+            requesterIdentity: {
+              email: "person@sentry.io",
+              fullName: "Person Example",
+            },
           },
         ],
       };
@@ -123,6 +127,107 @@ function reporting(): JuniorReporting {
     async listRecentConversations() {
       return [];
     },
+    async listRequesters() {
+      return {
+        generatedAt: "2026-05-29T00:00:00.000Z",
+        people: [
+          {
+            active: 1,
+            activeDays: 1,
+            conversations: 1,
+            durationMs: 0,
+            failed: 0,
+            firstSeenAt: "2026-05-29T00:00:00.000Z",
+            hung: 0,
+            lastSeenAt: "2026-05-29T00:00:01.000Z",
+            requester: {
+              email: "person@sentry.io",
+              fullName: "Person Example",
+            },
+            runs: 1,
+          },
+        ],
+        sampleLimit: 1,
+        sampleSize: 1,
+        source: "conversation_index",
+        truncated: false,
+      };
+    },
+    async getRequesterProfile(email: string) {
+      return {
+        activityDays: [
+          {
+            active: 1,
+            conversations: 1,
+            date: "2026-05-29",
+            durationMs: 0,
+            failed: 0,
+            hung: 0,
+            runs: 1,
+          },
+        ],
+        generatedAt: "2026-05-29T00:00:00.000Z",
+        locations: [
+          {
+            active: 1,
+            conversations: 1,
+            durationMs: 0,
+            failed: 0,
+            hung: 0,
+            label: "Public Channel",
+            runs: 1,
+          },
+        ],
+        recentConversations: [
+          {
+            conversationId: "slack:C1:123",
+            cumulativeDurationMs: 0,
+            id: "turn-1",
+            status: "active",
+            startedAt: "2026-05-29T00:00:00.000Z",
+            lastSeenAt: "2026-05-29T00:00:01.000Z",
+            lastProgressAt: "2026-05-29T00:00:01.000Z",
+            surface: "slack",
+            displayTitle: "Conversation",
+            channel: "C1",
+            requesterIdentity: {
+              email,
+              fullName: "Person Example",
+            },
+          },
+        ],
+        requester: {
+          email,
+          fullName: "Person Example",
+        },
+        sampleLimit: 1,
+        sampleSize: 1,
+        source: "conversation_index",
+        surfaces: [
+          {
+            active: 1,
+            conversations: 1,
+            durationMs: 0,
+            failed: 0,
+            hung: 0,
+            label: "Conversation",
+            runs: 1,
+          },
+        ],
+        totals: {
+          active: 1,
+          activeDays: 1,
+          conversations: 1,
+          durationMs: 0,
+          failed: 0,
+          hung: 0,
+          runs: 1,
+        },
+        truncated: false,
+        windowEnd: "2026-05-29T00:00:00.000Z",
+        windowStart: "2025-05-29T00:00:00.000Z",
+      };
+    },
     async getPluginOperationalReports() {
       return {
         source: "plugins",
@@ -168,6 +273,30 @@ function reporting(): JuniorReporting {
                 ],
               },
             ],
+          },
+        ],
+      };
+    },
+    async getConversationSubagentTranscript(
+      _conversationId,
+      _runId,
+      subagentId,
+    ) {
+      return {
+        type: "subagent",
+        createdAt: "2026-05-29T00:00:01.000Z",
+        endedAt: "2026-05-29T00:00:02.000Z",
+        id: subagentId,
+        outcome: "success",
+        parentToolCallId: "advisor-call",
+        status: "success",
+        subagentKind: "advisor",
+        transcriptAvailable: true,
+        transcriptMessageCount: 1,
+        transcript: [
+          {
+            role: "assistant",
+            parts: [{ type: "text", text: "Advisor transcript." }],
           },
         ],
       };
@@ -411,8 +540,11 @@ describe("dashboard routes", () => {
       "/api/skills",
       "/api/conversations",
       "/api/conversations/stats",
+      "/api/people",
+      "/api/people/person%40sentry.io",
       "/api/plugin-reports",
       "/api/conversations/slack%3AC1%3A123",
+      "/api/conversations/slack%3AC1%3A123/runs/turn-1/subagents/advisor-call",
       "/api/config",
       "/api/me",
     ]) {
@@ -477,14 +609,19 @@ describe("dashboard routes", () => {
       },
     });
 
-    const response = await app.fetch(
-      new Request("http://localhost/conversations"),
-    );
+    for (const path of [
+      "/conversations",
+      "/people",
+      "/people/person%40sentry.io",
+      "/plugins",
+    ]) {
+      const response = await app.fetch(new Request(`http://localhost${path}`));
 
-    expect(response.status).toBe(200);
-    expect(response.headers.get("content-type")).toContain("text/html");
-    const html = await response.text();
-    expect(html).toContain("<title>Junior</title>");
+      expect(response.status, path).toBe(200);
+      expect(response.headers.get("content-type"), path).toContain("text/html");
+      const html = await response.text();
+      expect(html, path).toContain("<title>Junior</title>");
+    }
   });
 
   it("serves the dashboard client bundle without browser caching", async () => {
@@ -575,6 +712,38 @@ describe("dashboard routes", () => {
         },
       ],
       source: "plugins",
+    });
+
+    const people = await app.fetch(new Request("http://localhost/api/people"));
+    expect(people.status).toBe(200);
+    expect(await people.json()).toMatchObject({
+      people: [
+        {
+          conversations: 1,
+          requester: {
+            email: "person@sentry.io",
+          },
+        },
+      ],
+      source: "conversation_index",
+    });
+
+    const profile = await app.fetch(
+      new Request("http://localhost/api/people/person%40sentry.io"),
+    );
+    expect(profile.status).toBe(200);
+    expect(await profile.json()).toMatchObject({
+      recentConversations: [
+        {
+          conversationId: "slack:C1:123",
+        },
+      ],
+      requester: {
+        email: "person@sentry.io",
+      },
+      totals: {
+        conversations: 1,
+      },
     });
   });
 
@@ -761,6 +930,36 @@ describe("dashboard routes", () => {
               ],
             },
           ],
+        },
+      ],
+    });
+  });
+
+  it("returns authenticated subagent transcript details", async () => {
+    const app = dashboard({
+      user: {
+        email: "person@sentry.io",
+        emailVerified: true,
+        hostedDomain: "sentry.io",
+      },
+    });
+
+    const response = await app.fetch(
+      new Request(
+        "http://localhost/api/conversations/slack%3AC1%3A123/runs/turn-1/subagents/advisor-call",
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      id: "advisor-call",
+      parentToolCallId: "advisor-call",
+      subagentKind: "advisor",
+      transcriptAvailable: true,
+      transcript: [
+        {
+          role: "assistant",
+          parts: [{ type: "text", text: "Advisor transcript." }],
         },
       ],
     });

--- a/packages/junior-dashboard/tests/format.test.ts
+++ b/packages/junior-dashboard/tests/format.test.ts
@@ -7,6 +7,9 @@ import {
   conversationFromDetail,
   conversationIdentityMeta,
   conversationRequesterLabel,
+  conversationRequesterOptions,
+  conversationSourceOptions,
+  filterConversationList,
   formatConversationDuration,
   formatDurationTotal,
   formatDurationTick,
@@ -477,6 +480,63 @@ describe("dashboard token formatting", () => {
     expect(conversationIdentityMeta(conversation, conversation?.id)).toBe(
       "alice · slack:C1:123",
     );
+  });
+
+  it("filters conversation rows by text, source, and requester", () => {
+    const conversations = buildConversations([
+      {
+        channel: "C1",
+        channelName: "proj-checkout",
+        conversationId: "slack:C1:123",
+        cumulativeDurationMs: 0,
+        displayTitle: "Checkout latency triage",
+        id: "turn-1",
+        lastProgressAt: "2026-06-01T10:05:00.000Z",
+        lastSeenAt: "2026-06-01T10:05:00.000Z",
+        requesterIdentity: {
+          email: "morgan@example.com",
+          fullName: "Morgan Lee",
+        },
+        startedAt: "2026-06-01T10:00:00.000Z",
+        status: "completed",
+        surface: "slack",
+      },
+      {
+        conversationId: "internal:memory:456",
+        cumulativeDurationMs: 0,
+        displayTitle: "Memory cleanup",
+        id: "turn-2",
+        lastProgressAt: "2026-06-01T11:05:00.000Z",
+        lastSeenAt: "2026-06-01T11:05:00.000Z",
+        requesterIdentity: { fullName: "Casey" },
+        startedAt: "2026-06-01T11:00:00.000Z",
+        status: "completed",
+        surface: "internal",
+      },
+    ]);
+
+    expect(conversationSourceOptions(conversations)).toEqual([
+      { label: "internal", value: "internal" },
+      { label: "slack", value: "slack" },
+    ]);
+    expect(conversationRequesterOptions(conversations)).toEqual([
+      { label: "Casey", value: "Casey" },
+      { label: "Morgan Lee", value: "morgan@example.com" },
+    ]);
+    expect(
+      filterConversationList(conversations, {
+        query: "checkout",
+        requester: "morgan@example.com",
+        source: "slack",
+      }).map((conversation) => conversation.id),
+    ).toEqual(["slack:C1:123"]);
+    expect(
+      filterConversationList(conversations, {
+        query: "checkout",
+        requester: "Casey",
+        source: "slack",
+      }),
+    ).toEqual([]);
   });
 
   it("formats conversation spans with the compact conversation duration rules", () => {

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -23,7 +23,7 @@ import { client } from "../src/client/api";
 import { CommandCenter } from "../src/client/pages/CommandCenter";
 import { ConversationPage } from "../src/client/pages/ConversationPage";
 import { ConversationsPage } from "../src/client/pages/ConversationsPage";
-import { Profile } from "../src/client/pages/PeoplePage";
+import { PeoplePageContent, Profile } from "../src/client/pages/PeoplePage";
 import { PluginsPage } from "../src/client/pages/PluginsPage";
 import type {
   ConversationDetailFeed,
@@ -377,6 +377,21 @@ describe("dashboard telemetry components", () => {
     expect(html).not.toContain(">runs<");
     expect(html).not.toContain(">attention<");
     expect(html).not.toContain(">People</a>");
+  });
+
+  it("renders people load failures separately from empty telemetry", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <PeoplePageContent
+          data={undefined}
+          error={new Error("people failed")}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(html).toContain("People failed to load");
+    expect(html).toContain("People telemetry is unavailable");
+    expect(html).not.toContain("No requester telemetry with trusted email");
   });
 
   it("keeps completed status badges quiet unless explicitly requested", () => {

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -9,7 +9,13 @@ import { Button } from "../src/client/components/Button";
 import { FilterTabs } from "../src/client/components/FilterTabs";
 import { PluginReports } from "../src/client/components/PluginReports";
 import { StatusBadge } from "../src/client/components/StatusBadge";
+import {
+  SubagentTranscriptDrawer,
+  type SubagentTranscriptTarget,
+} from "../src/client/components/SubagentTranscriptDrawer";
+import { ToolValueInspector } from "../src/client/components/ToolValueInspector";
 import { TranscriptHeader } from "../src/client/components/TranscriptHeader";
+import { TranscriptSubagentView } from "../src/client/components/TranscriptSubagentView";
 import { TranscriptToolView } from "../src/client/components/TranscriptToolView";
 import { ConversationTranscriptSegment } from "../src/client/components/TranscriptTurn";
 import { ConversationDurationChart } from "../src/client/components/ConversationDurationChart";
@@ -17,12 +23,14 @@ import { client } from "../src/client/api";
 import { CommandCenter } from "../src/client/pages/CommandCenter";
 import { ConversationPage } from "../src/client/pages/ConversationPage";
 import { ConversationsPage } from "../src/client/pages/ConversationsPage";
+import { Profile } from "../src/client/pages/PeoplePage";
 import { PluginsPage } from "../src/client/pages/PluginsPage";
 import type {
   ConversationDetailFeed,
   ConversationSummary,
   ConversationTurn,
   DashboardData,
+  RequesterProfile,
 } from "../src/client/types";
 
 afterEach(() => {
@@ -174,6 +182,201 @@ describe("dashboard telemetry components", () => {
     expect(transcript).not.toContain(">Transcript<");
     expect(transcript.match(/aria-pressed="true"/g) ?? []).toHaveLength(1);
     expect(transcript.match(/aria-pressed="false"/g) ?? []).toHaveLength(1);
+  });
+
+  it("renders transcript-backed subagent rows as inspectable events", () => {
+    const html = renderToStaticMarkup(
+      <TranscriptSubagentView
+        onOpenTranscript={() => {}}
+        part={{
+          id: "advisor-call",
+          outcome: "success",
+          parentToolCallId: "advisor-call",
+          status: "success",
+          subagentKind: "advisor",
+          transcriptAvailable: true,
+          type: "subagent",
+        }}
+        timestamp={Date.parse("2026-01-01T00:00:00.000Z")}
+      />,
+    );
+
+    expect(html).toContain("advisor");
+    expect(html).not.toContain("advisor subagent");
+    expect(html).toContain('aria-label="Open advisor transcript"');
+  });
+
+  it("renders advisor drawer headers with conversation identity", () => {
+    const target = {
+      conversationId: "parent-conversation",
+      part: {
+        id: "advisor-call",
+        outcome: "success",
+        parentToolCallId: "advisor-call",
+        status: "success",
+        subagentKind: "advisor",
+        transcriptAvailable: true,
+        type: "subagent",
+      },
+      turn: {
+        conversationId: "parent-conversation",
+        cumulativeDurationMs: 1000,
+        displayTitle: "Parent conversation",
+        id: "turn-1",
+        lastProgressAt: "2026-01-01T00:00:01.000Z",
+        lastSeenAt: "2026-01-01T00:00:01.000Z",
+        startedAt: "2026-01-01T00:00:00.000Z",
+        status: "completed",
+        surface: "internal",
+        transcript: [],
+        transcriptAvailable: true,
+      },
+    } satisfies SubagentTranscriptTarget;
+    client.setQueryData(
+      [
+        "conversation-subagent",
+        "parent-conversation",
+        "turn-1",
+        "advisor-call",
+      ],
+      {
+        type: "subagent",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        endedAt: "2026-01-01T00:00:01.000Z",
+        id: "advisor-call",
+        outcome: "success",
+        parentToolCallId: "advisor-call",
+        status: "success",
+        subagentConversationId: "junior:parent-conversation:advisor_session",
+        subagentKind: "advisor",
+        subagentSentryConversationUrl:
+          "https://sentry.example/explore/conversations/advisor",
+        transcript: [],
+        transcriptAvailable: false,
+      },
+    );
+
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={client}>
+        <SubagentTranscriptDrawer target={target} onClose={() => {}} />
+      </QueryClientProvider>,
+    );
+
+    expect(html).toContain(">advisor<");
+    expect(html).not.toContain("advisor subagent");
+    expect(html).toContain("Conversation ID");
+    expect(html).toContain("junior:parent-conversation:advisor_session");
+    expect(html).toContain("View in Sentry");
+    expect(html).toContain(
+      "https://sentry.example/explore/conversations/advisor",
+    );
+  });
+
+  it("renders requester profiles with activity and recent conversations", () => {
+    const profile: RequesterProfile = {
+      activityDays: [
+        {
+          active: 0,
+          conversations: 0,
+          date: "2026-01-01",
+          durationMs: 0,
+          failed: 0,
+          hung: 0,
+          runs: 0,
+        },
+        {
+          active: 0,
+          conversations: 2,
+          date: "2026-01-02",
+          durationMs: 1_200,
+          failed: 0,
+          hung: 0,
+          runs: 2,
+        },
+      ],
+      generatedAt: "2026-01-02T00:00:00.000Z",
+      locations: [
+        {
+          active: 0,
+          conversations: 2,
+          durationMs: 1_200,
+          failed: 0,
+          hung: 0,
+          label: "#proj-alpha",
+          runs: 2,
+        },
+      ],
+      recentConversations: [
+        {
+          conversationId: "slack:C1:123",
+          cumulativeDurationMs: 1_200,
+          displayTitle: "Incident triage",
+          id: "turn-1",
+          lastProgressAt: "2026-01-02T00:00:00.000Z",
+          lastSeenAt: "2026-01-02T00:00:00.000Z",
+          requesterIdentity: {
+            email: "avery@example.com",
+            fullName: "Avery Example",
+          },
+          startedAt: "2026-01-02T00:00:00.000Z",
+          status: "completed",
+          surface: "slack",
+        },
+      ],
+      requester: {
+        email: "avery@example.com",
+        fullName: "Avery Example",
+        slackUserName: "avery",
+      },
+      sampleLimit: 10,
+      sampleSize: 1,
+      source: "conversation_index",
+      surfaces: [
+        {
+          active: 0,
+          conversations: 2,
+          durationMs: 1_200,
+          failed: 0,
+          hung: 0,
+          label: "Conversation",
+          runs: 2,
+        },
+      ],
+      totals: {
+        active: 0,
+        activeDays: 1,
+        conversations: 2,
+        durationMs: 1_200,
+        failed: 0,
+        hung: 0,
+        runs: 2,
+      },
+      truncated: false,
+      windowEnd: "2026-01-02T00:00:00.000Z",
+      windowStart: "2025-01-02T00:00:00.000Z",
+    };
+
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <Profile profile={profile} />
+      </MemoryRouter>,
+    );
+
+    expect(html).toContain("Avery Example");
+    expect(html).toContain("avery@example.com");
+    expect(html).toContain("Activity");
+    expect(html).toContain("Incident triage");
+    expect(html).toContain("Daily Junior conversation activity");
+    expect(html).toContain(">Jan<");
+    expect(html).toContain(">Less<");
+    expect(html).toContain(">More<");
+    expect(html).toContain('href="/people/avery%40example.com"');
+    expect(html).toContain('aria-label="Search recent conversations"');
+    expect(html).not.toContain(">Places<");
+    expect(html).not.toContain(">active days<");
+    expect(html).not.toContain(">runs<");
+    expect(html).not.toContain(">attention<");
+    expect(html).not.toContain(">People</a>");
   });
 
   it("keeps completed status badges quiet unless explicitly requested", () => {
@@ -496,7 +699,7 @@ describe("dashboard telemetry components", () => {
     expect(html).not.toContain('aria-label="Execution activity"');
     expect(html).not.toContain("Execution Activity");
     expect(html).toContain("advisor");
-    expect(html).toContain("advisor subagent");
+    expect(html).not.toContain("advisor subagent");
     expect(html).toContain("running");
     expect(html.indexOf("advisor")).toBeGreaterThan(
       html.indexOf('aria-label="Transcript view"'),
@@ -574,6 +777,57 @@ describe("dashboard telemetry components", () => {
     expect(conversations).toContain("mx-auto w-full min-w-0 max-w-screen-xl");
     expect(command).toContain("mx-auto grid w-full min-w-0 max-w-screen-xl");
     expect(plugins).toContain("mx-auto w-full min-w-0 max-w-screen-xl");
+  });
+
+  it("filters the conversation list with search and facets", () => {
+    const data = dashboardData([
+      {
+        channel: "C1",
+        channelName: "proj-checkout",
+        conversationId: "slack:C1:100",
+        cumulativeDurationMs: 1_000,
+        displayTitle: "Checkout latency triage",
+        id: "turn-1",
+        lastProgressAt: "2026-01-01T00:00:01.000Z",
+        lastSeenAt: "2026-01-01T00:00:02.000Z",
+        requesterIdentity: {
+          email: "morgan@example.com",
+          fullName: "Morgan",
+        },
+        startedAt: "2026-01-01T00:00:00.000Z",
+        status: "completed",
+        surface: "slack",
+      },
+      {
+        conversationId: "internal:memory:200",
+        cumulativeDurationMs: 2_000,
+        displayTitle: "Memory cleanup",
+        id: "turn-2",
+        lastProgressAt: "2026-01-01T00:02:01.000Z",
+        lastSeenAt: "2026-01-01T00:02:02.000Z",
+        requesterIdentity: { fullName: "Casey" },
+        startedAt: "2026-01-01T00:02:00.000Z",
+        status: "completed",
+        surface: "internal",
+      },
+    ]);
+
+    const html = renderToStaticMarkup(
+      <MemoryRouter
+        initialEntries={[
+          "/conversations?q=checkout&source=slack&requester=morgan%40example.com",
+        ]}
+      >
+        <ConversationsPage data={data} />
+      </MemoryRouter>,
+    );
+
+    expect(html).toContain('aria-label="Search conversations"');
+    expect(html).toContain('aria-label="Source"');
+    expect(html).toContain('aria-label="Requester"');
+    expect(html).toContain("Checkout latency triage");
+    expect(html).toContain("1 of 2 conversations");
+    expect(html).not.toContain("Memory cleanup");
   });
 
   it("renders aggregate stats and plugin reports", () => {
@@ -690,8 +944,8 @@ describe("dashboard telemetry components", () => {
     );
 
     expect(commandHtml).toContain(">Stats<");
-    expect(commandHtml).toContain(">People<");
-    expect(commandHtml).toContain("Avery");
+    expect(commandHtml).not.toContain(">People<");
+    expect(commandHtml).not.toContain(">Places<");
     expect(commandHtml).not.toContain("Casey");
     expect(commandHtml).not.toContain("Old thread");
     expect(pluginHtml).toContain(">Plugins<");
@@ -910,6 +1164,68 @@ describe("dashboard telemetry components", () => {
     expect(html).toContain("<details");
   });
 
+  it("renders expanded tool payloads as structured key/value rows", () => {
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={client}>
+        <TranscriptToolView
+          call={{
+            input: {
+              filters: { environment: "production", release: "2026.1.0" },
+              query: "checkout latency",
+              teams: ["growth", "payments"],
+            },
+            name: "sentry.search_traces",
+            type: "tool_call",
+          }}
+          result={{
+            name: "sentry.search_traces",
+            output: {
+              rows: [
+                { count: 12, endpoint: "/checkout", p95: 842 },
+                { count: 5, endpoint: "/cart", p95: 310 },
+              ],
+              summary: "Checkout p95 regressed after deploy.",
+            },
+            type: "tool_result",
+          }}
+          resultTimestamp={10}
+          timestamp={0}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(html).toContain(">arguments<");
+    expect(html).toContain(">result<");
+    expect(html).toContain("checkout latency");
+    expect(html).toContain("environment");
+    expect(html).toContain("production");
+    expect(html).toContain("<table");
+    expect(html).toContain("/checkout");
+    expect(html).not.toContain("language-json");
+  });
+
+  it("renders generic tool values without dumping one JSON blob", () => {
+    const html = renderToStaticMarkup(
+      <ToolValueInspector
+        value={{
+          command: "pnpm test",
+          files: [
+            { added: 12, path: "src/a.ts" },
+            { added: 4, path: "src/b.ts" },
+          ],
+          stdout: "line one\nline two",
+        }}
+      />,
+    );
+
+    expect(html).toContain("command");
+    expect(html).toContain("pnpm test");
+    expect(html).toContain("<table");
+    expect(html).toContain("src/a.ts");
+    expect(html).toContain("line one");
+    expect(html).not.toContain("{&quot;command&quot;");
+  });
+
   it("does not highlight static tool summaries as expandable", () => {
     const html = renderToStaticMarkup(
       <QueryClientProvider client={client}>
@@ -981,22 +1297,24 @@ describe("dashboard telemetry components", () => {
     expect(html).toContain("Checking MCP output");
   });
 
-  it("collapses four consecutive tool calls to a reveal divider", () => {
+  it("renders four consecutive tool calls behind a reveal disclosure", () => {
     const html = renderToStaticMarkup(
       <QueryClientProvider client={client}>
         <ConversationTranscriptSegment turn={toolRunTurn(4)} view="rich" />
       </QueryClientProvider>,
     );
 
+    expect(html).toContain('<details class="min-w-0"><summary');
     expect(html).toContain("show 4 tool calls");
     expect(html).not.toContain("collapse");
+    expect(html).not.toContain('aria-expanded="false"');
     expect(html).toContain("cursor-pointer");
     expect(html).toContain("py-1.5 text-left font-mono");
     expect(html).not.toContain("pl-3 text-left font-mono");
-    expect(html).not.toContain("tool-0");
-    expect(html).not.toContain("tool-1");
-    expect(html).not.toContain("tool-2");
-    expect(html).not.toContain("tool-3");
+    expect(html).toContain("tool-0");
+    expect(html).toContain("tool-1");
+    expect(html).toContain("tool-2");
+    expect(html).toContain("tool-3");
   });
 
   it("keeps three consecutive tool calls expanded", () => {

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -743,6 +743,10 @@ describe("dashboard telemetry components", () => {
       status: "completed",
       surface: "slack",
       displayTitle: "Conversation",
+      requesterIdentity: {
+        email: "avery@example.com",
+        fullName: "Avery Example",
+      },
     } satisfies ConversationSummary;
     const detail = {
       conversationId: "conversation-1",
@@ -762,6 +766,7 @@ describe("dashboard telemetry components", () => {
 
     const html = renderConversationPage(dashboardData([summary]));
 
+    expect(html).toContain('href="/people/avery%40example.com"');
     expect(html).toContain("View in Sentry");
     expect(html).toContain(
       "https://sentry.example/explore/conversations/conversation-1/?project=1",

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -370,6 +370,17 @@ describe("dashboard telemetry components", () => {
     expect(html).toContain(">Jan<");
     expect(html).toContain(">Less<");
     expect(html).toContain(">More<");
+    const activityStart = html.indexOf(
+      'aria-label="Daily Junior conversation activity"',
+    );
+    expect(
+      html
+        .slice(
+          activityStart,
+          html.indexOf('aria-label="2026-01-01: 0 conversations"'),
+        )
+        .match(/class="size-3 border border-black\/40 bg-\[#101010\]"/g),
+    ).toHaveLength(4);
     expect(html).toContain('href="/people/avery%40example.com"');
     expect(html).toContain('aria-label="Search recent conversations"');
     expect(html).not.toContain(">Places<");

--- a/packages/junior/src/app.ts
+++ b/packages/junior/src/app.ts
@@ -359,7 +359,15 @@ function dashboardHostRoutePaths(dashboard: JuniorDashboardOptions): string[] {
   const authPath = normalizeDashboardPath(dashboard.authPath, "/api/auth");
   const pagePaths =
     basePath === "/"
-      ? ["/", "/conversations", "/conversations/*", "/plugins", "/plugins/*"]
+      ? [
+          "/",
+          "/conversations",
+          "/conversations/*",
+          "/people",
+          "/people/*",
+          "/plugins",
+          "/plugins/*",
+        ]
       : [basePath, `${basePath}/*`];
   const loginPath = basePath === "/" ? "/auth/login" : `${basePath}/auth/login`;
 
@@ -376,6 +384,8 @@ function dashboardHostRoutePaths(dashboard: JuniorDashboardOptions): string[] {
     "/api/skills",
     "/api/conversations",
     "/api/conversations/*",
+    "/api/people",
+    "/api/people/*",
     "/api/config",
     "/api/me",
     authPath,

--- a/packages/junior/src/chat/state/session-log.ts
+++ b/packages/junior/src/chat/state/session-log.ts
@@ -135,6 +135,8 @@ const subagentEndedEntrySchema = z.object({
     z.literal("aborted"),
   ]),
   errorCode: z.string().min(1).optional(),
+  transcriptEndMessageIndex: z.number().int().nonnegative().optional(),
+  transcriptStartMessageIndex: z.number().int().nonnegative().optional(),
   createdAtMs: z.number().int().nonnegative(),
 });
 
@@ -453,6 +455,8 @@ function subagentEndedEntry(args: {
   outcome: "success" | "error" | "aborted";
   sessionId: string;
   subagentInvocationId: string;
+  transcriptEndMessageIndex?: number;
+  transcriptStartMessageIndex?: number;
 }): SessionLogEntry {
   return {
     schemaVersion: AGENT_SESSION_LOG_SCHEMA_VERSION,
@@ -461,6 +465,12 @@ function subagentEndedEntry(args: {
     subagentInvocationId: args.subagentInvocationId,
     outcome: args.outcome,
     ...(args.errorCode ? { errorCode: args.errorCode } : {}),
+    ...(args.transcriptEndMessageIndex !== undefined
+      ? { transcriptEndMessageIndex: args.transcriptEndMessageIndex }
+      : {}),
+    ...(args.transcriptStartMessageIndex !== undefined
+      ? { transcriptStartMessageIndex: args.transcriptStartMessageIndex }
+      : {}),
     createdAtMs: args.createdAtMs,
   };
 }
@@ -914,6 +924,8 @@ export async function recordSubagentEnded(
     sessionId?: string;
     store?: SessionLogStore;
     subagentInvocationId: string;
+    transcriptEndMessageIndex?: number;
+    transcriptStartMessageIndex?: number;
     ttlMs: number;
   },
 ): Promise<void> {
@@ -929,6 +941,8 @@ export async function recordSubagentEnded(
         outcome: args.outcome,
         sessionId,
         subagentInvocationId: args.subagentInvocationId,
+        transcriptEndMessageIndex: args.transcriptEndMessageIndex,
+        transcriptStartMessageIndex: args.transcriptStartMessageIndex,
       }),
     ],
     ttlMs: args.ttlMs,

--- a/packages/junior/src/chat/tools/advisor/tool.ts
+++ b/packages/junior/src/chat/tools/advisor/tool.ts
@@ -197,6 +197,10 @@ export function createAdvisorTool(context: AdvisorToolRuntimeContext) {
       const endSubagent = async (
         outcome: "success" | "error" | "aborted",
         errorCode?: AdvisorErrorCode,
+        transcriptRange?: {
+          endMessageIndex: number;
+          startMessageIndex: number;
+        },
       ) =>
         recordSubagentEnded({
           conversationId,
@@ -204,6 +208,12 @@ export function createAdvisorTool(context: AdvisorToolRuntimeContext) {
           subagentInvocationId,
           outcome,
           ...(errorCode ? { errorCode } : {}),
+          ...(transcriptRange
+            ? {
+                transcriptEndMessageIndex: transcriptRange.endMessageIndex,
+                transcriptStartMessageIndex: transcriptRange.startMessageIndex,
+              }
+            : {}),
           ttlMs: THREAD_STATE_TTL_MS,
         });
       await recordSubagentStarted({
@@ -342,7 +352,10 @@ export function createAdvisorTool(context: AdvisorToolRuntimeContext) {
               "Advisor guidance is unavailable because advisor history could not be saved. Retry the advisor call or continue without assuming advisor history.",
             );
           }
-          await endSubagent("success");
+          await endSubagent("success", undefined, {
+            endMessageIndex: advisorAgent.state.messages.length,
+            startMessageIndex: beforeMessageCount,
+          });
           setSpanStatus("ok");
           return success(memo);
         },

--- a/packages/junior/src/reporting.ts
+++ b/packages/junior/src/reporting.ts
@@ -10,12 +10,18 @@ import { getConversationStore } from "@/chat/db";
 import {
   readConversationFeed,
   readConversationReport,
+  readConversationSubagentTranscriptReport,
   readConversationStatsReport,
+  readRequesterDirectoryReport,
+  readRequesterProfileReport,
   listRecentConversationSummaries,
   type ConversationFeed,
   type PluginConversationSummary,
   type ConversationReport,
+  type ConversationSubagentTranscriptReport,
   type ConversationStatsReport,
+  type RequesterDirectoryReport,
+  type RequesterProfileReport,
 } from "./reporting/conversations";
 
 export type {
@@ -29,13 +35,19 @@ export type {
   ConversationReportStatus,
   ConversationRunReport,
   ConversationSubagentActivityReport,
+  ConversationSubagentTranscriptReport,
   ConversationStatsItem,
   ConversationStatsReport,
   ConversationSummaryReport,
   ConversationSurface,
   ConversationToolActivityReport,
   ConversationUsage,
+  RequesterActivityDayReport,
+  RequesterDirectoryReport,
   RequesterIdentity,
+  RequesterProfileReport,
+  RequesterSummaryReport,
+  RequesterTotalsReport,
   TranscriptMessage,
   TranscriptPart,
   TranscriptPartType,
@@ -102,6 +114,10 @@ export interface JuniorReporting {
   listConversations(): Promise<ConversationFeed>;
   /** Read aggregate conversation stats for reporting consumers. */
   getConversationStats?(): Promise<ConversationStatsReport>;
+  /** List requester profiles derived from trusted conversation requester emails. */
+  listRequesters?(): Promise<RequesterDirectoryReport>;
+  /** Read one requester profile derived from trusted conversation requester emails. */
+  getRequesterProfile?(email: string): Promise<RequesterProfileReport>;
   /** Read recent conversation summaries without transcript payloads. */
   listRecentConversations?(options?: {
     limit?: number;
@@ -116,6 +132,12 @@ export interface JuniorReporting {
    * source. Avoid adding fields that require Redis-only transcript internals.
    */
   getConversation(conversationId: string): Promise<ConversationReport>;
+  /** Load a child-agent transcript only when an operator opens that subagent. */
+  getConversationSubagentTranscript(
+    conversationId: string,
+    runId: string,
+    subagentId: string,
+  ): Promise<ConversationSubagentTranscriptReport>;
 }
 
 function readDescriptionText(): string | undefined {
@@ -152,6 +174,8 @@ async function readPlugins(): Promise<PluginReport[]> {
 /** Create the read-only reporting boundary used by plugins and other consumers. */
 export function createJuniorReporting(): JuniorReporting & {
   getConversationStats(): Promise<ConversationStatsReport>;
+  listRequesters(): Promise<RequesterDirectoryReport>;
+  getRequesterProfile(email: string): Promise<RequesterProfileReport>;
   listRecentConversations(options?: {
     limit?: number;
   }): Promise<PluginConversationSummary[]>;
@@ -185,6 +209,9 @@ export function createJuniorReporting(): JuniorReporting & {
     listConversations: () => readConversationFeed({ conversationStore }),
     getConversationStats: () =>
       readConversationStatsReport({ conversationStore }),
+    listRequesters: () => readRequesterDirectoryReport({ conversationStore }),
+    getRequesterProfile: (email) =>
+      readRequesterProfileReport(email, { conversationStore }),
     listRecentConversations: listRecent,
     getPluginOperationalReports: async () => {
       const nowMs = Date.now();
@@ -198,5 +225,11 @@ export function createJuniorReporting(): JuniorReporting & {
     },
     getConversation: (conversationId) =>
       readConversationReport(conversationId, { conversationStore }),
+    getConversationSubagentTranscript: (conversationId, runId, subagentId) =>
+      readConversationSubagentTranscriptReport(
+        conversationId,
+        runId,
+        subagentId,
+      ),
   };
 }

--- a/packages/junior/src/reporting/conversations.ts
+++ b/packages/junior/src/reporting/conversations.ts
@@ -22,6 +22,7 @@ import {
   buildSentryConversationUrl,
   buildSentryTraceUrl,
 } from "@/chat/sentry-links";
+import { z } from "zod";
 import {
   formatSlackConversationRedactedLabel,
   resolveSlackConversationContextFromThreadId,
@@ -41,6 +42,7 @@ import {
   loadActivityEntries,
   type SessionActivityEntry,
 } from "@/chat/state/session-log";
+import { getStateAdapter } from "@/chat/state/adapter";
 import {
   toStoredSlackRequester,
   type Requester,
@@ -65,6 +67,9 @@ const SAFE_METADATA_KEY_LIMIT = 20;
 const PRIVATE_CONVERSATION_LABEL = "Private Conversation";
 const CONVERSATION_FEED_LIMIT = 50;
 const CONVERSATION_STATS_LIMIT = 5_000;
+const REQUESTER_PROFILE_SAMPLE_LIMIT = 5_000;
+const REQUESTER_PROFILE_RECENT_LIMIT = 25;
+const REQUESTER_PROFILE_ACTIVITY_DAYS = 366;
 const RECENT_CONVERSATION_STATS_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
 interface ConversationReaderOptions {
@@ -196,6 +201,7 @@ export interface ConversationSubagentActivityReport {
   parentToolCallId?: string;
   status: ConversationActivityStatus;
   subagentKind: string;
+  transcriptAvailable?: boolean;
 }
 
 export interface ConversationToolActivityReport extends ActivityPayloadMetadata {
@@ -221,6 +227,28 @@ export interface ConversationReport {
   generatedAt: string;
   sentryConversationUrl?: string;
   runs: ConversationRunReport[];
+}
+
+export interface ConversationSubagentTranscriptReport {
+  type: "subagent";
+  createdAt: string;
+  endedAt?: string;
+  id: string;
+  outcome?: "success" | "error" | "aborted";
+  parentToolCallId?: string;
+  status: ConversationActivityStatus;
+  subagentConversationId?: string;
+  subagentKind: string;
+  subagentSentryConversationUrl?: string;
+  transcript: TranscriptMessage[];
+  transcriptAvailable: boolean;
+  transcriptMessageCount?: number;
+  transcriptRedacted?: boolean;
+  transcriptRedactionReason?: "non_public_conversation";
+  unavailableReason?:
+    | "missing_transcript_range"
+    | "missing_transcript_ref"
+    | "not_found";
 }
 
 export interface ConversationFeed {
@@ -255,6 +283,59 @@ export interface ConversationStatsReport {
   tokens?: number;
   truncated: boolean;
   runs: number;
+  windowEnd: string;
+  windowStart: string;
+}
+
+export interface RequesterActivityDayReport {
+  active: number;
+  conversations: number;
+  date: string;
+  durationMs: number;
+  failed: number;
+  hung: number;
+  runs: number;
+  tokens?: number;
+}
+
+export interface RequesterTotalsReport {
+  active: number;
+  activeDays: number;
+  conversations: number;
+  durationMs: number;
+  failed: number;
+  hung: number;
+  runs: number;
+  tokens?: number;
+}
+
+export interface RequesterSummaryReport extends RequesterTotalsReport {
+  firstSeenAt: string;
+  lastSeenAt: string;
+  requester: RequesterIdentity & { email: string };
+}
+
+export interface RequesterDirectoryReport {
+  generatedAt: string;
+  people: RequesterSummaryReport[];
+  sampleLimit: number;
+  sampleSize: number;
+  source: "conversation_index";
+  truncated: boolean;
+}
+
+export interface RequesterProfileReport {
+  activityDays: RequesterActivityDayReport[];
+  generatedAt: string;
+  locations: ConversationStatsItem[];
+  recentConversations: ConversationSummaryReport[];
+  requester: RequesterIdentity & { email: string };
+  sampleLimit: number;
+  sampleSize: number;
+  source: "conversation_index";
+  surfaces: ConversationStatsItem[];
+  totals: RequesterTotalsReport;
+  truncated: boolean;
   windowEnd: string;
   windowStart: string;
 }
@@ -913,6 +994,364 @@ function buildConversationStatsReport(args: {
   };
 }
 
+function normalizeRequesterEmail(
+  email: string | undefined,
+): string | undefined {
+  const normalized = email?.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+function requesterIdentityWithEmail(
+  requester: RequesterIdentity | undefined,
+): (RequesterIdentity & { email: string }) | undefined {
+  const email = normalizeRequesterEmail(requester?.email);
+  if (!email) return undefined;
+  return {
+    email,
+    ...(requester?.fullName ? { fullName: requester.fullName } : {}),
+    ...(requester?.slackUserId ? { slackUserId: requester.slackUserId } : {}),
+    ...(requester?.slackUserName
+      ? { slackUserName: requester.slackUserName }
+      : {}),
+  };
+}
+
+function mergeRequesterIdentity(
+  current: RequesterIdentity & { email: string },
+  next: RequesterIdentity & { email: string },
+): RequesterIdentity & { email: string } {
+  return {
+    email: current.email,
+    ...((current.fullName ?? next.fullName)
+      ? { fullName: current.fullName ?? next.fullName }
+      : {}),
+    ...((current.slackUserId ?? next.slackUserId)
+      ? { slackUserId: current.slackUserId ?? next.slackUserId }
+      : {}),
+    ...((current.slackUserName ?? next.slackUserName)
+      ? { slackUserName: current.slackUserName ?? next.slackUserName }
+      : {}),
+  };
+}
+
+function reportDate(value: string): string | undefined {
+  const time = reportTime(value);
+  if (time === undefined) return undefined;
+  return new Date(time).toISOString().slice(0, 10);
+}
+
+function emptyRequesterTotals(): RequesterTotalsReport {
+  return {
+    active: 0,
+    activeDays: 0,
+    conversations: 0,
+    durationMs: 0,
+    failed: 0,
+    hung: 0,
+    runs: 0,
+  };
+}
+
+function addRequesterTokens(
+  target: Pick<RequesterTotalsReport, "tokens">,
+  tokens: number | undefined,
+): void {
+  if (tokens !== undefined) {
+    target.tokens = (target.tokens ?? 0) + tokens;
+  }
+}
+
+function addStatsSignals(
+  item: ConversationStatsItem,
+  signals: ReturnType<typeof statusSignals>,
+): void {
+  item.active += signals.active ? 1 : 0;
+  item.failed += signals.failed ? 1 : 0;
+  item.hung += signals.hung ? 1 : 0;
+}
+
+function addConversationSignals(
+  target: Pick<RequesterTotalsReport, "active" | "failed" | "hung">,
+  signals: ReturnType<typeof statusSignals>,
+): void {
+  target.active += signals.active ? 1 : 0;
+  target.failed += signals.failed ? 1 : 0;
+  target.hung += signals.hung ? 1 : 0;
+}
+
+type RequesterDirectoryAccumulator = RequesterTotalsReport & {
+  activeDates: Set<string>;
+  firstSeenMs: number;
+  lastSeenMs: number;
+  requester: RequesterIdentity & { email: string };
+};
+
+function directoryItem(
+  accumulator: RequesterDirectoryAccumulator,
+): RequesterSummaryReport {
+  return {
+    active: accumulator.active,
+    activeDays: accumulator.activeDates.size,
+    conversations: accumulator.conversations,
+    durationMs: accumulator.durationMs,
+    failed: accumulator.failed,
+    firstSeenAt: new Date(accumulator.firstSeenMs).toISOString(),
+    hung: accumulator.hung,
+    lastSeenAt: new Date(accumulator.lastSeenMs).toISOString(),
+    requester: accumulator.requester,
+    runs: accumulator.runs,
+    ...(accumulator.tokens !== undefined ? { tokens: accumulator.tokens } : {}),
+  };
+}
+
+function emptyRequesterActivityDay(date: string): RequesterActivityDayReport {
+  return {
+    active: 0,
+    conversations: 0,
+    date,
+    durationMs: 0,
+    failed: 0,
+    hung: 0,
+    runs: 0,
+  };
+}
+
+function requesterActivityDays(args: {
+  days: Map<string, RequesterActivityDayReport>;
+  nowMs: number;
+}): RequesterActivityDayReport[] {
+  const items: RequesterActivityDayReport[] = [];
+  const end = new Date(args.nowMs);
+  end.setUTCHours(0, 0, 0, 0);
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - (REQUESTER_PROFILE_ACTIVITY_DAYS - 1));
+
+  for (
+    const cursor = new Date(start);
+    cursor.getTime() <= end.getTime();
+    cursor.setUTCDate(cursor.getUTCDate() + 1)
+  ) {
+    const date = cursor.toISOString().slice(0, 10);
+    items.push(args.days.get(date) ?? emptyRequesterActivityDay(date));
+  }
+  return items;
+}
+
+async function requesterSample(options: ConversationReaderOptions = {}) {
+  const conversations = await conversationStore(options).listByActivity({
+    limit: REQUESTER_PROFILE_SAMPLE_LIMIT + 1,
+  });
+  return {
+    conversations: conversations.slice(0, REQUESTER_PROFILE_SAMPLE_LIMIT),
+    truncated: conversations.length > REQUESTER_PROFILE_SAMPLE_LIMIT,
+  };
+}
+
+/** Read the requester directory from durable conversation metadata. */
+export async function readRequesterDirectoryReport(
+  options: ConversationReaderOptions = {},
+): Promise<RequesterDirectoryReport> {
+  const nowMs = Date.now();
+  const { conversations, truncated } = await requesterSample(options);
+  const detailsByConversationId = await getConversationDetailsForIds(
+    conversations.map((conversation) => conversation.conversationId),
+  );
+  const people = new Map<string, RequesterDirectoryAccumulator>();
+
+  for (const conversation of conversations) {
+    const report = sessionReportFromConversation(
+      conversation,
+      nowMs,
+      detailsByConversationId.get(conversation.conversationId),
+    );
+    const requester = requesterIdentityWithEmail(report.requesterIdentity);
+    if (!requester) continue;
+
+    const lastSeenMs =
+      reportTime(report.lastSeenAt) ?? conversation.lastActivityAtMs;
+    const firstSeenMs =
+      reportTime(report.startedAt) ?? conversation.createdAtMs;
+    const signals = statusSignals([report]);
+    const date = reportDate(report.lastSeenAt);
+    const email = requester.email;
+    const accumulator =
+      people.get(email) ??
+      ({
+        ...emptyRequesterTotals(),
+        activeDates: new Set<string>(),
+        firstSeenMs,
+        lastSeenMs,
+        requester,
+      } satisfies RequesterDirectoryAccumulator);
+
+    accumulator.requester = mergeRequesterIdentity(
+      accumulator.requester,
+      requester,
+    );
+    accumulator.conversations += 1;
+    accumulator.runs += 1;
+    accumulator.durationMs += report.cumulativeDurationMs;
+    addRequesterTokens(accumulator, usageTokenTotal(report.cumulativeUsage));
+    addConversationSignals(accumulator, signals);
+    accumulator.firstSeenMs = Math.min(accumulator.firstSeenMs, firstSeenMs);
+    accumulator.lastSeenMs = Math.max(accumulator.lastSeenMs, lastSeenMs);
+    if (date) accumulator.activeDates.add(date);
+    people.set(email, accumulator);
+  }
+
+  return {
+    generatedAt: new Date(nowMs).toISOString(),
+    people: [...people.values()]
+      .map(directoryItem)
+      .sort(
+        (left, right) =>
+          (reportTime(right.lastSeenAt) ?? 0) -
+            (reportTime(left.lastSeenAt) ?? 0) ||
+          right.conversations - left.conversations ||
+          left.requester.email.localeCompare(right.requester.email),
+      ),
+    sampleLimit: REQUESTER_PROFILE_SAMPLE_LIMIT,
+    sampleSize: conversations.length,
+    source: "conversation_index",
+    truncated,
+  };
+}
+
+/** Read one requester profile without exposing transcript payloads. */
+export async function readRequesterProfileReport(
+  email: string,
+  options: ConversationReaderOptions = {},
+): Promise<RequesterProfileReport> {
+  const nowMs = Date.now();
+  const normalizedEmail = normalizeRequesterEmail(email) ?? email;
+  const { conversations, truncated } = await requesterSample(options);
+  const detailsByConversationId = await getConversationDetailsForIds(
+    conversations.map((conversation) => conversation.conversationId),
+  );
+  const reportsByConversation = await reportsFromConversations({
+    conversations,
+    detailsByConversationId,
+    nowMs,
+  });
+  const matchingConversations = conversations.filter((conversation) => {
+    const reports =
+      reportsByConversation.get(conversation.conversationId) ?? [];
+    const report =
+      reports.length > 0
+        ? newestRun(reports)
+        : sessionReportFromConversation(
+            conversation,
+            nowMs,
+            detailsByConversationId.get(conversation.conversationId),
+          );
+    return (
+      requesterIdentityWithEmail(report.requesterIdentity)?.email ===
+      normalizedEmail
+    );
+  });
+
+  let requester: (RequesterIdentity & { email: string }) | undefined;
+  const totals = emptyRequesterTotals();
+  const activeDates = new Set<string>();
+  const activityDays = new Map<string, RequesterActivityDayReport>();
+  const locations = new Map<string, ConversationStatsItem>();
+  const surfaces = new Map<string, ConversationStatsItem>();
+  const recentConversations: ConversationSummaryReport[] = [];
+
+  for (const conversation of matchingConversations) {
+    const reports = [
+      ...(reportsByConversation.get(conversation.conversationId) ?? [
+        sessionReportFromConversation(
+          conversation,
+          nowMs,
+          detailsByConversationId.get(conversation.conversationId),
+        ),
+      ]),
+    ].sort(
+      (left, right) =>
+        (reportTime(left.startedAt) ?? 0) -
+          (reportTime(right.startedAt) ?? 0) || left.id.localeCompare(right.id),
+    );
+    const newest = newestRun(reports);
+    const identity = requesterIdentityWithEmail(newest.requesterIdentity);
+    if (identity) {
+      requester = requester
+        ? mergeRequesterIdentity(requester, identity)
+        : identity;
+    }
+    recentConversations.push(newest);
+
+    const contributions = runContributions(reports);
+    const signals = statusSignals(reports);
+    const durationMs = contributionDurationTotal(contributions);
+    const tokens = contributionTokenTotal(contributions);
+    const date = reportDate(newest.lastSeenAt);
+
+    totals.conversations += 1;
+    totals.runs += reports.length;
+    totals.durationMs += durationMs;
+    addRequesterTokens(totals, tokens);
+    addConversationSignals(totals, signals);
+    if (date) {
+      activeDates.add(date);
+      const day = activityDays.get(date) ?? emptyRequesterActivityDay(date);
+      day.conversations += 1;
+      day.runs += reports.length;
+      day.durationMs += durationMs;
+      addRequesterTokens(day, tokens);
+      addConversationSignals(day, signals);
+      activityDays.set(date, day);
+    }
+
+    const location = locationLabel(newest);
+    const locationItem = locations.get(location) ?? emptyStatsItem(location);
+    locationItem.conversations += 1;
+    locationItem.runs += reports.length;
+    locationItem.durationMs += durationMs;
+    addItemTokens(locationItem, tokens);
+    addStatsSignals(locationItem, signals);
+    locations.set(location, locationItem);
+
+    const surface = surfaceFallbackLabel(newest.surface);
+    const surfaceItem = surfaces.get(surface) ?? emptyStatsItem(surface);
+    surfaceItem.conversations += 1;
+    surfaceItem.runs += reports.length;
+    surfaceItem.durationMs += durationMs;
+    addItemTokens(surfaceItem, tokens);
+    addStatsSignals(surfaceItem, signals);
+    surfaces.set(surface, surfaceItem);
+  }
+
+  totals.activeDays = activeDates.size;
+  const end = new Date(nowMs);
+  end.setUTCHours(0, 0, 0, 0);
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - (REQUESTER_PROFILE_ACTIVITY_DAYS - 1));
+
+  return {
+    activityDays: requesterActivityDays({ days: activityDays, nowMs }),
+    generatedAt: new Date(nowMs).toISOString(),
+    locations: statsItems(locations),
+    recentConversations: recentConversations
+      .sort(
+        (left, right) =>
+          (reportTime(right.lastSeenAt) ?? 0) -
+            (reportTime(left.lastSeenAt) ?? 0) ||
+          right.conversationId.localeCompare(left.conversationId),
+      )
+      .slice(0, REQUESTER_PROFILE_RECENT_LIMIT),
+    requester: requester ?? { email: normalizedEmail },
+    sampleLimit: REQUESTER_PROFILE_SAMPLE_LIMIT,
+    sampleSize: conversations.length,
+    source: "conversation_index",
+    surfaces: statsItems(surfaces),
+    totals,
+    truncated,
+    windowEnd: end.toISOString(),
+    windowStart: start.toISOString(),
+  };
+}
+
 function canExposeConversationTranscript(
   summary: AgentTurnSessionSummary,
 ): boolean {
@@ -1151,6 +1590,7 @@ function activityPayloadFields(
 function subagentActivity(
   entry: Extract<SessionActivityEntry, { type: "subagent_started" }>,
   options: {
+    canExposeTranscript: boolean;
     end?: Extract<SessionActivityEntry, { type: "subagent_ended" }>;
     parentStatus?: ConversationActivityStatus;
   },
@@ -1169,6 +1609,11 @@ function subagentActivity(
           endedAt: new Date(end.createdAtMs).toISOString(),
           outcome: end.outcome,
           status: end.outcome,
+          ...(options.canExposeTranscript &&
+          end.transcriptStartMessageIndex !== undefined &&
+          end.transcriptEndMessageIndex !== undefined
+            ? { transcriptAvailable: true }
+            : {}),
         }
       : { status: options.parentStatus ?? "running" }),
   };
@@ -1204,6 +1649,7 @@ function buildConversationActivity(args: {
       ? toolStatuses.get(entry.parentToolCallId)
       : undefined;
     const activity = subagentActivity(entry, {
+      canExposeTranscript: args.canExposePayload,
       end: subagentEnds.get(entry.subagentInvocationId),
       parentStatus,
     });
@@ -1331,6 +1777,116 @@ function traceIdFromTranscript(
     }
   }
   return undefined;
+}
+
+function subagentTranscriptReport(
+  activity: ConversationSubagentActivityReport,
+  options: {
+    subagentConversationId?: string;
+    subagentSentryConversationUrl?: string;
+    transcript?: TranscriptMessage[];
+    transcriptMessageCount?: number;
+    transcriptRedacted?: boolean;
+    transcriptRedactionReason?: "non_public_conversation";
+    unavailableReason?: ConversationSubagentTranscriptReport["unavailableReason"];
+  } = {},
+): ConversationSubagentTranscriptReport {
+  return {
+    type: "subagent",
+    ...(options.subagentConversationId
+      ? { subagentConversationId: options.subagentConversationId }
+      : {}),
+    createdAt: activity.createdAt,
+    id: activity.id,
+    status: activity.status,
+    ...(options.subagentSentryConversationUrl
+      ? { subagentSentryConversationUrl: options.subagentSentryConversationUrl }
+      : {}),
+    subagentKind: activity.subagentKind,
+    transcript: options.transcript ?? [],
+    transcriptAvailable: Boolean(options.transcript?.length),
+    ...(activity.endedAt ? { endedAt: activity.endedAt } : {}),
+    ...(activity.outcome ? { outcome: activity.outcome } : {}),
+    ...(activity.parentToolCallId
+      ? { parentToolCallId: activity.parentToolCallId }
+      : {}),
+    ...(options.transcriptMessageCount !== undefined
+      ? { transcriptMessageCount: options.transcriptMessageCount }
+      : {}),
+    ...(options.transcriptRedacted
+      ? { transcriptRedacted: options.transcriptRedacted }
+      : {}),
+    ...(options.transcriptRedactionReason
+      ? { transcriptRedactionReason: options.transcriptRedactionReason }
+      : {}),
+    ...(options.unavailableReason
+      ? { unavailableReason: options.unavailableReason }
+      : {}),
+  };
+}
+
+function subagentConversationFields(
+  ref: Extract<
+    SessionActivityEntry,
+    { type: "subagent_started" }
+  >["transcriptRef"],
+): Pick<
+  ConversationSubagentTranscriptReport,
+  "subagentConversationId" | "subagentSentryConversationUrl"
+> {
+  if (ref.type !== "advisor_session") {
+    return {};
+  }
+  const subagentConversationId = ref.key;
+  const subagentSentryConversationUrl = buildSentryConversationUrl(
+    subagentConversationId,
+  );
+  return {
+    subagentConversationId,
+    ...(subagentSentryConversationUrl ? { subagentSentryConversationUrl } : {}),
+  };
+}
+
+const piMessageSchema = z
+  .object({
+    content: z.array(z.unknown()),
+    role: z.string().min(1),
+  })
+  .passthrough()
+  .transform((value) => value as unknown as PiMessage);
+
+async function readTranscriptRefMessages(
+  ref: Extract<
+    SessionActivityEntry,
+    { type: "subagent_started" }
+  >["transcriptRef"],
+): Promise<PiMessage[]> {
+  if (ref.type !== "advisor_session") {
+    return [];
+  }
+
+  const stateAdapter = getStateAdapter();
+  await stateAdapter.connect();
+  const value = await stateAdapter.get<unknown>(ref.key);
+  const parsed = z.array(piMessageSchema).safeParse(value);
+  return parsed.success ? parsed.data : [];
+}
+
+function transcriptSliceBounds(
+  end: Extract<SessionActivityEntry, { type: "subagent_ended" }> | undefined,
+): { end: number; start: number } | undefined {
+  if (
+    end?.transcriptStartMessageIndex === undefined ||
+    end.transcriptEndMessageIndex === undefined ||
+    end.transcriptEndMessageIndex < end.transcriptStartMessageIndex
+  ) {
+    return undefined;
+  }
+
+  return {
+    end: end.transcriptEndMessageIndex,
+    start: end.transcriptStartMessageIndex,
+  };
 }
 
 async function summariesByConversation(
@@ -1602,4 +2158,96 @@ export async function readConversationReport(
     ...(sentryConversationUrl ? { sentryConversationUrl } : {}),
     runs: effectiveRuns,
   };
+}
+
+/** Read one child-agent transcript through its parent conversation run. */
+export async function readConversationSubagentTranscriptReport(
+  conversationId: string,
+  runId: string,
+  subagentId: string,
+): Promise<ConversationSubagentTranscriptReport> {
+  const summaries =
+    await listAgentTurnSessionSummariesForConversation(conversationId);
+  const summary = summaries.find((candidate) => candidate.sessionId === runId);
+  if (!summary) {
+    return {
+      type: "subagent",
+      createdAt: new Date(0).toISOString(),
+      id: subagentId,
+      status: "error",
+      subagentKind: "unknown",
+      transcript: [],
+      transcriptAvailable: false,
+      unavailableReason: "not_found",
+    };
+  }
+
+  const entries = await loadActivityEntries({
+    conversationId,
+    sessionId: runId,
+  });
+  const start = entries.find(
+    (
+      entry,
+    ): entry is Extract<SessionActivityEntry, { type: "subagent_started" }> =>
+      entry.type === "subagent_started" &&
+      entry.subagentInvocationId === subagentId,
+  );
+  const end = entries.find(
+    (
+      entry,
+    ): entry is Extract<SessionActivityEntry, { type: "subagent_ended" }> =>
+      entry.type === "subagent_ended" &&
+      entry.subagentInvocationId === subagentId,
+  );
+
+  if (!start) {
+    return {
+      type: "subagent",
+      createdAt: new Date(0).toISOString(),
+      id: subagentId,
+      status: "error",
+      subagentKind: "unknown",
+      transcript: [],
+      transcriptAvailable: false,
+      unavailableReason: "not_found",
+    };
+  }
+
+  const canExposeTranscript = canExposeConversationTranscript(summary);
+  const activity = subagentActivity(start, { canExposeTranscript, end });
+  const conversationFields = subagentConversationFields(start.transcriptRef);
+  if (!canExposeTranscript) {
+    return subagentTranscriptReport(activity, {
+      ...conversationFields,
+      transcriptRedacted: true,
+      transcriptRedactionReason: "non_public_conversation",
+    });
+  }
+
+  const bounds = transcriptSliceBounds(end);
+  if (!bounds) {
+    return subagentTranscriptReport(activity, {
+      ...conversationFields,
+      unavailableReason: "missing_transcript_range",
+    });
+  }
+
+  const messages = await readTranscriptRefMessages(start.transcriptRef);
+  if (messages.length === 0) {
+    return subagentTranscriptReport(activity, {
+      ...conversationFields,
+      unavailableReason: "missing_transcript_ref",
+    });
+  }
+
+  const transcript = messages
+    .slice(0, bounds.end)
+    .map(normalizeTranscriptMessage);
+
+  return subagentTranscriptReport(activity, {
+    ...conversationFields,
+    transcript,
+    transcriptMessageCount: countConversationMessages(transcript),
+  });
 }

--- a/packages/junior/src/reporting/conversations.ts
+++ b/packages/junior/src/reporting/conversations.ts
@@ -1156,23 +1156,39 @@ export async function readRequesterDirectoryReport(
   const detailsByConversationId = await getConversationDetailsForIds(
     conversations.map((conversation) => conversation.conversationId),
   );
+  const reportsByConversation = await reportsFromConversations({
+    conversations,
+    detailsByConversationId,
+    nowMs,
+  });
   const people = new Map<string, RequesterDirectoryAccumulator>();
 
   for (const conversation of conversations) {
-    const report = sessionReportFromConversation(
-      conversation,
-      nowMs,
-      detailsByConversationId.get(conversation.conversationId),
+    const reports = [
+      ...(reportsByConversation.get(conversation.conversationId) ?? [
+        sessionReportFromConversation(
+          conversation,
+          nowMs,
+          detailsByConversationId.get(conversation.conversationId),
+        ),
+      ]),
+    ].sort(
+      (left, right) =>
+        (reportTime(left.startedAt) ?? 0) -
+          (reportTime(right.startedAt) ?? 0) || left.id.localeCompare(right.id),
     );
-    const requester = requesterIdentityWithEmail(report.requesterIdentity);
+    const newest = newestRun(reports);
+    const requester = requesterIdentityWithEmail(newest.requesterIdentity);
     if (!requester) continue;
 
     const lastSeenMs =
-      reportTime(report.lastSeenAt) ?? conversation.lastActivityAtMs;
+      reportTime(newest.lastSeenAt) ?? conversation.lastActivityAtMs;
     const firstSeenMs =
-      reportTime(report.startedAt) ?? conversation.createdAtMs;
-    const signals = statusSignals([report]);
-    const date = reportDate(report.lastSeenAt);
+      reportTime(reports[0]?.startedAt ?? newest.startedAt) ??
+      conversation.createdAtMs;
+    const contributions = runContributions(reports);
+    const signals = statusSignals(reports);
+    const date = reportDate(newest.lastSeenAt);
     const email = requester.email;
     const accumulator =
       people.get(email) ??
@@ -1189,9 +1205,9 @@ export async function readRequesterDirectoryReport(
       requester,
     );
     accumulator.conversations += 1;
-    accumulator.runs += 1;
-    accumulator.durationMs += report.cumulativeDurationMs;
-    addRequesterTokens(accumulator, usageTokenTotal(report.cumulativeUsage));
+    accumulator.runs += reports.length;
+    accumulator.durationMs += contributionDurationTotal(contributions);
+    addRequesterTokens(accumulator, contributionTokenTotal(contributions));
     addConversationSignals(accumulator, signals);
     accumulator.firstSeenMs = Math.min(accumulator.firstSeenMs, firstSeenMs);
     accumulator.lastSeenMs = Math.max(accumulator.lastSeenMs, lastSeenMs);

--- a/packages/junior/tests/integration/dashboard-reporting.test.ts
+++ b/packages/junior/tests/integration/dashboard-reporting.test.ts
@@ -874,6 +874,263 @@ describe("dashboard reporting", () => {
     );
   });
 
+  it("loads advisor subagent transcript history from a shared advisor session", async () => {
+    const { upsertAgentTurnSessionRecord } =
+      await import("@/chat/state/turn-session");
+    const {
+      recordSubagentEnded,
+      recordSubagentStarted,
+      recordToolExecutionStarted,
+    } = await import("@/chat/state/session-log");
+    const { getStateAdapter } = await import("@/chat/state/adapter");
+    const { createJuniorReporting } = await import("@/reporting");
+
+    const conversationId = "slack:C1:advisor-slices";
+    const runId = "turn-advisor-slices";
+    const advisorSessionKey = `junior:${conversationId}:advisor_session`;
+    const advisorMessages = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "first advisor question" }],
+        timestamp: 10,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "first advisor answer" }],
+        timestamp: 20,
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "second advisor question" }],
+        timestamp: 30,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "second advisor answer" }],
+        timestamp: 40,
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "third advisor question" }],
+        timestamp: 50,
+      },
+    ] as PiMessage[];
+    const stateAdapter = getStateAdapter();
+    await stateAdapter.connect();
+    await stateAdapter.set(advisorSessionKey, advisorMessages, 60_000);
+
+    await upsertAgentTurnSessionRecord({
+      conversationId,
+      sessionId: runId,
+      sliceId: 1,
+      state: "completed",
+      turnStartMessageIndex: 0,
+      piMessages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "make dashboard change" }],
+          timestamp: 1,
+        },
+        {
+          role: "toolResult",
+          toolCallId: "advisor-plan",
+          name: "advisor",
+          content: [{ type: "text", text: "plan result" }],
+          timestamp: 25,
+        },
+        {
+          role: "toolResult",
+          toolCallId: "advisor-review",
+          name: "advisor",
+          content: [{ type: "text", text: "review result" }],
+          timestamp: 45,
+        },
+      ] as PiMessage[],
+    });
+
+    for (const toolCallId of ["advisor-plan", "advisor-review"]) {
+      await recordToolExecutionStarted({
+        conversationId,
+        sessionId: runId,
+        createdAtMs: toolCallId === "advisor-plan" ? 2 : 30,
+        toolCallId,
+        toolName: "advisor",
+        args: { question: toolCallId },
+        ttlMs: 60_000,
+      });
+      await recordSubagentStarted({
+        conversationId,
+        sessionId: runId,
+        createdAtMs: toolCallId === "advisor-plan" ? 3 : 31,
+        historyMode: "shared",
+        parentConversationId: conversationId,
+        parentSessionId: runId,
+        parentToolCallId: toolCallId,
+        subagentInvocationId: toolCallId,
+        subagentKind: "advisor",
+        transcriptRef: {
+          type: "advisor_session",
+          parentConversationId: conversationId,
+          key: advisorSessionKey,
+        },
+        ttlMs: 60_000,
+      });
+      await recordSubagentEnded({
+        conversationId,
+        sessionId: runId,
+        createdAtMs: toolCallId === "advisor-plan" ? 25 : 45,
+        outcome: "success",
+        subagentInvocationId: toolCallId,
+        transcriptStartMessageIndex: toolCallId === "advisor-plan" ? 0 : 2,
+        transcriptEndMessageIndex: toolCallId === "advisor-plan" ? 2 : 4,
+        ttlMs: 60_000,
+      });
+    }
+
+    const reporting = createJuniorReporting();
+    const report = await reporting.getConversation(conversationId);
+    expect(report.runs[0]?.activity?.[0]).toMatchObject({
+      toolCallId: "advisor-plan",
+      subagents: [
+        expect.objectContaining({
+          id: "advisor-plan",
+          transcriptAvailable: true,
+        }),
+      ],
+    });
+
+    const first = await reporting.getConversationSubagentTranscript(
+      conversationId,
+      runId,
+      "advisor-plan",
+    );
+    const second = await reporting.getConversationSubagentTranscript(
+      conversationId,
+      runId,
+      "advisor-review",
+    );
+
+    expect(first.subagentConversationId).toBe(advisorSessionKey);
+    const encodedAdvisorSessionKey = encodeURIComponent(advisorSessionKey);
+    expect(
+      first.subagentSentryConversationUrl === undefined ||
+        first.subagentSentryConversationUrl.includes(encodedAdvisorSessionKey),
+    ).toBe(true);
+    expect(JSON.stringify(first.transcript)).toContain(
+      "first advisor question",
+    );
+    expect(JSON.stringify(first.transcript)).not.toContain(
+      "second advisor question",
+    );
+    expect(JSON.stringify(second.transcript)).toContain("first advisor answer");
+    expect(JSON.stringify(second.transcript)).toContain(
+      "second advisor answer",
+    );
+    expect(JSON.stringify(second.transcript)).not.toContain(
+      "third advisor question",
+    );
+  });
+
+  it("redacts advisor subagent transcript history for private conversations", async () => {
+    const { upsertAgentTurnSessionRecord } =
+      await import("@/chat/state/turn-session");
+    const {
+      recordSubagentEnded,
+      recordSubagentStarted,
+      recordToolExecutionStarted,
+    } = await import("@/chat/state/session-log");
+    const { getStateAdapter } = await import("@/chat/state/adapter");
+    const { createJuniorReporting } = await import("@/reporting");
+
+    const conversationId = "slack:D1:advisor-private";
+    const runId = "turn-advisor-private";
+    const toolCallId = "advisor-private";
+    const advisorSessionKey = `junior:${conversationId}:advisor_session`;
+    const privateAdvisorText = "private advisor question";
+    const stateAdapter = getStateAdapter();
+    await stateAdapter.connect();
+    await stateAdapter.set(
+      advisorSessionKey,
+      [
+        {
+          role: "user",
+          content: [{ type: "text", text: privateAdvisorText }],
+          timestamp: 10,
+        },
+      ] as PiMessage[],
+      60_000,
+    );
+
+    await upsertAgentTurnSessionRecord({
+      conversationId,
+      sessionId: runId,
+      sliceId: 1,
+      state: "completed",
+      turnStartMessageIndex: 0,
+      piMessages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "private parent request" }],
+          timestamp: 1,
+        },
+      ] as PiMessage[],
+    });
+    await recordToolExecutionStarted({
+      conversationId,
+      sessionId: runId,
+      createdAtMs: 2,
+      toolCallId,
+      toolName: "advisor",
+      args: { question: privateAdvisorText },
+      ttlMs: 60_000,
+    });
+    await recordSubagentStarted({
+      conversationId,
+      sessionId: runId,
+      createdAtMs: 3,
+      historyMode: "shared",
+      parentConversationId: conversationId,
+      parentSessionId: runId,
+      parentToolCallId: toolCallId,
+      subagentInvocationId: toolCallId,
+      subagentKind: "advisor",
+      transcriptRef: {
+        type: "advisor_session",
+        parentConversationId: conversationId,
+        key: advisorSessionKey,
+      },
+      ttlMs: 60_000,
+    });
+    await recordSubagentEnded({
+      conversationId,
+      sessionId: runId,
+      createdAtMs: 10,
+      outcome: "success",
+      subagentInvocationId: toolCallId,
+      transcriptStartMessageIndex: 0,
+      transcriptEndMessageIndex: 1,
+      ttlMs: 60_000,
+    });
+
+    const reporting = createJuniorReporting();
+    const parent = await reporting.getConversation(conversationId);
+    expect(JSON.stringify(parent.runs[0]?.activity ?? [])).not.toContain(
+      "transcriptAvailable",
+    );
+
+    const transcript = await reporting.getConversationSubagentTranscript(
+      conversationId,
+      runId,
+      toolCallId,
+    );
+
+    expect(transcript.subagentConversationId).toBe(advisorSessionKey);
+    expect(transcript.transcriptAvailable).toBe(false);
+    expect(transcript.transcriptRedacted).toBe(true);
+    expect(transcript.transcript).toEqual([]);
+    expect(JSON.stringify(transcript)).not.toContain(privateAdvisorText);
+  });
+
   it("derives unfinished subagent status from completed parent tool results", async () => {
     const { upsertAgentTurnSessionRecord } =
       await import("@/chat/state/turn-session");

--- a/packages/junior/tests/unit/app-config.test.ts
+++ b/packages/junior/tests/unit/app-config.test.ts
@@ -798,12 +798,24 @@ describe("createApp plugin config", () => {
 
     expect(response.status).toBe(200);
     await expect(response.text()).resolves.toBe("memory");
+
+    const peoplePage = await app.fetch(new Request("http://localhost/people"));
+    expect(peoplePage.status).toBe(200);
+    await expect(peoplePage.text()).resolves.toBe("dashboard");
+
+    const peopleApi = await app.fetch(
+      new Request("http://localhost/api/people"),
+    );
+    expect(peopleApi.status).toBe(200);
+    await expect(peopleApi.text()).resolves.toBe("dashboard");
   });
 
   it("rejects app-level plugin routes that conflict with core dashboard routes", async () => {
     for (const path of [
       "/api/plugins/*",
       "/api/conversations/*",
+      "/api/people/*",
+      "/people/*",
       "/*",
       "/api/*",
       "/:slug",

--- a/packages/junior/tests/unit/reporting-conversations.test.ts
+++ b/packages/junior/tests/unit/reporting-conversations.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { getConversationDetailsForIds } from "@/chat/state/conversation-details";
 import type {
   Conversation,
   ConversationStore,
@@ -6,6 +7,8 @@ import type {
 import {
   readConversationFeed,
   readConversationReport,
+  readRequesterDirectoryReport,
+  readRequesterProfileReport,
 } from "@/reporting/conversations";
 
 vi.mock("@/chat/sentry", () => ({
@@ -109,5 +112,143 @@ describe("conversation reporting", () => {
     expect(detail.sentryConversationUrl).toBe(
       "https://acme.sentry.io/explore/conversations/slack%3AC1%3A123/?project=4501",
     );
+  });
+
+  it("aggregates requester profiles by trusted email", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-15T12:00:00.000Z"));
+    const conversationStore = fixedConversationStore([
+      indexedConversation({
+        conversationId: "slack:C1:123",
+        channelName: "proj-alpha",
+        createdAtMs: Date.parse("2026-06-10T10:00:00.000Z"),
+        lastActivityAtMs: Date.parse("2026-06-10T10:03:00.000Z"),
+        requester: {
+          email: "Alice@Example.com",
+          fullName: "Alice Example",
+          slackUserId: "U1",
+          slackUserName: "alice",
+        },
+        source: "slack",
+      }),
+      indexedConversation({
+        conversationId: "slack:C1:456",
+        createdAtMs: Date.parse("2026-06-12T11:00:00.000Z"),
+        execution: {
+          status: "failed",
+          updatedAtMs: Date.parse("2026-06-12T11:01:00.000Z"),
+        },
+        lastActivityAtMs: Date.parse("2026-06-12T11:01:00.000Z"),
+        requester: {
+          email: "alice@example.com",
+          slackUserId: "U1",
+        },
+        source: "slack",
+      }),
+      indexedConversation({
+        conversationId: "slack:C2:789",
+        createdAtMs: Date.parse("2026-06-13T11:00:00.000Z"),
+        lastActivityAtMs: Date.parse("2026-06-13T11:01:00.000Z"),
+        requester: {
+          email: "bob@example.com",
+          fullName: "Bob Example",
+          slackUserId: "U2",
+        },
+        source: "slack",
+      }),
+      indexedConversation({
+        conversationId: "slack:C1:999",
+        createdAtMs: Date.parse("2026-06-11T09:00:00.000Z"),
+        lastActivityAtMs: Date.parse("2026-06-11T09:04:00.000Z"),
+        requester: {
+          email: "later@example.com",
+          fullName: "Later Assignee",
+          slackUserId: "U9",
+        },
+        source: "slack",
+      }),
+      indexedConversation({
+        conversationId: "slack:C3:000",
+        createdAtMs: Date.parse("2026-06-14T11:00:00.000Z"),
+        lastActivityAtMs: Date.parse("2026-06-14T11:01:00.000Z"),
+        requester: {
+          fullName: "No Email",
+          slackUserId: "U3",
+        },
+        source: "slack",
+      }),
+    ]);
+    vi.mocked(getConversationDetailsForIds).mockResolvedValue(
+      new Map([
+        [
+          "slack:C1:999",
+          {
+            conversationId: "slack:C1:999",
+            originRequester: {
+              email: "alice@example.com",
+              fullName: "Alice Origin",
+              slackUserId: "U1",
+            },
+          },
+        ],
+      ]),
+    );
+
+    const directory = await readRequesterDirectoryReport({
+      conversationStore,
+    });
+    const profile = await readRequesterProfileReport("ALICE@example.com", {
+      conversationStore,
+    });
+
+    expect(directory.people.map((person) => person.requester.email)).toEqual([
+      "bob@example.com",
+      "alice@example.com",
+    ]);
+    expect(
+      directory.people.find(
+        (person) => person.requester.email === "alice@example.com",
+      ),
+    ).toMatchObject({
+      activeDays: 3,
+      conversations: 3,
+      failed: 1,
+      requester: {
+        email: "alice@example.com",
+        fullName: "Alice Origin",
+      },
+    });
+    expect(profile).toMatchObject({
+      requester: {
+        email: "alice@example.com",
+        fullName: "Alice Origin",
+      },
+      totals: {
+        activeDays: 3,
+        conversations: 3,
+        failed: 1,
+        runs: 3,
+      },
+      locations: [
+        expect.objectContaining({
+          conversations: 2,
+          label: "Public Channel",
+        }),
+        expect.objectContaining({
+          conversations: 1,
+          label: "#proj-alpha",
+        }),
+      ],
+    });
+    expect(profile.activityDays).toHaveLength(366);
+    expect(
+      profile.activityDays.find((day) => day.date === "2026-06-12"),
+    ).toMatchObject({
+      conversations: 1,
+      failed: 1,
+    });
+    expect(
+      profile.recentConversations.map((item) => item.conversationId),
+    ).toEqual(["slack:C1:456", "slack:C1:999", "slack:C1:123"]);
   });
 });

--- a/packages/junior/tests/unit/reporting-conversations.test.ts
+++ b/packages/junior/tests/unit/reporting-conversations.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getConversationDetailsForIds } from "@/chat/state/conversation-details";
+import { listAgentTurnSessionSummariesForConversation } from "@/chat/state/turn-session";
 import type {
   Conversation,
   ConversationStore,
@@ -85,6 +86,8 @@ function indexedConversation(
 }
 
 afterEach(() => {
+  vi.mocked(getConversationDetailsForIds).mockResolvedValue(new Map());
+  vi.mocked(listAgentTurnSessionSummariesForConversation).mockResolvedValue([]);
   if (ORIGINAL_SENTRY_ORG_SLUG === undefined) {
     delete process.env.SENTRY_ORG_SLUG;
   } else {
@@ -250,5 +253,80 @@ describe("conversation reporting", () => {
     expect(
       profile.recentConversations.map((item) => item.conversationId),
     ).toEqual(["slack:C1:456", "slack:C1:999", "slack:C1:123"]);
+  });
+
+  it("aligns requester directory totals with stored turn summaries", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-15T12:00:00.000Z"));
+    const startedAtMs = Date.parse("2026-06-15T11:00:00.000Z");
+    const conversationStore = fixedConversationStore([
+      indexedConversation({
+        conversationId: "slack:C1:turns",
+        createdAtMs: startedAtMs,
+        lastActivityAtMs: startedAtMs + 2_000,
+        requester: {
+          email: "avery@example.com",
+          fullName: "Avery",
+          platform: "slack",
+          slackUserId: "U1",
+          teamId: "T1",
+        },
+        source: "slack",
+      }),
+    ]);
+    vi.mocked(
+      listAgentTurnSessionSummariesForConversation,
+    ).mockResolvedValueOnce([
+      {
+        conversationId: "slack:C1:turns",
+        cumulativeDurationMs: 1_000,
+        lastProgressAtMs: startedAtMs + 500,
+        requester: {
+          email: "avery@example.com",
+          fullName: "Avery",
+          platform: "slack",
+          teamId: "T1",
+          userId: "U1",
+        },
+        sessionId: "turn-1",
+        sliceId: 1,
+        startedAtMs,
+        state: "completed",
+        updatedAtMs: startedAtMs + 500,
+        version: 1,
+      },
+      {
+        conversationId: "slack:C1:turns",
+        cumulativeDurationMs: 2_000,
+        lastProgressAtMs: startedAtMs + 2_000,
+        requester: {
+          email: "avery@example.com",
+          fullName: "Avery",
+          platform: "slack",
+          teamId: "T1",
+          userId: "U1",
+        },
+        sessionId: "turn-2",
+        sliceId: 1,
+        startedAtMs: startedAtMs + 1_000,
+        state: "completed",
+        updatedAtMs: startedAtMs + 2_000,
+        version: 1,
+      },
+    ]);
+
+    const directory = await readRequesterDirectoryReport({
+      conversationStore,
+    });
+
+    expect(directory.people).toHaveLength(1);
+    expect(directory.people[0]).toMatchObject({
+      conversations: 1,
+      durationMs: 2_000,
+      requester: {
+        email: "avery@example.com",
+      },
+      runs: 2,
+    });
   });
 });

--- a/specs/dashboard.md
+++ b/specs/dashboard.md
@@ -55,8 +55,15 @@ export interface JuniorReporting {
   getSkills(): Promise<SkillReport[]>;
   listConversations(): Promise<ConversationFeed>;
   getConversationStats?(): Promise<ConversationStatsReport>;
+  listRequesters?(): Promise<RequesterDirectoryReport>;
+  getRequesterProfile?(email: string): Promise<RequesterProfileReport>;
   getPluginOperationalReports?(): Promise<PluginOperationalReportFeed>;
   getConversation(conversationId: string): Promise<ConversationReport>;
+  getConversationSubagentTranscript(
+    conversationId: string,
+    runId: string,
+    subagentId: string,
+  ): Promise<ConversationSubagentTranscriptReport>;
 }
 
 export function createJuniorReporting(): JuniorReporting;
@@ -115,6 +122,8 @@ The dashboard package owns browser-facing routes:
 | `GET /`                            | Better Auth session unless auth is explicitly disabled | React command-center UI.            |
 | `GET /conversations`               | Better Auth session unless auth is explicitly disabled | React conversation-history UI.      |
 | `GET /conversations/**`            | Better Auth session unless auth is explicitly disabled | React conversation-detail UI.       |
+| `GET /people`                      | Better Auth session unless auth is explicitly disabled | React requester-directory UI.       |
+| `GET /people/**`                   | Better Auth session unless auth is explicitly disabled | React requester-profile UI.         |
 | `GET /plugins`                     | Better Auth session unless auth is explicitly disabled | React plugin reporting UI.          |
 | `GET /_junior/dashboard/client.js` | Better Auth session unless auth is explicitly disabled | Dashboard browser bundle.           |
 | `/api/auth/**`                     | Better Auth                                            | Better Auth social login callbacks. |
@@ -124,19 +133,22 @@ Junior's product APIs are REST-style and authenticated by default when they are
 owned by the dashboard package. Only the auth callback/login paths and explicit
 public health route bypass dashboard auth.
 
-| Route                                  | Contract                                                                |
-| -------------------------------------- | ----------------------------------------------------------------------- |
-| `GET /api/health`                      | Command-center health pulse.                                            |
-| `GET /api/runtime`                     | Sanitized runtime paths, packages, and providers.                       |
-| `GET /api/plugins`                     | Loaded plugin inventory.                                                |
-| `GET /api/skills`                      | Discovered skill inventory.                                             |
-| `GET /api/conversations`               | Conversation feed from `conversation:by-activity`.                      |
-| `GET /api/conversations/stats`         | Aggregate conversation stats, leaderboards, and sampling metadata.      |
-| `GET /api/plugin-reports`              | Sanitized plugin operational summaries.                                 |
-| `/api/plugins/:plugin/**`              | Authenticated plugin-contributed APIs.                                  |
-| `GET /api/conversations/:conversation` | Conversation header metadata and transcript from expiring session logs. |
-| `GET /api/config`                      | Safe config counts, timezone, and feature signals.                      |
-| `GET /api/me`                          | Signed-in dashboard identity.                                           |
+| Route                                                                | Contract                                                                |
+| -------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `GET /api/health`                                                    | Command-center health pulse.                                            |
+| `GET /api/runtime`                                                   | Sanitized runtime paths, packages, and providers.                       |
+| `GET /api/plugins`                                                   | Loaded plugin inventory.                                                |
+| `GET /api/skills`                                                    | Discovered skill inventory.                                             |
+| `GET /api/conversations`                                             | Conversation feed from `conversation:by-activity`.                      |
+| `GET /api/conversations/stats`                                       | Aggregate conversation stats, leaderboards, and sampling metadata.      |
+| `GET /api/people`                                                    | Requester directory derived from trusted requester emails.              |
+| `GET /api/people/:email`                                             | Requester profile activity, stats, and recent conversation summaries.   |
+| `GET /api/plugin-reports`                                            | Sanitized plugin operational summaries.                                 |
+| `/api/plugins/:plugin/**`                                            | Authenticated plugin-contributed APIs.                                  |
+| `GET /api/conversations/:conversation`                               | Conversation header metadata and transcript from expiring session logs. |
+| `GET /api/conversations/:conversation/runs/:run/subagents/:subagent` | Child-agent transcript loaded on demand from the parent run activity.   |
+| `GET /api/config`                                                    | Safe config counts, timezone, and feature signals.                      |
+| `GET /api/me`                                                        | Signed-in dashboard identity.                                           |
 
 Conversation transcript responses may synthesize the static system prompt only
 when the exposed transcript begins at a model run boundary. Follow-up run


### PR DESCRIPTION
The dashboard now has a people surface built from trusted requester emails, searchable conversation/profile lists, source and requester filters, and a profile view with activity and recent conversation context. Conversation email labels link into those profiles so reviewers can move from a transcript to the relevant requester history without leaving the dashboard.

Transcript inspection is also deeper: dense tool runs reveal reliably, rich tool details render structured key/value and table views instead of raw JSON dumps, and subagent rows open an async drawer for the child transcript. Advisor transcripts use the advisor session as the child conversation identity, show a Sentry conversation link when available, and attribute advisor replies as "advisor" instead of Junior.

The reporting changes keep private transcripts redacted, expose advisor transcript ranges from shared advisor history, and keep requester profile membership aligned with the same origin-requester precedence used by conversation rows. Reviewers may want to start with the reporting contract in packages/junior/src/reporting/conversations.ts, then the dashboard drawer/tool inspector components.