### PR TITLE
fix(cli): Align init scaffold with example Nitro app

### DIFF
--- a/packages/docs/src/content/docs/cli/init.md
+++ b/packages/docs/src/content/docs/cli/init.md
@@ -25,12 +25,13 @@ The command requires exactly one argument: the target directory.
 
 The scaffold includes:
 
-- `package.json` with `@sentry/junior`, `@sentry/junior-maintenance`, `@sentry/junior-memory`, `hono`, `nitro`, `vite`, `typescript`, and `jiti`
+- `package.json` with `@sentry/junior`, `@sentry/junior-maintenance`, `@sentry/junior-memory`, `hono`, `nitro`, `typescript`, `jiti`, and `@types/node`
 - `plugins.ts` with `@sentry/junior-maintenance` and `createMemoryPlugin()` enabled
 - `server.ts`
 - `nitro.config.ts` pointing at `./plugins`
-- `vite.config.ts`
+- `tsconfig.json` extending Nitro's TypeScript config
 - `vercel.json`
+- `.github/workflows/ci.yml`
 - `app/SOUL.md`
 - `app/WORLD.md`
 - `app/DESCRIPTION.md`
@@ -74,7 +75,7 @@ junior command failed: refusing to initialize non-empty directory: /path/to/my-b
 After scaffolding:
 
 1. Run `cd my-bot && pnpm install`.
-2. Fill in the required values from `.env.example`.
+2. Fill in the required values from `.env.example`, including `DATABASE_URL`.
 3. Run `pnpm dev`.
 4. Check `http://localhost:3000/health`.
 

--- a/packages/docs/src/content/docs/cli/snapshot-create.md
+++ b/packages/docs/src/content/docs/cli/snapshot-create.md
@@ -60,7 +60,7 @@ The common case is a Vercel build command:
 ```json title="package.json"
 {
   "scripts": {
-    "build": "junior snapshot create && vite build"
+    "build": "junior snapshot create && nitro build"
   }
 }
 ```

--- a/packages/docs/src/content/docs/extend/index.md
+++ b/packages/docs/src/content/docs/extend/index.md
@@ -65,8 +65,9 @@ pnpm add @sentry/junior @sentry/junior-agent-browser @sentry/junior-cloudflare @
 Create one runtime-safe plugin set and point `juniorNitro()` at that module.
 Manifest-only packages use package-name strings. Plugins that need runtime
 hooks use JavaScript factories such as `githubPlugin()` and `schedulerPlugin()`.
-`createApp()` reads the same enabled plugin set from Nitro's virtual module at
-runtime.
+Import the same plugin set in `server.ts` and pass it to
+`createApp({ plugins })` so local dev and built bundles use identical runtime
+plugins.
 
 ```ts title="plugins.ts"
 import { defineJuniorPlugins } from "@sentry/junior";
@@ -112,8 +113,11 @@ export default defineConfig({
 
 ```ts title="server.ts"
 import { createApp } from "@sentry/junior";
+import { plugins } from "./plugins.ts";
 
-const app = await createApp();
+const app = await createApp({
+  plugins,
+});
 
 export default app;
 ```

--- a/packages/docs/src/content/docs/operate/sandbox-snapshots.md
+++ b/packages/docs/src/content/docs/operate/sandbox-snapshots.md
@@ -22,7 +22,7 @@ The common deploy path runs snapshot warmup during build:
 ```json title="package.json"
 {
   "scripts": {
-    "build": "junior snapshot create && vite build"
+    "build": "junior snapshot create && nitro build"
   }
 }
 ```

--- a/packages/docs/src/content/docs/start-here/deploy-to-vercel.md
+++ b/packages/docs/src/content/docs/start-here/deploy-to-vercel.md
@@ -48,8 +48,8 @@ The scaffolded `package.json` includes the production build script:
 {
   "scripts": {
     "check": "junior check",
-    "dev": "vite dev",
-    "build": "junior snapshot create && vite build"
+    "dev": "nitro dev",
+    "build": "junior snapshot create && nitro build"
   }
 }
 ```
