### PR TITLE
fix(test): skip postgres harness for example database urls

### DIFF
--- a/packages/junior/tests/fixtures/env.ts
+++ b/packages/junior/tests/fixtures/env.ts
@@ -1,11 +1,13 @@
 import fs from "node:fs";
 import path from "node:path";
+import { parseEnv } from "node:util";
 import {
   createDefaultEnvFileLoader,
   createEnvFileLoader,
 } from "../../src/env/files";
 
 const ENV_FILES = [".env", ".env.local", ".env.test", ".env.test.local"];
+const POSTGRES_HARNESS_SKIP_ENV = "JUNIOR_SKIP_POSTGRES_HARNESS";
 
 export interface JuniorTestEnvOptions {
   packageRoots: string[];
@@ -24,6 +26,9 @@ export function loadJuniorTestEnvFiles(options: JuniorTestEnvOptions): void {
     ...options.packageRoots,
   ];
   const seen = new Set<string>();
+  const shellProvidedDatabaseUrl = process.env.DATABASE_URL !== undefined;
+  const shellProvidedHarnessSkip = process.env[POSTGRES_HARNESS_SKIP_ENV];
+  let envFileProvidedDatabaseUrl = false;
 
   for (const root of roots) {
     const absoluteRoot = path.resolve(root);
@@ -42,7 +47,21 @@ export function loadJuniorTestEnvFiles(options: JuniorTestEnvOptions): void {
       if (!fs.existsSync(absolutePath)) {
         continue;
       }
+      if (
+        Object.hasOwn(
+          parseEnv(fs.readFileSync(absolutePath, "utf8")),
+          "DATABASE_URL",
+        )
+      ) {
+        envFileProvidedDatabaseUrl = true;
+      }
       applyEnvFile(absolutePath);
     }
+  }
+
+  if (!shellProvidedDatabaseUrl && !envFileProvidedDatabaseUrl) {
+    process.env[POSTGRES_HARNESS_SKIP_ENV] ??= "1";
+  } else if (shellProvidedHarnessSkip === undefined) {
+    delete process.env[POSTGRES_HARNESS_SKIP_ENV];
   }
 }

--- a/packages/junior/tests/fixtures/postgres/global-setup.ts
+++ b/packages/junior/tests/fixtures/postgres/global-setup.ts
@@ -16,7 +16,9 @@ declare module "vitest" {
   }
 }
 
-const TEST_DATABASE_URL = process.env.DATABASE_URL;
+const TEST_DATABASE_URL = process.env.JUNIOR_SKIP_POSTGRES_HARNESS
+  ? undefined
+  : process.env.DATABASE_URL;
 
 function assertLocalDatabaseUrl(databaseUrl: string): void {
   const { hostname } = new URL(databaseUrl);

--- a/packages/junior/tests/unit/config/env-files.test.ts
+++ b/packages/junior/tests/unit/config/env-files.test.ts
@@ -1,14 +1,16 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createEnvFileLoader } from "@/env/files";
 import { loadJuniorTestEnvFiles } from "../../fixtures/env";
 
 const TEST_ENV_KEYS = [
+  "DATABASE_URL",
   "ENV_FILE_PRECEDENCE",
   "ENV_FILE_EXISTING",
   "ENV_FILE_DEFAULT",
+  "JUNIOR_SKIP_POSTGRES_HARNESS",
 ];
 const originalEnv = { ...process.env };
 
@@ -23,12 +25,16 @@ function clearTestEnv(): void {
   }
 }
 
