### PR TITLE
feat(evals): Add explicit scenario event scheduling

### DIFF
--- a/packages/junior-evals/README.md
+++ b/packages/junior-evals/README.md
@@ -121,6 +121,9 @@ Evals require real Vercel Sandbox access. If sandbox bootstrap fails, the eval f
 ## Authoring Rules
 
 - Add core cases under `evals/core/*.eval.ts` and plugin-specific cases under `evals/<plugin>/` using `describeEval()` with `slackEvals`.
+- Put messages that should be pending before processing starts in `initialEvents`.
+- Put ordinary later events in `events`; each is delivered after preceding work settles.
+- Wrap messages with `steer(...)` when they should arrive through normal ingress while the preceding agent run is active.
 - Use event builders (`mention`, `threadMessage`, `threadStart`) from `src/helpers.ts`.
 - Use `auto_complete_mcp_oauth` or `auto_complete_oauth` when the harness should instantly complete the fake provider callback after our app has genuinely initiated auth.
 - For multi-turn, pass the same `thread` override so events land in one thread.
@@ -138,6 +141,27 @@ Evals require real Vercel Sandbox access. If sandbox bootstrap fails, the eval f
 - Keep user prompts natural. They should read like plausible user requests, not scripted implementation instructions.
 - Do not tell the assistant which exact internal command, tool, skill-loading step, or transport sequence to use unless that exact surface is what the user would naturally say and is the behavior under evaluation.
 - If an eval only passes when the prompt prescribes internal mechanics, the eval is invalid and the product behavior is not adequately covered.
+
+Scenario scheduling uses three forms:
+
+```ts
+await run({
+  initialEvents: [
+    threadMessage("A provider linked incident OPS-123 to this thread"),
+  ],
+  events: [
+    steer(mention("@junior summarize the incident")),
+    threadMessage("Now include the rollout owner"),
+  ],
+  criteria: rubric({
+    pass: ["The assistant follows the direct request and later follow-up."],
+  }),
+});
+```
+
+- `initialEvents` are pending before processing starts. Multiple initial events must be Slack messages and form one mailbox batch.
+- `steer(...)` delivers message events through normal ingress while the preceding agent run is active. Steering messages must target that same Slack conversation.
+- Plain `events` are ordinary later events delivered after preceding work settles.
 
 Do not do these in eval files:
 
