### PR TITLE
ref(chat): Align agent execution boundary with run/slice terminology and outcome contract

### DIFF
--- a/packages/junior-evals/src/behavior-harness.ts
+++ b/packages/junior-evals/src/behavior-harness.ts
@@ -40,9 +40,11 @@ import {
   scheduleSessionCompletedPluginTasks,
 } from "@/chat/plugins/task-runner";
 import type { PluginTaskQueueMessage } from "@/chat/plugins/task-message";
-import { generateAssistantReply } from "@/chat/respond";
+import { executeAgentRun } from "@/chat/agent-run";
+import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { resumeAwaitingSlackContinuation } from "@/chat/runtime/agent-continue-runner";
 import { scheduleAgentContinue } from "@/chat/services/agent-continue";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import {
   createSchedulerSqlStore,
   schedulerPlugin,
@@ -1485,113 +1487,121 @@ function buildRuntimeServices(
         }
       : {}),
     replyExecutor: {
-      generateAssistantReply: async (text, context) => {
-        replyCallCount += 1;
-        const mockImageGeneration = scenario.overrides?.mock_image_generation;
-        if (scenario.overrides?.fail_reply_call === replyCallCount) {
-          throw new Error(`forced reply failure on call ${replyCallCount}`);
-        }
-        const replyResult = replyResults[replyCallCount - 1];
-        if (replyResult) {
-          if (replyResult.stream_text) {
-            await context?.onTextDelta?.(replyResult.stream_text);
+      agentRunner: {
+        run: async (request) => {
+          replyCallCount += 1;
+          const mockImageGeneration = scenario.overrides?.mock_image_generation;
+          if (scenario.overrides?.fail_reply_call === replyCallCount) {
+            throw new Error(`forced reply failure on call ${replyCallCount}`);
           }
-          replyState.successfulCount += 1;
-          observations.toolInvocations.push(
-            ...(replyResult.tool_invocations ??
-              (replyResult.tool_calls ?? []).map((tool) => ({ tool }))),
-          );
-          return {
-            text: replyResult.text,
-            deliveryMode: "thread",
-            deliveryPlan: {
-              mode: "thread",
-              postThreadText: true,
-              attachFiles: "none",
-            },
-            diagnostics: {
-              assistantMessageCount: replyResult.assistant_message_count ?? 1,
-              ...(replyResult.error_message
-                ? { errorMessage: replyResult.error_message }
-                : {}),
-              modelId: "eval-reply-result",
-              outcome: replyResult.outcome ?? "success",
-              ...(replyResult.stop_reason
-                ? { stopReason: replyResult.stop_reason }
-                : {}),
-              toolCalls: replyResult.tool_calls ?? [],
-              toolErrorCount: replyResult.tool_error_count ?? 0,
-              toolResultCount: replyResult.tool_result_count ?? 0,
-              usedPrimaryText: replyResult.used_primary_text ?? true,
-            },
-          };
-        }
-        const replyText = replyTexts[replyState.successfulCount];
-        if (typeof replyText === "string") {
-          replyState.successfulCount += 1;
-          return {
-            text: replyText,
-            deliveryMode: "thread",
-            deliveryPlan: {
-              mode: "thread",
-              postThreadText: true,
-              attachFiles: "none",
-            },
-            diagnostics: {
-              assistantMessageCount: 1,
-              modelId: "eval-reply-text",
-              outcome: "success",
-              toolCalls: [],
-              toolErrorCount: 0,
-              toolResultCount: 0,
-              usedPrimaryText: true,
-            },
-          };
-        }
+          const replyResult = replyResults[replyCallCount - 1];
+          if (replyResult) {
+            if (replyResult.stream_text) {
+              await request.observers?.onTextDelta?.(replyResult.stream_text);
+            }
+            replyState.successfulCount += 1;
+            observations.toolInvocations.push(
+              ...(replyResult.tool_invocations ??
+                (replyResult.tool_calls ?? []).map((tool) => ({ tool }))),
+            );
+            return completedAgentRun({
+              text: replyResult.text,
+              deliveryMode: "thread",
+              deliveryPlan: {
+                mode: "thread",
+                postThreadText: true,
+                attachFiles: "none",
+              },
+              diagnostics: {
+                assistantMessageCount: replyResult.assistant_message_count ?? 1,
+                ...(replyResult.error_message
+                  ? { errorMessage: replyResult.error_message }
+                  : {}),
+                modelId: "eval-reply-result",
+                outcome: replyResult.outcome ?? "success",
+                ...(replyResult.stop_reason
+                  ? { stopReason: replyResult.stop_reason }
+                  : {}),
+                toolCalls: replyResult.tool_calls ?? [],
+                toolErrorCount: replyResult.tool_error_count ?? 0,
+                toolResultCount: replyResult.tool_result_count ?? 0,
+                usedPrimaryText: replyResult.used_primary_text ?? true,
+              },
+            });
+          }
+          const replyText = replyTexts[replyState.successfulCount];
+          if (typeof replyText === "string") {
+            replyState.successfulCount += 1;
+            return completedAgentRun({
+              text: replyText,
+              deliveryMode: "thread",
+              deliveryPlan: {
+                mode: "thread",
+                postThreadText: true,
+                attachFiles: "none",
+              },
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "eval-reply-text",
+                outcome: "success",
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            });
+          }
 
-        const gatewaySnapshot = snapshotEnv([
-          "AI_GATEWAY_API_KEY",
-          "VERCEL_OIDC_TOKEN",
-        ]);
-        const baseToolOverrides: ToolHooks["toolOverrides"] = {
-          ...(context?.toolOverrides ?? {}),
-        };
-        const toolOverrides = {
-          ...baseToolOverrides,
-          webFetch: createReplayWebFetchDeps(baseToolOverrides),
-          webSearch: createReplayWebSearchDeps(baseToolOverrides),
-          ...(mockImageGeneration
-            ? { imageGenerate: createMockImageGenerateDeps() }
-            : {}),
-        };
-        if (scenario.overrides?.unset_gateway_api_key) {
-          delete process.env.AI_GATEWAY_API_KEY;
-          delete process.env.VERCEL_OIDC_TOKEN;
-        }
-        try {
-          const reply = await generateAssistantReply(text, {
-            ...context,
-            turnDeadlineAtMs: Math.min(
-              context?.turnDeadlineAtMs ?? Number.POSITIVE_INFINITY,
-              Date.now() + replyTimeoutMs,
-            ),
-            onToolInvocation: (invocation) => {
-              observations.toolInvocations.push(
-                toEvalToolInvocation(invocation),
-              );
-            },
-            ...(env.configuredSkillDirs.length > 0
-              ? { skillDirs: env.configuredSkillDirs }
+          const gatewaySnapshot = snapshotEnv([
+            "AI_GATEWAY_API_KEY",
+            "VERCEL_OIDC_TOKEN",
+          ]);
+          const baseToolOverrides: ToolHooks["toolOverrides"] = {
+            ...(request.policy?.toolOverrides ?? {}),
+          };
+          const toolOverrides = {
+            ...baseToolOverrides,
+            webFetch: createReplayWebFetchDeps(baseToolOverrides),
+            webSearch: createReplayWebSearchDeps(baseToolOverrides),
+            ...(mockImageGeneration
+              ? { imageGenerate: createMockImageGenerateDeps() }
               : {}),
-            toolOverrides,
-          });
-          replyState.successfulCount += 1;
-          return reply;
-        } finally {
+          };
           if (scenario.overrides?.unset_gateway_api_key) {
-            gatewaySnapshot.restore();
+            delete process.env.AI_GATEWAY_API_KEY;
+            delete process.env.VERCEL_OIDC_TOKEN;
           }
-        }
+          try {
+            const outcome = await executeAgentRun({
+              ...request,
+              policy: {
+                ...request.policy,
+                turnDeadlineAtMs: Math.min(
+                  request.policy?.turnDeadlineAtMs ?? Number.POSITIVE_INFINITY,
+                  Date.now() + replyTimeoutMs,
+                ),
+                ...(env.configuredSkillDirs.length > 0
+                  ? { skillDirs: env.configuredSkillDirs }
+                  : {}),
+                toolOverrides,
+              },
+              observers: {
+                ...request.observers,
+                onToolInvocation: (invocation) => {
+                  observations.toolInvocations.push(
+                    toEvalToolInvocation(invocation),
+                  );
+                },
+              },
+            });
+            replyState.successfulCount += 1;
+            return outcome;
+          } finally {
+            if (scenario.overrides?.unset_gateway_api_key) {
+              gatewaySnapshot.restore();
+            }
+          }
+        },
       },
       scheduleAgentContinue: async (request) => {
         await scheduleAgentContinue(request, {
@@ -1637,7 +1647,7 @@ function buildRuntimeServices(
 async function processEvents(args: {
   scenario: EvalScenario;
   env: HarnessEnvironment;
-  generateAssistantReply: typeof generateAssistantReply;
+  agentRunner: AgentRunner;
   getSlackAdapter: () => FakeSlackAdapter;
   conversationWorkQueue: ConversationWorkQueueTestAdapter;
   slackRuntime: ReturnType<typeof createSlackRuntime>;
@@ -1647,7 +1657,7 @@ async function processEvents(args: {
   const {
     scenario,
     env,
-    generateAssistantReply,
+    agentRunner,
     getSlackAdapter,
     conversationWorkQueue,
     slackRuntime,
@@ -1713,7 +1723,7 @@ async function processEvents(args: {
             getSlackAdapter: () => getSlackAdapter() as unknown as SlackAdapter,
             resumeAwaitingContinuation: async (conversationId) =>
               await resumeAwaitingSlackContinuation(conversationId, {
-                generateReply: generateAssistantReply,
+                agentRunner,
                 scheduleAgentContinue: async (request) => {
                   await scheduleAgentContinue(request, {
                     queue: conversationWorkQueue,
@@ -1869,7 +1879,7 @@ async function processEvents(args: {
       if (!callback) {
         throw new Error("Scheduled eval dispatch callback was not captured.");
       }
-      await runAgentDispatchSlice(callback, { generateAssistantReply });
+      await runAgentDispatchSlice(callback, { agentRunner });
     }
   };
 
@@ -2024,9 +2034,8 @@ export async function runEvalScenario(
       observations,
       conversationWorkQueue,
     );
-    const generateEvalAssistantReply =
-      services.replyExecutor?.generateAssistantReply;
-    if (!generateEvalAssistantReply) {
+    const evalAgentRunner = services.replyExecutor?.agentRunner;
+    if (!evalAgentRunner) {
       throw new Error("Eval reply executor was not configured.");
     }
 
@@ -2038,7 +2047,7 @@ export async function runEvalScenario(
     await processEvents({
       scenario,
       env,
-      generateAssistantReply: generateEvalAssistantReply,
+      agentRunner: evalAgentRunner,
       getSlackAdapter: () => slackAdapter,
       conversationWorkQueue,
       slackRuntime,

--- a/packages/junior/src/app.ts
+++ b/packages/junior/src/app.ts
@@ -63,7 +63,7 @@ import {
   createProductionConversationWorkOptions,
   createProductionSlackWebhookServices,
 } from "@/chat/app/production";
-import { withSandboxTracePropagation } from "@/chat/app/services";
+import { createAgentRunner } from "@/chat/runtime/agent-runner";
 import type { WaitUntilFn } from "@/handlers/types";
 
 export { defineJuniorPlugins } from "./plugins";
@@ -592,10 +592,9 @@ export async function createApp(options?: JuniorAppOptions): Promise<Hono> {
   const slackWebhookServices = createProductionSlackWebhookServices({
     services: runtimeServiceOverrides,
   });
-  const generateReplyWithTracePropagation = withSandboxTracePropagation(
-    generateAssistantReply,
-    runtimeServiceOverrides.sandbox.tracePropagation,
-  );
+  const agentRunner = createAgentRunner(generateAssistantReply, {
+    tracePropagation: runtimeServiceOverrides.sandbox.tracePropagation,
+  });
 
   const app = new Hono();
 
@@ -629,18 +628,19 @@ export async function createApp(options?: JuniorAppOptions): Promise<Hono> {
   // because Hono matches routes top-down and `:provider` would swallow `mcp/`.
   app.get("/api/oauth/callback/mcp/:provider", (c) => {
     return mcpOauthCallbackGET(c.req.raw, c.req.param("provider"), waitUntil, {
-      generateReply: generateReplyWithTracePropagation,
+      agentRunner,
     });
   });
 
   app.get("/api/oauth/callback/:provider", (c) => {
     return oauthCallbackGET(c.req.raw, c.req.param("provider"), waitUntil, {
-      generateReply: generateReplyWithTracePropagation,
+      agentRunner,
     });
   });
 
   app.post("/api/internal/agent-dispatch", (c) => {
     return agentDispatchPOST(c.req.raw, waitUntil, {
+      agentRunner,
       tracePropagation: { domains: sandboxEgressTracePropagationDomains },
     });
   });

--- a/packages/junior/src/app.ts
+++ b/packages/junior/src/app.ts
@@ -11,7 +11,7 @@ import {
 import { getSlackReactionConfig, setSlackReactionConfig } from "@/chat/config";
 import { getDb } from "@/chat/db";
 import { logException } from "@/chat/logging";
-import { generateAssistantReply } from "@/chat/respond";
+import { executeAgentRun } from "@/chat/agent-run";
 import { normalizeSandboxEgressTracePropagationDomains } from "@/chat/sandbox/egress/tracing";
 import { pluginCatalogRuntime } from "@/chat/plugins/catalog-runtime";
 import {
@@ -592,7 +592,7 @@ export async function createApp(options?: JuniorAppOptions): Promise<Hono> {
   const slackWebhookServices = createProductionSlackWebhookServices({
     services: runtimeServiceOverrides,
   });
-  const agentRunner = createAgentRunner(generateAssistantReply, {
+  const agentRunner = createAgentRunner(executeAgentRun, {
     tracePropagation: runtimeServiceOverrides.sandbox.tracePropagation,
   });
 

--- a/packages/junior/src/chat/agent-dispatch/runner.ts
+++ b/packages/junior/src/chat/agent-dispatch/runner.ts
@@ -10,7 +10,9 @@ import { botConfig } from "@/chat/config";
 import {
   generateAssistantReply as generateAssistantReplyImpl,
   type AssistantReply,
+  type AssistantReplyRequestContext,
 } from "@/chat/respond";
+import type { AgentRunOutcome } from "@/chat/runtime/agent-run-outcome";
 import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress/tracing";
 import { logException } from "@/chat/logging";
 import {
@@ -46,7 +48,6 @@ import { persistWithRetry } from "@/chat/services/persist-retry";
 import { AuthorizationFlowDisabledError } from "@/chat/services/auth-pause";
 import { PluginCredentialFailureError } from "@/chat/services/plugin-auth-orchestration";
 import { scheduleSessionCompletedPluginTasks } from "@/chat/plugins/task-runner";
-import { isRetryableTurnError } from "@/chat/runtime/turn";
 import { scheduleDispatchCallback } from "./signing";
 import {
   getDispatchConversationId,
@@ -63,7 +64,10 @@ import type { DispatchCallback, DispatchRecord } from "./types";
 const DISPATCH_SLICE_LEASE_MS = 5 * 60 * 1000;
 
 export interface AgentDispatchRunnerDeps {
-  generateAssistantReply?: typeof generateAssistantReplyImpl;
+  generateAssistantReply?: (
+    messageText: string,
+    context: AssistantReplyRequestContext,
+  ) => Promise<AgentRunOutcome>;
   scheduleCallback?: typeof scheduleDispatchCallback;
   scheduleSessionCompletedPluginTasks?: typeof scheduleSessionCompletedPluginTasks;
   tracePropagation?: SandboxEgressTracePropagationConfig;
@@ -296,7 +300,7 @@ export async function runAgentDispatchSlice(
       excludeMessageId: userMessageId,
     });
 
-    let reply = await generateAssistantReply(dispatch.input, {
+    const outcome = await generateAssistantReply(dispatch.input, {
       authorizationFlowMode: "disabled",
       credentialContext: {
         actor: dispatch.actor,
@@ -353,6 +357,33 @@ export async function runAgentDispatchSlice(
         });
       },
     });
+    if (outcome.status === "awaiting_auth") {
+      await markDispatch({
+        dispatch,
+        status: "blocked",
+        errorMessage:
+          "Dispatch requires authorization from an interactive user turn.",
+      });
+      return;
+    }
+    if (outcome.status === "timed_out" || outcome.status === "yielded") {
+      if (typeof outcome.version === "number") {
+        const awaiting = await markDispatch({
+          dispatch,
+          status: "awaiting_resume",
+        });
+        await scheduleCallback({
+          id: awaiting.id,
+          expectedVersion: awaiting.version,
+        });
+        return;
+      }
+      throw new Error(
+        `Dispatch continuation ended with ${outcome.status} without a session record version`,
+      );
+    }
+
+    let reply = outcome.reply;
 
     const failure =
       reply.diagnostics.outcome === "success"
@@ -489,33 +520,6 @@ export async function runAgentDispatchSlice(
       });
       return;
     }
-    if (
-      isRetryableTurnError(error, "mcp_auth_resume") ||
-      isRetryableTurnError(error, "plugin_auth_resume")
-    ) {
-      await markDispatch({
-        dispatch,
-        status: "blocked",
-        errorMessage:
-          "Dispatch requires authorization from an interactive user turn.",
-      });
-      return;
-    }
-    if (isRetryableTurnError(error, "agent_continue")) {
-      const version = error.metadata?.version;
-      if (typeof version === "number") {
-        const awaiting = await markDispatch({
-          dispatch,
-          status: "awaiting_resume",
-        });
-        await scheduleCallback({
-          id: awaiting.id,
-          expectedVersion: awaiting.version,
-        });
-        return;
-      }
-    }
-
     logException(
       error,
       "agent_dispatch_run_failed",

--- a/packages/junior/src/chat/agent-dispatch/runner.ts
+++ b/packages/junior/src/chat/agent-dispatch/runner.ts
@@ -291,61 +291,72 @@ export async function runAgentDispatchSlice(
       excludeMessageId: userMessageId,
     });
 
-    const outcome = await deps.agentRunner.run(dispatch.input, {
-      authorizationFlowMode: "disabled",
-      credentialContext: {
-        actor: dispatch.actor,
-        ...(dispatch.credentialSubject
-          ? { subject: dispatch.credentialSubject }
-          : {}),
+    const outcome = await deps.agentRunner.run({
+      input: {
+        messageText: dispatch.input,
+        conversationContext,
+        piMessages: conversation.piMessages,
       },
-      configuration,
-      channelConfiguration,
-      conversationContext,
-      artifactState: artifacts,
-      piMessages: conversation.piMessages,
-      destination: dispatch.destination,
-      source: dispatch.source,
-      dispatch: {
-        actor: dispatch.actor,
-        metadata: dispatch.metadata,
-        plugin: dispatch.plugin,
-      },
-      correlation: {
-        conversationId,
-        threadId: conversationId,
-        turnId,
-        runId: dispatch.id,
-        channelId: dispatch.destination.channelId,
-        teamId: dispatch.destination.teamId,
-      },
-      surface: "api",
-      toolChannelId: dispatch.destination.channelId,
-      sandbox: {
-        sandboxId,
-        sandboxDependencyProfileHash,
-        tracePropagation: deps.tracePropagation,
-      },
-      onSandboxAcquired: async (sandbox) => {
-        sandboxId = sandbox.sandboxId;
-        sandboxDependencyProfileHash = sandbox.sandboxDependencyProfileHash;
-        await persistRuntimePatch({
+      routing: {
+        credentialContext: {
+          actor: dispatch.actor,
+          ...(dispatch.credentialSubject
+            ? { subject: dispatch.credentialSubject }
+            : {}),
+        },
+        destination: dispatch.destination,
+        source: dispatch.source,
+        dispatch: {
+          actor: dispatch.actor,
+          metadata: dispatch.metadata,
+          plugin: dispatch.plugin,
+        },
+        correlation: {
+          conversationId,
           threadId: conversationId,
-          conversation,
-          artifacts,
+          turnId,
+          runId: dispatch.id,
+          channelId: dispatch.destination.channelId,
+          teamId: dispatch.destination.teamId,
+        },
+        surface: "api",
+        toolChannelId: dispatch.destination.channelId,
+      },
+      policy: {
+        authorizationFlowMode: "disabled",
+        configuration,
+        channelConfiguration,
+        sandbox: {
           sandboxId,
           sandboxDependencyProfileHash,
-        });
+          tracePropagation: deps.tracePropagation,
+        },
       },
-      onArtifactStateUpdated: async (nextArtifacts) => {
-        artifacts = nextArtifacts;
-        await persistRuntimePatch({
-          threadId: conversationId,
-          conversation,
-          artifacts,
-          sandboxId,
-          sandboxDependencyProfileHash,
-        });
+      state: {
+        artifactState: artifacts,
+      },
+      durability: {
+        onSandboxAcquired: async (sandbox) => {
+          sandboxId = sandbox.sandboxId;
+          sandboxDependencyProfileHash = sandbox.sandboxDependencyProfileHash;
+          await persistRuntimePatch({
+            threadId: conversationId,
+            conversation,
+            artifacts,
+            sandboxId,
+            sandboxDependencyProfileHash,
+          });
+        },
+        onArtifactStateUpdated: async (nextArtifacts) => {
+          artifacts = nextArtifacts;
+          await persistRuntimePatch({
+            threadId: conversationId,
+            conversation,
+            artifacts,
+            sandboxId,
+            sandboxDependencyProfileHash,
+          });
+        },
       },
     });
     if (outcome.status === "awaiting_auth") {

--- a/packages/junior/src/chat/agent-dispatch/runner.ts
+++ b/packages/junior/src/chat/agent-dispatch/runner.ts
@@ -7,12 +7,8 @@
  * state, and schedules follow-up slices when a turn needs to continue.
  */
 import { botConfig } from "@/chat/config";
-import {
-  generateAssistantReply as generateAssistantReplyImpl,
-  type AssistantReply,
-  type AssistantReplyRequestContext,
-} from "@/chat/respond";
-import type { AgentRunOutcome } from "@/chat/runtime/agent-run-outcome";
+import type { AssistantReply } from "@/chat/respond";
+import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress/tracing";
 import { logException } from "@/chat/logging";
 import {
@@ -64,10 +60,7 @@ import type { DispatchCallback, DispatchRecord } from "./types";
 const DISPATCH_SLICE_LEASE_MS = 5 * 60 * 1000;
 
 export interface AgentDispatchRunnerDeps {
-  generateAssistantReply?: (
-    messageText: string,
-    context: AssistantReplyRequestContext,
-  ) => Promise<AgentRunOutcome>;
+  agentRunner: AgentRunner;
   scheduleCallback?: typeof scheduleDispatchCallback;
   scheduleSessionCompletedPluginTasks?: typeof scheduleSessionCompletedPluginTasks;
   tracePropagation?: SandboxEgressTracePropagationConfig;
@@ -176,10 +169,8 @@ function canClaimDispatch(record: DispatchRecord, nowMs: number): boolean {
 /** Run one serverless slice for a core-owned agent dispatch. */
 export async function runAgentDispatchSlice(
   callback: DispatchCallback,
-  deps: AgentDispatchRunnerDeps = {},
+  deps: AgentDispatchRunnerDeps,
 ): Promise<void> {
-  const generateAssistantReply =
-    deps.generateAssistantReply ?? generateAssistantReplyImpl;
   const scheduleCallback = deps.scheduleCallback ?? scheduleDispatchCallback;
   const scheduleCompletedTasks =
     deps.scheduleSessionCompletedPluginTasks ??
@@ -300,7 +291,7 @@ export async function runAgentDispatchSlice(
       excludeMessageId: userMessageId,
     });
 
-    const outcome = await generateAssistantReply(dispatch.input, {
+    const outcome = await deps.agentRunner.run(dispatch.input, {
       authorizationFlowMode: "disabled",
       credentialContext: {
         actor: dispatch.actor,

--- a/packages/junior/src/chat/agent-dispatch/runner.ts
+++ b/packages/junior/src/chat/agent-dispatch/runner.ts
@@ -7,7 +7,7 @@
  * state, and schedules follow-up slices when a turn needs to continue.
  */
 import { botConfig } from "@/chat/config";
-import type { AssistantReply } from "@/chat/respond";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress/tracing";
 import { logException } from "@/chat/logging";
@@ -78,7 +78,7 @@ function buildDispatchConversationText(dispatch: DispatchRecord): string {
   return `[dispatched task] ${dispatch.input}`;
 }
 
-function ensureVisibleDeliveryText(reply: AssistantReply): AssistantReply {
+function ensureVisibleDeliveryText(reply: AgentRunResult): AgentRunResult {
   if (reply.text.trim().length > 0 || !reply.files?.length) {
     return reply;
   }
@@ -385,7 +385,7 @@ export async function runAgentDispatchSlice(
       );
     }
 
-    let reply = outcome.reply;
+    let reply = outcome.result;
 
     const failure =
       reply.diagnostics.outcome === "success"

--- a/packages/junior/src/chat/agent-run-helpers.ts
+++ b/packages/junior/src/chat/agent-run-helpers.ts
@@ -1,5 +1,5 @@
 /**
- * Pure helper functions used by the agent reply orchestration in respond.ts.
+ * Pure helper functions used by the agent-run orchestration in agent-run.ts.
  *
  * These are extracted to reduce the size of the main orchestration module and
  * make individual helpers independently testable.

--- a/packages/junior/src/chat/agent-run.ts
+++ b/packages/junior/src/chat/agent-run.ts
@@ -1,16 +1,14 @@
 /**
- * Agent turn orchestration.
+ * Agent run orchestration.
  *
- * This module owns the Pi-facing execution boundary for one Junior turn after
+ * This module owns the Pi-facing execution boundary for one Junior run after
  * Slack/runtime code has parsed and routed the request. It assembles prompt context,
  * restores durable Pi/session state, wires tools/MCP/auth, executes the agent,
  * and persists resumable checkpoints. Slack delivery and thread presentation
  * should stay outside this file.
  */
-import { Agent, type AgentTool } from "@earendil-works/pi-agent-core";
-import type { Destination, Source } from "@sentry/junior-plugin-api";
+import { Agent } from "@earendil-works/pi-agent-core";
 import { THREAD_STATE_TTL_MS, type FileUpload } from "chat";
-import { z } from "zod";
 import { botConfig } from "@/chat/config";
 import {
   extractGenAiUsageAttributes,
@@ -20,59 +18,23 @@ import {
   logWarn,
   serializeGenAiAttribute,
   setSpanAttributes,
-  setTags,
   withSpan,
   type LogContext,
 } from "@/chat/logging";
-import { listReferenceFiles } from "@/chat/discovery";
-import {
-  buildPluginSystemPromptContributions,
-  buildSystemPrompt,
-  buildTurnContextPrompt,
-} from "@/chat/prompt";
-import {
-  extractCurrentInstructionBody,
-  renderCurrentInstruction,
-} from "@/chat/current-instruction";
-import { createUserTokenStore } from "@/chat/capabilities/factory";
-import { maybeExecuteJrRpcCustomCommand } from "@/chat/capabilities/jr-rpc-command";
 import { getConfigDefaults } from "@/chat/configuration/defaults";
-import type { ChannelConfigurationService } from "@/chat/configuration/types";
 import { SkillSandbox } from "@/chat/sandbox/skill-sandbox";
 import {
-  discoverSkills,
   findSkillByName,
   parseSkillInvocation,
   type Skill,
 } from "@/chat/skills";
-import { pluginCatalogRuntime } from "@/chat/plugins/catalog-runtime";
-import {
-  createPluginHookRunner,
-  getPluginSystemPromptContributions,
-  getPluginUserPromptContributions,
-} from "@/chat/plugins/agent-hooks";
 import { McpToolManager } from "@/chat/mcp/tool-manager";
-import {
-  inferActiveMcpProvidersFromPiMessages,
-  inferLoadedSkillNamesFromPiMessages,
-} from "@/chat/pi/derived-state";
 import type { ThreadArtifactsState } from "@/chat/state/artifacts";
-import type { ConversationPendingAuthState } from "@/chat/state/conversation";
 import {
   loadConnectedMcpProviders,
   recordToolExecutionStarted,
   recordMcpProviderConnected,
 } from "@/chat/state/session-log";
-import { createTools } from "@/chat/tools";
-import type { ToolDefinition } from "@/chat/tools/definition";
-import { toActiveMcpCatalogSummaries } from "@/chat/tools/skill/mcp-tool-summary";
-import type {
-  ImageGenerateToolDeps,
-  ToolRuntimeContext,
-  WebFetchToolDeps,
-  WebSearchToolDeps,
-} from "@/chat/tools/types";
-import { createAdvisorToolDefinitions } from "@/chat/tools/advisor/tool";
 import {
   GEN_AI_PROVIDER_NAME,
   GEN_AI_SERVER_ADDRESS,
@@ -83,41 +45,17 @@ import {
 } from "@/chat/pi/client";
 import type { PiMessage } from "@/chat/pi/messages";
 import { createTracedStreamFn } from "@/chat/pi/traced-stream";
-import {
-  createSandboxExecutor,
-  type SandboxAcquiredState,
-  type SandboxExecutor,
-} from "@/chat/sandbox/sandbox";
-import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress/tracing";
-import type { SandboxWorkspace } from "@/chat/sandbox/workspace";
+import type { SandboxExecutor } from "@/chat/sandbox/sandbox";
 import { shouldEmitDevAgentTrace } from "@/chat/runtime/dev-agent-trace";
-import type { AssistantStatusSpec } from "@/chat/slack/assistant-thread/status";
-import type { SlackConversationContext } from "@/chat/slack/conversation-context";
-import {
-  createAgentTools,
-  type ToolExecutionReport,
-} from "@/chat/tools/agent-tools";
-import { mergeArtifactsState } from "@/chat/runtime/thread-state";
-import {
-  CooperativeTurnYieldError,
-  TurnInputCommitLostError,
-  isTurnInputCommitLostError,
-} from "@/chat/runtime/turn";
+import { isTurnInputCommitLostError } from "@/chat/runtime/turn";
 import {
   completedAgentRun,
   failedAgentRun,
   type AgentRunOutcome,
 } from "@/chat/runtime/agent-run-outcome";
 import {
-  buildUserTurnText,
-  encodeNonImageAttachmentForPrompt,
-  getSessionIdentifiers,
-  hasRuntimeTurnContext,
   isAssistantMessage,
-  stripRuntimeTurnContext,
   summarizeMessageText,
-  toObservablePromptPart,
-  upsertActiveSkill,
 } from "@/chat/agent-run-helpers";
 import { buildTurnResult } from "@/chat/services/turn-result";
 import {
@@ -134,25 +72,10 @@ import {
   hasAgentTurnUsage,
   type AgentTurnUsage,
 } from "@/chat/usage";
-import {
-  loadTurnSessionRecord,
-  persistAuthPauseSessionRecord,
-  persistRunningSessionRecord,
-  persistTimeoutSessionRecord,
-  persistYieldSessionRecord,
-} from "@/chat/services/turn-session-record";
 import type { AgentTurnSurface } from "@/chat/state/turn-session";
-import type { CredentialContext } from "@/chat/credentials/context";
 import { parseSlackThreadId } from "@/chat/slack/context";
-import { createMcpAuthOrchestration } from "@/chat/services/mcp-auth-orchestration";
-import { createPluginAuthOrchestration } from "@/chat/services/plugin-auth-orchestration";
-import { createPluginEgress } from "@/chat/egress/plugin";
 import { createRequester, type Requester } from "@/chat/requester";
-import {
-  AuthorizationFlowDisabledError,
-  AuthorizationPauseError,
-  type AuthorizationFlowMode,
-} from "@/chat/services/auth-pause";
+import { AuthorizationFlowDisabledError } from "@/chat/services/auth-pause";
 import {
   resolveConversationPrivacy,
   runWithConversationPrivacy,
@@ -160,6 +83,39 @@ import {
   toGenAiMessagesTraceAttributes,
   type ConversationPrivacy,
 } from "@/chat/conversation-privacy";
+import {
+  createSliceCheckpointer,
+  type SliceCheckpointer,
+} from "@/chat/agent-run/checkpointer";
+import { restoreSessionRecord } from "@/chat/agent-run/session-restore";
+import {
+  discoverRunSkills,
+  restoreSkillRuntime,
+} from "@/chat/agent-run/skills";
+import { subscribeToAgentEvents } from "@/chat/agent-run/events";
+import {
+  assemblePrompt,
+  buildPromptInput,
+  buildSteeringPiMessage,
+} from "@/chat/agent-run/prompt";
+import { wireAgentTools } from "@/chat/agent-run/tools";
+import type {
+  AgentRunRequest,
+  AgentRunRouting,
+} from "@/chat/agent-run/request";
+
+export { buildSteeringPiMessage } from "@/chat/agent-run/prompt";
+export type {
+  AgentRunAttachment,
+  AgentRunDurability,
+  AgentRunInput,
+  AgentRunObservers,
+  AgentRunPolicy,
+  AgentRunRequest,
+  AgentRunRouting,
+  AgentRunState,
+  AgentRunSteeringMessage,
+} from "@/chat/agent-run/request";
 
 const AGENT_ABORT_SETTLE_GRACE_MS = 5_000;
 
@@ -201,199 +157,13 @@ function waitForAbortSettlement(
   });
 }
 
-/** Carries the user-visible content and prior transcript for one agent-run slice. */
-export interface AgentRunInput {
-  messageText: string;
-  userAttachments?: AgentRunAttachment[];
-  inboundAttachmentCount?: number;
-  omittedImageAttachmentCount?: number;
-  /** Durable Pi transcript for this conversation, excluding ephemeral turn context. */
-  piMessages?: PiMessage[];
-  conversationContext?: string;
-}
-
-/** Carries identity and addressing needed to route tools, auth, and delivery. */
-export interface AgentRunRouting {
-  credentialContext?: CredentialContext;
-  requester?: Requester;
-  source: Source;
-  slackConversation?: SlackConversationContext;
-  destination: Destination;
-  surface?: AgentTurnSurface;
-  dispatch?: {
-    actor?: { id: string; type: string };
-    metadata?: Record<string, string>;
-    plugin?: string;
-  };
-  correlation?: {
-    conversationId?: string;
-    threadId?: string;
-    turnId?: string;
-    runId?: string;
-    channelId?: string;
-    channelName?: string;
-    teamId?: string;
-    messageTs?: string;
-    threadTs?: string;
-    requesterId?: string;
-  };
-  toolChannelId?: string;
-}
-
-/** Carries execution limits and dependency overrides for one run slice. */
-export interface AgentRunPolicy {
-  /** Absolute wall-clock deadline for this host request, in milliseconds. */
-  turnDeadlineAtMs?: number;
-  authorizationFlowMode?: AuthorizationFlowMode;
-  configuration?: Record<string, unknown>;
-  channelConfiguration?: ChannelConfigurationService;
-  skillDirs?: string[];
-  sandbox?: {
-    sandboxId?: string;
-    sandboxDependencyProfileHash?: string;
-    /** Per-slice override for app-owned sandbox egress trace propagation. */
-    tracePropagation?: SandboxEgressTracePropagationConfig;
-  };
-  toolOverrides?: {
-    imageGenerate?: ImageGenerateToolDeps;
-    webFetch?: WebFetchToolDeps;
-    webSearch?: WebSearchToolDeps;
-  };
-}
-
-/** Carries durable state snapshots already loaded by the caller. */
-export interface AgentRunState {
-  artifactState?: ThreadArtifactsState;
-  pendingAuth?: ConversationPendingAuthState;
-}
-
-/** Carries non-blocking notifications for streaming UI and status surfaces. */
-export interface AgentRunObservers {
-  onTextDelta?: (deltaText: string) => void | Promise<void>;
-  onAssistantMessageStart?: () => void | Promise<void>;
-  onToolInvocation?: (invocation: {
-    toolName: string;
-    params: Record<string, unknown>;
-  }) => void | Promise<void>;
-  onToolResult?: (result: ToolExecutionReport) => void | Promise<void>;
-  onStatus?: (status: AssistantStatusSpec) => void | Promise<void>;
-}
-
-/** Carries durable-worker ports that commit or update resumable run state. */
-export interface AgentRunDurability {
-  onInputCommitted?: () => void | Promise<void>;
-  /** Return true when the durable worker should pause at the next Pi boundary. */
-  shouldYield?: () => boolean;
-  drainSteeringMessages?: (
-    accept: (messages: AgentRunSteeringMessage[]) => Promise<void>,
-  ) => Promise<AgentRunSteeringMessage[]>;
-  recordPendingAuth?: (
-    pendingAuth: ConversationPendingAuthState,
-  ) => void | Promise<void>;
-  onSandboxAcquired?: (sandbox: SandboxAcquiredState) => void | Promise<void>;
-  onArtifactStateUpdated?: (
-    artifactState: ThreadArtifactsState,
-  ) => void | Promise<void>;
-}
-
-/** Groups the per-slice agent-run request by the runtime role each field serves. */
-export interface AgentRunRequest {
-  input: AgentRunInput;
-  routing: AgentRunRouting;
-  policy?: AgentRunPolicy;
-  state?: AgentRunState;
-  observers?: AgentRunObservers;
-  durability?: AgentRunDurability;
-}
-
-type FlatAgentRunRequest = AgentRunInput &
-  AgentRunRouting &
-  AgentRunPolicy &
-  AgentRunState &
-  AgentRunObservers &
-  AgentRunDurability;
-
-function flattenAgentRunRequest(request: AgentRunRequest): FlatAgentRunRequest {
-  return {
-    ...request.input,
-    ...request.routing,
-    ...(request.policy ?? {}),
-    ...(request.state ?? {}),
-    ...(request.observers ?? {}),
-    ...(request.durability ?? {}),
-  };
-}
-
-export interface AgentRunAttachment {
-  data?: Buffer;
-  mediaType: string;
-  filename?: string;
-  promptText?: string;
-}
-
-export interface AgentRunSteeringMessage {
-  omittedImageAttachmentCount?: number;
-  text: string;
-  timestampMs?: number;
-  userAttachments?: AgentRunAttachment[];
-}
-
-let startupDiscoveryLogged = false;
-const MAX_ROUTER_ATTACHMENT_PREVIEW_CHARS = 2_000;
-
-type UserTurnContentPart =
-  | { type: "text"; text: string }
-  | { type: "image"; data: string; mimeType: string };
-
-const legacyStoredTextPartSchema = z
-  .object({
-    text: z.string(),
-    type: z.literal("text"),
-  })
-  .strict();
-
-type UserTurnAttachment = NonNullable<AgentRunInput["userAttachments"]>[number];
-
-function buildOmittedImageAttachmentNotice(count: number): string {
-  return [
-    "<omitted-image-attachments>",
-    `count: ${count}`,
-    "Slack included image attachments with this turn, but this runtime cannot analyze images because no vision model is configured.",
-    "Do not claim that no image was attached.",
-    "If the user asks about image contents, explain that image analysis is unavailable in this runtime and continue with any text or non-image files that are still available.",
-    "</omitted-image-attachments>",
-  ].join("\n");
-}
-
-function trimRouterAttachmentText(text: string): string {
-  const normalized = text.replaceAll("\0", " ").trim();
-  if (!normalized) {
-    return "";
-  }
-  return normalized.length <= MAX_ROUTER_ATTACHMENT_PREVIEW_CHARS
-    ? normalized
-    : `${normalized.slice(0, MAX_ROUTER_ATTACHMENT_PREVIEW_CHARS)}...`;
-}
-
-function extractSliceUsage(
-  messages: PiMessage[],
-  beforeMessageCount: number,
-): AgentTurnUsage | undefined {
-  const usage = extractGenAiUsageSummary(
-    ...messages.slice(beforeMessageCount).filter(isAssistantMessage),
-  );
-  return hasAgentTurnUsage(usage) ? usage : undefined;
-}
-
-function requesterFromContext(
-  context: FlatAgentRunRequest,
-): Requester | undefined {
-  return actorRequesterFromContext(context);
+function requesterFromRouting(routing: AgentRunRouting): Requester | undefined {
+  return actorRequesterFromRouting(routing);
 }
 
 /** Reject requester identities that do not belong to the active destination. */
-function assertRequesterDestinationMatch(context: FlatAgentRunRequest): void {
-  const { destination, requester } = context;
+function assertRequesterDestinationMatch(routing: AgentRunRouting): void {
+  const { destination, requester } = routing;
   if (!requester) {
     return;
   }
@@ -412,8 +182,8 @@ function assertRequesterDestinationMatch(context: FlatAgentRunRequest): void {
 }
 
 /** Reject legacy Slack correlation fields that conflict with the destination. */
-function assertCorrelationDestinationMatch(context: FlatAgentRunRequest): void {
-  const { correlation, destination } = context;
+function assertCorrelationDestinationMatch(routing: AgentRunRouting): void {
+  const { correlation, destination } = routing;
   if (destination.platform !== "slack") {
     return;
   }
@@ -435,48 +205,37 @@ function assertCorrelationDestinationMatch(context: FlatAgentRunRequest): void {
   }
 }
 
-function actorRequesterFromContext(
-  context: FlatAgentRunRequest,
+function actorRequesterFromRouting(
+  routing: AgentRunRouting,
 ): Requester | undefined {
-  return createRequester(context.requester, {
+  return createRequester(routing.requester, {
     platform:
-      context.requester?.platform ??
-      (context.destination.platform === "slack" ? "slack" : undefined),
+      routing.requester?.platform ??
+      (routing.destination.platform === "slack" ? "slack" : undefined),
     teamId:
-      (context.destination.platform === "slack"
-        ? context.destination.teamId
+      (routing.destination.platform === "slack"
+        ? routing.destination.teamId
         : undefined) ??
-      context.correlation?.teamId ??
-      (context.requester?.platform === "slack"
-        ? context.requester.teamId
+      routing.correlation?.teamId ??
+      (routing.requester?.platform === "slack"
+        ? routing.requester.teamId
         : undefined),
-    userId: context.correlation?.requesterId,
+    userId: routing.correlation?.requesterId,
   });
 }
 
-function toolInvocationDestination(context: FlatAgentRunRequest): Destination {
-  if (context.destination.platform !== "slack" || !context.toolChannelId) {
-    return context.destination;
-  }
-  return {
-    platform: "slack",
-    teamId: context.destination.teamId,
-    channelId: context.toolChannelId,
-  };
-}
-
-function surfaceFromContext(
-  context: FlatAgentRunRequest,
+function surfaceFromRouting(
+  routing: AgentRunRouting,
 ): AgentTurnSurface | undefined {
-  if (context.surface) {
-    return context.surface;
+  if (routing.surface) {
+    return routing.surface;
   }
   const conversationId =
-    context.correlation?.conversationId ??
-    context.correlation?.threadId ??
-    context.correlation?.runId;
+    routing.correlation?.conversationId ??
+    routing.correlation?.threadId ??
+    routing.correlation?.runId;
   if (
-    context.slackConversation ||
+    routing.slackConversation ||
     (conversationId ? parseSlackThreadId(conversationId) : undefined)
   ) {
     return "slack";
@@ -487,267 +246,74 @@ function surfaceFromContext(
   return undefined;
 }
 
-function supportsRouterTextPreview(mediaType: string): boolean {
-  const baseMediaType = mediaType.split(";", 1)[0]?.trim().toLowerCase();
-  if (!baseMediaType) {
-    return false;
-  }
-  return (
-    baseMediaType.startsWith("text/") ||
-    baseMediaType === "application/json" ||
-    baseMediaType === "application/xml" ||
-    baseMediaType === "application/x-www-form-urlencoded" ||
-    baseMediaType.endsWith("+json") ||
-    baseMediaType.endsWith("+xml")
-  );
-}
-
-function buildRouterAttachmentBlock(attachment: UserTurnAttachment): string {
-  if (attachment.promptText) {
-    return trimRouterAttachmentText(attachment.promptText);
-  }
-
-  const header = [
-    "<attachment>",
-    `filename: ${attachment.filename ?? "unnamed"}`,
-    `media_type: ${attachment.mediaType}`,
-  ];
-
-  if (attachment.data && supportsRouterTextPreview(attachment.mediaType)) {
-    const preview = trimRouterAttachmentText(attachment.data.toString("utf8"));
-    if (preview) {
-      return [
-        ...header,
-        "<text-preview>",
-        preview,
-        "</text-preview>",
-        "</attachment>",
-      ].join("\n");
-    }
-  }
-
-  return [...header, "</attachment>"].join("\n");
-}
-
-function buildUserTurnInput(args: {
-  omittedImageAttachmentCount: number;
-  userAttachments?: AgentRunInput["userAttachments"];
-  userTurnText: string;
-}): {
-  routerBlocks: string[];
-  userContentParts: UserTurnContentPart[];
-} {
-  const routerBlocks: string[] = [];
-  const userContentParts: UserTurnContentPart[] = [
-    { type: "text", text: args.userTurnText },
-  ];
-
-  if (args.omittedImageAttachmentCount > 0) {
-    const omittedImagesNotice = buildOmittedImageAttachmentNotice(
-      args.omittedImageAttachmentCount,
-    );
-    userContentParts.push({ type: "text", text: omittedImagesNotice });
-    routerBlocks.push(omittedImagesNotice);
-  }
-
-  for (const attachment of args.userAttachments ?? []) {
-    routerBlocks.push(buildRouterAttachmentBlock(attachment));
-
-    if (attachment.promptText) {
-      userContentParts.push({
-        type: "text",
-        text: attachment.promptText,
-      });
-      continue;
-    }
-
-    if (attachment.mediaType.startsWith("image/")) {
-      if (!attachment.data) {
-        throw new Error("Image attachment is missing image data");
-      }
-      userContentParts.push({
-        type: "image",
-        data: attachment.data.toString("base64"),
-        mimeType: attachment.mediaType,
-      });
-      continue;
-    }
-
-    if (!attachment.data) {
-      throw new Error("Attachment is missing attachment data");
-    }
-
-    userContentParts.push({
-      type: "text",
-      text: encodeNonImageAttachmentForPrompt({
-        data: attachment.data,
-        mediaType: attachment.mediaType,
-        filename: attachment.filename,
-      }),
-    });
-  }
-
-  return { routerBlocks, userContentParts };
-}
-
-/**
- * Convert a mid-run user message into the Pi user message shape used for
- * steering injection and parked-conversation session-log appends, so both
- * paths store identical durable history.
- */
-export function buildSteeringPiMessage(
-  message: AgentRunSteeringMessage,
-): PiMessage {
-  const { userContentParts } = buildUserTurnInput({
-    userTurnText: buildUserTurnText(message.text),
-    userAttachments: message.userAttachments,
-    omittedImageAttachmentCount: message.omittedImageAttachmentCount ?? 0,
-  });
-  return {
-    role: "user",
-    content: userContentParts,
-    timestamp: message.timestampMs ?? Date.now(),
-  } as PiMessage;
-}
-
-function withoutTrailingUncheckpointedUserPrompt(
-  messages: PiMessage[] | undefined,
-  userContentParts: UserTurnContentPart[],
-): PiMessage[] {
-  if (!messages || messages.length === 0) {
-    return [];
-  }
-
-  const lastMessage = messages.at(-1) as
-    | { content?: unknown; role?: unknown }
-    | undefined;
-  if (lastMessage?.role !== "user") {
-    return messages;
-  }
-  const comparableLastMessage = stripRuntimeTurnContext([
-    lastMessage as PiMessage,
-  ])[0] as { content?: unknown } | undefined;
-  if (
-    !userPromptContentMatches(comparableLastMessage?.content, userContentParts)
-  ) {
-    return messages;
-  }
-  return messages.slice(0, -1);
-}
-
-/** Match stored resume prompts against the current wrapped prompt shape. */
-function userPromptContentMatches(
-  storedContent: unknown,
-  currentContent: UserTurnContentPart[],
-): boolean {
-  if (JSON.stringify(storedContent) === JSON.stringify(currentContent)) {
-    return true;
-  }
-  if (!Array.isArray(storedContent)) {
-    return false;
-  }
-  if (storedContent.length !== currentContent.length) {
-    return false;
-  }
-
-  return storedContent.every((storedPart, index) => {
-    const currentPart = currentContent[index];
-    if (index === 0 && currentPart?.type === "text") {
-      const legacyTextPart = legacyStoredTextPartSchema.safeParse(storedPart);
-      if (legacyTextPart.success) {
-        // TODO(v0.84.0): Remove legacy unwrapped resume prompt matching after
-        // pre-current-instruction session records expire.
-        return legacyTextPartMatchesCurrentText(
-          legacyTextPart.data.text,
-          currentPart.text,
-        );
-      }
-    }
-
-    return JSON.stringify(storedPart) === JSON.stringify(currentPart);
-  });
-}
-
-function legacyTextPartMatchesCurrentText(
-  storedText: string,
-  currentText: string,
-): boolean {
-  const storedInstructionBody = extractCurrentInstructionBody(storedText);
-  if (storedInstructionBody !== undefined) {
-    return renderCurrentInstruction(storedInstructionBody) === currentText;
-  }
-
-  return renderCurrentInstruction(storedText) === currentText;
-}
-
-/** Run a full agent turn: discover skills, execute tools, and return the assistant reply. */
+/** Run one agent execution slice and return its lifecycle outcome. */
 export async function executeAgentRun(
   request: AgentRunRequest,
 ): Promise<AgentRunOutcome> {
-  const context = flattenAgentRunRequest(request);
-  const messageText = request.input.messageText;
   const conversationPrivacy = resolveConversationPrivacy({
-    channelId: context.correlation?.channelId,
+    channelId: request.routing.correlation?.channelId,
     conversationId:
-      context.correlation?.conversationId ??
-      context.correlation?.threadId ??
-      context.correlation?.runId,
+      request.routing.correlation?.conversationId ??
+      request.routing.correlation?.threadId ??
+      request.routing.correlation?.runId,
     // Source-confirmed visibility from the live event's channel_type; without
-    // it the turn fails closed to private telemetry capture.
-    visibility: context.slackConversation?.visibility,
+    // it the run fails closed to private telemetry capture.
+    visibility: request.routing.slackConversation?.visibility,
   });
   return runWithConversationPrivacy(conversationPrivacy ?? "private", () =>
-    executeAgentRunInPrivacyContext(messageText, context, conversationPrivacy),
+    executeAgentRunInPrivacyContext(request, conversationPrivacy),
   );
 }
 
 async function executeAgentRunInPrivacyContext(
-  messageText: string,
-  context: FlatAgentRunRequest,
+  request: AgentRunRequest,
   conversationPrivacy: ConversationPrivacy | undefined,
 ): Promise<AgentRunOutcome> {
-  if (!context.destination) {
+  const {
+    input,
+    routing,
+    policy = {},
+    state = {},
+    observers = {},
+    durability = {},
+  } = request;
+  const { messageText } = input;
+
+  if (!routing.destination) {
     throw new TypeError("Assistant reply generation requires a destination");
   }
-  assertRequesterDestinationMatch(context);
-  assertCorrelationDestinationMatch(context);
+  assertRequesterDestinationMatch(routing);
+  assertCorrelationDestinationMatch(routing);
 
   const replyStartedAtMs = Date.now();
   const configuredTurnDeadlineAtMs = replyStartedAtMs + botConfig.turnTimeoutMs;
   const contextTurnDeadlineAtMs =
-    typeof context.turnDeadlineAtMs === "number" &&
-    Number.isFinite(context.turnDeadlineAtMs)
-      ? Math.floor(context.turnDeadlineAtMs)
+    typeof policy.turnDeadlineAtMs === "number" &&
+    Number.isFinite(policy.turnDeadlineAtMs)
+      ? Math.floor(policy.turnDeadlineAtMs)
       : undefined;
   const turnDeadlineAtMs =
     contextTurnDeadlineAtMs === undefined
       ? configuredTurnDeadlineAtMs
       : Math.min(configuredTurnDeadlineAtMs, contextTurnDeadlineAtMs);
   const turnTimeoutBudgetMs = Math.max(0, turnDeadlineAtMs - replyStartedAtMs);
-  let timeoutResumeConversationId: string | undefined;
-  let timeoutResumeSessionId: string | undefined;
-  let timeoutResumeSliceId = 1;
-  let timeoutResumeMessages: PiMessage[] = [];
-  let beforeMessageCount = 0;
-  let turnStartMessageIndex: number | undefined;
-  let lastKnownSandboxId: string | undefined = context.sandbox?.sandboxId;
+  let lastKnownSandboxId: string | undefined = policy.sandbox?.sandboxId;
   let lastKnownSandboxDependencyProfileHash: string | undefined =
-    context.sandbox?.sandboxDependencyProfileHash;
+    policy.sandbox?.sandboxDependencyProfileHash;
   let loadedSkillNamesForResume: string[] = [];
   let mcpToolManager: McpToolManager | undefined;
   let connectedMcpProviders = new Set<string>();
   let canRecordMcpProviders = false;
+  let mcpProviderConversationId: string | undefined;
   let sandboxExecutor: SandboxExecutor | undefined;
-  let timedOut = false;
-  let cooperativeYieldError: CooperativeTurnYieldError | undefined;
-  let inputCommitted = false;
+  let sliceCheckpointer: SliceCheckpointer | undefined;
   let turnUsage: AgentTurnUsage | undefined;
   let thinkingSelection: TurnThinkingSelection | undefined;
-  const requester = requesterFromContext(context);
-  const actorRequester = actorRequesterFromContext(context);
-  const surface = surfaceFromContext(context);
-  const runSource = context.source;
-  const credentialActor = context.credentialContext?.actor;
+  const requester = requesterFromRouting(routing);
+  const actorRequester = actorRequesterFromRouting(routing);
+  const surface = surfaceFromRouting(routing);
+  const runSource = routing.source;
+  const credentialActor = routing.credentialContext?.actor;
   const credentialActorLogContext = credentialActor
     ? {
         actorType: credentialActor.type,
@@ -758,10 +324,10 @@ async function executeAgentRunInPrivacyContext(
       }
     : {};
   const sessionRecordLogContext = {
-    threadId: context.correlation?.threadId,
-    requesterId: context.correlation?.requesterId,
-    channelId: context.correlation?.channelId,
-    runId: context.correlation?.runId,
+    threadId: routing.correlation?.threadId,
+    requesterId: routing.correlation?.requesterId,
+    channelId: routing.correlation?.channelId,
+    runId: routing.correlation?.runId,
     ...credentialActorLogContext,
     assistantUserName: botConfig.userName,
     modelId: botConfig.modelId,
@@ -769,13 +335,13 @@ async function executeAgentRunInPrivacyContext(
   const recordConnectedMcpProvider = async (provider: string) => {
     if (
       !canRecordMcpProviders ||
-      !timeoutResumeConversationId ||
+      !mcpProviderConversationId ||
       connectedMcpProviders.has(provider)
     ) {
       return;
     }
     await recordMcpProviderConnected({
-      conversationId: timeoutResumeConversationId,
+      conversationId: mcpProviderConversationId,
       provider,
       ttlMs: THREAD_STATE_TTL_MS,
     });
@@ -805,49 +371,28 @@ async function executeAgentRunInPrivacyContext(
     const shouldTrace = shouldEmitDevAgentTrace();
     const spanContext: LogContext = {
       conversationId:
-        context.correlation?.conversationId ??
-        context.correlation?.threadId ??
-        context.correlation?.runId,
-      slackThreadId: context.correlation?.threadId,
-      slackUserId: context.correlation?.requesterId,
-      slackChannelId: context.correlation?.channelId,
-      runId: context.correlation?.runId,
+        routing.correlation?.conversationId ??
+        routing.correlation?.threadId ??
+        routing.correlation?.runId,
+      slackThreadId: routing.correlation?.threadId,
+      slackUserId: routing.correlation?.requesterId,
+      slackChannelId: routing.correlation?.channelId,
+      runId: routing.correlation?.runId,
       ...credentialActorLogContext,
       assistantUserName: botConfig.userName,
       modelId: botConfig.modelId,
     };
 
     // ── Skill discovery ──────────────────────────────────────────────
-    const availableSkills = await discoverSkills({
-      additionalRoots: context.skillDirs,
+    const availableSkills = await discoverRunSkills({
+      skillDirs: policy.skillDirs,
+      spanContext,
     });
-    if (!startupDiscoveryLogged) {
-      startupDiscoveryLogged = true;
-      const plugins = pluginCatalogRuntime.getProviders();
-      const roots = [
-        ...new Set(availableSkills.map((skill) => skill.skillPath)),
-      ].sort();
-      logInfo(
-        "startup_discovery_summary",
-        spanContext,
-        {
-          "app.skill.count": availableSkills.length,
-          "app.skill.names": availableSkills.map((skill) => skill.name).sort(),
-          "app.file.directories": roots,
-          "app.plugin.count": plugins.length,
-          "app.plugin.names": plugins
-            .map((plugin) => plugin.manifest.name)
-            .sort(),
-        },
-        "Discovered startup SOUL/skills/plugins",
-      );
-    }
-    let baseInstructions = "";
     let configurationValues: Record<string, unknown>;
     const userInput = messageText;
     if (shouldTrace) {
-      const inboundAttachmentCount = context.inboundAttachmentCount ?? 0;
-      const promptAttachmentCount = context.userAttachments?.length ?? 0;
+      const inboundAttachmentCount = input.inboundAttachmentCount ?? 0;
+      const promptAttachmentCount = input.userAttachments?.length ?? 0;
       logInfo(
         "agent_message_in",
         spanContext,
@@ -859,7 +404,7 @@ async function executeAgentRunInPrivacyContext(
           // look indistinguishable from Slack ingress dropping attachments.
           "app.message.attachment_count": inboundAttachmentCount,
           "app.message.prompt_attachment_count": promptAttachmentCount,
-          "messaging.message.id": context.correlation?.messageTs ?? "",
+          "messaging.message.id": routing.correlation?.messageTs ?? "",
         },
         "Agent message received",
       );
@@ -874,28 +419,44 @@ async function executeAgentRunInPrivacyContext(
     };
     const skillSandbox = new SkillSandbox(availableSkills, activeSkills);
 
-    // ── Turn Session Record ────────────────────────────────────────
-    const { conversationId: sessionConversationId, sessionId } =
-      getSessionIdentifiers(context);
-    const turnSessionState = await loadTurnSessionRecord({
-      conversationId: sessionConversationId,
+    // ── Session Record ────────────────────────────────────────
+    const {
+      currentSliceId,
+      existingSessionRecord,
+      resumedFromSessionRecord,
+      sessionConversationId,
       sessionId,
-    });
-    const { resumedFromSessionRecord, currentSliceId, existingSessionRecord } =
-      turnSessionState;
-    timeoutResumeConversationId = sessionConversationId;
-    timeoutResumeSessionId = sessionId;
-    timeoutResumeSliceId = currentSliceId;
+      sessionRecordState,
+    } = await restoreSessionRecord(routing);
+    mcpProviderConversationId = sessionConversationId;
     canRecordMcpProviders = Boolean(
-      turnSessionState.canUseTurnSession && sessionConversationId && sessionId,
+      sessionRecordState.canUseTurnSession &&
+      sessionConversationId &&
+      sessionId,
     );
+    const checkpointer = createSliceCheckpointer({
+      channelName: routing.correlation?.channelName,
+      destination: routing.destination,
+      durability,
+      logContext: sessionRecordLogContext,
+      recordActiveMcpProviders,
+      requester,
+      runSource,
+      sessionConversationId,
+      sessionId,
+      startedAtMs: replyStartedAtMs,
+      surface,
+      sessionRecordState,
+      getLoadedSkillNames: () => loadedSkillNamesForResume,
+    });
+    sliceCheckpointer = checkpointer;
     const recordParentToolExecutionStart = async (event: {
       args: unknown;
       toolCallId: string;
       toolName: string;
     }) => {
       if (
-        !turnSessionState.canUseTurnSession ||
+        !sessionRecordState.canUseTurnSession ||
         !sessionConversationId ||
         !sessionId
       ) {
@@ -912,7 +473,7 @@ async function executeAgentRunInPrivacyContext(
         });
       } catch (error) {
         // Host-only activity events are best-effort reporting writes; a
-        // failed append must not abort the in-flight model turn.
+        // failed append must not abort the in-flight model run.
         logException(
           error,
           "agent_turn_session_log_append_failed",
@@ -924,176 +485,50 @@ async function executeAgentRunInPrivacyContext(
         );
       }
     };
-    const persistedConfigurationValues = context.channelConfiguration
-      ? await context.channelConfiguration.resolveValues()
+    const persistedConfigurationValues = policy.channelConfiguration
+      ? await policy.channelConfiguration.resolveValues()
       : {};
     configurationValues = {
       ...getConfigDefaults(),
-      ...(context.configuration ?? {}),
+      ...(policy.configuration ?? {}),
       ...persistedConfigurationValues,
     };
-    // ── Sandbox ──────────────────────────────────────────────────────
-    const authRequesterId =
-      context.credentialContext?.actor.type === "user"
-        ? context.credentialContext.actor.userId
-        : undefined;
-    const userTokenStore = createUserTokenStore();
-    const pluginHooks = createPluginHookRunner({
-      requester: actorRequester,
-    });
-    sandboxExecutor = createSandboxExecutor({
-      sandboxId: context.sandbox?.sandboxId,
-      sandboxDependencyProfileHash:
-        context.sandbox?.sandboxDependencyProfileHash,
-      traceContext: spanContext,
-      tracePropagation: context.sandbox?.tracePropagation,
-      credentialEgress: context.credentialContext,
-      agentHooks: pluginHooks,
-      onSandboxAcquired: async (sandbox) => {
-        lastKnownSandboxId = sandbox.sandboxId;
-        lastKnownSandboxDependencyProfileHash =
-          sandbox.sandboxDependencyProfileHash;
-        await context.onSandboxAcquired?.(sandbox);
-      },
-      runBashCustomCommand: async (command) => {
-        const result = await maybeExecuteJrRpcCustomCommand(command, {
-          activeSkill: skillSandbox.getActiveSkill(),
-          channelConfiguration: context.channelConfiguration,
-          requesterId: actorRequester?.userId,
-          onConfigurationValueChanged: (key, value) => {
-            if (value === undefined) {
-              delete configurationValues[key];
-              return;
-            }
-            configurationValues[key] = value;
-          },
-        });
-        return result.handled
-          ? { handled: true, result: result.result }
-          : { handled: false };
-      },
-    });
-    const currentSandboxExecutor = sandboxExecutor;
-    sandboxExecutor.configureSkills(availableSkills);
-    sandboxExecutor.configureReferenceFiles(listReferenceFiles());
     // Match the history source the agent will actually receive so crash retries
     // do not let an unstripped running record suppress fresh turn context.
     const priorPiMessages = resumedFromSessionRecord
       ? existingSessionRecord?.piMessages
-      : context.piMessages;
+      : input.piMessages;
     connectedMcpProviders = new Set(
-      turnSessionState.canUseTurnSession && sessionConversationId
+      sessionRecordState.canUseTurnSession && sessionConversationId
         ? await loadConnectedMcpProviders({
             conversationId: sessionConversationId,
           })
         : [],
     );
-    let sandboxPromise: Promise<SandboxWorkspace> | undefined;
-    let sandboxPromiseId: string | undefined;
-    const clearSandboxPromise = (): void => {
-      sandboxPromise = undefined;
-      sandboxPromiseId = undefined;
-    };
-    const getSandbox = (reason: {
-      trigger: string;
-      path?: string;
-      cmd?: string;
-      cwd?: string;
-    }): Promise<SandboxWorkspace> => {
-      const currentSandboxId = currentSandboxExecutor.getSandboxId();
-      if (
-        sandboxPromise &&
-        sandboxPromiseId &&
-        currentSandboxId !== sandboxPromiseId
-      ) {
-        clearSandboxPromise();
-      }
-
-      if (!sandboxPromise) {
-        logInfo(
-          "sandbox_boot_requested",
-          spanContext,
-          {
-            "app.sandbox.boot.trigger": reason.trigger,
-            ...(reason.path ? { "file.path": reason.path } : {}),
-            ...(reason.cmd ? { "process.executable.name": reason.cmd } : {}),
-            ...(reason.cwd ? { "file.directory": reason.cwd } : {}),
-          },
-          "Lazy sandbox boot requested",
-        );
-        sandboxPromise = currentSandboxExecutor
-          .createSandbox()
-          .then((sandbox) => {
-            sandboxPromiseId = sandbox.sandboxId;
-            return sandbox;
-          })
-          .catch((error) => {
-            clearSandboxPromise();
-            throw error;
-          });
-      }
-      return sandboxPromise;
-    };
-    const sandbox: SandboxWorkspace = {
-      readFileToBuffer: async (input) =>
-        (
-          await getSandbox({
-            trigger: "workspace.readFileToBuffer",
-            path: input.path,
-          })
-        ).readFileToBuffer(input),
-      runCommand: async (input) =>
-        (
-          await getSandbox({
-            trigger: "workspace.runCommand",
-            cmd: input.cmd,
-            cwd: input.cwd,
-          })
-        ).runCommand(input),
-    };
-
     // ── Restore skill runtime handles from durable Pi history ────────
-    for (const skillName of inferLoadedSkillNamesFromPiMessages(
+    await restoreSkillRuntime({
+      activeSkills,
+      invokedSkill,
       priorPiMessages,
-    )) {
-      const restoredSkill = await skillSandbox.loadSkill(skillName);
-      if (restoredSkill) {
-        upsertActiveSkill(activeSkills, restoredSkill);
-        syncLoadedSkillNamesForResume();
-      }
-    }
-    if (invokedSkill) {
-      const restoredSkill = await skillSandbox.loadSkill(invokedSkill.name);
-      if (restoredSkill) {
-        upsertActiveSkill(activeSkills, restoredSkill);
-        syncLoadedSkillNamesForResume();
-      }
-    }
+      skillSandbox,
+      syncLoadedSkillNamesForResume,
+    });
 
-    const promptConversationContext =
-      context.piMessages && context.piMessages.length > 0
-        ? undefined
-        : context.conversationContext;
-    const userTurnText = buildUserTurnText(
+    const { routerBlocks, userContentParts } = buildPromptInput({
+      input,
       userInput,
-      promptConversationContext,
-    );
-    const { routerBlocks, userContentParts } = buildUserTurnInput({
-      omittedImageAttachmentCount: context.omittedImageAttachmentCount ?? 0,
-      userAttachments: context.userAttachments,
-      userTurnText,
     });
     const preAgentPromptMessages = (): PiMessage[] =>
-      existingSessionRecord?.piMessages ?? [...(context.piMessages ?? [])];
+      existingSessionRecord?.piMessages ?? [...(input.piMessages ?? [])];
 
     thinkingSelection = await selectTurnThinkingLevel({
       completeObject,
-      conversationContext: context.conversationContext,
+      conversationContext: input.conversationContext,
       context: {
-        threadId: context.correlation?.threadId,
-        channelId: context.correlation?.channelId,
-        requesterId: context.correlation?.requesterId,
-        runId: context.correlation?.runId,
+        threadId: routing.correlation?.threadId,
+        channelId: routing.correlation?.channelId,
+        requesterId: routing.correlation?.requesterId,
+        runId: routing.correlation?.runId,
       },
       currentTurnBlocks: routerBlocks,
       fastModelId: botConfig.fastModelId,
@@ -1110,463 +545,95 @@ async function executeAgentRunInPrivacyContext(
         : {}),
     });
 
-    // ── Mutable turn state ───────────────────────────────────────────
-    timeoutResumeMessages = [];
+    // ── Mutable run state ────────────────────────────────────────────
+    checkpointer.resetResumeSnapshot();
     const generatedFiles: FileUpload[] = [];
-    const replyFiles: FileUpload[] = [];
+    const deliveryFiles: FileUpload[] = [];
     const artifactStatePatch: Partial<ThreadArtifactsState> = {};
     const toolCalls: string[] = [];
-    let advisorTools: AgentTool[] = [];
     let agent: Agent | undefined;
-    let latestSafeBoundaryMessages: PiMessage[] = [];
-    const getResumeSnapshot = (): PiMessage[] => {
-      const currentMessages = agent ? [...agent.state.messages] : [];
-      return latestSafeBoundaryMessages.length > currentMessages.length
-        ? [...latestSafeBoundaryMessages]
-        : currentMessages;
+    const captureCurrentResumeSnapshot = (): void => {
+      checkpointer.captureResumeSnapshot(
+        checkpointer.getResumeSnapshot(agent ? [...agent.state.messages] : []),
+      );
     };
 
-    // ── MCP auth orchestration ───────────────────────────────────────
-    const slackDestination =
-      context.destination.platform === "slack"
-        ? context.destination
-        : undefined;
-    const slackChannelId = slackDestination?.channelId;
-
-    const mcpAuth = createMcpAuthOrchestration({
+    const toolWiring = await wireAgentTools({
       abortAgent: () => agent?.abort(),
-      conversationId: sessionConversationId,
-      sessionId,
-      requesterId: authRequesterId,
-      channelId: slackChannelId,
-      destination: context.destination,
-      source: runSource,
-      threadTs: context.correlation?.threadTs,
-      toolChannelId: context.toolChannelId,
-      userMessage: userInput,
-      pendingAuth: context.pendingAuth,
-      getConfiguration: () => configurationValues,
-      getArtifactState: () => context.artifactState,
-      getMergedArtifactState: () =>
-        mergeArtifactsState(context.artifactState ?? {}, artifactStatePatch),
-      recordPendingAuth: context.recordPendingAuth,
-      authorizationFlowMode: context.authorizationFlowMode,
-    });
-    const pluginAuth = createPluginAuthOrchestration({
-      abortAgent: () => agent?.abort(),
-      conversationId: sessionConversationId,
-      sessionId,
-      requesterId: authRequesterId,
-      channelId: slackChannelId,
-      destination: context.destination,
-      source: runSource,
-      threadTs: context.correlation?.threadTs,
-      userMessage: userInput,
-      channelConfiguration: context.channelConfiguration,
-      pendingAuth: context.pendingAuth,
-      recordPendingAuth: context.recordPendingAuth,
-      authorizationFlowMode: context.authorizationFlowMode,
-      userTokenStore,
-    });
-
-    mcpToolManager = new McpToolManager(
-      pluginCatalogRuntime.getMcpProviders(),
-      {
-        authProviderFactory: mcpAuth.authProviderFactory,
-        onAuthorizationRequired: mcpAuth.onAuthorizationRequired,
+      activeSkills,
+      actorRequester,
+      artifactStatePatch,
+      availableSkills,
+      checkpointer,
+      configurationValues,
+      connectedMcpProviders,
+      conversationPrivacy,
+      deliveryFiles,
+      durability,
+      generatedFiles,
+      invokedSkill,
+      observers,
+      onSandboxMetadataChanged: (sandbox) => {
+        lastKnownSandboxId = sandbox.sandboxId;
+        lastKnownSandboxDependencyProfileHash =
+          sandbox.sandboxDependencyProfileHash;
       },
-    );
-    const turnMcpToolManager = mcpToolManager;
-    const getPendingAuthPause = () =>
-      pluginAuth.getPendingPause() ?? mcpAuth.getPendingPause();
-    setTags({
-      conversationId: spanContext.conversationId,
-      slackThreadId: context.correlation?.threadId,
-      slackUserId: context.correlation?.requesterId,
-      slackChannelId: context.correlation?.channelId,
-      runId: context.correlation?.runId,
-      ...credentialActorLogContext,
-      assistantUserName: botConfig.userName,
-      modelId: botConfig.modelId,
-    });
-
-    // ── Tool creation ────────────────────────────────────────────────
-    const loadableSkills = availableSkills.filter(
-      (skill) =>
-        skill.disableModelInvocation !== true ||
-        skill.name === invokedSkill?.name,
-    );
-    const commonToolRuntimeContext = {
-      conversationId: sessionConversationId,
-      userText: userInput,
-      artifactState: context.artifactState,
-      configuration: configurationValues,
-      egress: createPluginEgress({
-        credentialContext: context.credentialContext,
-        pluginAuth: {
-          async handleAuthRequired(signal) {
-            await pluginAuth.maybeHandleAuthSignal({
-              auth_required: {
-                ...(signal.authorization
-                  ? { authorization: signal.authorization }
-                  : {}),
-                createdAtMs: Date.now(),
-                grant: signal.grant,
-                kind: signal.kind,
-                message: signal.message,
-                provider: signal.provider,
-              },
-            });
-          },
-        },
-      }),
-      mcpToolManager: turnMcpToolManager,
-      sandbox,
+      policy,
+      preAgentPromptMessages,
+      priorPiMessages,
+      recordConnectedMcpProvider,
+      routing,
+      runSource,
+      sessionConversationId,
+      sessionId,
+      skillInvocation,
+      skillSandbox,
+      spanContext,
+      state,
       surface,
-      advisor: {
-        config: botConfig.advisor,
-        conversationId: sessionConversationId,
-        conversationPrivacy,
-        parentSessionId: sessionId,
-        logContext: spanContext,
-        getTools: () => advisorTools,
-        streamFn: createTracedStreamFn({ conversationPrivacy }),
-      },
-    };
-    const toolSource = runSource;
-    const toolDestination = toolInvocationDestination(context);
-    let toolRuntimeContext: ToolRuntimeContext;
-    if (toolSource.platform === "slack") {
-      if (toolDestination.platform !== "slack") {
-        throw new TypeError("Slack tool runtime requires a Slack destination");
-      }
-      toolRuntimeContext = {
-        ...commonToolRuntimeContext,
-        destination: toolDestination,
-        requester:
-          actorRequester?.platform === "slack" ? actorRequester : undefined,
-        source: toolSource,
-      };
-    } else {
-      if (toolDestination.platform !== "local") {
-        throw new TypeError("Local tool runtime requires a local destination");
-      }
-      toolRuntimeContext = {
-        ...commonToolRuntimeContext,
-        destination: toolDestination,
-        requester:
-          actorRequester?.platform === "local" ? actorRequester : undefined,
-        source: toolSource,
-      };
-    }
-    const tools = createTools(
-      loadableSkills,
-      {
-        getGeneratedFile: (filename) =>
-          generatedFiles.find((file) => file.filename === filename),
-        onGeneratedArtifactFiles: (files) => {
-          generatedFiles.push(...files);
-        },
-        onGeneratedFiles: (files) => {
-          replyFiles.push(...files);
-        },
-        onArtifactStatePatch: async (patch) => {
-          Object.assign(artifactStatePatch, patch);
-          await context.onArtifactStateUpdated?.(
-            mergeArtifactsState(
-              context.artifactState ?? {},
-              artifactStatePatch,
-            ),
-          );
-        },
-        toolOverrides: context.toolOverrides,
-        onSkillLoaded: async (loadedSkill) => {
-          const resolvedSkill = await skillSandbox.loadSkill(loadedSkill.name);
-          const effective = resolvedSkill ?? loadedSkill;
-          upsertActiveSkill(activeSkills, effective);
-          syncLoadedSkillNamesForResume();
-          if (await turnMcpToolManager.activateForSkill(effective)) {
-            await recordConnectedMcpProvider(effective.pluginProvider!);
-          }
-          if (mcpAuth.getPendingPause()) {
-            // Auth pause requested — suppress loadSkill failure and let the
-            // aborted turn park cleanly.
-            return undefined;
-          }
-          if (!effective.pluginProvider) {
-            return undefined;
-          }
-          if (
-            !turnMcpToolManager
-              .getActiveProviders()
-              .includes(effective.pluginProvider)
-          ) {
-            return undefined;
-          }
-          const availableToolCount = turnMcpToolManager.getActiveToolCatalog({
-            provider: effective.pluginProvider,
-          }).length;
-          return {
-            mcp_provider: effective.pluginProvider,
-            available_tool_count: availableToolCount,
-          };
-        },
-      },
+      syncLoadedSkillNamesForResume,
+      toolCalls,
+      userInput,
+    });
+    mcpToolManager = toolWiring.mcpToolManager;
+    sandboxExecutor = toolWiring.currentSandboxExecutor;
+    const currentSandboxExecutor = toolWiring.currentSandboxExecutor;
+    const { agentTools, getPendingAuthPause, toolRuntimeContext } = toolWiring;
+
+    const {
+      baseInstructions,
+      inputMessages,
+      inputMessagesAttribute,
+      promptContentParts,
+      promptHistoryMessages,
+      shouldPromptAgent,
+    } = await assemblePrompt({
+      activeMcpCatalogs: toolWiring.activeMcpCatalogs,
+      actorRequester,
+      artifactState: state.artifactState,
+      availableSkills,
+      configurationValues,
+      conversationPrivacy,
+      dispatch: routing.dispatch,
+      existingRunStartMessageIndex:
+        existingSessionRecord?.turnStartMessageIndex,
+      existingSessionPiMessages: existingSessionRecord?.piMessages,
+      invocation: skillInvocation,
+      priorPiMessages,
+      resumedFromSessionRecord,
+      routing,
+      source: runSource,
+      spanContext,
+      toolGuidance: toolWiring.toolGuidance,
       toolRuntimeContext,
-    );
-
-    const toolGuidance = Object.entries(
-      tools as Record<string, ToolDefinition<any>>,
-    ).map(([name, definition]) => ({
-      name,
-      promptGuidelines: definition.promptGuidelines,
-      promptSnippet: definition.promptSnippet,
-    }));
-
-    // ── MCP provider activation ──────────────────────────────────────
-    // If a prior turn left an MCP provider pending user authorization, skip
-    // eager restoration of that provider here. Without this guard, a later
-    // unrelated turn in the same conversation can try to activate the
-    // still-unauthenticated provider, throw McpAuthorizationPauseError, and
-    // abort before the agent sees the user's request.
-    //
-    // Skipping only suppresses the eager-restore path. The agent can still
-    // trigger the auth flow intentionally (via loadSkill + searchMcpTools)
-    // when the user's request genuinely requires that provider.
-    const pendingMcpProvider =
-      context.pendingAuth?.kind === "mcp"
-        ? context.pendingAuth.provider
-        : undefined;
-
-    // Restore providers visible in durable Pi session history. In serverless
-    // runtimes, later slices and follow-up turns usually run in a fresh
-    // process, so in-memory MCP clients cannot be reused.
-    const providersToRestore = new Set([
-      ...connectedMcpProviders,
-      ...inferActiveMcpProvidersFromPiMessages(priorPiMessages),
-    ]);
-    for (const provider of providersToRestore) {
-      if (provider === pendingMcpProvider) {
-        continue; // awaiting user authorization — skip to avoid aborting unrelated turns
-      }
-      if (await turnMcpToolManager.activateProvider(provider)) {
-        await recordConnectedMcpProvider(provider);
-      }
-      if (mcpAuth.getPendingPause()) {
-        timeoutResumeMessages = preAgentPromptMessages();
-        throw mcpAuth.getPendingPause()!;
-      }
-    }
-    // Activate MCP for skills recovered from durable Pi history.
-    for (const skill of activeSkills) {
-      if (skill.pluginProvider === pendingMcpProvider) {
-        continue; // awaiting user authorization — skip to avoid aborting unrelated turns
-      }
-      if (await turnMcpToolManager.activateForSkill(skill)) {
-        await recordConnectedMcpProvider(skill.pluginProvider!);
-      }
-      if (mcpAuth.getPendingPause()) {
-        timeoutResumeMessages = preAgentPromptMessages();
-        throw mcpAuth.getPendingPause()!;
-      }
-    }
-
-    // ── Prompt context ───────────────────────────────────────────────
-    const activeMcpCatalogs = toActiveMcpCatalogSummaries(
-      turnMcpToolManager.getActiveToolCatalog(),
-    );
-    const hasPromptCheckpoint =
-      resumedFromSessionRecord &&
-      existingSessionRecord?.turnStartMessageIndex !== undefined;
-    const shouldPromptAgent = !resumedFromSessionRecord || !hasPromptCheckpoint;
-    // Every re-prompt shape must trim a trailing checkpointed copy of the same
-    // user prompt, including redelivery of the same inbound message after a
-    // lost input commit against a still-`running` record; otherwise the prompt
-    // appears twice in Pi history.
-    const promptHistoryMessages = shouldPromptAgent
-      ? withoutTrailingUncheckpointedUserPrompt(
-          priorPiMessages,
-          userContentParts,
-        )
-      : existingSessionRecord!.piMessages;
-    const needsBootstrapContextForPrompt =
-      shouldPromptAgent && !hasRuntimeTurnContext(promptHistoryMessages);
-    const systemPromptContributions =
-      await getPluginSystemPromptContributions(toolSource);
-    const pluginSystemPrompt = buildPluginSystemPromptContributions(
-      systemPromptContributions,
-    );
-    baseInstructions = [
-      buildSystemPrompt({ source: toolSource }),
-      pluginSystemPrompt,
-    ]
-      .filter((section): section is string => Boolean(section))
-      .join("\n\n");
-    const pluginUserPromptContributions = !shouldPromptAgent
-      ? []
-      : await getPluginUserPromptContributions({
-          context: toolRuntimeContext,
-        });
-    const turnContextPrompt =
-      needsBootstrapContextForPrompt || pluginUserPromptContributions.length > 0
-        ? buildTurnContextPrompt({
-            availableSkills,
-            activeMcpCatalogs,
-            includeSessionContext: needsBootstrapContextForPrompt,
-            pluginPromptContributions: pluginUserPromptContributions,
-            toolGuidance,
-            runtime: {
-              conversationId: spanContext.conversationId,
-              slackConversation: context.slackConversation,
-            },
-            dispatch: context.dispatch
-              ? {
-                  ...context.dispatch,
-                  destination: context.destination,
-                  source: toolSource,
-                }
-              : undefined,
-            invocation: skillInvocation,
-            requester: actorRequester,
-            artifactState: context.artifactState,
-            configuration: configurationValues,
-          })
-        : null;
-    const turnContextParts: UserTurnContentPart[] = turnContextPrompt
-      ? [{ type: "text", text: turnContextPrompt }]
-      : [];
-    const promptContentParts: UserTurnContentPart[] = [
-      ...turnContextParts,
-      ...userContentParts,
-    ];
-
-    const inputMessages = [
-      {
-        role: "system",
-        content: [{ type: "text", text: baseInstructions }],
-      },
-      {
-        role: "user",
-        content: promptContentParts.map((part) => toObservablePromptPart(part)),
-      },
-    ];
-    const inputMessagesAttribute = serializeGenAiAttribute(
-      conversationPrivacy !== "public"
-        ? inputMessages.map(toGenAiMessageMetadata)
-        : inputMessages,
-    );
-
-    // ── Agent tools ──────────────────────────────────────────────────
-    const onToolCall = async (
-      toolName: string,
-      params: Record<string, unknown>,
-    ) => {
-      toolCalls.push(toolName);
-      try {
-        await context.onToolInvocation?.({ toolName, params });
-      } catch (error) {
-        logWarn(
-          "tool_invocation_observer_failed",
-          spanContext,
-          {
-            "gen_ai.tool.name": toolName,
-            "exception.message":
-              error instanceof Error ? error.message : String(error),
-          },
-          "Tool invocation observer failed",
-        );
-      }
-    };
-    const agentTools = createAgentTools(
-      tools,
-      skillSandbox,
-      spanContext,
-      context.onStatus,
-      sandboxExecutor,
-      pluginAuth,
-      onToolCall,
-      pluginHooks,
-      conversationPrivacy,
-      context.onToolResult,
-    );
-    advisorTools = createAgentTools(
-      createAdvisorToolDefinitions(tools),
-      skillSandbox,
-      spanContext,
-      context.onStatus,
-      sandboxExecutor,
-      pluginAuth,
-      onToolCall,
-      pluginHooks,
-      conversationPrivacy,
-      context.onToolResult,
-    );
-    // Keep Pi's native tool schema static for the whole turn. Ideally this
-    // would use provider-native tool loading/search APIs, but Pi's generic
-    // AgentTool surface cannot yet express OpenAI/Anthropic deferred MCP tools.
-    // Until it can, MCP tools are searched/disclosed as data and executed
-    // through callMcpTool so provider cache/session affinity never sees a
-    // mid-run native tool-list mutation.
+      userContentParts,
+    });
 
     // ── Agent execution ──────────────────────────────────────────────
-    let hasEmittedText = false;
-    let needsSeparator = false;
-    const commitInput = async (): Promise<void> => {
-      if (inputCommitted) {
-        return;
-      }
-      await context.onInputCommitted?.();
-      inputCommitted = true;
-    };
-    const persistSafeBoundary = async (
-      messages: PiMessage[],
-    ): Promise<boolean> => {
-      if (
-        !turnSessionState.canUseTurnSession ||
-        !sessionConversationId ||
-        !sessionId
-      ) {
-        return false;
-      }
-
-      const persisted = await persistRunningSessionRecord({
-        channelName: context.correlation?.channelName,
-        conversationId: sessionConversationId,
-        destination: context.destination,
-        source: runSource,
-        sessionId,
-        sliceId: currentSliceId,
-        messages,
-        loadedSkillNames: loadedSkillNamesForResume,
-        logContext: sessionRecordLogContext,
-        requester,
-        ...(surface ? { surface } : {}),
-        ...(turnStartMessageIndex !== undefined
-          ? { turnStartMessageIndex }
-          : {}),
-      });
-      if (!persisted) {
-        return false;
-      }
-
-      latestSafeBoundaryMessages = [...messages];
-      return true;
-    };
-    const requireDurableInputCheckpoint = async (
-      messages: PiMessage[],
-    ): Promise<boolean> => {
-      const persisted = await persistSafeBoundary(messages);
-      if (!persisted && context.onInputCommitted) {
-        throw new TurnInputCommitLostError(
-          `Durable turn input could not be checkpointed for conversation=${sessionConversationId ?? "unknown"} session=${sessionId ?? "unknown"}`,
-        );
-      }
-      return persisted;
-    };
     const drainSteeringMessages = async (): Promise<void> => {
       if (
-        !context.drainSteeringMessages ||
-        !turnSessionState.canUseTurnSession ||
+        !durability.drainSteeringMessages ||
+        !sessionRecordState.canUseTurnSession ||
         !sessionConversationId ||
         !sessionId
       ) {
@@ -1575,12 +642,12 @@ async function executeAgentRunInPrivacyContext(
 
       try {
         let steeredMessageCount = 0;
-        await context.drainSteeringMessages(async (messages) => {
+        await durability.drainSteeringMessages(async (messages) => {
           const piMessages = messages.map(buildSteeringPiMessage);
           if (piMessages.length === 0) {
             return;
           }
-          await requireDurableInputCheckpoint([
+          await checkpointer.requireDurableInputCheckpoint([
             ...agent!.state.messages,
             ...piMessages,
           ]);
@@ -1614,20 +681,6 @@ async function executeAgentRunInPrivacyContext(
         );
       }
     };
-    const yieldAtSafeBoundaryIfDue = (): void => {
-      if (!context.shouldYield?.()) {
-        return;
-      }
-
-      timeoutResumeMessages = getResumeSnapshot();
-      cooperativeYieldError = new CooperativeTurnYieldError(
-        `Agent turn yielded at a safe boundary after ${
-          Date.now() - replyStartedAtMs
-        }ms`,
-      );
-      throw cooperativeYieldError;
-    };
-
     const apiKeyOverride = getPiGatewayApiKey();
     agent = new Agent({
       ...(apiKeyOverride ? { getApiKey: () => apiKeyOverride } : {}),
@@ -1635,7 +688,9 @@ async function executeAgentRunInPrivacyContext(
       steeringMode: "all",
       prepareNextTurn: async () => {
         await drainSteeringMessages();
-        yieldAtSafeBoundaryIfDue();
+        checkpointer.yieldAtSafeBoundaryIfDue(
+          agent ? [...agent.state.messages] : [],
+        );
         return undefined;
       },
       initialState: {
@@ -1646,68 +701,30 @@ async function executeAgentRunInPrivacyContext(
       },
     });
 
-    const unsubscribe = agent.subscribe((event) => {
-      if (event.type === "tool_execution_start") {
-        return recordParentToolExecutionStart(event);
-      }
-      if (event.type === "turn_end" && event.toolResults.length > 0) {
-        return persistSafeBoundary([...agent!.state.messages]).then(
-          () => undefined,
-        );
-      }
-      if (event.type === "message_start") {
-        Promise.resolve(context.onAssistantMessageStart?.()).catch((error) => {
-          logWarn(
-            "streaming_message_start_error",
-            {},
-            {
-              "exception.message":
-                error instanceof Error ? error.message : String(error),
-            },
-            "Failed to deliver assistant message start to stream coordinator",
-          );
-        });
-        if (hasEmittedText) {
-          needsSeparator = true;
-        }
-        return;
-      }
-      if (event.type !== "message_update") return;
-      if (event.assistantMessageEvent.type !== "text_delta") return;
-      const deltaText = event.assistantMessageEvent.delta;
-      if (!deltaText) return;
-
-      const text = needsSeparator ? "\n\n" + deltaText : deltaText;
-      needsSeparator = false;
-      hasEmittedText = true;
-
-      Promise.resolve(context.onTextDelta?.(text)).catch((error) => {
-        logWarn(
-          "streaming_text_delta_error",
-          {},
-          {
-            "exception.message":
-              error instanceof Error ? error.message : String(error),
-          },
-          "Failed to deliver text delta to stream",
-        );
-      });
+    const unsubscribe = subscribeToAgentEvents({
+      agent,
+      checkpointer,
+      observers,
+      recordParentToolExecutionStart,
+      spanContext,
     });
 
     let newMessages: PiMessage[] = [];
-    beforeMessageCount = agent.state.messages.length;
+    checkpointer.setBeforeMessageCount(agent.state.messages.length);
     try {
       if (resumedFromSessionRecord) {
         agent.state.messages = shouldPromptAgent
           ? promptHistoryMessages
           : existingSessionRecord!.piMessages;
-        turnStartMessageIndex = existingSessionRecord!.turnStartMessageIndex;
+        checkpointer.setRunStartMessageIndex(
+          existingSessionRecord!.turnStartMessageIndex,
+        );
       } else if (promptHistoryMessages.length > 0) {
         agent.state.messages = [...promptHistoryMessages];
       }
-      beforeMessageCount = agent.state.messages.length;
+      checkpointer.setBeforeMessageCount(agent.state.messages.length);
       if (shouldPromptAgent) {
-        turnStartMessageIndex = beforeMessageCount;
+        checkpointer.setRunStartMessageIndex(checkpointer.beforeMessageCount);
       }
 
       await withSpan(
@@ -1722,12 +739,13 @@ async function executeAgentRunInPrivacyContext(
             timestamp: Date.now(),
           } as PiMessage;
           if (shouldPromptAgent) {
-            const promptPersisted = await requireDurableInputCheckpoint([
-              ...agent.state.messages,
-              freshPromptMessage,
-            ]);
+            const promptPersisted =
+              await checkpointer.requireDurableInputCheckpoint([
+                ...agent.state.messages,
+                freshPromptMessage,
+              ]);
             if (promptPersisted) {
-              await commitInput();
+              await checkpointer.commitInput();
             }
           }
 
@@ -1737,7 +755,7 @@ async function executeAgentRunInPrivacyContext(
             let timeoutId: ReturnType<typeof setTimeout> | undefined;
             const timeoutPromise = new Promise<never>((_, reject) => {
               const rejectWithTimeout = () => {
-                timedOut = true;
+                checkpointer.markTimedOut();
                 agent.abort();
                 reject(
                   new Error(
@@ -1756,7 +774,7 @@ async function executeAgentRunInPrivacyContext(
             try {
               return await Promise.race([run, timeoutPromise]);
             } catch (error) {
-              if (timedOut) {
+              if (checkpointer.timedOut) {
                 logWarn(
                   "agent_turn_timeout",
                   {},
@@ -1793,10 +811,10 @@ async function executeAgentRunInPrivacyContext(
                     "Timed-out agent run did not settle after abort before resume snapshot",
                   );
                 }
-                timeoutResumeMessages = getResumeSnapshot();
+                captureCurrentResumeSnapshot();
               }
               if (getPendingAuthPause()) {
-                timeoutResumeMessages = getResumeSnapshot();
+                captureCurrentResumeSnapshot();
                 throw getPendingAuthPause()!;
               }
               throw error;
@@ -1813,11 +831,14 @@ async function executeAgentRunInPrivacyContext(
           let retryUsage: AgentTurnUsage | undefined;
           for (let attempt = 0; ; attempt += 1) {
             promptResult = await runAgentStep(run);
-            if (cooperativeYieldError) {
+            if (checkpointer.cooperativeYieldError) {
+              const cooperativeYieldError = checkpointer.cooperativeYieldError;
               throw cooperativeYieldError;
             }
 
-            newMessages = agent.state.messages.slice(beforeMessageCount);
+            newMessages = agent.state.messages.slice(
+              checkpointer.beforeMessageCount,
+            );
             const outputMessages = newMessages.filter(isAssistantMessage);
             const outputMessagesAttribute = serializeGenAiAttribute(
               conversationPrivacy !== "public"
@@ -1844,7 +865,7 @@ async function executeAgentRunInPrivacyContext(
               ...extractGenAiUsageAttributes(usageSummary),
             });
             if (getPendingAuthPause()) {
-              timeoutResumeMessages = getResumeSnapshot();
+              captureCurrentResumeSnapshot();
               throw getPendingAuthPause()!;
             }
 
@@ -1860,7 +881,7 @@ async function executeAgentRunInPrivacyContext(
 
             retryUsage = turnUsage;
             agent.state.messages = providerRetry.messages;
-            await persistSafeBoundary(providerRetry.messages);
+            await checkpointer.persistSafeBoundary(providerRetry.messages);
             logWarn(
               "agent_turn_provider_retry",
               spanContext,
@@ -1885,9 +906,7 @@ async function executeAgentRunInPrivacyContext(
             ? { "app.ai.session.conversation_id": sessionConversationId }
             : {}),
           ...(sessionId ? { "app.ai.turn.session_id": sessionId } : {}),
-          ...(timeoutResumeSliceId
-            ? { "app.ai.turn.slice_id": timeoutResumeSliceId }
-            : {}),
+          ...(currentSliceId ? { "app.ai.turn.slice_id": currentSliceId } : {}),
           "app.ai.reasoning_effort": thinkingSelection.thinkingLevel,
           ...toGenAiMessagesTraceAttributes("app.ai.input", inputMessages),
           ...(inputMessagesAttribute
@@ -1900,7 +919,7 @@ async function executeAgentRunInPrivacyContext(
     }
 
     if (
-      turnSessionState.canUseTurnSession &&
+      sessionRecordState.canUseTurnSession &&
       sessionConversationId &&
       sessionId
     ) {
@@ -1918,7 +937,7 @@ async function executeAgentRunInPrivacyContext(
       buildTurnResult({
         newMessages,
         userInput,
-        replyFiles,
+        replyFiles: deliveryFiles,
         artifactStatePatch,
         toolCalls,
         sandboxId: currentSandboxExecutor.getSandboxId(),
@@ -1931,136 +950,21 @@ async function executeAgentRunInPrivacyContext(
         spanContext,
         usage: turnUsage,
         thinkingSelection,
-        correlation: context.correlation,
+        correlation: routing.correlation,
         assistantUserName: botConfig.userName,
       }),
     );
   } catch (error) {
-    if (
-      cooperativeYieldError &&
-      error instanceof CooperativeTurnYieldError &&
-      timeoutResumeConversationId &&
-      timeoutResumeSessionId
-    ) {
-      turnUsage =
-        turnUsage ??
-        extractSliceUsage(timeoutResumeMessages, beforeMessageCount);
-      await recordActiveMcpProviders();
-      const sessionRecord = await persistYieldSessionRecord({
-        channelName: context.correlation?.channelName,
-        conversationId: timeoutResumeConversationId,
-        destination: context.destination,
-        source: runSource,
-        sessionId: timeoutResumeSessionId,
-        currentSliceId: timeoutResumeSliceId,
-        currentDurationMs: Date.now() - replyStartedAtMs,
-        currentUsage: turnUsage,
-        messages: timeoutResumeMessages,
-        errorMessage: error.message,
-        loadedSkillNames: loadedSkillNamesForResume,
-        logContext: sessionRecordLogContext,
-        requester,
-        ...(surface ? { surface } : {}),
-      });
-      if (!sessionRecord) {
-        throw new Error(
-          `Failed to persist cooperative yield continuation for conversation=${timeoutResumeConversationId} session=${timeoutResumeSessionId}`,
-        );
-      }
-      return {
-        status: "yielded",
-        conversationId: timeoutResumeConversationId,
-        sessionId: timeoutResumeSessionId,
-        sliceId: sessionRecord.sliceId,
-        version: sessionRecord.version,
-      };
+    const expectedEnding = await sliceCheckpointer?.translateExpectedEnding({
+      currentUsage: turnUsage,
+      error,
+      thinkingSelection,
+    });
+    if (expectedEnding?.usage) {
+      turnUsage = expectedEnding.usage;
     }
-
-    if (timedOut && timeoutResumeConversationId && timeoutResumeSessionId) {
-      turnUsage =
-        turnUsage ??
-        extractSliceUsage(timeoutResumeMessages, beforeMessageCount);
-      await recordActiveMcpProviders();
-      const sessionRecord = await persistTimeoutSessionRecord({
-        channelName: context.correlation?.channelName,
-        conversationId: timeoutResumeConversationId,
-        destination: context.destination,
-        source: runSource,
-        sessionId: timeoutResumeSessionId,
-        currentSliceId: timeoutResumeSliceId,
-        currentDurationMs: Date.now() - replyStartedAtMs,
-        currentUsage: turnUsage,
-        messages: timeoutResumeMessages,
-        errorMessage: error instanceof Error ? error.message : String(error),
-        loadedSkillNames: loadedSkillNamesForResume,
-        logContext: sessionRecordLogContext,
-        requester,
-        ...(surface ? { surface } : {}),
-      });
-      if (!sessionRecord) {
-        throw new Error(
-          `Failed to persist timeout continuation for conversation=${timeoutResumeConversationId} session=${timeoutResumeSessionId}`,
-        );
-      }
-      if (sessionRecord.state === "awaiting_resume") {
-        return {
-          status: "timed_out",
-          conversationId: timeoutResumeConversationId,
-          sessionId: timeoutResumeSessionId,
-          sliceId: sessionRecord.sliceId,
-          version: sessionRecord.version,
-        };
-      }
-      throw new Error(
-        sessionRecord.errorMessage ??
-          (error instanceof Error ? error.message : String(error)),
-      );
-    }
-
-    // ── MCP auth pause → session continuation ────────────────────────
-    if (
-      error instanceof AuthorizationPauseError &&
-      timeoutResumeConversationId &&
-      timeoutResumeSessionId
-    ) {
-      if (!turnUsage && timeoutResumeMessages.length > 0) {
-        turnUsage = extractSliceUsage(
-          timeoutResumeMessages,
-          beforeMessageCount,
-        );
-      }
-      await recordActiveMcpProviders();
-      const sessionRecord = await persistAuthPauseSessionRecord({
-        channelName: context.correlation?.channelName,
-        conversationId: timeoutResumeConversationId,
-        destination: context.destination,
-        source: runSource,
-        sessionId: timeoutResumeSessionId,
-        currentSliceId: timeoutResumeSliceId,
-        currentDurationMs: Date.now() - replyStartedAtMs,
-        currentUsage: turnUsage,
-        messages: timeoutResumeMessages,
-        errorMessage: error.message,
-        loadedSkillNames: loadedSkillNamesForResume,
-        logContext: sessionRecordLogContext,
-        requester,
-        ...(surface ? { surface } : {}),
-      });
-      if (sessionRecord) {
-        return {
-          status: "awaiting_auth",
-          authDisposition: error.disposition,
-          authDurationMs: Date.now() - replyStartedAtMs,
-          authKind: error.kind,
-          authProvider: error.provider,
-          authProviderDisplayName: error.providerDisplayName,
-          authThinkingLevel: thinkingSelection?.thinkingLevel,
-          authUsage: turnUsage,
-          conversationId: timeoutResumeConversationId,
-          sessionId: timeoutResumeSessionId,
-          sliceId: sessionRecord.sliceId,
-        };
-      }
+    if (expectedEnding?.outcome) {
+      return expectedEnding.outcome;
     }
 
     if (isProviderRetryError(error)) {
@@ -2072,7 +976,7 @@ async function executeAgentRunInPrivacyContext(
     if (error instanceof AuthorizationFlowDisabledError) {
       throw error;
     }
-    if (context.onInputCommitted && !inputCommitted) {
+    if (durability.onInputCommitted && !sliceCheckpointer?.inputCommitted) {
       throw error;
     }
 
@@ -2080,10 +984,10 @@ async function executeAgentRunInPrivacyContext(
       error,
       "assistant_reply_generation_failed",
       {
-        slackThreadId: context.correlation?.threadId,
-        slackUserId: context.correlation?.requesterId,
-        slackChannelId: context.correlation?.channelId,
-        runId: context.correlation?.runId,
+        slackThreadId: routing.correlation?.threadId,
+        slackUserId: routing.correlation?.requesterId,
+        slackChannelId: routing.correlation?.channelId,
+        runId: routing.correlation?.runId,
         ...credentialActorLogContext,
         assistantUserName: botConfig.userName,
         modelId: botConfig.modelId,

--- a/packages/junior/src/chat/agent-run.ts
+++ b/packages/junior/src/chat/agent-run.ts
@@ -118,12 +118,8 @@ import {
   summarizeMessageText,
   toObservablePromptPart,
   upsertActiveSkill,
-} from "@/chat/respond-helpers";
-import {
-  buildTurnResult,
-  type AssistantReply,
-  type AgentTurnDiagnostics,
-} from "@/chat/services/turn-result";
+} from "@/chat/agent-run-helpers";
+import { buildTurnResult } from "@/chat/services/turn-result";
 import {
   isProviderRetryError,
   nextProviderRetry,
@@ -164,9 +160,6 @@ import {
   toGenAiMessagesTraceAttributes,
   type ConversationPrivacy,
 } from "@/chat/conversation-privacy";
-
-// Re-export types for backward compatibility with existing consumers.
-export type { AssistantReply, AgentTurnDiagnostics };
 
 const AGENT_ABORT_SETTLE_GRACE_MS = 5_000;
 
@@ -209,9 +202,9 @@ function waitForAbortSettlement(
 }
 
 /** Carries the user-visible content and prior transcript for one agent-run slice. */
-export interface ReplyRequestInput {
+export interface AgentRunInput {
   messageText: string;
-  userAttachments?: ReplyRequestAttachment[];
+  userAttachments?: AgentRunAttachment[];
   inboundAttachmentCount?: number;
   omittedImageAttachmentCount?: number;
   /** Durable Pi transcript for this conversation, excluding ephemeral turn context. */
@@ -220,7 +213,7 @@ export interface ReplyRequestInput {
 }
 
 /** Carries identity and addressing needed to route tools, auth, and delivery. */
-export interface ReplyRequestRouting {
+export interface AgentRunRouting {
   credentialContext?: CredentialContext;
   requester?: Requester;
   source: Source;
@@ -248,7 +241,7 @@ export interface ReplyRequestRouting {
 }
 
 /** Carries execution limits and dependency overrides for one run slice. */
-export interface ReplyRequestPolicy {
+export interface AgentRunPolicy {
   /** Absolute wall-clock deadline for this host request, in milliseconds. */
   turnDeadlineAtMs?: number;
   authorizationFlowMode?: AuthorizationFlowMode;
@@ -269,13 +262,13 @@ export interface ReplyRequestPolicy {
 }
 
 /** Carries durable state snapshots already loaded by the caller. */
-export interface ReplyRequestState {
+export interface AgentRunState {
   artifactState?: ThreadArtifactsState;
   pendingAuth?: ConversationPendingAuthState;
 }
 
 /** Carries non-blocking notifications for streaming UI and status surfaces. */
-export interface ReplyRequestObservers {
+export interface AgentRunObservers {
   onTextDelta?: (deltaText: string) => void | Promise<void>;
   onAssistantMessageStart?: () => void | Promise<void>;
   onToolInvocation?: (invocation: {
@@ -287,13 +280,13 @@ export interface ReplyRequestObservers {
 }
 
 /** Carries durable-worker ports that commit or update resumable run state. */
-export interface ReplyRequestDurability {
+export interface AgentRunDurability {
   onInputCommitted?: () => void | Promise<void>;
   /** Return true when the durable worker should pause at the next Pi boundary. */
   shouldYield?: () => boolean;
   drainSteeringMessages?: (
-    accept: (messages: ReplySteeringMessage[]) => Promise<void>,
-  ) => Promise<ReplySteeringMessage[]>;
+    accept: (messages: AgentRunSteeringMessage[]) => Promise<void>,
+  ) => Promise<AgentRunSteeringMessage[]>;
   recordPendingAuth?: (
     pendingAuth: ConversationPendingAuthState,
   ) => void | Promise<void>;
@@ -303,28 +296,24 @@ export interface ReplyRequestDurability {
   ) => void | Promise<void>;
 }
 
-/** Groups the per-slice reply request by the runtime role each field serves. */
-export interface ReplyRequestContext {
-  input: ReplyRequestInput;
-  routing: ReplyRequestRouting;
-  policy?: ReplyRequestPolicy;
-  state?: ReplyRequestState;
-  observers?: ReplyRequestObservers;
-  durability?: ReplyRequestDurability;
+/** Groups the per-slice agent-run request by the runtime role each field serves. */
+export interface AgentRunRequest {
+  input: AgentRunInput;
+  routing: AgentRunRouting;
+  policy?: AgentRunPolicy;
+  state?: AgentRunState;
+  observers?: AgentRunObservers;
+  durability?: AgentRunDurability;
 }
 
-export type AssistantReplyRequestContext = ReplyRequestContext;
+type FlatAgentRunRequest = AgentRunInput &
+  AgentRunRouting &
+  AgentRunPolicy &
+  AgentRunState &
+  AgentRunObservers &
+  AgentRunDurability;
 
-type FlatReplyRequestContext = ReplyRequestInput &
-  ReplyRequestRouting &
-  ReplyRequestPolicy &
-  ReplyRequestState &
-  ReplyRequestObservers &
-  ReplyRequestDurability;
-
-function flattenReplyRequestContext(
-  request: ReplyRequestContext,
-): FlatReplyRequestContext {
+function flattenAgentRunRequest(request: AgentRunRequest): FlatAgentRunRequest {
   return {
     ...request.input,
     ...request.routing,
@@ -335,18 +324,18 @@ function flattenReplyRequestContext(
   };
 }
 
-export interface ReplyRequestAttachment {
+export interface AgentRunAttachment {
   data?: Buffer;
   mediaType: string;
   filename?: string;
   promptText?: string;
 }
 
-export interface ReplySteeringMessage {
+export interface AgentRunSteeringMessage {
   omittedImageAttachmentCount?: number;
   text: string;
   timestampMs?: number;
-  userAttachments?: ReplyRequestAttachment[];
+  userAttachments?: AgentRunAttachment[];
 }
 
 let startupDiscoveryLogged = false;
@@ -363,9 +352,7 @@ const legacyStoredTextPartSchema = z
   })
   .strict();
 
-type UserTurnAttachment = NonNullable<
-  ReplyRequestInput["userAttachments"]
->[number];
+type UserTurnAttachment = NonNullable<AgentRunInput["userAttachments"]>[number];
 
 function buildOmittedImageAttachmentNotice(count: number): string {
   return [
@@ -399,15 +386,13 @@ function extractSliceUsage(
 }
 
 function requesterFromContext(
-  context: FlatReplyRequestContext,
+  context: FlatAgentRunRequest,
 ): Requester | undefined {
   return actorRequesterFromContext(context);
 }
 
 /** Reject requester identities that do not belong to the active destination. */
-function assertRequesterDestinationMatch(
-  context: FlatReplyRequestContext,
-): void {
+function assertRequesterDestinationMatch(context: FlatAgentRunRequest): void {
   const { destination, requester } = context;
   if (!requester) {
     return;
@@ -427,9 +412,7 @@ function assertRequesterDestinationMatch(
 }
 
 /** Reject legacy Slack correlation fields that conflict with the destination. */
-function assertCorrelationDestinationMatch(
-  context: FlatReplyRequestContext,
-): void {
+function assertCorrelationDestinationMatch(context: FlatAgentRunRequest): void {
   const { correlation, destination } = context;
   if (destination.platform !== "slack") {
     return;
@@ -453,7 +436,7 @@ function assertCorrelationDestinationMatch(
 }
 
 function actorRequesterFromContext(
-  context: FlatReplyRequestContext,
+  context: FlatAgentRunRequest,
 ): Requester | undefined {
   return createRequester(context.requester, {
     platform:
@@ -471,9 +454,7 @@ function actorRequesterFromContext(
   });
 }
 
-function toolInvocationDestination(
-  context: FlatReplyRequestContext,
-): Destination {
+function toolInvocationDestination(context: FlatAgentRunRequest): Destination {
   if (context.destination.platform !== "slack" || !context.toolChannelId) {
     return context.destination;
   }
@@ -485,7 +466,7 @@ function toolInvocationDestination(
 }
 
 function surfaceFromContext(
-  context: FlatReplyRequestContext,
+  context: FlatAgentRunRequest,
 ): AgentTurnSurface | undefined {
   if (context.surface) {
     return context.surface;
@@ -550,7 +531,7 @@ function buildRouterAttachmentBlock(attachment: UserTurnAttachment): string {
 
 function buildUserTurnInput(args: {
   omittedImageAttachmentCount: number;
-  userAttachments?: ReplyRequestInput["userAttachments"];
+  userAttachments?: AgentRunInput["userAttachments"];
   userTurnText: string;
 }): {
   routerBlocks: string[];
@@ -615,7 +596,7 @@ function buildUserTurnInput(args: {
  * paths store identical durable history.
  */
 export function buildSteeringPiMessage(
-  message: ReplySteeringMessage,
+  message: AgentRunSteeringMessage,
 ): PiMessage {
   const { userContentParts } = buildUserTurnInput({
     userTurnText: buildUserTurnText(message.text),
@@ -700,10 +681,10 @@ function legacyTextPartMatchesCurrentText(
 }
 
 /** Run a full agent turn: discover skills, execute tools, and return the assistant reply. */
-export async function generateAssistantReply(
-  request: AssistantReplyRequestContext,
+export async function executeAgentRun(
+  request: AgentRunRequest,
 ): Promise<AgentRunOutcome> {
-  const context = flattenReplyRequestContext(request);
+  const context = flattenAgentRunRequest(request);
   const messageText = request.input.messageText;
   const conversationPrivacy = resolveConversationPrivacy({
     channelId: context.correlation?.channelId,
@@ -716,17 +697,13 @@ export async function generateAssistantReply(
     visibility: context.slackConversation?.visibility,
   });
   return runWithConversationPrivacy(conversationPrivacy ?? "private", () =>
-    generateAssistantReplyInPrivacyContext(
-      messageText,
-      context,
-      conversationPrivacy,
-    ),
+    executeAgentRunInPrivacyContext(messageText, context, conversationPrivacy),
   );
 }
 
-async function generateAssistantReplyInPrivacyContext(
+async function executeAgentRunInPrivacyContext(
   messageText: string,
-  context: FlatReplyRequestContext,
+  context: FlatAgentRunRequest,
   conversationPrivacy: ConversationPrivacy | undefined,
 ): Promise<AgentRunOutcome> {
   if (!context.destination) {
@@ -2112,7 +2089,7 @@ async function generateAssistantReplyInPrivacyContext(
         modelId: botConfig.modelId,
       },
       {},
-      "generateAssistantReply failed",
+      "executeAgentRun failed",
     );
 
     // Raw exception text is diagnostics-only; the failure-response service

--- a/packages/junior/src/chat/agent-run/checkpointer.ts
+++ b/packages/junior/src/chat/agent-run/checkpointer.ts
@@ -1,0 +1,295 @@
+import type { Destination, Source } from "@sentry/junior-plugin-api";
+import type { PiMessage } from "@/chat/pi/messages";
+import {
+  CooperativeTurnYieldError,
+  TurnInputCommitLostError,
+} from "@/chat/runtime/turn";
+import type { AgentRunOutcome } from "@/chat/runtime/agent-run-outcome";
+import type { AgentTurnSurface } from "@/chat/state/turn-session";
+import type { Requester } from "@/chat/requester";
+import {
+  loadTurnSessionRecord,
+  persistAuthPauseSessionRecord,
+  persistRunningSessionRecord,
+  persistTimeoutSessionRecord,
+  persistYieldSessionRecord,
+} from "@/chat/services/turn-session-record";
+import { AuthorizationPauseError } from "@/chat/services/auth-pause";
+import type { TurnThinkingSelection } from "@/chat/services/turn-thinking-level";
+import { hasAgentTurnUsage, type AgentTurnUsage } from "@/chat/usage";
+import { extractGenAiUsageSummary } from "@/chat/logging";
+import { isAssistantMessage } from "@/chat/agent-run-helpers";
+import type { AgentRunDurability } from "@/chat/agent-run/request";
+
+type LoadedSessionRecordState = Awaited<
+  ReturnType<typeof loadTurnSessionRecord>
+>;
+type SessionRecordLogContext = NonNullable<
+  Parameters<typeof persistRunningSessionRecord>[0]["logContext"]
+>;
+
+interface SliceCheckpointerArgs {
+  channelName?: string;
+  destination: Destination;
+  durability: AgentRunDurability;
+  logContext: SessionRecordLogContext;
+  recordActiveMcpProviders: () => Promise<void>;
+  requester?: Requester;
+  runSource: Source;
+  sessionConversationId?: string;
+  sessionId?: string;
+  startedAtMs: number;
+  surface?: AgentTurnSurface;
+  sessionRecordState: LoadedSessionRecordState;
+  getLoadedSkillNames: () => string[];
+}
+
+interface ExpectedEndingTranslationArgs {
+  currentUsage?: AgentTurnUsage;
+  error: unknown;
+  thinkingSelection?: TurnThinkingSelection;
+}
+
+interface ExpectedEndingTranslation {
+  outcome?: AgentRunOutcome;
+  usage?: AgentTurnUsage;
+}
+
+function extractSliceUsage(
+  messages: PiMessage[],
+  beforeMessageCount: number,
+): AgentTurnUsage | undefined {
+  const usage = extractGenAiUsageSummary(
+    ...messages.slice(beforeMessageCount).filter(isAssistantMessage),
+  );
+  return hasAgentTurnUsage(usage) ? usage : undefined;
+}
+
+/** Owns durable safe-boundary checkpoints and expected slice-ending persistence. */
+export function createSliceCheckpointer(args: SliceCheckpointerArgs) {
+  let beforeMessageCount = 0;
+  let cooperativeYieldError: CooperativeTurnYieldError | undefined;
+  let inputCommitted = false;
+  let latestSafeBoundaryMessages: PiMessage[] = [];
+  let timedOut = false;
+  let timeoutResumeMessages: PiMessage[] = [];
+  let turnStartMessageIndex: number | undefined;
+
+  const currentSliceId = args.sessionRecordState.currentSliceId;
+  const canPersistSession =
+    args.sessionRecordState.canUseTurnSession &&
+    Boolean(args.sessionConversationId && args.sessionId);
+
+  const currentDurationMs = () => Date.now() - args.startedAtMs;
+  const currentUsage = (
+    existingUsage: AgentTurnUsage | undefined,
+  ): AgentTurnUsage | undefined =>
+    existingUsage ??
+    extractSliceUsage(timeoutResumeMessages, beforeMessageCount);
+
+  const sessionRecordBase = () => ({
+    channelName: args.channelName,
+    conversationId: args.sessionConversationId!,
+    destination: args.destination,
+    source: args.runSource,
+    sessionId: args.sessionId!,
+    loadedSkillNames: args.getLoadedSkillNames(),
+    logContext: args.logContext,
+    requester: args.requester,
+    ...(args.surface ? { surface: args.surface } : {}),
+  });
+
+  return {
+    get cooperativeYieldError(): CooperativeTurnYieldError | undefined {
+      return cooperativeYieldError;
+    },
+    get inputCommitted(): boolean {
+      return inputCommitted;
+    },
+    get beforeMessageCount(): number {
+      return beforeMessageCount;
+    },
+    get timedOut(): boolean {
+      return timedOut;
+    },
+    setRunStartMessageIndex(index: number | undefined): void {
+      turnStartMessageIndex = index;
+    },
+    setBeforeMessageCount(count: number): void {
+      beforeMessageCount = count;
+    },
+    resetResumeSnapshot(): void {
+      timeoutResumeMessages = [];
+    },
+    captureResumeSnapshot(messages: PiMessage[]): void {
+      timeoutResumeMessages = [...messages];
+    },
+    getResumeSnapshot(currentMessages: PiMessage[]): PiMessage[] {
+      return latestSafeBoundaryMessages.length > currentMessages.length
+        ? [...latestSafeBoundaryMessages]
+        : [...currentMessages];
+    },
+    markTimedOut(): void {
+      timedOut = true;
+    },
+    async commitInput(): Promise<void> {
+      if (inputCommitted) {
+        return;
+      }
+      await args.durability.onInputCommitted?.();
+      inputCommitted = true;
+    },
+    async persistSafeBoundary(messages: PiMessage[]): Promise<boolean> {
+      if (!canPersistSession) {
+        return false;
+      }
+
+      const persisted = await persistRunningSessionRecord({
+        ...sessionRecordBase(),
+        sliceId: currentSliceId,
+        messages,
+        ...(turnStartMessageIndex !== undefined
+          ? { turnStartMessageIndex }
+          : {}),
+      });
+      if (!persisted) {
+        return false;
+      }
+
+      latestSafeBoundaryMessages = [...messages];
+      return true;
+    },
+    async requireDurableInputCheckpoint(
+      messages: PiMessage[],
+    ): Promise<boolean> {
+      const persisted = await this.persistSafeBoundary(messages);
+      if (!persisted && args.durability.onInputCommitted) {
+        throw new TurnInputCommitLostError(
+          `Durable turn input could not be checkpointed for conversation=${args.sessionConversationId ?? "unknown"} session=${args.sessionId ?? "unknown"}`,
+        );
+      }
+      return persisted;
+    },
+    yieldAtSafeBoundaryIfDue(currentMessages: PiMessage[]): void {
+      if (!args.durability.shouldYield?.()) {
+        return;
+      }
+
+      timeoutResumeMessages = this.getResumeSnapshot(currentMessages);
+      cooperativeYieldError = new CooperativeTurnYieldError(
+        `Agent turn yielded at a safe boundary after ${currentDurationMs()}ms`,
+      );
+      throw cooperativeYieldError;
+    },
+    async translateExpectedEnding({
+      currentUsage: existingUsage,
+      error,
+      thinkingSelection,
+    }: ExpectedEndingTranslationArgs): Promise<ExpectedEndingTranslation> {
+      if (!args.sessionConversationId || !args.sessionId) {
+        return {};
+      }
+
+      if (cooperativeYieldError && error instanceof CooperativeTurnYieldError) {
+        const usage = currentUsage(existingUsage);
+        await args.recordActiveMcpProviders();
+        const sessionRecord = await persistYieldSessionRecord({
+          ...sessionRecordBase(),
+          currentSliceId,
+          currentDurationMs: currentDurationMs(),
+          currentUsage: usage,
+          messages: timeoutResumeMessages,
+          errorMessage: error.message,
+        });
+        if (!sessionRecord) {
+          throw new Error(
+            `Failed to persist cooperative yield continuation for conversation=${args.sessionConversationId} session=${args.sessionId}`,
+          );
+        }
+        return {
+          usage,
+          outcome: {
+            status: "yielded",
+            conversationId: args.sessionConversationId,
+            sessionId: args.sessionId,
+            sliceId: sessionRecord.sliceId,
+            version: sessionRecord.version,
+          },
+        };
+      }
+
+      if (timedOut) {
+        const usage = currentUsage(existingUsage);
+        await args.recordActiveMcpProviders();
+        const sessionRecord = await persistTimeoutSessionRecord({
+          ...sessionRecordBase(),
+          currentSliceId,
+          currentDurationMs: currentDurationMs(),
+          currentUsage: usage,
+          messages: timeoutResumeMessages,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        });
+        if (!sessionRecord) {
+          throw new Error(
+            `Failed to persist timeout continuation for conversation=${args.sessionConversationId} session=${args.sessionId}`,
+          );
+        }
+        if (sessionRecord.state === "awaiting_resume") {
+          return {
+            usage,
+            outcome: {
+              status: "timed_out",
+              conversationId: args.sessionConversationId,
+              sessionId: args.sessionId,
+              sliceId: sessionRecord.sliceId,
+              version: sessionRecord.version,
+            },
+          };
+        }
+        throw new Error(
+          sessionRecord.errorMessage ??
+            (error instanceof Error ? error.message : String(error)),
+        );
+      }
+
+      if (error instanceof AuthorizationPauseError) {
+        const usage =
+          existingUsage ??
+          (timeoutResumeMessages.length > 0
+            ? extractSliceUsage(timeoutResumeMessages, beforeMessageCount)
+            : undefined);
+        await args.recordActiveMcpProviders();
+        const sessionRecord = await persistAuthPauseSessionRecord({
+          ...sessionRecordBase(),
+          currentSliceId,
+          currentDurationMs: currentDurationMs(),
+          currentUsage: usage,
+          messages: timeoutResumeMessages,
+          errorMessage: error.message,
+        });
+        if (sessionRecord) {
+          return {
+            usage,
+            outcome: {
+              status: "awaiting_auth",
+              authDisposition: error.disposition,
+              authDurationMs: currentDurationMs(),
+              authKind: error.kind,
+              authProvider: error.provider,
+              authProviderDisplayName: error.providerDisplayName,
+              authThinkingLevel: thinkingSelection?.thinkingLevel,
+              authUsage: usage,
+              conversationId: args.sessionConversationId,
+              sessionId: args.sessionId,
+              sliceId: sessionRecord.sliceId,
+            },
+          };
+        }
+      }
+
+      return {};
+    },
+  };
+}
+
+export type SliceCheckpointer = ReturnType<typeof createSliceCheckpointer>;

--- a/packages/junior/src/chat/agent-run/events.ts
+++ b/packages/junior/src/chat/agent-run/events.ts
@@ -1,0 +1,69 @@
+import type { Agent } from "@earendil-works/pi-agent-core";
+import { logWarn, type LogContext } from "@/chat/logging";
+import type { AgentRunObservers } from "@/chat/agent-run/request";
+import type { SliceCheckpointer } from "@/chat/agent-run/checkpointer";
+
+/** Subscribes to Pi events so streaming observers and safe-boundary writes stay coupled. */
+export function subscribeToAgentEvents(args: {
+  agent: Agent;
+  checkpointer: SliceCheckpointer;
+  observers: AgentRunObservers;
+  recordParentToolExecutionStart: (event: {
+    args: unknown;
+    toolCallId: string;
+    toolName: string;
+  }) => Promise<void>;
+  spanContext: LogContext;
+}): () => void {
+  let hasEmittedText = false;
+  let needsSeparator = false;
+  return args.agent.subscribe((event) => {
+    if (event.type === "tool_execution_start") {
+      return args.recordParentToolExecutionStart(event);
+    }
+    if (event.type === "turn_end" && event.toolResults.length > 0) {
+      return args.checkpointer
+        .persistSafeBoundary([...args.agent.state.messages])
+        .then(() => undefined);
+    }
+    if (event.type === "message_start") {
+      Promise.resolve(args.observers.onAssistantMessageStart?.()).catch(
+        (error) => {
+          logWarn(
+            "streaming_message_start_error",
+            {},
+            {
+              "exception.message":
+                error instanceof Error ? error.message : String(error),
+            },
+            "Failed to deliver assistant message start to stream coordinator",
+          );
+        },
+      );
+      if (hasEmittedText) {
+        needsSeparator = true;
+      }
+      return;
+    }
+    if (event.type !== "message_update") return;
+    if (event.assistantMessageEvent.type !== "text_delta") return;
+    const deltaText = event.assistantMessageEvent.delta;
+    if (!deltaText) return;
+
+    const text = needsSeparator ? "\n\n" + deltaText : deltaText;
+    needsSeparator = false;
+    hasEmittedText = true;
+
+    Promise.resolve(args.observers.onTextDelta?.(text)).catch((error) => {
+      logWarn(
+        "streaming_text_delta_error",
+        {},
+        {
+          "exception.message":
+            error instanceof Error ? error.message : String(error),
+        },
+        "Failed to deliver text delta to stream",
+      );
+    });
+  });
+}

--- a/packages/junior/src/chat/agent-run/prompt.ts
+++ b/packages/junior/src/chat/agent-run/prompt.ts
@@ -1,0 +1,417 @@
+import type { Source } from "@sentry/junior-plugin-api";
+import { z } from "zod";
+import {
+  extractCurrentInstructionBody,
+  renderCurrentInstruction,
+} from "@/chat/current-instruction";
+import {
+  buildPluginSystemPromptContributions,
+  buildSystemPrompt,
+  buildTurnContextPrompt,
+} from "@/chat/prompt";
+import {
+  getPluginSystemPromptContributions,
+  getPluginUserPromptContributions,
+} from "@/chat/plugins/agent-hooks";
+import type { PiMessage } from "@/chat/pi/messages";
+import {
+  hasRuntimeTurnContext,
+  stripRuntimeTurnContext,
+  toObservablePromptPart,
+  buildUserTurnText,
+  encodeNonImageAttachmentForPrompt,
+} from "@/chat/agent-run-helpers";
+import { serializeGenAiAttribute, type LogContext } from "@/chat/logging";
+import {
+  toGenAiMessageMetadata,
+  type ConversationPrivacy,
+} from "@/chat/conversation-privacy";
+import type { SkillInvocation, SkillMetadata } from "@/chat/skills";
+import type { ToolRuntimeContext } from "@/chat/tools/types";
+import type { ToolDefinition } from "@/chat/tools/definition";
+import type { Requester } from "@/chat/requester";
+import type { ThreadArtifactsState } from "@/chat/state/artifacts";
+import type { AgentRunInput, AgentRunRouting } from "@/chat/agent-run/request";
+
+const MAX_ROUTER_ATTACHMENT_PREVIEW_CHARS = 2_000;
+
+export type UserContentPart =
+  | { type: "text"; text: string }
+  | { type: "image"; data: string; mimeType: string };
+
+const legacyStoredTextPartSchema = z
+  .object({
+    text: z.string(),
+    type: z.literal("text"),
+  })
+  .strict();
+
+type UserRunAttachment = NonNullable<AgentRunInput["userAttachments"]>[number];
+
+export interface PromptInput {
+  routerBlocks: string[];
+  userContentParts: UserContentPart[];
+}
+
+export interface PromptAssembly {
+  baseInstructions: string;
+  inputMessages: Array<{
+    role: string;
+    content: Record<string, unknown>[];
+  }>;
+  inputMessagesAttribute: string | undefined;
+  promptContentParts: UserContentPart[];
+  promptHistoryMessages: PiMessage[];
+  shouldPromptAgent: boolean;
+}
+
+function buildOmittedImageAttachmentNotice(count: number): string {
+  return [
+    "<omitted-image-attachments>",
+    `count: ${count}`,
+    "Slack included image attachments with this turn, but this runtime cannot analyze images because no vision model is configured.",
+    "Do not claim that no image was attached.",
+    "If the user asks about image contents, explain that image analysis is unavailable in this runtime and continue with any text or non-image files that are still available.",
+    "</omitted-image-attachments>",
+  ].join("\n");
+}
+
+function trimRouterAttachmentText(text: string): string {
+  const normalized = text.replaceAll("\0", " ").trim();
+  if (!normalized) {
+    return "";
+  }
+  return normalized.length <= MAX_ROUTER_ATTACHMENT_PREVIEW_CHARS
+    ? normalized
+    : `${normalized.slice(0, MAX_ROUTER_ATTACHMENT_PREVIEW_CHARS)}...`;
+}
+
+function supportsRouterTextPreview(mediaType: string): boolean {
+  const baseMediaType = mediaType.split(";", 1)[0]?.trim().toLowerCase();
+  if (!baseMediaType) {
+    return false;
+  }
+  return (
+    baseMediaType.startsWith("text/") ||
+    baseMediaType === "application/json" ||
+    baseMediaType === "application/xml" ||
+    baseMediaType === "application/x-www-form-urlencoded" ||
+    baseMediaType.endsWith("+json") ||
+    baseMediaType.endsWith("+xml")
+  );
+}
+
+function buildRouterAttachmentBlock(attachment: UserRunAttachment): string {
+  if (attachment.promptText) {
+    return trimRouterAttachmentText(attachment.promptText);
+  }
+
+  const header = [
+    "<attachment>",
+    `filename: ${attachment.filename ?? "unnamed"}`,
+    `media_type: ${attachment.mediaType}`,
+  ];
+
+  if (attachment.data && supportsRouterTextPreview(attachment.mediaType)) {
+    const preview = trimRouterAttachmentText(attachment.data.toString("utf8"));
+    if (preview) {
+      return [
+        ...header,
+        "<text-preview>",
+        preview,
+        "</text-preview>",
+        "</attachment>",
+      ].join("\n");
+    }
+  }
+
+  return [...header, "</attachment>"].join("\n");
+}
+
+function buildUserRunInput(args: {
+  omittedImageAttachmentCount: number;
+  userAttachments?: AgentRunInput["userAttachments"];
+  userRunText: string;
+}): PromptInput {
+  const routerBlocks: string[] = [];
+  const userContentParts: UserContentPart[] = [
+    { type: "text", text: args.userRunText },
+  ];
+
+  if (args.omittedImageAttachmentCount > 0) {
+    const omittedImagesNotice = buildOmittedImageAttachmentNotice(
+      args.omittedImageAttachmentCount,
+    );
+    userContentParts.push({ type: "text", text: omittedImagesNotice });
+    routerBlocks.push(omittedImagesNotice);
+  }
+
+  for (const attachment of args.userAttachments ?? []) {
+    routerBlocks.push(buildRouterAttachmentBlock(attachment));
+
+    if (attachment.promptText) {
+      userContentParts.push({
+        type: "text",
+        text: attachment.promptText,
+      });
+      continue;
+    }
+
+    if (attachment.mediaType.startsWith("image/")) {
+      if (!attachment.data) {
+        throw new Error("Image attachment is missing image data");
+      }
+      userContentParts.push({
+        type: "image",
+        data: attachment.data.toString("base64"),
+        mimeType: attachment.mediaType,
+      });
+      continue;
+    }
+
+    if (!attachment.data) {
+      throw new Error("Attachment is missing attachment data");
+    }
+
+    userContentParts.push({
+      type: "text",
+      text: encodeNonImageAttachmentForPrompt({
+        data: attachment.data,
+        mediaType: attachment.mediaType,
+        filename: attachment.filename,
+      }),
+    });
+  }
+
+  return { routerBlocks, userContentParts };
+}
+
+/** Builds the prompt-facing user input while keeping attachment routing text aligned with Pi content. */
+export function buildPromptInput(args: {
+  input: AgentRunInput;
+  userInput: string;
+}): PromptInput {
+  const promptConversationContext =
+    args.input.piMessages && args.input.piMessages.length > 0
+      ? undefined
+      : args.input.conversationContext;
+  const userRunText = buildUserTurnText(
+    args.userInput,
+    promptConversationContext,
+  );
+  return buildUserRunInput({
+    omittedImageAttachmentCount: args.input.omittedImageAttachmentCount ?? 0,
+    userAttachments: args.input.userAttachments,
+    userRunText,
+  });
+}
+
+/**
+ * Convert a mid-run user message into the Pi user message shape used for
+ * steering injection and parked-conversation session-log appends, so both
+ * paths store identical durable history.
+ */
+export function buildSteeringPiMessage(message: {
+  omittedImageAttachmentCount?: number;
+  text: string;
+  timestampMs?: number;
+  userAttachments?: AgentRunInput["userAttachments"];
+}): PiMessage {
+  const { userContentParts } = buildUserRunInput({
+    userRunText: buildUserTurnText(message.text),
+    userAttachments: message.userAttachments,
+    omittedImageAttachmentCount: message.omittedImageAttachmentCount ?? 0,
+  });
+  return {
+    role: "user",
+    content: userContentParts,
+    timestamp: message.timestampMs ?? Date.now(),
+  } as PiMessage;
+}
+
+function withoutTrailingUncheckpointedUserPrompt(
+  messages: PiMessage[] | undefined,
+  userContentParts: UserContentPart[],
+): PiMessage[] {
+  if (!messages || messages.length === 0) {
+    return [];
+  }
+
+  const lastMessage = messages.at(-1) as
+    | { content?: unknown; role?: unknown }
+    | undefined;
+  if (lastMessage?.role !== "user") {
+    return messages;
+  }
+  const comparableLastMessage = stripRuntimeTurnContext([
+    lastMessage as PiMessage,
+  ])[0] as { content?: unknown } | undefined;
+  if (
+    !userPromptContentMatches(comparableLastMessage?.content, userContentParts)
+  ) {
+    return messages;
+  }
+  return messages.slice(0, -1);
+}
+
+/** Match stored resume prompts against the current wrapped prompt shape. */
+function userPromptContentMatches(
+  storedContent: unknown,
+  currentContent: UserContentPart[],
+): boolean {
+  if (JSON.stringify(storedContent) === JSON.stringify(currentContent)) {
+    return true;
+  }
+  if (!Array.isArray(storedContent)) {
+    return false;
+  }
+  if (storedContent.length !== currentContent.length) {
+    return false;
+  }
+
+  return storedContent.every((storedPart, index) => {
+    const currentPart = currentContent[index];
+    if (index === 0 && currentPart?.type === "text") {
+      const legacyTextPart = legacyStoredTextPartSchema.safeParse(storedPart);
+      if (legacyTextPart.success) {
+        // TODO(v0.84.0): Remove legacy unwrapped resume prompt matching after
+        // pre-current-instruction session records expire.
+        return legacyTextPartMatchesCurrentText(
+          legacyTextPart.data.text,
+          currentPart.text,
+        );
+      }
+    }
+
+    return JSON.stringify(storedPart) === JSON.stringify(currentPart);
+  });
+}
+
+function legacyTextPartMatchesCurrentText(
+  storedText: string,
+  currentText: string,
+): boolean {
+  const storedInstructionBody = extractCurrentInstructionBody(storedText);
+  if (storedInstructionBody !== undefined) {
+    return renderCurrentInstruction(storedInstructionBody) === currentText;
+  }
+
+  return renderCurrentInstruction(storedText) === currentText;
+}
+
+/** Assembles prompt history and telemetry input from restored state and wired tools. */
+export async function assemblePrompt(args: {
+  activeMcpCatalogs: ReturnType<
+    typeof import("@/chat/tools/skill/mcp-tool-summary").toActiveMcpCatalogSummaries
+  >;
+  actorRequester?: Requester;
+  artifactState?: ThreadArtifactsState;
+  availableSkills: SkillMetadata[];
+  configurationValues: Record<string, unknown>;
+  conversationPrivacy?: ConversationPrivacy;
+  dispatch?: AgentRunRouting["dispatch"];
+  existingRunStartMessageIndex?: number;
+  existingSessionPiMessages?: PiMessage[];
+  invocation: SkillInvocation | null;
+  priorPiMessages?: PiMessage[];
+  resumedFromSessionRecord: boolean;
+  routing: AgentRunRouting;
+  source: Source;
+  spanContext: LogContext;
+  toolGuidance: Array<{
+    name: string;
+    promptGuidelines: ToolDefinition<any>["promptGuidelines"];
+    promptSnippet: ToolDefinition<any>["promptSnippet"];
+  }>;
+  toolRuntimeContext: ToolRuntimeContext;
+  userContentParts: UserContentPart[];
+}): Promise<PromptAssembly> {
+  const hasPromptCheckpoint =
+    args.resumedFromSessionRecord &&
+    args.existingRunStartMessageIndex !== undefined;
+  const shouldPromptAgent =
+    !args.resumedFromSessionRecord || !hasPromptCheckpoint;
+  // Every re-prompt shape must trim a trailing checkpointed copy of the same
+  // user prompt, including redelivery of the same inbound message after a
+  // lost input commit against a still-`running` record; otherwise the prompt
+  // appears twice in Pi history.
+  const promptHistoryMessages = shouldPromptAgent
+    ? withoutTrailingUncheckpointedUserPrompt(
+        args.priorPiMessages,
+        args.userContentParts,
+      )
+    : args.existingSessionPiMessages!;
+  const needsBootstrapContextForPrompt =
+    shouldPromptAgent && !hasRuntimeTurnContext(promptHistoryMessages);
+  const systemPromptContributions = await getPluginSystemPromptContributions(
+    args.source,
+  );
+  const pluginSystemPrompt = buildPluginSystemPromptContributions(
+    systemPromptContributions,
+  );
+  const baseInstructions = [
+    buildSystemPrompt({ source: args.source }),
+    pluginSystemPrompt,
+  ]
+    .filter((section): section is string => Boolean(section))
+    .join("\n\n");
+  const pluginUserPromptContributions = !shouldPromptAgent
+    ? []
+    : await getPluginUserPromptContributions({
+        context: args.toolRuntimeContext,
+      });
+  const turnContextPrompt =
+    needsBootstrapContextForPrompt || pluginUserPromptContributions.length > 0
+      ? buildTurnContextPrompt({
+          availableSkills: args.availableSkills,
+          activeMcpCatalogs: args.activeMcpCatalogs,
+          includeSessionContext: needsBootstrapContextForPrompt,
+          pluginPromptContributions: pluginUserPromptContributions,
+          toolGuidance: args.toolGuidance,
+          runtime: {
+            conversationId: args.spanContext.conversationId,
+            slackConversation: args.routing.slackConversation,
+          },
+          dispatch: args.dispatch
+            ? {
+                ...args.dispatch,
+                destination: args.routing.destination,
+                source: args.source,
+              }
+            : undefined,
+          invocation: args.invocation,
+          requester: args.actorRequester,
+          artifactState: args.artifactState,
+          configuration: args.configurationValues,
+        })
+      : null;
+  const turnContextParts: UserContentPart[] = turnContextPrompt
+    ? [{ type: "text", text: turnContextPrompt }]
+    : [];
+  const promptContentParts = [...turnContextParts, ...args.userContentParts];
+
+  const inputMessages = [
+    {
+      role: "system",
+      content: [{ type: "text", text: baseInstructions }],
+    },
+    {
+      role: "user",
+      content: promptContentParts.map((part) => toObservablePromptPart(part)),
+    },
+  ];
+  const inputMessagesAttribute = serializeGenAiAttribute(
+    args.conversationPrivacy !== "public"
+      ? inputMessages.map(toGenAiMessageMetadata)
+      : inputMessages,
+  );
+
+  return {
+    baseInstructions,
+    inputMessages,
+    inputMessagesAttribute,
+    promptContentParts,
+    promptHistoryMessages,
+    shouldPromptAgent,
+  };
+}

--- a/packages/junior/src/chat/agent-run/request.ts
+++ b/packages/junior/src/chat/agent-run/request.ts
@@ -1,0 +1,138 @@
+import type { Destination, Source } from "@sentry/junior-plugin-api";
+import type { SandboxAcquiredState } from "@/chat/sandbox/sandbox";
+import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress/tracing";
+import type { AssistantStatusSpec } from "@/chat/slack/assistant-thread/status";
+import type { SlackConversationContext } from "@/chat/slack/conversation-context";
+import type { ThreadArtifactsState } from "@/chat/state/artifacts";
+import type { ConversationPendingAuthState } from "@/chat/state/conversation";
+import type { AgentTurnSurface } from "@/chat/state/turn-session";
+import type { CredentialContext } from "@/chat/credentials/context";
+import type { Requester } from "@/chat/requester";
+import type { ChannelConfigurationService } from "@/chat/configuration/types";
+import type {
+  ImageGenerateToolDeps,
+  WebFetchToolDeps,
+  WebSearchToolDeps,
+} from "@/chat/tools/types";
+import type { ToolExecutionReport } from "@/chat/tools/agent-tools";
+import type { AuthorizationFlowMode } from "@/chat/services/auth-pause";
+import type { PiMessage } from "@/chat/pi/messages";
+
+/** Carries the user-visible content and prior transcript for one agent-run slice. */
+export interface AgentRunInput {
+  messageText: string;
+  userAttachments?: AgentRunAttachment[];
+  inboundAttachmentCount?: number;
+  omittedImageAttachmentCount?: number;
+  /** Durable Pi transcript for this conversation, excluding ephemeral turn context. */
+  piMessages?: PiMessage[];
+  conversationContext?: string;
+}
+
+/** Carries identity and addressing needed to route tools, auth, and delivery. */
+export interface AgentRunRouting {
+  credentialContext?: CredentialContext;
+  requester?: Requester;
+  source: Source;
+  slackConversation?: SlackConversationContext;
+  destination: Destination;
+  surface?: AgentTurnSurface;
+  dispatch?: {
+    actor?: { id: string; type: string };
+    metadata?: Record<string, string>;
+    plugin?: string;
+  };
+  correlation?: {
+    conversationId?: string;
+    threadId?: string;
+    turnId?: string;
+    runId?: string;
+    channelId?: string;
+    channelName?: string;
+    teamId?: string;
+    messageTs?: string;
+    threadTs?: string;
+    requesterId?: string;
+  };
+  toolChannelId?: string;
+}
+
+/** Carries execution limits and dependency overrides for one run slice. */
+export interface AgentRunPolicy {
+  /** Absolute wall-clock deadline for this host request, in milliseconds. */
+  turnDeadlineAtMs?: number;
+  authorizationFlowMode?: AuthorizationFlowMode;
+  configuration?: Record<string, unknown>;
+  channelConfiguration?: ChannelConfigurationService;
+  skillDirs?: string[];
+  sandbox?: {
+    sandboxId?: string;
+    sandboxDependencyProfileHash?: string;
+    /** Per-slice override for app-owned sandbox egress trace propagation. */
+    tracePropagation?: SandboxEgressTracePropagationConfig;
+  };
+  toolOverrides?: {
+    imageGenerate?: ImageGenerateToolDeps;
+    webFetch?: WebFetchToolDeps;
+    webSearch?: WebSearchToolDeps;
+  };
+}
+
+/** Carries durable state snapshots already loaded by the caller. */
+export interface AgentRunState {
+  artifactState?: ThreadArtifactsState;
+  pendingAuth?: ConversationPendingAuthState;
+}
+
+/** Carries non-blocking notifications for streaming UI and status surfaces. */
+export interface AgentRunObservers {
+  onTextDelta?: (deltaText: string) => void | Promise<void>;
+  onAssistantMessageStart?: () => void | Promise<void>;
+  onToolInvocation?: (invocation: {
+    toolName: string;
+    params: Record<string, unknown>;
+  }) => void | Promise<void>;
+  onToolResult?: (result: ToolExecutionReport) => void | Promise<void>;
+  onStatus?: (status: AssistantStatusSpec) => void | Promise<void>;
+}
+
+/** Carries durable-worker ports that commit or update resumable run state. */
+export interface AgentRunDurability {
+  onInputCommitted?: () => void | Promise<void>;
+  /** Return true when the durable worker should pause at the next Pi boundary. */
+  shouldYield?: () => boolean;
+  drainSteeringMessages?: (
+    accept: (messages: AgentRunSteeringMessage[]) => Promise<void>,
+  ) => Promise<AgentRunSteeringMessage[]>;
+  recordPendingAuth?: (
+    pendingAuth: ConversationPendingAuthState,
+  ) => void | Promise<void>;
+  onSandboxAcquired?: (sandbox: SandboxAcquiredState) => void | Promise<void>;
+  onArtifactStateUpdated?: (
+    artifactState: ThreadArtifactsState,
+  ) => void | Promise<void>;
+}
+
+/** Groups the per-slice agent-run request by the runtime role each field serves. */
+export interface AgentRunRequest {
+  input: AgentRunInput;
+  routing: AgentRunRouting;
+  policy?: AgentRunPolicy;
+  state?: AgentRunState;
+  observers?: AgentRunObservers;
+  durability?: AgentRunDurability;
+}
+
+export interface AgentRunAttachment {
+  data?: Buffer;
+  mediaType: string;
+  filename?: string;
+  promptText?: string;
+}
+
+export interface AgentRunSteeringMessage {
+  omittedImageAttachmentCount?: number;
+  text: string;
+  timestampMs?: number;
+  userAttachments?: AgentRunAttachment[];
+}

--- a/packages/junior/src/chat/agent-run/sandbox-workspace.ts
+++ b/packages/junior/src/chat/agent-run/sandbox-workspace.ts
@@ -1,0 +1,74 @@
+import { logInfo, type LogContext } from "@/chat/logging";
+import type { SandboxExecutor } from "@/chat/sandbox/sandbox";
+import type { SandboxWorkspace } from "@/chat/sandbox/workspace";
+
+/** Preserves lazy sandbox boot semantics while exposing a stable workspace port to tools. */
+export function createLazySandboxWorkspace(args: {
+  executor: SandboxExecutor;
+  spanContext: LogContext;
+}): SandboxWorkspace {
+  let sandboxPromise: Promise<SandboxWorkspace> | undefined;
+  let sandboxPromiseId: string | undefined;
+  const clearSandboxPromise = (): void => {
+    sandboxPromise = undefined;
+    sandboxPromiseId = undefined;
+  };
+  const getSandbox = (reason: {
+    trigger: string;
+    path?: string;
+    cmd?: string;
+    cwd?: string;
+  }): Promise<SandboxWorkspace> => {
+    const currentSandboxId = args.executor.getSandboxId();
+    if (
+      sandboxPromise &&
+      sandboxPromiseId &&
+      currentSandboxId !== sandboxPromiseId
+    ) {
+      clearSandboxPromise();
+    }
+
+    if (!sandboxPromise) {
+      logInfo(
+        "sandbox_boot_requested",
+        args.spanContext,
+        {
+          "app.sandbox.boot.trigger": reason.trigger,
+          ...(reason.path ? { "file.path": reason.path } : {}),
+          ...(reason.cmd ? { "process.executable.name": reason.cmd } : {}),
+          ...(reason.cwd ? { "file.directory": reason.cwd } : {}),
+        },
+        "Lazy sandbox boot requested",
+      );
+      sandboxPromise = args.executor
+        .createSandbox()
+        .then((sandbox) => {
+          sandboxPromiseId = sandbox.sandboxId;
+          return sandbox;
+        })
+        .catch((error) => {
+          clearSandboxPromise();
+          throw error;
+        });
+    }
+    return sandboxPromise;
+  };
+
+  return {
+    readFileToBuffer: async (input) =>
+      (
+        await getSandbox({
+          trigger: "workspace.readFileToBuffer",
+          path: input.path,
+        })
+      ).readFileToBuffer(input),
+    runCommand: async (input) =>
+      (
+        await getSandbox({
+          trigger: "workspace.runCommand",
+          cmd: input.cmd,
+          cwd: input.cwd,
+        })
+      ).runCommand(input),
+  };
+}

--- a/packages/junior/src/chat/agent-run/session-restore.ts
+++ b/packages/junior/src/chat/agent-run/session-restore.ts
@@ -1,0 +1,34 @@
+import { getSessionIdentifiers } from "@/chat/agent-run-helpers";
+import { loadTurnSessionRecord } from "@/chat/services/turn-session-record";
+import type { AgentRunRouting } from "@/chat/agent-run/request";
+
+type LoadedSessionRecordState = Awaited<
+  ReturnType<typeof loadTurnSessionRecord>
+>;
+
+/** Restores the persisted session projection before tool and prompt phases need it. */
+export async function restoreSessionRecord(routing: AgentRunRouting): Promise<{
+  existingSessionRecord: LoadedSessionRecordState["existingSessionRecord"];
+  currentSliceId: number;
+  resumedFromSessionRecord: boolean;
+  sessionConversationId?: string;
+  sessionId?: string;
+  sessionRecordState: LoadedSessionRecordState;
+}> {
+  const { conversationId: sessionConversationId, sessionId } =
+    getSessionIdentifiers({ correlation: routing.correlation });
+  const sessionRecordState = await loadTurnSessionRecord({
+    conversationId: sessionConversationId,
+    sessionId,
+  });
+  const { resumedFromSessionRecord, currentSliceId, existingSessionRecord } =
+    sessionRecordState;
+  return {
+    currentSliceId,
+    existingSessionRecord,
+    resumedFromSessionRecord,
+    sessionConversationId,
+    sessionId,
+    sessionRecordState,
+  };
+}

--- a/packages/junior/src/chat/agent-run/skills.ts
+++ b/packages/junior/src/chat/agent-run/skills.ts
@@ -1,0 +1,69 @@
+import { logInfo, type LogContext } from "@/chat/logging";
+import { discoverSkills, type Skill, type SkillMetadata } from "@/chat/skills";
+import { SkillSandbox } from "@/chat/sandbox/skill-sandbox";
+import { inferLoadedSkillNamesFromPiMessages } from "@/chat/pi/derived-state";
+import type { PiMessage } from "@/chat/pi/messages";
+import { pluginCatalogRuntime } from "@/chat/plugins/catalog-runtime";
+import { upsertActiveSkill } from "@/chat/agent-run-helpers";
+
+let startupDiscoveryLogged = false;
+
+/** Discovers skills once per slice and emits the startup discovery summary once per process. */
+export async function discoverRunSkills(args: {
+  skillDirs?: string[];
+  spanContext: LogContext;
+}): Promise<Awaited<ReturnType<typeof discoverSkills>>> {
+  const availableSkills = await discoverSkills({
+    additionalRoots: args.skillDirs,
+  });
+  if (!startupDiscoveryLogged) {
+    startupDiscoveryLogged = true;
+    const plugins = pluginCatalogRuntime.getProviders();
+    const roots = [
+      ...new Set(availableSkills.map((skill) => skill.skillPath)),
+    ].sort();
+    logInfo(
+      "startup_discovery_summary",
+      args.spanContext,
+      {
+        "app.skill.count": availableSkills.length,
+        "app.skill.names": availableSkills.map((skill) => skill.name).sort(),
+        "app.file.directories": roots,
+        "app.plugin.count": plugins.length,
+        "app.plugin.names": plugins
+          .map((plugin) => plugin.manifest.name)
+          .sort(),
+      },
+      "Discovered startup SOUL/skills/plugins",
+    );
+  }
+  return availableSkills;
+}
+
+/** Rehydrates active skill handles from durable Pi history and explicit invocation. */
+export async function restoreSkillRuntime(args: {
+  activeSkills: Skill[];
+  invokedSkill: SkillMetadata | null;
+  priorPiMessages: PiMessage[] | undefined;
+  skillSandbox: SkillSandbox;
+  syncLoadedSkillNamesForResume: () => void;
+}): Promise<void> {
+  for (const skillName of inferLoadedSkillNamesFromPiMessages(
+    args.priorPiMessages,
+  )) {
+    const restoredSkill = await args.skillSandbox.loadSkill(skillName);
+    if (restoredSkill) {
+      upsertActiveSkill(args.activeSkills, restoredSkill);
+      args.syncLoadedSkillNamesForResume();
+    }
+  }
+  if (args.invokedSkill) {
+    const restoredSkill = await args.skillSandbox.loadSkill(
+      args.invokedSkill.name,
+    );
+    if (restoredSkill) {
+      upsertActiveSkill(args.activeSkills, restoredSkill);
+      args.syncLoadedSkillNamesForResume();
+    }
+  }
+}

--- a/packages/junior/src/chat/agent-run/tools.ts
+++ b/packages/junior/src/chat/agent-run/tools.ts
@@ -1,0 +1,464 @@
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import type { Destination, Source } from "@sentry/junior-plugin-api";
+import type { FileUpload } from "chat";
+import { botConfig } from "@/chat/config";
+import { listReferenceFiles } from "@/chat/discovery";
+import { maybeExecuteJrRpcCustomCommand } from "@/chat/capabilities/jr-rpc-command";
+import { createUserTokenStore } from "@/chat/capabilities/factory";
+import { SkillSandbox } from "@/chat/sandbox/skill-sandbox";
+import type { Skill, SkillInvocation, SkillMetadata } from "@/chat/skills";
+import {
+  createPluginHookRunner,
+  type PluginHookRunner,
+} from "@/chat/plugins/agent-hooks";
+import { pluginCatalogRuntime } from "@/chat/plugins/catalog-runtime";
+import { McpToolManager } from "@/chat/mcp/tool-manager";
+import { inferActiveMcpProvidersFromPiMessages } from "@/chat/pi/derived-state";
+import { createTools } from "@/chat/tools";
+import type { ToolDefinition } from "@/chat/tools/definition";
+import type { ToolRuntimeContext } from "@/chat/tools/types";
+import { toActiveMcpCatalogSummaries } from "@/chat/tools/skill/mcp-tool-summary";
+import { createAdvisorToolDefinitions } from "@/chat/tools/advisor/tool";
+import { createAgentTools } from "@/chat/tools/agent-tools";
+import {
+  createSandboxExecutor,
+  type SandboxExecutor,
+} from "@/chat/sandbox/sandbox";
+import { createLazySandboxWorkspace } from "@/chat/agent-run/sandbox-workspace";
+import { createMcpAuthOrchestration } from "@/chat/services/mcp-auth-orchestration";
+import { createPluginAuthOrchestration } from "@/chat/services/plugin-auth-orchestration";
+import { createPluginEgress } from "@/chat/egress/plugin";
+import { createTracedStreamFn } from "@/chat/pi/traced-stream";
+import type { PiMessage } from "@/chat/pi/messages";
+import type { LogContext } from "@/chat/logging";
+import { logWarn, setTags } from "@/chat/logging";
+import type { ConversationPrivacy } from "@/chat/conversation-privacy";
+import { mergeArtifactsState } from "@/chat/runtime/thread-state";
+import { upsertActiveSkill } from "@/chat/agent-run-helpers";
+import type { Requester } from "@/chat/requester";
+import type { ThreadArtifactsState } from "@/chat/state/artifacts";
+import type {
+  AgentRunDurability,
+  AgentRunObservers,
+  AgentRunPolicy,
+  AgentRunRouting,
+  AgentRunState,
+} from "@/chat/agent-run/request";
+import type { AgentTurnSurface } from "@/chat/state/turn-session";
+import type { AuthorizationPauseError } from "@/chat/services/auth-pause";
+import type { SliceCheckpointer } from "@/chat/agent-run/checkpointer";
+
+interface ToolWiringArgs {
+  abortAgent: () => void;
+  activeSkills: Skill[];
+  actorRequester?: Requester;
+  artifactStatePatch: Partial<ThreadArtifactsState>;
+  availableSkills: SkillMetadata[];
+  checkpointer: SliceCheckpointer;
+  configurationValues: Record<string, unknown>;
+  connectedMcpProviders: Set<string>;
+  conversationPrivacy?: ConversationPrivacy;
+  deliveryFiles: FileUpload[];
+  durability: AgentRunDurability;
+  generatedFiles: FileUpload[];
+  invokedSkill: SkillMetadata | null;
+  observers: AgentRunObservers;
+  onSandboxMetadataChanged: (sandbox: {
+    sandboxId?: string;
+    sandboxDependencyProfileHash?: string;
+  }) => void;
+  policy: AgentRunPolicy;
+  preAgentPromptMessages: () => PiMessage[];
+  priorPiMessages: PiMessage[] | undefined;
+  recordConnectedMcpProvider: (provider: string) => Promise<void>;
+  routing: AgentRunRouting;
+  runSource: Source;
+  sessionConversationId?: string;
+  sessionId?: string;
+  skillInvocation: SkillInvocation | null;
+  skillSandbox: SkillSandbox;
+  spanContext: LogContext;
+  state: AgentRunState;
+  surface?: AgentTurnSurface;
+  syncLoadedSkillNamesForResume: () => void;
+  toolCalls: string[];
+  userInput: string;
+}
+
+export interface ToolWiring {
+  activeMcpCatalogs: ReturnType<typeof toActiveMcpCatalogSummaries>;
+  agentTools: AgentTool[];
+  currentSandboxExecutor: SandboxExecutor;
+  getPendingAuthPause: () => AuthorizationPauseError | undefined;
+  mcpToolManager: McpToolManager;
+  pluginHooks: PluginHookRunner;
+  toolGuidance: Array<{
+    name: string;
+    promptGuidelines: ToolDefinition<any>["promptGuidelines"];
+    promptSnippet: ToolDefinition<any>["promptSnippet"];
+  }>;
+  toolRuntimeContext: ToolRuntimeContext;
+}
+
+function toolInvocationDestination(routing: AgentRunRouting): Destination {
+  if (routing.destination.platform !== "slack" || !routing.toolChannelId) {
+    return routing.destination;
+  }
+  return {
+    platform: "slack",
+    teamId: routing.destination.teamId,
+    channelId: routing.toolChannelId,
+  };
+}
+
+/** Wires sandbox, auth orchestration, MCP restoration, and Pi tool surfaces for one run slice. */
+export async function wireAgentTools(
+  args: ToolWiringArgs,
+): Promise<ToolWiring> {
+  const authRequesterId =
+    args.routing.credentialContext?.actor.type === "user"
+      ? args.routing.credentialContext.actor.userId
+      : undefined;
+  const userTokenStore = createUserTokenStore();
+  const pluginHooks = createPluginHookRunner({
+    requester: args.actorRequester,
+  });
+  const sandboxExecutor = createSandboxExecutor({
+    sandboxId: args.policy.sandbox?.sandboxId,
+    sandboxDependencyProfileHash:
+      args.policy.sandbox?.sandboxDependencyProfileHash,
+    traceContext: args.spanContext,
+    tracePropagation: args.policy.sandbox?.tracePropagation,
+    credentialEgress: args.routing.credentialContext,
+    agentHooks: pluginHooks,
+    onSandboxAcquired: async (sandbox) => {
+      args.onSandboxMetadataChanged({
+        sandboxId: sandbox.sandboxId,
+        sandboxDependencyProfileHash: sandbox.sandboxDependencyProfileHash,
+      });
+      await args.durability.onSandboxAcquired?.(sandbox);
+    },
+    runBashCustomCommand: async (command) => {
+      const result = await maybeExecuteJrRpcCustomCommand(command, {
+        activeSkill: args.skillSandbox.getActiveSkill(),
+        channelConfiguration: args.policy.channelConfiguration,
+        requesterId: args.actorRequester?.userId,
+        onConfigurationValueChanged: (key, value) => {
+          if (value === undefined) {
+            delete args.configurationValues[key];
+            return;
+          }
+          args.configurationValues[key] = value;
+        },
+      });
+      return result.handled
+        ? { handled: true, result: result.result }
+        : { handled: false };
+    },
+  });
+  const currentSandboxExecutor = sandboxExecutor;
+  sandboxExecutor.configureSkills(args.availableSkills);
+  sandboxExecutor.configureReferenceFiles(listReferenceFiles());
+  const sandbox = createLazySandboxWorkspace({
+    executor: currentSandboxExecutor,
+    spanContext: args.spanContext,
+  });
+
+  const slackDestination =
+    args.routing.destination.platform === "slack"
+      ? args.routing.destination
+      : undefined;
+  const slackChannelId = slackDestination?.channelId;
+
+  const mcpAuth = createMcpAuthOrchestration({
+    abortAgent: args.abortAgent,
+    conversationId: args.sessionConversationId,
+    sessionId: args.sessionId,
+    requesterId: authRequesterId,
+    channelId: slackChannelId,
+    destination: args.routing.destination,
+    source: args.runSource,
+    threadTs: args.routing.correlation?.threadTs,
+    toolChannelId: args.routing.toolChannelId,
+    userMessage: args.userInput,
+    pendingAuth: args.state.pendingAuth,
+    getConfiguration: () => args.configurationValues,
+    getArtifactState: () => args.state.artifactState,
+    getMergedArtifactState: () =>
+      mergeArtifactsState(
+        args.state.artifactState ?? {},
+        args.artifactStatePatch,
+      ),
+    recordPendingAuth: args.durability.recordPendingAuth,
+    authorizationFlowMode: args.policy.authorizationFlowMode,
+  });
+  const pluginAuth = createPluginAuthOrchestration({
+    abortAgent: args.abortAgent,
+    conversationId: args.sessionConversationId,
+    sessionId: args.sessionId,
+    requesterId: authRequesterId,
+    channelId: slackChannelId,
+    destination: args.routing.destination,
+    source: args.runSource,
+    threadTs: args.routing.correlation?.threadTs,
+    userMessage: args.userInput,
+    channelConfiguration: args.policy.channelConfiguration,
+    pendingAuth: args.state.pendingAuth,
+    recordPendingAuth: args.durability.recordPendingAuth,
+    authorizationFlowMode: args.policy.authorizationFlowMode,
+    userTokenStore,
+  });
+
+  const mcpToolManager = new McpToolManager(
+    pluginCatalogRuntime.getMcpProviders(),
+    {
+      authProviderFactory: mcpAuth.authProviderFactory,
+      onAuthorizationRequired: mcpAuth.onAuthorizationRequired,
+    },
+  );
+  const activeMcpToolManager = mcpToolManager;
+  const getPendingAuthPause = () =>
+    pluginAuth.getPendingPause() ?? mcpAuth.getPendingPause();
+  setTags({
+    conversationId: args.spanContext.conversationId,
+    slackThreadId: args.routing.correlation?.threadId,
+    slackUserId: args.routing.correlation?.requesterId,
+    slackChannelId: args.routing.correlation?.channelId,
+    runId: args.routing.correlation?.runId,
+    assistantUserName: botConfig.userName,
+    modelId: botConfig.modelId,
+  });
+
+  const loadableSkills = args.availableSkills.filter(
+    (skill) =>
+      skill.disableModelInvocation !== true ||
+      skill.name === args.invokedSkill?.name,
+  );
+  let advisorTools: AgentTool[] = [];
+  const commonToolRuntimeContext = {
+    conversationId: args.sessionConversationId,
+    userText: args.userInput,
+    artifactState: args.state.artifactState,
+    configuration: args.configurationValues,
+    egress: createPluginEgress({
+      credentialContext: args.routing.credentialContext,
+      pluginAuth: {
+        async handleAuthRequired(signal) {
+          await pluginAuth.maybeHandleAuthSignal({
+            auth_required: {
+              ...(signal.authorization
+                ? { authorization: signal.authorization }
+                : {}),
+              createdAtMs: Date.now(),
+              grant: signal.grant,
+              kind: signal.kind,
+              message: signal.message,
+              provider: signal.provider,
+            },
+          });
+        },
+      },
+    }),
+    mcpToolManager: activeMcpToolManager,
+    sandbox,
+    surface: args.surface,
+    advisor: {
+      config: botConfig.advisor,
+      conversationId: args.sessionConversationId,
+      conversationPrivacy: args.conversationPrivacy,
+      parentSessionId: args.sessionId,
+      logContext: args.spanContext,
+      getTools: () => advisorTools,
+      streamFn: createTracedStreamFn({
+        conversationPrivacy: args.conversationPrivacy,
+      }),
+    },
+  };
+  const toolSource = args.runSource;
+  const toolDestination = toolInvocationDestination(args.routing);
+  let toolRuntimeContext: ToolRuntimeContext;
+  if (toolSource.platform === "slack") {
+    if (toolDestination.platform !== "slack") {
+      throw new TypeError("Slack tool runtime requires a Slack destination");
+    }
+    toolRuntimeContext = {
+      ...commonToolRuntimeContext,
+      destination: toolDestination,
+      requester:
+        args.actorRequester?.platform === "slack"
+          ? args.actorRequester
+          : undefined,
+      source: toolSource,
+    };
+  } else {
+    if (toolDestination.platform !== "local") {
+      throw new TypeError("Local tool runtime requires a local destination");
+    }
+    toolRuntimeContext = {
+      ...commonToolRuntimeContext,
+      destination: toolDestination,
+      requester:
+        args.actorRequester?.platform === "local"
+          ? args.actorRequester
+          : undefined,
+      source: toolSource,
+    };
+  }
+  const tools = createTools(
+    loadableSkills,
+    {
+      getGeneratedFile: (filename) =>
+        args.generatedFiles.find((file) => file.filename === filename),
+      onGeneratedArtifactFiles: (files) => {
+        args.generatedFiles.push(...files);
+      },
+      onGeneratedFiles: (files) => {
+        args.deliveryFiles.push(...files);
+      },
+      onArtifactStatePatch: async (patch) => {
+        Object.assign(args.artifactStatePatch, patch);
+        await args.durability.onArtifactStateUpdated?.(
+          mergeArtifactsState(
+            args.state.artifactState ?? {},
+            args.artifactStatePatch,
+          ),
+        );
+      },
+      toolOverrides: args.policy.toolOverrides,
+      onSkillLoaded: async (loadedSkill) => {
+        const resolvedSkill = await args.skillSandbox.loadSkill(
+          loadedSkill.name,
+        );
+        const effective = resolvedSkill ?? loadedSkill;
+        upsertActiveSkill(args.activeSkills, effective);
+        args.syncLoadedSkillNamesForResume();
+        if (await activeMcpToolManager.activateForSkill(effective)) {
+          await args.recordConnectedMcpProvider(effective.pluginProvider!);
+        }
+        if (mcpAuth.getPendingPause()) {
+          // Auth pause requested — suppress loadSkill failure and let the
+          // aborted run park cleanly.
+          return undefined;
+        }
+        if (!effective.pluginProvider) {
+          return undefined;
+        }
+        if (
+          !activeMcpToolManager
+            .getActiveProviders()
+            .includes(effective.pluginProvider)
+        ) {
+          return undefined;
+        }
+        const availableToolCount = activeMcpToolManager.getActiveToolCatalog({
+          provider: effective.pluginProvider,
+        }).length;
+        return {
+          mcp_provider: effective.pluginProvider,
+          available_tool_count: availableToolCount,
+        };
+      },
+    },
+    toolRuntimeContext,
+  );
+
+  const toolGuidance = Object.entries(
+    tools as Record<string, ToolDefinition<any>>,
+  ).map(([name, definition]) => ({
+    name,
+    promptGuidelines: definition.promptGuidelines,
+    promptSnippet: definition.promptSnippet,
+  }));
+
+  const pendingMcpProvider =
+    args.state.pendingAuth?.kind === "mcp"
+      ? args.state.pendingAuth.provider
+      : undefined;
+  const providersToRestore = new Set([
+    ...args.connectedMcpProviders,
+    ...inferActiveMcpProvidersFromPiMessages(args.priorPiMessages),
+  ]);
+  for (const provider of providersToRestore) {
+    if (provider === pendingMcpProvider) {
+      continue;
+    }
+    if (await activeMcpToolManager.activateProvider(provider)) {
+      await args.recordConnectedMcpProvider(provider);
+    }
+    if (mcpAuth.getPendingPause()) {
+      args.checkpointer.captureResumeSnapshot(args.preAgentPromptMessages());
+      throw mcpAuth.getPendingPause()!;
+    }
+  }
+  for (const skill of args.activeSkills) {
+    if (skill.pluginProvider === pendingMcpProvider) {
+      continue;
+    }
+    if (await activeMcpToolManager.activateForSkill(skill)) {
+      await args.recordConnectedMcpProvider(skill.pluginProvider!);
+    }
+    if (mcpAuth.getPendingPause()) {
+      args.checkpointer.captureResumeSnapshot(args.preAgentPromptMessages());
+      throw mcpAuth.getPendingPause()!;
+    }
+  }
+
+  const activeMcpCatalogs = toActiveMcpCatalogSummaries(
+    activeMcpToolManager.getActiveToolCatalog(),
+  );
+  const onToolCall = async (
+    toolName: string,
+    params: Record<string, unknown>,
+  ) => {
+    args.toolCalls.push(toolName);
+    try {
+      await args.observers.onToolInvocation?.({ toolName, params });
+    } catch (error) {
+      logWarn(
+        "tool_invocation_observer_failed",
+        args.spanContext,
+        {
+          "gen_ai.tool.name": toolName,
+          "exception.message":
+            error instanceof Error ? error.message : String(error),
+        },
+        "Tool invocation observer failed",
+      );
+    }
+  };
+  const agentTools = createAgentTools(
+    tools,
+    args.skillSandbox,
+    args.spanContext,
+    args.observers.onStatus,
+    sandboxExecutor,
+    pluginAuth,
+    onToolCall,
+    pluginHooks,
+    args.conversationPrivacy,
+    args.observers.onToolResult,
+  );
+  advisorTools = createAgentTools(
+    createAdvisorToolDefinitions(tools),
+    args.skillSandbox,
+    args.spanContext,
+    args.observers.onStatus,
+    sandboxExecutor,
+    pluginAuth,
+    onToolCall,
+    pluginHooks,
+    args.conversationPrivacy,
+    args.observers.onToolResult,
+  );
+
+  return {
+    activeMcpCatalogs,
+    agentTools,
+    currentSandboxExecutor,
+    getPendingAuthPause,
+    mcpToolManager,
+    pluginHooks,
+    toolGuidance,
+    toolRuntimeContext,
+  };
+}

--- a/packages/junior/src/chat/app/production.ts
+++ b/packages/junior/src/chat/app/production.ts
@@ -1,6 +1,6 @@
 import type { SlackAdapter } from "@chat-adapter/slack";
 import { createSlackRuntime } from "@/chat/app/factory";
-import { withSandboxTracePropagation } from "@/chat/app/services";
+import { createAgentRunner } from "@/chat/runtime/agent-runner";
 import { createUserTokenStore } from "@/chat/capabilities/factory";
 import {
   getSlackBotToken,
@@ -98,6 +98,11 @@ export function createProductionConversationWorkOptions(options?: {
   services?: JuniorRuntimeServiceOverrides;
 }): VercelConversationWorkCallbackOptions {
   const conversationStore = getProductionConversationStore();
+  const agentRunner =
+    options?.services?.replyExecutor?.agentRunner ??
+    createAgentRunner(generateAssistantReply, {
+      tracePropagation: options?.services?.sandbox?.tracePropagation,
+    });
   const runtime = createSlackRuntime({
     getSlackAdapter: getProductionSlackAdapter,
     services: options?.services,
@@ -110,10 +115,7 @@ export function createProductionConversationWorkOptions(options?: {
       conversationStore,
       resumeAwaitingContinuation: async (conversationId) =>
         await resumeAwaitingSlackContinuation(conversationId, {
-          generateReply: withSandboxTracePropagation(
-            generateAssistantReply,
-            options?.services?.sandbox?.tracePropagation,
-          ),
+          agentRunner,
           scheduleSessionCompletedPluginTasks:
             options?.services?.replyExecutor
               ?.scheduleSessionCompletedPluginTasks,

--- a/packages/junior/src/chat/app/production.ts
+++ b/packages/junior/src/chat/app/production.ts
@@ -16,7 +16,7 @@ import { getVercelConversationWorkQueue } from "@/chat/task-execution/vercel-que
 import type { VercelConversationWorkCallbackOptions } from "@/chat/task-execution/vercel-callback";
 import { resumeAwaitingSlackContinuation } from "@/chat/runtime/agent-continue-runner";
 import type { JuniorRuntimeServiceOverrides } from "@/chat/app/services";
-import { generateAssistantReply } from "@/chat/respond";
+import { executeAgentRun } from "@/chat/agent-run";
 import { getConversationStore } from "@/chat/db";
 import type { ConversationStore } from "@/chat/conversations/store";
 
@@ -100,7 +100,7 @@ export function createProductionConversationWorkOptions(options?: {
   const conversationStore = getProductionConversationStore();
   const agentRunner =
     options?.services?.replyExecutor?.agentRunner ??
-    createAgentRunner(generateAssistantReply, {
+    createAgentRunner(executeAgentRun, {
       tracePropagation: options?.services?.sandbox?.tracePropagation,
     });
   const runtime = createSlackRuntime({

--- a/packages/junior/src/chat/app/services.ts
+++ b/packages/junior/src/chat/app/services.ts
@@ -1,5 +1,5 @@
 import { completeObject, completeText } from "@/chat/pi/client";
-import { generateAssistantReply as generateAssistantReplyImpl } from "@/chat/respond";
+import { executeAgentRun as executeAgentRunImpl } from "@/chat/agent-run";
 import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress/tracing";
 import {
   getAwaitingAgentContinueRequest,
@@ -78,7 +78,7 @@ export function createJuniorRuntimeServices(
         overrides.replyExecutor?.contextCompactor ?? contextCompactor,
       agentRunner:
         overrides.replyExecutor?.agentRunner ??
-        createAgentRunner(generateAssistantReplyImpl, {
+        createAgentRunner(executeAgentRunImpl, {
           tracePropagation: overrides.sandbox?.tracePropagation,
         }),
       getAwaitingAgentContinueRequest:

--- a/packages/junior/src/chat/app/services.ts
+++ b/packages/junior/src/chat/app/services.ts
@@ -1,8 +1,5 @@
 import { completeObject, completeText } from "@/chat/pi/client";
-import {
-  generateAssistantReply as generateAssistantReplyImpl,
-  type AssistantReplyRequestContext,
-} from "@/chat/respond";
+import { generateAssistantReply as generateAssistantReplyImpl } from "@/chat/respond";
 import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress/tracing";
 import {
   getAwaitingAgentContinueRequest,
@@ -33,6 +30,7 @@ import {
   type VisionContextDeps,
   type VisionContextService,
 } from "@/chat/services/vision-context";
+import { createAgentRunner } from "@/chat/runtime/agent-runner";
 
 export interface JuniorRuntimeServices {
   conversationMemory: ConversationMemoryService;
@@ -51,22 +49,6 @@ export interface JuniorRuntimeServiceOverrides {
     tracePropagation?: SandboxEgressTracePropagationConfig;
   };
   visionContext?: Partial<VisionContextDeps>;
-}
-
-/** Apply app-owned sandbox egress trace config unless a turn overrides it. */
-export function withSandboxTracePropagation(
-  generateReply: typeof generateAssistantReplyImpl,
-  tracePropagation?: SandboxEgressTracePropagationConfig,
-): typeof generateAssistantReplyImpl {
-  return async (messageText: string, context: AssistantReplyRequestContext) =>
-    await generateReply(messageText, {
-      ...context,
-      sandbox: {
-        ...context?.sandbox,
-        tracePropagation:
-          context?.sandbox?.tracePropagation ?? tracePropagation,
-      },
-    });
 }
 
 export function createJuniorRuntimeServices(
@@ -94,12 +76,11 @@ export function createJuniorRuntimeServices(
     replyExecutor: {
       contextCompactor:
         overrides.replyExecutor?.contextCompactor ?? contextCompactor,
-      generateAssistantReply:
-        overrides.replyExecutor?.generateAssistantReply ??
-        withSandboxTracePropagation(
-          generateAssistantReplyImpl,
-          overrides.sandbox?.tracePropagation,
-        ),
+      agentRunner:
+        overrides.replyExecutor?.agentRunner ??
+        createAgentRunner(generateAssistantReplyImpl, {
+          tracePropagation: overrides.sandbox?.tracePropagation,
+        }),
       getAwaitingAgentContinueRequest:
         overrides.replyExecutor?.getAwaitingAgentContinueRequest ??
         getAwaitingAgentContinueRequest,

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -6,12 +6,8 @@
  * a local destination, and only commits assistant delivery after the CLI sink
  * accepts the final output.
  */
-import {
-  generateAssistantReply as generateAssistantReplyImpl,
-  type AssistantReply,
-  type AssistantReplyRequestContext,
-} from "@/chat/respond";
-import type { AgentRunOutcome } from "@/chat/runtime/agent-run-outcome";
+import type { AssistantReply } from "@/chat/respond";
+import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import {
   createLocalSource,
   localDestinationSchema,
@@ -68,11 +64,8 @@ export interface LocalToolInvocation {
 export type LocalToolResult = ToolExecutionReport;
 
 export interface LocalAgentTurnDeps {
+  agentRunner: AgentRunner;
   deliverReply: (reply: LocalAgentReply) => Promise<void>;
-  generateAssistantReply?: (
-    messageText: string,
-    context: AssistantReplyRequestContext,
-  ) => Promise<AgentRunOutcome>;
   now?: () => number;
   onStatus?: (status: string) => void | Promise<void>;
   onTextDelta?: (deltaText: string) => void | Promise<void>;
@@ -183,8 +176,6 @@ export async function runLocalAgentTurn(
   const destination = localDestination(input.conversationId);
   const source = createLocalSource(destination.conversationId);
 
-  const generateAssistantReply =
-    deps.generateAssistantReply ?? generateAssistantReplyImpl;
   const now = deps.now ?? (() => Date.now());
   const persisted = await getPersistedThreadState(input.conversationId);
   const conversation = coerceThreadConversationState(persisted);
@@ -232,7 +223,7 @@ export async function runLocalAgentTurn(
       fallback: conversation.piMessages,
     });
     piMessagesBeforeRun = piMessages;
-    const outcome = await generateAssistantReply(text, {
+    const outcome = await deps.agentRunner.run(text, {
       authorizationFlowMode: "disabled",
       conversationContext: buildConversationContext(conversation, {
         excludeMessageId: userMessageId,

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -9,7 +9,9 @@
 import {
   generateAssistantReply as generateAssistantReplyImpl,
   type AssistantReply,
+  type AssistantReplyRequestContext,
 } from "@/chat/respond";
+import type { AgentRunOutcome } from "@/chat/runtime/agent-run-outcome";
 import {
   createLocalSource,
   localDestinationSchema,
@@ -67,7 +69,10 @@ export type LocalToolResult = ToolExecutionReport;
 
 export interface LocalAgentTurnDeps {
   deliverReply: (reply: LocalAgentReply) => Promise<void>;
-  generateAssistantReply?: typeof generateAssistantReplyImpl;
+  generateAssistantReply?: (
+    messageText: string,
+    context: AssistantReplyRequestContext,
+  ) => Promise<AgentRunOutcome>;
   now?: () => number;
   onStatus?: (status: string) => void | Promise<void>;
   onTextDelta?: (deltaText: string) => void | Promise<void>;
@@ -227,7 +232,7 @@ export async function runLocalAgentTurn(
       fallback: conversation.piMessages,
     });
     piMessagesBeforeRun = piMessages;
-    reply = await generateAssistantReply(text, {
+    const outcome = await generateAssistantReply(text, {
       authorizationFlowMode: "disabled",
       conversationContext: buildConversationContext(conversation, {
         excludeMessageId: userMessageId,
@@ -285,6 +290,14 @@ export async function runLocalAgentTurn(
         await deps.onToolResult?.(result);
       },
     });
+    if (
+      outcome.status === "awaiting_auth" ||
+      outcome.status === "timed_out" ||
+      outcome.status === "yielded"
+    ) {
+      throw new Error(`Local agent run ended with ${outcome.status}`);
+    }
+    reply = outcome.reply;
 
     // Failed turns deliver the sanitized fallback (or genuine partial model
     // text), never raw exception strings and never silence.

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -223,62 +223,75 @@ export async function runLocalAgentTurn(
       fallback: conversation.piMessages,
     });
     piMessagesBeforeRun = piMessages;
-    const outcome = await deps.agentRunner.run(text, {
-      authorizationFlowMode: "disabled",
-      conversationContext: buildConversationContext(conversation, {
-        excludeMessageId: userMessageId,
-      }),
-      artifactState: artifacts,
-      credentialContext: {
-        actor: { type: "system", id: "local-cli" },
+    const outcome = await deps.agentRunner.run({
+      input: {
+        messageText: text,
+        conversationContext: buildConversationContext(conversation, {
+          excludeMessageId: userMessageId,
+        }),
+        piMessages,
       },
-      destination,
-      source,
-      requester: {
-        fullName: "Local CLI",
-        platform: "local",
-        userId: "local-cli",
-        userName: "local",
+      routing: {
+        credentialContext: {
+          actor: { type: "system", id: "local-cli" },
+        },
+        destination,
+        source,
+        requester: {
+          fullName: "Local CLI",
+          platform: "local",
+          userId: "local-cli",
+          userName: "local",
+        },
+        surface: "internal",
+        correlation: {
+          conversationId: input.conversationId,
+          turnId,
+          runId: turnId,
+        },
       },
-      piMessages,
-      surface: "internal",
-      correlation: {
-        conversationId: input.conversationId,
-        turnId,
-        runId: turnId,
-      },
-      sandbox: {
-        sandboxId,
-        sandboxDependencyProfileHash,
-      },
-      onArtifactStateUpdated: async (nextArtifacts) => {
-        artifacts = nextArtifacts;
-        await persistThreadStateById(input.conversationId, {
-          artifacts,
-          conversation,
+      policy: {
+        authorizationFlowMode: "disabled",
+        sandbox: {
           sandboxId,
           sandboxDependencyProfileHash,
-        });
+        },
       },
-      onSandboxAcquired: async (sandbox) => {
-        sandboxId = sandbox.sandboxId;
-        sandboxDependencyProfileHash = sandbox.sandboxDependencyProfileHash;
-        await persistThreadStateById(input.conversationId, {
-          artifacts,
-          conversation,
-          sandboxId,
-          sandboxDependencyProfileHash,
-        });
+      state: {
+        artifactState: artifacts,
       },
-      onStatus: async (status) => {
-        await deps.onStatus?.(status.text);
+      observers: {
+        onStatus: async (status) => {
+          await deps.onStatus?.(status.text);
+        },
+        onTextDelta: deps.onTextDelta,
+        onToolInvocation: async (invocation) => {
+          await deps.onToolInvocation?.(invocation);
+        },
+        onToolResult: async (result) => {
+          await deps.onToolResult?.(result);
+        },
       },
-      onTextDelta: deps.onTextDelta,
-      onToolInvocation: async (invocation) => {
-        await deps.onToolInvocation?.(invocation);
-      },
-      onToolResult: async (result) => {
-        await deps.onToolResult?.(result);
+      durability: {
+        onArtifactStateUpdated: async (nextArtifacts) => {
+          artifacts = nextArtifacts;
+          await persistThreadStateById(input.conversationId, {
+            artifacts,
+            conversation,
+            sandboxId,
+            sandboxDependencyProfileHash,
+          });
+        },
+        onSandboxAcquired: async (sandbox) => {
+          sandboxId = sandbox.sandboxId;
+          sandboxDependencyProfileHash = sandbox.sandboxDependencyProfileHash;
+          await persistThreadStateById(input.conversationId, {
+            artifacts,
+            conversation,
+            sandboxId,
+            sandboxDependencyProfileHash,
+          });
+        },
       },
     });
     if (

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -2,11 +2,11 @@
  * Local agent turn runtime.
  *
  * This module owns the Slack-free execution boundary for CLI-originated turns:
- * it persists local conversation state, invokes the shared reply generator with
+ * it persists local conversation state, invokes the shared agent runner with
  * a local destination, and only commits assistant delivery after the CLI sink
  * accepts the final output.
  */
-import type { AssistantReply } from "@/chat/respond";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import {
   createLocalSource,
@@ -23,7 +23,7 @@ import { THREAD_STATE_TTL_MS } from "chat";
 import {
   stripRuntimeTurnContext,
   trimTrailingAssistantMessages,
-} from "@/chat/respond-helpers";
+} from "@/chat/agent-run-helpers";
 import { buildDeliveredTurnStatePatch } from "@/chat/runtime/delivered-turn-state";
 import {
   getPersistedSandboxState,
@@ -52,7 +52,7 @@ export interface LocalAgentTurnInput {
 }
 
 export interface LocalAgentReply {
-  files?: AssistantReply["files"];
+  files?: AgentRunResult["files"];
   text: string;
 }
 
@@ -75,7 +75,7 @@ export interface LocalAgentTurnDeps {
 
 export interface LocalAgentTurnResult {
   conversationId: string;
-  outcome: AssistantReply["diagnostics"]["outcome"];
+  outcome: AgentRunResult["diagnostics"]["outcome"];
 }
 
 function localDestination(conversationId: string): LocalDestination {
@@ -93,7 +93,7 @@ function localTurnId(sequence: number): string {
   return `local-turn-${sequence}`;
 }
 
-function localReply(reply: AssistantReply): LocalAgentReply {
+function localReply(reply: AgentRunResult): LocalAgentReply {
   return {
     ...(reply.files ? { files: reply.files } : {}),
     text: reply.text,
@@ -161,7 +161,7 @@ async function persistDeliveredLocalTurnState(
   throw lastError;
 }
 
-/** Run one local CLI message through Junior's shared agent reply boundary. */
+/** Run one local CLI message through Junior's shared agent-run boundary. */
 export async function runLocalAgentTurn(
   input: LocalAgentTurnInput,
   deps: LocalAgentTurnDeps,
@@ -212,7 +212,7 @@ export async function runLocalAgentTurn(
   });
   await persistThreadStateById(input.conversationId, { conversation });
 
-  let reply: AssistantReply | undefined;
+  let reply: AgentRunResult | undefined;
   let completedState: ReturnType<typeof buildDeliveredTurnStatePatch>;
   let piMessagesBeforeRun:
     | Awaited<ReturnType<typeof loadLocalPiMessages>>
@@ -301,7 +301,7 @@ export async function runLocalAgentTurn(
     ) {
       throw new Error(`Local agent run ended with ${outcome.status}`);
     }
-    reply = outcome.reply;
+    reply = outcome.result;
 
     // Failed turns deliver the sanitized fallback (or genuine partial model
     // text), never raw exception strings and never silence.

--- a/packages/junior/src/chat/plugins/task-runner.ts
+++ b/packages/junior/src/chat/plugins/task-runner.ts
@@ -23,7 +23,7 @@ import {
   isToolResultMessage,
   normalizeToolNameFromResult,
   stripRuntimeTurnContext,
-} from "@/chat/respond-helpers";
+} from "@/chat/agent-run-helpers";
 import { getAgentTurnSessionRecord } from "@/chat/state/turn-session";
 import { getPlugins } from "./agent-hooks";
 import {

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -100,11 +100,14 @@ import {
 import { mergeArtifactsState } from "@/chat/runtime/thread-state";
 import {
   CooperativeTurnYieldError,
-  RetryableTurnError,
   TurnInputCommitLostError,
   isTurnInputCommitLostError,
-  isRetryableTurnError,
 } from "@/chat/runtime/turn";
+import {
+  completedAgentRun,
+  failedAgentRun,
+  type AgentRunOutcome,
+} from "@/chat/runtime/agent-run-outcome";
 import {
   buildUserTurnText,
   encodeNonImageAttachmentForPrompt,
@@ -642,7 +645,7 @@ function legacyTextPartMatchesCurrentText(
 export async function generateAssistantReply(
   messageText: string,
   context: AssistantReplyRequestContext,
-): Promise<AssistantReply> {
+): Promise<AgentRunOutcome> {
   const conversationPrivacy = resolveConversationPrivacy({
     channelId: context.correlation?.channelId,
     conversationId:
@@ -666,7 +669,7 @@ async function generateAssistantReplyInPrivacyContext(
   messageText: string,
   context: AssistantReplyRequestContext,
   conversationPrivacy: ConversationPrivacy | undefined,
-): Promise<AssistantReply> {
+): Promise<AgentRunOutcome> {
   if (!context.destination) {
     throw new TypeError("Assistant reply generation requires a destination");
   }
@@ -1875,25 +1878,27 @@ async function generateAssistantReplyInPrivacyContext(
     }
 
     // ── Build turn result ────────────────────────────────────────────
-    return buildTurnResult({
-      newMessages,
-      userInput,
-      replyFiles,
-      artifactStatePatch,
-      toolCalls,
-      sandboxId: currentSandboxExecutor.getSandboxId(),
-      sandboxDependencyProfileHash:
-        currentSandboxExecutor.getDependencyProfileHash(),
-      piMessages: [...agent.state.messages],
-      durationMs: Date.now() - replyStartedAtMs,
-      generatedFileCount: generatedFiles.length,
-      shouldTrace,
-      spanContext,
-      usage: turnUsage,
-      thinkingSelection,
-      correlation: context.correlation,
-      assistantUserName: botConfig.userName,
-    });
+    return completedAgentRun(
+      buildTurnResult({
+        newMessages,
+        userInput,
+        replyFiles,
+        artifactStatePatch,
+        toolCalls,
+        sandboxId: currentSandboxExecutor.getSandboxId(),
+        sandboxDependencyProfileHash:
+          currentSandboxExecutor.getDependencyProfileHash(),
+        piMessages: [...agent.state.messages],
+        durationMs: Date.now() - replyStartedAtMs,
+        generatedFileCount: generatedFiles.length,
+        shouldTrace,
+        spanContext,
+        usage: turnUsage,
+        thinkingSelection,
+        correlation: context.correlation,
+        assistantUserName: botConfig.userName,
+      }),
+    );
   } catch (error) {
     if (
       cooperativeYieldError &&
@@ -1926,7 +1931,13 @@ async function generateAssistantReplyInPrivacyContext(
           `Failed to persist cooperative yield continuation for conversation=${timeoutResumeConversationId} session=${timeoutResumeSessionId}`,
         );
       }
-      throw error;
+      return {
+        status: "yielded",
+        conversationId: timeoutResumeConversationId,
+        sessionId: timeoutResumeSessionId,
+        sliceId: sessionRecord.sliceId,
+        version: sessionRecord.version,
+      };
     }
 
     if (timedOut && timeoutResumeConversationId && timeoutResumeSessionId) {
@@ -1956,16 +1967,13 @@ async function generateAssistantReplyInPrivacyContext(
         );
       }
       if (sessionRecord.state === "awaiting_resume") {
-        throw new RetryableTurnError(
-          "agent_continue",
-          `conversation=${timeoutResumeConversationId} session=${timeoutResumeSessionId} slice=${sessionRecord.sliceId} version=${sessionRecord.version}`,
-          {
-            conversationId: timeoutResumeConversationId,
-            sessionId: timeoutResumeSessionId,
-            sliceId: sessionRecord.sliceId,
-            version: sessionRecord.version,
-          },
-        );
+        return {
+          status: "timed_out",
+          conversationId: timeoutResumeConversationId,
+          sessionId: timeoutResumeSessionId,
+          sliceId: sessionRecord.sliceId,
+          version: sessionRecord.version,
+        };
       }
       throw new Error(
         sessionRecord.errorMessage ??
@@ -2003,28 +2011,22 @@ async function generateAssistantReplyInPrivacyContext(
         ...(surface ? { surface } : {}),
       });
       if (sessionRecord) {
-        throw new RetryableTurnError(
-          error.kind === "plugin" ? "plugin_auth_resume" : "mcp_auth_resume",
-          `conversation=${timeoutResumeConversationId} session=${timeoutResumeSessionId} slice=${sessionRecord.sliceId}`,
-          {
-            authDisposition: error.disposition,
-            authDurationMs: Date.now() - replyStartedAtMs,
-            authKind: error.kind,
-            authProvider: error.provider,
-            authProviderDisplayName: error.providerDisplayName,
-            authThinkingLevel: thinkingSelection?.thinkingLevel,
-            authUsage: turnUsage,
-            conversationId: timeoutResumeConversationId,
-            sessionId: timeoutResumeSessionId,
-            sliceId: sessionRecord.sliceId,
-          },
-        );
+        return {
+          status: "awaiting_auth",
+          authDisposition: error.disposition,
+          authDurationMs: Date.now() - replyStartedAtMs,
+          authKind: error.kind,
+          authProvider: error.provider,
+          authProviderDisplayName: error.providerDisplayName,
+          authThinkingLevel: thinkingSelection?.thinkingLevel,
+          authUsage: turnUsage,
+          conversationId: timeoutResumeConversationId,
+          sessionId: timeoutResumeSessionId,
+          sliceId: sessionRecord.sliceId,
+        };
       }
     }
 
-    if (isRetryableTurnError(error)) {
-      throw error;
-    }
     if (isProviderRetryError(error)) {
       throw error;
     }
@@ -2057,7 +2059,7 @@ async function generateAssistantReplyInPrivacyContext(
     // Raw exception text is diagnostics-only; the failure-response service
     // owns the sanitized user-visible fallback for empty provider errors.
     const message = error instanceof Error ? error.message : String(error);
-    return {
+    return failedAgentRun({
       text: "",
       ...getSandboxMetadata(),
       diagnostics: {
@@ -2077,7 +2079,7 @@ async function generateAssistantReplyInPrivacyContext(
         errorMessage: message,
         providerError: error,
       },
-    };
+    });
   } finally {
     try {
       await mcpToolManager?.close();

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -208,8 +208,19 @@ function waitForAbortSettlement(
   });
 }
 
-export interface ReplyRequestContext {
-  skillDirs?: string[];
+/** Carries the user-visible content and prior transcript for one agent-run slice. */
+export interface ReplyRequestInput {
+  messageText: string;
+  userAttachments?: ReplyRequestAttachment[];
+  inboundAttachmentCount?: number;
+  omittedImageAttachmentCount?: number;
+  /** Durable Pi transcript for this conversation, excluding ephemeral turn context. */
+  piMessages?: PiMessage[];
+  conversationContext?: string;
+}
+
+/** Carries identity and addressing needed to route tools, auth, and delivery. */
+export interface ReplyRequestRouting {
   credentialContext?: CredentialContext;
   requester?: Requester;
   source: Source;
@@ -234,44 +245,37 @@ export interface ReplyRequestContext {
     requesterId?: string;
   };
   toolChannelId?: string;
-  conversationContext?: string;
-  artifactState?: ThreadArtifactsState;
-  pendingAuth?: ConversationPendingAuthState;
-  authorizationFlowMode?: AuthorizationFlowMode;
-  configuration?: Record<string, unknown>;
-  /** Durable Pi transcript for this conversation, excluding ephemeral turn context. */
-  piMessages?: PiMessage[];
+}
+
+/** Carries execution limits and dependency overrides for one run slice. */
+export interface ReplyRequestPolicy {
   /** Absolute wall-clock deadline for this host request, in milliseconds. */
   turnDeadlineAtMs?: number;
+  authorizationFlowMode?: AuthorizationFlowMode;
+  configuration?: Record<string, unknown>;
   channelConfiguration?: ChannelConfigurationService;
-  userAttachments?: ReplyRequestAttachment[];
-  inboundAttachmentCount?: number;
-  omittedImageAttachmentCount?: number;
+  skillDirs?: string[];
   sandbox?: {
     sandboxId?: string;
     sandboxDependencyProfileHash?: string;
-    /** Per-turn override for app-owned sandbox egress trace propagation. */
+    /** Per-slice override for app-owned sandbox egress trace propagation. */
     tracePropagation?: SandboxEgressTracePropagationConfig;
   };
-  onSandboxAcquired?: (sandbox: SandboxAcquiredState) => void | Promise<void>;
-  onArtifactStateUpdated?: (
-    artifactState: ThreadArtifactsState,
-  ) => void | Promise<void>;
-  onInputCommitted?: () => void | Promise<void>;
   toolOverrides?: {
     imageGenerate?: ImageGenerateToolDeps;
     webFetch?: WebFetchToolDeps;
     webSearch?: WebSearchToolDeps;
   };
-  onStatus?: (status: AssistantStatusSpec) => void | Promise<void>;
-  drainSteeringMessages?: (
-    accept: (messages: ReplySteeringMessage[]) => Promise<void>,
-  ) => Promise<ReplySteeringMessage[]>;
-  /** Return true when the durable worker should pause at the next Pi boundary. */
-  shouldYield?: () => boolean;
-  recordPendingAuth?: (
-    pendingAuth: ConversationPendingAuthState,
-  ) => void | Promise<void>;
+}
+
+/** Carries durable state snapshots already loaded by the caller. */
+export interface ReplyRequestState {
+  artifactState?: ThreadArtifactsState;
+  pendingAuth?: ConversationPendingAuthState;
+}
+
+/** Carries non-blocking notifications for streaming UI and status surfaces. */
+export interface ReplyRequestObservers {
   onTextDelta?: (deltaText: string) => void | Promise<void>;
   onAssistantMessageStart?: () => void | Promise<void>;
   onToolInvocation?: (invocation: {
@@ -279,9 +283,57 @@ export interface ReplyRequestContext {
     params: Record<string, unknown>;
   }) => void | Promise<void>;
   onToolResult?: (result: ToolExecutionReport) => void | Promise<void>;
+  onStatus?: (status: AssistantStatusSpec) => void | Promise<void>;
+}
+
+/** Carries durable-worker ports that commit or update resumable run state. */
+export interface ReplyRequestDurability {
+  onInputCommitted?: () => void | Promise<void>;
+  /** Return true when the durable worker should pause at the next Pi boundary. */
+  shouldYield?: () => boolean;
+  drainSteeringMessages?: (
+    accept: (messages: ReplySteeringMessage[]) => Promise<void>,
+  ) => Promise<ReplySteeringMessage[]>;
+  recordPendingAuth?: (
+    pendingAuth: ConversationPendingAuthState,
+  ) => void | Promise<void>;
+  onSandboxAcquired?: (sandbox: SandboxAcquiredState) => void | Promise<void>;
+  onArtifactStateUpdated?: (
+    artifactState: ThreadArtifactsState,
+  ) => void | Promise<void>;
+}
+
+/** Groups the per-slice reply request by the runtime role each field serves. */
+export interface ReplyRequestContext {
+  input: ReplyRequestInput;
+  routing: ReplyRequestRouting;
+  policy?: ReplyRequestPolicy;
+  state?: ReplyRequestState;
+  observers?: ReplyRequestObservers;
+  durability?: ReplyRequestDurability;
 }
 
 export type AssistantReplyRequestContext = ReplyRequestContext;
+
+type FlatReplyRequestContext = ReplyRequestInput &
+  ReplyRequestRouting &
+  ReplyRequestPolicy &
+  ReplyRequestState &
+  ReplyRequestObservers &
+  ReplyRequestDurability;
+
+function flattenReplyRequestContext(
+  request: ReplyRequestContext,
+): FlatReplyRequestContext {
+  return {
+    ...request.input,
+    ...request.routing,
+    ...(request.policy ?? {}),
+    ...(request.state ?? {}),
+    ...(request.observers ?? {}),
+    ...(request.durability ?? {}),
+  };
+}
 
 export interface ReplyRequestAttachment {
   data?: Buffer;
@@ -312,7 +364,7 @@ const legacyStoredTextPartSchema = z
   .strict();
 
 type UserTurnAttachment = NonNullable<
-  ReplyRequestContext["userAttachments"]
+  ReplyRequestInput["userAttachments"]
 >[number];
 
 function buildOmittedImageAttachmentNotice(count: number): string {
@@ -347,13 +399,15 @@ function extractSliceUsage(
 }
 
 function requesterFromContext(
-  context: ReplyRequestContext,
+  context: FlatReplyRequestContext,
 ): Requester | undefined {
   return actorRequesterFromContext(context);
 }
 
 /** Reject requester identities that do not belong to the active destination. */
-function assertRequesterDestinationMatch(context: ReplyRequestContext): void {
+function assertRequesterDestinationMatch(
+  context: FlatReplyRequestContext,
+): void {
   const { destination, requester } = context;
   if (!requester) {
     return;
@@ -373,7 +427,9 @@ function assertRequesterDestinationMatch(context: ReplyRequestContext): void {
 }
 
 /** Reject legacy Slack correlation fields that conflict with the destination. */
-function assertCorrelationDestinationMatch(context: ReplyRequestContext): void {
+function assertCorrelationDestinationMatch(
+  context: FlatReplyRequestContext,
+): void {
   const { correlation, destination } = context;
   if (destination.platform !== "slack") {
     return;
@@ -397,7 +453,7 @@ function assertCorrelationDestinationMatch(context: ReplyRequestContext): void {
 }
 
 function actorRequesterFromContext(
-  context: ReplyRequestContext,
+  context: FlatReplyRequestContext,
 ): Requester | undefined {
   return createRequester(context.requester, {
     platform:
@@ -415,7 +471,9 @@ function actorRequesterFromContext(
   });
 }
 
-function toolInvocationDestination(context: ReplyRequestContext): Destination {
+function toolInvocationDestination(
+  context: FlatReplyRequestContext,
+): Destination {
   if (context.destination.platform !== "slack" || !context.toolChannelId) {
     return context.destination;
   }
@@ -427,7 +485,7 @@ function toolInvocationDestination(context: ReplyRequestContext): Destination {
 }
 
 function surfaceFromContext(
-  context: ReplyRequestContext,
+  context: FlatReplyRequestContext,
 ): AgentTurnSurface | undefined {
   if (context.surface) {
     return context.surface;
@@ -492,7 +550,7 @@ function buildRouterAttachmentBlock(attachment: UserTurnAttachment): string {
 
 function buildUserTurnInput(args: {
   omittedImageAttachmentCount: number;
-  userAttachments?: ReplyRequestContext["userAttachments"];
+  userAttachments?: ReplyRequestInput["userAttachments"];
   userTurnText: string;
 }): {
   routerBlocks: string[];
@@ -643,9 +701,10 @@ function legacyTextPartMatchesCurrentText(
 
 /** Run a full agent turn: discover skills, execute tools, and return the assistant reply. */
 export async function generateAssistantReply(
-  messageText: string,
-  context: AssistantReplyRequestContext,
+  request: AssistantReplyRequestContext,
 ): Promise<AgentRunOutcome> {
+  const context = flattenReplyRequestContext(request);
+  const messageText = request.input.messageText;
   const conversationPrivacy = resolveConversationPrivacy({
     channelId: context.correlation?.channelId,
     conversationId:
@@ -667,7 +726,7 @@ export async function generateAssistantReply(
 
 async function generateAssistantReplyInPrivacyContext(
   messageText: string,
-  context: AssistantReplyRequestContext,
+  context: FlatReplyRequestContext,
   conversationPrivacy: ConversationPrivacy | undefined,
 ): Promise<AgentRunOutcome> {
   if (!context.destination) {

--- a/packages/junior/src/chat/runtime/agent-continue-runner.ts
+++ b/packages/junior/src/chat/runtime/agent-continue-runner.ts
@@ -360,41 +360,51 @@ export async function continueSlackAgentRun(
           messageText: userMessage.text,
           messageTs: getTurnUserSlackMessageTs(userMessage),
           replyContext: {
-            credentialContext: {
-              actor: {
-                type: "user",
-                userId: requester.userId,
+            input: {
+              conversationContext,
+              piMessages: conversation.piMessages,
+              ...getTurnUserReplyAttachmentContext(userMessage),
+            },
+            routing: {
+              credentialContext: {
+                actor: {
+                  type: "user",
+                  userId: requester.userId,
+                },
+              },
+              requester,
+              destination: payload.destination,
+              source: activeSessionRecord.source,
+              correlation: {
+                conversationId: payload.conversationId,
+                turnId: payload.sessionId,
+                channelId: thread.channelId,
+                threadTs: thread.threadTs,
+                requesterId: requester.userId,
+              },
+              toolChannelId:
+                artifacts.assistantContextChannelId ?? thread.channelId,
+            },
+            policy: {
+              channelConfiguration,
+              sandbox,
+            },
+            state: {
+              artifactState: artifacts,
+              pendingAuth: conversation.processing.pendingAuth,
+            },
+            durability: {
+              recordPendingAuth: async (nextPendingAuth) => {
+                await applyPendingAuthUpdate({
+                  conversation,
+                  conversationId: payload.conversationId,
+                  nextPendingAuth,
+                });
+                await persistThreadStateById(payload.conversationId, {
+                  conversation,
+                });
               },
             },
-            requester,
-            destination: payload.destination,
-            source: activeSessionRecord.source,
-            correlation: {
-              conversationId: payload.conversationId,
-              turnId: payload.sessionId,
-              channelId: thread.channelId,
-              threadTs: thread.threadTs,
-              requesterId: requester.userId,
-            },
-            toolChannelId:
-              artifacts.assistantContextChannelId ?? thread.channelId,
-            artifactState: artifacts,
-            pendingAuth: conversation.processing.pendingAuth,
-            conversationContext,
-            channelConfiguration,
-            piMessages: conversation.piMessages,
-            sandbox,
-            recordPendingAuth: async (nextPendingAuth) => {
-              await applyPendingAuthUpdate({
-                conversation,
-                conversationId: payload.conversationId,
-                nextPendingAuth,
-              });
-              await persistThreadStateById(payload.conversationId, {
-                conversation,
-              });
-            },
-            ...getTurnUserReplyAttachmentContext(userMessage),
           },
           onSuccess: async (reply: AssistantReply) => {
             await persistCompletedReplyState({

--- a/packages/junior/src/chat/runtime/agent-continue-runner.ts
+++ b/packages/junior/src/chat/runtime/agent-continue-runner.ts
@@ -60,7 +60,7 @@ import {
   type SlackRequester,
 } from "@/chat/requester";
 import { getConversationWorkState } from "@/chat/task-execution/store";
-import type { AssistantReply } from "@/chat/respond";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { persistAuthPauseTurnState } from "@/chat/runtime/auth-pause-state";
 import {
@@ -89,7 +89,7 @@ function sleep(ms: number): Promise<void> {
 /** Persist a delivered continuation reply as the terminal thread state. */
 async function persistCompletedReplyState(args: {
   sessionRecord: AgentTurnSessionRecord;
-  reply: AssistantReply;
+  reply: AgentRunResult;
 }): Promise<void> {
   const currentState = await getPersistedThreadState(
     args.sessionRecord.conversationId,
@@ -406,7 +406,7 @@ export async function continueSlackAgentRun(
               },
             },
           },
-          onSuccess: async (reply: AssistantReply) => {
+          onSuccess: async (reply: AgentRunResult) => {
             await persistCompletedReplyState({
               sessionRecord: activeSessionRecord,
               reply,

--- a/packages/junior/src/chat/runtime/agent-continue-runner.ts
+++ b/packages/junior/src/chat/runtime/agent-continue-runner.ts
@@ -60,7 +60,8 @@ import {
   type SlackRequester,
 } from "@/chat/requester";
 import { getConversationWorkState } from "@/chat/task-execution/store";
-import type { AssistantReply, generateAssistantReply } from "@/chat/respond";
+import type { AssistantReply } from "@/chat/respond";
+import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { persistAuthPauseTurnState } from "@/chat/runtime/auth-pause-state";
 import {
   applyPendingAuthUpdate,
@@ -72,7 +73,7 @@ const AGENT_CONTINUE_LOCK_RETRY_DELAYS_MS = [250, 1_000, 2_000] as const;
 
 /** Runtime ports for agent continuation scheduling. */
 export interface AgentContinueRunnerOptions {
-  generateReply?: typeof generateAssistantReply;
+  agentRunner: AgentRunner;
   resumeTurn?: typeof resumeSlackTurn;
   scheduleAgentContinue?: (request: AgentContinueRequest) => Promise<void>;
   scheduleSessionCompletedPluginTasks?: (params: {
@@ -267,7 +268,7 @@ async function failUnresumableContinuation(args: {
  */
 export async function continueSlackAgentRun(
   payload: AgentContinueRequest,
-  options: AgentContinueRunnerOptions = {},
+  options: AgentContinueRunnerOptions,
 ): Promise<boolean> {
   const thread = parseSlackThreadId(payload.conversationId);
   if (!thread) {
@@ -284,7 +285,7 @@ export async function continueSlackAgentRun(
     channelId: thread.channelId,
     threadTs: thread.threadTs,
     lockKey: payload.conversationId,
-    generateReply: options.generateReply,
+    agentRunner: options.agentRunner,
     scheduleSessionCompletedPluginTasks:
       options.scheduleSessionCompletedPluginTasks,
     beforeStart: async () => {
@@ -593,7 +594,7 @@ async function recoverStrandedRunningSession(args: {
 /** Resume the first valid paused Slack session for an idle conversation. */
 export async function resumeAwaitingSlackContinuation(
   conversationId: string,
-  options: AgentContinueRunnerOptions = {},
+  options: AgentContinueRunnerOptions,
 ): Promise<boolean> {
   const summaries =
     await listAgentTurnSessionSummariesForConversation(conversationId);
@@ -653,7 +654,7 @@ export async function resumeAwaitingSlackContinuation(
  */
 export async function continueSlackAgentRunWithLockRetry(
   payload: AgentContinueRequest,
-  options: AgentContinueRunnerOptions = {},
+  options: AgentContinueRunnerOptions,
 ): Promise<boolean> {
   const scheduleAgentContinue =
     options.scheduleAgentContinue ?? defaultScheduleAgentContinue;

--- a/packages/junior/src/chat/runtime/agent-run-outcome.ts
+++ b/packages/junior/src/chat/runtime/agent-run-outcome.ts
@@ -1,0 +1,83 @@
+import type { AssistantReply } from "@/chat/services/turn-result";
+import type {
+  AuthorizationPauseDisposition,
+  AuthorizationPauseKind,
+} from "@/chat/services/auth-pause";
+import type { TurnThinkingSelection } from "@/chat/services/turn-thinking-level";
+import type { AgentTurnUsage } from "@/chat/usage";
+import {
+  RetryableTurnError,
+  type AuthResumeRetryableTurnError,
+} from "@/chat/runtime/turn";
+
+export interface AgentRunContinuationIds {
+  conversationId: string;
+  sessionId: string;
+  sliceId: number;
+  version?: number;
+}
+
+export interface AgentRunAuthPauseMetadata extends AgentRunContinuationIds {
+  authDisposition: AuthorizationPauseDisposition;
+  authDurationMs: number;
+  authKind: AuthorizationPauseKind;
+  authProvider: string;
+  authProviderDisplayName: string;
+  authThinkingLevel?: TurnThinkingSelection["thinkingLevel"];
+  authUsage?: AgentTurnUsage;
+}
+
+export type AgentRunOutcome =
+  | { status: "completed"; reply: AssistantReply }
+  | { status: "failed"; reply: AssistantReply }
+  | ({ status: "yielded" } & AgentRunContinuationIds)
+  | ({ status: "timed_out" } & AgentRunContinuationIds)
+  | ({ status: "awaiting_auth" } & Omit<AgentRunAuthPauseMetadata, "version">);
+
+/** Return a successful final reply as an agent-run outcome. */
+export function completedAgentRun(reply: AssistantReply): AgentRunOutcome {
+  return { status: "completed", reply };
+}
+
+/** Return a terminal provider-failure reply as an agent-run outcome. */
+export function failedAgentRun(reply: AssistantReply): AgentRunOutcome {
+  return { status: "failed", reply };
+}
+
+/** Recreate the historical timeout continuation error at outer boundaries. */
+export function retryableTurnErrorFromTimedOutAgentRun(
+  outcome: Extract<AgentRunOutcome, { status: "timed_out" }>,
+): RetryableTurnError {
+  return new RetryableTurnError(
+    "agent_continue",
+    `conversation=${outcome.conversationId} session=${outcome.sessionId} slice=${outcome.sliceId} version=${outcome.version}`,
+    {
+      conversationId: outcome.conversationId,
+      sessionId: outcome.sessionId,
+      sliceId: outcome.sliceId,
+      version: outcome.version,
+    },
+  );
+}
+
+/** Recreate the historical auth-pause error for callback APIs not yet migrated. */
+export function retryableTurnErrorFromAuthAgentRun(
+  outcome: Extract<AgentRunOutcome, { status: "awaiting_auth" }>,
+): AuthResumeRetryableTurnError {
+  return new RetryableTurnError(
+    outcome.authKind === "plugin" ? "plugin_auth_resume" : "mcp_auth_resume",
+    `conversation=${outcome.conversationId} session=${outcome.sessionId} slice=${outcome.sliceId}`,
+    {
+      authDisposition: outcome.authDisposition,
+      authDurationMs: outcome.authDurationMs,
+      authKind: outcome.authKind,
+      authProvider: outcome.authProvider,
+      authProviderDisplayName: outcome.authProviderDisplayName,
+      authThinkingLevel: outcome.authThinkingLevel,
+      authUsage: outcome.authUsage,
+      conversationId: outcome.conversationId,
+      sessionId: outcome.sessionId,
+      sliceId: outcome.sliceId,
+    },
+  ) as AuthResumeRetryableTurnError;
+}

--- a/packages/junior/src/chat/runtime/agent-run-outcome.ts
+++ b/packages/junior/src/chat/runtime/agent-run-outcome.ts
@@ -1,4 +1,4 @@
-import type { AssistantReply } from "@/chat/services/turn-result";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 import type {
   AuthorizationPauseDisposition,
   AuthorizationPauseKind,
@@ -28,20 +28,20 @@ export interface AgentRunAuthPauseMetadata extends AgentRunContinuationIds {
 }
 
 export type AgentRunOutcome =
-  | { status: "completed"; reply: AssistantReply }
-  | { status: "failed"; reply: AssistantReply }
+  | { status: "completed"; result: AgentRunResult }
+  | { status: "failed"; result: AgentRunResult }
   | ({ status: "yielded" } & AgentRunContinuationIds)
   | ({ status: "timed_out" } & AgentRunContinuationIds)
   | ({ status: "awaiting_auth" } & Omit<AgentRunAuthPauseMetadata, "version">);
 
-/** Return a successful final reply as an agent-run outcome. */
-export function completedAgentRun(reply: AssistantReply): AgentRunOutcome {
-  return { status: "completed", reply };
+/** Return a successful final result as an agent-run outcome. */
+export function completedAgentRun(result: AgentRunResult): AgentRunOutcome {
+  return { status: "completed", result };
 }
 
-/** Return a terminal provider-failure reply as an agent-run outcome. */
-export function failedAgentRun(reply: AssistantReply): AgentRunOutcome {
-  return { status: "failed", reply };
+/** Return a terminal provider-failure result as an agent-run outcome. */
+export function failedAgentRun(result: AgentRunResult): AgentRunOutcome {
+  return { status: "failed", result };
 }
 
 /** Recreate the historical timeout continuation error at outer boundaries. */

--- a/packages/junior/src/chat/runtime/agent-runner.ts
+++ b/packages/junior/src/chat/runtime/agent-runner.ts
@@ -1,13 +1,13 @@
-import type { ReplyRequestContext } from "@/chat/respond";
+import type { AgentRunRequest } from "@/chat/agent-run";
 import type { AgentRunOutcome } from "@/chat/runtime/agent-run-outcome";
 import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress/tracing";
 
 /** Run one agent-run slice behind runtime-owned orchestration boundaries. */
 export interface AgentRunner {
-  run(request: ReplyRequestContext): Promise<AgentRunOutcome>;
+  run(request: AgentRunRequest): Promise<AgentRunOutcome>;
 }
 
-/** Adapt the Pi-facing reply generator behind the runtime-owned runner seam. */
+/** Adapt the Pi-facing agent-run executor behind the runtime-owned runner seam. */
 export function createAgentRunner(
   run: AgentRunner["run"],
   options?: { tracePropagation?: SandboxEgressTracePropagationConfig },

--- a/packages/junior/src/chat/runtime/agent-runner.ts
+++ b/packages/junior/src/chat/runtime/agent-runner.ts
@@ -4,10 +4,7 @@ import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress/
 
 /** Run one agent-run slice behind runtime-owned orchestration boundaries. */
 export interface AgentRunner {
-  run(
-    messageText: string,
-    context: ReplyRequestContext,
-  ): Promise<AgentRunOutcome>;
+  run(request: ReplyRequestContext): Promise<AgentRunOutcome>;
 }
 
 /** Adapt the Pi-facing reply generator behind the runtime-owned runner seam. */
@@ -16,13 +13,17 @@ export function createAgentRunner(
   options?: { tracePropagation?: SandboxEgressTracePropagationConfig },
 ): AgentRunner {
   return {
-    run: async (messageText, context) =>
-      await run(messageText, {
-        ...context,
-        sandbox: {
-          ...context.sandbox,
-          tracePropagation:
-            context.sandbox?.tracePropagation ?? options?.tracePropagation,
+    run: async (request) =>
+      await run({
+        ...request,
+        policy: {
+          ...request.policy,
+          sandbox: {
+            ...request.policy?.sandbox,
+            tracePropagation:
+              request.policy?.sandbox?.tracePropagation ??
+              options?.tracePropagation,
+          },
         },
       }),
   };

--- a/packages/junior/src/chat/runtime/agent-runner.ts
+++ b/packages/junior/src/chat/runtime/agent-runner.ts
@@ -1,0 +1,29 @@
+import type { ReplyRequestContext } from "@/chat/respond";
+import type { AgentRunOutcome } from "@/chat/runtime/agent-run-outcome";
+import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress/tracing";
+
+/** Run one agent-run slice behind runtime-owned orchestration boundaries. */
+export interface AgentRunner {
+  run(
+    messageText: string,
+    context: ReplyRequestContext,
+  ): Promise<AgentRunOutcome>;
+}
+
+/** Adapt the Pi-facing reply generator behind the runtime-owned runner seam. */
+export function createAgentRunner(
+  run: AgentRunner["run"],
+  options?: { tracePropagation?: SandboxEgressTracePropagationConfig },
+): AgentRunner {
+  return {
+    run: async (messageText, context) =>
+      await run(messageText, {
+        ...context,
+        sandbox: {
+          ...context.sandbox,
+          tracePropagation:
+            context.sandbox?.tracePropagation ?? options?.tracePropagation,
+        },
+      }),
+  };
+}

--- a/packages/junior/src/chat/runtime/delivered-turn-state.ts
+++ b/packages/junior/src/chat/runtime/delivered-turn-state.ts
@@ -1,5 +1,5 @@
 import { botConfig } from "@/chat/config";
-import type { AssistantReply } from "@/chat/respond";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { ThreadConversationState } from "@/chat/state/conversation";
 import type { ThreadArtifactsState } from "@/chat/state/artifacts";
 import {
@@ -23,7 +23,7 @@ export function buildDeliveredTurnStatePatch(args: {
   artifactStatePatch?: Partial<ThreadArtifactsState>;
   artifacts: ThreadArtifactsState;
   conversation: ThreadConversationState;
-  reply: AssistantReply;
+  reply: AgentRunResult;
   sessionId: string;
   userMessageId?: string;
 }): ThreadStatePatch & { conversation: ThreadConversationState } {

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -1,10 +1,10 @@
 /**
  * Slack reply execution boundary.
  *
- * This module bridges prepared Slack thread state into `generateAssistantReply`
+ * This module bridges prepared Slack thread state into the agent runner
  * and commits the resulting Slack-visible delivery/state updates. It is where
  * queued messages, compaction, status updates, and Slack posting meet; agent
- * internals stay behind the reply generator.
+ * internals stay behind the runner seam.
  */
 import { THREAD_STATE_TTL_MS } from "chat";
 import type { Message, SentMessage, Thread } from "chat";
@@ -31,13 +31,10 @@ import { buildSlackOutputMessage } from "@/chat/slack/output";
 import { getSlackErrorObservabilityAttributes } from "@/chat/slack/errors";
 import {
   buildSteeringPiMessage,
-  type AssistantReplyRequestContext,
   type ReplySteeringMessage,
 } from "@/chat/respond";
-import {
-  retryableTurnErrorFromTimedOutAgentRun,
-  type AgentRunOutcome,
-} from "@/chat/runtime/agent-run-outcome";
+import { retryableTurnErrorFromTimedOutAgentRun } from "@/chat/runtime/agent-run-outcome";
+import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import type { CredentialContext } from "@/chat/credentials/context";
 import { shouldEmitDevAgentTrace } from "@/chat/runtime/dev-agent-trace";
 import {
@@ -280,11 +277,8 @@ async function loadPiMessagesForTurn(args: {
 }
 
 export interface ReplyExecutorServices {
+  agentRunner: AgentRunner;
   contextCompactor: ContextCompactor;
-  generateAssistantReply: (
-    messageText: string,
-    context: AssistantReplyRequestContext,
-  ) => Promise<AgentRunOutcome>;
   generateThreadTitle: ConversationMemoryService["generateThreadTitle"];
   getAwaitingAgentContinueRequest: (args: {
     conversationId: string;
@@ -1043,7 +1037,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                 );
               }
             : undefined;
-          const outcome = await deps.services.generateAssistantReply(
+          const outcome = await deps.services.agentRunner.run(
             effectiveUserText,
             {
               credentialContext,

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -31,8 +31,8 @@ import { buildSlackOutputMessage } from "@/chat/slack/output";
 import { getSlackErrorObservabilityAttributes } from "@/chat/slack/errors";
 import {
   buildSteeringPiMessage,
-  type ReplySteeringMessage,
-} from "@/chat/respond";
+  type AgentRunSteeringMessage,
+} from "@/chat/agent-run";
 import { retryableTurnErrorFromTimedOutAgentRun } from "@/chat/runtime/agent-run-outcome";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import type { CredentialContext } from "@/chat/credentials/context";
@@ -126,7 +126,7 @@ import { persistWithRetry } from "@/chat/services/persist-retry";
 import {
   stripRuntimeTurnContext,
   trimTrailingAssistantMessages,
-} from "@/chat/respond-helpers";
+} from "@/chat/agent-run-helpers";
 import { requireSlackDestination } from "@/chat/destination";
 
 /**
@@ -516,7 +516,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
         let activeTurnId = preparedState.conversation.processing.activeTurnId;
         const resolveSteeringMessages = async (
           queuedMessages: QueuedTurnMessage[],
-        ): Promise<ReplySteeringMessage[]> => {
+        ): Promise<AgentRunSteeringMessage[]> => {
           return await Promise.all(
             queuedMessages.map(async (queued) => {
               const attachments = queued.message.attachments;
@@ -1021,9 +1021,9 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             preparedState.artifacts.assistantContextChannelId ?? channelId;
           const drainSteeringMessages = options.drainSteeringMessages
             ? async (
-                accept: (messages: ReplySteeringMessage[]) => Promise<void>,
-              ): Promise<ReplySteeringMessage[]> => {
-                let acceptedMessages: ReplySteeringMessage[] | undefined;
+                accept: (messages: AgentRunSteeringMessage[]) => Promise<void>,
+              ): Promise<AgentRunSteeringMessage[]> => {
+                let acceptedMessages: AgentRunSteeringMessage[] | undefined;
                 const drained = await options.drainSteeringMessages!(
                   async (queuedMessages) => {
                     acceptedMessages =
@@ -1214,7 +1214,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             throw agentContinuePropagationError;
           }
 
-          let reply = outcome.reply;
+          let reply = outcome.result;
           const diagnosticsContext = {
             slackThreadId: threadId,
             slackUserId: message.author.userId,

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -1037,27 +1037,22 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                 );
               }
             : undefined;
-          const outcome = await deps.services.agentRunner.run(
-            effectiveUserText,
-            {
-              credentialContext,
-              requester,
+          const outcome = await deps.services.agentRunner.run({
+            input: {
+              messageText: effectiveUserText,
               conversationContext: preparedState.conversationContext,
-              artifactState: preparedState.artifacts,
               piMessages,
-              pendingAuth: preparedState.conversation.processing.pendingAuth,
-              configuration: preparedState.configuration,
-              channelConfiguration: preparedState.channelConfiguration,
               inboundAttachmentCount: turnAttachments.length,
               omittedImageAttachmentCount,
               userAttachments,
+            },
+            routing: {
+              credentialContext,
+              requester,
               slackConversation,
               source,
               destination,
               surface: "slack",
-              authorizationFlowMode:
-                message.author.isBot === true ? "disabled" : undefined,
-              turnDeadlineAtMs: getTurnRequestDeadline()?.deadlineAtMs,
               correlation: {
                 conversationId,
                 threadId,
@@ -1071,11 +1066,31 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                 requesterId: slackRequesterId,
               },
               toolChannelId,
+            },
+            policy: {
+              configuration: preparedState.configuration,
+              channelConfiguration: preparedState.channelConfiguration,
+              authorizationFlowMode:
+                message.author.isBot === true ? "disabled" : undefined,
+              turnDeadlineAtMs: getTurnRequestDeadline()?.deadlineAtMs,
               sandbox: {
                 sandboxId: preparedState.sandboxId,
                 sandboxDependencyProfileHash:
                   preparedState.sandboxDependencyProfileHash,
               },
+            },
+            state: {
+              artifactState: preparedState.artifacts,
+              pendingAuth: preparedState.conversation.processing.pendingAuth,
+            },
+            observers: {
+              onStatus: (nextStatus) => status.update(nextStatus),
+              onToolInvocation: options.onToolInvocation,
+            },
+            durability: {
+              onInputCommitted: options.ack,
+              drainSteeringMessages,
+              shouldYield: options.shouldYield,
               onSandboxAcquired: async (sandbox) => {
                 await persistThreadState(thread, {
                   sandboxId: sandbox.sandboxId,
@@ -1102,13 +1117,8 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                   conversation: preparedState.conversation,
                 });
               },
-              onStatus: (nextStatus) => status.update(nextStatus),
-              onToolInvocation: options.onToolInvocation,
-              onInputCommitted: options.ack,
-              drainSteeringMessages,
-              shouldYield: options.shouldYield,
             },
-          );
+          });
           if (outcome.status === "yielded") {
             shouldPersistFailureState = false;
             throw new CooperativeTurnYieldError();

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -31,9 +31,13 @@ import { buildSlackOutputMessage } from "@/chat/slack/output";
 import { getSlackErrorObservabilityAttributes } from "@/chat/slack/errors";
 import {
   buildSteeringPiMessage,
-  generateAssistantReply as generateAssistantReplyImpl,
+  type AssistantReplyRequestContext,
   type ReplySteeringMessage,
 } from "@/chat/respond";
+import {
+  retryableTurnErrorFromTimedOutAgentRun,
+  type AgentRunOutcome,
+} from "@/chat/runtime/agent-run-outcome";
 import type { CredentialContext } from "@/chat/credentials/context";
 import { shouldEmitDevAgentTrace } from "@/chat/runtime/dev-agent-trace";
 import {
@@ -94,9 +98,7 @@ import {
 import { ensureSlackMessageActorIdentity } from "@/chat/services/message-actor-identity";
 import type { AgentContinueRequest } from "@/chat/services/agent-continue";
 import {
-  isAuthResumeRetryableTurnError,
-  isCooperativeTurnYieldError,
-  isRetryableTurnError,
+  CooperativeTurnYieldError,
   TurnInputDeferredError,
 } from "@/chat/runtime/turn";
 import { buildDeterministicTurnId } from "@/chat/runtime/turn";
@@ -279,7 +281,10 @@ async function loadPiMessagesForTurn(args: {
 
 export interface ReplyExecutorServices {
   contextCompactor: ContextCompactor;
-  generateAssistantReply: typeof generateAssistantReplyImpl;
+  generateAssistantReply: (
+    messageText: string,
+    context: AssistantReplyRequestContext,
+  ) => Promise<AgentRunOutcome>;
   generateThreadTitle: ConversationMemoryService["generateThreadTitle"];
   getAwaitingAgentContinueRequest: (args: {
     conversationId: string;
@@ -907,6 +912,8 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
         let finalReplyDelivered = false;
         let latestArtifacts = preparedState.artifacts;
         let assistantTitleArtifacts: Partial<ThreadArtifactsState> = {};
+        let agentContinuePropagationError: unknown;
+        let agentContinueScheduleError: unknown;
         const hasVisibleSlackDelivery = (post: {
           files?: unknown[];
           text: string;
@@ -1036,7 +1043,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                 );
               }
             : undefined;
-          let reply = await deps.services.generateAssistantReply(
+          const outcome = await deps.services.generateAssistantReply(
             effectiveUserText,
             {
               credentialContext,
@@ -1108,6 +1115,102 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               shouldYield: options.shouldYield,
             },
           );
+          if (outcome.status === "yielded") {
+            shouldPersistFailureState = false;
+            throw new CooperativeTurnYieldError();
+          }
+          if (outcome.status === "awaiting_auth") {
+            if (!requester) {
+              const text = `I could not act on this subscribed event because ${outcome.authProviderDisplayName} needs user authorization. Ask me in this thread to connect ${outcome.authProviderDisplayName} before retrying.`;
+              await postThreadReply(
+                buildSlackOutputMessage(text),
+                "thread_reply",
+              );
+              markConversationMessage(
+                preparedState.conversation,
+                preparedState.userMessageId,
+                {
+                  replied: true,
+                  skippedReason: undefined,
+                },
+              );
+              upsertConversationMessage(preparedState.conversation, {
+                id: generateConversationId("assistant"),
+                role: "assistant",
+                text: normalizeConversationText(text),
+                createdAtMs: Date.now(),
+                author: {
+                  userName: botConfig.userName,
+                  isBot: true,
+                },
+                meta: {
+                  replied: true,
+                },
+              });
+              markTurnClosed({
+                conversation: preparedState.conversation,
+                nowMs: Date.now(),
+                sessionId: turnId,
+                updateConversationStats,
+              });
+              await persistThreadState(thread, {
+                conversation: preparedState.conversation,
+              });
+              persistedAtLeastOnce = true;
+              shouldPersistFailureState = false;
+              return;
+            }
+            await postAuthPauseNotice(outcome.authProviderDisplayName);
+            completeAuthPauseTurn({
+              conversation: preparedState.conversation,
+              sessionId: outcome.sessionId,
+            });
+            await persistThreadState(thread, {
+              conversation: preparedState.conversation,
+            });
+            persistedAtLeastOnce = true;
+            shouldPersistFailureState = false;
+            return;
+          }
+          if (outcome.status === "timed_out") {
+            if (typeof outcome.version === "number" && destination) {
+              try {
+                await deps.services.scheduleAgentContinue({
+                  conversationId: outcome.conversationId,
+                  destination,
+                  sessionId: outcome.sessionId,
+                  expectedVersion: outcome.version,
+                });
+                shouldPersistFailureState = false;
+              } catch (scheduleError) {
+                logException(
+                  scheduleError,
+                  "agent_continue_schedule_failed",
+                  turnTraceContext,
+                  {
+                    ...(messageTs ? { "messaging.message.id": messageTs } : {}),
+                    "app.ai.resume_session_version": outcome.version,
+                  },
+                  "Failed to schedule agent continuation",
+                );
+                shouldPersistFailureState = true;
+                agentContinueScheduleError = scheduleError;
+                throw scheduleError;
+              }
+              return;
+            }
+            logWarn(
+              "agent_continue_metadata_missing",
+              turnTraceContext,
+              messageTs ? { "messaging.message.id": messageTs } : {},
+              "Agent continuation could not be scheduled because retry metadata was incomplete",
+            );
+            agentContinuePropagationError =
+              retryableTurnErrorFromTimedOutAgentRun(outcome);
+            throw agentContinuePropagationError;
+          }
+
+          let reply = outcome.reply;
           const diagnosticsContext = {
             slackThreadId: threadId,
             slackUserId: message.author.userId,
@@ -1338,108 +1441,18 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             );
             return;
           }
-          if (isCooperativeTurnYieldError(error)) {
+          if (error instanceof CooperativeTurnYieldError) {
             shouldPersistFailureState = false;
             throw error;
           }
-
-          if (isAuthResumeRetryableTurnError(error)) {
-            if (!requester) {
-              const text = `I could not act on this subscribed event because ${error.metadata.authProviderDisplayName} needs user authorization. Ask me in this thread to connect ${error.metadata.authProviderDisplayName} before retrying.`;
-              await postThreadReply(
-                buildSlackOutputMessage(text),
-                "thread_reply",
-              );
-              markConversationMessage(
-                preparedState.conversation,
-                preparedState.userMessageId,
-                {
-                  replied: true,
-                  skippedReason: undefined,
-                },
-              );
-              upsertConversationMessage(preparedState.conversation, {
-                id: generateConversationId("assistant"),
-                role: "assistant",
-                text: normalizeConversationText(text),
-                createdAtMs: Date.now(),
-                author: {
-                  userName: botConfig.userName,
-                  isBot: true,
-                },
-                meta: {
-                  replied: true,
-                },
-              });
-              markTurnClosed({
-                conversation: preparedState.conversation,
-                nowMs: Date.now(),
-                sessionId: turnId,
-                updateConversationStats,
-              });
-              await persistThreadState(thread, {
-                conversation: preparedState.conversation,
-              });
-              persistedAtLeastOnce = true;
-              shouldPersistFailureState = false;
-              return;
-            }
-            await postAuthPauseNotice(error.metadata.authProviderDisplayName);
-            completeAuthPauseTurn({
-              conversation: preparedState.conversation,
-              sessionId: error.metadata?.sessionId ?? turnId,
-            });
-            await persistThreadState(thread, {
-              conversation: preparedState.conversation,
-            });
-            persistedAtLeastOnce = true;
-            shouldPersistFailureState = false;
-            return;
+          if (error === agentContinueScheduleError) {
+            shouldPersistFailureState = true;
+            throw error;
           }
-
-          if (isRetryableTurnError(error, "agent_continue")) {
-            const conversationIdForResume = error.metadata?.conversationId;
-            const sessionIdForResume = error.metadata?.sessionId;
-            const version = error.metadata?.version;
-            if (
-              conversationIdForResume &&
-              sessionIdForResume &&
-              typeof version === "number" &&
-              destination
-            ) {
-              try {
-                await deps.services.scheduleAgentContinue({
-                  conversationId: conversationIdForResume,
-                  destination,
-                  sessionId: sessionIdForResume,
-                  expectedVersion: version,
-                });
-                shouldPersistFailureState = false;
-              } catch (scheduleError) {
-                logException(
-                  scheduleError,
-                  "agent_continue_schedule_failed",
-                  turnTraceContext,
-                  {
-                    ...(messageTs ? { "messaging.message.id": messageTs } : {}),
-                    "app.ai.resume_session_version": version,
-                  },
-                  "Failed to schedule agent continuation",
-                );
-                shouldPersistFailureState = true;
-                throw scheduleError;
-              }
-              return;
-            } else {
-              logWarn(
-                "agent_continue_metadata_missing",
-                turnTraceContext,
-                messageTs ? { "messaging.message.id": messageTs } : {},
-                "Agent continuation could not be scheduled because retry metadata was incomplete",
-              );
-            }
+          if (error === agentContinuePropagationError) {
+            shouldPersistFailureState = true;
+            throw error;
           }
-
           shouldPersistFailureState = true;
           const createdCanvasUrl = getCurrentTurnCanvasUrl({
             before: preparedState.artifacts,

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -12,6 +12,11 @@ import {
   type AssistantReply,
   type AssistantReplyRequestContext,
 } from "@/chat/respond";
+import {
+  retryableTurnErrorFromAuthAgentRun,
+  retryableTurnErrorFromTimedOutAgentRun,
+  type AgentRunOutcome,
+} from "@/chat/runtime/agent-run-outcome";
 import type { Source } from "@sentry/junior-plugin-api";
 import { scheduleSessionCompletedPluginTasks } from "@/chat/plugins/task-runner";
 import {
@@ -65,6 +70,11 @@ function resolveReplyTimeoutMs(explicitTimeoutMs?: number): number | undefined {
   const parsed = Number.parseInt(raw, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
+
+type ResumeGenerateReply = (
+  messageText: string,
+  context: AssistantReplyRequestContext,
+) => Promise<AgentRunOutcome>;
 
 async function postSlackMessageBestEffort(
   channelId: string,
@@ -142,7 +152,7 @@ interface ResumeSlackTurnArgs {
   replyContext?: ResumeReplyContext;
   lockKey?: string;
   initialText?: string;
-  generateReply?: typeof generateAssistantReply;
+  generateReply?: ResumeGenerateReply;
   scheduleSessionCompletedPluginTasks?: (params: {
     conversationId: string;
     sessionId: string;
@@ -376,7 +386,7 @@ export async function resumeSlackTurn(
     const replyContext = createResumeReplyContext(runArgs, status);
     const replyPromise = generateReply(runArgs.messageText, replyContext);
     const replyTimeoutMs = resolveReplyTimeoutMs(runArgs.replyTimeoutMs);
-    let reply =
+    const outcome =
       typeof replyTimeoutMs === "number"
         ? await Promise.race([
             replyPromise,
@@ -393,6 +403,16 @@ export async function resumeSlackTurn(
             ),
           ])
         : await replyPromise;
+    if (outcome.status === "awaiting_auth") {
+      throw retryableTurnErrorFromAuthAgentRun(outcome);
+    }
+    if (outcome.status === "timed_out") {
+      throw retryableTurnErrorFromTimedOutAgentRun(outcome);
+    }
+    if (outcome.status === "yielded") {
+      throw new Error("Slack resume yielded without a queue worker boundary");
+    }
+    let reply = outcome.reply;
     reply = finalizeFailedTurnReply({
       reply,
       logException,
@@ -578,7 +598,7 @@ export async function resumeAuthorizedRequest(args: {
   connectedText: string;
   replyContext?: ResumeReplyContext;
   lockKey?: string;
-  generateReply?: typeof generateAssistantReply;
+  generateReply?: ResumeGenerateReply;
   onSuccess?: (reply: AssistantReply) => Promise<void>;
   onFailure?: (error: unknown) => Promise<void>;
   onAuthPause?: (error: unknown) => Promise<void>;

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -7,10 +7,8 @@
  */
 import { botConfig } from "@/chat/config";
 import type { ChannelConfigurationService } from "@/chat/configuration/types";
-import {
-  type AssistantReply,
-  type AssistantReplyRequestContext,
-} from "@/chat/respond";
+import type { AgentRunRequest } from "@/chat/agent-run";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 import {
   retryableTurnErrorFromAuthAgentRun,
   retryableTurnErrorFromTimedOutAgentRun,
@@ -150,7 +148,7 @@ interface ResumeSlackTurnArgs {
     conversationId: string;
     sessionId: string;
   }) => Promise<void>;
-  onSuccess?: (reply: AssistantReply) => Promise<void>;
+  onSuccess?: (reply: AgentRunResult) => Promise<void>;
   onFailure?: (error: unknown) => Promise<void>;
   onAuthPause?: (error: unknown) => Promise<void>;
   onTimeoutPause?: (error: unknown) => Promise<void>;
@@ -159,8 +157,8 @@ interface ResumeSlackTurnArgs {
   replyTimeoutMs?: number;
 }
 
-type ResumeReplyContext = Omit<AssistantReplyRequestContext, "input"> & {
-  input?: Omit<AssistantReplyRequestContext["input"], "messageText">;
+type ResumeReplyContext = Omit<AgentRunRequest, "input"> & {
+  input?: Omit<AgentRunRequest["input"], "messageText">;
 };
 
 function getDefaultLockKey(channelId: string, threadTs: string): string {
@@ -247,7 +245,7 @@ async function handleResumeFailure(args: {
 function createResumeReplyContext(
   args: ResumeSlackTurnArgs,
   statusSession: AssistantStatusSession,
-): AssistantReplyRequestContext {
+): AgentRunRequest {
   const replyContext = args.replyContext;
   if (!replyContext) {
     throw new TypeError("Slack resume requires a reply context");
@@ -406,7 +404,7 @@ export async function resumeSlackTurn(
                 () =>
                   reject(
                     new Error(
-                      `generateAssistantReply timed out after ${replyTimeoutMs}ms`,
+                      `executeAgentRun timed out after ${replyTimeoutMs}ms`,
                     ),
                   ),
                 replyTimeoutMs,
@@ -423,7 +421,7 @@ export async function resumeSlackTurn(
     if (outcome.status === "yielded") {
       throw new Error("Slack resume yielded without a queue worker boundary");
     }
-    let reply = outcome.reply;
+    let reply = outcome.result;
     reply = finalizeFailedTurnReply({
       reply,
       logException,
@@ -610,7 +608,7 @@ export async function resumeAuthorizedRequest(args: {
   replyContext?: ResumeReplyContext;
   lockKey?: string;
   agentRunner: AgentRunner;
-  onSuccess?: (reply: AssistantReply) => Promise<void>;
+  onSuccess?: (reply: AgentRunResult) => Promise<void>;
   onFailure?: (error: unknown) => Promise<void>;
   onAuthPause?: (error: unknown) => Promise<void>;
   onTimeoutPause?: (error: unknown) => Promise<void>;

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -16,7 +16,6 @@ import {
   retryableTurnErrorFromTimedOutAgentRun,
 } from "@/chat/runtime/agent-run-outcome";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
-import type { Source } from "@sentry/junior-plugin-api";
 import { scheduleSessionCompletedPluginTasks } from "@/chat/plugins/task-runner";
 import {
   buildTurnFailureResponse,
@@ -160,8 +159,8 @@ interface ResumeSlackTurnArgs {
   replyTimeoutMs?: number;
 }
 
-type ResumeReplyContext = AssistantReplyRequestContext & {
-  source: Source;
+type ResumeReplyContext = Omit<AssistantReplyRequestContext, "input"> & {
+  input?: Omit<AssistantReplyRequestContext["input"], "messageText">;
 };
 
 function getDefaultLockKey(channelId: string, threadTs: string): string {
@@ -172,15 +171,15 @@ function getResumeLogContext(
   args: ResumeSlackTurnArgs,
   lockKey: string,
 ): LogContext {
+  const routing = args.replyContext?.routing;
   return {
-    conversationId: args.replyContext?.correlation?.conversationId ?? lockKey,
-    slackThreadId: args.replyContext?.correlation?.threadId ?? lockKey,
+    conversationId: routing?.correlation?.conversationId ?? lockKey,
+    slackThreadId: routing?.correlation?.threadId ?? lockKey,
     slackUserId:
-      args.replyContext?.requester?.userId ??
-      args.replyContext?.correlation?.requesterId,
-    slackUserName: args.replyContext?.requester?.userName,
+      routing?.requester?.userId ?? routing?.correlation?.requesterId,
+    slackUserName: routing?.requester?.userName,
     slackChannelId: args.channelId,
-    runId: args.replyContext?.correlation?.runId,
+    runId: routing?.correlation?.runId,
     assistantUserName: botConfig.userName,
     modelId: botConfig.modelId,
   };
@@ -191,7 +190,7 @@ function getResumeConversationId(
   args: ResumeSlackTurnArgs,
   lockKey: string,
 ): string {
-  return args.replyContext?.correlation?.conversationId ?? lockKey;
+  return args.replyContext?.routing.correlation?.conversationId ?? lockKey;
 }
 
 async function postResumeFailureReply(args: {
@@ -248,55 +247,73 @@ async function handleResumeFailure(args: {
 function createResumeReplyContext(
   args: ResumeSlackTurnArgs,
   statusSession: AssistantStatusSession,
-): ResumeReplyContext {
+): AssistantReplyRequestContext {
   const replyContext = args.replyContext;
   if (!replyContext) {
     throw new TypeError("Slack resume requires a reply context");
   }
-  if (!replyContext.source) {
+  if (!replyContext.routing.source) {
     throw new TypeError("Slack resume requires a reply context source");
   }
-  const source = replyContext.source;
-  if (replyContext.destination.platform !== "slack") {
+  const source = replyContext.routing.source;
+  if (replyContext.routing.destination.platform !== "slack") {
     throw new TypeError("Slack resume requires a Slack destination");
   }
   const requestDeadline = getTurnRequestDeadline();
   const threadId =
     args.lockKey ?? getDefaultLockKey(args.channelId, args.threadTs);
   const persistedChannelConfiguration =
-    replyContext.channelConfiguration ??
-    (replyContext.configuration
-      ? createReadOnlyConfigService(replyContext.configuration)
+    replyContext.policy?.channelConfiguration ??
+    (replyContext.policy?.configuration
+      ? createReadOnlyConfigService(replyContext.policy.configuration)
       : undefined);
 
   return {
-    ...replyContext,
-    source,
-    turnDeadlineAtMs:
-      replyContext.turnDeadlineAtMs ?? requestDeadline?.deadlineAtMs,
-    correlation: {
-      ...replyContext.correlation,
-      threadId: replyContext.correlation?.threadId ?? threadId,
-      channelId: replyContext.correlation?.channelId ?? args.channelId,
-      threadTs: replyContext.correlation?.threadTs ?? args.threadTs,
-      requesterId:
-        replyContext.correlation?.requesterId ?? replyContext.requester?.userId,
+    input: {
+      ...(replyContext.input ?? {}),
+      messageText: args.messageText,
     },
-    channelConfiguration: persistedChannelConfiguration,
-    onSandboxAcquired: async (sandbox) => {
-      await persistThreadStateById(threadId, {
-        sandboxId: sandbox.sandboxId,
-        sandboxDependencyProfileHash: sandbox.sandboxDependencyProfileHash,
-      });
-      await replyContext.onSandboxAcquired?.(sandbox);
+    routing: {
+      ...replyContext.routing,
+      source,
+      correlation: {
+        ...replyContext.routing.correlation,
+        threadId: replyContext.routing.correlation?.threadId ?? threadId,
+        channelId:
+          replyContext.routing.correlation?.channelId ?? args.channelId,
+        threadTs: replyContext.routing.correlation?.threadTs ?? args.threadTs,
+        requesterId:
+          replyContext.routing.correlation?.requesterId ??
+          replyContext.routing.requester?.userId,
+      },
     },
-    onArtifactStateUpdated: async (artifacts) => {
-      await persistThreadStateById(threadId, { artifacts });
-      await replyContext.onArtifactStateUpdated?.(artifacts);
+    policy: {
+      ...replyContext.policy,
+      turnDeadlineAtMs:
+        replyContext.policy?.turnDeadlineAtMs ?? requestDeadline?.deadlineAtMs,
+      channelConfiguration: persistedChannelConfiguration,
     },
-    onStatus: async (nextStatus) => {
-      statusSession.update(nextStatus);
-      await replyContext.onStatus?.(nextStatus);
+    state: replyContext.state,
+    observers: {
+      ...replyContext.observers,
+      onStatus: async (nextStatus) => {
+        statusSession.update(nextStatus);
+        await replyContext.observers?.onStatus?.(nextStatus);
+      },
+    },
+    durability: {
+      ...replyContext.durability,
+      onSandboxAcquired: async (sandbox) => {
+        await persistThreadStateById(threadId, {
+          sandboxId: sandbox.sandboxId,
+          sandboxDependencyProfileHash: sandbox.sandboxDependencyProfileHash,
+        });
+        await replyContext.durability?.onSandboxAcquired?.(sandbox);
+      },
+      onArtifactStateUpdated: async (artifacts) => {
+        await persistThreadStateById(threadId, { artifacts });
+        await replyContext.durability?.onArtifactStateUpdated?.(artifacts);
+      },
     },
   };
 }
@@ -343,16 +360,17 @@ export async function resumeSlackTurn(
       runArgs = { ...args, ...preparedArgs };
     }
 
-    if (!runArgs.replyContext?.requester?.userId) {
+    if (!runArgs.replyContext?.routing.requester?.userId) {
       throw new Error("Resumed turn requires replyContext.requester.userId");
     }
-    const credentialContext = runArgs.replyContext.credentialContext;
+    const credentialContext = runArgs.replyContext.routing.credentialContext;
     if (!credentialContext) {
       throw new Error("Resumed turn requires replyContext.credentialContext");
     }
     if (
       credentialContext.actor.type !== "user" ||
-      credentialContext.actor.userId !== runArgs.replyContext.requester.userId
+      credentialContext.actor.userId !==
+        runArgs.replyContext.routing.requester.userId
     ) {
       throw new Error(
         "Resumed turn credential actor must match replyContext.requester.userId",
@@ -377,10 +395,7 @@ export async function resumeSlackTurn(
     status.start();
 
     const replyContext = createResumeReplyContext(runArgs, status);
-    const replyPromise = runArgs.agentRunner.run(
-      runArgs.messageText,
-      replyContext,
-    );
+    const replyPromise = runArgs.agentRunner.run(replyContext);
     const replyTimeoutMs = resolveReplyTimeoutMs(runArgs.replyTimeoutMs);
     const outcome =
       typeof replyTimeoutMs === "number"
@@ -431,25 +446,25 @@ export async function resumeSlackTurn(
     // final assistant messages and the terminal completed session record.
     // Persistence failures are logged inside and never fail the turn.
     if (
-      replyContext.correlation?.conversationId &&
-      replyContext.correlation.turnId &&
+      replyContext.routing.correlation?.conversationId &&
+      replyContext.routing.correlation.turnId &&
       reply.piMessages?.length
     ) {
       await persistCompletedSessionRecord({
-        conversationId: replyContext.correlation.conversationId,
-        sessionId: replyContext.correlation.turnId,
+        conversationId: replyContext.routing.correlation.conversationId,
+        sessionId: replyContext.routing.correlation.turnId,
         allMessages: reply.piMessages,
         currentDurationMs: reply.diagnostics.durationMs,
         currentUsage: reply.diagnostics.usage,
-        destination: replyContext.destination,
-        source: replyContext.source,
-        requester: replyContext.requester,
+        destination: replyContext.routing.destination,
+        source: replyContext.routing.source,
+        requester: replyContext.routing.requester,
         surface: "slack",
         logContext: {
-          threadId: replyContext.correlation.threadId,
-          requesterId: replyContext.requester?.userId,
+          threadId: replyContext.routing.correlation.threadId,
+          requesterId: replyContext.routing.requester?.userId,
           channelId: runArgs.channelId,
-          runId: replyContext.correlation.runId,
+          runId: replyContext.routing.correlation.runId,
           assistantUserName: botConfig.userName,
           modelId: reply.diagnostics.modelId,
         },
@@ -458,13 +473,13 @@ export async function resumeSlackTurn(
     await runArgs.onSuccess?.(reply);
     if (
       reply.diagnostics.outcome === "success" &&
-      replyContext.correlation?.conversationId &&
-      replyContext.correlation.turnId
+      replyContext.routing.correlation?.conversationId &&
+      replyContext.routing.correlation.turnId
     ) {
       try {
         const params = {
-          conversationId: replyContext.correlation.conversationId,
-          sessionId: replyContext.correlation.turnId,
+          conversationId: replyContext.routing.correlation.conversationId,
+          sessionId: replyContext.routing.correlation.turnId,
         };
         if (runArgs.scheduleSessionCompletedPluginTasks) {
           await runArgs.scheduleSessionCompletedPluginTasks(params);
@@ -504,7 +519,7 @@ export async function resumeSlackTurn(
       deferredAuthInfo = {
         providerDisplayName: error.metadata.authProviderDisplayName,
         // The try body validates requester.userId; catch scope does not retain that narrowing.
-        requesterId: runArgs.replyContext?.requester?.userId,
+        requesterId: runArgs.replyContext?.routing.requester?.userId,
       };
       deferredPauseHandler = async () => {
         await onAuthPause(error);

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -8,15 +8,14 @@
 import { botConfig } from "@/chat/config";
 import type { ChannelConfigurationService } from "@/chat/configuration/types";
 import {
-  generateAssistantReply,
   type AssistantReply,
   type AssistantReplyRequestContext,
 } from "@/chat/respond";
 import {
   retryableTurnErrorFromAuthAgentRun,
   retryableTurnErrorFromTimedOutAgentRun,
-  type AgentRunOutcome,
 } from "@/chat/runtime/agent-run-outcome";
+import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import type { Source } from "@sentry/junior-plugin-api";
 import { scheduleSessionCompletedPluginTasks } from "@/chat/plugins/task-runner";
 import {
@@ -70,11 +69,6 @@ function resolveReplyTimeoutMs(explicitTimeoutMs?: number): number | undefined {
   const parsed = Number.parseInt(raw, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
-
-type ResumeGenerateReply = (
-  messageText: string,
-  context: AssistantReplyRequestContext,
-) => Promise<AgentRunOutcome>;
 
 async function postSlackMessageBestEffort(
   channelId: string,
@@ -152,7 +146,7 @@ interface ResumeSlackTurnArgs {
   replyContext?: ResumeReplyContext;
   lockKey?: string;
   initialText?: string;
-  generateReply?: ResumeGenerateReply;
+  agentRunner: AgentRunner;
   scheduleSessionCompletedPluginTasks?: (params: {
     conversationId: string;
     sessionId: string;
@@ -382,9 +376,11 @@ export async function resumeSlackTurn(
     }
     status.start();
 
-    const generateReply = runArgs.generateReply ?? generateAssistantReply;
     const replyContext = createResumeReplyContext(runArgs, status);
-    const replyPromise = generateReply(runArgs.messageText, replyContext);
+    const replyPromise = runArgs.agentRunner.run(
+      runArgs.messageText,
+      replyContext,
+    );
     const replyTimeoutMs = resolveReplyTimeoutMs(runArgs.replyTimeoutMs);
     const outcome =
       typeof replyTimeoutMs === "number"
@@ -598,7 +594,7 @@ export async function resumeAuthorizedRequest(args: {
   connectedText: string;
   replyContext?: ResumeReplyContext;
   lockKey?: string;
-  generateReply?: ResumeGenerateReply;
+  agentRunner: AgentRunner;
   onSuccess?: (reply: AssistantReply) => Promise<void>;
   onFailure?: (error: unknown) => Promise<void>;
   onAuthPause?: (error: unknown) => Promise<void>;
@@ -615,7 +611,7 @@ export async function resumeAuthorizedRequest(args: {
     replyContext: args.replyContext,
     lockKey: args.lockKey,
     initialText: args.connectedText,
-    generateReply: args.generateReply,
+    agentRunner: args.agentRunner,
     onSuccess: args.onSuccess,
     onFailure: args.onFailure,
     onAuthPause: args.onAuthPause,

--- a/packages/junior/src/chat/runtime/turn.ts
+++ b/packages/junior/src/chat/runtime/turn.ts
@@ -47,7 +47,10 @@ export type AuthResumeRetryableTurnError = RetryableTurnError & {
   readonly metadata: AuthResumeRetryableTurnMetadata;
 };
 
-/** Error indicating an agent run can continue later after timeout or auth pause. */
+/**
+ * Historical turn error for outer resume/callback boundaries; expected
+ * generateAssistantReply lifecycle endings are represented by AgentRunOutcome.
+ */
 export class RetryableTurnError extends Error {
   readonly code = "retryable_turn";
   readonly metadata?: RetryableTurnMetadata;
@@ -101,7 +104,11 @@ export function isAuthResumeRetryableTurnError(
   );
 }
 
-/** Error indicating the turn paused voluntarily at a safe continuation boundary. */
+/**
+ * Historical turn error for queue-worker yield routing; respond.ts returns a
+ * yielded AgentRunOutcome and the Slack executor recreates this at the worker
+ * boundary.
+ */
 export class CooperativeTurnYieldError extends Error {
   readonly code = "cooperative_turn_yield";
 

--- a/packages/junior/src/chat/runtime/turn.ts
+++ b/packages/junior/src/chat/runtime/turn.ts
@@ -49,7 +49,7 @@ export type AuthResumeRetryableTurnError = RetryableTurnError & {
 
 /**
  * Historical turn error for outer resume/callback boundaries; expected
- * generateAssistantReply lifecycle endings are represented by AgentRunOutcome.
+ * executeAgentRun lifecycle endings are represented by AgentRunOutcome.
  */
 export class RetryableTurnError extends Error {
   readonly code = "retryable_turn";
@@ -105,7 +105,7 @@ export function isAuthResumeRetryableTurnError(
 }
 
 /**
- * Historical turn error for queue-worker yield routing; respond.ts returns a
+ * Historical turn error for queue-worker yield routing; agent-run.ts returns a
  * yielded AgentRunOutcome and the Slack executor recreates this at the worker
  * boundary.
  */

--- a/packages/junior/src/chat/services/context-compaction.ts
+++ b/packages/junior/src/chat/services/context-compaction.ts
@@ -25,7 +25,7 @@ import { logWarn, setSpanAttributes } from "@/chat/logging";
 import {
   stripRuntimeTurnContext,
   trimTrailingAssistantMessages,
-} from "@/chat/respond-helpers";
+} from "@/chat/agent-run-helpers";
 import { updateConversationStats } from "@/chat/services/conversation-memory";
 
 const RETAINED_USER_MESSAGE_TOKENS = 20_000;

--- a/packages/junior/src/chat/services/provider-retry.ts
+++ b/packages/junior/src/chat/services/provider-retry.ts
@@ -3,7 +3,7 @@ import type { PiMessage } from "@/chat/pi/messages";
 import {
   getPiMessageRole,
   trimTrailingAssistantMessages,
-} from "@/chat/respond-helpers";
+} from "@/chat/agent-run-helpers";
 
 const PROVIDER_RETRY_DELAYS_MS = [2_000, 4_000, 8_000] as const;
 const PROVIDER_ERROR_PREFIX = "AI provider error:";

--- a/packages/junior/src/chat/services/turn-failure-response.ts
+++ b/packages/junior/src/chat/services/turn-failure-response.ts
@@ -2,7 +2,7 @@ import type { LogContext } from "@/chat/logging";
 import { buildTurnFailureResponse } from "@/chat/logging";
 import { getInterruptionMarker } from "@/chat/interruption-marker";
 import { GEN_AI_PROVIDER_NAME } from "@/chat/pi/client";
-import type { AssistantReply } from "@/chat/services/turn-result";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 
 type LogException = (
   error: unknown,
@@ -43,7 +43,7 @@ function getExecutionFailureReason(reply: {
   return "empty assistant turn";
 }
 
-function getFailureCapture(reply: AssistantReply): {
+function getFailureCapture(reply: AgentRunResult): {
   attributes: Record<string, unknown>;
   body: string;
   error: unknown;
@@ -76,7 +76,7 @@ function getFailureCapture(reply: AssistantReply): {
 
 /** Keep failed-turn Sentry captures and completion spans on the same keys. */
 export function getAgentTurnDiagnosticsAttributes(
-  reply: AssistantReply,
+  reply: AgentRunResult,
 ): Record<string, unknown> {
   return {
     "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
@@ -105,11 +105,11 @@ export function getAgentTurnDiagnosticsAttributes(
 
 /** Enforce one captured, event-ID-bearing failure response before delivery. */
 export function finalizeFailedTurnReply(args: {
-  reply: AssistantReply;
+  reply: AgentRunResult;
   logException: LogException;
   context: LogContext;
   attributes?: Record<string, unknown>;
-}): AssistantReply {
+}): AgentRunResult {
   if (args.reply.diagnostics.outcome === "success") {
     return args.reply;
   }

--- a/packages/junior/src/chat/services/turn-result.ts
+++ b/packages/junior/src/chat/services/turn-result.ts
@@ -27,7 +27,7 @@ import {
   isToolResultMessage,
   normalizeToolNameFromResult,
   summarizeMessageText,
-} from "@/chat/respond-helpers";
+} from "@/chat/agent-run-helpers";
 
 const POST_CANVAS_REPLY_MAX_CHARS = 700;
 const POST_CANVAS_REPLY_MAX_LINES = 8;
@@ -51,7 +51,7 @@ export interface AgentTurnDiagnostics {
   usedPrimaryText: boolean;
 }
 
-export interface AssistantReply {
+export interface AgentRunResult {
   text: string;
   files?: FileUpload[];
   artifactStatePatch?: Partial<ThreadArtifactsState>;
@@ -131,8 +131,8 @@ function stripThinkingXmlBlocks(text: string): string {
   return result;
 }
 
-/** Process raw agent messages into a structured AssistantReply. */
-export function buildTurnResult(input: TurnResultInput): AssistantReply {
+/** Process raw agent messages into a structured AgentRunResult. */
+export function buildTurnResult(input: TurnResultInput): AgentRunResult {
   const {
     newMessages,
     userInput,

--- a/packages/junior/src/chat/services/turn-session-record.ts
+++ b/packages/junior/src/chat/services/turn-session-record.ts
@@ -11,7 +11,7 @@ import type { PiMessage } from "@/chat/pi/messages";
 import {
   getPiMessageRole,
   trimTrailingAssistantMessages,
-} from "@/chat/respond-helpers";
+} from "@/chat/agent-run-helpers";
 import { addAgentTurnUsage, type AgentTurnUsage } from "@/chat/usage";
 
 export const AGENT_CONTINUE_MAX_SLICES = 48;

--- a/packages/junior/src/chat/slack/reply.ts
+++ b/packages/junior/src/chat/slack/reply.ts
@@ -1,6 +1,6 @@
 import { Buffer } from "node:buffer";
 import type { FileUpload } from "chat";
-import type { AssistantReply } from "@/chat/respond";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { ReplyFileDelivery } from "@/chat/services/reply-delivery-plan";
 import {
   buildSlackReplyBlocks,
@@ -23,7 +23,7 @@ export interface PlannedSlackReplyPost {
   text: string;
 }
 
-function resolveReplyDelivery(reply: AssistantReply): {
+function resolveReplyDelivery(reply: AgentRunResult): {
   shouldPostThreadReply: boolean;
   attachFiles: ReplyFileDelivery;
 } {
@@ -135,7 +135,7 @@ async function uploadReplyFiles(args: {
  * including chunking, interruption markers, and file delivery.
  */
 export function planSlackReplyPosts(args: {
-  reply: AssistantReply;
+  reply: AgentRunResult;
 }): PlannedSlackReplyPost[] {
   const replyFiles =
     args.reply.files && args.reply.files.length > 0

--- a/packages/junior/src/chat/tools/advisor/tool.ts
+++ b/packages/junior/src/chat/tools/advisor/tool.ts
@@ -30,7 +30,7 @@ import type { PiMessage } from "@/chat/pi/messages";
 import {
   extractAssistantText,
   isAssistantMessage,
-} from "@/chat/respond-helpers";
+} from "@/chat/agent-run-helpers";
 import {
   createStateAdvisorSessionStore,
   getAdvisorSessionKey,

--- a/packages/junior/src/cli/chat.ts
+++ b/packages/junior/src/cli/chat.ts
@@ -16,7 +16,7 @@ import { createJiti } from "jiti";
 import { loadAppPluginSet } from "@/plugin-module";
 import { normalizeLocalConversationId } from "@/chat/local/conversation";
 import type { LocalAgentReply, LocalToolResult } from "@/chat/local/runner";
-import { generateAssistantReply } from "@/chat/respond";
+import { executeAgentRun } from "@/chat/agent-run";
 import { createAgentRunner } from "@/chat/runtime/agent-runner";
 import type { JuniorPluginSet } from "@/plugins";
 
@@ -240,7 +240,7 @@ async function runPrompt(
   defaultStateAdapterForLocalChat();
   await configureLocalChatPlugins(pluginSet);
   const conversationId = newRunConversationId();
-  const agentRunner = createAgentRunner(generateAssistantReply);
+  const agentRunner = createAgentRunner(executeAgentRun);
 
   const { runLocalAgentTurn } = await import("@/chat/local/runner");
   const result = await runLocalAgentTurn(
@@ -271,7 +271,7 @@ async function runInteractive(
   defaultStateAdapterForLocalChat();
   await configureLocalChatPlugins(pluginSet);
   const conversationId = newRunConversationId();
-  const agentRunner = createAgentRunner(generateAssistantReply);
+  const agentRunner = createAgentRunner(executeAgentRun);
 
   const { runLocalAgentTurn } = await import("@/chat/local/runner");
   const rl = readline.createInterface({

--- a/packages/junior/src/cli/chat.ts
+++ b/packages/junior/src/cli/chat.ts
@@ -16,6 +16,8 @@ import { createJiti } from "jiti";
 import { loadAppPluginSet } from "@/plugin-module";
 import { normalizeLocalConversationId } from "@/chat/local/conversation";
 import type { LocalAgentReply, LocalToolResult } from "@/chat/local/runner";
+import { generateAssistantReply } from "@/chat/respond";
+import { createAgentRunner } from "@/chat/runtime/agent-runner";
 import type { JuniorPluginSet } from "@/plugins";
 
 export const CHAT_USAGE = "usage: junior chat\n       junior chat -p <message>";
@@ -238,6 +240,7 @@ async function runPrompt(
   defaultStateAdapterForLocalChat();
   await configureLocalChatPlugins(pluginSet);
   const conversationId = newRunConversationId();
+  const agentRunner = createAgentRunner(generateAssistantReply);
 
   const { runLocalAgentTurn } = await import("@/chat/local/runner");
   const result = await runLocalAgentTurn(
@@ -246,6 +249,7 @@ async function runPrompt(
       message: options.message,
     },
     {
+      agentRunner,
       deliverReply: async (reply) => {
         await deliverReply(io, reply);
       },
@@ -267,6 +271,7 @@ async function runInteractive(
   defaultStateAdapterForLocalChat();
   await configureLocalChatPlugins(pluginSet);
   const conversationId = newRunConversationId();
+  const agentRunner = createAgentRunner(generateAssistantReply);
 
   const { runLocalAgentTurn } = await import("@/chat/local/runner");
   const rl = readline.createInterface({
@@ -290,6 +295,7 @@ async function runInteractive(
             message,
           },
           {
+            agentRunner,
             deliverReply: async (reply) => {
               await deliverReply(io, reply);
             },

--- a/packages/junior/src/handlers/agent-dispatch.ts
+++ b/packages/junior/src/handlers/agent-dispatch.ts
@@ -2,9 +2,11 @@ import { logException } from "@/chat/logging";
 import { runAgentDispatchSlice } from "@/chat/agent-dispatch/runner";
 import { verifyDispatchCallbackRequest } from "@/chat/agent-dispatch/signing";
 import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress/tracing";
+import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import type { WaitUntilFn } from "@/handlers/types";
 
 interface AgentDispatchHandlerOptions {
+  agentRunner: AgentRunner;
   tracePropagation?: SandboxEgressTracePropagationConfig;
 }
 
@@ -12,7 +14,7 @@ interface AgentDispatchHandlerOptions {
 export async function POST(
   request: Request,
   waitUntil: WaitUntilFn,
-  options: AgentDispatchHandlerOptions = {},
+  options: AgentDispatchHandlerOptions,
 ): Promise<Response> {
   const payload = await verifyDispatchCallbackRequest(request);
   if (!payload) {
@@ -21,6 +23,7 @@ export async function POST(
 
   waitUntil(() =>
     runAgentDispatchSlice(payload, {
+      agentRunner: options.agentRunner,
       tracePropagation: options.tracePropagation,
     }).catch((error) => {
       logException(

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -349,41 +349,51 @@ async function resumeAuthorizedMcpTurn(args: {
         messageText: lockedUserMessage.text,
         messageTs: lockedMessageTs,
         replyContext: {
-          credentialContext: {
-            actor: { type: "user", userId: requester.userId },
+          input: {
+            conversationContext: lockedConversationContext,
+            piMessages: lockedConversation.piMessages,
+            ...getTurnUserReplyAttachmentContext(lockedUserMessage),
           },
-          requester,
-          destination,
-          source: lockedSessionRecord.source,
-          correlation: {
-            conversationId: authSession.conversationId,
-            turnId: lockedSessionId,
-            channelId: authSession.channelId,
-            threadTs: authSession.threadTs,
-            requesterId: requester.userId,
-          },
-          toolChannelId:
-            authSession.toolChannelId ??
-            lockedArtifacts.assistantContextChannelId ??
-            authSession.channelId,
-          conversationContext: lockedConversationContext,
-          artifactState: lockedArtifacts,
-          piMessages: lockedConversation.piMessages,
-          configuration: authSession.configuration,
-          pendingAuth: lockedPendingAuth,
-          channelConfiguration: lockedChannelConfiguration,
-          sandbox: getPersistedSandboxState(lockedState),
-          recordPendingAuth: async (nextPendingAuth) => {
-            await applyPendingAuthUpdate({
-              conversation: lockedConversation,
+          routing: {
+            credentialContext: {
+              actor: { type: "user", userId: requester.userId },
+            },
+            requester,
+            destination,
+            source: lockedSessionRecord.source,
+            correlation: {
               conversationId: authSession.conversationId,
-              nextPendingAuth,
-            });
-            await persistThreadStateById(threadId, {
-              conversation: lockedConversation,
-            });
+              turnId: lockedSessionId,
+              channelId: authSession.channelId,
+              threadTs: authSession.threadTs,
+              requesterId: requester.userId,
+            },
+            toolChannelId:
+              authSession.toolChannelId ??
+              lockedArtifacts.assistantContextChannelId ??
+              authSession.channelId,
           },
-          ...getTurnUserReplyAttachmentContext(lockedUserMessage),
+          policy: {
+            configuration: authSession.configuration,
+            channelConfiguration: lockedChannelConfiguration,
+            sandbox: getPersistedSandboxState(lockedState),
+          },
+          state: {
+            artifactState: lockedArtifacts,
+            pendingAuth: lockedPendingAuth,
+          },
+          durability: {
+            recordPendingAuth: async (nextPendingAuth) => {
+              await applyPendingAuthUpdate({
+                conversation: lockedConversation,
+                conversationId: authSession.conversationId,
+                nextPendingAuth,
+              });
+              await persistThreadStateById(threadId, {
+                conversation: lockedConversation,
+              });
+            },
+          },
         },
         onSuccess: async (reply: AssistantReply) => {
           await persistCompletedReplyState(

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -14,7 +14,7 @@ import {
 } from "@/chat/mcp/auth-store";
 import { finalizeMcpAuthorization } from "@/chat/mcp/oauth";
 import { logException, logWarn } from "@/chat/logging";
-import type { AssistantReply } from "@/chat/respond";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import {
   getChannelConfigurationServiceById,
@@ -106,7 +106,7 @@ async function persistCompletedReplyState(
   channelId: string,
   threadTs: string,
   sessionId: string,
-  reply: AssistantReply,
+  reply: AgentRunResult,
 ): Promise<void> {
   const threadId = `slack:${channelId}:${threadTs}`;
   const currentState = await getPersistedThreadState(threadId);
@@ -395,7 +395,7 @@ async function resumeAuthorizedMcpTurn(args: {
             },
           },
         },
-        onSuccess: async (reply: AssistantReply) => {
+        onSuccess: async (reply: AgentRunResult) => {
           await persistCompletedReplyState(
             authSession.channelId!,
             authSession.threadTs!,

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -14,7 +14,8 @@ import {
 } from "@/chat/mcp/auth-store";
 import { finalizeMcpAuthorization } from "@/chat/mcp/oauth";
 import { logException, logWarn } from "@/chat/logging";
-import type { AssistantReply, generateAssistantReply } from "@/chat/respond";
+import type { AssistantReply } from "@/chat/respond";
+import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import {
   getChannelConfigurationServiceById,
   getPersistedSandboxState,
@@ -86,7 +87,7 @@ const CALLBACK_PAGES = {
 } as const;
 
 interface McpOAuthCallbackOptions {
-  generateReply?: typeof generateAssistantReply;
+  agentRunner: AgentRunner;
 }
 
 function mcpAuthorizationId(args: {
@@ -185,10 +186,10 @@ async function persistFailedReplyState(
 
 async function resumeAuthorizedMcpTurn(args: {
   authSession: McpAuthSessionState;
-  generateReply?: typeof generateAssistantReply;
+  agentRunner: AgentRunner;
   provider: string;
 }): Promise<void> {
-  const { authSession, generateReply, provider } = args;
+  const { authSession, agentRunner, provider } = args;
   if (
     !authSession.channelId ||
     !authSession.destination ||
@@ -238,7 +239,7 @@ async function resumeAuthorizedMcpTurn(args: {
     messageTs: getTurnUserSlackMessageTs(userMessage),
     lockKey: threadId,
     connectedText: "",
-    generateReply,
+    agentRunner,
     beforeStart: async () => {
       const lockedState = await getPersistedThreadState(threadId);
       const lockedConversation = coerceThreadConversationState(lockedState);
@@ -462,7 +463,7 @@ export async function GET(
   request: Request,
   provider: string,
   waitUntil: WaitUntilFn,
-  options: McpOAuthCallbackOptions = {},
+  options: McpOAuthCallbackOptions,
 ): Promise<Response> {
   const url = new URL(request.url);
   const state = url.searchParams.get("state")?.trim();
@@ -496,7 +497,7 @@ export async function GET(
     waitUntil(() =>
       resumeAuthorizedMcpTurn({
         authSession,
-        generateReply: options.generateReply,
+        agentRunner: options.agentRunner,
         provider,
       }),
     );

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -62,7 +62,7 @@ import {
 import { escapeXml } from "@/chat/xml";
 import type { WaitUntilFn } from "@/handlers/types";
 import { scheduleAgentContinue } from "@/chat/services/agent-continue";
-import type { AssistantReply } from "@/chat/respond";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { requireSlackDestination } from "@/chat/destination";
 
@@ -88,7 +88,7 @@ function htmlErrorResponse(
 async function persistCompletedOAuthReplyState(args: {
   conversationId: string;
   sessionId: string;
-  reply: AssistantReply;
+  reply: AgentRunResult;
 }): Promise<void> {
   const currentState = await getPersistedThreadState(args.conversationId);
   const conversation = coerceThreadConversationState(currentState);
@@ -423,7 +423,7 @@ async function resumeOAuthSessionRecordTurn(
             },
           },
         },
-        onSuccess: async (reply: AssistantReply) => {
+        onSuccess: async (reply: AgentRunResult) => {
           logInfo(
             "oauth_callback_resume_complete",
             {},

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -377,41 +377,51 @@ async function resumeOAuthSessionRecordTurn(
           : (stored.pendingMessage ?? lockedUserMessage.text),
         messageTs: lockedMessageTs,
         replyContext: {
-          credentialContext: {
-            actor: {
-              type: "user",
-              userId: requester.userId,
+          input: {
+            conversationContext: lockedConversationContext,
+            piMessages: lockedConversation.piMessages,
+            ...getTurnUserReplyAttachmentContext(lockedUserMessage),
+          },
+          routing: {
+            credentialContext: {
+              actor: {
+                type: "user",
+                userId: requester.userId,
+              },
+            },
+            requester,
+            destination,
+            source: lockedSessionRecord.source,
+            correlation: {
+              conversationId: stored.resumeConversationId!,
+              turnId: lockedSessionId,
+              channelId: stored.channelId!,
+              threadTs: stored.threadTs!,
+              requesterId: requester.userId,
+            },
+            toolChannelId:
+              lockedArtifacts.assistantContextChannelId ?? stored.channelId!,
+          },
+          policy: {
+            channelConfiguration: lockedChannelConfiguration,
+            sandbox: getPersistedSandboxState(lockedState),
+          },
+          state: {
+            artifactState: lockedArtifacts,
+            pendingAuth: lockedPendingAuth,
+          },
+          durability: {
+            recordPendingAuth: async (nextPendingAuth) => {
+              await applyPendingAuthUpdate({
+                conversation: lockedConversation,
+                conversationId: stored.resumeConversationId!,
+                nextPendingAuth,
+              });
+              await persistThreadStateById(stored.resumeConversationId!, {
+                conversation: lockedConversation,
+              });
             },
           },
-          requester,
-          destination,
-          source: lockedSessionRecord.source,
-          correlation: {
-            conversationId: stored.resumeConversationId!,
-            turnId: lockedSessionId,
-            channelId: stored.channelId!,
-            threadTs: stored.threadTs!,
-            requesterId: requester.userId,
-          },
-          toolChannelId:
-            lockedArtifacts.assistantContextChannelId ?? stored.channelId!,
-          artifactState: lockedArtifacts,
-          pendingAuth: lockedPendingAuth,
-          conversationContext: lockedConversationContext,
-          channelConfiguration: lockedChannelConfiguration,
-          piMessages: lockedConversation.piMessages,
-          sandbox: getPersistedSandboxState(lockedState),
-          recordPendingAuth: async (nextPendingAuth) => {
-            await applyPendingAuthUpdate({
-              conversation: lockedConversation,
-              conversationId: stored.resumeConversationId!,
-              nextPendingAuth,
-            });
-            await persistThreadStateById(stored.resumeConversationId!, {
-              conversation: lockedConversation,
-            });
-          },
-          ...getTurnUserReplyAttachmentContext(lockedUserMessage),
         },
         onSuccess: async (reply: AssistantReply) => {
           logInfo(
@@ -518,21 +528,27 @@ async function resumePendingOAuthMessage(
     connectedText: "",
     agentRunner: options.agentRunner,
     replyContext: {
-      credentialContext: {
-        actor: { type: "user", userId: stored.userId },
+      input: {
+        conversationContext,
+        piMessages: conversation.piMessages,
       },
-      requester,
-      destination: stored.destination,
-      source,
-      correlation: {
-        conversationId: threadId,
-        channelId: stored.channelId,
-        threadTs: stored.threadTs,
-        requesterId: stored.userId,
+      routing: {
+        credentialContext: {
+          actor: { type: "user", userId: stored.userId },
+        },
+        requester,
+        destination: stored.destination,
+        source,
+        correlation: {
+          conversationId: threadId,
+          channelId: stored.channelId,
+          threadTs: stored.threadTs,
+          requesterId: stored.userId,
+        },
       },
-      conversationContext,
-      piMessages: conversation.piMessages,
-      configuration: stored.configuration,
+      policy: {
+        configuration: stored.configuration,
+      },
     },
     onSuccess: async (reply) => {
       logInfo(

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -62,11 +62,12 @@ import {
 import { escapeXml } from "@/chat/xml";
 import type { WaitUntilFn } from "@/handlers/types";
 import { scheduleAgentContinue } from "@/chat/services/agent-continue";
-import type { AssistantReply, generateAssistantReply } from "@/chat/respond";
+import type { AssistantReply } from "@/chat/respond";
+import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { requireSlackDestination } from "@/chat/destination";
 
 interface OAuthCallbackOptions {
-  generateReply?: typeof generateAssistantReply;
+  agentRunner: AgentRunner;
 }
 
 /**
@@ -261,7 +262,7 @@ async function resumeOAuthSessionRecordTurn(
     messageTs: getTurnUserSlackMessageTs(userMessage),
     lockKey: stored.resumeConversationId,
     initialText: "",
-    generateReply: options.generateReply,
+    agentRunner: options.agentRunner,
     beforeStart: async () => {
       const lockedState = await getPersistedThreadState(
         stored.resumeConversationId!,
@@ -515,7 +516,7 @@ async function resumePendingOAuthMessage(
     threadTs: stored.threadTs,
     messageTs,
     connectedText: "",
-    generateReply: options.generateReply,
+    agentRunner: options.agentRunner,
     replyContext: {
       credentialContext: {
         actor: { type: "user", userId: stored.userId },
@@ -552,7 +553,7 @@ export async function GET(
   request: Request,
   provider: string,
   waitUntil: WaitUntilFn,
-  options: OAuthCallbackOptions = {},
+  options: OAuthCallbackOptions,
 ): Promise<Response> {
   const providerConfig = pluginCatalogRuntime.getOAuthConfig(provider);
   if (!providerConfig) {

--- a/packages/junior/tests/component/runtime/agent-continue-runner.test.ts
+++ b/packages/junior/tests/component/runtime/agent-continue-runner.test.ts
@@ -6,6 +6,7 @@ import {
   getAgentTurnSessionRecord,
   upsertAgentTurnSessionRecord,
 } from "@/chat/state/turn-session";
+import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { SLACK_DESTINATION } from "../../fixtures/conversation-work";
 
 const SLACK_SOURCE = createSlackSource({
@@ -30,6 +31,12 @@ function restoreEnv(name: string, value: string | undefined): void {
   }
   process.env[name] = value;
 }
+
+const agentRunnerShouldNotRun: AgentRunner = {
+  run: async () => {
+    throw new Error("agent runner should not run in this test");
+  },
+};
 
 describe("agent continuation runner callbacks", () => {
   beforeEach(async () => {
@@ -117,6 +124,7 @@ describe("agent continuation runner callbacks", () => {
           expectedVersion: sessionRecord.version,
         },
         {
+          agentRunner: agentRunnerShouldNotRun,
           resumeTurn: async (args) => {
             const prepared = await args.beforeStart?.();
             if (!prepared) {
@@ -219,6 +227,7 @@ describe("agent continuation runner callbacks", () => {
           expectedVersion: sessionRecord.version,
         },
         {
+          agentRunner: agentRunnerShouldNotRun,
           resumeTurn: async (args) => {
             const prepared = await args.beforeStart?.();
             if (prepared !== false) {
@@ -308,6 +317,7 @@ describe("agent continuation runner callbacks", () => {
           expectedVersion: sessionRecord.version,
         },
         {
+          agentRunner: agentRunnerShouldNotRun,
           resumeTurn: async (args) => {
             const prepared = await args.beforeStart?.();
             if (prepared !== false) {

--- a/packages/junior/tests/component/runtime/agent-continue-runner.test.ts
+++ b/packages/junior/tests/component/runtime/agent-continue-runner.test.ts
@@ -133,7 +133,7 @@ describe("agent continuation runner callbacks", () => {
             if (!prepared.replyContext) {
               throw new Error("Expected prepared continuation reply context");
             }
-            expect(prepared.replyContext.requester).toEqual({
+            expect(prepared.replyContext.routing.requester).toEqual({
               email: "stored@example.com",
               fullName: "Stored User",
               platform: "slack",

--- a/packages/junior/tests/component/runtime/agent-continue.test.ts
+++ b/packages/junior/tests/component/runtime/agent-continue.test.ts
@@ -11,6 +11,7 @@ import {
   SLACK_DESTINATION,
   createConversationWorkQueueTestAdapter,
 } from "../../fixtures/conversation-work";
+import type { AgentRunner } from "@/chat/runtime/agent-runner";
 
 const ORIGINAL_ENV = vi.hoisted(() => {
   const original = {
@@ -27,6 +28,12 @@ function restoreEnv(name: string, value: string | undefined): void {
   }
   process.env[name] = value;
 }
+
+const agentRunnerShouldNotRun: AgentRunner = {
+  run: async () => {
+    throw new Error("agent runner should not run in this test");
+  },
+};
 
 describe("agent continuation scheduling", () => {
   beforeEach(async () => {
@@ -125,7 +132,7 @@ describe("agent continuation scheduling", () => {
         sessionId: "turn_msg_2",
         expectedVersion: 1,
       },
-      { scheduleAgentContinue },
+      { agentRunner: agentRunnerShouldNotRun, scheduleAgentContinue },
     );
 
     await vi.advanceTimersByTimeAsync(4_000);
@@ -156,9 +163,11 @@ describe("agent continuation scheduling", () => {
       piMessages: [],
     });
 
-    await expect(resumeAwaitingSlackContinuation(conversationId)).resolves.toBe(
-      false,
-    );
+    await expect(
+      resumeAwaitingSlackContinuation(conversationId, {
+        agentRunner: agentRunnerShouldNotRun,
+      }),
+    ).resolves.toBe(false);
     await expect(
       getAgentTurnSessionRecord(conversationId, "turn_msg_3"),
     ).resolves.toMatchObject({
@@ -187,13 +196,13 @@ describe("agent continuation scheduling", () => {
 
     await expect(
       resumeAwaitingSlackContinuation(conversationId, {
-        generateReply,
+        agentRunner: { run: generateReply },
         resumeTurn,
       }),
     ).resolves.toBe(true);
 
     expect(resumeTurn).toHaveBeenCalledWith(
-      expect.objectContaining({ generateReply }),
+      expect.objectContaining({ agentRunner: { run: generateReply } }),
     );
   });
 
@@ -253,9 +262,11 @@ describe("agent continuation scheduling", () => {
       },
     });
 
-    await expect(resumeAwaitingSlackContinuation(conversationId)).resolves.toBe(
-      false,
-    );
+    await expect(
+      resumeAwaitingSlackContinuation(conversationId, {
+        agentRunner: agentRunnerShouldNotRun,
+      }),
+    ).resolves.toBe(false);
     await expect(
       getAgentTurnSessionRecord(conversationId, sessionId),
     ).resolves.toMatchObject({

--- a/packages/junior/tests/component/runtime/agent-run-error-path.test.ts
+++ b/packages/junior/tests/component/runtime/agent-run-error-path.test.ts
@@ -16,11 +16,11 @@ vi.mock("@/chat/skills", () => ({
   parseSkillInvocation: vi.fn(),
 }));
 
-const { generateAssistantReply } = await import("@/chat/respond");
+const { executeAgentRun } = await import("@/chat/agent-run");
 
 const LOCAL_DESTINATION = {
   platform: "local" as const,
-  conversationId: "local:test:respond-error-path",
+  conversationId: "local:test:agent-run-error-path",
 };
 const LOCAL_SOURCE = createLocalSource(LOCAL_DESTINATION.conversationId);
 const SLACK_DESTINATION = {
@@ -34,7 +34,7 @@ const SLACK_SOURCE = createSlackSource({
   type: "priv",
 });
 
-describe("generateAssistantReply error path", () => {
+describe("executeAgentRun error path", () => {
   afterAll(() => {
     if (originalAiModel === undefined) {
       delete process.env.AI_MODEL;
@@ -44,7 +44,7 @@ describe("generateAssistantReply error path", () => {
   });
 
   it("preserves sandbox dependency hash on non-retryable failures", async () => {
-    const outcome = await generateAssistantReply({
+    const outcome = await executeAgentRun({
       input: { messageText: "hello" },
       routing: { destination: LOCAL_DESTINATION, source: LOCAL_SOURCE },
       policy: {
@@ -55,7 +55,7 @@ describe("generateAssistantReply error path", () => {
       },
     });
     expect(outcome.status).toBe("failed");
-    const reply = outcome.status === "failed" ? outcome.reply : undefined;
+    const reply = outcome.status === "failed" ? outcome.result : undefined;
     expect(reply).toBeDefined();
 
     // Raw exception text stays in diagnostics; it is never reply text.
@@ -71,7 +71,7 @@ describe("generateAssistantReply error path", () => {
 
   it("propagates pre-commit failures when durable input commit is required", async () => {
     await expect(
-      generateAssistantReply({
+      executeAgentRun({
         input: { messageText: "hello" },
         routing: { destination: LOCAL_DESTINATION, source: LOCAL_SOURCE },
         durability: {
@@ -85,16 +85,16 @@ describe("generateAssistantReply error path", () => {
 
   it("hard-fails missing destinations", async () => {
     await expect(
-      generateAssistantReply({
+      executeAgentRun({
         input: { messageText: "hello" },
-        routing: {} as Parameters<typeof generateAssistantReply>[0]["routing"],
+        routing: {} as Parameters<typeof executeAgentRun>[0]["routing"],
       }),
     ).rejects.toThrow("Assistant reply generation requires a destination");
   });
 
   it("hard-fails requester and destination platform mismatches", async () => {
     await expect(
-      generateAssistantReply({
+      executeAgentRun({
         input: { messageText: "hello" },
         routing: {
           destination: LOCAL_DESTINATION,
@@ -113,7 +113,7 @@ describe("generateAssistantReply error path", () => {
 
   it("hard-fails Slack correlation and destination mismatches", async () => {
     await expect(
-      generateAssistantReply({
+      executeAgentRun({
         input: { messageText: "hello" },
         routing: {
           destination: SLACK_DESTINATION,

--- a/packages/junior/tests/component/runtime/respond-error-path.test.ts
+++ b/packages/junior/tests/component/runtime/respond-error-path.test.ts
@@ -44,7 +44,7 @@ describe("generateAssistantReply error path", () => {
   });
 
   it("preserves sandbox dependency hash on non-retryable failures", async () => {
-    const reply = await generateAssistantReply("hello", {
+    const outcome = await generateAssistantReply("hello", {
       destination: LOCAL_DESTINATION,
       source: LOCAL_SOURCE,
       sandbox: {
@@ -52,16 +52,19 @@ describe("generateAssistantReply error path", () => {
         sandboxDependencyProfileHash: "hash-abc",
       },
     });
+    expect(outcome.status).toBe("failed");
+    const reply = outcome.status === "failed" ? outcome.reply : undefined;
+    expect(reply).toBeDefined();
 
     // Raw exception text stays in diagnostics; it is never reply text.
-    expect(reply.text).toBe("");
-    expect(reply.diagnostics.errorMessage).toBe("discover failed");
-    expect(reply.diagnostics.assistantMessageCount).toBe(0);
-    expect(reply.sandboxId).toBe("sb-123");
-    expect(reply.sandboxDependencyProfileHash).toBe("hash-abc");
-    expect(reply.diagnostics.outcome).toBe("provider_error");
-    expect(reply.diagnostics.modelId).toBe("openai/gpt-5.4");
-    expect(reply.diagnostics.thinkingLevel).toBeUndefined();
+    expect(reply!.text).toBe("");
+    expect(reply!.diagnostics.errorMessage).toBe("discover failed");
+    expect(reply!.diagnostics.assistantMessageCount).toBe(0);
+    expect(reply!.sandboxId).toBe("sb-123");
+    expect(reply!.sandboxDependencyProfileHash).toBe("hash-abc");
+    expect(reply!.diagnostics.outcome).toBe("provider_error");
+    expect(reply!.diagnostics.modelId).toBe("openai/gpt-5.4");
+    expect(reply!.diagnostics.thinkingLevel).toBeUndefined();
   });
 
   it("propagates pre-commit failures when durable input commit is required", async () => {

--- a/packages/junior/tests/component/runtime/respond-error-path.test.ts
+++ b/packages/junior/tests/component/runtime/respond-error-path.test.ts
@@ -44,12 +44,14 @@ describe("generateAssistantReply error path", () => {
   });
 
   it("preserves sandbox dependency hash on non-retryable failures", async () => {
-    const outcome = await generateAssistantReply("hello", {
-      destination: LOCAL_DESTINATION,
-      source: LOCAL_SOURCE,
-      sandbox: {
-        sandboxId: "sb-123",
-        sandboxDependencyProfileHash: "hash-abc",
+    const outcome = await generateAssistantReply({
+      input: { messageText: "hello" },
+      routing: { destination: LOCAL_DESTINATION, source: LOCAL_SOURCE },
+      policy: {
+        sandbox: {
+          sandboxId: "sb-123",
+          sandboxDependencyProfileHash: "hash-abc",
+        },
       },
     });
     expect(outcome.status).toBe("failed");
@@ -69,11 +71,13 @@ describe("generateAssistantReply error path", () => {
 
   it("propagates pre-commit failures when durable input commit is required", async () => {
     await expect(
-      generateAssistantReply("hello", {
-        destination: LOCAL_DESTINATION,
-        source: LOCAL_SOURCE,
-        onInputCommitted: async () => {
-          throw new Error("input should not commit before startup succeeds");
+      generateAssistantReply({
+        input: { messageText: "hello" },
+        routing: { destination: LOCAL_DESTINATION, source: LOCAL_SOURCE },
+        durability: {
+          onInputCommitted: async () => {
+            throw new Error("input should not commit before startup succeeds");
+          },
         },
       }),
     ).rejects.toThrow("discover failed");
@@ -81,22 +85,25 @@ describe("generateAssistantReply error path", () => {
 
   it("hard-fails missing destinations", async () => {
     await expect(
-      generateAssistantReply(
-        "hello",
-        {} as Parameters<typeof generateAssistantReply>[1],
-      ),
+      generateAssistantReply({
+        input: { messageText: "hello" },
+        routing: {} as Parameters<typeof generateAssistantReply>[0]["routing"],
+      }),
     ).rejects.toThrow("Assistant reply generation requires a destination");
   });
 
   it("hard-fails requester and destination platform mismatches", async () => {
     await expect(
-      generateAssistantReply("hello", {
-        destination: LOCAL_DESTINATION,
-        source: LOCAL_SOURCE,
-        requester: {
-          platform: "slack",
-          teamId: "T123",
-          userId: "U123",
+      generateAssistantReply({
+        input: { messageText: "hello" },
+        routing: {
+          destination: LOCAL_DESTINATION,
+          source: LOCAL_SOURCE,
+          requester: {
+            platform: "slack",
+            teamId: "T123",
+            userId: "U123",
+          },
         },
       }),
     ).rejects.toThrow(
@@ -106,12 +113,15 @@ describe("generateAssistantReply error path", () => {
 
   it("hard-fails Slack correlation and destination mismatches", async () => {
     await expect(
-      generateAssistantReply("hello", {
-        destination: SLACK_DESTINATION,
-        source: SLACK_SOURCE,
-        correlation: {
-          channelId: "C999",
-          teamId: "T123",
+      generateAssistantReply({
+        input: { messageText: "hello" },
+        routing: {
+          destination: SLACK_DESTINATION,
+          source: SLACK_SOURCE,
+          correlation: {
+            channelId: "C999",
+            teamId: "T123",
+          },
         },
       }),
     ).rejects.toThrow(

--- a/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
@@ -1607,7 +1607,17 @@ describe("Slack conversation work execution", () => {
       services: {
         replyExecutor: {
           agentRunner: {
-            run: async (_text, context) => {
+            run: async (request) => {
+              const _text = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               await context?.onInputCommitted?.();
               await context?.onArtifactStateUpdated?.({
                 lastCanvasId: "F_YIELD_CANVAS",

--- a/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
@@ -26,12 +26,16 @@ import {
 } from "@/chat/task-execution/slack-work";
 import { getMessageActorIdentity } from "@/chat/services/message-actor-identity";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
+import { coerceThreadConversationState } from "@/chat/state/conversation";
 import {
   failAgentTurnSessionRecord,
   getAgentTurnSessionRecord,
   upsertAgentTurnSessionRecord,
 } from "@/chat/state/turn-session";
-import { persistThreadStateById } from "@/chat/runtime/thread-state";
+import {
+  getPersistedThreadState,
+  persistThreadStateById,
+} from "@/chat/runtime/thread-state";
 import { createTestChatRuntime } from "../../fixtures/chat-runtime";
 import {
   getCapturedSlackApiCalls,
@@ -1588,5 +1592,92 @@ describe("Slack conversation work execution", () => {
         "slack:T123:slack:C123:1712345.0001:1712345.0001",
       ]),
     );
+  });
+
+  it("keeps yielded executor outcomes resumable without failure recovery", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    const state = getStateAdapter();
+    await state.connect();
+    const slackAdapter = createSlackAdapterFixture();
+    let currentNowMs = 1_000;
+    let yieldedSessionId: string | undefined;
+    const { slackRuntime } = createTestChatRuntime({
+      services: {
+        replyExecutor: {
+          generateAssistantReply: async (_text, context) => {
+            await context?.onInputCommitted?.();
+            await context?.onArtifactStateUpdated?.({
+              lastCanvasId: "F_YIELD_CANVAS",
+              lastCanvasUrl: "https://slack.example/docs/T/F_YIELD_CANVAS",
+              recentCanvases: [
+                {
+                  id: "F_YIELD_CANVAS",
+                  title: "Yielded canvas",
+                  url: "https://slack.example/docs/T/F_YIELD_CANVAS",
+                  createdAt: "2026-07-02T12:00:00.000Z",
+                },
+              ],
+            });
+            currentNowMs = 242_000;
+            yieldedSessionId = context?.correlation?.turnId;
+            return {
+              status: "yielded",
+              conversationId:
+                context?.correlation?.conversationId ?? CONVERSATION_ID,
+              sessionId: yieldedSessionId ?? "missing-session",
+              sliceId: 1,
+              version: 1,
+            };
+          },
+        },
+      },
+    });
+
+    await handleSlackWebhookAndFlush({
+      request: slackWebhookRequest(
+        slackEnvelope({
+          text: `<@${SLACK_BOT_USER_ID}> create the canvas and continue later`,
+        }),
+      ),
+      services: {
+        getSlackAdapter: () => slackAdapter,
+        queue,
+        runtime: createNoopSlackWebhookRuntime(),
+        state,
+      },
+    });
+    queue.clearSentRecords();
+
+    await expect(
+      processNextQueuedSlackWork({
+        getSlackAdapter: () => slackAdapter,
+        nowMs: () => currentNowMs,
+        queue,
+        runtime: slackRuntime,
+        state,
+      }),
+    ).resolves.toEqual({ status: "yielded" });
+
+    expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([]);
+    expect(queue.sentRecords()).toMatchObject([
+      {
+        conversationId: CONVERSATION_ID,
+        idempotencyKey: `yield:${CONVERSATION_ID}:242000`,
+      },
+    ]);
+    const work = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+      state,
+    });
+    expect(work?.needsRun).toBe(true);
+    expect(work?.messages).toEqual([]);
+    const persistedState = await getPersistedThreadState(CONVERSATION_ID);
+    const conversation = coerceThreadConversationState(persistedState);
+    expect(conversation.processing.activeTurnId).toBe(yieldedSessionId);
+    const sessionRecord = await getAgentTurnSessionRecord(
+      CONVERSATION_ID,
+      yieldedSessionId ?? "",
+    );
+    expect(sessionRecord?.state).not.toBe("failed");
   });
 });

--- a/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
@@ -1307,8 +1307,10 @@ describe("Slack conversation work execution", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => {
-            throw new Error("persistent queued failure");
+          agentRunner: {
+            run: async () => {
+              throw new Error("persistent queued failure");
+            },
           },
         },
       },
@@ -1604,30 +1606,32 @@ describe("Slack conversation work execution", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async (_text, context) => {
-            await context?.onInputCommitted?.();
-            await context?.onArtifactStateUpdated?.({
-              lastCanvasId: "F_YIELD_CANVAS",
-              lastCanvasUrl: "https://slack.example/docs/T/F_YIELD_CANVAS",
-              recentCanvases: [
-                {
-                  id: "F_YIELD_CANVAS",
-                  title: "Yielded canvas",
-                  url: "https://slack.example/docs/T/F_YIELD_CANVAS",
-                  createdAt: "2026-07-02T12:00:00.000Z",
-                },
-              ],
-            });
-            currentNowMs = 242_000;
-            yieldedSessionId = context?.correlation?.turnId;
-            return {
-              status: "yielded",
-              conversationId:
-                context?.correlation?.conversationId ?? CONVERSATION_ID,
-              sessionId: yieldedSessionId ?? "missing-session",
-              sliceId: 1,
-              version: 1,
-            };
+          agentRunner: {
+            run: async (_text, context) => {
+              await context?.onInputCommitted?.();
+              await context?.onArtifactStateUpdated?.({
+                lastCanvasId: "F_YIELD_CANVAS",
+                lastCanvasUrl: "https://slack.example/docs/T/F_YIELD_CANVAS",
+                recentCanvases: [
+                  {
+                    id: "F_YIELD_CANVAS",
+                    title: "Yielded canvas",
+                    url: "https://slack.example/docs/T/F_YIELD_CANVAS",
+                    createdAt: "2026-07-02T12:00:00.000Z",
+                  },
+                ],
+              });
+              currentNowMs = 242_000;
+              yieldedSessionId = context?.correlation?.turnId;
+              return {
+                status: "yielded",
+                conversationId:
+                  context?.correlation?.conversationId ?? CONVERSATION_ID,
+                sessionId: yieldedSessionId ?? "missing-session",
+                sliceId: 1,
+                version: 1,
+              };
+            },
           },
         },
       },

--- a/packages/junior/tests/fixtures/mcp-oauth-callback-harness.ts
+++ b/packages/junior/tests/fixtures/mcp-oauth-callback-harness.ts
@@ -17,6 +17,14 @@ export async function runMcpOauthCallbackRoute(args: {
     ),
     args.provider,
     testWaitUntil,
+    {
+      agentRunner: {
+        run: async (messageText, context) => {
+          const { generateAssistantReply } = await import("@/chat/respond");
+          return await generateAssistantReply(messageText, context);
+        },
+      },
+    },
   );
   const callbacks = waitUntilCallbacks.splice(0, waitUntilCallbacks.length);
   for (const callback of callbacks) {

--- a/packages/junior/tests/fixtures/mcp-oauth-callback-harness.ts
+++ b/packages/junior/tests/fixtures/mcp-oauth-callback-harness.ts
@@ -20,8 +20,8 @@ export async function runMcpOauthCallbackRoute(args: {
     {
       agentRunner: {
         run: async (request) => {
-          const { generateAssistantReply } = await import("@/chat/respond");
-          return await generateAssistantReply(request);
+          const { executeAgentRun } = await import("@/chat/agent-run");
+          return await executeAgentRun(request);
         },
       },
     },

--- a/packages/junior/tests/fixtures/mcp-oauth-callback-harness.ts
+++ b/packages/junior/tests/fixtures/mcp-oauth-callback-harness.ts
@@ -19,9 +19,9 @@ export async function runMcpOauthCallbackRoute(args: {
     testWaitUntil,
     {
       agentRunner: {
-        run: async (messageText, context) => {
+        run: async (request) => {
           const { generateAssistantReply } = await import("@/chat/respond");
-          return await generateAssistantReply(messageText, context);
+          return await generateAssistantReply(request);
         },
       },
     },

--- a/packages/junior/tests/fixtures/oauth-callback-harness.ts
+++ b/packages/junior/tests/fixtures/oauth-callback-harness.ts
@@ -19,9 +19,9 @@ export async function runOauthCallbackRoute(args: {
     testWaitUntil,
     {
       agentRunner: {
-        run: async (messageText, context) => {
+        run: async (request) => {
           const { generateAssistantReply } = await import("@/chat/respond");
-          return await generateAssistantReply(messageText, context);
+          return await generateAssistantReply(request);
         },
       },
     },

--- a/packages/junior/tests/fixtures/oauth-callback-harness.ts
+++ b/packages/junior/tests/fixtures/oauth-callback-harness.ts
@@ -20,8 +20,8 @@ export async function runOauthCallbackRoute(args: {
     {
       agentRunner: {
         run: async (request) => {
-          const { generateAssistantReply } = await import("@/chat/respond");
-          return await generateAssistantReply(request);
+          const { executeAgentRun } = await import("@/chat/agent-run");
+          return await executeAgentRun(request);
         },
       },
     },

--- a/packages/junior/tests/fixtures/oauth-callback-harness.ts
+++ b/packages/junior/tests/fixtures/oauth-callback-harness.ts
@@ -17,6 +17,14 @@ export async function runOauthCallbackRoute(args: {
     ),
     args.provider,
     testWaitUntil,
+    {
+      agentRunner: {
+        run: async (messageText, context) => {
+          const { generateAssistantReply } = await import("@/chat/respond");
+          return await generateAssistantReply(messageText, context);
+        },
+      },
+    },
   );
   const callbacks = waitUntilCallbacks.splice(0, waitUntilCallbacks.length);
   for (const callback of callbacks) {

--- a/packages/junior/tests/integration/agent-continue-slack.test.ts
+++ b/packages/junior/tests/integration/agent-continue-slack.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../fixtures/conversation-work";
 import { slackApiOutbox } from "../fixtures/slack-api-outbox";
 import { resetSlackApiMockState } from "../msw/handlers/slack-api";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const generateAssistantReplyMock = vi.fn();
 
@@ -21,6 +22,18 @@ function slackSource(threadTs: string) {
 
     type: "priv",
   });
+}
+
+function makeDiagnostics() {
+  return {
+    assistantMessageCount: 1,
+    modelId: "fake-agent-model",
+    outcome: "success" as const,
+    toolCalls: [],
+    toolErrorCount: 0,
+    toolResultCount: 0,
+    usedPrimaryText: true,
+  };
 }
 
 type StateAdapterModule = typeof import("@/chat/state/adapter");
@@ -70,13 +83,12 @@ describe("agent continuation Slack integration", () => {
   beforeEach(async () => {
     queue = createConversationWorkQueueTestAdapter();
     generateAssistantReplyMock.mockReset();
-    generateAssistantReplyMock.mockResolvedValue({
-      text: "Final resumed answer",
-      diagnostics: {
-        outcome: "success",
-        toolCalls: [],
-      },
-    });
+    generateAssistantReplyMock.mockResolvedValue(
+      completedAgentRun({
+        text: "Final resumed answer",
+        diagnostics: makeDiagnostics(),
+      }),
+    );
     resetSlackApiMockState();
     process.env = {
       ...ORIGINAL_ENV,
@@ -839,25 +851,24 @@ describe("agent continuation Slack integration", () => {
     // exactly one visible reply and only then a delivered/completed session.
     const conversationId = "slack:C123:1712345.0008";
     const sessionId = "turn_msg_8";
-    generateAssistantReplyMock.mockResolvedValueOnce({
-      text: "Final resumed answer",
-      piMessages: [
-        {
-          role: "user",
-          content: [{ type: "text", text: "hello" }],
-          timestamp: 1,
-        },
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "Final resumed answer" }],
-          timestamp: 2,
-        },
-      ],
-      diagnostics: {
-        outcome: "success",
-        toolCalls: [],
-      },
-    });
+    generateAssistantReplyMock.mockResolvedValueOnce(
+      completedAgentRun({
+        text: "Final resumed answer",
+        piMessages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "hello" }],
+            timestamp: 1,
+          },
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "Final resumed answer" }],
+            timestamp: 2,
+          },
+        ] as any,
+        diagnostics: makeDiagnostics(),
+      }),
+    );
     await turnSessionStoreModule.upsertAgentTurnSessionRecord({
       conversationId,
       sessionId,
@@ -1095,19 +1106,18 @@ describe("agent continuation Slack integration", () => {
         },
       });
 
-    generateAssistantReplyMock.mockResolvedValueOnce({
-      text: "Final resumed answer with artifact",
-      files: [
-        {
-          data: Buffer.from("resume-file"),
-          filename: "resume.txt",
-        },
-      ],
-      diagnostics: {
-        outcome: "success",
-        toolCalls: [],
-      },
-    });
+    generateAssistantReplyMock.mockResolvedValueOnce(
+      completedAgentRun({
+        text: "Final resumed answer with artifact",
+        files: [
+          {
+            data: Buffer.from("resume-file"),
+            filename: "resume.txt",
+          },
+        ],
+        diagnostics: makeDiagnostics(),
+      }),
+    );
 
     await threadStateModule.persistThreadStateById(conversationId, {
       artifacts: {

--- a/packages/junior/tests/integration/agent-continue-slack.test.ts
+++ b/packages/junior/tests/integration/agent-continue-slack.test.ts
@@ -69,7 +69,7 @@ function continueAgentRun(args: {
         sessionId: args.sessionId,
       },
       {
-        generateReply: generateAssistantReplyMock,
+        agentRunner: { run: generateAssistantReplyMock },
         scheduleAgentContinue: (request) =>
           agentContinueServiceModule.scheduleAgentContinue(request, {
             queue,
@@ -932,7 +932,7 @@ describe("agent continuation Slack integration", () => {
       agentContinueRunnerModule.resumeAwaitingSlackContinuation(
         conversationId,
         {
-          generateReply: generateAssistantReplyMock,
+          agentRunner: { run: generateAssistantReplyMock },
           scheduleAgentContinue: (request) =>
             agentContinueServiceModule.scheduleAgentContinue(request, {
               queue,
@@ -1046,7 +1046,7 @@ describe("agent continuation Slack integration", () => {
       agentContinueRunnerModule.resumeAwaitingSlackContinuation(
         conversationId,
         {
-          generateReply: generateAssistantReplyMock,
+          agentRunner: { run: generateAssistantReplyMock },
         },
       ),
     );

--- a/packages/junior/tests/integration/agent-continue-slack.test.ts
+++ b/packages/junior/tests/integration/agent-continue-slack.test.ts
@@ -213,36 +213,44 @@ describe("agent continuation Slack integration", () => {
     expect(continued).toBe(true);
 
     expect(generateAssistantReplyMock).toHaveBeenCalledWith(
-      "resume this request",
       expect.objectContaining({
-        requester: expect.objectContaining({
-          email: "testuser@example.com",
-          fullName: "Test User",
-          userId: "U123",
-          userName: "testuser",
+        input: expect.objectContaining({
+          messageText: "resume this request",
+          inboundAttachmentCount: 2,
+          omittedImageAttachmentCount: 1,
         }),
-        destination: SLACK_DESTINATION,
-        source: storedSource,
-        toolChannelId: "C999",
-        inboundAttachmentCount: 2,
-        omittedImageAttachmentCount: 1,
-        sandbox: expect.objectContaining({
-          sandboxId: undefined,
-          sandboxDependencyProfileHash: undefined,
+        routing: expect.objectContaining({
+          requester: expect.objectContaining({
+            email: "testuser@example.com",
+            fullName: "Test User",
+            userId: "U123",
+            userName: "testuser",
+          }),
+          destination: SLACK_DESTINATION,
+          source: storedSource,
+          toolChannelId: "C999",
+        }),
+        policy: expect.objectContaining({
+          sandbox: expect.objectContaining({
+            sandboxId: undefined,
+            sandboxDependencyProfileHash: undefined,
+          }),
         }),
       }),
     );
-    const resumeContext = generateAssistantReplyMock.mock.calls[0]?.[1] as {
-      channelConfiguration?: {
-        resolve: (key: string) => Promise<unknown>;
+    const resumeContext = generateAssistantReplyMock.mock.calls[0]?.[0] as {
+      policy?: {
+        channelConfiguration?: {
+          resolve: (key: string) => Promise<unknown>;
+        };
+        turnDeadlineAtMs?: number;
       };
-      turnDeadlineAtMs?: number;
     };
-    expect(resumeContext.turnDeadlineAtMs).toEqual(expect.any(Number));
-    expect(resumeContext.turnDeadlineAtMs).toBeGreaterThan(Date.now());
-    expect(await resumeContext.channelConfiguration?.resolve("demo.org")).toBe(
-      "acme",
-    );
+    expect(resumeContext.policy?.turnDeadlineAtMs).toEqual(expect.any(Number));
+    expect(resumeContext.policy?.turnDeadlineAtMs).toBeGreaterThan(Date.now());
+    expect(
+      await resumeContext.policy?.channelConfiguration?.resolve("demo.org"),
+    ).toBe("acme");
 
     expect(slackApiOutbox.calls("assistant.threads.setStatus")).toEqual(
       expect.arrayContaining([
@@ -366,13 +374,15 @@ describe("agent continuation Slack integration", () => {
       }),
     ]);
     expect(generateAssistantReplyMock).toHaveBeenCalledWith(
-      "resume this request",
       expect.objectContaining({
-        requester: {
-          platform: "slack",
-          teamId: "T123",
-          userId: "U123",
-        },
+        input: expect.objectContaining({ messageText: "resume this request" }),
+        routing: expect.objectContaining({
+          requester: {
+            platform: "slack",
+            teamId: "T123",
+            userId: "U123",
+          },
+        }),
       }),
     );
   });
@@ -727,13 +737,15 @@ describe("agent continuation Slack integration", () => {
 
     expect(continued).toBe(true);
     expect(generateAssistantReplyMock).toHaveBeenCalledWith(
-      "resume this request",
       expect.objectContaining({
-        requester: expect.objectContaining({
-          userId: "U123",
-          userName: "testuser",
-          fullName: "Test User",
-          email: "testuser@example.com",
+        input: expect.objectContaining({ messageText: "resume this request" }),
+        routing: expect.objectContaining({
+          requester: expect.objectContaining({
+            userId: "U123",
+            userName: "testuser",
+            fullName: "Test User",
+            email: "testuser@example.com",
+          }),
         }),
       }),
     );
@@ -943,9 +955,11 @@ describe("agent continuation Slack integration", () => {
 
     expect(resumed).toBe(true);
     expect(generateAssistantReplyMock).toHaveBeenCalledWith(
-      "resume this request",
       expect.objectContaining({
-        destination: SLACK_DESTINATION,
+        input: expect.objectContaining({ messageText: "resume this request" }),
+        routing: expect.objectContaining({
+          destination: SLACK_DESTINATION,
+        }),
       }),
     );
     // Exactly one visible reply for the interrupted request.

--- a/packages/junior/tests/integration/agent-continue-slack.test.ts
+++ b/packages/junior/tests/integration/agent-continue-slack.test.ts
@@ -10,7 +10,7 @@ import { slackApiOutbox } from "../fixtures/slack-api-outbox";
 import { resetSlackApiMockState } from "../msw/handlers/slack-api";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
-const generateAssistantReplyMock = vi.fn();
+const executeAgentRunMock = vi.fn();
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -69,7 +69,7 @@ function continueAgentRun(args: {
         sessionId: args.sessionId,
       },
       {
-        agentRunner: { run: generateAssistantReplyMock },
+        agentRunner: { run: executeAgentRunMock },
         scheduleAgentContinue: (request) =>
           agentContinueServiceModule.scheduleAgentContinue(request, {
             queue,
@@ -82,8 +82,8 @@ function continueAgentRun(args: {
 describe("agent continuation Slack integration", () => {
   beforeEach(async () => {
     queue = createConversationWorkQueueTestAdapter();
-    generateAssistantReplyMock.mockReset();
-    generateAssistantReplyMock.mockResolvedValue(
+    executeAgentRunMock.mockReset();
+    executeAgentRunMock.mockResolvedValue(
       completedAgentRun({
         text: "Final resumed answer",
         diagnostics: makeDiagnostics(),
@@ -212,7 +212,7 @@ describe("agent continuation Slack integration", () => {
 
     expect(continued).toBe(true);
 
-    expect(generateAssistantReplyMock).toHaveBeenCalledWith(
+    expect(executeAgentRunMock).toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({
           messageText: "resume this request",
@@ -238,7 +238,7 @@ describe("agent continuation Slack integration", () => {
         }),
       }),
     );
-    const resumeContext = generateAssistantReplyMock.mock.calls[0]?.[0] as {
+    const resumeContext = executeAgentRunMock.mock.calls[0]?.[0] as {
       policy?: {
         channelConfiguration?: {
           resolve: (key: string) => Promise<unknown>;
@@ -373,7 +373,7 @@ describe("agent continuation Slack integration", () => {
         }),
       }),
     ]);
-    expect(generateAssistantReplyMock).toHaveBeenCalledWith(
+    expect(executeAgentRunMock).toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({ messageText: "resume this request" }),
         routing: expect.objectContaining({
@@ -454,7 +454,7 @@ describe("agent continuation Slack integration", () => {
     });
 
     const { RetryableTurnError } = await import("@/chat/runtime/turn");
-    generateAssistantReplyMock.mockRejectedValueOnce(
+    executeAgentRunMock.mockRejectedValueOnce(
       new RetryableTurnError("agent_continue", "timed out again", {
         conversationId,
         sessionId,
@@ -553,7 +553,7 @@ describe("agent continuation Slack integration", () => {
     });
 
     expect(continued).toBe(true);
-    expect(generateAssistantReplyMock).not.toHaveBeenCalled();
+    expect(executeAgentRunMock).not.toHaveBeenCalled();
     await expect(
       turnSessionStoreModule.getAgentTurnSessionRecord(
         conversationId,
@@ -633,7 +633,7 @@ describe("agent continuation Slack integration", () => {
     });
 
     expect(continued).toBe(false);
-    expect(generateAssistantReplyMock).not.toHaveBeenCalled();
+    expect(executeAgentRunMock).not.toHaveBeenCalled();
     await expect(
       turnSessionStoreModule.getAgentTurnSessionRecord(
         conversationId,
@@ -736,7 +736,7 @@ describe("agent continuation Slack integration", () => {
     });
 
     expect(continued).toBe(true);
-    expect(generateAssistantReplyMock).toHaveBeenCalledWith(
+    expect(executeAgentRunMock).toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({ messageText: "resume this request" }),
         routing: expect.objectContaining({
@@ -827,7 +827,7 @@ describe("agent continuation Slack integration", () => {
     });
 
     const { RetryableTurnError } = await import("@/chat/runtime/turn");
-    generateAssistantReplyMock.mockRejectedValueOnce(
+    executeAgentRunMock.mockRejectedValueOnce(
       new RetryableTurnError("agent_continue", "timed out again", {
         conversationId,
         sessionId,
@@ -863,7 +863,7 @@ describe("agent continuation Slack integration", () => {
     // exactly one visible reply and only then a delivered/completed session.
     const conversationId = "slack:C123:1712345.0008";
     const sessionId = "turn_msg_8";
-    generateAssistantReplyMock.mockResolvedValueOnce(
+    executeAgentRunMock.mockResolvedValueOnce(
       completedAgentRun({
         text: "Final resumed answer",
         piMessages: [
@@ -944,7 +944,7 @@ describe("agent continuation Slack integration", () => {
       agentContinueRunnerModule.resumeAwaitingSlackContinuation(
         conversationId,
         {
-          agentRunner: { run: generateAssistantReplyMock },
+          agentRunner: { run: executeAgentRunMock },
           scheduleAgentContinue: (request) =>
             agentContinueServiceModule.scheduleAgentContinue(request, {
               queue,
@@ -954,7 +954,7 @@ describe("agent continuation Slack integration", () => {
     );
 
     expect(resumed).toBe(true);
-    expect(generateAssistantReplyMock).toHaveBeenCalledWith(
+    expect(executeAgentRunMock).toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({ messageText: "resume this request" }),
         routing: expect.objectContaining({
@@ -1060,13 +1060,13 @@ describe("agent continuation Slack integration", () => {
       agentContinueRunnerModule.resumeAwaitingSlackContinuation(
         conversationId,
         {
-          agentRunner: { run: generateAssistantReplyMock },
+          agentRunner: { run: executeAgentRunMock },
         },
       ),
     );
 
     expect(resumed).toBe(false);
-    expect(generateAssistantReplyMock).not.toHaveBeenCalled();
+    expect(executeAgentRunMock).not.toHaveBeenCalled();
     await expect(
       turnSessionStoreModule.getAgentTurnSessionRecord(
         conversationId,
@@ -1120,7 +1120,7 @@ describe("agent continuation Slack integration", () => {
         },
       });
 
-    generateAssistantReplyMock.mockResolvedValueOnce(
+    executeAgentRunMock.mockResolvedValueOnce(
       completedAgentRun({
         text: "Final resumed answer with artifact",
         files: [

--- a/packages/junior/tests/integration/agent-dispatch-runner.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-runner.test.ts
@@ -6,6 +6,7 @@ import {
   getDispatchDestinationLockId,
   getDispatchRecord,
   getDispatchStorageKey,
+  getDispatchTurnId,
   parseDispatchRecord,
   updateDispatchRecord,
   withDispatchLock,
@@ -15,7 +16,6 @@ import {
   getPersistedThreadState,
   persistThreadStateById,
 } from "@/chat/runtime/thread-state";
-import { RetryableTurnError } from "@/chat/runtime/turn";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import type { AssistantReply } from "@/chat/respond";
@@ -25,6 +25,10 @@ import {
   createSlackDirectCredentialSubject,
 } from "@/chat/credentials/subject";
 import { getAgentTurnSessionRecord } from "@/chat/state/turn-session";
+import {
+  completedAgentRun,
+  failedAgentRun,
+} from "@/chat/runtime/agent-run-outcome";
 import { chatPostMessageOk } from "../fixtures/slack/factories/api";
 import {
   getCapturedSlackApiCalls,
@@ -200,7 +204,7 @@ describe("agent dispatch runner", () => {
       expect(context.sandbox?.tracePropagation).toEqual({
         domains: ["*.sentry.io"],
       });
-      return createReply();
+      return completedAgentRun(createReply());
     });
     const scheduleSessionCompletedPluginTasks = vi.fn(async () => undefined);
 
@@ -309,7 +313,7 @@ describe("agent dispatch runner", () => {
     const generateAssistantReply = vi.fn(async (_input, context) => {
       expect(context.conversationContext).toBeUndefined();
       expect(context.piMessages).toEqual([]);
-      return createReply();
+      return completedAgentRun(createReply());
     });
 
     await runAgentDispatchSlice(
@@ -356,10 +360,13 @@ describe("agent dispatch runner", () => {
     });
     const scheduleCallback = vi.fn(async () => undefined);
     const generateAssistantReply = vi.fn(async () => {
-      throw new RetryableTurnError("agent_continue", "slice timed out", {
+      return {
+        status: "timed_out" as const,
+        conversationId: getDispatchConversationId(created.record),
+        sessionId: getDispatchTurnId(created.record.id),
         version: 7,
         sliceId: 2,
-      });
+      };
     });
 
     await runAgentDispatchSlice(
@@ -414,7 +421,7 @@ describe("agent dispatch runner", () => {
         },
       });
       expect(context.authorizationFlowMode).toBe("disabled");
-      return createReply();
+      return completedAgentRun(createReply());
     });
 
     await runAgentDispatchSlice(
@@ -466,7 +473,9 @@ describe("agent dispatch runner", () => {
           id: created.record.id,
           expectedVersion: created.record.version,
         },
-        { generateAssistantReply: async () => createReply() },
+        {
+          generateAssistantReply: async () => completedAgentRun(createReply()),
+        },
       );
     } finally {
       setSpy.mockRestore();
@@ -512,17 +521,19 @@ describe("agent dispatch runner", () => {
     });
     const dispatchConversationId = getDispatchConversationId(created.record);
     const failedReply = createReply();
-    const generateAssistantReply = vi.fn(async () => ({
-      ...failedReply,
-      text: "",
-      diagnostics: {
-        ...failedReply.diagnostics,
-        errorMessage: "provider failed",
-        outcome: "provider_error" as const,
-        usedPrimaryText: false,
-      },
-      piMessages: failedDispatchPiMessages(),
-    }));
+    const generateAssistantReply = vi.fn(async () =>
+      failedAgentRun({
+        ...failedReply,
+        text: "",
+        diagnostics: {
+          ...failedReply.diagnostics,
+          errorMessage: "provider failed",
+          outcome: "provider_error" as const,
+          usedPrimaryText: false,
+        },
+        piMessages: failedDispatchPiMessages(),
+      }),
+    );
 
     await runAgentDispatchSlice(
       {
@@ -571,7 +582,7 @@ describe("agent dispatch runner", () => {
         id: created.record.id,
         expectedVersion: created.record.version,
       },
-      { generateAssistantReply: async () => createReply() },
+      { generateAssistantReply: async () => completedAgentRun(createReply()) },
     );
     await expect(getDispatchRecord(created.record.id)).resolves.toMatchObject({
       status: "completed",

--- a/packages/junior/tests/integration/agent-dispatch-runner.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-runner.test.ts
@@ -18,7 +18,7 @@ import {
 } from "@/chat/runtime/thread-state";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
-import type { AssistantReply } from "@/chat/respond";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { PiMessage } from "@/chat/pi/messages";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import {
@@ -57,7 +57,7 @@ function zeroUsage() {
   };
 }
 
-function createReply(): AssistantReply {
+function createReply(): AgentRunResult {
   return {
     text: "Dispatch delivered.",
     deliveryMode: "thread",
@@ -96,7 +96,7 @@ function createReply(): AssistantReply {
   };
 }
 
-function flattenReplyRequestForTest(
+function flattenAgentRunRequestForTest(
   request: Parameters<AgentRunner["run"]>[0],
 ) {
   return {
@@ -196,33 +196,31 @@ describe("agent dispatch runner", () => {
       },
     });
     const dispatchConversationId = getDispatchConversationId(created.record);
-    const generateAssistantReply = vi.fn<AgentRunner["run"]>(
-      async (request) => {
-        const context = flattenReplyRequestForTest(request);
-        expect(context.requester).toBeUndefined();
-        expect(context.authorizationFlowMode).toBe("disabled");
-        expect(context.surface).toBe("api");
-        expect(context.source).toEqual(slackSource());
-        expect(context.dispatch).toEqual({
-          actor: { type: "system", id: "scheduler" },
-          metadata: { runId: "run-1" },
-          plugin: "scheduler",
-        });
-        expect(context.correlation).toMatchObject({
-          conversationId: dispatchConversationId,
-          threadId: dispatchConversationId,
-          channelId: "C123",
-          teamId: "T123",
-        });
-        expect(context.credentialContext).toEqual({
-          actor: { type: "system", id: "scheduler" },
-        });
-        expect(context.sandbox?.tracePropagation).toEqual({
-          domains: ["*.sentry.io"],
-        });
-        return completedAgentRun(createReply());
-      },
-    );
+    const executeAgentRun = vi.fn<AgentRunner["run"]>(async (request) => {
+      const context = flattenAgentRunRequestForTest(request);
+      expect(context.requester).toBeUndefined();
+      expect(context.authorizationFlowMode).toBe("disabled");
+      expect(context.surface).toBe("api");
+      expect(context.source).toEqual(slackSource());
+      expect(context.dispatch).toEqual({
+        actor: { type: "system", id: "scheduler" },
+        metadata: { runId: "run-1" },
+        plugin: "scheduler",
+      });
+      expect(context.correlation).toMatchObject({
+        conversationId: dispatchConversationId,
+        threadId: dispatchConversationId,
+        channelId: "C123",
+        teamId: "T123",
+      });
+      expect(context.credentialContext).toEqual({
+        actor: { type: "system", id: "scheduler" },
+      });
+      expect(context.sandbox?.tracePropagation).toEqual({
+        domains: ["*.sentry.io"],
+      });
+      return completedAgentRun(createReply());
+    });
     const scheduleSessionCompletedPluginTasks = vi.fn(async () => undefined);
 
     await runAgentDispatchSlice(
@@ -231,7 +229,7 @@ describe("agent dispatch runner", () => {
         expectedVersion: created.record.version,
       },
       {
-        agentRunner: { run: generateAssistantReply },
+        agentRunner: { run: executeAgentRun },
         scheduleSessionCompletedPluginTasks,
         tracePropagation: { domains: ["*.sentry.io"] },
       },
@@ -327,21 +325,19 @@ describe("agent dispatch runner", () => {
       },
     });
     const dispatchConversationId = getDispatchConversationId(created.record);
-    const generateAssistantReply = vi.fn<AgentRunner["run"]>(
-      async (request) => {
-        const context = flattenReplyRequestForTest(request);
-        expect(context.conversationContext).toBeUndefined();
-        expect(context.piMessages).toEqual([]);
-        return completedAgentRun(createReply());
-      },
-    );
+    const executeAgentRun = vi.fn<AgentRunner["run"]>(async (request) => {
+      const context = flattenAgentRunRequestForTest(request);
+      expect(context.conversationContext).toBeUndefined();
+      expect(context.piMessages).toEqual([]);
+      return completedAgentRun(createReply());
+    });
 
     await runAgentDispatchSlice(
       {
         id: created.record.id,
         expectedVersion: created.record.version,
       },
-      { agentRunner: { run: generateAssistantReply } },
+      { agentRunner: { run: executeAgentRun } },
     );
 
     const persistedDestination =
@@ -379,7 +375,7 @@ describe("agent dispatch runner", () => {
       },
     });
     const scheduleCallback = vi.fn(async () => undefined);
-    const generateAssistantReply = vi.fn(async () => {
+    const executeAgentRun = vi.fn(async () => {
       return {
         status: "timed_out" as const,
         conversationId: getDispatchConversationId(created.record),
@@ -394,7 +390,7 @@ describe("agent dispatch runner", () => {
         id: created.record.id,
         expectedVersion: created.record.version,
       },
-      { agentRunner: { run: generateAssistantReply }, scheduleCallback },
+      { agentRunner: { run: executeAgentRun }, scheduleCallback },
     );
 
     await expect(getDispatchRecord(created.record.id)).resolves.toMatchObject({
@@ -424,35 +420,33 @@ describe("agent dispatch runner", () => {
         source: slackSource("D123"),
       },
     });
-    const generateAssistantReply = vi.fn<AgentRunner["run"]>(
-      async (request) => {
-        const context = flattenReplyRequestForTest(request);
-        expect(context.requester).toBeUndefined();
-        expect(context.credentialContext).toEqual({
-          actor: { type: "system", id: "scheduler" },
-          subject: {
-            type: "user",
-            userId: "U123",
-            allowedWhen: "private-direct-conversation",
-            binding: {
-              type: "slack-direct-conversation",
-              teamId: "T123",
-              channelId: "D123",
-              signature: expect.any(String),
-            },
+    const executeAgentRun = vi.fn<AgentRunner["run"]>(async (request) => {
+      const context = flattenAgentRunRequestForTest(request);
+      expect(context.requester).toBeUndefined();
+      expect(context.credentialContext).toEqual({
+        actor: { type: "system", id: "scheduler" },
+        subject: {
+          type: "user",
+          userId: "U123",
+          allowedWhen: "private-direct-conversation",
+          binding: {
+            type: "slack-direct-conversation",
+            teamId: "T123",
+            channelId: "D123",
+            signature: expect.any(String),
           },
-        });
-        expect(context.authorizationFlowMode).toBe("disabled");
-        return completedAgentRun(createReply());
-      },
-    );
+        },
+      });
+      expect(context.authorizationFlowMode).toBe("disabled");
+      return completedAgentRun(createReply());
+    });
 
     await runAgentDispatchSlice(
       {
         id: created.record.id,
         expectedVersion: created.record.version,
       },
-      { agentRunner: { run: generateAssistantReply } },
+      { agentRunner: { run: executeAgentRun } },
     );
 
     await expect(getDispatchRecord(created.record.id)).resolves.toMatchObject({
@@ -544,7 +538,7 @@ describe("agent dispatch runner", () => {
     });
     const dispatchConversationId = getDispatchConversationId(created.record);
     const failedReply = createReply();
-    const generateAssistantReply = vi.fn(async () =>
+    const executeAgentRun = vi.fn(async () =>
       failedAgentRun({
         ...failedReply,
         text: "",
@@ -563,7 +557,7 @@ describe("agent dispatch runner", () => {
         id: created.record.id,
         expectedVersion: created.record.version,
       },
-      { agentRunner: { run: generateAssistantReply } },
+      { agentRunner: { run: executeAgentRun } },
     );
 
     await expect(getDispatchRecord(created.record.id)).resolves.toMatchObject({

--- a/packages/junior/tests/integration/agent-dispatch-runner.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-runner.test.ts
@@ -20,6 +20,7 @@ import { coerceThreadConversationState } from "@/chat/state/conversation";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import type { AssistantReply } from "@/chat/respond";
 import type { PiMessage } from "@/chat/pi/messages";
+import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import {
   bindSlackDirectCredentialSubject,
   createSlackDirectCredentialSubject,
@@ -92,6 +93,19 @@ function createReply(): AssistantReply {
         usage: zeroUsage(),
       },
     ],
+  };
+}
+
+function flattenReplyRequestForTest(
+  request: Parameters<AgentRunner["run"]>[0],
+) {
+  return {
+    ...request.input,
+    ...request.routing,
+    ...(request.policy ?? {}),
+    ...(request.state ?? {}),
+    ...(request.observers ?? {}),
+    ...(request.durability ?? {}),
   };
 }
 
@@ -182,30 +196,33 @@ describe("agent dispatch runner", () => {
       },
     });
     const dispatchConversationId = getDispatchConversationId(created.record);
-    const generateAssistantReply = vi.fn(async (_input, context) => {
-      expect(context.requester).toBeUndefined();
-      expect(context.authorizationFlowMode).toBe("disabled");
-      expect(context.surface).toBe("api");
-      expect(context.source).toEqual(slackSource());
-      expect(context.dispatch).toEqual({
-        actor: { type: "system", id: "scheduler" },
-        metadata: { runId: "run-1" },
-        plugin: "scheduler",
-      });
-      expect(context.correlation).toMatchObject({
-        conversationId: dispatchConversationId,
-        threadId: dispatchConversationId,
-        channelId: "C123",
-        teamId: "T123",
-      });
-      expect(context.credentialContext).toEqual({
-        actor: { type: "system", id: "scheduler" },
-      });
-      expect(context.sandbox?.tracePropagation).toEqual({
-        domains: ["*.sentry.io"],
-      });
-      return completedAgentRun(createReply());
-    });
+    const generateAssistantReply = vi.fn<AgentRunner["run"]>(
+      async (request) => {
+        const context = flattenReplyRequestForTest(request);
+        expect(context.requester).toBeUndefined();
+        expect(context.authorizationFlowMode).toBe("disabled");
+        expect(context.surface).toBe("api");
+        expect(context.source).toEqual(slackSource());
+        expect(context.dispatch).toEqual({
+          actor: { type: "system", id: "scheduler" },
+          metadata: { runId: "run-1" },
+          plugin: "scheduler",
+        });
+        expect(context.correlation).toMatchObject({
+          conversationId: dispatchConversationId,
+          threadId: dispatchConversationId,
+          channelId: "C123",
+          teamId: "T123",
+        });
+        expect(context.credentialContext).toEqual({
+          actor: { type: "system", id: "scheduler" },
+        });
+        expect(context.sandbox?.tracePropagation).toEqual({
+          domains: ["*.sentry.io"],
+        });
+        return completedAgentRun(createReply());
+      },
+    );
     const scheduleSessionCompletedPluginTasks = vi.fn(async () => undefined);
 
     await runAgentDispatchSlice(
@@ -310,11 +327,14 @@ describe("agent dispatch runner", () => {
       },
     });
     const dispatchConversationId = getDispatchConversationId(created.record);
-    const generateAssistantReply = vi.fn(async (_input, context) => {
-      expect(context.conversationContext).toBeUndefined();
-      expect(context.piMessages).toEqual([]);
-      return completedAgentRun(createReply());
-    });
+    const generateAssistantReply = vi.fn<AgentRunner["run"]>(
+      async (request) => {
+        const context = flattenReplyRequestForTest(request);
+        expect(context.conversationContext).toBeUndefined();
+        expect(context.piMessages).toEqual([]);
+        return completedAgentRun(createReply());
+      },
+    );
 
     await runAgentDispatchSlice(
       {
@@ -404,25 +424,28 @@ describe("agent dispatch runner", () => {
         source: slackSource("D123"),
       },
     });
-    const generateAssistantReply = vi.fn(async (_input, context) => {
-      expect(context.requester).toBeUndefined();
-      expect(context.credentialContext).toEqual({
-        actor: { type: "system", id: "scheduler" },
-        subject: {
-          type: "user",
-          userId: "U123",
-          allowedWhen: "private-direct-conversation",
-          binding: {
-            type: "slack-direct-conversation",
-            teamId: "T123",
-            channelId: "D123",
-            signature: expect.any(String),
+    const generateAssistantReply = vi.fn<AgentRunner["run"]>(
+      async (request) => {
+        const context = flattenReplyRequestForTest(request);
+        expect(context.requester).toBeUndefined();
+        expect(context.credentialContext).toEqual({
+          actor: { type: "system", id: "scheduler" },
+          subject: {
+            type: "user",
+            userId: "U123",
+            allowedWhen: "private-direct-conversation",
+            binding: {
+              type: "slack-direct-conversation",
+              teamId: "T123",
+              channelId: "D123",
+              signature: expect.any(String),
+            },
           },
-        },
-      });
-      expect(context.authorizationFlowMode).toBe("disabled");
-      return completedAgentRun(createReply());
-    });
+        });
+        expect(context.authorizationFlowMode).toBe("disabled");
+        return completedAgentRun(createReply());
+      },
+    );
 
     await runAgentDispatchSlice(
       {

--- a/packages/junior/tests/integration/agent-dispatch-runner.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-runner.test.ts
@@ -214,7 +214,7 @@ describe("agent dispatch runner", () => {
         expectedVersion: created.record.version,
       },
       {
-        generateAssistantReply,
+        agentRunner: { run: generateAssistantReply },
         scheduleSessionCompletedPluginTasks,
         tracePropagation: { domains: ["*.sentry.io"] },
       },
@@ -321,7 +321,7 @@ describe("agent dispatch runner", () => {
         id: created.record.id,
         expectedVersion: created.record.version,
       },
-      { generateAssistantReply },
+      { agentRunner: { run: generateAssistantReply } },
     );
 
     const persistedDestination =
@@ -374,7 +374,7 @@ describe("agent dispatch runner", () => {
         id: created.record.id,
         expectedVersion: created.record.version,
       },
-      { generateAssistantReply, scheduleCallback },
+      { agentRunner: { run: generateAssistantReply }, scheduleCallback },
     );
 
     await expect(getDispatchRecord(created.record.id)).resolves.toMatchObject({
@@ -429,7 +429,7 @@ describe("agent dispatch runner", () => {
         id: created.record.id,
         expectedVersion: created.record.version,
       },
-      { generateAssistantReply },
+      { agentRunner: { run: generateAssistantReply } },
     );
 
     await expect(getDispatchRecord(created.record.id)).resolves.toMatchObject({
@@ -474,7 +474,7 @@ describe("agent dispatch runner", () => {
           expectedVersion: created.record.version,
         },
         {
-          generateAssistantReply: async () => completedAgentRun(createReply()),
+          agentRunner: { run: async () => completedAgentRun(createReply()) },
         },
       );
     } finally {
@@ -496,7 +496,7 @@ describe("agent dispatch runner", () => {
         id: created.record.id,
         expectedVersion: created.record.version,
       },
-      { generateAssistantReply: rerunGenerate },
+      { agentRunner: { run: rerunGenerate } },
     );
     expect(rerunGenerate).not.toHaveBeenCalled();
     expect(getCapturedSlackApiCalls("chat.postMessage")).toHaveLength(1);
@@ -540,7 +540,7 @@ describe("agent dispatch runner", () => {
         id: created.record.id,
         expectedVersion: created.record.version,
       },
-      { generateAssistantReply },
+      { agentRunner: { run: generateAssistantReply } },
     );
 
     await expect(getDispatchRecord(created.record.id)).resolves.toMatchObject({
@@ -582,7 +582,7 @@ describe("agent dispatch runner", () => {
         id: created.record.id,
         expectedVersion: created.record.version,
       },
-      { generateAssistantReply: async () => completedAgentRun(createReply()) },
+      { agentRunner: { run: async () => completedAgentRun(createReply()) } },
     );
     await expect(getDispatchRecord(created.record.id)).resolves.toMatchObject({
       status: "completed",
@@ -618,7 +618,7 @@ describe("agent dispatch runner", () => {
         id: created.record.id,
         expectedVersion: reverted.version,
       },
-      { generateAssistantReply: rerunGenerate },
+      { agentRunner: { run: rerunGenerate } },
     );
 
     expect(rerunGenerate).not.toHaveBeenCalled();
@@ -655,8 +655,10 @@ describe("agent dispatch runner", () => {
           expectedVersion: created.record.version,
         },
         {
-          generateAssistantReply: async () => {
-            throw new Error("busy conversation should not run");
+          agentRunner: {
+            run: async () => {
+              throw new Error("busy conversation should not run");
+            },
           },
         },
       );

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type {
-  AssistantReply,
-  generateAssistantReply,
-  ReplyRequestContext,
-} from "@/chat/respond";
+import type { AssistantReply, ReplyRequestContext } from "@/chat/respond";
 import {
   defineJuniorPlugin,
   type PluginRunContext,
@@ -16,6 +12,7 @@ import {
   type LocalToolResult,
 } from "@/chat/local/runner";
 import type { PiMessage } from "@/chat/pi/messages";
+import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { persistCompletedSessionRecord } from "@/chat/services/turn-session-record";
 import {
   getPersistedSandboxState,
@@ -86,12 +83,10 @@ describe("local agent runner", () => {
     expect(conversationId).toBeDefined();
 
     const contexts: ReplyRequestContext[] = [];
-    const generateReply = vi.fn<typeof generateAssistantReply>(
-      async (_text, context) => {
-        contexts.push(context);
-        return completedAgentRun(successReply("hello from local"));
-      },
-    );
+    const generateReply = vi.fn<AgentRunner["run"]>(async (_text, context) => {
+      contexts.push(context);
+      return completedAgentRun(successReply("hello from local"));
+    });
     const delivered: LocalAgentReply[] = [];
 
     await runLocalAgentTurn(
@@ -103,7 +98,7 @@ describe("local agent runner", () => {
         deliverReply: async (reply) => {
           delivered.push(reply);
         },
-        generateAssistantReply: generateReply,
+        agentRunner: { run: generateReply },
       },
     );
 
@@ -171,23 +166,21 @@ describe("local agent runner", () => {
     });
     expect(conversationId).toBeDefined();
 
-    const generateReply = vi.fn<typeof generateAssistantReply>(
-      async (_text, context) => {
-        context.onToolInvocation?.({
-          toolName: "createMemory",
-          params: { content: "The requester prefers short updates." },
-        });
-        await context.onToolResult?.({
-          ok: true,
-          toolName: "createMemory",
-          params: { content: "The requester prefers short updates." },
-          result: { ok: true },
-        });
-        return completedAgentRun(
-          successReply("saved", { toolCalls: ["createMemory"] }),
-        );
-      },
-    );
+    const generateReply = vi.fn<AgentRunner["run"]>(async (_text, context) => {
+      context.onToolInvocation?.({
+        toolName: "createMemory",
+        params: { content: "The requester prefers short updates." },
+      });
+      await context.onToolResult?.({
+        ok: true,
+        toolName: "createMemory",
+        params: { content: "The requester prefers short updates." },
+        result: { ok: true },
+      });
+      return completedAgentRun(
+        successReply("saved", { toolCalls: ["createMemory"] }),
+      );
+    });
     const invocations: LocalToolInvocation[] = [];
     const results: LocalToolResult[] = [];
 
@@ -198,7 +191,7 @@ describe("local agent runner", () => {
       },
       {
         deliverReply: async () => undefined,
-        generateAssistantReply: generateReply,
+        agentRunner: { run: generateReply },
         onToolInvocation: async (invocation) => {
           invocations.push(invocation);
         },
@@ -258,23 +251,25 @@ describe("local agent runner", () => {
         },
         {
           deliverReply: async () => undefined,
-          generateAssistantReply: async (_text, context) => {
-            const piMessages = [
-              {
-                role: "user",
-                content: "capture this local turn",
-              },
-              {
-                role: "assistant",
-                content: "captured",
-              },
-            ] as PiMessage[];
-            await persistCompletedSessionForFakeReply(context, piMessages);
-            return completedAgentRun(
-              successReply("captured", {
-                piMessages,
-              }),
-            );
+          agentRunner: {
+            run: async (_text, context) => {
+              const piMessages = [
+                {
+                  role: "user",
+                  content: "capture this local turn",
+                },
+                {
+                  role: "assistant",
+                  content: "captured",
+                },
+              ] as PiMessage[];
+              await persistCompletedSessionForFakeReply(context, piMessages);
+              return completedAgentRun(
+                successReply("captured", {
+                  piMessages,
+                }),
+              );
+            },
           },
         },
       );
@@ -323,12 +318,10 @@ describe("local agent runner", () => {
     expect(conversationId).toBeDefined();
 
     const contexts: ReplyRequestContext[] = [];
-    const generateReply = vi.fn<typeof generateAssistantReply>(
-      async (text, context) => {
-        contexts.push(context);
-        return completedAgentRun(successReply(`reply to ${text}`));
-      },
-    );
+    const generateReply = vi.fn<AgentRunner["run"]>(async (text, context) => {
+      contexts.push(context);
+      return completedAgentRun(successReply(`reply to ${text}`));
+    });
 
     await runLocalAgentTurn(
       {
@@ -337,7 +330,7 @@ describe("local agent runner", () => {
       },
       {
         deliverReply: async () => undefined,
-        generateAssistantReply: generateReply,
+        agentRunner: { run: generateReply },
       },
     );
     await runLocalAgentTurn(
@@ -347,7 +340,7 @@ describe("local agent runner", () => {
       },
       {
         deliverReply: async () => undefined,
-        generateAssistantReply: generateReply,
+        agentRunner: { run: generateReply },
       },
     );
 
@@ -373,7 +366,7 @@ describe("local agent runner", () => {
     });
     expect(conversationId).toBeDefined();
 
-    const generateReply = vi.fn<typeof generateAssistantReply>(async () =>
+    const generateReply = vi.fn<AgentRunner["run"]>(async () =>
       completedAgentRun(successReply("not delivered")),
     );
 
@@ -384,7 +377,7 @@ describe("local agent runner", () => {
           message: "hello",
         },
         {
-          generateAssistantReply: generateReply,
+          agentRunner: { run: generateReply },
         } as unknown as Parameters<typeof runLocalAgentTurn>[1],
       ),
     ).rejects.toThrow("Local reply delivery is required");
@@ -396,7 +389,7 @@ describe("local agent runner", () => {
   });
 
   it("rejects malformed local conversation ids before generation", async () => {
-    const generateReply = vi.fn<typeof generateAssistantReply>(async () => {
+    const generateReply = vi.fn<AgentRunner["run"]>(async () => {
       throw new Error("generation should not run");
     });
 
@@ -408,7 +401,7 @@ describe("local agent runner", () => {
         },
         {
           deliverReply: async () => undefined,
-          generateAssistantReply: generateReply,
+          agentRunner: { run: generateReply },
         },
       ),
     ).rejects.toThrow("Invalid local conversation id");
@@ -431,12 +424,10 @@ describe("local agent runner", () => {
     });
 
     const contexts: ReplyRequestContext[] = [];
-    const generateReply = vi.fn<typeof generateAssistantReply>(
-      async (_text, context) => {
-        contexts.push(context);
-        return completedAgentRun(successReply("uses projection"));
-      },
-    );
+    const generateReply = vi.fn<AgentRunner["run"]>(async (_text, context) => {
+      contexts.push(context);
+      return completedAgentRun(successReply("uses projection"));
+    });
 
     await runLocalAgentTurn(
       {
@@ -445,7 +436,7 @@ describe("local agent runner", () => {
       },
       {
         deliverReply: async () => undefined,
-        generateAssistantReply: generateReply,
+        agentRunner: { run: generateReply },
       },
     );
 
@@ -469,7 +460,7 @@ describe("local agent runner", () => {
         content: [{ type: "text", text: "persisted pi output" }],
       },
     ] as PiMessage[];
-    const generateReply = vi.fn<typeof generateAssistantReply>(async () =>
+    const generateReply = vi.fn<AgentRunner["run"]>(async () =>
       completedAgentRun(
         successReply("persisted visible output", {
           piMessages: generatedMessages,
@@ -484,7 +475,7 @@ describe("local agent runner", () => {
       },
       {
         deliverReply: async () => undefined,
-        generateAssistantReply: generateReply,
+        agentRunner: { run: generateReply },
       },
     );
 
@@ -503,9 +494,11 @@ describe("local agent runner", () => {
       },
       {
         deliverReply: async () => undefined,
-        generateAssistantReply: async (_text, context) => {
-          contexts.push(context);
-          return completedAgentRun(successReply("follow up reply"));
+        agentRunner: {
+          run: async (_text, context) => {
+            contexts.push(context);
+            return completedAgentRun(successReply("follow up reply"));
+          },
         },
       },
     );
@@ -561,16 +554,18 @@ describe("local agent runner", () => {
             deliverReply: async (reply) => {
               delivered.push(reply);
             },
-            generateAssistantReply: async (_text, context) => {
-              await persistCompletedSessionForFakeReply(
-                context,
-                generatedMessages,
-              );
-              return completedAgentRun(
-                successReply("visible reply", {
-                  piMessages: generatedMessages,
-                }),
-              );
+            agentRunner: {
+              run: async (_text, context) => {
+                await persistCompletedSessionForFakeReply(
+                  context,
+                  generatedMessages,
+                );
+                return completedAgentRun(
+                  successReply("visible reply", {
+                    piMessages: generatedMessages,
+                  }),
+                );
+              },
             },
           },
         ),
@@ -625,9 +620,11 @@ describe("local agent runner", () => {
       },
       {
         deliverReply: async () => undefined,
-        generateAssistantReply: async (_text, context) => {
-          contexts.push(context);
-          return completedAgentRun(successReply("uses newer fallback"));
+        agentRunner: {
+          run: async (_text, context) => {
+            contexts.push(context);
+            return completedAgentRun(successReply("uses newer fallback"));
+          },
         },
       },
     );
@@ -646,24 +643,22 @@ describe("local agent runner", () => {
       role: "assistant",
       content: [{ type: "text", text: "undelivered pi output" }],
     } as PiMessage;
-    const generateReply = vi.fn<typeof generateAssistantReply>(
-      async (_text, context) => {
-        await context.onArtifactStateUpdated?.({
-          lastCanvasId: "canvas-undelivered",
-          lastCanvasUrl: "https://example.invalid/canvas",
-        });
-        await context.onSandboxAcquired?.({
-          sandboxDependencyProfileHash: "profile-undelivered",
-          sandboxId: "sandbox-undelivered",
-        });
-        await commitMessages({
-          conversationId: conversationId!,
-          messages: [assistantMessage],
-          ttlMs: 60_000,
-        });
-        return completedAgentRun(successReply("not delivered"));
-      },
-    );
+    const generateReply = vi.fn<AgentRunner["run"]>(async (_text, context) => {
+      await context.onArtifactStateUpdated?.({
+        lastCanvasId: "canvas-undelivered",
+        lastCanvasUrl: "https://example.invalid/canvas",
+      });
+      await context.onSandboxAcquired?.({
+        sandboxDependencyProfileHash: "profile-undelivered",
+        sandboxId: "sandbox-undelivered",
+      });
+      await commitMessages({
+        conversationId: conversationId!,
+        messages: [assistantMessage],
+        ttlMs: 60_000,
+      });
+      return completedAgentRun(successReply("not delivered"));
+    });
 
     await expect(
       runLocalAgentTurn(
@@ -675,7 +670,7 @@ describe("local agent runner", () => {
           deliverReply: async () => {
             throw new Error("stdout closed");
           },
-          generateAssistantReply: generateReply,
+          agentRunner: { run: generateReply },
         },
       ),
     ).rejects.toThrow("stdout closed");

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -26,6 +26,7 @@ import { commitMessages, loadProjection } from "@/chat/state/session-log";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
 import { coerceThreadArtifactsState } from "@/chat/state/artifacts";
 import { setPlugins } from "@/chat/plugins/agent-hooks";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 function successReply(
   text: string,
@@ -88,7 +89,7 @@ describe("local agent runner", () => {
     const generateReply = vi.fn<typeof generateAssistantReply>(
       async (_text, context) => {
         contexts.push(context);
-        return successReply("hello from local");
+        return completedAgentRun(successReply("hello from local"));
       },
     );
     const delivered: LocalAgentReply[] = [];
@@ -182,7 +183,9 @@ describe("local agent runner", () => {
           params: { content: "The requester prefers short updates." },
           result: { ok: true },
         });
-        return successReply("saved", { toolCalls: ["createMemory"] });
+        return completedAgentRun(
+          successReply("saved", { toolCalls: ["createMemory"] }),
+        );
       },
     );
     const invocations: LocalToolInvocation[] = [];
@@ -267,9 +270,11 @@ describe("local agent runner", () => {
               },
             ] as PiMessage[];
             await persistCompletedSessionForFakeReply(context, piMessages);
-            return successReply("captured", {
-              piMessages,
-            });
+            return completedAgentRun(
+              successReply("captured", {
+                piMessages,
+              }),
+            );
           },
         },
       );
@@ -321,7 +326,7 @@ describe("local agent runner", () => {
     const generateReply = vi.fn<typeof generateAssistantReply>(
       async (text, context) => {
         contexts.push(context);
-        return successReply(`reply to ${text}`);
+        return completedAgentRun(successReply(`reply to ${text}`));
       },
     );
 
@@ -369,7 +374,7 @@ describe("local agent runner", () => {
     expect(conversationId).toBeDefined();
 
     const generateReply = vi.fn<typeof generateAssistantReply>(async () =>
-      successReply("not delivered"),
+      completedAgentRun(successReply("not delivered")),
     );
 
     await expect(
@@ -429,7 +434,7 @@ describe("local agent runner", () => {
     const generateReply = vi.fn<typeof generateAssistantReply>(
       async (_text, context) => {
         contexts.push(context);
-        return successReply("uses projection");
+        return completedAgentRun(successReply("uses projection"));
       },
     );
 
@@ -465,9 +470,11 @@ describe("local agent runner", () => {
       },
     ] as PiMessage[];
     const generateReply = vi.fn<typeof generateAssistantReply>(async () =>
-      successReply("persisted visible output", {
-        piMessages: generatedMessages,
-      }),
+      completedAgentRun(
+        successReply("persisted visible output", {
+          piMessages: generatedMessages,
+        }),
+      ),
     );
 
     await runLocalAgentTurn(
@@ -498,7 +505,7 @@ describe("local agent runner", () => {
         deliverReply: async () => undefined,
         generateAssistantReply: async (_text, context) => {
           contexts.push(context);
-          return successReply("follow up reply");
+          return completedAgentRun(successReply("follow up reply"));
         },
       },
     );
@@ -559,9 +566,11 @@ describe("local agent runner", () => {
                 context,
                 generatedMessages,
               );
-              return successReply("visible reply", {
-                piMessages: generatedMessages,
-              });
+              return completedAgentRun(
+                successReply("visible reply", {
+                  piMessages: generatedMessages,
+                }),
+              );
             },
           },
         ),
@@ -618,7 +627,7 @@ describe("local agent runner", () => {
         deliverReply: async () => undefined,
         generateAssistantReply: async (_text, context) => {
           contexts.push(context);
-          return successReply("uses newer fallback");
+          return completedAgentRun(successReply("uses newer fallback"));
         },
       },
     );
@@ -652,7 +661,7 @@ describe("local agent runner", () => {
           messages: [assistantMessage],
           ttlMs: 60_000,
         });
-        return successReply("not delivered");
+        return completedAgentRun(successReply("not delivered"));
       },
     );
 

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -48,8 +48,21 @@ function successReply(
   };
 }
 
+function flattenReplyRequestForTest(request: ReplyRequestContext) {
+  return {
+    ...request.input,
+    ...request.routing,
+    ...(request.policy ?? {}),
+    ...(request.state ?? {}),
+    ...(request.observers ?? {}),
+    ...(request.durability ?? {}),
+  };
+}
+
+type FlatReplyRequestContext = ReturnType<typeof flattenReplyRequestForTest>;
+
 async function persistCompletedSessionForFakeReply(
-  context: ReplyRequestContext,
+  context: FlatReplyRequestContext,
   piMessages: PiMessage[],
 ): Promise<void> {
   const conversationId = context.correlation?.conversationId;
@@ -82,8 +95,10 @@ describe("local agent runner", () => {
     });
     expect(conversationId).toBeDefined();
 
-    const contexts: ReplyRequestContext[] = [];
-    const generateReply = vi.fn<AgentRunner["run"]>(async (_text, context) => {
+    const contexts: FlatReplyRequestContext[] = [];
+    const generateReply = vi.fn<AgentRunner["run"]>(async (request) => {
+      const context = flattenReplyRequestForTest(request);
+
       contexts.push(context);
       return completedAgentRun(successReply("hello from local"));
     });
@@ -103,17 +118,19 @@ describe("local agent runner", () => {
     );
 
     expect(generateReply).toHaveBeenCalledWith(
-      "hello",
       expect.objectContaining({
-        authorizationFlowMode: "disabled",
-        credentialContext: {
-          actor: { type: "system", id: "local-cli" },
-        },
-        destination: {
-          platform: "local",
-          conversationId,
-        },
-        surface: "internal",
+        input: expect.objectContaining({ messageText: "hello" }),
+        policy: expect.objectContaining({ authorizationFlowMode: "disabled" }),
+        routing: expect.objectContaining({
+          credentialContext: {
+            actor: { type: "system", id: "local-cli" },
+          },
+          destination: {
+            platform: "local",
+            conversationId,
+          },
+          surface: "internal",
+        }),
       }),
     );
     expect(contexts[0]?.requester).toEqual({
@@ -166,7 +183,9 @@ describe("local agent runner", () => {
     });
     expect(conversationId).toBeDefined();
 
-    const generateReply = vi.fn<AgentRunner["run"]>(async (_text, context) => {
+    const generateReply = vi.fn<AgentRunner["run"]>(async (request) => {
+      const context = flattenReplyRequestForTest(request);
+
       context.onToolInvocation?.({
         toolName: "createMemory",
         params: { content: "The requester prefers short updates." },
@@ -252,7 +271,9 @@ describe("local agent runner", () => {
         {
           deliverReply: async () => undefined,
           agentRunner: {
-            run: async (_text, context) => {
+            run: async (request) => {
+              const context = flattenReplyRequestForTest(request);
+
               const piMessages = [
                 {
                   role: "user",
@@ -317,8 +338,11 @@ describe("local agent runner", () => {
     });
     expect(conversationId).toBeDefined();
 
-    const contexts: ReplyRequestContext[] = [];
-    const generateReply = vi.fn<AgentRunner["run"]>(async (text, context) => {
+    const contexts: FlatReplyRequestContext[] = [];
+    const generateReply = vi.fn<AgentRunner["run"]>(async (request) => {
+      const text = request.input.messageText;
+      const context = flattenReplyRequestForTest(request);
+
       contexts.push(context);
       return completedAgentRun(successReply(`reply to ${text}`));
     });
@@ -423,8 +447,10 @@ describe("local agent runner", () => {
       ttlMs: 60_000,
     });
 
-    const contexts: ReplyRequestContext[] = [];
-    const generateReply = vi.fn<AgentRunner["run"]>(async (_text, context) => {
+    const contexts: FlatReplyRequestContext[] = [];
+    const generateReply = vi.fn<AgentRunner["run"]>(async (request) => {
+      const context = flattenReplyRequestForTest(request);
+
       contexts.push(context);
       return completedAgentRun(successReply("uses projection"));
     });
@@ -486,7 +512,7 @@ describe("local agent runner", () => {
     const conversation = coerceThreadConversationState(state);
     expect(conversation.piMessages).toEqual(generatedMessages);
 
-    const contexts: ReplyRequestContext[] = [];
+    const contexts: FlatReplyRequestContext[] = [];
     await runLocalAgentTurn(
       {
         conversationId: conversationId!,
@@ -495,7 +521,9 @@ describe("local agent runner", () => {
       {
         deliverReply: async () => undefined,
         agentRunner: {
-          run: async (_text, context) => {
+          run: async (request) => {
+            const context = flattenReplyRequestForTest(request);
+
             contexts.push(context);
             return completedAgentRun(successReply("follow up reply"));
           },
@@ -555,7 +583,9 @@ describe("local agent runner", () => {
               delivered.push(reply);
             },
             agentRunner: {
-              run: async (_text, context) => {
+              run: async (request) => {
+                const context = flattenReplyRequestForTest(request);
+
                 await persistCompletedSessionForFakeReply(
                   context,
                   generatedMessages,
@@ -612,7 +642,7 @@ describe("local agent runner", () => {
     conversation.piMessages = newerMessages;
     await persistThreadStateById(conversationId!, { conversation });
 
-    const contexts: ReplyRequestContext[] = [];
+    const contexts: FlatReplyRequestContext[] = [];
     await runLocalAgentTurn(
       {
         conversationId: conversationId!,
@@ -621,7 +651,9 @@ describe("local agent runner", () => {
       {
         deliverReply: async () => undefined,
         agentRunner: {
-          run: async (_text, context) => {
+          run: async (request) => {
+            const context = flattenReplyRequestForTest(request);
+
             contexts.push(context);
             return completedAgentRun(successReply("uses newer fallback"));
           },
@@ -643,7 +675,9 @@ describe("local agent runner", () => {
       role: "assistant",
       content: [{ type: "text", text: "undelivered pi output" }],
     } as PiMessage;
-    const generateReply = vi.fn<AgentRunner["run"]>(async (_text, context) => {
+    const generateReply = vi.fn<AgentRunner["run"]>(async (request) => {
+      const context = flattenReplyRequestForTest(request);
+
       await context.onArtifactStateUpdated?.({
         lastCanvasId: "canvas-undelivered",
         lastCanvasUrl: "https://example.invalid/canvas",

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import type { AssistantReply, ReplyRequestContext } from "@/chat/respond";
+import type { AgentRunRequest } from "@/chat/agent-run";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 import {
   defineJuniorPlugin,
   type PluginRunContext,
@@ -28,11 +29,11 @@ import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 function successReply(
   text: string,
   options: Partial<
-    Pick<AssistantReply, "piMessages"> & {
+    Pick<AgentRunResult, "piMessages"> & {
       toolCalls: string[];
     }
   > = {},
-): AssistantReply {
+): AgentRunResult {
   return {
     text,
     ...(options.piMessages ? { piMessages: options.piMessages } : {}),
@@ -48,7 +49,7 @@ function successReply(
   };
 }
 
-function flattenReplyRequestForTest(request: ReplyRequestContext) {
+function flattenAgentRunRequestForTest(request: AgentRunRequest) {
   return {
     ...request.input,
     ...request.routing,
@@ -59,10 +60,10 @@ function flattenReplyRequestForTest(request: ReplyRequestContext) {
   };
 }
 
-type FlatReplyRequestContext = ReturnType<typeof flattenReplyRequestForTest>;
+type FlatAgentRunRequest = ReturnType<typeof flattenAgentRunRequestForTest>;
 
 async function persistCompletedSessionForFakeReply(
-  context: FlatReplyRequestContext,
+  context: FlatAgentRunRequest,
   piMessages: PiMessage[],
 ): Promise<void> {
   const conversationId = context.correlation?.conversationId;
@@ -95,9 +96,9 @@ describe("local agent runner", () => {
     });
     expect(conversationId).toBeDefined();
 
-    const contexts: FlatReplyRequestContext[] = [];
+    const contexts: FlatAgentRunRequest[] = [];
     const generateReply = vi.fn<AgentRunner["run"]>(async (request) => {
-      const context = flattenReplyRequestForTest(request);
+      const context = flattenAgentRunRequestForTest(request);
 
       contexts.push(context);
       return completedAgentRun(successReply("hello from local"));
@@ -176,7 +177,7 @@ describe("local agent runner", () => {
     });
   });
 
-  it("forwards tool events from the shared reply boundary", async () => {
+  it("forwards tool events from the shared agent-run boundary", async () => {
     const conversationId = normalizeLocalConversationId({
       alias: "tools",
       cwd: "/tmp/local-agent-runner-tools",
@@ -184,7 +185,7 @@ describe("local agent runner", () => {
     expect(conversationId).toBeDefined();
 
     const generateReply = vi.fn<AgentRunner["run"]>(async (request) => {
-      const context = flattenReplyRequestForTest(request);
+      const context = flattenAgentRunRequestForTest(request);
 
       context.onToolInvocation?.({
         toolName: "createMemory",
@@ -272,7 +273,7 @@ describe("local agent runner", () => {
           deliverReply: async () => undefined,
           agentRunner: {
             run: async (request) => {
-              const context = flattenReplyRequestForTest(request);
+              const context = flattenAgentRunRequestForTest(request);
 
               const piMessages = [
                 {
@@ -338,10 +339,10 @@ describe("local agent runner", () => {
     });
     expect(conversationId).toBeDefined();
 
-    const contexts: FlatReplyRequestContext[] = [];
+    const contexts: FlatAgentRunRequest[] = [];
     const generateReply = vi.fn<AgentRunner["run"]>(async (request) => {
       const text = request.input.messageText;
-      const context = flattenReplyRequestForTest(request);
+      const context = flattenAgentRunRequestForTest(request);
 
       contexts.push(context);
       return completedAgentRun(successReply(`reply to ${text}`));
@@ -447,9 +448,9 @@ describe("local agent runner", () => {
       ttlMs: 60_000,
     });
 
-    const contexts: FlatReplyRequestContext[] = [];
+    const contexts: FlatAgentRunRequest[] = [];
     const generateReply = vi.fn<AgentRunner["run"]>(async (request) => {
-      const context = flattenReplyRequestForTest(request);
+      const context = flattenAgentRunRequestForTest(request);
 
       contexts.push(context);
       return completedAgentRun(successReply("uses projection"));
@@ -512,7 +513,7 @@ describe("local agent runner", () => {
     const conversation = coerceThreadConversationState(state);
     expect(conversation.piMessages).toEqual(generatedMessages);
 
-    const contexts: FlatReplyRequestContext[] = [];
+    const contexts: FlatAgentRunRequest[] = [];
     await runLocalAgentTurn(
       {
         conversationId: conversationId!,
@@ -522,7 +523,7 @@ describe("local agent runner", () => {
         deliverReply: async () => undefined,
         agentRunner: {
           run: async (request) => {
-            const context = flattenReplyRequestForTest(request);
+            const context = flattenAgentRunRequestForTest(request);
 
             contexts.push(context);
             return completedAgentRun(successReply("follow up reply"));
@@ -584,7 +585,7 @@ describe("local agent runner", () => {
             },
             agentRunner: {
               run: async (request) => {
-                const context = flattenReplyRequestForTest(request);
+                const context = flattenAgentRunRequestForTest(request);
 
                 await persistCompletedSessionForFakeReply(
                   context,
@@ -642,7 +643,7 @@ describe("local agent runner", () => {
     conversation.piMessages = newerMessages;
     await persistThreadStateById(conversationId!, { conversation });
 
-    const contexts: FlatReplyRequestContext[] = [];
+    const contexts: FlatAgentRunRequest[] = [];
     await runLocalAgentTurn(
       {
         conversationId: conversationId!,
@@ -652,7 +653,7 @@ describe("local agent runner", () => {
         deliverReply: async () => undefined,
         agentRunner: {
           run: async (request) => {
-            const context = flattenReplyRequestForTest(request);
+            const context = flattenAgentRunRequestForTest(request);
 
             contexts.push(context);
             return completedAgentRun(successReply("uses newer fallback"));
@@ -676,7 +677,7 @@ describe("local agent runner", () => {
       content: [{ type: "text", text: "undelivered pi output" }],
     } as PiMessage;
     const generateReply = vi.fn<AgentRunner["run"]>(async (request) => {
-      const context = flattenReplyRequestForTest(request);
+      const context = flattenAgentRunRequestForTest(request);
 
       await context.onArtifactStateUpdated?.({
         lastCanvasId: "canvas-undelivered",

--- a/packages/junior/tests/integration/local-chat-cli.test.ts
+++ b/packages/junior/tests/integration/local-chat-cli.test.ts
@@ -2,13 +2,13 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AssistantReply } from "@/chat/respond";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
-const generateAssistantReplyMock = vi.hoisted(() => vi.fn());
+const executeAgentRunMock = vi.hoisted(() => vi.fn());
 
-vi.mock("@/chat/respond", () => ({
-  generateAssistantReply: generateAssistantReplyMock,
+vi.mock("@/chat/agent-run", () => ({
+  executeAgentRun: executeAgentRunMock,
 }));
 
 const ORIGINAL_CWD = process.cwd();
@@ -23,7 +23,7 @@ function restoreEnv(name: string, value: string | undefined): void {
   process.env[name] = value;
 }
 
-function successReply(text: string): AssistantReply {
+function successReply(text: string): AgentRunResult {
   return {
     text,
     diagnostics: {
@@ -41,7 +41,7 @@ function successReply(text: string): AssistantReply {
 describe("local chat CLI integration", () => {
   beforeEach(() => {
     vi.resetModules();
-    generateAssistantReplyMock.mockReset();
+    executeAgentRunMock.mockReset();
   });
 
   afterEach(async () => {
@@ -76,7 +76,7 @@ export const plugins = {
 `,
     );
     process.chdir(tempDir);
-    generateAssistantReplyMock.mockResolvedValue(
+    executeAgentRunMock.mockResolvedValue(
       completedAgentRun(successReply("hello local")),
     );
     const output: string[] = [];
@@ -103,7 +103,7 @@ export const plugins = {
           .getProviders()
           .map((plugin) => plugin.manifest.name),
       ).toContain("local-chat-plugin");
-      expect(generateAssistantReplyMock).toHaveBeenCalledWith(
+      expect(executeAgentRunMock).toHaveBeenCalledWith(
         expect.objectContaining({
           input: expect.objectContaining({ messageText: "hello" }),
           policy: expect.objectContaining({

--- a/packages/junior/tests/integration/local-chat-cli.test.ts
+++ b/packages/junior/tests/integration/local-chat-cli.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AssistantReply } from "@/chat/respond";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const generateAssistantReplyMock = vi.hoisted(() => vi.fn());
 
@@ -75,7 +76,9 @@ export const plugins = {
 `,
     );
     process.chdir(tempDir);
-    generateAssistantReplyMock.mockResolvedValue(successReply("hello local"));
+    generateAssistantReplyMock.mockResolvedValue(
+      completedAgentRun(successReply("hello local")),
+    );
     const output: string[] = [];
 
     try {

--- a/packages/junior/tests/integration/local-chat-cli.test.ts
+++ b/packages/junior/tests/integration/local-chat-cli.test.ts
@@ -104,10 +104,14 @@ export const plugins = {
           .map((plugin) => plugin.manifest.name),
       ).toContain("local-chat-plugin");
       expect(generateAssistantReplyMock).toHaveBeenCalledWith(
-        "hello",
         expect.objectContaining({
-          authorizationFlowMode: "disabled",
-          destination: expect.objectContaining({ platform: "local" }),
+          input: expect.objectContaining({ messageText: "hello" }),
+          policy: expect.objectContaining({
+            authorizationFlowMode: "disabled",
+          }),
+          routing: expect.objectContaining({
+            destination: expect.objectContaining({ platform: "local" }),
+          }),
         }),
       );
       expect(output).toEqual(["hello local\n"]);

--- a/packages/junior/tests/integration/mcp-oauth-callback-slack.test.ts
+++ b/packages/junior/tests/integration/mcp-oauth-callback-slack.test.ts
@@ -18,6 +18,7 @@ import {
   createPluginAppFixture,
   type PluginAppFixture,
 } from "../fixtures/plugin-app";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const { generateAssistantReplyMock } = vi.hoisted(() => ({
   generateAssistantReplyMock: vi.fn(),
@@ -46,6 +47,18 @@ function slackSource(threadTs: string) {
 
     type: "priv",
   });
+}
+
+function makeDiagnostics() {
+  return {
+    assistantMessageCount: 1,
+    modelId: "fake-mcp-oauth-callback",
+    outcome: "success" as const,
+    toolCalls: [],
+    toolErrorCount: 0,
+    toolResultCount: 0,
+    usedPrimaryText: true,
+  };
 }
 
 type ArtifactStateModule = typeof import("@/chat/state/artifacts");
@@ -145,18 +158,17 @@ async function createAwaitingMcpTurnRecord(args: {
 describe("mcp oauth callback slack integration", () => {
   beforeEach(async () => {
     generateAssistantReplyMock.mockReset();
-    generateAssistantReplyMock.mockResolvedValue({
-      text: "The budget deadline you mentioned earlier was Friday.",
-      artifactStatePatch: {
-        lastCanvasUrl: "https://example.com/canvas",
-      },
-      sandboxId: "sandbox-1",
-      sandboxDependencyProfileHash: "hash-1",
-      diagnostics: {
-        outcome: "success",
-        toolCalls: [],
-      },
-    });
+    generateAssistantReplyMock.mockResolvedValue(
+      completedAgentRun({
+        text: "The budget deadline you mentioned earlier was Friday.",
+        artifactStatePatch: {
+          lastCanvasUrl: "https://example.com/canvas",
+        },
+        sandboxId: "sandbox-1",
+        sandboxDependencyProfileHash: "hash-1",
+        diagnostics: makeDiagnostics(),
+      }),
+    );
     resetSlackApiMockState();
     process.env = {
       ...ORIGINAL_ENV,
@@ -894,24 +906,23 @@ describe("mcp oauth callback slack integration", () => {
   });
 
   it("uploads resumed reply files without posting an extra thread message for empty inline text", async () => {
-    generateAssistantReplyMock.mockResolvedValueOnce({
-      text: "",
-      files: [
-        {
-          data: Buffer.from("hello"),
-          filename: "resume.txt",
+    generateAssistantReplyMock.mockResolvedValueOnce(
+      completedAgentRun({
+        text: "",
+        files: [
+          {
+            data: Buffer.from("hello"),
+            filename: "resume.txt",
+          },
+        ],
+        deliveryPlan: {
+          mode: "thread",
+          postThreadText: true,
+          attachFiles: "inline",
         },
-      ],
-      deliveryPlan: {
-        mode: "thread",
-        postThreadText: true,
-        attachFiles: "inline",
-      },
-      diagnostics: {
-        outcome: "success",
-        toolCalls: [],
-      },
-    });
+        diagnostics: makeDiagnostics(),
+      }),
+    );
     await stateAdapterModule
       .getStateAdapter()
       .set("thread-state:slack:C123:1700000000.002", {
@@ -980,24 +991,23 @@ describe("mcp oauth callback slack integration", () => {
   });
 
   it("uploads resumed reply files even when thread text delivery is suppressed", async () => {
-    generateAssistantReplyMock.mockResolvedValueOnce({
-      text: "👍",
-      files: [
-        {
-          data: Buffer.from("hello"),
-          filename: "resume.txt",
+    generateAssistantReplyMock.mockResolvedValueOnce(
+      completedAgentRun({
+        text: "👍",
+        files: [
+          {
+            data: Buffer.from("hello"),
+            filename: "resume.txt",
+          },
+        ],
+        deliveryPlan: {
+          mode: "thread",
+          postThreadText: false,
+          attachFiles: "inline",
         },
-      ],
-      deliveryPlan: {
-        mode: "thread",
-        postThreadText: false,
-        attachFiles: "inline",
-      },
-      diagnostics: {
-        outcome: "success",
-        toolCalls: [],
-      },
-    });
+        diagnostics: makeDiagnostics(),
+      }),
+    );
     await stateAdapterModule
       .getStateAdapter()
       .set("thread-state:slack:C123:1700000000.003", {

--- a/packages/junior/tests/integration/mcp-oauth-callback-slack.test.ts
+++ b/packages/junior/tests/integration/mcp-oauth-callback-slack.test.ts
@@ -20,12 +20,12 @@ import {
 } from "../fixtures/plugin-app";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
-const { generateAssistantReplyMock } = vi.hoisted(() => ({
-  generateAssistantReplyMock: vi.fn(),
+const { executeAgentRunMock } = vi.hoisted(() => ({
+  executeAgentRunMock: vi.fn(),
 }));
 
-vi.mock("@/chat/respond", () => ({
-  generateAssistantReply: generateAssistantReplyMock,
+vi.mock("@/chat/agent-run", () => ({
+  executeAgentRun: executeAgentRunMock,
 }));
 
 const ORIGINAL_ENV = { ...process.env };
@@ -157,8 +157,8 @@ async function createAwaitingMcpTurnRecord(args: {
 
 describe("mcp oauth callback slack integration", () => {
   beforeEach(async () => {
-    generateAssistantReplyMock.mockReset();
-    generateAssistantReplyMock.mockResolvedValue(
+    executeAgentRunMock.mockReset();
+    executeAgentRunMock.mockResolvedValue(
       completedAgentRun({
         text: "The budget deadline you mentioned earlier was Friday.",
         artifactStatePatch: {
@@ -371,7 +371,7 @@ describe("mcp oauth callback slack integration", () => {
       refresh_token: "eval-auth-refresh-token",
     });
 
-    expect(generateAssistantReplyMock).toHaveBeenCalledWith(
+    expect(executeAgentRunMock).toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({
           messageText: "what did i say about the budget?",
@@ -403,7 +403,7 @@ describe("mcp oauth callback slack integration", () => {
       }),
     );
 
-    const resumeContext = generateAssistantReplyMock.mock.calls[0]?.[0] as {
+    const resumeContext = executeAgentRunMock.mock.calls[0]?.[0] as {
       input?: { conversationContext?: string };
       policy?: { configuration?: Record<string, unknown> };
       routing?: { source?: unknown };
@@ -526,7 +526,7 @@ describe("mcp oauth callback slack integration", () => {
       });
 
     expect(response.status).toBe(200);
-    expect(generateAssistantReplyMock).not.toHaveBeenCalled();
+    expect(executeAgentRunMock).not.toHaveBeenCalled();
     await expect(
       turnSessionStoreModule.getAgentTurnSessionRecord(threadId, sessionId),
     ).resolves.toMatchObject({
@@ -666,7 +666,7 @@ describe("mcp oauth callback slack integration", () => {
       getSpy.mockRestore();
     }
 
-    expect(generateAssistantReplyMock).toHaveBeenCalledWith(
+    expect(executeAgentRunMock).toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({
           messageText: "what did i say about the budget?",
@@ -680,7 +680,7 @@ describe("mcp oauth callback slack integration", () => {
         }),
       }),
     );
-    const resumeContext = generateAssistantReplyMock.mock.calls[0]?.[0] as {
+    const resumeContext = executeAgentRunMock.mock.calls[0]?.[0] as {
       input?: { conversationContext?: string };
       routing?: { source?: unknown };
     };
@@ -774,7 +774,7 @@ describe("mcp oauth callback slack integration", () => {
       });
 
     expect(response.status).toBe(200);
-    expect(generateAssistantReplyMock).not.toHaveBeenCalled();
+    expect(executeAgentRunMock).not.toHaveBeenCalled();
     expect(getCapturedSlackApiCalls("chat.postMessage")).toHaveLength(0);
 
     const persistedState = await stateAdapterModule
@@ -839,7 +839,7 @@ describe("mcp oauth callback slack integration", () => {
       });
 
     expect(response.status).toBe(200);
-    expect(generateAssistantReplyMock).not.toHaveBeenCalled();
+    expect(executeAgentRunMock).not.toHaveBeenCalled();
     expect(getCapturedSlackApiCalls("chat.postMessage")).toHaveLength(0);
   });
 
@@ -903,7 +903,7 @@ describe("mcp oauth callback slack integration", () => {
       });
 
     expect(response.status).toBe(200);
-    expect(generateAssistantReplyMock).not.toHaveBeenCalled();
+    expect(executeAgentRunMock).not.toHaveBeenCalled();
     expect(getCapturedSlackApiCalls("chat.postMessage")).toHaveLength(0);
     await expect(
       turnSessionStoreModule.getAgentTurnSessionRecord(
@@ -918,7 +918,7 @@ describe("mcp oauth callback slack integration", () => {
   });
 
   it("uploads resumed reply files without posting an extra thread message for empty inline text", async () => {
-    generateAssistantReplyMock.mockResolvedValueOnce(
+    executeAgentRunMock.mockResolvedValueOnce(
       completedAgentRun({
         text: "",
         files: [
@@ -1003,7 +1003,7 @@ describe("mcp oauth callback slack integration", () => {
   });
 
   it("uploads resumed reply files even when thread text delivery is suppressed", async () => {
-    generateAssistantReplyMock.mockResolvedValueOnce(
+    executeAgentRunMock.mockResolvedValueOnce(
       completedAgentRun({
         text: "👍",
         files: [

--- a/packages/junior/tests/integration/mcp-oauth-callback-slack.test.ts
+++ b/packages/junior/tests/integration/mcp-oauth-callback-slack.test.ts
@@ -372,40 +372,46 @@ describe("mcp oauth callback slack integration", () => {
     });
 
     expect(generateAssistantReplyMock).toHaveBeenCalledWith(
-      "what did i say about the budget?",
       expect.objectContaining({
-        requester: expect.objectContaining({
-          email: "stored@example.com",
-          fullName: "Stored User",
-          platform: "slack",
-          teamId: "T123",
-          userId: "U123",
-          userName: "stored-user",
+        input: expect.objectContaining({
+          messageText: "what did i say about the budget?",
+          inboundAttachmentCount: 1,
+          omittedImageAttachmentCount: 1,
+          conversationContext: expect.stringContaining(
+            "You need the budget by Friday.",
+          ),
         }),
-        destination: SLACK_DESTINATION,
-        source: storedSource,
-        toolChannelId: "C999",
-        inboundAttachmentCount: 1,
-        omittedImageAttachmentCount: 1,
-        artifactState: expect.objectContaining({
-          assistantContextChannelId: "C999",
-          lastCanvasId: "F123",
+        routing: expect.objectContaining({
+          requester: expect.objectContaining({
+            email: "stored@example.com",
+            fullName: "Stored User",
+            platform: "slack",
+            teamId: "T123",
+            userId: "U123",
+            userName: "stored-user",
+          }),
+          destination: SLACK_DESTINATION,
+          source: storedSource,
+          toolChannelId: "C999",
         }),
-        conversationContext: expect.stringContaining(
-          "You need the budget by Friday.",
-        ),
+        state: expect.objectContaining({
+          artifactState: expect.objectContaining({
+            assistantContextChannelId: "C999",
+            lastCanvasId: "F123",
+          }),
+        }),
       }),
     );
 
-    const resumeContext = generateAssistantReplyMock.mock.calls[0]?.[1] as {
-      conversationContext?: string;
-      configuration?: Record<string, unknown>;
-      source?: unknown;
+    const resumeContext = generateAssistantReplyMock.mock.calls[0]?.[0] as {
+      input?: { conversationContext?: string };
+      policy?: { configuration?: Record<string, unknown> };
+      routing?: { source?: unknown };
     };
-    expect(resumeContext.conversationContext).not.toContain(
+    expect(resumeContext.input?.conversationContext).not.toContain(
       "what did i say about the budget?",
     );
-    expect(resumeContext.configuration?.region).toBe("us");
+    expect(resumeContext.policy?.configuration?.region).toBe("us");
 
     const persistedState = await stateAdapterModule
       .getStateAdapter()
@@ -661,21 +667,27 @@ describe("mcp oauth callback slack integration", () => {
     }
 
     expect(generateAssistantReplyMock).toHaveBeenCalledWith(
-      "what did i say about the budget?",
       expect.objectContaining({
-        destination: SLACK_DESTINATION,
-        toolChannelId: "CFRESH",
-        conversationContext: expect.stringContaining(
-          "Fresh MCP context loaded after the lock.",
-        ),
+        input: expect.objectContaining({
+          messageText: "what did i say about the budget?",
+          conversationContext: expect.stringContaining(
+            "Fresh MCP context loaded after the lock.",
+          ),
+        }),
+        routing: expect.objectContaining({
+          destination: SLACK_DESTINATION,
+          toolChannelId: "CFRESH",
+        }),
       }),
     );
-    const resumeContext = generateAssistantReplyMock.mock.calls[0]?.[1] as {
-      conversationContext?: string;
-      source?: unknown;
+    const resumeContext = generateAssistantReplyMock.mock.calls[0]?.[0] as {
+      input?: { conversationContext?: string };
+      routing?: { source?: unknown };
     };
-    expect(resumeContext.source).toEqual(slackSource("1700000000.005"));
-    expect(resumeContext.conversationContext).not.toContain(
+    expect(resumeContext.routing?.source).toEqual(
+      slackSource("1700000000.005"),
+    );
+    expect(resumeContext.input?.conversationContext).not.toContain(
       "Old MCP context that should not be used.",
     );
     expect(getCapturedSlackApiCalls("reactions.add")).toEqual([

--- a/packages/junior/tests/integration/oauth-callback-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-callback-slack.test.ts
@@ -9,6 +9,7 @@ import {
   createPluginAppFixture,
   type PluginAppFixture,
 } from "../fixtures/plugin-app";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const { generateAssistantReplyMock } = vi.hoisted(() => ({
   generateAssistantReplyMock: vi.fn(),
@@ -39,6 +40,18 @@ function slackSource(threadTs: string) {
   });
 }
 
+function makeDiagnostics() {
+  return {
+    assistantMessageCount: 1,
+    modelId: "fake-oauth-callback",
+    outcome: "success" as const,
+    toolCalls: [],
+    toolErrorCount: 0,
+    toolResultCount: 0,
+    usedPrimaryText: true,
+  };
+}
+
 type StateAdapterModule = typeof import("@/chat/state/adapter");
 type OAuthCallbackHarnessModule =
   typeof import("../fixtures/oauth-callback-harness");
@@ -52,13 +65,12 @@ let pluginApp: PluginAppFixture | undefined;
 describe("oauth callback slack integration", () => {
   beforeEach(async () => {
     generateAssistantReplyMock.mockReset();
-    generateAssistantReplyMock.mockResolvedValue({
-      text: "Here are your Sentry issues.",
-      diagnostics: {
-        outcome: "success",
-        toolCalls: [],
-      },
-    });
+    generateAssistantReplyMock.mockResolvedValue(
+      completedAgentRun({
+        text: "Here are your Sentry issues.",
+        diagnostics: makeDiagnostics(),
+      }),
+    );
     resetSlackApiMockState();
     process.env = {
       ...ORIGINAL_ENV,

--- a/packages/junior/tests/integration/oauth-callback-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-callback-slack.test.ts
@@ -11,12 +11,12 @@ import {
 } from "../fixtures/plugin-app";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
-const { generateAssistantReplyMock } = vi.hoisted(() => ({
-  generateAssistantReplyMock: vi.fn(),
+const { executeAgentRunMock } = vi.hoisted(() => ({
+  executeAgentRunMock: vi.fn(),
 }));
 
-vi.mock("@/chat/respond", () => ({
-  generateAssistantReply: generateAssistantReplyMock,
+vi.mock("@/chat/agent-run", () => ({
+  executeAgentRun: executeAgentRunMock,
 }));
 
 const ORIGINAL_ENV = { ...process.env };
@@ -64,8 +64,8 @@ let pluginApp: PluginAppFixture | undefined;
 
 describe("oauth callback slack integration", () => {
   beforeEach(async () => {
-    generateAssistantReplyMock.mockReset();
-    generateAssistantReplyMock.mockResolvedValue(
+    executeAgentRunMock.mockReset();
+    executeAgentRunMock.mockResolvedValue(
       completedAgentRun({
         text: "Here are your Sentry issues.",
         diagnostics: makeDiagnostics(),
@@ -177,7 +177,7 @@ describe("oauth callback slack integration", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(generateAssistantReplyMock).toHaveBeenCalledWith(
+    expect(executeAgentRunMock).toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({
           messageText: "list my sentry issues",
@@ -191,7 +191,7 @@ describe("oauth callback slack integration", () => {
         }),
       }),
     );
-    const resumeContext = generateAssistantReplyMock.mock.calls[0]?.[0] as {
+    const resumeContext = executeAgentRunMock.mock.calls[0]?.[0] as {
       input?: { conversationContext?: string };
     };
     expect(resumeContext.input?.conversationContext).not.toContain(
@@ -366,7 +366,7 @@ describe("oauth callback slack integration", () => {
         }),
       ]),
     );
-    expect(generateAssistantReplyMock).toHaveBeenCalledWith(
+    expect(executeAgentRunMock).toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({
           messageText: "list my sentry issues",
@@ -394,7 +394,7 @@ describe("oauth callback slack integration", () => {
         }),
       }),
     );
-    const resumeContext = generateAssistantReplyMock.mock.calls[0]?.[0] as {
+    const resumeContext = executeAgentRunMock.mock.calls[0]?.[0] as {
       input?: { conversationContext?: string };
       routing?: { source?: unknown };
     };
@@ -527,7 +527,7 @@ describe("oauth callback slack integration", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(generateAssistantReplyMock).not.toHaveBeenCalled();
+    expect(executeAgentRunMock).not.toHaveBeenCalled();
     await expect(
       turnSessionStoreModule.getAgentTurnSessionRecord(
         conversationId,
@@ -680,7 +680,7 @@ describe("oauth callback slack integration", () => {
       getSpy.mockRestore();
     }
 
-    expect(generateAssistantReplyMock).toHaveBeenCalledWith(
+    expect(executeAgentRunMock).toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({
           messageText: "list my sentry issues",
@@ -694,7 +694,7 @@ describe("oauth callback slack integration", () => {
         }),
       }),
     );
-    const resumeContext = generateAssistantReplyMock.mock.calls[0]?.[0] as {
+    const resumeContext = executeAgentRunMock.mock.calls[0]?.[0] as {
       input?: { conversationContext?: string };
     };
     expect(resumeContext.input?.conversationContext).not.toContain(
@@ -818,7 +818,7 @@ describe("oauth callback slack integration", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(generateAssistantReplyMock).toHaveBeenCalledWith(
+    expect(executeAgentRunMock).toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({ messageText: "new request" }),
         routing: expect.objectContaining({
@@ -879,7 +879,7 @@ describe("oauth callback slack integration", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(generateAssistantReplyMock).not.toHaveBeenCalled();
+    expect(executeAgentRunMock).not.toHaveBeenCalled();
     expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([]);
   });
 });

--- a/packages/junior/tests/integration/oauth-callback-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-callback-slack.test.ts
@@ -178,19 +178,23 @@ describe("oauth callback slack integration", () => {
 
     expect(response.status).toBe(200);
     expect(generateAssistantReplyMock).toHaveBeenCalledWith(
-      "list my sentry issues",
       expect.objectContaining({
-        destination: SLACK_DESTINATION,
-        source: storedSource,
-        conversationContext: expect.stringContaining(
-          "You need the budget by Friday.",
-        ),
+        input: expect.objectContaining({
+          messageText: "list my sentry issues",
+          conversationContext: expect.stringContaining(
+            "You need the budget by Friday.",
+          ),
+        }),
+        routing: expect.objectContaining({
+          destination: SLACK_DESTINATION,
+          source: storedSource,
+        }),
       }),
     );
-    const resumeContext = generateAssistantReplyMock.mock.calls[0]?.[1] as {
-      conversationContext?: string;
+    const resumeContext = generateAssistantReplyMock.mock.calls[0]?.[0] as {
+      input?: { conversationContext?: string };
     };
-    expect(resumeContext.conversationContext).not.toContain(
+    expect(resumeContext.input?.conversationContext).not.toContain(
       "list my sentry issues",
     );
 
@@ -363,38 +367,42 @@ describe("oauth callback slack integration", () => {
       ]),
     );
     expect(generateAssistantReplyMock).toHaveBeenCalledWith(
-      "list my sentry issues",
       expect.objectContaining({
-        requester: expect.objectContaining({
-          email: "stored@example.com",
-          fullName: "Stored User",
-          platform: "slack",
-          teamId: "T123",
-          userId: "U123",
-          userName: "stored-user",
+        input: expect.objectContaining({
+          messageText: "list my sentry issues",
+          conversationContext: expect.stringContaining(
+            "You need the budget by Friday.",
+          ),
         }),
-        destination: SLACK_DESTINATION,
-        source: storedSource,
-        correlation: expect.objectContaining({
-          channelId: "C123",
-          threadTs: "1700000000.009",
-          requesterId: "U123",
+        routing: expect.objectContaining({
+          requester: expect.objectContaining({
+            email: "stored@example.com",
+            fullName: "Stored User",
+            platform: "slack",
+            teamId: "T123",
+            userId: "U123",
+            userName: "stored-user",
+          }),
+          destination: SLACK_DESTINATION,
+          source: storedSource,
+          correlation: expect.objectContaining({
+            channelId: "C123",
+            threadTs: "1700000000.009",
+            requesterId: "U123",
+          }),
+          toolChannelId: "C999",
         }),
-        toolChannelId: "C999",
-        conversationContext: expect.stringContaining(
-          "You need the budget by Friday.",
-        ),
       }),
     );
-    const resumeContext = generateAssistantReplyMock.mock.calls[0]?.[1] as {
-      conversationContext?: string;
-      source?: unknown;
+    const resumeContext = generateAssistantReplyMock.mock.calls[0]?.[0] as {
+      input?: { conversationContext?: string };
+      routing?: { source?: unknown };
     };
-    expect(resumeContext.source).toEqual({
+    expect(resumeContext.routing?.source).toEqual({
       ...slackSource("1700000000.009"),
       messageTs: "1700000000.session-source",
     });
-    expect(resumeContext.conversationContext).not.toContain(
+    expect(resumeContext.input?.conversationContext).not.toContain(
       "list my sentry issues",
     );
 
@@ -673,19 +681,23 @@ describe("oauth callback slack integration", () => {
     }
 
     expect(generateAssistantReplyMock).toHaveBeenCalledWith(
-      "list my sentry issues",
       expect.objectContaining({
-        toolChannelId: "CFRESH",
-        destination: SLACK_DESTINATION,
-        conversationContext: expect.stringContaining(
-          "Fresh context loaded after the lock.",
-        ),
+        input: expect.objectContaining({
+          messageText: "list my sentry issues",
+          conversationContext: expect.stringContaining(
+            "Fresh context loaded after the lock.",
+          ),
+        }),
+        routing: expect.objectContaining({
+          toolChannelId: "CFRESH",
+          destination: SLACK_DESTINATION,
+        }),
       }),
     );
-    const resumeContext = generateAssistantReplyMock.mock.calls[0]?.[1] as {
-      conversationContext?: string;
+    const resumeContext = generateAssistantReplyMock.mock.calls[0]?.[0] as {
+      input?: { conversationContext?: string };
     };
-    expect(resumeContext.conversationContext).not.toContain(
+    expect(resumeContext.input?.conversationContext).not.toContain(
       "Old context that should not be used.",
     );
     expect(getCapturedSlackApiCalls("reactions.add")).toEqual([
@@ -807,10 +819,12 @@ describe("oauth callback slack integration", () => {
 
     expect(response.status).toBe(200);
     expect(generateAssistantReplyMock).toHaveBeenCalledWith(
-      "new request",
       expect.objectContaining({
-        correlation: expect.objectContaining({
-          turnId: newSessionId,
+        input: expect.objectContaining({ messageText: "new request" }),
+        routing: expect.objectContaining({
+          correlation: expect.objectContaining({
+            turnId: newSessionId,
+          }),
         }),
       }),
     );

--- a/packages/junior/tests/integration/oauth-resume-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-resume-slack.test.ts
@@ -85,16 +85,18 @@ describe("oauth resume slack integration", () => {
         source: testSlackSource("1700000000.001"),
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
-      generateReply: async () =>
-        completedAgentRun({
-          text: "The budget deadline you mentioned earlier was Friday.",
-          diagnostics: makeDiagnostics("success", {
-            durationMs: 842,
-            usage: {
-              totalTokens: 1234,
-            },
+      agentRunner: {
+        run: async () =>
+          completedAgentRun({
+            text: "The budget deadline you mentioned earlier was Friday.",
+            diagnostics: makeDiagnostics("success", {
+              durationMs: 842,
+              usage: {
+                totalTokens: 1234,
+              },
+            }),
           }),
-        }),
+      },
     });
 
     expect(getCapturedSlackApiCalls("assistant.threads.setStatus")).toEqual([
@@ -187,16 +189,18 @@ describe("oauth resume slack integration", () => {
           turnId: "turn-1",
         },
       },
-      generateReply: async () =>
-        completedAgentRun({
-          text: "done",
-          diagnostics: makeDiagnostics("success", {
-            durationMs: 500,
-            usage: {
-              outputTokens: 7,
-            },
+      agentRunner: {
+        run: async () =>
+          completedAgentRun({
+            text: "done",
+            diagnostics: makeDiagnostics("success", {
+              durationMs: 500,
+              usage: {
+                outputTokens: 7,
+              },
+            }),
           }),
-        }),
+      },
     });
 
     expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([
@@ -247,13 +251,15 @@ describe("oauth resume slack integration", () => {
           turnId: "turn-auth-pause",
         },
       },
-      generateReply: async () => {
-        throw new RetryableTurnError("mcp_auth_resume", "auth required", {
-          authDisposition: "link_sent",
-          authKind: "mcp",
-          authProvider: "eval-auth",
-          authProviderDisplayName: "Eval Auth",
-        });
+      agentRunner: {
+        run: async () => {
+          throw new RetryableTurnError("mcp_auth_resume", "auth required", {
+            authDisposition: "link_sent",
+            authKind: "mcp",
+            authProvider: "eval-auth",
+            authProviderDisplayName: "Eval Auth",
+          });
+        },
       },
       onAuthPause: async () => undefined,
     });
@@ -294,11 +300,13 @@ describe("oauth resume slack integration", () => {
         source: testSlackSource("1700000000.002"),
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
-      generateReply: async () =>
-        completedAgentRun({
-          text: longReply,
-          diagnostics: makeDiagnostics(),
-        }),
+      agentRunner: {
+        run: async () =>
+          completedAgentRun({
+            text: longReply,
+            diagnostics: makeDiagnostics(),
+          }),
+      },
     });
 
     const postCalls = getCapturedSlackApiCalls("chat.postMessage");
@@ -334,11 +342,13 @@ describe("oauth resume slack integration", () => {
         source: testSlackSource("1700000000.003"),
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
-      generateReply: async () =>
-        failedAgentRun({
-          text: "Partial output",
-          diagnostics: makeDiagnostics("provider_error"),
-        }),
+      agentRunner: {
+        run: async () =>
+          failedAgentRun({
+            text: "Partial output",
+            diagnostics: makeDiagnostics("provider_error"),
+          }),
+      },
     });
 
     const postCalls = getCapturedSlackApiCalls("chat.postMessage");
@@ -371,14 +381,16 @@ describe("oauth resume slack integration", () => {
         source: testSlackSource("1700000000.006"),
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
-      generateReply: async () =>
-        failedAgentRun({
-          text: "",
-          diagnostics: makeDiagnostics("execution_failure", {
-            assistantMessageCount: 0,
-            usedPrimaryText: false,
+      agentRunner: {
+        run: async () =>
+          failedAgentRun({
+            text: "",
+            diagnostics: makeDiagnostics("execution_failure", {
+              assistantMessageCount: 0,
+              usedPrimaryText: false,
+            }),
           }),
-        }),
+      },
     });
 
     const postCalls = getCapturedSlackApiCalls("chat.postMessage");
@@ -409,17 +421,19 @@ describe("oauth resume slack integration", () => {
         source: testSlackSource("1700000000.004"),
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
-      generateReply: async () =>
-        completedAgentRun({
-          text: "Here is the resumed artifact.",
-          files: [
-            {
-              data: Buffer.from("resume-file"),
-              filename: "resume.txt",
-            },
-          ],
-          diagnostics: makeDiagnostics(),
-        }),
+      agentRunner: {
+        run: async () =>
+          completedAgentRun({
+            text: "Here is the resumed artifact.",
+            files: [
+              {
+                data: Buffer.from("resume-file"),
+                filename: "resume.txt",
+              },
+            ],
+            diagnostics: makeDiagnostics(),
+          }),
+      },
     });
 
     const postCalls = getCapturedSlackApiCalls("chat.postMessage");
@@ -468,17 +482,19 @@ describe("oauth resume slack integration", () => {
         source: testSlackSource("1700000000.005"),
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
-      generateReply: async () =>
-        completedAgentRun({
-          text: "Here is the resumed artifact.",
-          files: [
-            {
-              data: Buffer.from("resume-file"),
-              filename: "resume.txt",
-            },
-          ],
-          diagnostics: makeDiagnostics(),
-        }),
+      agentRunner: {
+        run: async () =>
+          completedAgentRun({
+            text: "Here is the resumed artifact.",
+            files: [
+              {
+                data: Buffer.from("resume-file"),
+                filename: "resume.txt",
+              },
+            ],
+            diagnostics: makeDiagnostics(),
+          }),
+      },
     });
 
     expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([

--- a/packages/junior/tests/integration/oauth-resume-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-resume-slack.test.ts
@@ -78,12 +78,14 @@ describe("oauth resume slack integration", () => {
       connectedText:
         "Your eval-auth MCP access is now connected. Continuing the original request...",
       replyContext: {
-        credentialContext: {
-          actor: { type: "user", userId: "U123" },
+        routing: {
+          credentialContext: {
+            actor: { type: "user", userId: "U123" },
+          },
+          destination: TEST_SLACK_DESTINATION,
+          source: testSlackSource("1700000000.001"),
+          requester: { platform: "slack", teamId: "T123", userId: "U123" },
         },
-        destination: TEST_SLACK_DESTINATION,
-        source: testSlackSource("1700000000.001"),
-        requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       agentRunner: {
         run: async () =>
@@ -178,15 +180,17 @@ describe("oauth resume slack integration", () => {
       threadTs: "1700000000.007",
       connectedText: "",
       replyContext: {
-        credentialContext: {
-          actor: { type: "user", userId: "U123" },
-        },
-        destination: TEST_SLACK_DESTINATION,
-        source: testSlackSource("1700000000.007"),
-        requester: { platform: "slack", teamId: "T123", userId: "U123" },
-        correlation: {
-          conversationId: "conversation-1",
-          turnId: "turn-1",
+        routing: {
+          credentialContext: {
+            actor: { type: "user", userId: "U123" },
+          },
+          destination: TEST_SLACK_DESTINATION,
+          source: testSlackSource("1700000000.007"),
+          requester: { platform: "slack", teamId: "T123", userId: "U123" },
+          correlation: {
+            conversationId: "conversation-1",
+            turnId: "turn-1",
+          },
         },
       },
       agentRunner: {
@@ -240,15 +244,17 @@ describe("oauth resume slack integration", () => {
       threadTs: "1700000000.008",
       connectedText: "",
       replyContext: {
-        credentialContext: {
-          actor: { type: "user", userId: "U123" },
-        },
-        destination: TEST_SLACK_DESTINATION,
-        source: testSlackSource("1700000000.008"),
-        requester: { platform: "slack", teamId: "T123", userId: "U123" },
-        correlation: {
-          conversationId: "conversation-auth-pause",
-          turnId: "turn-auth-pause",
+        routing: {
+          credentialContext: {
+            actor: { type: "user", userId: "U123" },
+          },
+          destination: TEST_SLACK_DESTINATION,
+          source: testSlackSource("1700000000.008"),
+          requester: { platform: "slack", teamId: "T123", userId: "U123" },
+          correlation: {
+            conversationId: "conversation-auth-pause",
+            turnId: "turn-auth-pause",
+          },
         },
       },
       agentRunner: {
@@ -293,12 +299,14 @@ describe("oauth resume slack integration", () => {
       threadTs: "1700000000.002",
       connectedText: "Connected. Continuing...",
       replyContext: {
-        credentialContext: {
-          actor: { type: "user", userId: "U123" },
+        routing: {
+          credentialContext: {
+            actor: { type: "user", userId: "U123" },
+          },
+          destination: TEST_SLACK_DESTINATION,
+          source: testSlackSource("1700000000.002"),
+          requester: { platform: "slack", teamId: "T123", userId: "U123" },
         },
-        destination: TEST_SLACK_DESTINATION,
-        source: testSlackSource("1700000000.002"),
-        requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       agentRunner: {
         run: async () =>
@@ -335,12 +343,14 @@ describe("oauth resume slack integration", () => {
       threadTs: "1700000000.003",
       connectedText: "Connected. Continuing...",
       replyContext: {
-        credentialContext: {
-          actor: { type: "user", userId: "U123" },
+        routing: {
+          credentialContext: {
+            actor: { type: "user", userId: "U123" },
+          },
+          destination: TEST_SLACK_DESTINATION,
+          source: testSlackSource("1700000000.003"),
+          requester: { platform: "slack", teamId: "T123", userId: "U123" },
         },
-        destination: TEST_SLACK_DESTINATION,
-        source: testSlackSource("1700000000.003"),
-        requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       agentRunner: {
         run: async () =>
@@ -374,12 +384,14 @@ describe("oauth resume slack integration", () => {
       threadTs: "1700000000.006",
       connectedText: "Connected. Continuing...",
       replyContext: {
-        credentialContext: {
-          actor: { type: "user", userId: "U123" },
+        routing: {
+          credentialContext: {
+            actor: { type: "user", userId: "U123" },
+          },
+          destination: TEST_SLACK_DESTINATION,
+          source: testSlackSource("1700000000.006"),
+          requester: { platform: "slack", teamId: "T123", userId: "U123" },
         },
-        destination: TEST_SLACK_DESTINATION,
-        source: testSlackSource("1700000000.006"),
-        requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       agentRunner: {
         run: async () =>
@@ -414,12 +426,14 @@ describe("oauth resume slack integration", () => {
       threadTs: "1700000000.004",
       connectedText: "Connected. Continuing...",
       replyContext: {
-        credentialContext: {
-          actor: { type: "user", userId: "U123" },
+        routing: {
+          credentialContext: {
+            actor: { type: "user", userId: "U123" },
+          },
+          destination: TEST_SLACK_DESTINATION,
+          source: testSlackSource("1700000000.004"),
+          requester: { platform: "slack", teamId: "T123", userId: "U123" },
         },
-        destination: TEST_SLACK_DESTINATION,
-        source: testSlackSource("1700000000.004"),
-        requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       agentRunner: {
         run: async () =>
@@ -475,12 +489,14 @@ describe("oauth resume slack integration", () => {
       threadTs: "1700000000.005",
       connectedText: "Connected. Continuing...",
       replyContext: {
-        credentialContext: {
-          actor: { type: "user", userId: "U123" },
+        routing: {
+          credentialContext: {
+            actor: { type: "user", userId: "U123" },
+          },
+          destination: TEST_SLACK_DESTINATION,
+          source: testSlackSource("1700000000.005"),
+          requester: { platform: "slack", teamId: "T123", userId: "U123" },
         },
-        destination: TEST_SLACK_DESTINATION,
-        source: testSlackSource("1700000000.005"),
-        requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       agentRunner: {
         run: async () =>

--- a/packages/junior/tests/integration/oauth-resume-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-resume-slack.test.ts
@@ -11,6 +11,10 @@ import {
   getCapturedSlackFileUploadCalls,
   queueSlackApiError,
 } from "../msw/handlers/slack-api";
+import {
+  completedAgentRun,
+  failedAgentRun,
+} from "@/chat/runtime/agent-run-outcome";
 
 function makeDiagnostics(
   outcome: "success" | "execution_failure" | "provider_error" = "success",
@@ -82,7 +86,7 @@ describe("oauth resume slack integration", () => {
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       generateReply: async () =>
-        ({
+        completedAgentRun({
           text: "The budget deadline you mentioned earlier was Friday.",
           diagnostics: makeDiagnostics("success", {
             durationMs: 842,
@@ -90,7 +94,7 @@ describe("oauth resume slack integration", () => {
               totalTokens: 1234,
             },
           }),
-        }) as any,
+        }),
     });
 
     expect(getCapturedSlackApiCalls("assistant.threads.setStatus")).toEqual([
@@ -184,7 +188,7 @@ describe("oauth resume slack integration", () => {
         },
       },
       generateReply: async () =>
-        ({
+        completedAgentRun({
           text: "done",
           diagnostics: makeDiagnostics("success", {
             durationMs: 500,
@@ -192,7 +196,7 @@ describe("oauth resume slack integration", () => {
               outputTokens: 7,
             },
           }),
-        }) as any,
+        }),
     });
 
     expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([
@@ -291,10 +295,10 @@ describe("oauth resume slack integration", () => {
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       generateReply: async () =>
-        ({
+        completedAgentRun({
           text: longReply,
           diagnostics: makeDiagnostics(),
-        }) as any,
+        }),
     });
 
     const postCalls = getCapturedSlackApiCalls("chat.postMessage");
@@ -331,10 +335,10 @@ describe("oauth resume slack integration", () => {
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       generateReply: async () =>
-        ({
+        failedAgentRun({
           text: "Partial output",
           diagnostics: makeDiagnostics("provider_error"),
-        }) as any,
+        }),
     });
 
     const postCalls = getCapturedSlackApiCalls("chat.postMessage");
@@ -368,13 +372,13 @@ describe("oauth resume slack integration", () => {
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       generateReply: async () =>
-        ({
+        failedAgentRun({
           text: "",
           diagnostics: makeDiagnostics("execution_failure", {
             assistantMessageCount: 0,
             usedPrimaryText: false,
           }),
-        }) as any,
+        }),
     });
 
     const postCalls = getCapturedSlackApiCalls("chat.postMessage");
@@ -406,7 +410,7 @@ describe("oauth resume slack integration", () => {
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       generateReply: async () =>
-        ({
+        completedAgentRun({
           text: "Here is the resumed artifact.",
           files: [
             {
@@ -415,7 +419,7 @@ describe("oauth resume slack integration", () => {
             },
           ],
           diagnostics: makeDiagnostics(),
-        }) as any,
+        }),
     });
 
     const postCalls = getCapturedSlackApiCalls("chat.postMessage");
@@ -465,7 +469,7 @@ describe("oauth resume slack integration", () => {
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       generateReply: async () =>
-        ({
+        completedAgentRun({
           text: "Here is the resumed artifact.",
           files: [
             {
@@ -474,7 +478,7 @@ describe("oauth resume slack integration", () => {
             },
           ],
           diagnostics: makeDiagnostics(),
-        }) as any,
+        }),
     });
 
     expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([

--- a/packages/junior/tests/integration/plugin-prompt-hooks.test.ts
+++ b/packages/junior/tests/integration/plugin-prompt-hooks.test.ts
@@ -158,12 +158,15 @@ describe("plugin prompt hooks", () => {
   });
 
   it("renders prompt messages from plugin hooks", async () => {
-    await generateAssistantReply("hello", {
-      destination: LOCAL_DESTINATION,
-      source: LOCAL_SOURCE,
-      correlation: {
-        conversationId: "conversation-plugin-prompt-hooks",
-        turnId: "turn-plugin-prompt-hooks",
+    await generateAssistantReply({
+      input: { messageText: "hello" },
+      routing: {
+        destination: LOCAL_DESTINATION,
+        source: LOCAL_SOURCE,
+        correlation: {
+          conversationId: "conversation-plugin-prompt-hooks",
+          turnId: "turn-plugin-prompt-hooks",
+        },
       },
     });
 
@@ -174,32 +177,40 @@ describe("plugin prompt hooks", () => {
   });
 
   it("runs user prompt hooks for non-bootstrap follow-up prompts", async () => {
-    await generateAssistantReply("hello", {
-      destination: LOCAL_DESTINATION,
-      source: LOCAL_SOURCE,
-      correlation: {
-        conversationId: "conversation-plugin-prompt-follow-up",
-        turnId: "turn-plugin-prompt-follow-up-1",
+    await generateAssistantReply({
+      input: { messageText: "hello" },
+      routing: {
+        destination: LOCAL_DESTINATION,
+        source: LOCAL_SOURCE,
+        correlation: {
+          conversationId: "conversation-plugin-prompt-follow-up",
+          turnId: "turn-plugin-prompt-follow-up-1",
+        },
       },
     });
     const firstPromptMessage = captured.promptMessages[0];
     captured.promptMessages = [];
 
-    await generateAssistantReply("again", {
-      destination: LOCAL_DESTINATION,
-      source: LOCAL_SOURCE,
-      correlation: {
-        conversationId: "conversation-plugin-prompt-follow-up",
-        turnId: "turn-plugin-prompt-follow-up-2",
+    await generateAssistantReply({
+      input: {
+        messageText: "again",
+        piMessages: [
+          firstPromptMessage,
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "Done." }],
+            stopReason: "stop",
+          },
+        ] as never,
       },
-      piMessages: [
-        firstPromptMessage,
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "Done." }],
-          stopReason: "stop",
+      routing: {
+        destination: LOCAL_DESTINATION,
+        source: LOCAL_SOURCE,
+        correlation: {
+          conversationId: "conversation-plugin-prompt-follow-up",
+          turnId: "turn-plugin-prompt-follow-up-2",
         },
-      ] as never,
+      },
     });
 
     expect(captured.userPromptTexts).toEqual(["hello", "again"]);
@@ -209,16 +220,21 @@ describe("plugin prompt hooks", () => {
   });
 
   it("does not run user prompt hooks for steering messages", async () => {
-    await generateAssistantReply("hello", {
-      destination: LOCAL_DESTINATION,
-      source: LOCAL_SOURCE,
-      correlation: {
-        conversationId: "conversation-plugin-prompt-steering",
-        turnId: "turn-plugin-prompt-steering",
+    await generateAssistantReply({
+      input: { messageText: "hello" },
+      routing: {
+        destination: LOCAL_DESTINATION,
+        source: LOCAL_SOURCE,
+        correlation: {
+          conversationId: "conversation-plugin-prompt-steering",
+          turnId: "turn-plugin-prompt-steering",
+        },
       },
-      drainSteeringMessages: async (inject) => {
-        await inject([{ text: "steer me" }]);
-        return [];
+      durability: {
+        drainSteeringMessages: async (inject) => {
+          await inject([{ text: "steer me" }]);
+          return [];
+        },
       },
     });
 
@@ -242,12 +258,15 @@ describe("plugin prompt hooks", () => {
       errorMessage: "authorization required",
     });
 
-    await generateAssistantReply("resume me", {
-      destination: LOCAL_DESTINATION,
-      source: LOCAL_SOURCE,
-      correlation: {
-        conversationId: "conversation-plugin-prompt-resume-before-prompt",
-        turnId: "turn-plugin-prompt-resume-before-prompt",
+    await generateAssistantReply({
+      input: { messageText: "resume me" },
+      routing: {
+        destination: LOCAL_DESTINATION,
+        source: LOCAL_SOURCE,
+        correlation: {
+          conversationId: "conversation-plugin-prompt-resume-before-prompt",
+          turnId: "turn-plugin-prompt-resume-before-prompt",
+        },
       },
     });
 
@@ -275,12 +294,15 @@ describe("plugin prompt hooks", () => {
       errorMessage: "timed out",
     });
 
-    await generateAssistantReply("resume me", {
-      destination: LOCAL_DESTINATION,
-      source: LOCAL_SOURCE,
-      correlation: {
-        conversationId: "conversation-plugin-prompt-resume-after-prompt",
-        turnId: "turn-plugin-prompt-resume-after-prompt",
+    await generateAssistantReply({
+      input: { messageText: "resume me" },
+      routing: {
+        destination: LOCAL_DESTINATION,
+        source: LOCAL_SOURCE,
+        correlation: {
+          conversationId: "conversation-plugin-prompt-resume-after-prompt",
+          turnId: "turn-plugin-prompt-resume-after-prompt",
+        },
       },
     });
 

--- a/packages/junior/tests/integration/plugin-prompt-hooks.test.ts
+++ b/packages/junior/tests/integration/plugin-prompt-hooks.test.ts
@@ -101,7 +101,7 @@ vi.mock("@/chat/pi/client", () => ({
 }));
 
 import { defineJuniorPlugin } from "@sentry/junior-plugin-api";
-import { generateAssistantReply } from "@/chat/respond";
+import { executeAgentRun } from "@/chat/agent-run";
 import { setPlugins } from "@/chat/plugins/agent-hooks";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
 import { upsertAgentTurnSessionRecord } from "@/chat/state/turn-session";
@@ -158,7 +158,7 @@ describe("plugin prompt hooks", () => {
   });
 
   it("renders prompt messages from plugin hooks", async () => {
-    await generateAssistantReply({
+    await executeAgentRun({
       input: { messageText: "hello" },
       routing: {
         destination: LOCAL_DESTINATION,
@@ -177,7 +177,7 @@ describe("plugin prompt hooks", () => {
   });
 
   it("runs user prompt hooks for non-bootstrap follow-up prompts", async () => {
-    await generateAssistantReply({
+    await executeAgentRun({
       input: { messageText: "hello" },
       routing: {
         destination: LOCAL_DESTINATION,
@@ -191,7 +191,7 @@ describe("plugin prompt hooks", () => {
     const firstPromptMessage = captured.promptMessages[0];
     captured.promptMessages = [];
 
-    await generateAssistantReply({
+    await executeAgentRun({
       input: {
         messageText: "again",
         piMessages: [
@@ -220,7 +220,7 @@ describe("plugin prompt hooks", () => {
   });
 
   it("does not run user prompt hooks for steering messages", async () => {
-    await generateAssistantReply({
+    await executeAgentRun({
       input: { messageText: "hello" },
       routing: {
         destination: LOCAL_DESTINATION,
@@ -258,7 +258,7 @@ describe("plugin prompt hooks", () => {
       errorMessage: "authorization required",
     });
 
-    await generateAssistantReply({
+    await executeAgentRun({
       input: { messageText: "resume me" },
       routing: {
         destination: LOCAL_DESTINATION,
@@ -294,7 +294,7 @@ describe("plugin prompt hooks", () => {
       errorMessage: "timed out",
     });
 
-    await generateAssistantReply({
+    await executeAgentRun({
       input: { messageText: "resume me" },
       routing: {
         destination: LOCAL_DESTINATION,

--- a/packages/junior/tests/integration/slack/assistant-context-canvas-routing.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-context-canvas-routing.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createCanvas } from "@/chat/tools/slack/canvases";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import {
   canvasesAccessSetOk,
   canvasesCreateOk,
@@ -47,7 +48,7 @@ describe("Slack behavior: assistant context canvas routing", () => {
               markdown: "Context-aware update",
               channelId: context?.toolChannelId,
             });
-            return {
+            return completedAgentRun({
               text: "Shared canvas created.",
               diagnostics: {
                 assistantMessageCount: 1,
@@ -58,7 +59,7 @@ describe("Slack behavior: assistant context canvas routing", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },

--- a/packages/junior/tests/integration/slack/assistant-context-canvas-routing.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-context-canvas-routing.test.ts
@@ -42,24 +42,26 @@ describe("Slack behavior: assistant context canvas routing", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async (_prompt, context) => {
-            await createCanvas({
-              title: "Shared update",
-              markdown: "Context-aware update",
-              channelId: context?.toolChannelId,
-            });
-            return completedAgentRun({
-              text: "Shared canvas created.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            });
+          agentRunner: {
+            run: async (_prompt, context) => {
+              await createCanvas({
+                title: "Shared update",
+                markdown: "Context-aware update",
+                channelId: context?.toolChannelId,
+              });
+              return completedAgentRun({
+                text: "Shared canvas created.",
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "fake-agent-model",
+                  outcome: "success",
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              });
+            },
           },
         },
       },

--- a/packages/junior/tests/integration/slack/assistant-context-canvas-routing.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-context-canvas-routing.test.ts
@@ -43,7 +43,17 @@ describe("Slack behavior: assistant context canvas routing", () => {
       services: {
         replyExecutor: {
           agentRunner: {
-            run: async (_prompt, context) => {
+            run: async (request) => {
+              const _prompt = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               await createCanvas({
                 title: "Shared update",
                 markdown: "Context-aware update",

--- a/packages/junior/tests/integration/slack/assistant-context-channel-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-context-channel-behavior.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import { createTestChatRuntime } from "../../fixtures/chat-runtime";
 import {
   createTestMessage,
@@ -15,7 +16,7 @@ describe("Slack behavior: assistant context channel routing", () => {
         replyExecutor: {
           generateAssistantReply: async (_prompt, context) => {
             capturedToolChannelIds.push(context?.toolChannelId);
-            return {
+            return completedAgentRun({
               text: "Canvas draft prepared.",
               diagnostics: {
                 assistantMessageCount: 1,
@@ -26,7 +27,7 @@ describe("Slack behavior: assistant context channel routing", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },

--- a/packages/junior/tests/integration/slack/assistant-context-channel-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-context-channel-behavior.test.ts
@@ -14,20 +14,22 @@ describe("Slack behavior: assistant context channel routing", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async (_prompt, context) => {
-            capturedToolChannelIds.push(context?.toolChannelId);
-            return completedAgentRun({
-              text: "Canvas draft prepared.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            });
+          agentRunner: {
+            run: async (_prompt, context) => {
+              capturedToolChannelIds.push(context?.toolChannelId);
+              return completedAgentRun({
+                text: "Canvas draft prepared.",
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "fake-agent-model",
+                  outcome: "success",
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              });
+            },
           },
         },
       },

--- a/packages/junior/tests/integration/slack/assistant-context-channel-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-context-channel-behavior.test.ts
@@ -15,7 +15,17 @@ describe("Slack behavior: assistant context channel routing", () => {
       services: {
         replyExecutor: {
           agentRunner: {
-            run: async (_prompt, context) => {
+            run: async (request) => {
+              const _prompt = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               capturedToolChannelIds.push(context?.toolChannelId);
               return completedAgentRun({
                 text: "Canvas draft prepared.",

--- a/packages/junior/tests/integration/slack/assistant-thread-contract.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-thread-contract.test.ts
@@ -9,7 +9,7 @@ import { createSlackWebhookTestClient } from "../../fixtures/slack/webhook-clien
 import { createSlackRuntime } from "@/chat/app/factory";
 import { JuniorChat } from "@/chat/ingress/junior-chat";
 import { makeAssistantStatus } from "@/chat/slack/assistant-thread/status";
-import type { ReplyExecutorServices } from "@/chat/runtime/reply-executor";
+import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { createJuniorSlackAdapter } from "@/chat/slack/adapter";
 import type { ConversationMemoryDeps } from "@/chat/services/conversation-memory";
 import { handleChatSdkPlatformWebhook } from "@/handlers/webhooks";
@@ -76,7 +76,7 @@ function makeCompletedReply(text: string) {
 
 async function createDirectMessageBot(args: {
   completeText?: ConversationMemoryDeps["completeText"];
-  generateAssistantReply: ReplyExecutorServices["generateAssistantReply"];
+  agentRunner: AgentRunner;
 }) {
   const bot = new JuniorChat<{ slack: SlackAdapter }>({
     userName: "junior",
@@ -101,7 +101,7 @@ async function createDirectMessageBot(args: {
           }
         : {}),
       replyExecutor: {
-        generateAssistantReply: args.generateAssistantReply,
+        agentRunner: args.agentRunner,
       },
     },
   });
@@ -115,9 +115,7 @@ async function createDirectMessageBot(args: {
   return bot;
 }
 
-async function createMentionBot(args: {
-  generateAssistantReply: ReplyExecutorServices["generateAssistantReply"];
-}) {
+async function createMentionBot(args: { agentRunner: AgentRunner }) {
   const bot = new JuniorChat<{ slack: SlackAdapter }>({
     userName: "junior",
     adapters: {
@@ -133,7 +131,7 @@ async function createMentionBot(args: {
     getSlackAdapter: () => bot.getAdapter("slack"),
     services: {
       replyExecutor: {
-        generateAssistantReply: args.generateAssistantReply,
+        agentRunner: args.agentRunner,
       },
     },
   });
@@ -158,9 +156,11 @@ describe("Slack contract: assistant-thread delivery", () => {
 
   it("does not post assistant status when the DM message omits thread_ts", async () => {
     const bot = await createDirectMessageBot({
-      generateAssistantReply: async (_prompt, context) => {
-        await context?.onStatus?.(makeAssistantStatus("running", "bash"));
-        return makeCompletedReply("Done.");
+      agentRunner: {
+        run: async (_prompt, context) => {
+          await context?.onStatus?.(makeAssistantStatus("running", "bash"));
+          return makeCompletedReply("Done.");
+        },
       },
     });
     const waitUntil = slackWebhookClient.waitUntil();
@@ -180,9 +180,11 @@ describe("Slack contract: assistant-thread delivery", () => {
 
   it("posts assistant status with a raw DM channel id when thread_ts is present", async () => {
     const bot = await createDirectMessageBot({
-      generateAssistantReply: async (_prompt, context) => {
-        await context?.onStatus?.(makeAssistantStatus("running", "bash"));
-        return makeCompletedReply("Done.");
+      agentRunner: {
+        run: async (_prompt, context) => {
+          await context?.onStatus?.(makeAssistantStatus("running", "bash"));
+          return makeCompletedReply("Done.");
+        },
       },
     });
     const waitUntil = slackWebhookClient.waitUntil();
@@ -221,9 +223,11 @@ describe("Slack contract: assistant-thread delivery", () => {
 
   it("posts assistant status for the first channel-thread reply before Slack adds thread_ts", async () => {
     const bot = await createMentionBot({
-      generateAssistantReply: async (_prompt, context) => {
-        await context?.onStatus?.(makeAssistantStatus("running", "bash"));
-        return makeCompletedReply("Done.");
+      agentRunner: {
+        run: async (_prompt, context) => {
+          await context?.onStatus?.(makeAssistantStatus("running", "bash"));
+          return makeCompletedReply("Done.");
+        },
       },
     });
     const waitUntil = slackWebhookClient.waitUntil();
@@ -265,8 +269,10 @@ describe("Slack contract: assistant-thread delivery", () => {
           text: "Debugging Node.js Memory Leaks",
           message: { role: "assistant", content: "" },
         }) as any,
-      generateAssistantReply: async () =>
-        makeCompletedReply("Here is how to debug memory leaks."),
+      agentRunner: {
+        run: async () =>
+          makeCompletedReply("Here is how to debug memory leaks."),
+      },
     });
     const waitUntil = slackWebhookClient.waitUntil();
 
@@ -305,8 +311,10 @@ describe("Slack contract: assistant-thread delivery", () => {
             } as any);
           };
         }),
-      generateAssistantReply: async () =>
-        makeCompletedReply("Here is how to debug memory leaks."),
+      agentRunner: {
+        run: async () =>
+          makeCompletedReply("Here is how to debug memory leaks."),
+      },
     });
     const waitUntil = slackWebhookClient.waitUntil();
 
@@ -333,6 +341,7 @@ describe("Slack contract: assistant-thread delivery", () => {
       ]),
     );
 
+    resetSlackApiMockState();
     resolveTitle!();
     await vi.waitFor(() => {
       expect(slackApiOutbox.calls("assistant.threads.setTitle")).toEqual([
@@ -354,8 +363,10 @@ describe("Slack contract: assistant-thread delivery", () => {
           text: "Debugging Node.js Memory Leaks",
           message: { role: "assistant", content: "" },
         }) as any,
-      generateAssistantReply: async () =>
-        makeCompletedReply("Here is how to debug memory leaks."),
+      agentRunner: {
+        run: async () =>
+          makeCompletedReply("Here is how to debug memory leaks."),
+      },
     });
     const waitUntil = slackWebhookClient.waitUntil();
 

--- a/packages/junior/tests/integration/slack/assistant-thread-contract.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-thread-contract.test.ts
@@ -13,6 +13,7 @@ import type { ReplyExecutorServices } from "@/chat/runtime/reply-executor";
 import { createJuniorSlackAdapter } from "@/chat/slack/adapter";
 import type { ConversationMemoryDeps } from "@/chat/services/conversation-memory";
 import { handleChatSdkPlatformWebhook } from "@/handlers/webhooks";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const SIGNING_SECRET = "test-signing-secret";
 const BOT_USER_ID = "U_BOT";
@@ -64,6 +65,13 @@ function makeDiagnostics() {
     toolResultCount: 0,
     usedPrimaryText: true,
   };
+}
+
+function makeCompletedReply(text: string) {
+  return completedAgentRun({
+    text,
+    diagnostics: makeDiagnostics(),
+  });
 }
 
 async function createDirectMessageBot(args: {
@@ -152,10 +160,7 @@ describe("Slack contract: assistant-thread delivery", () => {
     const bot = await createDirectMessageBot({
       generateAssistantReply: async (_prompt, context) => {
         await context?.onStatus?.(makeAssistantStatus("running", "bash"));
-        return {
-          text: "Done.",
-          diagnostics: makeDiagnostics(),
-        };
+        return makeCompletedReply("Done.");
       },
     });
     const waitUntil = slackWebhookClient.waitUntil();
@@ -177,10 +182,7 @@ describe("Slack contract: assistant-thread delivery", () => {
     const bot = await createDirectMessageBot({
       generateAssistantReply: async (_prompt, context) => {
         await context?.onStatus?.(makeAssistantStatus("running", "bash"));
-        return {
-          text: "Done.",
-          diagnostics: makeDiagnostics(),
-        };
+        return makeCompletedReply("Done.");
       },
     });
     const waitUntil = slackWebhookClient.waitUntil();
@@ -221,10 +223,7 @@ describe("Slack contract: assistant-thread delivery", () => {
     const bot = await createMentionBot({
       generateAssistantReply: async (_prompt, context) => {
         await context?.onStatus?.(makeAssistantStatus("running", "bash"));
-        return {
-          text: "Done.",
-          diagnostics: makeDiagnostics(),
-        };
+        return makeCompletedReply("Done.");
       },
     });
     const waitUntil = slackWebhookClient.waitUntil();
@@ -266,10 +265,8 @@ describe("Slack contract: assistant-thread delivery", () => {
           text: "Debugging Node.js Memory Leaks",
           message: { role: "assistant", content: "" },
         }) as any,
-      generateAssistantReply: async () => ({
-        text: "Here is how to debug memory leaks.",
-        diagnostics: makeDiagnostics(),
-      }),
+      generateAssistantReply: async () =>
+        makeCompletedReply("Here is how to debug memory leaks."),
     });
     const waitUntil = slackWebhookClient.waitUntil();
 
@@ -308,10 +305,8 @@ describe("Slack contract: assistant-thread delivery", () => {
             } as any);
           };
         }),
-      generateAssistantReply: async () => ({
-        text: "Here is how to debug memory leaks.",
-        diagnostics: makeDiagnostics(),
-      }),
+      generateAssistantReply: async () =>
+        makeCompletedReply("Here is how to debug memory leaks."),
     });
     const waitUntil = slackWebhookClient.waitUntil();
 
@@ -359,10 +354,8 @@ describe("Slack contract: assistant-thread delivery", () => {
           text: "Debugging Node.js Memory Leaks",
           message: { role: "assistant", content: "" },
         }) as any,
-      generateAssistantReply: async () => ({
-        text: "Here is how to debug memory leaks.",
-        diagnostics: makeDiagnostics(),
-      }),
+      generateAssistantReply: async () =>
+        makeCompletedReply("Here is how to debug memory leaks."),
     });
     const waitUntil = slackWebhookClient.waitUntil();
 

--- a/packages/junior/tests/integration/slack/assistant-thread-contract.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-thread-contract.test.ts
@@ -157,7 +157,17 @@ describe("Slack contract: assistant-thread delivery", () => {
   it("does not post assistant status when the DM message omits thread_ts", async () => {
     const bot = await createDirectMessageBot({
       agentRunner: {
-        run: async (_prompt, context) => {
+        run: async (request) => {
+          const _prompt = request.input.messageText;
+          const context = {
+            ...request.input,
+            ...request.routing,
+            ...(request.policy ?? {}),
+            ...(request.state ?? {}),
+            ...(request.observers ?? {}),
+            ...(request.durability ?? {}),
+          };
+
           await context?.onStatus?.(makeAssistantStatus("running", "bash"));
           return makeCompletedReply("Done.");
         },
@@ -181,7 +191,17 @@ describe("Slack contract: assistant-thread delivery", () => {
   it("posts assistant status with a raw DM channel id when thread_ts is present", async () => {
     const bot = await createDirectMessageBot({
       agentRunner: {
-        run: async (_prompt, context) => {
+        run: async (request) => {
+          const _prompt = request.input.messageText;
+          const context = {
+            ...request.input,
+            ...request.routing,
+            ...(request.policy ?? {}),
+            ...(request.state ?? {}),
+            ...(request.observers ?? {}),
+            ...(request.durability ?? {}),
+          };
+
           await context?.onStatus?.(makeAssistantStatus("running", "bash"));
           return makeCompletedReply("Done.");
         },
@@ -224,7 +244,17 @@ describe("Slack contract: assistant-thread delivery", () => {
   it("posts assistant status for the first channel-thread reply before Slack adds thread_ts", async () => {
     const bot = await createMentionBot({
       agentRunner: {
-        run: async (_prompt, context) => {
+        run: async (request) => {
+          const _prompt = request.input.messageText;
+          const context = {
+            ...request.input,
+            ...request.routing,
+            ...(request.policy ?? {}),
+            ...(request.state ?? {}),
+            ...(request.observers ?? {}),
+            ...(request.durability ?? {}),
+          };
+
           await context?.onStatus?.(makeAssistantStatus("running", "bash"));
           return makeCompletedReply("Done.");
         },

--- a/packages/junior/tests/integration/slack/attachment-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/attachment-behavior.test.ts
@@ -5,6 +5,7 @@ import {
   createTestThread,
   createTestDestination,
 } from "../../fixtures/slack-harness";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -67,18 +68,18 @@ describe("Slack behavior: attachment handling", () => {
               capturedAttachmentMediaTypes.push(attachments[0].mediaType);
             }
 
-            return {
+            return completedAgentRun({
               text: "Image received. The chart trend is upward.",
               diagnostics: {
                 assistantMessageCount: 1,
                 modelId: "fake-agent-model",
-                outcome: "success",
+                outcome: "success" as const,
                 toolCalls: [],
                 toolErrorCount: 0,
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },
@@ -119,18 +120,20 @@ describe("Slack behavior: attachment handling", () => {
     const completeTextMock = vi.fn(async () => {
       throw new Error("vision unavailable");
     });
-    const generateAssistantReply = vi.fn(async () => ({
-      text: "should not post",
-      diagnostics: {
-        assistantMessageCount: 1,
-        modelId: "fake-agent-model",
-        outcome: "success" as const,
-        toolCalls: [],
-        toolErrorCount: 0,
-        toolResultCount: 0,
-        usedPrimaryText: true,
-      },
-    }));
+    const generateAssistantReply = vi.fn(async () =>
+      completedAgentRun({
+        text: "should not post",
+        diagnostics: {
+          assistantMessageCount: 1,
+          modelId: "fake-agent-model",
+          outcome: "success" as const,
+          toolCalls: [],
+          toolErrorCount: 0,
+          toolResultCount: 0,
+          usedPrimaryText: true,
+        },
+      }),
+    );
 
     const { slackRuntime } = await createRuntime({
       services: {

--- a/packages/junior/tests/integration/slack/attachment-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/attachment-behavior.test.ts
@@ -61,25 +61,27 @@ describe("Slack behavior: attachment handling", () => {
           completeText: completeTextMock,
         },
         replyExecutor: {
-          generateAssistantReply: async (_prompt, context) => {
-            const attachments = context?.userAttachments ?? [];
-            capturedAttachmentCounts.push(attachments.length);
-            if (attachments[0]) {
-              capturedAttachmentMediaTypes.push(attachments[0].mediaType);
-            }
+          agentRunner: {
+            run: async (_prompt, context) => {
+              const attachments = context?.userAttachments ?? [];
+              capturedAttachmentCounts.push(attachments.length);
+              if (attachments[0]) {
+                capturedAttachmentMediaTypes.push(attachments[0].mediaType);
+              }
 
-            return completedAgentRun({
-              text: "Image received. The chart trend is upward.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success" as const,
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            });
+              return completedAgentRun({
+                text: "Image received. The chart trend is upward.",
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "fake-agent-model",
+                  outcome: "success" as const,
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              });
+            },
           },
         },
       },
@@ -141,7 +143,7 @@ describe("Slack behavior: attachment handling", () => {
           completeText: completeTextMock,
         },
         replyExecutor: {
-          generateAssistantReply,
+          agentRunner: { run: generateAssistantReply },
         },
       },
     });

--- a/packages/junior/tests/integration/slack/attachment-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/attachment-behavior.test.ts
@@ -62,7 +62,17 @@ describe("Slack behavior: attachment handling", () => {
         },
         replyExecutor: {
           agentRunner: {
-            run: async (_prompt, context) => {
+            run: async (request) => {
+              const _prompt = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               const attachments = context?.userAttachments ?? [];
               capturedAttachmentCounts.push(attachments.length);
               if (attachments[0]) {

--- a/packages/junior/tests/integration/slack/attachment-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/attachment-behavior.test.ts
@@ -132,7 +132,7 @@ describe("Slack behavior: attachment handling", () => {
     const completeTextMock = vi.fn(async () => {
       throw new Error("vision unavailable");
     });
-    const generateAssistantReply = vi.fn(async () =>
+    const executeAgentRun = vi.fn(async () =>
       completedAgentRun({
         text: "should not post",
         diagnostics: {
@@ -153,7 +153,7 @@ describe("Slack behavior: attachment handling", () => {
           completeText: completeTextMock,
         },
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
         },
       },
     });
@@ -182,7 +182,7 @@ describe("Slack behavior: attachment handling", () => {
 
     expect(attachmentFetch).toHaveBeenCalledTimes(1);
     expect(completeTextMock).toHaveBeenCalledTimes(1);
-    expect(generateAssistantReply).not.toHaveBeenCalled();
+    expect(executeAgentRun).not.toHaveBeenCalled();
     expect(thread.posts).toHaveLength(1);
     expect(toPostedText(thread.posts[0])).toContain(
       "I ran into an internal error while processing that.",

--- a/packages/junior/tests/integration/slack/attachment-media-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/attachment-media-behavior.test.ts
@@ -5,6 +5,7 @@ import {
   createTestThread,
   createTestDestination,
 } from "../../fixtures/slack-harness";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -76,18 +77,18 @@ describe("Slack behavior: mixed attachment media", () => {
               capturedAttachmentNames.push(
                 attachments.map((attachment) => attachment.filename ?? ""),
               );
-              return {
+              return completedAgentRun({
                 text: "Processed attachments.",
                 diagnostics: {
                   assistantMessageCount: 1,
                   modelId: "fake-agent-model",
-                  outcome: "success",
+                  outcome: "success" as const,
                   toolCalls: [],
                   toolErrorCount: 0,
                   toolResultCount: 0,
                   usedPrimaryText: true,
                 },
-              };
+              });
             },
           },
         },
@@ -173,18 +174,18 @@ describe("Slack behavior: mixed attachment media", () => {
             capturedOmittedImageCounts.push(
               context?.omittedImageAttachmentCount ?? 0,
             );
-            return {
+            return completedAgentRun({
               text: "Processed attachments.",
               diagnostics: {
                 assistantMessageCount: 1,
                 modelId: "fake-agent-model",
-                outcome: "success",
+                outcome: "success" as const,
                 toolCalls: [],
                 toolErrorCount: 0,
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },
@@ -229,7 +230,7 @@ describe("Slack behavior: mixed attachment media", () => {
     const capturedOmittedImageCounts: number[] = [];
     const generateAssistantReply = vi.fn(
       async (_prompt?: string, _context?: unknown) => {
-        return {
+        return completedAgentRun({
           text: "I can’t inspect the attached image in this runtime, but I do see that an image was included.",
           diagnostics: {
             assistantMessageCount: 1,
@@ -240,7 +241,7 @@ describe("Slack behavior: mixed attachment media", () => {
             toolResultCount: 0,
             usedPrimaryText: true,
           },
-        };
+        });
       },
     );
 

--- a/packages/junior/tests/integration/slack/attachment-media-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/attachment-media-behavior.test.ts
@@ -69,26 +69,28 @@ describe("Slack behavior: mixed attachment media", () => {
             completeText: completeTextMock,
           },
           replyExecutor: {
-            generateAssistantReply: async (_prompt, context) => {
-              const attachments = context?.userAttachments ?? [];
-              capturedAttachmentMediaTypes.push(
-                attachments.map((attachment) => attachment.mediaType),
-              );
-              capturedAttachmentNames.push(
-                attachments.map((attachment) => attachment.filename ?? ""),
-              );
-              return completedAgentRun({
-                text: "Processed attachments.",
-                diagnostics: {
-                  assistantMessageCount: 1,
-                  modelId: "fake-agent-model",
-                  outcome: "success" as const,
-                  toolCalls: [],
-                  toolErrorCount: 0,
-                  toolResultCount: 0,
-                  usedPrimaryText: true,
-                },
-              });
+            agentRunner: {
+              run: async (_prompt, context) => {
+                const attachments = context?.userAttachments ?? [];
+                capturedAttachmentMediaTypes.push(
+                  attachments.map((attachment) => attachment.mediaType),
+                );
+                capturedAttachmentNames.push(
+                  attachments.map((attachment) => attachment.filename ?? ""),
+                );
+                return completedAgentRun({
+                  text: "Processed attachments.",
+                  diagnostics: {
+                    assistantMessageCount: 1,
+                    modelId: "fake-agent-model",
+                    outcome: "success" as const,
+                    toolCalls: [],
+                    toolErrorCount: 0,
+                    toolResultCount: 0,
+                    usedPrimaryText: true,
+                  },
+                });
+              },
             },
           },
         },
@@ -163,29 +165,31 @@ describe("Slack behavior: mixed attachment media", () => {
     const { slackRuntime } = await createRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async (_prompt, context) => {
-            const attachments = context?.userAttachments ?? [];
-            capturedAttachmentMediaTypes.push(
-              attachments.map((attachment) => attachment.mediaType),
-            );
-            capturedAttachmentNames.push(
-              attachments.map((attachment) => attachment.filename ?? ""),
-            );
-            capturedOmittedImageCounts.push(
-              context?.omittedImageAttachmentCount ?? 0,
-            );
-            return completedAgentRun({
-              text: "Processed attachments.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success" as const,
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            });
+          agentRunner: {
+            run: async (_prompt, context) => {
+              const attachments = context?.userAttachments ?? [];
+              capturedAttachmentMediaTypes.push(
+                attachments.map((attachment) => attachment.mediaType),
+              );
+              capturedAttachmentNames.push(
+                attachments.map((attachment) => attachment.filename ?? ""),
+              );
+              capturedOmittedImageCounts.push(
+                context?.omittedImageAttachmentCount ?? 0,
+              );
+              return completedAgentRun({
+                text: "Processed attachments.",
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "fake-agent-model",
+                  outcome: "success" as const,
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              });
+            },
           },
         },
       },
@@ -248,11 +252,13 @@ describe("Slack behavior: mixed attachment media", () => {
     const { slackRuntime } = await createRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async (prompt, context) => {
-            capturedOmittedImageCounts.push(
-              context?.omittedImageAttachmentCount ?? 0,
-            );
-            return generateAssistantReply(prompt, context);
+          agentRunner: {
+            run: async (prompt, context) => {
+              capturedOmittedImageCounts.push(
+                context?.omittedImageAttachmentCount ?? 0,
+              );
+              return generateAssistantReply(prompt, context);
+            },
           },
         },
       },

--- a/packages/junior/tests/integration/slack/attachment-media-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/attachment-media-behavior.test.ts
@@ -253,22 +253,20 @@ describe("Slack behavior: mixed attachment media", () => {
   it("still runs the assistant when only images are attached and vision is disabled", async () => {
     const imageFetch = vi.fn(async () => Buffer.from("image-bytes"));
     const capturedOmittedImageCounts: number[] = [];
-    const generateAssistantReply = vi.fn<AgentRunner["run"]>(
-      async (_request) => {
-        return completedAgentRun({
-          text: "I can’t inspect the attached image in this runtime, but I do see that an image was included.",
-          diagnostics: {
-            assistantMessageCount: 1,
-            modelId: "fake-agent-model",
-            outcome: "success" as const,
-            toolCalls: [],
-            toolErrorCount: 0,
-            toolResultCount: 0,
-            usedPrimaryText: true,
-          },
-        });
-      },
-    );
+    const executeAgentRun = vi.fn<AgentRunner["run"]>(async (_request) => {
+      return completedAgentRun({
+        text: "I can’t inspect the attached image in this runtime, but I do see that an image was included.",
+        diagnostics: {
+          assistantMessageCount: 1,
+          modelId: "fake-agent-model",
+          outcome: "success" as const,
+          toolCalls: [],
+          toolErrorCount: 0,
+          toolResultCount: 0,
+          usedPrimaryText: true,
+        },
+      });
+    });
 
     const { slackRuntime } = await createRuntime({
       services: {
@@ -287,7 +285,7 @@ describe("Slack behavior: mixed attachment media", () => {
               capturedOmittedImageCounts.push(
                 context?.omittedImageAttachmentCount ?? 0,
               );
-              return generateAssistantReply(request);
+              return executeAgentRun(request);
             },
           },
         },
@@ -317,7 +315,7 @@ describe("Slack behavior: mixed attachment media", () => {
     });
 
     expect(imageFetch).not.toHaveBeenCalled();
-    expect(generateAssistantReply).toHaveBeenCalledTimes(1);
+    expect(executeAgentRun).toHaveBeenCalledTimes(1);
     expect(capturedOmittedImageCounts).toEqual([1]);
     expect(thread.posts).toHaveLength(1);
     expect(toPostedText(thread.posts[0])).toContain(

--- a/packages/junior/tests/integration/slack/attachment-media-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/attachment-media-behavior.test.ts
@@ -6,6 +6,7 @@ import {
   createTestDestination,
 } from "../../fixtures/slack-harness";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
+import type { AgentRunner } from "@/chat/runtime/agent-runner";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -70,7 +71,17 @@ describe("Slack behavior: mixed attachment media", () => {
           },
           replyExecutor: {
             agentRunner: {
-              run: async (_prompt, context) => {
+              run: async (request) => {
+                const _prompt = request.input.messageText;
+                const context = {
+                  ...request.input,
+                  ...request.routing,
+                  ...(request.policy ?? {}),
+                  ...(request.state ?? {}),
+                  ...(request.observers ?? {}),
+                  ...(request.durability ?? {}),
+                };
+
                 const attachments = context?.userAttachments ?? [];
                 capturedAttachmentMediaTypes.push(
                   attachments.map((attachment) => attachment.mediaType),
@@ -166,7 +177,17 @@ describe("Slack behavior: mixed attachment media", () => {
       services: {
         replyExecutor: {
           agentRunner: {
-            run: async (_prompt, context) => {
+            run: async (request) => {
+              const _prompt = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               const attachments = context?.userAttachments ?? [];
               capturedAttachmentMediaTypes.push(
                 attachments.map((attachment) => attachment.mediaType),
@@ -232,8 +253,8 @@ describe("Slack behavior: mixed attachment media", () => {
   it("still runs the assistant when only images are attached and vision is disabled", async () => {
     const imageFetch = vi.fn(async () => Buffer.from("image-bytes"));
     const capturedOmittedImageCounts: number[] = [];
-    const generateAssistantReply = vi.fn(
-      async (_prompt?: string, _context?: unknown) => {
+    const generateAssistantReply = vi.fn<AgentRunner["run"]>(
+      async (_request) => {
         return completedAgentRun({
           text: "I can’t inspect the attached image in this runtime, but I do see that an image was included.",
           diagnostics: {
@@ -253,11 +274,20 @@ describe("Slack behavior: mixed attachment media", () => {
       services: {
         replyExecutor: {
           agentRunner: {
-            run: async (prompt, context) => {
+            run: async (request) => {
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               capturedOmittedImageCounts.push(
                 context?.omittedImageAttachmentCount ?? 0,
               );
-              return generateAssistantReply(prompt, context);
+              return generateAssistantReply(request);
             },
           },
         },

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -4,7 +4,10 @@ import type { JuniorRuntimeServiceOverrides } from "@/chat/app/services";
 import type { ReplyRequestContext } from "@/chat/respond";
 import { makeAssistantStatus } from "@/chat/slack/assistant-thread/status";
 import { getSlackInterruptionMarker } from "@/chat/slack/output";
-import { RetryableTurnError } from "@/chat/runtime/turn";
+import {
+  completedAgentRun,
+  failedAgentRun,
+} from "@/chat/runtime/agent-run-outcome";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import { acquireActiveLock } from "@/chat/state/locks";
 import { loadProjection } from "@/chat/state/session-log";
@@ -176,18 +179,19 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: "Hello from the bot!",
-            diagnostics: {
-              assistantMessageCount: 1,
-              modelId: "test-model",
-              outcome: "success" as const,
-              toolCalls: [],
-              toolErrorCount: 0,
-              toolResultCount: 0,
-              usedPrimaryText: true,
-            },
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: "Hello from the bot!",
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "test-model",
+                outcome: "success" as const,
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            }),
           scheduleSessionCompletedPluginTasks,
         },
         visionContext: {
@@ -325,18 +329,19 @@ describe("bot handlers (integration)", () => {
             }) as any,
         },
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: "Replying to mention",
-            diagnostics: {
-              assistantMessageCount: 1,
-              modelId: "test-model",
-              outcome: "success" as const,
-              toolCalls: [],
-              toolErrorCount: 0,
-              toolResultCount: 0,
-              usedPrimaryText: true,
-            },
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: "Replying to mention",
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "test-model",
+                outcome: "success" as const,
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            }),
         },
         visionContext: {
           listThreadReplies: async () => [],
@@ -490,7 +495,7 @@ describe("bot handlers (integration)", () => {
               state: "running",
               piMessages: promptMessages,
             });
-            return {
+            return completedAgentRun({
               text: finalText,
               piMessages: [
                 ...promptMessages,
@@ -527,7 +532,7 @@ describe("bot handlers (integration)", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
         visionContext: {
@@ -605,18 +610,19 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: finalText,
-            diagnostics: {
-              assistantMessageCount: 1,
-              modelId: "fake-agent-model",
-              outcome: "success" as const,
-              toolCalls: [],
-              toolErrorCount: 0,
-              toolResultCount: 0,
-              usedPrimaryText: true,
-            },
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: finalText,
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "fake-agent-model",
+                outcome: "success" as const,
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            }),
         },
         visionContext: {
           listThreadReplies: async () => [],
@@ -685,7 +691,7 @@ describe("bot handlers (integration)", () => {
               turnId: context?.correlation?.turnId,
               runId: context?.correlation?.runId,
             });
-            return {
+            return completedAgentRun({
               text: "Done.",
               diagnostics: {
                 assistantMessageCount: 1,
@@ -696,7 +702,7 @@ describe("bot handlers (integration)", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },
@@ -734,16 +740,17 @@ describe("bot handlers (integration)", () => {
       services: {
         replyExecutor: {
           generateAssistantReply: async () => {
-            throw new RetryableTurnError(
-              "mcp_auth_resume",
-              "simulated auth pause",
-              {
-                authDisposition: "link_sent",
-                authKind: "mcp",
-                authProvider: "notion",
-                authProviderDisplayName: "Notion",
-              },
-            );
+            return {
+              status: "awaiting_auth",
+              authDisposition: "link_sent",
+              authDurationMs: 1,
+              authKind: "mcp",
+              authProvider: "notion",
+              authProviderDisplayName: "Notion",
+              conversationId: "slack:C_AUTH:1700000000.000",
+              sessionId: "turn_msg-auth-pause",
+              sliceId: 2,
+            };
           },
         },
       },
@@ -817,16 +824,17 @@ describe("bot handlers (integration)", () => {
       services: {
         replyExecutor: {
           generateAssistantReply: async () => {
-            throw new RetryableTurnError(
-              "plugin_auth_resume",
-              "simulated plugin auth pause",
-              {
-                authDisposition: "link_sent",
-                authKind: "plugin",
-                authProvider: "github",
-                authProviderDisplayName: "GitHub",
-              },
-            );
+            return {
+              status: "awaiting_auth",
+              authDisposition: "link_sent",
+              authDurationMs: 1,
+              authKind: "plugin",
+              authProvider: "github",
+              authProviderDisplayName: "GitHub",
+              conversationId: "slack:C_PLUGIN_AUTH:1700000000.000",
+              sessionId: "turn_msg-plugin-auth-pause",
+              sliceId: 2,
+            };
           },
         },
       },
@@ -907,16 +915,13 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           scheduleAgentContinue,
           generateAssistantReply: async () => {
-            throw new RetryableTurnError(
-              "agent_continue",
-              "simulated timeout continuation",
-              {
-                conversationId,
-                sessionId,
-                version: 3,
-                sliceId: 2,
-              },
-            );
+            return {
+              status: "timed_out",
+              conversationId,
+              sessionId,
+              version: 3,
+              sliceId: 2,
+            };
           },
         },
       },
@@ -966,16 +971,13 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           scheduleAgentContinue,
           generateAssistantReply: async () => {
-            throw new RetryableTurnError(
-              "agent_continue",
-              "simulated timeout continuation",
-              {
-                conversationId,
-                sessionId,
-                version: 4,
-                sliceId: 2,
-              },
-            );
+            return {
+              status: "timed_out",
+              conversationId,
+              sessionId,
+              version: 4,
+              sliceId: 2,
+            };
           },
         },
       },
@@ -1018,16 +1020,13 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           scheduleAgentContinue,
           generateAssistantReply: async () => {
-            throw new RetryableTurnError(
-              "agent_continue",
-              "simulated timeout continuation",
-              {
-                conversationId,
-                sessionId,
-                version: 3,
-                sliceId: 2,
-              },
-            );
+            return {
+              status: "timed_out",
+              conversationId,
+              sessionId,
+              version: 3,
+              sliceId: 2,
+            };
           },
         },
       },
@@ -1145,18 +1144,20 @@ describe("bot handlers (integration)", () => {
   it("answers a follow-up as a fresh turn when the active session is auth-parked", async () => {
     const conversationId = "slack:C_AUTH_PARKED:1700000000.000";
     const activeSessionId = "turn_msg-auth-original";
-    const generateAssistantReply = vi.fn().mockResolvedValue({
-      text: "Fresh answer without the provider.",
-      diagnostics: {
-        assistantMessageCount: 1,
-        modelId: "test-model",
-        outcome: "success" as const,
-        toolCalls: [],
-        toolErrorCount: 0,
-        toolResultCount: 0,
-        usedPrimaryText: true,
-      },
-    });
+    const generateAssistantReply = vi.fn().mockResolvedValue(
+      completedAgentRun({
+        text: "Fresh answer without the provider.",
+        diagnostics: {
+          assistantMessageCount: 1,
+          modelId: "test-model",
+          outcome: "success" as const,
+          toolCalls: [],
+          toolErrorCount: 0,
+          toolResultCount: 0,
+          usedPrimaryText: true,
+        },
+      }),
+    );
     await upsertAgentTurnSessionRecord({
       conversationId,
       sessionId: activeSessionId,
@@ -1527,18 +1528,20 @@ describe("bot handlers (integration)", () => {
   it("fails malformed awaiting continuations before handling the follow-up", async () => {
     const conversationId = "slack:C_BAD_CONTINUATION:1700000000.000";
     const activeSessionId = "turn_msg-timeout-original";
-    const generateAssistantReply = vi.fn().mockResolvedValue({
-      text: "Recovered.",
-      diagnostics: {
-        assistantMessageCount: 1,
-        modelId: "test-model",
-        outcome: "success" as const,
-        toolCalls: [],
-        toolErrorCount: 0,
-        toolResultCount: 0,
-        usedPrimaryText: true,
-      },
-    });
+    const generateAssistantReply = vi.fn().mockResolvedValue(
+      completedAgentRun({
+        text: "Recovered.",
+        diagnostics: {
+          assistantMessageCount: 1,
+          modelId: "test-model",
+          outcome: "success" as const,
+          toolCalls: [],
+          toolErrorCount: 0,
+          toolResultCount: 0,
+          usedPrimaryText: true,
+        },
+      }),
+    );
     await upsertAgentTurnSessionRecord({
       conversationId,
       sessionId: activeSessionId,
@@ -1805,7 +1808,7 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           generateAssistantReply: async (_prompt, context) => {
             await context?.onTextDelta?.("Partial output...");
-            return {
+            return failedAgentRun({
               text: "Partial output...",
               diagnostics: {
                 assistantMessageCount: 1,
@@ -1816,7 +1819,7 @@ describe("bot handlers (integration)", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },
@@ -1857,7 +1860,7 @@ describe("bot handlers (integration)", () => {
             await context?.onStatus?.(
               makeAssistantStatus("reading", "channel messages"),
             );
-            return {
+            return completedAgentRun({
               text: "Done.",
               diagnostics: {
                 assistantMessageCount: 1,
@@ -1868,7 +1871,7 @@ describe("bot handlers (integration)", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },
@@ -1926,7 +1929,7 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           generateAssistantReply: async () => {
             replyStarted = true;
-            return {
+            return completedAgentRun({
               text: "Still replied while status was pending.",
               diagnostics: {
                 assistantMessageCount: 1,
@@ -1937,7 +1940,7 @@ describe("bot handlers (integration)", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },
@@ -2009,7 +2012,7 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           generateAssistantReply: async () => {
             replyStarted = true;
-            return {
+            return completedAgentRun({
               text: "Reply lands after the pending status is drained.",
               diagnostics: {
                 assistantMessageCount: 1,
@@ -2020,7 +2023,7 @@ describe("bot handlers (integration)", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },
@@ -2070,18 +2073,19 @@ describe("bot handlers (integration)", () => {
             }) as any,
         },
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: "Here is how to debug memory leaks.",
-            diagnostics: {
-              assistantMessageCount: 1,
-              modelId: "test-model",
-              outcome: "success" as const,
-              toolCalls: [],
-              toolErrorCount: 0,
-              toolResultCount: 0,
-              usedPrimaryText: true,
-            },
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: "Here is how to debug memory leaks.",
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "test-model",
+                outcome: "success" as const,
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            }),
         },
       },
     });
@@ -2130,18 +2134,19 @@ describe("bot handlers (integration)", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: "Here is the updated answer.",
-            diagnostics: {
-              assistantMessageCount: 1,
-              modelId: "test-model",
-              outcome: "success" as const,
-              toolCalls: [],
-              toolErrorCount: 0,
-              toolResultCount: 0,
-              usedPrimaryText: true,
-            },
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: "Here is the updated answer.",
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "test-model",
+                outcome: "success" as const,
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            }),
         },
       },
     });
@@ -2189,18 +2194,19 @@ describe("bot handlers (integration)", () => {
             }) as any,
         },
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: "Today is April 16, 2026.",
-            diagnostics: {
-              assistantMessageCount: 1,
-              modelId: "test-model",
-              outcome: "success" as const,
-              toolCalls: [],
-              toolErrorCount: 0,
-              toolResultCount: 0,
-              usedPrimaryText: true,
-            },
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: "Today is April 16, 2026.",
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "test-model",
+                outcome: "success" as const,
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            }),
         },
       },
     });
@@ -2259,18 +2265,19 @@ describe("bot handlers (integration)", () => {
             }),
         },
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: "Today is April 16, 2026.",
-            diagnostics: {
-              assistantMessageCount: 1,
-              modelId: "test-model",
-              outcome: "success" as const,
-              toolCalls: [],
-              toolErrorCount: 0,
-              toolResultCount: 0,
-              usedPrimaryText: true,
-            },
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: "Today is April 16, 2026.",
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "test-model",
+                outcome: "success" as const,
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            }),
         },
       },
     });
@@ -2338,7 +2345,7 @@ describe("bot handlers (integration)", () => {
             await context?.onArtifactStateUpdated?.({
               lastCanvasId: "F_CANVAS",
             });
-            return {
+            return completedAgentRun({
               text: "Today is April 16, 2026.",
               diagnostics: {
                 assistantMessageCount: 1,
@@ -2349,7 +2356,7 @@ describe("bot handlers (integration)", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },
@@ -2392,7 +2399,7 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           generateAssistantReply: async () => {
             turnCount += 1;
-            return {
+            return completedAgentRun({
               text: `reply-${turnCount}`,
               diagnostics: {
                 assistantMessageCount: 1,
@@ -2403,7 +2410,7 @@ describe("bot handlers (integration)", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },
@@ -2468,18 +2475,19 @@ describe("bot handlers (integration)", () => {
             }) as any,
         },
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: "This reply should still succeed.",
-            diagnostics: {
-              assistantMessageCount: 1,
-              modelId: "test-model",
-              outcome: "success" as const,
-              toolCalls: [],
-              toolErrorCount: 0,
-              toolResultCount: 0,
-              usedPrimaryText: true,
-            },
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: "This reply should still succeed.",
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "test-model",
+                outcome: "success" as const,
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            }),
         },
       },
     });
@@ -2528,18 +2536,19 @@ describe("bot handlers (integration)", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: "Reply still succeeds.",
-            diagnostics: {
-              assistantMessageCount: 1,
-              modelId: "test-model",
-              outcome: "success" as const,
-              toolCalls: [],
-              toolErrorCount: 0,
-              toolResultCount: 0,
-              usedPrimaryText: true,
-            },
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: "Reply still succeeds.",
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "test-model",
+                outcome: "success" as const,
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            }),
         },
       },
     });
@@ -2577,7 +2586,7 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           generateAssistantReply: async (_prompt, context) => {
             capturedContexts.push(context?.conversationContext);
-            return {
+            return completedAgentRun({
               text: "First reply.",
               diagnostics: {
                 assistantMessageCount: 1,
@@ -2588,7 +2597,7 @@ describe("bot handlers (integration)", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },
@@ -2618,7 +2627,7 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           generateAssistantReply: async (_prompt, context) => {
             capturedContexts.push(context?.conversationContext);
-            return {
+            return completedAgentRun({
               text: "Follow-up reply.",
               diagnostics: {
                 assistantMessageCount: 1,
@@ -2629,7 +2638,7 @@ describe("bot handlers (integration)", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },
@@ -2688,7 +2697,7 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           generateAssistantReply: async (_prompt, context) => {
             capturedContexts.push(context?.conversationContext);
-            return {
+            return completedAgentRun({
               text: "Responding to first message only.",
               diagnostics: {
                 assistantMessageCount: 1,
@@ -2699,7 +2708,7 @@ describe("bot handlers (integration)", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },
@@ -2746,7 +2755,7 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           generateAssistantReply: async () => {
             turnCount += 1;
-            return {
+            return completedAgentRun({
               text: `reply-${turnCount}`,
               diagnostics: {
                 assistantMessageCount: 1,
@@ -2757,7 +2766,7 @@ describe("bot handlers (integration)", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSlackSource, type Destination } from "@sentry/junior-plugin-api";
 import type { JuniorRuntimeServiceOverrides } from "@/chat/app/services";
-import type { ReplyRequestContext } from "@/chat/respond";
 import { makeAssistantStatus } from "@/chat/slack/assistant-thread/status";
 import { getSlackInterruptionMarker } from "@/chat/slack/output";
 import {
@@ -695,7 +694,17 @@ describe("bot handlers (integration)", () => {
       services: {
         replyExecutor: {
           agentRunner: {
-            run: async (_prompt, context) => {
+            run: async (request) => {
+              const _prompt = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               capturedCorrelation.push({
                 conversationId: context?.correlation?.conversationId,
                 threadId: context?.correlation?.threadId,
@@ -1215,7 +1224,9 @@ describe("bot handlers (integration)", () => {
     // The follow-up supersedes the pause: it must be answered, not consumed
     // into a resume that only happens if the user ever authorizes.
     expect(generateAssistantReply).toHaveBeenCalledOnce();
-    expect(generateAssistantReply.mock.calls[0]?.[0]).toContain("any update?");
+    expect(
+      generateAssistantReply.mock.calls[0]?.[0].input.messageText,
+    ).toContain("any update?");
     expect(postIncludes(thread, "Fresh answer without the provider.")).toBe(
       true,
     );
@@ -1479,7 +1490,17 @@ describe("bot handlers (integration)", () => {
       services: {
         replyExecutor: {
           agentRunner: {
-            run: async (_input, context) => {
+            run: async (request) => {
+              const _input = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               await context.onInputCommitted?.();
               throw new Error("post-ack turn failure");
             },
@@ -1835,7 +1856,17 @@ describe("bot handlers (integration)", () => {
       services: {
         replyExecutor: {
           agentRunner: {
-            run: async (_prompt, context) => {
+            run: async (request) => {
+              const _prompt = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               await context?.onTextDelta?.("Partial output...");
               return failedAgentRun({
                 text: "Partial output...",
@@ -1887,7 +1918,17 @@ describe("bot handlers (integration)", () => {
       services: {
         replyExecutor: {
           agentRunner: {
-            run: async (_prompt, context) => {
+            run: async (request) => {
+              const _prompt = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               await context?.onStatus?.(
                 makeAssistantStatus("reading", "channel messages"),
               );
@@ -2376,7 +2417,17 @@ describe("bot handlers (integration)", () => {
         },
         replyExecutor: {
           agentRunner: {
-            run: async (_text: string, context?: ReplyRequestContext) => {
+            run: async (request) => {
+              const _text = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               await vi.waitFor(() => {
                 expect(
                   fakeAdapter.titleCalls.some(
@@ -2634,7 +2685,17 @@ describe("bot handlers (integration)", () => {
       services: {
         replyExecutor: {
           agentRunner: {
-            run: async (_prompt, context) => {
+            run: async (request) => {
+              const _prompt = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               capturedContexts.push(context?.conversationContext);
               return completedAgentRun({
                 text: "First reply.",
@@ -2677,7 +2738,17 @@ describe("bot handlers (integration)", () => {
       services: {
         replyExecutor: {
           agentRunner: {
-            run: async (_prompt, context) => {
+            run: async (request) => {
+              const _prompt = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               capturedContexts.push(context?.conversationContext);
               return completedAgentRun({
                 text: "Follow-up reply.",
@@ -2749,7 +2820,17 @@ describe("bot handlers (integration)", () => {
         },
         replyExecutor: {
           agentRunner: {
-            run: async (_prompt, context) => {
+            run: async (request) => {
+              const _prompt = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               capturedContexts.push(context?.conversationContext);
               return completedAgentRun({
                 text: "Responding to first message only.",

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -173,7 +173,7 @@ describe("bot handlers (integration)", () => {
     await disconnectStateAdapter();
   });
 
-  it("handleNewMention: posts reply from generateAssistantReply", async () => {
+  it("handleNewMention: posts reply from executeAgentRun", async () => {
     const scheduleSessionCompletedPluginTasks = vi.fn(async () => undefined);
     const { slackRuntime } = createTestChatRuntime({
       services: {
@@ -237,11 +237,11 @@ describe("bot handlers (integration)", () => {
 
   it("does not replay a message that already has a delivered reply", async () => {
     const conversationId = "slack:C_REPLAY:1700000000.000";
-    const generateAssistantReply = vi.fn();
+    const executeAgentRun = vi.fn();
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
         },
       },
     });
@@ -311,7 +311,7 @@ describe("bot handlers (integration)", () => {
       ),
     ).resolves.toBeUndefined();
 
-    expect(generateAssistantReply).not.toHaveBeenCalled();
+    expect(executeAgentRun).not.toHaveBeenCalled();
     expect(thread.posts).toEqual([]);
   });
 
@@ -400,7 +400,7 @@ describe("bot handlers (integration)", () => {
       { destination: createTestDestination(thread) },
     );
 
-    // Should not have posted a reply (no generateAssistantReply call)
+    // Should not have posted a reply (no executeAgentRun call)
     const hasReply = thread.posts.some((p) => {
       if (typeof p === "string") return !p.startsWith("Error:");
       if (
@@ -444,7 +444,7 @@ describe("bot handlers (integration)", () => {
     expect(fakeAdapter.promptCalls[0].prompts.length).toBe(3);
   });
 
-  it("error recovery: posts safe error message when generateAssistantReply throws", async () => {
+  it("error recovery: posts safe error message when executeAgentRun throws", async () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
@@ -492,7 +492,7 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           agentRunner: {
             run: async () => {
-              // Simulate respond's durable input checkpoint: the session record
+              // Simulate agent-run durable input checkpoint: the session record
               // is running at the prompt boundary when generation finishes.
               await upsertAgentTurnSessionRecord({
                 conversationId,
@@ -1101,13 +1101,13 @@ describe("bot handlers (integration)", () => {
       sessionId: activeSessionId,
       expectedVersion: 4,
     });
-    const generateAssistantReply = vi.fn();
+    const executeAgentRun = vi.fn();
     const ack = vi.fn();
     const onTurnStatePersisted = vi.fn();
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
           getAwaitingAgentContinueRequest,
           scheduleAgentContinue,
         },
@@ -1146,7 +1146,7 @@ describe("bot handlers (integration)", () => {
       sessionId: activeSessionId,
       expectedVersion: 4,
     });
-    expect(generateAssistantReply).not.toHaveBeenCalled();
+    expect(executeAgentRun).not.toHaveBeenCalled();
     expect(onTurnStatePersisted).toHaveBeenCalledOnce();
     expect(ack).toHaveBeenCalledOnce();
     expect(thread.posts).toEqual([]);
@@ -1175,7 +1175,7 @@ describe("bot handlers (integration)", () => {
   it("answers a follow-up as a fresh turn when the active session is auth-parked", async () => {
     const conversationId = "slack:C_AUTH_PARKED:1700000000.000";
     const activeSessionId = "turn_msg-auth-original";
-    const generateAssistantReply = vi.fn().mockResolvedValue(
+    const executeAgentRun = vi.fn().mockResolvedValue(
       completedAgentRun({
         text: "Fresh answer without the provider.",
         diagnostics: {
@@ -1200,7 +1200,7 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
         },
       },
     });
@@ -1223,10 +1223,10 @@ describe("bot handlers (integration)", () => {
 
     // The follow-up supersedes the pause: it must be answered, not consumed
     // into a resume that only happens if the user ever authorizes.
-    expect(generateAssistantReply).toHaveBeenCalledOnce();
-    expect(
-      generateAssistantReply.mock.calls[0]?.[0].input.messageText,
-    ).toContain("any update?");
+    expect(executeAgentRun).toHaveBeenCalledOnce();
+    expect(executeAgentRun.mock.calls[0]?.[0].input.messageText).toContain(
+      "any update?",
+    );
     expect(postIncludes(thread, "Fresh answer without the provider.")).toBe(
       true,
     );
@@ -1267,12 +1267,12 @@ describe("bot handlers (integration)", () => {
         JSON.stringify(await loadProjection({ conversationId })),
       );
     });
-    const generateAssistantReply = vi.fn();
+    const executeAgentRun = vi.fn();
     const ack = vi.fn();
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
           scheduleAgentContinue,
         },
       },
@@ -1294,7 +1294,7 @@ describe("bot handlers (integration)", () => {
       ack,
     });
 
-    expect(generateAssistantReply).not.toHaveBeenCalled();
+    expect(executeAgentRun).not.toHaveBeenCalled();
     expect(thread.posts).toEqual([]);
     expect(ack).toHaveBeenCalledOnce();
     expect(scheduleAgentContinue).toHaveBeenCalledWith({
@@ -1577,7 +1577,7 @@ describe("bot handlers (integration)", () => {
   it("fails malformed awaiting continuations before handling the follow-up", async () => {
     const conversationId = "slack:C_BAD_CONTINUATION:1700000000.000";
     const activeSessionId = "turn_msg-timeout-original";
-    const generateAssistantReply = vi.fn().mockResolvedValue(
+    const executeAgentRun = vi.fn().mockResolvedValue(
       completedAgentRun({
         text: "Recovered.",
         diagnostics: {
@@ -1602,7 +1602,7 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
         },
       },
     });
@@ -1623,7 +1623,7 @@ describe("bot handlers (integration)", () => {
       { destination: createTestDestination(thread) },
     );
 
-    expect(generateAssistantReply).toHaveBeenCalledOnce();
+    expect(executeAgentRun).toHaveBeenCalledOnce();
     expect(postIncludes(thread, "Recovered.")).toBe(true);
     const failedRecord = await getAgentTurnSessionRecord(
       conversationId,
@@ -1653,11 +1653,11 @@ describe("bot handlers (integration)", () => {
       sessionId: activeSessionId,
       expectedVersion: 4,
     });
-    const generateAssistantReply = vi.fn();
+    const executeAgentRun = vi.fn();
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
           getAwaitingAgentContinueRequest,
           scheduleAgentContinue,
         },
@@ -1689,7 +1689,7 @@ describe("bot handlers (integration)", () => {
       sessionId: activeSessionId,
       expectedVersion: 4,
     });
-    expect(generateAssistantReply).not.toHaveBeenCalled();
+    expect(executeAgentRun).not.toHaveBeenCalled();
   });
 
   it("does not reschedule an awaiting continuation for an already-replied duplicate", async () => {
@@ -1703,12 +1703,12 @@ describe("bot handlers (integration)", () => {
       sessionId: activeSessionId,
       expectedVersion: 4,
     });
-    const generateAssistantReply = vi.fn();
+    const executeAgentRun = vi.fn();
     const onTurnStatePersisted = vi.fn();
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
           getAwaitingAgentContinueRequest,
           scheduleAgentContinue,
         },
@@ -1740,7 +1740,7 @@ describe("bot handlers (integration)", () => {
 
     expect(getAwaitingAgentContinueRequest).not.toHaveBeenCalled();
     expect(scheduleAgentContinue).not.toHaveBeenCalled();
-    expect(generateAssistantReply).not.toHaveBeenCalled();
+    expect(executeAgentRun).not.toHaveBeenCalled();
     expect(onTurnStatePersisted).toHaveBeenCalledOnce();
     expect(thread.posts).toEqual([]);
   });
@@ -1756,11 +1756,11 @@ describe("bot handlers (integration)", () => {
       sessionId: activeSessionId,
       expectedVersion: 4,
     });
-    const generateAssistantReply = vi.fn();
+    const executeAgentRun = vi.fn();
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
           getAwaitingAgentContinueRequest,
           scheduleAgentContinue,
         },
@@ -1789,7 +1789,7 @@ describe("bot handlers (integration)", () => {
       sessionId: activeSessionId,
       expectedVersion: 4,
     });
-    expect(generateAssistantReply).not.toHaveBeenCalled();
+    expect(executeAgentRun).not.toHaveBeenCalled();
     expect(thread.posts).toEqual([]);
 
     const state = thread.getState();
@@ -1816,11 +1816,11 @@ describe("bot handlers (integration)", () => {
       sessionId: activeSessionId,
       expectedVersion: 4,
     });
-    const generateAssistantReply = vi.fn();
+    const executeAgentRun = vi.fn();
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
           getAwaitingAgentContinueRequest,
           scheduleAgentContinue,
         },
@@ -1843,7 +1843,7 @@ describe("bot handlers (integration)", () => {
       { destination },
     );
 
-    expect(generateAssistantReply).not.toHaveBeenCalled();
+    expect(executeAgentRun).not.toHaveBeenCalled();
     expect(thread.posts).toEqual([
       expect.stringContaining(
         "I ran into an internal error while processing that.",

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -179,19 +179,21 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () =>
-            completedAgentRun({
-              text: "Hello from the bot!",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "test-model",
-                outcome: "success" as const,
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            }),
+          agentRunner: {
+            run: async () =>
+              completedAgentRun({
+                text: "Hello from the bot!",
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "test-model",
+                  outcome: "success" as const,
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              }),
+          },
           scheduleSessionCompletedPluginTasks,
         },
         visionContext: {
@@ -240,7 +242,7 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply,
+          agentRunner: { run: generateAssistantReply },
         },
       },
     });
@@ -329,19 +331,21 @@ describe("bot handlers (integration)", () => {
             }) as any,
         },
         replyExecutor: {
-          generateAssistantReply: async () =>
-            completedAgentRun({
-              text: "Replying to mention",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "test-model",
-                outcome: "success" as const,
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            }),
+          agentRunner: {
+            run: async () =>
+              completedAgentRun({
+                text: "Replying to mention",
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "test-model",
+                  outcome: "success" as const,
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              }),
+          },
         },
         visionContext: {
           listThreadReplies: async () => [],
@@ -445,8 +449,10 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => {
-            throw new Error("LLM unavailable");
+          agentRunner: {
+            run: async () => {
+              throw new Error("LLM unavailable");
+            },
           },
         },
         visionContext: {
@@ -485,54 +491,56 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => {
-            // Simulate respond's durable input checkpoint: the session record
-            // is running at the prompt boundary when generation finishes.
-            await upsertAgentTurnSessionRecord({
-              conversationId,
-              sessionId,
-              sliceId: 1,
-              state: "running",
-              piMessages: promptMessages,
-            });
-            return completedAgentRun({
-              text: finalText,
-              piMessages: [
-                ...promptMessages,
-                {
-                  role: "assistant" as const,
-                  content: [{ type: "text" as const, text: finalText }],
-                  api: "responses" as const,
-                  provider: "openai",
-                  model: "gpt-5.3",
-                  usage: {
-                    input: 1,
-                    output: 1,
-                    cacheRead: 0,
-                    cacheWrite: 0,
-                    totalTokens: 2,
-                    cost: {
-                      input: 0,
-                      output: 0,
+          agentRunner: {
+            run: async () => {
+              // Simulate respond's durable input checkpoint: the session record
+              // is running at the prompt boundary when generation finishes.
+              await upsertAgentTurnSessionRecord({
+                conversationId,
+                sessionId,
+                sliceId: 1,
+                state: "running",
+                piMessages: promptMessages,
+              });
+              return completedAgentRun({
+                text: finalText,
+                piMessages: [
+                  ...promptMessages,
+                  {
+                    role: "assistant" as const,
+                    content: [{ type: "text" as const, text: finalText }],
+                    api: "responses" as const,
+                    provider: "openai",
+                    model: "gpt-5.3",
+                    usage: {
+                      input: 1,
+                      output: 1,
                       cacheRead: 0,
                       cacheWrite: 0,
-                      total: 0,
+                      totalTokens: 2,
+                      cost: {
+                        input: 0,
+                        output: 0,
+                        cacheRead: 0,
+                        cacheWrite: 0,
+                        total: 0,
+                      },
                     },
+                    stopReason: "stop" as const,
+                    timestamp: 2,
                   },
-                  stopReason: "stop" as const,
-                  timestamp: 2,
+                ],
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "fake-agent-model",
+                  outcome: "success" as const,
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
                 },
-              ],
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success" as const,
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            });
+              });
+            },
           },
         },
         visionContext: {
@@ -610,19 +618,21 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () =>
-            completedAgentRun({
-              text: finalText,
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success" as const,
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            }),
+          agentRunner: {
+            run: async () =>
+              completedAgentRun({
+                text: finalText,
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "fake-agent-model",
+                  outcome: "success" as const,
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              }),
+          },
         },
         visionContext: {
           listThreadReplies: async () => [],
@@ -684,25 +694,27 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async (_prompt, context) => {
-            capturedCorrelation.push({
-              conversationId: context?.correlation?.conversationId,
-              threadId: context?.correlation?.threadId,
-              turnId: context?.correlation?.turnId,
-              runId: context?.correlation?.runId,
-            });
-            return completedAgentRun({
-              text: "Done.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "test-model",
-                outcome: "success" as const,
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            });
+          agentRunner: {
+            run: async (_prompt, context) => {
+              capturedCorrelation.push({
+                conversationId: context?.correlation?.conversationId,
+                threadId: context?.correlation?.threadId,
+                turnId: context?.correlation?.turnId,
+                runId: context?.correlation?.runId,
+              });
+              return completedAgentRun({
+                text: "Done.",
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "test-model",
+                  outcome: "success" as const,
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              });
+            },
           },
         },
       },
@@ -739,18 +751,20 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => {
-            return {
-              status: "awaiting_auth",
-              authDisposition: "link_sent",
-              authDurationMs: 1,
-              authKind: "mcp",
-              authProvider: "notion",
-              authProviderDisplayName: "Notion",
-              conversationId: "slack:C_AUTH:1700000000.000",
-              sessionId: "turn_msg-auth-pause",
-              sliceId: 2,
-            };
+          agentRunner: {
+            run: async () => {
+              return {
+                status: "awaiting_auth",
+                authDisposition: "link_sent",
+                authDurationMs: 1,
+                authKind: "mcp",
+                authProvider: "notion",
+                authProviderDisplayName: "Notion",
+                conversationId: "slack:C_AUTH:1700000000.000",
+                sessionId: "turn_msg-auth-pause",
+                sliceId: 2,
+              };
+            },
           },
         },
       },
@@ -823,18 +837,20 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => {
-            return {
-              status: "awaiting_auth",
-              authDisposition: "link_sent",
-              authDurationMs: 1,
-              authKind: "plugin",
-              authProvider: "github",
-              authProviderDisplayName: "GitHub",
-              conversationId: "slack:C_PLUGIN_AUTH:1700000000.000",
-              sessionId: "turn_msg-plugin-auth-pause",
-              sliceId: 2,
-            };
+          agentRunner: {
+            run: async () => {
+              return {
+                status: "awaiting_auth",
+                authDisposition: "link_sent",
+                authDurationMs: 1,
+                authKind: "plugin",
+                authProvider: "github",
+                authProviderDisplayName: "GitHub",
+                conversationId: "slack:C_PLUGIN_AUTH:1700000000.000",
+                sessionId: "turn_msg-plugin-auth-pause",
+                sliceId: 2,
+              };
+            },
           },
         },
       },
@@ -914,14 +930,16 @@ describe("bot handlers (integration)", () => {
       services: {
         replyExecutor: {
           scheduleAgentContinue,
-          generateAssistantReply: async () => {
-            return {
-              status: "timed_out",
-              conversationId,
-              sessionId,
-              version: 3,
-              sliceId: 2,
-            };
+          agentRunner: {
+            run: async () => {
+              return {
+                status: "timed_out",
+                conversationId,
+                sessionId,
+                version: 3,
+                sliceId: 2,
+              };
+            },
           },
         },
       },
@@ -970,14 +988,16 @@ describe("bot handlers (integration)", () => {
       services: {
         replyExecutor: {
           scheduleAgentContinue,
-          generateAssistantReply: async () => {
-            return {
-              status: "timed_out",
-              conversationId,
-              sessionId,
-              version: 4,
-              sliceId: 2,
-            };
+          agentRunner: {
+            run: async () => {
+              return {
+                status: "timed_out",
+                conversationId,
+                sessionId,
+                version: 4,
+                sliceId: 2,
+              };
+            },
           },
         },
       },
@@ -1019,14 +1039,16 @@ describe("bot handlers (integration)", () => {
       services: {
         replyExecutor: {
           scheduleAgentContinue,
-          generateAssistantReply: async () => {
-            return {
-              status: "timed_out",
-              conversationId,
-              sessionId,
-              version: 3,
-              sliceId: 2,
-            };
+          agentRunner: {
+            run: async () => {
+              return {
+                status: "timed_out",
+                conversationId,
+                sessionId,
+                version: 3,
+                sliceId: 2,
+              };
+            },
           },
         },
       },
@@ -1076,7 +1098,7 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply,
+          agentRunner: { run: generateAssistantReply },
           getAwaitingAgentContinueRequest,
           scheduleAgentContinue,
         },
@@ -1169,7 +1191,7 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply,
+          agentRunner: { run: generateAssistantReply },
         },
       },
     });
@@ -1239,7 +1261,7 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply,
+          agentRunner: { run: generateAssistantReply },
           scheduleAgentContinue,
         },
       },
@@ -1319,7 +1341,7 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: vi.fn(),
+          agentRunner: { run: vi.fn() },
           scheduleAgentContinue,
         },
       },
@@ -1376,7 +1398,7 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: vi.fn(),
+          agentRunner: { run: vi.fn() },
           scheduleAgentContinue,
         },
       },
@@ -1421,8 +1443,10 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => {
-            throw new Error("transient turn failure");
+          agentRunner: {
+            run: async () => {
+              throw new Error("transient turn failure");
+            },
           },
         },
       },
@@ -1454,9 +1478,11 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async (_input, context) => {
-            await context.onInputCommitted?.();
-            throw new Error("post-ack turn failure");
+          agentRunner: {
+            run: async (_input, context) => {
+              await context.onInputCommitted?.();
+              throw new Error("post-ack turn failure");
+            },
           },
         },
       },
@@ -1493,8 +1519,10 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => {
-            throw new Error("persistent turn failure");
+          agentRunner: {
+            run: async () => {
+              throw new Error("persistent turn failure");
+            },
           },
         },
       },
@@ -1553,7 +1581,7 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply,
+          agentRunner: { run: generateAssistantReply },
         },
       },
     });
@@ -1608,7 +1636,7 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply,
+          agentRunner: { run: generateAssistantReply },
           getAwaitingAgentContinueRequest,
           scheduleAgentContinue,
         },
@@ -1659,7 +1687,7 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply,
+          agentRunner: { run: generateAssistantReply },
           getAwaitingAgentContinueRequest,
           scheduleAgentContinue,
         },
@@ -1711,7 +1739,7 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply,
+          agentRunner: { run: generateAssistantReply },
           getAwaitingAgentContinueRequest,
           scheduleAgentContinue,
         },
@@ -1771,7 +1799,7 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply,
+          agentRunner: { run: generateAssistantReply },
           getAwaitingAgentContinueRequest,
           scheduleAgentContinue,
         },
@@ -1806,20 +1834,22 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async (_prompt, context) => {
-            await context?.onTextDelta?.("Partial output...");
-            return failedAgentRun({
-              text: "Partial output...",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "test-model",
-                outcome: "provider_error" as const,
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            });
+          agentRunner: {
+            run: async (_prompt, context) => {
+              await context?.onTextDelta?.("Partial output...");
+              return failedAgentRun({
+                text: "Partial output...",
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "test-model",
+                  outcome: "provider_error" as const,
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              });
+            },
           },
         },
       },
@@ -1856,22 +1886,24 @@ describe("bot handlers (integration)", () => {
       slackAdapter: fakeAdapter,
       services: {
         replyExecutor: {
-          generateAssistantReply: async (_prompt, context) => {
-            await context?.onStatus?.(
-              makeAssistantStatus("reading", "channel messages"),
-            );
-            return completedAgentRun({
-              text: "Done.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "test-model",
-                outcome: "success" as const,
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            });
+          agentRunner: {
+            run: async (_prompt, context) => {
+              await context?.onStatus?.(
+                makeAssistantStatus("reading", "channel messages"),
+              );
+              return completedAgentRun({
+                text: "Done.",
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "test-model",
+                  outcome: "success" as const,
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              });
+            },
           },
         },
       },
@@ -1927,20 +1959,22 @@ describe("bot handlers (integration)", () => {
           completeText: async () => ({ text: "Status thread" }) as never,
         },
         replyExecutor: {
-          generateAssistantReply: async () => {
-            replyStarted = true;
-            return completedAgentRun({
-              text: "Still replied while status was pending.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "test-model",
-                outcome: "success" as const,
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            });
+          agentRunner: {
+            run: async () => {
+              replyStarted = true;
+              return completedAgentRun({
+                text: "Still replied while status was pending.",
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "test-model",
+                  outcome: "success" as const,
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              });
+            },
           },
         },
       },
@@ -2010,20 +2044,22 @@ describe("bot handlers (integration)", () => {
           completeText: async () => ({ text: "Status thread" }) as never,
         },
         replyExecutor: {
-          generateAssistantReply: async () => {
-            replyStarted = true;
-            return completedAgentRun({
-              text: "Reply lands after the pending status is drained.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "test-model",
-                outcome: "success" as const,
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            });
+          agentRunner: {
+            run: async () => {
+              replyStarted = true;
+              return completedAgentRun({
+                text: "Reply lands after the pending status is drained.",
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "test-model",
+                  outcome: "success" as const,
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              });
+            },
           },
         },
       },
@@ -2073,19 +2109,21 @@ describe("bot handlers (integration)", () => {
             }) as any,
         },
         replyExecutor: {
-          generateAssistantReply: async () =>
-            completedAgentRun({
-              text: "Here is how to debug memory leaks.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "test-model",
-                outcome: "success" as const,
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            }),
+          agentRunner: {
+            run: async () =>
+              completedAgentRun({
+                text: "Here is how to debug memory leaks.",
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "test-model",
+                  outcome: "success" as const,
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              }),
+          },
         },
       },
     });
@@ -2134,19 +2172,21 @@ describe("bot handlers (integration)", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async () =>
-            completedAgentRun({
-              text: "Here is the updated answer.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "test-model",
-                outcome: "success" as const,
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            }),
+          agentRunner: {
+            run: async () =>
+              completedAgentRun({
+                text: "Here is the updated answer.",
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "test-model",
+                  outcome: "success" as const,
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              }),
+          },
         },
       },
     });
@@ -2194,19 +2234,21 @@ describe("bot handlers (integration)", () => {
             }) as any,
         },
         replyExecutor: {
-          generateAssistantReply: async () =>
-            completedAgentRun({
-              text: "Today is April 16, 2026.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "test-model",
-                outcome: "success" as const,
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            }),
+          agentRunner: {
+            run: async () =>
+              completedAgentRun({
+                text: "Today is April 16, 2026.",
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "test-model",
+                  outcome: "success" as const,
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              }),
+          },
         },
       },
     });
@@ -2265,19 +2307,21 @@ describe("bot handlers (integration)", () => {
             }),
         },
         replyExecutor: {
-          generateAssistantReply: async () =>
-            completedAgentRun({
-              text: "Today is April 16, 2026.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "test-model",
-                outcome: "success" as const,
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            }),
+          agentRunner: {
+            run: async () =>
+              completedAgentRun({
+                text: "Today is April 16, 2026.",
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "test-model",
+                  outcome: "success" as const,
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              }),
+          },
         },
       },
     });
@@ -2331,32 +2375,31 @@ describe("bot handlers (integration)", () => {
             }) as any,
         },
         replyExecutor: {
-          generateAssistantReply: async (
-            _text: string,
-            context?: ReplyRequestContext,
-          ) => {
-            await vi.waitFor(() => {
-              expect(
-                fakeAdapter.titleCalls.some(
-                  (call) => call.title === "Today's Date",
-                ),
-              ).toBe(true);
-            });
-            await context?.onArtifactStateUpdated?.({
-              lastCanvasId: "F_CANVAS",
-            });
-            return completedAgentRun({
-              text: "Today is April 16, 2026.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "test-model",
-                outcome: "success" as const,
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            });
+          agentRunner: {
+            run: async (_text: string, context?: ReplyRequestContext) => {
+              await vi.waitFor(() => {
+                expect(
+                  fakeAdapter.titleCalls.some(
+                    (call) => call.title === "Today's Date",
+                  ),
+                ).toBe(true);
+              });
+              await context?.onArtifactStateUpdated?.({
+                lastCanvasId: "F_CANVAS",
+              });
+              return completedAgentRun({
+                text: "Today is April 16, 2026.",
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "test-model",
+                  outcome: "success" as const,
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              });
+            },
           },
         },
       },
@@ -2397,20 +2440,22 @@ describe("bot handlers (integration)", () => {
             }) as any,
         },
         replyExecutor: {
-          generateAssistantReply: async () => {
-            turnCount += 1;
-            return completedAgentRun({
-              text: `reply-${turnCount}`,
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "test-model",
-                outcome: "success" as const,
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            });
+          agentRunner: {
+            run: async () => {
+              turnCount += 1;
+              return completedAgentRun({
+                text: `reply-${turnCount}`,
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "test-model",
+                  outcome: "success" as const,
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              });
+            },
           },
         },
       },
@@ -2475,19 +2520,21 @@ describe("bot handlers (integration)", () => {
             }) as any,
         },
         replyExecutor: {
-          generateAssistantReply: async () =>
-            completedAgentRun({
-              text: "This reply should still succeed.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "test-model",
-                outcome: "success" as const,
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            }),
+          agentRunner: {
+            run: async () =>
+              completedAgentRun({
+                text: "This reply should still succeed.",
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "test-model",
+                  outcome: "success" as const,
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              }),
+          },
         },
       },
     });
@@ -2536,19 +2583,21 @@ describe("bot handlers (integration)", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async () =>
-            completedAgentRun({
-              text: "Reply still succeeds.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "test-model",
-                outcome: "success" as const,
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            }),
+          agentRunner: {
+            run: async () =>
+              completedAgentRun({
+                text: "Reply still succeeds.",
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "test-model",
+                  outcome: "success" as const,
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              }),
+          },
         },
       },
     });
@@ -2584,20 +2633,22 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async (_prompt, context) => {
-            capturedContexts.push(context?.conversationContext);
-            return completedAgentRun({
-              text: "First reply.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "test-model",
-                outcome: "success" as const,
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            });
+          agentRunner: {
+            run: async (_prompt, context) => {
+              capturedContexts.push(context?.conversationContext);
+              return completedAgentRun({
+                text: "First reply.",
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "test-model",
+                  outcome: "success" as const,
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              });
+            },
           },
         },
       },
@@ -2625,20 +2676,22 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async (_prompt, context) => {
-            capturedContexts.push(context?.conversationContext);
-            return completedAgentRun({
-              text: "Follow-up reply.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "test-model",
-                outcome: "success" as const,
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            });
+          agentRunner: {
+            run: async (_prompt, context) => {
+              capturedContexts.push(context?.conversationContext);
+              return completedAgentRun({
+                text: "Follow-up reply.",
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "test-model",
+                  outcome: "success" as const,
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              });
+            },
           },
         },
       },
@@ -2695,20 +2748,22 @@ describe("bot handlers (integration)", () => {
             }) as any,
         },
         replyExecutor: {
-          generateAssistantReply: async (_prompt, context) => {
-            capturedContexts.push(context?.conversationContext);
-            return completedAgentRun({
-              text: "Responding to first message only.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "test-model",
-                outcome: "success" as const,
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            });
+          agentRunner: {
+            run: async (_prompt, context) => {
+              capturedContexts.push(context?.conversationContext);
+              return completedAgentRun({
+                text: "Responding to first message only.",
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "test-model",
+                  outcome: "success" as const,
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              });
+            },
           },
         },
       },
@@ -2753,20 +2808,22 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => {
-            turnCount += 1;
-            return completedAgentRun({
-              text: `reply-${turnCount}`,
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "test-model",
-                outcome: "success" as const,
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            });
+          agentRunner: {
+            run: async () => {
+              turnCount += 1;
+              return completedAgentRun({
+                text: `reply-${turnCount}`,
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "test-model",
+                  outcome: "success" as const,
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              });
+            },
           },
         },
       },

--- a/packages/junior/tests/integration/slack/bot-image-hydration.test.ts
+++ b/packages/junior/tests/integration/slack/bot-image-hydration.test.ts
@@ -83,7 +83,7 @@ describe("bot image hydration", () => {
             listThreadReplies: listThreadRepliesMock,
           },
           replyExecutor: {
-            generateAssistantReply: async () => makeSuccessOutcome(),
+            agentRunner: { run: async () => makeSuccessOutcome() },
           },
         },
       },
@@ -182,7 +182,7 @@ describe("bot image hydration", () => {
           listThreadReplies: listThreadRepliesMock,
         },
         replyExecutor: {
-          generateAssistantReply: async () => makeSuccessOutcome(),
+          agentRunner: { run: async () => makeSuccessOutcome() },
         },
       },
     });
@@ -284,7 +284,7 @@ describe("bot image hydration", () => {
           listThreadReplies: listThreadRepliesMock,
         },
         replyExecutor: {
-          generateAssistantReply: async () => makeSuccessOutcome(),
+          agentRunner: { run: async () => makeSuccessOutcome() },
         },
       },
     });
@@ -366,7 +366,7 @@ describe("bot image hydration", () => {
             completeText: completeTextMock,
           },
           replyExecutor: {
-            generateAssistantReply: async () => makeSuccessOutcome(),
+            agentRunner: { run: async () => makeSuccessOutcome() },
           },
         },
       },
@@ -476,7 +476,7 @@ describe("bot image hydration", () => {
             completeText: completeTextMock,
           },
           replyExecutor: {
-            generateAssistantReply,
+            agentRunner: { run: generateAssistantReply },
           },
         },
       },
@@ -631,7 +631,7 @@ describe("bot image hydration", () => {
             completeText: completeTextMock,
           },
           replyExecutor: {
-            generateAssistantReply,
+            agentRunner: { run: generateAssistantReply },
           },
         },
       },
@@ -790,7 +790,7 @@ describe("bot image hydration", () => {
             completeText: completeTextMock,
           },
           replyExecutor: {
-            generateAssistantReply,
+            agentRunner: { run: generateAssistantReply },
           },
         },
       },
@@ -913,7 +913,7 @@ describe("bot image hydration", () => {
             completeText: completeTextMock,
           },
           replyExecutor: {
-            generateAssistantReply,
+            agentRunner: { run: generateAssistantReply },
           },
         },
       },
@@ -1015,11 +1015,13 @@ describe("bot image hydration", () => {
           listThreadReplies: listThreadRepliesMock.mockResolvedValue([]),
         },
         replyExecutor: {
-          generateAssistantReply: async () =>
-            completedAgentRun({
-              ...makeSuccessReply("Here is your image"),
-              files: [generatedFile],
-            }),
+          agentRunner: {
+            run: async () =>
+              completedAgentRun({
+                ...makeSuccessReply("Here is your image"),
+                files: [generatedFile],
+              }),
+          },
         },
       },
     });
@@ -1071,17 +1073,19 @@ describe("bot image hydration", () => {
           listThreadReplies: listThreadRepliesMock.mockResolvedValue([]),
         },
         replyExecutor: {
-          generateAssistantReply: async (_text: string, _context: any) => {
-            return completedAgentRun({
-              ...makeSuccessReply("finalized content"),
-              files: [
-                {
-                  data: Buffer.from("fake-png"),
-                  filename: "generated.png",
-                  mimeType: "image/png",
-                },
-              ],
-            });
+          agentRunner: {
+            run: async (_text: string, _context: any) => {
+              return completedAgentRun({
+                ...makeSuccessReply("finalized content"),
+                files: [
+                  {
+                    data: Buffer.from("fake-png"),
+                    filename: "generated.png",
+                    mimeType: "image/png",
+                  },
+                ],
+              });
+            },
           },
         },
       },

--- a/packages/junior/tests/integration/slack/bot-image-hydration.test.ts
+++ b/packages/junior/tests/integration/slack/bot-image-hydration.test.ts
@@ -5,6 +5,7 @@ import {
   createTestThread,
   createTestDestination,
 } from "../../fixtures/slack-harness";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const listThreadRepliesMock = vi.fn();
 const ORIGINAL_ENV = { ...process.env };
@@ -40,6 +41,10 @@ function makeSuccessReply(text = "ok") {
       usedPrimaryText: true,
     },
   };
+}
+
+function makeSuccessOutcome(text = "ok") {
+  return completedAgentRun(makeSuccessReply(text));
 }
 
 function extractImageAttachmentSummary(
@@ -78,7 +83,7 @@ describe("bot image hydration", () => {
             listThreadReplies: listThreadRepliesMock,
           },
           replyExecutor: {
-            generateAssistantReply: async () => makeSuccessReply(),
+            generateAssistantReply: async () => makeSuccessOutcome(),
           },
         },
       },
@@ -177,7 +182,7 @@ describe("bot image hydration", () => {
           listThreadReplies: listThreadRepliesMock,
         },
         replyExecutor: {
-          generateAssistantReply: async () => makeSuccessReply(),
+          generateAssistantReply: async () => makeSuccessOutcome(),
         },
       },
     });
@@ -279,7 +284,7 @@ describe("bot image hydration", () => {
           listThreadReplies: listThreadRepliesMock,
         },
         replyExecutor: {
-          generateAssistantReply: async () => makeSuccessReply(),
+          generateAssistantReply: async () => makeSuccessOutcome(),
         },
       },
     });
@@ -361,7 +366,7 @@ describe("bot image hydration", () => {
             completeText: completeTextMock,
           },
           replyExecutor: {
-            generateAssistantReply: async () => makeSuccessReply(),
+            generateAssistantReply: async () => makeSuccessOutcome(),
           },
         },
       },
@@ -451,7 +456,7 @@ describe("bot image hydration", () => {
         expect(context?.conversationContext).toContain(
           "Passive screenshot summary",
         );
-        return makeSuccessReply();
+        return makeSuccessOutcome();
       },
     );
 
@@ -613,7 +618,7 @@ describe("bot image hydration", () => {
             promptText: expect.stringContaining("Current screenshot summary"),
           }),
         ]);
-        return makeSuccessReply();
+        return makeSuccessOutcome();
       },
     );
 
@@ -772,7 +777,7 @@ describe("bot image hydration", () => {
             promptText: expect.stringContaining("Second cached summary"),
           }),
         ]);
-        return makeSuccessReply();
+        return makeSuccessOutcome();
       },
     );
 
@@ -896,7 +901,7 @@ describe("bot image hydration", () => {
         const summary = extractImageAttachmentSummary(promptText);
         expect(summary).toBe(longSummary.slice(0, 500));
         expect(summary).toHaveLength(500);
-        return makeSuccessReply();
+        return makeSuccessOutcome();
       },
     );
 
@@ -1010,10 +1015,11 @@ describe("bot image hydration", () => {
           listThreadReplies: listThreadRepliesMock.mockResolvedValue([]),
         },
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            ...makeSuccessReply("Here is your image"),
-            files: [generatedFile],
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              ...makeSuccessReply("Here is your image"),
+              files: [generatedFile],
+            }),
         },
       },
     });
@@ -1066,7 +1072,7 @@ describe("bot image hydration", () => {
         },
         replyExecutor: {
           generateAssistantReply: async (_text: string, _context: any) => {
-            return {
+            return completedAgentRun({
               ...makeSuccessReply("finalized content"),
               files: [
                 {
@@ -1075,7 +1081,7 @@ describe("bot image hydration", () => {
                   mimeType: "image/png",
                 },
               ],
-            };
+            });
           },
         },
       },

--- a/packages/junior/tests/integration/slack/bot-image-hydration.test.ts
+++ b/packages/junior/tests/integration/slack/bot-image-hydration.test.ts
@@ -6,9 +6,23 @@ import {
   createTestDestination,
 } from "../../fixtures/slack-harness";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
+import type { AgentRunner } from "@/chat/runtime/agent-runner";
 
 const listThreadRepliesMock = vi.fn();
 const ORIGINAL_ENV = { ...process.env };
+
+function flattenReplyRequestForTest(
+  request: Parameters<AgentRunner["run"]>[0],
+) {
+  return {
+    ...request.input,
+    ...request.routing,
+    ...(request.policy ?? {}),
+    ...(request.state ?? {}),
+    ...(request.observers ?? {}),
+    ...(request.durability ?? {}),
+  };
+}
 
 async function createRuntime(
   args: Parameters<
@@ -451,8 +465,9 @@ describe("bot image hydration", () => {
       text: "Passive screenshot summary",
       message: {} as never,
     }));
-    const generateAssistantReply = vi.fn(
-      async (_text: string, context: any) => {
+    const generateAssistantReply = vi.fn<AgentRunner["run"]>(
+      async (request) => {
+        const context = flattenReplyRequestForTest(request);
         expect(context?.conversationContext).toContain(
           "Passive screenshot summary",
         );
@@ -609,8 +624,9 @@ describe("bot image hydration", () => {
       message: {} as never,
     }));
     const attachmentFetch = vi.fn(async () => Buffer.from("attachment-image"));
-    const generateAssistantReply = vi.fn(
-      async (_text: string, context: any) => {
+    const generateAssistantReply = vi.fn<AgentRunner["run"]>(
+      async (request) => {
+        const context = flattenReplyRequestForTest(request);
         expect(context?.userAttachments).toEqual([
           expect.objectContaining({
             mediaType: "image/png",
@@ -765,8 +781,9 @@ describe("bot image hydration", () => {
     const secondAttachmentFetch = vi.fn(async () =>
       Buffer.from("second-image"),
     );
-    const generateAssistantReply = vi.fn(
-      async (_text: string, context: any) => {
+    const generateAssistantReply = vi.fn<AgentRunner["run"]>(
+      async (request) => {
+        const context = flattenReplyRequestForTest(request);
         expect(context?.userAttachments).toEqual([
           expect.objectContaining({
             filename: "first.png",
@@ -895,8 +912,9 @@ describe("bot image hydration", () => {
       text: longSummary,
       message: {} as never,
     }));
-    const generateAssistantReply = vi.fn(
-      async (_text: string, context: any) => {
+    const generateAssistantReply = vi.fn<AgentRunner["run"]>(
+      async (request) => {
+        const context = flattenReplyRequestForTest(request);
         const promptText = context?.userAttachments?.[0]?.promptText;
         const summary = extractImageAttachmentSummary(promptText);
         expect(summary).toBe(longSummary.slice(0, 500));
@@ -1074,7 +1092,17 @@ describe("bot image hydration", () => {
         },
         replyExecutor: {
           agentRunner: {
-            run: async (_text: string, _context: any) => {
+            run: async (request) => {
+              const _text = request.input.messageText;
+              const _context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               return completedAgentRun({
                 ...makeSuccessReply("finalized content"),
                 files: [

--- a/packages/junior/tests/integration/slack/bot-image-hydration.test.ts
+++ b/packages/junior/tests/integration/slack/bot-image-hydration.test.ts
@@ -11,7 +11,7 @@ import type { AgentRunner } from "@/chat/runtime/agent-runner";
 const listThreadRepliesMock = vi.fn();
 const ORIGINAL_ENV = { ...process.env };
 
-function flattenReplyRequestForTest(
+function flattenAgentRunRequestForTest(
   request: Parameters<AgentRunner["run"]>[0],
 ) {
   return {
@@ -465,15 +465,13 @@ describe("bot image hydration", () => {
       text: "Passive screenshot summary",
       message: {} as never,
     }));
-    const generateAssistantReply = vi.fn<AgentRunner["run"]>(
-      async (request) => {
-        const context = flattenReplyRequestForTest(request);
-        expect(context?.conversationContext).toContain(
-          "Passive screenshot summary",
-        );
-        return makeSuccessOutcome();
-      },
-    );
+    const executeAgentRun = vi.fn<AgentRunner["run"]>(async (request) => {
+      const context = flattenAgentRunRequestForTest(request);
+      expect(context?.conversationContext).toContain(
+        "Passive screenshot summary",
+      );
+      return makeSuccessOutcome();
+    });
 
     const { slackRuntime } = await createRuntime(
       {
@@ -491,7 +489,7 @@ describe("bot image hydration", () => {
             completeText: completeTextMock,
           },
           replyExecutor: {
-            agentRunner: { run: generateAssistantReply },
+            agentRunner: { run: executeAgentRun },
           },
         },
       },
@@ -550,7 +548,7 @@ describe("bot image hydration", () => {
       { destination: createTestDestination(thread) },
     );
 
-    expect(generateAssistantReply).not.toHaveBeenCalled();
+    expect(executeAgentRun).not.toHaveBeenCalled();
     expect(listThreadRepliesMock).not.toHaveBeenCalled();
 
     await slackRuntime.handleNewMention(
@@ -574,7 +572,7 @@ describe("bot image hydration", () => {
     expect(listThreadRepliesMock).toHaveBeenCalledTimes(1);
     expect(downloadFileMock).toHaveBeenCalledTimes(1);
     expect(completeTextMock).toHaveBeenCalledTimes(1);
-    expect(generateAssistantReply).toHaveBeenCalledTimes(1);
+    expect(executeAgentRun).toHaveBeenCalledTimes(1);
 
     const persistedState = thread.getState() as {
       conversation: {
@@ -624,19 +622,17 @@ describe("bot image hydration", () => {
       message: {} as never,
     }));
     const attachmentFetch = vi.fn(async () => Buffer.from("attachment-image"));
-    const generateAssistantReply = vi.fn<AgentRunner["run"]>(
-      async (request) => {
-        const context = flattenReplyRequestForTest(request);
-        expect(context?.userAttachments).toEqual([
-          expect.objectContaining({
-            mediaType: "image/png",
-            filename: "screen.png",
-            promptText: expect.stringContaining("Current screenshot summary"),
-          }),
-        ]);
-        return makeSuccessOutcome();
-      },
-    );
+    const executeAgentRun = vi.fn<AgentRunner["run"]>(async (request) => {
+      const context = flattenAgentRunRequestForTest(request);
+      expect(context?.userAttachments).toEqual([
+        expect.objectContaining({
+          mediaType: "image/png",
+          filename: "screen.png",
+          promptText: expect.stringContaining("Current screenshot summary"),
+        }),
+      ]);
+      return makeSuccessOutcome();
+    });
 
     const { slackRuntime } = await createRuntime(
       {
@@ -647,7 +643,7 @@ describe("bot image hydration", () => {
             completeText: completeTextMock,
           },
           replyExecutor: {
-            agentRunner: { run: generateAssistantReply },
+            agentRunner: { run: executeAgentRun },
           },
         },
       },
@@ -735,7 +731,7 @@ describe("bot image hydration", () => {
     expect(downloadFileMock).toHaveBeenCalledTimes(1);
     expect(completeTextMock).toHaveBeenCalledTimes(1);
     expect(attachmentFetch).not.toHaveBeenCalled();
-    expect(generateAssistantReply).toHaveBeenCalledTimes(1);
+    expect(executeAgentRun).toHaveBeenCalledTimes(1);
   });
 
   it("keeps cached image summaries aligned with attachment positions", async () => {
@@ -781,22 +777,20 @@ describe("bot image hydration", () => {
     const secondAttachmentFetch = vi.fn(async () =>
       Buffer.from("second-image"),
     );
-    const generateAssistantReply = vi.fn<AgentRunner["run"]>(
-      async (request) => {
-        const context = flattenReplyRequestForTest(request);
-        expect(context?.userAttachments).toEqual([
-          expect.objectContaining({
-            filename: "first.png",
-            promptText: expect.stringContaining("First attachment summary"),
-          }),
-          expect.objectContaining({
-            filename: "second.png",
-            promptText: expect.stringContaining("Second cached summary"),
-          }),
-        ]);
-        return makeSuccessOutcome();
-      },
-    );
+    const executeAgentRun = vi.fn<AgentRunner["run"]>(async (request) => {
+      const context = flattenAgentRunRequestForTest(request);
+      expect(context?.userAttachments).toEqual([
+        expect.objectContaining({
+          filename: "first.png",
+          promptText: expect.stringContaining("First attachment summary"),
+        }),
+        expect.objectContaining({
+          filename: "second.png",
+          promptText: expect.stringContaining("Second cached summary"),
+        }),
+      ]);
+      return makeSuccessOutcome();
+    });
 
     const { slackRuntime } = await createRuntime(
       {
@@ -807,7 +801,7 @@ describe("bot image hydration", () => {
             completeText: completeTextMock,
           },
           replyExecutor: {
-            agentRunner: { run: generateAssistantReply },
+            agentRunner: { run: executeAgentRun },
           },
         },
       },
@@ -902,7 +896,7 @@ describe("bot image hydration", () => {
     expect(completeTextMock).toHaveBeenCalledTimes(3);
     expect(firstAttachmentFetch).toHaveBeenCalledTimes(1);
     expect(secondAttachmentFetch).not.toHaveBeenCalled();
-    expect(generateAssistantReply).toHaveBeenCalledTimes(1);
+    expect(executeAgentRun).toHaveBeenCalledTimes(1);
   });
 
   it("truncates inline image summaries to the cached summary limit", async () => {
@@ -912,16 +906,14 @@ describe("bot image hydration", () => {
       text: longSummary,
       message: {} as never,
     }));
-    const generateAssistantReply = vi.fn<AgentRunner["run"]>(
-      async (request) => {
-        const context = flattenReplyRequestForTest(request);
-        const promptText = context?.userAttachments?.[0]?.promptText;
-        const summary = extractImageAttachmentSummary(promptText);
-        expect(summary).toBe(longSummary.slice(0, 500));
-        expect(summary).toHaveLength(500);
-        return makeSuccessOutcome();
-      },
-    );
+    const executeAgentRun = vi.fn<AgentRunner["run"]>(async (request) => {
+      const context = flattenAgentRunRequestForTest(request);
+      const promptText = context?.userAttachments?.[0]?.promptText;
+      const summary = extractImageAttachmentSummary(promptText);
+      expect(summary).toBe(longSummary.slice(0, 500));
+      expect(summary).toHaveLength(500);
+      return makeSuccessOutcome();
+    });
 
     const { slackRuntime } = await createRuntime(
       {
@@ -931,7 +923,7 @@ describe("bot image hydration", () => {
             completeText: completeTextMock,
           },
           replyExecutor: {
-            agentRunner: { run: generateAssistantReply },
+            agentRunner: { run: executeAgentRun },
           },
         },
       },
@@ -1017,7 +1009,7 @@ describe("bot image hydration", () => {
     );
 
     expect(completeTextMock).toHaveBeenCalledTimes(1);
-    expect(generateAssistantReply).toHaveBeenCalledTimes(1);
+    expect(executeAgentRun).toHaveBeenCalledTimes(1);
   });
 
   it("includes generated files in thread.post via SDK file upload", async () => {

--- a/packages/junior/tests/integration/slack/canvas-failure-recovery-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/canvas-failure-recovery-behavior.test.ts
@@ -23,8 +23,8 @@ function toPostedText(value: unknown): string {
 describe("Slack behavior: canvas failure recovery", () => {
   it("points to a created canvas when reply generation fails before final text", async () => {
     const generateAssistantReply = vi.fn(
-      async (_text: string, context?: ReplyRequestContext) => {
-        await context?.onArtifactStateUpdated?.({
+      async (request: ReplyRequestContext) => {
+        await request.durability?.onArtifactStateUpdated?.({
           lastCanvasId: "F_CANVAS",
           lastCanvasUrl: "https://slack.example/docs/T/F_CANVAS",
           recentCanvases: [

--- a/packages/junior/tests/integration/slack/canvas-failure-recovery-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/canvas-failure-recovery-behavior.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { ReplyRequestContext } from "@/chat/respond";
+import type { AgentRunRequest } from "@/chat/agent-run";
 import { createTestChatRuntime } from "../../fixtures/chat-runtime";
 import {
   createTestMessage,
@@ -22,27 +22,25 @@ function toPostedText(value: unknown): string {
 
 describe("Slack behavior: canvas failure recovery", () => {
   it("points to a created canvas when reply generation fails before final text", async () => {
-    const generateAssistantReply = vi.fn(
-      async (request: ReplyRequestContext) => {
-        await request.durability?.onArtifactStateUpdated?.({
-          lastCanvasId: "F_CANVAS",
-          lastCanvasUrl: "https://slack.example/docs/T/F_CANVAS",
-          recentCanvases: [
-            {
-              id: "F_CANVAS",
-              title: "Research reference",
-              url: "https://slack.example/docs/T/F_CANVAS",
-              createdAt: "2026-05-20T20:00:00.000Z",
-            },
-          ],
-        });
-        throw new Error("forced failure after canvas");
-      },
-    );
+    const executeAgentRun = vi.fn(async (request: AgentRunRequest) => {
+      await request.durability?.onArtifactStateUpdated?.({
+        lastCanvasId: "F_CANVAS",
+        lastCanvasUrl: "https://slack.example/docs/T/F_CANVAS",
+        recentCanvases: [
+          {
+            id: "F_CANVAS",
+            title: "Research reference",
+            url: "https://slack.example/docs/T/F_CANVAS",
+            createdAt: "2026-05-20T20:00:00.000Z",
+          },
+        ],
+      });
+      throw new Error("forced failure after canvas");
+    });
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
         },
       },
     });
@@ -74,13 +72,13 @@ describe("Slack behavior: canvas failure recovery", () => {
   });
 
   it("does not recover with a canvas from a prior turn", async () => {
-    const generateAssistantReply = vi.fn(async () => {
+    const executeAgentRun = vi.fn(async () => {
       throw new Error("forced unrelated failure");
     });
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
         },
       },
     });

--- a/packages/junior/tests/integration/slack/canvas-failure-recovery-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/canvas-failure-recovery-behavior.test.ts
@@ -42,7 +42,7 @@ describe("Slack behavior: canvas failure recovery", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply,
+          agentRunner: { run: generateAssistantReply },
         },
       },
     });
@@ -80,7 +80,7 @@ describe("Slack behavior: canvas failure recovery", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply,
+          agentRunner: { run: generateAssistantReply },
         },
       },
     });

--- a/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
@@ -13,7 +13,7 @@ import { slackApiOutbox } from "../../fixtures/slack-api-outbox";
 import { resetSlackApiMockState } from "../../msw/handlers/slack-api";
 import { createSlackRuntime } from "@/chat/app/factory";
 import type { JuniorRuntimeServiceOverrides } from "@/chat/app/services";
-import type { ReplyExecutorServices } from "@/chat/runtime/reply-executor";
+import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import type { ReplySteeringMessage } from "@/chat/respond";
 import { createJuniorSlackAdapter } from "@/chat/slack/adapter";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
@@ -103,7 +103,7 @@ function completeObjectWithDecision(
 
 function createTurnHarness(args: {
   completeObject?: CompleteObjectOverride;
-  generateAssistantReply: ReplyExecutorServices["generateAssistantReply"];
+  agentRunner: AgentRunner;
   services?: Parameters<typeof createSlackRuntime>[0]["services"];
   state: StateAdapter;
 }) {
@@ -119,7 +119,7 @@ function createTurnHarness(args: {
       ...(args.services ?? {}),
       replyExecutor: {
         ...(args.services?.replyExecutor ?? {}),
-        generateAssistantReply: args.generateAssistantReply,
+        agentRunner: args.agentRunner,
       },
       subscribedReplyPolicy: {
         completeObject:
@@ -179,11 +179,13 @@ describe("Slack behavior: durable turn steering", () => {
   it("does not enqueue duplicate Slack event retries for a persisted message", async () => {
     const state = getStateAdapter();
     const { conversationId, queue, services } = createTurnHarness({
-      generateAssistantReply: async () =>
-        completedAgentRun({
-          text: "not used",
-          diagnostics: makeDiagnostics(),
-        }),
+      agentRunner: {
+        run: async () =>
+          completedAgentRun({
+            text: "not used",
+            diagnostics: makeDiagnostics(),
+          }),
+      },
       state,
     });
     const event = makeMessageEvent({
@@ -245,35 +247,37 @@ describe("Slack behavior: durable turn steering", () => {
       steeringTexts: string[];
     }> = [];
     const state = getStateAdapter();
-    const generateAssistantReply: ReplyExecutorServices["generateAssistantReply"] =
-      async (prompt, context) => {
-        await context?.onInputCommitted?.();
-        if (!blockingCallReleased) {
-          agentEntered.resolve();
-          await releaseAgent.promise;
-          blockingCallReleased = true;
-        }
+    const generateAssistantReply: AgentRunner["run"] = async (
+      prompt,
+      context,
+    ) => {
+      await context?.onInputCommitted?.();
+      if (!blockingCallReleased) {
+        agentEntered.resolve();
+        await releaseAgent.promise;
+        blockingCallReleased = true;
+      }
 
-        const steeringMessages: ReplySteeringMessage[] = [];
-        const drained = await context?.drainSteeringMessages?.(
-          async (messages) => {
-            steeringMessages.push(...messages);
-          },
-        );
-        if (steeringMessages.length === 0 && drained) {
-          steeringMessages.push(...drained);
-        }
+      const steeringMessages: ReplySteeringMessage[] = [];
+      const drained = await context?.drainSteeringMessages?.(
+        async (messages) => {
+          steeringMessages.push(...messages);
+        },
+      );
+      if (steeringMessages.length === 0 && drained) {
+        steeringMessages.push(...drained);
+      }
 
-        const steeringTexts = steeringMessages.map((message) => message.text);
-        agentCalls.push({ prompt, steeringTexts });
-        return completedAgentRun({
-          text: [
-            `Handled initial: ${prompt}`,
-            `Steered: ${steeringTexts.join(" | ")}`,
-          ].join("\n"),
-          diagnostics: makeDiagnostics(),
-        });
-      };
+      const steeringTexts = steeringMessages.map((message) => message.text);
+      agentCalls.push({ prompt, steeringTexts });
+      return completedAgentRun({
+        text: [
+          `Handled initial: ${prompt}`,
+          `Steered: ${steeringTexts.join(" | ")}`,
+        ].join("\n"),
+        diagnostics: makeDiagnostics(),
+      });
+    };
     const { conversationId, queue, runNextQueuedWork, services } =
       createTurnHarness({
         completeObject: completeObjectWithDecision((prompt) =>
@@ -291,7 +295,7 @@ describe("Slack behavior: durable turn steering", () => {
                 reason: "active steering follow-up",
               },
         ),
-        generateAssistantReply,
+        agentRunner: { run: generateAssistantReply },
         state,
       });
 
@@ -444,13 +448,15 @@ describe("Slack behavior: durable turn steering", () => {
           confidence: 1,
           reason: "side conversation",
         })),
-        generateAssistantReply: async (prompt, context) => {
-          replyCalls.push(prompt);
-          await context?.onInputCommitted?.();
-          return completedAgentRun({
-            text: "Started.",
-            diagnostics: makeDiagnostics(),
-          });
+        agentRunner: {
+          run: async (prompt, context) => {
+            replyCalls.push(prompt);
+            await context?.onInputCommitted?.();
+            return completedAgentRun({
+              text: "Started.",
+              diagnostics: makeDiagnostics(),
+            });
+          },
         },
         state,
       });
@@ -504,24 +510,26 @@ describe("Slack behavior: durable turn steering", () => {
     const releaseAgent = deferred();
     const drainedTexts: string[] = [];
     const state = getStateAdapter();
-    const generateAssistantReply: ReplyExecutorServices["generateAssistantReply"] =
-      async (_prompt, context) => {
-        await context?.onInputCommitted?.();
-        agentEntered.resolve();
-        await releaseAgent.promise;
-        const drained = await context?.drainSteeringMessages?.(
-          async (messages) => {
-            drainedTexts.push(...messages.map((message) => message.text));
-          },
-        );
-        if (drainedTexts.length === 0 && drained) {
-          drainedTexts.push(...drained.map((message) => message.text));
-        }
-        return completedAgentRun({
-          text: "Done with the initial request.",
-          diagnostics: makeDiagnostics(),
-        });
-      };
+    const generateAssistantReply: AgentRunner["run"] = async (
+      _prompt,
+      context,
+    ) => {
+      await context?.onInputCommitted?.();
+      agentEntered.resolve();
+      await releaseAgent.promise;
+      const drained = await context?.drainSteeringMessages?.(
+        async (messages) => {
+          drainedTexts.push(...messages.map((message) => message.text));
+        },
+      );
+      if (drainedTexts.length === 0 && drained) {
+        drainedTexts.push(...drained.map((message) => message.text));
+      }
+      return completedAgentRun({
+        text: "Done with the initial request.",
+        diagnostics: makeDiagnostics(),
+      });
+    };
     const { conversationId, runNextQueuedWork, services } = createTurnHarness({
       completeObject: completeObjectWithDecision((prompt) =>
         prompt.includes("stop watching")
@@ -538,7 +546,7 @@ describe("Slack behavior: durable turn steering", () => {
               reason: "active steering follow-up",
             },
       ),
-      generateAssistantReply,
+      agentRunner: { run: generateAssistantReply },
       state,
     });
 
@@ -626,14 +634,16 @@ describe("Slack behavior: durable turn steering", () => {
 
   it("keeps the mailbox pending when the agent fails before input commit", async () => {
     const state = getStateAdapter();
-    const generateAssistantReply: ReplyExecutorServices["generateAssistantReply"] =
-      async (_prompt, context) => {
-        expect(context?.onInputCommitted).toEqual(expect.any(Function));
-        throw new Error("agent crashed before input commit");
-      };
+    const generateAssistantReply: AgentRunner["run"] = async (
+      _prompt,
+      context,
+    ) => {
+      expect(context?.onInputCommitted).toEqual(expect.any(Function));
+      throw new Error("agent crashed before input commit");
+    };
     const { conversationId, queue, runNextQueuedWork, services } =
       createTurnHarness({
-        generateAssistantReply,
+        agentRunner: { run: generateAssistantReply },
         state,
       });
 

--- a/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
@@ -25,6 +25,7 @@ import {
   getConversationWorkState,
 } from "@/chat/task-execution/store";
 import { processConversationQueueMessage } from "@/chat/task-execution/vercel-callback";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const CHANNEL_ID = "CSTEER";
 const THREAD_TS = "1712345.000100";
@@ -178,10 +179,11 @@ describe("Slack behavior: durable turn steering", () => {
   it("does not enqueue duplicate Slack event retries for a persisted message", async () => {
     const state = getStateAdapter();
     const { conversationId, queue, services } = createTurnHarness({
-      generateAssistantReply: async () => ({
-        text: "not used",
-        diagnostics: makeDiagnostics(),
-      }),
+      generateAssistantReply: async () =>
+        completedAgentRun({
+          text: "not used",
+          diagnostics: makeDiagnostics(),
+        }),
       state,
     });
     const event = makeMessageEvent({
@@ -264,13 +266,13 @@ describe("Slack behavior: durable turn steering", () => {
 
         const steeringTexts = steeringMessages.map((message) => message.text);
         agentCalls.push({ prompt, steeringTexts });
-        return {
+        return completedAgentRun({
           text: [
             `Handled initial: ${prompt}`,
             `Steered: ${steeringTexts.join(" | ")}`,
           ].join("\n"),
           diagnostics: makeDiagnostics(),
-        };
+        });
       };
     const { conversationId, queue, runNextQueuedWork, services } =
       createTurnHarness({
@@ -445,10 +447,10 @@ describe("Slack behavior: durable turn steering", () => {
         generateAssistantReply: async (prompt, context) => {
           replyCalls.push(prompt);
           await context?.onInputCommitted?.();
-          return {
+          return completedAgentRun({
             text: "Started.",
             diagnostics: makeDiagnostics(),
-          };
+          });
         },
         state,
       });
@@ -515,10 +517,10 @@ describe("Slack behavior: durable turn steering", () => {
         if (drainedTexts.length === 0 && drained) {
           drainedTexts.push(...drained.map((message) => message.text));
         }
-        return {
+        return completedAgentRun({
           text: "Done with the initial request.",
           diagnostics: makeDiagnostics(),
-        };
+        });
       };
     const { conversationId, runNextQueuedWork, services } = createTurnHarness({
       completeObject: completeObjectWithDecision((prompt) =>

--- a/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
@@ -247,11 +247,9 @@ describe("Slack behavior: durable turn steering", () => {
       steeringTexts: string[];
     }> = [];
     const state = getStateAdapter();
-    const generateAssistantReply: AgentRunner["run"] = async (
-      prompt,
-      context,
-    ) => {
-      await context?.onInputCommitted?.();
+    const generateAssistantReply: AgentRunner["run"] = async (request) => {
+      const prompt = request.input.messageText;
+      await request.durability?.onInputCommitted?.();
       if (!blockingCallReleased) {
         agentEntered.resolve();
         await releaseAgent.promise;
@@ -259,7 +257,7 @@ describe("Slack behavior: durable turn steering", () => {
       }
 
       const steeringMessages: ReplySteeringMessage[] = [];
-      const drained = await context?.drainSteeringMessages?.(
+      const drained = await request.durability?.drainSteeringMessages?.(
         async (messages) => {
           steeringMessages.push(...messages);
         },
@@ -449,7 +447,17 @@ describe("Slack behavior: durable turn steering", () => {
           reason: "side conversation",
         })),
         agentRunner: {
-          run: async (prompt, context) => {
+          run: async (request) => {
+            const prompt = request.input.messageText;
+            const context = {
+              ...request.input,
+              ...request.routing,
+              ...(request.policy ?? {}),
+              ...(request.state ?? {}),
+              ...(request.observers ?? {}),
+              ...(request.durability ?? {}),
+            };
+
             replyCalls.push(prompt);
             await context?.onInputCommitted?.();
             return completedAgentRun({
@@ -510,14 +518,11 @@ describe("Slack behavior: durable turn steering", () => {
     const releaseAgent = deferred();
     const drainedTexts: string[] = [];
     const state = getStateAdapter();
-    const generateAssistantReply: AgentRunner["run"] = async (
-      _prompt,
-      context,
-    ) => {
-      await context?.onInputCommitted?.();
+    const generateAssistantReply: AgentRunner["run"] = async (request) => {
+      await request.durability?.onInputCommitted?.();
       agentEntered.resolve();
       await releaseAgent.promise;
-      const drained = await context?.drainSteeringMessages?.(
+      const drained = await request.durability?.drainSteeringMessages?.(
         async (messages) => {
           drainedTexts.push(...messages.map((message) => message.text));
         },
@@ -634,11 +639,10 @@ describe("Slack behavior: durable turn steering", () => {
 
   it("keeps the mailbox pending when the agent fails before input commit", async () => {
     const state = getStateAdapter();
-    const generateAssistantReply: AgentRunner["run"] = async (
-      _prompt,
-      context,
-    ) => {
-      expect(context?.onInputCommitted).toEqual(expect.any(Function));
+    const generateAssistantReply: AgentRunner["run"] = async (request) => {
+      expect(request.durability?.onInputCommitted).toEqual(
+        expect.any(Function),
+      );
       throw new Error("agent crashed before input commit");
     };
     const { conversationId, queue, runNextQueuedWork, services } =

--- a/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
@@ -14,7 +14,7 @@ import { resetSlackApiMockState } from "../../msw/handlers/slack-api";
 import { createSlackRuntime } from "@/chat/app/factory";
 import type { JuniorRuntimeServiceOverrides } from "@/chat/app/services";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
-import type { ReplySteeringMessage } from "@/chat/respond";
+import type { AgentRunSteeringMessage } from "@/chat/agent-run";
 import { createJuniorSlackAdapter } from "@/chat/slack/adapter";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
@@ -247,7 +247,7 @@ describe("Slack behavior: durable turn steering", () => {
       steeringTexts: string[];
     }> = [];
     const state = getStateAdapter();
-    const generateAssistantReply: AgentRunner["run"] = async (request) => {
+    const executeAgentRun: AgentRunner["run"] = async (request) => {
       const prompt = request.input.messageText;
       await request.durability?.onInputCommitted?.();
       if (!blockingCallReleased) {
@@ -256,7 +256,7 @@ describe("Slack behavior: durable turn steering", () => {
         blockingCallReleased = true;
       }
 
-      const steeringMessages: ReplySteeringMessage[] = [];
+      const steeringMessages: AgentRunSteeringMessage[] = [];
       const drained = await request.durability?.drainSteeringMessages?.(
         async (messages) => {
           steeringMessages.push(...messages);
@@ -293,7 +293,7 @@ describe("Slack behavior: durable turn steering", () => {
                 reason: "active steering follow-up",
               },
         ),
-        agentRunner: { run: generateAssistantReply },
+        agentRunner: { run: executeAgentRun },
         state,
       });
 
@@ -518,7 +518,7 @@ describe("Slack behavior: durable turn steering", () => {
     const releaseAgent = deferred();
     const drainedTexts: string[] = [];
     const state = getStateAdapter();
-    const generateAssistantReply: AgentRunner["run"] = async (request) => {
+    const executeAgentRun: AgentRunner["run"] = async (request) => {
       await request.durability?.onInputCommitted?.();
       agentEntered.resolve();
       await releaseAgent.promise;
@@ -551,7 +551,7 @@ describe("Slack behavior: durable turn steering", () => {
               reason: "active steering follow-up",
             },
       ),
-      agentRunner: { run: generateAssistantReply },
+      agentRunner: { run: executeAgentRun },
       state,
     });
 
@@ -639,7 +639,7 @@ describe("Slack behavior: durable turn steering", () => {
 
   it("keeps the mailbox pending when the agent fails before input commit", async () => {
     const state = getStateAdapter();
-    const generateAssistantReply: AgentRunner["run"] = async (request) => {
+    const executeAgentRun: AgentRunner["run"] = async (request) => {
       expect(request.durability?.onInputCommitted).toEqual(
         expect.any(Function),
       );
@@ -647,7 +647,7 @@ describe("Slack behavior: durable turn steering", () => {
     };
     const { conversationId, queue, runNextQueuedWork, services } =
       createTurnHarness({
-        agentRunner: { run: generateAssistantReply },
+        agentRunner: { run: executeAgentRun },
         state,
       });
 

--- a/packages/junior/tests/integration/slack/file-delivery-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/file-delivery-behavior.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import { createTestChatRuntime } from "../../fixtures/chat-runtime";
 import {
   createTestMessage,
@@ -28,7 +29,7 @@ describe("Slack behavior: file delivery", () => {
         replyExecutor: {
           generateAssistantReply: async (_prompt, context) => {
             await context?.onTextDelta?.("Preview is ready.");
-            return {
+            return completedAgentRun({
               text: "Preview is ready.",
               deliveryPlan: {
                 mode: "thread",
@@ -45,7 +46,7 @@ describe("Slack behavior: file delivery", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },

--- a/packages/junior/tests/integration/slack/file-delivery-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/file-delivery-behavior.test.ts
@@ -27,26 +27,28 @@ describe("Slack behavior: file delivery", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async (_prompt, context) => {
-            await context?.onTextDelta?.("Preview is ready.");
-            return completedAgentRun({
-              text: "Preview is ready.",
-              deliveryPlan: {
-                mode: "thread",
+          agentRunner: {
+            run: async (_prompt, context) => {
+              await context?.onTextDelta?.("Preview is ready.");
+              return completedAgentRun({
+                text: "Preview is ready.",
+                deliveryPlan: {
+                  mode: "thread",
 
-                postThreadText: true,
-                attachFiles: "followup",
-              },
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            });
+                  postThreadText: true,
+                  attachFiles: "followup",
+                },
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "fake-agent-model",
+                  outcome: "success",
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              });
+            },
           },
         },
       },

--- a/packages/junior/tests/integration/slack/file-delivery-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/file-delivery-behavior.test.ts
@@ -28,7 +28,17 @@ describe("Slack behavior: file delivery", () => {
       services: {
         replyExecutor: {
           agentRunner: {
-            run: async (_prompt, context) => {
+            run: async (request) => {
+              const _prompt = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               await context?.onTextDelta?.("Preview is ready.");
               return completedAgentRun({
                 text: "Preview is ready.",

--- a/packages/junior/tests/integration/slack/finalized-reply-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/finalized-reply-behavior.test.ts
@@ -74,7 +74,17 @@ describe("Slack behavior: finalized thread replies", () => {
       services: {
         replyExecutor: {
           agentRunner: {
-            run: async (_prompt, context) => {
+            run: async (request) => {
+              const _prompt = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               await context?.onTextDelta?.("Hello ");
               await context?.onTextDelta?.("world");
               return completedAgentRun({
@@ -110,7 +120,17 @@ describe("Slack behavior: finalized thread replies", () => {
       services: {
         replyExecutor: {
           agentRunner: {
-            run: async (_prompt, context) => {
+            run: async (request) => {
+              const _prompt = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               await context?.onTextDelta?.("Fetching sources now...");
               await context?.onAssistantMessageStart?.();
               await context?.onTextDelta?.(finalReply);

--- a/packages/junior/tests/integration/slack/finalized-reply-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/finalized-reply-behavior.test.ts
@@ -11,6 +11,10 @@ import {
   createTestThread,
   createTestDestination,
 } from "../../fixtures/slack-harness";
+import {
+  completedAgentRun,
+  failedAgentRun,
+} from "@/chat/runtime/agent-run-outcome";
 
 function toPostedText(value: unknown): string {
   if (typeof value === "string") {
@@ -72,10 +76,10 @@ describe("Slack behavior: finalized thread replies", () => {
           generateAssistantReply: async (_prompt, context) => {
             await context?.onTextDelta?.("Hello ");
             await context?.onTextDelta?.("world");
-            return {
+            return completedAgentRun({
               text: "Hello world",
               diagnostics: makeDiagnostics(),
-            };
+            });
           },
         },
       },
@@ -107,10 +111,10 @@ describe("Slack behavior: finalized thread replies", () => {
             await context?.onTextDelta?.("Fetching sources now...");
             await context?.onAssistantMessageStart?.();
             await context?.onTextDelta?.(finalReply);
-            return {
+            return completedAgentRun({
               text: finalReply,
               diagnostics: makeDiagnostics({ toolCalls: ["webSearch"] }),
-            };
+            });
           },
         },
       },
@@ -136,11 +140,12 @@ describe("Slack behavior: finalized thread replies", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: "",
-            files: [{ data: Buffer.from("hello"), filename: "hello.txt" }],
-            diagnostics: makeDiagnostics(),
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: "",
+              files: [{ data: Buffer.from("hello"), filename: "hello.txt" }],
+              diagnostics: makeDiagnostics(),
+            }),
         },
       },
     });
@@ -168,16 +173,17 @@ describe("Slack behavior: finalized thread replies", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: "Posted it in channel.",
-            files: [{ data: Buffer.from("report"), filename: "report.txt" }],
-            deliveryPlan: {
-              mode: "channel_only",
-              postThreadText: false,
-              attachFiles: "inline",
-            },
-            diagnostics: makeDiagnostics(),
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: "Posted it in channel.",
+              files: [{ data: Buffer.from("report"), filename: "report.txt" }],
+              deliveryPlan: {
+                mode: "channel_only",
+                postThreadText: false,
+                attachFiles: "inline",
+              },
+              diagnostics: makeDiagnostics(),
+            }),
         },
       },
     });
@@ -205,15 +211,16 @@ describe("Slack behavior: finalized thread replies", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: "",
-            deliveryPlan: {
-              mode: "thread",
-              postThreadText: true,
-              attachFiles: "none",
-            },
-            diagnostics: makeDiagnostics(),
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: "",
+              deliveryPlan: {
+                mode: "thread",
+                postThreadText: true,
+                attachFiles: "none",
+              },
+              diagnostics: makeDiagnostics(),
+            }),
         },
       },
     });
@@ -240,13 +247,14 @@ describe("Slack behavior: finalized thread replies", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: "ok",
-            files: [{ data: Buffer.from("report"), filename: "report.txt" }],
-            diagnostics: makeDiagnostics({
-              toolCalls: ["slackMessageAddReaction"],
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: "ok",
+              files: [{ data: Buffer.from("report"), filename: "report.txt" }],
+              diagnostics: makeDiagnostics({
+                toolCalls: ["slackMessageAddReaction"],
+              }),
             }),
-          }),
         },
       },
     });
@@ -278,10 +286,11 @@ describe("Slack behavior: finalized thread replies", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: longReply,
-            diagnostics: makeDiagnostics(),
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: longReply,
+              diagnostics: makeDiagnostics(),
+            }),
         },
       },
     });
@@ -314,10 +323,11 @@ describe("Slack behavior: finalized thread replies", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: longReply,
-            diagnostics: makeDiagnostics(),
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: longReply,
+              diagnostics: makeDiagnostics(),
+            }),
         },
       },
     });
@@ -351,10 +361,11 @@ describe("Slack behavior: finalized thread replies", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: longReply,
-            diagnostics: makeDiagnostics({ outcome: "provider_error" }),
-          }),
+          generateAssistantReply: async () =>
+            failedAgentRun({
+              text: longReply,
+              diagnostics: makeDiagnostics({ outcome: "provider_error" }),
+            }),
         },
       },
     });

--- a/packages/junior/tests/integration/slack/finalized-reply-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/finalized-reply-behavior.test.ts
@@ -73,13 +73,15 @@ describe("Slack behavior: finalized thread replies", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async (_prompt, context) => {
-            await context?.onTextDelta?.("Hello ");
-            await context?.onTextDelta?.("world");
-            return completedAgentRun({
-              text: "Hello world",
-              diagnostics: makeDiagnostics(),
-            });
+          agentRunner: {
+            run: async (_prompt, context) => {
+              await context?.onTextDelta?.("Hello ");
+              await context?.onTextDelta?.("world");
+              return completedAgentRun({
+                text: "Hello world",
+                diagnostics: makeDiagnostics(),
+              });
+            },
           },
         },
       },
@@ -107,14 +109,16 @@ describe("Slack behavior: finalized thread replies", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async (_prompt, context) => {
-            await context?.onTextDelta?.("Fetching sources now...");
-            await context?.onAssistantMessageStart?.();
-            await context?.onTextDelta?.(finalReply);
-            return completedAgentRun({
-              text: finalReply,
-              diagnostics: makeDiagnostics({ toolCalls: ["webSearch"] }),
-            });
+          agentRunner: {
+            run: async (_prompt, context) => {
+              await context?.onTextDelta?.("Fetching sources now...");
+              await context?.onAssistantMessageStart?.();
+              await context?.onTextDelta?.(finalReply);
+              return completedAgentRun({
+                text: finalReply,
+                diagnostics: makeDiagnostics({ toolCalls: ["webSearch"] }),
+              });
+            },
           },
         },
       },
@@ -140,12 +144,14 @@ describe("Slack behavior: finalized thread replies", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () =>
-            completedAgentRun({
-              text: "",
-              files: [{ data: Buffer.from("hello"), filename: "hello.txt" }],
-              diagnostics: makeDiagnostics(),
-            }),
+          agentRunner: {
+            run: async () =>
+              completedAgentRun({
+                text: "",
+                files: [{ data: Buffer.from("hello"), filename: "hello.txt" }],
+                diagnostics: makeDiagnostics(),
+              }),
+          },
         },
       },
     });
@@ -173,17 +179,21 @@ describe("Slack behavior: finalized thread replies", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () =>
-            completedAgentRun({
-              text: "Posted it in channel.",
-              files: [{ data: Buffer.from("report"), filename: "report.txt" }],
-              deliveryPlan: {
-                mode: "channel_only",
-                postThreadText: false,
-                attachFiles: "inline",
-              },
-              diagnostics: makeDiagnostics(),
-            }),
+          agentRunner: {
+            run: async () =>
+              completedAgentRun({
+                text: "Posted it in channel.",
+                files: [
+                  { data: Buffer.from("report"), filename: "report.txt" },
+                ],
+                deliveryPlan: {
+                  mode: "channel_only",
+                  postThreadText: false,
+                  attachFiles: "inline",
+                },
+                diagnostics: makeDiagnostics(),
+              }),
+          },
         },
       },
     });
@@ -211,16 +221,18 @@ describe("Slack behavior: finalized thread replies", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () =>
-            completedAgentRun({
-              text: "",
-              deliveryPlan: {
-                mode: "thread",
-                postThreadText: true,
-                attachFiles: "none",
-              },
-              diagnostics: makeDiagnostics(),
-            }),
+          agentRunner: {
+            run: async () =>
+              completedAgentRun({
+                text: "",
+                deliveryPlan: {
+                  mode: "thread",
+                  postThreadText: true,
+                  attachFiles: "none",
+                },
+                diagnostics: makeDiagnostics(),
+              }),
+          },
         },
       },
     });
@@ -247,14 +259,18 @@ describe("Slack behavior: finalized thread replies", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () =>
-            completedAgentRun({
-              text: "ok",
-              files: [{ data: Buffer.from("report"), filename: "report.txt" }],
-              diagnostics: makeDiagnostics({
-                toolCalls: ["slackMessageAddReaction"],
+          agentRunner: {
+            run: async () =>
+              completedAgentRun({
+                text: "ok",
+                files: [
+                  { data: Buffer.from("report"), filename: "report.txt" },
+                ],
+                diagnostics: makeDiagnostics({
+                  toolCalls: ["slackMessageAddReaction"],
+                }),
               }),
-            }),
+          },
         },
       },
     });
@@ -286,11 +302,13 @@ describe("Slack behavior: finalized thread replies", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () =>
-            completedAgentRun({
-              text: longReply,
-              diagnostics: makeDiagnostics(),
-            }),
+          agentRunner: {
+            run: async () =>
+              completedAgentRun({
+                text: longReply,
+                diagnostics: makeDiagnostics(),
+              }),
+          },
         },
       },
     });
@@ -323,11 +341,13 @@ describe("Slack behavior: finalized thread replies", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () =>
-            completedAgentRun({
-              text: longReply,
-              diagnostics: makeDiagnostics(),
-            }),
+          agentRunner: {
+            run: async () =>
+              completedAgentRun({
+                text: longReply,
+                diagnostics: makeDiagnostics(),
+              }),
+          },
         },
       },
     });
@@ -361,11 +381,13 @@ describe("Slack behavior: finalized thread replies", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () =>
-            failedAgentRun({
-              text: longReply,
-              diagnostics: makeDiagnostics({ outcome: "provider_error" }),
-            }),
+          agentRunner: {
+            run: async () =>
+              failedAgentRun({
+                text: longReply,
+                diagnostics: makeDiagnostics({ outcome: "provider_error" }),
+              }),
+          },
         },
       },
     });

--- a/packages/junior/tests/integration/slack/message-changed-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/message-changed-behavior.test.ts
@@ -15,6 +15,7 @@ import { createSlackRuntime } from "@/chat/app/factory";
 import { JuniorChat } from "@/chat/ingress/junior-chat";
 import { createJuniorSlackAdapter } from "@/chat/slack/adapter";
 import { handleChatSdkPlatformWebhook } from "@/handlers/webhooks";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const SIGNING_SECRET = "test-signing-secret";
 const BOT_USER_ID = "U_BOT";
@@ -272,10 +273,10 @@ describe("Slack behavior: message_changed webhook ingress", () => {
               userName: "dcramer",
             });
             await context?.onTextDelta?.("Hello world");
-            return {
+            return completedAgentRun({
               text: "Hello world",
               diagnostics: makeDiagnostics(),
-            };
+            });
           },
         },
       },

--- a/packages/junior/tests/integration/slack/message-changed-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/message-changed-behavior.test.ts
@@ -263,20 +263,22 @@ describe("Slack behavior: message_changed webhook ingress", () => {
             fullName: "David Cramer",
             userName: "dcramer",
           }),
-          generateAssistantReply: async (_prompt, context) => {
-            expect(context?.requester).toEqual({
-              email: "david@example.com",
-              fullName: "David Cramer",
-              platform: "slack",
-              teamId: TEST_SLACK_TEAM_ID,
-              userId: "U123",
-              userName: "dcramer",
-            });
-            await context?.onTextDelta?.("Hello world");
-            return completedAgentRun({
-              text: "Hello world",
-              diagnostics: makeDiagnostics(),
-            });
+          agentRunner: {
+            run: async (_prompt, context) => {
+              expect(context?.requester).toEqual({
+                email: "david@example.com",
+                fullName: "David Cramer",
+                platform: "slack",
+                teamId: TEST_SLACK_TEAM_ID,
+                userId: "U123",
+                userName: "dcramer",
+              });
+              await context?.onTextDelta?.("Hello world");
+              return completedAgentRun({
+                text: "Hello world",
+                diagnostics: makeDiagnostics(),
+              });
+            },
           },
         },
       },

--- a/packages/junior/tests/integration/slack/message-changed-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/message-changed-behavior.test.ts
@@ -264,7 +264,17 @@ describe("Slack behavior: message_changed webhook ingress", () => {
             userName: "dcramer",
           }),
           agentRunner: {
-            run: async (_prompt, context) => {
+            run: async (request) => {
+              const _prompt = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               expect(context?.requester).toEqual({
                 email: "david@example.com",
                 fullName: "David Cramer",

--- a/packages/junior/tests/integration/slack/message-changed-reply-contract.test.ts
+++ b/packages/junior/tests/integration/slack/message-changed-reply-contract.test.ts
@@ -10,6 +10,7 @@ import { JuniorChat } from "@/chat/ingress/junior-chat";
 import type { ReplyExecutorServices } from "@/chat/runtime/reply-executor";
 import { createJuniorSlackAdapter } from "@/chat/slack/adapter";
 import { handleChatSdkPlatformWebhook } from "@/handlers/webhooks";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const SIGNING_SECRET = "test-signing-secret";
 const BOT_USER_ID = "U_BOT";
@@ -101,10 +102,10 @@ describe("Slack contract: edited-message reply delivery", () => {
     const bot = await createEditedDmBot({
       generateAssistantReply: async (_prompt, context) => {
         await context?.onTextDelta?.("Hello world");
-        return {
+        return completedAgentRun({
           text: "Hello world",
           diagnostics: makeDiagnostics(),
-        };
+        });
       },
     });
     const waitUntil = slackWebhookClient.waitUntil();
@@ -156,10 +157,11 @@ describe("Slack contract: edited-message reply delivery", () => {
       (_, i) => `line ${i + 1}`,
     ).join("\n");
     const bot = await createEditedDmBot({
-      generateAssistantReply: async () => ({
-        text: longReply,
-        diagnostics: makeDiagnostics(),
-      }),
+      generateAssistantReply: async () =>
+        completedAgentRun({
+          text: longReply,
+          diagnostics: makeDiagnostics(),
+        }),
     });
     const waitUntil = slackWebhookClient.waitUntil();
 

--- a/packages/junior/tests/integration/slack/message-changed-reply-contract.test.ts
+++ b/packages/junior/tests/integration/slack/message-changed-reply-contract.test.ts
@@ -7,7 +7,7 @@ import { slackApiOutbox } from "../../fixtures/slack-api-outbox";
 import { createSlackWebhookTestClient } from "../../fixtures/slack/webhook-client";
 import { createSlackRuntime } from "@/chat/app/factory";
 import { JuniorChat } from "@/chat/ingress/junior-chat";
-import type { ReplyExecutorServices } from "@/chat/runtime/reply-executor";
+import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { createJuniorSlackAdapter } from "@/chat/slack/adapter";
 import { handleChatSdkPlatformWebhook } from "@/handlers/webhooks";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
@@ -63,9 +63,7 @@ function createEditedMentionRequest(args: {
   });
 }
 
-async function createEditedDmBot(args: {
-  generateAssistantReply: ReplyExecutorServices["generateAssistantReply"];
-}) {
+async function createEditedDmBot(args: { agentRunner: AgentRunner }) {
   const state = createMemoryState();
   await state.connect();
   const bot = new JuniorChat<{ slack: SlackAdapter }>({
@@ -83,7 +81,7 @@ async function createEditedDmBot(args: {
     getSlackAdapter: () => bot.getAdapter("slack"),
     services: {
       replyExecutor: {
-        generateAssistantReply: args.generateAssistantReply,
+        agentRunner: args.agentRunner,
       },
     },
   });
@@ -100,12 +98,14 @@ async function createEditedDmBot(args: {
 describe("Slack contract: edited-message reply delivery", () => {
   it("posts the finalized reply into the edited DM thread with chat.postMessage", async () => {
     const bot = await createEditedDmBot({
-      generateAssistantReply: async (_prompt, context) => {
-        await context?.onTextDelta?.("Hello world");
-        return completedAgentRun({
-          text: "Hello world",
-          diagnostics: makeDiagnostics(),
-        });
+      agentRunner: {
+        run: async (_prompt, context) => {
+          await context?.onTextDelta?.("Hello world");
+          return completedAgentRun({
+            text: "Hello world",
+            diagnostics: makeDiagnostics(),
+          });
+        },
       },
     });
     const waitUntil = slackWebhookClient.waitUntil();
@@ -157,11 +157,13 @@ describe("Slack contract: edited-message reply delivery", () => {
       (_, i) => `line ${i + 1}`,
     ).join("\n");
     const bot = await createEditedDmBot({
-      generateAssistantReply: async () =>
-        completedAgentRun({
-          text: longReply,
-          diagnostics: makeDiagnostics(),
-        }),
+      agentRunner: {
+        run: async () =>
+          completedAgentRun({
+            text: longReply,
+            diagnostics: makeDiagnostics(),
+          }),
+      },
     });
     const waitUntil = slackWebhookClient.waitUntil();
 

--- a/packages/junior/tests/integration/slack/message-changed-reply-contract.test.ts
+++ b/packages/junior/tests/integration/slack/message-changed-reply-contract.test.ts
@@ -99,7 +99,17 @@ describe("Slack contract: edited-message reply delivery", () => {
   it("posts the finalized reply into the edited DM thread with chat.postMessage", async () => {
     const bot = await createEditedDmBot({
       agentRunner: {
-        run: async (_prompt, context) => {
+        run: async (request) => {
+          const _prompt = request.input.messageText;
+          const context = {
+            ...request.input,
+            ...request.routing,
+            ...(request.policy ?? {}),
+            ...(request.state ?? {}),
+            ...(request.observers ?? {}),
+            ...(request.durability ?? {}),
+          };
+
           await context?.onTextDelta?.("Hello world");
           return completedAgentRun({
             text: "Hello world",

--- a/packages/junior/tests/integration/slack/message-content-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/message-content-behavior.test.ts
@@ -15,11 +15,27 @@ import {
   createTestThread,
   createTestDestination,
 } from "../../fixtures/slack-harness";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 interface CapturedCall {
   contextConversation?: string;
   piMessages?: PiMessage[];
   prompt: string;
+}
+
+function completedReply(text: string) {
+  return completedAgentRun({
+    text,
+    diagnostics: {
+      assistantMessageCount: 1,
+      modelId: "fake-agent-model",
+      outcome: "success" as const,
+      toolCalls: [],
+      toolErrorCount: 0,
+      toolResultCount: 0,
+      usedPrimaryText: true,
+    },
+  });
 }
 
 describe("Slack behavior: message content", () => {
@@ -50,18 +66,7 @@ describe("Slack behavior: message content", () => {
               prompt,
               contextConversation: context?.conversationContext,
             });
-            return {
-              text: "Summary sent.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("Summary sent.");
           },
         },
       },
@@ -92,18 +97,7 @@ describe("Slack behavior: message content", () => {
         replyExecutor: {
           generateAssistantReply: async (prompt) => {
             calls.push({ prompt });
-            return {
-              text: "Done.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("Done.");
           },
         },
       },
@@ -137,18 +131,7 @@ describe("Slack behavior: message content", () => {
               prompt,
               contextConversation: context?.conversationContext,
             });
-            return {
-              text: "Alert reviewed.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("Alert reviewed.");
           },
         },
       },
@@ -195,18 +178,7 @@ describe("Slack behavior: message content", () => {
         replyExecutor: {
           generateAssistantReply: async () => {
             replyCalled = true;
-            return {
-              text: "Should not happen",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("Should not happen");
           },
         },
       },
@@ -286,18 +258,9 @@ describe("Slack behavior: message content", () => {
                 piMessages: storedFirstTurnHistory,
               });
             }
-            return {
-              text: calls.length === 1 ? "First response." : "Second response.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply(
+              calls.length === 1 ? "First response." : "Second response.",
+            );
           },
         },
       },
@@ -382,18 +345,7 @@ describe("Slack behavior: message content", () => {
               contextConversation: context?.conversationContext,
               piMessages: context?.piMessages,
             });
-            return {
-              text: "Done.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("Done.");
           },
         },
       },
@@ -505,18 +457,7 @@ describe("Slack behavior: message content", () => {
               contextConversation: context?.conversationContext,
               piMessages: context?.piMessages,
             });
-            return {
-              text: "Done.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("Done.");
           },
         },
       },

--- a/packages/junior/tests/integration/slack/message-content-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/message-content-behavior.test.ts
@@ -61,12 +61,14 @@ describe("Slack behavior: message content", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async (prompt, context) => {
-            calls.push({
-              prompt,
-              contextConversation: context?.conversationContext,
-            });
-            return completedReply("Summary sent.");
+          agentRunner: {
+            run: async (prompt, context) => {
+              calls.push({
+                prompt,
+                contextConversation: context?.conversationContext,
+              });
+              return completedReply("Summary sent.");
+            },
           },
         },
       },
@@ -95,9 +97,11 @@ describe("Slack behavior: message content", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async (prompt) => {
-            calls.push({ prompt });
-            return completedReply("Done.");
+          agentRunner: {
+            run: async (prompt) => {
+              calls.push({ prompt });
+              return completedReply("Done.");
+            },
           },
         },
       },
@@ -126,12 +130,14 @@ describe("Slack behavior: message content", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async (prompt, context) => {
-            calls.push({
-              prompt,
-              contextConversation: context?.conversationContext,
-            });
-            return completedReply("Alert reviewed.");
+          agentRunner: {
+            run: async (prompt, context) => {
+              calls.push({
+                prompt,
+                contextConversation: context?.conversationContext,
+              });
+              return completedReply("Alert reviewed.");
+            },
           },
         },
       },
@@ -176,9 +182,11 @@ describe("Slack behavior: message content", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => {
-            replyCalled = true;
-            return completedReply("Should not happen");
+          agentRunner: {
+            run: async () => {
+              replyCalled = true;
+              return completedReply("Should not happen");
+            },
           },
         },
       },
@@ -239,28 +247,30 @@ describe("Slack behavior: message content", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async (prompt, context) => {
-            calls.push({
-              prompt,
-              contextConversation: context?.conversationContext,
-              piMessages: context?.piMessages,
-            });
-            if (
-              calls.length === 1 &&
-              context?.correlation?.conversationId &&
-              context.correlation.turnId
-            ) {
-              await upsertAgentTurnSessionRecord({
-                conversationId: context.correlation.conversationId,
-                sessionId: context.correlation.turnId,
-                sliceId: 1,
-                state: "completed",
-                piMessages: storedFirstTurnHistory,
+          agentRunner: {
+            run: async (prompt, context) => {
+              calls.push({
+                prompt,
+                contextConversation: context?.conversationContext,
+                piMessages: context?.piMessages,
               });
-            }
-            return completedReply(
-              calls.length === 1 ? "First response." : "Second response.",
-            );
+              if (
+                calls.length === 1 &&
+                context?.correlation?.conversationId &&
+                context.correlation.turnId
+              ) {
+                await upsertAgentTurnSessionRecord({
+                  conversationId: context.correlation.conversationId,
+                  sessionId: context.correlation.turnId,
+                  sliceId: 1,
+                  state: "completed",
+                  piMessages: storedFirstTurnHistory,
+                });
+              }
+              return completedReply(
+                calls.length === 1 ? "First response." : "Second response.",
+              );
+            },
           },
         },
       },
@@ -339,13 +349,15 @@ describe("Slack behavior: message content", () => {
           autoCompactionTriggerTokens: 100,
         },
         replyExecutor: {
-          generateAssistantReply: async (prompt, context) => {
-            calls.push({
-              prompt,
-              contextConversation: context?.conversationContext,
-              piMessages: context?.piMessages,
-            });
-            return completedReply("Done.");
+          agentRunner: {
+            run: async (prompt, context) => {
+              calls.push({
+                prompt,
+                contextConversation: context?.conversationContext,
+                piMessages: context?.piMessages,
+              });
+              return completedReply("Done.");
+            },
           },
         },
       },
@@ -451,13 +463,15 @@ describe("Slack behavior: message content", () => {
           autoCompactionTriggerTokens: 100,
         },
         replyExecutor: {
-          generateAssistantReply: async (prompt, context) => {
-            calls.push({
-              prompt,
-              contextConversation: context?.conversationContext,
-              piMessages: context?.piMessages,
-            });
-            return completedReply("Done.");
+          agentRunner: {
+            run: async (prompt, context) => {
+              calls.push({
+                prompt,
+                contextConversation: context?.conversationContext,
+                piMessages: context?.piMessages,
+              });
+              return completedReply("Done.");
+            },
           },
         },
       },

--- a/packages/junior/tests/integration/slack/message-content-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/message-content-behavior.test.ts
@@ -62,7 +62,17 @@ describe("Slack behavior: message content", () => {
         },
         replyExecutor: {
           agentRunner: {
-            run: async (prompt, context) => {
+            run: async (request) => {
+              const prompt = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               calls.push({
                 prompt,
                 contextConversation: context?.conversationContext,
@@ -98,7 +108,9 @@ describe("Slack behavior: message content", () => {
       services: {
         replyExecutor: {
           agentRunner: {
-            run: async (prompt) => {
+            run: async (request) => {
+              const prompt = request.input.messageText;
+
               calls.push({ prompt });
               return completedReply("Done.");
             },
@@ -131,7 +143,17 @@ describe("Slack behavior: message content", () => {
       services: {
         replyExecutor: {
           agentRunner: {
-            run: async (prompt, context) => {
+            run: async (request) => {
+              const prompt = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               calls.push({
                 prompt,
                 contextConversation: context?.conversationContext,
@@ -248,7 +270,17 @@ describe("Slack behavior: message content", () => {
         },
         replyExecutor: {
           agentRunner: {
-            run: async (prompt, context) => {
+            run: async (request) => {
+              const prompt = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               calls.push({
                 prompt,
                 contextConversation: context?.conversationContext,
@@ -350,7 +382,17 @@ describe("Slack behavior: message content", () => {
         },
         replyExecutor: {
           agentRunner: {
-            run: async (prompt, context) => {
+            run: async (request) => {
+              const prompt = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               calls.push({
                 prompt,
                 contextConversation: context?.conversationContext,
@@ -464,7 +506,17 @@ describe("Slack behavior: message content", () => {
         },
         replyExecutor: {
           agentRunner: {
-            run: async (prompt, context) => {
+            run: async (request) => {
+              const prompt = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               calls.push({
                 prompt,
                 contextConversation: context?.conversationContext,

--- a/packages/junior/tests/integration/slack/message-im-attachment-contract.test.ts
+++ b/packages/junior/tests/integration/slack/message-im-attachment-contract.test.ts
@@ -6,6 +6,7 @@ import { slackEventsApiEnvelope } from "../../fixtures/slack/factories/events";
 import { createSlackWebhookTestClient } from "../../fixtures/slack/webhook-client";
 import { mswServer } from "../../msw/server";
 import type { ReplyExecutorServices } from "@/chat/runtime/reply-executor";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const SIGNING_SECRET = "test-signing-secret";
 const BOT_USER_ID = "U_BOT";
@@ -110,10 +111,10 @@ describe("Slack contract: message.im attachment ingress", () => {
         capturedAttachmentNames.push(
           attachments.map((attachment) => attachment.filename ?? ""),
         );
-        return {
+        return completedAgentRun({
           text: "Processed screenshot.",
           diagnostics: makeDiagnostics(),
-        };
+        });
       },
     });
     const waitUntil = slackWebhookClient.waitUntil();

--- a/packages/junior/tests/integration/slack/message-im-attachment-contract.test.ts
+++ b/packages/junior/tests/integration/slack/message-im-attachment-contract.test.ts
@@ -5,7 +5,7 @@ import { createMemoryState } from "@chat-adapter/state-memory";
 import { slackEventsApiEnvelope } from "../../fixtures/slack/factories/events";
 import { createSlackWebhookTestClient } from "../../fixtures/slack/webhook-client";
 import { mswServer } from "../../msw/server";
-import type { ReplyExecutorServices } from "@/chat/runtime/reply-executor";
+import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const SIGNING_SECRET = "test-signing-secret";
@@ -31,7 +31,7 @@ function makeDiagnostics() {
 
 async function createDirectMessageBot(args: {
   completeText: () => Promise<{ text: string; message: never }>;
-  generateAssistantReply: ReplyExecutorServices["generateAssistantReply"];
+  agentRunner: AgentRunner;
 }) {
   const [{ createSlackRuntime }, { JuniorChat }, { createJuniorSlackAdapter }] =
     await Promise.all([
@@ -57,7 +57,7 @@ async function createDirectMessageBot(args: {
         completeText: args.completeText,
       },
       replyExecutor: {
-        generateAssistantReply: args.generateAssistantReply,
+        agentRunner: args.agentRunner,
       },
     },
   });
@@ -103,18 +103,20 @@ describe("Slack contract: message.im attachment ingress", () => {
         text: "Screenshot shows the current incident chart.",
         message: {} as never,
       }),
-      generateAssistantReply: async (_prompt, context) => {
-        const attachments = context?.userAttachments ?? [];
-        capturedAttachmentMediaTypes.push(
-          attachments.map((attachment) => attachment.mediaType),
-        );
-        capturedAttachmentNames.push(
-          attachments.map((attachment) => attachment.filename ?? ""),
-        );
-        return completedAgentRun({
-          text: "Processed screenshot.",
-          diagnostics: makeDiagnostics(),
-        });
+      agentRunner: {
+        run: async (_prompt, context) => {
+          const attachments = context?.userAttachments ?? [];
+          capturedAttachmentMediaTypes.push(
+            attachments.map((attachment) => attachment.mediaType),
+          );
+          capturedAttachmentNames.push(
+            attachments.map((attachment) => attachment.filename ?? ""),
+          );
+          return completedAgentRun({
+            text: "Processed screenshot.",
+            diagnostics: makeDiagnostics(),
+          });
+        },
       },
     });
     const waitUntil = slackWebhookClient.waitUntil();

--- a/packages/junior/tests/integration/slack/message-im-attachment-contract.test.ts
+++ b/packages/junior/tests/integration/slack/message-im-attachment-contract.test.ts
@@ -104,7 +104,17 @@ describe("Slack contract: message.im attachment ingress", () => {
         message: {} as never,
       }),
       agentRunner: {
-        run: async (_prompt, context) => {
+        run: async (request) => {
+          const _prompt = request.input.messageText;
+          const context = {
+            ...request.input,
+            ...request.routing,
+            ...(request.policy ?? {}),
+            ...(request.state ?? {}),
+            ...(request.observers ?? {}),
+            ...(request.durability ?? {}),
+          };
+
           const attachments = context?.userAttachments ?? [];
           capturedAttachmentMediaTypes.push(
             attachments.map((attachment) => attachment.mediaType),

--- a/packages/junior/tests/integration/slack/new-mention-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/new-mention-behavior.test.ts
@@ -53,11 +53,13 @@ describe("Slack behavior: new mention", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async (prompt) => {
-            fakeReplyCalls.push({ prompt });
-            return completedReply(
-              "Acknowledged. Rollback is complete and error rates are stable.",
-            );
+          agentRunner: {
+            run: async (prompt) => {
+              fakeReplyCalls.push({ prompt });
+              return completedReply(
+                "Acknowledged. Rollback is complete and error rates are stable.",
+              );
+            },
           },
         },
       },
@@ -94,9 +96,11 @@ describe("Slack behavior: new mention", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async (prompt) => {
-            fakeReplyCalls.push({ prompt });
-            return completedReply("Handled both updates.");
+          agentRunner: {
+            run: async (prompt) => {
+              fakeReplyCalls.push({ prompt });
+              return completedReply("Handled both updates.");
+            },
           },
         },
       },
@@ -162,17 +166,19 @@ describe("Slack behavior: new mention", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async (prompt, context) => {
-            const attachments = context?.userAttachments ?? [];
-            fakeReplyCalls.push({
-              prompt,
-              inboundAttachmentCount: context?.inboundAttachmentCount,
-              filenames: attachments.map(
-                (attachment) => attachment.filename ?? "",
-              ),
-              attachmentText: attachments[0]?.data?.toString("utf8"),
-            });
-            return completedReply("Handled queued attachment.");
+          agentRunner: {
+            run: async (prompt, context) => {
+              const attachments = context?.userAttachments ?? [];
+              fakeReplyCalls.push({
+                prompt,
+                inboundAttachmentCount: context?.inboundAttachmentCount,
+                filenames: attachments.map(
+                  (attachment) => attachment.filename ?? "",
+                ),
+                attachmentText: attachments[0]?.data?.toString("utf8"),
+              });
+              return completedReply("Handled queued attachment.");
+            },
           },
         },
       },
@@ -230,9 +236,11 @@ describe("Slack behavior: new mention", () => {
       slackAdapter,
       services: {
         replyExecutor: {
-          generateAssistantReply: async (_prompt, context) => {
-            await context?.onStatus?.(makeAssistantStatus("running", "bash"));
-            return completedReply("Done.", ["bash"]);
+          agentRunner: {
+            run: async (_prompt, context) => {
+              await context?.onStatus?.(makeAssistantStatus("running", "bash"));
+              return completedReply("Done.", ["bash"]);
+            },
           },
         },
       },
@@ -267,8 +275,10 @@ describe("Slack behavior: new mention", () => {
       slackAdapter,
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => {
-            throw new Error("model exploded");
+          agentRunner: {
+            run: async () => {
+              throw new Error("model exploded");
+            },
           },
         },
       },
@@ -301,20 +311,22 @@ describe("Slack behavior: new mention", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => {
-            return completedAgentRun({
-              text: "Posted in channel.",
-              deliveryMode: "channel_only" as const,
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success" as const,
-                toolCalls: ["slackChannelPostMessage"],
-                toolErrorCount: 0,
-                toolResultCount: 1,
-                usedPrimaryText: true,
-              },
-            });
+          agentRunner: {
+            run: async () => {
+              return completedAgentRun({
+                text: "Posted in channel.",
+                deliveryMode: "channel_only" as const,
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "fake-agent-model",
+                  outcome: "success" as const,
+                  toolCalls: ["slackChannelPostMessage"],
+                  toolErrorCount: 0,
+                  toolResultCount: 1,
+                  usedPrimaryText: true,
+                },
+              });
+            },
           },
         },
       },

--- a/packages/junior/tests/integration/slack/new-mention-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/new-mention-behavior.test.ts
@@ -10,6 +10,7 @@ import {
   createTestMessage,
   createTestThread,
 } from "../../fixtures/slack-harness";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 interface FakeReplyCall {
   prompt: string;
@@ -30,6 +31,21 @@ function toPostedText(value: unknown): string {
   return String(value);
 }
 
+function completedReply(text: string, toolCalls: string[] = []) {
+  return completedAgentRun({
+    text,
+    diagnostics: {
+      assistantMessageCount: 1,
+      modelId: "fake-agent-model",
+      outcome: "success" as const,
+      toolCalls,
+      toolErrorCount: 0,
+      toolResultCount: toolCalls.length,
+      usedPrimaryText: true,
+    },
+  });
+}
+
 describe("Slack behavior: new mention", () => {
   it("handles a mention with real runtime wiring and fake agent response", async () => {
     const fakeReplyCalls: FakeReplyCall[] = [];
@@ -39,18 +55,9 @@ describe("Slack behavior: new mention", () => {
         replyExecutor: {
           generateAssistantReply: async (prompt) => {
             fakeReplyCalls.push({ prompt });
-            return {
-              text: "Acknowledged. Rollback is complete and error rates are stable.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply(
+              "Acknowledged. Rollback is complete and error rates are stable.",
+            );
           },
         },
       },
@@ -89,18 +96,7 @@ describe("Slack behavior: new mention", () => {
         replyExecutor: {
           generateAssistantReply: async (prompt) => {
             fakeReplyCalls.push({ prompt });
-            return {
-              text: "Handled both updates.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("Handled both updates.");
           },
         },
       },
@@ -176,18 +172,7 @@ describe("Slack behavior: new mention", () => {
               ),
               attachmentText: attachments[0]?.data?.toString("utf8"),
             });
-            return {
-              text: "Handled queued attachment.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("Handled queued attachment.");
           },
         },
       },
@@ -247,18 +232,7 @@ describe("Slack behavior: new mention", () => {
         replyExecutor: {
           generateAssistantReply: async (_prompt, context) => {
             await context?.onStatus?.(makeAssistantStatus("running", "bash"));
-            return {
-              text: "Done.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: ["bash"],
-                toolErrorCount: 0,
-                toolResultCount: 1,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("Done.", ["bash"]);
           },
         },
       },
@@ -328,19 +302,19 @@ describe("Slack behavior: new mention", () => {
       services: {
         replyExecutor: {
           generateAssistantReply: async () => {
-            return {
+            return completedAgentRun({
               text: "Posted in channel.",
-              deliveryMode: "channel_only",
+              deliveryMode: "channel_only" as const,
               diagnostics: {
                 assistantMessageCount: 1,
                 modelId: "fake-agent-model",
-                outcome: "success",
+                outcome: "success" as const,
                 toolCalls: ["slackChannelPostMessage"],
                 toolErrorCount: 0,
                 toolResultCount: 1,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },

--- a/packages/junior/tests/integration/slack/new-mention-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/new-mention-behavior.test.ts
@@ -54,7 +54,9 @@ describe("Slack behavior: new mention", () => {
       services: {
         replyExecutor: {
           agentRunner: {
-            run: async (prompt) => {
+            run: async (request) => {
+              const prompt = request.input.messageText;
+
               fakeReplyCalls.push({ prompt });
               return completedReply(
                 "Acknowledged. Rollback is complete and error rates are stable.",
@@ -97,7 +99,9 @@ describe("Slack behavior: new mention", () => {
       services: {
         replyExecutor: {
           agentRunner: {
-            run: async (prompt) => {
+            run: async (request) => {
+              const prompt = request.input.messageText;
+
               fakeReplyCalls.push({ prompt });
               return completedReply("Handled both updates.");
             },
@@ -167,7 +171,17 @@ describe("Slack behavior: new mention", () => {
       services: {
         replyExecutor: {
           agentRunner: {
-            run: async (prompt, context) => {
+            run: async (request) => {
+              const prompt = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               const attachments = context?.userAttachments ?? [];
               fakeReplyCalls.push({
                 prompt,
@@ -237,7 +251,17 @@ describe("Slack behavior: new mention", () => {
       services: {
         replyExecutor: {
           agentRunner: {
-            run: async (_prompt, context) => {
+            run: async (request) => {
+              const _prompt = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               await context?.onStatus?.(makeAssistantStatus("running", "bash"));
               return completedReply("Done.", ["bash"]);
             },

--- a/packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts
@@ -6,6 +6,7 @@ import {
   createTestDestination,
 } from "../../fixtures/slack-harness";
 import { slackApiOutbox } from "../../fixtures/slack-api-outbox";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 function successDiagnostics(toolCalls: string[] = []) {
   return {
@@ -37,10 +38,10 @@ describe("Slack behavior: processing reaction", () => {
           generateAssistantReply: async () => {
             expect(slackApiOutbox.reactionAdds()).toHaveLength(1);
             expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
-            return {
+            return completedAgentRun({
               text: "Done.",
               diagnostics: successDiagnostics(),
-            };
+            });
           },
         },
       },
@@ -145,10 +146,10 @@ describe("Slack behavior: processing reaction", () => {
           generateAssistantReply: async () => {
             expect(slackApiOutbox.reactionAdds()).toHaveLength(1);
             expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
-            return {
+            return completedAgentRun({
               text: "Done.",
               diagnostics: successDiagnostics(),
-            };
+            });
           },
         },
       },
@@ -189,10 +190,10 @@ describe("Slack behavior: processing reaction", () => {
           generateAssistantReply: async () => {
             expect(slackApiOutbox.reactionAdds()).toHaveLength(0);
             expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
-            return {
+            return completedAgentRun({
               text: "Done.",
               diagnostics: successDiagnostics(),
-            };
+            });
           },
         },
       },
@@ -242,10 +243,10 @@ describe("Slack behavior: processing reaction", () => {
               toolName: "slackMessageAddReaction",
               params: { emoji: ":eyes:" },
             });
-            return {
+            return completedAgentRun({
               text: "Done.",
               diagnostics: successDiagnostics(["slackMessageAddReaction"]),
-            };
+            });
           },
         },
       },

--- a/packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts
@@ -35,13 +35,15 @@ describe("Slack behavior: processing reaction", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => {
-            expect(slackApiOutbox.reactionAdds()).toHaveLength(1);
-            expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
-            return completedAgentRun({
-              text: "Done.",
-              diagnostics: successDiagnostics(),
-            });
+          agentRunner: {
+            run: async () => {
+              expect(slackApiOutbox.reactionAdds()).toHaveLength(1);
+              expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
+              return completedAgentRun({
+                text: "Done.",
+                diagnostics: successDiagnostics(),
+              });
+            },
           },
         },
       },
@@ -93,8 +95,10 @@ describe("Slack behavior: processing reaction", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async () => {
-            throw new Error("assistant should not run for skipped message");
+          agentRunner: {
+            run: async () => {
+              throw new Error("assistant should not run for skipped message");
+            },
           },
         },
       },
@@ -143,13 +147,15 @@ describe("Slack behavior: processing reaction", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async () => {
-            expect(slackApiOutbox.reactionAdds()).toHaveLength(1);
-            expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
-            return completedAgentRun({
-              text: "Done.",
-              diagnostics: successDiagnostics(),
-            });
+          agentRunner: {
+            run: async () => {
+              expect(slackApiOutbox.reactionAdds()).toHaveLength(1);
+              expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
+              return completedAgentRun({
+                text: "Done.",
+                diagnostics: successDiagnostics(),
+              });
+            },
           },
         },
       },
@@ -187,13 +193,15 @@ describe("Slack behavior: processing reaction", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => {
-            expect(slackApiOutbox.reactionAdds()).toHaveLength(0);
-            expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
-            return completedAgentRun({
-              text: "Done.",
-              diagnostics: successDiagnostics(),
-            });
+          agentRunner: {
+            run: async () => {
+              expect(slackApiOutbox.reactionAdds()).toHaveLength(0);
+              expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
+              return completedAgentRun({
+                text: "Done.",
+                diagnostics: successDiagnostics(),
+              });
+            },
           },
         },
       },
@@ -238,15 +246,17 @@ describe("Slack behavior: processing reaction", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async (_prompt, context) => {
-            context?.onToolInvocation?.({
-              toolName: "slackMessageAddReaction",
-              params: { emoji: ":eyes:" },
-            });
-            return completedAgentRun({
-              text: "Done.",
-              diagnostics: successDiagnostics(["slackMessageAddReaction"]),
-            });
+          agentRunner: {
+            run: async (_prompt, context) => {
+              context?.onToolInvocation?.({
+                toolName: "slackMessageAddReaction",
+                params: { emoji: ":eyes:" },
+              });
+              return completedAgentRun({
+                text: "Done.",
+                diagnostics: successDiagnostics(["slackMessageAddReaction"]),
+              });
+            },
           },
         },
       },

--- a/packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts
@@ -247,7 +247,17 @@ describe("Slack behavior: processing reaction", () => {
       services: {
         replyExecutor: {
           agentRunner: {
-            run: async (_prompt, context) => {
+            run: async (request) => {
+              const _prompt = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               context?.onToolInvocation?.({
                 toolName: "slackMessageAddReaction",
                 params: { emoji: ":eyes:" },

--- a/packages/junior/tests/integration/slack/provider-default-config-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/provider-default-config-behavior.test.ts
@@ -26,7 +26,7 @@ describe("Slack behavior: provider default configuration", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply,
+          agentRunner: { run: generateAssistantReply },
         },
       },
     });
@@ -87,7 +87,7 @@ describe("Slack behavior: provider default configuration", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply,
+          agentRunner: { run: generateAssistantReply },
         },
       },
     });

--- a/packages/junior/tests/integration/slack/provider-default-config-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/provider-default-config-behavior.test.ts
@@ -22,11 +22,11 @@ function toPostedText(value: unknown): string {
 
 describe("Slack behavior: provider default configuration", () => {
   it("sets an explicit default GitHub repo without starting an agent turn", async () => {
-    const generateAssistantReply = vi.fn();
+    const executeAgentRun = vi.fn();
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
         },
       },
     });
@@ -47,7 +47,7 @@ describe("Slack behavior: provider default configuration", () => {
       { destination: createTestDestination(thread) },
     );
 
-    expect(generateAssistantReply).not.toHaveBeenCalled();
+    expect(executeAgentRun).not.toHaveBeenCalled();
     expect(thread.posts).toHaveLength(1);
     expect(toPostedText(thread.posts[0])).toContain("getsentry/junior");
     expect(channelStateRef.value).toMatchObject({
@@ -64,7 +64,7 @@ describe("Slack behavior: provider default configuration", () => {
   });
 
   it("does not intercept combined repo setup and agent work", async () => {
-    const generateAssistantReply = vi.fn(async () =>
+    const executeAgentRun = vi.fn(async () =>
       completedAgentRun({
         text: "Created the issue.",
         deliveryMode: "thread" as const,
@@ -87,7 +87,7 @@ describe("Slack behavior: provider default configuration", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
         },
       },
     });
@@ -108,7 +108,7 @@ describe("Slack behavior: provider default configuration", () => {
       { destination: createTestDestination(thread) },
     );
 
-    expect(generateAssistantReply).toHaveBeenCalledOnce();
+    expect(executeAgentRun).toHaveBeenCalledOnce();
     expect(toPostedText(thread.posts[0])).toContain("Created the issue.");
     expect(channelStateRef.value).not.toMatchObject({
       configuration: {

--- a/packages/junior/tests/integration/slack/provider-default-config-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/provider-default-config-behavior.test.ts
@@ -5,6 +5,7 @@ import {
   createTestThread,
   createTestDestination,
 } from "../../fixtures/slack-harness";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 function toPostedText(value: unknown): string {
   if (typeof value === "string") {
@@ -63,24 +64,26 @@ describe("Slack behavior: provider default configuration", () => {
   });
 
   it("does not intercept combined repo setup and agent work", async () => {
-    const generateAssistantReply = vi.fn(async () => ({
-      text: "Created the issue.",
-      deliveryMode: "thread" as const,
-      deliveryPlan: {
-        mode: "thread" as const,
-        postThreadText: true,
-        attachFiles: "none" as const,
-      },
-      diagnostics: {
-        assistantMessageCount: 1,
-        modelId: "test-model",
-        outcome: "success" as const,
-        toolCalls: [],
-        toolErrorCount: 0,
-        toolResultCount: 0,
-        usedPrimaryText: true,
-      },
-    }));
+    const generateAssistantReply = vi.fn(async () =>
+      completedAgentRun({
+        text: "Created the issue.",
+        deliveryMode: "thread" as const,
+        deliveryPlan: {
+          mode: "thread" as const,
+          postThreadText: true,
+          attachFiles: "none" as const,
+        },
+        diagnostics: {
+          assistantMessageCount: 1,
+          modelId: "test-model",
+          outcome: "success" as const,
+          toolCalls: [],
+          toolErrorCount: 0,
+          toolResultCount: 0,
+          usedPrimaryText: true,
+        },
+      }),
+    );
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {

--- a/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import {
-  RetryableTurnError,
-  TurnInputCommitLostError,
-} from "@/chat/runtime/turn";
+import { TurnInputCommitLostError } from "@/chat/runtime/turn";
 import type { JuniorRuntimeServiceOverrides } from "@/chat/app/services";
 import { createProviderError } from "@/chat/services/provider-retry";
 import { createTestChatRuntime } from "../../fixtures/chat-runtime";
@@ -11,6 +8,7 @@ import {
   createTestThread,
   createTestDestination,
 } from "../../fixtures/slack-harness";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const emptyThreadReplies = async () => [];
 
@@ -44,6 +42,21 @@ function toPostedText(value: unknown): string {
   }
 
   return String(value);
+}
+
+function completedReply(text: string) {
+  return completedAgentRun({
+    text,
+    diagnostics: {
+      assistantMessageCount: 1,
+      modelId: "fake-agent-model",
+      outcome: "success" as const,
+      toolCalls: [],
+      toolErrorCount: 0,
+      toolResultCount: 0,
+      usedPrimaryText: true,
+    },
+  });
 }
 
 describe("Slack behavior: subscribed messages", () => {
@@ -144,18 +157,7 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async (_prompt, context) => {
             replyContexts.push(context);
-            return {
-              text: "I checked the subscribed PR event.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("I checked the subscribed PR event.");
           },
         },
       },
@@ -212,12 +214,17 @@ describe("Slack behavior: subscribed messages", () => {
         },
         replyExecutor: {
           generateAssistantReply: async () => {
-            throw new RetryableTurnError("mcp_auth_resume", "auth required", {
+            return {
+              status: "awaiting_auth",
+              authDisposition: "link_sent",
+              authDurationMs: 1,
+              authKind: "mcp",
               authProvider: "github",
               authProviderDisplayName: "GitHub",
               conversationId: "slack:C_BEHAVIOR:1700002000.003",
               sessionId: "resource-event-auth",
-            });
+              sliceId: 2,
+            };
           },
         },
       },
@@ -278,18 +285,9 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async (prompt) => {
             replyCalls.push(prompt);
-            return {
-              text: "Action item captured: monitor dashboards for 30 minutes.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply(
+              "Action item captured: monitor dashboards for 30 minutes.",
+            );
           },
         },
       },
@@ -336,18 +334,7 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async (prompt) => {
             replyCalls.push(prompt);
-            return {
-              text: "Yes. Shipping status is green.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("Yes. Shipping status is green.");
           },
         },
       },
@@ -389,18 +376,7 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async (prompt) => {
             replyCalls.push(prompt);
-            return {
-              text: "Handled queued subscribed turn.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("Handled queued subscribed turn.");
           },
         },
       },
@@ -465,21 +441,11 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async (prompt) => {
             replyCalls.push(prompt);
-            return {
-              text:
-                replyCalls.length === 1
-                  ? "I can help with this thread."
-                  : "I'm back because you mentioned me again.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply(
+              replyCalls.length === 1
+                ? "I can help with this thread."
+                : "I'm back because you mentioned me again.",
+            );
           },
         },
       },
@@ -556,18 +522,7 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async () => {
             replyCalled = true;
-            return {
-              text: "This should never be posted.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("This should never be posted.");
           },
         },
       },
@@ -613,18 +568,7 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async () => {
             replyCalled = true;
-            return {
-              text: "This should never be posted.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("This should never be posted.");
           },
         },
       },
@@ -676,18 +620,7 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async () => {
             replyCalled = true;
-            return {
-              text: "This should never be posted.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("This should never be posted.");
           },
         },
       },
@@ -741,18 +674,7 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async () => {
             replyCalled = true;
-            return {
-              text: "This should never be posted.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("This should never be posted.");
           },
         },
       },
@@ -804,18 +726,7 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async () => {
             replyCalled = true;
-            return {
-              text: "This should never be posted.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("This should never be posted.");
           },
         },
       },
@@ -874,18 +785,7 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async () => {
             replyCalled = true;
-            return {
-              text: "This should never be posted.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("This should never be posted.");
           },
         },
       },
@@ -945,18 +845,7 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async () => {
             replyCalled = true;
-            return {
-              text: "This should never be posted.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("This should never be posted.");
           },
         },
       },
@@ -1026,18 +915,7 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async (prompt) => {
             replyCalls.push(prompt);
-            return {
-              text: "You asked for the budget by Friday.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("You asked for the budget by Friday.");
           },
         },
       },
@@ -1096,21 +974,11 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async (prompt) => {
             replyCalls.push(prompt);
-            return {
-              text:
-                replyCalls.length === 1
-                  ? "The deploy changed billing, auth, and the API gateway."
-                  : "The three services were billing, auth, and the API gateway.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply(
+              replyCalls.length === 1
+                ? "The deploy changed billing, auth, and the API gateway."
+                : "The three services were billing, auth, and the API gateway.",
+            );
           },
         },
       },

--- a/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
@@ -160,7 +160,17 @@ describe("Slack behavior: subscribed messages", () => {
         },
         replyExecutor: {
           agentRunner: {
-            run: async (_prompt, context) => {
+            run: async (request) => {
+              const _prompt = request.input.messageText;
+              const context = {
+                ...request.input,
+                ...request.routing,
+                ...(request.policy ?? {}),
+                ...(request.state ?? {}),
+                ...(request.observers ?? {}),
+                ...(request.durability ?? {}),
+              };
+
               replyContexts.push(context);
               return completedReply("I checked the subscribed PR event.");
             },
@@ -292,7 +302,9 @@ describe("Slack behavior: subscribed messages", () => {
         },
         replyExecutor: {
           agentRunner: {
-            run: async (prompt) => {
+            run: async (request) => {
+              const prompt = request.input.messageText;
+
               replyCalls.push(prompt);
               return completedReply(
                 "Action item captured: monitor dashboards for 30 minutes.",
@@ -343,7 +355,9 @@ describe("Slack behavior: subscribed messages", () => {
         },
         replyExecutor: {
           agentRunner: {
-            run: async (prompt) => {
+            run: async (request) => {
+              const prompt = request.input.messageText;
+
               replyCalls.push(prompt);
               return completedReply("Yes. Shipping status is green.");
             },
@@ -387,7 +401,9 @@ describe("Slack behavior: subscribed messages", () => {
         },
         replyExecutor: {
           agentRunner: {
-            run: async (prompt) => {
+            run: async (request) => {
+              const prompt = request.input.messageText;
+
               replyCalls.push(prompt);
               return completedReply("Handled queued subscribed turn.");
             },
@@ -454,7 +470,9 @@ describe("Slack behavior: subscribed messages", () => {
         },
         replyExecutor: {
           agentRunner: {
-            run: async (prompt) => {
+            run: async (request) => {
+              const prompt = request.input.messageText;
+
               replyCalls.push(prompt);
               return completedReply(
                 replyCalls.length === 1
@@ -944,7 +962,9 @@ describe("Slack behavior: subscribed messages", () => {
         },
         replyExecutor: {
           agentRunner: {
-            run: async (prompt) => {
+            run: async (request) => {
+              const prompt = request.input.messageText;
+
               replyCalls.push(prompt);
               return completedReply("You asked for the budget by Friday.");
             },
@@ -1005,7 +1025,9 @@ describe("Slack behavior: subscribed messages", () => {
         },
         replyExecutor: {
           agentRunner: {
-            run: async (prompt) => {
+            run: async (request) => {
+              const prompt = request.input.messageText;
+
               replyCalls.push(prompt);
               return completedReply(
                 replyCalls.length === 1

--- a/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
@@ -82,7 +82,7 @@ describe("Slack behavior: subscribed messages", () => {
           agentRunner: {
             run: async () => {
               throw new Error(
-                "generateAssistantReply should not run when classifier skips reply",
+                "executeAgentRun should not run when classifier skips reply",
               );
             },
           },
@@ -122,7 +122,7 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           agentRunner: {
             run: async () => {
-              throw new Error("generateAssistantReply should not run");
+              throw new Error("executeAgentRun should not run");
             },
           },
         },

--- a/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
@@ -79,10 +79,12 @@ describe("Slack behavior: subscribed messages", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async () => {
-            throw new Error(
-              "generateAssistantReply should not run when classifier skips reply",
-            );
+          agentRunner: {
+            run: async () => {
+              throw new Error(
+                "generateAssistantReply should not run when classifier skips reply",
+              );
+            },
           },
         },
       },
@@ -118,8 +120,10 @@ describe("Slack behavior: subscribed messages", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async () => {
-            throw new Error("generateAssistantReply should not run");
+          agentRunner: {
+            run: async () => {
+              throw new Error("generateAssistantReply should not run");
+            },
           },
         },
       },
@@ -155,9 +159,11 @@ describe("Slack behavior: subscribed messages", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async (_prompt, context) => {
-            replyContexts.push(context);
-            return completedReply("I checked the subscribed PR event.");
+          agentRunner: {
+            run: async (_prompt, context) => {
+              replyContexts.push(context);
+              return completedReply("I checked the subscribed PR event.");
+            },
           },
         },
       },
@@ -213,18 +219,20 @@ describe("Slack behavior: subscribed messages", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async () => {
-            return {
-              status: "awaiting_auth",
-              authDisposition: "link_sent",
-              authDurationMs: 1,
-              authKind: "mcp",
-              authProvider: "github",
-              authProviderDisplayName: "GitHub",
-              conversationId: "slack:C_BEHAVIOR:1700002000.003",
-              sessionId: "resource-event-auth",
-              sliceId: 2,
-            };
+          agentRunner: {
+            run: async () => {
+              return {
+                status: "awaiting_auth",
+                authDisposition: "link_sent",
+                authDurationMs: 1,
+                authKind: "mcp",
+                authProvider: "github",
+                authProviderDisplayName: "GitHub",
+                conversationId: "slack:C_BEHAVIOR:1700002000.003",
+                sessionId: "resource-event-auth",
+                sliceId: 2,
+              };
+            },
           },
         },
       },
@@ -283,11 +291,13 @@ describe("Slack behavior: subscribed messages", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async (prompt) => {
-            replyCalls.push(prompt);
-            return completedReply(
-              "Action item captured: monitor dashboards for 30 minutes.",
-            );
+          agentRunner: {
+            run: async (prompt) => {
+              replyCalls.push(prompt);
+              return completedReply(
+                "Action item captured: monitor dashboards for 30 minutes.",
+              );
+            },
           },
         },
       },
@@ -332,9 +342,11 @@ describe("Slack behavior: subscribed messages", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async (prompt) => {
-            replyCalls.push(prompt);
-            return completedReply("Yes. Shipping status is green.");
+          agentRunner: {
+            run: async (prompt) => {
+              replyCalls.push(prompt);
+              return completedReply("Yes. Shipping status is green.");
+            },
           },
         },
       },
@@ -374,9 +386,11 @@ describe("Slack behavior: subscribed messages", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async (prompt) => {
-            replyCalls.push(prompt);
-            return completedReply("Handled queued subscribed turn.");
+          agentRunner: {
+            run: async (prompt) => {
+              replyCalls.push(prompt);
+              return completedReply("Handled queued subscribed turn.");
+            },
           },
         },
       },
@@ -439,13 +453,15 @@ describe("Slack behavior: subscribed messages", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async (prompt) => {
-            replyCalls.push(prompt);
-            return completedReply(
-              replyCalls.length === 1
-                ? "I can help with this thread."
-                : "I'm back because you mentioned me again.",
-            );
+          agentRunner: {
+            run: async (prompt) => {
+              replyCalls.push(prompt);
+              return completedReply(
+                replyCalls.length === 1
+                  ? "I can help with this thread."
+                  : "I'm back because you mentioned me again.",
+              );
+            },
           },
         },
       },
@@ -520,9 +536,11 @@ describe("Slack behavior: subscribed messages", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async () => {
-            replyCalled = true;
-            return completedReply("This should never be posted.");
+          agentRunner: {
+            run: async () => {
+              replyCalled = true;
+              return completedReply("This should never be posted.");
+            },
           },
         },
       },
@@ -566,9 +584,11 @@ describe("Slack behavior: subscribed messages", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async () => {
-            replyCalled = true;
-            return completedReply("This should never be posted.");
+          agentRunner: {
+            run: async () => {
+              replyCalled = true;
+              return completedReply("This should never be posted.");
+            },
           },
         },
       },
@@ -618,9 +638,11 @@ describe("Slack behavior: subscribed messages", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async () => {
-            replyCalled = true;
-            return completedReply("This should never be posted.");
+          agentRunner: {
+            run: async () => {
+              replyCalled = true;
+              return completedReply("This should never be posted.");
+            },
           },
         },
       },
@@ -672,9 +694,11 @@ describe("Slack behavior: subscribed messages", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async () => {
-            replyCalled = true;
-            return completedReply("This should never be posted.");
+          agentRunner: {
+            run: async () => {
+              replyCalled = true;
+              return completedReply("This should never be posted.");
+            },
           },
         },
       },
@@ -724,9 +748,11 @@ describe("Slack behavior: subscribed messages", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async () => {
-            replyCalled = true;
-            return completedReply("This should never be posted.");
+          agentRunner: {
+            run: async () => {
+              replyCalled = true;
+              return completedReply("This should never be posted.");
+            },
           },
         },
       },
@@ -783,9 +809,11 @@ describe("Slack behavior: subscribed messages", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async () => {
-            replyCalled = true;
-            return completedReply("This should never be posted.");
+          agentRunner: {
+            run: async () => {
+              replyCalled = true;
+              return completedReply("This should never be posted.");
+            },
           },
         },
       },
@@ -843,9 +871,11 @@ describe("Slack behavior: subscribed messages", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async () => {
-            replyCalled = true;
-            return completedReply("This should never be posted.");
+          agentRunner: {
+            run: async () => {
+              replyCalled = true;
+              return completedReply("This should never be posted.");
+            },
           },
         },
       },
@@ -913,9 +943,11 @@ describe("Slack behavior: subscribed messages", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async (prompt) => {
-            replyCalls.push(prompt);
-            return completedReply("You asked for the budget by Friday.");
+          agentRunner: {
+            run: async (prompt) => {
+              replyCalls.push(prompt);
+              return completedReply("You asked for the budget by Friday.");
+            },
           },
         },
       },
@@ -972,13 +1004,15 @@ describe("Slack behavior: subscribed messages", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async (prompt) => {
-            replyCalls.push(prompt);
-            return completedReply(
-              replyCalls.length === 1
-                ? "The deploy changed billing, auth, and the API gateway."
-                : "The three services were billing, auth, and the API gateway.",
-            );
+          agentRunner: {
+            run: async (prompt) => {
+              replyCalls.push(prompt);
+              return completedReply(
+                replyCalls.length === 1
+                  ? "The deploy changed billing, auth, and the API gateway."
+                  : "The three services were billing, auth, and the API gateway.",
+              );
+            },
           },
         },
       },

--- a/packages/junior/tests/integration/slack/thread-continuity-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/thread-continuity-behavior.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import { createTestChatRuntime } from "../../fixtures/chat-runtime";
 import {
   createTestMessage,
@@ -46,7 +47,7 @@ describe("Slack behavior: thread continuity", () => {
         replyExecutor: {
           generateAssistantReply: async (prompt) => {
             prompts.push(prompt);
-            return {
+            return completedAgentRun({
               text:
                 scriptedReplies[prompts.length - 1] ?? "Unexpected extra reply",
               diagnostics: {
@@ -58,7 +59,7 @@ describe("Slack behavior: thread continuity", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },

--- a/packages/junior/tests/integration/slack/thread-continuity-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/thread-continuity-behavior.test.ts
@@ -45,21 +45,24 @@ describe("Slack behavior: thread continuity", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async (prompt) => {
-            prompts.push(prompt);
-            return completedAgentRun({
-              text:
-                scriptedReplies[prompts.length - 1] ?? "Unexpected extra reply",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            });
+          agentRunner: {
+            run: async (prompt) => {
+              prompts.push(prompt);
+              return completedAgentRun({
+                text:
+                  scriptedReplies[prompts.length - 1] ??
+                  "Unexpected extra reply",
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "fake-agent-model",
+                  outcome: "success",
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              });
+            },
           },
         },
       },

--- a/packages/junior/tests/integration/slack/thread-continuity-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/thread-continuity-behavior.test.ts
@@ -46,7 +46,9 @@ describe("Slack behavior: thread continuity", () => {
         },
         replyExecutor: {
           agentRunner: {
-            run: async (prompt) => {
+            run: async (request) => {
+              const prompt = request.input.messageText;
+
               prompts.push(prompt);
               return completedAgentRun({
                 text:

--- a/packages/junior/tests/unit/handlers/mcp-oauth-callback.test.ts
+++ b/packages/junior/tests/unit/handlers/mcp-oauth-callback.test.ts
@@ -20,6 +20,12 @@ function makeRequest(url: string): Request {
   return new Request(url, { method: "GET" });
 }
 
+const testAgentRunner = {
+  run: vi.fn(async () => {
+    throw new Error("test agent runner should not run");
+  }),
+};
+
 describe("mcp oauth callback handler", () => {
   beforeEach(() => {
     finalizeMcpAuthorizationMock.mockReset();
@@ -35,6 +41,7 @@ describe("mcp oauth callback handler", () => {
       makeRequest("https://example.com/api/oauth/callback/mcp/demo?code=abc"),
       "demo",
       waitUntil.fn,
+      { agentRunner: testAgentRunner },
     );
 
     expect(response.status).toBe(400);
@@ -50,6 +57,7 @@ describe("mcp oauth callback handler", () => {
       ),
       "demo",
       waitUntil.fn,
+      { agentRunner: testAgentRunner },
     );
 
     expect(response.status).toBe(400);
@@ -70,6 +78,7 @@ describe("mcp oauth callback handler", () => {
       ),
       "demo",
       waitUntil.fn,
+      { agentRunner: testAgentRunner },
     );
 
     expect(response.status).toBe(500);

--- a/packages/junior/tests/unit/handlers/oauth-callback.test.ts
+++ b/packages/junior/tests/unit/handlers/oauth-callback.test.ts
@@ -118,6 +118,12 @@ const testWaitUntil: WaitUntilFn = (task) => {
   waitUntilCallbacks.push(typeof task === "function" ? task : () => task);
 };
 
+const testAgentRunner = {
+  run: vi.fn(async () => {
+    throw new Error("test agent runner should not run");
+  }),
+};
+
 beforeEach(async () => {
   process.env.JUNIOR_STATE_ADAPTER = "memory";
   await disconnectStateAdapter();
@@ -249,6 +255,7 @@ describe("oauth callback handler", () => {
       ),
       "unknown",
       testWaitUntil,
+      { agentRunner: testAgentRunner },
     );
 
     expect(response.status).toBe(404);
@@ -262,6 +269,7 @@ describe("oauth callback handler", () => {
       makeRequest("https://example.com/api/oauth/callback/sentry"),
       "sentry",
       testWaitUntil,
+      { agentRunner: testAgentRunner },
     );
 
     expect(response.status).toBe(400);
@@ -277,6 +285,7 @@ describe("oauth callback handler", () => {
       ),
       "sentry",
       testWaitUntil,
+      { agentRunner: testAgentRunner },
     );
 
     expect(response.status).toBe(400);
@@ -301,6 +310,7 @@ describe("oauth callback handler", () => {
       ),
       "sentry",
       testWaitUntil,
+      { agentRunner: testAgentRunner },
     );
 
     expect(response.status).toBe(400);
@@ -329,6 +339,7 @@ describe("oauth callback handler", () => {
       ),
       "sentry",
       testWaitUntil,
+      { agentRunner: testAgentRunner },
     );
 
     expect(await getStoredState(stateKey)).toBeFalsy();
@@ -349,6 +360,7 @@ describe("oauth callback handler", () => {
       ),
       "sentry",
       testWaitUntil,
+      { agentRunner: testAgentRunner },
     );
 
     expect(response.status).toBe(500);
@@ -379,6 +391,7 @@ describe("oauth callback handler", () => {
       ),
       "sentry",
       testWaitUntil,
+      { agentRunner: testAgentRunner },
     );
 
     expect(response.status).toBe(200);
@@ -416,6 +429,7 @@ describe("oauth callback handler", () => {
       ),
       "example",
       testWaitUntil,
+      { agentRunner: testAgentRunner },
     );
 
     expect(response.status).toBe(200);
@@ -473,6 +487,7 @@ describe("oauth callback handler", () => {
       ),
       "github",
       testWaitUntil,
+      { agentRunner: testAgentRunner },
     );
 
     expect(response.status).toBe(200);
@@ -524,6 +539,7 @@ describe("oauth callback handler", () => {
       ),
       "sentry",
       testWaitUntil,
+      { agentRunner: testAgentRunner },
     );
 
     expect(response.status).toBe(400);
@@ -549,6 +565,7 @@ describe("oauth callback handler", () => {
       ),
       "sentry",
       testWaitUntil,
+      { agentRunner: testAgentRunner },
     );
 
     expect(response.status).toBe(500);
@@ -573,6 +590,7 @@ describe("oauth callback handler", () => {
       ),
       "sentry",
       testWaitUntil,
+      { agentRunner: testAgentRunner },
     );
 
     expect(response.status).toBe(500);
@@ -595,6 +613,7 @@ describe("oauth callback handler", () => {
       ),
       "sentry",
       testWaitUntil,
+      { agentRunner: testAgentRunner },
     );
 
     expect(response.status).toBe(400);
@@ -615,6 +634,7 @@ describe("oauth callback handler", () => {
       ),
       "sentry",
       testWaitUntil,
+      { agentRunner: testAgentRunner },
     );
 
     expect(response.status).toBe(400);
@@ -630,6 +650,7 @@ describe("oauth callback handler", () => {
       ),
       "sentry",
       testWaitUntil,
+      { agentRunner: testAgentRunner },
     );
 
     expect(response.status).toBe(400);
@@ -645,6 +666,7 @@ describe("oauth callback handler", () => {
       ),
       "sentry",
       testWaitUntil,
+      { agentRunner: testAgentRunner },
     );
 
     expect(response.status).toBe(400);
@@ -683,6 +705,7 @@ describe("oauth callback handler", () => {
       ),
       "sentry",
       testWaitUntil,
+      { agentRunner: testAgentRunner },
     );
 
     expect(response.status).toBe(200);

--- a/packages/junior/tests/unit/handlers/oauth-resume.test.ts
+++ b/packages/junior/tests/unit/handlers/oauth-resume.test.ts
@@ -121,7 +121,7 @@ describe("resumeAuthorizedRequest", () => {
         source: testSlackSource("1700000000.0001"),
         requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
       },
-      generateReply: () => new Promise<never>(() => {}),
+      agentRunner: { run: () => new Promise<never>(() => {}) },
       replyTimeoutMs: 10,
       onFailure,
     });
@@ -164,8 +164,10 @@ describe("resumeAuthorizedRequest", () => {
         source: testSlackSource("1700000000.0004"),
         requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
       },
-      generateReply: async () => {
-        throw new Error("resume failed");
+      agentRunner: {
+        run: async () => {
+          throw new Error("resume failed");
+        },
       },
       onFailure,
     });
@@ -205,19 +207,21 @@ describe("resumeAuthorizedRequest", () => {
           source: testSlackSource("1700000000.0005"),
           requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
         },
-        generateReply: async () =>
-          completedAgentRun({
-            text: "Final resumed answer",
-            diagnostics: {
-              assistantMessageCount: 1,
-              modelId: "fake-agent-model",
-              outcome: "success" as const,
-              toolCalls: [],
-              toolErrorCount: 0,
-              toolResultCount: 0,
-              usedPrimaryText: true,
-            },
-          }),
+        agentRunner: {
+          run: async () =>
+            completedAgentRun({
+              text: "Final resumed answer",
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "fake-agent-model",
+                outcome: "success" as const,
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            }),
+        },
         onSuccess: async () => {
           throw new Error("state write failed");
         },
@@ -263,19 +267,21 @@ describe("resumeAuthorizedRequest", () => {
         source: testSlackSource("1700000000.0006"),
         requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
       },
-      generateReply: async () =>
-        completedAgentRun({
-          text: "Final resumed answer",
-          diagnostics: {
-            assistantMessageCount: 1,
-            modelId: "fake-agent-model",
-            outcome: "success" as const,
-            toolCalls: [],
-            toolErrorCount: 0,
-            toolResultCount: 0,
-            usedPrimaryText: true,
-          },
-        }),
+      agentRunner: {
+        run: async () =>
+          completedAgentRun({
+            text: "Final resumed answer",
+            diagnostics: {
+              assistantMessageCount: 1,
+              modelId: "fake-agent-model",
+              outcome: "success" as const,
+              toolCalls: [],
+              toolErrorCount: 0,
+              toolResultCount: 0,
+              usedPrimaryText: true,
+            },
+          }),
+      },
       scheduleSessionCompletedPluginTasks,
     });
 
@@ -311,13 +317,15 @@ describe("resumeAuthorizedRequest", () => {
         source: testSlackSource("1700000000.0002"),
         requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
       },
-      generateReply: async () => {
-        throw new RetryableTurnError("agent_continue", "timed out again", {
-          conversationId: "conversation-1",
-          sessionId: "turn-1",
-          version: 3,
-          sliceId: 3,
-        });
+      agentRunner: {
+        run: async () => {
+          throw new RetryableTurnError("agent_continue", "timed out again", {
+            conversationId: "conversation-1",
+            sessionId: "turn-1",
+            version: 3,
+            sliceId: 3,
+          });
+        },
       },
       onTimeoutPause,
     });
@@ -341,13 +349,15 @@ describe("resumeAuthorizedRequest", () => {
         source: testSlackSource("1700000000.0003"),
         requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
       },
-      generateReply: async () => {
-        throw new RetryableTurnError("agent_continue", "timed out again", {
-          conversationId: "conversation-1",
-          sessionId: "turn-1",
-          version: 3,
-          sliceId: 6,
-        });
+      agentRunner: {
+        run: async () => {
+          throw new RetryableTurnError("agent_continue", "timed out again", {
+            conversationId: "conversation-1",
+            sessionId: "turn-1",
+            version: 3,
+            sliceId: 6,
+          });
+        },
       },
       onTimeoutPause: async () => {
         throw new Error("continuation scheduling failed");

--- a/packages/junior/tests/unit/handlers/oauth-resume.test.ts
+++ b/packages/junior/tests/unit/handlers/oauth-resume.test.ts
@@ -3,6 +3,7 @@ import { createSlackSource } from "@sentry/junior-plugin-api";
 import { RetryableTurnError } from "@/chat/runtime/turn";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import { setPlugins } from "@/chat/plugins/agent-hooks";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const { postMessageMock, setStatusMock, uploadFilesToThreadMock } = vi.hoisted(
   () => ({
@@ -204,18 +205,19 @@ describe("resumeAuthorizedRequest", () => {
           source: testSlackSource("1700000000.0005"),
           requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
         },
-        generateReply: async () => ({
-          text: "Final resumed answer",
-          diagnostics: {
-            assistantMessageCount: 1,
-            modelId: "fake-agent-model",
-            outcome: "success",
-            toolCalls: [],
-            toolErrorCount: 0,
-            toolResultCount: 0,
-            usedPrimaryText: true,
-          },
-        }),
+        generateReply: async () =>
+          completedAgentRun({
+            text: "Final resumed answer",
+            diagnostics: {
+              assistantMessageCount: 1,
+              modelId: "fake-agent-model",
+              outcome: "success" as const,
+              toolCalls: [],
+              toolErrorCount: 0,
+              toolResultCount: 0,
+              usedPrimaryText: true,
+            },
+          }),
         onSuccess: async () => {
           throw new Error("state write failed");
         },
@@ -261,18 +263,19 @@ describe("resumeAuthorizedRequest", () => {
         source: testSlackSource("1700000000.0006"),
         requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
       },
-      generateReply: async () => ({
-        text: "Final resumed answer",
-        diagnostics: {
-          assistantMessageCount: 1,
-          modelId: "fake-agent-model",
-          outcome: "success",
-          toolCalls: [],
-          toolErrorCount: 0,
-          toolResultCount: 0,
-          usedPrimaryText: true,
-        },
-      }),
+      generateReply: async () =>
+        completedAgentRun({
+          text: "Final resumed answer",
+          diagnostics: {
+            assistantMessageCount: 1,
+            modelId: "fake-agent-model",
+            outcome: "success" as const,
+            toolCalls: [],
+            toolErrorCount: 0,
+            toolResultCount: 0,
+            usedPrimaryText: true,
+          },
+        }),
       scheduleSessionCompletedPluginTasks,
     });
 

--- a/packages/junior/tests/unit/handlers/oauth-resume.test.ts
+++ b/packages/junior/tests/unit/handlers/oauth-resume.test.ts
@@ -114,12 +114,14 @@ describe("resumeAuthorizedRequest", () => {
       threadTs: "1700000000.0001",
       connectedText: "connected",
       replyContext: {
-        credentialContext: {
-          actor: { type: "user", userId: "U-test" },
+        routing: {
+          credentialContext: {
+            actor: { type: "user", userId: "U-test" },
+          },
+          destination: TEST_SLACK_DESTINATION,
+          source: testSlackSource("1700000000.0001"),
+          requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
         },
-        destination: TEST_SLACK_DESTINATION,
-        source: testSlackSource("1700000000.0001"),
-        requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
       },
       agentRunner: { run: () => new Promise<never>(() => {}) },
       replyTimeoutMs: 10,
@@ -157,12 +159,14 @@ describe("resumeAuthorizedRequest", () => {
       threadTs: "1700000000.0004",
       connectedText: "connected",
       replyContext: {
-        credentialContext: {
-          actor: { type: "user", userId: "U-test" },
+        routing: {
+          credentialContext: {
+            actor: { type: "user", userId: "U-test" },
+          },
+          destination: TEST_SLACK_DESTINATION,
+          source: testSlackSource("1700000000.0004"),
+          requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
         },
-        destination: TEST_SLACK_DESTINATION,
-        source: testSlackSource("1700000000.0004"),
-        requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
       },
       agentRunner: {
         run: async () => {
@@ -200,12 +204,18 @@ describe("resumeAuthorizedRequest", () => {
         channelId: "C-test",
         threadTs: "1700000000.0005",
         replyContext: {
-          credentialContext: {
-            actor: { type: "user", userId: "U-test" },
+          routing: {
+            credentialContext: {
+              actor: { type: "user", userId: "U-test" },
+            },
+            destination: TEST_SLACK_DESTINATION,
+            source: testSlackSource("1700000000.0005"),
+            requester: {
+              platform: "slack",
+              teamId: "T-test",
+              userId: "U-test",
+            },
           },
-          destination: TEST_SLACK_DESTINATION,
-          source: testSlackSource("1700000000.0005"),
-          requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
         },
         agentRunner: {
           run: async () =>
@@ -256,16 +266,18 @@ describe("resumeAuthorizedRequest", () => {
       channelId: "C-test",
       threadTs: "1700000000.0006",
       replyContext: {
-        credentialContext: {
-          actor: { type: "user", userId: "U-test" },
+        routing: {
+          credentialContext: {
+            actor: { type: "user", userId: "U-test" },
+          },
+          correlation: {
+            conversationId: "slack:T-test:C-test:1700000000.0006",
+            turnId: "turn_1700000000_0006",
+          },
+          destination: TEST_SLACK_DESTINATION,
+          source: testSlackSource("1700000000.0006"),
+          requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
         },
-        correlation: {
-          conversationId: "slack:T-test:C-test:1700000000.0006",
-          turnId: "turn_1700000000_0006",
-        },
-        destination: TEST_SLACK_DESTINATION,
-        source: testSlackSource("1700000000.0006"),
-        requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
       },
       agentRunner: {
         run: async () =>
@@ -310,12 +322,14 @@ describe("resumeAuthorizedRequest", () => {
       channelId: "C-test",
       threadTs: "1700000000.0002",
       replyContext: {
-        credentialContext: {
-          actor: { type: "user", userId: "U-test" },
+        routing: {
+          credentialContext: {
+            actor: { type: "user", userId: "U-test" },
+          },
+          destination: TEST_SLACK_DESTINATION,
+          source: testSlackSource("1700000000.0002"),
+          requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
         },
-        destination: TEST_SLACK_DESTINATION,
-        source: testSlackSource("1700000000.0002"),
-        requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
       },
       agentRunner: {
         run: async () => {
@@ -342,12 +356,14 @@ describe("resumeAuthorizedRequest", () => {
       channelId: "C-test",
       threadTs: "1700000000.0003",
       replyContext: {
-        credentialContext: {
-          actor: { type: "user", userId: "U-test" },
+        routing: {
+          credentialContext: {
+            actor: { type: "user", userId: "U-test" },
+          },
+          destination: TEST_SLACK_DESTINATION,
+          source: testSlackSource("1700000000.0003"),
+          requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
         },
-        destination: TEST_SLACK_DESTINATION,
-        source: testSlackSource("1700000000.0003"),
-        requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
       },
       agentRunner: {
         run: async () => {

--- a/packages/junior/tests/unit/misc/agent-run-helpers-runtime-context.test.ts
+++ b/packages/junior/tests/unit/misc/agent-run-helpers-runtime-context.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { PiMessage } from "@/chat/pi/messages";
-import { prependMissingRuntimeTurnContext } from "@/chat/respond-helpers";
+import { prependMissingRuntimeTurnContext } from "@/chat/agent-run-helpers";
 
 describe("prependMissingRuntimeTurnContext", () => {
   it("leaves recorded bootstrap prompts unchanged", () => {

--- a/packages/junior/tests/unit/misc/agent-run-helpers-tools.test.ts
+++ b/packages/junior/tests/unit/misc/agent-run-helpers-tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getSuccessfulToolCalls } from "@/chat/respond-helpers";
+import { getSuccessfulToolCalls } from "@/chat/agent-run-helpers";
 
 describe("getSuccessfulToolCalls", () => {
   it("omits failed tool results", () => {

--- a/packages/junior/tests/unit/misc/agent-run-helpers-user-turn.test.ts
+++ b/packages/junior/tests/unit/misc/agent-run-helpers-user-turn.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildUserTurnText } from "@/chat/respond-helpers";
+import { buildUserTurnText } from "@/chat/agent-run-helpers";
 
 describe("buildUserTurnText", () => {
   it("wraps input in the current instruction boundary without context", () => {

--- a/packages/junior/tests/unit/runtime/agent-run-agent-continue.test.ts
+++ b/packages/junior/tests/unit/runtime/agent-run-agent-continue.test.ts
@@ -248,7 +248,7 @@ vi.mock("@/chat/skills", async (importOriginal) => ({
   parseSkillInvocation: () => null,
 }));
 
-import { generateAssistantReply } from "@/chat/respond";
+import { executeAgentRun } from "@/chat/agent-run";
 import { isTurnInputCommitLostError } from "@/chat/runtime/turn";
 import { AGENT_CONTINUE_MAX_SLICES } from "@/chat/services/turn-session-record";
 import { getConversationStore } from "@/chat/db";
@@ -276,7 +276,7 @@ const TEST_REQUESTER = {
   userId: "U123",
 } as const;
 
-describe("generateAssistantReply agent continuation", () => {
+describe("executeAgentRun agent continuation", () => {
   beforeEach(async () => {
     promptAborted.value = false;
     continueCalls.value = 0;
@@ -298,7 +298,7 @@ describe("generateAssistantReply agent continuation", () => {
   it("rejects durable input when no prompt checkpoint can be persisted", async () => {
     const onInputCommitted = vi.fn();
 
-    const error = await generateAssistantReply({
+    const error = await executeAgentRun({
       input: { messageText: "help me" },
       routing: { destination: TEST_DESTINATION, source: TEST_SOURCE },
       durability: { onInputCommitted },
@@ -309,7 +309,7 @@ describe("generateAssistantReply agent continuation", () => {
   });
 
   it("stores the last safe boundary and returns a timed-out outcome", async () => {
-    const replyPromise = generateAssistantReply({
+    const replyPromise = executeAgentRun({
       input: { messageText: "help me" },
       routing: {
         destination: TEST_DESTINATION,
@@ -371,7 +371,7 @@ describe("generateAssistantReply agent continuation", () => {
       resumeReason: "timeout",
     });
 
-    const replyPromise = generateAssistantReply({
+    const replyPromise = executeAgentRun({
       input: { messageText: "help me" },
       routing: {
         destination: TEST_DESTINATION,
@@ -407,7 +407,7 @@ describe("generateAssistantReply agent continuation", () => {
 
   it("records the effective request deadline timeout budget", async () => {
     const startedAtMs = Date.now();
-    const replyPromise = generateAssistantReply({
+    const replyPromise = executeAgentRun({
       input: { messageText: "help me" },
       routing: {
         destination: TEST_DESTINATION,
@@ -438,7 +438,7 @@ describe("generateAssistantReply agent continuation", () => {
   });
 
   it("persists omitted-image context in the session-recorded Pi user message", async () => {
-    const replyPromise = generateAssistantReply({
+    const replyPromise = executeAgentRun({
       input: {
         messageText: "what is in this image?",
         omittedImageAttachmentCount: 1,
@@ -483,7 +483,7 @@ describe("generateAssistantReply agent continuation", () => {
 
   it("persists agent continuation state when abort does not settle the agent run", async () => {
     promptMode.value = "hangsAfterAbort";
-    const replyPromise = generateAssistantReply({
+    const replyPromise = executeAgentRun({
       input: { messageText: "help me" },
       routing: {
         destination: TEST_DESTINATION,
@@ -531,7 +531,7 @@ describe("generateAssistantReply agent continuation", () => {
 
   it("uses one wall-clock timeout budget across provider retries", async () => {
     promptMode.value = "providerRetryThenHangs";
-    const replyPromise = generateAssistantReply({
+    const replyPromise = executeAgentRun({
       input: { messageText: "help me" },
       routing: {
         destination: TEST_DESTINATION,

--- a/packages/junior/tests/unit/runtime/agent-run-lazy-sandbox.test.ts
+++ b/packages/junior/tests/unit/runtime/agent-run-lazy-sandbox.test.ts
@@ -518,24 +518,21 @@ vi.mock("@/chat/sandbox/sandbox", () => ({
   },
 }));
 
-import {
-  generateAssistantReply,
-  type ReplyRequestContext,
-} from "@/chat/respond";
+import { executeAgentRun, type AgentRunRequest } from "@/chat/agent-run";
 
 const LOCAL_DESTINATION = {
   platform: "local" as const,
-  conversationId: "local:test:respond-lazy-sandbox",
+  conversationId: "local:test:agent-run-lazy-sandbox",
 };
 const LOCAL_SOURCE = createLocalSource(LOCAL_DESTINATION.conversationId);
 
 async function generateLocalReply(
   message: string,
-  context: Partial<Omit<ReplyRequestContext, "input" | "routing">> & {
-    input?: Partial<Omit<ReplyRequestContext["input"], "messageText">>;
+  context: Partial<Omit<AgentRunRequest, "input" | "routing">> & {
+    input?: Partial<Omit<AgentRunRequest["input"], "messageText">>;
   } = {},
 ) {
-  const outcome = await generateAssistantReply({
+  const outcome = await executeAgentRun({
     ...context,
     input: {
       messageText: message,
@@ -549,10 +546,10 @@ async function generateLocalReply(
   if (outcome.status !== "completed" && outcome.status !== "failed") {
     throw new Error(`Expected final reply, got ${outcome.status}`);
   }
-  return outcome.reply;
+  return outcome.result;
 }
 
-describe("generateAssistantReply lazy sandbox boot", () => {
+describe("executeAgentRun lazy sandbox boot", () => {
   beforeEach(() => {
     agentMode.value = "plain";
     createSandboxCallCount.value = 0;
@@ -628,7 +625,7 @@ describe("generateAssistantReply lazy sandbox boot", () => {
       input: {
         userAttachments: [
           {
-            data: Buffer.from("TypeError: x is undefined\nat respond.ts:42"),
+            data: Buffer.from("TypeError: x is undefined\nat agent-run.ts:42"),
             filename: "error.txt",
             mediaType: "text/plain",
           },
@@ -645,7 +642,7 @@ describe("generateAssistantReply lazy sandbox boot", () => {
       input: {
         userAttachments: [
           {
-            data: Buffer.from("TypeError: x is undefined\nat respond.ts:42"),
+            data: Buffer.from("TypeError: x is undefined\nat agent-run.ts:42"),
             filename: "error.json",
             mediaType: "application/vnd.api+json; charset=utf-8",
           },

--- a/packages/junior/tests/unit/runtime/agent-run-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/unit/runtime/agent-run-mcp-progressive-loading.test.ts
@@ -559,26 +559,21 @@ vi.mock("@/chat/mcp/client", () => {
   };
 });
 
-import {
-  generateAssistantReply,
-  type ReplyRequestContext,
-} from "@/chat/respond";
+import { executeAgentRun, type AgentRunRequest } from "@/chat/agent-run";
 import {
   getAgentTurnSessionRecord,
   upsertAgentTurnSessionRecord,
 } from "@/chat/state/turn-session";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
 
-function finalReply(
-  outcome: Awaited<ReturnType<typeof generateAssistantReply>>,
-) {
+function finalReply(outcome: Awaited<ReturnType<typeof executeAgentRun>>) {
   if (outcome.status !== "completed" && outcome.status !== "failed") {
     throw new Error(`Expected final reply, got ${outcome.status}`);
   }
-  return outcome.reply;
+  return outcome.result;
 }
 
-function makeReplyRequest(
+function makeAgentRunRequest(
   messageText: string,
   args: {
     conversationId: string;
@@ -586,14 +581,14 @@ function makeReplyRequest(
     turnId: string;
   },
   overrides: {
-    input?: Partial<Omit<ReplyRequestContext["input"], "messageText">>;
-    routing?: Partial<ReplyRequestContext["routing"]>;
-    policy?: ReplyRequestContext["policy"];
-    state?: ReplyRequestContext["state"];
-    observers?: ReplyRequestContext["observers"];
-    durability?: ReplyRequestContext["durability"];
+    input?: Partial<Omit<AgentRunRequest["input"], "messageText">>;
+    routing?: Partial<AgentRunRequest["routing"]>;
+    policy?: AgentRunRequest["policy"];
+    state?: AgentRunRequest["state"];
+    observers?: AgentRunRequest["observers"];
+    durability?: AgentRunRequest["durability"];
   } = {},
-): ReplyRequestContext {
+): AgentRunRequest {
   const destination = {
     platform: "slack" as const,
     teamId: "T123",
@@ -639,7 +634,7 @@ function makeReplyRequest(
 
 // This suite validates local progressive-loading logic through a mocked
 // agent/runtime seam; it is not integration coverage.
-describe("generateAssistantReply progressive MCP loading", () => {
+describe("executeAgentRun progressive MCP loading", () => {
   beforeEach(async () => {
     agentInitialToolNames.length = 0;
     agentInitialSystemPrompts.length = 0;
@@ -712,13 +707,13 @@ describe("generateAssistantReply progressive MCP loading", () => {
   });
 
   it("persists loaded plugin skills across auth pause and resume", async () => {
-    const context = makeReplyRequest("help me", {
+    const context = makeAgentRunRequest("help me", {
       conversationId: "conversation-1",
       threadTs: "1712345.0001",
       turnId: "turn-1",
     });
 
-    const firstError = await generateAssistantReply(context);
+    const firstError = await executeAgentRun(context);
 
     expect(firstError.status).toBe("awaiting_auth");
     expect(agentInitialToolNames[0]).toContain("loadSkill");
@@ -750,7 +745,7 @@ describe("generateAssistantReply progressive MCP loading", () => {
     ]);
     expect(loadSkillExecutionErrorCount.value).toBe(0);
 
-    const reply = finalReply(await generateAssistantReply(context));
+    const reply = finalReply(await executeAgentRun(context));
 
     expect(reply.text).toBe("resumed reply");
     expect(promptCallCount.value).toBe(1);
@@ -795,8 +790,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
     listToolsMock.mockResolvedValue(makeDemoMcpTools());
 
     const reply = finalReply(
-      await generateAssistantReply(
-        makeReplyRequest("help me", {
+      await executeAgentRun(
+        makeAgentRunRequest("help me", {
           conversationId: "conversation-2",
           threadTs: "1712345.0002",
           turnId: "turn-2",
@@ -838,8 +833,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
     listToolsMock.mockReset();
     listToolsMock.mockResolvedValue(makeDemoMcpTools());
 
-    await generateAssistantReply(
-      makeReplyRequest(
+    await executeAgentRun(
+      makeAgentRunRequest(
         "help me",
         {
           conversationId: "conversation-restored-provider",
@@ -890,8 +885,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
       },
     ] as unknown as PiMessage[];
 
-    const firstError = await generateAssistantReply(
-      makeReplyRequest(
+    const firstError = await executeAgentRun(
+      makeAgentRunRequest(
         "current follow-up",
         {
           conversationId: "conversation-restore-auth",
@@ -929,8 +924,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
     );
 
     const reply = finalReply(
-      await generateAssistantReply(
-        makeReplyRequest(
+      await executeAgentRun(
+        makeAgentRunRequest(
           "current follow-up",
           {
             conversationId: "conversation-restore-auth",
@@ -981,8 +976,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
       },
     ] as PiMessage[];
 
-    await generateAssistantReply(
-      makeReplyRequest(
+    await executeAgentRun(
+      makeAgentRunRequest(
         "help me",
         {
           conversationId: "conversation-history",
@@ -1044,8 +1039,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
       errorMessage: "authorization required",
     });
 
-    await generateAssistantReply(
-      makeReplyRequest("continue after auth", {
+    await executeAgentRun(
+      makeAgentRunRequest("continue after auth", {
         conversationId: "conversation-raw-current-resume",
         threadTs: "1712345.0092",
         turnId: "turn-raw-current-resume",
@@ -1094,8 +1089,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
       errorMessage: "authorization required",
     });
 
-    await generateAssistantReply(
-      makeReplyRequest(messageText, {
+    await executeAgentRun(
+      makeAgentRunRequest(messageText, {
         conversationId: "conversation-unescaped-current-resume",
         threadTs: "1712345.0093",
         turnId: "turn-unescaped-current-resume",
@@ -1139,8 +1134,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
       piMessages: storedRunningMessages,
     });
 
-    await generateAssistantReply(
-      makeReplyRequest(
+    await executeAgentRun(
+      makeAgentRunRequest(
         "continue after crash",
         {
           conversationId: "conversation-crash-retry",
@@ -1181,8 +1176,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
       },
     ] as PiMessage[];
 
-    await generateAssistantReply(
-      makeReplyRequest(
+    await executeAgentRun(
+      makeAgentRunRequest(
         "help me",
         {
           conversationId: "conversation-history-with-context",
@@ -1228,13 +1223,13 @@ describe("generateAssistantReply progressive MCP loading", () => {
       );
     });
 
-    const context = makeReplyRequest("help me", {
+    const context = makeAgentRunRequest("help me", {
       conversationId: "conversation-4",
       threadTs: "1712345.0004",
       turnId: "turn-4",
     });
 
-    const firstError = await generateAssistantReply(context);
+    const firstError = await executeAgentRun(context);
 
     expect(firstError.status).toBe("awaiting_auth");
     expect(deliverPrivateMessageMock).toHaveBeenCalledTimes(1);
@@ -1248,7 +1243,7 @@ describe("generateAssistantReply progressive MCP loading", () => {
       resumeReason: "auth",
     });
 
-    const reply = finalReply(await generateAssistantReply(context));
+    const reply = finalReply(await executeAgentRun(context));
 
     expect(reply.text).toBe("resumed reply");
 
@@ -1271,8 +1266,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
     listToolsMock.mockResolvedValue([makeDemoMcpTool("ping")]);
 
     const reply = finalReply(
-      await generateAssistantReply(
-        makeReplyRequest("help me", {
+      await executeAgentRun(
+        makeAgentRunRequest("help me", {
           conversationId: "conversation-5",
           threadTs: "1712345.0005",
           turnId: "turn-5",
@@ -1298,8 +1293,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
       });
 
     const reply = finalReply(
-      await generateAssistantReply(
-        makeReplyRequest("help me", {
+      await executeAgentRun(
+        makeAgentRunRequest("help me", {
           conversationId: "conversation-3",
           threadTs: "1712345.0003",
           turnId: "turn-3",
@@ -1376,8 +1371,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
       );
     });
 
-    const firstError = await generateAssistantReply(
-      makeReplyRequest("help me", {
+    const firstError = await executeAgentRun(
+      makeAgentRunRequest("help me", {
         conversationId: "conversation-5",
         threadTs: "1712345.0005",
         turnId: "turn-5",
@@ -1402,8 +1397,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
   it("still parks for auth when abort leaves an empty completed assistant frame", async () => {
     completeEmptyAssistantOnAbort.value = true;
 
-    const firstError = await generateAssistantReply(
-      makeReplyRequest("help me", {
+    const firstError = await executeAgentRun(
+      makeAgentRunRequest("help me", {
         conversationId: "conversation-6",
         threadTs: "1712345.0006",
         turnId: "turn-6",

--- a/packages/junior/tests/unit/runtime/agent-run-provider-retry.test.ts
+++ b/packages/junior/tests/unit/runtime/agent-run-provider-retry.test.ts
@@ -321,7 +321,7 @@ vi.mock("@/chat/skills", async (importOriginal) => ({
   parseSkillInvocation: () => null,
 }));
 
-import { generateAssistantReply } from "@/chat/respond";
+import { executeAgentRun } from "@/chat/agent-run";
 import { getConversationStore } from "@/chat/db";
 import { getAwaitingAgentContinueRequest } from "@/chat/services/agent-continue";
 import { persistCompletedSessionRecord } from "@/chat/services/turn-session-record";
@@ -329,13 +329,11 @@ import { disconnectStateAdapter } from "@/chat/state/adapter";
 import * as turnSessionState from "@/chat/state/turn-session";
 import { createJuniorReporting } from "@/reporting";
 
-function finalReply(
-  outcome: Awaited<ReturnType<typeof generateAssistantReply>>,
-) {
+function finalReply(outcome: Awaited<ReturnType<typeof executeAgentRun>>) {
   if (outcome.status !== "completed" && outcome.status !== "failed") {
     throw new Error(`Expected final reply, got ${outcome.status}`);
   }
-  return outcome.reply;
+  return outcome.result;
 }
 
 const TEST_DESTINATION = {
@@ -350,7 +348,7 @@ const TEST_SOURCE = createSlackSource({
   type: "priv",
 });
 
-describe("generateAssistantReply provider retry", () => {
+describe("executeAgentRun provider retry", () => {
   beforeEach(async () => {
     agentMode.value = "providerRetry";
     counters.continueCalls = 0;
@@ -370,7 +368,7 @@ describe("generateAssistantReply provider retry", () => {
   });
 
   it("continues from the last safe boundary after a transient provider stream error", async () => {
-    const replyPromise = generateAssistantReply({
+    const replyPromise = executeAgentRun({
       input: { messageText: "help me" },
       routing: {
         destination: TEST_DESTINATION,
@@ -461,7 +459,7 @@ describe("generateAssistantReply provider retry", () => {
     });
 
     const reply = finalReply(
-      await generateAssistantReply({
+      await executeAgentRun({
         input: { messageText: "help me", piMessages: priorMessages },
         routing: {
           destination: TEST_DESTINATION,
@@ -536,7 +534,7 @@ describe("generateAssistantReply provider retry", () => {
   it("parks the turn when the worker asks to yield at a Pi boundary", async () => {
     agentMode.value = "cooperativeYield";
 
-    const outcome = await generateAssistantReply({
+    const outcome = await executeAgentRun({
       input: { messageText: "help me" },
       routing: {
         destination: TEST_DESTINATION,
@@ -590,7 +588,7 @@ describe("generateAssistantReply provider retry", () => {
   it("keeps steered messages when yielding after steering drain", async () => {
     agentMode.value = "cooperativeYield";
 
-    const outcome = await generateAssistantReply({
+    const outcome = await executeAgentRun({
       input: { messageText: "help me" },
       routing: {
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
@@ -649,7 +647,7 @@ describe("generateAssistantReply provider retry", () => {
       .spyOn(turnSessionState, "upsertAgentTurnSessionRecord")
       .mockRejectedValue(new Error("storage unavailable"));
 
-    const error = await generateAssistantReply({
+    const error = await executeAgentRun({
       input: { messageText: "help me" },
       routing: {
         destination: TEST_DESTINATION,
@@ -686,7 +684,7 @@ describe("generateAssistantReply provider retry", () => {
     sessionLogState.failToolExecutionAppend = true;
 
     const reply = finalReply(
-      await generateAssistantReply({
+      await executeAgentRun({
         input: { messageText: "run the tool" },
         routing: {
           destination: TEST_DESTINATION,
@@ -728,7 +726,7 @@ describe("generateAssistantReply provider retry", () => {
     });
 
     const reply = finalReply(
-      await generateAssistantReply({
+      await executeAgentRun({
         input: { messageText: "help me", piMessages: [checkpointedPrompt] },
         routing: {
           destination: TEST_DESTINATION,
@@ -763,7 +761,7 @@ describe("generateAssistantReply provider retry", () => {
     let injectRejected = false;
     let injectCompleted = false;
 
-    await generateAssistantReply({
+    await executeAgentRun({
       input: { messageText: "help me" },
       routing: {
         destination: TEST_DESTINATION,

--- a/packages/junior/tests/unit/runtime/respond-agent-continue.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-agent-continue.test.ts
@@ -249,10 +249,7 @@ vi.mock("@/chat/skills", async (importOriginal) => ({
 }));
 
 import { generateAssistantReply } from "@/chat/respond";
-import {
-  isRetryableTurnError,
-  isTurnInputCommitLostError,
-} from "@/chat/runtime/turn";
+import { isTurnInputCommitLostError } from "@/chat/runtime/turn";
 import { AGENT_CONTINUE_MAX_SLICES } from "@/chat/services/turn-session-record";
 import { getConversationStore } from "@/chat/db";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
@@ -311,7 +308,7 @@ describe("generateAssistantReply agent continuation", () => {
     expect(onInputCommitted).not.toHaveBeenCalled();
   });
 
-  it("stores the last safe boundary and throws a retryable timeout error", async () => {
+  it("stores the last safe boundary and returns a timed-out outcome", async () => {
     const replyPromise = generateAssistantReply("help me", {
       destination: TEST_DESTINATION,
       source: TEST_SOURCE,
@@ -322,14 +319,14 @@ describe("generateAssistantReply agent continuation", () => {
         channelId: "C123",
         threadTs: "1712345.0001",
       },
-    }).catch((caught) => caught);
+    });
 
     await vi.advanceTimersByTimeAsync(10_000);
-    const error = await replyPromise;
+    const outcome = await replyPromise;
 
     expect(promptAborted.value).toBe(true);
-    expect(isRetryableTurnError(error, "agent_continue")).toBe(true);
-    expect(error.metadata).toMatchObject({
+    expect(outcome).toMatchObject({
+      status: "timed_out",
       conversationId: "conversation-1",
       sessionId: "turn-1",
       version: expect.any(Number),
@@ -388,7 +385,6 @@ describe("generateAssistantReply agent continuation", () => {
 
     expect(error).toBeInstanceOf(Error);
     expect(error).not.toHaveProperty("text");
-    expect(isRetryableTurnError(error, "agent_continue")).toBe(false);
     expect(error.message).toContain("slice limit");
 
     const sessionRecord = await getAgentTurnSessionRecord(
@@ -416,13 +412,13 @@ describe("generateAssistantReply agent continuation", () => {
         channelId: "C123",
         threadTs: "1712345.0005",
       },
-    }).catch((caught) => caught);
+    });
 
     await vi.advanceTimersByTimeAsync(2_500);
-    const error = await replyPromise;
+    const outcome = await replyPromise;
 
     expect(promptAborted.value).toBe(true);
-    expect(isRetryableTurnError(error, "agent_continue")).toBe(true);
+    expect(outcome.status).toBe("timed_out");
     const sessionRecord = await getAgentTurnSessionRecord(
       "conversation-short-deadline",
       "turn-short-deadline",
@@ -483,16 +479,16 @@ describe("generateAssistantReply agent continuation", () => {
         channelId: "C123",
         threadTs: "1712345.0003",
       },
-    }).catch((caught) => caught);
+    });
 
     await waitForPromptCall(1);
     await realSleep(10);
     await vi.advanceTimersByTimeAsync(15_000);
-    const error = await replyPromise;
+    const outcome = await replyPromise;
 
     expect(promptAborted.value).toBe(true);
-    expect(isRetryableTurnError(error, "agent_continue")).toBe(true);
-    expect(error.metadata).toMatchObject({
+    expect(outcome).toMatchObject({
+      status: "timed_out",
       conversationId: "conversation-hung",
       sessionId: "turn-hung",
       version: expect.any(Number),
@@ -528,17 +524,17 @@ describe("generateAssistantReply agent continuation", () => {
         channelId: "C123",
         threadTs: "1712345.0004",
       },
-    }).catch((caught) => caught);
+    });
 
     await waitForPromptCall(1);
     await vi.advanceTimersByTimeAsync(8_000);
     await waitForProviderPromptSettlement();
     await advanceUntilContinueCall(5_000);
     await vi.advanceTimersByTimeAsync(1);
-    const error = await replyPromise;
+    const outcome = await replyPromise;
 
     expect(promptAborted.value).toBe(true);
-    expect(isRetryableTurnError(error, "agent_continue")).toBe(true);
+    expect(outcome.status).toBe("timed_out");
     const sessionRecord = await getAgentTurnSessionRecord(
       "conversation-retry",
       "turn-retry",

--- a/packages/junior/tests/unit/runtime/respond-agent-continue.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-agent-continue.test.ts
@@ -298,10 +298,10 @@ describe("generateAssistantReply agent continuation", () => {
   it("rejects durable input when no prompt checkpoint can be persisted", async () => {
     const onInputCommitted = vi.fn();
 
-    const error = await generateAssistantReply("help me", {
-      destination: TEST_DESTINATION,
-      source: TEST_SOURCE,
-      onInputCommitted,
+    const error = await generateAssistantReply({
+      input: { messageText: "help me" },
+      routing: { destination: TEST_DESTINATION, source: TEST_SOURCE },
+      durability: { onInputCommitted },
     }).catch((caught) => caught);
 
     expect(isTurnInputCommitLostError(error)).toBe(true);
@@ -309,15 +309,18 @@ describe("generateAssistantReply agent continuation", () => {
   });
 
   it("stores the last safe boundary and returns a timed-out outcome", async () => {
-    const replyPromise = generateAssistantReply("help me", {
-      destination: TEST_DESTINATION,
-      source: TEST_SOURCE,
-      requester: TEST_REQUESTER,
-      correlation: {
-        conversationId: "conversation-1",
-        turnId: "turn-1",
-        channelId: "C123",
-        threadTs: "1712345.0001",
+    const replyPromise = generateAssistantReply({
+      input: { messageText: "help me" },
+      routing: {
+        destination: TEST_DESTINATION,
+        source: TEST_SOURCE,
+        requester: TEST_REQUESTER,
+        correlation: {
+          conversationId: "conversation-1",
+          turnId: "turn-1",
+          channelId: "C123",
+          threadTs: "1712345.0001",
+        },
       },
     });
 
@@ -368,15 +371,18 @@ describe("generateAssistantReply agent continuation", () => {
       resumeReason: "timeout",
     });
 
-    const replyPromise = generateAssistantReply("help me", {
-      destination: TEST_DESTINATION,
-      source: TEST_SOURCE,
-      requester: TEST_REQUESTER,
-      correlation: {
-        conversationId: "conversation-timeout-cap",
-        turnId: "turn-timeout-cap",
-        channelId: "C123",
-        threadTs: "1712345.0006",
+    const replyPromise = generateAssistantReply({
+      input: { messageText: "help me" },
+      routing: {
+        destination: TEST_DESTINATION,
+        source: TEST_SOURCE,
+        requester: TEST_REQUESTER,
+        correlation: {
+          conversationId: "conversation-timeout-cap",
+          turnId: "turn-timeout-cap",
+          channelId: "C123",
+          threadTs: "1712345.0006",
+        },
       },
     }).catch((caught) => caught);
 
@@ -401,17 +407,20 @@ describe("generateAssistantReply agent continuation", () => {
 
   it("records the effective request deadline timeout budget", async () => {
     const startedAtMs = Date.now();
-    const replyPromise = generateAssistantReply("help me", {
-      destination: TEST_DESTINATION,
-      source: TEST_SOURCE,
-      requester: TEST_REQUESTER,
-      turnDeadlineAtMs: startedAtMs + 2_500,
-      correlation: {
-        conversationId: "conversation-short-deadline",
-        turnId: "turn-short-deadline",
-        channelId: "C123",
-        threadTs: "1712345.0005",
+    const replyPromise = generateAssistantReply({
+      input: { messageText: "help me" },
+      routing: {
+        destination: TEST_DESTINATION,
+        source: TEST_SOURCE,
+        requester: TEST_REQUESTER,
+        correlation: {
+          conversationId: "conversation-short-deadline",
+          turnId: "turn-short-deadline",
+          channelId: "C123",
+          threadTs: "1712345.0005",
+        },
       },
+      policy: { turnDeadlineAtMs: startedAtMs + 2_500 },
     });
 
     await vi.advanceTimersByTimeAsync(2_500);
@@ -429,16 +438,21 @@ describe("generateAssistantReply agent continuation", () => {
   });
 
   it("persists omitted-image context in the session-recorded Pi user message", async () => {
-    const replyPromise = generateAssistantReply("what is in this image?", {
-      destination: TEST_DESTINATION,
-      source: TEST_SOURCE,
-      requester: TEST_REQUESTER,
-      omittedImageAttachmentCount: 1,
-      correlation: {
-        conversationId: "conversation-2",
-        turnId: "turn-2",
-        channelId: "C123",
-        threadTs: "1712345.0002",
+    const replyPromise = generateAssistantReply({
+      input: {
+        messageText: "what is in this image?",
+        omittedImageAttachmentCount: 1,
+      },
+      routing: {
+        destination: TEST_DESTINATION,
+        source: TEST_SOURCE,
+        requester: TEST_REQUESTER,
+        correlation: {
+          conversationId: "conversation-2",
+          turnId: "turn-2",
+          channelId: "C123",
+          threadTs: "1712345.0002",
+        },
       },
     }).catch((caught) => caught);
 
@@ -469,15 +483,18 @@ describe("generateAssistantReply agent continuation", () => {
 
   it("persists agent continuation state when abort does not settle the agent run", async () => {
     promptMode.value = "hangsAfterAbort";
-    const replyPromise = generateAssistantReply("help me", {
-      destination: TEST_DESTINATION,
-      source: TEST_SOURCE,
-      requester: TEST_REQUESTER,
-      correlation: {
-        conversationId: "conversation-hung",
-        turnId: "turn-hung",
-        channelId: "C123",
-        threadTs: "1712345.0003",
+    const replyPromise = generateAssistantReply({
+      input: { messageText: "help me" },
+      routing: {
+        destination: TEST_DESTINATION,
+        source: TEST_SOURCE,
+        requester: TEST_REQUESTER,
+        correlation: {
+          conversationId: "conversation-hung",
+          turnId: "turn-hung",
+          channelId: "C123",
+          threadTs: "1712345.0003",
+        },
       },
     });
 
@@ -514,15 +531,18 @@ describe("generateAssistantReply agent continuation", () => {
 
   it("uses one wall-clock timeout budget across provider retries", async () => {
     promptMode.value = "providerRetryThenHangs";
-    const replyPromise = generateAssistantReply("help me", {
-      destination: TEST_DESTINATION,
-      source: TEST_SOURCE,
-      requester: TEST_REQUESTER,
-      correlation: {
-        conversationId: "conversation-retry",
-        turnId: "turn-retry",
-        channelId: "C123",
-        threadTs: "1712345.0004",
+    const replyPromise = generateAssistantReply({
+      input: { messageText: "help me" },
+      routing: {
+        destination: TEST_DESTINATION,
+        source: TEST_SOURCE,
+        requester: TEST_REQUESTER,
+        correlation: {
+          conversationId: "conversation-retry",
+          turnId: "turn-retry",
+          channelId: "C123",
+          threadTs: "1712345.0004",
+        },
       },
     });
 

--- a/packages/junior/tests/unit/runtime/respond-lazy-sandbox.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-lazy-sandbox.test.ts
@@ -529,15 +529,19 @@ const LOCAL_DESTINATION = {
 };
 const LOCAL_SOURCE = createLocalSource(LOCAL_DESTINATION.conversationId);
 
-function generateLocalReply(
+async function generateLocalReply(
   message: string,
   context: Omit<ReplyRequestContext, "destination" | "source"> = {},
 ) {
-  return generateAssistantReply(message, {
+  const outcome = await generateAssistantReply(message, {
     ...context,
     destination: LOCAL_DESTINATION,
     source: LOCAL_SOURCE,
   });
+  if (outcome.status !== "completed" && outcome.status !== "failed") {
+    throw new Error(`Expected final reply, got ${outcome.status}`);
+  }
+  return outcome.reply;
 }
 
 describe("generateAssistantReply lazy sandbox boot", () => {

--- a/packages/junior/tests/unit/runtime/respond-lazy-sandbox.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-lazy-sandbox.test.ts
@@ -531,12 +531,20 @@ const LOCAL_SOURCE = createLocalSource(LOCAL_DESTINATION.conversationId);
 
 async function generateLocalReply(
   message: string,
-  context: Omit<ReplyRequestContext, "destination" | "source"> = {},
+  context: Partial<Omit<ReplyRequestContext, "input" | "routing">> & {
+    input?: Partial<Omit<ReplyRequestContext["input"], "messageText">>;
+  } = {},
 ) {
-  const outcome = await generateAssistantReply(message, {
+  const outcome = await generateAssistantReply({
     ...context,
-    destination: LOCAL_DESTINATION,
-    source: LOCAL_SOURCE,
+    input: {
+      messageText: message,
+      ...(context.input ?? {}),
+    },
+    routing: {
+      destination: LOCAL_DESTINATION,
+      source: LOCAL_SOURCE,
+    },
   });
   if (outcome.status !== "completed" && outcome.status !== "failed") {
     throw new Error(`Expected final reply, got ${outcome.status}`);
@@ -617,13 +625,15 @@ describe("generateAssistantReply lazy sandbox boot", () => {
 
   it("uses attachment text when routing the turn thinking level", async () => {
     const reply = await generateLocalReply("can you fix this?", {
-      userAttachments: [
-        {
-          data: Buffer.from("TypeError: x is undefined\nat respond.ts:42"),
-          filename: "error.txt",
-          mediaType: "text/plain",
-        },
-      ],
+      input: {
+        userAttachments: [
+          {
+            data: Buffer.from("TypeError: x is undefined\nat respond.ts:42"),
+            filename: "error.txt",
+            mediaType: "text/plain",
+          },
+        ],
+      },
     });
 
     expect(reply.text).toBe("Plain reply.");
@@ -632,13 +642,15 @@ describe("generateAssistantReply lazy sandbox boot", () => {
 
   it("uses structured-suffix attachment text when the media type has parameters", async () => {
     const reply = await generateLocalReply("can you fix this?", {
-      userAttachments: [
-        {
-          data: Buffer.from("TypeError: x is undefined\nat respond.ts:42"),
-          filename: "error.json",
-          mediaType: "application/vnd.api+json; charset=utf-8",
-        },
-      ],
+      input: {
+        userAttachments: [
+          {
+            data: Buffer.from("TypeError: x is undefined\nat respond.ts:42"),
+            filename: "error.json",
+            mediaType: "application/vnd.api+json; charset=utf-8",
+          },
+        ],
+      },
     });
 
     expect(reply.text).toBe("Plain reply.");
@@ -663,7 +675,9 @@ describe("generateAssistantReply lazy sandbox boot", () => {
     const onSandboxAcquired = vi.fn();
 
     const reply = await generateLocalReply("attach the report", {
-      onSandboxAcquired,
+      durability: {
+        onSandboxAcquired,
+      },
     });
 
     // Raw exception text stays in diagnostics; it is never reply text.

--- a/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
@@ -97,41 +97,6 @@ const TEST_REQUESTER = {
   userId: "U123",
 } as const;
 
-function makeReplyContext(args: {
-  conversationId: string;
-  threadTs: string;
-  turnId: string;
-}) {
-  const destination = {
-    platform: "slack" as const,
-    teamId: "T123",
-    channelId: "C123",
-  };
-  return {
-    credentialContext: {
-      actor: { type: "user" as const, userId: "U123" },
-    },
-    destination,
-    source: createSlackSource({
-      teamId: destination.teamId,
-      channelId: destination.channelId,
-      threadTs: args.threadTs,
-
-      type: "priv",
-    }),
-    requester: TEST_REQUESTER,
-    recordPendingAuth: async (pendingAuth: ConversationPendingAuthState) => {
-      pendingAuthRecords.push(pendingAuth);
-    },
-    correlation: {
-      channelId: "C123",
-      conversationId: args.conversationId,
-      threadTs: args.threadTs,
-      turnId: args.turnId,
-    },
-  };
-}
-
 vi.mock("@earendil-works/pi-agent-core", () => {
   class MockAgent {
     state: {
@@ -594,7 +559,10 @@ vi.mock("@/chat/mcp/client", () => {
   };
 });
 
-import { generateAssistantReply } from "@/chat/respond";
+import {
+  generateAssistantReply,
+  type ReplyRequestContext,
+} from "@/chat/respond";
 import {
   getAgentTurnSessionRecord,
   upsertAgentTurnSessionRecord,
@@ -608,6 +576,65 @@ function finalReply(
     throw new Error(`Expected final reply, got ${outcome.status}`);
   }
   return outcome.reply;
+}
+
+function makeReplyRequest(
+  messageText: string,
+  args: {
+    conversationId: string;
+    threadTs: string;
+    turnId: string;
+  },
+  overrides: {
+    input?: Partial<Omit<ReplyRequestContext["input"], "messageText">>;
+    routing?: Partial<ReplyRequestContext["routing"]>;
+    policy?: ReplyRequestContext["policy"];
+    state?: ReplyRequestContext["state"];
+    observers?: ReplyRequestContext["observers"];
+    durability?: ReplyRequestContext["durability"];
+  } = {},
+): ReplyRequestContext {
+  const destination = {
+    platform: "slack" as const,
+    teamId: "T123",
+    channelId: "C123",
+  };
+  return {
+    input: {
+      messageText,
+      ...(overrides.input ?? {}),
+    },
+    routing: {
+      credentialContext: {
+        actor: { type: "user" as const, userId: "U123" },
+      },
+      destination,
+      source: createSlackSource({
+        teamId: destination.teamId,
+        channelId: destination.channelId,
+        threadTs: args.threadTs,
+
+        type: "priv",
+      }),
+      requester: TEST_REQUESTER,
+      correlation: {
+        channelId: "C123",
+        conversationId: args.conversationId,
+        threadTs: args.threadTs,
+        turnId: args.turnId,
+      },
+      ...(overrides.routing ?? {}),
+    },
+    ...(overrides.policy ? { policy: overrides.policy } : {}),
+    ...(overrides.state ? { state: overrides.state } : {}),
+    ...(overrides.observers ? { observers: overrides.observers } : {}),
+    durability: {
+      recordPendingAuth: async (pendingAuth: ConversationPendingAuthState) => {
+        pendingAuthRecords.push(pendingAuth);
+      },
+      ...(overrides.durability ?? {}),
+    },
+  };
 }
 
 // This suite validates local progressive-loading logic through a mocked
@@ -685,13 +712,13 @@ describe("generateAssistantReply progressive MCP loading", () => {
   });
 
   it("persists loaded plugin skills across auth pause and resume", async () => {
-    const context = makeReplyContext({
+    const context = makeReplyRequest("help me", {
       conversationId: "conversation-1",
       threadTs: "1712345.0001",
       turnId: "turn-1",
     });
 
-    const firstError = await generateAssistantReply("help me", context);
+    const firstError = await generateAssistantReply(context);
 
     expect(firstError.status).toBe("awaiting_auth");
     expect(agentInitialToolNames[0]).toContain("loadSkill");
@@ -723,7 +750,7 @@ describe("generateAssistantReply progressive MCP loading", () => {
     ]);
     expect(loadSkillExecutionErrorCount.value).toBe(0);
 
-    const reply = finalReply(await generateAssistantReply("help me", context));
+    const reply = finalReply(await generateAssistantReply(context));
 
     expect(reply.text).toBe("resumed reply");
     expect(promptCallCount.value).toBe(1);
@@ -769,8 +796,7 @@ describe("generateAssistantReply progressive MCP loading", () => {
 
     const reply = finalReply(
       await generateAssistantReply(
-        "help me",
-        makeReplyContext({
+        makeReplyRequest("help me", {
           conversationId: "conversation-2",
           threadTs: "1712345.0002",
           turnId: "turn-2",
@@ -812,25 +838,32 @@ describe("generateAssistantReply progressive MCP loading", () => {
     listToolsMock.mockReset();
     listToolsMock.mockResolvedValue(makeDemoMcpTools());
 
-    await generateAssistantReply("help me", {
-      ...makeReplyContext({
-        conversationId: "conversation-restored-provider",
-        threadTs: "1712345.0090",
-        turnId: "turn-restored-provider",
-      }),
-      piMessages: [
+    await generateAssistantReply(
+      makeReplyRequest(
+        "help me",
         {
-          role: "toolResult",
-          toolName: "callMcpTool",
-          isError: false,
-          content: [{ type: "text", text: "pong" }],
+          conversationId: "conversation-restored-provider",
+          threadTs: "1712345.0090",
+          turnId: "turn-restored-provider",
+        },
+        {
           input: {
-            tool_name: "mcp__demo__ping",
-            arguments: { query: "prior" },
+            piMessages: [
+              {
+                role: "toolResult",
+                toolName: "callMcpTool",
+                isError: false,
+                content: [{ type: "text", text: "pong" }],
+                input: {
+                  tool_name: "mcp__demo__ping",
+                  arguments: { query: "prior" },
+                },
+              },
+            ] as unknown as PiMessage[],
           },
         },
-      ] as unknown as PiMessage[],
-    });
+      ),
+    );
 
     expect(turnContextInputs[0]?.activeMcpCatalogs).toEqual([
       { provider: "demo", available_tool_count: 1 },
@@ -857,14 +890,19 @@ describe("generateAssistantReply progressive MCP loading", () => {
       },
     ] as unknown as PiMessage[];
 
-    const firstError = await generateAssistantReply("current follow-up", {
-      ...makeReplyContext({
-        conversationId: "conversation-restore-auth",
-        threadTs: "1712345.0091",
-        turnId: "turn-restore-auth",
-      }),
-      piMessages: priorMessages,
-    }).catch((error) => error);
+    const firstError = await generateAssistantReply(
+      makeReplyRequest(
+        "current follow-up",
+        {
+          conversationId: "conversation-restore-auth",
+          threadTs: "1712345.0091",
+          turnId: "turn-restore-auth",
+        },
+        {
+          input: { piMessages: priorMessages },
+        },
+      ),
+    ).catch((error) => error);
 
     expect(firstError.status).toBe("awaiting_auth");
 
@@ -891,14 +929,19 @@ describe("generateAssistantReply progressive MCP loading", () => {
     );
 
     const reply = finalReply(
-      await generateAssistantReply("current follow-up", {
-        ...makeReplyContext({
-          conversationId: "conversation-restore-auth",
-          threadTs: "1712345.0091",
-          turnId: "turn-restore-auth",
-        }),
-        piMessages: priorMessages,
-      }),
+      await generateAssistantReply(
+        makeReplyRequest(
+          "current follow-up",
+          {
+            conversationId: "conversation-restore-auth",
+            threadTs: "1712345.0091",
+            turnId: "turn-restore-auth",
+          },
+          {
+            input: { piMessages: priorMessages },
+          },
+        ),
+      ),
     );
 
     expect(reply.text).toBe("resumed reply");
@@ -938,15 +981,22 @@ describe("generateAssistantReply progressive MCP loading", () => {
       },
     ] as PiMessage[];
 
-    await generateAssistantReply("help me", {
-      ...makeReplyContext({
-        conversationId: "conversation-history",
-        threadTs: "1712345.0003",
-        turnId: "turn-history",
-      }),
-      conversationContext: "duplicated prior transcript",
-      piMessages: priorMessages,
-    });
+    await generateAssistantReply(
+      makeReplyRequest(
+        "help me",
+        {
+          conversationId: "conversation-history",
+          threadTs: "1712345.0003",
+          turnId: "turn-history",
+        },
+        {
+          input: {
+            conversationContext: "duplicated prior transcript",
+            piMessages: priorMessages,
+          },
+        },
+      ),
+    );
 
     expect(promptSeedMessages[0]).toEqual(priorMessages);
     expect(JSON.stringify(promptMessages[0])).not.toContain(
@@ -994,13 +1044,13 @@ describe("generateAssistantReply progressive MCP loading", () => {
       errorMessage: "authorization required",
     });
 
-    await generateAssistantReply("continue after auth", {
-      ...makeReplyContext({
+    await generateAssistantReply(
+      makeReplyRequest("continue after auth", {
         conversationId: "conversation-raw-current-resume",
         threadTs: "1712345.0092",
         turnId: "turn-raw-current-resume",
       }),
-    });
+    );
 
     expect(promptSeedMessages.at(-1)).toEqual([storedMessages[0]]);
     expect(JSON.stringify(promptMessages.at(-1))).toContain(
@@ -1044,13 +1094,13 @@ describe("generateAssistantReply progressive MCP loading", () => {
       errorMessage: "authorization required",
     });
 
-    await generateAssistantReply(messageText, {
-      ...makeReplyContext({
+    await generateAssistantReply(
+      makeReplyRequest(messageText, {
         conversationId: "conversation-unescaped-current-resume",
         threadTs: "1712345.0093",
         turnId: "turn-unescaped-current-resume",
       }),
-    });
+    );
 
     expect(promptSeedMessages.at(-1)).toEqual([storedMessages[0]]);
     expect(JSON.stringify(promptMessages.at(-1))).toContain(
@@ -1089,14 +1139,19 @@ describe("generateAssistantReply progressive MCP loading", () => {
       piMessages: storedRunningMessages,
     });
 
-    await generateAssistantReply("continue after crash", {
-      ...makeReplyContext({
-        conversationId: "conversation-crash-retry",
-        threadTs: "1712345.00032",
-        turnId: "turn-crash-retry",
-      }),
-      piMessages: strippedHistory,
-    });
+    await generateAssistantReply(
+      makeReplyRequest(
+        "continue after crash",
+        {
+          conversationId: "conversation-crash-retry",
+          threadTs: "1712345.00032",
+          turnId: "turn-crash-retry",
+        },
+        {
+          input: { piMessages: strippedHistory },
+        },
+      ),
+    );
 
     expect(promptSeedMessages[0]).toEqual(strippedHistory);
     expect(turnContextInputs.at(-1)?.includeSessionContext).toBe(true);
@@ -1126,14 +1181,19 @@ describe("generateAssistantReply progressive MCP loading", () => {
       },
     ] as PiMessage[];
 
-    await generateAssistantReply("help me", {
-      ...makeReplyContext({
-        conversationId: "conversation-history-with-context",
-        threadTs: "1712345.00031",
-        turnId: "turn-history-with-context",
-      }),
-      piMessages: priorMessages,
-    });
+    await generateAssistantReply(
+      makeReplyRequest(
+        "help me",
+        {
+          conversationId: "conversation-history-with-context",
+          threadTs: "1712345.00031",
+          turnId: "turn-history-with-context",
+        },
+        {
+          input: { piMessages: priorMessages },
+        },
+      ),
+    );
 
     expect(promptSeedMessages[0]).toEqual(priorMessages);
     expect(turnContextInputs).toHaveLength(0);
@@ -1168,13 +1228,13 @@ describe("generateAssistantReply progressive MCP loading", () => {
       );
     });
 
-    const context = makeReplyContext({
+    const context = makeReplyRequest("help me", {
       conversationId: "conversation-4",
       threadTs: "1712345.0004",
       turnId: "turn-4",
     });
 
-    const firstError = await generateAssistantReply("help me", context);
+    const firstError = await generateAssistantReply(context);
 
     expect(firstError.status).toBe("awaiting_auth");
     expect(deliverPrivateMessageMock).toHaveBeenCalledTimes(1);
@@ -1188,7 +1248,7 @@ describe("generateAssistantReply progressive MCP loading", () => {
       resumeReason: "auth",
     });
 
-    const reply = finalReply(await generateAssistantReply("help me", context));
+    const reply = finalReply(await generateAssistantReply(context));
 
     expect(reply.text).toBe("resumed reply");
 
@@ -1212,8 +1272,7 @@ describe("generateAssistantReply progressive MCP loading", () => {
 
     const reply = finalReply(
       await generateAssistantReply(
-        "help me",
-        makeReplyContext({
+        makeReplyRequest("help me", {
           conversationId: "conversation-5",
           threadTs: "1712345.0005",
           turnId: "turn-5",
@@ -1238,35 +1297,15 @@ describe("generateAssistantReply progressive MCP loading", () => {
         return await originalUpsert(args);
       });
 
-    const context = {
-      credentialContext: {
-        actor: { type: "user" as const, userId: "U123" },
-      },
-      destination: {
-        platform: "slack" as const,
-        teamId: "T123",
-        channelId: "C123",
-      },
-      source: createSlackSource({
-        teamId: "T123",
-        channelId: "C123",
-        threadTs: "1712345.0003",
-
-        type: "priv",
-      }),
-      requester: TEST_REQUESTER,
-      recordPendingAuth: async (pendingAuth: ConversationPendingAuthState) => {
-        pendingAuthRecords.push(pendingAuth);
-      },
-      correlation: {
-        conversationId: "conversation-3",
-        turnId: "turn-3",
-        channelId: "C123",
-        threadTs: "1712345.0003",
-      },
-    };
-
-    const reply = finalReply(await generateAssistantReply("help me", context));
+    const reply = finalReply(
+      await generateAssistantReply(
+        makeReplyRequest("help me", {
+          conversationId: "conversation-3",
+          threadTs: "1712345.0003",
+          turnId: "turn-3",
+        }),
+      ),
+    );
 
     expect(reply.diagnostics.outcome).toBe("provider_error");
     expect(sessionRecordSpy).toHaveBeenCalled();
@@ -1337,33 +1376,13 @@ describe("generateAssistantReply progressive MCP loading", () => {
       );
     });
 
-    const firstError = await generateAssistantReply("help me", {
-      credentialContext: {
-        actor: { type: "user", userId: "U123" },
-      },
-      destination: {
-        platform: "slack",
-        teamId: "T123",
-        channelId: "C123",
-      },
-      source: createSlackSource({
-        teamId: "T123",
-        channelId: "C123",
-        threadTs: "1712345.0005",
-
-        type: "priv",
-      }),
-      requester: TEST_REQUESTER,
-      recordPendingAuth: async (pendingAuth: ConversationPendingAuthState) => {
-        pendingAuthRecords.push(pendingAuth);
-      },
-      correlation: {
+    const firstError = await generateAssistantReply(
+      makeReplyRequest("help me", {
         conversationId: "conversation-5",
-        turnId: "turn-5",
-        channelId: "C123",
         threadTs: "1712345.0005",
-      },
-    }).catch((error) => error);
+        turnId: "turn-5",
+      }),
+    ).catch((error) => error);
 
     expect(firstError.status).toBe("awaiting_auth");
 
@@ -1383,33 +1402,13 @@ describe("generateAssistantReply progressive MCP loading", () => {
   it("still parks for auth when abort leaves an empty completed assistant frame", async () => {
     completeEmptyAssistantOnAbort.value = true;
 
-    const firstError = await generateAssistantReply("help me", {
-      credentialContext: {
-        actor: { type: "user", userId: "U123" },
-      },
-      destination: {
-        platform: "slack",
-        teamId: "T123",
-        channelId: "C123",
-      },
-      source: createSlackSource({
-        teamId: "T123",
-        channelId: "C123",
-        threadTs: "1712345.0006",
-
-        type: "priv",
-      }),
-      requester: TEST_REQUESTER,
-      recordPendingAuth: async (pendingAuth: ConversationPendingAuthState) => {
-        pendingAuthRecords.push(pendingAuth);
-      },
-      correlation: {
+    const firstError = await generateAssistantReply(
+      makeReplyRequest("help me", {
         conversationId: "conversation-6",
-        turnId: "turn-6",
-        channelId: "C123",
         threadTs: "1712345.0006",
-      },
-    }).catch((error) => error);
+        turnId: "turn-6",
+      }),
+    ).catch((error) => error);
 
     expect(firstError.status).toBe("awaiting_auth");
 

--- a/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
@@ -600,7 +600,15 @@ import {
   upsertAgentTurnSessionRecord,
 } from "@/chat/state/turn-session";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
-import { isRetryableTurnError } from "@/chat/runtime/turn";
+
+function finalReply(
+  outcome: Awaited<ReturnType<typeof generateAssistantReply>>,
+) {
+  if (outcome.status !== "completed" && outcome.status !== "failed") {
+    throw new Error(`Expected final reply, got ${outcome.status}`);
+  }
+  return outcome.reply;
+}
 
 // This suite validates local progressive-loading logic through a mocked
 // agent/runtime seam; it is not integration coverage.
@@ -683,11 +691,9 @@ describe("generateAssistantReply progressive MCP loading", () => {
       turnId: "turn-1",
     });
 
-    const firstError = await generateAssistantReply("help me", context).catch(
-      (error) => error,
-    );
+    const firstError = await generateAssistantReply("help me", context);
 
-    expect(isRetryableTurnError(firstError, "mcp_auth_resume")).toBe(true);
+    expect(firstError.status).toBe("awaiting_auth");
     expect(agentInitialToolNames[0]).toContain("loadSkill");
     expect(agentInitialToolNames[0]).toContain("searchMcpTools");
     expect(agentInitialToolNames[0]).toContain("callMcpTool");
@@ -717,7 +723,7 @@ describe("generateAssistantReply progressive MCP loading", () => {
     ]);
     expect(loadSkillExecutionErrorCount.value).toBe(0);
 
-    const reply = await generateAssistantReply("help me", context);
+    const reply = finalReply(await generateAssistantReply("help me", context));
 
     expect(reply.text).toBe("resumed reply");
     expect(promptCallCount.value).toBe(1);
@@ -761,13 +767,15 @@ describe("generateAssistantReply progressive MCP loading", () => {
     listToolsMock.mockReset();
     listToolsMock.mockResolvedValue(makeDemoMcpTools());
 
-    const reply = await generateAssistantReply(
-      "help me",
-      makeReplyContext({
-        conversationId: "conversation-2",
-        threadTs: "1712345.0002",
-        turnId: "turn-2",
-      }),
+    const reply = finalReply(
+      await generateAssistantReply(
+        "help me",
+        makeReplyContext({
+          conversationId: "conversation-2",
+          threadTs: "1712345.0002",
+          turnId: "turn-2",
+        }),
+      ),
     );
 
     expect(reply.text).toBe("resumed reply");
@@ -858,7 +866,7 @@ describe("generateAssistantReply progressive MCP loading", () => {
       piMessages: priorMessages,
     }).catch((error) => error);
 
-    expect(isRetryableTurnError(firstError, "mcp_auth_resume")).toBe(true);
+    expect(firstError.status).toBe("awaiting_auth");
 
     const pausedSessionRecord = await getAgentTurnSessionRecord(
       "conversation-restore-auth",
@@ -882,14 +890,16 @@ describe("generateAssistantReply progressive MCP loading", () => {
       "current follow-up",
     );
 
-    const reply = await generateAssistantReply("current follow-up", {
-      ...makeReplyContext({
-        conversationId: "conversation-restore-auth",
-        threadTs: "1712345.0091",
-        turnId: "turn-restore-auth",
+    const reply = finalReply(
+      await generateAssistantReply("current follow-up", {
+        ...makeReplyContext({
+          conversationId: "conversation-restore-auth",
+          threadTs: "1712345.0091",
+          turnId: "turn-restore-auth",
+        }),
+        piMessages: priorMessages,
       }),
-      piMessages: priorMessages,
-    });
+    );
 
     expect(reply.text).toBe("resumed reply");
     expect(resumeMessages).toHaveLength(0);
@@ -1164,11 +1174,9 @@ describe("generateAssistantReply progressive MCP loading", () => {
       turnId: "turn-4",
     });
 
-    const firstError = await generateAssistantReply("help me", context).catch(
-      (error) => error,
-    );
+    const firstError = await generateAssistantReply("help me", context);
 
-    expect(isRetryableTurnError(firstError, "mcp_auth_resume")).toBe(true);
+    expect(firstError.status).toBe("awaiting_auth");
     expect(deliverPrivateMessageMock).toHaveBeenCalledTimes(1);
 
     const pausedSessionRecord = await getAgentTurnSessionRecord(
@@ -1180,7 +1188,7 @@ describe("generateAssistantReply progressive MCP loading", () => {
       resumeReason: "auth",
     });
 
-    const reply = await generateAssistantReply("help me", context);
+    const reply = finalReply(await generateAssistantReply("help me", context));
 
     expect(reply.text).toBe("resumed reply");
 
@@ -1202,13 +1210,15 @@ describe("generateAssistantReply progressive MCP loading", () => {
     listToolsMock.mockReset();
     listToolsMock.mockResolvedValue([makeDemoMcpTool("ping")]);
 
-    const reply = await generateAssistantReply(
-      "help me",
-      makeReplyContext({
-        conversationId: "conversation-5",
-        threadTs: "1712345.0005",
-        turnId: "turn-5",
-      }),
+    const reply = finalReply(
+      await generateAssistantReply(
+        "help me",
+        makeReplyContext({
+          conversationId: "conversation-5",
+          threadTs: "1712345.0005",
+          turnId: "turn-5",
+        }),
+      ),
     );
 
     expect(reply.text).toBe("");
@@ -1256,9 +1266,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
       },
     };
 
-    const reply = await generateAssistantReply("help me", context);
+    const reply = finalReply(await generateAssistantReply("help me", context));
 
-    expect(isRetryableTurnError(reply, "mcp_auth_resume")).toBe(false);
     expect(reply.diagnostics.outcome).toBe("provider_error");
     expect(sessionRecordSpy).toHaveBeenCalled();
   });
@@ -1356,7 +1365,7 @@ describe("generateAssistantReply progressive MCP loading", () => {
       },
     }).catch((error) => error);
 
-    expect(isRetryableTurnError(firstError, "mcp_auth_resume")).toBe(true);
+    expect(firstError.status).toBe("awaiting_auth");
 
     const resumedSessionRecord = await getAgentTurnSessionRecord(
       "conversation-5",
@@ -1402,7 +1411,7 @@ describe("generateAssistantReply progressive MCP loading", () => {
       },
     }).catch((error) => error);
 
-    expect(isRetryableTurnError(firstError, "mcp_auth_resume")).toBe(true);
+    expect(firstError.status).toBe("awaiting_auth");
 
     const pausedSessionRecord = await getAgentTurnSessionRecord(
       "conversation-6",

--- a/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
@@ -370,15 +370,18 @@ describe("generateAssistantReply provider retry", () => {
   });
 
   it("continues from the last safe boundary after a transient provider stream error", async () => {
-    const replyPromise = generateAssistantReply("help me", {
-      destination: TEST_DESTINATION,
-      source: TEST_SOURCE,
-      requester: { platform: "slack", teamId: "T123", userId: "U123" },
-      correlation: {
-        conversationId: "conversation-1",
-        turnId: "turn-1",
-        channelId: "C123",
-        threadTs: "1712345.0001",
+    const replyPromise = generateAssistantReply({
+      input: { messageText: "help me" },
+      routing: {
+        destination: TEST_DESTINATION,
+        source: TEST_SOURCE,
+        requester: { platform: "slack", teamId: "T123", userId: "U123" },
+        correlation: {
+          conversationId: "conversation-1",
+          turnId: "turn-1",
+          channelId: "C123",
+          threadTs: "1712345.0001",
+        },
       },
     });
 
@@ -458,24 +461,28 @@ describe("generateAssistantReply provider retry", () => {
     });
 
     const reply = finalReply(
-      await generateAssistantReply("help me", {
-        destination: TEST_DESTINATION,
-        source: TEST_SOURCE,
-        piMessages: priorMessages,
-        requester: { platform: "slack", teamId: "T123", userId: "U123" },
-        correlation: {
-          conversationId: "slack:C123:1712345.0001",
-          turnId: "turn-steering",
-          channelId: "C123",
-          threadTs: "1712345.0001",
+      await generateAssistantReply({
+        input: { messageText: "help me", piMessages: priorMessages },
+        routing: {
+          destination: TEST_DESTINATION,
+          source: TEST_SOURCE,
+          requester: { platform: "slack", teamId: "T123", userId: "U123" },
+          correlation: {
+            conversationId: "slack:C123:1712345.0001",
+            turnId: "turn-steering",
+            channelId: "C123",
+            threadTs: "1712345.0001",
+          },
         },
-        drainSteeringMessages: async (inject) => {
-          const messages = [
-            { text: "actually do the other thing", timestampMs: 2_000 },
-          ];
-          await inject(messages);
-          injectedTexts.push(...messages.map((message) => message.text));
-          return messages;
+        durability: {
+          drainSteeringMessages: async (inject) => {
+            const messages = [
+              { text: "actually do the other thing", timestampMs: 2_000 },
+            ];
+            await inject(messages);
+            injectedTexts.push(...messages.map((message) => message.text));
+            return messages;
+          },
         },
       }),
     );
@@ -529,17 +536,20 @@ describe("generateAssistantReply provider retry", () => {
   it("parks the turn when the worker asks to yield at a Pi boundary", async () => {
     agentMode.value = "cooperativeYield";
 
-    const outcome = await generateAssistantReply("help me", {
-      destination: TEST_DESTINATION,
-      source: TEST_SOURCE,
-      requester: { platform: "slack", teamId: "T123", userId: "U123" },
-      correlation: {
-        conversationId: "conversation-yield",
-        turnId: "turn-yield",
-        channelId: "C123",
-        threadTs: "1712345.0003",
+    const outcome = await generateAssistantReply({
+      input: { messageText: "help me" },
+      routing: {
+        destination: TEST_DESTINATION,
+        source: TEST_SOURCE,
+        requester: { platform: "slack", teamId: "T123", userId: "U123" },
+        correlation: {
+          conversationId: "conversation-yield",
+          turnId: "turn-yield",
+          channelId: "C123",
+          threadTs: "1712345.0003",
+        },
       },
-      shouldYield: () => true,
+      durability: { shouldYield: () => true },
     });
 
     expect(outcome).toMatchObject({
@@ -580,24 +590,29 @@ describe("generateAssistantReply provider retry", () => {
   it("keeps steered messages when yielding after steering drain", async () => {
     agentMode.value = "cooperativeYield";
 
-    const outcome = await generateAssistantReply("help me", {
-      requester: { platform: "slack", teamId: "T123", userId: "U123" },
-      correlation: {
-        conversationId: "conversation-yield-steering",
-        turnId: "turn-yield-steering",
-        channelId: "C123",
-        threadTs: "1712345.0005",
+    const outcome = await generateAssistantReply({
+      input: { messageText: "help me" },
+      routing: {
+        requester: { platform: "slack", teamId: "T123", userId: "U123" },
+        correlation: {
+          conversationId: "conversation-yield-steering",
+          turnId: "turn-yield-steering",
+          channelId: "C123",
+          threadTs: "1712345.0005",
+        },
+        destination: TEST_DESTINATION,
+        source: TEST_SOURCE,
       },
-      destination: TEST_DESTINATION,
-      source: TEST_SOURCE,
-      drainSteeringMessages: async (inject) => {
-        const messages = [
-          { text: "actually do the other thing", timestampMs: 2_000 },
-        ];
-        await inject(messages);
-        return messages;
+      durability: {
+        drainSteeringMessages: async (inject) => {
+          const messages = [
+            { text: "actually do the other thing", timestampMs: 2_000 },
+          ];
+          await inject(messages);
+          return messages;
+        },
+        shouldYield: () => true,
       },
-      shouldYield: () => true,
     });
 
     expect(outcome).toMatchObject({
@@ -634,17 +649,20 @@ describe("generateAssistantReply provider retry", () => {
       .spyOn(turnSessionState, "upsertAgentTurnSessionRecord")
       .mockRejectedValue(new Error("storage unavailable"));
 
-    const error = await generateAssistantReply("help me", {
-      destination: TEST_DESTINATION,
-      source: TEST_SOURCE,
-      requester: { platform: "slack", teamId: "T123", userId: "U123" },
-      correlation: {
-        conversationId: "conversation-yield-persist-failure",
-        turnId: "turn-yield-persist-failure",
-        channelId: "C123",
-        threadTs: "1712345.0004",
+    const error = await generateAssistantReply({
+      input: { messageText: "help me" },
+      routing: {
+        destination: TEST_DESTINATION,
+        source: TEST_SOURCE,
+        requester: { platform: "slack", teamId: "T123", userId: "U123" },
+        correlation: {
+          conversationId: "conversation-yield-persist-failure",
+          turnId: "turn-yield-persist-failure",
+          channelId: "C123",
+          threadTs: "1712345.0004",
+        },
       },
-      shouldYield: () => true,
+      durability: { shouldYield: () => true },
     }).then(
       () => undefined,
       (caught: unknown) => caught,
@@ -668,15 +686,18 @@ describe("generateAssistantReply provider retry", () => {
     sessionLogState.failToolExecutionAppend = true;
 
     const reply = finalReply(
-      await generateAssistantReply("run the tool", {
-        destination: TEST_DESTINATION,
-        source: TEST_SOURCE,
-        requester: { platform: "slack", teamId: "T123", userId: "U123" },
-        correlation: {
-          conversationId: "conversation-tool-activity",
-          turnId: "turn-tool-activity",
-          channelId: "C123",
-          threadTs: "1712345.0006",
+      await generateAssistantReply({
+        input: { messageText: "run the tool" },
+        routing: {
+          destination: TEST_DESTINATION,
+          source: TEST_SOURCE,
+          requester: { platform: "slack", teamId: "T123", userId: "U123" },
+          correlation: {
+            conversationId: "conversation-tool-activity",
+            turnId: "turn-tool-activity",
+            channelId: "C123",
+            threadTs: "1712345.0006",
+          },
         },
       }),
     );
@@ -707,16 +728,18 @@ describe("generateAssistantReply provider retry", () => {
     });
 
     const reply = finalReply(
-      await generateAssistantReply("help me", {
-        destination: TEST_DESTINATION,
-        source: TEST_SOURCE,
-        piMessages: [checkpointedPrompt],
-        requester: { platform: "slack", teamId: "T123", userId: "U123" },
-        correlation: {
-          conversationId,
-          turnId: sessionId,
-          channelId: "C123",
-          threadTs: "1712345.0007",
+      await generateAssistantReply({
+        input: { messageText: "help me", piMessages: [checkpointedPrompt] },
+        routing: {
+          destination: TEST_DESTINATION,
+          source: TEST_SOURCE,
+          requester: { platform: "slack", teamId: "T123", userId: "U123" },
+          correlation: {
+            conversationId,
+            turnId: sessionId,
+            channelId: "C123",
+            threadTs: "1712345.0007",
+          },
         },
       }),
     );
@@ -740,28 +763,33 @@ describe("generateAssistantReply provider retry", () => {
     let injectRejected = false;
     let injectCompleted = false;
 
-    await generateAssistantReply("help me", {
-      destination: TEST_DESTINATION,
-      source: TEST_SOURCE,
-      requester: { platform: "slack", teamId: "T123", userId: "U123" },
-      correlation: {
-        conversationId: "conversation-steering-failure",
-        turnId: "turn-steering-failure",
-        channelId: "C123",
-        threadTs: "1712345.0002",
+    await generateAssistantReply({
+      input: { messageText: "help me" },
+      routing: {
+        destination: TEST_DESTINATION,
+        source: TEST_SOURCE,
+        requester: { platform: "slack", teamId: "T123", userId: "U123" },
+        correlation: {
+          conversationId: "conversation-steering-failure",
+          turnId: "turn-steering-failure",
+          channelId: "C123",
+          threadTs: "1712345.0002",
+        },
       },
-      drainSteeringMessages: async (inject) => {
-        const messages = [
-          { text: "actually do the other thing", timestampMs: 2_000 },
-        ];
-        try {
-          await inject(messages);
-          injectCompleted = true;
-          return messages;
-        } catch {
-          injectRejected = true;
-          throw new Error("inject rejected");
-        }
+      durability: {
+        drainSteeringMessages: async (inject) => {
+          const messages = [
+            { text: "actually do the other thing", timestampMs: 2_000 },
+          ];
+          try {
+            await inject(messages);
+            injectCompleted = true;
+            return messages;
+          } catch {
+            injectRejected = true;
+            throw new Error("inject rejected");
+          }
+        },
       },
     });
 

--- a/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
@@ -323,12 +323,20 @@ vi.mock("@/chat/skills", async (importOriginal) => ({
 
 import { generateAssistantReply } from "@/chat/respond";
 import { getConversationStore } from "@/chat/db";
-import { isCooperativeTurnYieldError } from "@/chat/runtime/turn";
 import { getAwaitingAgentContinueRequest } from "@/chat/services/agent-continue";
 import { persistCompletedSessionRecord } from "@/chat/services/turn-session-record";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
 import * as turnSessionState from "@/chat/state/turn-session";
 import { createJuniorReporting } from "@/reporting";
+
+function finalReply(
+  outcome: Awaited<ReturnType<typeof generateAssistantReply>>,
+) {
+  if (outcome.status !== "completed" && outcome.status !== "failed") {
+    throw new Error(`Expected final reply, got ${outcome.status}`);
+  }
+  return outcome.reply;
+}
 
 const TEST_DESTINATION = {
   platform: "slack",
@@ -376,7 +384,7 @@ describe("generateAssistantReply provider retry", () => {
 
     await waitForPromptCall(1);
     await advanceUntilContinueCall(5_000);
-    const reply = await replyPromise;
+    const reply = finalReply(await replyPromise);
 
     expect(reply.text).toBe("Recovered.");
     expect(reply.diagnostics.outcome).toBe("success");
@@ -449,26 +457,28 @@ describe("generateAssistantReply provider retry", () => {
       visibility: "public",
     });
 
-    const reply = await generateAssistantReply("help me", {
-      destination: TEST_DESTINATION,
-      source: TEST_SOURCE,
-      piMessages: priorMessages,
-      requester: { platform: "slack", teamId: "T123", userId: "U123" },
-      correlation: {
-        conversationId: "slack:C123:1712345.0001",
-        turnId: "turn-steering",
-        channelId: "C123",
-        threadTs: "1712345.0001",
-      },
-      drainSteeringMessages: async (inject) => {
-        const messages = [
-          { text: "actually do the other thing", timestampMs: 2_000 },
-        ];
-        await inject(messages);
-        injectedTexts.push(...messages.map((message) => message.text));
-        return messages;
-      },
-    });
+    const reply = finalReply(
+      await generateAssistantReply("help me", {
+        destination: TEST_DESTINATION,
+        source: TEST_SOURCE,
+        piMessages: priorMessages,
+        requester: { platform: "slack", teamId: "T123", userId: "U123" },
+        correlation: {
+          conversationId: "slack:C123:1712345.0001",
+          turnId: "turn-steering",
+          channelId: "C123",
+          threadTs: "1712345.0001",
+        },
+        drainSteeringMessages: async (inject) => {
+          const messages = [
+            { text: "actually do the other thing", timestampMs: 2_000 },
+          ];
+          await inject(messages);
+          injectedTexts.push(...messages.map((message) => message.text));
+          return messages;
+        },
+      }),
+    );
 
     expect(reply.text).toBe("Steered.");
     expect(injectedTexts).toEqual(["actually do the other thing"]);
@@ -519,7 +529,7 @@ describe("generateAssistantReply provider retry", () => {
   it("parks the turn when the worker asks to yield at a Pi boundary", async () => {
     agentMode.value = "cooperativeYield";
 
-    const error = await generateAssistantReply("help me", {
+    const outcome = await generateAssistantReply("help me", {
       destination: TEST_DESTINATION,
       source: TEST_SOURCE,
       requester: { platform: "slack", teamId: "T123", userId: "U123" },
@@ -530,12 +540,15 @@ describe("generateAssistantReply provider retry", () => {
         threadTs: "1712345.0003",
       },
       shouldYield: () => true,
-    }).then(
-      () => undefined,
-      (caught: unknown) => caught,
-    );
+    });
 
-    expect(isCooperativeTurnYieldError(error)).toBe(true);
+    expect(outcome).toMatchObject({
+      status: "yielded",
+      conversationId: "conversation-yield",
+      sessionId: "turn-yield",
+      sliceId: 1,
+      version: expect.any(Number),
+    });
     const sessionRecord = await turnSessionState.getAgentTurnSessionRecord(
       "conversation-yield",
       "turn-yield",
@@ -567,7 +580,7 @@ describe("generateAssistantReply provider retry", () => {
   it("keeps steered messages when yielding after steering drain", async () => {
     agentMode.value = "cooperativeYield";
 
-    const error = await generateAssistantReply("help me", {
+    const outcome = await generateAssistantReply("help me", {
       requester: { platform: "slack", teamId: "T123", userId: "U123" },
       correlation: {
         conversationId: "conversation-yield-steering",
@@ -585,12 +598,15 @@ describe("generateAssistantReply provider retry", () => {
         return messages;
       },
       shouldYield: () => true,
-    }).then(
-      () => undefined,
-      (caught: unknown) => caught,
-    );
+    });
 
-    expect(isCooperativeTurnYieldError(error)).toBe(true);
+    expect(outcome).toMatchObject({
+      status: "yielded",
+      conversationId: "conversation-yield-steering",
+      sessionId: "turn-yield-steering",
+      sliceId: 1,
+      version: expect.any(Number),
+    });
     const sessionRecord = await turnSessionState.getAgentTurnSessionRecord(
       "conversation-yield-steering",
       "turn-yield-steering",
@@ -639,7 +655,6 @@ describe("generateAssistantReply provider retry", () => {
     expect((error as Error).message).toContain(
       "Failed to persist cooperative yield continuation",
     );
-    expect(isCooperativeTurnYieldError(error)).toBe(false);
     await expect(
       turnSessionState.getAgentTurnSessionRecord(
         "conversation-yield-persist-failure",
@@ -652,17 +667,19 @@ describe("generateAssistantReply provider retry", () => {
     agentMode.value = "toolActivity";
     sessionLogState.failToolExecutionAppend = true;
 
-    const reply = await generateAssistantReply("run the tool", {
-      destination: TEST_DESTINATION,
-      source: TEST_SOURCE,
-      requester: { platform: "slack", teamId: "T123", userId: "U123" },
-      correlation: {
-        conversationId: "conversation-tool-activity",
-        turnId: "turn-tool-activity",
-        channelId: "C123",
-        threadTs: "1712345.0006",
-      },
-    });
+    const reply = finalReply(
+      await generateAssistantReply("run the tool", {
+        destination: TEST_DESTINATION,
+        source: TEST_SOURCE,
+        requester: { platform: "slack", teamId: "T123", userId: "U123" },
+        correlation: {
+          conversationId: "conversation-tool-activity",
+          turnId: "turn-tool-activity",
+          channelId: "C123",
+          threadTs: "1712345.0006",
+        },
+      }),
+    );
 
     expect(sessionLogState.toolExecutionAppendCalls).toBe(1);
     expect(reply.diagnostics.outcome).toBe("success");
@@ -689,18 +706,20 @@ describe("generateAssistantReply provider retry", () => {
       turnStartMessageIndex: 0,
     });
 
-    const reply = await generateAssistantReply("help me", {
-      destination: TEST_DESTINATION,
-      source: TEST_SOURCE,
-      piMessages: [checkpointedPrompt],
-      requester: { platform: "slack", teamId: "T123", userId: "U123" },
-      correlation: {
-        conversationId,
-        turnId: sessionId,
-        channelId: "C123",
-        threadTs: "1712345.0007",
-      },
-    });
+    const reply = finalReply(
+      await generateAssistantReply("help me", {
+        destination: TEST_DESTINATION,
+        source: TEST_SOURCE,
+        piMessages: [checkpointedPrompt],
+        requester: { platform: "slack", teamId: "T123", userId: "U123" },
+        correlation: {
+          conversationId,
+          turnId: sessionId,
+          channelId: "C123",
+          threadTs: "1712345.0007",
+        },
+      }),
+    );
 
     expect(reply.diagnostics.outcome).toBe("success");
     const sessionRecord = await turnSessionState.getAgentTurnSessionRecord(

--- a/packages/junior/tests/unit/services/turn-failure-response.test.ts
+++ b/packages/junior/tests/unit/services/turn-failure-response.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import { getInterruptionMarker } from "@/chat/interruption-marker";
 import { finalizeFailedTurnReply } from "@/chat/services/turn-failure-response";
-import type { AssistantReply } from "@/chat/services/turn-result";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 
 function providerErrorReply(args: {
   assistantMessageCount: number;
   errorMessage?: string;
   text: string;
-}): AssistantReply {
+}): AgentRunResult {
   return {
     text: args.text,
     diagnostics: {

--- a/packages/junior/tests/unit/services/turn-thinking-level.test.ts
+++ b/packages/junior/tests/unit/services/turn-thinking-level.test.ts
@@ -46,7 +46,7 @@ describe("selectTurnThinkingLevel", () => {
       completeObject,
       fastModelId: "openai/gpt-5.4-mini",
       messageText:
-        "fix the failing test in packages/junior/src/chat/respond.ts",
+        "fix the failing test in packages/junior/src/chat/agent-run.ts",
     });
 
     expect(profile).toMatchObject({

--- a/specs/agent-prompt.md
+++ b/specs/agent-prompt.md
@@ -66,7 +66,7 @@ Trusted deployment-authored Markdown files, such as `SOUL.md` and `WORLD.md`, sh
 
 ### Current Task Declaration
 
-Every model-visible active user task assembled by the Junior turn runtime must render the user-authored task text inside `<current-instruction>`. This wrapper is required even when there is no thread background, dispatch metadata, plugin contribution, attachment, or runtime context. It applies to Slack turns, local turns, dispatched or scheduled work that enters the shared reply boundary, and queued steering messages injected during an active turn.
+Every model-visible active user task assembled by the Junior turn runtime must render the user-authored task text inside `<current-instruction>`. This wrapper is required even when there is no thread background, dispatch metadata, plugin contribution, attachment, or runtime context. It applies to Slack turns, local turns, dispatched or scheduled work that enters the shared agent-run boundary, and queued steering messages injected during an active turn.
 
 Thread background, runtime context, plugin prompt contributions, requester/configuration metadata, and attachments must remain outside `<current-instruction>` as sibling blocks or content parts. Internal helper prompts and subagent/tool prompts may use task-specific wrappers when they are not model-visible Junior user turns.
 

--- a/specs/archive/agent-stability-evaluation-2026-02.md
+++ b/specs/archive/agent-stability-evaluation-2026-02.md
@@ -9,7 +9,6 @@
 
 - 2026-03-03: Standardized metadata headers and reconciled spec references/structure.
 
-
 Last updated: 2026-02-27
 
 ## Scope
@@ -30,17 +29,17 @@ This document tracks stability risks in the Slack agent loop, concrete mitigatio
 
 ## Evaluation Checklist
 
-| Concern | Plan | Status | Validation |
-| --- | --- | --- | --- |
-| Collapse compounding retry structure | Remove classifier-driven continuation loop and keep bounded deterministic finalization | Completed | `src/chat/respond.ts` no longer runs completion classifier/retry agent branch |
-| Reduce terminal nondeterminism | Remove LLM-based completion classifier from terminal decision path | Completed | `src/chat/respond.ts` no longer depends on `classifyCompletionOutcome` |
-| Preserve retry context | Rework retries to use prior response messages/tool context rather than only corrective text | Completed | Finalization retries now include `...finalResult.response.messages` |
-| Tool failure semantics | Throw operational tool failures to emit `tool-error` outputs | Completed | Updated `web-fetch`, `image-generate`, and Slack tool catch paths to throw |
-| Tool-loop control | Add deterministic prepare-step guardrails against repetitive tool call patterns | Completed | Added `prepareStep` loop guard + `onStepFinish` tool-error logging in `respond.ts` |
-| Side-effect idempotency | Add per-turn dedupe keys for create/update Slack artifact tools | Completed | Added operation cache in `ToolState` + dedupe keys in side-effect tools |
-| PI continue-loop diagnosis | Remove/replace auto-continue branch and document behavior change | Completed | Removed PI-style auto-continue retry loop from `respond.ts` |
-| Test coverage | Add focused tests for idempotency + regression-prone loop helpers | Completed | Added `tests/integration/tool-idempotency.test.ts` |
-| Channel member enrichment rate limits | Refactor member profile lookup to bounded concurrency (or staged hydration) | Pending | `src/chat/slack-actions/channel.ts` currently uses broad `Promise.all` fan-out |
+| Concern                               | Plan                                                                                        | Status    | Validation                                                                           |
+| ------------------------------------- | ------------------------------------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------ |
+| Collapse compounding retry structure  | Remove classifier-driven continuation loop and keep bounded deterministic finalization      | Completed | `src/chat/agent-run.ts` no longer runs completion classifier/retry agent branch      |
+| Reduce terminal nondeterminism        | Remove LLM-based completion classifier from terminal decision path                          | Completed | `src/chat/agent-run.ts` no longer depends on `classifyCompletionOutcome`             |
+| Preserve retry context                | Rework retries to use prior response messages/tool context rather than only corrective text | Completed | Finalization retries now include `...finalResult.response.messages`                  |
+| Tool failure semantics                | Throw operational tool failures to emit `tool-error` outputs                                | Completed | Updated `web-fetch`, `image-generate`, and Slack tool catch paths to throw           |
+| Tool-loop control                     | Add deterministic prepare-step guardrails against repetitive tool call patterns             | Completed | Added `prepareStep` loop guard + `onStepFinish` tool-error logging in `agent-run.ts` |
+| Side-effect idempotency               | Add per-turn dedupe keys for create/update Slack artifact tools                             | Completed | Added operation cache in `ToolState` + dedupe keys in side-effect tools              |
+| PI continue-loop diagnosis            | Remove/replace auto-continue branch and document behavior change                            | Completed | Removed PI-style auto-continue retry loop from `agent-run.ts`                        |
+| Test coverage                         | Add focused tests for idempotency + regression-prone loop helpers                           | Completed | Added `tests/integration/tool-idempotency.test.ts`                                   |
+| Channel member enrichment rate limits | Refactor member profile lookup to bounded concurrency (or staged hydration)                 | Pending   | `src/chat/slack-actions/channel.ts` currently uses broad `Promise.all` fan-out       |
 
 ## Notes
 
@@ -51,7 +50,7 @@ This document tracks stability risks in the Slack agent loop, concrete mitigatio
 - Post-merge regression (2026-02-25):
   - Symptom: `AI_MissingToolResultsError` during finalization retries.
   - Cause: Retry history reused `response.messages` that could contain unresolved non-provider `tool-call` parts before appending a new user message.
-  - Mitigation: sanitize retry history and strip unresolved non-provider tool calls before finalization retry generation (`src/chat/respond.ts`).
+  - Mitigation: sanitize retry history and strip unresolved non-provider tool calls before finalization retry generation (`src/chat/agent-run.ts`).
 - Policy update (2026-02-25):
   - Finalization retries are disabled for now to avoid masking failures and compounding instability.
   - Runtime flow is now: primary loop -> forced no-tool finalization (single fallback) -> explicit failure surfacing.
@@ -59,5 +58,5 @@ This document tracks stability risks in the Slack agent loop, concrete mitigatio
   - `pnpm typecheck` passed
   - `pnpm test` passed (8 files, 25 tests)
 - Residual risks:
-  - Loop guard behavior is covered by unit-level logic and compile checks, but not by a full mocked `generateAssistantReply` integration test.
+  - Loop guard behavior is covered by unit-level logic and compile checks, but not by a full mocked `executeAgentRun` integration test.
   - Tool idempotency cache is per turn (intended) and does not dedupe across separate Slack invocations.

--- a/specs/archive/non-normative-cleanup-notes-2026-05-28.md
+++ b/specs/archive/non-normative-cleanup-notes-2026-05-28.md
@@ -54,7 +54,7 @@ Previous migration matrix:
 
 1. `packages/junior/src/handlers/webhooks.ts`: unknown platform, handler failures, request lifecycle.
 2. `packages/junior/src/chat/runtime/slack-runtime.ts`: attachment handling, thread lifecycle, handler failures.
-3. `packages/junior/src/chat/respond.ts`: empty/fallback behaviors, retries, model/tool anomalies. Per-turn diagnostics are captured on turn spans, not required as info logs.
+3. `packages/junior/src/chat/agent-run.ts`: empty/fallback behaviors, retries, model/tool anomalies. Per-turn diagnostics are captured on turn spans, not required as info logs.
 4. `packages/junior/src/chat/skills.ts`: skill discovery/read/frontmatter parse issues.
 5. `packages/junior/src/chat/slack/output.ts`: output normalization fallback.
 
@@ -69,7 +69,7 @@ Previous rollout phases:
 
 Previous logging TODOs:
 
-1. Migrate duplicated per-turn context in `packages/junior/src/chat/respond.ts` to ambient `withContext`/`withLogContext`.
+1. Migrate duplicated per-turn context in `packages/junior/src/chat/agent-run.ts` to ambient `withContext`/`withLogContext`.
 2. Update `packages/junior/src/chat/runtime/slack-runtime.ts` logging call patterns to rely on ambient context by default.
 3. Normalize remaining ad-hoc context passing in `packages/junior/src/chat/capabilities/*` and `packages/junior/src/chat/queue/*`.
 4. Add unit tests for context merge precedence and async propagation in `packages/junior/src/chat/logging.ts`.

--- a/specs/chat-architecture.md
+++ b/specs/chat-architecture.md
@@ -51,7 +51,7 @@ flowchart TD
   F --> G[Restore Pi state from reduced session log]
   LA[Local CLI input] --> LB[Direct local runner: persist local turn and load state]
   LB --> G
-  G --> J[respond.ts generateAssistantReply / continue]
+  G --> J[agent-run.ts executeAgentRun / continue]
   J --> K[Build prompt context from durable conversation, config, artifacts, sandbox, attachments]
   K --> L[Pi agent continue loop]
   L --> M[Tools, skills, MCP, sandbox]
@@ -83,7 +83,7 @@ Normative rules:
 2. The task execution layer owns queue wake-ups, conversation leases, worker check-ins, and heartbeat recovery. Chat SDK queue/lock semantics are not canonical.
 3. The first-pass local CLI adapter uses the direct local runner from [Local Agent Spec](./local-agent.md). It must not claim mailbox-backed local source semantics until a local mailbox ingress contract exists.
 4. The mailbox worker is the only point that drains inbound messages into persisted agent session context for mailbox-backed paths.
-5. `respond.ts` is the only owner of Pi agent execution, prompt/continue selection, timeout detection, and safe-boundary session-log event creation.
+5. `agent-run.ts` is the only owner of Pi agent execution, prompt/continue selection, timeout detection, and safe-boundary session-log event creation.
 6. Tool calls and tool failures are internal agent-loop data until the assistant produces final run diagnostics. Tool execution errors must be captured, but they are not automatically terminal user replies. Model-repairable failures must use the tool-error semantics from [Agent Execution Discipline Spec](./agent-execution.md).
 7. User-visible assistant text is posted only after the reply is finalized and planned for destination delivery.
 8. Final run success is defined by the destination delivery port accepting the visible final reply, not by model generation completing. Slack acceptance is one destination implementation.
@@ -290,7 +290,7 @@ Rules:
 
 1. Recovery continues the existing conversation from durable thread state plus the reduced agent-session log keyed by the predictable conversation id. It must not start a second active run for the same conversation.
 2. Conversation mailbox state, queue wake-ups, and leases protect inbound delivery. They do not replace session continuation because they do not carry Junior's canonical agent session log, sandbox/artifact state, pending auth, or final destination delivery state.
-3. `respond.ts` appends safe session-log boundaries; the mailbox worker enqueues cooperative continuations; heartbeat re-enqueues expired leases and stranded pending mailbox work.
+3. `agent-run.ts` appends safe session-log boundaries; the mailbox worker enqueues cooperative continuations; heartbeat re-enqueues expired leases and stranded pending mailbox work.
 4. Routine cooperative continuation does not create a platform acknowledgement message. Assistant status and `reportProgress` own progress UX.
 5. Queue duplicate and active-lease cases are harmless because queue messages are conversation wake-up nudges, not canonical work records.
 

--- a/specs/context-compaction.md
+++ b/specs/context-compaction.md
@@ -104,7 +104,7 @@ Compaction projection events must use a deterministic event id derived from the 
 Automatic pre-turn compaction may replace an oversized reusable conversation-log projection before the next agent turn starts. It must:
 
 1. Run after reusable Pi history is loaded.
-2. Finish before `generateAssistantReply(...)` receives `piMessages`.
+2. Finish before `executeAgentRun(...)` receives `piMessages`.
 3. Use the compacted replacement history for the upcoming turn.
 4. Append the compaction projection before final thread-state persistence for the turn.
 5. Start explicit assistant progress after the threshold decision and before summarization when a status surface is available, then return to the normal turn status before agent execution.

--- a/specs/harness-agent.md
+++ b/specs/harness-agent.md
@@ -11,7 +11,7 @@ Define the canonical runtime contract for assistant-turn execution and user-visi
 
 ## Scope
 
-- Turn execution in `generateAssistantReply(...)`.
+- Turn execution in `executeAgentRun(...)`.
 - Assistant text streaming and final output resolution.
 - Diagnostics emitted for each turn.
 
@@ -44,7 +44,7 @@ Define the canonical runtime contract for assistant-turn execution and user-visi
 
 ### Timeout behavior
 
-- `generateAssistantReply(...)` aborts the Pi agent on timeout and waits for the in-flight prompt/continue call to settle before inspecting Pi messages.
+- `executeAgentRun(...)` aborts the Pi agent on timeout and waits for the in-flight prompt/continue call to settle before inspecting Pi messages.
 - When resumability context is available (`conversation_id` + `session_id`) and a safe-boundary session record can be persisted, timeout throws `RetryableTurnError("agent_continue")` with session record metadata instead of returning a normal reply payload.
 - When no resumable session record can be persisted, timeout falls back to the standard provider-error reply path.
 - The harness does not decide whether timed-out work should be auto-resumed after user-visible output has started. Higher-level runtime code applies the visibility rules from [Agent Session Resumability Spec](./agent-session-resumability.md).

--- a/specs/local-agent.md
+++ b/specs/local-agent.md
@@ -148,7 +148,7 @@ Rules:
 1. The CLI must call the shared conversation runtime or shared local runner
    boundary. It must not call Slack runtime methods.
 2. The CLI must not construct Chat SDK `Thread`, `Message`, or Slack adapter
-   wrappers to reach `generateAssistantReply`.
+   wrappers to reach `executeAgentRun`.
 3. Runtime context must set `surface: "internal"` until a distinct `local`
    surface is added across reporting and session schemas.
 4. Runtime correlation must include `conversationId`, `runId`, and a local

--- a/specs/plugin-dispatch.md
+++ b/specs/plugin-dispatch.md
@@ -199,7 +199,7 @@ The internal callback runs a core-owned dispatched agent runner. The runner owns
 - loading dispatch-scoped persisted conversation/artifact/sandbox state and destination channel config state
 - creating or reusing synthetic system-authored conversation messages
 - building conversation context
-- calling `generateAssistantReply`
+- calling `executeAgentRun`
 - delivering the reply
 - committing conversation, artifact, sandbox, and dispatch state
 - marking auth-required runs as blocked
@@ -224,7 +224,7 @@ Slack post and state commit are not atomic. If Slack accepts the post but persis
 
 Dispatched requests must not use the Slack conversation queue used for interactive conversations. Timeout continuation uses the dispatch callback path:
 
-1. `generateAssistantReply` persists a resumable session record for the dispatch conversation and turn id.
+1. `executeAgentRun` persists a resumable session record for the dispatch conversation and turn id.
 2. Runner catches `agent_continue`.
 3. Runner marks dispatch `awaiting_resume` with the next record version.
 4. Runner signs another callback for the same dispatch id.

--- a/specs/task-execution.md
+++ b/specs/task-execution.md
@@ -581,7 +581,7 @@ Rules:
    local ingress uses `source: "local"`.
 2. Local CLI conversation ids must be stable across prompts in the same selected
    terminal session.
-3. Local CLI must use the shared conversation runtime and `generateAssistantReply`
+3. Local CLI must use the shared conversation runtime and `executeAgentRun`
    path. It must not instantiate Slack thread/message wrappers to reach the
    agent.
 4. Local CLI may stream assistant deltas and status updates to stdout/stderr, but

--- a/specs/terminology.md
+++ b/specs/terminology.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-06-12
-- Last Edited: 2026-06-12
+- Last Edited: 2026-07-02
 
 ## Purpose
 
@@ -72,11 +72,37 @@ Prefer comments that clarify the current meaning:
 
 > historical turn-session name; represents an agent-run session record
 
+### `reply`
+
+Use `reply` only for destination-visible messages owned by delivery and
+reply-policy layers.
+
+Allowed uses:
+
+- Delivery and policy identifiers that already describe destination-visible
+  messages, such as `SubscribedReplyPolicy`, `ReplyDeliveryPlan`, and
+  `slack/reply.ts`.
+- Historical identifiers in existing delivery-facing APIs, storage fields, and
+  tests when the value is a destination-visible message.
+- User-facing product copy that describes a visible response in Slack, local
+  CLI, or another destination.
+
+Agent execution layers use run/slice vocabulary instead. New executor-boundary
+identifiers must not use `reply` or `respond`; use `agent run`, `result`,
+`outcome`, or `delivery` terms according to ownership.
+
+When touching historical `reply` names, do not rename them opportunistically.
+Prefer comments that clarify the current meaning:
+
+> historical delivery reply name; represents a destination-visible message
+
 ### Naming Rules
 
 - Use `run` for response-producing execution.
 - Use `slice` for one resumable serverless invocation segment.
 - Use `step` for model/tool/action events inside a run.
+- Use `reply` only for destination-visible messages owned by delivery or
+  reply-policy layers.
 - Use `message` for source events and transcript entries.
 - Use `conversation` for the durable container that owns visible history and
   execution state.


### PR DESCRIPTION
The chat executor previously signaled expected run endings — cooperative yield, continuable timeout, auth pause — by throwing `CooperativeTurnYieldError` and `RetryableTurnError`, so every caller caught and type-sniffed control flow, and the boundary mixed three vocabularies (`reply`/`respond`, legacy `turn`, and the spec-canonical run/slice). This lands the full contract cleanup from #746 in five commits, one per phase:

1. `executeAgentRun` (né `generateAssistantReply`) returns a discriminated `AgentRunOutcome` (`completed | failed | yielded | timed_out | awaiting_auth`); genuine errors still throw. Outer boundaries that need the historical errors (queue worker yield routing, OAuth resume callbacks) construct them from the outcome instead of catching them.
2. A small `AgentRunner` interface replaces five `typeof`-function injection slots; composition roots build it, and the silent production-impl fallbacks in dispatch/local/continuation runners are gone.
3. The flat ~35-field request bag becomes six role groups (`input`/`routing`/`policy`/`state`/`observers`/`durability`), so `AgentRunner.run` takes one grouped request.
4. Hard-cutover rename to run vocabulary (`respond.ts` → `agent-run.ts`, no compat aliases), with spec references updated and `specs/terminology.md` now governing `reply` (reserved for destination-visible messages owned by delivery/policy layers).
5. The ~1,450-line executor body decomposes into a `chat/agent-run/` feature directory — the slice checkpointer owns resume/persistence state and translates expected endings into outcomes, so the catch block is a thin translation; tool wiring and prompt assembly are explicit-contract phase modules.

Behavior is unchanged throughout: persistence ordering, telemetry keys, delivery semantics, and the historical `turn`-named identifiers (`AgentTurnSessionRecord`, `RetryableTurnError`, …) are preserved per the terminology spec's grandfathering rules. A new component test pins the highest-risk invariant: a yielded slice must stay resumable — no failure persistence, no canvas-recovery hijack, mailbox requeued.

Review order: commits are independently green and reviewable in sequence; the rename commit (`bffd9b70`) is mechanical, and the decomposition commit (`e0f64f8e`) moves code without changing consumer import paths.

Fixes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)