### PR TITLE
fix(agent): Prefer event subscriptions over polling

### DIFF
--- a/packages/junior-evals/evals/core/resource-event-subscriptions.eval.ts
+++ b/packages/junior-evals/evals/core/resource-event-subscriptions.eval.ts
@@ -1,6 +1,7 @@
-import { assistantMessages, describeEval } from "vitest-evals";
+import { assistantMessages, describeEval, toolCalls } from "vitest-evals";
 import { expect } from "vitest";
 import {
+  mention,
   resourceEventNotification,
   rubric,
   slackEvals,
@@ -21,6 +22,67 @@ function visibleThreadReplies(
 }
 
 describeEval("Resource Event Subscriptions", slackEvals, (it) => {
+  it("when a created PR can emit requested events, subscribe instead of polling", async ({
+    run,
+  }) => {
+    const result = await run({
+      overrides: {
+        plugin_dirs: ["fixtures/resource-event-plugins"],
+      },
+      events: [
+        mention(
+          "/eval-resource-events Use the provider to create a pull request titled 'Prefer event subscriptions', then check it every five minutes and tell this thread if checks fail, review feedback arrives, it merges, or it closes.",
+        ),
+      ],
+      criteria: rubric({
+        pass: [
+          "The assistant creates the requested pull request.",
+          "The assistant subscribes this conversation to the requested high-signal pull request events.",
+          "The reply confirms the pull request and event-based monitoring without claiming a recurring polling schedule was created.",
+        ],
+        fail: [
+          "Do not create a scheduled task to poll the pull request.",
+          "Do not ask the user to monitor GitHub manually.",
+          "Do not omit the event subscription after creating the pull request.",
+        ],
+      }),
+    });
+
+    expect(toolCalls(result.session)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "callMcpTool",
+          arguments: expect.objectContaining({
+            tool_name:
+              "mcp__eval-resource-events__create-watchable-pull-request",
+            arguments: expect.objectContaining({
+              title: "Prefer event subscriptions",
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          name: "subscribeToResourceEvents",
+          arguments: expect.objectContaining({
+            provider: "github",
+            resourceRef: "github:pull_request:getsentry/junior#208",
+            resourceType: "pull_request",
+            events: expect.arrayContaining([
+              "checks.failed",
+              "review.changes_requested",
+              "review.commented",
+              "review_comment.created",
+              "state.merged",
+              "state.closed_unmerged",
+            ]),
+          }),
+        }),
+      ]),
+    );
+    expect(toolCalls(result.session).map((call) => call.name)).not.toContain(
+      "scheduler_slackScheduleCreateTask",
+    );
+  });
+
   it("when a subscribed PR check fails, summarize the failure and suggest next steps", async ({
     run,
   }) => {

--- a/packages/junior-evals/evals/core/resource-event-subscriptions.eval.ts
+++ b/packages/junior-evals/evals/core/resource-event-subscriptions.eval.ts
@@ -98,7 +98,6 @@ describeEval("Resource Event Subscriptions", slackEvals, (it) => {
       ],
       criteria: rubric({
         pass: [
-          "The normalized transcript contains exactly one assistant thread reply.",
           "The reply says GitHub PR getsentry/junior#691 has a failed CI/checks result.",
           'The reply mentions the failing workflow "test" or commit abcdef123456.',
           "The reply gives a concrete next step such as checking CI logs, inspecting the failed workflow, or preparing a fix.",
@@ -130,7 +129,6 @@ describeEval("Resource Event Subscriptions", slackEvals, (it) => {
       ],
       criteria: rubric({
         pass: [
-          "The normalized transcript contains exactly one assistant thread reply.",
           "The reply says GitHub PR getsentry/junior#702 was merged.",
           "The reply frames the merge as the subscribed outcome this thread was waiting for.",
           "The reply stays brief and does not propose unnecessary follow-up work.",

--- a/packages/junior-evals/evals/core/resource-event-subscriptions.eval.ts
+++ b/packages/junior-evals/evals/core/resource-event-subscriptions.eval.ts
@@ -36,14 +36,11 @@ describeEval("Resource Event Subscriptions", slackEvals, (it) => {
       ],
       criteria: rubric({
         pass: [
-          "The assistant creates the requested pull request.",
-          "The assistant subscribes this conversation to the requested high-signal pull request events.",
-          "The reply confirms the pull request and event-based monitoring without claiming a recurring polling schedule was created.",
+          "The reply confirms the pull request will be monitored through event-based updates for the requested outcomes.",
         ],
         fail: [
-          "Do not create a scheduled task to poll the pull request.",
           "Do not ask the user to monitor GitHub manually.",
-          "Do not omit the event subscription after creating the pull request.",
+          "Do not claim a recurring five-minute polling task or schedule was created.",
         ],
       }),
     });

--- a/packages/junior-evals/evals/scheduler/workflows.eval.ts
+++ b/packages/junior-evals/evals/scheduler/workflows.eval.ts
@@ -1,4 +1,5 @@
-import { describeEval } from "vitest-evals";
+import { describeEval, toolCalls } from "vitest-evals";
+import { expect } from "vitest";
 import {
   mention,
   rubric,
@@ -6,16 +7,49 @@ import {
   slackEvals,
 } from "../../src/helpers";
 
+const REMINDER_ONLY_FORBIDDEN_TOOLS = [
+  "webSearch",
+  "webFetch",
+  "bash",
+  "readFile",
+  "editFile",
+  "grep",
+  "findFiles",
+  "listDir",
+  "writeFile",
+  "callMcpTool",
+  "slackThreadRead",
+  "slackChannelListMessages",
+] as const;
+
+function scheduledTaskCreateCall(session: Parameters<typeof toolCalls>[0]) {
+  const calls = toolCalls(session).filter(
+    (call) => call.name === "scheduler_slackScheduleCreateTask",
+  );
+  expect(calls).toHaveLength(1);
+  return calls[0]!;
+}
+
+function expectNoToolCalls(
+  session: Parameters<typeof toolCalls>[0],
+  names: readonly string[],
+) {
+  expect(
+    toolCalls(session)
+      .map((call) => call.name)
+      .filter((name) => names.includes(name)),
+  ).toEqual([]);
+}
+
 describeEval("Scheduler", slackEvals, (it) => {
   it("when asked for a simple one-off reminder, create it without asking for confirmation", async ({
     run,
   }) => {
-    await run({
+    const result = await run({
       events: [mention("@bot remind me in 1 minute to wash my hands")],
       criteria: rubric({
         pass: [
           "The reply confirms that a one-off reminder to wash hands was scheduled.",
-          "The schedule creation omits recurrence.",
           "The reply does not ask the user to confirm first.",
         ],
         fail: [
@@ -25,17 +59,19 @@ describeEval("Scheduler", slackEvals, (it) => {
         ],
       }),
     });
+    const createCall = scheduledTaskCreateCall(result.session);
+    expect(createCall.arguments).toMatchObject({ schedule_kind: "one_off" });
+    expect(createCall.arguments).not.toHaveProperty("recurrence");
   });
 
   it("when asked for a terse one-off reminder, create it without recurrence", async ({
     run,
   }) => {
-    await run({
+    const result = await run({
       events: [mention("@bot remind me to drink water in 1m")],
       criteria: rubric({
         pass: [
           "The reply confirms that a one-off reminder to drink water was scheduled.",
-          "The schedule creation omits recurrence.",
           "The reply does not ask the user to retry with a different one-time format.",
         ],
         fail: [
@@ -45,12 +81,15 @@ describeEval("Scheduler", slackEvals, (it) => {
         ],
       }),
     });
+    const createCall = scheduledTaskCreateCall(result.session);
+    expect(createCall.arguments).toMatchObject({ schedule_kind: "one_off" });
+    expect(createCall.arguments).not.toHaveProperty("recurrence");
   });
 
   it("when asked for a specific one-off reminder, preserve the future work in the schedule", async ({
     run,
   }) => {
-    await run({
+    const result = await run({
       events: [
         mention(
           "@bot remind me in 2 minutes to tell the channel standup moved",
@@ -58,8 +97,6 @@ describeEval("Scheduler", slackEvals, (it) => {
       ],
       criteria: rubric({
         pass: [
-          "The observed scheduler_slackScheduleCreateTask tool call has schedule_kind=one_off.",
-          "The observed scheduler_slackScheduleCreateTask tool call omits recurrence.",
           "The observed scheduler_slackScheduleCreateTask task is the reminder work to perform later, not instructions for how to create or manage a schedule.",
         ],
         fail: [
@@ -68,12 +105,15 @@ describeEval("Scheduler", slackEvals, (it) => {
         ],
       }),
     });
+    const createCall = scheduledTaskCreateCall(result.session);
+    expect(createCall.arguments).toMatchObject({ schedule_kind: "one_off" });
+    expect(createCall.arguments).not.toHaveProperty("recurrence");
   });
 
   it("when asked to schedule clear recurring work, create it without confirmation", async ({
     run,
   }) => {
-    await run({
+    const result = await run({
       events: [
         mention(
           "@bot schedule this every Monday at 9am Pacific: check open GitHub issues about the scheduler and post a short digest here.",
@@ -82,7 +122,6 @@ describeEval("Scheduler", slackEvals, (it) => {
       criteria: rubric({
         pass: [
           "The created task describes checking scheduler-related GitHub issues, not creating a schedule.",
-          "The schedule creation sets recurrence=weekly.",
           "The reply confirms the recurring schedule was created for Monday at 9am Pacific.",
         ],
         fail: [
@@ -92,12 +131,16 @@ describeEval("Scheduler", slackEvals, (it) => {
         ],
       }),
     });
+    expect(scheduledTaskCreateCall(result.session).arguments).toMatchObject({
+      schedule_kind: "recurring",
+      recurrence: "weekly",
+    });
   });
 
   it("when a one-off reminder becomes due, deliver the reminder outcome", async ({
     run,
   }) => {
-    await run({
+    const result = await run({
       events: [
         scheduledTaskDue("Post this reminder: Standup moved to 10:30 today.", {
           schedule: "Once at noon UTC",
@@ -111,19 +154,19 @@ describeEval("Scheduler", slackEvals, (it) => {
           "The delivered message does not ask for clarification or confirmation.",
         ],
         fail: [
-          "Do not use webSearch, webFetch, bash, callMcpTool, sandbox, or Slack history tools for this reminder-only task.",
           "Do not say that a reminder was scheduled or will be scheduled.",
           "Do not omit the 10:30 standup update.",
           "Do not ask the user what to do with the reminder.",
         ],
       }),
     });
+    expectNoToolCalls(result.session, REMINDER_ONLY_FORBIDDEN_TOOLS);
   });
 
   it("when a recurring scheduled task becomes due, deliver that occurrence", async ({
     run,
   }) => {
-    await run({
+    const result = await run({
       events: [
         scheduledTaskDue(
           "Post this reminder: Submit timesheets by 5pm today.",
@@ -141,12 +184,12 @@ describeEval("Scheduler", slackEvals, (it) => {
           "The delivered message is not just a confirmation that a recurring task exists.",
         ],
         fail: [
-          "Do not use webSearch, webFetch, bash, callMcpTool, sandbox, or Slack history tools for this reminder-only task.",
           "Do not say only that a weekly reminder was scheduled.",
           "Do not omit the timesheets by 5pm content.",
           "Do not ask the user to confirm the recurring task before posting.",
         ],
       }),
     });
+    expectNoToolCalls(result.session, REMINDER_ONLY_FORBIDDEN_TOOLS);
   });
 });

--- a/packages/junior-evals/fixtures/resource-event-plugins/eval-resource-events/plugin.yaml
+++ b/packages/junior-evals/fixtures/resource-event-plugins/eval-resource-events/plugin.yaml
@@ -1,0 +1,8 @@
+name: eval-resource-events
+display-name: Eval Resource Events
+description: Creates eval pull requests with subscribable resource events
+
+mcp:
+  url: https://eval-mcp.example.test/mcp
+  allowed-tools:
+    - create-watchable-pull-request

--- a/packages/junior-scheduler/src/tools/create-task.ts
+++ b/packages/junior-scheduler/src/tools/create-task.ts
@@ -28,7 +28,7 @@ export function createSlackScheduleCreateTaskTool(
 ) {
   return definePluginTool({
     description:
-      "Create a one-time or recurring Junior task in the active Slack conversation. For one-time reminders or one-time scheduled work, omit recurrence entirely; never choose a default recurrence. Use only when the user explicitly asks Junior to do work later or on a recurring cadence. Only manage tasks for the active Slack DM or channel; never target threads, other channels, or another user's DM. When the task, schedule, and destination are clear, create it without asking for confirmation; ask only when one of those is ambiguous.",
+      "Create a one-time or recurring Junior task in the active Slack conversation. For one-time reminders or one-time scheduled work, omit recurrence entirely; never choose a default recurrence. Use only when the user explicitly asks Junior to do work later or on a recurring cadence. Do not create scheduled polling tasks to watch provider resources when a subscribable tool result can deliver the requested events. Only manage tasks for the active Slack DM or channel; never target threads, other channels, or another user's DM. When the task, schedule, and destination are clear, create it without asking for confirmation; ask only when one of those is ambiguous.",
     executionMode: "sequential",
     inputSchema: z.object({
       task: z.string().min(1).max(4000),

--- a/packages/junior/src/chat/prompt.ts
+++ b/packages/junior/src/chat/prompt.ts
@@ -355,7 +355,7 @@ const TOOL_POLICY_RULES = [
   "- For repository or implementation questions, inspect the target repository first: local checkout when present, otherwise the configured GitHub/source provider. Do not treat loaded skill files as repo source unless the user asks about the skill. Cite file paths, symbols, PRs/issues, commits, or URLs that support the answer.",
   "- If a sandbox-backed tool reports that sandbox execution is unavailable, treat that as a blocker for local file/shell inspection; do not pretend host files were inspected.",
   "- For user-provided URLs, use `webFetch`; for discovery, use `webSearch` then fetch/read promising sources; for current time/date context, use `systemTime`.",
-  "- When a tool result includes a subscribable resource, subscribe only when high-signal follow-up events clearly serve the user's current intent; use the suggested events when they fit and write a concise intent summary.",
+  "- When a tool result includes a subscribable resource, use resource-event subscriptions for high-signal provider changes that serve the user's current intent; do not create scheduled polling tasks for events the subscription can deliver. Use the suggested events when they fit and write a concise intent summary.",
   "- Run `jr-rpc config get|set|unset|list` for provider defaults and `jr-rpc plugins list` for installed plugin introspection as standalone bash commands; do not chain them with `cd`, `&&`, pipes, or provider commands.",
   "- If the first result is empty, stale, ambiguous, or incomplete, try a focused alternate query, path, command, or source before concluding the answer cannot be verified.",
 ];

--- a/packages/junior/tests/msw/handlers/eval-mcp-auth.ts
+++ b/packages/junior/tests/msw/handlers/eval-mcp-auth.ts
@@ -84,9 +84,27 @@ export const evalMcpAuthHandlers = [
                 additionalProperties: false,
               },
             },
+            {
+              name: "create-watchable-pull-request",
+              title: "Create Watchable Pull Request",
+              description:
+                "Create an eval pull request and return its subscribable resource events.",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  title: { type: "string" },
+                },
+                required: ["title"],
+                additionalProperties: false,
+              },
+            },
           ],
         });
       case "tools/call": {
+        const toolName =
+          message?.params && typeof message.params.name === "string"
+            ? message.params.name
+            : undefined;
         const args =
           message?.params &&
           typeof message.params === "object" &&
@@ -94,6 +112,55 @@ export const evalMcpAuthHandlers = [
           typeof message.params.arguments === "object"
             ? (message.params.arguments as Record<string, unknown>)
             : undefined;
+        if (toolName === "create-watchable-pull-request") {
+          if (typeof args?.title !== "string") {
+            return jsonRpcResult(message?.id ?? null, {
+              content: [
+                {
+                  type: "text",
+                  text: 'Input validation error: Invalid arguments for tool create-watchable-pull-request:\n- "title": expected string, received undefined',
+                },
+              ],
+              isError: true,
+            });
+          }
+          return jsonRpcResult(message?.id ?? null, {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify({
+                  number: 208,
+                  url: "https://github.com/getsentry/junior/pull/208",
+                  title: args.title,
+                  subscribable: {
+                    provider: "github",
+                    type: "pull_request",
+                    resourceRef: "github:pull_request:getsentry/junior#208",
+                    label: "GitHub PR getsentry/junior#208",
+                    supportedEvents: [
+                      "checks.failed",
+                      "comment.created",
+                      "review.changes_requested",
+                      "review.commented",
+                      "review_comment.created",
+                      "state.merged",
+                      "state.closed_unmerged",
+                    ],
+                    suggestedEvents: [
+                      "checks.failed",
+                      "review.changes_requested",
+                      "review.commented",
+                      "review_comment.created",
+                      "state.merged",
+                      "state.closed_unmerged",
+                    ],
+                  },
+                }),
+              },
+            ],
+            isError: false,
+          });
+        }
         if (typeof args?.query !== "string") {
           return jsonRpcResult(message?.id ?? null, {
             content: [

--- a/specs/resource-event-subscriptions.md
+++ b/specs/resource-event-subscriptions.md
@@ -94,6 +94,9 @@ Rules:
    action that produced the resource.
 4. Tool results must not include provider webhook filters, Slack coordinates, or
    credentials in the subscribable hint.
+5. When requested follow-up can be represented by supported resource events,
+   Junior must subscribe instead of creating a scheduled task that polls the
+   provider for the same changes.
 
 ### Core Subscription Tools
 

--- a/specs/scheduler.md
+++ b/specs/scheduler.md
@@ -20,6 +20,8 @@ Define the first scheduler contract for Junior: users can create durable tasks t
 ## Non-Goals
 
 - A generic event-rule engine for GitHub, Slack, Sentry, or webhook events.
+- Polling provider resources for changes that resource-event subscriptions can
+  deliver.
 - A full durable workflow runtime such as Temporal or Vercel Workflow.
 - Reusing agent continuation callbacks as the product scheduler.
 - Slack `chat.scheduleMessage` as the execution mechanism.


### PR DESCRIPTION
Junior now treats subscribable provider events as the preferred follow-up mechanism when they cover the user's requested outcome. Scheduler guidance explicitly rejects recurring polling tasks for those resources, while time-based work remains unchanged.

The resource-event and scheduler specs now describe this boundary. A focused agent eval asks Junior to check a created pull request every five minutes, then deterministically verifies the exact PR subscription, requested events, and absence of a scheduler task. Related scheduler evals now assert schedule arguments and forbidden tool use directly from the normalized session, leaving judge rubrics focused on task meaning and user-visible replies.

The subscription eval uses an isolated MCP fixture so unrelated provider workflows do not gain additional action tools.