### PR TITLE
feat(tools): Discover deferred tools by source

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,16 @@ Co-Authored-By: (agent model name) <email>
 - Prefer integration tests for most product/runtime changes that need real wiring.
 - Use evals as the integration-style layer for agent/prompt/natural-language behavior. See `packages/junior-evals/README.md`.
 - In evals, use the normalized `vitest-evals` session and `toolCalls(result.session)` as the primary assertion surfaces; do not invent local transcript/tool-call schemas.
+- Eval cases should pair semantic `criteria: rubric({ pass, fail })` with deterministic assertions when a concrete boundary matters:
+  ```ts
+  const result = await run({
+    events,
+    criteria: rubric({ pass: ["User-visible behavior happens."] }),
+  });
+  expect(toolCalls(result.session)).toEqual(
+    expect.arrayContaining([expect.objectContaining({ name: "searchTools" })]),
+  );
+  ```
 - For any non-Slack-specific product/runtime/prompt/tool/plugin behavior change, use the local agent as the first manual behavior check. Follow `packages/docs/src/content/docs/contribute/local-agent-validation.md`; from this monorepo, run it with `pnpm cli -- chat ...`, which uses `apps/example` as the canonical local validation app.
 - Run evals through the package scripts only: `pnpm evals` for the full suite or `pnpm --filter @sentry/junior-evals evals ...` for focused runs. Do not use `pnpm exec vitest` directly for evals.
 - Pass eval file paths and `-t` filters directly after `evals`; do not insert `--` before eval args.

--- a/openspec/changes/deferred-tool-discovery/proposal.md
+++ b/openspec/changes/deferred-tool-discovery/proposal.md
@@ -1,0 +1,97 @@
+# Deferred Tool Discovery
+
+## Summary
+
+Make deferred catalog tools discoverable by source so the model can find plugin
+and future provider tools without those tools being directly registered as
+native model tools.
+
+## Motivation
+
+Memory workflow eval failures in #784 point at a discoverability gap: memory
+tools exist as deferred plugin tools, but the model must already know to call
+`searchTools` and then `executeTool`. The current direct tool description says
+there is an executable catalog, but it does not advertise that deferred tools
+exist or which sources can be searched.
+
+Codex has useful prior art here: its tool search surface tells the model that
+tools are available from known sources and that some tools may need discovery.
+Junior should adopt the source-advertising pattern while keeping its current
+`executeTool` bridge because Junior does not yet load discovered tools into the
+next model turn.
+
+## Scope
+
+- Add `source` as the model-facing grouping concept for deferred catalog tools.
+- Advertise available deferred sources in the `searchTools` description.
+- Add an optional `source` filter to `searchTools`.
+- Return compact source summaries and compact per-tool metadata from search.
+- Auto-summarize model-visible tool and source descriptions.
+- Carry source metadata from plugin tool registration into the executable
+  catalog.
+- Leave `executeTool` as the current execution bridge.
+- Align the shape with a future where MCP provider tools can share the same
+  catalog through sources such as `mcp:sentry`.
+
+## Non-Goals
+
+- Direct-registering every plugin or MCP tool as a native model tool.
+- Implementing Codex-style deferred tool loading into the next model turn.
+- Replacing existing MCP activation rules in this change.
+- Defining provider-specific workflows or memory storage semantics.
+- Emitting full plugin or MCP provider metadata in every search result.
+
+## Design Notes
+
+`source` should be the single public grouping term. Avoid introducing separate
+model-facing names such as namespace, domain, or owner for the same concept.
+
+`searchTools` should accept:
+
+```ts
+{
+  query?: string | null;
+  source?: string | null;
+  max_results?: number | null;
+}
+```
+
+The native `searchTools` description should list known deferred sources, not all
+known tools:
+
+```text
+Deferred tools are grouped by source. Use searchTools with source to inspect one
+source, then executeTool with the exact returned tool_name.
+
+Available sources:
+- memory: Long-term memory storage, recall, listing, and removal.
+```
+
+Search results should include source summaries once at the top level. When a
+search is filtered to one source, per-tool results should omit `source`. When a
+search spans sources, per-tool results may include only the compact source id.
+
+Descriptions shown to the model should be summarized by normalizing whitespace,
+using the first meaningful line or paragraph before a blank break, and applying
+a hard cap around 160-200 characters. Full descriptions may still be used for
+search indexing.
+
+## Compatibility
+
+Existing direct tools remain direct. Existing deferred tools remain executable
+through `executeTool`. Models that already know an exact catalog `tool_name` may
+still call `executeTool` directly, but the intended model path is discovery via
+`searchTools` when the exact name is unknown.
+
+Dedicated MCP search/execution paths may remain while MCP activation is
+separate. Future MCP unification should map providers into the same `source`
+contract instead of inventing a second grouping field.
+
+## Risks
+
+- Source descriptions could become another prompt-bloat surface if not
+  truncated.
+- Empty-query discovery could dump too much of the catalog unless explicitly
+  bounded.
+- If source metadata is only inferred from plugin names, source descriptions may
+  be weak until plugin registration carries concise descriptions.

