### PR TITLE
feat(tools): Add Zod schema adapters

### DIFF
--- a/openspec/changes/zod-tool-schema-adapter/proposal.md
+++ b/openspec/changes/zod-tool-schema-adapter/proposal.md
@@ -1,0 +1,43 @@
+# Zod Tool Schema Adapter
+
+## Summary
+
+Add a schema adapter layer for Junior-owned agent tools so tools can be authored
+with Zod parsers while Pi continues to receive JSON Schema-compatible tool
+parameters.
+
+## Motivation
+
+Junior-owned tools currently use TypeBox schemas primarily because Pi's public
+tool types are TypeBox-shaped. Pi's runtime already accepts plain JSON Schema
+for provider payloads and validation fallback, and Zod gives Junior a stronger
+parser boundary for model-produced arguments. A Zod adapter lets tool executors
+receive parsed inputs, turns parser failures into model-visible tool errors, and
+keeps the Pi compatibility cast isolated at the adapter boundary.
+
+## Scope
+
+- Introduce an internal `zodTool(...)` wrapper for Junior-owned tools.
+- Introduce a public `definePluginTool(...)` helper for plugin-authored tools.
+- Represent model-facing tool parameters as JSON Schema-compatible schemas in
+  Junior's erased tool registry.
+- Convert Zod tool input schemas to JSON Schema before handing them to Pi.
+- Parse model arguments with Zod before executor code runs.
+- Convert Zod parse failures into the appropriate tool input error type so Pi
+  records an `isError=true` tool result that the agent can repair.
+- Optionally validate tool outputs with Zod as developer/runtime contract
+  failures, not model-input failures.
+- Migrate Junior-owned internal tools to the wrapper in this change.
+
+## Non-Goals
+
+- Converting provider-owned MCP schemas.
+- Converting plugin tools that do not opt in to the plugin API helper.
+- Synthesizing real TypeBox schemas from Zod-generated JSON Schema.
+- Changing Pi package source or vendoring Pi types.
+
+## Compatibility
+
+Existing TypeBox-authored tools remain valid during the migration. The final
+internal tool registry should expose JSON Schema-compatible parameters to Pi and
+keep any TypeBox-only casts localized to Pi adapter code.

--- a/openspec/changes/zod-tool-schema-adapter/specs/internal-tool-schemas/spec.md
+++ b/openspec/changes/zod-tool-schema-adapter/specs/internal-tool-schemas/spec.md
@@ -1,0 +1,91 @@
+# Internal Tool Schemas
+
+## ADDED Requirements
+
+### Requirement: Zod-Authored Junior Tools
+
+Junior-owned agent tools SHALL support an internal `zodTool(...)` authoring
+helper that accepts a Zod input schema and infers the executor input type from
+that schema.
+
+#### Scenario: Parsed executor input
+
+- **WHEN** a Junior-owned tool is authored with `zodTool(...)`
+- **AND** Pi supplies model-generated arguments for that tool
+- **THEN** the tool's executor receives the Zod-parsed output type
+- **AND** executor code does not need ad hoc object-shape checks for fields
+  already owned by the input schema.
+
+### Requirement: Pi-Compatible Model Schema
+
+Junior-owned Zod tool schemas SHALL be converted to JSON Schema-compatible tool
+parameters before they are handed to Pi.
+
+#### Scenario: Model-facing parameters
+
+- **WHEN** `createAgentTools(...)` exposes a Zod-authored tool to Pi
+- **THEN** the Pi tool `parameters` value is a JSON Schema-compatible object
+- **AND** the code does not claim the generated JSON Schema is a real TypeBox
+  schema except at the narrow Pi type adapter boundary.
+
+### Requirement: Model-Repairable Parse Failures
+
+Zod input parse failures from Junior-owned tools SHALL become expected tool
+input failures.
+
+#### Scenario: Invalid model arguments
+
+- **WHEN** the model calls a Zod-authored Junior tool with invalid arguments
+- **THEN** the parse failure is converted to `ToolInputError`
+- **AND** Pi records a tool result with `isError=true`
+- **AND** the error message is concise enough for the model to repair the tool
+  call.
+
+### Requirement: Output Validation Is Runtime Contract Validation
+
+If a Junior-owned tool declares an output schema, output parse failures SHALL be
+treated as tool implementation/runtime failures rather than model-repairable
+input failures.
+
+#### Scenario: Invalid executor output
+
+- **WHEN** a Zod-authored tool executor returns output that fails its output
+  schema
+- **THEN** Junior treats that failure as a tool execution error
+- **AND** the failure is not classified as `tool_input_error`.
+
+### Requirement: Existing Schema Sources Remain Compatible
+
+The adapter layer SHALL preserve existing support for TypeBox-authored tools,
+provider-owned MCP schemas, and plugin-owned tool schemas during migration.
+
+#### Scenario: Non-Zod tool schema
+
+- **WHEN** a tool is not authored through `zodTool(...)`
+- **THEN** the existing schema and prepare/execute behavior remains unchanged.
+
+### Requirement: Zod-Authored Plugin Tools
+
+Plugin-authored tools SHALL support a public `definePluginTool(...)` helper
+that accepts a Zod input schema and infers the plugin executor input type from
+that schema.
+
+#### Scenario: Plugin model-facing parameters
+
+- **WHEN** a plugin tool is authored with `definePluginTool(...)`
+- **THEN** the helper exposes JSON Schema-compatible tool parameters to Junior
+  and Pi
+- **AND** the plugin executor receives the Zod-parsed output type.
+
+#### Scenario: Plugin parse failure
+
+- **WHEN** model-generated plugin tool arguments fail the helper's Zod schema
+- **THEN** the parse failure is converted to `PluginToolInputError`
+- **AND** Pi records a tool result with `isError=true`.
+
+#### Scenario: Existing plugin definitions
+
+- **WHEN** a plugin continues to provide an existing tool definition without
+  `definePluginTool(...)`
+- **THEN** Junior preserves that tool's existing schema and prepare/execute
+  behavior.

--- a/openspec/changes/zod-tool-schema-adapter/tasks.md
+++ b/openspec/changes/zod-tool-schema-adapter/tasks.md
@@ -1,0 +1,41 @@
+# Tasks
+
+## 1. Tool Schema Adapter
+
+- [x] Add a JSON Schema-compatible internal tool schema type.
+- [x] Add `zodTool(...)` beside the existing TypeBox `tool(...)` helper.
+- [x] Convert Zod schemas to model-facing JSON Schema in the helper.
+- [x] Parse `prepareArguments` with Zod and convert `ZodError` to
+      `ToolInputError` with concise model-actionable messages.
+- [x] Support optional output schema validation as a runtime contract failure.
+- [x] Keep Pi `TSchema` casts isolated in `createAgentTools(...)` or the
+      smallest Pi adapter boundary.
+- [x] Add a public plugin helper that converts Zod parse failures into
+      `PluginToolInputError`.
+
+## 2. Internal Tool Migration
+
+- [x] Migrate Junior-owned non-plugin tools from TypeBox `tool(...)` to
+      `zodTool(...)`.
+- [x] Preserve field descriptions, nullability, defaults, and executor
+      semantics.
+- [x] Leave provider-owned MCP schemas and non-helper plugin-owned schemas
+      unchanged.
+- [x] Remove internal TypeBox dependencies only when no remaining owned tool or
+      runtime path needs them.
+
+## 3. Tests
+
+- [x] Cover valid Zod argument parsing and executor input typing.
+- [x] Cover invalid Zod arguments becoming Pi-compatible `isError=true` tool
+      results.
+- [x] Cover model-facing JSON Schema shape for at least one converted tool.
+- [x] Cover output schema validation behavior if output validation is included.
+- [x] Run focused tests for converted tool families.
+
+## 4. Verification
+
+- [x] `pnpm typecheck`
+- [x] `pnpm lint`
+- [x] Focused tool tests
+- [x] Any package builds affected by public or publishable surfaces

