### PR TITLE
fix(auth): do not unlink provider token on egress auth_required signal

### DIFF
--- a/packages/junior/src/chat/services/plugin-auth-orchestration.ts
+++ b/packages/junior/src/chat/services/plugin-auth-orchestration.ts
@@ -281,9 +281,14 @@ export function createPluginAuthOrchestration(
         );
       }
 
+      // Do not unlink here. This signal can represent either missing credentials
+      // before lease issuance or an upstream 401 after credential injection. In
+      // the latter case the token may be valid and the 401 caused by a
+      // scope/org/permission mismatch unrelated to the stored credential.
+      // OAuth completion overwrites the stored token via userTokenStore.set(),
+      // so proactive deletion is unnecessary and destroys a working connection.
       await startAuthorizationPause(authorization.provider, {
         ...(authorization.scope ? { scope: authorization.scope } : {}),
-        unlinkExistingProvider: true,
       });
     },
     getPendingPause: () => pendingPause,

--- a/packages/junior/src/chat/services/plugin-auth-orchestration.ts
+++ b/packages/junior/src/chat/services/plugin-auth-orchestration.ts
@@ -13,7 +13,6 @@
 import { THREAD_STATE_TTL_MS } from "chat";
 import type { Destination, Source } from "@sentry/junior-plugin-api";
 import type { ChannelConfigurationService } from "@/chat/configuration/types";
-import { unlinkProvider } from "@/chat/credentials/unlink-provider";
 import type { UserTokenStore } from "@/chat/credentials/user-token-store";
 import { formatProviderLabel, startOAuthFlow } from "@/chat/oauth-flow";
 import { canReusePendingAuthLink } from "@/chat/services/pending-auth";
