### PR TITLE
fix(docs): reduce homepage hero vertical padding

### DIFF
--- a/packages/docs/src/styles/custom.css
+++ b/packages/docs/src/styles/custom.css
@@ -22,6 +22,10 @@
   width: 2rem;
 }
 
+:root:not([data-has-sidebar]) .hero {
+  padding-block: clamp(1.5rem, 0.5rem + 5vmin, 5rem);
+}
+
 :root:not([data-has-sidebar]) .hero :is(h1, [data-page-title]) {
   max-width: 46rem;
 }
@@ -65,7 +69,7 @@
 }
 
 .jr-home {
-  margin-top: 2rem;
+  margin-top: 1rem;
 }
 
 .slk-window {


### PR DESCRIPTION
The hero `padding-block` was `clamp(2.5rem, 1rem + 10vmin, 10rem)`, computing to **116px per side** at a typical 1440×1000 desktop viewport — way too much vertical breathing room.

## What changed

- Added a `padding-block` override on `:root:not([data-has-sidebar]) .hero` → `clamp(1.5rem, 0.5rem + 5vmin, 5rem)`, landing at **~58px** at 1440×1000 (half the original). Targets only the splash/no-sidebar homepage so sidebar pages are unaffected.
- Trimmed `.jr-home { margin-top }` from `2rem` → `1rem`.

## Verified

- `astro build` passes (99 pages, 0 errors)
- Visual QA on localhost preview: desktop (1440×1000) and mobile (iPhone 14) — hero is compact, Slack window demo is more visible above the fold, no layout breakage

<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC0AHB7N2JCR%3A1782945032.085809/?project=4510944073809921)

<!-- junior-session-footer:end -->