--- a/packages/docs/src/content/docs/extend/build-a-plugin.md
+++ b/packages/docs/src/content/docs/extend/build-a-plugin.md
@@ -192,8 +192,11 @@ Junior exposes them to the agent as `<pluginNamespace>_<toolName>`, where
 `my-provider` tool `ping` is exposed as `myProvider_ping`.
 
 ```ts title="index.ts"
-import { Type } from "@sinclair/typebox";
-import { defineJuniorPlugin } from "@sentry/junior-plugin-api";
+import {
+  defineJuniorPlugin,
+  definePluginTool,
+} from "@sentry/junior-plugin-api";
+import { z } from "zod";
 
 export function myProviderPlugin() {
   return defineJuniorPlugin({
@@ -204,14 +207,14 @@ export function myProviderPlugin() {
     hooks: {
       tools(ctx) {
         return {
-          ping: {
+          ping: definePluginTool({
             description: "Check my-provider connectivity.",
-            inputSchema: Type.Object({}),
+            inputSchema: z.object({}),
             execute: async () => {
               ctx.log.info("Running my-provider ping");
               return { ok: true };
             },
-          },
+          }),
         };
       },
     },

--- a/packages/docs/src/content/docs/reference/api/README.md
+++ b/packages/docs/src/content/docs/reference/api/README.md
@@ -65,6 +65,7 @@ title: "@sentry/junior"
 - [createApp](/reference/api/functions/createapp/)
 - [createJuniorReporting](/reference/api/functions/createjuniorreporting/)
 - [defineJuniorPlugins](/reference/api/functions/definejuniorplugins/)
+- [definePluginTool](/reference/api/functions/defineplugintool/)
 - [initSentry](/reference/api/functions/initsentry/)
 - [juniorNitro](/reference/api/functions/juniornitro/)
 - [juniorVercelConfig](/reference/api/functions/juniorvercelconfig/)

--- a/packages/docs/src/content/docs/reference/api/functions/definePluginTool.md
+++ b/packages/docs/src/content/docs/reference/api/functions/definePluginTool.md
@@ -1,0 +1,28 @@
+---
+editUrl: false
+next: false
+prev: false
+title: "definePluginTool"
+---
+
+> **definePluginTool**\<`TInputSchema`\>(`definition`): `PluginToolDefinition`\<`output`\<`TInputSchema`\>\>
+
+Defined in: [junior-plugin-api/src/tools.ts:157](https://github.com/getsentry/junior/blob/main/packages/junior-plugin-api/src/tools.ts#L157)
+
+Define a plugin tool with JSON-Schema-representable Zod input parsing.
+
+## Type Parameters
+
+### TInputSchema
+
+`TInputSchema` _extends_ `ZodType`\<`unknown`, `unknown`, `$ZodTypeInternals`\<`unknown`, `unknown`\>\>
+
+## Parameters
+
+### definition
+
+`ZodPluginToolDefinition`\<`TInputSchema`\>
+
+## Returns
+
+`PluginToolDefinition`\<`output`\<`TInputSchema`\>\>

--- a/packages/junior-plugin-api/src/tools.ts
+++ b/packages/junior-plugin-api/src/tools.ts
@@ -8,6 +8,7 @@ import type {
 } from "./context";
 import type { PluginCredentialSubject } from "./credentials";
 import type { PluginState } from "./state";
+import { z, type ZodTypeAny } from "zod";
 
 export interface PluginEnv {
   get(key: string): string | undefined;
@@ -115,6 +116,67 @@ export interface PluginToolDefinition<TInput = unknown> {
    */
   promptSnippet?: string;
   execute?: PluginToolExecute<TInput>;
+}
+
+type ZodPluginToolDefinition<TInputSchema extends ZodTypeAny> = Omit<
+  PluginToolDefinition<z.output<TInputSchema>>,
+  "inputSchema" | "prepareArguments"
+> & {
+  inputSchema: TInputSchema;
+  prepareArguments?: (args: unknown) => z.input<TInputSchema>;
+};
+
+function formatZodPath(path: readonly PropertyKey[]): string {
+  return path.length > 0 ? path.map(String).join(".") : "root";
+}
+
+function formatPluginToolInputError(error: z.ZodError): string {
+  const details = error.issues
+    .slice(0, 5)
+    .map((issue) => `${formatZodPath(issue.path)}: ${issue.message}`)
+    .join("; ");
+  return `Invalid tool arguments: ${details || "input did not match schema"}`;
+}
+
+function parsePluginToolInput<TInputSchema extends ZodTypeAny>(
+  schema: TInputSchema,
+  args: unknown,
+): z.output<TInputSchema> {
+  const result = schema.safeParse(args);
+  if (!result.success) {
+    throw new PluginToolInputError(formatPluginToolInputError(result.error), {
+      cause: result.error,
+    });
+  }
+  return result.data;
+}
+
+/**
+ * Define a plugin tool with JSON-Schema-representable Zod input parsing.
+ */
+export function definePluginTool<TInputSchema extends ZodTypeAny>(
+  definition: ZodPluginToolDefinition<TInputSchema>,
+): PluginToolDefinition<z.output<TInputSchema>> {
+  const { inputSchema, prepareArguments, ...tool } = definition;
+  let modelInputSchema: unknown;
+  try {
+    modelInputSchema = z.toJSONSchema(inputSchema);
+  } catch (error) {
+    throw new TypeError(
+      "definePluginTool() inputSchema must be representable as JSON Schema.",
+      { cause: error },
+    );
+  }
+  return {
+    ...tool,
+    inputSchema: modelInputSchema,
+    prepareArguments(args) {
+      return parsePluginToolInput(
+        inputSchema,
+        prepareArguments ? prepareArguments(args) : args,
+      );
+    },
+  };
 }
 
 export interface SlackToolRegistrationHookContext {

--- a/packages/junior-scheduler/package.json
+++ b/packages/junior-scheduler/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@sentry/junior-plugin-api": "workspace:*",
-    "@sinclair/typebox": "^0.34.49",
     "drizzle-orm": "catalog:",
     "zod": "catalog:"
   },

--- a/packages/junior-scheduler/src/plugin.ts
+++ b/packages/junior-scheduler/src/plugin.ts
@@ -431,7 +431,7 @@ export function createSchedulerPlugin() {
           ctx.source.platform !== "slack" ||
           ctx.requester?.platform !== "slack"
         ) {
-          return {} as Record<string, PluginToolDefinition<any>>;
+          return {} as Record<string, PluginToolDefinition>;
         }
         const context = createSchedulerToolContext(ctx);
         return {
@@ -440,7 +440,7 @@ export function createSchedulerPlugin() {
           slackScheduleUpdateTask: createSlackScheduleUpdateTaskTool(context),
           slackScheduleDeleteTask: createSlackScheduleDeleteTaskTool(context),
           slackScheduleRunTaskNow: createSlackScheduleRunTaskNowTool(context),
-        } satisfies Record<string, PluginToolDefinition<any>>;
+        } satisfies Record<string, PluginToolDefinition>;
       },
       async heartbeat(ctx) {
         const store = schedulerStore(ctx);

--- a/packages/junior-scheduler/src/schedule-tools.ts
+++ b/packages/junior-scheduler/src/schedule-tools.ts
@@ -1,15 +1,15 @@
 import { randomUUID } from "node:crypto";
-import { Type } from "@sinclair/typebox";
 import {
+  definePluginTool,
   PluginToolInputError,
   pluginCredentialSubjectSchema,
   sourceSchema,
   type PluginCredentialSubject,
-  type PluginToolDefinition,
   type SlackDestination,
   type SlackRequester,
   type SlackSource,
 } from "@sentry/junior-plugin-api";
+import { z } from "zod";
 import { buildCalendarRecurrence, parseScheduleTimestamp } from "./cadence";
 import { sanitizeScheduledTaskPrincipal } from "./identity";
 import { type SchedulerStore } from "./store";
@@ -99,12 +99,6 @@ function requireRequester(
       ? { fullName: context.requester.fullName }
       : {}),
   });
-}
-
-function tool<TInput = any>(
-  definition: PluginToolDefinition<TInput>,
-): PluginToolDefinition<TInput> {
-  return definition;
 }
 
 function isDmChannel(channelId: string): boolean {
@@ -373,50 +367,40 @@ function parseNextRunAtMs(
 export function createSlackScheduleCreateTaskTool(
   context: SchedulerToolContext,
 ) {
-  return tool({
+  return definePluginTool({
     description:
       "Create a one-time or recurring Junior task in the active Slack conversation. For one-time reminders or one-time scheduled work, omit recurrence entirely; never choose a default recurrence. Use only when the user explicitly asks Junior to do work later or on a recurring cadence. Only manage tasks for the active Slack DM or channel; never target threads, other channels, or another user's DM. When the task, schedule, and destination are clear, create it without asking for confirmation; ask only when one of those is ambiguous.",
     executionMode: "sequential",
-    inputSchema: Type.Object({
-      task: Type.String({ minLength: 1, maxLength: 4000 }),
-      schedule: Type.String({ minLength: 1, maxLength: 300 }),
-      schedule_kind: Type.Union(
-        [Type.Literal("one_off"), Type.Literal("recurring")],
-        {
-          description:
-            "Required schedule classification. Use one_off for one-time reminders or one-time scheduled work. Use recurring only when the user explicitly asks for a repeating schedule.",
-        },
-      ),
-      timezone: Type.Optional(
-        Type.String({
-          minLength: 1,
-          maxLength: 80,
-          description:
-            "IANA timezone, e.g. 'America/Los_Angeles'. Defaults to the channel's configured timezone.",
-        }),
-      ),
-      next_run_at: Type.Optional(
-        Type.String({
-          minLength: 1,
-          description:
-            "Exact next run time as an ISO timestamp, computed from the user's requested schedule.",
-        }),
-      ),
-      recurrence: Type.Optional(
-        Type.Union(
-          [
-            Type.Literal("daily"),
-            Type.Literal("weekly"),
-            Type.Literal("monthly"),
-            Type.Literal("yearly"),
-            Type.Null(),
-          ],
-          {
-            description:
-              "Required when schedule_kind is recurring. Omit when schedule_kind is one_off. Recurring tasks run at most once per day: use daily, weekly, monthly, or yearly only.",
-          },
+    inputSchema: z.object({
+      task: z.string().min(1).max(4000),
+      schedule: z.string().min(1).max(300),
+      schedule_kind: z
+        .enum(["one_off", "recurring"])
+        .describe(
+          "Required schedule classification. Use one_off for one-time reminders or one-time scheduled work. Use recurring only when the user explicitly asks for a repeating schedule.",
         ),
-      ),
+      timezone: z
+        .string()
+        .min(1)
+        .max(80)
+        .describe(
+          "IANA timezone, e.g. 'America/Los_Angeles'. Defaults to the channel's configured timezone.",
+        )
+        .optional(),
+      next_run_at: z
+        .string()
+        .min(1)
+        .describe(
+          "Exact next run time as an ISO timestamp, computed from the user's requested schedule.",
+        )
+        .optional(),
+      recurrence: z
+        .enum(["daily", "weekly", "monthly", "yearly"])
+        .nullable()
+        .describe(
+          "Required when schedule_kind is recurring. Omit when schedule_kind is one_off. Recurring tasks run at most once per day: use daily, weekly, monthly, or yearly only.",
+        )
+        .optional(),
     }),
     execute: async (input) => {
       const destination = requireActiveConversation(context);
@@ -480,11 +464,11 @@ export function createSlackScheduleCreateTaskTool(
 export function createSlackScheduleListTasksTool(
   context: SchedulerToolContext,
 ) {
-  return tool({
+  return definePluginTool({
     description:
       "List scheduled Junior tasks for the active Slack conversation. Use when the user asks what is scheduled here, or when task IDs are needed before editing, deleting, or running schedules. Only manages tasks for the active Slack DM or channel.",
     annotations: { readOnlyHint: true, destructiveHint: false },
-    inputSchema: Type.Object({}),
+    inputSchema: z.object({}),
     execute: async () => {
       const destination = requireActiveConversation(context);
 
@@ -509,53 +493,38 @@ export function createSlackScheduleListTasksTool(
 export function createSlackScheduleUpdateTaskTool(
   context: SchedulerToolContext,
 ) {
-  return tool({
+  return definePluginTool({
     description:
       "Edit, pause, resume, or reschedule an existing Junior scheduled task in the active Slack conversation. Use only task IDs returned for this conversation. Do not move scheduled tasks across conversations.",
     executionMode: "sequential",
-    inputSchema: Type.Object({
-      task_id: Type.String({
-        minLength: 1,
-        description:
+    inputSchema: z.object({
+      task_id: z
+        .string()
+        .min(1)
+        .describe(
           "ID of the task to update. Must be from this active Slack conversation.",
-      }),
-      task: Type.Optional(Type.String({ minLength: 1, maxLength: 4000 })),
-      schedule: Type.Optional(Type.String({ minLength: 1, maxLength: 300 })),
-      timezone: Type.Optional(Type.String({ minLength: 1, maxLength: 80 })),
-      next_run_at: Type.Optional(
-        Type.String({
-          minLength: 1,
-          description: "Exact ISO timestamp when changing the next run time.",
-        }),
-      ),
-      recurrence: Type.Optional(
-        Type.Union(
-          [
-            Type.Literal("daily"),
-            Type.Literal("weekly"),
-            Type.Literal("monthly"),
-            Type.Literal("yearly"),
-            Type.Null(),
-          ],
-          {
-            description:
-              "Provide only for repeating schedules. Omit for one-time requests. Set to null to convert a recurring task to one-time.",
-          },
         ),
-      ),
-      status: Type.Optional(
-        Type.Union(
-          [
-            Type.Literal("active"),
-            Type.Literal("paused"),
-            Type.Literal("blocked"),
-          ],
-          {
-            description:
-              "Set to active, paused, or blocked to resume, pause, or block the task.",
-          },
-        ),
-      ),
+      task: z.string().min(1).max(4000).optional(),
+      schedule: z.string().min(1).max(300).optional(),
+      timezone: z.string().min(1).max(80).optional(),
+      next_run_at: z
+        .string()
+        .min(1)
+        .describe("Exact ISO timestamp when changing the next run time.")
+        .optional(),
+      recurrence: z
+        .enum(["daily", "weekly", "monthly", "yearly"])
+        .nullable()
+        .describe(
+          "Provide only for repeating schedules. Omit for one-time requests. Set to null to convert a recurring task to one-time.",
+        )
+        .optional(),
+      status: z
+        .enum(["active", "paused", "blocked"])
+        .describe(
+          "Set to active, paused, or blocked to resume, pause, or block the task.",
+        )
+        .optional(),
     }),
     execute: async (input) => {
       const lookup = await getWritableTask({
@@ -626,16 +595,17 @@ export function createSlackScheduleUpdateTaskTool(
 export function createSlackScheduleDeleteTaskTool(
   context: SchedulerToolContext,
 ) {
-  return tool({
+  return definePluginTool({
     description:
       "Delete one scheduled Junior task from the active Slack conversation. Use only task IDs returned for this conversation. Do not delete schedules from threads, other channels, or another user's DM.",
     executionMode: "sequential",
-    inputSchema: Type.Object({
-      task_id: Type.String({
-        minLength: 1,
-        description:
+    inputSchema: z.object({
+      task_id: z
+        .string()
+        .min(1)
+        .describe(
           "ID of the task to delete. Must be from this active Slack conversation.",
-      }),
+        ),
     }),
     execute: async ({ task_id }) => {
       const lookup = await getWritableTask({ context, taskId: task_id });
@@ -661,16 +631,17 @@ export function createSlackScheduleDeleteTaskTool(
 export function createSlackScheduleRunTaskNowTool(
   context: SchedulerToolContext,
 ) {
-  return tool({
+  return definePluginTool({
     description:
       "Queue an existing active scheduled Junior task to run as soon as possible, without changing its cadence. Use when the user asks to run an existing scheduled task now. Use only task IDs returned for this conversation.",
     executionMode: "sequential",
-    inputSchema: Type.Object({
-      task_id: Type.String({
-        minLength: 1,
-        description:
+    inputSchema: z.object({
+      task_id: z
+        .string()
+        .min(1)
+        .describe(
           "ID of the active task to run now. Must be from this active Slack conversation.",
-      }),
+        ),
     }),
     execute: async ({ task_id }) => {
       const lookup = await getWritableTask({ context, taskId: task_id });

--- a/packages/junior-scheduler/tsup.config.ts
+++ b/packages/junior-scheduler/tsup.config.ts
@@ -9,5 +9,5 @@ export default defineConfig({
   dts: false,
   outDir: "dist",
   clean: true,
-  external: ["@sentry/junior-plugin-api", "@sinclair/typebox"],
+  external: ["@sentry/junior-plugin-api", "zod"],
 });

--- a/packages/junior/src/api-reference.ts
+++ b/packages/junior/src/api-reference.ts
@@ -18,6 +18,7 @@ export type {
   SubscribableResource,
 } from "@sentry/junior-plugin-api";
 export {
+  definePluginTool,
   pluginRunContextSchema,
   pluginRunTranscriptEntrySchema,
 } from "@sentry/junior-plugin-api";

--- a/packages/junior/src/chat/slack/id-param.ts
+++ b/packages/junior/src/chat/slack/id-param.ts
@@ -1,10 +1,10 @@
-import { Type } from "@sinclair/typebox";
 import {
   parseSlackChannelId,
   parseSlackUserId,
   type SlackChannelId,
   type SlackUserId,
 } from "@/chat/slack/ids";
+import { z } from "zod";
 
 type RequiredSlackChannelIdParamResult =
   | { ok: true; value: SlackChannelId }
@@ -14,22 +14,16 @@ type RequiredSlackUserIdParamResult =
   | { ok: true; value: SlackUserId }
   | { ok: false; error: string };
 
-// Tool schemas stay TypeBox strings for the model-facing contract; execution
-// parses those values into Zod-branded Slack IDs before provider calls.
+// Tool schemas stay model-facing strings; execution parses those values into
+// Zod-branded Slack IDs before provider calls.
 /** Define a model-facing Slack channel ID parameter. */
 export function slackChannelIdParam(description: string) {
-  return Type.String({
-    minLength: 1,
-    description,
-  });
+  return z.string().min(1).describe(description);
 }
 
 /** Define a model-facing Slack user ID parameter. */
 export function slackUserIdParam(description: string) {
-  return Type.String({
-    minLength: 1,
-    description,
-  });
+  return z.string().min(1).describe(description);
 }
 
 /** Parse a required tool input channel ID into a branded Slack channel ID. */

--- a/packages/junior/src/chat/slack/timestamp-param.ts
+++ b/packages/junior/src/chat/slack/timestamp-param.ts
@@ -1,8 +1,8 @@
-import { Type } from "@sinclair/typebox";
 import {
   parseSlackMessageTs,
   type SlackMessageTs,
 } from "@/chat/slack/timestamp";
+import { z } from "zod";
 
 type SlackTimestampParamResult =
   | { ok: true; value: SlackMessageTs | undefined }
@@ -12,29 +12,34 @@ type RequiredSlackTimestampParamResult =
   | { ok: true; value: SlackMessageTs }
   | { ok: false; error: string };
 
-/** Define a model-facing Slack timestamp string parameter. */
+/** Define a model-facing Slack timestamp, normalizing numeric model args to strings. */
 export function slackTimestampParam(description: string) {
-  return Type.String({
-    minLength: 1,
-    description,
-  });
+  return z
+    .preprocess(
+      (value) =>
+        typeof value === "number" && Number.isFinite(value)
+          ? String(value)
+          : value,
+      z.string().min(1),
+    )
+    .describe(description);
 }
 
 /** Define an optional model-facing Slack timestamp string parameter. */
 export function optionalSlackTimestampParam(description: string) {
-  return Type.Optional(slackTimestampParam(description));
+  return slackTimestampParam(description).optional();
 }
 
 /** Parse tool input into a branded Slack timestamp before provider calls. */
 export function parseSlackTimestampParam(
   field: string,
-  value: string | undefined,
+  value: string | number | undefined,
 ): SlackTimestampParamResult {
   if (!value) {
     return { ok: true, value: undefined };
   }
 
-  const timestamp = parseSlackMessageTs(value);
+  const timestamp = parseSlackMessageTs(String(value));
   if (timestamp) {
     return { ok: true, value: timestamp };
   }
@@ -48,9 +53,9 @@ export function parseSlackTimestampParam(
 /** Parse a required tool input timestamp into a branded Slack timestamp. */
 export function parseRequiredSlackTimestampParam(
   field: string,
-  value: string,
+  value: string | number,
 ): RequiredSlackTimestampParamResult {
-  const timestamp = parseSlackMessageTs(value);
+  const timestamp = parseSlackMessageTs(String(value));
   if (timestamp) {
     return { ok: true, value: timestamp };
   }

--- a/packages/junior/src/chat/slack/tools/canvas/create.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/create.ts
@@ -3,29 +3,22 @@ import { isConversationScopedChannel } from "@/chat/slack/client";
 import { createCanvas } from "@/chat/slack/tools/canvas/api";
 import { mergeRecentCanvases } from "@/chat/slack/tools/canvas/context";
 import type { SlackToolContext } from "@/chat/slack/tools/context";
-import { tool } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 import { createOperationKey } from "@/chat/tools/idempotency";
 import type { ToolState } from "@/chat/tools/types";
-import { Type } from "@sinclair/typebox";
 
 /** Create a tool that provisions a new Slack canvas in the active channel. */
 export function createSlackCanvasCreateTool(
   context: SlackToolContext,
   state: ToolState,
 ) {
-  return tool({
+  return zodTool({
     description:
       "Create a Slack canvas for long-form output in the active assistant context channel. Use when the answer is better as a reusable document than a thread reply: long-form research, timelines, bios/profiles, structured notes, plans, comparisons, or anything likely to exceed one compact Slack reply. After creating it, reply with one or two short sentences plus the canvas link; do not recap the canvas contents. Do not use for short answers that fit cleanly in one normal thread reply.",
-    inputSchema: Type.Object({
-      title: Type.String({
-        minLength: 1,
-        maxLength: 160,
-        description: "Canvas title.",
-      }),
-      markdown: Type.String({
-        minLength: 1,
-        description: "Canvas markdown body content.",
-      }),
+    inputSchema: z.object({
+      title: z.string().min(1).max(160).describe("Canvas title."),
+      markdown: z.string().min(1).describe("Canvas markdown body content."),
     }),
     execute: async ({ title, markdown }) => {
       const targetChannelId = context.destinationChannelId;

--- a/packages/junior/src/chat/slack/tools/canvas/edit.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/edit.ts
@@ -5,7 +5,8 @@ import {
   writeCanvasMarkdown,
 } from "@/chat/slack/tools/canvas/api";
 import { resolveCanvasTarget } from "@/chat/slack/tools/canvas/context";
-import { tool } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 import { createOperationKey } from "@/chat/tools/idempotency";
 import { normalizeToLf } from "@/chat/tools/sandbox/file-utils";
 import {
@@ -15,7 +16,6 @@ import {
   type TextReplacement,
 } from "@/chat/tools/sandbox/text-edits";
 import type { ToolState } from "@/chat/tools/types";
-import { Type } from "@sinclair/typebox";
 
 function prepareCanvasEditArguments(input: unknown): {
   canvas: string;
@@ -24,42 +24,35 @@ function prepareCanvasEditArguments(input: unknown): {
   return prepareTextReplacementArguments(input);
 }
 
-const editReplacementSchema = Type.Object(
-  {
-    oldText: Type.String({
-      minLength: 1,
-      description:
-        "Exact Canvas markdown to replace. It must be unique in the current Canvas body and must not overlap another edit.",
-    }),
-    newText: Type.String({
-      description: "Replacement Canvas markdown for this edit.",
-    }),
-  },
-  { additionalProperties: false },
-);
+const editReplacementSchema = z.object({
+  oldText: z
+    .string()
+    .min(1)
+    .describe(
+      "Exact Canvas markdown to replace. It must be unique in the current Canvas body and must not overlap another edit.",
+    ),
+  newText: z.string().describe("Replacement Canvas markdown for this edit."),
+});
 
 /** Create a tool that edits a Slack canvas like a markdown file. */
 export function createSlackCanvasEditTool(state: ToolState) {
-  return tool({
+  return zodTool({
     description:
       "Edit one Slack canvas with exact markdown replacements. Use for precise changes to existing Canvas content; prefer this over slackCanvasWrite for targeted changes. Each oldText must match exactly, be unique, and not overlap another edit. Returns a diff. Multiple changes to the same canvas: use one edits[] call.",
     prepareArguments: prepareCanvasEditArguments,
     executionMode: "sequential",
-    inputSchema: Type.Object(
-      {
-        canvas: Type.String({
-          minLength: 1,
-          description:
-            "Canvas/file ID (e.g. `F0ABCDEF`) or Slack canvas/docs URL.",
-        }),
-        edits: Type.Array(editReplacementSchema, {
-          minItems: 1,
-          description:
-            "Exact replacements matched against the current Canvas body, not incrementally.",
-        }),
-      },
-      { additionalProperties: false },
-    ),
+    inputSchema: z.object({
+      canvas: z
+        .string()
+        .min(1)
+        .describe("Canvas/file ID (e.g. `F0ABCDEF`) or Slack canvas/docs URL."),
+      edits: z
+        .array(editReplacementSchema)
+        .min(1)
+        .describe(
+          "Exact replacements matched against the current Canvas body, not incrementally.",
+        ),
+    }),
     execute: async ({ canvas, edits }) => {
       const target = resolveCanvasTarget(canvas);
       if (!target.ok) {

--- a/packages/junior/src/chat/slack/tools/canvas/read.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/read.ts
@@ -1,10 +1,10 @@
 import { logWarn } from "@/chat/logging";
 import { readCanvas } from "@/chat/slack/tools/canvas/api";
 import { resolveCanvasTarget } from "@/chat/slack/tools/canvas/context";
-import { tool } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 import { normalizeToLf } from "@/chat/tools/sandbox/file-utils";
 import { sliceFileContent } from "@/chat/tools/sandbox/read-file";
-import { Type } from "@sinclair/typebox";
 
 /**
  * Create a tool that reads a Slack canvas the bot has access to. Accepts
@@ -12,32 +12,30 @@ import { Type } from "@sinclair/typebox";
  * canvas body downloaded via the bot's file access.
  */
 export function createSlackCanvasReadTool() {
-  return tool({
+  return zodTool({
     description:
       "Read a bounded line range from a Slack canvas as markdown. Use when you need exact Canvas contents to verify facts or make edits safely. Do not use for generic web pages — use webFetch for those.",
     annotations: { readOnlyHint: true, destructiveHint: false },
-    inputSchema: Type.Object(
-      {
-        canvas: Type.String({
-          minLength: 1,
-          description:
-            "Canvas/file ID (e.g. `F0ABCDEF`) or Slack canvas/docs URL (e.g. `https://team.slack.com/docs/T.../F...`).",
-        }),
-        offset: Type.Optional(
-          Type.Integer({
-            minimum: 1,
-            description: "1-indexed line number to start reading from.",
-          }),
+    inputSchema: z.object({
+      canvas: z
+        .string()
+        .min(1)
+        .describe(
+          "Canvas/file ID (e.g. `F0ABCDEF`) or Slack canvas/docs URL (e.g. `https://team.slack.com/docs/T.../F...`).",
         ),
-        limit: Type.Optional(
-          Type.Integer({
-            minimum: 1,
-            description: "Maximum number of lines to read. Defaults to 1000.",
-          }),
-        ),
-      },
-      { additionalProperties: false },
-    ),
+      offset: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .describe("1-indexed line number to start reading from.")
+        .optional(),
+      limit: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .describe("Maximum number of lines to read. Defaults to 1000.")
+        .optional(),
+    }),
     execute: async ({ canvas, offset, limit }) => {
       const target = resolveCanvasTarget(canvas);
       if (!target.ok) {

--- a/packages/junior/src/chat/slack/tools/canvas/write.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/write.ts
@@ -4,30 +4,24 @@ import {
   resolveCanvasTarget,
   storedCanvasUrl,
 } from "@/chat/slack/tools/canvas/context";
-import { tool } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 import { createOperationKey } from "@/chat/tools/idempotency";
 import type { ToolState } from "@/chat/tools/types";
-import { Type } from "@sinclair/typebox";
 
 /** Create a tool that deliberately replaces a Slack canvas body. */
 export function createSlackCanvasWriteTool(state: ToolState) {
-  return tool({
+  return zodTool({
     description:
       "Write UTF-8 markdown content to a Slack canvas. Use for deliberate full-Canvas replacement after validation; use slackCanvasEdit for targeted changes to existing canvas content.",
     executionMode: "sequential",
-    inputSchema: Type.Object(
-      {
-        canvas: Type.String({
-          minLength: 1,
-          description:
-            "Canvas/file ID (e.g. `F0ABCDEF`) or Slack canvas/docs URL.",
-        }),
-        content: Type.String({
-          description: "UTF-8 markdown content to write.",
-        }),
-      },
-      { additionalProperties: false },
-    ),
+    inputSchema: z.object({
+      canvas: z
+        .string()
+        .min(1)
+        .describe("Canvas/file ID (e.g. `F0ABCDEF`) or Slack canvas/docs URL."),
+      content: z.string().describe("UTF-8 markdown content to write."),
+    }),
     execute: async ({ canvas, content }) => {
       const target = resolveCanvasTarget(canvas);
       if (!target.ok) {

--- a/packages/junior/src/chat/slack/tools/channel-list-messages.ts
+++ b/packages/junior/src/chat/slack/tools/channel-list-messages.ts
@@ -1,4 +1,3 @@
-import { Type } from "@sinclair/typebox";
 import { SlackActionError } from "@/chat/slack/client";
 import { listChannelMessages } from "@/chat/slack/channel";
 import { parseSlackThreadId } from "@/chat/slack/context";
@@ -8,9 +7,18 @@ import {
   optionalSlackTimestampParam,
   parseSlackTimestampParam,
 } from "@/chat/slack/timestamp-param";
-import { tool } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 import type { SlackToolContext } from "@/chat/slack/tools/context";
+
+const booleanInput = (description: string) =>
+  z
+    .preprocess(
+      (value) => (value === "true" ? true : value === "false" ? false : value),
+      z.boolean(),
+    )
+    .describe(description);
 
 /**
  * Accept numeric Slack ts bounds and recover matching Junior
@@ -18,7 +26,7 @@ import type { SlackToolContext } from "@/chat/slack/tools/context";
  */
 function normalizeRangeTimestamp(
   field: "oldest" | "latest",
-  value: string | undefined,
+  value: number | string | undefined,
   targetChannelId: SlackChannelId,
 ):
   | { ok: true; value: SlackMessageTs | undefined }
@@ -27,7 +35,7 @@ function normalizeRangeTimestamp(
     return { ok: true, value: undefined };
   }
 
-  const trimmed = value.trim();
+  const trimmed = String(value).trim();
   if (!trimmed) {
     return parseSlackTimestampParam(field, value);
   }
@@ -52,43 +60,39 @@ function normalizeRangeTimestamp(
 
 /** Create the active-channel history tool with preflight timestamp normalization. */
 export function createSlackChannelListMessagesTool(context: SlackToolContext) {
-  return tool({
+  return zodTool({
     description:
       "List channel messages from Slack history in the active channel context. Use when the user asks for recent or historical channel context outside this thread. Do not use for live monitoring or when current thread context already answers the question.",
     annotations: { readOnlyHint: true, destructiveHint: false },
-    inputSchema: Type.Object({
-      limit: Type.Optional(
-        Type.Integer({
-          minimum: 1,
-          maximum: 1000,
-          description: "Maximum number of messages to return across pages.",
-        }),
-      ),
-      cursor: Type.Optional(
-        Type.String({
-          minLength: 1,
-          description: "Optional cursor to continue from a prior call.",
-        }),
-      ),
+    inputSchema: z.object({
+      limit: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(1000)
+        .describe("Maximum number of messages to return across pages.")
+        .optional(),
+      cursor: z
+        .string()
+        .min(1)
+        .describe("Optional cursor to continue from a prior call.")
+        .optional(),
       oldest: optionalSlackTimestampParam(
         "Optional oldest message timestamp (Slack ts) for range filtering.",
       ),
       latest: optionalSlackTimestampParam(
         "Optional latest message timestamp (Slack ts) for range filtering.",
       ),
-      inclusive: Type.Optional(
-        Type.Boolean({
-          description: "Whether oldest/latest bounds should be inclusive.",
-        }),
-      ),
-      max_pages: Type.Optional(
-        Type.Integer({
-          minimum: 1,
-          maximum: 10,
-          description:
-            "Maximum number of API pages to traverse in a single call.",
-        }),
-      ),
+      inclusive: booleanInput(
+        "Whether oldest/latest bounds should be inclusive.",
+      ).optional(),
+      max_pages: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(10)
+        .describe("Maximum number of API pages to traverse in a single call.")
+        .optional(),
     }),
     execute: async ({
       limit,

--- a/packages/junior/src/chat/slack/tools/list/add-items.ts
+++ b/packages/junior/src/chat/slack/tools/list/add-items.ts
@@ -3,34 +3,31 @@ import {
   parseRequiredSlackUserIdParam,
   slackUserIdParam,
 } from "@/chat/slack/id-param";
-import { tool } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 import { createOperationKey } from "@/chat/tools/idempotency";
 import type { ToolState } from "@/chat/tools/types";
-import { Type } from "@sinclair/typebox";
 
 /** Create a tool that appends items to the active Slack list. */
 export function createSlackListAddItemsTool(state: ToolState) {
-  return tool({
+  return zodTool({
     description:
       "Add tasks to the active Slack list tracked in artifact context. Use when the user wants actionable items recorded in the current thread list. Do not use when no list exists and list creation was not requested.",
-    inputSchema: Type.Object({
-      items: Type.Array(Type.String({ minLength: 1 }), {
-        minItems: 1,
-        maxItems: 25,
-        description: "List item titles to create.",
-      }),
-      assignee_user_id: Type.Optional(
-        slackUserIdParam(
-          "Optional Slack user ID assigned to all created items.",
-        ),
-      ),
-      due_date: Type.Optional(
-        Type.String({
-          pattern: "^\\d{4}-\\d{2}-\\d{2}$",
-          description: "Optional due date in YYYY-MM-DD format.",
-        }),
-      ),
+    inputSchema: z.object({
+      items: z
+        .array(z.string().min(1))
+        .min(1)
+        .max(25)
+        .describe("List item titles to create."),
+      assignee_user_id: slackUserIdParam(
+        "Optional Slack user ID assigned to all created items.",
+      ).optional(),
+      due_date: z
+        .string()
+        .regex(/^\d{4}-\d{2}-\d{2}$/)
+        .describe("Optional due date in YYYY-MM-DD format.")
+        .optional(),
     }),
     execute: async ({ items, assignee_user_id, due_date }) => {
       const targetListId = state.getCurrentListId();

--- a/packages/junior/src/chat/slack/tools/list/create.ts
+++ b/packages/junior/src/chat/slack/tools/list/create.ts
@@ -1,20 +1,16 @@
 import { createTodoList } from "@/chat/slack/tools/list/api";
-import { tool } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 import { createOperationKey } from "@/chat/tools/idempotency";
 import type { ToolState } from "@/chat/tools/types";
-import { Type } from "@sinclair/typebox";
 
 /** Create a tool that provisions a new Slack todo list. */
 export function createSlackListCreateTool(state: ToolState) {
-  return tool({
+  return zodTool({
     description:
       "Create a Slack todo list for action tracking. Use when the user needs structured tasks with ownership/completion tracking. Do not use for one-off notes without task management needs.",
-    inputSchema: Type.Object({
-      name: Type.String({
-        minLength: 1,
-        maxLength: 160,
-        description: "Name for the new Slack list.",
-      }),
+    inputSchema: z.object({
+      name: z.string().min(1).max(160).describe("Name for the new Slack list."),
     }),
     execute: async ({ name }) => {
       const operationKey = createOperationKey("slackListCreate", { name });

--- a/packages/junior/src/chat/slack/tools/list/get-items.ts
+++ b/packages/junior/src/chat/slack/tools/list/get-items.ts
@@ -1,22 +1,22 @@
 import { listItems } from "@/chat/slack/tools/list/api";
-import { tool } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 import type { ToolState } from "@/chat/tools/types";
-import { Type } from "@sinclair/typebox";
 
 /** Create a tool that reads items from the active Slack list. */
 export function createSlackListGetItemsTool(state: ToolState) {
-  return tool({
+  return zodTool({
     description:
       "Read items from the active Slack list tracked in artifact context. Use when the user asks for task status, open items, or list contents. Do not use when list state is already known from the immediately prior result.",
     annotations: { readOnlyHint: true, destructiveHint: false },
-    inputSchema: Type.Object({
-      limit: Type.Optional(
-        Type.Integer({
-          minimum: 1,
-          maximum: 200,
-          description: "Maximum number of list items to return.",
-        }),
-      ),
+    inputSchema: z.object({
+      limit: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(200)
+        .describe("Maximum number of list items to return.")
+        .optional(),
     }),
     execute: async ({ limit }) => {
       const targetListId = state.getCurrentListId();

--- a/packages/junior/src/chat/slack/tools/list/update-item.ts
+++ b/packages/junior/src/chat/slack/tools/list/update-item.ts
@@ -1,36 +1,36 @@
 import { updateListItem } from "@/chat/slack/tools/list/api";
-import { tool } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 import { createOperationKey } from "@/chat/tools/idempotency";
 import type { ToolState } from "@/chat/tools/types";
-import { Type } from "@sinclair/typebox";
+
+const booleanInput = (description: string) =>
+  z
+    .preprocess(
+      (value) => (value === "true" ? true : value === "false" ? false : value),
+      z.boolean(),
+    )
+    .describe(description);
+
+const updateListItemInputSchema = z.union([
+  z.object({
+    item_id: z.string().min(1).describe("ID of the Slack list item to update."),
+    completed: booleanInput("Optional completion status update."),
+    title: z.string().min(1).describe("Optional new item title.").optional(),
+  }),
+  z.object({
+    item_id: z.string().min(1).describe("ID of the Slack list item to update."),
+    completed: booleanInput("Optional completion status update.").optional(),
+    title: z.string().min(1).describe("Optional new item title."),
+  }),
+]);
 
 /** Create a tool that updates an item in the active Slack list. */
 export function createSlackListUpdateItemTool(state: ToolState) {
-  return tool({
+  return zodTool({
     description:
       "Update an item in the active Slack list tracked in artifact context (title/completion). Use when the user asks to mark progress or rename a tracked task. Do not use to add new tasks.",
-    inputSchema: Type.Object(
-      {
-        item_id: Type.String({
-          minLength: 1,
-          description: "ID of the Slack list item to update.",
-        }),
-        completed: Type.Optional(
-          Type.Boolean({
-            description: "Optional completion status update.",
-          }),
-        ),
-        title: Type.Optional(
-          Type.String({
-            minLength: 1,
-            description: "Optional new item title.",
-          }),
-        ),
-      },
-      {
-        anyOf: [{ required: ["completed"] }, { required: ["title"] }],
-      },
-    ),
+    inputSchema: updateListItemInputSchema,
     execute: async ({ item_id, completed, title }) => {
       const targetListId = state.getCurrentListId();
       if (!targetListId) {

--- a/packages/junior/src/chat/slack/tools/message-add-reaction.ts
+++ b/packages/junior/src/chat/slack/tools/message-add-reaction.ts
@@ -1,7 +1,7 @@
-import { Type } from "@sinclair/typebox";
 import { normalizeSlackEmojiName } from "@/chat/slack/emoji";
 import { addReactionToMessage } from "@/chat/slack/outbound";
-import { tool } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 import { createOperationKey } from "@/chat/tools/idempotency";
 import type { SlackToolContext } from "@/chat/slack/tools/context";
@@ -12,16 +12,17 @@ export function createSlackMessageAddReactionTool(
   context: SlackToolContext,
   state: ToolState,
 ) {
-  return tool({
+  return zodTool({
     description:
       "Add an emoji reaction to the current inbound Slack message. Use when the user asks for a reaction on the current message without another target. Provide a Slack emoji alias name (for example `thumbsup`, `white_check_mark`, or `thumbsup::skin-tone-6`), not a unicode emoji glyph. The target message is injected by runtime context; do not use this for arbitrary historical messages.",
-    inputSchema: Type.Object({
-      emoji: Type.String({
-        minLength: 1,
-        maxLength: 64,
-        description:
+    inputSchema: z.object({
+      emoji: z
+        .string()
+        .min(1)
+        .max(64)
+        .describe(
           "Slack emoji alias name to react with (for example `thumbsup`, `white_check_mark`, or `thumbsup::skin-tone-6`). Optional surrounding colons are allowed.",
-      }),
+        ),
     }),
     execute: async ({ emoji }) => {
       const targetChannelId = context.sourceChannelId;

--- a/packages/junior/src/chat/slack/tools/send-message.ts
+++ b/packages/junior/src/chat/slack/tools/send-message.ts
@@ -1,11 +1,11 @@
 import { createHash } from "node:crypto";
-import { Type } from "@sinclair/typebox";
 import {
   postSlackMessage,
   uploadFilesToConversation,
 } from "@/chat/slack/outbound";
 import type { SlackToolContext } from "@/chat/slack/tools/context";
-import { tool } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 import { createOperationKey } from "@/chat/tools/idempotency";
 import type { SandboxFileUpload } from "@/chat/tools/sandbox/file-uploads";
@@ -24,27 +24,28 @@ type MessageFileInput = {
   mimeType?: string | null;
 };
 
-const fileInputSchema = Type.Object(
-  {
-    path: Type.String({
-      minLength: 1,
-      description:
-        "Sandbox file path to include in the message. Absolute paths and workspace-relative paths are supported.",
-    }),
-    filename: Type.Optional(
-      Type.Union([Type.String({ minLength: 1 }), Type.Null()], {
-        description:
-          "Optional filename override shown in Slack. Null is treated as omitted.",
-      }),
+const fileInputSchema = z.object({
+  path: z
+    .string()
+    .min(1)
+    .describe(
+      "Sandbox file path to include in the message. Absolute paths and workspace-relative paths are supported.",
     ),
-    mimeType: Type.Optional(
-      Type.Union([Type.String({ minLength: 1 }), Type.Null()], {
-        description: "Optional MIME type override. Null is treated as omitted.",
-      }),
+  filename: z
+    .string()
+    .min(1)
+    .nullable()
+    .optional()
+    .describe(
+      "Optional filename override shown in Slack. Null is treated as omitted.",
     ),
-  },
-  { additionalProperties: false },
-);
+  mimeType: z
+    .string()
+    .min(1)
+    .nullable()
+    .optional()
+    .describe("Optional MIME type override. Null is treated as omitted."),
+});
 
 interface SendMessageResult {
   ok: true;
@@ -91,29 +92,25 @@ export function createSendMessageTool(
   state: ToolState,
   materializeFile: MaterializeMessageFile,
 ) {
-  return tool({
+  return zodTool({
     description:
       "Send a Slack message with optional files into the active Slack conversation. Use when the user asks to attach, send, or share files here, in this conversation, or in this thread. The message can contain text, files, or both; file-only messages are allowed. Do not use for top-level channel posts, other named channels, inline @mentions, or pinging mentioned users.",
-    inputSchema: Type.Object(
-      {
-        text: Type.Optional(
-          Type.Union([Type.String({ maxLength: 40000 }), Type.Null()], {
-            description:
-              "Slack mrkdwn text to send. Null is treated as omitted.",
-          }),
+    inputSchema: z.object({
+      text: z
+        .string()
+        .max(40000)
+        .nullable()
+        .optional()
+        .describe("Slack mrkdwn text to send. Null is treated as omitted."),
+      files: z
+        .array(fileInputSchema)
+        .min(1)
+        .nullable()
+        .optional()
+        .describe(
+          "Sandbox files to include in the message. Null is treated as omitted.",
         ),
-        files: Type.Optional(
-          Type.Union(
-            [Type.Array(fileInputSchema, { minItems: 1 }), Type.Null()],
-            {
-              description:
-                "Sandbox files to include in the message. Null is treated as omitted.",
-            },
-          ),
-        ),
-      },
-      { additionalProperties: false },
-    ),
+    }),
     execute: async ({ text, files }) => {
       const filesToSend = normalizeMessageFiles(files);
       const activeChannelId = context.sourceChannelId;

--- a/packages/junior/src/chat/slack/tools/thread-read.ts
+++ b/packages/junior/src/chat/slack/tools/thread-read.ts
@@ -1,4 +1,3 @@
-import { Type } from "@sinclair/typebox";
 import { SlackActionError } from "@/chat/slack/client";
 import { listThreadReplies } from "@/chat/slack/channel";
 import {
@@ -9,7 +8,8 @@ import {
   parseRequiredSlackChannelIdParam,
   slackChannelIdParam,
 } from "@/chat/slack/id-param";
-import { tool } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 import { parseSlackMessageReference } from "@/chat/slack/tools/slack-message-url";
 import type { SlackToolContext } from "@/chat/slack/tools/context";
 import {
@@ -80,42 +80,38 @@ export function createSlackThreadReadTool(
   context: SlackToolContext,
   deps: { visibilityStore?: DestinationVisibilityReader } = {},
 ) {
-  return tool({
+  return zodTool({
     description:
       "Read a Slack thread from a shared Slack message archive URL or explicit channel + timestamp. Use when the user shares a Slack message link (https://*.slack.com/archives/...) and you need the referenced message and its thread context. Only the current conversation and public channels Junior has seen in this workspace are readable.",
     annotations: { readOnlyHint: true, destructiveHint: false },
-    inputSchema: Type.Object({
-      url: Type.Optional(
-        Type.String({
-          minLength: 1,
-          description:
-            "Slack message archive URL, e.g. https://workspace.slack.com/archives/C123/p1700000000123456",
-        }),
-      ),
-      channel_id: Type.Optional(
-        slackChannelIdParam(
-          "Slack channel/conversation ID (e.g. C123). Use with `ts` as an alternative to `url`.",
-        ),
-      ),
-      ts: Type.Optional(
-        slackTimestampParam(
-          "Slack message timestamp (e.g. 1700000000.123456). May be the thread root or any message in the thread.",
-        ),
-      ),
-      limit: Type.Optional(
-        Type.Integer({
-          minimum: 1,
-          maximum: 1000,
-          description: "Maximum number of thread messages to fetch.",
-        }),
-      ),
-      max_pages: Type.Optional(
-        Type.Integer({
-          minimum: 1,
-          maximum: 10,
-          description: "Maximum number of Slack API pages to traverse.",
-        }),
-      ),
+    inputSchema: z.object({
+      url: z
+        .string()
+        .min(1)
+        .describe(
+          "Slack message archive URL, e.g. https://workspace.slack.com/archives/C123/p1700000000123456",
+        )
+        .optional(),
+      channel_id: slackChannelIdParam(
+        "Slack channel/conversation ID (e.g. C123). Use with `ts` as an alternative to `url`.",
+      ).optional(),
+      ts: slackTimestampParam(
+        "Slack message timestamp (e.g. 1700000000.123456). May be the thread root or any message in the thread.",
+      ).optional(),
+      limit: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(1000)
+        .describe("Maximum number of thread messages to fetch.")
+        .optional(),
+      max_pages: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(10)
+        .describe("Maximum number of Slack API pages to traverse.")
+        .optional(),
     }),
     execute: async ({ url, channel_id, ts, limit, max_pages }) => {
       let channelId: SlackChannelId;

--- a/packages/junior/src/chat/slack/tools/user-lookup.ts
+++ b/packages/junior/src/chat/slack/tools/user-lookup.ts
@@ -1,4 +1,3 @@
-import { Type } from "@sinclair/typebox";
 import { SlackActionError } from "@/chat/slack/client";
 import {
   lookupSlackUserProfile,
@@ -9,56 +8,62 @@ import {
   parseRequiredSlackUserIdParam,
   slackUserIdParam,
 } from "@/chat/slack/id-param";
-import { tool } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
+
+const booleanInput = (description: string) =>
+  z
+    .preprocess(
+      (value) => (value === "true" ? true : value === "false" ? false : value),
+      z.boolean(),
+    )
+    .describe(description);
 
 /** Create the tool that resolves Slack users by ID, handle, or email. */
 export function createSlackUserLookupTool() {
-  return tool({
+  return zodTool({
     description:
       "Look up Slack user profiles by user ID, email, or name search. Use when you need to identify a user, resolve cross-platform identity, or look up profile details like title or status. Returns profile fields including custom fields. For user ID lookup, pass a Slack user ID (e.g. U039RR91S). For search, pass a name query.",
     annotations: { readOnlyHint: true, destructiveHint: false },
-    inputSchema: Type.Object({
-      user_id: Type.Optional(
-        slackUserIdParam(
-          "Slack user ID to look up (e.g. U039RR91S). Mutually exclusive with email and query.",
-        ),
-      ),
-      email: Type.Optional(
-        Type.String({
-          minLength: 3,
-          description:
-            "Email address to look up. Mutually exclusive with user_id and query.",
-        }),
-      ),
-      query: Type.Optional(
-        Type.String({
-          minLength: 2,
-          description:
-            "Name to search for (matches against username, display name, real name). Mutually exclusive with user_id and email.",
-        }),
-      ),
-      limit: Type.Optional(
-        Type.Integer({
-          minimum: 1,
-          maximum: 20,
-          description:
-            "Maximum number of results to return for name search. Defaults to 10.",
-        }),
-      ),
-      max_pages: Type.Optional(
-        Type.Integer({
-          minimum: 1,
-          maximum: 5,
-          description:
-            "Maximum number of Slack API pages to scan for name search. Defaults to 3.",
-        }),
-      ),
-      include_bots: Type.Optional(
-        Type.Boolean({
-          description:
-            "Include bot accounts in name search results. Defaults to false.",
-        }),
-      ),
+    inputSchema: z.object({
+      user_id: slackUserIdParam(
+        "Slack user ID to look up (e.g. U039RR91S). Mutually exclusive with email and query.",
+      ).optional(),
+      email: z
+        .string()
+        .min(3)
+        .describe(
+          "Email address to look up. Mutually exclusive with user_id and query.",
+        )
+        .optional(),
+      query: z
+        .string()
+        .min(2)
+        .describe(
+          "Name to search for (matches against username, display name, real name). Mutually exclusive with user_id and email.",
+        )
+        .optional(),
+      limit: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(20)
+        .describe(
+          "Maximum number of results to return for name search. Defaults to 10.",
+        )
+        .optional(),
+      max_pages: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(5)
+        .describe(
+          "Maximum number of Slack API pages to scan for name search. Defaults to 3.",
+        )
+        .optional(),
+      include_bots: booleanInput(
+        "Include bot accounts in name search results. Defaults to false.",
+      ).optional(),
     }),
     execute: async ({
       user_id,

--- a/packages/junior/src/chat/tools/advisor/tool.ts
+++ b/packages/junior/src/chat/tools/advisor/tool.ts
@@ -3,7 +3,6 @@ import {
   type AgentTool,
   type StreamFn,
 } from "@earendil-works/pi-agent-core";
-import { Type } from "@sinclair/typebox";
 import { THREAD_STATE_TTL_MS } from "chat";
 import type { AdvisorConfig } from "@/chat/config";
 import {
@@ -37,7 +36,8 @@ import {
   recordSubagentEnded,
   recordSubagentStarted,
 } from "@/chat/state/session-log";
-import { tool, type AnyToolDefinition } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool, type AnyToolDefinition } from "@/chat/tools/definition";
 import { escapeXml } from "@/chat/xml";
 
 export type AdvisorErrorCode =
@@ -145,18 +145,19 @@ export function createAdvisorTool(context: AdvisorToolRuntimeContext) {
   const store = context.store ?? createStateAdvisorSessionStore();
   const spanContext = context.logContext ?? {};
 
-  return tool({
+  return zodTool({
     description: ADVISOR_TOOL_DESCRIPTION,
-    inputSchema: Type.Object({
-      question: Type.String({
-        minLength: 1,
-        description: "Focused advisor question or decision point.",
-      }),
-      context: Type.String({
-        minLength: 1,
-        description:
+    inputSchema: z.object({
+      question: z
+        .string()
+        .min(1)
+        .describe("Focused advisor question or decision point."),
+      context: z
+        .string()
+        .min(1)
+        .describe(
           "Curated evidence packet: relevant requirements, constraints, current plan, alternatives, code snippets, diffs, command output, and open questions.",
-      }),
+        ),
     }),
     execute: async (
       { question, context: suppliedContext },

--- a/packages/junior/src/chat/tools/agent-tools.ts
+++ b/packages/junior/src/chat/tools/agent-tools.ts
@@ -185,7 +185,7 @@ export function createAgentTools(
     name: toolName,
     label: toolName,
     description: toolDef.description,
-    parameters: toolDef.inputSchema,
+    parameters: toolDef.inputSchema as AgentTool["parameters"],
     prepareArguments: toolDef.prepareArguments,
     executionMode: toolDef.executionMode,
     execute: async (

--- a/packages/junior/src/chat/tools/definition.ts
+++ b/packages/junior/src/chat/tools/definition.ts
@@ -1,7 +1,19 @@
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
-import type { Static, TSchema } from "@sinclair/typebox";
+import { Kind, type Static, type TSchema } from "@sinclair/typebox";
 import type { ToolExecutionMode } from "@earendil-works/pi-agent-core";
+import { z, type ZodTypeAny } from "zod";
 import type { ConversationPrivacy } from "@/chat/conversation-privacy";
+import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
+
+/**
+ * Tool definition boundary for Pi-facing agent tools. `tool()` keeps the
+ * legacy TypeBox path, while `zodTool()` projects Zod schemas to JSON Schema
+ * and owns model-input parse errors before execution.
+ */
+export interface JsonSchemaObject {
+  [key: string]: unknown;
+}
+export type ToolInputSchema = TSchema | JsonSchemaObject;
 
 export type ToolExposure = "direct" | "deferred" | "modelOnly" | "hidden";
 
@@ -12,7 +24,7 @@ export interface ToolExecuteOptions {
   toolCallId?: string;
 }
 
-export interface ToolDefinition<TInputSchema extends TSchema = TSchema> {
+interface BaseToolDefinition<TInput, TInputSchema extends ToolInputSchema> {
   /** Stable internal owner-qualified identity for plugin-contributed tools. */
   identity?: {
     id: string;
@@ -35,21 +47,45 @@ export interface ToolDefinition<TInputSchema extends TSchema = TSchema> {
    * removed in a future major version.
    */
   promptGuidelines?: string[];
-  prepareArguments?: (args: unknown) => Static<TInputSchema>;
+  prepareArguments?: (args: unknown) => TInput;
   executionMode?: ToolExecutionMode;
   execute?: (
-    input: Static<TInputSchema>,
+    input: TInput,
     options: ToolExecuteOptions,
   ) => Promise<unknown> | unknown;
 }
 
+export interface ToolDefinition<
+  TInputSchema extends TSchema = TSchema,
+> extends BaseToolDefinition<Static<TInputSchema>, TInputSchema> {}
+
 /**
  * Schema-erased view for heterogeneous registries after Pi validates tool input.
  */
-export interface AnyToolDefinition extends Omit<
-  ToolDefinition<TSchema>,
-  "execute" | "prepareArguments"
-> {
+export interface AnyToolDefinition {
+  /** Stable internal owner-qualified identity for plugin-contributed tools. */
+  identity?: {
+    id: string;
+    name: string;
+    plugin: string;
+  };
+  description: string;
+  exposure?: ToolExposure;
+  inputSchema: ToolInputSchema;
+  annotations?: ToolAnnotations;
+  /**
+   * @deprecated Put tool-selection and usage guidance directly in `description`
+   * and parameter descriptions. Retained for plugin compatibility; may be
+   * removed in a future major version.
+   */
+  promptSnippet?: string;
+  /**
+   * @deprecated Put tool-selection and usage guidance directly in `description`
+   * and parameter descriptions. Retained for plugin compatibility; may be
+   * removed in a future major version.
+   */
+  promptGuidelines?: string[];
+  executionMode?: ToolExecutionMode;
   execute?(
     input: unknown,
     options: ToolExecuteOptions,
@@ -57,9 +93,102 @@ export interface AnyToolDefinition extends Omit<
   prepareArguments?(args: unknown): unknown;
 }
 
+/** Distinguish legacy TypeBox schemas from JSON Schema projected from Zod. */
+export function isTypeBoxInputSchema(schema: ToolInputSchema): schema is TSchema {
+  return typeof schema === "object" && schema !== null && Kind in schema;
+}
+
 /** Infer execute parameter types from the inputSchema via generic binding. */
 export function tool<TInputSchema extends TSchema>(
   definition: ToolDefinition<TInputSchema>,
 ): ToolDefinition<TInputSchema> {
   return definition;
+}
+
+type ZodToolDefinition<
+  TInputSchema extends ZodTypeAny,
+  TOutputSchema extends ZodTypeAny | undefined = undefined,
+> = Omit<
+  BaseToolDefinition<z.output<TInputSchema>, JsonSchemaObject>,
+  "inputSchema" | "prepareArguments" | "execute"
+> & {
+  inputSchema: TInputSchema;
+  outputSchema?: TOutputSchema;
+  prepareArguments?: (args: unknown) => z.input<TInputSchema>;
+  execute?: (
+    input: z.output<TInputSchema>,
+    options: ToolExecuteOptions,
+  ) =>
+    | Promise<
+        TOutputSchema extends ZodTypeAny ? z.input<TOutputSchema> : unknown
+      >
+    | (TOutputSchema extends ZodTypeAny ? z.input<TOutputSchema> : unknown);
+};
+
+function formatZodPath(path: readonly PropertyKey[]): string {
+  return path.length > 0 ? path.map(String).join(".") : "root";
+}
+
+function formatToolInputError(error: z.ZodError): string {
+  const details = error.issues
+    .slice(0, 5)
+    .map((issue) => `${formatZodPath(issue.path)}: ${issue.message}`)
+    .join("; ");
+  return `Invalid tool arguments: ${details || "input did not match schema"}`;
+}
+
+function parseToolInput<TInputSchema extends ZodTypeAny>(
+  schema: TInputSchema,
+  args: unknown,
+): z.output<TInputSchema> {
+  const result = schema.safeParse(args);
+  if (!result.success) {
+    throw new ToolInputError(formatToolInputError(result.error), {
+      cause: result.error,
+    });
+  }
+  return result.data;
+}
+
+/**
+ * Define a Junior-owned tool with Zod input parsing and JSON Schema parameters.
+ */
+export function zodTool<
+  TInputSchema extends ZodTypeAny,
+  TOutputSchema extends ZodTypeAny | undefined = undefined,
+>(
+  definition: ZodToolDefinition<TInputSchema, TOutputSchema>,
+): AnyToolDefinition {
+  const { inputSchema, outputSchema, prepareArguments, execute, ...toolDef } =
+    definition;
+  let modelInputSchema: JsonSchemaObject;
+  try {
+    modelInputSchema = z.toJSONSchema(inputSchema) as JsonSchemaObject;
+  } catch (error) {
+    throw new TypeError(
+      "zodTool() inputSchema must be representable as JSON Schema.",
+      { cause: error },
+    );
+  }
+  return {
+    ...toolDef,
+    inputSchema: modelInputSchema,
+    prepareArguments(args) {
+      return parseToolInput(
+        inputSchema,
+        prepareArguments ? prepareArguments(args) : args,
+      );
+    },
+    ...(execute
+      ? {
+          async execute(input, options) {
+            const result = await execute(
+              input as z.output<TInputSchema>,
+              options,
+            );
+            return outputSchema ? outputSchema.parse(result) : result;
+          },
+        }
+      : {}),
+  };
 }

--- a/packages/junior/src/chat/tools/execute-tool.ts
+++ b/packages/junior/src/chat/tools/execute-tool.ts
@@ -1,7 +1,10 @@
-import { Type } from "@sinclair/typebox";
+import { Type, type TSchema } from "@sinclair/typebox";
 import { Value } from "@sinclair/typebox/value";
-import type { AnyToolDefinition } from "@/chat/tools/definition";
-import { tool } from "@/chat/tools/definition";
+import {
+  isTypeBoxInputSchema,
+  tool,
+  type AnyToolDefinition,
+} from "@/chat/tools/definition";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 
 export const EXECUTE_TOOL_NAME = "executeTool";
@@ -13,10 +16,10 @@ export interface DeferredToolCall {
 }
 
 function schemaErrorText(
-  definition: AnyToolDefinition,
+  schema: TSchema,
   value: unknown,
 ): string {
-  const firstError = [...Value.Errors(definition.inputSchema, value)][0];
+  const firstError = [...Value.Errors(schema, value)][0];
   if (!firstError) {
     return "invalid arguments";
   }
@@ -98,9 +101,12 @@ export function prepareDeferredToolCall(
   const prepared = call.definition.prepareArguments
     ? call.definition.prepareArguments(call.arguments)
     : call.arguments;
-  if (!Value.Check(call.definition.inputSchema, prepared)) {
+  if (
+    isTypeBoxInputSchema(call.definition.inputSchema) &&
+    !Value.Check(call.definition.inputSchema, prepared)
+  ) {
     throw new ToolInputError(
-      `executeTool arguments do not match schema for ${call.toolName}: ${schemaErrorText(call.definition, prepared)}`,
+      `executeTool arguments do not match schema for ${call.toolName}: ${schemaErrorText(call.definition.inputSchema, prepared)}`,
     );
   }
   if (!prepared || typeof prepared !== "object" || Array.isArray(prepared)) {

--- a/packages/junior/src/chat/tools/resource-events.ts
+++ b/packages/junior/src/chat/tools/resource-events.ts
@@ -1,5 +1,5 @@
-import { Type, type Static } from "@sinclair/typebox";
-import { tool } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 import type { ToolRuntimeContext } from "@/chat/tools/types";
 import {
   cancelResourceEventSubscription,
@@ -10,52 +10,46 @@ import {
 const DEFAULT_TTL_MS = 14 * 24 * 60 * 60 * 1000;
 const MAX_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 
-const subscribeInputSchema = Type.Object(
-  {
-    resourceRef: Type.String({
-      description:
-        "Opaque resource ref copied from a subscribable tool result.",
-    }),
-    provider: Type.String({
-      description: "Provider that owns the resource ref.",
-    }),
-    resourceType: Type.String({
-      description: "Provider-defined resource type from the subscribable hint.",
-    }),
-    label: Type.String({
-      description: "Human-readable resource label from the subscribable hint.",
-    }),
-    events: Type.Array(Type.String(), {
-      description:
-        "High-signal event names to deliver to this conversation when they occur.",
-      minItems: 1,
-    }),
-    intent: Type.String({
-      description:
-        "Concise reason this conversation wants these events, used when an event arrives.",
-    }),
-    ttlMs: Type.Optional(
-      Type.Number({
-        description:
-          "How long to keep the subscription active. Defaults to 14 days and is capped at 30 days.",
-      }),
+const subscribeInputSchema = z.object({
+  resourceRef: z
+    .string()
+    .describe("Opaque resource ref copied from a subscribable tool result."),
+  provider: z.string().describe("Provider that owns the resource ref."),
+  resourceType: z
+    .string()
+    .describe("Provider-defined resource type from the subscribable hint."),
+  label: z
+    .string()
+    .describe("Human-readable resource label from the subscribable hint."),
+  events: z
+    .array(z.string())
+    .min(1)
+    .describe(
+      "High-signal event names to deliver to this conversation when they occur.",
     ),
-  },
-  { additionalProperties: false },
-);
+  intent: z
+    .string()
+    .describe(
+      "Concise reason this conversation wants these events, used when an event arrives.",
+    ),
+  ttlMs: z.coerce
+    .number()
+    .describe(
+      "How long to keep the subscription active. Defaults to 14 days and is capped at 30 days.",
+    )
+    .optional(),
+});
 
-const cancelInputSchema = Type.Object(
-  {
-    subscriptionId: Type.String({
-      description:
-        "Subscription id returned by subscribeToResourceEvents or listResourceEventSubscriptions.",
-    }),
-  },
-  { additionalProperties: false },
-);
+const cancelInputSchema = z.object({
+  subscriptionId: z
+    .string()
+    .describe(
+      "Subscription id returned by subscribeToResourceEvents or listResourceEventSubscriptions.",
+    ),
+});
 
-type SubscribeInput = Static<typeof subscribeInputSchema>;
-type CancelInput = Static<typeof cancelInputSchema>;
+type SubscribeInput = z.output<typeof subscribeInputSchema>;
+type CancelInput = z.output<typeof cancelInputSchema>;
 
 function requireConversationContext(context: ToolRuntimeContext): string {
   if (!context.conversationId) {
@@ -115,7 +109,7 @@ function ttlMs(input: SubscribeInput): number {
 export function createSubscribeToResourceEventsTool(
   context: ToolRuntimeContext,
 ) {
-  return tool({
+  return zodTool({
     description:
       "Subscribe the current conversation to high-signal events for a resource returned by a subscribable tool result. Matching events are queued as normal conversation messages; they do not interrupt active work.",
     inputSchema: subscribeInputSchema,
@@ -153,10 +147,10 @@ export function createSubscribeToResourceEventsTool(
 export function createListResourceEventSubscriptionsTool(
   context: ToolRuntimeContext,
 ) {
-  return tool({
+  return zodTool({
     description:
       "List active resource event subscriptions for the current conversation.",
-    inputSchema: Type.Object({}, { additionalProperties: false }),
+    inputSchema: z.object({}),
     async execute() {
       const conversationId = requireConversationContext(context);
       const subscriptions = await listResourceEventSubscriptions({
@@ -182,7 +176,7 @@ export function createListResourceEventSubscriptionsTool(
 export function createCancelResourceEventSubscriptionTool(
   context: ToolRuntimeContext,
 ) {
-  return tool({
+  return zodTool({
     description:
       "Cancel a resource event subscription for the current conversation.",
     inputSchema: cancelInputSchema,

--- a/packages/junior/src/chat/tools/runtime/report-progress.ts
+++ b/packages/junior/src/chat/tools/runtime/report-progress.ts
@@ -1,16 +1,16 @@
-import { Type } from "@sinclair/typebox";
-import { tool } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 
 /** Create the internal tool the model uses for sparse progress updates. */
 export function createReportProgressTool() {
-  return tool({
+  return zodTool({
     description:
       "Update the user-visible assistant loading message with a short progress phase. For every non-trivial turn, call this early with the initial major work phase, then call it again only when the major phase meaningfully changes. Messages must be written in sentence case with a present-participle verb (e.g. 'Searching docs', 'Reviewing results', 'Running checks'). Skip trivial direct answers, generic filler, and minor substeps.",
-    inputSchema: Type.Object({
-      message: Type.String({
-        minLength: 1,
-        description: "Short user-facing progress message.",
-      }),
+    inputSchema: z.object({
+      message: z
+        .string()
+        .min(1)
+        .describe("Short user-facing progress message."),
     }),
   });
 }

--- a/packages/junior/src/chat/tools/sandbox/bash.ts
+++ b/packages/junior/src/chat/tools/sandbox/bash.ts
@@ -1,27 +1,25 @@
-import { tool } from "@/chat/tools/definition";
-import { Type } from "@sinclair/typebox";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 
 /** Create the sandbox shell tool definition exposed to the agent. */
 export function createBashTool() {
-  return tool({
+  return zodTool({
     description:
       "Run a bash command inside the isolated sandbox workspace. Use this for repository inspection/execution tasks that need shell access. Do not use for network-sensitive or destructive actions unless explicitly required.",
-    inputSchema: Type.Object(
-      {
-        command: Type.String({
-          minLength: 1,
-          description: "Bash command to run inside the sandbox.",
-        }),
-        timeoutMs: Type.Optional(
-          Type.Integer({
-            minimum: 1000,
-            description:
-              "Optional command timeout in milliseconds. Use for commands that may hang.",
-          }),
-        ),
-      },
-      { additionalProperties: false },
-    ),
+    inputSchema: z.object({
+      command: z
+        .string()
+        .min(1)
+        .describe("Bash command to run inside the sandbox."),
+      timeoutMs: z.coerce
+        .number()
+        .int()
+        .min(1000)
+        .describe(
+          "Optional command timeout in milliseconds. Use for commands that may hang.",
+        )
+        .optional(),
+    }),
     // Bash is sequential so sandbox egress auth signals stay command-scoped.
     executionMode: "sequential",
     execute: async () => {

--- a/packages/junior/src/chat/tools/sandbox/edit-file.ts
+++ b/packages/junior/src/chat/tools/sandbox/edit-file.ts
@@ -14,8 +14,8 @@ import {
   validateAndApplyTextEdits,
   type TextReplacement,
 } from "@/chat/tools/sandbox/text-edits";
-import { Type } from "@sinclair/typebox";
-import { tool } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 
 type EditReplacement = TextReplacement;
 
@@ -90,41 +90,35 @@ export async function editFile(params: {
   };
 }
 
-const editReplacementSchema = Type.Object(
-  {
-    oldText: Type.String({
-      minLength: 1,
-      description:
-        "Exact text to replace. It must be unique in the original file and must not overlap another edit.",
-    }),
-    newText: Type.String({
-      description: "Replacement text for this edit.",
-    }),
-  },
-  { additionalProperties: false },
-);
+const editReplacementSchema = z.object({
+  oldText: z
+    .string()
+    .min(1)
+    .describe(
+      "Exact text to replace. It must be unique in the original file and must not overlap another edit.",
+    ),
+  newText: z.string().describe("Replacement text for this edit."),
+});
 
 /** Create the sandbox edit tool definition exposed to the agent. */
 export function createEditFileTool() {
-  return tool({
+  return zodTool({
     description:
       "Edit one sandbox workspace file with exact text replacements. Use for precise changes to existing files; prefer this over writeFile for targeted changes. Each oldText must match exactly, be unique, and not overlap another edit. Returns a diff. Multiple changes to the same file: use one edits[] call.",
     prepareArguments: prepareEditFileArguments,
     executionMode: "sequential",
-    inputSchema: Type.Object(
-      {
-        path: Type.String({
-          minLength: 1,
-          description: "Path to edit in the sandbox workspace.",
-        }),
-        edits: Type.Array(editReplacementSchema, {
-          minItems: 1,
-          description:
-            "Exact replacements matched against the original file, not incrementally.",
-        }),
-      },
-      { additionalProperties: false },
-    ),
+    inputSchema: z.object({
+      path: z
+        .string()
+        .min(1)
+        .describe("Path to edit in the sandbox workspace."),
+      edits: z
+        .array(editReplacementSchema)
+        .min(1)
+        .describe(
+          "Exact replacements matched against the original file, not incrementally.",
+        ),
+    }),
     execute: async () => {
       throw new Error(
         "editFile can only run when sandbox execution is enabled.",

--- a/packages/junior/src/chat/tools/sandbox/find-files.ts
+++ b/packages/junior/src/chat/tools/sandbox/find-files.ts
@@ -1,5 +1,4 @@
 import path from "node:path";
-import { Type } from "@sinclair/typebox";
 import {
   MAX_TEXT_CHARS,
   collectFiles,
@@ -10,7 +9,8 @@ import {
   type SandboxFileSystem,
   type TextSearchResultDetails,
 } from "@/chat/tools/sandbox/file-utils";
-import { tool } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 
 const DEFAULT_FIND_LIMIT = 1000;
 
@@ -85,34 +85,31 @@ export async function findFiles(params: {
 
 /** Create the sandbox file discovery tool definition exposed to the agent. */
 export function createFindFilesTool() {
-  return tool({
+  return zodTool({
     description:
       "Find sandbox workspace files by glob pattern. Returns bounded paths relative to the search root and skips dependency/cache directories.",
     annotations: { readOnlyHint: true, destructiveHint: false },
-    inputSchema: Type.Object(
-      {
-        pattern: Type.String({
-          minLength: 1,
-          description:
-            "Glob pattern to match, for example '*.ts', '**/*.json', or 'src/**/*.test.ts'.",
-        }),
-        path: Type.Optional(
-          Type.String({
-            minLength: 1,
-            description:
-              "Directory or file path in the sandbox workspace. Defaults to the workspace root.",
-          }),
+    inputSchema: z.object({
+      pattern: z
+        .string()
+        .min(1)
+        .describe(
+          "Glob pattern to match, for example '*.ts', '**/*.json', or 'src/**/*.test.ts'.",
         ),
-        limit: Type.Optional(
-          Type.Integer({
-            minimum: 1,
-            description:
-              "Maximum number of file paths to return. Defaults to 1000.",
-          }),
-        ),
-      },
-      { additionalProperties: false },
-    ),
+      path: z
+        .string()
+        .min(1)
+        .describe(
+          "Directory or file path in the sandbox workspace. Defaults to the workspace root.",
+        )
+        .optional(),
+      limit: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .describe("Maximum number of file paths to return. Defaults to 1000.")
+        .optional(),
+    }),
     execute: async () => {
       throw new Error(
         "findFiles can only run when sandbox execution is enabled.",

--- a/packages/junior/src/chat/tools/sandbox/grep.ts
+++ b/packages/junior/src/chat/tools/sandbox/grep.ts
@@ -1,5 +1,4 @@
 import path from "node:path";
-import { Type } from "@sinclair/typebox";
 import {
   MAX_TEXT_CHARS,
   collectFiles,
@@ -12,7 +11,8 @@ import {
   type SandboxFileSystem,
   type TextSearchResultDetails,
 } from "@/chat/tools/sandbox/file-utils";
-import { tool } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 
 const DEFAULT_GREP_LIMIT = 100;
@@ -25,6 +25,14 @@ interface GrepResult {
     match_limit_reached?: number;
   };
 }
+
+const booleanInput = (description: string) =>
+  z
+    .preprocess(
+      (value) => (value === "true" ? true : value === "false" ? false : value),
+      z.boolean(),
+    )
+    .describe(description);
 
 function truncateGrepLine(value: string): { line: string; truncated: boolean } {
   if (value.length <= MAX_GREP_LINE_CHARS) {
@@ -201,55 +209,46 @@ export async function grepFiles(params: {
 
 /** Create the sandbox grep tool definition exposed to the agent. */
 export function createGrepTool() {
-  return tool({
+  return zodTool({
     description:
       "Search sandbox workspace file contents. Returns bounded matching lines with file paths and line numbers. Respects path/glob filters and includes truncation notices.",
     annotations: { readOnlyHint: true, destructiveHint: false },
-    inputSchema: Type.Object(
-      {
-        pattern: Type.String({
-          minLength: 1,
-          description: "Regex pattern or literal text to search for.",
-        }),
-        path: Type.Optional(
-          Type.String({
-            minLength: 1,
-            description:
-              "Directory or file path in the sandbox workspace. Defaults to the workspace root.",
-          }),
-        ),
-        glob: Type.Optional(
-          Type.String({
-            minLength: 1,
-            description:
-              "Optional glob filter such as '*.ts' or '**/*.test.ts'.",
-          }),
-        ),
-        ignoreCase: Type.Optional(
-          Type.Boolean({
-            description: "Whether matching should ignore case.",
-          }),
-        ),
-        literal: Type.Optional(
-          Type.Boolean({
-            description: "Treat pattern as literal text instead of regex.",
-          }),
-        ),
-        context: Type.Optional(
-          Type.Integer({
-            minimum: 0,
-            description: "Number of surrounding context lines to include.",
-          }),
-        ),
-        limit: Type.Optional(
-          Type.Integer({
-            minimum: 1,
-            description: "Maximum matches to return. Defaults to 100.",
-          }),
-        ),
-      },
-      { additionalProperties: false },
-    ),
+    inputSchema: z.object({
+      pattern: z
+        .string()
+        .min(1)
+        .describe("Regex pattern or literal text to search for."),
+      path: z
+        .string()
+        .min(1)
+        .describe(
+          "Directory or file path in the sandbox workspace. Defaults to the workspace root.",
+        )
+        .optional(),
+      glob: z
+        .string()
+        .min(1)
+        .describe("Optional glob filter such as '*.ts' or '**/*.test.ts'.")
+        .optional(),
+      ignoreCase: booleanInput(
+        "Whether matching should ignore case.",
+      ).optional(),
+      literal: booleanInput(
+        "Treat pattern as literal text instead of regex.",
+      ).optional(),
+      context: z.coerce
+        .number()
+        .int()
+        .min(0)
+        .describe("Number of surrounding context lines to include.")
+        .optional(),
+      limit: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .describe("Maximum matches to return. Defaults to 100.")
+        .optional(),
+    }),
     execute: async () => {
       throw new Error("grep can only run when sandbox execution is enabled.");
     },

--- a/packages/junior/src/chat/tools/sandbox/list-dir.ts
+++ b/packages/junior/src/chat/tools/sandbox/list-dir.ts
@@ -1,5 +1,4 @@
 import path from "node:path";
-import { Type } from "@sinclair/typebox";
 import {
   MAX_TEXT_CHARS,
   isMissingPathError,
@@ -10,7 +9,8 @@ import {
   type SandboxFileSystem,
   type TextSearchResultDetails,
 } from "@/chat/tools/sandbox/file-utils";
-import { tool } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 
 const DEFAULT_LIST_LIMIT = 500;
@@ -110,28 +110,25 @@ export async function listDir(params: {
 
 /** Create the sandbox directory listing tool definition exposed to the agent. */
 export function createListDirTool() {
-  return tool({
+  return zodTool({
     description:
       "List a sandbox workspace directory. Returns sorted entries with '/' suffixes for directories and bounded truncation notices.",
     annotations: { readOnlyHint: true, destructiveHint: false },
-    inputSchema: Type.Object(
-      {
-        path: Type.Optional(
-          Type.String({
-            minLength: 1,
-            description:
-              "Directory path in the sandbox workspace. Defaults to the workspace root.",
-          }),
-        ),
-        limit: Type.Optional(
-          Type.Integer({
-            minimum: 1,
-            description: "Maximum entries to return. Defaults to 500.",
-          }),
-        ),
-      },
-      { additionalProperties: false },
-    ),
+    inputSchema: z.object({
+      path: z
+        .string()
+        .min(1)
+        .describe(
+          "Directory path in the sandbox workspace. Defaults to the workspace root.",
+        )
+        .optional(),
+      limit: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .describe("Maximum entries to return. Defaults to 500.")
+        .optional(),
+    }),
     execute: async () => {
       throw new Error(
         "listDir can only run when sandbox execution is enabled.",

--- a/packages/junior/src/chat/tools/sandbox/read-file.ts
+++ b/packages/junior/src/chat/tools/sandbox/read-file.ts
@@ -1,9 +1,9 @@
-import { Type } from "@sinclair/typebox";
 import {
   normalizeToLf,
   positiveInteger,
 } from "@/chat/tools/sandbox/file-utils";
-import { tool } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 
 const DEFAULT_READ_LIMIT = 1000;
 
@@ -75,31 +75,28 @@ export function missingFileResult(path: string): TextRangeMissingPathResult {
 
 /** Create the sandbox read tool definition exposed to the agent. */
 export function createReadFileTool() {
-  return tool({
+  return zodTool({
     description:
       "Read a bounded line range from a file in the sandbox workspace. Use when you need exact file contents to verify facts or make edits safely. Prefer grep/findFiles/listDir for broad discovery.",
     annotations: { readOnlyHint: true, destructiveHint: false },
-    inputSchema: Type.Object(
-      {
-        path: Type.String({
-          minLength: 1,
-          description: "Path to the file in the sandbox workspace.",
-        }),
-        offset: Type.Optional(
-          Type.Integer({
-            minimum: 1,
-            description: "1-indexed line number to start reading from.",
-          }),
-        ),
-        limit: Type.Optional(
-          Type.Integer({
-            minimum: 1,
-            description: "Maximum number of lines to read. Defaults to 1000.",
-          }),
-        ),
-      },
-      { additionalProperties: false },
-    ),
+    inputSchema: z.object({
+      path: z
+        .string()
+        .min(1)
+        .describe("Path to the file in the sandbox workspace."),
+      offset: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .describe("1-indexed line number to start reading from.")
+        .optional(),
+      limit: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .describe("Maximum number of lines to read. Defaults to 1000.")
+        .optional(),
+    }),
     execute: async () => {
       throw new Error(
         "readFile can only run when sandbox execution is enabled.",

--- a/packages/junior/src/chat/tools/sandbox/write-file.ts
+++ b/packages/junior/src/chat/tools/sandbox/write-file.ts
@@ -1,24 +1,19 @@
-import { Type } from "@sinclair/typebox";
-import { tool } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 
 /** Create the sandbox full-file write tool definition exposed to the agent. */
 export function createWriteFileTool() {
-  return tool({
+  return zodTool({
     description:
       "Write UTF-8 content to a file in the sandbox workspace. Use for intentional file creation or deliberate full-file replacement after validation; use editFile instead for targeted changes to existing files. Do not use for exploratory analysis-only turns.",
     executionMode: "sequential",
-    inputSchema: Type.Object(
-      {
-        path: Type.String({
-          minLength: 1,
-          description: "Path to write in the sandbox workspace.",
-        }),
-        content: Type.String({
-          description: "UTF-8 file content to write.",
-        }),
-      },
-      { additionalProperties: false },
-    ),
+    inputSchema: z.object({
+      path: z
+        .string()
+        .min(1)
+        .describe("Path to write in the sandbox workspace."),
+      content: z.string().describe("UTF-8 file content to write."),
+    }),
     execute: async () => {
       throw new Error(
         "writeFile can only run when sandbox execution is enabled.",

--- a/packages/junior/src/chat/tools/search-tools.ts
+++ b/packages/junior/src/chat/tools/search-tools.ts
@@ -1,4 +1,4 @@
-import { Type, type TSchema } from "@sinclair/typebox";
+import { Type } from "@sinclair/typebox";
 import type { AnyToolDefinition } from "@/chat/tools/definition";
 import { tool } from "@/chat/tools/definition";
 import { effectiveToolExposure } from "@/chat/tool-exposure";
@@ -15,7 +15,7 @@ function normalize(value: string): string {
     .trim();
 }
 
-function schemaText(schema: TSchema): string {
+function schemaText(schema: unknown): string {
   try {
     return JSON.stringify(schema);
   } catch {

--- a/packages/junior/src/chat/tools/skill/call-mcp-tool.ts
+++ b/packages/junior/src/chat/tools/skill/call-mcp-tool.ts
@@ -1,9 +1,9 @@
-import { Type } from "@sinclair/typebox";
 import { setSpanAttributes } from "@/chat/logging";
 import { McpToolError } from "@/chat/mcp/errors";
 import type { ManagedMcpTool } from "@/chat/mcp/tool-manager";
 import { parseMcpProviderFromToolName } from "@/chat/mcp/tool-name";
-import { tool } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 
 interface CallMcpToolManager {
   activateProvider(provider: string): Promise<boolean>;
@@ -51,24 +51,21 @@ function missingToolMessage(toolName: string, provider: string | undefined) {
 
 /** Create the stable dispatcher for active MCP provider tools. */
 export function createCallMcpToolTool(mcpToolManager: CallMcpToolManager) {
-  return tool({
+  return zodTool({
     description:
       "Call an active MCP tool by exact tool_name. Use searchMcpTools to discover tool names and schemas; copy required provider fields into arguments. Do not call with only tool_name unless the discovered tool has no arguments. Authorization is handled by the runtime when required.",
-    inputSchema: Type.Object(
-      {
-        tool_name: Type.String({
-          minLength: 1,
-          description: "Exact MCP tool_name from searchMcpTools.",
-        }),
-        arguments: Type.Optional(
-          Type.Record(Type.String(), Type.Unknown(), {
-            description:
-              'Arguments matching the disclosed MCP tool schema, for example { "query": "..." } when searchMcpTools shows query is required.',
-          }),
-        ),
-      },
-      { additionalProperties: false },
-    ),
+    inputSchema: z.object({
+      tool_name: z
+        .string()
+        .min(1)
+        .describe("Exact MCP tool_name from searchMcpTools."),
+      arguments: z
+        .record(z.string(), z.unknown())
+        .describe(
+          'Arguments matching the disclosed MCP tool schema, for example { "query": "..." } when searchMcpTools shows query is required.',
+        )
+        .optional(),
+    }),
     execute: async (input, options) => {
       const { tool_name } = input;
       const provider = parseMcpProviderFromToolName(tool_name);

--- a/packages/junior/src/chat/tools/skill/load-skill.ts
+++ b/packages/junior/src/chat/tools/skill/load-skill.ts
@@ -1,5 +1,5 @@
-import { tool } from "@/chat/tools/definition";
-import { Type } from "@sinclair/typebox";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 import { sandboxSkillDir, sandboxSkillFile } from "@/chat/sandbox/paths";
 import {
   loadSkillsByName,
@@ -100,14 +100,14 @@ export function createLoadSkillTool(
     ) => void | LoadSkillMetadata | Promise<void | LoadSkillMetadata>;
   },
 ) {
-  return tool({
+  return zodTool({
     description:
       "Load a skill by name for this turn. The result includes working_directory; resolve skill paths there and run skill-owned bash commands from there or with absolute paths. When the result includes mcp_provider, use searchMcpTools before callMcpTool. Use when a request clearly matches a known skill.",
-    inputSchema: Type.Object({
-      skill_name: Type.String({
-        minLength: 1,
-        description: "Skill name to load, without the leading slash.",
-      }),
+    inputSchema: z.object({
+      skill_name: z
+        .string()
+        .min(1)
+        .describe("Skill name to load, without the leading slash."),
     }),
     execute: async ({ skill_name }) => {
       const result = await loadSkillFromHost(availableSkills, skill_name);

--- a/packages/junior/src/chat/tools/skill/search-mcp-tools.ts
+++ b/packages/junior/src/chat/tools/skill/search-mcp-tools.ts
@@ -1,6 +1,6 @@
-import { Type } from "@sinclair/typebox";
 import type { ManagedMcpToolDescriptor } from "@/chat/mcp/tool-manager";
-import { tool } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 import { toExposedToolSummary } from "@/chat/tools/skill/mcp-tool-summary";
 
 const DEFAULT_MAX_RESULTS = 5;
@@ -185,35 +185,32 @@ function searchProviderCatalog(
 
 /** Create the progressive MCP catalog search tool used before callMcpTool. */
 export function createSearchMcpToolsTool(mcpToolManager: SearchMcpToolManager) {
-  return tool({
+  return zodTool({
     description:
       "List or search MCP providers and active MCP tools. When provider is supplied and not yet active, Junior connects to it on demand and returns tool descriptors including schemas. Without provider, returns active tools plus matching configured providers without connecting. Use when choosing a provider tool or when callMcpTool arguments are unclear.",
-    inputSchema: Type.Object(
-      {
-        query: Type.Optional(
-          Type.String({
-            minLength: 1,
-            description:
-              "Optional search terms describing the MCP tool or arguments needed.",
-          }),
-        ),
-        provider: Type.Optional(
-          Type.String({
-            minLength: 1,
-            description:
-              "Optional provider name to list or search within. If configured but not yet connected, Junior activates it on demand.",
-          }),
-        ),
-        max_results: Type.Optional(
-          Type.Integer({
-            minimum: 1,
-            maximum: MAX_RESULTS,
-            description: "Maximum matching tool descriptors to return.",
-          }),
-        ),
-      },
-      { additionalProperties: false },
-    ),
+    inputSchema: z.object({
+      query: z
+        .string()
+        .min(1)
+        .describe(
+          "Optional search terms describing the MCP tool or arguments needed.",
+        )
+        .optional(),
+      provider: z
+        .string()
+        .min(1)
+        .describe(
+          "Optional provider name to list or search within. If configured but not yet connected, Junior activates it on demand.",
+        )
+        .optional(),
+      max_results: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(MAX_RESULTS)
+        .describe("Maximum matching tool descriptors to return.")
+        .optional(),
+    }),
     execute: async ({ query, provider, max_results }) => {
       if (provider) {
         await mcpToolManager.activateProvider(provider);

--- a/packages/junior/src/chat/tools/system-time.ts
+++ b/packages/junior/src/chat/tools/system-time.ts
@@ -1,12 +1,12 @@
-import { Type } from "@sinclair/typebox";
-import { tool } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 
 export function createSystemTimeTool() {
-  return tool({
+  return zodTool({
     description:
       "Return current system time in UTC and local ISO formats. Use when the user asks for current time/date context. Do not use as a substitute for historical or timezone-conversion research.",
     annotations: { readOnlyHint: true, destructiveHint: false },
-    inputSchema: Type.Object({}),
+    inputSchema: z.object({}),
     execute: async () => {
       const now = new Date();
       return {

--- a/packages/junior/src/chat/tools/web/fetch-tool.ts
+++ b/packages/junior/src/chat/tools/web/fetch-tool.ts
@@ -1,5 +1,5 @@
-import { tool } from "@/chat/tools/definition";
-import { Type } from "@sinclair/typebox";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 import {
   FETCH_TIMEOUT_MS,
   MAX_FETCH_BYTES,
@@ -43,7 +43,7 @@ export function createWebFetchTool(
   options: { canSendFilesToActiveConversation?: boolean } = {},
 ) {
   const override = hooks.toolOverrides?.webFetch;
-  return tool({
+  return zodTool({
     description:
       "Fetch and extract readable content from a specific URL. Use when you need details from a known page or document. Do not use for discovery when search is the first step.",
     annotations: {
@@ -51,19 +51,15 @@ export function createWebFetchTool(
       destructiveHint: false,
       openWorldHint: true,
     },
-    inputSchema: Type.Object({
-      url: Type.String({
-        minLength: 1,
-        description: "HTTP(S) URL to fetch.",
-      }),
-      max_chars: Type.Optional(
-        Type.Integer({
-          minimum: 500,
-          maximum: MAX_FETCH_CHARS,
-          description:
-            "Optional maximum number of extracted characters to return.",
-        }),
-      ),
+    inputSchema: z.object({
+      url: z.string().min(1).describe("HTTP(S) URL to fetch."),
+      max_chars: z.coerce
+        .number()
+        .int()
+        .min(500)
+        .max(MAX_FETCH_CHARS)
+        .describe("Optional maximum number of extracted characters to return.")
+        .optional(),
     }),
     execute: async ({ url, max_chars }) => {
       if (override?.execute) {

--- a/packages/junior/src/chat/tools/web/image-generate.ts
+++ b/packages/junior/src/chat/tools/web/image-generate.ts
@@ -1,5 +1,5 @@
-import { tool } from "@/chat/tools/definition";
-import { Type } from "@sinclair/typebox";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 import type { ImageGenerateToolDeps, ToolHooks } from "@/chat/tools/types";
 import { botConfig } from "@/chat/config";
 import {
@@ -83,15 +83,11 @@ export function createImageGenerateTool(
   options: { canSendFilesToActiveConversation?: boolean } = {},
   deps: ImageGenerateToolDeps = {},
 ) {
-  return tool({
+  return zodTool({
     description:
       "Generate images from a prompt. Use when the user wants to visually show or represent something — feelings, concepts, art, humor, or any visual idea. Also use for explicit image creation requests.",
-    inputSchema: Type.Object({
-      prompt: Type.String({
-        minLength: 1,
-        maxLength: 4000,
-        description: "Image generation prompt.",
-      }),
+    inputSchema: z.object({
+      prompt: z.string().min(1).max(4000).describe("Image generation prompt."),
     }),
     execute: async ({ prompt }) => {
       const fetchImpl = deps.fetch ?? fetch;

--- a/packages/junior/src/chat/tools/web/search.ts
+++ b/packages/junior/src/chat/tools/web/search.ts
@@ -1,8 +1,8 @@
-import { tool } from "@/chat/tools/definition";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
 import { generateText } from "ai";
 import { createGatewayProvider } from "@ai-sdk/gateway";
 import { getModel } from "@earendil-works/pi-ai";
-import { Type } from "@sinclair/typebox";
 import { withTimeout } from "@/chat/tools/web/network";
 import { logException } from "@/chat/logging";
 import type { WebSearchToolDeps } from "@/chat/tools/types";
@@ -75,7 +75,7 @@ function isAuthFailure(message: string): boolean {
 }
 
 export function createWebSearchTool(override?: WebSearchToolDeps) {
-  return tool({
+  return zodTool({
     description:
       "Search public web sources and return top snippets/URLs. Use when you need discovery or source candidates. Do not use when the user already provided a specific URL to inspect.",
     annotations: {
@@ -83,19 +83,15 @@ export function createWebSearchTool(override?: WebSearchToolDeps) {
       destructiveHint: false,
       openWorldHint: true,
     },
-    inputSchema: Type.Object({
-      query: Type.String({
-        minLength: 1,
-        maxLength: 500,
-        description: "Search query.",
-      }),
-      max_results: Type.Optional(
-        Type.Integer({
-          minimum: 1,
-          maximum: MAX_RESULTS,
-          description: "Max results to return.",
-        }),
-      ),
+    inputSchema: z.object({
+      query: z.string().min(1).max(500).describe("Search query."),
+      max_results: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(MAX_RESULTS)
+        .describe("Max results to return.")
+        .optional(),
     }),
     execute: async ({ query, max_results }) => {
       if (override?.execute) {

--- a/packages/junior/tests/integration/deferred-tools.test.ts
+++ b/packages/junior/tests/integration/deferred-tools.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createLocalSource,
+  definePluginTool,
   defineJuniorPlugin,
 } from "@sentry/junior-plugin-api";
+import { z } from "zod";
 import { Type } from "@sinclair/typebox";
 import { setPlugins } from "@/chat/plugins/agent-hooks";
 import { SkillSandbox } from "@/chat/sandbox/skill-sandbox";
@@ -140,6 +142,62 @@ describe("deferred tools", () => {
         arguments: {},
       }),
     ).rejects.toThrow("arguments do not match schema");
+  });
+
+  it("executes deferred plugin tools with Zod input parsing", async () => {
+    setPlugins([
+      defineJuniorPlugin({
+        manifest: {
+          name: "agent-demo",
+          displayName: "Agent Demo",
+          description: "Agent demo",
+        },
+        hooks: {
+          tools() {
+            return {
+              summarizeAccount: definePluginTool({
+                description: "Summarize account risk.",
+                inputSchema: z.object({
+                  account_id: z.string().min(1),
+                  include_notes: z.coerce.boolean().default(false),
+                }),
+                execute: async ({ account_id, include_notes }) => ({
+                  account_id,
+                  include_notes,
+                  status: "reviewed",
+                }),
+              }),
+            };
+          },
+        },
+      }),
+    ]);
+
+    const tools = createAgentTools(
+      createTools([], {}, runtimeContext()),
+      new SkillSandbox([], []),
+      {},
+    );
+
+    const executeResult = await agentTool(tools, "executeTool").execute(
+      "tool-execute-zod",
+      {
+        tool_name: "agentDemo_summarizeAccount",
+        arguments: { account_id: "A123", include_notes: "true" },
+      },
+    );
+
+    expect(executeResult.details).toEqual({
+      account_id: "A123",
+      include_notes: true,
+      status: "reviewed",
+    });
+    await expect(
+      agentTool(tools, "executeTool").execute("tool-invalid-zod", {
+        tool_name: "agentDemo_summarizeAccount",
+        arguments: { account_id: "" },
+      }),
+    ).rejects.toThrow("Invalid tool arguments");
   });
 
   it("does not let executeTool call direct, hidden, or unknown tools", async () => {

--- a/packages/junior/tests/integration/slack-channel-tools.test.ts
+++ b/packages/junior/tests/integration/slack-channel-tools.test.ts
@@ -348,6 +348,35 @@ describe("slack channel tools", () => {
     });
   });
 
+  it("normalizes numeric channel history timestamps before calling Slack", async () => {
+    queueSlackApiResponse("conversations.history", {
+      body: conversationsHistoryPage({
+        messages: [{ ts: "1700000000.300000", text: "hello", user: "U1" }],
+      }),
+    });
+    const tool = createSlackChannelListMessagesTool(
+      createContext("list channel messages"),
+    );
+
+    const result = await executeTool(tool, {
+      oldest: 1690000000.123456,
+      latest: 1710000000.654321,
+    });
+
+    expect(result.details).toMatchObject({
+      ok: true,
+      channel_id: "C123",
+      count: 1,
+    });
+    expect(
+      getCapturedSlackApiCalls("conversations.history")[0]?.params,
+    ).toMatchObject({
+      channel: "C123",
+      oldest: "1690000000.123456",
+      latest: "1710000000.654321",
+    });
+  });
+
   it("rejects invalid channel history timestamps before calling Slack", async () => {
     const tool = createSlackChannelListMessagesTool(
       createContext("list channel messages"),

--- a/packages/junior/tests/integration/slack-schedule-tools.test.ts
+++ b/packages/junior/tests/integration/slack-schedule-tools.test.ts
@@ -1,7 +1,5 @@
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { TSchema } from "@sinclair/typebox";
-import { Value } from "@sinclair/typebox/value";
 import { createSlackSource } from "@sentry/junior-plugin-api";
 import {
   PluginToolInputError,
@@ -165,34 +163,35 @@ describe("Slack schedule tools", () => {
       properties?: Record<
         string,
         {
-          anyOf?: Array<{ const?: unknown }>;
+          enum?: unknown[];
           oneOf?: Array<{ const?: unknown }>;
         }
       >;
       required?: string[];
     };
     const scheduleKind = schema.properties?.schedule_kind;
-    const options = (scheduleKind?.anyOf ?? scheduleKind?.oneOf ?? [])
-      .map((option) => option.const)
-      .sort();
+    const options = (scheduleKind?.enum ??
+      scheduleKind?.oneOf?.map((option) => option.const) ??
+      []) as unknown[];
 
     expect(schema.required).toContain("schedule_kind");
-    expect(options).toEqual(["one_off", "recurring"]);
+    expect([...options].sort()).toEqual(["one_off", "recurring"]);
   });
 
   it("accepts null recurrence in the create schema", async () => {
-    const schema = createSlackScheduleCreateTaskTool(createContext())
-      .inputSchema as TSchema;
+    const tool = createSlackScheduleCreateTaskTool(createContext());
 
     expect(
-      Value.Check(schema, {
+      tool.prepareArguments?.({
         task: "Remind Greg to drink water.",
         schedule: "In 1 minute",
         schedule_kind: "one_off",
         next_run_at: "2026-05-28T02:18:48.005Z",
         recurrence: null,
       }),
-    ).toBe(true);
+    ).toMatchObject({
+      recurrence: null,
+    });
   });
 
   it("creates and lists tasks only for the active Slack conversation", async () => {
@@ -743,13 +742,14 @@ describe("Slack schedule tools", () => {
     const created = (await createTask(context)) as {
       task: { id: string };
     };
+    const updateTool = createSlackScheduleUpdateTaskTool(context);
 
     await expect(
-      executeTool(createSlackScheduleUpdateTaskTool(context), {
+      executeTool(updateTool, {
         task_id: created.task.id,
         schedule: "Every hour",
         recurrence: "hourly",
-      }),
+      } as unknown as Parameters<NonNullable<typeof updateTool.execute>>[0]),
     ).rejects.toThrow(
       "Recurring scheduled tasks can run at most once per day.",
     );

--- a/packages/junior/tests/unit/plugins/define-plugin-tool.test.ts
+++ b/packages/junior/tests/unit/plugins/define-plugin-tool.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  definePluginTool,
+  PluginToolInputError,
+} from "@sentry/junior-plugin-api";
+import { z } from "zod";
+
+describe("definePluginTool", () => {
+  it("projects Zod input schemas to JSON Schema and parses tool arguments", async () => {
+    const execute = vi.fn(async (input: { count: number }) => input.count);
+    const tool = definePluginTool({
+      description: "Count things.",
+      inputSchema: z.object({
+        count: z.coerce.number().int(),
+      }),
+      execute,
+    });
+
+    expect(tool.inputSchema).toMatchObject({
+      properties: {
+        count: { type: "integer" },
+      },
+      required: ["count"],
+      type: "object",
+    });
+
+    const parsed = tool.prepareArguments?.({ count: "3" });
+    expect(parsed).toEqual({ count: 3 });
+
+    await tool.execute?.(parsed as { count: number }, {});
+    expect(execute).toHaveBeenCalledWith({ count: 3 }, {});
+  });
+
+  it("runs custom argument preparation before Zod parsing", () => {
+    const tool = definePluginTool({
+      description: "Normalize names.",
+      inputSchema: z.object({
+        name: z.string().min(1),
+      }),
+      prepareArguments(args) {
+        return {
+          name: (args as { rawName: string }).rawName.trim(),
+        };
+      },
+      execute: async () => ({ ok: true }),
+    });
+
+    expect(tool.prepareArguments?.({ rawName: " Ada " })).toEqual({
+      name: "Ada",
+    });
+    expect(() => tool.prepareArguments?.({ rawName: " " })).toThrow(
+      PluginToolInputError,
+    );
+    expect(() => tool.prepareArguments?.({ rawName: " " })).toThrow(
+      "Invalid tool arguments: name:",
+    );
+  });
+
+  it("rejects parser schemas that cannot be represented as JSON Schema", () => {
+    expect(() =>
+      definePluginTool({
+        description: "Transform input.",
+        inputSchema: z.object({
+          value: z.string().transform((value) => value.trim()),
+        }),
+        execute: async () => ({ ok: true }),
+      }),
+    ).toThrow(
+      "definePluginTool() inputSchema must be representable as JSON Schema.",
+    );
+  });
+});

--- a/packages/junior/tests/unit/tools/sandbox/file-tools.test.ts
+++ b/packages/junior/tests/unit/tools/sandbox/file-tools.test.ts
@@ -6,7 +6,7 @@ import {
   prepareEditFileArguments,
 } from "@/chat/tools/sandbox/edit-file";
 import { findFiles } from "@/chat/tools/sandbox/find-files";
-import { grepFiles } from "@/chat/tools/sandbox/grep";
+import { createGrepTool, grepFiles } from "@/chat/tools/sandbox/grep";
 import { listDir } from "@/chat/tools/sandbox/list-dir";
 import { sliceFileContent } from "@/chat/tools/sandbox/read-file";
 import type { SandboxFileSystem } from "@/chat/tools/sandbox/file-utils";
@@ -176,6 +176,21 @@ describe("sandbox file tools", () => {
         },
       ],
       details: { ok: true, path: "src", truncated: false },
+    });
+  });
+
+  it("prepares grep string booleans like the previous TypeBox schema", () => {
+    const tool = createGrepTool();
+
+    expect(
+      tool.prepareArguments?.({
+        pattern: "hello",
+        ignoreCase: "false",
+        literal: "true",
+      }),
+    ).toMatchObject({
+      ignoreCase: false,
+      literal: true,
     });
   });
 

--- a/packages/junior/tests/unit/tools/zod-tool.test.ts
+++ b/packages/junior/tests/unit/tools/zod-tool.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { zodTool } from "@/chat/tools/definition";
+import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
+
+describe("zodTool", () => {
+  it("projects Zod input schemas to JSON Schema and parses tool arguments", async () => {
+    const execute = vi.fn(async (input: { count: number }) => input.count);
+    const tool = zodTool({
+      description: "Count things.",
+      inputSchema: z.object({
+        count: z.coerce.number().int(),
+      }),
+      execute,
+    });
+
+    expect(tool.inputSchema).toMatchObject({
+      properties: {
+        count: { type: "integer" },
+      },
+      required: ["count"],
+      type: "object",
+    });
+
+    const parsed = tool.prepareArguments!({ count: "3" });
+    expect(parsed).toEqual({ count: 3 });
+
+    await tool.execute?.(parsed, {});
+    expect(execute).toHaveBeenCalledWith({ count: 3 }, {});
+  });
+
+  it("converts input parse failures into ToolInputError", () => {
+    const tool = zodTool({
+      description: "Count things.",
+      inputSchema: z.object({
+        count: z.coerce.number().int(),
+      }),
+      execute: async () => ({ ok: true }),
+    });
+
+    expect(() => tool.prepareArguments?.({ count: "nope" })).toThrow(
+      ToolInputError,
+    );
+    expect(() => tool.prepareArguments?.({ count: "nope" })).toThrow(
+      "Invalid tool arguments: count:",
+    );
+  });
+
+  it("runs custom argument preparation before Zod parsing", () => {
+    const tool = zodTool({
+      description: "Normalize names.",
+      inputSchema: z.object({
+        name: z.string().min(1),
+      }),
+      prepareArguments(args) {
+        return {
+          name: (args as { rawName: string }).rawName.trim(),
+        };
+      },
+      execute: async () => ({ ok: true }),
+    });
+
+    expect(tool.prepareArguments?.({ rawName: " Ada " })).toEqual({
+      name: "Ada",
+    });
+    expect(() => tool.prepareArguments?.({ rawName: " " })).toThrow(
+      ToolInputError,
+    );
+  });
+
+  it("validates declared output without classifying failures as tool input errors", async () => {
+    const tool = zodTool({
+      description: "Return result.",
+      inputSchema: z.object({ value: z.string() }),
+      outputSchema: z.object({ ok: z.literal(true) }),
+      execute: async () => ({ ok: false }) as never,
+    });
+
+    const parsed = tool.prepareArguments!({ value: "test" });
+    await expect(tool.execute?.(parsed, {})).rejects.not.toThrow(
+      ToolInputError,
+    );
+  });
+
+  it("rejects parser schemas that cannot be represented as JSON Schema", () => {
+    expect(() =>
+      zodTool({
+        description: "Transform input.",
+        inputSchema: z.object({
+          value: z.string().transform((value) => value.trim()),
+        }),
+        execute: async () => ({ ok: true }),
+      }),
+    ).toThrow("zodTool() inputSchema must be representable as JSON Schema.");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -511,9 +511,6 @@ importers:
       "@sentry/junior-plugin-api":
         specifier: workspace:*
         version: link:../junior-plugin-api
-      "@sinclair/typebox":
-        specifier: ^0.34.49
-        version: 0.34.49
       drizzle-orm:
         specifier: "catalog:"
         version: 0.45.2(@neondatabase/serverless@1.1.0)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.21.0)(sql.js@1.14.1)
@@ -15000,7 +14997,6 @@ snapshots:
   "@sentry/junior-scheduler@file:packages/junior-scheduler":
     dependencies:
       "@sentry/junior-plugin-api": file:packages/junior-plugin-api
-      "@sinclair/typebox": 0.34.49
       drizzle-orm: 0.45.2
       zod: 4.4.3
     transitivePeerDependencies:
@@ -15037,7 +15033,6 @@ snapshots:
   "@sentry/junior-scheduler@file:packages/junior-scheduler(@neondatabase/serverless@1.1.0)(@types/pg@8.15.6)(pg@8.21.0)":
     dependencies:
       "@sentry/junior-plugin-api": file:packages/junior-plugin-api
-      "@sinclair/typebox": 0.34.49
       drizzle-orm: 0.45.2(@neondatabase/serverless@1.1.0)(@types/pg@8.15.6)(pg@8.21.0)
       zod: 4.4.3
     transitivePeerDependencies:


### PR DESCRIPTION
Junior-owned and plugin-owned tools can now be authored with Zod while Pi still receives JSON Schema-compatible parameters. The internal `zodTool` adapter owns Zod-to-JSON-Schema projection, argument parsing, and `ToolInputError` conversion; the public `definePluginTool` helper gives plugin tools the same parser boundary with `PluginToolInputError`.

This migrates the owned Slack, sandbox, web, skill, advisor, resource-event, and scheduler tools onto the adapter while keeping the legacy TypeBox `tool()` path available for compatibility and leaving provider-owned MCP schemas unchanged. Review the adapter/helper contracts first; most tool file changes are schema-authoring migrations.