### PR TITLE
fix(resource-events): Wait for subscription locks

### DIFF
--- a/packages/junior/src/chat/resource-events/ingest.ts
+++ b/packages/junior/src/chat/resource-events/ingest.ts
@@ -44,6 +44,7 @@ export async function ingestResourceEvent(
   });
   let enqueued = 0;
   const errors: unknown[] = [];
+  const waitDeadlineMs = Date.now() + 10_000;
   for (const subscription of subscriptions) {
     try {
       const delivered = await deliverResourceEventSubscription({
@@ -54,6 +55,7 @@ export async function ingestResourceEvent(
         nowMs,
         state: options.state,
         subscription,
+        waitDeadlineMs,
         deliver: async (current) => {
           const result = await enqueueResourceEventNotification({
             event,

--- a/packages/junior/src/chat/resource-events/store.ts
+++ b/packages/junior/src/chat/resource-events/store.ts
@@ -113,6 +113,7 @@ async function withSubscriptionLock<T>(
     subscriptionId,
     waitDeadlineMs,
   );
+  let lockLostError: Error | undefined;
   let heartbeatError: Error | undefined;
   let heartbeat: Promise<void> | undefined;
   const timer = setInterval(() => {
@@ -122,8 +123,10 @@ async function withSubscriptionLock<T>(
     heartbeat = state
       .extendLock(lock, SUBSCRIPTION_LOCK_TTL_MS)
       .then((extended) => {
-        if (!extended) {
-          heartbeatError = new Error(
+        if (extended) {
+          heartbeatError = undefined;
+        } else {
+          lockLostError = new Error(
             `Resource event subscription lock was lost for ${subscriptionId}`,
           );
         }
@@ -147,8 +150,9 @@ async function withSubscriptionLock<T>(
     await heartbeat;
     await state.releaseLock(lock);
   }
-  if (heartbeatError) {
-    throw heartbeatError;
+  const lockError = lockLostError ?? heartbeatError;
+  if (lockError) {
+    throw lockError;
   }
   return result;
 }

--- a/packages/junior/src/chat/resource-events/store.ts
+++ b/packages/junior/src/chat/resource-events/store.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import type { StateAdapter } from "chat";
+import type { Lock, StateAdapter } from "chat";
 import { destinationSchema, type Destination } from "@sentry/junior-plugin-api";
 import { z } from "zod";
 import { getStateAdapter } from "@/chat/state/adapter";
@@ -8,6 +8,9 @@ import { JUNIOR_THREAD_STATE_TTL_MS } from "@/chat/state/ttl";
 const RESOURCE_EVENT_PREFIX = "junior:resource_event_subscription";
 const INDEX_LOCK_TTL_MS = 10_000;
 const SUBSCRIPTION_LOCK_TTL_MS = 10_000;
+const SUBSCRIPTION_LOCK_WAIT_MS = 10_000;
+const SUBSCRIPTION_LOCK_RETRY_MS = 25;
+const SUBSCRIPTION_LOCK_HEARTBEAT_MS = 3_000;
 
 const subscriptionStatusSchema = z.enum(["active", "cancelled", "completed"]);
 
@@ -67,6 +70,87 @@ function conversationIndexKey(conversationId: string): string {
 
 function indexLockKey(key: string): string {
   return `${key}:lock`;
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    (timer as { unref?: () => void }).unref?.();
+  });
+}
+
+async function acquireSubscriptionLock(
+  state: StateAdapter,
+  subscriptionId: string,
+  waitDeadlineMs = Date.now() + SUBSCRIPTION_LOCK_WAIT_MS,
+): Promise<Lock> {
+  while (true) {
+    const lock = await state.acquireLock(
+      subscriptionLockKey(subscriptionId),
+      SUBSCRIPTION_LOCK_TTL_MS,
+    );
+    if (lock) {
+      return lock;
+    }
+    if (Date.now() >= waitDeadlineMs) {
+      throw new Error(
+        `Could not acquire resource event subscription lock for ${subscriptionId}`,
+      );
+    }
+    await sleep(SUBSCRIPTION_LOCK_RETRY_MS);
+  }
+}
+
+/** Run one subscription lifecycle transition while keeping its lease alive. */
+async function withSubscriptionLock<T>(
+  state: StateAdapter,
+  subscriptionId: string,
+  callback: () => Promise<T>,
+  waitDeadlineMs?: number,
+): Promise<T> {
+  const lock = await acquireSubscriptionLock(
+    state,
+    subscriptionId,
+    waitDeadlineMs,
+  );
+  let heartbeatError: Error | undefined;
+  let heartbeat: Promise<void> | undefined;
+  const timer = setInterval(() => {
+    if (heartbeat) {
+      return;
+    }
+    heartbeat = state
+      .extendLock(lock, SUBSCRIPTION_LOCK_TTL_MS)
+      .then((extended) => {
+        if (!extended) {
+          heartbeatError = new Error(
+            `Resource event subscription lock was lost for ${subscriptionId}`,
+          );
+        }
+      })
+      .catch((error: unknown) => {
+        heartbeatError =
+          error instanceof Error
+            ? error
+            : new Error(`Failed to extend subscription lock: ${String(error)}`);
+      })
+      .finally(() => {
+        heartbeat = undefined;
+      });
+  }, SUBSCRIPTION_LOCK_HEARTBEAT_MS);
+  timer.unref?.();
+  let result: T;
+  try {
+    result = await callback();
+  } finally {
+    clearInterval(timer);
+    await heartbeat;
+    await state.releaseLock(lock);
+  }
+  if (heartbeatError) {
+    throw heartbeatError;
+  }
+  return result;
 }
 
 function ttlUntil(expiresAtMs: number, nowMs: number): number {
@@ -289,14 +373,7 @@ export async function cancelResourceEventSubscription(input: {
 }): Promise<ResourceEventSubscription | undefined> {
   const state = input.state ?? getStateAdapter();
   await state.connect();
-  const lock = await state.acquireLock(
-    subscriptionLockKey(input.id),
-    SUBSCRIPTION_LOCK_TTL_MS,
-  );
-  if (!lock) {
-    throw new Error(`Could not acquire subscription lock for ${input.id}`);
-  }
-  try {
+  return await withSubscriptionLock(state, input.id, async () => {
     const current = parseSubscription(
       await state.get(subscriptionKey(input.id)),
     );
@@ -327,9 +404,7 @@ export async function cancelResourceEventSubscription(input: {
       nowMs,
     );
     return next;
-  } finally {
-    await state.releaseLock(lock);
-  }
+  });
 }
 
 /** Find active subscriptions interested in a normalized provider event. */
@@ -374,71 +449,66 @@ export async function deliverResourceEventSubscription(input: {
   state?: StateAdapter;
   subscription: ResourceEventSubscription;
   terminal?: boolean;
+  waitDeadlineMs?: number;
 }): Promise<boolean> {
   const state = input.state ?? getStateAdapter();
   await state.connect();
-  const lock = await state.acquireLock(
-    subscriptionLockKey(input.subscription.id),
-    SUBSCRIPTION_LOCK_TTL_MS,
-  );
-  if (!lock) {
-    throw new Error(
-      `Resource event subscription delivery lock busy: ${input.subscription.id}`,
-    );
-  }
-  try {
-    const nowMs = input.nowMs ?? Date.now();
-    const current = parseSubscription(
-      await state.get(subscriptionKey(input.subscription.id)),
-    );
-    if (
-      !current ||
-      !matchesEvent(current, {
-        eventType: input.eventType,
-        nowMs,
-        provider: input.provider,
-        resourceRef: input.resourceRef,
-      })
-    ) {
-      return false;
-    }
-    const delivered = await input.deliver(current);
-    if (input.terminal) {
-      const latest = parseSubscription(
-        await state.get(subscriptionKey(current.id)),
+  return await withSubscriptionLock(
+    state,
+    input.subscription.id,
+    async () => {
+      const nowMs = input.nowMs ?? Date.now();
+      const current = parseSubscription(
+        await state.get(subscriptionKey(input.subscription.id)),
       );
       if (
-        !latest ||
-        latest.status !== current.status ||
-        latest.updatedAtMs !== current.updatedAtMs
+        !current ||
+        !matchesEvent(current, {
+          eventType: input.eventType,
+          nowMs,
+          provider: input.provider,
+          resourceRef: input.resourceRef,
+        })
       ) {
-        return delivered;
+        return false;
       }
-      const next: ResourceEventSubscription = {
-        ...current,
-        status: "completed",
-        updatedAtMs: nowMs,
-      };
-      await state.set(
-        subscriptionKey(current.id),
-        next,
-        JUNIOR_THREAD_STATE_TTL_MS,
-      );
-      await removeFromIndex(
-        state,
-        resourceIndexKey(current.provider, current.resourceRef),
-        current.id,
-        nowMs,
-      );
-      await removeFromIndex(
-        state,
-        conversationIndexKey(current.conversationId),
-        current.id,
-        nowMs,
-      );
-    }
-    return delivered;
-  } finally {
-    await state.releaseLock(lock);
-  }
+      const delivered = await input.deliver(current);
+      if (input.terminal) {
+        const latest = parseSubscription(
+          await state.get(subscriptionKey(current.id)),
+        );
+        if (
+          !latest ||
+          latest.status !== current.status ||
+          latest.updatedAtMs !== current.updatedAtMs
+        ) {
+          return delivered;
+        }
+        const next: ResourceEventSubscription = {
+          ...current,
+          status: "completed",
+          updatedAtMs: nowMs,
+        };
+        await state.set(
+          subscriptionKey(current.id),
+          next,
+          JUNIOR_THREAD_STATE_TTL_MS,
+        );
+        await removeFromIndex(
+          state,
+          resourceIndexKey(current.provider, current.resourceRef),
+          current.id,
+          nowMs,
+        );
+        await removeFromIndex(
+          state,
+          conversationIndexKey(current.conversationId),
+          current.id,
+          nowMs,
+        );
+      }
+      return delivered;
+    },
+    input.waitDeadlineMs,
+  );
 }

--- a/packages/junior/tests/component/resource-events/resource-events.test.ts
+++ b/packages/junior/tests/component/resource-events/resource-events.test.ts
@@ -252,11 +252,12 @@ describe("resource event subscriptions", () => {
     expect(deliver).not.toHaveBeenCalled();
   });
 
-  it("continues delivering later subscriptions when one delivery lock is busy", async () => {
+  it("waits for a contended delivery lock before delivering all matches", async () => {
     const queue = createConversationWorkQueueTestAdapter();
     const baseState = getStateAdapter();
     await baseState.connect();
-    let busySubscriptionId: string | undefined;
+    let contendedSubscriptionId: string | undefined;
+    let contendedAttempts = 0;
     const state = {
       connect: async () => {
         await baseState.connect();
@@ -268,10 +269,17 @@ describe("resource event subscriptions", () => {
       set: async (key: string, value: unknown, ttlMs?: number) =>
         await baseState.set(key, value, ttlMs),
       delete: async (key: string) => await baseState.delete(key),
-      acquireLock: async (key: string, ttlMs?: number) =>
-        busySubscriptionId && key.endsWith(`:${busySubscriptionId}`)
-          ? undefined
-          : await baseState.acquireLock(key, ttlMs ?? 10_000),
+      acquireLock: async (key: string, ttlMs?: number) => {
+        if (
+          contendedSubscriptionId &&
+          key.endsWith(`:${contendedSubscriptionId}`) &&
+          contendedAttempts < 2
+        ) {
+          contendedAttempts += 1;
+          return null;
+        }
+        return await baseState.acquireLock(key, ttlMs ?? 10_000);
+      },
       extendLock: async (
         lock: Parameters<StateAdapter["extendLock"]>[0],
         ttlMs: number,
@@ -284,7 +292,7 @@ describe("resource event subscriptions", () => {
         }
       },
     } as StateAdapter;
-    const busySubscription = await createGithubPrSubscription({
+    const contendedSubscription = await createGithubPrSubscription({
       events: ["checks.failed"],
       state,
     });
@@ -306,7 +314,7 @@ describe("resource event subscriptions", () => {
       },
       { nowMs: 1_000, state },
     );
-    busySubscriptionId = busySubscription.id;
+    contendedSubscriptionId = contendedSubscription.id;
 
     await expect(
       ingestResourceEvent(
@@ -320,15 +328,52 @@ describe("resource event subscriptions", () => {
         },
         { nowMs: 1_500, queue, state },
       ),
-    ).rejects.toThrow(
-      "Failed to deliver one or more resource event subscriptions",
-    );
+    ).resolves.toEqual({ enqueued: 2 });
+    expect(contendedAttempts).toBe(2);
 
-    expect(queue.sentRecords()).toEqual([
-      expect.objectContaining({
-        conversationId: "slack:C456:1712345.0002",
-      }),
-    ]);
+    expect(queue.sentRecords()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ conversationId: CONVERSATION_ID }),
+        expect.objectContaining({
+          conversationId: "slack:C456:1712345.0002",
+        }),
+      ]),
+    );
+  });
+
+  it("keeps the subscription lock leased during a long delivery", async () => {
+    vi.useFakeTimers({ now: 1_000 });
+    const state = getStateAdapter();
+    await state.connect();
+    const subscription = await createGithubPrSubscription({
+      events: ["checks.failed"],
+      state,
+    });
+    let finishDelivery: (() => void) | undefined;
+    const delivery = deliverResourceEventSubscription({
+      eventType: "checks.failed",
+      nowMs: 1_500,
+      provider: "github",
+      resourceRef: "github:pull_request:getsentry/junior#691",
+      state,
+      subscription,
+      deliver: async () =>
+        await new Promise<boolean>((resolve) => {
+          finishDelivery = () => resolve(true);
+        }),
+    });
+
+    await vi.advanceTimersByTimeAsync(12_000);
+
+    await expect(
+      state.acquireLock(
+        `junior:resource_event_subscription:lock:${subscription.id}`,
+        10_000,
+      ),
+    ).resolves.toBeNull();
+
+    finishDelivery?.();
+    await expect(delivery).resolves.toBe(true);
   });
 
   it("does not complete a subscription refreshed during terminal delivery", async () => {

--- a/packages/junior/tests/component/resource-events/resource-events.test.ts
+++ b/packages/junior/tests/component/resource-events/resource-events.test.ts
@@ -376,6 +376,52 @@ describe("resource event subscriptions", () => {
     await expect(delivery).resolves.toBe(true);
   });
 
+  it("recovers after a transient subscription lock heartbeat failure", async () => {
+    vi.useFakeTimers({ now: 1_000 });
+    const baseState = getStateAdapter();
+    await baseState.connect();
+    let extendAttempts = 0;
+    const state = new Proxy(baseState, {
+      get(target, property, receiver) {
+        if (property === "extendLock") {
+          return async (
+            lock: Parameters<StateAdapter["extendLock"]>[0],
+            ttlMs: number,
+          ) => {
+            extendAttempts += 1;
+            if (extendAttempts === 1) {
+              throw new Error("transient state backend failure");
+            }
+            return await target.extendLock(lock, ttlMs);
+          };
+        }
+        const value = Reflect.get(target, property, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as StateAdapter;
+    const subscription = await createGithubPrSubscription({
+      events: ["checks.failed"],
+      state,
+    });
+    const delivery = deliverResourceEventSubscription({
+      eventType: "checks.failed",
+      nowMs: 1_500,
+      provider: "github",
+      resourceRef: "github:pull_request:getsentry/junior#691",
+      state,
+      subscription,
+      deliver: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 7_000));
+        return true;
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(7_000);
+
+    await expect(delivery).resolves.toBe(true);
+    expect(extendAttempts).toBe(2);
+  });
+
   it("does not complete a subscription refreshed during terminal delivery", async () => {
     const subscription = await createGithubPrSubscription({
       events: ["state.merged"],


### PR DESCRIPTION
Resource-event ingestion now waits through brief subscription lock contention instead of failing the provider webhook immediately. The lock remains leased while delivery or cancellation is active, preventing another invocation from acquiring an expired lease while the original holder is still appending mailbox work.

All subscriptions matched by one provider event share a single contention deadline, so webhook latency remains bounded rather than growing by ten seconds for every contended subscription. The regression coverage exercises both transient contention and delivery that lasts beyond the initial lock TTL.

Fixes JUNIOR-4K