### PR TITLE
ref(runtime): Tighten chat boundary typing

### DIFF
--- a/packages/junior/src/chat/agent/prompt.ts
+++ b/packages/junior/src/chat/agent/prompt.ts
@@ -33,7 +33,7 @@ import {
 import type { SkillInvocation, SkillMetadata } from "@/chat/skills";
 import type { ActiveMcpCatalogSummary } from "@/chat/tools/skill/mcp-tool-summary";
 import type { ToolRuntimeContext } from "@/chat/tools/types";
-import type { ToolDefinition } from "@/chat/tools/definition";
+import type { AnyToolDefinition } from "@/chat/tools/definition";
 import type { Requester } from "@/chat/requester";
 import type { ThreadArtifactsState } from "@/chat/state/artifacts";
 import type {
@@ -397,8 +397,8 @@ export async function assemblePrompt(args: {
   spanContext: LogContext;
   toolGuidance: Array<{
     name: string;
-    promptGuidelines: ToolDefinition<any>["promptGuidelines"];
-    promptSnippet: ToolDefinition<any>["promptSnippet"];
+    promptGuidelines: AnyToolDefinition["promptGuidelines"];
+    promptSnippet: AnyToolDefinition["promptSnippet"];
   }>;
   toolRuntimeContext: ToolRuntimeContext;
   userContentParts: UserContentPart[];

--- a/packages/junior/src/chat/agent/tools.ts
+++ b/packages/junior/src/chat/agent/tools.ts
@@ -23,7 +23,7 @@ import { pluginCatalogRuntime } from "@/chat/plugins/catalog-runtime";
 import { McpToolManager } from "@/chat/mcp/tool-manager";
 import { inferActiveMcpProvidersFromPiMessages } from "@/chat/pi/derived-state";
 import { createTools } from "@/chat/tools";
-import type { ToolDefinition } from "@/chat/tools/definition";
+import type { AnyToolDefinition } from "@/chat/tools/definition";
 import type { ToolRuntimeContext } from "@/chat/tools/types";
 import {
   toActiveMcpCatalogSummaries,
@@ -104,8 +104,8 @@ export interface ToolWiring {
   sandboxExecutor: SandboxExecutor;
   toolGuidance: Array<{
     name: string;
-    promptGuidelines: ToolDefinition<any>["promptGuidelines"];
-    promptSnippet: ToolDefinition<any>["promptSnippet"];
+    promptGuidelines: AnyToolDefinition["promptGuidelines"];
+    promptSnippet: AnyToolDefinition["promptSnippet"];
   }>;
   toolRuntimeContext: ToolRuntimeContext;
 }
@@ -351,7 +351,7 @@ export async function wireAgentTools(
   );
 
   const toolGuidance = Object.entries(
-    tools as Record<string, ToolDefinition<any>>,
+    tools as Record<string, AnyToolDefinition>,
   ).map(([name, definition]) => ({
     name,
     promptGuidelines: definition.promptGuidelines,

--- a/packages/junior/src/chat/pi/messages.ts
+++ b/packages/junior/src/chat/pi/messages.ts
@@ -1,4 +1,22 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { z } from "zod";
+
+/** Permissive schema for durable Pi SDK messages whose content shape may evolve. */
+export const piMessageSchema = z
+  .object({
+    role: z.string(),
+  })
+  .passthrough()
+  .transform((value) => value as unknown as AgentMessage);
 
 /** Durable Pi transcript message stored across turns. */
-export type PiMessage = AgentMessage;
+export type PiMessage = z.output<typeof piMessageSchema>;
+
+/** Reporting transcript entries only render messages with structured content parts. */
+export const piContentMessageSchema = z
+  .object({
+    content: z.array(z.unknown()),
+    role: z.string().min(1),
+  })
+  .passthrough()
+  .transform((value) => value as unknown as PiMessage);

--- a/packages/junior/src/chat/plugins/agent-hooks.ts
+++ b/packages/junior/src/chat/plugins/agent-hooks.ts
@@ -22,7 +22,7 @@ import { createPluginEmbedder, createPluginModel } from "@/chat/plugins/model";
 import type { PluginPromptContributionContext } from "@/chat/plugins/prompt";
 import { createPluginState } from "@/chat/plugins/state";
 import { SANDBOX_WORKSPACE_ROOT } from "@/chat/sandbox/paths";
-import type { ToolDefinition } from "@/chat/tools/definition";
+import type { AnyToolDefinition } from "@/chat/tools/definition";
 import { getSlackToolContext } from "@/chat/slack/tools/context";
 import type { ToolRuntimeContext } from "@/chat/tools/types";
 import type {
@@ -384,8 +384,8 @@ export async function getPluginUserPromptContributions(args: {
 /** Collect turn-scoped tools exposed by plugins. */
 export function getPluginTools(
   context: ToolRuntimeContext,
-): Record<string, ToolDefinition<any>> {
-  const tools: Record<string, ToolDefinition<any>> = {};
+): Record<string, AnyToolDefinition> {
+  const tools: Record<string, AnyToolDefinition> = {};
   for (const plugin of getPlugins()) {
     const pluginName = plugin.manifest.name;
     const hook = plugin.hooks?.tools;
@@ -468,7 +468,7 @@ export function getPluginTools(
           `Duplicate plugin tool "${name}" from plugin "${pluginName}"`,
         );
       }
-      const definition = tool as unknown as ToolDefinition<any>;
+      const definition = tool as unknown as AnyToolDefinition;
       definition.identity = {
         id: `${pluginName}.${localName}`,
         name: localName,

--- a/packages/junior/src/chat/runtime/thread-context.ts
+++ b/packages/junior/src/chat/runtime/thread-context.ts
@@ -6,6 +6,7 @@ import { getWorkspaceTeamId } from "@/chat/slack/workspace-context";
 import { isSlackTeamId } from "@/chat/slack/ids";
 import {
   parseSlackThreadId,
+  readSlackRawMessageContext,
   resolveSlackChannelIdFromThreadId,
   resolveSlackChannelIdFromMessage,
 } from "@/chat/slack/context";
@@ -21,6 +22,17 @@ function toSlackTeamId(value: unknown): string | undefined {
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function readObjectField(value: object, key: string): unknown {
+  return (value as Record<string, unknown>)[key];
+}
+
+function readOptionalStringField(
+  value: object,
+  key: string,
+): string | undefined {
+  return toOptionalString(readObjectField(value, key));
 }
 
 interface StripLeadingBotMentionOptions {
@@ -72,8 +84,8 @@ export function getThreadId(
 
 export function getRunId(thread: Thread, message: Message): string | undefined {
   return (
-    toOptionalString((thread as unknown as { runId?: unknown }).runId) ??
-    toOptionalString((message as unknown as { runId?: unknown }).runId)
+    readOptionalStringField(thread, "runId") ??
+    readOptionalStringField(message, "runId")
   );
 }
 
@@ -104,24 +116,19 @@ export function getThreadTs(threadId: string | undefined): string | undefined {
 export function getAssistantThreadContext(
   message: Message,
 ): { channelId: string; threadTs: string } | undefined {
-  const raw = (message as unknown as { raw?: unknown }).raw;
-  const rawRecord =
-    raw && typeof raw === "object"
-      ? (raw as Record<string, unknown>)
-      : undefined;
-  const channelId = toOptionalString(rawRecord?.channel);
+  const rawContext = readSlackRawMessageContext(message);
+  const channelId = rawContext?.channelId;
   if (channelId) {
-    const rawThreadTs = toOptionalString(rawRecord?.thread_ts);
     const threadTs = isDmChannel(channelId)
-      ? rawThreadTs
-      : (rawThreadTs ?? toOptionalString(rawRecord?.ts));
+      ? rawContext.threadTs
+      : (rawContext.threadTs ?? rawContext.messageTs);
     if (threadTs) {
       return { channelId, threadTs };
     }
   }
 
   const parsedThreadId = parseSlackThreadId(
-    toOptionalString((message as unknown as { threadId?: unknown }).threadId),
+    readOptionalStringField(message, "threadId"),
   );
   if (!parsedThreadId || isDmChannel(parsedThreadId.channelId)) {
     return undefined;
@@ -132,24 +139,18 @@ export function getAssistantThreadContext(
 
 /** Resolve the native Slack timestamp for a message that can target Slack APIs. */
 export function getMessageTs(message: Message): SlackMessageTs | undefined {
-  const directTs = toOptionalString(
-    (message as unknown as { ts?: unknown }).ts,
-  );
+  const directTs = readOptionalStringField(message, "ts");
   const parsedDirectTs = parseSlackMessageTs(directTs);
   if (parsedDirectTs) {
     return parsedDirectTs;
   }
 
-  const raw = (message as unknown as { raw?: unknown }).raw;
-  if (!raw || typeof raw !== "object") {
+  const rawContext = readSlackRawMessageContext(message);
+  if (!rawContext) {
     return undefined;
   }
 
-  const rawRecord = raw as Record<string, unknown>;
-  const candidates = [
-    rawRecord.ts,
-    (rawRecord.message as { ts?: unknown } | undefined)?.ts,
-  ];
+  const candidates = [rawContext.messageTs, rawContext.nestedMessageTs];
   for (const candidate of candidates) {
     const ts = parseSlackMessageTs(candidate);
     if (ts) {
@@ -161,16 +162,14 @@ export function getMessageTs(message: Message): SlackMessageTs | undefined {
 
 /** Resolve the Slack workspace/team id from the raw inbound message payload. */
 export function getTeamId(message: Message): string | undefined {
-  const raw = (message as unknown as { raw?: unknown }).raw;
-  if (!raw || typeof raw !== "object") {
+  const rawContext = readSlackRawMessageContext(message);
+  if (!rawContext) {
     return undefined;
   }
 
-  const rawRecord = raw as Record<string, unknown>;
   return (
-    toSlackTeamId(rawRecord.team_id) ??
-    toSlackTeamId(rawRecord.team) ??
+    toSlackTeamId(rawContext.teamId) ??
     toSlackTeamId(getWorkspaceTeamId()) ??
-    toSlackTeamId(rawRecord.user_team)
+    toSlackTeamId(rawContext.authorTeamId)
   );
 }

--- a/packages/junior/src/chat/slack/context.ts
+++ b/packages/junior/src/chat/slack/context.ts
@@ -1,5 +1,11 @@
+import { z } from "zod";
 import { toOptionalString } from "@/chat/coerce";
-import { parseSlackChannelId, type SlackChannelId } from "@/chat/slack/ids";
+import {
+  parseSlackChannelId,
+  parseSlackTeamId,
+  type SlackChannelId,
+  type SlackTeamId,
+} from "@/chat/slack/ids";
 import {
   parseSlackMessageTs,
   type SlackMessageTs,
@@ -8,6 +14,65 @@ import {
 function toTrimmedSlackString(value: unknown): string | undefined {
   const normalized = toOptionalString(value);
   return normalized?.trim() || undefined;
+}
+
+const slackMessageEnvelopeSchema = z.object({
+  raw: z.unknown().optional(),
+});
+
+const rawSlackMessageSchema = z.object({
+  channel: z.unknown().optional(),
+  message: z.unknown().optional(),
+  team: z.unknown().optional(),
+  team_id: z.unknown().optional(),
+  thread_ts: z.unknown().optional(),
+  ts: z.unknown().optional(),
+  user_team: z.unknown().optional(),
+});
+
+const nestedRawSlackMessageSchema = z.object({
+  ts: z.unknown().optional(),
+});
+
+export interface SlackRawMessageContext {
+  authorTeamId?: SlackTeamId;
+  channelId?: SlackChannelId;
+  messageTs?: SlackMessageTs;
+  nestedMessageTs?: SlackMessageTs;
+  teamId?: SlackTeamId;
+  threadTs?: SlackMessageTs;
+}
+
+/** Project only the Slack raw fields consumed by runtime thread context. */
+export function readSlackRawMessageContext(
+  message: unknown,
+): SlackRawMessageContext | undefined {
+  const envelope = slackMessageEnvelopeSchema.safeParse(message);
+  if (!envelope.success) {
+    return undefined;
+  }
+  const raw = rawSlackMessageSchema.safeParse(envelope.data.raw);
+  if (!raw.success) {
+    return undefined;
+  }
+  const nestedMessage = nestedRawSlackMessageSchema.safeParse(raw.data.message);
+  const channelId = parseSlackChannelId(raw.data.channel);
+  const threadTs = parseSlackMessageTs(raw.data.thread_ts);
+  const messageTs = parseSlackMessageTs(raw.data.ts);
+  const nestedMessageTs =
+    nestedMessage.success && parseSlackMessageTs(nestedMessage.data.ts);
+  const teamId =
+    parseSlackTeamId(raw.data.team_id) ?? parseSlackTeamId(raw.data.team);
+  const authorTeamId = parseSlackTeamId(raw.data.user_team);
+
+  return {
+    ...(channelId ? { channelId } : {}),
+    ...(threadTs ? { threadTs } : {}),
+    ...(messageTs ? { messageTs } : {}),
+    ...(nestedMessageTs ? { nestedMessageTs } : {}),
+    ...(teamId ? { teamId } : {}),
+    ...(authorTeamId ? { authorTeamId } : {}),
+  };
 }
 
 /** Extract a channel ID and validated Slack timestamp from `slack:<channel>:<ts>`. */

--- a/packages/junior/src/chat/state/session-log.ts
+++ b/packages/junior/src/chat/state/session-log.ts
@@ -10,7 +10,7 @@ import { isDeepStrictEqual } from "node:util";
 import type { RedisStateAdapter } from "@chat-adapter/state-redis";
 import { z } from "zod";
 import { getChatConfig } from "@/chat/config";
-import type { PiMessage } from "@/chat/pi/messages";
+import { piMessageSchema, type PiMessage } from "@/chat/pi/messages";
 import {
   storedSlackRequesterSchema,
   type StoredSlackRequester,
@@ -25,13 +25,6 @@ const AGENT_SESSION_LOG_SCHEMA_VERSION = 1;
 const INITIAL_SESSION_ID = "session_0";
 const SESSION_ID_PREFIX = "session_";
 const STATE_STORE_LOCK_TTL_MS = 5_000;
-
-const piMessageSchema = z
-  .object({
-    role: z.string(),
-  })
-  .passthrough()
-  .transform((value) => value as unknown as PiMessage);
 
 const piMessageEntrySchema = z.object({
   schemaVersion: z.literal(AGENT_SESSION_LOG_SCHEMA_VERSION),

--- a/packages/junior/src/chat/tools/advisor/tool.ts
+++ b/packages/junior/src/chat/tools/advisor/tool.ts
@@ -37,7 +37,7 @@ import {
   recordSubagentEnded,
   recordSubagentStarted,
 } from "@/chat/state/session-log";
-import { tool, type ToolDefinition } from "@/chat/tools/definition";
+import { tool, type AnyToolDefinition } from "@/chat/tools/definition";
 import { escapeXml } from "@/chat/xml";
 
 export type AdvisorErrorCode =
@@ -119,7 +119,7 @@ function success(memo: string): AdvisorToolResult {
 }
 
 function hasReadOnlyToolAnnotations(
-  annotations: ToolDefinition["annotations"],
+  annotations: AnyToolDefinition["annotations"],
 ): boolean {
   return (
     annotations?.readOnlyHint === true && annotations.destructiveHint !== true
@@ -128,8 +128,8 @@ function hasReadOnlyToolAnnotations(
 
 /** Build the advisor's read-only tool definition subset. */
 export function createAdvisorToolDefinitions(
-  definitions: Record<string, ToolDefinition<any>>,
-): Record<string, ToolDefinition<any>> {
+  definitions: Record<string, AnyToolDefinition>,
+): Record<string, AnyToolDefinition> {
   return Object.fromEntries(
     Object.entries(definitions).filter(
       ([name, definition]) =>

--- a/packages/junior/src/chat/tools/agent-tools.ts
+++ b/packages/junior/src/chat/tools/agent-tools.ts
@@ -22,7 +22,7 @@ import { buildReportedProgressStatus } from "@/chat/runtime/report-progress";
 import type { AssistantStatusSpec } from "@/chat/slack/assistant-thread/status";
 import type { SandboxExecutor } from "@/chat/sandbox/sandbox";
 import type { SkillSandbox } from "@/chat/sandbox/skill-sandbox";
-import type { ToolDefinition } from "@/chat/tools/definition";
+import type { AnyToolDefinition } from "@/chat/tools/definition";
 import { buildSandboxInput } from "@/chat/tools/execution/build-sandbox-input";
 import { normalizeToolResult } from "@/chat/tools/execution/normalize-result";
 import { handleToolExecutionError } from "@/chat/tools/execution/tool-error-handler";
@@ -38,7 +38,7 @@ export interface ToolExecutionReport {
 
 /** Wrap tool definitions into Pi Agent tool objects with logging, validation, and sandbox execution. */
 export function createAgentTools(
-  tools: Record<string, ToolDefinition<any>>,
+  tools: Record<string, AnyToolDefinition>,
   sandbox: SkillSandbox,
   spanContext: LogContext,
   onStatus?: (status: AssistantStatusSpec) => void | Promise<void>,
@@ -145,7 +145,7 @@ export function createAgentTools(
                   input: sandboxInput,
                   ...(signal ? { signal } : {}),
                 })
-              : await toolDef.execute(toolInput as never, {
+              : await toolDef.execute(toolInput, {
                   experimental_context: sandbox,
                   ...(signal ? { signal } : {}),
                   conversationPrivacy: effectiveConversationPrivacy,

--- a/packages/junior/src/chat/tools/definition.ts
+++ b/packages/junior/src/chat/tools/definition.ts
@@ -3,6 +3,13 @@ import type { Static, TSchema } from "@sinclair/typebox";
 import type { ToolExecutionMode } from "@earendil-works/pi-agent-core";
 import type { ConversationPrivacy } from "@/chat/conversation-privacy";
 
+export interface ToolExecuteOptions {
+  experimental_context?: unknown;
+  signal?: AbortSignal;
+  conversationPrivacy?: ConversationPrivacy;
+  toolCallId?: string;
+}
+
 export interface ToolDefinition<TInputSchema extends TSchema = TSchema> {
   /** Stable internal owner-qualified identity for plugin-contributed tools. */
   identity?: {
@@ -29,13 +36,22 @@ export interface ToolDefinition<TInputSchema extends TSchema = TSchema> {
   executionMode?: ToolExecutionMode;
   execute?: (
     input: Static<TInputSchema>,
-    options: {
-      experimental_context?: unknown;
-      signal?: AbortSignal;
-      conversationPrivacy?: ConversationPrivacy;
-      toolCallId?: string;
-    },
+    options: ToolExecuteOptions,
   ) => Promise<unknown> | unknown;
+}
+
+/**
+ * Schema-erased view for heterogeneous registries after Pi validates tool input.
+ */
+export interface AnyToolDefinition extends Omit<
+  ToolDefinition<TSchema>,
+  "execute" | "prepareArguments"
+> {
+  execute?(
+    input: unknown,
+    options: ToolExecuteOptions,
+  ): Promise<unknown> | unknown;
+  prepareArguments?(args: unknown): unknown;
 }
 
 /** Infer execute parameter types from the inputSchema via generic binding. */

--- a/packages/junior/src/chat/tools/index.ts
+++ b/packages/junior/src/chat/tools/index.ts
@@ -34,7 +34,7 @@ import { createSlackThreadReadTool } from "@/chat/slack/tools/thread-read";
 import { createSlackUserLookupTool } from "@/chat/slack/tools/user-lookup";
 import { createSystemTimeTool } from "@/chat/tools/system-time";
 import { createAdvisorTool } from "@/chat/tools/advisor/tool";
-import type { ToolDefinition } from "@/chat/tools/definition";
+import type { AnyToolDefinition } from "@/chat/tools/definition";
 import type {
   ToolHooks,
   ToolRuntimeContext,
@@ -97,7 +97,7 @@ export function createTools(
   const canSendFilesToActiveConversation = Boolean(
     slackContext && slackSourceCapabilities?.canSendMessage,
   );
-  const tools: Record<string, ToolDefinition<any>> = {
+  const tools: Record<string, AnyToolDefinition> = {
     loadSkill: createLoadSkillTool(availableSkills, {
       onSkillLoaded: hooks.onSkillLoaded,
     }),

--- a/packages/junior/src/reporting/conversations.ts
+++ b/packages/junior/src/reporting/conversations.ts
@@ -12,7 +12,7 @@ import {
   type ConversationPrivacy,
 } from "@/chat/conversation-privacy";
 import { unwrapCurrentInstruction } from "@/chat/current-instruction";
-import type { PiMessage } from "@/chat/pi/messages";
+import { piContentMessageSchema, type PiMessage } from "@/chat/pi/messages";
 import { buildSystemPrompt } from "@/chat/prompt";
 import type {
   PluginConversationStatus,
@@ -1503,14 +1503,6 @@ function subagentConversationFields(
   };
 }
 
-const piMessageSchema = z
-  .object({
-    content: z.array(z.unknown()),
-    role: z.string().min(1),
-  })
-  .passthrough()
-  .transform((value) => value as unknown as PiMessage);
-
 async function readTranscriptRefMessages(
   ref: Extract<
     SessionActivityEntry,
@@ -1524,7 +1516,7 @@ async function readTranscriptRefMessages(
   const stateAdapter = getStateAdapter();
   await stateAdapter.connect();
   const value = await stateAdapter.get<unknown>(ref.key);
-  const parsed = z.array(piMessageSchema).safeParse(value);
+  const parsed = z.array(piContentMessageSchema).safeParse(value);
   return parsed.success ? parsed.data : [];
 }
 

--- a/packages/junior/tests/unit/runtime/thread-context.test.ts
+++ b/packages/junior/tests/unit/runtime/thread-context.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   getAssistantThreadContext,
+  getMessageTs,
   getTeamId,
   stripLeadingBotMention,
 } from "@/chat/runtime/thread-context";
@@ -93,6 +94,41 @@ describe("getAssistantThreadContext", () => {
         threadId: "slack:D12345:1700000000.300",
       } as any),
     ).toBeUndefined();
+  });
+});
+
+describe("getMessageTs", () => {
+  it("uses a direct normalized message timestamp first", () => {
+    expect(
+      getMessageTs({
+        raw: {
+          ts: "1700000000.100",
+        },
+        ts: "1700000000.200",
+      } as any),
+    ).toBe("1700000000.200");
+  });
+
+  it("uses the raw Slack message timestamp when direct ts is absent", () => {
+    expect(
+      getMessageTs({
+        raw: {
+          ts: "1700000000.300",
+        },
+      } as any),
+    ).toBe("1700000000.300");
+  });
+
+  it("falls back to the nested Slack message timestamp", () => {
+    expect(
+      getMessageTs({
+        raw: {
+          message: {
+            ts: "1700000000.400",
+          },
+        },
+      } as any),
+    ).toBe("1700000000.400");
   });
 });
 


### PR DESCRIPTION
Pi transcript parsing now lives behind shared schemas, and Slack raw message fields are projected inside the Slack-owned context boundary before runtime thread helpers use them. Tool registry plumbing now uses a schema-erased definition view for heterogeneous registries without changing model-facing TypeBox schemas.

The refactor preserves existing behavior while making the key runtime boundaries harder to accidentally widen. The added thread-context cases cover direct Slack timestamps plus raw and nested raw timestamp fallbacks.