### PR TITLE
fix(telemetry): Emit canonical GenAI message attributes

### DIFF
--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -71,6 +71,7 @@ import { AuthorizationFlowDisabledError } from "@/chat/services/auth-pause";
 import {
   resolveConversationPrivacy,
   runWithConversationPrivacy,
+  toCanonicalOutputMessage,
   toGenAiMessageMetadata,
   toGenAiMessagesTraceAttributes,
   type ConversationPrivacy,
@@ -405,7 +406,7 @@ async function executeAgentRunInPrivacyContext(
     });
     setSpanAttributes({
       "gen_ai.request.model": botConfig.modelId,
-      "app.ai.reasoning_effort": thinkingSelection.thinkingLevel,
+      "gen_ai.request.reasoning.level": thinkingSelection.thinkingLevel,
       "app.ai.thinking_level_reason": thinkingSelection.reason,
       ...(thinkingSelection.confidence !== undefined
         ? {
@@ -697,7 +698,7 @@ async function executeAgentRunInPrivacyContext(
                     "gen_ai.request.model": botConfig.modelId,
                     ...(thinkingSelection
                       ? {
-                          "app.ai.reasoning_effort":
+                          "gen_ai.request.reasoning.level":
                             thinkingSelection.thinkingLevel,
                         }
                       : {}),
@@ -759,7 +760,7 @@ async function executeAgentRunInPrivacyContext(
             const outputMessagesAttribute = serializeGenAiAttribute(
               conversationPrivacy !== "public"
                 ? outputMessages.map(toGenAiMessageMetadata)
-                : outputMessages,
+                : outputMessages.map(toCanonicalOutputMessage),
             );
             const usageSummary = extractGenAiUsageSummary(
               promptResult,
@@ -825,7 +826,7 @@ async function executeAgentRunInPrivacyContext(
             : {}),
           ...(sessionId ? { "app.ai.turn.session_id": sessionId } : {}),
           ...(currentSliceId ? { "app.ai.turn.slice_id": currentSliceId } : {}),
-          "app.ai.reasoning_effort": thinkingSelection.thinkingLevel,
+          "gen_ai.request.reasoning.level": thinkingSelection.thinkingLevel,
           ...toGenAiMessagesTraceAttributes("app.ai.input", inputMessages),
           ...(inputMessagesAttribute
             ? { "gen_ai.input.messages": inputMessagesAttribute }

--- a/packages/junior/src/chat/conversation-privacy.ts
+++ b/packages/junior/src/chat/conversation-privacy.ts
@@ -1,4 +1,12 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import type {
+  AssistantMessage,
+  ImageContent,
+  Message,
+  TextContent,
+  ThinkingContent,
+  ToolCall,
+} from "@earendil-works/pi-ai";
 import { parseSlackThreadId } from "@/chat/slack/context";
 
 export type ConversationPrivacy = "public" | "private";
@@ -94,10 +102,16 @@ function contentMetadata(content: unknown): unknown {
       return { type: typeof part };
     }
     const record = part as Record<string, unknown>;
-    const type = typeof record.type === "string" ? record.type : "unknown";
+    const type = canonicalContentPartType(
+      typeof record.type === "string" ? record.type : "unknown",
+    );
     return {
       type,
-      ...(typeof record.text === "string" ? { chars: record.text.length } : {}),
+      ...(typeof record.text === "string"
+        ? { chars: record.text.length }
+        : typeof record.thinking === "string" && record.thinking.length > 0
+          ? { chars: record.thinking.length }
+          : {}),
       ...(typeof record.mimeType === "string"
         ? { mimeType: record.mimeType }
         : {}),
@@ -208,10 +222,14 @@ function summarizeContent(content: unknown): {
       continue;
     }
     const record = part as Record<string, unknown>;
-    const type = typeof record.type === "string" ? record.type : "unknown";
+    const type = canonicalContentPartType(
+      typeof record.type === "string" ? record.type : "unknown",
+    );
     partTypes.add(type);
     if (typeof record.text === "string") {
       chars += record.text.length;
+    } else if (typeof record.thinking === "string") {
+      chars += record.thinking.length;
     } else if (typeof record.data === "string") {
       chars += record.data.length;
     } else {
@@ -219,6 +237,84 @@ function summarizeContent(content: unknown): {
     }
   }
   return { chars, partTypes: [...partTypes] };
+}
+
+// ---------------------------------------------------------------------------
+// Canonical gen_ai attribute format mappers
+// ---------------------------------------------------------------------------
+
+function normalizeFinishReason(reason: string): string {
+  return reason === "toolUse" ? "tool_use" : reason;
+}
+
+function canonicalContentPartType(type: string): string {
+  if (type === "thinking") return "reasoning";
+  if (type === "toolCall") return "tool_call";
+  return type;
+}
+
+function toCanonicalPart(
+  part: TextContent | ThinkingContent | ImageContent | ToolCall,
+): Record<string, unknown> {
+  if (part.type === "text") {
+    return { type: "text", content: part.text };
+  }
+  if (part.type === "thinking") {
+    if (part.redacted) {
+      return { type: "reasoning", redacted: true };
+    }
+    return { type: "reasoning", content: part.thinking };
+  }
+  if (part.type === "toolCall") {
+    return {
+      type: "tool_call",
+      id: part.id,
+      name: part.name,
+      arguments: part.arguments,
+    };
+  }
+  // image — omit raw base64 data, keep type and mimeType only
+  return { type: "image", mimeType: (part as ImageContent).mimeType };
+}
+
+/**
+ * Map a pi-ai AssistantMessage to the canonical gen_ai.output.messages shape:
+ * `{ role, parts: [...], finish_reason }` — drops provider noise fields.
+ */
+export function toCanonicalOutputMessage(
+  message: AssistantMessage,
+): Record<string, unknown> {
+  return {
+    role: "assistant",
+    parts: message.content.map(toCanonicalPart),
+    finish_reason: normalizeFinishReason(message.stopReason),
+  };
+}
+
+/**
+ * Map a pi-ai Message (user/assistant/toolResult) to the canonical
+ * gen_ai.input.messages shape: `{ role, parts: [...] }`.
+ */
+export function toCanonicalInputMessage(
+  message: Message,
+): Record<string, unknown> {
+  if (message.role === "user") {
+    const parts =
+      typeof message.content === "string"
+        ? [{ type: "text", content: message.content }]
+        : message.content.map(toCanonicalPart);
+    return { role: "user", parts };
+  }
+  if (message.role === "toolResult") {
+    return {
+      role: "tool",
+      id: message.toolCallId,
+      name: message.toolName,
+      parts: message.content.map(toCanonicalPart),
+    };
+  }
+  // AssistantMessage appearing as a prior turn in input context
+  return toCanonicalOutputMessage(message as AssistantMessage);
 }
 
 /** Summarize a message list without exposing raw message content. */

--- a/packages/junior/src/chat/logging.ts
+++ b/packages/junior/src/chat/logging.ts
@@ -1978,18 +1978,27 @@ export function extractGenAiUsageAttributes(
   Record<
     | "gen_ai.usage.input_tokens"
     | "gen_ai.usage.output_tokens"
-    | "gen_ai.usage.cache_read.input_tokens"
-    | "gen_ai.usage.cache_creation.input_tokens",
+    | "gen_ai.usage.input_tokens.cached"
+    | "gen_ai.usage.input_tokens.cache_write"
+    | "gen_ai.usage.total_tokens",
     number
   >
 > {
-  const { inputTokens, outputTokens, cachedInputTokens, cacheCreationTokens } =
-    extractGenAiUsageSummary(...sources);
+  const {
+    inputTokens,
+    outputTokens,
+    cachedInputTokens,
+    cacheCreationTokens,
+    totalTokens,
+  } = extractGenAiUsageSummary(...sources);
   const semanticInputTokens = sumTokenCounts(
     inputTokens,
     cachedInputTokens,
     cacheCreationTokens,
   );
+
+  const semanticTotalTokens =
+    totalTokens ?? sumTokenCounts(semanticInputTokens, outputTokens);
 
   return {
     ...(semanticInputTokens !== undefined
@@ -1998,11 +2007,14 @@ export function extractGenAiUsageAttributes(
     ...(outputTokens !== undefined
       ? { "gen_ai.usage.output_tokens": outputTokens }
       : {}),
+    ...(semanticTotalTokens !== undefined
+      ? { "gen_ai.usage.total_tokens": semanticTotalTokens }
+      : {}),
     ...(cachedInputTokens !== undefined
-      ? { "gen_ai.usage.cache_read.input_tokens": cachedInputTokens }
+      ? { "gen_ai.usage.input_tokens.cached": cachedInputTokens }
       : {}),
     ...(cacheCreationTokens !== undefined
-      ? { "gen_ai.usage.cache_creation.input_tokens": cacheCreationTokens }
+      ? { "gen_ai.usage.input_tokens.cache_write": cacheCreationTokens }
       : {}),
   };
 }

--- a/packages/junior/src/chat/pi/client.ts
+++ b/packages/junior/src/chat/pi/client.ts
@@ -39,6 +39,8 @@ import { toOptionalTrimmed } from "@/chat/optional-string";
 import {
   getCurrentConversationPrivacy,
   resolveConversationPrivacy,
+  toCanonicalInputMessage,
+  toCanonicalOutputMessage,
   toGenAiMessageMetadata,
   toGenAiMessagesTraceAttributes,
   toGenAiTextMetadata,
@@ -139,7 +141,7 @@ export async function completeText(params: {
   const requestMessagesAttribute = serializeGenAiAttribute(
     messageAttributeMode === "metadata"
       ? params.messages.map(toGenAiMessageMetadata)
-      : params.messages,
+      : params.messages.map(toCanonicalInputMessage),
   );
   const systemInstructionsAttribute = params.system
     ? serializeGenAiAttribute(
@@ -157,7 +159,7 @@ export async function completeText(params: {
     "server.port": GEN_AI_SERVER_PORT,
     "app.conversation.privacy": effectivePrivacy,
     ...(params.thinkingLevel
-      ? { "app.ai.reasoning_effort": params.thinkingLevel }
+      ? { "gen_ai.request.reasoning.level": params.thinkingLevel }
       : {}),
   };
   const startAttributes = {
@@ -208,12 +210,7 @@ export async function completeText(params: {
                 content: outputText ? [toGenAiTextMetadata(outputText)] : [],
               },
             ]
-          : [
-              {
-                role: "assistant",
-                content: outputText ? [{ type: "text", text: outputText }] : [],
-              },
-            ],
+          : [toCanonicalOutputMessage(message)],
       );
       const usageAttributes = extractGenAiUsageAttributes(message);
       const endAttributes = {
@@ -326,7 +323,7 @@ export async function completeObject<TSchema extends ZodTypeAny>(params: {
         "server.address": GEN_AI_SERVER_ADDRESS,
         "server.port": GEN_AI_SERVER_PORT,
         ...(params.thinkingLevel
-          ? { "app.ai.reasoning_effort": params.thinkingLevel }
+          ? { "gen_ai.request.reasoning.level": params.thinkingLevel }
           : {}),
       },
     );

--- a/packages/junior/src/chat/pi/traced-stream.ts
+++ b/packages/junior/src/chat/pi/traced-stream.ts
@@ -20,6 +20,8 @@ import {
 } from "@/chat/pi/client";
 import {
   type ConversationPrivacy,
+  toCanonicalInputMessage,
+  toCanonicalOutputMessage,
   toGenAiMessageMetadata,
   toGenAiMessagesTraceAttributes,
   toGenAiTextMetadata,
@@ -60,7 +62,7 @@ function buildChatStartAttributes(
   const inputMessages = serializeGenAiAttribute(
     mode === "metadata"
       ? context.messages.map(toGenAiMessageMetadata)
-      : context.messages,
+      : context.messages.map(toCanonicalInputMessage),
   );
   if (inputMessages) {
     attributes["gen_ai.input.messages"] = inputMessages;
@@ -92,7 +94,9 @@ function buildChatEndAttributes(
   };
 
   const outputMessages = serializeGenAiAttribute(
-    mode === "metadata" ? [toGenAiMessageMetadata(message)] : [message],
+    mode === "metadata"
+      ? [toGenAiMessageMetadata(message)]
+      : [toCanonicalOutputMessage(message)],
   );
   if (outputMessages) {
     attributes["gen_ai.output.messages"] = outputMessages;

--- a/packages/junior/src/chat/services/turn-failure-response.ts
+++ b/packages/junior/src/chat/services/turn-failure-response.ts
@@ -89,7 +89,7 @@ export function getAgentTurnDiagnosticsAttributes(
     "app.ai.used_primary_text": reply.diagnostics.usedPrimaryText,
     ...(reply.diagnostics.thinkingLevel
       ? {
-          "app.ai.reasoning_effort": reply.diagnostics.thinkingLevel,
+          "gen_ai.request.reasoning.level": reply.diagnostics.thinkingLevel,
         }
       : {}),
     ...(reply.diagnostics.stopReason

--- a/packages/junior/src/chat/tools/advisor/tool.ts
+++ b/packages/junior/src/chat/tools/advisor/tool.ts
@@ -7,6 +7,8 @@ import { THREAD_STATE_TTL_MS } from "chat";
 import type { AdvisorConfig } from "@/chat/config";
 import {
   type ConversationPrivacy,
+  toCanonicalInputMessage,
+  toCanonicalOutputMessage,
   toGenAiMessageMetadata,
   toGenAiMessagesTraceAttributes,
 } from "@/chat/conversation-privacy";
@@ -244,18 +246,14 @@ export function createAdvisorTool(context: AdvisorToolRuntimeContext) {
         "</executor-context>",
       ].join("\n");
       const advisorInputMessage = {
-        role: "user",
-        content: [
-          {
-            type: "text",
-            text: requestText,
-          },
-        ],
+        role: "user" as const,
+        content: [{ type: "text" as const, text: requestText }],
+        timestamp: Date.now(),
       };
       const advisorInputMessagesAttribute = serializeGenAiAttribute(
         conversationPrivacy !== "public"
           ? [toGenAiMessageMetadata(advisorInputMessage)]
-          : [advisorInputMessage],
+          : [toCanonicalInputMessage(advisorInputMessage)],
       );
 
       return await withSpan(
@@ -314,7 +312,7 @@ export function createAdvisorTool(context: AdvisorToolRuntimeContext) {
           const outputMessagesAttribute = serializeGenAiAttribute(
             conversationPrivacy !== "public"
               ? outputMessages.map(toGenAiMessageMetadata)
-              : outputMessages,
+              : outputMessages.map(toCanonicalOutputMessage),
           );
           setSpanAttributes({
             ...(outputMessagesAttribute

--- a/packages/junior/tests/unit/chat/pi/traced-stream.test.ts
+++ b/packages/junior/tests/unit/chat/pi/traced-stream.test.ts
@@ -222,6 +222,81 @@ describe("createTracedStreamFn", () => {
     expect(span.end).toHaveBeenCalledTimes(1);
   });
 
+  it("serializes gen_ai.output.messages in canonical format for public conversations", async () => {
+    const { createTracedStreamFn } = await import("@/chat/pi/traced-stream");
+    const stream = createAssistantMessageEventStream();
+    const base = vi.fn(() => stream);
+
+    const traced = createTracedStreamFn({
+      base: base as unknown as StreamFn,
+      conversationPrivacy: "public",
+    });
+    await traced(
+      fakeModel("openai/gpt-5.4"),
+      { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
+      undefined,
+    );
+
+    stream.end({
+      ...fakeMessage(),
+      content: [
+        { type: "thinking", thinking: "I should use the search tool." },
+        { type: "thinking", thinking: "", redacted: true },
+        { type: "text", text: "The answer is 42." },
+        {
+          type: "toolCall",
+          id: "call_1",
+          name: "search",
+          arguments: { q: "foo" },
+        },
+      ],
+      stopReason: "toolUse",
+    });
+    await stream.result();
+    await new Promise((r) => setImmediate(r));
+
+    const span = getSpan();
+    const endAttributes = Object.fromEntries(
+      span.setAttribute.mock.calls.map((c) => [c[0], c[1]]),
+    );
+
+    const outputMessages = JSON.parse(
+      endAttributes["gen_ai.output.messages"] as string,
+    );
+    expect(outputMessages).toHaveLength(1);
+    const msg = outputMessages[0];
+    expect(msg.role).toBe("assistant");
+    expect(msg.finish_reason).toBe("tool_use");
+    expect(msg.parts).toEqual([
+      { type: "reasoning", content: "I should use the search tool." },
+      { type: "reasoning", redacted: true },
+      { type: "text", content: "The answer is 42." },
+      {
+        type: "tool_call",
+        id: "call_1",
+        name: "search",
+        arguments: { q: "foo" },
+      },
+    ]);
+    // must NOT contain raw pi-ai fields
+    expect(msg).not.toHaveProperty("content");
+    expect(msg).not.toHaveProperty("stopReason");
+    expect(msg).not.toHaveProperty("api");
+    expect(msg).not.toHaveProperty("usage");
+
+    // input messages should also be in canonical format
+    const startOpts = startInactiveSpan.mock.calls[0]?.[0] as unknown as {
+      attributes: Record<string, unknown>;
+    };
+    const inputMessages = JSON.parse(
+      startOpts.attributes["gen_ai.input.messages"] as string,
+    );
+    expect(inputMessages[0]).toEqual({
+      role: "user",
+      parts: [{ type: "text", content: "hello" }],
+    });
+  });
+
   it("normalizes Pi toolUse finish reasons for telemetry", async () => {
     const { createTracedStreamFn } = await import("@/chat/pi/traced-stream");
     const stream = createAssistantMessageEventStream();

--- a/packages/junior/tests/unit/logging/extract-gen-ai-usage-summary.test.ts
+++ b/packages/junior/tests/unit/logging/extract-gen-ai-usage-summary.test.ts
@@ -111,8 +111,9 @@ describe("extractGenAiUsageSummary", () => {
     ).toEqual({
       "gen_ai.usage.input_tokens": 15,
       "gen_ai.usage.output_tokens": 2,
-      "gen_ai.usage.cache_read.input_tokens": 4,
-      "gen_ai.usage.cache_creation.input_tokens": 1,
+      "gen_ai.usage.total_tokens": 17,
+      "gen_ai.usage.input_tokens.cached": 4,
+      "gen_ai.usage.input_tokens.cache_write": 1,
     });
   });
 });

--- a/packages/junior/tests/unit/pi/client.test.ts
+++ b/packages/junior/tests/unit/pi/client.test.ts
@@ -104,7 +104,7 @@ describe("completeText", () => {
         "gen_ai.output.type": "text",
         "server.address": "ai-gateway.vercel.sh",
         "server.port": 443,
-        "app.ai.reasoning_effort": "low",
+        "gen_ai.request.reasoning.level": "low",
       }),
     );
     expect(attributes["gen_ai.system_instructions"]).toBeDefined();

--- a/specs/harness-agent.md
+++ b/specs/harness-agent.md
@@ -91,14 +91,15 @@ Define the canonical runtime contract for assistant-turn execution and user-visi
 - Every assistant turn must annotate active spans with turn diagnostics after generation completes.
 - Required attributes when available:
   - `gen_ai.request.model`
+  - `gen_ai.request.reasoning.level` (when requested)
   - `gen_ai.provider.name`
   - `gen_ai.operation.name`
   - `gen_ai.input.messages`
   - `gen_ai.output.messages`
   - `gen_ai.usage.input_tokens`
-  - `gen_ai.usage.output_tokens`
-  - `gen_ai.usage.cache_read.input_tokens` (when available)
-  - `gen_ai.usage.cache_creation.input_tokens` (when available)
+  - `gen_ai.usage.output_tokens` / `gen_ai.usage.total_tokens`
+  - `gen_ai.usage.input_tokens.cached` (when available)
+  - `gen_ai.usage.input_tokens.cache_write` (when available)
   - `app.ai.outcome` (`success|execution_failure|provider_error`)
   - `app.ai.assistant_messages`
   - `app.ai.tool_results`

--- a/specs/logging.md
+++ b/specs/logging.md
@@ -174,14 +174,15 @@ Rules:
 ### GenAI
 
 - `gen_ai.request.model`
+- `gen_ai.request.reasoning.level` (when requested)
 - `gen_ai.provider.name` (provider/gateway)
 - `gen_ai.operation.name` (e.g. `chat`, `invoke_agent`, `execute_tool`)
 - `gen_ai.response.finish_reasons` (when available)
 - `gen_ai.system_instructions` (when captured and provided separately)
 - `gen_ai.input.messages` (serialized request messages when captured)
 - `gen_ai.output.messages` (serialized model output messages when captured)
-- `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` (when available)
-- `gen_ai.usage.cache_read.input_tokens` / `gen_ai.usage.cache_creation.input_tokens` (when available)
+- `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` / `gen_ai.usage.total_tokens` (when available)
+- `gen_ai.usage.input_tokens.cached` / `gen_ai.usage.input_tokens.cache_write` (when available)
 - `gen_ai.tool.description` (for tool-call spans when available)
 - `gen_ai.tool.call.arguments` / `gen_ai.tool.call.result` (for tool-call spans when captured)
 

--- a/specs/otel-semantics.md
+++ b/specs/otel-semantics.md
@@ -61,6 +61,7 @@ This file is the canonical attribute and naming map for instrumentation in this 
 - `gen_ai.provider.name`
 - `gen_ai.operation.name`
 - `gen_ai.request.model`
+- `gen_ai.request.reasoning.level` (when requested)
 - `gen_ai.output.type`
 - `gen_ai.request.stream`
 - `gen_ai.response.finish_reasons` (when available)
@@ -71,8 +72,9 @@ This file is the canonical attribute and naming map for instrumentation in this 
 - `gen_ai.output.messages` (when captured)
 - `gen_ai.usage.input_tokens` (when available)
 - `gen_ai.usage.output_tokens` (when available)
-- `gen_ai.usage.cache_read.input_tokens` (when available)
-- `gen_ai.usage.cache_creation.input_tokens` (when available)
+- `gen_ai.usage.total_tokens` (when available)
+- `gen_ai.usage.input_tokens.cached` (when available)
+- `gen_ai.usage.input_tokens.cache_write` (when available)
 - `gen_ai.tool.description` (when available)
 - `gen_ai.tool.name` (for `execute_tool`)
 - `gen_ai.tool.type` (when available)

--- a/specs/tracing.md
+++ b/specs/tracing.md
@@ -58,6 +58,7 @@ Define the canonical tracing contract for span naming, boundaries, attributes, a
 - `gen_ai.conversation.id` on GenAI spans when the conversation/thread identifier is known.
 - `messaging.destination.name` for channel context when available.
 - `gen_ai.request.model` for model-level tracing.
+- `gen_ai.request.reasoning.level` for requested reasoning/thinking level when known.
 - `gen_ai.output.type` for the requested response type when known.
 - `gen_ai.request.stream` on streaming model calls.
 - `server.address` for GenAI client/provider spans when known.
@@ -69,8 +70,8 @@ Define the canonical tracing contract for span naming, boundaries, attributes, a
 - Custom `app.ai.input.*` / `app.ai.output.*` bounded message shape metadata
   (`message_count`, `content_chars`, `roles`, `part_types`) only when scalar
   query pivots are needed beyond the standard `gen_ai.*.messages` attributes.
-- `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` when available from provider responses.
-- `gen_ai.usage.cache_read.input_tokens` / `gen_ai.usage.cache_creation.input_tokens` when available from provider responses.
+- `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` / `gen_ai.usage.total_tokens` when available from provider responses.
+- `gen_ai.usage.input_tokens.cached` / `gen_ai.usage.input_tokens.cache_write` when available from provider responses.
 - `gen_ai.tool.description` when available on tool execution spans.
 - `gen_ai.tool.type` when available on tool execution spans.
 - `gen_ai.tool.call.arguments` / `gen_ai.tool.call.result` on tool execution spans when captured.


### PR DESCRIPTION
Junior now emits GenAI prompt and response spans in Sentry's canonical message shape instead of serializing raw pi-ai messages. Public conversations use `{ role, parts }` payloads with `text`, `reasoning`, and `tool_call` parts, while private conversations keep the existing metadata-only capture so raw Slack/user content is not exposed.

Before, `gen_ai.output.messages` could contain pi-ai-specific fields like `content`, `stopReason`, `toolCall`, provider metadata, and usage payloads. After this change, response messages use `parts`, `finish_reason`, canonical `tool_call` names, and `reasoning` parts for model thinking so Sentry Conversations can render the user-visible transcript separately from reasoning.

The related GenAI usage attributes now use the OpenTelemetry semantic convention names for reasoning level, cache reads/writes, and total tokens, and the repo instrumentation specs match those keys.