### PR TITLE
fix(prompt): Wrap current user task consistently

### DIFF
--- a/packages/junior/src/chat/current-instruction.ts
+++ b/packages/junior/src/chat/current-instruction.ts
@@ -1,0 +1,33 @@
+import { escapeXml } from "@/chat/xml";
+
+const CURRENT_INSTRUCTION_TAG = "current-instruction";
+const CURRENT_INSTRUCTION_PATTERN = new RegExp(
+  `<${CURRENT_INSTRUCTION_TAG}>\\n([\\s\\S]*?)\\n</${CURRENT_INSTRUCTION_TAG}>`,
+);
+
+function unescapeXml(value: string): string {
+  return value
+    .replaceAll("&quot;", '"')
+    .replaceAll("&apos;", "'")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&amp;", "&");
+}
+
+/** Render the active user task in a stable prompt boundary. */
+export function renderCurrentInstruction(instruction: string): string {
+  return [
+    `<${CURRENT_INSTRUCTION_TAG}>`,
+    escapeXml(instruction),
+    `</${CURRENT_INSTRUCTION_TAG}>`,
+  ].join("\n");
+}
+
+/** Recover display text from the internal current-task prompt boundary. */
+export function unwrapCurrentInstruction(text: string): string | undefined {
+  const match = text.match(CURRENT_INSTRUCTION_PATTERN);
+  if (!match) {
+    return undefined;
+  }
+  return unescapeXml(match[1]);
+}

--- a/packages/junior/src/chat/current-instruction.ts
+++ b/packages/junior/src/chat/current-instruction.ts
@@ -4,6 +4,9 @@ const CURRENT_INSTRUCTION_TAG = "current-instruction";
 const CURRENT_INSTRUCTION_PATTERN = new RegExp(
   `<${CURRENT_INSTRUCTION_TAG}>\\n([\\s\\S]*?)\\n</${CURRENT_INSTRUCTION_TAG}>`,
 );
+const STANDALONE_CURRENT_INSTRUCTION_PATTERN = new RegExp(
+  `^<${CURRENT_INSTRUCTION_TAG}>\\n([\\s\\S]*?)\\n</${CURRENT_INSTRUCTION_TAG}>$`,
+);
 
 function unescapeXml(value: string): string {
   return value
@@ -21,6 +24,14 @@ export function renderCurrentInstruction(instruction: string): string {
     escapeXml(instruction),
     `</${CURRENT_INSTRUCTION_TAG}>`,
   ].join("\n");
+}
+
+/** Read the exact body from a standalone current-task prompt boundary. */
+export function extractCurrentInstructionBody(
+  text: string,
+): string | undefined {
+  const match = text.match(STANDALONE_CURRENT_INSTRUCTION_PATTERN);
+  return match?.[1];
 }
 
 /** Recover display text from the internal current-task prompt boundary. */

