### PR TITLE
feat(sandbox): Allow larger sandboxes

### DIFF
--- a/packages/docs/src/content/docs/operate/sandbox-snapshots.md
+++ b/packages/docs/src/content/docs/operate/sandbox-snapshots.md
@@ -54,6 +54,12 @@ Rebuilds happen when:
 
 The default floating dependency max age is seven days. Set `SANDBOX_SNAPSHOT_FLOATING_MAX_AGE_MS=0` only when you intentionally want floating dependencies rebuilt every time.
 
+## Build resources
+
+Snapshot builds use the same `SANDBOX_VCPUS` setting as runtime sandboxes. Set it when dependency installation or agent work needs more CPU or memory than the Vercel Sandbox default. Each vCPU provides 2 GB of memory, so `SANDBOX_VCPUS=4` creates 8 GB sandboxes.
+
+Leave the variable unset to use the Vercel default. Requested vCPU counts must be supported by the deployment's Vercel plan; unsupported values cause sandbox creation to fail.
+
 ## Failure behavior
 
 Snapshot build failures are deploy blockers. Junior must not silently continue with partially installed dependencies.

--- a/packages/docs/src/content/docs/reference/config-and-env.md
+++ b/packages/docs/src/content/docs/reference/config-and-env.md
@@ -27,6 +27,7 @@ related:
 | `AI_EMBEDDING_MODEL`                        | No          | Embedding model for plugin-owned vector retrieval. Defaults to `openai/text-embedding-3-small`; memory v1 stores fixed 1536-dimensional vectors.      |
 | `AI_VISION_MODEL`                           | No          | Dedicated image-understanding model; unset disables vision features.                                                                                  |
 | `AI_WEB_SEARCH_MODEL`                       | No          | Override for the `webSearch` tool model. Defaults to `openai/gpt-5.4`; does not fall through to `AI_MODEL`.                                           |
+| `SANDBOX_VCPUS`                             | No          | vCPUs for newly created Vercel Sandboxes; each vCPU provides 2 GB of memory. Defaults to the Vercel Sandbox resource setting.                         |
 | `JUNIOR_BASE_URL`                           | No          | Canonical base URL for callback/auth URL generation.                                                                                                  |
 | `JUNIOR_STATE_KEY_PREFIX`                   | No          | Optional namespace prepended to all state-adapter keys, locks, and queues. Use separate prefixes when sharing one Redis database across environments. |
 | `CRON_SECRET` or `JUNIOR_SCHEDULER_SECRET`  | Conditional | Bearer token for the internal heartbeat route; use `CRON_SECRET` with Vercel Cron, or `JUNIOR_SCHEDULER_SECRET` for a non-Vercel heartbeat caller.    |
@@ -73,6 +74,11 @@ If your build command runs `junior snapshot create`:
 
 - `REDIS_URL` must be available during build.
 - `VERCEL_OIDC_TOKEN` must be available during build (via Vercel OIDC settings).
+
+| Variable                               | Required | Purpose                                                                              |
+| -------------------------------------- | -------- | ------------------------------------------------------------------------------------ |
+| `SANDBOX_SNAPSHOT_FLOATING_MAX_AGE_MS` | No       | Maximum cached age for snapshots with floating dependencies. Defaults to seven days. |
+| `SANDBOX_SNAPSHOT_REBUILD_EPOCH`       | No       | Operator-controlled value that forces a new snapshot profile when changed.           |
 
 ## Sandbox credential egress
 

--- a/packages/junior/src/chat/sandbox/resources.ts
+++ b/packages/junior/src/chat/sandbox/resources.ts
@@ -1,0 +1,12 @@
+/** Resolve optional resource sizing shared by every newly created sandbox. */
+export function getSandboxResources(): { vcpus: number } | undefined {
+  const value = process.env.SANDBOX_VCPUS?.trim();
+  if (!value || !/^\d+$/.test(value)) {
+    return undefined;
+  }
+  const vcpus = Number(value);
+  if (!Number.isSafeInteger(vcpus) || vcpus <= 0) {
+    return undefined;
+  }
+  return { vcpus };
+}

--- a/packages/junior/src/chat/sandbox/runtime-dependency-snapshots.ts
+++ b/packages/junior/src/chat/sandbox/runtime-dependency-snapshots.ts
@@ -13,6 +13,7 @@ import type {
   PluginRuntimePostinstallCommand,
 } from "@/chat/plugins/types";
 import { SANDBOX_WORKSPACE_ROOT } from "@/chat/sandbox/paths";
+import { getSandboxResources } from "@/chat/sandbox/resources";
 import { getStateAdapter } from "@/chat/state/adapter";
 
 const SNAPSHOT_CACHE_PREFIX = "junior:sandbox_snapshot_profile";
