### PR TITLE
fix(github): Allow workflow dispatch credentials

### DIFF
--- a/packages/docs/src/content/docs/extend/github-plugin.md
+++ b/packages/docs/src/content/docs/extend/github-plugin.md
@@ -1,8 +1,8 @@
 ---
 title: GitHub Plugin
-description: Configure GitHub App credentials for GitHub issue and pull request workflows.
+description: Configure GitHub App credentials for GitHub repository workflows.
 type: tutorial
-summary: Set up Junior-owned GitHub issues, pull requests, and branch pushes.
+summary: Set up Junior-owned GitHub workflow dispatches, issues, pull requests, and branch pushes.
 prerequisites:
   - /extend/
 related:
@@ -11,7 +11,7 @@ related:
   - /reference/runtime-commands/
 ---
 
-The GitHub plugin uses one GitHub App permission envelope for the repositories Junior can reach. Junior acts as the App installation for reads, issue and pull request maintenance, and Git branch pushes. Human OAuth remains reserved for operations whose GitHub meaning is personal, such as submitting a pull request review.
+The GitHub plugin uses one GitHub App permission envelope for the repositories Junior can reach. Junior acts as the App installation for reads, workflow dispatches, issue and pull request maintenance, and Git branch pushes. Human OAuth remains reserved for operations whose GitHub meaning is personal, such as submitting a pull request review.
 
 ## Install
 
