### PR TITLE
fix(cli): Exempt Sentry packages from release delay

### DIFF
--- a/packages/docs/src/content/docs/cli/init.md
+++ b/packages/docs/src/content/docs/cli/init.md
@@ -26,6 +26,7 @@ The command requires exactly one argument: the target directory.
 The scaffold includes:
 
 - `package.json` with `@sentry/junior`, `@sentry/junior-maintenance`, `@sentry/junior-memory`, `hono`, `nitro`, `typescript`, `jiti`, and `@types/node`
+- `pnpm-workspace.yaml` with a 24-hour dependency release delay and an immediate exception for the `@sentry/*` package scope
 - `plugins.ts` with `@sentry/junior-maintenance` and `createMemoryPlugin()` enabled
 - `server.ts`
 - `nitro.config.ts` pointing at `./plugins`

--- a/packages/junior-maintenance/skills/self-update/SKILL.md
+++ b/packages/junior-maintenance/skills/self-update/SKILL.md
@@ -54,7 +54,7 @@ Save total PR count, breaking PRs (`!` or `BREAKING CHANGE`), and config-relevan
 
 ### 5. Sync `minimumReleaseAgeExclude`
 
-If `pnpm-workspace.yaml` has a `minimumReleaseAgeExclude` list, ensure every Junior package from step 2 is listed. Add missing entries before `pnpm add`. Append at end, preserve existing order.
+If `pnpm-workspace.yaml` has a `minimumReleaseAgeExclude` list, ensure every Junior package from step 2 is covered by an exact entry or an existing package pattern. Add missing entries before `pnpm add`, but do not add exact entries already covered by `@sentry/*`. Append at end and preserve existing order.
 
 ### 6. Update deps (section-preserving)
 

--- a/packages/junior/src/cli/init.ts
+++ b/packages/junior/src/cli/init.ts
@@ -69,6 +69,16 @@ function writeTsConfig(targetDir: string): void {
   );
 }
 
+function writePnpmWorkspace(targetDir: string): void {
+  fs.writeFileSync(
+    path.join(targetDir, "pnpm-workspace.yaml"),
+    `minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - "@sentry/*"
+`,
+  );
+}
+
 function writeVercelJson(targetDir: string): void {
   fs.writeFileSync(
     path.join(targetDir, "vercel.json"),
@@ -220,6 +230,7 @@ SENTRY_ORG_SLUG=
   writePluginsFile(target);
   writeNitroConfig(target);
   writeTsConfig(target);
+  writePnpmWorkspace(target);
   writeVercelJson(target);
   writeGitHubWorkflow(target);
 

--- a/packages/junior/tests/unit/cli/init-cli.test.ts
+++ b/packages/junior/tests/unit/cli/init-cli.test.ts
@@ -160,6 +160,15 @@ describe("init cli", () => {
     expect(pkg.scripts.preview).toBe("nitro preview");
     expect(pkg.scripts.typecheck).toBe("tsc --noEmit");
 
+    const pnpmWorkspace = fs.readFileSync(
+      path.join(target, "pnpm-workspace.yaml"),
+      "utf8",
+    );
+    expect(pnpmWorkspace).toBe(`minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - "@sentry/*"
+`);
+
     const envExample = fs.readFileSync(
       path.join(target, ".env.example"),
       "utf8",


### PR DESCRIPTION
`junior init` now writes `pnpm-workspace.yaml` with a 24-hour minimum release age while exempting trusted `@sentry/*` packages, so newly published Junior and other Sentry dependencies can install immediately without disabling the delay for the rest of the dependency graph.

The maintenance self-update guidance recognizes the scope pattern instead of appending redundant exact package entries, and the scaffold contract test and public CLI docs track the generated configuration.