### PR TITLE
fix(tools): Clarify MCP tool execution arguments

### DIFF
--- a/packages/junior-evals/evals/core/skill-infra.eval.ts
+++ b/packages/junior-evals/evals/core/skill-infra.eval.ts
@@ -1,4 +1,5 @@
-import { describeEval } from "vitest-evals";
+import { expect } from "vitest";
+import { describeEval, toolCalls } from "vitest-evals";
 import { mention, rubric, slackEvals, threadMessage } from "../../src/helpers";
 
 describeEval("Skill Infrastructure", slackEvals, (it) => {
@@ -93,7 +94,7 @@ describeEval("Skill Infrastructure", slackEvals, (it) => {
   it("when an MCP-backed skill handles a lookup, return the provider-backed answer", async ({
     run,
   }) => {
-    await run({
+    const result = await run({
       overrides: {
         plugin_dirs: ["fixtures/plugins"],
       },
@@ -115,5 +116,24 @@ describeEval("Skill Infrastructure", slackEvals, (it) => {
         ],
       }),
     });
+    expect(toolCalls(result.session)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "loadSkill",
+          arguments: expect.objectContaining({
+            skill_name: "eval-mcp",
+          }),
+        }),
+        expect.objectContaining({
+          name: "callMcpTool",
+          arguments: expect.objectContaining({
+            tool_name: "mcp__eval-mcp__handbook-search",
+            arguments: expect.objectContaining({
+              query: expect.stringMatching(/US holidays/i),
+            }),
+          }),
+        }),
+      ]),
+    );
   });
 });

--- a/packages/junior/src/chat/tools/search-tools.ts
+++ b/packages/junior/src/chat/tools/search-tools.ts
@@ -18,12 +18,21 @@ const searchToolsSourceSchema = z
   })
   .strict();
 
+const toolCallExampleSchema = z
+  .object({
+    tool_name: z.string(),
+    arguments: z.record(z.string(), z.string()),
+  })
+  .strict();
+
 const searchToolsToolSchema = z
   .object({
     tool_name: z.string(),
     description: z.string(),
     exposure: z.enum(["direct", "deferred", "modelOnly", "hidden"]),
     source: z.string().optional(),
+    signature: z.string(),
+    call: toolCallExampleSchema,
     input_schema: z.unknown(),
     input_schema_summary: z.string(),
     call_notes: z.array(z.string()),
@@ -40,6 +49,8 @@ const searchToolsOutputSchema = juniorToolResultSchema
     total_eligible_tools: z.number().int().nonnegative(),
     total_matches: z.number().int().nonnegative(),
     returned_tools: z.number().int().nonnegative(),
+    execution_tool: z.literal("executeTool"),
+    execution_example: toolCallExampleSchema,
     tools: z.array(searchToolsToolSchema),
   })
   .strict();
@@ -136,6 +147,99 @@ function callNotes(definition: AnyToolDefinition): string[] {
   ];
 }
 
