### PR TITLE
fix(slack): Send files through active conversation messages

### DIFF
--- a/packages/junior-evals/evals/core/slack-message-delivery.eval.ts
+++ b/packages/junior-evals/evals/core/slack-message-delivery.eval.ts
@@ -23,41 +23,31 @@ function visibleText(session: EvalSession): string {
     .join("\n");
 }
 
-function sendMessageTargets(session: EvalSession): unknown[] {
-  return toolCalls(session)
-    .filter((call) => call.name === "sendMessage")
-    .map((call) => call.arguments?.target);
-}
-
 describeEval("Slack Message Delivery", slackEvals, (it) => {
-  it("when asked to post in channel, send a channel message without duplicate thread text", async ({
+  it("when asked for a top-level channel post, explain the limitation instead", async ({
     run,
   }) => {
     const result = await run({
-      events: [mention("@bot say hello to the channel!")],
+      events: [mention("@bot post this to the channel: deploy is unblocked")],
       criteria: rubric({
         pass: [
-          "The normalized transcript contains exactly one hello-style channel_post assistant message with no thread_ts.",
-          "The assistant tool calls include sendMessage with channel target for the requested channel post.",
-          "The normalized transcript does not contain that hello-style message as a thread reply.",
+          "The assistant does not call sendMessage.",
+          "The assistant posts exactly one visible thread reply.",
+          "The reply clearly explains it cannot make top-level channel posts from this runtime or can only send into the active conversation/thread.",
         ],
         fail: [
-          "Do not add a redundant thread reply acknowledging the channel post.",
+          "Do not send the requested text into the active thread with sendMessage.",
+          "Do not claim the message was posted to the channel.",
           `Do not leak the literal marker ${NO_REPLY_MARKER} as visible text.`,
         ],
       }),
     });
 
-    expect(toolCalls(result.session)).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: "sendMessage",
-          arguments: expect.objectContaining({ target: "channel" }),
-        }),
-      ]),
+    expect(toolCalls(result.session).map((call) => call.name)).not.toContain(
+      "sendMessage",
     );
-    expect(visibleThreadReplies(result.session)).toEqual([]);
     expect(visibleText(result.session)).not.toContain(NO_REPLY_MARKER);
+    expect(visibleThreadReplies(result.session)).toHaveLength(1);
   });
 
   it("when a generated image should be shared here, send it to the thread", async ({
@@ -86,49 +76,14 @@ describeEval("Slack Message Delivery", slackEvals, (it) => {
         expect.objectContaining({ name: "imageGenerate" }),
         expect.objectContaining({
           name: "sendMessage",
-          arguments: expect.objectContaining({ target: "thread" }),
         }),
       ]),
     );
-    expect(sendMessageTargets(result.session)).toContain("thread");
-    expect(sendMessageTargets(result.session)).not.toContain("channel");
+    const sendMessageCall = toolCalls(result.session).find(
+      (call) => call.name === "sendMessage",
+    );
+    expect(sendMessageCall?.arguments).not.toHaveProperty("target");
     expect(visibleText(result.session)).not.toContain(NO_REPLY_MARKER);
     expect(visibleThreadReplies(result.session).length).toBeGreaterThan(0);
-  });
-
-  it("when a generated image should be posted to the channel, use channel target", async ({
-    run,
-  }) => {
-    const result = await run({
-      overrides: { mock_image_generation: true },
-      events: [
-        mention(
-          "make a small launch checklist image and post it to the channel",
-        ),
-      ],
-      criteria: rubric({
-        pass: [
-          "The assistant generates an image and posts it as a top-level channel message.",
-          "The assistant does not duplicate that channel post as a normal thread attachment.",
-        ],
-        fail: [
-          "Do not only describe the image in text.",
-          "Do not send the image only into the thread when the user asked to post it to the channel.",
-          "Do not add a redundant thread reply that repeats the posted channel message.",
-        ],
-      }),
-    });
-
-    expect(toolCalls(result.session)).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ name: "imageGenerate" }),
-        expect.objectContaining({
-          name: "sendMessage",
-          arguments: expect.objectContaining({ target: "channel" }),
-        }),
-      ]),
-    );
-    expect(sendMessageTargets(result.session)).toContain("channel");
-    expect(sendMessageTargets(result.session)).not.toContain("thread");
   });
 });

--- a/packages/junior/src/chat/plugins/agent-hooks.ts
+++ b/packages/junior/src/chat/plugins/agent-hooks.ts
@@ -30,7 +30,7 @@ import type {
   SandboxInstance,
 } from "@/chat/sandbox/workspace";
 import { createSlackDirectCredentialSubject } from "@/chat/credentials/subject";
-import { resolveChannelCapabilities } from "@/chat/tools/channel-capabilities";
+import { resolveChannelCapabilities } from "@/chat/slack/tools/channel-capabilities";
 import type { Requester } from "@/chat/requester";
 import { z } from "zod";
 

