### PR TITLE
fix(slack): add no-reply marker for side effects

### DIFF
--- a/packages/junior-evals/evals/core/resource-event-subscriptions.eval.ts
+++ b/packages/junior-evals/evals/core/resource-event-subscriptions.eval.ts
@@ -1,15 +1,30 @@
-import { describeEval } from "vitest-evals";
+import { assistantMessages, describeEval } from "vitest-evals";
+import { expect } from "vitest";
 import {
   resourceEventNotification,
   rubric,
   slackEvals,
 } from "../../src/helpers";
 
+function textContent(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function visibleThreadReplies(
+  session: Parameters<typeof assistantMessages>[0],
+) {
+  return assistantMessages(session).filter(
+    (message) =>
+      message.metadata?.event_type === "thread_post" &&
+      textContent(message.content).trim().length > 0,
+  );
+}
+
 describeEval("Resource Event Subscriptions", slackEvals, (it) => {
   it("when a subscribed PR check fails, summarize the failure and suggest next steps", async ({
     run,
   }) => {
-    await run({
+    const result = await run({
       events: [
         resourceEventNotification({
           eventKey: "github-delivery-checks-failed",
@@ -36,12 +51,13 @@ describeEval("Resource Event Subscriptions", slackEvals, (it) => {
         ],
       }),
     });
+    expect(visibleThreadReplies(result.session)).toHaveLength(1);
   });
 
   it("when a subscribed PR is merged, report completion without extra work", async ({
     run,
   }) => {
-    await run({
+    const result = await run({
       events: [
         resourceEventNotification({
           eventKey: "github-delivery-pr-merged",
@@ -67,5 +83,6 @@ describeEval("Resource Event Subscriptions", slackEvals, (it) => {
         ],
       }),
     });
+    expect(visibleThreadReplies(result.session)).toHaveLength(1);
   });
 });

--- a/packages/junior-evals/evals/core/routing-and-continuity.eval.ts
+++ b/packages/junior-evals/evals/core/routing-and-continuity.eval.ts
@@ -1,5 +1,27 @@
-import { describeEval } from "vitest-evals";
+import { assistantMessages, describeEval, toolCalls } from "vitest-evals";
+import { expect } from "vitest";
+import { NO_REPLY_MARKER } from "@/chat/no-reply";
 import { mention, rubric, slackEvals, threadMessage } from "../../src/helpers";
+
+type EvalSession = Parameters<typeof assistantMessages>[0];
+
+function textContent(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function visibleThreadReplies(session: EvalSession) {
+  return assistantMessages(session).filter(
+    (message) =>
+      message.metadata?.event_type === "thread_post" &&
+      textContent(message.content).trim().length > 0,
+  );
+}
+
+function visibleText(session: EvalSession): string {
+  return assistantMessages(session)
+    .map((message) => textContent(message.content))
+    .join("\n");
+}
 
 describeEval("Routing and Continuity", slackEvals, (it) => {
   it("when a thread message explicitly mentions Junior, post a direct reply", async ({
@@ -20,15 +42,27 @@ describeEval("Routing and Continuity", slackEvals, (it) => {
   it("when asked to post in channel, send a channel post instead of a thread reply", async ({
     run,
   }) => {
-    await run({
+    const result = await run({
       events: [mention("@bot say hello to the channel!")],
       criteria: rubric({
         pass: [
           "The normalized transcript contains exactly one hello-style channel_post assistant message with no thread_ts.",
+          "The assistant tool calls include slackChannelPostMessage for the requested channel post.",
           "The normalized transcript does not contain that hello-style message as a thread reply.",
+        ],
+        fail: [
+          "Do not add a redundant thread reply acknowledging the channel post.",
+          `Do not leak the literal marker ${NO_REPLY_MARKER} as visible text.`,
         ],
       }),
     });
+    expect(toolCalls(result.session)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "slackChannelPostMessage" }),
+      ]),
+    );
+    expect(visibleThreadReplies(result.session)).toEqual([]);
+    expect(visibleText(result.session)).not.toContain(NO_REPLY_MARKER);
   });
 
   it("when asked to post in another named channel, explain the limitation instead", async ({
@@ -103,18 +137,29 @@ describeEval("Routing and Continuity", slackEvals, (it) => {
   it("when the request is reaction-only, add a reaction without reply clutter", async ({
     run,
   }) => {
-    await run({
+    const result = await run({
       events: [mention("react to this")],
       criteria: rubric({
         pass: [
           "The normalized transcript contains at least one reaction_added assistant message.",
+          "The assistant tool calls include slackMessageAddReaction for the requested reaction.",
+          `The visible transcript contains no thread reply; the no-reply marker ${NO_REPLY_MARKER} is only an internal publication signal.`,
         ],
         fail: [
+          "Do not rely only on a runtime processing reaction.",
           "Do not add a redundant thread reply that echoes the emoji.",
           "Do not add a short acknowledgement reply such as 'Done'.",
+          `Do not leak the literal marker ${NO_REPLY_MARKER} as visible text.`,
         ],
       }),
     });
+    expect(toolCalls(result.session)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "slackMessageAddReaction" }),
+      ]),
+    );
+    expect(visibleThreadReplies(result.session)).toEqual([]);
+    expect(visibleText(result.session)).not.toContain(NO_REPLY_MARKER);
   });
 
   const continuityThread = {

--- a/packages/junior/src/chat/no-reply.ts
+++ b/packages/junior/src/chat/no-reply.ts
@@ -1,0 +1,16 @@
+export const NO_REPLY_MARKER = "[[NO_REPLY]]";
+
+/** Detect the reserved marker so Slack side effects can intentionally complete without thread text. */
+export function isNoReplyMarker(text: string): boolean {
+  return text.trim() === NO_REPLY_MARKER;
+}
+
+/** Detect marker leaks before publication strips or rejects them. */
+export function containsNoReplyMarker(text: string): boolean {
+  return text.includes(NO_REPLY_MARKER);
+}
+
+/** Remove the reserved marker from mixed assistant text so it is never shown to users. */
+export function stripNoReplyMarker(text: string): string {
+  return text.replaceAll(NO_REPLY_MARKER, "").trim();
+}

--- a/packages/junior/src/chat/prompt.ts
+++ b/packages/junior/src/chat/prompt.ts
@@ -16,6 +16,7 @@ import {
   worldPathCandidates,
 } from "@/chat/discovery";
 import { logInfo, logWarn } from "@/chat/logging";
+import { NO_REPLY_MARKER } from "@/chat/no-reply";
 import { slackOutputPolicy } from "@/chat/slack/output";
 import {
   SANDBOX_DATA_ROOT,
@@ -384,12 +385,10 @@ const CONVERSATION_RULES = [
 ];
 
 const SLACK_ACTION_RULES = [
-  "- Context-bound Slack tools use runtime-owned targets; do not invent channel, canvas, list, or message IDs.",
-  "- Use first-class Slack tools for Slack side effects; do not use bash, curl, or provider APIs to bypass Slack tool targeting.",
-  "- Use channel-post and emoji-reaction tools only when the user explicitly asks for that Slack side effect.",
-  "- For explicit channel-post or emoji-reaction requests, skip a duplicate thread text reply when the tool result already satisfies the request.",
-  "- Do not claim an attachment, canvas, channel post, list update, or reaction succeeded unless the tool returned success this turn; when it did, include any link the tool returned.",
-  "- Do not use reactions as progress indicators.",
+  "- Slack tools target the current runtime context; if the requested Slack target differs, explain the limitation instead of calling the tool.",
+  "- Use channel-post and emoji-reaction tools only for explicit user-requested Slack side effects.",
+  "- Ambient reaction requests target the current inbound message; do not ask for a message reference.",
+  `- Side-effect-only completion for channel posts or reactions: call the requested tool first; if it succeeds and fully satisfies the request, final message must be exactly ${NO_REPLY_MARKER}.`,
 ];
 
 const SAFETY_RULES = [
@@ -446,7 +445,7 @@ function buildOutputSection(platform: PromptPlatform): string {
     "- Use Slack-flavored Markdown: **bold** section labels, `code`, [text](url) links, bullet lists, and fenced code blocks. No hash-prefixed headings and no tables. When the answer primarily lists several URLs, show each URL bare instead of as a labeled link.",
     "- Keep replies brief and scannable; use bullets or short code blocks when helpful, and one compact thread reply when it fits.",
     "- When a research or document-style answer would benefit from continuation, multiple sections, or future reference value, create a Slack canvas and keep the thread reply to one or two short sentences plus the link; do not recap the canvas contents.",
-    "- Unless a successful Slack side-effect tool intentionally satisfied the request by itself, end every turn with a final user-facing markdown response.",
+    "- End every turn with a final user-facing markdown response unless the Slack action rules allow a side-effect-only completion.",
     "</output>",
   ].join("\n");
 }

--- a/packages/junior/src/chat/runtime/delivered-turn-state.ts
+++ b/packages/junior/src/chat/runtime/delivered-turn-state.ts
@@ -16,6 +16,8 @@ import {
 } from "@/chat/services/conversation-memory";
 import { clearPendingAuth } from "@/chat/services/pending-auth";
 
+const NO_VISIBLE_REPLY_CONVERSATION_TEXT = "[no visible reply]";
+
 /** Build the canonical thread-state patch after final Slack delivery succeeds. */
 export function buildDeliveredTurnStatePatch(args: {
   artifactStatePatch?: Partial<ThreadArtifactsState>;
@@ -36,6 +38,11 @@ export function buildDeliveredTurnStatePatch(args: {
       : undefined;
 
   clearPendingAuth(conversation, args.sessionId);
+  const assistantText =
+    normalizeConversationText(args.reply.text) ||
+    (args.reply.deliveryPlan?.postThreadText === false
+      ? NO_VISIBLE_REPLY_CONVERSATION_TEXT
+      : "[empty response]");
   markConversationMessage(conversation, args.userMessageId, {
     replied: true,
     skippedReason: undefined,
@@ -43,7 +50,7 @@ export function buildDeliveredTurnStatePatch(args: {
   upsertConversationMessage(conversation, {
     id: generateConversationId("assistant"),
     role: "assistant",
-    text: normalizeConversationText(args.reply.text) || "[empty response]",
+    text: assistantText,
     createdAtMs: Date.now(),
     author: {
       userName: botConfig.userName,

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -102,8 +102,6 @@ import {
 import { buildDeterministicTurnId } from "@/chat/runtime/turn";
 import { markTurnClosed, markTurnFailed } from "@/chat/runtime/turn";
 import { startActiveTurn } from "@/chat/runtime/turn";
-import { isRedundantReactionAckText } from "@/chat/services/reply-delivery-plan";
-import { deleteSlackMessage } from "@/chat/slack/outbound";
 import {
   finalizeFailedTurnReply,
   getAgentTurnDiagnosticsAttributes,
@@ -1132,9 +1130,6 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           const artifactStatePatch: Partial<ThreadArtifactsState> =
             reply.artifactStatePatch ? { ...reply.artifactStatePatch } : {};
 
-          const reactionPerformed = reply.diagnostics.toolCalls.includes(
-            "slackMessageAddReaction",
-          );
           const plannedPosts = planSlackReplyPosts({ reply });
           const replyFooter = buildSlackReplyFooter({
             conversationId,
@@ -1144,10 +1139,9 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             Boolean(channelId && threadTs) &&
             (thread.adapter as { name?: string } | undefined)?.name === "slack";
 
-          // Final Slack delivery is part of turn success. We only mark the turn
-          // completed after the visible reply has been accepted by Slack.
+          // Text replies must be accepted by Slack before completion;
+          // side-effect-only turns may already be visibly complete.
           if (plannedPosts.length > 0) {
-            let sent: SentMessage | undefined;
             const hasVisibleDelivery = plannedPosts.some(
               hasVisibleSlackDelivery,
             );
@@ -1165,7 +1159,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                 );
               }
 
-              const sentMessageTs = await postSlackApiReplyPosts({
+              await postSlackApiReplyPosts({
                 beforePost: beforeFirstResponsePost,
                 channelId: slackChannelId,
                 threadTs: slackThreadTs,
@@ -1188,61 +1182,21 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                   );
                 },
               });
-
-              if (sentMessageTs) {
-                sent = {
-                  id: sentMessageTs,
-                  text: reply.text,
-                  delete: async () => {
-                    await deleteSlackMessage({
-                      channelId: slackChannelId,
-                      timestamp: sentMessageTs,
-                    });
-                  },
-                } as SentMessage;
-              }
             } else {
               for (const post of plannedPosts) {
                 if (!hasVisibleSlackDelivery(post)) {
                   continue;
                 }
-                sent = await postThreadReply(
+                await postThreadReply(
                   buildSlackOutputMessage(post.text, post.files),
                   post.stage,
                 );
               }
             }
             // Slack accepted every final post: the turn is delivered even if
-            // the redundant-ack cleanup or completion persistence below fails.
+            // completion persistence below fails.
             finalReplyDelivered = true;
             shouldPersistFailureState = false;
-            const firstPlannedMessageHasFiles =
-              (plannedPosts[0]?.files?.length ?? 0) > 0;
-            // When a reaction already acknowledged the turn, delete the
-            // redundant thread reply. The post itself completes Slack's
-            // assistant response cycle (clearing the typing indicator).
-            if (
-              sent &&
-              reactionPerformed &&
-              plannedPosts.length === 1 &&
-              !firstPlannedMessageHasFiles &&
-              isRedundantReactionAckText(reply.text)
-            ) {
-              try {
-                await sent.delete();
-              } catch (error) {
-                // Best effort: the turn is already delivered, and a thrown
-                // delete here would skip the completed-record commit below
-                // and leave the session record stuck running.
-                logException(
-                  error,
-                  "slack_redundant_ack_delete_failed",
-                  turnTraceContext,
-                  messageTs ? { "messaging.message.id": messageTs } : {},
-                  "Failed to delete redundant reaction-ack reply",
-                );
-              }
-            }
           } else {
             // Side-effect-only turns (for example reactions or channel posts)
             // have no thread reply to deliver; the successful tool result is

--- a/packages/junior/src/chat/services/reply-delivery-plan.ts
+++ b/packages/junior/src/chat/services/reply-delivery-plan.ts
@@ -7,49 +7,6 @@ export interface ReplyDeliveryPlan {
   attachFiles: ReplyFileDelivery;
 }
 
-const REACTION_ONLY_ACK_RE =
-  /^(?::[a-z0-9_+-]+:|[\p{Extended_Pictographic}\uFE0F\u200D]+)$/u;
-const REDUNDANT_REACTION_ACK_TEXT = ["done", "got it", "ok", "okay"] as const;
-const REACTION_INTENT_RE =
-  /\b(react|reaction|emoji|thumbs?\s*up|acknowledge)\b/i;
-const REACTION_WITH_REPLY_INTENT_RE =
-  /\b(confirm|explain|reply|respond|say|tell|summari[sz]e|why)\b/i;
-
-function normalizeReactionAckText(text: string): string {
-  return text
-    .trim()
-    .toLowerCase()
-    .replace(/[!.]+$/g, "");
-}
-
-/** Check if text is a short acknowledgment (emoji, "ok", etc.) that a reaction already covers. */
-export function isRedundantReactionAckText(text: string): boolean {
-  const trimmed = text.trim();
-  if (!trimmed) {
-    return false;
-  }
-  if (REACTION_ONLY_ACK_RE.test(trimmed)) {
-    return true;
-  }
-
-  const normalized = normalizeReactionAckText(text);
-  return REDUNDANT_REACTION_ACK_TEXT.includes(
-    normalized as (typeof REDUNDANT_REACTION_ACK_TEXT)[number],
-  );
-}
-
-/** Check if the user asked for a reaction without also asking for text. */
-export function isReactionOnlyIntent(text: string): boolean {
-  const normalized = text.trim();
-  if (!normalized) {
-    return false;
-  }
-  return (
-    REACTION_INTENT_RE.test(normalized) &&
-    !REACTION_WITH_REPLY_INTENT_RE.test(normalized)
-  );
-}
-
 /** Determine how a reply should be delivered (thread vs channel, file handling). */
 export function buildReplyDeliveryPlan(args: {
   explicitChannelPostIntent: boolean;

--- a/packages/junior/src/chat/services/turn-result.ts
+++ b/packages/junior/src/chat/services/turn-result.ts
@@ -2,12 +2,16 @@ import type { FileUpload } from "chat";
 import { botConfig } from "@/chat/config";
 import { logInfo, logWarn } from "@/chat/logging";
 import type { LogContext } from "@/chat/logging";
+import {
+  containsNoReplyMarker,
+  isNoReplyMarker,
+  stripNoReplyMarker,
+} from "@/chat/no-reply";
 import type { PiMessage } from "@/chat/pi/messages";
 import type { TurnThinkingSelection } from "@/chat/services/turn-thinking-level";
 import type { AgentTurnUsage } from "@/chat/usage";
 import {
   buildReplyDeliveryPlan,
-  isReactionOnlyIntent,
   type ReplyDeliveryPlan,
 } from "@/chat/services/reply-delivery-plan";
 import { isExplicitChannelPostIntent } from "@/chat/services/channel-intent";
@@ -150,11 +154,19 @@ export function buildTurnResult(input: TurnResultInput): AssistantReply {
   const assistantMessages = newMessages.filter(isAssistantMessage);
   const terminalAssistantMessages = getTerminalAssistantMessages(newMessages);
 
-  const primaryText = stripThinkingXmlBlocks(
+  const rawPrimaryText = stripThinkingXmlBlocks(
     terminalAssistantMessages
       .map((message) => extractAssistantText(message))
       .join("\n\n"),
   ).trim();
+  const exactNoReplyMarker = isNoReplyMarker(rawPrimaryText);
+  const mixedNoReplyMarker =
+    !exactNoReplyMarker && containsNoReplyMarker(rawPrimaryText);
+  const primaryText = exactNoReplyMarker
+    ? ""
+    : mixedNoReplyMarker
+      ? stripNoReplyMarker(rawPrimaryText)
+      : rawPrimaryText;
 
   const toolErrorCount = toolResults.filter((result) => result.isError).length;
   const explicitChannelPostIntent = isExplicitChannelPostIntent(userInput);
@@ -169,15 +181,18 @@ export function buildTurnResult(input: TurnResultInput): AssistantReply {
   );
   const canvasCreated = successfulToolNames.has("slackCanvasCreate");
   const reactionPerformed = successfulToolNames.has("slackMessageAddReaction");
+  const markerSideEffectSuccess =
+    exactNoReplyMarker &&
+    toolErrorCount === 0 &&
+    (reactionPerformed || channelPostPerformed || replyFiles.length > 0);
+  const fileOnlySuccess =
+    !rawPrimaryText && toolErrorCount === 0 && replyFiles.length > 0;
+  const sideEffectOnlySuccess = markerSideEffectSuccess || fileOnlySuccess;
   const baseDeliveryPlan = buildReplyDeliveryPlan({
-    explicitChannelPostIntent,
+    explicitChannelPostIntent: exactNoReplyMarker && explicitChannelPostIntent,
     channelPostPerformed,
     hasFiles: replyFiles.length > 0,
   });
-  const sideEffectOnlySuccess =
-    !primaryText &&
-    toolErrorCount === 0 &&
-    (reactionPerformed || channelPostPerformed || replyFiles.length > 0);
   const lastAssistant = terminalAssistantMessages.at(-1) as
     | { stopReason?: unknown; errorMessage?: unknown }
     | undefined;
@@ -191,7 +206,69 @@ export function buildTurnResult(input: TurnResultInput): AssistantReply {
       : undefined;
   const isProviderError = stopReason === "error";
 
-  if (!primaryText && !sideEffectOnlySuccess && !isProviderError) {
+  if (exactNoReplyMarker) {
+    const markerCategory = reactionPerformed
+      ? "reaction"
+      : channelPostPerformed
+        ? "channel_post"
+        : replyFiles.length > 0
+          ? "file"
+          : "none";
+    const markerContext = {
+      slackThreadId: correlation?.threadId,
+      slackUserId: correlation?.requesterId,
+      slackChannelId: correlation?.channelId,
+      runId: correlation?.runId,
+      assistantUserName,
+      modelId: botConfig.modelId,
+    };
+    const markerAttributes = {
+      "app.ai.no_reply_marker": true,
+      "app.ai.no_reply_marker_category": markerCategory,
+      "app.ai.no_reply_marker_accepted":
+        sideEffectOnlySuccess && !isProviderError,
+    };
+
+    if (sideEffectOnlySuccess && !isProviderError) {
+      logInfo(
+        "ai_no_reply_marker_accepted",
+        markerContext,
+        markerAttributes,
+        "No-reply marker suppressed visible thread text",
+      );
+    } else if (!isProviderError) {
+      logWarn(
+        "ai_no_reply_marker_rejected",
+        markerContext,
+        markerAttributes,
+        "No-reply marker requires a successful visible side effect",
+      );
+    }
+  } else if (mixedNoReplyMarker) {
+    logWarn(
+      "ai_no_reply_marker_mixed_text",
+      {
+        slackThreadId: correlation?.threadId,
+        slackUserId: correlation?.requesterId,
+        slackChannelId: correlation?.channelId,
+        runId: correlation?.runId,
+        assistantUserName,
+        modelId: botConfig.modelId,
+      },
+      {
+        "app.ai.no_reply_marker": true,
+        "app.ai.no_reply_marker_mode": "mixed",
+      },
+      "No-reply marker appeared with visible assistant text",
+    );
+  }
+
+  if (
+    !primaryText &&
+    !sideEffectOnlySuccess &&
+    !isProviderError &&
+    !exactNoReplyMarker
+  ) {
     logWarn(
       "ai_model_response_empty",
       {
@@ -211,7 +288,7 @@ export function buildTurnResult(input: TurnResultInput): AssistantReply {
     );
   }
 
-  const usedPrimaryText = Boolean(primaryText);
+  const usedPrimaryText = Boolean(rawPrimaryText);
   let outcome: AgentTurnDiagnostics["outcome"];
   if (isProviderError) {
     outcome = "provider_error";
@@ -220,13 +297,7 @@ export function buildTurnResult(input: TurnResultInput): AssistantReply {
   } else {
     outcome = "execution_failure";
   }
-  const suppressReactionOnlyText =
-    reactionPerformed &&
-    !channelPostPerformed &&
-    replyFiles.length === 0 &&
-    Boolean(primaryText) &&
-    isReactionOnlyIntent(userInput);
-  const rawResponseText = suppressReactionOnlyText ? "" : primaryText;
+  const rawResponseText = primaryText;
   const responseText =
     canvasCreated && isVerbosePostCanvasReply(rawResponseText)
       ? buildBriefPostCanvasReply(artifactStatePatch)

--- a/packages/junior/src/chat/tools/slack/channel-post-message.ts
+++ b/packages/junior/src/chat/tools/slack/channel-post-message.ts
@@ -12,7 +12,7 @@ export function createSlackChannelPostMessageTool(
 ) {
   return tool({
     description:
-      "Post a new top-level message to the current Slack channel. Use only when the user explicitly asks to post/send/share/say something to the channel. Do not use for thread replies, inline @mentions, or pinging mentioned users.",
+      "Post a new top-level message to the current Slack channel. Use only when the user explicitly asks to post/send/share/say something to the current channel. Do not use for other named channels, thread replies, inline @mentions, or pinging mentioned users.",
     inputSchema: Type.Object({
       text: Type.String({
         minLength: 1,

--- a/packages/junior/src/chat/tools/slack/message-add-reaction.ts
+++ b/packages/junior/src/chat/tools/slack/message-add-reaction.ts
@@ -2,6 +2,7 @@ import { Type } from "@sinclair/typebox";
 import { normalizeSlackEmojiName } from "@/chat/slack/emoji";
 import { addReactionToMessage } from "@/chat/slack/outbound";
 import { tool } from "@/chat/tools/definition";
+import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 import { createOperationKey } from "@/chat/tools/idempotency";
 import type { SlackToolContext } from "@/chat/tools/slack/context";
 import type { ToolState } from "@/chat/tools/types";
@@ -12,7 +13,7 @@ export function createSlackMessageAddReactionTool(
 ) {
   return tool({
     description:
-      "Add an emoji reaction to the current inbound Slack message. Use sparingly for lightweight acknowledgements. Provide a Slack emoji alias name (for example `thumbsup`, `white_check_mark`, or `thumbsup::skin-tone-6`), not a unicode emoji glyph. The target message is injected by runtime context; do not use this for arbitrary historical messages.",
+      "Add an emoji reaction to the current inbound Slack message. Use when the user asks for a reaction on the current message without another target. Provide a Slack emoji alias name (for example `thumbsup`, `white_check_mark`, or `thumbsup::skin-tone-6`), not a unicode emoji glyph. The target message is injected by runtime context; do not use this for arbitrary historical messages.",
     inputSchema: Type.Object({
       emoji: Type.String({
         minLength: 1,
@@ -25,18 +26,15 @@ export function createSlackMessageAddReactionTool(
       const targetChannelId = context.sourceChannelId;
       const targetMessageTs = context.messageTs;
       if (!targetMessageTs) {
-        return {
-          ok: false,
-          error: "No active message timestamp is available for reactions",
-        };
+        throw new ToolInputError(
+          "No active message timestamp is available for reactions.",
+        );
       }
       const normalizedEmoji = normalizeSlackEmojiName(emoji);
       if (!normalizedEmoji) {
-        return {
-          ok: false,
-          error:
-            "Emoji must be a valid Slack emoji alias name (for example `thumbsup` or `thumbsup::skin-tone-6`)",
-        };
+        throw new ToolInputError(
+          "Emoji must be a valid Slack emoji alias name (for example `thumbsup` or `thumbsup::skin-tone-6`).",
+        );
       }
 
       const operationKey = createOperationKey("slackMessageAddReaction", {

--- a/packages/junior/tests/integration/slack/new-mention-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/new-mention-behavior.test.ts
@@ -287,58 +287,6 @@ describe("Slack behavior: new mention", () => {
     });
   });
 
-  it("deletes redundant reply and clears status for reaction-only turn", async () => {
-    const slackAdapter = new FakeSlackAdapter();
-    const { slackRuntime } = createTestChatRuntime({
-      slackAdapter,
-      services: {
-        replyExecutor: {
-          generateAssistantReply: async (_prompt, context) => {
-            await context?.onStatus?.(makeAssistantStatus("drafting", "reply"));
-            return {
-              text: "Done!",
-              deliveryMode: "thread",
-
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: ["slackMessageAddReaction"],
-                toolErrorCount: 0,
-                toolResultCount: 1,
-                usedPrimaryText: true,
-              },
-            };
-          },
-        },
-      },
-    });
-
-    const thread = createTestThread({
-      id: "slack:C_STATUS:1700004000.000",
-    });
-    await slackRuntime.handleNewMention(
-      thread,
-      createTestMessage({
-        id: "m-reaction-only",
-        text: "<@U_APP> add a reaction to this message",
-        isMention: true,
-        threadId: thread.id,
-      }),
-      { destination: createTestDestination(thread) },
-    );
-
-    // Reply posted then deleted to complete Slack's response cycle without visible noise
-    expect(thread.posts).toHaveLength(0);
-    expect(slackAdapter.statusCalls.length).toBeGreaterThan(0);
-    expect(slackAdapter.statusCalls.at(-1)).toEqual({
-      channelId: "C_STATUS",
-      threadTs: "1700004000.000",
-      text: "",
-      loadingMessages: undefined,
-    });
-  });
-
   it("clears assistant status after agent error", async () => {
     const slackAdapter = new FakeSlackAdapter();
     const { slackRuntime } = createTestChatRuntime({

--- a/packages/junior/tests/unit/slack/slack-message-add-reaction-tool.test.ts
+++ b/packages/junior/tests/unit/slack/slack-message-add-reaction-tool.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { createSlackSource } from "@sentry/junior-plugin-api";
 import { createSlackMessageAddReactionTool } from "@/chat/tools/slack/message-add-reaction";
+import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 import type { SlackToolContext } from "@/chat/tools/slack/context";
 
 const addReactionToMessage = vi.fn();
@@ -50,11 +51,8 @@ describe("slackMessageAddReaction tool", () => {
       throw new Error("Expected executable tool");
     }
 
-    const result = await tool.execute({ emoji: "✅" }, {} as any);
-    expect(result).toEqual(
-      expect.objectContaining({
-        ok: false,
-      }),
+    await expect(tool.execute({ emoji: "✅" }, {} as any)).rejects.toThrow(
+      ToolInputError,
     );
     expect(addReactionToMessage).not.toHaveBeenCalled();
   });

--- a/packages/junior/tests/unit/turn-result.test.ts
+++ b/packages/junior/tests/unit/turn-result.test.ts
@@ -230,63 +230,6 @@ describe("buildTurnResult", () => {
     expect(reply.diagnostics.usedPrimaryText).toBe(false);
   });
 
-  it("treats reaction-only turns as successful without fallback text", () => {
-    const reply = buildTurnResult({
-      newMessages: [
-        {
-          role: "toolResult",
-          toolName: "slackMessageAddReaction",
-          isError: false,
-          content: [{ type: "text", text: "reaction added" }],
-        },
-      ],
-      userInput: "react to this",
-      replyFiles: [],
-      artifactStatePatch: {},
-      toolCalls: ["slackMessageAddReaction"],
-      generatedFileCount: 0,
-      shouldTrace: false,
-      spanContext: {},
-      thinkingSelection,
-    });
-
-    expect(reply.text).toBe("");
-    expect(reply.deliveryPlan).toMatchObject({
-      postThreadText: false,
-    });
-    expect(reply.diagnostics.outcome).toBe("success");
-    expect(reply.diagnostics.usedPrimaryText).toBe(false);
-  });
-
-  it("suppresses empty thread text when a channel post is the successful side effect", () => {
-    const reply = buildTurnResult({
-      newMessages: [
-        {
-          role: "toolResult",
-          toolName: "slackChannelPostMessage",
-          isError: false,
-          content: [{ type: "text", text: "message posted" }],
-        },
-      ],
-      userInput: "share the update",
-      replyFiles: [],
-      artifactStatePatch: {},
-      toolCalls: ["slackChannelPostMessage"],
-      generatedFileCount: 0,
-      shouldTrace: false,
-      spanContext: {},
-      thinkingSelection,
-    });
-
-    expect(reply.text).toBe("");
-    expect(reply.deliveryPlan).toMatchObject({
-      mode: "thread",
-      postThreadText: false,
-    });
-    expect(reply.diagnostics.outcome).toBe("success");
-    expect(reply.diagnostics.usedPrimaryText).toBe(false);
-  });
-
   it("keeps thread text when a turn adds a reaction and returns real text", () => {
     const reply = buildTurnResult({
       newMessages: [
@@ -315,39 +258,6 @@ describe("buildTurnResult", () => {
     expect(reply.text).toBe("Handled it.");
     expect(reply.deliveryPlan).toMatchObject({
       postThreadText: true,
-    });
-    expect(reply.diagnostics.outcome).toBe("success");
-    expect(reply.diagnostics.usedPrimaryText).toBe(true);
-  });
-
-  it("suppresses model text for reaction-only requests", () => {
-    const reply = buildTurnResult({
-      newMessages: [
-        {
-          role: "toolResult",
-          toolName: "slackMessageAddReaction",
-          isError: false,
-          content: [{ type: "text", text: "reaction added" }],
-        },
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "արձագանքեցի :thumbsup:" }],
-          stopReason: "stop",
-        },
-      ],
-      userInput: "react to this",
-      replyFiles: [],
-      artifactStatePatch: {},
-      toolCalls: ["slackMessageAddReaction"],
-      generatedFileCount: 0,
-      shouldTrace: false,
-      spanContext: {},
-      thinkingSelection,
-    });
-
-    expect(reply.text).toBe("");
-    expect(reply.deliveryPlan).toMatchObject({
-      postThreadText: false,
     });
     expect(reply.diagnostics.outcome).toBe("success");
     expect(reply.diagnostics.usedPrimaryText).toBe(true);

--- a/specs/agent-turn-handling.md
+++ b/specs/agent-turn-handling.md
@@ -126,7 +126,7 @@ Scenarios:
 2. User asks Junior to react:
    - When the user explicitly asks Junior to add a Slack reaction, Junior must use the Slack reaction tool when the runtime provides a valid target and must not treat automatic processing reactions as satisfying the user's request.
 3. Slack side effect satisfies the turn:
-   - When a successful Slack side-effect tool already satisfies the user's request and a duplicate thread reply would only restate the same acknowledgement, Junior may suppress the duplicate final thread text according to the reply-delivery plan.
+   - When a successful Slack side-effect tool already satisfies the user's request, Junior may suppress a duplicate final thread reply according to the reply-delivery plan only when the assistant used the no-reply marker.
 
 ### 8. Progress And Resumed-Turn Behavior
 

--- a/specs/slack-agent-delivery.md
+++ b/specs/slack-agent-delivery.md
@@ -146,14 +146,14 @@ Current rules:
 
 ### 6. Primary Reply Contract
 
-Junior has one primary visible reply surface per turn: finalized Slack thread replies.
+Junior's primary visible text reply surface is finalized Slack thread replies.
 
 Current rules:
 
 1. Do not create a visible Slack text artifact until the assistant reply is final enough to budget, normalize, and persist.
 2. Deliver visible reply text through finalized thread posts, not through incremental text streaming.
-3. Only mark a turn successful after the final visible Slack reply has been accepted by Slack.
-4. If explicit user intent requested an in-channel post and that post already satisfied the request, Junior may suppress the thread text reply according to the reply-delivery plan.
+3. Only mark a text-reply turn successful after the final visible Slack reply has been accepted by Slack. When a successful requested Slack side effect, such as a reaction or in-channel post, fully satisfies the turn and the assistant uses the no-reply marker, that side effect is the visible completion.
+4. If explicit user intent requested a Slack side effect and that successful side effect already satisfied the request, Junior may suppress the thread text reply according to the reply-delivery plan only when the assistant used the no-reply marker.
 5. Persisted assistant conversation state must reflect the same finalized reply content the user saw, not provisional pre-tool text.
 6. Reply text must be rendered through the shared Slack output translator before delivery; raw Slack API writers do not own markdown translation rules.
 7. When Junior adds finalized reply footer metadata, it attaches that metadata as a Slack `context` block on the final text chunk only, while keeping the main reply text as the top-level fallback.


### PR DESCRIPTION
Fixes #724

Adds a shared `[[NO_REPLY]]` marker for Slack side-effect-only turns. Thread suppression now requires the exact marker plus a successful requested Slack side-effect tool, so reactions/channel posts do not rely on natural-language heuristics or post-then-delete cleanup.

Also tightens Slack prompt/tool wording around current-context targets and expands eval assertions for channel posts, reactions, subscribed resource notifications, and passive no-response behavior.

Validation:
- `pnpm --filter @sentry/junior typecheck`
- `pnpm --filter @sentry/junior exec vitest run tests/unit/slack/slack-message-add-reaction-tool.test.ts tests/unit/turn-result.test.ts tests/integration/slack/new-mention-behavior.test.ts`
- `pnpm --filter @sentry/junior-evals evals evals/core/routing-and-continuity.eval.ts`
- `pnpm --filter @sentry/junior-evals evals evals/core/resource-event-subscriptions.eval.ts evals/core/passive-behavior.eval.ts`
- `git diff --check`

Garfield: pass