### PR TITLE
fix(dashboard): Collapse thinking rows by default

### DIFF
--- a/packages/junior-dashboard/src/client/components/TranscriptThinkingView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptThinkingView.tsx
@@ -1,105 +1,42 @@
-import { useEffect, useRef, useState } from "react";
-
 import { formatMessageTimestamp, stringifyPartValue } from "../format";
-import { cn } from "../styles";
 import {
   TranscriptHeadingMeta,
   TranscriptHeadingRow,
   TranscriptThoughtLabel,
 } from "./TranscriptHeadingRow";
-import { previewToolValue } from "./transcriptPreview";
-
-const PREVIEW_OVERFLOW_EPSILON = 1;
+import { HighlightText, useTranscriptSearch } from "./transcriptSearch";
 
 function isString(value: string | undefined): value is string {
   return typeof value === "string" && value.length > 0;
 }
 
-/** Render a thinking transcript event with layout-aware expansion. */
+/** Render a thinking transcript event collapsed until expanded or searched. */
 export function TranscriptThinkingView(props: {
   timestamp?: number;
   value: unknown;
 }) {
-  const [open, setOpen] = useState(false);
-  const [previewOverflows, setPreviewOverflows] = useState(false);
-  const previewMeasureRef = useRef<HTMLSpanElement>(null);
+  const { active: searchActive } = useTranscriptSearch();
   const rendered = stringifyPartValue(props.value);
   const expandedText = rendered || "{}";
-  const preview = previewToolValue(props.value);
-  const contentChangesOnExpand =
-    preview !== expandedText || expandedText.includes("\n");
-  const shouldMeasurePreview = !contentChangesOnExpand;
   const meta = [
     typeof props.timestamp === "number"
       ? formatMessageTimestamp(props.timestamp)
       : undefined,
   ].filter(isString);
   const metaText = meta.join(" · ");
-  const canExpand = contentChangesOnExpand || previewOverflows;
 
-  useEffect(() => {
-    if (!shouldMeasurePreview) {
-      setPreviewOverflows(false);
-      return;
-    }
-
-    const node = previewMeasureRef.current;
-    if (!node) return;
-
-    const measure = () => {
-      const next =
-        node.scrollWidth - node.clientWidth > PREVIEW_OVERFLOW_EPSILON;
-      setPreviewOverflows((current) => (current === next ? current : next));
-    };
-    measure();
-
-    const observer =
-      typeof ResizeObserver === "undefined"
-        ? undefined
-        : new ResizeObserver(measure);
-    observer?.observe(node);
-    if (node.parentElement) observer?.observe(node.parentElement);
-    window.addEventListener("resize", measure);
-
-    return () => {
-      observer?.disconnect();
-      window.removeEventListener("resize", measure);
-    };
-  }, [preview, shouldMeasurePreview]);
-
-  useEffect(() => {
-    if (!canExpand && open) setOpen(false);
-  }, [canExpand, open]);
-
-  const rowContent = (expanded: boolean) => (
+  const summary = (
     <>
       <TranscriptThoughtLabel />
       <TranscriptHeadingRow
-        className={expanded ? "items-start" : undefined}
         left={
-          <span className="relative min-w-0 flex-1 italic">
-            {shouldMeasurePreview ? (
-              <span
-                aria-hidden="true"
-                className="pointer-events-none invisible absolute inset-x-0 top-0 block truncate"
-                ref={previewMeasureRef}
-              >
-                {preview}
-              </span>
-            ) : null}
-            <span
-              className={cn(
-                "block min-w-0",
-                expanded
-                  ? "whitespace-pre-wrap break-words text-[#9a9a9a]"
-                  : "truncate",
-              )}
-            >
-              {expanded ? expandedText : preview}
-            </span>
+          <span
+            aria-hidden="true"
+            className="min-w-0 font-mono text-[0.78rem] font-bold uppercase text-[#888]"
+          >
+            thinking
           </span>
         }
-        leftClassName={expanded ? "items-start" : undefined}
         right={
           metaText ? (
             <TranscriptHeadingMeta className="min-w-0 break-words text-[0.78rem] not-italic text-[#777] max-md:hidden">
@@ -112,28 +49,8 @@ export function TranscriptThinkingView(props: {
     </>
   );
 
-  if (!canExpand) {
-    return (
-      <div className="py-1.5 text-[0.84rem] leading-relaxed text-[#888]">
-        <div className="grid list-none grid-cols-[1rem_minmax(0,1fr)] items-start gap-2">
-          {rowContent(false)}
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <details
-      className="py-1.5 text-[0.84rem] leading-relaxed text-[#888]"
-      onToggle={(event) => {
-        if (event.currentTarget !== event.target) return;
-        setOpen(event.currentTarget.open);
-      }}
-      open={open}
-    >
-      <summary className="grid cursor-pointer list-none grid-cols-[1rem_minmax(0,1fr)] items-start gap-2 transition-colors hover:text-[#b8b8b8] [&::-webkit-details-marker]:hidden">
-        {rowContent(open)}
-      </summary>
+  const content = (
+    <>
       {metaText ? (
         <div className="hidden min-w-0 grid-cols-[1rem_minmax(0,1fr)] gap-2 max-md:grid">
           <span aria-hidden="true" />
@@ -142,6 +59,32 @@ export function TranscriptThinkingView(props: {
           </div>
         </div>
       ) : null}
+      <div className="grid min-w-0 grid-cols-[1rem_minmax(0,1fr)] gap-2">
+        <span aria-hidden="true" />
+        <div className="min-w-0 whitespace-pre-wrap break-words py-1 italic text-[#9a9a9a]">
+          <HighlightText text={expandedText} />
+        </div>
+      </div>
+    </>
+  );
+
+  if (searchActive) {
+    return (
+      <div className="py-1.5 text-[0.84rem] leading-relaxed text-[#888]">
+        <div className="grid list-none grid-cols-[1rem_minmax(0,1fr)] items-start gap-2">
+          {summary}
+        </div>
+        {content}
+      </div>
+    );
+  }
+
+  return (
+    <details className="py-1.5 text-[0.84rem] leading-relaxed text-[#888]">
+      <summary className="grid cursor-pointer list-none grid-cols-[1rem_minmax(0,1fr)] items-start gap-2 transition-colors hover:text-[#b8b8b8] [&::-webkit-details-marker]:hidden">
+        {summary}
+      </summary>
+      {content}
     </details>
   );
 }

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -18,6 +18,7 @@ import { TranscriptHeader } from "../src/client/components/TranscriptHeader";
 import { TranscriptSubagentView } from "../src/client/components/TranscriptSubagentView";
 import { TranscriptToolView } from "../src/client/components/TranscriptToolView";
 import { ConversationTranscriptSegment } from "../src/client/components/TranscriptTurn";
+import { TranscriptSearchProvider } from "../src/client/components/transcriptSearch";
 import { ConversationDurationChart } from "../src/client/components/ConversationDurationChart";
 import { client } from "../src/client/api";
 import { CommandCenter } from "../src/client/pages/CommandCenter";
@@ -1361,7 +1362,7 @@ describe("dashboard telemetry components", () => {
     expect(html).toContain("tool-2");
   });
 
-  it("moves thinking metadata out of mobile summaries", () => {
+  it("renders thinking rows as collapsed disclosures", () => {
     const turn = {
       conversationId: "conversation-1",
       id: "turn-1",
@@ -1397,12 +1398,21 @@ describe("dashboard telemetry components", () => {
     expect(html).toContain("py-1.5 text-[0.84rem] leading-relaxed");
     expect(html).toContain("grid-cols-[1rem_minmax(0,1fr)]");
     expect(html).toContain("inline-flex size-4 shrink-0 items-center");
+    expect(html).toContain(">thinking<");
     expect(html).toContain("not-italic text-[#777] max-md:hidden");
     expect(html).toContain("hidden min-w-0 grid-cols-[1rem_minmax(0,1fr)]");
     expect(html).toContain("not-italic leading-snug text-[#777]");
+    expect(html).not.toContain("<details open");
+
+    const summary = html.slice(
+      html.indexOf("<summary"),
+      html.indexOf("</summary>"),
+    );
+    expect(summary).not.toContain("checking the rollout");
+    expect(summary).not.toContain("listing deploy windows");
   });
 
-  it("keeps fully visible thinking rows static until layout clips them", () => {
+  it("collapses short thinking rows by default", () => {
     const turn = {
       conversationId: "conversation-1",
       id: "turn-1",
@@ -1428,11 +1438,52 @@ describe("dashboard telemetry components", () => {
       </QueryClientProvider>,
     );
 
-    expect(html).not.toContain("<details");
-    expect(html).not.toContain("cursor-pointer");
+    expect(html).toContain("<details");
+    expect(html).toContain(">thinking<");
     expect(html).toContain("checking the rollout");
-    expect(html).toContain(
-      "pointer-events-none invisible absolute inset-x-0 top-0 block truncate",
+
+    const summary = html.slice(
+      html.indexOf("<summary"),
+      html.indexOf("</summary>"),
     );
+    expect(summary).not.toContain("checking the rollout");
+  });
+
+  it("expands thinking rows during transcript search", () => {
+    const turn = {
+      conversationId: "conversation-1",
+      id: "turn-1",
+      lastProgressAt: "2026-01-01T00:00:10.000Z",
+      lastSeenAt: "2026-01-01T00:00:10.000Z",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      status: "completed",
+      surface: "slack",
+      displayTitle: "Conversation",
+      transcript: [
+        {
+          role: "assistant",
+          timestamp: Date.parse("2026-01-01T00:00:10.000Z"),
+          parts: [
+            {
+              type: "thinking",
+              output: "checking the rollout\nlisting deploy windows",
+            },
+          ],
+        },
+      ],
+      transcriptAvailable: true,
+    } as ConversationTurn;
+
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={client}>
+        <TranscriptSearchProvider query="deploy">
+          <ConversationTranscriptSegment turn={turn} view="rich" />
+        </TranscriptSearchProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(html).toContain("checking the rollout");
+    expect(html).toContain("listing <mark");
+    expect(html).toContain(">deploy<");
   });
 });


### PR DESCRIPTION
Collapse dashboard transcript thinking rows by default so internal reasoning no longer fills the transcript view. Thinking rows now mirror the existing tool-call behavior: the closed row shows only the thinking label and timestamp, and the full content remains available when the row is expanded.

Transcript search still needs to reveal matching reasoning text, so matching thinking rows render expanded with highlighted search matches while a query is active.

The existing dashboard mock release conversation already includes interleaved thinking and tool activity, so no mock fixture expansion was needed.

Fixes #726