### PR TITLE
fix(tools): Preserve safe private trace results

### DIFF
--- a/packages/docs/src/content/docs/extend/build-a-plugin.md
+++ b/packages/docs/src/content/docs/extend/build-a-plugin.md
@@ -194,9 +194,14 @@ Junior exposes them to the agent as `<pluginNamespace>_<toolName>`, where
 ```ts title="index.ts"
 import {
   defineJuniorPlugin,
-  definePluginTool,
+  pluginToolResultSchema,
+  zodTool,
 } from "@sentry/junior-plugin-api";
 import { z } from "zod";
+
+const pingResultSchema = pluginToolResultSchema.extend({
+  latency_ms: z.number(),
+});
 
 export function myProviderPlugin() {
   return defineJuniorPlugin({
@@ -207,12 +212,22 @@ export function myProviderPlugin() {
     hooks: {
       tools(ctx) {
         return {
-          ping: definePluginTool({
+          ping: zodTool({
             description: "Check my-provider connectivity.",
             inputSchema: z.object({}),
+            outputSchema: pingResultSchema,
+            privateTraceResult: (result) => ({
+              ok: result.ok,
+              status: result.status,
+              latency_ms: result.latency_ms,
+            }),
             execute: async () => {
               ctx.log.info("Running my-provider ping");
-              return { ok: true };
+              return {
+                ok: true,
+                status: "success",
+                latency_ms: 12,
+              };
             },
           }),
         };
@@ -221,6 +236,10 @@ export function myProviderPlugin() {
   });
 }
 ```
+
+Use `privateTraceResult` only for fields that are safe to retain when the
+conversation is private. Without it, Junior records bounded result metadata
+instead of the raw structured result.
 
 `heartbeat(ctx)` is for plugins that need server-side background work.
 Use `ctx.state` for plugin-namespaced durable state. Use

--- a/packages/docs/src/content/docs/reference/api/README.md
+++ b/packages/docs/src/content/docs/reference/api/README.md
@@ -69,3 +69,4 @@ title: "@sentry/junior"
 - [initSentry](/reference/api/functions/initsentry/)
 - [juniorNitro](/reference/api/functions/juniornitro/)
 - [juniorVercelConfig](/reference/api/functions/juniorvercelconfig/)
+- [zodTool](/reference/api/functions/zodtool/)

--- a/packages/docs/src/content/docs/reference/api/functions/zodTool.md
+++ b/packages/docs/src/content/docs/reference/api/functions/zodTool.md
@@ -1,0 +1,32 @@
+---
+editUrl: false
+next: false
+prev: false
+title: "zodTool"
+---
+
+> **zodTool**\<`TInputSchema`, `TOutputSchema`\>(`definition`): `PluginToolDefinition`\<`output`\<`TInputSchema`\>, `output`\<`TOutputSchema`\>\>
+
+Defined in: [junior-plugin-api/src/tools.ts:251](https://github.com/getsentry/junior/blob/main/packages/junior-plugin-api/src/tools.ts#L251)
+
+Define a plugin tool with Zod input parsing and validated structured results.
+
+## Type Parameters
+
+### TInputSchema
+
+`TInputSchema` _extends_ `ZodType`\<`unknown`, `unknown`, `$ZodTypeInternals`\<`unknown`, `unknown`\>\>
+
+### TOutputSchema
+
+`TOutputSchema` _extends_ `ZodType`\<\{\[`key`: `string`\]: `unknown`; `continuation?`: \{ `arguments`: `Record`\<`string`, `unknown`\>; `reason?`: `string`; \}; `data?`: `unknown`; `error?`: `string` \| \{ `kind`: `string`; `message`: `string`; `retryable?`: `boolean`; \}; `ok`: `boolean`; `status`: `"error"` \| `"success"`; `target?`: `string`; `truncated?`: `boolean`; \}, `unknown`, `$ZodTypeInternals`\<\{\[`key`: `string`\]: `unknown`; `continuation?`: \{ `arguments`: `Record`\<`string`, `unknown`\>; `reason?`: `string`; \}; `data?`: `unknown`; `error?`: `string` \| \{ `kind`: `string`; `message`: `string`; `retryable?`: `boolean`; \}; `ok`: `boolean`; `status`: `"error"` \| `"success"`; `target?`: `string`; `truncated?`: `boolean`; \}, `unknown`\>\>
+
+## Parameters
+
+### definition
+
+`ZodPluginToolDefinition`\<`TInputSchema`, `TOutputSchema`\>
+
+## Returns
+
+`PluginToolDefinition`\<`output`\<`TInputSchema`\>, `output`\<`TOutputSchema`\>\>

--- a/packages/junior-plugin-api/src/tools.ts
+++ b/packages/junior-plugin-api/src/tools.ts
@@ -134,6 +134,11 @@ export interface PluginToolDefinition<TInput = unknown, TOutput = unknown> {
   executionMode?: unknown;
   inputSchema: unknown;
   outputSchema?: unknown;
+  /**
+   * Select result fields that are safe to retain in private traces.
+   * Returning `undefined` suppresses private result capture.
+   */
+  privateTraceResult?(result: TOutput): unknown;
   prepareArguments?: (args: unknown) => unknown;
   /**
    * @deprecated Put tool-selection and usage guidance directly in `description`
@@ -191,14 +196,12 @@ function parsePluginToolInput<TInputSchema extends ZodTypeAny>(
   return result.data;
 }
 
-/**
- * Define a plugin tool with Zod input parsing and the structured result contract.
- */
-export function definePluginTool<
+function createZodTool<
   TInputSchema extends ZodTypeAny,
   TOutputSchema extends ZodType<PluginToolResult>,
 >(
   definition: ZodPluginToolDefinition<TInputSchema, TOutputSchema>,
+  helperName: "definePluginTool" | "zodTool",
 ): PluginToolDefinition<z.output<TInputSchema>, z.output<TOutputSchema>> {
   const { inputSchema, outputSchema, prepareArguments, execute, ...tool } =
     definition;
@@ -208,7 +211,7 @@ export function definePluginTool<
     modelInputSchema = z.toJSONSchema(inputSchema);
   } catch (error) {
     throw new TypeError(
-      "definePluginTool() inputSchema must be representable as JSON Schema.",
+      `${helperName}() inputSchema must be representable as JSON Schema.`,
       { cause: error },
     );
   }
@@ -216,7 +219,7 @@ export function definePluginTool<
     modelOutputSchema = z.toJSONSchema(outputSchema);
   } catch (error) {
     throw new TypeError(
-      "definePluginTool() outputSchema must be representable as JSON Schema.",
+      `${helperName}() outputSchema must be representable as JSON Schema.`,
       { cause: error },
     );
   }
@@ -242,6 +245,26 @@ export function definePluginTool<
         }
       : {}),
   };
