### PR TITLE
fix(mcp): Handle protected-resource OAuth challenges

### DIFF
--- a/packages/junior/src/chat/mcp/client.ts
+++ b/packages/junior/src/chat/mcp/client.ts
@@ -9,6 +9,7 @@ import {
 } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { setSpanAttributes } from "@/chat/logging";
 import type { PluginDefinition } from "@/chat/plugins/types";
+import { createMcpTransportFetch } from "./transport-fetch";
 
 type ListedTool = Awaited<ReturnType<Client["listTools"]>>["tools"][number];
 type ToolCallResult = Awaited<ReturnType<Client["callTool"]>>;
@@ -179,9 +180,10 @@ export class PluginMcpClient {
 
     const sessionId = await this.getStoredTransportSessionId();
     this.lastAttemptedTransportSessionId = sessionId;
-    const transport = new StreamableHTTPClientTransport(new URL(mcp.url), {
+    const serverUrl = new URL(mcp.url);
+    const transport = new StreamableHTTPClientTransport(serverUrl, {
       ...(Object.keys(requestInit).length > 0 ? { requestInit } : {}),
-      ...(this.options.fetch ? { fetch: this.options.fetch } : {}),
+      fetch: createMcpTransportFetch(serverUrl, this.options.fetch),
       ...(this.options.authProvider
         ? { authProvider: this.options.authProvider }
         : {}),

--- a/packages/junior/src/chat/mcp/transport-fetch.ts
+++ b/packages/junior/src/chat/mcp/transport-fetch.ts
@@ -1,0 +1,126 @@
+const CLOUDFLARE_ACCESS_SCHEME = /^Cloudflare-Access\b/i;
+const RESOURCE_METADATA_PARAMETER = /(?:^|[,\s])resource_metadata\s*=/i;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const BODY_HEADERS = [
+  "content-encoding",
+  "content-language",
+  "content-location",
+  "content-type",
+];
+const CROSS_ORIGIN_CREDENTIAL_HEADERS = [
+  "authorization",
+  "cookie",
+  "proxy-authorization",
+];
+
+function isRedirect(status: number): boolean {
+  return REDIRECT_STATUSES.has(status);
+}
+
+/** Rewrites only Cloudflare Access challenges that identify OAuth metadata. */
+function normalizeCloudflareAccessChallenge(response: Response): Response {
+  const challenge = response.headers.get("www-authenticate");
+  if (
+    (response.status !== 302 && response.status !== 403) ||
+    !challenge ||
+    !CLOUDFLARE_ACCESS_SCHEME.test(challenge) ||
+    !RESOURCE_METADATA_PARAMETER.test(challenge)
+  ) {
+    return response;
+  }
+
+  const headers = new Headers(response.headers);
+  headers.set(
+    "www-authenticate",
+    challenge.replace(CLOUDFLARE_ACCESS_SCHEME, "Bearer"),
+  );
+  headers.delete("location");
+  return new Response(response.body, {
+    status: 401,
+    headers,
+  });
+}
+
+/** Continues a captured redirect without replaying the MCP resource request. */
+async function followRedirect(
+  request: Request,
+  response: Response,
+  baseFetch: typeof fetch,
+): Promise<Response> {
+  if (request.redirect === "manual") {
+    return response;
+  }
+  if (request.redirect === "error") {
+    throw new TypeError("MCP resource request redirected");
+  }
+
+  const location = response.headers.get("location");
+  if (!location) {
+    return response;
+  }
+
+  const redirectUrl = new URL(location, request.url);
+  const headers = new Headers(request.headers);
+  const becomesGet =
+    (response.status === 303 &&
+      request.method !== "GET" &&
+      request.method !== "HEAD") ||
+    ((response.status === 301 || response.status === 302) &&
+      request.method === "POST");
+  if (becomesGet) {
+    for (const header of BODY_HEADERS) {
+      headers.delete(header);
+    }
+  }
+  if (redirectUrl.origin !== new URL(request.url).origin) {
+    for (const header of CROSS_ORIGIN_CREDENTIAL_HEADERS) {
+      headers.delete(header);
+    }
+  }
+
+  const redirectInit: RequestInit & { duplex?: "half" } = {
+    cache: request.cache,
+    credentials: request.credentials,
+    headers,
+    integrity: request.integrity,
+    keepalive: request.keepalive,
+    method: becomesGet ? "GET" : request.method,
+    mode: request.mode,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    signal: request.signal,
+  };
+  if (!becomesGet && request.body) {
+    redirectInit.body = await request.arrayBuffer();
+    redirectInit.duplex = "half";
+  }
+
+  return await baseFetch(redirectUrl, redirectInit);
+}
+
+/** Adapts Cloudflare Access MCP challenges to the OAuth SDK's Bearer contract. */
+export function createMcpTransportFetch(
+  serverUrl: URL,
+  baseFetch: typeof fetch = globalThis.fetch,
+): typeof fetch {
+  return async (input, init) => {
+    const request = new Request(input, init);
+    if (request.url !== serverUrl.href) {
+      return await baseFetch(input, init);
+    }
+
+    const response = await baseFetch(request.clone(), {
+      redirect: "manual",
+    });
+    const normalized = normalizeCloudflareAccessChallenge(response);
+    if (normalized !== response) {
+      return normalized;
+    }
+
+    if (isRedirect(response.status)) {
+      return await followRedirect(request, response, baseFetch);
+    }
+    return response;
+  };
+}

--- a/packages/junior/src/chat/mcp/transport-fetch.ts
+++ b/packages/junior/src/chat/mcp/transport-fetch.ts
@@ -1,4 +1,5 @@
-const CLOUDFLARE_ACCESS_SCHEME = /^Cloudflare-Access\b/i;
+const AUTH_SCHEME = /^\s*[!#$%&'*+\-.^_`|~0-9A-Za-z]+(?=\s)/;
+const BEARER_CHALLENGE = /(?:^|,)\s*Bearer(?:\s|$)/i;
 const RESOURCE_METADATA_PARAMETER = /(?:^|[,\s])resource_metadata\s*=/i;
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 const BODY_HEADERS = [
@@ -17,23 +18,21 @@ function isRedirect(status: number): boolean {
   return REDIRECT_STATUSES.has(status);
 }
 
-/** Rewrites only Cloudflare Access challenges that identify OAuth metadata. */
-function normalizeCloudflareAccessChallenge(response: Response): Response {
+/** Adapts nonstandard protected-resource challenges without masking scope errors. */
+function normalizeProtectedResourceChallenge(response: Response): Response {
   const challenge = response.headers.get("www-authenticate");
   if (
-    (response.status !== 302 && response.status !== 403) ||
     !challenge ||
-    !CLOUDFLARE_ACCESS_SCHEME.test(challenge) ||
+    !AUTH_SCHEME.test(challenge) ||
+    (response.status !== 302 &&
+      (response.status !== 403 || BEARER_CHALLENGE.test(challenge))) ||
     !RESOURCE_METADATA_PARAMETER.test(challenge)
   ) {
     return response;
   }
 
   const headers = new Headers(response.headers);
-  headers.set(
-    "www-authenticate",
-    challenge.replace(CLOUDFLARE_ACCESS_SCHEME, "Bearer"),
-  );
+  headers.set("www-authenticate", challenge.replace(AUTH_SCHEME, "Bearer"));
   headers.delete("location");
   return new Response(response.body, {
     status: 401,
@@ -84,7 +83,7 @@ async function followRedirect(
   return await baseFetch(redirectUrl, redirectInit);
 }
 
-/** Adapts Cloudflare Access MCP challenges to the OAuth SDK's Bearer contract. */
+/** Adapts protected-resource OAuth challenges to the MCP SDK contract. */
 export function createMcpTransportFetch(
   serverUrl: URL,
   baseFetch: typeof fetch = globalThis.fetch,
@@ -98,7 +97,7 @@ export function createMcpTransportFetch(
     const response = await baseFetch(request.clone(), {
       redirect: "manual",
     });
-    const normalized = normalizeCloudflareAccessChallenge(response);
+    const normalized = normalizeProtectedResourceChallenge(response);
     if (normalized !== response) {
       return normalized;
     }

--- a/packages/junior/src/chat/mcp/transport-fetch.ts
+++ b/packages/junior/src/chat/mcp/transport-fetch.ts
@@ -47,13 +47,6 @@ async function followRedirect(
   response: Response,
   baseFetch: typeof fetch,
 ): Promise<Response> {
-  if (request.redirect === "manual") {
-    return response;
-  }
-  if (request.redirect === "error") {
-    throw new TypeError("MCP resource request redirected");
-  }
-
   const location = response.headers.get("location");
   if (!location) {
     return response;
@@ -79,16 +72,8 @@ async function followRedirect(
   }
 
   const redirectInit: RequestInit & { duplex?: "half" } = {
-    cache: request.cache,
-    credentials: request.credentials,
     headers,
-    integrity: request.integrity,
-    keepalive: request.keepalive,
     method: becomesGet ? "GET" : request.method,
-    mode: request.mode,
-    redirect: request.redirect,
-    referrer: request.referrer,
-    referrerPolicy: request.referrerPolicy,
     signal: request.signal,
   };
   if (!becomesGet && request.body) {

--- a/packages/junior/tests/integration/mcp-oauth-callback-slack.test.ts
+++ b/packages/junior/tests/integration/mcp-oauth-callback-slack.test.ts
@@ -6,8 +6,10 @@ import {
   type Source,
 } from "@sentry/junior-plugin-api";
 import {
+  configureEvalMcpAuthMock,
   EVAL_MCP_AUTH_CODE,
   EVAL_MCP_AUTH_PROVIDER,
+  getCapturedEvalMcpAuthRequests,
 } from "../msw/handlers/eval-mcp-auth";
 import {
   getCapturedSlackApiCalls,
@@ -220,6 +222,7 @@ describe("mcp oauth callback slack integration", () => {
   });
 
   it("finalizes MCP OAuth and resumes the stored thread with persisted context", async () => {
+    configureEvalMcpAuthMock({ challenge: "cloudflare-access" });
     const threadId = "slack:C123:1700000000.001";
     const sessionId = "turn_user-1";
     const storedSource = createSlackSource({
@@ -497,6 +500,52 @@ describe("mcp oauth callback slack integration", () => {
         }),
       ]),
     );
+
+    expect(getCapturedEvalMcpAuthRequests()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          authenticated: false,
+          kind: "mcp",
+          method: "POST",
+        }),
+        expect.objectContaining({
+          kind: "cloudflare-resource-metadata",
+          method: "GET",
+        }),
+      ]),
+    );
+    expect(
+      getCapturedEvalMcpAuthRequests().some(
+        (request) => request.kind === "cloudflare-login",
+      ),
+    ).toBe(false);
+  });
+
+  it("starts MCP OAuth from a Cloudflare Access 403 challenge", async () => {
+    configureEvalMcpAuthMock({
+      challenge: "cloudflare-access",
+      cloudflareStatus: 403,
+    });
+    const authProvider = await createPendingAuthSession({
+      conversationId: "conversation-cloudflare-403",
+      sessionId: "turn-cloudflare-403",
+      userMessage: "list the budget",
+      channelId: "C123",
+      threadTs: "1700000000.403",
+    });
+
+    await expect(
+      mcpAuthStoreModule.getMcpAuthSession(authProvider.authSessionId),
+    ).resolves.toMatchObject({
+      authorizationUrl: expect.stringContaining(
+        "https://eval-auth.example.test/oauth/authorize",
+      ),
+    });
+    expect(
+      getCapturedEvalMcpAuthRequests().some(
+        (request) => request.kind === "cloudflare-login",
+      ),
+    ).toBe(false);
   });
 
   it("fails MCP OAuth resume when stored actor team mismatches destination", async () => {

--- a/packages/junior/tests/integration/mcp-oauth-callback-slack.test.ts
+++ b/packages/junior/tests/integration/mcp-oauth-callback-slack.test.ts
@@ -222,7 +222,7 @@ describe("mcp oauth callback slack integration", () => {
   });
 
   it("finalizes MCP OAuth and resumes the stored thread with persisted context", async () => {
-    configureEvalMcpAuthMock({ challenge: "cloudflare-access" });
+    configureEvalMcpAuthMock({ challenge: "nonstandard" });
     const threadId = "slack:C123:1700000000.001";
     const sessionId = "turn_user-1";
     const storedSource = createSlackSource({
@@ -509,26 +509,26 @@ describe("mcp oauth callback slack integration", () => {
           method: "POST",
         }),
         expect.objectContaining({
-          kind: "cloudflare-resource-metadata",
+          kind: "compat-resource-metadata",
           method: "GET",
         }),
       ]),
     );
     expect(
       getCapturedEvalMcpAuthRequests().some(
-        (request) => request.kind === "cloudflare-login",
+        (request) => request.kind === "authorization-login",
       ),
     ).toBe(false);
   });
 
-  it("starts MCP OAuth from a Cloudflare Access 403 challenge", async () => {
+  it("starts MCP OAuth from a non-Bearer protected-resource 403 challenge", async () => {
     configureEvalMcpAuthMock({
-      challenge: "cloudflare-access",
-      cloudflareStatus: 403,
+      challenge: "nonstandard",
+      compatibilityStatus: 403,
     });
     const authProvider = await createPendingAuthSession({
-      conversationId: "conversation-cloudflare-403",
-      sessionId: "turn-cloudflare-403",
+      conversationId: "conversation-compat-403",
+      sessionId: "turn-compat-403",
       userMessage: "list the budget",
       channelId: "C123",
       threadTs: "1700000000.403",
@@ -543,7 +543,7 @@ describe("mcp oauth callback slack integration", () => {
     });
     expect(
       getCapturedEvalMcpAuthRequests().some(
-        (request) => request.kind === "cloudflare-login",
+        (request) => request.kind === "authorization-login",
       ),
     ).toBe(false);
   });

--- a/packages/junior/tests/msw/handlers/eval-mcp-auth.ts
+++ b/packages/junior/tests/msw/handlers/eval-mcp-auth.ts
@@ -27,6 +27,7 @@ let challenge: EvalMcpAuthChallenge = "bearer";
 let cloudflareStatus: 302 | 403 = 302;
 const capturedRequests: EvalMcpAuthRequest[] = [];
 
+/** Records assertion-safe request metadata without retaining credentials. */
 function captureRequest(
   kind: EvalMcpAuthRequest["kind"],
   request: Request,
@@ -38,6 +39,7 @@ function captureRequest(
   });
 }
 
+/** Models the configured protected-resource challenge at the MCP boundary. */
 function unauthorizedResponse() {
   if (challenge === "cloudflare-access") {
     return new HttpResponse(null, {

--- a/packages/junior/tests/msw/handlers/eval-mcp-auth.ts
+++ b/packages/junior/tests/msw/handlers/eval-mcp-auth.ts
@@ -7,24 +7,24 @@ export const EVAL_MCP_SERVER_URL = `${EVAL_MCP_AUTH_ORIGIN}/mcp`;
 const EVAL_MCP_NO_AUTH_ORIGIN = "https://eval-mcp.example.test";
 const EVAL_MCP_NO_AUTH_SERVER_URL = `${EVAL_MCP_NO_AUTH_ORIGIN}/mcp`;
 const EVAL_MCP_RESOURCE_METADATA_URL = `${EVAL_MCP_AUTH_ORIGIN}/.well-known/oauth-protected-resource/mcp`;
-const EVAL_MCP_CLOUDFLARE_RESOURCE_METADATA_URL = `${EVAL_MCP_AUTH_ORIGIN}/.well-known/cloudflare-access-protected-resource/mcp`;
-const EVAL_MCP_CLOUDFLARE_LOGIN_URL = `${EVAL_MCP_AUTH_ORIGIN}/cdn-cgi/access/login`;
+const EVAL_MCP_COMPAT_RESOURCE_METADATA_URL = `${EVAL_MCP_AUTH_ORIGIN}/.well-known/oauth-protected-resource/compat/mcp`;
+const EVAL_MCP_AUTH_LOGIN_URL = `${EVAL_MCP_AUTH_ORIGIN}/oauth/login`;
 export const EVAL_MCP_AUTHORIZATION_ENDPOINT = `${EVAL_MCP_AUTH_ORIGIN}/oauth/authorize`;
 const EVAL_MCP_TOKEN_ENDPOINT = `${EVAL_MCP_AUTH_ORIGIN}/oauth/token`;
 const EVAL_MCP_REGISTRATION_ENDPOINT = `${EVAL_MCP_AUTH_ORIGIN}/oauth/register`;
 const EVAL_MCP_ACCESS_TOKEN = "eval-auth-access-token";
 const EVAL_MCP_SESSION_ID = "eval-auth-session";
 
-type EvalMcpAuthChallenge = "bearer" | "cloudflare-access";
+type EvalMcpAuthChallenge = "bearer" | "nonstandard";
 
 interface EvalMcpAuthRequest {
   authenticated: boolean;
-  kind: "cloudflare-login" | "cloudflare-resource-metadata" | "mcp";
+  kind: "authorization-login" | "compat-resource-metadata" | "mcp";
   method: string;
 }
 
 let challenge: EvalMcpAuthChallenge = "bearer";
-let cloudflareStatus: 302 | 403 = 302;
+let compatibilityStatus: 302 | 403 = 302;
 const capturedRequests: EvalMcpAuthRequest[] = [];
 
 /** Records assertion-safe request metadata without retaining credentials. */
@@ -41,12 +41,12 @@ function captureRequest(
 
 /** Models the configured protected-resource challenge at the MCP boundary. */
 function unauthorizedResponse() {
-  if (challenge === "cloudflare-access") {
+  if (challenge === "nonstandard") {
     return new HttpResponse(null, {
-      status: cloudflareStatus,
+      status: compatibilityStatus,
       headers: {
-        location: EVAL_MCP_CLOUDFLARE_LOGIN_URL,
-        "WWW-Authenticate": `Cloudflare-Access resource_metadata="${EVAL_MCP_CLOUDFLARE_RESOURCE_METADATA_URL}", scope="mcp:read"`,
+        location: EVAL_MCP_AUTH_LOGIN_URL,
+        "WWW-Authenticate": `Resource-OAuth resource_metadata="${EVAL_MCP_COMPAT_RESOURCE_METADATA_URL}", scope="mcp:read"`,
       },
     });
   }
@@ -74,10 +74,10 @@ function jsonRpcResult(id: unknown, result: unknown, headers?: HeadersInit) {
 /** Enables adversarial protected-resource challenges in OAuth integration tests. */
 export function configureEvalMcpAuthMock(options: {
   challenge: EvalMcpAuthChallenge;
-  cloudflareStatus?: 302 | 403;
+  compatibilityStatus?: 302 | 403;
 }): void {
   challenge = options.challenge;
-  cloudflareStatus = options.cloudflareStatus ?? 302;
+  compatibilityStatus = options.compatibilityStatus ?? 302;
 }
 
 /** Exposes a secret-free outbox for asserting the external OAuth request flow. */
@@ -88,7 +88,7 @@ export function getCapturedEvalMcpAuthRequests(): EvalMcpAuthRequest[] {
 /** Isolates OAuth integration tests that share the stateful protocol fixture. */
 export function resetEvalMcpAuthMockState(): void {
   challenge = "bearer";
-  cloudflareStatus = 302;
+  compatibilityStatus = 302;
   capturedRequests.length = 0;
 }
 
@@ -374,17 +374,17 @@ export const evalMcpAuthHandlers = [
       scopes_supported: ["mcp:read"],
     }),
   ),
-  http.get(EVAL_MCP_CLOUDFLARE_RESOURCE_METADATA_URL, async ({ request }) => {
-    captureRequest("cloudflare-resource-metadata", request);
+  http.get(EVAL_MCP_COMPAT_RESOURCE_METADATA_URL, async ({ request }) => {
+    captureRequest("compat-resource-metadata", request);
     return HttpResponse.json({
       resource: EVAL_MCP_SERVER_URL,
       authorization_servers: [EVAL_MCP_AUTH_ORIGIN],
       scopes_supported: ["mcp:read"],
     });
   }),
-  http.get(EVAL_MCP_CLOUDFLARE_LOGIN_URL, async ({ request }) => {
-    captureRequest("cloudflare-login", request);
-    return new HttpResponse("Cloudflare Access login", {
+  http.get(EVAL_MCP_AUTH_LOGIN_URL, async ({ request }) => {
+    captureRequest("authorization-login", request);
+    return new HttpResponse("OAuth login", {
       status: 200,
       headers: { "content-type": "text/html" },
     });

--- a/packages/junior/tests/msw/handlers/eval-mcp-auth.ts
+++ b/packages/junior/tests/msw/handlers/eval-mcp-auth.ts
@@ -7,13 +7,47 @@ export const EVAL_MCP_SERVER_URL = `${EVAL_MCP_AUTH_ORIGIN}/mcp`;
 const EVAL_MCP_NO_AUTH_ORIGIN = "https://eval-mcp.example.test";
 const EVAL_MCP_NO_AUTH_SERVER_URL = `${EVAL_MCP_NO_AUTH_ORIGIN}/mcp`;
 const EVAL_MCP_RESOURCE_METADATA_URL = `${EVAL_MCP_AUTH_ORIGIN}/.well-known/oauth-protected-resource/mcp`;
+const EVAL_MCP_CLOUDFLARE_RESOURCE_METADATA_URL = `${EVAL_MCP_AUTH_ORIGIN}/.well-known/cloudflare-access-protected-resource/mcp`;
+const EVAL_MCP_CLOUDFLARE_LOGIN_URL = `${EVAL_MCP_AUTH_ORIGIN}/cdn-cgi/access/login`;
 export const EVAL_MCP_AUTHORIZATION_ENDPOINT = `${EVAL_MCP_AUTH_ORIGIN}/oauth/authorize`;
 const EVAL_MCP_TOKEN_ENDPOINT = `${EVAL_MCP_AUTH_ORIGIN}/oauth/token`;
 const EVAL_MCP_REGISTRATION_ENDPOINT = `${EVAL_MCP_AUTH_ORIGIN}/oauth/register`;
 const EVAL_MCP_ACCESS_TOKEN = "eval-auth-access-token";
 const EVAL_MCP_SESSION_ID = "eval-auth-session";
 
+type EvalMcpAuthChallenge = "bearer" | "cloudflare-access";
+
+interface EvalMcpAuthRequest {
+  authenticated: boolean;
+  kind: "cloudflare-login" | "cloudflare-resource-metadata" | "mcp";
+  method: string;
+}
+
+let challenge: EvalMcpAuthChallenge = "bearer";
+let cloudflareStatus: 302 | 403 = 302;
+const capturedRequests: EvalMcpAuthRequest[] = [];
+
+function captureRequest(
+  kind: EvalMcpAuthRequest["kind"],
+  request: Request,
+): void {
+  capturedRequests.push({
+    authenticated: request.headers.has("authorization"),
+    kind,
+    method: request.method,
+  });
+}
+
 function unauthorizedResponse() {
+  if (challenge === "cloudflare-access") {
+    return new HttpResponse(null, {
+      status: cloudflareStatus,
+      headers: {
+        location: EVAL_MCP_CLOUDFLARE_LOGIN_URL,
+        "WWW-Authenticate": `Cloudflare-Access resource_metadata="${EVAL_MCP_CLOUDFLARE_RESOURCE_METADATA_URL}", scope="mcp:read"`,
+      },
+    });
+  }
   return new HttpResponse(null, {
     status: 401,
     headers: {
@@ -35,7 +69,26 @@ function jsonRpcResult(id: unknown, result: unknown, headers?: HeadersInit) {
   );
 }
 
-export function resetEvalMcpAuthMockState(): void {}
+/** Enables adversarial protected-resource challenges in OAuth integration tests. */
+export function configureEvalMcpAuthMock(options: {
+  challenge: EvalMcpAuthChallenge;
+  cloudflareStatus?: 302 | 403;
+}): void {
+  challenge = options.challenge;
+  cloudflareStatus = options.cloudflareStatus ?? 302;
+}
+
+/** Exposes a secret-free outbox for asserting the external OAuth request flow. */
+export function getCapturedEvalMcpAuthRequests(): EvalMcpAuthRequest[] {
+  return capturedRequests.map((request) => ({ ...request }));
+}
+
+/** Isolates OAuth integration tests that share the stateful protocol fixture. */
+export function resetEvalMcpAuthMockState(): void {
+  challenge = "bearer";
+  cloudflareStatus = 302;
+  capturedRequests.length = 0;
+}
 
 export const evalMcpAuthHandlers = [
   http.get(
@@ -204,6 +257,7 @@ export const evalMcpAuthHandlers = [
     async () => new HttpResponse(null, { status: 405 }),
   ),
   http.post(EVAL_MCP_SERVER_URL, async ({ request }) => {
+    captureRequest("mcp", request);
     const authorization = request.headers.get("authorization");
     if (authorization !== `Bearer ${EVAL_MCP_ACCESS_TOKEN}`) {
       return unauthorizedResponse();
@@ -318,6 +372,21 @@ export const evalMcpAuthHandlers = [
       scopes_supported: ["mcp:read"],
     }),
   ),
+  http.get(EVAL_MCP_CLOUDFLARE_RESOURCE_METADATA_URL, async ({ request }) => {
+    captureRequest("cloudflare-resource-metadata", request);
+    return HttpResponse.json({
+      resource: EVAL_MCP_SERVER_URL,
+      authorization_servers: [EVAL_MCP_AUTH_ORIGIN],
+      scopes_supported: ["mcp:read"],
+    });
+  }),
+  http.get(EVAL_MCP_CLOUDFLARE_LOGIN_URL, async ({ request }) => {
+    captureRequest("cloudflare-login", request);
+    return new HttpResponse("Cloudflare Access login", {
+      status: 200,
+      headers: { "content-type": "text/html" },
+    });
+  }),
   http.get(
     `${EVAL_MCP_AUTH_ORIGIN}/.well-known/oauth-authorization-server`,
     async () =>

--- a/packages/junior/tests/unit/mcp/client.test.ts
+++ b/packages/junior/tests/unit/mcp/client.test.ts
@@ -285,8 +285,12 @@ describe("PluginMcpClient", () => {
     await expect(client.listTools()).resolves.toHaveLength(1);
     expect(authProvider.saveMcpServerSessionId).toHaveBeenCalledWith(undefined);
     expect(transportOptions).toEqual([
-      { authProvider, sessionId: "stale-session" },
-      { authProvider },
+      {
+        authProvider,
+        fetch: expect.any(Function),
+        sessionId: "stale-session",
+      },
+      { authProvider, fetch: expect.any(Function) },
     ]);
   });
 

--- a/packages/junior/tests/unit/mcp/client.test.ts
+++ b/packages/junior/tests/unit/mcp/client.test.ts
@@ -285,12 +285,11 @@ describe("PluginMcpClient", () => {
     await expect(client.listTools()).resolves.toHaveLength(1);
     expect(authProvider.saveMcpServerSessionId).toHaveBeenCalledWith(undefined);
     expect(transportOptions).toEqual([
-      {
+      expect.objectContaining({
         authProvider,
-        fetch: expect.any(Function),
         sessionId: "stale-session",
-      },
-      { authProvider, fetch: expect.any(Function) },
+      }),
+      expect.objectContaining({ authProvider }),
     ]);
   });
 

--- a/packages/junior/tests/unit/mcp/transport-fetch.test.ts
+++ b/packages/junior/tests/unit/mcp/transport-fetch.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMcpTransportFetch } from "@/chat/mcp/transport-fetch";
+
+describe("createMcpTransportFetch", () => {
+  it("continues an ordinary redirect without replaying the MCP request", async () => {
+    const serverUrl = new URL("https://mcp.example.test/mcp");
+    const redirectedUrl = "https://mcp.example.test/v2/mcp";
+    const baseFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { location: redirectedUrl },
+        }),
+      )
+      .mockResolvedValueOnce(new Response("redirected", { status: 200 }));
+    const transportFetch = createMcpTransportFetch(serverUrl, baseFetch);
+
+    const response = await transportFetch(serverUrl, {
+      method: "POST",
+      body: "request body",
+      headers: { "content-type": "application/json" },
+    });
+
+    await expect(response.text()).resolves.toBe("redirected");
+    expect(baseFetch).toHaveBeenCalledTimes(2);
+    const initialRequest = baseFetch.mock.calls[0]?.[0];
+    expect(initialRequest).toBeInstanceOf(Request);
+    expect((initialRequest as Request).url).toBe(serverUrl.href);
+    expect(baseFetch.mock.calls[1]?.[0]).toEqual(new URL(redirectedUrl));
+    expect(baseFetch.mock.calls[1]?.[1]).toMatchObject({
+      method: "GET",
+      redirect: "follow",
+    });
+  });
+});

--- a/packages/junior/tests/unit/mcp/transport-fetch.test.ts
+++ b/packages/junior/tests/unit/mcp/transport-fetch.test.ts
@@ -30,7 +30,6 @@ describe("createMcpTransportFetch", () => {
     expect(baseFetch.mock.calls[1]?.[0]).toEqual(new URL(redirectedUrl));
     expect(baseFetch.mock.calls[1]?.[1]).toMatchObject({
       method: "GET",
-      redirect: "follow",
     });
   });
 });

--- a/packages/junior/tests/unit/mcp/transport-fetch.test.ts
+++ b/packages/junior/tests/unit/mcp/transport-fetch.test.ts
@@ -32,4 +32,41 @@ describe("createMcpTransportFetch", () => {
       method: "GET",
     });
   });
+
+  it("preserves standard Bearer insufficient-scope responses", async () => {
+    const serverUrl = new URL("https://mcp.example.test/mcp");
+    const challenge =
+      'Bearer error="insufficient_scope", scope="mcp:write", resource_metadata="https://mcp.example.test/.well-known/oauth-protected-resource"';
+    const baseFetch = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(null, {
+        status: 403,
+        headers: { "www-authenticate": challenge },
+      }),
+    );
+    const transportFetch = createMcpTransportFetch(serverUrl, baseFetch);
+
+    const response = await transportFetch(serverUrl, { method: "POST" });
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get("www-authenticate")).toBe(challenge);
+    expect(baseFetch).toHaveBeenCalledOnce();
+  });
+
+  it("preserves Bearer scope errors after another challenge", async () => {
+    const serverUrl = new URL("https://mcp.example.test/mcp");
+    const challenge =
+      'Resource-OAuth resource_metadata="https://mcp.example.test/.well-known/oauth-protected-resource", Bearer error="insufficient_scope", scope="mcp:write"';
+    const baseFetch = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(null, {
+        status: 403,
+        headers: { "www-authenticate": challenge },
+      }),
+    );
+    const transportFetch = createMcpTransportFetch(serverUrl, baseFetch);
+
+    const response = await transportFetch(serverUrl, { method: "POST" });
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get("www-authenticate")).toBe(challenge);
+  });
 });

--- a/specs/oauth-flows.md
+++ b/specs/oauth-flows.md
@@ -92,8 +92,8 @@ User: invokes a skill that exposes MCP-backed tools
 Agent: calls an MCP tool from the same plugin
   │
   ├─ MCP server responds with a standard 401 Bearer auth challenge
-  │    • Cloudflare Access 302/403 challenges are accepted only when they carry resource_metadata
-  │    • the transport normalizes that exact compatibility case to the SDK's 401 Bearer contract
+  │    • nonstandard 302 challenges are accepted only when they carry resource_metadata
+  │    • non-Bearer 403 challenges with resource_metadata are normalized without masking Bearer scope errors
   ├─ MCP OAuth provider persists auth session state
   ├─ Runtime privately delivers the authorization link to the requesting user
   ├─ Runtime posts a brief visible thread note that authorization is needed

--- a/specs/oauth-flows.md
+++ b/specs/oauth-flows.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-03-03
-- Last Edited: 2026-06-12
+- Last Edited: 2026-07-10
 
 ## Related
 
@@ -91,7 +91,9 @@ User: invokes a skill that exposes MCP-backed tools
   ▼
 Agent: calls an MCP tool from the same plugin
   │
-  ├─ MCP server responds with 401 / auth challenge
+  ├─ MCP server responds with a standard 401 Bearer auth challenge
+  │    • Cloudflare Access 302/403 challenges are accepted only when they carry resource_metadata
+  │    • the transport normalizes that exact compatibility case to the SDK's 401 Bearer contract
   ├─ MCP OAuth provider persists auth session state
   ├─ Runtime privately delivers the authorization link to the requesting user
   ├─ Runtime posts a brief visible thread note that authorization is needed


### PR DESCRIPTION
MCP OAuth now recovers when a protected resource returns a nonstandard redirect or non-Bearer forbidden challenge containing `resource_metadata`. Detection uses protocol signals only; standard Bearer 403 scope errors remain untouched, including combined challenge headers, and ordinary redirects continue without replaying the original MCP request.

The shared OAuth fixture models the 302 and 403 variants without provider-specific response shapes and covers the complete callback and Slack resume path.

Fixes #832
Refs #838