### PR TITLE
feat(chat)!: Bind per-message actor provenance through runs, plugins, and memory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,7 @@ Co-Authored-By: (agent model name) <email>
 - `specs/slack-agent-delivery.md` (Slack entry surfaces, reply delivery, continuation, files, images, and resume behavior contract)
 - `specs/slack-outbound-contract.md` (Slack outbound boundary, message/file/reaction safety rules, and markdown-to-`mrkdwn` ownership)
 - `specs/identity.md` (current actor, system actor, author, creator, credential subject, service principal, and display identity contract)
+- `specs/multi-actor-runs.md` (run-level actor attribution — `run.actor` and `run.actors` — membership semantics, and the attribution-not-authority naming contract)
 - `specs/credential-injection.md` (actor-bound credential injection contract)
 - `specs/oauth-flows.md` (OAuth authorization code flow + Slack UX contract)
 - `specs/agent-prompt.md` (core prompt ownership, execution-bias, and bloat-control contract)

--- a/packages/junior-evals/evals/memory/multi-actor-provenance.eval.ts
+++ b/packages/junior-evals/evals/memory/multi-actor-provenance.eval.ts
@@ -41,6 +41,12 @@ const BOB = {
   full_name: "Bob Example",
 };
 
+const CAROL = {
+  user_id: "U_CAROL",
+  user_name: "carol",
+  full_name: "Carol Example",
+};
+
 interface MemoryThread {
   channel_type?: "channel" | "group" | "im" | "mpim";
   channel_id: string;
@@ -86,7 +92,7 @@ describeEval("Memory Multi-Actor Provenance", slackEvals, (it) => {
     channel_type: "channel",
     id: "thread-memory-bystander-preference",
     channel_id: "CMEMORYBYSTANDER",
-    thread_ts: "17000000.memory-bystander",
+    thread_ts: "1700000000.000001",
   } satisfies MemoryThread;
 
   it("when a non-actor states a first-person preference in a shared thread, store no personal memory for the actor", async ({
@@ -101,6 +107,13 @@ describeEval("Memory Multi-Actor Provenance", slackEvals, (it) => {
           {
             thread: bystanderPreferenceThread,
             author: ALICE,
+          },
+        ),
+        threadMessage(
+          "Biggest takeaway from my side: the rollout checklist missed cache invalidation, and we only caught it because support flagged the stale pages.",
+          {
+            thread: bystanderPreferenceThread,
+            author: CAROL,
           },
         ),
         threadMessage(
@@ -119,26 +132,35 @@ describeEval("Memory Multi-Actor Provenance", slackEvals, (it) => {
       criteria: rubric({
         pass: [
           "The assistant answers the follow-up using the thread discussion.",
-          "The assistant does not claim it saved a summary-style preference for the current actor.",
+          "The assistant does not present the summary-style preference as belonging to the current actor or as saved for the current actor. Mentioning that another participant stated the preference, or that it will be kept in mind for the write-up, is acceptable and expected.",
         ],
         fail: [
-          "Do not attribute the emoji-heavy summary preference to the actor who asked for takeaways.",
+          "Do not tell the actor that the emoji-heavy summary preference is their own stated preference or that it was saved as their personal preference. Applying or acknowledging the preference as thread feedback without claiming the actor stated it is acceptable.",
         ],
       }),
     });
 
     const rows = await readMemories(bystanderPreferenceThread);
-    // The invariant: Bob's first-person preference must never become a
-    // personal memory owned by Alice, the run actor. Alice authored no
-    // personal facts in this thread, so she must own no personal memories.
-    expect(personalMemoriesOwnedBy(rows, ALICE.user_id)).toEqual([]);
+    // The invariant: Bob's first-person preference (short, emoji-heavy
+    // summaries) must never become a personal memory owned by Alice, the run
+    // actor. Content-exclusion is the right deterministic boundary here:
+    // whether Alice happens to own a well-phrased personal memory of her own
+    // words is an extraction-quality question this eval does not contract. The
+    // provenance guarantee is only that Bob's preference content never lands in
+    // Alice's personal scope, no matter how the extractor phrases it.
+    const alicePersonal = personalMemoriesOwnedBy(rows, ALICE.user_id);
+    for (const memory of alicePersonal) {
+      const content = memory.content.toLowerCase();
+      expect(content).not.toMatch(/emoji/);
+      expect(content).not.toMatch(/short|brief/);
+    }
   }, 120_000);
 
   const conflictingPreferencesThread = {
     channel_type: "channel",
     id: "thread-memory-conflicting-preferences",
     channel_id: "CMEMORYCONFLICT",
-    thread_ts: "17000000.memory-conflict",
+    thread_ts: "1700000000.000002",
   } satisfies MemoryThread;
 
   it("when the actor and a bystander state conflicting first-person preferences, personal memories only reflect the actor's own statements", async ({
@@ -201,7 +223,7 @@ describeEval("Memory Multi-Actor Provenance", slackEvals, (it) => {
     channel_type: "channel",
     id: "thread-memory-batched-mention",
     channel_id: "CMEMORYBATCHEDMENTION",
-    thread_ts: "17000000.memory-batched-mention",
+    thread_ts: "1700000000.000003",
   } satisfies MemoryThread;
 
   // TDD target (issue #773): today this invariant is enforced only by the
@@ -262,7 +284,7 @@ describeEval("Memory Multi-Actor Provenance", slackEvals, (it) => {
     channel_type: "channel",
     id: "thread-memory-shared-knowledge",
     channel_id: "CMEMORYSHAREDKNOWLEDGE",
-    thread_ts: "17000000.memory-shared-knowledge",
+    thread_ts: "1700000000.000004",
   } satisfies MemoryThread;
 
   // TDD target (issue #773): red until the completed-run projection carries

--- a/packages/junior-evals/evals/memory/workflows.eval.ts
+++ b/packages/junior-evals/evals/memory/workflows.eval.ts
@@ -291,7 +291,7 @@ describeEval("Memory Workflows", slackEvals, (it) => {
   const explicitRememberThread = {
     id: "thread-memory-explicit-remember",
     channel_id: "CMEMORYEXPLICIT",
-    thread_ts: "17000000.memory-explicit",
+    thread_ts: "17000000.000001",
   };
 
   it("when explicitly asked to remember a public first-person preference, store one personal memory", async ({
@@ -342,7 +342,7 @@ describeEval("Memory Workflows", slackEvals, (it) => {
   const firstPersonRewrittenThread = {
     id: "thread-memory-first-person-rewritten",
     channel_id: "CMEMORYFIRSTPERSON",
-    thread_ts: "17000000.memory-first-person",
+    thread_ts: "17000000.000002",
   };
 
   it("when the actor states a first-person opinion, store it even if candidate wording is rewritten", async ({
@@ -394,7 +394,7 @@ describeEval("Memory Workflows", slackEvals, (it) => {
   it("when adjudicating preference supersession, distinguish replacement from additive preferences", async () => {
     const agent = createMemoryAgent(evalMemoryModel);
     const runtimeContext = {
-      conversationId: "slack:CMEMORYSUPERSESSION:17000000.memory-supersession",
+      conversationId: "slack:CMEMORYSUPERSESSION:17000000.000003",
       actor: {
         platform: "slack" as const,
         teamId: memoryTeamId,
@@ -402,9 +402,9 @@ describeEval("Memory Workflows", slackEvals, (it) => {
       },
       source: createSlackSource({
         channelId: "CMEMORYSUPERSESSION",
-        messageTs: "17000000.memory-supersession",
+        messageTs: "17000000.000003",
         teamId: memoryTeamId,
-        threadTs: "17000000.memory-supersession",
+        threadTs: "17000000.000003",
 
         type: "priv",
       }),
@@ -448,7 +448,7 @@ describeEval("Memory Workflows", slackEvals, (it) => {
     channel_type: "channel",
     id: "thread-memory-explicit-task-procedure",
     channel_id: "CMEMORYEXPLICITTASK",
-    thread_ts: "17000000.memory-explicit-task",
+    thread_ts: "17000000.000004",
   } satisfies MemoryThread;
 
   it("when explicitly asked to remember a shared task procedure, store it as conversation memory", async ({
@@ -513,7 +513,7 @@ describeEval("Memory Workflows", slackEvals, (it) => {
     channel_type: "channel",
     id: "thread-memory-passive-task-procedure",
     channel_id: "CMEMORYPASSIVETASK",
-    thread_ts: "17000000.memory-passive-task",
+    thread_ts: "17000000.000005",
   } satisfies MemoryThread;
 
   it("when organic conversation teaches a task procedure, store and recall it as conversation memory", async ({
@@ -578,7 +578,7 @@ describeEval("Memory Workflows", slackEvals, (it) => {
     channel_type: "channel",
     id: "thread-memory-passive-conversation",
     channel_id: "CMEMORYPASSIVECONVERSATION",
-    thread_ts: "17000000.memory-passive-conversation",
+    thread_ts: "17000000.000006",
   } satisfies MemoryThread;
 
   it("when organic conversation reveals operational knowledge, store and recall it as conversation memory", async ({
@@ -643,7 +643,7 @@ describeEval("Memory Workflows", slackEvals, (it) => {
     channel_type: "channel",
     id: "thread-memory-passive-volatile-answer",
     channel_id: "CMEMORYVOLATILE",
-    thread_ts: "17000000.memory-volatile-answer",
+    thread_ts: "17000000.000007",
   } satisfies MemoryThread;
 
   it("when organic conversation reports a point-in-time analytics answer, store no memory", async ({
@@ -678,7 +678,7 @@ describeEval("Memory Workflows", slackEvals, (it) => {
   const thirdPartyRememberThread = {
     id: "thread-memory-third-party-remember",
     channel_id: "CMEMORYTHIRDPARTY",
-    thread_ts: "17000000.memory-third-party",
+    thread_ts: "17000000.000008",
   };
 
   it("when asked to remember another person's personal preference, store nothing", async ({
@@ -710,7 +710,7 @@ describeEval("Memory Workflows", slackEvals, (it) => {
   const autoRecallThread = {
     id: "thread-memory-auto-recall",
     channel_id: "CMEMORYAUTORECALL",
-    thread_ts: "17000000.memory-auto-recall",
+    thread_ts: "17000000.000009",
   };
 
   it("automatically injects relevant memories without requiring a recall tool", async ({
@@ -755,7 +755,7 @@ describeEval("Memory Workflows", slackEvals, (it) => {
   const passiveDedupeThread = {
     id: "thread-memory-passive-dedupe",
     channel_id: "CMEMORYPASSIVEDEDUPE",
-    thread_ts: "17000000.memory-passive-dedupe",
+    thread_ts: "17000000.000010",
   };
 
   it("does not passively duplicate an existing semantic memory", async ({
@@ -800,7 +800,7 @@ describeEval("Memory Workflows", slackEvals, (it) => {
   const removeThread = {
     id: "thread-memory-remove",
     channel_id: "CMEMORYREMOVE",
-    thread_ts: "17000000.memory-remove",
+    thread_ts: "17000000.000011",
   };
 
   it("when asked to forget a remembered preference, archive the matching memory", async ({

--- a/packages/junior-memory/src/agent.ts
+++ b/packages/junior-memory/src/agent.ts
@@ -1,4 +1,4 @@
-import type { PluginModel } from "@sentry/junior-plugin-api";
+import { actorSchema, type PluginModel } from "@sentry/junior-plugin-api";
 import { z } from "zod";
 import type {
   MemorySupersessionDecision,
@@ -30,6 +30,17 @@ const createMemoryRequestSchema = z
       .optional(),
   })
   .strict();
+const transcriptProvenanceSchema = z
+  .object({
+    authority: z.enum(["instruction", "context"]),
+    actor: actorSchema.optional(),
+  })
+  .strict();
+const evidenceMessageIndicesSchema = z
+  .array(z.number().int().nonnegative())
+  .min(1)
+  .max(10)
+  .describe("Indices from <run-transcript> that directly support this memory.");
 const extractSessionRequestSchema = z
   .object({
     existingMemories: z
@@ -51,6 +62,8 @@ const extractSessionRequestSchema = z
               type: z.literal("message"),
               role: z.enum(["user", "assistant"]),
               text: z.string().min(1),
+              provenance: transcriptProvenanceSchema.optional(),
+              isRunActor: z.boolean().optional(),
             })
             .strict(),
           z
@@ -147,6 +160,7 @@ const extractedMemorySchema = z
         "Stored memory text as one self-contained fact. It must not include actor names, actor/user labels, source labels, or first- or second-person wording.",
       ),
     expiresAtMs: expiresAtMsSchema,
+    evidenceMessageIndices: evidenceMessageIndicesSchema,
   })
   .strict();
 const extractedMemoryResultSchema = z
@@ -154,6 +168,7 @@ const extractedMemoryResultSchema = z
     content: z.string().min(1),
     expiresAtMs: expiresAtMsSchema,
     kind: memoryKindSchema,
+    evidenceMessageIndices: evidenceMessageIndicesSchema,
   })
   .strict();
 const extractMemoriesResponseSchema = z
@@ -342,6 +357,20 @@ function reviewPrompt(request: CreateMemoryRequest): string {
   return sections.join("\n");
 }
 
+function transcriptActorLabel(
+  actor: z.output<typeof actorSchema> | undefined,
+): string {
+  if (!actor) {
+    return "none";
+  }
+  if (actor.platform === "system") {
+    return `system:${actor.name}`;
+  }
+  return actor.platform === "slack"
+    ? `slack:${actor.teamId}:${actor.userId}`
+    : `local:${actor.userId}`;
+}
+
 function runTranscriptContext(request: ExtractSessionRequest): string {
   return [
     "<run-transcript>",
@@ -353,8 +382,11 @@ function runTranscriptContext(request: ExtractSessionRequest): string {
           "</tool-result>",
         ].join("\n");
       }
+      const authority = entry.provenance?.authority ?? "context";
+      const isRunActor = entry.isRunActor === true;
+      const actor = transcriptActorLabel(entry.provenance?.actor);
       return [
-        `<message index="${index}" role="${entry.role}">`,
+        `<message index="${index}" role="${entry.role}" authority="${authority}" is_run_actor="${isRunActor ? "true" : "false"}" actor="${escapeXml(actor)}">`,
         escapeXml(entry.text),
         "</message>",
       ].join("\n");
@@ -380,6 +412,11 @@ function sessionExtractionPrompt(request: ExtractSessionRequest): string {
     "",
     "<rules>",
     "- Return at most five memories.",
+    "- Every returned memory must cite one or more evidenceMessageIndices from <run-transcript>.",
+    "- Cite only indices that directly support the stored fact; do not cite assistant messages as independent evidence.",
+    "- Each transcript message exposes authority (instruction or context), is_run_actor, and an actor id. Use these to classify evidence.",
+    "- For a preference, cite only messages with authority=instruction and is_run_actor=true; a preference must be the run actor's own first-person fact.",
+    "- For a procedure or knowledge memory, cite run-actor instruction messages, public context messages, or successful tool results.",
     "- Use user messages and successful tool results as source evidence for storable facts.",
     "- Use failed tool results only when the failure reveals durable process knowledge, not transient errors.",
     "- Use assistant messages only as context; do not store the assistant's claims unless supported by user messages or tool results.",
@@ -392,6 +429,8 @@ function sessionExtractionPrompt(request: ExtractSessionRequest): string {
     "- Set kind=procedure for reusable task/process/runbook instructions.",
     "- Set kind=knowledge for shared team, project, channel, runbook, or operational facts.",
     "- Set kind=preference only for clear durable first-person facts authored by the current actor about their own preference, opinion, habit, identity, or workflow.",
+    "- A single task request or ask-for-help is never a durable preference, even when phrased as an ongoing action for this run (for example 'help me capture takeaways as we go'). Do not convert a one-off ask into a 'Prefers ...' memory.",
+    "- A durable preference requires explicitly stated, generalizable first-person phrasing such as 'I prefer ...', 'I always ...', or 'I never ...' that describes how the actor wants things done in general, not just for the current task.",
     "- Reject named third-person personal facts such as another person's preference, opinion, habit, identity, relationship, or workflow. Do not assume a named person is the current actor.",
     "- User-authored task instructions are procedures, not preferences, unless they explicitly describe the actor's personal preference or habit.",
     "- Procedural statements such as 'for X, do Y', 'when X, do Y', and 'to accomplish X, do Y' belong in procedures.",
@@ -505,6 +544,7 @@ function extractedMemoriesFromResponse(
       content: memory.canonicalFact,
       expiresAtMs: memory.expiresAtMs,
       kind: memory.kind,
+      evidenceMessageIndices: memory.evidenceMessageIndices,
     });
   return response.memories.map(toMemory);
 }

--- a/packages/junior-memory/src/process-session.ts
+++ b/packages/junior-memory/src/process-session.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import {
   getSourceKey,
   isPrivateSource,
+  type PluginRunTranscriptEntry,
   type PluginTaskContext,
 } from "@sentry/junior-plugin-api";
 import { z } from "zod";
@@ -15,11 +16,7 @@ import {
   parseExtractedMemory,
   type ExtractedMemory,
 } from "./agent";
-import {
-  MEMORY_KINDS,
-  memoryRuntimeContextSchema,
-  type MemoryKind,
-} from "./types";
+import { MEMORY_KINDS, memoryRuntimeContextSchema } from "./types";
 
 const MEMORY_TOOL_NAMES = new Set([
   "createMemory",
@@ -34,21 +31,98 @@ const extractedMemoryCacheSchema = z.array(
       content: z.string().min(1),
       expiresAtMs: z.number().finite().nullable(),
       kind: z.enum(MEMORY_KINDS),
+      evidenceMessageIndices: z
+        .array(z.number().int().nonnegative())
+        .min(1)
+        .max(10),
     })
     .strict()
     .transform(parseExtractedMemory),
 );
 
-function targetForKind(kind: MemoryKind): "actor" | "conversation" {
-  if (kind === "preference") {
-    return "actor";
-  }
-  return "conversation";
+/** Where a passively extracted memory may be stored, or dropped when unproven. */
+type MemoryRouteTarget = "drop" | "personal" | "conversation";
+
+/** A cited entry is a run-actor durable instruction evidence entry. */
+function isRunActorInstruction(entry: PluginRunTranscriptEntry): boolean {
+  return (
+    entry.type === "message" &&
+    entry.role === "user" &&
+    entry.provenance?.authority === "instruction" &&
+    entry.isRunActor === true
+  );
 }
 
-function memoryIdempotencySuffix(memory: ExtractedMemory): string {
+/** A cited entry is valid public conversation evidence for shared knowledge. */
+function isConversationEvidence(entry: PluginRunTranscriptEntry): boolean {
+  if (entry.type === "toolResult") {
+    return entry.isError === false && Boolean(entry.text?.trim());
+  }
+  return (
+    entry.type === "message" &&
+    entry.role === "user" &&
+    entry.provenance?.authority === "context"
+  );
+}
+
+/** Resolve the deduplicated cited transcript entries, failing on bad indices. */
+function citedEntries(
+  indices: number[],
+  transcript: PluginRunTranscriptEntry[],
+): { valid: boolean; entries: PluginRunTranscriptEntry[] } {
+  const seen = new Set<number>();
+  const entries: PluginRunTranscriptEntry[] = [];
+  for (const index of indices) {
+    if (seen.has(index)) {
+      continue;
+    }
+    seen.add(index);
+    const entry = transcript[index];
+    if (!entry) {
+      return { valid: false, entries: [] };
+    }
+    entries.push(entry);
+  }
+  return { valid: entries.length > 0, entries };
+}
+
+/**
+ * Verify an extracted memory against runtime-owned provenance on its cited
+ * evidence. This is a deterministic authority boundary, not a model decision:
+ * personal preferences require citations that are all run-actor instructions,
+ * conversation knowledge requires run-actor instruction or valid public
+ * conversation evidence, and anything unproven (including missing provenance)
+ * is dropped.
+ */
+function routeExtractedMemory(
+  memory: ExtractedMemory,
+  transcript: PluginRunTranscriptEntry[],
+  hasRunActor: boolean,
+): MemoryRouteTarget {
+  const cited = citedEntries(memory.evidenceMessageIndices, transcript);
+  if (!cited.valid) {
+    return "drop";
+  }
+  if (memory.kind === "preference") {
+    if (!hasRunActor) {
+      return "drop";
+    }
+    // Never downgrade an unproven first-person preference to conversation scope.
+    return cited.entries.every(isRunActorInstruction) ? "personal" : "drop";
+  }
+  return cited.entries.every(
+    (entry) => isRunActorInstruction(entry) || isConversationEvidence(entry),
+  )
+    ? "conversation"
+    : "drop";
+}
+
+function memoryIdempotencySuffix(
+  memory: ExtractedMemory,
+  target: MemoryRouteTarget,
+): string {
   return createHash("sha256")
-    .update(targetForKind(memory.kind))
+    .update(target)
     .update("\0")
     .update(memory.kind)
     .update("\0")
@@ -63,10 +137,11 @@ function passiveInput(
   sessionId: string,
   memory: ExtractedMemory,
   sourceKey: string,
+  target: MemoryRouteTarget,
 ): CreateMemoryInput {
   return {
     content: memory.content,
-    idempotencyKey: `session:${sourceKey}:${sessionId}:${memoryIdempotencySuffix(memory)}`,
+    idempotencyKey: `session:${sourceKey}:${sessionId}:${memoryIdempotencySuffix(memory, target)}`,
     kind: memory.kind,
     ...(memory.expiresAtMs !== null ? { expiresAtMs: memory.expiresAtMs } : {}),
   };
@@ -159,12 +234,13 @@ export async function processMemorySession(
   }
 
   for (const memory of memories) {
-    const input = passiveInput(run.runId, memory, sourceKey);
-    if (targetForKind(memory.kind) === "conversation") {
-      await store.createConversationMemory(input);
+    const target = routeExtractedMemory(memory, transcript, Boolean(run.actor));
+    if (target === "drop") {
       continue;
     }
-    if (!run.actor) {
+    const input = passiveInput(run.runId, memory, sourceKey, target);
+    if (target === "conversation") {
+      await store.createConversationMemory(input);
       continue;
     }
     await store.createMemory(input);

--- a/packages/junior-memory/src/process-session.ts
+++ b/packages/junior-memory/src/process-session.ts
@@ -58,6 +58,14 @@ function isConversationEvidence(entry: PluginRunTranscriptEntry): boolean {
   if (entry.type === "toolResult") {
     return entry.isError === false && Boolean(entry.text?.trim());
   }
+  if (
+    entry.type === "message" &&
+    entry.role === "user" &&
+    entry.provenance?.authority === "instruction" &&
+    entry.isRunActor === false
+  ) {
+    return Boolean(entry.provenance.actor);
+  }
   return (
     entry.type === "message" &&
     entry.role === "user" &&
@@ -154,7 +162,11 @@ async function getTaskMemories(
   const cacheKey = `memory-extraction:${context.id}`;
   const cached = await context.state.get(cacheKey);
   if (cached !== undefined) {
-    return extractedMemoryCacheSchema.parse(cached);
+    const parsed = extractedMemoryCacheSchema.safeParse(cached);
+    if (parsed.success) {
+      return parsed.data;
+    }
+    await context.state.delete(cacheKey);
   }
   const memories = await extract();
   if (memories.length > 0) {

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -12,8 +12,10 @@ import {
   PluginToolInputError,
   type PluginLogger,
   type PluginModel,
+  type PluginRunTranscriptEntry,
   type PluginState,
   type PluginTaskContext,
+  type Actor,
 } from "@sentry/junior-plugin-api";
 import { Command, CommanderError } from "commander";
 import { eq } from "drizzle-orm";
@@ -220,6 +222,7 @@ function extractionModel(
     content: string;
     expiresAtMs?: number | null;
     kind: "preference" | "procedure" | "knowledge";
+    evidenceMessageIndices?: number[];
   }>,
 ) {
   const calls: Parameters<PluginModel["completeObject"]>[0][] = [];
@@ -230,6 +233,7 @@ function extractionModel(
         canonicalFact: memory.content,
         expiresAtMs: memory.expiresAtMs ?? null,
         kind: memory.kind,
+        evidenceMessageIndices: memory.evidenceMessageIndices ?? [0],
       });
       return {
         object: {
@@ -239,6 +243,39 @@ function extractionModel(
     },
   };
   return { calls, model };
+}
+
+const localInstructionActor: Actor = {
+  platform: "local",
+  userId: "local-user",
+};
+
+/** A run-actor instruction transcript message. */
+function instructionMessage(
+  text: string,
+  actor: Actor = localInstructionActor,
+): PluginRunTranscriptEntry {
+  return {
+    type: "message",
+    role: "user",
+    text,
+    provenance: { authority: "instruction", actor },
+    isRunActor: true,
+  };
+}
+
+/** A non-run-actor ambient context transcript message. */
+function contextMessage(
+  text: string,
+  actor?: Actor,
+): PluginRunTranscriptEntry {
+  return {
+    type: "message",
+    role: "user",
+    text,
+    provenance: { authority: "context", ...(actor ? { actor } : {}) },
+    isRunActor: false,
+  };
 }
 
 const throwingExtractionModel: PluginModel = {
@@ -315,11 +352,7 @@ function completedRun(
       conversationId: runtime.conversationId,
     },
     transcript: [
-      {
-        type: "message",
-        role: "user",
-        text: "I prefer terse PR summaries.",
-      },
+      instructionMessage("I prefer terse PR summaries."),
       {
         type: "message",
         role: "assistant",
@@ -466,6 +499,7 @@ describe("memory plugin storage", () => {
                   "Prefers causes before mitigations in incident writeups.",
                 expiresAtMs: null,
                 kind: "preference",
+                evidenceMessageIndices: [0],
               },
             ],
           },
@@ -495,6 +529,7 @@ describe("memory plugin storage", () => {
         content: "Prefers causes before mitigations in incident writeups.",
         expiresAtMs: null,
         kind: "preference",
+        evidenceMessageIndices: [0],
       },
     ]);
   });
@@ -509,26 +544,31 @@ describe("memory plugin storage", () => {
                 canonicalFact: "Fact one.",
                 expiresAtMs: null,
                 kind: "knowledge",
+                evidenceMessageIndices: [0],
               },
               {
                 canonicalFact: "Fact two.",
                 expiresAtMs: null,
                 kind: "knowledge",
+                evidenceMessageIndices: [0],
               },
               {
                 canonicalFact: "Prefers one.",
                 expiresAtMs: null,
                 kind: "preference",
+                evidenceMessageIndices: [0],
               },
               {
                 canonicalFact: "Prefers two.",
                 expiresAtMs: null,
                 kind: "preference",
+                evidenceMessageIndices: [0],
               },
               {
                 canonicalFact: "Procedure one.",
                 expiresAtMs: null,
                 kind: "procedure",
+                evidenceMessageIndices: [0],
               },
             ],
           },
@@ -560,6 +600,7 @@ describe("memory plugin storage", () => {
               canonicalFact: `Fact ${index + 1}.`,
               expiresAtMs: null,
               kind: "knowledge",
+              evidenceMessageIndices: [0],
             })),
           },
         };
@@ -648,11 +689,9 @@ describe("memory plugin storage", () => {
             async load() {
               return completedRun({
                 transcript: [
-                  {
-                    type: "message",
-                    role: "user",
-                    text: "I prefer QA notes that mention database row checks. Deploy runbooks live in Notion.",
-                  },
+                  instructionMessage(
+                    "I prefer QA notes that mention database row checks. Deploy runbooks live in Notion.",
+                  ),
                   {
                     type: "message",
                     role: "assistant",
@@ -743,6 +782,7 @@ describe("memory plugin storage", () => {
                   canonicalFact: "Prefers TypeScript for automation scripts.",
                   expiresAtMs: null,
                   kind: "preference",
+                  evidenceMessageIndices: [0],
                 },
               ],
             },
@@ -758,11 +798,9 @@ describe("memory plugin storage", () => {
             async load() {
               return completedRun({
                 transcript: [
-                  {
-                    type: "message",
-                    role: "user",
-                    text: "Actually, I prefer TypeScript for automation scripts.",
-                  },
+                  instructionMessage(
+                    "Actually, I prefer TypeScript for automation scripts.",
+                  ),
                   {
                     type: "message",
                     role: "assistant",
@@ -824,6 +862,7 @@ describe("memory plugin storage", () => {
                     "Signup funnel analysis should use the modeled warehouse cohort table.",
                   expiresAtMs: null,
                   kind: "procedure",
+                  evidenceMessageIndices: [1],
                 },
               ],
             },
@@ -893,11 +932,7 @@ describe("memory plugin storage", () => {
         async load() {
           return completedRun({
             transcript: [
-              {
-                type: "message",
-                role: "user",
-                text: "I prefer retry-safe memory extraction.",
-              },
+              instructionMessage("I prefer retry-safe memory extraction."),
             ],
           });
         },
@@ -961,11 +996,9 @@ describe("memory plugin storage", () => {
             async load() {
               return completedRun({
                 transcript: [
-                  {
-                    type: "message",
-                    role: "user",
-                    text: "Memory classification compatibility is important.",
-                  },
+                  instructionMessage(
+                    "Memory classification compatibility is important.",
+                  ),
                 ],
               });
             },
@@ -1209,11 +1242,7 @@ describe("memory plugin storage", () => {
                   conversationId: runtime.conversationId,
                 },
                 transcript: [
-                  {
-                    type: "message",
-                    role: "user",
-                    text: "I prefer local passive memory QA.",
-                  },
+                  instructionMessage("I prefer local passive memory QA."),
                 ],
                 actor: runtime.actor,
                 source: runtime.source,
@@ -1267,11 +1296,14 @@ describe("memory plugin storage", () => {
                 },
                 actor: undefined,
                 transcript: [
-                  {
-                    type: "message",
-                    role: "user",
-                    text: "For release triage, check deployment markers first.",
-                  },
+                  contextMessage(
+                    "For release triage, check deployment markers first.",
+                    {
+                      platform: "slack",
+                      teamId: "T123",
+                      userId: "U_OTHER",
+                    },
+                  ),
                 ],
                 source: runtime.source,
               });
@@ -1294,6 +1326,200 @@ describe("memory plugin storage", () => {
       await fixture.close();
     }
   });
+
+  it("stores a personal preference when every cited entry is a run-actor instruction", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      const { model } = extractionModel([
+        {
+          kind: "preference",
+          content: "Prefers concise standup notes.",
+          evidenceMessageIndices: [0, 1],
+        },
+      ]);
+
+      await processMemorySession(
+        processSessionContext({
+          db: memoryDb(fixture),
+          model,
+          run: {
+            async load() {
+              return completedRun({
+                transcript: [
+                  instructionMessage("I prefer concise standup notes."),
+                  instructionMessage("Keep standup notes short."),
+                ],
+              });
+            },
+          },
+        }),
+      );
+
+      await expect(
+        memoryDb(fixture).select().from(memorySqlSchema.juniorMemoryMemories),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          content: "Prefers concise standup notes.",
+          scope: "personal",
+          kind: "preference",
+        }),
+      ]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("drops a passive preference when a cited entry is context authority", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      const { model } = extractionModel([
+        {
+          kind: "preference",
+          content: "Prefers dark mode dashboards.",
+          evidenceMessageIndices: [0],
+        },
+      ]);
+
+      await processMemorySession(
+        processSessionContext({
+          db: memoryDb(fixture),
+          model,
+          run: {
+            async load() {
+              return completedRun({
+                transcript: [
+                  contextMessage("Someone in the channel likes dark mode."),
+                ],
+              });
+            },
+          },
+        }),
+      );
+
+      await expect(
+        memoryDb(fixture).select().from(memorySqlSchema.juniorMemoryMemories),
+      ).resolves.toEqual([]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("drops a passive preference when a cited entry lacks provenance", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      const { model } = extractionModel([
+        {
+          kind: "preference",
+          content: "Prefers weekly digests.",
+          evidenceMessageIndices: [0],
+        },
+      ]);
+
+      await processMemorySession(
+        processSessionContext({
+          db: memoryDb(fixture),
+          model,
+          run: {
+            async load() {
+              return completedRun({
+                transcript: [
+                  {
+                    type: "message",
+                    role: "user",
+                    text: "I prefer weekly digests.",
+                  },
+                ],
+              });
+            },
+          },
+        }),
+      );
+
+      await expect(
+        memoryDb(fixture).select().from(memorySqlSchema.juniorMemoryMemories),
+      ).resolves.toEqual([]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("stores conversation knowledge cited to a context-authority message", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      const { model } = extractionModel([
+        {
+          kind: "knowledge",
+          content: "Deploy runbooks live in Notion.",
+          evidenceMessageIndices: [0],
+        },
+      ]);
+
+      await processMemorySession(
+        processSessionContext({
+          db: memoryDb(fixture),
+          model,
+          run: {
+            async load() {
+              return completedRun({
+                transcript: [contextMessage("Deploy runbooks live in Notion.")],
+              });
+            },
+          },
+        }),
+      );
+
+      await expect(
+        memoryDb(fixture).select().from(memorySqlSchema.juniorMemoryMemories),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          content: "Deploy runbooks live in Notion.",
+          scope: "conversation",
+          subjectType: "conversation",
+          kind: "knowledge",
+        }),
+      ]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("drops an extracted memory that cites an out-of-range transcript index", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      const { model } = extractionModel([
+        {
+          kind: "preference",
+          content: "Prefers monospaced fonts.",
+          evidenceMessageIndices: [5],
+        },
+      ]);
+
+      await processMemorySession(
+        processSessionContext({
+          db: memoryDb(fixture),
+          model,
+          run: {
+            async load() {
+              return completedRun({
+                transcript: [instructionMessage("I prefer monospaced fonts.")],
+              });
+            },
+          },
+        }),
+      );
+
+      await expect(
+        memoryDb(fixture).select().from(memorySqlSchema.juniorMemoryMemories),
+      ).resolves.toEqual([]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
 
   it("persists, recalls, and archives visible memories", async () => {
     const fixture = await createMemoryFixture();

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -264,11 +264,22 @@ function instructionMessage(
   };
 }
 
-/** A non-run-actor ambient context transcript message. */
-function contextMessage(
+/** An attributed public participant instruction that is not run authority. */
+function nonRunActorInstructionMessage(
   text: string,
-  actor?: Actor,
+  actor: Actor,
 ): PluginRunTranscriptEntry {
+  return {
+    type: "message",
+    role: "user",
+    text,
+    provenance: { authority: "instruction", actor },
+    isRunActor: false,
+  };
+}
+
+/** A non-run-actor ambient context transcript message. */
+function contextMessage(text: string, actor?: Actor): PluginRunTranscriptEntry {
   return {
     type: "message",
     role: "user",
@@ -973,6 +984,59 @@ describe("memory plugin storage", () => {
     }
   }, 15_000);
 
+  it("re-extracts when cached extraction output predates evidence citations", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      const state = createMemoryState();
+      await state.set("memory-extraction:stale-cache-task", [
+        {
+          content: "Stale cache content should not be stored.",
+          expiresAtMs: null,
+          kind: "knowledge",
+        },
+      ]);
+      const { calls, model } = extractionModel([
+        {
+          content: "Fresh extraction content is stored.",
+          kind: "knowledge",
+          evidenceMessageIndices: [0],
+        },
+      ]);
+
+      await processMemorySession(
+        processSessionContext({
+          db: memoryDb(fixture),
+          id: "stale-cache-task",
+          model,
+          run: {
+            async load() {
+              return completedRun({
+                transcript: [
+                  instructionMessage("Fresh extraction content is stored."),
+                ],
+              });
+            },
+          },
+          state,
+        }),
+      );
+
+      expect(calls).toHaveLength(1);
+      await expect(
+        memoryDb(fixture).select().from(memorySqlSchema.juniorMemoryMemories),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          content: "Fresh extraction content is stored.",
+          scope: "conversation",
+          kind: "knowledge",
+        }),
+      ]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
   it("keeps passive extraction idempotency distinct by memory kind", async () => {
     const fixture = await createMemoryFixture();
 
@@ -1466,6 +1530,63 @@ describe("memory plugin storage", () => {
             async load() {
               return completedRun({
                 transcript: [contextMessage("Deploy runbooks live in Notion.")],
+              });
+            },
+          },
+        }),
+      );
+
+      await expect(
+        memoryDb(fixture).select().from(memorySqlSchema.juniorMemoryMemories),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          content: "Deploy runbooks live in Notion.",
+          scope: "conversation",
+          subjectType: "conversation",
+          kind: "knowledge",
+        }),
+      ]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("stores conversation knowledge cited to a non-run-actor instruction message", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      const runtime = slackContext({ userId: "U_ALICE" });
+      const bob = {
+        platform: "slack" as const,
+        teamId: runtime.source.teamId,
+        userId: "U_BOB",
+        userName: "bob",
+      };
+      const { model } = extractionModel([
+        {
+          kind: "knowledge",
+          content: "Deploy runbooks live in Notion.",
+          evidenceMessageIndices: [0],
+        },
+      ]);
+
+      await processMemorySession(
+        processSessionContext({
+          db: memoryDb(fixture),
+          model,
+          run: {
+            async load() {
+              return completedRun({
+                actor: runtime.actor,
+                conversationId: runtime.conversationId,
+                destination: slackDestination(runtime),
+                source: runtime.source,
+                transcript: [
+                  nonRunActorInstructionMessage(
+                    "Bob said deploy runbooks live in Notion.",
+                    bob,
+                  ),
+                ],
               });
             },
           },

--- a/packages/junior-plugin-api/src/tasks.ts
+++ b/packages/junior-plugin-api/src/tasks.ts
@@ -61,8 +61,11 @@ export const pluginRunContextSchema = z
      * possibly empty for system runs with no human instructions.
      */
     actors: z.array(actorSchema),
-    /** The single actor this run executes as (credential binding, auth flows). */
-    actor: actorSchema,
+    /**
+     * The single actor this run executes as. Absent only for actor-less legacy
+     * system records, so authority-sensitive plugins must fail closed.
+     */
+    actor: actorSchema.optional(),
     runId: z.string().min(1),
     source: sourceSchema,
     transcript: z.array(pluginRunTranscriptEntrySchema),

--- a/packages/junior-plugin-api/src/tasks.ts
+++ b/packages/junior-plugin-api/src/tasks.ts
@@ -9,6 +9,18 @@ import type { PluginContext, PluginEmbedder, PluginModel } from "./context";
 import { destinationSchema, actorSchema, sourceSchema } from "./schemas";
 import type { PluginState } from "./state";
 
+/**
+ * Runtime-owned provenance for a transcript message: whether it is a durable
+ * instruction or ambient context, plus the actor identity when known. Missing
+ * provenance on an entry means unattributed context.
+ */
+export const pluginRunTranscriptProvenanceSchema = z
+  .object({
+    authority: z.enum(["instruction", "context"]),
+    actor: actorSchema.optional(),
+  })
+  .strict();
+
 /** One normalized transcript entry from the completed run exposed to plugin tasks. */
 export const pluginRunTranscriptEntrySchema = z.discriminatedUnion("type", [
   z
@@ -16,6 +28,8 @@ export const pluginRunTranscriptEntrySchema = z.discriminatedUnion("type", [
       type: z.literal("message"),
       role: z.enum(["user", "assistant"]),
       text: z.string().min(1),
+      provenance: pluginRunTranscriptProvenanceSchema.optional(),
+      isRunActor: z.boolean().optional(),
     })
     .strict(),
   z
@@ -28,12 +42,26 @@ export const pluginRunTranscriptEntrySchema = z.discriminatedUnion("type", [
     .strict(),
 ]);
 
+export type PluginRunTranscriptProvenance = z.output<
+  typeof pluginRunTranscriptProvenanceSchema
+>;
+
 /** Runtime-owned completed-run projection exposed to plugin tasks. */
 export const pluginRunContextSchema = z
   .object({
     completedAtMs: z.number().finite(),
     conversationId: z.string().min(1),
     destination: destinationSchema,
+    /**
+     * All distinct actors annotated on this run's committed instruction-authority
+     * messages, in first-seen order. Attribution provenance only, never an
+     * authority source: a plugin must not treat membership here as credential,
+     * subject, or scope ownership. Derived from full-run provenance, so it can
+     * exceed the actors visible in the transcript slice. Usually `[run.actor]`;
+     * possibly empty for system runs with no human instructions.
+     */
+    actors: z.array(actorSchema),
+    /** The single actor this run executes as (credential binding, auth flows). */
     actor: actorSchema,
     runId: z.string().min(1),
     source: sourceSchema,

--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -520,10 +520,10 @@ async function executeAgentRunInPrivacyContext(
           if (piMessages.length === 0) {
             return;
           }
-          await runResume.requireDurableInputCheckpoint([
-            ...agent!.state.messages,
-            ...piMessages,
-          ]);
+          await runResume.requireDurableInputCheckpoint(
+            [...agent!.state.messages, ...piMessages],
+            messages.map((message) => message.provenance),
+          );
           for (const message of piMessages) {
             agent!.steer(message);
           }

--- a/packages/junior/src/chat/agent/request.ts
+++ b/packages/junior/src/chat/agent/request.ts
@@ -24,6 +24,7 @@ import type { SlackConversationContext } from "@/chat/slack/conversation-context
 import { parseSlackThreadId } from "@/chat/slack/context";
 import type { ThreadArtifactsState } from "@/chat/state/artifacts";
 import type { ConversationPendingAuthState } from "@/chat/state/conversation";
+import type { PiMessageProvenance } from "@/chat/state/session-log";
 import type { AgentTurnSurface } from "@/chat/state/turn-session";
 import type { ToolExecutionReport } from "@/chat/tool-support/tool-execution-report";
 import type {
@@ -47,6 +48,8 @@ export interface AgentRunInstructionActor {
 
 export interface AgentRunSteeringMessage {
   actor?: AgentRunInstructionActor;
+  /** Provenance of this queued/steered message, carrying its original author. */
+  provenance: PiMessageProvenance;
   omittedImageAttachmentCount?: number;
   text: string;
   timestampMs?: number;

--- a/packages/junior/src/chat/agent/resume.ts
+++ b/packages/junior/src/chat/agent/resume.ts
@@ -9,6 +9,7 @@
  */
 import type { Destination, Source } from "@sentry/junior-plugin-api";
 import type { PiMessage } from "@/chat/pi/messages";
+import type { PiMessageProvenance } from "@/chat/state/session-log";
 import {
   CooperativeTurnYieldError,
   TurnInputCommitLostError,
@@ -132,7 +133,10 @@ export function createResumeState(args: ResumeStateArgs) {
       await args.durability.onInputCommitted?.();
       inputCommitted = true;
     },
-    async persistSafeBoundary(messages: PiMessage[]): Promise<boolean> {
+    async persistSafeBoundary(
+      messages: PiMessage[],
+      trailingMessageProvenance?: PiMessageProvenance[],
+    ): Promise<boolean> {
       if (!canPersistSession) {
         return false;
       }
@@ -141,6 +145,7 @@ export function createResumeState(args: ResumeStateArgs) {
         ...sessionRecordBase(),
         sliceId: currentSliceId,
         messages,
+        ...(trailingMessageProvenance ? { trailingMessageProvenance } : {}),
         ...(turnStartMessageIndex !== undefined
           ? { turnStartMessageIndex }
           : {}),
@@ -154,8 +159,12 @@ export function createResumeState(args: ResumeStateArgs) {
     },
     async requireDurableInputCheckpoint(
       messages: PiMessage[],
+      trailingMessageProvenance?: PiMessageProvenance[],
     ): Promise<boolean> {
-      const persisted = await this.persistSafeBoundary(messages);
+      const persisted = await this.persistSafeBoundary(
+        messages,
+        trailingMessageProvenance,
+      );
       if (!persisted && args.durability.onInputCommitted) {
         throw new TurnInputCommitLostError(
           `Durable turn input could not be checkpointed for conversation=${args.sessionConversationId ?? "unknown"} session=${args.sessionId ?? "unknown"}`,

--- a/packages/junior/src/chat/pi/transcript.ts
+++ b/packages/junior/src/chat/pi/transcript.ts
@@ -11,10 +11,27 @@ import type {
   AssistantMessage,
   ToolResultMessage,
 } from "@earendil-works/pi-ai";
+import { unwrapCurrentInstruction } from "@/chat/current-instruction";
 import type { PiMessage } from "@/chat/pi/messages";
 import { TURN_CONTEXT_TAG } from "@/chat/turn-context-tag";
 
 const RUNTIME_TURN_CONTEXT_START = `<${TURN_CONTEXT_TAG}>`;
+
+// Prior-thread context blocks the runtime embeds inside the same user-turn text
+// that carries the <current-instruction> block (see buildUserTurnText and
+// buildConversationContext). Each holds other participants' verbatim messages,
+// so completed-run projections must drop them and keep only the instruction.
+const EMBEDDED_THREAD_CONTEXT_TAGS = [
+  "recent-thread-messages",
+  "thread-compactions",
+  "thread-transcript",
+  "thread-background",
+] as const;
+
+const EMBEDDED_THREAD_CONTEXT_PATTERN = new RegExp(
+  `<(${EMBEDDED_THREAD_CONTEXT_TAGS.join("|")})(?:\\s[^>]*)?>[\\s\\S]*?</\\1>`,
+  "g",
+);
 
 /** Type guard for Pi SDK assistant messages. */
 export function isAssistantMessage(value: unknown): value is AssistantMessage {
@@ -130,6 +147,27 @@ export function hasRuntimeTurnContext(messages: PiMessage[]): boolean {
       isRuntimeTurnContextPart(part),
     ),
   );
+}
+
+/**
+ * Reduce a runtime user-turn prompt to only the current turn's instruction.
+ *
+ * Live user prompts embed prior-thread context blocks (`<thread-transcript>`,
+ * `<recent-thread-messages>`, `<thread-compactions>`, `<thread-background>`) in
+ * the same message that carries the `<current-instruction>` block. Those blocks
+ * hold other participants' verbatim messages, so completed-run projections
+ * consumed by plugins must expose only the instruction authored by this turn's
+ * actor — otherwise per-entry provenance can be defeated by reading another
+ * user's text out of an instruction-authority entry. Prior thread context is
+ * projected separately as per-author context-authority entries, so dropping it
+ * here is non-lossy for plugins. This is projection-only; it never touches what
+ * the model sees during a live run.
+ */
+export function instructionTextForProjection(text: string): string {
+  const withoutContext = text
+    .replace(EMBEDDED_THREAD_CONTEXT_PATTERN, "")
+    .trim();
+  return unwrapCurrentInstruction(withoutContext) ?? withoutContext;
 }
 
 /** Remove volatile runtime context before reusing messages as history. */

--- a/packages/junior/src/chat/plugins/task-runner.ts
+++ b/packages/junior/src/chat/plugins/task-runner.ts
@@ -33,6 +33,7 @@ import {
 import { getPersistedThreadState } from "@/chat/runtime/thread-state";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
 import type { ConversationMessage } from "@/chat/state/conversation";
+import { parseSlackMessageTs } from "@/chat/slack/timestamp";
 import type { PiMessageProvenance } from "@/chat/state/session-log";
 import {
   getAgentTurnSessionRecord,
@@ -233,6 +234,34 @@ function slackContextAuthor(
   };
 }
 
+function slackTimestampMs(value: unknown): number | undefined {
+  const timestamp = parseSlackMessageTs(value);
+  if (!timestamp) {
+    return undefined;
+  }
+  const timestampMs = Number(timestamp) * 1000;
+  return Number.isFinite(timestampMs) ? timestampMs : undefined;
+}
+
+function conversationMessageTimestampMs(
+  message: ConversationMessage,
+): number | undefined {
+  if (message.meta?.slackTs !== undefined) {
+    return slackTimestampMs(message.meta.slackTs);
+  }
+  return Number.isFinite(message.createdAtMs) ? message.createdAtMs : undefined;
+}
+
+function messageExistedAtRunCompletion(
+  message: ConversationMessage,
+  completedAtMs: number,
+): boolean {
+  const messageTimestampMs = conversationMessageTimestampMs(message);
+  return (
+    messageTimestampMs !== undefined && messageTimestampMs <= completedAtMs
+  );
+}
+
 /**
  * Project bounded public-thread context into the run transcript.
  *
@@ -253,6 +282,9 @@ async function loadConversationContextTranscriptEntries(
   const entries: PluginRunTranscriptEntry[] = [];
   for (const message of conversation.messages) {
     if (message.role !== "user") {
+      continue;
+    }
+    if (!messageExistedAtRunCompletion(message, record.updatedAtMs)) {
       continue;
     }
     const text = sanitizeText(message.text);

--- a/packages/junior/src/chat/plugins/task-runner.ts
+++ b/packages/junior/src/chat/plugins/task-runner.ts
@@ -6,12 +6,17 @@
  * payloads.
  */
 import type {
+  Actor,
   PluginRegistration,
   PluginRunContext,
   PluginRunTranscriptEntry,
+  PluginRunTranscriptProvenance,
   PluginTaskContext,
 } from "@sentry/junior-plugin-api";
-import { pluginRunContextSchema } from "@sentry/junior-plugin-api";
+import {
+  isPrivateSource,
+  pluginRunContextSchema,
+} from "@sentry/junior-plugin-api";
 import { getDb } from "@/chat/db";
 import { createPluginLogger } from "@/chat/plugins/logging";
 import { createPluginEmbedder, createPluginModel } from "@/chat/plugins/model";
@@ -19,12 +24,20 @@ import { createPluginState } from "@/chat/plugins/state";
 import type { PiMessage } from "@/chat/pi/messages";
 import {
   getPiMessageRole,
+  instructionTextForProjection,
   isToolResultError,
   isToolResultMessage,
   normalizeToolNameFromResult,
   stripRuntimeTurnContext,
 } from "@/chat/pi/transcript";
-import { getAgentTurnSessionRecord } from "@/chat/state/turn-session";
+import { getPersistedThreadState } from "@/chat/runtime/thread-state";
+import { coerceThreadConversationState } from "@/chat/state/conversation";
+import type { ConversationMessage } from "@/chat/state/conversation";
+import type { PiMessageProvenance } from "@/chat/state/session-log";
+import {
+  getAgentTurnSessionRecord,
+  type AgentTurnSessionRecord,
+} from "@/chat/state/turn-session";
 import { getPlugins } from "./agent-hooks";
 import {
   pluginTaskId,
@@ -101,16 +114,64 @@ function sanitizeText(text: string): string {
     .trim();
 }
 
+/** Compare two actors by runtime identity only, never by display name. */
+function sameActorIdentity(
+  left: Actor | undefined,
+  right: Actor | undefined,
+): boolean {
+  if (!left || !right || left.platform !== right.platform) {
+    return false;
+  }
+  if (left.platform === "system" || right.platform === "system") {
+    return (
+      left.platform === "system" &&
+      right.platform === "system" &&
+      left.name === right.name
+    );
+  }
+  if (left.platform === "slack" && right.platform === "slack") {
+    return left.teamId === right.teamId && left.userId === right.userId;
+  }
+  return left.userId === right.userId;
+}
+
+/** Build the transcript provenance for a user message from its Pi provenance. */
+function messageProvenance(
+  provenance: PiMessageProvenance,
+): PluginRunTranscriptProvenance {
+  return {
+    authority: provenance.authority,
+    ...(provenance.actor ? { actor: provenance.actor } : {}),
+  };
+}
+
 function runTranscriptEntry(
   message: PiMessage,
+  provenance: PiMessageProvenance,
+  runActor: Actor | undefined,
 ): PluginRunTranscriptEntry | undefined {
   const role = getPiMessageRole(message);
   if (role === "user" || role === "assistant") {
-    const text = messageText(message);
+    // User entries are instruction-authority evidence, so they must expose only
+    // this turn's actual instruction — never the prior-thread context blocks the
+    // runtime embeds alongside it, which carry other participants' verbatim text.
+    const text =
+      role === "user"
+        ? instructionTextForProjection(messageText(message))
+        : messageText(message);
     if (!text) {
       return undefined;
     }
-    return { type: "message", role, text };
+    if (role === "assistant") {
+      return { type: "message", role, text };
+    }
+    return {
+      type: "message",
+      role,
+      text,
+      provenance: messageProvenance(provenance),
+      isRunActor: sameActorIdentity(provenance.actor, runActor),
+    };
   }
 
   if (!isToolResultMessage(message)) {
@@ -127,6 +188,90 @@ function runTranscriptEntry(
     isError: isToolResultError(message),
     ...(text ? { text } : {}),
   };
+}
+
+/**
+ * Slice the current turn's Pi messages with their aligned provenance and strip
+ * runtime turn context, keeping each surviving message paired with the exact
+ * provenance recorded for it. Stripping can drop or rewrite messages, so the
+ * pairing is applied per message rather than by post-strip index.
+ */
+function turnMessagesWithProvenance(
+  record: AgentTurnSessionRecord,
+): Array<{ message: PiMessage; provenance: PiMessageProvenance }> {
+  const startIndex = record.turnStartMessageIndex ?? 0;
+  const messages = record.piMessages.slice(startIndex);
+  const provenance = record.piMessageProvenance.slice(startIndex);
+  const paired: Array<{ message: PiMessage; provenance: PiMessageProvenance }> =
+    [];
+  for (const [index, message] of messages.entries()) {
+    for (const stripped of stripRuntimeTurnContext([message])) {
+      paired.push({
+        message: stripped,
+        provenance: provenance[index] ?? { authority: "context" },
+      });
+    }
+  }
+  return paired;
+}
+
+/** Recover the Slack context author identity from a persisted thread message. */
+function slackContextAuthor(
+  source: { teamId: string },
+  message: ConversationMessage,
+): Actor | undefined {
+  const userId = message.author?.userId?.trim();
+  if (!userId) {
+    return undefined;
+  }
+  return {
+    platform: "slack",
+    teamId: source.teamId,
+    userId,
+    ...(message.author?.userName ? { userName: message.author.userName } : {}),
+    ...(message.author?.fullName ? { fullName: message.author.fullName } : {}),
+  };
+}
+
+/**
+ * Project bounded public-thread context into the run transcript.
+ *
+ * Prior public Slack messages are durable conversation evidence a completed run
+ * may have acted on, so passive consumers can cite them. They are always
+ * context authority (never instruction), and only public Slack sources
+ * contribute; private and local sources add nothing here.
+ */
+async function loadConversationContextTranscriptEntries(
+  record: AgentTurnSessionRecord,
+): Promise<PluginRunTranscriptEntry[]> {
+  const source = record.source;
+  if (source?.platform !== "slack" || isPrivateSource(source)) {
+    return [];
+  }
+  const state = await getPersistedThreadState(record.conversationId);
+  const conversation = coerceThreadConversationState(state);
+  const entries: PluginRunTranscriptEntry[] = [];
+  for (const message of conversation.messages) {
+    if (message.role !== "user") {
+      continue;
+    }
+    const text = sanitizeText(message.text);
+    if (!text) {
+      continue;
+    }
+    const author = slackContextAuthor(source, message);
+    entries.push({
+      type: "message",
+      role: "user",
+      text,
+      provenance: {
+        authority: "context",
+        ...(author ? { actor: author } : {}),
+      },
+      isRunActor: sameActorIdentity(author, record.actor),
+    });
+  }
+  return entries;
 }
 
 async function withPluginTaskLock<T>(
@@ -169,19 +314,32 @@ async function loadPluginRun(
       "Completed plugin task session record is missing source or destination",
     );
   }
-  const sessionMessages = stripRuntimeTurnContext(
-    record.piMessages.slice(record.turnStartMessageIndex ?? 0),
+  const runEntries = turnMessagesWithProvenance(record)
+    .map(({ message, provenance }) =>
+      runTranscriptEntry(message, provenance, record.actor),
+    )
+    .filter((entry): entry is PluginRunTranscriptEntry => Boolean(entry));
+  const runMessageTexts = new Set(
+    runEntries
+      .filter((entry) => entry.type === "message")
+      .map((entry) => entry.text),
+  );
+  const contextEntries = (
+    await loadConversationContextTranscriptEntries(record)
+  ).filter(
+    (entry) => entry.type !== "message" || !runMessageTexts.has(entry.text),
   );
   return pluginRunContextSchema.parse({
     completedAtMs: record.updatedAtMs,
     conversationId: record.conversationId,
     destination: record.destination,
+    // Derived from the full run provenance on the record, not the sliced or
+    // stripped transcript, so it reflects every committed instruction actor.
+    actors: record.actors,
     ...(record.actor ? { actor: record.actor } : {}),
     runId: record.sessionId,
     source: record.source,
-    transcript: sessionMessages
-      .map(runTranscriptEntry)
-      .filter((entry): entry is PluginRunTranscriptEntry => Boolean(entry)),
+    transcript: [...contextEntries, ...runEntries],
   });
 }
 

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -84,6 +84,7 @@ import { appendSlackLegacyAttachmentText } from "@/chat/slack/legacy-attachments
 import { type ThreadArtifactsState } from "@/chat/state/artifacts";
 import { lookupSlackUser } from "@/chat/slack/user";
 import {
+  createActor,
   toStoredSlackActor,
   parseActorUserId,
   type Actor,
@@ -120,7 +121,14 @@ import {
   initConversationContext,
   setConversationTitle,
 } from "@/chat/state/conversation-details";
-import { commitMessages, loadProjection } from "@/chat/state/session-log";
+import {
+  commitMessages,
+  contextProvenance,
+  instructionProvenanceFor,
+  loadProjection,
+  loadProjectionWithProvenance,
+  type PiMessageProvenance,
+} from "@/chat/state/session-log";
 import { getStateAdapter } from "@/chat/state/adapter";
 import { acquireActiveLock } from "@/chat/state/locks";
 import { persistWithRetry } from "@/chat/services/persist-retry";
@@ -240,6 +248,33 @@ function queuedInstructionActor(
     ...(authorName ? { authorName } : {}),
     ...(slackTs ? { slackTs } : {}),
   };
+}
+
+/**
+ * Provenance for a queued or steered Slack message: a user-authored instruction
+ * attributed to the message's own author, or unauthored context for
+ * system-originated resource events.
+ */
+function queuedInstructionProvenance(
+  queued: QueuedTurnMessage,
+  teamId: string,
+): PiMessageProvenance {
+  if (isResourceEventMessage(queued.message)) {
+    return contextProvenance;
+  }
+  const identity = getMessageActorIdentity(queued.message);
+  const author =
+    identity && "platform" in identity
+      ? identity
+      : createActor(
+          { userId: parseActorUserId(queued.message.author.userId) },
+          {
+            platform: "slack",
+            teamId,
+            userId: parseActorUserId(queued.message.author.userId),
+          },
+        );
+  return instructionProvenanceFor(author);
 }
 
 function isResourceEventMessage(message: Message): boolean {
@@ -590,6 +625,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               const attachments = queued.message.attachments;
               return {
                 actor: queuedInstructionActor(queued),
+                provenance: queuedInstructionProvenance(queued, teamId),
                 text: queued.userText,
                 timestampMs: queued.message.metadata.dateSent.getTime(),
                 omittedImageAttachmentCount:
@@ -658,20 +694,28 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             return false;
           }
           try {
-            const piMessages = (
+            // Each parked message keeps its own author's instruction
+            // provenance, so a multi-author batch is not collapsed to a single
+            // latest-wins actor.
+            const parkedPairs = (
               await resolveSteeringMessages(parkedMessages)
-            ).map(buildSteeringPiMessage);
-            const projection = await loadProjection({ conversationId });
+            ).map((steering) => ({
+              message: buildSteeringPiMessage(steering),
+              provenance: steering.provenance,
+            }));
+            const projection = await loadProjectionWithProvenance({
+              conversationId,
+            });
             // Dedupe per message: a partial-overlap redelivery (some messages
             // already appended before a schedule failure) must append only
             // the missing ones.
             const appendedKeys = new Set(
-              projection
+              projection.messages
                 .map(parkedInputKey)
                 .filter((key): key is string => key !== undefined),
             );
-            const missing = piMessages.filter((piMessage) => {
-              const key = parkedInputKey(piMessage);
+            const missing = parkedPairs.filter((pair) => {
+              const key = parkedInputKey(pair.message);
               return key === undefined || !appendedKeys.has(key);
             });
             if (missing.length === 0) {
@@ -680,8 +724,14 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             }
             await commitMessages({
               conversationId,
-              messages: [...projection, ...missing],
-              actor: storedActor,
+              messages: [
+                ...projection.messages,
+                ...missing.map((pair) => pair.message),
+              ],
+              provenance: [
+                ...projection.provenance,
+                ...missing.map((pair) => pair.provenance),
+              ],
               ttlMs: THREAD_STATE_TTL_MS,
             });
             return true;

--- a/packages/junior/src/chat/services/context-compaction.ts
+++ b/packages/junior/src/chat/services/context-compaction.ts
@@ -141,17 +141,31 @@ function userMessage(text: string): PiMessage {
   } as PiMessage;
 }
 
+interface RetainedUserMessage {
+  message: PiMessage;
+  sourceIndex: number;
+}
+
 /** Build retained user messages for a compacted Pi replacement history. */
-export function selectRetainedUserMessages(
+function selectRetainedUserMessageEntries(
   messages: PiMessage[],
   maxTokens = RETAINED_USER_MESSAGE_TOKENS,
-): PiMessage[] {
-  const stripped = stripRuntimeTurnContext(messages);
-  const selected: string[] = [];
+): RetainedUserMessage[] {
+  const selected: RetainedUserMessage[] = [];
   let remaining = maxTokens;
 
-  for (const message of [...stripped].reverse()) {
-    if ((message as { role?: unknown }).role !== "user" || remaining <= 0) {
+  for (
+    let sourceIndex = messages.length - 1;
+    sourceIndex >= 0;
+    sourceIndex -= 1
+  ) {
+    const stripped = stripRuntimeTurnContext([messages[sourceIndex]!]);
+    const message = stripped[0];
+    if (
+      !message ||
+      (message as { role?: unknown }).role !== "user" ||
+      remaining <= 0
+    ) {
       continue;
     }
 
@@ -162,19 +176,29 @@ export function selectRetainedUserMessages(
 
     const tokens = estimateTextTokens(text);
     if (tokens <= remaining) {
-      selected.push(text);
+      selected.push({ message: userMessage(text), sourceIndex });
       remaining -= tokens;
       continue;
     }
 
     const truncated = truncateToTokenBudget(text, remaining);
     if (truncated) {
-      selected.push(truncated);
+      selected.push({ message: userMessage(truncated), sourceIndex });
     }
     break;
   }
 
-  return selected.reverse().map(userMessage);
+  return selected.reverse();
+}
+
+/** Build retained user messages for a compacted Pi replacement history. */
+export function selectRetainedUserMessages(
+  messages: PiMessage[],
+  maxTokens = RETAINED_USER_MESSAGE_TOKENS,
+): PiMessage[] {
+  return selectRetainedUserMessageEntries(messages, maxTokens).map(
+    (entry) => entry.message,
+  );
 }
 
 function renderMessageForSummary(message: PiMessage): string | undefined {
@@ -296,29 +320,17 @@ function estimateHistoryTokens(messages: PiMessage[]): number {
 }
 
 /**
- * Preserve each retained user message's original instruction author by matching
- * its sanitized text back to the source projection provenance; the synthetic
- * handoff summary is always unauthored context.
+ * Preserve each retained user message's original instruction author by using
+ * the retained source projection index; the synthetic handoff summary is
+ * always unauthored context.
  */
 function buildReplacementProvenance(args: {
-  retained: PiMessage[];
+  retained: RetainedUserMessage[];
   sourceProvenance: PiMessageProvenance[];
-  sourceMessages: PiMessage[];
 }): PiMessageProvenance[] {
-  const provenanceByText = new Map<string, PiMessageProvenance>();
-  args.sourceMessages.forEach((message, index) => {
-    if ((message as { role?: unknown }).role === "user") {
-      provenanceByText.set(
-        sanitizeText(messageText(message)),
-        args.sourceProvenance[index] ?? contextProvenance,
-      );
-    }
-  });
   return [
     ...args.retained.map(
-      (message) =>
-        provenanceByText.get(sanitizeText(messageText(message))) ??
-        contextProvenance,
+      (entry) => args.sourceProvenance[entry.sourceIndex] ?? contextProvenance,
     ),
     contextProvenance,
   ];
@@ -411,25 +423,24 @@ async function writeCompactedThreadContext(
     triggerTokens?: number;
   },
 ): Promise<CompactContextResult> {
-  const retained = selectRetainedUserMessages(
-    trimTrailingAssistantMessages(sourceMessages),
+  const sourceProjection = await loadProjectionWithProvenance({
+    conversationId: args.conversationId,
+  });
+  const retained = selectRetainedUserMessageEntries(
+    trimTrailingAssistantMessages(sourceProjection.messages),
   );
   const replacement = [
-    ...retained,
+    ...retained.map((entry) => entry.message),
     userMessage(`${COMPACTION_SUMMARY_PREFIX}\n${summary}`),
   ];
   // Provenance comes from the committed projection so retained user asks keep
   // their original instruction author across the compaction reset.
-  const sourceProjection = await loadProjectionWithProvenance({
-    conversationId: args.conversationId,
-  });
   await commitMessages({
     conversationId: args.conversationId,
     messages: replacement,
     provenance: buildReplacementProvenance({
       retained,
       sourceProvenance: sourceProjection.provenance,
-      sourceMessages: sourceProjection.messages,
     }),
     ttlMs: THREAD_STATE_TTL_MS,
   });

--- a/packages/junior/src/chat/services/context-compaction.ts
+++ b/packages/junior/src/chat/services/context-compaction.ts
@@ -19,7 +19,12 @@ import {
   estimateTextTokens,
   getAgentContextCompactionTriggerTokens,
 } from "@/chat/services/context-budget";
-import { commitMessages } from "@/chat/state/session-log";
+import {
+  commitMessages,
+  contextProvenance,
+  loadProjectionWithProvenance,
+  type PiMessageProvenance,
+} from "@/chat/state/session-log";
 import type { ThreadConversationState } from "@/chat/state/conversation";
 import { logWarn, setSpanAttributes } from "@/chat/logging";
 import {
@@ -290,14 +295,32 @@ function estimateHistoryTokens(messages: PiMessage[]): number {
   return Math.max(usageEstimate, structuralEstimate);
 }
 
-/** Build a compacted Pi projection from retained recent asks plus the summary. */
-function buildReplacementHistory(args: {
-  messages: PiMessage[];
-  summary: string;
-}): PiMessage[] {
+/**
+ * Preserve each retained user message's original instruction author by matching
+ * its sanitized text back to the source projection provenance; the synthetic
+ * handoff summary is always unauthored context.
+ */
+function buildReplacementProvenance(args: {
+  retained: PiMessage[];
+  sourceProvenance: PiMessageProvenance[];
+  sourceMessages: PiMessage[];
+}): PiMessageProvenance[] {
+  const provenanceByText = new Map<string, PiMessageProvenance>();
+  args.sourceMessages.forEach((message, index) => {
+    if ((message as { role?: unknown }).role === "user") {
+      provenanceByText.set(
+        sanitizeText(messageText(message)),
+        args.sourceProvenance[index] ?? contextProvenance,
+      );
+    }
+  });
   return [
-    ...selectRetainedUserMessages(args.messages),
-    userMessage(`${COMPACTION_SUMMARY_PREFIX}\n${args.summary}`),
+    ...args.retained.map(
+      (message) =>
+        provenanceByText.get(sanitizeText(messageText(message))) ??
+        contextProvenance,
+    ),
+    contextProvenance,
   ];
 }
 
@@ -388,13 +411,26 @@ async function writeCompactedThreadContext(
     triggerTokens?: number;
   },
 ): Promise<CompactContextResult> {
-  const replacement = buildReplacementHistory({
-    messages: trimTrailingAssistantMessages(sourceMessages),
-    summary,
+  const retained = selectRetainedUserMessages(
+    trimTrailingAssistantMessages(sourceMessages),
+  );
+  const replacement = [
+    ...retained,
+    userMessage(`${COMPACTION_SUMMARY_PREFIX}\n${summary}`),
+  ];
+  // Provenance comes from the committed projection so retained user asks keep
+  // their original instruction author across the compaction reset.
+  const sourceProjection = await loadProjectionWithProvenance({
+    conversationId: args.conversationId,
   });
   await commitMessages({
     conversationId: args.conversationId,
     messages: replacement,
+    provenance: buildReplacementProvenance({
+      retained,
+      sourceProvenance: sourceProjection.provenance,
+      sourceMessages: sourceProjection.messages,
+    }),
     ttlMs: THREAD_STATE_TTL_MS,
   });
 

--- a/packages/junior/src/chat/services/turn-session-record.ts
+++ b/packages/junior/src/chat/services/turn-session-record.ts
@@ -8,6 +8,7 @@ import type { ConversationPrivacy } from "@/chat/conversation-privacy";
 import type { Destination, Actor, Source } from "@sentry/junior-plugin-api";
 import { getActiveTraceId, logException } from "@/chat/logging";
 import type { PiMessage } from "@/chat/pi/messages";
+import type { PiMessageProvenance } from "@/chat/state/session-log";
 import {
   getPiMessageRole,
   trimTrailingAssistantMessages,
@@ -133,6 +134,8 @@ export async function persistRunningSessionRecord(args: {
   sessionId: string;
   sliceId: number;
   messages: PiMessage[];
+  /** Provenance for trailing newly committed messages, such as steering. */
+  trailingMessageProvenance?: PiMessageProvenance[];
   loadedSkillNames?: string[];
   logContext: SessionRecordLogContext;
   actor?: Actor;
@@ -165,6 +168,9 @@ export async function persistRunningSessionRecord(args: {
       sliceId: args.sliceId,
       state: "running",
       piMessages: args.messages,
+      ...(args.trailingMessageProvenance
+        ? { trailingMessageProvenance: args.trailingMessageProvenance }
+        : {}),
       ...((args.surface ?? latestSessionRecord?.surface)
         ? { surface: args.surface ?? latestSessionRecord?.surface }
         : {}),

--- a/packages/junior/src/chat/state/session-log.ts
+++ b/packages/junior/src/chat/state/session-log.ts
@@ -710,6 +710,7 @@ function resolveCommitProvenance(args: {
   existing: SessionProjection;
   nextMessages: PiMessage[];
   explicitProvenance?: PiMessageProvenance[];
+  trailingMessageProvenance?: PiMessageProvenance[];
   newMessageProvenance?: PiMessageProvenance;
 }): PiMessageProvenance[] {
   if (args.explicitProvenance) {
@@ -738,6 +739,23 @@ function resolveCommitProvenance(args: {
         break;
       }
     }
+  }
+  if (args.trailingMessageProvenance) {
+    if (args.trailingMessageProvenance.length > provenance.length) {
+      throw new Error(
+        "trailing commit provenance cannot exceed committed messages",
+      );
+    }
+    const newMessageCount = args.nextMessages.length - matchingPrefix;
+    if (args.trailingMessageProvenance.length > newMessageCount) {
+      throw new Error(
+        "trailing commit provenance must align to newly committed messages",
+      );
+    }
+    const start = provenance.length - args.trailingMessageProvenance.length;
+    args.trailingMessageProvenance.forEach((entry, offset) => {
+      provenance[start + offset] = entry;
+    });
   }
   return provenance;
 }
@@ -1181,6 +1199,8 @@ export async function commitMessages(
     ttlMs: number;
     /** Explicit per-message provenance aligned one-to-one with `messages`. */
     provenance?: PiMessageProvenance[];
+    /** Explicit provenance for the trailing newly committed messages. */
+    trailingMessageProvenance?: PiMessageProvenance[];
     /** Default applied to the last new user message when no explicit array. */
     newMessageProvenance?: PiMessageProvenance;
   },
@@ -1193,6 +1213,9 @@ export async function commitMessages(
     existing: existingProjection,
     nextMessages: args.messages,
     ...(args.provenance ? { explicitProvenance: args.provenance } : {}),
+    ...(args.trailingMessageProvenance
+      ? { trailingMessageProvenance: args.trailingMessageProvenance }
+      : {}),
     ...(args.newMessageProvenance
       ? { newMessageProvenance: args.newMessageProvenance }
       : {}),

--- a/packages/junior/src/chat/state/session-log.ts
+++ b/packages/junior/src/chat/state/session-log.ts
@@ -9,6 +9,7 @@
 import { isDeepStrictEqual } from "node:util";
 import type { RedisStateAdapter } from "@chat-adapter/state-redis";
 import { z } from "zod";
+import { actorSchema, type Actor } from "@sentry/junior-plugin-api";
 import { getChatConfig } from "@/chat/config";
 import { piMessageSchema, type PiMessage } from "@/chat/pi/messages";
 import { storedSlackActorSchema, type StoredSlackActor } from "@/chat/actor";
@@ -18,36 +19,98 @@ import {
 } from "@/chat/state/adapter";
 
 const AGENT_SESSION_LOG_PREFIX = "junior:agent-session-log";
-const AGENT_SESSION_LOG_SCHEMA_VERSION = 1;
+const AGENT_SESSION_LOG_SCHEMA_VERSION = 2;
 const INITIAL_SESSION_ID = "session_0";
 const SESSION_ID_PREFIX = "session_";
 const STATE_STORE_LOCK_TTL_MS = 5_000;
 
+// Decode both the current (v2, per-entry provenance) and legacy (v1,
+// latest-wins actor) session-log shapes; new writes always emit v2.
+const schemaVersionSchema = z.union([z.literal(1), z.literal(2)]);
+
+const piMessageAuthoritySchema = z.union([
+  z.literal("instruction"),
+  z.literal("context"),
+]);
+
+const piMessageProvenanceSchema = z
+  .object({
+    authority: piMessageAuthoritySchema,
+    actor: actorSchema.optional(),
+  })
+  .strict();
+
+/** Whether a user-role Pi message is a durable instruction or ambient context. */
+export type PiMessageAuthority = z.output<typeof piMessageAuthoritySchema>;
+/** Per-message record of the actor a Pi message came from and its authority weight. */
+export type PiMessageProvenance = z.output<typeof piMessageProvenanceSchema>;
+
+const unattributedContextProvenance: PiMessageProvenance = {
+  authority: "context",
+};
+
+function instructionProvenance(actor?: Actor): PiMessageProvenance {
+  return actor
+    ? { authority: "instruction", actor }
+    : { authority: "instruction" };
+}
+
+/** A provenance entry carries no signal when it is unattributed ambient context. */
+function isDefaultContextProvenance(provenance: PiMessageProvenance): boolean {
+  return provenance.authority === "context" && !provenance.actor;
+}
+
+/**
+ * Recover per-message provenance from a legacy v1 pi_message. A stored Slack
+ * actor on the entry meant that user message was the turn instruction, so it
+ * decodes to an authored instruction when the identity is intact; anything
+ * missing or malformed fails closed to unauthored context.
+ */
+function legacyActorProvenance(actor: StoredSlackActor): PiMessageProvenance {
+  if (actor.teamId && actor.slackUserId && actor.platform) {
+    return instructionProvenance({
+      platform: "slack",
+      teamId: actor.teamId,
+      userId: actor.slackUserId,
+      ...(actor.slackUserName ? { userName: actor.slackUserName } : {}),
+      ...(actor.fullName ? { fullName: actor.fullName } : {}),
+      ...(actor.email ? { email: actor.email } : {}),
+    });
+  }
+  return unattributedContextProvenance;
+}
+
 const piMessageEntrySchema = z.object({
-  schemaVersion: z.literal(AGENT_SESSION_LOG_SCHEMA_VERSION),
+  schemaVersion: schemaVersionSchema,
   type: z.literal("pi_message"),
   sessionId: z.string().min(1).default(INITIAL_SESSION_ID),
   message: piMessageSchema,
+  provenance: piMessageProvenanceSchema.optional(),
+  // Legacy v1 latest-wins actor, decoded into provenance on read.
   actor: storedSlackActorSchema.optional(),
 });
 
 const projectionResetEntrySchema = z.object({
-  schemaVersion: z.literal(AGENT_SESSION_LOG_SCHEMA_VERSION),
+  schemaVersion: schemaVersionSchema,
   type: z.literal("projection_reset"),
   sessionId: z.string().min(1).default(INITIAL_SESSION_ID),
   messages: z.array(piMessageSchema),
+  provenance: z.array(piMessageProvenanceSchema).optional(),
+  // Legacy v1 latest-wins actor; v1 resets carry no per-message provenance.
   actor: storedSlackActorSchema.optional(),
 });
 
+// Legacy v1 latest-wins actor event, decoded but not projected: attribution
+// that cannot be aligned to a specific message fails closed to context.
 const actorRecordedEntrySchema = z.object({
-  schemaVersion: z.literal(AGENT_SESSION_LOG_SCHEMA_VERSION),
+  schemaVersion: schemaVersionSchema,
   type: z.literal("actor_recorded"),
   sessionId: z.string().min(1).default(INITIAL_SESSION_ID),
   actor: storedSlackActorSchema,
 });
 
 const mcpProviderConnectedEntrySchema = z.object({
-  schemaVersion: z.literal(AGENT_SESSION_LOG_SCHEMA_VERSION),
+  schemaVersion: schemaVersionSchema,
   type: z.literal("mcp_provider_connected"),
   sessionId: z.string().min(1).default(INITIAL_SESSION_ID),
   provider: z.string().min(1),
@@ -59,7 +122,7 @@ const authorizationKindSchema = z.union([
 ]);
 
 const authorizationRequestedEntrySchema = z.object({
-  schemaVersion: z.literal(AGENT_SESSION_LOG_SCHEMA_VERSION),
+  schemaVersion: schemaVersionSchema,
   type: z.literal("authorization_requested"),
   sessionId: z.string().min(1).default(INITIAL_SESSION_ID),
   createdAtMs: z.number().int().nonnegative(),
@@ -74,7 +137,7 @@ const authorizationRequestedEntrySchema = z.object({
 });
 
 const authorizationCompletedEntrySchema = z.object({
-  schemaVersion: z.literal(AGENT_SESSION_LOG_SCHEMA_VERSION),
+  schemaVersion: schemaVersionSchema,
   type: z.literal("authorization_completed"),
   sessionId: z.string().min(1).default(INITIAL_SESSION_ID),
   createdAtMs: z.number().int().nonnegative(),
@@ -91,7 +154,7 @@ const transcriptRefSchema = z.object({
 });
 
 const toolExecutionStartedEntrySchema = z.object({
-  schemaVersion: z.literal(AGENT_SESSION_LOG_SCHEMA_VERSION),
+  schemaVersion: schemaVersionSchema,
   type: z.literal("tool_execution_started"),
   sessionId: z.string().min(1).default(INITIAL_SESSION_ID),
   createdAtMs: z.number().int().nonnegative(),
@@ -101,7 +164,7 @@ const toolExecutionStartedEntrySchema = z.object({
 });
 
 const subagentStartedEntrySchema = z.object({
-  schemaVersion: z.literal(AGENT_SESSION_LOG_SCHEMA_VERSION),
+  schemaVersion: schemaVersionSchema,
   type: z.literal("subagent_started"),
   sessionId: z.string().min(1).default(INITIAL_SESSION_ID),
   subagentInvocationId: z.string().min(1),
@@ -115,7 +178,7 @@ const subagentStartedEntrySchema = z.object({
 });
 
 const subagentEndedEntrySchema = z.object({
-  schemaVersion: z.literal(AGENT_SESSION_LOG_SCHEMA_VERSION),
+  schemaVersion: schemaVersionSchema,
   type: z.literal("subagent_ended"),
   sessionId: z.string().min(1).default(INITIAL_SESSION_ID),
   subagentInvocationId: z.string().min(1),
@@ -301,53 +364,40 @@ function projectionEntries(
     .filter((entry) => entrySessionId(entry) === currentId);
 }
 
-function findLastIndex<T>(
-  values: T[],
-  predicate: (value: T) => boolean,
-): number {
-  for (let index = values.length - 1; index >= 0; index -= 1) {
-    if (predicate(values[index]!)) return index;
-  }
-  return -1;
-}
-
 function piEntry(
   message: PiMessage,
   sessionId: string,
-  actor?: StoredSlackActor,
+  provenance?: PiMessageProvenance,
 ): SessionLogEntry {
   return {
     schemaVersion: AGENT_SESSION_LOG_SCHEMA_VERSION,
     type: "pi_message",
     sessionId,
     message,
-    ...(actor ? { actor } : {}),
+    // Ambient context is the decode default, so only attributed/instruction
+    // provenance needs to be persisted on the entry.
+    ...(provenance && !isDefaultContextProvenance(provenance)
+      ? { provenance }
+      : {}),
   };
 }
 
 function resetEntry(
   messages: PiMessage[],
   sessionId: string,
-  actor?: StoredSlackActor,
+  provenance: PiMessageProvenance[],
 ): SessionLogEntry {
+  if (provenance.length !== messages.length) {
+    throw new Error(
+      "projection_reset provenance must align one-to-one with messages",
+    );
+  }
   return {
     schemaVersion: AGENT_SESSION_LOG_SCHEMA_VERSION,
     type: "projection_reset",
     sessionId,
     messages,
-    ...(actor ? { actor } : {}),
-  };
-}
-
-function actorRecordedEntry(
-  actor: StoredSlackActor,
-  sessionId: string,
-): SessionLogEntry {
-  return {
-    schemaVersion: AGENT_SESSION_LOG_SCHEMA_VERSION,
-    type: "actor_recorded",
-    sessionId,
-    actor,
+    provenance,
   };
 }
 
@@ -508,48 +558,64 @@ function decode(value: unknown): SessionLogEntry {
   return piEntry(piMessageSchema.parse(value), INITIAL_SESSION_ID);
 }
 
+/** Aligned Pi-message projection: `provenance[i]` describes `messages[i]`. */
 export interface SessionProjection {
   messages: PiMessage[];
-  actor?: StoredSlackActor;
+  provenance: PiMessageProvenance[];
+}
+
+/** Decode the provenance a projected pi_message carries, tolerating v1 shapes. */
+function piEntryProvenance(
+  entry: Extract<SessionLogEntry, { type: "pi_message" }>,
+): PiMessageProvenance {
+  if (entry.provenance) {
+    return entry.provenance;
+  }
+  if (entry.actor) {
+    return legacyActorProvenance(entry.actor);
+  }
+  return unattributedContextProvenance;
 }
 
 /**
- * Materialize Pi messages and actor identity from log entries.
+ * Materialize Pi messages and per-message provenance from log entries.
  *
- * Actor is taken from the latest actor-bearing user pi_message,
- * actor_recorded event, or projection_reset event.
+ * Each projected message carries its own provenance instead of a single
+ * latest-wins actor; legacy entries without provenance decode as
+ * unauthored context, and misaligned reset provenance fails closed.
  */
 function project(
   entries: SessionLogEntry[],
   sessionId?: string,
 ): SessionProjection {
   let messages: PiMessage[] = [];
-  let actor: StoredSlackActor | undefined;
+  let provenance: PiMessageProvenance[] = [];
   for (const entry of projectionEntries(entries, sessionId)) {
     if (entry.type === "pi_message") {
       messages.push(entry.message);
-      if (entry.message.role === "user" && entry.actor) {
-        actor = entry.actor;
-      }
-      continue;
-    }
-    if (entry.type === "actor_recorded") {
-      actor = entry.actor;
+      provenance.push(piEntryProvenance(entry));
       continue;
     }
     if (entry.type === "authorization_completed") {
       messages.push(authorizationObservationMessage(entry));
+      provenance.push(unattributedContextProvenance);
       continue;
     }
     if (entry.type === "projection_reset") {
-      messages = [...entry.messages];
-      if (entry.actor) {
-        actor = entry.actor;
+      const resetProvenance =
+        entry.provenance ??
+        entry.messages.map(() => unattributedContextProvenance);
+      if (resetProvenance.length !== entry.messages.length) {
+        throw new Error(
+          "projection_reset provenance must align one-to-one with messages",
+        );
       }
+      messages = [...entry.messages];
+      provenance = [...resetProvenance];
       continue;
     }
   }
-  return { messages, actor };
+  return { messages, provenance };
 }
 
 function projectMessages(
@@ -557,6 +623,62 @@ function projectMessages(
   sessionId?: string,
 ): PiMessage[] {
   return project(entries, sessionId).messages;
+}
+
+/** Find the newest instruction actor, used for latest-actor compatibility. */
+function latestInstructionActor(
+  provenance: PiMessageProvenance[],
+): Actor | undefined {
+  for (let index = provenance.length - 1; index >= 0; index -= 1) {
+    const entry = provenance[index]!;
+    if (entry.authority === "instruction" && entry.actor) {
+      return entry.actor;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Stable identity key for an actor: platform + name for system actors,
+ * platform + team + user for Slack, platform + user otherwise. Never uses
+ * display fields, so the same human under two profiles collapses to one
+ * identity.
+ */
+function actorIdentityKey(actor: Actor): string {
+  if (actor.platform === "system") {
+    return `system ${actor.name}`;
+  }
+  return actor.platform === "slack"
+    ? `slack ${actor.teamId} ${actor.userId}`
+    : `${actor.platform} ${actor.userId}`;
+}
+
+/**
+ * All distinct actors annotated on instruction-authority messages, in
+ * first-seen order — the run's actors. This is attribution, never
+ * authority: it exists so provenance consumers know which actors
+ * contributed instructions to a run. It must never feed credential
+ * issuance, credential-subject selection, or scope ownership.
+ * Unattributable instructions (no resolvable actor) never join;
+ * distinctness is by identity ids only, never display fields.
+ */
+export function instructionActors(
+  provenance: PiMessageProvenance[],
+): Actor[] {
+  const seen = new Set<string>();
+  const actors: Actor[] = [];
+  for (const entry of provenance) {
+    if (entry.authority !== "instruction" || !entry.actor) {
+      continue;
+    }
+    const identity = actorIdentityKey(entry.actor);
+    if (seen.has(identity)) {
+      continue;
+    }
+    seen.add(identity);
+    actors.push(entry.actor);
+  }
+  return actors;
 }
 
 function connectedMcpProviders(
@@ -572,47 +694,79 @@ function connectedMcpProviders(
   return [...providers].sort((left, right) => left.localeCompare(right));
 }
 
+function isUserMessage(message: PiMessage): boolean {
+  return (message as { role?: unknown }).role === "user";
+}
+
+/**
+ * Resolve the aligned provenance to persist for `nextMessages`.
+ *
+ * Explicit per-message provenance always wins; otherwise the unchanged prefix
+ * reuses its committed provenance, new messages default to unauthored context,
+ * and any new-user-message default (the turn author's instruction) is attached
+ * to the last new user message — the current turn's input.
+ */
+function resolveCommitProvenance(args: {
+  existing: SessionProjection;
+  nextMessages: PiMessage[];
+  explicitProvenance?: PiMessageProvenance[];
+  newMessageProvenance?: PiMessageProvenance;
+}): PiMessageProvenance[] {
+  if (args.explicitProvenance) {
+    if (args.explicitProvenance.length !== args.nextMessages.length) {
+      throw new Error("commit provenance must align one-to-one with messages");
+    }
+    return args.explicitProvenance;
+  }
+  const matchingPrefix = countMatchingPrefix(
+    args.existing.messages,
+    args.nextMessages,
+  );
+  const provenance = args.nextMessages.map((_, index) =>
+    index < matchingPrefix
+      ? (args.existing.provenance[index] ?? unattributedContextProvenance)
+      : unattributedContextProvenance,
+  );
+  if (args.newMessageProvenance) {
+    for (
+      let index = args.nextMessages.length - 1;
+      index >= matchingPrefix;
+      index -= 1
+    ) {
+      if (isUserMessage(args.nextMessages[index]!)) {
+        provenance[index] = args.newMessageProvenance;
+        break;
+      }
+    }
+  }
+  return provenance;
+}
+
 /**
  * Commit by appending when history advanced normally, or by writing an explicit
  * projection reset when the runtime intentionally replaces visible history.
  */
 function commitEntries(
-  existingMessages: PiMessage[],
+  existing: SessionProjection,
   nextMessages: PiMessage[],
+  nextProvenance: PiMessageProvenance[],
   sessionId: string,
   entries: SessionLogEntry[],
-  existingActor?: StoredSlackActor,
-  actor?: StoredSlackActor,
 ): { entries: SessionLogEntry[]; sessionId: string } {
-  const matchingPrefix = countMatchingPrefix(existingMessages, nextMessages);
-  if (matchingPrefix === existingMessages.length) {
+  const matchingPrefix = countMatchingPrefix(existing.messages, nextMessages);
+  if (matchingPrefix === existing.messages.length) {
     const newMessages = nextMessages.slice(matchingPrefix);
-    if (
-      newMessages.length === 0 &&
-      actor &&
-      !isDeepStrictEqual(existingActor, actor)
-    ) {
-      return {
-        entries: [actorRecordedEntry(actor, sessionId)],
-        sessionId,
-      };
-    }
-    // Attach actor to the last new user message — the current turn's
-    // input. Using last rather than first avoids tagging older context
-    // messages that may be included at the head of a fresh commit.
-    const actorIndex = actor
-      ? findLastIndex(newMessages, (m) => m.role === "user")
-      : -1;
+    const newProvenance = nextProvenance.slice(matchingPrefix);
     return {
       entries: newMessages.map((message, index) =>
-        piEntry(message, sessionId, index === actorIndex ? actor : undefined),
+        piEntry(message, sessionId, newProvenance[index]),
       ),
       sessionId,
     };
   }
   const resetSessionId = nextSessionId(entries);
   return {
-    entries: [resetEntry(nextMessages, resetSessionId, actor ?? existingActor)],
+    entries: [resetEntry(nextMessages, resetSessionId, nextProvenance)],
     sessionId: resetSessionId,
   };
 }
@@ -726,6 +880,28 @@ export async function loadMessages(
     : undefined;
 }
 
+/** Load the committed Pi-message projection with aligned per-message provenance. */
+export async function loadMessagesWithProvenance(
+  args: Scope & {
+    store?: SessionLogStore;
+    messageCount: number;
+    sessionId?: string;
+  },
+): Promise<SessionProjection | undefined> {
+  const messageCount = normalizeMessageCount(args.messageCount);
+  if (messageCount === 0) {
+    return { messages: [], provenance: [] };
+  }
+
+  const projection = project(await loadEntries(args), args.sessionId);
+  return projection.messages.length >= messageCount
+    ? {
+        messages: projection.messages.slice(0, messageCount),
+        provenance: projection.provenance.slice(0, messageCount),
+      }
+    : undefined;
+}
+
 /** Load the full current Pi-message projection for a conversation. */
 export async function loadProjection(
   args: Scope & {
@@ -737,16 +913,46 @@ export async function loadProjection(
 }
 
 /**
- * Load the Pi-message projection and derived actor identity in one read.
- * Used at continuation boundaries to avoid a second log scan.
+ * Load the Pi-message projection with aligned per-message provenance in one
+ * read. Used at continuation boundaries to avoid a second log scan.
  */
-export async function loadProjectionWithActor(
+export async function loadProjectionWithProvenance(
   args: Scope & {
     store?: SessionLogStore;
     sessionId?: string;
   },
 ): Promise<SessionProjection> {
   return project(await loadEntries(args), args.sessionId);
+}
+
+/**
+ * Load the projection with the latest instruction actor as a stored Slack
+ * actor. Retained for callers that still key on a single latest actor; it
+ * derives the actor from per-message provenance rather than a latest-wins
+ * field.
+ */
+export async function loadProjectionWithActor(
+  args: Scope & {
+    store?: SessionLogStore;
+    sessionId?: string;
+  },
+): Promise<{ messages: PiMessage[]; actor?: StoredSlackActor }> {
+  const projection = project(await loadEntries(args), args.sessionId);
+  const actor = latestInstructionActor(projection.provenance);
+  if (actor?.platform === "slack") {
+    return {
+      messages: projection.messages,
+      actor: {
+        platform: "slack",
+        slackUserId: actor.userId,
+        teamId: actor.teamId,
+        ...(actor.userName ? { slackUserName: actor.userName } : {}),
+        ...(actor.fullName ? { fullName: actor.fullName } : {}),
+        ...(actor.email ? { email: actor.email } : {}),
+      },
+    };
+  }
+  return { messages: projection.messages };
 }
 
 /** Load MCP providers that were durably connected in this conversation. */
@@ -973,20 +1179,30 @@ export async function commitMessages(
     store?: SessionLogStore;
     messages: PiMessage[];
     ttlMs: number;
-    actor?: StoredSlackActor;
+    /** Explicit per-message provenance aligned one-to-one with `messages`. */
+    provenance?: PiMessageProvenance[];
+    /** Default applied to the last new user message when no explicit array. */
+    newMessageProvenance?: PiMessageProvenance;
   },
-): Promise<{ sessionId: string }> {
+): Promise<{ sessionId: string; provenance: PiMessageProvenance[] }> {
   const store = args.store ?? (await defaultStore());
   const entries = await store.read(args);
   const existingProjection = project(entries);
   const currentId = currentSessionId(entries);
+  const nextProvenance = resolveCommitProvenance({
+    existing: existingProjection,
+    nextMessages: args.messages,
+    ...(args.provenance ? { explicitProvenance: args.provenance } : {}),
+    ...(args.newMessageProvenance
+      ? { newMessageProvenance: args.newMessageProvenance }
+      : {}),
+  });
   const commit = commitEntries(
-    existingProjection.messages,
+    existingProjection,
     args.messages,
+    nextProvenance,
     currentId,
     entries,
-    existingProjection.actor,
-    args.actor,
   );
   await store.append({
     scope: args,
@@ -995,5 +1211,41 @@ export async function commitMessages(
   });
   return {
     sessionId: commit.sessionId,
+    provenance: nextProvenance,
   };
+}
+
+/** Build an instruction-provenance record for the given actor. */
+export function instructionProvenanceFor(
+  actor: Actor | undefined,
+): PiMessageProvenance {
+  return instructionProvenance(actor);
+}
+
+/** Unattributed ambient-context provenance for non-instruction Pi messages. */
+export const contextProvenance: PiMessageProvenance =
+  unattributedContextProvenance;
+
+/**
+ * Parse durably-stored message provenance, failing closed on misalignment.
+ *
+ * A missing field is a legacy record: it materializes as unauthored context of
+ * the expected length. A present-but-malformed or wrong-length value returns
+ * undefined so callers reject the record rather than zip a mismatched array.
+ */
+export function parseStoredMessageProvenance(
+  value: unknown,
+  expectedLength: number,
+): PiMessageProvenance[] | undefined {
+  if (value === undefined) {
+    return Array.from(
+      { length: expectedLength },
+      () => unattributedContextProvenance,
+    );
+  }
+  const parsed = z.array(piMessageProvenanceSchema).safeParse(value);
+  if (!parsed.success || parsed.data.length !== expectedLength) {
+    return undefined;
+  }
+  return parsed.data;
 }

--- a/packages/junior/src/chat/state/turn-session.ts
+++ b/packages/junior/src/chat/state/turn-session.ts
@@ -16,7 +16,16 @@ import { isRecord } from "@/chat/coerce";
 import { parseDestination } from "@/chat/destination";
 import type { PiMessage } from "@/chat/pi/messages";
 import { parseActor, toStoredSlackActor, type Actor } from "@/chat/actor";
-import { commitMessages, loadMessages, loadProjection } from "./session-log";
+import {
+  commitMessages,
+  instructionActors,
+  instructionProvenanceFor,
+  loadMessagesWithProvenance,
+  loadProjectionWithProvenance,
+  parseStoredMessageProvenance,
+  type PiMessageProvenance,
+  type SessionProjection,
+} from "./session-log";
 import type { AgentTurnUsage } from "@/chat/usage";
 import { getStateAdapter } from "./adapter";
 import { getConversationStore } from "@/chat/db";
@@ -55,6 +64,16 @@ export interface AgentTurnSessionRecord {
   lastProgressAtMs: number;
   loadedSkillNames?: string[];
   piMessages: PiMessage[];
+  /** Per-message provenance aligned one-to-one with `piMessages`. */
+  piMessageProvenance: PiMessageProvenance[];
+  /**
+   * All distinct actors annotated on this run's committed instruction-authority
+   * messages, in first-seen order. Derived from `piMessageProvenance` at
+   * materialization — never persisted separately, so it cannot drift from
+   * provenance. Attribution only; never an authority source.
+   */
+  actors: Actor[];
+  /** The single actor this run executes as (credential binding, auth flows). */
   actor?: Actor;
   resumeReason?: AgentTurnResumeReason;
   resumedFromSliceId?: number;
@@ -70,20 +89,26 @@ export interface AgentTurnSessionRecord {
 
 export type AgentTurnSessionSummary = Omit<
   AgentTurnSessionRecord,
-  "errorMessage" | "piMessages" | "turnStartMessageIndex"
+  | "errorMessage"
+  | "actors"
+  | "piMessages"
+  | "piMessageProvenance"
+  | "turnStartMessageIndex"
 >;
 
 interface StoredAgentTurnSessionRecord extends Omit<
   AgentTurnSessionRecord,
-  "piMessages"
+  "actors" | "piMessages" | "piMessageProvenance"
 > {
   committedMessageCount: number;
+  /** Provenance aligned to the committed message count, persisted for durability. */
+  committedMessageProvenance: PiMessageProvenance[];
   logSessionId?: string;
 }
 
 type ParsedAgentTurnSessionFields = Omit<
   StoredAgentTurnSessionRecord,
-  "committedMessageCount"
+  "committedMessageCount" | "committedMessageProvenance"
 >;
 
 function agentTurnSessionKey(
@@ -303,10 +328,19 @@ function parseAgentTurnSessionRecord(
   if (!fields || committedMessageCount === undefined) {
     return undefined;
   }
+  const committedMessageProvenance = parseStoredMessageProvenance(
+    parsed.committedMessageProvenance,
+    committedMessageCount,
+  );
+  if (!committedMessageProvenance) {
+    // Misaligned durable provenance fails closed rather than being zipped.
+    return undefined;
+  }
 
   return {
     ...fields,
     committedMessageCount,
+    committedMessageProvenance,
   };
 }
 
@@ -402,33 +436,36 @@ async function recordConversationActivityMetadata(args: {
  * Rehydrate the continuable Pi boundary from the session log, tolerating a
  * compacted projection when the exact historical prefix is no longer visible.
  */
-function materializePiMessages(
+function materializePiProjection(
   committedMessageCount: number,
   includeProjectionTail: boolean,
-  sessionMessages: PiMessage[] | undefined,
-  sessionProjection: PiMessage[],
-): PiMessage[] | undefined {
+  sessionMessages: SessionProjection | undefined,
+  sessionProjection: SessionProjection,
+): SessionProjection | undefined {
   if (committedMessageCount === 0) {
     return sessionProjection;
   }
   if (
     includeProjectionTail &&
-    sessionProjection.length >= committedMessageCount
+    sessionProjection.messages.length >= committedMessageCount
   ) {
     return sessionProjection;
   }
   if (sessionMessages) {
     return sessionMessages;
   }
-  if (sessionProjection.length >= committedMessageCount) {
-    return sessionProjection.slice(0, committedMessageCount);
+  if (sessionProjection.messages.length >= committedMessageCount) {
+    return {
+      messages: sessionProjection.messages.slice(0, committedMessageCount),
+      provenance: sessionProjection.provenance.slice(0, committedMessageCount),
+    };
   }
   return undefined;
 }
 
 function materializeAgentTurnSessionRecord(
   stored: StoredAgentTurnSessionRecord,
-  piMessages: PiMessage[],
+  piProjection: SessionProjection,
 ): AgentTurnSessionRecord {
   return {
     version: stored.version,
@@ -440,7 +477,9 @@ function materializeAgentTurnSessionRecord(
     startedAtMs: stored.startedAtMs,
     lastProgressAtMs: stored.lastProgressAtMs,
     updatedAtMs: stored.updatedAtMs,
-    piMessages,
+    piMessages: piProjection.messages,
+    piMessageProvenance: piProjection.provenance,
+    actors: instructionActors(piProjection.provenance),
     cumulativeDurationMs: stored.cumulativeDurationMs,
     ...(stored.destination ? { destination: stored.destination } : {}),
     ...(stored.source ? { source: stored.source } : {}),
@@ -490,26 +529,26 @@ export async function getAgentTurnSessionRecord(
     return undefined;
   }
 
-  const sessionMessages = await loadMessages({
+  const sessionMessages = await loadMessagesWithProvenance({
     conversationId,
     messageCount: parsed.committedMessageCount,
     ...(parsed.logSessionId ? { sessionId: parsed.logSessionId } : {}),
   });
-  const sessionProjection = await loadProjection({
+  const sessionProjection = await loadProjectionWithProvenance({
     conversationId,
     ...(parsed.logSessionId ? { sessionId: parsed.logSessionId } : {}),
   });
-  const piMessages = materializePiMessages(
+  const piProjection = materializePiProjection(
     parsed.committedMessageCount,
     parsed.state === "running" || parsed.state === "awaiting_resume",
     sessionMessages,
     sessionProjection,
   );
-  if (!piMessages) {
+  if (!piProjection) {
     return undefined;
   }
 
-  return materializeAgentTurnSessionRecord(parsed, piMessages);
+  return materializeAgentTurnSessionRecord(parsed, piProjection);
 }
 
 /** Build the storage record that advances optimistic resume versioning. */
@@ -521,6 +560,7 @@ function buildStoredRecord(args: {
   destination?: Destination;
   source?: Source;
   committedMessageCount: number;
+  committedMessageProvenance: PiMessageProvenance[];
   lastProgressAtMs?: number;
   loadedSkillNames?: string[];
   logSessionId?: string;
@@ -549,6 +589,7 @@ function buildStoredRecord(args: {
     lastProgressAtMs: args.lastProgressAtMs ?? nowMs,
     updatedAtMs: nowMs,
     committedMessageCount: args.committedMessageCount,
+    committedMessageProvenance: args.committedMessageProvenance,
     ...(args.logSessionId ? { logSessionId: args.logSessionId } : {}),
     cumulativeDurationMs: args.cumulativeDurationMs,
     ...(args.cumulativeUsage ? { cumulativeUsage: args.cumulativeUsage } : {}),
@@ -580,6 +621,7 @@ async function setStoredRecord(args: {
   /** Source-confirmed destination visibility from the current event's signal. */
   destinationVisibility?: ConversationPrivacy;
   piMessages: PiMessage[];
+  piMessageProvenance: PiMessageProvenance[];
   record: StoredAgentTurnSessionRecord;
   ttlMs: number;
 }): Promise<AgentTurnSessionRecord> {
@@ -593,6 +635,7 @@ async function setStoredRecord(args: {
   );
   const {
     committedMessageCount: _committedMessageCount,
+    committedMessageProvenance: _committedMessageProvenance,
     errorMessage: _errorMessage,
     logSessionId: _logSessionId,
     turnStartMessageIndex: _turnStartMessageIndex,
@@ -605,7 +648,10 @@ async function setStoredRecord(args: {
     nowMs: Date.now(),
     summary,
   });
-  return materializeAgentTurnSessionRecord(args.record, [...args.piMessages]);
+  return materializeAgentTurnSessionRecord(args.record, {
+    messages: [...args.piMessages],
+    provenance: [...args.piMessageProvenance],
+  });
 }
 
 /**
@@ -627,6 +673,7 @@ async function updateAgentTurnSessionState(args: {
 
   return await setStoredRecord({
     piMessages: args.existing.piMessages,
+    piMessageProvenance: args.existing.piMessageProvenance,
     ttlMs: AGENT_TURN_SESSION_TTL_MS,
     record: buildStoredRecord({
       conversationId: args.existing.conversationId,
@@ -634,6 +681,7 @@ async function updateAgentTurnSessionState(args: {
       sliceId: args.existing.sliceId,
       state: args.state,
       committedMessageCount: parsed.committedMessageCount,
+      committedMessageProvenance: parsed.committedMessageProvenance,
       ...(parsed.channelName ? { channelName: parsed.channelName } : {}),
       startedAtMs: parsed.startedAtMs,
       lastProgressAtMs: parsed.lastProgressAtMs,
@@ -700,10 +748,16 @@ export async function upsertAgentTurnSessionRecord(args: {
     args.sessionId,
   );
   const ttlMs = Math.max(1, args.ttlMs ?? AGENT_TURN_SESSION_TTL_MS);
+  // Attribute new user input to the turn's actor as an instruction; the session
+  // log reuses committed provenance for the unchanged prefix and defaults the
+  // rest to context. Platform-neutral so local identities are preserved too.
+  const instructionActor = args.actor ?? existingRecord?.actor;
   const commit = await commitMessages({
     conversationId: args.conversationId,
     messages: args.piMessages,
-    actor: sessionLogActor(args.actor ?? existingRecord?.actor),
+    ...(instructionActor
+      ? { newMessageProvenance: instructionProvenanceFor(instructionActor) }
+      : {}),
     ttlMs,
   });
 
@@ -711,8 +765,10 @@ export async function upsertAgentTurnSessionRecord(args: {
     conversationStore: args.conversationStore,
     destinationVisibility: args.destinationVisibility,
     piMessages: args.piMessages,
+    piMessageProvenance: commit.provenance,
     ttlMs,
     record: buildStoredRecord({
+      committedMessageProvenance: commit.provenance,
       ...((args.channelName ?? existingRecord?.channelName)
         ? { channelName: args.channelName ?? existingRecord?.channelName }
         : {}),

--- a/packages/junior/src/chat/state/turn-session.ts
+++ b/packages/junior/src/chat/state/turn-session.ts
@@ -247,7 +247,8 @@ function parseAgentTurnSessionFields(
   const lastProgressAtMs = toFiniteNonNegativeNumber(parsed.lastProgressAtMs);
   const logSessionId =
     typeof parsed.logSessionId === "string" ? parsed.logSessionId : undefined;
-  const actorValue = parsed.actor ?? parsed.requester;
+  const actorValue =
+    parsed.actor !== undefined ? parsed.actor : parsed.requester;
   const actor = actorValue === undefined ? undefined : parseActor(actorValue);
   const startedAtMs = toFiniteNonNegativeNumber(parsed.startedAtMs);
   const surface = parseAgentTurnSurface(parsed.surface);
@@ -735,6 +736,8 @@ export async function upsertAgentTurnSessionRecord(args: {
   state: AgentTurnSessionStatus;
   surface?: AgentTurnSurface;
   piMessages: PiMessage[];
+  /** Provenance for trailing newly committed messages, such as steering. */
+  trailingMessageProvenance?: PiMessageProvenance[];
   actor?: Actor;
   resumeReason?: AgentTurnResumeReason;
   errorMessage?: string;
@@ -757,6 +760,9 @@ export async function upsertAgentTurnSessionRecord(args: {
     messages: args.piMessages,
     ...(instructionActor
       ? { newMessageProvenance: instructionProvenanceFor(instructionActor) }
+      : {}),
+    ...(args.trailingMessageProvenance
+      ? { trailingMessageProvenance: args.trailingMessageProvenance }
       : {}),
     ttlMs,
   });

--- a/packages/junior/tests/component/plugins/plugin-tasks.test.ts
+++ b/packages/junior/tests/component/plugins/plugin-tasks.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import {
   createLocalSource,
+  createSlackSource,
   defineJuniorPlugin,
   type PluginRunContext,
 } from "@sentry/junior-plugin-api";
@@ -183,11 +184,30 @@ describe("plugin background tasks", () => {
         conversationId: runConversationId,
         destination: runDestination,
         runId: runSessionId,
+        // Exposed from the full-run provenance: the single instruction author.
+        actors: [
+          {
+            fullName: "Local CLI",
+            platform: "local",
+            userId: "local-cli",
+            userName: "local",
+          },
+        ],
         transcript: [
           {
             type: "message",
             role: "user",
             text: "I prefer pull request summaries with test evidence.",
+            provenance: {
+              authority: "instruction",
+              actor: {
+                fullName: "Local CLI",
+                platform: "local",
+                userId: "local-cli",
+                userName: "local",
+              },
+            },
+            isRunActor: true,
           },
           {
             type: "toolResult",
@@ -210,6 +230,336 @@ describe("plugin background tasks", () => {
         source: runSource,
       }),
     ]);
+  });
+
+  it("exposes only the instruction content when a user turn embeds another user's thread-transcript block", async () => {
+    const runId = randomUUID();
+    const runConversationId = `${conversationId}-embedded-${runId}`;
+    const runSessionId = `${sessionId}:embedded:${runId}`;
+    const runSource = createLocalSource(runConversationId);
+    const queue = new PluginTaskQueueTestAdapter();
+    const loadedRuns: PluginRunContext[] = [];
+    const { setPlugins } = await import("@/chat/plugins/agent-hooks");
+    const { processPluginTask, scheduleSessionCompletedPluginTasks } =
+      await import("@/chat/plugins/task-runner");
+    const { upsertAgentTurnSessionRecord } =
+      await import("@/chat/state/turn-session");
+    setPlugins([
+      defineJuniorPlugin({
+        manifest: {
+          name: "task-embedded-demo",
+          displayName: "Task Embedded Demo",
+          description: "Task embedded demo",
+        },
+        tasks: {
+          processSession: {
+            async run(ctx) {
+              loadedRuns.push(await ctx.run.load());
+            },
+          },
+        },
+      }),
+    ]);
+
+    // The live runtime embeds prior-thread context (here Bob's verbatim
+    // message) in the same user-turn text that carries the current
+    // instruction. The projection must never surface that embedded text on an
+    // instruction-authority entry.
+    const embeddedUserText = [
+      "<thread-transcript>",
+      '  <message index="1" role="user" author="bob" actor_id="U_BOB">',
+      "  I prefer really short, emoji-heavy summaries when these get written up.",
+      "  </message>",
+      "</thread-transcript>",
+      "",
+      '<current-instruction author_id="local-cli">',
+      "What are the takeaways so far?",
+      "</current-instruction>",
+    ].join("\n");
+
+    await upsertAgentTurnSessionRecord({
+      conversationId: runConversationId,
+      destination: { ...destination, conversationId: runConversationId },
+      piMessages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: embeddedUserText }],
+        },
+        { role: "assistant", content: "Here are the takeaways." },
+      ] as PiMessage[],
+      sessionId: runSessionId,
+      sliceId: 1,
+      source: runSource,
+      actor: {
+        fullName: "Local CLI",
+        platform: "local",
+        userId: "local-cli",
+        userName: "local",
+      },
+      state: "completed",
+      surface: "internal",
+      turnStartMessageIndex: 0,
+    });
+
+    await scheduleSessionCompletedPluginTasks(
+      { conversationId: runConversationId, sessionId: runSessionId },
+      { send: (message) => queue.send(message) },
+    );
+    await processPluginTask(queue.queuedMessages()[0]!);
+
+    const transcript = loadedRuns[0]!.transcript;
+    const instructionEntries = transcript.filter(
+      (entry) =>
+        entry.type === "message" &&
+        entry.role === "user" &&
+        entry.provenance?.authority === "instruction",
+    );
+    expect(instructionEntries).toEqual([
+      {
+        type: "message",
+        role: "user",
+        text: "What are the takeaways so far?",
+        provenance: {
+          authority: "instruction",
+          actor: {
+            fullName: "Local CLI",
+            platform: "local",
+            userId: "local-cli",
+            userName: "local",
+          },
+        },
+        isRunActor: true,
+      },
+    ]);
+    // Bob's embedded preference must not appear in ANY instruction-authority
+    // entry, so a passive consumer cannot cite Alice's instruction while
+    // reading Bob's text out of the same block.
+    for (const entry of instructionEntries) {
+      expect(entry.type === "message" && entry.text).not.toMatch(/emoji/i);
+      expect(entry.type === "message" && entry.text).not.toMatch(
+        /thread-transcript/,
+      );
+    }
+  });
+
+  it("projects prior public Slack thread messages as context-authority transcript entries", async () => {
+    const teamId = "T123";
+    const channelId = "C123";
+    const slackConversationId = "slack:C123:1700000000.000000";
+    const slackSessionId = "slack-session-context";
+    const alice = {
+      platform: "slack",
+      teamId,
+      userId: "U_ALICE",
+      userName: "alice",
+    } as const;
+    const source = createSlackSource({
+      teamId,
+      channelId,
+      type: "pub",
+      messageTs: "1700000000.000100",
+      threadTs: "1700000000.000000",
+    });
+    const loadedRuns: PluginRunContext[] = [];
+    const queue = new PluginTaskQueueTestAdapter();
+    const { setPlugins } = await import("@/chat/plugins/agent-hooks");
+    const { processPluginTask, scheduleSessionCompletedPluginTasks } =
+      await import("@/chat/plugins/task-runner");
+    const { upsertAgentTurnSessionRecord } =
+      await import("@/chat/state/turn-session");
+    const { persistThreadStateById } =
+      await import("@/chat/runtime/thread-state");
+    const { coerceThreadConversationState } =
+      await import("@/chat/state/conversation");
+    setPlugins([
+      defineJuniorPlugin({
+        manifest: {
+          name: "task-context-demo",
+          displayName: "Task Context Demo",
+          description: "Task context demo",
+        },
+        tasks: {
+          processSession: {
+            async run(ctx) {
+              loadedRuns.push(await ctx.run.load());
+            },
+          },
+        },
+      }),
+    ]);
+
+    await persistThreadStateById(slackConversationId, {
+      conversation: coerceThreadConversationState({
+        conversation: {
+          messages: [
+            {
+              id: "m-bob",
+              role: "user",
+              text: "Bob's prior note: incident runbooks live in Notion.",
+              createdAtMs: 1,
+              author: { userId: "U_BOB", userName: "bob" },
+            },
+            {
+              id: "m-alice",
+              role: "user",
+              text: "Deploy the release now.",
+              createdAtMs: 2,
+              author: { userId: "U_ALICE", userName: "alice" },
+            },
+          ],
+        },
+      }),
+    });
+
+    await upsertAgentTurnSessionRecord({
+      conversationId: slackConversationId,
+      destination: { platform: "slack", teamId, channelId },
+      piMessages: [
+        { role: "user", content: "Deploy the release now." },
+        { role: "assistant", content: "On it." },
+      ] as PiMessage[],
+      sessionId: slackSessionId,
+      sliceId: 1,
+      source,
+      actor: alice,
+      state: "completed",
+      surface: "slack",
+      turnStartMessageIndex: 0,
+    });
+
+    await scheduleSessionCompletedPluginTasks(
+      { conversationId: slackConversationId, sessionId: slackSessionId },
+      { send: (message) => queue.send(message) },
+    );
+    await processPluginTask(queue.queuedMessages()[0]!);
+
+    const transcript = loadedRuns[0]!.transcript;
+    expect(transcript).toContainEqual({
+      type: "message",
+      role: "user",
+      text: "Bob's prior note: incident runbooks live in Notion.",
+      provenance: {
+        authority: "context",
+        actor: { platform: "slack", teamId, userId: "U_BOB", userName: "bob" },
+      },
+      isRunActor: false,
+    });
+    // The active run-actor instruction appears once; the context projection is
+    // deduplicated against messages already present in the run transcript.
+    expect(
+      transcript.filter(
+        (entry) =>
+          entry.type === "message" && entry.text === "Deploy the release now.",
+      ),
+    ).toEqual([
+      {
+        type: "message",
+        role: "user",
+        text: "Deploy the release now.",
+        provenance: { authority: "instruction", actor: alice },
+        isRunActor: true,
+      },
+    ]);
+  });
+
+  it("adds no context transcript entries for private Slack sources", async () => {
+    const teamId = "T123";
+    const channelId = "D123";
+    const slackConversationId = "slack:D123:1700000000.000000";
+    const slackSessionId = "slack-session-private";
+    const alice = {
+      platform: "slack",
+      teamId,
+      userId: "U_ALICE",
+      userName: "alice",
+    } as const;
+    const source = createSlackSource({
+      teamId,
+      channelId,
+      type: "priv",
+      messageTs: "1700000000.000100",
+      threadTs: "1700000000.000000",
+    });
+    const loadedRuns: PluginRunContext[] = [];
+    const queue = new PluginTaskQueueTestAdapter();
+    const { setPlugins } = await import("@/chat/plugins/agent-hooks");
+    const { processPluginTask, scheduleSessionCompletedPluginTasks } =
+      await import("@/chat/plugins/task-runner");
+    const { upsertAgentTurnSessionRecord } =
+      await import("@/chat/state/turn-session");
+    const { persistThreadStateById } =
+      await import("@/chat/runtime/thread-state");
+    const { coerceThreadConversationState } =
+      await import("@/chat/state/conversation");
+    setPlugins([
+      defineJuniorPlugin({
+        manifest: {
+          name: "task-private-demo",
+          displayName: "Task Private Demo",
+          description: "Task private demo",
+        },
+        tasks: {
+          processSession: {
+            async run(ctx) {
+              loadedRuns.push(await ctx.run.load());
+            },
+          },
+        },
+      }),
+    ]);
+
+    await persistThreadStateById(slackConversationId, {
+      conversation: coerceThreadConversationState({
+        conversation: {
+          messages: [
+            {
+              id: "m-bob",
+              role: "user",
+              text: "Bob's private note stays out of the transcript.",
+              createdAtMs: 1,
+              author: { userId: "U_BOB", userName: "bob" },
+            },
+          ],
+        },
+      }),
+    });
+
+    await upsertAgentTurnSessionRecord({
+      conversationId: slackConversationId,
+      destination: { platform: "slack", teamId, channelId },
+      piMessages: [
+        { role: "user", content: "Handle this direct message." },
+        { role: "assistant", content: "Sure." },
+      ] as PiMessage[],
+      sessionId: slackSessionId,
+      sliceId: 1,
+      source,
+      actor: alice,
+      state: "completed",
+      surface: "slack",
+      turnStartMessageIndex: 0,
+    });
+
+    await scheduleSessionCompletedPluginTasks(
+      { conversationId: slackConversationId, sessionId: slackSessionId },
+      { send: (message) => queue.send(message) },
+    );
+    await processPluginTask(queue.queuedMessages()[0]!);
+
+    const transcript = loadedRuns[0]!.transcript;
+    expect(
+      transcript.some(
+        (entry) =>
+          entry.type === "message" && entry.provenance?.authority === "context",
+      ),
+    ).toBe(false);
+    expect(
+      transcript.some(
+        (entry) =>
+          entry.type === "message" &&
+          entry.text === "Bob's private note stays out of the transcript.",
+      ),
+    ).toBe(false);
   });
 
   it("lets task failures bubble to the queue retry boundary", async () => {

--- a/packages/junior/tests/component/plugins/plugin-tasks.test.ts
+++ b/packages/junior/tests/component/plugins/plugin-tasks.test.ts
@@ -78,6 +78,7 @@ afterEach(async () => {
   const { disconnectStateAdapter } = await import("@/chat/state/adapter");
   setPlugins([]);
   await disconnectStateAdapter();
+  vi.useRealTimers();
   vi.resetModules();
   process.env = { ...ORIGINAL_ENV };
 });
@@ -460,6 +461,125 @@ describe("plugin background tasks", () => {
         isRunActor: true,
       },
     ]);
+  });
+
+  it("bounds public Slack context transcript entries to the completed run window", async () => {
+    const teamId = "T123";
+    const channelId = "C123";
+    const completionMs = 1_700_000_001_000;
+    const slackConversationId = "slack:C123:1700000000.000200";
+    const slackSessionId = "slack-session-context-window";
+    const alice = {
+      platform: "slack",
+      teamId,
+      userId: "U_ALICE",
+      userName: "alice",
+    } as const;
+    const source = createSlackSource({
+      teamId,
+      channelId,
+      type: "pub",
+      messageTs: "1700000000.950000",
+      threadTs: "1700000000.000200",
+    });
+    const loadedRuns: PluginRunContext[] = [];
+    const queue = new PluginTaskQueueTestAdapter();
+    const { setPlugins } = await import("@/chat/plugins/agent-hooks");
+    const { processPluginTask, scheduleSessionCompletedPluginTasks } =
+      await import("@/chat/plugins/task-runner");
+    const { getAgentTurnSessionRecord, upsertAgentTurnSessionRecord } =
+      await import("@/chat/state/turn-session");
+    const { persistThreadStateById } =
+      await import("@/chat/runtime/thread-state");
+    const { coerceThreadConversationState } =
+      await import("@/chat/state/conversation");
+    setPlugins([
+      defineJuniorPlugin({
+        manifest: {
+          name: "task-context-window-demo",
+          displayName: "Task Context Window Demo",
+          description: "Task context window demo",
+        },
+        tasks: {
+          processSession: {
+            async run(ctx) {
+              loadedRuns.push(await ctx.run.load());
+            },
+          },
+        },
+      }),
+    ]);
+
+    vi.useFakeTimers({ now: completionMs });
+    await upsertAgentTurnSessionRecord({
+      conversationId: slackConversationId,
+      destination: { platform: "slack", teamId, channelId },
+      piMessages: [
+        { role: "user", content: "Summarize the thread context." },
+        { role: "assistant", content: "On it." },
+      ] as PiMessage[],
+      sessionId: slackSessionId,
+      sliceId: 1,
+      source,
+      actor: alice,
+      state: "completed",
+      surface: "slack",
+      turnStartMessageIndex: 0,
+    });
+    expect(
+      await getAgentTurnSessionRecord(slackConversationId, slackSessionId),
+    ).toMatchObject({ updatedAtMs: completionMs });
+
+    vi.setSystemTime(completionMs + 10_000);
+    await persistThreadStateById(slackConversationId, {
+      conversation: coerceThreadConversationState({
+        conversation: {
+          messages: [
+            {
+              id: "m-before-completion",
+              role: "user",
+              text: "Before completion: staging smoke tests passed.",
+              createdAtMs: completionMs - 500,
+              meta: { slackTs: "1700000000.900000" },
+              author: { userId: "U_BOB", userName: "bob" },
+            },
+            {
+              id: "m-after-completion",
+              role: "user",
+              text: "After completion: cite this only in the next run.",
+              createdAtMs: completionMs - 500,
+              meta: { slackTs: "1700000001.100000" },
+              author: { userId: "U_CAROL", userName: "carol" },
+            },
+          ],
+        },
+      }),
+    });
+
+    await scheduleSessionCompletedPluginTasks(
+      { conversationId: slackConversationId, sessionId: slackSessionId },
+      { send: (message) => queue.send(message) },
+    );
+    await processPluginTask(queue.queuedMessages()[0]!);
+
+    const transcript = loadedRuns[0]!.transcript;
+    expect(transcript).toContainEqual({
+      type: "message",
+      role: "user",
+      text: "Before completion: staging smoke tests passed.",
+      provenance: {
+        authority: "context",
+        actor: { platform: "slack", teamId, userId: "U_BOB", userName: "bob" },
+      },
+      isRunActor: false,
+    });
+    expect(
+      transcript.some(
+        (entry) =>
+          entry.type === "message" &&
+          entry.text === "After completion: cite this only in the next run.",
+      ),
+    ).toBe(false);
   });
 
   it("loads actor-less legacy completed session records without run authority", async () => {

--- a/packages/junior/tests/component/plugins/plugin-tasks.test.ts
+++ b/packages/junior/tests/component/plugins/plugin-tasks.test.ts
@@ -462,6 +462,79 @@ describe("plugin background tasks", () => {
     ]);
   });
 
+  it("loads actor-less legacy completed session records without run authority", async () => {
+    const runId = randomUUID();
+    const runConversationId = `${conversationId}-actorless-${runId}`;
+    const runSessionId = `${sessionId}:actorless:${runId}`;
+    const runSource = createLocalSource(runConversationId);
+    const loadedRuns: PluginRunContext[] = [];
+    const queue = new PluginTaskQueueTestAdapter();
+    const { setPlugins } = await import("@/chat/plugins/agent-hooks");
+    const { processPluginTask, scheduleSessionCompletedPluginTasks } =
+      await import("@/chat/plugins/task-runner");
+    const { upsertAgentTurnSessionRecord } =
+      await import("@/chat/state/turn-session");
+    setPlugins([
+      defineJuniorPlugin({
+        manifest: {
+          name: "task-actorless-demo",
+          displayName: "Task Actorless Demo",
+          description: "Task actorless demo",
+        },
+        tasks: {
+          processSession: {
+            async run(ctx) {
+              loadedRuns.push(await ctx.run.load());
+            },
+          },
+        },
+      }),
+    ]);
+
+    await upsertAgentTurnSessionRecord({
+      conversationId: runConversationId,
+      destination: { ...destination, conversationId: runConversationId },
+      piMessages: [
+        { role: "user", content: "Run a legacy system task." },
+        { role: "assistant", content: "Done." },
+      ] as PiMessage[],
+      sessionId: runSessionId,
+      sliceId: 1,
+      source: runSource,
+      state: "completed",
+      surface: "internal",
+      turnStartMessageIndex: 0,
+    });
+
+    await scheduleSessionCompletedPluginTasks(
+      { conversationId: runConversationId, sessionId: runSessionId },
+      { send: (message) => queue.send(message) },
+    );
+    await processPluginTask(queue.queuedMessages()[0]!);
+
+    expect(loadedRuns).toHaveLength(1);
+    expect(loadedRuns[0]).not.toHaveProperty("actor");
+    expect(loadedRuns[0]).toMatchObject({
+      actors: [],
+      conversationId: runConversationId,
+      runId: runSessionId,
+      transcript: [
+        {
+          type: "message",
+          role: "user",
+          text: "Run a legacy system task.",
+          provenance: { authority: "context" },
+          isRunActor: false,
+        },
+        {
+          type: "message",
+          role: "assistant",
+          text: "Done.",
+        },
+      ],
+    });
+  });
+
   it("adds no context transcript entries for private Slack sources", async () => {
     const teamId = "T123";
     const channelId = "D123";

--- a/packages/junior/tests/component/services/context-compaction.test.ts
+++ b/packages/junior/tests/component/services/context-compaction.test.ts
@@ -235,6 +235,64 @@ describe("context compaction projection reset", () => {
     });
   });
 
+  it("preserves retained user provenance positionally when authors send identical text", async () => {
+    const { createContextCompactor } =
+      await import("@/chat/services/context-compaction");
+    const { coerceThreadConversationState } =
+      await import("@/chat/state/conversation");
+    const { commitMessages, loadProjectionWithProvenance } =
+      await import("@/chat/state/session-log");
+
+    const alice = {
+      platform: "slack" as const,
+      teamId: "T123",
+      userId: "U_ALICE",
+      userName: "alice",
+    };
+    const bob = {
+      platform: "slack" as const,
+      teamId: "T123",
+      userId: "U_BOB",
+      userName: "bob",
+    };
+    const priorMessages = [user("same request", 1), user("same request", 2)];
+
+    await commitMessages({
+      conversationId: "conversation-identical-retained-text",
+      messages: priorMessages,
+      ttlMs: 60_000,
+      provenance: [
+        { authority: "instruction", actor: alice },
+        { authority: "instruction", actor: bob },
+      ],
+    });
+
+    const compactor = createContextCompactor({
+      completeText: async () =>
+        ({ text: "Both matching requests remain distinct." }) as never,
+      autoCompactionTriggerTokens: 0,
+    });
+
+    const result = await compactor.maybeCompact({
+      conversation: coerceThreadConversationState({}),
+      conversationId: "conversation-identical-retained-text",
+      piMessages: priorMessages,
+    });
+
+    expect(result.compacted).toBe(true);
+    const projection = await loadProjectionWithProvenance({
+      conversationId: "conversation-identical-retained-text",
+    });
+    expect(projection.messages.slice(0, 2).map(textOf)).toEqual([
+      "same request",
+      "same request",
+    ]);
+    expect(projection.provenance.slice(0, 2)).toEqual([
+      { authority: "instruction", actor: alice },
+      { authority: "instruction", actor: bob },
+    ]);
+  });
+
   it("summarizes recent history when compaction input is oversized", async () => {
     const { createContextCompactor } =
       await import("@/chat/services/context-compaction");

--- a/packages/junior/tests/component/services/context-compaction.test.ts
+++ b/packages/junior/tests/component/services/context-compaction.test.ts
@@ -182,11 +182,16 @@ describe("context compaction projection reset", () => {
       conversationId: "conversation-1",
       messages: priorMessages,
       ttlMs: 60_000,
-      actor: {
-        slackUserId: "U123",
-        slackUserName: "alice",
-        fullName: "Alice Example",
-        email: "alice@sentry.io",
+      newMessageProvenance: {
+        authority: "instruction",
+        actor: {
+          platform: "slack",
+          teamId: "T123",
+          userId: "U123",
+          userName: "alice",
+          fullName: "Alice Example",
+          email: "alice@sentry.io",
+        },
       },
     });
     const conversation = coerceThreadConversationState({});

--- a/packages/junior/tests/component/services/turn-session-record.test.ts
+++ b/packages/junior/tests/component/services/turn-session-record.test.ts
@@ -466,6 +466,138 @@ describe("persistAuthPauseSessionRecord", () => {
     expect(summaries[0]).not.toHaveProperty("turnStartMessageIndex");
   });
 
+  it("persists and materializes per-message provenance aligned to piMessages", async () => {
+    const { getAgentTurnSessionRecord, upsertAgentTurnSessionRecord } =
+      await import("@/chat/state/turn-session");
+
+    const priorContext: PiMessage = {
+      role: "user",
+      content: [{ type: "text", text: "prior context" }],
+      timestamp: 1,
+    } as PiMessage;
+    const currentQuestion: PiMessage = {
+      role: "user",
+      content: [{ type: "text", text: "current question" }],
+      timestamp: 2,
+    } as PiMessage;
+    const answer: PiMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "answer" }],
+      timestamp: 3,
+    } as PiMessage;
+
+    await upsertAgentTurnSessionRecord({
+      conversationId: "conversation-provenance",
+      sessionId: "turn-provenance",
+      sliceId: 1,
+      state: "completed",
+      piMessages: [priorContext, currentQuestion, answer],
+      actor: {
+        platform: "slack",
+        teamId: "T123",
+        userId: "U123",
+        userName: "alice",
+      },
+    });
+
+    const record = await getAgentTurnSessionRecord(
+      "conversation-provenance",
+      "turn-provenance",
+    );
+    // The current turn's user input is an instruction attributed to its actor;
+    // prior context and assistant output are unattributed context.
+    expect(record?.piMessageProvenance).toEqual([
+      { authority: "context" },
+      {
+        authority: "instruction",
+        actor: {
+          platform: "slack",
+          teamId: "T123",
+          userId: "U123",
+          userName: "alice",
+        },
+      },
+      { authority: "context" },
+    ]);
+    expect(record?.piMessageProvenance).toHaveLength(record!.piMessages.length);
+  });
+
+  it("derives run actors across steering by a second author and reproduces the set on re-materialization", async () => {
+    const { getAgentTurnSessionRecord, upsertAgentTurnSessionRecord } =
+      await import("@/chat/state/turn-session");
+
+    const alice = {
+      platform: "slack" as const,
+      teamId: "T123",
+      userId: "U_ALICE",
+      userName: "alice",
+    };
+    const bob = {
+      platform: "slack" as const,
+      teamId: "T123",
+      userId: "U_BOB",
+      userName: "bob",
+    };
+    const aliceMessage: PiMessage = {
+      role: "user",
+      content: [{ type: "text", text: "start the deploy" }],
+      timestamp: 1,
+    } as PiMessage;
+    const bobMessage: PiMessage = {
+      role: "user",
+      content: [{ type: "text", text: "actually wait, run the tests first" }],
+      timestamp: 2,
+    } as PiMessage;
+
+    await upsertAgentTurnSessionRecord({
+      conversationId: "conversation-multi-actor",
+      sessionId: "turn-multi-actor",
+      sliceId: 1,
+      state: "running",
+      piMessages: [aliceMessage],
+      actor: alice,
+    });
+    // A second human steers the same run; their message commits as an
+    // instruction attributed to bob, so bob joins the actor set.
+    await upsertAgentTurnSessionRecord({
+      conversationId: "conversation-multi-actor",
+      sessionId: "turn-multi-actor",
+      sliceId: 2,
+      state: "completed",
+      piMessages: [aliceMessage, bobMessage],
+      actor: bob,
+    });
+
+    // getAgentTurnSessionRecord re-materializes from the stored record and the
+    // committed provenance, so this is also the continuation/materialization
+    // path — it must reproduce the same first-seen-ordered set.
+    const record = await getAgentTurnSessionRecord(
+      "conversation-multi-actor",
+      "turn-multi-actor",
+    );
+    expect(record?.actors).toEqual([alice, bob]);
+  });
+
+  it("has an empty run-actors set for a system-actor run with no human instructions", async () => {
+    const { getAgentTurnSessionRecord, upsertAgentTurnSessionRecord } =
+      await import("@/chat/state/turn-session");
+
+    await upsertAgentTurnSessionRecord({
+      conversationId: "conversation-system-actor",
+      sessionId: "turn-system-actor",
+      sliceId: 1,
+      state: "completed",
+      // No actor: nothing is attributed as an instruction actor.
+      piMessages: [userMessage("system dispatch input")],
+    });
+
+    const record = await getAgentTurnSessionRecord(
+      "conversation-system-actor",
+      "turn-system-actor",
+    );
+    expect(record?.actors).toEqual([]);
+  });
+
   it("carries cumulative diagnostics across pause records", async () => {
     const { persistTimeoutSessionRecord } =
       await import("@/chat/services/turn-session-record");

--- a/packages/junior/tests/component/services/turn-session-record.test.ts
+++ b/packages/junior/tests/component/services/turn-session-record.test.ts
@@ -395,6 +395,63 @@ describe("persistAuthPauseSessionRecord", () => {
     });
   });
 
+  it("decodes legacy stored requester as the bound actor on rehydration", async () => {
+    const { getStateAdapter } = await import("@/chat/state/adapter");
+    const { commitMessages } = await import("@/chat/state/session-log");
+    const { getAgentTurnSessionRecord } =
+      await import("@/chat/state/turn-session");
+
+    const actor = {
+      platform: "slack" as const,
+      teamId: "T123",
+      userId: "U123",
+      userName: "alice",
+      fullName: "Alice Example",
+      email: "alice@sentry.io",
+    };
+    const message = userMessage("resume the deploy");
+
+    await commitMessages({
+      conversationId: "conversation-legacy-requester",
+      messages: [message],
+      ttlMs: 60_000,
+      provenance: [{ authority: "instruction", actor }],
+    });
+
+    const stateAdapter = getStateAdapter();
+    await stateAdapter.connect();
+    await stateAdapter.set(
+      "junior:agent_turn_session:conversation-legacy-requester:turn-legacy-requester",
+      {
+        version: 1,
+        conversationId: "conversation-legacy-requester",
+        sessionId: "turn-legacy-requester",
+        sliceId: 1,
+        state: "awaiting_resume",
+        startedAtMs: 1,
+        lastProgressAtMs: 1,
+        updatedAtMs: 1,
+        cumulativeDurationMs: 0,
+        committedMessageCount: 1,
+        committedMessageProvenance: [{ authority: "instruction", actor }],
+        requester: actor,
+        resumeReason: "auth",
+      },
+      60_000,
+    );
+
+    await expect(
+      getAgentTurnSessionRecord(
+        "conversation-legacy-requester",
+        "turn-legacy-requester",
+      ),
+    ).resolves.toMatchObject({
+      actor,
+      actors: [actor],
+      piMessages: [message],
+    });
+  });
+
   it("persists turn transcript scope and actor in the session log", async () => {
     const {
       getAgentTurnSessionRecord,
@@ -522,8 +579,10 @@ describe("persistAuthPauseSessionRecord", () => {
     expect(record?.piMessageProvenance).toHaveLength(record!.piMessages.length);
   });
 
-  it("derives run actors across steering by a second author and reproduces the set on re-materialization", async () => {
-    const { getAgentTurnSessionRecord, upsertAgentTurnSessionRecord } =
+  it("derives run actors from steered message provenance while preserving the run actor", async () => {
+    const { persistRunningSessionRecord } =
+      await import("@/chat/services/turn-session-record");
+    const { getAgentTurnSessionRecord } =
       await import("@/chat/state/turn-session");
 
     const alice = {
@@ -549,23 +608,28 @@ describe("persistAuthPauseSessionRecord", () => {
       timestamp: 2,
     } as PiMessage;
 
-    await upsertAgentTurnSessionRecord({
+    await persistRunningSessionRecord({
       conversationId: "conversation-multi-actor",
       sessionId: "turn-multi-actor",
       sliceId: 1,
-      state: "running",
-      piMessages: [aliceMessage],
+      messages: [aliceMessage],
       actor: alice,
+      logContext: {
+        modelId: "test-model",
+      },
     });
     // A second human steers the same run; their message commits as an
-    // instruction attributed to bob, so bob joins the actor set.
-    await upsertAgentTurnSessionRecord({
+    // instruction attributed to bob, while Alice remains the bound run actor.
+    await persistRunningSessionRecord({
       conversationId: "conversation-multi-actor",
       sessionId: "turn-multi-actor",
       sliceId: 2,
-      state: "completed",
-      piMessages: [aliceMessage, bobMessage],
-      actor: bob,
+      messages: [aliceMessage, bobMessage],
+      actor: alice,
+      trailingMessageProvenance: [{ authority: "instruction", actor: bob }],
+      logContext: {
+        modelId: "test-model",
+      },
     });
 
     // getAgentTurnSessionRecord re-materializes from the stored record and the
@@ -575,6 +639,11 @@ describe("persistAuthPauseSessionRecord", () => {
       "conversation-multi-actor",
       "turn-multi-actor",
     );
+    expect(record?.actor).toEqual(alice);
+    expect(record?.piMessageProvenance).toEqual([
+      { authority: "instruction", actor: alice },
+      { authority: "instruction", actor: bob },
+    ]);
     expect(record?.actors).toEqual([alice, bob]);
   });
 

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -302,6 +302,14 @@ describe("local agent runner", () => {
             type: "message",
             role: "user",
             text: "capture this local turn",
+            isRunActor: true,
+            provenance: {
+              authority: "instruction",
+              actor: expect.objectContaining({
+                platform: "local",
+                userId: "local-cli",
+              }),
+            },
           },
           {
             type: "message",
@@ -313,6 +321,12 @@ describe("local agent runner", () => {
           platform: "local",
           userId: "local-cli",
         }),
+        actors: [
+          expect.objectContaining({
+            platform: "local",
+            userId: "local-cli",
+          }),
+        ],
         source: {
           platform: "local",
           type: "priv",

--- a/packages/junior/tests/integration/plugin-prompt-hooks.test.ts
+++ b/packages/junior/tests/integration/plugin-prompt-hooks.test.ts
@@ -232,7 +232,9 @@ describe("plugin prompt hooks", () => {
       },
       durability: {
         drainSteeringMessages: async (inject) => {
-          await inject([{ text: "steer me" }]);
+          await inject([
+            { text: "steer me", provenance: { authority: "instruction" } },
+          ]);
           return [];
         },
       },

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -6,7 +6,10 @@ import { getSlackInterruptionMarker } from "@/chat/slack/output";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import { acquireActiveLock } from "@/chat/state/locks";
-import { loadProjection } from "@/chat/state/session-log";
+import {
+  loadProjection,
+  loadProjectionWithProvenance,
+} from "@/chat/state/session-log";
 import {
   getAgentTurnSessionRecord,
   upsertAgentTurnSessionRecord,
@@ -1348,6 +1351,78 @@ describe("bot handlers (integration)", () => {
     const serialized = JSON.stringify(await loadProjection({ conversationId }));
     expect(serialized.split("first follow-up")).toHaveLength(2);
     expect(serialized.split("second follow-up")).toHaveLength(2);
+  });
+
+  it("records each parked follow-up author's own instruction provenance", async () => {
+    const conversationId = "slack:C9PARKEDAUTH:1700000000.000";
+    const destination = slackDestination("C9PARKEDAUTH");
+    const activeSessionId = "turn_msg-original";
+    await upsertAgentTurnSessionRecord({
+      conversationId,
+      sessionId: activeSessionId,
+      sliceId: 1,
+      state: "awaiting_resume",
+      resumeReason: "yield",
+      destination,
+      source: createSlackSourceForTest("C9PARKEDAUTH"),
+      piMessages: turnPiMessages("please keep working"),
+      turnStartMessageIndex: 0,
+    });
+    const { slackRuntime } = createRuntime({
+      services: {
+        replyExecutor: {
+          agentRunner: { run: vi.fn() },
+          scheduleAgentContinue: vi.fn(),
+        },
+      },
+    });
+    const thread = createTestThread({
+      id: conversationId,
+      state: createAwaitingContinuationState({ activeSessionId }),
+    });
+    const fromAlice = createTestMessage({
+      id: "msg-parked-alice",
+      threadId: conversationId,
+      text: "alice question",
+      isMention: true,
+      author: { userId: "U-alice" },
+    });
+    const fromBob = createTestMessage({
+      id: "msg-parked-bob",
+      threadId: conversationId,
+      text: "bob question",
+      isMention: true,
+      author: { userId: "U-bob" },
+    });
+
+    // A single drain carries two mentions from different authors: each must
+    // keep its own author, not be collapsed to one latest-wins actor.
+    await slackRuntime.handleNewMention(thread, fromBob, {
+      destination,
+      messageContext: { skipped: [fromAlice], totalSinceLastHandler: 1 },
+    });
+
+    const projection = await loadProjectionWithProvenance({ conversationId });
+    const entries = projection.messages.map((message, index) => ({
+      text: JSON.stringify(
+        (message as { content?: unknown }).content ?? message,
+      ),
+      provenance: projection.provenance[index],
+    }));
+    const aliceEntry = entries.find((entry) =>
+      entry.text.includes("alice question"),
+    );
+    const bobEntry = entries.find((entry) =>
+      entry.text.includes("bob question"),
+    );
+    expect(aliceEntry?.provenance).toMatchObject({
+      authority: "instruction",
+      actor: { platform: "slack", teamId: "T123", userId: "U-alice" },
+    });
+    expect(bobEntry?.provenance).toMatchObject({
+      authority: "instruction",
+      actor: { platform: "slack", teamId: "T123", userId: "U-bob" },
+    });
   });
 
   it("leaves the parked follow-up unconsumed while a live resume holds the thread lock", async () => {

--- a/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
@@ -248,6 +248,7 @@ describe("Slack behavior: durable turn steering", () => {
       prompt: string;
       steeringTexts: string[];
     }> = [];
+    const steeringProvenance: AgentRunSteeringMessage["provenance"][] = [];
     const state = getStateAdapter();
     const executeAgentRun: AgentRunner["run"] = async (request) => {
       const prompt = request.input.messageText;
@@ -268,6 +269,9 @@ describe("Slack behavior: durable turn steering", () => {
         steeringMessages.push(...drained);
       }
 
+      steeringProvenance.push(
+        ...steeringMessages.map((message) => message.provenance),
+      );
       const steeringTexts = steeringMessages.map((message) => message.text);
       agentCalls.push({
         context: request.input.conversationContext,
@@ -360,6 +364,19 @@ describe("Slack behavior: durable turn steering", () => {
         context: undefined,
         prompt: "start the incident summary",
         steeringTexts: ["include the rollback owner"],
+      },
+    ]);
+
+    // The steered follow-up keeps its own Slack author as an instruction,
+    // rather than being attributed to the current run's actor.
+    expect(steeringProvenance).toEqual([
+      {
+        authority: "instruction",
+        actor: expect.objectContaining({
+          platform: "slack",
+          teamId: "T123",
+          userId: "U123",
+        }),
       },
     ]);
 

--- a/packages/junior/tests/unit/runtime/agent-run-provider-retry.test.ts
+++ b/packages/junior/tests/unit/runtime/agent-run-provider-retry.test.ts
@@ -487,7 +487,11 @@ describe("executeAgentRun provider retry", () => {
         durability: {
           drainSteeringMessages: async (inject) => {
             const messages = [
-              { text: "actually do the other thing", timestampMs: 2_000 },
+              {
+                text: "actually do the other thing",
+                timestampMs: 2_000,
+                provenance: { authority: "instruction" as const },
+              },
             ];
             await inject(messages);
             injectedTexts.push(...messages.map((message) => message.text));
@@ -613,7 +617,11 @@ describe("executeAgentRun provider retry", () => {
       durability: {
         drainSteeringMessages: async (inject) => {
           const messages = [
-            { text: "actually do the other thing", timestampMs: 2_000 },
+            {
+              text: "actually do the other thing",
+              timestampMs: 2_000,
+              provenance: { authority: "instruction" as const },
+            },
           ];
           await inject(messages);
           return messages;
@@ -783,7 +791,11 @@ describe("executeAgentRun provider retry", () => {
       durability: {
         drainSteeringMessages: async (inject) => {
           const messages = [
-            { text: "actually do the other thing", timestampMs: 2_000 },
+            {
+              text: "actually do the other thing",
+              timestampMs: 2_000,
+              provenance: { authority: "instruction" as const },
+            },
           ];
           try {
             await inject(messages);

--- a/packages/junior/tests/unit/state/session-log.test.ts
+++ b/packages/junior/tests/unit/state/session-log.test.ts
@@ -877,6 +877,26 @@ describe("session log message provenance", () => {
     ).toEqual([alice, aliceTeamB]);
   });
 
+  it("does not collapse Slack actors whose concatenated team and user ids collide", () => {
+    const first = {
+      platform: "slack" as const,
+      teamId: "T1",
+      userId: "1U2",
+    };
+    const second = {
+      platform: "slack" as const,
+      teamId: "T11",
+      userId: "U2",
+    };
+
+    expect(
+      instructionActors([
+        { authority: "instruction", actor: first },
+        { authority: "instruction", actor: second },
+      ]),
+    ).toEqual([first, second]);
+  });
+
   it("excludes context and unattributable instruction messages", () => {
     // A system-actor / no-human run: nothing carries an instruction actor.
     expect(

--- a/packages/junior/tests/unit/state/session-log.test.ts
+++ b/packages/junior/tests/unit/state/session-log.test.ts
@@ -8,6 +8,7 @@ import {
   loadMessages,
   loadProjection,
   loadProjectionWithActor,
+  loadProjectionWithProvenance,
   recordAuthorizationCompleted,
   recordAuthorizationRequested,
   recordMcpProviderConnected,
@@ -592,6 +593,12 @@ describe("session log message provenance", () => {
     fullName: "Alice Example",
     email: "alice@sentry.io",
   };
+  const bob = {
+    platform: "slack" as const,
+    teamId: "T123",
+    userId: "U456",
+    userName: "bob",
+  };
 
   it("attaches instruction provenance to the last new user message on commit", async () => {
     const store = memoryStore();
@@ -667,6 +674,49 @@ describe("session log message provenance", () => {
       provenance: [
         { authority: "context" },
         { authority: "instruction", actor: alice },
+      ],
+    });
+  });
+
+  it("lets trailing provenance override the run actor default for steered messages", async () => {
+    const store = memoryStore();
+    const initial: PiMessage = {
+      role: "user",
+      content: [{ type: "text", text: "start the deploy" }],
+      timestamp: 1,
+    } as PiMessage;
+    const steered: PiMessage = {
+      role: "user",
+      content: [{ type: "text", text: "actually run tests first" }],
+      timestamp: 2,
+    } as PiMessage;
+
+    await commitMessages({
+      store,
+      conversationId: "conv-prov-steering",
+      messages: [initial],
+      ttlMs: 60_000,
+      newMessageProvenance: { authority: "instruction", actor: alice },
+    });
+    await commitMessages({
+      store,
+      conversationId: "conv-prov-steering",
+      messages: [initial, steered],
+      ttlMs: 60_000,
+      newMessageProvenance: { authority: "instruction", actor: alice },
+      trailingMessageProvenance: [{ authority: "instruction", actor: bob }],
+    });
+
+    await expect(
+      loadProjectionWithProvenance({
+        store,
+        conversationId: "conv-prov-steering",
+      }),
+    ).resolves.toEqual({
+      messages: [initial, steered],
+      provenance: [
+        { authority: "instruction", actor: alice },
+        { authority: "instruction", actor: bob },
       ],
     });
   });

--- a/packages/junior/tests/unit/state/session-log.test.ts
+++ b/packages/junior/tests/unit/state/session-log.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PiMessage } from "@/chat/pi/messages";
 import {
   commitMessages,
+  instructionActors,
   loadActivityEntries,
   loadConnectedMcpProviders,
   loadMessages,
@@ -13,6 +14,7 @@ import {
   recordSubagentEnded,
   recordSubagentStarted,
   recordToolExecutionStarted,
+  type PiMessageProvenance,
   type SessionLogEntry,
   type SessionLogStore,
 } from "@/chat/state/session-log";
@@ -66,13 +68,13 @@ describe("agent session log store", () => {
 
     expect(store.entries).toEqual([
       {
-        schemaVersion: 1,
+        schemaVersion: 2,
         type: "pi_message",
         sessionId: "session_0",
         message: first,
       },
       {
-        schemaVersion: 1,
+        schemaVersion: 2,
         type: "pi_message",
         sessionId: "session_0",
         message: second,
@@ -190,22 +192,23 @@ describe("agent session log store", () => {
 
     expect(store.entries).toEqual([
       {
-        schemaVersion: 1,
+        schemaVersion: 2,
         type: "pi_message",
         sessionId: "session_0",
         message: first,
       },
       {
-        schemaVersion: 1,
+        schemaVersion: 2,
         type: "pi_message",
         sessionId: "session_0",
         message: unsafe,
       },
       {
-        schemaVersion: 1,
+        schemaVersion: 2,
         type: "projection_reset",
         sessionId: "session_1",
         messages: [first, replacement],
+        provenance: [{ authority: "context" }, { authority: "context" }],
       },
     ]);
     await expect(
@@ -383,27 +386,27 @@ describe("agent session log store", () => {
       } as unknown as SessionLogEntry,
     );
 
-    await expect(
-      loadProjectionWithActor({
-        store,
-        conversationId: "conversation-1",
-      }),
-    ).resolves.toMatchObject({
-      messages: [
-        first,
-        {
-          role: "user",
-          content: [
-            {
-              type: "text",
-              text: 'Authorization completed for provider "github". Continue the blocked request and retry the provider operation if needed.',
-            },
-          ],
-          timestamp: 2,
-        },
-      ],
-      actor: { slackUserId: "U456", email: "bob@sentry.io" },
+    const projection = await loadProjectionWithActor({
+      store,
+      conversationId: "conversation-1",
     });
+    expect(projection.messages).toEqual([
+      first,
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: 'Authorization completed for provider "github". Continue the blocked request and retry the provider operation if needed.',
+          },
+        ],
+        timestamp: 2,
+      },
+    ]);
+    // Legacy latest-wins actor metadata cannot be aligned to a specific
+    // message, so attribution fails closed instead of adopting the recorded
+    // actor for the whole projection.
+    expect(projection.actor).toBeUndefined();
   });
 
   it("records connected MCP providers outside the Pi projection", async () => {
@@ -435,13 +438,13 @@ describe("agent session log store", () => {
 
     expect(store.entries).toEqual([
       {
-        schemaVersion: 1,
+        schemaVersion: 2,
         type: "pi_message",
         sessionId: "session_0",
         message,
       },
       {
-        schemaVersion: 1,
+        schemaVersion: 2,
         type: "mcp_provider_connected",
         sessionId: "session_0",
         provider: "linear",
@@ -519,13 +522,13 @@ describe("agent session log store", () => {
 
     expect(store.entries).toEqual([
       {
-        schemaVersion: 1,
+        schemaVersion: 2,
         type: "pi_message",
         sessionId: "session_0",
         message,
       },
       {
-        schemaVersion: 1,
+        schemaVersion: 2,
         type: "authorization_requested",
         sessionId: "session_0",
         createdAtMs: 1_000,
@@ -536,7 +539,7 @@ describe("agent session log store", () => {
         delivery: "private_link_sent",
       },
       {
-        schemaVersion: 1,
+        schemaVersion: 2,
         type: "authorization_completed",
         sessionId: "session_0",
         createdAtMs: 1_000,
@@ -580,8 +583,17 @@ describe("agent session log store", () => {
   });
 });
 
-describe("session log actor identity", () => {
-  it("attaches actor to the last new user message on commit", async () => {
+describe("session log message provenance", () => {
+  const alice = {
+    platform: "slack" as const,
+    teamId: "T123",
+    userId: "U123",
+    userName: "alice",
+    fullName: "Alice Example",
+    email: "alice@sentry.io",
+  };
+
+  it("attaches instruction provenance to the last new user message on commit", async () => {
     const store = memoryStore();
     const contextMsg: PiMessage = {
       role: "user",
@@ -596,155 +608,318 @@ describe("session log actor identity", () => {
 
     await commitMessages({
       store,
-      conversationId: "conv-req-1",
+      conversationId: "conv-prov-1",
       messages: [contextMsg, turnMsg],
       ttlMs: 60_000,
-      actor: {
-        slackUserId: "U123",
-        slackUserName: "alice",
-        fullName: "Alice Example",
-        email: "alice@sentry.io",
-      },
+      newMessageProvenance: { authority: "instruction", actor: alice },
     });
 
-    // Actor is attached to the LAST new user message (turnMsg), not contextMsg
-    const entries = store.entries;
-    const piEntries = entries.filter((e) => e.type === "pi_message");
+    // Instruction provenance lands on the LAST new user message (turnMsg);
+    // the earlier context message stays unauthored context (field omitted).
+    const piEntries = store.entries.filter((e) => e.type === "pi_message");
     expect(piEntries).toHaveLength(2);
-    expect((piEntries[0] as { actor?: unknown }).actor).toBeUndefined();
-    expect((piEntries[1] as { actor?: unknown }).actor).toMatchObject({
+    expect(
+      (piEntries[0] as { provenance?: unknown }).provenance,
+    ).toBeUndefined();
+    expect((piEntries[1] as { provenance?: unknown }).provenance).toEqual({
+      authority: "instruction",
+      actor: alice,
+    });
+
+    // Provenance is not on the model-visible Pi message object.
+    const msgPayload = piEntries[1] as {
+      message?: { provenance?: unknown };
+    };
+    expect(msgPayload.message?.provenance).toBeUndefined();
+  });
+
+  it("returns aligned per-message provenance from loadMessagesWithProvenance", async () => {
+    const store = memoryStore();
+    const contextMsg: PiMessage = {
+      role: "user",
+      content: [{ type: "text", text: "prior context" }],
+      timestamp: 1,
+    } as PiMessage;
+    const turnMsg: PiMessage = {
+      role: "user",
+      content: [{ type: "text", text: "current question" }],
+      timestamp: 2,
+    } as PiMessage;
+
+    await commitMessages({
+      store,
+      conversationId: "conv-prov-2",
+      messages: [contextMsg, turnMsg],
+      ttlMs: 60_000,
+      newMessageProvenance: { authority: "instruction", actor: alice },
+    });
+
+    const { loadMessagesWithProvenance } =
+      await import("@/chat/state/session-log");
+    await expect(
+      loadMessagesWithProvenance({
+        store,
+        conversationId: "conv-prov-2",
+        messageCount: 2,
+      }),
+    ).resolves.toEqual({
+      messages: [contextMsg, turnMsg],
+      provenance: [
+        { authority: "context" },
+        { authority: "instruction", actor: alice },
+      ],
+    });
+  });
+
+  it("derives the latest instruction actor via loadProjectionWithActor", async () => {
+    const store = memoryStore();
+    const turnMsg: PiMessage = {
+      role: "user",
+      content: [{ type: "text", text: "question" }],
+      timestamp: 1,
+    } as PiMessage;
+
+    await commitMessages({
+      store,
+      conversationId: "conv-prov-3",
+      messages: [turnMsg],
+      ttlMs: 60_000,
+      newMessageProvenance: { authority: "instruction", actor: alice },
+    });
+
+    const { loadProjectionWithActor } =
+      await import("@/chat/state/session-log");
+    const projection = await loadProjectionWithActor({
+      store,
+      conversationId: "conv-prov-3",
+    });
+
+    expect(projection.actor).toMatchObject({
       slackUserId: "U123",
       slackUserName: "alice",
       fullName: "Alice Example",
       email: "alice@sentry.io",
     });
-
-    // Actor is NOT on the Pi message object (not model-visible)
-    const msgPayload = piEntries[1] as { message?: { actor?: unknown } };
-    expect(msgPayload.message?.actor).toBeUndefined();
-  });
-
-  it("derives actor from session log via loadProjectionWithActor", async () => {
-    const store = memoryStore();
-    const turnMsg: PiMessage = {
-      role: "user",
-      content: [{ type: "text", text: "question" }],
-      timestamp: 1,
-    } as PiMessage;
-
-    await commitMessages({
-      store,
-      conversationId: "conv-req-2",
-      messages: [turnMsg],
-      ttlMs: 60_000,
-      actor: { slackUserId: "U456", email: "bob@sentry.io" },
-    });
-
-    const { loadProjectionWithActor } =
-      await import("@/chat/state/session-log");
-    const projection = await loadProjectionWithActor({
-      store,
-      conversationId: "conv-req-2",
-    });
-
-    expect(projection.actor).toMatchObject({
-      slackUserId: "U456",
-      email: "bob@sentry.io",
-    });
     expect(projection.messages).toHaveLength(1);
   });
 
-  it("records actor metadata without resetting session-scoped facts", async () => {
+  it("writes aligned provenance through a projection reset", async () => {
     const store = memoryStore();
-    const turnMsg: PiMessage = {
-      role: "user",
-      content: [{ type: "text", text: "question" }],
-      timestamp: 1,
-    } as PiMessage;
-
-    await commitMessages({
-      store,
-      conversationId: "conv-req-3",
-      messages: [turnMsg],
-      ttlMs: 60_000,
-    });
-    await recordMcpProviderConnected({
-      store,
-      conversationId: "conv-req-3",
-      provider: "github",
-      ttlMs: 60_000,
-    });
-    await commitMessages({
-      store,
-      conversationId: "conv-req-3",
-      messages: [turnMsg],
-      ttlMs: 60_000,
-      actor: { slackUserId: "U999", email: "drew@sentry.io" },
-    });
-
-    expect(store.entries.map((entry) => entry.type)).toEqual([
-      "pi_message",
-      "mcp_provider_connected",
-      "actor_recorded",
-    ]);
-    await expect(
-      loadProjectionWithActor({
-        store,
-        conversationId: "conv-req-3",
-      }),
-    ).resolves.toMatchObject({
-      messages: [turnMsg],
-      actor: {
-        slackUserId: "U999",
-        email: "drew@sentry.io",
-      },
-    });
-    await expect(
-      loadConnectedMcpProviders({
-        store,
-        conversationId: "conv-req-3",
-      }),
-    ).resolves.toEqual(["github"]);
-  });
-
-  it("preserves actor through a projection reset without a new actor", async () => {
-    const store = memoryStore();
-    const msg1: PiMessage = {
+    const first: PiMessage = {
       role: "user",
       content: [{ type: "text", text: "first" }],
       timestamp: 1,
     } as PiMessage;
-    const msg2: PiMessage = {
+    const replacementUser: PiMessage = {
       role: "user",
-      content: [{ type: "text", text: "replaced" }],
+      content: [{ type: "text", text: "replacement user" }],
+      timestamp: 2,
+    } as PiMessage;
+    const replacementSummary: PiMessage = {
+      role: "user",
+      content: [{ type: "text", text: "context handoff" }],
+      timestamp: 3,
+    } as PiMessage;
+
+    await commitMessages({
+      store,
+      conversationId: "conv-prov-4",
+      messages: [first],
+      ttlMs: 60_000,
+    });
+    // A reset with explicit per-message provenance keeps the retained actor
+    // as an instruction while the synthetic summary is unauthored context.
+    await commitMessages({
+      store,
+      conversationId: "conv-prov-4",
+      messages: [replacementUser, replacementSummary],
+      ttlMs: 60_000,
+      provenance: [
+        { authority: "instruction", actor: alice },
+        { authority: "context" },
+      ],
+    });
+
+    const resetEntry = store.entries.find(
+      (entry) => entry.type === "projection_reset",
+    );
+    expect(resetEntry).toMatchObject({
+      messages: [replacementUser, replacementSummary],
+      provenance: [
+        { authority: "instruction", actor: alice },
+        { authority: "context" },
+      ],
+    });
+    await expect(
+      loadProjectionWithActor({ store, conversationId: "conv-prov-4" }),
+    ).resolves.toMatchObject({ actor: { slackUserId: "U123" } });
+  });
+
+  it("fails closed on misaligned explicit provenance", async () => {
+    const store = memoryStore();
+    const turnMsg: PiMessage = {
+      role: "user",
+      content: [{ type: "text", text: "question" }],
+      timestamp: 1,
+    } as PiMessage;
+
+    await expect(
+      commitMessages({
+        store,
+        conversationId: "conv-prov-5",
+        messages: [turnMsg],
+        ttlMs: 60_000,
+        provenance: [
+          { authority: "instruction", actor: alice },
+          { authority: "context" },
+        ],
+      }),
+    ).rejects.toThrow(/align/);
+  });
+
+  it("returns a single actor for a single-actor run", () => {
+    expect(
+      instructionActors([
+        { authority: "context" },
+        { authority: "instruction", actor: alice },
+        { authority: "context" },
+      ]),
+    ).toEqual([alice]);
+  });
+
+  it("collects batched multi-actor input in first-seen order, distinct by ids", () => {
+    const bob = {
+      platform: "slack" as const,
+      teamId: "T123",
+      userId: "U456",
+      userName: "bob",
+    };
+    // Same human as alice by identity ids, but a different display profile;
+    // distinctness is by ids only, so it must collapse onto the first entry.
+    const aliceRenamed = {
+      platform: "slack" as const,
+      teamId: "T123",
+      userId: "U123",
+      userName: "alice-mobile",
+      fullName: "Alice On Mobile",
+    };
+    const provenance: PiMessageProvenance[] = [
+      { authority: "instruction", actor: alice },
+      { authority: "instruction", actor: bob },
+      { authority: "instruction", actor: aliceRenamed },
+    ];
+
+    // First-seen order preserved; the second alice profile does not re-add.
+    expect(instructionActors(provenance)).toEqual([alice, bob]);
+  });
+
+  it("treats matching user ids on different teams as distinct authors", () => {
+    const aliceTeamB = {
+      platform: "slack" as const,
+      teamId: "T999",
+      userId: "U123",
+    };
+    expect(
+      instructionActors([
+        { authority: "instruction", actor: alice },
+        { authority: "instruction", actor: aliceTeamB },
+      ]),
+    ).toEqual([alice, aliceTeamB]);
+  });
+
+  it("excludes context and unattributable instruction messages", () => {
+    // A system-actor / no-human run: nothing carries an instruction actor.
+    expect(
+      instructionActors([
+        { authority: "context" },
+        { authority: "context", actor: alice },
+        { authority: "instruction" },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("is monotonic across a growing prefix, so continuation reuses the prefix set", () => {
+    const bob = {
+      platform: "slack" as const,
+      teamId: "T123",
+      userId: "U456",
+      userName: "bob",
+    };
+    const full: PiMessageProvenance[] = [
+      { authority: "instruction", actor: alice },
+      { authority: "context" },
+      { authority: "instruction", actor: bob },
+    ];
+    const committedPrefix = full.slice(0, 2);
+
+    // The prefix set is a prefix of the full set: mid-run readers see a lower
+    // bound and a continuation derived from the committed prefix is stable.
+    expect(instructionActors(committedPrefix)).toEqual([alice]);
+    expect(instructionActors(full)).toEqual([alice, bob]);
+  });
+
+  it("decodes legacy v1 entries as unauthored context", async () => {
+    const store = memoryStore();
+    const legacyContext: PiMessage = {
+      role: "user",
+      content: [{ type: "text", text: "legacy context" }],
+      timestamp: 1,
+    } as PiMessage;
+    const legacyInstruction: PiMessage = {
+      role: "user",
+      content: [{ type: "text", text: "legacy instruction" }],
       timestamp: 2,
     } as PiMessage;
 
-    // First commit with actor
-    await commitMessages({
-      store,
-      conversationId: "conv-req-4",
-      messages: [msg1],
-      ttlMs: 60_000,
-      actor: { slackUserId: "U789", email: "carol@sentry.io" },
-    });
+    store.entries.push(
+      {
+        schemaVersion: 1,
+        type: "pi_message",
+        sessionId: "session_0",
+        message: legacyContext,
+      } as unknown as SessionLogEntry,
+      {
+        schemaVersion: 1,
+        type: "pi_message",
+        sessionId: "session_0",
+        message: legacyInstruction,
+        requester: {
+          platform: "slack",
+          slackUserId: "U123",
+          slackUserName: "alice",
+          teamId: "T123",
+        },
+      } as unknown as SessionLogEntry,
+    );
 
-    // Trigger a reset by replacing history
-    await commitMessages({
-      store,
-      conversationId: "conv-req-4",
-      messages: [msg2],
-      ttlMs: 60_000,
-    });
-
-    const { loadProjectionWithActor } =
+    const { loadMessagesWithProvenance, loadProjectionWithActor } =
       await import("@/chat/state/session-log");
-    const projection = await loadProjectionWithActor({
-      store,
-      conversationId: "conv-req-4",
+    await expect(
+      loadMessagesWithProvenance({
+        store,
+        conversationId: "conv-prov-legacy",
+        messageCount: 2,
+      }),
+    ).resolves.toEqual({
+      messages: [legacyContext, legacyInstruction],
+      provenance: [
+        { authority: "context" },
+        {
+          authority: "instruction",
+          actor: {
+            platform: "slack",
+            teamId: "T123",
+            userId: "U123",
+            userName: "alice",
+          },
+        },
+      ],
     });
-
-    expect(projection.actor?.slackUserId).toBe("U789");
-    expect(projection.messages).toHaveLength(1);
+    await expect(
+      loadProjectionWithActor({
+        store,
+        conversationId: "conv-prov-legacy",
+      }),
+    ).resolves.toMatchObject({ actor: { slackUserId: "U123" } });
   });
 });

--- a/specs/context-compaction.md
+++ b/specs/context-compaction.md
@@ -62,6 +62,12 @@ That reset advances the current `sessionId`; later entries in the same
 conversation carry the new marker, and reducers ignore events from older
 sessions.
 
+The `projection_reset` carries per-message provenance aligned one-to-one with
+its replacement messages. Retained real user messages preserve their original
+instruction actor from the pre-compaction projection; the synthetic handoff
+summary is unattributed `context`. Reset provenance that does not align with the
+replacement messages fails closed rather than being zipped or truncated.
+
 The replacement history must exclude stale runtime turn context, old capability catalogs, raw image/base64 payloads, and unbounded tool output. Runtime turn context is injected again on the next actual turn by `buildTurnContextPrompt(...)`.
 
 The replacement history must preserve enough session-log evidence to derive required runtime handles, or deliberately omit handles that are no longer valid after compaction. If compaction drops old `loadSkill` results or `mcp_provider_connected` events, the next turn must rediscover/reload those capabilities through normal tools rather than relying on side metadata.

--- a/specs/identity.md
+++ b/specs/identity.md
@@ -31,6 +31,7 @@ Define how Junior carries human, system, delegated, destination, and display ide
 - **Actor:** the current authority for behavior. An actor is either a user actor or a system actor.
 - **User actor:** the human currently asking Junior to act.
 - **System actor:** a named Junior-owned execution authority, such as `scheduler` or a plugin dispatch actor.
+- **Run actor:** the single actor a run executes as (see `multi-actor-runs.md`). "Requester" is retired vocabulary for this concept; the codebase-wide rename is complete (#786).
 - **Author:** the actor metadata persisted with a conversation message for transcript attribution.
 - **Creator:** audit and notification metadata for durable objects such as scheduled tasks. Creator is not automatically the actor for later execution.
 - **Credential subject:** an explicit subject used only to choose a stored user OAuth token. It is not the current actor and does not grant actor semantics.
@@ -156,6 +157,10 @@ User-authored conversation messages must carry exact author identity when they a
 
 Prompt context must preserve who is asking now versus who authored prior messages. A later user in the same Slack thread becomes the current actor for the new turn without changing attribution for earlier messages.
 
+Run-level attribution of the distinct actors that originated instruction-authority input to a run (`run.actors`) is derived from this per-message provenance and specified in `multi-actor-runs.md`. It is attribution only and never an authority source.
+
+The durable Pi session log records per-message provenance (`{ authority: "instruction" | "context", actor?: Actor }`) aligned one-to-one with the committed messages, rather than a single latest-wins requester. User-authored turn input is an `instruction` attributed to its own actor; synthetic or system-originated user-role messages (authorization observations, compaction summaries, plugin dispatch) are unattributed `context`. Actors are platform-neutral identity values (today's `Requester` type) so Slack and local identities are preserved. Legacy entries without provenance decode as unattributed context, and misaligned provenance fails closed rather than being zipped or truncated. `AgentTurnSessionRecord` persists this provenance aligned to `piMessages`.
+
 ### Slack Side Effects
 
 Actor-sensitive Slack side effects, including ephemeral responses and OAuth continuations, must use the current actor id from turn context. They must not fall back to channel id, bot id, last human author, task creator, or display profile fields.
@@ -206,6 +211,7 @@ Use evals only when the contract depends on model interpretation, such as preser
 ## Related Specs
 
 - `./chat-architecture.md`
+- `./multi-actor-runs.md`
 - `./task-execution.md`
 - `./local-agent.md`
 - `./agent-turn-handling.md`

--- a/specs/index.md
+++ b/specs/index.md
@@ -39,6 +39,7 @@ Define spec taxonomy, naming conventions, and canonical source-of-truth document
 - `specs/slack-agent-delivery.md`
 - `specs/slack-outbound-contract.md`
 - `specs/identity.md`
+- `specs/multi-actor-runs.md`
 - `specs/credential-injection.md`
 - `specs/oauth-flows.md`
 - `specs/agent-prompt.md`
@@ -97,6 +98,7 @@ For chat/agent/Slack execution and response behavior:
 - `specs/slack-agent-delivery.md` owns Slack entry surfaces, progress UX, continuation acknowledgements, and final reply delivery.
 - `specs/slack-outbound-contract.md` owns Slack API write formatting, file uploads, reactions, retries, and error mapping.
 - `specs/identity.md` owns current actor, system actor, actor, author, creator, credential subject, service principal, and display identity separation across runtime boundaries.
+- `specs/multi-actor-runs.md` owns run-level actor attribution (`run.actor` and `run.actors`), its membership/distinctness/monotonicity semantics, and the attribution-not-authority naming contract; it defers all authority and permission decisions to `specs/identity.md`.
 - `specs/postgres-test-harness.md` owns real Postgres test database lifecycle, migrated template setup, fixture isolation, and rollback semantics.
 
 ## Archived Superseded Specs

--- a/specs/memory-plugin/policy.md
+++ b/specs/memory-plugin/policy.md
@@ -204,6 +204,19 @@ clear first-person source evidence from the user and must still be visible only
 to that actor. Explicit memory-management tool calls suppress passive
 extraction for the same completed session so the tool path owns its effect.
 
+Passive extraction must require structured evidence citations. Every extracted
+memory cites one or more transcript entries, and a deterministic router verifies
+those citations against runtime-owned provenance before storage:
+
+- Personal passive memories require every cited evidence entry to be an
+  instruction from the run actor. A first-person preference whose citations are
+  not all run-actor instructions is dropped, never downgraded to conversation
+  scope.
+- Non-run-actor public messages and successful tool results may support
+  conversation-scoped operational knowledge, procedures, and shared facts.
+- Missing provenance is treated as unattributed context and cannot authorize a
+  personal memory.
+
 ## Automatic Injection Policy
 
 Automatic memory injection is enabled when the memory plugin is enabled.

--- a/specs/memory-plugin/policy.md
+++ b/specs/memory-plugin/policy.md
@@ -212,8 +212,10 @@ those citations against runtime-owned provenance before storage:
   instruction from the run actor. A first-person preference whose citations are
   not all run-actor instructions is dropped, never downgraded to conversation
   scope.
-- Non-run-actor public messages and successful tool results may support
-  conversation-scoped operational knowledge, procedures, and shared facts.
+- Non-run-actor public messages (whether projected as context authority or as
+  attributed instruction-authority participant input) and successful tool
+  results may support conversation-scoped operational knowledge, procedures,
+  and shared facts.
 - Missing provenance is treated as unattributed context and cannot authorize a
   personal memory.
 

--- a/specs/memory-plugin/security.md
+++ b/specs/memory-plugin/security.md
@@ -121,6 +121,13 @@ Passive processing tasks should reload bounded completed-run projections
 through the core-provided run helper rather than carrying raw messages in task
 params or queue payloads.
 
+Plugin completed-run projections may include bounded public context transcript
+entries with runtime-owned provenance (authority and author identity). The
+model-visible author and authority labels are classification hints only. The
+deterministic router verifies each memory's cited transcript indices against
+that runtime-owned provenance before storage, so context-authority entries and
+entries with missing provenance cannot authorize a run-actor personal write.
+
 ## Logging And Reporting
 
 Logs, spans, dashboards, and plugin operational reports may include:

--- a/specs/multi-actor-runs.md
+++ b/specs/multi-actor-runs.md
@@ -125,11 +125,11 @@ text is untrusted for this purpose.
   and is not persisted separately, so it cannot drift from the provenance it is
   derived from. `AgentTurnSessionRecord.actor` carries the run actor.
 - The plugin run context exposes the same fields to plugin tasks:
-  `pluginRunContextSchema.actor` (the run actor) and `pluginRunContextSchema.actors`
-  (the run actors), populated in `loadPluginRun`. `run.actors` is derived from
-  the full run provenance (the same source as the record), never from the sliced
-  or stripped transcript, so it can exceed the actors visible in the transcript
-  slice.
+  `pluginRunContextSchema.actor` (the run actor, absent only for actor-less
+  legacy system records) and `pluginRunContextSchema.actors` (the run actors),
+  populated in `loadPluginRun`. `run.actors` is derived from the full run
+  provenance (the same source as the record), never from the sliced or stripped
+  transcript, so it can exceed the actors visible in the transcript slice.
 
 ## Failure Model
 

--- a/specs/multi-actor-runs.md
+++ b/specs/multi-actor-runs.md
@@ -1,0 +1,181 @@
+# Multi-Actor Runs Spec
+
+## Metadata
+
+- Created: 2026-07-07
+- Last Edited: 2026-07-07
+
+## Purpose
+
+Define how a single run represents instruction input that originates from more
+than one actor. A run executes as exactly one actor — its authority — but the
+actors who contribute instructions to that run, through active steering or asks
+batched before the turn started, are not always the same. This spec defines the
+attribution model for those contributors, the membership semantics of the
+contributor set, and the naming contract that separates attribution from
+authority.
+
+## Scope
+
+- Run-level attribution of instruction-authority input to the actors that
+  originated it (`run.actors`).
+- Membership semantics: when an actor joins the set, ordering, and distinctness.
+- The relationship between attribution and authority, and the terms that keep
+  them separate.
+- Exposure of the attribution set on the turn session record and the plugin run
+  context.
+
+## Non-Goals
+
+- Changing run authority. A run still executes as one actor; this spec never
+  introduces multi-actor authority.
+- Credential issuance, credential-subject selection, memory scope ownership, or
+  any permission decision. Those are owned by `identity.md` and the
+  point-of-action authority model (issue #773 section D).
+- Steer-versus-queue routing of cross-actor input. That is a UX optimization and
+  must never gate authority; it is out of scope here.
+- Reply-phrasing quality when a run blends multiple actors' asks. That is model
+  quality, not an attribution contract.
+
+## Terms
+
+- **Actor:** unchanged from `identity.md`. A user or system that originates
+  instructions or executes work. There is no separate "requester", "author", or
+  "instruction author" concept — those were redundant names for the same thing
+  in different positions. "Requester" is retired vocabulary for **run actor**;
+  the codebase-wide rename is complete (#786). The only remaining `requester`
+  spellings are string literals that decode legacy stored records.
+- **Run actor:** the single actor a run executes as (credential binding, auth
+  flows). Exposed as `run.actor`. One run, one run actor.
+- **Run actors:** all distinct actors annotated on the run's committed
+  instruction-authority messages, in first-seen order. Exposed as `run.actors`.
+  Usually `[run.actor]`. Attribution only, never authority.
+- **Per-instruction actor annotation:** every instruction committed to a run
+  carries the actor it came from, via per-message provenance
+  (`{ authority: "instruction" | "context", actor?: Actor }`; see `identity.md`,
+  Conversation History). `run.actors` is a pure projection of these annotations:
+  the distinct `actor` values across messages whose `authority` is
+  `instruction`.
+
+## Contracts
+
+### Membership Rule
+
+An actor joins `run.actors` when a message it originated is committed to the run
+as **instruction authority**. This happens at the same commit points that record
+instruction-authority provenance: turn start, batched parked input draining into
+the run, and steering input draining mid-run. Membership is a pure projection of
+per-message provenance, never a separately maintained list.
+
+### Fail-Closed Identity
+
+An instruction-authority message requires a resolvable actor. Input that cannot
+be attributed to a resolvable actor identity is committed as **context
+authority** and never joins `run.actors`. There is no guessed or inferred actor:
+a missing, malformed, or absent actor yields context authority, not a fabricated
+member.
+
+### Distinctness And Order
+
+Distinctness is by identity ids only, never display fields: `platform` +
+`teamId` + `userId` for Slack, `platform` + `userId` otherwise. The same actor
+appearing under two display profiles collapses to one member. Matching user ids
+on different teams are distinct members. First-seen order is preserved.
+
+### Monotonic Mid-Run, Complete At Completion
+
+The set only grows within a run; a committed instruction actor is never removed.
+A reader of a **completed** run record receives the closed, final set. A reader
+observing a run **mid-run** must treat the set as a lower bound: more actors may
+still join before completion.
+
+### Continuation Inherits From Committed Provenance
+
+Because the set is derived from committed per-message provenance, a continuation
+(timeout resume, auth resume, later slice) reproduces the same set from the
+committed provenance prefix. The set is stable across slices and requires no
+separate persistence. This falls out of the derivation rather than being coded
+as a distinct path.
+
+### Attribution, Not Authority
+
+`run.actors` is attribution only. It must never feed:
+
+- credential issuance,
+- credential-subject selection,
+- memory scope ownership,
+- or any other permission decision.
+
+The intended consumer of run authority is the point-of-action authority model
+(issue #773 section D), where each credentialed operation is checked against the
+run actor and cross-actor instruction conflicts fail closed into a consent
+request. `run.actors` informs provenance and citation; it does not select a
+principal.
+
+### Derivation Is Runtime-Owned
+
+The set is derived by the runtime from per-message provenance. It is never
+parsed from prompt text, transcript text, or model output. Prompt/transcript
+text is untrusted for this purpose.
+
+### Exposure
+
+- `AgentTurnSessionRecord.actors` is derived at materialization from
+  `piMessageProvenance` (the `instructionActors` projection). It is a projection
+  and is not persisted separately, so it cannot drift from the provenance it is
+  derived from. `AgentTurnSessionRecord.actor` carries the run actor.
+- The plugin run context exposes the same fields to plugin tasks:
+  `pluginRunContextSchema.actor` (the run actor) and `pluginRunContextSchema.actors`
+  (the run actors), populated in `loadPluginRun`. `run.actors` is derived from
+  the full run provenance (the same source as the record), never from the sliced
+  or stripped transcript, so it can exceed the actors visible in the transcript
+  slice.
+
+## Failure Model
+
+- Misaligned or absent provenance yields context authority (an empty or smaller
+  set), never a guessed actor.
+- A malformed actor on an otherwise instruction-authority entry does not join
+  and does not fail the run; the entry degrades to context authority.
+- A consumer must never treat a mid-run set as final, nor treat membership as an
+  authority or permission signal.
+
+## Observability
+
+`run.actors` is attribution provenance, not a behavior contract. Logs and spans
+may include the distinct actor count or safe identity dimensions (actor type and
+id, per `identity.md`) when useful for debugging, but membership must never be
+asserted as a monitored behavior and must never be logged as an authority or
+permission signal.
+
+## Verification
+
+Unit tests (`packages/junior/tests/unit/state/session-log.test.ts`,
+`instructionActors` helper):
+
+- Single-actor run returns `[the run actor]`.
+- Batched multi-actor input returns both actors in first-seen order, distinct by
+  ids (a second display profile for the same id does not re-add).
+- Matching user ids on different teams are distinct actors.
+- Context and unattributable instruction messages are excluded; a run with no
+  human instruction actor returns an empty set.
+- The set is monotonic across a growing prefix, so a continuation derived from
+  the committed prefix is a prefix of the full set.
+
+Component tests (`packages/junior/tests/component/services/turn-session-record.test.ts`):
+
+- Steering by a second actor adds that actor, and re-materializing the stored
+  record reproduces the same first-seen-ordered set.
+- A system-actor run with no human instructions has an empty set.
+
+Component test (`packages/junior/tests/component/plugins/plugin-tasks.test.ts`):
+
+- The plugin run context exposes `actor`, `actors`, and per-entry `isRunActor`.
+
+## Related Specs
+
+- `./identity.md`
+- `./task-execution.md`
+- `./agent-turn-handling.md`
+- `./plugin-tasks.md`
+- `./context-compaction.md`

--- a/specs/plugin-tasks.md
+++ b/specs/plugin-tasks.md
@@ -190,8 +190,8 @@ interface PluginRunContext {
   completedAtMs: number;
   conversationId: string;
   destination: Destination;
-  /** The single actor the run executes as. */
-  actor: Actor;
+  /** The single actor the run executes as; absent only for actor-less legacy system records. */
+  actor?: Actor;
   /** All distinct actors annotated on the run's instructions, first-seen order. */
   actors: Actor[];
   runId: string;
@@ -225,6 +225,11 @@ tool-result text, source, destination, the run actor, and the run actors. It
 must not expose raw Pi internals, raw tool arguments, full unbounded transcript
 history, provider credentials, OAuth tokens, Slack tokens, or private binary
 payloads.
+
+`actor` may be absent for legacy completed records that predate first-class run
+actors. Plugins that need personal scope or credentials must treat an absent run
+actor as unavailable authority. `actors` may still be empty for system runs with
+no human instruction actors.
 
 Message entries may carry runtime-owned provenance. `authority` is `instruction`
 for a durable turn instruction and `context` for ambient conversation context.

--- a/specs/plugin-tasks.md
+++ b/specs/plugin-tasks.md
@@ -241,7 +241,9 @@ authority: the transcript is evidence a task may cite. An entry with no
 `context` provenance must be treated as context-only and cannot stand in for a
 run-actor instruction. Public prior-thread messages may appear as
 `context`-authority entries so a task can cite shared conversation evidence;
-private and local sources contribute no such context entries.
+private and local sources contribute no such context entries. Public thread
+context entries are bounded to messages whose runtime timestamp is at or before
+`completedAtMs`; messages without a usable runtime timestamp are excluded.
 
 If the session record is unavailable, incomplete, missing source/destination,
 or not completed, `run.load()` throws so the task follows the normal retry

--- a/specs/plugin-tasks.md
+++ b/specs/plugin-tasks.md
@@ -190,14 +190,28 @@ interface PluginRunContext {
   completedAtMs: number;
   conversationId: string;
   destination: Destination;
+  /** The single actor the run executes as. */
   actor: Actor;
+  /** All distinct actors annotated on the run's instructions, first-seen order. */
+  actors: Actor[];
   runId: string;
   source: Source;
   transcript: PluginRunTranscriptEntry[];
 }
 
+type PluginRunTranscriptProvenance = {
+  authority: "instruction" | "context";
+  actor?: Actor;
+};
+
 type PluginRunTranscriptEntry =
-  | { type: "message"; role: "user" | "assistant"; text: string }
+  | {
+      type: "message";
+      role: "user" | "assistant";
+      text: string;
+      provenance?: PluginRunTranscriptProvenance;
+      isRunActor?: boolean;
+    }
   | {
       type: "toolResult";
       toolName: string;
@@ -207,9 +221,22 @@ type PluginRunTranscriptEntry =
 ```
 
 The projection may include normalized user-authored text, assistant reply text,
-tool-result text, source, destination, and actor. It must not expose raw Pi
-internals, raw tool arguments, full unbounded transcript history, provider
-credentials, OAuth tokens, Slack tokens, or private binary payloads.
+tool-result text, source, destination, the run actor, and the run actors. It
+must not expose raw Pi internals, raw tool arguments, full unbounded transcript
+history, provider credentials, OAuth tokens, Slack tokens, or private binary
+payloads.
+
+Message entries may carry runtime-owned provenance. `authority` is `instruction`
+for a durable turn instruction and `context` for ambient conversation context.
+`actor` and `isRunActor` are derived from runtime identity
+(platform/team/user ids), never from display names; `isRunActor` marks an entry
+whose actor is the run actor. Runtime context, not the transcript, is the
+authority: the transcript is evidence a task may cite. An entry with no
+`provenance` is unattributed context. For authority-sensitive work, missing or
+`context` provenance must be treated as context-only and cannot stand in for a
+run-actor instruction. Public prior-thread messages may appear as
+`context`-authority entries so a task can cite shared conversation evidence;
+private and local sources contribute no such context entries.
 
 If the session record is unavailable, incomplete, missing source/destination,
 or not completed, `run.load()` throws so the task follows the normal retry


### PR DESCRIPTION
A run's instructions can come from multiple people (batched mentions, mid-run steering, continuation), but identity was flattened to a single latest-wins requester at every projection boundary — by the time anything reached a plugin, the only author signal left was prompt text, which must never be treated as authority. Confirmed failure: Bob posts "I prefer terse code reviews" in Alice's thread and it lands as Alice's personal memory. This is the confused deputy problem tracked in #773; this PR is Track 1.

The runtime now records provenance (`{ authority: "instruction" | "context", actor }`) on every user-role message and carries it per-entry through the session log, projection resets, compaction, and the turn session record, failing closed to unattributed context for legacy entries. Memory extraction must cite evidence message indices, and a deterministic router verifies them: personal-scope writes require every cited entry to be a run-actor instruction (unproven preferences are dropped, never downgraded), while public thread messages now reach plugins as context-authority evidence so shared operational knowledge still becomes conversation-scope memory. Instruction entries in the plugin projection are stripped of embedded thread-context blocks so another user's text can never ride inside an instruction-authority citation.

This also lands the naming contract from `specs/multi-actor-runs.md`: one identity concept — actor — annotated per instruction. "requester" is retired vocabulary; the codebase-wide rename is #778.

Breaking plugin contract (`@sentry/junior-plugin-api`); all in-repo consumers are updated:

```jsonc
// before
{ "run": { "requester": {...} }, "transcript": [{ "type": "message", "role": "user", "text": "..." }] }

// after
{
  "run": { "actor": {...}, "actors": [{...}] },  // actors = everyone whose instructions joined the run
  "transcript": [{ "type": "message", "role": "user", "text": "...",
                   "provenance": { "authority": "instruction", "actor": {...} }, "isRunActor": true }]
}
```

The multi-actor evals were written first and red (`packages/junior-evals/evals/memory/multi-actor-provenance.eval.ts`); they pass deterministically with this change. Along the way both memory eval files turned out to have label-suffixed `thread_ts` fixtures that fail Slack timestamp parsing, which mis-keyed every stored memory and made all DB assertions silently vacuous — fixtures are repaired here, so those assertions are meaningful for the first time. Five `workflows.eval.ts` cases are now correctly red: they document the live memory write/forget tool paths failing, a pre-existing bug the vacuous fixtures had masked (#784). They are intentionally left red as evidence.

Review order: `chat/state/session-log.ts` (the provenance primitive) → `chat/state/turn-session.ts` → `chat/plugins/task-runner.ts` + `junior-plugin-api/src/tasks.ts` (the contract) → `junior-memory/src/process-session.ts` (the deterministic router) → `specs/multi-actor-runs.md`.

Refs GH-773
Refs GH-784

🤖 Generated with [Claude Code](https://claude.com/claude-code)