--- a/packages/junior/src/chat/prompt.ts
+++ b/packages/junior/src/chat/prompt.ts
@@ -814,7 +814,7 @@ export function buildTurnContextPrompt(
   const sections = [
     `<${TURN_CONTEXT_TAG}>`,
     TURN_CONTEXT_HEADER,
-    "The current user instruction appears after this block in the same message.",
+    "The current user instruction appears after this block in `<current-instruction>` in the same message.",
     ...runtimeSections,
     `</${TURN_CONTEXT_TAG}>`,
   ].filter((section): section is string => Boolean(section));

--- a/packages/junior/src/chat/respond-helpers.ts
+++ b/packages/junior/src/chat/respond-helpers.ts
@@ -8,6 +8,7 @@ import type {
   AssistantMessage,
   ToolResultMessage,
 } from "@earendil-works/pi-ai";
+import { renderCurrentInstruction } from "@/chat/current-instruction";
 import type { PiMessage } from "@/chat/pi/messages";
 import type { Skill } from "@/chat/skills";
 import { TURN_CONTEXT_TAG } from "@/chat/turn-context-tag";
@@ -160,25 +161,23 @@ function renderThreadContextForPrompt(context: string): string {
 }
 
 /**
- * Put prior thread text before the current instruction when no Pi history
- * exists. Structured thread XML is already a top-level prompt block.
+ * Keep thread text separate from the canonical active task boundary.
  */
 export function buildUserTurnText(
   userInput: string,
   conversationContext?: string,
 ): string {
   const trimmedContext = conversationContext?.trim();
+  const currentInstruction = renderCurrentInstruction(userInput);
 
   if (!trimmedContext) {
-    return userInput;
+    return currentInstruction;
   }
 
   return [
     renderThreadContextForPrompt(trimmedContext),
     "",
-    "<current-instruction>",
-    userInput,
-    "</current-instruction>",
+    currentInstruction,
   ].join("\n");
 }
 

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -30,7 +30,10 @@ import {
   buildSystemPrompt,
   buildTurnContextPrompt,
 } from "@/chat/prompt";
-import { renderCurrentInstruction } from "@/chat/current-instruction";
+import {
+  extractCurrentInstructionBody,
+  renderCurrentInstruction,
+} from "@/chat/current-instruction";
 import { createUserTokenStore } from "@/chat/capabilities/factory";
 import { maybeExecuteJrRpcCustomCommand } from "@/chat/capabilities/jr-rpc-command";
 import { getConfigDefaults } from "@/chat/configuration/defaults";
@@ -606,15 +609,27 @@ function userPromptContentMatches(
       if (legacyTextPart.success) {
         // TODO(v0.84.0): Remove legacy unwrapped resume prompt matching after
         // pre-current-instruction session records expire.
-        return (
-          renderCurrentInstruction(legacyTextPart.data.text) ===
-          currentPart.text
+        return legacyTextPartMatchesCurrentText(
+          legacyTextPart.data.text,
+          currentPart.text,
         );
       }
     }
 
     return JSON.stringify(storedPart) === JSON.stringify(currentPart);
   });
+}
+
+function legacyTextPartMatchesCurrentText(
+  storedText: string,
+  currentText: string,
+): boolean {
+  const storedInstructionBody = extractCurrentInstructionBody(storedText);
+  if (storedInstructionBody !== undefined) {
+    return renderCurrentInstruction(storedInstructionBody) === currentText;
+  }
+
+  return renderCurrentInstruction(storedText) === currentText;
 }
 
 /** Run a full agent turn: discover skills, execute tools, and return the assistant reply. */

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -10,6 +10,7 @@
 import { Agent, type AgentTool } from "@earendil-works/pi-agent-core";
 import type { Destination, Source } from "@sentry/junior-plugin-api";
 import { THREAD_STATE_TTL_MS, type FileUpload } from "chat";