@@ -134,7 +133,6 @@ export function createPluginAuthOrchestration(
     provider: string,
     options?: {
       scope?: string;
-      unlinkExistingProvider?: boolean;
     },
   ): Promise<never> => {
     if (pendingPause) {
@@ -189,14 +187,6 @@ export function createPluginAuthOrchestration(
           `I need to connect your ${providerLabel} account first, but I wasn't able to send you a private authorization link. Please send me a direct message and try again.`,
         );
       }
-    }
-
-    if (
-      options?.unlinkExistingProvider &&
-      input.actorId &&
-      input.userTokenStore
-    ) {
-      await unlinkProvider(input.actorId, provider, input.userTokenStore);
     }
 
     if (input.sessionId && recordPendingAuth) {

--- a/packages/junior/src/chat/services/plugin-auth-orchestration.ts
+++ b/packages/junior/src/chat/services/plugin-auth-orchestration.ts
@@ -277,9 +277,10 @@ export function createPluginAuthOrchestration(
       // scope/org/permission mismatch unrelated to the stored credential.
       // OAuth completion overwrites the stored token via userTokenStore.set(),
       // so proactive deletion is unnecessary and destroys a working connection.
-      await startAuthorizationPause(authorization.provider, {
-        ...(authorization.scope ? { scope: authorization.scope } : {}),
-      });
+      await startAuthorizationPause(
+        authorization.provider,
+        authorization.scope ? { scope: authorization.scope } : undefined,
+      );
     },
     getPendingPause: () => pendingPause,
   };

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -740,12 +740,15 @@ export async function GET(
         if (error instanceof ResumeTurnBusyError) {
           logWarn(
             "oauth_callback_resume_busy",
-            {},
+            {
+              ...(stored.resumeConversationId
+                ? { conversationId: stored.resumeConversationId }
+                : {}),
+              ...(stored.userId ? { actorId: stored.userId } : {}),
+              ...(stored.channelId ? { channelId: stored.channelId } : {}),
+            },
             {
               "app.credential.provider": stored.provider,
-              ...(stored.resumeConversationId
-                ? { "app.ai.conversation_id": stored.resumeConversationId }
-                : {}),
               ...(stored.resumeSessionId
                 ? { "app.ai.session_id": stored.resumeSessionId }
                 : {}),

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -20,7 +20,7 @@ import {
   resumeSlackTurn,
 } from "@/chat/runtime/slack-resume";
 import { persistAuthPauseTurnState } from "@/chat/runtime/auth-pause-state";
-import { logException, logInfo } from "@/chat/logging";
+import { logException, logInfo, logWarn } from "@/chat/logging";
 import { htmlCallbackResponse } from "@/handlers/oauth-html";
 import {
   getChannelConfigurationServiceById,
@@ -738,6 +738,20 @@ export async function GET(
         }
       } catch (error) {
         if (error instanceof ResumeTurnBusyError) {
+          logWarn(
+            "oauth_callback_resume_busy",
+            {},
+            {
+              "app.credential.provider": stored.provider,
+              ...(stored.resumeConversationId
+                ? { "app.ai.conversation_id": stored.resumeConversationId }
+                : {}),
+              ...(stored.resumeSessionId
+                ? { "app.ai.session_id": stored.resumeSessionId }
+                : {}),
+            },
+            "OAuth callback resume was busy; user must send another message to continue",
+          );
           return;
         }
         throw error;

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -741,17 +741,17 @@ export async function GET(
           logWarn(
             "oauth_callback_resume_busy",
             {
-              ...(stored.resumeConversationId
-                ? { conversationId: stored.resumeConversationId }
-                : {}),
-              ...(stored.userId ? { actorId: stored.userId } : {}),
-              ...(stored.channelId ? { channelId: stored.channelId } : {}),
+              ...(stored.resumeConversationId && {
+                conversationId: stored.resumeConversationId,
+              }),
+              ...(stored.userId && { actorId: stored.userId }),
+              ...(stored.channelId && { channelId: stored.channelId }),
             },
             {
               "app.credential.provider": stored.provider,
-              ...(stored.resumeSessionId
-                ? { "app.ai.session_id": stored.resumeSessionId }
-                : {}),
+              ...(stored.resumeSessionId && {
+                "app.ai.session_id": stored.resumeSessionId,
+              }),
             },
             "OAuth callback resume was busy; user must send another message to continue",
           );

--- a/packages/junior/tests/unit/services/plugin-auth-orchestration.test.ts
+++ b/packages/junior/tests/unit/services/plugin-auth-orchestration.test.ts
@@ -122,7 +122,7 @@ describe("createPluginAuthOrchestration", () => {
         userMessage: "check Sentry",
       }),
     );
-    expect(unlinkProvider).toHaveBeenCalledWith("U123", "sentry", tokens);
+    expect(unlinkProvider).not.toHaveBeenCalled();
   });
 
   it("starts oauth when exit code is 0 (pipe-masked failure)", async () => {
@@ -185,7 +185,7 @@ describe("createPluginAuthOrchestration", () => {
     expect(startOAuthFlow).not.toHaveBeenCalled();
   });
 
-  it("unlinks the stored token only after oauth restart is launched", async () => {
+  it("starts oauth before throwing pause error without unlinking stored token", async () => {
     const order: string[] = [];
     const tokens = tokenStore();
     const abortAgent = vi.fn();
@@ -193,9 +193,6 @@ describe("createPluginAuthOrchestration", () => {
     startOAuthFlow.mockImplementation(async () => {
       order.push("oauth");
       return { ok: true, delivery: { channelId: "D123" } };
-    });
-    unlinkProvider.mockImplementation(async () => {
-      order.push("unlink");
     });
 
     const orchestration = createPluginAuthOrchestration({
@@ -209,8 +206,12 @@ describe("createPluginAuthOrchestration", () => {
       orchestration.maybeHandleAuthSignal({ auth_required: sentryAuthSignal }),
     ).rejects.toBeInstanceOf(PluginAuthorizationPauseError);
 
-    expect(order).toEqual(["oauth", "unlink"]);
-    expect(unlinkProvider).toHaveBeenCalledWith("U123", "sentry", tokens);
+    // OAuth starts but the stored token is NOT deleted: a 401 from the upstream
+    // may be caused by scope/org mismatch rather than an invalid credential.
+    // The new OAuth flow overwrites the token on completion; proactive deletion
+    // destroys a working connection and causes the re-auth loop.
+    expect(order).toEqual(["oauth"]);
+    expect(unlinkProvider).not.toHaveBeenCalled();
     expect(abortAgent).toHaveBeenCalledTimes(1);
   });
 
@@ -282,7 +283,7 @@ describe("createPluginAuthOrchestration", () => {
         userMessage: "push the branch",
       }),
     );
-    expect(unlinkProvider).toHaveBeenCalledWith("U123", "github", tokens);
+    expect(unlinkProvider).not.toHaveBeenCalled();
   });
 
   it("sends a fresh link when the pending auth belongs to a previous session", async () => {


### PR DESCRIPTION
`maybeHandleAuthSignal` was unconditionally calling `startAuthorizationPause` with `unlinkExistingProvider: true`, deleting the stored OAuth token before sending a new auth link. When the signal originates from an upstream 401 after credential injection (scope/org/permission mismatch), the stored token is still valid — destroying it creates a re-auth loop where authorization succeeds in the browser but Junior immediately asks again.

**Token preservation on auth_required**

Removed `unlinkExistingProvider: true` from `maybeHandleAuthSignal`. The signal can represent either a pre-injection credential miss (missing/expired token) or a post-injection upstream 401. In the latter case the stored credential is fine. OAuth completion already overwrites the stored token via `userTokenStore.set()`, so proactive deletion is unnecessary in both cases.

**ResumeTurnBusyError observability**

Added `logWarn` when the OAuth callback `waitUntil` resume is dropped due to a busy conversation lock. Previously silently swallowed, making lock contention invisible in production.

Fixes #799

<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC0AHB7N2JCR%3A1783551696.996219/?project=4510944073809921)

<!-- junior-session-footer:end -->