### PR TITLE
fix(conversation-memory): fall back to userId when no display name available

### DIFF
--- a/packages/junior/src/chat/services/conversation-memory.ts
+++ b/packages/junior/src/chat/services/conversation-memory.ts
@@ -98,6 +98,7 @@ function conversationAuthorDisplayName(message: ConversationMessage): string {
   return (
     fullName ??
     userName ??
+    author?.userId ??
     (message.role === "assistant" ? botConfig.userName : message.role)
   );
 }

--- a/packages/junior/tests/unit/services/conversation-memory.test.ts
+++ b/packages/junior/tests/unit/services/conversation-memory.test.ts
@@ -138,7 +138,7 @@ describe("buildConversationContext", () => {
     expect(context).not.toContain("<thread-transcript>");
   });
 
-  it("does not render raw Slack ids as author display names", () => {
+  it("uses Slack user ID as author label when userName and fullName match the ID or are absent", () => {
     const conversation = coerceThreadConversationState({});
     conversation.messages = [
       {
@@ -157,9 +157,39 @@ describe("buildConversationContext", () => {
 
     const context = buildConversationContext(conversation);
 
-    expect(context).toContain('author="user"');
+    // userId is preserved as the author label so distinct users remain distinguishable
+    expect(context).toContain('author="U039RR91S"');
     expect(context).toContain('actor_id="U039RR91S"');
-    expect(context).toContain("[user] user: hello");
+    expect(context).toContain("[user] U039RR91S: hello");
     expect(context).not.toContain("@U039RR91S");
+  });
+
+  it("keeps distinct author labels for two users with no display names", () => {
+    const conversation = coerceThreadConversationState({});
+    conversation.messages = [
+      {
+        id: "msg-1",
+        role: "user",
+        text: "first message",
+        createdAtMs: 1000,
+        author: { isBot: false, userId: "UALICE" },
+      },
+      {
+        id: "msg-2",
+        role: "user",
+        text: "second message",
+        createdAtMs: 2000,
+        author: { isBot: false, userId: "UBOB" },
+      },
+    ];
+
+    const context = buildConversationContext(conversation);
+
+    expect(context).toContain('actor_id="UALICE"');
+    expect(context).toContain('actor_id="UBOB"');
+    // authors must be distinct, not both "user"
+    expect(context).toContain('author="UALICE"');
+    expect(context).toContain('author="UBOB"');
+    expect(context).not.toContain('author="user"');
   });
 });


### PR DESCRIPTION
## What

When a Slack participant has no resolved `fullName` or `userName`, the author label in the model-facing transcript fell back to the generic role string (`"user"`). In multi-participant threads this made distinct humans indistinguishable — every unresolved user appeared as `author="user"` even though `actor_id` was distinct.

## Change

One-line fix in `conversationAuthorDisplayName`: add `author?.userId` as a fallback before the generic role label.

```ts
return (
  fullName ??
  userName ??
  author?.userId ??  // <-- added
  (message.role === "assistant" ? botConfig.userName : message.role)
);
```

This updates the existing test (which explicitly asserted the old `author="user"` behavior) and adds a new test for the multi-user disambiguation contract.

## Why this is safe

- `actor_id` already exposed the raw Slack user ID in the XML attribute; this just makes `author` consistent with it
- Named users (resolved `fullName`/`userName`) are unaffected — the new fallback is only reached when both are absent
- No new API calls or external lookups

## Not fixed by this PR

- Issue #801 (wrong-first-response bug) — still needs backend logs to identify root cause
- Full participant name hydration from Slack at transcript-build time — deferred; this PR delivers the safe identity-preservation contract first

Refs #310

<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC0AHB7N2JCR%3A1783554340.280229/?project=4510944073809921)

<!-- junior-session-footer:end -->