### PR TITLE
ref(chat): Rename agent execution boundary to run vocabulary

### DIFF
--- a/packages/junior-evals/src/behavior-harness.ts
+++ b/packages/junior-evals/src/behavior-harness.ts
@@ -40,7 +40,7 @@ import {
   scheduleSessionCompletedPluginTasks,
 } from "@/chat/plugins/task-runner";
 import type { PluginTaskQueueMessage } from "@/chat/plugins/task-message";
-import { generateAssistantReply } from "@/chat/respond";
+import { executeAgentRun } from "@/chat/agent-run";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { resumeAwaitingSlackContinuation } from "@/chat/runtime/agent-continue-runner";
@@ -1572,7 +1572,7 @@ function buildRuntimeServices(
             delete process.env.VERCEL_OIDC_TOKEN;
           }
           try {
-            const outcome = await generateAssistantReply({
+            const outcome = await executeAgentRun({
               ...request,
               policy: {
                 ...request.policy,

--- a/packages/junior/src/app.ts
+++ b/packages/junior/src/app.ts
@@ -11,7 +11,7 @@ import {
 import { getSlackReactionConfig, setSlackReactionConfig } from "@/chat/config";
 import { getDb } from "@/chat/db";
 import { logException } from "@/chat/logging";
-import { generateAssistantReply } from "@/chat/respond";
+import { executeAgentRun } from "@/chat/agent-run";
 import { normalizeSandboxEgressTracePropagationDomains } from "@/chat/sandbox/egress/tracing";
 import { pluginCatalogRuntime } from "@/chat/plugins/catalog-runtime";
 import {
@@ -585,7 +585,7 @@ export async function createApp(options?: JuniorAppOptions): Promise<Hono> {
 
   const waitUntil = options?.waitUntil ?? (await defaultWaitUntil());
   const tracePropagation = { domains: sandboxEgressTracePropagationDomains };
-  const agentRunner = createAgentRunner(generateAssistantReply, {
+  const agentRunner = createAgentRunner(executeAgentRun, {
     tracePropagation,
   });
   const runtimeServiceOverrides = {

--- a/packages/junior/src/chat/agent-dispatch/runner.ts
+++ b/packages/junior/src/chat/agent-dispatch/runner.ts
@@ -7,7 +7,7 @@
  * state, and schedules follow-up slices when a turn needs to continue.
  */
 import { botConfig } from "@/chat/config";
-import type { AssistantReply } from "@/chat/respond";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { logException } from "@/chat/logging";
 import {
@@ -76,7 +76,7 @@ function buildDispatchConversationText(dispatch: DispatchRecord): string {
   return `[dispatched task] ${dispatch.input}`;
 }
 
-function ensureVisibleDeliveryText(reply: AssistantReply): AssistantReply {
+function ensureVisibleDeliveryText(reply: AgentRunResult): AgentRunResult {
   if (reply.text.trim().length > 0 || !reply.files?.length) {
     return reply;
   }
@@ -377,7 +377,7 @@ export async function runAgentDispatchSlice(
       return;
     }
 
-    let reply = outcome.reply;
+    let reply = outcome.result;
 
     const failure =
       reply.diagnostics.outcome === "success"

--- a/packages/junior/src/chat/agent-run-helpers.ts
+++ b/packages/junior/src/chat/agent-run-helpers.ts
@@ -1,5 +1,5 @@
 /**
- * Pure helper functions used by the agent reply orchestration in respond.ts.
+ * Pure helper functions used by the agent-run orchestration in agent-run.ts.
  *
  * These are extracted to reduce the size of the main orchestration module and
  * make individual helpers independently testable.

--- a/packages/junior/src/chat/agent-run.ts
+++ b/packages/junior/src/chat/agent-run.ts
@@ -114,12 +114,8 @@ import {
   summarizeMessageText,
   toObservablePromptPart,
   upsertActiveSkill,
-} from "@/chat/respond-helpers";
-import {
-  buildTurnResult,
-  type AssistantReply,
-  type AgentTurnDiagnostics,
-} from "@/chat/services/turn-result";
+} from "@/chat/agent-run-helpers";
+import { buildTurnResult } from "@/chat/services/turn-result";
 import {
   isProviderRetryError,
   nextProviderRetry,
@@ -160,9 +156,6 @@ import {
   toGenAiMessagesTraceAttributes,
   type ConversationPrivacy,
 } from "@/chat/conversation-privacy";
-
-// Re-export types for backward compatibility with existing consumers.
-export type { AssistantReply, AgentTurnDiagnostics };
 
 const AGENT_ABORT_SETTLE_GRACE_MS = 5_000;
 
@@ -205,9 +198,9 @@ function waitForAbortSettlement(
 }
 
 /** Carries the user-visible content and prior transcript for one agent-run slice. */
-export interface ReplyRequestInput {
+export interface AgentRunInput {
   messageText: string;
-  userAttachments?: ReplyRequestAttachment[];
+  userAttachments?: AgentRunAttachment[];
   inboundAttachmentCount?: number;
   omittedImageAttachmentCount?: number;
   /** Durable Pi transcript for this conversation, excluding ephemeral turn context. */
@@ -216,7 +209,7 @@ export interface ReplyRequestInput {
 }
 
 /** Carries identity and addressing needed to route tools, auth, and delivery. */
-export interface ReplyRequestRouting {
+export interface AgentRunRouting {
   credentialContext?: CredentialContext;
   requester?: Requester;
   source: Source;
@@ -247,7 +240,7 @@ export interface ReplyRequestRouting {
  * Carries execution limits, dependency overrides, and persisted sandbox
  * reuse state for one run slice.
  */
-export interface ReplyRequestPolicy {
+export interface AgentRunPolicy {
   /** Absolute wall-clock deadline for this host request, in milliseconds. */
   turnDeadlineAtMs?: number;
   authorizationFlowMode?: AuthorizationFlowMode;
@@ -268,7 +261,7 @@ export interface ReplyRequestPolicy {
 }
 
 /** Carries durable state snapshots already loaded by the caller. */
-export interface ReplyRequestState {
+export interface AgentRunState {
   artifactState?: ThreadArtifactsState;
   pendingAuth?: ConversationPendingAuthState;
 }
@@ -277,7 +270,7 @@ export interface ReplyRequestState {
  * Carries notification-only callbacks for streaming UI and status surfaces;
  * their failures never affect the run.
  */
-export interface ReplyRequestObservers {
+export interface AgentRunObservers {
   onTextDelta?: (deltaText: string) => void | Promise<void>;
   onAssistantMessageStart?: () => void | Promise<void>;
   onToolInvocation?: (invocation: {
@@ -289,13 +282,13 @@ export interface ReplyRequestObservers {
 }
 
 /** Carries durable-worker ports that commit or update resumable run state. */
-export interface ReplyRequestDurability {
+export interface AgentRunDurability {
   onInputCommitted?: () => void | Promise<void>;
   /** Return true when the durable worker should pause at the next Pi boundary. */
   shouldYield?: () => boolean;
   drainSteeringMessages?: (
-    accept: (messages: ReplySteeringMessage[]) => Promise<void>,
-  ) => Promise<ReplySteeringMessage[]>;
+    accept: (messages: AgentRunSteeringMessage[]) => Promise<void>,
+  ) => Promise<AgentRunSteeringMessage[]>;
   recordPendingAuth?: (
     pendingAuth: ConversationPendingAuthState,
   ) => void | Promise<void>;
@@ -305,33 +298,29 @@ export interface ReplyRequestDurability {
   ) => void | Promise<void>;
 }
 
-/** Groups the per-slice reply request by the runtime role each field serves. */
-export interface ReplyRequestContext {
-  input: ReplyRequestInput;
-  routing: ReplyRequestRouting;
-  policy?: ReplyRequestPolicy;
-  state?: ReplyRequestState;
-  observers?: ReplyRequestObservers;
-  durability?: ReplyRequestDurability;
+/** Groups the per-slice run request by the runtime role each field serves. */
+export interface AgentRunRequest {
+  input: AgentRunInput;
+  routing: AgentRunRouting;
+  policy?: AgentRunPolicy;
+  state?: AgentRunState;
+  observers?: AgentRunObservers;
+  durability?: AgentRunDurability;
 }
 
-export type AssistantReplyRequestContext = ReplyRequestContext;
-
-type FlatReplyRequestContext = ReplyRequestInput &
-  ReplyRequestRouting &
-  ReplyRequestPolicy &
-  ReplyRequestState &
-  ReplyRequestObservers &
-  ReplyRequestDurability;
+type FlatAgentRunRequest = AgentRunInput &
+  AgentRunRouting &
+  AgentRunPolicy &
+  AgentRunState &
+  AgentRunObservers &
+  AgentRunDurability;
 
 /**
  * Interim shim: run internals still consume the historical flat shape
  * (grouped rewrite deferred to #746 Phase 5). The groups must stay
  * key-disjoint or later spreads silently shadow earlier fields.
  */
-function flattenReplyRequestContext(
-  request: ReplyRequestContext,
-): FlatReplyRequestContext {
+function flattenAgentRunRequest(request: AgentRunRequest): FlatAgentRunRequest {
   return {
     ...request.input,
     ...request.routing,
@@ -342,18 +331,18 @@ function flattenReplyRequestContext(
   };
 }
 
-export interface ReplyRequestAttachment {
+export interface AgentRunAttachment {
   data?: Buffer;
   mediaType: string;
   filename?: string;
   promptText?: string;
 }
 
-export interface ReplySteeringMessage {
+export interface AgentRunSteeringMessage {
   omittedImageAttachmentCount?: number;
   text: string;
   timestampMs?: number;
-  userAttachments?: ReplyRequestAttachment[];
+  userAttachments?: AgentRunAttachment[];
 }
 
 let startupDiscoveryLogged = false;
@@ -370,9 +359,7 @@ const legacyStoredTextPartSchema = z
   })
   .strict();
 
-type UserTurnAttachment = NonNullable<
-  ReplyRequestInput["userAttachments"]
->[number];
+type UserTurnAttachment = NonNullable<AgentRunInput["userAttachments"]>[number];
 
 function buildOmittedImageAttachmentNotice(count: number): string {
   return [
@@ -406,15 +393,13 @@ function extractSliceUsage(
 }
 
 function requesterFromContext(
-  context: FlatReplyRequestContext,
+  context: FlatAgentRunRequest,
 ): Requester | undefined {
   return actorRequesterFromContext(context);
 }
 
 /** Reject requester identities that do not belong to the active destination. */
-function assertRequesterDestinationMatch(
-  context: FlatReplyRequestContext,
-): void {
+function assertRequesterDestinationMatch(context: FlatAgentRunRequest): void {
   const { destination, requester } = context;
   if (!requester) {
     return;
@@ -434,9 +419,7 @@ function assertRequesterDestinationMatch(
 }
 
 /** Reject legacy Slack correlation fields that conflict with the destination. */
-function assertCorrelationDestinationMatch(
-  context: FlatReplyRequestContext,
-): void {
+function assertCorrelationDestinationMatch(context: FlatAgentRunRequest): void {
   const { correlation, destination } = context;
   if (destination.platform !== "slack") {
     return;
@@ -460,7 +443,7 @@ function assertCorrelationDestinationMatch(
 }
 
 function actorRequesterFromContext(
-  context: FlatReplyRequestContext,
+  context: FlatAgentRunRequest,
 ): Requester | undefined {
   return createRequester(context.requester, {
     platform:
@@ -478,9 +461,7 @@ function actorRequesterFromContext(
   });
 }
 
-function toolInvocationDestination(
-  context: FlatReplyRequestContext,
-): Destination {
+function toolInvocationDestination(context: FlatAgentRunRequest): Destination {
   if (context.destination.platform !== "slack" || !context.toolChannelId) {
     return context.destination;
   }
@@ -492,7 +473,7 @@ function toolInvocationDestination(
 }
 
 function surfaceFromContext(
-  context: FlatReplyRequestContext,
+  context: FlatAgentRunRequest,
 ): AgentTurnSurface | undefined {
   if (context.surface) {
     return context.surface;
@@ -557,7 +538,7 @@ function buildRouterAttachmentBlock(attachment: UserTurnAttachment): string {
 
 function buildUserTurnInput(args: {
   omittedImageAttachmentCount: number;
-  userAttachments?: ReplyRequestInput["userAttachments"];
+  userAttachments?: AgentRunInput["userAttachments"];
   userTurnText: string;
 }): {
   routerBlocks: string[];
@@ -622,7 +603,7 @@ function buildUserTurnInput(args: {
  * paths store identical durable history.
  */
 export function buildSteeringPiMessage(
-  message: ReplySteeringMessage,
+  message: AgentRunSteeringMessage,
 ): PiMessage {
   const { userContentParts } = buildUserTurnInput({
     userTurnText: buildUserTurnText(message.text),
@@ -707,10 +688,10 @@ function legacyTextPartMatchesCurrentText(
 }
 
 /** Run a full agent turn: discover skills, execute tools, and return the assistant reply. */
-export async function generateAssistantReply(
-  request: AssistantReplyRequestContext,
+export async function executeAgentRun(
+  request: AgentRunRequest,
 ): Promise<AgentRunOutcome> {
-  const context = flattenReplyRequestContext(request);
+  const context = flattenAgentRunRequest(request);
   const messageText = request.input.messageText;
   const conversationPrivacy = resolveConversationPrivacy({
     channelId: context.correlation?.channelId,
@@ -723,17 +704,13 @@ export async function generateAssistantReply(
     visibility: context.slackConversation?.visibility,
   });
   return runWithConversationPrivacy(conversationPrivacy ?? "private", () =>
-    generateAssistantReplyInPrivacyContext(
-      messageText,
-      context,
-      conversationPrivacy,
-    ),
+    executeAgentRunInPrivacyContext(messageText, context, conversationPrivacy),
   );
 }
 
-async function generateAssistantReplyInPrivacyContext(
+async function executeAgentRunInPrivacyContext(
   messageText: string,
-  context: FlatReplyRequestContext,
+  context: FlatAgentRunRequest,
   conversationPrivacy: ConversationPrivacy | undefined,
 ): Promise<AgentRunOutcome> {
   if (!context.destination) {
@@ -1946,7 +1923,7 @@ async function generateAssistantReplyInPrivacyContext(
     // ── Build turn result ────────────────────────────────────────────
     return {
       status: "completed",
-      reply: buildTurnResult({
+      result: buildTurnResult({
         newMessages,
         userInput,
         replyFiles,
@@ -2099,7 +2076,7 @@ async function generateAssistantReplyInPrivacyContext(
         modelId: botConfig.modelId,
       },
       {},
-      "generateAssistantReply failed",
+      "executeAgentRun failed",
     );
 
     // Raw exception text is diagnostics-only; the failure-response service
@@ -2107,7 +2084,7 @@ async function generateAssistantReplyInPrivacyContext(
     const message = error instanceof Error ? error.message : String(error);
     return {
       status: "completed",
-      reply: {
+      result: {
         text: "",
         ...getSandboxMetadata(),
         diagnostics: {

--- a/packages/junior/src/chat/app/services.ts
+++ b/packages/junior/src/chat/app/services.ts
@@ -1,5 +1,5 @@
 import { completeObject, completeText } from "@/chat/pi/client";
-import { generateAssistantReply as generateAssistantReplyImpl } from "@/chat/respond";
+import { executeAgentRun as executeAgentRunImpl } from "@/chat/agent-run";
 import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress/tracing";
 import {
   getAwaitingAgentContinueRequest,
@@ -78,7 +78,7 @@ export function createJuniorRuntimeServices(
         overrides.replyExecutor?.contextCompactor ?? contextCompactor,
       agentRunner:
         overrides.replyExecutor?.agentRunner ??
-        createAgentRunner(generateAssistantReplyImpl, {
+        createAgentRunner(executeAgentRunImpl, {
           tracePropagation: overrides.sandbox?.tracePropagation,
         }),
       getAwaitingAgentContinueRequest:

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -2,11 +2,11 @@
  * Local agent turn runtime.
  *
  * This module owns the Slack-free execution boundary for CLI-originated turns:
- * it persists local conversation state, invokes the shared reply generator with
+ * it persists local conversation state, invokes the shared agent runner with
  * a local destination, and only commits assistant delivery after the CLI sink
  * accepts the final output.
  */
-import type { AssistantReply } from "@/chat/respond";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import {
   createLocalSource,
@@ -23,7 +23,7 @@ import { THREAD_STATE_TTL_MS } from "chat";
 import {
   stripRuntimeTurnContext,
   trimTrailingAssistantMessages,
-} from "@/chat/respond-helpers";
+} from "@/chat/agent-run-helpers";
 import { buildDeliveredTurnStatePatch } from "@/chat/runtime/delivered-turn-state";
 import {
   getPersistedSandboxState,
@@ -52,7 +52,7 @@ export interface LocalAgentTurnInput {
 }
 
 export interface LocalAgentReply {
-  files?: AssistantReply["files"];
+  files?: AgentRunResult["files"];
   text: string;
 }
 
@@ -75,7 +75,7 @@ export interface LocalAgentTurnDeps {
 
 export interface LocalAgentTurnResult {
   conversationId: string;
-  outcome: AssistantReply["diagnostics"]["outcome"];
+  outcome: AgentRunResult["diagnostics"]["outcome"];
 }
 
 function localDestination(conversationId: string): LocalDestination {
@@ -93,7 +93,7 @@ function localTurnId(sequence: number): string {
   return `local-turn-${sequence}`;
 }
 
-function localReply(reply: AssistantReply): LocalAgentReply {
+function localReply(reply: AgentRunResult): LocalAgentReply {
   return {
     ...(reply.files ? { files: reply.files } : {}),
     text: reply.text,
@@ -161,7 +161,7 @@ async function persistDeliveredLocalTurnState(
   throw lastError;
 }
 
-/** Run one local CLI message through Junior's shared agent reply boundary. */
+/** Run one local CLI message through Junior's shared agent-run boundary. */
 export async function runLocalAgentTurn(
   input: LocalAgentTurnInput,
   deps: LocalAgentTurnDeps,
@@ -212,7 +212,7 @@ export async function runLocalAgentTurn(
   });
   await persistThreadStateById(input.conversationId, { conversation });
 
-  let reply: AssistantReply | undefined;
+  let reply: AgentRunResult | undefined;
   let completedState: ReturnType<typeof buildDeliveredTurnStatePatch>;
   let piMessagesBeforeRun:
     | Awaited<ReturnType<typeof loadLocalPiMessages>>
@@ -297,7 +297,7 @@ export async function runLocalAgentTurn(
     if (outcome.status !== "completed") {
       throw new Error(`Local agent run ended with ${outcome.status}`);
     }
-    reply = outcome.reply;
+    reply = outcome.result;
 
     // Failed turns deliver the sanitized fallback (or genuine partial model
     // text), never raw exception strings and never silence.

--- a/packages/junior/src/chat/plugins/task-runner.ts
+++ b/packages/junior/src/chat/plugins/task-runner.ts
@@ -23,7 +23,7 @@ import {
   isToolResultMessage,
   normalizeToolNameFromResult,
   stripRuntimeTurnContext,
-} from "@/chat/respond-helpers";
+} from "@/chat/agent-run-helpers";
 import { getAgentTurnSessionRecord } from "@/chat/state/turn-session";
 import { getPlugins } from "./agent-hooks";
 import {

--- a/packages/junior/src/chat/runtime/agent-continue-runner.ts
+++ b/packages/junior/src/chat/runtime/agent-continue-runner.ts
@@ -60,7 +60,7 @@ import {
   type SlackRequester,
 } from "@/chat/requester";
 import { getConversationWorkState } from "@/chat/task-execution/store";
-import type { AssistantReply } from "@/chat/respond";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { persistAuthPauseTurnState } from "@/chat/runtime/auth-pause-state";
 import {
@@ -89,7 +89,7 @@ function sleep(ms: number): Promise<void> {
 /** Persist a delivered continuation reply as the terminal thread state. */
 async function persistCompletedReplyState(args: {
   sessionRecord: AgentTurnSessionRecord;
-  reply: AssistantReply;
+  reply: AgentRunResult;
 }): Promise<void> {
   const currentState = await getPersistedThreadState(
     args.sessionRecord.conversationId,
@@ -406,7 +406,7 @@ export async function continueSlackAgentRun(
               },
             },
           },
-          onSuccess: async (reply: AssistantReply) => {
+          onSuccess: async (reply: AgentRunResult) => {
             await persistCompletedReplyState({
               sessionRecord: activeSessionRecord,
               reply,

--- a/packages/junior/src/chat/runtime/agent-run-outcome.ts
+++ b/packages/junior/src/chat/runtime/agent-run-outcome.ts
@@ -1,19 +1,19 @@
-import type { AssistantReply } from "@/chat/services/turn-result";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 
 /**
- * How an agent run ended. `completed` carries the terminal reply (success or
- * failure — `reply.diagnostics` distinguishes them). `suspended` means the run
+ * How an agent run ended. `completed` carries the terminal result (success or
+ * failure — `result.diagnostics` distinguishes them). `suspended` means the run
  * persisted an awaiting_resume session record and stopped at a safe boundary;
  * the caller resumes it by scheduling a continuation against `resumeVersion`,
  * the session record's optimistic-concurrency version. `awaiting_auth` means
  * the run parked for user authorization.
  */
 export type AgentRunOutcome =
-  | { status: "completed"; reply: AssistantReply }
+  | { status: "completed"; result: AgentRunResult }
   | { status: "suspended"; resumeVersion: number }
   | { status: "awaiting_auth"; providerDisplayName: string };
 
-/** Wrap a terminal reply (successful or failed per its diagnostics) as an outcome. */
-export function completedAgentRun(reply: AssistantReply): AgentRunOutcome {
-  return { status: "completed", reply };
+/** Wrap a terminal result (successful or failed per its diagnostics) as an outcome. */
+export function completedAgentRun(result: AgentRunResult): AgentRunOutcome {
+  return { status: "completed", result };
 }

--- a/packages/junior/src/chat/runtime/agent-runner.ts
+++ b/packages/junior/src/chat/runtime/agent-runner.ts
@@ -1,13 +1,13 @@
-import type { ReplyRequestContext } from "@/chat/respond";
+import type { AgentRunRequest } from "@/chat/agent-run";
 import type { AgentRunOutcome } from "@/chat/runtime/agent-run-outcome";
 import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress/tracing";
 
 /** Run one agent-run slice behind runtime-owned orchestration boundaries. */
 export interface AgentRunner {
-  run(request: ReplyRequestContext): Promise<AgentRunOutcome>;
+  run(request: AgentRunRequest): Promise<AgentRunOutcome>;
 }
 
-/** Adapt the Pi-facing reply generator behind the runtime-owned runner seam. */
+/** Adapt the Pi-facing agent-run executor behind the runtime-owned runner seam. */
 export function createAgentRunner(
   run: AgentRunner["run"],
   options?: { tracePropagation?: SandboxEgressTracePropagationConfig },

--- a/packages/junior/src/chat/runtime/delivered-turn-state.ts
+++ b/packages/junior/src/chat/runtime/delivered-turn-state.ts
@@ -1,5 +1,5 @@
 import { botConfig } from "@/chat/config";
-import type { AssistantReply } from "@/chat/respond";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { ThreadConversationState } from "@/chat/state/conversation";
 import type { ThreadArtifactsState } from "@/chat/state/artifacts";
 import {
@@ -23,7 +23,7 @@ export function buildDeliveredTurnStatePatch(args: {
   artifactStatePatch?: Partial<ThreadArtifactsState>;
   artifacts: ThreadArtifactsState;
   conversation: ThreadConversationState;
-  reply: AssistantReply;
+  reply: AgentRunResult;
   sessionId: string;
   userMessageId?: string;
 }): ThreadStatePatch & { conversation: ThreadConversationState } {

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -31,8 +31,8 @@ import { buildSlackOutputMessage } from "@/chat/slack/output";
 import { getSlackErrorObservabilityAttributes } from "@/chat/slack/errors";
 import {
   buildSteeringPiMessage,
-  type ReplySteeringMessage,
-} from "@/chat/respond";
+  type AgentRunSteeringMessage,
+} from "@/chat/agent-run";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import type { CredentialContext } from "@/chat/credentials/context";
 import { shouldEmitDevAgentTrace } from "@/chat/runtime/dev-agent-trace";
@@ -125,7 +125,7 @@ import { persistWithRetry } from "@/chat/services/persist-retry";
 import {
   stripRuntimeTurnContext,
   trimTrailingAssistantMessages,
-} from "@/chat/respond-helpers";
+} from "@/chat/agent-run-helpers";
 import { requireSlackDestination } from "@/chat/destination";
 
 /**
@@ -515,7 +515,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
         let activeTurnId = preparedState.conversation.processing.activeTurnId;
         const resolveSteeringMessages = async (
           queuedMessages: QueuedTurnMessage[],
-        ): Promise<ReplySteeringMessage[]> => {
+        ): Promise<AgentRunSteeringMessage[]> => {
           return await Promise.all(
             queuedMessages.map(async (queued) => {
               const attachments = queued.message.attachments;
@@ -1019,9 +1019,9 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             preparedState.artifacts.assistantContextChannelId ?? channelId;
           const drainSteeringMessages = options.drainSteeringMessages
             ? async (
-                accept: (messages: ReplySteeringMessage[]) => Promise<void>,
-              ): Promise<ReplySteeringMessage[]> => {
-                let acceptedMessages: ReplySteeringMessage[] | undefined;
+                accept: (messages: AgentRunSteeringMessage[]) => Promise<void>,
+              ): Promise<AgentRunSteeringMessage[]> => {
+                let acceptedMessages: AgentRunSteeringMessage[] | undefined;
                 const drained = await options.drainSteeringMessages!(
                   async (queuedMessages) => {
                     acceptedMessages =
@@ -1210,7 +1210,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             return;
           }
 
-          let reply = outcome.reply;
+          let reply = outcome.result;
           const diagnosticsContext = {
             slackThreadId: threadId,
             slackUserId: message.author.userId,

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -7,10 +7,8 @@
  */
 import { botConfig } from "@/chat/config";
 import type { ChannelConfigurationService } from "@/chat/configuration/types";
-import {
-  type AssistantReply,
-  type AssistantReplyRequestContext,
-} from "@/chat/respond";
+import type { AgentRunRequest } from "@/chat/agent-run";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { scheduleSessionCompletedPluginTasks } from "@/chat/plugins/task-runner";
 import {
@@ -142,7 +140,7 @@ interface ResumeSlackTurnArgs {
     conversationId: string;
     sessionId: string;
   }) => Promise<void>;
-  onSuccess?: (reply: AssistantReply) => Promise<void>;
+  onSuccess?: (reply: AgentRunResult) => Promise<void>;
   onFailure?: (error: unknown) => Promise<void>;
   onAuthPause?: (pause: { providerDisplayName: string }) => Promise<void>;
   onTimeoutPause?: (resume: { resumeVersion: number }) => Promise<void>;
@@ -153,8 +151,8 @@ interface ResumeSlackTurnArgs {
 
 // Resume args carry the user message text, so stored contexts hold only the
 // remaining input fields.
-type ResumeReplyContext = Omit<AssistantReplyRequestContext, "input"> & {
-  input?: Omit<AssistantReplyRequestContext["input"], "messageText">;
+type ResumeReplyContext = Omit<AgentRunRequest, "input"> & {
+  input?: Omit<AgentRunRequest["input"], "messageText">;
 };
 
 function getDefaultLockKey(channelId: string, threadTs: string): string {
@@ -241,7 +239,7 @@ async function handleResumeFailure(args: {
 function createResumeReplyContext(
   args: ResumeSlackTurnArgs,
   statusSession: AssistantStatusSession,
-): AssistantReplyRequestContext {
+): AgentRunRequest {
   const replyContext = args.replyContext;
   if (!replyContext) {
     throw new TypeError("Slack resume requires a reply context");
@@ -402,7 +400,7 @@ export async function resumeSlackTurn(
                 () =>
                   reject(
                     new Error(
-                      `generateAssistantReply timed out after ${replyTimeoutMs}ms`,
+                      `executeAgentRun timed out after ${replyTimeoutMs}ms`,
                     ),
                   ),
                 replyTimeoutMs,
@@ -446,7 +444,7 @@ export async function resumeSlackTurn(
         };
       }
     } else {
-      let reply = outcome.reply;
+      let reply = outcome.result;
       reply = finalizeFailedTurnReply({
         reply,
         logException,
@@ -614,7 +612,7 @@ export async function resumeAuthorizedRequest(args: {
   replyContext?: ResumeReplyContext;
   lockKey?: string;
   agentRunner: AgentRunner;
-  onSuccess?: (reply: AssistantReply) => Promise<void>;
+  onSuccess?: (reply: AgentRunResult) => Promise<void>;
   onFailure?: (error: unknown) => Promise<void>;
   onAuthPause?: (pause: { providerDisplayName: string }) => Promise<void>;
   onTimeoutPause?: (resume: { resumeVersion: number }) => Promise<void>;

--- a/packages/junior/src/chat/services/context-compaction.ts
+++ b/packages/junior/src/chat/services/context-compaction.ts
@@ -25,7 +25,7 @@ import { logWarn, setSpanAttributes } from "@/chat/logging";
 import {
   stripRuntimeTurnContext,
   trimTrailingAssistantMessages,
-} from "@/chat/respond-helpers";
+} from "@/chat/agent-run-helpers";
 import { updateConversationStats } from "@/chat/services/conversation-memory";
 
 const RETAINED_USER_MESSAGE_TOKENS = 20_000;

--- a/packages/junior/src/chat/services/provider-retry.ts
+++ b/packages/junior/src/chat/services/provider-retry.ts
@@ -3,7 +3,7 @@ import type { PiMessage } from "@/chat/pi/messages";
 import {
   getPiMessageRole,
   trimTrailingAssistantMessages,
-} from "@/chat/respond-helpers";
+} from "@/chat/agent-run-helpers";
 
 const PROVIDER_RETRY_DELAYS_MS = [2_000, 4_000, 8_000] as const;
 const PROVIDER_ERROR_PREFIX = "AI provider error:";

--- a/packages/junior/src/chat/services/turn-failure-response.ts
+++ b/packages/junior/src/chat/services/turn-failure-response.ts
@@ -2,7 +2,7 @@ import type { LogContext } from "@/chat/logging";
 import { buildTurnFailureResponse } from "@/chat/logging";
 import { getInterruptionMarker } from "@/chat/interruption-marker";
 import { GEN_AI_PROVIDER_NAME } from "@/chat/pi/client";
-import type { AssistantReply } from "@/chat/services/turn-result";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 
 type LogException = (
   error: unknown,
@@ -43,7 +43,7 @@ function getExecutionFailureReason(reply: {
   return "empty assistant turn";
 }
 
-function getFailureCapture(reply: AssistantReply): {
+function getFailureCapture(reply: AgentRunResult): {
   attributes: Record<string, unknown>;
   body: string;
   error: unknown;
@@ -76,7 +76,7 @@ function getFailureCapture(reply: AssistantReply): {
 
 /** Keep failed-turn Sentry captures and completion spans on the same keys. */
 export function getAgentTurnDiagnosticsAttributes(
-  reply: AssistantReply,
+  reply: AgentRunResult,
 ): Record<string, unknown> {
   return {
     "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
@@ -105,11 +105,11 @@ export function getAgentTurnDiagnosticsAttributes(
 
 /** Enforce one captured, event-ID-bearing failure response before delivery. */
 export function finalizeFailedTurnReply(args: {
-  reply: AssistantReply;
+  reply: AgentRunResult;
   logException: LogException;
   context: LogContext;
   attributes?: Record<string, unknown>;
-}): AssistantReply {
+}): AgentRunResult {
   if (args.reply.diagnostics.outcome === "success") {
     return args.reply;
   }

--- a/packages/junior/src/chat/services/turn-result.ts
+++ b/packages/junior/src/chat/services/turn-result.ts
@@ -27,7 +27,7 @@ import {
   isToolResultMessage,
   normalizeToolNameFromResult,
   summarizeMessageText,
-} from "@/chat/respond-helpers";
+} from "@/chat/agent-run-helpers";
 
 const POST_CANVAS_REPLY_MAX_CHARS = 700;
 const POST_CANVAS_REPLY_MAX_LINES = 8;
@@ -51,7 +51,7 @@ export interface AgentTurnDiagnostics {
   usedPrimaryText: boolean;
 }
 
-export interface AssistantReply {
+export interface AgentRunResult {
   text: string;
   files?: FileUpload[];
   artifactStatePatch?: Partial<ThreadArtifactsState>;
@@ -131,8 +131,8 @@ function stripThinkingXmlBlocks(text: string): string {
   return result;
 }
 
-/** Process raw agent messages into a structured AssistantReply. */
-export function buildTurnResult(input: TurnResultInput): AssistantReply {
+/** Process raw agent messages into a structured AgentRunResult. */
+export function buildTurnResult(input: TurnResultInput): AgentRunResult {
   const {
     newMessages,
     userInput,

--- a/packages/junior/src/chat/services/turn-session-record.ts
+++ b/packages/junior/src/chat/services/turn-session-record.ts
@@ -11,7 +11,7 @@ import type { PiMessage } from "@/chat/pi/messages";
 import {
   getPiMessageRole,
   trimTrailingAssistantMessages,
-} from "@/chat/respond-helpers";
+} from "@/chat/agent-run-helpers";
 import { addAgentTurnUsage, type AgentTurnUsage } from "@/chat/usage";
 
 export const AGENT_CONTINUE_MAX_SLICES = 48;

--- a/packages/junior/src/chat/slack/reply.ts
+++ b/packages/junior/src/chat/slack/reply.ts
@@ -1,6 +1,6 @@
 import { Buffer } from "node:buffer";
 import type { FileUpload } from "chat";
-import type { AssistantReply } from "@/chat/respond";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { ReplyFileDelivery } from "@/chat/services/reply-delivery-plan";
 import {
   buildSlackReplyBlocks,
@@ -23,7 +23,7 @@ export interface PlannedSlackReplyPost {
   text: string;
 }
 
-function resolveReplyDelivery(reply: AssistantReply): {
+function resolveReplyDelivery(reply: AgentRunResult): {
   shouldPostThreadReply: boolean;
   attachFiles: ReplyFileDelivery;
 } {
@@ -135,7 +135,7 @@ async function uploadReplyFiles(args: {
  * including chunking, interruption markers, and file delivery.
  */
 export function planSlackReplyPosts(args: {
-  reply: AssistantReply;
+  reply: AgentRunResult;
 }): PlannedSlackReplyPost[] {
   const replyFiles =
     args.reply.files && args.reply.files.length > 0

--- a/packages/junior/src/chat/tools/advisor/tool.ts
+++ b/packages/junior/src/chat/tools/advisor/tool.ts
@@ -30,7 +30,7 @@ import type { PiMessage } from "@/chat/pi/messages";
 import {
   extractAssistantText,
   isAssistantMessage,
-} from "@/chat/respond-helpers";
+} from "@/chat/agent-run-helpers";
 import {
   createStateAdvisorSessionStore,
   getAdvisorSessionKey,

--- a/packages/junior/src/cli/chat.ts
+++ b/packages/junior/src/cli/chat.ts
@@ -20,7 +20,7 @@ import type {
   LocalAgentTurnDeps,
   LocalToolResult,
 } from "@/chat/local/runner";
-import { generateAssistantReply } from "@/chat/respond";
+import { executeAgentRun } from "@/chat/agent-run";
 import { createAgentRunner } from "@/chat/runtime/agent-runner";
 import type { JuniorPluginSet } from "@/plugins";
 
@@ -245,7 +245,7 @@ async function prepareLocalChatRun(
   await configureLocalChatPlugins(pluginSet);
   const { runLocalAgentTurn } = await import("@/chat/local/runner");
   const deps: LocalAgentTurnDeps = {
-    agentRunner: createAgentRunner(generateAssistantReply),
+    agentRunner: createAgentRunner(executeAgentRun),
     deliverReply: async (reply) => {
       await deliverReply(io, reply);
     },

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -14,7 +14,7 @@ import {
 } from "@/chat/mcp/auth-store";
 import { finalizeMcpAuthorization } from "@/chat/mcp/oauth";
 import { logException, logWarn } from "@/chat/logging";
-import type { AssistantReply } from "@/chat/respond";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import {
   getChannelConfigurationServiceById,
@@ -106,7 +106,7 @@ async function persistCompletedReplyState(
   channelId: string,
   threadTs: string,
   sessionId: string,
-  reply: AssistantReply,
+  reply: AgentRunResult,
 ): Promise<void> {
   const threadId = `slack:${channelId}:${threadTs}`;
   const currentState = await getPersistedThreadState(threadId);
@@ -395,7 +395,7 @@ async function resumeAuthorizedMcpTurn(args: {
             },
           },
         },
-        onSuccess: async (reply: AssistantReply) => {
+        onSuccess: async (reply: AgentRunResult) => {
           await persistCompletedReplyState(
             authSession.channelId!,
             authSession.threadTs!,

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -62,7 +62,7 @@ import {
 import { escapeXml } from "@/chat/xml";
 import type { WaitUntilFn } from "@/handlers/types";
 import { scheduleAgentContinue } from "@/chat/services/agent-continue";
-import type { AssistantReply } from "@/chat/respond";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { requireSlackDestination } from "@/chat/destination";
 
@@ -88,7 +88,7 @@ function htmlErrorResponse(
 async function persistCompletedOAuthReplyState(args: {
   conversationId: string;
   sessionId: string;
-  reply: AssistantReply;
+  reply: AgentRunResult;
 }): Promise<void> {
   const currentState = await getPersistedThreadState(args.conversationId);
   const conversation = coerceThreadConversationState(currentState);
@@ -423,7 +423,7 @@ async function resumeOAuthSessionRecordTurn(
             },
           },
         },
-        onSuccess: async (reply: AssistantReply) => {
+        onSuccess: async (reply: AgentRunResult) => {
           logInfo(
             "oauth_callback_resume_complete",
             {},

--- a/packages/junior/tests/component/runtime/agent-run-error-path.test.ts
+++ b/packages/junior/tests/component/runtime/agent-run-error-path.test.ts
@@ -16,7 +16,7 @@ vi.mock("@/chat/skills", () => ({
   parseSkillInvocation: vi.fn(),
 }));
 
-const { generateAssistantReply } = await import("@/chat/respond");
+const { executeAgentRun } = await import("@/chat/agent-run");
 
 const LOCAL_DESTINATION = {
   platform: "local" as const,
@@ -34,7 +34,7 @@ const SLACK_SOURCE = createSlackSource({
   type: "priv",
 });
 
-describe("generateAssistantReply error path", () => {
+describe("executeAgentRun error path", () => {
   afterAll(() => {
     if (originalAiModel === undefined) {
       delete process.env.AI_MODEL;
@@ -44,7 +44,7 @@ describe("generateAssistantReply error path", () => {
   });
 
   it("preserves sandbox dependency hash on non-retryable failures", async () => {
-    const outcome = await generateAssistantReply({
+    const outcome = await executeAgentRun({
       input: { messageText: "hello" },
       routing: { destination: LOCAL_DESTINATION, source: LOCAL_SOURCE },
       policy: {
@@ -54,7 +54,7 @@ describe("generateAssistantReply error path", () => {
         },
       },
     });
-    const reply = outcome.status === "completed" ? outcome.reply : undefined;
+    const reply = outcome.status === "completed" ? outcome.result : undefined;
     expect(reply).toBeDefined();
     expect(reply!.diagnostics.outcome).toBe("provider_error");
 
@@ -71,7 +71,7 @@ describe("generateAssistantReply error path", () => {
 
   it("propagates pre-commit failures when durable input commit is required", async () => {
     await expect(
-      generateAssistantReply({
+      executeAgentRun({
         input: { messageText: "hello" },
         routing: { destination: LOCAL_DESTINATION, source: LOCAL_SOURCE },
         durability: {
@@ -85,16 +85,16 @@ describe("generateAssistantReply error path", () => {
 
   it("hard-fails missing destinations", async () => {
     await expect(
-      generateAssistantReply({
+      executeAgentRun({
         input: { messageText: "hello" },
-        routing: {} as Parameters<typeof generateAssistantReply>[0]["routing"],
+        routing: {} as Parameters<typeof executeAgentRun>[0]["routing"],
       }),
     ).rejects.toThrow("Assistant reply generation requires a destination");
   });
 
   it("hard-fails requester and destination platform mismatches", async () => {
     await expect(
-      generateAssistantReply({
+      executeAgentRun({
         input: { messageText: "hello" },
         routing: {
           destination: LOCAL_DESTINATION,
@@ -113,7 +113,7 @@ describe("generateAssistantReply error path", () => {
 
   it("hard-fails Slack correlation and destination mismatches", async () => {
     await expect(
-      generateAssistantReply({
+      executeAgentRun({
         input: { messageText: "hello" },
         routing: {
           destination: SLACK_DESTINATION,

--- a/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
@@ -54,7 +54,7 @@ import {
   slackEnvelope,
   slackWebhookRequest,
 } from "../../fixtures/conversation-work";
-import { flattenReplyRequestForTest } from "../../fixtures/agent-runner";
+import { flattenAgentRunRequestForTest } from "../../fixtures/agent-runner";
 
 type SlackWorkerOptions = Parameters<typeof createSlackConversationWorker>[0];
 
@@ -1611,7 +1611,7 @@ describe("Slack conversation work execution", () => {
             run: async (request) => {
               const _text = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               await context?.onInputCommitted?.();

--- a/packages/junior/tests/fixtures/agent-runner.ts
+++ b/packages/junior/tests/fixtures/agent-runner.ts
@@ -1,14 +1,14 @@
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 
 /**
- * Default harness runner: resolve @/chat/respond at call time so a test's
+ * Default harness runner: resolve @/chat/agent-run at call time so a test's
  * vi.mock of that module is honored regardless of import order, while tests
- * without the mock exercise the real reply generator.
+ * without the mock exercise the real executor.
  */
-export const respondAgentRunner: AgentRunner = {
+export const realAgentRunner: AgentRunner = {
   run: async (request) => {
-    const { generateAssistantReply } = await import("@/chat/respond");
-    return await generateAssistantReply(request);
+    const { executeAgentRun } = await import("@/chat/agent-run");
+    return await executeAgentRun(request);
   },
 };
 
@@ -16,7 +16,7 @@ export const respondAgentRunner: AgentRunner = {
  * Flatten a grouped run request so tests can assert on the legacy flat field
  * surface without hand-copying the group spreads at every mock boundary.
  */
-export function flattenReplyRequestForTest(
+export function flattenAgentRunRequestForTest(
   request: Parameters<AgentRunner["run"]>[0],
 ) {
   return {

--- a/packages/junior/tests/fixtures/mcp-oauth-callback-harness.ts
+++ b/packages/junior/tests/fixtures/mcp-oauth-callback-harness.ts
@@ -3,7 +3,7 @@ import {
   waitUntilCallbacks,
   testWaitUntil,
 } from "./oauth-callback-after-harness";
-import { respondAgentRunner } from "./agent-runner";
+import { realAgentRunner } from "./agent-runner";
 
 export async function runMcpOauthCallbackRoute(args: {
   provider: string;
@@ -20,7 +20,7 @@ export async function runMcpOauthCallbackRoute(args: {
     ),
     args.provider,
     testWaitUntil,
-    { agentRunner: args.agentRunner ?? respondAgentRunner },
+    { agentRunner: args.agentRunner ?? realAgentRunner },
   );
   const callbacks = waitUntilCallbacks.splice(0, waitUntilCallbacks.length);
   for (const callback of callbacks) {

--- a/packages/junior/tests/fixtures/oauth-callback-harness.ts
+++ b/packages/junior/tests/fixtures/oauth-callback-harness.ts
@@ -3,7 +3,7 @@ import {
   waitUntilCallbacks,
   testWaitUntil,
 } from "./oauth-callback-after-harness";
-import { respondAgentRunner } from "./agent-runner";
+import { realAgentRunner } from "./agent-runner";
 
 export async function runOauthCallbackRoute(args: {
   provider: string;
@@ -20,7 +20,7 @@ export async function runOauthCallbackRoute(args: {
     ),
     args.provider,
     testWaitUntil,
-    { agentRunner: args.agentRunner ?? respondAgentRunner },
+    { agentRunner: args.agentRunner ?? realAgentRunner },
   );
   const callbacks = waitUntilCallbacks.splice(0, waitUntilCallbacks.length);
   for (const callback of callbacks) {

--- a/packages/junior/tests/integration/agent-continue-slack.test.ts
+++ b/packages/junior/tests/integration/agent-continue-slack.test.ts
@@ -10,7 +10,7 @@ import { slackApiOutbox } from "../fixtures/slack-api-outbox";
 import { resetSlackApiMockState } from "../msw/handlers/slack-api";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
-const generateAssistantReplyMock = vi.fn();
+const executeAgentRunMock = vi.fn();
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -69,7 +69,7 @@ function continueAgentRun(args: {
         sessionId: args.sessionId,
       },
       {
-        agentRunner: { run: generateAssistantReplyMock },
+        agentRunner: { run: executeAgentRunMock },
         scheduleAgentContinue: (request) =>
           agentContinueServiceModule.scheduleAgentContinue(request, {
             queue,
@@ -82,8 +82,8 @@ function continueAgentRun(args: {
 describe("agent continuation Slack integration", () => {
   beforeEach(async () => {
     queue = createConversationWorkQueueTestAdapter();
-    generateAssistantReplyMock.mockReset();
-    generateAssistantReplyMock.mockResolvedValue(
+    executeAgentRunMock.mockReset();
+    executeAgentRunMock.mockResolvedValue(
       completedAgentRun({
         text: "Final resumed answer",
         diagnostics: makeDiagnostics(),
@@ -212,7 +212,7 @@ describe("agent continuation Slack integration", () => {
 
     expect(continued).toBe(true);
 
-    expect(generateAssistantReplyMock).toHaveBeenCalledWith(
+    expect(executeAgentRunMock).toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({
           messageText: "resume this request",
@@ -238,7 +238,7 @@ describe("agent continuation Slack integration", () => {
         }),
       }),
     );
-    const resumeContext = generateAssistantReplyMock.mock.calls[0]?.[0] as {
+    const resumeContext = executeAgentRunMock.mock.calls[0]?.[0] as {
       policy?: {
         channelConfiguration?: {
           resolve: (key: string) => Promise<unknown>;
@@ -373,7 +373,7 @@ describe("agent continuation Slack integration", () => {
         }),
       }),
     ]);
-    expect(generateAssistantReplyMock).toHaveBeenCalledWith(
+    expect(executeAgentRunMock).toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({ messageText: "resume this request" }),
         routing: expect.objectContaining({
@@ -453,7 +453,7 @@ describe("agent continuation Slack integration", () => {
       },
     });
 
-    generateAssistantReplyMock.mockResolvedValueOnce({
+    executeAgentRunMock.mockResolvedValueOnce({
       status: "suspended",
       resumeVersion: sessionRecord.version + 1,
     });
@@ -548,7 +548,7 @@ describe("agent continuation Slack integration", () => {
     });
 
     expect(continued).toBe(true);
-    expect(generateAssistantReplyMock).not.toHaveBeenCalled();
+    expect(executeAgentRunMock).not.toHaveBeenCalled();
     await expect(
       turnSessionStoreModule.getAgentTurnSessionRecord(
         conversationId,
@@ -628,7 +628,7 @@ describe("agent continuation Slack integration", () => {
     });
 
     expect(continued).toBe(false);
-    expect(generateAssistantReplyMock).not.toHaveBeenCalled();
+    expect(executeAgentRunMock).not.toHaveBeenCalled();
     await expect(
       turnSessionStoreModule.getAgentTurnSessionRecord(
         conversationId,
@@ -731,7 +731,7 @@ describe("agent continuation Slack integration", () => {
     });
 
     expect(continued).toBe(true);
-    expect(generateAssistantReplyMock).toHaveBeenCalledWith(
+    expect(executeAgentRunMock).toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({ messageText: "resume this request" }),
         routing: expect.objectContaining({
@@ -821,7 +821,7 @@ describe("agent continuation Slack integration", () => {
       },
     });
 
-    generateAssistantReplyMock.mockResolvedValueOnce({
+    executeAgentRunMock.mockResolvedValueOnce({
       status: "suspended",
       resumeVersion: sessionRecord.version + 1,
     });
@@ -853,7 +853,7 @@ describe("agent continuation Slack integration", () => {
     // exactly one visible reply and only then a delivered/completed session.
     const conversationId = "slack:C123:1712345.0008";
     const sessionId = "turn_msg_8";
-    generateAssistantReplyMock.mockResolvedValueOnce(
+    executeAgentRunMock.mockResolvedValueOnce(
       completedAgentRun({
         text: "Final resumed answer",
         piMessages: [
@@ -934,7 +934,7 @@ describe("agent continuation Slack integration", () => {
       agentContinueRunnerModule.resumeAwaitingSlackContinuation(
         conversationId,
         {
-          agentRunner: { run: generateAssistantReplyMock },
+          agentRunner: { run: executeAgentRunMock },
           scheduleAgentContinue: (request) =>
             agentContinueServiceModule.scheduleAgentContinue(request, {
               queue,
@@ -944,7 +944,7 @@ describe("agent continuation Slack integration", () => {
     );
 
     expect(resumed).toBe(true);
-    expect(generateAssistantReplyMock).toHaveBeenCalledWith(
+    expect(executeAgentRunMock).toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({ messageText: "resume this request" }),
         routing: expect.objectContaining({
@@ -1050,13 +1050,13 @@ describe("agent continuation Slack integration", () => {
       agentContinueRunnerModule.resumeAwaitingSlackContinuation(
         conversationId,
         {
-          agentRunner: { run: generateAssistantReplyMock },
+          agentRunner: { run: executeAgentRunMock },
         },
       ),
     );
 
     expect(resumed).toBe(false);
-    expect(generateAssistantReplyMock).not.toHaveBeenCalled();
+    expect(executeAgentRunMock).not.toHaveBeenCalled();
     await expect(
       turnSessionStoreModule.getAgentTurnSessionRecord(
         conversationId,
@@ -1110,7 +1110,7 @@ describe("agent continuation Slack integration", () => {
         },
       });
 
-    generateAssistantReplyMock.mockResolvedValueOnce(
+    executeAgentRunMock.mockResolvedValueOnce(
       completedAgentRun({
         text: "Final resumed answer with artifact",
         files: [

--- a/packages/junior/tests/integration/agent-dispatch-runner.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-runner.test.ts
@@ -17,7 +17,7 @@ import {
 } from "@/chat/runtime/thread-state";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
-import type { AssistantReply } from "@/chat/respond";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { PiMessage } from "@/chat/pi/messages";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import {
@@ -32,7 +32,7 @@ import {
   getCapturedSlackApiCalls,
   queueSlackApiResponse,
 } from "../msw/handlers/slack-api";
-import { flattenReplyRequestForTest } from "../fixtures/agent-runner";
+import { flattenAgentRunRequestForTest } from "../fixtures/agent-runner";
 
 vi.hoisted(() => {
   process.env.JUNIOR_STATE_ADAPTER = "memory";
@@ -55,7 +55,7 @@ function zeroUsage() {
   };
 }
 
-function createReply(): AssistantReply {
+function createReply(): AgentRunResult {
   return {
     text: "Dispatch delivered.",
     deliveryMode: "thread",
@@ -181,33 +181,31 @@ describe("agent dispatch runner", () => {
       },
     });
     const dispatchConversationId = getDispatchConversationId(created.record);
-    const generateAssistantReply = vi.fn<AgentRunner["run"]>(
-      async (request) => {
-        const context = flattenReplyRequestForTest(request);
-        expect(context.requester).toBeUndefined();
-        expect(context.authorizationFlowMode).toBe("disabled");
-        expect(context.surface).toBe("api");
-        expect(context.source).toEqual(slackSource());
-        expect(context.dispatch).toEqual({
-          actor: { type: "system", id: "scheduler" },
-          metadata: { runId: "run-1" },
-          plugin: "scheduler",
-        });
-        expect(context.correlation).toMatchObject({
-          conversationId: dispatchConversationId,
-          threadId: dispatchConversationId,
-          channelId: "C123",
-          teamId: "T123",
-        });
-        expect(context.credentialContext).toEqual({
-          actor: { type: "system", id: "scheduler" },
-        });
-        expect(context.sandbox?.tracePropagation).toEqual({
-          domains: ["*.sentry.io"],
-        });
-        return completedAgentRun(createReply());
-      },
-    );
+    const executeAgentRun = vi.fn<AgentRunner["run"]>(async (request) => {
+      const context = flattenAgentRunRequestForTest(request);
+      expect(context.requester).toBeUndefined();
+      expect(context.authorizationFlowMode).toBe("disabled");
+      expect(context.surface).toBe("api");
+      expect(context.source).toEqual(slackSource());
+      expect(context.dispatch).toEqual({
+        actor: { type: "system", id: "scheduler" },
+        metadata: { runId: "run-1" },
+        plugin: "scheduler",
+      });
+      expect(context.correlation).toMatchObject({
+        conversationId: dispatchConversationId,
+        threadId: dispatchConversationId,
+        channelId: "C123",
+        teamId: "T123",
+      });
+      expect(context.credentialContext).toEqual({
+        actor: { type: "system", id: "scheduler" },
+      });
+      expect(context.sandbox?.tracePropagation).toEqual({
+        domains: ["*.sentry.io"],
+      });
+      return completedAgentRun(createReply());
+    });
     const scheduleSessionCompletedPluginTasks = vi.fn(async () => undefined);
 
     await runAgentDispatchSlice(
@@ -216,7 +214,7 @@ describe("agent dispatch runner", () => {
         expectedVersion: created.record.version,
       },
       {
-        agentRunner: createAgentRunner(generateAssistantReply, {
+        agentRunner: createAgentRunner(executeAgentRun, {
           tracePropagation: { domains: ["*.sentry.io"] },
         }),
         scheduleSessionCompletedPluginTasks,
@@ -313,21 +311,19 @@ describe("agent dispatch runner", () => {
       },
     });
     const dispatchConversationId = getDispatchConversationId(created.record);
-    const generateAssistantReply = vi.fn<AgentRunner["run"]>(
-      async (request) => {
-        const context = flattenReplyRequestForTest(request);
-        expect(context.conversationContext).toBeUndefined();
-        expect(context.piMessages).toEqual([]);
-        return completedAgentRun(createReply());
-      },
-    );
+    const executeAgentRun = vi.fn<AgentRunner["run"]>(async (request) => {
+      const context = flattenAgentRunRequestForTest(request);
+      expect(context.conversationContext).toBeUndefined();
+      expect(context.piMessages).toEqual([]);
+      return completedAgentRun(createReply());
+    });
 
     await runAgentDispatchSlice(
       {
         id: created.record.id,
         expectedVersion: created.record.version,
       },
-      { agentRunner: { run: generateAssistantReply } },
+      { agentRunner: { run: executeAgentRun } },
     );
 
     const persistedDestination =
@@ -365,7 +361,7 @@ describe("agent dispatch runner", () => {
       },
     });
     const scheduleCallback = vi.fn(async () => undefined);
-    const generateAssistantReply = vi.fn(async () => {
+    const executeAgentRun = vi.fn(async () => {
       return { status: "suspended" as const, resumeVersion: 7 };
     });
 
@@ -374,7 +370,7 @@ describe("agent dispatch runner", () => {
         id: created.record.id,
         expectedVersion: created.record.version,
       },
-      { agentRunner: { run: generateAssistantReply }, scheduleCallback },
+      { agentRunner: { run: executeAgentRun }, scheduleCallback },
     );
 
     await expect(getDispatchRecord(created.record.id)).resolves.toMatchObject({
@@ -404,35 +400,33 @@ describe("agent dispatch runner", () => {
         source: slackSource("D123"),
       },
     });
-    const generateAssistantReply = vi.fn<AgentRunner["run"]>(
-      async (request) => {
-        const context = flattenReplyRequestForTest(request);
-        expect(context.requester).toBeUndefined();
-        expect(context.credentialContext).toEqual({
-          actor: { type: "system", id: "scheduler" },
-          subject: {
-            type: "user",
-            userId: "U123",
-            allowedWhen: "private-direct-conversation",
-            binding: {
-              type: "slack-direct-conversation",
-              teamId: "T123",
-              channelId: "D123",
-              signature: expect.any(String),
-            },
+    const executeAgentRun = vi.fn<AgentRunner["run"]>(async (request) => {
+      const context = flattenAgentRunRequestForTest(request);
+      expect(context.requester).toBeUndefined();
+      expect(context.credentialContext).toEqual({
+        actor: { type: "system", id: "scheduler" },
+        subject: {
+          type: "user",
+          userId: "U123",
+          allowedWhen: "private-direct-conversation",
+          binding: {
+            type: "slack-direct-conversation",
+            teamId: "T123",
+            channelId: "D123",
+            signature: expect.any(String),
           },
-        });
-        expect(context.authorizationFlowMode).toBe("disabled");
-        return completedAgentRun(createReply());
-      },
-    );
+        },
+      });
+      expect(context.authorizationFlowMode).toBe("disabled");
+      return completedAgentRun(createReply());
+    });
 
     await runAgentDispatchSlice(
       {
         id: created.record.id,
         expectedVersion: created.record.version,
       },
-      { agentRunner: { run: generateAssistantReply } },
+      { agentRunner: { run: executeAgentRun } },
     );
 
     await expect(getDispatchRecord(created.record.id)).resolves.toMatchObject({
@@ -524,7 +518,7 @@ describe("agent dispatch runner", () => {
     });
     const dispatchConversationId = getDispatchConversationId(created.record);
     const failedReply = createReply();
-    const generateAssistantReply = vi.fn(async () =>
+    const executeAgentRun = vi.fn(async () =>
       completedAgentRun({
         ...failedReply,
         text: "",
@@ -543,7 +537,7 @@ describe("agent dispatch runner", () => {
         id: created.record.id,
         expectedVersion: created.record.version,
       },
-      { agentRunner: { run: generateAssistantReply } },
+      { agentRunner: { run: executeAgentRun } },
     );
 
     await expect(getDispatchRecord(created.record.id)).resolves.toMatchObject({

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { AssistantReply } from "@/chat/respond";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 import {
   defineJuniorPlugin,
   type PluginRunContext,
@@ -24,16 +24,16 @@ import { coerceThreadConversationState } from "@/chat/state/conversation";
 import { coerceThreadArtifactsState } from "@/chat/state/artifacts";
 import { setPlugins } from "@/chat/plugins/agent-hooks";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
-import { flattenReplyRequestForTest } from "../fixtures/agent-runner";
+import { flattenAgentRunRequestForTest } from "../fixtures/agent-runner";
 
 function successReply(
   text: string,
   options: Partial<
-    Pick<AssistantReply, "piMessages"> & {
+    Pick<AgentRunResult, "piMessages"> & {
       toolCalls: string[];
     }
   > = {},
-): AssistantReply {
+): AgentRunResult {
   return {
     text,
     ...(options.piMessages ? { piMessages: options.piMessages } : {}),
@@ -49,10 +49,10 @@ function successReply(
   };
 }
 
-type FlatReplyRequestContext = ReturnType<typeof flattenReplyRequestForTest>;
+type FlatAgentRunRequest = ReturnType<typeof flattenAgentRunRequestForTest>;
 
 async function persistCompletedSessionForFakeReply(
-  context: FlatReplyRequestContext,
+  context: FlatAgentRunRequest,
   piMessages: PiMessage[],
 ): Promise<void> {
   const conversationId = context.correlation?.conversationId;
@@ -85,9 +85,9 @@ describe("local agent runner", () => {
     });
     expect(conversationId).toBeDefined();
 
-    const contexts: FlatReplyRequestContext[] = [];
+    const contexts: FlatAgentRunRequest[] = [];
     const generateReply = vi.fn<AgentRunner["run"]>(async (request) => {
-      const context = flattenReplyRequestForTest(request);
+      const context = flattenAgentRunRequestForTest(request);
 
       contexts.push(context);
       return completedAgentRun(successReply("hello from local"));
@@ -174,7 +174,7 @@ describe("local agent runner", () => {
     expect(conversationId).toBeDefined();
 
     const generateReply = vi.fn<AgentRunner["run"]>(async (request) => {
-      const context = flattenReplyRequestForTest(request);
+      const context = flattenAgentRunRequestForTest(request);
 
       context.onToolInvocation?.({
         toolName: "createMemory",
@@ -262,7 +262,7 @@ describe("local agent runner", () => {
           deliverReply: async () => undefined,
           agentRunner: {
             run: async (request) => {
-              const context = flattenReplyRequestForTest(request);
+              const context = flattenAgentRunRequestForTest(request);
 
               const piMessages = [
                 {
@@ -328,10 +328,10 @@ describe("local agent runner", () => {
     });
     expect(conversationId).toBeDefined();
 
-    const contexts: FlatReplyRequestContext[] = [];
+    const contexts: FlatAgentRunRequest[] = [];
     const generateReply = vi.fn<AgentRunner["run"]>(async (request) => {
       const text = request.input.messageText;
-      const context = flattenReplyRequestForTest(request);
+      const context = flattenAgentRunRequestForTest(request);
 
       contexts.push(context);
       return completedAgentRun(successReply(`reply to ${text}`));
@@ -437,9 +437,9 @@ describe("local agent runner", () => {
       ttlMs: 60_000,
     });
 
-    const contexts: FlatReplyRequestContext[] = [];
+    const contexts: FlatAgentRunRequest[] = [];
     const generateReply = vi.fn<AgentRunner["run"]>(async (request) => {
-      const context = flattenReplyRequestForTest(request);
+      const context = flattenAgentRunRequestForTest(request);
 
       contexts.push(context);
       return completedAgentRun(successReply("uses projection"));
@@ -502,7 +502,7 @@ describe("local agent runner", () => {
     const conversation = coerceThreadConversationState(state);
     expect(conversation.piMessages).toEqual(generatedMessages);
 
-    const contexts: FlatReplyRequestContext[] = [];
+    const contexts: FlatAgentRunRequest[] = [];
     await runLocalAgentTurn(
       {
         conversationId: conversationId!,
@@ -512,7 +512,7 @@ describe("local agent runner", () => {
         deliverReply: async () => undefined,
         agentRunner: {
           run: async (request) => {
-            const context = flattenReplyRequestForTest(request);
+            const context = flattenAgentRunRequestForTest(request);
 
             contexts.push(context);
             return completedAgentRun(successReply("follow up reply"));
@@ -574,7 +574,7 @@ describe("local agent runner", () => {
             },
             agentRunner: {
               run: async (request) => {
-                const context = flattenReplyRequestForTest(request);
+                const context = flattenAgentRunRequestForTest(request);
 
                 await persistCompletedSessionForFakeReply(
                   context,
@@ -632,7 +632,7 @@ describe("local agent runner", () => {
     conversation.piMessages = newerMessages;
     await persistThreadStateById(conversationId!, { conversation });
 
-    const contexts: FlatReplyRequestContext[] = [];
+    const contexts: FlatAgentRunRequest[] = [];
     await runLocalAgentTurn(
       {
         conversationId: conversationId!,
@@ -642,7 +642,7 @@ describe("local agent runner", () => {
         deliverReply: async () => undefined,
         agentRunner: {
           run: async (request) => {
-            const context = flattenReplyRequestForTest(request);
+            const context = flattenAgentRunRequestForTest(request);
 
             contexts.push(context);
             return completedAgentRun(successReply("uses newer fallback"));
@@ -666,7 +666,7 @@ describe("local agent runner", () => {
       content: [{ type: "text", text: "undelivered pi output" }],
     } as PiMessage;
     const generateReply = vi.fn<AgentRunner["run"]>(async (request) => {
-      const context = flattenReplyRequestForTest(request);
+      const context = flattenAgentRunRequestForTest(request);
 
       await context.onArtifactStateUpdated?.({
         lastCanvasId: "canvas-undelivered",

--- a/packages/junior/tests/integration/local-chat-cli.test.ts
+++ b/packages/junior/tests/integration/local-chat-cli.test.ts
@@ -2,13 +2,13 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AssistantReply } from "@/chat/respond";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
-const generateAssistantReplyMock = vi.hoisted(() => vi.fn());
+const executeAgentRunMock = vi.hoisted(() => vi.fn());
 
-vi.mock("@/chat/respond", () => ({
-  generateAssistantReply: generateAssistantReplyMock,
+vi.mock("@/chat/agent-run", () => ({
+  executeAgentRun: executeAgentRunMock,
 }));
 
 const ORIGINAL_CWD = process.cwd();
@@ -23,7 +23,7 @@ function restoreEnv(name: string, value: string | undefined): void {
   process.env[name] = value;
 }
 
-function successReply(text: string): AssistantReply {
+function successReply(text: string): AgentRunResult {
   return {
     text,
     diagnostics: {
@@ -41,7 +41,7 @@ function successReply(text: string): AssistantReply {
 describe("local chat CLI integration", () => {
   beforeEach(() => {
     vi.resetModules();
-    generateAssistantReplyMock.mockReset();
+    executeAgentRunMock.mockReset();
   });
 
   afterEach(async () => {
@@ -76,7 +76,7 @@ export const plugins = {
 `,
     );
     process.chdir(tempDir);
-    generateAssistantReplyMock.mockResolvedValue(
+    executeAgentRunMock.mockResolvedValue(
       completedAgentRun(successReply("hello local")),
     );
     const output: string[] = [];
@@ -103,7 +103,7 @@ export const plugins = {
           .getProviders()
           .map((plugin) => plugin.manifest.name),
       ).toContain("local-chat-plugin");
-      expect(generateAssistantReplyMock).toHaveBeenCalledWith(
+      expect(executeAgentRunMock).toHaveBeenCalledWith(
         expect.objectContaining({
           input: expect.objectContaining({ messageText: "hello" }),
           policy: expect.objectContaining({

--- a/packages/junior/tests/integration/mcp-oauth-callback-slack.test.ts
+++ b/packages/junior/tests/integration/mcp-oauth-callback-slack.test.ts
@@ -20,8 +20,8 @@ import {
 } from "../fixtures/plugin-app";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
-const generateAssistantReplyMock = vi.fn();
-const testAgentRunner = { run: generateAssistantReplyMock };
+const executeAgentRunMock = vi.fn();
+const testAgentRunner = { run: executeAgentRunMock };
 
 const ORIGINAL_ENV = { ...process.env };
 const EVAL_MCP_PLUGIN_ROOT = path.resolve(
@@ -152,8 +152,8 @@ async function createAwaitingMcpTurnRecord(args: {
 
 describe("mcp oauth callback slack integration", () => {
   beforeEach(async () => {
-    generateAssistantReplyMock.mockReset();
-    generateAssistantReplyMock.mockResolvedValue(
+    executeAgentRunMock.mockReset();
+    executeAgentRunMock.mockResolvedValue(
       completedAgentRun({
         text: "The budget deadline you mentioned earlier was Friday.",
         artifactStatePatch: {
@@ -367,7 +367,7 @@ describe("mcp oauth callback slack integration", () => {
       refresh_token: "eval-auth-refresh-token",
     });
 
-    expect(generateAssistantReplyMock).toHaveBeenCalledWith(
+    expect(executeAgentRunMock).toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({
           messageText: "what did i say about the budget?",
@@ -399,7 +399,7 @@ describe("mcp oauth callback slack integration", () => {
       }),
     );
 
-    const resumeContext = generateAssistantReplyMock.mock.calls[0]?.[0] as {
+    const resumeContext = executeAgentRunMock.mock.calls[0]?.[0] as {
       input?: { conversationContext?: string };
       policy?: { configuration?: Record<string, unknown> };
       routing?: { source?: unknown };
@@ -523,7 +523,7 @@ describe("mcp oauth callback slack integration", () => {
       });
 
     expect(response.status).toBe(200);
-    expect(generateAssistantReplyMock).not.toHaveBeenCalled();
+    expect(executeAgentRunMock).not.toHaveBeenCalled();
     await expect(
       turnSessionStoreModule.getAgentTurnSessionRecord(threadId, sessionId),
     ).resolves.toMatchObject({
@@ -664,7 +664,7 @@ describe("mcp oauth callback slack integration", () => {
       getSpy.mockRestore();
     }
 
-    expect(generateAssistantReplyMock).toHaveBeenCalledWith(
+    expect(executeAgentRunMock).toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({
           messageText: "what did i say about the budget?",
@@ -678,7 +678,7 @@ describe("mcp oauth callback slack integration", () => {
         }),
       }),
     );
-    const resumeContext = generateAssistantReplyMock.mock.calls[0]?.[0] as {
+    const resumeContext = executeAgentRunMock.mock.calls[0]?.[0] as {
       input?: { conversationContext?: string };
       routing?: { source?: unknown };
     };
@@ -773,7 +773,7 @@ describe("mcp oauth callback slack integration", () => {
       });
 
     expect(response.status).toBe(200);
-    expect(generateAssistantReplyMock).not.toHaveBeenCalled();
+    expect(executeAgentRunMock).not.toHaveBeenCalled();
     expect(getCapturedSlackApiCalls("chat.postMessage")).toHaveLength(0);
 
     const persistedState = await stateAdapterModule
@@ -839,7 +839,7 @@ describe("mcp oauth callback slack integration", () => {
       });
 
     expect(response.status).toBe(200);
-    expect(generateAssistantReplyMock).not.toHaveBeenCalled();
+    expect(executeAgentRunMock).not.toHaveBeenCalled();
     expect(getCapturedSlackApiCalls("chat.postMessage")).toHaveLength(0);
   });
 
@@ -904,7 +904,7 @@ describe("mcp oauth callback slack integration", () => {
       });
 
     expect(response.status).toBe(200);
-    expect(generateAssistantReplyMock).not.toHaveBeenCalled();
+    expect(executeAgentRunMock).not.toHaveBeenCalled();
     expect(getCapturedSlackApiCalls("chat.postMessage")).toHaveLength(0);
     await expect(
       turnSessionStoreModule.getAgentTurnSessionRecord(
@@ -919,7 +919,7 @@ describe("mcp oauth callback slack integration", () => {
   });
 
   it("uploads resumed reply files without posting an extra thread message for empty inline text", async () => {
-    generateAssistantReplyMock.mockResolvedValueOnce(
+    executeAgentRunMock.mockResolvedValueOnce(
       completedAgentRun({
         text: "",
         files: [
@@ -1005,7 +1005,7 @@ describe("mcp oauth callback slack integration", () => {
   });
 
   it("uploads resumed reply files even when thread text delivery is suppressed", async () => {
-    generateAssistantReplyMock.mockResolvedValueOnce(
+    executeAgentRunMock.mockResolvedValueOnce(
       completedAgentRun({
         text: "👍",
         files: [

--- a/packages/junior/tests/integration/oauth-callback-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-callback-slack.test.ts
@@ -11,8 +11,8 @@ import {
 } from "../fixtures/plugin-app";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 
-const generateAssistantReplyMock = vi.fn();
-const testAgentRunner = { run: generateAssistantReplyMock };
+const executeAgentRunMock = vi.fn();
+const testAgentRunner = { run: executeAgentRunMock };
 
 const ORIGINAL_ENV = { ...process.env };
 const EVAL_OAUTH_PLUGIN_ROOT = path.resolve(
@@ -59,8 +59,8 @@ let pluginApp: PluginAppFixture | undefined;
 
 describe("oauth callback slack integration", () => {
   beforeEach(async () => {
-    generateAssistantReplyMock.mockReset();
-    generateAssistantReplyMock.mockResolvedValue(
+    executeAgentRunMock.mockReset();
+    executeAgentRunMock.mockResolvedValue(
       completedAgentRun({
         text: "Here are your Sentry issues.",
         diagnostics: makeDiagnostics(),
@@ -174,7 +174,7 @@ describe("oauth callback slack integration", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(generateAssistantReplyMock).toHaveBeenCalledWith(
+    expect(executeAgentRunMock).toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({
           messageText: "list my sentry issues",
@@ -188,7 +188,7 @@ describe("oauth callback slack integration", () => {
         }),
       }),
     );
-    const resumeContext = generateAssistantReplyMock.mock.calls[0]?.[0] as {
+    const resumeContext = executeAgentRunMock.mock.calls[0]?.[0] as {
       input?: { conversationContext?: string };
     };
     expect(resumeContext.input?.conversationContext).not.toContain(
@@ -364,7 +364,7 @@ describe("oauth callback slack integration", () => {
         }),
       ]),
     );
-    expect(generateAssistantReplyMock).toHaveBeenCalledWith(
+    expect(executeAgentRunMock).toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({
           messageText: "list my sentry issues",
@@ -392,7 +392,7 @@ describe("oauth callback slack integration", () => {
         }),
       }),
     );
-    const resumeContext = generateAssistantReplyMock.mock.calls[0]?.[0] as {
+    const resumeContext = executeAgentRunMock.mock.calls[0]?.[0] as {
       input?: { conversationContext?: string };
       routing?: { source?: unknown };
     };
@@ -526,7 +526,7 @@ describe("oauth callback slack integration", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(generateAssistantReplyMock).not.toHaveBeenCalled();
+    expect(executeAgentRunMock).not.toHaveBeenCalled();
     await expect(
       turnSessionStoreModule.getAgentTurnSessionRecord(
         conversationId,
@@ -680,7 +680,7 @@ describe("oauth callback slack integration", () => {
       getSpy.mockRestore();
     }
 
-    expect(generateAssistantReplyMock).toHaveBeenCalledWith(
+    expect(executeAgentRunMock).toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({
           messageText: "list my sentry issues",
@@ -694,7 +694,7 @@ describe("oauth callback slack integration", () => {
         }),
       }),
     );
-    const resumeContext = generateAssistantReplyMock.mock.calls[0]?.[0] as {
+    const resumeContext = executeAgentRunMock.mock.calls[0]?.[0] as {
       input?: { conversationContext?: string };
     };
     expect(resumeContext.input?.conversationContext).not.toContain(
@@ -819,7 +819,7 @@ describe("oauth callback slack integration", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(generateAssistantReplyMock).toHaveBeenCalledWith(
+    expect(executeAgentRunMock).toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({ messageText: "new request" }),
         routing: expect.objectContaining({
@@ -881,7 +881,7 @@ describe("oauth callback slack integration", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(generateAssistantReplyMock).not.toHaveBeenCalled();
+    expect(executeAgentRunMock).not.toHaveBeenCalled();
     expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([]);
   });
 });

--- a/packages/junior/tests/integration/plugin-prompt-hooks.test.ts
+++ b/packages/junior/tests/integration/plugin-prompt-hooks.test.ts
@@ -101,7 +101,7 @@ vi.mock("@/chat/pi/client", () => ({
 }));
 
 import { defineJuniorPlugin } from "@sentry/junior-plugin-api";
-import { generateAssistantReply } from "@/chat/respond";
+import { executeAgentRun } from "@/chat/agent-run";
 import { setPlugins } from "@/chat/plugins/agent-hooks";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
 import { upsertAgentTurnSessionRecord } from "@/chat/state/turn-session";
@@ -158,7 +158,7 @@ describe("plugin prompt hooks", () => {
   });
 
   it("renders prompt messages from plugin hooks", async () => {
-    await generateAssistantReply({
+    await executeAgentRun({
       input: { messageText: "hello" },
       routing: {
         destination: LOCAL_DESTINATION,
@@ -177,7 +177,7 @@ describe("plugin prompt hooks", () => {
   });
 
   it("runs user prompt hooks for non-bootstrap follow-up prompts", async () => {
-    await generateAssistantReply({
+    await executeAgentRun({
       input: { messageText: "hello" },
       routing: {
         destination: LOCAL_DESTINATION,
@@ -191,7 +191,7 @@ describe("plugin prompt hooks", () => {
     const firstPromptMessage = captured.promptMessages[0];
     captured.promptMessages = [];
 
-    await generateAssistantReply({
+    await executeAgentRun({
       input: {
         messageText: "again",
         piMessages: [
@@ -220,7 +220,7 @@ describe("plugin prompt hooks", () => {
   });
 
   it("does not run user prompt hooks for steering messages", async () => {
-    await generateAssistantReply({
+    await executeAgentRun({
       input: { messageText: "hello" },
       routing: {
         destination: LOCAL_DESTINATION,
@@ -258,7 +258,7 @@ describe("plugin prompt hooks", () => {
       errorMessage: "authorization required",
     });
 
-    await generateAssistantReply({
+    await executeAgentRun({
       input: { messageText: "resume me" },
       routing: {
         destination: LOCAL_DESTINATION,
@@ -294,7 +294,7 @@ describe("plugin prompt hooks", () => {
       errorMessage: "timed out",
     });
 
-    await generateAssistantReply({
+    await executeAgentRun({
       input: { messageText: "resume me" },
       routing: {
         destination: LOCAL_DESTINATION,

--- a/packages/junior/tests/integration/slack/assistant-context-canvas-routing.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-context-canvas-routing.test.ts
@@ -16,7 +16,7 @@ import {
   getCapturedSlackApiCalls,
   queueSlackApiResponse,
 } from "../../msw/handlers/slack-api";
-import { flattenReplyRequestForTest } from "../../fixtures/agent-runner";
+import { flattenAgentRunRequestForTest } from "../../fixtures/agent-runner";
 
 describe("Slack behavior: assistant context canvas routing", () => {
   beforeEach(() => {
@@ -47,7 +47,7 @@ describe("Slack behavior: assistant context canvas routing", () => {
             run: async (request) => {
               const _prompt = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               await createCanvas({

--- a/packages/junior/tests/integration/slack/assistant-context-channel-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-context-channel-behavior.test.ts
@@ -6,7 +6,7 @@ import {
   createTestThread,
   createTestDestination,
 } from "../../fixtures/slack-harness";
-import { flattenReplyRequestForTest } from "../../fixtures/agent-runner";
+import { flattenAgentRunRequestForTest } from "../../fixtures/agent-runner";
 
 describe("Slack behavior: assistant context channel routing", () => {
   it("prefers assistantContextChannelId over DM channel for tool execution context", async () => {
@@ -19,7 +19,7 @@ describe("Slack behavior: assistant context channel routing", () => {
             run: async (request) => {
               const _prompt = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               capturedToolChannelIds.push(context?.toolChannelId);

--- a/packages/junior/tests/integration/slack/assistant-thread-contract.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-thread-contract.test.ts
@@ -14,7 +14,7 @@ import { createJuniorSlackAdapter } from "@/chat/slack/adapter";
 import type { ConversationMemoryDeps } from "@/chat/services/conversation-memory";
 import { handleChatSdkPlatformWebhook } from "@/handlers/webhooks";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
-import { flattenReplyRequestForTest } from "../../fixtures/agent-runner";
+import { flattenAgentRunRequestForTest } from "../../fixtures/agent-runner";
 
 const SIGNING_SECRET = "test-signing-secret";
 const BOT_USER_ID = "U_BOT";
@@ -161,7 +161,7 @@ describe("Slack contract: assistant-thread delivery", () => {
         run: async (request) => {
           const _prompt = request.input.messageText;
           const context = {
-            ...flattenReplyRequestForTest(request),
+            ...flattenAgentRunRequestForTest(request),
           };
 
           await context?.onStatus?.(makeAssistantStatus("running", "bash"));
@@ -190,7 +190,7 @@ describe("Slack contract: assistant-thread delivery", () => {
         run: async (request) => {
           const _prompt = request.input.messageText;
           const context = {
-            ...flattenReplyRequestForTest(request),
+            ...flattenAgentRunRequestForTest(request),
           };
 
           await context?.onStatus?.(makeAssistantStatus("running", "bash"));
@@ -238,7 +238,7 @@ describe("Slack contract: assistant-thread delivery", () => {
         run: async (request) => {
           const _prompt = request.input.messageText;
           const context = {
-            ...flattenReplyRequestForTest(request),
+            ...flattenAgentRunRequestForTest(request),
           };
 
           await context?.onStatus?.(makeAssistantStatus("running", "bash"));

--- a/packages/junior/tests/integration/slack/attachment-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/attachment-behavior.test.ts
@@ -6,7 +6,7 @@ import {
   createTestDestination,
 } from "../../fixtures/slack-harness";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
-import { flattenReplyRequestForTest } from "../../fixtures/agent-runner";
+import { flattenAgentRunRequestForTest } from "../../fixtures/agent-runner";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -66,7 +66,7 @@ describe("Slack behavior: attachment handling", () => {
             run: async (request) => {
               const _prompt = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               const attachments = context?.userAttachments ?? [];
@@ -128,7 +128,7 @@ describe("Slack behavior: attachment handling", () => {
     const completeTextMock = vi.fn(async () => {
       throw new Error("vision unavailable");
     });
-    const generateAssistantReply = vi.fn(async () =>
+    const executeAgentRun = vi.fn(async () =>
       completedAgentRun({
         text: "should not post",
         diagnostics: {
@@ -149,7 +149,7 @@ describe("Slack behavior: attachment handling", () => {
           completeText: completeTextMock,
         },
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
         },
       },
     });
@@ -178,7 +178,7 @@ describe("Slack behavior: attachment handling", () => {
 
     expect(attachmentFetch).toHaveBeenCalledTimes(1);
     expect(completeTextMock).toHaveBeenCalledTimes(1);
-    expect(generateAssistantReply).not.toHaveBeenCalled();
+    expect(executeAgentRun).not.toHaveBeenCalled();
     expect(thread.posts).toHaveLength(1);
     expect(toPostedText(thread.posts[0])).toContain(
       "I ran into an internal error while processing that.",

--- a/packages/junior/tests/integration/slack/attachment-media-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/attachment-media-behavior.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../../fixtures/slack-harness";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
-import { flattenReplyRequestForTest } from "../../fixtures/agent-runner";
+import { flattenAgentRunRequestForTest } from "../../fixtures/agent-runner";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -75,7 +75,7 @@ describe("Slack behavior: mixed attachment media", () => {
               run: async (request) => {
                 const _prompt = request.input.messageText;
                 const context = {
-                  ...flattenReplyRequestForTest(request),
+                  ...flattenAgentRunRequestForTest(request),
                 };
 
                 const attachments = context?.userAttachments ?? [];
@@ -176,7 +176,7 @@ describe("Slack behavior: mixed attachment media", () => {
             run: async (request) => {
               const _prompt = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               const attachments = context?.userAttachments ?? [];
@@ -244,22 +244,20 @@ describe("Slack behavior: mixed attachment media", () => {
   it("still runs the assistant when only images are attached and vision is disabled", async () => {
     const imageFetch = vi.fn(async () => Buffer.from("image-bytes"));
     const capturedOmittedImageCounts: number[] = [];
-    const generateAssistantReply = vi.fn<AgentRunner["run"]>(
-      async (_request) => {
-        return completedAgentRun({
-          text: "I can’t inspect the attached image in this runtime, but I do see that an image was included.",
-          diagnostics: {
-            assistantMessageCount: 1,
-            modelId: "fake-agent-model",
-            outcome: "success" as const,
-            toolCalls: [],
-            toolErrorCount: 0,
-            toolResultCount: 0,
-            usedPrimaryText: true,
-          },
-        });
-      },
-    );
+    const executeAgentRun = vi.fn<AgentRunner["run"]>(async (_request) => {
+      return completedAgentRun({
+        text: "I can’t inspect the attached image in this runtime, but I do see that an image was included.",
+        diagnostics: {
+          assistantMessageCount: 1,
+          modelId: "fake-agent-model",
+          outcome: "success" as const,
+          toolCalls: [],
+          toolErrorCount: 0,
+          toolResultCount: 0,
+          usedPrimaryText: true,
+        },
+      });
+    });
 
     const { slackRuntime } = await createRuntime({
       services: {
@@ -267,13 +265,13 @@ describe("Slack behavior: mixed attachment media", () => {
           agentRunner: {
             run: async (request) => {
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               capturedOmittedImageCounts.push(
                 context?.omittedImageAttachmentCount ?? 0,
               );
-              return generateAssistantReply(request);
+              return executeAgentRun(request);
             },
           },
         },
@@ -303,7 +301,7 @@ describe("Slack behavior: mixed attachment media", () => {
     });
 
     expect(imageFetch).not.toHaveBeenCalled();
-    expect(generateAssistantReply).toHaveBeenCalledTimes(1);
+    expect(executeAgentRun).toHaveBeenCalledTimes(1);
     expect(capturedOmittedImageCounts).toEqual([1]);
     expect(thread.posts).toHaveLength(1);
     expect(toPostedText(thread.posts[0])).toContain(

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -22,7 +22,7 @@ import {
   createTestDestination,
 } from "../../fixtures/slack-harness";
 import { createTestChatRuntime } from "../../fixtures/chat-runtime";
-import { flattenReplyRequestForTest } from "../../fixtures/agent-runner";
+import { flattenAgentRunRequestForTest } from "../../fixtures/agent-runner";
 
 const emptyThreadReplies = async () => [];
 
@@ -171,7 +171,7 @@ describe("bot handlers (integration)", () => {
     await disconnectStateAdapter();
   });
 
-  it("handleNewMention: posts reply from generateAssistantReply", async () => {
+  it("handleNewMention: posts reply from executeAgentRun", async () => {
     const scheduleSessionCompletedPluginTasks = vi.fn(async () => undefined);
     const { slackRuntime } = createTestChatRuntime({
       services: {
@@ -235,11 +235,11 @@ describe("bot handlers (integration)", () => {
 
   it("does not replay a message that already has a delivered reply", async () => {
     const conversationId = "slack:C_REPLAY:1700000000.000";
-    const generateAssistantReply = vi.fn();
+    const executeAgentRun = vi.fn();
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
         },
       },
     });
@@ -309,7 +309,7 @@ describe("bot handlers (integration)", () => {
       ),
     ).resolves.toBeUndefined();
 
-    expect(generateAssistantReply).not.toHaveBeenCalled();
+    expect(executeAgentRun).not.toHaveBeenCalled();
     expect(thread.posts).toEqual([]);
   });
 
@@ -398,7 +398,7 @@ describe("bot handlers (integration)", () => {
       { destination: createTestDestination(thread) },
     );
 
-    // Should not have posted a reply (no generateAssistantReply call)
+    // Should not have posted a reply (no executeAgentRun call)
     const hasReply = thread.posts.some((p) => {
       if (typeof p === "string") return !p.startsWith("Error:");
       if (
@@ -442,7 +442,7 @@ describe("bot handlers (integration)", () => {
     expect(fakeAdapter.promptCalls[0].prompts.length).toBe(3);
   });
 
-  it("error recovery: posts safe error message when generateAssistantReply throws", async () => {
+  it("error recovery: posts safe error message when executeAgentRun throws", async () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
@@ -490,7 +490,7 @@ describe("bot handlers (integration)", () => {
         replyExecutor: {
           agentRunner: {
             run: async () => {
-              // Simulate respond's durable input checkpoint: the session record
+              // Simulate agent-run durable input checkpoint: the session record
               // is running at the prompt boundary when generation finishes.
               await upsertAgentTurnSessionRecord({
                 conversationId,
@@ -695,7 +695,7 @@ describe("bot handlers (integration)", () => {
             run: async (request) => {
               const _prompt = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               capturedCorrelation.push({
@@ -1062,13 +1062,13 @@ describe("bot handlers (integration)", () => {
       sessionId: activeSessionId,
       expectedVersion: 4,
     });
-    const generateAssistantReply = vi.fn();
+    const executeAgentRun = vi.fn();
     const ack = vi.fn();
     const onTurnStatePersisted = vi.fn();
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
           getAwaitingAgentContinueRequest,
           scheduleAgentContinue,
         },
@@ -1107,7 +1107,7 @@ describe("bot handlers (integration)", () => {
       sessionId: activeSessionId,
       expectedVersion: 4,
     });
-    expect(generateAssistantReply).not.toHaveBeenCalled();
+    expect(executeAgentRun).not.toHaveBeenCalled();
     expect(onTurnStatePersisted).toHaveBeenCalledOnce();
     expect(ack).toHaveBeenCalledOnce();
     expect(thread.posts).toEqual([]);
@@ -1136,7 +1136,7 @@ describe("bot handlers (integration)", () => {
   it("answers a follow-up as a fresh turn when the active session is auth-parked", async () => {
     const conversationId = "slack:C_AUTH_PARKED:1700000000.000";
     const activeSessionId = "turn_msg-auth-original";
-    const generateAssistantReply = vi.fn().mockResolvedValue(
+    const executeAgentRun = vi.fn().mockResolvedValue(
       completedAgentRun({
         text: "Fresh answer without the provider.",
         diagnostics: {
@@ -1161,7 +1161,7 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
         },
       },
     });
@@ -1184,10 +1184,10 @@ describe("bot handlers (integration)", () => {
 
     // The follow-up supersedes the pause: it must be answered, not consumed
     // into a resume that only happens if the user ever authorizes.
-    expect(generateAssistantReply).toHaveBeenCalledOnce();
-    expect(
-      generateAssistantReply.mock.calls[0]?.[0].input.messageText,
-    ).toContain("any update?");
+    expect(executeAgentRun).toHaveBeenCalledOnce();
+    expect(executeAgentRun.mock.calls[0]?.[0].input.messageText).toContain(
+      "any update?",
+    );
     expect(postIncludes(thread, "Fresh answer without the provider.")).toBe(
       true,
     );
@@ -1228,12 +1228,12 @@ describe("bot handlers (integration)", () => {
         JSON.stringify(await loadProjection({ conversationId })),
       );
     });
-    const generateAssistantReply = vi.fn();
+    const executeAgentRun = vi.fn();
     const ack = vi.fn();
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
           scheduleAgentContinue,
         },
       },
@@ -1255,7 +1255,7 @@ describe("bot handlers (integration)", () => {
       ack,
     });
 
-    expect(generateAssistantReply).not.toHaveBeenCalled();
+    expect(executeAgentRun).not.toHaveBeenCalled();
     expect(thread.posts).toEqual([]);
     expect(ack).toHaveBeenCalledOnce();
     expect(scheduleAgentContinue).toHaveBeenCalledWith({
@@ -1454,7 +1454,7 @@ describe("bot handlers (integration)", () => {
             run: async (request) => {
               const _input = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               await context.onInputCommitted?.();
@@ -1533,7 +1533,7 @@ describe("bot handlers (integration)", () => {
   it("fails malformed awaiting continuations before handling the follow-up", async () => {
     const conversationId = "slack:C_BAD_CONTINUATION:1700000000.000";
     const activeSessionId = "turn_msg-timeout-original";
-    const generateAssistantReply = vi.fn().mockResolvedValue(
+    const executeAgentRun = vi.fn().mockResolvedValue(
       completedAgentRun({
         text: "Recovered.",
         diagnostics: {
@@ -1558,7 +1558,7 @@ describe("bot handlers (integration)", () => {
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
         },
       },
     });
@@ -1579,7 +1579,7 @@ describe("bot handlers (integration)", () => {
       { destination: createTestDestination(thread) },
     );
 
-    expect(generateAssistantReply).toHaveBeenCalledOnce();
+    expect(executeAgentRun).toHaveBeenCalledOnce();
     expect(postIncludes(thread, "Recovered.")).toBe(true);
     const failedRecord = await getAgentTurnSessionRecord(
       conversationId,
@@ -1609,11 +1609,11 @@ describe("bot handlers (integration)", () => {
       sessionId: activeSessionId,
       expectedVersion: 4,
     });
-    const generateAssistantReply = vi.fn();
+    const executeAgentRun = vi.fn();
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
           getAwaitingAgentContinueRequest,
           scheduleAgentContinue,
         },
@@ -1645,7 +1645,7 @@ describe("bot handlers (integration)", () => {
       sessionId: activeSessionId,
       expectedVersion: 4,
     });
-    expect(generateAssistantReply).not.toHaveBeenCalled();
+    expect(executeAgentRun).not.toHaveBeenCalled();
   });
 
   it("does not reschedule an awaiting continuation for an already-replied duplicate", async () => {
@@ -1659,12 +1659,12 @@ describe("bot handlers (integration)", () => {
       sessionId: activeSessionId,
       expectedVersion: 4,
     });
-    const generateAssistantReply = vi.fn();
+    const executeAgentRun = vi.fn();
     const onTurnStatePersisted = vi.fn();
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
           getAwaitingAgentContinueRequest,
           scheduleAgentContinue,
         },
@@ -1696,7 +1696,7 @@ describe("bot handlers (integration)", () => {
 
     expect(getAwaitingAgentContinueRequest).not.toHaveBeenCalled();
     expect(scheduleAgentContinue).not.toHaveBeenCalled();
-    expect(generateAssistantReply).not.toHaveBeenCalled();
+    expect(executeAgentRun).not.toHaveBeenCalled();
     expect(onTurnStatePersisted).toHaveBeenCalledOnce();
     expect(thread.posts).toEqual([]);
   });
@@ -1712,11 +1712,11 @@ describe("bot handlers (integration)", () => {
       sessionId: activeSessionId,
       expectedVersion: 4,
     });
-    const generateAssistantReply = vi.fn();
+    const executeAgentRun = vi.fn();
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
           getAwaitingAgentContinueRequest,
           scheduleAgentContinue,
         },
@@ -1745,7 +1745,7 @@ describe("bot handlers (integration)", () => {
       sessionId: activeSessionId,
       expectedVersion: 4,
     });
-    expect(generateAssistantReply).not.toHaveBeenCalled();
+    expect(executeAgentRun).not.toHaveBeenCalled();
     expect(thread.posts).toEqual([]);
 
     const state = thread.getState();
@@ -1772,11 +1772,11 @@ describe("bot handlers (integration)", () => {
       sessionId: activeSessionId,
       expectedVersion: 4,
     });
-    const generateAssistantReply = vi.fn();
+    const executeAgentRun = vi.fn();
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
           getAwaitingAgentContinueRequest,
           scheduleAgentContinue,
         },
@@ -1799,7 +1799,7 @@ describe("bot handlers (integration)", () => {
       { destination },
     );
 
-    expect(generateAssistantReply).not.toHaveBeenCalled();
+    expect(executeAgentRun).not.toHaveBeenCalled();
     expect(thread.posts).toEqual([
       expect.stringContaining(
         "I ran into an internal error while processing that.",
@@ -1815,7 +1815,7 @@ describe("bot handlers (integration)", () => {
             run: async (request) => {
               const _prompt = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               await context?.onTextDelta?.("Partial output...");
@@ -1872,7 +1872,7 @@ describe("bot handlers (integration)", () => {
             run: async (request) => {
               const _prompt = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               await context?.onStatus?.(
@@ -2366,7 +2366,7 @@ describe("bot handlers (integration)", () => {
             run: async (request) => {
               const _text = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               await vi.waitFor(() => {
@@ -2629,7 +2629,7 @@ describe("bot handlers (integration)", () => {
             run: async (request) => {
               const _prompt = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               capturedContexts.push(context?.conversationContext);
@@ -2677,7 +2677,7 @@ describe("bot handlers (integration)", () => {
             run: async (request) => {
               const _prompt = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               capturedContexts.push(context?.conversationContext);
@@ -2754,7 +2754,7 @@ describe("bot handlers (integration)", () => {
             run: async (request) => {
               const _prompt = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               capturedContexts.push(context?.conversationContext);

--- a/packages/junior/tests/integration/slack/bot-image-hydration.test.ts
+++ b/packages/junior/tests/integration/slack/bot-image-hydration.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../../fixtures/slack-harness";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
-import { flattenReplyRequestForTest } from "../../fixtures/agent-runner";
+import { flattenAgentRunRequestForTest } from "../../fixtures/agent-runner";
 
 const listThreadRepliesMock = vi.fn();
 const ORIGINAL_ENV = { ...process.env };
@@ -453,15 +453,13 @@ describe("bot image hydration", () => {
       text: "Passive screenshot summary",
       message: {} as never,
     }));
-    const generateAssistantReply = vi.fn<AgentRunner["run"]>(
-      async (request) => {
-        const context = flattenReplyRequestForTest(request);
-        expect(context?.conversationContext).toContain(
-          "Passive screenshot summary",
-        );
-        return makeSuccessOutcome();
-      },
-    );
+    const executeAgentRun = vi.fn<AgentRunner["run"]>(async (request) => {
+      const context = flattenAgentRunRequestForTest(request);
+      expect(context?.conversationContext).toContain(
+        "Passive screenshot summary",
+      );
+      return makeSuccessOutcome();
+    });
 
     const { slackRuntime } = await createRuntime(
       {
@@ -479,7 +477,7 @@ describe("bot image hydration", () => {
             completeText: completeTextMock,
           },
           replyExecutor: {
-            agentRunner: { run: generateAssistantReply },
+            agentRunner: { run: executeAgentRun },
           },
         },
       },
@@ -538,7 +536,7 @@ describe("bot image hydration", () => {
       { destination: createTestDestination(thread) },
     );
 
-    expect(generateAssistantReply).not.toHaveBeenCalled();
+    expect(executeAgentRun).not.toHaveBeenCalled();
     expect(listThreadRepliesMock).not.toHaveBeenCalled();
 
     await slackRuntime.handleNewMention(
@@ -562,7 +560,7 @@ describe("bot image hydration", () => {
     expect(listThreadRepliesMock).toHaveBeenCalledTimes(1);
     expect(downloadFileMock).toHaveBeenCalledTimes(1);
     expect(completeTextMock).toHaveBeenCalledTimes(1);
-    expect(generateAssistantReply).toHaveBeenCalledTimes(1);
+    expect(executeAgentRun).toHaveBeenCalledTimes(1);
 
     const persistedState = thread.getState() as {
       conversation: {
@@ -612,19 +610,17 @@ describe("bot image hydration", () => {
       message: {} as never,
     }));
     const attachmentFetch = vi.fn(async () => Buffer.from("attachment-image"));
-    const generateAssistantReply = vi.fn<AgentRunner["run"]>(
-      async (request) => {
-        const context = flattenReplyRequestForTest(request);
-        expect(context?.userAttachments).toEqual([
-          expect.objectContaining({
-            mediaType: "image/png",
-            filename: "screen.png",
-            promptText: expect.stringContaining("Current screenshot summary"),
-          }),
-        ]);
-        return makeSuccessOutcome();
-      },
-    );
+    const executeAgentRun = vi.fn<AgentRunner["run"]>(async (request) => {
+      const context = flattenAgentRunRequestForTest(request);
+      expect(context?.userAttachments).toEqual([
+        expect.objectContaining({
+          mediaType: "image/png",
+          filename: "screen.png",
+          promptText: expect.stringContaining("Current screenshot summary"),
+        }),
+      ]);
+      return makeSuccessOutcome();
+    });
 
     const { slackRuntime } = await createRuntime(
       {
@@ -635,7 +631,7 @@ describe("bot image hydration", () => {
             completeText: completeTextMock,
           },
           replyExecutor: {
-            agentRunner: { run: generateAssistantReply },
+            agentRunner: { run: executeAgentRun },
           },
         },
       },
@@ -723,7 +719,7 @@ describe("bot image hydration", () => {
     expect(downloadFileMock).toHaveBeenCalledTimes(1);
     expect(completeTextMock).toHaveBeenCalledTimes(1);
     expect(attachmentFetch).not.toHaveBeenCalled();
-    expect(generateAssistantReply).toHaveBeenCalledTimes(1);
+    expect(executeAgentRun).toHaveBeenCalledTimes(1);
   });
 
   it("keeps cached image summaries aligned with attachment positions", async () => {
@@ -769,22 +765,20 @@ describe("bot image hydration", () => {
     const secondAttachmentFetch = vi.fn(async () =>
       Buffer.from("second-image"),
     );
-    const generateAssistantReply = vi.fn<AgentRunner["run"]>(
-      async (request) => {
-        const context = flattenReplyRequestForTest(request);
-        expect(context?.userAttachments).toEqual([
-          expect.objectContaining({
-            filename: "first.png",
-            promptText: expect.stringContaining("First attachment summary"),
-          }),
-          expect.objectContaining({
-            filename: "second.png",
-            promptText: expect.stringContaining("Second cached summary"),
-          }),
-        ]);
-        return makeSuccessOutcome();
-      },
-    );
+    const executeAgentRun = vi.fn<AgentRunner["run"]>(async (request) => {
+      const context = flattenAgentRunRequestForTest(request);
+      expect(context?.userAttachments).toEqual([
+        expect.objectContaining({
+          filename: "first.png",
+          promptText: expect.stringContaining("First attachment summary"),
+        }),
+        expect.objectContaining({
+          filename: "second.png",
+          promptText: expect.stringContaining("Second cached summary"),
+        }),
+      ]);
+      return makeSuccessOutcome();
+    });
 
     const { slackRuntime } = await createRuntime(
       {
@@ -795,7 +789,7 @@ describe("bot image hydration", () => {
             completeText: completeTextMock,
           },
           replyExecutor: {
-            agentRunner: { run: generateAssistantReply },
+            agentRunner: { run: executeAgentRun },
           },
         },
       },
@@ -890,7 +884,7 @@ describe("bot image hydration", () => {
     expect(completeTextMock).toHaveBeenCalledTimes(3);
     expect(firstAttachmentFetch).toHaveBeenCalledTimes(1);
     expect(secondAttachmentFetch).not.toHaveBeenCalled();
-    expect(generateAssistantReply).toHaveBeenCalledTimes(1);
+    expect(executeAgentRun).toHaveBeenCalledTimes(1);
   });
 
   it("truncates inline image summaries to the cached summary limit", async () => {
@@ -900,16 +894,14 @@ describe("bot image hydration", () => {
       text: longSummary,
       message: {} as never,
     }));
-    const generateAssistantReply = vi.fn<AgentRunner["run"]>(
-      async (request) => {
-        const context = flattenReplyRequestForTest(request);
-        const promptText = context?.userAttachments?.[0]?.promptText;
-        const summary = extractImageAttachmentSummary(promptText);
-        expect(summary).toBe(longSummary.slice(0, 500));
-        expect(summary).toHaveLength(500);
-        return makeSuccessOutcome();
-      },
-    );
+    const executeAgentRun = vi.fn<AgentRunner["run"]>(async (request) => {
+      const context = flattenAgentRunRequestForTest(request);
+      const promptText = context?.userAttachments?.[0]?.promptText;
+      const summary = extractImageAttachmentSummary(promptText);
+      expect(summary).toBe(longSummary.slice(0, 500));
+      expect(summary).toHaveLength(500);
+      return makeSuccessOutcome();
+    });
 
     const { slackRuntime } = await createRuntime(
       {
@@ -919,7 +911,7 @@ describe("bot image hydration", () => {
             completeText: completeTextMock,
           },
           replyExecutor: {
-            agentRunner: { run: generateAssistantReply },
+            agentRunner: { run: executeAgentRun },
           },
         },
       },
@@ -1005,7 +997,7 @@ describe("bot image hydration", () => {
     );
 
     expect(completeTextMock).toHaveBeenCalledTimes(1);
-    expect(generateAssistantReply).toHaveBeenCalledTimes(1);
+    expect(executeAgentRun).toHaveBeenCalledTimes(1);
   });
 
   it("includes generated files in thread.post via SDK file upload", async () => {
@@ -1083,7 +1075,7 @@ describe("bot image hydration", () => {
             run: async (request) => {
               const _text = request.input.messageText;
               const _context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               return completedAgentRun({

--- a/packages/junior/tests/integration/slack/canvas-failure-recovery-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/canvas-failure-recovery-behavior.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { ReplyRequestContext } from "@/chat/respond";
+import type { AgentRunRequest } from "@/chat/agent-run";
 import { createTestChatRuntime } from "../../fixtures/chat-runtime";
 import {
   createTestMessage,
@@ -22,27 +22,25 @@ function toPostedText(value: unknown): string {
 
 describe("Slack behavior: canvas failure recovery", () => {
   it("points to a created canvas when reply generation fails before final text", async () => {
-    const generateAssistantReply = vi.fn(
-      async (request: ReplyRequestContext) => {
-        await request.durability?.onArtifactStateUpdated?.({
-          lastCanvasId: "F_CANVAS",
-          lastCanvasUrl: "https://slack.example/docs/T/F_CANVAS",
-          recentCanvases: [
-            {
-              id: "F_CANVAS",
-              title: "Research reference",
-              url: "https://slack.example/docs/T/F_CANVAS",
-              createdAt: "2026-05-20T20:00:00.000Z",
-            },
-          ],
-        });
-        throw new Error("forced failure after canvas");
-      },
-    );
+    const executeAgentRun = vi.fn(async (request: AgentRunRequest) => {
+      await request.durability?.onArtifactStateUpdated?.({
+        lastCanvasId: "F_CANVAS",
+        lastCanvasUrl: "https://slack.example/docs/T/F_CANVAS",
+        recentCanvases: [
+          {
+            id: "F_CANVAS",
+            title: "Research reference",
+            url: "https://slack.example/docs/T/F_CANVAS",
+            createdAt: "2026-05-20T20:00:00.000Z",
+          },
+        ],
+      });
+      throw new Error("forced failure after canvas");
+    });
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
         },
       },
     });
@@ -74,13 +72,13 @@ describe("Slack behavior: canvas failure recovery", () => {
   });
 
   it("does not recover with a canvas from a prior turn", async () => {
-    const generateAssistantReply = vi.fn(async () => {
+    const executeAgentRun = vi.fn(async () => {
       throw new Error("forced unrelated failure");
     });
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
         },
       },
     });

--- a/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
@@ -14,7 +14,7 @@ import { resetSlackApiMockState } from "../../msw/handlers/slack-api";
 import { createSlackRuntime } from "@/chat/app/factory";
 import type { JuniorRuntimeServiceOverrides } from "@/chat/app/services";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
-import type { ReplySteeringMessage } from "@/chat/respond";
+import type { AgentRunSteeringMessage } from "@/chat/agent-run";
 import { createJuniorSlackAdapter } from "@/chat/slack/adapter";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
@@ -26,7 +26,7 @@ import {
 } from "@/chat/task-execution/store";
 import { processConversationQueueMessage } from "@/chat/task-execution/vercel-callback";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
-import { flattenReplyRequestForTest } from "../../fixtures/agent-runner";
+import { flattenAgentRunRequestForTest } from "../../fixtures/agent-runner";
 
 const CHANNEL_ID = "CSTEER";
 const THREAD_TS = "1712345.000100";
@@ -248,7 +248,7 @@ describe("Slack behavior: durable turn steering", () => {
       steeringTexts: string[];
     }> = [];
     const state = getStateAdapter();
-    const generateAssistantReply: AgentRunner["run"] = async (request) => {
+    const executeAgentRun: AgentRunner["run"] = async (request) => {
       const prompt = request.input.messageText;
       await request.durability?.onInputCommitted?.();
       if (!blockingCallReleased) {
@@ -257,7 +257,7 @@ describe("Slack behavior: durable turn steering", () => {
         blockingCallReleased = true;
       }
 
-      const steeringMessages: ReplySteeringMessage[] = [];
+      const steeringMessages: AgentRunSteeringMessage[] = [];
       const drained = await request.durability?.drainSteeringMessages?.(
         async (messages) => {
           steeringMessages.push(...messages);
@@ -294,7 +294,7 @@ describe("Slack behavior: durable turn steering", () => {
                 reason: "active steering follow-up",
               },
         ),
-        agentRunner: { run: generateAssistantReply },
+        agentRunner: { run: executeAgentRun },
         state,
       });
 
@@ -451,7 +451,7 @@ describe("Slack behavior: durable turn steering", () => {
           run: async (request) => {
             const prompt = request.input.messageText;
             const context = {
-              ...flattenReplyRequestForTest(request),
+              ...flattenAgentRunRequestForTest(request),
             };
 
             replyCalls.push(prompt);
@@ -514,7 +514,7 @@ describe("Slack behavior: durable turn steering", () => {
     const releaseAgent = deferred();
     const drainedTexts: string[] = [];
     const state = getStateAdapter();
-    const generateAssistantReply: AgentRunner["run"] = async (request) => {
+    const executeAgentRun: AgentRunner["run"] = async (request) => {
       await request.durability?.onInputCommitted?.();
       agentEntered.resolve();
       await releaseAgent.promise;
@@ -547,7 +547,7 @@ describe("Slack behavior: durable turn steering", () => {
               reason: "active steering follow-up",
             },
       ),
-      agentRunner: { run: generateAssistantReply },
+      agentRunner: { run: executeAgentRun },
       state,
     });
 
@@ -635,7 +635,7 @@ describe("Slack behavior: durable turn steering", () => {
 
   it("keeps the mailbox pending when the agent fails before input commit", async () => {
     const state = getStateAdapter();
-    const generateAssistantReply: AgentRunner["run"] = async (request) => {
+    const executeAgentRun: AgentRunner["run"] = async (request) => {
       expect(request.durability?.onInputCommitted).toEqual(
         expect.any(Function),
       );
@@ -643,7 +643,7 @@ describe("Slack behavior: durable turn steering", () => {
     };
     const { conversationId, queue, runNextQueuedWork, services } =
       createTurnHarness({
-        agentRunner: { run: generateAssistantReply },
+        agentRunner: { run: executeAgentRun },
         state,
       });
 

--- a/packages/junior/tests/integration/slack/file-delivery-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/file-delivery-behavior.test.ts
@@ -6,7 +6,7 @@ import {
   createTestThread,
   createTestDestination,
 } from "../../fixtures/slack-harness";
-import { flattenReplyRequestForTest } from "../../fixtures/agent-runner";
+import { flattenAgentRunRequestForTest } from "../../fixtures/agent-runner";
 
 function toPostedText(value: unknown): string {
   if (typeof value === "string") {
@@ -32,7 +32,7 @@ describe("Slack behavior: file delivery", () => {
             run: async (request) => {
               const _prompt = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               await context?.onTextDelta?.("Preview is ready.");

--- a/packages/junior/tests/integration/slack/finalized-reply-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/finalized-reply-behavior.test.ts
@@ -12,7 +12,7 @@ import {
   createTestDestination,
 } from "../../fixtures/slack-harness";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
-import { flattenReplyRequestForTest } from "../../fixtures/agent-runner";
+import { flattenAgentRunRequestForTest } from "../../fixtures/agent-runner";
 
 function toPostedText(value: unknown): string {
   if (typeof value === "string") {
@@ -75,7 +75,7 @@ describe("Slack behavior: finalized thread replies", () => {
             run: async (request) => {
               const _prompt = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               await context?.onTextDelta?.("Hello ");
@@ -116,7 +116,7 @@ describe("Slack behavior: finalized thread replies", () => {
             run: async (request) => {
               const _prompt = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               await context?.onTextDelta?.("Fetching sources now...");

--- a/packages/junior/tests/integration/slack/message-changed-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/message-changed-behavior.test.ts
@@ -16,7 +16,7 @@ import { JuniorChat } from "@/chat/ingress/junior-chat";
 import { createJuniorSlackAdapter } from "@/chat/slack/adapter";
 import { handleChatSdkPlatformWebhook } from "@/handlers/webhooks";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
-import { flattenReplyRequestForTest } from "../../fixtures/agent-runner";
+import { flattenAgentRunRequestForTest } from "../../fixtures/agent-runner";
 
 const SIGNING_SECRET = "test-signing-secret";
 const BOT_USER_ID = "U_BOT";
@@ -268,7 +268,7 @@ describe("Slack behavior: message_changed webhook ingress", () => {
             run: async (request) => {
               const _prompt = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               expect(context?.requester).toEqual({

--- a/packages/junior/tests/integration/slack/message-changed-reply-contract.test.ts
+++ b/packages/junior/tests/integration/slack/message-changed-reply-contract.test.ts
@@ -11,7 +11,7 @@ import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { createJuniorSlackAdapter } from "@/chat/slack/adapter";
 import { handleChatSdkPlatformWebhook } from "@/handlers/webhooks";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
-import { flattenReplyRequestForTest } from "../../fixtures/agent-runner";
+import { flattenAgentRunRequestForTest } from "../../fixtures/agent-runner";
 
 const SIGNING_SECRET = "test-signing-secret";
 const BOT_USER_ID = "U_BOT";
@@ -103,7 +103,7 @@ describe("Slack contract: edited-message reply delivery", () => {
         run: async (request) => {
           const _prompt = request.input.messageText;
           const context = {
-            ...flattenReplyRequestForTest(request),
+            ...flattenAgentRunRequestForTest(request),
           };
 
           await context?.onTextDelta?.("Hello world");

--- a/packages/junior/tests/integration/slack/message-content-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/message-content-behavior.test.ts
@@ -16,7 +16,7 @@ import {
   createTestDestination,
 } from "../../fixtures/slack-harness";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
-import { flattenReplyRequestForTest } from "../../fixtures/agent-runner";
+import { flattenAgentRunRequestForTest } from "../../fixtures/agent-runner";
 
 interface CapturedCall {
   contextConversation?: string;
@@ -66,7 +66,7 @@ describe("Slack behavior: message content", () => {
             run: async (request) => {
               const prompt = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               calls.push({
@@ -142,7 +142,7 @@ describe("Slack behavior: message content", () => {
             run: async (request) => {
               const prompt = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               calls.push({
@@ -264,7 +264,7 @@ describe("Slack behavior: message content", () => {
             run: async (request) => {
               const prompt = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               calls.push({
@@ -371,7 +371,7 @@ describe("Slack behavior: message content", () => {
             run: async (request) => {
               const prompt = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               calls.push({
@@ -490,7 +490,7 @@ describe("Slack behavior: message content", () => {
             run: async (request) => {
               const prompt = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               calls.push({

--- a/packages/junior/tests/integration/slack/message-im-attachment-contract.test.ts
+++ b/packages/junior/tests/integration/slack/message-im-attachment-contract.test.ts
@@ -7,7 +7,7 @@ import { createSlackWebhookTestClient } from "../../fixtures/slack/webhook-clien
 import { mswServer } from "../../msw/server";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
-import { flattenReplyRequestForTest } from "../../fixtures/agent-runner";
+import { flattenAgentRunRequestForTest } from "../../fixtures/agent-runner";
 
 const SIGNING_SECRET = "test-signing-secret";
 const BOT_USER_ID = "U_BOT";
@@ -108,7 +108,7 @@ describe("Slack contract: message.im attachment ingress", () => {
         run: async (request) => {
           const _prompt = request.input.messageText;
           const context = {
-            ...flattenReplyRequestForTest(request),
+            ...flattenAgentRunRequestForTest(request),
           };
 
           const attachments = context?.userAttachments ?? [];

--- a/packages/junior/tests/integration/slack/new-mention-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/new-mention-behavior.test.ts
@@ -11,7 +11,7 @@ import {
   createTestThread,
 } from "../../fixtures/slack-harness";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
-import { flattenReplyRequestForTest } from "../../fixtures/agent-runner";
+import { flattenAgentRunRequestForTest } from "../../fixtures/agent-runner";
 
 interface FakeReplyCall {
   prompt: string;
@@ -175,7 +175,7 @@ describe("Slack behavior: new mention", () => {
             run: async (request) => {
               const prompt = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               const attachments = context?.userAttachments ?? [];
@@ -250,7 +250,7 @@ describe("Slack behavior: new mention", () => {
             run: async (request) => {
               const _prompt = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               await context?.onStatus?.(makeAssistantStatus("running", "bash"));

--- a/packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../../fixtures/slack-harness";
 import { slackApiOutbox } from "../../fixtures/slack-api-outbox";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
-import { flattenReplyRequestForTest } from "../../fixtures/agent-runner";
+import { flattenAgentRunRequestForTest } from "../../fixtures/agent-runner";
 
 function successDiagnostics(toolCalls: string[] = []) {
   return {
@@ -251,7 +251,7 @@ describe("Slack behavior: processing reaction", () => {
             run: async (request) => {
               const _prompt = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               context?.onToolInvocation?.({

--- a/packages/junior/tests/integration/slack/provider-default-config-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/provider-default-config-behavior.test.ts
@@ -22,11 +22,11 @@ function toPostedText(value: unknown): string {
 
 describe("Slack behavior: provider default configuration", () => {
   it("sets an explicit default GitHub repo without starting an agent turn", async () => {
-    const generateAssistantReply = vi.fn();
+    const executeAgentRun = vi.fn();
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
         },
       },
     });
@@ -47,7 +47,7 @@ describe("Slack behavior: provider default configuration", () => {
       { destination: createTestDestination(thread) },
     );
 
-    expect(generateAssistantReply).not.toHaveBeenCalled();
+    expect(executeAgentRun).not.toHaveBeenCalled();
     expect(thread.posts).toHaveLength(1);
     expect(toPostedText(thread.posts[0])).toContain("getsentry/junior");
     expect(channelStateRef.value).toMatchObject({
@@ -64,7 +64,7 @@ describe("Slack behavior: provider default configuration", () => {
   });
 
   it("does not intercept combined repo setup and agent work", async () => {
-    const generateAssistantReply = vi.fn(async () =>
+    const executeAgentRun = vi.fn(async () =>
       completedAgentRun({
         text: "Created the issue.",
         deliveryMode: "thread" as const,
@@ -87,7 +87,7 @@ describe("Slack behavior: provider default configuration", () => {
     const { slackRuntime } = createTestChatRuntime({
       services: {
         replyExecutor: {
-          agentRunner: { run: generateAssistantReply },
+          agentRunner: { run: executeAgentRun },
         },
       },
     });
@@ -108,7 +108,7 @@ describe("Slack behavior: provider default configuration", () => {
       { destination: createTestDestination(thread) },
     );
 
-    expect(generateAssistantReply).toHaveBeenCalledOnce();
+    expect(executeAgentRun).toHaveBeenCalledOnce();
     expect(toPostedText(thread.posts[0])).toContain("Created the issue.");
     expect(channelStateRef.value).not.toMatchObject({
       configuration: {

--- a/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
@@ -9,7 +9,7 @@ import {
   createTestDestination,
 } from "../../fixtures/slack-harness";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
-import { flattenReplyRequestForTest } from "../../fixtures/agent-runner";
+import { flattenAgentRunRequestForTest } from "../../fixtures/agent-runner";
 
 const emptyThreadReplies = async () => [];
 
@@ -83,7 +83,7 @@ describe("Slack behavior: subscribed messages", () => {
           agentRunner: {
             run: async () => {
               throw new Error(
-                "generateAssistantReply should not run when classifier skips reply",
+                "executeAgentRun should not run when classifier skips reply",
               );
             },
           },
@@ -123,7 +123,7 @@ describe("Slack behavior: subscribed messages", () => {
         replyExecutor: {
           agentRunner: {
             run: async () => {
-              throw new Error("generateAssistantReply should not run");
+              throw new Error("executeAgentRun should not run");
             },
           },
         },
@@ -164,7 +164,7 @@ describe("Slack behavior: subscribed messages", () => {
             run: async (request) => {
               const _prompt = request.input.messageText;
               const context = {
-                ...flattenReplyRequestForTest(request),
+                ...flattenAgentRunRequestForTest(request),
               };
 
               replyContexts.push(context);

--- a/packages/junior/tests/unit/misc/agent-run-helpers-runtime-context.test.ts
+++ b/packages/junior/tests/unit/misc/agent-run-helpers-runtime-context.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { PiMessage } from "@/chat/pi/messages";
-import { prependMissingRuntimeTurnContext } from "@/chat/respond-helpers";
+import { prependMissingRuntimeTurnContext } from "@/chat/agent-run-helpers";
 
 describe("prependMissingRuntimeTurnContext", () => {
   it("leaves recorded bootstrap prompts unchanged", () => {

--- a/packages/junior/tests/unit/misc/agent-run-helpers-tools.test.ts
+++ b/packages/junior/tests/unit/misc/agent-run-helpers-tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getSuccessfulToolCalls } from "@/chat/respond-helpers";
+import { getSuccessfulToolCalls } from "@/chat/agent-run-helpers";
 
 describe("getSuccessfulToolCalls", () => {
   it("omits failed tool results", () => {

--- a/packages/junior/tests/unit/misc/agent-run-helpers-user-turn.test.ts
+++ b/packages/junior/tests/unit/misc/agent-run-helpers-user-turn.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildUserTurnText } from "@/chat/respond-helpers";
+import { buildUserTurnText } from "@/chat/agent-run-helpers";
 
 describe("buildUserTurnText", () => {
   it("wraps input in the current instruction boundary without context", () => {

--- a/packages/junior/tests/unit/runtime/agent-run-agent-continue.test.ts
+++ b/packages/junior/tests/unit/runtime/agent-run-agent-continue.test.ts
@@ -259,7 +259,7 @@ vi.mock("@/chat/skills", async (importOriginal) => ({
   parseSkillInvocation: () => null,
 }));
 
-import { generateAssistantReply } from "@/chat/respond";
+import { executeAgentRun } from "@/chat/agent-run";
 import { isTurnInputCommitLostError } from "@/chat/runtime/turn";
 import { AGENT_CONTINUE_MAX_SLICES } from "@/chat/services/turn-session-record";
 import { getConversationStore } from "@/chat/db";
@@ -287,7 +287,7 @@ const TEST_REQUESTER = {
   userId: "U123",
 } as const;
 
-describe("generateAssistantReply agent continuation", () => {
+describe("executeAgentRun agent continuation", () => {
   beforeEach(async () => {
     promptAborted.value = false;
     continueCalls.value = 0;
@@ -309,7 +309,7 @@ describe("generateAssistantReply agent continuation", () => {
   it("rejects durable input when no prompt checkpoint can be persisted", async () => {
     const onInputCommitted = vi.fn();
 
-    const error = await generateAssistantReply({
+    const error = await executeAgentRun({
       input: { messageText: "help me" },
       routing: { destination: TEST_DESTINATION, source: TEST_SOURCE },
       durability: { onInputCommitted },
@@ -320,7 +320,7 @@ describe("generateAssistantReply agent continuation", () => {
   });
 
   it("stores the last safe boundary and returns a timed-out outcome", async () => {
-    const replyPromise = generateAssistantReply({
+    const replyPromise = executeAgentRun({
       input: { messageText: "help me" },
       routing: {
         destination: TEST_DESTINATION,
@@ -379,7 +379,7 @@ describe("generateAssistantReply agent continuation", () => {
       resumeReason: "timeout",
     });
 
-    const replyPromise = generateAssistantReply({
+    const replyPromise = executeAgentRun({
       input: { messageText: "help me" },
       routing: {
         destination: TEST_DESTINATION,
@@ -415,7 +415,7 @@ describe("generateAssistantReply agent continuation", () => {
 
   it("records the effective request deadline timeout budget", async () => {
     const startedAtMs = Date.now();
-    const replyPromise = generateAssistantReply({
+    const replyPromise = executeAgentRun({
       input: { messageText: "help me" },
       routing: {
         destination: TEST_DESTINATION,
@@ -446,7 +446,7 @@ describe("generateAssistantReply agent continuation", () => {
   });
 
   it("persists omitted-image context in the session-recorded Pi user message", async () => {
-    const replyPromise = generateAssistantReply({
+    const replyPromise = executeAgentRun({
       input: {
         messageText: "what is in this image?",
         omittedImageAttachmentCount: 1,
@@ -491,7 +491,7 @@ describe("generateAssistantReply agent continuation", () => {
 
   it("persists agent continuation state when abort does not settle the agent run", async () => {
     promptMode.value = "hangsAfterAbort";
-    const replyPromise = generateAssistantReply({
+    const replyPromise = executeAgentRun({
       input: { messageText: "help me" },
       routing: {
         destination: TEST_DESTINATION,
@@ -536,7 +536,7 @@ describe("generateAssistantReply agent continuation", () => {
 
   it("uses one wall-clock timeout budget across provider retries", async () => {
     promptMode.value = "providerRetryThenHangs";
-    const replyPromise = generateAssistantReply({
+    const replyPromise = executeAgentRun({
       input: { messageText: "help me" },
       routing: {
         destination: TEST_DESTINATION,

--- a/packages/junior/tests/unit/runtime/agent-run-lazy-sandbox.test.ts
+++ b/packages/junior/tests/unit/runtime/agent-run-lazy-sandbox.test.ts
@@ -518,24 +518,21 @@ vi.mock("@/chat/sandbox/sandbox", () => ({
   },
 }));
 
-import {
-  generateAssistantReply,
-  type ReplyRequestContext,
-} from "@/chat/respond";
+import { executeAgentRun, type AgentRunRequest } from "@/chat/agent-run";
 
 const LOCAL_DESTINATION = {
   platform: "local" as const,
-  conversationId: "local:test:respond-lazy-sandbox",
+  conversationId: "local:test:agent-run-lazy-sandbox",
 };
 const LOCAL_SOURCE = createLocalSource(LOCAL_DESTINATION.conversationId);
 
 async function generateLocalReply(
   message: string,
-  context: Partial<Omit<ReplyRequestContext, "input" | "routing">> & {
-    input?: Partial<Omit<ReplyRequestContext["input"], "messageText">>;
+  context: Partial<Omit<AgentRunRequest, "input" | "routing">> & {
+    input?: Partial<Omit<AgentRunRequest["input"], "messageText">>;
   } = {},
 ) {
-  const outcome = await generateAssistantReply({
+  const outcome = await executeAgentRun({
     ...context,
     input: {
       messageText: message,
@@ -549,10 +546,10 @@ async function generateLocalReply(
   if (outcome.status !== "completed") {
     throw new Error(`Expected final reply, got ${outcome.status}`);
   }
-  return outcome.reply;
+  return outcome.result;
 }
 
-describe("generateAssistantReply lazy sandbox boot", () => {
+describe("executeAgentRun lazy sandbox boot", () => {
   beforeEach(() => {
     agentMode.value = "plain";
     createSandboxCallCount.value = 0;
@@ -628,7 +625,7 @@ describe("generateAssistantReply lazy sandbox boot", () => {
       input: {
         userAttachments: [
           {
-            data: Buffer.from("TypeError: x is undefined\nat respond.ts:42"),
+            data: Buffer.from("TypeError: x is undefined\nat agent-run.ts:42"),
             filename: "error.txt",
             mediaType: "text/plain",
           },
@@ -645,7 +642,7 @@ describe("generateAssistantReply lazy sandbox boot", () => {
       input: {
         userAttachments: [
           {
-            data: Buffer.from("TypeError: x is undefined\nat respond.ts:42"),
+            data: Buffer.from("TypeError: x is undefined\nat agent-run.ts:42"),
             filename: "error.json",
             mediaType: "application/vnd.api+json; charset=utf-8",
           },

--- a/packages/junior/tests/unit/runtime/agent-run-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/unit/runtime/agent-run-mcp-progressive-loading.test.ts
@@ -559,26 +559,21 @@ vi.mock("@/chat/mcp/client", () => {
   };
 });
 
-import {
-  generateAssistantReply,
-  type ReplyRequestContext,
-} from "@/chat/respond";
+import { executeAgentRun, type AgentRunRequest } from "@/chat/agent-run";
 import {
   getAgentTurnSessionRecord,
   upsertAgentTurnSessionRecord,
 } from "@/chat/state/turn-session";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
 
-function finalReply(
-  outcome: Awaited<ReturnType<typeof generateAssistantReply>>,
-) {
+function finalReply(outcome: Awaited<ReturnType<typeof executeAgentRun>>) {
   if (outcome.status !== "completed") {
     throw new Error(`Expected final reply, got ${outcome.status}`);
   }
-  return outcome.reply;
+  return outcome.result;
 }
 
-function makeReplyRequest(
+function makeAgentRunRequest(
   messageText: string,
   args: {
     conversationId: string;
@@ -586,14 +581,14 @@ function makeReplyRequest(
     turnId: string;
   },
   overrides: {
-    input?: Partial<Omit<ReplyRequestContext["input"], "messageText">>;
-    routing?: Partial<ReplyRequestContext["routing"]>;
-    policy?: ReplyRequestContext["policy"];
-    state?: ReplyRequestContext["state"];
-    observers?: ReplyRequestContext["observers"];
-    durability?: ReplyRequestContext["durability"];
+    input?: Partial<Omit<AgentRunRequest["input"], "messageText">>;
+    routing?: Partial<AgentRunRequest["routing"]>;
+    policy?: AgentRunRequest["policy"];
+    state?: AgentRunRequest["state"];
+    observers?: AgentRunRequest["observers"];
+    durability?: AgentRunRequest["durability"];
   } = {},
-): ReplyRequestContext {
+): AgentRunRequest {
   const destination = {
     platform: "slack" as const,
     teamId: "T123",
@@ -639,7 +634,7 @@ function makeReplyRequest(
 
 // This suite validates local progressive-loading logic through a mocked
 // agent/runtime seam; it is not integration coverage.
-describe("generateAssistantReply progressive MCP loading", () => {
+describe("executeAgentRun progressive MCP loading", () => {
   beforeEach(async () => {
     agentInitialToolNames.length = 0;
     agentInitialSystemPrompts.length = 0;
@@ -712,13 +707,13 @@ describe("generateAssistantReply progressive MCP loading", () => {
   });
 
   it("persists loaded plugin skills across auth pause and resume", async () => {
-    const context = makeReplyRequest("help me", {
+    const context = makeAgentRunRequest("help me", {
       conversationId: "conversation-1",
       threadTs: "1712345.0001",
       turnId: "turn-1",
     });
 
-    const firstError = await generateAssistantReply(context);
+    const firstError = await executeAgentRun(context);
 
     expect(firstError.status).toBe("awaiting_auth");
     expect(agentInitialToolNames[0]).toContain("loadSkill");
@@ -750,7 +745,7 @@ describe("generateAssistantReply progressive MCP loading", () => {
     ]);
     expect(loadSkillExecutionErrorCount.value).toBe(0);
 
-    const reply = finalReply(await generateAssistantReply(context));
+    const reply = finalReply(await executeAgentRun(context));
 
     expect(reply.text).toBe("resumed reply");
     expect(promptCallCount.value).toBe(1);
@@ -795,8 +790,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
     listToolsMock.mockResolvedValue(makeDemoMcpTools());
 
     const reply = finalReply(
-      await generateAssistantReply(
-        makeReplyRequest("help me", {
+      await executeAgentRun(
+        makeAgentRunRequest("help me", {
           conversationId: "conversation-2",
           threadTs: "1712345.0002",
           turnId: "turn-2",
@@ -838,8 +833,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
     listToolsMock.mockReset();
     listToolsMock.mockResolvedValue(makeDemoMcpTools());
 
-    await generateAssistantReply(
-      makeReplyRequest(
+    await executeAgentRun(
+      makeAgentRunRequest(
         "help me",
         {
           conversationId: "conversation-restored-provider",
@@ -890,8 +885,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
       },
     ] as unknown as PiMessage[];
 
-    const firstError = await generateAssistantReply(
-      makeReplyRequest(
+    const firstError = await executeAgentRun(
+      makeAgentRunRequest(
         "current follow-up",
         {
           conversationId: "conversation-restore-auth",
@@ -929,8 +924,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
     );
 
     const reply = finalReply(
-      await generateAssistantReply(
-        makeReplyRequest(
+      await executeAgentRun(
+        makeAgentRunRequest(
           "current follow-up",
           {
             conversationId: "conversation-restore-auth",
@@ -981,8 +976,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
       },
     ] as PiMessage[];
 
-    await generateAssistantReply(
-      makeReplyRequest(
+    await executeAgentRun(
+      makeAgentRunRequest(
         "help me",
         {
           conversationId: "conversation-history",
@@ -1044,8 +1039,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
       errorMessage: "authorization required",
     });
 
-    await generateAssistantReply(
-      makeReplyRequest("continue after auth", {
+    await executeAgentRun(
+      makeAgentRunRequest("continue after auth", {
         conversationId: "conversation-raw-current-resume",
         threadTs: "1712345.0092",
         turnId: "turn-raw-current-resume",
@@ -1094,8 +1089,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
       errorMessage: "authorization required",
     });
 
-    await generateAssistantReply(
-      makeReplyRequest(messageText, {
+    await executeAgentRun(
+      makeAgentRunRequest(messageText, {
         conversationId: "conversation-unescaped-current-resume",
         threadTs: "1712345.0093",
         turnId: "turn-unescaped-current-resume",
@@ -1139,8 +1134,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
       piMessages: storedRunningMessages,
     });
 
-    await generateAssistantReply(
-      makeReplyRequest(
+    await executeAgentRun(
+      makeAgentRunRequest(
         "continue after crash",
         {
           conversationId: "conversation-crash-retry",
@@ -1181,8 +1176,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
       },
     ] as PiMessage[];
 
-    await generateAssistantReply(
-      makeReplyRequest(
+    await executeAgentRun(
+      makeAgentRunRequest(
         "help me",
         {
           conversationId: "conversation-history-with-context",
@@ -1228,13 +1223,13 @@ describe("generateAssistantReply progressive MCP loading", () => {
       );
     });
 
-    const context = makeReplyRequest("help me", {
+    const context = makeAgentRunRequest("help me", {
       conversationId: "conversation-4",
       threadTs: "1712345.0004",
       turnId: "turn-4",
     });
 
-    const firstError = await generateAssistantReply(context);
+    const firstError = await executeAgentRun(context);
 
     expect(firstError.status).toBe("awaiting_auth");
     expect(deliverPrivateMessageMock).toHaveBeenCalledTimes(1);
@@ -1248,7 +1243,7 @@ describe("generateAssistantReply progressive MCP loading", () => {
       resumeReason: "auth",
     });
 
-    const reply = finalReply(await generateAssistantReply(context));
+    const reply = finalReply(await executeAgentRun(context));
 
     expect(reply.text).toBe("resumed reply");
 
@@ -1271,8 +1266,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
     listToolsMock.mockResolvedValue([makeDemoMcpTool("ping")]);
 
     const reply = finalReply(
-      await generateAssistantReply(
-        makeReplyRequest("help me", {
+      await executeAgentRun(
+        makeAgentRunRequest("help me", {
           conversationId: "conversation-5",
           threadTs: "1712345.0005",
           turnId: "turn-5",
@@ -1298,8 +1293,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
       });
 
     const reply = finalReply(
-      await generateAssistantReply(
-        makeReplyRequest("help me", {
+      await executeAgentRun(
+        makeAgentRunRequest("help me", {
           conversationId: "conversation-3",
           threadTs: "1712345.0003",
           turnId: "turn-3",
@@ -1376,8 +1371,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
       );
     });
 
-    const firstError = await generateAssistantReply(
-      makeReplyRequest("help me", {
+    const firstError = await executeAgentRun(
+      makeAgentRunRequest("help me", {
         conversationId: "conversation-5",
         threadTs: "1712345.0005",
         turnId: "turn-5",
@@ -1402,8 +1397,8 @@ describe("generateAssistantReply progressive MCP loading", () => {
   it("still parks for auth when abort leaves an empty completed assistant frame", async () => {
     completeEmptyAssistantOnAbort.value = true;
 
-    const firstError = await generateAssistantReply(
-      makeReplyRequest("help me", {
+    const firstError = await executeAgentRun(
+      makeAgentRunRequest("help me", {
         conversationId: "conversation-6",
         threadTs: "1712345.0006",
         turnId: "turn-6",

--- a/packages/junior/tests/unit/runtime/agent-run-provider-retry.test.ts
+++ b/packages/junior/tests/unit/runtime/agent-run-provider-retry.test.ts
@@ -332,7 +332,7 @@ vi.mock("@/chat/skills", async (importOriginal) => ({
   parseSkillInvocation: () => null,
 }));
 
-import { generateAssistantReply } from "@/chat/respond";
+import { executeAgentRun } from "@/chat/agent-run";
 import { getConversationStore } from "@/chat/db";
 import { getAwaitingAgentContinueRequest } from "@/chat/services/agent-continue";
 import { persistCompletedSessionRecord } from "@/chat/services/turn-session-record";
@@ -340,13 +340,11 @@ import { disconnectStateAdapter } from "@/chat/state/adapter";
 import * as turnSessionState from "@/chat/state/turn-session";
 import { createJuniorReporting } from "@/reporting";
 
-function finalReply(
-  outcome: Awaited<ReturnType<typeof generateAssistantReply>>,
-) {
+function finalReply(outcome: Awaited<ReturnType<typeof executeAgentRun>>) {
   if (outcome.status !== "completed") {
     throw new Error(`Expected final reply, got ${outcome.status}`);
   }
-  return outcome.reply;
+  return outcome.result;
 }
 
 const TEST_DESTINATION = {
@@ -361,7 +359,7 @@ const TEST_SOURCE = createSlackSource({
   type: "priv",
 });
 
-describe("generateAssistantReply provider retry", () => {
+describe("executeAgentRun provider retry", () => {
   beforeEach(async () => {
     agentMode.value = "providerRetry";
     counters.continueCalls = 0;
@@ -381,7 +379,7 @@ describe("generateAssistantReply provider retry", () => {
   });
 
   it("continues from the last safe boundary after a transient provider stream error", async () => {
-    const replyPromise = generateAssistantReply({
+    const replyPromise = executeAgentRun({
       input: { messageText: "help me" },
       routing: {
         destination: TEST_DESTINATION,
@@ -472,7 +470,7 @@ describe("generateAssistantReply provider retry", () => {
     });
 
     const reply = finalReply(
-      await generateAssistantReply({
+      await executeAgentRun({
         input: { messageText: "help me", piMessages: priorMessages },
         routing: {
           destination: TEST_DESTINATION,
@@ -547,7 +545,7 @@ describe("generateAssistantReply provider retry", () => {
   it("parks the turn when the worker asks to yield at a Pi boundary", async () => {
     agentMode.value = "cooperativeYield";
 
-    const outcome = await generateAssistantReply({
+    const outcome = await executeAgentRun({
       input: { messageText: "help me" },
       routing: {
         destination: TEST_DESTINATION,
@@ -598,7 +596,7 @@ describe("generateAssistantReply provider retry", () => {
   it("keeps steered messages when yielding after steering drain", async () => {
     agentMode.value = "cooperativeYield";
 
-    const outcome = await generateAssistantReply({
+    const outcome = await executeAgentRun({
       input: { messageText: "help me" },
       routing: {
         requester: { platform: "slack", teamId: "T123", userId: "U123" },
@@ -654,7 +652,7 @@ describe("generateAssistantReply provider retry", () => {
       .spyOn(turnSessionState, "upsertAgentTurnSessionRecord")
       .mockRejectedValue(new Error("storage unavailable"));
 
-    const error = await generateAssistantReply({
+    const error = await executeAgentRun({
       input: { messageText: "help me" },
       routing: {
         destination: TEST_DESTINATION,
@@ -691,7 +689,7 @@ describe("generateAssistantReply provider retry", () => {
     sessionLogState.failToolExecutionAppend = true;
 
     const reply = finalReply(
-      await generateAssistantReply({
+      await executeAgentRun({
         input: { messageText: "run the tool" },
         routing: {
           destination: TEST_DESTINATION,
@@ -733,7 +731,7 @@ describe("generateAssistantReply provider retry", () => {
     });
 
     const reply = finalReply(
-      await generateAssistantReply({
+      await executeAgentRun({
         input: { messageText: "help me", piMessages: [checkpointedPrompt] },
         routing: {
           destination: TEST_DESTINATION,
@@ -768,7 +766,7 @@ describe("generateAssistantReply provider retry", () => {
     let injectRejected = false;
     let injectCompleted = false;
 
-    await generateAssistantReply({
+    await executeAgentRun({
       input: { messageText: "help me" },
       routing: {
         destination: TEST_DESTINATION,

--- a/packages/junior/tests/unit/services/turn-failure-response.test.ts
+++ b/packages/junior/tests/unit/services/turn-failure-response.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import { getInterruptionMarker } from "@/chat/interruption-marker";
 import { finalizeFailedTurnReply } from "@/chat/services/turn-failure-response";
-import type { AssistantReply } from "@/chat/services/turn-result";
+import type { AgentRunResult } from "@/chat/services/turn-result";
 
 function providerErrorReply(args: {
   assistantMessageCount: number;
   errorMessage?: string;
   text: string;
-}): AssistantReply {
+}): AgentRunResult {
   return {
     text: args.text,
     diagnostics: {

--- a/packages/junior/tests/unit/services/turn-thinking-level.test.ts
+++ b/packages/junior/tests/unit/services/turn-thinking-level.test.ts
@@ -46,7 +46,7 @@ describe("selectTurnThinkingLevel", () => {
       completeObject,
       fastModelId: "openai/gpt-5.4-mini",
       messageText:
-        "fix the failing test in packages/junior/src/chat/respond.ts",
+        "fix the failing test in packages/junior/src/chat/agent-run.ts",
     });
 
     expect(profile).toMatchObject({

--- a/specs/agent-prompt.md
+++ b/specs/agent-prompt.md
@@ -66,7 +66,7 @@ Trusted deployment-authored Markdown files, such as `SOUL.md` and `WORLD.md`, sh
 
 ### Current Task Declaration
 
-Every model-visible active user task assembled by the Junior turn runtime must render the user-authored task text inside `<current-instruction>`. This wrapper is required even when there is no thread background, dispatch metadata, plugin contribution, attachment, or runtime context. It applies to Slack turns, local turns, dispatched or scheduled work that enters the shared reply boundary, and queued steering messages injected during an active turn.
+Every model-visible active user task assembled by the Junior turn runtime must render the user-authored task text inside `<current-instruction>`. This wrapper is required even when there is no thread background, dispatch metadata, plugin contribution, attachment, or runtime context. It applies to Slack turns, local turns, dispatched or scheduled work that enters the shared agent-run boundary, and queued steering messages injected during an active turn.
 
 Thread background, runtime context, plugin prompt contributions, requester/configuration metadata, and attachments must remain outside `<current-instruction>` as sibling blocks or content parts. Internal helper prompts and subagent/tool prompts may use task-specific wrappers when they are not model-visible Junior user turns.
 

--- a/specs/archive/agent-stability-evaluation-2026-02.md
+++ b/specs/archive/agent-stability-evaluation-2026-02.md
@@ -9,7 +9,6 @@
 
 - 2026-03-03: Standardized metadata headers and reconciled spec references/structure.
 
-
 Last updated: 2026-02-27
 
 ## Scope
@@ -30,17 +29,17 @@ This document tracks stability risks in the Slack agent loop, concrete mitigatio
 
 ## Evaluation Checklist
 
-| Concern | Plan | Status | Validation |
-| --- | --- | --- | --- |
-| Collapse compounding retry structure | Remove classifier-driven continuation loop and keep bounded deterministic finalization | Completed | `src/chat/respond.ts` no longer runs completion classifier/retry agent branch |
-| Reduce terminal nondeterminism | Remove LLM-based completion classifier from terminal decision path | Completed | `src/chat/respond.ts` no longer depends on `classifyCompletionOutcome` |
-| Preserve retry context | Rework retries to use prior response messages/tool context rather than only corrective text | Completed | Finalization retries now include `...finalResult.response.messages` |
-| Tool failure semantics | Throw operational tool failures to emit `tool-error` outputs | Completed | Updated `web-fetch`, `image-generate`, and Slack tool catch paths to throw |
-| Tool-loop control | Add deterministic prepare-step guardrails against repetitive tool call patterns | Completed | Added `prepareStep` loop guard + `onStepFinish` tool-error logging in `respond.ts` |
-| Side-effect idempotency | Add per-turn dedupe keys for create/update Slack artifact tools | Completed | Added operation cache in `ToolState` + dedupe keys in side-effect tools |
-| PI continue-loop diagnosis | Remove/replace auto-continue branch and document behavior change | Completed | Removed PI-style auto-continue retry loop from `respond.ts` |
-| Test coverage | Add focused tests for idempotency + regression-prone loop helpers | Completed | Added `tests/integration/tool-idempotency.test.ts` |
-| Channel member enrichment rate limits | Refactor member profile lookup to bounded concurrency (or staged hydration) | Pending | `src/chat/slack-actions/channel.ts` currently uses broad `Promise.all` fan-out |
+| Concern                               | Plan                                                                                        | Status    | Validation                                                                           |
+| ------------------------------------- | ------------------------------------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------ |
+| Collapse compounding retry structure  | Remove classifier-driven continuation loop and keep bounded deterministic finalization      | Completed | `src/chat/agent-run.ts` no longer runs completion classifier/retry agent branch      |
+| Reduce terminal nondeterminism        | Remove LLM-based completion classifier from terminal decision path                          | Completed | `src/chat/agent-run.ts` no longer depends on `classifyCompletionOutcome`             |
+| Preserve retry context                | Rework retries to use prior response messages/tool context rather than only corrective text | Completed | Finalization retries now include `...finalResult.response.messages`                  |
+| Tool failure semantics                | Throw operational tool failures to emit `tool-error` outputs                                | Completed | Updated `web-fetch`, `image-generate`, and Slack tool catch paths to throw           |
+| Tool-loop control                     | Add deterministic prepare-step guardrails against repetitive tool call patterns             | Completed | Added `prepareStep` loop guard + `onStepFinish` tool-error logging in `agent-run.ts` |
+| Side-effect idempotency               | Add per-turn dedupe keys for create/update Slack artifact tools                             | Completed | Added operation cache in `ToolState` + dedupe keys in side-effect tools              |
+| PI continue-loop diagnosis            | Remove/replace auto-continue branch and document behavior change                            | Completed | Removed PI-style auto-continue retry loop from `agent-run.ts`                        |
+| Test coverage                         | Add focused tests for idempotency + regression-prone loop helpers                           | Completed | Added `tests/integration/tool-idempotency.test.ts`                                   |
+| Channel member enrichment rate limits | Refactor member profile lookup to bounded concurrency (or staged hydration)                 | Pending   | `src/chat/slack-actions/channel.ts` currently uses broad `Promise.all` fan-out       |
 
 ## Notes
 
@@ -51,7 +50,7 @@ This document tracks stability risks in the Slack agent loop, concrete mitigatio
 - Post-merge regression (2026-02-25):
   - Symptom: `AI_MissingToolResultsError` during finalization retries.
   - Cause: Retry history reused `response.messages` that could contain unresolved non-provider `tool-call` parts before appending a new user message.
-  - Mitigation: sanitize retry history and strip unresolved non-provider tool calls before finalization retry generation (`src/chat/respond.ts`).
+  - Mitigation: sanitize retry history and strip unresolved non-provider tool calls before finalization retry generation (`src/chat/agent-run.ts`).
 - Policy update (2026-02-25):
   - Finalization retries are disabled for now to avoid masking failures and compounding instability.
   - Runtime flow is now: primary loop -> forced no-tool finalization (single fallback) -> explicit failure surfacing.
@@ -59,5 +58,5 @@ This document tracks stability risks in the Slack agent loop, concrete mitigatio
   - `pnpm typecheck` passed
   - `pnpm test` passed (8 files, 25 tests)
 - Residual risks:
-  - Loop guard behavior is covered by unit-level logic and compile checks, but not by a full mocked `generateAssistantReply` integration test.
+  - Loop guard behavior is covered by unit-level logic and compile checks, but not by a full mocked `executeAgentRun` integration test.
   - Tool idempotency cache is per turn (intended) and does not dedupe across separate Slack invocations.

--- a/specs/archive/non-normative-cleanup-notes-2026-05-28.md
+++ b/specs/archive/non-normative-cleanup-notes-2026-05-28.md
@@ -54,7 +54,7 @@ Previous migration matrix:
 
 1. `packages/junior/src/handlers/webhooks.ts`: unknown platform, handler failures, request lifecycle.
 2. `packages/junior/src/chat/runtime/slack-runtime.ts`: attachment handling, thread lifecycle, handler failures.
-3. `packages/junior/src/chat/respond.ts`: empty/fallback behaviors, retries, model/tool anomalies. Per-turn diagnostics are captured on turn spans, not required as info logs.
+3. `packages/junior/src/chat/agent-run.ts`: empty/fallback behaviors, retries, model/tool anomalies. Per-turn diagnostics are captured on turn spans, not required as info logs.
 4. `packages/junior/src/chat/skills.ts`: skill discovery/read/frontmatter parse issues.
 5. `packages/junior/src/chat/slack/output.ts`: output normalization fallback.
 
@@ -69,7 +69,7 @@ Previous rollout phases:
 
 Previous logging TODOs:
 
-1. Migrate duplicated per-turn context in `packages/junior/src/chat/respond.ts` to ambient `withContext`/`withLogContext`.
+1. Migrate duplicated per-turn context in `packages/junior/src/chat/agent-run.ts` to ambient `withContext`/`withLogContext`.
 2. Update `packages/junior/src/chat/runtime/slack-runtime.ts` logging call patterns to rely on ambient context by default.
 3. Normalize remaining ad-hoc context passing in `packages/junior/src/chat/capabilities/*` and `packages/junior/src/chat/queue/*`.
 4. Add unit tests for context merge precedence and async propagation in `packages/junior/src/chat/logging.ts`.

--- a/specs/chat-architecture.md
+++ b/specs/chat-architecture.md
@@ -51,7 +51,7 @@ flowchart TD
   F --> G[Restore Pi state from reduced session log]
   LA[Local CLI input] --> LB[Direct local runner: persist local turn and load state]
   LB --> G
-  G --> J[respond.ts generateAssistantReply / continue]
+  G --> J[agent-run.ts executeAgentRun / continue]
   J --> K[Build prompt context from durable conversation, config, artifacts, sandbox, attachments]
   K --> L[Pi agent continue loop]
   L --> M[Tools, skills, MCP, sandbox]
@@ -83,7 +83,7 @@ Normative rules:
 2. The task execution layer owns queue wake-ups, conversation leases, worker check-ins, and heartbeat recovery. Chat SDK queue/lock semantics are not canonical.
 3. The first-pass local CLI adapter uses the direct local runner from [Local Agent Spec](./local-agent.md). It must not claim mailbox-backed local source semantics until a local mailbox ingress contract exists.
 4. The mailbox worker is the only point that drains inbound messages into persisted agent session context for mailbox-backed paths.
-5. `respond.ts` is the only owner of Pi agent execution, prompt/continue selection, timeout detection, and safe-boundary session-log event creation.
+5. `agent-run.ts` is the only owner of Pi agent execution, prompt/continue selection, timeout detection, and safe-boundary session-log event creation.
 6. Tool calls and tool failures are internal agent-loop data until the assistant produces final run diagnostics. Tool execution errors must be captured, but they are not automatically terminal user replies. Model-repairable failures must use the tool-error semantics from [Agent Execution Discipline Spec](./agent-execution.md).
 7. User-visible assistant text is posted only after the reply is finalized and planned for destination delivery.
 8. Final run success is defined by the destination delivery port accepting the visible final reply, not by model generation completing. Slack acceptance is one destination implementation.
@@ -290,7 +290,7 @@ Rules:
 
 1. Recovery continues the existing conversation from durable thread state plus the reduced agent-session log keyed by the predictable conversation id. It must not start a second active run for the same conversation.
 2. Conversation mailbox state, queue wake-ups, and leases protect inbound delivery. They do not replace session continuation because they do not carry Junior's canonical agent session log, sandbox/artifact state, pending auth, or final destination delivery state.
-3. `respond.ts` appends safe session-log boundaries; the mailbox worker enqueues cooperative continuations; heartbeat re-enqueues expired leases and stranded pending mailbox work.
+3. `agent-run.ts` appends safe session-log boundaries; the mailbox worker enqueues cooperative continuations; heartbeat re-enqueues expired leases and stranded pending mailbox work.
 4. Routine cooperative continuation does not create a platform acknowledgement message. Assistant status and `reportProgress` own progress UX.
 5. Queue duplicate and active-lease cases are harmless because queue messages are conversation wake-up nudges, not canonical work records.
 

--- a/specs/context-compaction.md
+++ b/specs/context-compaction.md
@@ -104,7 +104,7 @@ Compaction projection events must use a deterministic event id derived from the 
 Automatic pre-turn compaction may replace an oversized reusable conversation-log projection before the next agent turn starts. It must:
 
 1. Run after reusable Pi history is loaded.
-2. Finish before `generateAssistantReply(...)` receives `piMessages`.
+2. Finish before `executeAgentRun(...)` receives `piMessages`.
 3. Use the compacted replacement history for the upcoming turn.
 4. Append the compaction projection before final thread-state persistence for the turn.
 5. Start explicit assistant progress after the threshold decision and before summarization when a status surface is available, then return to the normal turn status before agent execution.

--- a/specs/harness-agent.md
+++ b/specs/harness-agent.md
@@ -11,7 +11,7 @@ Define the canonical runtime contract for assistant-turn execution and user-visi
 
 ## Scope
 
-- Turn execution in `generateAssistantReply(...)`.
+- Turn execution in `executeAgentRun(...)`.
 - Assistant text streaming and final output resolution.
 - Diagnostics emitted for each turn.
 
@@ -44,7 +44,7 @@ Define the canonical runtime contract for assistant-turn execution and user-visi
 
 ### Timeout behavior
 
-- `generateAssistantReply(...)` aborts the Pi agent on timeout and waits for the in-flight prompt/continue call to settle before inspecting Pi messages.
+- `executeAgentRun(...)` aborts the Pi agent on timeout and waits for the in-flight prompt/continue call to settle before inspecting Pi messages.
 - When resumability context is available (`conversation_id` + `session_id`) and a safe-boundary session record can be persisted, timeout throws `RetryableTurnError("agent_continue")` with session record metadata instead of returning a normal reply payload.
 - When no resumable session record can be persisted, timeout falls back to the standard provider-error reply path.
 - The harness does not decide whether timed-out work should be auto-resumed after user-visible output has started. Higher-level runtime code applies the visibility rules from [Agent Session Resumability Spec](./agent-session-resumability.md).

--- a/specs/local-agent.md
+++ b/specs/local-agent.md
@@ -148,7 +148,7 @@ Rules:
 1. The CLI must call the shared conversation runtime or shared local runner
    boundary. It must not call Slack runtime methods.
 2. The CLI must not construct Chat SDK `Thread`, `Message`, or Slack adapter
-   wrappers to reach `generateAssistantReply`.
+   wrappers to reach `executeAgentRun`.
 3. Runtime context must set `surface: "internal"` until a distinct `local`
    surface is added across reporting and session schemas.
 4. Runtime correlation must include `conversationId`, `runId`, and a local

--- a/specs/plugin-dispatch.md
+++ b/specs/plugin-dispatch.md
@@ -199,7 +199,7 @@ The internal callback runs a core-owned dispatched agent runner. The runner owns
 - loading dispatch-scoped persisted conversation/artifact/sandbox state and destination channel config state
 - creating or reusing synthetic system-authored conversation messages
 - building conversation context
-- calling `generateAssistantReply`
+- calling `executeAgentRun`
 - delivering the reply
 - committing conversation, artifact, sandbox, and dispatch state
 - marking auth-required runs as blocked
@@ -224,7 +224,7 @@ Slack post and state commit are not atomic. If Slack accepts the post but persis
 
 Dispatched requests must not use the Slack conversation queue used for interactive conversations. Timeout continuation uses the dispatch callback path:
 
-1. `generateAssistantReply` persists a resumable session record for the dispatch conversation and turn id.
+1. `executeAgentRun` persists a resumable session record for the dispatch conversation and turn id.
 2. Runner catches `agent_continue`.
 3. Runner marks dispatch `awaiting_resume` with the next record version.
 4. Runner signs another callback for the same dispatch id.

--- a/specs/task-execution.md
+++ b/specs/task-execution.md
@@ -581,7 +581,7 @@ Rules:
    local ingress uses `source: "local"`.
 2. Local CLI conversation ids must be stable across prompts in the same selected
    terminal session.
-3. Local CLI must use the shared conversation runtime and `generateAssistantReply`
+3. Local CLI must use the shared conversation runtime and `executeAgentRun`
    path. It must not instantiate Slack thread/message wrappers to reach the
    agent.
 4. Local CLI may stream assistant deltas and status updates to stdout/stderr, but

--- a/specs/terminology.md
+++ b/specs/terminology.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-06-12
-- Last Edited: 2026-06-12
+- Last Edited: 2026-07-02
 
 ## Purpose
 
@@ -72,11 +72,37 @@ Prefer comments that clarify the current meaning:
 
 > historical turn-session name; represents an agent-run session record
 
+### `reply`
+
+Use `reply` only for destination-visible messages owned by delivery and
+reply-policy layers.
+
+Allowed uses:
+
+- Delivery and policy identifiers that already describe destination-visible
+  messages, such as `SubscribedReplyPolicy`, `ReplyDeliveryPlan`, and
+  `slack/reply.ts`.
+- Historical identifiers in existing delivery-facing APIs, storage fields, and
+  tests when the value is a destination-visible message.
+- User-facing product copy that describes a visible response in Slack, local
+  CLI, or another destination.
+
+Agent execution layers use run/slice vocabulary instead. New executor-boundary
+identifiers must not use `reply` or `respond`; use `agent run`, `result`,
+`outcome`, or `delivery` terms according to ownership.
+
+When touching historical `reply` names, do not rename them opportunistically.
+Prefer comments that clarify the current meaning:
+
+> historical delivery reply name; represents a destination-visible message
+
 ### Naming Rules
 
 - Use `run` for response-producing execution.
 - Use `slice` for one resumable serverless invocation segment.
 - Use `step` for model/tool/action events inside a run.
+- Use `reply` only for destination-visible messages owned by delivery or
+  reply-policy layers.
 - Use `message` for source events and transcript entries.
 - Use `conversation` for the durable container that owns visible history and
   execution state.


### PR DESCRIPTION
Hard cutover of the executor boundary from reply/respond vocabulary to the run/slice vocabulary that `specs/terminology.md` canonicalizes. This is the fourth slice of the #746 series (after #750–#752), ported from the original #748 branch onto the reworked outcome model:

- `generateAssistantReply` → `executeAgentRun`, `respond.ts` → `agent-run.ts`, `respond-helpers.ts` → `agent-run-helpers.ts`
- `ReplyRequestContext` → `AgentRunRequest` (group interfaces follow suit), `ReplySteeringMessage` → `AgentRunSteeringMessage`
- `AssistantReply` → `AgentRunResult`; the `AgentRunOutcome` completed variant carries `result` instead of `reply`
- The `AssistantReplyRequestContext` compat alias and the type re-export layer on the executor module are deleted; consumers import `AgentRunResult` from `@/chat/services/turn-result` directly
- Test fixture follows: `respondAgentRunner` → `realAgentRunner`, `flattenReplyRequestForTest` → `flattenAgentRunRequestForTest`

No behavior change — the diff is renames plus spec-reference updates. `reply` stays reserved for destination-visible messages owned by delivery and reply-policy layers (`specs/terminology.md` now says this explicitly), which is why `reply-executor.ts` and its locals keep their names. The module stays at the chat root because it composes tools, plugins, MCP, sandbox, and capabilities, which `runtime/` modules may not depend on under the dependency-cruiser rules.

Review order: `specs/terminology.md` for the vocabulary rule, then `src/chat/agent-run.ts` and `runtime/agent-run-outcome.ts` for the boundary surface; the rest is mechanical rename fallout.

Refs #746