### PR TITLE
fix(slack): Trust no-reply marker completions

### DIFF
--- a/packages/junior-evals/evals/core/slack-message-delivery.eval.ts
+++ b/packages/junior-evals/evals/core/slack-message-delivery.eval.ts
@@ -24,6 +24,29 @@ function visibleText(session: EvalSession): string {
 }
 
 describeEval("Slack Message Delivery", slackEvals, (it) => {
+  it("when asked for no visible reply, complete silently", async ({ run }) => {
+    const result = await run({
+      events: [
+        mention(
+          "please record that this has been seen, but do not post a visible reply",
+        ),
+      ],
+      criteria: rubric({
+        pass: [
+          "The assistant posts no visible thread reply.",
+          `The no-reply marker ${NO_REPLY_MARKER} is only an internal publication signal.`,
+        ],
+        fail: [
+          "Do not post an acknowledgement such as 'Done', 'Seen', or 'Got it'.",
+          `Do not leak the literal marker ${NO_REPLY_MARKER} as visible text.`,
+        ],
+      }),
+    });
+
+    expect(visibleThreadReplies(result.session)).toEqual([]);
+    expect(visibleText(result.session)).not.toContain(NO_REPLY_MARKER);
+  });
+
   it("when asked for a top-level channel post, explain the limitation instead", async ({
     run,
   }) => {

--- a/packages/junior/src/chat/no-reply.ts
+++ b/packages/junior/src/chat/no-reply.ts
@@ -1,6 +1,6 @@
 export const NO_REPLY_MARKER = "[[NO_REPLY]]";
 
-/** Detect the reserved marker so Slack side effects can intentionally complete without thread text. */
+/** Detect the reserved marker for intentionally completing without thread text. */
 export function isNoReplyMarker(text: string): boolean {
   return text.trim() === NO_REPLY_MARKER;
 }

--- a/packages/junior/src/chat/prompt.ts
+++ b/packages/junior/src/chat/prompt.ts
@@ -394,7 +394,7 @@ const SLACK_ACTION_RULES = [
   "- sendMessage has no target argument; it always sends into the active Slack conversation/thread. For top-level channel posts, other channels, or named recipients, explain that this runtime can only send into the active conversation.",
   "- sendMessage is not final-reply delivery. After using sendMessage, provide a brief normal final answer unless the user requested no further text.",
   "- Ambient reaction requests target the current inbound message; do not ask for a message reference.",
-  `- Side-effect-only completion for addReaction: call the requested tool first; if it succeeds and fully satisfies the request, final message must be exactly ${NO_REPLY_MARKER}.`,
+  `- When no visible final thread reply is useful, make the final message exactly ${NO_REPLY_MARKER}.`,
 ];
 
 const SAFETY_RULES = [
@@ -451,7 +451,7 @@ function buildOutputSection(platform: PromptPlatform): string {
     "- Use Slack-flavored Markdown: **bold** section labels, `code`, [text](url) links, bullet lists, and fenced code blocks. No hash-prefixed headings and no tables. When the answer primarily lists several URLs, show each URL bare instead of as a labeled link.",
     "- Keep replies brief and scannable; use bullets or short code blocks when helpful, and one compact thread reply when it fits.",
     "- When a research or document-style answer would benefit from continuation, multiple sections, or future reference value, create a Slack canvas and keep the thread reply to one or two short sentences plus the link; do not recap the canvas contents.",
-    "- End every turn with a final user-facing markdown response unless the Slack action rules allow a side-effect-only completion.",
+    "- End every turn with a final user-facing markdown response unless the Slack action rules allow a no-reply completion.",
     "</output>",
   ].join("\n");
 }

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -1440,7 +1440,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             (thread.adapter as { name?: string } | undefined)?.name === "slack";
 
           // Text replies must be accepted by Slack before completion;
-          // side-effect-only turns may already be visibly complete.
+          // no-reply turns intentionally complete without thread text.
           if (plannedPosts.length > 0) {
             const hasVisibleDelivery = plannedPosts.some(
               hasVisibleSlackDelivery,
@@ -1497,9 +1497,8 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             finalReplyDelivered = true;
             shouldPersistFailureState = false;
           } else {
-            // Side-effect-only turns (for example reactions or channel posts)
-            // have no thread reply to deliver; the successful tool result is
-            // the visible Slack acceptance boundary.
+            // No-reply turns have no thread reply to deliver; the assistant's
+            // reserved marker is the completion boundary.
             finalReplyDelivered = true;
             shouldPersistFailureState = false;
           }

--- a/packages/junior/src/chat/services/turn-result.ts
+++ b/packages/junior/src/chat/services/turn-result.ts
@@ -243,9 +243,7 @@ export function buildTurnResult(input: TurnResultInput): AgentRunResult {
   );
   const canvasCreated = successfulToolNames.has("slackCanvasCreate");
   const reactionPerformed = successfulToolNames.has("addReaction");
-  const markerSideEffectSuccess =
-    exactNoReplyMarker && toolErrorCount === 0 && reactionPerformed;
-  const sideEffectOnlySuccess = markerSideEffectSuccess;
+  const silentCompletionSuccess = exactNoReplyMarker;
   const baseDeliveryPlan: ReplyDeliveryPlan = {
     mode: "thread",
     postThreadText: true,
@@ -276,23 +274,15 @@ export function buildTurnResult(input: TurnResultInput): AgentRunResult {
     const markerAttributes = {
       "app.ai.no_reply_marker": true,
       "app.ai.no_reply_marker_category": markerCategory,
-      "app.ai.no_reply_marker_accepted":
-        sideEffectOnlySuccess && !isProviderError,
+      "app.ai.no_reply_marker_accepted": !isProviderError,
     };
 
-    if (sideEffectOnlySuccess && !isProviderError) {
+    if (!isProviderError) {
       logInfo(
         "ai_no_reply_marker_accepted",
         markerContext,
         markerAttributes,
         "No-reply marker suppressed visible thread text",
-      );
-    } else if (!isProviderError) {
-      logWarn(
-        "ai_no_reply_marker_rejected",
-        markerContext,
-        markerAttributes,
-        "No-reply marker requires a successful visible side effect",
       );
     }
   } else if (mixedNoReplyMarker) {
@@ -314,12 +304,7 @@ export function buildTurnResult(input: TurnResultInput): AgentRunResult {
     );
   }
 
-  if (
-    !primaryText &&
-    !sideEffectOnlySuccess &&
-    !isProviderError &&
-    !exactNoReplyMarker
-  ) {
+  if (!primaryText && !silentCompletionSuccess && !isProviderError) {
     logWarn(
       "ai_model_response_empty",
       {
@@ -343,7 +328,7 @@ export function buildTurnResult(input: TurnResultInput): AgentRunResult {
   let outcome: AgentTurnDiagnostics["outcome"];
   if (isProviderError) {
     outcome = "provider_error";
-  } else if (primaryText || sideEffectOnlySuccess) {
+  } else if (primaryText || silentCompletionSuccess) {
     outcome = "success";
   } else {
     outcome = "execution_failure";
@@ -362,7 +347,7 @@ export function buildTurnResult(input: TurnResultInput): AgentRunResult {
     ? "execution_failure"
     : outcome;
   const deliveryPlan =
-    resolvedOutcome === "success" && !resolvedText && reactionPerformed
+    resolvedOutcome === "success" && !resolvedText
       ? {
           ...baseDeliveryPlan,
           postThreadText: false,

--- a/packages/junior/tests/unit/prompt.test.ts
+++ b/packages/junior/tests/unit/prompt.test.ts
@@ -3,6 +3,7 @@ import {
   createLocalSource,
   createSlackSource,
 } from "@sentry/junior-plugin-api";
+import { NO_REPLY_MARKER } from "@/chat/no-reply";
 import { buildSystemPrompt, buildTurnContextPrompt } from "@/chat/prompt";
 
 describe("prompt builders", () => {
@@ -16,6 +17,24 @@ describe("prompt builders", () => {
     const systemPrompt = buildSystemPrompt({ source });
 
     expect(buildSystemPrompt({ source })).toBe(systemPrompt);
+  });
+
+  it("tells Slack agents to use the no-reply marker for silent completion", () => {
+    const systemPrompt = buildSystemPrompt({
+      source: createSlackSource({
+        teamId: "T123",
+        channelId: "C123",
+        type: "priv",
+      }),
+    });
+
+    expect(systemPrompt).toContain(
+      `When no visible final thread reply is useful, make the final message exactly ${NO_REPLY_MARKER}.`,
+    );
+    expect(systemPrompt).not.toContain(
+      "Side-effect-only completion for addReaction",
+    );
+    expect(systemPrompt).not.toContain("side-effect-only completion");
   });
 
   it("returns a byte-stable local system prompt variant", () => {

--- a/packages/junior/tests/unit/turn-result.test.ts
+++ b/packages/junior/tests/unit/turn-result.test.ts
@@ -298,30 +298,19 @@ describe("buildTurnResult", () => {
     expect(reply.diagnostics.usedPrimaryText).toBe(true);
   });
 
-  it("does not treat sendMessage as final reply completion", () => {
+  it("treats the no-reply marker as intentional silent completion", () => {
     const reply = buildTurnResult({
       newMessages: [
-        {
-          role: "toolResult",
-          toolName: "sendMessage",
-          isError: false,
-          content: [{ type: "text", text: "posted in thread" }],
-          details: {
-            ok: true,
-            channel_id: "C123",
-            thread_ts: "1700000000.321",
-          },
-        },
         {
           role: "assistant",
           content: [{ type: "text", text: NO_REPLY_MARKER }],
           stopReason: "stop",
         },
       ],
-      userInput: "attach it here",
+      userInput: "Do whatever makes sense here",
       artifactStatePatch: {},
-      toolCalls: ["sendMessage"],
-      generatedFileCount: 1,
+      toolCalls: [],
+      generatedFileCount: 0,
       shouldTrace: false,
       spanContext: {},
       thinkingSelection,
@@ -330,10 +319,41 @@ describe("buildTurnResult", () => {
     expect(reply.text).toBe("");
     expect(reply.deliveryMode).toBe("thread");
     expect(reply.deliveryPlan).toMatchObject({
-      postThreadText: true,
+      postThreadText: false,
     });
-    expect(reply.diagnostics.outcome).toBe("execution_failure");
+    expect(reply.diagnostics.outcome).toBe("success");
     expect(reply.diagnostics.usedPrimaryText).toBe(true);
+  });
+
+  it("keeps no-reply marker silent when side-effect tools also ran", () => {
+    const reply = buildTurnResult({
+      newMessages: [
+        {
+          role: "toolResult",
+          toolName: "sendMessage",
+          isError: false,
+          content: [{ type: "text", text: "posted in thread" }],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: NO_REPLY_MARKER }],
+          stopReason: "stop",
+        },
+      ],
+      userInput: "share this here without extra commentary",
+      artifactStatePatch: {},
+      toolCalls: ["sendMessage"],
+      generatedFileCount: 0,
+      shouldTrace: false,
+      spanContext: {},
+      thinkingSelection,
+    });
+
+    expect(reply.text).toBe("");
+    expect(reply.deliveryPlan).toMatchObject({
+      postThreadText: false,
+    });
+    expect(reply.diagnostics.outcome).toBe("success");
   });
 
   it("does not correct attachment claims after sendMessage sends files", () => {

--- a/specs/agent-turn-handling.md
+++ b/specs/agent-turn-handling.md
@@ -130,7 +130,7 @@ Scenarios:
 3. User asks Junior to react:
    - When the user explicitly asks Junior to add a Slack reaction, Junior must use `addReaction` when the runtime provides a valid target and must not treat automatic processing reactions as satisfying the user's request.
 4. Slack side effect satisfies the turn:
-   - When a successful Slack side-effect tool already satisfies the user's request, Junior may suppress a duplicate final thread reply according to the reply-delivery plan when the assistant used the no-reply marker.
+   - Junior may suppress a duplicate final thread reply according to the reply-delivery plan when the assistant used the no-reply marker.
    - `sendMessage` does not by itself satisfy the final assistant reply contract.
 
 ### 8. Progress And Resumed-Turn Behavior
@@ -167,8 +167,9 @@ Scenarios:
    - When Junior completes model/tool execution and final Slack delivery accepts the visible reply, Junior must mark the turn as completed and persist the assistant message as visible conversation state.
 2. Tool or provider failure:
    - When a tool, provider, or runtime failure prevents the requested work from completing, Junior must either recover within the turn, pause through the appropriate runtime mechanism, or provide an explicit user-visible failure response.
-3. Final answer cannot be empty:
-   - When a turn does not produce a successful side effect, pause notice, or non-empty assistant answer, Junior must deliver an explicit fallback response rather than silently completing the turn.
+3. Silent completion:
+   - When the assistant intentionally emits the no-reply marker as its final answer, Junior must complete the turn without posting visible thread text.
+   - When a turn produces no assistant answer and no no-reply marker, Junior must deliver an explicit fallback response rather than silently completing the turn.
 
 ## Failure Model
 
@@ -176,7 +177,7 @@ Scenarios:
 2. Active request failures must produce a visible answer, runtime-owned pause notice, or fallback failure response.
 3. Junior-authored messages must not start recursive turns.
 4. Slack side effects must not be reported as successful unless the tool succeeded in the same turn.
-5. Empty model output is not a successful final answer unless a successful side effect or runtime-owned pause already satisfied the turn.
+5. Exact no-reply marker output is an intentional silent completion. Empty model output without the marker is not a successful final answer.
 6. User-visible failure text is the sanitized fallback response with its correlation/event id. Raw exception messages, stack traces, and internal error strings must not be delivered as reply text. Partial output may be delivered only when it is genuine model-authored text.
 7. Repeated failures for the same inbound message are bounded by the dead-letter contract in `./task-execution.md`; one inbound message produces at most one visible failure reply.
 

--- a/specs/slack-agent-delivery.md
+++ b/specs/slack-agent-delivery.md
@@ -152,8 +152,8 @@ Current rules:
 
 1. Do not create a visible Slack text artifact until the assistant reply is final enough to budget, normalize, and persist.
 2. Deliver visible reply text through finalized thread posts, not through incremental text streaming.
-3. Only mark a text-reply turn successful after the final visible Slack reply has been accepted by Slack. When a successful requested Slack side effect, such as a reaction, fully satisfies the turn and the assistant uses the no-reply marker, that side effect is the visible completion. `sendMessage` is an active-conversation side effect and does not replace final reply delivery.
-4. If the assistant chose a Slack side-effect tool and that successful side effect already satisfied the request, Junior may suppress the thread text reply according to the reply-delivery plan only when the assistant used the no-reply marker or produced no assistant text. Delivery code must rely on tool results and structured markers for this decision, not regex or keyword matching against user or assistant prose.
+3. Only mark a text-reply turn successful after the final visible Slack reply has been accepted by Slack. When the assistant uses the no-reply marker, the turn completes without visible thread text. `sendMessage` is an active-conversation side effect and does not replace final reply delivery unless the assistant also intentionally completes with no reply.
+4. Junior may suppress the thread text reply according to the reply-delivery plan when the assistant used the no-reply marker. Delivery code must rely on the structured marker, not regex or keyword matching against user or assistant prose.
 5. Persisted assistant conversation state must reflect the same finalized reply content the user saw, not provisional pre-tool text.
 6. Reply text must be rendered through the shared Slack output translator before delivery; raw Slack API writers do not own markdown translation rules.
 7. When Junior adds finalized reply footer metadata, it attaches that metadata as a Slack `context` block on the final text chunk only, while keeping the main reply text as the top-level fallback.
@@ -246,7 +246,7 @@ Required split:
 1. Slack status-update failures are best effort and must not by themselves fail the turn.
 2. Slack thread-post or final delivery failures are turn failures because the visible reply contract was not satisfied.
 3. Junior must not persist assistant conversation state for a turn until final Slack delivery succeeds. This includes the durable session-log/Pi transcript: an undelivered assistant reply must not surface to later turns as delivered conversation history.
-4. If a final reply normalizes to empty, Junior must post an explicit fallback message rather than silently succeeding.
+4. If a final reply normalizes to empty without the exact no-reply marker, Junior must post an explicit fallback message rather than silently succeeding.
 5. If a chunked reply overflows a code fence boundary, fence integrity must still be preserved in the delivered Slack posts.
 
 ## Observability


### PR DESCRIPTION
Exact no-reply markers now complete Slack turns silently instead of requiring a successful side-effect tool first. This keeps true empty model output on the fallback path, but lets the assistant intentionally avoid a visible final thread reply when that is the right outcome.

The prompt, Slack/turn specs, runtime comments, unit coverage, and a focused eval now all describe the marker as the completion signal rather than an addReaction-only escape hatch.

Fixes JUNIOR-4B