### PR TITLE
fix(dashboard)!: Keep OAuth on the canonical origin

### DIFF
--- a/packages/docs/src/content/docs/operate/dashboard.md
+++ b/packages/docs/src/content/docs/operate/dashboard.md
@@ -124,7 +124,7 @@ Set the required environment variables:
 | `GOOGLE_CLIENT_SECRET` | Google OAuth client secret. |
 
 Dashboard cookies are signed with `JUNIOR_SECRET` by default. Set `BETTER_AUTH_SECRET` only when you need a separate rotation boundary for browser sessions.
-Dashboard callbacks use `dashboard.baseURL`, `JUNIOR_BASE_URL`, Vercel URL envs, or local dev by default. Set `BETTER_AUTH_URL` only when dashboard auth needs a different public origin. The same public origin is used for Slack footer links to dashboard conversation pages.
+Dashboard callbacks use `dashboard.baseURL`, `JUNIOR_BASE_URL`, Vercel URL envs, or local dev by default. Set `JUNIOR_BASE_URL` to the public origin users should visit. Alternate deployment origins redirect there before Google sign-in so the OAuth state and callback cookies share one host. The same public origin is used for Slack footer links to dashboard conversation pages.
 
 ## Verify
 

--- a/packages/docs/src/content/docs/reference/config-and-env.md
+++ b/packages/docs/src/content/docs/reference/config-and-env.md
@@ -58,12 +58,11 @@ Use one stable value per deployment. Rotating it invalidates pending internal qu
 
 If you mount `@sentry/junior-dashboard`, set these browser-auth variables:
 
-| Variable               | Required | Purpose                                                                                           |
-| ---------------------- | -------- | ------------------------------------------------------------------------------------------------- |
-| `GOOGLE_CLIENT_ID`     | Yes      | Google OAuth client ID.                                                                           |
-| `GOOGLE_CLIENT_SECRET` | Yes      | Google OAuth client secret.                                                                       |
-| `BETTER_AUTH_URL`      | No       | Optional dashboard callback origin. Defaults to `JUNIOR_BASE_URL`, Vercel URL envs, or local dev. |
-| `BETTER_AUTH_SECRET`   | No       | Optional override for dashboard cookies. Defaults to `JUNIOR_SECRET`.                             |
+| Variable               | Required | Purpose                                                               |
+| ---------------------- | -------- | --------------------------------------------------------------------- |
+| `GOOGLE_CLIENT_ID`     | Yes      | Google OAuth client ID.                                               |
+| `GOOGLE_CLIENT_SECRET` | Yes      | Google OAuth client secret.                                           |
+| `BETTER_AUTH_SECRET`   | No       | Optional override for dashboard cookies. Defaults to `JUNIOR_SECRET`. |
 
 Configure allowed Google Workspace domains in `createApp({ dashboard })` and `juniorNitro({ dashboard })` for normal deployments. Set these optional policy variables when you prefer environment-managed dashboard authorization:
 

--- a/packages/junior-dashboard/src/app.ts
+++ b/packages/junior-dashboard/src/app.ts
@@ -32,6 +32,7 @@ import {
   readMockConversationStats,
   readMockConversationSubagent,
 } from "./mock-conversations";
+import { resolveDashboardBaseURL } from "./url";
 
 const DEFAULT_BASE_PATH = "/";
 const DEFAULT_AUTH_PATH = "/api/auth";
@@ -196,9 +197,15 @@ function requestedReturnPath(url: URL, basePath: string): string | undefined {
   return `${returnUrl.pathname}${returnUrl.search}`;
 }
 
