### PR TITLE
fix(slack): Resume continuations without stored requester

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ Co-Authored-By: (agent model name) <email>
 - `policies/policy-template.md` (template for adding new policy docs)
 - `policies/runtime-boundary-schemas.md` (strict runtime schemas and inferred types for boundary contracts)
 - `policies/test-adapters.md` (Django-inspired shared test adapters, outboxes, and isolation rules)
+- `policies/testing.md` (integration/eval-first testing policy and unit-test churn guardrails)
 
 ## Investigation-First Development
 

--- a/packages/junior/src/chat/requester.ts
+++ b/packages/junior/src/chat/requester.ts
@@ -264,21 +264,20 @@ export function toStoredSlackRequester(
   };
 }
 
-/** Resolve a Slack resume requester from stored runtime identity and the active actor. */
+/** Resolve a Slack resume requester from stored profile data and the active actor. */
 export function createSlackResumeRequester(args: {
   requester?: Requester;
   teamId: string;
   userId: string;
 }): SlackRequester {
-  if (!args.requester) {
-    throw new Error("Stored Slack requester is required for resume");
-  }
-  if (
-    args.requester.platform !== "slack" ||
-    args.requester.teamId !== args.teamId ||
-    args.requester.userId !== args.userId
-  ) {
-    throw new Error("Stored Slack requester did not match resume actor");
+  if (args.requester) {
+    if (
+      args.requester.platform !== "slack" ||
+      args.requester.teamId !== args.teamId ||
+      args.requester.userId !== args.userId
+    ) {
+      throw new Error("Stored Slack requester did not match resume actor");
+    }
   }
   const requester = createRequester(args.requester, {
     platform: "slack",

--- a/packages/junior/tests/integration/agent-continue-slack.test.ts
+++ b/packages/junior/tests/integration/agent-continue-slack.test.ts
@@ -267,6 +267,92 @@ describe("agent continuation Slack integration", () => {
     });
   });
 
+  it("resumes and delivers when the continuation record is missing stored requester profile data", async () => {
+    const conversationId = "slack:C123:1712345.0008";
+    const sessionId = "turn_msg_8";
+    const sessionRecord =
+      await turnSessionStoreModule.upsertAgentTurnSessionRecord({
+        conversationId,
+        sessionId,
+        sliceId: 2,
+        state: "awaiting_resume",
+        destination: SLACK_DESTINATION,
+        source: slackSource("1712345.0008"),
+        piMessages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "hello" }],
+            timestamp: 1,
+          },
+        ],
+        resumeReason: "timeout",
+        resumedFromSliceId: 1,
+        errorMessage: "Agent turn timed out",
+      });
+
+    await threadStateModule.persistThreadStateById(conversationId, {
+      artifacts: {
+        listColumnMap: {},
+      },
+      conversation: {
+        schemaVersion: 1,
+        backfill: {},
+        compactions: [],
+        piMessages: [],
+        messages: [
+          {
+            id: "msg.8",
+            role: "user",
+            text: "resume this request",
+            createdAtMs: 1,
+            author: {
+              userId: "U123",
+            },
+          },
+        ],
+        processing: {
+          activeTurnId: sessionId,
+        },
+        stats: {
+          compactedMessageCount: 0,
+          estimatedContextTokens: 0,
+          totalMessageCount: 1,
+          updatedAtMs: 1,
+        },
+        vision: {
+          byFileId: {},
+        },
+      },
+    });
+
+    const continued = await continueAgentRun({
+      conversationId,
+      sessionId,
+      expectedVersion: sessionRecord.version,
+    });
+
+    expect(continued).toBe(true);
+    expect(slackApiOutbox.messages()).toEqual([
+      expect.objectContaining({
+        params: expect.objectContaining({
+          channel: "C123",
+          thread_ts: "1712345.0008",
+          text: "Final resumed answer",
+        }),
+      }),
+    ]);
+    expect(generateAssistantReplyMock).toHaveBeenCalledWith(
+      "resume this request",
+      expect.objectContaining({
+        requester: {
+          platform: "slack",
+          teamId: "T123",
+          userId: "U123",
+        },
+      }),
+    );
+  });
+
   it("schedules another continuation for high slice ids", async () => {
     const conversationId = "slack:C123:1712345.0002";
     const sessionId = "turn_msg_2";

--- a/policies/testing.md
+++ b/policies/testing.md
@@ -1,0 +1,41 @@
+# Testing
+
+## Intent
+
+Tests should protect product contracts without freezing implementation details.
+Prefer higher-fidelity behavior coverage when it is deterministic enough, so
+routine refactors do not churn brittle unit tests.
+
+## Policy
+
+- Prefer integration tests for product/runtime behavior when the contract can be
+  proven through real wiring with only the allowed fake boundary.
+- Prefer evals for agent-facing behavior that depends on model interpretation,
+  continuity, routing, or reply quality.
+- Use unit tests only for tightly local deterministic logic where integration or
+  eval coverage would be materially slower, less deterministic, or less
+  diagnostic.
+- Do not add unit tests as duplicate confidence for behavior already covered by
+  integration or eval tests.
+- Delete or avoid unit tests that mainly mirror helper branches behind a
+  user-visible behavior contract.
+- Keep coverage proportional: one representative happy path, one realistic
+  failure or policy guardrail, and edge cases only when they have production
+  history or meaningfully different safety/routing semantics.
+- Mock one boundary per test, and only the boundary allowed for that test layer.
+  Do not stack mocks across persistence, runtime, delivery, and reply execution
+  to simulate a product workflow.
+- Prefer existing harnesses, shared fixtures, memory adapters, MSW handlers, and
+  outboxes over ad hoc mocks or local payload schemas.
+- Assert user-visible outcomes and external contracts before implementation
+  details. Logs, spans, and status telemetry are not behavior contracts unless
+  the test is explicitly about instrumentation.
+
+## Exceptions
+
+- A unit test is appropriate for pure parsing, normalization, retry math,
+  scoring, small deterministic transforms, and local algorithmic invariants.
+- A component test is appropriate for deterministic service/runtime contracts
+  that cross modules but do not need full product wiring.
+- Very low-level contract tests may inspect implementation-shaped payloads when
+  the payload shape itself is the external contract.

--- a/specs/component-testing.md
+++ b/specs/component-testing.md
@@ -3,67 +3,32 @@
 ## Metadata
 
 - Created: 2026-06-02
-- Last Edited: 2026-06-02
+- Last Edited: 2026-07-02
 
-## Intent
+## Purpose
 
-Component tests validate deterministic service/runtime contracts that span more
-than one module but do not need full product wiring to prove the invariant.
+Component tests cover deterministic service/runtime contracts that cross modules
+without needing full product wiring. Layer-selection judgment lives in
+`../policies/testing.md`.
 
-Use this layer when real domain code, memory-backed state, and explicit local
-ports give a clearer contract test than either a narrow unit test or a broad
-integration test.
+## Use For
 
-## Scope
-
-In scope:
-
-- Durable store and state-machine contracts.
+- Durable stores and state machines.
 - Queue wake-up, lease, heartbeat, and worker coordination.
-- Service orchestration where the dependency boundary is a small injected port.
-- Adapter contracts that can be proven with a fake client or MSW without running
-  the full Slack/runtime path.
-- Persistence behavior using the shared memory state adapter.
+- Service orchestration through small injected ports.
+- Adapter contracts where the adapter boundary itself is the contract.
 
-## Non-Goals
-
-- Slack-visible behavior, final reply delivery, and Slack HTTP request contracts
-  that require real runtime wiring.
-- Model-dependent behavior or conversational quality.
-- Tests that patch production singletons or module imports to steer a user-visible
-  workflow.
-- Exhaustive branch coverage for implementation details.
-
-## Substitution Policy
-
-Allowed:
-
-- Fake queue, clock, random-id, callback, and agent-runner ports.
-- Shared memory-backed state adapters.
-- MSW handlers when the adapter boundary itself is the contract.
-- Local spies on explicit injected ports.
-
-Disallowed:
-
-- Broad dependency bags or service locators created only for tests.
-- `vi.mock` of runtime modules to force unrelated branches.
-- Fake Slack delivery and fake reply execution together to prove a single
-  user-visible outcome. Use integration or eval for that.
-
-## Naming and Placement
+## Mechanics
 
 - Preferred path: `packages/junior/tests/component/**`.
-- Test titles should name the durable/service outcome, not the implementation
-  branch that happens to produce it.
-- Keep component files focused by feature or service boundary, for example
-  `tests/component/task-execution/*`.
+- Use real domain modules for the contract under test.
+- Use shared memory-backed state adapters when persistence is involved.
+- Fake ports should be explicit, small, and role-named.
+- MSW is acceptable when the adapter boundary is the contract.
 
-## Required Characteristics
+## Do Not Use For
 
-1. Use real domain modules for the contract under test.
-2. Keep fake ports explicit, small, and role-named.
-3. Assert the externally relevant service result first, then durable state when
-   the durable state is part of the contract.
-4. Prefer one representative failure or race case per invariant.
-5. Do not promote a component test to integration solely to satisfy a coverage
-   checklist.
+- Slack-visible behavior or final reply delivery.
+- Model-dependent behavior.
+- Tests that patch production singletons or runtime imports to steer product
+  behavior.

--- a/specs/eval-testing.md
+++ b/specs/eval-testing.md
@@ -1,79 +1,43 @@
-# Eval (E2E Behavior) Testing Spec
+# Eval Testing Spec
 
 ## Metadata
 
 - Created: 2026-03-03
-- Last Edited: 2026-06-18
+- Last Edited: 2026-07-02
 
-## Intent
+## Purpose
 
-Evals validate end-to-end conversational behavior outcomes through the runtime harness and LLM-judged criteria. Treat them as the integration-style layer for agent-facing behavior: use them when the contract depends on natural-language interpretation, continuity, prompt behavior, or reply quality. The Slack eval judge uses the same harness prompt seam as the suite, backed by Junior's Pi client and Vercel AI Gateway.
+Evals cover agent-facing behavior through the runtime harness when the contract
+depends on model interpretation. Layer-selection judgment lives in
+`../policies/testing.md`.
 
-The normalized `vitest-evals` session is the canonical eval surface. Judges and deterministic assertions should use `result.session`, `toolCalls(result.session)`, artifacts, and traces before introducing any repo-local output schema. If a case needs a fully ordered agent transcript, use or improve the native `vitest-evals` Pi harness boundary instead of building a repo-local event log.
+## Use For
 
-## Scope
+- Natural-language routing and intent handling.
+- Reply quality and continuity.
+- Prompt, skill, tool-choice, and provider behavior.
+- User-visible multi-turn outcomes.
 
-In scope:
+## Mechanics
 
-- Multi-turn conversational behavior.
-- User-visible response quality and continuity.
-- Lifecycle/resilience behavior as observed by users.
+- Define suites with `describeEval()`.
+- Define cases as normal `it()` tests that call `run(...)`.
+- Use realistic prompts; do not script internal tool names or implementation
+  steps into the user request.
+- Put semantic expectations in `rubric({ pass, fail })`.
+- Put deterministic boundary assertions against `result.session`,
+  `toolCalls(result.session)`, artifacts, or traces.
+- Run focused files with:
+  `pnpm --filter @sentry/junior-evals evals path/to/eval.eval.ts`
 
-## Non-Goals
+## Assertion Surface
 
-- Low-level Slack Web API request payload shape assertions.
-- Internal implementation details not observable to end users.
+The normalized `vitest-evals` session is canonical. Do not create repo-local
+transcript, event-log, or tool-call schemas when the harness surface can be
+improved instead.
 
-## Authoring Rules
+## Do Not Use For
 
-1. Define suites via `describeEval()` with the shared Slack harness options, and define cases as plain `it()` tests that call `run(...)` with event builders.
-2. Keep each case focused on one primary behavior outcome.
-3. Express expectations through the structured rubric shape used by `rubric({ pass, fail })`.
-4. Every new or edited eval must keep its rubric human-readable to maintainers.
-   The eval test name states the scenario and expected outcome.
-   `pass` lists the observable pass conditions.
-   `fail` lists failure conditions or forbidden output.
-5. Do not write judge criteria as one dense paragraph.
-6. Let the `describeEval()` block own the behavior area. The file path and `describeEval()` context already provide scope, so each individual eval name should only state the specific scenario and outcome.
-7. Prefer `when <trigger>, <outcome>` over vague labels like `continuity: remembers prior turn context`.
-8. Avoid asserting tool-internal mechanics unless explicitly user-visible.
-9. Keep user prompts natural and product-realistic. Do not script exact internal commands, tool names, or implementation steps into the prompt just to force a path.
-10. If a case only works when the prompt prescribes internal mechanics, treat that as an eval-design failure or product-behavior gap, not a passing eval.
-11. If a case uses harness-controlled decision fixtures such as subscribed-message reply gating, do not claim those gated behaviors are being validated by the eval outcome.
-12. Put semantic, model-dependent expectations in the rubric; put deterministic boundary expectations in normal Vitest assertions against `result.session`, `toolCalls(result.session)`, or `result.artifacts`.
-13. Do not create parallel transcript, event-log, or tool-call schemas for assertions. If the `vitest-evals` primitives cannot express the contract, improve the harness boundary first.
-
-## Boundaries
-
-Do not in eval files:
-
-- Import Slack action internals for direct contract assertions.
-- Use MSW queue/capture helpers intended for integration contract tests.
-- Rely on implementation-only identifiers (exact internal tool names, opaque IDs) unless the case intentionally evaluates that surface.
-- Encode exact internal commands or tool choices in user prompts when the contract under test is higher-level conversational behavior.
-- Assert product behavior from logs, spans, or status telemetry. Use session/tool/artifact primitives for behavior contracts; reserve traces/spans for instrumentation tests or diagnostics.
-
-## Relationship to Other Layers
-
-- Integration tests own Slack HTTP contract assertions and most runtime/product wiring.
-- Integration tests own real runtime behavior when a deterministic fake agent is sufficient and the contract is not model interpretation itself.
-- Unit tests own isolated deterministic logic invariants.
-- Evals own agent-facing conversational outcomes across realistic flows and replace ordinary integration tests for that surface.
-- Agent-level evals for prompt behavior, skill routing, tool choice, provider/tool calls, and reply quality should use the Pi-agent `vitest-evals` harness boundary when Slack transport is not the behavior under test.
-- Slack evals own Slack/runtime behavior: mentions, thread/channel delivery, OAuth privacy, lifecycle/resume behavior, reactions, and Slack-visible side effects.
-
-## When To Choose Evals
-
-Use evals when:
-
-1. The behavior depends on the model interpreting user language correctly.
-2. The behavior is about reply quality, continuity, passive participation, or natural-language routing rather than transport wiring.
-3. Lower-fidelity integration coverage would only prove a mocked version of the real contract.
-
-Do not choose evals for ordinary Slack payload-shape assertions, deterministic resume wiring, or handler contracts that integration tests can prove directly.
-
-## Execution
-
-Operational commands and harness details live in `packages/junior-evals/README.md`.
-
-The eval session contract should preserve user-visible output structure. In particular, assistant thread posts must retain attachment metadata instead of flattening attachments into synthetic text. Do not collapse the normalized session into prose or synthetic summaries for judge scoring.
+- Slack payload-shape assertions.
+- Deterministic resume or handler wiring that integration tests can prove.
+- Product behavior from logs, spans, or status telemetry.

--- a/specs/integration-testing.md
+++ b/specs/integration-testing.md
@@ -3,11 +3,15 @@
 ## Metadata
 
 - Created: 2026-03-03
-- Last Edited: 2026-06-02
+- Last Edited: 2026-07-02
 
 ## Intent
 
 Integration tests validate real runtime wiring and Slack-facing behavior, with deterministic control only at the agent boundary. Use this layer when the contract depends on production composition, handler routing, external transport behavior, or user-visible runtime outcomes. Evals take this role only when the contract is agent-facing behavior that depends on model interpretation.
+
+When integration can prove the same runtime/product behavior as a unit test,
+prefer the integration test and do not add parallel unit coverage for the helper
+branch. The integration test should own the contract.
 
 ## Scope
 
@@ -73,6 +77,10 @@ If the behavior under test depends on natural-language interpretation, continuit
 If a product/runtime change can be proven only by real wiring plus a deterministic fake agent, integration is the right answer. If the contract is a deterministic store, worker, queue-port, lease, or service-coordination invariant, prefer a component test.
 
 Do not keep a scenario in integration solely because a fake classifier fixture is easier than writing the corresponding eval. When the real contract is ambiguous natural-language behavior or reply quality, promote it to eval.
+
+If the behavior is user-visible or crosses runtime boundaries, do not demote it
+to unit tests just because the fix happens in a small helper. Exercise the
+production path and let helper internals remain refactorable.
 
 ## Core Scenarios to Cover
 

--- a/specs/integration-testing.md
+++ b/specs/integration-testing.md
@@ -5,125 +5,45 @@
 - Created: 2026-03-03
 - Last Edited: 2026-07-02
 
-## Intent
+## Purpose
 
-Integration tests validate real runtime wiring and Slack-facing behavior, with deterministic control only at the agent boundary. Use this layer when the contract depends on production composition, handler routing, external transport behavior, or user-visible runtime outcomes. Evals take this role only when the contract is agent-facing behavior that depends on model interpretation.
+Integration tests cover product/runtime behavior through real wiring with a
+deterministic fake agent boundary when needed. Layer-selection judgment lives in
+`../policies/testing.md`.
 
-When integration can prove the same runtime/product behavior as a unit test,
-prefer the integration test and do not add parallel unit coverage for the helper
-branch. The integration test should own the contract.
+## Use For
 
-## Scope
+- Slack event ingestion, routing, delivery, and HTTP contracts.
+- Auth callback and resume flows.
+- Runtime orchestration with real persistence/routing.
+- User-visible behavior that does not require model interpretation.
+- API or handler behavior through the real app path.
 
-In scope:
+## Mechanics
 
-- Slack event ingestion and routing behavior.
-- Runtime orchestration and state interactions.
-- Slack HTTP contracts (request shape, retries, error mapping) through MSW.
-- Auth callback and resume flows, persisted thread recovery, and other user-visible product wiring.
-- Behavior outcomes from real runtime flow using deterministic fake-agent outputs.
+- Preferred path: `packages/junior/tests/integration/**`.
+- Use real app/runtime modules for behavior paths.
+- Use MSW handlers and Slack fixtures for outbound Slack HTTP.
+- Substitute only the approved fake-agent/composition boundary for behavior
+  tests.
+- Assert user-visible output or external contract effects before internal
+  context details.
 
-## Non-Goals
+## Behavior vs Transport Contract
 
-- Pure algorithmic invariants better covered by unit tests.
-- Deterministic service/runtime contracts better covered by component tests.
-- Judge-scored conversational quality (belongs to evals).
+- Behavior tests assert scenario outcomes first.
+- Slack transport-contract tests may assert request payload shape, ordering, or
+  recipient metadata when that shape is the external contract.
+- Keep low-level Slack request assertions in dedicated contract-focused tests or
+  clearly separated suites.
 
-## Required Runtime Shape
+## Do Not Use
 
-1. Use real app/runtime modules for behavior paths.
-2. Use MSW handlers and Slack fixtures for outbound Slack HTTP.
-3. Keep persistence/routing code real unless the test is explicitly categorized as unit.
+- Runtime module mocks for behavior paths.
+- Ad hoc Slack HTTP stubs when MSW can express the contract.
+- Fake persistence and fake delivery together to simulate a product workflow.
 
-## Substitution Policy
+## Related Harness Docs
 
-Allowed:
-
-- Fake agent or service substitution at the composition boundary only (`createSlackRuntime(...)`, `createTestChatRuntime(...)`, or approved thin wrapper helpers over them).
-
-Disallowed in integration behavior tests:
-
-- Mutable runtime-global behavior seams or singleton patching for core chat behavior.
-- `vi.mock` for runtime behavior modules (`@/chat/state/*`, workflow router/runtime handlers, ingress binding/router paths, etc.).
-- Ad-hoc stubbing of Slack HTTP fetch/webclient internals in test files.
-- Ad-hoc fake persistence or fake Slack delivery layers when the shared memory adapter + MSW harness can prove the same contract.
-
-## Fixture and Harness Rules
-
-1. Use `packages/junior/tests/fixtures/slack/*` factories and harness helpers.
-2. Use `packages/junior/tests/msw/*` handler utilities for Slack API sequencing and assertions.
-3. Prefer scenario-style tests that drive events and assert resulting user-visible outputs + captured Slack API calls.
-
-## Behavior vs Transport-Contract Tests
-
-Both of the following remain integration tests when they use the real runtime path:
-
-1. Behavior integration tests:
-   - describe the scenario in user/runtime terms
-   - assert user-visible outcomes first
-   - avoid framing the test around internal call choreography
-2. Slack transport-contract integration tests:
-   - assert request payload shape, stream lifecycle, recipient metadata, or other Slack API details when those details are the real external contract
-   - should live in dedicated `*contract*.test.ts` files or clearly separated contract-focused suites
-
-Do not let low-level stream ordering or request-shape assertions dominate general `*-behavior.test.ts` files.
-
-## Classification Guidance
-
-If a test relies on runtime module mocks to drive control-flow branches, classify it as unit or component instead of integration.
-
-If the behavior under test depends on natural-language interpretation, continuity, or model choice, classify it as eval instead of integration.
-
-If a product/runtime change can be proven only by real wiring plus a deterministic fake agent, integration is the right answer. If the contract is a deterministic store, worker, queue-port, lease, or service-coordination invariant, prefer a component test.
-
-Do not keep a scenario in integration solely because a fake classifier fixture is easier than writing the corresponding eval. When the real contract is ambiguous natural-language behavior or reply quality, promote it to eval.
-
-If the behavior is user-visible or crosses runtime boundaries, do not demote it
-to unit tests just because the fix happens in a small helper. Exercise the
-production path and let helper internals remain refactorable.
-
-## Core Scenarios to Cover
-
-1. Mention and subscribed-thread routing behavior.
-2. Rapid same-thread message ordering/continuity.
-3. Error handling that remains user-visible and non-silent.
-4. Slack API contract correctness for tools/actions used by runtime paths.
-5. Context-bound tool targeting behavior (harness-resolved targets, no model-selected destination overrides).
-
-## Workflow Coverage Requirements
-
-Integration tests that cover workflow ingress/execution must assert workflow-boundary behavior, not just handler internals:
-
-1. Verify ingress payloads sent to workflow routing are serializable and contain serialized `chat:Message` / `chat:Thread` data (no function-valued fields).
-2. Exercise the real message-kind routing behavior (`new_mention` vs `subscribed_message`) through `routeIncomingMessageToWorkflow(...)`.
-3. Validate de-dup behavior on ingress and de-dup behavior in workflow stream processing.
-
-## Context-Bound Tool Coverage Requirements
-
-For tools governed by harness context (for example Slack channel/canvas/list operations):
-
-1. Assert destination/target comes from harness/runtime context rather than model-supplied IDs.
-2. Assert missing context fails safely with actionable error responses.
-3. Assert disallowed fallback scopes (for example bot-private artifacts for shared deliverables) are not used.
-
-## Scope Discipline (Do Not Over-Test)
-
-Integration tests should prove wiring and external behavior contracts, not exhaust every edge-case permutation.
-
-Required approach:
-
-1. Cover one representative happy path per runtime contract.
-2. Add failure-path coverage only for distinct, realistic regressions.
-3. Add edge-case coverage when:
-   - the behavior has caused production bugs before, or
-   - the edge case changes routing/safety semantics.
-
-Avoid:
-
-1. Duplicating the same assertion across multiple near-identical payload variants.
-2. Asserting internal call choreography that is not part of the contract. If request ordering is the contract, move it into a dedicated transport-contract integration test instead of a general behavior file.
-3. Encoding speculative edge cases with no concrete bug history or risk signal.
-
-## Enforcement
-
-`pnpm lint` enforces integration boundary policy for designated behavior integration tests.
+- Slack MSW and fixtures: `./slack-http-mocking.md`
+- Harness tool targeting: `./harness-tool-context.md`

--- a/specs/slack-http-mocking.md
+++ b/specs/slack-http-mocking.md
@@ -1,95 +1,44 @@
-# Slack HTTP Mocking Spec (MSW + Fixtures)
+# Slack HTTP Mocking Spec
 
 ## Metadata
 
 - Created: 2026-03-02
-- Last Edited: 2026-05-28
+- Last Edited: 2026-07-02
 
 ## Purpose
 
-Define the Slack HTTP contract testing model used by integration tests.
-This spec is subordinate to `specs/integration-testing.md`.
+Document the Slack MSW and fixture harness used by integration tests.
 
-## Summary
+## Runtime
 
-- Use MSW in Node test runtime as the default interception layer for Slack HTTP.
-- Use shared factories/fixtures for Slack API responses and inbound webhook/event payloads.
-- Do not stub Slack HTTP directly in test files.
-- Integration behavior tests keep runtime wiring real and only substitute the agent boundary.
+- Vitest runs Slack HTTP tests in Node.
+- `packages/junior/tests/msw/setup.ts` starts/stops MSW.
+- `packages/junior/tests/msw/server.ts` owns strict unhandled Slack request
+  behavior.
+- Slack SDK and native `fetch` calls to Slack endpoints are intercepted by MSW.
 
-## Goals
+## Fixtures And Handlers
 
-- Deterministic, network-isolated Slack contract tests.
-- High-confidence request/response coverage for Slack-facing actions.
-- Reusable fixtures and consistent test setup across files.
+- Slack handlers: `packages/junior/tests/msw/handlers/slack-api.ts`
+- Slack webhook handlers: `packages/junior/tests/msw/handlers/slack-webhooks.ts`
+- API factories: `packages/junior/tests/fixtures/slack/factories/api.ts`
+- Event factories: `packages/junior/tests/fixtures/slack/factories/events.ts`
+- ID factories: `packages/junior/tests/fixtures/slack/factories/ids.ts`
 
-## Non-goals
+Handlers cover success responses, Slack error envelopes, pagination, rate
+limits, and contract validation for Slack-only request shapes.
 
-- Replacing live Slack transport/integration tests.
-- Defining unit-test mocking policy (see `unit.md`).
-- Defining eval authoring policy (see `evals.md`).
+## Test Rules
 
-## Runtime and Compatibility
-
-- Test runtime: Vitest (`environment: "node"`).
-- MSW runtime: `msw/node`.
-- Slack SDK compatibility:
-  - `@slack/web-api` HTTP calls are intercepted by MSW handlers.
-  - Native `fetch` calls to Slack endpoints are intercepted by MSW handlers.
-
-## Architecture
-
-### 1) Global MSW lifecycle
-
-- `packages/junior/tests/msw/setup.ts` starts and stops MSW for test/eval runs.
-- `packages/junior/tests/msw/server.ts` configures strict unhandled Slack request behavior.
-- Setup is wired in `vitest.config.ts` and `vitest.evals.config.ts`.
-
-### 2) Centralized Slack handlers
-
-- `packages/junior/tests/msw/handlers/slack-api.ts`
-- `packages/junior/tests/msw/handlers/slack-webhooks.ts`
-
-Handlers support:
-
-- success responses
-- Slack API error envelopes
-- pagination cursors
-- rate limit responses and retry paths
-- contract validation for Slack-only request shapes that matter in production, including rejecting adapter-scoped `slack:<channel>` IDs where Slack expects raw conversation IDs
-
-### 3) Shared fixture/factory layer
-
-- `packages/junior/tests/fixtures/slack/factories/api.ts`
-- `packages/junior/tests/fixtures/slack/factories/events.ts`
-- `packages/junior/tests/fixtures/slack/factories/ids.ts`
-
-Conventions:
-
-- deterministic defaults
-- narrow payloads with fields consumed by app/test assertions
-- override-friendly builders
-
-## Test Authoring Rules
-
-1. Use MSW handlers for outbound Slack HTTP contract assertions.
-2. Use fixture factories for inbound payload construction.
-3. Do not directly stub Slack `fetch` endpoints in tests.
+1. Use MSW handlers for Slack HTTP assertions.
+2. Use fixture factories for inbound Slack payloads.
+3. Do not stub Slack `fetch` endpoints directly in tests.
 4. Do not use broad `vi.mock("@slack/web-api")` in integration tests.
-5. In behavior integration tests, do not mock runtime modules; control behavior through the fake-agent seam.
+5. In behavior integration tests, keep runtime wiring real and control behavior
+   through the fake-agent seam.
 
-## Required Slack Contract Scenarios
+## Acceptance
 
-- Success flow for each supported Slack API area.
-- Error mapping coverage (`missing_scope`, `not_in_channel`, `invalid_arguments`, `not_found`, etc.).
-- Retry coverage for rate limits (`429`, retry-after).
-- Pagination coverage where list/history APIs are used.
-- Failure on adapter-scoped `slack:<channel>` conversation IDs for endpoints that require raw Slack conversation IDs.
-- Failure on unhandled Slack request paths.
-
-## Acceptance Criteria
-
-- Slack tests run without real Slack network access.
-- Shared fixtures/factories are used consistently.
-- Contract assertions remain explicit and endpoint-specific.
-- Any fallback away from MSW is narrowly scoped and documented in the test file.
+- Tests must not access real Slack network endpoints.
+- Contract assertions should be endpoint-specific.
+- Any fallback away from MSW must be narrow and documented in the test file.

--- a/specs/testing.md
+++ b/specs/testing.md
@@ -7,120 +7,43 @@
 
 ## Purpose
 
-This index defines the project testing taxonomy and the contract between test layers.
-Use this file as the source of truth for where a test belongs and what it is allowed to mock.
+Testing judgment lives in `../policies/testing.md`. Use this file only to pick
+the repo test layer and find the harness docs.
 
-## Default Decision Rule
+## Layer Choice
 
-Start from the real product contract, not the easiest seam to mock.
+1. Use `eval` when model interpretation, continuity, tool choice, routing, or
+   reply quality is the behavior.
+2. Use `integration` when product/runtime behavior crosses real wiring,
+   persistence, Slack delivery, auth resume, API, or handler boundaries.
+3. Use `component` when a deterministic service/runtime contract crosses
+   modules but full product wiring is unnecessary.
+4. Use `unit` only for local deterministic logic and algorithms.
 
-1. Use evals when the contract is agent-facing behavior. Treat evals as the integration-style layer for prompt behavior, natural-language routing, continuity, reply quality, and other outcomes where model interpretation is the contract.
-2. Use integration tests when the contract is real product wiring or an external/user-visible boundary: handler behavior, Slack-facing contracts, persistence/routing through production composition, auth resumes, final delivery, and other behavior that does not depend on the model interpreting language correctly.
-3. Use component tests for deterministic service/runtime contracts that cross modules but are still best proven through explicit local ports: durable stores, queue wake-up ports, worker state machines, lease/recovery coordination, persistence adapters, and similar orchestration invariants.
-4. Use unit tests only for tightly local deterministic logic: parsing, scoring, routing heuristics, retry math, pure transforms, normalization, and similar algorithmic invariants. Unit tests are the exception, not the default, when a change touches product or runtime behavior.
+Default to the highest deterministic layer that proves the contract. Do not add
+lower-layer duplicate coverage when a higher-fidelity test owns the behavior.
 
-For runtime/product regressions, reproduce the failure at the highest deterministic boundary that owns the behavior. Prefer one integration or eval that drives real ingress, persistence, routing, and delivery wiring over unit tests that recreate intermediate state. Do not force deterministic service contracts into broad integration tests when a component test proves the invariant with fewer fake layers.
+## Layer References
 
-Prefer integration/eval coverage over unit coverage whenever both can prove the
-same user-visible or runtime contract. Unit tests that mirror helper branches
-already exercised by integration/eval coverage create churn and should be
-deleted or avoided. Add a unit test only when the invariant is local enough that
-an integration/eval would be materially slower, less deterministic, or less
-diagnostic.
+- Unit mechanics: `./unit-testing.md`
+- Component mechanics: `./component-testing.md`
+- Integration mechanics: `./integration-testing.md`
+- Eval mechanics: `./eval-testing.md`
+- Slack MSW and fixtures: `./slack-http-mocking.md`
+- Harness tool targeting: `./harness-tool-context.md`
 
-## Test Layers
+## Commands
 
-| Layer                 | Primary Goal                                             | Scope                                                                    | Allowed Substitutions                                                           | Disallowed                                                                                            |
-| --------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| Unit                  | Validate local deterministic invariants                  | Single module/function and tight collaborators                           | Local stubs/mocks (`vi.mock`, fakes)                                            | Baseline product/runtime behavior, Slack HTTP contract assertions, and conversational quality scoring |
-| Component             | Validate deterministic service/runtime contracts         | Real domain modules plus memory state and explicit local ports           | Fake queue/clock/agent-runner ports, memory adapters, MSW for adapter contracts | User-visible Slack delivery flows, model interpretation, broad runtime module mocks                   |
-| Integration           | Validate runtime/product behavior and external contracts | Real app wiring + Slack-facing behavior + persistence/routing boundaries | Deterministic fake agent at the agent boundary only                             | Runtime module/function mocks for behavior paths                                                      |
-| Eval (Agent Behavior) | Validate agent-facing conversational outcomes end-to-end | End-to-end harnessed conversation flows scored by judge criteria         | Case-level behavior fixtures and controlled environment flags                   | Low-level HTTP payload-shape assertions and internals-only checks                                     |
-
-## Canonical Specs
-
-- Unit rules: `./unit-testing.md`
-- Component rules: `./component-testing.md`
-- Integration rules: `./integration-testing.md`
-- Evals rules: `./eval-testing.md`
-- Slack HTTP fixture/MSW details: `./slack-http-mocking.md`
-- Harness tool-targeting rules: `./harness-tool-context.md`
-
-## Shared Rules Across All Layers
-
-Layer selection is mandatory: classify the test contract first and choose `unit`, `component`, `integration`, or `eval` before writing assertions.
-
-1. Tests must be deterministic and isolated.
-2. External HTTP is blocked by default in tests and evals; use MSW or the shared HTTP interceptor fixtures. Local URLs, model endpoints, and Vercel sandbox/OIDC control-plane traffic are the only live exceptions.
-3. Slack network access is blocked in tests; use MSW fixtures for Slack HTTP.
-4. Use centralized fixtures/factories (`packages/junior/tests/fixtures/slack/*`) over ad-hoc payload literals when available.
-5. Prefer asserting user-visible behavior and external contracts over implementation details.
-6. Keep test names descriptive of outcomes, not implementation mechanics.
-7. Do not over-test: cover representative, high-risk scenarios for each contract, not every theoretical permutation.
-8. Prefer one focused assertion path per behavior contract; add more cases only when they validate a distinct failure mode.
-9. Workflow and regression integration tests should execute real runtime paths and only substitute deterministic fake agent output at the agent boundary. Construct state by driving the owning path when practical; hand-build persisted state only when the state shape itself is the contract or real setup would require unrelated external systems.
-10. Do not assert internal observability emission (`logInfo`, `logWarn`, spans, trace attributes) in behavior tests unless instrumentation output is itself the contract under test.
-11. Do not assert prompt prose by checking that a string is present in a generated prompt. Prompt wording is not a stable contract; validate the resulting behavior in evals or integration tests instead.
-12. If Slack API call shape or ordering is the external contract under test, keep those assertions in dedicated transport-contract integration suites; general behavior files should stay scenario-readable.
-13. Prefer real in-memory adapters, fixtures, and harnesses over bespoke fake stores when the contract crosses module boundaries.
-14. Do not add a unit test as "extra confidence" for behavior already covered at integration/eval level. The higher-fidelity test owns that contract.
-
-## Coverage Budget (Avoid Over-Testing)
-
-Over-testing means adding low-signal tests that duplicate the same contract with different constants, mirror implementation branches without new behavior risk, or assert internal details that users do not observe.
-
-This includes logger calls and trace metadata for ordinary behavior paths. Those assertions belong only in instrumentation-focused tests or surfaces where the emitted output is the product (for example CLI output).
-
-Use this practical budget:
-
-1. Happy path for the contract.
-2. One high-likelihood failure mode (or policy guardrail).
-3. One boundary scenario only when it has prior incident history or meaningful production risk.
-
-If a proposed test does not add a new contract guarantee, do not add it.
-
-When higher-level coverage proves the user-visible contract, do not add parallel unit tests for the same workflow. Keep unit tests for deterministic helper logic the higher-level test cannot localize cleanly, and remove unit tests that become implementation-only duplicates after integration/eval coverage lands.
-
-## Layer Selection Guide
-
-This section is mandatory policy, not guidance.
-
-Ask these questions in order:
-
-1. Does the contract depend on the model choosing the right behavior or producing the right reply quality?
-   Use `eval`.
-   Examples: natural-language routing, passive participation, multi-turn continuity, prompt/skill behavior, research-answer shape.
-2. Otherwise, is this a product/runtime change whose contract is real wiring, Slack-visible behavior, auth resume, final delivery, or API contract effects?
-   Use `integration`.
-3. Otherwise, is this a deterministic service/runtime contract that crosses modules but can be proven through real domain code plus explicit local ports?
-   Use `component`.
-   Examples: mailbox/lease state machines, queue wake-up coordination, heartbeat repair, persistence adapter contracts, workflow runner decisions, and service orchestration with fake queue/clock/agent-runner ports.
-4. Otherwise, is the contract tightly local deterministic logic or an algorithmic invariant?
-   Use `unit`.
-   Examples: retry math, pure transforms, normalization, local scoring, parser behavior, deterministic state transitions.
-
-Before choosing `unit`, check whether an existing integration/eval harness can
-prove the same behavior through the production path with only the allowed fake
-boundary. If yes, use that higher-fidelity layer and skip the unit test.
-
-If a test must mock large parts of runtime, hand-build durable state, or assert private call sequencing to prove a user-visible flow, it belongs in integration or eval instead.
-
-## Mock Confidence Rules
-
-These rules are mandatory whenever mocks or fakes appear in a test.
-
-1. Mock one boundary, not a whole workflow.
-2. The mocked boundary must be the thing the layer is explicitly allowed to replace.
-3. If a component test needs fake ports, keep them explicit and role-named. Do not use module-level mocks to steer unrelated runtime branches.
-4. If a test needs to fake persisted state, Slack delivery, and reply execution together to prove one user-visible outcome, move it to integration or eval.
-5. If the same user-visible contract is already covered by a higher-fidelity integration or eval test, narrow the mocked test to a local invariant or delete it.
-6. Prefer real memory-backed state and the shared Slack/MSW harness over ad-hoc `Map` stores when the behavior crosses handler/runtime boundaries.
+- Unit/component/integration file:
+  `pnpm --filter @sentry/junior exec vitest run tests/path/file.test.ts`
+- Eval file:
+  `pnpm --filter @sentry/junior-evals evals path/to/eval.eval.ts`
 
 ## Enforcement
 
-`pnpm lint` enforces major Slack boundary rules for designated integration behavior tests:
+`pnpm lint` enforces major Slack behavior-test boundaries, including:
 
 - Eval files cannot import Slack contract internals.
 - Integration behavior tests cannot use runtime module mocks.
 
-See the ast-grep rules under `ast-grep/rules/`.
+See `ast-grep/rules/` for the mechanical checks.

--- a/specs/testing.md
+++ b/specs/testing.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-03-03
-- Last Edited: 2026-06-27
+- Last Edited: 2026-07-02
 
 ## Purpose
 
@@ -17,9 +17,16 @@ Start from the real product contract, not the easiest seam to mock.
 1. Use evals when the contract is agent-facing behavior. Treat evals as the integration-style layer for prompt behavior, natural-language routing, continuity, reply quality, and other outcomes where model interpretation is the contract.
 2. Use integration tests when the contract is real product wiring or an external/user-visible boundary: handler behavior, Slack-facing contracts, persistence/routing through production composition, auth resumes, final delivery, and other behavior that does not depend on the model interpreting language correctly.
 3. Use component tests for deterministic service/runtime contracts that cross modules but are still best proven through explicit local ports: durable stores, queue wake-up ports, worker state machines, lease/recovery coordination, persistence adapters, and similar orchestration invariants.
-4. Use unit tests only for tightly local deterministic logic: parsing, scoring, routing heuristics, retry math, pure transforms, normalization, and similar algorithmic invariants.
+4. Use unit tests only for tightly local deterministic logic: parsing, scoring, routing heuristics, retry math, pure transforms, normalization, and similar algorithmic invariants. Unit tests are the exception, not the default, when a change touches product or runtime behavior.
 
 For runtime/product regressions, reproduce the failure at the highest deterministic boundary that owns the behavior. Prefer one integration or eval that drives real ingress, persistence, routing, and delivery wiring over unit tests that recreate intermediate state. Do not force deterministic service contracts into broad integration tests when a component test proves the invariant with fewer fake layers.
+
+Prefer integration/eval coverage over unit coverage whenever both can prove the
+same user-visible or runtime contract. Unit tests that mirror helper branches
+already exercised by integration/eval coverage create churn and should be
+deleted or avoided. Add a unit test only when the invariant is local enough that
+an integration/eval would be materially slower, less deterministic, or less
+diagnostic.
 
 ## Test Layers
 
@@ -56,6 +63,7 @@ Layer selection is mandatory: classify the test contract first and choose `unit`
 11. Do not assert prompt prose by checking that a string is present in a generated prompt. Prompt wording is not a stable contract; validate the resulting behavior in evals or integration tests instead.
 12. If Slack API call shape or ordering is the external contract under test, keep those assertions in dedicated transport-contract integration suites; general behavior files should stay scenario-readable.
 13. Prefer real in-memory adapters, fixtures, and harnesses over bespoke fake stores when the contract crosses module boundaries.
+14. Do not add a unit test as "extra confidence" for behavior already covered at integration/eval level. The higher-fidelity test owns that contract.
 
 ## Coverage Budget (Avoid Over-Testing)
 
@@ -71,7 +79,7 @@ Use this practical budget:
 
 If a proposed test does not add a new contract guarantee, do not add it.
 
-When higher-level coverage proves the user-visible contract, do not add parallel unit tests for the same workflow. Keep unit tests for deterministic helper logic the higher-level test cannot localize cleanly.
+When higher-level coverage proves the user-visible contract, do not add parallel unit tests for the same workflow. Keep unit tests for deterministic helper logic the higher-level test cannot localize cleanly, and remove unit tests that become implementation-only duplicates after integration/eval coverage lands.
 
 ## Layer Selection Guide
 
@@ -90,6 +98,10 @@ Ask these questions in order:
 4. Otherwise, is the contract tightly local deterministic logic or an algorithmic invariant?
    Use `unit`.
    Examples: retry math, pure transforms, normalization, local scoring, parser behavior, deterministic state transitions.
+
+Before choosing `unit`, check whether an existing integration/eval harness can
+prove the same behavior through the production path with only the allowed fake
+boundary. If yes, use that higher-fidelity layer and skip the unit test.
 
 If a test must mock large parts of runtime, hand-build durable state, or assert private call sequencing to prove a user-visible flow, it belongs in integration or eval instead.
 

--- a/specs/unit-testing.md
+++ b/specs/unit-testing.md
@@ -5,66 +5,30 @@
 - Created: 2026-03-03
 - Last Edited: 2026-07-02
 
-## Intent
+## Purpose
 
-Unit tests validate isolated logic with tight control of dependencies. Use them for algorithm-type things and tightly local deterministic invariants. They are not the default for runtime/product behavior.
+Unit tests are for local deterministic logic only. Layer-selection judgment
+lives in `../policies/testing.md`.
 
-Prefer not to add unit tests when an integration test or eval can prove the
-same behavior through the production path. Duplicate unit coverage for helper
-branches makes refactors noisy without strengthening the product contract.
+## Use For
 
-## Scope
+- Parsing and validation helpers.
+- Normalization and pure transforms.
+- Retry/backoff math.
+- Scoring, sorting, dedupe, and other local algorithms.
+- Small deterministic adapter wrappers without network contracts.
 
-In scope:
-
-- Pure functions and local control-flow logic.
-- Module-level invariants such as retry/backoff calculations, dedupe trimming, normalization helpers, scoring/routing heuristics, and pure transforms.
-- Small adapter wrappers where behavior is deterministic without network contracts.
-
-## Non-Goals
-
-- Real handler/runtime flows that rebuild thread state, call Slack APIs, or exercise multi-module orchestration.
-- Deterministic multi-module service contracts better covered by component tests.
-- Slack HTTP request/response contract validation.
-- Full runtime Slack event handling behavior.
-- Conversational quality and multi-turn judge-scored outcomes.
-- Helper branches whose only product meaning is already covered by integration
-  or eval behavior.
-
-## Mocking Policy
-
-Allowed:
-
-- `vi.mock`, local fakes, and spies.
-- Dependency stubs for clocks, random IDs, and boundary services.
-
-Recommended:
-
-- Keep the mocked surface minimal.
-- Mock one boundary for one local invariant; do not stack mocks across persistence, Slack delivery, and reply execution just to simulate an end-to-end flow.
-- Assert behavior at module outputs rather than internal calls where practical.
-- Do not treat logger or tracer calls as required behavior unless the test is explicitly validating instrumentation.
-- Do not unit test prompt builders by asserting exact or substring prompt prose. If prompt wording matters, cover the resulting user-visible behavior with evals or integration tests.
-- If a test has to mock large parts of the runtime or Slack client to prove a user-visible flow, reclassify it as component, integration, or eval instead of growing the unit seam.
-- Do not add a unit test as a companion to integration/eval coverage unless it
-  isolates a genuinely local invariant that the higher-fidelity test cannot
-  diagnose cleanly.
-
-## Data and Fixtures
-
-- Use shared fixtures for common Slack entities when they improve consistency.
-- Avoid random data in assertions unless uniqueness itself is under test.
-
-## Naming and Placement
+## Mechanics
 
 - Preferred path: `packages/junior/tests/unit/**`.
-- Test titles should describe observable unit behavior.
+- No real network calls.
+- Local stubs, spies, and `vi.mock` are allowed when they isolate one local
+  invariant.
+- Avoid shared runtime state unless the test resets it locally.
 
-## Required Characteristics
+## Do Not Use For
 
-1. No real network calls.
-2. Deterministic results across runs.
-3. Clear failure messages that localize logic regressions quickly.
-4. A unit test should fail because one local invariant broke, not because an end-to-end workflow changed shape.
-5. A unit test should not merely encode the current implementation shape of a
-   behavior already covered by integration or eval.
+- Product/runtime workflows.
+- Slack HTTP contracts or Slack-visible behavior.
+- Prompt quality, model interpretation, or multi-turn continuity.
+- Helper branches already exercised by integration or eval coverage.

--- a/specs/unit-testing.md
+++ b/specs/unit-testing.md
@@ -3,11 +3,15 @@
 ## Metadata
 
 - Created: 2026-03-03
-- Last Edited: 2026-06-02
+- Last Edited: 2026-07-02
 
 ## Intent
 
 Unit tests validate isolated logic with tight control of dependencies. Use them for algorithm-type things and tightly local deterministic invariants. They are not the default for runtime/product behavior.
+
+Prefer not to add unit tests when an integration test or eval can prove the
+same behavior through the production path. Duplicate unit coverage for helper
+branches makes refactors noisy without strengthening the product contract.
 
 ## Scope
 
@@ -24,6 +28,8 @@ In scope:
 - Slack HTTP request/response contract validation.
 - Full runtime Slack event handling behavior.
 - Conversational quality and multi-turn judge-scored outcomes.
+- Helper branches whose only product meaning is already covered by integration
+  or eval behavior.
 
 ## Mocking Policy
 
@@ -40,6 +46,9 @@ Recommended:
 - Do not treat logger or tracer calls as required behavior unless the test is explicitly validating instrumentation.
 - Do not unit test prompt builders by asserting exact or substring prompt prose. If prompt wording matters, cover the resulting user-visible behavior with evals or integration tests.
 - If a test has to mock large parts of the runtime or Slack client to prove a user-visible flow, reclassify it as component, integration, or eval instead of growing the unit seam.
+- Do not add a unit test as a companion to integration/eval coverage unless it
+  isolates a genuinely local invariant that the higher-fidelity test cannot
+  diagnose cleanly.
 
 ## Data and Fixtures
 
@@ -57,3 +66,5 @@ Recommended:
 2. Deterministic results across runs.
 3. Clear failure messages that localize logic regressions quickly.
 4. A unit test should fail because one local invariant broke, not because an end-to-end workflow changed shape.
+5. A unit test should not merely encode the current implementation shape of a
+   behavior already covered by integration or eval.


### PR DESCRIPTION
Slack continuation resumes now tolerate awaiting records that are missing stored requester profile data. The resume path builds a minimal requester from the validated destination/team and original user message, while still rejecting stored requester identities that disagree with the resume actor.

The regression coverage lives in the Slack continuation integration suite so final Slack delivery remains the behavior contract. The testing docs now put that judgment in a concise policy, and the layer specs are trimmed down to repo mechanics: placement, harnesses, and assertion surfaces.

Validated with:
- `pnpm --filter @sentry/junior exec vitest run tests/integration/agent-continue-slack.test.ts`
- `pnpm --filter @sentry/junior typecheck`
- `pnpm --filter @sentry/junior build`