### PR TITLE
ci: Secure third-party action usage

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -4,7 +4,7 @@ description: Install pnpm, setup Node.js, and restore the pnpm store cache.
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       with:
         run_install: false
 

--- a/.github/scripts/ci-paths.sh
+++ b/.github/scripts/ci-paths.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+filters=(ci core dashboard docs evals example lint_config plugins release repo)
+
+if [[ "${GITHUB_EVENT_NAME:-}" != "pull_request" ]]; then
+  for filter in "${filters[@]}"; do
+    echo "$filter=true" >> "$GITHUB_OUTPUT"
+  done
+  echo "full=true" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+if [[ ! "${BASE_SHA:-}" =~ ^[0-9a-f]{40}$ || ! "${HEAD_SHA:-}" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "Expected full pull request base and head SHAs" >&2
+  exit 1
+fi
+
+matched=false
+
+match() {
+  local filter="$1"
+  shift
+
+  local status
+  set +e
+  git diff --quiet "$BASE_SHA...$HEAD_SHA" -- "$@"
+  status=$?
+  set -e
+
+  local value
+  case "$status" in
+    0) value=false ;;
+    1)
+      value=true
+      matched=true
+      ;;
+    *)
+      echo "git diff failed for $filter" >&2
+      exit "$status"
+      ;;
+  esac
+
+  printf -v "$filter" "%s" "$value"
+  echo "$filter=$value" >> "$GITHUB_OUTPUT"
+}
+
+match ci .github/workflows .github/actions .github/scripts
+match core packages/junior packages/junior-plugin-api packages/junior-scheduler packages/junior-testing specs policies
+match dashboard packages/junior-dashboard packages/junior packages/junior-plugin-api
+match docs packages/docs README.md specs policies
+match evals packages/junior-evals
+match example apps/example packages/junior packages/junior-plugin-api
+match lint_config ast-grep sgconfig.yml
+match plugins \
+  packages/junior-agent-browser \
+  packages/junior-amplitude \
+  packages/junior-cloudflare \
+  packages/junior-datadog \
+  packages/junior-github \
+  packages/junior-hex \
+  packages/junior-linear \
+  packages/junior-maintenance \
+  packages/junior-memory \
+  packages/junior-notion \
+  packages/junior-sentry \
+  packages/junior-vercel
+match repo \
+  package.json \
+  pnpm-lock.yaml \
+  pnpm-workspace.yaml \
+  ":(glob)tsconfig*.json" \
+  ":(glob)packages/*/package.json" \
+  ":(glob)apps/*/package.json"
+match release \
+  .craft.yml \
+  .github/workflows/ci.yml \
+  .github/workflows/release.yml \
+  CONTRIBUTING.md \
+  README.md \
+  scripts/bump-release-versions.mjs \
+  scripts/check-release-config.mjs \
+  ":(glob)packages/*/package.json" \
+  packages/docs
+
+if [[ "$repo" == "true" || "$matched" == "false" ]]; then
+  echo "full=true" >> "$GITHUB_OUTPUT"
+else
+  echo "full=false" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/scripts/ci-paths.test.sh
+++ b/.github/scripts/ci-paths.test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script="$(cd "$(dirname "$0")" && pwd)/ci-paths.sh"
+repo="$(mktemp -d)"
+trap 'rm -rf "$repo"' EXIT
+
+git -C "$repo" init --quiet
+git -C "$repo" config user.email test@example.com
+git -C "$repo" config user.name Test
+echo base > "$repo/base.txt"
+git -C "$repo" add .
+git -C "$repo" commit --quiet -m base
+base_sha="$(git -C "$repo" rev-parse HEAD)"
+filters=(ci core dashboard docs evals example lint_config plugins release repo)
+
+check() {
+  local name="$1"
+  local file="$2"
+  local true_filters="$3"
+  local expected_full="$4"
+
+  git -C "$repo" reset --quiet --hard "$base_sha"
+  git -C "$repo" clean --quiet -fd
+  mkdir -p "$repo/$(dirname "$file")"
+  echo "$name" > "$repo/$file"
+  git -C "$repo" add .
+  git -C "$repo" commit --quiet -m "$name"
+
+  local output="$repo/$name.out"
+  (
+    cd "$repo"
+    GITHUB_EVENT_NAME=pull_request \
+      BASE_SHA="$base_sha" \
+      HEAD_SHA="$(git rev-parse HEAD)" \
+      GITHUB_OUTPUT="$output" \
+      "$script"
+  )
+
+  for filter in "${filters[@]}"; do
+    local value=false
+    if [[ " $true_filters " == *" $filter "* ]]; then
+      value=true
+    fi
+    grep --quiet --line-regexp "$filter=$value" "$output"
+  done
+  grep --quiet --line-regexp "full=$expected_full" "$output"
+  [[ "$(wc -l < "$output")" -eq 11 ]]
+}
+
+check docs packages/docs/guide.md "docs release" false
+check core packages/junior/src/example.ts "core dashboard example" false
+check plugin packages/junior-sentry/src/example.ts plugins false
+check repo packages/new/package.json "release repo" true
+check selector .github/scripts/ci-paths.sh ci false
+check unknown misc/file.txt "" true
+
+push_output="$repo/push.out"
+GITHUB_EVENT_NAME=push GITHUB_OUTPUT="$push_output" "$script"
+for filter in "${filters[@]}"; do
+  grep --quiet --line-regexp "$filter=true" "$push_output"
+done
+grep --quiet --line-regexp full=true "$push_output"
+[[ "$(wc -l < "$push_output")" -eq 11 ]]
+
+invalid_output="$repo/invalid.out"
+if GITHUB_EVENT_NAME=pull_request \
+  BASE_SHA=invalid \
+  HEAD_SHA="$(git -C "$repo" rev-parse HEAD)" \
+  GITHUB_OUTPUT="$invalid_output" \
+  "$script" 2>/dev/null; then
+  exit 1
+fi
+
+missing_output="$repo/missing.out"
+if GITHUB_EVENT_NAME=pull_request \
+  BASE_SHA=1111111111111111111111111111111111111111 \
+  HEAD_SHA="$(git -C "$repo" rev-parse HEAD)" \
+  GITHUB_OUTPUT="$missing_output" \
+  "$script" 2>/dev/null; then
+  exit 1
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ name: CI
 
 permissions:
   contents: read