-function dashboardLoginUrl(request: Request, basePath: string): string {
+function dashboardLoginUrl(
+  request: Request,
+  basePath: string,
+  canonicalBaseURL?: string,
+): string {
   const requestUrl = new URL(request.url);
-  const url = new URL(request.url);
+  const url = canonicalBaseURL
+    ? new URL(canonicalBaseURL)
+    : new URL(request.url);
   url.pathname = dashboardLoginPath(basePath);
   url.search = "";
   const returnPath = dashboardReturnPath(requestUrl, basePath);
@@ -206,6 +213,25 @@ function dashboardLoginUrl(request: Request, basePath: string): string {
     url.searchParams.set(LOGIN_NEXT_PARAM, returnPath);
   }
   return url.toString();
+}
+
+function canonicalLoginUrl(
+  request: Request,
+  canonicalBaseURL: string | undefined,
+): string | undefined {
+  if (!canonicalBaseURL) {
+    return undefined;
+  }
+
+  const requestUrl = new URL(request.url);
+  const canonicalUrl = new URL(canonicalBaseURL);
+  if (requestUrl.origin === canonicalUrl.origin) {
+    return undefined;
+  }
+
+  canonicalUrl.pathname = requestUrl.pathname;
+  canonicalUrl.search = requestUrl.search;
+  return canonicalUrl.toString();
 }
 
 function dashboardLoginPath(basePath: string): string {
@@ -244,11 +270,18 @@ function isAuthorized(
   );
 }
 
-function unauthorized(request: Request, basePath: string): Response {
+function unauthorized(
+  request: Request,
+  basePath: string,
+  canonicalBaseURL?: string,
+): Response {
   if (isJsonRoute(new URL(request.url).pathname)) {
     return Response.json({ error: "unauthenticated" }, { status: 401 });
   }
-  return Response.redirect(dashboardLoginUrl(request, basePath), 302);
+  return Response.redirect(
+    dashboardLoginUrl(request, basePath, canonicalBaseURL),
+    302,
+  );
 }
 
 function forbidden(request: Request): Response {
@@ -492,6 +525,11 @@ export function createDashboardApp(
   const allowedEmails = normalizeValues(options.allowedEmails);
 
   const authRequired = options.authRequired !== false;
+  const configuredBaseURL = options.baseURL ?? process.env.JUNIOR_BASE_URL;
+  let canonicalBaseURL: string | undefined;
+  if (authRequired && (configuredBaseURL || !options.auth)) {
+    canonicalBaseURL = resolveDashboardBaseURL({ baseURL: configuredBaseURL });
+  }
 
   if (
     authRequired &&
@@ -516,6 +554,10 @@ export function createDashboardApp(
   const app = new Hono<{ Variables: Variables }>();
 
   app.get(dashboardLoginPath(basePath), async (c) => {
+    const canonicalUrl = canonicalLoginUrl(c.req.raw, canonicalBaseURL);
+    if (canonicalUrl) {
+      return Response.redirect(canonicalUrl, 302);
+    }
     const returnUrl = callbackUrl(c.req.raw, basePath);
     if (!auth) {
       return Response.redirect(returnUrl, 302);
@@ -548,11 +590,11 @@ export function createDashboardApp(
     }
 
     if (!auth) {
-      return unauthorized(c.req.raw, basePath);
+      return unauthorized(c.req.raw, basePath, canonicalBaseURL);
     }
     const session = await auth.getSession(c.req.raw);
     if (!session) {
-      return unauthorized(c.req.raw, basePath);
+      return unauthorized(c.req.raw, basePath, canonicalBaseURL);
     }
     if (!isAuthorized(session, allowedDomains, allowedEmails)) {
       return forbidden(c.req.raw);

--- a/packages/junior-dashboard/src/url.ts
+++ b/packages/junior-dashboard/src/url.ts
@@ -33,10 +33,7 @@ export function normalizeDashboardPath(
 export function resolveDashboardBaseURL(
   config: DashboardBaseURLConfig = {},
 ): string {
-  const explicit =
-    config.baseURL ??
-    process.env.BETTER_AUTH_URL ??
-    process.env.JUNIOR_BASE_URL;
+  const explicit = config.baseURL ?? process.env.JUNIOR_BASE_URL;
   if (explicit?.trim()) {
     return stripTrailingSlashes(withHttps(explicit.trim()));
   }

--- a/packages/junior-dashboard/tests/dashboard-routes.test.ts
+++ b/packages/junior-dashboard/tests/dashboard-routes.test.ts
@@ -71,6 +71,9 @@ function mockDashboardVirtualConfig() {
 describe("dashboard routes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    for (const name of dashboardEnvNames) {
+      delete process.env[name];
+    }
   });
 
   afterEach(() => {
@@ -120,7 +123,6 @@ describe("dashboard routes", () => {
         callbackURL = value;
       }),
     });
-
     const unauthenticated = await app.fetch(
       new Request("http://localhost/conversations/slack%3AC1%3A123?view=tools"),
     );
@@ -132,6 +134,51 @@ describe("dashboard routes", () => {
     expect(signIn.status).toBe(302);
     expect(callbackURL).toBe(
       "http://localhost/conversations/slack%3AC1%3A123?view=tools",
+    );
+  });
+
+  it("starts OAuth on the JUNIOR_BASE_URL origin", async () => {
+    process.env.BETTER_AUTH_URL = "https://legacy-auth.example.com";
+    process.env.JUNIOR_BASE_URL = "https://junior.example.com";
+    let callbackURL: string | undefined;
+    const app = createDashboardApp({
+      allowedGoogleDomains: ["sentry.io"],
+      auth: auth(null, (value) => {
+        callbackURL = value;
+      }),
+    });
+    const canonicalLogin =
+      "https://junior.example.com/auth/login?next=%2Fconversations%2Fslack%253AC1%253A123%3Fview%3Dtools";
+
+    const directLogin = await app.fetch(
+      new Request(
+        "https://junior-prod.vercel.app/auth/login?next=%2Fconversations%2Fslack%253AC1%253A123%3Fview%3Dtools",
+      ),
+    );
+
+    expect(directLogin.status).toBe(302);
+    expect(directLogin.headers.get("location")).toBe(canonicalLogin);
+    expect(callbackURL).toBeUndefined();
+
+    const unauthenticated = await app.fetch(
+      new Request(
+        "https://junior-prod.vercel.app/conversations/slack%3AC1%3A123?view=tools",
+      ),
+    );
+
+    expect(unauthenticated.status).toBe(302);
+    expect(unauthenticated.headers.get("location")).toBe(canonicalLogin);
+
+    const signIn = await app.fetch(
+      new Request(unauthenticated.headers.get("location")!),
+    );
+
+    expect(signIn.status).toBe(302);
+    expect(signIn.headers.get("location")).toBe(
+      "https://accounts.google.com/o/oauth2/v2/auth",
+    );
+    expect(callbackURL).toBe(
+      "https://junior.example.com/conversations/slack%3AC1%3A123?view=tools",
     );
   });
 
@@ -737,7 +784,7 @@ describe("dashboard routes", () => {
     ).toThrow("GOOGLE_CLIENT_ID is required for Junior dashboard auth");
   });
 
-  it("does not require BETTER_AUTH_URL in local development", () => {
+  it("defaults dashboard auth to the local development URL", () => {
     process.env.JUNIOR_SECRET = "junior-secret";
     process.env.GOOGLE_CLIENT_ID = "google-client-id";
     process.env.GOOGLE_CLIENT_SECRET = "google-client-secret";

--- a/packages/junior/src/chat/slack/dashboard-link.ts
+++ b/packages/junior/src/chat/slack/dashboard-link.ts
@@ -32,10 +32,7 @@ function normalizeDashboardPath(
 function resolveDashboardBaseURL(
   config: DashboardConversationLinkOptions,
 ): string {
-  const explicit =
-    config.baseURL ??
-    process.env.BETTER_AUTH_URL ??
-    process.env.JUNIOR_BASE_URL;
+  const explicit = config.baseURL ?? process.env.JUNIOR_BASE_URL;
   if (explicit?.trim()) {
     return stripTrailingSlashes(withHttps(explicit.trim()));
   }

--- a/packages/junior/tests/unit/slack/footer.test.ts
+++ b/packages/junior/tests/unit/slack/footer.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@/chat/slack/footer";
 
 const originalJuniorBaseUrl = process.env.JUNIOR_BASE_URL;
+const originalBetterAuthUrl = process.env.BETTER_AUTH_URL;
 
 afterEach(() => {
   setDashboardConversationLinkOptions(undefined);
@@ -13,6 +14,11 @@ afterEach(() => {
     delete process.env.JUNIOR_BASE_URL;
   } else {
     process.env.JUNIOR_BASE_URL = originalJuniorBaseUrl;
+  }
+  if (originalBetterAuthUrl === undefined) {
+    delete process.env.BETTER_AUTH_URL;
+  } else {
+    process.env.BETTER_AUTH_URL = originalBetterAuthUrl;
   }
 });
 
@@ -73,6 +79,7 @@ describe("buildSlackReplyFooter", () => {
   });
 
   it("uses JUNIOR_BASE_URL for core dashboard footer links", () => {
+    process.env.BETTER_AUTH_URL = "https://legacy-auth.example.com";
     process.env.JUNIOR_BASE_URL = "https://junior-env.example.com";
     setDashboardConversationLinkOptions({
       basePath: "/ops",

--- a/specs/dashboard.md
+++ b/specs/dashboard.md
@@ -209,7 +209,7 @@ Required properties:
 Required environment/config inputs when dashboard auth is enabled:
 
 - `JUNIOR_SECRET`, or optional `BETTER_AUTH_SECRET` override
-- dashboard origin from optional `BETTER_AUTH_URL`, `JUNIOR_BASE_URL`, Vercel URL envs, or local dev
+- dashboard origin from optional dashboard config, `JUNIOR_BASE_URL`, Vercel URL envs, or local dev
 - `GOOGLE_CLIENT_ID`
 - `GOOGLE_CLIENT_SECRET`
 - dashboard origin or trusted origins


### PR DESCRIPTION
Unauthenticated dashboard entrypoints now redirect to the configured public origin before Better Auth starts Google OAuth. Previously, entering through an alternate deployment hostname could place the OAuth state cookie on a different host from the callback and force users through a second login. The redirect preserves the requested dashboard path and query, and regression coverage exercises both direct login and protected-page entry.

Dashboard callbacks and Slack dashboard links now use JUNIOR_BASE_URL as their environment-level origin. Deployments that currently set BETTER_AUTH_URL must move that value to JUNIOR_BASE_URL or the explicit dashboard.baseURL option.