### PR TITLE
test(oauth): Complete headless MCP auth fixture

### DIFF
--- a/packages/junior-evals/src/behavior-harness.ts
+++ b/packages/junior-evals/src/behavior-harness.ts
@@ -95,11 +95,10 @@ import {
   EVAL_OAUTH_PROVIDER,
 } from "@junior-tests/msw/handlers/eval-oauth";
 import {
-  EVAL_MCP_AUTH_CODE,
   EVAL_MCP_AUTHORIZATION_ENDPOINT,
   EVAL_MCP_AUTH_PROVIDER,
 } from "@junior-tests/msw/handlers/eval-mcp-auth";
-import { runMcpOauthCallbackRoute } from "@junior-tests/fixtures/mcp-oauth-callback-harness";
+import { completeMcpOauthCallbackRoute } from "@junior-tests/fixtures/mcp-oauth-callback-harness";
 import { runOauthCallbackRoute } from "@junior-tests/fixtures/oauth-callback-harness";
 import {
   readCapturedSlackApiCalls,
@@ -1266,18 +1265,12 @@ async function seedExpiredOAuthTokens(input: {
   }
 }
 
-function getDefaultAuthCode(
-  type: "mcp-oauth" | "oauth",
-  provider: string,
-): string {
-  if (type === "mcp-oauth" && provider === EVAL_MCP_AUTH_PROVIDER) {
-    return EVAL_MCP_AUTH_CODE;
-  }
-  if (type === "oauth" && provider === EVAL_OAUTH_PROVIDER) {
+function getDefaultOauthCode(provider: string): string {
+  if (provider === EVAL_OAUTH_PROVIDER) {
     return EVAL_OAUTH_CODE;
   }
   throw new Error(
-    `No default eval ${type} code configured for provider "${provider}"`,
+    `No default eval OAuth code configured for provider "${provider}"`,
   );
 }
 
@@ -1401,10 +1394,9 @@ async function autoCompleteMcpOauth(args: {
     );
   }
 
-  const response = await runMcpOauthCallbackRoute({
+  const response = await completeMcpOauthCallbackRoute({
     provider,
-    state: delivered.state,
-    code: getDefaultAuthCode("mcp-oauth", provider),
+    authSessionId: delivered.state,
     agentRunner: args.agentRunner,
   });
   if (response.status !== 200) {
@@ -1472,7 +1464,7 @@ async function autoCompleteOauth(args: {
   const response = await runOauthCallbackRoute({
     provider,
     state: delivered.state,
-    code: getDefaultAuthCode("oauth", provider),
+    code: getDefaultOauthCode(provider),
     agentRunner: args.agentRunner,
   });
   if (response.status !== 200) {

--- a/packages/junior/tests/fixtures/mcp-oauth-callback-harness.ts
+++ b/packages/junior/tests/fixtures/mcp-oauth-callback-harness.ts
@@ -33,3 +33,35 @@ export async function runMcpOauthCallbackRoute(args: {
   }
   return response;
 }
+
+/** Complete the headless authorization transition and run its callback route. */
+export async function completeMcpOauthCallbackRoute(args: {
+  provider: string;
+  authSessionId: string;
+  agentRunner?: AgentRunner;
+}) {
+  const { getMcpAuthSession } = await import("@/chat/mcp/auth-store");
+  const session = await getMcpAuthSession(args.authSessionId);
+  if (!session?.authorizationUrl) {
+    throw new Error(`Missing MCP authorization URL: ${args.authSessionId}`);
+  }
+  const authorization = await fetch(session.authorizationUrl, {
+    redirect: "manual",
+  });
+  const location = authorization.headers.get("location");
+  if (authorization.status !== 302 || !location) {
+    throw new Error(`MCP authorization failed: ${authorization.status}`);
+  }
+  const callback = new URL(location);
+  const state = callback.searchParams.get("state");
+  const code = callback.searchParams.get("code");
+  if (!state || !code) {
+    throw new Error("MCP authorization callback omitted code or state");
+  }
+  return await runMcpOauthCallbackRoute({
+    provider: args.provider,
+    state,
+    code,
+    ...(args.agentRunner ? { agentRunner: args.agentRunner } : {}),
+  });
+}

--- a/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
+++ b/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
@@ -1,10 +1,7 @@
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { z } from "zod";
-import {
-  EVAL_MCP_AUTH_CODE,
-  EVAL_MCP_AUTH_PROVIDER,
-} from "../msw/handlers/eval-mcp-auth";
+import { EVAL_MCP_AUTH_PROVIDER } from "../msw/handlers/eval-mcp-auth";
 import {
   getCapturedSlackApiCalls,
   resetSlackApiMockState,
@@ -551,10 +548,9 @@ describe("mcp auth runtime slack integration", () => {
     });
 
     const response =
-      await mcpOauthCallbackHarnessModule.runMcpOauthCallbackRoute({
+      await mcpOauthCallbackHarnessModule.completeMcpOauthCallbackRoute({
         provider: EVAL_MCP_AUTH_PROVIDER,
-        state: pendingAuthSession!.authSessionId,
-        code: EVAL_MCP_AUTH_CODE,
+        authSessionId: pendingAuthSession!.authSessionId,
       });
 
     expect(response.status).toBe(200);
@@ -1038,10 +1034,9 @@ describe("mcp auth runtime slack integration", () => {
     });
 
     const response =
-      await mcpOauthCallbackHarnessModule.runMcpOauthCallbackRoute({
+      await mcpOauthCallbackHarnessModule.completeMcpOauthCallbackRoute({
         provider: EVAL_MCP_AUTH_PROVIDER,
-        state: pendingAuthSession!.authSessionId,
-        code: EVAL_MCP_AUTH_CODE,
+        authSessionId: pendingAuthSession!.authSessionId,
       });
 
     expect(response.status).toBe(200);

--- a/packages/junior/tests/integration/mcp-oauth-callback-slack.test.ts
+++ b/packages/junior/tests/integration/mcp-oauth-callback-slack.test.ts
@@ -5,10 +5,7 @@ import {
   type Actor,
   type Source,
 } from "@sentry/junior-plugin-api";
-import {
-  EVAL_MCP_AUTH_CODE,
-  EVAL_MCP_AUTH_PROVIDER,
-} from "../msw/handlers/eval-mcp-auth";
+import { EVAL_MCP_AUTH_PROVIDER } from "../msw/handlers/eval-mcp-auth";
 import {
   getCapturedSlackApiCalls,
   resetSlackApiMockState,
@@ -436,10 +433,9 @@ describe("mcp oauth callback slack integration", () => {
     );
 
     const response =
-      await mcpOauthCallbackHarnessModule.runMcpOauthCallbackRoute({
+      await mcpOauthCallbackHarnessModule.completeMcpOauthCallbackRoute({
         provider: EVAL_MCP_AUTH_PROVIDER,
-        state: authProvider.authSessionId,
-        code: EVAL_MCP_AUTH_CODE,
+        authSessionId: authProvider.authSessionId,
         agentRunner: testAgentRunner,
       });
 
@@ -622,10 +618,9 @@ describe("mcp oauth callback slack integration", () => {
     });
 
     const response =
-      await mcpOauthCallbackHarnessModule.runMcpOauthCallbackRoute({
+      await mcpOauthCallbackHarnessModule.completeMcpOauthCallbackRoute({
         provider: EVAL_MCP_AUTH_PROVIDER,
-        state: authProvider.authSessionId,
-        code: EVAL_MCP_AUTH_CODE,
+        authSessionId: authProvider.authSessionId,
         agentRunner: testAgentRunner,
       });
 
@@ -768,10 +763,9 @@ describe("mcp oauth callback slack integration", () => {
 
     try {
       const response =
-        await mcpOauthCallbackHarnessModule.runMcpOauthCallbackRoute({
+        await mcpOauthCallbackHarnessModule.completeMcpOauthCallbackRoute({
           provider: EVAL_MCP_AUTH_PROVIDER,
-          state: authProvider.authSessionId,
-          code: EVAL_MCP_AUTH_CODE,
+          authSessionId: authProvider.authSessionId,
           agentRunner: testAgentRunner,
         });
 
@@ -886,10 +880,9 @@ describe("mcp oauth callback slack integration", () => {
     });
 
     const response =
-      await mcpOauthCallbackHarnessModule.runMcpOauthCallbackRoute({
+      await mcpOauthCallbackHarnessModule.completeMcpOauthCallbackRoute({
         provider: EVAL_MCP_AUTH_PROVIDER,
-        state: authProvider.authSessionId,
-        code: EVAL_MCP_AUTH_CODE,
+        authSessionId: authProvider.authSessionId,
         agentRunner: testAgentRunner,
       });
 
@@ -956,10 +949,9 @@ describe("mcp oauth callback slack integration", () => {
     });
 
     const response =
-      await mcpOauthCallbackHarnessModule.runMcpOauthCallbackRoute({
+      await mcpOauthCallbackHarnessModule.completeMcpOauthCallbackRoute({
         provider: EVAL_MCP_AUTH_PROVIDER,
-        state: authProvider.authSessionId,
-        code: EVAL_MCP_AUTH_CODE,
+        authSessionId: authProvider.authSessionId,
         agentRunner: testAgentRunner,
       });
 
@@ -1025,10 +1017,9 @@ describe("mcp oauth callback slack integration", () => {
     });
 
     const response =
-      await mcpOauthCallbackHarnessModule.runMcpOauthCallbackRoute({
+      await mcpOauthCallbackHarnessModule.completeMcpOauthCallbackRoute({
         provider: EVAL_MCP_AUTH_PROVIDER,
-        state: authProvider.authSessionId,
-        code: EVAL_MCP_AUTH_CODE,
+        authSessionId: authProvider.authSessionId,
         agentRunner: testAgentRunner,
       });
 

--- a/packages/junior/tests/msw/handlers/eval-mcp-auth.ts
+++ b/packages/junior/tests/msw/handlers/eval-mcp-auth.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { http, HttpResponse } from "msw";
 
 export const EVAL_MCP_AUTH_PROVIDER = "eval-auth";
@@ -12,6 +13,29 @@ const EVAL_MCP_TOKEN_ENDPOINT = `${EVAL_MCP_AUTH_ORIGIN}/oauth/token`;
 const EVAL_MCP_REGISTRATION_ENDPOINT = `${EVAL_MCP_AUTH_ORIGIN}/oauth/register`;
 const EVAL_MCP_ACCESS_TOKEN = "eval-auth-access-token";
 const EVAL_MCP_SESSION_ID = "eval-auth-session";
+const EVAL_MCP_CLIENT_ID = "eval-auth-client-id";
+const EVAL_MCP_CALLBACK_PATH = "/api/oauth/callback/mcp/eval-auth";
+
+interface AuthorizationGrant {
+  clientId: string;
+  codeChallenge: string;
+  redirectUri: string;
+  scope?: string;
+}
+
+let authorizationGrant: AuthorizationGrant | undefined;
+let clientRegistered = false;
+let tokenIssued = false;
+
+function pkceChallenge(verifier: string): string {
+  return createHash("sha256").update(verifier).digest("base64url");
+}
+
+function getEvalMcpCallbackUrl(): string {
+  const baseUrl =
+    process.env.JUNIOR_BASE_URL?.trim() || "https://junior.example.com";
+  return new URL(EVAL_MCP_CALLBACK_PATH, baseUrl).toString();
+}
 
 function unauthorizedResponse() {
   return new HttpResponse(null, {
@@ -35,7 +59,12 @@ function jsonRpcResult(id: unknown, result: unknown, headers?: HeadersInit) {
   );
 }
 
-export function resetEvalMcpAuthMockState(): void {}
+/** Reset headless OAuth state between integration tests. */
+export function resetEvalMcpAuthMockState(): void {
+  authorizationGrant = undefined;
+  clientRegistered = false;
+  tokenIssued = false;
+}
 
 export const evalMcpAuthHandlers = [
   http.get(
@@ -205,7 +234,7 @@ export const evalMcpAuthHandlers = [
   ),
   http.post(EVAL_MCP_SERVER_URL, async ({ request }) => {
     const authorization = request.headers.get("authorization");
-    if (authorization !== `Bearer ${EVAL_MCP_ACCESS_TOKEN}`) {
+    if (!tokenIssued || authorization !== `Bearer ${EVAL_MCP_ACCESS_TOKEN}`) {
       return unauthorizedResponse();
     }
 
@@ -332,10 +361,57 @@ export const evalMcpAuthHandlers = [
         code_challenge_methods_supported: ["S256"],
       }),
   ),
+  http.get(EVAL_MCP_AUTHORIZATION_ENDPOINT, async ({ request }) => {
+    const url = new URL(request.url);
+    const clientId = url.searchParams.get("client_id");
+    const redirectUri = url.searchParams.get("redirect_uri");
+    const callbackUrl = getEvalMcpCallbackUrl();
+    const state = url.searchParams.get("state");
+    const codeChallenge = url.searchParams.get("code_challenge");
+    if (
+      !clientRegistered ||
+      clientId !== EVAL_MCP_CLIENT_ID ||
+      redirectUri !== callbackUrl ||
+      !state ||
+      !codeChallenge ||
+      url.searchParams.get("code_challenge_method") !== "S256" ||
+      url.searchParams.get("response_type") !== "code"
+    ) {
+      return HttpResponse.json({ error: "invalid_request" }, { status: 400 });
+    }
+
+    authorizationGrant = {
+      clientId,
+      codeChallenge,
+      redirectUri,
+      ...(url.searchParams.get("scope")
+        ? { scope: url.searchParams.get("scope")! }
+        : {}),
+    };
+    const callback = new URL(redirectUri);
+    callback.searchParams.set("code", EVAL_MCP_AUTH_CODE);
+    callback.searchParams.set("state", state);
+    return new HttpResponse(null, {
+      status: 302,
+      headers: { Location: callback.toString() },
+    });
+  }),
   http.post(EVAL_MCP_REGISTRATION_ENDPOINT, async ({ request }) => {
     const body = (await request.json()) as Record<string, unknown>;
+    const callbackUrl = getEvalMcpCallbackUrl();
+    if (
+      !Array.isArray(body.redirect_uris) ||
+      body.redirect_uris.length !== 1 ||
+      body.redirect_uris[0] !== callbackUrl
+    ) {
+      return HttpResponse.json(
+        { error: "invalid_client_metadata" },
+        { status: 400 },
+      );
+    }
+    clientRegistered = true;
     return HttpResponse.json({
-      client_id: "eval-auth-client-id",
+      client_id: EVAL_MCP_CLIENT_ID,
       client_id_issued_at: Math.floor(Date.now() / 1000),
       ...(Array.isArray(body.redirect_uris)
         ? { redirect_uris: body.redirect_uris }
@@ -360,7 +436,16 @@ export const evalMcpAuthHandlers = [
     const bodyText = await request.text();
     const params = new URLSearchParams(bodyText);
     const code = params.get("code");
-    if (code !== EVAL_MCP_AUTH_CODE) {
+    const verifier = params.get("code_verifier");
+    if (
+      params.get("grant_type") !== "authorization_code" ||
+      code !== EVAL_MCP_AUTH_CODE ||
+      !authorizationGrant ||
+      params.get("client_id") !== authorizationGrant.clientId ||
+      params.get("redirect_uri") !== authorizationGrant.redirectUri ||
+      !verifier ||
+      pkceChallenge(verifier) !== authorizationGrant.codeChallenge
+    ) {
       return HttpResponse.json(
         {
           error: "invalid_grant",
@@ -370,12 +455,16 @@ export const evalMcpAuthHandlers = [
       );
     }
 
+    const scope = authorizationGrant.scope ?? "mcp:read";
+    authorizationGrant = undefined;
+    tokenIssued = true;
+
     return HttpResponse.json({
       access_token: EVAL_MCP_ACCESS_TOKEN,
       token_type: "Bearer",
       expires_in: 3600,
       refresh_token: "eval-auth-refresh-token",
-      scope: "mcp:read",
+      scope,
     });
   }),
 ];


### PR DESCRIPTION
Junior's MCP OAuth fixture now performs dynamic client registration and a
headless authorization redirect before callback completion instead of accepting
an injected authorization code. It binds the registered client, configured
callback URI, state, and S256 PKCE verifier to a single-use grant, and keeps
authenticated MCP requests unavailable until the token is issued.

The callback/runtime integration tests and the `auto_complete_mcp_oauth` eval
path traverse the same fixture. The scope remains test-only: this adds no
production OAuth behavior and does not simulate refresh or concurrent grants.

Refs #838