@@ -197,7 +221,7 @@ import { mention, rubric, slackEvals } from "../../src/helpers";
 describeEval("Routing", slackEvals, (it) => {
   it("when explicitly mentioned, post one direct reply", async ({ run }) => {
     await run({
-      events: [mention("Summarize this")],
+      initialEvents: [mention("Summarize this")],
       criteria: rubric({
         pass: ["The assistant posts exactly one reply to the mention."],
       }),

--- a/packages/junior-evals/evals/core/coding-file-tools.eval.ts
+++ b/packages/junior-evals/evals/core/coding-file-tools.eval.ts
@@ -11,7 +11,7 @@ describeEval("Coding File Tools", slackEvals, (it) => {
   }) => {
     await run({
       overrides: codingFixtureOverrides,
-      events: [
+      initialEvents: [
         mention(
           "In the eval coding fixture, change the default retry count from 2 to 3. Keep the reply brief and tell me which file changed.",
         ),
@@ -33,7 +33,7 @@ describeEval("Coding File Tools", slackEvals, (it) => {
   }) => {
     await run({
       overrides: codingFixtureOverrides,
-      events: [
+      initialEvents: [
         mention(
           "In the eval coding fixture, compare project/src/alerts.ts and project/docs/operations.md for emergency mode behavior. Summarize what each file says and do not change any files.",
         ),

--- a/packages/junior-evals/evals/core/conversation-storage.eval.ts
+++ b/packages/junior-evals/evals/core/conversation-storage.eval.ts
@@ -16,7 +16,7 @@ describeEval("Conversation Storage", slackEvals, (it) => {
     const userText =
       "What is the capital of France? Answer in one short sentence.";
     const result = await run({
-      events: [mention(userText)],
+      initialEvents: [mention(userText)],
       requireSandboxReady: false,
       criteria: rubric({
         pass: ["The assistant posts one reply that names Paris."],
@@ -81,11 +81,13 @@ describeEval("Conversation Storage", slackEvals, (it) => {
         auto_complete_mcp_oauth: [EVAL_MCP_PROVIDER],
         plugin_dirs: ["fixtures/plugins"],
       },
-      events: [
+      initialEvents: [
         threadMessage(
           "<@U_APP> /eval-auth Use the demo MCP connection to check our current budget status.",
           { thread: providerReuseThread, is_mention: true },
         ),
+      ],
+      events: [
         threadMessage(
           "<@U_APP> /eval-auth Using that same connection, check the budget status one more time.",
           { thread: providerReuseThread, is_mention: true },

--- a/packages/junior-evals/evals/core/lifecycle-and-resilience.eval.ts
+++ b/packages/junior-evals/evals/core/lifecycle-and-resilience.eval.ts
@@ -6,7 +6,7 @@ describeEval("Lifecycle and Resilience", slackEvals, (it) => {
     run,
   }) => {
     await run({
-      events: [threadStart()],
+      initialEvents: [threadStart()],
       criteria: rubric({
         pass: [
           "No assistant reply is posted.",
@@ -22,7 +22,7 @@ describeEval("Lifecycle and Resilience", slackEvals, (it) => {
   }) => {
     await run({
       overrides: { fail_reply_call: 1 },
-      events: [mention("What's the status of the deploy?")],
+      initialEvents: [mention("What's the status of the deploy?")],
       criteria: rubric({
         pass: [
           "The normalized transcript contains exactly one assistant thread reply.",
@@ -48,7 +48,7 @@ describeEval("Lifecycle and Resilience", slackEvals, (it) => {
           },
         ],
       },
-      events: [mention("Quick budget update?")],
+      initialEvents: [mention("Quick budget update?")],
       criteria: rubric({
         pass: [
           "The normalized transcript contains exactly one assistant thread reply because this answer fits in a single Slack post.",

--- a/packages/junior-evals/evals/core/media-and-attachments.eval.ts
+++ b/packages/junior-evals/evals/core/media-and-attachments.eval.ts
@@ -8,7 +8,9 @@ describeEval("Media and Attachments", slackEvals, (it) => {
   }) => {
     const result = await run({
       overrides: { mock_image_generation: true },
-      events: [mention("make an image showing how you feel and share it here")],
+      initialEvents: [
+        mention("make an image showing how you feel and share it here"),
+      ],
       criteria: rubric({
         pass: ["The assistant responds by attaching an image in the thread."],
         fail: [

--- a/packages/junior-evals/evals/core/oauth-workflows.eval.ts
+++ b/packages/junior-evals/evals/core/oauth-workflows.eval.ts
@@ -85,11 +85,13 @@ describeEval("OAuth Workflows", slackEvals, (it) => {
         auto_complete_mcp_oauth: ["eval-auth"],
         plugin_dirs: ["fixtures/plugins"],
       },
-      events: [
+      initialEvents: [
         threadMessage("Remember: the budget deadline is Friday.", {
           thread: mcpAuthResumeThread,
           is_mention: false,
         }),
+      ],
+      events: [
         threadMessage(
           "/eval-auth Connect, then tell me the budget deadline I mentioned.",
           { thread: mcpAuthResumeThread, is_mention: true },
@@ -143,11 +145,13 @@ describeEval("OAuth Workflows", slackEvals, (it) => {
         auto_complete_oauth: ["eval-oauth"],
         plugin_dirs: ["fixtures/plugins"],
       },
-      events: [
+      initialEvents: [
         threadMessage("Remember: the budget deadline is Friday.", {
           thread: oauthResumeThread,
           is_mention: false,
         }),
+      ],
+      events: [
         threadMessage(
           "/eval-oauth Connect, then tell me the budget deadline I mentioned.",
           { thread: oauthResumeThread, is_mention: true },
@@ -203,7 +207,7 @@ describeEval("OAuth Workflows", slackEvals, (it) => {
         auto_complete_oauth: ["eval-oauth"],
         plugin_dirs: ["fixtures/plugins"],
       },
-      events: [
+      initialEvents: [
         threadMessage(
           "Disconnect my eval-oauth account and reconnect it so we can test the auth flow.",
           { thread: oauthReconnectThread, is_mention: true },

--- a/packages/junior-evals/evals/core/output-contract.eval.ts
+++ b/packages/junior-evals/evals/core/output-contract.eval.ts
@@ -6,7 +6,7 @@ describeEval("Output Contract", slackEvals, (it) => {
     run,
   }) => {
     await run({
-      events: [
+      initialEvents: [
         mention(
           "Give me a short overview of how OAuth 2.0 authorization code flow works. Cover the authorization request, token exchange, and refresh. Keep it to a few short sections.",
         ),
@@ -29,7 +29,7 @@ describeEval("Output Contract", slackEvals, (it) => {
     run,
   }) => {
     await run({
-      events: [
+      initialEvents: [
         mention(
           "Where can I find the official documentation for the Slack Web API, Slack Bolt JS, and Slack Block Kit? Just point me at the three canonical starting pages.",
         ),
@@ -52,7 +52,7 @@ describeEval("Output Contract", slackEvals, (it) => {
     run,
   }) => {
     await run({
-      events: [
+      initialEvents: [
         mention(
           "Give me a short comparison of REST and GraphQL across these three dimensions: caching, over-fetching, and tooling maturity. Keep it tight.",
         ),

--- a/packages/junior-evals/evals/core/passive-behavior.eval.ts
+++ b/packages/junior-evals/evals/core/passive-behavior.eval.ts
@@ -17,13 +17,15 @@ describeEval("Passive Behavior", slackEvals, (it) => {
           "The deploy changed the billing worker and the API auth flow.",
         ],
       },
-      events: [
+      initialEvents: [
         mention(
           "Summarize this deploy in one sentence. It changed the billing worker and the API auth flow.",
           {
             thread: sideConversationThread,
           },
         ),
+      ],
+      events: [
         threadMessage("@sam can you take the billing worker rollback?", {
           thread: sideConversationThread,
         }),
@@ -52,10 +54,12 @@ describeEval("Passive Behavior", slackEvals, (it) => {
       overrides: {
         reply_texts: ["You need the budget by Friday."],
       },
-      events: [
+      initialEvents: [
         mention("I need the budget by Friday.", {
           thread: directedFollowUpThread,
         }),
+      ],
+      events: [
         threadMessage("What did you just say about the budget?", {
           thread: directedFollowUpThread,
         }),
@@ -84,11 +88,13 @@ describeEval("Passive Behavior", slackEvals, (it) => {
           "The deploy changed the billing worker and the API auth flow.",
         ],
       },
-      events: [
+      initialEvents: [
         mention(
           "Summarize this deploy in one sentence. It changed the billing worker and the API auth flow.",
           { thread: casualPronounThread },
         ),
+      ],
+      events: [
         threadMessage("Is that the right approach?", {
           thread: casualPronounThread,
         }),
@@ -119,10 +125,12 @@ describeEval("Passive Behavior", slackEvals, (it) => {
           "The billing worker handles invoice processing and payment retries.",
         ],
       },
-      events: [
+      initialEvents: [
         mention("What does the billing worker do?", {
           thread: domainVocabThread,
         }),
+      ],
+      events: [
         threadMessage("What about the billing worker timeline?", {
           thread: domainVocabThread,
         }),
@@ -151,8 +159,10 @@ describeEval("Passive Behavior", slackEvals, (it) => {
       overrides: {
         reply_texts: ["Here's the deployment status."],
       },
-      events: [
+      initialEvents: [
         mention("Show me the deployment status.", { thread: canYouThread }),
+      ],
+      events: [
         threadMessage("Can you check on this?", { thread: canYouThread }),
       ],
       criteria: rubric({
@@ -177,13 +187,15 @@ describeEval("Passive Behavior", slackEvals, (it) => {
       overrides: {
         reply_texts: ["The deploy changed three services."],
       },
-      events: [
+      initialEvents: [
         mention(
           "What changed in the last deploy? It updated the API gateway, billing worker, and auth service.",
           {
             thread: genuineFollowUpThread,
           },
         ),
+      ],
+      events: [
         threadMessage("Can you explain your last response in more detail?", {
           thread: genuineFollowUpThread,
         }),
@@ -213,10 +225,12 @@ describeEval("Passive Behavior", slackEvals, (it) => {
           "The three services were billing, auth, and the API gateway.",
         ],
       },
-      events: [
+      initialEvents: [
         mention("What changed in the deploy?", {
           thread: terseFollowUpThread,
         }),
+      ],
+      events: [
         threadMessage("Which one?", {
           thread: terseFollowUpThread,
         }),
@@ -243,10 +257,12 @@ describeEval("Passive Behavior", slackEvals, (it) => {
       overrides: {
         reply_texts: ["The deploy changed billing, auth, and the API gateway."],
       },
-      events: [
+      initialEvents: [
         mention("What changed in the deploy?", {
           thread: humansTookFloorThread,
         }),
+      ],
+      events: [
         threadMessage("I think auth should roll back first.", {
           thread: humansTookFloorThread,
         }),
@@ -279,8 +295,10 @@ describeEval("Passive Behavior", slackEvals, (it) => {
           "I'm back because you mentioned me again.",
         ],
       },
-      events: [
+      initialEvents: [
         mention("Can you help in this thread?", { thread: optOutThread }),
+      ],
+      events: [
         threadMessage("Stop watching or participating in this thread", {
           thread: optOutThread,
           is_mention: true,

--- a/packages/junior-evals/evals/core/research-reply-shape.eval.ts
+++ b/packages/junior-evals/evals/core/research-reply-shape.eval.ts
@@ -6,7 +6,7 @@ describeEval("Research Reply Shape", slackEvals, (it) => {
     run,
   }) => {
     await run({
-      events: [
+      initialEvents: [
         mention(
           "Read these three sources and give me one brief, coherent summary of how modern Slack agent streaming works. Keep it short enough to fit in one normal Slack reply, and do not include code samples: https://docs.slack.dev/changelog/2025/10/7/chat-streaming , https://docs.slack.dev/reference/methods/chat.startStream/ , https://docs.slack.dev/reference/methods/chat.stopStream/ .",
         ),
@@ -29,7 +29,7 @@ describeEval("Research Reply Shape", slackEvals, (it) => {
     run,
   }) => {
     await run({
-      events: [
+      initialEvents: [
         mention(
           "Create a concise reusable canvas reference for modern Slack agent streaming that I can come back to later. Use these notes: Slack apps can stream AI responses with start, append, and stop stream methods; streamed messages should live in the user request thread; chunks can include markdown text and task updates; finalized messages can include blocks; apps need to account for content limits, rate limits, retries, and migration from single final replies. Keep the thread reply brief.",
         ),

--- a/packages/junior-evals/evals/core/resource-event-subscriptions.eval.ts
+++ b/packages/junior-evals/evals/core/resource-event-subscriptions.eval.ts
@@ -29,7 +29,7 @@ describeEval("Resource Event Subscriptions", slackEvals, (it) => {
       overrides: {
         plugin_dirs: ["fixtures/resource-event-plugins"],
       },
-      events: [
+      initialEvents: [
         mention(
           "/eval-resource-events Use the provider to create a pull request titled 'Prefer event subscriptions', then check it every five minutes and tell this thread if checks fail, review feedback arrives, it merges, or it closes.",
         ),
@@ -84,7 +84,7 @@ describeEval("Resource Event Subscriptions", slackEvals, (it) => {
     run,
   }) => {
     const result = await run({
-      events: [
+      initialEvents: [
         resourceEventNotification({
           eventKey: "github-delivery-checks-failed",
           eventType: "checks.failed",
@@ -116,7 +116,7 @@ describeEval("Resource Event Subscriptions", slackEvals, (it) => {
     run,
   }) => {
     const result = await run({
-      events: [
+      initialEvents: [
         resourceEventNotification({
           eventKey: "github-delivery-pr-merged",
           eventType: "state.merged",

--- a/packages/junior-evals/evals/core/routing-and-continuity.eval.ts
+++ b/packages/junior-evals/evals/core/routing-and-continuity.eval.ts
@@ -1,7 +1,14 @@
 import { assistantMessages, describeEval, toolCalls } from "vitest-evals";
 import { expect } from "vitest";
 import { NO_REPLY_MARKER } from "@/chat/no-reply";
-import { mention, rubric, slackEvals, threadMessage } from "../../src/helpers";
+import {
+  mention,
+  resourceEventNotification,
+  rubric,
+  slackEvals,
+  steer,
+  threadMessage,
+} from "../../src/helpers";
 
 type EvalSession = Parameters<typeof assistantMessages>[0];
 
@@ -24,11 +31,59 @@ function visibleText(session: EvalSession): string {
 }
 
 describeEval("Routing and Continuity", slackEvals, (it) => {
+  const steeringThread = {
+    id: "thread-direct-mention-steering",
+    channel_id: "CDIRECTMENTIONSTEERING",
+    thread_ts: "17000000.1300",
+  };
+
+  it("when directly mentioned during a bot-notification run, answer the user's instruction only", async ({
+    run,
+  }) => {
+    const result = await run({
+      initialEvents: [
+        resourceEventNotification({
+          eventKey: "linear-issue-linked",
+          eventType: "issue.linked",
+          intent: "Track linked infrastructure work in this Slack thread.",
+          label: "Linear issue OPS-123",
+          provider: "linear",
+          resourceRef: "linear:issue:OPS-123",
+          thread: steeringThread,
+          trustedSummary: "Linear issue OPS-123 was linked to this thread.",
+        }),
+      ],
+      events: [
+        steer(
+          mention(
+            "@junior The deployment owner is Alice. Tell the thread who owns the deployment.",
+            { thread: steeringThread },
+          ),
+        ),
+      ],
+      criteria: rubric({
+        pass: [
+          "The assistant posts exactly one visible reply.",
+          "The reply says Alice owns the deployment.",
+          "The Linear notification is treated only as context for the user's direct instruction.",
+        ],
+        fail: [
+          "Do not post a standalone response to the Linear notification.",
+          "Do not say there is nothing to act on before answering the user.",
+        ],
+      }),
+    });
+
+    const replies = visibleThreadReplies(result.session);
+    expect(replies).toHaveLength(1);
+    expect(textContent(replies[0]?.content)).toMatch(/Alice/i);
+  });
+
   it("when a thread message explicitly mentions Junior, post a direct reply", async ({
     run,
   }) => {
     await run({
-      events: [threadMessage("What is 2+2?", { is_mention: true })],
+      initialEvents: [threadMessage("What is 2+2?", { is_mention: true })],
       criteria: rubric({
         pass: [
           "The assistant posts exactly one reply.",
@@ -43,7 +98,7 @@ describeEval("Routing and Continuity", slackEvals, (it) => {
     run,
   }) => {
     await run({
-      events: [
+      initialEvents: [
         mention(
           "@bot post this in #discuss-design-engineering instead: Heads up, design review starts in 10 minutes.",
         ),
@@ -72,7 +127,7 @@ describeEval("Routing and Continuity", slackEvals, (it) => {
     run,
   }) => {
     await run({
-      events: [
+      initialEvents: [
         mention("The billing rollout is paused until the retry queue drains.", {
           thread: actorIdentityThread,
           author: {
@@ -81,6 +136,8 @@ describeEval("Routing and Continuity", slackEvals, (it) => {
             full_name: "Alice Example",
           },
         }),
+      ],
+      events: [
         threadMessage(
           "Can you draft the one-sentence status update for this?",
           {
@@ -118,7 +175,7 @@ describeEval("Routing and Continuity", slackEvals, (it) => {
     run,
   }) => {
     const result = await run({
-      events: [
+      initialEvents: [
         mention(
           "For the rollout summary, my preferred wording is formal and cautious.",
           {
@@ -130,6 +187,8 @@ describeEval("Routing and Continuity", slackEvals, (it) => {
             },
           },
         ),
+      ],
+      events: [
         threadMessage(
           "For the rollout summary, my preferred wording is casual and direct. What wording preference did I just give you?",
           {
@@ -166,7 +225,7 @@ describeEval("Routing and Continuity", slackEvals, (it) => {
     run,
   }) => {
     const result = await run({
-      events: [mention("react to this")],
+      initialEvents: [mention("react to this")],
       criteria: rubric({
         pass: [
           "The normalized transcript contains at least one reaction_added assistant message.",
@@ -200,8 +259,10 @@ describeEval("Routing and Continuity", slackEvals, (it) => {
     run,
   }) => {
     await run({
-      events: [
+      initialEvents: [
         mention("I need the budget by Friday.", { thread: continuityThread }),
+      ],
+      events: [
         threadMessage("what did i just ask?", {
           thread: continuityThread,
           is_mention: true,

--- a/packages/junior-evals/evals/core/skill-infra.eval.ts
+++ b/packages/junior-evals/evals/core/skill-infra.eval.ts
@@ -8,7 +8,7 @@ describeEval("Skill Infrastructure", slackEvals, (it) => {
   }) => {
     await run({
       overrides: { skill_dirs: ["fixtures/skills"] },
-      events: [mention("/candidate-brief David Cramer")],
+      initialEvents: [mention("/candidate-brief David Cramer")],
       criteria: rubric({
         pass: [
           "The assistant posts exactly one reply for David Cramer.",
@@ -30,10 +30,12 @@ describeEval("Skill Infrastructure", slackEvals, (it) => {
   }) => {
     await run({
       overrides: { skill_dirs: ["fixtures/skills"] },
-      events: [
+      initialEvents: [
         mention("/candidate-brief Alice Example", {
           thread: candidateBriefThread,
         }),
+      ],
+      events: [
         threadMessage("/candidate-brief Bob Example", {
           thread: candidateBriefThread,
           is_mention: true,
@@ -55,7 +57,7 @@ describeEval("Skill Infrastructure", slackEvals, (it) => {
   }) => {
     await run({
       overrides: { skill_dirs: ["fixtures/skills"] },
-      events: [mention("/list-working-directory")],
+      initialEvents: [mention("/list-working-directory")],
       criteria: rubric({
         pass: [
           "The assistant posts exactly one working-directory listing reply.",
@@ -71,7 +73,7 @@ describeEval("Skill Infrastructure", slackEvals, (it) => {
   }) => {
     await run({
       overrides: { skill_dirs: ["fixtures/skills"] },
-      events: [
+      initialEvents: [
         mention(
           "Can you double-check what the source handbook says about closed tracking issues proving capability support? I think there was a note for this.",
         ),
@@ -98,7 +100,7 @@ describeEval("Skill Infrastructure", slackEvals, (it) => {
       overrides: {
         plugin_dirs: ["fixtures/plugins"],
       },
-      events: [
+      initialEvents: [
         mention(
           "/eval-mcp Ask the handbook what it says about US holidays, then summarize the result.",
         ),

--- a/packages/junior-evals/evals/core/skill-invocation-control.eval.ts
+++ b/packages/junior-evals/evals/core/skill-invocation-control.eval.ts
@@ -9,7 +9,9 @@ describeEval("Skill Invocation Control", slackEvals, (it) => {
   }) => {
     await run({
       overrides: { skill_dirs: skillDirs },
-      events: [mention("What's the weather like in San Francisco today?")],
+      initialEvents: [
+        mention("What's the weather like in San Francisco today?"),
+      ],
       criteria: rubric({
         pass: [
           "The assistant does not return the weather-lookup skill's simulated report (72°F, partly cloudy, 8 mph NW).",
@@ -26,7 +28,7 @@ describeEval("Skill Invocation Control", slackEvals, (it) => {
   }) => {
     await run({
       overrides: { skill_dirs: skillDirs },
-      events: [
+      initialEvents: [
         mention(
           "Use the weather-lookup skill to check the weather in San Francisco.",
         ),
@@ -48,7 +50,7 @@ describeEval("Skill Invocation Control", slackEvals, (it) => {
   }) => {
     await run({
       overrides: { skill_dirs: skillDirs },
-      events: [
+      initialEvents: [
         mention(
           "Can you double-check what the source handbook says about capability support verification?",
         ),

--- a/packages/junior-evals/evals/core/slack-message-delivery.eval.ts
+++ b/packages/junior-evals/evals/core/slack-message-delivery.eval.ts
@@ -26,7 +26,7 @@ function visibleText(session: EvalSession): string {
 describeEval("Slack Message Delivery", slackEvals, (it) => {
   it("when asked for no visible reply, complete silently", async ({ run }) => {
     const result = await run({
-      events: [
+      initialEvents: [
         mention(
           "please record that this has been seen, but do not post a visible reply",
         ),
@@ -51,7 +51,9 @@ describeEval("Slack Message Delivery", slackEvals, (it) => {
     run,
   }) => {
     const result = await run({
-      events: [mention("@bot post this to the channel: deploy is unblocked")],
+      initialEvents: [
+        mention("@bot post this to the channel: deploy is unblocked"),
+      ],
       criteria: rubric({
         pass: [
           "The assistant does not call sendMessage.",
@@ -78,7 +80,7 @@ describeEval("Slack Message Delivery", slackEvals, (it) => {
   }) => {
     const result = await run({
       overrides: { mock_image_generation: true },
-      events: [
+      initialEvents: [
         mention("make a small image of a launch checklist and share it here"),
       ],
       criteria: rubric({

--- a/packages/junior-evals/evals/github/skill-workflows.eval.ts
+++ b/packages/junior-evals/evals/github/skill-workflows.eval.ts
@@ -16,7 +16,7 @@ describeEval("GitHub Skill Workflows", slackEvals, (it) => {
       overrides: {
         skill_dirs: ["fixtures/github-headless-skills"],
       },
-      events: [
+      initialEvents: [
         resourceEventNotification({
           eventType: "checks.failed",
           intent:
@@ -59,7 +59,7 @@ describeEval("GitHub Skill Workflows", slackEvals, (it) => {
         plugin_packages: ["@sentry/junior-github"],
         skill_dirs: ["../junior/skills"],
       },
-      events: [
+      initialEvents: [
         mention(
           "Before you open a GitHub pull request from an existing branch, what credentials do you need and in what order? Keep it short.",
         ),
@@ -101,10 +101,12 @@ describeEval("GitHub Skill Workflows", slackEvals, (it) => {
         plugin_packages: ["@sentry/junior-github"],
         skill_dirs: ["../junior/skills"],
       },
-      events: [
+      initialEvents: [
         mention("Set the default repo to getsentry/junior for this channel.", {
           thread: defaultRepoThread,
         }),
+      ],
+      events: [
         threadMessage(
           "Now tell me which GitHub repo you'd use for issue commands when I omit --repo.",
           {
@@ -133,7 +135,7 @@ describeEval("GitHub Skill Workflows", slackEvals, (it) => {
         plugin_packages: ["@sentry/junior-github"],
         skill_dirs: ["../junior/skills"],
       },
-      events: [
+      initialEvents: [
         threadMessage(
           "Set the default repo to getsentry/junior-eval-bot-never-exists for this channel. Do not verify it exists.",
           {
@@ -141,6 +143,8 @@ describeEval("GitHub Skill Workflows", slackEvals, (it) => {
             is_mention: true,
           },
         ),
+      ],
+      events: [
         threadMessage(
           "We need a tracking issue for the Junior bot. This example from getsentry/junior-eval-reference-never-exists#123 shows GitHub issue references can be mistaken for the target repo. Draft the issue I should approve with target repo, title, and body. Do not run GitHub commands.",
           {
@@ -172,7 +176,7 @@ describeEval("GitHub Skill Workflows", slackEvals, (it) => {
         plugin_packages: ["@sentry/junior-github"],
         skill_dirs: ["../junior/skills"],
       },
-      events: [
+      initialEvents: [
         threadMessage(
           "Set the default repo to getsentry/junior-eval-bot-never-exists for this channel. Do not verify it exists.",
           {
@@ -180,6 +184,8 @@ describeEval("GitHub Skill Workflows", slackEvals, (it) => {
             is_mention: true,
           },
         ),
+      ],
+      events: [
         threadMessage(
           "Before I approve a later comment, confirm the target issue for getsentry/junior-eval-reference-never-exists#123. Do not run GitHub commands.",
           {

--- a/packages/junior-evals/evals/memory/multi-actor-provenance.eval.ts
+++ b/packages/junior-evals/evals/memory/multi-actor-provenance.eval.ts
@@ -6,13 +6,7 @@ import {
   juniorMemoryEmbeddings,
   juniorMemoryMemories,
 } from "../../../junior-memory/src/db/schema";
-import {
-  batch,
-  mention,
-  rubric,
-  slackEvals,
-  threadMessage,
-} from "../../src/helpers";
+import { mention, rubric, slackEvals, threadMessage } from "../../src/helpers";
 
 /**
  * Multi-actor provenance evals for passive memory extraction.
@@ -106,7 +100,7 @@ describeEval("Memory Multi-Actor Provenance", slackEvals, (it) => {
     await clearMemories();
     await run({
       overrides: memoryPluginOverrides,
-      events: [
+      initialEvents: [
         mention(
           "Can you help capture takeaways from this retro discussion as we go?",
           {
@@ -114,6 +108,8 @@ describeEval("Memory Multi-Actor Provenance", slackEvals, (it) => {
             author: ALICE,
           },
         ),
+      ],
+      events: [
         threadMessage(
           "Biggest takeaway from my side: the rollout checklist missed cache invalidation, and we only caught it because support flagged the stale pages.",
           {
@@ -174,7 +170,7 @@ describeEval("Memory Multi-Actor Provenance", slackEvals, (it) => {
     await clearMemories();
     await run({
       overrides: memoryPluginOverrides,
-      events: [
+      initialEvents: [
         mention(
           "I prefer status updates with risks listed first. Can you draft one for the rollout pause?",
           {
@@ -182,6 +178,8 @@ describeEval("Memory Multi-Actor Provenance", slackEvals, (it) => {
             author: ALICE,
           },
         ),
+      ],
+      events: [
         threadMessage(
           "personally I prefer status updates that lead with the customer impact, not risks.",
           {
@@ -245,23 +243,21 @@ describeEval("Memory Multi-Actor Provenance", slackEvals, (it) => {
     // where Bob's first-person statement rides inside Alice's transcript.
     await run({
       overrides: memoryPluginOverrides,
-      events: [
-        batch(
-          mention(
-            "When you write up the recap, I prefer short bullet summaries over prose.",
-            {
-              thread: batchedMentionThread,
-              author: BOB,
-            },
-          ),
-          threadMessage(
-            "Can you recap what has been asked in this thread so far?",
-            {
-              thread: batchedMentionThread,
-              is_mention: true,
-              author: ALICE,
-            },
-          ),
+      initialEvents: [
+        mention(
+          "When you write up the recap, I prefer short bullet summaries over prose.",
+          {
+            thread: batchedMentionThread,
+            author: BOB,
+          },
+        ),
+        threadMessage(
+          "Can you recap what has been asked in this thread so far?",
+          {
+            thread: batchedMentionThread,
+            is_mention: true,
+            author: ALICE,
+          },
         ),
       ],
       criteria: rubric({
@@ -316,23 +312,21 @@ describeEval("Memory Multi-Actor Provenance", slackEvals, (it) => {
     // actors on the completed run.
     await run({
       overrides: memoryPluginOverrides,
-      events: [
-        batch(
-          mention(
-            "Can you list the open questions from this thread when you get a chance?",
-            {
-              thread: actorPreferenceMultiActorThread,
-              author: BOB,
-            },
-          ),
-          threadMessage(
-            "I prefer recaps as numbered lists, not paragraphs. Can you recap the asks in this thread so far?",
-            {
-              thread: actorPreferenceMultiActorThread,
-              is_mention: true,
-              author: ALICE,
-            },
-          ),
+      initialEvents: [
+        mention(
+          "Can you list the open questions from this thread when you get a chance?",
+          {
+            thread: actorPreferenceMultiActorThread,
+            author: BOB,
+          },
+        ),
+        threadMessage(
+          "I prefer recaps as numbered lists, not paragraphs. Can you recap the asks in this thread so far?",
+          {
+            thread: actorPreferenceMultiActorThread,
+            is_mention: true,
+            author: ALICE,
+          },
         ),
       ],
       criteria: rubric({
@@ -397,11 +391,13 @@ describeEval("Memory Multi-Actor Provenance", slackEvals, (it) => {
     await clearMemories();
     await run({
       overrides: memoryPluginOverrides,
-      events: [
+      initialEvents: [
         mention("Can you help us plan the deploy for the retention fix?", {
           thread: sharedKnowledgeThread,
           author: ALICE,
         }),
+      ],
+      events: [
         threadMessage(
           "Just so you know, deploys freeze every Friday at noon here — risky changes always need to land earlier in the week.",
           {

--- a/packages/junior-evals/evals/memory/workflows.eval.ts
+++ b/packages/junior-evals/evals/memory/workflows.eval.ts
@@ -301,10 +301,12 @@ describeEval("Memory Workflows", slackEvals, (it) => {
     await clearMemories();
     const result = await run({
       overrides: memoryPluginOverrides,
-      events: [
+      initialEvents: [
         mention("Please remember that I prefer terse PR summaries.", {
           thread: explicitRememberThread,
         }),
+      ],
+      events: [
         mention("List the exact stored memory content for that preference.", {
           thread: explicitRememberThread,
         }),
@@ -364,10 +366,12 @@ describeEval("Memory Workflows", slackEvals, (it) => {
     const userText = "ok remember that i think types in python are bad";
     const result = await run({
       overrides: memoryPluginOverrides,
-      events: [
+      initialEvents: [
         mention(userText, {
           thread: firstPersonRewrittenThread,
         }),
+      ],
+      events: [
         mention("What exact memory did you store about Python types?", {
           thread: firstPersonRewrittenThread,
         }),
@@ -471,10 +475,12 @@ describeEval("Memory Workflows", slackEvals, (it) => {
       "Please remember that for flaky webhook triage, inspect delivery headers before retrying the job.";
     const result = await run({
       overrides: memoryPluginOverrides,
-      events: [
+      initialEvents: [
         mention(userText, {
           thread: explicitTaskProcedureThread,
         }),
+      ],
+      events: [
         mention("How should flaky webhook triage be done?", {
           thread: explicitTaskProcedureThread,
         }),
@@ -536,10 +542,12 @@ describeEval("Memory Workflows", slackEvals, (it) => {
       "For sandbox timeout triage, inspect heartbeat gaps before increasing the timeout.";
     const result = await run({
       overrides: memoryPluginOverrides,
-      events: [
+      initialEvents: [
         mention(userText, {
           thread: passiveTaskProcedureThread,
         }),
+      ],
+      events: [
         mention("How should sandbox timeout triage be done?", {
           thread: passiveTaskProcedureThread,
         }),
@@ -601,10 +609,12 @@ describeEval("Memory Workflows", slackEvals, (it) => {
       "Branch QA runbooks require risk notes before summary notes.";
     const result = await run({
       overrides: memoryPluginOverrides,
-      events: [
+      initialEvents: [
         mention(userText, {
           thread: passiveConversationThread,
         }),
+      ],
+      events: [
         mention("What do branch QA runbooks require?", {
           thread: passiveConversationThread,
         }),
@@ -664,7 +674,7 @@ describeEval("Memory Workflows", slackEvals, (it) => {
     await clearMemories();
     await run({
       overrides: memoryPluginOverrides,
-      events: [
+      initialEvents: [
         mention(
           "The analytics query says today's signup conversion rate is 8.4%.",
           {
@@ -699,7 +709,7 @@ describeEval("Memory Workflows", slackEvals, (it) => {
     await clearMemories();
     await run({
       overrides: memoryPluginOverrides,
-      events: [
+      initialEvents: [
         mention("Please remember that David prefers terse PR summaries.", {
           thread: thirdPartyRememberThread,
         }),
@@ -737,7 +747,7 @@ describeEval("Memory Workflows", slackEvals, (it) => {
 
     await run({
       overrides: memoryPluginOverrides,
-      events: [
+      initialEvents: [
         mention("How should I structure my next PR summary?", {
           thread: autoRecallThread,
         }),
@@ -782,7 +792,7 @@ describeEval("Memory Workflows", slackEvals, (it) => {
 
     await run({
       overrides: memoryPluginOverrides,
-      events: [
+      initialEvents: [
         mention("For PR summaries, I still want risk notes first.", {
           thread: passiveDedupeThread,
         }),
@@ -827,7 +837,7 @@ describeEval("Memory Workflows", slackEvals, (it) => {
 
     await run({
       overrides: memoryPluginOverrides,
-      events: [
+      initialEvents: [
         mention("Please forget that I prefer terse PR summaries.", {
           thread: removeThread,
         }),

--- a/packages/junior-evals/evals/scheduler/workflows.eval.ts
+++ b/packages/junior-evals/evals/scheduler/workflows.eval.ts
@@ -46,7 +46,7 @@ describeEval("Scheduler", slackEvals, (it) => {
     run,
   }) => {
     const result = await run({
-      events: [mention("@bot remind me in 1 minute to wash my hands")],
+      initialEvents: [mention("@bot remind me in 1 minute to wash my hands")],
       criteria: rubric({
         pass: [
           "The reply confirms that a one-off reminder to wash hands was scheduled.",
@@ -68,7 +68,7 @@ describeEval("Scheduler", slackEvals, (it) => {
     run,
   }) => {
     const result = await run({
-      events: [mention("@bot remind me to drink water in 1m")],
+      initialEvents: [mention("@bot remind me to drink water in 1m")],
       criteria: rubric({
         pass: [
           "The reply confirms that a one-off reminder to drink water was scheduled.",
@@ -90,7 +90,7 @@ describeEval("Scheduler", slackEvals, (it) => {
     run,
   }) => {
     const result = await run({
-      events: [
+      initialEvents: [
         mention(
           "@bot remind me in 2 minutes to tell the channel standup moved",
         ),
@@ -114,7 +114,7 @@ describeEval("Scheduler", slackEvals, (it) => {
     run,
   }) => {
     const result = await run({
-      events: [
+      initialEvents: [
         mention(
           "@bot schedule this every Monday at 9am Pacific: check open GitHub issues about the scheduler and post a short digest here.",
         ),
@@ -141,7 +141,7 @@ describeEval("Scheduler", slackEvals, (it) => {
     run,
   }) => {
     const result = await run({
-      events: [
+      initialEvents: [
         scheduledTaskDue("Post this reminder: Standup moved to 10:30 today.", {
           schedule: "Once at noon UTC",
           schedule_kind: "one_off",
@@ -167,7 +167,7 @@ describeEval("Scheduler", slackEvals, (it) => {
     run,
   }) => {
     const result = await run({
-      events: [
+      initialEvents: [
         scheduledTaskDue(
           "Post this reminder: Submit timesheets by 5pm today.",
           {

--- a/packages/junior-evals/evals/sentry/skill-workflows.eval.ts
+++ b/packages/junior-evals/evals/sentry/skill-workflows.eval.ts
@@ -17,8 +17,8 @@ describeEval("Sentry Skill Workflows", slackEvals, (it) => {
         credential_providers: ["sentry"],
         plugin_packages: ["@sentry/junior-sentry"],
       },
+      initialEvents: [mention("are you working", { thread: followUpThread })],
       events: [
-        mention("are you working", { thread: followUpThread }),
         threadMessage("what's up with the latest Sentry issues in getsentry?", {
           thread: followUpThread,
           is_mention: true,

--- a/packages/junior-evals/src/behavior-harness.ts
+++ b/packages/junior-evals/src/behavior-harness.ts
@@ -210,15 +210,10 @@ interface SubscribedMessageEvent extends EvalBaseEvent {
   type: "subscribed_message";
 }
 
-/**
- * Messages that are pending together in the conversation mailbox and are
- * handled as one worker turn: the last message becomes the live turn and the
- * earlier ones arrive as queued/skipped context, matching production mailbox
- * batching.
- */
-interface MessageBatchEvent {
+/** Models Slack messages that arrive while the preceding agent run is active. */
+export interface SteerEvent {
   events: Array<MentionEvent | SubscribedMessageEvent>;
-  type: "message_batch";
+  type: "steer";
 }
 
 interface AssistantThreadStartedEvent extends EvalBaseEvent {
@@ -244,18 +239,29 @@ interface ScheduledTaskDueEvent extends EvalBaseEvent {
 export type EvalEvent =
   | MentionEvent
   | SubscribedMessageEvent
-  | MessageBatchEvent
   | AssistantThreadStartedEvent
   | AssistantContextChangedEvent
   | ScheduledTaskDueEvent;
 
-/** Expand message batches so consumers can treat scenario events uniformly. */
-function flattenEvalEvents(
-  events: readonly EvalEvent[],
-): Array<Exclude<EvalEvent, MessageBatchEvent>> {
-  return events.flatMap((event) =>
-    event.type === "message_batch" ? event.events : [event],
-  );
+type SlackMessageEvent = MentionEvent | SubscribedMessageEvent;
+
+function isSlackMessageEvent(event: EvalEvent): event is SlackMessageEvent {
+  return event.type === "new_mention" || event.type === "subscribed_message";
+}
+
+/** Events present before processing begins; multiple events form one Slack mailbox batch. */
+export type InitialEvents =
+  | []
+  | [EvalEvent]
+  | [SlackMessageEvent, SlackMessageEvent, ...SlackMessageEvent[]];
+
+function scenarioEvents(scenario: EvalScenario): EvalEvent[] {
+  return [
+    ...scenario.initialEvents,
+    ...(scenario.events ?? []).flatMap((event) =>
+      event.type === "steer" ? event.events : [event],
+    ),
+  ];
 }
 
 interface SubscribedDecisionFixture {
@@ -294,13 +300,18 @@ export interface EvalOverrides {
 }
 
 export interface EvalScenario {
-  events: EvalEvent[];
+  initialEvents: InitialEvents;
+  events?: Array<EvalEvent | SteerEvent>;
   overrides?: EvalOverrides;
 }
 
 interface EvalScenarioRunOptions {
   logRecords?: EmittedLogRecord[];
   signal?: AbortSignal;
+}
+
+interface SteeringDelivery {
+  deliver?: () => Promise<void>;
 }
 
 export interface EvalResult {
@@ -879,9 +890,9 @@ function attachTranscriptAccessors(
 
 async function cleanupHarnessThreadState(
   stateAdapter: HarnessStateAdapter,
-  scenarioEvents: readonly EvalEvent[],
+  scenario: EvalScenario,
 ): Promise<void> {
-  const events = flattenEvalEvents(scenarioEvents);
+  const events = scenarioEvents(scenario);
   const runtimeThreadIds = new Set(
     events.map((event) => buildRuntimeThreadId(event.thread)),
   );
@@ -1593,7 +1604,7 @@ async function setupHarnessEnvironment(
       scenario.overrides?.credential_providers ?? [],
     );
     const authActorUsers = new Set(
-      flattenEvalEvents(scenario.events).flatMap((event) =>
+      scenarioEvents(scenario).flatMap((event) =>
         "message" in event
           ? [event.message.author?.user_id?.trim() || TEST_USER_ID]
           : "user_id" in event && event.user_id
@@ -1628,7 +1639,7 @@ async function setupHarnessEnvironment(
       : undefined;
     resetSkillDiscoveryCache();
     resetTestGitHubHttpFixtures();
-    await cleanupHarnessThreadState(stateAdapter, scenario.events);
+    await cleanupHarnessThreadState(stateAdapter, scenario);
     await cleanupMcpAuthState(authActorUsers, autoCompleteMcpOauthProviders);
     await cleanupOAuthTokens(authActorUsers, autoCompleteOauthProviders);
     await cleanupOAuthTokens(authActorUsers, credentialProviders);
@@ -1665,7 +1676,7 @@ async function teardownHarnessEnvironment(
 ): Promise<void> {
   resetSkillDiscoveryCache();
   pluginCatalogRuntime.setConfig(undefined);
-  await cleanupHarnessThreadState(env.stateAdapter, scenario.events);
+  await cleanupHarnessThreadState(env.stateAdapter, scenario);
   await cleanupMcpAuthState(
     env.authActorUsers,
     env.autoCompleteMcpOauthProviders,
@@ -1687,6 +1698,7 @@ function buildRuntimeServices(
   threadRecordsById: Map<string, EvalThreadRecord>,
   observations: RuntimeObservations,
   conversationWorkQueue: ConversationWorkQueueTestAdapter,
+  steeringDelivery: SteeringDelivery,
   signal?: AbortSignal,
 ): JuniorRuntimeServiceOverrides {
   const replyResults = scenario.overrides?.reply_results ?? [];
@@ -1736,6 +1748,23 @@ function buildRuntimeServices(
     replyExecutor: {
       agentRunner: {
         run: async (request) => {
+          const pendingSteeringDelivery = steeringDelivery.deliver;
+          const runRequest = pendingSteeringDelivery
+            ? {
+                ...request,
+                durability: {
+                  ...request.durability,
+                  onInputCommitted: async () => {
+                    await request.durability?.onInputCommitted?.();
+                    if (steeringDelivery.deliver !== pendingSteeringDelivery) {
+                      return;
+                    }
+                    steeringDelivery.deliver = undefined;
+                    await pendingSteeringDelivery();
+                  },
+                },
+              }
+            : request;
           replyCallCount += 1;
           const mockImageGeneration = scenario.overrides?.mock_image_generation;
           if (scenario.overrides?.fail_reply_call === replyCallCount) {
@@ -1743,8 +1772,11 @@ function buildRuntimeServices(
           }
           const replyResult = replyResults[replyCallCount - 1];
           if (replyResult) {
+            await runRequest.durability?.onInputCommitted?.();
             if (replyResult.stream_text) {
-              await request.observers?.onTextDelta?.(replyResult.stream_text);
+              await runRequest.observers?.onTextDelta?.(
+                replyResult.stream_text,
+              );
             }
             replyState.successfulCount += 1;
             observations.toolInvocations.push(
@@ -1777,6 +1809,7 @@ function buildRuntimeServices(
           }
           const replyText = replyTexts[replyState.successfulCount];
           if (typeof replyText === "string") {
+            await runRequest.durability?.onInputCommitted?.();
             replyState.successfulCount += 1;
             return completedAgentRun({
               text: replyText,
@@ -1822,12 +1855,13 @@ function buildRuntimeServices(
               params: Record<string, unknown>;
             }> = [];
             const outcome = await executeAgentRun({
-              ...request,
+              ...runRequest,
               policy: {
-                ...request.policy,
+                ...runRequest.policy,
                 signal,
                 turnDeadlineAtMs: Math.min(
-                  request.policy?.turnDeadlineAtMs ?? Number.POSITIVE_INFINITY,
+                  runRequest.policy?.turnDeadlineAtMs ??
+                    Number.POSITIVE_INFINITY,
                   Date.now() + replyTimeoutMs,
                 ),
                 ...(env.configuredSkillDirs.length > 0
@@ -1836,7 +1870,7 @@ function buildRuntimeServices(
                 toolOverrides,
               },
               observers: {
-                ...request.observers,
+                ...runRequest.observers,
                 onToolInvocation: (invocation) => {
                   const evalInvocation = toEvalToolInvocation(invocation);
                   observations.toolInvocations.push(evalInvocation);
@@ -1928,6 +1962,7 @@ async function processEvents(args: {
   findEvalThread: (threadId: string) => TestThread | undefined;
   observations: RuntimeObservations;
   readyQueueDeliveries: QueueDelivery[];
+  steeringDelivery: SteeringDelivery;
 }): Promise<void> {
   const {
     scenario,
@@ -1939,6 +1974,7 @@ async function processEvents(args: {
     getThreadRecord,
     findEvalThread,
     readyQueueDeliveries,
+    steeringDelivery,
   } = args;
 
   const consumedOauthStates = new Set<string>();
@@ -2046,12 +2082,10 @@ async function processEvents(args: {
     }
   };
 
-  // Persist batch members through real Slack ingress so the conversation
-  // worker claims them as one mailbox batch (latest live, earlier queued).
-  const appendMailboxBatch = async (
-    batch: MessageBatchEvent,
+  const appendMailboxMessages = async (
+    events: Array<MentionEvent | SubscribedMessageEvent>,
   ): Promise<void> => {
-    for (const [index, event] of batch.events.entries()) {
+    for (const [index, event] of events.entries()) {
       const { thread, transcript } = getThreadRecord(event.thread);
       const route =
         (event.message.is_mention ?? event.type === "new_mention")
@@ -2221,13 +2255,7 @@ async function processEvents(args: {
     }
   };
 
-  for (const event of scenario.events) {
-    if (event.type === "message_batch") {
-      await appendMailboxBatch(event);
-      await maybeAutoCompleteAuth();
-      await drainQueuedConversationWork();
-      continue;
-    }
+  const processSettledEvent = async (event: EvalEvent): Promise<void> => {
     if (event.type === "new_mention" || event.type === "subscribed_message") {
       enqueueEvent(event);
     } else if (event.type === "scheduled_task_due") {
@@ -2240,6 +2268,87 @@ async function processEvents(args: {
       await maybeAutoCompleteAuth();
       await drainQueuedConversationWork();
     }
+  };
+
+  const processMessageGroup = async (
+    messages: Array<MentionEvent | SubscribedMessageEvent>,
+    steering?: SteerEvent,
+  ): Promise<void> => {
+    if (steering) {
+      const conversationIds = new Set(
+        [...messages, ...steering.events].map((event) =>
+          buildRuntimeThreadId(event.thread),
+        ),
+      );
+      if (conversationIds.size !== 1) {
+        throw new Error(
+          "steer() messages must target the preceding Slack conversation",
+        );
+      }
+      steeringDelivery.deliver = async () => {
+        await appendMailboxMessages(steering.events);
+      };
+    }
+    await appendMailboxMessages(messages);
+    await maybeAutoCompleteAuth();
+    await drainQueuedConversationWork();
+    if (steeringDelivery.deliver) {
+      steeringDelivery.deliver = undefined;
+      throw new Error(
+        "steer() requires the preceding message group to start an agent run",
+      );
+    }
+  };
+
+  const remainingEvents = scenario.events ?? [];
+  let nextIndex = 0;
+  const initialSteering =
+    remainingEvents[0]?.type === "steer" ? remainingEvents[0] : undefined;
+  if (initialSteering) {
+    nextIndex = 1;
+  }
+
+  const initialMessages = Array.from(scenario.initialEvents).filter(
+    isSlackMessageEvent,
+  );
+
+  if (
+    initialMessages.length > 0 &&
+    initialMessages.length === scenario.initialEvents.length
+  ) {
+    await processMessageGroup(initialMessages, initialSteering);
+  } else {
+    if (scenario.initialEvents.length > 1 || initialSteering !== undefined) {
+      throw new Error(
+        "Multiple initialEvents and steer() require Slack message events",
+      );
+    }
+    const initialEvent = scenario.initialEvents[0];
+    if (initialEvent) {
+      await processSettledEvent(initialEvent);
+    }
+  }
+
+  while (nextIndex < remainingEvents.length) {
+    const event = remainingEvents[nextIndex];
+    if (!event) {
+      break;
+    }
+    if (event.type === "steer") {
+      throw new Error("steer() must follow a Slack message event");
+    }
+    const nextEvent = remainingEvents[nextIndex + 1];
+    const steering = nextEvent?.type === "steer" ? nextEvent : undefined;
+    if (steering) {
+      if (event.type !== "new_mention" && event.type !== "subscribed_message") {
+        throw new Error("steer() must follow a Slack message event");
+      }
+      await processMessageGroup([event], steering);
+      nextIndex += 2;
+      continue;
+    }
+    await processSettledEvent(event);
+    nextIndex += 1;
   }
 
   while (readyQueueDeliveries.length > 0) {
@@ -2374,12 +2483,14 @@ export async function runEvalScenario(
     };
 
     const conversationWorkQueue = createConversationWorkQueueTestAdapter();
+    const steeringDelivery: SteeringDelivery = {};
     const services = buildRuntimeServices(
       scenario,
       env,
       threadRecordsById,
       observations,
       conversationWorkQueue,
+      steeringDelivery,
       options.signal,
     );
     const evalAgentRunner = services.replyExecutor?.agentRunner;
@@ -2403,6 +2514,7 @@ export async function runEvalScenario(
       findEvalThread: (threadId) => threadRecordsById.get(threadId)?.thread,
       observations,
       readyQueueDeliveries,
+      steeringDelivery,
     });
 
     return collectResults(

--- a/packages/junior-evals/src/helpers.ts
+++ b/packages/junior-evals/src/helpers.ts
@@ -33,6 +33,8 @@ import {
   type EvalEvent,
   type EvalOverrides,
   type EvalResult,
+  type InitialEvents,
+  type SteerEvent,
   runEvalScenario,
 } from "./behavior-harness";
 
@@ -258,7 +260,8 @@ interface EvalRubric {
 }
 
 export interface SlackEvalInput {
-  events: EvalEvent[];
+  initialEvents: InitialEvents;
+  events?: Array<EvalEvent | SteerEvent>;
   overrides?: EvalOverrides;
   criteria: EvalRubric;
   requireGatewayReady?: boolean;
@@ -465,6 +468,7 @@ export const slackHarness: Harness<SlackEvalInput> = {
       assertTimeoutBudget(input);
       const taskPromise = runEvalScenario(
         {
+          initialEvents: input.initialEvents,
           events: input.events,
           overrides: input.overrides,
         },
@@ -670,7 +674,7 @@ export function mention(
   };
 }
 
-/** Builds a follow-up subscribed-thread message for a harnessed Slack eval. */
+/** Builds a subscribed-thread message for a harnessed Slack eval. */
 export function threadMessage(
   text: string,
   opts?: {
@@ -699,19 +703,17 @@ export function threadMessage(
   };
 }
 
-/**
- * Groups messages that are pending together in the conversation mailbox so
- * the worker handles them as one turn: the last message becomes the live
- * turn and earlier ones arrive as queued context, matching production
- * mailbox batching when messages land faster than turns complete.
- */
-export function batch(
+/** Models Slack messages that arrive while the preceding agent run is active. */
+export function steer(
   ...events: Array<
     ReturnType<typeof mention> | ReturnType<typeof threadMessage>
   >
 ) {
+  if (events.length === 0) {
+    throw new Error("steer() requires at least one message event");
+  }
   return {
-    type: "message_batch" as const,
+    type: "steer" as const,
     events,
   };
 }

--- a/packages/junior-evals/tests/unit/harness/behavior-harness.test.ts
+++ b/packages/junior-evals/tests/unit/harness/behavior-harness.test.ts
@@ -15,6 +15,7 @@ const {
     destinationChannelId: undefined as string | undefined,
     juniorBaseUrl: undefined as string | undefined,
     messageThreadId: undefined as string | undefined,
+    receivedAck: false,
     threadId: undefined as string | undefined,
   };
 
@@ -32,11 +33,16 @@ const {
       async (
         thread: { id: string; post: (value: unknown) => Promise<void> },
         message: { threadId?: string },
-        options?: { destination?: { channelId?: string } },
+        options?: {
+          ack?: () => Promise<void>;
+          destination?: { channelId?: string };
+        },
       ) => {
+        await options?.ack?.();
         observedRuntimeIds.destinationChannelId =
           options?.destination?.channelId;
         observedRuntimeIds.juniorBaseUrl = process.env.JUNIOR_BASE_URL;
+        observedRuntimeIds.receivedAck = Boolean(options?.ack);
         observedRuntimeIds.threadId = thread.id;
         observedRuntimeIds.messageThreadId = message.threadId;
         await thread.post("observed");
@@ -46,11 +52,16 @@ const {
       async (
         thread: { id: string; post: (value: unknown) => Promise<void> },
         message: { threadId?: string },
-        options?: { destination?: { channelId?: string } },
+        options?: {
+          ack?: () => Promise<void>;
+          destination?: { channelId?: string };
+        },
       ) => {
+        await options?.ack?.();
         observedRuntimeIds.destinationChannelId =
           options?.destination?.channelId;
         observedRuntimeIds.juniorBaseUrl = process.env.JUNIOR_BASE_URL;
+        observedRuntimeIds.receivedAck = Boolean(options?.ack);
         observedRuntimeIds.threadId = thread.id;
         observedRuntimeIds.messageThreadId = message.threadId;
         await thread.post("observed");
@@ -102,6 +113,7 @@ describe("behavior harness", () => {
     observedRuntimeIds.juniorBaseUrl = undefined;
     observedRuntimeIds.threadId = undefined;
     observedRuntimeIds.messageThreadId = undefined;
+    observedRuntimeIds.receivedAck = false;
     runtimeState.agentRunner = undefined;
     executeAgentRunMock.mockClear();
     handleNewMentionMock.mockClear();
@@ -112,7 +124,9 @@ describe("behavior harness", () => {
   it("forwards the host signal into the eval agent policy", async () => {
     const controller = new AbortController();
 
-    await runEvalScenario({ events: [] }, { signal: controller.signal });
+    await runEvalScenario({ initialEvents: [] }, {
+      signal: controller.signal,
+    });
     await runtimeState.agentRunner?.run({ policy: {} });
 
     expect(executeAgentRunMock).toHaveBeenCalledWith(
@@ -124,7 +138,7 @@ describe("behavior harness", () => {
 
   it("normalizes eval thread fixtures to Slack-style runtime thread ids", async () => {
     const result = await runEvalScenario({
-      events: [
+      initialEvents: [
         {
           type: "new_mention",
           thread: {
@@ -149,6 +163,7 @@ describe("behavior harness", () => {
     expect(observedRuntimeIds.messageThreadId).toBe(
       "slack:CAUTH:1700000000.0001",
     );
+    expect(observedRuntimeIds.receivedAck).toBe(true);
     expect(result.posts).toEqual([
       {
         channel: "CAUTH",
@@ -161,14 +176,14 @@ describe("behavior harness", () => {
 
   it("normalizes eval destinations from adapter channel ids", async () => {
     await runEvalScenario({
-      events: [
+      initialEvents: [
         {
           type: "new_mention",
           thread: {
-            id: "slack:CAUTH:1700000000.0001",
+            id: "slack:CAUTH:1700000000.0002",
           },
           message: {
-            id: "m-auth-1",
+            id: "m-auth-2",
             text: "hello",
             is_mention: true,
           },
@@ -191,7 +206,7 @@ describe("behavior harness", () => {
           overrides: {
             credential_providers: ["github"],
           },
-          events: [],
+          initialEvents: [],
         }),
       ).rejects.toThrow(
         "Eval sandbox HTTP interception requires CLOUDFLARE_TUNNEL_TOKEN",
@@ -215,7 +230,7 @@ describe("behavior harness", () => {
     process.env.JUNIOR_BASE_URL = "https://junior-eval.example.dev";
     try {
       await runEvalScenario({
-        events: [
+        initialEvents: [
           {
             type: "new_mention",
             thread: {
@@ -253,7 +268,7 @@ describe("behavior harness", () => {
           overrides: {
             credential_providers: ["github"],
           },
-          events: [],
+          initialEvents: [],
         }),
       ).rejects.toThrow(
         "Eval sandbox HTTP interception requires JUNIOR_BASE_URL",
@@ -275,7 +290,7 @@ describe("behavior harness", () => {
     };
 
     const result = await runEvalScenario({
-      events: [
+      initialEvents: [
         {
           type: "new_mention",
           thread,
@@ -288,6 +303,8 @@ describe("behavior harness", () => {
             },
           },
         },
+      ],
+      events: [
         {
           type: "subscribed_message",
           thread,
@@ -321,9 +338,58 @@ describe("behavior harness", () => {
     ]);
   });
 
+  it("handles initial message events as one mailbox batch", async () => {
+    const thread = {
+      id: "fixture-initial-batch",
+      channel_id: "CINITIALBATCH",
+      thread_ts: "1700000000.0004",
+    };
+
+    const result = await runEvalScenario({
+      initialEvents: [
+        {
+          type: "new_mention",
+          thread,
+          message: {
+            id: "m-initial-batch-1",
+            text: "include the rollout owner",
+            is_mention: true,
+            author: { user_id: "UINITIALBATCH" },
+          },
+        },
+        {
+          type: "subscribed_message",
+          thread,
+          message: {
+            id: "m-initial-batch-2",
+            text: "summarize the thread",
+            is_mention: true,
+            author: { user_id: "UINITIALBATCH" },
+          },
+        },
+      ],
+    });
+
+    expect(handleNewMentionMock).toHaveBeenCalledTimes(1);
+    expect(handleSubscribedMessageMock).not.toHaveBeenCalled();
+    expect(result.posts).toEqual([
+      {
+        channel: "CINITIALBATCH",
+        files: [],
+        text: "observed",
+        thread_ts: "1700000000.0004",
+      },
+    ]);
+  });
+
   it("preserves attached file metadata on assistant thread posts", async () => {
     handleNewMentionMock.mockImplementationOnce(
-      async (thread: { post: (value: unknown) => Promise<void> }) => {
+      async (
+        thread: { post: (value: unknown) => Promise<void> },
+        _message: unknown,
+        options?: { ack?: () => Promise<void> },
+      ) => {
+        await options?.ack?.();
         await thread.post({
           raw: "",
           files: [
@@ -338,7 +404,7 @@ describe("behavior harness", () => {
     );
 
     const result = await runEvalScenario({
-      events: [
+      initialEvents: [
         {
           type: "new_mention",
           thread: {
@@ -380,7 +446,7 @@ describe("behavior harness", () => {
 
     await expect(
       runEvalScenario({
-        events: [],
+        initialEvents: [],
         overrides: {
           plugin_dirs: ["fixtures/plugins"],
           plugin_packages: ["../bad-package"],

--- a/packages/junior-evals/tests/unit/harness/helpers.test.ts
+++ b/packages/junior-evals/tests/unit/harness/helpers.test.ts
@@ -19,7 +19,7 @@ it("forwards the Vitest abort signal to the eval scenario", async () => {
 
   await expect(
     slackHarness.run(
-      { criteria: { pass: [] }, events: [] },
+      { criteria: { pass: [] }, initialEvents: [] },
       {
         artifacts: {},
         setArtifact: vi.fn(),
@@ -29,7 +29,7 @@ it("forwards the Vitest abort signal to the eval scenario", async () => {
   ).rejects.toBe(runError);
 
   expect(runEvalScenarioMock).toHaveBeenCalledWith(
-    { events: [], overrides: undefined },
+    { initialEvents: [], events: undefined, overrides: undefined },
     { logRecords: [], signal: controller.signal },
   );
 });


### PR DESCRIPTION
Eval scenarios now distinguish messages pending before processing (`initialEvents`), ordinary events delivered after preceding work settles (`events`), and messages arriving during an active run (`steer(...)`). Steering enters through normal Slack ingress and the durable conversation mailbox rather than an agent-internal control API, so scenarios exercise production scheduling behavior end to end.

Existing evals migrate to the new contract. The new routing case is the only eval that exercises `steer(...)`: it models the event ordering discussed in #801 by delivering a direct mention while a resource notification is being processed, then asserts that the user receives one response to the direct instruction. It is behavior coverage for active-run input timing, not evidence that #801 currently reproduces.

`batch()` is removed; multiple Slack messages in `initialEvents` now form one mailbox batch.

Refs #801