--- a/packages/junior/src/chat/prompt.ts
+++ b/packages/junior/src/chat/prompt.ts
@@ -385,12 +385,11 @@ const CONVERSATION_RULES = [
 
 const SLACK_ACTION_RULES = [
   "- Slack tools target the current runtime context; if the requested Slack target differs, explain the limitation instead of calling the tool.",
-  "- Use sendMessage with target `channel` and addReaction only for explicit user-requested Slack side effects.",
-  "- Generic Slack requests like 'share it here' refer to the current thread. Use sendMessage with target `thread` when you need to send text, files, or both into the current Slack thread; use target `channel` only for explicit channel/top-level post requests.",
-  `- Channel-target sendMessage is visible delivery. After a successful sendMessage with target \`channel\`, do not add a normal thread acknowledgement; final message must be exactly ${NO_REPLY_MARKER} unless there is separate requested content that was not sent to the channel.`,
-  "- Thread-target sendMessage is not final-reply delivery. After using sendMessage with target `thread`, provide a brief normal final answer unless the user requested no further text.",
+  "- Use sendMessage only when the user asks to send, share, or attach text, sandbox-path files, or both in the active Slack conversation.",
+  "- sendMessage has no target argument; it always sends into the active Slack conversation/thread. For top-level channel posts, other channels, or named recipients, explain that this runtime can only send into the active conversation.",
+  "- sendMessage is not final-reply delivery. After using sendMessage, provide a brief normal final answer unless the user requested no further text.",
   "- Ambient reaction requests target the current inbound message; do not ask for a message reference.",
-  `- Side-effect-only completion for sendMessage target \`channel\` or addReaction: call the requested tool first; if it succeeds and fully satisfies the request, final message must be exactly ${NO_REPLY_MARKER}.`,
+  `- Side-effect-only completion for addReaction: call the requested tool first; if it succeeds and fully satisfies the request, final message must be exactly ${NO_REPLY_MARKER}.`,
 ];
 
 const SAFETY_RULES = [

--- a/packages/junior/src/chat/services/reply-delivery-plan.ts
+++ b/packages/junior/src/chat/services/reply-delivery-plan.ts
@@ -7,25 +7,13 @@ export interface ReplyDeliveryPlan {
   attachFiles: ReplyFileDelivery;
 }
 
-/** Determine how a reply should be delivered (thread vs channel, file handling). */
+/** Determine how a normal finalized reply should be delivered. */
 export function buildReplyDeliveryPlan(args: {
-  channelOnlySideEffect: boolean;
-  channelPostPerformed: boolean;
   hasFiles: boolean;
 }): ReplyDeliveryPlan {
-  const mode: ReplyDeliveryMode =
-    args.channelOnlySideEffect && args.channelPostPerformed
-      ? "channel_only"
-      : "thread";
-
-  let attachFiles: ReplyFileDelivery = "none";
-  if (args.hasFiles && mode === "thread") {
-    attachFiles = "inline";
-  }
-
   return {
-    mode,
-    postThreadText: mode === "thread",
-    attachFiles,
+    mode: "thread",
+    postThreadText: true,
+    attachFiles: args.hasFiles ? "inline" : "none",
   };
 }

--- a/packages/junior/src/chat/services/turn-result.ts
+++ b/packages/junior/src/chat/services/turn-result.ts
@@ -204,13 +204,6 @@ function stripThinkingXmlBlocks(text: string): string {
   return result;
 }
 
-function sendMessageResultTarget(
-  result: unknown,
-): "channel" | "thread" | undefined {
-  const target = (result as { details?: { target?: unknown } }).details?.target;
-  return target === "channel" || target === "thread" ? target : undefined;
-}
-
 /** Process raw agent messages into a structured AgentRunResult. */
 export function buildTurnResult(input: TurnResultInput): AgentRunResult {
   const {
@@ -256,30 +249,16 @@ export function buildTurnResult(input: TurnResultInput): AgentRunResult {
       .map((result) => normalizeToolNameFromResult(result))
       .filter((value): value is string => Boolean(value)),
   );
-  const channelPostPerformed = successfulToolResults.some(
-    (result) =>
-      normalizeToolNameFromResult(result) === "sendMessage" &&
-      sendMessageResultTarget(result) === "channel",
-  );
   const canvasCreated = successfulToolNames.has("slackCanvasCreate");
   const reactionPerformed = successfulToolNames.has("addReaction");
   const markerSideEffectSuccess =
     exactNoReplyMarker &&
     toolErrorCount === 0 &&
-    (reactionPerformed || channelPostPerformed || replyFiles.length > 0);
+    (reactionPerformed || replyFiles.length > 0);
   const fileOnlySuccess =
     !rawPrimaryText && toolErrorCount === 0 && replyFiles.length > 0;
-  const channelMessageOnlySuccess =
-    !rawPrimaryText && toolErrorCount === 0 && channelPostPerformed;
-  const sideEffectOnlySuccess =
-    markerSideEffectSuccess || fileOnlySuccess || channelMessageOnlySuccess;
-  const channelOnlySideEffect =
-    channelPostPerformed &&
-    replyFiles.length === 0 &&
-    (exactNoReplyMarker || channelMessageOnlySuccess);
+  const sideEffectOnlySuccess = markerSideEffectSuccess || fileOnlySuccess;
   const baseDeliveryPlan = buildReplyDeliveryPlan({
-    channelOnlySideEffect,
-    channelPostPerformed,
     hasFiles: replyFiles.length > 0,
   });
   const lastAssistant = terminalAssistantMessages.at(-1) as
@@ -298,11 +277,9 @@ export function buildTurnResult(input: TurnResultInput): AgentRunResult {
   if (exactNoReplyMarker) {
     const markerCategory = reactionPerformed
       ? "reaction"
-      : channelPostPerformed
-        ? "channel_post"
-        : replyFiles.length > 0
-          ? "file"
-          : "none";
+      : replyFiles.length > 0
+        ? "file"
+        : "none";
     const markerContext = {
       slackThreadId: correlation?.threadId,
       slackUserId: correlation?.requesterId,
@@ -405,7 +382,7 @@ export function buildTurnResult(input: TurnResultInput): AgentRunResult {
     resolvedOutcome === "success" &&
     !resolvedText &&
     replyFiles.length === 0 &&
-    (reactionPerformed || channelPostPerformed)
+    reactionPerformed
       ? {
           ...baseDeliveryPlan,
           postThreadText: false,

--- a/packages/junior/src/chat/slack/tools/channel-capabilities.ts
+++ b/packages/junior/src/chat/slack/tools/channel-capabilities.ts
@@ -7,6 +7,8 @@ import {
 export interface ChannelCapabilities {
   /** Can create canvases in this channel (C/G/D channels). */
   canCreateCanvas: boolean;
+  /** Can send messages into this conversation scope (C/G/D channels). */
+  canSendMessage: boolean;
   /** Can post standalone messages to this channel (C/G channels only). */
   canPostToChannel: boolean;
   /** Can add reactions to messages (C/G/D channels). */
@@ -19,6 +21,7 @@ export function resolveChannelCapabilities(
 ): ChannelCapabilities {
   return {
     canCreateCanvas: isConversationScopedChannel(channelId),
+    canSendMessage: isConversationScopedChannel(channelId),
     canPostToChannel: isConversationChannel(channelId),
     canAddReactions: isConversationScopedChannel(channelId),
   };

--- a/packages/junior/src/chat/slack/tools/send-message.ts
+++ b/packages/junior/src/chat/slack/tools/send-message.ts
@@ -46,11 +46,8 @@ const fileInputSchema = Type.Object(
   { additionalProperties: false },
 );
 
-type SendMessageTarget = "channel" | "thread";
-
 interface SendMessageResult {
   ok: true;
-  target: SendMessageTarget;
   channel_id: string;
   file_count?: number;
   file_ids?: string[];
@@ -61,16 +58,6 @@ interface SendMessageResult {
 
 function hasText(text: string | null | undefined): text is string {
   return typeof text === "string" && text.trim().length > 0;
-}
-
-function normalizeSendMessageTarget(target: unknown): SendMessageTarget {
-  if (target == null) {
-    return "channel";
-  }
-  if (target === "channel" || target === "thread") {
-    return target;
-  }
-  throw new ToolInputError("sendMessage target must be `channel` or `thread`.");
 }
 
 function normalizeMessageFiles(
@@ -98,7 +85,7 @@ function fileOperationInput(files: SandboxFileUpload[]) {
   }));
 }
 
-/** Create the current Slack side-effect tool for channel or thread text and file messages. */
+/** Create the Slack side-effect tool for active-conversation text and file messages. */
 export function createSendMessageTool(
   context: SlackToolContext,
   state: ToolState,
@@ -106,18 +93,9 @@ export function createSendMessageTool(
 ) {
   return tool({
     description:
-      "Send a Slack message with optional files. Use target `thread` when the user asks to attach, send, or share files here, in this conversation, or in this thread. Use target `channel` only when the user explicitly asks for a top-level/current-channel post, for example `post this to the channel`. After a successful target `channel` send that satisfies the request, do not add a normal thread acknowledgement; final text should be the no-reply marker. The message can contain text, files, or both; file-only messages are allowed. Do not use for other named channels, inline @mentions, or pinging mentioned users.",
+      "Send a Slack message with optional files into the active Slack conversation. Use when the user asks to attach, send, or share files here, in this conversation, or in this thread. The message can contain text, files, or both; file-only messages are allowed. Do not use for top-level channel posts, other named channels, inline @mentions, or pinging mentioned users.",
     inputSchema: Type.Object(
       {
-        target: Type.Optional(
-          Type.Union(
-            [Type.Literal("channel"), Type.Literal("thread"), Type.Null()],
-            {
-              description:
-                "Delivery target. `thread` sends into the current Slack thread. `channel` posts a new top-level channel message and requires explicit channel/top-level intent. Text-only messages default to `channel`; messages with files default to `thread`. Null is treated as omitted.",
-            },
-          ),
-        ),
         text: Type.Optional(
           Type.Union([Type.String({ maxLength: 40000 }), Type.Null()], {
             description:
@@ -136,28 +114,17 @@ export function createSendMessageTool(
       },
       { additionalProperties: false },
     ),
-    execute: async ({ target, text, files }) => {
+    execute: async ({ text, files }) => {
       const filesToSend = normalizeMessageFiles(files);
-      const deliveryTarget = normalizeSendMessageTarget(
-        target ?? (filesToSend.length > 0 ? "thread" : "channel"),
-      );
-      const targetChannelId =
-        deliveryTarget === "thread"
-          ? context.sourceChannelId
-          : context.destinationChannelId;
-      if (!targetChannelId) {
-        throw new ToolInputError(
-          deliveryTarget === "thread"
-            ? "No active Slack source thread is available."
-            : "No active Slack destination is available.",
-        );
+      const activeChannelId = context.sourceChannelId;
+      if (!activeChannelId) {
+        throw new ToolInputError("No active Slack conversation is available.");
       }
-      const threadTs =
-        deliveryTarget === "thread"
-          ? (context.threadTs ?? context.messageTs)
-          : undefined;
-      if (deliveryTarget === "thread" && !threadTs) {
-        throw new ToolInputError("No active Slack thread is available.");
+      const threadTs = context.threadTs ?? context.messageTs;
+      if (!threadTs) {
+        throw new ToolInputError(
+          "No active Slack conversation timestamp is available.",
+        );
       }
       const textToSend = hasText(text) ? text : undefined;
       if (!textToSend && filesToSend.length === 0) {
@@ -170,9 +137,8 @@ export function createSendMessageTool(
         filesToSend.map((file) => materializeFile(file)),
       );
       const operationKey = createOperationKey("sendMessage", {
-        target: deliveryTarget,
-        channel_id: targetChannelId,
-        ...(threadTs ? { thread_ts: threadTs } : {}),
+        channel_id: activeChannelId,
+        thread_ts: threadTs,
         ...(textToSend ? { text: textToSend } : {}),
         ...(materializedFiles.length > 0
           ? { files: fileOperationInput(materializedFiles) }
@@ -193,26 +159,25 @@ export function createSendMessageTool(
       const posted =
         uploads.length === 0 && textToSend
           ? await postSlackMessage({
-              channelId: targetChannelId,
+              channelId: activeChannelId,
               text: textToSend,
-              ...(threadTs ? { threadTs } : {}),
+              threadTs,
               includePermalink: true,
             })
           : undefined;
       const uploaded =
         uploads.length > 0
           ? await uploadFilesToConversation({
-              channelId: targetChannelId,
+              channelId: activeChannelId,
               files: uploads,
-              ...(threadTs ? { threadTs } : {}),
+              threadTs,
               ...(textToSend ? { initialComment: textToSend } : {}),
             })
           : undefined;
       const response = {
         ok: true,
-        target: deliveryTarget,
-        channel_id: targetChannelId,
-        ...(threadTs ? { thread_ts: threadTs } : {}),
+        channel_id: activeChannelId,
+        thread_ts: threadTs,
         ...(posted ? { ts: posted.ts, permalink: posted.permalink } : {}),
         ...(uploads.length > 0 ? { file_count: uploads.length } : {}),
         ...(uploaded?.files

--- a/packages/junior/src/chat/tools/index.ts
+++ b/packages/junior/src/chat/tools/index.ts
@@ -1,4 +1,4 @@
-import { resolveChannelCapabilities } from "@/chat/tools/channel-capabilities";
+import { resolveChannelCapabilities } from "@/chat/slack/tools/channel-capabilities";
 import { createBashTool } from "@/chat/tools/sandbox/bash";
 import { createEditFileTool } from "@/chat/tools/sandbox/edit-file";
 import { createFindFilesTool } from "@/chat/tools/sandbox/find-files";
@@ -84,6 +84,7 @@ function createToolState(
 
 export type { ToolHooks, ToolRuntimeContext };
 
+/** Build the model-facing tool registry from runtime-owned context and capabilities. */
 export function createTools(
   availableSkills: SkillMetadata[],
   hooks: ToolHooks = {},
@@ -97,7 +98,6 @@ export function createTools(
     reportProgress: createReportProgressTool(),
     systemTime: createSystemTimeTool(),
     bash: createBashTool(),
-    attachFile: createAttachFileTool(context.sandbox, hooks),
     readFile: createReadFileTool(),
     editFile: createEditFileTool(),
     grep: createGrepTool(),
@@ -112,6 +112,9 @@ export function createTools(
       { writeGeneratedArtifacts: hooks.writeGeneratedArtifacts },
       hooks.toolOverrides?.imageGenerate,
     );
+  }
+  if (context.source.platform !== "slack") {
+    tools.attachFile = createAttachFileTool(context.sandbox, hooks);
   }
 
   if (context.advisor) {
@@ -148,7 +151,7 @@ export function createTools(
     const outputCapabilities = outputChannelId
       ? resolveChannelCapabilities(outputChannelId)
       : undefined;
-    const canPostStandaloneSlackMessage =
+    const canUseInteractiveSlackSideEffects =
       context.surface === undefined || context.surface === "slack";
     const rawChannelCapabilities = resolveChannelCapabilities(
       slackContext.sourceChannelId,
@@ -161,7 +164,10 @@ export function createTools(
       );
     }
 
-    if (outputCapabilities?.canPostToChannel && canPostStandaloneSlackMessage) {
+    if (
+      canUseInteractiveSlackSideEffects &&
+      rawChannelCapabilities.canSendMessage
+    ) {
       tools.sendMessage = createSendMessageTool(slackContext, state, (input) =>
         readSandboxFileUpload(context.sandbox, input),
       );

--- a/packages/junior/src/chat/tools/web/image-generate.ts
+++ b/packages/junior/src/chat/tools/web/image-generate.ts
@@ -184,7 +184,7 @@ export function createImageGenerateTool(
             bytes: artifact.bytes,
           })),
           delivery:
-            "Generated images were written to sandbox paths. Use sendMessage with target `thread` to share or attach the image here. Use target `channel` only if the user explicitly asked for a top-level/current-channel post; after a successful channel send, use the no-reply marker instead of adding a thread acknowledgement.",
+            "Generated images were written to sandbox paths. Use sendMessage to share or attach the image in the active Slack conversation.",
         };
       }
 

--- a/packages/junior/tests/integration/slack-channel-tools.test.ts
+++ b/packages/junior/tests/integration/slack-channel-tools.test.ts
@@ -151,7 +151,7 @@ async function executeTool<TInput>(tool: any, input: TInput) {
 }
 
 describe("slack channel tools", () => {
-  it("posts to channel even without explicit post-intent phrasing in user text", async () => {
+  it("posts text into the active Slack conversation", async () => {
     queueSlackApiResponse("chat.postMessage", {
       body: chatPostMessageOk({
         ts: "1700000000.111",
@@ -175,12 +175,19 @@ describe("slack channel tools", () => {
     expect(result).toMatchObject({
       ok: true,
       channel_id: "C123",
+      thread_ts: "1700000000.321",
       ts: "1700000000.111",
     });
-    expect(getCapturedSlackApiCalls("chat.postMessage")).toHaveLength(1);
+    expect(
+      getCapturedSlackApiCalls("chat.postMessage")[0]?.params,
+    ).toMatchObject({
+      channel: "C123",
+      thread_ts: "1700000000.321",
+      text: "Posting this update",
+    });
   });
 
-  it("uses assistant context channel for channel delivery tools in DM turns", async () => {
+  it("uses source coordinates for sendMessage and destination context for channel reads", async () => {
     const context = createContext("share this in the current channel", {
       sourceChannelId: "D123",
       destinationChannelId: "C0SHARED",
@@ -188,7 +195,7 @@ describe("slack channel tools", () => {
     queueSlackApiResponse("chat.postMessage", {
       body: chatPostMessageOk({
         ts: "1700000000.112",
-        channel: "C0SHARED",
+        channel: "D123",
       }),
     });
     queueSlackApiResponse("chat.getPermalink", {
@@ -217,7 +224,8 @@ describe("slack channel tools", () => {
     expect(
       getCapturedSlackApiCalls("chat.postMessage")[0]?.params,
     ).toMatchObject({
-      channel: "C0SHARED",
+      channel: "D123",
+      thread_ts: "1700000000.321",
       text: "Shared update",
     });
     expect(
@@ -227,7 +235,7 @@ describe("slack channel tools", () => {
     });
   });
 
-  it("posts to channel when explicit post intent is present and deduplicates within turn", async () => {
+  it("sends active-conversation text once for duplicate inputs", async () => {
     queueSlackApiResponse("chat.postMessage", {
       body: chatPostMessageOk({
         ts: "1700000000.200",
@@ -240,7 +248,7 @@ describe("slack channel tools", () => {
       }),
     });
     const tool = createSendMessageTool(
-      createContext("please post this in #eng channel"),
+      createContext("please share this here"),
       createToolState(),
       createMaterializeFile(),
     );
@@ -255,6 +263,7 @@ describe("slack channel tools", () => {
     expect(first).toMatchObject({
       ok: true,
       channel_id: "C123",
+      thread_ts: "1700000000.321",
       ts: "1700000000.200",
     });
     expect(second).toMatchObject({
@@ -266,6 +275,7 @@ describe("slack channel tools", () => {
     expect(postCalls).toHaveLength(1);
     expect(postCalls[0]?.params).toMatchObject({
       channel: "C123",
+      thread_ts: "1700000000.321",
       text: "Incident resolved.",
     });
     expect(getCapturedSlackApiCalls("chat.getPermalink")).toHaveLength(1);
@@ -389,7 +399,7 @@ describe("slack channel tools", () => {
     expect(getCapturedSlackApiCalls("conversations.history")).toHaveLength(0);
   });
 
-  it("returns posted message even when permalink lookup fails", async () => {
+  it("returns posted conversation message even when permalink lookup fails", async () => {
     queueSlackApiResponse("chat.postMessage", {
       body: chatPostMessageOk({
         ts: "1700000000.400",
@@ -411,8 +421,8 @@ describe("slack channel tools", () => {
 
     expect(result).toEqual({
       ok: true,
-      target: "channel",
       channel_id: "C123",
+      thread_ts: "1700000000.321",
       ts: "1700000000.400",
       permalink: undefined,
     });
@@ -430,7 +440,6 @@ describe("slack channel tools", () => {
     );
 
     const result = await executeTool(tool, {
-      target: "channel",
       text: "Here is the report.",
       files: [{ path: "/tmp/report.txt" }],
     });
@@ -448,6 +457,7 @@ describe("slack channel tools", () => {
       getCapturedSlackApiCalls("files.completeUploadExternal")[0]?.params,
     ).toMatchObject({
       channel_id: "C123",
+      thread_ts: "1700000000.321",
       initial_comment: "Here is the report.",
     });
   });
@@ -462,7 +472,6 @@ describe("slack channel tools", () => {
     );
 
     const result = await executeTool(tool, {
-      target: "channel",
       files: [{ path: "/tmp/report.txt" }],
     });
 
@@ -476,6 +485,7 @@ describe("slack channel tools", () => {
       getCapturedSlackApiCalls("files.completeUploadExternal")[0]?.params,
     ).toMatchObject({
       channel_id: "C123",
+      thread_ts: "1700000000.321",
     });
     expect(
       getCapturedSlackApiCalls("files.completeUploadExternal")[0]?.params,
@@ -503,13 +513,11 @@ describe("slack channel tools", () => {
     );
 
     const result = await executeTool(tool, {
-      target: "thread",
       text: "Thread update.",
     });
 
     expect(result).toMatchObject({
       ok: true,
-      target: "thread",
       channel_id: "C123",
       thread_ts: "1700000000.321",
       ts: "1700000000.700",
@@ -538,13 +546,11 @@ describe("slack channel tools", () => {
     );
 
     const result = await executeTool(tool, {
-      target: "thread",
       files: [{ path: "/tmp/report.txt" }],
     });
 
     expect(result).toMatchObject({
       ok: true,
-      target: "thread",
       channel_id: "D123",
       thread_ts: "1700000000.321",
       file_count: 1,
@@ -569,13 +575,11 @@ describe("slack channel tools", () => {
     );
 
     const result = await executeTool(tool, {
-      target: "thread",
       files: [{ path: "/tmp/report.txt" }],
     });
 
     expect(result).toMatchObject({
       ok: true,
-      target: "thread",
       channel_id: "C123",
       thread_ts: "1700000000.321",
       file_count: 1,
@@ -606,7 +610,6 @@ describe("slack channel tools", () => {
 
     expect(result).toMatchObject({
       ok: true,
-      target: "thread",
       channel_id: "C123",
       thread_ts: "1700000000.321",
       file_count: 1,
@@ -631,14 +634,12 @@ describe("slack channel tools", () => {
     );
 
     const result = await executeTool(tool, {
-      target: null,
       text: null,
       files: [{ path: "/tmp/report.txt", filename: null, mimeType: null }],
     });
 
     expect(result).toMatchObject({
       ok: true,
-      target: "thread",
       channel_id: "C123",
       thread_ts: "1700000000.321",
       file_count: 1,
@@ -649,22 +650,6 @@ describe("slack channel tools", () => {
       channel_id: "C123",
       thread_ts: "1700000000.321",
     });
-  });
-
-  it("rejects invalid sendMessage targets", async () => {
-    const tool = createSendMessageTool(
-      createContext("send this"),
-      createToolState(),
-      createMaterializeFile(),
-    );
-
-    await expect(
-      executeTool(tool, {
-        target: "dm",
-        text: "Invalid target.",
-      }),
-    ).rejects.toThrow("sendMessage target must be `channel` or `thread`");
-    expect(getCapturedSlackApiCalls("chat.postMessage")).toHaveLength(0);
   });
 
   it("does not deduplicate changed file contents at the same path", async () => {

--- a/packages/junior/tests/unit/delivery/plan.test.ts
+++ b/packages/junior/tests/unit/delivery/plan.test.ts
@@ -2,16 +2,14 @@ import { describe, expect, it } from "vitest";
 import { buildReplyDeliveryPlan } from "@/chat/services/reply-delivery-plan";
 
 describe("buildReplyDeliveryPlan", () => {
-  it("returns channel_only mode when a channel side effect owns the reply", () => {
+  it("keeps finalized replies in the thread without files", () => {
     expect(
       buildReplyDeliveryPlan({
-        channelOnlySideEffect: true,
-        channelPostPerformed: true,
         hasFiles: false,
       }),
     ).toEqual({
-      mode: "channel_only",
-      postThreadText: false,
+      mode: "thread",
+      postThreadText: true,
       attachFiles: "none",
     });
   });
@@ -19,8 +17,6 @@ describe("buildReplyDeliveryPlan", () => {
   it("keeps files inline with finalized thread replies", () => {
     expect(
       buildReplyDeliveryPlan({
-        channelOnlySideEffect: false,
-        channelPostPerformed: false,
         hasFiles: true,
       }),
     ).toEqual({

--- a/packages/junior/tests/unit/slack/channel-capabilities.test.ts
+++ b/packages/junior/tests/unit/slack/channel-capabilities.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveChannelCapabilities } from "@/chat/tools/channel-capabilities";
+import { resolveChannelCapabilities } from "@/chat/slack/tools/channel-capabilities";
 
 describe("resolveChannelCapabilities", () => {
   it.each([
@@ -8,6 +8,7 @@ describe("resolveChannelCapabilities", () => {
       channelId: "C123",
       expected: {
         canCreateCanvas: true,
+        canSendMessage: true,
         canPostToChannel: true,
         canAddReactions: true,
       },
@@ -17,6 +18,7 @@ describe("resolveChannelCapabilities", () => {
       channelId: "G456",
       expected: {
         canCreateCanvas: true,
+        canSendMessage: true,
         canPostToChannel: true,
         canAddReactions: true,
       },
@@ -26,6 +28,7 @@ describe("resolveChannelCapabilities", () => {
       channelId: "D789",
       expected: {
         canCreateCanvas: true,
+        canSendMessage: true,
         canPostToChannel: false,
         canAddReactions: true,
       },
@@ -35,6 +38,7 @@ describe("resolveChannelCapabilities", () => {
       channelId: undefined,
       expected: {
         canCreateCanvas: false,
+        canSendMessage: false,
         canPostToChannel: false,
         canAddReactions: false,
       },
@@ -44,6 +48,7 @@ describe("resolveChannelCapabilities", () => {
       channelId: "",
       expected: {
         canCreateCanvas: false,
+        canSendMessage: false,
         canPostToChannel: false,
         canAddReactions: false,
       },

--- a/packages/junior/tests/unit/slack/tool-registration.test.ts
+++ b/packages/junior/tests/unit/slack/tool-registration.test.ts
@@ -58,10 +58,16 @@ describe("Slack tool registration", () => {
     vi.restoreAllMocks();
   });
 
-  it("does not register channel-scope tools in DM context", () => {
+  it("registers thread sendMessage but not channel-only tools in DM context", () => {
     const tools = createTools([], {}, ctx("D12345"));
 
-    expect(tools).not.toHaveProperty("sendMessage");
+    expect(tools).toHaveProperty("sendMessage");
+    const sendMessageTool = tools.sendMessage;
+    if (!sendMessageTool) {
+      throw new Error("sendMessage tool missing");
+    }
+    expect(sendMessageTool.inputSchema).not.toHaveProperty("properties.target");
+    expect(tools).not.toHaveProperty("attachFile");
     expect(tools).not.toHaveProperty("slackChannelListMessages");
     expect(tools).toHaveProperty("addReaction");
     expect(tools).toHaveProperty("slackCanvasCreate");
@@ -71,6 +77,7 @@ describe("Slack tool registration", () => {
     const tools = createTools([], {}, ctx("C12345"));
 
     expect(tools).toHaveProperty("sendMessage");
+    expect(tools).not.toHaveProperty("attachFile");
     expect(tools).toHaveProperty("slackChannelListMessages");
     expect(tools).toHaveProperty("addReaction");
     expect(tools).toHaveProperty("slackCanvasCreate");
@@ -192,6 +199,7 @@ describe("Slack tool registration", () => {
     expect(
       Object.keys(tools).filter((name) => name.startsWith("slack")),
     ).toEqual([]);
+    expect(tools).toHaveProperty("attachFile");
   });
 
   it("registers image generation only when artifact persistence is available", () => {

--- a/packages/junior/tests/unit/turn-result.test.ts
+++ b/packages/junior/tests/unit/turn-result.test.ts
@@ -306,75 +306,6 @@ describe("buildTurnResult", () => {
     expect(reply.diagnostics.usedPrimaryText).toBe(true);
   });
 
-  it("suppresses duplicate thread replies after sendMessage succeeds", () => {
-    const reply = buildTurnResult({
-      newMessages: [
-        {
-          role: "toolResult",
-          toolName: "sendMessage",
-          isError: false,
-          content: [{ type: "text", text: "posted" }],
-          details: { ok: true, target: "channel", channel_id: "C123" },
-        },
-        {
-          role: "assistant",
-          content: [{ type: "text", text: NO_REPLY_MARKER }],
-          stopReason: "stop",
-        },
-      ],
-      userInput: "say hello to the channel",
-      replyFiles: [],
-      artifactStatePatch: {},
-      toolCalls: ["sendMessage"],
-      generatedFileCount: 0,
-      shouldTrace: false,
-      spanContext: {},
-      thinkingSelection,
-    });
-
-    expect(reply.text).toBe("");
-    expect(reply.deliveryMode).toBe("channel_only");
-    expect(reply.deliveryPlan).toMatchObject({
-      postThreadText: false,
-    });
-    expect(reply.diagnostics.outcome).toBe("success");
-  });
-
-  it("treats empty sendMessage-only turns as channel-only success", () => {
-    const reply = buildTurnResult({
-      newMessages: [
-        {
-          role: "toolResult",
-          toolName: "sendMessage",
-          isError: false,
-          content: [{ type: "text", text: '{"file_count":1}' }],
-          details: {
-            ok: true,
-            target: "channel",
-            channel_id: "C123",
-            file_count: 1,
-          },
-        },
-      ],
-      userInput: "send the generated image to the channel",
-      replyFiles: [],
-      artifactStatePatch: {},
-      toolCalls: ["sendMessage"],
-      generatedFileCount: 1,
-      shouldTrace: false,
-      spanContext: {},
-      thinkingSelection,
-    });
-
-    expect(reply.text).toBe("");
-    expect(reply.deliveryMode).toBe("channel_only");
-    expect(reply.deliveryPlan).toMatchObject({
-      postThreadText: false,
-    });
-    expect(reply.diagnostics.outcome).toBe("success");
-    expect(reply.diagnostics.usedPrimaryText).toBe(false);
-  });
-
   it("keeps pending reply files in the thread after sendMessage succeeds", () => {
     const reply = buildTurnResult({
       newMessages: [
@@ -383,7 +314,11 @@ describe("buildTurnResult", () => {
           toolName: "sendMessage",
           isError: false,
           content: [{ type: "text", text: "posted" }],
-          details: { ok: true, target: "channel", channel_id: "C123" },
+          details: {
+            ok: true,
+            channel_id: "C123",
+            thread_ts: "1700000000.321",
+          },
         },
       ],
       userInput: "send the message and attach the report",
@@ -413,7 +348,7 @@ describe("buildTurnResult", () => {
     expect(reply.diagnostics.usedPrimaryText).toBe(false);
   });
 
-  it("does not treat thread-target sendMessage as final reply completion", () => {
+  it("does not treat sendMessage as final reply completion", () => {
     const reply = buildTurnResult({
       newMessages: [
         {
@@ -423,7 +358,6 @@ describe("buildTurnResult", () => {
           content: [{ type: "text", text: "posted in thread" }],
           details: {
             ok: true,
-            target: "thread",
             channel_id: "C123",
             thread_ts: "1700000000.321",
           },

--- a/specs/agent-turn-handling.md
+++ b/specs/agent-turn-handling.md
@@ -122,17 +122,16 @@ Junior must use Slack side-effect tools only when the user explicitly requests t
 Scenarios:
 
 1. User asks Junior to send content in thread:
-   - When Junior needs to send, share, or attach text, sandbox-path files, or both here, in this conversation, or in the current Slack thread, Junior may use `sendMessage` with `target: "thread"`.
-   - Thread-target `sendMessage` is a Slack side effect, not the final assistant reply. Junior may still provide normal final assistant text afterward when useful.
+   - When Junior needs to send, share, or attach text, sandbox-path files, or both here, in this conversation, or in the current Slack thread, Junior may use `sendMessage`.
+   - `sendMessage` has no model-supplied target. Runtime source context owns the active Slack conversation/thread.
+   - `sendMessage` is a Slack side effect, not the final assistant reply. Junior may still provide normal final assistant text afterward when useful.
 2. User asks Junior to post in channel:
-   - When the user explicitly asks Junior to post, send, say, or share a top-level message in the current Slack channel, Junior must use the `sendMessage` tool with `target: "channel"` when the runtime provides a valid target and must not use a normal thread reply as a substitute for the requested channel post.
-   - Channel-target `sendMessage` may send text, sandbox-path files, or both. File-only messages are valid when the user's requested message is represented entirely by attachments.
+   - Top-level channel posting is not currently a model-facing Slack side-effect capability. Junior must explain that it can send only into the active conversation instead of pretending a thread reply is a top-level channel post.
 3. User asks Junior to react:
    - When the user explicitly asks Junior to add a Slack reaction, Junior must use `addReaction` when the runtime provides a valid target and must not treat automatic processing reactions as satisfying the user's request.
 4. Slack side effect satisfies the turn:
    - When a successful Slack side-effect tool already satisfies the user's request, Junior may suppress a duplicate final thread reply according to the reply-delivery plan when the assistant used the no-reply marker.
-   - A successful channel-target `sendMessage` call with no visible final assistant text also satisfies the turn, because the requested channel message has already been delivered.
-   - A thread-target `sendMessage` call does not by itself satisfy the final assistant reply contract.
+   - `sendMessage` does not by itself satisfy the final assistant reply contract.
 
 ### 8. Progress And Resumed-Turn Behavior
 

--- a/specs/harness-tool-context.md
+++ b/specs/harness-tool-context.md
@@ -32,7 +32,7 @@ For context-bound side-effect tools, target selection is owned by the harness/ru
 
 Examples:
 
-- First-class Slack delivery tools (channel post, canvas create, list messages, and private thread-read context) resolve their target channel from `ToolRuntimeContext.destination.channelId`. Slack message reactions use `ToolRuntimeContext.source.channelId` and `ToolRuntimeContext.source.messageTs` because they target the current inbound Slack message.
+- First-class Slack delivery tools resolve runtime-owned destinations rather than model-supplied targets. `sendMessage` uses `ToolRuntimeContext.source.channelId` and the active source thread/message timestamp because it sends into the active conversation. Canvas create and channel list messages use `ToolRuntimeContext.destination.channelId`. Slack message reactions use `ToolRuntimeContext.source.channelId` and `ToolRuntimeContext.source.messageTs` because they target the current inbound Slack message.
 - Plugin tools receive `ToolRegistrationHookContext.source` as Junior's shared inbound context. When an outbound target exists, plugins also receive `ToolRegistrationHookContext.destination`. When `source.platform === "slack"`, plugins receive Slack-specific helper context at `ToolRegistrationHookContext.slack`, including source-channel capabilities and any source-bound credential subject. Local hook contexts must not include `slack`.
 - List follow-up operations resolve target artifacts from harness-managed artifact state (`lastListId`, turn-created IDs).
 - Slack Canvas document operations use explicit file-like handles (`canvas`). Canvas IDs and URLs may be attempted directly; Slack file permissions and Canvas metadata decide whether the operation can proceed.
@@ -47,7 +47,7 @@ Examples:
 
 ## Slack-Specific Targeting Rules
 
-1. Channel-scoped Slack delivery tools use `ToolRuntimeContext.destination.channelId` as the outbound target. The model cannot override this. If no destination is present, outbound tools must not register or must fail with an actionable tool input error.
+1. Slack side-effect tools use runtime-owned coordinates. `sendMessage` uses the active source conversation and thread/message timestamp; channel-scoped read or artifact tools use `ToolRuntimeContext.destination.channelId`. The model cannot override these coordinates. If required context is absent, outbound tools must not register or must fail with an actionable tool input error.
 2. Slack reactions use `ToolRuntimeContext.source.channelId` and `ToolRuntimeContext.source.messageTs`.
 3. Canvas creation uses the active Slack outbound destination (`C*`/`G*`/`D*`) without model-provided destination overrides.
 4. Canvas read/edit/write tools are document tools: `canvas` is analogous to a file path, accepts a Slack canvas/file ID or URL, and must not expose Slack section IDs or section lookup criteria.

--- a/specs/slack-agent-delivery.md
+++ b/specs/slack-agent-delivery.md
@@ -152,7 +152,7 @@ Current rules:
 
 1. Do not create a visible Slack text artifact until the assistant reply is final enough to budget, normalize, and persist.
 2. Deliver visible reply text through finalized thread posts, not through incremental text streaming.
-3. Only mark a text-reply turn successful after the final visible Slack reply has been accepted by Slack. When a successful requested Slack side effect, such as a reaction or in-channel post, fully satisfies the turn and the assistant uses the no-reply marker, that side effect is the visible completion.
+3. Only mark a text-reply turn successful after the final visible Slack reply has been accepted by Slack. When a successful requested Slack side effect, such as a reaction, fully satisfies the turn and the assistant uses the no-reply marker, that side effect is the visible completion. `sendMessage` is an active-conversation side effect and does not replace final reply delivery.
 4. If the assistant chose a Slack side-effect tool and that successful side effect already satisfied the request, Junior may suppress the thread text reply according to the reply-delivery plan only when the assistant used the no-reply marker or produced no assistant text. Delivery code must rely on tool results and structured markers for this decision, not regex or keyword matching against user or assistant prose.
 5. Persisted assistant conversation state must reflect the same finalized reply content the user saw, not provisional pre-tool text.
 6. Reply text must be rendered through the shared Slack output translator before delivery; raw Slack API writers do not own markdown translation rules.
@@ -195,7 +195,7 @@ Current rules:
 
 1. Thread replies attach files inline on the first visible reply post when possible.
 2. File-only replies must still create a visible Slack thread reply carrying the file payload.
-3. `sendMessage` with `target: "thread"` may send text, files, or both into the current Slack thread as a side effect. It does not replace the final assistant reply contract.
+3. `sendMessage` may send text, files, or both into the active Slack conversation/thread as a side effect. It has no model-supplied target and does not replace the final assistant reply contract.
 4. If thread text is intentionally suppressed, files may still be delivered through the thread reply planner when the reply contract requires visible artifacts.
 5. Resume and OAuth callback flows must use the same file-delivery semantics as the main runtime path.
 


### PR DESCRIPTION
Slack file and text side effects now go through sendMessage in the active source conversation/thread. Slack contexts no longer expose attachFile, and top-level channel posting is treated as unsupported instead of trying to retarget a thread send.

This keeps Slack coordinates runtime-owned: sendMessage has no target argument, reply planning no longer treats channel posts as final delivery, and the Slack capability helper now lives under the Slack tool module. Coverage includes integration tests for payload coordinates plus evals for both share-here and unsupported top-level channel-post requests.

Refs #737