### PR TITLE
fix(dashboard): Polish subagent transcript handling

### DIFF
--- a/packages/junior-dashboard/e2e/dashboard.spec.ts
+++ b/packages/junior-dashboard/e2e/dashboard.spec.ts
@@ -195,3 +195,39 @@ test("hydrates the built dashboard client in a real browser", async ({
   ).toBeVisible();
   expect(browserErrors).toEqual([]);
 });
+
+test("inspects and copies an advisor transcript", async ({ context, page }) => {
+  await context.grantPermissions(["clipboard-read", "clipboard-write"], {
+    origin: baseURL,
+  });
+  await page.goto(
+    `${baseURL}/conversations/${encodeURIComponent("internal:dashboard-qa")}`,
+  );
+
+  await expect(
+    page.getByRole("heading", { name: "Dashboard QA edge cases" }),
+  ).toBeVisible();
+  const subagentRow = page
+    .getByRole("button", { name: "Open advisor transcript" })
+    .first();
+  await expect(subagentRow).toHaveCSS("cursor", "pointer");
+  await subagentRow.click();
+
+  const drawer = page.getByRole("dialog");
+  await expect(drawer.getByRole("heading", { name: "advisor" })).toBeVisible();
+  await expect(drawer.getByText("Conversation ID")).toBeVisible();
+  const copy = drawer.getByRole("button", { name: "Copy as Markdown" });
+  await expect(copy).toBeEnabled();
+  await copy.click();
+  await expect(drawer.getByRole("button", { name: "Copied" })).toBeVisible();
+  const markdown = await page.evaluate(() => navigator.clipboard.readText());
+  expect(markdown).toContain("# advisor");
+  expect(markdown).toContain("Review the dashboard plan before editing.");
+  expect(markdown).toContain(
+    "Actor identity email is a reasonable profile key",
+  );
+
+  await page.setViewportSize({ height: 844, width: 390 });
+  await expect(drawer).toBeVisible();
+  await expect(drawer.getByRole("button", { name: "Copied" })).toBeVisible();
+});

--- a/packages/junior-dashboard/src/client/components/CopyMarkdownButton.tsx
+++ b/packages/junior-dashboard/src/client/components/CopyMarkdownButton.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+
+import { Button } from "./Button";
+
+/** Copy an available Markdown document while exposing clipboard result state. */
+export function CopyMarkdownButton(props: { getMarkdown?: () => string }) {
+  const [status, setStatus] = useState<"copied" | "failed" | "idle">("idle");
+  const label =
+    status === "copied"
+      ? "Copied"
+      : status === "failed"
+        ? "Copy failed"
+        : "Copy as Markdown";
+  const Icon = status === "copied" ? Check : Copy;
+
+  async function copyMarkdown() {
+    if (!props.getMarkdown) return;
+
+    try {
+      await navigator.clipboard.writeText(props.getMarkdown());
+      setStatus("copied");
+    } catch {
+      setStatus("failed");
+    }
+  }
+
+  return (
+    <Button
+      aria-label={label}
+      disabled={!props.getMarkdown}
+      onClick={() => void copyMarkdown()}
+      size="icon"
+      title={label}
+    >
+      <Icon aria-hidden="true" size={15} strokeWidth={2} />
+    </Button>
+  );
+}

--- a/packages/junior-dashboard/src/client/components/SubagentTranscriptDrawer.tsx
+++ b/packages/junior-dashboard/src/client/components/SubagentTranscriptDrawer.tsx
@@ -3,13 +3,19 @@ import { Bot, ExternalLink, X } from "lucide-react";
 
 import { useConversationSubagentTranscriptData } from "../api";
 import { formatMessageTimestamp, formatMs } from "../format";
+import { buildSubagentMarkdown } from "../markdownExport";
 import { cn } from "../styles";
+import {
+  subagentDurationMs,
+  subagentTranscriptTurn,
+} from "../subagentTranscript";
 import type {
   ConversationSubagentTranscript,
   ConversationTurn,
   TranscriptViewSubagentPart,
 } from "../types";
 import { Button } from "./Button";
+import { CopyMarkdownButton } from "./CopyMarkdownButton";
 import { Transcript } from "./Transcript";
 import { TranscriptLoading } from "./TranscriptLoading";
 import { transcriptEmptyClass } from "./transcriptStyles";
