### PR TITLE
ref(chat): Return agent-run outcomes from executor

### DIFF
--- a/packages/junior/src/chat/agent-dispatch/runner.ts
+++ b/packages/junior/src/chat/agent-dispatch/runner.ts
@@ -10,7 +10,9 @@ import { botConfig } from "@/chat/config";
 import {
   generateAssistantReply as generateAssistantReplyImpl,
   type AssistantReply,
+  type AssistantReplyRequestContext,
 } from "@/chat/respond";
+import type { AgentRunOutcome } from "@/chat/runtime/agent-run-outcome";
 import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress/tracing";
 import { logException } from "@/chat/logging";
 import {
@@ -46,7 +48,6 @@ import { persistWithRetry } from "@/chat/services/persist-retry";
 import { AuthorizationFlowDisabledError } from "@/chat/services/auth-pause";
 import { PluginCredentialFailureError } from "@/chat/services/plugin-auth-orchestration";
 import { scheduleSessionCompletedPluginTasks } from "@/chat/plugins/task-runner";
-import { isRetryableTurnError } from "@/chat/runtime/turn";
 import { scheduleDispatchCallback } from "./signing";
 import {
   getDispatchConversationId,
@@ -63,7 +64,10 @@ import type { DispatchCallback, DispatchRecord } from "./types";
 const DISPATCH_SLICE_LEASE_MS = 5 * 60 * 1000;
 
 export interface AgentDispatchRunnerDeps {
-  generateAssistantReply?: typeof generateAssistantReplyImpl;
+  generateAssistantReply?: (
+    messageText: string,
+    context: AssistantReplyRequestContext,
+  ) => Promise<AgentRunOutcome>;
   scheduleCallback?: typeof scheduleDispatchCallback;
   scheduleSessionCompletedPluginTasks?: typeof scheduleSessionCompletedPluginTasks;
   tracePropagation?: SandboxEgressTracePropagationConfig;
@@ -296,7 +300,7 @@ export async function runAgentDispatchSlice(
       excludeMessageId: userMessageId,
     });
 
-    let reply = await generateAssistantReply(dispatch.input, {
+    const outcome = await generateAssistantReply(dispatch.input, {
       authorizationFlowMode: "disabled",
       credentialContext: {
         actor: dispatch.actor,
@@ -353,6 +357,33 @@ export async function runAgentDispatchSlice(
         });
       },
     });
+    if (outcome.status === "awaiting_auth") {
+      await markDispatch({
+        dispatch,
+        status: "blocked",
+        errorMessage:
+          "Dispatch requires authorization from an interactive user turn.",
+      });
+      return;
+    }
+    if (outcome.status === "timed_out" || outcome.status === "yielded") {
+      if (typeof outcome.version === "number") {
+        const awaiting = await markDispatch({
+          dispatch,
+          status: "awaiting_resume",
+        });
+        await scheduleCallback({
+          id: awaiting.id,
+          expectedVersion: awaiting.version,
+        });
+        return;
+      }
+      throw new Error(
+        `Dispatch continuation ended with ${outcome.status} without a session record version`,
+      );
+    }
+
+    let reply = outcome.reply;
 
     const failure =
       reply.diagnostics.outcome === "success"
@@ -489,33 +520,6 @@ export async function runAgentDispatchSlice(
       });
       return;
     }
-    if (
-      isRetryableTurnError(error, "mcp_auth_resume") ||
-      isRetryableTurnError(error, "plugin_auth_resume")
-    ) {
-      await markDispatch({
-        dispatch,
-        status: "blocked",
-        errorMessage:
-          "Dispatch requires authorization from an interactive user turn.",
-      });
-      return;
-    }
-    if (isRetryableTurnError(error, "agent_continue")) {
-      const version = error.metadata?.version;
-      if (typeof version === "number") {
-        const awaiting = await markDispatch({
-          dispatch,
-          status: "awaiting_resume",
-        });
-        await scheduleCallback({
-          id: awaiting.id,
-          expectedVersion: awaiting.version,
-        });
-        return;
-      }
-    }
-
     logException(
       error,
       "agent_dispatch_run_failed",

--- a/packages/junior/src/chat/agent-dispatch/runner.ts
+++ b/packages/junior/src/chat/agent-dispatch/runner.ts
@@ -366,21 +366,16 @@ export async function runAgentDispatchSlice(
       });
       return;
     }
