### PR TITLE
fix(oauth): Retain refresh token when providers omit rotation

### DIFF
--- a/packages/junior-evals/evals/core/oauth-workflows.eval.ts
+++ b/packages/junior-evals/evals/core/oauth-workflows.eval.ts
@@ -1,6 +1,7 @@
 import { assistantMessages, describeEval, toolCalls } from "vitest-evals";
 import type { HarnessRun } from "vitest-evals/harness";
 import { expect } from "vitest";
+import { readEvalOAuthRefreshTokens } from "@junior-tests/msw/handlers/eval-oauth";
 import {
   authorizationCompletions,
   rubric,
@@ -191,6 +192,44 @@ describeEval("OAuth Workflows", slackEvals, (it) => {
     ).toBeGreaterThanOrEqual(3);
     expectFinalThreadReply(result, oauthResumeThread, /\bFriday\b/i);
     expectFinalThreadReply(result, oauthResumeThread, /eval-oauth-user/i);
+  });
+
+  const oauthRefreshThread = {
+    id: "thread-oauth-refresh",
+    channel_id: "COAUTHREFRESH",
+    thread_ts: "17000000.1004",
+  };
+
+  it("refreshes an expired generic OAuth credential during a normal turn", async ({
+    run,
+  }) => {
+    const result = await run({
+      overrides: {
+        expired_oauth_tokens: ["eval-oauth"],
+        plugin_dirs: ["fixtures/plugins"],
+      },
+      initialEvents: [
+        threadMessage(
+          "/eval-oauth Tell me which eval identity is currently active.",
+          { thread: oauthRefreshThread, is_mention: true },
+        ),
+      ],
+      criteria: rubric({
+        pass: [
+          "The response identifies the active account as eval-oauth-user.",
+          "The request completes without asking the user to authorize or reconnect.",
+        ],
+        fail: [
+          "Do not post a generic failure message.",
+          "Do not ask the user to authorize, connect, or reconnect the account.",
+        ],
+      }),
+    });
+
+    expectEvalOauthIdentityCheck(result);
+    expect(authorizationCompletions(result)).toEqual([]);
+    expect(readEvalOAuthRefreshTokens()).toEqual(["eval-oauth-refresh-token"]);
+    expectFinalThreadReply(result, oauthRefreshThread, /eval-oauth-user/i);
   });
 
   const oauthReconnectThread = {

--- a/packages/junior-evals/src/behavior-harness.ts
+++ b/packages/junior-evals/src/behavior-harness.ts
@@ -287,6 +287,7 @@ export interface EvalOverrides {
   auto_complete_mcp_oauth?: string[];
   auto_complete_oauth?: string[];
   credential_providers?: Array<"github" | "sentry">;
+  expired_oauth_tokens?: string[];
   fail_reply_call?: number;
   mock_image_generation?: boolean;
   plugin_dirs?: string[];
@@ -670,7 +671,8 @@ function isSandboxReachableBaseUrl(value: string): boolean {
 function scenarioNeedsEvalEgress(scenario: EvalScenario): boolean {
   return Boolean(
     scenario.overrides?.credential_providers?.length ||
-    scenario.overrides?.auto_complete_oauth?.length,
+    scenario.overrides?.auto_complete_oauth?.length ||
+    scenario.overrides?.expired_oauth_tokens?.length,
   );
 }
 
@@ -1327,6 +1329,28 @@ async function seedCredentialProviderTokens(input: {
   }
 }
 
+async function seedExpiredOAuthTokens(input: {
+  providers: Set<string>;
+  userIds: Iterable<string>;
+}): Promise<void> {
+  const userTokenStore = createUserTokenStore();
+  for (const provider of input.providers) {
+    if (provider !== EVAL_OAUTH_PROVIDER) {
+      throw new Error(
+        `No expired OAuth eval fixture for provider "${provider}"`,
+      );
+    }
+    for (const userId of input.userIds) {
+      await userTokenStore.set(userId, provider, {
+        accessToken: "expired-eval-oauth-access-token",
+        refreshToken: "eval-oauth-refresh-token",
+        expiresAt: Date.now() - 1,
+        scope: "read",
+      });
+    }
+  }
+}
+
 function getDefaultAuthCode(
   type: "mcp-oauth" | "oauth",
   provider: string,
@@ -1570,6 +1594,7 @@ interface HarnessEnvironment {
   autoCompleteMcpOauthProviders: Set<string>;
   autoCompleteOauthProviders: Set<string>;
   credentialProviders: Set<"github" | "sentry">;
+  expiredOauthProviders: Set<string>;
   configuredPluginDirs: string[];
   configuredSkillDirs: string[];
   envSnapshot: EnvSnapshot;
@@ -1602,6 +1627,11 @@ async function setupHarnessEnvironment(
     );
     const credentialProviders = new Set(
       scenario.overrides?.credential_providers ?? [],
+    );
+    const expiredOauthProviders = new Set(
+      scenario.overrides?.expired_oauth_tokens?.map((provider) =>
+        provider.trim(),
+      ) ?? [],
     );
     const authActorUsers = new Set(
       scenarioEvents(scenario).flatMap((event) =>
@@ -1643,8 +1673,13 @@ async function setupHarnessEnvironment(
     await cleanupMcpAuthState(authActorUsers, autoCompleteMcpOauthProviders);
     await cleanupOAuthTokens(authActorUsers, autoCompleteOauthProviders);
     await cleanupOAuthTokens(authActorUsers, credentialProviders);
+    await cleanupOAuthTokens(authActorUsers, expiredOauthProviders);
     await seedCredentialProviderTokens({
       providers: credentialProviders,
+      userIds: authActorUsers,
+    });
+    await seedExpiredOAuthTokens({
+      providers: expiredOauthProviders,
       userIds: authActorUsers,
     });
 
@@ -1653,6 +1688,7 @@ async function setupHarnessEnvironment(
       autoCompleteMcpOauthProviders,
       autoCompleteOauthProviders,
       credentialProviders,
+      expiredOauthProviders,
       configuredPluginDirs,
       configuredSkillDirs,
       envSnapshot,
@@ -1683,6 +1719,7 @@ async function teardownHarnessEnvironment(
   );
   await cleanupOAuthTokens(env.authActorUsers, env.autoCompleteOauthProviders);
   await cleanupOAuthTokens(env.authActorUsers, env.credentialProviders);
+  await cleanupOAuthTokens(env.authActorUsers, env.expiredOauthProviders);
   await env.egressServer?.close();
   env.envSnapshot.restore();
   await env.pluginApp?.cleanup();

--- a/packages/junior/src/chat/plugins/auth/oauth-bearer-broker.ts
+++ b/packages/junior/src/chat/plugins/auth/oauth-bearer-broker.ts
@@ -99,6 +99,7 @@ async function refreshAccessToken(
   const data = (await response.json()) as Record<string, unknown>;
   return parseOAuthTokenResponse(data, requestedScope, {
     treatEmptyScopeAsUnreported: oauth.treatEmptyScopeAsUnreported,
+    currentRefreshToken: refreshToken,
   });
 }
 

--- a/packages/junior/src/chat/plugins/auth/oauth-bearer-broker.ts
+++ b/packages/junior/src/chat/plugins/auth/oauth-bearer-broker.ts
@@ -99,7 +99,7 @@ async function refreshAccessToken(
   const data = (await response.json()) as Record<string, unknown>;
   return parseOAuthTokenResponse(data, requestedScope, {
     treatEmptyScopeAsUnreported: oauth.treatEmptyScopeAsUnreported,
-    currentRefreshToken: refreshToken,
+    refreshToken,
   });
 }
 

--- a/packages/junior/src/chat/plugins/auth/oauth-request.ts
+++ b/packages/junior/src/chat/plugins/auth/oauth-request.ts
@@ -91,21 +91,22 @@ export function buildOAuthTokenRequest(input: OAuthTokenRequestInput): {
   };
 }
 
+/** Parse provider tokens, retaining the request token when a refresh response omits rotation. */
 export function parseOAuthTokenResponse(
   data: unknown,
   requestedScope?: string,
   options?: {
     treatEmptyScopeAsUnreported?: boolean;
-    currentRefreshToken?: string;
+    refreshToken?: string;
   },
 ): OAuthTokenResponse {
   const response = requireTokenResponseObject(data);
   const accessToken = requireNonEmptyTokenField(response, "access_token");
-  const refreshToken =
+  const resolvedRefreshToken =
     response.refresh_token === undefined
-      ? options?.currentRefreshToken
+      ? options?.refreshToken
       : requireNonEmptyTokenField(response, "refresh_token");
-  if (!refreshToken) {
+  if (!resolvedRefreshToken) {
     throw new Error("OAuth token response missing refresh_token");
   }
   const expiresIn = response.expires_in;
@@ -135,7 +136,11 @@ export function parseOAuthTokenResponse(
     expiresAt?: number;
     refreshTokenExpiresAt?: number;
     scope?: string;
-  } = { accessToken, refreshToken, ...(scope ? { scope } : {}) };
+  } = {
+    accessToken,
+    refreshToken: resolvedRefreshToken,
+    ...(scope ? { scope } : {}),
+  };
 
   if (expiresIn !== undefined) {
     if (

--- a/packages/junior/src/chat/plugins/auth/oauth-request.ts
+++ b/packages/junior/src/chat/plugins/auth/oauth-request.ts
@@ -94,11 +94,20 @@ export function buildOAuthTokenRequest(input: OAuthTokenRequestInput): {
 export function parseOAuthTokenResponse(
   data: unknown,
   requestedScope?: string,
-  options?: { treatEmptyScopeAsUnreported?: boolean },
+  options?: {
+    treatEmptyScopeAsUnreported?: boolean;
+    currentRefreshToken?: string;
+  },
 ): OAuthTokenResponse {
   const response = requireTokenResponseObject(data);
   const accessToken = requireNonEmptyTokenField(response, "access_token");
-  const refreshToken = requireNonEmptyTokenField(response, "refresh_token");
+  const refreshToken =
+    response.refresh_token === undefined
+      ? options?.currentRefreshToken
+      : requireNonEmptyTokenField(response, "refresh_token");
+  if (!refreshToken) {
+    throw new Error("OAuth token response missing refresh_token");
+  }
   const expiresIn = response.expires_in;
   const refreshTokenExpiresIn = response.refresh_token_expires_in;
   const responseScope = response.scope;

--- a/packages/junior/tests/msw/handlers/eval-oauth.ts
+++ b/packages/junior/tests/msw/handlers/eval-oauth.ts
@@ -5,13 +5,37 @@ export const EVAL_OAUTH_CODE = "eval-oauth-code";
 export const EVAL_OAUTH_ORIGIN = "https://example.com";
 const EVAL_OAUTH_TOKEN_ENDPOINT = `${EVAL_OAUTH_ORIGIN}/junior-eval-oauth/oauth/token`;
 const EVAL_OAUTH_ACCESS_TOKEN = "eval-oauth-access-token";
+const EVAL_OAUTH_REFRESH_TOKEN = "eval-oauth-refresh-token";
+const refreshTokens: string[] = [];
 
-export function resetEvalOAuthMockState(): void {}
+/** Clear captured eval OAuth refresh requests between scenarios. */
+export function resetEvalOAuthMockState(): void {
+  refreshTokens.length = 0;
+}
+
+/** Return refresh tokens submitted to the eval OAuth token endpoint. */
+export function readEvalOAuthRefreshTokens(): string[] {
+  return [...refreshTokens];
+}
 
 export const evalOAuthHandlers = [
   http.post(EVAL_OAUTH_TOKEN_ENDPOINT, async ({ request }) => {
     const bodyText = await request.text();
     const params = new URLSearchParams(bodyText);
+    if (params.get("grant_type") === "refresh_token") {
+      const refreshToken = params.get("refresh_token") ?? "";
+      refreshTokens.push(refreshToken);
+      if (refreshToken !== EVAL_OAUTH_REFRESH_TOKEN) {
+        return HttpResponse.json({ error: "invalid_grant" }, { status: 400 });
+      }
+      return HttpResponse.json({
+        access_token: EVAL_OAUTH_ACCESS_TOKEN,
+        token_type: "Bearer",
+        expires_in: 3600,
+        scope: "read",
+      });
+    }
+
     const code = params.get("code");
     if (code !== EVAL_OAUTH_CODE) {
       return HttpResponse.json(
@@ -27,7 +51,7 @@ export const evalOAuthHandlers = [
       access_token: EVAL_OAUTH_ACCESS_TOKEN,
       token_type: "Bearer",
       expires_in: 3600,
-      refresh_token: "eval-oauth-refresh-token",
+      refresh_token: EVAL_OAUTH_REFRESH_TOKEN,
       scope: "read",
     });
   }),

--- a/packages/junior/tests/unit/plugins/oauth-token-response.test.ts
+++ b/packages/junior/tests/unit/plugins/oauth-token-response.test.ts
@@ -54,6 +54,39 @@ describe("parseOAuthTokenResponse", () => {
     expect(result.scope).toBe("gist repo");
   });
 
+  it("keeps the current refresh token when a refresh response omits refresh_token", () => {
+    const result = parseOAuthTokenResponse({ access_token: "access" }, "repo", {
+      currentRefreshToken: "current-refresh",
+    });
+    expect(result.refreshToken).toBe("current-refresh");
+    expect(result.accessToken).toBe("access");
+  });
+
+  it("prefers a rotated refresh token over the fallback", () => {
+    const result = parseOAuthTokenResponse(
+      { access_token: "access", refresh_token: "rotated" },
+      "repo",
+      { currentRefreshToken: "current-refresh" },
+    );
+    expect(result.refreshToken).toBe("rotated");
+  });
+
+  it("rejects a missing refresh_token when no fallback is provided", () => {
+    expect(() =>
+      parseOAuthTokenResponse({ access_token: "access" }, "repo"),
+    ).toThrow("OAuth token response missing refresh_token");
+  });
+
+  it("rejects an invalid refresh_token even when a fallback is provided", () => {
+    expect(() =>
+      parseOAuthTokenResponse(
+        { access_token: "access", refresh_token: "" },
+        "repo",
+        { currentRefreshToken: "current-refresh" },
+      ),
+    ).toThrow("OAuth token response missing refresh_token");
+  });
+
   it("records refresh token expiry separately from access token expiry", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-24T00:00:00Z"));

--- a/packages/junior/tests/unit/plugins/oauth-token-response.test.ts
+++ b/packages/junior/tests/unit/plugins/oauth-token-response.test.ts
@@ -56,7 +56,7 @@ describe("parseOAuthTokenResponse", () => {
 
   it("keeps the current refresh token when a refresh response omits refresh_token", () => {
     const result = parseOAuthTokenResponse({ access_token: "access" }, "repo", {
-      currentRefreshToken: "current-refresh",
+      refreshToken: "current-refresh",
     });
     expect(result.refreshToken).toBe("current-refresh");
     expect(result.accessToken).toBe("access");
@@ -66,7 +66,7 @@ describe("parseOAuthTokenResponse", () => {
     const result = parseOAuthTokenResponse(
       { access_token: "access", refresh_token: "rotated" },
       "repo",
-      { currentRefreshToken: "current-refresh" },
+      { refreshToken: "current-refresh" },
     );
     expect(result.refreshToken).toBe("rotated");
   });
@@ -82,7 +82,7 @@ describe("parseOAuthTokenResponse", () => {
       parseOAuthTokenResponse(
         { access_token: "access", refresh_token: "" },
         "repo",
-        { currentRefreshToken: "current-refresh" },
+        { refreshToken: "current-refresh" },
       ),
     ).toThrow("OAuth token response missing refresh_token");
   });

--- a/packages/junior/tests/unit/plugins/sentry-broker.test.ts
+++ b/packages/junior/tests/unit/plugins/sentry-broker.test.ts
@@ -185,7 +185,7 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
     ).rejects.toThrow(CredentialUnavailableError);
   });
 
-  it("refreshes tokens that are near expiry", async () => {
+  it("retains the refresh token when refreshing near expiry without rotation", async () => {
     process.env.SENTRY_CLIENT_ID = "client-id";
     process.env.SENTRY_CLIENT_SECRET = "client-secret";
     const refreshTokenExpiresAt = Date.now() + 30 * 24 * 60 * 60 * 1000;
@@ -204,7 +204,6 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
       ok: true,
       json: async () => ({
         access_token: "new-access-token",
-        refresh_token: "new-refresh-token",
         expires_in: 3600,
       }),
     })) as unknown as typeof fetch;
@@ -228,7 +227,7 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
 
     const stored = await tokenStore.get("U123", "sentry");
     expect(stored?.accessToken).toBe("new-access-token");
-    expect(stored?.refreshToken).toBe("new-refresh-token");
+    expect(stored?.refreshToken).toBe("old-refresh-token");
     expect(stored?.refreshTokenExpiresAt).toBe(refreshTokenExpiresAt);
     expect(globalThis.fetch).toHaveBeenCalledWith(
       "https://sentry.io/oauth/token/",


### PR DESCRIPTION
Plugin OAuth refreshes now keep the stored refresh token when a provider returns a new access token without a `refresh_token`. This covers providers like Asana that do not rotate refresh tokens on refresh; previously those responses were rejected, so plugin auth failed consistently after the access token expired.

Fresh authorization responses still require a refresh token, and explicitly invalid refresh token values are still rejected instead of silently falling back to the stored credential. Verified with `pnpm --filter @sentry/junior exec vitest run tests/unit/plugins/oauth-token-response.test.ts`.