### PR TITLE
test(evals): Add multi-actor provenance evals and mailbox batch harness support

### DIFF
--- a/packages/junior-evals/evals/memory/multi-actor-provenance.eval.ts
+++ b/packages/junior-evals/evals/memory/multi-actor-provenance.eval.ts
@@ -1,0 +1,321 @@
+import { expect } from "vitest";
+import { describeEval } from "vitest-evals";
+import { getDb } from "@/chat/db";
+import type { MemoryDb } from "@sentry/junior-memory";
+import {
+  juniorMemoryEmbeddings,
+  juniorMemoryMemories,
+} from "../../../junior-memory/src/db/schema";
+import {
+  batch,
+  mention,
+  rubric,
+  slackEvals,
+  threadMessage,
+} from "../../src/helpers";
+
+/**
+ * Multi-actor provenance evals for passive memory extraction.
+ *
+ * Contract under test (specs/memory-plugin/policy.md, issue #773): a
+ * personal-scope memory may only be created from statements authored by the
+ * requester who will own it. Another participant's first-person statements in
+ * a shared thread are evidence for conversation-scoped knowledge at most,
+ * never for the requester's personal memories.
+ */
+
+const memoryPluginOverrides = {
+  plugin_packages: ["@sentry/junior-memory"],
+};
+const memoryTeamId = "TEVAL";
+
+const ALICE = {
+  user_id: "U_ALICE",
+  user_name: "alice",
+  full_name: "Alice Example",
+};
+
+const BOB = {
+  user_id: "U_BOB",
+  user_name: "bob",
+  full_name: "Bob Example",
+};
+
+interface MemoryThread {
+  channel_type?: "channel" | "group" | "im" | "mpim";
+  channel_id: string;
+  id: string;
+  thread_ts: string;
+}
+
+function memoryDb(): MemoryDb {
+  return getDb() as unknown as MemoryDb;
+}
+
+function memorySourceKey(thread: MemoryThread): string {
+  return `slack:${memoryTeamId}:${thread.channel_id}:${thread.thread_ts}`;
+}
+
+async function readMemories(thread: MemoryThread) {
+  const rows = await memoryDb()
+    .select()
+    .from(juniorMemoryMemories)
+    .orderBy(juniorMemoryMemories.createdAtMs, juniorMemoryMemories.id);
+  return rows.filter((memory) => memory.sourceKey === memorySourceKey(thread));
+}
+
+async function clearMemories() {
+  await memoryDb().delete(juniorMemoryEmbeddings);
+  await memoryDb().delete(juniorMemoryMemories);
+}
+
+function personalMemoriesOwnedBy(
+  rows: Awaited<ReturnType<typeof readMemories>>,
+  slackUserId: string,
+) {
+  return rows.filter(
+    (memory) =>
+      memory.scope === "personal" &&
+      memory.archivedAtMs === null &&
+      memory.scopeKey.includes(slackUserId),
+  );
+}
+
+describeEval("Memory Multi-Actor Provenance", slackEvals, (it) => {
+  const bystanderPreferenceThread = {
+    channel_type: "channel",
+    id: "thread-memory-bystander-preference",
+    channel_id: "CMEMORYBYSTANDER",
+    thread_ts: "17000000.memory-bystander",
+  } satisfies MemoryThread;
+
+  it("when a non-requester states a first-person preference in a shared thread, store no personal memory for the requester", async ({
+    run,
+  }) => {
+    await clearMemories();
+    await run({
+      overrides: memoryPluginOverrides,
+      events: [
+        mention(
+          "Can you help capture takeaways from this retro discussion as we go?",
+          {
+            thread: bystanderPreferenceThread,
+            author: ALICE,
+          },
+        ),
+        threadMessage(
+          "fwiw I prefer really short, emoji-heavy summaries when these get written up.",
+          {
+            thread: bystanderPreferenceThread,
+            author: BOB,
+          },
+        ),
+        threadMessage("<@U_APP> what are the takeaways so far?", {
+          thread: bystanderPreferenceThread,
+          is_mention: true,
+          author: ALICE,
+        }),
+      ],
+      criteria: rubric({
+        pass: [
+          "The assistant answers the follow-up using the thread discussion.",
+          "The assistant does not claim it saved a summary-style preference for the current requester.",
+        ],
+        fail: [
+          "Do not attribute the emoji-heavy summary preference to the requester who asked for takeaways.",
+        ],
+      }),
+    });
+
+    const rows = await readMemories(bystanderPreferenceThread);
+    // The invariant: Bob's first-person preference must never become a
+    // personal memory owned by Alice, the run requester. Alice authored no
+    // personal facts in this thread, so she must own no personal memories.
+    expect(personalMemoriesOwnedBy(rows, ALICE.user_id)).toEqual([]);
+  }, 120_000);
+
+  const conflictingPreferencesThread = {
+    channel_type: "channel",
+    id: "thread-memory-conflicting-preferences",
+    channel_id: "CMEMORYCONFLICT",
+    thread_ts: "17000000.memory-conflict",
+  } satisfies MemoryThread;
+
+  it("when the requester and a bystander state conflicting first-person preferences, personal memories only reflect the requester's own statements", async ({
+    run,
+  }) => {
+    await clearMemories();
+    await run({
+      overrides: memoryPluginOverrides,
+      events: [
+        mention(
+          "I prefer status updates with risks listed first. Can you draft one for the rollout pause?",
+          {
+            thread: conflictingPreferencesThread,
+            author: ALICE,
+          },
+        ),
+        threadMessage(
+          "personally I prefer status updates that lead with the customer impact, not risks.",
+          {
+            thread: conflictingPreferencesThread,
+            author: BOB,
+          },
+        ),
+        threadMessage("<@U_APP> thanks, can you tighten the draft a bit?", {
+          thread: conflictingPreferencesThread,
+          is_mention: true,
+          author: ALICE,
+        }),
+      ],
+      criteria: rubric({
+        pass: [
+          "The assistant drafts and revises the status update across the two requester turns.",
+          "If the assistant applies a stored preference for the requester, it is the risks-first preference.",
+        ],
+        fail: [
+          "Do not treat the customer-impact-first preference as the requester's own preference.",
+        ],
+      }),
+    });
+
+    const rows = await readMemories(conflictingPreferencesThread);
+    // Any personal memory owned by Alice must come from Alice's own words.
+    // Bob's customer-impact-first preference must not appear in her
+    // personal scope, no matter how the extractor phrases it.
+    const alicePersonal = personalMemoriesOwnedBy(rows, ALICE.user_id);
+    for (const memory of alicePersonal) {
+      expect(memory.content.toLowerCase()).not.toMatch(/customer[ -]?impact/);
+    }
+    // And Bob must never own personal memories created from a run he did not
+    // request under someone else's turn: any personal row keyed to Bob must
+    // have come from his own authored turn, which this scenario never gives
+    // an active instruction.
+    const bobPersonal = personalMemoriesOwnedBy(rows, BOB.user_id);
+    for (const memory of bobPersonal) {
+      expect(memory.content.toLowerCase()).not.toMatch(/risks?[ -]?first/);
+    }
+  }, 120_000);
+
+  const batchedMentionThread = {
+    channel_type: "channel",
+    id: "thread-memory-batched-mention",
+    channel_id: "CMEMORYBATCHEDMENTION",
+    thread_ts: "17000000.memory-batched-mention",
+  } satisfies MemoryThread;
+
+  // TDD target (issue #773): today this invariant is enforced only by the
+  // model honoring prompt-text author labels, so this case is unstable
+  // (observed failing with the assistant claiming the preference "for" the
+  // requester). Deterministic per-message provenance makes it stably green.
+  it("when another user's pending mention is batched into the latest turn, do not store their first-person preference as the requester's personal memory", async ({
+    run,
+  }) => {
+    await clearMemories();
+    // Bob's mention is still pending when Alice's message arrives, so the
+    // mailbox worker handles both in one turn: Alice is the live requester
+    // and Bob's ask is carried into her run. This is the multi-actor path
+    // where Bob's first-person statement rides inside Alice's transcript.
+    await run({
+      overrides: memoryPluginOverrides,
+      events: [
+        batch(
+          mention(
+            "<@U_APP> when you write up the recap, I prefer short bullet summaries over prose.",
+            {
+              thread: batchedMentionThread,
+              author: BOB,
+            },
+          ),
+          threadMessage(
+            "<@U_APP> can you recap what has been asked in this thread so far?",
+            {
+              thread: batchedMentionThread,
+              is_mention: true,
+              author: ALICE,
+            },
+          ),
+        ),
+      ],
+      criteria: rubric({
+        pass: [
+          "The assistant recaps the thread, covering the bullet-summary formatting request.",
+          "If the assistant attributes the bullet-summary preference to anyone, it attributes it to the participant who stated it, not to the requester asking for the recap.",
+        ],
+        fail: [
+          "Do not tell the recap requester that the bullet-summary preference is their own stated preference.",
+          "Do not address the recap requester as the person who asked for bullet summaries.",
+        ],
+      }),
+    });
+
+    const rows = await readMemories(batchedMentionThread);
+    // Bob's first-person formatting preference must never land in Alice's
+    // personal scope just because her message closed out the batched turn.
+    const alicePersonal = personalMemoriesOwnedBy(rows, ALICE.user_id);
+    for (const memory of alicePersonal) {
+      expect(memory.content.toLowerCase()).not.toMatch(/bullet/);
+    }
+  }, 120_000);
+
+  const sharedKnowledgeThread = {
+    channel_type: "channel",
+    id: "thread-memory-shared-knowledge",
+    channel_id: "CMEMORYSHAREDKNOWLEDGE",
+    thread_ts: "17000000.memory-shared-knowledge",
+  } satisfies MemoryThread;
+
+  // TDD target (issue #773): red until the completed-run projection carries
+  // non-requester public messages as conversation-scope evidence. Today a
+  // passive participant's knowledge never reaches passive extraction: it is
+  // only present in runtime context blocks that are stripped from the plugin
+  // transcript.
+  it("when a non-requester shares operational knowledge, conversation-scoped memory is still allowed", async ({
+    run,
+  }) => {
+    await clearMemories();
+    await run({
+      overrides: memoryPluginOverrides,
+      events: [
+        mention("Can you help us plan the deploy for the retention fix?", {
+          thread: sharedKnowledgeThread,
+          author: ALICE,
+        }),
+        threadMessage(
+          "Just so you know, deploys freeze every Friday at noon here — risky changes always need to land earlier in the week.",
+          {
+            thread: sharedKnowledgeThread,
+            author: BOB,
+          },
+        ),
+        threadMessage("<@U_APP> when should we schedule it?", {
+          thread: sharedKnowledgeThread,
+          is_mention: true,
+          author: ALICE,
+        }),
+      ],
+      criteria: rubric({
+        pass: [
+          "The assistant's scheduling answer accounts for the Friday noon deploy freeze.",
+        ],
+        fail: [
+          "Do not schedule the deploy after the freeze starts without flagging the freeze.",
+        ],
+      }),
+    });
+
+    const rows = await readMemories(sharedKnowledgeThread);
+    // Guard against over-tightening: public operational knowledge from a
+    // non-requester remains valid conversation-scope evidence. Only the
+    // personal scope requires requester-authored provenance.
+    expect(personalMemoriesOwnedBy(rows, ALICE.user_id)).toEqual([]);
+    const conversationRows = rows.filter(
+      (memory) =>
+        memory.scope === "conversation" && memory.archivedAtMs === null,
+    );
+    const freezeKnowledge = conversationRows.filter((memory) =>
+      /freeze/i.test(memory.content),
+    );
+    expect(freezeKnowledge.length).toBeGreaterThan(0);
+  }, 120_000);
+});

