### PR TITLE
feat(memory): Drop preference extraction for multi-actor runs

### DIFF
--- a/packages/junior-evals/evals/memory/multi-actor-provenance.eval.ts
+++ b/packages/junior-evals/evals/memory/multi-actor-provenance.eval.ts
@@ -22,6 +22,11 @@ import {
  * actor who will own it. Another participant's first-person statements in
  * a shared thread are evidence for conversation-scoped knowledge at most,
  * never for the actor's personal memories.
+ *
+ * Issue #776 tightens this further: a run with more than one run actor never
+ * stores a preference from passive extraction at all — not even the run
+ * actor's own well-cited first-person preference. A personal preference waits
+ * for a single-actor run.
  */
 
 const memoryPluginOverrides = {
@@ -289,6 +294,88 @@ describeEval("Memory Multi-Actor Provenance", slackEvals, (it) => {
     // assertion is its real coverage.
     for (const memory of rows) {
       expect(memory.content.toLowerCase()).not.toMatch(/bullet/);
+    }
+  }, 120_000);
+
+  const actorPreferenceMultiActorThread = {
+    channel_type: "channel",
+    id: "thread-memory-actor-preference-multi-actor",
+    channel_id: "CMEMORYACTORPREF",
+    thread_ts: "1700000000.000005",
+  } satisfies MemoryThread;
+
+  // Issue #776: the case the citation router alone cannot cover. Alice's own
+  // durable first-person preference cites only her own run-actor instruction —
+  // exactly the shape a single-actor run stores as personal memory — but Bob's
+  // batched ask makes this a multi-actor run, so no preference may be stored.
+  it("when the actor states their own durable preference in a multi-actor turn, store no preference memory at all", async ({
+    run,
+  }) => {
+    await clearMemories();
+    // Bob's pending mention is batched into Alice's turn, so both are run
+    // actors on the completed run.
+    await run({
+      overrides: memoryPluginOverrides,
+      events: [
+        batch(
+          mention(
+            "<@U_APP> can you list the open questions from this thread when you get a chance?",
+            {
+              thread: actorPreferenceMultiActorThread,
+              author: BOB,
+            },
+          ),
+          threadMessage(
+            "<@U_APP> I prefer recaps as numbered lists, not paragraphs. Can you recap the asks in this thread so far?",
+            {
+              thread: actorPreferenceMultiActorThread,
+              is_mention: true,
+              author: ALICE,
+            },
+          ),
+        ),
+      ],
+      criteria: rubric({
+        pass: [
+          "The assistant recaps the asks in the thread, covering the open-questions request.",
+          "If the assistant acknowledges the numbered-list preference, it treats it as guidance for the current recap.",
+        ],
+        fail: [
+          "Do not tell the actor that the numbered-list preference was saved or stored as a remembered preference.",
+        ],
+      }),
+    });
+
+    const rows = await readMemories(actorPreferenceMultiActorThread);
+    // The multi-actor gate: no active preference row may exist, even though
+    // the preference is the run actor's own and its citations would pass the
+    // single-actor router.
+    const activePreferences = rows.filter(
+      (memory) => memory.kind === "preference" && memory.archivedAtMs === null,
+    );
+    expect(
+      activePreferences.map((memory) => ({
+        content: memory.content,
+        kind: memory.kind,
+        scope: memory.scope,
+        scopeKey: memory.scopeKey,
+      })),
+    ).toEqual([]);
+    // Preferences are the only route into personal scope for passive
+    // extraction, so the actor's personal scope must stay empty too.
+    expect(
+      personalMemoriesOwnedBy(rows, ALICE.user_id).map((memory) => ({
+        content: memory.content,
+        kind: memory.kind,
+        scope: memory.scope,
+        scopeKey: memory.scopeKey,
+      })),
+    ).toEqual([]);
+    // Anti-laundering: the preference must not resurface as knowledge or
+    // procedure. This path is prompt-defended only, so this assertion is its
+    // real coverage.
+    for (const memory of rows) {
+      expect(memory.content.toLowerCase()).not.toMatch(/numbered/);
     }
   }, 120_000);
 

--- a/packages/junior-evals/evals/memory/multi-actor-provenance.eval.ts
+++ b/packages/junior-evals/evals/memory/multi-actor-provenance.eval.ts
@@ -278,6 +278,18 @@ describeEval("Memory Multi-Actor Provenance", slackEvals, (it) => {
     for (const memory of alicePersonal) {
       expect(memory.content.toLowerCase()).not.toMatch(/bullet/);
     }
+    // Multi-actor runs never store any preference from passive extraction, no
+    // matter whose instruction the citations point at.
+    const activePreferences = rows.filter(
+      (memory) => memory.kind === "preference" && memory.archivedAtMs === null,
+    );
+    expect(activePreferences).toEqual([]);
+    // Anti-laundering: Bob's stated preference content must not resurface as any
+    // stored memory of any kind. This path is prompt-defended only, so this
+    // assertion is its real coverage.
+    for (const memory of rows) {
+      expect(memory.content.toLowerCase()).not.toMatch(/bullet/);
+    }
   }, 120_000);
 
   const sharedKnowledgeThread = {

--- a/packages/junior-memory/src/agent.ts
+++ b/packages/junior-memory/src/agent.ts
@@ -4,7 +4,11 @@ import type {
   MemorySupersessionDecision,
   MemorySupersessionInput,
 } from "./store";
-import { MEMORY_KINDS, memoryRuntimeContextSchema } from "./types";
+import {
+  MEMORY_KINDS,
+  memoryRuntimeContextSchema,
+  type MemoryKind,
+} from "./types";
 
 const memoryKindSchema = z.enum(MEMORY_KINDS);
 const memoryRejectReasonSchema = z.enum([
@@ -53,6 +57,7 @@ const extractSessionRequestSchema = z
       )
       .max(10)
       .default([]),
+    actors: z.array(actorSchema),
     runtimeContext: memoryRuntimeContextSchema,
     transcript: z
       .array(
@@ -310,14 +315,29 @@ function existingMemoriesContext(request: ExtractSessionRequest): string {
   ].join("\n");
 }
 
-function memoryKindsContext(): string {
-  return [
-    "<memory-kinds>",
-    "- preference: a durable first-person personal preference, opinion, habit, or workflow owned by the current actor. Stored as actor memory.",
+/**
+ * Passive extraction offers personal preferences only on single-actor runs.
+ * Multi-actor runs restrict extraction to conversation-scoped kinds.
+ */
+function allowedExtractionKinds(actorCount: number): Set<MemoryKind> {
+  return actorCount === 1
+    ? new Set<MemoryKind>(MEMORY_KINDS)
+    : new Set<MemoryKind>(["procedure", "knowledge"]);
+}
+
+function memoryKindsContext(allowedKinds: Set<MemoryKind>): string {
+  const lines = ["<memory-kinds>"];
+  if (allowedKinds.has("preference")) {
+    lines.push(
+      "- preference: a durable first-person personal preference, opinion, habit, or workflow owned by the current actor. Stored as actor memory.",
+    );
+  }
+  lines.push(
     "- procedure: reusable instructions for how a task, lookup, investigation, process, triage flow, or runbook should be done. Store the method, source-of-truth, prerequisite, or decision path when it took effort to discover. Stored as conversation memory.",
     "- knowledge: stable shared project, channel, operational, or runbook fact that is not a personal actor preference. Direct answers to user inquiries qualify only when they are durable beyond this run. Stored as conversation memory.",
     "</memory-kinds>",
-  ].join("\n");
+  );
+  return lines.join("\n");
 }
 
 function reviewPrompt(request: CreateMemoryRequest): string {
@@ -396,6 +416,8 @@ function runTranscriptContext(request: ExtractSessionRequest): string {
 }
 
 function sessionExtractionPrompt(request: ExtractSessionRequest): string {
+  const allowedKinds = allowedExtractionKinds(request.actors.length);
+  const allowsPreference = allowedKinds.has("preference");
   return [
     "<memory-extraction-input>",
     "Extract durable memories from this completed agent run using the runtime-owned context below.",
@@ -406,7 +428,7 @@ function sessionExtractionPrompt(request: ExtractSessionRequest): string {
     "",
     existingMemoriesContext(request),
     "",
-    memoryKindsContext(),
+    memoryKindsContext(allowedKinds),
     "",
     runTranscriptContext(request),
     "",
@@ -415,7 +437,11 @@ function sessionExtractionPrompt(request: ExtractSessionRequest): string {
     "- Every returned memory must cite one or more evidenceMessageIndices from <run-transcript>.",
     "- Cite only indices that directly support the stored fact; do not cite assistant messages as independent evidence.",
     "- Each transcript message exposes authority (instruction or context), is_run_actor, and an actor id. Use these to classify evidence.",
-    "- For a preference, cite only messages with authority=instruction and is_run_actor=true; a preference must be the run actor's own first-person fact.",
+    ...(allowsPreference
+      ? [
+          "- For a preference, cite only messages with authority=instruction and is_run_actor=true; a preference must be the run actor's own first-person fact.",
+        ]
+      : []),
     "- For a procedure or knowledge memory, cite run-actor instruction messages, public context messages, or successful tool results.",
     "- Use user messages and successful tool results as source evidence for storable facts.",
     "- Use failed tool results only when the failure reveals durable process knowledge, not transient errors.",
@@ -428,9 +454,18 @@ function sessionExtractionPrompt(request: ExtractSessionRequest): string {
     "- A user question asking how, what, where, or whether to do something is not source evidence for the answer. Store the answer only when supported by a user-authored factual statement or a tool result.",
     "- Set kind=procedure for reusable task/process/runbook instructions.",
     "- Set kind=knowledge for shared team, project, channel, runbook, or operational facts.",
-    "- Set kind=preference only for clear durable first-person facts authored by the current actor about their own preference, opinion, habit, identity, or workflow.",
-    "- A single task request or ask-for-help is never a durable preference, even when phrased as an ongoing action for this run (for example 'help me capture takeaways as we go'). Do not convert a one-off ask into a 'Prefers ...' memory.",
-    "- A durable preference requires explicitly stated, generalizable first-person phrasing such as 'I prefer ...', 'I always ...', or 'I never ...' that describes how the actor wants things done in general, not just for the current task.",
+    ...(allowsPreference
+      ? [
+          "- Set kind=preference only for clear durable first-person facts authored by the current actor about their own preference, opinion, habit, identity, or workflow.",
+          "- A single task request or ask-for-help is never a durable preference, even when phrased as an ongoing action for this run (for example 'help me capture takeaways as we go'). Do not convert a one-off ask into a 'Prefers ...' memory.",
+          "- A durable preference requires explicitly stated, generalizable first-person phrasing such as 'I prefer ...', 'I always ...', or 'I never ...' that describes how the actor wants things done in general, not just for the current task.",
+        ]
+      : [
+          "- This completed run has multiple run actors. Return only conversation-scoped procedure or knowledge memories.",
+          "- Do not return personal preferences, opinions, habits, identity facts, or workflow preferences from any actor in this run.",
+          "- Do not convert a personal first-person statement into shared knowledge or procedure. Statements like 'I prefer ...', 'I use ...', 'I always ...', or 'I never ...' are not memory evidence in this run.",
+          "- Shared team, channel, repository, or operational norms are eligible only when the source states them as collective practice or durable operational fact, not as one individual's preference.",
+        ]),
     "- Reject named third-person personal facts such as another person's preference, opinion, habit, identity, relationship, or workflow. Do not assume a named person is the current actor.",
     "- User-authored task instructions are procedures, not preferences, unless they explicitly describe the actor's personal preference or habit.",
     "- Procedural statements such as 'for X, do Y', 'when X, do Y', and 'to accomplish X, do Y' belong in procedures.",

--- a/packages/junior-memory/src/process-session.ts
+++ b/packages/junior-memory/src/process-session.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import {
   getSourceKey,
   isPrivateSource,
+  type PluginRunContext,
   type PluginRunTranscriptEntry,
   type PluginTaskContext,
 } from "@sentry/junior-plugin-api";
@@ -97,22 +98,27 @@ function citedEntries(
 /**
  * Verify an extracted memory against runtime-owned provenance on its cited
  * evidence. This is a deterministic authority boundary, not a model decision:
- * personal preferences require citations that are all run-actor instructions,
- * conversation knowledge requires run-actor instruction or valid public
- * conversation evidence, and anything unproven (including missing provenance)
- * is dropped.
+ * personal preferences require a single-actor run whose citations are all
+ * run-actor instructions, conversation knowledge requires run-actor instruction
+ * or valid public conversation evidence, and anything unproven (including
+ * missing provenance) is dropped. Multi-actor runs interleave first-person
+ * statements from different people, so they never store a preference regardless
+ * of citations; a personal preference can wait for a single-actor run.
  */
 function routeExtractedMemory(
   memory: ExtractedMemory,
   transcript: PluginRunTranscriptEntry[],
-  hasRunActor: boolean,
+  run: Pick<PluginRunContext, "actor" | "actors">,
 ): MemoryRouteTarget {
   const cited = citedEntries(memory.evidenceMessageIndices, transcript);
   if (!cited.valid) {
     return "drop";
   }
   if (memory.kind === "preference") {
-    if (!hasRunActor) {
+    // Only a run attributed to exactly one run actor may store a preference; an
+    // empty actor set (system runs) fails closed to "drop".
+    const exactlyOneRunActor = Boolean(run.actor) && run.actors.length === 1;
+    if (!exactlyOneRunActor) {
       return "drop";
     }
     // Never downgrade an unproven first-person preference to conversation scope.
@@ -237,6 +243,7 @@ export async function processMemorySession(
       existingMemories: existingMemories.map((memory) => ({
         content: memory.content,
       })),
+      actors: run.actors,
       transcript,
       runtimeContext,
     });
@@ -246,7 +253,10 @@ export async function processMemorySession(
   }
 
   for (const memory of memories) {
-    const target = routeExtractedMemory(memory, transcript, Boolean(run.actor));
+    // The routing gate stays even though extraction is also actor-gated:
+    // getTaskMemories caches extraction output for 7 days, so a retry can replay
+    // preference proposals cached before this gate existed.
+    const target = routeExtractedMemory(memory, transcript, run);
     if (target === "drop") {
       continue;
     }

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -371,6 +371,7 @@ function completedRun(
       },
     ],
     actor: runtime.actor,
+    actors: [runtime.actor],
     runId: "local-turn-1",
     source: runtime.source,
     ...overrides,
@@ -533,6 +534,7 @@ describe("memory plugin storage", () => {
             text: "Got it.",
           },
         ],
+        actors: [localContext().actor],
         runtimeContext: localContext(),
       }),
     ).resolves.toEqual([
@@ -597,6 +599,7 @@ describe("memory plugin storage", () => {
             text: "Store several durable facts.",
           },
         ],
+        actors: [localContext().actor],
         runtimeContext: localContext(),
       }),
     ).resolves.toHaveLength(5);
@@ -628,6 +631,7 @@ describe("memory plugin storage", () => {
             text: "Store several durable facts.",
           },
         ],
+        actors: [localContext().actor],
         runtimeContext: localContext(),
       }),
     ).rejects.toThrow("Too big");
@@ -1429,6 +1433,88 @@ describe("memory plugin storage", () => {
           kind: "preference",
         }),
       ]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("drops a cached passive preference when the completed run has multiple actors", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      const state = createMemoryState();
+      const secondActor: Actor = {
+        platform: "local",
+        userId: "local-user-2",
+      };
+      // Seed the extraction cache with a preference proposed before the
+      // multi-actor gate existed. The routing gate must still drop it on replay.
+      await state.set("memory-extraction:multi-actor-task", [
+        {
+          content: "Prefers concise standup notes.",
+          expiresAtMs: null,
+          kind: "preference",
+          evidenceMessageIndices: [0],
+        },
+      ]);
+
+      await processMemorySession(
+        processSessionContext({
+          db: memoryDb(fixture),
+          id: "multi-actor-task",
+          model: throwingExtractionModel,
+          run: {
+            async load() {
+              return completedRun({
+                actors: [localInstructionActor, secondActor],
+                transcript: [
+                  instructionMessage("I prefer concise standup notes."),
+                ],
+              });
+            },
+          },
+          state,
+        }),
+      );
+
+      await expect(
+        memoryDb(fixture).select().from(memorySqlSchema.juniorMemoryMemories),
+      ).resolves.toEqual([]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("drops a passive preference when the completed run has no attributed actors", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      const { model } = extractionModel([
+        {
+          kind: "preference",
+          content: "Prefers weekly digests.",
+          evidenceMessageIndices: [0],
+        },
+      ]);
+
+      await processMemorySession(
+        processSessionContext({
+          db: memoryDb(fixture),
+          model,
+          run: {
+            async load() {
+              return completedRun({
+                actors: [],
+                transcript: [instructionMessage("I prefer weekly digests.")],
+              });
+            },
+          },
+        }),
+      );
+
+      await expect(
+        memoryDb(fixture).select().from(memorySqlSchema.juniorMemoryMemories),
+      ).resolves.toEqual([]);
     } finally {
       await fixture.close();
     }

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -650,17 +650,74 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           );
         };
         /**
-         * Durably append this turn's user input to the session log at the
-         * parked safe boundary so the resumed `continue()` sees it. The
-         * awaiting record pins the log session and materializes the projection
-         * tail, so the append needs no record mutation. Must complete before
-         * `ack` consumes the mailbox record.
+         * Commit drained parked/batched input pairs to the conversation
+         * session log, deduping by `parkedInputKey` so a redelivery never
+         * double-appends. This is the Membership-Rule commit point
+         * (specs/multi-actor-runs.md): each drained message is written with its
+         * own author's instruction provenance while that author is still known,
+         * rather than collapsing to a single latest-wins actor.
          *
          * The read-compute-append races a concurrently-resumed slice, which
          * runs under the thread resume lock; take the same lock so the two
-         * writers never interleave. Returns false when the lock is busy (a
-         * live resume owns the session log): the caller must leave the
-         * mailbox message pending for the next drain instead of consuming it.
+         * writers never interleave. Returns false when the lock is busy (a live
+         * resume owns the session log): the caller must leave the mailbox
+         * message pending for the next drain instead of consuming it.
+         */
+        const drainParkedInputToSessionLog = async (
+          pairs: Array<{ message: PiMessage; provenance: PiMessageProvenance }>,
+        ): Promise<boolean> => {
+          if (!conversationId || pairs.length === 0) {
+            return true;
+          }
+          const stateAdapter = getStateAdapter();
+          await stateAdapter.connect();
+          const lock = await acquireActiveLock(stateAdapter, conversationId);
+          if (!lock) {
+            return false;
+          }
+          try {
+            const projection = await loadProjectionWithProvenance({
+              conversationId,
+            });
+            // Dedupe per message: a partial-overlap redelivery (some messages
+            // already appended before a schedule failure) must append only
+            // the missing ones.
+            const appendedKeys = new Set(
+              projection.messages
+                .map(parkedInputKey)
+                .filter((key): key is string => key !== undefined),
+            );
+            const missing = pairs.filter((pair) => {
+              const key = parkedInputKey(pair.message);
+              return key === undefined || !appendedKeys.has(key);
+            });
+            if (missing.length === 0) {
+              // A prior delivery already appended this input durably.
+              return true;
+            }
+            await commitMessages({
+              conversationId,
+              messages: [
+                ...projection.messages,
+                ...missing.map((pair) => pair.message),
+              ],
+              provenance: [
+                ...projection.provenance,
+                ...missing.map((pair) => pair.provenance),
+              ],
+              ttlMs: THREAD_STATE_TTL_MS,
+            });
+            return true;
+          } finally {
+            await stateAdapter.releaseLock(lock);
+          }
+        };
+        /**
+         * Durably append this turn's parked user input to the session log at
+         * the parked safe boundary so the resumed `continue()` sees it. The
+         * awaiting record pins the log session and materializes the projection
+         * tail, so the append needs no record mutation. Must complete before
+         * `ack` consumes the mailbox record.
          */
         const appendParkedTurnInput = async (
           parkedSessionId: string,
@@ -687,57 +744,13 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           if (parkedMessages.length === 0) {
             return true;
           }
-          const stateAdapter = getStateAdapter();
-          await stateAdapter.connect();
-          const lock = await acquireActiveLock(stateAdapter, conversationId);
-          if (!lock) {
-            return false;
-          }
-          try {
-            // Each parked message keeps its own author's instruction
-            // provenance, so a multi-author batch is not collapsed to a single
-            // latest-wins actor.
-            const parkedPairs = (
-              await resolveSteeringMessages(parkedMessages)
-            ).map((steering) => ({
-              message: buildSteeringPiMessage(steering),
-              provenance: steering.provenance,
-            }));
-            const projection = await loadProjectionWithProvenance({
-              conversationId,
-            });
-            // Dedupe per message: a partial-overlap redelivery (some messages
-            // already appended before a schedule failure) must append only
-            // the missing ones.
-            const appendedKeys = new Set(
-              projection.messages
-                .map(parkedInputKey)
-                .filter((key): key is string => key !== undefined),
-            );
-            const missing = parkedPairs.filter((pair) => {
-              const key = parkedInputKey(pair.message);
-              return key === undefined || !appendedKeys.has(key);
-            });
-            if (missing.length === 0) {
-              // A prior delivery already appended this input durably.
-              return true;
-            }
-            await commitMessages({
-              conversationId,
-              messages: [
-                ...projection.messages,
-                ...missing.map((pair) => pair.message),
-              ],
-              provenance: [
-                ...projection.provenance,
-                ...missing.map((pair) => pair.provenance),
-              ],
-              ttlMs: THREAD_STATE_TTL_MS,
-            });
-            return true;
-          } finally {
-            await stateAdapter.releaseLock(lock);
-          }
+          const parkedPairs = (
+            await resolveSteeringMessages(parkedMessages)
+          ).map((steering) => ({
+            message: buildSteeringPiMessage(steering),
+            provenance: steering.provenance,
+          }));
+          return drainParkedInputToSessionLog(parkedPairs);
         };
         if (preparedState.userMessageAlreadyReplied) {
           await persistThreadState(thread, {
@@ -1063,18 +1076,52 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             }
           }
           const hasDurablePromptHistory = Boolean(piMessages?.length);
-          const queuedInstructionPiMessages = (
+          // Batched parked input: each explicit-mention message another actor
+          // sent before this turn started, drained into it, kept with its own
+          // author's provenance so every contributor joins the run's actors.
+          const batchedInstructions = (
             await resolveSteeringMessages(
               (options.queuedMessages ?? []).filter(
                 (queued) => queued.explicitMention,
               ),
             )
-          ).map(buildSteeringPiMessage);
-          if (queuedInstructionPiMessages.length > 0) {
-            piMessages = [
-              ...(piMessages ?? []),
-              ...queuedInstructionPiMessages,
-            ];
+          ).map((steering) => ({
+            message: buildSteeringPiMessage(steering),
+            provenance: steering.provenance,
+          }));
+          // Commit the batch to the session log before the run starts — the
+          // Membership-Rule commit point (specs/multi-actor-runs.md) — so its
+          // authors' instruction provenance is durable while they are known.
+          // The fresh prompt checkpoint then matches these merged messages as
+          // an already-committed prefix and reuses that provenance instead of
+          // collapsing them to the live actor.
+          if (!(await drainParkedInputToSessionLog(batchedInstructions))) {
+            // A live resume owns the session-log read-modify-write. Defer the
+            // turn (as appendParkedTurnInput does) so the worker releases the
+            // lease and the next drain commits provenance before running;
+            // never run with the batch uncommitted.
+            shouldPersistFailureState = false;
+            throw new TurnInputDeferredError();
+          }
+          if (batchedInstructions.length > 0) {
+            // Merge the committed batch into the transcript the model sees. A
+            // redelivery reloads the batch from the durable log, so skip any
+            // message already present by `parkedInputKey` — never merge (and
+            // later re-commit) the same batched message twice.
+            const presentKeys = new Set(
+              (piMessages ?? [])
+                .map(parkedInputKey)
+                .filter((key): key is string => key !== undefined),
+            );
+            const newlyBatched = batchedInstructions
+              .map((entry) => entry.message)
+              .filter((batchedMessage) => {
+                const key = parkedInputKey(batchedMessage);
+                return key === undefined || !presentKeys.has(key);
+              });
+            if (newlyBatched.length > 0) {
+              piMessages = [...(piMessages ?? []), ...newlyBatched];
+            }
           }
 
           status.start();
@@ -1591,6 +1638,10 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             return;
           }
           if (error instanceof CooperativeTurnYieldError) {
+            shouldPersistFailureState = false;
+            throw error;
+          }
+          if (error instanceof TurnInputDeferredError) {
             shouldPersistFailureState = false;
             throw error;
           }

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -7,6 +7,7 @@ import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import { acquireActiveLock } from "@/chat/state/locks";
 import {
+  instructionActors,
   loadProjection,
   loadProjectionWithProvenance,
 } from "@/chat/state/session-log";
@@ -1425,6 +1426,95 @@ describe("bot handlers (integration)", () => {
     });
   });
 
+  it("carries a batched mention's own author provenance into a fresh turn", async () => {
+    const conversationId = "slack:C9BATCHFRESH:1700000000.000";
+    const destination = slackDestination("C9BATCHFRESH");
+    let capturedInput:
+      | {
+          piMessages?: unknown[];
+        }
+      | undefined;
+    let capturedActorUserId: string | undefined;
+    const { slackRuntime } = createRuntime({
+      services: {
+        replyExecutor: {
+          agentRunner: {
+            run: async (request) => {
+              capturedInput = request.input;
+              const runActor = request.routing.actor;
+              capturedActorUserId =
+                runActor && "userId" in runActor ? runActor.userId : undefined;
+              await request.durability?.onInputCommitted?.();
+              return completedAgentRun({
+                text: "Recapped.",
+                diagnostics: {
+                  assistantMessageCount: 1,
+                  modelId: "test-model",
+                  outcome: "success" as const,
+                  toolCalls: [],
+                  toolErrorCount: 0,
+                  toolResultCount: 0,
+                  usedPrimaryText: true,
+                },
+              });
+            },
+          },
+        },
+      },
+    });
+    const thread = createTestThread({ id: conversationId });
+    // Bob's mention was still pending when Alice's arrived, so the mailbox
+    // drains both into Alice's fresh turn: Alice is the live run actor and
+    // Bob's ask rides along as batched parked input.
+    const fromBob = createTestMessage({
+      id: "msg-batch-bob",
+      threadId: conversationId,
+      text: "bob question",
+      isMention: true,
+      author: { userId: "U-bob" },
+    });
+    const fromAlice = createTestMessage({
+      id: "msg-batch-alice",
+      threadId: conversationId,
+      text: "alice recap request",
+      isMention: true,
+      author: { userId: "U-alice" },
+    });
+
+    await slackRuntime.handleNewMention(thread, fromAlice, {
+      destination,
+      messageContext: { skipped: [fromBob], totalSinceLastHandler: 1 },
+    });
+
+    expect(capturedActorUserId).toBe("U-alice");
+    // The drain commits Bob's batched mention to the session log before the run
+    // with his own instruction provenance, so he joins the run's actors instead
+    // of being dropped as anonymous context under Alice's turn.
+    const projection = await loadProjectionWithProvenance({ conversationId });
+    const bobEntry = projection.messages
+      .map((message, index) => ({
+        text: JSON.stringify(
+          (message as { content?: unknown }).content ?? message,
+        ),
+        provenance: projection.provenance[index],
+      }))
+      .find((entry) => entry.text.includes("bob question"));
+    expect(bobEntry?.provenance).toMatchObject({
+      authority: "instruction",
+      actor: { platform: "slack", teamId: "T123", userId: "U-bob" },
+    });
+    expect(
+      instructionActors(projection.provenance).map((actor) =>
+        "userId" in actor ? actor.userId : undefined,
+      ),
+    ).toContain("U-bob");
+    // The same committed message rides in the run's transcript, so the fresh
+    // prompt checkpoint matches it as an already-committed prefix.
+    expect(JSON.stringify(capturedInput?.piMessages ?? [])).toContain(
+      "bob question",
+    );
+  });
+
   it("leaves the parked follow-up unconsumed while a live resume holds the thread lock", async () => {
     const conversationId = "slack:C9PARKEDLOCK:1700000000.000";
     const destination = slackDestination("C9PARKEDLOCK");
@@ -1484,6 +1574,61 @@ describe("bot handlers (integration)", () => {
     expect(
       JSON.stringify(await loadProjection({ conversationId })),
     ).not.toContain("also check the logs");
+  });
+
+  it("defers a batched fresh turn while a live resume holds the thread lock", async () => {
+    const conversationId = "slack:C9BATCHLOCK:1700000000.000";
+    const destination = slackDestination("C9BATCHLOCK");
+    const run = vi.fn();
+    const ack = vi.fn();
+    const { slackRuntime } = createRuntime({
+      services: {
+        replyExecutor: {
+          agentRunner: { run },
+        },
+      },
+    });
+    const thread = createTestThread({ id: conversationId });
+    const fromBob = createTestMessage({
+      id: "msg-batchlock-bob",
+      threadId: conversationId,
+      text: "bob pending ask",
+      isMention: true,
+      author: { userId: "U-bob" },
+    });
+    const fromAlice = createTestMessage({
+      id: "msg-batchlock-alice",
+      threadId: conversationId,
+      text: "alice live ask",
+      isMention: true,
+      author: { userId: "U-alice" },
+    });
+
+    // Simulate a live resume: it holds the thread resume lock, so the batch
+    // drain cannot commit provenance and the turn must defer, not run or fail.
+    const stateAdapter = getStateAdapter();
+    await stateAdapter.connect();
+    const lock = await acquireActiveLock(stateAdapter, conversationId);
+    expect(lock).not.toBeNull();
+    try {
+      await expect(
+        slackRuntime.handleNewMention(thread, fromAlice, {
+          destination,
+          ack,
+          messageContext: { skipped: [fromBob], totalSinceLastHandler: 1 },
+        }),
+      ).rejects.toThrow("Turn input is deferred until the active resume ends");
+    } finally {
+      await stateAdapter.releaseLock(lock!);
+    }
+
+    // Nothing ran, nothing was consumed, nothing was committed: the batch
+    // stays pending in the mailbox for the next drain.
+    expect(run).not.toHaveBeenCalled();
+    expect(ack).not.toHaveBeenCalled();
+    expect(
+      JSON.stringify(await loadProjection({ conversationId })),
+    ).not.toContain("bob pending ask");
   });
 
   it("suppresses the visible failure reply when the mailbox will retry the delivery", async () => {

--- a/specs/memory-plugin/policy.md
+++ b/specs/memory-plugin/policy.md
@@ -212,6 +212,11 @@ those citations against runtime-owned provenance before storage:
   instruction from the run actor. A first-person preference whose citations are
   not all run-actor instructions is dropped, never downgraded to conversation
   scope.
+- Runs with more than one run actor never store preference memories from passive
+  extraction. Extraction for a multi-actor run is restricted to procedure and
+  knowledge, and the router drops any preference regardless of its citations.
+  This is defense in depth: multi-actor turns interleave first-person statements
+  from different people, so a personal preference waits for a single-actor run.
 - Non-run-actor public messages (whether projected as context authority or as
   attributed instruction-authority participant input) and successful tool
   results may support conversation-scoped operational knowledge, procedures,


### PR DESCRIPTION
Passive memory extraction no longer stores personal `preference` memories from runs with more than one run actor, even when every evidence citation points at a run-actor instruction. Multi-actor turns interleave first-person statements from different people, so a model mis-cite there is exactly where a cross-actor personal write is most costly; a genuine preference can wait for a single-actor run to restate it. Single-actor passive extraction, explicit memory tools, and supersession are unchanged.

The memory gate has two layers:

- `routeExtractedMemory` receives run identity (`run.actor` + `run.actors`) and routes to the personal target only for a run with exactly one run actor whose citations are all run-actor instructions. Anything else — including an empty actor set on system runs — fails closed to drop, never a downgrade to conversation scope.
- The extraction agent derives its allowed kind set from `run.actors`: on multi-actor runs the prompt omits the preference kind and rules entirely and adds an explicit block forbidding the laundering of first-person statements into `knowledge`/`procedure`. The deterministic gate stays anyway because extraction output is cached in task state for 7 days and retries can replay proposals cached before the gate existed.

The branch also fixes the chat runtime bug that made this gate unreachable in its motivating scenario. A pending message batched into another actor's fresh turn was committed to the session log as unattributed context: the reply executor resolved each queued explicit mention with its author's instruction provenance, then dropped that provenance when merging the bare Pi messages into prompt history, so the fresh-turn checkpoint stamped only the live actor's prompt and the batched author never joined `run.actors`. The fix makes the drain the commit point, per the `specs/multi-actor-runs.md` Membership Rule: the fresh-turn path durably appends each batched message to the session log with its own author's instruction provenance before the run starts — through the same lock-and-dedupe helper the parked-resume path already uses — then merges the same messages into the transcript, where the fresh-prompt checkpoint matches them as an already-committed prefix. `piMessages` stays the single transcript channel into a run (no new run-input fields), the dedupe also stops redeliveries from duplicating batched messages in the log, and a busy session-log lock defers the turn back to the mailbox instead of running with the batch uncommitted.

Review order: the runtime fix is contained to `chat/runtime/reply-executor.ts`; then the memory gate (`junior-memory`), then the eval. The new eval case is the acceptance test for the pair: the run actor's own well-cited preference stated in a batched multi-actor turn must not be stored under any memory kind — it fails on the gate alone without the runtime fix. The other multi-actor provenance cases guard against over-tightening (non-actor operational knowledge still stores as conversation memory), and integration tests cover the committed per-author provenance, the lock-busy deferral, and redelivery dedupe at the durable log boundary.

Known flake: the pre-existing batched-mention case's rubric can conflate the two users in reply phrasing because the eval harness renders every profile as the same display name; its DB assertions are stable. Harness display identity is worth a follow-up.

Fixes #776