### PR TITLE
feat(amplitude): Add read-only analytics plugin

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -12,6 +12,9 @@ targets:
     id: "@sentry/junior-agent-browser"
     includeNames: /^sentry-junior-agent-browser-\d.*\.tgz$/
   - name: npm
+    id: "@sentry/junior-amplitude"
+    includeNames: /^sentry-junior-amplitude-\d.*\.tgz$/
+  - name: npm
     id: "@sentry/junior-cloudflare"
     includeNames: /^sentry-junior-cloudflare-\d.*\.tgz$/
   - name: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
           pnpm --filter @sentry/junior pack --pack-destination artifacts
           pnpm --filter @sentry/junior-plugin-api pack --pack-destination artifacts
           pnpm --filter @sentry/junior-agent-browser pack --pack-destination artifacts
+          pnpm --filter @sentry/junior-amplitude pack --pack-destination artifacts
           pnpm --filter @sentry/junior-cloudflare pack --pack-destination artifacts
           pnpm --filter @sentry/junior-dashboard pack --pack-destination artifacts
           pnpm --filter @sentry/junior-datadog pack --pack-destination artifacts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,7 @@ This repo uses Craft for manual lockstep npm releases of:
 - `@sentry/junior`
 - `@sentry/junior-plugin-api`
 - `@sentry/junior-agent-browser`
+- `@sentry/junior-amplitude`
 - `@sentry/junior-cloudflare`
 - `@sentry/junior-dashboard`
 - `@sentry/junior-datadog`

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Start here:
 | `@sentry/junior`               | Core Slack bot runtime                                                       |
 | `@sentry/junior-plugin-api`    | Lightweight plugin API types and helpers                                     |
 | `@sentry/junior-agent-browser` | Agent Browser plugin package for browser automation                          |
+| `@sentry/junior-amplitude`     | Read-only Amplitude product analytics through Amplitude's hosted MCP server  |
 | `@sentry/junior-cloudflare`    | Cloudflare plugin package for production operations                          |
 | `@sentry/junior-dashboard`     | Authenticated dashboard package for Junior runtime diagnostics               |
 | `@sentry/junior-datadog`       | Datadog plugin package for observability workflows through Datadog's Pup CLI |

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@sentry/junior": "workspace:*",
     "@sentry/junior-agent-browser": "workspace:*",
+    "@sentry/junior-amplitude": "workspace:*",
     "@sentry/junior-dashboard": "workspace:*",
     "@sentry/junior-datadog": "workspace:*",
     "@sentry/junior-github": "workspace:*",

