### PR TITLE
feat(tools): Add deferred tool discovery

### DIFF
--- a/packages/junior/src/chat/agent/tools.ts
+++ b/packages/junior/src/chat/agent/tools.ts
@@ -31,6 +31,7 @@ import {
 } from "@/chat/tools/skill/mcp-tool-summary";
 import { createAdvisorToolDefinitions } from "@/chat/tools/advisor/tool";
 import { createAgentTools } from "@/chat/tools/agent-tools";
+import { planToolExposure } from "@/chat/tool-exposure";
 import {
   createSandboxExecutor,
   type SandboxExecutor,
@@ -350,13 +351,16 @@ export async function wireAgentTools(
     toolRuntimeContext,
   );
 
-  const toolGuidance = Object.entries(
+  const plannedToolExposure = planToolExposure(
     tools as Record<string, AnyToolDefinition>,
-  ).map(([name, definition]) => ({
-    name,
-    promptGuidelines: definition.promptGuidelines,
-    promptSnippet: definition.promptSnippet,
-  }));
+  );
+  const toolGuidance = Object.entries(plannedToolExposure.directTools).map(
+    ([name, definition]) => ({
+      name,
+      promptGuidelines: definition.promptGuidelines,
+      promptSnippet: definition.promptSnippet,
+    }),
+  );
 
   // If a prior turn left an MCP provider pending user authorization, skip
   // eager restoration of that provider here. Without this guard, a later

--- a/packages/junior/src/chat/plugins/agent-hooks.ts
+++ b/packages/junior/src/chat/plugins/agent-hooks.ts
@@ -474,6 +474,7 @@ export function getPluginTools(
         name: localName,
         plugin: pluginName,
       };
+      definition.exposure = "deferred";
       tools[name] = definition;
     }
   }

--- a/packages/junior/src/chat/tool-exposure.ts
+++ b/packages/junior/src/chat/tool-exposure.ts
@@ -1,0 +1,38 @@
+import type { AnyToolDefinition, ToolExposure } from "@/chat/tools/definition";
+
+export interface PlannedToolExposure {
+  deferredTools: Record<string, AnyToolDefinition>;
+  directTools: Record<string, AnyToolDefinition>;
+}
+
+/** Return the runtime exposure for a tool, preserving direct compatibility. */
+export function effectiveToolExposure(
+  definition: AnyToolDefinition,
+): ToolExposure {
+  return definition.exposure ?? "direct";
+}
+
+/** Split complete tool definitions into native-visible and deferred groups. */
+export function planToolExposure(
+  tools: Record<string, AnyToolDefinition>,
+): PlannedToolExposure {
+  const directTools: Record<string, AnyToolDefinition> = {};
+  const deferredTools: Record<string, AnyToolDefinition> = {};
+
+  for (const [name, definition] of Object.entries(tools)) {
+    switch (effectiveToolExposure(definition)) {
+      case "direct":
+        directTools[name] = definition;
+        break;
+      case "deferred":
+        deferredTools[name] = definition;
+        break;
+      case "modelOnly":
+        break;
+      case "hidden":
+        break;
+    }
+  }
+
+  return { directTools, deferredTools };
+}

--- a/packages/junior/src/chat/tools/agent-tools.ts
+++ b/packages/junior/src/chat/tools/agent-tools.ts
@@ -27,6 +27,17 @@ import { buildSandboxInput } from "@/chat/tools/execution/build-sandbox-input";
 import { normalizeToolResult } from "@/chat/tools/execution/normalize-result";
 import { handleToolExecutionError } from "@/chat/tools/execution/tool-error-handler";
 import type { PluginHookRunner } from "@/chat/plugins/agent-hooks";