--- a/openspec/changes/deferred-tool-discovery/specs/deferred-tool-discovery/spec.md
+++ b/openspec/changes/deferred-tool-discovery/specs/deferred-tool-discovery/spec.md
@@ -1,0 +1,129 @@
+# Deferred Tool Discovery
+
+## ADDED Requirements
+
+### Requirement: Deferred Tools Are Discoverable By Source
+
+Junior SHALL expose deferred catalog tool availability through a stable
+model-facing `source` grouping.
+
+#### Scenario: Deferred plugin tool has source identity
+
+- **WHEN** a plugin registers a deferred tool
+- **THEN** Junior records a compact source id for that tool
+- **AND** first-party plugin tools use the plugin name as the source id
+- **AND** source ids do not include actor ids, workspace ids, credential
+  subjects, or transient connection state.
+
+#### Scenario: Future MCP provider source
+
+- **WHEN** MCP provider tools are represented in the deferred catalog
+- **THEN** Junior groups them under provider-qualified source ids such as
+  `mcp:sentry`
+- **AND** Junior does not create separate source ids for individual upstream
+  tools, resources, projects, or issues.
+
+### Requirement: Search Tool Advertises Deferred Sources
+
+The native `searchTools` tool SHALL tell the model that deferred tools exist and
+list the known searchable sources when those sources are known at turn start.
+
+#### Scenario: Search tool description includes sources
+
+- **WHEN** Junior creates the native `searchTools` definition
+- **THEN** the description explains that deferred tools are grouped by source
+- **AND** the description tells the model to search a source before using
+  `executeTool`
+- **AND** the description lists compact source summaries
+- **AND** the description does not enumerate every tool in every source.
+
+### Requirement: Search Tools Supports Source Filtering
+
+`searchTools` SHALL accept an optional nullable `source` field that filters
+catalog discovery.
+
+#### Scenario: Search within a source
+
+- **WHEN** the model calls `searchTools` with `source: "memory"`
+- **THEN** Junior returns only catalog tools from the `memory` source
+- **AND** query matching is applied within that source when `query` is present.
+
+#### Scenario: Empty source query lists source tools
+
+- **WHEN** the model calls `searchTools` with a source and no query filter
+- **THEN** Junior returns a bounded list of tools from that source.
+
+#### Scenario: Search across all sources
+
+- **WHEN** the model calls `searchTools` without a source
+- **THEN** Junior searches across all eligible catalog tools
+- **AND** an empty query returns source summaries and only a bounded tool sample.
+
+#### Scenario: Unknown source
+
+- **WHEN** the model calls `searchTools` with an unknown source
+- **THEN** Junior returns a structured result with no tools
+- **AND** the result includes known sources so the model can repair the call
+- **AND** Junior does not throw a runtime exception for the unknown source.
+
+### Requirement: Search Results Are Compact
+
+`searchTools` results SHALL avoid repeating expanded source metadata on every
+tool.
+
+#### Scenario: Filtered result shape
+
+- **WHEN** a search is filtered to one source
+- **THEN** the result includes the selected source in a top-level `sources`
+  array
+- **AND** individual tool results omit per-tool `source`.
+
+#### Scenario: Cross-source result shape
+
+- **WHEN** a search returns tools from multiple sources
+- **THEN** the result includes unique compact source summaries at the top level
+- **AND** individual tool results may include only the compact source id
+- **AND** individual tool results do not include expanded plugin manifests, MCP
+  provider configuration, credential state, or connection metadata.
+
+### Requirement: Model-Visible Descriptions Are Summarized
+
+Junior SHALL summarize source and tool descriptions before rendering them in
+native tool descriptions or `searchTools` results.
+
+#### Scenario: Long description is rendered
+
+- **WHEN** a source or tool description contains multiple paragraphs or exceeds
+  the model-visible summary cap
+- **THEN** Junior normalizes whitespace
+- **AND** Junior prefers the first meaningful line or paragraph before a blank
+  break
+- **AND** Junior truncates the rendered summary to a hard cap around 160-200
+  characters.
+
+#### Scenario: Search indexing uses richer text
+
+- **WHEN** Junior searches the catalog
+- **THEN** it may use full tool descriptions, prompt snippets, prompt
+  guidelines, schemas, and annotations for matching
+- **AND** the rendered result still uses summarized model-visible descriptions.
+
+### Requirement: Execute Tool Remains The Deferred Execution Bridge
+
+Junior SHALL continue using `executeTool` to execute deferred catalog tools until
+Junior supports first-class deferred tool loading.
+
+#### Scenario: Model discovers then executes a tool
+
+- **WHEN** the model needs a deferred capability but does not know the exact
+  tool name
+- **THEN** it can call `searchTools`
+- **AND** use the returned exact `tool_name` in `executeTool`
+- **AND** pass arguments matching the selected tool schema.
+
+#### Scenario: Invalid catalog execution
+
+- **WHEN** the model calls `executeTool` for a tool outside the executable
+  catalog or with invalid arguments
+- **THEN** Junior returns the existing model-repairable tool error
+- **AND** it does not silently execute an unavailable or mismatched tool.

