### PR TITLE
fix(dashboard): Restore thinking preview text and consolidate tool+thinking runs

### DIFF
--- a/packages/junior-dashboard/src/client/components/TranscriptThinkingView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptThinkingView.tsx
@@ -10,7 +10,7 @@ function isString(value: string | undefined): value is string {
   return typeof value === "string" && value.length > 0;
 }
 
-/** Render a thinking transcript event collapsed until expanded or searched. */
+/** Render a thinking transcript event collapsed with a truncated preview until expanded or searched. */
 export function TranscriptThinkingView(props: {
   timestamp?: number;
   value: unknown;
@@ -30,11 +30,8 @@ export function TranscriptThinkingView(props: {
       <TranscriptThoughtLabel />
       <TranscriptHeadingRow
         left={
-          <span
-            aria-hidden="true"
-            className="min-w-0 font-mono text-[0.78rem] font-bold uppercase text-[#888]"
-          >
-            thinking
+          <span className="block min-w-0 truncate italic text-[#9a9a9a]">
+            {expandedText}
           </span>
         }
         right={

--- a/packages/junior-dashboard/src/client/components/TranscriptToolRun.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptToolRun.tsx
@@ -1,14 +1,19 @@
 import { Fragment, type ReactNode } from "react";
 
-import type { RenderedToolEntry } from "./transcriptRenderModel";
+import type {
+  RenderedThinkingEntry,
+  RenderedToolEntry,
+  RenderedToolRunEntry,
+} from "./transcriptRenderModel";
 import { useTranscriptSearch } from "./transcriptSearch";
 
 const TOOL_RUN_REVEAL_THRESHOLD = 4;
 
-/** Render a consecutive tool run with a one-way reveal for dense middle calls. */
+/** Render a consecutive tool-and-thinking run with a one-way reveal for dense middle calls. */
 export function TranscriptToolRun(props: {
-  entries: RenderedToolEntry[];
+  entries: RenderedToolRunEntry[];
   keyPrefix: string;
+  renderThinking: (entry: RenderedThinkingEntry, index: number) => ReactNode;
   renderTool: (entry: RenderedToolEntry, index: number) => ReactNode;
   startIndex: number;
 }) {
@@ -17,11 +22,12 @@ export function TranscriptToolRun(props: {
   if (props.entries.length < TOOL_RUN_REVEAL_THRESHOLD || searchActive) {
     return (
       <>
-        {renderToolEntries(
+        {renderRunEntries(
           props.entries,
           props.startIndex,
           props.keyPrefix,
           props.renderTool,
+          props.renderThinking,
         )}
       </>
     );
@@ -29,40 +35,59 @@ export function TranscriptToolRun(props: {
 
   return (
     <details className="min-w-0">
-      <ToolRunReveal hiddenCount={props.entries.length} />
+      <ToolRunReveal entries={props.entries} />
       <div className="mt-2 grid min-w-0 grid-cols-[minmax(0,1fr)] gap-2">
-        {renderToolEntries(
+        {renderRunEntries(
           props.entries,
           props.startIndex,
           props.keyPrefix,
           props.renderTool,
+          props.renderThinking,
         )}
       </div>
     </details>
   );
 }
 
-function renderToolEntries(
-  entries: RenderedToolEntry[],
+function renderRunEntries(
+  entries: RenderedToolRunEntry[],
   startIndex: number,
   keyPrefix: string,
   renderTool: (entry: RenderedToolEntry, index: number) => ReactNode,
+  renderThinking: (entry: RenderedThinkingEntry, index: number) => ReactNode,
 ): ReactNode[] {
   return entries.map((entry, offset) => {
     const index = startIndex + offset;
     return (
-      <Fragment key={`${keyPrefix}:tool:${index}`}>
-        {renderTool(entry, index)}
+      <Fragment key={`${keyPrefix}:run:${index}`}>
+        {entry.kind === "thinking"
+          ? renderThinking(entry, index)
+          : renderTool(entry, index)}
       </Fragment>
     );
   });
 }
 
-function ToolRunReveal(props: { hiddenCount: number }) {
+function formatRunRevealLabel(entries: RenderedToolRunEntry[]): string {
+  const toolCount = entries.filter((e) => e.kind === "tool").length;
+  const thinkingCount = entries.filter((e) => e.kind === "thinking").length;
+  const parts: string[] = [];
+  if (toolCount > 0) {
+    parts.push(`${toolCount} tool ${toolCount === 1 ? "call" : "calls"}`);
+  }
+  if (thinkingCount > 0) {
+    parts.push(
+      `${thinkingCount} thinking ${thinkingCount === 1 ? "entry" : "entries"}`,
+    );
+  }
+  return `show ${parts.join(" and ")}`;
+}
+
+function ToolRunReveal(props: { entries: RenderedToolRunEntry[] }) {
   return (
     <summary className="group flex w-full cursor-pointer list-none items-center gap-2 py-1.5 text-left font-mono text-[0.78rem] leading-tight text-[#888] transition-colors hover:text-[#d6d6d6] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[#beaaff]/55 [&::-webkit-details-marker]:hidden">
       <span className="h-px min-w-4 flex-1 bg-white/10 transition-colors group-hover:bg-white/20" />
-      <span className="shrink-0">show {props.hiddenCount} tool calls</span>
+      <span className="shrink-0">{formatRunRevealLabel(props.entries)}</span>
       <span className="h-px min-w-4 flex-1 bg-white/10 transition-colors group-hover:bg-white/20" />
     </summary>
   );

--- a/packages/junior-dashboard/src/client/components/TranscriptToolRun.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptToolRun.tsx
@@ -59,7 +59,7 @@ function renderRunEntries(
   return entries.map((entry, offset) => {
     const index = startIndex + offset;
     return (
-      <Fragment key={`${keyPrefix}:run:${index}`}>
+      <Fragment key={`${keyPrefix}:${entry.kind}:${index}`}>
         {entry.kind === "thinking"
           ? renderThinking(entry, index)
           : renderTool(entry, index)}

--- a/packages/junior-dashboard/src/client/components/TranscriptTurn.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptTurn.tsx
@@ -55,7 +55,6 @@ import {
   groupTranscriptMessages,
   groupTranscriptParts,
   messageRawText,
-  type RenderedThinkingEntry,
   type RenderedToolRunEntry,
   type RenderedTranscriptPart,
   type TranscriptViewMode,
@@ -334,38 +333,14 @@ function TranscriptEntryList(props: {
         props.entries[index]?.kind === "tool" ||
         props.entries[index]?.kind === "thinking"
       ) {
-        runEntries.push(
-          props.entries[index] as RenderedToolRunEntry,
-        );
+        runEntries.push(props.entries[index] as RenderedToolRunEntry);
         index += 1;
       }
-
-      // Pure-thinking runs render individually (no reveal group).
-      const hasTool = runEntries.some((e) => e.kind === "tool");
-      if (!hasTool) {
-        for (let i = 0; i < runEntries.length; i += 1) {
-          const thinkingEntry = runEntries[i] as TranscriptThinkingEntry;
-          if (
-            !search.active ||
-            entryMatchesSearch(thinkingEntry, search.normalizedQuery)
-          ) {
-            rows.push(
-              <Fragment key={`${props.keyPrefix}:thinking:${startIndex + i}`}>
-                {props.renderThinking(thinkingEntry, startIndex + i)}
-              </Fragment>,
-            );
-          }
-        }
-        continue;
-      }
-
-      // Mixed or tool-only runs: filter per-entry and pass to TranscriptToolRun.
       const visibleEntries = search.active
         ? runEntries.filter((e) =>
             entryMatchesSearch(e, search.normalizedQuery),
           )
         : runEntries;
-
       if (visibleEntries.length > 0) {
         rows.push(
           <TranscriptToolRun

--- a/packages/junior-dashboard/src/client/components/TranscriptTurn.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptTurn.tsx
@@ -55,6 +55,8 @@ import {
   groupTranscriptMessages,
   groupTranscriptParts,
   messageRawText,
+  type RenderedThinkingEntry,
+  type RenderedToolRunEntry,
   type RenderedTranscriptPart,
   type TranscriptViewMode,
 } from "./transcriptRenderModel";
@@ -325,26 +327,52 @@ function TranscriptEntryList(props: {
   for (let index = 0; index < props.entries.length; ) {
     const entry = props.entries[index]!;
 
-    if (entry.kind === "tool") {
+    if (entry.kind === "tool" || entry.kind === "thinking") {
       const startIndex = index;
-      const tools: TranscriptToolEntry[] = [];
-      while (props.entries[index]?.kind === "tool") {
-        tools.push(props.entries[index] as TranscriptToolEntry);
+      const runEntries: RenderedToolRunEntry[] = [];
+      while (
+        props.entries[index]?.kind === "tool" ||
+        props.entries[index]?.kind === "thinking"
+      ) {
+        runEntries.push(
+          props.entries[index] as RenderedToolRunEntry,
+        );
         index += 1;
       }
-      // When searching, filter within the original group to preserve group boundaries.
-      const visibleTools = search.active
-        ? tools.filter((tool) =>
-            entryMatchesSearch(tool, search.normalizedQuery),
-          )
-        : tools;
 
-      if (visibleTools.length > 0) {
+      // Pure-thinking runs render individually (no reveal group).
+      const hasTool = runEntries.some((e) => e.kind === "tool");
+      if (!hasTool) {
+        for (let i = 0; i < runEntries.length; i += 1) {
+          const thinkingEntry = runEntries[i] as TranscriptThinkingEntry;
+          if (
+            !search.active ||
+            entryMatchesSearch(thinkingEntry, search.normalizedQuery)
+          ) {
+            rows.push(
+              <Fragment key={`${props.keyPrefix}:thinking:${startIndex + i}`}>
+                {props.renderThinking(thinkingEntry, startIndex + i)}
+              </Fragment>,
+            );
+          }
+        }
+        continue;
+      }
+
+      // Mixed or tool-only runs: filter per-entry and pass to TranscriptToolRun.
+      const visibleEntries = search.active
+        ? runEntries.filter((e) =>
+            entryMatchesSearch(e, search.normalizedQuery),
+          )
+        : runEntries;
+
+      if (visibleEntries.length > 0) {
         rows.push(
           <TranscriptToolRun
-            entries={visibleTools}
+            entries={visibleEntries}
             key={`${props.keyPrefix}:tool-run:${startIndex}`}
             keyPrefix={props.keyPrefix}
+            renderThinking={props.renderThinking}
             renderTool={props.renderTool}
             startIndex={startIndex}
           />,
@@ -356,11 +384,9 @@ function TranscriptEntryList(props: {
     if (!search.active || entryMatchesSearch(entry, search.normalizedQuery)) {
       rows.push(
         <Fragment key={`${props.keyPrefix}:${entry.kind}:${index}`}>
-          {entry.kind === "thinking"
-            ? props.renderThinking(entry, index)
-            : entry.kind === "subagent"
-              ? props.renderSubagent(entry, index)
-              : props.renderMessage(entry, index)}
+          {entry.kind === "subagent"
+            ? props.renderSubagent(entry, index)
+            : props.renderMessage(entry, index)}
         </Fragment>,
       );
     }

--- a/packages/junior-dashboard/src/client/components/transcriptRenderModel.ts
+++ b/packages/junior-dashboard/src/client/components/transcriptRenderModel.ts
@@ -25,11 +25,14 @@ export type RenderedTranscriptEntry =
   | RenderedThinkingEntry
   | RenderedToolEntry;
 
-type RenderedThinkingEntry = {
+export type RenderedThinkingEntry = {
   kind: "thinking";
   part: TranscriptViewPart;
   timestamp?: number;
 };
+
+/** A single entry in a mixed tool-and-thinking run group. */
+export type RenderedToolRunEntry = RenderedToolEntry | RenderedThinkingEntry;
 
 export type RenderedSubagentEntry = {
   kind: "subagent";

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -1398,7 +1398,6 @@ describe("dashboard telemetry components", () => {
     expect(html).toContain("py-1.5 text-[0.84rem] leading-relaxed");
     expect(html).toContain("grid-cols-[1rem_minmax(0,1fr)]");
     expect(html).toContain("inline-flex size-4 shrink-0 items-center");
-    expect(html).toContain(">thinking<");
     expect(html).toContain("not-italic text-[#777] max-md:hidden");
     expect(html).toContain("hidden min-w-0 grid-cols-[1rem_minmax(0,1fr)]");
     expect(html).toContain("not-italic leading-snug text-[#777]");
@@ -1408,8 +1407,9 @@ describe("dashboard telemetry components", () => {
       html.indexOf("<summary"),
       html.indexOf("</summary>"),
     );
-    expect(summary).not.toContain("checking the rollout");
-    expect(summary).not.toContain("listing deploy windows");
+    // Summary shows truncated thinking text preview (not just a static label).
+    expect(summary).toContain("checking the rollout");
+    expect(summary).toContain("listing deploy windows");
   });
 
   it("collapses short thinking rows by default", () => {
@@ -1439,14 +1439,14 @@ describe("dashboard telemetry components", () => {
     );
 
     expect(html).toContain("<details");
-    expect(html).toContain(">thinking<");
     expect(html).toContain("checking the rollout");
 
     const summary = html.slice(
       html.indexOf("<summary"),
       html.indexOf("</summary>"),
     );
-    expect(summary).not.toContain("checking the rollout");
+    // Summary shows the truncated thinking text so users can scan before expanding.
+    expect(summary).toContain("checking the rollout");
   });
 
   it("expands thinking rows during transcript search", () => {
@@ -1485,5 +1485,160 @@ describe("dashboard telemetry components", () => {
     expect(html).toContain("checking the rollout");
     expect(html).toContain("listing <mark");
     expect(html).toContain(">deploy<");
+  });
+
+  it("consolidates mixed tool-and-thinking run at threshold behind a reveal", () => {
+    // 2 tool calls + 2 thinking entries = 4 total = at threshold
+    const turn = {
+      conversationId: "conversation-1",
+      id: "turn-1",
+      lastProgressAt: "2026-01-01T00:00:10.000Z",
+      lastSeenAt: "2026-01-01T00:00:10.000Z",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      status: "completed",
+      surface: "slack",
+      displayTitle: "Conversation",
+      transcript: [
+        {
+          role: "assistant",
+          timestamp: Date.parse("2026-01-01T00:00:10.000Z"),
+          parts: [
+            { id: "call-0", name: "tool-0", type: "tool_call" },
+            { type: "thinking", output: "first thought" },
+            { id: "call-1", name: "tool-1", type: "tool_call" },
+            { type: "thinking", output: "second thought" },
+          ],
+        },
+      ],
+      transcriptAvailable: true,
+    } as ConversationTurn;
+
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={client}>
+        <ConversationTranscriptSegment turn={turn} view="rich" />
+      </QueryClientProvider>,
+    );
+
+    // All four entries collapse into one reveal group.
+    expect(html).toContain('<details class="min-w-0"><summary');
+    expect(html).toContain("show 2 tool calls and 2 thinking entries");
+    expect(html).toContain("tool-0");
+    expect(html).toContain("tool-1");
+    expect(html).toContain("first thought");
+    expect(html).toContain("second thought");
+  });
+
+  it("keeps mixed tool-and-thinking run below threshold expanded flat", () => {
+    // 1 tool + 2 thinking = 3 total, below threshold
+    const turn = {
+      conversationId: "conversation-1",
+      id: "turn-1",
+      lastProgressAt: "2026-01-01T00:00:10.000Z",
+      lastSeenAt: "2026-01-01T00:00:10.000Z",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      status: "completed",
+      surface: "slack",
+      displayTitle: "Conversation",
+      transcript: [
+        {
+          role: "assistant",
+          timestamp: Date.parse("2026-01-01T00:00:10.000Z"),
+          parts: [
+            { id: "call-0", name: "tool-0", type: "tool_call" },
+            { type: "thinking", output: "first thought" },
+            { type: "thinking", output: "second thought" },
+          ],
+        },
+      ],
+      transcriptAvailable: true,
+    } as ConversationTurn;
+
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={client}>
+        <ConversationTranscriptSegment turn={turn} view="rich" />
+      </QueryClientProvider>,
+    );
+
+    expect(html).not.toContain("show");
+    expect(html).toContain("tool-0");
+    expect(html).toContain("first thought");
+    expect(html).toContain("second thought");
+  });
+
+  it("shows correct counts in mixed-run reveal label", () => {
+    // 5 tool calls + 2 thinking entries
+    const toolParts = Array.from({ length: 5 }, (_, i) => ({
+      id: `call-${i}`,
+      name: `tool-${i}`,
+      type: "tool_call",
+    }));
+    const turn = {
+      conversationId: "conversation-1",
+      id: "turn-1",
+      lastProgressAt: "2026-01-01T00:00:10.000Z",
+      lastSeenAt: "2026-01-01T00:00:10.000Z",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      status: "completed",
+      surface: "slack",
+      displayTitle: "Conversation",
+      transcript: [
+        {
+          role: "assistant",
+          timestamp: Date.parse("2026-01-01T00:00:10.000Z"),
+          parts: [
+            ...toolParts,
+            { type: "thinking", output: "thought a" },
+            { type: "thinking", output: "thought b" },
+          ],
+        },
+      ],
+      transcriptAvailable: true,
+    } as ConversationTurn;
+
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={client}>
+        <ConversationTranscriptSegment turn={turn} view="rich" />
+      </QueryClientProvider>,
+    );
+
+    expect(html).toContain("show 5 tool calls and 2 thinking entries");
+  });
+
+  it("renders pure-thinking runs individually without a reveal group", () => {
+    // 4 consecutive thinking entries — no tools, so no consolidation
+    const turn = {
+      conversationId: "conversation-1",
+      id: "turn-1",
+      lastProgressAt: "2026-01-01T00:00:10.000Z",
+      lastSeenAt: "2026-01-01T00:00:10.000Z",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      status: "completed",
+      surface: "slack",
+      displayTitle: "Conversation",
+      transcript: [
+        {
+          role: "assistant",
+          timestamp: Date.parse("2026-01-01T00:00:10.000Z"),
+          parts: [
+            { type: "thinking", output: "thought 1" },
+            { type: "thinking", output: "thought 2" },
+            { type: "thinking", output: "thought 3" },
+            { type: "thinking", output: "thought 4" },
+          ],
+        },
+      ],
+      transcriptAvailable: true,
+    } as ConversationTurn;
+
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={client}>
+        <ConversationTranscriptSegment turn={turn} view="rich" />
+      </QueryClientProvider>,
+    );
+
+    // No reveal group — pure thinking runs stay as individual collapsed rows.
+    expect(html).not.toContain("show");
+    expect(html).toContain("thought 1");
+    expect(html).toContain("thought 4");
   });
 });

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -1604,8 +1604,8 @@ describe("dashboard telemetry components", () => {
     expect(html).toContain("show 5 tool calls and 2 thinking entries");
   });
 
-  it("renders pure-thinking runs individually without a reveal group", () => {
-    // 4 consecutive thinking entries — no tools, so no consolidation
+  it("collapses four consecutive pure-thinking entries behind a reveal", () => {
+    // 4 consecutive thinking entries collapse the same as tool runs
     const turn = {
       conversationId: "conversation-1",
       id: "turn-1",
@@ -1636,8 +1636,8 @@ describe("dashboard telemetry components", () => {
       </QueryClientProvider>,
     );
 
-    // No reveal group — pure thinking runs stay as individual collapsed rows.
-    expect(html).not.toContain("show");
+    expect(html).toContain('<details class="min-w-0"><summary');
+    expect(html).toContain("show 4 thinking entries");
     expect(html).toContain("thought 1");
     expect(html).toContain("thought 4");
   });


### PR DESCRIPTION
Fixes two gaps from PR #731.

## Gap 1 — Regression: thinking summary text hidden

PR #731 replaced the truncated thinking text preview in the collapsed `<summary>` with a static `"thinking"` label, hiding all content until expanded.

**Fix:** Restore a single-line truncated preview of the thinking text in the `<summary>`. The `<details>` collapsing, search-expand behavior, and full expanded content are unchanged.

## Gap 2 — Missing: consecutive tool+thinking entries not consolidated

`TranscriptEntryList` only grouped consecutive `tool` entries. `thinking` entries between tool calls broke out of the group and rendered individually.

**Fix:** All contiguous `tool` and `thinking` entries now collect into a single run and pass through `TranscriptToolRun`. The reveal label counts each kind separately:

- `show 4 tool calls`
- `show 4 thinking entries`
- `show 4 tool calls and 2 thinking entries`

The threshold applies to total mixed-run entry count (4+). There is no special-casing for pure-thinking runs — treating them identically to tool runs is simpler and more consistent with the stated preference that both be collapsed by default.

## Shape

The `TranscriptEntryList` loop is now uniform: one collector, one search-filter path, one `TranscriptToolRun` render path. No `hasTool` branch. Fragment keys use `entry.kind` as prefix (`:tool:`, `:thinking:`) to preserve React key stability.

## Verification

- 162 tests pass
- TypeScript clean
- Visual QA: confirmed reveal labels, truncated summary text, CSS clipping on long thinking text
- 4 new tests: mixed run at threshold, below-threshold flat render, per-category label counts, pure-thinking reveal

Refs #726