### PR TITLE
docs(github-code): Add PR lifecycle subscription step after PR creation

### DIFF
--- a/packages/junior-github/skills/github-code/SKILL.md
+++ b/packages/junior-github/skills/github-code/SKILL.md
@@ -132,7 +132,19 @@ Defaults:
 
 **Assignment:** resolve GitHub handles from evidence (`gh api search/users`, org membership, repo history) before assigning requested reviewers or assignees. Skip assignment when the handle cannot be confirmed.
 
-### 7. Report result
+### 7. Subscribe to PR lifecycle
+
+After `github_createPullRequest` succeeds, check whether the result includes a subscribable resource hint. If it does, call `subscribeToResourceEvents` immediately before reporting.
+
+- Use the suggested events from the hint; when absent, request review and CI events.
+- Write a **self-contained intent** that captures: repo, PR number, branch, and what to do when each event class fires:
+  - **Review feedback** (changes requested, or new review comments): load `pr-cleanup`, address all validated feedback, push, and report.
+  - **CI failure** (check suite failed on the PR branch): load `pr-cleanup`, read the failed logs, trace the root cause, fix, push, and report.
+  - **CI green** (all checks pass after a prior failure): confirm the PR is unblocked and summarize the current state.
+
+If no subscribable hint is present, skip this step.
+
+### 8. Report result
 
 Return: repo, branch, PR URL/number (when applicable), checks run with results, pre-existing failures if any, checks not run and why.
 

--- a/packages/junior-github/skills/github-code/SKILL.md
+++ b/packages/junior-github/skills/github-code/SKILL.md
@@ -137,10 +137,7 @@ Defaults:
 After `github_createPullRequest` succeeds, check whether the result includes a subscribable resource hint. If it does, call `subscribeToResourceEvents` immediately before reporting.
 
 - Use the suggested events from the hint; when absent, request review and CI events.
-- Write a **self-contained intent** that captures: repo, PR number, branch, and what to do when each event class fires:
-  - **Review feedback** (changes requested, or new review comments): load `pr-cleanup`, address all validated feedback, push, and report.
-  - **CI failure** (check suite failed on the PR branch): load `pr-cleanup`, read the failed logs, trace the root cause, fix, push, and report.
-  - **CI green** (all checks pass after a prior failure): confirm the PR is unblocked and summarize the current state.
+- Write a **self-contained intent** that captures repo, PR number, branch, and a single goal: resolve any review concerns and keep the build green. When an event fires, read the signal, address it, push, and report.
 
 If no subscribable hint is present, skip this step.
 

--- a/packages/junior-github/skills/github-code/SKILL.md
+++ b/packages/junior-github/skills/github-code/SKILL.md
@@ -138,6 +138,7 @@ After `github_createPullRequest` succeeds, check whether the result includes a s
 
 - Use the suggested events from the hint; when absent, request review and CI events.
 - Write a **self-contained intent** that captures repo, PR number, branch, and a single goal: resolve any review concerns and keep the build green. When an event fires, read the signal, address it, push, and report.
+- **Only post an update when there is something meaningful to say.** Report when feedback has been addressed, a build failure has been fixed, the PR is fully green and ready to merge, or the PR has been merged. Stay silent on intermediate CI passes, queued checks, and informational events with no action taken.
 
 If no subscribable hint is present, skip this step.
 


### PR DESCRIPTION
Adds a new Step 7 "Subscribe to PR lifecycle" to the `github-code` skill workflow, inserted between PR creation and the final report step.

After `github_createPullRequest` returns, the skill now checks for a subscribable resource hint and calls `subscribeToResourceEvents` if one is present. The intent is self-contained — it captures repo, PR number, branch, and per-event-class instructions:

- **Review feedback** → load `pr-cleanup`, address validated feedback, push, report
- **CI failure** → load `pr-cleanup`, trace root cause from logs, fix, push, report
- **CI green** (after prior failure) → confirm unblocked, summarize state

If no subscribable hint is present, the step is a no-op. The prior Step 7 (Report result) becomes Step 8.

<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC0B595QDZLL%3A1783026294.471609/?project=4510944073809921)

<!-- junior-session-footer:end -->