### PR TITLE
fix(chat): Close privacy, recovery, and delivery gaps in the message pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,7 @@ Co-Authored-By: (agent model name) <email>
 - `policies/frontend-components.md` (Tailwind colocation and component-owned frontend styling)
 - `policies/interface-design.md` (domain naming, module paths, and minimal interface boundaries)
 - `policies/policy-template.md` (template for adding new policy docs)
+- `policies/provider-boundaries.md` (keep provider SDKs and primitives inside provider-owned modules)
 - `policies/runtime-boundary-schemas.md` (strict runtime schemas and inferred types for boundary contracts)
 - `policies/test-adapters.md` (Django-inspired shared test adapters, outboxes, and isolation rules)
 - `policies/testing.md` (integration/eval-first testing policy and unit-test churn guardrails)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,7 @@ Co-Authored-By: (agent model name) <email>
 - `policies/README.md` (when to add a policy doc and how policy docs should stay scoped)
 - `policies/agentic-semantics.md` (agentic semantic decisions vs deterministic boundary checks)
 - `policies/code-comments.md` (repo default for code comments, docstrings, and exported-function JSDoc)
+- `policies/correctness-complexity.md` (balancing correctness fixes against simplicity, understandability, and maintainability)
 - `policies/context-bound-systems.md` (explicit actor/destination/context propagation across runtime boundaries)
 - `policies/evals.md` (evals as behavior integration tests and rubric authoring boundaries)
 - `policies/error-handling.md` (when to catch locally vs let top-level handlers own failures)

--- a/packages/junior-dashboard/src/client/format.ts
+++ b/packages/junior-dashboard/src/client/format.ts
@@ -610,6 +610,15 @@ export function conversationIdentityMeta(
   return owner ? `${owner} · ${id}` : id;
 }
 
+const REDACTED_CHANNEL_LABELS = new Set([
+  "Public Channel",
+  "Private Channel",
+  "Group DM",
+  "Direct Message",
+  "Private Channel or Group DM",
+  "Private Conversation",
+]);
+
 /** Convert Slack channel ids and names into user-facing location labels. */
 export function slackLocationLabel(
   input: Pick<ConversationSummary, "channel" | "channelName">,
@@ -619,8 +628,13 @@ export function slackLocationLabel(
   if (!channelId) return undefined;
 
   const includeId = options.includeId ?? true;
-  const name = input.channelName?.replace(/^#/, "");
   const idSuffix = includeId ? ` (${channelId})` : "";
+  // Privacy-redacted conversations carry a generic type label instead of a
+  // channel name; render it as-is rather than formatting it like a name.
+  if (input.channelName && REDACTED_CHANNEL_LABELS.has(input.channelName)) {
+    return `${input.channelName}${idSuffix}`;
+  }
+  const name = input.channelName?.replace(/^#/, "");
   if (channelId.startsWith("D")) {
     return `Direct Message${idSuffix}`;
   }

--- a/packages/junior-dashboard/src/client/format.ts
+++ b/packages/junior-dashboard/src/client/format.ts
@@ -610,18 +610,12 @@ export function conversationIdentityMeta(
   return owner ? `${owner} · ${id}` : id;
 }
 
-const REDACTED_CHANNEL_LABELS = new Set([
-  "Public Channel",
-  "Private Channel",
-  "Group DM",
-  "Direct Message",
-  "Private Channel or Group DM",
-  "Private Conversation",
-]);
-
 /** Convert Slack channel ids and names into user-facing location labels. */
 export function slackLocationLabel(
-  input: Pick<ConversationSummary, "channel" | "channelName">,
+  input: Pick<
+    ConversationSummary,
+    "channel" | "channelName" | "channelNameRedacted"
+  >,
   options: { includeId?: boolean } = {},
 ): string | undefined {
   const channelId = input.channel;
@@ -629,9 +623,7 @@ export function slackLocationLabel(
 
   const includeId = options.includeId ?? true;
   const idSuffix = includeId ? ` (${channelId})` : "";
-  // Privacy-redacted conversations carry a generic type label instead of a
-  // channel name; render it as-is rather than formatting it like a name.
-  if (input.channelName && REDACTED_CHANNEL_LABELS.has(input.channelName)) {
+  if (input.channelNameRedacted && input.channelName) {
     return `${input.channelName}${idSuffix}`;
   }
   const name = input.channelName?.replace(/^#/, "");

--- a/packages/junior-dashboard/tests/format.test.ts
+++ b/packages/junior-dashboard/tests/format.test.ts
@@ -757,27 +757,24 @@ describe("canRenderStructuredMarkup", () => {
 });
 
 describe("slackLocationLabel redacted labels", () => {
-  const redactedLabels = [
-    "Public Channel",
-    "Private Channel",
-    "Group DM",
-    "Direct Message",
-    "Private Channel or Group DM",
-    "Private Conversation",
-  ];
-
-  it("returns redacted type labels verbatim instead of formatting them as channel names", () => {
-    for (const label of redactedLabels) {
-      expect(slackLocationLabel({ channel: "C123", channelName: label })).toBe(
-        `${label} (C123)`,
-      );
-      expect(
-        slackLocationLabel(
-          { channel: "C123", channelName: label },
-          { includeId: false },
-        ),
-      ).toBe(label);
-    }
+  it("returns redacted type labels verbatim when the report marks them redacted", () => {
+    expect(
+      slackLocationLabel({
+        channel: "C123",
+        channelName: "Private Conversation",
+        channelNameRedacted: true,
+      }),
+    ).toBe("Private Conversation (C123)");
+    expect(
+      slackLocationLabel(
+        {
+          channel: "C123",
+          channelName: "Private Conversation",
+          channelNameRedacted: true,
+        },
+        { includeId: false },
+      ),
+    ).toBe("Private Conversation");
   });
 
   it("still formats real channel names with a # prefix", () => {
@@ -787,5 +784,11 @@ describe("slackLocationLabel redacted labels", () => {
         { includeId: false },
       ),
     ).toBe("#proj-alpha");
+    expect(
+      slackLocationLabel(
+        { channel: "C123", channelName: "Private Conversation" },
+        { includeId: false },
+      ),
+    ).toBe("#Private Conversation");
   });
 });

--- a/packages/junior-dashboard/tests/format.test.ts
+++ b/packages/junior-dashboard/tests/format.test.ts
@@ -17,6 +17,7 @@ import {
   formatUsageTotal,
   parseMarkdownBlocks,
   requesterLabel,
+  slackLocationLabel,
   summarizeMessages,
   summarizeToolCalls,
   summarizeUsage,
@@ -752,5 +753,39 @@ describe("canRenderStructuredMarkup", () => {
     const [block] = parseMarkdownBlocks("<foo>bar</foo>", { outputOnly: true });
     expect(block?.language).toBe("markdown");
     expect(canRenderStructuredMarkup(block!)).toBe(false);
+  });
+});
+
+describe("slackLocationLabel redacted labels", () => {
+  const redactedLabels = [
+    "Public Channel",
+    "Private Channel",
+    "Group DM",
+    "Direct Message",
+    "Private Channel or Group DM",
+    "Private Conversation",
+  ];
+
+  it("returns redacted type labels verbatim instead of formatting them as channel names", () => {
+    for (const label of redactedLabels) {
+      expect(slackLocationLabel({ channel: "C123", channelName: label })).toBe(
+        `${label} (C123)`,
+      );
+      expect(
+        slackLocationLabel(
+          { channel: "C123", channelName: label },
+          { includeId: false },
+        ),
+      ).toBe(label);
+    }
+  });
+
+  it("still formats real channel names with a # prefix", () => {
+    expect(
+      slackLocationLabel(
+        { channel: "C123", channelName: "proj-alpha" },
+        { includeId: false },
+      ),
+    ).toBe("#proj-alpha");
   });
 });

--- a/packages/junior-evals/evals/memory/workflows.eval.ts
+++ b/packages/junior-evals/evals/memory/workflows.eval.ts
@@ -44,6 +44,8 @@ async function seedMemory(args: {
       messageTs: args.thread.thread_ts,
       teamId: memoryTeamId,
       threadTs: args.thread.thread_ts,
+
+      type: "priv",
     }),
   });
   const input = {
@@ -403,6 +405,8 @@ describeEval("Memory Workflows", slackEvals, (it) => {
         messageTs: "17000000.memory-supersession",
         teamId: memoryTeamId,
         threadTs: "17000000.memory-supersession",
+
+        type: "priv",
       }),
     };
 

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -268,9 +268,9 @@ function slackContext(
     source: createSlackSource({
       teamId,
       channelId,
-      // Only channel_type can mark a source public; C-prefixed test channels
-      // model public channels unless a test overrides this.
-      ...(channelId.startsWith("C") ? { channelType: "channel" as const } : {}),
+      // The Slack boundary supplies normalized public visibility for these
+      // C-prefixed test channels unless a test overrides the channel id.
+      ...(channelId.startsWith("C") ? { type: "pub" as const } : {}),
       messageTs: threadTs,
       threadTs,
     }),
@@ -1168,6 +1168,8 @@ describe("memory plugin storage", () => {
                 source: createSlackSource({
                   teamId: runtime.source.teamId,
                   channelId: runtime.source.channelId,
+
+                  type: "priv",
                 }),
               });
             },

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -268,6 +268,9 @@ function slackContext(
     source: createSlackSource({
       teamId,
       channelId,
+      // Only channel_type can mark a source public; C-prefixed test channels
+      // model public channels unless a test overrides this.
+      ...(channelId.startsWith("C") ? { channelType: "channel" as const } : {}),
       messageTs: threadTs,
       threadTs,
     }),

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -270,7 +270,7 @@ function slackContext(
       channelId,
       // The Slack boundary supplies normalized public visibility for these
       // C-prefixed test channels unless a test overrides the channel id.
-      ...(channelId.startsWith("C") ? { type: "pub" as const } : {}),
+      type: channelId.startsWith("C") ? "pub" : "priv",
       messageTs: threadTs,
       threadTs,
     }),

--- a/packages/junior-plugin-api/src/context.ts
+++ b/packages/junior-plugin-api/src/context.ts
@@ -88,16 +88,25 @@ export interface LocalInvocationContext extends BaseInvocationContext {
 
 export type InvocationContext = LocalInvocationContext | SlackInvocationContext;
 
+/** Slack Events API channel_type values accepted as source visibility signals. */
+export type SlackSourceChannelType = "channel" | "group" | "im" | "mpim";
+
 /** Build a normalized Slack source from runtime-owned Slack coordinates. */
 export function createSlackSource(input: {
   channelId: string;
+  /**
+   * Slack Events API `channel_type` for the inbound event. This is the only
+   * signal that can mark a source public; without it the source fails closed
+   * to private.
+   */
+  channelType?: SlackSourceChannelType;
   messageTs?: string;
   teamId: string;
   threadTs?: string;
 }): SlackSource {
   return {
     platform: "slack",
-    type: slackSourceType(input.channelId),
+    type: slackSourceType(input.channelId, input.channelType),
     teamId: input.teamId,
     channelId: input.channelId,
     ...(input.messageTs ? { messageTs: input.messageTs } : {}),
@@ -105,11 +114,24 @@ export function createSlackSource(input: {
   };
 }
 
-/** Classify Slack's documented C/D/G channel id prefixes into source visibility. */
-function slackSourceType(channelId: string): SourceType {
-  if (channelId.startsWith("C")) return "pub";
-  if (channelId.startsWith("D") || channelId.startsWith("G")) return "priv";
-  throw new Error(`Unsupported Slack channel ID prefix: ${channelId}`);
+/**
+ * Classify Slack source visibility from the event's channel_type signal.
+ *
+ * Channel-id prefixes cannot prove a conversation public — modern Slack
+ * private channels also use `C`-prefixed ids — so prefixes may only narrow
+ * toward private and unsigned `C` sources fail closed to private.
+ */
+function slackSourceType(
+  channelId: string,
+  channelType: SlackSourceChannelType | undefined,
+): SourceType {
+  if (channelId.startsWith("D") || channelId.startsWith("G")) {
+    return "priv";
+  }
+  if (!channelId.startsWith("C")) {
+    throw new Error(`Unsupported Slack channel ID prefix: ${channelId}`);
+  }
+  return channelType === "channel" ? "pub" : "priv";
 }
 
 /** Build a normalized local source from a local conversation id. */

--- a/packages/junior-plugin-api/src/context.ts
+++ b/packages/junior-plugin-api/src/context.ts
@@ -88,50 +88,23 @@ export interface LocalInvocationContext extends BaseInvocationContext {
 
 export type InvocationContext = LocalInvocationContext | SlackInvocationContext;
 
-/** Slack Events API channel_type values accepted as source visibility signals. */
-export type SlackSourceChannelType = "channel" | "group" | "im" | "mpim";
-
 /** Build a normalized Slack source from runtime-owned Slack coordinates. */
 export function createSlackSource(input: {
   channelId: string;
-  /**
-   * Slack Events API `channel_type` for the inbound event. This is the only
-   * signal that can mark a source public; without it the source fails closed
-   * to private.
-   */
-  channelType?: SlackSourceChannelType;
   messageTs?: string;
   teamId: string;
   threadTs?: string;
+  /** Runtime-normalized source visibility. */
+  type: SourceType;
 }): SlackSource {
   return {
     platform: "slack",
-    type: slackSourceType(input.channelId, input.channelType),
+    type: input.type,
     teamId: input.teamId,
     channelId: input.channelId,
     ...(input.messageTs ? { messageTs: input.messageTs } : {}),
     ...(input.threadTs ? { threadTs: input.threadTs } : {}),
   };
-}
-
-/**
- * Classify Slack source visibility from the event's channel_type signal.
- *
- * Channel-id prefixes cannot prove a conversation public — modern Slack
- * private channels also use `C`-prefixed ids — so prefixes may only narrow
- * toward private and unsigned `C` sources fail closed to private.
- */
-function slackSourceType(
-  channelId: string,
-  channelType: SlackSourceChannelType | undefined,
-): SourceType {
-  if (channelId.startsWith("D") || channelId.startsWith("G")) {
-    return "priv";
-  }
-  if (!channelId.startsWith("C")) {
-    throw new Error(`Unsupported Slack channel ID prefix: ${channelId}`);
-  }
-  return channelType === "channel" ? "pub" : "priv";
 }
 
 /** Build a normalized local source from a local conversation id. */

--- a/packages/junior-scheduler/src/plugin.ts
+++ b/packages/junior-scheduler/src/plugin.ts
@@ -80,6 +80,8 @@ function scheduledTaskDispatchSource(task: ScheduledTask): Source {
   return createSlackSource({
     teamId: task.destination.teamId,
     channelId: task.destination.channelId,
+
+    type: "priv",
   });
 }
 

--- a/packages/junior/.dependency-cruiser.mjs
+++ b/packages/junior/.dependency-cruiser.mjs
@@ -37,6 +37,19 @@ export default {
       },
     },
     {
+      name: "no-slack-sdk-outside-provider-modules",
+      comment:
+        "Slack SDK imports must stay in Slack-owned infrastructure or Slack tool modules.",
+      severity: "error",
+      from: {
+        path: "^src/chat/",
+        pathNot: "^src/chat/(slack/|tools/slack/)",
+      },
+      to: {
+        path: "^@slack/",
+      },
+    },
+    {
       name: "no-chat-slack-to-runtime",
       comment:
         "Slack modules must own Slack behavior and avoid runtime orchestration imports.",

--- a/packages/junior/src/chat/agent-dispatch/runner.ts
+++ b/packages/junior/src/chat/agent-dispatch/runner.ts
@@ -41,6 +41,7 @@ import {
 } from "@/chat/slack/reply";
 import { buildSlackReplyFooter } from "@/chat/slack/footer";
 import { finalizeFailedTurnReply } from "@/chat/services/turn-failure-response";
+import { persistCompletedSessionRecord } from "@/chat/services/turn-session-record";
 import { AuthorizationFlowDisabledError } from "@/chat/services/auth-pause";
 import { PluginCredentialFailureError } from "@/chat/services/plugin-auth-orchestration";
 import { scheduleSessionCompletedPluginTasks } from "@/chat/plugins/task-runner";
@@ -124,6 +125,38 @@ async function persistRuntimePatch(args: {
     sandboxId: args.sandboxId,
     sandboxDependencyProfileHash: args.sandboxDependencyProfileHash,
   });
+}
+
+const DELIVERED_PATCH_PERSIST_ATTEMPTS = 3;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Persist the post-delivery dispatch state with a short retry so a transient
+ * state write does not drop the delivered marker that suppresses re-posts.
+ */
+async function persistRuntimePatchWithRetry(
+  args: Parameters<typeof persistRuntimePatch>[0],
+): Promise<void> {
+  let lastError: unknown;
+  for (
+    let attempt = 1;
+    attempt <= DELIVERED_PATCH_PERSIST_ATTEMPTS;
+    attempt += 1
+  ) {
+    try {
+      await persistRuntimePatch(args);
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt < DELIVERED_PATCH_PERSIST_ATTEMPTS) {
+        await sleep(attempt * 100);
+      }
+    }
+  }
+  throw lastError;
 }
 
 async function markDispatch(args: {
@@ -374,6 +407,12 @@ export async function runAgentDispatchSlice(
       fileUploadFailureMode: "strict",
     });
 
+    // Slack accepted the reply: everything after this point serves duplicate
+    // suppression and bookkeeping, and must not turn into a failed dispatch
+    // that a retry would re-post. Persist the delivered marker
+    // (`meta.slackTs`, checked by the redelivery guard above) immediately and
+    // durably before the dispatch is marked terminal so the crash window
+    // between post and marker stays as small as possible.
     markConversationMessage(conversation, userMessageId, {
       replied: true,
       skippedReason: undefined,
@@ -396,14 +435,53 @@ export async function runAgentDispatchSlice(
     const nextArtifacts = reply.artifactStatePatch
       ? mergeArtifactsState(artifacts, reply.artifactStatePatch)
       : artifacts;
-    await persistRuntimePatch({
-      threadId: conversationId,
-      conversation,
-      artifacts: nextArtifacts,
-      sandboxId: reply.sandboxId ?? sandboxId,
-      sandboxDependencyProfileHash:
-        reply.sandboxDependencyProfileHash ?? sandboxDependencyProfileHash,
-    });
+    try {
+      await persistRuntimePatchWithRetry({
+        threadId: conversationId,
+        conversation,
+        artifacts: nextArtifacts,
+        sandboxId: reply.sandboxId ?? sandboxId,
+        sandboxDependencyProfileHash:
+          reply.sandboxDependencyProfileHash ?? sandboxDependencyProfileHash,
+      });
+    } catch (persistError) {
+      logException(
+        persistError,
+        "agent_dispatch_post_delivery_persist_failed",
+        {
+          conversationId,
+          slackThreadId: conversationId,
+          slackChannelId: dispatch.destination.channelId,
+          runId: dispatch.id,
+          actorType: dispatch.actor.type,
+          actorId: dispatch.actor.id,
+          assistantUserName: botConfig.userName,
+        },
+        {},
+        "Failed to persist delivered dispatch state after Slack accepted the reply",
+      );
+    }
+    if (!failure && reply.piMessages?.length) {
+      // Destination acceptance is the completion boundary for the session
+      // record too; this call swallows its own persistence failures.
+      await persistCompletedSessionRecord({
+        conversationId,
+        sessionId: getDispatchTurnId(dispatch.id),
+        allMessages: reply.piMessages,
+        currentDurationMs: reply.diagnostics.durationMs,
+        currentUsage: reply.diagnostics.usage,
+        destination: dispatch.destination,
+        source: dispatch.source,
+        surface: "api",
+        logContext: {
+          threadId: conversationId,
+          channelId: dispatch.destination.channelId,
+          runId: dispatch.id,
+          assistantUserName: botConfig.userName,
+          modelId: reply.diagnostics.modelId,
+        },
+      });
+    }
     dispatch = await markDispatch({
       dispatch,
       status: failure ? "failed" : "completed",

--- a/packages/junior/src/chat/agent-dispatch/runner.ts
+++ b/packages/junior/src/chat/agent-dispatch/runner.ts
@@ -428,7 +428,7 @@ export async function runAgentDispatchSlice(
         "Failed to persist delivered dispatch state after Slack accepted the reply",
       );
     }
-    if (!failure && reply.piMessages?.length) {
+    if (reply.piMessages?.length) {
       // Destination acceptance is the completion boundary for the session
       // record too; this call swallows its own persistence failures.
       await completeDeliveredTurn({

--- a/packages/junior/src/chat/agent-dispatch/runner.ts
+++ b/packages/junior/src/chat/agent-dispatch/runner.ts
@@ -41,7 +41,7 @@ import {
 } from "@/chat/slack/reply";
 import { buildSlackReplyFooter } from "@/chat/slack/footer";
 import { finalizeFailedTurnReply } from "@/chat/services/turn-failure-response";
-import { persistCompletedSessionRecord } from "@/chat/services/turn-session-record";
+import { completeDeliveredTurn } from "@/chat/services/turn-session-record";
 import { persistWithRetry } from "@/chat/services/persist-retry";
 import { AuthorizationFlowDisabledError } from "@/chat/services/auth-pause";
 import { PluginCredentialFailureError } from "@/chat/services/plugin-auth-orchestration";
@@ -431,12 +431,13 @@ export async function runAgentDispatchSlice(
     if (!failure && reply.piMessages?.length) {
       // Destination acceptance is the completion boundary for the session
       // record too; this call swallows its own persistence failures.
-      await persistCompletedSessionRecord({
+      await completeDeliveredTurn({
         conversationId,
         sessionId: turnId,
-        allMessages: reply.piMessages,
-        currentDurationMs: reply.diagnostics.durationMs,
-        currentUsage: reply.diagnostics.usage,
+        sliceId: 1,
+        messages: reply.piMessages,
+        durationMs: reply.diagnostics.durationMs,
+        usage: reply.diagnostics.usage,
         destination: dispatch.destination,
         source: dispatch.source,
         surface: "api",

--- a/packages/junior/src/chat/agent-dispatch/runner.ts
+++ b/packages/junior/src/chat/agent-dispatch/runner.ts
@@ -128,16 +128,6 @@ async function persistRuntimePatch(args: {
   });
 }
 
-/**
- * Persist the post-delivery dispatch state with a short retry so a transient
- * state write does not drop the delivered marker that suppresses re-posts.
- */
-async function persistRuntimePatchWithRetry(
-  args: Parameters<typeof persistRuntimePatch>[0],
-): Promise<void> {
-  await persistWithRetry(() => persistRuntimePatch(args));
-}
-
 async function markDispatch(args: {
   dispatch: DispatchRecord;
   errorMessage?: string;
@@ -215,6 +205,16 @@ export async function runAgentDispatchSlice(
   let dispatch = claimedDispatch;
 
   const conversationId = getDispatchConversationId(dispatch);
+  const turnId = getDispatchTurnId(dispatch.id);
+  const logContext = {
+    conversationId,
+    slackThreadId: conversationId,
+    slackChannelId: dispatch.destination.channelId,
+    runId: dispatch.id,
+    actorType: dispatch.actor.type,
+    actorId: dispatch.actor.id,
+    assistantUserName: botConfig.userName,
+  };
   const destinationLockId = getDispatchDestinationLockId(dispatch.destination);
   const stateAdapter = getStateAdapter();
   await stateAdapter.connect();
@@ -319,7 +319,7 @@ export async function runAgentDispatchSlice(
       correlation: {
         conversationId,
         threadId: conversationId,
-        turnId: getDispatchTurnId(dispatch.id),
+        turnId,
         runId: dispatch.id,
         channelId: dispatch.destination.channelId,
         teamId: dispatch.destination.teamId,
@@ -364,13 +364,7 @@ export async function runAgentDispatchSlice(
         reply,
         logException,
         context: {
-          conversationId,
-          slackThreadId: conversationId,
-          slackChannelId: dispatch.destination.channelId,
-          runId: dispatch.id,
-          actorType: dispatch.actor.type,
-          actorId: dispatch.actor.id,
-          assistantUserName: botConfig.userName,
+          ...logContext,
           modelId: reply.diagnostics.modelId,
         },
       });
@@ -415,27 +409,21 @@ export async function runAgentDispatchSlice(
       ? mergeArtifactsState(artifacts, reply.artifactStatePatch)
       : artifacts;
     try {
-      await persistRuntimePatchWithRetry({
-        threadId: conversationId,
-        conversation,
-        artifacts: nextArtifacts,
-        sandboxId: reply.sandboxId ?? sandboxId,
-        sandboxDependencyProfileHash:
-          reply.sandboxDependencyProfileHash ?? sandboxDependencyProfileHash,
-      });
+      await persistWithRetry(() =>
+        persistRuntimePatch({
+          threadId: conversationId,
+          conversation,
+          artifacts: nextArtifacts,
+          sandboxId: reply.sandboxId ?? sandboxId,
+          sandboxDependencyProfileHash:
+            reply.sandboxDependencyProfileHash ?? sandboxDependencyProfileHash,
+        }),
+      );
     } catch (persistError) {
       logException(
         persistError,
         "agent_dispatch_post_delivery_persist_failed",
-        {
-          conversationId,
-          slackThreadId: conversationId,
-          slackChannelId: dispatch.destination.channelId,
-          runId: dispatch.id,
-          actorType: dispatch.actor.type,
-          actorId: dispatch.actor.id,
-          assistantUserName: botConfig.userName,
-        },
+        logContext,
         {},
         "Failed to persist delivered dispatch state after Slack accepted the reply",
       );
@@ -445,7 +433,7 @@ export async function runAgentDispatchSlice(
       // record too; this call swallows its own persistence failures.
       await persistCompletedSessionRecord({
         conversationId,
-        sessionId: getDispatchTurnId(dispatch.id),
+        sessionId: turnId,
         allMessages: reply.piMessages,
         currentDurationMs: reply.diagnostics.durationMs,
         currentUsage: reply.diagnostics.usage,
@@ -471,21 +459,13 @@ export async function runAgentDispatchSlice(
       try {
         await scheduleCompletedTasks({
           conversationId,
-          sessionId: getDispatchTurnId(dispatch.id),
+          sessionId: turnId,
         });
       } catch (error) {
         logException(
           error,
           "plugin_session_completed_task_schedule_failed",
-          {
-            conversationId,
-            slackThreadId: conversationId,
-            slackChannelId: dispatch.destination.channelId,
-            runId: dispatch.id,
-            actorType: dispatch.actor.type,
-            actorId: dispatch.actor.id,
-            assistantUserName: botConfig.userName,
-          },
+          logContext,
           {},
           "Plugin session.completed task scheduling failed",
         );
@@ -539,13 +519,7 @@ export async function runAgentDispatchSlice(
       error,
       "agent_dispatch_run_failed",
       {
-        conversationId,
-        slackThreadId: conversationId,
-        slackChannelId: dispatch.destination.channelId,
-        runId: dispatch.id,
-        actorType: dispatch.actor.type,
-        actorId: dispatch.actor.id,
-        assistantUserName: botConfig.userName,
+        ...logContext,
         modelId: botConfig.modelId,
       },
       {},

--- a/packages/junior/src/chat/agent-dispatch/runner.ts
+++ b/packages/junior/src/chat/agent-dispatch/runner.ts
@@ -42,6 +42,7 @@ import {
 import { buildSlackReplyFooter } from "@/chat/slack/footer";
 import { finalizeFailedTurnReply } from "@/chat/services/turn-failure-response";
 import { persistCompletedSessionRecord } from "@/chat/services/turn-session-record";
+import { persistWithRetry } from "@/chat/services/persist-retry";
 import { AuthorizationFlowDisabledError } from "@/chat/services/auth-pause";
 import { PluginCredentialFailureError } from "@/chat/services/plugin-auth-orchestration";
 import { scheduleSessionCompletedPluginTasks } from "@/chat/plugins/task-runner";
@@ -127,12 +128,6 @@ async function persistRuntimePatch(args: {
   });
 }
 
-const DELIVERED_PATCH_PERSIST_ATTEMPTS = 3;
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 /**
  * Persist the post-delivery dispatch state with a short retry so a transient
  * state write does not drop the delivered marker that suppresses re-posts.
@@ -140,23 +135,7 @@ function sleep(ms: number): Promise<void> {
 async function persistRuntimePatchWithRetry(
   args: Parameters<typeof persistRuntimePatch>[0],
 ): Promise<void> {
-  let lastError: unknown;
-  for (
-    let attempt = 1;
-    attempt <= DELIVERED_PATCH_PERSIST_ATTEMPTS;
-    attempt += 1
-  ) {
-    try {
-      await persistRuntimePatch(args);
-      return;
-    } catch (error) {
-      lastError = error;
-      if (attempt < DELIVERED_PATCH_PERSIST_ATTEMPTS) {
-        await sleep(attempt * 100);
-      }
-    }
-  }
-  throw lastError;
+  await persistWithRetry(() => persistRuntimePatch(args));
 }
 
 async function markDispatch(args: {

--- a/packages/junior/src/chat/conversation-privacy.ts
+++ b/packages/junior/src/chat/conversation-privacy.ts
@@ -6,40 +6,61 @@ type TraceAttributeValue = string | number | boolean | string[];
 const SAFE_METADATA_KEY_LIMIT = 20;
 const conversationPrivacyStorage = new AsyncLocalStorage<ConversationPrivacy>();
 
-function conversationPrivacyFromChannelId(
+function privateNarrowingFromChannelId(
   channelId: string | undefined,
 ): ConversationPrivacy | undefined {
   const normalized = channelId?.trim();
   if (!normalized) return undefined;
-  return normalized.startsWith("C") ? "public" : "private";
+  // Channel-id prefixes may only narrow toward private. `C`-prefixed ids do
+  // not prove a conversation public: modern Slack private channels also use
+  // `C` prefixes, so they stay unknown without a confirmed signal.
+  return normalized.startsWith("D") || normalized.startsWith("G")
+    ? "private"
+    : undefined;
 }
 
-function conversationPrivacyFromConversationId(
+function privateNarrowingFromConversationId(
   conversationId: string | undefined,
 ): ConversationPrivacy | undefined {
   if (!conversationId?.trim()) return undefined;
   const slackThread = parseSlackThreadId(conversationId);
   if (slackThread) {
-    return conversationPrivacyFromChannelId(slackThread.channelId);
+    return privateNarrowingFromChannelId(slackThread.channelId);
   }
+  // Non-Slack conversations (local CLI, internal runs) are private surfaces.
   return "private";
 }
 
-/** Resolve whether a conversation may expose raw payloads based on known Slack identity. */
+/**
+ * Resolve whether a conversation may expose raw payloads.
+ *
+ * Only a confirmed visibility — the source event's `channel_type` /
+ * `conversations.info` `is_private`, or the persisted source-confirmed
+ * destination visibility — can classify a conversation public. Identifier
+ * prefixes may only narrow classification toward private. Unknown stays
+ * undefined so callers fail closed to private.
+ */
 export function resolveConversationPrivacy(input: {
   channelId?: string;
   conversationId?: string;
+  /** Source-confirmed or persisted-confirmed visibility, when the caller has one. */
+  visibility?: ConversationPrivacy;
 }): ConversationPrivacy | undefined {
-  return (
-    conversationPrivacyFromChannelId(input.channelId) ??
-    conversationPrivacyFromConversationId(input.conversationId)
-  );
+  const narrowed =
+    privateNarrowingFromChannelId(input.channelId) ??
+    privateNarrowingFromConversationId(input.conversationId);
+  if (narrowed === "private") {
+    return "private";
+  }
+  return input.visibility;
 }
 
-/** Gate raw transcript/tool payload exposure to conversations known to be public. */
+/** Gate raw transcript/tool payload exposure to conversations confirmed public. */
 export function canExposeConversationPayload(input: {
   channelId?: string;
   conversationId?: string;
+  /** Source-confirmed or persisted-confirmed visibility, when the caller has one. */
+  visibility?: ConversationPrivacy;
 }): boolean {
   return resolveConversationPrivacy(input) === "public";
 }

--- a/packages/junior/src/chat/conversation-privacy.ts
+++ b/packages/junior/src/chat/conversation-privacy.ts
@@ -34,16 +34,14 @@ function privateNarrowingFromConversationId(
 /**
  * Resolve whether a conversation may expose raw payloads.
  *
- * Only a confirmed visibility — the source event's `channel_type` /
- * `conversations.info` `is_private`, or the persisted source-confirmed
- * destination visibility — can classify a conversation public. Identifier
- * prefixes may only narrow classification toward private. Unknown stays
- * undefined so callers fail closed to private.
+ * Only a live source signal or persisted destination visibility can classify
+ * a conversation public. Identifier prefixes may only narrow classification
+ * toward private. Unknown stays undefined so callers fail closed to private.
  */
 export function resolveConversationPrivacy(input: {
   channelId?: string;
   conversationId?: string;
-  /** Source-confirmed or persisted-confirmed visibility, when the caller has one. */
+  /** Live source or persisted visibility, when the caller has one. */
   visibility?: ConversationPrivacy;
 }): ConversationPrivacy | undefined {
   const narrowed =
@@ -55,11 +53,11 @@ export function resolveConversationPrivacy(input: {
   return input.visibility;
 }
 
-/** Gate raw transcript/tool payload exposure to conversations confirmed public. */
+/** Gate raw transcript/tool payload exposure to public conversations. */
 export function canExposeConversationPayload(input: {
   channelId?: string;
   conversationId?: string;
-  /** Source-confirmed or persisted-confirmed visibility, when the caller has one. */
+  /** Live source or persisted visibility, when the caller has one. */
   visibility?: ConversationPrivacy;
 }): boolean {
   return resolveConversationPrivacy(input) === "public";

--- a/packages/junior/src/chat/conversations/sql/migrations.ts
+++ b/packages/junior/src/chat/conversations/sql/migrations.ts
@@ -156,24 +156,20 @@ CREATE INDEX IF NOT EXISTS junior_conversations_origin_idx
 `,
 ] as const;
 
-/**
- * Expand-only: adds a nullable confirmation timestamp so readers can
- * distinguish source-confirmed visibility from legacy prefix-derived values.
- * Legacy rows keep a NULL confirmation and must read as private until a live
- * source signal re-confirms them.
- */
-const destinationVisibilityConfirmationStatements = [
+const destinationVisibilityBackfillStatements = [
   `
-ALTER TABLE junior_destinations
-  ADD COLUMN IF NOT EXISTS visibility_confirmed_at TIMESTAMPTZ
+UPDATE junior_destinations
+  SET visibility = 'private'
+  WHERE provider = 'slack'
+    AND visibility = 'public'
 `,
 ] as const;
 
 export const migrations = [
   defineMigration("0001_conversation_core", coreMetadataStatements),
   defineMigration(
-    "0002_destination_visibility_confirmation",
-    destinationVisibilityConfirmationStatements,
+    "0002_slack_destination_visibility_backfill",
+    destinationVisibilityBackfillStatements,
   ),
 ] as const;
 

--- a/packages/junior/src/chat/conversations/sql/migrations.ts
+++ b/packages/junior/src/chat/conversations/sql/migrations.ts
@@ -156,8 +156,25 @@ CREATE INDEX IF NOT EXISTS junior_conversations_origin_idx
 `,
 ] as const;
 
+/**
+ * Expand-only: adds a nullable confirmation timestamp so readers can
+ * distinguish source-confirmed visibility from legacy prefix-derived values.
+ * Legacy rows keep a NULL confirmation and must read as private until a live
+ * source signal re-confirms them.
+ */
+const destinationVisibilityConfirmationStatements = [
+  `
+ALTER TABLE junior_destinations
+  ADD COLUMN IF NOT EXISTS visibility_confirmed_at TIMESTAMPTZ
+`,
+] as const;
+
 export const migrations = [
   defineMigration("0001_conversation_core", coreMetadataStatements),
+  defineMigration(
+    "0002_destination_visibility_confirmation",
+    destinationVisibilityConfirmationStatements,
+  ),
 ] as const;
 
 export { schema };

--- a/packages/junior/src/chat/conversations/sql/schema/destinations.ts
+++ b/packages/junior/src/chat/conversations/sql/schema/destinations.ts
@@ -32,6 +32,13 @@ export const juniorDestinations = pgTable(
     metadata: jsonb("metadata_json"),
     createdAt: timestamptz("created_at").notNull(),
     updatedAt: timestamptz("updated_at").notNull(),
+    /**
+     * Set only when `visibility` came from a source-provided signal (Slack
+     * `channel_type` / `conversations.info` `is_private`). NULL rows —
+     * including legacy prefix-derived values — are unconfirmed and must read
+     * as private. Appended last to match the expand-only migration order.
+     */
+    visibilityConfirmedAt: timestamptz("visibility_confirmed_at"),
   },
   (table) => [
     uniqueIndex("junior_destinations_provider_destination_uidx").on(

--- a/packages/junior/src/chat/conversations/sql/schema/destinations.ts
+++ b/packages/junior/src/chat/conversations/sql/schema/destinations.ts
@@ -32,13 +32,6 @@ export const juniorDestinations = pgTable(
     metadata: jsonb("metadata_json"),
     createdAt: timestamptz("created_at").notNull(),
     updatedAt: timestamptz("updated_at").notNull(),
-    /**
-     * Set only when `visibility` came from a source-provided signal (Slack
-     * `channel_type` / `conversations.info` `is_private`). NULL rows —
-     * including legacy prefix-derived values — are unconfirmed and must read
-     * as private. Appended last to match the expand-only migration order.
-     */
-    visibilityConfirmedAt: timestamptz("visibility_confirmed_at"),
   },
   (table) => [
     uniqueIndex("junior_destinations_provider_destination_uidx").on(

--- a/packages/junior/src/chat/conversations/sql/store.ts
+++ b/packages/junior/src/chat/conversations/sql/store.ts
@@ -35,7 +35,7 @@ type ConversationRow = typeof juniorConversations.$inferSelect;
 interface ConversationReadRow {
   conversation: ConversationRow;
   destinationVisibility: JuniorDestinationVisibility | null;
-  destinationVisibilityConfirmedAt: Date | string | null;
+  destinationVisibilityConfirmedAt: Date | null;
 }
 
 interface IdentityUpsert {
@@ -259,10 +259,7 @@ function executionStatusFromValue(value: unknown): ConversationStatus {
 function confirmedVisibilityFromRow(
   row: ConversationReadRow,
 ): ConversationPrivacy | undefined {
-  if (
-    row.destinationVisibilityConfirmedAt === null ||
-    row.destinationVisibilityConfirmedAt === undefined
-  ) {
+  if (row.destinationVisibilityConfirmedAt === null) {
     return undefined;
   }
   return row.destinationVisibility === "public" ? "public" : "private";

--- a/packages/junior/src/chat/conversations/sql/store.ts
+++ b/packages/junior/src/chat/conversations/sql/store.ts
@@ -35,7 +35,6 @@ type ConversationRow = typeof juniorConversations.$inferSelect;
 interface ConversationReadRow {
   conversation: ConversationRow;
   destinationVisibility: JuniorDestinationVisibility | null;
-  destinationVisibilityConfirmedAt: Date | null;
 }
 
 interface IdentityUpsert {
@@ -56,9 +55,8 @@ interface DestinationUpsert {
   provider: string;
   providerDestinationId: string;
   providerTenantId?: string;
+  refreshVisibility: boolean;
   visibility: JuniorDestinationVisibility;
-  /** True only when `visibility` came from a source-provided signal. */
-  visibilityConfirmed: boolean;
 }
 
 const CONVERSATION_MUTATION_LOCK_PREFIX = "junior_conversation";
@@ -178,27 +176,6 @@ function localWorkspaceFromConversationId(
   return match?.[1];
 }
 
-/**
- * Persist Slack visibility only from source-provided signals: without a
- * confirmed value, id prefixes may narrow toward private (`D`/`G`) but a `C`
- * prefix stays `unknown` because modern private channels also use it.
- */
-function slackDestinationVisibility(
-  channelId: string,
-  confirmed: ConversationPrivacy | undefined,
-): JuniorDestinationVisibility {
-  if (channelId.startsWith("D")) {
-    return "direct";
-  }
-  if (confirmed === "public") {
-    return "public";
-  }
-  if (confirmed === "private" || channelId.startsWith("G")) {
-    return "private";
-  }
-  return "unknown";
-}
-
 function destinationUpsertFromDestination(args: {
   channelName?: string;
   conversationId?: string;
@@ -222,8 +199,8 @@ function destinationUpsertFromDestination(args: {
       provider: "slack",
       providerTenantId: destination.teamId,
       providerDestinationId: channelId,
-      visibility: slackDestinationVisibility(channelId, args.visibility),
-      visibilityConfirmed: args.visibility !== undefined,
+      refreshVisibility: args.visibility !== undefined,
+      visibility: args.visibility ?? "private",
       ...(args.channelName ? { displayName: args.channelName } : {}),
       metadata: { platform: "slack" },
     };
@@ -235,9 +212,8 @@ function destinationUpsertFromDestination(args: {
       localWorkspaceFromConversationId(destination.conversationId) ??
       localWorkspaceFromConversationId(args.conversationId ?? ""),
     providerDestinationId: destination.conversationId,
+    refreshVisibility: true,
     visibility: "direct",
-    // Local conversations are direct by construction of the platform.
-    visibilityConfirmed: true,
     metadata: { platform: "local" },
   };
 }
@@ -255,11 +231,11 @@ function executionStatusFromValue(value: unknown): ConversationStatus {
   throw new Error("Conversation record execution status is invalid");
 }
 
-/** Project joined destination columns into source-confirmed visibility. */
-function confirmedVisibilityFromRow(
+/** Project joined destination columns into conversation privacy. */
+function privacyFromRow(
   row: ConversationReadRow,
 ): ConversationPrivacy | undefined {
-  if (row.destinationVisibilityConfirmedAt === null) {
+  if (row.destinationVisibility === null) {
     return undefined;
   }
   return row.destinationVisibility === "public" ? "public" : "private";
@@ -268,7 +244,7 @@ function confirmedVisibilityFromRow(
 /** Decode one SQL row and reject invalid durable conversation records. */
 function conversationFromRow(readRow: ConversationReadRow): Conversation {
   const row = readRow.conversation;
-  const visibility = confirmedVisibilityFromRow(readRow);
+  const visibility = privacyFromRow(readRow);
   if (row.schemaVersion !== 1) {
     throw new Error("Conversation record schema version is invalid");
   }
@@ -536,8 +512,6 @@ export class SqlStore implements ConversationStore {
       .select({
         conversation: juniorConversations,
         destinationVisibility: juniorDestinations.visibility,
-        destinationVisibilityConfirmedAt:
-          juniorDestinations.visibilityConfirmedAt,
       })
       .from(juniorConversations)
       .leftJoin(
@@ -566,7 +540,6 @@ export class SqlStore implements ConversationStore {
       .db()
       .select({
         visibility: juniorDestinations.visibility,
-        visibilityConfirmedAt: juniorDestinations.visibilityConfirmedAt,
       })
       .from(juniorDestinations)
       .where(
@@ -583,7 +556,7 @@ export class SqlStore implements ConversationStore {
         ),
       );
     const row = rows[0];
-    if (!row || row.visibilityConfirmedAt === null) {
+    if (!row) {
       return undefined;
     }
     return row.visibility === "public" ? "public" : "private";
@@ -608,8 +581,6 @@ export class SqlStore implements ConversationStore {
       .select({
         conversation: juniorConversations,
         destinationVisibility: juniorDestinations.visibility,
-        destinationVisibilityConfirmedAt:
-          juniorDestinations.visibilityConfirmedAt,
       })
       .from(juniorConversations)
       .leftJoin(
@@ -763,6 +734,9 @@ export class SqlStore implements ConversationStore {
     if (!destination) {
       return undefined;
     }
+    const visibilityUpdate = destination.refreshVisibility
+      ? sql`excluded.visibility`
+      : juniorDestinations.visibility;
     const rows = await this.executor
       .db()
       .insert(juniorDestinations)
@@ -775,9 +749,6 @@ export class SqlStore implements ConversationStore {
         parentDestinationId: null,
         displayName: destination.displayName ?? null,
         visibility: destination.visibility,
-        visibilityConfirmedAt: destination.visibilityConfirmed
-          ? dateFromMs(nowMs)
-          : null,
         metadata: destination.metadata ?? null,
         createdAt: dateFromMs(nowMs),
         updatedAt: dateFromMs(nowMs),
@@ -791,11 +762,10 @@ export class SqlStore implements ConversationStore {
         set: {
           kind: sql`excluded.kind`,
           displayName: sql`coalesce(excluded.display_name, ${juniorDestinations.displayName})`,
-          // A source-confirmed write refreshes visibility (so converted
-          // channels converge on the next message); unconfirmed writes must
-          // not clobber a previously confirmed value.
-          visibility: sql`case when excluded.visibility_confirmed_at is not null then excluded.visibility else ${juniorDestinations.visibility} end`,
-          visibilityConfirmedAt: sql`coalesce(excluded.visibility_confirmed_at, ${juniorDestinations.visibilityConfirmedAt})`,
+          // Signal-less writes insert as private but must not clobber an
+          // existing public/private value. Live source signals refresh this
+          // field so converted channels converge on the next message.
+          visibility: visibilityUpdate,
           metadata: sql`coalesce(excluded.metadata_json, ${juniorDestinations.metadata})`,
           updatedAt: sql`excluded.updated_at`,
         },

--- a/packages/junior/src/chat/conversations/sql/store.ts
+++ b/packages/junior/src/chat/conversations/sql/store.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { Destination } from "@sentry/junior-plugin-api";
-import { asc, desc, eq, sql } from "drizzle-orm";
+import { and, asc, desc, eq, sql } from "drizzle-orm";
+import type { ConversationPrivacy } from "@/chat/conversation-privacy";
 import { parseDestination, sameDestination } from "@/chat/destination";
 import {
   parseStoredSlackRequester,
@@ -31,6 +32,12 @@ import type { JuniorIdentityKind } from "./schema/identities";
 
 type ConversationRow = typeof juniorConversations.$inferSelect;
 
+interface ConversationReadRow {
+  conversation: ConversationRow;
+  destinationVisibility: JuniorDestinationVisibility | null;
+  destinationVisibilityConfirmedAt: Date | string | null;
+}
+
 interface IdentityUpsert {
   email?: string;
   displayName?: string;
@@ -50,6 +57,8 @@ interface DestinationUpsert {
   providerDestinationId: string;
   providerTenantId?: string;
   visibility: JuniorDestinationVisibility;
+  /** True only when `visibility` came from a source-provided signal. */
+  visibilityConfirmed: boolean;
 }
 
 const CONVERSATION_MUTATION_LOCK_PREFIX = "junior_conversation";
@@ -169,10 +178,33 @@ function localWorkspaceFromConversationId(
   return match?.[1];
 }
 
+/**
+ * Persist Slack visibility only from source-provided signals: without a
+ * confirmed value, id prefixes may narrow toward private (`D`/`G`) but a `C`
+ * prefix stays `unknown` because modern private channels also use it.
+ */
+function slackDestinationVisibility(
+  channelId: string,
+  confirmed: ConversationPrivacy | undefined,
+): JuniorDestinationVisibility {
+  if (channelId.startsWith("D")) {
+    return "direct";
+  }
+  if (confirmed === "public") {
+    return "public";
+  }
+  if (confirmed === "private" || channelId.startsWith("G")) {
+    return "private";
+  }
+  return "unknown";
+}
+
 function destinationUpsertFromDestination(args: {
   channelName?: string;
   conversationId?: string;
   destination: Destination | undefined;
+  /** Source-confirmed visibility from the current event's signal only. */
+  visibility?: ConversationPrivacy;
 }): DestinationUpsert | undefined {
   const { destination } = args;
   if (!destination) {
@@ -185,17 +217,13 @@ function destinationUpsertFromDestination(args: {
       : channelId.startsWith("G")
         ? "group"
         : "channel";
-    const visibility = channelId.startsWith("D")
-      ? "direct"
-      : channelId.startsWith("G")
-        ? "private"
-        : "public";
     return {
       kind: channelKind,
       provider: "slack",
       providerTenantId: destination.teamId,
       providerDestinationId: channelId,
-      visibility,
+      visibility: slackDestinationVisibility(channelId, args.visibility),
+      visibilityConfirmed: args.visibility !== undefined,
       ...(args.channelName ? { displayName: args.channelName } : {}),
       metadata: { platform: "slack" },
     };
@@ -208,6 +236,8 @@ function destinationUpsertFromDestination(args: {
       localWorkspaceFromConversationId(args.conversationId ?? ""),
     providerDestinationId: destination.conversationId,
     visibility: "direct",
+    // Local conversations are direct by construction of the platform.
+    visibilityConfirmed: true,
     metadata: { platform: "local" },
   };
 }
@@ -225,8 +255,23 @@ function executionStatusFromValue(value: unknown): ConversationStatus {
   throw new Error("Conversation record execution status is invalid");
 }
 
+/** Project joined destination columns into source-confirmed visibility. */
+function confirmedVisibilityFromRow(
+  row: ConversationReadRow,
+): ConversationPrivacy | undefined {
+  if (
+    row.destinationVisibilityConfirmedAt === null ||
+    row.destinationVisibilityConfirmedAt === undefined
+  ) {
+    return undefined;
+  }
+  return row.destinationVisibility === "public" ? "public" : "private";
+}
+
 /** Decode one SQL row and reject invalid durable conversation records. */
-function conversationFromRow(row: ConversationRow): Conversation {
+function conversationFromRow(readRow: ConversationReadRow): Conversation {
+  const row = readRow.conversation;
+  const visibility = confirmedVisibilityFromRow(readRow);
   if (row.schemaVersion !== 1) {
     throw new Error("Conversation record schema version is invalid");
   }
@@ -273,6 +318,7 @@ function conversationFromRow(row: ConversationRow): Conversation {
     ...(row.channelName ? { channelName: row.channelName } : {}),
     ...(source ? { source } : {}),
     ...(row.title ? { title: row.title } : {}),
+    ...(visibility ? { visibility } : {}),
   };
 }
 
@@ -353,6 +399,7 @@ export class SqlStore implements ConversationStore {
     requester?: StoredSlackRequester;
     source?: ConversationSource;
     title?: string;
+    visibility?: ConversationPrivacy;
   }): Promise<void> {
     const nowMs = args.nowMs ?? now();
     const activityAtMs = args.activityAtMs ?? nowMs;
@@ -375,9 +422,12 @@ export class SqlStore implements ConversationStore {
           nowMs,
           source: args.source,
         });
+      // Persist visibility only from the current event's live signal; the
+      // previously stored confirmation must not be replayed as a new signal.
+      const { visibility: _persisted, ...currentWithoutVisibility } = current;
       await this.upsertConversation({
         conversation: {
-          ...current,
+          ...currentWithoutVisibility,
           destination: current.destination ?? args.destination,
           source: current.source ?? args.source,
           channelName: current.channelName ?? args.channelName,
@@ -389,6 +439,7 @@ export class SqlStore implements ConversationStore {
             ...current.execution,
             updatedAtMs: current.execution.updatedAtMs ?? nowMs,
           },
+          ...(args.visibility ? { visibility: args.visibility } : {}),
         },
       });
     });
@@ -405,6 +456,7 @@ export class SqlStore implements ConversationStore {
     source?: ConversationSource;
     title?: string;
     updatedAtMs: number;
+    visibility?: ConversationPrivacy;
   }): Promise<void> {
     await this.withConversationMutation(args.conversationId, async () => {
       await this.upsertConversation({
@@ -419,6 +471,7 @@ export class SqlStore implements ConversationStore {
           ...(args.requester ? { requester: args.requester } : {}),
           ...(args.source ? { source: args.source } : {}),
           ...(args.title ? { title: args.title } : {}),
+          ...(args.visibility ? { visibility: args.visibility } : {}),
           execution: args.execution,
         },
       });
@@ -426,7 +479,10 @@ export class SqlStore implements ConversationStore {
   }
 
   /** Copy one conversation record into SQL during backfill. */
-  async backfillConversation(conversation: Conversation): Promise<void> {
+  async backfillConversation(sourceConversation: Conversation): Promise<void> {
+    // Backfilled records are not live source signals: never let them confirm
+    // destination visibility.
+    const { visibility: _visibility, ...conversation } = sourceConversation;
     await this.withConversationMutation(
       conversation.conversationId,
       async () => {
@@ -480,8 +536,17 @@ export class SqlStore implements ConversationStore {
   ): Promise<Conversation[]> {
     const rows = await this.executor
       .db()
-      .select()
+      .select({
+        conversation: juniorConversations,
+        destinationVisibility: juniorDestinations.visibility,
+        destinationVisibilityConfirmedAt:
+          juniorDestinations.visibilityConfirmedAt,
+      })
       .from(juniorConversations)
+      .leftJoin(
+        juniorDestinations,
+        eq(juniorDestinations.id, juniorConversations.destinationId),
+      )
       .orderBy(
         desc(juniorConversations.lastActivityAt),
         asc(juniorConversations.conversationId),
@@ -493,6 +558,38 @@ export class SqlStore implements ConversationStore {
       conversations.push(conversationFromRow(row));
     }
     return conversations;
+  }
+
+  async getDestinationVisibility(args: {
+    provider: string;
+    providerDestinationId: string;
+    providerTenantId?: string;
+  }): Promise<ConversationPrivacy | undefined> {
+    const rows = await this.executor
+      .db()
+      .select({
+        visibility: juniorDestinations.visibility,
+        visibilityConfirmedAt: juniorDestinations.visibilityConfirmedAt,
+      })
+      .from(juniorDestinations)
+      .where(
+        and(
+          eq(juniorDestinations.provider, args.provider),
+          eq(
+            juniorDestinations.providerTenantId,
+            tenantId(args.providerTenantId),
+          ),
+          eq(
+            juniorDestinations.providerDestinationId,
+            args.providerDestinationId,
+          ),
+        ),
+      );
+    const row = rows[0];
+    if (!row || row.visibilityConfirmedAt === null) {
+      return undefined;
+    }
+    return row.visibility === "public" ? "public" : "private";
   }
 
   /** Serialize all durable mutations for one conversation inside a SQL transaction. */
@@ -508,11 +605,20 @@ export class SqlStore implements ConversationStore {
 
   private async readConversationRow(
     conversationId: string,
-  ): Promise<ConversationRow | undefined> {
+  ): Promise<ConversationReadRow | undefined> {
     const rows = await this.executor
       .db()
-      .select()
+      .select({
+        conversation: juniorConversations,
+        destinationVisibility: juniorDestinations.visibility,
+        destinationVisibilityConfirmedAt:
+          juniorDestinations.visibilityConfirmedAt,
+      })
       .from(juniorConversations)
+      .leftJoin(
+        juniorDestinations,
+        eq(juniorDestinations.id, juniorConversations.destinationId),
+      )
       .where(eq(juniorConversations.conversationId, conversationId));
     return rows[0];
   }
@@ -530,6 +636,9 @@ export class SqlStore implements ConversationStore {
         channelName: conversation.channelName,
         conversationId: conversation.conversationId,
         destination: conversation.destination,
+        ...(conversation.visibility
+          ? { visibility: conversation.visibility }
+          : {}),
       }),
       conversation.updatedAtMs,
     );
@@ -669,6 +778,9 @@ export class SqlStore implements ConversationStore {
         parentDestinationId: null,
         displayName: destination.displayName ?? null,
         visibility: destination.visibility,
+        visibilityConfirmedAt: destination.visibilityConfirmed
+          ? dateFromMs(nowMs)
+          : null,
         metadata: destination.metadata ?? null,
         createdAt: dateFromMs(nowMs),
         updatedAt: dateFromMs(nowMs),
@@ -682,7 +794,11 @@ export class SqlStore implements ConversationStore {
         set: {
           kind: sql`excluded.kind`,
           displayName: sql`coalesce(excluded.display_name, ${juniorDestinations.displayName})`,
-          visibility: sql`excluded.visibility`,
+          // A source-confirmed write refreshes visibility (so converted
+          // channels converge on the next message); unconfirmed writes must
+          // not clobber a previously confirmed value.
+          visibility: sql`case when excluded.visibility_confirmed_at is not null then excluded.visibility else ${juniorDestinations.visibility} end`,
+          visibilityConfirmedAt: sql`coalesce(excluded.visibility_confirmed_at, ${juniorDestinations.visibilityConfirmedAt})`,
           metadata: sql`coalesce(excluded.metadata_json, ${juniorDestinations.metadata})`,
           updatedAt: sql`excluded.updated_at`,
         },

--- a/packages/junior/src/chat/conversations/state.ts
+++ b/packages/junior/src/chat/conversations/state.ts
@@ -13,6 +13,9 @@ export function createStateConversationStore(
 ): ConversationStore {
   return {
     get: (args) => getTaskConversation({ ...args, state }),
+    // Task-execution state has no destination records, so visibility is never
+    // source-confirmed here and cross-context reads fail closed to private.
+    getDestinationVisibility: async () => undefined,
     recordActivity: (args) =>
       recordTaskConversationActivity({ ...args, state }),
     recordExecution: (args) =>

--- a/packages/junior/src/chat/conversations/store.ts
+++ b/packages/junior/src/chat/conversations/store.ts
@@ -1,4 +1,5 @@
 import type { Destination } from "@sentry/junior-plugin-api";
+import type { ConversationPrivacy } from "@/chat/conversation-privacy";
 import type { StoredSlackRequester } from "@/chat/requester";
 
 export type ConversationSource =
@@ -37,11 +38,27 @@ export interface Conversation {
   source?: ConversationSource;
   title?: string;
   updatedAtMs: number;
+  /**
+   * Source-confirmed destination visibility. Undefined means unconfirmed —
+   * legacy prefix-derived rows included — and readers must treat it as
+   * private.
+   */
+  visibility?: ConversationPrivacy;
 }
 
 /** Persist and read durable conversation metadata for reporting surfaces. */
 export interface ConversationStore {
   get(args: { conversationId: string }): Promise<Conversation | undefined>;
+  /**
+   * Read persisted source-confirmed visibility for one destination, used by
+   * cross-conversation privacy gates. Undefined means unconfirmed and must be
+   * treated as private.
+   */
+  getDestinationVisibility(args: {
+    provider: string;
+    providerDestinationId: string;
+    providerTenantId?: string;
+  }): Promise<ConversationPrivacy | undefined>;
   recordActivity(args: {
     activityAtMs?: number;
     channelName?: string;
@@ -51,6 +68,8 @@ export interface ConversationStore {
     requester?: StoredSlackRequester;
     source?: ConversationSource;
     title?: string;
+    /** Source-confirmed visibility from the current event's signal only. */
+    visibility?: ConversationPrivacy;
   }): Promise<void>;
   /** Store task-execution metadata for long-term conversation history. */
   recordExecution(args: {
@@ -64,6 +83,8 @@ export interface ConversationStore {
     source?: ConversationSource;
     title?: string;
     updatedAtMs: number;
+    /** Source-confirmed visibility from the current event's signal only. */
+    visibility?: ConversationPrivacy;
   }): Promise<void>;
   listByActivity(args?: {
     limit?: number;

--- a/packages/junior/src/chat/conversations/store.ts
+++ b/packages/junior/src/chat/conversations/store.ts
@@ -38,22 +38,14 @@ export interface Conversation {
   source?: ConversationSource;
   title?: string;
   updatedAtMs: number;
-  /**
-   * Source-confirmed destination visibility. Undefined means unconfirmed —
-   * legacy prefix-derived rows included — and readers must treat it as
-   * private.
-   */
+  /** Persisted destination visibility. Undefined means no destination row exists. */
   visibility?: ConversationPrivacy;
 }
 
 /** Persist and read durable conversation metadata for reporting surfaces. */
 export interface ConversationStore {
   get(args: { conversationId: string }): Promise<Conversation | undefined>;
-  /**
-   * Read persisted source-confirmed visibility for one destination, used by
-   * cross-conversation privacy gates. Undefined means unconfirmed and must be
-   * treated as private.
-   */
+  /** Read persisted visibility for one destination. Missing rows fail closed. */
   getDestinationVisibility(args: {
     provider: string;
     providerDestinationId: string;

--- a/packages/junior/src/chat/ingress/message-changed.ts
+++ b/packages/junior/src/chat/ingress/message-changed.ts
@@ -23,6 +23,7 @@ interface SlackMessageChangedEvent {
     type: "message";
     subtype: "message_changed";
     channel: string;
+    channel_type?: string;
     message: {
       bot_id?: string;
       files?: SlackEditedMessageFile[];
@@ -147,9 +148,14 @@ export function extractMessageChangedMention(
       : undefined;
   const botId =
     typeof event.message.bot_id === "string" ? event.message.bot_id : undefined;
+  // Preserve the event's channel_type so visibility confirmation still works
+  // for channels whose only Junior traffic is edited mentions.
+  const channelType =
+    typeof event.channel_type === "string" ? event.channel_type : undefined;
 
   const raw: Record<string, unknown> = {
     channel: channelId,
+    ...(channelType ? { channel_type: channelType } : {}),
     ts: messageTs,
     thread_ts: threadTs,
     user: userId,

--- a/packages/junior/src/chat/ingress/message-changed.ts
+++ b/packages/junior/src/chat/ingress/message-changed.ts
@@ -24,6 +24,7 @@ interface SlackMessageChangedEvent {
     subtype: "message_changed";
     channel: string;
     message: {
+      bot_id?: string;
       files?: SlackEditedMessageFile[];
       source_team?: string;
       text?: string;
@@ -144,6 +145,8 @@ export function extractMessageChangedMention(
     typeof event.message.source_team === "string"
       ? event.message.source_team
       : undefined;
+  const botId =
+    typeof event.message.bot_id === "string" ? event.message.bot_id : undefined;
 
   const raw: Record<string, unknown> = {
     channel: channelId,
@@ -153,6 +156,7 @@ export function extractMessageChangedMention(
     ...(teamId ? { team_id: teamId } : {}),
     ...(userTeam ? { user_team: userTeam } : {}),
     ...(sourceTeam ? { source_team: sourceTeam } : {}),
+    ...(botId ? { bot_id: botId } : {}),
   };
 
   const message = new Message({
@@ -169,8 +173,11 @@ export function extractMessageChangedMention(
       // Raw message_changed payloads do not include profile fields.
       userName: "",
       fullName: "",
-      isBot: false,
-      isMe: false,
+      // Mirror the fresh-message parse so the shared ingress author gate
+      // applies: synthesized flags must never launder a bot-authored or
+      // self-authored edit into a routable user message.
+      isBot: Boolean(botId),
+      isMe: userId === botUserId,
     },
   });
 

--- a/packages/junior/src/chat/ingress/slack-webhook.ts
+++ b/packages/junior/src/chat/ingress/slack-webhook.ts
@@ -284,7 +284,12 @@ async function handleMessageChanged(args: {
   }
   const botUserId = args.adapter.botUserId;
   if (!botUserId) {
-    return false;
+    // Entry classification requires resolved bot identity; degrading into
+    // silently dropped edited-mention events would hide the outage. Throwing
+    // makes the webhook return a retryable non-2xx so Slack redelivers.
+    throw new Error(
+      "Slack bot identity is unresolved; cannot classify message_changed event",
+    );
   }
 
   const result = extractMessageChangedMention(
@@ -292,7 +297,7 @@ async function handleMessageChanged(args: {
     botUserId,
     args.adapter,
   );
-  if (!result) {
+  if (!result || shouldIgnoreMessage(result.message)) {
     return true;
   }
 
@@ -678,12 +683,15 @@ export async function handleSlackWebhook(args: {
       try {
         await eventTask;
       } catch (error) {
-        if (!(error instanceof SlackEventPersistenceError)) {
-          logException(error, "slack_event_enqueue_failed");
-          return new Response("ok", { status: 200 });
+        // Any failure before durable mailbox append — installation/token
+        // resolution, routing-state reads, persistence — must be retryable.
+        // Acking 200 here would silently drop the user's message.
+        if (error instanceof SlackEventPersistenceError) {
+          logException(error.cause, "slack_event_persist_failed");
+        } else {
+          logException(error, "slack_event_routing_failed");
         }
-        logException(error.cause, "slack_event_persist_failed");
-        return new Response("Slack event persistence failed", { status: 503 });
+        return new Response("Slack event handling failed", { status: 503 });
       }
     } else {
       enqueue(

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -34,7 +34,7 @@ import {
 } from "@/chat/runtime/thread-state";
 import { startActiveTurn, markTurnFailed } from "@/chat/runtime/turn";
 import { finalizeFailedTurnReply } from "@/chat/services/turn-failure-response";
-import { persistCompletedSessionRecord } from "@/chat/services/turn-session-record";
+import { completeDeliveredTurn } from "@/chat/services/turn-session-record";
 import {
   buildConversationContext,
   markConversationMessage,
@@ -344,15 +344,13 @@ export async function runLocalAgentTurn(
     // the final assistant messages to the session log and marks the session
     // record completed only after the CLI sink accepted the reply. Failures
     // are logged inside and never fail the delivered turn.
-    await persistCompletedSessionRecord({
+    await completeDeliveredTurn({
       conversationId: input.conversationId,
       sessionId: turnId,
-      // Local turns are single-slice by design: there is no local resume
-      // machinery, so a completion here is always slice 1.
       sliceId: 1,
-      allMessages: reply.piMessages,
-      currentDurationMs: reply.diagnostics.durationMs,
-      currentUsage: reply.diagnostics.usage,
+      messages: reply.piMessages,
+      durationMs: reply.diagnostics.durationMs,
+      usage: reply.diagnostics.usage,
       destination,
       source,
       surface: "internal",

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -33,6 +33,7 @@ import {
   persistThreadStateById,
 } from "@/chat/runtime/thread-state";
 import { startActiveTurn, markTurnFailed } from "@/chat/runtime/turn";
+import { finalizeFailedTurnReply } from "@/chat/services/turn-failure-response";
 import {
   buildConversationContext,
   markConversationMessage,
@@ -282,6 +283,14 @@ export async function runLocalAgentTurn(
       onToolResult: async (result) => {
         await deps.onToolResult?.(result);
       },
+    });
+
+    // Failed turns deliver the sanitized fallback (or genuine partial model
+    // text), never raw exception strings and never silence.
+    reply = finalizeFailedTurnReply({
+      reply,
+      logException,
+      context: { conversationId: input.conversationId },
     });
 
     completedState = buildDeliveredTurnStatePatch({

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -347,6 +347,9 @@ export async function runLocalAgentTurn(
     await persistCompletedSessionRecord({
       conversationId: input.conversationId,
       sessionId: turnId,
+      // Local turns are single-slice by design: there is no local resume
+      // machinery, so a completion here is always slice 1.
+      sliceId: 1,
       allMessages: reply.piMessages,
       currentDurationMs: reply.diagnostics.durationMs,
       currentUsage: reply.diagnostics.usage,

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -34,6 +34,7 @@ import {
 } from "@/chat/runtime/thread-state";
 import { startActiveTurn, markTurnFailed } from "@/chat/runtime/turn";
 import { finalizeFailedTurnReply } from "@/chat/services/turn-failure-response";
+import { persistCompletedSessionRecord } from "@/chat/services/turn-session-record";
 import {
   buildConversationContext,
   markConversationMessage,
@@ -338,11 +339,21 @@ export async function runLocalAgentTurn(
     sandboxDependencyProfileHash:
       reply.sandboxDependencyProfileHash ?? sandboxDependencyProfileHash,
   });
-  if (reply.piMessages) {
-    await commitMessages({
+  if (reply.piMessages?.length) {
+    // Destination acceptance is the completion boundary: this first commits
+    // the final assistant messages to the session log and marks the session
+    // record completed only after the CLI sink accepted the reply. Failures
+    // are logged inside and never fail the delivered turn.
+    await persistCompletedSessionRecord({
       conversationId: input.conversationId,
-      messages: reply.piMessages,
-      ttlMs: THREAD_STATE_TTL_MS,
+      sessionId: turnId,
+      allMessages: reply.piMessages,
+      currentDurationMs: reply.diagnostics.durationMs,
+      currentUsage: reply.diagnostics.usage,
+      destination,
+      source,
+      surface: "internal",
+      logContext: { modelId: reply.diagnostics.modelId },
     });
   }
   if (reply.diagnostics.outcome === "success") {

--- a/packages/junior/src/chat/pi/client.ts
+++ b/packages/junior/src/chat/pi/client.ts
@@ -37,6 +37,7 @@ import {
 } from "@/chat/logging";
 import { toOptionalTrimmed } from "@/chat/optional-string";
 import {
+  getCurrentConversationPrivacy,
   resolveConversationPrivacy,
   toGenAiMessageMetadata,
   toGenAiMessagesTraceAttributes,
@@ -116,18 +117,21 @@ export async function completeText(params: {
     : toOptionalTrimmed(process.env.VERCEL_OIDC_TOKEN)
       ? "oidc"
       : "api_key";
-  const privacy = resolveConversationPrivacy({
-    channelId:
-      typeof params.metadata?.channelId === "string"
-        ? params.metadata.channelId
-        : undefined,
-    conversationId:
-      typeof params.metadata?.conversationId === "string"
-        ? params.metadata.conversationId
-        : typeof params.metadata?.threadId === "string"
-          ? params.metadata.threadId
+  // Identifier metadata can only narrow toward private; the turn-scoped
+  // privacy context carries the source-confirmed classification.
+  const privacy =
+    resolveConversationPrivacy({
+      channelId:
+        typeof params.metadata?.channelId === "string"
+          ? params.metadata.channelId
           : undefined,
-  });
+      conversationId:
+        typeof params.metadata?.conversationId === "string"
+          ? params.metadata.conversationId
+          : typeof params.metadata?.threadId === "string"
+            ? params.metadata.threadId
+            : undefined,
+    }) ?? getCurrentConversationPrivacy();
   const effectivePrivacy = privacy ?? "private";
   const messageAttributeMode =
     params.messageAttributeMode ??

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -131,7 +131,6 @@ import {
 } from "@/chat/usage";
 import {
   loadTurnSessionRecord,
-  persistCompletedSessionRecord,
   persistAuthPauseSessionRecord,
   persistRunningSessionRecord,
   persistTimeoutSessionRecord,
@@ -1807,24 +1806,12 @@ async function generateAssistantReplyInPrivacyContext(
       sessionId
     ) {
       await recordActiveMcpProviders();
-      await persistCompletedSessionRecord({
-        channelName: context.correlation?.channelName,
-        conversationId: sessionConversationId,
-        currentDurationMs: Date.now() - replyStartedAtMs,
-        currentUsage: turnUsage,
-        destination: context.destination,
-        source: runSource,
-        sessionId,
-        sliceId: currentSliceId,
-        allMessages: agent.state.messages,
-        loadedSkillNames: loadedSkillNamesForResume,
-        logContext: sessionRecordLogContext,
-        requester,
-        ...(surface ? { surface } : {}),
-        ...(turnStartMessageIndex !== undefined
-          ? { turnStartMessageIndex }
-          : {}),
-      });
+      // Generation completing is not delivery: the session record stays at its
+      // latest running safe boundary here. The destination boundary commits
+      // the final messages and terminal completed state only after the visible
+      // reply is accepted, so an undelivered assistant reply never surfaces as
+      // delivered conversation history and a crash before delivery stays
+      // recoverable through stranded-running continuation.
     }
 
     // ── Build turn result ────────────────────────────────────────────

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -536,7 +536,14 @@ function buildUserTurnInput(args: {
   return { routerBlocks, userContentParts };
 }
 
-function buildSteeringPiMessage(message: ReplySteeringMessage): PiMessage {
+/**
+ * Convert a mid-run user message into the Pi user message shape used for
+ * steering injection and parked-conversation session-log appends, so both
+ * paths store identical durable history.
+ */
+export function buildSteeringPiMessage(
+  message: ReplySteeringMessage,
+): PiMessage {
   const { userContentParts } = buildUserTurnInput({
     userTurnText: message.text,
     userAttachments: message.userAttachments,
@@ -795,14 +802,29 @@ async function generateAssistantReplyInPrivacyContext(
       ) {
         return;
       }
-      await recordToolExecutionStarted({
-        conversationId: sessionConversationId,
-        sessionId,
-        toolCallId: event.toolCallId,
-        toolName: event.toolName,
-        args: event.args,
-        ttlMs: THREAD_STATE_TTL_MS,
-      });
+      try {
+        await recordToolExecutionStarted({
+          conversationId: sessionConversationId,
+          sessionId,
+          toolCallId: event.toolCallId,
+          toolName: event.toolName,
+          args: event.args,
+          ttlMs: THREAD_STATE_TTL_MS,
+        });
+      } catch (error) {
+        // Host-only activity events are best-effort reporting writes; a
+        // failed append must not abort the in-flight model turn.
+        logWarn(
+          "agent_turn_session_log_append_failed",
+          spanContext,
+          {
+            "gen_ai.tool.name": event.toolName,
+            "exception.message":
+              error instanceof Error ? error.message : String(error),
+          },
+          "Failed to record host-only tool execution start",
+        );
+      }
     };
     const persistedConfigurationValues = context.channelConfiguration
       ? await context.channelConfiguration.resolveValues()
@@ -1259,15 +1281,16 @@ async function generateAssistantReplyInPrivacyContext(
       resumedFromSessionRecord &&
       existingSessionRecord?.turnStartMessageIndex !== undefined;
     const shouldPromptAgent = !resumedFromSessionRecord || !hasPromptCheckpoint;
-    const promptHistoryMessages =
-      shouldPromptAgent && resumedFromSessionRecord
-        ? withoutTrailingUncheckpointedUserPrompt(
-            priorPiMessages,
-            userContentParts,
-          )
-        : shouldPromptAgent
-          ? (priorPiMessages ?? [])
-          : existingSessionRecord!.piMessages;
+    // Every re-prompt shape must trim a trailing checkpointed copy of the same
+    // user prompt, including redelivery of the same inbound message after a
+    // lost input commit against a still-`running` record; otherwise the prompt
+    // appears twice in Pi history.
+    const promptHistoryMessages = shouldPromptAgent
+      ? withoutTrailingUncheckpointedUserPrompt(
+          priorPiMessages,
+          userContentParts,
+        )
+      : existingSessionRecord!.piMessages;
     const needsBootstrapContextForPrompt =
       shouldPromptAgent && !hasRuntimeTurnContext(promptHistoryMessages);
     const systemPromptContributions =
@@ -1578,11 +1601,11 @@ async function generateAssistantReplyInPrivacyContext(
     try {
       if (resumedFromSessionRecord) {
         agent.state.messages = shouldPromptAgent
-          ? (promptHistoryMessages ?? [])
+          ? promptHistoryMessages
           : existingSessionRecord!.piMessages;
         turnStartMessageIndex = existingSessionRecord!.turnStartMessageIndex;
-      } else if (context.piMessages && context.piMessages.length > 0) {
-        agent.state.messages = [...context.piMessages];
+      } else if (promptHistoryMessages.length > 0) {
+        agent.state.messages = [...promptHistoryMessages];
       }
       beforeMessageCount = agent.state.messages.length;
       if (shouldPromptAgent) {
@@ -1984,9 +2007,11 @@ async function generateAssistantReplyInPrivacyContext(
       "generateAssistantReply failed",
     );
 
+    // Raw exception text is diagnostics-only; the failure-response service
+    // owns the sanitized user-visible fallback for empty provider errors.
     const message = error instanceof Error ? error.message : String(error);
     return {
-      text: `Error: ${message}`,
+      text: "",
       ...getSandboxMetadata(),
       diagnostics: {
         outcome: "provider_error",

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -582,6 +582,9 @@ export async function generateAssistantReply(
       context.correlation?.conversationId ??
       context.correlation?.threadId ??
       context.correlation?.runId,
+    // Source-confirmed visibility from the live event's channel_type; without
+    // it the turn fails closed to private telemetry capture.
+    visibility: context.slackConversation?.visibility,
   });
   return runWithConversationPrivacy(conversationPrivacy ?? "private", () =>
     generateAssistantReplyInPrivacyContext(

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -813,13 +813,12 @@ async function generateAssistantReplyInPrivacyContext(
       } catch (error) {
         // Host-only activity events are best-effort reporting writes; a
         // failed append must not abort the in-flight model turn.
-        logWarn(
+        logException(
+          error,
           "agent_turn_session_log_append_failed",
           spanContext,
           {
             "gen_ai.tool.name": event.toolName,
-            "exception.message":
-              error instanceof Error ? error.message : String(error),
           },
           "Failed to record host-only tool execution start",
         );

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -256,7 +256,7 @@ export interface ReplyRequestContext {
   };
   onStatus?: (status: AssistantStatusSpec) => void | Promise<void>;
   drainSteeringMessages?: (
-    inject: (messages: ReplySteeringMessage[]) => Promise<void>,
+    accept: (messages: ReplySteeringMessage[]) => Promise<void>,
   ) => Promise<ReplySteeringMessage[]>;
   /** Return true when the durable worker should pause at the next Pi boundary. */
   shouldYield?: () => boolean;
@@ -1491,12 +1491,12 @@ async function generateAssistantReplyInPrivacyContext(
         });
         if (steeredMessageCount > 0) {
           logInfo(
-            "agent_turn_steering_messages_injected",
+            "agent_turn_steering_messages_accepted",
             spanContext,
             {
               "app.ai.steering_message_count": steeredMessageCount,
             },
-            "Agent turn steering messages injected",
+            "Agent turn steering messages accepted",
           );
         }
       } catch (error) {

--- a/packages/junior/src/chat/runtime/agent-continue-runner.ts
+++ b/packages/junior/src/chat/runtime/agent-continue-runner.ts
@@ -53,7 +53,13 @@ import { getStateAdapter } from "@/chat/state/adapter";
 import { acquireActiveLock } from "@/chat/state/locks";
 import { persistYieldSessionRecord } from "@/chat/services/turn-session-record";
 import { requireTurnFailureEventId } from "@/chat/services/turn-failure-response";
-import { createSlackResumeRequester } from "@/chat/requester";
+import {
+  createSlackRequester,
+  createSlackResumeRequester,
+  type Requester,
+  type SlackRequester,
+} from "@/chat/requester";
+import { getConversationWorkState } from "@/chat/task-execution/store";
 import type { AssistantReply, generateAssistantReply } from "@/chat/respond";
 import { persistAuthPauseTurnState } from "@/chat/runtime/auth-pause-state";
 import {
@@ -185,6 +191,54 @@ async function failContinuationStartup(args: {
   }
 }
 
+/**
+ * Resolve the resume requester without ever throwing for missing identity.
+ *
+ * A throw escaping `beforeStart` NACKs the continue queue delivery and
+ * permanently wedges the conversation (issue #727), so identity gaps must
+ * resolve to `undefined` and let the caller fail the session visibly. When
+ * the session record lacks a usable requester, recovery consults the durable
+ * conversation work record — but only an identity that matches the resume
+ * actor (team + user) is ever rebuilt; we never fabricate one.
+ */
+async function resolveContinuationRequester(args: {
+  conversationId: string;
+  sessionRecordRequester: Requester | undefined;
+  teamId: string;
+  userId: string;
+}): Promise<SlackRequester | undefined> {
+  const stored = args.sessionRecordRequester;
+  if (
+    stored?.platform === "slack" &&
+    stored.teamId === args.teamId &&
+    stored.userId === args.userId
+  ) {
+    return createSlackResumeRequester({
+      requester: stored,
+      teamId: args.teamId,
+      userId: args.userId,
+    });
+  }
+
+  const work = await getConversationWorkState({
+    conversationId: args.conversationId,
+  });
+  const workRequester = work?.requester;
+  if (
+    workRequester &&
+    workRequester.teamId === args.teamId &&
+    workRequester.slackUserId === args.userId
+  ) {
+    return createSlackRequester(args.teamId, args.userId, {
+      email: workRequester.email,
+      fullName: workRequester.fullName,
+      userName: workRequester.slackUserName,
+    });
+  }
+
+  return undefined;
+}
+
 function isContinuationResume(summary: AgentTurnSessionSummary): boolean {
   return (
     summary.state === "awaiting_resume" &&
@@ -277,11 +331,20 @@ export async function continueSlackAgentRun(
           payload.destination,
           "Slack continuation",
         );
-        const requester = createSlackResumeRequester({
-          requester: activeSessionRecord.requester,
+        const requester = await resolveContinuationRequester({
+          conversationId: payload.conversationId,
+          sessionRecordRequester: activeSessionRecord.requester,
           teamId: destination.teamId,
           userId: userMessage.author.userId,
         });
+        if (!requester) {
+          await failStrandedSessionWithFallback({
+            conversationId: payload.conversationId,
+            errorMessage: "Stored Slack requester missing for continuation",
+            sessionRecord: activeSessionRecord,
+          });
+          return false;
+        }
         if (!activeSessionRecord.source) {
           await failAgentTurnSessionRecord({
             conversationId: payload.conversationId,

--- a/packages/junior/src/chat/runtime/agent-continue-runner.ts
+++ b/packages/junior/src/chat/runtime/agent-continue-runner.ts
@@ -5,7 +5,12 @@
  * drop stale callbacks before generation, while any started continuation must
  * durably record success, failure, auth pause, or another safe pause boundary.
  */
-import { logException, logWarn } from "@/chat/logging";
+import { botConfig } from "@/chat/config";
+import {
+  buildTurnFailureResponse,
+  logException,
+  logWarn,
+} from "@/chat/logging";
 import {
   ResumeTurnBusyError,
   resumeSlackTurn,
@@ -43,6 +48,11 @@ import {
   type AgentContinueRequest,
 } from "@/chat/services/agent-continue";
 import { parseSlackThreadId } from "@/chat/slack/context";
+import { postSlackMessage } from "@/chat/slack/outbound";
+import { getStateAdapter } from "@/chat/state/adapter";
+import { acquireActiveLock } from "@/chat/state/locks";
+import { persistYieldSessionRecord } from "@/chat/services/turn-session-record";
+import { requireTurnFailureEventId } from "@/chat/services/turn-failure-response";
 import { createSlackResumeRequester } from "@/chat/requester";
 import type { AssistantReply, generateAssistantReply } from "@/chat/respond";
 import { persistAuthPauseTurnState } from "@/chat/runtime/auth-pause-state";
@@ -386,6 +396,137 @@ export async function continueSlackAgentRun(
   });
 }
 
+/** Terminally fail a stranded session and post the standard visible fallback. */
+async function failStrandedSessionWithFallback(args: {
+  conversationId: string;
+  errorMessage: string;
+  sessionRecord: AgentTurnSessionRecord;
+}): Promise<void> {
+  await failAgentTurnSessionRecord({
+    conversationId: args.conversationId,
+    expectedVersion: args.sessionRecord.version,
+    sessionId: args.sessionRecord.sessionId,
+    errorMessage: args.errorMessage,
+  });
+  const currentState = await getPersistedThreadState(args.conversationId);
+  const conversation = coerceThreadConversationState(currentState);
+  markTurnFailed({
+    conversation,
+    nowMs: Date.now(),
+    sessionId: args.sessionRecord.sessionId,
+    userMessageId: getTurnUserMessage(
+      conversation,
+      args.sessionRecord.sessionId,
+    )?.id,
+    markConversationMessage,
+    updateConversationStats,
+  });
+  await persistThreadStateById(args.conversationId, { conversation });
+
+  const thread = parseSlackThreadId(args.conversationId);
+  if (!thread) {
+    return;
+  }
+  const eventName = "agent_turn_stranded_session_failed";
+  const eventId = logException(
+    new Error(args.errorMessage),
+    eventName,
+    { conversationId: args.conversationId },
+    {
+      "app.ai.conversation_id": args.conversationId,
+      "app.ai.session_id": args.sessionRecord.sessionId,
+    },
+    "Stranded running agent session terminally failed",
+  );
+  await postSlackMessage({
+    channelId: thread.channelId,
+    threadTs: thread.threadTs,
+    text: buildTurnFailureResponse(
+      requireTurnFailureEventId(eventId, eventName),
+    ),
+  });
+}
+
+/**
+ * Recover a conversation whose newest session is still `running` with no live
+ * owner (hard worker death mid-slice). The session is re-parked at its latest
+ * durable safe boundary and continued; when no resumable boundary remains it
+ * is terminally failed with the standard visible fallback so the interrupted
+ * request never dies silently.
+ */
+async function recoverStrandedRunningSession(args: {
+  conversationId: string;
+  options: AgentContinueRunnerOptions;
+  summary: AgentTurnSessionSummary;
+}): Promise<boolean> {
+  // A live resume outside the mailbox lease (OAuth/timeout continuation)
+  // holds the thread resume lock for its whole run; only a dead slice leaves
+  // a running record unlocked.
+  const stateAdapter = getStateAdapter();
+  await stateAdapter.connect();
+  const probe = await acquireActiveLock(stateAdapter, args.conversationId);
+  if (!probe) {
+    return false;
+  }
+  await stateAdapter.releaseLock(probe);
+
+  const sessionRecord = await getAgentTurnSessionRecord(
+    args.conversationId,
+    args.summary.sessionId,
+  );
+  if (!sessionRecord || sessionRecord.state !== "running") {
+    return false;
+  }
+
+  const parked = await persistYieldSessionRecord({
+    channelName: sessionRecord.channelName,
+    conversationId: args.conversationId,
+    sessionId: sessionRecord.sessionId,
+    currentSliceId: sessionRecord.sliceId,
+    destination: sessionRecord.destination,
+    source: sessionRecord.source,
+    messages: sessionRecord.piMessages,
+    errorMessage: "Recovered running session after hard worker death",
+    logContext: { modelId: botConfig.modelId },
+    requester: sessionRecord.requester,
+    surface: sessionRecord.surface,
+  });
+  if (!parked) {
+    await failStrandedSessionWithFallback({
+      conversationId: args.conversationId,
+      errorMessage:
+        "Stranded running session had no resumable boundary after worker death",
+      sessionRecord,
+    });
+    return false;
+  }
+
+  const request = await getAwaitingAgentContinueRequest({
+    conversationId: args.conversationId,
+    sessionId: sessionRecord.sessionId,
+  });
+  if (!request) {
+    await failStrandedSessionWithFallback({
+      conversationId: args.conversationId,
+      errorMessage:
+        "Stranded running session could not materialize continuation metadata",
+      sessionRecord: parked,
+    });
+    return false;
+  }
+
+  if (await continueSlackAgentRunWithLockRetry(request, args.options)) {
+    return true;
+  }
+  await failUnresumableContinuation({
+    conversationId: args.conversationId,
+    expectedVersion: request.expectedVersion,
+    summary: args.summary,
+    errorMessage: "Awaiting agent continuation was stale before it could run",
+  });
+  return false;
+}
+
 /** Resume the first valid paused Slack session for an idle conversation. */
 export async function resumeAwaitingSlackContinuation(
   conversationId: string,
@@ -393,6 +534,18 @@ export async function resumeAwaitingSlackContinuation(
 ): Promise<boolean> {
   const summaries =
     await listAgentTurnSessionSummariesForConversation(conversationId);
+
+  // Recovery must cover every non-terminal session: a newest `running` record
+  // under the (already re-acquired) conversation lease means the previous
+  // worker died mid-slice without persisting a pause boundary.
+  const newest = summaries[0];
+  if (newest?.state === "running") {
+    return await recoverStrandedRunningSession({
+      conversationId,
+      options,
+      summary: newest,
+    });
+  }
 
   for (const summary of summaries) {
     if (!isContinuationResume(summary)) {

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -117,7 +117,7 @@ import {
   getAgentTurnSessionRecord,
   recordAgentTurnSessionSummary,
 } from "@/chat/state/turn-session";
-import { persistCompletedSessionRecord } from "@/chat/services/turn-session-record";
+import { completeDeliveredTurn } from "@/chat/services/turn-session-record";
 import {
   initConversationContext,
   setConversationTitle,
@@ -328,14 +328,14 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
       beforeFirstResponsePost?: () => Promise<void>;
       destination: Destination;
       explicitMention?: boolean;
-      onInputCommitted?: () => Promise<void>;
+      ack?: () => Promise<void>;
       onToolInvocation?: (invocation: TurnToolInvocation) => void;
       onTurnCompleted?: () => Promise<void>;
       onTurnStatePersisted?: () => Promise<void>;
       preparedState?: PreparedTurnState;
       queuedMessages?: QueuedTurnMessage[];
       drainSteeringMessages?: (
-        inject: (messages: QueuedTurnMessage[]) => Promise<void>,
+        accept: (messages: QueuedTurnMessage[]) => Promise<void>,
         context?: { conversationContext?: string },
       ) => Promise<QueuedTurnMessage[]>;
       shouldYield?: () => boolean;
@@ -552,7 +552,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
          * parked safe boundary so the resumed `continue()` sees it. The
          * awaiting record pins the log session and materializes the projection
          * tail, so the append needs no record mutation. Must complete before
-         * `onInputCommitted` consumes the mailbox record.
+         * `ack` consumes the mailbox record.
          *
          * The read-compute-append races a concurrently-resumed slice, which
          * runs under the thread resume lock; take the same lock so the two
@@ -628,7 +628,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             conversation: preparedState.conversation,
           });
           await options.onTurnStatePersisted?.();
-          await options.onInputCommitted?.();
+          await options.ack?.();
           await options.onTurnCompleted?.();
           return;
         }
@@ -640,7 +640,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             });
           if (resumeRequest) {
             // Durable session-log append first: rescheduling a continuation
-            // does not consume the message, and `onInputCommitted` may only
+            // does not consume the message, and `ack` may only
             // fire after the input is model-visible.
             if (!(await appendParkedTurnInput(resumeRequest.sessionId))) {
               // A live resume holds the thread lock; leave the mailbox
@@ -670,7 +670,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               conversation: preparedState.conversation,
             });
             await options.onTurnStatePersisted?.();
-            await options.onInputCommitted?.();
+            await options.ack?.();
             return;
           }
 
@@ -752,7 +752,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             conversation: preparedState.conversation,
           });
           await options.onTurnStatePersisted?.();
-          await options.onInputCommitted?.();
+          await options.ack?.();
           return;
         }
         startActiveTurn({
@@ -1018,19 +1018,19 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             preparedState.artifacts.assistantContextChannelId ?? channelId;
           const drainSteeringMessages = options.drainSteeringMessages
             ? async (
-                inject: (messages: ReplySteeringMessage[]) => Promise<void>,
+                accept: (messages: ReplySteeringMessage[]) => Promise<void>,
               ): Promise<ReplySteeringMessage[]> => {
-                let injectedMessages: ReplySteeringMessage[] | undefined;
+                let acceptedMessages: ReplySteeringMessage[] | undefined;
                 const drained = await options.drainSteeringMessages!(
                   async (queuedMessages) => {
-                    injectedMessages =
+                    acceptedMessages =
                       await resolveSteeringMessages(queuedMessages);
-                    await inject(injectedMessages);
+                    await accept(acceptedMessages);
                   },
                   { conversationContext: preparedState.conversationContext },
                 );
                 return (
-                  injectedMessages ?? (await resolveSteeringMessages(drained))
+                  acceptedMessages ?? (await resolveSteeringMessages(drained))
                 );
               }
             : undefined;
@@ -1101,7 +1101,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               },
               onStatus: (nextStatus) => status.update(nextStatus),
               onToolInvocation: options.onToolInvocation,
-              onInputCommitted: options.onInputCommitted,
+              onInputCommitted: options.ack,
               drainSteeringMessages,
               shouldYield: options.shouldYield,
             },
@@ -1254,16 +1254,17 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             // regenerating an already-delivered reply if the thread-state
             // write below fails.
             if (conversationId && reply.piMessages?.length) {
-              await persistCompletedSessionRecord({
+              await completeDeliveredTurn({
                 channelName,
                 conversationId,
-                currentDurationMs: reply.diagnostics.durationMs,
-                currentUsage: reply.diagnostics.usage,
+                durationMs: reply.diagnostics.durationMs,
+                usage: reply.diagnostics.usage,
                 destination,
                 destinationVisibility,
                 source,
                 sessionId: turnId,
-                allMessages: reply.piMessages,
+                sliceId: 1,
+                messages: reply.piMessages,
                 logContext: {
                   threadId,
                   requesterId: slackRequesterId,

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -909,6 +909,10 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
         let finalReplyDelivered = false;
         let latestArtifacts = preparedState.artifacts;
         let assistantTitleArtifacts: Partial<ThreadArtifactsState> = {};
+        const hasVisibleSlackDelivery = (post: {
+          files?: unknown[];
+          text: string;
+        }) => post.text.trim().length > 0 || Boolean(post.files?.length);
 
         try {
           const loadedPiMessages = await loadPiMessagesForTurn({
@@ -1144,6 +1148,14 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           // completed after the visible reply has been accepted by Slack.
           if (plannedPosts.length > 0) {
             let sent: SentMessage | undefined;
+            const hasVisibleDelivery = plannedPosts.some(
+              hasVisibleSlackDelivery,
+            );
+            if (!hasVisibleDelivery) {
+              throw new Error(
+                "Slack final reply plan did not contain visible delivery",
+              );
+            }
             if (shouldUseSlackFooter) {
               const slackChannelId = channelId;
               const slackThreadTs = threadTs;
@@ -1191,6 +1203,9 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               }
             } else {
               for (const post of plannedPosts) {
+                if (!hasVisibleSlackDelivery(post)) {
+                  continue;
+                }
                 sent = await postThreadReply(
                   buildSlackOutputMessage(post.text, post.files),
                   post.stage,
@@ -1228,11 +1243,13 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                 );
               }
             }
+          } else {
+            // Side-effect-only turns (for example reactions or channel posts)
+            // have no thread reply to deliver; the successful tool result is
+            // the visible Slack acceptance boundary.
+            finalReplyDelivered = true;
+            shouldPersistFailureState = false;
           }
-          // Zero planned posts means there is nothing to deliver; treat the
-          // turn as accepted so completion persistence proceeds.
-          finalReplyDelivered = true;
-          shouldPersistFailureState = false;
 
           const completedState = buildDeliveredTurnStatePatch({
             artifactStatePatch: {

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -77,6 +77,7 @@ import {
 import { buildSlackReplyFooter } from "@/chat/slack/footer";
 import { maybeUpdateAssistantTitle } from "@/chat/slack/assistant-thread/title";
 import {
+  conversationVisibilityFromSlackChannelType,
   resolveSlackChannelTypeFromMessage,
   resolveSlackConversationContext,
 } from "@/chat/slack/conversation-context";
@@ -318,6 +319,10 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
       channelName,
       channelType: slackChannelType,
     });
+    // Source-confirmed visibility for destination persistence; undefined when
+    // the event carries no channel_type so stored rows stay unconfirmed.
+    const destinationVisibility =
+      conversationVisibilityFromSlackChannelType(slackChannelType);
     const threadTs = getThreadTs(threadId);
     const assistantThreadContext = getAssistantThreadContext(message);
     const messageTs = getMessageTs(message);
@@ -328,6 +333,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
     const teamId = destination.teamId;
     const source = createSlackSource({
       channelId: channelId ?? destination.channelId,
+      channelType: slackChannelType,
       messageTs,
       teamId,
       threadTs,
@@ -603,6 +609,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             surface: "slack",
             requester,
             destination,
+            destinationVisibility,
             source,
             traceId: getActiveTraceId(),
           }).catch((error) => {
@@ -1108,6 +1115,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               state: "completed",
               requester,
               destination,
+              destinationVisibility,
               source,
               traceId: getActiveTraceId(),
             });
@@ -1326,6 +1334,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                   state: "failed",
                   requester,
                   destination,
+                  destinationVisibility,
                   source,
                   traceId: getActiveTraceId(),
                 });

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -357,7 +357,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
       channelType: slackChannelType,
     });
     // Source-confirmed visibility for destination persistence; undefined when
-    // the event carries no channel_type so stored rows stay unconfirmed.
+    // the event carries no channel_type so existing visibility is not changed.
     const destinationVisibility =
       conversationVisibilityFromSlackChannelType(slackChannelType);
     const threadTs = getThreadTs(threadId);
@@ -370,10 +370,10 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
     const teamId = destination.teamId;
     const source = createSlackSource({
       channelId: channelId ?? destination.channelId,
-      channelType: slackChannelType,
       messageTs,
       teamId,
       threadTs,
+      type: destinationVisibility === "public" ? "pub" : "priv",
     });
     const runId = getRunId(thread, message);
     const conversationId = threadId ?? runId;

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -117,6 +117,7 @@ import {
   getAgentTurnSessionRecord,
   recordAgentTurnSessionSummary,
 } from "@/chat/state/turn-session";
+import { persistCompletedSessionRecord } from "@/chat/services/turn-session-record";
 import {
   initConversationContext,
   setConversationTitle,
@@ -127,6 +128,39 @@ import {
   trimTrailingAssistantMessages,
 } from "@/chat/respond-helpers";
 import { requireSlackDestination } from "@/chat/destination";
+
+const DELIVERED_STATE_PERSIST_ATTEMPTS = 3;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Persist post-delivery thread state with a short retry so a transient state
+ * write does not lose the delivered outcome of an already-accepted reply.
+ */
+async function persistThreadStateWithRetry(
+  thread: Thread,
+  patch: Parameters<typeof persistThreadState>[1],
+): Promise<void> {
+  let lastError: unknown;
+  for (
+    let attempt = 1;
+    attempt <= DELIVERED_STATE_PERSIST_ATTEMPTS;
+    attempt += 1
+  ) {
+    try {
+      await persistThreadState(thread, patch);
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt < DELIVERED_STATE_PERSIST_ATTEMPTS) {
+        await sleep(attempt * 100);
+      }
+    }
+  }
+  throw lastError;
+}
 
 function collectCanvasUrls(artifacts: Partial<ThreadArtifactsState>) {
   return new Set(
@@ -839,6 +873,10 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
         };
         let persistedAtLeastOnce = false;
         let shouldPersistFailureState = true;
+        // Mirrors slack-resume's finalReplyDelivered guard: once the
+        // destination accepted the final posts, later errors in the same turn
+        // must not mark it failed or trigger the fallback failure reply.
+        let finalReplyDelivered = false;
         let latestArtifacts = preparedState.artifacts;
         let assistantTitleArtifacts: Partial<ThreadArtifactsState> = {};
 
@@ -1129,6 +1167,10 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                 );
               }
             }
+            // Slack accepted every final post: the turn is delivered even if
+            // the redundant-ack cleanup or completion persistence below fails.
+            finalReplyDelivered = true;
+            shouldPersistFailureState = false;
             const firstPlannedMessageHasFiles =
               (plannedPosts[0]?.files?.length ?? 0) > 0;
             // When a reaction already acknowledged the turn, delete the
@@ -1144,6 +1186,10 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               await sent.delete();
             }
           }
+          // Zero planned posts means there is nothing to deliver; treat the
+          // turn as accepted so completion persistence proceeds.
+          finalReplyDelivered = true;
+          shouldPersistFailureState = false;
 
           const completedState = buildDeliveredTurnStatePatch({
             artifactStatePatch: {
@@ -1159,37 +1205,77 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           if (completedState.artifacts) {
             latestArtifacts = completedState.artifacts;
           }
-          await persistThreadState(thread, {
-            ...completedState,
-          });
-          if (
-            completedState.artifacts &&
-            (assistantTitleArtifacts.assistantTitle !== undefined ||
-              assistantTitleArtifacts.assistantTitleSourceMessageId !==
-                undefined) &&
-            (completedState.artifacts.assistantTitle !==
-              assistantTitleArtifacts.assistantTitle ||
-              completedState.artifacts.assistantTitleSourceMessageId !==
-                assistantTitleArtifacts.assistantTitleSourceMessageId)
-          ) {
-            await persistThreadState(thread, { artifacts: latestArtifacts });
-          }
-          if (conversationId) {
-            await recordAgentTurnSessionSummary({
-              channelName,
-              conversationId,
-              cumulativeDurationMs: reply.diagnostics.durationMs,
-              cumulativeUsage: reply.diagnostics.usage,
-              sessionId: turnId,
-              sliceId: 1,
-              startedAtMs: message.metadata.dateSent.getTime(),
-              state: "completed",
-              requester,
-              destination,
-              destinationVisibility,
-              source,
-              traceId: getActiveTraceId(),
+          try {
+            // Commit the terminal completed session record first: it is the
+            // delivered marker that keeps stranded-running recovery from
+            // regenerating an already-delivered reply if the thread-state
+            // write below fails.
+            if (conversationId && reply.piMessages?.length) {
+              await persistCompletedSessionRecord({
+                channelName,
+                conversationId,
+                currentDurationMs: reply.diagnostics.durationMs,
+                currentUsage: reply.diagnostics.usage,
+                destination,
+                destinationVisibility,
+                source,
+                sessionId: turnId,
+                allMessages: reply.piMessages,
+                logContext: {
+                  threadId,
+                  requesterId: slackRequesterId,
+                  channelId,
+                  runId,
+                  assistantUserName: botConfig.userName,
+                  modelId: reply.diagnostics.modelId,
+                },
+                requester,
+                surface: "slack",
+              });
+            } else if (conversationId) {
+              await recordAgentTurnSessionSummary({
+                channelName,
+                conversationId,
+                cumulativeDurationMs: reply.diagnostics.durationMs,
+                cumulativeUsage: reply.diagnostics.usage,
+                sessionId: turnId,
+                sliceId: 1,
+                startedAtMs: message.metadata.dateSent.getTime(),
+                state: "completed",
+                requester,
+                destination,
+                destinationVisibility,
+                source,
+                traceId: getActiveTraceId(),
+              });
+            }
+            await persistThreadStateWithRetry(thread, {
+              ...completedState,
             });
+            if (
+              completedState.artifacts &&
+              (assistantTitleArtifacts.assistantTitle !== undefined ||
+                assistantTitleArtifacts.assistantTitleSourceMessageId !==
+                  undefined) &&
+              (completedState.artifacts.assistantTitle !==
+                assistantTitleArtifacts.assistantTitle ||
+                completedState.artifacts.assistantTitleSourceMessageId !==
+                  assistantTitleArtifacts.assistantTitleSourceMessageId)
+            ) {
+              await persistThreadStateWithRetry(thread, {
+                artifacts: latestArtifacts,
+              });
+            }
+          } catch (commitError) {
+            // The user already saw the reply; keep the turn successful and
+            // record the persistence failure for operators.
+            logException(
+              commitError,
+              "slack_reply_post_delivery_commit_failed",
+              turnTraceContext,
+              messageTs ? { "messaging.message.id": messageTs } : {},
+              "Post-delivery turn state persistence failed after Slack accepted the reply",
+            );
           }
           preparedState.conversation = completedState.conversation;
           persistedAtLeastOnce = true;
@@ -1223,6 +1309,20 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             }
           }
         } catch (error) {
+          if (finalReplyDelivered) {
+            // Delivered-turn guard: errors after Slack accepted the final
+            // reply (redundant-ack cleanup, completion callbacks) must not
+            // fail the turn or trigger the visible failure fallback.
+            shouldPersistFailureState = false;
+            logException(
+              error,
+              "slack_reply_post_delivery_commit_failed",
+              turnTraceContext,
+              messageTs ? { "messaging.message.id": messageTs } : {},
+              "Post-delivery turn work failed after Slack accepted the reply",
+            );
+            return;
+          }
           if (isCooperativeTurnYieldError(error)) {
             shouldPersistFailureState = false;
             throw error;

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -6,7 +6,9 @@
  * queued messages, compaction, status updates, and Slack posting meet; agent
  * internals stay behind the reply generator.
  */
+import { THREAD_STATE_TTL_MS } from "chat";
 import type { Message, SentMessage, Thread } from "chat";
+import { isDeepStrictEqual } from "node:util";
 import type { SlackAdapter } from "@chat-adapter/slack";
 import { createSlackSource, type Destination } from "@sentry/junior-plugin-api";
 import { botConfig } from "@/chat/config";
@@ -29,6 +31,7 @@ import {
 import { buildSlackOutputMessage } from "@/chat/slack/output";
 import { getSlackErrorObservabilityAttributes } from "@/chat/slack/errors";
 import {
+  buildSteeringPiMessage,
   generateAssistantReply as generateAssistantReplyImpl,
   type ReplySteeringMessage,
 } from "@/chat/respond";
@@ -109,6 +112,7 @@ import { buildAuthPauseResponse } from "@/chat/services/auth-pause-response";
 import { maybeApplyProviderDefaultConfigRequest } from "@/chat/services/provider-default-config";
 import type { PiMessage } from "@/chat/pi/messages";
 import {
+  abandonAgentTurnSessionRecord,
   failAgentTurnSessionRecord,
   getAgentTurnSessionRecord,
   recordAgentTurnSessionSummary,
@@ -117,7 +121,7 @@ import {
   initConversationContext,
   setConversationTitle,
 } from "@/chat/state/conversation-details";
-import { loadProjection } from "@/chat/state/session-log";
+import { commitMessages, loadProjection } from "@/chat/state/session-log";
 import {
   stripRuntimeTurnContext,
   trimTrailingAssistantMessages,
@@ -480,6 +484,86 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           }
         };
         let activeTurnId = preparedState.conversation.processing.activeTurnId;
+        const resolveSteeringMessages = async (
+          queuedMessages: QueuedTurnMessage[],
+        ): Promise<ReplySteeringMessage[]> => {
+          return await Promise.all(
+            queuedMessages.map(async (queued) => {
+              const attachments = queued.message.attachments;
+              return {
+                text: queued.userText,
+                timestampMs: queued.message.metadata.dateSent.getTime(),
+                omittedImageAttachmentCount:
+                  !isVisionEnabled() && hasPotentialImageAttachment(attachments)
+                    ? countPotentialImageAttachments(attachments)
+                    : 0,
+                userAttachments: await deps.resolveUserAttachments(
+                  attachments,
+                  {
+                    threadId,
+                    requesterId: isResourceEventMessage(queued.message)
+                      ? undefined
+                      : queued.message.author.userId,
+                    channelId,
+                    runId,
+                    conversation: preparedState.conversation,
+                    messageTs: getSlackMessageTs(queued.message),
+                  },
+                ),
+              };
+            }),
+          );
+        };
+        /**
+         * Durably append this turn's user input to the session log at the
+         * parked safe boundary so the resumed `continue()` sees it. The
+         * awaiting record pins the log session and materializes the projection
+         * tail, so the append needs no record mutation. Must complete before
+         * `onInputCommitted` consumes the mailbox record.
+         */
+        const appendParkedTurnInput = async (
+          parkedSessionId: string,
+        ): Promise<void> => {
+          if (!conversationId) {
+            return;
+          }
+          const parkedMessages = [
+            ...(options.queuedMessages ?? []),
+            {
+              explicitMention: Boolean(
+                options.explicitMention || message.isMention,
+              ),
+              message,
+              rawText: currentText.rawText,
+              userText: currentText.userText,
+            },
+          ].filter(
+            // Redelivery of the parked turn's own message must not duplicate
+            // the prompt that already started the session.
+            (queued) =>
+              buildDeterministicTurnId(queued.message.id) !== parkedSessionId,
+          );
+          if (parkedMessages.length === 0) {
+            return;
+          }
+          const piMessages = (
+            await resolveSteeringMessages(parkedMessages)
+          ).map(buildSteeringPiMessage);
+          const projection = await loadProjection({ conversationId });
+          if (
+            piMessages.length <= projection.length &&
+            isDeepStrictEqual(projection.slice(-piMessages.length), piMessages)
+          ) {
+            // A prior delivery already appended this input durably.
+            return;
+          }
+          await commitMessages({
+            conversationId,
+            messages: [...projection, ...piMessages],
+            requester: storedRequester,
+            ttlMs: THREAD_STATE_TTL_MS,
+          });
+        };
         if (preparedState.userMessageAlreadyReplied) {
           await persistThreadState(thread, {
             conversation: preparedState.conversation,
@@ -496,6 +580,10 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               sessionId: activeTurnId,
             });
           if (resumeRequest) {
+            // Durable session-log append first: rescheduling a continuation
+            // does not consume the message, and `onInputCommitted` may only
+            // fire after the input is model-visible.
+            await appendParkedTurnInput(resumeRequest.sessionId);
             try {
               await deps.services.scheduleAgentContinue(resumeRequest);
             } catch (error) {
@@ -528,29 +616,43 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           );
           if (sessionRecord?.state === "awaiting_resume") {
             if (sessionRecord.resumeReason === "auth") {
-              await persistThreadState(thread, {
-                conversation: preparedState.conversation,
+              // A user follow-up supersedes the auth-parked run: answer it
+              // now as a fresh turn instead of consuming it into a pause that
+              // may never resume. The parked prompt stays model-visible via
+              // the session-log projection, pendingAuth state keeps the
+              // authorization link reusable, and the abandoned record turns a
+              // late OAuth callback into a stale no-op instead of a competing
+              // run.
+              await abandonAgentTurnSessionRecord({
+                conversationId,
+                sessionId: activeTurnId,
+                errorMessage:
+                  "Auth-parked session superseded by a new user message",
               });
-              await options.onTurnStatePersisted?.();
-              await options.onInputCommitted?.();
-              return;
+              markTurnClosed({
+                conversation: preparedState.conversation,
+                nowMs: Date.now(),
+                sessionId: activeTurnId,
+                updateConversationStats,
+              });
+              activeTurnId = undefined;
+            } else {
+              await failAgentTurnSessionRecord({
+                conversationId,
+                expectedVersion: sessionRecord.version,
+                sessionId: activeTurnId,
+                errorMessage:
+                  "Awaiting agent continuation metadata could not be materialized",
+              });
+              markTurnFailed({
+                conversation: preparedState.conversation,
+                nowMs: Date.now(),
+                sessionId: activeTurnId,
+                markConversationMessage,
+                updateConversationStats,
+              });
+              activeTurnId = undefined;
             }
-
-            await failAgentTurnSessionRecord({
-              conversationId,
-              expectedVersion: sessionRecord.version,
-              sessionId: activeTurnId,
-              errorMessage:
-                "Awaiting agent continuation metadata could not be materialized",
-            });
-            markTurnFailed({
-              conversation: preparedState.conversation,
-              nowMs: Date.now(),
-              sessionId: activeTurnId,
-              markConversationMessage,
-              updateConversationStats,
-            });
-            activeTurnId = undefined;
           }
         }
         const configReply = await maybeApplyProviderDefaultConfigRequest({
@@ -846,37 +948,6 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             });
           const toolChannelId =
             preparedState.artifacts.assistantContextChannelId ?? channelId;
-          const resolveSteeringMessages = async (
-            queuedMessages: QueuedTurnMessage[],
-          ): Promise<ReplySteeringMessage[]> => {
-            return await Promise.all(
-              queuedMessages.map(async (queued) => {
-                const attachments = queued.message.attachments;
-                return {
-                  text: queued.userText,
-                  timestampMs: queued.message.metadata.dateSent.getTime(),
-                  omittedImageAttachmentCount:
-                    !isVisionEnabled() &&
-                    hasPotentialImageAttachment(attachments)
-                      ? countPotentialImageAttachments(attachments)
-                      : 0,
-                  userAttachments: await deps.resolveUserAttachments(
-                    attachments,
-                    {
-                      threadId,
-                      requesterId: isResourceEventMessage(queued.message)
-                        ? undefined
-                        : queued.message.author.userId,
-                      channelId,
-                      runId,
-                      conversation: preparedState.conversation,
-                      messageTs: getSlackMessageTs(queued.message),
-                    },
-                  ),
-                };
-              }),
-            );
-          };
           const drainSteeringMessages = options.drainSteeringMessages
             ? async (
                 inject: (messages: ReplySteeringMessage[]) => Promise<void>,

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -97,6 +97,7 @@ import {
   isAuthResumeRetryableTurnError,
   isCooperativeTurnYieldError,
   isRetryableTurnError,
+  TurnInputDeferredError,
 } from "@/chat/runtime/turn";
 import { buildDeterministicTurnId } from "@/chat/runtime/turn";
 import { markTurnClosed, markTurnFailed } from "@/chat/runtime/turn";
@@ -645,7 +646,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               // A live resume holds the thread lock; leave the mailbox
               // message pending so the next drain re-delivers it after the
               // resume completes.
-              return;
+              throw new TurnInputDeferredError();
             }
             try {
               await deps.services.scheduleAgentContinue(resumeRequest);

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -8,7 +8,6 @@
  */
 import { THREAD_STATE_TTL_MS } from "chat";
 import type { Message, SentMessage, Thread } from "chat";
-import { isDeepStrictEqual } from "node:util";
 import type { SlackAdapter } from "@chat-adapter/slack";
 import { createSlackSource, type Destination } from "@sentry/junior-plugin-api";
 import { botConfig } from "@/chat/config";
@@ -123,17 +122,14 @@ import {
   setConversationTitle,
 } from "@/chat/state/conversation-details";
 import { commitMessages, loadProjection } from "@/chat/state/session-log";
+import { getStateAdapter } from "@/chat/state/adapter";
+import { acquireActiveLock } from "@/chat/state/locks";
+import { persistWithRetry } from "@/chat/services/persist-retry";
 import {
   stripRuntimeTurnContext,
   trimTrailingAssistantMessages,
 } from "@/chat/respond-helpers";
 import { requireSlackDestination } from "@/chat/destination";
-
-const DELIVERED_STATE_PERSIST_ATTEMPTS = 3;
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 /**
  * Persist post-delivery thread state with a short retry so a transient state
@@ -143,23 +139,7 @@ async function persistThreadStateWithRetry(
   thread: Thread,
   patch: Parameters<typeof persistThreadState>[1],
 ): Promise<void> {
-  let lastError: unknown;
-  for (
-    let attempt = 1;
-    attempt <= DELIVERED_STATE_PERSIST_ATTEMPTS;
-    attempt += 1
-  ) {
-    try {
-      await persistThreadState(thread, patch);
-      return;
-    } catch (error) {
-      lastError = error;
-      if (attempt < DELIVERED_STATE_PERSIST_ATTEMPTS) {
-        await sleep(attempt * 100);
-      }
-    }
-  }
-  throw lastError;
+  await persistWithRetry(() => persistThreadState(thread, patch));
 }
 
 function collectCanvasUrls(artifacts: Partial<ThreadArtifactsState>) {
@@ -173,6 +153,24 @@ function collectCanvasUrls(artifacts: Partial<ThreadArtifactsState>) {
 
 function turnRequester(requester: SlackRequester): StoredSlackRequester {
   return toStoredSlackRequester(requester);
+}
+
+/**
+ * Identity key for parked-input dedupe: the inbound timestamp plus the user
+ * turn text (always the first content part). Attachment resolution may differ
+ * across queue redeliveries, so resolved attachment parts must not decide
+ * whether the same inbound message was already appended.
+ */
+function parkedInputKey(message: PiMessage): string | undefined {
+  if (message.role !== "user") {
+    return undefined;
+  }
+  const first = Array.isArray(message.content) ? message.content[0] : undefined;
+  const text =
+    first && typeof first === "object" && "text" in first
+      ? String((first as { text?: unknown }).text ?? "")
+      : "";
+  return `${message.timestamp}:${text}`;
 }
 
 function isResourceEventMessage(message: Message): boolean {
@@ -554,12 +552,18 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
          * awaiting record pins the log session and materializes the projection
          * tail, so the append needs no record mutation. Must complete before
          * `onInputCommitted` consumes the mailbox record.
+         *
+         * The read-compute-append races a concurrently-resumed slice, which
+         * runs under the thread resume lock; take the same lock so the two
+         * writers never interleave. Returns false when the lock is busy (a
+         * live resume owns the session log): the caller must leave the
+         * mailbox message pending for the next drain instead of consuming it.
          */
         const appendParkedTurnInput = async (
           parkedSessionId: string,
-        ): Promise<void> => {
+        ): Promise<boolean> => {
           if (!conversationId) {
-            return;
+            return true;
           }
           const parkedMessages = [
             ...(options.queuedMessages ?? []),
@@ -578,25 +582,45 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               buildDeterministicTurnId(queued.message.id) !== parkedSessionId,
           );
           if (parkedMessages.length === 0) {
-            return;
+            return true;
           }
-          const piMessages = (
-            await resolveSteeringMessages(parkedMessages)
-          ).map(buildSteeringPiMessage);
-          const projection = await loadProjection({ conversationId });
-          if (
-            piMessages.length <= projection.length &&
-            isDeepStrictEqual(projection.slice(-piMessages.length), piMessages)
-          ) {
-            // A prior delivery already appended this input durably.
-            return;
+          const stateAdapter = getStateAdapter();
+          await stateAdapter.connect();
+          const lock = await acquireActiveLock(stateAdapter, conversationId);
+          if (!lock) {
+            return false;
           }
-          await commitMessages({
-            conversationId,
-            messages: [...projection, ...piMessages],
-            requester: storedRequester,
-            ttlMs: THREAD_STATE_TTL_MS,
-          });
+          try {
+            const piMessages = (
+              await resolveSteeringMessages(parkedMessages)
+            ).map(buildSteeringPiMessage);
+            const projection = await loadProjection({ conversationId });
+            // Dedupe per message: a partial-overlap redelivery (some messages
+            // already appended before a schedule failure) must append only
+            // the missing ones.
+            const appendedKeys = new Set(
+              projection
+                .map(parkedInputKey)
+                .filter((key): key is string => key !== undefined),
+            );
+            const missing = piMessages.filter((piMessage) => {
+              const key = parkedInputKey(piMessage);
+              return key === undefined || !appendedKeys.has(key);
+            });
+            if (missing.length === 0) {
+              // A prior delivery already appended this input durably.
+              return true;
+            }
+            await commitMessages({
+              conversationId,
+              messages: [...projection, ...missing],
+              requester: storedRequester,
+              ttlMs: THREAD_STATE_TTL_MS,
+            });
+            return true;
+          } finally {
+            await stateAdapter.releaseLock(lock);
+          }
         };
         if (preparedState.userMessageAlreadyReplied) {
           await persistThreadState(thread, {
@@ -617,7 +641,12 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             // Durable session-log append first: rescheduling a continuation
             // does not consume the message, and `onInputCommitted` may only
             // fire after the input is model-visible.
-            await appendParkedTurnInput(resumeRequest.sessionId);
+            if (!(await appendParkedTurnInput(resumeRequest.sessionId))) {
+              // A live resume holds the thread lock; leave the mailbox
+              // message pending so the next drain re-delivers it after the
+              // resume completes.
+              return;
+            }
             try {
               await deps.services.scheduleAgentContinue(resumeRequest);
             } catch (error) {
@@ -1183,7 +1212,20 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               !firstPlannedMessageHasFiles &&
               isRedundantReactionAckText(reply.text)
             ) {
-              await sent.delete();
+              try {
+                await sent.delete();
+              } catch (error) {
+                // Best effort: the turn is already delivered, and a thrown
+                // delete here would skip the completed-record commit below
+                // and leave the session record stuck running.
+                logException(
+                  error,
+                  "slack_redundant_ack_delete_failed",
+                  turnTraceContext,
+                  messageTs ? { "messaging.message.id": messageTs } : {},
+                  "Failed to delete redundant reaction-ack reply",
+                );
+              }
             }
           }
           // Zero planned posts means there is nothing to deliver; treat the

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -27,6 +27,7 @@ import {
   finalizeFailedTurnReply,
   requireTurnFailureEventId,
 } from "@/chat/services/turn-failure-response";
+import { persistCompletedSessionRecord } from "@/chat/services/turn-session-record";
 import { persistThreadStateById } from "@/chat/runtime/thread-state";
 import {
   createSlackWebApiAssistantStatusSession,
@@ -409,6 +410,34 @@ export async function resumeSlackTurn(
       footer,
     });
     finalReplyDelivered = true;
+    // Destination acceptance is the completion boundary: only now commit the
+    // final assistant messages and the terminal completed session record.
+    // Persistence failures are logged inside and never fail the turn.
+    if (
+      replyContext.correlation?.conversationId &&
+      replyContext.correlation.turnId &&
+      reply.piMessages?.length
+    ) {
+      await persistCompletedSessionRecord({
+        conversationId: replyContext.correlation.conversationId,
+        sessionId: replyContext.correlation.turnId,
+        allMessages: reply.piMessages,
+        currentDurationMs: reply.diagnostics.durationMs,
+        currentUsage: reply.diagnostics.usage,
+        destination: replyContext.destination,
+        source: replyContext.source,
+        requester: replyContext.requester,
+        surface: "slack",
+        logContext: {
+          threadId: replyContext.correlation.threadId,
+          requesterId: replyContext.requester?.userId,
+          channelId: runArgs.channelId,
+          runId: replyContext.correlation.runId,
+          assistantUserName: botConfig.userName,
+          modelId: reply.diagnostics.modelId,
+        },
+      });
+    }
     await runArgs.onSuccess?.(reply);
     if (
       reply.diagnostics.outcome === "success" &&

--- a/packages/junior/src/chat/runtime/slack-runtime.ts
+++ b/packages/junior/src/chat/runtime/slack-runtime.ts
@@ -65,21 +65,16 @@ export interface SteeringCandidateMessage {
 export interface ReplyHooks {
   beforeFirstResponsePost?: () => Promise<void>;
   drainSteeringMessages?: (
-    inject: (
+    accept: (
       messages: SteeringCandidateMessage[],
     ) => Promise<readonly string[] | void>,
   ) => Promise<void>;
   messageContext?: MessageContext;
-  onInputCommitted?: () => Promise<void>;
+  ack?: () => Promise<void>;
   onToolInvocation?: (invocation: TurnToolInvocation) => void;
   onTurnStatePersisted?: () => Promise<void>;
+  isFinalAttempt?: boolean;
   shouldYield?: () => boolean;
-  /**
-   * Whether a failed turn for this delivery will be redelivered by the durable
-   * mailbox. When true, the handler suppresses the visible failure reply so a
-   * bounded retry sequence posts at most one fallback (on the final attempt).
-   */
-  willRetryOnFailure?: () => boolean;
 }
 
 interface SteeringDrainContext {
@@ -197,14 +192,14 @@ export interface SlackTurnRuntimeDependencies<TPreparedState> {
       beforeFirstResponsePost?: () => Promise<void>;
       destination: Destination;
       explicitMention?: boolean;
-      onInputCommitted?: () => Promise<void>;
+      ack?: () => Promise<void>;
       onToolInvocation?: (invocation: TurnToolInvocation) => void;
       onTurnCompleted?: () => Promise<void>;
       onTurnStatePersisted?: () => Promise<void>;
       preparedState?: TPreparedState;
       queuedMessages?: QueuedTurnMessage[];
       drainSteeringMessages?: (
-        inject: (messages: QueuedTurnMessage[]) => Promise<void>,
+        accept: (messages: QueuedTurnMessage[]) => Promise<void>,
         context?: SteeringDrainContext,
       ) => Promise<QueuedTurnMessage[]>;
       shouldYield?: () => boolean;
@@ -297,7 +292,7 @@ function createAcceptedSteeringDrain(
   },
 ):
   | ((
-      inject: (messages: QueuedTurnMessage[]) => Promise<void>,
+      accept: (messages: QueuedTurnMessage[]) => Promise<void>,
       context?: SteeringDrainContext,
     ) => Promise<QueuedTurnMessage[]>)
   | undefined {
@@ -305,7 +300,7 @@ function createAcceptedSteeringDrain(
     return undefined;
   }
 
-  return async (inject, context) => {
+  return async (accept, context) => {
     let interruptedMessages: Message[] | undefined;
     await hooks.drainSteeringMessages!(async (messages) => {
       const selection = await options.selectMessages(messages, context);
@@ -315,7 +310,7 @@ function createAcceptedSteeringDrain(
       const interrupted = selection.accepted
         .filter((accepted) => accepted.mode === "interrupt")
         .map((accepted) => accepted.message);
-      await inject(getQueuedMessagesFromSlackMessages(interrupted, options));
+      await accept(getQueuedMessagesFromSlackMessages(interrupted, options));
       interruptedMessages = interrupted;
       await options.onAcceptedForProcessing?.(interrupted);
       return [
@@ -565,7 +560,7 @@ export function createSlackTurnRuntime<
     message: Message;
     decision: SubscribedReplyDecision;
     context: TurnContext;
-    onInputCommitted?: () => Promise<void>;
+    ack?: () => Promise<void>;
     preparedState?: TPreparedState;
     text: TurnMessageText;
   }): Promise<void> => {
@@ -591,7 +586,7 @@ export function createSlackTurnRuntime<
     // Mark the inbound mailbox messages as consumed even though we are not
     // replying. Without this, completeConversationWork sees pendingMessages > 0
     // and re-enqueues indefinitely — an infinite loop for every skipped message.
-    await args.onInputCommitted?.();
+    await args.ack?.();
   };
 
   const selectAcceptedSteeringMessages = async (args: {
@@ -704,6 +699,7 @@ export function createSlackTurnRuntime<
       let processingReaction: ProcessingReactionSession | undefined;
       const skippedSteeringMessages: SteeringMessageDecision[] = [];
       let completed = false;
+      let acked = false;
       const onTurnCompleted = async (): Promise<void> => {
         completed = true;
         await flushSkippedSteeringMessagesBestEffort({
@@ -753,8 +749,9 @@ export function createSlackTurnRuntime<
               ),
             );
           };
-          const onInputCommitted = async (): Promise<void> => {
-            await hooks.onInputCommitted?.();
+          const ack = async (): Promise<void> => {
+            await hooks.ack?.();
+            acked = true;
             await startQueuedProcessingReactions();
           };
           const drainSteeringMessages = createAcceptedSteeringDrain(hooks, {
@@ -786,7 +783,7 @@ export function createSlackTurnRuntime<
             beforeFirstResponsePost: hooks.beforeFirstResponsePost,
             destination: hooks.destination,
             queuedMessages,
-            onInputCommitted,
+            ack,
             onToolInvocation: toolInvocationHook,
             onTurnCompleted,
             drainSteeringMessages,
@@ -846,7 +843,7 @@ export function createSlackTurnRuntime<
           {},
           "onNewMention failed",
         );
-        if (hooks.willRetryOnFailure?.()) {
+        if (!acked && hooks.isFinalAttempt === false) {
           // The mailbox redelivers this message; only the final bounded
           // attempt posts the visible failure reply.
           return;
@@ -894,6 +891,7 @@ export function createSlackTurnRuntime<
       let processingReaction: ProcessingReactionSession | undefined;
       const skippedSteeringMessages: SteeringMessageDecision[] = [];
       let completed = false;
+      let acked = false;
       const onTurnCompleted = async (): Promise<void> => {
         completed = true;
         await flushSkippedSteeringMessagesBestEffort({
@@ -972,7 +970,7 @@ export function createSlackTurnRuntime<
               message,
               decision: { shouldReply: false, reason },
               context: threadContext,
-              onInputCommitted: hooks.onInputCommitted,
+              ack: hooks.ack,
               text: combinedText,
             });
             return;
@@ -1021,7 +1019,7 @@ export function createSlackTurnRuntime<
               message,
               decision,
               context: threadContext,
-              onInputCommitted: hooks.onInputCommitted,
+              ack: hooks.ack,
               preparedState,
               text: combinedText,
             });
@@ -1034,7 +1032,7 @@ export function createSlackTurnRuntime<
               message,
               decision,
               context: threadContext,
-              onInputCommitted: hooks.onInputCommitted,
+              ack: hooks.ack,
               preparedState,
               text: combinedText,
             });
@@ -1084,8 +1082,9 @@ export function createSlackTurnRuntime<
               ),
             );
           };
-          const onInputCommitted = async (): Promise<void> => {
-            await hooks.onInputCommitted?.();
+          const ack = async (): Promise<void> => {
+            await hooks.ack?.();
+            acked = true;
             await startQueuedProcessingReactions();
           };
           const toolInvocationHook = createToolInvocationHook(
@@ -1099,7 +1098,7 @@ export function createSlackTurnRuntime<
             preparedState,
             beforeFirstResponsePost: hooks.beforeFirstResponsePost,
             queuedMessages,
-            onInputCommitted,
+            ack,
             onToolInvocation: toolInvocationHook,
             onTurnCompleted,
             drainSteeringMessages,
@@ -1159,7 +1158,7 @@ export function createSlackTurnRuntime<
           {},
           "onSubscribedMessage failed",
         );
-        if (hooks.willRetryOnFailure?.()) {
+        if (!acked && hooks.isFinalAttempt === false) {
           // The mailbox redelivers this message; only the final bounded
           // attempt posts the visible failure reply.
           return;

--- a/packages/junior/src/chat/runtime/slack-runtime.ts
+++ b/packages/junior/src/chat/runtime/slack-runtime.ts
@@ -73,6 +73,12 @@ export interface ReplyHooks {
   onToolInvocation?: (invocation: TurnToolInvocation) => void;
   onTurnStatePersisted?: () => Promise<void>;
   shouldYield?: () => boolean;
+  /**
+   * Whether a failed turn for this delivery will be redelivered by the durable
+   * mailbox. When true, the handler suppresses the visible failure reply so a
+   * bounded retry sequence posts at most one fallback (on the final attempt).
+   */
+  willRetryOnFailure?: () => boolean;
 }
 
 interface SteeringDrainContext {
@@ -838,6 +844,11 @@ export function createSlackTurnRuntime<
           {},
           "onNewMention failed",
         );
+        if (hooks.willRetryOnFailure?.()) {
+          // The mailbox redelivers this message; only the final bounded
+          // attempt posts the visible failure reply.
+          return;
+        }
         if (!eventId) {
           throw new Error(
             "Sentry did not return an event ID for mention_handler_failed",
@@ -1146,6 +1157,11 @@ export function createSlackTurnRuntime<
           {},
           "onSubscribedMessage failed",
         );
+        if (hooks.willRetryOnFailure?.()) {
+          // The mailbox redelivers this message; only the final bounded
+          // attempt posts the visible failure reply.
+          return;
+        }
         if (!eventId) {
           throw new Error(
             "Sentry did not return an event ID for subscribed_message_handler_failed",

--- a/packages/junior/src/chat/runtime/slack-runtime.ts
+++ b/packages/junior/src/chat/runtime/slack-runtime.ts
@@ -14,6 +14,7 @@ import { AuthorizationFlowDisabledError } from "@/chat/services/auth-pause";
 import { SlackActionError } from "@/chat/slack/client";
 import {
   isCooperativeTurnYieldError,
+  isTurnInputDeferredError,
   isTurnInputCommitLostError,
   isRetryableTurnError,
 } from "@/chat/runtime/turn";
@@ -97,6 +98,7 @@ function shouldRethrowTurnControlError(error: unknown): boolean {
   return (
     isCooperativeTurnYieldError(error) ||
     isTurnInputCommitLostError(error) ||
+    isTurnInputDeferredError(error) ||
     isProviderRetryError(error)
   );
 }

--- a/packages/junior/src/chat/runtime/turn.ts
+++ b/packages/junior/src/chat/runtime/turn.ts
@@ -134,6 +134,23 @@ export function isTurnInputCommitLostError(
   return error instanceof TurnInputCommitLostError;
 }
 
+/** Error indicating durable turn input should stay pending for a later worker. */
+export class TurnInputDeferredError extends Error {
+  readonly code = "turn_input_deferred";
+
+  constructor(message = "Turn input is deferred until the active resume ends") {
+    super(message);
+    this.name = "TurnInputDeferredError";
+  }
+}
+
+/** Return whether an error means the durable worker should redeliver input later. */
+export function isTurnInputDeferredError(
+  error: unknown,
+): error is TurnInputDeferredError {
+  return error instanceof TurnInputDeferredError;
+}
+
 // ---------------------------------------------------------------------------
 // Turn lifecycle mutations
 // ---------------------------------------------------------------------------

--- a/packages/junior/src/chat/services/persist-retry.ts
+++ b/packages/junior/src/chat/services/persist-retry.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared post-delivery persist retry.
+ *
+ * Delivered outcomes the user already saw must not be lost to a transient
+ * state-write failure, so both the Slack reply executor and the dispatch
+ * runner retry these persists with the same short linear backoff.
+ */
+const PERSIST_ATTEMPTS = 3;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Retry a delivered-state persist briefly before surfacing the failure. */
+export async function persistWithRetry(
+  persist: () => Promise<void>,
+): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= PERSIST_ATTEMPTS; attempt += 1) {
+    try {
+      await persist();
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt < PERSIST_ATTEMPTS) {
+        await sleep(attempt * 100);
+      }
+    }
+  }
+  throw lastError;
+}

--- a/packages/junior/src/chat/services/turn-failure-response.ts
+++ b/packages/junior/src/chat/services/turn-failure-response.ts
@@ -130,8 +130,13 @@ export function finalizeFailedTurnReply(args: {
     capture.eventName,
   );
 
+  // Only text derived from actual assistant messages may be delivered as
+  // partial output. Synthesized failure replies (runtime catch-alls) report
+  // zero assistant messages, so raw exception text never reaches the user;
+  // the sanitized fallback with its event id owns the visible failure.
   const providerPartialText =
-    args.reply.diagnostics.outcome === "provider_error"
+    args.reply.diagnostics.outcome === "provider_error" &&
+    args.reply.diagnostics.assistantMessageCount > 0
       ? args.reply.text.trim()
       : "";
 

--- a/packages/junior/src/chat/services/turn-session-record.ts
+++ b/packages/junior/src/chat/services/turn-session-record.ts
@@ -303,6 +303,43 @@ export async function persistCompletedSessionRecord(args: {
   }
 }
 
+/** Complete a delivered single-slice run with an explicit session boundary. */
+export async function completeDeliveredTurn(args: {
+  channelName?: string;
+  conversationId: string;
+  destination: Destination;
+  destinationVisibility?: ConversationPrivacy;
+  durationMs?: number;
+  loadedSkillNames?: string[];
+  logContext: SessionRecordLogContext;
+  messages: PiMessage[];
+  requester?: Requester;
+  sessionId: string;
+  sliceId: number;
+  source: Source;
+  surface: AgentTurnSurface;
+  turnStartMessageIndex?: number;
+  usage?: AgentTurnUsage;
+}): Promise<void> {
+  await persistCompletedSessionRecord({
+    channelName: args.channelName,
+    conversationId: args.conversationId,
+    currentDurationMs: args.durationMs,
+    currentUsage: args.usage,
+    destination: args.destination,
+    destinationVisibility: args.destinationVisibility,
+    source: args.source,
+    sessionId: args.sessionId,
+    sliceId: args.sliceId,
+    allMessages: args.messages,
+    loadedSkillNames: args.loadedSkillNames,
+    logContext: args.logContext,
+    requester: args.requester,
+    surface: args.surface,
+    turnStartMessageIndex: args.turnStartMessageIndex,
+  });
+}
+
 /**
  * Persist an auth-pause session record. Returns the durable record only when
  * the caller can safely hand the user to an authorization resume flow.

--- a/packages/junior/src/chat/services/turn-session-record.ts
+++ b/packages/junior/src/chat/services/turn-session-record.ts
@@ -228,12 +228,20 @@ export async function persistCompletedSessionRecord(args: {
   surface?: AgentTurnSurface;
   turnStartMessageIndex?: number;
 }): Promise<void> {
-  const sliceIdForLog = args.sliceId ?? 1;
+  let sliceId = args.sliceId;
   try {
     const latestSessionRecord = await getAgentTurnSessionRecord(
       args.conversationId,
       args.sessionId,
     );
+    sliceId = sliceId ?? latestSessionRecord?.sliceId;
+    if (sliceId === undefined) {
+      // Never fabricate a slice-1 completion: a completion without a known
+      // slice is a caller bug and must surface as the standard failure path.
+      throw new Error(
+        "Completed session record requires a slice id from the caller or the latest stored record",
+      );
+    }
     await upsertAgentTurnSessionRecord({
       ...((args.channelName ?? latestSessionRecord?.channelName)
         ? { channelName: args.channelName ?? latestSessionRecord?.channelName }
@@ -257,7 +265,7 @@ export async function persistCompletedSessionRecord(args: {
         ? { destinationVisibility: args.destinationVisibility }
         : {}),
       sessionId: args.sessionId,
-      sliceId: args.sliceId ?? latestSessionRecord?.sliceId ?? 1,
+      sliceId,
       state: "completed",
       piMessages: args.allMessages,
       ...((args.surface ?? latestSessionRecord?.surface)
@@ -289,9 +297,7 @@ export async function persistCompletedSessionRecord(args: {
       recordError,
       "agent_turn_completed_session_record_failed",
       args,
-      {
-        "app.ai.resume_slice_id": sliceIdForLog,
-      },
+      sliceId !== undefined ? { "app.ai.resume_slice_id": sliceId } : {},
       "Failed to persist completed turn session record",
     );
   }

--- a/packages/junior/src/chat/services/turn-session-record.ts
+++ b/packages/junior/src/chat/services/turn-session-record.ts
@@ -4,6 +4,7 @@ import {
   type AgentTurnSessionRecord,
   type AgentTurnSurface,
 } from "@/chat/state/turn-session";
+import type { ConversationPrivacy } from "@/chat/conversation-privacy";
 import type { Destination, Requester, Source } from "@sentry/junior-plugin-api";
 import { getActiveTraceId, logException } from "@/chat/logging";
 import type { PiMessage } from "@/chat/pi/messages";
@@ -200,16 +201,26 @@ export async function persistRunningSessionRecord(args: {
   }
 }
 
-/** Persist a completed turn session record. */
+/**
+ * Commit the delivered final reply as the terminal completed session record.
+ *
+ * Generation completing is not delivery: call this only after the destination
+ * accepted the visible final reply, so an undelivered assistant reply never
+ * becomes durable conversation history or a terminal completed state. Failures
+ * are logged and swallowed because the reply is already user-visible.
+ */
 export async function persistCompletedSessionRecord(args: {
   channelName?: string;
   conversationId: string;
   currentDurationMs?: number;
   currentUsage?: AgentTurnUsage;
   destination?: Destination;
+  /** Source-confirmed destination visibility from the current event's signal. */
+  destinationVisibility?: ConversationPrivacy;
   source?: Source;
   sessionId: string;
-  sliceId: number;
+  /** Defaults to the latest stored slice when the deliverer does not know it. */
+  sliceId?: number;
   allMessages: PiMessage[];
   loadedSkillNames?: string[];
   logContext: SessionRecordLogContext;
@@ -217,6 +228,7 @@ export async function persistCompletedSessionRecord(args: {
   surface?: AgentTurnSurface;
   turnStartMessageIndex?: number;
 }): Promise<void> {
+  const sliceIdForLog = args.sliceId ?? 1;
   try {
     const latestSessionRecord = await getAgentTurnSessionRecord(
       args.conversationId,
@@ -241,15 +253,21 @@ export async function persistCompletedSessionRecord(args: {
       ...((args.source ?? latestSessionRecord?.source)
         ? { source: args.source ?? latestSessionRecord?.source }
         : {}),
+      ...(args.destinationVisibility
+        ? { destinationVisibility: args.destinationVisibility }
+        : {}),
       sessionId: args.sessionId,
-      sliceId: args.sliceId,
+      sliceId: args.sliceId ?? latestSessionRecord?.sliceId ?? 1,
       state: "completed",
       piMessages: args.allMessages,
       ...((args.surface ?? latestSessionRecord?.surface)
         ? { surface: args.surface ?? latestSessionRecord?.surface }
         : {}),
-      ...(args.loadedSkillNames
-        ? { loadedSkillNames: args.loadedSkillNames }
+      ...((args.loadedSkillNames ?? latestSessionRecord?.loadedSkillNames)
+        ? {
+            loadedSkillNames:
+              args.loadedSkillNames ?? latestSessionRecord?.loadedSkillNames,
+          }
         : {}),
       ...((args.requester ?? latestSessionRecord?.requester)
         ? { requester: args.requester ?? latestSessionRecord?.requester }
@@ -272,7 +290,7 @@ export async function persistCompletedSessionRecord(args: {
       "agent_turn_completed_session_record_failed",
       args,
       {
-        "app.ai.resume_slice_id": args.sliceId,
+        "app.ai.resume_slice_id": sliceIdForLog,
       },
       "Failed to persist completed turn session record",
     );

--- a/packages/junior/src/chat/slack/adapter-context.ts
+++ b/packages/junior/src/chat/slack/adapter-context.ts
@@ -1,5 +1,6 @@
 import type { SlackAdapter } from "@chat-adapter/slack";
 import type { ChatInstance, StateAdapter } from "chat";
+import { runWithSlackInstallationToken } from "@/chat/slack/client";
 import { getStateAdapter } from "@/chat/state/adapter";
 
 interface SlackAdapterInternals {
@@ -53,6 +54,14 @@ export async function ensureSlackAdapterInitialized(args: {
   await args.adapter.initialize({
     getState: () => state,
   } as unknown as ChatInstance);
+  const internals = args.adapter as unknown as SlackAdapterInternals;
+  if (internals.defaultBotTokenProvider && !args.adapter.botUserId) {
+    // A single-workspace adapter that failed `auth.test` has no bot identity,
+    // which disables self-message filtering and mention detection. Caching it
+    // would lock that broken state in for the process lifetime, so fail
+    // retryably and let the next event re-attempt initialization.
+    throw new Error("Slack adapter initialized without a resolved bot user id");
+  }
   initializedAdapters.add(args.adapter);
 }
 
@@ -119,6 +128,6 @@ export async function runWithSlackInstallation<T>(args: {
       enterpriseId: args.installation.enterpriseId,
       isEnterpriseInstall: args.installation.isEnterpriseInstall,
     },
-    args.task,
+    () => runWithSlackInstallationToken(tokenContext.token, args.task),
   );
 }

--- a/packages/junior/src/chat/slack/client.ts
+++ b/packages/junior/src/chat/slack/client.ts
@@ -197,6 +197,11 @@ export function runWithSlackInstallationToken<T>(
   return installationTokenStorage.run({ token: trimmed }, fn);
 }
 
+/**
+ * Token precedence: ambient installation token, then env token, then a hard
+ * failure for team-scoped calls — a call scoped to one workspace must never
+ * silently fall through to another workspace's credentials.
+ */
 function resolveSlackToken(): string {
   const ambientToken = installationTokenStorage.getStore()?.token;
   if (ambientToken) {
@@ -242,14 +247,17 @@ export function normalizeSlackConversationId(
   return parts[1]?.trim() || undefined;
 }
 
+/**
+ * Return the per-token cached WebClient. `withSlackRetries` owns retry
+ * classification for this boundary: the WebClient's built-in policy would
+ * re-post timed-out writes (a duplicate-message hazard) and sleep for the
+ * full unbounded Retry-After inside the request, so both internal behaviors
+ * are disabled here.
+ */
 function getClient(): WebClient {
   const token = resolveSlackToken();
   let cached = clientsByToken.get(token);
   if (!cached) {
-    // withSlackRetries owns retry classification for this boundary. The
-    // WebClient's built-in policy would re-post timed-out writes (duplicate
-    // message hazard) and sleep for the full unbounded Retry-After inside the
-    // request, so both internal behaviors are disabled here.
     cached = new WebClient(token, {
       retryConfig: { retries: 0 },
       rejectRateLimitedCalls: true,
@@ -420,6 +428,12 @@ function hasSocketHangUpMessage(error: unknown): boolean {
   );
 }
 
+/**
+ * Classify a failed Slack call for retry: rate limits, Slack 5xx, and
+ * connection-phase failures are always retryable; timeouts are retried only
+ * for idempotent operations because Slack may already have accepted the
+ * request.
+ */
 function classifySlackRetry(
   raw: unknown,
   mapped: SlackActionError,
@@ -606,8 +620,9 @@ export function getSlackClient(): WebClient {
 
 /**
  * Slack channel ID prefixes:
- * - C: public channel
- * - G: private channel / group DM
+ * - C: channel — modern private channels also use C, so the prefix never
+ *   proves a channel is public
+ * - G: legacy private channel / group DM
  * - D: direct message (1:1)
  */
 export function isDmChannel(channelId: string): boolean {

--- a/packages/junior/src/chat/slack/client.ts
+++ b/packages/junior/src/chat/slack/client.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { WebClient } from "@slack/web-api";
 import { getSlackBotToken } from "@/chat/config";
 import {
@@ -6,6 +7,7 @@ import {
   setSpanStatus,
   withSpan,
 } from "@/chat/logging";
+import { getWorkspaceTeamId } from "@/chat/slack/workspace-context";
 
 // Slack canvas/list methods are not exposed by the current chat adapter public API,
 // so this module owns direct Web API calls for artifact actions.
@@ -72,6 +74,14 @@ export class SlackActionError extends Error {
 interface SlackRetryContext {
   action?: string;
   attributes?: Record<string, string | number | boolean>;
+  /**
+   * Whether repeating the operation cannot produce a duplicate user-visible
+   * effect (reads, deletes, reactions). Request timeouts are ambiguous — Slack
+   * may have accepted the write — so they are only retried when the caller
+   * marks the operation idempotent. Defaults to false (never risk a duplicate
+   * post).
+   */
+  idempotent?: boolean;
   /** Extra attributes forwarded onto the per-attempt Sentry span. */
   spanAttributes?: Record<string, string | number | boolean>;
 }
@@ -159,7 +169,61 @@ function parseSlackCanvasDetail(detail: unknown): {
   return parsed;
 }
 
-let client: WebClient | null = null;
+/**
+ * Ambient destination-installation token for Slack outbound calls, bound by
+ * installation-scoped entry points so writes carry the destination
+ * workspace's credentials instead of the process-global env token.
+ */
+const installationTokenStorage = new AsyncLocalStorage<{ token: string }>();
+
+const clientsByToken = new Map<string, WebClient>();
+
+/**
+ * Bind a workspace installation token for all Slack Web API calls inside
+ * `fn`, so multi-workspace outbound writes use the destination workspace's
+ * credentials rather than the env fallback token.
+ */
+export function runWithSlackInstallationToken<T>(
+  token: string,
+  fn: () => T,
+): T {
+  const trimmed = token.trim();
+  if (!trimmed) {
+    throw new SlackActionError(
+      "Slack installation token binding requires a non-empty token",
+      "missing_token",
+    );
+  }
+  return installationTokenStorage.run({ token: trimmed }, fn);
+}
+
+function resolveSlackToken(): string {
+  const ambientToken = installationTokenStorage.getStore()?.token;
+  if (ambientToken) {
+    return ambientToken;
+  }
+
+  // The env token mirrors the Slack adapter's single-workspace mode: when a
+  // default bot token is configured, installation-scoped entry points do not
+  // bind a per-team token because the env token is the workspace's token.
+  const envToken = getSlackBotToken();
+  if (envToken) {
+    return envToken;
+  }
+
+  const teamId = getWorkspaceTeamId();
+  if (teamId) {
+    throw new SlackActionError(
+      `Slack call is scoped to workspace ${teamId} but no installation token is bound and no default bot token is configured`,
+      "missing_token",
+    );
+  }
+
+  throw new SlackActionError(
+    "SLACK_BOT_TOKEN (or SLACK_BOT_USER_TOKEN) is required for Slack Web API actions in this service",
+    "missing_token",
+  );
+}
 
 export function normalizeSlackConversationId(
   channelId: string | undefined,
@@ -179,18 +243,20 @@ export function normalizeSlackConversationId(
 }
 
 function getClient(): WebClient {
-  if (client) return client;
-
-  const token = getSlackBotToken();
-  if (!token) {
-    throw new SlackActionError(
-      "SLACK_BOT_TOKEN (or SLACK_BOT_USER_TOKEN) is required for Slack canvas/list actions in this service",
-      "missing_token",
-    );
+  const token = resolveSlackToken();
+  let cached = clientsByToken.get(token);
+  if (!cached) {
+    // withSlackRetries owns retry classification for this boundary. The
+    // WebClient's built-in policy would re-post timed-out writes (duplicate
+    // message hazard) and sleep for the full unbounded Retry-After inside the
+    // request, so both internal behaviors are disabled here.
+    cached = new WebClient(token, {
+      retryConfig: { retries: 0 },
+      rejectRateLimitedCalls: true,
+    });
+    clientsByToken.set(token, cached);
   }
-
-  client = new WebClient(token);
-  return client;
+  return cached;
 }
 
 function mapSlackError(error: unknown): SlackActionError {
@@ -296,12 +362,105 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// Retry pauses are bounded so a hostile or huge Retry-After header cannot eat
+// the remaining serverless execution slice during final delivery.
+const MAX_RETRY_DELAY_MS = 10_000;
+const MAX_TOTAL_RETRY_DELAY_MS = 20_000;
+
+// Connection-phase failures: the request is known not to have reached Slack,
+// so retrying can never duplicate a write.
+const CONNECTION_ERROR_CODES = new Set([
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+]);
+
+// Timeouts are ambiguous: Slack may have accepted the request before the
+// deadline elapsed, so these are only retried for idempotent operations.
+const TIMEOUT_ERROR_CODES = new Set([
+  "ETIMEDOUT",
+  "ECONNABORTED",
+  "ESOCKETTIMEDOUT",
+]);
+
+type SlackRetryClass =
+  | "rate_limited"
+  | "connection"
+  | "timeout"
+  | "server_error"
+  | "none";
+
+function findNetworkErrorCode(error: unknown, depth = 0): string | undefined {
+  if (!error || typeof error !== "object" || depth > 4) {
+    return undefined;
+  }
+  const candidate = error as {
+    code?: unknown;
+    original?: unknown;
+    cause?: unknown;
+  };
+  if (
+    typeof candidate.code === "string" &&
+    (CONNECTION_ERROR_CODES.has(candidate.code) ||
+      TIMEOUT_ERROR_CODES.has(candidate.code))
+  ) {
+    return candidate.code;
+  }
+  return (
+    findNetworkErrorCode(candidate.original, depth + 1) ??
+    findNetworkErrorCode(candidate.cause, depth + 1)
+  );
+}
+
+function hasSocketHangUpMessage(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.toLowerCase().includes("socket hang up")
+  );
+}
+
+function classifySlackRetry(
+  raw: unknown,
+  mapped: SlackActionError,
+): SlackRetryClass {
+  if (mapped.code === "rate_limited") {
+    return "rate_limited";
+  }
+  if (mapped.statusCode !== undefined && mapped.statusCode >= 500) {
+    return "server_error";
+  }
+  const networkCode = findNetworkErrorCode(raw);
+  if (networkCode && CONNECTION_ERROR_CODES.has(networkCode)) {
+    return "connection";
+  }
+  if (networkCode && TIMEOUT_ERROR_CODES.has(networkCode)) {
+    return "timeout";
+  }
+  // A hang-up before any response was received never reached Slack's API
+  // layer, so it is safe to retry alongside other connection-phase failures.
+  if (hasSocketHangUpMessage(raw)) {
+    return "connection";
+  }
+  return "none";
+}
+
+/**
+ * Run a Slack Web API call with bounded retries so transient platform
+ * failures do not surface as turn failures, while non-idempotent posts are
+ * never re-sent when Slack may already have accepted them.
+ *
+ * Retry classes: rate limits (bounded Retry-After), connection-phase network
+ * failures, and Slack 5xx responses always retry; request timeouts retry only
+ * when the caller marks the operation `idempotent`.
+ */
 export async function withSlackRetries<T>(
   task: () => Promise<T>,
   maxAttempts = 3,
   context: SlackRetryContext = {},
 ): Promise<T> {
   let attempt = 0;
+  let totalDelayMs = 0;
 
   const action = context.action ?? "unknown";
 
@@ -354,7 +513,13 @@ export async function withSlackRetries<T>(
       );
     } catch (error) {
       const mapped = mapSlackError(error);
-      const isRetryable = mapped.code === "rate_limited";
+      const retryClass = classifySlackRetry(error, mapped);
+      const isRetryable =
+        retryClass === "rate_limited" ||
+        retryClass === "connection" ||
+        retryClass === "server_error" ||
+        (retryClass === "timeout" && context.idempotent === true);
+      const remainingDelayBudgetMs = MAX_TOTAL_RETRY_DELAY_MS - totalDelayMs;
       const baseLogAttributes: Record<string, string | number | boolean> = {
         "app.slack.action": action,
         "app.slack.error_code": mapped.code,
@@ -375,7 +540,11 @@ export async function withSlackRetries<T>(
         ...(context.attributes ?? {}),
       };
 
-      if (!isRetryable || attempt >= maxAttempts) {
+      if (
+        !isRetryable ||
+        attempt >= maxAttempts ||
+        remainingDelayBudgetMs <= 0
+      ) {
         logWarn(
           "slack_action_failed",
           {},
@@ -396,18 +565,25 @@ export async function withSlackRetries<T>(
         {
           ...baseLogAttributes,
           "app.slack.retry_attempt": attempt,
+          "app.slack.retry_class": retryClass,
         },
         "Retrying Slack action after transient failure",
       );
 
       const retryAfterMs =
-        mapped.code === "rate_limited" &&
+        retryClass === "rate_limited" &&
         mapped.retryAfterSeconds &&
         mapped.retryAfterSeconds > 0
           ? mapped.retryAfterSeconds * 1000
           : undefined;
       const backoffMs = Math.min(2000, 250 * 2 ** (attempt - 1));
-      await sleep(retryAfterMs ?? backoffMs);
+      const delayMs = Math.min(
+        retryAfterMs ?? backoffMs,
+        MAX_RETRY_DELAY_MS,
+        remainingDelayBudgetMs,
+      );
+      totalDelayMs += delayMs;
+      await sleep(delayMs);
     }
   }
 
@@ -417,6 +593,13 @@ export async function withSlackRetries<T>(
   );
 }
 
+/**
+ * Slack Web API client for the current destination workspace: the ambient
+ * installation token when one is bound, otherwise the env bot token for
+ * single-workspace deployments. Fails instead of falling back when the call
+ * is workspace-scoped and no installation token can be resolved, so a write
+ * never goes out with another workspace's credentials.
+ */
 export function getSlackClient(): WebClient {
   return getClient();
 }
@@ -466,6 +649,7 @@ export async function getFilePermalink(
     3,
     {
       action: "files.info",
+      idempotent: true,
       spanAttributes: { "app.slack.file_id": fileId },
     },
   );
@@ -474,13 +658,9 @@ export async function getFilePermalink(
 }
 
 export async function downloadPrivateSlackFile(url: string): Promise<Buffer> {
-  const token = getSlackBotToken();
-  if (!token) {
-    throw new SlackActionError(
-      "SLACK_BOT_TOKEN (or SLACK_BOT_USER_TOKEN) is required for Slack file downloads in this service",
-      "missing_token",
-    );
-  }
+  // Private file URLs are workspace-scoped, so downloads use the same
+  // destination-installation token resolution as Web API calls.
+  const token = resolveSlackToken();
 
   return withSpan(
     "GET files.slack.com",

--- a/packages/junior/src/chat/slack/conversation-context.ts
+++ b/packages/junior/src/chat/slack/conversation-context.ts
@@ -12,10 +12,19 @@ export type SlackConversationType =
   | "direct_message"
   | "private_channel_or_group_dm";
 
+/** Conversation visibility classification derived from source-provided signals. */
+export type SlackConversationVisibility = "public" | "private";
+
 /** Slack conversation facts available to the bot for runtime context. */
 export interface SlackConversationContext {
   type: SlackConversationType;
   name?: string;
+  /**
+   * Visibility proven by a source signal (`channel_type`) or narrowed toward
+   * private by a `D`/`G` id prefix. Undefined for `C`-prefixed conversations
+   * without a signal, which may be public or private.
+   */
+  visibility?: SlackConversationVisibility;
 }
 
 function normalizeConversationName(
@@ -74,6 +83,30 @@ function toSlackEventChannelType(
   return undefined;
 }
 
+/**
+ * Map Slack's Events API channel_type to a source-confirmed visibility.
+ *
+ * This is the only mapping allowed to classify a Slack conversation public;
+ * channel-id prefixes may only narrow classification toward private.
+ */
+export function conversationVisibilityFromSlackChannelType(
+  channelType: SlackEventChannelType | undefined,
+): SlackConversationVisibility | undefined {
+  if (!channelType) return undefined;
+  return channelType === "channel" ? "public" : "private";
+}
+
+function visibilityFromChannelIdPrefix(
+  channelId: string | undefined,
+): SlackConversationVisibility | undefined {
+  const normalized = normalizeSlackConversationId(channelId);
+  if (!normalized) return undefined;
+  if (normalized.startsWith("D") || normalized.startsWith("G")) {
+    return "private";
+  }
+  return undefined;
+}
+
 /** Resolve Slack's raw event channel type from a Chat SDK message-like object. */
 export function resolveSlackChannelTypeFromMessage(
   message: unknown,
@@ -101,10 +134,14 @@ export function resolveSlackConversationContext(input: {
   if (!type) return undefined;
 
   const name = normalizeConversationName(type, input.channelName);
+  const visibility =
+    conversationVisibilityFromSlackChannelType(input.channelType) ??
+    visibilityFromChannelIdPrefix(input.channelId);
 
   return {
     type,
     ...(name ? { name } : {}),
+    ...(visibility ? { visibility } : {}),
   };
 }
 

--- a/packages/junior/src/chat/slack/conversation-context.ts
+++ b/packages/junior/src/chat/slack/conversation-context.ts
@@ -169,21 +169,6 @@ export function formatSlackConversationTypeLabel(
   return "Private Channel or Group DM";
 }
 
-/**
- * Every redacted conversation-type label this module can emit, so consumers
- * that must treat redacted labels differently from channel names (e.g.
- * reporting) stay in sync with the formatter instead of duplicating strings.
- */
-export const SLACK_REDACTED_CONVERSATION_LABELS: readonly string[] = (
-  [
-    "public_channel",
-    "private_channel",
-    "group_dm",
-    "direct_message",
-    "private_channel_or_group_dm",
-  ] satisfies SlackConversationType[]
-).map(formatSlackConversationTypeLabel);
-
 /** Render a Slack conversation label for surfaces allowed to expose names. */
 export function formatSlackConversationContextLabel(
   context: SlackConversationContext | undefined,

--- a/packages/junior/src/chat/slack/conversation-context.ts
+++ b/packages/junior/src/chat/slack/conversation-context.ts
@@ -96,6 +96,7 @@ export function conversationVisibilityFromSlackChannelType(
   return channelType === "channel" ? "public" : "private";
 }
 
+// Narrows toward private only; never asserts public.
 function visibilityFromChannelIdPrefix(
   channelId: string | undefined,
 ): SlackConversationVisibility | undefined {
@@ -167,6 +168,21 @@ export function formatSlackConversationTypeLabel(
   if (type === "direct_message") return "Direct Message";
   return "Private Channel or Group DM";
 }
+
+/**
+ * Every redacted conversation-type label this module can emit, so consumers
+ * that must treat redacted labels differently from channel names (e.g.
+ * reporting) stay in sync with the formatter instead of duplicating strings.
+ */
+export const SLACK_REDACTED_CONVERSATION_LABELS: readonly string[] = (
+  [
+    "public_channel",
+    "private_channel",
+    "group_dm",
+    "direct_message",
+    "private_channel_or_group_dm",
+  ] satisfies SlackConversationType[]
+).map(formatSlackConversationTypeLabel);
 
 /** Render a Slack conversation label for surfaces allowed to expose names. */
 export function formatSlackConversationContextLabel(

--- a/packages/junior/src/chat/slack/outbound.ts
+++ b/packages/junior/src/chat/slack/outbound.ts
@@ -63,6 +63,7 @@ async function getPermalinkBestEffort(args: {
       3,
       {
         action: "chat.getPermalink",
+        idempotent: true,
         spanAttributes: {
           "app.slack.channel_id": args.channelId,
           "app.slack.message_ts": args.messageTs,
@@ -157,6 +158,7 @@ export async function deleteSlackMessage(input: {
     3,
     {
       action: "chat.delete",
+      idempotent: true,
       spanAttributes: {
         "app.slack.channel_id": channelId,
         "app.slack.message_ts": timestamp,
@@ -296,6 +298,7 @@ export async function addReactionToMessage(input: {
       3,
       {
         action: "reactions.add",
+        idempotent: true,
         spanAttributes: {
           "app.slack.channel_id": channelId,
           "app.slack.message_ts": timestamp,
@@ -343,6 +346,7 @@ export async function removeReactionFromMessage(input: {
       3,
       {
         action: "reactions.remove",
+        idempotent: true,
         spanAttributes: {
           "app.slack.channel_id": channelId,
           "app.slack.message_ts": timestamp,

--- a/packages/junior/src/chat/state/turn-session.ts
+++ b/packages/junior/src/chat/state/turn-session.ts
@@ -585,6 +585,8 @@ function buildStoredRecord(args: {
 
 async function setStoredRecord(args: {
   conversationStore?: ConversationStore;
+  /** Source-confirmed destination visibility from the current event's signal. */
+  destinationVisibility?: ConversationPrivacy;
   piMessages: PiMessage[];
   record: StoredAgentTurnSessionRecord;
   ttlMs: number;
@@ -607,6 +609,7 @@ async function setStoredRecord(args: {
   await appendAgentTurnSessionSummary(summary, args.ttlMs);
   await recordConversationActivityMetadata({
     conversationStore: args.conversationStore,
+    destinationVisibility: args.destinationVisibility,
     nowMs: Date.now(),
     summary,
   });
@@ -683,6 +686,8 @@ export async function upsertAgentTurnSessionRecord(args: {
   cumulativeDurationMs?: number;
   cumulativeUsage?: AgentTurnUsage;
   destination?: Destination;
+  /** Source-confirmed destination visibility from the current event's signal. */
+  destinationVisibility?: ConversationPrivacy;
   source?: Source;
   lastProgressAtMs?: number;
   loadedSkillNames?: string[];
@@ -714,6 +719,7 @@ export async function upsertAgentTurnSessionRecord(args: {
 
   return await setStoredRecord({
     conversationStore: args.conversationStore,
+    destinationVisibility: args.destinationVisibility,
     piMessages: args.piMessages,
     ttlMs,
     record: buildStoredRecord({

--- a/packages/junior/src/chat/state/turn-session.ts
+++ b/packages/junior/src/chat/state/turn-session.ts
@@ -24,6 +24,7 @@ import { commitMessages, loadMessages, loadProjection } from "./session-log";
 import type { AgentTurnUsage } from "@/chat/usage";
 import { getStateAdapter } from "./adapter";
 import { getConversationStore } from "@/chat/db";
+import type { ConversationPrivacy } from "@/chat/conversation-privacy";
 import type {
   ConversationExecution,
   ConversationStore,
@@ -359,6 +360,8 @@ async function appendAgentTurnSessionSummary(
 /** Store run summary metadata in the configured conversation store. */
 async function recordConversationActivityMetadata(args: {
   conversationStore?: ConversationStore;
+  /** Source-confirmed destination visibility from the current event's signal. */
+  destinationVisibility?: ConversationPrivacy;
   nowMs: number;
   summary: AgentTurnSessionSummary;
 }): Promise<void> {
@@ -376,6 +379,7 @@ async function recordConversationActivityMetadata(args: {
       nowMs: args.nowMs,
       requester: sessionLogRequester(args.summary.requester),
       source,
+      visibility: args.destinationVisibility,
     });
     await conversationStore.recordExecution({
       channelName: args.summary.channelName,
@@ -387,6 +391,7 @@ async function recordConversationActivityMetadata(args: {
       requester: sessionLogRequester(args.summary.requester),
       source,
       updatedAtMs: args.nowMs,
+      visibility: args.destinationVisibility,
     });
   } catch (error) {
     logWarn(
@@ -777,6 +782,12 @@ export async function recordAgentTurnSessionSummary(args: {
   cumulativeDurationMs?: number;
   cumulativeUsage?: AgentTurnUsage;
   destination?: Destination;
+  /**
+   * Source-confirmed destination visibility from the current event's signal
+   * (Slack `channel_type`). Leave unset when no live signal exists so the
+   * stored destination stays unconfirmed.
+   */
+  destinationVisibility?: ConversationPrivacy;
   source?: Source;
   lastProgressAtMs?: number;
   loadedSkillNames?: string[];
@@ -845,6 +856,7 @@ export async function recordAgentTurnSessionSummary(args: {
   await appendAgentTurnSessionSummary(summary, ttlMs);
   await recordConversationActivityMetadata({
     conversationStore: args.conversationStore,
+    destinationVisibility: args.destinationVisibility,
     nowMs,
     summary,
   });

--- a/packages/junior/src/chat/state/turn-session.ts
+++ b/packages/junior/src/chat/state/turn-session.ts
@@ -790,8 +790,8 @@ export async function recordAgentTurnSessionSummary(args: {
   destination?: Destination;
   /**
    * Source-confirmed destination visibility from the current event's signal
-   * (Slack `channel_type`). Leave unset when no live signal exists so the
-   * stored destination stays unconfirmed.
+   * (Slack `channel_type`). Leave unset when no live signal exists so an
+   * existing destination visibility is not overwritten.
    */
   destinationVisibility?: ConversationPrivacy;
   source?: Source;

--- a/packages/junior/src/chat/task-execution/heartbeat.ts
+++ b/packages/junior/src/chat/task-execution/heartbeat.ts
@@ -7,8 +7,10 @@ import {
   ensureConversationWake,
   getConversationWorkState,
   hasRunnableConversationWork,
+  isInvalidConversationRecordError,
   listActiveConversationIds,
   removeActiveConversation,
+  type ConversationWorkState,
 } from "./store";
 
 const DEFAULT_RECOVERY_LIMIT = 25;
@@ -45,11 +47,32 @@ export async function recoverConversationWork(args: {
   });
 
   for (const conversationId of ids) {
+    let work: ConversationWorkState | undefined;
     try {
-      const work = await getConversationWorkState({
+      work = await getConversationWorkState({
         conversationId,
         state: args.state,
       });
+    } catch (error) {
+      logException(
+        error,
+        "conversation_work_recovery_failed",
+        { conversationId },
+        {},
+        "Conversation work heartbeat recovery failed",
+      );
+      // An invalid record can never become runnable again; drop it from the
+      // bounded oldest-first scan so it cannot starve recovery for every
+      // other conversation.
+      if (isInvalidConversationRecordError(error)) {
+        await removeActiveConversation({
+          conversationId,
+          state: args.state,
+        });
+      }
+      continue;
+    }
+    try {
       if (!work) {
         await removeActiveConversation({
           conversationId,

--- a/packages/junior/src/chat/task-execution/queue.ts
+++ b/packages/junior/src/chat/task-execution/queue.ts
@@ -8,6 +8,7 @@ export interface ConversationQueueMessage {
 export type ConversationQueueMessageRejectReason =
   | "destination_mismatch"
   | "expired"
+  | "invalid_record"
   | "malformed"
   | "signature_mismatch";
 

--- a/packages/junior/src/chat/task-execution/slack-work.ts
+++ b/packages/junior/src/chat/task-execution/slack-work.ts
@@ -13,6 +13,7 @@ import type {
 } from "@/chat/runtime/slack-runtime";
 import {
   isCooperativeTurnYieldError,
+  isTurnInputDeferredError,
   isTurnInputCommitLostError,
   TurnInputCommitLostError,
 } from "@/chat/runtime/turn";
@@ -395,7 +396,18 @@ export function createSlackConversationWorker(
       }),
     );
     if (records.length === 0) {
-      await options.resumeAwaitingContinuation(context.conversationId);
+      const destination = requireSlackDestination(
+        context.destination,
+        "Slack continuation recovery",
+      );
+      await runWithSlackInstallation({
+        adapter,
+        installation: { teamId: destination.teamId },
+        state,
+        task: async () => {
+          await options.resumeAwaitingContinuation(context.conversationId);
+        },
+      });
       return { status: "completed" };
     }
 
@@ -530,6 +542,9 @@ export function createSlackConversationWorker(
             willRetryOnFailure,
           });
         } catch (error) {
+          if (isTurnInputDeferredError(error)) {
+            return { status: "deferred" } satisfies ConversationWorkerResult;
+          }
           if (isCooperativeTurnYieldError(error)) {
             return { status: "yielded" } satisfies ConversationWorkerResult;
           }
@@ -541,6 +556,7 @@ export function createSlackConversationWorker(
       },
     });
     if (
+      turnResult?.status === "deferred" ||
       turnResult?.status === "yielded" ||
       turnResult?.status === "lost_lease"
     ) {

--- a/packages/junior/src/chat/task-execution/slack-work.ts
+++ b/packages/junior/src/chat/task-execution/slack-work.ts
@@ -487,6 +487,11 @@ export function createSlackConversationWorker(
             );
           }
         };
+        // Failures before input commit leave the records pending, so the
+        // worker redelivers them; suppress visible failure replies until the
+        // final bounded attempt.
+        const willRetryOnFailure = (): boolean =>
+          !initialMessagesPersisted && !isFinalSlackDeliveryAttempt(records);
         // Restore stored mailbox entries as Slack steering candidates; the
         // runtime returns only the inbound ids it handled durably.
         const drainSteeringMessages = async (
@@ -523,6 +528,7 @@ export function createSlackConversationWorker(
               drainSteeringMessages,
               onInputCommitted,
               shouldYield: context.shouldYield,
+              willRetryOnFailure,
             });
             return;
           }
@@ -533,6 +539,7 @@ export function createSlackConversationWorker(
             drainSteeringMessages,
             onInputCommitted,
             shouldYield: context.shouldYield,
+            willRetryOnFailure,
           });
         } catch (error) {
           if (isCooperativeTurnYieldError(error)) {

--- a/packages/junior/src/chat/task-execution/slack-work.ts
+++ b/packages/junior/src/chat/task-execution/slack-work.ts
@@ -23,6 +23,7 @@ import type { ConversationStore } from "@/chat/conversations/store";
 import type { AgentInput, InboundMessage } from "@/chat/task-execution/store";
 import {
   getConversationWorkState,
+  isFinalConversationDeliveryAttempt,
   markConversationMessagesInjected,
 } from "@/chat/task-execution/store";
 import type {
@@ -375,6 +376,19 @@ function getPendingRecords(
     return [];
   }
   return work.execution.pendingMessages.sort(compareInboundMessages);
+}
+
+/**
+ * Whether the restored records are on their final bounded delivery attempt.
+ *
+ * Records carry the durable `attemptCount` from the conversation mailbox; the
+ * Slack runtime uses this seam to post a visible failure reply only on the
+ * final attempt instead of once per retried delivery.
+ */
+export function isFinalSlackDeliveryAttempt(
+  records: InboundMessage[],
+): boolean {
+  return records.some((record) => isFinalConversationDeliveryAttempt(record));
 }
 
 /** Build the worker run function for queued Slack conversation work. */

--- a/packages/junior/src/chat/task-execution/slack-work.ts
+++ b/packages/junior/src/chat/task-execution/slack-work.ts
@@ -8,7 +8,7 @@ import {
   type StateAdapter,
 } from "chat";
 import type {
-  SlackTurnRuntime,
+  SlackTurnOptions,
   SteeringCandidateMessage,
 } from "@/chat/runtime/slack-runtime";
 import {
@@ -22,11 +22,6 @@ import { rehydrateAttachmentFetchers } from "@/chat/slack/attachment-fetchers";
 import { getStateAdapter } from "@/chat/state/adapter";
 import type { ConversationStore } from "@/chat/conversations/store";
 import type { AgentInput, InboundMessage } from "@/chat/task-execution/store";
-import {
-  getConversationWorkState,
-  isFinalConversationDeliveryAttempt,
-  markConversationMessagesInjected,
-} from "@/chat/task-execution/store";
 import type {
   ConversationWorkerContext,
   ConversationWorkerResult,
@@ -52,6 +47,24 @@ export interface SlackConversationMessageMetadata {
   platform: "slack";
   route: SlackConversationRoute;
   thread: SerializedThread;
+}
+
+type SlackInboxTurnOptions = SlackTurnOptions & {
+  ack: () => Promise<void>;
+  isFinalAttempt: boolean;
+};
+
+interface SlackInboxTurnRuntime {
+  handleNewMention(
+    thread: ThreadImpl,
+    message: Message,
+    hooks: SlackInboxTurnOptions,
+  ): Promise<void>;
+  handleSubscribedMessage(
+    thread: ThreadImpl,
+    message: Message,
+    hooks: SlackInboxTurnOptions,
+  ): Promise<void>;
 }
 
 interface SlackResourceEventInboundInput {
@@ -82,10 +95,7 @@ export interface CreateSlackConversationWorkerOptions {
   ) => Promise<SlackRequesterProfile | null | undefined>;
   resumeAwaitingContinuation: (conversationId: string) => Promise<boolean>;
   conversationStore?: ConversationStore;
-  runtime: Pick<
-    SlackTurnRuntime<unknown>,
-    "handleNewMention" | "handleSubscribedMessage"
-  >;
+  runtime: SlackInboxTurnRuntime;
   state?: StateAdapter;
 }
 
@@ -389,12 +399,9 @@ export function createSlackConversationWorker(
     const state = getConnectedState(options.state);
     await state.connect();
 
-    const records = getPendingRecords(
-      await getConversationWorkState({
-        conversationId: context.conversationId,
-        state,
-      }),
-    );
+    const records = getPendingRecords({
+      execution: { pendingMessages: [...context.attempt.messages] },
+    });
     if (records.length === 0) {
       const destination = requireSlackDestination(
         context.destination,
@@ -461,45 +468,28 @@ export function createSlackConversationWorker(
           skipped,
           totalSinceLastHandler: messages.length,
         };
-        const initialInboundMessageIds = records.map(
-          (record) => record.inboundMessageId,
-        );
-        let initialMessagesPersisted = false;
-        const markInitialMessagesInjected = async (): Promise<boolean> => {
-          if (initialMessagesPersisted) {
-            return true;
+        let initialMessagesAcked = false;
+        const ack = async (): Promise<void> => {
+          if (initialMessagesAcked) {
+            return;
           }
-          const marked = await markConversationMessagesInjected({
-            conversationId: context.conversationId,
-            inboundMessageIds: initialInboundMessageIds,
-            leaseToken: context.leaseToken,
-            conversationStore: options.conversationStore,
-            state,
-          });
-          initialMessagesPersisted = marked;
-          return marked;
-        };
-        const onInputCommitted = async (): Promise<void> => {
-          if (!(await markInitialMessagesInjected())) {
+          try {
+            await context.attempt.ack();
+            initialMessagesAcked = true;
+          } catch {
             throw new TurnInputCommitLostError(
-              `Conversation work lease lost before Slack input commit for ${context.conversationId}`,
+              `Conversation work lease lost before Slack inbox ack for ${context.conversationId}`,
             );
           }
         };
-        // Failures before input commit leave the records pending, so the
-        // worker redelivers them; suppress visible failure replies until the
-        // final bounded attempt.
-        const willRetryOnFailure = (): boolean =>
-          !initialMessagesPersisted &&
-          !records.some((record) => isFinalConversationDeliveryAttempt(record));
         // Restore stored mailbox entries as Slack steering candidates; the
         // runtime returns only the inbound ids it handled durably.
         const drainSteeringMessages = async (
-          inject: (
+          accept: (
             messages: SteeringCandidateMessage[],
           ) => Promise<readonly string[] | void>,
         ): Promise<void> => {
-          await context.drainMailbox(async (pendingRecords) => {
+          await context.attempt.drain(async (pendingRecords) => {
             const messages = pendingRecords.map((record) => {
               const metadata = record.input.metadata;
               if (!isSlackMetadata(metadata)) {
@@ -516,7 +506,7 @@ export function createSlackConversationWorker(
                 message,
               };
             });
-            return await inject(messages);
+            return await accept(messages);
           });
         };
 
@@ -526,9 +516,9 @@ export function createSlackConversationWorker(
               destination: context.destination,
               messageContext,
               drainSteeringMessages,
-              onInputCommitted,
+              ack,
+              isFinalAttempt: context.attempt.isFinalAttempt,
               shouldYield: context.shouldYield,
-              willRetryOnFailure,
             });
             return;
           }
@@ -537,9 +527,9 @@ export function createSlackConversationWorker(
             destination: context.destination,
             messageContext,
             drainSteeringMessages,
-            onInputCommitted,
+            ack,
+            isFinalAttempt: context.attempt.isFinalAttempt,
             shouldYield: context.shouldYield,
-            willRetryOnFailure,
           });
         } catch (error) {
           if (isTurnInputDeferredError(error)) {

--- a/packages/junior/src/chat/task-execution/slack-work.ts
+++ b/packages/junior/src/chat/task-execution/slack-work.ts
@@ -378,19 +378,6 @@ function getPendingRecords(
   return work.execution.pendingMessages.sort(compareInboundMessages);
 }
 
-/**
- * Whether the restored records are on their final bounded delivery attempt.
- *
- * Records carry the durable `attemptCount` from the conversation mailbox; the
- * Slack runtime uses this seam to post a visible failure reply only on the
- * final attempt instead of once per retried delivery.
- */
-export function isFinalSlackDeliveryAttempt(
-  records: InboundMessage[],
-): boolean {
-  return records.some((record) => isFinalConversationDeliveryAttempt(record));
-}
-
 /** Build the worker run function for queued Slack conversation work. */
 export function createSlackConversationWorker(
   options: CreateSlackConversationWorkerOptions,
@@ -491,7 +478,8 @@ export function createSlackConversationWorker(
         // worker redelivers them; suppress visible failure replies until the
         // final bounded attempt.
         const willRetryOnFailure = (): boolean =>
-          !initialMessagesPersisted && !isFinalSlackDeliveryAttempt(records);
+          !initialMessagesPersisted &&
+          !records.some((record) => isFinalConversationDeliveryAttempt(record));
         // Restore stored mailbox entries as Slack steering candidates; the
         // runtime returns only the inbound ids it handled durably.
         const drainSteeringMessages = async (

--- a/packages/junior/src/chat/task-execution/state.ts
+++ b/packages/junior/src/chat/task-execution/state.ts
@@ -40,11 +40,28 @@ class InvalidConversationRecordError extends Error {
   }
 }
 
+/** Return whether an error means a stored conversation record failed validation. */
+export function isInvalidConversationRecordError(
+  error: unknown,
+): error is InvalidConversationRecordError {
+  return error instanceof InvalidConversationRecordError;
+}
+
+class ConversationMutationFencedError extends Error {
+  constructor(conversationId: string) {
+    super(
+      `Conversation mutation lock was lost before write for ${conversationId}`,
+    );
+    this.name = "ConversationMutationFencedError";
+  }
+}
+
 export const CONVERSATION_BY_ACTIVITY_INDEX_KEY = `${CONVERSATION_PREFIX}:by-activity`;
 export const CONVERSATION_ACTIVE_INDEX_KEY = `${CONVERSATION_PREFIX}:active`;
 export const CONVERSATION_WORK_LEASE_TTL_MS = 90_000;
 export const CONVERSATION_WORK_CHECK_IN_INTERVAL_MS = 15_000;
 export const CONVERSATION_WORK_STALE_ENQUEUE_MS = 60_000;
+export const CONVERSATION_WORK_MAX_DELIVERY_ATTEMPTS = 5;
 
 export type Source =
   | "api"
@@ -70,6 +87,7 @@ export interface AgentInput {
 }
 
 export interface InboundMessage {
+  attemptCount?: number;
   conversationId: string;
   createdAtMs: number;
   destination: Destination;
@@ -208,6 +226,28 @@ function compareMessages(left: InboundMessage, right: InboundMessage): number {
   );
 }
 
+function inputHasAttachments(input: AgentInput): boolean {
+  return Array.isArray(input.attachments) && input.attachments.length > 0;
+}
+
+/**
+ * Upgrade a still-pending payload when a duplicate source event carries file
+ * attachments the stored copy lacks (Slack `app_mention`/`message` twins),
+ * keeping the stored ordering timestamps and delivery attempts.
+ */
+function upgradedPendingMessage(
+  stored: InboundMessage,
+  duplicate: InboundMessage,
+): InboundMessage {
+  if (
+    !inputHasAttachments(duplicate.input) ||
+    inputHasAttachments(stored.input)
+  ) {
+    return stored;
+  }
+  return { ...stored, input: duplicate.input };
+}
+
 function compareIndexDescending(
   left: ConversationIndexEntry,
   right: ConversationIndexEntry,
@@ -318,7 +358,17 @@ function normalizeMessage(value: unknown): InboundMessage | undefined {
     receivedAtMs,
     input,
     injectedAtMs: toOptionalNumber(value.injectedAtMs),
+    attemptCount: toOptionalNumber(value.attemptCount),
   };
+}
+
+/** Whether one more failed delivery would consume the message as poison work. */
+export function isFinalConversationDeliveryAttempt(
+  message: Pick<InboundMessage, "attemptCount">,
+): boolean {
+  return (
+    (message.attemptCount ?? 0) >= CONVERSATION_WORK_MAX_DELIVERY_ATTEMPTS - 1
+  );
 }
 
 function normalizeRequester(value: unknown): StoredSlackRequester | undefined {
@@ -872,12 +922,12 @@ async function withConversationMutation<T>(
     conversationId: string;
     state?: StateAdapter;
   },
-  callback: (state: StateAdapter) => Promise<T>,
+  callback: (state: StateAdapter, lock: Lock) => Promise<T>,
 ): Promise<T> {
   const state = await getConnectedState(args.state);
   const lock = await acquireMutationLock(state, args.conversationId);
   try {
-    return await callback(state);
+    return await callback(state, lock);
   } finally {
     await state.releaseLock(lock);
   }
@@ -900,9 +950,15 @@ async function readConversation(
 
 /**
  * Persist a conversation and refresh its reporting and active-recovery indexes.
+ *
+ * Conversation writes are lock-serialized blind whole-record writes, so the
+ * mutation lock is re-validated (and extended) immediately before the write:
+ * a stalled mutator that lost its lock must fail loudly instead of clobbering
+ * a newer record with a stale copy.
  */
 async function writeConversation(
   state: StateAdapter,
+  lock: Lock,
   conversation: Conversation,
 ): Promise<void> {
   const execution = executionWithPendingMessages(
@@ -913,6 +969,13 @@ async function writeConversation(
     ...conversation,
     execution,
   };
+  const fenced = await state.extendLock(
+    lock,
+    CONVERSATION_MUTATION_LOCK_TTL_MS,
+  );
+  if (!fenced) {
+    throw new ConversationMutationFencedError(next.conversationId);
+  }
   await state.set(
     conversationKey(next.conversationId),
     next,
@@ -1016,7 +1079,7 @@ export async function appendInboundMessage(args: {
   const nowMs = args.nowMs ?? now();
   return await withConversationMutation(
     { conversationId: args.message.conversationId, state: args.state },
-    async (state) => {
+    async (state, lock) => {
       const current =
         (await readConversation(state, args.message.conversationId)) ??
         emptyConversation({
@@ -1046,11 +1109,18 @@ export async function appendInboundMessage(args: {
             : current.execution.status;
         await writeConversation(
           state,
+          lock,
           withExecutionUpdate(
             current,
             {
               ...current.execution,
               status: nextStatus,
+              pendingMessages: current.execution.pendingMessages.map(
+                (message) =>
+                  message.inboundMessageId === args.message.inboundMessageId
+                    ? upgradedPendingMessage(message, args.message)
+                    : message,
+              ),
             },
             nowMs,
           ),
@@ -1072,6 +1142,7 @@ export async function appendInboundMessage(args: {
       };
       await writeConversation(
         state,
+        lock,
         withExecutionUpdate(
           next,
           {
@@ -1102,7 +1173,7 @@ export async function requestConversationWork(args: {
   state?: StateAdapter;
 }): Promise<RequestConversationWorkResult> {
   const nowMs = args.nowMs ?? now();
-  return await withConversationMutation(args, async (state) => {
+  return await withConversationMutation(args, async (state, lock) => {
     const existing = await readConversation(state, args.conversationId);
     if (existing) {
       assertSameConversationDestination({
@@ -1121,6 +1192,7 @@ export async function requestConversationWork(args: {
     const status = current.execution.lease ? "awaiting_resume" : "pending";
     await writeConversation(
       state,
+      lock,
       withExecutionUpdate(
         {
           ...current,
@@ -1151,7 +1223,7 @@ export async function recordConversationActivity(args: {
 }): Promise<void> {
   const nowMs = args.nowMs ?? now();
   const activityAtMs = args.activityAtMs ?? nowMs;
-  await withConversationMutation(args, async (state) => {
+  await withConversationMutation(args, async (state, lock) => {
     const existing = await readConversation(state, args.conversationId);
     if (existing && args.destination) {
       assertSameConversationDestination({
@@ -1168,7 +1240,7 @@ export async function recordConversationActivity(args: {
         nowMs,
         source: args.source,
       });
-    await writeConversation(state, {
+    await writeConversation(state, lock, {
       ...current,
       ...((current.destination ?? args.destination)
         ? { destination: current.destination ?? args.destination }
@@ -1216,7 +1288,7 @@ export async function recordConversationExecution(args: {
   updatedAtMs: number;
 }): Promise<void> {
   const nowMs = args.updatedAtMs;
-  await withConversationMutation(args, async (state) => {
+  await withConversationMutation(args, async (state, lock) => {
     const existing = await readConversation(state, args.conversationId);
     if (existing && args.destination) {
       assertSameConversationDestination({
@@ -1235,6 +1307,7 @@ export async function recordConversationExecution(args: {
       });
     await writeConversation(
       state,
+      lock,
       withExecutionUpdate(
         {
           ...current,
@@ -1276,13 +1349,14 @@ export async function markConversationWorkEnqueued(args: {
   state?: StateAdapter;
 }): Promise<void> {
   const nowMs = args.nowMs ?? now();
-  await withConversationMutation(args, async (state) => {
+  await withConversationMutation(args, async (state, lock) => {
     const current = await readConversation(state, args.conversationId);
     if (!current) {
       return;
     }
     await writeConversation(
       state,
+      lock,
       withExecutionUpdate(
         current,
         {
@@ -1302,7 +1376,7 @@ export async function clearConsumedConversationWake(args: {
   state?: StateAdapter;
 }): Promise<boolean> {
   const nowMs = args.nowMs ?? now();
-  return await withConversationMutation(args, async (state) => {
+  return await withConversationMutation(args, async (state, lock) => {
     const current = await readConversation(state, args.conversationId);
     if (
       !current ||
@@ -1313,6 +1387,7 @@ export async function clearConsumedConversationWake(args: {
     }
     await writeConversation(
       state,
+      lock,
       withExecutionUpdate(
         current,
         {
@@ -1333,7 +1408,7 @@ export async function startConversationWork(args: {
   state?: StateAdapter;
 }): Promise<StartConversationWorkResult> {
   const nowMs = args.nowMs ?? now();
-  return await withConversationMutation(args, async (state) => {
+  return await withConversationMutation(args, async (state, lock) => {
     const current = await readConversation(state, args.conversationId);
     if (!current) {
       return { status: "no_work" };
@@ -1356,6 +1431,7 @@ export async function startConversationWork(args: {
     };
     await writeConversation(
       state,
+      lock,
       withExecutionUpdate(
         current,
         {
@@ -1384,13 +1460,14 @@ export async function checkInConversationWork(args: {
   state?: StateAdapter;
 }): Promise<boolean> {
   const nowMs = args.nowMs ?? now();
-  return await withConversationMutation(args, async (state) => {
+  return await withConversationMutation(args, async (state, lock) => {
     const current = await readConversation(state, args.conversationId);
     if (!current || current.execution.lease?.token !== args.leaseToken) {
       return false;
     }
     await writeConversation(
       state,
+      lock,
       withExecutionUpdate(
         current,
         {
@@ -1450,7 +1527,7 @@ export async function drainConversationMailbox(args: {
     acknowledgedIds ?? pending.map((message) => message.inboundMessageId),
   );
 
-  await withConversationMutation(args, async (state) => {
+  await withConversationMutation(args, async (state, lock) => {
     const current = await readConversation(state, args.conversationId);
     if (!current || current.execution.lease?.token !== args.leaseToken) {
       throw new Error(
@@ -1462,6 +1539,7 @@ export async function drainConversationMailbox(args: {
     );
     await writeConversation(
       state,
+      lock,
       withExecutionUpdate(
         current,
         {
@@ -1490,7 +1568,7 @@ export async function markConversationMessagesInjected(args: {
 }): Promise<boolean> {
   const nowMs = args.nowMs ?? now();
   const inboundMessageIds = new Set(args.inboundMessageIds);
-  return await withConversationMutation(args, async (state) => {
+  return await withConversationMutation(args, async (state, lock) => {
     const current = await readConversation(state, args.conversationId);
     if (!current || current.execution.lease?.token !== args.leaseToken) {
       return false;
@@ -1508,6 +1586,7 @@ export async function markConversationMessagesInjected(args: {
 
     await writeConversation(
       state,
+      lock,
       withExecutionUpdate(
         current,
         {
@@ -1530,7 +1609,7 @@ export async function requestConversationContinuation(args: {
   state?: StateAdapter;
 }): Promise<boolean> {
   const nowMs = args.nowMs ?? now();
-  return await withConversationMutation(args, async (state) => {
+  return await withConversationMutation(args, async (state, lock) => {
     const current = await readConversation(state, args.conversationId);
     if (!current || current.execution.lease?.token !== args.leaseToken) {
       return false;
@@ -1542,6 +1621,7 @@ export async function requestConversationContinuation(args: {
     });
     await writeConversation(
       state,
+      lock,
       withExecutionUpdate(
         current,
         {
@@ -1563,13 +1643,14 @@ export async function releaseConversationWork(args: {
   state?: StateAdapter;
 }): Promise<boolean> {
   const nowMs = args.nowMs ?? now();
-  return await withConversationMutation(args, async (state) => {
+  return await withConversationMutation(args, async (state, lock) => {
     const current = await readConversation(state, args.conversationId);
     if (!current || current.execution.lease?.token !== args.leaseToken) {
       return false;
     }
     await writeConversation(
       state,
+      lock,
       withExecutionUpdate(
         current,
         {
@@ -1595,7 +1676,7 @@ export async function completeConversationWork(args: {
   state?: StateAdapter;
 }): Promise<"completed" | "lost_lease" | "pending"> {
   const nowMs = args.nowMs ?? now();
-  return await withConversationMutation(args, async (state) => {
+  return await withConversationMutation(args, async (state, lock) => {
     const current = await readConversation(state, args.conversationId);
     if (!current || current.execution.lease?.token !== args.leaseToken) {
       return "lost_lease";
@@ -1605,6 +1686,7 @@ export async function completeConversationWork(args: {
     const runnable = needsRun || hasPending;
     await writeConversation(
       state,
+      lock,
       withExecutionUpdate(
         current,
         {
@@ -1620,6 +1702,121 @@ export async function completeConversationWork(args: {
   });
 }
 
+export interface ConversationWorkFailureRecord {
+  pendingCount: number;
+  poisonedMessages: InboundMessage[];
+  status: "lost_lease" | "recorded" | "skipped";
+}
+
+/**
+ * Record one failed delivery attempt for the pending messages a run was
+ * offered, consuming messages that reach the poison limit so a deterministic
+ * failure cannot requeue forever.
+ *
+ * Attempts are counted only when the run made no durable progress: if any
+ * offered message left the mailbox, the remaining pending entries may be
+ * deliberate deferrals and are left untouched. Consumed message ids stay in
+ * `inboundMessageIds` so source retries remain duplicates.
+ */
+export async function recordConversationWorkFailure(args: {
+  conversationId: string;
+  inboundMessageIds: string[];
+  leaseToken: string;
+  nowMs?: number;
+  state?: StateAdapter;
+}): Promise<ConversationWorkFailureRecord> {
+  const nowMs = args.nowMs ?? now();
+  return await withConversationMutation(args, async (state, lock) => {
+    const current = await readConversation(state, args.conversationId);
+    if (!current || current.execution.lease?.token !== args.leaseToken) {
+      return { status: "lost_lease", pendingCount: 0, poisonedMessages: [] };
+    }
+    const pendingIds = new Set(
+      current.execution.pendingMessages.map(
+        (message) => message.inboundMessageId,
+      ),
+    );
+    if (
+      args.inboundMessageIds.length === 0 ||
+      args.inboundMessageIds.some((id) => !pendingIds.has(id))
+    ) {
+      return {
+        status: "skipped",
+        pendingCount: current.execution.pendingMessages.length,
+        poisonedMessages: [],
+      };
+    }
+
+    const offered = new Set(args.inboundMessageIds);
+    const poisonedMessages: InboundMessage[] = [];
+    const pendingMessages: InboundMessage[] = [];
+    for (const message of current.execution.pendingMessages) {
+      if (!offered.has(message.inboundMessageId)) {
+        pendingMessages.push(message);
+        continue;
+      }
+      const attempted = {
+        ...message,
+        attemptCount: (message.attemptCount ?? 0) + 1,
+      };
+      if (attempted.attemptCount >= CONVERSATION_WORK_MAX_DELIVERY_ATTEMPTS) {
+        poisonedMessages.push(attempted);
+        continue;
+      }
+      pendingMessages.push(attempted);
+    }
+    await writeConversation(
+      state,
+      lock,
+      withExecutionUpdate(
+        current,
+        {
+          ...current.execution,
+          pendingMessages,
+        },
+        nowMs,
+      ),
+    );
+    return {
+      status: "recorded",
+      pendingCount: pendingMessages.length,
+      poisonedMessages,
+    };
+  });
+}
+
+/** Record a terminal failure completion for a leased conversation. */
+export async function failConversationWork(args: {
+  conversationId: string;
+  leaseToken: string;
+  nowMs?: number;
+  state?: StateAdapter;
+}): Promise<"failed" | "lost_lease" | "pending"> {
+  const nowMs = args.nowMs ?? now();
+  return await withConversationMutation(args, async (state, lock) => {
+    const current = await readConversation(state, args.conversationId);
+    if (!current || current.execution.lease?.token !== args.leaseToken) {
+      return "lost_lease";
+    }
+    const runnable = pendingMessages(current).length > 0;
+    await writeConversation(
+      state,
+      lock,
+      withExecutionUpdate(
+        current,
+        {
+          ...current.execution,
+          lease: undefined,
+          status: runnable ? "pending" : "failed",
+          runId: runnable ? current.execution.runId : undefined,
+        },
+        nowMs,
+      ),
+    );
+    return runnable ? "pending" : "failed";
+  });
+}
+
 /** Clear an expired durable lease so a later worker can resume safely. */
 export async function clearExpiredConversationLease(args: {
   conversationId: string;
@@ -1627,7 +1824,7 @@ export async function clearExpiredConversationLease(args: {
   state?: StateAdapter;
 }): Promise<boolean> {
   const nowMs = args.nowMs ?? now();
-  return await withConversationMutation(args, async (state) => {
+  return await withConversationMutation(args, async (state, lock) => {
     const current = await readConversation(state, args.conversationId);
     if (
       !current?.execution.lease ||
@@ -1637,6 +1834,7 @@ export async function clearExpiredConversationLease(args: {
     }
     await writeConversation(
       state,
+      lock,
       withExecutionUpdate(
         current,
         {

--- a/packages/junior/src/chat/task-execution/state.ts
+++ b/packages/junior/src/chat/task-execution/state.ts
@@ -362,8 +362,8 @@ function normalizeMessage(value: unknown): InboundMessage | undefined {
   };
 }
 
-/** Whether one more failed delivery would consume the message as poison work. */
-export function isFinalConversationDeliveryAttempt(
+/** Whether this is the final attempt before an unacked message is dead-lettered. */
+export function isFinalAttempt(
   message: Pick<InboundMessage, "attemptCount">,
 ): boolean {
   return (
@@ -1489,11 +1489,11 @@ export async function checkInConversationWork(args: {
  * Drain pending mailbox entries after the caller acknowledges durable handling.
  *
  * Returning ids acknowledges only that subset; returning nothing acknowledges
- * every offered pending entry.
+ * every pending entry passed to the handler.
  */
 export async function drainConversationMailbox(args: {
   conversationId: string;
-  inject: (messages: InboundMessage[]) => Promise<readonly string[] | void>;
+  handle: (messages: InboundMessage[]) => Promise<readonly string[] | void>;
   leaseToken: string;
   nowMs?: number;
   state?: StateAdapter;
@@ -1512,12 +1512,12 @@ export async function drainConversationMailbox(args: {
     return [];
   }
 
-  const acknowledgedIds = await args.inject(pending);
-  const offeredIds = new Set(
+  const acknowledgedIds = await args.handle(pending);
+  const pendingIds = new Set(
     pending.map((message) => message.inboundMessageId),
   );
   for (const inboundMessageId of acknowledgedIds ?? []) {
-    if (!offeredIds.has(inboundMessageId)) {
+    if (!pendingIds.has(inboundMessageId)) {
       throw new Error(
         `Conversation mailbox acknowledgement is not pending for ${args.conversationId}`,
       );
@@ -1558,8 +1558,8 @@ export async function drainConversationMailbox(args: {
   return pending.filter((message) => drainedIds.has(message.inboundMessageId));
 }
 
-/** Mark selected leased mailbox entries after their session-log injection succeeds. */
-export async function markConversationMessagesInjected(args: {
+/** Acknowledge leased mailbox entries after the handler accepts responsibility. */
+export async function ackMessages(args: {
   conversationId: string;
   inboundMessageIds: string[];
   leaseToken: string;
@@ -1703,34 +1703,38 @@ export async function completeConversationWork(args: {
 }
 
 /** Failure outcome: `lost_lease` (another owner took over), `recorded` (attempt counted), or `skipped` (durable progress was made). */
-export interface ConversationWorkFailureRecord {
+export interface AttemptFailure {
   pendingCount: number;
-  poisonedMessages: InboundMessage[];
+  deadLetteredMessages: InboundMessage[];
   status: "lost_lease" | "recorded" | "skipped";
 }
 
 /**
- * Record one failed delivery attempt for the pending messages a run was
- * offered, consuming messages that reach the poison limit so a deterministic
+ * Record one failed delivery attempt for the pending messages a run attempted,
+ * dead-lettering messages that reach the retry limit so a deterministic
  * failure cannot requeue forever.
  *
  * Attempts are counted only when the run made no durable progress: if any
- * offered message left the mailbox, the remaining pending entries may be
+ * attempted message left the mailbox, the remaining pending entries may be
  * deliberate deferrals and are left untouched. Consumed message ids stay in
  * `inboundMessageIds` so source retries remain duplicates.
  */
-export async function recordConversationWorkFailure(args: {
+export async function recordAttemptFailure(args: {
   conversationId: string;
   inboundMessageIds: string[];
   leaseToken: string;
   nowMs?: number;
   state?: StateAdapter;
-}): Promise<ConversationWorkFailureRecord> {
+}): Promise<AttemptFailure> {
   const nowMs = args.nowMs ?? now();
   return await withConversationMutation(args, async (state, lock) => {
     const current = await readConversation(state, args.conversationId);
     if (!current || current.execution.lease?.token !== args.leaseToken) {
-      return { status: "lost_lease", pendingCount: 0, poisonedMessages: [] };
+      return {
+        status: "lost_lease",
+        pendingCount: 0,
+        deadLetteredMessages: [],
+      };
     }
     const pendingIds = new Set(
       current.execution.pendingMessages.map(
@@ -1744,15 +1748,15 @@ export async function recordConversationWorkFailure(args: {
       return {
         status: "skipped",
         pendingCount: current.execution.pendingMessages.length,
-        poisonedMessages: [],
+        deadLetteredMessages: [],
       };
     }
 
-    const offered = new Set(args.inboundMessageIds);
-    const poisonedMessages: InboundMessage[] = [];
+    const attemptedIds = new Set(args.inboundMessageIds);
+    const deadLetteredMessages: InboundMessage[] = [];
     const pendingMessages: InboundMessage[] = [];
     for (const message of current.execution.pendingMessages) {
-      if (!offered.has(message.inboundMessageId)) {
+      if (!attemptedIds.has(message.inboundMessageId)) {
         pendingMessages.push(message);
         continue;
       }
@@ -1761,7 +1765,7 @@ export async function recordConversationWorkFailure(args: {
         attemptCount: (message.attemptCount ?? 0) + 1,
       };
       if (attempted.attemptCount >= CONVERSATION_WORK_MAX_DELIVERY_ATTEMPTS) {
-        poisonedMessages.push(attempted);
+        deadLetteredMessages.push(attempted);
         continue;
       }
       pendingMessages.push(attempted);
@@ -1781,13 +1785,13 @@ export async function recordConversationWorkFailure(args: {
     return {
       status: "recorded",
       pendingCount: pendingMessages.length,
-      poisonedMessages,
+      deadLetteredMessages,
     };
   });
 }
 
 /** Record a terminal failure completion for a leased conversation. */
-export async function failConversationWork(args: {
+export async function deadLetterAttempt(args: {
   conversationId: string;
   leaseToken: string;
   nowMs?: number;

--- a/packages/junior/src/chat/task-execution/state.ts
+++ b/packages/junior/src/chat/task-execution/state.ts
@@ -1702,6 +1702,7 @@ export async function completeConversationWork(args: {
   });
 }
 
+/** Failure outcome: `lost_lease` (another owner took over), `recorded` (attempt counted), or `skipped` (durable progress was made). */
 export interface ConversationWorkFailureRecord {
   pendingCount: number;
   poisonedMessages: InboundMessage[];

--- a/packages/junior/src/chat/task-execution/store.ts
+++ b/packages/junior/src/chat/task-execution/store.ts
@@ -11,14 +11,14 @@ export {
   CONVERSATION_WORK_LEASE_TTL_MS,
   CONVERSATION_WORK_MAX_DELIVERY_ATTEMPTS,
   CONVERSATION_WORK_STALE_ENQUEUE_MS,
-  isFinalConversationDeliveryAttempt,
+  isFinalAttempt,
   isInvalidConversationRecordError,
   type AgentInput,
+  type AttemptFailure,
   type AppendAndEnqueueInboundMessageResult,
   type AppendInboundMessageResult,
   type Conversation,
   type ConversationExecution,
-  type ConversationWorkFailureRecord,
   type ConversationWorkLease,
   type ConversationWorkState,
   type ExecutionStatus,
@@ -362,7 +362,7 @@ export async function checkInConversationWork(args: {
   return result;
 }
 
-/** Drain pending mailbox entries after the caller has durably injected them. */
+/** Drain pending mailbox entries after the caller accepts responsibility. */
 export async function drainConversationMailbox(
   args: Parameters<typeof workState.drainConversationMailbox>[0] & {
     conversationStore?: ConversationStore;
@@ -376,8 +376,8 @@ export async function drainConversationMailbox(
   return result;
 }
 
-/** Mark selected leased mailbox entries after their session-log injection succeeds. */
-export async function markConversationMessagesInjected(args: {
+/** Acknowledge leased mailbox entries after the handler accepts responsibility. */
+export async function ackMessages(args: {
   conversationId: string;
   inboundMessageIds: string[];
   leaseToken: string;
@@ -385,7 +385,7 @@ export async function markConversationMessagesInjected(args: {
   nowMs?: number;
   state?: StateAdapter;
 }) {
-  const result = await workState.markConversationMessagesInjected(args);
+  const result = await workState.ackMessages(args);
   await recordExecutionMetadata(args);
   return result;
 }
@@ -430,8 +430,8 @@ export async function completeConversationWork(args: {
   return result;
 }
 
-/** Record one failed delivery attempt and consume poisoned mailbox messages. */
-export async function recordConversationWorkFailure(args: {
+/** Record one failed delivery attempt and dead-letter messages at their limit. */
+export async function recordAttemptFailure(args: {
   conversationId: string;
   inboundMessageIds: string[];
   leaseToken: string;
@@ -439,7 +439,7 @@ export async function recordConversationWorkFailure(args: {
   nowMs?: number;
   state?: StateAdapter;
 }) {
-  const result = await workState.recordConversationWorkFailure(args);
+  const result = await workState.recordAttemptFailure(args);
   if (result.status === "recorded") {
     await recordExecutionMetadata(args);
   }
@@ -447,14 +447,14 @@ export async function recordConversationWorkFailure(args: {
 }
 
 /** Record a terminal failure completion for a leased conversation. */
-export async function failConversationWork(args: {
+export async function deadLetterAttempt(args: {
   conversationId: string;
   leaseToken: string;
   conversationStore?: ConversationStore;
   nowMs?: number;
   state?: StateAdapter;
 }) {
-  const result = await workState.failConversationWork(args);
+  const result = await workState.deadLetterAttempt(args);
   await recordExecutionMetadata(args);
   return result;
 }

--- a/packages/junior/src/chat/task-execution/store.ts
+++ b/packages/junior/src/chat/task-execution/store.ts
@@ -9,12 +9,16 @@ export {
   CONVERSATION_BY_ACTIVITY_INDEX_KEY,
   CONVERSATION_WORK_CHECK_IN_INTERVAL_MS,
   CONVERSATION_WORK_LEASE_TTL_MS,
+  CONVERSATION_WORK_MAX_DELIVERY_ATTEMPTS,
   CONVERSATION_WORK_STALE_ENQUEUE_MS,
+  isFinalConversationDeliveryAttempt,
+  isInvalidConversationRecordError,
   type AgentInput,
   type AppendAndEnqueueInboundMessageResult,
   type AppendInboundMessageResult,
   type Conversation,
   type ConversationExecution,
+  type ConversationWorkFailureRecord,
   type ConversationWorkLease,
   type ConversationWorkState,
   type ExecutionStatus,
@@ -422,6 +426,35 @@ export async function completeConversationWork(args: {
   state?: StateAdapter;
 }) {
   const result = await workState.completeConversationWork(args);
+  await recordExecutionMetadata(args);
+  return result;
+}
+
+/** Record one failed delivery attempt and consume poisoned mailbox messages. */
+export async function recordConversationWorkFailure(args: {
+  conversationId: string;
+  inboundMessageIds: string[];
+  leaseToken: string;
+  conversationStore?: ConversationStore;
+  nowMs?: number;
+  state?: StateAdapter;
+}) {
+  const result = await workState.recordConversationWorkFailure(args);
+  if (result.status === "recorded") {
+    await recordExecutionMetadata(args);
+  }
+  return result;
+}
+
+/** Record a terminal failure completion for a leased conversation. */
+export async function failConversationWork(args: {
+  conversationId: string;
+  leaseToken: string;
+  conversationStore?: ConversationStore;
+  nowMs?: number;
+  state?: StateAdapter;
+}) {
+  const result = await workState.failConversationWork(args);
   await recordExecutionMetadata(args);
   return result;
 }

--- a/packages/junior/src/chat/task-execution/worker.ts
+++ b/packages/junior/src/chat/task-execution/worker.ts
@@ -10,21 +10,23 @@ import {
   type ConversationWorkQueue,
 } from "./queue";
 import {
+  ackMessages,
   checkInConversationWork,
   clearConsumedConversationWake,
   completeConversationWork,
   CONVERSATION_WORK_CHECK_IN_INTERVAL_MS,
   countPendingConversationMessages,
+  deadLetterAttempt,
   drainConversationMailbox,
   ensureConversationWake,
-  failConversationWork,
   getConversationWorkState,
+  isFinalAttempt,
   isInvalidConversationRecordError,
-  recordConversationWorkFailure,
+  recordAttemptFailure,
   releaseConversationWork,
   requestConversationContinuation,
   startConversationWork,
-  type ConversationWorkFailureRecord,
+  type AttemptFailure,
   type ConversationWorkState,
   type InboundMessage,
 } from "./store";
@@ -33,14 +35,22 @@ export const CONVERSATION_WORK_DEFER_DELAY_MS = 15_000;
 export const CONVERSATION_WORK_SOFT_YIELD_AFTER_MS = 240_000;
 
 export interface ConversationWorkerContext {
+  attempt: InboxAttempt;
   checkIn(): Promise<boolean>;
   conversationId: string;
   destination: Destination;
-  drainMailbox(
-    inject: (messages: InboundMessage[]) => Promise<readonly string[] | void>,
-  ): Promise<InboundMessage[]>;
-  leaseToken: string;
   shouldYield(): boolean;
+}
+
+export interface InboxAttempt {
+  ack(): Promise<void>;
+  conversationId: string;
+  destination: Destination;
+  drain(
+    handle: (messages: InboundMessage[]) => Promise<readonly string[] | void>,
+  ): Promise<InboundMessage[]>;
+  isFinalAttempt: boolean;
+  messages: InboundMessage[];
 }
 
 export interface ConversationWorkerResult {
@@ -124,29 +134,29 @@ async function requestLostLeaseRecovery(args: {
 }
 
 /**
- * Record one failed delivery attempt and surface consumed poison messages.
+ * Record one failed delivery attempt and surface dead-lettered messages.
  *
- * Consumption is logged here so every poisoned message leaves a
- * `conversation_work_poisoned` trail with its terminal attempt count.
+ * Consumption is logged here so every dead-lettered message leaves a
+ * `conversation_work_dead_lettered` trail with its terminal attempt count.
  */
 async function recordFailedDeliveryAttempt(args: {
   conversationId: string;
   leaseToken: string;
   nowMs: number;
-  offeredInboundMessageIds: string[];
+  messageIds: string[];
   options: ProcessConversationWorkOptions;
-}): Promise<ConversationWorkFailureRecord> {
-  const failure = await recordConversationWorkFailure({
+}): Promise<AttemptFailure> {
+  const failure = await recordAttemptFailure({
     conversationId: args.conversationId,
-    inboundMessageIds: args.offeredInboundMessageIds,
+    inboundMessageIds: args.messageIds,
     leaseToken: args.leaseToken,
     conversationStore: args.options.conversationStore,
     nowMs: args.nowMs,
     state: args.options.state,
   });
-  for (const message of failure.poisonedMessages) {
+  for (const message of failure.deadLetteredMessages) {
     logWarn(
-      "conversation_work_poisoned",
+      "conversation_work_dead_lettered",
       { conversationId: args.conversationId },
       {
         "app.conversation.source": message.source,
@@ -160,11 +170,11 @@ async function recordFailedDeliveryAttempt(args: {
   return failure;
 }
 
-/** True only when this attempt poisoned messages and left no further pending work. */
-function isTerminalFailure(failure: ConversationWorkFailureRecord): boolean {
+/** True only when this attempt dead-lettered messages and left no further pending work. */
+function isTerminalFailure(failure: AttemptFailure): boolean {
   return (
     failure.status === "recorded" &&
-    failure.poisonedMessages.length > 0 &&
+    failure.deadLetteredMessages.length > 0 &&
     failure.pendingCount === 0
   );
 }
@@ -304,7 +314,12 @@ export async function processConversationWork(
   const softYieldDeadlineMs =
     startedAtMs +
     (options.softYieldAfterMs ?? CONVERSATION_WORK_SOFT_YIELD_AFTER_MS);
-  const offeredInboundMessageIds = initial.messages.map(
+  const leasedWork = await getConversationWorkState({
+    conversationId,
+    state: options.state,
+  });
+  const attemptMessages = leasedWork?.messages ?? initial.messages;
+  const attemptMessageIds = attemptMessages.map(
     (message) => message.inboundMessageId,
   );
   let leaseLost = false;
@@ -327,10 +342,48 @@ export async function processConversationWork(
     "Conversation work lease acquired",
   );
 
+  const drainInbox = (
+    handle: (messages: InboundMessage[]) => Promise<readonly string[] | void>,
+  ) =>
+    drainConversationMailbox({
+      conversationId,
+      leaseToken: lease.leaseToken,
+      conversationStore: options.conversationStore,
+      handle,
+      nowMs: now(options),
+      state: options.state,
+    });
+
+  const ack = async (): Promise<void> => {
+    const acknowledged = await ackMessages({
+      conversationId,
+      inboundMessageIds: attemptMessageIds,
+      leaseToken: lease.leaseToken,
+      conversationStore: options.conversationStore,
+      nowMs: now(options),
+      state: options.state,
+    });
+    if (!acknowledged) {
+      markLeaseLost();
+      throw new Error(
+        `Conversation work lease lost before inbox ack for ${conversationId}`,
+      );
+    }
+  };
+
   const workerContext: ConversationWorkerContext = {
+    attempt: {
+      ack,
+      conversationId,
+      destination,
+      drain: drainInbox,
+      isFinalAttempt: attemptMessages.some((message) =>
+        isFinalAttempt(message),
+      ),
+      messages: attemptMessages,
+    },
     conversationId,
     destination,
-    leaseToken: lease.leaseToken,
     shouldYield: () => leaseLost || now(options) >= softYieldDeadlineMs,
     checkIn: async () => {
       const checkedIn = await checkInConversationWork({
@@ -345,15 +398,6 @@ export async function processConversationWork(
       }
       return checkedIn;
     },
-    drainMailbox: (inject) =>
-      drainConversationMailbox({
-        conversationId,
-        leaseToken: lease.leaseToken,
-        conversationStore: options.conversationStore,
-        inject,
-        nowMs: now(options),
-        state: options.state,
-      }),
   };
 
   try {
@@ -451,19 +495,19 @@ export async function processConversationWork(
         : { status: "completed" };
     }
 
-    // A run that returns without durably handling any offered message is a
+    // A run that returns without durably handling any attempted message is a
     // failed delivery attempt, even when the runner swallowed its error:
     // completing would requeue the untouched mailbox forever.
-    if (offeredInboundMessageIds.length > 0) {
+    if (attemptMessageIds.length > 0) {
       const failure = await recordFailedDeliveryAttempt({
         conversationId,
         leaseToken: lease.leaseToken,
         nowMs: now(options),
-        offeredInboundMessageIds,
+        messageIds: attemptMessageIds,
         options,
       });
       if (isTerminalFailure(failure)) {
-        await failConversationWork({
+        await deadLetterAttempt({
           conversationId,
           leaseToken: lease.leaseToken,
           conversationStore: options.conversationStore,
@@ -521,17 +565,17 @@ export async function processConversationWork(
     let recoveryRecorded = false;
     try {
       const failure =
-        offeredInboundMessageIds.length > 0
+        attemptMessageIds.length > 0
           ? await recordFailedDeliveryAttempt({
               conversationId,
               leaseToken: lease.leaseToken,
               nowMs: errorNowMs,
-              offeredInboundMessageIds,
+              messageIds: attemptMessageIds,
               options,
             })
           : undefined;
       if (failure && isTerminalFailure(failure)) {
-        await failConversationWork({
+        await deadLetterAttempt({
           conversationId,
           leaseToken: lease.leaseToken,
           conversationStore: options.conversationStore,

--- a/packages/junior/src/chat/task-execution/worker.ts
+++ b/packages/junior/src/chat/task-execution/worker.ts
@@ -160,6 +160,7 @@ async function recordFailedDeliveryAttempt(args: {
   return failure;
 }
 
+/** True only when this attempt poisoned messages and left no further pending work. */
 function isTerminalFailure(failure: ConversationWorkFailureRecord): boolean {
   return (
     failure.status === "recorded" &&

--- a/packages/junior/src/chat/task-execution/worker.ts
+++ b/packages/junior/src/chat/task-execution/worker.ts
@@ -17,10 +17,15 @@ import {
   countPendingConversationMessages,
   drainConversationMailbox,
   ensureConversationWake,
+  failConversationWork,
   getConversationWorkState,
+  isInvalidConversationRecordError,
+  recordConversationWorkFailure,
   releaseConversationWork,
   requestConversationContinuation,
   startConversationWork,
+  type ConversationWorkFailureRecord,
+  type ConversationWorkState,
   type InboundMessage,
 } from "./store";
 
@@ -46,6 +51,7 @@ export interface ConversationWorkProcessResult {
   status:
     | "active"
     | "completed"
+    | "failed"
     | "lost_lease"
     | "no_work"
     | "pending_requeued"
@@ -117,6 +123,51 @@ async function requestLostLeaseRecovery(args: {
   });
 }
 
+/**
+ * Record one failed delivery attempt and surface consumed poison messages.
+ *
+ * Consumption is logged here so every poisoned message leaves a
+ * `conversation_work_poisoned` trail with its terminal attempt count.
+ */
+async function recordFailedDeliveryAttempt(args: {
+  conversationId: string;
+  leaseToken: string;
+  nowMs: number;
+  offeredInboundMessageIds: string[];
+  options: ProcessConversationWorkOptions;
+}): Promise<ConversationWorkFailureRecord> {
+  const failure = await recordConversationWorkFailure({
+    conversationId: args.conversationId,
+    inboundMessageIds: args.offeredInboundMessageIds,
+    leaseToken: args.leaseToken,
+    conversationStore: args.options.conversationStore,
+    nowMs: args.nowMs,
+    state: args.options.state,
+  });
+  for (const message of failure.poisonedMessages) {
+    logWarn(
+      "conversation_work_poisoned",
+      { conversationId: args.conversationId },
+      {
+        "app.conversation.source": message.source,
+        "app.inbound.attempt_count": message.attemptCount ?? 0,
+        "app.inbound.message_id": message.inboundMessageId,
+        "app.inbound.pending_count": failure.pendingCount,
+      },
+      "Conversation work message consumed after exceeding the delivery attempt limit",
+    );
+  }
+  return failure;
+}
+
+function isTerminalFailure(failure: ConversationWorkFailureRecord): boolean {
+  return (
+    failure.status === "recorded" &&
+    failure.poisonedMessages.length > 0 &&
+    failure.pendingCount === 0
+  );
+}
+
 function startLeaseCheckIn(args: {
   conversationId: string;
   leaseToken: string;
@@ -164,10 +215,24 @@ export async function processConversationWork(
   options: ProcessConversationWorkOptions,
 ): Promise<ConversationWorkProcessResult> {
   const conversationId = message.conversationId;
-  const initial = await getConversationWorkState({
-    conversationId,
-    state: options.state,
-  });
+  let initial: ConversationWorkState | undefined;
+  try {
+    initial = await getConversationWorkState({
+      conversationId,
+      state: options.state,
+    });
+  } catch (error) {
+    // Redelivery cannot repair a permanently invalid record, so the delivery
+    // is acknowledged as rejected instead of retried until retention expiry.
+    if (isInvalidConversationRecordError(error)) {
+      throw new ConversationQueueMessageRejectedError(
+        "invalid_record",
+        `Conversation record failed validation for ${conversationId}`,
+        { conversationId },
+      );
+    }
+    throw error;
+  }
   if (
     !initial ||
     (countPendingConversationMessages(initial) === 0 &&
@@ -238,6 +303,9 @@ export async function processConversationWork(
   const softYieldDeadlineMs =
     startedAtMs +
     (options.softYieldAfterMs ?? CONVERSATION_WORK_SOFT_YIELD_AFTER_MS);
+  const offeredInboundMessageIds = initial.messages.map(
+    (message) => message.inboundMessageId,
+  );
   let leaseLost = false;
   const markLeaseLost = (): void => {
     leaseLost = true;
@@ -353,6 +421,29 @@ export async function processConversationWork(
       return { status: "yielded" };
     }
 
+    // A run that returns without durably handling any offered message is a
+    // failed delivery attempt, even when the runner swallowed its error:
+    // completing would requeue the untouched mailbox forever.
+    if (offeredInboundMessageIds.length > 0) {
+      const failure = await recordFailedDeliveryAttempt({
+        conversationId,
+        leaseToken: lease.leaseToken,
+        nowMs: now(options),
+        offeredInboundMessageIds,
+        options,
+      });
+      if (isTerminalFailure(failure)) {
+        await failConversationWork({
+          conversationId,
+          leaseToken: lease.leaseToken,
+          conversationStore: options.conversationStore,
+          nowMs: now(options),
+          state: options.state,
+        });
+        return { status: "failed" };
+      }
+    }
+
     const completion = await completeConversationWork({
       conversationId,
       leaseToken: lease.leaseToken,
@@ -393,53 +484,69 @@ export async function processConversationWork(
     return { status: "completed" };
   } catch (error) {
     const errorNowMs = now(options);
+    // A failed run must not both NACK the queue delivery and schedule a
+    // recovery nudge. Once durable recovery state is recorded and one nudge is
+    // sent, the delivery is acknowledged; only when recording recovery state
+    // itself fails is the error rethrown so plain redelivery retries it.
+    let recoveryRecorded = false;
     try {
-      const continuationMarked = await requestConversationContinuation({
-        conversationId,
-        destination,
-        leaseToken: lease.leaseToken,
-        conversationStore: options.conversationStore,
-        nowMs: errorNowMs,
-        state: options.state,
-      });
-      if (continuationMarked) {
-        await ensureConversationWake({
+      const failure =
+        offeredInboundMessageIds.length > 0
+          ? await recordFailedDeliveryAttempt({
+              conversationId,
+              leaseToken: lease.leaseToken,
+              nowMs: errorNowMs,
+              offeredInboundMessageIds,
+              options,
+            })
+          : undefined;
+      if (failure && isTerminalFailure(failure)) {
+        await failConversationWork({
           conversationId,
+          leaseToken: lease.leaseToken,
           conversationStore: options.conversationStore,
-          idempotencyKey: nudgeIdempotencyKey(
-            "error",
-            conversationId,
-            errorNowMs,
-          ),
           nowMs: errorNowMs,
-          queue: options.queue,
+          state: options.state,
+        });
+      } else {
+        const continuationMarked = await requestConversationContinuation({
+          conversationId,
+          destination,
+          leaseToken: lease.leaseToken,
+          conversationStore: options.conversationStore,
+          nowMs: errorNowMs,
+          state: options.state,
+        });
+        if (continuationMarked) {
+          await ensureConversationWake({
+            conversationId,
+            conversationStore: options.conversationStore,
+            idempotencyKey: nudgeIdempotencyKey(
+              "error",
+              conversationId,
+              errorNowMs,
+            ),
+            nowMs: errorNowMs,
+            queue: options.queue,
+            state: options.state,
+          });
+        }
+        await releaseConversationWork({
+          conversationId,
+          leaseToken: lease.leaseToken,
+          conversationStore: options.conversationStore,
+          nowMs: errorNowMs,
           state: options.state,
         });
       }
-    } catch (requeueError) {
+      recoveryRecorded = true;
+    } catch (recoveryError) {
       logException(
-        requeueError,
+        recoveryError,
         "conversation_work_requeue_failed",
         { conversationId },
         {},
-        "Conversation work requeue failed after runner error",
-      );
-    }
-    try {
-      await releaseConversationWork({
-        conversationId,
-        leaseToken: lease.leaseToken,
-        conversationStore: options.conversationStore,
-        nowMs: errorNowMs,
-        state: options.state,
-      });
-    } catch (releaseError) {
-      logException(
-        releaseError,
-        "conversation_work_release_failed",
-        { conversationId },
-        {},
-        "Conversation work release failed after runner error",
+        "Conversation work recovery failed after runner error",
       );
     }
     if (!isProviderRetryError(error)) {
@@ -453,7 +560,10 @@ export async function processConversationWork(
         "Conversation work failed",
       );
     }
-    throw error;
+    if (!recoveryRecorded) {
+      throw error;
+    }
+    return { status: "failed" };
   } finally {
     clearInterval(timer);
   }

--- a/packages/junior/src/chat/task-execution/worker.ts
+++ b/packages/junior/src/chat/task-execution/worker.ts
@@ -44,7 +44,7 @@ export interface ConversationWorkerContext {
 }
 
 export interface ConversationWorkerResult {
-  status: "completed" | "lost_lease" | "yielded";
+  status: "completed" | "deferred" | "lost_lease" | "yielded";
 }
 
 export interface ConversationWorkProcessResult {
@@ -420,6 +420,35 @@ export async function processConversationWork(
         "Conversation work yielded cooperatively",
       );
       return { status: "yielded" };
+    }
+
+    if (result.status === "deferred") {
+      const deferredNowMs = now(options);
+      const released = await releaseConversationWork({
+        conversationId,
+        leaseToken: lease.leaseToken,
+        conversationStore: options.conversationStore,
+        nowMs: deferredNowMs,
+        state: options.state,
+      });
+      if (!released) {
+        return { status: "lost_lease" };
+      }
+      const wake = await ensureConversationWake({
+        conversationId,
+        conversationStore: options.conversationStore,
+        idempotencyKey: nudgeIdempotencyKey(
+          "deferred",
+          conversationId,
+          deferredNowMs,
+        ),
+        nowMs: deferredNowMs,
+        queue: options.queue,
+        state: options.state,
+      });
+      return wake.status === "enqueued"
+        ? { status: "pending_requeued" }
+        : { status: "completed" };
     }
 
     // A run that returns without durably handling any offered message is a

--- a/packages/junior/src/chat/tools/slack/channel-access.ts
+++ b/packages/junior/src/chat/tools/slack/channel-access.ts
@@ -19,9 +19,9 @@ export type SlackChannelReadAccess =
  * Decide whether the model may read Slack content from a target channel.
  *
  * The current conversation is always readable. Any other channel requires
- * persisted source-confirmed `public` visibility in the same workspace:
- * channel-id prefixes cannot prove a channel public (modern Slack private
- * channels also use `C` ids), so unknown or unconfirmed channels fail closed.
+ * persisted `public` visibility in the same workspace: channel-id prefixes
+ * cannot prove a channel public (modern Slack private channels also use `C`
+ * ids), so missing or private destinations fail closed.
  */
 export async function checkSlackChannelReadAccess(args: {
   currentChannelIds: Array<string | undefined>;
@@ -54,6 +54,6 @@ export async function checkSlackChannelReadAccess(args: {
   return {
     allowed: false,
     error:
-      "Cannot read this Slack conversation: only the current conversation or channels Junior has confirmed as public in this workspace are readable.",
+      "Cannot read this Slack conversation: only the current conversation or public channels Junior has seen in this workspace are readable.",
   };
 }

--- a/packages/junior/src/chat/tools/slack/channel-access.ts
+++ b/packages/junior/src/chat/tools/slack/channel-access.ts
@@ -1,0 +1,59 @@
+import type { ConversationPrivacy } from "@/chat/conversation-privacy";
+import { normalizeSlackConversationId } from "@/chat/slack/client";
+import { getConversationStore } from "@/chat/db";
+
+/** Minimal persisted-visibility port for cross-conversation read gates. */
+export interface DestinationVisibilityReader {
+  getDestinationVisibility(args: {
+    provider: string;
+    providerDestinationId: string;
+    providerTenantId?: string;
+  }): Promise<ConversationPrivacy | undefined>;
+}
+
+export type SlackChannelReadAccess =
+  | { allowed: true }
+  | { allowed: false; error: string };
+
+/**
+ * Decide whether the model may read Slack content from a target channel.
+ *
+ * The current conversation is always readable. Any other channel requires
+ * persisted source-confirmed `public` visibility in the same workspace:
+ * channel-id prefixes cannot prove a channel public (modern Slack private
+ * channels also use `C` ids), so unknown or unconfirmed channels fail closed.
+ */
+export async function checkSlackChannelReadAccess(args: {
+  currentChannelIds: Array<string | undefined>;
+  store?: DestinationVisibilityReader;
+  targetChannelId: string;
+  teamId: string;
+}): Promise<SlackChannelReadAccess> {
+  const target = normalizeSlackConversationId(args.targetChannelId);
+  if (!target) {
+    return { allowed: false, error: "Invalid Slack channel ID." };
+  }
+
+  const currentChannels = args.currentChannelIds
+    .map((channelId) => normalizeSlackConversationId(channelId))
+    .filter((channelId): channelId is string => Boolean(channelId));
+  if (currentChannels.includes(target)) {
+    return { allowed: true };
+  }
+
+  const store = args.store ?? getConversationStore();
+  const visibility = await store.getDestinationVisibility({
+    provider: "slack",
+    providerTenantId: args.teamId,
+    providerDestinationId: target,
+  });
+  if (visibility === "public") {
+    return { allowed: true };
+  }
+
+  return {
+    allowed: false,
+    error:
+      "Cannot read this Slack conversation: only the current conversation or channels Junior has confirmed as public in this workspace are readable.",
+  };
+}

--- a/packages/junior/src/chat/tools/slack/thread-read.ts
+++ b/packages/junior/src/chat/tools/slack/thread-read.ts
@@ -75,7 +75,7 @@ export function createSlackThreadReadTool(
 ) {
   return tool({
     description:
-      "Read a Slack thread from a shared Slack message archive URL or explicit channel + timestamp. Use when the user shares a Slack message link (https://*.slack.com/archives/...) and you need the referenced message and its thread context. Only the current conversation and channels Junior has confirmed as public in this workspace are readable.",
+      "Read a Slack thread from a shared Slack message archive URL or explicit channel + timestamp. Use when the user shares a Slack message link (https://*.slack.com/archives/...) and you need the referenced message and its thread context. Only the current conversation and public channels Junior has seen in this workspace are readable.",
     annotations: { readOnlyHint: true, destructiveHint: false },
     inputSchema: Type.Object({
       url: Type.Optional(
@@ -141,9 +141,8 @@ export function createSlackThreadReadTool(
         };
       }
 
-      // Cross-conversation reads require persisted confirmed-public
-      // visibility in the current workspace; the active delivery context is
-      // always readable.
+      // Cross-conversation reads require persisted public visibility in the
+      // current workspace; the active delivery context is always readable.
       const access = await checkSlackChannelReadAccess({
         currentChannelIds: [
           context.destinationChannelId,

--- a/packages/junior/src/chat/tools/slack/thread-read.ts
+++ b/packages/junior/src/chat/tools/slack/thread-read.ts
@@ -1,9 +1,10 @@
 import { Type } from "@sinclair/typebox";
-import {
-  SlackActionError,
-  normalizeSlackConversationId,
-} from "@/chat/slack/client";
+import { SlackActionError } from "@/chat/slack/client";
 import { listThreadReplies } from "@/chat/slack/channel";
+import {
+  checkSlackChannelReadAccess,
+  type DestinationVisibilityReader,
+} from "@/chat/tools/slack/channel-access";
 import { tool } from "@/chat/tools/definition";
 import {
   SLACK_TS_PATTERN,
@@ -67,47 +68,14 @@ function truncateMessages(
   return { messages: kept, omitted: messages.length - kept.length };
 }
 
-/**
- * Check whether reading the target channel is allowed using only local
- * channel ID conventions — no Slack API call needed.
- *
- * Public channels (C-prefix) are always readable. Private channels (G-prefix)
- * and DMs (D-prefix) are only allowed when the target matches the channel the
- * user is currently messaging from.
- */
-function checkChannelAccess(
-  targetChannelId: string,
-  currentChannelId: string | undefined,
-): { allowed: true } | { allowed: false; error: string } {
-  const target = normalizeSlackConversationId(targetChannelId);
-  const current = normalizeSlackConversationId(currentChannelId);
-
-  if (!target) {
-    return { allowed: false, error: "Invalid Slack channel ID." };
-  }
-
-  // Public channels — any workspace member can see.
-  if (target.startsWith("C")) {
-    return { allowed: true };
-  }
-
-  // Private channels / DMs — only if user is messaging from that channel.
-  if (target === current) {
-    return { allowed: true };
-  }
-
-  return {
-    allowed: false,
-    error:
-      "Cannot read private channels or DMs unless the link is from the current conversation.",
-  };
-}
-
 /** Create a tool that reads a Slack thread from a shared message URL or explicit coordinates. */
-export function createSlackThreadReadTool(context: SlackToolContext) {
+export function createSlackThreadReadTool(
+  context: SlackToolContext,
+  deps: { visibilityStore?: DestinationVisibilityReader } = {},
+) {
   return tool({
     description:
-      "Read a Slack thread from a shared Slack message archive URL or explicit channel + timestamp. Use when the user shares a Slack message link (https://*.slack.com/archives/...) and you need the referenced message and its thread context. Public channel links can be read if the bot has access; private channels and DMs are only readable when they are the current conversation.",
+      "Read a Slack thread from a shared Slack message archive URL or explicit channel + timestamp. Use when the user shares a Slack message link (https://*.slack.com/archives/...) and you need the referenced message and its thread context. Only the current conversation and channels Junior has confirmed as public in this workspace are readable.",
     annotations: { readOnlyHint: true, destructiveHint: false },
     inputSchema: Type.Object({
       url: Type.Optional(
@@ -173,11 +141,18 @@ export function createSlackThreadReadTool(context: SlackToolContext) {
         };
       }
 
-      // Restrict private-thread reads to the active Slack delivery context.
-      const access = checkChannelAccess(
-        channelId,
-        context.destinationChannelId,
-      );
+      // Cross-conversation reads require persisted confirmed-public
+      // visibility in the current workspace; the active delivery context is
+      // always readable.
+      const access = await checkSlackChannelReadAccess({
+        currentChannelIds: [
+          context.destinationChannelId,
+          context.sourceChannelId,
+        ],
+        store: deps.visibilityStore,
+        targetChannelId: channelId,
+        teamId: context.teamId,
+      });
       if (!access.allowed) {
         return {
           ok: false,

--- a/packages/junior/src/reporting/conversations.ts
+++ b/packages/junior/src/reporting/conversations.ts
@@ -25,6 +25,7 @@ import {
 } from "@/chat/sentry-links";
 import { z } from "zod";
 import {
+  SLACK_REDACTED_CONVERSATION_LABELS,
   formatSlackConversationRedactedLabel,
   resolveSlackConversationContextFromThreadId,
 } from "@/chat/slack/conversation-context";
@@ -767,11 +768,7 @@ function requesterLabel(
 }
 
 const REDACTED_LOCATION_LABELS = new Set([
-  "Public Channel",
-  "Private Channel",
-  "Group DM",
-  "Direct Message",
-  "Private Channel or Group DM",
+  ...SLACK_REDACTED_CONVERSATION_LABELS,
   PRIVATE_CONVERSATION_LABEL,
 ]);
 

--- a/packages/junior/src/reporting/conversations.ts
+++ b/packages/junior/src/reporting/conversations.ts
@@ -25,7 +25,6 @@ import {
 } from "@/chat/sentry-links";
 import { z } from "zod";
 import {
-  SLACK_REDACTED_CONVERSATION_LABELS,
   formatSlackConversationRedactedLabel,
   resolveSlackConversationContextFromThreadId,
 } from "@/chat/slack/conversation-context";
@@ -73,6 +72,20 @@ const REQUESTER_PROFILE_SAMPLE_LIMIT = 5_000;
 const REQUESTER_PROFILE_RECENT_LIMIT = 25;
 const REQUESTER_PROFILE_ACTIVITY_DAYS = 366;
 const RECENT_CONVERSATION_STATS_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+function privateConversationLabel(
+  slackConversation: ReturnType<
+    typeof resolveSlackConversationContextFromThreadId
+  >,
+): string {
+  if (!slackConversation) {
+    return PRIVATE_CONVERSATION_LABEL;
+  }
+  return slackConversation.visibility === "private"
+    ? (formatSlackConversationRedactedLabel(slackConversation) ??
+        PRIVATE_CONVERSATION_LABEL)
+    : PRIVATE_CONVERSATION_LABEL;
+}
 
 interface ConversationReaderOptions {
   conversationStore?: ConversationStore;
@@ -124,6 +137,7 @@ export interface ConversationSummaryReport {
   requesterIdentity?: RequesterIdentity;
   channel?: string;
   channelName?: string;
+  channelNameRedacted?: boolean;
   sentryTraceUrl?: string;
   traceId?: string;
 }
@@ -457,9 +471,7 @@ function sessionReportFromSummary(
   });
   const privateLabel =
     privacy !== "public"
-      ? slackConversation
-        ? formatSlackConversationRedactedLabel(slackConversation)
-        : PRIVATE_CONVERSATION_LABEL
+      ? privateConversationLabel(slackConversation)
       : undefined;
   const channelName = privateLabel ?? effectiveChannelName;
   const effectiveSurface =
@@ -496,6 +508,7 @@ function sessionReportFromSummary(
     ...(requesterIdentity ? { requesterIdentity } : {}),
     ...(slackThread ? { channel: slackThread.channelId } : {}),
     ...(channelName ? { channelName } : {}),
+    ...(privateLabel ? { channelNameRedacted: true } : {}),
     ...(summary.traceId ? { traceId: summary.traceId } : {}),
     ...(sentryTraceUrl ? { sentryTraceUrl } : {}),
   };
@@ -543,9 +556,7 @@ function titleFromConversation(args: {
       conversationId: args.conversation.conversationId,
       visibility: args.conversation.visibility,
     }) !== "public"
-      ? slackConversation
-        ? formatSlackConversationRedactedLabel(slackConversation)
-        : PRIVATE_CONVERSATION_LABEL
+      ? privateConversationLabel(slackConversation)
       : undefined;
   return (
     privateLabel ??
@@ -578,12 +589,26 @@ function channelNameFromConversation(
       visibility: conversation.visibility,
     }) !== "public"
   ) {
-    return (
-      formatSlackConversationRedactedLabel(slackConversation) ??
-      (slackConversation ? undefined : PRIVATE_CONVERSATION_LABEL)
-    );
+    return privateConversationLabel(slackConversation);
   }
   return effectiveChannelName;
+}
+
+function channelNameRedactedFromConversation(
+  conversation: StoredConversation,
+  details?: ConversationDetailsRecord,
+): boolean {
+  const effectiveChannelName = details?.channelName ?? conversation.channelName;
+  const slackThread = parseSlackThreadId(conversation.conversationId);
+  if (!effectiveChannelName && !slackThread) {
+    return false;
+  }
+  return (
+    resolveConversationPrivacy({
+      conversationId: conversation.conversationId,
+      visibility: conversation.visibility,
+    }) !== "public"
+  );
 }
 
 function applyConversationIndexMetadata(args: {
@@ -604,6 +629,10 @@ function applyConversationIndexMetadata(args: {
   const effectiveChannelName =
     channelNameFromConversation(args.conversation, args.details) ??
     args.report.channelName;
+  const channelNameRedacted = channelNameRedactedFromConversation(
+    args.conversation,
+    args.details,
+  );
   const requesterIdentity =
     requesterIdentityReport(args.details?.originRequester) ??
     args.report.requesterIdentity ??
@@ -617,8 +646,10 @@ function applyConversationIndexMetadata(args: {
     reportTime(args.report.lastSeenAt) ?? 0,
     args.conversation.lastActivityAtMs,
   );
+  const { channelNameRedacted: _oldChannelNameRedacted, ...report } =
+    args.report;
   return {
-    ...args.report,
+    ...report,
     displayTitle: titleFromConversation({
       conversation: args.conversation,
       details: args.details,
@@ -630,6 +661,7 @@ function applyConversationIndexMetadata(args: {
     ...(requesterIdentity ? { requesterIdentity } : {}),
     ...(slackThread ? { channel: slackThread.channelId } : {}),
     ...(effectiveChannelName ? { channelName: effectiveChannelName } : {}),
+    ...(channelNameRedacted ? { channelNameRedacted: true } : {}),
   };
 }
 
@@ -646,6 +678,10 @@ function sessionReportFromConversation(
   );
   const slackThread = parseSlackThreadId(conversation.conversationId);
   const channelName = channelNameFromConversation(conversation, details);
+  const channelNameRedacted = channelNameRedactedFromConversation(
+    conversation,
+    details,
+  );
   return {
     conversationId: conversation.conversationId,
     cumulativeDurationMs: 0,
@@ -661,6 +697,7 @@ function sessionReportFromConversation(
     ...(requesterIdentity ? { requesterIdentity } : {}),
     ...(slackThread ? { channel: slackThread.channelId } : {}),
     ...(channelName ? { channelName } : {}),
+    ...(channelNameRedacted ? { channelNameRedacted: true } : {}),
   };
 }
 
@@ -767,20 +804,16 @@ function requesterLabel(
   return email ?? fullName ?? slackUserName ?? requester?.slackUserId;
 }
 
-const REDACTED_LOCATION_LABELS = new Set([
-  ...SLACK_REDACTED_CONVERSATION_LABELS,
-  PRIVATE_CONVERSATION_LABEL,
-]);
-
 function slackStatsLocationLabel(
-  input: Pick<ConversationSummaryReport, "channel" | "channelName">,
+  input: Pick<
+    ConversationSummaryReport,
+    "channel" | "channelName" | "channelNameRedacted"
+  >,
 ): string | undefined {
   const channelId = input.channel;
   if (!channelId) return undefined;
 
-  // Privacy-redacted rows carry a generic type label instead of a channel
-  // name; keep it as-is instead of formatting it like a channel name.
-  if (input.channelName && REDACTED_LOCATION_LABELS.has(input.channelName)) {
+  if (input.channelNameRedacted && input.channelName) {
     return input.channelName;
   }
 
@@ -818,8 +851,7 @@ function displayTitleFromDetails(
   });
   const privateLabel =
     resolveConversationPrivacy({ conversationId, visibility }) !== "public"
-      ? (formatSlackConversationRedactedLabel(slackConversation) ??
-        PRIVATE_CONVERSATION_LABEL)
+      ? privateConversationLabel(slackConversation)
       : undefined;
   return (
     privateLabel ??
@@ -2059,6 +2091,10 @@ export async function listRecentConversationSummaries(
       conversation.conversationId,
     );
     const channelName = channelNameFromConversation(conversation, details);
+    const channelNameRedacted = channelNameRedactedFromConversation(
+      conversation,
+      details,
+    );
     const report = newestRun(
       reportsByConversation.get(conversation.conversationId) ?? [
         sessionReportFromConversation(conversation, nowMs, details),
@@ -2073,6 +2109,7 @@ export async function listRecentConversationSummaries(
       ).toISOString(),
       status: report.status,
       ...(channelName ? { channelName } : {}),
+      ...(channelNameRedacted ? { channelNameRedacted: true } : {}),
       ...(conversation.source ? { source: conversation.source } : {}),
     };
   });

--- a/packages/junior/src/reporting/conversations.ts
+++ b/packages/junior/src/reporting/conversations.ts
@@ -9,6 +9,7 @@ import { isRecord } from "@/chat/coerce";
 import {
   canExposeConversationPayload,
   resolveConversationPrivacy,
+  type ConversationPrivacy,
 } from "@/chat/conversation-privacy";
 import type { PiMessage } from "@/chat/pi/messages";
 import { buildSystemPrompt } from "@/chat/prompt";
@@ -441,10 +442,12 @@ function sessionReportFromSummary(
   summary: AgentTurnSessionSummary,
   nowMs = Date.now(),
   details?: ConversationDetailsRecord,
+  visibility?: ConversationPrivacy,
 ): ConversationSummaryReport {
   const slackThread = parseSlackThreadId(summary.conversationId);
   const privacy = resolveConversationPrivacy({
     conversationId: summary.conversationId,
+    visibility,
   });
   const effectiveChannelName = details?.channelName ?? summary.channelName;
   const slackConversation = resolveSlackConversationContextFromThreadId({
@@ -537,6 +540,7 @@ function titleFromConversation(args: {
   const privateLabel =
     resolveConversationPrivacy({
       conversationId: args.conversation.conversationId,
+      visibility: args.conversation.visibility,
     }) !== "public"
       ? slackConversation
         ? formatSlackConversationRedactedLabel(slackConversation)
@@ -570,6 +574,7 @@ function channelNameFromConversation(
   if (
     resolveConversationPrivacy({
       conversationId: conversation.conversationId,
+      visibility: conversation.visibility,
     }) !== "public"
   ) {
     return (
@@ -761,11 +766,26 @@ function requesterLabel(
   return email ?? fullName ?? slackUserName ?? requester?.slackUserId;
 }
 
+const REDACTED_LOCATION_LABELS = new Set([
+  "Public Channel",
+  "Private Channel",
+  "Group DM",
+  "Direct Message",
+  "Private Channel or Group DM",
+  PRIVATE_CONVERSATION_LABEL,
+]);
+
 function slackStatsLocationLabel(
   input: Pick<ConversationSummaryReport, "channel" | "channelName">,
 ): string | undefined {
   const channelId = input.channel;
   if (!channelId) return undefined;
+
+  // Privacy-redacted rows carry a generic type label instead of a channel
+  // name; keep it as-is instead of formatting it like a channel name.
+  if (input.channelName && REDACTED_LOCATION_LABELS.has(input.channelName)) {
+    return input.channelName;
+  }
 
   const name = input.channelName?.replace(/^#/, "");
   if (channelId.startsWith("D")) {
@@ -791,6 +811,7 @@ function surfaceFallbackLabel(surface: ConversationSurface): string {
 function displayTitleFromDetails(
   conversationId: string,
   details: ConversationDetailsRecord | undefined,
+  visibility?: ConversationPrivacy,
 ): string | undefined {
   if (!details) return undefined;
   const slackThread = parseSlackThreadId(conversationId);
@@ -799,7 +820,7 @@ function displayTitleFromDetails(
     channelName: details.channelName,
   });
   const privateLabel =
-    resolveConversationPrivacy({ conversationId }) !== "public"
+    resolveConversationPrivacy({ conversationId, visibility }) !== "public"
       ? (formatSlackConversationRedactedLabel(slackConversation) ??
         PRIVATE_CONVERSATION_LABEL)
       : undefined;
@@ -1370,9 +1391,11 @@ export async function readRequesterProfileReport(
 
 function canExposeConversationTranscript(
   summary: AgentTurnSessionSummary,
+  visibility: ConversationPrivacy | undefined,
 ): boolean {
   return canExposeConversationPayload({
     conversationId: summary.conversationId,
+    visibility,
   });
 }
 
@@ -1939,7 +1962,12 @@ async function reportsFromConversations(args: {
               conversation,
               details,
               nowMs: args.nowMs,
-              report: sessionReportFromSummary(summary, args.nowMs, details),
+              report: sessionReportFromSummary(
+                summary,
+                args.nowMs,
+                details,
+                conversation.visibility,
+              ),
             }),
           )
         : [sessionReportFromConversation(conversation, args.nowMs, details)];
@@ -2087,7 +2115,10 @@ export async function readConversationReport(
             sessionRecord.turnStartMessageIndex,
           )
         : { messages: [], startsAtRunBoundary: false };
-      const canExposeTranscript = canExposeConversationTranscript(summary);
+      const canExposeTranscript = canExposeConversationTranscript(
+        summary,
+        conversation?.visibility,
+      );
       const normalizedTranscript = scopedMessages.messages.map(
         normalizeTranscriptMessage,
       );
@@ -2117,7 +2148,12 @@ export async function readConversationReport(
         (canExposeTranscript ? traceIdFromTranscript(transcript) : undefined);
       const sentryTraceUrl = traceId ? buildSentryTraceUrl(traceId) : undefined;
       const report: ConversationRunReport = {
-        ...sessionReportFromSummary(summary, nowMs, details),
+        ...sessionReportFromSummary(
+          summary,
+          nowMs,
+          details,
+          conversation?.visibility,
+        ),
         ...(traceId ? { traceId } : {}),
         ...(sentryTraceUrl ? { sentryTraceUrl } : {}),
         activity,
@@ -2163,7 +2199,11 @@ export async function readConversationReport(
   const firstRun = effectiveRuns[0];
   const displayTitle =
     firstRun?.displayTitle ??
-    displayTitleFromDetails(conversationId, details) ??
+    displayTitleFromDetails(
+      conversationId,
+      details,
+      conversation?.visibility,
+    ) ??
     surfaceFallbackLabel(firstRun?.surface ?? "slack");
   const sentryConversationUrl = buildSentryConversationUrl(conversationId);
 
@@ -2181,9 +2221,13 @@ export async function readConversationSubagentTranscriptReport(
   conversationId: string,
   runId: string,
   subagentId: string,
+  options: ConversationReaderOptions = {},
 ): Promise<ConversationSubagentTranscriptReport> {
-  const summaries =
-    await listAgentTurnSessionSummariesForConversation(conversationId);
+  const store = conversationStore(options);
+  const [summaries, conversation] = await Promise.all([
+    listAgentTurnSessionSummariesForConversation(conversationId),
+    store.get({ conversationId }),
+  ]);
   const summary = summaries.find((candidate) => candidate.sessionId === runId);
   if (!summary) {
     return {
@@ -2230,7 +2274,10 @@ export async function readConversationSubagentTranscriptReport(
     };
   }
 
-  const canExposeTranscript = canExposeConversationTranscript(summary);
+  const canExposeTranscript = canExposeConversationTranscript(
+    summary,
+    conversation?.visibility,
+  );
   const activity = subagentActivity(start, { canExposeTranscript, end });
   const conversationFields = subagentConversationFields(start.transcriptRef);
   if (!canExposeTranscript) {

--- a/packages/junior/tests/component/conversation-sql-store.test.ts
+++ b/packages/junior/tests/component/conversation-sql-store.test.ts
@@ -742,7 +742,7 @@ INSERT INTO junior_conversations (
         conversationStore: store,
         queue,
         run: async (context) => {
-          await context.drainMailbox(async () => {});
+          await context.attempt.drain(async () => {});
           entered.resolve();
           await finish.promise;
           return { status: "completed" };
@@ -800,7 +800,7 @@ INSERT INTO junior_conversations (
       await drainConversationMailbox({
         conversationId: CONVERSATION_ID,
         conversationStore: store,
-        inject: async () => {},
+        handle: async () => {},
         leaseToken: lease.leaseToken,
         nowMs: 3_000,
         state,

--- a/packages/junior/tests/component/conversation-sql-store.test.ts
+++ b/packages/junior/tests/component/conversation-sql-store.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { backfillToSql } from "@/chat/conversations/sql/backfill";
+import { migrateSchema, migrations } from "@/chat/conversations/sql/migrations";
 import { createSqlStore, SqlStore } from "@/chat/conversations/sql/store";
 import { createStateConversationStore } from "@/chat/conversations/state";
 import {
@@ -180,7 +181,7 @@ describe("conversation SQL store", () => {
     }
   });
 
-  it("persists visibility only from source-confirmed signals and converges on newer signals", async () => {
+  it("persists visibility from source signals and converges on newer signals", async () => {
     const fixture = await createLocalJuniorSqlFixture();
 
     try {
@@ -206,7 +207,7 @@ describe("conversation SQL store", () => {
         }),
       ).resolves.toBe("private");
 
-      // A signal-less write must not clobber the confirmed value.
+      // A signal-less write must not clobber the stored value.
       await store.recordActivity({
         conversationId: CONVERSATION_ID,
         destination,
@@ -233,20 +234,29 @@ describe("conversation SQL store", () => {
           providerDestinationId: "C123",
         }),
       ).resolves.toBe("public");
+
+      await store.recordActivity({
+        conversationId: CONVERSATION_ID,
+        destination,
+        nowMs: 4_000,
+      });
+      await expect(
+        store.get({ conversationId: CONVERSATION_ID }),
+      ).resolves.toMatchObject({ visibility: "public" });
     } finally {
       await fixture.close();
     }
   });
 
-  it("treats unsigned and legacy prefix-derived destinations as unconfirmed", async () => {
+  it("defaults unsigned Slack destinations to private", async () => {
     const fixture = await createLocalJuniorSqlFixture();
 
     try {
       const store = createSqlStore(fixture.sql);
       await store.migrate();
 
-      // A write without a live source signal stays unconfirmed even though
-      // the channel id is C-prefixed.
+      // A write without a live source signal fails closed to private even
+      // though the channel id is C-prefixed.
       await store.recordActivity({
         conversationId: CONVERSATION_ID,
         destination: inboundMessage("unsigned").destination,
@@ -255,17 +265,24 @@ describe("conversation SQL store", () => {
       const conversation = await store.get({
         conversationId: CONVERSATION_ID,
       });
-      expect(conversation?.visibility).toBeUndefined();
+      expect(conversation?.visibility).toBe("private");
       await expect(
         store.getDestinationVisibility({
           provider: "slack",
           providerTenantId: "T123",
           providerDestinationId: "C123",
         }),
-      ).resolves.toBeUndefined();
+      ).resolves.toBe("private");
+    } finally {
+      await fixture.close();
+    }
+  });
 
-      // A legacy row whose visibility was derived from the id prefix has no
-      // confirmation timestamp and must read as unconfirmed.
+  it("migrates historical Slack public visibility guesses to private", async () => {
+    const fixture = await createLocalJuniorSqlFixture();
+
+    try {
+      await migrateSchema(fixture.sql, [migrations[0]]);
       await fixture.sql.execute(
         `
 INSERT INTO junior_destinations (
@@ -274,7 +291,7 @@ INSERT INTO junior_destinations (
 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 `,
         [
-          "legacy-destination",
+          "historical-public-destination",
           "slack",
           "T999",
           "C_LEGACY",
@@ -284,13 +301,17 @@ INSERT INTO junior_destinations (
           new Date(1_000).toISOString(),
         ],
       );
+
+      const store = createSqlStore(fixture.sql);
+      await store.migrate();
+
       await expect(
         store.getDestinationVisibility({
           provider: "slack",
           providerTenantId: "T999",
           providerDestinationId: "C_LEGACY",
         }),
-      ).resolves.toBeUndefined();
+      ).resolves.toBe("private");
     } finally {
       await fixture.close();
     }

--- a/packages/junior/tests/component/conversation-sql-store.test.ts
+++ b/packages/junior/tests/component/conversation-sql-store.test.ts
@@ -56,7 +56,7 @@ describe("conversation SQL store", () => {
         fixture.sql.query(
           "SELECT id FROM junior_schema_migrations ORDER BY id ASC",
         ),
-      ).resolves.toHaveLength(1);
+      ).resolves.toHaveLength(2);
     } finally {
       await fixture.close();
     }
@@ -175,6 +175,122 @@ describe("conversation SQL store", () => {
           requesterTenant: "T123",
         },
       ]);
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  it("persists visibility only from source-confirmed signals and converges on newer signals", async () => {
+    const fixture = await createLocalJuniorSqlFixture();
+
+    try {
+      const store = createSqlStore(fixture.sql);
+      await store.migrate();
+      const destination = inboundMessage("visibility").destination;
+
+      // Slack reports this C-prefixed channel private (channel_type: group).
+      await store.recordActivity({
+        conversationId: CONVERSATION_ID,
+        destination,
+        visibility: "private",
+        nowMs: 1_000,
+      });
+      await expect(
+        store.get({ conversationId: CONVERSATION_ID }),
+      ).resolves.toMatchObject({ visibility: "private" });
+      await expect(
+        store.getDestinationVisibility({
+          provider: "slack",
+          providerTenantId: "T123",
+          providerDestinationId: "C123",
+        }),
+      ).resolves.toBe("private");
+
+      // A signal-less write must not clobber the confirmed value.
+      await store.recordActivity({
+        conversationId: CONVERSATION_ID,
+        destination,
+        nowMs: 2_000,
+      });
+      await expect(
+        store.get({ conversationId: CONVERSATION_ID }),
+      ).resolves.toMatchObject({ visibility: "private" });
+
+      // A channel converted private -> public converges on the next signal.
+      await store.recordActivity({
+        conversationId: CONVERSATION_ID,
+        destination,
+        visibility: "public",
+        nowMs: 3_000,
+      });
+      await expect(
+        store.get({ conversationId: CONVERSATION_ID }),
+      ).resolves.toMatchObject({ visibility: "public" });
+      await expect(
+        store.getDestinationVisibility({
+          provider: "slack",
+          providerTenantId: "T123",
+          providerDestinationId: "C123",
+        }),
+      ).resolves.toBe("public");
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  it("treats unsigned and legacy prefix-derived destinations as unconfirmed", async () => {
+    const fixture = await createLocalJuniorSqlFixture();
+
+    try {
+      const store = createSqlStore(fixture.sql);
+      await store.migrate();
+
+      // A write without a live source signal stays unconfirmed even though
+      // the channel id is C-prefixed.
+      await store.recordActivity({
+        conversationId: CONVERSATION_ID,
+        destination: inboundMessage("unsigned").destination,
+        nowMs: 1_000,
+      });
+      const conversation = await store.get({
+        conversationId: CONVERSATION_ID,
+      });
+      expect(conversation?.visibility).toBeUndefined();
+      await expect(
+        store.getDestinationVisibility({
+          provider: "slack",
+          providerTenantId: "T123",
+          providerDestinationId: "C123",
+        }),
+      ).resolves.toBeUndefined();
+
+      // A legacy row whose visibility was derived from the id prefix has no
+      // confirmation timestamp and must read as unconfirmed.
+      await fixture.sql.execute(
+        `
+INSERT INTO junior_destinations (
+  id, provider, provider_tenant_id, provider_destination_id,
+  kind, visibility, created_at, updated_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+`,
+        [
+          "legacy-destination",
+          "slack",
+          "T999",
+          "C_LEGACY",
+          "channel",
+          "public",
+          new Date(1_000).toISOString(),
+          new Date(1_000).toISOString(),
+        ],
+      );
+      await expect(
+        store.getDestinationVisibility({
+          provider: "slack",
+          providerTenantId: "T999",
+          providerDestinationId: "C_LEGACY",
+        }),
+      ).resolves.toBeUndefined();
     } finally {
       await fixture.close();
     }

--- a/packages/junior/tests/component/memory-plugin-storage.test.ts
+++ b/packages/junior/tests/component/memory-plugin-storage.test.ts
@@ -145,6 +145,8 @@ WHERE table_name = 'junior_memory_memories'
         channelId: "C123",
         messageTs: "1718800000.000000",
         threadTs: "1718800000.000000",
+
+        type: "priv",
       });
       const store = createMemoryStore(fixture.sql.db() as unknown as MemoryDb, {
         conversationId,

--- a/packages/junior/tests/component/resource-events/resource-events.test.ts
+++ b/packages/junior/tests/component/resource-events/resource-events.test.ts
@@ -35,6 +35,7 @@ function createRecordingStateAdapter() {
         token: `lock:${threadId}`,
         expiresAt: Date.now() + 10_000,
       }),
+      extendLock: async () => true,
       releaseLock: async () => {},
     } as unknown as StateAdapter,
     set,
@@ -271,6 +272,10 @@ describe("resource event subscriptions", () => {
         busySubscriptionId && key.endsWith(`:${busySubscriptionId}`)
           ? undefined
           : await baseState.acquireLock(key, ttlMs ?? 10_000),
+      extendLock: async (
+        lock: Parameters<StateAdapter["extendLock"]>[0],
+        ttlMs: number,
+      ) => await baseState.extendLock(lock, ttlMs),
       releaseLock: async (
         lock: Awaited<ReturnType<StateAdapter["acquireLock"]>>,
       ) => {

--- a/packages/junior/tests/component/runtime/agent-continue-runner.test.ts
+++ b/packages/junior/tests/component/runtime/agent-continue-runner.test.ts
@@ -12,6 +12,7 @@ const SLACK_SOURCE = createSlackSource({
   teamId: SLACK_DESTINATION.teamId,
   channelId: SLACK_DESTINATION.channelId,
   threadTs: "1712345.0005",
+  type: "priv",
 });
 
 const ORIGINAL_ENV = vi.hoisted(() => {

--- a/packages/junior/tests/component/runtime/agent-continue-runner.test.ts
+++ b/packages/junior/tests/component/runtime/agent-continue-runner.test.ts
@@ -295,6 +295,9 @@ describe("agent continuation runner callbacks", () => {
     const { continueSlackAgentRun } =
       await import("@/chat/runtime/agent-continue-runner");
 
+    // A mismatched stored requester must never throw out of the continue
+    // callback (issue #727: a throw NACKs the queue delivery and wedges the
+    // conversation); it terminally fails the session instead.
     await expect(
       continueSlackAgentRun(
         {
@@ -305,16 +308,20 @@ describe("agent continuation runner callbacks", () => {
         },
         {
           resumeTurn: async (args) => {
-            await args.beforeStart?.();
-            throw new Error("continuation should not prepare");
+            const prepared = await args.beforeStart?.();
+            if (prepared !== false) {
+              throw new Error("Expected continuation preparation to fail");
+            }
+            return true;
           },
         },
       ),
-    ).rejects.toThrow("Stored Slack requester did not match resume actor");
+    ).resolves.toBe(true);
     await expect(
       getAgentTurnSessionRecord(conversationId, sessionId),
     ).resolves.toMatchObject({
       state: "failed",
+      errorMessage: "Stored Slack requester missing for continuation",
     });
   });
 });

--- a/packages/junior/tests/component/runtime/respond-error-path.test.ts
+++ b/packages/junior/tests/component/runtime/respond-error-path.test.ts
@@ -52,7 +52,10 @@ describe("generateAssistantReply error path", () => {
       },
     });
 
-    expect(reply.text).toContain("Error: discover failed");
+    // Raw exception text stays in diagnostics; it is never reply text.
+    expect(reply.text).toBe("");
+    expect(reply.diagnostics.errorMessage).toBe("discover failed");
+    expect(reply.diagnostics.assistantMessageCount).toBe(0);
     expect(reply.sandboxId).toBe("sb-123");
     expect(reply.sandboxDependencyProfileHash).toBe("hash-abc");
     expect(reply.diagnostics.outcome).toBe("provider_error");

--- a/packages/junior/tests/component/runtime/respond-error-path.test.ts
+++ b/packages/junior/tests/component/runtime/respond-error-path.test.ts
@@ -31,6 +31,7 @@ const SLACK_DESTINATION = {
 const SLACK_SOURCE = createSlackSource({
   teamId: SLACK_DESTINATION.teamId,
   channelId: SLACK_DESTINATION.channelId,
+  type: "priv",
 });
 
 describe("generateAssistantReply error path", () => {

--- a/packages/junior/tests/component/services/turn-session-record.test.ts
+++ b/packages/junior/tests/component/services/turn-session-record.test.ts
@@ -17,6 +17,7 @@ const SLACK_SOURCE = createSlackSource({
   teamId: "T123",
   channelId: "C123",
   threadTs: "1700000000.001",
+  type: "priv",
 }) satisfies Source;
 
 function userMessage(text: string): PiMessage {

--- a/packages/junior/tests/component/services/turn-session-record.test.ts
+++ b/packages/junior/tests/component/services/turn-session-record.test.ts
@@ -30,6 +30,7 @@ function userMessage(text: string): PiMessage {
 function failingConversationStore(): ConversationStore {
   return {
     get: vi.fn(),
+    getDestinationVisibility: vi.fn(async () => undefined),
     recordActivity: vi.fn(async () => {
       throw new Error("conversation metadata unavailable");
     }),

--- a/packages/junior/tests/component/task-execution/conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/conversation-work.test.ts
@@ -17,7 +17,7 @@ import {
   getConversationWorkState,
   listActiveConversationIds,
   listConversationsByActivity,
-  markConversationMessagesInjected,
+  ackMessages,
   recordConversationActivity,
   requestConversationContinuation,
   requestConversationWork,
@@ -554,7 +554,7 @@ describe("conversation work execution", () => {
       queue,
       run: async (context) => {
         runs += 1;
-        await context.drainMailbox(async () => {});
+        await context.attempt.drain(async () => {});
         entered.resolve();
         await finish.promise;
         return { status: "completed" };
@@ -594,7 +594,7 @@ describe("conversation work execution", () => {
       nowMs: () => currentNowMs,
       queue,
       run: async (context) => {
-        await context.drainMailbox(async () => {});
+        await context.attempt.drain(async () => {});
         entered.resolve();
         await finish.promise;
         return { status: "completed" };
@@ -709,7 +709,7 @@ describe("conversation work execution", () => {
         nowMs: () => currentNowMs,
         queue,
         run: async (context) => {
-          await context.drainMailbox(async () => {});
+          await context.attempt.drain(async () => {});
           currentNowMs = 2_000;
           await requestConversationWork({
             conversationId: context.conversationId,
@@ -745,7 +745,7 @@ describe("conversation work execution", () => {
         nowMs: () => currentNowMs,
         queue,
         run: async (context) => {
-          await context.drainMailbox(async () => {});
+          await context.attempt.drain(async () => {});
           currentNowMs = 2_000;
           await requestConversationWork({
             conversationId: context.conversationId,
@@ -791,7 +791,7 @@ describe("conversation work execution", () => {
         nowMs: () => currentNowMs,
         queue,
         run: async (context) => {
-          await context.drainMailbox(async () => {});
+          await context.attempt.drain(async () => {});
           currentNowMs = 2_000;
           await requestConversationWork({
             conversationId: context.conversationId,
@@ -916,7 +916,7 @@ describe("conversation work execution", () => {
         nowMs: () => currentNowMs,
         queue,
         run: async (context) => {
-          await context.drainMailbox(async () => {});
+          await context.attempt.drain(async () => {});
           currentNowMs = 2_000;
           await scheduleAgentContinue(
             {
@@ -947,13 +947,13 @@ describe("conversation work execution", () => {
     ]);
   });
 
-  it("consumes a message that exceeds the delivery attempt limit as poison work", async () => {
+  it("dead-letters a message that exceeds the delivery attempt limit", async () => {
     const queue = createConversationWorkQueueTestAdapter();
     let currentNowMs = 1_000;
     await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
 
-    // Deterministic pre-input-commit failure: the runner returns without
-    // durably handling the offered message, which requeued forever before
+    // Deterministic pre-ack failure: the runner returns without durably
+    // handling the attempted message, which requeued forever before
     // attempts were bounded.
     const runSlice = () =>
       processConversationWork(conversationQueueMessage(), {
@@ -1078,7 +1078,7 @@ describe("conversation work execution", () => {
       processConversationWork(conversationQueueMessage(), {
         queue,
         run: async (context) => {
-          injected.push(await context.drainMailbox(async () => {}));
+          injected.push(await context.attempt.drain(async () => {}));
           return { status: "completed" };
         },
       }),
@@ -1111,7 +1111,7 @@ describe("conversation work execution", () => {
       processConversationWork(conversationQueueMessage(), {
         queue,
         run: async (context) => {
-          await context.drainMailbox(async (messages) => {
+          await context.attempt.drain(async (messages) => {
             injected.push(messages.map((message) => message.inboundMessageId));
             return messages
               .filter((message) => message.inboundMessageId === "m1")
@@ -1132,7 +1132,7 @@ describe("conversation work execution", () => {
     ]);
   });
 
-  it("rejects mailbox acknowledgements outside the offered pending set", async () => {
+  it("rejects mailbox acknowledgements outside the pending set", async () => {
     const queue = createConversationWorkQueueTestAdapter();
     await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
 
@@ -1142,7 +1142,7 @@ describe("conversation work execution", () => {
         queue,
         run: async (context) => {
           try {
-            await context.drainMailbox(async () => ["different-message"]);
+            await context.attempt.drain(async () => ["different-message"]);
           } catch (error) {
             drainError = error;
             throw error;
@@ -1183,7 +1183,7 @@ describe("conversation work execution", () => {
         queue,
         state: observed.state,
         run: async (context) => {
-          const drain = context.drainMailbox(async () => {
+          const drain = context.attempt.drain(async () => {
             expect(observed.isHeld()).toBe(false);
             injectionStarted.resolve();
             await finishInjection.promise;
@@ -1232,7 +1232,7 @@ describe("conversation work execution", () => {
       checkInIntervalMs: 15_000,
       queue,
       run: async (context) => {
-        await context.drainMailbox(async () => {});
+        await context.attempt.drain(async () => {});
         entered.resolve();
         await finish.promise;
         return { status: "completed" };
@@ -1264,7 +1264,6 @@ describe("conversation work execution", () => {
     const queue = createConversationWorkQueueTestAdapter();
     await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
     const entered = deferred<{
-      leaseToken: string;
       shouldYield: () => boolean;
     }>();
     const finish = deferred<void>();
@@ -1273,9 +1272,8 @@ describe("conversation work execution", () => {
       checkInIntervalMs: 15_000,
       queue,
       run: async (context) => {
-        await context.drainMailbox(async () => {});
+        await context.attempt.drain(async () => {});
         entered.resolve({
-          leaseToken: context.leaseToken,
           shouldYield: context.shouldYield,
         });
         await finish.promise;
@@ -1283,10 +1281,15 @@ describe("conversation work execution", () => {
       },
     });
     const runningContext = await entered.promise;
+    const leased = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+    });
+    const leaseToken = leased?.execution.lease?.token;
+    expect(leaseToken).toBeDefined();
 
     await releaseConversationWork({
       conversationId: CONVERSATION_ID,
-      leaseToken: runningContext.leaseToken,
+      leaseToken: leaseToken!,
       nowMs: 2_000,
     });
     await vi.advanceTimersByTimeAsync(15_000);
@@ -1333,7 +1336,7 @@ describe("conversation work execution", () => {
     if (lease.status !== "acquired") {
       return;
     }
-    await markConversationMessagesInjected({
+    await ackMessages({
       conversationId: CONVERSATION_ID,
       inboundMessageIds: ["m1"],
       leaseToken: lease.leaseToken,
@@ -1506,7 +1509,7 @@ describe("conversation work execution", () => {
       processConversationWork(conversationQueueMessage(), {
         queue,
         run: async (context) => {
-          const first = await context.drainMailbox(async () => {});
+          const first = await context.attempt.drain(async () => {});
           injected.push(first.map((message) => message.inboundMessageId));
           await appendInboundMessage({
             message: inboundMessage("m2", {
@@ -1515,7 +1518,7 @@ describe("conversation work execution", () => {
             }),
             nowMs: 2_100,
           });
-          const second = await context.drainMailbox(async () => {});
+          const second = await context.attempt.drain(async () => {});
           injected.push(second.map((message) => message.inboundMessageId));
           return { status: "completed" };
         },
@@ -1533,7 +1536,7 @@ describe("conversation work execution", () => {
       processConversationWork(conversationQueueMessage(), {
         queue,
         run: async (context) => {
-          await context.drainMailbox(async () => {});
+          await context.attempt.drain(async () => {});
           await appendInboundMessage({
             message: inboundMessage("m2", {
               createdAtMs: 2_000,
@@ -1541,7 +1544,7 @@ describe("conversation work execution", () => {
             }),
             nowMs: 2_100,
           });
-          await context.drainMailbox(async () => {});
+          await context.attempt.drain(async () => {});
           return { status: "completed" };
         },
       }),
@@ -1564,7 +1567,7 @@ describe("conversation work execution", () => {
         nowMs: () => currentNowMs,
         queue,
         run: async (context) => {
-          await context.drainMailbox(async () => {});
+          await context.attempt.drain(async () => {});
           currentNowMs = 2_100;
           await appendInboundMessage({
             message: inboundMessage("m2", {
@@ -1595,7 +1598,7 @@ describe("conversation work execution", () => {
         nowMs: () => currentNowMs,
         queue,
         run: async (context) => {
-          await context.drainMailbox(async () => {});
+          await context.attempt.drain(async () => {});
           currentNowMs = 242_000;
           expect(context.shouldYield()).toBe(true);
           return { status: "yielded" };
@@ -1638,7 +1641,7 @@ describe("conversation work execution", () => {
       drainConversationMailbox({
         conversationId: CONVERSATION_ID,
         leaseToken: "wrong-token",
-        inject: async () => {},
+        handle: async () => {},
         nowMs: 3_000,
       }),
     ).rejects.toThrow("lease is not held");
@@ -1650,7 +1653,7 @@ describe("conversation work execution", () => {
       }),
     ).resolves.toBe("lost_lease");
     await expect(
-      markConversationMessagesInjected({
+      ackMessages({
         conversationId: CONVERSATION_ID,
         inboundMessageIds: ["m1"],
         leaseToken: "wrong-token",
@@ -1818,7 +1821,7 @@ describe("conversation work execution", () => {
       processConversationQueueMessage(conversationQueueMessage(), {
         queue,
         run: async (context) => {
-          const messages = await context.drainMailbox(async () => {});
+          const messages = await context.attempt.drain(async () => {});
           injected.push(...messages.map((message) => message.inboundMessageId));
           return { status: "completed" };
         },

--- a/packages/junior/tests/component/task-execution/conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/conversation-work.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { StateAdapter } from "chat";
 import { scheduleAgentContinue } from "@/chat/services/agent-continue";
 import { recoverConversationWork } from "@/chat/task-execution/heartbeat";
 import { runHeartbeat } from "@/chat/agent-dispatch/heartbeat";
@@ -10,6 +11,7 @@ import {
   CONVERSATION_BY_ACTIVITY_INDEX_KEY,
   completeConversationWork,
   CONVERSATION_WORK_LEASE_TTL_MS,
+  CONVERSATION_WORK_MAX_DELIVERY_ATTEMPTS,
   countPendingConversationMessages,
   drainConversationMailbox,
   getConversationWorkState,
@@ -61,6 +63,7 @@ const CONVERSATION_WORK_STATE_KEY = `junior:conversation:${CONVERSATION_ID}`;
 function failingMetadataStore(): ConversationStore {
   return {
     get: vi.fn(async () => undefined),
+    getDestinationVisibility: vi.fn(async () => undefined),
     recordActivity: vi.fn(),
     recordExecution: vi.fn(async () => {
       throw new Error("metadata unavailable");
@@ -72,6 +75,7 @@ function failingMetadataStore(): ConversationStore {
 function metadataEventsStore(events: string[]): ConversationStore {
   return {
     get: vi.fn(async () => undefined),
+    getDestinationVisibility: vi.fn(async () => undefined),
     recordActivity: vi.fn(),
     recordExecution: vi.fn(async () => {
       events.push("metadata");
@@ -229,6 +233,46 @@ describe("conversation work execution", () => {
       },
     ]);
     expect(queue.sentRecords()).toEqual(queue.sendAttempts());
+  });
+
+  it("upgrades a still-pending twin payload that adds file attachments", async () => {
+    await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
+
+    const twinWithFiles = inboundMessage("m1", {
+      receivedAtMs: 2_000,
+      input: {
+        text: "message m1",
+        authorId: "U123",
+        attachments: [{ id: "F123" }],
+        metadata: { platform: "slack", hasFiles: true },
+      },
+    });
+    await expect(
+      appendInboundMessage({ message: twinWithFiles, nowMs: 2_000 }),
+    ).resolves.toEqual({ status: "duplicate" });
+
+    let work = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+    });
+    expect(work?.messages).toEqual([
+      expect.objectContaining({
+        inboundMessageId: "m1",
+        receivedAtMs: 1_100,
+        input: expect.objectContaining({
+          attachments: [{ id: "F123" }],
+          metadata: { platform: "slack", hasFiles: true },
+        }),
+      }),
+    ]);
+
+    // A later attachment-less twin must not downgrade the stored payload.
+    await expect(
+      appendInboundMessage({ message: inboundMessage("m1"), nowMs: 3_000 }),
+    ).resolves.toEqual({ status: "duplicate" });
+    work = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+    });
+    expect(work?.messages[0]?.input.attachments).toEqual([{ id: "F123" }]);
   });
 
   it("retries transient conversation work index lock contention", async () => {
@@ -828,7 +872,7 @@ describe("conversation work execution", () => {
     ]);
   });
 
-  it("nudges failed worker runs before releasing runnable work", async () => {
+  it("acknowledges failed worker runs after one nudge instead of a queue retry", async () => {
     const queue = createConversationWorkQueueTestAdapter();
     let currentNowMs = 1_000;
     await requestConversationWork({
@@ -846,7 +890,7 @@ describe("conversation work execution", () => {
           throw new Error("runner failed");
         },
       }),
-    ).rejects.toThrow("runner failed");
+    ).resolves.toEqual({ status: "failed" });
 
     const state = await getConversationWorkState({
       conversationId: CONVERSATION_ID,
@@ -886,7 +930,7 @@ describe("conversation work execution", () => {
           throw new Error("runner failed");
         },
       }),
-    ).rejects.toThrow("runner failed");
+    ).resolves.toEqual({ status: "failed" });
 
     const state = await getConversationWorkState({
       conversationId: CONVERSATION_ID,
@@ -901,6 +945,96 @@ describe("conversation work execution", () => {
         idempotencyKey: `agent-continue:${CONVERSATION_ID}:turn-1:2:2000`,
       },
     ]);
+  });
+
+  it("consumes a message that exceeds the delivery attempt limit as poison work", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    let currentNowMs = 1_000;
+    await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
+
+    // Deterministic pre-input-commit failure: the runner returns without
+    // durably handling the offered message, which requeued forever before
+    // attempts were bounded.
+    const runSlice = () =>
+      processConversationWork(conversationQueueMessage(), {
+        nowMs: () => currentNowMs,
+        queue,
+        run: async () => ({ status: "completed" }),
+      });
+
+    for (
+      let attempt = 1;
+      attempt < CONVERSATION_WORK_MAX_DELIVERY_ATTEMPTS;
+      attempt += 1
+    ) {
+      currentNowMs = attempt * 1_000;
+      await expect(runSlice()).resolves.toEqual({
+        status: "pending_requeued",
+      });
+      const state = await getConversationWorkState({
+        conversationId: CONVERSATION_ID,
+      });
+      expect(state?.messages).toEqual([
+        expect.objectContaining({
+          inboundMessageId: "m1",
+          attemptCount: attempt,
+        }),
+      ]);
+    }
+
+    queue.clearSentRecords();
+    currentNowMs = 9_000;
+    await expect(runSlice()).resolves.toEqual({ status: "failed" });
+
+    const state = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+    });
+    expect(state?.messages).toEqual([]);
+    expect(state?.execution.inboundMessageIds).toEqual(["m1"]);
+    expect(state?.execution.status).toBe("failed");
+    expect(state?.needsRun).toBe(false);
+    expect(state?.lease).toBeUndefined();
+    expect(queue.sentRecords()).toEqual([]);
+    await expect(listActiveConversationIds()).resolves.toEqual([]);
+
+    // Source retries of the consumed message stay duplicates.
+    await expect(
+      appendInboundMessage({ message: inboundMessage("m1"), nowMs: 10_000 }),
+    ).resolves.toEqual({ status: "duplicate" });
+    await expect(
+      getConversationWorkState({ conversationId: CONVERSATION_ID }),
+    ).resolves.toMatchObject({ messages: [] });
+  });
+
+  it("acknowledges deliveries for conversation records that fail validation as rejected", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    const state = getStateAdapter();
+    await state.connect();
+    await state.set(CONVERSATION_WORK_STATE_KEY, {
+      schemaVersion: 1,
+      conversationId: CONVERSATION_ID,
+      createdAtMs: 1_000,
+      destination: SLACK_DESTINATION,
+      execution: { status: "bogus" },
+      lastActivityAtMs: 1_000,
+      updatedAtMs: 1_000,
+    });
+    const run = vi.fn(async () => ({ status: "completed" as const }));
+
+    await expect(
+      processConversationWork(conversationQueueMessage(), {
+        queue,
+        run,
+        state,
+      }),
+    ).rejects.toMatchObject({
+      name: "ConversationQueueMessageRejectedError",
+      reason: "invalid_record",
+      conversationId: CONVERSATION_ID,
+    });
+
+    expect(run).not.toHaveBeenCalled();
+    expect(queue.sendAttempts()).toEqual([]);
   });
 
   it("releases and requeues runnable work when the runner reports lost lease", async () => {
@@ -1002,15 +1136,23 @@ describe("conversation work execution", () => {
     const queue = createConversationWorkQueueTestAdapter();
     await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
 
+    let drainError: unknown;
     await expect(
       processConversationWork(conversationQueueMessage(), {
         queue,
         run: async (context) => {
-          await context.drainMailbox(async () => ["different-message"]);
+          try {
+            await context.drainMailbox(async () => ["different-message"]);
+          } catch (error) {
+            drainError = error;
+            throw error;
+          }
           return { status: "completed" };
         },
       }),
-    ).rejects.toThrow(
+    ).resolves.toEqual({ status: "failed" });
+
+    expect(String(drainError)).toContain(
       "Conversation mailbox acknowledgement is not pending for",
     );
 
@@ -1245,6 +1387,95 @@ describe("conversation work execution", () => {
     expect(queue.sentRecords().map((send) => send.idempotencyKey)).toEqual([
       `heartbeat:pending:${CONVERSATION_ID}:62000`,
       `heartbeat:pending:${CONVERSATION_ID}:122001`,
+    ]);
+  });
+
+  it("removes unreadable conversation records from the active index and repairs the rest", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    const state = getStateAdapter();
+    await state.connect();
+    const unreadableConversationId = "slack:C123:9999.0001";
+
+    await requestConversationWork({
+      conversationId: unreadableConversationId,
+      destination: SLACK_DESTINATION,
+      nowMs: 500,
+      state,
+    });
+    await state.set(`junior:conversation:${unreadableConversationId}`, {
+      schemaVersion: 1,
+      conversationId: unreadableConversationId,
+      createdAtMs: 500,
+      destination: SLACK_DESTINATION,
+      execution: { status: "bogus" },
+      lastActivityAtMs: 500,
+      updatedAtMs: 500,
+    });
+    await appendInboundMessage({
+      message: inboundMessage("m1"),
+      nowMs: 1_000,
+      state,
+    });
+
+    await expect(
+      recoverConversationWork({ nowMs: 62_000, queue, state }),
+    ).resolves.toEqual({ expiredLeaseCount: 0, pendingCount: 1 });
+
+    expect(queue.sentRecords()).toEqual([
+      expect.objectContaining({ conversationId: CONVERSATION_ID }),
+    ]);
+    const activeIds = await listActiveConversationIds({ state });
+    expect(activeIds).not.toContain(unreadableConversationId);
+    expect(activeIds).toContain(CONVERSATION_ID);
+  });
+
+  it("refuses a stale conversation write after the mutation lock is lost", async () => {
+    const state = getStateAdapter();
+    await state.connect();
+    await appendInboundMessage({
+      message: inboundMessage("m1"),
+      nowMs: 1_000,
+      state,
+    });
+
+    let stealLockOnNextRead = false;
+    const proxied = new Proxy(state, {
+      get(target, prop, receiver) {
+        if (prop === "get") {
+          return async (key: string) => {
+            const value = await target.get(key);
+            if (stealLockOnNextRead && key === CONVERSATION_WORK_STATE_KEY) {
+              stealLockOnNextRead = false;
+              await target.forceReleaseLock(
+                `junior:conversation:mutation:${CONVERSATION_ID}`,
+              );
+            }
+            return value;
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as StateAdapter;
+
+    stealLockOnNextRead = true;
+    await expect(
+      appendInboundMessage({
+        message: inboundMessage("m2", {
+          createdAtMs: 2_000,
+          receivedAtMs: 2_100,
+        }),
+        nowMs: 2_000,
+        state: proxied,
+      }),
+    ).rejects.toThrow("Conversation mutation lock was lost before write");
+
+    const work = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+      state,
+    });
+    expect(work?.messages.map((message) => message.inboundMessageId)).toEqual([
+      "m1",
     ]);
   });
 

--- a/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
@@ -1062,6 +1062,51 @@ describe("Slack conversation work execution", () => {
     });
   });
 
+  it("exposes mailbox retry state to the runtime failure path", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    const state = getStateAdapter();
+    await state.connect();
+    const slackAdapter = createSlackAdapterFixture();
+
+    await handleSlackWebhookAndFlush({
+      request: slackWebhookRequest(
+        slackEnvelope({
+          text: `<@${SLACK_BOT_USER_ID}> first`,
+        }),
+      ),
+      services: {
+        getSlackAdapter: () => slackAdapter,
+        queue,
+        runtime: createNoopSlackWebhookRuntime(),
+        state,
+      },
+    });
+
+    const observed: Array<boolean | undefined> = [];
+    await expect(
+      processNextQueuedSlackWork({
+        getSlackAdapter: () => slackAdapter,
+        queue,
+        runtime: {
+          handleNewMention: async (_thread, _message, hooks) => {
+            // Before input commit a failure leaves the record pending, so the
+            // mailbox retries and the visible failure reply is suppressed.
+            observed.push(hooks.willRetryOnFailure?.());
+            await hooks.onInputCommitted?.();
+            // After input commit no redelivery happens: the failure is final.
+            observed.push(hooks.willRetryOnFailure?.());
+          },
+          handleSubscribedMessage: async () => {
+            throw new Error("unexpected subscribed route");
+          },
+        },
+        state,
+      }),
+    ).resolves.toEqual({ status: "completed" });
+
+    expect(observed).toEqual([true, false]);
+  });
+
   it("keeps Slack mailbox records pending when input commit fails", async () => {
     const queue = createConversationWorkQueueTestAdapter();
     const state = getStateAdapter();

--- a/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
@@ -1096,7 +1096,7 @@ describe("Slack conversation work execution", () => {
         },
         state,
       }),
-    ).rejects.toThrow("runtime failed before input commit");
+    ).resolves.toEqual({ status: "failed" });
 
     const work = await getConversationWorkState({
       conversationId: CONVERSATION_ID,
@@ -1105,6 +1105,7 @@ describe("Slack conversation work execution", () => {
     expect(work?.lease).toBeUndefined();
     expect(work ? countPendingConversationMessages(work) : 0).toBe(1);
     expect(work?.messages[0]?.injectedAtMs).toBeUndefined();
+    expect(work?.messages[0]?.attemptCount).toBe(1);
   });
 
   it("requeues Slack mailbox records when the runtime returns without input commit", async () => {

--- a/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
@@ -10,9 +10,10 @@ import { recoverConversationWork } from "@/chat/task-execution/heartbeat";
 import {
   appendInboundMessage,
   CONVERSATION_WORK_LEASE_TTL_MS,
+  CONVERSATION_WORK_MAX_DELIVERY_ATTEMPTS,
   countPendingConversationMessages,
   getConversationWorkState,
-  markConversationMessagesInjected,
+  ackMessages,
   requestConversationWork,
   startConversationWork,
 } from "@/chat/task-execution/store";
@@ -31,6 +32,11 @@ import {
   upsertAgentTurnSessionRecord,
 } from "@/chat/state/turn-session";
 import { persistThreadStateById } from "@/chat/runtime/thread-state";
+import { createTestChatRuntime } from "../../fixtures/chat-runtime";
+import {
+  getCapturedSlackApiCalls,
+  resetSlackApiMockState,
+} from "../../msw/handlers/slack-api";
 import {
   CONVERSATION_ID,
   SLACK_DESTINATION,
@@ -90,6 +96,7 @@ describe("Slack conversation work execution", () => {
   });
 
   afterEach(async () => {
+    resetSlackApiMockState();
     await disconnectStateAdapter();
   });
 
@@ -182,7 +189,7 @@ describe("Slack conversation work execution", () => {
             throw new Error("unexpected mention route");
           },
           handleSubscribedMessage: async (_thread, message, hooks) => {
-            await hooks.onInputCommitted?.();
+            await hooks.ack?.();
             calls.push(message);
           },
         },
@@ -289,7 +296,7 @@ describe("Slack conversation work execution", () => {
         queue,
         runtime: {
           handleNewMention: async (thread, message, hooks) => {
-            await hooks.onInputCommitted?.();
+            await hooks.ack?.();
             calls.push({ thread, message });
           },
           handleSubscribedMessage: async () => {
@@ -351,7 +358,7 @@ describe("Slack conversation work execution", () => {
 
     const runtime: SlackWorkerOptions["runtime"] = {
       handleNewMention: async (thread, message, hooks) => {
-        await hooks.onInputCommitted?.();
+        await hooks.ack?.();
         calls.push({
           destination: hooks.destination,
           thread,
@@ -418,7 +425,7 @@ describe("Slack conversation work execution", () => {
     const runtime: SlackWorkerOptions["runtime"] = {
       handleNewMention: async (_thread, message, hooks) => {
         capturedMessage = message;
-        await hooks.onInputCommitted?.();
+        await hooks.ack?.();
       },
       handleSubscribedMessage: async () => {
         throw new Error("unexpected subscribed route");
@@ -507,7 +514,7 @@ describe("Slack conversation work execution", () => {
 
     const runtime: SlackWorkerOptions["runtime"] = {
       handleNewMention: async (thread, message, hooks) => {
-        await hooks.onInputCommitted?.();
+        await hooks.ack?.();
         subscribedValues.push(await thread.isSubscribed());
         calls.push({
           thread,
@@ -573,7 +580,7 @@ describe("Slack conversation work execution", () => {
         resumeAwaitingContinuation,
         runtime: {
           handleNewMention: async (_thread, message, hooks) => {
-            await hooks.onInputCommitted?.();
+            await hooks.ack?.();
             calls.push(message.text);
           },
           handleSubscribedMessage: async () => {
@@ -626,7 +633,7 @@ describe("Slack conversation work execution", () => {
         resumeAwaitingContinuation,
         runtime: {
           handleNewMention: async (_thread, message, hooks) => {
-            await hooks.onInputCommitted?.();
+            await hooks.ack?.();
             calls.push(message.text);
           },
           handleSubscribedMessage: async () => {
@@ -673,7 +680,7 @@ describe("Slack conversation work execution", () => {
     const injected: string[][] = [];
     const runtime: SlackWorkerOptions["runtime"] = {
       handleNewMention: async (_thread, _message, hooks) => {
-        await hooks.onInputCommitted?.();
+        await hooks.ack?.();
         await handleSlackWebhookAndFlush({
           request: slackWebhookRequest(
             slackEnvelope({
@@ -751,7 +758,7 @@ describe("Slack conversation work execution", () => {
     const observed: Array<Array<{ activeRequest: boolean; id: string }>> = [];
     const runtime: SlackWorkerOptions["runtime"] = {
       handleNewMention: async (_thread, _message, hooks) => {
-        await hooks.onInputCommitted?.();
+        await hooks.ack?.();
         const followUp = new Message({
           id: "1712345.1002",
           threadId: conversationId,
@@ -856,7 +863,7 @@ describe("Slack conversation work execution", () => {
     });
     const inboundMessageIds =
       work?.messages.map((message) => message.inboundMessageId) ?? [];
-    await markConversationMessagesInjected({
+    await ackMessages({
       conversationId: CONVERSATION_ID,
       inboundMessageIds,
       leaseToken: lease.leaseToken,
@@ -1128,7 +1135,7 @@ describe("Slack conversation work execution", () => {
     });
   });
 
-  it("exposes mailbox retry state to the runtime failure path", async () => {
+  it("exposes final attempt state to the runtime failure path", async () => {
     const queue = createConversationWorkQueueTestAdapter();
     const state = getStateAdapter();
     await state.connect();
@@ -1155,12 +1162,9 @@ describe("Slack conversation work execution", () => {
         queue,
         runtime: {
           handleNewMention: async (_thread, _message, hooks) => {
-            // Before input commit a failure leaves the record pending, so the
-            // mailbox retries and the visible failure reply is suppressed.
-            observed.push(hooks.willRetryOnFailure?.());
-            await hooks.onInputCommitted?.();
-            // After input commit no redelivery happens: the failure is final.
-            observed.push(hooks.willRetryOnFailure?.());
+            observed.push(hooks.isFinalAttempt);
+            await hooks.ack?.();
+            observed.push(hooks.isFinalAttempt);
           },
           handleSubscribedMessage: async () => {
             throw new Error("unexpected subscribed route");
@@ -1170,10 +1174,10 @@ describe("Slack conversation work execution", () => {
       }),
     ).resolves.toEqual({ status: "completed" });
 
-    expect(observed).toEqual([true, false]);
+    expect(observed).toEqual([false, false]);
   });
 
-  it("keeps Slack mailbox records pending when input commit fails", async () => {
+  it("keeps Slack mailbox records pending when ack fails", async () => {
     const queue = createConversationWorkQueueTestAdapter();
     const state = getStateAdapter();
     await state.connect();
@@ -1199,7 +1203,7 @@ describe("Slack conversation work execution", () => {
         queue,
         runtime: {
           handleNewMention: async () => {
-            throw new Error("runtime failed before input commit");
+            throw new Error("runtime failed before ack");
           },
           handleSubscribedMessage: async () => {
             throw new Error("unexpected subscribed route");
@@ -1217,6 +1221,143 @@ describe("Slack conversation work execution", () => {
     expect(work ? countPendingConversationMessages(work) : 0).toBe(1);
     expect(work?.messages[0]?.injectedAtMs).toBeUndefined();
     expect(work?.messages[0]?.attemptCount).toBe(1);
+  });
+
+  it("marks the terminal Slack delivery attempt before dead-lettering", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    const state = getStateAdapter();
+    await state.connect();
+    const slackAdapter = createSlackAdapterFixture();
+
+    await handleSlackWebhookAndFlush({
+      request: slackWebhookRequest(
+        slackEnvelope({
+          text: `<@${SLACK_BOT_USER_ID}> first`,
+        }),
+      ),
+      services: {
+        getSlackAdapter: () => slackAdapter,
+        queue,
+        runtime: createNoopSlackWebhookRuntime(),
+        state,
+      },
+    });
+
+    const observed: boolean[] = [];
+    const runtime: SlackWorkerOptions["runtime"] = {
+      handleNewMention: async (_thread, _message, hooks) => {
+        observed.push(hooks.isFinalAttempt === true);
+        throw new Error("runtime failed before ack");
+      },
+      handleSubscribedMessage: async () => {
+        throw new Error("unexpected subscribed route");
+      },
+    };
+
+    for (
+      let attempt = 1;
+      attempt < CONVERSATION_WORK_MAX_DELIVERY_ATTEMPTS;
+      attempt += 1
+    ) {
+      await expect(
+        processNextQueuedSlackWork({
+          getSlackAdapter: () => slackAdapter,
+          queue,
+          runtime,
+          state,
+        }),
+      ).resolves.toEqual({ status: "failed" });
+      const work = await getConversationWorkState({
+        conversationId: CONVERSATION_ID,
+        state,
+      });
+      expect(work?.messages[0]?.attemptCount).toBe(attempt);
+      expect(queue.hasQueuedMessages()).toBe(true);
+    }
+
+    await expect(
+      processNextQueuedSlackWork({
+        getSlackAdapter: () => slackAdapter,
+        queue,
+        runtime,
+        state,
+      }),
+    ).resolves.toEqual({ status: "failed" });
+
+    expect(observed).toEqual([false, false, false, false, true]);
+    const work = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+      state,
+    });
+    expect(work?.messages).toEqual([]);
+    expect(work?.needsRun).toBe(false);
+    expect(work?.execution.status).toBe("failed");
+  });
+
+  it("posts one fallback reply on the final queued Slack delivery attempt", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    const state = getStateAdapter();
+    await state.connect();
+    const slackAdapter = createSlackAdapterFixture();
+    const { slackRuntime } = createTestChatRuntime({
+      services: {
+        replyExecutor: {
+          generateAssistantReply: async () => {
+            throw new Error("persistent queued failure");
+          },
+        },
+      },
+    });
+
+    await handleSlackWebhookAndFlush({
+      request: slackWebhookRequest(
+        slackEnvelope({
+          text: `<@${SLACK_BOT_USER_ID}> first`,
+        }),
+      ),
+      services: {
+        getSlackAdapter: () => slackAdapter,
+        queue,
+        runtime: createNoopSlackWebhookRuntime(),
+        state,
+      },
+    });
+
+    for (
+      let attempt = 1;
+      attempt < CONVERSATION_WORK_MAX_DELIVERY_ATTEMPTS;
+      attempt += 1
+    ) {
+      await expect(
+        processNextQueuedSlackWork({
+          getSlackAdapter: () => slackAdapter,
+          queue,
+          runtime: slackRuntime,
+          state,
+        }),
+      ).resolves.toEqual({ status: "pending_requeued" });
+      expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([]);
+    }
+
+    await expect(
+      processNextQueuedSlackWork({
+        getSlackAdapter: () => slackAdapter,
+        queue,
+        runtime: slackRuntime,
+        state,
+      }),
+    ).resolves.toEqual({ status: "failed" });
+
+    expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({
+          channel: "C123",
+          text: expect.stringContaining(
+            "I ran into an internal error while processing that.",
+          ),
+        }),
+      }),
+    ]);
   });
 
   it("requeues deferred Slack mailbox records without consuming retry attempts", async () => {
@@ -1277,7 +1418,7 @@ describe("Slack conversation work execution", () => {
     expect(work?.messages[0]?.attemptCount).toBeUndefined();
   });
 
-  it("reports lost lease when input commit loses the mailbox lease", async () => {
+  it("reports lost lease when ack loses the mailbox lease", async () => {
     const queue = createConversationWorkQueueTestAdapter();
     const state = getStateAdapter();
     await state.connect();
@@ -1312,7 +1453,7 @@ describe("Slack conversation work execution", () => {
               queue,
               state,
             });
-            await hooks.onInputCommitted?.();
+            await hooks.ack?.();
           },
           handleSubscribedMessage: async () => {
             throw new Error("unexpected subscribed route");
@@ -1368,7 +1509,7 @@ describe("Slack conversation work execution", () => {
         runtime: {
           handleNewMention: async (_thread, _message, hooks) => {
             currentNowMs = 242_000;
-            await hooks.onInputCommitted?.();
+            await hooks.ack?.();
           },
           handleSubscribedMessage: async () => {
             throw new Error("unexpected subscribed route");
@@ -1416,7 +1557,7 @@ describe("Slack conversation work execution", () => {
         queue,
         runtime: {
           handleNewMention: async (_thread, _message, hooks) => {
-            await hooks.onInputCommitted?.();
+            await hooks.ack?.();
             currentNowMs = 242_000;
             throw new CooperativeTurnYieldError();
           },

--- a/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Message, ThreadImpl, type StateAdapter, type Thread } from "chat";
-import { CooperativeTurnYieldError } from "@/chat/runtime/turn";
+import type { SlackAdapter } from "@chat-adapter/slack";
+import {
+  CooperativeTurnYieldError,
+  TurnInputDeferredError,
+} from "@/chat/runtime/turn";
+import { getSlackClient } from "@/chat/slack/client";
 import { recoverConversationWork } from "@/chat/task-execution/heartbeat";
 import {
   appendInboundMessage,
@@ -955,6 +960,67 @@ describe("Slack conversation work execution", () => {
     });
   });
 
+  it("binds the destination installation token while recovering idle continuations", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    const state = getStateAdapter();
+    await state.connect();
+    const resolveTokenForTeam = vi.fn(
+      async (teamId: string, isEnterpriseInstall?: boolean) => ({
+        botUserId: SLACK_BOT_USER_ID,
+        token: `xoxb-${isEnterpriseInstall ? "enterprise" : teamId}`,
+      }),
+    );
+    const requestContextRun = vi.fn(
+      async (_context: unknown, fn: () => Promise<void>) => await fn(),
+    );
+    const slackAdapter = {
+      botUserId: SLACK_BOT_USER_ID,
+      initialize: vi.fn(async () => {}),
+      requestContext: {
+        run: requestContextRun,
+      },
+      resolveTokenForTeam,
+    } as unknown as SlackAdapter;
+
+    await requestConversationWork({
+      conversationId: CONVERSATION_ID,
+      destination: SLACK_DESTINATION,
+      nowMs: 1_000,
+      state,
+    });
+
+    let observedToken: string | undefined;
+    await expect(
+      processConversationWork(conversationQueueMessage(), {
+        queue,
+        state,
+        run: createSlackConversationWorker({
+          getSlackAdapter: () => slackAdapter,
+          resumeAwaitingContinuation: async () => {
+            observedToken = getSlackClient().token;
+            return true;
+          },
+          runtime: {
+            handleNewMention: async () => {
+              throw new Error("injected messages should not replay");
+            },
+            handleSubscribedMessage: async () => {
+              throw new Error("injected messages should not replay");
+            },
+          },
+          state,
+        }),
+      }),
+    ).resolves.toEqual({ status: "completed" });
+
+    expect(resolveTokenForTeam).toHaveBeenCalledWith("T123", undefined);
+    expect(requestContextRun).toHaveBeenCalledWith(
+      expect.objectContaining({ token: "xoxb-T123" }),
+      expect.any(Function),
+    );
+    expect(observedToken).toBe("xoxb-T123");
+  });
+
   it("terminalizes stale idle continuations skipped by resume startup", async () => {
     const queue = createConversationWorkQueueTestAdapter();
     const state = getStateAdapter();
@@ -1153,7 +1219,7 @@ describe("Slack conversation work execution", () => {
     expect(work?.messages[0]?.attemptCount).toBe(1);
   });
 
-  it("requeues Slack mailbox records when the runtime returns without input commit", async () => {
+  it("requeues deferred Slack mailbox records without consuming retry attempts", async () => {
     const queue = createConversationWorkQueueTestAdapter();
     const state = getStateAdapter();
     await state.connect();
@@ -1183,6 +1249,7 @@ describe("Slack conversation work execution", () => {
         runtime: {
           handleNewMention: async () => {
             handled += 1;
+            throw new TurnInputDeferredError();
           },
           handleSubscribedMessage: async () => {
             throw new Error("unexpected subscribed route");
@@ -1196,7 +1263,7 @@ describe("Slack conversation work execution", () => {
     expect(queue.sentRecords()).toEqual([
       expect.objectContaining({
         conversationId: CONVERSATION_ID,
-        idempotencyKey: `pending:${CONVERSATION_ID}:3000`,
+        idempotencyKey: `deferred:${CONVERSATION_ID}:3000`,
       }),
     ]);
     const work = await getConversationWorkState({
@@ -1207,6 +1274,7 @@ describe("Slack conversation work execution", () => {
     expect(work?.needsRun).toBe(true);
     expect(work ? countPendingConversationMessages(work) : 0).toBe(1);
     expect(work?.messages[0]?.injectedAtMs).toBeUndefined();
+    expect(work?.messages[0]?.attemptCount).toBeUndefined();
   });
 
   it("reports lost lease when input commit loses the mailbox lease", async () => {

--- a/packages/junior/tests/fixtures/slack/factories/api.ts
+++ b/packages/junior/tests/fixtures/slack/factories/api.ts
@@ -33,6 +33,16 @@ export function slackError(
   };
 }
 
+export function authTestOk(
+  input: { botId?: string; userId?: string; userName?: string } = {},
+): { ok: true; bot_id: string; user: string; user_id: string } {
+  return slackOk({
+    bot_id: input.botId ?? "B_TEST_BOT",
+    user: input.userName ?? "junior",
+    user_id: input.userId ?? TEST_USER_ID,
+  });
+}
+
 export function chatPostMessageOk(
   input: { ts?: string; channel?: string } = {},
 ): { ok: true; ts: string; channel: string } {

--- a/packages/junior/tests/integration/agent-continue-slack.test.ts
+++ b/packages/junior/tests/integration/agent-continue-slack.test.ts
@@ -629,8 +629,30 @@ describe("agent continuation Slack integration", () => {
   });
 
   it("resumes a lease-expired running session from its latest durable boundary", async () => {
+    // Process death between generation and the final post leaves a running
+    // record at its last durable safe boundary; queue redelivery must produce
+    // exactly one visible reply and only then a delivered/completed session.
     const conversationId = "slack:C123:1712345.0008";
     const sessionId = "turn_msg_8";
+    generateAssistantReplyMock.mockResolvedValueOnce({
+      text: "Final resumed answer",
+      piMessages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "hello" }],
+          timestamp: 1,
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Final resumed answer" }],
+          timestamp: 2,
+        },
+      ],
+      diagnostics: {
+        outcome: "success",
+        toolCalls: [],
+      },
+    });
     await turnSessionStoreModule.upsertAgentTurnSessionRecord({
       conversationId,
       sessionId,
@@ -710,6 +732,7 @@ describe("agent continuation Slack integration", () => {
         destination: SLACK_DESTINATION,
       }),
     );
+    // Exactly one visible reply for the interrupted request.
     expect(slackApiOutbox.messages()).toEqual([
       expect.objectContaining({
         params: expect.objectContaining({
@@ -719,6 +742,15 @@ describe("agent continuation Slack integration", () => {
         }),
       }),
     ]);
+    // Completion is committed only after Slack accepted the reply.
+    await expect(
+      turnSessionStoreModule.getAgentTurnSessionRecord(
+        conversationId,
+        sessionId,
+      ),
+    ).resolves.toMatchObject({
+      state: "completed",
+    });
   });
 
   it("terminally fails a stranded running session with no resumable boundary", async () => {

--- a/packages/junior/tests/integration/agent-continue-slack.test.ts
+++ b/packages/junior/tests/integration/agent-continue-slack.test.ts
@@ -628,6 +628,205 @@ describe("agent continuation Slack integration", () => {
     ]);
   });
 
+  it("resumes a lease-expired running session from its latest durable boundary", async () => {
+    const conversationId = "slack:C123:1712345.0008";
+    const sessionId = "turn_msg_8";
+    await turnSessionStoreModule.upsertAgentTurnSessionRecord({
+      conversationId,
+      sessionId,
+      sliceId: 1,
+      state: "running",
+      destination: SLACK_DESTINATION,
+      source: slackSource("1712345.0008"),
+      piMessages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "hello" }],
+          timestamp: 1,
+        },
+      ],
+      requester: {
+        platform: "slack",
+        teamId: SLACK_DESTINATION.teamId,
+        userId: "U123",
+        userName: "testuser",
+        fullName: "Test User",
+        email: "testuser@example.com",
+      },
+    });
+
+    await threadStateModule.persistThreadStateById(conversationId, {
+      artifacts: {
+        listColumnMap: {},
+      },
+      conversation: {
+        schemaVersion: 1,
+        backfill: {},
+        compactions: [],
+        piMessages: [],
+        messages: [
+          {
+            id: "msg.8",
+            role: "user",
+            text: "resume this request",
+            createdAtMs: 1,
+            author: {
+              userId: "U123",
+            },
+          },
+        ],
+        processing: {
+          activeTurnId: sessionId,
+        },
+        stats: {
+          compactedMessageCount: 0,
+          estimatedContextTokens: 0,
+          totalMessageCount: 1,
+          updatedAtMs: 1,
+        },
+        vision: {
+          byFileId: {},
+        },
+      },
+    });
+
+    const resumed = await requestDeadlineModule.runWithTurnRequestDeadline(() =>
+      agentContinueRunnerModule.resumeAwaitingSlackContinuation(
+        conversationId,
+        {
+          generateReply: generateAssistantReplyMock,
+          scheduleAgentContinue: (request) =>
+            agentContinueServiceModule.scheduleAgentContinue(request, {
+              queue,
+            }),
+        },
+      ),
+    );
+
+    expect(resumed).toBe(true);
+    expect(generateAssistantReplyMock).toHaveBeenCalledWith(
+      "resume this request",
+      expect.objectContaining({
+        destination: SLACK_DESTINATION,
+      }),
+    );
+    expect(slackApiOutbox.messages()).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({
+          channel: "C123",
+          thread_ts: "1712345.0008",
+          text: "Final resumed answer",
+        }),
+      }),
+    ]);
+  });
+
+  it("terminally fails a stranded running session with no resumable boundary", async () => {
+    const conversationId = "slack:C123:1712345.0009";
+    const sessionId = "turn_msg_9";
+    await turnSessionStoreModule.upsertAgentTurnSessionRecord({
+      conversationId,
+      sessionId,
+      sliceId: 1,
+      state: "running",
+      destination: SLACK_DESTINATION,
+      source: slackSource("1712345.0009"),
+      // Only uncommitted trailing assistant output survived the crash: there
+      // is no continuable user/toolResult boundary to resume from.
+      piMessages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "partial output" }],
+          api: "responses",
+          provider: "openai",
+          model: "gpt-5.3",
+          usage: {
+            input: 1,
+            output: 1,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 2,
+            cost: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              total: 0,
+            },
+          },
+          stopReason: "stop",
+          timestamp: 2,
+        },
+      ],
+    });
+    await threadStateModule.persistThreadStateById(conversationId, {
+      artifacts: {
+        listColumnMap: {},
+      },
+      conversation: {
+        schemaVersion: 1,
+        backfill: {},
+        compactions: [],
+        piMessages: [],
+        messages: [
+          {
+            id: "msg.9",
+            role: "user",
+            text: "resume this request",
+            createdAtMs: 1,
+            author: {
+              userId: "U123",
+            },
+          },
+        ],
+        processing: {
+          activeTurnId: sessionId,
+        },
+        stats: {
+          compactedMessageCount: 0,
+          estimatedContextTokens: 0,
+          totalMessageCount: 1,
+          updatedAtMs: 1,
+        },
+        vision: {
+          byFileId: {},
+        },
+      },
+    });
+
+    const resumed = await requestDeadlineModule.runWithTurnRequestDeadline(() =>
+      agentContinueRunnerModule.resumeAwaitingSlackContinuation(
+        conversationId,
+        {
+          generateReply: generateAssistantReplyMock,
+        },
+      ),
+    );
+
+    expect(resumed).toBe(false);
+    expect(generateAssistantReplyMock).not.toHaveBeenCalled();
+    await expect(
+      turnSessionStoreModule.getAgentTurnSessionRecord(
+        conversationId,
+        sessionId,
+      ),
+    ).resolves.toMatchObject({
+      state: "failed",
+      errorMessage: expect.stringContaining("no resumable boundary"),
+    });
+    expect(slackApiOutbox.messages()).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({
+          channel: "C123",
+          thread_ts: "1712345.0009",
+          text: expect.stringContaining(
+            "I ran into an internal error while processing that.",
+          ),
+        }),
+      }),
+    ]);
+  });
+
   it("uploads resumed reply files through the shared delivery path", async () => {
     const conversationId = "slack:C123:1712345.0003";
     const sessionId = "turn_msg_3";

--- a/packages/junior/tests/integration/agent-continue-slack.test.ts
+++ b/packages/junior/tests/integration/agent-continue-slack.test.ts
@@ -18,6 +18,8 @@ function slackSource(threadTs: string) {
     teamId: SLACK_DESTINATION.teamId,
     channelId: SLACK_DESTINATION.channelId,
     threadTs,
+
+    type: "priv",
   });
 }
 
@@ -112,6 +114,8 @@ describe("agent continuation Slack integration", () => {
       channelId: "C123",
       messageTs: "1712345.continue-source",
       threadTs: "1712345.0001",
+
+      type: "priv",
     });
     const sessionRecord =
       await turnSessionStoreModule.upsertAgentTurnSessionRecord({

--- a/packages/junior/tests/integration/agent-continue-slack.test.ts
+++ b/packages/junior/tests/integration/agent-continue-slack.test.ts
@@ -291,6 +291,11 @@ describe("agent continuation Slack integration", () => {
         resumeReason: "timeout",
         resumedFromSliceId: 1,
         errorMessage: "Agent turn timed out",
+        requester: {
+          platform: "slack",
+          teamId: SLACK_DESTINATION.teamId,
+          userId: "U123",
+        },
       });
 
     await threadStateModule.persistThreadStateById(conversationId, {

--- a/packages/junior/tests/integration/agent-continue-slack.test.ts
+++ b/packages/junior/tests/integration/agent-continue-slack.test.ts
@@ -29,6 +29,7 @@ type RequestDeadlineModule = typeof import("@/chat/runtime/request-deadline");
 type TurnSessionStoreModule = typeof import("@/chat/state/turn-session");
 type AgentContinueServiceModule =
   typeof import("@/chat/services/agent-continue");
+type TaskExecutionStoreModule = typeof import("@/chat/task-execution/store");
 
 let stateAdapterModule: StateAdapterModule;
 let threadStateModule: ThreadStateModule;
@@ -36,6 +37,7 @@ let agentContinueRunnerModule: AgentContinueRunnerModule;
 let requestDeadlineModule: RequestDeadlineModule;
 let turnSessionStoreModule: TurnSessionStoreModule;
 let agentContinueServiceModule: AgentContinueServiceModule;
+let taskExecutionStoreModule: TaskExecutionStoreModule;
 let queue: ConversationWorkQueueTestAdapter;
 
 function continueAgentRun(args: {
@@ -90,6 +92,7 @@ describe("agent continuation Slack integration", () => {
     requestDeadlineModule = await import("@/chat/runtime/request-deadline");
     turnSessionStoreModule = await import("@/chat/state/turn-session");
     agentContinueServiceModule = await import("@/chat/services/agent-continue");
+    taskExecutionStoreModule = await import("@/chat/task-execution/store");
 
     await stateAdapterModule.disconnectStateAdapter();
     await stateAdapterModule.getStateAdapter().connect();
@@ -529,6 +532,199 @@ describe("agent continuation Slack integration", () => {
       state: "failed",
       errorMessage: "Paused agent run failed while continuing",
     });
+  });
+
+  it("terminally fails with a visible fallback when no stored requester can be recovered", async () => {
+    // Issue #727: a missing stored requester must never throw out of the
+    // continue callback (a throw NACKs the queue delivery and wedges the
+    // conversation forever).
+    const conversationId = "slack:C123:1712345.0010";
+    const sessionId = "turn_msg_10";
+    const sessionRecord =
+      await turnSessionStoreModule.upsertAgentTurnSessionRecord({
+        conversationId,
+        sessionId,
+        sliceId: 2,
+        state: "awaiting_resume",
+        destination: SLACK_DESTINATION,
+        source: slackSource("1712345.0010"),
+        piMessages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "hello" }],
+            timestamp: 1,
+          },
+        ],
+        resumeReason: "timeout",
+        resumedFromSliceId: 1,
+        errorMessage: "Agent turn timed out",
+      });
+
+    await threadStateModule.persistThreadStateById(conversationId, {
+      artifacts: {
+        listColumnMap: {},
+      },
+      conversation: {
+        schemaVersion: 1,
+        backfill: {},
+        compactions: [],
+        piMessages: [],
+        messages: [
+          {
+            id: "msg.10",
+            role: "user",
+            text: "resume this request",
+            createdAtMs: 1,
+            author: {
+              userId: "U123",
+            },
+          },
+        ],
+        processing: {
+          activeTurnId: sessionId,
+        },
+        stats: {
+          compactedMessageCount: 0,
+          estimatedContextTokens: 0,
+          totalMessageCount: 1,
+          updatedAtMs: 1,
+        },
+        vision: {
+          byFileId: {},
+        },
+      },
+    });
+
+    const continued = await continueAgentRun({
+      conversationId,
+      sessionId,
+      expectedVersion: sessionRecord.version,
+    });
+
+    expect(continued).toBe(false);
+    expect(generateAssistantReplyMock).not.toHaveBeenCalled();
+    await expect(
+      turnSessionStoreModule.getAgentTurnSessionRecord(
+        conversationId,
+        sessionId,
+      ),
+    ).resolves.toMatchObject({
+      state: "failed",
+      errorMessage: "Stored Slack requester missing for continuation",
+    });
+    expect(slackApiOutbox.messages()).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({
+          channel: "C123",
+          thread_ts: "1712345.0010",
+          text: expect.stringContaining(
+            "I ran into an internal error while processing that.",
+          ),
+        }),
+      }),
+    ]);
+  });
+
+  it("recovers the resume requester from the durable conversation record", async () => {
+    // Issue #727 recovery path: older session records were persisted without
+    // a requester; the durable conversation work record still carries the
+    // matching identity, so the resume completes instead of failing.
+    const conversationId = "slack:C123:1712345.0011";
+    const sessionId = "turn_msg_11";
+    const sessionRecord =
+      await turnSessionStoreModule.upsertAgentTurnSessionRecord({
+        conversationId,
+        sessionId,
+        sliceId: 2,
+        state: "awaiting_resume",
+        destination: SLACK_DESTINATION,
+        source: slackSource("1712345.0011"),
+        piMessages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "hello" }],
+            timestamp: 1,
+          },
+        ],
+        resumeReason: "timeout",
+        resumedFromSliceId: 1,
+        errorMessage: "Agent turn timed out",
+      });
+    await taskExecutionStoreModule.recordConversationActivity({
+      conversationId,
+      destination: SLACK_DESTINATION,
+      requester: {
+        platform: "slack",
+        teamId: SLACK_DESTINATION.teamId,
+        slackUserId: "U123",
+        slackUserName: "testuser",
+        fullName: "Test User",
+        email: "testuser@example.com",
+      },
+    });
+
+    await threadStateModule.persistThreadStateById(conversationId, {
+      artifacts: {
+        listColumnMap: {},
+      },
+      conversation: {
+        schemaVersion: 1,
+        backfill: {},
+        compactions: [],
+        piMessages: [],
+        messages: [
+          {
+            id: "msg.11",
+            role: "user",
+            text: "resume this request",
+            createdAtMs: 1,
+            author: {
+              userId: "U123",
+            },
+          },
+        ],
+        processing: {
+          activeTurnId: sessionId,
+        },
+        stats: {
+          compactedMessageCount: 0,
+          estimatedContextTokens: 0,
+          totalMessageCount: 1,
+          updatedAtMs: 1,
+        },
+        vision: {
+          byFileId: {},
+        },
+      },
+    });
+
+    const continued = await continueAgentRun({
+      conversationId,
+      sessionId,
+      expectedVersion: sessionRecord.version,
+    });
+
+    expect(continued).toBe(true);
+    expect(generateAssistantReplyMock).toHaveBeenCalledWith(
+      "resume this request",
+      expect.objectContaining({
+        requester: expect.objectContaining({
+          userId: "U123",
+          userName: "testuser",
+          fullName: "Test User",
+          email: "testuser@example.com",
+        }),
+      }),
+    );
+    expect(slackApiOutbox.messages()).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({
+          channel: "C123",
+          thread_ts: "1712345.0011",
+          text: "Final resumed answer",
+        }),
+      }),
+    ]);
   });
 
   it("schedules a durable continuation without posting a notice when a resumed slice times out again", async () => {

--- a/packages/junior/tests/integration/agent-dispatch-runner.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-runner.test.ts
@@ -86,6 +86,8 @@ function slackAddress(channelId = "C123") {
 function slackSource(channelId = "C123") {
   return createSlackSource({
     ...slackAddress(channelId),
+
+    type: "priv",
   });
 }
 

--- a/packages/junior/tests/integration/agent-dispatch-runner.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-runner.test.ts
@@ -19,6 +19,7 @@ import { RetryableTurnError } from "@/chat/runtime/turn";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import type { AssistantReply } from "@/chat/respond";
+import type { PiMessage } from "@/chat/pi/messages";
 import {
   bindSlackDirectCredentialSubject,
   createSlackDirectCredentialSubject,
@@ -33,6 +34,23 @@ import {
 vi.hoisted(() => {
   process.env.JUNIOR_STATE_ADAPTER = "memory";
 });
+
+function zeroUsage() {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 0,
+    },
+  };
+}
 
 function createReply(): AssistantReply {
   return {
@@ -54,10 +72,44 @@ function createReply(): AssistantReply {
       usedPrimaryText: true,
     },
     piMessages: [
-      { role: "user", content: "Run the scheduled task." },
-      { role: "assistant", content: "Dispatch delivered." },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Run the scheduled task." }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Dispatch delivered." }],
+        api: "responses",
+        provider: "openai",
+        model: "test-model",
+        stopReason: "stop",
+        timestamp: 2,
+        usage: zeroUsage(),
+      },
     ],
   };
+}
+
+function failedDispatchPiMessages(): PiMessage[] {
+  return [
+    {
+      role: "user",
+      content: [{ type: "text", text: "Run the scheduled task." }],
+      timestamp: 1,
+    },
+    {
+      role: "assistant",
+      content: [],
+      api: "responses",
+      provider: "openai",
+      model: "test-model",
+      errorMessage: "provider failed",
+      stopReason: "error",
+      timestamp: 2,
+      usage: zeroUsage(),
+    },
+  ];
 }
 
 function createCredentialSubject() {
@@ -439,6 +491,62 @@ describe("agent dispatch runner", () => {
     );
     expect(rerunGenerate).not.toHaveBeenCalled();
     expect(getCapturedSlackApiCalls("chat.postMessage")).toHaveLength(1);
+  });
+
+  it("completes the session record after delivering a failed dispatch fallback", async () => {
+    queueSlackApiResponse("chat.postMessage", {
+      body: chatPostMessageOk({
+        channel: "C123",
+        ts: "1700000000.000006",
+      }),
+    });
+    const created = await createOrGetDispatch({
+      plugin: "scheduler",
+      nowMs: Date.parse("2026-05-26T12:00:00.000Z"),
+      options: {
+        idempotencyKey: "run-fallback-completed",
+        destination: slackAddress(),
+        input: "Run the scheduled task.",
+        source: slackSource(),
+      },
+    });
+    const dispatchConversationId = getDispatchConversationId(created.record);
+    const failedReply = createReply();
+    const generateAssistantReply = vi.fn(async () => ({
+      ...failedReply,
+      text: "",
+      diagnostics: {
+        ...failedReply.diagnostics,
+        errorMessage: "provider failed",
+        outcome: "provider_error" as const,
+        usedPrimaryText: false,
+      },
+      piMessages: failedDispatchPiMessages(),
+    }));
+
+    await runAgentDispatchSlice(
+      {
+        id: created.record.id,
+        expectedVersion: created.record.version,
+      },
+      { generateAssistantReply },
+    );
+
+    await expect(getDispatchRecord(created.record.id)).resolves.toMatchObject({
+      status: "failed",
+      resultMessageTs: "1700000000.000006",
+    });
+    await expect(
+      getAgentTurnSessionRecord(
+        dispatchConversationId,
+        `dispatch:${created.record.id}`,
+      ),
+    ).resolves.toMatchObject({
+      conversationId: dispatchConversationId,
+      sessionId: `dispatch:${created.record.id}`,
+      state: "completed",
+      surface: "api",
+    });
   });
 
   it("suppresses re-posting when a redelivered slice finds the delivered marker", async () => {

--- a/packages/junior/tests/integration/agent-dispatch-runner.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-runner.test.ts
@@ -5,6 +5,10 @@ import {
   getDispatchConversationId,
   getDispatchDestinationLockId,
   getDispatchRecord,
+  getDispatchStorageKey,
+  parseDispatchRecord,
+  updateDispatchRecord,
+  withDispatchLock,
 } from "@/chat/agent-dispatch/store";
 import { runAgentDispatchSlice } from "@/chat/agent-dispatch/runner";
 import {
@@ -353,6 +357,137 @@ describe("agent dispatch runner", () => {
     await expect(getDispatchRecord(created.record.id)).resolves.toMatchObject({
       status: "completed",
       resultMessageTs: "1700000000.000002",
+    });
+  });
+
+  it("does not re-post when the delivered-state persist fails after Slack accepted the reply", async () => {
+    queueSlackApiResponse("chat.postMessage", {
+      body: chatPostMessageOk({
+        channel: "C123",
+        ts: "1700000000.000004",
+      }),
+    });
+    const created = await createOrGetDispatch({
+      plugin: "scheduler",
+      nowMs: Date.parse("2026-05-26T12:00:00.000Z"),
+      options: {
+        idempotencyKey: "run-persist-fail",
+        destination: slackAddress(),
+        input: "Run the scheduled task.",
+        source: slackSource(),
+      },
+    });
+    const state = getStateAdapter();
+    await state.connect();
+    const originalSet = state.set.bind(state);
+    const setSpy = vi
+      .spyOn(state, "set")
+      .mockImplementation(async (key, value, ttlMs) => {
+        if (String(key).startsWith("thread-state:")) {
+          throw new Error("state store unavailable");
+        }
+        return originalSet(key, value, ttlMs);
+      });
+
+    try {
+      await runAgentDispatchSlice(
+        {
+          id: created.record.id,
+          expectedVersion: created.record.version,
+        },
+        { generateAssistantReply: async () => createReply() },
+      );
+    } finally {
+      setSpy.mockRestore();
+    }
+
+    // Delivery already happened: the dispatch is terminal so a retry cannot
+    // re-post, and the persistence failure is logged instead of failing it.
+    await expect(getDispatchRecord(created.record.id)).resolves.toMatchObject({
+      status: "completed",
+      resultMessageTs: "1700000000.000004",
+    });
+
+    const rerunGenerate = vi.fn(async () => {
+      throw new Error("must not regenerate a delivered dispatch");
+    });
+    await runAgentDispatchSlice(
+      {
+        id: created.record.id,
+        expectedVersion: created.record.version,
+      },
+      { generateAssistantReply: rerunGenerate },
+    );
+    expect(rerunGenerate).not.toHaveBeenCalled();
+    expect(getCapturedSlackApiCalls("chat.postMessage")).toHaveLength(1);
+  });
+
+  it("suppresses re-posting when a redelivered slice finds the delivered marker", async () => {
+    queueSlackApiResponse("chat.postMessage", {
+      body: chatPostMessageOk({
+        channel: "C123",
+        ts: "1700000000.000005",
+      }),
+    });
+    const created = await createOrGetDispatch({
+      plugin: "scheduler",
+      nowMs: Date.parse("2026-05-26T12:00:00.000Z"),
+      options: {
+        idempotencyKey: "run-crash-window",
+        destination: slackAddress(),
+        input: "Run the scheduled task.",
+        source: slackSource(),
+      },
+    });
+    await runAgentDispatchSlice(
+      {
+        id: created.record.id,
+        expectedVersion: created.record.version,
+      },
+      { generateAssistantReply: async () => createReply() },
+    );
+    await expect(getDispatchRecord(created.record.id)).resolves.toMatchObject({
+      status: "completed",
+      resultMessageTs: "1700000000.000005",
+    });
+
+    // Simulate a crash after the delivered marker persisted but before the
+    // dispatch was marked terminal: the record reverts to a lease-expired
+    // running attempt that queue redelivery will re-claim.
+    const reverted = await withDispatchLock(
+      created.record.id,
+      async (state) => {
+        const current = parseDispatchRecord(
+          await state.get(getDispatchStorageKey(created.record.id)),
+        );
+        if (!current) {
+          throw new Error("Expected dispatch record");
+        }
+        return await updateDispatchRecord(state, {
+          ...current,
+          status: "running",
+          attempt: 1,
+          leaseExpiresAtMs: Date.now() - 1,
+        });
+      },
+    );
+
+    const rerunGenerate = vi.fn(async () => {
+      throw new Error("must not regenerate a delivered dispatch");
+    });
+    await runAgentDispatchSlice(
+      {
+        id: created.record.id,
+        expectedVersion: reverted.version,
+      },
+      { generateAssistantReply: rerunGenerate },
+    );
+
+    expect(rerunGenerate).not.toHaveBeenCalled();
+    expect(getCapturedSlackApiCalls("chat.postMessage")).toHaveLength(1);
+    await expect(getDispatchRecord(created.record.id)).resolves.toMatchObject({
+      status: "completed",
+      resultMessageTs: "1700000000.000005",
     });
   });
 

--- a/packages/junior/tests/integration/agent-dispatch-runner.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-runner.test.ts
@@ -23,6 +23,7 @@ import {
   bindSlackDirectCredentialSubject,
   createSlackDirectCredentialSubject,
 } from "@/chat/credentials/subject";
+import { getAgentTurnSessionRecord } from "@/chat/state/turn-session";
 import { chatPostMessageOk } from "../fixtures/slack/factories/api";
 import {
   getCapturedSlackApiCalls,
@@ -52,6 +53,10 @@ function createReply(): AssistantReply {
       toolResultCount: 0,
       usedPrimaryText: true,
     },
+    piMessages: [
+      { role: "user", content: "Run the scheduled task." },
+      { role: "assistant", content: "Dispatch delivered." },
+    ],
   };
 }
 
@@ -196,6 +201,18 @@ describe("agent dispatch runner", () => {
     expect(scheduleSessionCompletedPluginTasks).toHaveBeenCalledWith({
       conversationId: dispatchConversationId,
       sessionId: `dispatch:${created.record.id}`,
+    });
+    await expect(
+      getAgentTurnSessionRecord(
+        dispatchConversationId,
+        `dispatch:${created.record.id}`,
+      ),
+    ).resolves.toMatchObject({
+      conversationId: dispatchConversationId,
+      sessionId: `dispatch:${created.record.id}`,
+      sliceId: 1,
+      state: "completed",
+      surface: "api",
     });
     await expect(getPersistedThreadState("slack:T123:C123")).resolves.toEqual(
       {},

--- a/packages/junior/tests/integration/dashboard-reporting.test.ts
+++ b/packages/junior/tests/integration/dashboard-reporting.test.ts
@@ -47,6 +47,9 @@ function fixedConversationStore(
         (conversation) => conversation.conversationId === args.conversationId,
       );
     },
+    async getDestinationVisibility() {
+      return undefined;
+    },
     async recordActivity() {},
     async recordExecution() {},
     async listByActivity(args = {}) {
@@ -92,6 +95,22 @@ async function createStateReportingReader() {
     readConversationReport,
     readConversationStatsReport,
   };
+}
+
+/**
+ * Record a source-confirmed public destination so reads may expose raw
+ * content, mirroring a live event whose channel_type was "channel".
+ */
+async function confirmPublicSlackConversation(
+  conversationId: string,
+  channelId = "C1",
+) {
+  const { getConversationStore } = await import("@/chat/db");
+  await getConversationStore().recordActivity({
+    conversationId,
+    destination: { platform: "slack", teamId: "T1", channelId },
+    visibility: "public",
+  });
 }
 
 describe("dashboard reporting", () => {
@@ -198,9 +217,11 @@ describe("dashboard reporting", () => {
     await conversationStore.recordActivity({
       conversationId: "slack:C1:111",
       channelName: "incidents",
+      destination: { platform: "slack", teamId: "T1", channelId: "C1" },
       nowMs: 1_000,
       source: "slack",
       title: "Incident follow-up",
+      visibility: "public",
     });
 
     const reporting = createJuniorReporting();
@@ -266,6 +287,53 @@ describe("dashboard reporting", () => {
       conversationId: "slack:G1:222",
       status: "completed",
     });
+  });
+
+  it("redacts C-prefixed conversations Slack reports as private", async () => {
+    const { getConversationStore } = await import("@/chat/db");
+    const { createJuniorReporting } = await import("@/reporting");
+    const conversationStore = getConversationStore();
+
+    // Modern Slack private channels use C-prefixed ids; the event said
+    // channel_type: group, so the destination is confirmed private.
+    await conversationStore.recordActivity({
+      conversationId: "slack:C9:333",
+      channelName: "stealth-project",
+      destination: { platform: "slack", teamId: "T1", channelId: "C9" },
+      nowMs: 1_000,
+      source: "slack",
+      title: "Stealth planning",
+      visibility: "private",
+    });
+
+    const summaries = await createJuniorReporting().listRecentConversations();
+
+    expect(JSON.stringify(summaries)).not.toContain("stealth-project");
+    expect(JSON.stringify(summaries)).not.toContain("Stealth planning");
+    expect(summaries[0]).toMatchObject({
+      conversationId: "slack:C9:333",
+    });
+  });
+
+  it("redacts C-prefixed conversations without confirmed visibility", async () => {
+    const { getConversationStore } = await import("@/chat/db");
+    const { createJuniorReporting } = await import("@/reporting");
+    const conversationStore = getConversationStore();
+
+    // Legacy-style row: no live signal ever confirmed this channel public.
+    await conversationStore.recordActivity({
+      conversationId: "slack:C9:444",
+      channelName: "maybe-private-room",
+      destination: { platform: "slack", teamId: "T1", channelId: "C9" },
+      nowMs: 1_000,
+      source: "slack",
+      title: "Unconfirmed visibility",
+    });
+
+    const summaries = await createJuniorReporting().listRecentConversations();
+
+    expect(JSON.stringify(summaries)).not.toContain("maybe-private-room");
+    expect(JSON.stringify(summaries)).not.toContain("Unconfirmed visibility");
   });
 
   it("refreshes conversation context ttl without replacing origin context", async () => {
@@ -344,6 +412,7 @@ describe("dashboard reporting", () => {
       await import("@/chat/state/conversation-details");
     const { createJuniorReporting } = await import("@/reporting");
 
+    await confirmPublicSlackConversation("slack:C1:details-only");
     await initConversationContext("slack:C1:details-only", {
       channelName: "proj-alpha",
       originSurface: "slack",
@@ -357,11 +426,15 @@ describe("dashboard reporting", () => {
       "slack:C1:details-only",
     );
 
+    // The confirmed-public destination record surfaces as an index-only run;
+    // the details title may only appear because the conversation is public.
     expect(report).toMatchObject({
       conversationId: "slack:C1:details-only",
       displayTitle: "Details Only Title",
-      runs: [],
     });
+    expect(report.runs.every((run) => run.transcriptAvailable === false)).toBe(
+      true,
+    );
   });
 
   it("reports conversation-index detail when turn summaries are absent", async () => {
@@ -465,6 +538,7 @@ describe("dashboard reporting", () => {
           lastActivityAtMs: Date.parse("2026-06-01T10:04:00.000Z"),
           requester: { fullName: "Blake" },
           source: "slack",
+          visibility: "public",
         }),
         indexedConversation({
           conversationId: "slack:D1:200",
@@ -537,6 +611,8 @@ describe("dashboard reporting", () => {
     await recordAgentTurnSessionSummary({
       conversationId: "slack:C1:100",
       cumulativeDurationMs: 1_000,
+      destination: { platform: "slack", teamId: "T1", channelId: "C1" },
+      destinationVisibility: "public",
       requester: slackRequester("Later Requester"),
       sessionId: "turn-1",
       sliceId: 1,
@@ -688,6 +764,7 @@ describe("dashboard reporting", () => {
       await import("@/chat/state/turn-session");
     const { createJuniorReporting } = await import("@/reporting");
 
+    await confirmPublicSlackConversation("slack:C1:222");
     await upsertAgentTurnSessionRecord({
       conversationId: "slack:C1:222",
       sessionId: "turn-current",
@@ -888,6 +965,7 @@ describe("dashboard reporting", () => {
 
     const conversationId = "slack:C1:advisor-slices";
     const runId = "turn-advisor-slices";
+    await confirmPublicSlackConversation(conversationId);
     const advisorSessionKey = `junior:${conversationId}:advisor_session`;
     const advisorMessages = [
       {
@@ -1212,6 +1290,7 @@ describe("dashboard reporting", () => {
       await import("@/chat/state/turn-session");
     const { createJuniorReporting } = await import("@/reporting");
 
+    await confirmPublicSlackConversation("slack:C1:steering-transcript");
     await upsertAgentTurnSessionRecord({
       conversationId: "slack:C1:steering-transcript",
       sessionId: "turn-steering",
@@ -1291,6 +1370,17 @@ describe("dashboard reporting", () => {
       await import("@/chat/state/turn-session");
     const { conversationStore, readConversationReport } =
       await createStateReportingReader();
+    // The state-backed store cannot persist confirmed visibility; present the
+    // conversation as source-confirmed public for this read.
+    const publicConversationStore: ConversationStore = {
+      ...conversationStore,
+      get: async (args) => {
+        const conversation = await conversationStore.get(args);
+        return conversation
+          ? { ...conversation, visibility: "public" as const }
+          : conversation;
+      },
+    };
 
     await upsertAgentTurnSessionRecord({
       conversationStore,
@@ -1341,7 +1431,7 @@ describe("dashboard reporting", () => {
     }
 
     const report = await readConversationReport("slack:C1:999", {
-      conversationStore,
+      conversationStore: publicConversationStore,
     });
 
     expect(report.runs).toHaveLength(1);
@@ -1364,6 +1454,7 @@ describe("dashboard reporting", () => {
       await import("@/chat/state/turn-session");
     const { createJuniorReporting } = await import("@/reporting");
 
+    await confirmPublicSlackConversation("slack:C1:333");
     await upsertAgentTurnSessionRecord({
       conversationId: "slack:C1:333",
       destination: {

--- a/packages/junior/tests/integration/dashboard-reporting.test.ts
+++ b/packages/junior/tests/integration/dashboard-reporting.test.ts
@@ -315,25 +315,30 @@ describe("dashboard reporting", () => {
     });
   });
 
-  it("redacts C-prefixed conversations without confirmed visibility", async () => {
+  it("redacts C-prefixed conversations without public visibility", async () => {
     const { getConversationStore } = await import("@/chat/db");
     const { createJuniorReporting } = await import("@/reporting");
     const conversationStore = getConversationStore();
 
-    // Legacy-style row: no live signal ever confirmed this channel public.
+    // Legacy-style row: no live signal ever marked this channel public.
     await conversationStore.recordActivity({
       conversationId: "slack:C9:444",
       channelName: "maybe-private-room",
       destination: { platform: "slack", teamId: "T1", channelId: "C9" },
       nowMs: 1_000,
       source: "slack",
-      title: "Unconfirmed visibility",
+      title: "Private by default",
     });
 
     const summaries = await createJuniorReporting().listRecentConversations();
 
     expect(JSON.stringify(summaries)).not.toContain("maybe-private-room");
-    expect(JSON.stringify(summaries)).not.toContain("Unconfirmed visibility");
+    expect(JSON.stringify(summaries)).not.toContain("Private by default");
+    expect(summaries[0]).toMatchObject({
+      channelName: "Private Conversation",
+      channelNameRedacted: true,
+      displayTitle: "Private Conversation",
+    });
   });
 
   it("refreshes conversation context ttl without replacing origin context", async () => {
@@ -426,7 +431,7 @@ describe("dashboard reporting", () => {
       "slack:C1:details-only",
     );
 
-    // The confirmed-public destination record surfaces as an index-only run;
+    // The persisted-public destination record surfaces as an index-only run;
     // the details title may only appear because the conversation is public.
     expect(report).toMatchObject({
       conversationId: "slack:C1:details-only",
@@ -1371,8 +1376,8 @@ describe("dashboard reporting", () => {
       await import("@/chat/state/turn-session");
     const { conversationStore, readConversationReport } =
       await createStateReportingReader();
-    // The state-backed store cannot persist confirmed visibility; present the
-    // conversation as source-confirmed public for this read.
+    // The state-backed store cannot persist destination visibility; present
+    // the conversation as public for this read.
     const publicConversationStore: ConversationStore = {
       ...conversationStore,
       get: async (args) => {
@@ -1618,6 +1623,7 @@ describe("dashboard reporting", () => {
     expect(report.runs[0]).toMatchObject({
       displayTitle: "Direct Message",
       channelName: "Direct Message",
+      channelNameRedacted: true,
       id: "turn-private",
       requesterIdentity: {
         email: "david@sentry.io",
@@ -1664,6 +1670,7 @@ describe("dashboard reporting", () => {
     expect(report.runs[0]).toMatchObject({
       displayTitle: "Direct Message",
       channelName: "Direct Message",
+      channelNameRedacted: true,
       id: "turn-private-expired",
       transcriptAvailable: false,
       transcriptMetadata: [],

--- a/packages/junior/tests/integration/dashboard-reporting.test.ts
+++ b/packages/junior/tests/integration/dashboard-reporting.test.ts
@@ -432,6 +432,7 @@ describe("dashboard reporting", () => {
       conversationId: "slack:C1:details-only",
       displayTitle: "Details Only Title",
     });
+    expect(report.runs.length).toBeGreaterThan(0);
     expect(report.runs.every((run) => run.transcriptAvailable === false)).toBe(
       true,
     );

--- a/packages/junior/tests/integration/heartbeat.test.ts
+++ b/packages/junior/tests/integration/heartbeat.test.ts
@@ -49,12 +49,15 @@ const SLACK_DESTINATION = {
 } satisfies Destination;
 const SLACK_SOURCE = createSlackSource({
   ...SLACK_DESTINATION,
+  type: "priv",
 }) satisfies Source;
 
 function slackDmSource(channelId = "D123"): Source {
   return createSlackSource({
     teamId: "T123",
     channelId,
+
+    type: "priv",
   });
 }
 
@@ -849,6 +852,8 @@ describe("plugin heartbeat", () => {
       createSlackSource({
         teamId: "T123",
         channelId: "C123",
+
+        type: "priv",
       }),
     );
     expect(dispatchRecord?.metadata).toMatchObject({

--- a/packages/junior/tests/integration/mcp-oauth-callback-slack.test.ts
+++ b/packages/junior/tests/integration/mcp-oauth-callback-slack.test.ts
@@ -43,6 +43,8 @@ function slackSource(threadTs: string) {
     teamId: SLACK_DESTINATION.teamId,
     channelId: SLACK_DESTINATION.channelId,
     threadTs,
+
+    type: "priv",
   });
 }
 
@@ -194,6 +196,8 @@ describe("mcp oauth callback slack integration", () => {
       channelId: "C123",
       messageTs: "1700000000.mcp-source",
       threadTs: "1700000000.001",
+
+      type: "priv",
     });
 
     await stateAdapterModule.getStateAdapter().set(`thread-state:${threadId}`, {

--- a/packages/junior/tests/integration/oauth-callback-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-callback-slack.test.ts
@@ -34,6 +34,8 @@ function slackSource(threadTs: string) {
     teamId: SLACK_DESTINATION.teamId,
     channelId: SLACK_DESTINATION.channelId,
     threadTs,
+
+    type: "priv",
   });
 }
 
@@ -113,6 +115,8 @@ describe("oauth callback slack integration", () => {
       channelId: "C123",
       messageTs: "1700000000.oauth-source",
       threadTs: "1700000000.001",
+
+      type: "priv",
     });
     await stateAdapterModule
       .getStateAdapter()
@@ -199,6 +203,8 @@ describe("oauth callback slack integration", () => {
       channelId: "C123",
       messageTs: "1700000000.session-source",
       threadTs: "1700000000.009",
+
+      type: "priv",
     });
 
     await turnSessionStoreModule.upsertAgentTurnSessionRecord({

--- a/packages/junior/tests/integration/oauth-resume-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-resume-slack.test.ts
@@ -39,6 +39,8 @@ function testSlackSource(threadTs: string) {
     teamId: TEST_SLACK_DESTINATION.teamId,
     channelId: TEST_SLACK_DESTINATION.channelId,
     threadTs,
+
+    type: "priv",
   });
 }
 

--- a/packages/junior/tests/integration/slack-channel-tools.test.ts
+++ b/packages/junior/tests/integration/slack-channel-tools.test.ts
@@ -52,6 +52,8 @@ function createContext(
       teamId: "T123",
       channelId: sourceChannelId,
       messageTs: "1700000000.321",
+
+      type: "priv",
     }),
     destinationChannelId,
     messageTs: "1700000000.321",

--- a/packages/junior/tests/integration/slack-schedule-tools.test.ts
+++ b/packages/junior/tests/integration/slack-schedule-tools.test.ts
@@ -71,6 +71,8 @@ function createContext(
     source: createSlackSource({
       teamId,
       channelId,
+
+      type: "priv",
     }),
     requester: {
       platform: "slack",
@@ -328,6 +330,8 @@ describe("Slack schedule tools", () => {
           teamId: TEST_TEAM_ID,
           channelId: "C123",
           threadTs: "1700000000.000",
+
+          type: "priv",
         }),
       }),
     );
@@ -887,6 +891,8 @@ describe("Slack schedule tools", () => {
             ...createSlackSource({
               teamId: TEST_TEAM_ID,
               channelId: "D123",
+
+              type: "priv",
             }),
             teamId: TEST_TEAM_ID,
             channelId: "slack:D123:1700000000.000",
@@ -1219,6 +1225,8 @@ describe("Slack schedule tool wiring via getPluginTools", () => {
         source: createSlackSource({
           teamId: TEAM_ID,
           channelId: "DDM",
+
+          type: "priv",
         }),
         destination: {
           platform: "slack",

--- a/packages/junior/tests/integration/slack-thread-read.test.ts
+++ b/packages/junior/tests/integration/slack-thread-read.test.ts
@@ -27,6 +27,8 @@ function createContext(
       createSlackSource({
         teamId: "T123",
         channelId: sourceChannelId,
+
+        type: "priv",
       }),
     destinationChannelId,
     sourceChannelId,
@@ -35,8 +37,8 @@ function createContext(
   };
 }
 
-/** Persisted-visibility fake: only listed channels are confirmed public in T123. */
-function confirmedPublicChannels(
+/** Persisted-visibility fake: only listed channels are public in T123. */
+function persistedPublicChannels(
   ...channelIds: string[]
 ): DestinationVisibilityReader {
   return {
@@ -53,10 +55,10 @@ function confirmedPublicChannels(
 
 function createTool(
   overrides: Partial<SlackToolContext> = {},
-  confirmedPublic: string[] = [],
+  publicChannels: string[] = [],
 ) {
   return createSlackThreadReadTool(createContext(overrides), {
-    visibilityStore: confirmedPublicChannels(...confirmedPublic),
+    visibilityStore: persistedPublicChannels(...publicChannels),
   });
 }
 
@@ -295,7 +297,7 @@ describe("slackThreadRead", () => {
     expect(getCapturedSlackApiCalls("conversations.replies")).toHaveLength(0);
   });
 
-  it("blocks reading a C-prefixed channel without confirmed public visibility", async () => {
+  it("blocks reading a C-prefixed channel without persisted public visibility", async () => {
     const tool = createTool({ sourceChannelId: "C_CURRENT" });
     const result = await executeTool(tool, {
       url: "https://sentry.slack.com/archives/C0UNCONFIRMED/p1700000000100000",
@@ -305,7 +307,7 @@ describe("slackThreadRead", () => {
       ok: false,
       channel_id: "C0UNCONFIRMED",
     });
-    expect(result.error).toContain("confirmed as public");
+    expect(result.error).toContain("public channels Junior has seen");
     // Blocked locally, no Slack API traffic.
     expect(getCapturedSlackApiCalls("conversations.replies")).toHaveLength(0);
   });

--- a/packages/junior/tests/integration/slack-thread-read.test.ts
+++ b/packages/junior/tests/integration/slack-thread-read.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createSlackSource } from "@sentry/junior-plugin-api";
 import { createSlackThreadReadTool } from "@/chat/tools/slack/thread-read";
+import type { DestinationVisibilityReader } from "@/chat/tools/slack/channel-access";
 import type { SlackToolContext } from "@/chat/tools/slack/context";
 import { conversationsRepliesPage } from "../fixtures/slack/factories/api";
 import {
@@ -34,6 +35,31 @@ function createContext(
   };
 }
 
+/** Persisted-visibility fake: only listed channels are confirmed public in T123. */
+function confirmedPublicChannels(
+  ...channelIds: string[]
+): DestinationVisibilityReader {
+  return {
+    async getDestinationVisibility(args) {
+      if (args.provider !== "slack" || args.providerTenantId !== "T123") {
+        return undefined;
+      }
+      return channelIds.includes(args.providerDestinationId)
+        ? "public"
+        : undefined;
+    },
+  };
+}
+
+function createTool(
+  overrides: Partial<SlackToolContext> = {},
+  confirmedPublic: string[] = [],
+) {
+  return createSlackThreadReadTool(createContext(overrides), {
+    visibilityStore: confirmedPublicChannels(...confirmedPublic),
+  });
+}
+
 async function executeTool<TInput>(tool: any, input: TInput) {
   if (typeof tool?.execute !== "function") {
     throw new Error("tool execute function missing");
@@ -63,7 +89,7 @@ describe("slackThreadRead", () => {
       }),
     });
 
-    const tool = createSlackThreadReadTool(createContext());
+    const tool = createTool({}, ["C0AHB7N2JCR"]);
     const result = await executeTool(tool, {
       url: "https://sentry.slack.com/archives/C0AHB7N2JCR/p1700000000123456",
     });
@@ -81,7 +107,7 @@ describe("slackThreadRead", () => {
     expect(result.messages[0].text).toBe("root message");
     expect(result.messages[1].text).toBe("reply message");
 
-    // No conversations.info call — access determined by channel prefix
+    // No conversations.info call — access determined by persisted visibility
     expect(getCapturedSlackApiCalls("conversations.info")).toHaveLength(0);
     expect(getCapturedSlackApiCalls("conversations.replies")).toHaveLength(1);
   });
@@ -107,7 +133,7 @@ describe("slackThreadRead", () => {
       }),
     });
 
-    const tool = createSlackThreadReadTool(createContext());
+    const tool = createTool({}, ["C123"]);
     const result = await executeTool(tool, {
       url: "https://sentry.slack.com/archives/C123/p1700000000999999?thread_ts=1700000000.000000&cid=C123",
     });
@@ -143,7 +169,7 @@ describe("slackThreadRead", () => {
       }),
     });
 
-    const tool = createSlackThreadReadTool(createContext());
+    const tool = createTool({}, ["C_MANUAL"]);
     const result = await executeTool(tool, {
       channel_id: "C_MANUAL",
       ts: "1700000000.500000",
@@ -172,9 +198,7 @@ describe("slackThreadRead", () => {
       }),
     });
 
-    const tool = createSlackThreadReadTool(
-      createContext({ sourceChannelId: "G_PRIVATE" }),
-    );
+    const tool = createTool({ sourceChannelId: "G_PRIVATE" });
     const result = await executeTool(tool, {
       channel_id: "G_PRIVATE",
       ts: "1700000000.100000",
@@ -206,12 +230,10 @@ describe("slackThreadRead", () => {
       }),
     });
 
-    const tool = createSlackThreadReadTool(
-      createContext({
-        sourceChannelId: "D_DM",
-        destinationChannelId: "G_PRIVATE",
-      }),
-    );
+    const tool = createTool({
+      sourceChannelId: "D_DM",
+      destinationChannelId: "G_PRIVATE",
+    });
     const result = await executeTool(tool, {
       channel_id: "G_PRIVATE",
       ts: "1700000000.100000",
@@ -226,9 +248,7 @@ describe("slackThreadRead", () => {
   });
 
   it("blocks reading a private group channel from a DM conversation without assistant context", async () => {
-    const tool = createSlackThreadReadTool(
-      createContext({ sourceChannelId: "D_DM" }),
-    );
+    const tool = createTool({ sourceChannelId: "D_DM" });
     const result = await executeTool(tool, {
       channel_id: "G_PRIVATE",
       ts: "1700000000.100000",
@@ -238,14 +258,12 @@ describe("slackThreadRead", () => {
       ok: false,
       channel_id: "G_PRIVATE",
     });
-    expect(result.error).toContain("private channel");
+    expect(result.error).toContain("current conversation");
     expect(getCapturedSlackApiCalls("conversations.replies")).toHaveLength(0);
   });
 
   it("blocks reading a private channel that is not the current channel", async () => {
-    const tool = createSlackThreadReadTool(
-      createContext({ sourceChannelId: "C_CURRENT" }),
-    );
+    const tool = createTool({ sourceChannelId: "C_CURRENT" });
     const result = await executeTool(tool, {
       url: "https://sentry.slack.com/archives/G0OTHER/p1700000000100000",
     });
@@ -255,7 +273,7 @@ describe("slackThreadRead", () => {
       channel_id: "G0OTHER",
       target_message_ts: "1700000000.100000",
     });
-    expect(result.error).toContain("private channel");
+    expect(result.error).toContain("current conversation");
 
     // Should NOT call any Slack API — blocked locally
     expect(getCapturedSlackApiCalls("conversations.info")).toHaveLength(0);
@@ -263,7 +281,7 @@ describe("slackThreadRead", () => {
   });
 
   it("blocks reading a DM channel that is not the current channel", async () => {
-    const tool = createSlackThreadReadTool(createContext());
+    const tool = createTool();
     const result = await executeTool(tool, {
       channel_id: "D_SOMEONE",
       ts: "1700000000.100000",
@@ -273,7 +291,22 @@ describe("slackThreadRead", () => {
       ok: false,
       channel_id: "D_SOMEONE",
     });
-    expect(result.error).toContain("private channel");
+    expect(result.error).toContain("current conversation");
+    expect(getCapturedSlackApiCalls("conversations.replies")).toHaveLength(0);
+  });
+
+  it("blocks reading a C-prefixed channel without confirmed public visibility", async () => {
+    const tool = createTool({ sourceChannelId: "C_CURRENT" });
+    const result = await executeTool(tool, {
+      url: "https://sentry.slack.com/archives/C0UNCONFIRMED/p1700000000100000",
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      channel_id: "C0UNCONFIRMED",
+    });
+    expect(result.error).toContain("confirmed as public");
+    // Blocked locally, no Slack API traffic.
     expect(getCapturedSlackApiCalls("conversations.replies")).toHaveLength(0);
   });
 
@@ -282,7 +315,7 @@ describe("slackThreadRead", () => {
       error: "not_in_channel",
     });
 
-    const tool = createSlackThreadReadTool(createContext());
+    const tool = createTool({}, ["C_FLAKY"]);
     const result = await executeTool(tool, {
       channel_id: "C_FLAKY",
       ts: "1700000000.100000",
@@ -297,7 +330,7 @@ describe("slackThreadRead", () => {
   });
 
   it("returns an error for invalid URL input", async () => {
-    const tool = createSlackThreadReadTool(createContext());
+    const tool = createTool();
     const result = await executeTool(tool, {
       url: "not a valid url",
     });
@@ -309,7 +342,7 @@ describe("slackThreadRead", () => {
   });
 
   it("returns an error when neither url nor channel_id+ts are provided", async () => {
-    const tool = createSlackThreadReadTool(createContext());
+    const tool = createTool();
     const result = await executeTool(tool, {});
 
     expect(result).toMatchObject({
@@ -319,7 +352,7 @@ describe("slackThreadRead", () => {
   });
 
   it("rejects invalid explicit ts format", async () => {
-    const tool = createSlackThreadReadTool(createContext());
+    const tool = createTool();
     const result = await executeTool(tool, {
       channel_id: "C123",
       ts: "not-a-timestamp",
@@ -367,7 +400,7 @@ describe("slackThreadRead", () => {
       }),
     });
 
-    const tool = createSlackThreadReadTool(createContext());
+    const tool = createTool({}, ["C_PAGED"]);
     const result = await executeTool(tool, {
       channel_id: "C_PAGED",
       ts: "1700000000.000000",
@@ -413,7 +446,7 @@ describe("slackThreadRead", () => {
       }),
     });
 
-    const tool = createSlackThreadReadTool(createContext());
+    const tool = createTool({}, ["C123"]);
     const result = await executeTool(tool, {
       channel_id: "C123",
       ts: "1700000000.100000",
@@ -446,7 +479,7 @@ describe("slackThreadRead", () => {
       }),
     });
 
-    const tool = createSlackThreadReadTool(createContext());
+    const tool = createTool({}, ["C123"]);
     await executeTool(tool, {
       url: "https://sentry.slack.com/archives/C123/p1700000000100000",
     });

--- a/packages/junior/tests/integration/slack-user-lookup.test.ts
+++ b/packages/junior/tests/integration/slack-user-lookup.test.ts
@@ -346,6 +346,8 @@ describe("slackUserLookup", () => {
           source: createSlackSource({
             teamId: "T_TEST",
             channelId: "C_TEST",
+
+            type: "priv",
           }),
           destination: {
             platform: "slack",

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -470,22 +470,62 @@ describe("bot handlers (integration)", () => {
   });
 
   it("does not persist an assistant message when final Slack delivery fails", async () => {
+    const conversationId = "slack:C_DELIVERY_FAIL:1700000000.000";
+    const sessionId = "turn_msg-delivery-fail";
     const finalText = "This reply never reaches Slack.";
+    const promptMessages = turnPiMessages("please answer");
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: finalText,
-            diagnostics: {
-              assistantMessageCount: 1,
-              modelId: "fake-agent-model",
-              outcome: "success",
-              toolCalls: [],
-              toolErrorCount: 0,
-              toolResultCount: 0,
-              usedPrimaryText: true,
-            },
-          }),
+          generateAssistantReply: async () => {
+            // Simulate respond's durable input checkpoint: the session record
+            // is running at the prompt boundary when generation finishes.
+            await upsertAgentTurnSessionRecord({
+              conversationId,
+              sessionId,
+              sliceId: 1,
+              state: "running",
+              piMessages: promptMessages,
+            });
+            return {
+              text: finalText,
+              piMessages: [
+                ...promptMessages,
+                {
+                  role: "assistant" as const,
+                  content: [{ type: "text" as const, text: finalText }],
+                  api: "responses" as const,
+                  provider: "openai",
+                  model: "gpt-5.3",
+                  usage: {
+                    input: 1,
+                    output: 1,
+                    cacheRead: 0,
+                    cacheWrite: 0,
+                    totalTokens: 2,
+                    cost: {
+                      input: 0,
+                      output: 0,
+                      cacheRead: 0,
+                      cacheWrite: 0,
+                      total: 0,
+                    },
+                  },
+                  stopReason: "stop" as const,
+                  timestamp: 2,
+                },
+              ],
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "fake-agent-model",
+                outcome: "success" as const,
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            };
+          },
         },
         visionContext: {
           listThreadReplies: async () => [],
@@ -493,7 +533,7 @@ describe("bot handlers (integration)", () => {
       },
     });
     const thread = createTestThread({
-      id: "slack:C_DELIVERY_FAIL:1700000000.000",
+      id: conversationId,
     });
     thread.post = vi.fn(async () => {
       throw new Error("Slack unavailable");
@@ -504,7 +544,7 @@ describe("bot handlers (integration)", () => {
         thread,
         createTestMessage({
           id: "msg-delivery-fail",
-          threadId: "slack:C_DELIVERY_FAIL:1700000000.000",
+          threadId: conversationId,
           text: "please answer",
           isMention: true,
         }),
@@ -544,6 +584,85 @@ describe("bot handlers (integration)", () => {
         skippedReason: "reply failed",
       },
     });
+
+    // The session must not be recorded as delivered, and the undelivered
+    // assistant reply must not surface to later turns as durable history.
+    const sessionRecord = await getAgentTurnSessionRecord(
+      conversationId,
+      sessionId,
+    );
+    expect(sessionRecord?.state).toBe("failed");
+    const projection = await loadProjection({ conversationId });
+    expect(JSON.stringify(projection)).not.toContain(finalText);
+  });
+
+  it("keeps the turn successful when persistence fails after Slack accepted the reply", async () => {
+    const conversationId = "slack:C_POST_DELIVERY:1700000000.000";
+    const finalText = "Delivered before the state store failed.";
+    const { slackRuntime } = createTestChatRuntime({
+      services: {
+        replyExecutor: {
+          generateAssistantReply: async () => ({
+            text: finalText,
+            diagnostics: {
+              assistantMessageCount: 1,
+              modelId: "fake-agent-model",
+              outcome: "success" as const,
+              toolCalls: [],
+              toolErrorCount: 0,
+              toolResultCount: 0,
+              usedPrimaryText: true,
+            },
+          }),
+        },
+        visionContext: {
+          listThreadReplies: async () => [],
+        },
+      },
+    });
+    const thread = createTestThread({ id: conversationId });
+    const originalPost = thread.post.bind(thread);
+    const originalSetState = thread.setState.bind(thread);
+    let replyPosted = false;
+    thread.post = (async (message: unknown) => {
+      const sent = await originalPost(
+        message as Parameters<typeof originalPost>[0],
+      );
+      replyPosted = true;
+      return sent;
+    }) as typeof thread.post;
+    thread.setState = (async (
+      next: Parameters<typeof originalSetState>[0],
+      options?: Parameters<typeof originalSetState>[1],
+    ) => {
+      if (replyPosted) {
+        throw new Error("state store unavailable");
+      }
+      return originalSetState(next, options);
+    }) as typeof thread.setState;
+
+    // The user already saw the answer: post-delivery persistence failures are
+    // logged, the turn stays successful, and no fallback failure reply posts.
+    await expect(
+      slackRuntime.handleNewMention(
+        thread,
+        createTestMessage({
+          id: "msg-post-delivery",
+          threadId: conversationId,
+          text: "please answer",
+          isMention: true,
+        }),
+        { destination: createTestDestination(thread) },
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(postIncludes(thread, finalText)).toBe(true);
+    expect(
+      postIncludes(
+        thread,
+        "I ran into an internal error while processing that.",
+      ),
+    ).toBe(false);
   });
 
   it("passes conversation and turn correlation IDs into assistant reply context", async () => {

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { Destination } from "@sentry/junior-plugin-api";
+import { createSlackSource, type Destination } from "@sentry/junior-plugin-api";
 import type { JuniorRuntimeServiceOverrides } from "@/chat/app/services";
 import type { ReplyRequestContext } from "@/chat/respond";
 import { makeAssistantStatus } from "@/chat/slack/assistant-thread/status";
 import { getSlackInterruptionMarker } from "@/chat/slack/output";
 import { RetryableTurnError } from "@/chat/runtime/turn";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
+import { loadProjection } from "@/chat/state/session-log";
 import {
   getAgentTurnSessionRecord,
   upsertAgentTurnSessionRecord,
@@ -64,6 +65,14 @@ function createRuntime(
         ...(services.visionContext ?? {}),
       },
     },
+  });
+}
+
+function createSlackSourceForTest(channelId: string) {
+  return createSlackSource({
+    teamId: "T123",
+    channelId,
+    threadTs: "1700000000.000",
   });
 }
 
@@ -1011,11 +1020,21 @@ describe("bot handlers (integration)", () => {
     expect(followUp?.meta?.skippedReason).toBeUndefined();
   });
 
-  it("parks auth-paused active turns without starting a new follow-up turn", async () => {
+  it("answers a follow-up as a fresh turn when the active session is auth-parked", async () => {
     const conversationId = "slack:C_AUTH_PARKED:1700000000.000";
     const activeSessionId = "turn_msg-auth-original";
-    const generateAssistantReply = vi.fn();
-    const onTurnStatePersisted = vi.fn();
+    const generateAssistantReply = vi.fn().mockResolvedValue({
+      text: "Fresh answer without the provider.",
+      diagnostics: {
+        assistantMessageCount: 1,
+        modelId: "test-model",
+        outcome: "success" as const,
+        toolCalls: [],
+        toolErrorCount: 0,
+        toolResultCount: 0,
+        usedPrimaryText: true,
+      },
+    });
     await upsertAgentTurnSessionRecord({
       conversationId,
       sessionId: activeSessionId,
@@ -1045,34 +1064,185 @@ describe("bot handlers (integration)", () => {
         text: "any update?",
         isMention: true,
       }),
-      {
-        destination: createTestDestination(thread),
-        onTurnStatePersisted,
-      },
+      { destination: createTestDestination(thread) },
     );
 
-    expect(generateAssistantReply).not.toHaveBeenCalled();
-    expect(onTurnStatePersisted).toHaveBeenCalledOnce();
-    expect(thread.posts).toEqual([]);
+    // The follow-up supersedes the pause: it must be answered, not consumed
+    // into a resume that only happens if the user ever authorizes.
+    expect(generateAssistantReply).toHaveBeenCalledOnce();
+    expect(generateAssistantReply.mock.calls[0]?.[0]).toContain("any update?");
+    expect(postIncludes(thread, "Fresh answer without the provider.")).toBe(
+      true,
+    );
+    await expect(
+      getAgentTurnSessionRecord(conversationId, activeSessionId),
+    ).resolves.toMatchObject({
+      state: "abandoned",
+      errorMessage: "Auth-parked session superseded by a new user message",
+    });
     const state = thread.getState();
     const conversation = (
       state as {
-        conversation?: {
-          messages?: Array<{
-            id?: string;
-            meta?: { replied?: boolean; skippedReason?: string };
-          }>;
-          processing?: { activeTurnId?: string };
-        };
+        conversation?: { processing?: { activeTurnId?: string } };
       }
     ).conversation;
-    expect(conversation?.processing?.activeTurnId).toBe(activeSessionId);
-    const followUp = conversation?.messages?.find(
-      (message) => message.id === "msg-auth-follow-up",
+    expect(conversation?.processing?.activeTurnId).toBeUndefined();
+  });
+
+  it("appends a parked-conversation follow-up to the session log before consuming it", async () => {
+    const conversationId = "slack:C9PARKEDLOG:1700000000.000";
+    const destination = slackDestination("C9PARKEDLOG");
+    const activeSessionId = "turn_msg-original";
+    const storedSource = createSlackSourceForTest("C9PARKEDLOG");
+    const parkedRecord = await upsertAgentTurnSessionRecord({
+      conversationId,
+      sessionId: activeSessionId,
+      sliceId: 1,
+      state: "awaiting_resume",
+      resumeReason: "yield",
+      destination,
+      source: storedSource,
+      piMessages: turnPiMessages("please keep working"),
+      turnStartMessageIndex: 0,
+    });
+    const projectionAtScheduleTime: string[] = [];
+    const scheduleAgentContinue = vi.fn(async () => {
+      projectionAtScheduleTime.push(
+        JSON.stringify(await loadProjection({ conversationId })),
+      );
+    });
+    const generateAssistantReply = vi.fn();
+    const onInputCommitted = vi.fn();
+    const { slackRuntime } = createRuntime({
+      services: {
+        replyExecutor: {
+          generateAssistantReply,
+          scheduleAgentContinue,
+        },
+      },
+    });
+
+    const thread = createTestThread({
+      id: conversationId,
+      state: createAwaitingContinuationState({ activeSessionId }),
+    });
+    const followUp = createTestMessage({
+      id: "msg-parked-follow-up",
+      threadId: conversationId,
+      text: "also check the logs",
+      isMention: true,
+    });
+
+    await slackRuntime.handleNewMention(thread, followUp, {
+      destination,
+      onInputCommitted,
+    });
+
+    expect(generateAssistantReply).not.toHaveBeenCalled();
+    expect(thread.posts).toEqual([]);
+    expect(onInputCommitted).toHaveBeenCalledOnce();
+    expect(scheduleAgentContinue).toHaveBeenCalledWith({
+      conversationId,
+      destination,
+      sessionId: activeSessionId,
+      // The append is a log-only write: the resume request stays valid.
+      expectedVersion: parkedRecord.version,
+    });
+    // The durable append happened before the continuation was scheduled.
+    expect(projectionAtScheduleTime[0]).toContain("also check the logs");
+
+    // The resumed continue() replays the record's Pi history, which must now
+    // end with the follow-up at a continuable user boundary.
+    const record = await getAgentTurnSessionRecord(
+      conversationId,
+      activeSessionId,
     );
-    expect(followUp).toBeDefined();
-    expect(followUp?.meta?.replied).toBeUndefined();
-    expect(followUp?.meta?.skippedReason).toBeUndefined();
+    expect(record?.state).toBe("awaiting_resume");
+    const lastMessage = record?.piMessages.at(-1) as
+      | { content?: Array<{ text?: string }>; role?: string }
+      | undefined;
+    expect(lastMessage?.role).toBe("user");
+    expect(JSON.stringify(lastMessage?.content)).toContain(
+      "also check the logs",
+    );
+
+    // Redelivery of the same follow-up must not duplicate the append.
+    await slackRuntime.handleNewMention(thread, followUp, {
+      destination,
+      onInputCommitted,
+    });
+    const projection = await loadProjection({ conversationId });
+    expect(
+      JSON.stringify(projection).split("also check the logs"),
+    ).toHaveLength(2);
+  });
+
+  it("suppresses the visible failure reply when the mailbox will retry the delivery", async () => {
+    const { slackRuntime } = createRuntime({
+      services: {
+        replyExecutor: {
+          generateAssistantReply: async () => {
+            throw new Error("transient turn failure");
+          },
+        },
+      },
+    });
+
+    const thread = createTestThread({
+      id: "slack:C_RETRYQUIET:1700000000.000",
+    });
+
+    await slackRuntime.handleNewMention(
+      thread,
+      createTestMessage({
+        id: "msg-retryable-failure",
+        threadId: "slack:C_RETRYQUIET:1700000000.000",
+        text: "do work",
+        isMention: true,
+      }),
+      {
+        destination: createTestDestination(thread),
+        willRetryOnFailure: () => true,
+      },
+    );
+
+    expect(thread.posts).toEqual([]);
+  });
+
+  it("posts the failure fallback on the final delivery attempt", async () => {
+    const { slackRuntime } = createRuntime({
+      services: {
+        replyExecutor: {
+          generateAssistantReply: async () => {
+            throw new Error("persistent turn failure");
+          },
+        },
+      },
+    });
+
+    const thread = createTestThread({
+      id: "slack:C_RETRYFINAL:1700000000.000",
+    });
+
+    await slackRuntime.handleNewMention(
+      thread,
+      createTestMessage({
+        id: "msg-final-failure",
+        threadId: "slack:C_RETRYFINAL:1700000000.000",
+        text: "do work",
+        isMention: true,
+      }),
+      {
+        destination: createTestDestination(thread),
+        willRetryOnFailure: () => false,
+      },
+    );
+
+    expect(thread.posts).toEqual([
+      expect.stringContaining(
+        "I ran into an internal error while processing that.",
+      ),
+    ]);
   });
 
   it("fails malformed awaiting continuations before handling the follow-up", async () => {

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -1072,7 +1072,7 @@ describe("bot handlers (integration)", () => {
       expectedVersion: 4,
     });
     const generateAssistantReply = vi.fn();
-    const onInputCommitted = vi.fn();
+    const ack = vi.fn();
     const onTurnStatePersisted = vi.fn();
     const { slackRuntime } = createRuntime({
       services: {
@@ -1100,7 +1100,7 @@ describe("bot handlers (integration)", () => {
         }),
         {
           destination,
-          onInputCommitted,
+          ack,
           onTurnStatePersisted,
         },
       ),
@@ -1118,7 +1118,7 @@ describe("bot handlers (integration)", () => {
     });
     expect(generateAssistantReply).not.toHaveBeenCalled();
     expect(onTurnStatePersisted).toHaveBeenCalledOnce();
-    expect(onInputCommitted).toHaveBeenCalledOnce();
+    expect(ack).toHaveBeenCalledOnce();
     expect(thread.posts).toEqual([]);
 
     const state = thread.getState();
@@ -1234,7 +1234,7 @@ describe("bot handlers (integration)", () => {
       );
     });
     const generateAssistantReply = vi.fn();
-    const onInputCommitted = vi.fn();
+    const ack = vi.fn();
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
@@ -1257,12 +1257,12 @@ describe("bot handlers (integration)", () => {
 
     await slackRuntime.handleNewMention(thread, followUp, {
       destination,
-      onInputCommitted,
+      ack,
     });
 
     expect(generateAssistantReply).not.toHaveBeenCalled();
     expect(thread.posts).toEqual([]);
-    expect(onInputCommitted).toHaveBeenCalledOnce();
+    expect(ack).toHaveBeenCalledOnce();
     expect(scheduleAgentContinue).toHaveBeenCalledWith({
       conversationId,
       destination,
@@ -1291,7 +1291,7 @@ describe("bot handlers (integration)", () => {
     // Redelivery of the same follow-up must not duplicate the append.
     await slackRuntime.handleNewMention(thread, followUp, {
       destination,
-      onInputCommitted,
+      ack,
     });
     const projection = await loadProjection({ conversationId });
     expect(
@@ -1371,7 +1371,7 @@ describe("bot handlers (integration)", () => {
       turnStartMessageIndex: 0,
     });
     const scheduleAgentContinue = vi.fn();
-    const onInputCommitted = vi.fn();
+    const ack = vi.fn();
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
@@ -1397,17 +1397,19 @@ describe("bot handlers (integration)", () => {
     const lock = await acquireActiveLock(stateAdapter, conversationId);
     expect(lock).not.toBeNull();
     try {
-      await slackRuntime.handleNewMention(thread, followUp, {
-        destination,
-        onInputCommitted,
-      });
+      await expect(
+        slackRuntime.handleNewMention(thread, followUp, {
+          destination,
+          ack,
+        }),
+      ).rejects.toThrow("Turn input is deferred until the active resume ends");
     } finally {
       await stateAdapter.releaseLock(lock!);
     }
 
     // The message was not consumed and nothing was appended or scheduled: it
     // stays pending in the mailbox for the next drain.
-    expect(onInputCommitted).not.toHaveBeenCalled();
+    expect(ack).not.toHaveBeenCalled();
     expect(scheduleAgentContinue).not.toHaveBeenCalled();
     expect(
       JSON.stringify(await loadProjection({ conversationId })),
@@ -1439,11 +1441,51 @@ describe("bot handlers (integration)", () => {
       }),
       {
         destination: createTestDestination(thread),
-        willRetryOnFailure: () => true,
+        isFinalAttempt: false,
       },
     );
 
     expect(thread.posts).toEqual([]);
+  });
+
+  it("posts the failure fallback after ack even when the attempt is not final", async () => {
+    const ack = vi.fn().mockResolvedValue(undefined);
+    const { slackRuntime } = createRuntime({
+      services: {
+        replyExecutor: {
+          generateAssistantReply: async (_input, context) => {
+            await context.onInputCommitted?.();
+            throw new Error("post-ack turn failure");
+          },
+        },
+      },
+    });
+
+    const thread = createTestThread({
+      id: "slack:C_RETRYACKED:1700000000.000",
+    });
+
+    await slackRuntime.handleNewMention(
+      thread,
+      createTestMessage({
+        id: "msg-acked-failure",
+        threadId: "slack:C_RETRYACKED:1700000000.000",
+        text: "do work",
+        isMention: true,
+      }),
+      {
+        ack,
+        destination: createTestDestination(thread),
+        isFinalAttempt: false,
+      },
+    );
+
+    expect(ack).toHaveBeenCalledOnce();
+    expect(thread.posts).toEqual([
+      expect.stringContaining(
+        "I ran into an internal error while processing that.",
+      ),
+    ]);
   });
 
   it("posts the failure fallback on the final delivery attempt", async () => {
@@ -1471,7 +1513,7 @@ describe("bot handlers (integration)", () => {
       }),
       {
         destination: createTestDestination(thread),
-        willRetryOnFailure: () => false,
+        isFinalAttempt: true,
       },
     );
 

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -74,6 +74,8 @@ function createSlackSourceForTest(channelId: string) {
     teamId: "T123",
     channelId,
     threadTs: "1700000000.000",
+
+    type: "priv",
   });
 }
 

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -5,7 +5,8 @@ import type { ReplyRequestContext } from "@/chat/respond";
 import { makeAssistantStatus } from "@/chat/slack/assistant-thread/status";
 import { getSlackInterruptionMarker } from "@/chat/slack/output";
 import { RetryableTurnError } from "@/chat/runtime/turn";
-import { disconnectStateAdapter } from "@/chat/state/adapter";
+import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
+import { acquireActiveLock } from "@/chat/state/locks";
 import { loadProjection } from "@/chat/state/session-log";
 import {
   getAgentTurnSessionRecord,
@@ -1294,6 +1295,121 @@ describe("bot handlers (integration)", () => {
     expect(
       JSON.stringify(projection).split("also check the logs"),
     ).toHaveLength(2);
+  });
+
+  it("appends only the missing parked messages on a partial-overlap redelivery", async () => {
+    const conversationId = "slack:C9PARKEDPART:1700000000.000";
+    const destination = slackDestination("C9PARKEDPART");
+    const activeSessionId = "turn_msg-original";
+    await upsertAgentTurnSessionRecord({
+      conversationId,
+      sessionId: activeSessionId,
+      sliceId: 1,
+      state: "awaiting_resume",
+      resumeReason: "yield",
+      destination,
+      source: createSlackSourceForTest("C9PARKEDPART"),
+      piMessages: turnPiMessages("please keep working"),
+      turnStartMessageIndex: 0,
+    });
+    const scheduleAgentContinue = vi.fn();
+    const { slackRuntime } = createRuntime({
+      services: {
+        replyExecutor: {
+          generateAssistantReply: vi.fn(),
+          scheduleAgentContinue,
+        },
+      },
+    });
+    const thread = createTestThread({
+      id: conversationId,
+      state: createAwaitingContinuationState({ activeSessionId }),
+    });
+    const first = createTestMessage({
+      id: "msg-parked-first",
+      threadId: conversationId,
+      text: "first follow-up",
+      isMention: true,
+    });
+    const second = createTestMessage({
+      id: "msg-parked-second",
+      threadId: conversationId,
+      text: "second follow-up",
+      isMention: true,
+    });
+
+    // First delivery durably appends the first follow-up.
+    await slackRuntime.handleNewMention(thread, first, { destination });
+
+    // Redelivery arrives carrying the already-appended message plus a new
+    // one; only the missing message may be appended.
+    await slackRuntime.handleNewMention(thread, second, {
+      destination,
+      messageContext: { skipped: [first], totalSinceLastHandler: 1 },
+    });
+
+    const serialized = JSON.stringify(await loadProjection({ conversationId }));
+    expect(serialized.split("first follow-up")).toHaveLength(2);
+    expect(serialized.split("second follow-up")).toHaveLength(2);
+  });
+
+  it("leaves the parked follow-up unconsumed while a live resume holds the thread lock", async () => {
+    const conversationId = "slack:C9PARKEDLOCK:1700000000.000";
+    const destination = slackDestination("C9PARKEDLOCK");
+    const activeSessionId = "turn_msg-original";
+    await upsertAgentTurnSessionRecord({
+      conversationId,
+      sessionId: activeSessionId,
+      sliceId: 1,
+      state: "awaiting_resume",
+      resumeReason: "yield",
+      destination,
+      source: createSlackSourceForTest("C9PARKEDLOCK"),
+      piMessages: turnPiMessages("please keep working"),
+      turnStartMessageIndex: 0,
+    });
+    const scheduleAgentContinue = vi.fn();
+    const onInputCommitted = vi.fn();
+    const { slackRuntime } = createRuntime({
+      services: {
+        replyExecutor: {
+          generateAssistantReply: vi.fn(),
+          scheduleAgentContinue,
+        },
+      },
+    });
+    const thread = createTestThread({
+      id: conversationId,
+      state: createAwaitingContinuationState({ activeSessionId }),
+    });
+    const followUp = createTestMessage({
+      id: "msg-parked-locked",
+      threadId: conversationId,
+      text: "also check the logs",
+      isMention: true,
+    });
+
+    // Simulate a live resume: it holds the thread resume lock for its run.
+    const stateAdapter = getStateAdapter();
+    await stateAdapter.connect();
+    const lock = await acquireActiveLock(stateAdapter, conversationId);
+    expect(lock).not.toBeNull();
+    try {
+      await slackRuntime.handleNewMention(thread, followUp, {
+        destination,
+        onInputCommitted,
+      });
+    } finally {
+      await stateAdapter.releaseLock(lock!);
+    }
+
+    // The message was not consumed and nothing was appended or scheduled: it
+    // stays pending in the mailbox for the next drain.
+    expect(onInputCommitted).not.toHaveBeenCalled();
+    expect(scheduleAgentContinue).not.toHaveBeenCalled();
+    expect(
+      JSON.stringify(await loadProjection({ conversationId })),
+    ).not.toContain("also check the logs");
   });
 
   it("suppresses the visible failure reply when the mailbox will retry the delivery", async () => {

--- a/packages/junior/tests/integration/slack/finalized-reply-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/finalized-reply-behavior.test.ts
@@ -201,6 +201,41 @@ describe("Slack behavior: finalized thread replies", () => {
     ]);
   });
 
+  it("posts a failure fallback instead of completing an empty final post plan", async () => {
+    const { slackRuntime } = createTestChatRuntime({
+      services: {
+        replyExecutor: {
+          generateAssistantReply: async () => ({
+            text: "",
+            deliveryPlan: {
+              mode: "thread",
+              postThreadText: true,
+              attachFiles: "none",
+            },
+            diagnostics: makeDiagnostics(),
+          }),
+        },
+      },
+    });
+
+    const thread = createTestThread({ id: "slack:C_FINAL:1700006005.000" });
+    await slackRuntime.handleNewMention(
+      thread,
+      createTestMessage({
+        id: "m-final-empty-plan",
+        text: "<@U_APP> reply invisibly",
+        isMention: true,
+        threadId: thread.id,
+      }),
+      { destination: createTestDestination(thread), isFinalAttempt: true },
+    );
+
+    expect(thread.postKinds).toEqual(["value"]);
+    expect(toPostedText(thread.posts[0])).toContain(
+      "I ran into an internal error while processing that.",
+    );
+  });
+
   it("does not delete an ack reply when it also carries files", async () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {

--- a/packages/junior/tests/integration/slack/message-changed-gate-contract.test.ts
+++ b/packages/junior/tests/integration/slack/message-changed-gate-contract.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
+import {
+  SLACK_BOT_USER_ID,
+  createConversationWorkQueueTestAdapter,
+  createNoopSlackWebhookRuntime,
+  createSlackAdapterFixture,
+  handleSlackWebhookAndFlush,
+  slackWebhookRequest,
+} from "../../fixtures/conversation-work";
+
+const EDITED_TS = "1712345.0042";
+
+function messageChangedEnvelope(message: {
+  bot_id?: string;
+  user: string;
+  user_team?: string;
+}) {
+  const editedText = `<@${SLACK_BOT_USER_ID}> edited ask`;
+  return {
+    team_id: "T123",
+    type: "event_callback",
+    event: {
+      type: "message",
+      subtype: "message_changed",
+      channel: "C123",
+      hidden: true,
+      message: {
+        type: "message",
+        text: editedText,
+        ts: EDITED_TS,
+        ...message,
+      },
+      previous_message: {
+        type: "message",
+        user: message.user,
+        text: "edited ask",
+        ts: EDITED_TS,
+      },
+    },
+  };
+}
+
+describe("Slack message_changed author gate contract", () => {
+  afterEach(async () => {
+    await disconnectStateAdapter();
+  });
+
+  async function runEditedMentionWebhook(envelope: unknown) {
+    const queue = createConversationWorkQueueTestAdapter();
+    const state = getStateAdapter();
+    await state.connect();
+    const slackAdapter = createSlackAdapterFixture();
+
+    const response = await handleSlackWebhookAndFlush({
+      request: slackWebhookRequest(envelope),
+      services: {
+        getSlackAdapter: () => slackAdapter,
+        queue,
+        runtime: createNoopSlackWebhookRuntime(),
+        state,
+      },
+    });
+    return { queue, response };
+  }
+
+  it("drops an edited mention from a Slack Connect external user", async () => {
+    const { queue, response } = await runEditedMentionWebhook(
+      messageChangedEnvelope({ user: "U_EXTERNAL", user_team: "T_OTHER_ORG" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(queue.sentRecords()).toEqual([]);
+  });
+
+  it("drops a bot-authored edit that adds a mention", async () => {
+    const { queue, response } = await runEditedMentionWebhook(
+      messageChangedEnvelope({ bot_id: "B_JUNIOR", user: SLACK_BOT_USER_ID }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(queue.sentRecords()).toEqual([]);
+  });
+
+  it("routes an edited mention from a same-workspace user", async () => {
+    const { queue, response } = await runEditedMentionWebhook(
+      messageChangedEnvelope({ user: "U123", user_team: "T123" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(queue.sentRecords()).toEqual([
+      expect.objectContaining({
+        conversationId: `slack:C123:${EDITED_TS}`,
+      }),
+    ]);
+  });
+});

--- a/packages/junior/tests/integration/slack/outbound-installation-token-contract.test.ts
+++ b/packages/junior/tests/integration/slack/outbound-installation-token-contract.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { runWithSlackInstallationToken } from "@/chat/slack/client";
+import { postSlackMessage } from "@/chat/slack/outbound";
+import {
+  getCapturedSlackApiCalls,
+  resetSlackApiMockState,
+} from "../../msw/handlers/slack-api";
+
+describe("Slack contract: outbound installation token", () => {
+  beforeEach(() => {
+    process.env.SLACK_BOT_TOKEN =
+      process.env.SLACK_BOT_TOKEN ?? "xoxb-test-token";
+    resetSlackApiMockState();
+  });
+
+  it("posts with the ambient destination installation token when bound", async () => {
+    await runWithSlackInstallationToken(
+      "xoxb-destination-workspace-token",
+      () =>
+        postSlackMessage({
+          channelId: "slack:C123",
+          text: "hello from another workspace",
+        }),
+    );
+
+    const calls = getCapturedSlackApiCalls("chat.postMessage");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.headers.authorization).toBe(
+      "Bearer xoxb-destination-workspace-token",
+    );
+  });
+
+  it("posts with the env bot token when no installation token is bound", async () => {
+    await postSlackMessage({
+      channelId: "slack:C123",
+      text: "hello from the default workspace",
+    });
+
+    const calls = getCapturedSlackApiCalls("chat.postMessage");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.headers.authorization).toBe("Bearer xoxb-test-token");
+  });
+});

--- a/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
@@ -1151,9 +1151,9 @@ describe("Slack behavior: subscribed messages", () => {
 
   // Regression: skipped subscribed messages must commit inbound input so the
   // durable mailbox does not re-enqueue them forever.
-  it("calls onInputCommitted when preflight skips a message directed at another user", async () => {
+  it("calls ack when preflight skips a message directed at another user", async () => {
     const { slackRuntime } = createRuntime();
-    const onInputCommitted = vi.fn().mockResolvedValue(undefined);
+    const ack = vi.fn().mockResolvedValue(undefined);
     const thread = createTestThread({ id: "slack:C_REGRESS:1700010000.001" });
 
     await slackRuntime.handleSubscribedMessage(
@@ -1165,16 +1165,16 @@ describe("Slack behavior: subscribed messages", () => {
         threadId: thread.id,
         author: { userId: "U_TESTER" },
       }),
-      { destination: createTestDestination(thread), onInputCommitted },
+      { destination: createTestDestination(thread), ack },
     );
 
-    expect(onInputCommitted).toHaveBeenCalledTimes(1);
+    expect(ack).toHaveBeenCalledTimes(1);
     expect(thread.posts).toHaveLength(0);
   });
 
   it("preserves an unrelated active continuation when preflight skips a message", async () => {
     const { slackRuntime } = createRuntime();
-    const onInputCommitted = vi.fn().mockResolvedValue(undefined);
+    const ack = vi.fn().mockResolvedValue(undefined);
     const activeTurnId = "turn_existing_resume";
     const thread = createTestThread({
       id: "slack:C_REGRESS:1700010000.005",
@@ -1196,19 +1196,19 @@ describe("Slack behavior: subscribed messages", () => {
         threadId: thread.id,
         author: { userId: "U_TESTER" },
       }),
-      { destination: createTestDestination(thread), onInputCommitted },
+      { destination: createTestDestination(thread), ack },
     );
 
     const state = (await thread.state) ?? {};
     const conversation = state.conversation as {
       processing?: { activeTurnId?: string };
     };
-    expect(onInputCommitted).toHaveBeenCalledTimes(1);
+    expect(ack).toHaveBeenCalledTimes(1);
     expect(conversation.processing?.activeTurnId).toBe(activeTurnId);
     expect(thread.posts).toHaveLength(0);
   });
 
-  it("calls onInputCommitted when the classifier decides not to reply", async () => {
+  it("calls ack when the classifier decides not to reply", async () => {
     const { slackRuntime } = createRuntime({
       services: {
         subscribedReplyPolicy: {
@@ -1224,7 +1224,7 @@ describe("Slack behavior: subscribed messages", () => {
         },
       },
     });
-    const onInputCommitted = vi.fn().mockResolvedValue(undefined);
+    const ack = vi.fn().mockResolvedValue(undefined);
     const thread = createTestThread({ id: "slack:C_REGRESS:1700010000.002" });
 
     await slackRuntime.handleSubscribedMessage(
@@ -1236,14 +1236,14 @@ describe("Slack behavior: subscribed messages", () => {
         threadId: thread.id,
         author: { userId: "U_TESTER" },
       }),
-      { destination: createTestDestination(thread), onInputCommitted },
+      { destination: createTestDestination(thread), ack },
     );
 
-    expect(onInputCommitted).toHaveBeenCalledTimes(1);
+    expect(ack).toHaveBeenCalledTimes(1);
     expect(thread.posts).toHaveLength(0);
   });
 
-  it("calls onInputCommitted on the opt-out skip path", async () => {
+  it("calls ack on the opt-out skip path", async () => {
     const { slackRuntime } = createRuntime({
       services: {
         subscribedReplyPolicy: {
@@ -1260,7 +1260,7 @@ describe("Slack behavior: subscribed messages", () => {
         },
       },
     });
-    const onInputCommitted = vi.fn().mockResolvedValue(undefined);
+    const ack = vi.fn().mockResolvedValue(undefined);
     const thread = createTestThread({ id: "slack:C_REGRESS:1700010000.003" });
     // Subscribe first so opt-out has something to unsubscribe from.
     thread.subscribe();
@@ -1274,18 +1274,18 @@ describe("Slack behavior: subscribed messages", () => {
         threadId: thread.id,
         author: { userId: "U_TESTER" },
       }),
-      { destination: createTestDestination(thread), onInputCommitted },
+      { destination: createTestDestination(thread), ack },
     );
 
-    expect(onInputCommitted).toHaveBeenCalledTimes(1);
+    expect(ack).toHaveBeenCalledTimes(1);
   });
 
-  it("propagates TurnInputCommitLostError when onInputCommitted fails on skip", async () => {
+  it("propagates TurnInputCommitLostError when ack fails on skip", async () => {
     const { slackRuntime } = createRuntime();
     const commitError = new TurnInputCommitLostError(
       "lease lost during skip commit",
     );
-    const onInputCommitted = vi.fn().mockRejectedValue(commitError);
+    const ack = vi.fn().mockRejectedValue(commitError);
     const thread = createTestThread({ id: "slack:C_REGRESS:1700010000.004" });
 
     await expect(
@@ -1298,7 +1298,7 @@ describe("Slack behavior: subscribed messages", () => {
           threadId: thread.id,
           author: { userId: "U_TESTER" },
         }),
-        { destination: createTestDestination(thread), onInputCommitted },
+        { destination: createTestDestination(thread), ack },
       ),
     ).rejects.toThrow(TurnInputCommitLostError);
   });

--- a/packages/junior/tests/integration/slack/webhook-persistence-contract.test.ts
+++ b/packages/junior/tests/integration/slack/webhook-persistence-contract.test.ts
@@ -1,7 +1,15 @@
+import type { StateAdapter } from "chat";
 import { afterEach, describe, expect, it } from "vitest";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
+import { createJuniorSlackAdapter } from "@/chat/slack/adapter";
+import { authTestOk } from "../../fixtures/slack/factories/api";
+import {
+  queueSlackApiError,
+  queueSlackApiResponse,
+} from "../../msw/handlers/slack-api";
 import {
   SLACK_BOT_USER_ID,
+  SLACK_SIGNING_SECRET,
   createConversationWorkQueueTestAdapter,
   createNoopSlackWebhookRuntime,
   createSlackAdapterFixture,
@@ -9,6 +17,20 @@ import {
   slackEnvelope,
   slackWebhookRequest,
 } from "../../fixtures/conversation-work";
+
+function failIsSubscribed(state: StateAdapter): StateAdapter {
+  return new Proxy(state, {
+    get(target, prop, receiver) {
+      if (prop === "isSubscribed") {
+        return async () => {
+          throw new Error("transient state read failure");
+        };
+      }
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  }) as StateAdapter;
+}
 
 describe("Slack webhook persistence contract", () => {
   afterEach(async () => {
@@ -53,4 +75,91 @@ describe("Slack webhook persistence contract", () => {
       expect(queue.queuedMessages()).toEqual([]);
     },
   );
+
+  it("returns retryable response when a routing-state read fails before persistence", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    const state = getStateAdapter();
+    await state.connect();
+    const slackAdapter = createSlackAdapterFixture();
+
+    const response = await handleSlackWebhookAndFlush({
+      request: slackWebhookRequest(
+        slackEnvelope({ eventType: "message", text: "no mention here" }),
+      ),
+      services: {
+        getSlackAdapter: () => slackAdapter,
+        queue,
+        runtime: createNoopSlackWebhookRuntime(),
+        state: failIsSubscribed(state),
+      },
+    });
+
+    expect(response.status).toBe(503);
+    expect(queue.queuedMessages()).toEqual([]);
+  });
+
+  it("acks unsubscribed channel chatter without retry when routing state is healthy", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    const state = getStateAdapter();
+    await state.connect();
+    const slackAdapter = createSlackAdapterFixture();
+
+    const response = await handleSlackWebhookAndFlush({
+      request: slackWebhookRequest(
+        slackEnvelope({ eventType: "message", text: "no mention here" }),
+      ),
+      services: {
+        getSlackAdapter: () => slackAdapter,
+        queue,
+        runtime: createNoopSlackWebhookRuntime(),
+        state,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(queue.queuedMessages()).toEqual([]);
+  });
+
+  it("returns retryable response for unresolved bot identity and recovers on redelivery", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    const state = getStateAdapter();
+    await state.connect();
+    // No configured botUserId: identity must come from auth.test at initialize.
+    const slackAdapter = createJuniorSlackAdapter({
+      botToken: "slack-bot-fixture",
+      signingSecret: SLACK_SIGNING_SECRET,
+    });
+    queueSlackApiError("auth.test", { error: "invalid_auth" });
+    const services = {
+      getSlackAdapter: () => slackAdapter,
+      queue,
+      runtime: createNoopSlackWebhookRuntime(),
+      state,
+    };
+    const envelope = slackEnvelope({
+      text: `<@${SLACK_BOT_USER_ID}> deploy status`,
+    });
+
+    const failedResponse = await handleSlackWebhookAndFlush({
+      request: slackWebhookRequest(envelope),
+      services,
+    });
+
+    expect(failedResponse.status).toBe(503);
+    expect(queue.queuedMessages()).toEqual([]);
+
+    // Slack redelivers: initialization must not have cached the broken
+    // adapter, so a healthy auth.test resolves identity and the message routes.
+    queueSlackApiResponse("auth.test", {
+      body: authTestOk({ userId: SLACK_BOT_USER_ID }),
+    });
+
+    const retriedResponse = await handleSlackWebhookAndFlush({
+      request: slackWebhookRequest(envelope),
+      services,
+    });
+
+    expect(retriedResponse.status).toBe(200);
+    expect(queue.queuedMessages()).toHaveLength(1);
+  });
 });

--- a/packages/junior/tests/integration/tool-idempotency.test.ts
+++ b/packages/junior/tests/integration/tool-idempotency.test.ts
@@ -60,6 +60,8 @@ function slackContext(channelId: string): SlackToolContext {
     source: createSlackSource({
       teamId: "T123",
       channelId,
+
+      type: "priv",
     }),
     destinationChannelId: channelId,
     sourceChannelId: channelId,

--- a/packages/junior/tests/msw/handlers/slack-api.ts
+++ b/packages/junior/tests/msw/handlers/slack-api.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from "msw";
 import {
   slackOk,
+  authTestOk,
   canvasesAccessSetOk,
   canvasesCreateOk,
   canvasesEditOk,
@@ -30,6 +31,7 @@ const PRIVATE_FILE_DOWNLOAD_KEY = "__files.download.private__";
 
 export const SUPPORTED_SLACK_API_METHODS = [
   "assistant.threads.setStatus",
+  "auth.test",
   "assistant.threads.setSuggestedPrompts",
   "assistant.threads.setTitle",
   "chat.postMessage",
@@ -185,6 +187,8 @@ function defaultSlackApiResponse(
     case "assistant.threads.setSuggestedPrompts":
     case "assistant.threads.setTitle":
       return { body: slackOk() };
+    case "auth.test":
+      return { body: authTestOk() };
     case "chat.postMessage":
       return { body: chatPostMessageOk() };
     case "chat.delete":

--- a/packages/junior/tests/unit/conversations/sql-migrations.test.ts
+++ b/packages/junior/tests/unit/conversations/sql-migrations.test.ts
@@ -76,7 +76,7 @@ describe("conversation SQL migrations", () => {
     expect(executor.statements[0]).toContain(
       "CREATE TABLE IF NOT EXISTS junior_schema_migrations",
     );
-    expect(executor.transactions).toHaveLength(1);
+    expect(executor.transactions).toHaveLength(2);
     expect(executor.transactions[0]).toEqual(
       expect.arrayContaining([
         expect.stringContaining("CREATE TABLE IF NOT EXISTS junior_identities"),
@@ -89,11 +89,19 @@ describe("conversation SQL migrations", () => {
         expect.stringContaining("INSERT INTO junior_schema_migrations"),
       ]),
     );
+    expect(executor.transactions[1]).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          "ADD COLUMN IF NOT EXISTS visibility_confirmed_at",
+        ),
+      ]),
+    );
   });
 
   it("does not reapply migrations already recorded with the same checksum", async () => {
-    const migration = migrations[0];
-    const executor = new FakeSqlExecutor([[migration.id, migration.checksum]]);
+    const executor = new FakeSqlExecutor(
+      migrations.map((migration) => [migration.id, migration.checksum]),
+    );
 
     await migrateSchema(executor);
 

--- a/packages/junior/tests/unit/conversations/sql-migrations.test.ts
+++ b/packages/junior/tests/unit/conversations/sql-migrations.test.ts
@@ -89,13 +89,6 @@ describe("conversation SQL migrations", () => {
         expect.stringContaining("INSERT INTO junior_schema_migrations"),
       ]),
     );
-    expect(executor.transactions[1]).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining(
-          "ADD COLUMN IF NOT EXISTS visibility_confirmed_at",
-        ),
-      ]),
-    );
   });
 
   it("does not reapply migrations already recorded with the same checksum", async () => {

--- a/packages/junior/tests/unit/handlers/oauth-callback.test.ts
+++ b/packages/junior/tests/unit/handlers/oauth-callback.test.ts
@@ -663,6 +663,8 @@ describe("oauth callback handler", () => {
         teamId: "T123",
         channelId: "C123",
         threadTs: "123.789",
+
+        type: "priv",
       }),
       threadTs: "123.789",
       pendingMessage: "list my sentry issues",

--- a/packages/junior/tests/unit/handlers/oauth-resume.test.ts
+++ b/packages/junior/tests/unit/handlers/oauth-resume.test.ts
@@ -81,6 +81,8 @@ function testSlackSource(threadTs: string) {
     teamId: TEST_SLACK_DESTINATION.teamId,
     channelId: TEST_SLACK_DESTINATION.channelId,
     threadTs,
+
+    type: "priv",
   });
 }
 

--- a/packages/junior/tests/unit/pi/client.test.ts
+++ b/packages/junior/tests/unit/pi/client.test.ts
@@ -185,6 +185,53 @@ describe("completeText", () => {
     );
   });
 
+  it("scrubs C-prefixed channel traces unless the turn confirmed the channel public", async () => {
+    mocks.completeSimple.mockResolvedValue({
+      content: [{ type: "text", text: "maybe private answer" }],
+      stopReason: "stop",
+      usage: { input: 12, output: 4, totalTokens: 16 },
+    });
+
+    const { completeText } = await import("@/chat/pi/client");
+    const { runWithConversationPrivacy } =
+      await import("@/chat/conversation-privacy");
+
+    // Modern Slack private channels also use C ids: without a confirmed
+    // signal the capture stays metadata-only.
+    await completeText({
+      modelId: "openai/gpt-4o-mini",
+      messages: [
+        { role: "user", content: "possibly private question", timestamp: 1 },
+      ] as any,
+      metadata: { conversationId: "slack:C1:123", channelId: "C1" },
+    });
+    const unconfirmed = mocks.withSpan.mock.calls[0]?.[4] as Record<
+      string,
+      unknown
+    >;
+    expect(unconfirmed["app.conversation.privacy"]).toBe("private");
+    expect(unconfirmed["gen_ai.input.messages"]).not.toContain(
+      "possibly private question",
+    );
+
+    // The turn-scoped privacy context carries the source-confirmed signal.
+    await runWithConversationPrivacy("public", () =>
+      completeText({
+        modelId: "openai/gpt-4o-mini",
+        messages: [
+          { role: "user", content: "public question", timestamp: 1 },
+        ] as any,
+        metadata: { conversationId: "slack:C1:123", channelId: "C1" },
+      }),
+    );
+    const confirmed = mocks.withSpan.mock.calls[1]?.[4] as Record<
+      string,
+      unknown
+    >;
+    expect(confirmed["app.conversation.privacy"]).toBe("public");
+    expect(confirmed["gen_ai.input.messages"]).toContain("public question");
+  });
+
   it("uses AI SDK structured output for object completions", async () => {
     mocks.generateObject.mockResolvedValue({
       object: { ok: true },

--- a/packages/junior/tests/unit/pi/client.test.ts
+++ b/packages/junior/tests/unit/pi/client.test.ts
@@ -205,12 +205,12 @@ describe("completeText", () => {
       ] as any,
       metadata: { conversationId: "slack:C1:123", channelId: "C1" },
     });
-    const unconfirmed = mocks.withSpan.mock.calls[0]?.[4] as Record<
+    const noSignal = mocks.withSpan.mock.calls[0]?.[4] as Record<
       string,
       unknown
     >;
-    expect(unconfirmed["app.conversation.privacy"]).toBe("private");
-    expect(unconfirmed["gen_ai.input.messages"]).not.toContain(
+    expect(noSignal["app.conversation.privacy"]).toBe("private");
+    expect(noSignal["gen_ai.input.messages"]).not.toContain(
       "possibly private question",
     );
 
@@ -224,12 +224,12 @@ describe("completeText", () => {
         metadata: { conversationId: "slack:C1:123", channelId: "C1" },
       }),
     );
-    const confirmed = mocks.withSpan.mock.calls[1]?.[4] as Record<
+    const publicSignal = mocks.withSpan.mock.calls[1]?.[4] as Record<
       string,
       unknown
     >;
-    expect(confirmed["app.conversation.privacy"]).toBe("public");
-    expect(confirmed["gen_ai.input.messages"]).toContain("public question");
+    expect(publicSignal["app.conversation.privacy"]).toBe("public");
+    expect(publicSignal["gen_ai.input.messages"]).toContain("public question");
   });
 
   it("uses AI SDK structured output for object completions", async () => {

--- a/packages/junior/tests/unit/plugin-api-source.test.ts
+++ b/packages/junior/tests/unit/plugin-api-source.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from "vitest";
 import { createSlackSource } from "@sentry/junior-plugin-api";
 
 describe("plugin source helpers", () => {
-  it("classifies Slack source visibility from the event channel_type signal", () => {
+  it("accepts Slack source visibility from the runtime boundary", () => {
     expect(
       createSlackSource({
         teamId: "T123",
         channelId: "C123",
-        channelType: "channel",
+        type: "pub",
       }),
     ).toMatchObject({ type: "pub" });
     // Modern Slack private channels also use C-prefixed ids.
@@ -15,20 +15,32 @@ describe("plugin source helpers", () => {
       createSlackSource({
         teamId: "T123",
         channelId: "C123",
-        channelType: "group",
+        type: "priv",
       }),
     ).toMatchObject({ type: "priv" });
   });
 
-  it("fails closed to private when no channel_type signal exists", () => {
+  it("constructs private Slack sources from caller-provided visibility", () => {
     expect(
-      createSlackSource({ teamId: "T123", channelId: "C123" }),
+      createSlackSource({
+        teamId: "T123",
+        channelId: "C123",
+        type: "priv",
+      }),
     ).toMatchObject({ type: "priv" });
     expect(
-      createSlackSource({ teamId: "T123", channelId: "G123" }),
+      createSlackSource({
+        teamId: "T123",
+        channelId: "G123",
+        type: "priv",
+      }),
     ).toMatchObject({ type: "priv" });
     expect(
-      createSlackSource({ teamId: "T123", channelId: "D123" }),
+      createSlackSource({
+        teamId: "T123",
+        channelId: "D123",
+        type: "priv",
+      }),
     ).toMatchObject({ type: "priv" });
   });
 });

--- a/packages/junior/tests/unit/plugin-api-source.test.ts
+++ b/packages/junior/tests/unit/plugin-api-source.test.ts
@@ -2,10 +2,28 @@ import { describe, expect, it } from "vitest";
 import { createSlackSource } from "@sentry/junior-plugin-api";
 
 describe("plugin source helpers", () => {
-  it("infers Slack source visibility from channel ids when event type is unavailable", () => {
+  it("classifies Slack source visibility from the event channel_type signal", () => {
+    expect(
+      createSlackSource({
+        teamId: "T123",
+        channelId: "C123",
+        channelType: "channel",
+      }),
+    ).toMatchObject({ type: "pub" });
+    // Modern Slack private channels also use C-prefixed ids.
+    expect(
+      createSlackSource({
+        teamId: "T123",
+        channelId: "C123",
+        channelType: "group",
+      }),
+    ).toMatchObject({ type: "priv" });
+  });
+
+  it("fails closed to private when no channel_type signal exists", () => {
     expect(
       createSlackSource({ teamId: "T123", channelId: "C123" }),
-    ).toMatchObject({ type: "pub" });
+    ).toMatchObject({ type: "priv" });
     expect(
       createSlackSource({ teamId: "T123", channelId: "G123" }),
     ).toMatchObject({ type: "priv" });

--- a/packages/junior/tests/unit/plugins/agent-hooks.test.ts
+++ b/packages/junior/tests/unit/plugins/agent-hooks.test.ts
@@ -123,14 +123,23 @@ function fakeSandbox(
 }
 
 describe("agent plugin hooks", () => {
-  it("infers Slack source visibility from channel ID prefixes", () => {
+  it("classifies Slack source visibility from the channel_type signal", () => {
+    expect(
+      createSlackSource({
+        teamId: "T123",
+        channelId: "C123",
+        channelType: "channel",
+        threadTs: "1718800000.000000",
+      }).type,
+    ).toBe("pub");
+    // Without a signal, C-prefixed channels fail closed to private.
     expect(
       createSlackSource({
         teamId: "T123",
         channelId: "C123",
         threadTs: "1718800000.000000",
       }).type,
-    ).toBe("pub");
+    ).toBe("priv");
     expect(
       createSlackSource({
         teamId: "T123",

--- a/packages/junior/tests/unit/plugins/agent-hooks.test.ts
+++ b/packages/junior/tests/unit/plugins/agent-hooks.test.ts
@@ -54,6 +54,7 @@ const SLACK_DESTINATION = {
 const SLACK_SOURCE = createSlackSource({
   teamId: SLACK_DESTINATION.teamId,
   channelId: SLACK_DESTINATION.channelId,
+  type: "priv",
 });
 
 class PrototypeTool {
@@ -69,6 +70,8 @@ function slackSource(channelId: string) {
   return createSlackSource({
     teamId: "T123",
     channelId,
+
+    type: "priv",
   });
 }
 
@@ -123,12 +126,12 @@ function fakeSandbox(
 }
 
 describe("agent plugin hooks", () => {
-  it("classifies Slack source visibility from the channel_type signal", () => {
+  it("accepts Slack source visibility from the runtime boundary", () => {
     expect(
       createSlackSource({
         teamId: "T123",
         channelId: "C123",
-        channelType: "channel",
+        type: "pub",
         threadTs: "1718800000.000000",
       }).type,
     ).toBe("pub");
@@ -138,6 +141,8 @@ describe("agent plugin hooks", () => {
         teamId: "T123",
         channelId: "C123",
         threadTs: "1718800000.000000",
+
+        type: "priv",
       }).type,
     ).toBe("priv");
     expect(
@@ -145,6 +150,8 @@ describe("agent plugin hooks", () => {
         teamId: "T123",
         channelId: "D123",
         threadTs: "1718800000.000000",
+
+        type: "priv",
       }).type,
     ).toBe("priv");
     expect(
@@ -152,14 +159,10 @@ describe("agent plugin hooks", () => {
         teamId: "T123",
         channelId: "G123",
         threadTs: "1718800000.000000",
+
+        type: "priv",
       }).type,
     ).toBe("priv");
-    expect(() =>
-      createSlackSource({
-        teamId: "T123",
-        channelId: "X123",
-      }),
-    ).toThrow("Unsupported Slack channel ID prefix");
   });
 
   it("collects system prompt contributions from configured plugins", async () => {

--- a/packages/junior/tests/unit/privacy/conversation-privacy.test.ts
+++ b/packages/junior/tests/unit/privacy/conversation-privacy.test.ts
@@ -15,7 +15,7 @@ describe("conversation privacy classification", () => {
     expect(canExposeConversationPayload({ channelId: "C123" })).toBe(false);
   });
 
-  it("classifies public only from a confirmed visibility signal", () => {
+  it("classifies public only from an explicit visibility signal", () => {
     expect(
       resolveConversationPrivacy({ channelId: "C123", visibility: "public" }),
     ).toBe("public");

--- a/packages/junior/tests/unit/privacy/conversation-privacy.test.ts
+++ b/packages/junior/tests/unit/privacy/conversation-privacy.test.ts
@@ -1,8 +1,47 @@
 import { describe, expect, it } from "vitest";
 import {
+  canExposeConversationPayload,
+  resolveConversationPrivacy,
   toGenAiPayloadMetadata,
   toGenAiPayloadTraceAttributes,
 } from "@/chat/conversation-privacy";
+
+describe("conversation privacy classification", () => {
+  it("never classifies a conversation public from a C-prefixed id alone", () => {
+    expect(resolveConversationPrivacy({ channelId: "C123" })).toBeUndefined();
+    expect(
+      resolveConversationPrivacy({ conversationId: "slack:C123:1712345.0001" }),
+    ).toBeUndefined();
+    expect(canExposeConversationPayload({ channelId: "C123" })).toBe(false);
+  });
+
+  it("classifies public only from a confirmed visibility signal", () => {
+    expect(
+      resolveConversationPrivacy({ channelId: "C123", visibility: "public" }),
+    ).toBe("public");
+    // Slack reported channel_type group despite the C prefix.
+    expect(
+      resolveConversationPrivacy({ channelId: "C123", visibility: "private" }),
+    ).toBe("private");
+  });
+
+  it("narrows toward private from D/G prefixes even against a public claim", () => {
+    expect(resolveConversationPrivacy({ channelId: "D123" })).toBe("private");
+    expect(resolveConversationPrivacy({ channelId: "G123" })).toBe("private");
+    expect(
+      resolveConversationPrivacy({ channelId: "D123", visibility: "public" }),
+    ).toBe("private");
+  });
+
+  it("classifies non-Slack conversations private", () => {
+    expect(
+      resolveConversationPrivacy({ conversationId: "local:workspace:run-1" }),
+    ).toBe("private");
+    expect(
+      resolveConversationPrivacy({ conversationId: "agent-dispatch:run-2" }),
+    ).toBe("private");
+  });
+});
 
 describe("conversation privacy metadata", () => {
   it("bounds top-level private payload keys", () => {

--- a/packages/junior/tests/unit/prompt.test.ts
+++ b/packages/junior/tests/unit/prompt.test.ts
@@ -10,6 +10,8 @@ describe("prompt builders", () => {
     const source = createSlackSource({
       teamId: "T123",
       channelId: "C123",
+
+      type: "priv",
     });
     const systemPrompt = buildSystemPrompt({ source });
 
@@ -26,6 +28,8 @@ describe("prompt builders", () => {
         source: createSlackSource({
           teamId: "T123",
           channelId: "C123",
+
+          type: "priv",
         }),
       }),
     );
@@ -75,6 +79,8 @@ describe("prompt builders", () => {
         source: createSlackSource({
           teamId: "T123",
           channelId: "C123",
+
+          type: "priv",
         }),
         destination: {
           platform: "slack",

--- a/packages/junior/tests/unit/reporting-conversations.test.ts
+++ b/packages/junior/tests/unit/reporting-conversations.test.ts
@@ -241,7 +241,8 @@ describe("conversation reporting", () => {
       locations: [
         expect.objectContaining({
           conversations: 2,
-          label: "Public Channel",
+          failed: 1,
+          label: "Private Conversation",
         }),
         expect.objectContaining({
           conversations: 1,

--- a/packages/junior/tests/unit/reporting-conversations.test.ts
+++ b/packages/junior/tests/unit/reporting-conversations.test.ts
@@ -52,6 +52,9 @@ function fixedConversationStore(
         (conversation) => conversation.conversationId === args.conversationId,
       );
     },
+    async getDestinationVisibility() {
+      return undefined;
+    },
     async recordActivity() {},
     async recordExecution() {},
     async listByActivity(args = {}) {
@@ -133,6 +136,9 @@ describe("conversation reporting", () => {
           slackUserName: "alice",
         },
         source: "slack",
+        // Only a source-confirmed public destination may expose the channel
+        // name in labels.
+        visibility: "public",
       }),
       indexedConversation({
         conversationId: "slack:C1:456",

--- a/packages/junior/tests/unit/runtime/agent-dispatch-validation.test.ts
+++ b/packages/junior/tests/unit/runtime/agent-dispatch-validation.test.ts
@@ -21,6 +21,8 @@ const validOptions = {
   source: createSlackSource({
     teamId: "T123",
     channelId: "C123",
+
+    type: "priv",
   }),
 };
 

--- a/packages/junior/tests/unit/runtime/respond-agent-continue.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-agent-continue.test.ts
@@ -270,6 +270,7 @@ const TEST_SOURCE = createSlackSource({
   teamId: TEST_DESTINATION.teamId,
   channelId: TEST_DESTINATION.channelId,
   threadTs: "1712345.0001",
+  type: "priv",
 });
 
 const TEST_REQUESTER = {

--- a/packages/junior/tests/unit/runtime/respond-lazy-sandbox.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-lazy-sandbox.test.ts
@@ -646,7 +646,9 @@ describe("generateAssistantReply lazy sandbox boot", () => {
 
     const reply = await generateLocalReply("attach the report");
 
-    expect(reply.text).toContain("Error: agent exploded");
+    // Raw exception text stays in diagnostics; it is never reply text.
+    expect(reply.text).toBe("");
+    expect(reply.diagnostics.errorMessage).toContain("agent exploded");
     expect(createSandboxCallCount.value).toBe(1);
     expect(reply.sandboxId).toBe("sandbox-test");
     expect(reply.sandboxDependencyProfileHash).toBe("hash-test");
@@ -660,7 +662,9 @@ describe("generateAssistantReply lazy sandbox boot", () => {
       onSandboxAcquired,
     });
 
-    expect(reply.text).toContain("Error: agent exploded");
+    // Raw exception text stays in diagnostics; it is never reply text.
+    expect(reply.text).toBe("");
+    expect(reply.diagnostics.errorMessage).toContain("agent exploded");
     expect(onSandboxAcquired).toHaveBeenCalledTimes(1);
     expect(onSandboxAcquired).toHaveBeenCalledWith({
       sandboxId: "sandbox-test",
@@ -673,7 +677,9 @@ describe("generateAssistantReply lazy sandbox boot", () => {
 
     const reply = await generateLocalReply("run pwd");
 
-    expect(reply.text).toContain("Error: agent exploded");
+    // Raw exception text stays in diagnostics; it is never reply text.
+    expect(reply.text).toBe("");
+    expect(reply.diagnostics.errorMessage).toContain("agent exploded");
     expect(createSandboxCallCount.value).toBe(1);
     expect(reply.sandboxId).toBe("sandbox-test");
     expect(reply.sandboxDependencyProfileHash).toBe("hash-test");

--- a/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
@@ -116,6 +116,8 @@ function makeReplyContext(args: {
       teamId: destination.teamId,
       channelId: destination.channelId,
       threadTs: args.threadTs,
+
+      type: "priv",
     }),
     requester: TEST_REQUESTER,
     recordPendingAuth: async (pendingAuth: ConversationPendingAuthState) => {
@@ -1180,6 +1182,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
         teamId: "T123",
         channelId: "C123",
         threadTs: "1712345.0003",
+
+        type: "priv",
       }),
       requester: TEST_REQUESTER,
       recordPendingAuth: async (pendingAuth: ConversationPendingAuthState) => {
@@ -1278,6 +1282,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
         teamId: "T123",
         channelId: "C123",
         threadTs: "1712345.0005",
+
+        type: "priv",
       }),
       requester: TEST_REQUESTER,
       recordPendingAuth: async (pendingAuth: ConversationPendingAuthState) => {
@@ -1322,6 +1328,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
         teamId: "T123",
         channelId: "C123",
         threadTs: "1712345.0006",
+
+        type: "priv",
       }),
       requester: TEST_REQUESTER,
       recordPendingAuth: async (pendingAuth: ConversationPendingAuthState) => {

--- a/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
@@ -744,12 +744,14 @@ describe("generateAssistantReply progressive MCP loading", () => {
       { query: "hello" },
     );
 
+    // Generation completing is not delivery: the record stays resumable until
+    // the destination boundary commits completion after Slack acceptance.
     const resumedSessionRecord = await getAgentTurnSessionRecord(
       "conversation-1",
       "turn-1",
     );
     expect(resumedSessionRecord).toMatchObject({
-      state: "completed",
+      state: "awaiting_resume",
     });
   });
 
@@ -785,12 +787,14 @@ describe("generateAssistantReply progressive MCP loading", () => {
       { query: "hello" },
     );
 
+    // Generation completing is not delivery: the record stays at its running
+    // safe boundary until the destination boundary commits completion.
     const sessionRecord = await getAgentTurnSessionRecord(
       "conversation-2",
       "turn-2",
     );
     expect(sessionRecord).toMatchObject({
-      state: "completed",
+      state: "running",
     });
   });
 
@@ -1119,12 +1123,14 @@ describe("generateAssistantReply progressive MCP loading", () => {
 
     expect(reply.text).toBe("resumed reply");
 
+    // Generation completing is not delivery: the record stays resumable until
+    // the destination boundary commits completion after Slack acceptance.
     const resumedSessionRecord = await getAgentTurnSessionRecord(
       "conversation-4",
       "turn-4",
     );
     expect(resumedSessionRecord).toMatchObject({
-      state: "completed",
+      state: "awaiting_resume",
     });
   });
 

--- a/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
@@ -4,17 +4,22 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSlackSource, type Destination } from "@sentry/junior-plugin-api";
 import type { PiMessage } from "@/chat/pi/messages";
 
-const { agentMode, counters } = vi.hoisted(() => ({
+const { agentMode, counters, sessionLogState } = vi.hoisted(() => ({
   agentMode: {
     value: "providerRetry" as
       | "providerRetry"
       | "cooperativeYield"
       | "steering"
-      | "steeringSteerThrows",
+      | "steeringSteerThrows"
+      | "toolActivity",
   },
   counters: {
     continueCalls: 0,
     promptCalls: 0,
+  },
+  sessionLogState: {
+    failToolExecutionAppend: false,
+    toolExecutionAppendCalls: 0,
   },
 }));
 
@@ -43,6 +48,23 @@ async function advanceUntilContinueCall(maxMs: number): Promise<void> {
   throw new Error("Expected provider retry continuation to start");
 }
 
+vi.mock("@/chat/state/session-log", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/chat/state/session-log")>();
+  return {
+    ...actual,
+    recordToolExecutionStarted: async (
+      ...args: Parameters<typeof actual.recordToolExecutionStarted>
+    ) => {
+      sessionLogState.toolExecutionAppendCalls += 1;
+      if (sessionLogState.failToolExecutionAppend) {
+        throw new Error("redis blip during host-only append");
+      }
+      return actual.recordToolExecutionStarted(...args);
+    },
+  };
+});
+
 vi.mock("@earendil-works/pi-agent-core", () => {
   class MockAgent {
     state: {
@@ -53,6 +75,7 @@ vi.mock("@earendil-works/pi-agent-core", () => {
     };
     private prepareNextTurn?: () => Promise<unknown> | unknown;
     private steeringMessages: unknown[] = [];
+    private subscribers: Array<(event: unknown) => unknown> = [];
 
     constructor(input: {
       initialState: {
@@ -71,8 +94,13 @@ vi.mock("@earendil-works/pi-agent-core", () => {
       this.prepareNextTurn = input.prepareNextTurn;
     }
 
-    subscribe() {
-      return () => undefined;
+    subscribe(subscriber: (event: unknown) => unknown) {
+      this.subscribers.push(subscriber);
+      return () => {
+        this.subscribers = this.subscribers.filter(
+          (candidate) => candidate !== subscriber,
+        );
+      };
     }
 
     steer(message: unknown) {
@@ -102,6 +130,41 @@ vi.mock("@earendil-works/pi-agent-core", () => {
     async prompt(message: unknown) {
       counters.promptCalls += 1;
       this.state.messages.push(message);
+      if (agentMode.value === "toolActivity") {
+        // Pi surfaces subscriber rejections as run failures; a host-only
+        // activity append that rejects must not reach this path.
+        try {
+          await Promise.all(
+            this.subscribers.map((subscriber) =>
+              subscriber({
+                type: "tool_execution_start",
+                toolCallId: "call_1",
+                toolName: "bash",
+                args: { cmd: "ls" },
+              }),
+            ),
+          );
+        } catch (error) {
+          this.recordRunFailure(error);
+          return {};
+        }
+        this.state.messages.push({
+          role: "toolResult",
+          toolName: "bash",
+          isError: false,
+          content: [{ type: "text", text: "ok" }],
+        });
+        this.state.messages.push({
+          role: "assistant",
+          content: [{ type: "text", text: "Tool done." }],
+          stopReason: "stop",
+          usage: {
+            input: 2,
+            output: 2,
+          },
+        });
+        return {};
+      }
       if (
         agentMode.value === "cooperativeYield" ||
         agentMode.value === "steering" ||
@@ -282,6 +345,8 @@ describe("generateAssistantReply provider retry", () => {
     agentMode.value = "providerRetry";
     counters.continueCalls = 0;
     counters.promptCalls = 0;
+    sessionLogState.failToolExecutionAppend = false;
+    sessionLogState.toolExecutionAppendCalls = 0;
     process.env.JUNIOR_STATE_ADAPTER = "memory";
     await disconnectStateAdapter();
     await getConversationStore().listByActivity({ limit: 1 });
@@ -561,6 +626,74 @@ describe("generateAssistantReply provider retry", () => {
         "turn-yield-persist-failure",
       ),
     ).resolves.toBeUndefined();
+  });
+
+  it("swallows failed host-only activity appends without killing the turn", async () => {
+    agentMode.value = "toolActivity";
+    sessionLogState.failToolExecutionAppend = true;
+
+    const reply = await generateAssistantReply("run the tool", {
+      destination: TEST_DESTINATION,
+      source: TEST_SOURCE,
+      requester: { platform: "slack", teamId: "T123", userId: "U123" },
+      correlation: {
+        conversationId: "conversation-tool-activity",
+        turnId: "turn-tool-activity",
+        channelId: "C123",
+        threadTs: "1712345.0006",
+      },
+    });
+
+    expect(sessionLogState.toolExecutionAppendCalls).toBe(1);
+    expect(reply.diagnostics.outcome).toBe("success");
+    expect(reply.text).toBe("Tool done.");
+  });
+
+  it("does not duplicate the user prompt when a lost input commit replays against a running record", async () => {
+    agentMode.value = "steering";
+    const conversationId = "conversation-replay";
+    const sessionId = "turn-replay";
+    const checkpointedPrompt = {
+      role: "user",
+      content: [{ type: "text", text: "help me" }],
+      timestamp: 5,
+    } satisfies PiMessage;
+    await turnSessionState.upsertAgentTurnSessionRecord({
+      conversationId,
+      sessionId,
+      sliceId: 1,
+      state: "running",
+      destination: TEST_DESTINATION,
+      source: TEST_SOURCE,
+      piMessages: [checkpointedPrompt],
+      turnStartMessageIndex: 0,
+    });
+
+    const reply = await generateAssistantReply("help me", {
+      destination: TEST_DESTINATION,
+      source: TEST_SOURCE,
+      piMessages: [checkpointedPrompt],
+      requester: { platform: "slack", teamId: "T123", userId: "U123" },
+      correlation: {
+        conversationId,
+        turnId: sessionId,
+        channelId: "C123",
+        threadTs: "1712345.0007",
+      },
+    });
+
+    expect(reply.diagnostics.outcome).toBe("success");
+    const sessionRecord = await turnSessionState.getAgentTurnSessionRecord(
+      conversationId,
+      sessionId,
+    );
+    const userMessages =
+      sessionRecord?.piMessages.filter((message) => message.role === "user") ??
+      [];
+    expect(userMessages).toHaveLength(1);
+    expect(
+      JSON.stringify(sessionRecord?.piMessages).split("help me"),
+    ).toHaveLength(2);
   });
 
   it("rejects steering injection when Pi steer fails", async () => {

--- a/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
@@ -325,6 +325,7 @@ import { generateAssistantReply } from "@/chat/respond";
 import { getConversationStore } from "@/chat/db";
 import { isCooperativeTurnYieldError } from "@/chat/runtime/turn";
 import { getAwaitingAgentContinueRequest } from "@/chat/services/agent-continue";
+import { persistCompletedSessionRecord } from "@/chat/services/turn-session-record";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
 import * as turnSessionState from "@/chat/state/turn-session";
 import { createJuniorReporting } from "@/reporting";
@@ -386,15 +387,22 @@ describe("generateAssistantReply provider retry", () => {
     expect(counters.promptCalls).toBe(1);
     expect(counters.continueCalls).toBe(1);
 
+    expect(reply.piMessages?.map((message) => message.role)).toEqual([
+      "user",
+      "toolResult",
+      "assistant",
+    ]);
+    // Generation completing is not delivery: the record stays running at the
+    // last safe boundary (no trailing assistant text) until the destination
+    // boundary commits completion after acceptance.
     const sessionRecord = await turnSessionState.getAgentTurnSessionRecord(
       "conversation-1",
       "turn-1",
     );
-    expect(sessionRecord?.state).toBe("completed");
+    expect(sessionRecord?.state).toBe("running");
     expect(sessionRecord?.piMessages.map((message) => message.role)).toEqual([
       "user",
       "toolResult",
-      "assistant",
     ]);
   });
 
@@ -463,6 +471,17 @@ describe("generateAssistantReply provider retry", () => {
 
     expect(reply.text).toBe("Steered.");
     expect(injectedTexts).toEqual(["actually do the other thing"]);
+
+    // Simulate the destination boundary committing completion after
+    // acceptance; generation itself no longer persists the final reply.
+    await persistCompletedSessionRecord({
+      conversationId: "slack:C123:1712345.0001",
+      sessionId: "turn-steering",
+      allMessages: reply.piMessages ?? [],
+      destination: TEST_DESTINATION,
+      source: TEST_SOURCE,
+      logContext: { modelId: "test-model" },
+    });
 
     const sessionRecord = await turnSessionState.getAgentTurnSessionRecord(
       "slack:C123:1712345.0001",

--- a/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
@@ -367,6 +367,14 @@ describe("generateAssistantReply provider retry", () => {
       },
     ] satisfies PiMessage[];
 
+    // Reading the transcript below requires a source-confirmed public
+    // destination; a bare C prefix no longer proves the channel public.
+    await getConversationStore().recordActivity({
+      conversationId: "slack:C123:1712345.0001",
+      destination: TEST_DESTINATION,
+      visibility: "public",
+    });
+
     const reply = await generateAssistantReply("help me", {
       destination: TEST_DESTINATION,
       source: TEST_SOURCE,

--- a/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
@@ -339,6 +339,7 @@ const TEST_SOURCE = createSlackSource({
   teamId: TEST_DESTINATION.teamId,
   channelId: TEST_DESTINATION.channelId,
   threadTs: "1712345.0001",
+  type: "priv",
 });
 
 describe("generateAssistantReply provider retry", () => {

--- a/packages/junior/tests/unit/services/mcp-auth-orchestration.test.ts
+++ b/packages/junior/tests/unit/services/mcp-auth-orchestration.test.ts
@@ -53,6 +53,7 @@ const slackSource = createSlackSource({
   channelId: "C123",
   messageTs: "1700000000.source",
   threadTs: "1700000000.000000",
+  type: "priv",
 });
 
 describe("createMcpAuthOrchestration", () => {

--- a/packages/junior/tests/unit/services/plugin-auth-orchestration.test.ts
+++ b/packages/junior/tests/unit/services/plugin-auth-orchestration.test.ts
@@ -63,6 +63,7 @@ const slackSource = createSlackSource({
   channelId: "C123",
   messageTs: "1700000000.source",
   threadTs: "1700000000.000000",
+  type: "priv",
 });
 
 describe("createPluginAuthOrchestration", () => {

--- a/packages/junior/tests/unit/services/turn-failure-response.test.ts
+++ b/packages/junior/tests/unit/services/turn-failure-response.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import { getInterruptionMarker } from "@/chat/interruption-marker";
+import { finalizeFailedTurnReply } from "@/chat/services/turn-failure-response";
+import type { AssistantReply } from "@/chat/services/turn-result";
+
+function providerErrorReply(args: {
+  assistantMessageCount: number;
+  errorMessage?: string;
+  text: string;
+}): AssistantReply {
+  return {
+    text: args.text,
+    diagnostics: {
+      outcome: "provider_error",
+      modelId: "test-model",
+      assistantMessageCount: args.assistantMessageCount,
+      toolCalls: [],
+      toolResultCount: 0,
+      toolErrorCount: 0,
+      usedPrimaryText: false,
+      ...(args.errorMessage ? { errorMessage: args.errorMessage } : {}),
+    },
+  };
+}
+
+describe("finalizeFailedTurnReply", () => {
+  it("never delivers synthesized error text without assistant messages", () => {
+    const logException = vi.fn().mockReturnValue("evt_123");
+
+    const finalized = finalizeFailedTurnReply({
+      reply: providerErrorReply({
+        assistantMessageCount: 0,
+        errorMessage: "ECONNRESET at redis.js:42",
+        text: "Error: ECONNRESET at redis.js:42",
+      }),
+      logException,
+      context: {},
+    });
+
+    expect(finalized.text).not.toContain("ECONNRESET");
+    expect(finalized.text).toContain("event_id=evt_123");
+  });
+
+  it("delivers genuine model-authored partial text with the interruption marker", () => {
+    const logException = vi.fn().mockReturnValue("evt_456");
+
+    const finalized = finalizeFailedTurnReply({
+      reply: providerErrorReply({
+        assistantMessageCount: 1,
+        text: "Here is what I found so far",
+      }),
+      logException,
+      context: {},
+    });
+
+    expect(finalized.text).toBe(
+      `Here is what I found so far${getInterruptionMarker()}`,
+    );
+  });
+});

--- a/packages/junior/tests/unit/slack/channel-action-context.test.ts
+++ b/packages/junior/tests/unit/slack/channel-action-context.test.ts
@@ -56,6 +56,7 @@ describe("slack outbound boundary", () => {
 
     expect(withSlackRetries).toHaveBeenCalledWith(expect.any(Function), 3, {
       action: "reactions.add",
+      idempotent: true,
       spanAttributes: {
         "app.slack.channel_id": "C123",
         "app.slack.message_ts": "1700000000.100",
@@ -89,6 +90,7 @@ describe("slack outbound boundary", () => {
 
     expect(withSlackRetries).toHaveBeenCalledWith(expect.any(Function), 3, {
       action: "reactions.remove",
+      idempotent: true,
       spanAttributes: {
         "app.slack.channel_id": "C123",
         "app.slack.message_ts": "1700000000.100",

--- a/packages/junior/tests/unit/slack/conversation-context.test.ts
+++ b/packages/junior/tests/unit/slack/conversation-context.test.ts
@@ -81,7 +81,7 @@ describe("Slack conversation prompt context", () => {
     ).toMatchObject({ visibility: "private" });
   });
 
-  it("leaves visibility unconfirmed for C-prefixed ids without a signal", () => {
+  it("leaves visibility undefined for C-prefixed ids without a signal", () => {
     expect(
       resolveSlackConversationContext({
         channelId: "C123",

--- a/packages/junior/tests/unit/slack/conversation-context.test.ts
+++ b/packages/junior/tests/unit/slack/conversation-context.test.ts
@@ -18,6 +18,7 @@ describe("Slack conversation prompt context", () => {
     ).toEqual({
       type: "public_channel",
       name: "#engineering",
+      visibility: "public",
     });
   });
 
@@ -28,21 +29,33 @@ describe("Slack conversation prompt context", () => {
         channelName: "private-roadmap",
         channelType: "group",
       }),
-    ).toEqual({ type: "private_channel", name: "#private-roadmap" });
+    ).toEqual({
+      type: "private_channel",
+      name: "#private-roadmap",
+      visibility: "private",
+    });
     expect(
       resolveSlackConversationContext({
         channelId: "G456",
         channelName: "mpdm-alice--bob-1",
         channelType: "mpim",
       }),
-    ).toEqual({ type: "group_dm", name: "mpdm-alice--bob-1" });
+    ).toEqual({
+      type: "group_dm",
+      name: "mpdm-alice--bob-1",
+      visibility: "private",
+    });
     expect(
       resolveSlackConversationContext({
         channelId: "D123",
         channelName: "alice",
         channelType: "im",
       }),
-    ).toEqual({ type: "direct_message", name: "alice" });
+    ).toEqual({
+      type: "direct_message",
+      name: "alice",
+      visibility: "private",
+    });
   });
 
   it("uses a conservative type when only a G-prefixed ID is known", () => {
@@ -51,7 +64,30 @@ describe("Slack conversation prompt context", () => {
         channelId: "G123",
         channelName: "maybe-private",
       }),
-    ).toEqual({ type: "private_channel_or_group_dm", name: "#maybe-private" });
+    ).toEqual({
+      type: "private_channel_or_group_dm",
+      name: "#maybe-private",
+      visibility: "private",
+    });
+  });
+
+  it("classifies a C-prefixed channel private when Slack reports channel_type group", () => {
+    expect(
+      resolveSlackConversationContext({
+        channelId: "C123",
+        channelName: "actually-private",
+        channelType: "group",
+      }),
+    ).toMatchObject({ visibility: "private" });
+  });
+
+  it("leaves visibility unconfirmed for C-prefixed ids without a signal", () => {
+    expect(
+      resolveSlackConversationContext({
+        channelId: "C123",
+        channelName: "maybe-public",
+      }),
+    ).toEqual({ type: "public_channel", name: "#maybe-public" });
   });
 
   it("extracts Slack channel type from message-like raw payloads", () => {

--- a/packages/junior/tests/unit/slack/message-changed-ingress.test.ts
+++ b/packages/junior/tests/unit/slack/message-changed-ingress.test.ts
@@ -14,6 +14,7 @@ const fakeAdapter = {} as Adapter;
 function makeEnvelope(overrides: {
   newText: string;
   prevText: string;
+  botId?: string;
   channel?: string;
   messageTs?: string;
   threadTs?: string;
@@ -31,6 +32,7 @@ function makeEnvelope(overrides: {
         ts: overrides.messageTs ?? MESSAGE_TS,
         thread_ts: overrides.threadTs ?? THREAD_TS,
         user: overrides.user ?? "U_SENDER",
+        ...(overrides.botId ? { bot_id: overrides.botId } : {}),
       },
       previous_message: {
         text: overrides.prevText,
@@ -99,6 +101,34 @@ describe("extractMessageChangedMention", () => {
     });
     expect(serialized?.author.userName).toBe("");
     expect(serialized?.author.fullName).toBe("");
+  });
+
+  it("derives bot author flags from the edited payload", () => {
+    const body = makeEnvelope({
+      newText: `<@${BOT_USER_ID}> please help`,
+      prevText: "please help",
+      botId: "B_APP",
+    });
+
+    const result = extractMessageChangedMention(body, BOT_USER_ID, fakeAdapter);
+
+    expect(result?.message.author.isBot).toBe(true);
+    expect(result?.message.author.isMe).toBe(false);
+    expect(
+      (result?.message.raw as { bot_id?: string } | undefined)?.bot_id,
+    ).toBe("B_APP");
+  });
+
+  it("marks self-authored edits with isMe", () => {
+    const body = makeEnvelope({
+      newText: `<@${BOT_USER_ID}> please help`,
+      prevText: "please help",
+      user: BOT_USER_ID,
+    });
+
+    const result = extractMessageChangedMention(body, BOT_USER_ID, fakeAdapter);
+
+    expect(result?.message.author.isMe).toBe(true);
   });
 
   it("returns null when bot mention was already in the previous message", () => {

--- a/packages/junior/tests/unit/slack/slack-client-retries.test.ts
+++ b/packages/junior/tests/unit/slack/slack-client-retries.test.ts
@@ -25,6 +25,123 @@ describe("withSlackRetries", () => {
     expect(task).toHaveBeenCalledTimes(2);
   });
 
+  it("caps a huge Retry-After header instead of honoring it verbatim", async () => {
+    vi.useFakeTimers();
+    const task = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce({
+        code: "slack_webapi_rate_limited_error",
+        statusCode: 429,
+        retryAfter: 3600,
+        message: "rate limited",
+      })
+      .mockResolvedValue("ok");
+
+    const promise = withSlackRetries(task, 3);
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await expect(promise).resolves.toBe("ok");
+    expect(task).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops retrying once the total retry delay budget is exhausted", async () => {
+    vi.useFakeTimers();
+    const task = vi.fn<() => Promise<string>>().mockRejectedValue({
+      code: "slack_webapi_rate_limited_error",
+      statusCode: 429,
+      retryAfter: 3600,
+      message: "rate limited",
+    });
+
+    const outcome = withSlackRetries(task, 5).catch((error: unknown) => error);
+    // Two capped 10s pauses spend the 20s budget; the third failure is final
+    // even though attempts remain.
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    await expect(outcome).resolves.toEqual(
+      expect.objectContaining<Partial<SlackActionError>>({
+        name: "SlackActionError",
+        code: "rate_limited",
+      }),
+    );
+    expect(task).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries connection-phase network failures that never reached Slack", async () => {
+    vi.useFakeTimers();
+    const task = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce({
+        code: "slack_webapi_request_error",
+        message: "A request error occurred: socket hang up",
+        original: { code: "ECONNRESET", message: "socket hang up" },
+      })
+      .mockResolvedValue("ok");
+
+    const promise = withSlackRetries(task, 3, { action: "chat.postMessage" });
+    await vi.advanceTimersByTimeAsync(250);
+
+    await expect(promise).resolves.toBe("ok");
+    expect(task).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries Slack 5xx responses", async () => {
+    vi.useFakeTimers();
+    const task = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce({
+        code: "slack_webapi_http_error",
+        statusCode: 503,
+        message: "An HTTP protocol error occurred: statusCode = 503",
+      })
+      .mockResolvedValue("ok");
+
+    const promise = withSlackRetries(task, 3, { action: "chat.postMessage" });
+    await vi.advanceTimersByTimeAsync(250);
+
+    await expect(promise).resolves.toBe("ok");
+    expect(task).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a timed-out post that Slack may have accepted", async () => {
+    const task = vi.fn<() => Promise<string>>().mockRejectedValue({
+      code: "slack_webapi_request_error",
+      message: "A request error occurred: ETIMEDOUT",
+      original: { code: "ETIMEDOUT" },
+    });
+
+    await expect(
+      withSlackRetries(task, 3, { action: "chat.postMessage" }),
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<SlackActionError>>({
+        name: "SlackActionError",
+        code: "internal_error",
+      }),
+    );
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a timed-out idempotent read", async () => {
+    vi.useFakeTimers();
+    const task = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce({
+        code: "slack_webapi_request_error",
+        message: "A request error occurred: ETIMEDOUT",
+        original: { code: "ETIMEDOUT" },
+      })
+      .mockResolvedValue("ok");
+
+    const promise = withSlackRetries(task, 3, {
+      action: "conversations.replies",
+      idempotent: true,
+    });
+    await vi.advanceTimersByTimeAsync(250);
+
+    await expect(promise).resolves.toBe("ok");
+    expect(task).toHaveBeenCalledTimes(2);
+  });
+
   it("does not retry non-retryable API errors", async () => {
     const task = vi.fn<() => Promise<string>>().mockRejectedValue({
       data: {

--- a/packages/junior/tests/unit/slack/slack-client-token.test.ts
+++ b/packages/junior/tests/unit/slack/slack-client-token.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getSlackClient,
+  runWithSlackInstallationToken,
+  SlackActionError,
+} from "@/chat/slack/client";
+import { runWithWorkspaceTeamId } from "@/chat/slack/workspace-context";
+
+const getSlackBotTokenMock = vi.hoisted(() =>
+  vi.fn<() => string | undefined>(),
+);
+
+vi.mock("@/chat/config", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/chat/config")>()),
+  getSlackBotToken: () => getSlackBotTokenMock(),
+}));
+
+describe("getSlackClient token resolution", () => {
+  beforeEach(() => {
+    getSlackBotTokenMock.mockReset();
+  });
+
+  it("uses the ambient destination installation token over the env token", () => {
+    getSlackBotTokenMock.mockReturnValue("xoxb-env-token");
+
+    const token = runWithSlackInstallationToken(
+      "xoxb-installation-token",
+      () => getSlackClient().token,
+    );
+
+    expect(token).toBe("xoxb-installation-token");
+  });
+
+  it("falls back to the env token for single-workspace deployments", () => {
+    getSlackBotTokenMock.mockReturnValue("xoxb-env-token");
+
+    expect(getSlackClient().token).toBe("xoxb-env-token");
+  });
+
+  it("fails a workspace-scoped call when no installation token can be resolved", () => {
+    getSlackBotTokenMock.mockReturnValue(undefined);
+
+    runWithWorkspaceTeamId("T_OTHER_WORKSPACE", () => {
+      let caught: unknown;
+      try {
+        getSlackClient();
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(SlackActionError);
+      expect((caught as SlackActionError).code).toBe("missing_token");
+      expect((caught as SlackActionError).message).toContain(
+        "T_OTHER_WORKSPACE",
+      );
+    });
+  });
+
+  it("rejects binding an empty installation token", () => {
+    expect(() => runWithSlackInstallationToken("   ", () => "ran")).toThrow(
+      SlackActionError,
+    );
+  });
+});

--- a/packages/junior/tests/unit/slack/slack-message-add-reaction-tool.test.ts
+++ b/packages/junior/tests/unit/slack/slack-message-add-reaction-tool.test.ts
@@ -19,6 +19,8 @@ const TEST_SLACK_CONTEXT: SlackToolContext = {
     teamId: "T123",
     channelId: "C123",
     messageTs: "1700000000.100",
+
+    type: "priv",
   }),
   destinationChannelId: "C123",
   messageTs: "1700000000.100",

--- a/packages/junior/tests/unit/slack/tool-registration.test.ts
+++ b/packages/junior/tests/unit/slack/tool-registration.test.ts
@@ -40,6 +40,8 @@ function ctx(channelId?: string): ToolRuntimeContext {
     source: createSlackSource({
       teamId: "T123",
       channelId,
+
+      type: "priv",
     }),
     egress: noopEgress,
     sandbox: noopSandbox,

--- a/policies/README.md
+++ b/policies/README.md
@@ -13,6 +13,7 @@ Good policy topics:
 - test adapters and harnesses
 - naming conventions
 - interface design
+- correctness and complexity tradeoffs
 - runtime boundary schemas
 - migration hygiene
 - automation safety boundaries

--- a/policies/correctness-complexity.md
+++ b/policies/correctness-complexity.md
@@ -1,0 +1,36 @@
+# Correctness and Complexity
+
+## Intent
+
+Correct behavior is required, but correctness work should not default to the
+most exhaustive design the model can imagine. A change is better only when its
+correctness gain is worth the added code, states, callbacks, and maintenance
+burden.
+
+## Policy
+
+- Evaluate non-trivial changes on four axes: correctness, simplicity,
+  understandability for an average repo developer, and maintainability.
+- Prefer the smallest design that closes the proven failure mode. Do not add
+  speculative states, abstractions, retries, fallbacks, or recovery paths for
+  failures that are not part of the current contract.
+- When correctness requires complexity, name the invariant at the owning
+  boundary and keep the implementation local to that boundary.
+- Avoid spreading one invariant across callbacks in multiple layers. If several
+  layers must participate, one layer should own the lifecycle transition and the
+  others should expose narrow capabilities.
+- Do not hide complexity behind best-effort logging, ambient context, or
+  one-hop wrappers. If a future developer must know about the hidden state to
+  change behavior safely, the design is not simple.
+- A review that finds "more correct but harder to understand" should require a
+  simplification pass before merge unless the risk is urgent and documented.
+- Tests should prove the invariant at the highest useful boundary, not encode
+  every internal step of a complex implementation.
+
+## Exceptions
+
+- Security, privacy, data-loss, and duplicate-side-effect fixes may temporarily
+  increase complexity when a smaller safe design is not available in the same
+  change.
+- Temporary complexity must be explicit in the PR description or follow-up
+  issue, including which invariant it protects and what simplification remains.

--- a/policies/provider-boundaries.md
+++ b/policies/provider-boundaries.md
@@ -1,0 +1,35 @@
+# Provider Boundaries
+
+## Intent
+
+Provider integrations should keep platform SDKs, payload shapes, formatting
+rules, and transport details inside the provider-owned module. Cross-provider
+runtime, service, state, plugin, and reporting code should depend on small
+Junior contracts instead of Slack, Vercel, GitHub, or other provider primitives.
+
+## Policy
+
+- Provider SDK clients, SDK response types, SDK errors, raw webhook payloads,
+  and provider-specific formatting primitives belong in the provider-owned
+  module or feature folder.
+- Cross-provider code should accept Junior-owned contracts such as
+  `Destination`, `Source`, requester identity, local ports, or feature-owned
+  projections instead of provider SDK types.
+- Provider-specific side effects must be exposed through narrow capability
+  ports or provider-owned services. Do not import provider infrastructure to
+  "just call the client" from runtime, service, state, reporting, or generic
+  tool code.
+- Provider-owned tests and fixtures may use provider primitives directly.
+  Product behavior tests outside the provider should exercise provider behavior
+  through the public adapter or runtime boundary.
+- If provider-specific behavior must cross a boundary, name the boundary by the
+  product role and keep the provider type private to the implementation.
+
+## Exceptions
+
+- Provider modules, provider feature tools, and ingress adapters may parse raw
+  provider payloads and call provider SDKs.
+- Composition roots may wire provider implementations to provider-neutral
+  interfaces, but they should not perform provider behavior themselves.
+- Existing legacy runtime code may keep provider imports while it is being
+  simplified, but new code should not add more provider primitives there.

--- a/specs/agent-session-resumability.md
+++ b/specs/agent-session-resumability.md
@@ -204,7 +204,10 @@ happened:
   fact is needed to explain execution continuity. Omit it when a following
   `slice_started` event with `reason=queue_resume|auth_resume` is enough.
 - `assistant_reply_delivered`: records that the final assistant reply for this
-  session was accepted by Slack.
+  session was accepted by Slack. Current implementation carries this fact as
+  the acceptance-gated `completed` transition on the turn-session read model
+  instead of a session-log event; add the event only when a log consumer
+  needs it.
 - `session_abandoned`: records that this session must not resume because a
   specific newer user input started a replacement session.
 - `session_error_recorded`: records a terminal user-visible or operator-visible
@@ -375,7 +378,10 @@ cache/index that can be rebuilt from the session log.
 - The reduced lifecycle is a projection, not a durable event vocabulary.
 - `awaiting_resume` is derived from the latest unconsumed `timeout_paused` or
   `auth_paused`.
-- `delivered` is derived from `assistant_reply_delivered`.
+- `delivered` is derived from the acceptance-gated delivered fact
+  (`assistant_reply_delivered`, currently the turn-session record's
+  `completed` transition, which is written only after destination
+  acceptance).
 - `abandoned` is derived from `session_abandoned`.
 - Terminal user-visible failure is currently reflected in conversation/thread
   state. Add `session_error_recorded` only when that durable fact is needed to
@@ -548,7 +554,10 @@ never be silently dropped.
    the same inbound message after a lost input commit against a `running`
    record: the same user prompt must not appear twice in Pi history.
 4. The queue worker runs and eagerly persists sandbox/artifact state as those values change.
-5. If Slack accepts the final assistant reply, append `assistant_reply_delivered`.
+5. If Slack accepts the final assistant reply, record the delivered fact
+   (`assistant_reply_delivered` semantics; currently the acceptance-gated
+   `completed` record commit). Final assistant messages are committed to the
+   durable log only after acceptance.
 6. If MCP auth pauses at a safe boundary, append `auth_paused`; the OAuth callback later consults auth-owned state before resuming.
 7. If the worker reaches a cooperative yield boundary, it ensures the latest safe boundary is durably represented in the session log, enqueues the conversation id, releases the lease, and exits.
 8. The next queue worker rebuilds durable runtime state, restores Pi messages, drains newly pending mailbox input, and calls `continue()`.

--- a/specs/agent-session-resumability.md
+++ b/specs/agent-session-resumability.md
@@ -49,7 +49,7 @@ This spec owns how agent session state is persisted and resumed across execution
   resume source.
 - `slice_id`: Diagnostic integer for one execution chunk in the same
   conversation. The mailbox worker must not enforce a slice cap; timeout
-  poison-work guards live in the agent-run read model.
+  retry-limit guards live in the agent-run read model.
 - `event_id`: Stable identity for one durable session-log event.
 - `pause_event_id`: Event id carried by timeout/auth resume callbacks so stale callbacks can be dropped.
 

--- a/specs/agent-session-resumability.md
+++ b/specs/agent-session-resumability.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-03-05
-- Last Edited: 2026-06-08
+- Last Edited: 2026-07-01
 
 ## Purpose
 
@@ -111,6 +111,13 @@ messages are marked injected in the mailbox. Queue delivery acknowledgement must
 happen only after the worker has durably committed final completion, safe
 cooperative yield, or a no-work result.
 
+Marking a mailbox message injected without a corresponding durable session-log
+append (or a persisted skip decision) is a contract violation. This applies
+equally while a conversation is `awaiting_resume`: a message that arrives while
+a run is parked either steers the resumed run at its next safe boundary or is
+appended to the session log before the resumed `continue()`. Rescheduling a
+continuation does not consume the message.
+
 ### Agent Session Log Contract
 
 The durable agent session log is the canonical state log for model execution. It is the source used to reconstruct `agent.state.messages`, derive model-visible runtime handles, and resume an interrupted session.
@@ -129,6 +136,12 @@ The session log has one clear projection into Pi messages:
 3. Projection must preserve chronological order and safe continuation boundaries.
 4. Projection must not invent loaded skills, provider activation, tool results, or assistant/user messages that were not represented in the durable log.
 5. Storage writes are append-only. If recovery must roll the active Pi projection back to a prior safe boundary, the writer appends an explicit projection-reset event instead of trimming or rewriting the stored list.
+
+Session-log writes are fenced by conversation ownership: a writer that no
+longer holds the conversation lease or resume lock must not append entries or
+reset the projection. Read-compute-append sequences must revalidate ownership
+before the append so an expired-lease slice cannot duplicate or roll back
+another writer's entries.
 
 The schema must be a strongly typed discriminated union with runtime validation
 at the storage boundary. The TypeScript type and the runtime parser must come
@@ -225,6 +238,10 @@ Host-only activity events (`tool_execution_started`, `subagent_started`, and
 `subagent_ended`) must not contribute to Pi replay or resume history. They are
 durable reporting facts for activity timelines and diagnostics; the Pi
 projection reducer must ignore them when constructing `agent.state.messages`.
+
+Host-only activity events are best-effort reporting writes. A failed append is
+logged and swallowed; it must not abort the model turn, end the run, or be
+classified as a provider failure.
 
 `authorization_completed` is a host-authored event that projects to one concise
 Pi-compatible observation in chronological order:
@@ -376,6 +393,14 @@ The implementation should not persist a separate `running` lease state in the
 session log. Conversation execution leases are mailbox-worker state owned by
 `./task-execution.md`.
 
+Generation completing is not delivery. A session must not be recorded in a
+terminal completed/delivered state before the destination accepts the final
+reply; until acceptance it remains resumable or is terminally failed with the
+standard visible fallback. Resume and redelivery paths must check the
+delivered marker before posting so duplicate deliveries of the same finalized
+reply are suppressed. An assistant reply that was never delivered must not be
+presented to later turns as delivered conversation history.
+
 ### Safe Resume Boundary Contract
 
 A pause boundary is resumable only when all conditions are true:
@@ -504,6 +529,13 @@ The worker must:
 4. Restore Pi messages with `agent.state.messages = ...`.
 5. Resume with `continue()`.
 
+Recovery must cover every non-terminal session, not only `awaiting_resume`.
+When the mailbox is empty and the newest session is `running` under an expired
+lease (hard worker death), the worker resumes it from the latest durable safe
+boundary; if no resumable boundary exists, it terminally fails the session and
+delivers the standard failure fallback. A lease-expired `running` session must
+never be silently dropped.
+
 ### Slice Lifecycle
 
 1. User message resolves a predictable `conversation_id`.
@@ -512,7 +544,9 @@ The worker must:
 3. If the reduced conversation projection already contains session bootstrap
    context, runtime loads and reduces it, restores Pi from the projected
    messages, and appends the new user input without duplicating bootstrap
-   context.
+   context. This dedupe applies to every replay shape, including redelivery of
+   the same inbound message after a lost input commit against a `running`
+   record: the same user prompt must not appear twice in Pi history.
 4. The queue worker runs and eagerly persists sandbox/artifact state as those values change.
 5. If Slack accepts the final assistant reply, append `assistant_reply_delivered`.
 6. If MCP auth pauses at a safe boundary, append `auth_paused`; the OAuth callback later consults auth-owned state before resuming.
@@ -529,6 +563,8 @@ The worker must:
 4. Timeout after visible assistant output begins: automatic continuation is skipped to avoid duplicate/corrupt user-visible output.
 5. Repeated cooperative yields before visible output may produce further execution chunks, but timeout continuation must stop at the configured high-water slice cap and mark the session failed instead of scheduling another queue nudge.
 6. A later user message after an ungraceful crash may build its prompt history from the active session's latest reduced Pi projection. If the prior session produced assistant text that was not committed to visible thread state, that trailing assistant text must be trimmed from the fresh-run history view.
+7. Hard worker death mid-slice leaves a `running` session with an expired lease: queue redelivery or heartbeat requeues the conversation, and the next worker resumes it from the latest durable boundary or terminally fails it with a visible fallback. The interrupted request must not die silently.
+8. Delivery fails after generation completed: the session is not delivered. It must remain resumable for redelivery or be terminally failed with a visible fallback, and the undelivered assistant reply must not surface as prior conversation history for later turns.
 
 ## Observability
 
@@ -563,6 +599,10 @@ Required attributes when available:
 8. Manual/eval: once assistant text is already visible, recovery does not auto-reconcile partial thread output.
 9. Component/integration: transient provider failures retry with `continue()` from a safe boundary and do not duplicate prior tool execution.
 10. Component/integration: successful provider activation appends one `mcp_provider_connected` event, and resume restores providers from those events. Legacy Pi-message inference is allowed only while pre-event session logs still exist.
+11. Component/integration: a user message arriving while a session is `awaiting_resume` reaches Pi history (steered or appended) and receives an answer; it is never marked injected without a session-log append.
+12. Component/integration: a lease-expired `running` session is resumed or terminally failed with a visible fallback; it never no-ops.
+13. Component: redelivery after a lost input commit does not duplicate the user prompt or bootstrap context in Pi history.
+14. Component: a failed host-only activity append is swallowed and the model turn continues.
 
 ## Related Specs
 

--- a/specs/agent-session-resumability.md
+++ b/specs/agent-session-resumability.md
@@ -137,11 +137,14 @@ The session log has one clear projection into Pi messages:
 4. Projection must not invent loaded skills, provider activation, tool results, or assistant/user messages that were not represented in the durable log.
 5. Storage writes are append-only. If recovery must roll the active Pi projection back to a prior safe boundary, the writer appends an explicit projection-reset event instead of trimming or rewriting the stored list.
 
-Session-log writes are fenced by conversation ownership: a writer that no
-longer holds the conversation lease or resume lock must not append entries or
-reset the projection. Read-compute-append sequences must revalidate ownership
-before the append so an expired-lease slice cannot duplicate or roll back
-another writer's entries.
+Session-log writers are serialized by conversation ownership at their call
+sites: conversation-record writes are fenced in the store (an expired lease
+surfaces as `ConversationMutationFencedError` via `extendLock`), and
+session-log read-compute-append sequences run under the conversation lease or
+the thread resume lock (including the parked-input append, which takes the
+resume lock). The session-log store itself does not implement a general
+in-store compare-and-swap; a writer that no longer holds its lease or lock
+must not append entries or reset the projection.
 
 The schema must be a strongly typed discriminated union with runtime validation
 at the storage boundary. The TypeScript type and the runtime parser must come
@@ -610,8 +613,8 @@ Required attributes when available:
 10. Component/integration: successful provider activation appends one `mcp_provider_connected` event, and resume restores providers from those events. Legacy Pi-message inference is allowed only while pre-event session logs still exist.
 11. Component/integration: a user message arriving while a session is `awaiting_resume` reaches Pi history (steered or appended) and receives an answer; it is never marked injected without a session-log append.
 12. Component/integration: a lease-expired `running` session is resumed or terminally failed with a visible fallback; it never no-ops.
-13. Component: redelivery after a lost input commit does not duplicate the user prompt or bootstrap context in Pi history.
-14. Component: a failed host-only activity append is swallowed and the model turn continues.
+13. Unit: redelivery after a lost input commit does not duplicate the user prompt or bootstrap context in Pi history.
+14. Unit: a failed host-only activity append is swallowed and the model turn continues.
 
 ## Related Specs
 

--- a/specs/agent-turn-handling.md
+++ b/specs/agent-turn-handling.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-05-30
-- Last Edited: 2026-06-08
+- Last Edited: 2026-07-01
 
 ## Purpose
 
@@ -71,21 +71,25 @@ Scenarios:
 
 Junior must avoid responding to messages authored by itself so Slack delivery, retries, and bot-authored follow-ups do not create reply loops.
 
-Scenario:
+Scenarios:
 
 1. Junior-authored message is observed:
    - When Junior observes a message whose author is Junior itself, Junior must not start a normal assistant turn for that message.
+2. Bot-authored passive message:
+   - When a subscribed thread receives a message authored by another bot and no human directed Junior to act, Junior must not reply. Bot-authored passive traffic fails closed to silence so two bots cannot enter a reply loop.
 
 ### 4. Queued And Skipped User Input
 
-Junior must preserve user-authored messages that arrive while a turn is active and include them in the next handled turn according to the Chat SDK queue contract.
+Junior must preserve user-authored messages that arrive while a turn is active or parked and make them model-visible in the same conversation according to the mailbox contract in `./task-execution.md`.
 
 Scenarios:
 
 1. Multiple messages arrive during an active turn:
-   - When users send one or more messages while the per-thread handler is still processing an earlier message, Junior must combine the queued user text with the dispatched message text for the next eligible turn.
+   - When users send one or more messages while an earlier message is still being processed, Junior must combine the queued user text with the dispatched message text for the next eligible turn.
 2. Skipped passive message later becomes relevant:
    - When Junior skips a passive subscribed-thread message and a later explicit mention asks about the same thread context, Junior must make the skipped message available as prior conversation context when building the later turn.
+3. Message arrives while a turn awaits continuation:
+   - When a user message arrives while the conversation is parked awaiting a timeout, yield, or auth continuation, Junior must make the message model-visible — steered into the resumed run or handled as the next turn — and answer or acknowledge it. Consuming the message without model visibility is a contract violation.
 
 ### 5. In-Turn Execution Policy
 
@@ -168,6 +172,8 @@ Scenarios:
 3. Junior-authored messages must not start recursive turns.
 4. Slack side effects must not be reported as successful unless the tool succeeded in the same turn.
 5. Empty model output is not a successful final answer unless a successful side effect, file-only reply, or runtime-owned pause already satisfied the turn.
+6. User-visible failure text is the sanitized fallback response with its correlation/event id. Raw exception messages, stack traces, and internal error strings must not be delivered as reply text. Partial output may be delivered only when it is genuine model-authored text.
+7. Repeated failures for the same inbound message are bounded by the poison-work contract in `./task-execution.md`; one inbound message produces at most one visible failure reply.
 
 ## Observability
 

--- a/specs/agent-turn-handling.md
+++ b/specs/agent-turn-handling.md
@@ -173,7 +173,7 @@ Scenarios:
 4. Slack side effects must not be reported as successful unless the tool succeeded in the same turn.
 5. Empty model output is not a successful final answer unless a successful side effect, file-only reply, or runtime-owned pause already satisfied the turn.
 6. User-visible failure text is the sanitized fallback response with its correlation/event id. Raw exception messages, stack traces, and internal error strings must not be delivered as reply text. Partial output may be delivered only when it is genuine model-authored text.
-7. Repeated failures for the same inbound message are bounded by the poison-work contract in `./task-execution.md`; one inbound message produces at most one visible failure reply.
+7. Repeated failures for the same inbound message are bounded by the dead-letter contract in `./task-execution.md`; one inbound message produces at most one visible failure reply.
 
 ## Observability
 

--- a/specs/chat-architecture.md
+++ b/specs/chat-architecture.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-03-21
-- Last Edited: 2026-06-11
+- Last Edited: 2026-07-01
 
 ## Purpose
 
@@ -93,19 +93,20 @@ Normative rules:
 
 Data authority by stage:
 
-| Data                                    | Authority                                              | Notes                                                                                                                              |
-| --------------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
-| Platform event shape                    | Source adapter ingress modules                         | Parse platform IDs and attachments before runtime; do not infer agent behavior here.                                               |
-| Queue wake-up and duplicate suppression | Conversation mailbox worker and lease                  | Queue messages are nudges; mailbox state and leases decide whether work exists and who may run it.                                 |
-| Conversation reporting rows             | `ConversationStore` / `./conversation-storage.md`      | Source for dashboard/API conversation lists; do not rebuild the primary list by grouping agent-run rows.                           |
-| Active execution discovery              | `conversation:active` index + conversation record      | Heartbeat discovers stale active conversations here, then uses the record to decide whether to enqueue a nudge.                    |
-| Conversation transcript                 | Persisted thread state                                 | Source for visible user/assistant thread history; assistant messages are added only after final destination delivery.              |
-| Active work routing                     | Conversation mailbox and lease                         | Pending messages are drained into the active conversation at safe boundaries for mailbox-backed paths.                             |
-| Pi execution transcript                 | Junior agent session log keyed by conversation id      | Append-only model-execution log with a deterministic Pi-message projection; not a replacement for visible conversation transcript. |
-| Sandbox/artifact state                  | Persisted thread state                                 | Persist eagerly as it changes so a resumed slice can rebuild the same runtime world.                                               |
-| Pending auth                            | Auth-owned callback state plus session-log pause event | Auth pauses end the live run after private link delivery and are resumed by callback.                                              |
-| Final destination reply                 | Destination delivery port acceptance                   | Completion is persisted only after the destination accepts the final visible reply.                                                |
-| Routine continuation progress           | Assistant status and `reportProgress`                  | Cooperative yields do not post filler thread messages.                                                                             |
+| Data                                    | Authority                                                  | Notes                                                                                                                              |
+| --------------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Platform event shape                    | Source adapter ingress modules                             | Parse platform IDs and attachments before runtime; do not infer agent behavior here.                                               |
+| Queue wake-up and duplicate suppression | Conversation mailbox worker and lease                      | Queue messages are nudges; mailbox state and leases decide whether work exists and who may run it.                                 |
+| Conversation reporting rows             | `ConversationStore` / `./conversation-storage.md`          | Source for dashboard/API conversation lists; do not rebuild the primary list by grouping agent-run rows.                           |
+| Active execution discovery              | `conversation:active` index + conversation record          | Heartbeat discovers stale active conversations here, then uses the record to decide whether to enqueue a nudge.                    |
+| Conversation transcript                 | Persisted thread state                                     | Source for visible user/assistant thread history; assistant messages are added only after final destination delivery.              |
+| Active work routing                     | Conversation mailbox and lease                             | Pending messages are drained into the active conversation at safe boundaries for mailbox-backed paths.                             |
+| Pi execution transcript                 | Junior agent session log keyed by conversation id          | Append-only model-execution log with a deterministic Pi-message projection; not a replacement for visible conversation transcript. |
+| Sandbox/artifact state                  | Persisted thread state                                     | Persist eagerly as it changes so a resumed slice can rebuild the same runtime world.                                               |
+| Pending auth                            | Auth-owned callback state plus session-log pause event     | Auth pauses end the live run after private link delivery and are resumed by callback.                                              |
+| Final destination reply                 | Destination delivery port acceptance                       | Completion is persisted only after the destination accepts the final visible reply.                                                |
+| Routine continuation progress           | Assistant status and `reportProgress`                      | Cooperative yields do not post filler thread messages.                                                                             |
+| Conversation visibility                 | Persisted destination record / `./conversation-storage.md` | Captured from source signals at ingress; consumed by redaction, transcript access, and reporting. Id prefixes never prove public.  |
 
 Related contract ownership:
 

--- a/specs/conversation-storage.md
+++ b/specs/conversation-storage.md
@@ -146,11 +146,11 @@ authority consumed by redaction, transcript access, and dashboard reporting
 - Ingress refreshes visibility from the current event's signal when it differs
   from the stored value, so a channel converted between public and private
   converges on the next message.
-- Readers must treat any value other than confirmed `public` as private.
-- Legacy rows whose visibility was derived from id prefixes are unconfirmed:
-  read them as private until a live source signal re-confirms them. No
-  destructive migration is required; this is a read-side rule plus write-side
-  refresh.
+- Readers must treat any value other than `public` as private.
+- Legacy Slack rows whose visibility was derived from id prefixes are migrated
+  to private. Losing historical public classification is acceptable because it
+  only reduces transcript/report exposure; the next live source signal can
+  restore public visibility.
 
 ### Retention And Erasure
 

--- a/specs/conversation-storage.md
+++ b/specs/conversation-storage.md
@@ -162,8 +162,10 @@ names.
   window owned by `./agent-session-resumability.md`. One constant owns each
   transcript key's TTL; writers must not apply divergent retention to the same
   key.
-- The conversation store must support deleting one conversation row together
-  with its now-unreferenced identity rows so erasure requests can be honored.
+- Deferred: single-conversation erasure (deleting one conversation row
+  together with its now-unreferenced identity rows) is a requirement the
+  store does not implement yet; it must be added before erasure requests can
+  be honored.
 - Bulk retention policy for SQL metadata is deployment-owned and out of scope
   here.
 

--- a/specs/conversation-storage.md
+++ b/specs/conversation-storage.md
@@ -134,6 +134,39 @@ Opaque JSON columns are allowed for source-specific payloads that are not used
 for authorization, lock ownership, credential routing, or external side-effect
 authority.
 
+### Destination Visibility
+
+`junior_destinations.visibility` is the persisted conversation-visibility
+authority consumed by redaction, transcript access, and dashboard reporting
+(`./data-redaction-policy.md`).
+
+- Visibility is captured from source-provided signals only. For Slack that is
+  the Events API `channel_type` or `conversations.info` `is_private`.
+  Identifier prefixes must not be used to mark a destination public.
+- Ingress refreshes visibility from the current event's signal when it differs
+  from the stored value, so a channel converted between public and private
+  converges on the next message.
+- Readers must treat any value other than confirmed `public` as private.
+- Legacy rows whose visibility was derived from id prefixes are unconfirmed:
+  read them as private until a live source signal re-confirms them. No
+  destructive migration is required; this is a read-side rule plus write-side
+  refresh.
+
+### Retention And Erasure
+
+SQL conversation metadata is durable and includes personal data: identity
+display and contact fields, requester JSON, generated titles, and channel
+names.
+
+- Transcript bodies stay in state-backed storage and expire with the retention
+  window owned by `./agent-session-resumability.md`. One constant owns each
+  transcript key's TTL; writers must not apply divergent retention to the same
+  key.
+- The conversation store must support deleting one conversation row together
+  with its now-unreferenced identity rows so erasure requests can be honored.
+- Bulk retention policy for SQL metadata is deployment-owned and out of scope
+  here.
+
 Inbound mailbox rows and lease fields are not part of the SQL schema. Pending
 input payloads and active lease ownership are temporary execution data and
 remain in the state-backed task-execution store until they either become
@@ -275,6 +308,7 @@ normal runtime tests.
 
 - `./task-execution.md`
 - `./chat-architecture.md`
+- `./data-redaction-policy.md`
 - `./agent-session-resumability.md`
 - `./scheduler.md`
 - `./plugin-database.md`

--- a/specs/data-redaction-policy.md
+++ b/specs/data-redaction-policy.md
@@ -22,13 +22,22 @@ dashboard reporting, logs, traces, and operational metadata.
 
 Junior classifies conversations as `public` or `private`.
 
-- Slack channels whose id starts with `C` are public.
-- Slack direct messages whose id starts with `D` are private.
-- Slack private channels and group DMs whose id starts with `G` are private.
-- Unknown or unparsable conversation ids are private.
+- Visibility comes from source-provided signals, not identifier shape. For
+  Slack, the accepted signals are the Events API `channel_type` (`channel` is
+  public; `group`, `im`, and `mpim` are private) and `conversations.info`
+  `is_private`.
+- Channel-id prefixes must not be used to prove a conversation public. Modern
+  Slack private channels also use `C`-prefixed ids. A prefix may only narrow
+  classification toward private (`D`, `G`).
+- Confirmed visibility is persisted on the destination record
+  (`./conversation-storage.md`). Persisted visibility is the authority for any
+  read that happens outside the originating event context: transcript tools,
+  dashboard reporting, and telemetry capture.
+- Unknown, unparsable, or unconfirmed visibility is private.
 
-Privacy checks must fail closed. A missing channel id, unknown conversation
-shape, or unsupported platform must not expose raw payloads.
+Privacy checks must fail closed. A missing channel id, missing visibility
+signal, unknown conversation shape, or unsupported platform must not expose
+raw payloads.
 
 ## Raw Payloads
 
@@ -63,6 +72,20 @@ debuggability and does not reveal raw content:
 
 Safe metadata must stay low-cardinality and bounded. Do not include arbitrary
 payload previews or nested values.
+
+## Model-Facing Transcript Access
+
+Transcript query tools expose stored conversation content to the model, so they
+are an exposure surface governed by the same visibility classification.
+
+- A conversation's transcript is always readable from that conversation's own
+  context.
+- Cross-conversation reads require persisted destination visibility of
+  `public` and the same provider tenant (Slack workspace) as the requesting
+  context.
+- Conversations with missing destinations or unconfirmed visibility are not
+  readable across contexts.
+- Local and Slack contexts must not read each other's transcripts.
 
 ## Dashboard Reporting
 
@@ -110,6 +133,10 @@ attribute.
 - Tool execution tests prove private tool arguments, results, and MCP error
   payloads are not exposed through reporting or telemetry capture paths.
 - Unknown conversation ids are treated as private.
+- Conversations Slack reports as private (`channel_type: group` or
+  `is_private: true`) are classified private regardless of a `C` id prefix.
+- Cross-context transcript reads are denied for conversations without
+  confirmed public visibility, including legacy rows classified by id prefix.
 
 ## Related Specs
 

--- a/specs/data-redaction-policy.md
+++ b/specs/data-redaction-policy.md
@@ -29,11 +29,11 @@ Junior classifies conversations as `public` or `private`.
 - Channel-id prefixes must not be used to prove a conversation public. Modern
   Slack private channels also use `C`-prefixed ids. A prefix may only narrow
   classification toward private (`D`, `G`).
-- Confirmed visibility is persisted on the destination record
-  (`./conversation-storage.md`). Persisted visibility is the authority for any
-  read that happens outside the originating event context: transcript tools,
-  dashboard reporting, and telemetry capture.
-- Unknown, unparsable, or unconfirmed visibility is private.
+- Visibility is persisted on the destination record
+  (`./conversation-storage.md`). Persisted `public` is the only public case for
+  reads outside the originating event context: transcript tools, dashboard
+  reporting, and telemetry capture.
+- Unknown, unparsable, missing, or historical visibility is private.
 
 Privacy checks must fail closed. A missing channel id, missing visibility
 signal, unknown conversation shape, or unsupported platform must not expose
@@ -83,7 +83,7 @@ are an exposure surface governed by the same visibility classification.
 - Cross-conversation reads require persisted destination visibility of
   `public` and the same provider tenant (Slack workspace) as the requesting
   context.
-- Conversations with missing destinations or unconfirmed visibility are not
+- Conversations with missing destinations or non-public visibility are not
   readable across contexts.
 - Local and Slack contexts must not read each other's transcripts.
 
@@ -135,8 +135,8 @@ attribute.
 - Unknown conversation ids are treated as private.
 - Conversations Slack reports as private (`channel_type: group` or
   `is_private: true`) are classified private regardless of a `C` id prefix.
-- Cross-context transcript reads are denied for conversations without
-  confirmed public visibility, including legacy rows classified by id prefix.
+- Cross-context transcript reads are denied unless the destination has
+  persisted public visibility.
 
 ## Related Specs
 

--- a/specs/slack-agent-delivery.md
+++ b/specs/slack-agent-delivery.md
@@ -276,8 +276,8 @@ Required verification coverage for this contract:
 4. Integration: file-only replies, suppressed-thread-text file delivery, and resume-path file parity.
 5. Integration: image attachments surviving edited-message ingress and skipped passive-thread hydration.
 6. Integration: assistant-thread lifecycle metadata initialization.
-7. Integration: edited-message mentions apply the shared author gate; external-user and bot-authored edits do not start turns.
-8. Integration: a mention delivered as both `app_mention` and `message` keeps its file attachments regardless of event arrival order.
+7. Integration: edited-message mentions apply the shared author gate; external-user and Junior-authored edits do not start turns.
+8. Component: a mention delivered as both `app_mention` and `message` keeps its file attachments regardless of event arrival order (mailbox twin-payload dedupe, `tests/component/task-execution/conversation-work.test.ts`).
 9. Evals: realistic user-visible multi-turn Slack behaviors when model interpretation is part of the contract.
 
 ## Related Specs

--- a/specs/slack-agent-delivery.md
+++ b/specs/slack-agent-delivery.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-04-15
-- Last Edited: 2026-06-27
+- Last Edited: 2026-07-01
 
 ## Purpose
 
@@ -30,23 +30,28 @@ This spec exists so Slack behavior is described in one place instead of being in
 - Re-specifying OAuth token security or MCP credential handling
 - Defining conversational quality criteria that belong to evals
 - Making Slack-native text streaming part of Junior's correctness contract
+- Reconciling message edits and deletions beyond the newly-added-mention entry path
 
 ## Contracts
 
 ### 1. Entry Surfaces
 
-Junior currently supports four Slack entry paths:
+Junior currently supports five Slack entry paths:
 
 1. Direct messages route through the explicit-mention path and must always be treated as reply-eligible.
 2. Channel or thread `@mentions` route through the explicit-mention path.
 3. Subscribed-thread follow-ups route through the subscribed-message path and may reply or stay silent based on the subscribed-thread policy.
-4. Slack assistant lifecycle events (`assistant_thread_started`, `assistant_thread_context_changed`) initialize or refresh assistant-thread metadata and context.
+4. Messages edited to newly mention Junior route through the explicit-mention path. Other edits and `message_deleted` events are not entry surfaces and are not reconciled into persisted context.
+5. Slack assistant lifecycle events (`assistant_thread_started`, `assistant_thread_context_changed`) initialize or refresh assistant-thread metadata and context.
 
 Implications:
 
 - DM traffic must not be silently treated like passive subscribed-thread traffic.
 - Explicit mentions bypass passive no-reply classification.
 - Assistant-thread lifecycle handling is part of the production surface even when the main conversational UX still happens in normal threads.
+- Every message entry path — including edited-message mentions — applies one shared author gate before persistence. Junior-authored, unparsable-author, and Slack Connect external-user messages are dropped by the same check on every path; no path may synthesize author flags that bypass it.
+- Entry classification requires resolved bot identity (the bot user id). If bot identity cannot be resolved, event handling must fail retryably. It must not degrade for the process lifetime into missed mention detection or disabled self-message filtering.
+- When Slack delivers both `app_mention` and `message` events for the same message, dedupe must preserve the richer payload: files and attachments must survive regardless of which event arrived first.
 
 ### 2. Context Sourcing Contract
 
@@ -238,7 +243,7 @@ Required split:
 
 1. Slack status-update failures are best effort and must not by themselves fail the turn.
 2. Slack thread-post or final delivery failures are turn failures because the visible reply contract was not satisfied.
-3. Junior must not persist assistant conversation state for a turn until final Slack delivery succeeds.
+3. Junior must not persist assistant conversation state for a turn until final Slack delivery succeeds. This includes the durable session-log/Pi transcript: an undelivered assistant reply must not surface to later turns as delivered conversation history.
 4. If a reply normalizes to empty and no files exist, Junior must post an explicit fallback message rather than silently succeeding.
 5. If a chunked reply overflows a code fence boundary, fence integrity must still be preserved in the delivered Slack posts.
 
@@ -271,7 +276,9 @@ Required verification coverage for this contract:
 4. Integration: file-only replies, suppressed-thread-text file delivery, and resume-path file parity.
 5. Integration: image attachments surviving edited-message ingress and skipped passive-thread hydration.
 6. Integration: assistant-thread lifecycle metadata initialization.
-7. Evals: realistic user-visible multi-turn Slack behaviors when model interpretation is part of the contract.
+7. Integration: edited-message mentions apply the shared author gate; external-user and bot-authored edits do not start turns.
+8. Integration: a mention delivered as both `app_mention` and `message` keeps its file attachments regardless of event arrival order.
+9. Evals: realistic user-visible multi-turn Slack behaviors when model interpretation is part of the contract.
 
 ## Related Specs
 

--- a/specs/slack-outbound-contract.md
+++ b/specs/slack-outbound-contract.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-04-16
-- Last Edited: 2026-04-30
+- Last Edited: 2026-07-01
 
 ## Purpose
 
@@ -35,6 +35,7 @@ Slack outbound behavior is split into two explicit boundaries:
 2. `packages/junior/src/chat/slack/outbound.ts` owns direct Slack Web API writes for message posts, ephemeral posts, file uploads, and reactions.
 3. Callers must not duplicate Slack outbound behavior with direct `getSlackClient().chat.postMessage(...)`, `chat.postEphemeral(...)`, `filesUploadV2(...)`, or `reactions.*(...)` outside `slack/outbound.ts`.
 4. Delivery modules must send already-rendered Slack text and must not apply their own Slack formatting rules after `slack/output.ts` has rendered it.
+5. Outbound writes resolve their token from the destination's workspace installation. A process-global token is a valid resolution only for single-workspace deployments; a write must never reach one workspace with another workspace's credentials.
 
 ### 2. Reply-Text Translation Contract
 
@@ -90,15 +91,17 @@ Current rules:
 
 Current rules:
 
-1. Slack rate limits are retried through `withSlackRetries`.
-2. Permanent Slack API failures are mapped into `SlackActionError` codes before surfacing.
-3. Error mapping must preserve the Slack API error string when available so callers and logs can distinguish specific platform failures.
-4. Idempotent success cases (`already_reacted`, `no_reaction`) are mapped explicitly so outbound callers can handle them intentionally.
+1. Slack rate limits are retried through `withSlackRetries`, honoring `Retry-After` bounded by the worker's remaining execution budget.
+2. Connection-phase network failures (the request is known not to have reached Slack) and Slack 5xx responses are retryable.
+3. Request timeouts where Slack may have accepted a message post are not retried, because a retry could duplicate a visible message. Reads and idempotent operations may retry timeouts.
+4. Permanent Slack API failures are mapped into `SlackActionError` codes before surfacing.
+5. Error mapping must preserve the Slack API error string when available so callers and logs can distinguish specific platform failures.
+6. Idempotent success cases (`already_reacted`, `no_reaction`) are mapped explicitly so outbound callers can handle them intentionally.
 
 ## Failure Model
 
 1. Invalid local inputs (missing channel IDs, empty text, empty file batches, invalid emoji aliases) fail before Slack is called.
-2. Rate-limited Slack writes may be retried.
+2. Rate-limited writes, connection-phase failures, and Slack 5xx responses may be retried; a transient network error on final delivery must not be surfaced as a turn failure before retries are exhausted.
 3. Non-retryable Slack failures surface as `SlackActionError` values unless the contract explicitly defines them as idempotent success.
 4. Best-effort follow-on work, such as permalink lookup, must not retroactively fail a successful message post.
 5. Message deletion used for post-delivery cleanup goes through the shared outbound boundary.

--- a/specs/task-execution.md
+++ b/specs/task-execution.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-06-01
-- Last Edited: 2026-06-12
+- Last Edited: 2026-07-01
 
 ## Purpose
 
@@ -210,6 +210,7 @@ interface InboundMessage {
   receivedAtMs: number;
   input: AgentInput;
   injectedAtMs?: number;
+  attemptCount?: number;
 }
 
 interface Lease {
@@ -360,6 +361,9 @@ record remains the public execution summary. The contract is:
   idempotent
 - messages that arrive while a worker is active remain pending until the worker
   drains them at a safe boundary or a later worker resumes the conversation
+- conversation record writes are fenced: a mutator that no longer holds the
+  mutation lock or lease must not overwrite the record. Blind read-modify-write
+  that can clobber a newer record with a stale copy is a contract violation.
 
 The `InboundMessage` and `ConversationExecution` shapes are defined in the
 conversation record above.
@@ -446,7 +450,7 @@ Initial timing defaults:
 ```text
 worker check-in interval: 15s
 lease ttl: 90s
-heartbeat scan interval: 30s
+heartbeat scan interval: 60s (production one-minute cron)
 recovery trigger: lease.expiresAtMs <= now
 ```
 
@@ -607,6 +611,10 @@ Rules specific to the mailbox worker:
 6. Slack delivery remains best effort around process death. First pass does not
    add a generalized receipt or reconciliation system beyond persisted
    conversation completion state.
+7. Any ingress failure before durable mailbox append — including installation
+   or token resolution and routing-state reads — must return a retryable
+   non-2xx response so Slack redelivers. Acknowledging without persistence is
+   allowed only for events classified as ignorable.
 
 ### Heartbeat Contract
 
@@ -625,6 +633,11 @@ On each bounded scan, heartbeat must:
    `{ conversationId, destination }` when there is no recent `lastEnqueuedAtMs`.
 6. Update `lastEnqueuedAtMs`, `execution.updatedAtMs`, and the active index score
    after a repair nudge is accepted.
+
+7. Conversation records that fail to load or validate must not stall the scan.
+   Heartbeat removes them from `junior:conversation:active` after recording the
+   failure, so unreadable records cannot permanently occupy the bounded scan
+   window and starve recovery for every other conversation.
 
 Heartbeat must not run the agent inline. It only repairs durable state and sends
 queue wake-up nudges.
@@ -647,16 +660,35 @@ selection remain owned by their domain specs. Once claimed, execution should use
 the same mailbox, lease, session-log, and delivery contracts as interactive
 work.
 
+### Poison Work And Retry Bounds
+
+Retries must be bounded so one bad message cannot loop forever or spam the
+destination.
+
+1. Each inbound message carries a durable delivery attempt count. A worker
+   failure that leaves the message pending increments it.
+2. When a message exceeds the configured attempt limit, the worker consumes
+   it: record a terminal failure, deliver at most one visible fallback reply
+   for the affected request, and remove the message from `pendingMessages`
+   while keeping its id in `inboundMessageIds`.
+3. A failed run must not both NACK the queue delivery and schedule a recovery
+   nudge. Record durable recovery state, send one nudge, and acknowledge the
+   delivery.
+4. A visible failure reply is posted at most once per inbound message.
+   Requeued work for a message that already produced a failure reply must not
+   post another one.
+5. A queue delivery whose conversation record cannot be loaded or validated is
+   acknowledged as rejected after recording the failure. Redelivery cannot
+   repair a permanently invalid record.
+
 ### TODO Guardrails
 
-The first pass intentionally avoids extra looping controls. After the mailbox
-worker is proven in production, add policy for:
+Remaining looping controls deferred until the mailbox worker has more
+production history:
 
 - maximum wall-clock age for one active conversation run
-- maximum consecutive recoveries without a new session-log boundary
 - explicit cancel/stop semantics for user messages that should abandon active
   work
-- duplicate final-delivery suppression if duplicate replies are observed
 
 These guardrails must not complicate the first-pass mailbox/lease design.
 
@@ -686,6 +718,12 @@ These guardrails must not complicate the first-pass mailbox/lease design.
    and does not add special reconciliation beyond persisted completion state.
 10. Heartbeat misses one scan: Vercel Queue redelivery or the next heartbeat can
     still recover because leases and mailbox messages are durable.
+11. A message fails deterministically on every attempt: the attempt limit
+    consumes it with a terminal failure record and one visible fallback reply
+    instead of an unbounded requeue loop.
+12. A conversation record becomes unparsable: queue deliveries for it are
+    acknowledged as rejected and heartbeat drops it from the active index; it
+    cannot starve recovery for other conversations.
 
 ## Observability
 
@@ -700,6 +738,7 @@ Required event names should distinguish normal progress from repair:
 - `conversation_work_pending_requeued`
 - `conversation_work_recovery_failed`
 - `conversation_work_failed`
+- `conversation_work_poisoned` (attempt limit reached, message consumed)
 
 Required attributes when available:
 
@@ -756,6 +795,10 @@ Required invariants, using the lowest layer that proves the contract:
 17. Integration: realistic multi-message Slack follow-ups during long work
     preserve user intent by interrupting active requests and deferring passive
     reply-eligible messages according to the Slack delivery contract.
+18. Component: a message exceeding the delivery attempt limit is consumed with
+    a terminal failure record and at most one visible fallback reply.
+19. Component: heartbeat removes unreadable conversation records from the
+    active index and continues repairing the remaining backlog.
 
 ## Related Specs
 

--- a/specs/task-execution.md
+++ b/specs/task-execution.md
@@ -34,7 +34,7 @@ invocations without turning every tool call into a queue round trip.
 - Queueing every model call or every tool call as a separate asynchronous task.
 - Exactly-once external side-effect delivery.
 - Mid-model-stream or mid-tool-call checkpointing.
-- Owning model-execution poison-work policy. Timeout slice caps belong to
+- Owning model-execution retry-limit policy. Timeout slice caps belong to
   `./agent-session-resumability.md`; this layer only requeues or releases
   conversation work based on durable runnable state.
 - Using Slack thread messages as progress filler for routine continuation.
@@ -738,7 +738,7 @@ Required event names should distinguish normal progress from repair:
 - `conversation_work_pending_requeued`
 - `conversation_work_recovery_failed`
 - `conversation_work_failed`
-- `conversation_work_poisoned` (attempt limit reached, message consumed)
+- `conversation_work_dead_lettered` (attempt limit reached, message consumed)
 
 Required attributes when available:
 


### PR DESCRIPTION
Junior's message receive→process→deliver pipeline went through a full architecture review; this branch tightens the specs where they were wrong or silent, then implements the fixes against them. The specs commit is the contract diff — reading it first makes the code review mostly a conformance check.

What changes in behavior:

- **Conversation privacy is no longer inferred from channel-id prefixes.** Modern Slack private channels use `C`-prefixed ids, so prefix inference classified them public — exposing private transcripts through cross-conversation thread reads, dashboard transcripts, and unredacted `gen_ai` telemetry. Visibility now comes from the Events API `channel_type` signal, is persisted on `junior_destinations` with a confirmation timestamp (expand-only migration `0002`), and every read surface fails closed to private.
- **Edited messages pass the same author gate as fresh ones.** A Slack Connect external user (or a bot edit) could previously start an agent turn by editing a mention into a message, because the `message_changed` path hardcoded author flags. Bot identity resolution also fails retryably now instead of caching a failed `auth.test` for the process lifetime, which silently disabled self-reply-loop protection and mention detection.
- **Messages can no longer be silently lost or answered stale.** Follow-ups arriving while a run is parked (`awaiting_resume`) are appended to the session log under the resume lock instead of being consumed invisibly; hard worker death mid-run resumes from the last durable boundary or fails visibly; ingress failures before durable mailbox append return 503 so Slack redelivers.
- **Failures are bounded and sanitized.** Inbound messages carry a durable attempt count, so a deterministic failure produces one visible fallback instead of a failure reply every queue cycle forever; unparsable conversation records are evicted from the recovery index instead of starving heartbeat for every conversation; raw exception text never reaches users.
- **Delivery is the durability boundary.** Session records reach `completed` only after Slack accepts the reply, so a failed post cannot poison later turns' history with an answer the user never saw, and post-acceptance persistence blips cannot post a contradictory failure reply after the correct one. Continuations that lack a stored requester now recover identity from the durable conversation record or terminally fail with a visible fallback instead of NACK-looping the continue queue.
- **Outbound hardening:** retries cover connection-phase failures and Slack 5xx with clamped `Retry-After` (timed-out posts are never retried, avoiding duplicates), and writes resolve the destination workspace's installation token rather than a process-global env token.

Rollout notes:

- `junior upgrade` applies migration `0002` (nullable `visibility_confirmed_at` on `junior_destinations`). The runtime degrades gracefully if code runs before the migration: metadata writes log and skip, turns are unaffected.
- Legacy prefix-classified rows read as **private** until a live event signal re-confirms them, so existing public-channel dashboard transcripts show redacted until each channel's next message.

Review order: `specs/` first, then ingress + privacy (`chat/ingress/`, `conversation-privacy.ts`, `conversations/sql/`), then `chat/task-execution/`, then runtime (`respond.ts`, `runtime/reply-executor.ts`, `runtime/agent-continue-runner.ts`), then `slack/client.ts`/`slack/outbound.ts`.

Accepted windows (documented in the specs): a crash in the instant between Slack acceptance and the completed-record commit can still double-post via stranded recovery — irreducible without an outbox, which the spec deliberately avoids; multi-workspace continuation delivery fails closed pending installation-token plumbing through resume paths.

Fixes GH-727

🤖 Generated with [Claude Code](https://claude.com/claude-code)