--- a/openspec/changes/deferred-tool-discovery/tasks.md
+++ b/openspec/changes/deferred-tool-discovery/tasks.md
@@ -1,0 +1,55 @@
+# Tasks
+
+## 1. Source Metadata
+
+- [ ] Add a compact source identity to deferred catalog tool metadata.
+- [ ] Populate plugin tool sources during plugin tool registration.
+- [ ] Use the plugin name as the first-party plugin source id, such as `memory`.
+- [ ] Add or derive concise source descriptions without exposing full plugin
+      manifests per tool.
+
+## 2. Search Tool Contract
+
+- [ ] Add optional nullable `source` input to `searchTools`.
+- [ ] Treat omitted, null, and empty `query` as no query filter.
+- [ ] Treat omitted and null `source` as all-source search.
+- [ ] Filter catalog search by source when provided.
+- [ ] Return structured empty results with known sources for unknown source
+      values.
+- [ ] Bound empty-query all-source responses so they do not dump the full
+      catalog.
+
+## 3. Model-Visible Guidance
+
+- [ ] Update the `searchTools` description to advertise deferred sources.
+- [ ] List source summaries, not every known tool, in the direct tool
+      description.
+- [ ] Keep `executeTool` guidance aligned with the discovery path.
+- [ ] Summarize source and tool descriptions before rendering them to the model.
+
+## 4. Result Shape
+
+- [ ] Return unique compact `sources` summaries at the top level.
+- [ ] Omit per-tool `source` when results are filtered to one source.
+- [ ] Include only compact per-tool source ids for cross-source results.
+- [ ] Avoid repeating expanded plugin or provider metadata per tool.
+- [ ] Preserve useful tool fields: `tool_name`, description, input schema,
+      input schema summary, call notes, and annotations.
+
+## 5. Verification
+
+- [ ] Add unit coverage for source filtering.
+- [ ] Add unit coverage for unknown source responses.
+- [ ] Add unit coverage for empty-query source listing behavior.
+- [ ] Add unit coverage for filtered and mixed-source result shapes.
+- [ ] Add unit coverage for description summarization/truncation.
+- [ ] Add integration coverage that plugin deferred tools carry source metadata.
+- [ ] Run focused memory workflow evals when local Postgres and model
+      credentials are available.
+- [ ] Run local-agent validation for explicit remember and forget flows.
+
+## 6. Documentation
+
+- [ ] Update canonical specs after the implementation contract is accepted.
+- [ ] Link the accepted contract from plugin runtime and agent/tool specs where
+      appropriate.

--- a/packages/junior-evals/evals/memory/workflows.eval.ts
+++ b/packages/junior-evals/evals/memory/workflows.eval.ts
@@ -1,5 +1,5 @@
 import { expect } from "vitest";
-import { assistantMessages, describeEval } from "vitest-evals";
+import { assistantMessages, describeEval, toolCalls } from "vitest-evals";
 import { getDb } from "@/chat/db";
 import { completeText, resolveGatewayModel } from "@/chat/pi/client";
 import { createMemoryStore, type MemoryDb } from "@sentry/junior-memory";
@@ -331,6 +331,17 @@ describeEval("Memory Workflows", slackEvals, (it) => {
         subjectType: "user",
       }),
     ]);
