### PR TITLE
ref(chat): Track excluded tool exposure

### DIFF
--- a/packages/junior/src/chat/tool-exposure.ts
+++ b/packages/junior/src/chat/tool-exposure.ts
@@ -3,6 +3,7 @@ import type { AnyToolDefinition, ToolExposure } from "@/chat/tools/definition";
 export interface PlannedToolExposure {
   deferredTools: Record<string, AnyToolDefinition>;
   directTools: Record<string, AnyToolDefinition>;
+  excludedTools: Record<string, AnyToolDefinition>;
 }
 
 /** Return the runtime exposure for a tool, preserving direct compatibility. */
@@ -12,12 +13,13 @@ export function effectiveToolExposure(
   return definition.exposure ?? "direct";
 }
 
-/** Split complete tool definitions into native-visible and deferred groups. */
+/** Plan which tools are native-visible, deferred through search, or withheld. */
 export function planToolExposure(
   tools: Record<string, AnyToolDefinition>,
 ): PlannedToolExposure {
   const directTools: Record<string, AnyToolDefinition> = {};
   const deferredTools: Record<string, AnyToolDefinition> = {};
+  const excludedTools: Record<string, AnyToolDefinition> = {};
 
   for (const [name, definition] of Object.entries(tools)) {
     switch (effectiveToolExposure(definition)) {
@@ -28,11 +30,11 @@ export function planToolExposure(
         deferredTools[name] = definition;
         break;
       case "modelOnly":
-        break;
       case "hidden":
+        excludedTools[name] = definition;
         break;
     }
   }
 
-  return { directTools, deferredTools };
+  return { directTools, deferredTools, excludedTools };
 }

--- a/packages/junior/tests/unit/tools/tool-exposure.test.ts
+++ b/packages/junior/tests/unit/tools/tool-exposure.test.ts
@@ -1,0 +1,55 @@
+import { Type } from "@sinclair/typebox";
+import { describe, expect, it } from "vitest";
+import { planToolExposure } from "@/chat/tool-exposure";
+import { tool } from "@/chat/tools/definition";
+
+describe("planToolExposure", () => {
+  it("separates direct, deferred, and excluded tools", () => {
+    const directDefault = tool({
+      description: "Direct by default",
+      inputSchema: Type.Object({}),
+    });
+    const directExplicit = tool({
+      description: "Direct explicitly",
+      exposure: "direct",
+      inputSchema: Type.Object({}),
+    });
+    const deferred = tool({
+      description: "Deferred",
+      exposure: "deferred",
+      inputSchema: Type.Object({}),
+    });
+    const modelOnly = tool({
+      description: "Reserved model-only exposure",
+      exposure: "modelOnly",
+      inputSchema: Type.Object({}),
+    });
+    const hidden = tool({
+      description: "Hidden",
+      exposure: "hidden",
+      inputSchema: Type.Object({}),
+    });
+
+    expect(
+      planToolExposure({
+        deferred,
+        directDefault,
+        directExplicit,
+        hidden,
+        modelOnly,
+      }),
+    ).toEqual({
+      directTools: {
+        directDefault,
+        directExplicit,
+      },
+      deferredTools: {
+        deferred,
+      },
+      excludedTools: {
+        hidden,
+        modelOnly,
+      },
+    });
+  });
+});


### PR DESCRIPTION
Tool exposure planning now returns an explicit withheld bucket alongside direct and deferred tools. That keeps hidden and reserved model-only definitions out of both native model tools and deferred search metadata while making the planner contract visible to callers.

The focused planner test covers default direct exposure, explicit direct exposure, deferred tools, hidden tools, and reserved model-only tools.