-  actions: write
-  statuses: write
-  pull-requests: read
 
 on:
   push:
@@ -25,6 +22,8 @@ jobs:
   changes:
     name: changes / detect
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       ci: ${{ steps.filter.outputs.ci }}
       core: ${{ steps.filter.outputs.core }}
@@ -32,74 +31,22 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
       evals: ${{ steps.filter.outputs.evals }}
       example: ${{ steps.filter.outputs.example }}
-      full: ${{ steps.filter.outputs.repo == 'true' || steps.filter.outputs.changes == '[]' }}
+      full: ${{ steps.filter.outputs.full }}
       lint_config: ${{ steps.filter.outputs.lint_config }}
       plugins: ${{ steps.filter.outputs.plugins }}
       release: ${{ steps.filter.outputs.release }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
         with:
-          filters: |
-            ci:
-              - ".github/workflows/**"
-              - ".github/actions/**"
-            core:
-              - "packages/junior/**"
-              - "packages/junior-plugin-api/**"
-              - "packages/junior-scheduler/**"
-              - "packages/junior-testing/**"
-              - "specs/**"
-              - "policies/**"
-            dashboard:
-              - "packages/junior-dashboard/**"
-              - "packages/junior/**"
-              - "packages/junior-plugin-api/**"
-            docs:
-              - "packages/docs/**"
-              - "README.md"
-              - "specs/**"
-              - "policies/**"
-            evals:
-              - "packages/junior-evals/**"
-            example:
-              - "apps/example/**"
-              - "packages/junior/**"
-              - "packages/junior-plugin-api/**"
-            lint_config:
-              - "ast-grep/**"
-              - "sgconfig.yml"
-            plugins:
-              - "packages/junior-agent-browser/**"
-              - "packages/junior-amplitude/**"
-              - "packages/junior-cloudflare/**"
-              - "packages/junior-datadog/**"
-              - "packages/junior-github/**"
-              - "packages/junior-hex/**"
-              - "packages/junior-linear/**"
-              - "packages/junior-maintenance/**"
-              - "packages/junior-memory/**"
-              - "packages/junior-notion/**"
-              - "packages/junior-sentry/**"
-              - "packages/junior-vercel/**"
-            repo:
-              - "package.json"
-              - "pnpm-lock.yaml"
-              - "pnpm-workspace.yaml"
-              - "tsconfig*.json"
-              - "packages/*/package.json"
-              - "apps/*/package.json"
-            release:
-              - ".craft.yml"
-              - ".github/workflows/ci.yml"
-              - ".github/workflows/release.yml"
-              - "CONTRIBUTING.md"
-              - "README.md"
-              - "scripts/bump-release-versions.mjs"
-              - "scripts/check-release-config.mjs"
-              - "packages/*/package.json"
-              - "packages/docs/**"
+          fetch-depth: 0
+          persist-credentials: false
+      - id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: .github/scripts/ci-paths.sh
+      - if: github.event_name == 'pull_request' && steps.filter.outputs.ci == 'true'
+        run: .github/scripts/ci-paths.test.sh
 
   release-check:
     name: check / release config
@@ -146,6 +93,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.core == 'true' || needs.changes.outputs.plugins == 'true' || needs.changes.outputs.full == 'true'
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+      statuses: write
     strategy:
       fail-fast: false
       matrix:
@@ -218,6 +170,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.dashboard == 'true' || needs.changes.outputs.full == 'true'
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+      statuses: write
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node-pnpm

--- a/.github/workflows/pr-risk.yml
+++ b/.github/workflows/pr-risk.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Score current PR
-        uses: getsentry/pr-risk-action@v0
+        uses: getsentry/pr-risk-action@f5126d7a979415ac5124b7c14919482b149382aa # v0
         with:
           repo: ${{ github.repository }}
           pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           echo "new=$NEW" >> $GITHUB_OUTPUT
 
       - name: Prepare release
-        uses: getsentry/action-prepare-release@v1
+        uses: getsentry/action-prepare-release@c8e1c2009ab08259029170132c384f03c1064c0e # v1
         env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         with:


### PR DESCRIPTION
Third-party actions now use immutable commit SHAs. CI replaces `dorny/paths-filter` with a repository-owned selector built from `git diff` and fixed Git pathspecs because upstream releases bundle production dependencies with current security advisories.

The selector preserves the existing area-based pull request gates and keeps full-suite behavior on pushes. It validates event SHAs, fails on Git errors, avoids persisted checkout credentials, and has deterministic tests that run whenever CI configuration changes. Workflow permissions now default to read-only contents, with artifact/status access scoped to the coverage-reporting jobs that require it.