### PR TITLE
fix(dashboard): Hide empty thinking messages

### DIFF
--- a/packages/junior-dashboard/src/client/components/TranscriptThinkingView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptThinkingView.tsx
@@ -17,7 +17,7 @@ export function TranscriptThinkingView(props: {
 }) {
   const { active: searchActive } = useTranscriptSearch();
   const rendered = stringifyPartValue(props.value);
-  const expandedText = rendered || "{}";
+  const expandedText = rendered || "thinking";
   const meta = [
     typeof props.timestamp === "number"
       ? formatMessageTimestamp(props.timestamp)

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -1434,6 +1434,34 @@ describe("dashboard telemetry components", () => {
     expect(summary).toContain("checking the rollout");
   });
 
+  it("does not render empty thinking as JSON", () => {
+    const turn = {
+      conversationId: "conversation-1",
+      lastProgressAt: "2026-01-01T00:00:10.000Z",
+      lastSeenAt: "2026-01-01T00:00:10.000Z",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      status: "completed",
+      surface: "slack",
+      displayTitle: "Conversation",
+      transcript: [
+        {
+          role: "assistant",
+          parts: [{ type: "thinking" }],
+        },
+      ],
+      transcriptAvailable: true,
+    } as ConversationTranscript;
+
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={client}>
+        <ConversationTranscriptView conversation={turn} view="rich" />
+      </QueryClientProvider>,
+    );
+
+    expect(html).not.toContain("{}");
+    expect(html).toContain("thinking");
+  });
+
   it("expands thinking rows during transcript search", () => {
     const turn = {
       conversationId: "conversation-1",

--- a/packages/junior/src/api/conversations/transcript.ts
+++ b/packages/junior/src/api/conversations/transcript.ts
@@ -58,6 +58,18 @@ function recordField(value: Record<string, unknown>, names: string[]): unknown {
   return undefined;
 }
 
+function thinkingOutput(part: Record<string, unknown>): unknown {
+  const output = recordField(part, ["thinking", "text", "content", "output"]);
+  return isRecord(output)
+    ? recordField(output, ["thinking", "text", "content", "output"])
+    : output;
+}
+
+function isDisplayableTranscriptPart(part: TranscriptPart): boolean {
+  if (part.type !== "thinking") return true;
+  return typeof part.output === "string" && part.output.trim().length > 0;
+}
+
 /** Normalize Pi content parts for user-facing transcript output. */
 function normalizeTranscriptPart(
   part: unknown,
@@ -112,7 +124,7 @@ function normalizeTranscriptPart(
   if (rawType === "thinking") {
     return {
       type: "thinking",
-      output: recordField(part, ["thinking", "text", "content", "output"]),
+      output: thinkingOutput(part),
     };
   }
 
@@ -182,13 +194,15 @@ function normalizeMessage(
       role === "toolResult"
         ? [normalizeToolResultMessage(record)]
         : Array.isArray(content)
-          ? content.map((part) =>
-              normalizeTranscriptPart(part, {
-                unwrapCurrentTask: role === "user",
-                unwrapLegacyAdvisorTask:
-                  options.unwrapLegacyAdvisorTask && role === "user",
-              }),
-            )
+          ? content
+              .map((part) =>
+                normalizeTranscriptPart(part, {
+                  unwrapCurrentTask: role === "user",
+                  unwrapLegacyAdvisorTask:
+                    options.unwrapLegacyAdvisorTask && role === "user",
+                }),
+              )
+              .filter(isDisplayableTranscriptPart)
           : [
               normalizeTranscriptPart(content, {
                 unwrapCurrentTask: role === "user",

--- a/packages/junior/tests/integration/dashboard-reporting.test.ts
+++ b/packages/junior/tests/integration/dashboard-reporting.test.ts
@@ -369,7 +369,8 @@ describe("dashboard reporting", () => {
         {
           role: "assistant",
           content: [
-            { type: "thinking", text: "I should use a tool" },
+            { type: "thinking", thinking: "I should use a tool" },
+            { type: "thinking", thinking: "" },
             {
               type: "toolCall",
               name: "search",


### PR DESCRIPTION
Models can return signature-only reasoning blocks without displayable summary text. The dashboard previously projected those as thinking events and rendered missing content as `{}`, making valid reasoning metadata look like broken JSON.

Transcript projection now keeps only thinking blocks with readable text, including canonical and nested Pi payloads. The renderer also uses a human-readable fallback if malformed empty data reaches the client, and regression coverage exercises both the API and dashboard paths.