+import { z } from "zod";
 import { botConfig } from "@/chat/config";
 import {
   extractGenAiUsageAttributes,
@@ -29,6 +30,7 @@ import {
   buildSystemPrompt,
   buildTurnContextPrompt,
 } from "@/chat/prompt";
+import { renderCurrentInstruction } from "@/chat/current-instruction";
 import { createUserTokenStore } from "@/chat/capabilities/factory";
 import { maybeExecuteJrRpcCustomCommand } from "@/chat/capabilities/jr-rpc-command";
 import { getConfigDefaults } from "@/chat/configuration/defaults";
@@ -106,6 +108,7 @@ import {
   getSessionIdentifiers,
   hasRuntimeTurnContext,
   isAssistantMessage,
+  stripRuntimeTurnContext,
   summarizeMessageText,
   toObservablePromptPart,
   upsertActiveSkill,
@@ -295,6 +298,13 @@ const MAX_ROUTER_ATTACHMENT_PREVIEW_CHARS = 2_000;
 type UserTurnContentPart =
   | { type: "text"; text: string }
   | { type: "image"; data: string; mimeType: string };
+
+const legacyStoredTextPartSchema = z
+  .object({
+    text: z.string(),
+    type: z.literal("text"),
+  })
+  .strict();
 
 type UserTurnAttachment = NonNullable<
   ReplyRequestContext["userAttachments"]
@@ -538,7 +548,7 @@ function buildUserTurnInput(args: {
 
 function buildSteeringPiMessage(message: ReplySteeringMessage): PiMessage {
   const { userContentParts } = buildUserTurnInput({
-    userTurnText: message.text,
+    userTurnText: buildUserTurnText(message.text),
     userAttachments: message.userAttachments,
     omittedImageAttachmentCount: message.omittedImageAttachmentCount ?? 0,
   });
@@ -563,12 +573,48 @@ function withoutTrailingUncheckpointedUserPrompt(
   if (lastMessage?.role !== "user") {
     return messages;
   }
+  const comparableLastMessage = stripRuntimeTurnContext([
+    lastMessage as PiMessage,
+  ])[0] as { content?: unknown } | undefined;
   if (
-    JSON.stringify(lastMessage.content) !== JSON.stringify(userContentParts)
+    !userPromptContentMatches(comparableLastMessage?.content, userContentParts)
   ) {
     return messages;
   }
   return messages.slice(0, -1);
+}
+
+/** Match stored resume prompts against the current wrapped prompt shape. */
+function userPromptContentMatches(
+  storedContent: unknown,
+  currentContent: UserTurnContentPart[],
+): boolean {
+  if (JSON.stringify(storedContent) === JSON.stringify(currentContent)) {
+    return true;
+  }
+  if (!Array.isArray(storedContent)) {
+    return false;
+  }
+  if (storedContent.length !== currentContent.length) {
+    return false;
+  }
+
+  return storedContent.every((storedPart, index) => {
+    const currentPart = currentContent[index];
+    if (index === 0 && currentPart?.type === "text") {
+      const legacyTextPart = legacyStoredTextPartSchema.safeParse(storedPart);
+      if (legacyTextPart.success) {
+        // TODO(v0.84.0): Remove legacy unwrapped resume prompt matching after
+        // pre-current-instruction session records expire.
+        return (
+          renderCurrentInstruction(legacyTextPart.data.text) ===
+          currentPart.text
+        );
+      }
+    }
+
+    return JSON.stringify(storedPart) === JSON.stringify(currentPart);
+  });
 }
 
 /** Run a full agent turn: discover skills, execute tools, and return the assistant reply. */

--- a/packages/junior/src/chat/services/context-compaction.ts
+++ b/packages/junior/src/chat/services/context-compaction.ts
@@ -12,6 +12,7 @@ import {
   estimateTokens,
 } from "@earendil-works/pi-agent-core";
 import { botConfig } from "@/chat/config";
+import { unwrapCurrentInstruction } from "@/chat/current-instruction";
 import type { completeText } from "@/chat/pi/client";
 import type { PiMessage } from "@/chat/pi/messages";
 import {
@@ -77,12 +78,22 @@ function textPart(value: unknown): string | undefined {
   return undefined;
 }
 
+/** Render Pi message text for compaction without retaining prompt-only wrappers. */
 function messageText(message: PiMessage): string {
   const content = (message as { content?: unknown }).content;
+  const unwrapTask = (message as { role?: unknown }).role === "user";
+  const displayText = (text: string) =>
+    unwrapTask ? (unwrapCurrentInstruction(text) ?? text) : text;
+
   if (!Array.isArray(content)) {
-    return typeof content === "string" ? content : "";
+    return typeof content === "string" ? displayText(content) : "";
   }
-  return content.map(textPart).filter(Boolean).join("\n").trim();
+  return content
+    .map(textPart)
+    .filter((text): text is string => Boolean(text))
+    .map(displayText)
+    .join("\n")
+    .trim();
 }
 
 function sanitizeText(text: string): string {

--- a/packages/junior/src/chat/services/turn-thinking-level.ts
+++ b/packages/junior/src/chat/services/turn-thinking-level.ts
@@ -1,6 +1,7 @@
 import type { ThinkingLevel as AgentThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { ThinkingLevel as ProviderThinkingLevel } from "@earendil-works/pi-ai";
 import { z } from "zod";
+import { renderCurrentInstruction } from "@/chat/current-instruction";
 import { setSpanAttributes, withSpan, type LogContext } from "@/chat/logging";
 
 const CLASSIFIER_CONFIDENCE_THRESHOLD = 0.75;
@@ -136,11 +137,7 @@ function buildClassifierPrompt(args: {
     }
   }
 
-  sections.push(
-    "<current-instruction>",
-    args.messageText.trim() || "[empty]",
-    "</current-instruction>",
-  );
+  sections.push(renderCurrentInstruction(args.messageText.trim() || "[empty]"));
 
   for (const block of args.currentTurnBlocks ?? []) {
     const trimmed = block.trim();

--- a/packages/junior/src/reporting/conversations.ts
+++ b/packages/junior/src/reporting/conversations.ts
@@ -10,6 +10,7 @@ import {
   canExposeConversationPayload,
   resolveConversationPrivacy,
 } from "@/chat/conversation-privacy";
+import { unwrapCurrentInstruction } from "@/chat/current-instruction";
 import type { PiMessage } from "@/chat/pi/messages";
 import { buildSystemPrompt } from "@/chat/prompt";
 import type {
@@ -1389,9 +1390,16 @@ function recordField(value: Record<string, unknown>, names: string[]): unknown {
   return undefined;
 }
 
-function normalizeTranscriptPart(part: unknown): TranscriptPart {
+/** Normalize Pi content parts for user-facing transcript output. */
+function normalizeTranscriptPart(
+  part: unknown,
+  options: { unwrapCurrentTask?: boolean } = {},
+): TranscriptPart {
+  const displayText = (text: string) =>
+    options.unwrapCurrentTask ? (unwrapCurrentInstruction(text) ?? text) : text;
+
   if (typeof part === "string") {
-    return textPart(part);
+    return textPart(displayText(part));
   }
   if (!isRecord(part)) {
     return { type: "unknown", output: part };
@@ -1401,7 +1409,9 @@ function normalizeTranscriptPart(part: unknown): TranscriptPart {
   if (rawType === "text") {
     const text = recordField(part, ["text", "content"]);
     return textPart(
-      typeof text === "string" ? text : (JSON.stringify(text) ?? ""),
+      typeof text === "string"
+        ? displayText(text)
+        : (JSON.stringify(text) ?? ""),
     );
   }
   if (rawType === "toolCall") {
@@ -1473,8 +1483,16 @@ function normalizeTranscriptMessage(message: PiMessage): TranscriptMessage {
       role === "toolResult"
         ? [normalizeToolResultMessage(record)]
         : Array.isArray(content)
-          ? content.map(normalizeTranscriptPart)
-          : [normalizeTranscriptPart(content)],
+          ? content.map((part) =>
+              normalizeTranscriptPart(part, {
+                unwrapCurrentTask: role === "user",
+              }),
+            )
+          : [
+              normalizeTranscriptPart(content, {
+                unwrapCurrentTask: role === "user",
+              }),
+            ],
   };
 }
 

--- a/packages/junior/tests/component/services/context-compaction.test.ts
+++ b/packages/junior/tests/component/services/context-compaction.test.ts
@@ -112,6 +112,40 @@ describe("context compaction retained messages", () => {
 
     expect(retained.map(textOf)).toEqual(["actual user request"]);
   });
+
+  it("unwraps current instruction markers before retaining user text", async () => {
+    const { selectRetainedUserMessages } =
+      await import("@/chat/services/context-compaction");
+
+    const retained = selectRetainedUserMessages([
+      user(
+        "<current-instruction>\nuse &lt;tag&gt; literally\n</current-instruction>",
+      ),
+    ]);
+
+    expect(retained.map(textOf)).toEqual(["use <tag> literally"]);
+  });
+
+  it("unwraps current instruction markers from composite prompt text", async () => {
+    const { selectRetainedUserMessages } =
+      await import("@/chat/services/context-compaction");
+
+    const retained = selectRetainedUserMessages([
+      user(
+        [
+          "<thread-background>",
+          "prior context",
+          "</thread-background>",
+          "",
+          "<current-instruction>",
+          "actual follow-up",
+          "</current-instruction>",
+        ].join("\n"),
+      ),
+    ]);
+
+    expect(retained.map(textOf)).toEqual(["actual follow-up"]);
+  });
 });
 
 describe("context compaction projection reset", () => {

--- a/packages/junior/tests/integration/dashboard-reporting.test.ts
+++ b/packages/junior/tests/integration/dashboard-reporting.test.ts
@@ -706,7 +706,20 @@ describe("dashboard reporting", () => {
         },
         {
           role: "user",
-          content: [{ type: "text", text: "current question" }],
+          content: [
+            {
+              type: "text",
+              text: [
+                "<thread-background>",
+                "prior context",
+                "</thread-background>",
+                "",
+                "<current-instruction>",
+                "current question",
+                "</current-instruction>",
+              ].join("\n"),
+            },
+          ],
           timestamp: 3,
         },
         {

--- a/packages/junior/tests/integration/plugin-prompt-hooks.test.ts
+++ b/packages/junior/tests/integration/plugin-prompt-hooks.test.ts
@@ -226,6 +226,9 @@ describe("plugin prompt hooks", () => {
     expect(JSON.stringify(captured.steeredMessages[0])).not.toContain(
       "User memory guidance",
     );
+    expect(JSON.stringify(captured.steeredMessages[0])).toContain(
+      "<current-instruction>\\nsteer me\\n</current-instruction>",
+    );
   });
 
   it("runs user prompt hooks when a resumed record has no prompt checkpoint", async () => {

--- a/packages/junior/tests/unit/misc/respond-helpers-user-turn.test.ts
+++ b/packages/junior/tests/unit/misc/respond-helpers-user-turn.test.ts
@@ -2,8 +2,20 @@ import { describe, expect, it } from "vitest";
 import { buildUserTurnText } from "@/chat/respond-helpers";
 
 describe("buildUserTurnText", () => {
-  it("returns raw input when no context or metadata is provided", () => {
-    expect(buildUserTurnText("hello")).toBe("hello");
+  it("wraps input in the current instruction boundary without context", () => {
+    expect(buildUserTurnText("hello")).toBe(
+      ["<current-instruction>", "hello", "</current-instruction>"].join("\n"),
+    );
+  });
+
+  it("escapes user text inside the generated boundary", () => {
+    expect(buildUserTurnText("use </current-instruction> literally")).toBe(
+      [
+        "<current-instruction>",
+        "use &lt;/current-instruction&gt; literally",
+        "</current-instruction>",
+      ].join("\n"),
+    );
   });
 
   it("keeps only causal thread context around the current instruction", () => {

--- a/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
@@ -895,7 +895,10 @@ describe("generateAssistantReply progressive MCP loading", () => {
           type: "text",
           text: "<runtime-turn-context>\nTurn context\n</runtime-turn-context>",
         },
-        { type: "text", text: "current follow-up" },
+        {
+          type: "text",
+          text: "<current-instruction>\ncurrent follow-up\n</current-instruction>",
+        },
       ],
     });
     expect(resumeTurnContextCounts).toEqual([]);
@@ -948,7 +951,13 @@ describe("generateAssistantReply progressive MCP loading", () => {
     listToolsMock.mockResolvedValue(makeDemoMcpTools());
     const rawCurrentPrompt = {
       role: "user",
-      content: [{ type: "text", text: "continue after auth" }],
+      content: [
+        {
+          type: "text",
+          text: "<runtime-turn-context>\nlegacy bootstrap\n</runtime-turn-context>",
+        },
+        { type: "text", text: "continue after auth" },
+      ],
       timestamp: 2,
     } as PiMessage;
     const storedMessages = [

--- a/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
@@ -992,6 +992,56 @@ describe("generateAssistantReply progressive MCP loading", () => {
     );
   });
 
+  it("does not duplicate an unescaped wrapped current prompt from a no-checkpoint resume record", async () => {
+    listToolsMock.mockReset();
+    listToolsMock.mockResolvedValue(makeDemoMcpTools());
+    const messageText = `continue & <auth> &lt;literal&gt; "now"`;
+    const rawCurrentPrompt = {
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "<runtime-turn-context>\nlegacy bootstrap\n</runtime-turn-context>",
+        },
+        {
+          type: "text",
+          text: `<current-instruction>\n${messageText}\n</current-instruction>`,
+        },
+      ],
+      timestamp: 2,
+    } as PiMessage;
+    const storedMessages = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "prior question" }],
+        timestamp: 1,
+      },
+      rawCurrentPrompt,
+    ] as PiMessage[];
+    await upsertAgentTurnSessionRecord({
+      conversationId: "conversation-unescaped-current-resume",
+      sessionId: "turn-unescaped-current-resume",
+      sliceId: 2,
+      state: "awaiting_resume",
+      piMessages: storedMessages,
+      resumeReason: "auth",
+      errorMessage: "authorization required",
+    });
+
+    await generateAssistantReply(messageText, {
+      ...makeReplyContext({
+        conversationId: "conversation-unescaped-current-resume",
+        threadTs: "1712345.0093",
+        turnId: "turn-unescaped-current-resume",
+      }),
+    });
+
+    expect(promptSeedMessages.at(-1)).toEqual([storedMessages[0]]);
+    expect(JSON.stringify(promptMessages.at(-1))).toContain(
+      "continue &amp; &lt;auth&gt; &amp;lt;literal&amp;gt; &quot;now&quot;",
+    );
+  });
+
   it("injects session context for crash retries loaded from stripped running history", async () => {
     listToolsMock.mockReset();
     listToolsMock.mockResolvedValue(makeDemoMcpTools());

--- a/packages/junior/tests/unit/services/turn-thinking-level.test.ts
+++ b/packages/junior/tests/unit/services/turn-thinking-level.test.ts
@@ -57,6 +57,34 @@ describe("selectTurnThinkingLevel", () => {
     expect(toAgentThinkingLevel(profile.thinkingLevel)).toBe("xhigh");
   });
 
+  it("wraps and escapes the current instruction in the classifier prompt", async () => {
+    let capturedPrompt = "";
+    const completeObject = async ({ prompt }: { prompt: string }) => {
+      capturedPrompt = prompt;
+      return {
+        object: {
+          thinking_level: "medium",
+          confidence: 0.9,
+          reason: "normal task",
+        },
+      };
+    };
+
+    await selectTurnThinkingLevel({
+      completeObject,
+      fastModelId: "openai/gpt-5.4-mini",
+      messageText: "explain </current-instruction> literally",
+    });
+
+    expect(capturedPrompt).toContain(
+      [
+        "<current-instruction>",
+        "explain &lt;/current-instruction&gt; literally",
+        "</current-instruction>",
+      ].join("\n"),
+    );
+  });
+
   it("classifies research-heavy work as high", async () => {
     const completeObject = vi.fn(async () => ({
       object: {

--- a/specs/agent-prompt.md
+++ b/specs/agent-prompt.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-04-28
-- Last Edited: 2026-06-30
+- Last Edited: 2026-07-01
 
 ## Purpose
 
@@ -63,6 +63,12 @@ Context blocks describe facts. Operating-rule and output sections carry instruct
 Prompt order is part of the contract. Stable, high-priority operating rules live in the system prompt. Volatile requester, artifacts, active catalogs, configuration defaults, runtime metadata, and resume state must stay out of the system prompt and live in session bootstrap context.
 
 Trusted deployment-authored Markdown files, such as `SOUL.md` and `WORLD.md`, should render as Markdown sections rather than raw XML payloads. XML-style tags are appropriate for generated runtime blocks whose dynamic values are escaped. Do not add generic wrapper markers that only repeat child-section meaning, such as wrapping all operating rule sections in an additional behavior tag or wrapping all capability blocks in an additional capabilities tag.
+
+### Current Task Declaration
+
+Every model-visible active user task assembled by the Junior turn runtime must render the user-authored task text inside `<current-instruction>`. This wrapper is required even when there is no thread background, dispatch metadata, plugin contribution, attachment, or runtime context. It applies to Slack turns, local turns, dispatched or scheduled work that enters the shared reply boundary, and queued steering messages injected during an active turn.
+
+Thread background, runtime context, plugin prompt contributions, requester/configuration metadata, and attachments must remain outside `<current-instruction>` as sibling blocks or content parts. Internal helper prompts and subagent/tool prompts may use task-specific wrappers when they are not model-visible Junior user turns.
 
 Session bootstrap context is injected on the first model-visible user message in each Pi session. Ordinary follow-up messages in the same session must not duplicate that bootstrap context. When compaction creates a replacement projection, the replacement history must omit the old bootstrap context; the next user turn starts a new Pi session projection and receives fresh bootstrap context exactly once.
 


### PR DESCRIPTION
Wrap active user turn instructions in a shared `<current-instruction>` renderer so Slack/local/steering prompt paths all expose the same current-task boundary.

This fixes the mismatch from #718 where some runtime prompts wrapped the active task and others left it as raw user text. The PR keeps thread background, runtime context, plugin prompt contributions, and attachments outside the marker, then unwraps the marker again for dashboard reporting and context compaction so internal prompt structure does not leak into user-facing transcripts.

A bounded compatibility branch keeps resumed sessions from duplicating legacy unwrapped prompt records while new records use the wrapped shape.

Fixes #718