### PR TITLE
fix(slack): Add typed Slack ID boundaries

### DIFF
--- a/packages/junior/src/chat/destination.ts
+++ b/packages/junior/src/chat/destination.ts
@@ -3,20 +3,19 @@ import {
   type Destination,
   type SlackDestination,
 } from "@sentry/junior-plugin-api";
-import { normalizeSlackConversationId } from "@/chat/slack/client";
-import { isSlackConversationId, isSlackTeamId } from "@/chat/slack/ids";
+import {
+  parseSlackChannelReferenceId,
+  parseSlackTeamId,
+} from "@/chat/slack/ids";
 
 /** Build Junior's canonical destination from Slack workspace and channel ids. */
 export function createSlackDestination(input: {
   channelId: string | undefined;
   teamId: string | undefined;
 }): Destination | undefined {
-  const channelId = normalizeSlackConversationId(input.channelId);
-  const teamId = input.teamId?.trim();
+  const channelId = parseSlackChannelReferenceId(input.channelId);
+  const teamId = parseSlackTeamId(input.teamId);
   if (!channelId || !teamId) {
-    return undefined;
-  }
-  if (!isSlackConversationId(channelId) || !isSlackTeamId(teamId)) {
     return undefined;
   }
   return { platform: "slack", teamId, channelId };

--- a/packages/junior/src/chat/requester.ts
+++ b/packages/junior/src/chat/requester.ts
@@ -6,9 +6,9 @@
  */
 import { z } from "zod";
 import { requesterSchema } from "@sentry/junior-plugin-api";
-import { isSlackTeamId } from "@/chat/slack/ids";
+import { parseSlackTeamId } from "@/chat/slack/ids";
 
-const SLACK_USER_ID_PATTERN = /^[UW][A-Z0-9]{5,}$/;
+const SLACK_USER_ID_DISPLAY_PATTERN = /^[UW][A-Z0-9]{5,}$/;
 const EMAIL_PATTERN = /^[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+$/;
 
 const exactStoredStringSchema = z
@@ -78,11 +78,7 @@ function isSyntheticActorUserId(value: string): boolean {
 }
 
 function isSlackUserId(value: string): boolean {
-  return SLACK_USER_ID_PATTERN.test(value);
-}
-
-function parseSlackTeamId(value: unknown): string | undefined {
-  return typeof value === "string" && isSlackTeamId(value) ? value : undefined;
+  return SLACK_USER_ID_DISPLAY_PATTERN.test(value);
 }
 
 function cleanRequesterDisplayName(

--- a/packages/junior/src/chat/slack/channel.ts
+++ b/packages/junior/src/chat/slack/channel.ts
@@ -1,8 +1,5 @@
-import {
-  getSlackClient,
-  normalizeSlackConversationId,
-  withSlackRetries,
-} from "@/chat/slack/client";
+import { getSlackClient, withSlackRetries } from "@/chat/slack/client";
+import type { SlackChannelId } from "@/chat/slack/ids";
 import type { SlackMessageTs } from "@/chat/slack/timestamp";
 
 export interface SlackChannelMessage {
@@ -39,7 +36,7 @@ export interface SlackThreadReply {
 
 /** List channel history using Slack-native, pre-validated timestamp bounds. */
 export async function listChannelMessages(input: {
-  channelId: string;
+  channelId: SlackChannelId;
   limit: number;
   cursor?: string;
   oldest?: SlackMessageTs;
@@ -48,10 +45,7 @@ export async function listChannelMessages(input: {
   maxPages?: number;
 }): Promise<{ messages: SlackChannelMessage[]; nextCursor?: string }> {
   const client = getSlackClient();
-  const channelId = normalizeSlackConversationId(input.channelId);
-  if (!channelId) {
-    throw new Error("Slack channel history lookup requires a valid channel ID");
-  }
+  const channelId = input.channelId;
   const targetLimit = Math.max(1, Math.min(input.limit, 1000));
   const maxPages = Math.max(1, Math.min(input.maxPages ?? 5, 10));
   const messages: SlackChannelMessage[] = [];
@@ -92,17 +86,14 @@ export async function listChannelMessages(input: {
 
 /** Read replies from a Slack thread identified by a validated native thread timestamp. */
 export async function listThreadReplies(input: {
-  channelId: string;
+  channelId: SlackChannelId;
   threadTs: SlackMessageTs;
   limit?: number;
   maxPages?: number;
   targetMessageTs?: string[];
 }): Promise<SlackThreadReply[]> {
   const client = getSlackClient();
-  const channelId = normalizeSlackConversationId(input.channelId);
-  if (!channelId) {
-    throw new Error("Slack thread reply lookup requires a valid channel ID");
-  }
+  const channelId = input.channelId;
   const targetLimit = Math.max(1, Math.min(input.limit ?? 1000, 1000));
   const maxPages = Math.max(1, Math.min(input.maxPages ?? 10, 10));
   const pendingTargets = new Set(

--- a/packages/junior/src/chat/slack/client.ts
+++ b/packages/junior/src/chat/slack/client.ts
@@ -7,6 +7,10 @@ import {
   setSpanStatus,
   withSpan,
 } from "@/chat/logging";
+import {
+  parseSlackChannelReferenceId,
+  type SlackChannelId,
+} from "@/chat/slack/ids";
 import { getWorkspaceTeamId } from "@/chat/slack/workspace-context";
 
 // Slack canvas/list methods are not exposed by the current chat adapter public API,
@@ -230,21 +234,11 @@ function resolveSlackToken(): string {
   );
 }
 
+/** Normalize Junior Slack references to native Slack conversation IDs. */
 export function normalizeSlackConversationId(
   channelId: string | undefined,
-): string | undefined {
-  if (!channelId) return undefined;
-  const trimmed = channelId.trim();
-  if (!trimmed) return undefined;
-
-  if (!trimmed.startsWith("slack:")) {
-    return trimmed;
-  }
-
-  const parts = trimmed.split(":");
-  // Accept both "slack:C123" and "slack:C123:1700000000.000" and normalize
-  // to the canonical conversation ID expected by Slack Web API methods.
-  return parts[1]?.trim() || undefined;
+): SlackChannelId | undefined {
+  return parseSlackChannelReferenceId(channelId);
 }
 
 /**

--- a/packages/junior/src/chat/slack/context.ts
+++ b/packages/junior/src/chat/slack/context.ts
@@ -1,4 +1,5 @@
 import { toOptionalString } from "@/chat/coerce";
+import { parseSlackChannelId, type SlackChannelId } from "@/chat/slack/ids";
 import {
   parseSlackMessageTs,
   type SlackMessageTs,
@@ -12,7 +13,7 @@ function toTrimmedSlackString(value: unknown): string | undefined {
 /** Extract a channel ID and validated Slack timestamp from `slack:<channel>:<ts>`. */
 export function parseSlackThreadId(
   threadId: string | undefined,
-): { channelId: string; threadTs: SlackMessageTs } | undefined {
+): { channelId: SlackChannelId; threadTs: SlackMessageTs } | undefined {
   const normalizedThreadId = toTrimmedSlackString(threadId);
   if (!normalizedThreadId) {
     return undefined;
@@ -23,7 +24,7 @@ export function parseSlackThreadId(
     return undefined;
   }
 
-  const channelId = toTrimmedSlackString(parts[1]);
+  const channelId = parseSlackChannelId(parts[1]);
   const threadTs = parseSlackMessageTs(parts[2]);
   if (!channelId || !threadTs) {
     return undefined;
@@ -35,15 +36,15 @@ export function parseSlackThreadId(
 /** Resolve the Slack channel ID from a `slack:<channel>:<ts>` thread identifier. */
 export function resolveSlackChannelIdFromThreadId(
   threadId: string | undefined,
-): string | undefined {
+): SlackChannelId | undefined {
   return parseSlackThreadId(threadId)?.channelId;
 }
 
 /** Best-effort channel ID extraction from a raw Slack message payload. */
 export function resolveSlackChannelIdFromMessage(
   message: unknown,
-): string | undefined {
-  const messageChannelId = toTrimmedSlackString(
+): SlackChannelId | undefined {
+  const messageChannelId = parseSlackChannelId(
     (message as { channelId?: unknown }).channelId,
   );
   if (messageChannelId) {
@@ -52,7 +53,7 @@ export function resolveSlackChannelIdFromMessage(
 
   const raw = (message as { raw?: unknown }).raw;
   if (raw && typeof raw === "object") {
-    const rawChannel = toTrimmedSlackString(
+    const rawChannel = parseSlackChannelId(
       (raw as { channel?: unknown }).channel,
     );
     if (rawChannel) {

--- a/packages/junior/src/chat/slack/id-param.ts
+++ b/packages/junior/src/chat/slack/id-param.ts
@@ -1,0 +1,65 @@
+import { Type } from "@sinclair/typebox";
+import {
+  parseSlackChannelId,
+  parseSlackUserId,
+  type SlackChannelId,
+  type SlackUserId,
+} from "@/chat/slack/ids";
+
+type RequiredSlackChannelIdParamResult =
+  | { ok: true; value: SlackChannelId }
+  | { ok: false; error: string };
+
+type RequiredSlackUserIdParamResult =
+  | { ok: true; value: SlackUserId }
+  | { ok: false; error: string };
+
+// Tool schemas stay TypeBox strings for the model-facing contract; execution
+// parses those values into Zod-branded Slack IDs before provider calls.
+/** Define a model-facing Slack channel ID parameter. */
+export function slackChannelIdParam(description: string) {
+  return Type.String({
+    minLength: 1,
+    description,
+  });
+}
+
+/** Define a model-facing Slack user ID parameter. */
+export function slackUserIdParam(description: string) {
+  return Type.String({
+    minLength: 1,
+    description,
+  });
+}
+
+/** Parse a required tool input channel ID into a branded Slack channel ID. */
+export function parseRequiredSlackChannelIdParam(
+  field: string,
+  value: unknown,
+): RequiredSlackChannelIdParamResult {
+  const channelId = parseSlackChannelId(value);
+  if (channelId) {
+    return { ok: true, value: channelId };
+  }
+
+  return {
+    ok: false,
+    error: `Invalid \`${field}\` Slack channel ID. Use a Slack conversation ID like \`C123\`, \`G123\`, or \`D123\`.`,
+  };
+}
+
+/** Parse a required tool input user ID into a branded Slack user ID. */
+export function parseRequiredSlackUserIdParam(
+  field: string,
+  value: unknown,
+): RequiredSlackUserIdParamResult {
+  const userId = parseSlackUserId(value);
+  if (userId) {
+    return { ok: true, value: userId };
+  }
+
+  return {
+    ok: false,
+    error: `Invalid \`${field}\` Slack user ID. Use a Slack user ID like \`U123\` or \`W123\`.`,
+  };
+}

--- a/packages/junior/src/chat/slack/ids.ts
+++ b/packages/junior/src/chat/slack/ids.ts
@@ -1,9 +1,79 @@
-/** Return true when a value is a Slack workspace/team id. */
-export function isSlackTeamId(value: string): boolean {
-  return /^T[A-Z0-9]+$/.test(value);
+import { z } from "zod";
+import { parseSlackMessageTs } from "@/chat/slack/timestamp";
+
+// Slack-owned runtime boundaries parse raw strings into branded IDs here.
+// Exact ID parsers reject Junior reference strings; reference parsing stays
+// explicit for persisted `slack:<channel>` and `slack:<channel>:<ts>` values.
+const slackChannelIdSchema = z
+  .string()
+  .regex(/^[CDG][A-Z0-9]+$/)
+  .brand<"SlackChannelId">();
+
+const slackTeamIdSchema = z
+  .string()
+  .regex(/^T[A-Z0-9]+$/)
+  .brand<"SlackTeamId">();
+
+const slackUserIdSchema = z
+  .string()
+  .regex(/^[UW][A-Z0-9]+$/)
+  .brand<"SlackUserId">();
+
+export type SlackChannelId = z.output<typeof slackChannelIdSchema>;
+export type SlackTeamId = z.output<typeof slackTeamIdSchema>;
+export type SlackUserId = z.output<typeof slackUserIdSchema>;
+
+function slackChannelReferenceCandidate(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("slack:")) {
+    return trimmed;
+  }
+
+  const parts = trimmed.split(":");
+  if (parts.length === 2) {
+    return parts[1]?.trim() ?? "";
+  }
+  if (parts.length === 3 && parseSlackMessageTs(parts[2])) {
+    return parts[1]?.trim() ?? "";
+  }
+  return "";
 }
 
-/** Return true when a value is a Slack conversation id. */
-export function isSlackConversationId(value: string): boolean {
-  return /^(C|G|D)[A-Z0-9]+$/.test(value);
+/** Parse an exact Slack channel/conversation ID from untrusted input. */
+export function parseSlackChannelId(
+  value: unknown,
+): SlackChannelId | undefined {
+  if (typeof value !== "string") return undefined;
+  const parsed = slackChannelIdSchema.safeParse(value.trim());
+  return parsed.success ? parsed.data : undefined;
+}
+
+/** Parse a Slack channel ID from native IDs or Junior Slack reference strings. */
+export function parseSlackChannelReferenceId(
+  value: unknown,
+): SlackChannelId | undefined {
+  if (typeof value !== "string") return undefined;
+  const parsed = slackChannelIdSchema.safeParse(
+    slackChannelReferenceCandidate(value),
+  );
+  return parsed.success ? parsed.data : undefined;
+}
+
+/** Parse a Slack workspace/team ID from untrusted metadata. */
+export function parseSlackTeamId(value: unknown): SlackTeamId | undefined {
+  if (typeof value !== "string") return undefined;
+  const parsed = slackTeamIdSchema.safeParse(value.trim());
+  return parsed.success ? parsed.data : undefined;
+}
+
+/** Parse a Slack user ID from untrusted metadata. */
+export function parseSlackUserId(value: unknown): SlackUserId | undefined {
+  if (typeof value !== "string") return undefined;
+  const parsed = slackUserIdSchema.safeParse(value.trim());
+  return parsed.success ? parsed.data : undefined;
+}
+
+/** Return true when a value is exactly a Slack workspace/team id. */
+export function isSlackTeamId(value: string): value is SlackTeamId {
+  return value === value.trim() && slackTeamIdSchema.safeParse(value).success;
 }

--- a/packages/junior/src/chat/slack/outbound.ts
+++ b/packages/junior/src/chat/slack/outbound.ts
@@ -6,7 +6,7 @@ import {
   withSlackRetries,
 } from "@/chat/slack/client";
 import { normalizeSlackEmojiName } from "@/chat/slack/emoji";
-import { parseActorUserId } from "@/chat/requester";
+import { parseSlackUserId, type SlackChannelId } from "@/chat/slack/ids";
 import {
   parseSlackMessageTs,
   type SlackMessageTs,
@@ -14,7 +14,10 @@ import {
 
 const MAX_SLACK_MESSAGE_TEXT_CHARS = 40_000;
 
-function requireSlackConversationId(channelId: string, action: string): string {
+function requireSlackConversationId(
+  channelId: string,
+  action: string,
+): SlackChannelId {
   const normalized = normalizeSlackConversationId(channelId);
   if (!normalized) {
     throw new Error(`${action} requires a valid channel ID`);
@@ -54,7 +57,7 @@ function requireSlackMessageText(text: string, action: string): string {
 }
 
 async function getPermalinkBestEffort(args: {
-  channelId: string;
+  channelId: SlackChannelId;
   messageTs: SlackMessageTs;
 }): Promise<string | undefined> {
   try {
@@ -186,7 +189,7 @@ export async function postSlackEphemeralMessage(input: {
     input.channelId,
     "Slack ephemeral message posting",
   );
-  const userId = parseActorUserId(input.userId);
+  const userId = parseSlackUserId(input.userId);
   if (!userId) {
     throw new Error("Slack ephemeral message posting requires a user ID");
   }

--- a/packages/junior/src/chat/slack/tools/channel-access.ts
+++ b/packages/junior/src/chat/slack/tools/channel-access.ts
@@ -1,6 +1,6 @@
 import type { ConversationPrivacy } from "@/chat/conversation-privacy";
-import { normalizeSlackConversationId } from "@/chat/slack/client";
 import { getConversationStore } from "@/chat/db";
+import type { SlackChannelId, SlackTeamId } from "@/chat/slack/ids";
 
 /** Minimal persisted-visibility port for cross-conversation read gates. */
 export interface DestinationVisibilityReader {
@@ -24,20 +24,15 @@ export type SlackChannelReadAccess =
  * ids), so missing or private destinations fail closed.
  */
 export async function checkSlackChannelReadAccess(args: {
-  currentChannelIds: Array<string | undefined>;
+  currentChannelIds: Array<SlackChannelId | undefined>;
   store?: DestinationVisibilityReader;
-  targetChannelId: string;
-  teamId: string;
+  targetChannelId: SlackChannelId;
+  teamId: SlackTeamId;
 }): Promise<SlackChannelReadAccess> {
-  const target = normalizeSlackConversationId(args.targetChannelId);
-  if (!target) {
-    return { allowed: false, error: "Invalid Slack channel ID." };
-  }
-
-  const currentChannels = args.currentChannelIds
-    .map((channelId) => normalizeSlackConversationId(channelId))
-    .filter((channelId): channelId is string => Boolean(channelId));
-  if (currentChannels.includes(target)) {
+  const currentChannels = args.currentChannelIds.filter(
+    (channelId): channelId is SlackChannelId => Boolean(channelId),
+  );
+  if (currentChannels.includes(args.targetChannelId)) {
     return { allowed: true };
   }
 
@@ -45,7 +40,7 @@ export async function checkSlackChannelReadAccess(args: {
   const visibility = await store.getDestinationVisibility({
     provider: "slack",
     providerTenantId: args.teamId,
-    providerDestinationId: target,
+    providerDestinationId: args.targetChannelId,
   });
   if (visibility === "public") {
     return { allowed: true };

--- a/packages/junior/src/chat/slack/tools/channel-list-messages.ts
+++ b/packages/junior/src/chat/slack/tools/channel-list-messages.ts
@@ -1,10 +1,8 @@
 import { Type } from "@sinclair/typebox";
-import {
-  normalizeSlackConversationId,
-  SlackActionError,
-} from "@/chat/slack/client";
+import { SlackActionError } from "@/chat/slack/client";
 import { listChannelMessages } from "@/chat/slack/channel";
 import { parseSlackThreadId } from "@/chat/slack/context";
+import type { SlackChannelId } from "@/chat/slack/ids";
 import type { SlackMessageTs } from "@/chat/slack/timestamp";
 import {
   optionalSlackTimestampParam,
@@ -21,7 +19,7 @@ import type { SlackToolContext } from "@/chat/slack/tools/context";
 function normalizeRangeTimestamp(
   field: "oldest" | "latest",
   value: string | undefined,
-  targetChannelId: string,
+  targetChannelId: SlackChannelId,
 ):
   | { ok: true; value: SlackMessageTs | undefined }
   | { ok: false; error: string } {
@@ -44,10 +42,7 @@ function normalizeRangeTimestamp(
     ? parseSlackTimestampParam(field, threadId.threadTs)
     : undefined;
   if (threadId && threadTimestamp?.ok && threadTimestamp.value) {
-    const referenceChannelId = normalizeSlackConversationId(threadId.channelId);
-    const normalizedTargetChannelId =
-      normalizeSlackConversationId(targetChannelId);
-    if (referenceChannelId === normalizedTargetChannelId) {
+    if (threadId.channelId === targetChannelId) {
       return threadTimestamp;
     }
   }

--- a/packages/junior/src/chat/slack/tools/context.ts
+++ b/packages/junior/src/chat/slack/tools/context.ts
@@ -3,7 +3,7 @@ import type { SlackDestination } from "@sentry/junior-plugin-api";
 import type { SlackSource } from "@sentry/junior-plugin-api";
 import type { SlackRequester } from "@/chat/requester";
 import {
-  parseSlackChannelId,
+  parseSlackChannelReferenceId,
   parseSlackTeamId,
   type SlackChannelId,
   type SlackTeamId,
@@ -34,10 +34,12 @@ export function getSlackToolContext(
   if (context.destination.platform !== "slack") {
     throw new TypeError("Slack source requires a Slack destination");
   }
-  const destinationChannelId = parseSlackChannelId(
+  const destinationChannelId = parseSlackChannelReferenceId(
     context.destination.channelId,
   );
-  const sourceChannelId = parseSlackChannelId(context.source.channelId);
+  const sourceChannelId = parseSlackChannelReferenceId(
+    context.source.channelId,
+  );
   const teamId = parseSlackTeamId(context.source.teamId);
   if (!destinationChannelId || !sourceChannelId || !teamId) {
     return undefined;

--- a/packages/junior/src/chat/slack/tools/context.ts
+++ b/packages/junior/src/chat/slack/tools/context.ts
@@ -3,6 +3,12 @@ import type { SlackDestination } from "@sentry/junior-plugin-api";
 import type { SlackSource } from "@sentry/junior-plugin-api";
 import type { SlackRequester } from "@/chat/requester";
 import {
+  parseSlackChannelId,
+  parseSlackTeamId,
+  type SlackChannelId,
+  type SlackTeamId,
+} from "@/chat/slack/ids";
+import {
   parseSlackMessageTs,
   type SlackMessageTs,
 } from "@/chat/slack/timestamp";
@@ -11,11 +17,11 @@ export interface SlackToolContext {
   destination: SlackDestination;
   source: SlackSource;
   requester?: SlackRequester;
-  destinationChannelId: string;
+  destinationChannelId: SlackChannelId;
   messageTs?: SlackMessageTs;
-  sourceChannelId: string;
-  teamId: string;
-  threadTs?: string;
+  sourceChannelId: SlackChannelId;
+  teamId: SlackTeamId;
+  threadTs?: SlackMessageTs;
 }
 
 /** Resolve Slack-specific tool context from the active source/destination/requester. */
@@ -28,15 +34,24 @@ export function getSlackToolContext(
   if (context.destination.platform !== "slack") {
     throw new TypeError("Slack source requires a Slack destination");
   }
+  const destinationChannelId = parseSlackChannelId(
+    context.destination.channelId,
+  );
+  const sourceChannelId = parseSlackChannelId(context.source.channelId);
+  const teamId = parseSlackTeamId(context.source.teamId);
+  if (!destinationChannelId || !sourceChannelId || !teamId) {
+    return undefined;
+  }
+
   return {
     destination: context.destination,
     source: context.source,
     requester:
       context.requester?.platform === "slack" ? context.requester : undefined,
-    destinationChannelId: context.destination.channelId,
+    destinationChannelId,
     messageTs: parseSlackMessageTs(context.source.messageTs),
-    sourceChannelId: context.source.channelId,
-    teamId: context.source.teamId,
-    threadTs: context.source.threadTs,
+    sourceChannelId,
+    teamId,
+    threadTs: parseSlackMessageTs(context.source.threadTs),
   };
 }

--- a/packages/junior/src/chat/slack/tools/list/add-items.ts
+++ b/packages/junior/src/chat/slack/tools/list/add-items.ts
@@ -1,5 +1,10 @@
 import { addListItems } from "@/chat/slack/tools/list/api";
+import {
+  parseRequiredSlackUserIdParam,
+  slackUserIdParam,
+} from "@/chat/slack/id-param";
 import { tool } from "@/chat/tools/definition";
+import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 import { createOperationKey } from "@/chat/tools/idempotency";
 import type { ToolState } from "@/chat/tools/types";
 import { Type } from "@sinclair/typebox";
@@ -16,10 +21,9 @@ export function createSlackListAddItemsTool(state: ToolState) {
         description: "List item titles to create.",
       }),
       assignee_user_id: Type.Optional(
-        Type.String({
-          minLength: 1,
-          description: "Optional Slack user ID assigned to all created items.",
-        }),
+        slackUserIdParam(
+          "Optional Slack user ID assigned to all created items.",
+        ),
       ),
       due_date: Type.Optional(
         Type.String({
@@ -33,10 +37,18 @@ export function createSlackListAddItemsTool(state: ToolState) {
       if (!targetListId) {
         return { ok: false, error: "No active list found in artifact context" };
       }
+      const parsedAssigneeUserId =
+        assignee_user_id === undefined
+          ? undefined
+          : parseRequiredSlackUserIdParam("assignee_user_id", assignee_user_id);
+      if (parsedAssigneeUserId?.ok === false) {
+        throw new ToolInputError(parsedAssigneeUserId.error);
+      }
+
       const operationKey = createOperationKey("slackListAddItems", {
         list_id: targetListId,
         items,
-        assignee_user_id: assignee_user_id ?? null,
+        assignee_user_id: parsedAssigneeUserId?.value ?? null,
         due_date: due_date ?? null,
       });
       const cached = state.getOperationResult<{
@@ -56,7 +68,7 @@ export function createSlackListAddItemsTool(state: ToolState) {
         listId: targetListId,
         titles: items,
         listColumnMap: state.artifactState.listColumnMap,
-        assigneeUserId: assignee_user_id,
+        assigneeUserId: parsedAssigneeUserId?.value,
         dueDate: due_date,
       });
 

--- a/packages/junior/src/chat/slack/tools/list/api.ts
+++ b/packages/junior/src/chat/slack/tools/list/api.ts
@@ -4,6 +4,7 @@ import {
   getSlackClient,
   withSlackRetries,
 } from "@/chat/slack/client";
+import type { SlackUserId } from "@/chat/slack/ids";
 import type { ListColumnMap } from "@/chat/state/artifacts";
 
 type RichTextBlock = {
@@ -153,7 +154,7 @@ export async function addListItems(input: {
   listId: string;
   titles: string[];
   listColumnMap?: ListColumnMap;
-  assigneeUserId?: string;
+  assigneeUserId?: SlackUserId;
   dueDate?: string;
 }): Promise<{ createdItemIds: string[]; listColumnMap?: ListColumnMap }> {
   const client = getSlackClient();

--- a/packages/junior/src/chat/slack/tools/slack-message-url.ts
+++ b/packages/junior/src/chat/slack/tools/slack-message-url.ts
@@ -1,11 +1,12 @@
 /** Parse Slack archive URLs into structured message references. */
+import { parseSlackChannelId, type SlackChannelId } from "@/chat/slack/ids";
 import {
   parseSlackMessageTs,
   type SlackMessageTs,
 } from "@/chat/slack/timestamp";
 
 export interface SlackMessageReference {
-  channelId: string;
+  channelId: SlackChannelId;
   messageTs: SlackMessageTs;
   threadTs?: SlackMessageTs;
 }
@@ -64,7 +65,10 @@ export function parseSlackMessageReference(input: string): ParseResult {
     return { ok: false, error: "URL path does not match Slack archive format" };
   }
 
-  const channelId = pathMatch[1]!;
+  const channelId = parseSlackChannelId(pathMatch[1]);
+  if (!channelId) {
+    return { ok: false, error: "Invalid channel ID in URL" };
+  }
   const messageTs = parseSlackMessageTs(
     pTimestampToTs(pathMatch[2]!, pathMatch[3]!),
   );

--- a/packages/junior/src/chat/slack/tools/thread-read.ts
+++ b/packages/junior/src/chat/slack/tools/thread-read.ts
@@ -5,6 +5,10 @@ import {
   checkSlackChannelReadAccess,
   type DestinationVisibilityReader,
 } from "@/chat/slack/tools/channel-access";
+import {
+  parseRequiredSlackChannelIdParam,
+  slackChannelIdParam,
+} from "@/chat/slack/id-param";
 import { tool } from "@/chat/tools/definition";
 import { parseSlackMessageReference } from "@/chat/slack/tools/slack-message-url";
 import type { SlackToolContext } from "@/chat/slack/tools/context";
@@ -12,6 +16,7 @@ import {
   parseRequiredSlackTimestampParam,
   slackTimestampParam,
 } from "@/chat/slack/timestamp-param";
+import type { SlackChannelId } from "@/chat/slack/ids";
 import type { SlackMessageTs } from "@/chat/slack/timestamp";
 import type { SlackThreadReply } from "@/chat/slack/channel";
 import { renderSlackLegacyAttachmentText } from "@/chat/slack/legacy-attachments";
@@ -88,11 +93,9 @@ export function createSlackThreadReadTool(
         }),
       ),
       channel_id: Type.Optional(
-        Type.String({
-          minLength: 1,
-          description:
-            "Slack channel/conversation ID (e.g. C123). Use with `ts` as an alternative to `url`.",
-        }),
+        slackChannelIdParam(
+          "Slack channel/conversation ID (e.g. C123). Use with `ts` as an alternative to `url`.",
+        ),
       ),
       ts: Type.Optional(
         slackTimestampParam(
@@ -115,7 +118,7 @@ export function createSlackThreadReadTool(
       ),
     }),
     execute: async ({ url, channel_id, ts, limit, max_pages }) => {
-      let channelId: string;
+      let channelId: SlackChannelId;
       let messageTs: SlackMessageTs;
       let threadTs: SlackMessageTs | undefined;
 
@@ -132,7 +135,14 @@ export function createSlackThreadReadTool(
         if (!parsedTs.ok) {
           return { ok: false, error: parsedTs.error };
         }
-        channelId = channel_id;
+        const parsedChannelId = parseRequiredSlackChannelIdParam(
+          "channel_id",
+          channel_id,
+        );
+        if (!parsedChannelId.ok) {
+          return { ok: false, error: parsedChannelId.error };
+        }
+        channelId = parsedChannelId.value;
         messageTs = parsedTs.value;
       } else {
         return {

--- a/packages/junior/src/chat/slack/tools/user-lookup.ts
+++ b/packages/junior/src/chat/slack/tools/user-lookup.ts
@@ -5,6 +5,10 @@ import {
   lookupSlackUserByEmail,
   searchSlackUsers,
 } from "@/chat/slack/users";
+import {
+  parseRequiredSlackUserIdParam,
+  slackUserIdParam,
+} from "@/chat/slack/id-param";
 import { tool } from "@/chat/tools/definition";
 
 /** Create the tool that resolves Slack users by ID, handle, or email. */
@@ -15,11 +19,9 @@ export function createSlackUserLookupTool() {
     annotations: { readOnlyHint: true, destructiveHint: false },
     inputSchema: Type.Object({
       user_id: Type.Optional(
-        Type.String({
-          minLength: 1,
-          description:
-            "Slack user ID to look up (e.g. U039RR91S). Mutually exclusive with email and query.",
-        }),
+        slackUserIdParam(
+          "Slack user ID to look up (e.g. U039RR91S). Mutually exclusive with email and query.",
+        ),
       ),
       email: Type.Optional(
         Type.String({
@@ -83,10 +85,18 @@ export function createSlackUserLookupTool() {
 
       try {
         if (user_id) {
+          const parsedUserId = parseRequiredSlackUserIdParam(
+            "user_id",
+            user_id,
+          );
+          if (!parsedUserId.ok) {
+            return { ok: false, error: parsedUserId.error };
+          }
+
           return {
             ok: true,
             mode: "user_id",
-            user: await lookupSlackUserProfile(user_id),
+            user: await lookupSlackUserProfile(parsedUserId.value),
           };
         }
 

--- a/packages/junior/src/chat/slack/users.ts
+++ b/packages/junior/src/chat/slack/users.ts
@@ -1,4 +1,5 @@
 import { getSlackClient, withSlackRetries } from "@/chat/slack/client";
+import type { SlackUserId } from "@/chat/slack/ids";
 
 /** Normalized Slack user profile with custom fields from the Slack workspace. */
 export interface SlackUserProfile {
@@ -82,7 +83,7 @@ function normalizeUser(raw: SlackUserRaw): SlackUserProfile {
 
 /** Look up a Slack user by ID, returning the full profile including custom fields. */
 export async function lookupSlackUserProfile(
-  userId: string,
+  userId: SlackUserId,
 ): Promise<SlackUserProfile> {
   const client = getSlackClient();
   const result = await withSlackRetries(

--- a/packages/junior/src/chat/slack/vision-context.ts
+++ b/packages/junior/src/chat/slack/vision-context.ts
@@ -4,6 +4,7 @@ import type { completeText } from "@/chat/pi/client";
 import type { ThreadConversationState } from "@/chat/state/conversation";
 import { toOptionalString } from "@/chat/coerce";
 import { logInfo, logWarn } from "@/chat/logging";
+import { parseSlackChannelId, type SlackChannelId } from "@/chat/slack/ids";
 import {
   parseSlackMessageTs,
   type SlackMessageTs,
@@ -46,7 +47,7 @@ export interface VisionContextDeps {
   completeText: typeof completeText;
   downloadFile: (url: string) => Promise<Buffer>;
   listThreadReplies: (input: {
-    channelId: string;
+    channelId: SlackChannelId;
     threadTs: SlackMessageTs;
     limit?: number;
     maxPages?: number;
@@ -466,6 +467,10 @@ async function hydrateConversationVisionContextWithDeps(
   if (!context.channelId || !context.threadTs) {
     return;
   }
+  const channelId = parseSlackChannelId(context.channelId);
+  if (!channelId) {
+    return;
+  }
   const threadTs = parseSlackMessageTs(context.threadTs);
   if (!threadTs) {
     return;
@@ -489,7 +494,7 @@ async function hydrateConversationVisionContextWithDeps(
   let replies: VisionThreadReply[];
   try {
     replies = await deps.listThreadReplies({
-      channelId: context.channelId,
+      channelId,
       threadTs,
       limit: 1000,
       maxPages: 10,

--- a/packages/junior/tests/component/conversation-sql-store.test.ts
+++ b/packages/junior/tests/component/conversation-sql-store.test.ts
@@ -621,7 +621,7 @@ INSERT INTO junior_destinations (
           "historical-public-destination",
           "slack",
           "T999",
-          "C_LEGACY",
+          "C0LEGACY",
           "channel",
           "public",
           new Date(1_000).toISOString(),
@@ -636,7 +636,7 @@ INSERT INTO junior_destinations (
         store.getDestinationVisibility({
           provider: "slack",
           providerTenantId: "T999",
-          providerDestinationId: "C_LEGACY",
+          providerDestinationId: "C0LEGACY",
         }),
       ).resolves.toBe("private");
     } finally {

--- a/packages/junior/tests/fixtures/conversation-work.ts
+++ b/packages/junior/tests/fixtures/conversation-work.ts
@@ -20,7 +20,7 @@ export const SLACK_DESTINATION = {
   teamId: "T123",
   channelId: "C123",
 } as const satisfies Destination;
-export const SLACK_BOT_USER_ID = "U_BOT";
+export const SLACK_BOT_USER_ID = "U0BOT";
 export const SLACK_SIGNING_SECRET = "slack-signature-fixture";
 
 export interface ConversationQueueSendRecord {

--- a/packages/junior/tests/fixtures/slack-harness.ts
+++ b/packages/junior/tests/fixtures/slack-harness.ts
@@ -73,7 +73,7 @@ export function createTestMessage(args: {
   attachments?: Message["attachments"];
   raw?: Record<string, unknown>;
 }): Message {
-  const threadId = args.threadId ?? "slack:C_TEST:1700000000.000";
+  const threadId = args.threadId ?? "slack:C0TEST:1700000000.000";
   const threadParts = threadId.split(":");
   const inferredChannel = threadParts.length === 3 ? threadParts[1] : undefined;
   const inferredTs = threadParts.length === 3 ? threadParts[2] : undefined;
@@ -162,7 +162,7 @@ export function createTestThread(args: {
   runId?: string;
   threadTs?: string;
 }): TestThread {
-  const id = args.id ?? "slack:C_TEST:1700000000.000";
+  const id = args.id ?? "slack:C0TEST:1700000000.000";
   const channelId = args.channelId ?? toAdapterChannelId(id) ?? id;
   let stateData: Record<string, unknown> = { ...(args.state ?? {}) };
   const posts: unknown[] = [];

--- a/packages/junior/tests/fixtures/slack/factories/events.ts
+++ b/packages/junior/tests/fixtures/slack/factories/events.ts
@@ -1,4 +1,9 @@
-import { TEST_CHANNEL_ID, TEST_THREAD_TS, TEST_USER_ID, slackThreadId } from "./ids";
+import {
+  TEST_CHANNEL_ID,
+  TEST_THREAD_TS,
+  TEST_USER_ID,
+  slackThreadId,
+} from "./ids";
 
 /**
  * Behavior-event fixtures model the normalized Chat SDK handler payload shape used by
@@ -64,80 +69,95 @@ const DEFAULT_AUTHOR: SlackEventUser = {
   user_name: "testuser",
   full_name: "Test User",
   is_me: false,
-  is_bot: false
+  is_bot: false,
 };
 
-export function slackEventThread(input: Partial<SlackEventThreadFixture> = {}): SlackEventThreadFixture {
+export function slackEventThread(
+  input: Partial<SlackEventThreadFixture> = {},
+): SlackEventThreadFixture {
   const channelId = input.channel_id ?? TEST_CHANNEL_ID;
   const threadTs = input.thread_ts ?? TEST_THREAD_TS;
   return {
     id: input.id ?? slackThreadId(channelId, threadTs),
     channel_id: channelId,
-    thread_ts: threadTs
+    thread_ts: threadTs,
   };
 }
 
-export function slackEventMessage(input: Partial<SlackEventMessageFixture> = {}): SlackEventMessageFixture {
+export function slackEventMessage(
+  input: Partial<SlackEventMessageFixture> = {},
+): SlackEventMessageFixture {
   return {
     id: input.id ?? "m-test",
     text: input.text ?? "hello",
     is_mention: input.is_mention ?? false,
     author: {
       ...DEFAULT_AUTHOR,
-      ...(input.author ?? {})
-    }
+      ...(input.author ?? {}),
+    },
   };
 }
 
 // Normalized explicit-mention behavior fixture.
 // Chat SDK contract: https://chat-sdk.dev/docs/reference/chat/on-new-mention
-export function slackMentionEvent(input: {
-  thread?: Partial<SlackEventThreadFixture>;
-  message?: Partial<SlackEventMessageFixture>;
-} = {}): SlackMentionBehaviorEventFixture {
+export function slackMentionEvent(
+  input: {
+    thread?: Partial<SlackEventThreadFixture>;
+    message?: Partial<SlackEventMessageFixture>;
+  } = {},
+): SlackMentionBehaviorEventFixture {
   return {
     type: "new_mention",
     thread: slackEventThread(input.thread),
-    message: slackEventMessage({ ...input.message, is_mention: true })
+    message: slackEventMessage({ ...input.message, is_mention: true }),
   };
 }
 
 // Normalized "non-mention message in subscribed thread" behavior fixture.
 // Chat SDK contract: https://chat-sdk.dev/docs/reference/chat/on-subscribed-message
-export function slackSubscribedMessageEvent(input: {
-  thread?: Partial<SlackEventThreadFixture>;
-  message?: Partial<SlackEventMessageFixture>;
-} = {}): SlackSubscribedMessageBehaviorEventFixture {
+export function slackSubscribedMessageEvent(
+  input: {
+    thread?: Partial<SlackEventThreadFixture>;
+    message?: Partial<SlackEventMessageFixture>;
+  } = {},
+): SlackSubscribedMessageBehaviorEventFixture {
   return {
     type: "subscribed_message",
     thread: slackEventThread(input.thread),
-    message: slackEventMessage({ ...input.message, is_mention: input.message?.is_mention ?? false })
+    message: slackEventMessage({
+      ...input.message,
+      is_mention: input.message?.is_mention ?? false,
+    }),
   };
 }
 
 // Slack assistant lifecycle callback fixture.
 // Slack event reference: https://docs.slack.dev/reference/events/assistant_thread_started/
-export function slackAssistantThreadStartedEvent(input: {
-  thread?: Partial<SlackEventThreadFixture>;
-  user_id?: string;
-} = {}): SlackAssistantThreadStartedBehaviorEventFixture {
+export function slackAssistantThreadStartedEvent(
+  input: {
+    thread?: Partial<SlackEventThreadFixture>;
+    user_id?: string;
+  } = {},
+): SlackAssistantThreadStartedBehaviorEventFixture {
   return {
     type: "assistant_thread_started",
     thread: slackEventThread(input.thread),
-    user_id: input.user_id ?? TEST_USER_ID
+    user_id: input.user_id ?? TEST_USER_ID,
   };
 }
 
 // Slack assistant context callback fixture.
 // Slack event reference: https://docs.slack.dev/reference/events/assistant_thread_context_changed/
-export function slackAssistantContextChangedEvent(input: {
-  thread?: Partial<SlackEventThreadFixture>;
-  user_id?: string;
-} = {}): SlackAssistantContextChangedBehaviorEventFixture {
+export function slackAssistantContextChangedEvent(
+  input: {
+    thread?: Partial<SlackEventThreadFixture>;
+    user_id?: string;
+  } = {},
+): SlackAssistantContextChangedBehaviorEventFixture {
   return {
     type: "assistant_context_changed",
     thread: slackEventThread(input.thread),
-    user_id: input.user_id ?? TEST_USER_ID
+    user_id: input.user_id ?? TEST_USER_ID,
   };
 }
 
@@ -160,7 +180,9 @@ export interface SlackEventsApiEnvelope {
   };
 }
 
-function deriveChannelType(channel: string): "channel" | "group" | "im" | undefined {
+function deriveChannelType(
+  channel: string,
+): "channel" | "group" | "im" | undefined {
   if (channel.startsWith("D")) return "im";
   if (channel.startsWith("G")) return "group";
   if (channel.startsWith("C")) return "channel";
@@ -175,22 +197,24 @@ function deriveChannelType(channel: string): "channel" | "group" | "im" | undefi
  * - https://docs.slack.dev/reference/events/message.im/
  * - https://docs.slack.dev/reference/events/assistant_thread_started/
  */
-export function slackEventsApiEnvelope(input: {
-  eventType?: "app_mention" | "message";
-  user?: string;
-  text?: string;
-  channel?: string;
-  ts?: string;
-  eventTs?: string;
-  threadTs?: string;
-} = {}): SlackEventsApiEnvelope {
+export function slackEventsApiEnvelope(
+  input: {
+    eventType?: "app_mention" | "message";
+    user?: string;
+    text?: string;
+    channel?: string;
+    ts?: string;
+    eventTs?: string;
+    threadTs?: string;
+  } = {},
+): SlackEventsApiEnvelope {
   const ts = input.ts ?? TEST_THREAD_TS;
   const channel = input.channel ?? TEST_CHANNEL_ID;
   const channelType = deriveChannelType(channel);
 
   return {
     token: "test-token",
-    team_id: "T_TEST",
+    team_id: "T0TEST",
     api_app_id: "A_TEST",
     type: "event_callback",
     event_id: "Ev_TEST",
@@ -198,12 +222,12 @@ export function slackEventsApiEnvelope(input: {
     event: {
       type: input.eventType ?? "app_mention",
       user: input.user ?? TEST_USER_ID,
-      text: input.text ?? "<@U_APP> hello",
+      text: input.text ?? "<@U0APP> hello",
       channel,
       ts,
       event_ts: input.eventTs ?? ts,
       ...(channelType ? { channel_type: channelType } : {}),
-      ...(input.threadTs ? { thread_ts: input.threadTs } : {})
-    }
+      ...(input.threadTs ? { thread_ts: input.threadTs } : {}),
+    },
   };
 }

--- a/packages/junior/tests/fixtures/slack/factories/ids.ts
+++ b/packages/junior/tests/fixtures/slack/factories/ids.ts
@@ -1,7 +1,7 @@
-export const TEST_CHANNEL_ID = "C_TEST";
-export const TEST_DM_CHANNEL_ID = "D_TEST";
-export const TEST_USER_ID = "U_TEST";
-export const TEST_BOT_USER_ID = "U_BOT";
+export const TEST_CHANNEL_ID = "C0TEST";
+export const TEST_DM_CHANNEL_ID = "D0TEST";
+export const TEST_USER_ID = "U0TEST";
+export const TEST_BOT_USER_ID = "U0BOT";
 export const TEST_THREAD_TS = "1700000000.000";
 export const TEST_THREAD_ID = `slack:${TEST_CHANNEL_ID}:${TEST_THREAD_TS}`;
 export const TEST_MESSAGE_TS = "1700000000.100";

--- a/packages/junior/tests/integration/dashboard-reporting.test.ts
+++ b/packages/junior/tests/integration/dashboard-reporting.test.ts
@@ -724,7 +724,7 @@ describe("dashboard reporting", () => {
       }),
       ...Array.from({ length: 5_000 }, (_, index) =>
         indexedConversation({
-          conversationId: `slack:C_FILL:${index}`,
+          conversationId: `slack:C0FILL:${index}`,
           createdAtMs: startedAtMs + (index + 1) * 1000,
           lastActivityAtMs: startedAtMs + (index + 1) * 1000,
           requester: { fullName: "Filler" },

--- a/packages/junior/tests/integration/plugin-auth-runtime-slack.test.ts
+++ b/packages/junior/tests/integration/plugin-auth-runtime-slack.test.ts
@@ -186,7 +186,7 @@ describe("plugin auth runtime slack integration", () => {
   });
 
   it("does not park or deliver plugin auth links for bot-authored messages", async () => {
-    const threadId = "slack:C_PLUGIN_BOT:1700000000.000";
+    const threadId = "slack:C0PLUGINBOT:1700000000.000";
     const { createTestChatRuntime } = chatRuntimeModule!;
     const { slackRuntime } = createTestChatRuntime({
       services: {
@@ -211,7 +211,7 @@ describe("plugin auth runtime slack integration", () => {
     const destination = {
       platform: "slack" as const,
       teamId: "T123",
-      channelId: "C_PLUGIN_BOT",
+      channelId: "C0PLUGINBOT",
     };
     const thread = createTestThread({
       id: threadId,
@@ -248,7 +248,7 @@ describe("plugin auth runtime slack integration", () => {
         },
         raw: {
           bot_id: "B123456",
-          channel: "C_PLUGIN_BOT",
+          channel: "C0PLUGINBOT",
           team_id: "T123",
           ts: "1700000000.001",
           thread_ts: "1700000000.000",

--- a/packages/junior/tests/integration/slack-channel-tools.test.ts
+++ b/packages/junior/tests/integration/slack-channel-tools.test.ts
@@ -5,6 +5,7 @@ import { createSlackChannelPostMessageTool } from "@/chat/slack/tools/channel-po
 import { createSlackMessageAddReactionTool } from "@/chat/slack/tools/message-add-reaction";
 import type { SlackToolContext } from "@/chat/slack/tools/context";
 import type { ToolState } from "@/chat/tools/types";
+import { parseSlackChannelId, parseSlackTeamId } from "@/chat/slack/ids";
 import { parseSlackMessageTs } from "@/chat/slack/timestamp";
 import {
   chatGetPermalinkOk,
@@ -36,13 +37,49 @@ function createToolState(): ToolState {
   };
 }
 
+type ContextOverrides = Omit<
+  Partial<SlackToolContext>,
+  "destinationChannelId" | "sourceChannelId" | "teamId"
+> & {
+  destinationChannelId?: string;
+  sourceChannelId?: string;
+  teamId?: string;
+};
+
+function requireSlackChannelId(value: string) {
+  const channelId = parseSlackChannelId(value);
+  if (!channelId) {
+    throw new Error(`Invalid test Slack channel ID: ${value}`);
+  }
+  return channelId;
+}
+
+function requireSlackTeamId(value: string) {
+  const teamId = parseSlackTeamId(value);
+  if (!teamId) {
+    throw new Error(`Invalid test Slack team ID: ${value}`);
+  }
+  return teamId;
+}
+
 function createContext(
   _userText: string,
-  overrides: Partial<SlackToolContext> = {},
+  overrides: ContextOverrides = {},
 ): SlackToolContext {
-  const sourceChannelId = overrides.sourceChannelId ?? "C123";
+  const sourceChannelId = requireSlackChannelId(
+    overrides.sourceChannelId ?? "C123",
+  );
   const destinationChannelId =
-    overrides.destinationChannelId ?? sourceChannelId;
+    overrides.destinationChannelId !== undefined
+      ? requireSlackChannelId(overrides.destinationChannelId)
+      : sourceChannelId;
+  const teamId = requireSlackTeamId(overrides.teamId ?? "T123");
+  const {
+    sourceChannelId: _sourceChannelId,
+    destinationChannelId: _destinationChannelId,
+    teamId: _teamId,
+    ...rest
+  } = overrides;
   const messageTs = parseSlackMessageTs("1700000000.321");
   if (!messageTs) {
     throw new Error("Test message timestamp must be a valid Slack ts");
@@ -50,11 +87,11 @@ function createContext(
   return {
     destination: {
       platform: "slack",
-      teamId: "T123",
+      teamId,
       channelId: destinationChannelId,
     },
     source: createSlackSource({
-      teamId: "T123",
+      teamId,
       channelId: sourceChannelId,
       messageTs,
 
@@ -63,8 +100,8 @@ function createContext(
     destinationChannelId,
     messageTs,
     sourceChannelId,
-    teamId: "T123",
-    ...overrides,
+    teamId,
+    ...rest,
   };
 }
 
@@ -107,12 +144,12 @@ describe("slack channel tools", () => {
   it("uses assistant context channel for channel delivery tools in DM turns", async () => {
     const context = createContext("share this in the current channel", {
       sourceChannelId: "D123",
-      destinationChannelId: "C_SHARED",
+      destinationChannelId: "C0SHARED",
     });
     queueSlackApiResponse("chat.postMessage", {
       body: chatPostMessageOk({
         ts: "1700000000.112",
-        channel: "C_SHARED",
+        channel: "C0SHARED",
       }),
     });
     queueSlackApiResponse("chat.getPermalink", {
@@ -137,13 +174,13 @@ describe("slack channel tools", () => {
     expect(
       getCapturedSlackApiCalls("chat.postMessage")[0]?.params,
     ).toMatchObject({
-      channel: "C_SHARED",
+      channel: "C0SHARED",
       text: "Shared update",
     });
     expect(
       getCapturedSlackApiCalls("conversations.history")[0]?.params,
     ).toMatchObject({
-      channel: "C_SHARED",
+      channel: "C0SHARED",
     });
   });
 
@@ -297,7 +334,7 @@ describe("slack channel tools", () => {
     );
 
     const result = await executeTool(tool, {
-      oldest: "slack:C_OTHER:1710000000.000000",
+      oldest: "slack:C0OTHER:1710000000.000000",
     });
 
     expect(result).toEqual({

--- a/packages/junior/tests/integration/slack-file-upload.test.ts
+++ b/packages/junior/tests/integration/slack-file-upload.test.ts
@@ -21,7 +21,7 @@ describe("uploadFilesToThread", () => {
   it("rejects empty file batches before calling Slack", async () => {
     await expect(
       uploadFilesToThread({
-        channelId: "C-test",
+        channelId: "C0TEST",
         threadTs: "1700000000.000",
         files: [],
       }),
@@ -54,7 +54,7 @@ describe("uploadFilesToThread", () => {
     };
 
     await uploadFilesToThread({
-      channelId: "C-test",
+      channelId: "C0TEST",
       threadTs: "1700000000.000",
       files: [testFile],
     });
@@ -77,7 +77,7 @@ describe("uploadFilesToThread", () => {
     );
     expect(completeCalls).toHaveLength(1);
     expect(completeCalls[0]?.params).toMatchObject({
-      channel_id: "C-test",
+      channel_id: "C0TEST",
       thread_ts: "1700000000.000",
     });
     expect(completeCalls[0]?.params.files).toEqual([
@@ -113,7 +113,7 @@ describe("uploadFilesToThread", () => {
     ];
 
     await uploadFilesToThread({
-      channelId: "C-multi",
+      channelId: "C0MULTI",
       threadTs: "1700000001.000",
       files,
     });
@@ -139,7 +139,7 @@ describe("uploadFilesToThread", () => {
     );
     expect(completeCalls).toHaveLength(1);
     expect(completeCalls[0]?.params).toMatchObject({
-      channel_id: "C-multi",
+      channel_id: "C0MULTI",
       thread_ts: "1700000001.000",
     });
     expect(completeCalls[0]?.params.files).toEqual([
@@ -163,7 +163,7 @@ describe("uploadFilesToThread", () => {
     });
 
     await uploadFilesToThread({
-      channelId: "C-retry",
+      channelId: "C0RETRY",
       threadTs: "1700000002.000",
       files: [{ data: Buffer.from("retry-data"), filename: "retry.png" }],
     });
@@ -192,7 +192,7 @@ describe("uploadFilesToThread", () => {
 
     await expect(
       uploadFilesToThread({
-        channelId: "C-scope",
+        channelId: "C0SCOPE",
         threadTs: "1700000003.000",
         files: [{ data: Buffer.from("scope-data"), filename: "scope.png" }],
       }),

--- a/packages/junior/tests/integration/slack-schedule-tools.test.ts
+++ b/packages/junior/tests/integration/slack-schedule-tools.test.ts
@@ -403,7 +403,7 @@ describe("Slack schedule tools", () => {
         id: "sched_bad_destination",
         destination: {
           platform: "slack",
-          teamId: "D_BAD_TEAM",
+          teamId: "0BADTEAM",
           channelId: "D123",
         },
       }),

--- a/packages/junior/tests/integration/slack-server.test.ts
+++ b/packages/junior/tests/integration/slack-server.test.ts
@@ -26,7 +26,7 @@ describe("Slack MSW server", () => {
         "content-type": "application/x-www-form-urlencoded",
       },
       body: new URLSearchParams({
-        channel: "C_TEST",
+        channel: "C0TEST",
         text: "hello",
       }).toString(),
     });
@@ -46,7 +46,7 @@ describe("Slack MSW server", () => {
           "content-type": "application/x-www-form-urlencoded",
         },
         body: new URLSearchParams({
-          channel_id: "slack:D_TEST",
+          channel_id: "slack:D0TEST",
           thread_ts: "1700000000.100",
           status: "Thinking …",
         }).toString(),

--- a/packages/junior/tests/integration/slack-thread-read.test.ts
+++ b/packages/junior/tests/integration/slack-thread-read.test.ts
@@ -3,6 +3,7 @@ import { createSlackSource } from "@sentry/junior-plugin-api";
 import { createSlackThreadReadTool } from "@/chat/slack/tools/thread-read";
 import type { DestinationVisibilityReader } from "@/chat/slack/tools/channel-access";
 import type { SlackToolContext } from "@/chat/slack/tools/context";
+import { parseSlackChannelId, parseSlackTeamId } from "@/chat/slack/ids";
 import { conversationsRepliesPage } from "../fixtures/slack/factories/api";
 import {
   getCapturedSlackApiCalls,
@@ -10,30 +11,64 @@ import {
   queueSlackApiResponse,
 } from "../msw/handlers/slack-api";
 
-function createContext(
-  overrides: Partial<SlackToolContext> = {},
-): SlackToolContext {
-  const sourceChannelId = overrides.sourceChannelId ?? "C_CURRENT";
+type ContextOverrides = Omit<
+  Partial<SlackToolContext>,
+  "destinationChannelId" | "sourceChannelId" | "teamId"
+> & {
+  destinationChannelId?: string;
+  sourceChannelId?: string;
+  teamId?: string;
+};
+
+function requireSlackChannelId(value: string) {
+  const channelId = parseSlackChannelId(value);
+  if (!channelId) {
+    throw new Error(`Invalid test Slack channel ID: ${value}`);
+  }
+  return channelId;
+}
+
+function requireSlackTeamId(value: string) {
+  const teamId = parseSlackTeamId(value);
+  if (!teamId) {
+    throw new Error(`Invalid test Slack team ID: ${value}`);
+  }
+  return teamId;
+}
+
+function createContext(overrides: ContextOverrides = {}): SlackToolContext {
+  const sourceChannelId = requireSlackChannelId(
+    overrides.sourceChannelId ?? "C0CURRENT",
+  );
   const destinationChannelId =
-    overrides.destinationChannelId ?? sourceChannelId;
+    overrides.destinationChannelId !== undefined
+      ? requireSlackChannelId(overrides.destinationChannelId)
+      : sourceChannelId;
+  const teamId = requireSlackTeamId(overrides.teamId ?? "T123");
+  const {
+    sourceChannelId: _sourceChannelId,
+    destinationChannelId: _destinationChannelId,
+    teamId: _teamId,
+    ...rest
+  } = overrides;
   return {
     destination: overrides.destination ?? {
       platform: "slack",
-      teamId: "T123",
+      teamId,
       channelId: destinationChannelId,
     },
     source:
       overrides.source ??
       createSlackSource({
-        teamId: "T123",
+        teamId,
         channelId: sourceChannelId,
 
         type: "priv",
       }),
     destinationChannelId,
     sourceChannelId,
-    teamId: "T123",
-    ...overrides,
+    teamId,
+    ...rest,
   };
 }
 
@@ -54,7 +89,7 @@ function persistedPublicChannels(
 }
 
 function createTool(
-  overrides: Partial<SlackToolContext> = {},
+  overrides: ContextOverrides = {},
   publicChannels: string[] = [],
 ) {
   return createSlackThreadReadTool(createContext(overrides), {
@@ -171,15 +206,15 @@ describe("slackThreadRead", () => {
       }),
     });
 
-    const tool = createTool({}, ["C_MANUAL"]);
+    const tool = createTool({}, ["C0MANUAL"]);
     const result = await executeTool(tool, {
-      channel_id: "C_MANUAL",
+      channel_id: "C0MANUAL",
       ts: "1700000000.500000",
     });
 
     expect(result).toMatchObject({
       ok: true,
-      channel_id: "C_MANUAL",
+      channel_id: "C0MANUAL",
       count: 1,
     });
     expect(result.messages[0].text).toBe("standalone message");
@@ -200,15 +235,15 @@ describe("slackThreadRead", () => {
       }),
     });
 
-    const tool = createTool({ sourceChannelId: "G_PRIVATE" });
+    const tool = createTool({ sourceChannelId: "G0PRIVATE" });
     const result = await executeTool(tool, {
-      channel_id: "G_PRIVATE",
+      channel_id: "G0PRIVATE",
       ts: "1700000000.100000",
     });
 
     expect(result).toMatchObject({
       ok: true,
-      channel_id: "G_PRIVATE",
+      channel_id: "G0PRIVATE",
       count: 1,
     });
 
@@ -233,39 +268,39 @@ describe("slackThreadRead", () => {
     });
 
     const tool = createTool({
-      sourceChannelId: "D_DM",
-      destinationChannelId: "G_PRIVATE",
+      sourceChannelId: "D0DM",
+      destinationChannelId: "G0PRIVATE",
     });
     const result = await executeTool(tool, {
-      channel_id: "G_PRIVATE",
+      channel_id: "G0PRIVATE",
       ts: "1700000000.100000",
     });
 
     expect(result).toMatchObject({
       ok: true,
-      channel_id: "G_PRIVATE",
+      channel_id: "G0PRIVATE",
       count: 1,
     });
     expect(getCapturedSlackApiCalls("conversations.replies")).toHaveLength(1);
   });
 
   it("blocks reading a private group channel from a DM conversation without assistant context", async () => {
-    const tool = createTool({ sourceChannelId: "D_DM" });
+    const tool = createTool({ sourceChannelId: "D0DM" });
     const result = await executeTool(tool, {
-      channel_id: "G_PRIVATE",
+      channel_id: "G0PRIVATE",
       ts: "1700000000.100000",
     });
 
     expect(result).toMatchObject({
       ok: false,
-      channel_id: "G_PRIVATE",
+      channel_id: "G0PRIVATE",
     });
     expect(result.error).toContain("current conversation");
     expect(getCapturedSlackApiCalls("conversations.replies")).toHaveLength(0);
   });
 
   it("blocks reading a private channel that is not the current channel", async () => {
-    const tool = createTool({ sourceChannelId: "C_CURRENT" });
+    const tool = createTool({ sourceChannelId: "C0CURRENT" });
     const result = await executeTool(tool, {
       url: "https://sentry.slack.com/archives/G0OTHER/p1700000000100000",
     });
@@ -285,20 +320,20 @@ describe("slackThreadRead", () => {
   it("blocks reading a DM channel that is not the current channel", async () => {
     const tool = createTool();
     const result = await executeTool(tool, {
-      channel_id: "D_SOMEONE",
+      channel_id: "D0SOMEONE",
       ts: "1700000000.100000",
     });
 
     expect(result).toMatchObject({
       ok: false,
-      channel_id: "D_SOMEONE",
+      channel_id: "D0SOMEONE",
     });
     expect(result.error).toContain("current conversation");
     expect(getCapturedSlackApiCalls("conversations.replies")).toHaveLength(0);
   });
 
   it("blocks reading a C-prefixed channel without persisted public visibility", async () => {
-    const tool = createTool({ sourceChannelId: "C_CURRENT" });
+    const tool = createTool({ sourceChannelId: "C0CURRENT" });
     const result = await executeTool(tool, {
       url: "https://sentry.slack.com/archives/C0UNCONFIRMED/p1700000000100000",
     });
@@ -317,15 +352,15 @@ describe("slackThreadRead", () => {
       error: "not_in_channel",
     });
 
-    const tool = createTool({}, ["C_FLAKY"]);
+    const tool = createTool({}, ["C0FLAKY"]);
     const result = await executeTool(tool, {
-      channel_id: "C_FLAKY",
+      channel_id: "C0FLAKY",
       ts: "1700000000.100000",
     });
 
     expect(result).toMatchObject({
       ok: false,
-      channel_id: "C_FLAKY",
+      channel_id: "C0FLAKY",
       slack_error: "not_in_channel",
     });
     expect(result.error).toContain("Could not read this Slack thread");
@@ -403,9 +438,9 @@ describe("slackThreadRead", () => {
       }),
     });
 
-    const tool = createTool({}, ["C_PAGED"]);
+    const tool = createTool({}, ["C0PAGED"]);
     const result = await executeTool(tool, {
-      channel_id: "C_PAGED",
+      channel_id: "C0PAGED",
       ts: "1700000000.000000",
     });
 

--- a/packages/junior/tests/integration/slack-user-lookup.test.ts
+++ b/packages/junior/tests/integration/slack-user-lookup.test.ts
@@ -67,20 +67,20 @@ describe("slackUserLookup", () => {
     it("returns user without custom fields when none are set", async () => {
       queueSlackApiResponse("users.info", {
         body: usersInfoOk({
-          userId: "U_BASIC",
+          userId: "U0BASIC",
           userName: "basic",
           realName: "Basic User",
         }),
       });
 
       const tool = createSlackUserLookupTool();
-      const result = await executeTool(tool, { user_id: "U_BASIC" });
+      const result = await executeTool(tool, { user_id: "U0BASIC" });
 
       expect(result).toMatchObject({
         ok: true,
         mode: "user_id",
         user: {
-          id: "U_BASIC",
+          id: "U0BASIC",
           name: "basic",
           real_name: "Basic User",
           is_bot: false,
@@ -93,7 +93,7 @@ describe("slackUserLookup", () => {
       queueSlackApiError("users.info", { error: "user_not_found" });
 
       const tool = createSlackUserLookupTool();
-      const result = await executeTool(tool, { user_id: "U_NONEXISTENT" });
+      const result = await executeTool(tool, { user_id: "U0NONEXISTENT" });
 
       expect(result.ok).toBe(false);
       expect(result.slack_error).toBe("user_not_found");
@@ -104,7 +104,7 @@ describe("slackUserLookup", () => {
     it("finds a user by email", async () => {
       queueSlackApiResponse("users.lookupByEmail", {
         body: usersInfoOk({
-          userId: "U_EMAIL",
+          userId: "U0EMAIL",
           userName: "emailuser",
           realName: "Email User",
           email: "emailuser@sentry.io",
@@ -118,7 +118,7 @@ describe("slackUserLookup", () => {
         ok: true,
         mode: "email",
         user: {
-          id: "U_EMAIL",
+          id: "U0EMAIL",
           name: "emailuser",
           email: "emailuser@sentry.io",
         },
@@ -344,15 +344,15 @@ describe("slackUserLookup", () => {
         {},
         {
           source: createSlackSource({
-            teamId: "T_TEST",
-            channelId: "C_TEST",
+            teamId: "T0TEST",
+            channelId: "C0TEST",
 
             type: "priv",
           }),
           destination: {
             platform: "slack",
-            teamId: "T_TEST",
-            channelId: "C_TEST",
+            teamId: "T0TEST",
+            channelId: "C0TEST",
           },
           egress: {
             async fetch() {
@@ -372,7 +372,7 @@ describe("slackUserLookup", () => {
     it("returns custom profile fields as-is", async () => {
       queueSlackApiResponse("users.info", {
         body: usersInfoOk({
-          userId: "U_GH",
+          userId: "U0GH",
           userName: "untitaker",
           realName: "Markus Unterwaditzer",
           fields: {
@@ -386,7 +386,7 @@ describe("slackUserLookup", () => {
       });
 
       const tool = createSlackUserLookupTool();
-      const result = await executeTool(tool, { user_id: "U_GH" });
+      const result = await executeTool(tool, { user_id: "U0GH" });
 
       expect(result.user.profile_fields).toHaveLength(1);
       expect(result.user.profile_fields[0]).toMatchObject({

--- a/packages/junior/tests/integration/slack/app-home-webhook.test.ts
+++ b/packages/junior/tests/integration/slack/app-home-webhook.test.ts
@@ -18,7 +18,7 @@ import { slackApiOutbox } from "../../fixtures/slack-api-outbox";
 import { createSlackWebhookTestClient } from "../../fixtures/slack/webhook-client";
 
 const SIGNING_SECRET = "test-signing-secret";
-const BOT_USER_ID = "U_BOT";
+const BOT_USER_ID = "U0BOT";
 const ORIGINAL_ENV = { ...process.env };
 
 function createSlackAdapter() {

--- a/packages/junior/tests/integration/slack/assistant-context-canvas-routing.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-context-canvas-routing.test.ts
@@ -74,19 +74,19 @@ describe("Slack behavior: assistant context canvas routing", () => {
     });
 
     const thread = createTestThread({
-      id: "slack:D_DM_THREAD:1700007100.000",
+      id: "slack:D0DMTHREAD:1700007100.000",
       state: {
         artifacts: {
-          assistantContextChannelId: "C_SHARED_CONTEXT",
+          assistantContextChannelId: "C0SHAREDCONTEXT",
         },
       },
     });
     const message = createTestMessage({
       id: "m-assistant-context-canvas-1",
-      text: "<@U_APP> publish this as a shared canvas",
+      text: "<@U0APP> publish this as a shared canvas",
       isMention: true,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
     });
 
     await slackRuntime.handleNewMention(thread, message, {
@@ -109,7 +109,7 @@ describe("Slack behavior: assistant context canvas routing", () => {
     expect(accessCalls[0]?.params).toMatchObject({
       canvas_id: "F_SHARED_CANVAS",
       access_level: "write",
-      channel_ids: ["C_SHARED_CONTEXT"],
+      channel_ids: ["C0SHAREDCONTEXT"],
     });
 
     expect(

--- a/packages/junior/tests/integration/slack/assistant-context-channel-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-context-channel-behavior.test.ts
@@ -42,25 +42,25 @@ describe("Slack behavior: assistant context channel routing", () => {
     });
 
     const thread = createTestThread({
-      id: "slack:D_DM_THREAD:1700007000.000",
+      id: "slack:D0DMTHREAD:1700007000.000",
       state: {
         artifacts: {
-          assistantContextChannelId: "C_SHARED_CONTEXT",
+          assistantContextChannelId: "C0SHAREDCONTEXT",
         },
       },
     });
     const message = createTestMessage({
       id: "m-assistant-context-1",
-      text: "<@U_APP> create a shared canvas update",
+      text: "<@U0APP> create a shared canvas update",
       isMention: true,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
     });
 
     await slackRuntime.handleNewMention(thread, message, {
       destination: createTestDestination(thread),
     });
 
-    expect(capturedToolChannelIds).toEqual(["C_SHARED_CONTEXT"]);
+    expect(capturedToolChannelIds).toEqual(["C0SHAREDCONTEXT"]);
   });
 });

--- a/packages/junior/tests/integration/slack/assistant-lifecycle-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-lifecycle-behavior.test.ts
@@ -18,15 +18,15 @@ describe("Slack behavior: assistant lifecycle", () => {
     const { slackRuntime } = createTestChatRuntime({ slackAdapter });
 
     await slackRuntime.handleAssistantThreadStarted({
-      threadId: "slack:C_LIFECYCLE:1700006000.000",
-      channelId: "C_LIFECYCLE",
+      threadId: "slack:C0LIFECYCLE:1700006000.000",
+      channelId: "C0LIFECYCLE",
       threadTs: "1700006000.000",
-      userId: "U_TEST",
+      userId: "U0TEST",
     });
 
     expect(slackAdapter.titleCalls).toEqual([
       {
-        channelId: "C_LIFECYCLE",
+        channelId: "C0LIFECYCLE",
         threadTs: "1700006000.000",
         title: "Junior",
       },
@@ -40,12 +40,12 @@ describe("Slack behavior: assistant lifecycle", () => {
     const { slackRuntime } = createTestChatRuntime({ slackAdapter });
 
     await slackRuntime.handleAssistantContextChanged({
-      threadId: "slack:C_LIFECYCLE:1700006000.000",
-      channelId: "C_LIFECYCLE",
+      threadId: "slack:C0LIFECYCLE:1700006000.000",
+      channelId: "C0LIFECYCLE",
       threadTs: "1700006000.000",
-      userId: "U_TEST",
+      userId: "U0TEST",
       context: {
-        channelId: "C_CONTEXT",
+        channelId: "C0CONTEXT",
       },
     });
 
@@ -57,7 +57,7 @@ describe("Slack behavior: assistant lifecycle", () => {
   it("persists the assistant context channel without replacing artifacts", async () => {
     await disconnectStateAdapter();
 
-    const threadId = "slack:C_LIFECYCLE:1700006001.000";
+    const threadId = "slack:C0LIFECYCLE:1700006001.000";
     await persistThreadStateById(threadId, {
       artifacts: {
         lastCanvasId: "canvas-1",
@@ -72,18 +72,18 @@ describe("Slack behavior: assistant lifecycle", () => {
 
     await slackRuntime.handleAssistantContextChanged({
       threadId,
-      channelId: "C_LIFECYCLE",
+      channelId: "C0LIFECYCLE",
       threadTs: "1700006001.000",
-      userId: "U_TEST",
+      userId: "U0TEST",
       context: {
-        channelId: "slack:C_CONTEXT",
+        channelId: "slack:C0CONTEXT",
       },
     });
 
     const artifacts = coerceThreadArtifactsState(
       await getPersistedThreadState(threadId),
     );
-    expect(artifacts.assistantContextChannelId).toBe("C_CONTEXT");
+    expect(artifacts.assistantContextChannelId).toBe("C0CONTEXT");
     expect(artifacts.lastCanvasId).toBe("canvas-1");
     expect(artifacts.listColumnMap?.titleColumnId).toBe("title-column");
   });

--- a/packages/junior/tests/integration/slack/assistant-lifecycle-contract.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-lifecycle-contract.test.ts
@@ -21,7 +21,7 @@ describe("Slack contract: assistant lifecycle delivery", () => {
   it("normalizes adapter-scoped channel ids before assistant lifecycle API calls", async () => {
     const slack = createJuniorSlackAdapter({
       botToken: "xoxb-test",
-      botUserId: "U_BOT",
+      botUserId: "U0BOT",
       signingSecret: "test-signing-secret",
     });
     const slackRuntime = createSlackRuntime({
@@ -32,7 +32,7 @@ describe("Slack contract: assistant lifecycle delivery", () => {
       threadId: `slack:${DM_CHANNEL_ID}:${DM_THREAD_TS}`,
       channelId: `slack:${DM_CHANNEL_ID}`,
       threadTs: DM_THREAD_TS,
-      userId: "U_TEST",
+      userId: "U0TEST",
     });
 
     expect(getCapturedSlackApiCalls("assistant.threads.setTitle")).toEqual([

--- a/packages/junior/tests/integration/slack/assistant-status-auth-contract.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-status-auth-contract.test.ts
@@ -14,7 +14,7 @@ import {
 const SIGNING_SECRET = "test-signing-secret";
 const DEFAULT_BOT_TOKEN = "xoxb-default";
 const TEAM_BOT_TOKEN = "xoxb-team";
-const BOT_USER_ID = "U_BOT";
+const BOT_USER_ID = "U0BOT";
 const DM_CHANNEL_ID = "D12345";
 const THREAD_TS = "1700000000.000001";
 const INITIAL_LOADING_MESSAGE = "Consulting the orb";

--- a/packages/junior/tests/integration/slack/assistant-thread-contract.test.ts
+++ b/packages/junior/tests/integration/slack/assistant-thread-contract.test.ts
@@ -17,7 +17,7 @@ import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import { flattenAgentRunRequestForTest } from "../../fixtures/agent-runner";
 
 const SIGNING_SECRET = "test-signing-secret";
-const BOT_USER_ID = "U_BOT";
+const BOT_USER_ID = "U0BOT";
 const DM_CHANNEL_ID = "D12345";
 const DM_THREAD_TS = "1700000000.000001";
 const CHANNEL_ID = "C12345";
@@ -249,7 +249,7 @@ describe("Slack contract: assistant-thread delivery", () => {
     const waitUntil = slackWebhookClient.waitUntil();
 
     const response = await handleChatSdkPlatformWebhook(
-      createChannelMentionRequest("<@U_BOT> run a command"),
+      createChannelMentionRequest("<@U0BOT> run a command"),
       "slack",
       waitUntil.fn,
       bot,

--- a/packages/junior/tests/integration/slack/attachment-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/attachment-behavior.test.ts
@@ -93,13 +93,13 @@ describe("Slack behavior: attachment handling", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700004000.000" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700004000.000" });
     const message = createTestMessage({
       id: "m-attachment-1",
-      text: "<@U_APP> summarize this chart",
+      text: "<@U0APP> summarize this chart",
       isMention: true,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
       attachments: [
         {
           type: "image",
@@ -154,13 +154,13 @@ describe("Slack behavior: attachment handling", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700004001.000" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700004001.000" });
     const message = createTestMessage({
       id: "m-attachment-2",
-      text: "<@U_APP> what does this screenshot mean?",
+      text: "<@U0APP> what does this screenshot mean?",
       isMention: true,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
       attachments: [
         {
           type: "image",

--- a/packages/junior/tests/integration/slack/attachment-media-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/attachment-media-behavior.test.ts
@@ -108,14 +108,14 @@ describe("Slack behavior: mixed attachment media", () => {
     );
 
     const thread = createTestThread({
-      id: "slack:C_BEHAVIOR:1700004010.000",
+      id: "slack:C0BEHAVIOR:1700004010.000",
     });
     const message = createTestMessage({
       id: "m-attachment-mixed-1",
-      text: "<@U_APP> summarize these files",
+      text: "<@U0APP> summarize these files",
       isMention: true,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
       attachments: [
         {
           type: "image",
@@ -207,13 +207,13 @@ describe("Slack behavior: mixed attachment media", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700004011.000" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700004011.000" });
     const message = createTestMessage({
       id: "m-attachment-mixed-2",
-      text: "<@U_APP> summarize these files",
+      text: "<@U0APP> summarize these files",
       isMention: true,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
       attachments: [
         {
           type: "image",
@@ -278,13 +278,13 @@ describe("Slack behavior: mixed attachment media", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700004012.000" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700004012.000" });
     const message = createTestMessage({
       id: "m-attachment-mixed-3",
-      text: "<@U_APP> what about this image?",
+      text: "<@U0APP> what about this image?",
       isMention: true,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
       attachments: [
         {
           type: "image",

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -199,13 +199,13 @@ describe("bot handlers (integration)", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_INT:1700000000.000" });
+    const thread = createTestThread({ id: "slack:C0INT:1700000000.000" });
 
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "msg-new-mention",
-        threadId: "slack:C_INT:1700000000.000",
+        threadId: "slack:C0INT:1700000000.000",
         text: "hey bot",
         isMention: true,
       }),
@@ -228,13 +228,13 @@ describe("bot handlers (integration)", () => {
     });
     expect(hasReply).toBe(true);
     expect(scheduleSessionCompletedPluginTasks).toHaveBeenCalledWith({
-      conversationId: "slack:C_INT:1700000000.000",
+      conversationId: "slack:C0INT:1700000000.000",
       sessionId: "turn_msg-new-mention",
     });
   });
 
   it("does not replay a message that already has a delivered reply", async () => {
-    const conversationId = "slack:C_REPLAY:1700000000.000";
+    const conversationId = "slack:C0REPLAY:1700000000.000";
     const executeAgentRun = vi.fn();
     const { slackRuntime } = createRuntime({
       services: {
@@ -350,13 +350,13 @@ describe("bot handlers (integration)", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_SUB:1700000000.000" });
+    const thread = createTestThread({ id: "slack:C0SUB:1700000000.000" });
 
     await slackRuntime.handleSubscribedMessage(
       thread,
       createTestMessage({
         id: "msg-sub-mention",
-        threadId: "slack:C_SUB:1700000000.000",
+        threadId: "slack:C0SUB:1700000000.000",
         text: "<@UBOT> check this",
         isMention: true,
       }),
@@ -386,13 +386,13 @@ describe("bot handlers (integration)", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_SKIP:1700000000.000" });
+    const thread = createTestThread({ id: "slack:C0SKIP:1700000000.000" });
 
     await slackRuntime.handleSubscribedMessage(
       thread,
       createTestMessage({
         id: "msg-sub-skip",
-        threadId: "slack:C_SKIP:1700000000.000",
+        threadId: "slack:C0SKIP:1700000000.000",
         text: "just chatting among ourselves",
       }),
       { destination: createTestDestination(thread) },
@@ -429,15 +429,15 @@ describe("bot handlers (integration)", () => {
     });
 
     await slackRuntime.handleAssistantThreadStarted({
-      threadId: "slack:C_ASSIST:1700000000.000",
-      channelId: "C_ASSIST",
+      threadId: "slack:C0ASSIST:1700000000.000",
+      channelId: "C0ASSIST",
       threadTs: "1700000000.000",
       userId: "U-starter",
     });
 
     expect(fakeAdapter.titleCalls.length).toBe(1);
     expect(fakeAdapter.titleCalls[0].title).toBe("Junior");
-    expect(fakeAdapter.titleCalls[0].channelId).toBe("C_ASSIST");
+    expect(fakeAdapter.titleCalls[0].channelId).toBe("C0ASSIST");
     expect(fakeAdapter.promptCalls.length).toBe(1);
     expect(fakeAdapter.promptCalls[0].prompts.length).toBe(3);
   });
@@ -458,13 +458,13 @@ describe("bot handlers (integration)", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_ERR:1700000000.000" });
+    const thread = createTestThread({ id: "slack:C0ERR:1700000000.000" });
 
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "msg-err",
-        threadId: "slack:C_ERR:1700000000.000",
+        threadId: "slack:C0ERR:1700000000.000",
         text: "trigger an error",
         isMention: true,
       }),
@@ -481,7 +481,7 @@ describe("bot handlers (integration)", () => {
   });
 
   it("does not persist an assistant message when final Slack delivery fails", async () => {
-    const conversationId = "slack:C_DELIVERY_FAIL:1700000000.000";
+    const conversationId = "slack:C0DELIVERYFAIL:1700000000.000";
     const sessionId = "turn_msg-delivery-fail";
     const finalText = "This reply never reaches Slack.";
     const promptMessages = turnPiMessages("please answer");
@@ -610,7 +610,7 @@ describe("bot handlers (integration)", () => {
   });
 
   it("keeps the turn successful when persistence fails after Slack accepted the reply", async () => {
-    const conversationId = "slack:C_POST_DELIVERY:1700000000.000";
+    const conversationId = "slack:C0POSTDELIVERY:1700000000.000";
     const finalText = "Delivered before the state store failed.";
     const { slackRuntime } = createTestChatRuntime({
       services: {
@@ -723,7 +723,7 @@ describe("bot handlers (integration)", () => {
     });
 
     const thread = createTestThread({
-      id: "slack:C_CORRELATION:1700000000.000",
+      id: "slack:C0CORRELATION:1700000000.000",
       runId: "run-123",
     });
 
@@ -731,7 +731,7 @@ describe("bot handlers (integration)", () => {
       thread,
       createTestMessage({
         id: "msg-correlation",
-        threadId: "slack:C_CORRELATION:1700000000.000",
+        threadId: "slack:C0CORRELATION:1700000000.000",
         text: "trace this turn",
         isMention: true,
       }),
@@ -741,8 +741,8 @@ describe("bot handlers (integration)", () => {
     expect(capturedCorrelation).toHaveLength(1);
     expect(capturedCorrelation[0]).toEqual(
       expect.objectContaining({
-        conversationId: "slack:C_CORRELATION:1700000000.000",
-        threadId: "slack:C_CORRELATION:1700000000.000",
+        conversationId: "slack:C0CORRELATION:1700000000.000",
+        threadId: "slack:C0CORRELATION:1700000000.000",
         runId: "run-123",
       }),
     );
@@ -765,13 +765,13 @@ describe("bot handlers (integration)", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_AUTH:1700000000.000" });
+    const thread = createTestThread({ id: "slack:C0AUTH:1700000000.000" });
     await expect(
       slackRuntime.handleNewMention(
         thread,
         createTestMessage({
           id: "msg-auth-pause",
-          threadId: "slack:C_AUTH:1700000000.000",
+          threadId: "slack:C0AUTH:1700000000.000",
           text: "please use notion",
           isMention: true,
         }),
@@ -783,7 +783,7 @@ describe("bot handlers (integration)", () => {
     expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([
       expect.objectContaining({
         params: expect.objectContaining({
-          channel: "C_AUTH",
+          channel: "C0AUTH",
           thread_ts: "1700000000.000",
           text: "<@U-test> I'll need you to authorize Notion. I sent you a link.",
         }),
@@ -791,7 +791,7 @@ describe("bot handlers (integration)", () => {
     ]);
     expectBlocksIncludeConversationId(
       getCapturedSlackApiCalls("chat.postMessage")[0]!.params,
-      "slack:C_AUTH:1700000000.000",
+      "slack:C0AUTH:1700000000.000",
     );
     const state = thread.getState();
     const conversation = (
@@ -845,14 +845,14 @@ describe("bot handlers (integration)", () => {
     });
 
     const thread = createTestThread({
-      id: "slack:C_PLUGIN_AUTH:1700000000.000",
+      id: "slack:C0PLUGINAUTH:1700000000.000",
     });
     await expect(
       slackRuntime.handleNewMention(
         thread,
         createTestMessage({
           id: "msg-plugin-auth-pause",
-          threadId: "slack:C_PLUGIN_AUTH:1700000000.000",
+          threadId: "slack:C0PLUGINAUTH:1700000000.000",
           text: "please use github",
           isMention: true,
         }),
@@ -864,7 +864,7 @@ describe("bot handlers (integration)", () => {
     expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([
       expect.objectContaining({
         params: expect.objectContaining({
-          channel: "C_PLUGIN_AUTH",
+          channel: "C0PLUGINAUTH",
           thread_ts: "1700000000.000",
           text: "<@U-test> I'll need you to authorize GitHub. I sent you a link.",
         }),
@@ -872,7 +872,7 @@ describe("bot handlers (integration)", () => {
     ]);
     expectBlocksIncludeConversationId(
       getCapturedSlackApiCalls("chat.postMessage")[0]!.params,
-      "slack:C_PLUGIN_AUTH:1700000000.000",
+      "slack:C0PLUGINAUTH:1700000000.000",
     );
     const state = thread.getState();
     const conversation = (
@@ -1134,7 +1134,7 @@ describe("bot handlers (integration)", () => {
   });
 
   it("answers a follow-up as a fresh turn when the active session is auth-parked", async () => {
-    const conversationId = "slack:C_AUTH_PARKED:1700000000.000";
+    const conversationId = "slack:C0AUTHPARKED:1700000000.000";
     const activeSessionId = "turn_msg-auth-original";
     const executeAgentRun = vi.fn().mockResolvedValue(
       completedAgentRun({
@@ -1425,14 +1425,14 @@ describe("bot handlers (integration)", () => {
     });
 
     const thread = createTestThread({
-      id: "slack:C_RETRYQUIET:1700000000.000",
+      id: "slack:C0RETRYQUIET:1700000000.000",
     });
 
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "msg-retryable-failure",
-        threadId: "slack:C_RETRYQUIET:1700000000.000",
+        threadId: "slack:C0RETRYQUIET:1700000000.000",
         text: "do work",
         isMention: true,
       }),
@@ -1466,14 +1466,14 @@ describe("bot handlers (integration)", () => {
     });
 
     const thread = createTestThread({
-      id: "slack:C_RETRYACKED:1700000000.000",
+      id: "slack:C0RETRYACKED:1700000000.000",
     });
 
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "msg-acked-failure",
-        threadId: "slack:C_RETRYACKED:1700000000.000",
+        threadId: "slack:C0RETRYACKED:1700000000.000",
         text: "do work",
         isMention: true,
       }),
@@ -1506,14 +1506,14 @@ describe("bot handlers (integration)", () => {
     });
 
     const thread = createTestThread({
-      id: "slack:C_RETRYFINAL:1700000000.000",
+      id: "slack:C0RETRYFINAL:1700000000.000",
     });
 
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "msg-final-failure",
-        threadId: "slack:C_RETRYFINAL:1700000000.000",
+        threadId: "slack:C0RETRYFINAL:1700000000.000",
         text: "do work",
         isMention: true,
       }),
@@ -1531,7 +1531,7 @@ describe("bot handlers (integration)", () => {
   });
 
   it("fails malformed awaiting continuations before handling the follow-up", async () => {
-    const conversationId = "slack:C_BAD_CONTINUATION:1700000000.000";
+    const conversationId = "slack:C0BADCONTINUATION:1700000000.000";
     const activeSessionId = "turn_msg-timeout-original";
     const executeAgentRun = vi.fn().mockResolvedValue(
       completedAgentRun({
@@ -1838,14 +1838,14 @@ describe("bot handlers (integration)", () => {
     });
 
     const thread = createTestThread({
-      id: "slack:C_STREAM_FAIL:1700000000.000",
+      id: "slack:C0STREAMFAIL:1700000000.000",
     });
 
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "msg-stream-fail",
-        threadId: "slack:C_STREAM_FAIL:1700000000.000",
+        threadId: "slack:C0STREAMFAIL:1700000000.000",
         text: "do work",
         isMention: true,
       }),
@@ -1896,13 +1896,13 @@ describe("bot handlers (integration)", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_STATUS:1700000000.000" });
+    const thread = createTestThread({ id: "slack:C0STATUS:1700000000.000" });
 
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "msg-status",
-        threadId: "slack:C_STATUS:1700000000.000",
+        threadId: "slack:C0STATUS:1700000000.000",
         text: "show the channel",
         isMention: true,
       }),
@@ -1912,12 +1912,12 @@ describe("bot handlers (integration)", () => {
     expect(fakeAdapter.statusCalls.length).toBeGreaterThan(0);
     expect(fakeAdapter.statusCalls[0]).toEqual(
       expect.objectContaining({
-        channelId: "C_STATUS",
+        channelId: "C0STATUS",
         threadTs: "1700000000.000",
       }),
     );
     expect(fakeAdapter.statusCalls.at(-1)).toEqual({
-      channelId: "C_STATUS",
+      channelId: "C0STATUS",
       threadTs: "1700000000.000",
       text: "",
       loadingMessages: undefined,
@@ -1969,14 +1969,14 @@ describe("bot handlers (integration)", () => {
 
     let settled = false;
     const thread = createTestThread({
-      id: "slack:D_STATUSBLOCK:1700000000.000",
+      id: "slack:D0STATUSBLOCK:1700000000.000",
     });
     const turnPromise = slackRuntime
       .handleNewMention(
         thread,
         createTestMessage({
           id: "msg-status-block",
-          threadId: "slack:D_STATUSBLOCK:1700000000.000",
+          threadId: "slack:D0STATUSBLOCK:1700000000.000",
           text: "show the channel",
           isMention: true,
         }),
@@ -2022,7 +2022,7 @@ describe("bot handlers (integration)", () => {
 
     let replyStarted = false;
     const thread = createTestThread({
-      id: "slack:D_STATUSORDER:1700000001.000",
+      id: "slack:D0STATUSORDER:1700000001.000",
     });
     const { slackRuntime } = createRuntime({
       slackAdapter: fakeAdapter,
@@ -2115,13 +2115,13 @@ describe("bot handlers (integration)", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:D_TITLE:1700000000.000" });
+    const thread = createTestThread({ id: "slack:D0TITLE:1700000000.000" });
 
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "msg-title-1",
-        threadId: "slack:D_TITLE:1700000000.000",
+        threadId: "slack:D0TITLE:1700000000.000",
         text: "How do I debug memory leaks in Node?",
         isMention: true,
       }),
@@ -2135,7 +2135,7 @@ describe("bot handlers (integration)", () => {
     );
     expect(generatedTitleCall).toBeDefined();
     expect(generatedTitleCall!.title).toBe("Debugging Node.js Memory Leaks");
-    expect(generatedTitleCall!.channelId).toBe("D_TITLE");
+    expect(generatedTitleCall!.channelId).toBe("D0TITLE");
     expect(generatedTitleCall!.threadTs).toBe("1700000000.000");
   });
 
@@ -2178,10 +2178,10 @@ describe("bot handlers (integration)", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:D_TITLE4:1700000000.000" });
+    const thread = createTestThread({ id: "slack:D0TITLE4:1700000000.000" });
     const earlierMessage = createTestMessage({
       id: "msg-title4-earlier",
-      threadId: "slack:D_TITLE4:1700000000.000",
+      threadId: "slack:D0TITLE4:1700000000.000",
       text: "Original production issue summary",
       author: { userId: "U-title4", isBot: false },
     });
@@ -2192,7 +2192,7 @@ describe("bot handlers (integration)", () => {
       thread,
       createTestMessage({
         id: "msg-title4-current",
-        threadId: "slack:D_TITLE4:1700000000.000",
+        threadId: "slack:D0TITLE4:1700000000.000",
         text: "Can you also include the regression window?",
         isMention: true,
       }),
@@ -2241,11 +2241,11 @@ describe("bot handlers (integration)", () => {
     });
 
     const thread = createTestThread({
-      id: "slack:D_TITLE5:1700000000.000",
+      id: "slack:D0TITLE5:1700000000.000",
     });
     const starterMessage = createTestMessage({
       id: "msg-title5-starter",
-      threadId: "slack:D_TITLE5:1700000000.000",
+      threadId: "slack:D0TITLE5:1700000000.000",
       text: "How can I help?",
       author: {
         isBot: true,
@@ -2261,7 +2261,7 @@ describe("bot handlers (integration)", () => {
       thread,
       createTestMessage({
         id: "msg-title5-user",
-        threadId: "slack:D_TITLE5:1700000000.000",
+        threadId: "slack:D0TITLE5:1700000000.000",
         text: "what's today's date",
         isMention: true,
       }),
@@ -2313,14 +2313,14 @@ describe("bot handlers (integration)", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:D_TITLE6:1700000000.000" });
+    const thread = createTestThread({ id: "slack:D0TITLE6:1700000000.000" });
     let settled = false;
     const turnPromise = slackRuntime
       .handleNewMention(
         thread,
         createTestMessage({
           id: "msg-title-6",
-          threadId: "slack:D_TITLE6:1700000000.000",
+          threadId: "slack:D0TITLE6:1700000000.000",
           text: "what's today's date",
           isMention: true,
         }),
@@ -2397,13 +2397,13 @@ describe("bot handlers (integration)", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:D_TITLE7:1700000000.000" });
+    const thread = createTestThread({ id: "slack:D0TITLE7:1700000000.000" });
 
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "msg-title-7",
-        threadId: "slack:D_TITLE7:1700000000.000",
+        threadId: "slack:D0TITLE7:1700000000.000",
         text: "what's today's date",
         isMention: true,
       }),
@@ -2453,13 +2453,13 @@ describe("bot handlers (integration)", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:D_TITLE2:1700000000.000" });
+    const thread = createTestThread({ id: "slack:D0TITLE2:1700000000.000" });
 
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "msg-t2-1",
-        threadId: "slack:D_TITLE2:1700000000.000",
+        threadId: "slack:D0TITLE2:1700000000.000",
         text: "first message",
         isMention: true,
       }),
@@ -2476,7 +2476,7 @@ describe("bot handlers (integration)", () => {
       thread,
       createTestMessage({
         id: "msg-t2-2",
-        threadId: "slack:D_TITLE2:1700000000.000",
+        threadId: "slack:D0TITLE2:1700000000.000",
         text: "second message",
         isMention: true,
       }),
@@ -2531,14 +2531,14 @@ describe("bot handlers (integration)", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:D_TITLE3:1700000000.000" });
+    const thread = createTestThread({ id: "slack:D0TITLE3:1700000000.000" });
 
     await expect(
       slackRuntime.handleNewMention(
         thread,
         createTestMessage({
           id: "msg-title-3",
-          threadId: "slack:D_TITLE3:1700000000.000",
+          threadId: "slack:D0TITLE3:1700000000.000",
           text: "title this thread please",
           isMention: true,
         }),
@@ -2594,13 +2594,13 @@ describe("bot handlers (integration)", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:D_TITLE7:1700000000.000" });
+    const thread = createTestThread({ id: "slack:D0TITLE7:1700000000.000" });
 
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "msg-title7-1",
-        threadId: "slack:D_TITLE7:1700000000.000",
+        threadId: "slack:D0TITLE7:1700000000.000",
         text: "first message",
         isMention: true,
       }),
@@ -2610,7 +2610,7 @@ describe("bot handlers (integration)", () => {
       thread,
       createTestMessage({
         id: "msg-title7-2",
-        threadId: "slack:D_TITLE7:1700000000.000",
+        threadId: "slack:D0TITLE7:1700000000.000",
         text: "second message",
         isMention: true,
       }),
@@ -2651,7 +2651,7 @@ describe("bot handlers (integration)", () => {
       },
     });
 
-    const threadId = "slack:C_FIRST_EMPTY:1700000000.000";
+    const threadId = "slack:C0FIRSTEMPTY:1700000000.000";
     const thread = createTestThread({ id: threadId });
 
     await slackRuntime.handleNewMention(
@@ -2699,7 +2699,7 @@ describe("bot handlers (integration)", () => {
       },
     });
 
-    const threadId = "slack:C_FIRST_EXISTING:1700000000.000";
+    const threadId = "slack:C0FIRSTEXISTING:1700000000.000";
     const thread = createTestThread({ id: threadId });
     const priorMessage = createTestMessage({
       id: "msg-first-prior",
@@ -2776,7 +2776,7 @@ describe("bot handlers (integration)", () => {
       },
     });
 
-    const threadId = "slack:D_ORDER:1700000000.000";
+    const threadId = "slack:D0ORDER:1700000000.000";
     const thread = createTestThread({ id: threadId });
     const firstMessage = createTestMessage({
       id: "1700000000.100",
@@ -2836,13 +2836,13 @@ describe("bot handlers (integration)", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_MULTI:1700000000.000" });
+    const thread = createTestThread({ id: "slack:C0MULTI:1700000000.000" });
 
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "msg-t1",
-        threadId: "slack:C_MULTI:1700000000.000",
+        threadId: "slack:C0MULTI:1700000000.000",
         text: "first turn",
         isMention: true,
       }),
@@ -2860,7 +2860,7 @@ describe("bot handlers (integration)", () => {
       thread,
       createTestMessage({
         id: "msg-t2",
-        threadId: "slack:C_MULTI:1700000000.000",
+        threadId: "slack:C0MULTI:1700000000.000",
         text: "second turn",
         isMention: true,
       }),

--- a/packages/junior/tests/integration/slack/bot-image-hydration.test.ts
+++ b/packages/junior/tests/integration/slack/bot-image-hydration.test.ts
@@ -94,7 +94,7 @@ describe("bot image hydration", () => {
       },
     );
     const firstThread = createTestThread({
-      id: "slack:C_IMAGE:1700000000.000",
+      id: "slack:C0IMAGE:1700000000.000",
       state: {
         conversation: {
           schemaVersion: 1,
@@ -137,7 +137,7 @@ describe("bot image hydration", () => {
       createTestMessage({
         id: "1700000000.200",
         text: "/brief on this candidate",
-        threadId: "slack:C_IMAGE:1700000000.000",
+        threadId: "slack:C0IMAGE:1700000000.000",
         isMention: true,
         author: {
           userId: "U-user",
@@ -152,7 +152,7 @@ describe("bot image hydration", () => {
 
     const persisted = firstThread.getState();
     const secondThread = createTestThread({
-      id: "slack:C_IMAGE:1700000000.000",
+      id: "slack:C0IMAGE:1700000000.000",
       state: persisted,
     });
 
@@ -161,7 +161,7 @@ describe("bot image hydration", () => {
       createTestMessage({
         id: "1700000000.300",
         text: "follow up without new images",
-        threadId: "slack:C_IMAGE:1700000000.000",
+        threadId: "slack:C0IMAGE:1700000000.000",
         isMention: true,
         author: {
           userId: "U-user",
@@ -189,7 +189,7 @@ describe("bot image hydration", () => {
       },
     });
     const thread = createTestThread({
-      id: "slack:C_IMAGE:1700000001.000",
+      id: "slack:C0IMAGE:1700000001.000",
       state: {
         conversation: {
           schemaVersion: 1,
@@ -218,7 +218,7 @@ describe("bot image hydration", () => {
       createTestMessage({
         id: "1700000001.200",
         text: "",
-        threadId: "slack:C_IMAGE:1700000001.000",
+        threadId: "slack:C0IMAGE:1700000001.000",
         isMention: true,
         author: {
           userId: "U-user",
@@ -291,7 +291,7 @@ describe("bot image hydration", () => {
       },
     });
     const firstThread = createTestThread({
-      id: "slack:C_IMAGE:1700000002.000",
+      id: "slack:C0IMAGE:1700000002.000",
       state: {
         conversation: {
           schemaVersion: 1,
@@ -320,7 +320,7 @@ describe("bot image hydration", () => {
       createTestMessage({
         id: "1700000002.100",
         text: "what is in this screenshot?",
-        threadId: "slack:C_IMAGE:1700000002.000",
+        threadId: "slack:C0IMAGE:1700000002.000",
         isMention: true,
         author: {
           userId: "U-user",
@@ -377,7 +377,7 @@ describe("bot image hydration", () => {
       },
     );
     const secondThread = createTestThread({
-      id: "slack:C_IMAGE:1700000002.000",
+      id: "slack:C0IMAGE:1700000002.000",
       state: firstThread.getState(),
     });
 
@@ -386,7 +386,7 @@ describe("bot image hydration", () => {
       createTestMessage({
         id: "1700000002.200",
         text: "follow up without new uploads",
-        threadId: "slack:C_IMAGE:1700000002.000",
+        threadId: "slack:C0IMAGE:1700000002.000",
         isMention: true,
         author: {
           userId: "U-user",
@@ -486,7 +486,7 @@ describe("bot image hydration", () => {
       },
     );
     const thread = createTestThread({
-      id: "slack:C_IMAGE:1700000006.000",
+      id: "slack:C0IMAGE:1700000006.000",
       state: {
         conversation: {
           schemaVersion: 1,
@@ -515,7 +515,7 @@ describe("bot image hydration", () => {
       createTestMessage({
         id: "1700000002.100",
         text: "@Cursor can you look at this?",
-        threadId: "slack:C_IMAGE:1700000006.000",
+        threadId: "slack:C0IMAGE:1700000006.000",
         isMention: false,
         author: {
           userId: "U-user",
@@ -543,8 +543,8 @@ describe("bot image hydration", () => {
       thread,
       createTestMessage({
         id: "1700000002.200",
-        text: "<@U_APP> what is in the screenshot above?",
-        threadId: "slack:C_IMAGE:1700000006.000",
+        text: "<@U0APP> what is in the screenshot above?",
+        threadId: "slack:C0IMAGE:1700000006.000",
         isMention: true,
         author: {
           userId: "U-user",
@@ -642,7 +642,7 @@ describe("bot image hydration", () => {
 
     await slackRuntime.handleNewMention(
       createTestThread({
-        id: "slack:C_IMAGE:1700000003.000",
+        id: "slack:C0IMAGE:1700000003.000",
         state: {
           conversation: {
             schemaVersion: 1,
@@ -668,7 +668,7 @@ describe("bot image hydration", () => {
       createTestMessage({
         id: "1700000003.100",
         text: "explain this screenshot",
-        threadId: "slack:C_IMAGE:1700000003.000",
+        threadId: "slack:C0IMAGE:1700000003.000",
         isMention: true,
         author: {
           userId: "U-user",
@@ -689,7 +689,7 @@ describe("bot image hydration", () => {
       {
         destination: createTestDestination(
           createTestThread({
-            id: "slack:C_IMAGE:1700000003.000",
+            id: "slack:C0IMAGE:1700000003.000",
             state: {
               conversation: {
                 schemaVersion: 1,
@@ -800,7 +800,7 @@ describe("bot image hydration", () => {
 
     await slackRuntime.handleNewMention(
       createTestThread({
-        id: "slack:C_IMAGE:1700000004.000",
+        id: "slack:C0IMAGE:1700000004.000",
         state: {
           conversation: {
             schemaVersion: 1,
@@ -826,7 +826,7 @@ describe("bot image hydration", () => {
       createTestMessage({
         id: "1700000004.100",
         text: "compare these screenshots",
-        threadId: "slack:C_IMAGE:1700000004.000",
+        threadId: "slack:C0IMAGE:1700000004.000",
         isMention: true,
         author: {
           userId: "U-user",
@@ -853,7 +853,7 @@ describe("bot image hydration", () => {
       {
         destination: createTestDestination(
           createTestThread({
-            id: "slack:C_IMAGE:1700000004.000",
+            id: "slack:C0IMAGE:1700000004.000",
             state: {
               conversation: {
                 schemaVersion: 1,
@@ -922,7 +922,7 @@ describe("bot image hydration", () => {
 
     await slackRuntime.handleNewMention(
       createTestThread({
-        id: "slack:C_IMAGE:1700000005.000",
+        id: "slack:C0IMAGE:1700000005.000",
         state: {
           conversation: {
             schemaVersion: 1,
@@ -948,7 +948,7 @@ describe("bot image hydration", () => {
       createTestMessage({
         id: "1700000005.100",
         text: "summarize this screenshot",
-        threadId: "slack:C_IMAGE:1700000005.000",
+        threadId: "slack:C0IMAGE:1700000005.000",
         isMention: true,
         author: {
           userId: "U-user",
@@ -969,7 +969,7 @@ describe("bot image hydration", () => {
       {
         destination: createTestDestination(
           createTestThread({
-            id: "slack:C_IMAGE:1700000005.000",
+            id: "slack:C0IMAGE:1700000005.000",
             state: {
               conversation: {
                 schemaVersion: 1,
@@ -1026,7 +1026,7 @@ describe("bot image hydration", () => {
 
     const postSpy = vi.fn().mockResolvedValue(undefined);
     const thread = createTestThread({
-      id: "slack:C_UPLOAD:1700000000.000",
+      id: "slack:C0UPLOAD:1700000000.000",
       state: {},
     });
     thread.post = postSpy as unknown as Thread["post"];
@@ -1036,7 +1036,7 @@ describe("bot image hydration", () => {
       createTestMessage({
         id: "1700000000.200",
         text: "generate an image",
-        threadId: "slack:C_UPLOAD:1700000000.000",
+        threadId: "slack:C0UPLOAD:1700000000.000",
         isMention: true,
         author: {
           userId: "U-user",
@@ -1096,7 +1096,7 @@ describe("bot image hydration", () => {
 
     const postSpy = vi.fn().mockResolvedValue(undefined);
     const thread = createTestThread({
-      id: "slack:C_STREAM:1700000000.000",
+      id: "slack:C0STREAM:1700000000.000",
       state: {},
     });
     thread.post = postSpy as unknown as Thread["post"];
@@ -1106,7 +1106,7 @@ describe("bot image hydration", () => {
       createTestMessage({
         id: "1700000000.200",
         text: "generate an image",
-        threadId: "slack:C_STREAM:1700000000.000",
+        threadId: "slack:C0STREAM:1700000000.000",
         isMention: true,
         author: {
           userId: "U-user",

--- a/packages/junior/tests/integration/slack/canvas-failure-recovery-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/canvas-failure-recovery-behavior.test.ts
@@ -45,14 +45,14 @@ describe("Slack behavior: canvas failure recovery", () => {
       },
     });
     const thread = createTestThread({
-      id: "slack:C_CANVAS:1700008008.000",
+      id: "slack:C0CANVAS:1700008008.000",
     });
 
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "m-canvas-1",
-        text: "<@U_APP> Put the research in a canvas.",
+        text: "<@U0APP> Put the research in a canvas.",
         isMention: true,
         threadId: thread.id,
       }),
@@ -83,7 +83,7 @@ describe("Slack behavior: canvas failure recovery", () => {
       },
     });
     const thread = createTestThread({
-      id: "slack:C_CANVAS:1700008009.000",
+      id: "slack:C0CANVAS:1700008009.000",
       state: {
         artifacts: {
           lastCanvasId: "F_OLD",
@@ -104,7 +104,7 @@ describe("Slack behavior: canvas failure recovery", () => {
       thread,
       createTestMessage({
         id: "m-canvas-2",
-        text: "<@U_APP> Summarize the latest thread update.",
+        text: "<@U0APP> Summarize the latest thread update.",
         isMention: true,
         threadId: thread.id,
       }),

--- a/packages/junior/tests/integration/slack/file-delivery-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/file-delivery-behavior.test.ts
@@ -60,13 +60,13 @@ describe("Slack behavior: file delivery", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_FILES:1700004020.000" });
+    const thread = createTestThread({ id: "slack:C0FILES:1700004020.000" });
     const message = createTestMessage({
       id: "m-file-plan-1",
-      text: "<@U_APP> show me the preview",
+      text: "<@U0APP> show me the preview",
       isMention: true,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
     });
 
     await slackRuntime.handleNewMention(thread, message, {

--- a/packages/junior/tests/integration/slack/finalized-reply-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/finalized-reply-behavior.test.ts
@@ -90,12 +90,12 @@ describe("Slack behavior: finalized thread replies", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_FINAL:1700006000.000" });
+    const thread = createTestThread({ id: "slack:C0FINAL:1700006000.000" });
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "m-final-1",
-        text: "<@U_APP> say hello",
+        text: "<@U0APP> say hello",
         isMention: true,
         threadId: thread.id,
       }),
@@ -132,12 +132,12 @@ describe("Slack behavior: finalized thread replies", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_FINAL:1700006001.000" });
+    const thread = createTestThread({ id: "slack:C0FINAL:1700006001.000" });
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "m-final-2",
-        text: "<@U_APP> summarize the news",
+        text: "<@U0APP> summarize the news",
         isMention: true,
         threadId: thread.id,
       }),
@@ -164,12 +164,12 @@ describe("Slack behavior: finalized thread replies", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_FINAL:1700006002.000" });
+    const thread = createTestThread({ id: "slack:C0FINAL:1700006002.000" });
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "m-final-3",
-        text: "<@U_APP> attach the file",
+        text: "<@U0APP> attach the file",
         isMention: true,
         threadId: thread.id,
       }),
@@ -206,12 +206,12 @@ describe("Slack behavior: finalized thread replies", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_FINAL:1700006003.000" });
+    const thread = createTestThread({ id: "slack:C0FINAL:1700006003.000" });
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "m-final-4",
-        text: "<@U_APP> post in channel",
+        text: "<@U0APP> post in channel",
         isMention: true,
         threadId: thread.id,
       }),
@@ -245,12 +245,12 @@ describe("Slack behavior: finalized thread replies", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_FINAL:1700006005.000" });
+    const thread = createTestThread({ id: "slack:C0FINAL:1700006005.000" });
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "m-final-empty-plan",
-        text: "<@U_APP> reply invisibly",
+        text: "<@U0APP> reply invisibly",
         isMention: true,
         threadId: thread.id,
       }),
@@ -283,12 +283,12 @@ describe("Slack behavior: finalized thread replies", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_FINAL:1700006004.000" });
+    const thread = createTestThread({ id: "slack:C0FINAL:1700006004.000" });
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "m-final-5",
-        text: "<@U_APP> react and attach",
+        text: "<@U0APP> react and attach",
         isMention: true,
         threadId: thread.id,
       }),
@@ -321,12 +321,12 @@ describe("Slack behavior: finalized thread replies", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_FINAL:1700006005.000" });
+    const thread = createTestThread({ id: "slack:C0FINAL:1700006005.000" });
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "m-final-6",
-        text: "<@U_APP> give me all lines",
+        text: "<@U0APP> give me all lines",
         isMention: true,
         threadId: thread.id,
       }),
@@ -360,12 +360,12 @@ describe("Slack behavior: finalized thread replies", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_FINAL:1700006006.000" });
+    const thread = createTestThread({ id: "slack:C0FINAL:1700006006.000" });
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "m-final-7",
-        text: "<@U_APP> send the script",
+        text: "<@U0APP> send the script",
         isMention: true,
         threadId: thread.id,
       }),
@@ -400,12 +400,12 @@ describe("Slack behavior: finalized thread replies", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_FINAL:1700006007.000" });
+    const thread = createTestThread({ id: "slack:C0FINAL:1700006007.000" });
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "m-final-8",
-        text: "<@U_APP> long reply please",
+        text: "<@U0APP> long reply please",
         isMention: true,
         threadId: thread.id,
       }),

--- a/packages/junior/tests/integration/slack/message-changed-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/message-changed-behavior.test.ts
@@ -19,7 +19,7 @@ import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import { flattenAgentRunRequestForTest } from "../../fixtures/agent-runner";
 
 const SIGNING_SECRET = "test-signing-secret";
-const BOT_USER_ID = "U_BOT";
+const BOT_USER_ID = "U0BOT";
 const ORIGINAL_ENV = { ...process.env };
 const slackWebhookClient = createSlackWebhookTestClient({
   signingSecret: SIGNING_SECRET,

--- a/packages/junior/tests/integration/slack/message-changed-gate-contract.test.ts
+++ b/packages/junior/tests/integration/slack/message-changed-gate-contract.test.ts
@@ -66,7 +66,7 @@ describe("Slack message_changed author gate contract", () => {
 
   it("drops an edited mention from a Slack Connect external user", async () => {
     const { queue, response } = await runEditedMentionWebhook(
-      messageChangedEnvelope({ user: "U_EXTERNAL", user_team: "T_OTHER_ORG" }),
+      messageChangedEnvelope({ user: "U0EXTERNAL", user_team: "T0OTHERORG" }),
     );
 
     expect(response.status).toBe(200);

--- a/packages/junior/tests/integration/slack/message-changed-reply-contract.test.ts
+++ b/packages/junior/tests/integration/slack/message-changed-reply-contract.test.ts
@@ -14,7 +14,7 @@ import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import { flattenAgentRunRequestForTest } from "../../fixtures/agent-runner";
 
 const SIGNING_SECRET = "test-signing-secret";
-const BOT_USER_ID = "U_BOT";
+const BOT_USER_ID = "U0BOT";
 const slackWebhookClient = createSlackWebhookTestClient({
   signingSecret: SIGNING_SECRET,
 });

--- a/packages/junior/tests/integration/slack/message-content-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/message-content-behavior.test.ts
@@ -80,13 +80,13 @@ describe("Slack behavior: message content", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700005000.000" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700005000.000" });
     const message = createTestMessage({
       id: "m-content-strip",
-      text: "<@U_APP>   please summarize the deploy status",
+      text: "<@U0APP>   please summarize the deploy status",
       isMention: true,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
     });
 
     await slackRuntime.handleNewMention(thread, message, {
@@ -115,13 +115,13 @@ describe("Slack behavior: message content", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700005001.000" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700005001.000" });
     const message = createTestMessage({
       id: "m-content-preserve",
-      text: "<@U_APP> remind me to message <@U_ONCALL> after deploy",
+      text: "<@U0APP> remind me to message <@U0ONCALL> after deploy",
       isMention: true,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
     });
 
     await slackRuntime.handleNewMention(thread, message, {
@@ -129,7 +129,7 @@ describe("Slack behavior: message content", () => {
     });
 
     expect(calls).toHaveLength(1);
-    expect(calls[0]?.prompt).toContain("message <@U_ONCALL> after deploy");
+    expect(calls[0]?.prompt).toContain("message <@U0ONCALL> after deploy");
   });
 
   it("passes legacy attachment text into the current turn prompt", async () => {
@@ -156,15 +156,15 @@ describe("Slack behavior: message content", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700005002.500" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700005002.500" });
     const message = createTestMessage({
       id: "m-content-legacy-attachment",
-      text: "<@U_APP>",
+      text: "<@U0APP>",
       isMention: true,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
       raw: {
-        channel: "C_BEHAVIOR",
+        channel: "C0BEHAVIOR",
         ts: "1700005002.500",
         thread_ts: "1700005002.500",
         attachments: [
@@ -205,14 +205,14 @@ describe("Slack behavior: message content", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700005002.000" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700005002.000" });
     const message = createTestMessage({
       id: "m-content-self",
-      text: "<@U_APP> do not respond",
+      text: "<@U0APP> do not respond",
       isMention: true,
       threadId: thread.id,
       author: {
-        userId: "U_BOT",
+        userId: "U0BOT",
         isMe: true,
       },
     });
@@ -294,20 +294,20 @@ describe("Slack behavior: message content", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700005003.000" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700005003.000" });
     const first = createTestMessage({
       id: "m-content-context-1",
-      text: "<@U_APP> I need the budget by Friday",
+      text: "<@U0APP> I need the budget by Friday",
       isMention: true,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
     });
     const second = createTestMessage({
       id: "m-content-context-2",
-      text: "<@U_APP> what did I just ask?",
+      text: "<@U0APP> what did I just ask?",
       isMention: true,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
     });
 
     await slackRuntime.handleNewMention(thread, first, {
@@ -348,7 +348,7 @@ describe("Slack behavior: message content", () => {
         timestamp: 2,
       },
     ] as PiMessage[];
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700005005.000" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700005005.000" });
     await commitMessages({
       conversationId: thread.id,
       messages: priorMessages,
@@ -390,10 +390,10 @@ describe("Slack behavior: message content", () => {
       thread,
       createTestMessage({
         id: "m-content-auto-compact",
-        text: "<@U_APP> continue",
+        text: "<@U0APP> continue",
         isMention: true,
         threadId: thread.id,
-        author: { userId: "U_TESTER" },
+        author: { userId: "U0TESTER" },
       }),
       { destination: createTestDestination(thread) },
     );
@@ -460,7 +460,7 @@ describe("Slack behavior: message content", () => {
         timestamp: 2,
       },
     ] as PiMessage[];
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700005006.000" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700005006.000" });
     await commitMessages({
       conversationId: thread.id,
       messages: priorMessages,
@@ -509,10 +509,10 @@ describe("Slack behavior: message content", () => {
       thread,
       createTestMessage({
         id: "m-content-active-session-record",
-        text: "<@U_APP> continue",
+        text: "<@U0APP> continue",
         isMention: true,
         threadId: thread.id,
-        author: { userId: "U_TESTER" },
+        author: { userId: "U0TESTER" },
       }),
       { destination: createTestDestination(thread) },
     );

--- a/packages/junior/tests/integration/slack/message-im-attachment-contract.test.ts
+++ b/packages/junior/tests/integration/slack/message-im-attachment-contract.test.ts
@@ -10,7 +10,7 @@ import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import { flattenAgentRunRequestForTest } from "../../fixtures/agent-runner";
 
 const SIGNING_SECRET = "test-signing-secret";
-const BOT_USER_ID = "U_BOT";
+const BOT_USER_ID = "U0BOT";
 const DM_CHANNEL_ID = "D12345";
 const DM_THREAD_TS = "1700000000.000001";
 const ORIGINAL_ENV = { ...process.env };

--- a/packages/junior/tests/integration/slack/new-mention-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/new-mention-behavior.test.ts
@@ -69,15 +69,15 @@ describe("Slack behavior: new mention", () => {
     });
 
     const thread = createTestThread({
-      id: "slack:C_BEHAVIOR:1700001234.000",
+      id: "slack:C0BEHAVIOR:1700001234.000",
     });
     const message = createTestMessage({
       id: "m-behavior-1",
-      text: "<@U_APP> give me a status update",
+      text: "<@U0APP> give me a status update",
       isMention: true,
       threadId: thread.id,
       author: {
-        userId: "U_TESTER",
+        userId: "U0TESTER",
         userName: "tester",
       },
     });
@@ -112,17 +112,17 @@ describe("Slack behavior: new mention", () => {
     });
 
     const thread = createTestThread({
-      id: "slack:C_QUEUED:1700001234.000",
+      id: "slack:C0QUEUED:1700001234.000",
     });
     const queued = createTestMessage({
       id: "m-queued",
-      text: "<@U_APP> first queued request",
+      text: "<@U0APP> first queued request",
       isMention: true,
       threadId: thread.id,
     });
     const latest = createTestMessage({
       id: "m-latest",
-      text: "<@U_APP> latest request",
+      text: "<@U0APP> latest request",
       isMention: true,
       threadId: thread.id,
     });
@@ -195,11 +195,11 @@ describe("Slack behavior: new mention", () => {
     });
 
     const thread = createTestThread({
-      id: "slack:C_QUEUED_ATTACHMENTS:1700001234.000",
+      id: "slack:C0QUEUEDATTACHMENTS:1700001234.000",
     });
     const queued = createTestMessage({
       id: "m-queued-file",
-      text: "<@U_APP> review this file first",
+      text: "<@U0APP> review this file first",
       isMention: true,
       threadId: thread.id,
       attachments: [
@@ -213,7 +213,7 @@ describe("Slack behavior: new mention", () => {
     });
     const latest = createTestMessage({
       id: "m-latest-file",
-      text: "<@U_APP> then answer now",
+      text: "<@U0APP> then answer now",
       isMention: true,
       threadId: thread.id,
     });
@@ -262,13 +262,13 @@ describe("Slack behavior: new mention", () => {
     });
 
     const thread = createTestThread({
-      id: "slack:C_STATUS:1700002000.000",
+      id: "slack:C0STATUS:1700002000.000",
     });
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "m-status-clear",
-        text: "<@U_APP> run a command",
+        text: "<@U0APP> run a command",
         isMention: true,
         threadId: thread.id,
       }),
@@ -277,7 +277,7 @@ describe("Slack behavior: new mention", () => {
 
     expect(slackAdapter.statusCalls.length).toBeGreaterThan(0);
     expect(slackAdapter.statusCalls.at(-1)).toEqual({
-      channelId: "C_STATUS",
+      channelId: "C0STATUS",
       threadTs: "1700002000.000",
       text: "",
       loadingMessages: undefined,
@@ -300,13 +300,13 @@ describe("Slack behavior: new mention", () => {
     });
 
     const thread = createTestThread({
-      id: "slack:C_STATUS:1700003000.000",
+      id: "slack:C0STATUS:1700003000.000",
     });
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "m-status-error",
-        text: "<@U_APP> do something",
+        text: "<@U0APP> do something",
         isMention: true,
         threadId: thread.id,
       }),
@@ -315,7 +315,7 @@ describe("Slack behavior: new mention", () => {
 
     expect(slackAdapter.statusCalls.length).toBeGreaterThan(0);
     expect(slackAdapter.statusCalls.at(-1)).toEqual({
-      channelId: "C_STATUS",
+      channelId: "C0STATUS",
       threadTs: "1700003000.000",
       text: "",
       loadingMessages: undefined,
@@ -348,15 +348,15 @@ describe("Slack behavior: new mention", () => {
     });
 
     const thread = createTestThread({
-      id: "slack:C_BEHAVIOR:1700005678.000",
+      id: "slack:C0BEHAVIOR:1700005678.000",
     });
     const message = createTestMessage({
       id: "m-behavior-2",
-      text: "<@U_APP> say hello to the channel",
+      text: "<@U0APP> say hello to the channel",
       isMention: true,
       threadId: thread.id,
       author: {
-        userId: "U_TESTER",
+        userId: "U0TESTER",
         userName: "tester",
       },
     });

--- a/packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/processing-reaction-behavior.test.ts
@@ -24,7 +24,7 @@ function successDiagnostics(toolCalls: string[] = []) {
 function reactionCall(name: string, timestamp: string) {
   return expect.objectContaining({
     params: expect.objectContaining({
-      channel: "C_PROCESSING",
+      channel: "C0PROCESSING",
       timestamp,
       name,
     }),
@@ -51,17 +51,17 @@ describe("Slack behavior: processing reaction", () => {
     });
 
     const thread = createTestThread({
-      id: "slack:C_PROCESSING:1700007000.000000",
+      id: "slack:C0PROCESSING:1700007000.000000",
     });
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "1700007001.000000",
-        text: "<@U_APP> handle this",
+        text: "<@U0APP> handle this",
         isMention: true,
         threadId: thread.id,
         raw: {
-          channel: "C_PROCESSING",
+          channel: "C0PROCESSING",
           ts: "1700007001.000000",
           thread_ts: "1700007000.000000",
         },
@@ -106,7 +106,7 @@ describe("Slack behavior: processing reaction", () => {
     });
 
     const thread = createTestThread({
-      id: "slack:C_PROCESSING:1700007100.000000",
+      id: "slack:C0PROCESSING:1700007100.000000",
     });
     await slackRuntime.handleSubscribedMessage(
       thread,
@@ -116,7 +116,7 @@ describe("Slack behavior: processing reaction", () => {
         isMention: false,
         threadId: thread.id,
         raw: {
-          channel: "C_PROCESSING",
+          channel: "C0PROCESSING",
           ts: "1700007101.000000",
           thread_ts: "1700007100.000000",
         },
@@ -163,7 +163,7 @@ describe("Slack behavior: processing reaction", () => {
     });
 
     const thread = createTestThread({
-      id: "slack:C_PROCESSING:1700007150.000000",
+      id: "slack:C0PROCESSING:1700007150.000000",
     });
     await slackRuntime.handleSubscribedMessage(
       thread,
@@ -173,7 +173,7 @@ describe("Slack behavior: processing reaction", () => {
         isMention: false,
         threadId: thread.id,
         raw: {
-          channel: "C_PROCESSING",
+          channel: "C0PROCESSING",
           ts: "1700007151.000000",
           thread_ts: "1700007150.000000",
         },
@@ -209,7 +209,7 @@ describe("Slack behavior: processing reaction", () => {
     });
 
     const thread = createTestThread({
-      id: "slack:C_PROCESSING:1700007160.000000",
+      id: "slack:C0PROCESSING:1700007160.000000",
     });
     await slackRuntime.handleSubscribedMessage(
       thread,
@@ -225,7 +225,7 @@ describe("Slack behavior: processing reaction", () => {
           isBot: true,
         },
         raw: {
-          channel: "C_PROCESSING",
+          channel: "C0PROCESSING",
           event_type: "resource_event",
           thread_ts: "1700007160.000000",
           // Historical malformed records used the synthetic mailbox id as raw.ts.
@@ -269,17 +269,17 @@ describe("Slack behavior: processing reaction", () => {
     });
 
     const thread = createTestThread({
-      id: "slack:C_PROCESSING:1700007200.000000",
+      id: "slack:C0PROCESSING:1700007200.000000",
     });
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "1700007201.000000",
-        text: "<@U_APP> add eyes to this",
+        text: "<@U0APP> add eyes to this",
         isMention: true,
         threadId: thread.id,
         raw: {
-          channel: "C_PROCESSING",
+          channel: "C0PROCESSING",
           ts: "1700007201.000000",
           thread_ts: "1700007200.000000",
         },

--- a/packages/junior/tests/integration/slack/provider-default-config-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/provider-default-config-behavior.test.ts
@@ -32,7 +32,7 @@ describe("Slack behavior: provider default configuration", () => {
     });
     const channelStateRef = { value: {} };
     const thread = createTestThread({
-      id: "slack:C_CONFIG:1700007007.000",
+      id: "slack:C0CONFIG:1700007007.000",
       channelStateRef,
     });
 
@@ -40,7 +40,7 @@ describe("Slack behavior: provider default configuration", () => {
       thread,
       createTestMessage({
         id: "m-config-1",
-        text: "<@U_APP> Set the default repo to getsentry/junior.",
+        text: "<@U0APP> Set the default repo to getsentry/junior.",
         isMention: true,
         threadId: thread.id,
       }),
@@ -93,7 +93,7 @@ describe("Slack behavior: provider default configuration", () => {
     });
     const channelStateRef = { value: {} };
     const thread = createTestThread({
-      id: "slack:C_CONFIG_COMBINED:1700007008.000",
+      id: "slack:C0CONFIGCOMBINED:1700007008.000",
       channelStateRef,
     });
 
@@ -101,7 +101,7 @@ describe("Slack behavior: provider default configuration", () => {
       thread,
       createTestMessage({
         id: "m-config-2",
-        text: "<@U_APP> Set the default repo to getsentry/junior and create an issue for flaky evals.",
+        text: "<@U0APP> Set the default repo to getsentry/junior and create an issue for flaky evals.",
         isMention: true,
         threadId: thread.id,
       }),

--- a/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
@@ -91,13 +91,13 @@ describe("Slack behavior: subscribed messages", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002000.000" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700002000.000" });
     const message = createTestMessage({
       id: "m-subscribed-skip",
       text: "sounds good thanks everyone",
       isMention: false,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
     });
 
     await slackRuntime.handleSubscribedMessage(thread, message, {
@@ -130,13 +130,13 @@ describe("Slack behavior: subscribed messages", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002000.001" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700002000.001" });
     const message = createTestMessage({
       id: "m-subscribed-provider-retry",
       text: "can you check this?",
       isMention: false,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
     });
 
     await expect(
@@ -175,7 +175,7 @@ describe("Slack behavior: subscribed messages", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002000.002" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700002000.002" });
     const message = createTestMessage({
       id: "resource-event-resub-1-check-suite-1",
       text: "[event notification]\n\nA subscribed resource changed.",
@@ -188,7 +188,7 @@ describe("Slack behavior: subscribed messages", () => {
         isBot: true,
       },
       raw: {
-        channel: "C_BEHAVIOR",
+        channel: "C0BEHAVIOR",
         event_type: "resource_event",
         thread_ts: "1700002000.002",
         ts: "resource-event-resub-1-check-suite-1",
@@ -237,7 +237,7 @@ describe("Slack behavior: subscribed messages", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002000.003" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700002000.003" });
     const message = createTestMessage({
       id: "resource-event-resub-1-check-suite-auth",
       text: "[event notification]\n\nA subscribed resource changed.",
@@ -250,7 +250,7 @@ describe("Slack behavior: subscribed messages", () => {
         isBot: true,
       },
       raw: {
-        channel: "C_BEHAVIOR",
+        channel: "C0BEHAVIOR",
         event_type: "resource_event",
         thread_ts: "1700002000.003",
         ts: "resource-event-resub-1-check-suite-auth",
@@ -304,13 +304,13 @@ describe("Slack behavior: subscribed messages", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002001.000" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700002001.000" });
     const message = createTestMessage({
       id: "m-subscribed-reply",
       text: "can you suggest one concrete next step?",
       isMention: false,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
     });
 
     await slackRuntime.handleSubscribedMessage(thread, message, {
@@ -355,13 +355,13 @@ describe("Slack behavior: subscribed messages", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002002.000" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700002002.000" });
     const message = createTestMessage({
       id: "m-subscribed-mention",
-      text: "<@U_APP> quick status?",
+      text: "<@U0APP> quick status?",
       isMention: true,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
     });
 
     await slackRuntime.handleSubscribedMessage(thread, message, {
@@ -401,21 +401,21 @@ describe("Slack behavior: subscribed messages", () => {
       },
     });
     const thread = createTestThread({
-      id: "slack:C_BEHAVIOR:1700002002.250",
+      id: "slack:C0BEHAVIOR:1700002002.250",
     });
     const queued = createTestMessage({
       id: "m-subscribed-queued-mention",
-      text: "<@U_APP> first queued request",
+      text: "<@U0APP> first queued request",
       isMention: true,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
     });
     const latest = createTestMessage({
       id: "m-subscribed-queued-latest",
       text: "latest follow-up",
       isMention: false,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
     });
 
     await slackRuntime.handleSubscribedMessage(thread, latest, {
@@ -474,16 +474,16 @@ describe("Slack behavior: subscribed messages", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002002.500" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700002002.500" });
 
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "m-stop-thread-initial",
-        text: "<@U_APP> can you help here?",
+        text: "<@U0APP> can you help here?",
         isMention: true,
         threadId: thread.id,
-        author: { userId: "U_TESTER" },
+        author: { userId: "U0TESTER" },
       }),
       { destination: createTestDestination(thread) },
     );
@@ -494,10 +494,10 @@ describe("Slack behavior: subscribed messages", () => {
       thread,
       createTestMessage({
         id: "m-stop-thread-opt-out",
-        text: "<@U_APP> stop watching or participating in this thread",
+        text: "<@U0APP> stop watching or participating in this thread",
         isMention: true,
         threadId: thread.id,
-        author: { userId: "U_TESTER" },
+        author: { userId: "U0TESTER" },
       }),
       { destination: createTestDestination(thread) },
     );
@@ -513,10 +513,10 @@ describe("Slack behavior: subscribed messages", () => {
       thread,
       createTestMessage({
         id: "m-stop-thread-remention",
-        text: "<@U_APP> actually, can you jump back in?",
+        text: "<@U0APP> actually, can you jump back in?",
         isMention: true,
         threadId: thread.id,
-        author: { userId: "U_TESTER" },
+        author: { userId: "U0TESTER" },
       }),
       { destination: createTestDestination(thread) },
     );
@@ -553,13 +553,13 @@ describe("Slack behavior: subscribed messages", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002003.000" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700002003.000" });
     const message = createTestMessage({
       id: "m-subscribed-ack",
       text: "thanks!",
       isMention: false,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
     });
 
     await slackRuntime.handleSubscribedMessage(thread, message, {
@@ -601,13 +601,13 @@ describe("Slack behavior: subscribed messages", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002003.125" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700002003.125" });
     const message = createTestMessage({
       id: "m-subscribed-ack-attachment",
       text: "thanks!",
       isMention: false,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
       attachments: [
         {
           type: "image",
@@ -655,13 +655,13 @@ describe("Slack behavior: subscribed messages", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002003.250" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700002003.250" });
     const message = createTestMessage({
       id: "m-subscribed-attachment-only",
       text: "",
       isMention: false,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
       attachments: [
         {
           type: "image",
@@ -711,15 +711,15 @@ describe("Slack behavior: subscribed messages", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002003.275" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700002003.275" });
     const message = createTestMessage({
       id: "m-subscribed-legacy-attachment-only",
       text: "",
       isMention: false,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
       raw: {
-        channel: "C_BEHAVIOR",
+        channel: "C0BEHAVIOR",
         ts: "1700002003.275",
         thread_ts: "1700002003.275",
         attachments: [
@@ -765,15 +765,15 @@ describe("Slack behavior: subscribed messages", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002003.300" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700002003.300" });
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "m-subscribed-generic-side-1",
-        text: "<@U_APP> summarize the deploy",
+        text: "<@U0APP> summarize the deploy",
         isMention: true,
         threadId: thread.id,
-        author: { userId: "U_TESTER" },
+        author: { userId: "U0TESTER" },
       }),
       { destination: createTestDestination(thread) },
     );
@@ -786,7 +786,7 @@ describe("Slack behavior: subscribed messages", () => {
         text: "can you check on this?",
         isMention: false,
         threadId: thread.id,
-        author: { userId: "U_TESTER" },
+        author: { userId: "U0TESTER" },
       }),
       { destination: createTestDestination(thread) },
     );
@@ -826,15 +826,15 @@ describe("Slack behavior: subscribed messages", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002003.350" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700002003.350" });
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "m-subscribed-generic-side-attachment-1",
-        text: "<@U_APP> summarize the deploy",
+        text: "<@U0APP> summarize the deploy",
         isMention: true,
         threadId: thread.id,
-        author: { userId: "U_TESTER" },
+        author: { userId: "U0TESTER" },
       }),
       { destination: createTestDestination(thread) },
     );
@@ -847,7 +847,7 @@ describe("Slack behavior: subscribed messages", () => {
         text: "can you check on this?",
         isMention: false,
         threadId: thread.id,
-        author: { userId: "U_TESTER" },
+        author: { userId: "U0TESTER" },
         attachments: [
           {
             type: "image",
@@ -888,13 +888,13 @@ describe("Slack behavior: subscribed messages", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002003.500" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700002003.500" });
     const message = createTestMessage({
       id: "m-subscribed-other-bot",
       text: "@Cursor can you help address issue 87?",
       isMention: false,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
     });
 
     await slackRuntime.handleSubscribedMessage(thread, message, {
@@ -962,15 +962,15 @@ describe("Slack behavior: subscribed messages", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002004.000" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700002004.000" });
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "m-subscribed-followup-1",
-        text: "<@U_APP> I need the budget by Friday",
+        text: "<@U0APP> I need the budget by Friday",
         isMention: true,
         threadId: thread.id,
-        author: { userId: "U_TESTER" },
+        author: { userId: "U0TESTER" },
       }),
       { destination: createTestDestination(thread) },
     );
@@ -982,7 +982,7 @@ describe("Slack behavior: subscribed messages", () => {
         text: "what did you just say about the budget?",
         isMention: false,
         threadId: thread.id,
-        author: { userId: "U_TESTER" },
+        author: { userId: "U0TESTER" },
       }),
       { destination: createTestDestination(thread) },
     );
@@ -1029,15 +1029,15 @@ describe("Slack behavior: subscribed messages", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700002004.500" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700002004.500" });
     await slackRuntime.handleNewMention(
       thread,
       createTestMessage({
         id: "m-subscribed-low-confidence-followup-1",
-        text: "<@U_APP> what changed in the deploy?",
+        text: "<@U0APP> what changed in the deploy?",
         isMention: true,
         threadId: thread.id,
-        author: { userId: "U_TESTER" },
+        author: { userId: "U0TESTER" },
       }),
       { destination: createTestDestination(thread) },
     );
@@ -1049,7 +1049,7 @@ describe("Slack behavior: subscribed messages", () => {
         text: "which one?",
         isMention: false,
         threadId: thread.id,
-        author: { userId: "U_TESTER" },
+        author: { userId: "U0TESTER" },
       }),
       { destination: createTestDestination(thread) },
     );
@@ -1067,7 +1067,7 @@ describe("Slack behavior: subscribed messages", () => {
   it("calls ack when preflight skips a message directed at another user", async () => {
     const { slackRuntime } = createRuntime();
     const ack = vi.fn().mockResolvedValue(undefined);
-    const thread = createTestThread({ id: "slack:C_REGRESS:1700010000.001" });
+    const thread = createTestThread({ id: "slack:C0REGRESS:1700010000.001" });
 
     await slackRuntime.handleSubscribedMessage(
       thread,
@@ -1076,7 +1076,7 @@ describe("Slack behavior: subscribed messages", () => {
         text: "@Alice can you take a look at this?",
         isMention: false,
         threadId: thread.id,
-        author: { userId: "U_TESTER" },
+        author: { userId: "U0TESTER" },
       }),
       { destination: createTestDestination(thread), ack },
     );
@@ -1090,7 +1090,7 @@ describe("Slack behavior: subscribed messages", () => {
     const ack = vi.fn().mockResolvedValue(undefined);
     const activeTurnId = "turn_existing_resume";
     const thread = createTestThread({
-      id: "slack:C_REGRESS:1700010000.005",
+      id: "slack:C0REGRESS:1700010000.005",
       state: {
         conversation: {
           processing: {
@@ -1107,7 +1107,7 @@ describe("Slack behavior: subscribed messages", () => {
         text: "@Alice can you take this one?",
         isMention: false,
         threadId: thread.id,
-        author: { userId: "U_TESTER" },
+        author: { userId: "U0TESTER" },
       }),
       { destination: createTestDestination(thread), ack },
     );
@@ -1138,7 +1138,7 @@ describe("Slack behavior: subscribed messages", () => {
       },
     });
     const ack = vi.fn().mockResolvedValue(undefined);
-    const thread = createTestThread({ id: "slack:C_REGRESS:1700010000.002" });
+    const thread = createTestThread({ id: "slack:C0REGRESS:1700010000.002" });
 
     await slackRuntime.handleSubscribedMessage(
       thread,
@@ -1147,7 +1147,7 @@ describe("Slack behavior: subscribed messages", () => {
         text: "sounds good, let's ship it",
         isMention: false,
         threadId: thread.id,
-        author: { userId: "U_TESTER" },
+        author: { userId: "U0TESTER" },
       }),
       { destination: createTestDestination(thread), ack },
     );
@@ -1174,7 +1174,7 @@ describe("Slack behavior: subscribed messages", () => {
       },
     });
     const ack = vi.fn().mockResolvedValue(undefined);
-    const thread = createTestThread({ id: "slack:C_REGRESS:1700010000.003" });
+    const thread = createTestThread({ id: "slack:C0REGRESS:1700010000.003" });
     // Subscribe first so opt-out has something to unsubscribe from.
     thread.subscribe();
 
@@ -1182,10 +1182,10 @@ describe("Slack behavior: subscribed messages", () => {
       thread,
       createTestMessage({
         id: "m-optout-skip",
-        text: "<@U_APP> please stop watching this thread",
+        text: "<@U0APP> please stop watching this thread",
         isMention: true,
         threadId: thread.id,
-        author: { userId: "U_TESTER" },
+        author: { userId: "U0TESTER" },
       }),
       { destination: createTestDestination(thread), ack },
     );
@@ -1199,7 +1199,7 @@ describe("Slack behavior: subscribed messages", () => {
       "lease lost during skip commit",
     );
     const ack = vi.fn().mockRejectedValue(commitError);
-    const thread = createTestThread({ id: "slack:C_REGRESS:1700010000.004" });
+    const thread = createTestThread({ id: "slack:C0REGRESS:1700010000.004" });
 
     await expect(
       slackRuntime.handleSubscribedMessage(
@@ -1209,7 +1209,7 @@ describe("Slack behavior: subscribed messages", () => {
           text: "@Alice handle this please",
           isMention: false,
           threadId: thread.id,
-          author: { userId: "U_TESTER" },
+          author: { userId: "U0TESTER" },
         }),
         { destination: createTestDestination(thread), ack },
       ),

--- a/packages/junior/tests/integration/slack/thread-continuity-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/thread-continuity-behavior.test.ts
@@ -70,20 +70,20 @@ describe("Slack behavior: thread continuity", () => {
       },
     });
 
-    const thread = createTestThread({ id: "slack:C_BEHAVIOR:1700003000.000" });
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700003000.000" });
     const firstMessage = createTestMessage({
       id: "m-continuity-1",
-      text: "<@U_APP> We rolled back the deploy after a 500 spike. Give me a status update.",
+      text: "<@U0APP> We rolled back the deploy after a 500 spike. Give me a status update.",
       isMention: true,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
     });
     const secondMessage = createTestMessage({
       id: "m-continuity-2",
-      text: "<@U_APP> Also give one concrete next step for follow-up.",
+      text: "<@U0APP> Also give one concrete next step for follow-up.",
       isMention: true,
       threadId: thread.id,
-      author: { userId: "U_TESTER" },
+      author: { userId: "U0TESTER" },
     });
 
     await slackRuntime.handleNewMention(thread, firstMessage, {

--- a/packages/junior/tests/integration/slack/webhook-auth-boundary.test.ts
+++ b/packages/junior/tests/integration/slack/webhook-auth-boundary.test.ts
@@ -18,7 +18,7 @@ describe("Slack webhook auth boundary", () => {
     const waitUntil = client.waitUntil();
     const adapter = createJuniorSlackAdapter({
       botToken: "xoxb-test-token",
-      botUserId: "U_BOT",
+      botUserId: "U0BOT",
       signingSecret: SIGNING_SECRET,
     });
 

--- a/packages/junior/tests/integration/tool-idempotency.test.ts
+++ b/packages/junior/tests/integration/tool-idempotency.test.ts
@@ -4,8 +4,10 @@ import { createSlackCanvasCreateTool } from "@/chat/slack/tools/canvas/create";
 import { createOperationKey } from "@/chat/tools/idempotency";
 import { createSlackListAddItemsTool } from "@/chat/slack/tools/list/add-items";
 import { SlackActionError } from "@/chat/slack/client";
+import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 import type { ToolState } from "@/chat/tools/types";
 import type { SlackToolContext } from "@/chat/slack/tools/context";
+import { parseSlackChannelId, parseSlackTeamId } from "@/chat/slack/ids";
 import {
   canvasesAccessSetOk,
   canvasesCreateOk,
@@ -50,22 +52,40 @@ function createToolState(
 
 const noopSandbox = {} as any;
 
+function requireSlackChannelId(value: string) {
+  const channelId = parseSlackChannelId(value);
+  if (!channelId) {
+    throw new Error(`Invalid test Slack channel ID: ${value}`);
+  }
+  return channelId;
+}
+
+function requireSlackTeamId(value: string) {
+  const teamId = parseSlackTeamId(value);
+  if (!teamId) {
+    throw new Error(`Invalid test Slack team ID: ${value}`);
+  }
+  return teamId;
+}
+
 function slackContext(channelId: string): SlackToolContext {
+  const parsedChannelId = requireSlackChannelId(channelId);
+  const teamId = requireSlackTeamId("T123");
   return {
     destination: {
       platform: "slack" as const,
-      teamId: "T123",
-      channelId,
+      teamId,
+      channelId: parsedChannelId,
     },
     source: createSlackSource({
-      teamId: "T123",
-      channelId,
+      teamId,
+      channelId: parsedChannelId,
 
       type: "priv",
     }),
-    destinationChannelId: channelId,
-    sourceChannelId: channelId,
-    teamId: "T123",
+    destinationChannelId: parsedChannelId,
+    sourceChannelId: parsedChannelId,
+    teamId,
   };
 }
 
@@ -199,15 +219,17 @@ describe("tool idempotency", () => {
       }),
     });
 
+    const sharedChannelId = requireSlackChannelId("C0SHARED");
+    const teamId = requireSlackTeamId("T123");
     const tool = createSlackCanvasCreateTool(
       {
         ...slackContext("D123"),
         destination: {
           platform: "slack" as const,
-          teamId: "T123",
-          channelId: "C_SHARED",
+          teamId,
+          channelId: sharedChannelId,
         },
-        destinationChannelId: "C_SHARED",
+        destinationChannelId: sharedChannelId,
       },
       createToolState(),
     );
@@ -226,7 +248,7 @@ describe("tool idempotency", () => {
     ).toMatchObject({
       canvas_id: "canvas-shared-1",
       access_level: "write",
-      channel_ids: ["C_SHARED"],
+      channel_ids: ["C0SHARED"],
     });
   });
 
@@ -291,6 +313,52 @@ describe("tool idempotency", () => {
       ok: true,
       list_id: "list-1",
       deduplicated: true,
+    });
+  });
+
+  it("validates slack_list_add_items assignee user ids before Slack calls", async () => {
+    const state = createToolState({
+      currentListId: "list-1",
+      listColumnMap: {
+        titleColumnId: "col-title",
+        assigneeColumnId: "col-assignee",
+      },
+    });
+    const tool = createSlackListAddItemsTool(state);
+
+    await expect(
+      executeTool(tool, {
+        items: ["Ship patch"],
+        assignee_user_id: "not-a-slack-user",
+      }),
+    ).rejects.toThrow(ToolInputError);
+    expect(getCapturedSlackApiCalls("slackLists.items.create")).toHaveLength(0);
+
+    queueSlackApiResponse("slackLists.items.create", {
+      body: slackListsItemsCreateOk({ itemId: "item-1" }),
+    });
+
+    await expect(
+      executeTool(tool, {
+        items: ["Ship patch"],
+        assignee_user_id: "U123",
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      list_id: "list-1",
+      created_count: 1,
+    });
+
+    expect(
+      getCapturedSlackApiCalls("slackLists.items.create")[0]?.params,
+    ).toMatchObject({
+      list_id: "list-1",
+      initial_fields: expect.arrayContaining([
+        expect.objectContaining({
+          column_id: "col-assignee",
+          user: ["U123"],
+        }),
+      ]),
     });
   });
 

--- a/packages/junior/tests/msw/handlers/slack-api.ts
+++ b/packages/junior/tests/msw/handlers/slack-api.ts
@@ -420,7 +420,7 @@ export const slackApiHandlers = [
 
   http.get("https://slack.com/api/users.info", async ({ request }) => {
     const url = new URL(request.url);
-    const userId = url.searchParams.get("user") ?? "U_TEST";
+    const userId = url.searchParams.get("user") ?? "U0TEST";
 
     capturedSlackApiCalls.push({
       method: "users.info",

--- a/packages/junior/tests/unit/prompt.test.ts
+++ b/packages/junior/tests/unit/prompt.test.ts
@@ -136,7 +136,7 @@ describe("prompt builders", () => {
         includeSessionContext: false,
         invocation: null,
         requester: {
-          userId: "U_BETA",
+          userId: "U0BETA",
           userName: "dcramer",
         },
         runtime: {

--- a/packages/junior/tests/unit/routing/subscribed-decision.test.ts
+++ b/packages/junior/tests/unit/routing/subscribed-decision.test.ts
@@ -223,7 +223,7 @@ describe("decideSubscribedThreadReply", () => {
       botUserName: "junior",
       modelId: "router-model",
       input: makeInput({
-        rawText: "<@U_APP> stop watching or participating in this thread",
+        rawText: "<@U0APP> stop watching or participating in this thread",
         text: "stop watching or participating in this thread",
         isExplicitMention: true,
       }),

--- a/packages/junior/tests/unit/runtime/conversation-message.test.ts
+++ b/packages/junior/tests/unit/runtime/conversation-message.test.ts
@@ -111,7 +111,7 @@ describe("conversation message actor identity", () => {
         fullName: "Other Person",
         platform: "slack",
         teamId: "T123",
-        userId: "U_OTHER",
+        userId: "U0OTHER",
         userName: "other",
       }),
     ).toThrow("Message requester user id mismatch");

--- a/packages/junior/tests/unit/runtime/thread-context.test.ts
+++ b/packages/junior/tests/unit/runtime/thread-context.test.ts
@@ -9,8 +9,8 @@ import { runWithWorkspaceTeamId } from "@/chat/slack/workspace-context";
 describe("stripLeadingBotMention", () => {
   it("strips the Slack adapter's normalized bot user id mention", () => {
     expect(
-      stripLeadingBotMention("@U_BOT start the incident summary", {
-        botUserId: "U_BOT",
+      stripLeadingBotMention("@U0BOT start the incident summary", {
+        botUserId: "U0BOT",
         stripLeadingSlackMentionToken: true,
       }),
     ).toBe("start the incident summary");
@@ -18,20 +18,20 @@ describe("stripLeadingBotMention", () => {
 
   it("keeps non-bot normalized mentions intact", () => {
     expect(
-      stripLeadingBotMention("@U_OTHER ask junior for help", {
-        botUserId: "U_BOT",
+      stripLeadingBotMention("@U0OTHER ask junior for help", {
+        botUserId: "U0BOT",
         stripLeadingSlackMentionToken: true,
       }),
-    ).toBe("@U_OTHER ask junior for help");
+    ).toBe("@U0OTHER ask junior for help");
   });
 
   it("preserves a referenced user after the leading bot mention", () => {
     expect(
-      stripLeadingBotMention("<@U_BOT> <@U_OTHER> status?", {
-        botUserId: "U_BOT",
+      stripLeadingBotMention("<@U0BOT> <@U0OTHER> status?", {
+        botUserId: "U0BOT",
         stripLeadingSlackMentionToken: true,
       }),
-    ).toBe("<@U_OTHER> status?");
+    ).toBe("<@U0OTHER> status?");
   });
 });
 

--- a/packages/junior/tests/unit/services/requester.test.ts
+++ b/packages/junior/tests/unit/services/requester.test.ts
@@ -110,9 +110,9 @@ describe("requester", () => {
           userId: "U039RR91S",
           userName: "dcramer",
         },
-        { teamId: "T123", userId: "U_OTHER" },
+        { teamId: "T123", userId: "U0OTHER" },
       ),
-    ).toEqual({ platform: "slack", teamId: "T123", userId: "U_OTHER" });
+    ).toEqual({ platform: "slack", teamId: "T123", userId: "U0OTHER" });
   });
 
   it("omits unresolved Slack profile fields instead of inventing identity", () => {

--- a/packages/junior/tests/unit/slack/assistant-thread-title.test.ts
+++ b/packages/junior/tests/unit/slack/assistant-thread-title.test.ts
@@ -68,7 +68,7 @@ function makeArgs(
     generateThreadTitle,
     getSlackAdapter: () => ({ setAssistantTitle }),
     modelId: "fast-model",
-    requesterId: "U_USER",
+    requesterId: "U0USER",
     runId: "run_001",
     threadId: `slack:${channelId}:${THREAD_TS}`,
     _setAssistantTitle: setAssistantTitle,

--- a/packages/junior/tests/unit/slack/message-changed-ingress.test.ts
+++ b/packages/junior/tests/unit/slack/message-changed-ingress.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 import type { Adapter } from "chat";
 import { extractMessageChangedMention } from "@/chat/ingress/message-changed";
 
-const BOT_USER_ID = "U_BOT_TEST";
-const CHANNEL_ID = "C_CHAN";
-const TEAM_ID = "T_TEAM";
+const BOT_USER_ID = "U0BOTTEST";
+const CHANNEL_ID = "C0CHAN";
+const TEAM_ID = "T0TEAM";
 const MESSAGE_TS = "1700000100.000";
 const THREAD_TS = "1700000000.000";
 const EDITED_MESSAGE_ID = `${MESSAGE_TS}:message_changed_mention`;
@@ -31,7 +31,7 @@ function makeEnvelope(overrides: {
         text: overrides.newText,
         ts: overrides.messageTs ?? MESSAGE_TS,
         thread_ts: overrides.threadTs ?? THREAD_TS,
-        user: overrides.user ?? "U_SENDER",
+        user: overrides.user ?? "U0SENDER",
         ...(overrides.botId ? { bot_id: overrides.botId } : {}),
       },
       previous_message: {
@@ -76,7 +76,7 @@ describe("extractMessageChangedMention", () => {
       _type: "chat:Message",
       attachments: [],
       author: {
-        userId: "U_SENDER",
+        userId: "U0SENDER",
         isBot: false,
         isMe: false,
       },
@@ -94,7 +94,7 @@ describe("extractMessageChangedMention", () => {
         team_id: TEAM_ID,
         ts: MESSAGE_TS,
         thread_ts: THREAD_TS,
-        user: "U_SENDER",
+        user: "U0SENDER",
       },
       text: `<@${BOT_USER_ID}> please help`,
       threadId: `slack:${CHANNEL_ID}:${THREAD_TS}`,
@@ -176,7 +176,7 @@ describe("extractMessageChangedMention", () => {
           text: `<@${BOT_USER_ID}> help`,
           ts: MESSAGE_TS,
           // no thread_ts
-          user: "U_SENDER",
+          user: "U0SENDER",
         },
         previous_message: {
           text: "help",

--- a/packages/junior/tests/unit/slack/slack-client-token.test.ts
+++ b/packages/junior/tests/unit/slack/slack-client-token.test.ts
@@ -40,7 +40,7 @@ describe("getSlackClient token resolution", () => {
   it("fails a workspace-scoped call when no installation token can be resolved", () => {
     getSlackBotTokenMock.mockReturnValue(undefined);
 
-    runWithWorkspaceTeamId("T_OTHER_WORKSPACE", () => {
+    runWithWorkspaceTeamId("T0OTHERWORKSPACE", () => {
       let caught: unknown;
       try {
         getSlackClient();
@@ -50,7 +50,7 @@ describe("getSlackClient token resolution", () => {
       expect(caught).toBeInstanceOf(SlackActionError);
       expect((caught as SlackActionError).code).toBe("missing_token");
       expect((caught as SlackActionError).message).toContain(
-        "T_OTHER_WORKSPACE",
+        "T0OTHERWORKSPACE",
       );
     });
   });

--- a/packages/junior/tests/unit/slack/slack-harness.test.ts
+++ b/packages/junior/tests/unit/slack/slack-harness.test.ts
@@ -10,14 +10,14 @@ describe("slack harness fixture", () => {
   });
 
   it("falls back to parsing channelId from slack thread id", () => {
-    const thread = createTestThread({ id: "slack:C_TEST:1700000000.000" });
+    const thread = createTestThread({ id: "slack:C0TEST:1700000000.000" });
 
-    expect(thread.channelId).toBe("slack:C_TEST");
-    expect(thread.channel.id).toBe("slack:C_TEST");
+    expect(thread.channelId).toBe("slack:C0TEST");
+    expect(thread.channel.id).toBe("slack:C0TEST");
   });
 
   it("keeps posts and postKinds aligned when deleting a duplicate post", async () => {
-    const thread = createTestThread({ id: "slack:C_TEST:1700000000.000" });
+    const thread = createTestThread({ id: "slack:C0TEST:1700000000.000" });
 
     await thread.post(
       (async function* () {

--- a/packages/junior/tests/unit/slack/slack-ids.test.ts
+++ b/packages/junior/tests/unit/slack/slack-ids.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSlackTeamId,
+  parseSlackChannelId,
+  parseSlackChannelReferenceId,
+  parseSlackTeamId,
+  parseSlackUserId,
+} from "@/chat/slack/ids";
+
+describe("slack ids", () => {
+  it("parses exact Slack channel ids", () => {
+    expect(parseSlackChannelId("C123")).toBe("C123");
+    expect(parseSlackChannelId("G123")).toBe("G123");
+    expect(parseSlackChannelId("D123")).toBe("D123");
+    expect(parseSlackChannelId(" slack:C123:1700000000.100 ")).toBeUndefined();
+    expect(parseSlackChannelId("X123")).toBeUndefined();
+    expect(parseSlackChannelId("slack:")).toBeUndefined();
+  });
+
+  it("parses channel ids from Junior slack references", () => {
+    expect(parseSlackChannelReferenceId("slack:C123")).toBe("C123");
+    expect(parseSlackChannelReferenceId(" slack:C123:1700000000.100 ")).toBe(
+      "C123",
+    );
+    expect(parseSlackChannelReferenceId("slack:C123:not-a-ts")).toBeUndefined();
+  });
+
+  it("parses Slack team and user ids", () => {
+    expect(parseSlackTeamId(" T123 ")).toBe("T123");
+    expect(parseSlackUserId(" U123 ")).toBe("U123");
+    expect(parseSlackUserId("W123")).toBe("W123");
+    expect(parseSlackTeamId("C123")).toBeUndefined();
+    expect(parseSlackUserId("unknown")).toBeUndefined();
+  });
+
+  it("keeps exact guard behavior for persisted ids", () => {
+    expect(isSlackTeamId("T123")).toBe(true);
+    expect(isSlackTeamId(" T123 ")).toBe(false);
+  });
+});

--- a/packages/junior/tests/unit/slack/slack-message-add-reaction-tool.test.ts
+++ b/packages/junior/tests/unit/slack/slack-message-add-reaction-tool.test.ts
@@ -3,6 +3,7 @@ import { createSlackSource } from "@sentry/junior-plugin-api";
 import { createSlackMessageAddReactionTool } from "@/chat/slack/tools/message-add-reaction";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 import type { SlackToolContext } from "@/chat/slack/tools/context";
+import { parseSlackChannelId, parseSlackTeamId } from "@/chat/slack/ids";
 import { parseSlackMessageTs } from "@/chat/slack/timestamp";
 
 const addReactionToMessage = vi.fn();
@@ -15,24 +16,32 @@ const TEST_MESSAGE_TS = parseSlackMessageTs("1700000000.100");
 if (!TEST_MESSAGE_TS) {
   throw new Error("Test message timestamp must be a valid Slack ts");
 }
+const TEST_CHANNEL_ID = parseSlackChannelId("C123");
+if (!TEST_CHANNEL_ID) {
+  throw new Error("Test Slack channel ID must be valid");
+}
+const TEST_TEAM_ID = parseSlackTeamId("T123");
+if (!TEST_TEAM_ID) {
+  throw new Error("Test Slack team ID must be valid");
+}
 
 const TEST_SLACK_CONTEXT: SlackToolContext = {
   destination: {
     platform: "slack",
-    teamId: "T123",
-    channelId: "C123",
+    teamId: TEST_TEAM_ID,
+    channelId: TEST_CHANNEL_ID,
   },
   source: createSlackSource({
-    teamId: "T123",
-    channelId: "C123",
+    teamId: TEST_TEAM_ID,
+    channelId: TEST_CHANNEL_ID,
     messageTs: TEST_MESSAGE_TS,
 
     type: "priv",
   }),
-  destinationChannelId: "C123",
+  destinationChannelId: TEST_CHANNEL_ID,
   messageTs: TEST_MESSAGE_TS,
-  sourceChannelId: "C123",
-  teamId: "T123",
+  sourceChannelId: TEST_CHANNEL_ID,
+  teamId: TEST_TEAM_ID,
 };
 
 function createState() {

--- a/packages/junior/tests/unit/slack/slack-runtime.test.ts
+++ b/packages/junior/tests/unit/slack/slack-runtime.test.ts
@@ -74,19 +74,19 @@ describe("createSlackTurnRuntime", () => {
     it("forwards queued SDK context as ordered turn messages", async () => {
       const deps = createMockDeps({
         stripLeadingBotMention: vi.fn((text: string) =>
-          text.replace("<@U_APP> ", ""),
+          text.replace("<@U0APP> ", ""),
         ),
       });
       const runtime = createSlackTurnRuntime<TestState>(deps);
       const thread = createTestThread({});
       const skipped = createTestMessage({
         id: "m-skipped",
-        text: "<@U_APP> first queued bit",
+        text: "<@U0APP> first queued bit",
         isMention: true,
       });
       const latest = createTestMessage({
         id: "m-latest",
-        text: "<@U_APP> latest queued bit",
+        text: "<@U0APP> latest queued bit",
         isMention: true,
       });
 
@@ -106,7 +106,7 @@ describe("createSlackTurnRuntime", () => {
             {
               explicitMention: true,
               message: skipped,
-              rawText: "<@U_APP> first queued bit",
+              rawText: "<@U0APP> first queued bit",
               userText: "first queued bit",
             },
           ],

--- a/packages/junior/tests/unit/slack/tool-registration.test.ts
+++ b/packages/junior/tests/unit/slack/tool-registration.test.ts
@@ -76,6 +76,15 @@ describe("Slack tool registration", () => {
     expect(tools).toHaveProperty("slackCanvasCreate");
   });
 
+  it("registers tools when runtime channel ids are Junior Slack references", () => {
+    const tools = createTools([], {}, ctx("slack:C12345"));
+
+    expect(tools).toHaveProperty("slackChannelPostMessage");
+    expect(tools).toHaveProperty("slackChannelListMessages");
+    expect(tools).toHaveProperty("slackMessageAddReaction");
+    expect(tools).toHaveProperty("slackCanvasCreate");
+  });
+
   it("does not register standalone channel posting outside interactive Slack turns", () => {
     const tools = createTools(
       [],

--- a/packages/junior/tests/unit/slack/workspace-membership.test.ts
+++ b/packages/junior/tests/unit/slack/workspace-membership.test.ts
@@ -4,8 +4,8 @@ import {
   runWithWorkspaceTeamId,
 } from "@/chat/ingress/workspace-membership";
 
-const LOCAL_TEAM = "T_LOCAL";
-const EXTERNAL_TEAM = "T_EXTERNAL";
+const LOCAL_TEAM = "T0LOCAL";
+const EXTERNAL_TEAM = "T0EXTERNAL";
 
 describe("isExternalSlackUser", () => {
   it("returns false when no workspace context is set", () => {


### PR DESCRIPTION
Slack channel, user, and team IDs now parse through reusable Zod-branded helpers before Slack-owned tool and provider boundaries. Tool schemas stay model-facing TypeBox strings, while execution bridges those inputs into branded IDs for channel/thread reads, user lookup, list assignment, outbound handling, and Slack context creation.

Exact Slack ID parsing is separate from Junior Slack reference parsing, so tool params reject non-canonical IDs while persisted `slack:<channel>` references still normalize where that compatibility is needed.

Refs #754