-    if (outcome.status === "timed_out" || outcome.status === "yielded") {
-      if (typeof outcome.version === "number") {
-        const awaiting = await markDispatch({
-          dispatch,
-          status: "awaiting_resume",
-        });
-        await scheduleCallback({
-          id: awaiting.id,
-          expectedVersion: awaiting.version,
-        });
-        return;
-      }
-      throw new Error(
-        `Dispatch continuation ended with ${outcome.status} without a session record version`,
-      );
+    if (outcome.status === "suspended") {
+      const awaiting = await markDispatch({
+        dispatch,
+        status: "awaiting_resume",
+      });
+      await scheduleCallback({
+        id: awaiting.id,
+        expectedVersion: awaiting.version,
+      });
+      return;
     }
 
     let reply = outcome.reply;

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -9,7 +9,9 @@
 import {
   generateAssistantReply as generateAssistantReplyImpl,
   type AssistantReply,
+  type AssistantReplyRequestContext,
 } from "@/chat/respond";
+import type { AgentRunOutcome } from "@/chat/runtime/agent-run-outcome";
 import {
   createLocalSource,
   localDestinationSchema,
@@ -67,7 +69,10 @@ export type LocalToolResult = ToolExecutionReport;
 
 export interface LocalAgentTurnDeps {
   deliverReply: (reply: LocalAgentReply) => Promise<void>;
-  generateAssistantReply?: typeof generateAssistantReplyImpl;
+  generateAssistantReply?: (
+    messageText: string,
+    context: AssistantReplyRequestContext,
+  ) => Promise<AgentRunOutcome>;
   now?: () => number;
   onStatus?: (status: string) => void | Promise<void>;
   onTextDelta?: (deltaText: string) => void | Promise<void>;
@@ -227,7 +232,7 @@ export async function runLocalAgentTurn(
       fallback: conversation.piMessages,
     });
     piMessagesBeforeRun = piMessages;
-    reply = await generateAssistantReply(text, {
+    const outcome = await generateAssistantReply(text, {
       authorizationFlowMode: "disabled",
       conversationContext: buildConversationContext(conversation, {
         excludeMessageId: userMessageId,
@@ -285,6 +290,14 @@ export async function runLocalAgentTurn(
         await deps.onToolResult?.(result);
       },
     });
+    if (
+      outcome.status === "awaiting_auth" ||
+      outcome.status === "timed_out" ||
+      outcome.status === "yielded"
+    ) {
+      throw new Error(`Local agent run ended with ${outcome.status}`);
+    }
+    reply = outcome.reply;
 
     // Failed turns deliver the sanitized fallback (or genuine partial model
     // text), never raw exception strings and never silence.

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -290,11 +290,7 @@ export async function runLocalAgentTurn(
         await deps.onToolResult?.(result);
       },
     });
-    if (
-      outcome.status === "awaiting_auth" ||
-      outcome.status === "timed_out" ||
-      outcome.status === "yielded"
-    ) {
+    if (outcome.status !== "completed") {
       throw new Error(`Local agent run ended with ${outcome.status}`);
     }
     reply = outcome.reply;

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -100,11 +100,14 @@ import {
 import { mergeArtifactsState } from "@/chat/runtime/thread-state";
 import {
   CooperativeTurnYieldError,
-  RetryableTurnError,
   TurnInputCommitLostError,
   isTurnInputCommitLostError,
-  isRetryableTurnError,
 } from "@/chat/runtime/turn";
+import {
+  completedAgentRun,
+  failedAgentRun,
+  type AgentRunOutcome,
+} from "@/chat/runtime/agent-run-outcome";
 import {
   buildUserTurnText,
   encodeNonImageAttachmentForPrompt,
@@ -642,7 +645,7 @@ function legacyTextPartMatchesCurrentText(
 export async function generateAssistantReply(
   messageText: string,
   context: AssistantReplyRequestContext,
-): Promise<AssistantReply> {
+): Promise<AgentRunOutcome> {
   const conversationPrivacy = resolveConversationPrivacy({
     channelId: context.correlation?.channelId,
     conversationId:
@@ -666,7 +669,7 @@ async function generateAssistantReplyInPrivacyContext(
   messageText: string,
   context: AssistantReplyRequestContext,
   conversationPrivacy: ConversationPrivacy | undefined,
-): Promise<AssistantReply> {
+): Promise<AgentRunOutcome> {
   if (!context.destination) {
     throw new TypeError("Assistant reply generation requires a destination");
   }
@@ -1875,25 +1878,27 @@ async function generateAssistantReplyInPrivacyContext(
     }
 
     // ── Build turn result ────────────────────────────────────────────
-    return buildTurnResult({
-      newMessages,
-      userInput,
-      replyFiles,
-      artifactStatePatch,
-      toolCalls,
-      sandboxId: currentSandboxExecutor.getSandboxId(),
-      sandboxDependencyProfileHash:
-        currentSandboxExecutor.getDependencyProfileHash(),
-      piMessages: [...agent.state.messages],
-      durationMs: Date.now() - replyStartedAtMs,
-      generatedFileCount: generatedFiles.length,
-      shouldTrace,
-      spanContext,
-      usage: turnUsage,
-      thinkingSelection,
-      correlation: context.correlation,
-      assistantUserName: botConfig.userName,
-    });
+    return completedAgentRun(
+      buildTurnResult({
+        newMessages,
+        userInput,
+        replyFiles,
+        artifactStatePatch,
+        toolCalls,
+        sandboxId: currentSandboxExecutor.getSandboxId(),
+        sandboxDependencyProfileHash:
+          currentSandboxExecutor.getDependencyProfileHash(),
+        piMessages: [...agent.state.messages],
+        durationMs: Date.now() - replyStartedAtMs,
+        generatedFileCount: generatedFiles.length,
+        shouldTrace,
+        spanContext,
+        usage: turnUsage,
+        thinkingSelection,
+        correlation: context.correlation,
+        assistantUserName: botConfig.userName,
+      }),
+    );
   } catch (error) {
     if (
       cooperativeYieldError &&
@@ -1926,7 +1931,13 @@ async function generateAssistantReplyInPrivacyContext(
           `Failed to persist cooperative yield continuation for conversation=${timeoutResumeConversationId} session=${timeoutResumeSessionId}`,
         );
       }
-      throw error;
+      return {
+        status: "yielded",
+        conversationId: timeoutResumeConversationId,
+        sessionId: timeoutResumeSessionId,
+        sliceId: sessionRecord.sliceId,
+        version: sessionRecord.version,
+      };
     }
 
     if (timedOut && timeoutResumeConversationId && timeoutResumeSessionId) {
@@ -1956,16 +1967,13 @@ async function generateAssistantReplyInPrivacyContext(
         );
       }
       if (sessionRecord.state === "awaiting_resume") {
-        throw new RetryableTurnError(
-          "agent_continue",
-          `conversation=${timeoutResumeConversationId} session=${timeoutResumeSessionId} slice=${sessionRecord.sliceId} version=${sessionRecord.version}`,
-          {
-            conversationId: timeoutResumeConversationId,
-            sessionId: timeoutResumeSessionId,
-            sliceId: sessionRecord.sliceId,
-            version: sessionRecord.version,
-          },
-        );
+        return {
+          status: "timed_out",
+          conversationId: timeoutResumeConversationId,
+          sessionId: timeoutResumeSessionId,
+          sliceId: sessionRecord.sliceId,
+          version: sessionRecord.version,
+        };
       }
       throw new Error(
         sessionRecord.errorMessage ??
@@ -2003,28 +2011,22 @@ async function generateAssistantReplyInPrivacyContext(
         ...(surface ? { surface } : {}),
       });
       if (sessionRecord) {
-        throw new RetryableTurnError(
-          error.kind === "plugin" ? "plugin_auth_resume" : "mcp_auth_resume",
-          `conversation=${timeoutResumeConversationId} session=${timeoutResumeSessionId} slice=${sessionRecord.sliceId}`,
-          {
-            authDisposition: error.disposition,
-            authDurationMs: Date.now() - replyStartedAtMs,
-            authKind: error.kind,
-            authProvider: error.provider,
-            authProviderDisplayName: error.providerDisplayName,
-            authThinkingLevel: thinkingSelection?.thinkingLevel,
-            authUsage: turnUsage,
-            conversationId: timeoutResumeConversationId,
-            sessionId: timeoutResumeSessionId,
-            sliceId: sessionRecord.sliceId,
-          },
-        );
+        return {
+          status: "awaiting_auth",
+          authDisposition: error.disposition,
+          authDurationMs: Date.now() - replyStartedAtMs,
+          authKind: error.kind,
+          authProvider: error.provider,
+          authProviderDisplayName: error.providerDisplayName,
+          authThinkingLevel: thinkingSelection?.thinkingLevel,
+          authUsage: turnUsage,
+          conversationId: timeoutResumeConversationId,
+          sessionId: timeoutResumeSessionId,
+          sliceId: sessionRecord.sliceId,
+        };
       }
     }
 
-    if (isRetryableTurnError(error)) {
-      throw error;
-    }
     if (isProviderRetryError(error)) {
       throw error;
     }
@@ -2057,7 +2059,7 @@ async function generateAssistantReplyInPrivacyContext(
     // Raw exception text is diagnostics-only; the failure-response service
     // owns the sanitized user-visible fallback for empty provider errors.
     const message = error instanceof Error ? error.message : String(error);
-    return {
+    return failedAgentRun({
       text: "",
       ...getSandboxMetadata(),
       diagnostics: {
@@ -2077,7 +2079,7 @@ async function generateAssistantReplyInPrivacyContext(
         errorMessage: message,
         providerError: error,
       },
-    };
+    });
   } finally {
     try {
       await mcpToolManager?.close();

--- a/packages/junior/src/chat/respond.ts
+++ b/packages/junior/src/chat/respond.ts
@@ -103,11 +103,7 @@ import {
   TurnInputCommitLostError,
   isTurnInputCommitLostError,
 } from "@/chat/runtime/turn";
-import {
-  completedAgentRun,
-  failedAgentRun,
-  type AgentRunOutcome,
-} from "@/chat/runtime/agent-run-outcome";
+import type { AgentRunOutcome } from "@/chat/runtime/agent-run-outcome";
 import {
   buildUserTurnText,
   encodeNonImageAttachmentForPrompt,
@@ -1878,8 +1874,9 @@ async function generateAssistantReplyInPrivacyContext(
     }
 
     // ── Build turn result ────────────────────────────────────────────
-    return completedAgentRun(
-      buildTurnResult({
+    return {
+      status: "completed",
+      reply: buildTurnResult({
         newMessages,
         userInput,
         replyFiles,
@@ -1898,7 +1895,7 @@ async function generateAssistantReplyInPrivacyContext(
         correlation: context.correlation,
         assistantUserName: botConfig.userName,
       }),
-    );
+    };
   } catch (error) {
     if (
       cooperativeYieldError &&
@@ -1931,13 +1928,7 @@ async function generateAssistantReplyInPrivacyContext(
           `Failed to persist cooperative yield continuation for conversation=${timeoutResumeConversationId} session=${timeoutResumeSessionId}`,
         );
       }
-      return {
-        status: "yielded",
-        conversationId: timeoutResumeConversationId,
-        sessionId: timeoutResumeSessionId,
-        sliceId: sessionRecord.sliceId,
-        version: sessionRecord.version,
-      };
+      return { status: "suspended", resumeVersion: sessionRecord.version };
     }
 
     if (timedOut && timeoutResumeConversationId && timeoutResumeSessionId) {
@@ -1967,13 +1958,7 @@ async function generateAssistantReplyInPrivacyContext(
         );
       }
       if (sessionRecord.state === "awaiting_resume") {
-        return {
-          status: "timed_out",
-          conversationId: timeoutResumeConversationId,
-          sessionId: timeoutResumeSessionId,
-          sliceId: sessionRecord.sliceId,
-          version: sessionRecord.version,
-        };
+        return { status: "suspended", resumeVersion: sessionRecord.version };
       }
       throw new Error(
         sessionRecord.errorMessage ??
@@ -2013,16 +1998,7 @@ async function generateAssistantReplyInPrivacyContext(
       if (sessionRecord) {
         return {
           status: "awaiting_auth",
-          authDisposition: error.disposition,
-          authDurationMs: Date.now() - replyStartedAtMs,
-          authKind: error.kind,
-          authProvider: error.provider,
-          authProviderDisplayName: error.providerDisplayName,
-          authThinkingLevel: thinkingSelection?.thinkingLevel,
-          authUsage: turnUsage,
-          conversationId: timeoutResumeConversationId,
-          sessionId: timeoutResumeSessionId,
-          sliceId: sessionRecord.sliceId,
+          providerDisplayName: error.providerDisplayName,
         };
       }
     }
@@ -2059,27 +2035,30 @@ async function generateAssistantReplyInPrivacyContext(
     // Raw exception text is diagnostics-only; the failure-response service
     // owns the sanitized user-visible fallback for empty provider errors.
     const message = error instanceof Error ? error.message : String(error);
-    return failedAgentRun({
-      text: "",
-      ...getSandboxMetadata(),
-      diagnostics: {
-        outcome: "provider_error",
-        modelId: botConfig.modelId,
-        assistantMessageCount: 0,
-        ...(thinkingSelection
-          ? {
-              thinkingLevel: thinkingSelection.thinkingLevel,
-            }
-          : {}),
-        toolCalls: [],
-        toolResultCount: 0,
-        toolErrorCount: 0,
-        usedPrimaryText: false,
-        durationMs: Date.now() - replyStartedAtMs,
-        errorMessage: message,
-        providerError: error,
+    return {
+      status: "completed",
+      reply: {
+        text: "",
+        ...getSandboxMetadata(),
+        diagnostics: {
+          outcome: "provider_error",
+          modelId: botConfig.modelId,
+          assistantMessageCount: 0,
+          ...(thinkingSelection
+            ? {
+                thinkingLevel: thinkingSelection.thinkingLevel,
+              }
+            : {}),
+          toolCalls: [],
+          toolResultCount: 0,
+          toolErrorCount: 0,
+          usedPrimaryText: false,
+          durationMs: Date.now() - replyStartedAtMs,
+          errorMessage: message,
+          providerError: error,
+        },
       },
-    });
+    };
   } finally {
     try {
       await mcpToolManager?.close();

--- a/packages/junior/src/chat/runtime/agent-continue-runner.ts
+++ b/packages/junior/src/chat/runtime/agent-continue-runner.ts
@@ -41,7 +41,7 @@ import {
   updateConversationStats,
 } from "@/chat/services/conversation-memory";
 import { coerceThreadArtifactsState } from "@/chat/state/artifacts";
-import { isRetryableTurnError, markTurnFailed } from "@/chat/runtime/turn";
+import { markTurnFailed } from "@/chat/runtime/turn";
 import {
   getAwaitingAgentContinueRequest,
   scheduleAgentContinue as defaultScheduleAgentContinue,
@@ -428,22 +428,12 @@ export async function continueSlackAgentRun(
               "Continued agent run parked for auth",
             );
           },
-          onTimeoutPause: async (error: unknown) => {
-            if (!isRetryableTurnError(error, "agent_continue")) {
-              throw error;
-            }
-            const version = error.metadata?.version;
-            if (typeof version !== "number") {
-              throw new Error(
-                "Agent continuation did not include a session record version",
-              );
-            }
-
+          onTimeoutPause: async ({ resumeVersion }) => {
             await scheduleAgentContinue({
               conversationId: payload.conversationId,
               destination: payload.destination,
               sessionId: payload.sessionId,
-              expectedVersion: version,
+              expectedVersion: resumeVersion,
             });
           },
         };

--- a/packages/junior/src/chat/runtime/agent-run-outcome.ts
+++ b/packages/junior/src/chat/runtime/agent-run-outcome.ts
@@ -1,0 +1,83 @@
+import type { AssistantReply } from "@/chat/services/turn-result";
+import type {
+  AuthorizationPauseDisposition,
+  AuthorizationPauseKind,
+} from "@/chat/services/auth-pause";
+import type { TurnThinkingSelection } from "@/chat/services/turn-thinking-level";
+import type { AgentTurnUsage } from "@/chat/usage";
+import {
+  RetryableTurnError,
+  type AuthResumeRetryableTurnError,
+} from "@/chat/runtime/turn";
+
+export interface AgentRunContinuationIds {
+  conversationId: string;
+  sessionId: string;
+  sliceId: number;
+  version?: number;
+}
+
+export interface AgentRunAuthPauseMetadata extends AgentRunContinuationIds {
+  authDisposition: AuthorizationPauseDisposition;
+  authDurationMs: number;
+  authKind: AuthorizationPauseKind;
+  authProvider: string;
+  authProviderDisplayName: string;
+  authThinkingLevel?: TurnThinkingSelection["thinkingLevel"];
+  authUsage?: AgentTurnUsage;
+}
+
+export type AgentRunOutcome =
+  | { status: "completed"; reply: AssistantReply }
+  | { status: "failed"; reply: AssistantReply }
+  | ({ status: "yielded" } & AgentRunContinuationIds)
+  | ({ status: "timed_out" } & AgentRunContinuationIds)
+  | ({ status: "awaiting_auth" } & Omit<AgentRunAuthPauseMetadata, "version">);
+
+/** Return a successful final reply as an agent-run outcome. */
+export function completedAgentRun(reply: AssistantReply): AgentRunOutcome {
+  return { status: "completed", reply };
+}
+
+/** Return a terminal provider-failure reply as an agent-run outcome. */
+export function failedAgentRun(reply: AssistantReply): AgentRunOutcome {
+  return { status: "failed", reply };
+}
+
+/** Recreate the historical timeout continuation error at outer boundaries. */
+export function retryableTurnErrorFromTimedOutAgentRun(
+  outcome: Extract<AgentRunOutcome, { status: "timed_out" }>,
+): RetryableTurnError {
+  return new RetryableTurnError(
+    "agent_continue",
+    `conversation=${outcome.conversationId} session=${outcome.sessionId} slice=${outcome.sliceId} version=${outcome.version}`,
+    {
+      conversationId: outcome.conversationId,
+      sessionId: outcome.sessionId,
+      sliceId: outcome.sliceId,
+      version: outcome.version,
+    },
+  );
+}
+
+/** Recreate the historical auth-pause error for callback APIs not yet migrated. */
+export function retryableTurnErrorFromAuthAgentRun(
+  outcome: Extract<AgentRunOutcome, { status: "awaiting_auth" }>,
+): AuthResumeRetryableTurnError {
+  return new RetryableTurnError(
+    outcome.authKind === "plugin" ? "plugin_auth_resume" : "mcp_auth_resume",
+    `conversation=${outcome.conversationId} session=${outcome.sessionId} slice=${outcome.sliceId}`,
+    {
+      authDisposition: outcome.authDisposition,
+      authDurationMs: outcome.authDurationMs,
+      authKind: outcome.authKind,
+      authProvider: outcome.authProvider,
+      authProviderDisplayName: outcome.authProviderDisplayName,
+      authThinkingLevel: outcome.authThinkingLevel,
+      authUsage: outcome.authUsage,
+      conversationId: outcome.conversationId,
+      sessionId: outcome.sessionId,
+      sliceId: outcome.sliceId,
+    },
+  ) as AuthResumeRetryableTurnError;
+}

--- a/packages/junior/src/chat/runtime/agent-run-outcome.ts
+++ b/packages/junior/src/chat/runtime/agent-run-outcome.ts
@@ -1,83 +1,19 @@
 import type { AssistantReply } from "@/chat/services/turn-result";
-import type {
-  AuthorizationPauseDisposition,
-  AuthorizationPauseKind,
-} from "@/chat/services/auth-pause";
-import type { TurnThinkingSelection } from "@/chat/services/turn-thinking-level";
-import type { AgentTurnUsage } from "@/chat/usage";
-import {
-  RetryableTurnError,
-  type AuthResumeRetryableTurnError,
-} from "@/chat/runtime/turn";
 
-export interface AgentRunContinuationIds {
-  conversationId: string;
-  sessionId: string;
-  sliceId: number;
-  version?: number;
-}
-
-export interface AgentRunAuthPauseMetadata extends AgentRunContinuationIds {
-  authDisposition: AuthorizationPauseDisposition;
-  authDurationMs: number;
-  authKind: AuthorizationPauseKind;
-  authProvider: string;
-  authProviderDisplayName: string;
-  authThinkingLevel?: TurnThinkingSelection["thinkingLevel"];
-  authUsage?: AgentTurnUsage;
-}
-
+/**
+ * How an agent run ended. `completed` carries the terminal reply (success or
+ * failure — `reply.diagnostics` distinguishes them). `suspended` means the run
+ * persisted an awaiting_resume session record and stopped at a safe boundary;
+ * the caller resumes it by scheduling a continuation against `resumeVersion`,
+ * the session record's optimistic-concurrency version. `awaiting_auth` means
+ * the run parked for user authorization.
+ */
 export type AgentRunOutcome =
   | { status: "completed"; reply: AssistantReply }
-  | { status: "failed"; reply: AssistantReply }
-  | ({ status: "yielded" } & AgentRunContinuationIds)
-  | ({ status: "timed_out" } & AgentRunContinuationIds)
-  | ({ status: "awaiting_auth" } & Omit<AgentRunAuthPauseMetadata, "version">);
+  | { status: "suspended"; resumeVersion: number }
+  | { status: "awaiting_auth"; providerDisplayName: string };
 
-/** Return a successful final reply as an agent-run outcome. */
+/** Wrap a terminal reply (successful or failed per its diagnostics) as an outcome. */
 export function completedAgentRun(reply: AssistantReply): AgentRunOutcome {
   return { status: "completed", reply };
-}
-
-/** Return a terminal provider-failure reply as an agent-run outcome. */
-export function failedAgentRun(reply: AssistantReply): AgentRunOutcome {
-  return { status: "failed", reply };
-}
-
-/** Recreate the historical timeout continuation error at outer boundaries. */
-export function retryableTurnErrorFromTimedOutAgentRun(
-  outcome: Extract<AgentRunOutcome, { status: "timed_out" }>,
-): RetryableTurnError {
-  return new RetryableTurnError(
-    "agent_continue",
-    `conversation=${outcome.conversationId} session=${outcome.sessionId} slice=${outcome.sliceId} version=${outcome.version}`,
-    {
-      conversationId: outcome.conversationId,
-      sessionId: outcome.sessionId,
-      sliceId: outcome.sliceId,
-      version: outcome.version,
-    },
-  );
-}
-
-/** Recreate the historical auth-pause error for callback APIs not yet migrated. */
-export function retryableTurnErrorFromAuthAgentRun(
-  outcome: Extract<AgentRunOutcome, { status: "awaiting_auth" }>,
-): AuthResumeRetryableTurnError {
-  return new RetryableTurnError(
-    outcome.authKind === "plugin" ? "plugin_auth_resume" : "mcp_auth_resume",
-    `conversation=${outcome.conversationId} session=${outcome.sessionId} slice=${outcome.sliceId}`,
-    {
-      authDisposition: outcome.authDisposition,
-      authDurationMs: outcome.authDurationMs,
-      authKind: outcome.authKind,
-      authProvider: outcome.authProvider,
-      authProviderDisplayName: outcome.authProviderDisplayName,
-      authThinkingLevel: outcome.authThinkingLevel,
-      authUsage: outcome.authUsage,
-      conversationId: outcome.conversationId,
-      sessionId: outcome.sessionId,
-      sliceId: outcome.sliceId,
-    },
-  ) as AuthResumeRetryableTurnError;
 }

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -34,10 +34,7 @@ import {
   type AssistantReplyRequestContext,
   type ReplySteeringMessage,
 } from "@/chat/respond";
-import {
-  retryableTurnErrorFromTimedOutAgentRun,
-  type AgentRunOutcome,
-} from "@/chat/runtime/agent-run-outcome";
+import type { AgentRunOutcome } from "@/chat/runtime/agent-run-outcome";
 import type { CredentialContext } from "@/chat/credentials/context";
 import { shouldEmitDevAgentTrace } from "@/chat/runtime/dev-agent-trace";
 import {
@@ -912,7 +909,6 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
         let finalReplyDelivered = false;
         let latestArtifacts = preparedState.artifacts;
         let assistantTitleArtifacts: Partial<ThreadArtifactsState> = {};
-        let agentContinuePropagationError: unknown;
         let agentContinueScheduleError: unknown;
         const hasVisibleSlackDelivery = (post: {
           files?: unknown[];
@@ -1115,13 +1111,9 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               shouldYield: options.shouldYield,
             },
           );
-          if (outcome.status === "yielded") {
-            shouldPersistFailureState = false;
-            throw new CooperativeTurnYieldError();
-          }
           if (outcome.status === "awaiting_auth") {
             if (!requester) {
-              const text = `I could not act on this subscribed event because ${outcome.authProviderDisplayName} needs user authorization. Ask me in this thread to connect ${outcome.authProviderDisplayName} before retrying.`;
+              const text = `I could not act on this subscribed event because ${outcome.providerDisplayName} needs user authorization. Ask me in this thread to connect ${outcome.providerDisplayName} before retrying.`;
               await postThreadReply(
                 buildSlackOutputMessage(text),
                 "thread_reply",
@@ -1160,10 +1152,10 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               shouldPersistFailureState = false;
               return;
             }
-            await postAuthPauseNotice(outcome.authProviderDisplayName);
+            await postAuthPauseNotice(outcome.providerDisplayName);
             completeAuthPauseTurn({
               conversation: preparedState.conversation,
-              sessionId: outcome.sessionId,
+              sessionId: turnId,
             });
             await persistThreadState(thread, {
               conversation: preparedState.conversation,
@@ -1172,42 +1164,44 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             shouldPersistFailureState = false;
             return;
           }
-          if (outcome.status === "timed_out") {
-            if (typeof outcome.version === "number" && destination) {
-              try {
-                await deps.services.scheduleAgentContinue({
-                  conversationId: outcome.conversationId,
-                  destination,
-                  sessionId: outcome.sessionId,
-                  expectedVersion: outcome.version,
-                });
-                shouldPersistFailureState = false;
-              } catch (scheduleError) {
-                logException(
-                  scheduleError,
-                  "agent_continue_schedule_failed",
-                  turnTraceContext,
-                  {
-                    ...(messageTs ? { "messaging.message.id": messageTs } : {}),
-                    "app.ai.resume_session_version": outcome.version,
-                  },
-                  "Failed to schedule agent continuation",
-                );
-                shouldPersistFailureState = true;
-                agentContinueScheduleError = scheduleError;
-                throw scheduleError;
-              }
-              return;
+          if (outcome.status === "suspended") {
+            // A cooperative yield only occurs when this caller's own
+            // shouldYield() fired, so the predicate — not the outcome —
+            // decides the resume route: hand the lease back to the queue
+            // worker, or schedule a direct continuation.
+            if (options.shouldYield?.()) {
+              shouldPersistFailureState = false;
+              throw new CooperativeTurnYieldError();
             }
-            logWarn(
-              "agent_continue_metadata_missing",
-              turnTraceContext,
-              messageTs ? { "messaging.message.id": messageTs } : {},
-              "Agent continuation could not be scheduled because retry metadata was incomplete",
-            );
-            agentContinuePropagationError =
-              retryableTurnErrorFromTimedOutAgentRun(outcome);
-            throw agentContinuePropagationError;
+            if (!destination || !conversationId) {
+              throw new Error(
+                "Agent continuation requires a destination and conversation id",
+              );
+            }
+            try {
+              await deps.services.scheduleAgentContinue({
+                conversationId,
+                destination,
+                sessionId: turnId,
+                expectedVersion: outcome.resumeVersion,
+              });
+              shouldPersistFailureState = false;
+            } catch (scheduleError) {
+              logException(
+                scheduleError,
+                "agent_continue_schedule_failed",
+                turnTraceContext,
+                {
+                  ...(messageTs ? { "messaging.message.id": messageTs } : {}),
+                  "app.ai.resume_session_version": outcome.resumeVersion,
+                },
+                "Failed to schedule agent continuation",
+              );
+              shouldPersistFailureState = true;
+              agentContinueScheduleError = scheduleError;
+              throw scheduleError;
+            }
+            return;
           }
 
           let reply = outcome.reply;
@@ -1446,10 +1440,6 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             throw error;
           }
           if (error === agentContinueScheduleError) {
-            shouldPersistFailureState = true;
-            throw error;
-          }
-          if (error === agentContinuePropagationError) {
             shouldPersistFailureState = true;
             throw error;
           }

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -31,9 +31,13 @@ import { buildSlackOutputMessage } from "@/chat/slack/output";
 import { getSlackErrorObservabilityAttributes } from "@/chat/slack/errors";
 import {
   buildSteeringPiMessage,
-  generateAssistantReply as generateAssistantReplyImpl,
+  type AssistantReplyRequestContext,
   type ReplySteeringMessage,
 } from "@/chat/respond";
+import {
+  retryableTurnErrorFromTimedOutAgentRun,
+  type AgentRunOutcome,
+} from "@/chat/runtime/agent-run-outcome";
 import type { CredentialContext } from "@/chat/credentials/context";
 import { shouldEmitDevAgentTrace } from "@/chat/runtime/dev-agent-trace";
 import {
@@ -94,9 +98,7 @@ import {
 import { ensureSlackMessageActorIdentity } from "@/chat/services/message-actor-identity";
 import type { AgentContinueRequest } from "@/chat/services/agent-continue";
 import {
-  isAuthResumeRetryableTurnError,
-  isCooperativeTurnYieldError,
-  isRetryableTurnError,
+  CooperativeTurnYieldError,
   TurnInputDeferredError,
 } from "@/chat/runtime/turn";
 import { buildDeterministicTurnId } from "@/chat/runtime/turn";
@@ -279,7 +281,10 @@ async function loadPiMessagesForTurn(args: {
 
 export interface ReplyExecutorServices {
   contextCompactor: ContextCompactor;
-  generateAssistantReply: typeof generateAssistantReplyImpl;
+  generateAssistantReply: (
+    messageText: string,
+    context: AssistantReplyRequestContext,
+  ) => Promise<AgentRunOutcome>;
   generateThreadTitle: ConversationMemoryService["generateThreadTitle"];
   getAwaitingAgentContinueRequest: (args: {
     conversationId: string;
@@ -907,6 +912,8 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
         let finalReplyDelivered = false;
         let latestArtifacts = preparedState.artifacts;
         let assistantTitleArtifacts: Partial<ThreadArtifactsState> = {};
+        let agentContinuePropagationError: unknown;
+        let agentContinueScheduleError: unknown;
         const hasVisibleSlackDelivery = (post: {
           files?: unknown[];
           text: string;
@@ -1036,7 +1043,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                 );
               }
             : undefined;
-          let reply = await deps.services.generateAssistantReply(
+          const outcome = await deps.services.generateAssistantReply(
             effectiveUserText,
             {
               credentialContext,
@@ -1108,6 +1115,102 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               shouldYield: options.shouldYield,
             },
           );
+          if (outcome.status === "yielded") {
+            shouldPersistFailureState = false;
+            throw new CooperativeTurnYieldError();
+          }
+          if (outcome.status === "awaiting_auth") {
+            if (!requester) {
+              const text = `I could not act on this subscribed event because ${outcome.authProviderDisplayName} needs user authorization. Ask me in this thread to connect ${outcome.authProviderDisplayName} before retrying.`;
+              await postThreadReply(
+                buildSlackOutputMessage(text),
+                "thread_reply",
+              );
+              markConversationMessage(
+                preparedState.conversation,
+                preparedState.userMessageId,
+                {
+                  replied: true,
+                  skippedReason: undefined,
+                },
+              );
+              upsertConversationMessage(preparedState.conversation, {
+                id: generateConversationId("assistant"),
+                role: "assistant",
+                text: normalizeConversationText(text),
+                createdAtMs: Date.now(),
+                author: {
+                  userName: botConfig.userName,
+                  isBot: true,
+                },
+                meta: {
+                  replied: true,
+                },
+              });
+              markTurnClosed({
+                conversation: preparedState.conversation,
+                nowMs: Date.now(),
+                sessionId: turnId,
+                updateConversationStats,
+              });
+              await persistThreadState(thread, {
+                conversation: preparedState.conversation,
+              });
+              persistedAtLeastOnce = true;
+              shouldPersistFailureState = false;
+              return;
+            }
+            await postAuthPauseNotice(outcome.authProviderDisplayName);
+            completeAuthPauseTurn({
+              conversation: preparedState.conversation,
+              sessionId: outcome.sessionId,
+            });
+            await persistThreadState(thread, {
+              conversation: preparedState.conversation,
+            });
+            persistedAtLeastOnce = true;
+            shouldPersistFailureState = false;
+            return;
+          }
+          if (outcome.status === "timed_out") {
+            if (typeof outcome.version === "number" && destination) {
+              try {
+                await deps.services.scheduleAgentContinue({
+                  conversationId: outcome.conversationId,
+                  destination,
+                  sessionId: outcome.sessionId,
+                  expectedVersion: outcome.version,
+                });
+                shouldPersistFailureState = false;
+              } catch (scheduleError) {
+                logException(
+                  scheduleError,
+                  "agent_continue_schedule_failed",
+                  turnTraceContext,
+                  {
+                    ...(messageTs ? { "messaging.message.id": messageTs } : {}),
+                    "app.ai.resume_session_version": outcome.version,
+                  },
+                  "Failed to schedule agent continuation",
+                );
+                shouldPersistFailureState = true;
+                agentContinueScheduleError = scheduleError;
+                throw scheduleError;
+              }
+              return;
+            }
+            logWarn(
+              "agent_continue_metadata_missing",
+              turnTraceContext,
+              messageTs ? { "messaging.message.id": messageTs } : {},
+              "Agent continuation could not be scheduled because retry metadata was incomplete",
+            );
+            agentContinuePropagationError =
+              retryableTurnErrorFromTimedOutAgentRun(outcome);
+            throw agentContinuePropagationError;
+          }
+
+          let reply = outcome.reply;
           const diagnosticsContext = {
             slackThreadId: threadId,
             slackUserId: message.author.userId,
@@ -1338,108 +1441,18 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             );
             return;
           }
-          if (isCooperativeTurnYieldError(error)) {
+          if (error instanceof CooperativeTurnYieldError) {
             shouldPersistFailureState = false;
             throw error;
           }
-
-          if (isAuthResumeRetryableTurnError(error)) {
-            if (!requester) {
-              const text = `I could not act on this subscribed event because ${error.metadata.authProviderDisplayName} needs user authorization. Ask me in this thread to connect ${error.metadata.authProviderDisplayName} before retrying.`;
-              await postThreadReply(
-                buildSlackOutputMessage(text),
-                "thread_reply",
-              );
-              markConversationMessage(
-                preparedState.conversation,
-                preparedState.userMessageId,
-                {
-                  replied: true,
-                  skippedReason: undefined,
-                },
-              );
-              upsertConversationMessage(preparedState.conversation, {
-                id: generateConversationId("assistant"),
-                role: "assistant",
-                text: normalizeConversationText(text),
-                createdAtMs: Date.now(),
-                author: {
-                  userName: botConfig.userName,
-                  isBot: true,
-                },
-                meta: {
-                  replied: true,
-                },
-              });
-              markTurnClosed({
-                conversation: preparedState.conversation,
-                nowMs: Date.now(),
-                sessionId: turnId,
-                updateConversationStats,
-              });
-              await persistThreadState(thread, {
-                conversation: preparedState.conversation,
-              });
-              persistedAtLeastOnce = true;
-              shouldPersistFailureState = false;
-              return;
-            }
-            await postAuthPauseNotice(error.metadata.authProviderDisplayName);
-            completeAuthPauseTurn({
-              conversation: preparedState.conversation,
-              sessionId: error.metadata?.sessionId ?? turnId,
-            });
-            await persistThreadState(thread, {
-              conversation: preparedState.conversation,
-            });
-            persistedAtLeastOnce = true;
-            shouldPersistFailureState = false;
-            return;
+          if (error === agentContinueScheduleError) {
+            shouldPersistFailureState = true;
+            throw error;
           }
-
-          if (isRetryableTurnError(error, "agent_continue")) {
-            const conversationIdForResume = error.metadata?.conversationId;
-            const sessionIdForResume = error.metadata?.sessionId;
-            const version = error.metadata?.version;
-            if (
-              conversationIdForResume &&
-              sessionIdForResume &&
-              typeof version === "number" &&
-              destination
-            ) {
-              try {
-                await deps.services.scheduleAgentContinue({
-                  conversationId: conversationIdForResume,
-                  destination,
-                  sessionId: sessionIdForResume,
-                  expectedVersion: version,
-                });
-                shouldPersistFailureState = false;
-              } catch (scheduleError) {
-                logException(
-                  scheduleError,
-                  "agent_continue_schedule_failed",
-                  turnTraceContext,
-                  {
-                    ...(messageTs ? { "messaging.message.id": messageTs } : {}),
-                    "app.ai.resume_session_version": version,
-                  },
-                  "Failed to schedule agent continuation",
-                );
-                shouldPersistFailureState = true;
-                throw scheduleError;
-              }
-              return;
-            } else {
-              logWarn(
-                "agent_continue_metadata_missing",
-                turnTraceContext,
-                messageTs ? { "messaging.message.id": messageTs } : {},
-                "Agent continuation could not be scheduled because retry metadata was incomplete",
-              );
-            }
+          if (error === agentContinuePropagationError) {
+            shouldPersistFailureState = true;
+            throw error;
           }
-
           shouldPersistFailureState = true;
           const createdCanvasUrl = getCurrentTurnCanvasUrl({
             before: preparedState.artifacts,

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -12,6 +12,11 @@ import {
   type AssistantReply,
   type AssistantReplyRequestContext,
 } from "@/chat/respond";
+import {
+  retryableTurnErrorFromAuthAgentRun,
+  retryableTurnErrorFromTimedOutAgentRun,
+  type AgentRunOutcome,
+} from "@/chat/runtime/agent-run-outcome";
 import type { Source } from "@sentry/junior-plugin-api";
 import { scheduleSessionCompletedPluginTasks } from "@/chat/plugins/task-runner";
 import {
@@ -65,6 +70,11 @@ function resolveReplyTimeoutMs(explicitTimeoutMs?: number): number | undefined {
   const parsed = Number.parseInt(raw, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
+
+type ResumeGenerateReply = (
+  messageText: string,
+  context: AssistantReplyRequestContext,
+) => Promise<AgentRunOutcome>;
 
 async function postSlackMessageBestEffort(
   channelId: string,
@@ -142,7 +152,7 @@ interface ResumeSlackTurnArgs {
   replyContext?: ResumeReplyContext;
   lockKey?: string;
   initialText?: string;
-  generateReply?: typeof generateAssistantReply;
+  generateReply?: ResumeGenerateReply;
   scheduleSessionCompletedPluginTasks?: (params: {
     conversationId: string;
     sessionId: string;
@@ -376,7 +386,7 @@ export async function resumeSlackTurn(
     const replyContext = createResumeReplyContext(runArgs, status);
     const replyPromise = generateReply(runArgs.messageText, replyContext);
     const replyTimeoutMs = resolveReplyTimeoutMs(runArgs.replyTimeoutMs);
-    let reply =
+    const outcome =
       typeof replyTimeoutMs === "number"
         ? await Promise.race([
             replyPromise,
@@ -393,6 +403,16 @@ export async function resumeSlackTurn(
             ),
           ])
         : await replyPromise;
+    if (outcome.status === "awaiting_auth") {
+      throw retryableTurnErrorFromAuthAgentRun(outcome);
+    }
+    if (outcome.status === "timed_out") {
+      throw retryableTurnErrorFromTimedOutAgentRun(outcome);
+    }
+    if (outcome.status === "yielded") {
+      throw new Error("Slack resume yielded without a queue worker boundary");
+    }
+    let reply = outcome.reply;
     reply = finalizeFailedTurnReply({
       reply,
       logException,
@@ -578,7 +598,7 @@ export async function resumeAuthorizedRequest(args: {
   connectedText: string;
   replyContext?: ResumeReplyContext;
   lockKey?: string;
-  generateReply?: typeof generateAssistantReply;
+  generateReply?: ResumeGenerateReply;
   onSuccess?: (reply: AssistantReply) => Promise<void>;
   onFailure?: (error: unknown) => Promise<void>;
   onAuthPause?: (error: unknown) => Promise<void>;

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -12,11 +12,7 @@ import {
   type AssistantReply,
   type AssistantReplyRequestContext,
 } from "@/chat/respond";
-import {
-  retryableTurnErrorFromAuthAgentRun,
-  retryableTurnErrorFromTimedOutAgentRun,
-  type AgentRunOutcome,
-} from "@/chat/runtime/agent-run-outcome";
+import type { AgentRunOutcome } from "@/chat/runtime/agent-run-outcome";
 import type { Source } from "@sentry/junior-plugin-api";
 import { scheduleSessionCompletedPluginTasks } from "@/chat/plugins/task-runner";
 import {
@@ -24,10 +20,6 @@ import {
   logException,
   type LogContext,
 } from "@/chat/logging";
-import {
-  isAuthResumeRetryableTurnError,
-  isRetryableTurnError,
-} from "@/chat/runtime/turn";
 import {
   finalizeFailedTurnReply,
   requireTurnFailureEventId,
@@ -159,8 +151,8 @@ interface ResumeSlackTurnArgs {
   }) => Promise<void>;
   onSuccess?: (reply: AssistantReply) => Promise<void>;
   onFailure?: (error: unknown) => Promise<void>;
-  onAuthPause?: (error: unknown) => Promise<void>;
-  onTimeoutPause?: (error: unknown) => Promise<void>;
+  onAuthPause?: (pause: { providerDisplayName: string }) => Promise<void>;
+  onTimeoutPause?: (resume: { resumeVersion: number }) => Promise<void>;
   onPostDeliveryCommitFailure?: (error: unknown) => Promise<void>;
   beforeStart?: () => Promise<Partial<ResumeSlackTurnArgs> | false | void>;
   replyTimeoutMs?: number;
@@ -403,93 +395,119 @@ export async function resumeSlackTurn(
             ),
           ])
         : await replyPromise;
-    if (outcome.status === "awaiting_auth") {
-      throw retryableTurnErrorFromAuthAgentRun(outcome);
-    }
-    if (outcome.status === "timed_out") {
-      throw retryableTurnErrorFromTimedOutAgentRun(outcome);
-    }
-    if (outcome.status === "yielded") {
-      throw new Error("Slack resume yielded without a queue worker boundary");
-    }
-    let reply = outcome.reply;
-    reply = finalizeFailedTurnReply({
-      reply,
-      logException,
-      context: getResumeLogContext(runArgs, lockKey),
-    });
-
-    await status.stop();
-    const footer = buildSlackReplyFooter({
-      conversationId: getResumeConversationId(runArgs, lockKey),
-    });
-    await postSlackApiReplyPosts({
-      channelId: runArgs.channelId,
-      threadTs: runArgs.threadTs,
-      posts: planSlackReplyPosts({ reply }),
-      fileUploadFailureMode: "best_effort",
-      footer,
-    });
-    finalReplyDelivered = true;
-    // Destination acceptance is the completion boundary: only now commit the
-    // final assistant messages and the terminal completed session record.
-    // Persistence failures are logged inside and never fail the turn.
-    if (
-      replyContext.correlation?.conversationId &&
-      replyContext.correlation.turnId &&
-      reply.piMessages?.length
-    ) {
-      await persistCompletedSessionRecord({
-        conversationId: replyContext.correlation.conversationId,
-        sessionId: replyContext.correlation.turnId,
-        allMessages: reply.piMessages,
-        currentDurationMs: reply.diagnostics.durationMs,
-        currentUsage: reply.diagnostics.usage,
-        destination: replyContext.destination,
-        source: replyContext.source,
-        requester: replyContext.requester,
-        surface: "slack",
-        logContext: {
-          threadId: replyContext.correlation.threadId,
-          requesterId: replyContext.requester?.userId,
-          channelId: runArgs.channelId,
-          runId: replyContext.correlation.runId,
-          assistantUserName: botConfig.userName,
-          modelId: reply.diagnostics.modelId,
-        },
+    if (outcome.status !== "completed") {
+      // Expected pauses defer their handlers until the lock is released,
+      // mirroring the failure path below.
+      await status.stop();
+      const onAuthPause = runArgs.onAuthPause;
+      const onTimeoutPause = runArgs.onTimeoutPause;
+      if (outcome.status === "awaiting_auth" && onAuthPause) {
+        deferredPauseKind = "auth";
+        deferredAuthInfo = {
+          providerDisplayName: outcome.providerDisplayName,
+          requesterId: runArgs.replyContext?.requester?.userId,
+        };
+        deferredPauseHandler = async () => {
+          await onAuthPause({
+            providerDisplayName: outcome.providerDisplayName,
+          });
+        };
+      } else if (outcome.status === "suspended" && onTimeoutPause) {
+        deferredPauseKind = "timeout";
+        deferredPauseHandler = async () => {
+          await onTimeoutPause({ resumeVersion: outcome.resumeVersion });
+        };
+      } else {
+        deferredFailureHandler = async () => {
+          await handleResumeFailure({
+            body: "Failed to resume Slack turn",
+            error: new Error(
+              `Resumed run ended ${outcome.status} without a pause handler`,
+            ),
+            eventName: "slack_resume_turn_failed",
+            lockKey,
+            resumeArgs: runArgs,
+          });
+        };
+      }
+    } else {
+      let reply = outcome.reply;
+      reply = finalizeFailedTurnReply({
+        reply,
+        logException,
+        context: getResumeLogContext(runArgs, lockKey),
       });
-    }
-    await runArgs.onSuccess?.(reply);
-    if (
-      reply.diagnostics.outcome === "success" &&
-      replyContext.correlation?.conversationId &&
-      replyContext.correlation.turnId
-    ) {
-      try {
-        const params = {
+
+      await status.stop();
+      const footer = buildSlackReplyFooter({
+        conversationId: getResumeConversationId(runArgs, lockKey),
+      });
+      await postSlackApiReplyPosts({
+        channelId: runArgs.channelId,
+        threadTs: runArgs.threadTs,
+        posts: planSlackReplyPosts({ reply }),
+        fileUploadFailureMode: "best_effort",
+        footer,
+      });
+      finalReplyDelivered = true;
+      // Destination acceptance is the completion boundary: only now commit the
+      // final assistant messages and the terminal completed session record.
+      // Persistence failures are logged inside and never fail the turn.
+      if (
+        replyContext.correlation?.conversationId &&
+        replyContext.correlation.turnId &&
+        reply.piMessages?.length
+      ) {
+        await persistCompletedSessionRecord({
           conversationId: replyContext.correlation.conversationId,
           sessionId: replyContext.correlation.turnId,
-        };
-        if (runArgs.scheduleSessionCompletedPluginTasks) {
-          await runArgs.scheduleSessionCompletedPluginTasks(params);
-        } else {
-          await scheduleSessionCompletedPluginTasks(params);
+          allMessages: reply.piMessages,
+          currentDurationMs: reply.diagnostics.durationMs,
+          currentUsage: reply.diagnostics.usage,
+          destination: replyContext.destination,
+          source: replyContext.source,
+          requester: replyContext.requester,
+          surface: "slack",
+          logContext: {
+            threadId: replyContext.correlation.threadId,
+            requesterId: replyContext.requester?.userId,
+            channelId: runArgs.channelId,
+            runId: replyContext.correlation.runId,
+            assistantUserName: botConfig.userName,
+            modelId: reply.diagnostics.modelId,
+          },
+        });
+      }
+      await runArgs.onSuccess?.(reply);
+      if (
+        reply.diagnostics.outcome === "success" &&
+        replyContext.correlation?.conversationId &&
+        replyContext.correlation.turnId
+      ) {
+        try {
+          const params = {
+            conversationId: replyContext.correlation.conversationId,
+            sessionId: replyContext.correlation.turnId,
+          };
+          if (runArgs.scheduleSessionCompletedPluginTasks) {
+            await runArgs.scheduleSessionCompletedPluginTasks(params);
+          } else {
+            await scheduleSessionCompletedPluginTasks(params);
+          }
+        } catch (scheduleError) {
+          logException(
+            scheduleError,
+            "plugin_session_completed_task_schedule_failed",
+            getResumeLogContext(runArgs, lockKey),
+            {},
+            "Plugin session.completed task scheduling failed",
+          );
         }
-      } catch (scheduleError) {
-        logException(
-          scheduleError,
-          "plugin_session_completed_task_schedule_failed",
-          getResumeLogContext(runArgs, lockKey),
-          {},
-          "Plugin session.completed task scheduling failed",
-        );
       }
     }
   } catch (error) {
     await status.stop();
 
-    const onAuthPause = runArgs.onAuthPause;
-    const onTimeoutPause = runArgs.onTimeoutPause;
     if (finalReplyDelivered) {
       postDeliveryCommitError = error;
       try {
@@ -503,24 +521,6 @@ export async function resumeSlackTurn(
           "Failed to terminalize resumed turn after post-delivery commit failure",
         );
       }
-    } else if (isAuthResumeRetryableTurnError(error) && onAuthPause) {
-      deferredPauseKind = "auth";
-      deferredAuthInfo = {
-        providerDisplayName: error.metadata.authProviderDisplayName,
-        // The try body validates requester.userId; catch scope does not retain that narrowing.
-        requesterId: runArgs.replyContext?.requester?.userId,
-      };
-      deferredPauseHandler = async () => {
-        await onAuthPause(error);
-      };
-    } else if (
-      isRetryableTurnError(error, "agent_continue") &&
-      onTimeoutPause
-    ) {
-      deferredPauseKind = "timeout";
-      deferredPauseHandler = async () => {
-        await onTimeoutPause(error);
-      };
     } else {
       deferredFailureHandler = async () => {
         await handleResumeFailure({
@@ -601,8 +601,8 @@ export async function resumeAuthorizedRequest(args: {
   generateReply?: ResumeGenerateReply;
   onSuccess?: (reply: AssistantReply) => Promise<void>;
   onFailure?: (error: unknown) => Promise<void>;
-  onAuthPause?: (error: unknown) => Promise<void>;
-  onTimeoutPause?: (error: unknown) => Promise<void>;
+  onAuthPause?: (pause: { providerDisplayName: string }) => Promise<void>;
+  onTimeoutPause?: (resume: { resumeVersion: number }) => Promise<void>;
   onPostDeliveryCommitFailure?: (error: unknown) => Promise<void>;
   beforeStart?: () => Promise<Partial<ResumeSlackTurnArgs> | false | void>;
   replyTimeoutMs?: number;

--- a/packages/junior/src/chat/runtime/slack-runtime.ts
+++ b/packages/junior/src/chat/runtime/slack-runtime.ts
@@ -16,7 +16,6 @@ import {
   isCooperativeTurnYieldError,
   isTurnInputDeferredError,
   isTurnInputCommitLostError,
-  isRetryableTurnError,
 } from "@/chat/runtime/turn";
 import { buildTurnFailureResponse } from "@/chat/logging";
 import { getSlackErrorObservabilityAttributes } from "@/chat/slack/errors";
@@ -802,19 +801,6 @@ export function createSlackTurnRuntime<
           channelId: deps.getChannelId(thread, message),
           runId: deps.getRunId(thread, message),
         });
-        if (
-          isRetryableTurnError(error, "mcp_auth_resume") ||
-          isRetryableTurnError(error, "plugin_auth_resume")
-        ) {
-          deps.logException(
-            error,
-            "mention_handler_auth_pause",
-            errorContext,
-            { "app.ai.retryable_reason": error.reason },
-            "onNewMention parked turn for auth resume",
-          );
-          return;
-        }
         if (error instanceof AuthorizationFlowDisabledError) {
           return;
         }
@@ -1117,19 +1103,6 @@ export function createSlackTurnRuntime<
           channelId: deps.getChannelId(thread, message),
           runId: deps.getRunId(thread, message),
         });
-        if (
-          isRetryableTurnError(error, "mcp_auth_resume") ||
-          isRetryableTurnError(error, "plugin_auth_resume")
-        ) {
-          deps.logException(
-            error,
-            "subscribed_message_handler_auth_pause",
-            errorContext,
-            { "app.ai.retryable_reason": error.reason },
-            "onSubscribedMessage parked turn for auth resume",
-          );
-          return;
-        }
         if (error instanceof AuthorizationFlowDisabledError) {
           return;
         }

--- a/packages/junior/src/chat/runtime/turn.ts
+++ b/packages/junior/src/chat/runtime/turn.ts
@@ -47,7 +47,10 @@ export type AuthResumeRetryableTurnError = RetryableTurnError & {
   readonly metadata: AuthResumeRetryableTurnMetadata;
 };
 
-/** Error indicating an agent run can continue later after timeout or auth pause. */
+/**
+ * Historical turn error for outer resume/callback boundaries; expected
+ * generateAssistantReply lifecycle endings are represented by AgentRunOutcome.
+ */
 export class RetryableTurnError extends Error {
   readonly code = "retryable_turn";
   readonly metadata?: RetryableTurnMetadata;
@@ -101,7 +104,11 @@ export function isAuthResumeRetryableTurnError(
   );
 }
 
-/** Error indicating the turn paused voluntarily at a safe continuation boundary. */
+/**
+ * Historical turn error for queue-worker yield routing; respond.ts returns a
+ * yielded AgentRunOutcome and the Slack executor recreates this at the worker
+ * boundary.
+ */
 export class CooperativeTurnYieldError extends Error {
   readonly code = "cooperative_turn_yield";
 

--- a/packages/junior/src/chat/runtime/turn.ts
+++ b/packages/junior/src/chat/runtime/turn.ts
@@ -1,10 +1,4 @@
 import type { ThreadConversationState } from "@/chat/state/conversation";
-import type {
-  AuthorizationPauseDisposition,
-  AuthorizationPauseKind,
-} from "@/chat/services/auth-pause";
-import type { TurnThinkingSelection } from "@/chat/services/turn-thinking-level";
-import type { AgentTurnUsage } from "@/chat/usage";
 
 export { buildDeterministicTurnId } from "@/chat/state/turn-id";
 
@@ -12,102 +6,10 @@ export { buildDeterministicTurnId } from "@/chat/state/turn-id";
 // Turn errors
 // ---------------------------------------------------------------------------
 
-export type RetryableTurnReason =
-  | "mcp_auth_resume"
-  | "plugin_auth_resume"
-  | "agent_continue";
-
-/** Auth-pause reasons require a known provider before a resume can be parked. */
-export type AuthResumeRetryableTurnReason = Extract<
-  RetryableTurnReason,
-  "mcp_auth_resume" | "plugin_auth_resume"
->;
-
-export interface RetryableTurnMetadata {
-  authDisposition?: AuthorizationPauseDisposition;
-  authDurationMs?: number;
-  authKind?: AuthorizationPauseKind;
-  authProvider?: string;
-  authProviderDisplayName?: string;
-  authThinkingLevel?: TurnThinkingSelection["thinkingLevel"];
-  authUsage?: AgentTurnUsage;
-  version?: number;
-  conversationId?: string;
-  sessionId?: string;
-  sliceId?: number;
-}
-
-export interface AuthResumeRetryableTurnMetadata extends RetryableTurnMetadata {
-  authProvider: string;
-  authProviderDisplayName: string;
-}
-
-export type AuthResumeRetryableTurnError = RetryableTurnError & {
-  readonly reason: AuthResumeRetryableTurnReason;
-  readonly metadata: AuthResumeRetryableTurnMetadata;
-};
-
 /**
- * Historical turn error for outer resume/callback boundaries; expected
- * generateAssistantReply lifecycle endings are represented by AgentRunOutcome.
- */
-export class RetryableTurnError extends Error {
-  readonly code = "retryable_turn";
-  readonly metadata?: RetryableTurnMetadata;
-  readonly reason: RetryableTurnReason;
-
-  constructor(
-    reason: AuthResumeRetryableTurnReason,
-    message: string,
-    metadata: AuthResumeRetryableTurnMetadata,
-  );
-  constructor(
-    reason: "agent_continue",
-    message: string,
-    metadata?: RetryableTurnMetadata,
-  );
-  constructor(
-    reason: RetryableTurnReason,
-    message: string,
-    metadata?: RetryableTurnMetadata,
-  ) {
-    super(message);
-    this.name = "RetryableTurnError";
-    this.reason = reason;
-    this.metadata = metadata;
-  }
-}
-
-export function isRetryableTurnError(
-  error: unknown,
-  reason?: RetryableTurnReason,
-): error is RetryableTurnError {
-  if (!(error instanceof RetryableTurnError)) {
-    return false;
-  }
-  if (!reason) {
-    return true;
-  }
-  return error.reason === reason;
-}
-
-/** Return whether a retryable turn is waiting for provider authorization. */
-export function isAuthResumeRetryableTurnError(
-  error: unknown,
-): error is AuthResumeRetryableTurnError {
-  return (
-    error instanceof RetryableTurnError &&
-    (error.reason === "mcp_auth_resume" ||
-      error.reason === "plugin_auth_resume") &&
-    typeof error.metadata?.authProvider === "string" &&
-    typeof error.metadata.authProviderDisplayName === "string"
-  );
-}
-
-/**
- * Historical turn error for queue-worker yield routing; respond.ts returns a
- * yielded AgentRunOutcome and the Slack executor recreates this at the worker
- * boundary.
+ * Queue-worker yield routing: respond.ts returns a suspended AgentRunOutcome
+ * and the Slack executor raises this at the worker boundary so the lease owner
+ * requeues the conversation.
  */
 export class CooperativeTurnYieldError extends Error {
   readonly code = "cooperative_turn_yield";

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -48,7 +48,7 @@ import {
   getAgentTurnSessionRecord,
 } from "@/chat/state/turn-session";
 import { recordAuthorizationCompleted } from "@/chat/state/session-log";
-import { isRetryableTurnError, markTurnFailed } from "@/chat/runtime/turn";
+import { markTurnFailed } from "@/chat/runtime/turn";
 import { scheduleAgentContinue } from "@/chat/services/agent-continue";
 import { htmlCallbackResponse } from "@/handlers/oauth-html";
 import type { WaitUntilFn } from "@/handlers/types";
@@ -419,7 +419,7 @@ async function resumeAuthorizedMcpTurn(args: {
             );
           }
         },
-        onAuthPause: async (error: unknown) => {
+        onAuthPause: async () => {
           await persistAuthPauseTurnState({
             sessionId: lockedSessionId,
             threadStateId: threadId,
@@ -427,30 +427,16 @@ async function resumeAuthorizedMcpTurn(args: {
           logWarn(
             "mcp_oauth_callback_resume_reparked_for_auth",
             {},
-            {
-              "app.credential.provider": provider,
-              ...(isRetryableTurnError(error)
-                ? { "app.ai.retryable_reason": error.reason }
-                : {}),
-            },
+            { "app.credential.provider": provider },
             "Resumed MCP turn requested another authorization flow",
           );
         },
-        onTimeoutPause: async (error: unknown) => {
-          if (!isRetryableTurnError(error, "agent_continue")) {
-            throw error;
-          }
-          const version = error.metadata?.version;
-          if (typeof version !== "number") {
-            throw new Error(
-              "MCP OAuth agent continuation did not include a session record version",
-            );
-          }
+        onTimeoutPause: async ({ resumeVersion }) => {
           await scheduleAgentContinue({
             conversationId: authSession.conversationId,
             destination,
             sessionId: lockedSessionId,
-            expectedVersion: version,
+            expectedVersion: resumeVersion,
           });
         },
       };

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -40,7 +40,7 @@ import {
   getTurnUserSlackMessageTs,
   getTurnUserReplyAttachmentContext,
 } from "@/chat/runtime/turn-user-message";
-import { isRetryableTurnError, markTurnFailed } from "@/chat/runtime/turn";
+import { markTurnFailed } from "@/chat/runtime/turn";
 import { publishAppHomeView } from "@/chat/slack/app-home";
 import { getSlackClient } from "@/chat/slack/client";
 import { createSlackResumeRequester, type Requester } from "@/chat/requester";
@@ -451,21 +451,12 @@ async function resumeOAuthSessionRecordTurn(
             threadStateId: stored.resumeConversationId!,
           });
         },
-        onTimeoutPause: async (error: unknown) => {
-          if (!isRetryableTurnError(error, "agent_continue")) {
-            throw error;
-          }
-          const version = error.metadata?.version;
-          if (typeof version !== "number") {
-            throw new Error(
-              "OAuth agent continuation did not include a session record version",
-            );
-          }
+        onTimeoutPause: async ({ resumeVersion }) => {
           await scheduleAgentContinue({
             conversationId: stored.resumeConversationId!,
             destination,
             sessionId: lockedSessionId,
-            expectedVersion: version,
+            expectedVersion: resumeVersion,
           });
         },
       };

--- a/packages/junior/tests/component/runtime/respond-error-path.test.ts
+++ b/packages/junior/tests/component/runtime/respond-error-path.test.ts
@@ -52,9 +52,9 @@ describe("generateAssistantReply error path", () => {
         sandboxDependencyProfileHash: "hash-abc",
       },
     });
-    expect(outcome.status).toBe("failed");
-    const reply = outcome.status === "failed" ? outcome.reply : undefined;
+    const reply = outcome.status === "completed" ? outcome.reply : undefined;
     expect(reply).toBeDefined();
+    expect(reply!.diagnostics.outcome).toBe("provider_error");
 
     // Raw exception text stays in diagnostics; it is never reply text.
     expect(reply!.text).toBe("");

--- a/packages/junior/tests/component/runtime/respond-error-path.test.ts
+++ b/packages/junior/tests/component/runtime/respond-error-path.test.ts
@@ -44,7 +44,7 @@ describe("generateAssistantReply error path", () => {
   });
 
   it("preserves sandbox dependency hash on non-retryable failures", async () => {
-    const reply = await generateAssistantReply("hello", {
+    const outcome = await generateAssistantReply("hello", {
       destination: LOCAL_DESTINATION,
       source: LOCAL_SOURCE,
       sandbox: {
@@ -52,16 +52,19 @@ describe("generateAssistantReply error path", () => {
         sandboxDependencyProfileHash: "hash-abc",
       },
     });
+    expect(outcome.status).toBe("failed");
+    const reply = outcome.status === "failed" ? outcome.reply : undefined;
+    expect(reply).toBeDefined();
 
     // Raw exception text stays in diagnostics; it is never reply text.
-    expect(reply.text).toBe("");
-    expect(reply.diagnostics.errorMessage).toBe("discover failed");
-    expect(reply.diagnostics.assistantMessageCount).toBe(0);
-    expect(reply.sandboxId).toBe("sb-123");
-    expect(reply.sandboxDependencyProfileHash).toBe("hash-abc");
-    expect(reply.diagnostics.outcome).toBe("provider_error");
-    expect(reply.diagnostics.modelId).toBe("openai/gpt-5.4");
-    expect(reply.diagnostics.thinkingLevel).toBeUndefined();
+    expect(reply!.text).toBe("");
+    expect(reply!.diagnostics.errorMessage).toBe("discover failed");
+    expect(reply!.diagnostics.assistantMessageCount).toBe(0);
+    expect(reply!.sandboxId).toBe("sb-123");
+    expect(reply!.sandboxDependencyProfileHash).toBe("hash-abc");
+    expect(reply!.diagnostics.outcome).toBe("provider_error");
+    expect(reply!.diagnostics.modelId).toBe("openai/gpt-5.4");
+    expect(reply!.diagnostics.thinkingLevel).toBeUndefined();
   });
 
   it("propagates pre-commit failures when durable input commit is required", async () => {

--- a/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
@@ -1620,14 +1620,7 @@ describe("Slack conversation work execution", () => {
             });
             currentNowMs = 242_000;
             yieldedSessionId = context?.correlation?.turnId;
-            return {
-              status: "yielded",
-              conversationId:
-                context?.correlation?.conversationId ?? CONVERSATION_ID,
-              sessionId: yieldedSessionId ?? "missing-session",
-              sliceId: 1,
-              version: 1,
-            };
+            return { status: "suspended", resumeVersion: 1 };
           },
         },
       },

--- a/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
@@ -26,12 +26,16 @@ import {
 } from "@/chat/task-execution/slack-work";
 import { getMessageActorIdentity } from "@/chat/services/message-actor-identity";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
+import { coerceThreadConversationState } from "@/chat/state/conversation";
 import {
   failAgentTurnSessionRecord,
   getAgentTurnSessionRecord,
   upsertAgentTurnSessionRecord,
 } from "@/chat/state/turn-session";
-import { persistThreadStateById } from "@/chat/runtime/thread-state";
+import {
+  getPersistedThreadState,
+  persistThreadStateById,
+} from "@/chat/runtime/thread-state";
 import { createTestChatRuntime } from "../../fixtures/chat-runtime";
 import {
   getCapturedSlackApiCalls,
@@ -1588,5 +1592,92 @@ describe("Slack conversation work execution", () => {
         "slack:T123:slack:C123:1712345.0001:1712345.0001",
       ]),
     );
+  });
+
+  it("keeps yielded executor outcomes resumable without failure recovery", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    const state = getStateAdapter();
+    await state.connect();
+    const slackAdapter = createSlackAdapterFixture();
+    let currentNowMs = 1_000;
+    let yieldedSessionId: string | undefined;
+    const { slackRuntime } = createTestChatRuntime({
+      services: {
+        replyExecutor: {
+          generateAssistantReply: async (_text, context) => {
+            await context?.onInputCommitted?.();
+            await context?.onArtifactStateUpdated?.({
+              lastCanvasId: "F_YIELD_CANVAS",
+              lastCanvasUrl: "https://slack.example/docs/T/F_YIELD_CANVAS",
+              recentCanvases: [
+                {
+                  id: "F_YIELD_CANVAS",
+                  title: "Yielded canvas",
+                  url: "https://slack.example/docs/T/F_YIELD_CANVAS",
+                  createdAt: "2026-07-02T12:00:00.000Z",
+                },
+              ],
+            });
+            currentNowMs = 242_000;
+            yieldedSessionId = context?.correlation?.turnId;
+            return {
+              status: "yielded",
+              conversationId:
+                context?.correlation?.conversationId ?? CONVERSATION_ID,
+              sessionId: yieldedSessionId ?? "missing-session",
+              sliceId: 1,
+              version: 1,
+            };
+          },
+        },
+      },
+    });
+
+    await handleSlackWebhookAndFlush({
+      request: slackWebhookRequest(
+        slackEnvelope({
+          text: `<@${SLACK_BOT_USER_ID}> create the canvas and continue later`,
+        }),
+      ),
+      services: {
+        getSlackAdapter: () => slackAdapter,
+        queue,
+        runtime: createNoopSlackWebhookRuntime(),
+        state,
+      },
+    });
+    queue.clearSentRecords();
+
+    await expect(
+      processNextQueuedSlackWork({
+        getSlackAdapter: () => slackAdapter,
+        nowMs: () => currentNowMs,
+        queue,
+        runtime: slackRuntime,
+        state,
+      }),
+    ).resolves.toEqual({ status: "yielded" });
+
+    expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([]);
+    expect(queue.sentRecords()).toMatchObject([
+      {
+        conversationId: CONVERSATION_ID,
+        idempotencyKey: `yield:${CONVERSATION_ID}:242000`,
+      },
+    ]);
+    const work = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+      state,
+    });
+    expect(work?.needsRun).toBe(true);
+    expect(work?.messages).toEqual([]);
+    const persistedState = await getPersistedThreadState(CONVERSATION_ID);
+    const conversation = coerceThreadConversationState(persistedState);
+    expect(conversation.processing.activeTurnId).toBe(yieldedSessionId);
+    const sessionRecord = await getAgentTurnSessionRecord(
+      CONVERSATION_ID,
+      yieldedSessionId ?? "",
+    );
+    expect(sessionRecord?.state).not.toBe("failed");
   });
 });

--- a/packages/junior/tests/integration/agent-continue-slack.test.ts
+++ b/packages/junior/tests/integration/agent-continue-slack.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../fixtures/conversation-work";
 import { slackApiOutbox } from "../fixtures/slack-api-outbox";
 import { resetSlackApiMockState } from "../msw/handlers/slack-api";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const generateAssistantReplyMock = vi.fn();
 
@@ -21,6 +22,18 @@ function slackSource(threadTs: string) {
 
     type: "priv",
   });
+}
+
+function makeDiagnostics() {
+  return {
+    assistantMessageCount: 1,
+    modelId: "fake-agent-model",
+    outcome: "success" as const,
+    toolCalls: [],
+    toolErrorCount: 0,
+    toolResultCount: 0,
+    usedPrimaryText: true,
+  };
 }
 
 type StateAdapterModule = typeof import("@/chat/state/adapter");
@@ -70,13 +83,12 @@ describe("agent continuation Slack integration", () => {
   beforeEach(async () => {
     queue = createConversationWorkQueueTestAdapter();
     generateAssistantReplyMock.mockReset();
-    generateAssistantReplyMock.mockResolvedValue({
-      text: "Final resumed answer",
-      diagnostics: {
-        outcome: "success",
-        toolCalls: [],
-      },
-    });
+    generateAssistantReplyMock.mockResolvedValue(
+      completedAgentRun({
+        text: "Final resumed answer",
+        diagnostics: makeDiagnostics(),
+      }),
+    );
     resetSlackApiMockState();
     process.env = {
       ...ORIGINAL_ENV,
@@ -839,25 +851,24 @@ describe("agent continuation Slack integration", () => {
     // exactly one visible reply and only then a delivered/completed session.
     const conversationId = "slack:C123:1712345.0008";
     const sessionId = "turn_msg_8";
-    generateAssistantReplyMock.mockResolvedValueOnce({
-      text: "Final resumed answer",
-      piMessages: [
-        {
-          role: "user",
-          content: [{ type: "text", text: "hello" }],
-          timestamp: 1,
-        },
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "Final resumed answer" }],
-          timestamp: 2,
-        },
-      ],
-      diagnostics: {
-        outcome: "success",
-        toolCalls: [],
-      },
-    });
+    generateAssistantReplyMock.mockResolvedValueOnce(
+      completedAgentRun({
+        text: "Final resumed answer",
+        piMessages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "hello" }],
+            timestamp: 1,
+          },
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "Final resumed answer" }],
+            timestamp: 2,
+          },
+        ] as any,
+        diagnostics: makeDiagnostics(),
+      }),
+    );
     await turnSessionStoreModule.upsertAgentTurnSessionRecord({
       conversationId,
       sessionId,
@@ -1095,19 +1106,18 @@ describe("agent continuation Slack integration", () => {
         },
       });
 
-    generateAssistantReplyMock.mockResolvedValueOnce({
-      text: "Final resumed answer with artifact",
-      files: [
-        {
-          data: Buffer.from("resume-file"),
-          filename: "resume.txt",
-        },
-      ],
-      diagnostics: {
-        outcome: "success",
-        toolCalls: [],
-      },
-    });
+    generateAssistantReplyMock.mockResolvedValueOnce(
+      completedAgentRun({
+        text: "Final resumed answer with artifact",
+        files: [
+          {
+            data: Buffer.from("resume-file"),
+            filename: "resume.txt",
+          },
+        ],
+        diagnostics: makeDiagnostics(),
+      }),
+    );
 
     await threadStateModule.persistThreadStateById(conversationId, {
       artifacts: {

--- a/packages/junior/tests/integration/agent-continue-slack.test.ts
+++ b/packages/junior/tests/integration/agent-continue-slack.test.ts
@@ -443,15 +443,10 @@ describe("agent continuation Slack integration", () => {
       },
     });
 
-    const { RetryableTurnError } = await import("@/chat/runtime/turn");
-    generateAssistantReplyMock.mockRejectedValueOnce(
-      new RetryableTurnError("agent_continue", "timed out again", {
-        conversationId,
-        sessionId,
-        version: sessionRecord.version + 1,
-        sliceId: 6,
-      }),
-    );
+    generateAssistantReplyMock.mockResolvedValueOnce({
+      status: "suspended",
+      resumeVersion: sessionRecord.version + 1,
+    });
 
     const continued = await continueAgentRun({
       conversationId,
@@ -814,15 +809,10 @@ describe("agent continuation Slack integration", () => {
       },
     });
 
-    const { RetryableTurnError } = await import("@/chat/runtime/turn");
-    generateAssistantReplyMock.mockRejectedValueOnce(
-      new RetryableTurnError("agent_continue", "timed out again", {
-        conversationId,
-        sessionId,
-        version: sessionRecord.version + 1,
-        sliceId: 3,
-      }),
-    );
+    generateAssistantReplyMock.mockResolvedValueOnce({
+      status: "suspended",
+      resumeVersion: sessionRecord.version + 1,
+    });
 
     const continued = await continueAgentRun({
       conversationId,

--- a/packages/junior/tests/integration/agent-dispatch-runner.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-runner.test.ts
@@ -6,6 +6,7 @@ import {
   getDispatchDestinationLockId,
   getDispatchRecord,
   getDispatchStorageKey,
+  getDispatchTurnId,
   parseDispatchRecord,
   updateDispatchRecord,
   withDispatchLock,
@@ -15,7 +16,6 @@ import {
   getPersistedThreadState,
   persistThreadStateById,
 } from "@/chat/runtime/thread-state";
-import { RetryableTurnError } from "@/chat/runtime/turn";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import type { AssistantReply } from "@/chat/respond";
@@ -25,6 +25,10 @@ import {
   createSlackDirectCredentialSubject,
 } from "@/chat/credentials/subject";
 import { getAgentTurnSessionRecord } from "@/chat/state/turn-session";
+import {
+  completedAgentRun,
+  failedAgentRun,
+} from "@/chat/runtime/agent-run-outcome";
 import { chatPostMessageOk } from "../fixtures/slack/factories/api";
 import {
   getCapturedSlackApiCalls,
@@ -200,7 +204,7 @@ describe("agent dispatch runner", () => {
       expect(context.sandbox?.tracePropagation).toEqual({
         domains: ["*.sentry.io"],
       });
-      return createReply();
+      return completedAgentRun(createReply());
     });
     const scheduleSessionCompletedPluginTasks = vi.fn(async () => undefined);
 
@@ -309,7 +313,7 @@ describe("agent dispatch runner", () => {
     const generateAssistantReply = vi.fn(async (_input, context) => {
       expect(context.conversationContext).toBeUndefined();
       expect(context.piMessages).toEqual([]);
-      return createReply();
+      return completedAgentRun(createReply());
     });
 
     await runAgentDispatchSlice(
@@ -356,10 +360,13 @@ describe("agent dispatch runner", () => {
     });
     const scheduleCallback = vi.fn(async () => undefined);
     const generateAssistantReply = vi.fn(async () => {
-      throw new RetryableTurnError("agent_continue", "slice timed out", {
+      return {
+        status: "timed_out" as const,
+        conversationId: getDispatchConversationId(created.record),
+        sessionId: getDispatchTurnId(created.record.id),
         version: 7,
         sliceId: 2,
-      });
+      };
     });
 
     await runAgentDispatchSlice(
@@ -414,7 +421,7 @@ describe("agent dispatch runner", () => {
         },
       });
       expect(context.authorizationFlowMode).toBe("disabled");
-      return createReply();
+      return completedAgentRun(createReply());
     });
 
     await runAgentDispatchSlice(
@@ -466,7 +473,9 @@ describe("agent dispatch runner", () => {
           id: created.record.id,
           expectedVersion: created.record.version,
         },
-        { generateAssistantReply: async () => createReply() },
+        {
+          generateAssistantReply: async () => completedAgentRun(createReply()),
+        },
       );
     } finally {
       setSpy.mockRestore();
@@ -512,17 +521,19 @@ describe("agent dispatch runner", () => {
     });
     const dispatchConversationId = getDispatchConversationId(created.record);
     const failedReply = createReply();
-    const generateAssistantReply = vi.fn(async () => ({
-      ...failedReply,
-      text: "",
-      diagnostics: {
-        ...failedReply.diagnostics,
-        errorMessage: "provider failed",
-        outcome: "provider_error" as const,
-        usedPrimaryText: false,
-      },
-      piMessages: failedDispatchPiMessages(),
-    }));
+    const generateAssistantReply = vi.fn(async () =>
+      failedAgentRun({
+        ...failedReply,
+        text: "",
+        diagnostics: {
+          ...failedReply.diagnostics,
+          errorMessage: "provider failed",
+          outcome: "provider_error" as const,
+          usedPrimaryText: false,
+        },
+        piMessages: failedDispatchPiMessages(),
+      }),
+    );
 
     await runAgentDispatchSlice(
       {
@@ -571,7 +582,7 @@ describe("agent dispatch runner", () => {
         id: created.record.id,
         expectedVersion: created.record.version,
       },
-      { generateAssistantReply: async () => createReply() },
+      { generateAssistantReply: async () => completedAgentRun(createReply()) },
     );
     await expect(getDispatchRecord(created.record.id)).resolves.toMatchObject({
       status: "completed",

--- a/packages/junior/tests/integration/agent-dispatch-runner.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-runner.test.ts
@@ -6,7 +6,6 @@ import {
   getDispatchDestinationLockId,
   getDispatchRecord,
   getDispatchStorageKey,
-  getDispatchTurnId,
   parseDispatchRecord,
   updateDispatchRecord,
   withDispatchLock,
@@ -25,10 +24,7 @@ import {
   createSlackDirectCredentialSubject,
 } from "@/chat/credentials/subject";
 import { getAgentTurnSessionRecord } from "@/chat/state/turn-session";
-import {
-  completedAgentRun,
-  failedAgentRun,
-} from "@/chat/runtime/agent-run-outcome";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import { chatPostMessageOk } from "../fixtures/slack/factories/api";
 import {
   getCapturedSlackApiCalls,
@@ -360,13 +356,7 @@ describe("agent dispatch runner", () => {
     });
     const scheduleCallback = vi.fn(async () => undefined);
     const generateAssistantReply = vi.fn(async () => {
-      return {
-        status: "timed_out" as const,
-        conversationId: getDispatchConversationId(created.record),
-        sessionId: getDispatchTurnId(created.record.id),
-        version: 7,
-        sliceId: 2,
-      };
+      return { status: "suspended" as const, resumeVersion: 7 };
     });
 
     await runAgentDispatchSlice(
@@ -522,7 +512,7 @@ describe("agent dispatch runner", () => {
     const dispatchConversationId = getDispatchConversationId(created.record);
     const failedReply = createReply();
     const generateAssistantReply = vi.fn(async () =>
-      failedAgentRun({
+      completedAgentRun({
         ...failedReply,
         text: "",
         diagnostics: {

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -26,6 +26,7 @@ import { commitMessages, loadProjection } from "@/chat/state/session-log";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
 import { coerceThreadArtifactsState } from "@/chat/state/artifacts";
 import { setPlugins } from "@/chat/plugins/agent-hooks";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 function successReply(
   text: string,
@@ -88,7 +89,7 @@ describe("local agent runner", () => {
     const generateReply = vi.fn<typeof generateAssistantReply>(
       async (_text, context) => {
         contexts.push(context);
-        return successReply("hello from local");
+        return completedAgentRun(successReply("hello from local"));
       },
     );
     const delivered: LocalAgentReply[] = [];
@@ -182,7 +183,9 @@ describe("local agent runner", () => {
           params: { content: "The requester prefers short updates." },
           result: { ok: true },
         });
-        return successReply("saved", { toolCalls: ["createMemory"] });
+        return completedAgentRun(
+          successReply("saved", { toolCalls: ["createMemory"] }),
+        );
       },
     );
     const invocations: LocalToolInvocation[] = [];
@@ -267,9 +270,11 @@ describe("local agent runner", () => {
               },
             ] as PiMessage[];
             await persistCompletedSessionForFakeReply(context, piMessages);
-            return successReply("captured", {
-              piMessages,
-            });
+            return completedAgentRun(
+              successReply("captured", {
+                piMessages,
+              }),
+            );
           },
         },
       );
@@ -321,7 +326,7 @@ describe("local agent runner", () => {
     const generateReply = vi.fn<typeof generateAssistantReply>(
       async (text, context) => {
         contexts.push(context);
-        return successReply(`reply to ${text}`);
+        return completedAgentRun(successReply(`reply to ${text}`));
       },
     );
 
@@ -369,7 +374,7 @@ describe("local agent runner", () => {
     expect(conversationId).toBeDefined();
 
     const generateReply = vi.fn<typeof generateAssistantReply>(async () =>
-      successReply("not delivered"),
+      completedAgentRun(successReply("not delivered")),
     );
 
     await expect(
@@ -429,7 +434,7 @@ describe("local agent runner", () => {
     const generateReply = vi.fn<typeof generateAssistantReply>(
       async (_text, context) => {
         contexts.push(context);
-        return successReply("uses projection");
+        return completedAgentRun(successReply("uses projection"));
       },
     );
 
@@ -465,9 +470,11 @@ describe("local agent runner", () => {
       },
     ] as PiMessage[];
     const generateReply = vi.fn<typeof generateAssistantReply>(async () =>
-      successReply("persisted visible output", {
-        piMessages: generatedMessages,
-      }),
+      completedAgentRun(
+        successReply("persisted visible output", {
+          piMessages: generatedMessages,
+        }),
+      ),
     );
 
     await runLocalAgentTurn(
@@ -498,7 +505,7 @@ describe("local agent runner", () => {
         deliverReply: async () => undefined,
         generateAssistantReply: async (_text, context) => {
           contexts.push(context);
-          return successReply("follow up reply");
+          return completedAgentRun(successReply("follow up reply"));
         },
       },
     );
@@ -559,9 +566,11 @@ describe("local agent runner", () => {
                 context,
                 generatedMessages,
               );
-              return successReply("visible reply", {
-                piMessages: generatedMessages,
-              });
+              return completedAgentRun(
+                successReply("visible reply", {
+                  piMessages: generatedMessages,
+                }),
+              );
             },
           },
         ),
@@ -618,7 +627,7 @@ describe("local agent runner", () => {
         deliverReply: async () => undefined,
         generateAssistantReply: async (_text, context) => {
           contexts.push(context);
-          return successReply("uses newer fallback");
+          return completedAgentRun(successReply("uses newer fallback"));
         },
       },
     );
@@ -652,7 +661,7 @@ describe("local agent runner", () => {
           messages: [assistantMessage],
           ttlMs: 60_000,
         });
-        return successReply("not delivered");
+        return completedAgentRun(successReply("not delivered"));
       },
     );
 

--- a/packages/junior/tests/integration/local-chat-cli.test.ts
+++ b/packages/junior/tests/integration/local-chat-cli.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AssistantReply } from "@/chat/respond";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const generateAssistantReplyMock = vi.hoisted(() => vi.fn());
 
@@ -75,7 +76,9 @@ export const plugins = {
 `,
     );
     process.chdir(tempDir);
-    generateAssistantReplyMock.mockResolvedValue(successReply("hello local"));
+    generateAssistantReplyMock.mockResolvedValue(
+      completedAgentRun(successReply("hello local")),
+    );
     const output: string[] = [];
 
     try {

--- a/packages/junior/tests/integration/mcp-oauth-callback-slack.test.ts
+++ b/packages/junior/tests/integration/mcp-oauth-callback-slack.test.ts
@@ -18,6 +18,7 @@ import {
   createPluginAppFixture,
   type PluginAppFixture,
 } from "../fixtures/plugin-app";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const { generateAssistantReplyMock } = vi.hoisted(() => ({
   generateAssistantReplyMock: vi.fn(),
@@ -46,6 +47,18 @@ function slackSource(threadTs: string) {
 
     type: "priv",
   });
+}
+
+function makeDiagnostics() {
+  return {
+    assistantMessageCount: 1,
+    modelId: "fake-mcp-oauth-callback",
+    outcome: "success" as const,
+    toolCalls: [],
+    toolErrorCount: 0,
+    toolResultCount: 0,
+    usedPrimaryText: true,
+  };
 }
 
 type ArtifactStateModule = typeof import("@/chat/state/artifacts");
@@ -145,18 +158,17 @@ async function createAwaitingMcpTurnRecord(args: {
 describe("mcp oauth callback slack integration", () => {
   beforeEach(async () => {
     generateAssistantReplyMock.mockReset();
-    generateAssistantReplyMock.mockResolvedValue({
-      text: "The budget deadline you mentioned earlier was Friday.",
-      artifactStatePatch: {
-        lastCanvasUrl: "https://example.com/canvas",
-      },
-      sandboxId: "sandbox-1",
-      sandboxDependencyProfileHash: "hash-1",
-      diagnostics: {
-        outcome: "success",
-        toolCalls: [],
-      },
-    });
+    generateAssistantReplyMock.mockResolvedValue(
+      completedAgentRun({
+        text: "The budget deadline you mentioned earlier was Friday.",
+        artifactStatePatch: {
+          lastCanvasUrl: "https://example.com/canvas",
+        },
+        sandboxId: "sandbox-1",
+        sandboxDependencyProfileHash: "hash-1",
+        diagnostics: makeDiagnostics(),
+      }),
+    );
     resetSlackApiMockState();
     process.env = {
       ...ORIGINAL_ENV,
@@ -894,24 +906,23 @@ describe("mcp oauth callback slack integration", () => {
   });
 
   it("uploads resumed reply files without posting an extra thread message for empty inline text", async () => {
-    generateAssistantReplyMock.mockResolvedValueOnce({
-      text: "",
-      files: [
-        {
-          data: Buffer.from("hello"),
-          filename: "resume.txt",
+    generateAssistantReplyMock.mockResolvedValueOnce(
+      completedAgentRun({
+        text: "",
+        files: [
+          {
+            data: Buffer.from("hello"),
+            filename: "resume.txt",
+          },
+        ],
+        deliveryPlan: {
+          mode: "thread",
+          postThreadText: true,
+          attachFiles: "inline",
         },
-      ],
-      deliveryPlan: {
-        mode: "thread",
-        postThreadText: true,
-        attachFiles: "inline",
-      },
-      diagnostics: {
-        outcome: "success",
-        toolCalls: [],
-      },
-    });
+        diagnostics: makeDiagnostics(),
+      }),
+    );
     await stateAdapterModule
       .getStateAdapter()
       .set("thread-state:slack:C123:1700000000.002", {
@@ -980,24 +991,23 @@ describe("mcp oauth callback slack integration", () => {
   });
 
   it("uploads resumed reply files even when thread text delivery is suppressed", async () => {
-    generateAssistantReplyMock.mockResolvedValueOnce({
-      text: "👍",
-      files: [
-        {
-          data: Buffer.from("hello"),
-          filename: "resume.txt",
+    generateAssistantReplyMock.mockResolvedValueOnce(
+      completedAgentRun({
+        text: "👍",
+        files: [
+          {
+            data: Buffer.from("hello"),
+            filename: "resume.txt",
+          },
+        ],
+        deliveryPlan: {
+          mode: "thread",
+          postThreadText: false,
+          attachFiles: "inline",
         },
-      ],
-      deliveryPlan: {
-        mode: "thread",
-        postThreadText: false,
-        attachFiles: "inline",
-      },
-      diagnostics: {
-        outcome: "success",
-        toolCalls: [],
-      },
-    });
+        diagnostics: makeDiagnostics(),
+      }),
+    );
     await stateAdapterModule
       .getStateAdapter()
       .set("thread-state:slack:C123:1700000000.003", {

--- a/packages/junior/tests/integration/oauth-callback-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-callback-slack.test.ts
@@ -9,6 +9,7 @@ import {
   createPluginAppFixture,
   type PluginAppFixture,
 } from "../fixtures/plugin-app";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const { generateAssistantReplyMock } = vi.hoisted(() => ({
   generateAssistantReplyMock: vi.fn(),
@@ -39,6 +40,18 @@ function slackSource(threadTs: string) {
   });
 }
 
+function makeDiagnostics() {
+  return {
+    assistantMessageCount: 1,
+    modelId: "fake-oauth-callback",
+    outcome: "success" as const,
+    toolCalls: [],
+    toolErrorCount: 0,
+    toolResultCount: 0,
+    usedPrimaryText: true,
+  };
+}
+
 type StateAdapterModule = typeof import("@/chat/state/adapter");
 type OAuthCallbackHarnessModule =
   typeof import("../fixtures/oauth-callback-harness");
@@ -52,13 +65,12 @@ let pluginApp: PluginAppFixture | undefined;
 describe("oauth callback slack integration", () => {
   beforeEach(async () => {
     generateAssistantReplyMock.mockReset();
-    generateAssistantReplyMock.mockResolvedValue({
-      text: "Here are your Sentry issues.",
-      diagnostics: {
-        outcome: "success",
-        toolCalls: [],
-      },
-    });
+    generateAssistantReplyMock.mockResolvedValue(
+      completedAgentRun({
+        text: "Here are your Sentry issues.",
+        diagnostics: makeDiagnostics(),
+      }),
+    );
     resetSlackApiMockState();
     process.env = {
       ...ORIGINAL_ENV,

--- a/packages/junior/tests/integration/oauth-resume-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-resume-slack.test.ts
@@ -11,10 +11,7 @@ import {
   getCapturedSlackFileUploadCalls,
   queueSlackApiError,
 } from "../msw/handlers/slack-api";
-import {
-  completedAgentRun,
-  failedAgentRun,
-} from "@/chat/runtime/agent-run-outcome";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 function makeDiagnostics(
   outcome: "success" | "execution_failure" | "provider_error" = "success",
@@ -228,7 +225,6 @@ describe("oauth resume slack integration", () => {
   it("posts resumed auth pause notices with the conversation footer", async () => {
     const { resumeAuthorizedRequest } =
       await import("@/chat/runtime/slack-resume");
-    const { RetryableTurnError } = await import("@/chat/runtime/turn");
 
     await resumeAuthorizedRequest({
       messageText: "continue this turn",
@@ -247,14 +243,10 @@ describe("oauth resume slack integration", () => {
           turnId: "turn-auth-pause",
         },
       },
-      generateReply: async () => {
-        throw new RetryableTurnError("mcp_auth_resume", "auth required", {
-          authDisposition: "link_sent",
-          authKind: "mcp",
-          authProvider: "eval-auth",
-          authProviderDisplayName: "Eval Auth",
-        });
-      },
+      generateReply: async () => ({
+        status: "awaiting_auth" as const,
+        providerDisplayName: "Eval Auth",
+      }),
       onAuthPause: async () => undefined,
     });
 
@@ -335,7 +327,7 @@ describe("oauth resume slack integration", () => {
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       generateReply: async () =>
-        failedAgentRun({
+        completedAgentRun({
           text: "Partial output",
           diagnostics: makeDiagnostics("provider_error"),
         }),
@@ -372,7 +364,7 @@ describe("oauth resume slack integration", () => {
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       generateReply: async () =>
-        failedAgentRun({
+        completedAgentRun({
           text: "",
           diagnostics: makeDiagnostics("execution_failure", {
             assistantMessageCount: 0,

--- a/packages/junior/tests/integration/oauth-resume-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-resume-slack.test.ts
@@ -11,6 +11,10 @@ import {
   getCapturedSlackFileUploadCalls,
   queueSlackApiError,
 } from "../msw/handlers/slack-api";
+import {
+  completedAgentRun,
+  failedAgentRun,
+} from "@/chat/runtime/agent-run-outcome";
 
 function makeDiagnostics(
   outcome: "success" | "execution_failure" | "provider_error" = "success",
@@ -82,7 +86,7 @@ describe("oauth resume slack integration", () => {
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       generateReply: async () =>
-        ({
+        completedAgentRun({
           text: "The budget deadline you mentioned earlier was Friday.",
           diagnostics: makeDiagnostics("success", {
             durationMs: 842,
@@ -90,7 +94,7 @@ describe("oauth resume slack integration", () => {
               totalTokens: 1234,
             },
           }),
-        }) as any,
+        }),
     });
 
     expect(getCapturedSlackApiCalls("assistant.threads.setStatus")).toEqual([
@@ -184,7 +188,7 @@ describe("oauth resume slack integration", () => {
         },
       },
       generateReply: async () =>
-        ({
+        completedAgentRun({
           text: "done",
           diagnostics: makeDiagnostics("success", {
             durationMs: 500,
@@ -192,7 +196,7 @@ describe("oauth resume slack integration", () => {
               outputTokens: 7,
             },
           }),
-        }) as any,
+        }),
     });
 
     expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([
@@ -291,10 +295,10 @@ describe("oauth resume slack integration", () => {
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       generateReply: async () =>
-        ({
+        completedAgentRun({
           text: longReply,
           diagnostics: makeDiagnostics(),
-        }) as any,
+        }),
     });
 
     const postCalls = getCapturedSlackApiCalls("chat.postMessage");
@@ -331,10 +335,10 @@ describe("oauth resume slack integration", () => {
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       generateReply: async () =>
-        ({
+        failedAgentRun({
           text: "Partial output",
           diagnostics: makeDiagnostics("provider_error"),
-        }) as any,
+        }),
     });
 
     const postCalls = getCapturedSlackApiCalls("chat.postMessage");
@@ -368,13 +372,13 @@ describe("oauth resume slack integration", () => {
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       generateReply: async () =>
-        ({
+        failedAgentRun({
           text: "",
           diagnostics: makeDiagnostics("execution_failure", {
             assistantMessageCount: 0,
             usedPrimaryText: false,
           }),
-        }) as any,
+        }),
     });
 
     const postCalls = getCapturedSlackApiCalls("chat.postMessage");
@@ -406,7 +410,7 @@ describe("oauth resume slack integration", () => {
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       generateReply: async () =>
-        ({
+        completedAgentRun({
           text: "Here is the resumed artifact.",
           files: [
             {
@@ -415,7 +419,7 @@ describe("oauth resume slack integration", () => {
             },
           ],
           diagnostics: makeDiagnostics(),
-        }) as any,
+        }),
     });
 
     const postCalls = getCapturedSlackApiCalls("chat.postMessage");
@@ -465,7 +469,7 @@ describe("oauth resume slack integration", () => {
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
       },
       generateReply: async () =>
-        ({
+        completedAgentRun({
           text: "Here is the resumed artifact.",
           files: [
             {
@@ -474,7 +478,7 @@ describe("oauth resume slack integration", () => {
             },
           ],
           diagnostics: makeDiagnostics(),
-        }) as any,
+        }),
     });
 
     expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([

--- a/packages/junior/tests/integration/slack/assistant-context-canvas-routing.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-context-canvas-routing.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createCanvas } from "@/chat/tools/slack/canvases";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import {
   canvasesAccessSetOk,
   canvasesCreateOk,
@@ -47,7 +48,7 @@ describe("Slack behavior: assistant context canvas routing", () => {
               markdown: "Context-aware update",
               channelId: context?.toolChannelId,
             });
-            return {
+            return completedAgentRun({
               text: "Shared canvas created.",
               diagnostics: {
                 assistantMessageCount: 1,
@@ -58,7 +59,7 @@ describe("Slack behavior: assistant context canvas routing", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },

--- a/packages/junior/tests/integration/slack/assistant-context-channel-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-context-channel-behavior.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import { createTestChatRuntime } from "../../fixtures/chat-runtime";
 import {
   createTestMessage,
@@ -15,7 +16,7 @@ describe("Slack behavior: assistant context channel routing", () => {
         replyExecutor: {
           generateAssistantReply: async (_prompt, context) => {
             capturedToolChannelIds.push(context?.toolChannelId);
-            return {
+            return completedAgentRun({
               text: "Canvas draft prepared.",
               diagnostics: {
                 assistantMessageCount: 1,
@@ -26,7 +27,7 @@ describe("Slack behavior: assistant context channel routing", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },

--- a/packages/junior/tests/integration/slack/assistant-thread-contract.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-thread-contract.test.ts
@@ -13,6 +13,7 @@ import type { ReplyExecutorServices } from "@/chat/runtime/reply-executor";
 import { createJuniorSlackAdapter } from "@/chat/slack/adapter";
 import type { ConversationMemoryDeps } from "@/chat/services/conversation-memory";
 import { handleChatSdkPlatformWebhook } from "@/handlers/webhooks";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const SIGNING_SECRET = "test-signing-secret";
 const BOT_USER_ID = "U_BOT";
@@ -64,6 +65,13 @@ function makeDiagnostics() {
     toolResultCount: 0,
     usedPrimaryText: true,
   };
+}
+
+function makeCompletedReply(text: string) {
+  return completedAgentRun({
+    text,
+    diagnostics: makeDiagnostics(),
+  });
 }
 
 async function createDirectMessageBot(args: {
@@ -152,10 +160,7 @@ describe("Slack contract: assistant-thread delivery", () => {
     const bot = await createDirectMessageBot({
       generateAssistantReply: async (_prompt, context) => {
         await context?.onStatus?.(makeAssistantStatus("running", "bash"));
-        return {
-          text: "Done.",
-          diagnostics: makeDiagnostics(),
-        };
+        return makeCompletedReply("Done.");
       },
     });
     const waitUntil = slackWebhookClient.waitUntil();
@@ -177,10 +182,7 @@ describe("Slack contract: assistant-thread delivery", () => {
     const bot = await createDirectMessageBot({
       generateAssistantReply: async (_prompt, context) => {
         await context?.onStatus?.(makeAssistantStatus("running", "bash"));
-        return {
-          text: "Done.",
-          diagnostics: makeDiagnostics(),
-        };
+        return makeCompletedReply("Done.");
       },
     });
     const waitUntil = slackWebhookClient.waitUntil();
@@ -221,10 +223,7 @@ describe("Slack contract: assistant-thread delivery", () => {
     const bot = await createMentionBot({
       generateAssistantReply: async (_prompt, context) => {
         await context?.onStatus?.(makeAssistantStatus("running", "bash"));
-        return {
-          text: "Done.",
-          diagnostics: makeDiagnostics(),
-        };
+        return makeCompletedReply("Done.");
       },
     });
     const waitUntil = slackWebhookClient.waitUntil();
@@ -266,10 +265,8 @@ describe("Slack contract: assistant-thread delivery", () => {
           text: "Debugging Node.js Memory Leaks",
           message: { role: "assistant", content: "" },
         }) as any,
-      generateAssistantReply: async () => ({
-        text: "Here is how to debug memory leaks.",
-        diagnostics: makeDiagnostics(),
-      }),
+      generateAssistantReply: async () =>
+        makeCompletedReply("Here is how to debug memory leaks."),
     });
     const waitUntil = slackWebhookClient.waitUntil();
 
@@ -308,10 +305,8 @@ describe("Slack contract: assistant-thread delivery", () => {
             } as any);
           };
         }),
-      generateAssistantReply: async () => ({
-        text: "Here is how to debug memory leaks.",
-        diagnostics: makeDiagnostics(),
-      }),
+      generateAssistantReply: async () =>
+        makeCompletedReply("Here is how to debug memory leaks."),
     });
     const waitUntil = slackWebhookClient.waitUntil();
 
@@ -359,10 +354,8 @@ describe("Slack contract: assistant-thread delivery", () => {
           text: "Debugging Node.js Memory Leaks",
           message: { role: "assistant", content: "" },
         }) as any,
-      generateAssistantReply: async () => ({
-        text: "Here is how to debug memory leaks.",
-        diagnostics: makeDiagnostics(),
-      }),
+      generateAssistantReply: async () =>
+        makeCompletedReply("Here is how to debug memory leaks."),
     });
     const waitUntil = slackWebhookClient.waitUntil();
 

--- a/packages/junior/tests/integration/slack/attachment-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/attachment-behavior.test.ts
@@ -5,6 +5,7 @@ import {
   createTestThread,
   createTestDestination,
 } from "../../fixtures/slack-harness";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -67,18 +68,18 @@ describe("Slack behavior: attachment handling", () => {
               capturedAttachmentMediaTypes.push(attachments[0].mediaType);
             }
 
-            return {
+            return completedAgentRun({
               text: "Image received. The chart trend is upward.",
               diagnostics: {
                 assistantMessageCount: 1,
                 modelId: "fake-agent-model",
-                outcome: "success",
+                outcome: "success" as const,
                 toolCalls: [],
                 toolErrorCount: 0,
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },
@@ -119,18 +120,20 @@ describe("Slack behavior: attachment handling", () => {
     const completeTextMock = vi.fn(async () => {
       throw new Error("vision unavailable");
     });
-    const generateAssistantReply = vi.fn(async () => ({
-      text: "should not post",
-      diagnostics: {
-        assistantMessageCount: 1,
-        modelId: "fake-agent-model",
-        outcome: "success" as const,
-        toolCalls: [],
-        toolErrorCount: 0,
-        toolResultCount: 0,
-        usedPrimaryText: true,
-      },
-    }));
+    const generateAssistantReply = vi.fn(async () =>
+      completedAgentRun({
+        text: "should not post",
+        diagnostics: {
+          assistantMessageCount: 1,
+          modelId: "fake-agent-model",
+          outcome: "success" as const,
+          toolCalls: [],
+          toolErrorCount: 0,
+          toolResultCount: 0,
+          usedPrimaryText: true,
+        },
+      }),
+    );
 
     const { slackRuntime } = await createRuntime({
       services: {

--- a/packages/junior/tests/integration/slack/attachment-media-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/attachment-media-behavior.test.ts
@@ -5,6 +5,7 @@ import {
   createTestThread,
   createTestDestination,
 } from "../../fixtures/slack-harness";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -76,18 +77,18 @@ describe("Slack behavior: mixed attachment media", () => {
               capturedAttachmentNames.push(
                 attachments.map((attachment) => attachment.filename ?? ""),
               );
-              return {
+              return completedAgentRun({
                 text: "Processed attachments.",
                 diagnostics: {
                   assistantMessageCount: 1,
                   modelId: "fake-agent-model",
-                  outcome: "success",
+                  outcome: "success" as const,
                   toolCalls: [],
                   toolErrorCount: 0,
                   toolResultCount: 0,
                   usedPrimaryText: true,
                 },
-              };
+              });
             },
           },
         },
@@ -173,18 +174,18 @@ describe("Slack behavior: mixed attachment media", () => {
             capturedOmittedImageCounts.push(
               context?.omittedImageAttachmentCount ?? 0,
             );
-            return {
+            return completedAgentRun({
               text: "Processed attachments.",
               diagnostics: {
                 assistantMessageCount: 1,
                 modelId: "fake-agent-model",
-                outcome: "success",
+                outcome: "success" as const,
                 toolCalls: [],
                 toolErrorCount: 0,
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },
@@ -229,7 +230,7 @@ describe("Slack behavior: mixed attachment media", () => {
     const capturedOmittedImageCounts: number[] = [];
     const generateAssistantReply = vi.fn(
       async (_prompt?: string, _context?: unknown) => {
-        return {
+        return completedAgentRun({
           text: "I can’t inspect the attached image in this runtime, but I do see that an image was included.",
           diagnostics: {
             assistantMessageCount: 1,
@@ -240,7 +241,7 @@ describe("Slack behavior: mixed attachment media", () => {
             toolResultCount: 0,
             usedPrimaryText: true,
           },
-        };
+        });
       },
     );
 

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -4,7 +4,10 @@ import type { JuniorRuntimeServiceOverrides } from "@/chat/app/services";
 import type { ReplyRequestContext } from "@/chat/respond";
 import { makeAssistantStatus } from "@/chat/slack/assistant-thread/status";
 import { getSlackInterruptionMarker } from "@/chat/slack/output";
-import { RetryableTurnError } from "@/chat/runtime/turn";
+import {
+  completedAgentRun,
+  failedAgentRun,
+} from "@/chat/runtime/agent-run-outcome";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import { acquireActiveLock } from "@/chat/state/locks";
 import { loadProjection } from "@/chat/state/session-log";
@@ -176,18 +179,19 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: "Hello from the bot!",
-            diagnostics: {
-              assistantMessageCount: 1,
-              modelId: "test-model",
-              outcome: "success" as const,
-              toolCalls: [],
-              toolErrorCount: 0,
-              toolResultCount: 0,
-              usedPrimaryText: true,
-            },
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: "Hello from the bot!",
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "test-model",
+                outcome: "success" as const,
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            }),
           scheduleSessionCompletedPluginTasks,
         },
         visionContext: {
@@ -325,18 +329,19 @@ describe("bot handlers (integration)", () => {
             }) as any,
         },
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: "Replying to mention",
-            diagnostics: {
-              assistantMessageCount: 1,
-              modelId: "test-model",
-              outcome: "success" as const,
-              toolCalls: [],
-              toolErrorCount: 0,
-              toolResultCount: 0,
-              usedPrimaryText: true,
-            },
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: "Replying to mention",
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "test-model",
+                outcome: "success" as const,
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            }),
         },
         visionContext: {
           listThreadReplies: async () => [],
@@ -490,7 +495,7 @@ describe("bot handlers (integration)", () => {
               state: "running",
               piMessages: promptMessages,
             });
-            return {
+            return completedAgentRun({
               text: finalText,
               piMessages: [
                 ...promptMessages,
@@ -527,7 +532,7 @@ describe("bot handlers (integration)", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
         visionContext: {
@@ -605,18 +610,19 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: finalText,
-            diagnostics: {
-              assistantMessageCount: 1,
-              modelId: "fake-agent-model",
-              outcome: "success" as const,
-              toolCalls: [],
-              toolErrorCount: 0,
-              toolResultCount: 0,
-              usedPrimaryText: true,
-            },
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: finalText,
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "fake-agent-model",
+                outcome: "success" as const,
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            }),
         },
         visionContext: {
           listThreadReplies: async () => [],
@@ -685,7 +691,7 @@ describe("bot handlers (integration)", () => {
               turnId: context?.correlation?.turnId,
               runId: context?.correlation?.runId,
             });
-            return {
+            return completedAgentRun({
               text: "Done.",
               diagnostics: {
                 assistantMessageCount: 1,
@@ -696,7 +702,7 @@ describe("bot handlers (integration)", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },
@@ -734,16 +740,17 @@ describe("bot handlers (integration)", () => {
       services: {
         replyExecutor: {
           generateAssistantReply: async () => {
-            throw new RetryableTurnError(
-              "mcp_auth_resume",
-              "simulated auth pause",
-              {
-                authDisposition: "link_sent",
-                authKind: "mcp",
-                authProvider: "notion",
-                authProviderDisplayName: "Notion",
-              },
-            );
+            return {
+              status: "awaiting_auth",
+              authDisposition: "link_sent",
+              authDurationMs: 1,
+              authKind: "mcp",
+              authProvider: "notion",
+              authProviderDisplayName: "Notion",
+              conversationId: "slack:C_AUTH:1700000000.000",
+              sessionId: "turn_msg-auth-pause",
+              sliceId: 2,
+            };
           },
         },
       },
@@ -817,16 +824,17 @@ describe("bot handlers (integration)", () => {
       services: {
         replyExecutor: {
           generateAssistantReply: async () => {
-            throw new RetryableTurnError(
-              "plugin_auth_resume",
-              "simulated plugin auth pause",
-              {
-                authDisposition: "link_sent",
-                authKind: "plugin",
-                authProvider: "github",
-                authProviderDisplayName: "GitHub",
-              },
-            );
+            return {
+              status: "awaiting_auth",
+              authDisposition: "link_sent",
+              authDurationMs: 1,
+              authKind: "plugin",
+              authProvider: "github",
+              authProviderDisplayName: "GitHub",
+              conversationId: "slack:C_PLUGIN_AUTH:1700000000.000",
+              sessionId: "turn_msg-plugin-auth-pause",
+              sliceId: 2,
+            };
           },
         },
       },
@@ -907,16 +915,13 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           scheduleAgentContinue,
           generateAssistantReply: async () => {
-            throw new RetryableTurnError(
-              "agent_continue",
-              "simulated timeout continuation",
-              {
-                conversationId,
-                sessionId,
-                version: 3,
-                sliceId: 2,
-              },
-            );
+            return {
+              status: "timed_out",
+              conversationId,
+              sessionId,
+              version: 3,
+              sliceId: 2,
+            };
           },
         },
       },
@@ -966,16 +971,13 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           scheduleAgentContinue,
           generateAssistantReply: async () => {
-            throw new RetryableTurnError(
-              "agent_continue",
-              "simulated timeout continuation",
-              {
-                conversationId,
-                sessionId,
-                version: 4,
-                sliceId: 2,
-              },
-            );
+            return {
+              status: "timed_out",
+              conversationId,
+              sessionId,
+              version: 4,
+              sliceId: 2,
+            };
           },
         },
       },
@@ -1018,16 +1020,13 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           scheduleAgentContinue,
           generateAssistantReply: async () => {
-            throw new RetryableTurnError(
-              "agent_continue",
-              "simulated timeout continuation",
-              {
-                conversationId,
-                sessionId,
-                version: 3,
-                sliceId: 2,
-              },
-            );
+            return {
+              status: "timed_out",
+              conversationId,
+              sessionId,
+              version: 3,
+              sliceId: 2,
+            };
           },
         },
       },
@@ -1145,18 +1144,20 @@ describe("bot handlers (integration)", () => {
   it("answers a follow-up as a fresh turn when the active session is auth-parked", async () => {
     const conversationId = "slack:C_AUTH_PARKED:1700000000.000";
     const activeSessionId = "turn_msg-auth-original";
-    const generateAssistantReply = vi.fn().mockResolvedValue({
-      text: "Fresh answer without the provider.",
-      diagnostics: {
-        assistantMessageCount: 1,
-        modelId: "test-model",
-        outcome: "success" as const,
-        toolCalls: [],
-        toolErrorCount: 0,
-        toolResultCount: 0,
-        usedPrimaryText: true,
-      },
-    });
+    const generateAssistantReply = vi.fn().mockResolvedValue(
+      completedAgentRun({
+        text: "Fresh answer without the provider.",
+        diagnostics: {
+          assistantMessageCount: 1,
+          modelId: "test-model",
+          outcome: "success" as const,
+          toolCalls: [],
+          toolErrorCount: 0,
+          toolResultCount: 0,
+          usedPrimaryText: true,
+        },
+      }),
+    );
     await upsertAgentTurnSessionRecord({
       conversationId,
       sessionId: activeSessionId,
@@ -1527,18 +1528,20 @@ describe("bot handlers (integration)", () => {
   it("fails malformed awaiting continuations before handling the follow-up", async () => {
     const conversationId = "slack:C_BAD_CONTINUATION:1700000000.000";
     const activeSessionId = "turn_msg-timeout-original";
-    const generateAssistantReply = vi.fn().mockResolvedValue({
-      text: "Recovered.",
-      diagnostics: {
-        assistantMessageCount: 1,
-        modelId: "test-model",
-        outcome: "success" as const,
-        toolCalls: [],
-        toolErrorCount: 0,
-        toolResultCount: 0,
-        usedPrimaryText: true,
-      },
-    });
+    const generateAssistantReply = vi.fn().mockResolvedValue(
+      completedAgentRun({
+        text: "Recovered.",
+        diagnostics: {
+          assistantMessageCount: 1,
+          modelId: "test-model",
+          outcome: "success" as const,
+          toolCalls: [],
+          toolErrorCount: 0,
+          toolResultCount: 0,
+          usedPrimaryText: true,
+        },
+      }),
+    );
     await upsertAgentTurnSessionRecord({
       conversationId,
       sessionId: activeSessionId,
@@ -1805,7 +1808,7 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           generateAssistantReply: async (_prompt, context) => {
             await context?.onTextDelta?.("Partial output...");
-            return {
+            return failedAgentRun({
               text: "Partial output...",
               diagnostics: {
                 assistantMessageCount: 1,
@@ -1816,7 +1819,7 @@ describe("bot handlers (integration)", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },
@@ -1857,7 +1860,7 @@ describe("bot handlers (integration)", () => {
             await context?.onStatus?.(
               makeAssistantStatus("reading", "channel messages"),
             );
-            return {
+            return completedAgentRun({
               text: "Done.",
               diagnostics: {
                 assistantMessageCount: 1,
@@ -1868,7 +1871,7 @@ describe("bot handlers (integration)", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },
@@ -1926,7 +1929,7 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           generateAssistantReply: async () => {
             replyStarted = true;
-            return {
+            return completedAgentRun({
               text: "Still replied while status was pending.",
               diagnostics: {
                 assistantMessageCount: 1,
@@ -1937,7 +1940,7 @@ describe("bot handlers (integration)", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },
@@ -2009,7 +2012,7 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           generateAssistantReply: async () => {
             replyStarted = true;
-            return {
+            return completedAgentRun({
               text: "Reply lands after the pending status is drained.",
               diagnostics: {
                 assistantMessageCount: 1,
@@ -2020,7 +2023,7 @@ describe("bot handlers (integration)", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },
@@ -2070,18 +2073,19 @@ describe("bot handlers (integration)", () => {
             }) as any,
         },
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: "Here is how to debug memory leaks.",
-            diagnostics: {
-              assistantMessageCount: 1,
-              modelId: "test-model",
-              outcome: "success" as const,
-              toolCalls: [],
-              toolErrorCount: 0,
-              toolResultCount: 0,
-              usedPrimaryText: true,
-            },
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: "Here is how to debug memory leaks.",
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "test-model",
+                outcome: "success" as const,
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            }),
         },
       },
     });
@@ -2130,18 +2134,19 @@ describe("bot handlers (integration)", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: "Here is the updated answer.",
-            diagnostics: {
-              assistantMessageCount: 1,
-              modelId: "test-model",
-              outcome: "success" as const,
-              toolCalls: [],
-              toolErrorCount: 0,
-              toolResultCount: 0,
-              usedPrimaryText: true,
-            },
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: "Here is the updated answer.",
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "test-model",
+                outcome: "success" as const,
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            }),
         },
       },
     });
@@ -2189,18 +2194,19 @@ describe("bot handlers (integration)", () => {
             }) as any,
         },
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: "Today is April 16, 2026.",
-            diagnostics: {
-              assistantMessageCount: 1,
-              modelId: "test-model",
-              outcome: "success" as const,
-              toolCalls: [],
-              toolErrorCount: 0,
-              toolResultCount: 0,
-              usedPrimaryText: true,
-            },
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: "Today is April 16, 2026.",
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "test-model",
+                outcome: "success" as const,
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            }),
         },
       },
     });
@@ -2259,18 +2265,19 @@ describe("bot handlers (integration)", () => {
             }),
         },
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: "Today is April 16, 2026.",
-            diagnostics: {
-              assistantMessageCount: 1,
-              modelId: "test-model",
-              outcome: "success" as const,
-              toolCalls: [],
-              toolErrorCount: 0,
-              toolResultCount: 0,
-              usedPrimaryText: true,
-            },
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: "Today is April 16, 2026.",
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "test-model",
+                outcome: "success" as const,
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            }),
         },
       },
     });
@@ -2338,7 +2345,7 @@ describe("bot handlers (integration)", () => {
             await context?.onArtifactStateUpdated?.({
               lastCanvasId: "F_CANVAS",
             });
-            return {
+            return completedAgentRun({
               text: "Today is April 16, 2026.",
               diagnostics: {
                 assistantMessageCount: 1,
@@ -2349,7 +2356,7 @@ describe("bot handlers (integration)", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },
@@ -2392,7 +2399,7 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           generateAssistantReply: async () => {
             turnCount += 1;
-            return {
+            return completedAgentRun({
               text: `reply-${turnCount}`,
               diagnostics: {
                 assistantMessageCount: 1,
@@ -2403,7 +2410,7 @@ describe("bot handlers (integration)", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },
@@ -2468,18 +2475,19 @@ describe("bot handlers (integration)", () => {
             }) as any,
         },
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: "This reply should still succeed.",
-            diagnostics: {
-              assistantMessageCount: 1,
-              modelId: "test-model",
-              outcome: "success" as const,
-              toolCalls: [],
-              toolErrorCount: 0,
-              toolResultCount: 0,
-              usedPrimaryText: true,
-            },
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: "This reply should still succeed.",
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "test-model",
+                outcome: "success" as const,
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            }),
         },
       },
     });
@@ -2528,18 +2536,19 @@ describe("bot handlers (integration)", () => {
           },
         },
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: "Reply still succeeds.",
-            diagnostics: {
-              assistantMessageCount: 1,
-              modelId: "test-model",
-              outcome: "success" as const,
-              toolCalls: [],
-              toolErrorCount: 0,
-              toolResultCount: 0,
-              usedPrimaryText: true,
-            },
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: "Reply still succeeds.",
+              diagnostics: {
+                assistantMessageCount: 1,
+                modelId: "test-model",
+                outcome: "success" as const,
+                toolCalls: [],
+                toolErrorCount: 0,
+                toolResultCount: 0,
+                usedPrimaryText: true,
+              },
+            }),
         },
       },
     });
@@ -2577,7 +2586,7 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           generateAssistantReply: async (_prompt, context) => {
             capturedContexts.push(context?.conversationContext);
-            return {
+            return completedAgentRun({
               text: "First reply.",
               diagnostics: {
                 assistantMessageCount: 1,
@@ -2588,7 +2597,7 @@ describe("bot handlers (integration)", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },
@@ -2618,7 +2627,7 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           generateAssistantReply: async (_prompt, context) => {
             capturedContexts.push(context?.conversationContext);
-            return {
+            return completedAgentRun({
               text: "Follow-up reply.",
               diagnostics: {
                 assistantMessageCount: 1,
@@ -2629,7 +2638,7 @@ describe("bot handlers (integration)", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },
@@ -2688,7 +2697,7 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           generateAssistantReply: async (_prompt, context) => {
             capturedContexts.push(context?.conversationContext);
-            return {
+            return completedAgentRun({
               text: "Responding to first message only.",
               diagnostics: {
                 assistantMessageCount: 1,
@@ -2699,7 +2708,7 @@ describe("bot handlers (integration)", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },
@@ -2746,7 +2755,7 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           generateAssistantReply: async () => {
             turnCount += 1;
-            return {
+            return completedAgentRun({
               text: `reply-${turnCount}`,
               diagnostics: {
                 assistantMessageCount: 1,
@@ -2757,7 +2766,7 @@ describe("bot handlers (integration)", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -4,10 +4,7 @@ import type { JuniorRuntimeServiceOverrides } from "@/chat/app/services";
 import type { ReplyRequestContext } from "@/chat/respond";
 import { makeAssistantStatus } from "@/chat/slack/assistant-thread/status";
 import { getSlackInterruptionMarker } from "@/chat/slack/output";
-import {
-  completedAgentRun,
-  failedAgentRun,
-} from "@/chat/runtime/agent-run-outcome";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import { acquireActiveLock } from "@/chat/state/locks";
 import { loadProjection } from "@/chat/state/session-log";
@@ -742,14 +739,7 @@ describe("bot handlers (integration)", () => {
           generateAssistantReply: async () => {
             return {
               status: "awaiting_auth",
-              authDisposition: "link_sent",
-              authDurationMs: 1,
-              authKind: "mcp",
-              authProvider: "notion",
-              authProviderDisplayName: "Notion",
-              conversationId: "slack:C_AUTH:1700000000.000",
-              sessionId: "turn_msg-auth-pause",
-              sliceId: 2,
+              providerDisplayName: "Notion",
             };
           },
         },
@@ -826,14 +816,7 @@ describe("bot handlers (integration)", () => {
           generateAssistantReply: async () => {
             return {
               status: "awaiting_auth",
-              authDisposition: "link_sent",
-              authDurationMs: 1,
-              authKind: "plugin",
-              authProvider: "github",
-              authProviderDisplayName: "GitHub",
-              conversationId: "slack:C_PLUGIN_AUTH:1700000000.000",
-              sessionId: "turn_msg-plugin-auth-pause",
-              sliceId: 2,
+              providerDisplayName: "GitHub",
             };
           },
         },
@@ -915,13 +898,7 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           scheduleAgentContinue,
           generateAssistantReply: async () => {
-            return {
-              status: "timed_out",
-              conversationId,
-              sessionId,
-              version: 3,
-              sliceId: 2,
-            };
+            return { status: "suspended", resumeVersion: 3 };
           },
         },
       },
@@ -971,13 +948,7 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           scheduleAgentContinue,
           generateAssistantReply: async () => {
-            return {
-              status: "timed_out",
-              conversationId,
-              sessionId,
-              version: 4,
-              sliceId: 2,
-            };
+            return { status: "suspended", resumeVersion: 4 };
           },
         },
       },
@@ -1020,13 +991,7 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           scheduleAgentContinue,
           generateAssistantReply: async () => {
-            return {
-              status: "timed_out",
-              conversationId,
-              sessionId,
-              version: 3,
-              sliceId: 2,
-            };
+            return { status: "suspended", resumeVersion: 3 };
           },
         },
       },
@@ -1808,7 +1773,7 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           generateAssistantReply: async (_prompt, context) => {
             await context?.onTextDelta?.("Partial output...");
-            return failedAgentRun({
+            return completedAgentRun({
               text: "Partial output...",
               diagnostics: {
                 assistantMessageCount: 1,

--- a/packages/junior/tests/integration/slack/bot-image-hydration.test.ts
+++ b/packages/junior/tests/integration/slack/bot-image-hydration.test.ts
@@ -5,6 +5,7 @@ import {
   createTestThread,
   createTestDestination,
 } from "../../fixtures/slack-harness";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const listThreadRepliesMock = vi.fn();
 const ORIGINAL_ENV = { ...process.env };
@@ -40,6 +41,10 @@ function makeSuccessReply(text = "ok") {
       usedPrimaryText: true,
     },
   };
+}
+
+function makeSuccessOutcome(text = "ok") {
+  return completedAgentRun(makeSuccessReply(text));
 }
 
 function extractImageAttachmentSummary(
@@ -78,7 +83,7 @@ describe("bot image hydration", () => {
             listThreadReplies: listThreadRepliesMock,
           },
           replyExecutor: {
-            generateAssistantReply: async () => makeSuccessReply(),
+            generateAssistantReply: async () => makeSuccessOutcome(),
           },
         },
       },
@@ -177,7 +182,7 @@ describe("bot image hydration", () => {
           listThreadReplies: listThreadRepliesMock,
         },
         replyExecutor: {
-          generateAssistantReply: async () => makeSuccessReply(),
+          generateAssistantReply: async () => makeSuccessOutcome(),
         },
       },
     });
@@ -279,7 +284,7 @@ describe("bot image hydration", () => {
           listThreadReplies: listThreadRepliesMock,
         },
         replyExecutor: {
-          generateAssistantReply: async () => makeSuccessReply(),
+          generateAssistantReply: async () => makeSuccessOutcome(),
         },
       },
     });
@@ -361,7 +366,7 @@ describe("bot image hydration", () => {
             completeText: completeTextMock,
           },
           replyExecutor: {
-            generateAssistantReply: async () => makeSuccessReply(),
+            generateAssistantReply: async () => makeSuccessOutcome(),
           },
         },
       },
@@ -451,7 +456,7 @@ describe("bot image hydration", () => {
         expect(context?.conversationContext).toContain(
           "Passive screenshot summary",
         );
-        return makeSuccessReply();
+        return makeSuccessOutcome();
       },
     );
 
@@ -613,7 +618,7 @@ describe("bot image hydration", () => {
             promptText: expect.stringContaining("Current screenshot summary"),
           }),
         ]);
-        return makeSuccessReply();
+        return makeSuccessOutcome();
       },
     );
 
@@ -772,7 +777,7 @@ describe("bot image hydration", () => {
             promptText: expect.stringContaining("Second cached summary"),
           }),
         ]);
-        return makeSuccessReply();
+        return makeSuccessOutcome();
       },
     );
 
@@ -896,7 +901,7 @@ describe("bot image hydration", () => {
         const summary = extractImageAttachmentSummary(promptText);
         expect(summary).toBe(longSummary.slice(0, 500));
         expect(summary).toHaveLength(500);
-        return makeSuccessReply();
+        return makeSuccessOutcome();
       },
     );
 
@@ -1010,10 +1015,11 @@ describe("bot image hydration", () => {
           listThreadReplies: listThreadRepliesMock.mockResolvedValue([]),
         },
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            ...makeSuccessReply("Here is your image"),
-            files: [generatedFile],
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              ...makeSuccessReply("Here is your image"),
+              files: [generatedFile],
+            }),
         },
       },
     });
@@ -1066,7 +1072,7 @@ describe("bot image hydration", () => {
         },
         replyExecutor: {
           generateAssistantReply: async (_text: string, _context: any) => {
-            return {
+            return completedAgentRun({
               ...makeSuccessReply("finalized content"),
               files: [
                 {
@@ -1075,7 +1081,7 @@ describe("bot image hydration", () => {
                   mimeType: "image/png",
                 },
               ],
-            };
+            });
           },
         },
       },

--- a/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
@@ -25,6 +25,7 @@ import {
   getConversationWorkState,
 } from "@/chat/task-execution/store";
 import { processConversationQueueMessage } from "@/chat/task-execution/vercel-callback";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const CHANNEL_ID = "CSTEER";
 const THREAD_TS = "1712345.000100";
@@ -178,10 +179,11 @@ describe("Slack behavior: durable turn steering", () => {
   it("does not enqueue duplicate Slack event retries for a persisted message", async () => {
     const state = getStateAdapter();
     const { conversationId, queue, services } = createTurnHarness({
-      generateAssistantReply: async () => ({
-        text: "not used",
-        diagnostics: makeDiagnostics(),
-      }),
+      generateAssistantReply: async () =>
+        completedAgentRun({
+          text: "not used",
+          diagnostics: makeDiagnostics(),
+        }),
       state,
     });
     const event = makeMessageEvent({
@@ -264,13 +266,13 @@ describe("Slack behavior: durable turn steering", () => {
 
         const steeringTexts = steeringMessages.map((message) => message.text);
         agentCalls.push({ prompt, steeringTexts });
-        return {
+        return completedAgentRun({
           text: [
             `Handled initial: ${prompt}`,
             `Steered: ${steeringTexts.join(" | ")}`,
           ].join("\n"),
           diagnostics: makeDiagnostics(),
-        };
+        });
       };
     const { conversationId, queue, runNextQueuedWork, services } =
       createTurnHarness({
@@ -445,10 +447,10 @@ describe("Slack behavior: durable turn steering", () => {
         generateAssistantReply: async (prompt, context) => {
           replyCalls.push(prompt);
           await context?.onInputCommitted?.();
-          return {
+          return completedAgentRun({
             text: "Started.",
             diagnostics: makeDiagnostics(),
-          };
+          });
         },
         state,
       });
@@ -515,10 +517,10 @@ describe("Slack behavior: durable turn steering", () => {
         if (drainedTexts.length === 0 && drained) {
           drainedTexts.push(...drained.map((message) => message.text));
         }
-        return {
+        return completedAgentRun({
           text: "Done with the initial request.",
           diagnostics: makeDiagnostics(),
-        };
+        });
       };
     const { conversationId, runNextQueuedWork, services } = createTurnHarness({
       completeObject: completeObjectWithDecision((prompt) =>

--- a/packages/junior/tests/integration/slack/file-delivery-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/file-delivery-behavior.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import { createTestChatRuntime } from "../../fixtures/chat-runtime";
 import {
   createTestMessage,
@@ -28,7 +29,7 @@ describe("Slack behavior: file delivery", () => {
         replyExecutor: {
           generateAssistantReply: async (_prompt, context) => {
             await context?.onTextDelta?.("Preview is ready.");
-            return {
+            return completedAgentRun({
               text: "Preview is ready.",
               deliveryPlan: {
                 mode: "thread",
@@ -45,7 +46,7 @@ describe("Slack behavior: file delivery", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },

--- a/packages/junior/tests/integration/slack/finalized-reply-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/finalized-reply-behavior.test.ts
@@ -11,6 +11,10 @@ import {
   createTestThread,
   createTestDestination,
 } from "../../fixtures/slack-harness";
+import {
+  completedAgentRun,
+  failedAgentRun,
+} from "@/chat/runtime/agent-run-outcome";
 
 function toPostedText(value: unknown): string {
   if (typeof value === "string") {
@@ -72,10 +76,10 @@ describe("Slack behavior: finalized thread replies", () => {
           generateAssistantReply: async (_prompt, context) => {
             await context?.onTextDelta?.("Hello ");
             await context?.onTextDelta?.("world");
-            return {
+            return completedAgentRun({
               text: "Hello world",
               diagnostics: makeDiagnostics(),
-            };
+            });
           },
         },
       },
@@ -107,10 +111,10 @@ describe("Slack behavior: finalized thread replies", () => {
             await context?.onTextDelta?.("Fetching sources now...");
             await context?.onAssistantMessageStart?.();
             await context?.onTextDelta?.(finalReply);
-            return {
+            return completedAgentRun({
               text: finalReply,
               diagnostics: makeDiagnostics({ toolCalls: ["webSearch"] }),
-            };
+            });
           },
         },
       },
@@ -136,11 +140,12 @@ describe("Slack behavior: finalized thread replies", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: "",
-            files: [{ data: Buffer.from("hello"), filename: "hello.txt" }],
-            diagnostics: makeDiagnostics(),
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: "",
+              files: [{ data: Buffer.from("hello"), filename: "hello.txt" }],
+              diagnostics: makeDiagnostics(),
+            }),
         },
       },
     });
@@ -168,16 +173,17 @@ describe("Slack behavior: finalized thread replies", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: "Posted it in channel.",
-            files: [{ data: Buffer.from("report"), filename: "report.txt" }],
-            deliveryPlan: {
-              mode: "channel_only",
-              postThreadText: false,
-              attachFiles: "inline",
-            },
-            diagnostics: makeDiagnostics(),
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: "Posted it in channel.",
+              files: [{ data: Buffer.from("report"), filename: "report.txt" }],
+              deliveryPlan: {
+                mode: "channel_only",
+                postThreadText: false,
+                attachFiles: "inline",
+              },
+              diagnostics: makeDiagnostics(),
+            }),
         },
       },
     });
@@ -205,15 +211,16 @@ describe("Slack behavior: finalized thread replies", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: "",
-            deliveryPlan: {
-              mode: "thread",
-              postThreadText: true,
-              attachFiles: "none",
-            },
-            diagnostics: makeDiagnostics(),
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: "",
+              deliveryPlan: {
+                mode: "thread",
+                postThreadText: true,
+                attachFiles: "none",
+              },
+              diagnostics: makeDiagnostics(),
+            }),
         },
       },
     });
@@ -240,13 +247,14 @@ describe("Slack behavior: finalized thread replies", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: "ok",
-            files: [{ data: Buffer.from("report"), filename: "report.txt" }],
-            diagnostics: makeDiagnostics({
-              toolCalls: ["slackMessageAddReaction"],
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: "ok",
+              files: [{ data: Buffer.from("report"), filename: "report.txt" }],
+              diagnostics: makeDiagnostics({
+                toolCalls: ["slackMessageAddReaction"],
+              }),
             }),
-          }),
         },
       },
     });
@@ -278,10 +286,11 @@ describe("Slack behavior: finalized thread replies", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: longReply,
-            diagnostics: makeDiagnostics(),
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: longReply,
+              diagnostics: makeDiagnostics(),
+            }),
         },
       },
     });
@@ -314,10 +323,11 @@ describe("Slack behavior: finalized thread replies", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: longReply,
-            diagnostics: makeDiagnostics(),
-          }),
+          generateAssistantReply: async () =>
+            completedAgentRun({
+              text: longReply,
+              diagnostics: makeDiagnostics(),
+            }),
         },
       },
     });
@@ -351,10 +361,11 @@ describe("Slack behavior: finalized thread replies", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          generateAssistantReply: async () => ({
-            text: longReply,
-            diagnostics: makeDiagnostics({ outcome: "provider_error" }),
-          }),
+          generateAssistantReply: async () =>
+            failedAgentRun({
+              text: longReply,
+              diagnostics: makeDiagnostics({ outcome: "provider_error" }),
+            }),
         },
       },
     });

--- a/packages/junior/tests/integration/slack/finalized-reply-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/finalized-reply-behavior.test.ts
@@ -11,10 +11,7 @@ import {
   createTestThread,
   createTestDestination,
 } from "../../fixtures/slack-harness";
-import {
-  completedAgentRun,
-  failedAgentRun,
-} from "@/chat/runtime/agent-run-outcome";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 function toPostedText(value: unknown): string {
   if (typeof value === "string") {
@@ -362,7 +359,7 @@ describe("Slack behavior: finalized thread replies", () => {
       services: {
         replyExecutor: {
           generateAssistantReply: async () =>
-            failedAgentRun({
+            completedAgentRun({
               text: longReply,
               diagnostics: makeDiagnostics({ outcome: "provider_error" }),
             }),

--- a/packages/junior/tests/integration/slack/message-changed-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/message-changed-behavior.test.ts
@@ -15,6 +15,7 @@ import { createSlackRuntime } from "@/chat/app/factory";
 import { JuniorChat } from "@/chat/ingress/junior-chat";
 import { createJuniorSlackAdapter } from "@/chat/slack/adapter";
 import { handleChatSdkPlatformWebhook } from "@/handlers/webhooks";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const SIGNING_SECRET = "test-signing-secret";
 const BOT_USER_ID = "U_BOT";
@@ -272,10 +273,10 @@ describe("Slack behavior: message_changed webhook ingress", () => {
               userName: "dcramer",
             });
             await context?.onTextDelta?.("Hello world");
-            return {
+            return completedAgentRun({
               text: "Hello world",
               diagnostics: makeDiagnostics(),
-            };
+            });
           },
         },
       },

--- a/packages/junior/tests/integration/slack/message-changed-reply-contract.test.ts
+++ b/packages/junior/tests/integration/slack/message-changed-reply-contract.test.ts
@@ -10,6 +10,7 @@ import { JuniorChat } from "@/chat/ingress/junior-chat";
 import type { ReplyExecutorServices } from "@/chat/runtime/reply-executor";
 import { createJuniorSlackAdapter } from "@/chat/slack/adapter";
 import { handleChatSdkPlatformWebhook } from "@/handlers/webhooks";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const SIGNING_SECRET = "test-signing-secret";
 const BOT_USER_ID = "U_BOT";
@@ -101,10 +102,10 @@ describe("Slack contract: edited-message reply delivery", () => {
     const bot = await createEditedDmBot({
       generateAssistantReply: async (_prompt, context) => {
         await context?.onTextDelta?.("Hello world");
-        return {
+        return completedAgentRun({
           text: "Hello world",
           diagnostics: makeDiagnostics(),
-        };
+        });
       },
     });
     const waitUntil = slackWebhookClient.waitUntil();
@@ -156,10 +157,11 @@ describe("Slack contract: edited-message reply delivery", () => {
       (_, i) => `line ${i + 1}`,
     ).join("\n");
     const bot = await createEditedDmBot({
-      generateAssistantReply: async () => ({
-        text: longReply,
-        diagnostics: makeDiagnostics(),
-      }),
+      generateAssistantReply: async () =>
+        completedAgentRun({
+          text: longReply,
+          diagnostics: makeDiagnostics(),
+        }),
     });
     const waitUntil = slackWebhookClient.waitUntil();
 

--- a/packages/junior/tests/integration/slack/message-content-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/message-content-behavior.test.ts
@@ -15,11 +15,27 @@ import {
   createTestThread,
   createTestDestination,
 } from "../../fixtures/slack-harness";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 interface CapturedCall {
   contextConversation?: string;
   piMessages?: PiMessage[];
   prompt: string;
+}
+
+function completedReply(text: string) {
+  return completedAgentRun({
+    text,
+    diagnostics: {
+      assistantMessageCount: 1,
+      modelId: "fake-agent-model",
+      outcome: "success" as const,
+      toolCalls: [],
+      toolErrorCount: 0,
+      toolResultCount: 0,
+      usedPrimaryText: true,
+    },
+  });
 }
 
 describe("Slack behavior: message content", () => {
@@ -50,18 +66,7 @@ describe("Slack behavior: message content", () => {
               prompt,
               contextConversation: context?.conversationContext,
             });
-            return {
-              text: "Summary sent.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("Summary sent.");
           },
         },
       },
@@ -92,18 +97,7 @@ describe("Slack behavior: message content", () => {
         replyExecutor: {
           generateAssistantReply: async (prompt) => {
             calls.push({ prompt });
-            return {
-              text: "Done.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("Done.");
           },
         },
       },
@@ -137,18 +131,7 @@ describe("Slack behavior: message content", () => {
               prompt,
               contextConversation: context?.conversationContext,
             });
-            return {
-              text: "Alert reviewed.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("Alert reviewed.");
           },
         },
       },
@@ -195,18 +178,7 @@ describe("Slack behavior: message content", () => {
         replyExecutor: {
           generateAssistantReply: async () => {
             replyCalled = true;
-            return {
-              text: "Should not happen",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("Should not happen");
           },
         },
       },
@@ -286,18 +258,9 @@ describe("Slack behavior: message content", () => {
                 piMessages: storedFirstTurnHistory,
               });
             }
-            return {
-              text: calls.length === 1 ? "First response." : "Second response.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply(
+              calls.length === 1 ? "First response." : "Second response.",
+            );
           },
         },
       },
@@ -382,18 +345,7 @@ describe("Slack behavior: message content", () => {
               contextConversation: context?.conversationContext,
               piMessages: context?.piMessages,
             });
-            return {
-              text: "Done.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("Done.");
           },
         },
       },
@@ -505,18 +457,7 @@ describe("Slack behavior: message content", () => {
               contextConversation: context?.conversationContext,
               piMessages: context?.piMessages,
             });
-            return {
-              text: "Done.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("Done.");
           },
         },
       },

--- a/packages/junior/tests/integration/slack/message-im-attachment-contract.test.ts
+++ b/packages/junior/tests/integration/slack/message-im-attachment-contract.test.ts
@@ -6,6 +6,7 @@ import { slackEventsApiEnvelope } from "../../fixtures/slack/factories/events";
 import { createSlackWebhookTestClient } from "../../fixtures/slack/webhook-client";
 import { mswServer } from "../../msw/server";
 import type { ReplyExecutorServices } from "@/chat/runtime/reply-executor";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const SIGNING_SECRET = "test-signing-secret";
 const BOT_USER_ID = "U_BOT";
@@ -110,10 +111,10 @@ describe("Slack contract: message.im attachment ingress", () => {
         capturedAttachmentNames.push(
           attachments.map((attachment) => attachment.filename ?? ""),
         );
-        return {
+        return completedAgentRun({
           text: "Processed screenshot.",
           diagnostics: makeDiagnostics(),
-        };
+        });
       },
     });
     const waitUntil = slackWebhookClient.waitUntil();

--- a/packages/junior/tests/integration/slack/new-mention-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/new-mention-behavior.test.ts
@@ -10,6 +10,7 @@ import {
   createTestMessage,
   createTestThread,
 } from "../../fixtures/slack-harness";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 interface FakeReplyCall {
   prompt: string;
@@ -30,6 +31,21 @@ function toPostedText(value: unknown): string {
   return String(value);
 }
 
+function completedReply(text: string, toolCalls: string[] = []) {
+  return completedAgentRun({
+    text,
+    diagnostics: {
+      assistantMessageCount: 1,
+      modelId: "fake-agent-model",
+      outcome: "success" as const,
+      toolCalls,
+      toolErrorCount: 0,
+      toolResultCount: toolCalls.length,
+      usedPrimaryText: true,
+    },
+  });
+}
+
 describe("Slack behavior: new mention", () => {
   it("handles a mention with real runtime wiring and fake agent response", async () => {
     const fakeReplyCalls: FakeReplyCall[] = [];
@@ -39,18 +55,9 @@ describe("Slack behavior: new mention", () => {
         replyExecutor: {
           generateAssistantReply: async (prompt) => {
             fakeReplyCalls.push({ prompt });
-            return {
-              text: "Acknowledged. Rollback is complete and error rates are stable.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply(
+              "Acknowledged. Rollback is complete and error rates are stable.",
+            );
           },
         },
       },
@@ -89,18 +96,7 @@ describe("Slack behavior: new mention", () => {
         replyExecutor: {
           generateAssistantReply: async (prompt) => {
             fakeReplyCalls.push({ prompt });
-            return {
-              text: "Handled both updates.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("Handled both updates.");
           },
         },
       },
@@ -176,18 +172,7 @@ describe("Slack behavior: new mention", () => {
               ),
               attachmentText: attachments[0]?.data?.toString("utf8"),
             });
-            return {
-              text: "Handled queued attachment.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("Handled queued attachment.");
           },
         },
       },
@@ -247,18 +232,7 @@ describe("Slack behavior: new mention", () => {
         replyExecutor: {
           generateAssistantReply: async (_prompt, context) => {
             await context?.onStatus?.(makeAssistantStatus("running", "bash"));
-            return {
-              text: "Done.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: ["bash"],
-                toolErrorCount: 0,
-                toolResultCount: 1,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("Done.", ["bash"]);
           },
         },
       },
@@ -328,19 +302,19 @@ describe("Slack behavior: new mention", () => {
       services: {
         replyExecutor: {
           generateAssistantReply: async () => {
-            return {
+            return completedAgentRun({
               text: "Posted in channel.",
-              deliveryMode: "channel_only",
+              deliveryMode: "channel_only" as const,
               diagnostics: {
                 assistantMessageCount: 1,
                 modelId: "fake-agent-model",
-                outcome: "success",
+                outcome: "success" as const,
                 toolCalls: ["slackChannelPostMessage"],
                 toolErrorCount: 0,
                 toolResultCount: 1,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },

--- a/packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts
@@ -6,6 +6,7 @@ import {
   createTestDestination,
 } from "../../fixtures/slack-harness";
 import { slackApiOutbox } from "../../fixtures/slack-api-outbox";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 function successDiagnostics(toolCalls: string[] = []) {
   return {
@@ -37,10 +38,10 @@ describe("Slack behavior: processing reaction", () => {
           generateAssistantReply: async () => {
             expect(slackApiOutbox.reactionAdds()).toHaveLength(1);
             expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
-            return {
+            return completedAgentRun({
               text: "Done.",
               diagnostics: successDiagnostics(),
-            };
+            });
           },
         },
       },
@@ -145,10 +146,10 @@ describe("Slack behavior: processing reaction", () => {
           generateAssistantReply: async () => {
             expect(slackApiOutbox.reactionAdds()).toHaveLength(1);
             expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
-            return {
+            return completedAgentRun({
               text: "Done.",
               diagnostics: successDiagnostics(),
-            };
+            });
           },
         },
       },
@@ -189,10 +190,10 @@ describe("Slack behavior: processing reaction", () => {
           generateAssistantReply: async () => {
             expect(slackApiOutbox.reactionAdds()).toHaveLength(0);
             expect(slackApiOutbox.reactionRemovals()).toHaveLength(0);
-            return {
+            return completedAgentRun({
               text: "Done.",
               diagnostics: successDiagnostics(),
-            };
+            });
           },
         },
       },
@@ -242,10 +243,10 @@ describe("Slack behavior: processing reaction", () => {
               toolName: "slackMessageAddReaction",
               params: { emoji: ":eyes:" },
             });
-            return {
+            return completedAgentRun({
               text: "Done.",
               diagnostics: successDiagnostics(["slackMessageAddReaction"]),
-            };
+            });
           },
         },
       },

--- a/packages/junior/tests/integration/slack/provider-default-config-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/provider-default-config-behavior.test.ts
@@ -5,6 +5,7 @@ import {
   createTestThread,
   createTestDestination,
 } from "../../fixtures/slack-harness";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 function toPostedText(value: unknown): string {
   if (typeof value === "string") {
@@ -63,24 +64,26 @@ describe("Slack behavior: provider default configuration", () => {
   });
 
   it("does not intercept combined repo setup and agent work", async () => {
-    const generateAssistantReply = vi.fn(async () => ({
-      text: "Created the issue.",
-      deliveryMode: "thread" as const,
-      deliveryPlan: {
-        mode: "thread" as const,
-        postThreadText: true,
-        attachFiles: "none" as const,
-      },
-      diagnostics: {
-        assistantMessageCount: 1,
-        modelId: "test-model",
-        outcome: "success" as const,
-        toolCalls: [],
-        toolErrorCount: 0,
-        toolResultCount: 0,
-        usedPrimaryText: true,
-      },
-    }));
+    const generateAssistantReply = vi.fn(async () =>
+      completedAgentRun({
+        text: "Created the issue.",
+        deliveryMode: "thread" as const,
+        deliveryPlan: {
+          mode: "thread" as const,
+          postThreadText: true,
+          attachFiles: "none" as const,
+        },
+        diagnostics: {
+          assistantMessageCount: 1,
+          modelId: "test-model",
+          outcome: "success" as const,
+          toolCalls: [],
+          toolErrorCount: 0,
+          toolResultCount: 0,
+          usedPrimaryText: true,
+        },
+      }),
+    );
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {

--- a/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import {
-  RetryableTurnError,
-  TurnInputCommitLostError,
-} from "@/chat/runtime/turn";
+import { TurnInputCommitLostError } from "@/chat/runtime/turn";
 import type { JuniorRuntimeServiceOverrides } from "@/chat/app/services";
 import { createProviderError } from "@/chat/services/provider-retry";
 import { createTestChatRuntime } from "../../fixtures/chat-runtime";
@@ -11,6 +8,7 @@ import {
   createTestThread,
   createTestDestination,
 } from "../../fixtures/slack-harness";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const emptyThreadReplies = async () => [];
 
@@ -44,6 +42,21 @@ function toPostedText(value: unknown): string {
   }
 
   return String(value);
+}
+
+function completedReply(text: string) {
+  return completedAgentRun({
+    text,
+    diagnostics: {
+      assistantMessageCount: 1,
+      modelId: "fake-agent-model",
+      outcome: "success" as const,
+      toolCalls: [],
+      toolErrorCount: 0,
+      toolResultCount: 0,
+      usedPrimaryText: true,
+    },
+  });
 }
 
 describe("Slack behavior: subscribed messages", () => {
@@ -144,18 +157,7 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async (_prompt, context) => {
             replyContexts.push(context);
-            return {
-              text: "I checked the subscribed PR event.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("I checked the subscribed PR event.");
           },
         },
       },
@@ -212,12 +214,17 @@ describe("Slack behavior: subscribed messages", () => {
         },
         replyExecutor: {
           generateAssistantReply: async () => {
-            throw new RetryableTurnError("mcp_auth_resume", "auth required", {
+            return {
+              status: "awaiting_auth",
+              authDisposition: "link_sent",
+              authDurationMs: 1,
+              authKind: "mcp",
               authProvider: "github",
               authProviderDisplayName: "GitHub",
               conversationId: "slack:C_BEHAVIOR:1700002000.003",
               sessionId: "resource-event-auth",
-            });
+              sliceId: 2,
+            };
           },
         },
       },
@@ -278,18 +285,9 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async (prompt) => {
             replyCalls.push(prompt);
-            return {
-              text: "Action item captured: monitor dashboards for 30 minutes.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply(
+              "Action item captured: monitor dashboards for 30 minutes.",
+            );
           },
         },
       },
@@ -336,18 +334,7 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async (prompt) => {
             replyCalls.push(prompt);
-            return {
-              text: "Yes. Shipping status is green.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("Yes. Shipping status is green.");
           },
         },
       },
@@ -389,18 +376,7 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async (prompt) => {
             replyCalls.push(prompt);
-            return {
-              text: "Handled queued subscribed turn.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("Handled queued subscribed turn.");
           },
         },
       },
@@ -465,21 +441,11 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async (prompt) => {
             replyCalls.push(prompt);
-            return {
-              text:
-                replyCalls.length === 1
-                  ? "I can help with this thread."
-                  : "I'm back because you mentioned me again.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply(
+              replyCalls.length === 1
+                ? "I can help with this thread."
+                : "I'm back because you mentioned me again.",
+            );
           },
         },
       },
@@ -556,18 +522,7 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async () => {
             replyCalled = true;
-            return {
-              text: "This should never be posted.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("This should never be posted.");
           },
         },
       },
@@ -613,18 +568,7 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async () => {
             replyCalled = true;
-            return {
-              text: "This should never be posted.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("This should never be posted.");
           },
         },
       },
@@ -676,18 +620,7 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async () => {
             replyCalled = true;
-            return {
-              text: "This should never be posted.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("This should never be posted.");
           },
         },
       },
@@ -741,18 +674,7 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async () => {
             replyCalled = true;
-            return {
-              text: "This should never be posted.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("This should never be posted.");
           },
         },
       },
@@ -804,18 +726,7 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async () => {
             replyCalled = true;
-            return {
-              text: "This should never be posted.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("This should never be posted.");
           },
         },
       },
@@ -874,18 +785,7 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async () => {
             replyCalled = true;
-            return {
-              text: "This should never be posted.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("This should never be posted.");
           },
         },
       },
@@ -945,18 +845,7 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async () => {
             replyCalled = true;
-            return {
-              text: "This should never be posted.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("This should never be posted.");
           },
         },
       },
@@ -1026,18 +915,7 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async (prompt) => {
             replyCalls.push(prompt);
-            return {
-              text: "You asked for the budget by Friday.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply("You asked for the budget by Friday.");
           },
         },
       },
@@ -1096,21 +974,11 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           generateAssistantReply: async (prompt) => {
             replyCalls.push(prompt);
-            return {
-              text:
-                replyCalls.length === 1
-                  ? "The deploy changed billing, auth, and the API gateway."
-                  : "The three services were billing, auth, and the API gateway.",
-              diagnostics: {
-                assistantMessageCount: 1,
-                modelId: "fake-agent-model",
-                outcome: "success",
-                toolCalls: [],
-                toolErrorCount: 0,
-                toolResultCount: 0,
-                usedPrimaryText: true,
-              },
-            };
+            return completedReply(
+              replyCalls.length === 1
+                ? "The deploy changed billing, auth, and the API gateway."
+                : "The three services were billing, auth, and the API gateway.",
+            );
           },
         },
       },

--- a/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
@@ -216,14 +216,7 @@ describe("Slack behavior: subscribed messages", () => {
           generateAssistantReply: async () => {
             return {
               status: "awaiting_auth",
-              authDisposition: "link_sent",
-              authDurationMs: 1,
-              authKind: "mcp",
-              authProvider: "github",
-              authProviderDisplayName: "GitHub",
-              conversationId: "slack:C_BEHAVIOR:1700002000.003",
-              sessionId: "resource-event-auth",
-              sliceId: 2,
+              providerDisplayName: "GitHub",
             };
           },
         },

--- a/packages/junior/tests/integration/slack/thread-continuity-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/thread-continuity-behavior.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import { createTestChatRuntime } from "../../fixtures/chat-runtime";
 import {
   createTestMessage,
@@ -46,7 +47,7 @@ describe("Slack behavior: thread continuity", () => {
         replyExecutor: {
           generateAssistantReply: async (prompt) => {
             prompts.push(prompt);
-            return {
+            return completedAgentRun({
               text:
                 scriptedReplies[prompts.length - 1] ?? "Unexpected extra reply",
               diagnostics: {
@@ -58,7 +59,7 @@ describe("Slack behavior: thread continuity", () => {
                 toolResultCount: 0,
                 usedPrimaryText: true,
               },
-            };
+            });
           },
         },
       },

--- a/packages/junior/tests/unit/handlers/oauth-resume.test.ts
+++ b/packages/junior/tests/unit/handlers/oauth-resume.test.ts
@@ -3,6 +3,7 @@ import { createSlackSource } from "@sentry/junior-plugin-api";
 import { RetryableTurnError } from "@/chat/runtime/turn";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import { setPlugins } from "@/chat/plugins/agent-hooks";
+import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
 const { postMessageMock, setStatusMock, uploadFilesToThreadMock } = vi.hoisted(
   () => ({
@@ -204,18 +205,19 @@ describe("resumeAuthorizedRequest", () => {
           source: testSlackSource("1700000000.0005"),
           requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
         },
-        generateReply: async () => ({
-          text: "Final resumed answer",
-          diagnostics: {
-            assistantMessageCount: 1,
-            modelId: "fake-agent-model",
-            outcome: "success",
-            toolCalls: [],
-            toolErrorCount: 0,
-            toolResultCount: 0,
-            usedPrimaryText: true,
-          },
-        }),
+        generateReply: async () =>
+          completedAgentRun({
+            text: "Final resumed answer",
+            diagnostics: {
+              assistantMessageCount: 1,
+              modelId: "fake-agent-model",
+              outcome: "success" as const,
+              toolCalls: [],
+              toolErrorCount: 0,
+              toolResultCount: 0,
+              usedPrimaryText: true,
+            },
+          }),
         onSuccess: async () => {
           throw new Error("state write failed");
         },
@@ -261,18 +263,19 @@ describe("resumeAuthorizedRequest", () => {
         source: testSlackSource("1700000000.0006"),
         requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
       },
-      generateReply: async () => ({
-        text: "Final resumed answer",
-        diagnostics: {
-          assistantMessageCount: 1,
-          modelId: "fake-agent-model",
-          outcome: "success",
-          toolCalls: [],
-          toolErrorCount: 0,
-          toolResultCount: 0,
-          usedPrimaryText: true,
-        },
-      }),
+      generateReply: async () =>
+        completedAgentRun({
+          text: "Final resumed answer",
+          diagnostics: {
+            assistantMessageCount: 1,
+            modelId: "fake-agent-model",
+            outcome: "success" as const,
+            toolCalls: [],
+            toolErrorCount: 0,
+            toolResultCount: 0,
+            usedPrimaryText: true,
+          },
+        }),
       scheduleSessionCompletedPluginTasks,
     });
 

--- a/packages/junior/tests/unit/handlers/oauth-resume.test.ts
+++ b/packages/junior/tests/unit/handlers/oauth-resume.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSlackSource } from "@sentry/junior-plugin-api";
-import { RetryableTurnError } from "@/chat/runtime/turn";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import { setPlugins } from "@/chat/plugins/agent-hooks";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
@@ -311,14 +310,10 @@ describe("resumeAuthorizedRequest", () => {
         source: testSlackSource("1700000000.0002"),
         requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
       },
-      generateReply: async () => {
-        throw new RetryableTurnError("agent_continue", "timed out again", {
-          conversationId: "conversation-1",
-          sessionId: "turn-1",
-          version: 3,
-          sliceId: 3,
-        });
-      },
+      generateReply: async () => ({
+        status: "suspended" as const,
+        resumeVersion: 3,
+      }),
       onTimeoutPause,
     });
 
@@ -341,14 +336,10 @@ describe("resumeAuthorizedRequest", () => {
         source: testSlackSource("1700000000.0003"),
         requester: { platform: "slack", teamId: "T-test", userId: "U-test" },
       },
-      generateReply: async () => {
-        throw new RetryableTurnError("agent_continue", "timed out again", {
-          conversationId: "conversation-1",
-          sessionId: "turn-1",
-          version: 3,
-          sliceId: 6,
-        });
-      },
+      generateReply: async () => ({
+        status: "suspended" as const,
+        resumeVersion: 3,
+      }),
       onTimeoutPause: async () => {
         throw new Error("continuation scheduling failed");
       },

--- a/packages/junior/tests/unit/runtime/respond-agent-continue.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-agent-continue.test.ts
@@ -249,10 +249,7 @@ vi.mock("@/chat/skills", async (importOriginal) => ({
 }));
 
 import { generateAssistantReply } from "@/chat/respond";
-import {
-  isRetryableTurnError,
-  isTurnInputCommitLostError,
-} from "@/chat/runtime/turn";
+import { isTurnInputCommitLostError } from "@/chat/runtime/turn";
 import { AGENT_CONTINUE_MAX_SLICES } from "@/chat/services/turn-session-record";
 import { getConversationStore } from "@/chat/db";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
@@ -311,7 +308,7 @@ describe("generateAssistantReply agent continuation", () => {
     expect(onInputCommitted).not.toHaveBeenCalled();
   });
 
-  it("stores the last safe boundary and throws a retryable timeout error", async () => {
+  it("stores the last safe boundary and returns a timed-out outcome", async () => {
     const replyPromise = generateAssistantReply("help me", {
       destination: TEST_DESTINATION,
       source: TEST_SOURCE,
@@ -322,14 +319,14 @@ describe("generateAssistantReply agent continuation", () => {
         channelId: "C123",
         threadTs: "1712345.0001",
       },
-    }).catch((caught) => caught);
+    });
 
     await vi.advanceTimersByTimeAsync(10_000);
-    const error = await replyPromise;
+    const outcome = await replyPromise;
 
     expect(promptAborted.value).toBe(true);
-    expect(isRetryableTurnError(error, "agent_continue")).toBe(true);
-    expect(error.metadata).toMatchObject({
+    expect(outcome).toMatchObject({
+      status: "timed_out",
       conversationId: "conversation-1",
       sessionId: "turn-1",
       version: expect.any(Number),
@@ -388,7 +385,6 @@ describe("generateAssistantReply agent continuation", () => {
 
     expect(error).toBeInstanceOf(Error);
     expect(error).not.toHaveProperty("text");
-    expect(isRetryableTurnError(error, "agent_continue")).toBe(false);
     expect(error.message).toContain("slice limit");
 
     const sessionRecord = await getAgentTurnSessionRecord(
@@ -416,13 +412,13 @@ describe("generateAssistantReply agent continuation", () => {
         channelId: "C123",
         threadTs: "1712345.0005",
       },
-    }).catch((caught) => caught);
+    });
 
     await vi.advanceTimersByTimeAsync(2_500);
-    const error = await replyPromise;
+    const outcome = await replyPromise;
 
     expect(promptAborted.value).toBe(true);
-    expect(isRetryableTurnError(error, "agent_continue")).toBe(true);
+    expect(outcome.status).toBe("timed_out");
     const sessionRecord = await getAgentTurnSessionRecord(
       "conversation-short-deadline",
       "turn-short-deadline",
@@ -483,16 +479,16 @@ describe("generateAssistantReply agent continuation", () => {
         channelId: "C123",
         threadTs: "1712345.0003",
       },
-    }).catch((caught) => caught);
+    });
 
     await waitForPromptCall(1);
     await realSleep(10);
     await vi.advanceTimersByTimeAsync(15_000);
-    const error = await replyPromise;
+    const outcome = await replyPromise;
 
     expect(promptAborted.value).toBe(true);
-    expect(isRetryableTurnError(error, "agent_continue")).toBe(true);
-    expect(error.metadata).toMatchObject({
+    expect(outcome).toMatchObject({
+      status: "timed_out",
       conversationId: "conversation-hung",
       sessionId: "turn-hung",
       version: expect.any(Number),
@@ -528,17 +524,17 @@ describe("generateAssistantReply agent continuation", () => {
         channelId: "C123",
         threadTs: "1712345.0004",
       },
-    }).catch((caught) => caught);
+    });
 
     await waitForPromptCall(1);
     await vi.advanceTimersByTimeAsync(8_000);
     await waitForProviderPromptSettlement();
     await advanceUntilContinueCall(5_000);
     await vi.advanceTimersByTimeAsync(1);
-    const error = await replyPromise;
+    const outcome = await replyPromise;
 
     expect(promptAborted.value).toBe(true);
-    expect(isRetryableTurnError(error, "agent_continue")).toBe(true);
+    expect(outcome.status).toBe("timed_out");
     const sessionRecord = await getAgentTurnSessionRecord(
       "conversation-retry",
       "turn-retry",

--- a/packages/junior/tests/unit/runtime/respond-agent-continue.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-agent-continue.test.ts
@@ -326,11 +326,8 @@ describe("generateAssistantReply agent continuation", () => {
 
     expect(promptAborted.value).toBe(true);
     expect(outcome).toMatchObject({
-      status: "timed_out",
-      conversationId: "conversation-1",
-      sessionId: "turn-1",
-      version: expect.any(Number),
-      sliceId: 2,
+      status: "suspended",
+      resumeVersion: expect.any(Number),
     });
 
     const sessionRecord = await getAgentTurnSessionRecord(
@@ -418,7 +415,7 @@ describe("generateAssistantReply agent continuation", () => {
     const outcome = await replyPromise;
 
     expect(promptAborted.value).toBe(true);
-    expect(outcome.status).toBe("timed_out");
+    expect(outcome.status).toBe("suspended");
     const sessionRecord = await getAgentTurnSessionRecord(
       "conversation-short-deadline",
       "turn-short-deadline",
@@ -488,11 +485,8 @@ describe("generateAssistantReply agent continuation", () => {
 
     expect(promptAborted.value).toBe(true);
     expect(outcome).toMatchObject({
-      status: "timed_out",
-      conversationId: "conversation-hung",
-      sessionId: "turn-hung",
-      version: expect.any(Number),
-      sliceId: 2,
+      status: "suspended",
+      resumeVersion: expect.any(Number),
     });
 
     const sessionRecord = await getAgentTurnSessionRecord(
@@ -534,7 +528,7 @@ describe("generateAssistantReply agent continuation", () => {
     const outcome = await replyPromise;
 
     expect(promptAborted.value).toBe(true);
-    expect(outcome.status).toBe("timed_out");
+    expect(outcome.status).toBe("suspended");
     const sessionRecord = await getAgentTurnSessionRecord(
       "conversation-retry",
       "turn-retry",

--- a/packages/junior/tests/unit/runtime/respond-lazy-sandbox.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-lazy-sandbox.test.ts
@@ -529,15 +529,19 @@ const LOCAL_DESTINATION = {
 };
 const LOCAL_SOURCE = createLocalSource(LOCAL_DESTINATION.conversationId);
 
-function generateLocalReply(
+async function generateLocalReply(
   message: string,
   context: Omit<ReplyRequestContext, "destination" | "source"> = {},
 ) {
-  return generateAssistantReply(message, {
+  const outcome = await generateAssistantReply(message, {
     ...context,
     destination: LOCAL_DESTINATION,
     source: LOCAL_SOURCE,
   });
+  if (outcome.status !== "completed" && outcome.status !== "failed") {
+    throw new Error(`Expected final reply, got ${outcome.status}`);
+  }
+  return outcome.reply;
 }
 
 describe("generateAssistantReply lazy sandbox boot", () => {

--- a/packages/junior/tests/unit/runtime/respond-lazy-sandbox.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-lazy-sandbox.test.ts
@@ -538,7 +538,7 @@ async function generateLocalReply(
     destination: LOCAL_DESTINATION,
     source: LOCAL_SOURCE,
   });
-  if (outcome.status !== "completed" && outcome.status !== "failed") {
+  if (outcome.status !== "completed") {
     throw new Error(`Expected final reply, got ${outcome.status}`);
   }
   return outcome.reply;

--- a/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
@@ -604,7 +604,7 @@ import { disconnectStateAdapter } from "@/chat/state/adapter";
 function finalReply(
   outcome: Awaited<ReturnType<typeof generateAssistantReply>>,
 ) {
-  if (outcome.status !== "completed" && outcome.status !== "failed") {
+  if (outcome.status !== "completed") {
     throw new Error(`Expected final reply, got ${outcome.status}`);
   }
   return outcome.reply;

--- a/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-mcp-progressive-loading.test.ts
@@ -600,7 +600,15 @@ import {
   upsertAgentTurnSessionRecord,
 } from "@/chat/state/turn-session";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
-import { isRetryableTurnError } from "@/chat/runtime/turn";
+
+function finalReply(
+  outcome: Awaited<ReturnType<typeof generateAssistantReply>>,
+) {
+  if (outcome.status !== "completed" && outcome.status !== "failed") {
+    throw new Error(`Expected final reply, got ${outcome.status}`);
+  }
+  return outcome.reply;
+}
 
 // This suite validates local progressive-loading logic through a mocked
 // agent/runtime seam; it is not integration coverage.
@@ -683,11 +691,9 @@ describe("generateAssistantReply progressive MCP loading", () => {
       turnId: "turn-1",
     });
 
-    const firstError = await generateAssistantReply("help me", context).catch(
-      (error) => error,
-    );
+    const firstError = await generateAssistantReply("help me", context);
 
-    expect(isRetryableTurnError(firstError, "mcp_auth_resume")).toBe(true);
+    expect(firstError.status).toBe("awaiting_auth");
     expect(agentInitialToolNames[0]).toContain("loadSkill");
     expect(agentInitialToolNames[0]).toContain("searchMcpTools");
     expect(agentInitialToolNames[0]).toContain("callMcpTool");
@@ -717,7 +723,7 @@ describe("generateAssistantReply progressive MCP loading", () => {
     ]);
     expect(loadSkillExecutionErrorCount.value).toBe(0);
 
-    const reply = await generateAssistantReply("help me", context);
+    const reply = finalReply(await generateAssistantReply("help me", context));
 
     expect(reply.text).toBe("resumed reply");
     expect(promptCallCount.value).toBe(1);
@@ -761,13 +767,15 @@ describe("generateAssistantReply progressive MCP loading", () => {
     listToolsMock.mockReset();
     listToolsMock.mockResolvedValue(makeDemoMcpTools());
 
-    const reply = await generateAssistantReply(
-      "help me",
-      makeReplyContext({
-        conversationId: "conversation-2",
-        threadTs: "1712345.0002",
-        turnId: "turn-2",
-      }),
+    const reply = finalReply(
+      await generateAssistantReply(
+        "help me",
+        makeReplyContext({
+          conversationId: "conversation-2",
+          threadTs: "1712345.0002",
+          turnId: "turn-2",
+        }),
+      ),
     );
 
     expect(reply.text).toBe("resumed reply");
@@ -858,7 +866,7 @@ describe("generateAssistantReply progressive MCP loading", () => {
       piMessages: priorMessages,
     }).catch((error) => error);
 
-    expect(isRetryableTurnError(firstError, "mcp_auth_resume")).toBe(true);
+    expect(firstError.status).toBe("awaiting_auth");
 
     const pausedSessionRecord = await getAgentTurnSessionRecord(
       "conversation-restore-auth",
@@ -882,14 +890,16 @@ describe("generateAssistantReply progressive MCP loading", () => {
       "current follow-up",
     );
 
-    const reply = await generateAssistantReply("current follow-up", {
-      ...makeReplyContext({
-        conversationId: "conversation-restore-auth",
-        threadTs: "1712345.0091",
-        turnId: "turn-restore-auth",
+    const reply = finalReply(
+      await generateAssistantReply("current follow-up", {
+        ...makeReplyContext({
+          conversationId: "conversation-restore-auth",
+          threadTs: "1712345.0091",
+          turnId: "turn-restore-auth",
+        }),
+        piMessages: priorMessages,
       }),
-      piMessages: priorMessages,
-    });
+    );
 
     expect(reply.text).toBe("resumed reply");
     expect(resumeMessages).toHaveLength(0);
@@ -1164,11 +1174,9 @@ describe("generateAssistantReply progressive MCP loading", () => {
       turnId: "turn-4",
     });
 
-    const firstError = await generateAssistantReply("help me", context).catch(
-      (error) => error,
-    );
+    const firstError = await generateAssistantReply("help me", context);
 
-    expect(isRetryableTurnError(firstError, "mcp_auth_resume")).toBe(true);
+    expect(firstError.status).toBe("awaiting_auth");
     expect(deliverPrivateMessageMock).toHaveBeenCalledTimes(1);
 
     const pausedSessionRecord = await getAgentTurnSessionRecord(
@@ -1180,7 +1188,7 @@ describe("generateAssistantReply progressive MCP loading", () => {
       resumeReason: "auth",
     });
 
-    const reply = await generateAssistantReply("help me", context);
+    const reply = finalReply(await generateAssistantReply("help me", context));
 
     expect(reply.text).toBe("resumed reply");
 
@@ -1202,13 +1210,15 @@ describe("generateAssistantReply progressive MCP loading", () => {
     listToolsMock.mockReset();
     listToolsMock.mockResolvedValue([makeDemoMcpTool("ping")]);
 
-    const reply = await generateAssistantReply(
-      "help me",
-      makeReplyContext({
-        conversationId: "conversation-5",
-        threadTs: "1712345.0005",
-        turnId: "turn-5",
-      }),
+    const reply = finalReply(
+      await generateAssistantReply(
+        "help me",
+        makeReplyContext({
+          conversationId: "conversation-5",
+          threadTs: "1712345.0005",
+          turnId: "turn-5",
+        }),
+      ),
     );
 
     expect(reply.text).toBe("");
@@ -1256,9 +1266,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
       },
     };
 
-    const reply = await generateAssistantReply("help me", context);
+    const reply = finalReply(await generateAssistantReply("help me", context));
 
-    expect(isRetryableTurnError(reply, "mcp_auth_resume")).toBe(false);
     expect(reply.diagnostics.outcome).toBe("provider_error");
     expect(sessionRecordSpy).toHaveBeenCalled();
   });
@@ -1356,7 +1365,7 @@ describe("generateAssistantReply progressive MCP loading", () => {
       },
     }).catch((error) => error);
 
-    expect(isRetryableTurnError(firstError, "mcp_auth_resume")).toBe(true);
+    expect(firstError.status).toBe("awaiting_auth");
 
     const resumedSessionRecord = await getAgentTurnSessionRecord(
       "conversation-5",
@@ -1402,7 +1411,7 @@ describe("generateAssistantReply progressive MCP loading", () => {
       },
     }).catch((error) => error);
 
-    expect(isRetryableTurnError(firstError, "mcp_auth_resume")).toBe(true);
+    expect(firstError.status).toBe("awaiting_auth");
 
     const pausedSessionRecord = await getAgentTurnSessionRecord(
       "conversation-6",

--- a/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
@@ -323,12 +323,20 @@ vi.mock("@/chat/skills", async (importOriginal) => ({
 
 import { generateAssistantReply } from "@/chat/respond";
 import { getConversationStore } from "@/chat/db";
-import { isCooperativeTurnYieldError } from "@/chat/runtime/turn";
 import { getAwaitingAgentContinueRequest } from "@/chat/services/agent-continue";
 import { persistCompletedSessionRecord } from "@/chat/services/turn-session-record";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
 import * as turnSessionState from "@/chat/state/turn-session";
 import { createJuniorReporting } from "@/reporting";
+
+function finalReply(
+  outcome: Awaited<ReturnType<typeof generateAssistantReply>>,
+) {
+  if (outcome.status !== "completed" && outcome.status !== "failed") {
+    throw new Error(`Expected final reply, got ${outcome.status}`);
+  }
+  return outcome.reply;
+}
 
 const TEST_DESTINATION = {
   platform: "slack",
@@ -376,7 +384,7 @@ describe("generateAssistantReply provider retry", () => {
 
     await waitForPromptCall(1);
     await advanceUntilContinueCall(5_000);
-    const reply = await replyPromise;
+    const reply = finalReply(await replyPromise);
 
     expect(reply.text).toBe("Recovered.");
     expect(reply.diagnostics.outcome).toBe("success");
@@ -449,26 +457,28 @@ describe("generateAssistantReply provider retry", () => {
       visibility: "public",
     });
 
-    const reply = await generateAssistantReply("help me", {
-      destination: TEST_DESTINATION,
-      source: TEST_SOURCE,
-      piMessages: priorMessages,
-      requester: { platform: "slack", teamId: "T123", userId: "U123" },
-      correlation: {
-        conversationId: "slack:C123:1712345.0001",
-        turnId: "turn-steering",
-        channelId: "C123",
-        threadTs: "1712345.0001",
-      },
-      drainSteeringMessages: async (inject) => {
-        const messages = [
-          { text: "actually do the other thing", timestampMs: 2_000 },
-        ];
-        await inject(messages);
-        injectedTexts.push(...messages.map((message) => message.text));
-        return messages;
-      },
-    });
+    const reply = finalReply(
+      await generateAssistantReply("help me", {
+        destination: TEST_DESTINATION,
+        source: TEST_SOURCE,
+        piMessages: priorMessages,
+        requester: { platform: "slack", teamId: "T123", userId: "U123" },
+        correlation: {
+          conversationId: "slack:C123:1712345.0001",
+          turnId: "turn-steering",
+          channelId: "C123",
+          threadTs: "1712345.0001",
+        },
+        drainSteeringMessages: async (inject) => {
+          const messages = [
+            { text: "actually do the other thing", timestampMs: 2_000 },
+          ];
+          await inject(messages);
+          injectedTexts.push(...messages.map((message) => message.text));
+          return messages;
+        },
+      }),
+    );
 
     expect(reply.text).toBe("Steered.");
     expect(injectedTexts).toEqual(["actually do the other thing"]);
@@ -519,7 +529,7 @@ describe("generateAssistantReply provider retry", () => {
   it("parks the turn when the worker asks to yield at a Pi boundary", async () => {
     agentMode.value = "cooperativeYield";
 
-    const error = await generateAssistantReply("help me", {
+    const outcome = await generateAssistantReply("help me", {
       destination: TEST_DESTINATION,
       source: TEST_SOURCE,
       requester: { platform: "slack", teamId: "T123", userId: "U123" },
@@ -530,12 +540,15 @@ describe("generateAssistantReply provider retry", () => {
         threadTs: "1712345.0003",
       },
       shouldYield: () => true,
-    }).then(
-      () => undefined,
-      (caught: unknown) => caught,
-    );
+    });
 
-    expect(isCooperativeTurnYieldError(error)).toBe(true);
+    expect(outcome).toMatchObject({
+      status: "yielded",
+      conversationId: "conversation-yield",
+      sessionId: "turn-yield",
+      sliceId: 1,
+      version: expect.any(Number),
+    });
     const sessionRecord = await turnSessionState.getAgentTurnSessionRecord(
       "conversation-yield",
       "turn-yield",
@@ -567,7 +580,7 @@ describe("generateAssistantReply provider retry", () => {
   it("keeps steered messages when yielding after steering drain", async () => {
     agentMode.value = "cooperativeYield";
 
-    const error = await generateAssistantReply("help me", {
+    const outcome = await generateAssistantReply("help me", {
       requester: { platform: "slack", teamId: "T123", userId: "U123" },
       correlation: {
         conversationId: "conversation-yield-steering",
@@ -585,12 +598,15 @@ describe("generateAssistantReply provider retry", () => {
         return messages;
       },
       shouldYield: () => true,
-    }).then(
-      () => undefined,
-      (caught: unknown) => caught,
-    );
+    });
 
-    expect(isCooperativeTurnYieldError(error)).toBe(true);
+    expect(outcome).toMatchObject({
+      status: "yielded",
+      conversationId: "conversation-yield-steering",
+      sessionId: "turn-yield-steering",
+      sliceId: 1,
+      version: expect.any(Number),
+    });
     const sessionRecord = await turnSessionState.getAgentTurnSessionRecord(
       "conversation-yield-steering",
       "turn-yield-steering",
@@ -639,7 +655,6 @@ describe("generateAssistantReply provider retry", () => {
     expect((error as Error).message).toContain(
       "Failed to persist cooperative yield continuation",
     );
-    expect(isCooperativeTurnYieldError(error)).toBe(false);
     await expect(
       turnSessionState.getAgentTurnSessionRecord(
         "conversation-yield-persist-failure",
@@ -652,17 +667,19 @@ describe("generateAssistantReply provider retry", () => {
     agentMode.value = "toolActivity";
     sessionLogState.failToolExecutionAppend = true;
 
-    const reply = await generateAssistantReply("run the tool", {
-      destination: TEST_DESTINATION,
-      source: TEST_SOURCE,
-      requester: { platform: "slack", teamId: "T123", userId: "U123" },
-      correlation: {
-        conversationId: "conversation-tool-activity",
-        turnId: "turn-tool-activity",
-        channelId: "C123",
-        threadTs: "1712345.0006",
-      },
-    });
+    const reply = finalReply(
+      await generateAssistantReply("run the tool", {
+        destination: TEST_DESTINATION,
+        source: TEST_SOURCE,
+        requester: { platform: "slack", teamId: "T123", userId: "U123" },
+        correlation: {
+          conversationId: "conversation-tool-activity",
+          turnId: "turn-tool-activity",
+          channelId: "C123",
+          threadTs: "1712345.0006",
+        },
+      }),
+    );
 
     expect(sessionLogState.toolExecutionAppendCalls).toBe(1);
     expect(reply.diagnostics.outcome).toBe("success");
@@ -689,18 +706,20 @@ describe("generateAssistantReply provider retry", () => {
       turnStartMessageIndex: 0,
     });
 
-    const reply = await generateAssistantReply("help me", {
-      destination: TEST_DESTINATION,
-      source: TEST_SOURCE,
-      piMessages: [checkpointedPrompt],
-      requester: { platform: "slack", teamId: "T123", userId: "U123" },
-      correlation: {
-        conversationId,
-        turnId: sessionId,
-        channelId: "C123",
-        threadTs: "1712345.0007",
-      },
-    });
+    const reply = finalReply(
+      await generateAssistantReply("help me", {
+        destination: TEST_DESTINATION,
+        source: TEST_SOURCE,
+        piMessages: [checkpointedPrompt],
+        requester: { platform: "slack", teamId: "T123", userId: "U123" },
+        correlation: {
+          conversationId,
+          turnId: sessionId,
+          channelId: "C123",
+          threadTs: "1712345.0007",
+        },
+      }),
+    );
 
     expect(reply.diagnostics.outcome).toBe("success");
     const sessionRecord = await turnSessionState.getAgentTurnSessionRecord(

--- a/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
+++ b/packages/junior/tests/unit/runtime/respond-provider-retry.test.ts
@@ -332,7 +332,7 @@ import { createJuniorReporting } from "@/reporting";
 function finalReply(
   outcome: Awaited<ReturnType<typeof generateAssistantReply>>,
 ) {
-  if (outcome.status !== "completed" && outcome.status !== "failed") {
+  if (outcome.status !== "completed") {
     throw new Error(`Expected final reply, got ${outcome.status}`);
   }
   return outcome.reply;
@@ -543,11 +543,8 @@ describe("generateAssistantReply provider retry", () => {
     });
 
     expect(outcome).toMatchObject({
-      status: "yielded",
-      conversationId: "conversation-yield",
-      sessionId: "turn-yield",
-      sliceId: 1,
-      version: expect.any(Number),
+      status: "suspended",
+      resumeVersion: expect.any(Number),
     });
     const sessionRecord = await turnSessionState.getAgentTurnSessionRecord(
       "conversation-yield",
@@ -601,11 +598,8 @@ describe("generateAssistantReply provider retry", () => {
     });
 
     expect(outcome).toMatchObject({
-      status: "yielded",
-      conversationId: "conversation-yield-steering",
-      sessionId: "turn-yield-steering",
-      sliceId: 1,
-      version: expect.any(Number),
+      status: "suspended",
+      resumeVersion: expect.any(Number),
     });
     const sessionRecord = await turnSessionState.getAgentTurnSessionRecord(
       "conversation-yield-steering",


### PR DESCRIPTION
`generateAssistantReply` now returns an `AgentRunOutcome` instead of throwing lifecycle-control exceptions, and the outcome carries only what callers actually read:

```ts
export type AgentRunOutcome =
  | { status: "completed"; reply: AssistantReply }   // reply.diagnostics distinguishes success/failure
  | { status: "suspended"; resumeVersion: number }   // resume the persisted session record at this version
  | { status: "awaiting_auth"; providerDisplayName: string };
```

Each dropped candidate field failed the "who reads it" test: `conversationId`/`sessionId` were echoes of the caller's own correlation input, `sliceId` had no readers at all, a separate `failed` status duplicated `reply.diagnostics.outcome`, and the auth-pause metadata (`authKind`, `authDisposition`, usage, timing) was carried but never consumed. `resumeVersion` stays because it is minted inside the run when the awaiting_resume session record persists — it is the one value a caller cannot know, and the optimistic-lock token every continuation needs.

Cooperative yield and slice timeout collapse into one `suspended` status. The two resume routes still exist, but the Slack executor picks between them from its own `shouldYield()` predicate — the only condition under which a cooperative yield can occur — so routing lives with the boundary that owns it: lease expiring → hand back to the queue worker; otherwise → schedule a direct continuation. Dispatch, local, and resume boundaries handled both flavors identically already.

With no producers left, `RetryableTurnError`, its metadata types, and both guards are deleted. `slack-resume` handles outcomes inline instead of throwing reconstructed errors to its own catch block, the oauth/continue pause callbacks take typed payloads (`{ resumeVersion }`, `{ providerDisplayName }`) instead of re-validating error metadata, and the auth-pause catch branches in `slack-runtime` that could no longer fire are removed. Genuine errors — lost input commits, provider retry errors, pre-commit failures — still throw, and `CooperativeTurnYieldError` remains as the one real cross-boundary control signal for the durable queue worker.

Persistence ordering, delivery semantics, and session-record state (including the stored `resumeReason`) are unchanged; a component test pins the highest-risk invariant that a yielded slice stays resumable without failure persistence.

Refs #746