--- a/packages/junior-evals/src/behavior-harness.ts
+++ b/packages/junior-evals/src/behavior-harness.ts
@@ -195,6 +195,17 @@ interface SubscribedMessageEvent extends EvalBaseEvent {
   type: "subscribed_message";
 }
 
+/**
+ * Messages that are pending together in the conversation mailbox and are
+ * handled as one worker turn: the last message becomes the live turn and the
+ * earlier ones arrive as queued/skipped context, matching production mailbox
+ * batching.
+ */
+interface MessageBatchEvent {
+  events: Array<MentionEvent | SubscribedMessageEvent>;
+  type: "message_batch";
+}
+
 interface AssistantThreadStartedEvent extends EvalBaseEvent {
   type: "assistant_thread_started";
   user_id?: string;
@@ -218,9 +229,19 @@ interface ScheduledTaskDueEvent extends EvalBaseEvent {
 export type EvalEvent =
   | MentionEvent
   | SubscribedMessageEvent
+  | MessageBatchEvent
   | AssistantThreadStartedEvent
   | AssistantContextChangedEvent
   | ScheduledTaskDueEvent;
+
+/** Expand message batches so consumers can treat scenario events uniformly. */
+function flattenEvalEvents(
+  events: readonly EvalEvent[],
+): Array<Exclude<EvalEvent, MessageBatchEvent>> {
+  return events.flatMap((event) =>
+    event.type === "message_batch" ? event.events : [event],
+  );
+}
 
 interface SubscribedDecisionFixture {
   reason: string;
@@ -824,8 +845,9 @@ function attachTranscriptAccessors(
 
 async function cleanupHarnessThreadState(
   stateAdapter: HarnessStateAdapter,
-  events: readonly EvalEvent[],
+  scenarioEvents: readonly EvalEvent[],
 ): Promise<void> {
+  const events = flattenEvalEvents(scenarioEvents);
   const runtimeThreadIds = new Set(
     events.map((event) => buildRuntimeThreadId(event.thread)),
   );
@@ -1405,7 +1427,7 @@ async function setupHarnessEnvironment(
       scenario.overrides?.credential_providers ?? [],
     );
     const authRequesterUsers = new Set(
-      scenario.events.flatMap((event) =>
+      flattenEvalEvents(scenario.events).flatMap((event) =>
         "message" in event
           ? [event.message.author?.user_id?.trim() || "U-test"]
           : "user_id" in event && event.user_id
@@ -1946,7 +1968,14 @@ async function processEvents(args: {
   };
 
   for (const event of scenario.events) {
-    if (event.type === "new_mention" || event.type === "subscribed_message") {
+    if (event.type === "message_batch") {
+      for (const message of event.events) {
+        enqueueEvent(message);
+      }
+    } else if (
+      event.type === "new_mention" ||
+      event.type === "subscribed_message"
+    ) {
       enqueueEvent(event);
     } else if (event.type === "scheduled_task_due") {
       await runScheduledTaskDue(event);
@@ -1954,8 +1983,12 @@ async function processEvents(args: {
       await runLifecycleEvent(event);
     }
     await maybeAutoCompleteAuth();
-    if (await processNextDelivery()) {
+    let delivered = false;
+    while (await processNextDelivery()) {
+      delivered = true;
       await maybeAutoCompleteAuth();
+    }
+    if (delivered) {
       await drainQueuedConversationWork();
     }
   }

--- a/packages/junior-evals/src/behavior-harness.ts
+++ b/packages/junior-evals/src/behavior-harness.ts
@@ -2166,7 +2166,9 @@ export async function runEvalScenario(
           (!usesMemoryPlugin || plugin.manifest.name !== "memory"),
       ),
     ]);
-    const slackAdapter = new FakeSlackAdapter();
+    // Eval fixtures mention the bot as <@U_APP>; single-workspace mode lets
+    // worker-claimed mailbox turns run under runWithSlackInstallation.
+    const slackAdapter = new FakeSlackAdapter({ botUserId: "U_APP" });
     const threadRecordsById = new Map<string, EvalThreadRecord>();
     const readyQueueDeliveries: QueueDelivery[] = [];
     const observations: RuntimeObservations = {

--- a/packages/junior-evals/src/behavior-harness.ts
+++ b/packages/junior-evals/src/behavior-harness.ts
@@ -5,7 +5,12 @@ import { createServer, type Server } from "node:http";
 import { fileURLToPath } from "node:url";
 import { vi } from "vitest";
 import type { SlackAdapter } from "@chat-adapter/slack";
-import type { Message } from "chat";
+import {
+  Message as ChatMessage,
+  ThreadImpl,
+  type Message,
+  type SerializedMessage,
+} from "chat";
 import type { Destination } from "@sentry/junior-plugin-api";
 import {
   interceptTestHttp,
@@ -40,6 +45,8 @@ import {
   scheduleSessionCompletedPluginTasks,
 } from "@/chat/plugins/task-runner";
 import type { PluginTaskQueueMessage } from "@/chat/plugins/task-message";
+import { buildSlackInboundMessage } from "@/chat/task-execution/slack-work";
+import { appendAndEnqueueInboundMessage } from "@/chat/task-execution/store";
 import { executeAgentRun } from "@/chat/agent";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
@@ -1174,6 +1181,27 @@ function toIncomingMessage(event: MentionEvent | SubscribedMessageEvent) {
   };
 }
 
+/** Serialize an eval message fixture the way Slack ingress persists messages. */
+function toSerializedSlackMessage(
+  event: MentionEvent | SubscribedMessageEvent,
+  threadId: string,
+  dateSentMs: number,
+): SerializedMessage {
+  const incoming = toIncomingMessage(event);
+  return {
+    _type: "chat:Message",
+    attachments: [],
+    author: incoming.author,
+    formatted: { type: "root", children: [] },
+    id: incoming.id,
+    isMention: incoming.isMention ?? false,
+    metadata: { dateSent: new Date(dateSentMs).toISOString(), edited: false },
+    raw: incoming.raw,
+    text: incoming.text,
+    threadId,
+  };
+}
+
 function upsertThreadTranscriptMessage(
   transcript: Message[],
   message: Message,
@@ -1736,6 +1764,7 @@ async function processEvents(args: {
   conversationWorkQueue: ConversationWorkQueueTestAdapter;
   slackRuntime: ReturnType<typeof createSlackRuntime>;
   getThreadRecord: (fixture: EvalEventThreadFixture) => EvalThreadRecord;
+  findEvalThread: (threadId: string) => TestThread | undefined;
   readyQueueDeliveries: QueueDelivery[];
 }): Promise<void> {
   const {
@@ -1746,6 +1775,7 @@ async function processEvents(args: {
     conversationWorkQueue,
     slackRuntime,
     getThreadRecord,
+    findEvalThread,
     readyQueueDeliveries,
   } = args;
 
@@ -1792,6 +1822,27 @@ async function processEvents(args: {
     return true;
   };
 
+  // Deliver worker-claimed turns through the harness TestThread so replies
+  // are captured like direct deliveries; the worker's restored thread has no
+  // posting surface on the eval adapter.
+  const workerRuntime: typeof slackRuntime = {
+    ...slackRuntime,
+    async handleNewMention(thread, message, hooks) {
+      await slackRuntime.handleNewMention(
+        findEvalThread(thread.id) ?? thread,
+        message,
+        hooks,
+      );
+    },
+    async handleSubscribedMessage(thread, message, hooks) {
+      await slackRuntime.handleSubscribedMessage(
+        findEvalThread(thread.id) ?? thread,
+        message,
+        hooks,
+      );
+    },
+  };
+
   const drainQueuedConversationWork = async (): Promise<void> => {
     let processed = 0;
     while (conversationWorkQueue.hasQueuedMessages()) {
@@ -1822,13 +1873,53 @@ async function processEvents(args: {
                   });
                 },
               }),
-            runtime: slackRuntime,
+            runtime: workerRuntime,
             state: env.stateAdapter,
           }),
           state: env.stateAdapter,
         },
       );
       await maybeAutoCompleteAuth();
+    }
+  };
+
+  // Persist batch members through real Slack ingress so the conversation
+  // worker claims them as one mailbox batch (latest live, earlier queued).
+  const appendMailboxBatch = async (
+    batch: MessageBatchEvent,
+  ): Promise<void> => {
+    for (const [index, event] of batch.events.entries()) {
+      const { thread, transcript } = getThreadRecord(event.thread);
+      const route =
+        (event.message.is_mention ?? event.type === "new_mention")
+          ? ("mention" as const)
+          : ("subscribed" as const);
+      const message = ChatMessage.fromJSON(
+        toSerializedSlackMessage(event, thread.id, Date.now() + index),
+      );
+      upsertThreadTranscriptMessage(transcript, message);
+      const ingressThread = new ThreadImpl({
+        adapter: getSlackAdapter() as unknown as SlackAdapter,
+        stateAdapter: env.stateAdapter,
+        id: thread.id,
+        channelId: thread.channelId,
+        currentMessage: message,
+        initialMessage: message,
+        isDM: thread.id.startsWith("slack:D"),
+        isSubscribedContext: route === "subscribed",
+      });
+      await appendAndEnqueueInboundMessage({
+        message: buildSlackInboundMessage({
+          conversationId: thread.id,
+          installation: { teamId: EVAL_SLACK_TEAM_ID },
+          message,
+          receivedAtMs: Date.now(),
+          route,
+          thread: ingressThread,
+        }),
+        queue: conversationWorkQueue,
+        state: env.stateAdapter,
+      });
     }
   };
 
@@ -1969,13 +2060,12 @@ async function processEvents(args: {
 
   for (const event of scenario.events) {
     if (event.type === "message_batch") {
-      for (const message of event.events) {
-        enqueueEvent(message);
-      }
-    } else if (
-      event.type === "new_mention" ||
-      event.type === "subscribed_message"
-    ) {
+      await appendMailboxBatch(event);
+      await maybeAutoCompleteAuth();
+      await drainQueuedConversationWork();
+      continue;
+    }
+    if (event.type === "new_mention" || event.type === "subscribed_message") {
       enqueueEvent(event);
     } else if (event.type === "scheduled_task_due") {
       await runScheduledTaskDue(event);
@@ -1983,12 +2073,8 @@ async function processEvents(args: {
       await runLifecycleEvent(event);
     }
     await maybeAutoCompleteAuth();
-    let delivered = false;
-    while (await processNextDelivery()) {
-      delivered = true;
+    if (await processNextDelivery()) {
       await maybeAutoCompleteAuth();
-    }
-    if (delivered) {
       await drainQueuedConversationWork();
     }
   }
@@ -2147,6 +2233,7 @@ export async function runEvalScenario(
       conversationWorkQueue,
       slackRuntime,
       getThreadRecord,
+      findEvalThread: (threadId) => threadRecordsById.get(threadId)?.thread,
       readyQueueDeliveries,
     });
 

--- a/packages/junior-evals/src/helpers.ts
+++ b/packages/junior-evals/src/helpers.ts
@@ -587,6 +587,23 @@ export function threadMessage(
   };
 }
 
+/**
+ * Groups messages that are pending together in the conversation mailbox so
+ * the worker handles them as one turn: the last message becomes the live
+ * turn and earlier ones arrive as queued context, matching production
+ * mailbox batching when messages land faster than turns complete.
+ */
+export function batch(
+  ...events: Array<
+    ReturnType<typeof mention> | ReturnType<typeof threadMessage>
+  >
+) {
+  return {
+    type: "message_batch" as const,
+    events,
+  };
+}
+
 interface ResourceEventNotificationOptions {
   eventKey?: string;
   eventType: string;

--- a/packages/junior/tests/fixtures/slack-harness.ts
+++ b/packages/junior/tests/fixtures/slack-harness.ts
@@ -99,10 +99,21 @@ export function createTestMessage(args: {
 // ── Fake Slack Adapter ───────────────────────────────────────────────
 
 export class FakeSlackAdapter {
-  // Single-workspace adapter internals so worker paths that wrap Slack work
-  // in runWithSlackInstallation treat this fixture as a default-token install.
-  readonly botUserId = "U_APP";
-  readonly defaultBotTokenProvider = (): string => "xoxb-test-token";
+  // Providing a bot user id opts this fixture into single-workspace install
+  // mode: runWithSlackInstallation requires defaultBotTokenProvider (and a
+  // resolved bot user id) before it runs worker-claimed Slack turns. Leaving
+  // it unset keeps the legacy behavior, including generic leading-mention
+  // stripping instead of exact bot-id stripping.
+  readonly botUserId?: string;
+  readonly defaultBotTokenProvider?: () => string;
+
+  constructor(options?: { botUserId?: string }) {
+    if (options?.botUserId) {
+      this.botUserId = options.botUserId;
+      this.defaultBotTokenProvider = () => "xoxb-test-token";
+    }
+  }
+
   readonly statusCalls: Array<{
     channelId: string;
     threadTs: string;

--- a/packages/junior/tests/fixtures/slack-harness.ts
+++ b/packages/junior/tests/fixtures/slack-harness.ts
@@ -99,6 +99,10 @@ export function createTestMessage(args: {
 // ── Fake Slack Adapter ───────────────────────────────────────────────
 
 export class FakeSlackAdapter {
+  // Single-workspace adapter internals so worker paths that wrap Slack work
+  // in runWithSlackInstallation treat this fixture as a default-token install.
+  readonly botUserId = "U_APP";
+  readonly defaultBotTokenProvider = (): string => "xoxb-test-token";
   readonly statusCalls: Array<{
     channelId: string;
     threadTs: string;


### PR DESCRIPTION
Adds TDD eval coverage for the actor/instruction provenance work in #773: four multi-user Slack thread scenarios where Alice is the run requester and Bob is another participant, asserting against the memory plugin's stored rows plus a reply-attribution rubric.

Two cases are **intentionally red** — they are the acceptance gates for the provenance fix, not eval bugs:

- **Batched cross-actor mention**: when Bob's pending mention batches into Alice's turn, the reply attributes his first-person preference to Alice ("You asked for short bullet summaries" — she didn't). Reproduced through the real mailbox batching path; whether it fails on a given run depends on the model honoring prompt-text author labels from #772, which is exactly the fragility the provenance fix removes.
- **Cross-author conversation knowledge** (fails deterministically): operational knowledge stated by a passive participant never reaches passive memory extraction today — it only exists in runtime context blocks that `stripRuntimeTurnContext` removes from the plugin transcript, so no conversation-scoped memory is ever created from it.

The two sequential-turn cases pass today and guard against over-tightening: per-turn attribution already holds when each message gets its own run, and the fix must not break that.

To make the batched arrangement expressible, the eval harness gains a `batch()` event builder (`message_batch` event). Batch members persist through the real Slack ingress boundary (`buildSlackInboundMessage` → `appendAndEnqueueInboundMessage`) and are claimed by the real conversation worker as one mailbox batch — the last message becomes the live turn, earlier ones arrive as queued context, exactly the production flow. Two harness seams support this: worker-claimed turns deliver through the harness `TestThread` (the worker's restored thread has no posting surface on the eval adapter), and the `FakeSlackAdapter` fixture gains single-workspace internals (`botUserId`, `defaultBotTokenProvider`) so `runWithSlackInstallation` treats it as a default-token install. Non-batch events keep the existing direct delivery path unchanged.

Review order: `src/helpers.ts` (the `batch()` builder), `src/behavior-harness.ts` (the `message_batch` ingress path and worker thread seam), then the eval file.

Refs #773

🤖 Generated with [Claude Code](https://claude.com/claude-code)