### PR TITLE
ref(tools): Move zod tool adapter to support

### DIFF
--- a/openspec/changes/zod-tool-schema-adapter/tasks.md
+++ b/openspec/changes/zod-tool-schema-adapter/tasks.md
@@ -3,7 +3,7 @@
 ## 1. Tool Schema Adapter
 
 - [x] Add a JSON Schema-compatible internal tool schema type.
-- [x] Add `zodTool(...)` beside the existing TypeBox `tool(...)` helper.
+- [x] Add `zodTool(...)` in the internal tool-support layer.
 - [x] Convert Zod schemas to model-facing JSON Schema in the helper.
 - [x] Parse `prepareArguments` with Zod and convert `ZodError` to
       `ToolInputError` with concise model-actionable messages.

--- a/packages/junior/src/chat/slack/tools/canvas/create.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/create.ts
@@ -4,7 +4,7 @@ import { createCanvas } from "@/chat/slack/tools/canvas/api";
 import { mergeRecentCanvases } from "@/chat/slack/tools/canvas/context";
 import type { SlackToolContext } from "@/chat/slack/tools/context";
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 import { createOperationKey } from "@/chat/tools/idempotency";
 import type { ToolState } from "@/chat/tools/types";
 

--- a/packages/junior/src/chat/slack/tools/canvas/edit.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/edit.ts
@@ -6,7 +6,7 @@ import {
 } from "@/chat/slack/tools/canvas/api";
 import { resolveCanvasTarget } from "@/chat/slack/tools/canvas/context";
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 import { createOperationKey } from "@/chat/tools/idempotency";
 import { normalizeToLf } from "@/chat/tools/sandbox/file-utils";
 import {

--- a/packages/junior/src/chat/slack/tools/canvas/read.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/read.ts
@@ -2,7 +2,7 @@ import { logWarn } from "@/chat/logging";
 import { readCanvas } from "@/chat/slack/tools/canvas/api";
 import { resolveCanvasTarget } from "@/chat/slack/tools/canvas/context";
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 import { normalizeToLf } from "@/chat/tools/sandbox/file-utils";
 import { sliceFileContent } from "@/chat/tools/sandbox/read-file";
 

--- a/packages/junior/src/chat/slack/tools/canvas/write.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/write.ts
@@ -5,7 +5,7 @@ import {
   storedCanvasUrl,
 } from "@/chat/slack/tools/canvas/context";
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 import { createOperationKey } from "@/chat/tools/idempotency";
 import type { ToolState } from "@/chat/tools/types";
 

--- a/packages/junior/src/chat/slack/tools/channel-list-messages.ts
+++ b/packages/junior/src/chat/slack/tools/channel-list-messages.ts
@@ -8,7 +8,7 @@ import {
   parseSlackTimestampParam,
 } from "@/chat/slack/timestamp-param";
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 import type { SlackToolContext } from "@/chat/slack/tools/context";
 

--- a/packages/junior/src/chat/slack/tools/list/add-items.ts
+++ b/packages/junior/src/chat/slack/tools/list/add-items.ts
@@ -4,7 +4,7 @@ import {
   slackUserIdParam,
 } from "@/chat/slack/id-param";
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 import { createOperationKey } from "@/chat/tools/idempotency";
 import type { ToolState } from "@/chat/tools/types";

--- a/packages/junior/src/chat/slack/tools/list/create.ts
+++ b/packages/junior/src/chat/slack/tools/list/create.ts
@@ -1,6 +1,6 @@
 import { createTodoList } from "@/chat/slack/tools/list/api";
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 import { createOperationKey } from "@/chat/tools/idempotency";
 import type { ToolState } from "@/chat/tools/types";
 

--- a/packages/junior/src/chat/slack/tools/list/get-items.ts
+++ b/packages/junior/src/chat/slack/tools/list/get-items.ts
@@ -1,6 +1,6 @@
 import { listItems } from "@/chat/slack/tools/list/api";
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 import type { ToolState } from "@/chat/tools/types";
 
 /** Create a tool that reads items from the active Slack list. */

--- a/packages/junior/src/chat/slack/tools/list/update-item.ts
+++ b/packages/junior/src/chat/slack/tools/list/update-item.ts
@@ -1,6 +1,6 @@
 import { updateListItem } from "@/chat/slack/tools/list/api";
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 import { createOperationKey } from "@/chat/tools/idempotency";
 import type { ToolState } from "@/chat/tools/types";
 

--- a/packages/junior/src/chat/slack/tools/message-add-reaction.ts
+++ b/packages/junior/src/chat/slack/tools/message-add-reaction.ts
@@ -1,7 +1,7 @@
 import { normalizeSlackEmojiName } from "@/chat/slack/emoji";
 import { addReactionToMessage } from "@/chat/slack/outbound";
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 import { createOperationKey } from "@/chat/tools/idempotency";
 import type { SlackToolContext } from "@/chat/slack/tools/context";

--- a/packages/junior/src/chat/slack/tools/send-message.ts
+++ b/packages/junior/src/chat/slack/tools/send-message.ts
@@ -5,7 +5,7 @@ import {
 } from "@/chat/slack/outbound";
 import type { SlackToolContext } from "@/chat/slack/tools/context";
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 import { createOperationKey } from "@/chat/tools/idempotency";
 import type { SandboxFileUpload } from "@/chat/tools/sandbox/file-uploads";

--- a/packages/junior/src/chat/slack/tools/thread-read.ts
+++ b/packages/junior/src/chat/slack/tools/thread-read.ts
@@ -9,7 +9,7 @@ import {
   slackChannelIdParam,
 } from "@/chat/slack/id-param";
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 import { parseSlackMessageReference } from "@/chat/slack/tools/slack-message-url";
 import type { SlackToolContext } from "@/chat/slack/tools/context";
 import {

--- a/packages/junior/src/chat/slack/tools/user-lookup.ts
+++ b/packages/junior/src/chat/slack/tools/user-lookup.ts
@@ -9,7 +9,7 @@ import {
   slackUserIdParam,
 } from "@/chat/slack/id-param";
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 
 const booleanInput = (description: string) =>
   z

--- a/packages/junior/src/chat/tool-support/zod-tool.ts
+++ b/packages/junior/src/chat/tool-support/zod-tool.ts
@@ -1,0 +1,101 @@
+import { z, type ZodTypeAny } from "zod";
+import type {
+  AnyToolDefinition,
+  JsonSchemaObject,
+  ToolExecuteOptions,
+} from "@/chat/tools/definition";
+import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
+
+type ZodToolDefinition<
+  TInputSchema extends ZodTypeAny,
+  TOutputSchema extends ZodTypeAny | undefined = undefined,
+> = Pick<
+  AnyToolDefinition,
+  | "identity"
+  | "description"
+  | "exposure"
+  | "annotations"
+  | "promptSnippet"
+  | "promptGuidelines"
+  | "executionMode"
+> & {
+  inputSchema: TInputSchema;
+  outputSchema?: TOutputSchema;
+  prepareArguments?: (args: unknown) => z.input<TInputSchema>;
+  execute?: (
+    input: z.output<TInputSchema>,
+    options: ToolExecuteOptions,
+  ) =>
+    | Promise<
+        TOutputSchema extends ZodTypeAny ? z.input<TOutputSchema> : unknown
+      >
+    | (TOutputSchema extends ZodTypeAny ? z.input<TOutputSchema> : unknown);
+};
+
+function formatZodPath(path: readonly PropertyKey[]): string {
+  return path.length > 0 ? path.map(String).join(".") : "root";
+}
+
+function formatToolInputError(error: z.ZodError): string {
+  const details = error.issues
+    .slice(0, 5)
+    .map((issue) => `${formatZodPath(issue.path)}: ${issue.message}`)
+    .join("; ");
+  return `Invalid tool arguments: ${details || "input did not match schema"}`;
+}
+
+function parseToolInput<TInputSchema extends ZodTypeAny>(
+  schema: TInputSchema,
+  args: unknown,
+): z.output<TInputSchema> {
+  const result = schema.safeParse(args);
+  if (!result.success) {
+    throw new ToolInputError(formatToolInputError(result.error), {
+      cause: result.error,
+    });
+  }
+  return result.data;
+}
+
+/**
+ * Define a Junior-owned tool with Zod input parsing and JSON Schema parameters.
+ */
+export function zodTool<
+  TInputSchema extends ZodTypeAny,
+  TOutputSchema extends ZodTypeAny | undefined = undefined,
+>(
+  definition: ZodToolDefinition<TInputSchema, TOutputSchema>,
+): AnyToolDefinition {
+  const { inputSchema, outputSchema, prepareArguments, execute, ...toolDef } =
+    definition;
+  let modelInputSchema: JsonSchemaObject;
+  try {
+    modelInputSchema = z.toJSONSchema(inputSchema) as JsonSchemaObject;
+  } catch (error) {
+    throw new TypeError(
+      "zodTool() inputSchema must be representable as JSON Schema.",
+      { cause: error },
+    );
+  }
+  return {
+    ...toolDef,
+    inputSchema: modelInputSchema,
+    prepareArguments(args) {
+      return parseToolInput(
+        inputSchema,
+        prepareArguments ? prepareArguments(args) : args,
+      );
+    },
+    ...(execute
+      ? {
+          async execute(input, options) {
+            const result = await execute(
+              input as z.output<TInputSchema>,
+              options,
+            );
+            return outputSchema ? outputSchema.parse(result) : result;
+          },
+        }
+      : {}),
+  };
+}

--- a/packages/junior/src/chat/tools/advisor/tool.ts
+++ b/packages/junior/src/chat/tools/advisor/tool.ts
@@ -36,8 +36,9 @@ import {
   recordSubagentEnded,
   recordSubagentStarted,
 } from "@/chat/state/session-log";
+import { zodTool } from "@/chat/tool-support/zod-tool";
+import type { AnyToolDefinition } from "@/chat/tools/definition";
 import { z } from "zod";
-import { zodTool, type AnyToolDefinition } from "@/chat/tools/definition";
 import { escapeXml } from "@/chat/xml";
 
 export type AdvisorErrorCode =

--- a/packages/junior/src/chat/tools/definition.ts
+++ b/packages/junior/src/chat/tools/definition.ts
@@ -1,14 +1,10 @@
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import { Kind, type Static, type TSchema } from "@sinclair/typebox";
 import type { ToolExecutionMode } from "@earendil-works/pi-agent-core";
-import { z, type ZodTypeAny } from "zod";
 import type { ConversationPrivacy } from "@/chat/conversation-privacy";
-import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 
 /**
- * Tool definition boundary for Pi-facing agent tools. `tool()` keeps the
- * legacy TypeBox path, while `zodTool()` projects Zod schemas to JSON Schema
- * and owns model-input parse errors before execution.
+ * Tool definition boundary for Pi-facing agent tools.
  */
 export interface JsonSchemaObject {
   [key: string]: unknown;
@@ -94,7 +90,9 @@ export interface AnyToolDefinition {
 }
 
 /** Distinguish legacy TypeBox schemas from JSON Schema projected from Zod. */
-export function isTypeBoxInputSchema(schema: ToolInputSchema): schema is TSchema {
+export function isTypeBoxInputSchema(
+  schema: ToolInputSchema,
+): schema is TSchema {
   return typeof schema === "object" && schema !== null && Kind in schema;
 }
 
@@ -103,92 +101,4 @@ export function tool<TInputSchema extends TSchema>(
   definition: ToolDefinition<TInputSchema>,
 ): ToolDefinition<TInputSchema> {
   return definition;
-}
-
-type ZodToolDefinition<
-  TInputSchema extends ZodTypeAny,
-  TOutputSchema extends ZodTypeAny | undefined = undefined,
-> = Omit<
-  BaseToolDefinition<z.output<TInputSchema>, JsonSchemaObject>,
-  "inputSchema" | "prepareArguments" | "execute"
-> & {
-  inputSchema: TInputSchema;
-  outputSchema?: TOutputSchema;
-  prepareArguments?: (args: unknown) => z.input<TInputSchema>;
-  execute?: (
-    input: z.output<TInputSchema>,
-    options: ToolExecuteOptions,
-  ) =>
-    | Promise<
-        TOutputSchema extends ZodTypeAny ? z.input<TOutputSchema> : unknown
-      >
-    | (TOutputSchema extends ZodTypeAny ? z.input<TOutputSchema> : unknown);
-};
-
-function formatZodPath(path: readonly PropertyKey[]): string {
-  return path.length > 0 ? path.map(String).join(".") : "root";
-}
-
-function formatToolInputError(error: z.ZodError): string {
-  const details = error.issues
-    .slice(0, 5)
-    .map((issue) => `${formatZodPath(issue.path)}: ${issue.message}`)
-    .join("; ");
-  return `Invalid tool arguments: ${details || "input did not match schema"}`;
-}
-
-function parseToolInput<TInputSchema extends ZodTypeAny>(
-  schema: TInputSchema,
-  args: unknown,
-): z.output<TInputSchema> {
-  const result = schema.safeParse(args);
-  if (!result.success) {
-    throw new ToolInputError(formatToolInputError(result.error), {
-      cause: result.error,
-    });
-  }
-  return result.data;
-}
-
-/**
- * Define a Junior-owned tool with Zod input parsing and JSON Schema parameters.
- */
-export function zodTool<
-  TInputSchema extends ZodTypeAny,
-  TOutputSchema extends ZodTypeAny | undefined = undefined,
->(
-  definition: ZodToolDefinition<TInputSchema, TOutputSchema>,
-): AnyToolDefinition {
-  const { inputSchema, outputSchema, prepareArguments, execute, ...toolDef } =
-    definition;
-  let modelInputSchema: JsonSchemaObject;
-  try {
-    modelInputSchema = z.toJSONSchema(inputSchema) as JsonSchemaObject;
-  } catch (error) {
-    throw new TypeError(
-      "zodTool() inputSchema must be representable as JSON Schema.",
-      { cause: error },
-    );
-  }
-  return {
-    ...toolDef,
-    inputSchema: modelInputSchema,
-    prepareArguments(args) {
-      return parseToolInput(
-        inputSchema,
-        prepareArguments ? prepareArguments(args) : args,
-      );
-    },
-    ...(execute
-      ? {
-          async execute(input, options) {
-            const result = await execute(
-              input as z.output<TInputSchema>,
-              options,
-            );
-            return outputSchema ? outputSchema.parse(result) : result;
-          },
-        }
-      : {}),
-  };
 }

--- a/packages/junior/src/chat/tools/resource-events.ts
+++ b/packages/junior/src/chat/tools/resource-events.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 import type { ToolRuntimeContext } from "@/chat/tools/types";
 import {
   cancelResourceEventSubscription,

--- a/packages/junior/src/chat/tools/runtime/report-progress.ts
+++ b/packages/junior/src/chat/tools/runtime/report-progress.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 
 /** Create the internal tool the model uses for sparse progress updates. */
 export function createReportProgressTool() {

--- a/packages/junior/src/chat/tools/sandbox/bash.ts
+++ b/packages/junior/src/chat/tools/sandbox/bash.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 
 /** Create the sandbox shell tool definition exposed to the agent. */
 export function createBashTool() {

--- a/packages/junior/src/chat/tools/sandbox/edit-file.ts
+++ b/packages/junior/src/chat/tools/sandbox/edit-file.ts
@@ -15,7 +15,7 @@ import {
   type TextReplacement,
 } from "@/chat/tools/sandbox/text-edits";
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 
 type EditReplacement = TextReplacement;
 

--- a/packages/junior/src/chat/tools/sandbox/find-files.ts
+++ b/packages/junior/src/chat/tools/sandbox/find-files.ts
@@ -10,7 +10,7 @@ import {
   type TextSearchResultDetails,
 } from "@/chat/tools/sandbox/file-utils";
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 
 const DEFAULT_FIND_LIMIT = 1000;
 

--- a/packages/junior/src/chat/tools/sandbox/grep.ts
+++ b/packages/junior/src/chat/tools/sandbox/grep.ts
@@ -12,7 +12,7 @@ import {
   type TextSearchResultDetails,
 } from "@/chat/tools/sandbox/file-utils";
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 
 const DEFAULT_GREP_LIMIT = 100;

--- a/packages/junior/src/chat/tools/sandbox/list-dir.ts
+++ b/packages/junior/src/chat/tools/sandbox/list-dir.ts
@@ -10,7 +10,7 @@ import {
   type TextSearchResultDetails,
 } from "@/chat/tools/sandbox/file-utils";
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 
 const DEFAULT_LIST_LIMIT = 500;

--- a/packages/junior/src/chat/tools/sandbox/read-file.ts
+++ b/packages/junior/src/chat/tools/sandbox/read-file.ts
@@ -3,7 +3,7 @@ import {
   positiveInteger,
 } from "@/chat/tools/sandbox/file-utils";
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 
 const DEFAULT_READ_LIMIT = 1000;
 

--- a/packages/junior/src/chat/tools/sandbox/write-file.ts
+++ b/packages/junior/src/chat/tools/sandbox/write-file.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 
 /** Create the sandbox full-file write tool definition exposed to the agent. */
 export function createWriteFileTool() {

--- a/packages/junior/src/chat/tools/skill/call-mcp-tool.ts
+++ b/packages/junior/src/chat/tools/skill/call-mcp-tool.ts
@@ -3,7 +3,7 @@ import { McpToolError } from "@/chat/mcp/errors";
 import type { ManagedMcpTool } from "@/chat/mcp/tool-manager";
 import { parseMcpProviderFromToolName } from "@/chat/mcp/tool-name";
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 
 interface CallMcpToolManager {
   activateProvider(provider: string): Promise<boolean>;

--- a/packages/junior/src/chat/tools/skill/load-skill.ts
+++ b/packages/junior/src/chat/tools/skill/load-skill.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 import { sandboxSkillDir, sandboxSkillFile } from "@/chat/sandbox/paths";
 import {
   loadSkillsByName,

--- a/packages/junior/src/chat/tools/system-time.ts
+++ b/packages/junior/src/chat/tools/system-time.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 
 export function createSystemTimeTool() {
   return zodTool({

--- a/packages/junior/src/chat/tools/web/fetch-tool.ts
+++ b/packages/junior/src/chat/tools/web/fetch-tool.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 import {
   FETCH_TIMEOUT_MS,
   MAX_FETCH_BYTES,

--- a/packages/junior/src/chat/tools/web/image-generate.ts
+++ b/packages/junior/src/chat/tools/web/image-generate.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 import type { ImageGenerateToolDeps, ToolHooks } from "@/chat/tools/types";
 import { botConfig } from "@/chat/config";
 import {

--- a/packages/junior/src/chat/tools/web/search.ts
+++ b/packages/junior/src/chat/tools/web/search.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 import { generateText } from "ai";
 import { createGatewayProvider } from "@ai-sdk/gateway";
 import { getModel } from "@earendil-works/pi-ai";

--- a/packages/junior/tests/unit/tool-support/zod-tool.test.ts
+++ b/packages/junior/tests/unit/tool-support/zod-tool.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
-import { zodTool } from "@/chat/tools/definition";
+import { zodTool } from "@/chat/tool-support/zod-tool";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 
 describe("zodTool", () => {


### PR DESCRIPTION
Keep the Zod-backed tool authoring adapter with the other tool-support code instead of the tool definition module. Update internal tool imports and move the focused unit test to match the new ownership.