### PR TITLE
fix(evals): Cancel provider retries after test timeout

### DIFF
--- a/packages/junior-evals/src/behavior-harness.ts
+++ b/packages/junior-evals/src/behavior-harness.ts
@@ -300,6 +300,7 @@ export interface EvalScenario {
 
 interface EvalScenarioRunOptions {
   logRecords?: EmittedLogRecord[];
+  signal?: AbortSignal;
 }
 
 export interface EvalResult {
@@ -1686,6 +1687,7 @@ function buildRuntimeServices(
   threadRecordsById: Map<string, EvalThreadRecord>,
   observations: RuntimeObservations,
   conversationWorkQueue: ConversationWorkQueueTestAdapter,
+  signal?: AbortSignal,
 ): JuniorRuntimeServiceOverrides {
   const replyResults = scenario.overrides?.reply_results ?? [];
   const replyTexts = scenario.overrides?.reply_texts ?? [];
@@ -1823,6 +1825,7 @@ function buildRuntimeServices(
               ...request,
               policy: {
                 ...request.policy,
+                signal,
                 turnDeadlineAtMs: Math.min(
                   request.policy?.turnDeadlineAtMs ?? Number.POSITIVE_INFINITY,
                   Date.now() + replyTimeoutMs,
@@ -2377,6 +2380,7 @@ export async function runEvalScenario(
       threadRecordsById,
       observations,
       conversationWorkQueue,
+      options.signal,
     );
     const evalAgentRunner = services.replyExecutor?.agentRunner;
     if (!evalAgentRunner) {

--- a/packages/junior-evals/src/helpers.ts
+++ b/packages/junior-evals/src/helpers.ts
@@ -456,7 +456,7 @@ function parseJudgeResult(text: string): JudgeResultPayload {
 /** Replays Slack events through the real runtime and returns normalized artifacts. */
 export const slackHarness: Harness<SlackEvalInput> = {
   name: "slack",
-  run: async (input) => {
+  run: async (input, { signal }) => {
     const logRecords: EmittedLogRecord[] = [];
     const unregisterLogSink = registerLogRecordSink((record) => {
       logRecords.push(record);
@@ -468,7 +468,7 @@ export const slackHarness: Harness<SlackEvalInput> = {
           events: input.events,
           overrides: input.overrides,
         },
-        { logRecords },
+        { logRecords, signal },
       );
       const result =
         typeof input.taskTimeout === "number" && input.taskTimeout > 0

--- a/packages/junior-evals/tests/unit/harness/behavior-harness.test.ts
+++ b/packages/junior-evals/tests/unit/harness/behavior-harness.test.ts
@@ -1,11 +1,13 @@
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 
 const {
+  executeAgentRunMock,
   handleSubscribedMessageMock,
   observedRuntimeIds,
   originalStateAdapterEnv,
   noopAsync,
   handleNewMentionMock,
+  runtimeState,
 } = vi.hoisted(() => {
   const originalStateAdapterEnv = process.env.JUNIOR_STATE_ADAPTER;
   process.env.JUNIOR_STATE_ADAPTER = "memory";
@@ -17,9 +19,15 @@ const {
   };
 
   return {
+    executeAgentRunMock: vi.fn(async () => ({})),
     observedRuntimeIds,
     originalStateAdapterEnv,
     noopAsync: vi.fn(async () => {}),
+    runtimeState: {
+      agentRunner: undefined as
+        | { run: (request: unknown) => Promise<unknown> }
+        | undefined,
+    },
     handleNewMentionMock: vi.fn(
       async (
         thread: { id: string; post: (value: unknown) => Promise<void> },
@@ -51,13 +59,28 @@ const {
   };
 });
 
+vi.mock("@/chat/agent", () => ({
+  executeAgentRun: executeAgentRunMock,
+}));
+
 vi.mock("@/chat/app/factory", () => ({
-  createSlackRuntime: vi.fn(() => ({
-    handleNewMention: handleNewMentionMock,
-    handleSubscribedMessage: handleSubscribedMessageMock,
-    handleAssistantThreadStarted: noopAsync,
-    handleAssistantContextChanged: noopAsync,
-  })),
+  createSlackRuntime: vi.fn(
+    (options: {
+      services?: {
+        replyExecutor?: {
+          agentRunner?: { run: (request: unknown) => Promise<unknown> };
+        };
+      };
+    }) => {
+      runtimeState.agentRunner = options.services?.replyExecutor?.agentRunner;
+      return {
+        handleNewMention: handleNewMentionMock,
+        handleSubscribedMessage: handleSubscribedMessageMock,
+        handleAssistantThreadStarted: noopAsync,
+        handleAssistantContextChanged: noopAsync,
+      };
+    },
+  ),
 }));
 
 import {
@@ -79,9 +102,24 @@ describe("behavior harness", () => {
     observedRuntimeIds.juniorBaseUrl = undefined;
     observedRuntimeIds.threadId = undefined;
     observedRuntimeIds.messageThreadId = undefined;
+    runtimeState.agentRunner = undefined;
+    executeAgentRunMock.mockClear();
     handleNewMentionMock.mockClear();
     handleSubscribedMessageMock.mockClear();
     noopAsync.mockClear();
+  });
+
+  it("forwards the host signal into the eval agent policy", async () => {
+    const controller = new AbortController();
+
+    await runEvalScenario({ events: [] }, { signal: controller.signal });
+    await runtimeState.agentRunner?.run({ policy: {} });
+
+    expect(executeAgentRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        policy: expect.objectContaining({ signal: controller.signal }),
+      }),
+    );
   });
 
   it("normalizes eval thread fixtures to Slack-style runtime thread ids", async () => {

--- a/packages/junior-evals/tests/unit/harness/helpers.test.ts
+++ b/packages/junior-evals/tests/unit/harness/helpers.test.ts
@@ -1,0 +1,35 @@
+import { expect, it, vi } from "vitest";
+
+const { runError, runEvalScenarioMock } = vi.hoisted(() => ({
+  runError: new Error("stop after capturing harness options"),
+  runEvalScenarioMock: vi.fn(async () => {
+    throw new Error("uninitialized run error");
+  }),
+}));
+
+vi.mock("../../../src/behavior-harness", () => ({
+  runEvalScenario: runEvalScenarioMock,
+}));
+
+import { slackHarness } from "../../../src/helpers";
+
+it("forwards the Vitest abort signal to the eval scenario", async () => {
+  runEvalScenarioMock.mockRejectedValueOnce(runError);
+  const controller = new AbortController();
+
+  await expect(
+    slackHarness.run(
+      { criteria: { pass: [] }, events: [] },
+      {
+        artifacts: {},
+        setArtifact: vi.fn(),
+        signal: controller.signal,
+      },
+    ),
+  ).rejects.toBe(runError);
+
+  expect(runEvalScenarioMock).toHaveBeenCalledWith(
+    { events: [], overrides: undefined },
+    { logRecords: [], signal: controller.signal },
+  );
+});

--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -99,12 +99,9 @@ import {
 } from "@/chat/agent/prompt";
 import { wireAgentTools } from "@/chat/agent/tools";
 import { createResumeState, type ResumeState } from "@/chat/agent/resume";
+import { sleep } from "@/chat/sleep";
 
 const AGENT_ABORT_SETTLE_GRACE_MS = 5_000;
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 /** Bound post-abort waiting so timeout recovery can persist before the host kills the slice. */
 function waitForAbortSettlement(
@@ -165,9 +162,12 @@ async function executeAgentRunInPrivacyContext(
 ): Promise<AgentRunOutcome> {
   const { input, routing } = request;
   const policy = request.policy ?? {};
+  const signal = policy.signal;
   const state = request.state ?? {};
   const observers = request.observers ?? {};
   const durability = request.durability ?? {};
+
+  signal?.throwIfAborted();
 
   if (!routing.destination) {
     throw new TypeError("Assistant reply generation requires a destination");
@@ -690,6 +690,7 @@ async function executeAgentRunInPrivacyContext(
             run: Promise<unknown>,
           ): Promise<unknown> => {
             let timeoutId: ReturnType<typeof setTimeout> | undefined;
+            let removeAbortListener: (() => void) | undefined;
             const timeoutPromise = new Promise<never>((_, reject) => {
               const rejectWithTimeout = () => {
                 runResume.markTimedOut();
@@ -707,9 +708,30 @@ async function executeAgentRunInPrivacyContext(
               }
               timeoutId = setTimeout(rejectWithTimeout, remainingTimeoutMs);
             });
+            const abortPromise = signal
+              ? new Promise<never>((_, reject) => {
+                  const rejectWithAbort = () => {
+                    agent!.abort();
+                    reject(signal.reason);
+                  };
+                  if (signal.aborted) {
+                    rejectWithAbort();
+                    return;
+                  }
+                  signal.addEventListener("abort", rejectWithAbort, {
+                    once: true,
+                  });
+                  removeAbortListener = () =>
+                    signal.removeEventListener("abort", rejectWithAbort);
+                })
+              : undefined;
 
             try {
-              return await Promise.race([run, timeoutPromise]);
+              return await Promise.race(
+                abortPromise
+                  ? [run, timeoutPromise, abortPromise]
+                  : [run, timeoutPromise],
+              );
             } catch (error) {
               if (runResume.timedOut) {
                 logWarn(
@@ -763,6 +785,7 @@ async function executeAgentRunInPrivacyContext(
               if (timeoutId) {
                 clearTimeout(timeoutId);
               }
+              removeAbortListener?.();
             }
           };
 
@@ -772,6 +795,7 @@ async function executeAgentRunInPrivacyContext(
           let retryUsage: AgentTurnUsage | undefined;
           for (let attempt = 0; ; attempt += 1) {
             promptResult = await runAgentStep(run);
+            signal?.throwIfAborted();
             if (runResume.cooperativeYieldError) {
               throw runResume.cooperativeYieldError;
             }
@@ -830,7 +854,8 @@ async function executeAgentRunInPrivacyContext(
               {},
               "Retrying transient provider failure",
             );
-            await sleep(providerRetry.delayMs);
+            await sleep(providerRetry.delayMs, signal);
+            signal?.throwIfAborted();
             run = agent!.continue();
           }
         },

--- a/packages/junior/src/chat/agent/request.ts
+++ b/packages/junior/src/chat/agent/request.ts
@@ -101,6 +101,8 @@ export interface AgentRunRouting {
 export interface AgentRunPolicy {
   /** Absolute wall-clock deadline for this host request, in milliseconds. */
   turnDeadlineAtMs?: number;
+  /** Cancels provider work when the owning host request is abandoned. */
+  signal?: AbortSignal;
   authorizationFlowMode?: AuthorizationFlowMode;
   configuration?: Record<string, unknown>;
   channelConfiguration?: ChannelConfigurationService;

--- a/packages/junior/src/chat/credentials/state-adapter-token-store.ts
+++ b/packages/junior/src/chat/credentials/state-adapter-token-store.ts
@@ -4,6 +4,7 @@ import type {
   UserTokenStore,
 } from "@/chat/credentials/user-token-store";
 import { storedTokensSchema } from "@/chat/credentials/user-token-store";
+import { sleep } from "@/chat/sleep";
 import { acquireActiveLock } from "@/chat/state/locks";
 
 const KEY_PREFIX = "oauth-token";
@@ -18,10 +19,6 @@ function tokenKey(userId: string, provider: string): string {
 
 function refreshLockKey(userId: string, provider: string): string {
   return `${tokenKey(userId, provider)}:refresh`;
-}
-
-async function sleep(ms: number): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export class StateAdapterTokenStore implements UserTokenStore {

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -47,6 +47,7 @@ import {
   commitMessages,
   loadProjection,
 } from "@/chat/conversations/projection";
+import { sleep } from "@/chat/sleep";
 
 const DELIVERED_STATE_PERSIST_ATTEMPTS = 3;
 
@@ -100,10 +101,6 @@ function localReply(reply: AgentRunResult): LocalAgentReply {
   return {
     text: reply.text,
   };
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function nextUserMessageSequence(

--- a/packages/junior/src/chat/runtime/agent-continue-runner.ts
+++ b/packages/junior/src/chat/runtime/agent-continue-runner.ts
@@ -71,6 +71,7 @@ import {
 } from "@/chat/services/pending-auth";
 import { requireSlackDestination } from "@/chat/destination";
 import type { CredentialContext } from "@/chat/credentials/context";
+import { sleep } from "@/chat/sleep";
 
 const AGENT_CONTINUE_LOCK_RETRY_DELAYS_MS = [250, 1_000, 2_000] as const;
 
@@ -83,10 +84,6 @@ export interface AgentContinueRunnerOptions {
     conversationId: string;
     sessionId: string;
   }) => Promise<void>;
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /** Persist a delivered continuation reply as the terminal thread state. */

--- a/packages/junior/src/chat/sandbox/runtime-dependency-snapshots.ts
+++ b/packages/junior/src/chat/sandbox/runtime-dependency-snapshots.ts
@@ -14,6 +14,7 @@ import type {
 } from "@/chat/plugins/types";
 import { SANDBOX_WORKSPACE_ROOT } from "@/chat/sandbox/paths";
 import { getSandboxResources } from "@/chat/sandbox/resources";
+import { sleep } from "@/chat/sleep";
 import { getStateAdapter } from "@/chat/state/adapter";
 
 const SNAPSHOT_CACHE_PREFIX = "junior:sandbox_snapshot_profile";
@@ -73,12 +74,6 @@ interface BuildLockResult {
   snapshotId: string;
   source: "wait_cache" | "callback_cache" | "built";
   waitedForLock: boolean;
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 function profileCacheKey(profileHash: string): string {

--- a/packages/junior/src/chat/sandbox/session.ts
+++ b/packages/junior/src/chat/sandbox/session.ts
@@ -33,6 +33,7 @@ import {
   type SandboxFileSystem,
   type SandboxInstance,
 } from "@/chat/sandbox/workspace";
+import { sleep } from "@/chat/sleep";
 import type { SkillMetadata } from "@/chat/skills";
 
 const DEFAULT_MAX_OUTPUT_LENGTH = 30_000;
@@ -131,12 +132,6 @@ function truncateOutput(
     value: `${output.slice(0, maxLength)}\n\n[output truncated: ${truncatedLength} characters removed]`,
     truncated: true,
   };
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 function parseKeepAliveMs(): number {

--- a/packages/junior/src/chat/services/persist-retry.ts
+++ b/packages/junior/src/chat/services/persist-retry.ts
@@ -5,11 +5,9 @@
  * state-write failure, so both the Slack reply executor and the dispatch
  * runner retry these persists with the same short linear backoff.
  */
-const PERSIST_ATTEMPTS = 3;
+import { sleep } from "@/chat/sleep";
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
+const PERSIST_ATTEMPTS = 3;
 
 /** Retry a delivered-state persist briefly before surfacing the failure. */
 export async function persistWithRetry(

--- a/packages/junior/src/chat/slack/client.ts
+++ b/packages/junior/src/chat/slack/client.ts
@@ -12,6 +12,7 @@ import {
   type SlackChannelId,
 } from "@/chat/slack/ids";
 import { getWorkspaceTeamId } from "@/chat/slack/workspace-context";
+import { sleep } from "@/chat/sleep";
 
 // Slack canvas/list methods are not exposed by the current chat adapter public API,
 // so this module owns direct Web API calls for artifact actions.
@@ -358,10 +359,6 @@ function mapSlackError(error: unknown): SlackActionError {
   }
 
   return new SlackActionError(message, "internal_error", baseOptions);
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 // Retry pauses are bounded so a hostile or huge Retry-After header cannot eat

--- a/packages/junior/src/chat/sleep.ts
+++ b/packages/junior/src/chat/sleep.ts
@@ -1,0 +1,21 @@
+/** Wait for a duration, rejecting with the owning signal reason when cancelled. */
+export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (!signal) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    const timeoutId = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timeoutId);
+      reject(signal.reason);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/packages/junior/tests/integration/runtime/agent-run-provider-retry.test.ts
+++ b/packages/junior/tests/integration/runtime/agent-run-provider-retry.test.ts
@@ -9,12 +9,14 @@ const { agentMode, counters, sessionLogState } = vi.hoisted(() => ({
   agentMode: {
     value: "providerRetry" as
       | "providerRetry"
+      | "pendingProviderCall"
       | "cooperativeYield"
       | "steering"
       | "steeringSteerThrows"
       | "toolActivity",
   },
   counters: {
+    abortCalls: 0,
     continueCalls: 0,
     promptCalls: 0,
   },
@@ -86,6 +88,7 @@ vi.mock("@earendil-works/pi-agent-core", () => {
       tools: unknown[];
     };
     private prepareNextTurn?: () => Promise<unknown> | unknown;
+    private finishPendingRun?: () => void;
     private steeringMessages: unknown[] = [];
     private subscribers: Array<(event: unknown) => unknown> = [];
 
@@ -123,7 +126,8 @@ vi.mock("@earendil-works/pi-agent-core", () => {
     }
 
     abort() {
-      return undefined;
+      counters.abortCalls += 1;
+      this.finishPendingRun?.();
     }
 
     private recordRunFailure(error: unknown) {
@@ -142,6 +146,12 @@ vi.mock("@earendil-works/pi-agent-core", () => {
     async prompt(message: unknown) {
       counters.promptCalls += 1;
       this.state.messages.push(message);
+      if (agentMode.value === "pendingProviderCall") {
+        await new Promise<void>((resolve) => {
+          this.finishPendingRun = resolve;
+        });
+        return {};
+      }
       if (agentMode.value === "toolActivity") {
         // Pi surfaces subscriber rejections as run failures; a host-only
         // activity append that rejects must not reach this path.
@@ -363,6 +373,7 @@ const TEST_SOURCE = createSlackSource({
 describe("executeAgentRun provider retry", () => {
   beforeEach(async () => {
     agentMode.value = "providerRetry";
+    counters.abortCalls = 0;
     counters.continueCalls = 0;
     counters.promptCalls = 0;
     sessionLogState.failToolExecutionAppend = false;
@@ -426,6 +437,70 @@ describe("executeAgentRun provider retry", () => {
       "toolResult",
     ]);
   }, 20_000);
+
+  it("stops provider retry backoff when the host request is cancelled", async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const controller = new AbortController();
+    const replyPromise = executeAgentRun({
+      input: { messageText: "help me" },
+      routing: {
+        destination: TEST_DESTINATION,
+        source: TEST_SOURCE,
+        actor: { platform: "slack", teamId: "T123", userId: "U123" },
+        correlation: {
+          conversationId: "conversation-cancelled-backoff",
+          turnId: "turn-cancelled-backoff",
+          channelId: "C123",
+          threadTs: "1712345.0001",
+        },
+      },
+      policy: { signal: controller.signal },
+    });
+
+    for (let attempt = 0; attempt < 2_000; attempt += 1) {
+      if (setTimeoutSpy.mock.calls.some((call) => call[1] === 2_000)) {
+        break;
+      }
+      await realSleep(5);
+    }
+    expect(setTimeoutSpy.mock.calls.some((call) => call[1] === 2_000)).toBe(
+      true,
+    );
+    controller.abort(new Error("eval test cancelled"));
+
+    const reply = finalReply(await replyPromise);
+    expect(reply.diagnostics.errorMessage).toBe("eval test cancelled");
+    expect(counters.continueCalls).toBe(0);
+    setTimeoutSpy.mockRestore();
+  });
+
+  it("aborts an active provider call when the host request is cancelled", async () => {
+    agentMode.value = "pendingProviderCall";
+    const controller = new AbortController();
+    const replyPromise = executeAgentRun({
+      input: { messageText: "help me" },
+      routing: {
+        destination: TEST_DESTINATION,
+        source: TEST_SOURCE,
+        actor: { platform: "slack", teamId: "T123", userId: "U123" },
+        correlation: {
+          conversationId: "conversation-cancelled-provider",
+          turnId: "turn-cancelled-provider",
+          channelId: "C123",
+          threadTs: "1712345.0001",
+        },
+      },
+      policy: { signal: controller.signal },
+    });
+
+    await waitForPromptCall(1);
+    controller.abort(new Error("eval test cancelled"));
+
+    const reply = finalReply(await replyPromise);
+    expect(reply.diagnostics.errorMessage).toBe("eval test cancelled");
+    expect(counters.abortCalls).toBe(1);
+    expect(counters.continueCalls).toBe(0);
+  });
 
   it("persists and queues steering messages at the next Pi boundary", async () => {
     agentMode.value = "steering";

--- a/packages/junior/tests/unit/chat/sleep.test.ts
+++ b/packages/junior/tests/unit/chat/sleep.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { sleep } from "@/chat/sleep";
+
+describe("sleep", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves after the requested duration", async () => {
+    vi.useFakeTimers();
+    const wait = sleep(100);
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(wait).resolves.toBeUndefined();
+  });
+
+  it("rejects with the owning signal reason", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const reason = new Error("cancelled");
+    const wait = sleep(100, controller.signal);
+
+    controller.abort(reason);
+
+    await expect(wait).rejects.toBe(reason);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("rejects immediately when the signal is already aborted", async () => {
+    const controller = new AbortController();
+    const reason = new Error("already cancelled");
+    controller.abort(reason);
+
+    await expect(sleep(100, controller.signal)).rejects.toBe(reason);
+  });
+});

--- a/specs/harness-agent.md
+++ b/specs/harness-agent.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-02-24
-- Last Edited: 2026-06-08
+- Last Edited: 2026-07-10
 
 ## Purpose
 
@@ -45,6 +45,7 @@ Define the canonical runtime contract for assistant-turn execution and user-visi
 ### Timeout behavior
 
 - `executeAgentRun(...)` aborts the Pi agent on timeout and waits for the in-flight prompt/continue call to settle before inspecting Pi messages.
+- When the owning host request is cancelled, `executeAgentRun(...)` aborts the active Pi call and any pending provider retry backoff.
 - When resumability context is available (`conversation_id` + `session_id`) and a safe-boundary session record can be persisted, timeout throws `RetryableTurnError("agent_continue")` with session record metadata instead of returning a normal reply payload.
 - When no resumable session record can be persisted, timeout falls back to the standard provider-error reply path.
 - The harness does not decide whether timed-out work should be auto-resumed after user-visible output has started. Higher-level runtime code applies the visibility rules from [Agent Session Resumability Spec](./agent-session-resumability.md).


### PR DESCRIPTION
Vitest already aborts the eval harness signal when a test times out, but the
Slack eval path dropped that signal before agent execution. Active provider
calls and provider retry backoff could therefore continue during teardown.

This passes the host signal through `runEvalScenario` into `AgentRunPolicy`.
The agent runner aborts the active Pi call and uses the shared abort-capable
`chat/sleep` utility for provider retry backoff. Other standard delay helpers
now use the same utility; the two lock delays that intentionally `unref()`
their timers remain feature-owned because they have different lifecycle
semantics.

Slack runtime, classifier, judge, and explicit `taskTimeout` behavior remain
unchanged. Focused coverage verifies harness signal wiring, active provider
cancellation, retry cancellation, and the shared delay contract.

Fixes #779