### PR TITLE
fix(conversations): repair Slack destination visibility via API after 0002 reset

### DIFF
--- a/packages/junior/src/cli/upgrade.ts
+++ b/packages/junior/src/cli/upgrade.ts
@@ -9,6 +9,7 @@ import { pluginStorageMigration } from "./upgrade/migrations/plugin-storage";
 import { sqlPluginMigration } from "./upgrade/migrations/plugin-sql";
 import { resolveUpgradePlugins } from "./upgrade/migrations/upgrade-plugins";
 import { redisConversationStateMigration } from "./upgrade/migrations/redis-conversation-state";
+import { slackDestinationVisibilityRepairMigration } from "./upgrade/migrations/slack-destination-visibility-repair";
 import type {
   MigrationContext,
   MigrationResult,
@@ -27,6 +28,7 @@ const MIGRATIONS: UpgradeMigration[] = [
   sqlConversationMigration,
   sqlPluginMigration,
   pluginStorageMigration,
+  slackDestinationVisibilityRepairMigration,
 ];
 
 function isMissingVirtualConfig(error: unknown): boolean {

--- a/packages/junior/src/cli/upgrade/migrations/slack-destination-visibility-repair.ts
+++ b/packages/junior/src/cli/upgrade/migrations/slack-destination-visibility-repair.ts
@@ -1,0 +1,145 @@
+/**
+ * Repair Slack destination visibility after migration 0002 over-aggressively
+ * reset all confirmed-public destinations to 'private'.
+ *
+ * Uses the Slack conversations.info API to confirm actual channel visibility
+ * for ambiguous C-prefixed destinations. DMs and group/private channels are
+ * left untouched; only 'channel'-kind rows are re-evaluated.
+ *
+ * This upgrade migration is safe to re-run: already-public rows are skipped,
+ * and the migration proceeds even if individual channels are unreachable.
+ * It skips entirely when no Slack bot token is configured.
+ */
+import { and, eq, ne } from "drizzle-orm";
+import { juniorDestinations } from "@/chat/conversations/sql/schema";
+import type { JuniorSqlExecutor } from "@/chat/sql/db";
+import { createJuniorSqlExecutor } from "@/chat/sql/executor";
+import { getSlackClient, withSlackRetries } from "@/chat/slack/client";
+import type { MigrationContext, MigrationResult } from "../types";
+
+const REPAIR_QUERY_LIMIT = 1_000;
+
+/** Resolved classification for one Slack channel. */
+type ChannelVisibilityResult =
+  | { kind: "public" }
+  | { kind: "private" }
+  | { kind: "skipped" };
+
+/**
+ * Call conversations.info once for a channel and map Slack's is_private field
+ * to a visibility result. Returns 'skipped' on any API error so callers
+ * never update visibility from an uncertain state.
+ */
+async function resolveChannelVisibility(
+  channelId: string,
+  infoFn: (id: string) => Promise<ChannelVisibilityResult>,
+): Promise<ChannelVisibilityResult> {
+  try {
+    return await infoFn(channelId);
+  } catch {
+    return { kind: "skipped" };
+  }
+}
+
+/** Build a conversations.info lookup backed by the live Slack WebClient. */
+function liveInfoFn(): (id: string) => Promise<ChannelVisibilityResult> {
+  return async (channelId) => {
+    const response = await withSlackRetries(
+      async () => getSlackClient().conversations.info({ channel: channelId }),
+      3,
+      { action: "conversations.info", idempotent: true },
+    );
+    return { kind: response.channel?.is_private ? "private" : "public" };
+  };
+}
+
+/** Repair Slack destination visibility using the Slack conversations.info API. */
+export async function repairSlackDestinationVisibility(
+  _context: MigrationContext,
+  options: {
+    /** Injected SQL executor; defaults to the configured database. */
+    executor?: JuniorSqlExecutor;
+    /** Injected Slack info function; defaults to the live WebClient. */
+    slackInfoFn?: (channelId: string) => Promise<ChannelVisibilityResult>;
+  } = {},
+): Promise<MigrationResult> {
+  const { getSlackBotToken, getChatConfig } = await import("@/chat/config");
+
+  if (!getSlackBotToken()) {
+    // No token means no Slack context to repair; skip silently.
+    return { existing: 0, migrated: 0, missing: 0, scanned: 0 };
+  }
+
+  const infoFn = options.slackInfoFn ?? liveInfoFn();
+
+  let executor = options.executor;
+  let closeExecutor: (() => Promise<void>) | undefined;
+  if (!executor) {
+    const { sql } = getChatConfig();
+    const created = createJuniorSqlExecutor({
+      connectionString: sql.databaseUrl,
+      driver: sql.driver,
+    });
+    executor = created;
+    closeExecutor = () => created.close();
+  }
+
+  try {
+    const db = executor.db();
+
+    // Only 'channel'-kind rows are ambiguous: DMs ('dm') and legacy private
+    // channels ('group') are definitively private by channel-ID prefix and
+    // need no Slack API confirmation.
+    const rows = await db
+      .select({
+        id: juniorDestinations.id,
+        providerDestinationId: juniorDestinations.providerDestinationId,
+      })
+      .from(juniorDestinations)
+      .where(
+        and(
+          eq(juniorDestinations.provider, "slack"),
+          eq(juniorDestinations.kind, "channel"),
+          ne(juniorDestinations.visibility, "public"),
+        ),
+      )
+      .limit(REPAIR_QUERY_LIMIT);
+
+    const nowMs = Date.now();
+    let migrated = 0;
+    let skipped = 0;
+
+    for (const row of rows) {
+      const result = await resolveChannelVisibility(
+        row.providerDestinationId,
+        infoFn,
+      );
+
+      if (result.kind === "public") {
+        await db
+          .update(juniorDestinations)
+          .set({ visibility: "public", updatedAt: new Date(nowMs) })
+          .where(eq(juniorDestinations.id, row.id));
+        migrated++;
+      } else if (result.kind === "skipped") {
+        skipped++;
+      }
+      // 'private': already correct, no update needed
+    }
+
+    return {
+      existing: rows.length - migrated - skipped,
+      migrated,
+      missing: 0,
+      scanned: rows.length,
+      skipped,
+    };
+  } finally {
+    await closeExecutor?.();
+  }
+}
+
+export const slackDestinationVisibilityRepairMigration = {
+  name: "repair-slack-destination-visibility",
+  run: repairSlackDestinationVisibility,
+};

--- a/packages/junior/src/cli/upgrade/migrations/slack-destination-visibility-repair.ts
+++ b/packages/junior/src/cli/upgrade/migrations/slack-destination-visibility-repair.ts
@@ -2,6 +2,9 @@
  * Repair Slack destination visibility after migration 0002 over-aggressively
  * reset all confirmed-public destinations to 'private'.
  *
+ * TODO(0.90): Remove this migration once all deployments have run it and
+ * destination rows have been re-confirmed by the live Slack Events API.
+ *
  * Uses the Slack conversations.info API to confirm actual channel visibility
  * for ambiguous C-prefixed destinations. DMs and group/private channels are
  * left untouched; only 'channel'-kind rows are re-evaluated.

--- a/packages/junior/tests/component/cli/slack-destination-visibility-repair.test.ts
+++ b/packages/junior/tests/component/cli/slack-destination-visibility-repair.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Integration tests for repairSlackDestinationVisibility.
+ *
+ * Uses PGlite (or a real Postgres fixture when DATABASE_URL points at
+ * localhost) to verify that the migration correctly restores public
+ * visibility for confirmed-public channels and leaves everything else alone.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { eq } from "drizzle-orm";
+
+// config.ts runs readChatConfig() at the module level, which requires
+// DATABASE_URL. Set a placeholder here (before any module imports execute)
+// so the config module initialises without throwing. Tests inject their own
+// SQL executor so this value is never actually used for connections.
+vi.hoisted(() => {
+  const original = {
+    DATABASE_URL: process.env.DATABASE_URL,
+    SLACK_BOT_TOKEN: process.env.SLACK_BOT_TOKEN,
+  };
+  process.env.DATABASE_URL =
+    process.env.DATABASE_URL ?? "postgres://localhost:5432/junior_test";
+  process.env.SLACK_BOT_TOKEN = "xoxb-test-token";
+  return original;
+});
+
+import { repairSlackDestinationVisibility } from "@/cli/upgrade/migrations/slack-destination-visibility-repair";
+import { juniorDestinations } from "@/chat/conversations/sql/schema";
+import { createSqlStore } from "@/chat/conversations/sql/store";
+import { createLocalJuniorSqlFixture } from "../../fixtures/sql";
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+afterEach(() => {
+  // Keep SLACK_BOT_TOKEN set between cases; restored in the final afterEach.
+  process.env.SLACK_BOT_TOKEN = "xoxb-test-token";
+});
+
+type InfoResult = { kind: "public" | "private" | "skipped" };
+
+/** Build a stub Slack info function that routes by channel ID. */
+function makeStubInfoFn(
+  channelMap: Record<string, InfoResult["kind"]>,
+): (channelId: string) => Promise<InfoResult> {
+  return async (channelId) => ({ kind: channelMap[channelId] ?? "skipped" });
+}
+
+const MOCK_CONTEXT = {
+  io: { info: () => {} },
+  stateAdapter: null as never,
+};
+
+const NOW = new Date("2026-01-01T00:00:00.000Z");
+
+describe("repairSlackDestinationVisibility", () => {
+  it("restores public visibility for confirmed public channels and leaves private ones alone", async () => {
+    const fixture = await createLocalJuniorSqlFixture();
+    const store = createSqlStore(fixture.sql);
+    await store.migrate();
+
+    try {
+      const db = fixture.sql.db();
+
+      await db.insert(juniorDestinations).values([
+        {
+          id: "dest-public",
+          provider: "slack",
+          providerTenantId: "T123",
+          providerDestinationId: "C111",
+          kind: "channel",
+          visibility: "private",
+          createdAt: NOW,
+          updatedAt: NOW,
+        },
+        {
+          id: "dest-private",
+          provider: "slack",
+          providerTenantId: "T123",
+          providerDestinationId: "C222",
+          kind: "channel",
+          visibility: "private",
+          createdAt: NOW,
+          updatedAt: NOW,
+        },
+      ]);
+
+      const result = await repairSlackDestinationVisibility(MOCK_CONTEXT, {
+        executor: fixture.sql,
+        slackInfoFn: makeStubInfoFn({ C111: "public", C222: "private" }),
+      });
+
+      expect(result.scanned).toBe(2);
+      expect(result.migrated).toBe(1);
+      expect(result.skipped).toBe(0);
+      // C111 should be public now
+      const [publicRow] = await db
+        .select({ visibility: juniorDestinations.visibility })
+        .from(juniorDestinations)
+        .where(eq(juniorDestinations.id, "dest-public"));
+      expect(publicRow?.visibility).toBe("public");
+      // C222 stays private
+      const [privateRow] = await db
+        .select({ visibility: juniorDestinations.visibility })
+        .from(juniorDestinations)
+        .where(eq(juniorDestinations.id, "dest-private"));
+      expect(privateRow?.visibility).toBe("private");
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  it("skips inaccessible channels without changing their visibility", async () => {
+    const fixture = await createLocalJuniorSqlFixture();
+    const store = createSqlStore(fixture.sql);
+    await store.migrate();
+
+    try {
+      const db = fixture.sql.db();
+
+      await db.insert(juniorDestinations).values([
+        {
+          id: "dest-inaccessible",
+          provider: "slack",
+          providerTenantId: "T123",
+          providerDestinationId: "C333",
+          kind: "channel",
+          visibility: "private",
+          createdAt: NOW,
+          updatedAt: NOW,
+        },
+      ]);
+
+      const result = await repairSlackDestinationVisibility(MOCK_CONTEXT, {
+        executor: fixture.sql,
+        slackInfoFn: async () => {
+          throw new Error("not_in_channel");
+        },
+      });
+
+      expect(result.scanned).toBe(1);
+      expect(result.migrated).toBe(0);
+      expect(result.skipped).toBe(1);
+
+      const [row] = await db
+        .select({ visibility: juniorDestinations.visibility })
+        .from(juniorDestinations)
+        .where(eq(juniorDestinations.id, "dest-inaccessible"));
+      expect(row?.visibility).toBe("private");
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  it("does not query already-public channel destinations", async () => {
+    const fixture = await createLocalJuniorSqlFixture();
+    const store = createSqlStore(fixture.sql);
+    await store.migrate();
+
+    try {
+      const db = fixture.sql.db();
+      const infoFn = vi.fn(makeStubInfoFn({}));
+
+      await db.insert(juniorDestinations).values([
+        {
+          id: "dest-already-public",
+          provider: "slack",
+          providerTenantId: "T123",
+          providerDestinationId: "C444",
+          kind: "channel",
+          visibility: "public",
+          createdAt: NOW,
+          updatedAt: NOW,
+        },
+      ]);
+
+      const result = await repairSlackDestinationVisibility(MOCK_CONTEXT, {
+        executor: fixture.sql,
+        slackInfoFn: infoFn,
+      });
+
+      expect(result.scanned).toBe(0);
+      expect(result.migrated).toBe(0);
+      expect(infoFn).not.toHaveBeenCalled();
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  it("does not touch dm or group kind destinations", async () => {
+    const fixture = await createLocalJuniorSqlFixture();
+    const store = createSqlStore(fixture.sql);
+    await store.migrate();
+
+    try {
+      const db = fixture.sql.db();
+      const infoFn = vi.fn(makeStubInfoFn({}));
+
+      await db.insert(juniorDestinations).values([
+        {
+          id: "dest-dm",
+          provider: "slack",
+          providerTenantId: "T123",
+          providerDestinationId: "D555",
+          kind: "dm",
+          visibility: "private",
+          createdAt: NOW,
+          updatedAt: NOW,
+        },
+        {
+          id: "dest-group",
+          provider: "slack",
+          providerTenantId: "T123",
+          providerDestinationId: "C666",
+          kind: "group",
+          visibility: "private",
+          createdAt: NOW,
+          updatedAt: NOW,
+        },
+      ]);
+
+      const result = await repairSlackDestinationVisibility(MOCK_CONTEXT, {
+        executor: fixture.sql,
+        slackInfoFn: infoFn,
+      });
+
+      expect(result.scanned).toBe(0);
+      expect(result.migrated).toBe(0);
+      expect(infoFn).not.toHaveBeenCalled();
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  it("returns zero counts and skips API calls when no Slack token is configured", async () => {
+    restoreEnv("SLACK_BOT_TOKEN", undefined);
+
+    const fixture = await createLocalJuniorSqlFixture();
+    const store = createSqlStore(fixture.sql);
+    await store.migrate();
+
+    try {
+      const infoFn = vi.fn(makeStubInfoFn({}));
+
+      const result = await repairSlackDestinationVisibility(MOCK_CONTEXT, {
+        executor: fixture.sql,
+        slackInfoFn: infoFn,
+      });
+
+      expect(result.scanned).toBe(0);
+      expect(infoFn).not.toHaveBeenCalled();
+    } finally {
+      await fixture.close();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Migration `0002_slack_destination_visibility_backfill` reset **all** confirmed-public Slack destinations to `'private'`, causing every channel conversation to appear as "Private Conversation" in the dashboard after the version bump.

A pure SQL repair is not safe. Modern Slack private channels use the same `C`-prefix as public channels, so `kind='channel'` rows are ambiguous:

| Case | Visibility after 0002 | Correct visibility |
|---|---|---|
| Previously confirmed public (0002 wiped) | `private` ❌ | `public` |
| Correctly confirmed private (C-prefix) | `private` ✅ | `private` |
| Never confirmed (default private) | `private` | unknown |

The only reliable signal is `channel_type = 'channel'` from Slack's Events API, which wasn't preserved in the destination row. So we can't recover this from stored data alone.

## Solution

New upgrade migration `repair-slack-destination-visibility` (registered in `MIGRATIONS`) that:

1. Queries all `kind='channel'` Slack destinations not already marked `'public'`
2. Calls `conversations.info` for each to get Slack's authoritative `is_private` field
3. Restores `visibility = 'public'` where confirmed; skips on any API error
4. Leaves `dm` and `group` kind rows untouched (definitively private by channel-ID prefix)

**Safety properties:**
- Idempotent: already-public rows are skipped and the Slack API is not called for them
- Error-tolerant: inaccessible/archived/not-in-channel errors skip that destination without guessing
- Opt-out: skips entirely if no `SLACK_BOT_TOKEN` is configured
- Runs during `junior upgrade`, so it applies before the deployment serves traffic

## What was verified

- `tsc --noEmit` clean on new files
- `oxlint` clean on new files
- Test coverage for: confirmed-public restore, confirmed-private unchanged, inaccessible skipped, already-public not queried, dm/group kinds untouched, no-token early exit

<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC0AHB7N2JCR%3A1783016794.773959/?project=4510944073809921)

<!-- junior-session-footer:end -->