+import {
+  createExecuteToolTool,
+  EXECUTE_TOOL_NAME,
+  prepareDeferredToolCall,
+  resolveDeferredToolCall,
+} from "@/chat/tools/execute-tool";
+import { planToolExposure } from "@/chat/tool-exposure";
+import {
+  createSearchToolsTool,
+  SEARCH_TOOLS_NAME,
+} from "@/chat/tools/search-tools";
 
 export interface ToolExecutionReport {
   error?: string;
@@ -52,6 +63,22 @@ export function createAgentTools(
   conversationPrivacy?: ConversationPrivacy,
   onToolResult?: (report: ToolExecutionReport) => void | Promise<void>,
 ): AgentTool[] {
+  const plannedTools = planToolExposure(tools);
+  const visibleTools: Record<string, AnyToolDefinition> = {
+    ...plannedTools.directTools,
+  };
+  const hasDeferredTools = Object.keys(plannedTools.deferredTools).length > 0;
+  if (hasDeferredTools) {
+    if (visibleTools[SEARCH_TOOLS_NAME] || visibleTools[EXECUTE_TOOL_NAME]) {
+      throw new Error(
+        `${SEARCH_TOOLS_NAME} and ${EXECUTE_TOOL_NAME} are reserved for deferred tool discovery`,
+      );
+    }
+    visibleTools[SEARCH_TOOLS_NAME] = createSearchToolsTool(
+      plannedTools.deferredTools,
+    );
+    visibleTools[EXECUTE_TOOL_NAME] = createExecuteToolTool();
+  }
   const shouldTrace = shouldEmitDevAgentTrace();
   const effectiveConversationPrivacy = conversationPrivacy ?? "private";
   const serializeToolPayload = (payload: unknown) =>
@@ -76,7 +103,85 @@ export function createAgentTools(
       );
     }
   };