@@ -481,11 +482,13 @@ async function createDependencySnapshot(
     },
     async () => {
       const sandboxCredentials = getVercelSandboxCredentials();
+      const resources = getSandboxResources();
       const sandbox = createSandboxInstance(
         await Sandbox.create({
           timeout: timeoutMs,
           runtime,
           ...(sandboxCredentials ?? {}),
+          ...(resources ? { resources } : {}),
         }),
       );
 

--- a/packages/junior/src/chat/sandbox/session.ts
+++ b/packages/junior/src/chat/sandbox/session.ts
@@ -19,6 +19,7 @@ import {
 } from "@/chat/sandbox/errors";
 import { buildNonInteractiveShellScript } from "@/chat/sandbox/noninteractive-command";
 import { SANDBOX_WORKSPACE_ROOT } from "@/chat/sandbox/paths";
+import { getSandboxResources } from "@/chat/sandbox/resources";
 import {
   getRuntimeDependencyProfileHash,
   isSnapshotMissingError,
@@ -362,6 +363,7 @@ export function createSandboxSessionManager(options?: {
     sandboxCredentials: SandboxCredentials | undefined,
     initialSandboxName: string,
   ): Promise<SandboxInstance> => {
+    const resources = getSandboxResources();
     for (let attempt = 0; attempt < SNAPSHOT_BOOT_RETRY_COUNT; attempt += 1) {
       const sandboxName =
         attempt === 0 ? initialSandboxName : createSandboxName();
@@ -377,6 +379,7 @@ export function createSandboxSessionManager(options?: {
               type: "snapshot",
               snapshotId,
             },
+            ...(resources ? { resources } : {}),
             ...(sandboxCredentials ?? {}),
           } as Parameters<typeof Sandbox.create>[0]),
         );
@@ -423,6 +426,7 @@ export function createSandboxSessionManager(options?: {
 
     if (!snapshot.snapshotId) {
       const networkPolicy = preflightNetworkPolicy(sandboxName);
+      const resources = getSandboxResources();
       return createSandboxInstance(
         await Sandbox.create({
           timeout: timeoutMs,
@@ -430,6 +434,7 @@ export function createSandboxSessionManager(options?: {
           ...(networkPolicy
             ? { name: sandboxName, persistent: false, networkPolicy }
             : {}),
+          ...(resources ? { resources } : {}),
           ...(sandboxCredentials ?? {}),
         } as Parameters<typeof Sandbox.create>[0]),
       );

--- a/packages/junior/tests/component/misc/sandbox-executor.test.ts
+++ b/packages/junior/tests/component/misc/sandbox-executor.test.ts
@@ -266,6 +266,7 @@ describe("createSandboxExecutor", () => {
     delete process.env.VERCEL_PROJECT_ID;
     delete process.env.VERCEL_OIDC_TOKEN;
     delete process.env.VERCEL_SANDBOX_KEEPALIVE_MS;
+    delete process.env.SANDBOX_VCPUS;
     process.env.JUNIOR_BASE_URL = "https://junior.example.com";
     process.env.JUNIOR_SECRET = "test-secret";
   });
@@ -650,6 +651,23 @@ describe("createSandboxExecutor", () => {
     expect(sandboxCreateMock).toHaveBeenCalledWith({
       timeout: 1000 * 60 * 30,
       runtime: "node22",
+    });
+  });
+
+  it("configures resources for fresh sandboxes", async () => {
+    process.env.SANDBOX_VCPUS = "4";
+    const freshSandbox = makeSandbox("sbx_resources");
+    sandboxCreateMock.mockResolvedValue(freshSandbox);
+
+    const executor = createSandboxExecutor();
+    executor.configureSkills([]);
+
+    await executor.createSandbox();
+
+    expect(sandboxCreateMock).toHaveBeenCalledWith({
+      timeout: 1000 * 60 * 30,
+      runtime: "node22",
+      resources: { vcpus: 4 },
     });
   });
 
@@ -1834,6 +1852,7 @@ describe("createSandboxExecutor", () => {
   });
 
   it("creates fresh sandboxes from dependency snapshots when available", async () => {
+    process.env.SANDBOX_VCPUS = "4";
     const snapshotSandbox = makeSandbox("sbx_snapshot");
     resolveRuntimeDependencySnapshotMock.mockResolvedValue({
       snapshotId: "snap_123",
@@ -1856,6 +1875,7 @@ describe("createSandboxExecutor", () => {
         type: "snapshot",
         snapshotId: "snap_123",
       },
+      resources: { vcpus: 4 },
     });
   });
 

--- a/packages/junior/tests/unit/runtime/runtime-dependency-snapshots.test.ts
+++ b/packages/junior/tests/unit/runtime/runtime-dependency-snapshots.test.ts
@@ -116,6 +116,7 @@ describe("runtime dependency snapshots", () => {
     getRuntimePostinstallMock.mockReturnValue([]);
     delete process.env.SANDBOX_SNAPSHOT_REBUILD_EPOCH;
     delete process.env.SANDBOX_SNAPSHOT_FLOATING_MAX_AGE_MS;
+    delete process.env.SANDBOX_VCPUS;
     delete process.env.VERCEL_TOKEN;
     delete process.env.VERCEL_TEAM_ID;
     delete process.env.VERCEL_PROJECT_ID;
@@ -276,6 +277,45 @@ describe("runtime dependency snapshots", () => {
       token: "sandbox-token",
       teamId: "team_123",
       projectId: "prj_123",
+    });
+  });
+
+  it("configures snapshot build resources from the environment", async () => {
+    process.env.SANDBOX_VCPUS = "4";
+    getRuntimeDependenciesMock.mockReturnValue([
+      { type: "npm", package: "sentry", version: "1.0.0" },
+    ]);
+    sandboxCreateMock.mockResolvedValueOnce(makeSandbox("snap_resources"));
+
+    await resolveRuntimeDependencySnapshot({
+      runtime: "node22",
+      timeoutMs: 60_000,
+    });
+
+    expect(sandboxCreateMock).toHaveBeenCalledWith({
+      timeout: 60_000,
+      runtime: "node22",
+      resources: { vcpus: 4 },
+    });
+  });
+
+  it("uses default snapshot build resources for invalid configuration", async () => {
+    process.env.SANDBOX_VCPUS = "4cores";
+    getRuntimeDependenciesMock.mockReturnValue([
+      { type: "npm", package: "sentry", version: "1.0.0" },
+    ]);
+    sandboxCreateMock.mockResolvedValueOnce(
+      makeSandbox("snap_default_resources"),
+    );
+
+    await resolveRuntimeDependencySnapshot({
+      runtime: "node22",
+      timeoutMs: 60_000,
+    });
+
+    expect(sandboxCreateMock).toHaveBeenCalledWith({
+      timeout: 60_000,
+      runtime: "node22",
     });
   });
 

--- a/specs/sandbox-snapshots.md
+++ b/specs/sandbox-snapshots.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-03-06
-- Last Edited: 2026-03-06
+- Last Edited: 2026-07-10
 
 ## Purpose
 
@@ -15,6 +15,7 @@ Define how Junior builds, caches, invalidates, and uses sandbox filesystem snaps
 - Runtime post-install command declarations from plugin manifests.
 - Dependency profile hashing and snapshot cache-key generation.
 - Redis-backed snapshot registry and build locking.
+- Shared sandbox resource configuration.
 - Sandbox creation behavior for cache hit/miss/stale snapshot paths.
 - Rebuild controls for floating dependency selectors.
 
@@ -69,11 +70,15 @@ Define how Junior builds, caches, invalidates, and uses sandbox filesystem snaps
 - System URL dependencies are downloaded with `curl`, verified with `sha256sum`, then installed via `dnf install -y <local-rpm>` with `sudo: true`.
 - Npm dependency install uses `<package>@<version>`. Omitted manifest versions are normalized to `latest` before install.
 - Runtime post-install commands run in declaration order and fail snapshot build on non-zero exit.
+- `SANDBOX_VCPUS` configures every newly created sandbox through `resources.vcpus` when set to a positive integer, including snapshot builders and runtime sandboxes.
+- Unset or invalid `SANDBOX_VCPUS` values use the Vercel Sandbox default resources.
+- Sandbox resource sizing does not participate in `profileHash`; changing it affects sandbox capacity, not snapshot identity.
 
 ### Sandbox Create Contract
 
 - Fresh sandbox acquisition attempts snapshot-backed creation first when `snapshotId` is available:
   - `Sandbox.create({ source: { type: "snapshot", snapshotId } })`
+- Fresh base sandboxes and snapshot-backed sandboxes use the same configured resources.
 - If snapshot is missing/stale, runtime rebuilds once and retries with rebuilt `snapshotId`.
 - Existing in-memory and `sandboxId` reuse behavior remains unchanged and takes precedence over fresh create.
 


### PR DESCRIPTION
Junior currently creates every Vercel Sandbox with the provider's default
resources. Memory-heavy dependency installs, browser tooling, and agent
workloads can exhaust that allocation, with no deployment-level way to
increase it.

Add `SANDBOX_VCPUS` and apply it to every newly created sandbox: base runtime
sandboxes, snapshot-backed runtime sandboxes, and dependency snapshot builders.
Valid positive integers are passed through `resources.vcpus`; unset or invalid
values keep Vercel's default. Resource sizing does not change snapshot cache
identity.

Fixes #715