+function getSchemaProperties(schema: unknown): Record<string, unknown> {
+  if (!schema || typeof schema !== "object" || !("properties" in schema)) {
+    return {};
+  }
+  const properties = (schema as { properties?: unknown }).properties;
+  return properties &&
+    typeof properties === "object" &&
+    !Array.isArray(properties)
+    ? (properties as Record<string, unknown>)
+    : {};
+}
+
+function getRequiredFields(schema: unknown): Set<string> {
+  if (!schema || typeof schema !== "object" || !("required" in schema)) {
+    return new Set<string>();
+  }
+  const required = (schema as { required?: unknown }).required;
+  return Array.isArray(required)
+    ? new Set(
+        required.filter((value): value is string => typeof value === "string"),
+      )
+    : new Set<string>();
+}
+
+function formatSchemaType(schema: unknown): string {
+  if (!schema || typeof schema !== "object") {
+    return "unknown";
+  }
+
+  const typed = schema as Record<string, unknown>;
+  const type = typed.type;
+  if (typeof type === "string") {
+    if (type === "array") {
+      return `${formatSchemaType(typed.items)}[]`;
+    }
+    return type;
+  }
+  if (Array.isArray(type)) {
+    return type.filter((value) => typeof value === "string").join(" | ");
+  }
+  if (Array.isArray(typed.enum) && typed.enum.length > 0) {
+    return typed.enum.map((value) => JSON.stringify(value)).join(" | ");
+  }
+  return "unknown";
+}
+
+function formatArgumentPlaceholder(name: string, schema: unknown): string {
+  const type = formatSchemaType(schema);
+  if (type === "string") {
+    return `<${name}>`;
+  }
+  if (type === "number" || type === "integer") {
+    return "<number>";
+  }
+  if (type === "boolean") {
+    return "<boolean>";
+  }
+  if (type.endsWith("[]")) {
+    return "<array>";
+  }
+  if (type === "object") {
+    return "<object>";
+  }
+  return `<${type}>`;
+}
+
+function formatToolSignature(name: string, schema: unknown): string {
+  const properties = getSchemaProperties(schema);
+  const required = getRequiredFields(schema);
+  const fields = Object.entries(properties).map(([field, propertySchema]) => {
+    const marker = required.has(field) ? "" : "?";
+    return `${field}${marker}: ${formatSchemaType(propertySchema)}`;
+  });
+  return fields.length > 0 ? `${name}({ ${fields.join(", ")} })` : `${name}()`;
+}
+
+function formatToolCallExample(
+  name: string,
+  schema: unknown,
+): z.output<typeof toolCallExampleSchema> {
+  return {
+    tool_name: name,
+    arguments: Object.fromEntries(
+      Object.entries(getSchemaProperties(schema)).map(
+        ([field, propertySchema]) => [
+          field,
+          formatArgumentPlaceholder(field, propertySchema),
+        ],
+      ),
+    ),
+  };
+}
+
 function sourceSummaries(
   tools: Record<string, AnyToolDefinition>,
 ): SourceSummary[] {
@@ -199,6 +303,8 @@ function toolMetadata(
     ...(includeSource && definition.source
       ? { source: definition.source.id }
       : {}),
+    signature: formatToolSignature(name, definition.inputSchema),
+    call: formatToolCallExample(name, definition.inputSchema),
     input_schema: definition.inputSchema,
     input_schema_summary: summarizeInputSchema(
       definition.inputSchema as Record<string, unknown>,
@@ -282,6 +388,13 @@ export function createSearchToolsTool(
         total_eligible_tools: totalEligibleTools,
         total_matches: allMatches.length,
         returned_tools: renderedTools.length,
+        execution_tool: "executeTool" as const,
+        execution_example: {
+          tool_name: "<returned tool_name>",
+          arguments: {
+            "<argument>": "<value from input_schema>",
+          },
+        },
         tools: renderedTools,
       };
       return {

--- a/packages/junior/src/chat/tools/skill/call-mcp-tool.ts
+++ b/packages/junior/src/chat/tools/skill/call-mcp-tool.ts
@@ -64,7 +64,7 @@ export function createCallMcpToolTool(mcpToolManager: CallMcpToolManager) {
           .min(1)
           .describe("Exact MCP tool_name from searchMcpTools."),
         arguments: z
-          .unknown()
+          .record(z.string(), z.unknown())
           .describe(
             'Arguments matching the disclosed MCP tool schema, for example { "query": "..." } when searchMcpTools shows query is required.',
           )

--- a/packages/junior/src/chat/tools/skill/search-mcp-tools.ts
+++ b/packages/junior/src/chat/tools/skill/search-mcp-tools.ts
@@ -15,6 +15,13 @@ const providerSummarySchema = z
   })
   .strict();
 
+const mcpCallExampleSchema = z
+  .object({
+    tool_name: z.string(),
+    arguments: z.record(z.string(), z.string()),
+  })
+  .strict();
+
 const exposedToolSummarySchema = z
   .object({
     tool_name: z.string(),
@@ -23,12 +30,7 @@ const exposedToolSummarySchema = z
     title: z.string().optional(),
     description: z.string(),
     signature: z.string(),
-    call: z
-      .object({
-        tool_name: z.string(),
-        arguments: z.record(z.string(), z.string()),
-      })
-      .strict(),
+    call: mcpCallExampleSchema,
     input_schema: z.record(z.string(), z.unknown()),
     input_schema_summary: z.string(),
     output_schema: z.record(z.string(), z.unknown()).optional(),
@@ -42,6 +44,8 @@ const searchMcpToolsOutputSchema = juniorToolResultSchema
     provider: z.string().nullable(),
     total_active_tools: z.number().int().nonnegative(),
     returned_tools: z.number().int().nonnegative(),
+    execution_tool: z.literal("callMcpTool"),
+    execution_example: mcpCallExampleSchema,
     available_providers: z.array(providerSummarySchema),
     tools: z.array(exposedToolSummarySchema),
   })
@@ -278,6 +282,13 @@ export function createSearchMcpToolsTool(mcpToolManager: SearchMcpToolManager) {
         provider: provider ?? null,
         total_active_tools: catalog.length,
         returned_tools: matches.length,
+        execution_tool: "callMcpTool" as const,
+        execution_example: {
+          tool_name: "<returned tool_name>",
+          arguments: {
+            "<argument>": "<value from input_schema>",
+          },
+        },
         available_providers: providers,
         tools: matches.map(toExposedToolSummary),
       };

--- a/packages/junior/tests/unit/tools/call-mcp-tool.test.ts
+++ b/packages/junior/tests/unit/tools/call-mcp-tool.test.ts
@@ -39,6 +39,22 @@ describe("callMcpTool", () => {
     );
   });
 
+  it("advertises nested MCP arguments as an object", () => {
+    const manager = {
+      activateProvider: vi.fn(async () => true),
+      getResolvedActiveTools: vi.fn(() => []),
+    };
+    const callMcpTool = createCallMcpToolTool(manager);
+
+    expect(callMcpTool.inputSchema).toMatchObject({
+      properties: {
+        arguments: {
+          type: "object",
+        },
+      },
+    });
+  });
+
   it("preserves native MCP content from the managed tool", async () => {
     const nativeContent = [
       { type: "text" as const, text: "image generated" },

--- a/packages/junior/tests/unit/tools/search-mcp-tools.test.ts
+++ b/packages/junior/tests/unit/tools/search-mcp-tools.test.ts
@@ -65,6 +65,11 @@ describe("searchMcpTools", () => {
       { query: "issue title", max_results: 1 },
       {},
     )) as {
+      execution_tool: string;
+      execution_example: {
+        tool_name: string;
+        arguments: Record<string, string>;
+      };
       tools: Array<{
         tool_name: string;
         signature: string;
@@ -79,6 +84,15 @@ describe("searchMcpTools", () => {
       }>;
     };
 
+    expect(result).toMatchObject({
+      execution_tool: "callMcpTool",
+      execution_example: {
+        tool_name: "<returned tool_name>",
+        arguments: {
+          "<argument>": "<value from input_schema>",
+        },
+      },
+    });
     expect(result.tools).toHaveLength(1);
     expect(result.tools[0]).toMatchObject({
       tool_name: "mcp__demo__create_issue",

--- a/packages/junior/tests/unit/tools/search-tools.test.ts
+++ b/packages/junior/tests/unit/tools/search-tools.test.ts
@@ -104,13 +104,35 @@ describe("searchTools", () => {
       total_catalog_tools: 3,
       total_matches: 1,
       returned_tools: 1,
+      execution_tool: "executeTool",
+      execution_example: {
+        tool_name: "<returned tool_name>",
+        arguments: {
+          "<argument>": "<value from input_schema>",
+        },
+      },
       tools: [
         {
           tool_name: "agentDemo_lookupCustomer",
           description: "Lookup customer health for account review.",
           exposure: "deferred",
           source: "agent-demo",
+          signature: "agentDemo_lookupCustomer({ customerId: string })",
+          call: {
+            tool_name: "agentDemo_lookupCustomer",
+            arguments: {
+              customerId: "<customerId>",
+            },
+          },
           input_schema_summary: "customerId (required)",
+          input_schema: {
+            properties: {
+              customerId: {
+                type: "string",
+                description: "Customer identifier to inspect.",
+              },
+            },
+          },
           call_notes: [
             "Use for renewal risk triage before drafting an account plan.",
             "Pass the customer identifier exactly as provided by the user.",
@@ -127,6 +149,13 @@ describe("searchTools", () => {
         {
           tool_name: "bash",
           exposure: "direct",
+          signature: "bash({ command: string })",
+          call: {
+            tool_name: "bash",
+            arguments: {
+              command: "<command>",
+            },
+          },
           input_schema_summary: "command (required)",
         },
       ],


### PR DESCRIPTION
MCP and catalog tool search results now show the dispatcher to use, a concrete call shape, and the input schema for each returned command, so agents can execute discovered tools without guessing the nested argument format.

callMcpTool now advertises MCP arguments as an object, and the MCP-backed skill eval asserts that the agent loads the skill and executes the exposed MCP command with nested arguments.

Fixes #796