@@ -74,7 +74,11 @@ import { juniorNitro } from "@sentry/junior/nitro";
 
 export default defineConfig({
   preset: "vercel",
-  modules: [juniorNitro()],
+  modules: [
+    juniorNitro({
+      plugins: "./plugins",
+    }),
+  ],
   routes: {
     "/**": { handler: "./server.ts" },
   },

--- a/packages/docs/src/content/docs/start-here/existing-app.md
+++ b/packages/docs/src/content/docs/start-here/existing-app.md
@@ -24,8 +24,11 @@ import { initSentry } from "@sentry/junior/instrumentation";
 initSentry();
 
 import { createApp } from "@sentry/junior";
+import { plugins } from "./plugins.ts";
 
-const app = await createApp();
+const app = await createApp({
+  plugins,
+});
 
 export default app;
 ```

--- a/packages/docs/src/content/docs/start-here/quickstart.md
+++ b/packages/docs/src/content/docs/start-here/quickstart.md
@@ -321,6 +321,7 @@ Use the same baseline that the scaffolded CI workflow uses:
 
 - Node.js 24
 - pnpm
+- A Postgres database for Junior SQL records and the default memory plugin
 - A Redis URL for runtime state, locks, and durable task records
 
 Slack credentials are needed before the bot can reply in Slack. You can scaffold and verify the local health route first, then finish [Slack App Setup](/start-here/slack-app-setup/).
@@ -335,7 +336,7 @@ cd my-bot
 pnpm install
 ```
 
-`junior init` creates the app entrypoint, Nitro/Vite config, Vercel config, Vercel queue consumer source, CI workflow, app context files, local plugin and skill directories, `.env.example`, and a `plugins.ts` with maintenance and memory enabled by default.
+`junior init` creates the app entrypoint, Nitro config, Vercel config, TypeScript config, CI workflow, app context files, local plugin and skill directories, `.env.example`, and a `plugins.ts` with maintenance and memory enabled by default.
 
 The generated `app/` files have separate jobs:
 
@@ -363,6 +364,8 @@ Set these values before running real turns:
 | ------------------------- | ---------------------- | -------------------------------------------------------------- |
 | `SLACK_SIGNING_SECRET`    | Yes, for Slack traffic | Verifies Slack requests.                                       |
 | `SLACK_BOT_TOKEN`         | Yes, for Slack replies | Posts thread replies and calls Slack APIs.                     |
+| `DATABASE_URL`            | Yes                    | Postgres connection string for Junior SQL records and memory.  |
+| `JUNIOR_DATABASE_DRIVER`  | No                     | SQL client driver: `neon` or `postgres`.                       |
 | `REDIS_URL`               | Yes                    | Runtime state, locks, and durable background task records.     |
 | `JUNIOR_SECRET`           | Yes                    | Signs internal resume callbacks and sandbox requester context. |
 | `JUNIOR_BOT_NAME`         | No                     | Bot display/config name.                                       |
@@ -376,7 +379,9 @@ Set these values before running real turns:
 
 See [Config & Environment](/reference/config-and-env/) for the full reference.
 If you keep the default memory plugin enabled, use a Postgres database with
-pgvector support before running migrations.
+pgvector support before running migrations. Local Postgres URLs automatically
+use the `postgres` driver; set `JUNIOR_DATABASE_DRIVER=postgres` for other
+non-Neon Postgres providers.
 
 ## Run locally
 
@@ -440,8 +445,8 @@ export const plugins = defineJuniorPlugins([
 ]);
 ```
 
-Point `juniorNitro()` at that module. `createApp()` reads the same plugin set
-from Nitro's virtual module, so the server entry does not repeat it:
+Point `juniorNitro()` at that module and pass the same plugin set to
+`createApp()` so local dev and built bundles use identical runtime plugins:
 
 ```ts title="nitro.config.ts"
 import { defineConfig } from "nitro";
@@ -462,8 +467,11 @@ export default defineConfig({
 
 ```ts title="server.ts"
 import { createApp } from "@sentry/junior";
+import { plugins } from "./plugins.ts";
 
-const app = await createApp();
+const app = await createApp({
+  plugins,
+});
 
 export default app;
 ```
@@ -488,8 +496,8 @@ When enabled plugins declare sandbox runtime dependencies, the scaffolded build 
 {
   "scripts": {
     "check": "junior check",
-    "dev": "vite dev",
-    "build": "junior snapshot create && vite build"
+    "dev": "nitro dev",
+    "build": "junior snapshot create && nitro build"
   }
 }
 ```

--- a/packages/junior/README.md
+++ b/packages/junior/README.md
@@ -10,6 +10,14 @@ pnpm add @sentry/junior hono @sentry/node
 
 ## Quick usage
 
+`plugins.ts`:
+
+```ts
+import { defineJuniorPlugins } from "@sentry/junior";
+
+export const plugins = defineJuniorPlugins([]);
+```
+
 `server.ts`:
 
 ```ts
@@ -17,8 +25,11 @@ import { initSentry } from "@sentry/junior/instrumentation";
 initSentry();
 
 import { createApp } from "@sentry/junior";
+import { plugins } from "./plugins.ts";
 
-const app = await createApp();
+const app = await createApp({
+  plugins,
+});
 
 export default app;
 ```
@@ -26,10 +37,10 @@ export default app;
 Run `junior init my-bot` to scaffold a complete project including `vercel.json` for Vercel deployment.
 
 Use `defineJuniorPlugins([...])` in a runtime-safe plugin module, then point
-`juniorNitro({ plugins: "./plugins" })` at that module. `createApp()` reads the
-same enabled set from Nitro's virtual module. Manifest-only packages use
-package-name strings; factories such as `githubPlugin()` register their
-manifest and in-process hooks together.
+`juniorNitro({ plugins: "./plugins" })` at that module and pass the same set to
+`createApp({ plugins })`. Manifest-only packages use package-name strings;
+factories such as `githubPlugin()` register their manifest and in-process hooks
+together.
 
 ## Full docs
 

--- a/packages/junior/src/cli/init.ts
+++ b/packages/junior/src/cli/init.ts
@@ -5,26 +5,17 @@ import { juniorVercelConfig } from "../vercel";
 function writeServerEntry(targetDir: string): void {
   fs.writeFileSync(
     path.join(targetDir, "server.ts"),
-    `import { initSentry } from "@sentry/junior/instrumentation";
+    `import { createApp } from "@sentry/junior";
+import { initSentry } from "@sentry/junior/instrumentation";
+import { plugins } from "./plugins.ts";
+
 initSentry();
 
-import { createApp } from "@sentry/junior";
-
-const app = await createApp();
+const app = await createApp({
+  plugins,
+});
 
 export default app;
-`,
-  );
-}
-
-function writeQueueConsumerEntry(targetDir: string): void {
-  const queueConsumerDir = path.join(targetDir, "api", "internal", "agent");
-  fs.mkdirSync(queueConsumerDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(queueConsumerDir, "continue.ts"),
-    `import app from "../../../server.ts";
-
-export const POST = (request: Request) => app.fetch(request);
 `,
   );
 }
@@ -64,19 +55,17 @@ export default defineConfig({
   );
 }
 
-function writeViteConfig(targetDir: string): void {
+function writeTsConfig(targetDir: string): void {
   fs.writeFileSync(
-    path.join(targetDir, "vite.config.ts"),
-    `import { defineConfig } from "vite";
-import { nitro } from "nitro/vite";
-
-export default defineConfig({
-  server: {
-    allowedHosts: true,
-  },
-  plugins: [nitro()],
-});
-`,
+    path.join(targetDir, "tsconfig.json"),
+    `${JSON.stringify(
+      {
+        extends: "nitro/tsconfig",
+        compilerOptions: {},
+      },
+      null,
+      2,
+    )}\n`,
   );
 }
 
@@ -111,7 +100,7 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install
       - run: pnpm check
       - run: pnpm build
 `,
@@ -147,21 +136,23 @@ export async function runInit(
     private: true,
     type: "module",
     scripts: {
-      dev: "vite dev",
+      dev: "nitro dev",
       check: "junior check",
-      build: "junior snapshot create && vite build",
+      build: "junior snapshot create && nitro build",
+      preview: "nitro preview",
+      typecheck: "tsc --noEmit",
     },
     dependencies: {
       "@sentry/junior": "latest",
       "@sentry/junior-memory": "latest",
       "@sentry/junior-maintenance": "latest",
-      hono: "^4.12.0",
+      hono: "^4.12.22",
     },
     devDependencies: {
-      jiti: "^2.6.1",
-      nitro: "3.0.260311-beta",
-      typescript: "^5.9.0",
-      vite: "^8.0.3",
+      "@types/node": "^25.9.1",
+      jiti: "^2.7.0",
+      nitro: "3.0.260522-beta",
+      typescript: "^6.0.3",
     },
   };
   fs.writeFileSync(
@@ -216,6 +207,8 @@ AI_EMBEDDING_MODEL=
 MEMORY_RECALL_MAX_VECTOR_DISTANCE=
 AI_VISION_MODEL=
 AI_WEB_SEARCH_MODEL=
+DATABASE_URL=
+JUNIOR_DATABASE_DRIVER=
 REDIS_URL=
 CRON_SECRET=
 SENTRY_DSN=
@@ -224,10 +217,9 @@ SENTRY_ORG_SLUG=
   );
 
   writeServerEntry(target);
-  writeQueueConsumerEntry(target);
   writePluginsFile(target);
   writeNitroConfig(target);
-  writeViteConfig(target);
+  writeTsConfig(target);
   writeVercelJson(target);
   writeGitHubWorkflow(target);
 

--- a/packages/junior/tests/unit/cli/init-cli.test.ts
+++ b/packages/junior/tests/unit/cli/init-cli.test.ts
@@ -6,11 +6,52 @@ import { runCheck } from "@/cli/check";
 import { runInit } from "@/cli/init";
 
 const tempRoots: string[] = [];
+const repoRoot = path.resolve(import.meta.dirname, "../../../../..");
+const examplePackageJsonPath = path.join(
+  repoRoot,
+  "apps",
+  "example",
+  "package.json",
+);
+
+function readJsonFile<T>(filePath: string): T {
+  return JSON.parse(fs.readFileSync(filePath, "utf8")) as T;
+}
 
 function makeTempDir(prefix: string): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   tempRoots.push(dir);
   return dir;
+}
+
+function normalizeText(source: string): string {
+  return source.trim().replace(/\n{3,}/g, "\n\n");
+}
+
+function removeExampleDashboardServerConfig(source: string): string {
+  return normalizeText(
+    source
+      .replace(
+        /import \{\n  exampleDashboardAuthRequired,\n  exampleDashboardMockConversations,\n\} from "\.\/dashboard\.ts";\n/,
+        "",
+      )
+      .replace(/  dashboard: \{[\s\S]*?  \},\n  plugins,/, "  plugins,")
+      .replace(/  configDefaults: \{[\s\S]*?  \},\n/, ""),
+  );
+}
+
+function removeExampleDashboardNitroConfig(source: string): string {
+  return normalizeText(
+    source
+      .replace(
+        /import \{\n  exampleDashboardAuthRequired,\n  exampleDashboardMockConversations,\n\} from "\.\/dashboard\.ts";\n/,
+        "",
+      )
+      .replace(
+        /      dashboard: \{[\s\S]*?      \},\n      plugins:/,
+        "      plugins:",
+      ),
+  );
 }
 
 afterEach(() => {
@@ -27,15 +68,12 @@ describe("init cli", () => {
 
     expect(fs.existsSync(path.join(target, "package.json"))).toBe(true);
     expect(fs.existsSync(path.join(target, "server.ts"))).toBe(true);
-    expect(
-      fs.existsSync(
-        path.join(target, "api", "internal", "agent", "continue.ts"),
-      ),
-    ).toBe(true);
+    expect(fs.existsSync(path.join(target, "api"))).toBe(false);
     expect(fs.existsSync(path.join(target, "vercel.json"))).toBe(true);
     expect(fs.existsSync(path.join(target, "nitro.config.ts"))).toBe(true);
     expect(fs.existsSync(path.join(target, "plugins.ts"))).toBe(true);
-    expect(fs.existsSync(path.join(target, "vite.config.ts"))).toBe(true);
+    expect(fs.existsSync(path.join(target, "vite.config.ts"))).toBe(false);
+    expect(fs.existsSync(path.join(target, "tsconfig.json"))).toBe(true);
     expect(fs.existsSync(path.join(target, "app", "SOUL.md"))).toBe(true);
     expect(fs.existsSync(path.join(target, "app", "WORLD.md"))).toBe(true);
     expect(fs.existsSync(path.join(target, "app", "DESCRIPTION.md"))).toBe(
@@ -51,10 +89,10 @@ describe("init cli", () => {
     );
     expect(workflow).toContain("pnpm check");
     expect(workflow).toContain("pnpm build");
-    expect(workflow).toContain("pnpm install --frozen-lockfile");
+    expect(workflow).toContain("pnpm install");
 
-    const vercelConfig = JSON.parse(
-      fs.readFileSync(path.join(target, "vercel.json"), "utf8"),
+    const vercelConfig = readJsonFile<Record<string, unknown>>(
+      path.join(target, "vercel.json"),
     );
     expect(vercelConfig.framework).toBe("nitro");
     expect(vercelConfig.buildCommand).toBe(
@@ -63,6 +101,17 @@ describe("init cli", () => {
     expect(vercelConfig.crons).toBeUndefined();
     expect(vercelConfig.functions).toBeUndefined();
 
+    const serverEntry = fs.readFileSync(path.join(target, "server.ts"), "utf8");
+    expect(serverEntry).toContain(
+      'import { initSentry } from "@sentry/junior/instrumentation";',
+    );
+    expect(serverEntry).toContain(
+      'import { createApp } from "@sentry/junior";',
+    );
+    expect(serverEntry).toContain('import { plugins } from "./plugins.ts";');
+    expect(serverEntry).toContain("createApp({");
+    expect(serverEntry).toContain("plugins,");
+
     const nitroConfig = fs.readFileSync(
       path.join(target, "nitro.config.ts"),
       "utf8",
@@ -70,8 +119,15 @@ describe("init cli", () => {
     expect(nitroConfig).toContain(
       'import { juniorNitro } from "@sentry/junior/nitro";',
     );
+    expect(nitroConfig).toContain('preset: "vercel"');
     expect(nitroConfig).toContain("juniorNitro({");
     expect(nitroConfig).toContain('plugins: "./plugins"');
+    expect(nitroConfig).toContain('"/**": { handler: "./server.ts" }');
+
+    const tsConfig = readJsonFile<Record<string, unknown>>(
+      path.join(target, "tsconfig.json"),
+    );
+    expect(tsConfig.extends).toBe("nitro/tsconfig");
 
     const pluginsFile = fs.readFileSync(
       path.join(target, "plugins.ts"),
@@ -87,18 +143,22 @@ describe("init cli", () => {
     expect(pluginsFile).toContain("createMemoryPlugin()");
     expect(pluginsFile).toContain('"@sentry/junior-maintenance"');
 
-    const pkg = JSON.parse(
-      fs.readFileSync(path.join(target, "package.json"), "utf8"),
-    );
+    const pkg = readJsonFile<{
+      dependencies: Record<string, string>;
+      devDependencies: Record<string, string>;
+      scripts: Record<string, string>;
+    }>(path.join(target, "package.json"));
     expect(pkg.dependencies["@sentry/junior"]).toBe("latest");
     expect(pkg.dependencies["@sentry/junior-memory"]).toBe("latest");
     expect(pkg.dependencies["@sentry/junior-maintenance"]).toBe("latest");
     expect(pkg.devDependencies.nitro).toBeDefined();
-    expect(pkg.devDependencies.vite).toBeDefined();
+    expect(pkg.devDependencies.vite).toBeUndefined();
     expect(pkg.devDependencies.vercel).toBeUndefined();
-    expect(pkg.scripts.dev).toBe("vite dev");
+    expect(pkg.scripts.dev).toBe("nitro dev");
     expect(pkg.scripts.check).toBe("junior check");
-    expect(pkg.scripts.build).toBe("junior snapshot create && vite build");
+    expect(pkg.scripts.build).toBe("junior snapshot create && nitro build");
+    expect(pkg.scripts.preview).toBe("nitro preview");
+    expect(pkg.scripts.typecheck).toBe("tsc --noEmit");
 
     const envExample = fs.readFileSync(
       path.join(target, ".env.example"),
@@ -106,6 +166,8 @@ describe("init cli", () => {
     );
     expect(envExample).toContain("CRON_SECRET=");
     expect(envExample).toContain("JUNIOR_SLASH_COMMAND=");
+    expect(envExample).toContain("DATABASE_URL=");
+    expect(envExample).toContain("JUNIOR_DATABASE_DRIVER=");
 
     const checkLines: string[] = [];
     await runCheck(target, {
@@ -114,6 +176,104 @@ describe("init cli", () => {
       error: (line) => checkLines.push(line),
     });
     expect(checkLines).toContain("✓ deployment config");
+  });
+
+  it("keeps the Nitro scaffold aligned with the example app", async () => {
+    const target = makeTempDir("junior-init-example-parity-");
+
+    await runInit(target, () => undefined);
+
+    const scaffoldPackage = readJsonFile<{
+      dependencies: Record<string, string>;
+      devDependencies: Record<string, string>;
+      scripts: Record<string, string>;
+    }>(path.join(target, "package.json"));
+    const examplePackage = readJsonFile<{
+      dependencies: Record<string, string>;
+      devDependencies: Record<string, string>;
+      scripts: Record<string, string>;
+    }>(examplePackageJsonPath);
+
+    const exampleCoreScriptNames = Object.keys(examplePackage.scripts)
+      .filter(
+        (name) =>
+          (name === "preview" || !name.startsWith("pre")) &&
+          !name.startsWith("post"),
+      )
+      .sort();
+    expect(Object.keys(scaffoldPackage.scripts).sort()).toEqual(
+      ["check", ...exampleCoreScriptNames].sort(),
+    );
+    expect(
+      Object.fromEntries(
+        exampleCoreScriptNames.map((name) => [
+          name,
+          scaffoldPackage.scripts[name],
+        ]),
+      ),
+    ).toEqual(
+      Object.fromEntries(
+        exampleCoreScriptNames.map((name) => [
+          name,
+          examplePackage.scripts[name],
+        ]),
+      ),
+    );
+
+    const scaffoldNonPluginDeps = Object.fromEntries(
+      Object.entries(scaffoldPackage.dependencies).filter(
+        ([name]) => !name.startsWith("@sentry/junior"),
+      ),
+    );
+    const exampleNonPluginDeps = Object.fromEntries(
+      Object.entries(examplePackage.dependencies).filter(
+        ([name]) => !name.startsWith("@sentry/junior"),
+      ),
+    );
+    expect(scaffoldNonPluginDeps).toEqual(exampleNonPluginDeps);
+    expect(scaffoldPackage.devDependencies).toEqual(
+      examplePackage.devDependencies,
+    );
+
+    const scaffoldVercelConfig = readJsonFile<Record<string, unknown>>(
+      path.join(target, "vercel.json"),
+    );
+    const exampleVercelConfig = readJsonFile<Record<string, unknown>>(
+      path.join(repoRoot, "apps", "example", "vercel.json"),
+    );
+    expect(scaffoldVercelConfig).toEqual(exampleVercelConfig);
+
+    const scaffoldNitroConfig = fs.readFileSync(
+      path.join(target, "nitro.config.ts"),
+      "utf8",
+    );
+    const exampleNitroConfig = fs.readFileSync(
+      path.join(repoRoot, "apps", "example", "nitro.config.ts"),
+      "utf8",
+    );
+    expect(normalizeText(scaffoldNitroConfig)).toEqual(
+      removeExampleDashboardNitroConfig(exampleNitroConfig),
+    );
+
+    const scaffoldServer = fs.readFileSync(
+      path.join(target, "server.ts"),
+      "utf8",
+    );
+    const exampleServer = fs.readFileSync(
+      path.join(repoRoot, "apps", "example", "server.ts"),
+      "utf8",
+    );
+    expect(normalizeText(scaffoldServer)).toEqual(
+      removeExampleDashboardServerConfig(exampleServer),
+    );
+
+    const scaffoldTsConfig = readJsonFile<Record<string, unknown>>(
+      path.join(target, "tsconfig.json"),
+    );
+    const exampleTsConfig = readJsonFile<Record<string, unknown>>(
+      path.join(repoRoot, "apps", "example", "tsconfig.json"),
+    );
+    expect(scaffoldTsConfig).toEqual(exampleTsConfig);
   });
 
   it("refuses to initialize a non-empty directory", async () => {


### PR DESCRIPTION
`junior init` now emits the same core Nitro app shape that `apps/example` exercises: direct `nitro dev`/`nitro build` scripts, explicit `plugins.ts` wiring into `createApp({ plugins })`, current Nitro-related dependency versions, and `tsconfig.json`. It no longer generates the stale Vite scaffold or top-level `/api/internal/agent/continue.ts` source, and the generated env/CI templates include the database variables and install flow a fresh app actually needs.

The init unit test now uses `apps/example` as a canary for core scripts, dependencies, `vercel.json`, Nitro config, server wiring, and TypeScript config so future drift fails deterministically. The setup docs and README snippets now match that generated shape.

Validation:
- `pnpm --filter @sentry/junior exec vitest run tests/unit/cli/init-cli.test.ts`
- `pnpm docs:check`
- Garfield review pass
