### PR TITLE
fix(github-issues): ban conventional commit prefixes in issue titles

### DIFF
--- a/packages/junior-github/skills/github-issues/SKILL.md
+++ b/packages/junior-github/skills/github-issues/SKILL.md
@@ -52,6 +52,7 @@ Follow [references/research-rules.md](references/research-rules.md) for cross-ty
 **Hard constraints — apply to every new issue:**
 
 - Title ≤ 60 characters. Descriptive for bugs, imperative for tasks/features.
+- **Issue title format: plain language, no type prefix.** Do not use `fix(x):`, `feat(x):`, `chore:`, `ref(x):`, or any other type-scope prefix — those belong in commit messages and PR titles, not issues.
 - Summary ≤ 3 sentences. Do not restate the title in the body.
 - Prefer flat bullet lists over headed sections for simple issues. Remove empty sections.
 - Generalize session framing — strip channel references, slash commands, Slack thread IDs, user @mentions, and transcript fragments; replace with the underlying technical problem.


### PR DESCRIPTION
## What failed

Junior was creating GitHub issues with conventional commit-style prefixes in their titles — `fix(attachments): ...`, `feat(sandbox): ...`, `ref(task-execution): ...` — which is wrong. That format belongs in commit messages and PR titles only.

## Evidence

Several real issues in `getsentry/junior` with the wrong format:
- #737: `fix(attachments): durable file attachment pipeline…`
- #735: `feat: first-class agents.toml / dotagents skill support`
- #715: `feat(sandbox): make snapshot sandbox vcpus/memory configurable via env var`
- #705: `ref(task-execution): centralize wake scheduling with ensureConversationWake()`
- #679: `feat(memory): add recall-layer relevance gate to filter low-relevance vector matches`

## Root cause

The `github-issues` skill had no explicit rule against conventional commit prefixes in issue titles. The `pr-writer` skill heavily uses `fix(scope):` for PR titles, and without a constraint in the issue skill the model generalizes the pattern to issues too.

## Fix

Added a single prescriptive hard constraint to `SKILL.md` § Draft issue content:

> **Issue title format: plain language, no type prefix.** Do not use `fix(x):`, `feat(x):`, `chore:`, `ref(x):`, or any other type-scope prefix — those belong in commit messages and PR titles, not issues.

## Verification

Content review — no automated checks applicable for skill text changes.