--- a/apps/example/plugins.ts
+++ b/apps/example/plugins.ts
@@ -9,6 +9,7 @@ process.env.GITHUB_APP_BOT_EMAIL ||=
 
 export const plugins = defineJuniorPlugins([
   "@sentry/junior-agent-browser",
+  "@sentry/junior-amplitude",
   "@sentry/junior-datadog",
   githubPlugin({
     botNameEnv: "GITHUB_APP_BOT_NAME",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "docs:dev": "pnpm --filter @sentry/junior-docs dev",
     "docs:build": "pnpm --filter @sentry/junior-docs build",
     "docs:check": "pnpm --filter @sentry/junior-docs check",
-    "package:lint": "for pkg in packages/junior packages/junior-plugin-api packages/junior-scheduler packages/junior-memory packages/junior-dashboard packages/junior-github packages/junior-agent-browser packages/junior-cloudflare packages/junior-datadog packages/junior-hex packages/junior-linear packages/junior-maintenance packages/junior-notion packages/junior-sentry packages/junior-vercel; do pnpm exec publint \"$pkg\" || exit $?; done",
+    "package:lint": "for pkg in packages/junior packages/junior-plugin-api packages/junior-scheduler packages/junior-memory packages/junior-dashboard packages/junior-github packages/junior-agent-browser packages/junior-amplitude packages/junior-cloudflare packages/junior-datadog packages/junior-hex packages/junior-linear packages/junior-maintenance packages/junior-notion packages/junior-sentry packages/junior-vercel; do pnpm exec publint \"$pkg\" || exit $?; done",
     "release:check": "node scripts/check-release-config.mjs",
     "start": "pnpm --filter @sentry/junior-example dev",
     "test": "pnpm --filter @sentry/junior build && pnpm --filter @sentry/junior-memory build && pnpm --filter @sentry/junior-github build && pnpm --filter @sentry/junior-dashboard build && pnpm --filter @sentry/junior test && pnpm --filter @sentry/junior-memory test && pnpm --filter @sentry/junior-github test && pnpm --filter @sentry/junior-dashboard test",

--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -19,11 +19,13 @@ export default defineConfig({
     "/deploy/vercel": "/start-here/deploy-to-vercel",
     "/extend/custom-plugins": "/extend/build-a-plugin",
     "/extend/plugins-overview": "/extend",
+    "/extend/amplitude": "/extend/amplitude-plugin",
     "/extend/cloudflare": "/extend/cloudflare-plugin",
     "/extend/datadog": "/extend/datadog-plugin",
     "/extend/hex": "/extend/hex-plugin",
     "/plugins/overview": "/extend",
     "/plugins/agent-browser": "/extend/agent-browser-plugin",
+    "/plugins/amplitude": "/extend/amplitude-plugin",
     "/plugins/cloudflare": "/extend/cloudflare-plugin",
     "/plugins/datadog": "/extend/datadog-plugin",
     "/plugins/github": "/extend/github-plugin",
@@ -103,6 +105,10 @@ export default defineConfig({
             {
               label: "Agent Browser Plugin",
               link: "/extend/agent-browser-plugin/",
+            },
+            {
+              label: "Amplitude Plugin",
+              link: "/extend/amplitude-plugin/",
             },
             {
               label: "Cloudflare Plugin",

--- a/packages/docs/src/content/docs/contribute/releasing.md
+++ b/packages/docs/src/content/docs/contribute/releasing.md
@@ -14,6 +14,7 @@ Junior uses lockstep package releases for:
 - `@sentry/junior`
 - `@sentry/junior-plugin-api`
 - `@sentry/junior-agent-browser`
+- `@sentry/junior-amplitude`
 - `@sentry/junior-cloudflare`
 - `@sentry/junior-dashboard`
 - `@sentry/junior-datadog`

--- a/packages/docs/src/content/docs/extend/amplitude-plugin.md
+++ b/packages/docs/src/content/docs/extend/amplitude-plugin.md
@@ -1,0 +1,139 @@
+---
+title: Amplitude Plugin
+description: Configure read-only Amplitude product analytics through Amplitude's hosted MCP server.
+type: tutorial
+summary: Connect Junior to Amplitude for read-only product analytics in Slack.
+prerequisites:
+  - /extend/
+related:
+  - /concepts/credentials-and-oauth/
+  - /operate/security-hardening/
+---
+
+The Amplitude plugin lets Slack users inspect product usage, active users, event segmentation, funnels, retention, saved charts and dashboards, experiments, cohorts, taxonomy, session replay, feature flags, guides and surveys, feedback, agent analytics, and user activity without granting Junior access to mutation tools.
+
+Junior connects to Amplitude's hosted MCP server and starts Amplitude's OAuth flow when a user first requests analytics. The plugin exposes a fixed allowlist of Amplitude's documented search, retrieval, and query tools.
+
+## Install
+
+Install the plugin package alongside `@sentry/junior`:
+
+```bash
+pnpm add @sentry/junior @sentry/junior-amplitude
+```
+
+## Runtime setup
+
+Add the package name to the plugin set exported from `plugins.ts`:
+
+```ts title="plugins.ts"
+import { defineJuniorPlugins } from "@sentry/junior";
+
+export const plugins = defineJuniorPlugins(["@sentry/junior-amplitude"]);
+```
+
+No Amplitude API key or secret key is required. Each user authorizes through Amplitude's hosted MCP OAuth flow, and Junior resumes the original conversation after authorization completes.
+
+## Regional endpoint
+
+The package defaults to Amplitude's US MCP endpoint:
+
+```text
+https://mcp.amplitude.com/mcp
+```
+
+For another Amplitude data region, set `AMPLITUDE_MCP_URL` to the regional MCP endpoint documented by Amplitude before starting Junior. The endpoint must use HTTPS.
+
+## Read-only boundary
+
+The plugin uses `allowed-tools` to expose only documented search, retrieval, list, and query operations. Rendering, creation, editing, updates, cohort sync triggers, taxonomy branch mutation, merge, and deletion tools never enter Junior's callable MCP catalog.
+
+This allowlist is a client-side exposure boundary. Amplitude authorization remains the provider-side permission boundary. For defense in depth, grant connected users or service accounts `USE_MCP_READ` only and remove `USE_MCP_WRITE` from their project role. Amplitude's Member, Manager, and Admin roles include MCP write access by default until an administrator adjusts the role.
+
+The plugin does not use Amplitude's progressive-discovery URL. Junior already loads provider catalogs on demand through `searchMcpTools`, while the standard endpoint supplies the complete catalog that Junior can filter before exposure.
+
+### Allowed tools
+
+The package exposes this exact provider tool surface:
+
+```text
+search
+get_from_url
+get_context
+get_project_context
+get_workspace_context
+get_charts
+get_dashboard
+get_cohorts
+get_experiments
+get_users
+get_flags
+get_deployments
+get_agent_results
+get_events
+get_properties
+get_custom_or_labeled_events
+get_transformations
+get_group_types
+get_session_replays
+list_session_replays
+get_session_replay_events
+query_chart
+query_charts
+query_amplitude_data
+query_experiment
+get_cohort_sync_destinations
+get_cohort_syncs
+get_cohort_sync_history
+get_branches
+list_guides_surveys
+get_guide_or_survey
+get_feedback_insights
+get_feedback_comments
+get_feedback_mentions
+get_feedback_sources
+get_feedback_trends
+query_agent_analytics_metrics
+query_agent_analytics_sessions
+query_agent_analytics_spans
+get_agent_analytics_conversation
+search_agent_analytics_conversations
+get_agent_analytics_schema
+```
+
+Every other Amplitude MCP tool is unavailable through the plugin. When Amplitude adds another read operation, the package must explicitly add it before Junior can call it.
+
+## What users can query
+
+- DAU, WAU, MAU, and other active-user trends
+- event totals, unique users, sessions, and property segmentation
+- funnel conversion and step drop-off
+- retention by cohort and interval
+- saved chart and dashboard results
+- experiment status and results
+- cohorts, taxonomy, and event definitions
+- session replay timelines and prior agent-analysis results
+- feature flag definitions and tracking-plan branches
+- guides, surveys, customer feedback, and agent analytics
+- individual user activity when the connected account has access
+
+Render, create, update, archive, delete, launch, stop, sync-trigger, and configuration operations are unavailable through this plugin. The skill also instructs Junior not to expose deployment API keys, credential fields, or unrelated raw feedback and conversation content returned by read tools.
+
+## Verify
+
+1. Ask Junior for an Amplitude metric, such as active users for the last seven days.
+2. Complete the private Amplitude OAuth flow when Junior prompts for it.
+3. Confirm the original conversation resumes with an analytics result.
+4. Ask Junior to create or edit an Amplitude chart and confirm it explains that the plugin is read-only.
+
+## Failure modes
+
+- **Authorization required:** Retry the analytics request and complete the private OAuth flow.
+- **Permission denied:** The connected Amplitude account cannot access the requested organization, project, or resource.
+- **No matching tool:** The requested operation is not in the package's read-only tool allowlist.
+- **Wrong region:** Set `AMPLITUDE_MCP_URL` to the correct regional MCP endpoint and restart the deployment.
+- **Ambiguous project:** Name the Amplitude project or provide a chart, dashboard, experiment, cohort, or user identifier.
+
+## Next step
+
+Review [Credentials & OAuth](/concepts/credentials-and-oauth/) and [Security Hardening](/operate/security-hardening/).

--- a/packages/docs/src/content/docs/extend/index.md
+++ b/packages/docs/src/content/docs/extend/index.md
@@ -59,7 +59,7 @@ my-junior-plugin/
 For reuse across apps or teams, package plugin manifests and any bundled skills as npm packages and install them next to `@sentry/junior`.
 
 ```bash
-pnpm add @sentry/junior @sentry/junior-agent-browser @sentry/junior-cloudflare @sentry/junior-datadog @sentry/junior-github @sentry/junior-hex @sentry/junior-linear @sentry/junior-maintenance @sentry/junior-memory @sentry/junior-notion @sentry/junior-scheduler @sentry/junior-sentry @sentry/junior-vercel
+pnpm add @sentry/junior @sentry/junior-agent-browser @sentry/junior-amplitude @sentry/junior-cloudflare @sentry/junior-datadog @sentry/junior-github @sentry/junior-hex @sentry/junior-linear @sentry/junior-maintenance @sentry/junior-memory @sentry/junior-notion @sentry/junior-scheduler @sentry/junior-sentry @sentry/junior-vercel
 ```
 
 Create one runtime-safe plugin set and point `juniorNitro()` at that module.
@@ -78,6 +78,7 @@ import { schedulerPlugin } from "@sentry/junior-scheduler";
 export const plugins = defineJuniorPlugins([
   createMemoryPlugin(),
   "@sentry/junior-agent-browser",
+  "@sentry/junior-amplitude",
   "@sentry/junior-cloudflare",
   "@sentry/junior-datadog",
   githubPlugin({

--- a/packages/docs/src/content/docs/start-here/quickstart.md
+++ b/packages/docs/src/content/docs/start-here/quickstart.md
@@ -415,7 +415,7 @@ Install only the plugins you plan to enable. If you are creating `plugins.ts`
 for an existing app, include the default maintenance and memory packages too:
 
 ```bash
-pnpm add @sentry/junior-maintenance @sentry/junior-memory @sentry/junior-agent-browser @sentry/junior-cloudflare @sentry/junior-datadog @sentry/junior-github @sentry/junior-hex @sentry/junior-linear @sentry/junior-notion @sentry/junior-scheduler @sentry/junior-sentry @sentry/junior-vercel
+pnpm add @sentry/junior-maintenance @sentry/junior-memory @sentry/junior-agent-browser @sentry/junior-amplitude @sentry/junior-cloudflare @sentry/junior-datadog @sentry/junior-github @sentry/junior-hex @sentry/junior-linear @sentry/junior-notion @sentry/junior-scheduler @sentry/junior-sentry @sentry/junior-vercel
 ```
 
 Add them to the plugin set in `plugins.ts`:
@@ -430,6 +430,7 @@ export const plugins = defineJuniorPlugins([
   createMemoryPlugin(),
   "@sentry/junior-maintenance",
   "@sentry/junior-agent-browser",
+  "@sentry/junior-amplitude",
   "@sentry/junior-cloudflare",
   "@sentry/junior-datadog",
   githubPlugin({

--- a/packages/junior-amplitude/README.md
+++ b/packages/junior-amplitude/README.md
@@ -1,0 +1,21 @@
+# `@sentry/junior-amplitude`
+
+Read-only Amplitude product analytics for Junior through Amplitude's hosted MCP server.
+
+## Install
+
+```bash
+pnpm add @sentry/junior @sentry/junior-amplitude
+```
+
+```ts
+import { defineJuniorPlugins } from "@sentry/junior";
+
+export const plugins = defineJuniorPlugins(["@sentry/junior-amplitude"]);
+```
+
+Junior starts Amplitude's per-user OAuth flow when the agent first needs Amplitude data. The plugin exposes a fixed allowlist of Amplitude's documented search, retrieval, list, and query tools across analytics, taxonomy, session replay, experiments, feature flags, cohorts, guides and surveys, feedback, and agent analytics. Rendering, creation, editing, update, sync, merge, and deletion tools are not available to the agent.
+
+The default MCP endpoint is `https://mcp.amplitude.com/mcp`. Set `AMPLITUDE_MCP_URL` to the regional endpoint documented by Amplitude when the deployment uses another data region.
+
+Full setup guide: https://junior.sentry.dev/extend/amplitude-plugin/

--- a/packages/junior-amplitude/package.json
+++ b/packages/junior-amplitude/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@sentry/junior-amplitude",
+  "version": "0.94.0",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getsentry/junior.git",
+    "directory": "packages/junior-amplitude"
+  },
+  "files": [
+    "plugin.yaml",
+    "skills"
+  ]
+}

--- a/packages/junior-amplitude/plugin.yaml
+++ b/packages/junior-amplitude/plugin.yaml
@@ -1,0 +1,53 @@
+name: amplitude
+display-name: Amplitude
+description: Read-only Amplitude analytics, taxonomy, replay, feedback, experiments, and product content
+
+env-vars:
+  AMPLITUDE_MCP_URL:
+    default: https://mcp.amplitude.com/mcp
+
+mcp:
+  url: ${AMPLITUDE_MCP_URL}
+  allowed-tools:
+    - search
+    - get_from_url
+    - get_context
+    - get_project_context
+    - get_workspace_context
+    - get_charts
+    - get_dashboard
+    - get_cohorts
+    - get_experiments
+    - get_users
+    - get_flags
+    - get_deployments
+    - get_agent_results
+    - get_events
+    - get_properties
+    - get_custom_or_labeled_events
+    - get_transformations
+    - get_group_types
+    - get_session_replays
+    - list_session_replays
+    - get_session_replay_events
+    - query_chart
+    - query_charts
+    - query_amplitude_data
+    - query_experiment
+    - get_cohort_sync_destinations
+    - get_cohort_syncs
+    - get_cohort_sync_history
+    - get_branches
+    - list_guides_surveys
+    - get_guide_or_survey
+    - get_feedback_insights
+    - get_feedback_comments
+    - get_feedback_mentions
+    - get_feedback_sources
+    - get_feedback_trends
+    - query_agent_analytics_metrics
+    - query_agent_analytics_sessions
+    - query_agent_analytics_spans
+    - get_agent_analytics_conversation
+    - search_agent_analytics_conversations
+    - get_agent_analytics_schema

--- a/packages/junior-amplitude/skills/amplitude/SKILL.md
+++ b/packages/junior-amplitude/skills/amplitude/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: amplitude
+description: Query read-only Amplitude product analytics. Use when users ask about active users, product usage, events, segmentation, funnels, conversion, retention, charts, dashboards, experiments, cohorts, taxonomy, session replay, feature flags, guides, surveys, feedback, agent analytics, or individual user activity in Amplitude. Do not use for changing Amplitude charts, dashboards, experiments, cohorts, flags, taxonomy, or project configuration.
+---
+
+# Amplitude Analytics
+
+Use this skill for read-only product analytics through Amplitude's hosted MCP server.
+
+## Workflow
+
+1. Define the question before querying:
+
+- Identify the metric or analysis type: active users, event segmentation, funnel, retention, chart, dashboard, experiment, cohort, taxonomy, session replay, feature flag, guide or survey, feedback, agent analytics, or user activity.
+- Preserve explicit event names, property names, chart IDs, dashboard IDs, experiment IDs, cohort IDs, and user IDs exactly.
+- Use the user's explicit time range. For relative ranges, state the concrete dates in the answer.
+- If the request has no time range, use the shortest conventional range that answers it and state the assumption.
+
+2. Discover the current Amplitude tool:
+
+- Inspect the available Amplitude MCP tools for the required analysis.
+- Use the exact live tool name and schema. Do not guess Amplitude MCP tool names or arguments.
+- Prefer direct chart, dashboard, experiment, cohort, or user lookup when the user provides its identifier.
+- If project or organization scope is ambiguous, inspect accessible scope through the read-only catalog and ask one focused question only when multiple plausible targets remain.
+
+3. Query narrowly:
+
+- Request only the events, properties, segments, metrics, and dates needed for the answer.
+- Prefer one complete query over several overlapping queries.
+- For comparisons, keep metric definitions and windows consistent.
+- Stop once the requested result is supported; do not enumerate unrelated project metadata.
+
+4. Report the result:
+
+- Lead with the metric, trend, conversion, retention, or experiment finding.
+- Include the date range, project or scope, filters, and metric definition needed to interpret it.
+- Distinguish unique users, event totals, sessions, and percentages explicitly.
+- Include Amplitude links returned by the MCP server when available.
+- State when data is empty, delayed, inaccessible, or insufficient rather than inferring a value.
+
+## Common Analyses
+
+- **DAU, WAU, MAU:** use active-user or event-segmentation tools with the requested interval and clarify whether the result is unique users or event totals.
+- **Event segmentation:** preserve the exact event and property filters; report the aggregation and interval.
+- **Funnels:** preserve ordered steps, conversion window, exclusions, and segment filters; report overall conversion and material drop-off steps.
+- **Retention:** report the starting event, returning event, cohort interval, and retention horizon.
+- **Saved charts and dashboards:** fetch by ID when available and summarize the returned definition and results without recreating the analysis from memory.
+- **Experiments:** report status, variants, exposure window, primary metric, and result confidence exactly as returned.
+- **Session replay:** narrow by time, user, or event before retrieving replay details; summarize only the interactions needed to answer the question.
+- **Feature flags:** report definitions, variants, and configuration without exposing deployment API keys or other credential fields.
+- **Guides, surveys, and feedback:** preserve source and date filters, distinguish processed themes from raw comments, and avoid returning unrelated customer text.
+- **Agent analytics:** distinguish sessions, spans, conversations, quality metrics, cost, and latency; return transcript content only when the user explicitly requests it.
+- **User activity:** use an explicit user identifier when possible and avoid exposing unrelated profile properties or event history.
+
+## Guardrails
+
+- Read-only only. The plugin exposes a fixed allowlist of Amplitude search, retrieval, and query tools.
+- Do not create, update, archive, delete, launch, stop, or otherwise modify Amplitude resources.
+- If the user asks for a change, explain that this plugin is read-only and offer to inspect the current state or describe the change they would need to make.
+- Do not weaken or bypass the plugin's tool filter, including by calling Amplitude APIs through shell commands.
+- Treat event and user properties as potentially sensitive. Return only fields needed to answer the request.
+- Never expose API keys, credential fields, or unrelated conversation and feedback content returned by read tools.
+- Do not fabricate event names, property values, metric definitions, experiment conclusions, or missing data.
+- On authorization failure, let Junior present Amplitude's OAuth flow. On permission failure, report that the connected Amplitude account cannot access the requested scope.

--- a/packages/junior-amplitude/skills/amplitude/SOURCES.md
+++ b/packages/junior-amplitude/skills/amplitude/SOURCES.md
@@ -1,0 +1,28 @@
+# Amplitude Skill Sources
+
+Last updated: 2026-07-10
+
+## Source inventory
+
+| Source                                                     | Trust tier            | Confidence | Contribution                                                                                                                                      | Usage constraints                                                                |
+| ---------------------------------------------------------- | --------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `https://amplitude.com/docs/amplitude-ai/amplitude-mcp`    | canonical             | high       | Hosted MCP endpoints, OAuth behavior, supported analytics surfaces, regional setup, and Amplitude access controls.                                | Treat live MCP schemas as authoritative for tool names and arguments.            |
+| `https://github.com/amplitude/mcp-marketplace`             | canonical             | high       | Amplitude-authored agent workflow examples and coverage across charts, dashboards, experiments, funnels, retention, cohorts, taxonomy, and users. | Adapt workflow intent; do not copy provider-specific prompt structure wholesale. |
+| `https://github.com/getsentry/junior/issues/810`           | local product context | high       | Required Junior use cases: active users, event segmentation, funnels, retention, saved charts, real-time activity, and user search.               | The issue's REST/CLI options predate the hosted MCP recommendation.              |
+| `specs/plugin.md`                                          | local canonical       | high       | Manifest-owned provider integration and host-managed MCP activation model.                                                                        | Junior runtime contract.                                                         |
+| `specs/plugin-manifest.md`                                 | local canonical       | high       | Hosted MCP, environment expansion, and strict tool allowlist contract.                                                                            | Junior runtime contract.                                                         |
+| `packages/junior/src/chat/tools/skill/search-mcp-tools.ts` | local canonical       | high       | Junior-native progressive provider and tool discovery.                                                                                            | Use instead of Amplitude's progressive-discovery URL.                            |
+
+## Adaptation decisions
+
+- Preserve Amplitude's analytics coverage and live schema authority.
+- Replace upstream client-specific commands with Junior's `searchMcpTools` and `callMcpTool` bridge.
+- Collapse many upstream workflow skills into one Slack-oriented read-only analytics skill for the initial release.
+- Allow only tool names that Amplitude's official MCP reference describes as search, retrieval, or query operations.
+- Include the standard server's documented search, retrieval, list, and query tools.
+- Omit render, create, update, edit, sync, branch mutation, merge, delete, launch, stop, and configuration workflows.
+- Keep provider schemas and tool names out of bundled prose because the MCP server is the current source of truth.
+
+## Retrieval stopping rationale
+
+The official MCP documentation, Amplitude marketplace, issue requirements, and Junior plugin contracts cover authentication, runtime integration, analytics workflows, safety boundaries, and failure handling. Additional REST endpoint documentation would duplicate the live MCP schema and encourage stale tool assumptions.

--- a/packages/junior-amplitude/skills/amplitude/SPEC.md
+++ b/packages/junior-amplitude/skills/amplitude/SPEC.md
@@ -1,0 +1,53 @@
+# Amplitude Skill Specification
+
+## Classification
+
+- Class: `integration-documentation`
+- Primary execution shape: `inline-guidance`
+- Simpler-shape decision: one coherent workflow is sufficient; references or scripts would duplicate live MCP schemas.
+- Portability: provider-specific MCP discovery is isolated to Junior's standard bridge tools.
+
+## Intent
+
+Answer product analytics questions from Amplitude while preventing the agent from invoking any provider tool outside the package's documented read-tool allowlist.
+
+## Trigger expectations
+
+Should trigger for:
+
+- DAU, WAU, MAU, active users, or new users in Amplitude
+- event counts, uniques, sessions, or property segmentation
+- funnel conversion and drop-off analysis
+- retention analysis
+- saved Amplitude chart or dashboard interpretation
+- experiment, cohort, taxonomy, session-replay, feature-flag, guide, survey, feedback, agent-analytics, or user-activity inspection
+
+Should not trigger for:
+
+- repository code or telemetry that merely mentions Amplitude
+- implementing Amplitude instrumentation or SDK setup
+- creating or editing Amplitude resources
+- analytics questions explicitly assigned to another provider
+
+## Runtime invariants
+
+1. Load the live Amplitude MCP catalog through Junior's provider bridge.
+2. Use exact discovered tool names and schemas.
+3. Expose only official Amplitude tools documented as search, retrieval, or query operations.
+4. Never bypass MCP filtering through direct HTTP or shell calls.
+5. Preserve explicit identifiers, filters, and time ranges.
+6. State assumptions and distinguish users, events, sessions, and percentages.
+
+## Validation
+
+- `pnpm skills:check`
+- `pnpm --filter @sentry/junior exec vitest run tests/component/plugins/amplitude-plugin.test.ts`
+- `pnpm release:check`
+- Pack `@sentry/junior-amplitude` and inspect the archive contents.
+- Manual OAuth smoke test through `pnpm cli -- chat ...` when an Amplitude account is available.
+
+## Maintenance
+
+- Update `SKILL.md` when supported read-only workflows or user-facing guardrails change.
+- Update `SOURCES.md` when Amplitude MCP endpoints, authentication, access controls, or marketplace guidance changes.
+- Update this file when trigger boundaries, runtime invariants, or validation requirements change.

--- a/packages/junior/tests/component/plugins/amplitude-plugin.test.ts
+++ b/packages/junior/tests/component/plugins/amplitude-plugin.test.ts
@@ -1,0 +1,144 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { listToolsMock } = vi.hoisted(() => ({
+  listToolsMock: vi.fn(),
+}));
+
+vi.mock("@/chat/mcp/client", () => ({
+  McpAuthorizationRequiredError: class extends Error {},
+  PluginMcpClient: class {
+    async listTools() {
+      return await listToolsMock();
+    }
+
+    async close() {}
+  },
+}));
+
+import { McpToolManager } from "@/chat/mcp/tool-manager";
+
+const originalCwd = process.cwd();
+const readOnlyTools = [
+  "search",
+  "get_from_url",
+  "get_context",
+  "get_project_context",
+  "get_workspace_context",
+  "get_charts",
+  "get_dashboard",
+  "get_cohorts",
+  "get_experiments",
+  "get_users",
+  "get_flags",
+  "get_deployments",
+  "get_agent_results",
+  "get_events",
+  "get_properties",
+  "get_custom_or_labeled_events",
+  "get_transformations",
+  "get_group_types",
+  "get_session_replays",
+  "list_session_replays",
+  "get_session_replay_events",
+  "query_chart",
+  "query_charts",
+  "query_amplitude_data",
+  "query_experiment",
+  "get_cohort_sync_destinations",
+  "get_cohort_syncs",
+  "get_cohort_sync_history",
+  "get_branches",
+  "list_guides_surveys",
+  "get_guide_or_survey",
+  "get_feedback_insights",
+  "get_feedback_comments",
+  "get_feedback_mentions",
+  "get_feedback_sources",
+  "get_feedback_trends",
+  "query_agent_analytics_metrics",
+  "query_agent_analytics_sessions",
+  "query_agent_analytics_spans",
+  "get_agent_analytics_conversation",
+  "search_agent_analytics_conversations",
+  "get_agent_analytics_schema",
+];
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  vi.resetModules();
+  vi.doUnmock("@/chat/discovery");
+  listToolsMock.mockReset();
+});
+
+describe("Amplitude plugin package", () => {
+  it("discovers the shipped manifest and exposes only allowlisted MCP tools", async () => {
+    const tempRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "junior-amplitude-package-"),
+    );
+    const packageRoot = path.join(
+      tempRoot,
+      "node_modules",
+      "@sentry",
+      "junior-amplitude",
+    );
+    await fs.mkdir(path.dirname(packageRoot), { recursive: true });
+    await fs.cp(
+      path.resolve(import.meta.dirname, "../../../../junior-amplitude"),
+      packageRoot,
+      { recursive: true },
+    );
+    await fs.writeFile(
+      path.join(tempRoot, "package.json"),
+      JSON.stringify({
+        name: "amplitude-test-app",
+        private: true,
+        dependencies: { "@sentry/junior-amplitude": "0.94.0" },
+      }),
+      "utf8",
+    );
+    process.chdir(tempRoot);
+
+    vi.resetModules();
+    vi.doMock("@/chat/discovery", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("@/chat/discovery")>()),
+      pluginRoots: () => [],
+    }));
+
+    const { pluginCatalogRuntime } =
+      await import("@/chat/plugins/catalog-runtime");
+    pluginCatalogRuntime.setConfig({
+      packages: ["@sentry/junior-amplitude"],
+    });
+    const providers = pluginCatalogRuntime.getProviders();
+
+    expect(providers).toHaveLength(1);
+    expect(providers[0]?.manifest.mcp).toMatchObject({
+      url: "https://mcp.amplitude.com/mcp",
+    });
+    const allowedTools = providers[0]?.manifest.mcp?.allowedTools;
+    expect(allowedTools).toEqual(readOnlyTools);
+
+    listToolsMock.mockResolvedValue([
+      ...readOnlyTools.map((name) => ({
+        name,
+        description: `Amplitude ${name}`,
+        inputSchema: { type: "object", properties: {} },
+      })),
+      {
+        name: "create_dashboard",
+        description: "Create a dashboard",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ]);
+
+    const manager = new McpToolManager(providers);
+    await manager.activateProvider("amplitude");
+
+    expect(manager.getActiveToolCatalog().map((tool) => tool.rawName)).toEqual(
+      readOnlyTools,
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@sentry/junior-agent-browser':
         specifier: workspace:*
         version: link:../../packages/junior-agent-browser
+      '@sentry/junior-amplitude':
+        specifier: workspace:*
+        version: link:../../packages/junior-amplitude
       '@sentry/junior-dashboard':
         specifier: workspace:*
         version: file:packages/junior-dashboard(jiti@2.7.0)
@@ -289,6 +292,8 @@ importers:
         version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(jiti@2.7.0)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(tsx@4.22.3)(yaml@2.9.0)
 
   packages/junior-agent-browser: {}
+
+  packages/junior-amplitude: {}
 
   packages/junior-cloudflare: {}
 

--- a/scripts/bump-release-versions.mjs
+++ b/scripts/bump-release-versions.mjs
@@ -12,6 +12,7 @@ const files = [
   "packages/junior/package.json",
   "packages/junior-plugin-api/package.json",
   "packages/junior-agent-browser/package.json",
+  "packages/junior-amplitude/package.json",
   "packages/junior-cloudflare/package.json",
   "packages/junior-dashboard/package.json",
   "packages/junior-datadog/package.json",


### PR DESCRIPTION
Adds `@sentry/junior-amplitude`, a manifest-only integration for Amplitude's hosted MCP server. The plugin exposes an explicit allowlist of 42 documented search, retrieval, list, and query tools while excluding rendering, creation, editing, sync triggers, taxonomy mutations, merges, and deletions.

The bundled skill covers product analytics, taxonomy, session replay, experiments, feature flags, guides and surveys, feedback, agent analytics, and user activity. It keeps queries narrow, treats user and event data as sensitive, and prevents credential fields or unrelated raw content from being returned.

The package is wired into the example app, public plugin documentation, release metadata, package linting, and CI artifacts. A component test discovers the shipped package and verifies that its exact read-only allowlist is the only MCP surface activated.

Fixes #810