+}
+
+/** Define a plugin tool with Zod input parsing and validated structured results. */
+export function zodTool<
+  TInputSchema extends ZodTypeAny,
+  TOutputSchema extends ZodType<PluginToolResult>,
+>(
+  definition: ZodPluginToolDefinition<TInputSchema, TOutputSchema>,
+): PluginToolDefinition<z.output<TInputSchema>, z.output<TOutputSchema>> {
+  return createZodTool(definition, "zodTool");
+}
+
+/** Define a plugin tool with Zod input parsing and the structured result contract. */
+export function definePluginTool<
+  TInputSchema extends ZodTypeAny,
+  TOutputSchema extends ZodType<PluginToolResult>,
+>(
+  definition: ZodPluginToolDefinition<TInputSchema, TOutputSchema>,
+): PluginToolDefinition<z.output<TInputSchema>, z.output<TOutputSchema>> {
+  return createZodTool(definition, "definePluginTool");
 }
 
 export interface SlackToolRegistrationHookContext {

--- a/packages/junior/src/api-reference.ts
+++ b/packages/junior/src/api-reference.ts
@@ -21,6 +21,7 @@ export {
   definePluginTool,
   pluginRunContextSchema,
   pluginRunTranscriptEntrySchema,
+  zodTool,
 } from "@sentry/junior-plugin-api";
 export { createJuniorReporting } from "./reporting";
 export type {

--- a/packages/junior/src/chat/sentry-payload-filter.ts
+++ b/packages/junior/src/chat/sentry-payload-filter.ts
@@ -1,4 +1,5 @@
 import { getCurrentConversationPrivacy } from "@/chat/conversation-privacy";
+import { consumePrivateTraceResultMarker } from "@/chat/tool-support/private-trace-result";
 import type * as Sentry from "@/chat/sentry";
 
 type AttributeMap = Record<string, unknown>;
@@ -47,10 +48,21 @@ function scrubPayloadAttributes(attributes: AttributeMap | undefined): void {
     return;
   }
 
+  const preserveProjectedToolResult =
+    consumePrivateTraceResultMarker(attributes);
+  let redacted = false;
   for (const key of PAYLOAD_ATTRIBUTE_KEYS) {
+    if (key === "gen_ai.tool.call.result" && preserveProjectedToolResult) {
+      continue;
+    }
+    if (key in attributes) {
+      redacted = true;
+    }
     delete attributes[key];
   }
-  attributes["app.conversation.payload_redacted"] = true;
+  if (redacted) {
+    attributes["app.conversation.payload_redacted"] = true;
+  }
 }
 
 function scrubContainer(container: AttributeContainer | undefined): void {

--- a/packages/junior/src/chat/tool-support/pi-tool-adapter.ts
+++ b/packages/junior/src/chat/tool-support/pi-tool-adapter.ts
@@ -24,6 +24,7 @@ import type { SandboxExecutor } from "@/chat/sandbox/sandbox";
 import type { SkillSandbox } from "@/chat/sandbox/skill-sandbox";
 import type { AnyToolDefinition } from "@/chat/tools/definition";
 import type { ToolExecutionReport } from "@/chat/tool-support/tool-execution-report";
+import { privateTraceResultAttributes } from "@/chat/tool-support/private-trace-result";
 import {
   prepareCatalogToolCall,
   resolveCatalogToolCall,
@@ -73,9 +74,12 @@ export function createPiAgentTools(
   visibleTools[EXECUTE_TOOL_NAME] = createExecuteToolTool();
   const shouldTrace = shouldEmitDevAgentTrace();
   const effectiveConversationPrivacy = conversationPrivacy ?? "private";
-  const serializeToolPayload = (payload: unknown) =>
+  const serializeToolPayload = (
+    payload: unknown,
+    options: { exposePrivate?: boolean } = {},
+  ) =>
     serializeGenAiAttribute(
-      effectiveConversationPrivacy === "private"
+      effectiveConversationPrivacy === "private" && !options.exposePrivate
         ? toGenAiPayloadMetadata(payload)
         : payload,
     );
@@ -164,10 +168,43 @@ export function createPiAgentTools(
       resultAttributeValue = (normalized.details as { rawResult: unknown })
         .rawResult;
     }
-    const toolResultAttribute = serializeToolPayload(resultAttributeValue);
+    let projectedPrivateResult: unknown;
+    let hasProjectedPrivateResult = false;
+    if (
+      effectiveConversationPrivacy === "private" &&
+      toolDef.privateTraceResult
+    ) {
+      try {
+        projectedPrivateResult =
+          toolDef.privateTraceResult(resultAttributeValue);
+        hasProjectedPrivateResult = projectedPrivateResult !== undefined;
+      } catch (error) {
+        logWarn(
+          "tool_private_trace_projection_failed",
+          spanContext,
+          {
+            "error.type": error instanceof Error ? error.name : typeof error,
+            "gen_ai.tool.name": toolName,
+          },
+          "Tool private trace projection failed",
+        );
+      }
+    }
+    const toolResultAttribute =
+      effectiveConversationPrivacy === "private" &&
+      toolDef.privateTraceResult &&
+      !hasProjectedPrivateResult
+        ? undefined
+        : serializeToolPayload(
+            hasProjectedPrivateResult
+              ? projectedPrivateResult
+              : resultAttributeValue,
+            { exposePrivate: hasProjectedPrivateResult },
+          );
     if (toolResultAttribute) {
       setSpanAttributes({
         "gen_ai.tool.call.result": toolResultAttribute,
+        ...(hasProjectedPrivateResult ? privateTraceResultAttributes() : {}),
         ...toGenAiPayloadTraceAttributes(
           "app.ai.tool.call.result",
           resultAttributeValue,
@@ -226,10 +263,19 @@ export function createPiAgentTools(
 
           try {
             if (toolName === EXECUTE_TOOL_NAME) {
-              const catalogCall = prepareCatalogToolCall(
-                resolveCatalogToolCall(parsed, plannedTools.catalogTools),
+              const resolvedCatalogCall = resolveCatalogToolCall(
+                parsed,
+                plannedTools.catalogTools,
               );
-              executionToolName = catalogCall.toolName;
+              executionToolName = resolvedCatalogCall.toolName;
+              executionParams = resolvedCatalogCall.arguments;
+              setSpanAttributes({
+                "app.ai.tool.dispatcher.name": EXECUTE_TOOL_NAME,
+                "gen_ai.tool.description":
+                  resolvedCatalogCall.definition.description,
+                "gen_ai.tool.name": resolvedCatalogCall.toolName,
+              });
+              const catalogCall = prepareCatalogToolCall(resolvedCatalogCall);
               executionParams = catalogCall.arguments;
               await reportStatus(executionToolName, executionParams);
               return await executeDefinition({

--- a/packages/junior/src/chat/tool-support/private-trace-result.ts
+++ b/packages/junior/src/chat/tool-support/private-trace-result.ts
@@ -1,0 +1,19 @@
+import { randomUUID } from "node:crypto";
+
+const PRIVATE_TRACE_RESULT_ATTRIBUTE = "app.ai.tool.call.result.exposure";
+const privateTraceResultToken = randomUUID();
+
+/** Mark one tool result as an adapter-approved private trace projection. */
+export function privateTraceResultAttributes(): Record<string, string> {
+  return { [PRIVATE_TRACE_RESULT_ATTRIBUTE]: privateTraceResultToken };
+}
+
+/** Consume and remove the adapter-owned private trace projection marker. */
+export function consumePrivateTraceResultMarker(
+  attributes: Record<string, unknown>,
+): boolean {
+  const projected =
+    attributes[PRIVATE_TRACE_RESULT_ATTRIBUTE] === privateTraceResultToken;
+  delete attributes[PRIVATE_TRACE_RESULT_ATTRIBUTE];
+  return projected;
+}

--- a/packages/junior/src/chat/tool-support/zod-tool.ts
+++ b/packages/junior/src/chat/tool-support/zod-tool.ts
@@ -39,6 +39,7 @@ type StructuredZodToolDefinition<
   TOutputSchema extends ZodType<JuniorToolResult>,
 > = ZodToolDefinitionBase<TInputSchema> & {
   outputSchema: TOutputSchema;
+  privateTraceResult?(result: z.output<TOutputSchema>): unknown;
   execute?: (
     input: z.output<TInputSchema>,
     options: ToolExecuteOptions,

--- a/packages/junior/src/chat/tools/definition.ts
+++ b/packages/junior/src/chat/tools/definition.ts
@@ -36,6 +36,7 @@ interface BaseToolDefinition<TInput, TInputSchema extends ToolInputSchema> {
   exposure?: ToolExposure;
   inputSchema: TInputSchema;
   outputSchema?: ToolInputSchema;
+  privateTraceResult?(result: unknown): unknown;
   annotations?: ToolAnnotations;
   /**
    * @deprecated Put tool-selection and usage guidance directly in `description`
@@ -80,6 +81,7 @@ export interface AnyToolDefinition {
   exposure?: ToolExposure;
   inputSchema: ToolInputSchema;
   outputSchema?: ToolInputSchema;
+  privateTraceResult?(result: unknown): unknown;
   annotations?: ToolAnnotations;
   /**
    * @deprecated Put tool-selection and usage guidance directly in `description`

--- a/packages/junior/src/chat/tools/search-tools.ts
+++ b/packages/junior/src/chat/tools/search-tools.ts
@@ -349,6 +349,13 @@ export function createSearchToolsTool(
       })
       .strict(),
     outputSchema: searchToolsOutputSchema,
+    privateTraceResult: (result) => ({
+      tools: result.tools.map(({ tool_name, description, input_schema }) => ({
+        tool_name,
+        description,
+        input_schema,
+      })),
+    }),
     execute: async ({ query, source, max_results }) => {
       const maxResults = max_results ?? DEFAULT_MAX_RESULTS;
       const requestedSource = source ?? null;

--- a/packages/junior/src/chat/tools/skill/search-mcp-tools.ts
+++ b/packages/junior/src/chat/tools/skill/search-mcp-tools.ts
@@ -259,6 +259,16 @@ export function createSearchMcpToolsTool(mcpToolManager: SearchMcpToolManager) {
       })
       .strict(),
     outputSchema: searchMcpToolsOutputSchema,
+    privateTraceResult: (result) => ({
+      ok: result.ok,
+      status: result.status,
+      total_active_tools: result.total_active_tools,
+      returned_tools: result.returned_tools,
+      execution_tool: result.execution_tool,
+      execution_example: result.execution_example,
+      available_providers: result.available_providers,
+      tools: result.tools,
+    }),
     execute: async ({ query, provider, max_results }) => {
       if (provider) {
         await mcpToolManager.activateProvider(provider);

--- a/packages/junior/src/chat/tools/system-time.ts
+++ b/packages/junior/src/chat/tools/system-time.ts
@@ -2,13 +2,28 @@ import { z } from "zod";
 import { juniorToolResultSchema } from "@/chat/tool-support/structured-result";
 import { zodTool } from "@/chat/tool-support/zod-tool";
 
+const systemTimeOutputSchema = juniorToolResultSchema.extend({
+  unix_ms: z.number(),
+  iso_utc: z.string(),
+  iso_local: z.string(),
+  timezone_offset_minutes: z.number(),
+});
+
 export function createSystemTimeTool() {
   return zodTool({
     description:
       "Return current system time in UTC and local ISO formats. Use when the user asks for current time/date context. Do not use as a substitute for historical or timezone-conversion research.",
     annotations: { readOnlyHint: true, destructiveHint: false },
     inputSchema: z.object({}),
-    outputSchema: juniorToolResultSchema,
+    outputSchema: systemTimeOutputSchema,
+    privateTraceResult: (result) => ({
+      ok: result.ok,
+      status: result.status,
+      unix_ms: result.unix_ms,
+      iso_utc: result.iso_utc,
+      iso_local: result.iso_local,
+      timezone_offset_minutes: result.timezone_offset_minutes,
+    }),
     execute: async () => {
       const now = new Date();
       const details = {

--- a/packages/junior/tests/component/tool-support/pi-tool-adapter.test.ts
+++ b/packages/junior/tests/component/tool-support/pi-tool-adapter.test.ts
@@ -5,12 +5,20 @@ import { SkillSandbox } from "@/chat/sandbox/skill-sandbox";
 import { createPiAgentTools } from "@/chat/tool-support/pi-tool-adapter";
 import { createReportProgressTool } from "@/chat/tools/runtime/report-progress";
 import { createBashTool } from "@/chat/tools/sandbox/bash";
+import { tool } from "@/chat/tools/definition";
 import type { Skill } from "@/chat/skills";
+import { Type } from "@sinclair/typebox";
 
-const { handleToolExecutionError } = vi.hoisted(() => ({
+const { handleToolExecutionError, setSpanAttributes } = vi.hoisted(() => ({
   handleToolExecutionError: vi.fn((error: unknown) => {
     throw error;
   }),
+  setSpanAttributes: vi.fn(),
+}));
+
+vi.mock("@/chat/logging", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/chat/logging")>()),
+  setSpanAttributes,
 }));
 
 vi.mock("@/chat/tools/execution/tool-error-handler", () => ({
@@ -29,6 +37,7 @@ const githubSkill: Skill = {
 describe("Pi tool adapter", () => {
   beforeEach(() => {
     handleToolExecutionError.mockClear();
+    setSpanAttributes.mockClear();
   });
 
   it("emits assistant status only for reportProgress", async () => {
@@ -85,6 +94,204 @@ describe("Pi tool adapter", () => {
     expect(onStatus).toHaveBeenCalledTimes(1);
     expect(onStatus).toHaveBeenCalledWith({
       text: "Reviewing catalog execution",
+    });
+  });
+
+  it("reports the resolved catalog tool name for executeTool", async () => {
+    const tools = createPiAgentTools(
+      {
+        catalogDemo: tool({
+          description: "Catalog demo",
+          exposure: "deferred",
+          inputSchema: Type.Object({}),
+          execute: async () => ({ ok: true }),
+        }),
+      },
+      new SkillSandbox([], []),
+      {},
+    );
+    const executeTool = tools.find(
+      (candidate) => candidate.name === "executeTool",
+    );
+
+    await executeTool!.execute("tool-catalog", {
+      tool_name: "catalogDemo",
+      arguments: {},
+    });
+
+    expect(setSpanAttributes).toHaveBeenCalledWith({
+      "app.ai.tool.dispatcher.name": "executeTool",
+      "gen_ai.tool.description": "Catalog demo",
+      "gen_ai.tool.name": "catalogDemo",
+    });
+  });
+
+  it("traces projected searchTools catalog data without its private query", async () => {
+    const tools = createPiAgentTools(
+      {
+        catalogDemo: tool({
+          description: "Catalog demo",
+          exposure: "deferred",
+          inputSchema: Type.Object({ account: Type.String() }),
+          execute: async () => ({ ok: true }),
+        }),
+      },
+      new SkillSandbox([], []),
+      {},
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "private",
+    );
+    const searchTools = tools.find(
+      (candidate) => candidate.name === "searchTools",
+    );
+
+    await searchTools!.execute("tool-search", {
+      query: "account",
+    });
+
+    const resultAttributes = setSpanAttributes.mock.calls
+      .map(([attributes]) => attributes as Record<string, unknown>)
+      .find((attributes) => "gen_ai.tool.call.result" in attributes);
+    const tracedResult = JSON.parse(
+      resultAttributes?.["gen_ai.tool.call.result"] as string,
+    );
+
+    expect(tracedResult.tools).toEqual([
+      expect.objectContaining({ tool_name: "catalogDemo" }),
+    ]);
+    expect(tracedResult).not.toHaveProperty("query");
+    expect(tracedResult).not.toHaveProperty("data");
+  });
+
+  it("suppresses private result capture when projection returns undefined", async () => {
+    const tools = createPiAgentTools(
+      {
+        safeDemo: {
+          description: "Safe demo",
+          inputSchema: Type.Object({}),
+          privateTraceResult: () => undefined,
+          execute: async () => ({ ok: true, secret: "private" }),
+        },
+      },
+      new SkillSandbox([], []),
+      {},
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "private",
+    );
+
+    await tools
+      .find((candidate) => candidate.name === "safeDemo")!
+      .execute("tool-safe", {});
+
+    expect(
+      setSpanAttributes.mock.calls.some(
+        ([attributes]) => "gen_ai.tool.call.result" in attributes,
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps tool execution successful when private projection throws", async () => {
+    const tools = createPiAgentTools(
+      {
+        safeDemo: {
+          description: "Safe demo",
+          inputSchema: Type.Object({}),
+          privateTraceResult() {
+            throw new TypeError("projection failed");
+          },
+          execute: async () => ({ ok: true, secret: "private" }),
+        },
+      },
+      new SkillSandbox([], []),
+      {},
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "private",
+    );
+
+    await expect(
+      tools
+        .find((candidate) => candidate.name === "safeDemo")!
+        .execute("tool-safe", {}),
+    ).resolves.toMatchObject({ details: { ok: true } });
+    expect(
+      setSpanAttributes.mock.calls.some(
+        ([attributes]) => "gen_ai.tool.call.result" in attributes,
+      ),
+    ).toBe(false);
+  });
+
+  it("records the full public result without invoking its private projector", async () => {
+    const privateTraceResult = vi.fn(() => ({ visible: "projected" }));
+    const tools = createPiAgentTools(
+      {
+        safeDemo: {
+          description: "Safe demo",
+          inputSchema: Type.Object({}),
+          privateTraceResult,
+          execute: async () => ({ ok: true, secret: "public result" }),
+        },
+      },
+      new SkillSandbox([], []),
+      {},
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "public",
+    );
+
+    await tools
+      .find((candidate) => candidate.name === "safeDemo")!
+      .execute("tool-safe", {});
+
+    const resultAttributes = setSpanAttributes.mock.calls
+      .map(([attributes]) => attributes as Record<string, unknown>)
+      .find((attributes) => "gen_ai.tool.call.result" in attributes);
+    expect(privateTraceResult).not.toHaveBeenCalled();
+    expect(
+      JSON.parse(resultAttributes?.["gen_ai.tool.call.result"] as string),
+    ).toMatchObject({ secret: "public result" });
+  });
+
+  it("reports resolved tool identity when catalog preparation fails", async () => {
+    const tools = createPiAgentTools(
+      {
+        catalogDemo: tool({
+          description: "Catalog demo",
+          exposure: "deferred",
+          inputSchema: Type.Object({}),
+          prepareArguments() {
+            throw new Error("preparation failed");
+          },
+          execute: async () => ({ ok: true }),
+        }),
+      },
+      new SkillSandbox([], []),
+      {},
+    );
+
+    await expect(
+      tools
+        .find((candidate) => candidate.name === "executeTool")!
+        .execute("tool-catalog", { tool_name: "catalogDemo", arguments: {} }),
+    ).rejects.toThrow("preparation failed");
+    expect(setSpanAttributes).toHaveBeenCalledWith({
+      "app.ai.tool.dispatcher.name": "executeTool",
+      "gen_ai.tool.description": "Catalog demo",
+      "gen_ai.tool.name": "catalogDemo",
     });
   });
 

--- a/packages/junior/tests/integration/tool-support/pi-tool-adapter.test.ts
+++ b/packages/junior/tests/integration/tool-support/pi-tool-adapter.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   createLocalSource,
-  definePluginTool,
   defineJuniorPlugin,
   pluginToolResultSchema,
+  zodTool,
 } from "@sentry/junior-plugin-api";
 import { Type } from "@sinclair/typebox";
 import { z } from "zod";
@@ -12,6 +12,15 @@ import { SkillSandbox } from "@/chat/sandbox/skill-sandbox";
 import { createTools } from "@/chat/tools";
 import { createPiAgentTools } from "@/chat/tool-support/pi-tool-adapter";
 import { tool, type AnyToolDefinition } from "@/chat/tools/definition";
+
+const { setSpanAttributes } = vi.hoisted(() => ({
+  setSpanAttributes: vi.fn(),
+}));
+
+vi.mock("@/chat/logging", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/chat/logging")>()),
+  setSpanAttributes,
+}));
 
 const customerResultSchema = pluginToolResultSchema.extend({
   ok: z.literal(true),
@@ -65,7 +74,7 @@ describe("Pi tool adapter integration", () => {
         hooks: {
           tools() {
             return {
-              lookupCustomer: definePluginTool({
+              lookupCustomer: zodTool({
                 description: "Lookup customer health for account review.",
                 inputSchema: z.object({
                   customerId: z
@@ -74,6 +83,10 @@ describe("Pi tool adapter integration", () => {
                     .describe("Customer identifier to inspect."),
                 }),
                 outputSchema: customerResultSchema,
+                privateTraceResult: (result) => ({
+                  customer_id: result.customer_id,
+                  status: result.status,
+                }),
                 prepareArguments: (args) => {
                   const input = args as Record<string, unknown>;
                   return typeof input.customer_id === "string"
@@ -108,6 +121,8 @@ describe("Pi tool adapter integration", () => {
         undefined,
         undefined,
         onToolCall,
+        undefined,
+        "private",
       );
 
       expect(registry.agentDemo_lookupCustomer?.exposure).toBe("deferred");
@@ -139,6 +154,7 @@ describe("Pi tool adapter integration", () => {
         ],
       });
 
+      setSpanAttributes.mockClear();
       const executeResult = await agentTool(tools, "executeTool").execute(
         "tool-execute",
         {
@@ -160,6 +176,12 @@ describe("Pi tool adapter integration", () => {
       expect(onToolCall).toHaveBeenCalledWith("agentDemo_lookupCustomer", {
         customerId: "C123",
       });
+      const resultAttributes = setSpanAttributes.mock.calls
+        .map(([attributes]) => attributes as Record<string, unknown>)
+        .find((attributes) => "gen_ai.tool.call.result" in attributes);
+      expect(
+        JSON.parse(resultAttributes?.["gen_ai.tool.call.result"] as string),
+      ).toEqual({ customer_id: "C123", status: "success" });
     } finally {
       setPlugins(previousPlugins);
     }

--- a/packages/junior/tests/unit/plugins/define-plugin-tool.test.ts
+++ b/packages/junior/tests/unit/plugins/define-plugin-tool.test.ts
@@ -3,6 +3,7 @@ import {
   definePluginTool,
   PluginToolInputError,
   pluginToolResultSchema,
+  zodTool,
 } from "@sentry/junior-plugin-api";
 import { z } from "zod";
 
@@ -78,6 +79,26 @@ describe("definePluginTool", () => {
     expect(() => tool.prepareArguments?.({ rawName: " " })).toThrow(
       "Invalid tool arguments: name:",
     );
+  });
+
+  it("exposes zodTool with typed private trace projection", async () => {
+    const tool = zodTool({
+      description: "Project plugin result.",
+      inputSchema: z.object({}),
+      outputSchema: countResultSchema,
+      privateTraceResult: (result) => ({ count: result.count }),
+      execute: async () => ({
+        ok: true as const,
+        status: "success" as const,
+        count: 3,
+        data: { count: 3 },
+      }),
+    });
+
+    const input = tool.prepareArguments?.({});
+    const result = await tool.execute?.(input as Record<string, never>, {});
+
+    expect(tool.privateTraceResult?.(result!)).toEqual({ count: 3 });
   });
 
   it("rejects parser schemas that cannot be represented as JSON Schema", () => {

--- a/packages/junior/tests/unit/sentry-payload-filter.test.ts
+++ b/packages/junior/tests/unit/sentry-payload-filter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { runWithConversationPrivacy } from "@/chat/conversation-privacy";
+import { privateTraceResultAttributes } from "@/chat/tool-support/private-trace-result";
 import {
   scrubPrivateSentryLog,
   scrubPrivateSentrySpan,
@@ -80,6 +81,78 @@ describe("Sentry private payload filtering", () => {
 
     expect(log.attributes?.["gen_ai.tool.call.arguments"]).toBeUndefined();
     expect(log.attributes?.["app.conversation.payload_redacted"]).toBe(true);
+  });
+
+  it("preserves explicitly projected private tool results", () => {
+    const projectedResult = JSON.stringify({ tools: ["safeTool"] });
+    const span = {
+      attributes: {
+        "gen_ai.tool.call.arguments": JSON.stringify({
+          query: "private search",
+        }),
+        "gen_ai.tool.call.result": projectedResult,
+        ...privateTraceResultAttributes(),
+      },
+      end_timestamp: 2,
+      is_segment: false,
+      name: "execute_tool searchTools",
+      span_id: "span",
+      start_timestamp: 1,
+      status: "ok",
+      trace_id: "trace",
+    } as SentrySpan;
+
+    runWithConversationPrivacy("private", () => scrubPrivateSentrySpan(span));
+
+    expect(span.attributes?.["gen_ai.tool.call.arguments"]).toBeUndefined();
+    expect(span.attributes?.["gen_ai.tool.call.result"]).toBe(projectedResult);
+    expect(span.attributes?.["app.conversation.payload_redacted"]).toBe(true);
+    expect(span.attributes).not.toHaveProperty(
+      "app.ai.tool.call.result.exposure",
+    );
+  });
+
+  it("redacts private results with a forged projection marker", () => {
+    const span = {
+      attributes: {
+        "gen_ai.tool.call.result": JSON.stringify({ secret: "private" }),
+        "app.ai.tool.call.result.exposure": "projected",
+      },
+      end_timestamp: 2,
+      is_segment: false,
+      name: "execute_tool unsafeTool",
+      span_id: "span",
+      start_timestamp: 1,
+      status: "ok",
+      trace_id: "trace",
+    } as SentrySpan;
+
+    runWithConversationPrivacy("private", () => scrubPrivateSentrySpan(span));
+
+    expect(span.attributes?.["gen_ai.tool.call.result"]).toBeUndefined();
+    expect(span.attributes).not.toHaveProperty(
+      "app.ai.tool.call.result.exposure",
+    );
+  });
+
+  it("redacts unmarked private tool results", () => {
+    const span = {
+      attributes: {
+        "gen_ai.tool.call.result": JSON.stringify({ secret: "private" }),
+      },
+      end_timestamp: 2,
+      is_segment: false,
+      name: "execute_tool unsafeTool",
+      span_id: "span",
+      start_timestamp: 1,
+      status: "ok",
+      trace_id: "trace",
+    } as SentrySpan;
+
+    runWithConversationPrivacy("private", () => scrubPrivateSentrySpan(span));
+
+    expect(span.attributes?.["gen_ai.tool.call.result"]).toBeUndefined();
+    expect(span.attributes?.["app.conversation.payload_redacted"]).toBe(true);
   });
 
   it("uses the current conversation privacy for transaction child spans", () => {

--- a/packages/junior/tests/unit/tool-support/zod-tool.test.ts
+++ b/packages/junior/tests/unit/tool-support/zod-tool.test.ts
@@ -39,6 +39,31 @@ describe("zodTool", () => {
     expect(execute).toHaveBeenCalledWith({ count: 3 }, {});
   });
 
+  it("preserves a typed private trace result projector", async () => {
+    const resultSchema = juniorToolResultSchema.extend({
+      visible: z.string(),
+      secret: z.string(),
+    });
+    const tool = zodTool({
+      description: "Return projected details.",
+      inputSchema: z.object({}),
+      outputSchema: resultSchema,
+      privateTraceResult: (result) => ({ visible: result.visible }),
+      execute: async () => ({
+        ok: true,
+        status: "success" as const,
+        visible: "catalog metadata",
+        secret: "private value",
+      }),
+    });
+
+    const result = await tool.execute?.(tool.prepareArguments!({}), {});
+
+    expect(tool.privateTraceResult?.(result)).toEqual({
+      visible: "catalog metadata",
+    });
+  });
+
   it("converts input parse failures into ToolInputError", () => {
     const tool = zodTool({
       description: "Count things.",

--- a/packages/junior/tests/unit/tools/search-mcp-tools.test.ts
+++ b/packages/junior/tests/unit/tools/search-mcp-tools.test.ts
@@ -65,11 +65,22 @@ describe("searchMcpTools", () => {
       { query: "issue title", max_results: 1 },
       {},
     )) as {
+      ok: boolean;
+      status: "success" | "error";
+      query: string | null;
+      provider: string | null;
+      total_active_tools: number;
+      returned_tools: number;
       execution_tool: string;
       execution_example: {
         tool_name: string;
         arguments: Record<string, string>;
       };
+      available_providers: Array<{
+        provider: string;
+        description: string;
+        active: boolean;
+      }>;
       tools: Array<{
         tool_name: string;
         signature: string;
@@ -92,6 +103,17 @@ describe("searchMcpTools", () => {
           "<argument>": "<value from input_schema>",
         },
       },
+    });
+    const privateTraceResult = searchMcpTools.privateTraceResult?.(result);
+    expect(privateTraceResult).toEqual({
+      ok: result.ok,
+      status: result.status,
+      total_active_tools: result.total_active_tools,
+      returned_tools: result.returned_tools,
+      execution_tool: result.execution_tool,
+      execution_example: result.execution_example,
+      available_providers: result.available_providers,
+      tools: result.tools,
     });
     expect(result.tools).toHaveLength(1);
     expect(result.tools[0]).toMatchObject({

--- a/packages/junior/tests/unit/tools/search-tools.test.ts
+++ b/packages/junior/tests/unit/tools/search-tools.test.ts
@@ -141,6 +141,17 @@ describe("searchTools", () => {
       ],
     });
 
+    const privateTraceResult = searchTools.privateTraceResult?.(result);
+    expect(privateTraceResult).toEqual({
+      tools: [
+        {
+          tool_name: "agentDemo_lookupCustomer",
+          description: "Lookup customer health for account review.",
+          input_schema: result.tools[0]?.input_schema,
+        },
+      ],
+    });
+
     const directResult = await searchTools.execute!({ query: "shell" }, {});
     expect(directResult).toMatchObject({
       returned_tools: 1,

--- a/packages/junior/tests/unit/tools/system-time.test.ts
+++ b/packages/junior/tests/unit/tools/system-time.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { createSystemTimeTool } from "@/chat/tools/system-time";
+
+describe("systemTime", () => {
+  it("projects only its stable time fields into private traces", async () => {
+    const systemTime = createSystemTimeTool();
+    const result = await systemTime.execute!(
+      systemTime.prepareArguments!({}),
+      {},
+    );
+
+    expect(systemTime.privateTraceResult?.(result)).toEqual({
+      ok: true,
+      status: "success",
+      unix_ms: result.unix_ms,
+      iso_utc: result.iso_utc,
+      iso_local: result.iso_local,
+      timezone_offset_minutes: result.timezone_offset_minutes,
+    });
+  });
+});

--- a/policies/tool-design.md
+++ b/policies/tool-design.md
@@ -47,6 +47,10 @@ contradictory or unsafe requests.
   provider schema such as an MCP `outputSchema` as the Junior Zod helper's
   structured result schema unless the Junior wrapper itself owns that result
   contract.
+- Structured tools may declare `privateTraceResult` when part of their validated
+  result is safe to retain in private traces. The projector must select only
+  static, public, or otherwise non-conversation data. Omission keeps the default
+  metadata-only behavior; returning `undefined` records no private result.
 - Keep reusable tool infrastructure in a `tool-support` module or another
   non-`tools` module owned by that package. In the host runtime this is
   `packages/junior/src/chat/tool-support`; plugin packages should follow the

--- a/specs/data-redaction-policy.md
+++ b/specs/data-redaction-policy.md
@@ -118,6 +118,14 @@ Tool execution spans in private conversations must not set raw
 `gen_ai.tool.call.arguments` or raw `gen_ai.tool.call.result`. They may set
 bounded `app.ai.tool.*` metadata such as type, size, and top-level keys.
 
+Tools may explicitly project a result that is safe to retain in private traces.
+The projection must contain only static, public, or otherwise non-conversation
+data selected by the tool owner. The runtime marks projected results before the
+final Sentry payload filter preserves them. Tool arguments, user-authored search
+queries and provider selectors, provider execution responses, credentials, and
+unprojected result fields remain subject to normal private-conversation
+redaction. Static MCP provider and tool catalog metadata may be projected.
+
 Enclosing workflow/agent spans should include `app.conversation.privacy` when
 the runtime can derive it. Child GenAI spans may inherit that trace context and
 must still apply the same capture policy even when they do not repeat the
@@ -130,8 +138,10 @@ attribute.
 - Public dashboard conversation APIs may return raw transcript content while the
   session-log entry is still present.
 - Private GenAI capture tests prove raw message content is not exposed.
-- Tool execution tests prove private tool arguments, results, and MCP error
-  payloads are not exposed through reporting or telemetry capture paths.
+- Tool execution tests prove private tool arguments, raw or unprojected results,
+  and MCP error payloads are not exposed through reporting or telemetry capture
+  paths, while only explicitly projected result fields survive the final
+  payload filter.
 - Unknown conversation ids are treated as private.
 - Conversations Slack reports as private (`channel_type: group` or
   `is_private: true`) are classified private regardless of a `C` id prefix.


### PR DESCRIPTION
Private traces can now retain tool-selected result projections instead of redacting every tool payload. Host and plugin tools opt in with `privateTraceResult`, including tools created through the new plugin-facing `zodTool()` helper, while the payload scrubber only preserves adapter-approved projections.

`searchTools` exposes only each tool's name, description, and input schema. `searchMcpTools` exposes its complete current catalog response, including provider summaries, execution hints, and full tool descriptors; only the echoed query/provider request context and redundant `data` copy remain redacted. `executeTool` also records the resolved catalog tool name even when argument preparation fails.

Fixes #794