@@ -53,6 +59,9 @@ export function SubagentTranscriptDrawer(props: {
   const visible = report ?? subagentFallback(props.target);
   const label = visible.subagentKind;
   const duration = subagentDuration(visible);
+  const transcriptTurn = report
+    ? subagentTranscriptTurn(props.target.conversationId, report)
+    : undefined;
   const meta = [
     statusLabel(visible),
     duration,
@@ -89,14 +98,24 @@ export function SubagentTranscriptDrawer(props: {
                 </div>
               ) : null}
             </div>
-            <Button
-              aria-label="Close subagent transcript"
-              onClick={props.onClose}
-              size="icon"
-              title="Close"
-            >
-              <X aria-hidden="true" size={15} strokeWidth={2.25} />
-            </Button>
+            <div className="flex shrink-0 items-center gap-1.5">
+              <CopyMarkdownButton
+                key={`${props.target.part.id}:${report?.endedAt ?? "loading"}`}
+                getMarkdown={
+                  report?.transcriptAvailable && transcriptTurn
+                    ? () => buildSubagentMarkdown(report, transcriptTurn)
+                    : undefined
+                }
+              />
+              <Button
+                aria-label="Close subagent transcript"
+                onClick={props.onClose}
+                size="icon"
+                title="Close"
+              >
+                <X aria-hidden="true" size={15} strokeWidth={2.25} />
+              </Button>
+            </div>
           </div>
         </header>
         <div className="min-h-0 overflow-auto px-4 py-4 md:px-5">
@@ -106,8 +125,8 @@ export function SubagentTranscriptDrawer(props: {
             <DrawerEmptyState tone="error">
               Transcript failed to load.
             </DrawerEmptyState>
-          ) : report?.transcriptAvailable ? (
-            <Transcript turns={[subagentTurn(props.target, report)]} />
+          ) : report?.transcriptAvailable && transcriptTurn ? (
+            <Transcript turns={[transcriptTurn]} />
           ) : (
             <DrawerEmptyState>
               {subagentUnavailableLabel(report)}
@@ -171,55 +190,6 @@ function subagentFallback(
       ? { parentToolCallId: target.part.parentToolCallId }
       : {}),
   };
-}
-
-function subagentTurn(
-  target: SubagentTranscriptTarget,
-  report: ConversationSubagentTranscript,
-): ConversationTurn {
-  const status =
-    report.status === "running"
-      ? "active"
-      : report.status === "error" || report.status === "aborted"
-        ? "failed"
-        : "completed";
-
-  return {
-    conversationId: target.conversationId,
-    assistantLabel: report.subagentKind,
-    cumulativeDurationMs: subagentDurationMs(report) ?? 0,
-    displayTitle: report.subagentKind,
-    id: report.id,
-    lastProgressAt: report.endedAt ?? report.createdAt,
-    lastSeenAt: report.endedAt ?? report.createdAt,
-    startedAt: report.createdAt,
-    status,
-    surface: "internal",
-    transcript: report.transcript,
-    transcriptAvailable: report.transcriptAvailable,
-    ...(report.endedAt ? { completedAt: report.endedAt } : {}),
-    ...(report.transcriptMessageCount !== undefined
-      ? { transcriptMessageCount: report.transcriptMessageCount }
-      : {}),
-    ...(report.transcriptRedacted
-      ? { transcriptRedacted: report.transcriptRedacted }
-      : {}),
-    ...(report.transcriptRedactionReason
-      ? { transcriptRedactionReason: report.transcriptRedactionReason }
-      : {}),
-  };
-}
-
-function subagentDurationMs(
-  report: Pick<ConversationSubagentTranscript, "createdAt" | "endedAt">,
-): number | undefined {
-  if (!report.endedAt) return undefined;
-  const startedAt = Date.parse(report.createdAt);
-  const endedAt = Date.parse(report.endedAt);
-  if (!Number.isFinite(startedAt) || !Number.isFinite(endedAt)) {
-    return undefined;
-  }
-  return endedAt >= startedAt ? endedAt - startedAt : undefined;
 }
 
 function subagentDuration(

--- a/packages/junior-dashboard/src/client/components/TranscriptSubagentView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptSubagentView.tsx
@@ -65,7 +65,7 @@ export function TranscriptSubagentView(props: {
   return (
     <button
       aria-label={`Open ${props.part.subagentKind} transcript`}
-      className="block w-full min-w-0 text-left transition-colors hover:bg-white/[0.035] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[#beaaff]/55"
+      className="block w-full min-w-0 cursor-pointer text-left transition-colors hover:bg-white/[0.035] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[#beaaff]/55"
       onClick={() => props.onOpenTranscript?.(props.part)}
       type="button"
     >

--- a/packages/junior-dashboard/src/client/components/transcriptRenderModel.ts
+++ b/packages/junior-dashboard/src/client/components/transcriptRenderModel.ts
@@ -130,19 +130,35 @@ export function groupTranscriptParts(
   return grouped;
 }
 
+/** Pair exact IDs across event rows and unique name-only calls before a message boundary. */
 function findToolEntry(
   entries: RenderedTranscriptEntry[],
   result: TranscriptViewPart,
 ): RenderedToolCallEntry | undefined {
+  const nameCandidates: RenderedToolCallEntry[] = [];
+
   for (let index = entries.length - 1; index >= 0; index -= 1) {
     const entry = entries[index]!;
-    if (entry.kind !== "tool") return undefined;
+    if (entry.kind !== "tool") {
+      if (!result.id && entry.kind === "message") break;
+      continue;
+    }
     if (!isRenderedToolCallEntry(entry) || entry.result) continue;
-    if (sameToolInvocation(entry.call, result)) {
-      return entry;
+
+    if (result.id) {
+      if (sameToolInvocation(entry.call, result)) return entry;
+      continue;
+    }
+
+    if (entry.call.name && entry.call.name === result.name) {
+      nameCandidates.push(entry);
     }
   }
-  return undefined;
+
+  const [candidate] = nameCandidates;
+  return nameCandidates.length === 1 && !candidate?.call.id
+    ? candidate
+    : undefined;
 }
 
 /** Flatten message-local tool parts into turn-level events for scan-friendly rendering. */

--- a/packages/junior-dashboard/src/client/markdownExport.ts
+++ b/packages/junior-dashboard/src/client/markdownExport.ts
@@ -16,6 +16,7 @@ import { turnTranscriptMessages } from "./transcriptActivity";
 import type {
   Conversation,
   ConversationDetailFeed,
+  ConversationSubagentTranscript,
   ConversationTurn,
   TranscriptViewMessage,
   TranscriptViewPart,
@@ -52,6 +53,27 @@ export function buildConversationMarkdown(
     appendTurnTranscript(lines, turn);
   });
 
+  return finishMarkdown(lines);
+}
+
+/** Build Markdown for one child-agent transcript using the shared formatter. */
+export function buildSubagentMarkdown(
+  report: ConversationSubagentTranscript,
+  turn: ConversationTurn,
+): string {
+  const lines: string[] = [`# ${headingText(report.subagentKind)}`, ""];
+  addMetaLine(lines, "Subagent ID", inlineCode(report.id));
+  addMetaLine(lines, "Conversation ID", report.subagentConversationId);
+  addMetaLine(lines, "Created", report.createdAt);
+  addMetaLine(lines, "Status", report.outcome ?? report.status);
+  addMetaLine(lines, "Duration", formatMs(turn.cumulativeDurationMs));
+  addMetaLine(
+    lines,
+    "Sentry conversation",
+    report.subagentSentryConversationUrl,
+  );
+  lines.push("", "## Transcript");
+  appendTurnTranscript(lines, turn);
   return finishMarkdown(lines);
 }
 
@@ -265,7 +287,7 @@ function messageRoleLabel(
   turn: ConversationTurn,
 ): string {
   const kind = transcriptRoleKind(message.role);
-  if (kind === "assistant") return "Junior";
+  if (kind === "assistant") return turn.assistantLabel ?? "Junior";
   if (kind === "user") return actorLabel(turn.actorIdentity) ?? "User";
   if (kind === "system") return "System";
   if (kind === "tool") return "Tool";

--- a/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from "react";
-import { Check, Copy } from "lucide-react";
+import { useState } from "react";
 import { Link, useParams } from "react-router";
 
 import { useConversationData } from "../api";
 import { buildConversationMarkdown } from "../markdownExport";
 import { Button } from "../components/Button";
+import { CopyMarkdownButton } from "../components/CopyMarkdownButton";
 import { StatusBadge } from "../components/StatusBadge";
 import {
   buildConversations,
@@ -55,6 +55,7 @@ export function ConversationPage(props: { data?: DashboardData }) {
     (item) => item.id === conversationId,
   );
   const conversation = conversationFromDetail(detail.data) ?? feedConversation;
+  const conversationDetail = detail.data;
   const visualStatus = conversation
     ? visualStatusForConversation(conversation)
     : undefined;
@@ -99,8 +100,16 @@ export function ConversationPage(props: { data?: DashboardData }) {
           <Transcript
             actions={
               <CopyMarkdownButton
-                conversation={conversation}
-                detail={detail.data}
+                key={`${conversationDetail?.conversationId ?? "loading"}:${conversationDetail?.generatedAt ?? ""}`}
+                getMarkdown={
+                  conversationDetail
+                    ? () =>
+                        buildConversationMarkdown(
+                          conversationDetail,
+                          conversation,
+                        )
+                    : undefined
+                }
               />
             }
             live={conversationIsLive(visualStatus, detail.data)}
@@ -126,50 +135,6 @@ function conversationIsLive(
 ): boolean {
   if (detail) return detail.runs.some((turn) => turn.status === "active");
   return visualStatus === "active";
-}
-
-function CopyMarkdownButton(props: {
-  conversation: Conversation | undefined;
-  detail: ConversationDetailFeed | undefined;
-}) {
-  const [status, setStatus] = useState<"copied" | "failed" | "idle">("idle");
-  const disabled = !props.detail;
-  const label =
-    status === "copied"
-      ? "Copied"
-      : status === "failed"
-        ? "Copy failed"
-        : "Copy as Markdown";
-  const Icon = status === "copied" ? Check : Copy;
-
-  useEffect(() => {
-    setStatus("idle");
-  }, [props.detail?.conversationId, props.detail?.generatedAt]);
-
-  async function copyMarkdown() {
-    if (!props.detail) return;
-
-    try {
-      await navigator.clipboard.writeText(
-        buildConversationMarkdown(props.detail, props.conversation),
-      );
-      setStatus("copied");
-    } catch {
-      setStatus("failed");
-    }
-  }
-
-  return (
-    <Button
-      aria-label={label}
-      disabled={disabled}
-      onClick={() => void copyMarkdown()}
-      size="icon"
-      title={label}
-    >
-      <Icon aria-hidden="true" size={15} strokeWidth={2} />
-    </Button>
-  );
 }
 
 function ConversationIdentity(props: {

--- a/packages/junior-dashboard/src/client/subagentTranscript.ts
+++ b/packages/junior-dashboard/src/client/subagentTranscript.ts
@@ -1,0 +1,52 @@
+import type { ConversationSubagentTranscript, ConversationTurn } from "./types";
+
+/** Project a child-agent report through the shared transcript renderer. */
+export function subagentTranscriptTurn(
+  conversationId: string,
+  report: ConversationSubagentTranscript,
+): ConversationTurn {
+  const status =
+    report.status === "running"
+      ? "active"
+      : report.status === "error" || report.status === "aborted"
+        ? "failed"
+        : "completed";
+
+  return {
+    conversationId,
+    assistantLabel: report.subagentKind,
+    cumulativeDurationMs: subagentDurationMs(report) ?? 0,
+    displayTitle: report.subagentKind,
+    id: report.id,
+    lastProgressAt: report.endedAt ?? report.createdAt,
+    lastSeenAt: report.endedAt ?? report.createdAt,
+    startedAt: report.createdAt,
+    status,
+    surface: "internal",
+    transcript: report.transcript,
+    transcriptAvailable: report.transcriptAvailable,
+    ...(report.endedAt ? { completedAt: report.endedAt } : {}),
+    ...(report.transcriptMessageCount !== undefined
+      ? { transcriptMessageCount: report.transcriptMessageCount }
+      : {}),
+    ...(report.transcriptRedacted
+      ? { transcriptRedacted: report.transcriptRedacted }
+      : {}),
+    ...(report.transcriptRedactionReason
+      ? { transcriptRedactionReason: report.transcriptRedactionReason }
+      : {}),
+  };
+}
+
+/** Calculate a completed child-agent run duration when timestamps are valid. */
+export function subagentDurationMs(
+  report: Pick<ConversationSubagentTranscript, "createdAt" | "endedAt">,
+): number | undefined {
+  if (!report.endedAt) return undefined;
+  const startedAt = Date.parse(report.createdAt);
+  const endedAt = Date.parse(report.endedAt);
+  if (!Number.isFinite(startedAt) || !Number.isFinite(endedAt)) {
+    return undefined;
+  }
+  return endedAt >= startedAt ? endedAt - startedAt : undefined;
+}

--- a/packages/junior-dashboard/tests/markdownExport.test.ts
+++ b/packages/junior-dashboard/tests/markdownExport.test.ts
@@ -1,13 +1,60 @@
 import { describe, expect, it } from "vitest";
 
-import { buildConversationMarkdown } from "../src/client/markdownExport";
+import {
+  buildConversationMarkdown,
+  buildSubagentMarkdown,
+} from "../src/client/markdownExport";
+import { subagentTranscriptTurn } from "../src/client/subagentTranscript";
 import type {
   Conversation,
   ConversationDetailFeed,
+  ConversationSubagentTranscript,
   ConversationTurn,
 } from "../src/client/types";
 
 describe("dashboard markdown export", () => {
+  it("serializes child-agent transcripts with shared formatting", () => {
+    const report = {
+      type: "subagent",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      endedAt: "2026-01-01T00:00:02.000Z",
+      id: "advisor-call",
+      outcome: "success",
+      status: "success",
+      subagentConversationId: "junior:conversation-1:advisor_session",
+      subagentKind: "advisor",
+      subagentSentryConversationUrl:
+        "https://sentry.example/explore/conversations/advisor",
+      transcript: [
+        {
+          role: "user",
+          timestamp: Date.parse("2026-01-01T00:00:00.000Z"),
+          parts: [{ type: "text", text: "Review the implementation." }],
+        },
+        {
+          role: "assistant",
+          timestamp: Date.parse("2026-01-01T00:00:02.000Z"),
+          parts: [{ type: "text", text: "The implementation is sound." }],
+        },
+      ],
+      transcriptAvailable: true,
+    } satisfies ConversationSubagentTranscript;
+    const turn = subagentTranscriptTurn("conversation-1", report);
+
+    const markdown = buildSubagentMarkdown(report, turn);
+
+    expect(markdown).toContain("# advisor");
+    expect(markdown).toContain("- Subagent ID: `advisor-call`");
+    expect(markdown).toContain(
+      "- Conversation ID: junior:conversation-1:advisor_session",
+    );
+    expect(markdown).toContain("- Duration: 2.0s");
+    expect(markdown).toContain("### User");
+    expect(markdown).toContain("Review the implementation.");
+    expect(markdown).toContain("### advisor");
+    expect(markdown).toContain("The implementation is sound.");
+  });
+
   it("serializes visible conversation transcripts as Markdown", () => {
     const startedAt = "2026-01-01T00:00:00.000Z";
     const detail = {

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -268,6 +268,8 @@ describe("dashboard telemetry components", () => {
     expect(html).toContain("Conversation ID");
     expect(html).toContain("junior:parent-conversation:advisor_session");
     expect(html).toContain("View in Sentry");
+    expect(html).toContain('aria-label="Copy as Markdown"');
+    expect(html).toContain("disabled");
     expect(html).toContain(
       "https://sentry.example/explore/conversations/advisor",
     );

--- a/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
+++ b/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
@@ -392,6 +392,12 @@ describe("transcript render model", () => {
           status: "completed",
         },
         kind: "tool",
+        result: {
+          type: "tool_result",
+          id: "advisor-call",
+          name: "advisor",
+        },
+        resultTimestamp: Date.parse("2026-01-01T00:00:03.000Z"),
         timestamp: Date.parse("2026-01-01T00:00:01.000Z"),
       },
       {
@@ -406,16 +412,147 @@ describe("transcript render model", () => {
         },
         timestamp: Date.parse("2026-01-01T00:00:02.000Z"),
       },
+    ]);
+  });
+
+  it("leaves ambiguous name-only tool results unpaired", () => {
+    const messages = [
+      {
+        role: "assistant",
+        timestamp: 1_000,
+        parts: [{ type: "tool_call", name: "search" }],
+      },
+      {
+        role: "assistant",
+        timestamp: 1_100,
+        parts: [{ type: "tool_call", name: "search" }],
+      },
+      {
+        role: "toolResult",
+        timestamp: 2_000,
+        parts: [{ type: "tool_result", name: "search" }],
+      },
+    ] as TranscriptMessage[];
+
+    expect(groupTranscriptMessages(messages)).toEqual([
+      {
+        call: { type: "tool_call", name: "search" },
+        kind: "tool",
+        timestamp: 1_000,
+      },
+      {
+        call: { type: "tool_call", name: "search" },
+        kind: "tool",
+        timestamp: 1_100,
+      },
       {
         kind: "tool",
-        result: {
-          type: "tool_result",
-          id: "advisor-call",
-          name: "advisor",
-        },
-        resultTimestamp: Date.parse("2026-01-01T00:00:03.000Z"),
+        result: { type: "tool_result", name: "search" },
+        resultTimestamp: 2_000,
       },
     ]);
+  });
+
+  it("does not pair name-only results across message boundaries", () => {
+    const messages = [
+      {
+        role: "assistant",
+        timestamp: 1_000,
+        parts: [{ type: "tool_call", name: "search" }],
+      },
+      {
+        role: "assistant",
+        timestamp: 1_500,
+        parts: [{ type: "text", text: "Continuing after the search." }],
+      },
+      {
+        role: "toolResult",
+        timestamp: 2_000,
+        parts: [{ type: "tool_result", name: "search" }],
+      },
+    ] as TranscriptMessage[];
+
+    expect(groupTranscriptMessages(messages)).toEqual([
+      {
+        call: { type: "tool_call", name: "search" },
+        kind: "tool",
+        timestamp: 1_000,
+      },
+      {
+        kind: "message",
+        message: {
+          role: "assistant",
+          timestamp: 1_500,
+          parts: [{ type: "text", text: "Continuing after the search." }],
+        },
+      },
+      {
+        kind: "tool",
+        result: { type: "tool_result", name: "search" },
+        resultTimestamp: 2_000,
+      },
+    ]);
+  });
+
+  it("pairs one name-only call across thinking activity", () => {
+    const messages = [
+      {
+        role: "assistant",
+        timestamp: 1_000,
+        parts: [{ type: "tool_call", name: "search" }],
+      },
+      {
+        role: "assistant",
+        timestamp: 1_500,
+        parts: [{ type: "thinking", output: "Waiting for search." }],
+      },
+      {
+        role: "toolResult",
+        timestamp: 2_000,
+        parts: [{ type: "tool_result", name: "search" }],
+      },
+    ] as TranscriptMessage[];
+
+    expect(groupTranscriptMessages(messages)).toEqual([
+      {
+        call: { type: "tool_call", name: "search" },
+        kind: "tool",
+        result: { type: "tool_result", name: "search" },
+        resultTimestamp: 2_000,
+        timestamp: 1_000,
+      },
+      {
+        kind: "thinking",
+        part: { type: "thinking", output: "Waiting for search." },
+        timestamp: 1_500,
+      },
+    ]);
+  });
+
+  it("treats mixed ID metadata as ambiguous for name-only results", () => {
+    const messages = [
+      {
+        role: "assistant",
+        timestamp: 1_000,
+        parts: [{ type: "tool_call", name: "search" }],
+      },
+      {
+        role: "assistant",
+        timestamp: 1_100,
+        parts: [{ type: "tool_call", id: "call-2", name: "search" }],
+      },
+      {
+        role: "toolResult",
+        timestamp: 2_000,
+        parts: [{ type: "tool_result", name: "search" }],
+      },
+    ] as TranscriptMessage[];
+
+    expect(groupTranscriptMessages(messages).at(-1)).toEqual({
+      kind: "tool",
+      result: { type: "tool_result", name: "search" },
+      resultTimestamp: 2_000,
+    });
   });
 
   it("matches derived activity rows in transcript search", () => {

--- a/packages/junior/src/chat/advisor-request.ts
+++ b/packages/junior/src/chat/advisor-request.ts
@@ -1,0 +1,45 @@
+import { escapeXml, unescapeXml } from "@/chat/xml";
+
+const TASK_OPEN = "<advisor-task>\n";
+const TASK_CLOSE = "\n</advisor-task>";
+const CONTEXT_OPEN = "<executor-context>\n";
+const CONTEXT_CLOSE = "\n</executor-context>";
+
+/** Render the executor's advisor request in stable model-facing boundaries. */
+export function renderAdvisorRequest(
+  question: string,
+  context: string,
+): string {
+  return [
+    TASK_OPEN,
+    escapeXml(question),
+    TASK_CLOSE,
+    "\n\n",
+    CONTEXT_OPEN,
+    escapeXml(context),
+    CONTEXT_CLOSE,
+  ].join("");
+}
+
+/** Recover readable task and context text from an advisor request message. */
+export function unwrapAdvisorRequest(text: string): string | undefined {
+  if (!text.startsWith(TASK_OPEN) || !text.endsWith(CONTEXT_CLOSE)) {
+    return undefined;
+  }
+
+  const taskEnd = text.indexOf(TASK_CLOSE, TASK_OPEN.length);
+  if (taskEnd < 0) {
+    return undefined;
+  }
+  const contextStart = taskEnd + TASK_CLOSE.length + 2;
+  if (!text.startsWith(CONTEXT_OPEN, contextStart)) {
+    return undefined;
+  }
+
+  const task = text.slice(TASK_OPEN.length, taskEnd);
+  const context = text.slice(
+    contextStart + CONTEXT_OPEN.length,
+    -CONTEXT_CLOSE.length,
+  );
+  return `${unescapeXml(task)}\n\nExecutor context:\n${unescapeXml(context)}`;
+}

--- a/packages/junior/src/chat/current-instruction.ts
+++ b/packages/junior/src/chat/current-instruction.ts
@@ -1,19 +1,10 @@
-import { escapeXml } from "@/chat/xml";
+import { escapeXml, unescapeXml } from "@/chat/xml";
 
 const CURRENT_INSTRUCTION_TAG = "current-instruction";
 const CURRENT_INSTRUCTION_OPEN_PREFIX = `<${CURRENT_INSTRUCTION_TAG}`;
 const CURRENT_INSTRUCTION_OPEN_BARE = `<${CURRENT_INSTRUCTION_TAG}>`;
 const CURRENT_INSTRUCTION_OPEN_ATTR_PREFIX = `<${CURRENT_INSTRUCTION_TAG} `;
 const CURRENT_INSTRUCTION_CLOSE = `\n</${CURRENT_INSTRUCTION_TAG}>`;
-
-function unescapeXml(value: string): string {
-  return value
-    .replaceAll("&quot;", '"')
-    .replaceAll("&apos;", "'")
-    .replaceAll("&gt;", ">")
-    .replaceAll("&lt;", "<")
-    .replaceAll("&amp;", "&");
-}
 
 function isCurrentInstructionOpeningTag(value: string): boolean {
   return (

--- a/packages/junior/src/chat/tools/advisor/tool.ts
+++ b/packages/junior/src/chat/tools/advisor/tool.ts
@@ -34,6 +34,7 @@ import {
   getAdvisorSessionKey,
   type AdvisorSessionStore,
 } from "@/chat/tools/advisor/session-store";
+import { renderAdvisorRequest } from "@/chat/advisor-request";
 import {
   recordSubagentEnded,
   recordSubagentStarted,
@@ -42,7 +43,6 @@ import { juniorToolResultSchema } from "@/chat/tool-support/structured-result";
 import { zodTool } from "@/chat/tool-support/zod-tool";
 import type { AnyToolDefinition } from "@/chat/tools/definition";
 import { z } from "zod";
-import { escapeXml } from "@/chat/xml";
 
 export type AdvisorErrorCode =
   | "invalid_context"
@@ -231,15 +231,7 @@ export function createAdvisorTool(context: AdvisorToolRuntimeContext) {
         ttlMs: THREAD_STATE_TTL_MS,
       });
       const conversationPrivacy = context.conversationPrivacy ?? "private";
-      const requestText = [
-        "<advisor-task>",
-        escapeXml(advisorQuestion),
-        "</advisor-task>",
-        "",
-        "<executor-context>",
-        escapeXml(advisorContext),
-        "</executor-context>",
-      ].join("\n");
+      const requestText = renderAdvisorRequest(advisorQuestion, advisorContext);
       const advisorInputMessage = {
         role: "user" as const,
         content: [{ type: "text" as const, text: requestText }],

--- a/packages/junior/src/chat/xml.ts
+++ b/packages/junior/src/chat/xml.ts
@@ -6,3 +6,13 @@ export function escapeXml(value: string): string {
     .replaceAll('"', "&quot;")
     .replaceAll("'", "&apos;");
 }
+
+/** Recover text escaped for an internal XML prompt boundary. */
+export function unescapeXml(value: string): string {
+  return value
+    .replaceAll("&quot;", '"')
+    .replaceAll("&apos;", "'")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&amp;", "&");
+}

--- a/packages/junior/src/reporting/conversations.ts
+++ b/packages/junior/src/reporting/conversations.ts
@@ -6,6 +6,7 @@
  * transcript payloads can leave this module.
  */
 import { isRecord } from "@/chat/coerce";
+import { unwrapAdvisorRequest } from "@/chat/advisor-request";
 import {
   canExposeConversationPayload,
   resolveConversationPrivacy,
@@ -1007,10 +1008,16 @@ function recordField(value: Record<string, unknown>, names: string[]): unknown {
 /** Normalize Pi content parts for user-facing transcript output. */
 function normalizeTranscriptPart(
   part: unknown,
-  options: { unwrapCurrentTask?: boolean } = {},
+  options: { unwrapAdvisorTask?: boolean; unwrapCurrentTask?: boolean } = {},
 ): TranscriptPart {
-  const displayText = (text: string) =>
-    options.unwrapCurrentTask ? (unwrapCurrentInstruction(text) ?? text) : text;
+  const displayText = (text: string) => {
+    if (options.unwrapCurrentTask) {
+      const instruction = unwrapCurrentInstruction(text);
+      if (instruction !== undefined) return instruction;
+    }
+    if (options.unwrapAdvisorTask) return unwrapAdvisorRequest(text) ?? text;
+    return text;
+  };
 
   if (typeof part === "string") {
     return textPart(displayText(part));
@@ -1084,7 +1091,10 @@ function normalizeToolResultMessage(
   };
 }
 
-function normalizeTranscriptMessage(message: PiMessage): TranscriptMessage {
+function normalizeTranscriptMessage(
+  message: PiMessage,
+  options: { unwrapAdvisorTask?: boolean } = {},
+): TranscriptMessage {
   const record = message as unknown as Record<string, unknown>;
   const content = record.content;
   const role = transcriptRole(record.role);
@@ -1099,11 +1109,13 @@ function normalizeTranscriptMessage(message: PiMessage): TranscriptMessage {
         : Array.isArray(content)
           ? content.map((part) =>
               normalizeTranscriptPart(part, {
+                unwrapAdvisorTask: options.unwrapAdvisorTask && role === "user",
                 unwrapCurrentTask: role === "user",
               }),
             )
           : [
               normalizeTranscriptPart(content, {
+                unwrapAdvisorTask: options.unwrapAdvisorTask && role === "user",
                 unwrapCurrentTask: role === "user",
               }),
             ],
@@ -1725,8 +1737,8 @@ export async function readConversationReport(
         summary,
         conversation?.visibility,
       );
-      const normalizedTranscript = scopedMessages.messages.map(
-        normalizeTranscriptMessage,
+      const normalizedTranscript = scopedMessages.messages.map((message) =>
+        normalizeTranscriptMessage(message),
       );
       const activity = buildConversationActivity({
         canExposePayload: canExposeTranscript,
@@ -1910,9 +1922,11 @@ export async function readConversationSubagentTranscriptReport(
     });
   }
 
-  const transcript = messages
-    .slice(0, bounds.end)
-    .map(normalizeTranscriptMessage);
+  const transcript = messages.slice(0, bounds.end).map((message) =>
+    normalizeTranscriptMessage(message, {
+      unwrapAdvisorTask: activity.subagentKind === "advisor",
+    }),
+  );
 
   return subagentTranscriptReport(activity, {
     ...conversationFields,

--- a/packages/junior/tests/integration/dashboard-reporting.test.ts
+++ b/packages/junior/tests/integration/dashboard-reporting.test.ts
@@ -4,6 +4,7 @@ import type {
   ConversationStore,
 } from "@/chat/conversations/store";
 import type { PiMessage } from "@/chat/pi/messages";
+import { renderAdvisorRequest } from "@/chat/advisor-request";
 import type { AgentTurnSessionSummary } from "@/chat/state/turn-session";
 
 vi.mock("@/chat/prompt", () => ({
@@ -989,7 +990,15 @@ describe("dashboard reporting", () => {
     const advisorMessages = [
       {
         role: "user",
-        content: [{ type: "text", text: "first advisor question" }],
+        content: [
+          {
+            type: "text",
+            text: renderAdvisorRequest(
+              "first advisor question",
+              "first <evidence> packet",
+            ),
+          },
+        ],
         timestamp: 10,
       },
       {
@@ -1116,6 +1125,13 @@ describe("dashboard reporting", () => {
     ).toBe(true);
     expect(JSON.stringify(first.transcript)).toContain(
       "first advisor question",
+    );
+    expect(JSON.stringify(first.transcript)).toContain(
+      "first <evidence> packet",
+    );
+    expect(JSON.stringify(first.transcript)).not.toContain("<advisor-task>");
+    expect(JSON.stringify(first.transcript)).not.toContain(
+      "<executor-context>",
     );
     expect(JSON.stringify(first.transcript)).not.toContain(
       "second advisor question",

--- a/packages/junior/tests/unit/chat/advisor-request.test.ts
+++ b/packages/junior/tests/unit/chat/advisor-request.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  renderAdvisorRequest,
+  unwrapAdvisorRequest,
+} from "@/chat/advisor-request";
+
+describe("advisor request", () => {
+  it("round trips XML-sensitive task and context text", () => {
+    const request = renderAdvisorRequest(
+      'Review <change> & "risk".',
+      "Use owner='dashboard' & preserve <context>.",
+    );
+
+    expect(request).toContain("Review &lt;change&gt; &amp; &quot;risk&quot;.");
+    expect(unwrapAdvisorRequest(request)).toBe(
+      `Review <change> & "risk".\n\nExecutor context:\nUse owner='dashboard' & preserve <context>.`,
+    );
+  });
+});


### PR DESCRIPTION
Advisor transcript drawers now project the internal advisor request envelope into readable task and context content, keep tool calls paired with results across synthetic subagent and thinking entries, and expose a shared Markdown copy action in both conversation and subagent views. Completed subagent rows also use the expected pointer affordance, and the drawer adapts cleanly to narrow screens.

Pairing remains bounded by real message boundaries and rejects ambiguous name-only matches, so unrelated tool activity is not combined. Regression coverage exercises the render-model edge cases, advisor reporting projection, copy behavior, and responsive drawer interaction.

Fixes #745