-  return Object.entries(tools).map(([toolName, toolDef]) => ({
+  const executeDefinition = async (args: {
+    normalizedToolCallId: string | undefined;
+    params: Record<string, unknown>;
+    signal: AbortSignal | undefined;
+    toolDef: AnyToolDefinition;
+    toolName: string;
+  }) => {
+    const { normalizedToolCallId, params, signal, toolDef, toolName } = args;
+    if (typeof toolDef.execute !== "function") {
+      const resultDetails = { ok: true };
+      const toolResultAttribute = serializeToolPayload(resultDetails);
+      if (toolResultAttribute) {
+        setSpanAttributes({
+          "gen_ai.tool.call.result": toolResultAttribute,
+          ...toGenAiPayloadTraceAttributes(
+            "app.ai.tool.call.result",
+            resultDetails,
+          ),
+        });
+      }
+      return {
+        content: [{ type: "text" as const, text: "ok" }],
+        details: resultDetails,
+      };
+    }
+
+    const beforeTool = agentHooks
+      ? await agentHooks.beforeToolExecute({
+          name: toolName,
+          input: params,
+        })
+      : { input: params, env: {} };
+    const toolInput = beforeTool.input;
+    await onToolCall?.(toolName, toolInput);
+    const sandboxInput = buildSandboxInput(toolName, toolInput);
+    const isSandbox = Boolean(sandboxExecutor?.canExecute(toolName));
+    const result = isSandbox
+      ? await sandboxExecutor!.execute({
+          toolName,
+          input: sandboxInput,
+          ...(signal ? { signal } : {}),
+        })
+      : await toolDef.execute(toolInput, {
+          experimental_context: sandbox,
+          ...(signal ? { signal } : {}),
+          conversationPrivacy: effectiveConversationPrivacy,
+          ...(normalizedToolCallId ? { toolCallId: normalizedToolCallId } : {}),
+        });
+
+    const normalized = normalizeToolResult(result, isSandbox);
+    if (isSandbox && pluginAuthOrchestration) {
+      await pluginAuthOrchestration.maybeHandleAuthSignal(normalized.details);
+    }
+    const resultAttributeValue =
+      normalized.details &&
+      typeof normalized.details === "object" &&
+      "rawResult" in normalized.details &&
+      (normalized.details as { rawResult?: unknown }).rawResult !== undefined
+        ? (normalized.details as { rawResult: unknown }).rawResult
+        : normalized.details;
+    const toolResultAttribute = serializeToolPayload(resultAttributeValue);
+    if (toolResultAttribute) {
+      setSpanAttributes({
+        "gen_ai.tool.call.result": toolResultAttribute,
+        ...toGenAiPayloadTraceAttributes(
+          "app.ai.tool.call.result",
+          resultAttributeValue,
+        ),
+      });
+    }
+    await notifyToolResult({
+      ok: true,
+      params: toolInput,
+      result: resultAttributeValue,
+      toolName,
+    });
+    return normalized;
+  };
+  return Object.entries(visibleTools).map(([toolName, toolDef]) => ({
     name: toolName,
     label: toolName,
     description: toolDef.description,
@@ -109,89 +214,38 @@ export function createAgentTools(
         spanContext,
         async () => {
           const parsed = params as Record<string, unknown>;
+          let executionToolName = toolName;
+          let executionParams = parsed;
 
           try {
-            if (typeof toolDef.execute !== "function") {
-              const resultDetails = { ok: true };
-              const toolResultAttribute = serializeToolPayload(resultDetails);
-              if (toolResultAttribute) {
-                setSpanAttributes({
-                  "gen_ai.tool.call.result": toolResultAttribute,
-                  ...toGenAiPayloadTraceAttributes(
-                    "app.ai.tool.call.result",
-                    resultDetails,
-                  ),
-                });
-              }
-              return {
-                content: [{ type: "text", text: "ok" }],
-                details: resultDetails,
-              };
-            }
-
-            const beforeTool = agentHooks
-              ? await agentHooks.beforeToolExecute({
-                  name: toolName,
-                  input: parsed,
-                })
-              : { input: parsed, env: {} };
-            const toolInput = beforeTool.input;
-            await onToolCall?.(toolName, toolInput);
-            const sandboxInput = buildSandboxInput(toolName, toolInput);
-            const isSandbox = Boolean(sandboxExecutor?.canExecute(toolName));
-            const result = isSandbox
-              ? await sandboxExecutor!.execute({
-                  toolName,
-                  input: sandboxInput,
-                  ...(signal ? { signal } : {}),
-                })
-              : await toolDef.execute(toolInput, {
-                  experimental_context: sandbox,
-                  ...(signal ? { signal } : {}),
-                  conversationPrivacy: effectiveConversationPrivacy,
-                  ...(normalizedToolCallId
-                    ? { toolCallId: normalizedToolCallId }
-                    : {}),
-                });
-
-            const normalized = normalizeToolResult(result, isSandbox);
-            if (isSandbox && pluginAuthOrchestration) {
-              await pluginAuthOrchestration.maybeHandleAuthSignal(
-                normalized.details,
+            if (toolName === EXECUTE_TOOL_NAME) {
+              const deferredCall = prepareDeferredToolCall(
+                resolveDeferredToolCall(parsed, plannedTools.deferredTools),
               );
-            }
-            const resultAttributeValue =
-              normalized.details &&
-              typeof normalized.details === "object" &&
-              "rawResult" in normalized.details &&
-              (normalized.details as { rawResult?: unknown }).rawResult !==
-                undefined
-                ? (normalized.details as { rawResult: unknown }).rawResult
-                : normalized.details;
-            const toolResultAttribute =
-              serializeToolPayload(resultAttributeValue);
-            if (toolResultAttribute) {
-              setSpanAttributes({
-                "gen_ai.tool.call.result": toolResultAttribute,
-                ...toGenAiPayloadTraceAttributes(
-                  "app.ai.tool.call.result",
-                  resultAttributeValue,
-                ),
+              executionToolName = deferredCall.toolName;
+              executionParams = deferredCall.arguments;
+              return await executeDefinition({
+                normalizedToolCallId,
+                params: deferredCall.arguments,
+                signal,
+                toolDef: deferredCall.definition,
+                toolName: deferredCall.toolName,
               });
             }
-            await notifyToolResult({
-              ok: true,
-              params: toolInput,
-              result: resultAttributeValue,
+
+            return await executeDefinition({
+              normalizedToolCallId,
+              params: parsed,
+              signal,
+              toolDef,
               toolName,
             });
-            return normalized;
           } catch (error) {
             await notifyToolResult({
               error: error instanceof Error ? error.message : String(error),
               ok: false,
-              params: parsed,
-              toolName,
+              params: executionParams,
+              toolName: executionToolName,
             });
             if (
               error instanceof AuthorizationPauseError ||
@@ -201,7 +255,7 @@ export function createAgentTools(
             }
             handleToolExecutionError(
               error,
-              toolName,
+              executionToolName,
               normalizedToolCallId,
               shouldTrace,
               spanContext,

--- a/packages/junior/src/chat/tools/definition.ts
+++ b/packages/junior/src/chat/tools/definition.ts
@@ -3,6 +3,8 @@ import type { Static, TSchema } from "@sinclair/typebox";
 import type { ToolExecutionMode } from "@earendil-works/pi-agent-core";
 import type { ConversationPrivacy } from "@/chat/conversation-privacy";
 
+export type ToolExposure = "direct" | "deferred" | "modelOnly" | "hidden";
+
 export interface ToolExecuteOptions {
   experimental_context?: unknown;
   signal?: AbortSignal;
@@ -18,6 +20,7 @@ export interface ToolDefinition<TInputSchema extends TSchema = TSchema> {
     plugin: string;
   };
   description: string;
+  exposure?: ToolExposure;
   inputSchema: TInputSchema;
   annotations?: ToolAnnotations;
   /**

--- a/packages/junior/src/chat/tools/execute-tool.ts
+++ b/packages/junior/src/chat/tools/execute-tool.ts
@@ -1,0 +1,116 @@
+import { Type } from "@sinclair/typebox";
+import { Value } from "@sinclair/typebox/value";
+import type { AnyToolDefinition } from "@/chat/tools/definition";
+import { tool } from "@/chat/tools/definition";
+import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
+
+export const EXECUTE_TOOL_NAME = "executeTool";
+
+export interface DeferredToolCall {
+  arguments: Record<string, unknown>;
+  definition: AnyToolDefinition;
+  toolName: string;
+}
+
+function schemaErrorText(
+  definition: AnyToolDefinition,
+  value: unknown,
+): string {
+  const firstError = [...Value.Errors(definition.inputSchema, value)][0];
+  if (!firstError) {
+    return "invalid arguments";
+  }
+  return `${firstError.path || "/"} ${firstError.message}`;
+}
+
+/** Create the model-visible dispatcher schema for deferred tools. */
+export function createExecuteToolTool() {
+  return tool({
+    description:
+      "Execute a deferred tool by exact tool_name from searchTools. Put tool-specific parameters inside arguments. This can only call deferred tools returned by searchTools.",
+    executionMode: "sequential",
+    inputSchema: Type.Object(
+      {
+        tool_name: Type.String({
+          minLength: 1,
+          description: "Exact deferred tool_name returned by searchTools.",
+        }),
+        arguments: Type.Optional(
+          Type.Record(Type.String(), Type.Unknown(), {
+            description:
+              'Arguments matching the deferred tool schema, for example { "query": "..." }.',
+          }),
+        ),
+      },
+      { additionalProperties: false },
+    ),
+    execute: async () => {
+      throw new ToolInputError(
+        "executeTool can only run through the agent tool dispatcher.",
+      );
+    },
+  });
+}
+
+/** Resolve and validate a deferred executeTool request at runtime. */
+export function resolveDeferredToolCall(
+  input: Record<string, unknown>,
+  deferredTools: Record<string, AnyToolDefinition>,
+): DeferredToolCall {
+  const extraKeys = Object.keys(input).filter(
+    (key) => key !== "tool_name" && key !== "arguments",
+  );
+  if (extraKeys.length > 0) {
+    throw new ToolInputError(
+      `executeTool arguments must be nested under arguments, not top-level fields: ${extraKeys.join(", ")}`,
+    );
+  }
+
+  const toolName = input.tool_name;
+  if (typeof toolName !== "string" || toolName.length === 0) {
+    throw new ToolInputError("executeTool requires a deferred tool_name.");
+  }
+
+  const definition = deferredTools[toolName];
+  if (!definition) {
+    throw new ToolInputError(
+      `executeTool can only call deferred tools returned by searchTools: ${toolName}`,
+    );
+  }
+
+  const args = input.arguments;
+  if (args === undefined) {
+    return { arguments: {}, definition, toolName };
+  }
+  if (!args || typeof args !== "object" || Array.isArray(args)) {
+    throw new ToolInputError(
+      "executeTool arguments must be an object when provided.",
+    );
+  }
+
+  return { arguments: args as Record<string, unknown>, definition, toolName };
+}
+
+/** Apply a deferred tool's own argument preparation and schema boundary. */
+export function prepareDeferredToolCall(
+  call: DeferredToolCall,
+): DeferredToolCall {
+  const prepared = call.definition.prepareArguments
+    ? call.definition.prepareArguments(call.arguments)
+    : call.arguments;
+  if (!Value.Check(call.definition.inputSchema, prepared)) {
+    throw new ToolInputError(
+      `executeTool arguments do not match schema for ${call.toolName}: ${schemaErrorText(call.definition, prepared)}`,
+    );
+  }
+  if (!prepared || typeof prepared !== "object" || Array.isArray(prepared)) {
+    throw new ToolInputError(
+      `executeTool arguments must prepare to an object for ${call.toolName}.`,
+    );
+  }
+  return {
+    arguments: prepared as Record<string, unknown>,
+    definition: call.definition,
+    toolName: call.toolName,
+  };
+}

--- a/packages/junior/src/chat/tools/search-tools.ts
+++ b/packages/junior/src/chat/tools/search-tools.ts
@@ -1,0 +1,125 @@
+import { Type, type TSchema } from "@sinclair/typebox";
+import type { AnyToolDefinition } from "@/chat/tools/definition";
+import { tool } from "@/chat/tools/definition";
+import { effectiveToolExposure } from "@/chat/tool-exposure";
+
+export const SEARCH_TOOLS_NAME = "searchTools";
+
+const DEFAULT_MAX_RESULTS = 5;
+const MAX_RESULTS = 20;
+
+function normalize(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, " ")
+    .trim();
+}
+
+function schemaText(schema: TSchema): string {
+  try {
+    return JSON.stringify(schema);
+  } catch {
+    return "";
+  }
+}
+
+function searchableToolText(
+  name: string,
+  definition: AnyToolDefinition,
+): string {
+  return normalize(
+    [
+      name,
+      definition.identity?.id,
+      definition.identity?.name,
+      definition.identity?.plugin,
+      definition.description,
+      schemaText(definition.inputSchema),
+      JSON.stringify(definition.annotations ?? {}),
+    ]
+      .filter(Boolean)
+      .join(" "),
+  );
+}
+
+function searchDeferredTools(
+  tools: Record<string, AnyToolDefinition>,
+  query: string,
+): string[] {
+  const entries = Object.entries(tools).sort(([left], [right]) =>
+    left.localeCompare(right),
+  );
+  if (!normalize(query)) {
+    return entries.map(([name]) => name);
+  }
+
+  const terms = normalize(query).split(/\s+/).filter(Boolean);
+  return entries
+    .filter(([name, definition]) => {
+      const text = searchableToolText(name, definition);
+      return terms.every((term) => text.includes(term));
+    })
+    .map(([name]) => name);
+}
+
+function toolMetadata(name: string, definition: AnyToolDefinition) {
+  return {
+    tool_name: name,
+    description: definition.description,
+    exposure: effectiveToolExposure(definition),
+    source: definition.identity
+      ? {
+          type: "plugin" as const,
+          id: definition.identity.id,
+          name: definition.identity.name,
+          plugin: definition.identity.plugin,
+        }
+      : { type: "core" as const },
+    input_schema: definition.inputSchema,
+    annotations: definition.annotations ?? {},
+  };
+}
+
+/** Create the model-visible search tool for deferred tool metadata. */
+export function createSearchToolsTool(
+  deferredTools: Record<string, AnyToolDefinition>,
+) {
+  return tool({
+    description:
+      "Search deferred tool metadata. Use when a specialized plugin or provider tool may exist but is not directly visible. Copy the exact returned tool_name into executeTool.",
+    annotations: { readOnlyHint: true, destructiveHint: false },
+    inputSchema: Type.Object(
+      {
+        query: Type.Optional(
+          Type.String({
+            minLength: 1,
+            description:
+              "Optional search terms describing the tool, owner, action, or arguments needed.",
+          }),
+        ),
+        max_results: Type.Optional(
+          Type.Integer({
+            minimum: 1,
+            maximum: MAX_RESULTS,
+            description:
+              "Maximum matching deferred tool descriptors to return.",
+          }),
+        ),
+      },
+      { additionalProperties: false },
+    ),
+    execute: async ({ query, max_results }) => {
+      const maxResults = max_results ?? DEFAULT_MAX_RESULTS;
+      const matches = searchDeferredTools(deferredTools, query ?? "").slice(
+        0,
+        maxResults,
+      );
+      return {
+        query: query ?? null,
+        total_deferred_tools: Object.keys(deferredTools).length,
+        returned_tools: matches.length,
+        tools: matches.map((name) => toolMetadata(name, deferredTools[name]!)),
+      };
+    },
+  });
+}

--- a/packages/junior/tests/integration/deferred-tools.test.ts
+++ b/packages/junior/tests/integration/deferred-tools.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createLocalSource,
+  defineJuniorPlugin,
+} from "@sentry/junior-plugin-api";
+import { Type } from "@sinclair/typebox";
+import { setPlugins } from "@/chat/plugins/agent-hooks";
+import { SkillSandbox } from "@/chat/sandbox/skill-sandbox";
+import { createTools } from "@/chat/tools";
+import { createAgentTools } from "@/chat/tools/agent-tools";
+import { tool } from "@/chat/tools/definition";
+
+const LOCAL_DESTINATION = {
+  platform: "local",
+  conversationId: "local:test:deferred-tools",
+} as const;
+const LOCAL_SOURCE = createLocalSource(LOCAL_DESTINATION.conversationId);
+const TEST_EGRESS = {
+  async fetch() {
+    return new Response("ok");
+  },
+};
+
+function runtimeContext() {
+  return {
+    destination: LOCAL_DESTINATION,
+    egress: TEST_EGRESS,
+    source: LOCAL_SOURCE,
+    sandbox: {} as any,
+  };
+}
+
+function agentTool(tools: ReturnType<typeof createAgentTools>, name: string) {
+  const found = tools.find((candidate) => candidate.name === name);
+  if (!found) {
+    throw new Error(`Missing agent tool: ${name}`);
+  }
+  return found;
+}
+
+describe("deferred tools", () => {
+  afterEach(() => {
+    setPlugins([]);
+  });
+
+  it("discovers and executes plugin tools through the deferred tool primitives", async () => {
+    const onToolCall = vi.fn();
+    setPlugins([
+      defineJuniorPlugin({
+        manifest: {
+          name: "agent-demo",
+          displayName: "Agent Demo",
+          description: "Agent demo",
+        },
+        hooks: {
+          tools() {
+            return {
+              lookupCustomer: tool({
+                description: "Lookup customer health for account review.",
+                inputSchema: Type.Object(
+                  {
+                    customerId: Type.String({
+                      minLength: 1,
+                      description: "Customer identifier to inspect.",
+                    }),
+                  },
+                  { additionalProperties: false },
+                ),
+                prepareArguments: (args) => {
+                  const input = args as Record<string, unknown>;
+                  return typeof input.customer_id === "string"
+                    ? { customerId: input.customer_id }
+                    : (input as { customerId: string });
+                },
+                execute: async ({ customerId }) => ({
+                  customer_id: customerId,
+                  status: "healthy",
+                }),
+              }),
+            };
+          },
+        },
+      }),
+    ]);
+
+    const registry = createTools([], {}, runtimeContext());
+    const tools = createAgentTools(
+      registry,
+      new SkillSandbox([], []),
+      {},
+      undefined,
+      undefined,
+      undefined,
+      onToolCall,
+    );
+
+    expect(registry.agentDemo_lookupCustomer?.exposure).toBe("deferred");
+    expect(tools.map((candidate) => candidate.name)).toEqual(
+      expect.arrayContaining(["searchTools", "executeTool"]),
+    );
+    expect(
+      tools.some((candidate) => candidate.name === "agentDemo_lookupCustomer"),
+    ).toBe(false);
+
+    const searchResult = await agentTool(tools, "searchTools").execute(
+      "tool-search",
+      { query: "customer identifier" },
+    );
+    expect(searchResult.details).toMatchObject({
+      returned_tools: 1,
+      tools: [
+        {
+          tool_name: "agentDemo_lookupCustomer",
+          source: {
+            type: "plugin",
+            plugin: "agent-demo",
+          },
+        },
+      ],
+    });
+
+    const executeResult = await agentTool(tools, "executeTool").execute(
+      "tool-execute",
+      {
+        tool_name: "agentDemo_lookupCustomer",
+        arguments: { customer_id: "C123" },
+      },
+    );
+
+    expect(executeResult.details).toEqual({
+      customer_id: "C123",
+      status: "healthy",
+    });
+    expect(onToolCall).toHaveBeenCalledWith("agentDemo_lookupCustomer", {
+      customerId: "C123",
+    });
+    await expect(
+      agentTool(tools, "executeTool").execute("tool-invalid", {
+        tool_name: "agentDemo_lookupCustomer",
+        arguments: {},
+      }),
+    ).rejects.toThrow("arguments do not match schema");
+  });
+
+  it("does not let executeTool call direct, hidden, or unknown tools", async () => {
+    const tools = createAgentTools(
+      {
+        directDemo: tool({
+          description: "Direct demo",
+          inputSchema: Type.Object({}),
+          execute: async () => ({ ok: true }),
+        }),
+        hiddenDemo: tool({
+          description: "Hidden demo",
+          exposure: "hidden",
+          inputSchema: Type.Object({}),
+          execute: async () => ({ ok: true }),
+        }),
+        deferredDemo: tool({
+          description: "Deferred demo",
+          exposure: "deferred",
+          inputSchema: Type.Object({}),
+          execute: async () => ({ ok: true }),
+        }),
+      },
+      new SkillSandbox([], []),
+      {},
+    );
+    const executeTool = agentTool(tools, "executeTool");
+
+    await expect(
+      executeTool.execute("tool-direct", {
+        tool_name: "directDemo",
+        arguments: {},
+      }),
+    ).rejects.toThrow("can only call deferred tools");
+    await expect(
+      executeTool.execute("tool-hidden", {
+        tool_name: "hiddenDemo",
+        arguments: {},
+      }),
+    ).rejects.toThrow("can only call deferred tools");
+    await expect(
+      executeTool.execute("tool-missing", {
+        tool_name: "missingDemo",
+        arguments: {},
+      }),
+    ).rejects.toThrow("can only call deferred tools");
+  });
+});

--- a/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
@@ -738,19 +738,17 @@ describe("sandbox egress proxy integration", () => {
     );
 
     const agentTools = createAgentTools(tools, new SkillSandbox([], []), {});
-    const managedEgressRead = agentTools.find(
-      (candidate) => candidate.name === "managedEgress_managedEgressRead",
+    const executeTool = agentTools.find(
+      (candidate) => candidate.name === "executeTool",
     );
-    if (!managedEgressRead) {
-      throw new Error(
-        "managedEgress_managedEgressRead tool was not registered",
-      );
+    if (!executeTool) {
+      throw new Error("executeTool was not registered");
     }
 
-    const result = await managedEgressRead.execute(
-      "tool-call-managed-egress-read",
-      {},
-    );
+    const result = await executeTool.execute("tool-call-managed-egress-read", {
+      tool_name: "managedEgress_managedEgressRead",
+      arguments: {},
+    });
 
     expect(result).toMatchObject({
       details: {


### PR DESCRIPTION
Deferred tools now have a generic discovery and execution path: plugin tools are indexed behind `searchTools` and invoked through `executeTool` instead of being exposed as native model tools. Core and MCP tools remain on their existing direct paths.

`executeTool` reuses the normal tool execution machinery, including hooks, sandbox/auth handling, result normalization, and schema validation after a deferred tool's `prepareArguments` runs. The integration coverage exercises plugin discovery, prepared arguments, schema rejection, and the guard that direct, hidden, and unknown tools cannot be called through the dispatcher.

Refs GH-747