-describe("createEnvFileLoader", () => {
-  afterEach(() => {
-    clearTestEnv();
-    process.env = { ...originalEnv };
-  });
+beforeEach(() => {
+  clearTestEnv();
+});
 
+afterEach(() => {
+  process.env = { ...originalEnv };
+  clearTestEnv();
+});
+
+describe("createEnvFileLoader", () => {
   it("lets later files override earlier values", () => {
     const applyEnvFile = createEnvFileLoader();
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "junior-env-file-"));
@@ -59,11 +65,6 @@ describe("createEnvFileLoader", () => {
 });
 
 describe("loadJuniorTestEnvFiles", () => {
-  afterEach(() => {
-    clearTestEnv();
-    process.env = { ...originalEnv };
-  });
-
   it("loads example env files as defaults before local overrides", () => {
     const workspaceRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), "junior-workspace-env-"),
@@ -103,5 +104,72 @@ describe("loadJuniorTestEnvFiles", () => {
     loadJuniorTestEnvFiles({ workspaceRoot, packageRoots: [packageRoot] });
 
     expect(process.env.ENV_FILE_DEFAULT).toBe("example");
+  });
+
+  it("skips the Postgres harness when DATABASE_URL only comes from example defaults", () => {
+    const workspaceRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "junior-workspace-env-"),
+    );
+    const exampleRoot = path.join(workspaceRoot, "apps/example");
+
+    writeFile(
+      path.join(exampleRoot, ".env.example"),
+      [
+        "DATABASE_URL=postgres://junior:junior@localhost:54322/junior",
+        "ENV_FILE_DEFAULT=example",
+        "",
+      ].join("\n"),
+    );
+
+    loadJuniorTestEnvFiles({ workspaceRoot, packageRoots: [] });
+
+    expect(process.env.DATABASE_URL).toBe(
+      "postgres://junior:junior@localhost:54322/junior",
+    );
+    expect(process.env.JUNIOR_SKIP_POSTGRES_HARNESS).toBe("1");
+    expect(process.env.ENV_FILE_DEFAULT).toBe("example");
+  });
+
+  it("allows local env files to provide DATABASE_URL", () => {
+    const workspaceRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "junior-workspace-env-"),
+    );
+    const exampleRoot = path.join(workspaceRoot, "apps/example");
+
+    writeFile(
+      path.join(exampleRoot, ".env.example"),
+      ["DATABASE_URL=postgres://example-default", ""].join("\n"),
+    );
+    writeFile(
+      path.join(exampleRoot, ".env.local"),
+      ["DATABASE_URL=postgres://local-override", ""].join("\n"),
+    );
+
+    loadJuniorTestEnvFiles({ workspaceRoot, packageRoots: [] });
+
+    expect(process.env.DATABASE_URL).toBe("postgres://local-override");
+    expect(process.env.JUNIOR_SKIP_POSTGRES_HARNESS).toBeUndefined();
+  });
+
+  it("preserves shell-provided DATABASE_URL", () => {
+    const workspaceRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "junior-workspace-env-"),
+    );
+    const exampleRoot = path.join(workspaceRoot, "apps/example");
+    process.env.DATABASE_URL = "postgres://shell";
+
+    writeFile(
+      path.join(exampleRoot, ".env.example"),
+      ["DATABASE_URL=postgres://example-default", ""].join("\n"),
+    );
+    writeFile(
+      path.join(exampleRoot, ".env.local"),
+      ["DATABASE_URL=postgres://local-override", ""].join("\n"),
+    );
+
+    loadJuniorTestEnvFiles({ workspaceRoot, packageRoots: [] });
+
+    expect(process.env.DATABASE_URL).toBe("postgres://shell");
+    expect(process.env.JUNIOR_SKIP_POSTGRES_HARNESS).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Fix the Junior Vitest env bootstrap so checked-in `.env.example` database defaults do not force the Postgres harness to start when a developer has not provided a real `DATABASE_URL`.

The env loader now marks the Postgres harness to skip when `DATABASE_URL` only came from example defaults, while preserving shell-provided values and local env-file overrides. The Postgres global setup respects that marker before attempting to connect.

## Verification

- `pnpm --filter @sentry/junior exec vitest run tests/unit/config/env-files.test.ts --maxWorkers=4 --reporter=verbose`
- `pnpm --filter @sentry/junior typecheck`
- `pnpm --filter @sentry/junior lint`

## Notes

A broader `pnpm --filter @sentry/junior exec vitest run tests/unit --maxWorkers=4` check was started but cancelled by the runtime before completion.