@@ -47,7 +47,7 @@ export const plugins = defineJuniorPlugins([
 ]);
 ```
 
-`appPermissions` should match the permissions configured on the GitHub App. Junior requests read-level installation tokens for read traffic and separate repository-scoped installation tokens for supported issue, pull request, and branch writes. Unsupported writes are denied instead of borrowing a user token.
+`appPermissions` should match the permissions configured on the GitHub App. Junior requests read-level installation tokens for read traffic and separate repository-scoped installation tokens for supported workflow dispatch, issue, pull request, and branch writes. Unsupported writes are denied instead of borrowing a user token.
 
 ## Configure environment variables
 
@@ -165,7 +165,7 @@ To verify PR event watches, create a PR through Junior in Slack and ask Junior t
 
 - Junior mints GitHub App installation and user-to-server tokens on the host, not in the sandbox.
 - When the GitHub skill runs authenticated `gh` or `git` commands, sandbox traffic to `api.github.com` and `github.com` is forwarded through Junior for host-side auth.
-- App-readable requests use installation tokens downscoped to read. Allowlisted issue, pull request, and branch writes use separate repository-scoped installation tokens. GitHub account identity checks and human review operations use user-to-server tokens.
+- App-readable requests use installation tokens downscoped to read. Allowlisted workflow dispatch, issue, pull request, and branch writes use separate repository-scoped installation tokens. GitHub account identity checks and human review operations use user-to-server tokens.
 - GitHub App user-to-server tokens do not use OAuth scopes as their permission model. Their effective access comes from the App permissions, installation scope, and requesting user's access.
 - The GitHub App installation determines which repositories are reachable, and repository write grants narrow issued tokens to the parsed target repository.
 - The host-side lease is bounded by the sandbox session and token expiry. It is not exposed as reusable long-lived auth inside the sandbox.

--- a/packages/junior-github/SETUP.md
+++ b/packages/junior-github/SETUP.md
@@ -1,6 +1,6 @@
 # GitHub plugin setup
 
-This plugin exposes two skills — `github-code` (clone, source-code investigation, pull requests) and `github-issues` (issue workflows). Junior uses GitHub App installation tokens for reads, allowlisted issue and pull request writes, and Git branch pushes. Human OAuth is reserved for explicitly personal operations such as pull request reviews.
+This plugin exposes two skills — `github-code` (clone, source-code investigation, pull requests) and `github-issues` (issue workflows). Junior uses GitHub App installation tokens for reads, workflow dispatches, allowlisted issue and pull request writes, and Git branch pushes. Human OAuth is reserved for explicitly personal operations such as pull request reviews.
 
 ## 1) Create/install GitHub App
 
@@ -98,7 +98,7 @@ Use `additionalUserScopes` only when a human-identity integration flow requires 
 ## 3) Runtime behavior
 
 - When either GitHub skill is active, authenticated `gh` and `git` commands cause the runtime to inject GitHub credentials automatically for the current turn.
-- The plugin classifies GitHub traffic from the forwarded HTTP request. Reads use `installation-read`, while `GET /user` uses `user-read`. Allowlisted issue and pull request mutations use repository-scoped installation grants. Git smart-HTTP pushes use `installation-pr-branch-write`. Unknown REST writes and GraphQL mutations are denied.
+- The plugin classifies GitHub traffic from the forwarded HTTP request. Reads use `installation-read`, while `GET /user` uses `user-read`. Workflow dispatches use the repository-scoped `installation-actions-write` grant. Allowlisted issue and pull request mutations use their own repository-scoped installation grants. Git smart-HTTP pushes use `installation-pr-branch-write`. Unknown REST writes and GraphQL mutations are denied.
 - `user-read` and the remaining explicitly human `user-write` operations require the actor, or an explicitly delegated user subject, to authorize the GitHub App through the private OAuth flow. Junior-owned issue, pull request, and branch operations do not fall back to user OAuth.
 - Headless resource-event turns use the `resource-event` system actor and may receive the same repository-scoped installation grants. This lets Junior respond to subscribed pull request events by committing and pushing fixes without inheriting a subscriber's OAuth credential.
 - Git commits use Junior as author and committer. Resolvable human run actors are credited once with `Co-Authored-By` trailers.
@@ -128,7 +128,7 @@ new resources through the typed tools, for example
 Use `gh` for the allowlisted lifecycle operations described by the skill.
 
 `gh` supports either direct `GITHUB_TOKEN` (for local debugging) or sandbox-level header injection.
-The plugin uses installation credentials for read-only GitHub traffic, allowlisted issue and pull request mutations, and Git smart-HTTP pushes. GitHub App permissions still need to cover the operation: issues for issue edits/comments/labels, contents for pushes, pull requests for PR mutations, and workflows for workflow-file pushes.
+The plugin uses installation credentials for read-only GitHub traffic, workflow dispatches, allowlisted issue and pull request mutations, and Git smart-HTTP pushes. GitHub App permissions still need to cover the operation: actions for workflow dispatches, issues for issue edits/comments/labels, contents for pushes, pull requests for PR mutations, and workflows for workflow-file pushes.
 
 Committing and pushing code uses more than one GitHub surface:
 

--- a/packages/junior-github/skills/github-code/SKILL.md
+++ b/packages/junior-github/skills/github-code/SKILL.md
@@ -161,7 +161,9 @@ Before finishing, reconcile any plan or checklist stated earlier — mark items 
 
 **PR inspection** — read-only `gh pr` and `gh api` commands. Query both conversation comments (`--json comments`) and review comments (`gh api .../pulls/{n}/comments` and `.../reviews`).
 
-**PR mutation** — push before create. Use only the allowlisted REST endpoints in the API reference. Merge, close-with-delete, workflow dispatch, REST ref mutation, and admin operations are unsupported. Git smart HTTP does not independently prevent force updates or ref deletion; rely on GitHub rulesets and do not request destructive pushes.
+**PR mutation** — push before create. Use only the allowlisted REST endpoints in the API reference. Merge, close-with-delete, REST ref mutation, and admin operations are unsupported. Git smart HTTP does not independently prevent force updates or ref deletion; rely on GitHub rulesets and do not request destructive pushes.
+
+**Workflow dispatch** — `gh workflow run` is supported for workflows that declare `workflow_dispatch`. Workflow reruns, cancellations, and other Actions mutations remain unsupported.
 
 ## Guardrails
 

--- a/packages/junior-github/skills/github-code/references/api-surface.md
+++ b/packages/junior-github/skills/github-code/references/api-surface.md
@@ -13,6 +13,7 @@ Treat explicit repo flags as command-targeting safety rails, not as a credential
 | Permission capability        | Commands                                                                             |
 | ---------------------------- | ------------------------------------------------------------------------------------ |
 | `github.actions.read`        | `gh run list`, `gh run view`, `gh run watch`, `gh workflow list`, `gh workflow view` |
+| `github.actions.write`       | `gh workflow run` only                                                               |
 | `github.contents.read`       | `gh repo clone`, `git fetch`                                                         |
 | `github.contents.write`      | Git smart-HTTP `git push` only                                                       |
 | `github.workflows.write`     | Workflow-file changes carried by Git smart-HTTP push                                 |
@@ -34,6 +35,7 @@ Treat explicit repo flags as command-targeting safety rails, not as a credential
 | Create branch                      | `git -C DIRECTORY checkout -b BRANCH`                                                                                    |
 | Stage and commit                   | `git -C DIRECTORY add -A && git -C DIRECTORY commit -m "message"`                                                        |
 | Push branch before PR creation     | `git -C DIRECTORY push -u origin BRANCH`                                                                                 |
+| Dispatch workflow                  | `gh workflow run WORKFLOW --repo owner/repo --ref REF [-f key=value]`                                                    |
 | Create pull request (draft)        | `github_createPullRequest({ repo: "owner/repo", head: "BRANCH", base: "BASE", title: "...", body: "...", draft: true })` |
 | Update pull request                | `gh api repos/owner/repo/pulls/NUMBER --method PATCH --input payload.json`                                               |
 | Mark ready for review              | `gh api repos/owner/repo/pulls/NUMBER/ready_for_review --method POST`                                                    |
@@ -65,7 +67,7 @@ jr-rpc config set github.repo owner/repo
 - A local `git commit` does not call GitHub. Pushing that commit uses Junior's repository-scoped installation credential and requires `github.contents.write` on the target repo.
 - If the commit changes workflow files under `.github/workflows`, expect `github.workflows.write` in addition to contents write.
 - Before `github_createPullRequest`, push the head branch explicitly and resolve the target repo's default branch for `base`. That push requires GitHub write access to the remote.
-- Merge, fork creation, workflow dispatch, REST contents/Git database writes, and repository administration are outside the current write allowlist.
+- Merge, fork creation, workflow reruns or cancellations, REST contents/Git database writes, and repository administration are outside the current write allowlist.
 - If the explicit `git push` fails with 401/403 or another access/permission error, verify the repo context and retry once. If it still fails, load troubleshooting guidance and report the exact command failure.
 - PR comments, labels, and assignees use GitHub's issue endpoints and therefore the issue grant; use the `github-issues` REST guidance for those operations.
 - Return actionable errors for access, permission, not-found, and validation failures.

--- a/packages/junior-github/src/index.ts
+++ b/packages/junior-github/src/index.ts
@@ -77,6 +77,7 @@ export interface GitHubPluginOptions {
 
 type JsonRecord = Record<string, unknown>;
 type GitHubGrantName =
+  | "installation-actions-write"
   | "installation-issues-write"
   | "installation-pr-branch-write"
   | "installation-pull-requests-write"
@@ -84,6 +85,7 @@ type GitHubGrantName =
   | "user-read"
   | "user-write";
 type GitHubGrantReason =
+  | "github.actions-workflow-dispatch"
   | "github.api-read"
   | "github.contents-write"
   | "github.fork-create"
@@ -174,6 +176,9 @@ const HTTP_READ_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 const USER_TOKEN_GRANTS = new Set(["user-read", "user-write"]);
 const CONTENTS_WRITE_REQUIREMENTS = [
   "GitHub App Contents: write on the target repository",
+];
+const ACTIONS_WRITE_REQUIREMENTS = [
+  "GitHub App Actions: write on the target repository",
 ];
 const ISSUES_WRITE_REQUIREMENTS = [
   "GitHub App Issues: write on the target repository",
@@ -1379,6 +1384,14 @@ function githubApiWriteReason(
   if (!isGitHubApiUrl(upstreamUrl)) {
     return undefined;
   }
+  if (
+    method === "POST" &&
+    /^\/repos\/[^/]+\/[^/]+\/actions\/workflows\/[^/]+\/dispatches$/.test(
+      pathname,
+    )
+  ) {
+    return "github.actions-workflow-dispatch";
+  }
   if (method === "POST" && /^\/repos\/[^/]+\/[^/]+\/issues$/.test(pathname)) {
     return "github.issue-create";
   }
@@ -1576,6 +1589,9 @@ function assertGitHubWriteAllowed(input: {
 }
 
 function grantRequirements(reason: GitHubGrantReason): string[] | undefined {
+  if (reason === "github.actions-workflow-dispatch") {
+    return ACTIONS_WRITE_REQUIREMENTS;
+  }
   if (reason === "github.git-write" || reason === "github.contents-write") {
     return CONTENTS_WRITE_REQUIREMENTS;
   }
@@ -1625,6 +1641,14 @@ function installationGrantForWrite(
   upstreamUrl: URL,
 ): GitHubGrant | undefined {
   const leaseScope = repositoryLeaseScope(upstreamUrl);
+  if (reason === "github.actions-workflow-dispatch") {
+    return grantForAccess(
+      "write",
+      reason,
+      "installation-actions-write",
+      leaseScope,
+    );
+  }
   if (reason === "github.issue-create" || reason === "github.issues-write") {
     return grantForAccess(
       "write",
@@ -1725,7 +1749,7 @@ async function githubGrantForEgress(
 
 function configuredWritePermission(
   appPermissions: GitHubAppPermissions | undefined,
-  permission: "issues" | "pull_requests",
+  permission: "actions" | "issues" | "pull_requests",
 ): Record<string, "read" | "write"> {
   const level = appPermissions?.[permission];
   if (level !== undefined && level !== "write" && level !== "admin") {
@@ -1908,6 +1932,7 @@ export function githubPlugin(
             });
           }
           if (
+            ctx.grant.name === "installation-actions-write" ||
             ctx.grant.name === "installation-issues-write" ||
             ctx.grant.name === "installation-pull-requests-write"
           ) {
@@ -1915,9 +1940,11 @@ export function githubPlugin(
               ctx.grant.leaseScope,
             );
             const permission =
-              ctx.grant.name === "installation-issues-write"
-                ? "issues"
-                : "pull_requests";
+              ctx.grant.name === "installation-actions-write"
+                ? "actions"
+                : ctx.grant.name === "installation-issues-write"
+                  ? "issues"
+                  : "pull_requests";
             return await issueInstallationCredential({
               appIdEnv,
               privateKeyEnv,

--- a/packages/junior-github/tests/github-plugin.test.ts
+++ b/packages/junior-github/tests/github-plugin.test.ts
@@ -558,6 +558,37 @@ describe("github plugin", () => {
     ).rejects.toThrow("github.fork-create is not enabled");
   });
 
+  it("maintains the workflow dispatch permission boundary", async () => {
+    expect(
+      await grantForEgress({
+        method: "POST",
+        url: "https://api.github.com/repos/getsentry/junior/actions/workflows/release.yml/dispatches",
+      }),
+    ).toMatchObject({
+      name: "installation-actions-write",
+      access: "write",
+      leaseScope: "repository:getsentry/junior",
+      reason: "github.actions-workflow-dispatch",
+      requirements: ["GitHub App Actions: write on the target repository"],
+    });
+    await expect(
+      grantForEgress({
+        method: "POST",
+        url: "https://api.github.com/repos/getsentry/junior/actions/runs/123/rerun",
+      }),
+    ).rejects.toThrow(
+      "GitHub write request is not an explicitly allowed Junior operation.",
+    );
+    await expect(
+      grantForEgress({
+        method: "POST",
+        url: "https://api.github.com/repos/getsentry/junior/actions/runs/123/cancel",
+      }),
+    ).rejects.toThrow(
+      "GitHub write request is not an explicitly allowed Junior operation.",
+    );
+  });
+
   it("denies raw GitHub issue creation outside the typed createIssue operation", async () => {
     await expect(
       grantForEgress({
@@ -1574,9 +1605,24 @@ Conversation: \`local:test:old-conversation\`
     const requests = mockGitHubInstallationApi();
     const plugin = githubPlugin({
       appPermissions: {
+        actions: "write",
         issues: "write",
         pull_requests: "write",
       },
+    });
+
+    const actionsResult = await plugin.hooks?.issueCredential?.({
+      actor: { platform: "system", name: "scheduler" },
+      grant: {
+        name: "installation-actions-write",
+        access: "write",
+        leaseScope: "repository:getsentry/junior",
+        reason: "github.actions-workflow-dispatch",
+      },
+      db,
+      log: pluginLog,
+      plugin: { name: "github" },
+      tokens: {},
     });
 
     const issueResult = await plugin.hooks?.issueCredential?.({
@@ -1607,17 +1653,25 @@ Conversation: \`local:test:old-conversation\`
       tokens: {},
     });
 
+    expect(actionsResult?.type).toBe("lease");
     expect(issueResult?.type).toBe("lease");
     expect(pullResult?.type).toBe("lease");
-    expect(requests).toHaveLength(2);
+    expect(requests).toHaveLength(3);
     expect(requests[0]).toMatchObject({
+      method: "POST",
+      body: {
+        permissions: { actions: "write", metadata: "read" },
+        repositories: ["junior"],
+      },
+    });
+    expect(requests[1]).toMatchObject({
       method: "POST",
       body: {
         permissions: { issues: "write", metadata: "read" },
         repositories: ["junior"],
       },
     });
-    expect(requests[1]).toMatchObject({
+    expect(requests[2]).toMatchObject({
       method: "POST",
       body: {
         permissions: { metadata: "read", pull_requests: "write" },

--- a/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
@@ -937,6 +937,61 @@ describe("sandbox egress proxy integration", () => {
     expect(upstreamFetch).toHaveBeenCalledTimes(1);
   });
 
+  it("uses repository-scoped GitHub App credentials for workflow dispatch", async () => {
+    configureGitHubAppEnv();
+    const tokenRequests = mockGitHubInstallationToken();
+    await registerGitHubPlugin({
+      appPermissions: {
+        actions: "write",
+      },
+    });
+    const credentialToken = modules.session.createSandboxEgressCredentialToken({
+      credentials: { actor: { type: "user", userId: ACTOR_ID } },
+      egressId: EGRESS_ID,
+      ttlMs: 60_000,
+    });
+    const networkPolicy = modules.policy.buildSandboxEgressNetworkPolicy({
+      credentialToken,
+    });
+    const forwardURL = forwardUrlFor(networkPolicy, GITHUB_API_HOST);
+    const upstreamFetch = vi.fn(
+      async (url: URL | string, init?: RequestInit) => {
+        expect(String(url)).toBe(
+          "https://api.github.com/repos/getsentry/junior/actions/workflows/release.yml/dispatches",
+        );
+        expect(init?.method).toBe("POST");
+        expect(new Headers(init?.headers).get("authorization")).toBe(
+          "Bearer installation-token",
+        );
+        return new Response(null, { status: 204 });
+      },
+    );
+
+    const response = await modules.proxy.proxySandboxEgressRequest(
+      proxiedRequest({
+        body: JSON.stringify({ ref: "main", inputs: { bump: "minor" } }),
+        forwardURL,
+        method: "POST",
+        upstreamHost: GITHUB_API_HOST,
+        upstreamPath:
+          "/repos/getsentry/junior/actions/workflows/release.yml/dispatches",
+      }),
+      {
+        fetch: upstreamFetch as typeof fetch,
+        verifyOidc: async () => ({ sandbox_id: EGRESS_ID }),
+      },
+    );
+
+    expect(response.status).toBe(204);
+    expect(upstreamFetch).toHaveBeenCalledTimes(1);
+    expect(tokenRequests).toEqual([
+      {
+        permissions: { actions: "write", metadata: "read" },
+        repositories: ["junior"],
+      },
+    ]);
+  });
+
   it("records GitHub GraphQL repository access errors without rewriting the response", async () => {
     configureGitHubAppEnv();
     mockGitHubInstallationToken();

--- a/specs/credential-injection.md
+++ b/specs/credential-injection.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-02-26
-- Last Edited: 2026-06-09
+- Last Edited: 2026-07-10
 
 ## Related
 
@@ -78,7 +78,8 @@ Define how Junior maps registered plugin provider domains to host-managed creden
 
 - Plugin manifest capabilities map to GitHub App installation permissions.
 - The GitHub plugin selects `installation-read` for app-readable egress,
-  repository-scoped `installation-issues-write` and
+  repository-scoped `installation-actions-write` for workflow dispatches,
+  `installation-issues-write` and
   `installation-pull-requests-write` grants for Junior-owned resource
   mutations, `installation-pr-branch-write` for Git smart-HTTP pushes,
   `user-read` for actor-account identity reads, and `user-write` only for
@@ -104,7 +105,7 @@ Define how Junior maps registered plugin provider domains to host-managed creden
 - The built-in GitHub plugin declares `api.github.com` for REST API calls and
   `github.com` for git smart-HTTP.
 - Runtime may reuse a short-lived sandbox egress lease for repeated GitHub commands in the same turn, but cache keys include the plugin grant name and opaque lease scope. A repository-scoped write lease must not be reused for another repository or grant family.
-- GitHub read grants are derived from runtime-visible HTTP evidence, including safe HTTP methods, GraphQL queries, `GET /user`, and `git-upload-pack`. Only allowlisted issue and pull request REST writes receive scoped installation resource grants. `git-receive-pack` receives the repository-scoped `installation-pr-branch-write` grant. Unknown REST writes and GraphQL mutations are denied rather than falling back to `user-write`.
+- GitHub read grants are derived from runtime-visible HTTP evidence, including safe HTTP methods, GraphQL queries, `GET /user`, and `git-upload-pack`. Allowlisted workflow dispatch, issue, and pull request REST writes receive scoped installation resource grants. Workflow dispatch is limited to `POST /repos/:owner/:repo/actions/workflows/:workflow_id/dispatches` and receives `installation-actions-write`. `git-receive-pack` receives the repository-scoped `installation-pr-branch-write` grant. Unknown REST writes and GraphQL mutations are denied rather than falling back to `user-write`.
 - The smart-HTTP push classifier scopes the token to the repository but does
   not independently distinguish a Junior-managed branch, detect a force
   update or ref deletion, or inspect the pushed commit range. Deployments must use GitHub
@@ -138,6 +139,31 @@ Define how Junior maps registered plugin provider domains to host-managed creden
 - `OAuthBearerBroker` checks for a per-user OAuth token stored by the credential user subject ID, which is the current user actor or an explicit delegated user subject.
 - If the token is near expiry, runtime refreshes it server-side.
 - Missing or stale auth triggers the private OAuth resume flow defined in the OAuth Flows Spec.
+
+## Verification
+
+A GitHub write surface is not supported until all of these contracts land in
+the same change:
+
+- the request classifier recognizes only the intended HTTP method and path;
+- credential issuance requests the minimum repository-scoped App permission;
+- the relevant GitHub skill documents both the supported command and adjacent
+  unsupported mutations;
+- `packages/junior-github/tests/github-plugin.test.ts` covers grant selection,
+  permission requirements, token permissions, and adjacent denials;
+- `packages/junior/tests/integration/sandbox-egress-proxy.test.ts` proves the
+  request crosses the real proxy with the scoped credential.
+
+Workflow dispatch must retain the named unit contract
+`maintains the workflow dispatch permission boundary` and the integration
+contract `uses repository-scoped GitHub App credentials for workflow dispatch`.
+The positive contract is only `workflow_dispatch`; rerun, cancel, and generic
+Actions writes must remain negative assertions unless this spec is explicitly
+expanded.
+
+Run the focused GitHub plugin and sandbox-egress integration files plus
+`pnpm skills:check`. Changes to this canonical spec also require the repository
+validation commands from `specs/AGENTS.md`.
 
 ## Observability
 


### PR DESCRIPTION
GitHub workflow dispatches now receive a repository-scoped installation token with `Actions: write`. Previously, the GitHub plugin rejected the dispatch REST endpoint as an unknown write even when the App installation had the required permission, which prevented release automation from starting workflows.

The allowlist remains intentionally narrow: only `POST /repos/{owner}/{repo}/actions/workflows/{workflow}/dispatches` is enabled. Workflow reruns, cancellations, and other Actions mutations stay denied. The GitHub skill, public setup guidance, and credential contract now describe the same boundary, with coverage through both grant selection and the real sandbox egress proxy.

The canonical credential spec now makes this a maintenance gate for every GitHub write surface: classifier, minimum scoped token, skill documentation, unit grant/token coverage, proxy integration coverage, and adjacent denial assertions must land together. The workflow dispatch tests have stable contract names so removing or broadening this behavior fails deterministically.