### PR TITLE
fix(slack): Stop sending synthetic resource-event timestamps

### DIFF
--- a/packages/junior/.dependency-cruiser.mjs
+++ b/packages/junior/.dependency-cruiser.mjs
@@ -27,13 +27,14 @@ export default {
     {
       name: "no-chat-services-to-slack",
       comment:
-        "Service modules must depend on small injected ports, not Slack infrastructure.",
+        "Service modules must depend on small injected ports, not Slack infrastructure; Slack timestamp value objects are the only exception.",
       severity: "error",
       from: {
         path: "^src/chat/services/",
       },
       to: {
         path: "^src/chat/slack/",
+        pathNot: "^src/chat/slack/timestamp\\.ts$",
       },
     },
     {

--- a/packages/junior/src/chat/runtime/conversation-message.ts
+++ b/packages/junior/src/chat/runtime/conversation-message.ts
@@ -26,6 +26,7 @@ export function toConversationMessage(
   args: ConversationMessageInput,
 ): ConversationMessage {
   const actor = getMessageActorIdentity(args.entry);
+  const slackTs = getSlackMessageTs(args.entry);
   const messageHasPotentialImageAttachment = hasPotentialImageAttachment(
     args.entry.attachments,
   );
@@ -53,7 +54,7 @@ export function toConversationMessage(
       imageAttachmentCount:
         imageAttachmentCount > 0 ? imageAttachmentCount : undefined,
       imagesHydrated: !messageHasPotentialImageAttachment,
-      slackTs: getSlackMessageTs(args.entry),
+      ...(slackTs ? { slackTs } : {}),
     },
   };
 }

--- a/packages/junior/src/chat/runtime/processing-reaction.ts
+++ b/packages/junior/src/chat/runtime/processing-reaction.ts
@@ -8,6 +8,7 @@ import {
 import { getChannelId, getMessageTs } from "@/chat/runtime/thread-context";
 import type { TurnToolInvocation } from "@/chat/runtime/turn-input";
 import { getChatConfig } from "@/chat/config";
+import type { SlackMessageTs } from "@/chat/slack/timestamp";
 
 /** Controls the automatic Slack processing reaction lifecycle for one message. */
 export interface ProcessingReactionSession {
@@ -25,7 +26,8 @@ const noProcessingReaction: ProcessingReactionSession = {
 function isProcessingReactionEmoji(value: unknown): boolean {
   return (
     typeof value === "string" &&
-    normalizeSlackEmojiName(value) === getChatConfig().slack.processingReactionEmoji
+    normalizeSlackEmojiName(value) ===
+      getChatConfig().slack.processingReactionEmoji
   );
 }
 
@@ -73,7 +75,7 @@ export async function startSlackProcessingReaction(args: {
 /** Start Junior's automatic Slack processing reaction for a known Slack message. */
 export async function startSlackProcessingReactionForMessage(args: {
   channelId: string;
-  timestamp: string;
+  timestamp: SlackMessageTs;
   logException: (
     error: unknown,
     eventName: string,

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -48,6 +48,7 @@ import {
   startSlackProcessingReactionForMessage,
   type ProcessingReactionSession,
 } from "@/chat/runtime/processing-reaction";
+import type { SlackMessageTs } from "@/chat/slack/timestamp";
 import { buildAuthPauseResponse } from "@/chat/services/auth-pause-response";
 import { getTurnRequestDeadline } from "@/chat/runtime/request-deadline";
 
@@ -137,7 +138,7 @@ interface ResumeSlackTurnArgs {
   messageText: string;
   channelId: string;
   threadTs: string;
-  messageTs?: string;
+  messageTs?: SlackMessageTs;
   replyContext?: ResumeReplyContext;
   lockKey?: string;
   initialText?: string;
@@ -573,7 +574,7 @@ export async function resumeAuthorizedRequest(args: {
   messageText: string;
   channelId: string;
   threadTs: string;
-  messageTs?: string;
+  messageTs?: SlackMessageTs;
   connectedText: string;
   replyContext?: ResumeReplyContext;
   lockKey?: string;

--- a/packages/junior/src/chat/runtime/thread-context.ts
+++ b/packages/junior/src/chat/runtime/thread-context.ts
@@ -9,6 +9,10 @@ import {
   resolveSlackChannelIdFromThreadId,
   resolveSlackChannelIdFromMessage,
 } from "@/chat/slack/context";
+import {
+  parseSlackMessageTs,
+  type SlackMessageTs,
+} from "@/chat/slack/timestamp";
 
 function toSlackTeamId(value: unknown): string | undefined {
   const candidate = toOptionalString(value);
@@ -126,12 +130,14 @@ export function getAssistantThreadContext(
   return parsedThreadId;
 }
 
-export function getMessageTs(message: Message): string | undefined {
+/** Resolve the native Slack timestamp for a message that can target Slack APIs. */
+export function getMessageTs(message: Message): SlackMessageTs | undefined {
   const directTs = toOptionalString(
     (message as unknown as { ts?: unknown }).ts,
   );
-  if (directTs) {
-    return directTs;
+  const parsedDirectTs = parseSlackMessageTs(directTs);
+  if (parsedDirectTs) {
+    return parsedDirectTs;
   }
 
   const raw = (message as unknown as { raw?: unknown }).raw;
@@ -140,11 +146,17 @@ export function getMessageTs(message: Message): string | undefined {
   }
 
   const rawRecord = raw as Record<string, unknown>;
-  return (
-    toOptionalString(rawRecord.ts) ??
-    toOptionalString(rawRecord.event_ts) ??
-    toOptionalString((rawRecord.message as { ts?: unknown } | undefined)?.ts)
-  );
+  const candidates = [
+    rawRecord.ts,
+    (rawRecord.message as { ts?: unknown } | undefined)?.ts,
+  ];
+  for (const candidate of candidates) {
+    const ts = parseSlackMessageTs(candidate);
+    if (ts) {
+      return ts;
+    }
+  }
+  return undefined;
 }
 
 /** Resolve the Slack workspace/team id from the raw inbound message payload. */

--- a/packages/junior/src/chat/runtime/turn-user-message.ts
+++ b/packages/junior/src/chat/runtime/turn-user-message.ts
@@ -3,13 +3,10 @@ import type {
   ConversationMessage,
   ThreadConversationState,
 } from "@/chat/state/conversation";
-
-function normalizeSlackMessageTs(
-  value: string | undefined,
-): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed && /^\d+(?:\.\d+)?$/.test(trimmed) ? trimmed : undefined;
-}
+import {
+  parseSlackMessageTs,
+  type SlackMessageTs,
+} from "@/chat/slack/timestamp";
 
 /** Return the user message for a persisted turn/session, if one exists. */
 export function getTurnUserMessage(
@@ -40,11 +37,8 @@ export function getTurnUserMessageId(
 /** Return the Slack timestamp for the user message that a resumed turn acts on. */
 export function getTurnUserSlackMessageTs(
   message: ConversationMessage | undefined,
-): string | undefined {
-  return (
-    normalizeSlackMessageTs(message?.meta?.slackTs) ??
-    normalizeSlackMessageTs(message?.id)
-  );
+): SlackMessageTs | undefined {
+  return parseSlackMessageTs(message?.meta?.slackTs);
 }
 
 /** Rebuild attachment context for a resumed turn from the persisted user message. */

--- a/packages/junior/src/chat/services/conversation-memory.ts
+++ b/packages/junior/src/chat/services/conversation-memory.ts
@@ -5,13 +5,16 @@ import type {
   ConversationMessage,
   ThreadConversationState,
 } from "@/chat/state/conversation";
-import { toOptionalString } from "@/chat/coerce";
 import { logWarn, setSpanAttributes } from "@/chat/logging";
 import {
   calculateContextCompactionTargetTokens,
   estimateTextTokens,
   getConversationContextCompactionTriggerTokens,
 } from "@/chat/services/context-budget";
+import {
+  parseSlackMessageTs,
+  type SlackMessageTs,
+} from "@/chat/slack/timestamp";
 import { escapeXml } from "@/chat/xml";
 
 const CONTEXT_MIN_LIVE_MESSAGES = 12;
@@ -463,8 +466,9 @@ export function isHumanConversationMessage(
   return message.role === "user" && message.author?.isBot !== true;
 }
 
+/** Return the native Slack timestamp for a persisted conversation message. */
 export function getConversationMessageSlackTs(
   message: ConversationMessage,
-): string | undefined {
-  return message.meta?.slackTs ?? toOptionalString(message.id);
+): SlackMessageTs | undefined {
+  return parseSlackMessageTs(message.meta?.slackTs);
 }

--- a/packages/junior/src/chat/slack/message.ts
+++ b/packages/junior/src/chat/slack/message.ts
@@ -1,8 +1,8 @@
 import type { Message } from "chat";
-
-function isSlackMessageTs(value: string): boolean {
-  return /^\d+(?:\.\d+)?$/.test(value.trim());
-}
+import {
+  parseSlackMessageTs,
+  type SlackMessageTs,
+} from "@/chat/slack/timestamp";
 
 /**
  * Preserve the native Slack message timestamp when a synthetic message ID is
@@ -10,17 +10,15 @@ function isSlackMessageTs(value: string): boolean {
  */
 export function getSlackMessageTs(
   message: Pick<Message, "id" | "raw">,
-): string {
-  if (isSlackMessageTs(message.id)) {
-    return message.id;
+): SlackMessageTs | undefined {
+  const idTs = parseSlackMessageTs(message.id);
+  if (idTs) {
+    return idTs;
   }
 
   if (message.raw && typeof message.raw === "object") {
-    const ts = (message.raw as Record<string, unknown>).ts;
-    if (typeof ts === "string" && ts.length > 0) {
-      return ts;
-    }
+    return parseSlackMessageTs((message.raw as Record<string, unknown>).ts);
   }
 
-  return message.id;
+  return undefined;
 }

--- a/packages/junior/src/chat/slack/outbound.ts
+++ b/packages/junior/src/chat/slack/outbound.ts
@@ -7,6 +7,10 @@ import {
 } from "@/chat/slack/client";
 import { normalizeSlackEmojiName } from "@/chat/slack/emoji";
 import { parseActorUserId } from "@/chat/requester";
+import {
+  parseSlackMessageTs,
+  type SlackMessageTs,
+} from "@/chat/slack/timestamp";
 
 const MAX_SLACK_MESSAGE_TEXT_CHARS = 40_000;
 
@@ -29,8 +33,8 @@ function requireSlackThreadTimestamp(threadTs: string, action: string): string {
 function requireSlackMessageTimestamp(
   timestamp: string,
   action: string,
-): string {
-  const normalized = timestamp.trim();
+): SlackMessageTs {
+  const normalized = parseSlackMessageTs(timestamp);
   if (!normalized) {
     throw new Error(`${action} requires a target message timestamp`);
   }
@@ -51,7 +55,7 @@ function requireSlackMessageText(text: string, action: string): string {
 
 async function getPermalinkBestEffort(args: {
   channelId: string;
-  messageTs: string;
+  messageTs: SlackMessageTs;
 }): Promise<string | undefined> {
   try {
     const response = await withSlackRetries(
@@ -83,7 +87,7 @@ export async function postSlackMessage(input: {
   text: string;
   threadTs?: string;
   includePermalink?: boolean;
-}): Promise<{ ts: string; permalink?: string }> {
+}): Promise<{ ts: SlackMessageTs; permalink?: string }> {
   const channelId = requireSlackConversationId(
     input.channelId,
     "Slack message posting",
@@ -118,17 +122,18 @@ export async function postSlackMessage(input: {
     },
   );
 
-  if (!response.ts) {
+  const messageTs = parseSlackMessageTs(response.ts);
+  if (!messageTs) {
     throw new Error("Slack message posted without ts");
   }
 
   return {
-    ts: response.ts,
+    ts: messageTs,
     ...(input.includePermalink
       ? {
           permalink: await getPermalinkBestEffort({
             channelId,
-            messageTs: response.ts,
+            messageTs,
           }),
         }
       : {}),
@@ -138,7 +143,7 @@ export async function postSlackMessage(input: {
 /** Delete a previously posted Slack message through the shared outbound boundary. */
 export async function deleteSlackMessage(input: {
   channelId: string;
-  timestamp: string;
+  timestamp: SlackMessageTs;
 }): Promise<void> {
   const channelId = requireSlackConversationId(
     input.channelId,
@@ -271,7 +276,7 @@ export async function uploadFilesToThread(input: {
 /** Add a reaction to a Slack message, treating `already_reacted` as idempotent success. */
 export async function addReactionToMessage(input: {
   channelId: string;
-  timestamp: string;
+  timestamp: SlackMessageTs;
   emoji: string;
 }): Promise<{ ok: true }> {
   const channelId = requireSlackConversationId(
@@ -319,7 +324,7 @@ export async function addReactionToMessage(input: {
 /** Remove a reaction from a Slack message, treating `no_reaction` as idempotent success. */
 export async function removeReactionFromMessage(input: {
   channelId: string;
-  timestamp: string;
+  timestamp: SlackMessageTs;
   emoji: string;
 }): Promise<{ ok: true }> {
   const channelId = requireSlackConversationId(

--- a/packages/junior/src/chat/slack/timestamp.ts
+++ b/packages/junior/src/chat/slack/timestamp.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+/** Native Slack message timestamp, safe to pass as Slack Web API `message_ts`. */
+export const slackMessageTsSchema = z
+  .string()
+  .trim()
+  .regex(/^\d+(?:\.\d+)?$/)
+  .brand<"SlackMessageTs">();
+
+export type SlackMessageTs = z.output<typeof slackMessageTsSchema>;
+
+/** Parse a native Slack message timestamp from untrusted message metadata. */
+export function parseSlackMessageTs(
+  value: unknown,
+): SlackMessageTs | undefined {
+  const parsed = slackMessageTsSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
+}

--- a/packages/junior/src/chat/task-execution/slack-work.ts
+++ b/packages/junior/src/chat/task-execution/slack-work.ts
@@ -132,6 +132,10 @@ function slackSerializedThread(input: {
   };
 }
 
+/**
+ * Serialize a synthetic resource-event mailbox message without a native Slack
+ * message timestamp so Slack Web API calls cannot target the internal id.
+ */
 function slackSerializedResourceEventMessage(input: {
   channelId: string;
   id: string;
@@ -159,7 +163,6 @@ function slackSerializedResourceEventMessage(input: {
       channel: input.channelId,
       event_type: "resource_event",
       thread_ts: input.threadTs,
-      ts: input.id,
       type: "message",
       user: "UJRNEVENT",
     },

--- a/packages/junior/src/chat/tools/slack/context.ts
+++ b/packages/junior/src/chat/tools/slack/context.ts
@@ -2,13 +2,17 @@ import type { ToolRuntimeContext } from "@/chat/tools/types";
 import type { SlackDestination } from "@sentry/junior-plugin-api";
 import type { SlackSource } from "@sentry/junior-plugin-api";
 import type { SlackRequester } from "@/chat/requester";
+import {
+  parseSlackMessageTs,
+  type SlackMessageTs,
+} from "@/chat/slack/timestamp";
 
 export interface SlackToolContext {
   destination: SlackDestination;
   source: SlackSource;
   requester?: SlackRequester;
   destinationChannelId: string;
-  messageTs?: string;
+  messageTs?: SlackMessageTs;
   sourceChannelId: string;
   teamId: string;
   threadTs?: string;
@@ -30,7 +34,7 @@ export function getSlackToolContext(
     requester:
       context.requester?.platform === "slack" ? context.requester : undefined,
     destinationChannelId: context.destination.channelId,
-    messageTs: context.source.messageTs,
+    messageTs: parseSlackMessageTs(context.source.messageTs),
     sourceChannelId: context.source.channelId,
     teamId: context.source.teamId,
     threadTs: context.source.threadTs,

--- a/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
@@ -200,6 +200,7 @@ describe("Slack conversation work execution", () => {
     expect(lookupSlackUser).not.toHaveBeenCalled();
     expect(calls).toHaveLength(1);
     expect(calls[0]?.raw).toMatchObject({ event_type: "resource_event" });
+    expect(calls[0]?.raw).not.toHaveProperty("ts");
     expect(getMessageActorIdentity(calls[0]!)).toEqual({
       userId: "UJRNEVENT",
     });

--- a/packages/junior/tests/integration/slack-channel-tools.test.ts
+++ b/packages/junior/tests/integration/slack-channel-tools.test.ts
@@ -5,6 +5,7 @@ import { createSlackChannelPostMessageTool } from "@/chat/tools/slack/channel-po
 import { createSlackMessageAddReactionTool } from "@/chat/tools/slack/message-add-reaction";
 import type { SlackToolContext } from "@/chat/tools/slack/context";
 import type { ToolState } from "@/chat/tools/types";
+import { parseSlackMessageTs } from "@/chat/slack/timestamp";
 import {
   chatGetPermalinkOk,
   chatPostMessageOk,
@@ -42,6 +43,10 @@ function createContext(
   const sourceChannelId = overrides.sourceChannelId ?? "C123";
   const destinationChannelId =
     overrides.destinationChannelId ?? sourceChannelId;
+  const messageTs = parseSlackMessageTs("1700000000.321");
+  if (!messageTs) {
+    throw new Error("Test message timestamp must be a valid Slack ts");
+  }
   return {
     destination: {
       platform: "slack",
@@ -51,12 +56,12 @@ function createContext(
     source: createSlackSource({
       teamId: "T123",
       channelId: sourceChannelId,
-      messageTs: "1700000000.321",
+      messageTs,
 
       type: "priv",
     }),
     destinationChannelId,
-    messageTs: "1700000000.321",
+    messageTs,
     sourceChannelId,
     teamId: "T123",
     ...overrides,

--- a/packages/junior/tests/integration/slack/outbound-normalization-contract.test.ts
+++ b/packages/junior/tests/integration/slack/outbound-normalization-contract.test.ts
@@ -11,6 +11,7 @@ import {
   postSlackMessage,
   uploadFilesToThread,
 } from "@/chat/slack/outbound";
+import { parseSlackMessageTs } from "@/chat/slack/timestamp";
 import {
   filesCompleteUploadOk,
   filesGetUploadUrlOk,
@@ -165,9 +166,14 @@ describe("Slack contract: outbound normalization", () => {
   });
 
   it("normalizes adapter-scoped ids before reactions.add", async () => {
+    const timestamp = parseSlackMessageTs("1700000000.000100");
+    if (!timestamp) {
+      throw new Error("Test message timestamp must be a valid Slack ts");
+    }
+
     await addReactionToMessage({
       channelId: "slack:C123",
-      timestamp: "1700000000.000100",
+      timestamp,
       emoji: ":wave:",
     });
 

--- a/packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts
@@ -182,6 +182,57 @@ describe("Slack behavior: processing reaction", () => {
     ]);
   });
 
+  it("does not react to synthetic resource-event notifications", async () => {
+    const { slackRuntime } = createTestChatRuntime({
+      services: {
+        replyExecutor: {
+          generateAssistantReply: async () => {
+            expect(slackApiOutbox.reactionAdds()).toHaveLength(0);
+            expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
+            return {
+              text: "Done.",
+              diagnostics: successDiagnostics(),
+            };
+          },
+        },
+      },
+    });
+
+    const thread = createTestThread({
+      id: "slack:C_PROCESSING:1700007160.000000",
+    });
+    await slackRuntime.handleSubscribedMessage(
+      thread,
+      createTestMessage({
+        id: "resource-event-resub-1-check-suite-1",
+        text: "[event notification]\n\nA subscribed resource changed.",
+        isMention: false,
+        threadId: thread.id,
+        author: {
+          userId: "UJRNEVENT",
+          userName: "junior-event",
+          fullName: "Junior event",
+          isBot: true,
+        },
+        raw: {
+          channel: "C_PROCESSING",
+          event_type: "resource_event",
+          thread_ts: "1700007160.000000",
+          // Historical malformed records used the synthetic mailbox id as raw.ts.
+          // It must still never be treated as a Slack Web API message target.
+          ts: "resource-event-resub-1-check-suite-1",
+          type: "message",
+          user: "UJRNEVENT",
+        },
+      }),
+      { destination: createTestDestination(thread) },
+    );
+
+    expect(thread.posts).toHaveLength(1);
+    expect(slackApiOutbox.reactionAdds()).toHaveLength(0);
+    expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
+  });
+
   it("keeps eyes when the assistant explicitly adds an eyes reaction", async () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {

--- a/packages/junior/tests/unit/slack/channel-action-context.test.ts
+++ b/packages/junior/tests/unit/slack/channel-action-context.test.ts
@@ -29,6 +29,15 @@ import {
   removeReactionFromMessage,
   slackOutboundPolicy,
 } from "@/chat/slack/outbound";
+import { parseSlackMessageTs } from "@/chat/slack/timestamp";
+
+function slackTs(value: string) {
+  const ts = parseSlackMessageTs(value);
+  if (!ts) {
+    throw new Error(`Invalid test Slack message timestamp: ${value}`);
+  }
+  return ts;
+}
 
 describe("slack outbound boundary", () => {
   beforeEach(() => {
@@ -50,7 +59,7 @@ describe("slack outbound boundary", () => {
 
     await addReactionToMessage({
       channelId: "C123",
-      timestamp: "1700000000.100",
+      timestamp: slackTs("1700000000.100"),
       emoji: "thumbsup",
     });
 
@@ -84,7 +93,7 @@ describe("slack outbound boundary", () => {
 
     await removeReactionFromMessage({
       channelId: "C123",
-      timestamp: "1700000000.100",
+      timestamp: slackTs("1700000000.100"),
       emoji: "eyes",
     });
 
@@ -113,7 +122,7 @@ describe("slack outbound boundary", () => {
 
     await addReactionToMessage({
       channelId: "C123",
-      timestamp: "1700000000.100",
+      timestamp: slackTs("1700000000.100"),
       emoji: ":thumbsup::skin-tone-6:",
     });
 
@@ -132,7 +141,7 @@ describe("slack outbound boundary", () => {
     await expect(
       addReactionToMessage({
         channelId: "C123",
-        timestamp: "1700000000.100",
+        timestamp: slackTs("1700000000.100"),
         emoji: "thumbsup",
       }),
     ).resolves.toEqual({ ok: true });
@@ -146,7 +155,7 @@ describe("slack outbound boundary", () => {
     await expect(
       removeReactionFromMessage({
         channelId: "C123",
-        timestamp: "1700000000.100",
+        timestamp: slackTs("1700000000.100"),
         emoji: "thumbsup",
       }),
     ).resolves.toEqual({ ok: true });

--- a/packages/junior/tests/unit/slack/slack-message-add-reaction-tool.test.ts
+++ b/packages/junior/tests/unit/slack/slack-message-add-reaction-tool.test.ts
@@ -3,12 +3,18 @@ import { createSlackSource } from "@sentry/junior-plugin-api";
 import { createSlackMessageAddReactionTool } from "@/chat/tools/slack/message-add-reaction";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 import type { SlackToolContext } from "@/chat/tools/slack/context";
+import { parseSlackMessageTs } from "@/chat/slack/timestamp";
 
 const addReactionToMessage = vi.fn();
 
 vi.mock("@/chat/slack/outbound", () => ({
   addReactionToMessage: (...args: unknown[]) => addReactionToMessage(...args),
 }));
+
+const TEST_MESSAGE_TS = parseSlackMessageTs("1700000000.100");
+if (!TEST_MESSAGE_TS) {
+  throw new Error("Test message timestamp must be a valid Slack ts");
+}
 
 const TEST_SLACK_CONTEXT: SlackToolContext = {
   destination: {
@@ -19,12 +25,12 @@ const TEST_SLACK_CONTEXT: SlackToolContext = {
   source: createSlackSource({
     teamId: "T123",
     channelId: "C123",
-    messageTs: "1700000000.100",
+    messageTs: TEST_MESSAGE_TS,
 
     type: "priv",
   }),
   destinationChannelId: "C123",
-  messageTs: "1700000000.100",
+  messageTs: TEST_MESSAGE_TS,
   sourceChannelId: "C123",
   teamId: "T123",
 };

--- a/specs/resource-event-subscriptions.md
+++ b/specs/resource-event-subscriptions.md
@@ -244,6 +244,11 @@ Rules:
    delivered to Slack conversations.
 4. Runtime prompt guidance must tell the agent to use subscription intent to
    decide whether a reply or follow-up action is warranted.
+5. Slack event notifications are synthetic mailbox messages, not native Slack
+   messages. Their internal message ids must not be written to Slack `ts`,
+   `message_ts`, or other Slack Web API timestamp fields, and they must not
+   drive message-targeting Slack side effects such as automatic processing
+   reactions.
 
 ### GitHub Pull Request MVP
 

--- a/specs/slack-agent-delivery.md
+++ b/specs/slack-agent-delivery.md
@@ -134,7 +134,7 @@ Junior must acknowledge Slack messages it is handling with an automatic processi
 Current rules:
 
 1. DM and explicit-mention handlers add `:eyes:` before turn preparation or assistant execution.
-2. Subscribed-thread handlers add `:eyes:` only after preflight and passive reply routing return `shouldReply: true`, immediately before assistant execution.
+2. Subscribed-thread handlers add `:eyes:` only after preflight and passive reply routing return `shouldReply: true`, immediately before assistant execution. Synthetic resource-event notifications are not native Slack messages and do not receive automatic processing reactions.
 3. Batched or steered Slack messages that Junior durably accepts into an active turn also get `:eyes:` so each handled user message has the same visible acknowledgement.
 4. When the accepted message completes with a final delivered reply or successful side effect, Junior replaces the automatic `:eyes:` with `:white_check_mark:`.
 5. Skipped subscribed-thread messages, including passive no-reply and opt-out decisions, do not add or remove an automatic reaction.

--- a/specs/slack-outbound-contract.md
+++ b/specs/slack-outbound-contract.md
@@ -86,6 +86,7 @@ Current rules:
 2. `already_reacted` is treated as idempotent success for add-reaction operations.
 3. `no_reaction` is treated as idempotent success for remove-reaction operations.
 4. Other Slack reaction failures still surface as action failures.
+5. Message-targeting Slack Web API timestamp fields must come from parsed native Slack message timestamps. Synthetic mailbox ids, including resource-event notification ids, must never be used as Slack `ts` or `message_ts` targets.
 
 ### 7. Retry and Error Mapping Contract
 


### PR DESCRIPTION
Prevent synthetic resource-event mailbox ids from crossing into Slack message-targeting APIs.

Resource-event notifications now serialize without a native Slack raw.ts, and Slack reaction/delete/resume/tool paths require a schema-branded SlackMessageTs parsed from native Slack timestamp fields. Durable resume and vision helpers now use explicit persisted meta.slackTs rather than inferring provider context from message ids.

This also updates the Slack/resource-event contracts so synthetic notifications are documented as mailbox context rather than native Slack messages, and adds regression coverage for historical malformed raw.ts payloads plus serializer output.

Found while investigating production Slack reactions.add message_not_found errors.

Fixes JUNIOR-3B