+    expect(toolCalls(result.session)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "searchTools",
+          arguments: expect.objectContaining({ source: "memory" }),
+        }),
+        expect.objectContaining({
+          name: "memory_createMemory",
+        }),
+      ]),
+    );
     await expectActorMemorySemantics({
       assistantText: visibleAssistantText(result),
       expectedMeaning: "The actor prefers terse pull request summaries.",

--- a/packages/junior/src/chat/plugins/agent-hooks.ts
+++ b/packages/junior/src/chat/plugins/agent-hooks.ts
@@ -466,6 +466,10 @@ export function getPluginTools(
         name: localName,
         plugin: pluginName,
       };
+      definition.source = {
+        id: pluginName,
+        description: plugin.manifest.description,
+      };
       definition.exposure = "deferred";
       tools[name] = definition;
     }

--- a/packages/junior/src/chat/slack/tools/canvas/edit.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/edit.ts
@@ -35,6 +35,20 @@ const editReplacementSchema = z.object({
   newText: z.string().describe("Replacement Canvas markdown for this edit."),
 });
 
+const slackCanvasEditOutputSchema = juniorToolResultSchema
+  .extend({
+    canvas_id: z.string().optional(),
+    title: z.string().optional(),
+    permalink: z.string().optional(),
+    diff: z.string().optional(),
+    first_changed_line: z.number().int().positive().optional(),
+    replacements: z.number().int().nonnegative().optional(),
+    normalized_heading_count: z.number().int().nonnegative().optional(),
+    summary: z.string().optional(),
+    deduplicated: z.boolean().optional(),
+  })
+  .strict();
+
 /** Create a tool that edits a Slack canvas like a markdown file. */
 export function createSlackCanvasEditTool(state: ToolState) {
   return zodTool({
@@ -54,7 +68,7 @@ export function createSlackCanvasEditTool(state: ToolState) {
           "Exact replacements matched against the current Canvas body, not incrementally.",
         ),
     }),
-    outputSchema: juniorToolResultSchema,
+    outputSchema: slackCanvasEditOutputSchema,
     execute: async ({ canvas, edits }) => {
       const target = resolveCanvasTarget(canvas);
       if (!target.ok) {

--- a/packages/junior/src/chat/slack/tools/canvas/read.ts
+++ b/packages/junior/src/chat/slack/tools/canvas/read.ts
@@ -7,6 +7,21 @@ import { zodTool } from "@/chat/tool-support/zod-tool";
 import { normalizeToLf } from "@/chat/tools/sandbox/file-utils";
 import { sliceFileContent } from "@/chat/tool-support/text-range-result";
 
+const slackCanvasReadOutputSchema = juniorToolResultSchema
+  .extend({
+    canvas_id: z.string().optional(),
+    title: z.string().optional(),
+    permalink: z.string().optional(),
+    mimetype: z.string().optional(),
+    filetype: z.string().optional(),
+    original_byte_length: z.number().int().nonnegative().optional(),
+    content: z.string().optional(),
+    start_line: z.number().int().positive().optional(),
+    end_line: z.number().int().nonnegative().optional(),
+    total_lines: z.number().int().nonnegative().optional(),
+  })
+  .strict();
+
 /**
  * Create a tool that reads a Slack canvas the bot has access to. Accepts
  * either a canvas/file ID (`F...`) or a Slack canvas/docs URL and returns the
@@ -37,7 +52,7 @@ export function createSlackCanvasReadTool() {
         .describe("Maximum number of lines to read. Defaults to 1000.")
         .optional(),
     }),
-    outputSchema: juniorToolResultSchema,
+    outputSchema: slackCanvasReadOutputSchema,
     execute: async ({ canvas, offset, limit }) => {
       const target = resolveCanvasTarget(canvas);
       if (!target.ok) {

--- a/packages/junior/src/chat/tool-support/zod-tool.ts
+++ b/packages/junior/src/chat/tool-support/zod-tool.ts
@@ -63,6 +63,35 @@ type ZodToolDefinition<
   | StructuredZodToolDefinition<TInputSchema, TOutputSchema>
   | ContentZodToolDefinition<TInputSchema>;
 
+type StructuredZodTool<
+  TInputSchema extends ZodTypeAny,
+  TOutputSchema extends ZodType<JuniorToolResult>,
+> = Omit<
+  AnyToolDefinition,
+  "inputSchema" | "outputSchema" | "prepareArguments" | "execute"
+> & {
+  inputSchema: JsonSchemaObject;
+  outputSchema: JsonSchemaObject;
+  prepareArguments(args: unknown): z.output<TInputSchema>;
+  execute?: (
+    input: unknown,
+    options: ToolExecuteOptions,
+  ) => Promise<z.output<TOutputSchema>> | z.output<TOutputSchema>;
+};
+
+type ContentZodTool<TInputSchema extends ZodTypeAny> = Omit<
+  AnyToolDefinition,
+  "inputSchema" | "outputSchema" | "prepareArguments" | "execute"
+> & {
+  inputSchema: JsonSchemaObject;
+  outputSchema?: undefined;
+  prepareArguments(args: unknown): z.output<TInputSchema>;
+  execute?: (
+    input: unknown,
+    options: ToolExecuteOptions,
+  ) => Promise<ContentOnlyToolResult> | ContentOnlyToolResult;
+};
+
 function isContentOnlyToolResult(
   value: unknown,
 ): value is ContentOnlyToolResult {
@@ -107,10 +136,10 @@ export function zodTool<
   TOutputSchema extends ZodType<JuniorToolResult>,
 >(
   definition: StructuredZodToolDefinition<TInputSchema, TOutputSchema>,
-): AnyToolDefinition;
+): StructuredZodTool<TInputSchema, TOutputSchema>;
 export function zodTool<TInputSchema extends ZodTypeAny>(
   definition: ContentZodToolDefinition<TInputSchema>,
-): AnyToolDefinition;
+): ContentZodTool<TInputSchema>;
 export function zodTool<
   TInputSchema extends ZodTypeAny,
   TOutputSchema extends ZodType<JuniorToolResult>,

--- a/packages/junior/src/chat/tool-support/zod-tool.ts
+++ b/packages/junior/src/chat/tool-support/zod-tool.ts
@@ -29,7 +29,7 @@ type StructuredToolExecuteResult<
   TOutputSchema extends ZodType<JuniorToolResult>,
 > = z.input<TOutputSchema>;
 
-interface ContentOnlyToolResult {
+export interface ContentOnlyToolResult {
   content: Array<TextContent | ImageContent>;
   details?: never;
 }

--- a/packages/junior/src/chat/tools/definition.ts
+++ b/packages/junior/src/chat/tools/definition.ts
@@ -27,6 +27,11 @@ interface BaseToolDefinition<TInput, TInputSchema extends ToolInputSchema> {
     name: string;
     plugin: string;
   };
+  /** Stable model-facing catalog grouping for deferred tool discovery. */
+  source?: {
+    description: string;
+    id: string;
+  };
   description: string;
   exposure?: ToolExposure;
   inputSchema: TInputSchema;
@@ -65,6 +70,11 @@ export interface AnyToolDefinition {
     id: string;
     name: string;
     plugin: string;
+  };
+  /** Stable model-facing catalog grouping for deferred tool discovery. */
+  source?: {
+    description: string;
+    id: string;
   };
   description: string;
   exposure?: ToolExposure;

--- a/packages/junior/src/chat/tools/search-tools.ts
+++ b/packages/junior/src/chat/tools/search-tools.ts
@@ -9,12 +9,65 @@ export const SEARCH_TOOLS_NAME = "searchTools";
 
 const DEFAULT_MAX_RESULTS = 5;
 const MAX_RESULTS = 20;
+const MODEL_VISIBLE_DESCRIPTION_CAP = 180;
+
+const searchToolsSourceSchema = z
+  .object({
+    id: z.string(),
+    description: z.string(),
+  })
+  .strict();
+
+const searchToolsToolSchema = z
+  .object({
+    tool_name: z.string(),
+    description: z.string(),
+    exposure: z.enum(["direct", "deferred", "modelOnly", "hidden"]),
+    source: z.string().optional(),
+    input_schema: z.unknown(),
+    input_schema_summary: z.string(),
+    call_notes: z.array(z.string()),
+    annotations: z.record(z.string(), z.unknown()),
+  })
+  .strict();
+
+const searchToolsOutputSchema = juniorToolResultSchema
+  .extend({
+    query: z.string().nullable(),
+    source: z.string().nullable(),
+    sources: z.array(searchToolsSourceSchema),
+    total_catalog_tools: z.number().int().nonnegative(),
+    total_eligible_tools: z.number().int().nonnegative(),
+    total_matches: z.number().int().nonnegative(),
+    returned_tools: z.number().int().nonnegative(),
+    tools: z.array(searchToolsToolSchema),
+  })
+  .strict();
+
+interface SourceSummary {
+  id: string;
+  description: string;
+}
 
 function normalize(value: string): string {
   return value
     .toLowerCase()
     .replace(/[^a-z0-9_]+/g, " ")
     .trim();
+}
+
+/** Summarize catalog descriptions before rendering them into model-visible data. */
+export function summarizeModelVisibleDescription(description: string): string {
+  const paragraph =
+    description
+      .split(/\n\s*\n/)
+      .map((part) => part.trim())
+      .find(Boolean) ?? "";
+  const normalized = paragraph.replace(/\s+/g, " ").trim();
+  if (normalized.length <= MODEL_VISIBLE_DESCRIPTION_CAP) {
+    return normalized;
+  }
+  return `${normalized.slice(0, MODEL_VISIBLE_DESCRIPTION_CAP - 3).trimEnd()}...`;
 }
 
 function schemaText(schema: unknown): string {
@@ -35,6 +88,8 @@ function searchableToolText(
       definition.identity?.id,
       definition.identity?.name,
       definition.identity?.plugin,
+      definition.source?.id,
+      definition.source?.description,
       definition.description,
       definition.promptSnippet,
       ...(definition.promptGuidelines ?? []),
@@ -49,16 +104,20 @@ function searchableToolText(
 function searchCatalogTools(
   tools: Record<string, AnyToolDefinition>,
   query: string,
+  source: string | null,
 ): string[] {
   const entries = Object.entries(tools).sort(([left], [right]) =>
     left.localeCompare(right),
   );
+  const sourceEntries = source
+    ? entries.filter(([, definition]) => definition.source?.id === source)
+    : entries;
   if (!normalize(query)) {
-    return entries.map(([name]) => name);
+    return sourceEntries.map(([name]) => name);
   }
 
   const terms = normalize(query).split(/\s+/).filter(Boolean);
-  return entries
+  return sourceEntries
     .filter(([name, definition]) => {
       const text = searchableToolText(name, definition);
       return terms.every((term) => text.includes(term));
@@ -77,20 +136,69 @@ function callNotes(definition: AnyToolDefinition): string[] {
   ];
 }
 
+function sourceSummaries(
+  tools: Record<string, AnyToolDefinition>,
+): SourceSummary[] {
+  const sources = new Map<string, SourceSummary>();
+  for (const definition of Object.values(tools)) {
+    if (!definition.source) {
+      continue;
+    }
+    sources.set(definition.source.id, {
+      id: definition.source.id,
+      description: summarizeModelVisibleDescription(
+        definition.source.description,
+      ),
+    });
+  }
+  return [...sources.values()].sort((left, right) =>
+    left.id.localeCompare(right.id),
+  );
+}
+
+function selectedSourceSummaries(
+  tools: Record<string, AnyToolDefinition>,
+  matches: string[],
+  requestedSource: string | null,
+  knownSources: SourceSummary[],
+): SourceSummary[] {
+  if (requestedSource) {
+    return knownSources.filter((source) => source.id === requestedSource);
+  }
+  const matchedSourceIds = new Set(
+    matches
+      .map((name) => tools[name]?.source?.id)
+      .filter((source): source is string => Boolean(source)),
+  );
+  return knownSources.filter((source) => matchedSourceIds.has(source.id));
+}
+
+function renderSearchToolsDescription(knownSources: SourceSummary[]): string {
+  const intro =
+    "Search the executable tool catalog. Deferred tools are grouped by source; use searchTools with source to inspect one source, then executeTool with the exact returned tool_name.";
+  if (knownSources.length === 0) {
+    return intro;
+  }
+  return [
+    intro,
+    "Available sources:",
+    ...knownSources.map((source) => `- ${source.id}: ${source.description}`),
+  ].join("\n");
+}
+
 /** Build the agent-visible catalog tool summary returned by searchTools. */
-function toolMetadata(name: string, definition: AnyToolDefinition) {
+function toolMetadata(
+  name: string,
+  definition: AnyToolDefinition,
+  includeSource: boolean,
+) {
   return {
     tool_name: name,
-    description: definition.description,
+    description: summarizeModelVisibleDescription(definition.description),
     exposure: effectiveToolExposure(definition),
-    source: definition.identity
-      ? {
-          type: "plugin" as const,
-          id: definition.identity.id,
-          name: definition.identity.name,
-          plugin: definition.identity.plugin,
-        }
-      : { type: "core" as const },
+    ...(includeSource && definition.source
+      ? { source: definition.source.id }
+      : {}),
     input_schema: definition.inputSchema,
     input_schema_summary: summarizeInputSchema(
       definition.inputSchema as Record<string, unknown>,
@@ -104,9 +212,9 @@ function toolMetadata(name: string, definition: AnyToolDefinition) {
 export function createSearchToolsTool(
   catalogTools: Record<string, AnyToolDefinition>,
 ) {
+  const knownSources = sourceSummaries(catalogTools);
   return zodTool({
-    description:
-      "Search the executable tool catalog. Use this to discover exact tool names, owners, schemas, and call notes before calling executeTool.",
+    description: renderSearchToolsDescription(knownSources),
     annotations: { readOnlyHint: true, destructiveHint: false },
     inputSchema: z
       .object({
@@ -115,6 +223,13 @@ export function createSearchToolsTool(
           .nullable()
           .describe(
             "Optional search terms describing the tool, owner, action, or arguments needed. Empty string lists catalog tools.",
+          )
+          .optional(),
+        source: z
+          .string()
+          .nullable()
+          .describe(
+            "Optional source id to search within, such as a plugin source returned in sources.",
           )
           .optional(),
         max_results: z
@@ -127,18 +242,47 @@ export function createSearchToolsTool(
           .optional(),
       })
       .strict(),
-    outputSchema: juniorToolResultSchema,
-    execute: async ({ query, max_results }) => {
+    outputSchema: searchToolsOutputSchema,
+    execute: async ({ query, source, max_results }) => {
       const maxResults = max_results ?? DEFAULT_MAX_RESULTS;
-      const matches = searchCatalogTools(catalogTools, query ?? "").slice(
-        0,
-        maxResults,
+      const requestedSource = source ?? null;
+      const sourceExists =
+        requestedSource === null ||
+        knownSources.some((candidate) => candidate.id === requestedSource);
+      const allMatches = sourceExists
+        ? searchCatalogTools(catalogTools, query ?? "", requestedSource)
+        : [];
+      const matches = allMatches.slice(0, maxResults);
+      const sources = !sourceExists
+        ? knownSources
+        : (query ?? "").trim()
+          ? selectedSourceSummaries(
+              catalogTools,
+              matches,
+              requestedSource,
+              knownSources,
+            )
+          : requestedSource
+            ? knownSources.filter(
+                (candidate) => candidate.id === requestedSource,
+              )
+            : knownSources;
+      const totalEligibleTools = sourceExists
+        ? searchCatalogTools(catalogTools, "", requestedSource).length
+        : 0;
+      const includePerToolSource = requestedSource === null;
+      const renderedTools = matches.map((name) =>
+        toolMetadata(name, catalogTools[name]!, includePerToolSource),
       );
       const data = {
         query: query ?? null,
+        source: requestedSource,
+        sources,
         total_catalog_tools: Object.keys(catalogTools).length,
-        returned_tools: matches.length,
-        tools: matches.map((name) => toolMetadata(name, catalogTools[name]!)),
+        total_eligible_tools: totalEligibleTools,
+        total_matches: allMatches.length,
+        returned_tools: renderedTools.length,
+        tools: renderedTools,
       };
       return {
         ok: true,

--- a/packages/junior/src/chat/tools/skill/search-mcp-tools.ts
+++ b/packages/junior/src/chat/tools/skill/search-mcp-tools.ts
@@ -7,6 +7,46 @@ import { zodTool } from "@/chat/tool-support/zod-tool";
 const DEFAULT_MAX_RESULTS = 5;
 const MAX_RESULTS = 20;
 
+const providerSummarySchema = z
+  .object({
+    provider: z.string(),
+    description: z.string(),
+    active: z.boolean(),
+  })
+  .strict();
+
+const exposedToolSummarySchema = z
+  .object({
+    tool_name: z.string(),
+    mcp_tool_name: z.string(),
+    provider: z.string(),
+    title: z.string().optional(),
+    description: z.string(),
+    signature: z.string(),
+    call: z
+      .object({
+        tool_name: z.string(),
+        arguments: z.record(z.string(), z.string()),
+      })
+      .strict(),
+    input_schema: z.record(z.string(), z.unknown()),
+    input_schema_summary: z.string(),
+    output_schema: z.record(z.string(), z.unknown()).optional(),
+    annotations: z.record(z.string(), z.unknown()).optional(),
+  })
+  .strict();
+
+const searchMcpToolsOutputSchema = juniorToolResultSchema
+  .extend({
+    query: z.string().nullable(),
+    provider: z.string().nullable(),
+    total_active_tools: z.number().int().nonnegative(),
+    returned_tools: z.number().int().nonnegative(),
+    available_providers: z.array(providerSummarySchema),
+    tools: z.array(exposedToolSummarySchema),
+  })
+  .strict();
+
 interface RankedTool {
   tool: ManagedMcpToolDescriptor;
   score: number;
@@ -214,7 +254,7 @@ export function createSearchMcpToolsTool(mcpToolManager: SearchMcpToolManager) {
           .optional(),
       })
       .strict(),
-    outputSchema: juniorToolResultSchema,
+    outputSchema: searchMcpToolsOutputSchema,
     execute: async ({ query, provider, max_results }) => {
       if (provider) {
         await mcpToolManager.activateProvider(provider);

--- a/packages/junior/src/chat/tools/web/image-generate.ts
+++ b/packages/junior/src/chat/tools/web/image-generate.ts
@@ -13,6 +13,27 @@ import { logInfo, logWarn } from "@/chat/logging";
 
 const DEFAULT_IMAGE_MODEL = "google/gemini-3-pro-image";
 
+const imageGenerateOutputSchema = juniorToolResultSchema
+  .extend({
+    model: z.string(),
+    prompt: z.string(),
+    enrichedPrompt: z.string(),
+    image_count: z.number().int().nonnegative(),
+    images: z.array(
+      z
+        .object({
+          filename: z.string(),
+          path: z.string(),
+          attachment_path: z.string(),
+          media_type: z.string().optional(),
+          bytes: z.number().int().nonnegative(),
+        })
+        .strict(),
+    ),
+    delivery: z.string(),
+  })
+  .strict();
+
 const ENRICHMENT_SYSTEM_PROMPT = `You are an image prompt enrichment agent. Your job is to rewrite image generation requests to reflect a specific visual identity and mood.
 
 <personality>
@@ -90,7 +111,7 @@ export function createImageGenerateTool(
     inputSchema: z.object({
       prompt: z.string().min(1).max(4000).describe("Image generation prompt."),
     }),
-    outputSchema: juniorToolResultSchema,
+    outputSchema: imageGenerateOutputSchema,
     execute: async ({ prompt }) => {
       const fetchImpl = deps.fetch ?? fetch;
       // Raw fetch does not resolve AI Gateway env auth on its own, so this

--- a/packages/junior/tests/integration/tool-support/pi-tool-adapter.test.ts
+++ b/packages/junior/tests/integration/tool-support/pi-tool-adapter.test.ts
@@ -111,6 +111,10 @@ describe("Pi tool adapter integration", () => {
       );
 
       expect(registry.agentDemo_lookupCustomer?.exposure).toBe("deferred");
+      expect(registry.agentDemo_lookupCustomer?.source).toEqual({
+        id: "agent-demo",
+        description: "Agent demo",
+      });
       expect(tools.map((candidate) => candidate.name)).toEqual(
         expect.arrayContaining(["searchTools", "executeTool"]),
       );
@@ -129,10 +133,7 @@ describe("Pi tool adapter integration", () => {
         tools: [
           {
             tool_name: "agentDemo_lookupCustomer",
-            source: {
-              type: "plugin",
-              plugin: "agent-demo",
-            },
+            source: "agent-demo",
             input_schema_summary: "customerId (required)",
           },
         ],

--- a/packages/junior/tests/unit/plugins/agent-hooks.test.ts
+++ b/packages/junior/tests/unit/plugins/agent-hooks.test.ts
@@ -445,6 +445,10 @@ describe("agent plugin hooks", () => {
         name: "demoTool",
         plugin: "agent-demo",
       });
+      expect(tools.agentDemo_demoTool?.source).toEqual({
+        id: "agent-demo",
+        description: "Agent demo",
+      });
     } finally {
       setPlugins(previous);
     }
@@ -482,6 +486,10 @@ describe("agent plugin hooks", () => {
         id: "agent-demo.prototypeTool",
         name: "prototypeTool",
         plugin: "agent-demo",
+      });
+      expect(tools.agentDemo_prototypeTool?.source).toEqual({
+        id: "agent-demo",
+        description: "Agent demo",
       });
       const prototypeResult = tools.agentDemo_prototypeTool?.execute?.(
         {},

--- a/packages/junior/tests/unit/tools/search-tools.test.ts
+++ b/packages/junior/tests/unit/tools/search-tools.test.ts
@@ -1,47 +1,90 @@
 import { Type } from "@sinclair/typebox";
 import { describe, expect, it } from "vitest";
-import { createSearchToolsTool } from "@/chat/tools/search-tools";
+import {
+  createSearchToolsTool,
+  summarizeModelVisibleDescription,
+} from "@/chat/tools/search-tools";
 import { tool } from "@/chat/tools/definition";
+
+function catalog() {
+  return {
+    bash: tool({
+      description: "Run a shell command.",
+      inputSchema: Type.Object(
+        {
+          command: Type.String({
+            minLength: 1,
+            description: "Command to execute.",
+          }),
+        },
+        { additionalProperties: false },
+      ),
+    }),
+    agentDemo_lookupCustomer: tool({
+      description:
+        "Lookup customer health for account review.\n\nSecond paragraph with extra implementation detail.",
+      promptSnippet:
+        "Use for renewal risk triage before drafting an account plan.",
+      promptGuidelines: [
+        "Pass the customer identifier exactly as provided by the user.",
+      ],
+      identity: {
+        id: "agent-demo.lookupCustomer",
+        name: "lookupCustomer",
+        plugin: "agent-demo",
+      },
+      source: {
+        id: "agent-demo",
+        description:
+          "Agent demo tools for customer health and account planning.\n\nInternal registration details should not be rendered.",
+      },
+      exposure: "deferred",
+      inputSchema: Type.Object(
+        {
+          customerId: Type.String({
+            minLength: 1,
+            description: "Customer identifier to inspect.",
+          }),
+        },
+        { additionalProperties: false },
+      ),
+    }),
+    memory_createMemory: tool({
+      description: "Create long-term memory records for explicit requests.",
+      identity: {
+        id: "memory.createMemory",
+        name: "createMemory",
+        plugin: "memory",
+      },
+      source: {
+        id: "memory",
+        description: "Long-term Junior memory storage and recall",
+      },
+      exposure: "deferred",
+      inputSchema: Type.Object(
+        {
+          candidate: Type.String({
+            minLength: 1,
+            description: "Memory candidate to store.",
+          }),
+        },
+        { additionalProperties: false },
+      ),
+    }),
+  };
+}
 
 describe("searchTools", () => {
   it("discovers catalog tools from metadata and returns call details", async () => {
-    const searchTools = createSearchToolsTool({
-      bash: tool({
-        description: "Run a shell command.",
-        inputSchema: Type.Object(
-          {
-            command: Type.String({
-              minLength: 1,
-              description: "Command to execute.",
-            }),
-          },
-          { additionalProperties: false },
-        ),
-      }),
-      agentDemo_lookupCustomer: tool({
-        description: "Lookup customer health for account review.",
-        promptSnippet:
-          "Use for renewal risk triage before drafting an account plan.",
-        promptGuidelines: [
-          "Pass the customer identifier exactly as provided by the user.",
-        ],
-        identity: {
-          id: "agent-demo.lookupCustomer",
-          name: "lookupCustomer",
-          plugin: "agent-demo",
-        },
-        exposure: "deferred",
-        inputSchema: Type.Object(
-          {
-            customerId: Type.String({
-              minLength: 1,
-              description: "Customer identifier to inspect.",
-            }),
-          },
-          { additionalProperties: false },
-        ),
-      }),
-    });
+    const searchTools = createSearchToolsTool(catalog());
+
+    expect(searchTools.description).toContain(
+      "Deferred tools are grouped by source",
+    );
+    expect(searchTools.description).toContain(
+      "- memory: Long-term Junior memory storage and recall",
+    );
+    expect(searchTools.description).not.toContain("memory_createMemory");
 
     const result = await searchTools.execute!(
       { query: "renewal risk", max_results: 1 },
@@ -50,19 +93,23 @@ describe("searchTools", () => {
 
     expect(result).toMatchObject({
       query: "renewal risk",
-      total_catalog_tools: 2,
+      source: null,
+      sources: [
+        {
+          id: "agent-demo",
+          description:
+            "Agent demo tools for customer health and account planning.",
+        },
+      ],
+      total_catalog_tools: 3,
+      total_matches: 1,
       returned_tools: 1,
       tools: [
         {
           tool_name: "agentDemo_lookupCustomer",
           description: "Lookup customer health for account review.",
           exposure: "deferred",
-          source: {
-            type: "plugin",
-            id: "agent-demo.lookupCustomer",
-            name: "lookupCustomer",
-            plugin: "agent-demo",
-          },
+          source: "agent-demo",
           input_schema_summary: "customerId (required)",
           call_notes: [
             "Use for renewal risk triage before drafting an account plan.",
@@ -75,14 +122,164 @@ describe("searchTools", () => {
     const directResult = await searchTools.execute!({ query: "shell" }, {});
     expect(directResult).toMatchObject({
       returned_tools: 1,
+      sources: [],
       tools: [
         {
           tool_name: "bash",
           exposure: "direct",
-          source: { type: "core" },
           input_schema_summary: "command (required)",
         },
       ],
     });
+    expect(directResult.tools[0]).not.toHaveProperty("source");
+  });
+
+  it("filters by source and omits per-tool source in filtered results", async () => {
+    const searchTools = createSearchToolsTool(catalog());
+
+    const result = await searchTools.execute!(
+      { source: "memory", query: "long-term" },
+      {},
+    );
+
+    expect(result).toMatchObject({
+      source: "memory",
+      sources: [
+        {
+          id: "memory",
+          description: "Long-term Junior memory storage and recall",
+        },
+      ],
+      total_eligible_tools: 1,
+      total_matches: 1,
+      returned_tools: 1,
+      tools: [
+        {
+          tool_name: "memory_createMemory",
+          description: "Create long-term memory records for explicit requests.",
+        },
+      ],
+    });
+    expect(result.tools[0]).not.toHaveProperty("source");
+
+    const noMatchResult = await searchTools.execute!(
+      { source: "memory", query: "customer" },
+      {},
+    );
+
+    expect(noMatchResult).toMatchObject({
+      source: "memory",
+      sources: [
+        {
+          id: "memory",
+          description: "Long-term Junior memory storage and recall",
+        },
+      ],
+      total_eligible_tools: 1,
+      total_matches: 0,
+      returned_tools: 0,
+      tools: [],
+    });
+  });
+
+  it("returns known sources without throwing for an unknown source", async () => {
+    const searchTools = createSearchToolsTool(catalog());
+
+    const result = await searchTools.execute!(
+      { source: "missing", query: "memory" },
+      {},
+    );
+
+    expect(result).toMatchObject({
+      source: "missing",
+      sources: [{ id: "agent-demo" }, { id: "memory" }],
+      total_eligible_tools: 0,
+      total_matches: 0,
+      returned_tools: 0,
+      tools: [],
+    });
+  });
+
+  it("bounds empty all-source search while listing known sources", async () => {
+    const searchTools = createSearchToolsTool(catalog());
+
+    const result = await searchTools.execute!(
+      { query: "", max_results: 1 },
+      {},
+    );
+
+    expect(result).toMatchObject({
+      query: "",
+      source: null,
+      sources: [
+        {
+          id: "agent-demo",
+          description:
+            "Agent demo tools for customer health and account planning.",
+        },
+        {
+          id: "memory",
+          description: "Long-term Junior memory storage and recall",
+        },
+      ],
+      total_eligible_tools: 3,
+      total_matches: 3,
+      returned_tools: 1,
+    });
+    expect(result.tools).toHaveLength(1);
+  });
+
+  it("returns compact source ids for mixed-source results", async () => {
+    const searchTools = createSearchToolsTool(catalog());
+
+    const result = await searchTools.execute!(
+      { query: "", max_results: 3 },
+      {},
+    );
+
+    expect(result).toMatchObject({
+      source: null,
+      sources: [
+        {
+          id: "agent-demo",
+          description:
+            "Agent demo tools for customer health and account planning.",
+        },
+        {
+          id: "memory",
+          description: "Long-term Junior memory storage and recall",
+        },
+      ],
+      returned_tools: 3,
+      tools: [
+        {
+          tool_name: "agentDemo_lookupCustomer",
+          source: "agent-demo",
+        },
+        {
+          tool_name: "bash",
+        },
+        {
+          tool_name: "memory_createMemory",
+          source: "memory",
+        },
+      ],
+    });
+    expect(result.tools[0]?.source).toBe("agent-demo");
+    expect(result.tools[2]?.source).toBe("memory");
+    expect(result.tools[1]).not.toHaveProperty("source");
+  });
+
+  it("summarizes model-visible descriptions", () => {
+    expect(
+      summarizeModelVisibleDescription(
+        `  First paragraph with\nextra spacing.  \n\nSecond paragraph.`,
+      ),
+    ).toBe("First paragraph with extra spacing.");
+
+    expect(summarizeModelVisibleDescription("x".repeat(220))).toHaveLength(180);
+    expect(summarizeModelVisibleDescription("x".repeat(220))).toMatch(
+      /\.\.\.$/,
+    );
   });
 });


### PR DESCRIPTION
Deferred catalog tools are now discoverable by source instead of requiring the model to know exact plugin tool names up front. Plugin tools carry compact source metadata, searchTools advertises available sources, accepts a nullable source filter, and returns source summaries once at the top level while keeping executeTool as the deferred execution bridge.

The tool helper now preserves concrete structured output types from Zod schemas, and the changed discovery/tool wrappers declare strict output schemas so runtime parsing and TypeScript stay aligned. The memory eval now pairs its existing behavioral rubric with a deterministic tool-call assertion that Junior discovers memory tools through searchTools before using the memory tool.