### PR TITLE
fix(reporting): Include auxiliary model costs

### DIFF
--- a/packages/junior/migrations/0002_tearful_harry_osborn.sql
+++ b/packages/junior/migrations/0002_tearful_harry_osborn.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "junior_conversation_usage_events" (
+	"id" text PRIMARY KEY NOT NULL,
+	"conversation_id" text NOT NULL,
+	"usage_json" jsonb NOT NULL,
+	"created_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "junior_conversation_usage_events" ADD CONSTRAINT "junior_conversation_usage_events_conversation_id_junior_conversations_conversation_id_fk" FOREIGN KEY ("conversation_id") REFERENCES "public"."junior_conversations"("conversation_id") ON DELETE cascade ON UPDATE no action;

--- a/packages/junior/migrations/meta/0002_snapshot.json
+++ b/packages/junior/migrations/meta/0002_snapshot.json
@@ -1,0 +1,1019 @@
+{
+  "id": "e429b0b5-cc38-4b66-89d2-e3e9dcba0f0b",
+  "prevId": "787c677c-20a2-48b4-8222-8bbb6aa5f45c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.junior_agent_steps": {
+      "name": "junior_agent_steps",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_epoch": {
+          "name": "context_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_agent_steps_epoch_idx": {
+          "name": "junior_agent_steps_epoch_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_epoch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_agent_steps_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_agent_steps_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_agent_steps",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_agent_steps_conversation_id_seq_pk": {
+          "name": "junior_agent_steps_conversation_id_seq_pk",
+          "columns": ["conversation_id", "seq"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversation_messages": {
+      "name": "junior_conversation_messages",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_identity_id": {
+          "name": "author_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replied_at": {
+          "name": "replied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_conversation_messages_activity_idx": {
+          "name": "junior_conversation_messages_activity_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_conversation_messages_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversation_messages_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversation_messages",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversation_messages_author_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversation_messages_author_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversation_messages",
+          "tableTo": "junior_identities",
+          "columnsFrom": ["author_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_conversation_messages_conversation_id_message_id_pk": {
+          "name": "junior_conversation_messages_conversation_id_message_id_pk",
+          "columns": ["conversation_id", "message_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversation_usage_events": {
+      "name": "junior_conversation_usage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_json": {
+          "name": "usage_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "junior_conversation_usage_events_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversation_usage_events_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversation_usage_events",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversations": {
+      "name": "junior_conversations",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_type": {
+          "name": "origin_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_id": {
+          "name": "origin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_run_id": {
+          "name": "origin_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_json": {
+          "name": "destination_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity_id": {
+          "name": "actor_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_identity_id": {
+          "name": "creator_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_subject_identity_id": {
+          "name": "credential_subject_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_json": {
+          "name": "actor_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_updated_at": {
+          "name": "execution_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_status": {
+          "name": "execution_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_checkpoint_at": {
+          "name": "last_checkpoint_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_enqueued_at": {
+          "name": "last_enqueued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_conversation_id": {
+          "name": "parent_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_purged_at": {
+          "name": "transcript_purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "usage_json": {
+          "name": "usage_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_duration_ms": {
+          "name": "execution_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "execution_usage_json": {
+          "name": "execution_usage_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_conversations_last_activity_idx": {
+          "name": "junior_conversations_last_activity_idx",
+          "columns": [
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_active_idx": {
+          "name": "junior_conversations_active_idx",
+          "columns": [
+            {
+              "expression": "coalesce(\"execution_updated_at\", \"updated_at\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_conversations\".\"execution_status\" <> 'idle'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_destination_activity_idx": {
+          "name": "junior_conversations_destination_activity_idx",
+          "columns": [
+            {
+              "expression": "destination_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_actor_activity_idx": {
+          "name": "junior_conversations_actor_activity_idx",
+          "columns": [
+            {
+              "expression": "actor_identity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_origin_idx": {
+          "name": "junior_conversations_origin_idx",
+          "columns": [
+            {
+              "expression": "origin_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "origin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_parent_idx": {
+          "name": "junior_conversations_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_conversations_destination_id_junior_destinations_id_fk": {
+          "name": "junior_conversations_destination_id_junior_destinations_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_destinations",
+          "columnsFrom": ["destination_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_actor_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversations_actor_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_identities",
+          "columnsFrom": ["actor_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_creator_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversations_creator_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_identities",
+          "columnsFrom": ["creator_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_credential_subject_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversations_credential_subject_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_identities",
+          "columnsFrom": ["credential_subject_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_parent_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversations_parent_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["parent_conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_destinations": {
+      "name": "junior_destinations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_tenant_id": {
+          "name": "provider_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "provider_destination_id": {
+          "name": "provider_destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_destination_id": {
+          "name": "parent_destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_destinations_provider_destination_uidx": {
+          "name": "junior_destinations_provider_destination_uidx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_destination_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_destinations_provider_kind_idx": {
+          "name": "junior_destinations_provider_kind_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_identities": {
+      "name": "junior_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_tenant_id": {
+          "name": "provider_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "provider_subject_id": {
+          "name": "provider_subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_normalized": {
+          "name": "email_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "junior_identities_provider_subject_uidx": {
+          "name": "junior_identities_provider_subject_uidx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_identities_user_idx": {
+          "name": "junior_identities_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_identities_verified_email_idx": {
+          "name": "junior_identities_verified_email_idx",
+          "columns": [
+            {
+              "expression": "email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_identities\".\"email_verified\" = true AND \"junior_identities\".\"email_normalized\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_identities_kind_provider_idx": {
+          "name": "junior_identities_kind_provider_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_identities_user_id_junior_users_id_fk": {
+          "name": "junior_identities_user_id_junior_users_id_fk",
+          "tableFrom": "junior_identities",
+          "tableTo": "junior_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_users": {
+      "name": "junior_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "primary_email": {
+          "name": "primary_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_email_normalized": {
+          "name": "primary_email_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_users_primary_email_normalized_uidx": {
+          "name": "junior_users_primary_email_normalized_uidx",
+          "columns": [
+            {
+              "expression": "primary_email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/junior/migrations/meta/_journal.json
+++ b/packages/junior/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1783781940092,
       "tag": "0001_conversation_metrics",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1783800919108,
+      "tag": "0002_tearful_harry_osborn",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/junior/src/chat/agent/tools.ts
+++ b/packages/junior/src/chat/agent/tools.ts
@@ -8,6 +8,7 @@
  * restoring providers are thrown here so the run parks before prompting.
  */
 import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { randomUUID } from "node:crypto";
 import type { FileUpload } from "chat";
 import { botConfig } from "@/chat/config";
 import { listReferenceFiles } from "@/chat/discovery";
@@ -61,6 +62,8 @@ import { createLazySandboxWorkspace } from "@/chat/agent/sandbox";
 import { upsertActiveSkill } from "@/chat/agent/skills";
 import type { ResumeState } from "@/chat/agent/resume";
 import { writeSandboxGeneratedArtifacts } from "@/chat/runtime/generated-artifacts";
+import { getConversationStore } from "@/chat/db";
+import { persistWithRetry } from "@/chat/services/persist-retry";
 
 interface ToolWiringArgs {
   abortAgent: () => void;
@@ -297,6 +300,18 @@ export async function wireAgentTools(
   const tools = createTools(
     loadableSkills,
     {
+      recordUsage: args.sessionConversationId
+        ? async (usage) => {
+            const id = randomUUID();
+            await persistWithRetry(async () => {
+              await getConversationStore().recordUsage({
+                conversationId: args.sessionConversationId!,
+                id,
+                usage,
+              });
+            });
+          }
+        : undefined,
       writeGeneratedArtifacts: async (files) => {
         const refs = await writeSandboxGeneratedArtifacts(
           await sandboxExecutor.createSandbox(),

--- a/packages/junior/src/chat/app/services.ts
+++ b/packages/junior/src/chat/app/services.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { completeObject, completeText } from "@/chat/pi/client";
 import { executeAgentRun as executeAgentRunImpl } from "@/chat/agent";
 import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress/tracing";
@@ -31,6 +32,60 @@ import {
   type VisionContextService,
 } from "@/chat/slack/vision-context";
 import { createAgentRunner } from "@/chat/runtime/agent-runner";
+import { getConversationStore } from "@/chat/db";
+import { hasAgentTurnUsage, type AgentTurnUsage } from "@/chat/usage";
+import { persistWithRetry } from "@/chat/services/persist-retry";
+
+function usageConversationId(
+  metadata: Record<string, unknown> | undefined,
+): string | undefined {
+  const conversationId = metadata?.conversationId;
+  return typeof conversationId === "string" && conversationId.trim()
+    ? conversationId
+    : undefined;
+}
+
+async function recordUsage(args: {
+  conversationId: string;
+  id: string;
+  usage: AgentTurnUsage | undefined;
+}): Promise<void> {
+  const usage = args.usage;
+  if (!hasAgentTurnUsage(usage)) {
+    return;
+  }
+  await persistWithRetry(async () => {
+    await getConversationStore().recordUsage({
+      conversationId: args.conversationId,
+      id: args.id,
+      usage,
+    });
+  });
+}
+
+function withTextUsage(base: typeof completeText): typeof completeText {
+  return async (params) => {
+    const id = randomUUID();
+    const result = await base(params);
+    const conversationId = usageConversationId(params.metadata);
+    if (conversationId) {
+      await recordUsage({ conversationId, id, usage: result.usage });
+    }
+    return result;
+  };
+}
+
+function withObjectUsage(base: typeof completeObject): typeof completeObject {
+  return async (params) => {
+    const id = randomUUID();
+    const result = await base(params);
+    const conversationId = usageConversationId(params.metadata);
+    if (conversationId) {
+      await recordUsage({ conversationId, id, usage: result.usage });
+    }
+    return result;
+  };
+}
 
 export interface JuniorRuntimeServices {
   conversationMemory: ConversationMemoryService;
@@ -54,16 +109,26 @@ export interface JuniorRuntimeServiceOverrides {
 export function createJuniorRuntimeServices(
   overrides: JuniorRuntimeServiceOverrides = {},
 ): JuniorRuntimeServices {
+  const textCompletion = withTextUsage(completeText);
   const conversationMemory = createConversationMemoryService({
-    completeText: overrides.conversationMemory?.completeText ?? completeText,
+    completeText:
+      overrides.conversationMemory?.completeText === undefined
+        ? textCompletion
+        : withTextUsage(overrides.conversationMemory.completeText),
   });
   const contextCompactor = createContextCompactor({
-    completeText: overrides.contextCompactor?.completeText ?? completeText,
+    completeText:
+      overrides.contextCompactor?.completeText === undefined
+        ? textCompletion
+        : withTextUsage(overrides.contextCompactor.completeText),
     autoCompactionTriggerTokens:
       overrides.contextCompactor?.autoCompactionTriggerTokens,
   });
   const visionContext = createVisionContextService({
-    completeText: overrides.visionContext?.completeText ?? completeText,
+    completeText:
+      overrides.visionContext?.completeText === undefined
+        ? textCompletion
+        : withTextUsage(overrides.visionContext.completeText),
     listThreadReplies:
       overrides.visionContext?.listThreadReplies ?? listThreadReplies,
     downloadFile:
@@ -96,8 +161,9 @@ export function createJuniorRuntimeServices(
       generateThreadTitle: conversationMemory.generateThreadTitle,
     },
     subscribedReplyPolicy: createSubscribedReplyPolicy({
-      completeObject:
+      completeObject: withObjectUsage(
         overrides.subscribedReplyPolicy?.completeObject ?? completeObject,
+      ),
     }),
     visionContext,
   };

--- a/packages/junior/src/chat/conversations/sql/migrations.ts
+++ b/packages/junior/src/chat/conversations/sql/migrations.ts
@@ -44,8 +44,13 @@ SELECT
   }
 
   const migrations = readMigrationFiles({ migrationsFolder });
-  const [metrics] = await executor.query<{ complete: boolean }>(`
-SELECT count(*) = 4 AS complete
+  const [schemaState] = await executor.query<{
+    metricsComplete: boolean;
+    usageEventsComplete: boolean;
+  }>(`
+SELECT
+  count(*) = 4 AS "metricsComplete",
+  to_regclass('public.junior_conversation_usage_events') IS NOT NULL AS "usageEventsComplete"
 FROM information_schema.columns
 WHERE table_schema = 'public'
   AND table_name = 'junior_conversations'
@@ -60,7 +65,7 @@ WHERE table_schema = 'public'
     checksum: string;
     id: string;
   }>("SELECT id, checksum FROM junior_schema_migrations");
-  const expectedIds = metrics?.complete
+  const expectedIds = schemaState?.metricsComplete
     ? [...LEGACY_CORE_MIGRATION_IDS, LEGACY_METRICS_MIGRATION_ID]
     : [...LEGACY_CORE_MIGRATION_IDS];
   const validIds = new Set(
@@ -75,7 +80,11 @@ WHERE table_schema = 'public'
     );
   }
 
-  const migration = metrics?.complete ? migrations.at(-1) : migrations[0];
+  const migration = schemaState?.usageEventsComplete
+    ? migrations.at(-1)
+    : schemaState?.metricsComplete
+      ? migrations[1]
+      : migrations[0];
   if (!migration) {
     throw new Error("No core Drizzle migrations were packaged");
   }

--- a/packages/junior/src/chat/conversations/sql/store.ts
+++ b/packages/junior/src/chat/conversations/sql/store.ts
@@ -15,11 +15,16 @@ import type {
   ConversationStore,
 } from "../store";
 import {
+  juniorConversationUsageEvents,
   juniorConversations,
   juniorDestinations,
   juniorIdentities,
 } from "@/db/schema";
-import type { AgentTurnCost, AgentTurnUsage } from "@/chat/usage";
+import {
+  addAgentTurnUsage,
+  type AgentTurnCost,
+  type AgentTurnUsage,
+} from "@/chat/usage";
 import type {
   JuniorDestinationKind,
   JuniorDestinationVisibility,
@@ -521,6 +526,55 @@ export class SqlStore implements ConversationStore {
           ...(args.visibility ? { visibility: args.visibility } : {}),
         },
       });
+    });
+  }
+
+  async recordUsage(args: {
+    conversationId: string;
+    id: string;
+    usage: AgentTurnUsage;
+    createdAtMs?: number;
+  }): Promise<void> {
+    await this.withConversationMutation(args.conversationId, async () => {
+      const atMs = args.createdAtMs ?? now();
+      await this.executor
+        .db()
+        .insert(juniorConversations)
+        .values({
+          conversationId: args.conversationId,
+          schemaVersion: 1,
+          createdAt: dateFromMs(atMs),
+          lastActivityAt: dateFromMs(atMs),
+          updatedAt: dateFromMs(atMs),
+          executionStatus: "idle",
+        })
+        .onConflictDoNothing({ target: juniorConversations.conversationId });
+      const inserted = await this.executor
+        .db()
+        .insert(juniorConversationUsageEvents)
+        .values({
+          id: args.id,
+          conversationId: args.conversationId,
+          usage: args.usage,
+          createdAt: dateFromMs(atMs),
+        })
+        .onConflictDoNothing({ target: juniorConversationUsageEvents.id })
+        .returning({ id: juniorConversationUsageEvents.id });
+      if (inserted.length === 0) {
+        return;
+      }
+      const row = await this.readConversationRow(args.conversationId);
+      await this.executor
+        .db()
+        .update(juniorConversations)
+        .set({
+          usage:
+            addAgentTurnUsage(
+              row?.conversation.usage ?? undefined,
+              args.usage,
+            ) ?? null,
+        })
+        .where(eq(juniorConversations.conversationId, args.conversationId));
     });
   }
 

--- a/packages/junior/src/chat/conversations/state.ts
+++ b/packages/junior/src/chat/conversations/state.ts
@@ -21,6 +21,8 @@ export function createStateConversationStore(
     ensureChildConversation: async () => undefined,
     recordActivity: (args) =>
       recordTaskConversationActivity({ ...args, state }),
+    // Auxiliary usage is SQL-only and is never written to legacy import state.
+    recordUsage: async () => undefined,
     recordExecution: (args) =>
       recordTaskConversationExecution({ ...args, state }),
     listByActivity: (args) =>

--- a/packages/junior/src/chat/conversations/store.ts
+++ b/packages/junior/src/chat/conversations/store.ts
@@ -70,6 +70,13 @@ export interface ConversationStore {
     /** Source-confirmed visibility from the current event's signal only. */
     visibility?: ConversationPrivacy;
   }): Promise<void>;
+  /** Add one idempotent auxiliary model-call contribution to root usage. */
+  recordUsage(args: {
+    conversationId: string;
+    id: string;
+    usage: AgentTurnUsage;
+    createdAtMs?: number;
+  }): Promise<void>;
   /**
    * Establish a subagent child conversation row linked to its parent.
    *

--- a/packages/junior/src/chat/pi/client.ts
+++ b/packages/junior/src/chat/pi/client.ts
@@ -1,4 +1,5 @@
 import {
+  calculateCost,
   completeSimple,
   getEnvApiKey,
   getModels,
@@ -7,6 +8,7 @@ import {
   streamSimpleAnthropic,
   type Message,
   type Model,
+  type PiUsage,
   type ThinkingLevel,
 } from "@/chat/pi/sdk";
 import { createGatewayProvider } from "@ai-sdk/gateway";
@@ -24,8 +26,10 @@ registerApiProvider({
 import type { ZodTypeAny, z } from "zod";
 import {
   extractGenAiUsageAttributes,
+  extractGenAiUsageSummary,
   serializeGenAiAttribute,
 } from "@/chat/logging";
+import type { AgentTurnUsage } from "@/chat/usage";
 import {
   logException,
   logWarn,
@@ -109,7 +113,11 @@ export async function completeText(params: {
   maxTokens?: number;
   signal?: AbortSignal;
   metadata?: Record<string, unknown>;
-}) {
+}): Promise<{
+  message: Awaited<ReturnType<typeof completeSimple>>;
+  text: string;
+  usage?: AgentTurnUsage;
+}> {
   const model = resolveGatewayModel(params.modelId);
   const apiKey = getPiGatewayApiKey();
   const authMode = toOptionalTrimmed(process.env.AI_GATEWAY_API_KEY)
@@ -246,6 +254,7 @@ export async function completeText(params: {
       return {
         message,
         text: outputText,
+        usage: extractGenAiUsageSummary(message),
       };
     },
     startAttributes,
@@ -278,6 +287,47 @@ function logContextFromMetadata(
   };
 }
 
+function normalizeAiSdkUsage(
+  model: Model<any>,
+  usage: {
+    inputTokens?: number;
+    inputTokenDetails?: {
+      noCacheTokens?: number;
+      cacheReadTokens?: number;
+      cacheWriteTokens?: number;
+    };
+    outputTokens?: number;
+    outputTokenDetails?: { reasoningTokens?: number };
+    totalTokens?: number;
+  },
+): AgentTurnUsage {
+  const cacheRead = usage.inputTokenDetails?.cacheReadTokens ?? 0;
+  const cacheWrite = usage.inputTokenDetails?.cacheWriteTokens ?? 0;
+  const input =
+    usage.inputTokenDetails?.noCacheTokens ??
+    Math.max(0, (usage.inputTokens ?? 0) - cacheRead - cacheWrite);
+  const output = usage.outputTokens ?? 0;
+  const normalized: PiUsage = {
+    input,
+    output,
+    cacheRead,
+    cacheWrite,
+    ...(usage.outputTokenDetails?.reasoningTokens !== undefined
+      ? { reasoning: usage.outputTokenDetails.reasoningTokens }
+      : {}),
+    totalTokens: usage.totalTokens ?? input + output + cacheRead + cacheWrite,
+    cost: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 0,
+    },
+  };
+  calculateCost(model, normalized);
+  return extractGenAiUsageSummary(normalized);
+}
+
 /** Execute a schema-constrained completion using the AI SDK structured output path. */
 export async function completeObject<TSchema extends ZodTypeAny>(params: {
   modelId: string;
@@ -289,7 +339,8 @@ export async function completeObject<TSchema extends ZodTypeAny>(params: {
   maxTokens?: number;
   signal?: AbortSignal;
   metadata?: Record<string, unknown>;
-}): Promise<{ object: z.infer<TSchema> }> {
+}): Promise<{ object: z.infer<TSchema>; usage?: AgentTurnUsage }> {
+  const model = resolveGatewayModel(params.modelId);
   const apiKey = getGatewayApiKey();
   const provider = createGatewayProvider(apiKey ? { apiKey } : {});
   try {
@@ -325,6 +376,7 @@ export async function completeObject<TSchema extends ZodTypeAny>(params: {
           : {}),
       },
     );
+    const usage = normalizeAiSdkUsage(model, result.usage);
     setSpanAttributes({
       "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
       "gen_ai.operation.name": GEN_AI_OPERATION_CHAT,
@@ -333,9 +385,12 @@ export async function completeObject<TSchema extends ZodTypeAny>(params: {
       "server.address": GEN_AI_SERVER_ADDRESS,
       "server.port": GEN_AI_SERVER_PORT,
       "gen_ai.response.finish_reasons": [result.finishReason],
-      ...extractGenAiUsageAttributes(result.usage),
+      ...extractGenAiUsageAttributes(usage),
     });
-    return { object: result.object as z.infer<TSchema> };
+    return {
+      object: result.object as z.infer<TSchema>,
+      usage,
+    };
   } catch (error) {
     const providerError = createProviderError(error);
     if (isProviderRetryError(providerError)) {

--- a/packages/junior/src/chat/pi/sdk.ts
+++ b/packages/junior/src/chat/pi/sdk.ts
@@ -13,6 +13,8 @@ export {
   type ThinkingLevel,
 } from "@earendil-works/pi-ai/compat";
 
+export { calculateCost, type Usage as PiUsage } from "@earendil-works/pi-ai";
+
 export {
   stream as streamAnthropic,
   streamSimple as streamSimpleAnthropic,

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -392,6 +392,7 @@ interface ReplyExecutorDeps {
   resolveUserAttachments: (
     attachments: Message["attachments"] | undefined,
     context: {
+      conversationId?: string;
       threadId?: string;
       actorId?: string;
       channelId?: string;
@@ -535,6 +536,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
             ),
             queuedMessages: options.queuedMessages,
             context: {
+              conversationId,
               threadId,
               actorId: slackActorId,
               channelId,
@@ -623,6 +625,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                 userAttachments: await deps.resolveUserAttachments(
                   attachments,
                   {
+                    conversationId,
                     threadId,
                     actorId: isResourceEventMessage(queued.message)
                       ? undefined
@@ -940,6 +943,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
         const userAttachments = await deps.resolveUserAttachments(
           turnAttachments,
           {
+            conversationId,
             threadId,
             actorId: slackActorId,
             channelId,

--- a/packages/junior/src/chat/runtime/slack-runtime.ts
+++ b/packages/junior/src/chat/runtime/slack-runtime.ts
@@ -925,6 +925,7 @@ export function createSlackTurnRuntime<
             ),
           };
           const threadContext: TurnContext = {
+            conversationId: threadId ?? runId,
             threadId,
             actorId,
             channelId,

--- a/packages/junior/src/chat/runtime/turn-input.ts
+++ b/packages/junior/src/chat/runtime/turn-input.ts
@@ -1,6 +1,7 @@
 import type { Message, Thread } from "chat";
 
 export interface TurnContext {
+  conversationId?: string;
   channelId?: string;
   actorId?: string;
   threadId?: string;

--- a/packages/junior/src/chat/services/context-compaction.ts
+++ b/packages/junior/src/chat/services/context-compaction.ts
@@ -267,6 +267,7 @@ function renderSummaryInput(
 /** Ask the fast model for a bounded handoff summary of durable thread context. */
 async function summarizeContext(
   args: {
+    conversationId: string;
     conversationContext?: string;
     piMessages: PiMessage[];
     metadata?: CompactContextArgs["metadata"];
@@ -299,6 +300,7 @@ async function summarizeContext(
       },
     ],
     metadata: {
+      conversationId: args.conversationId,
       modelId: botConfig.fastModelId,
       threadId: args.metadata?.threadId ?? "",
       channelId: args.metadata?.channelId ?? "",
@@ -383,6 +385,7 @@ async function maybeCompactWithDeps(
   try {
     summary = await summarizeContext(
       {
+        conversationId: args.conversationId,
         conversationContext: args.conversationContext,
         piMessages: source.messages,
         metadata: args.metadata,

--- a/packages/junior/src/chat/services/conversation-memory.ts
+++ b/packages/junior/src/chat/services/conversation-memory.ts
@@ -31,13 +31,17 @@ export interface ConversationMemoryService {
   compactConversationIfNeeded: (
     conversation: ThreadConversationState,
     context: {
+      conversationId?: string;
       threadId?: string;
       channelId?: string;
       actorId?: string;
       runId?: string;
     },
   ) => Promise<void>;
-  generateThreadTitle: (sourceText: string) => Promise<string>;
+  generateThreadTitle: (
+    sourceText: string,
+    context: { conversationId?: string },
+  ) => Promise<string>;
 }
 
 export function generateConversationId(
@@ -258,6 +262,7 @@ async function summarizeConversationChunk(
   messages: ConversationMessage[],
   conversation: ThreadConversationState,
   context: {
+    conversationId?: string;
     threadId?: string;
     channelId?: string;
     actorId?: string;
@@ -293,6 +298,7 @@ async function summarizeConversationChunk(
         },
       ],
       metadata: {
+        conversationId: context.conversationId ?? "",
         modelId: botConfig.fastModelId,
         threadId: context.threadId ?? "",
         channelId: context.channelId ?? "",
@@ -329,6 +335,7 @@ async function summarizeConversationChunk(
 
 async function generateThreadTitleWithDeps(
   sourceText: string,
+  context: { conversationId?: string },
   deps: ConversationMemoryDeps,
 ): Promise<string> {
   const result = await deps.completeText({
@@ -348,6 +355,7 @@ async function generateThreadTitleWithDeps(
       },
     ],
     metadata: {
+      conversationId: context.conversationId ?? "",
       modelId: botConfig.fastModelId,
     },
   });
@@ -455,8 +463,8 @@ export function createConversationMemoryService(
   return {
     compactConversationIfNeeded: async (conversation, context) =>
       await compactConversationIfNeededWithDeps(conversation, context, deps),
-    generateThreadTitle: async (sourceText) =>
-      await generateThreadTitleWithDeps(sourceText, deps),
+    generateThreadTitle: async (sourceText, context) =>
+      await generateThreadTitleWithDeps(sourceText, context, deps),
   };
 }
 

--- a/packages/junior/src/chat/services/subscribed-decision.ts
+++ b/packages/junior/src/chat/services/subscribed-decision.ts
@@ -21,6 +21,7 @@ export interface SubscribedDecisionInput {
   hasAttachments?: boolean;
   isExplicitMention?: boolean;
   context: {
+    conversationId?: string;
     threadId?: string;
     actorId?: string;
     channelId?: string;
@@ -467,6 +468,7 @@ export async function decideSubscribedThreadReply(args: {
       system: buildRouterSystemPrompt(args.botUserName),
       prompt: buildRouterPrompt(rawText, signals),
       metadata: {
+        conversationId: args.input.context.conversationId ?? "",
         modelId: args.modelId,
         threadId: args.input.context.threadId ?? "",
         channelId: args.input.context.channelId ?? "",

--- a/packages/junior/src/chat/slack/assistant-thread/title.ts
+++ b/packages/junior/src/chat/slack/assistant-thread/title.ts
@@ -59,7 +59,9 @@ export function maybeUpdateAssistantTitle(args: {
   return (async () => {
     let title: string | undefined;
     try {
-      title = await args.generateThreadTitle(titleSourceMessage.text);
+      title = await args.generateThreadTitle(titleSourceMessage.text, {
+        conversationId: args.threadId,
+      });
     } catch (error) {
       logWarn(
         "thread_title_generation_failed",

--- a/packages/junior/src/chat/slack/vision-context.ts
+++ b/packages/junior/src/chat/slack/vision-context.ts
@@ -59,6 +59,7 @@ export interface VisionContextService {
   hydrateConversationVisionContext: (
     conversation: ThreadConversationState,
     context: {
+      conversationId?: string;
       threadId?: string;
       channelId?: string;
       actorId?: string;
@@ -73,6 +74,7 @@ export interface VisionContextService {
 }
 
 interface ResolveUserAttachmentsContext {
+  conversationId?: string;
   threadId?: string;
   actorId?: string;
   channelId?: string;
@@ -280,6 +282,7 @@ async function resolveUserAttachmentsWithDeps(
             "Return plain text only.",
           ].join(" "),
           metadata: {
+            conversationId: context.conversationId ?? "",
             threadId: context.threadId ?? "",
             channelId: context.channelId ?? "",
             actorId: context.actorId ?? "",
@@ -389,6 +392,7 @@ async function summarizeConversationImage(
     mimeType: string;
     fileId: string;
     context: {
+      conversationId?: string;
       threadId?: string;
       channelId?: string;
       actorId?: string;
@@ -415,6 +419,7 @@ async function summarizeConversationImage(
         "Return plain text only.",
       ].join(" "),
       metadata: {
+        conversationId: args.context.conversationId ?? "",
         threadId: args.context.threadId ?? "",
         channelId: args.context.channelId ?? "",
         actorId: args.context.actorId ?? "",

--- a/packages/junior/src/chat/tools/advisor/tool.ts
+++ b/packages/junior/src/chat/tools/advisor/tool.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import {
   Agent,
   type AgentTool,
@@ -13,6 +14,7 @@ import {
 } from "@/chat/conversation-privacy";
 import {
   extractGenAiUsageAttributes,
+  extractGenAiUsageSummary,
   logWarn,
   serializeGenAiAttribute,
   setSpanAttributes,
@@ -40,6 +42,8 @@ import { juniorToolResultSchema } from "@/chat/tool-support/structured-result";
 import { zodTool } from "@/chat/tool-support/zod-tool";
 import type { AnyToolDefinition } from "@/chat/tools/definition";
 import { z } from "zod";
+import { hasAgentTurnUsage } from "@/chat/usage";
+import { persistWithRetry } from "@/chat/services/persist-retry";
 
 export type AdvisorErrorCode =
   | "invalid_context"
@@ -305,6 +309,7 @@ export function createAdvisorTool(context: AdvisorToolRuntimeContext) {
           });
           advisorAgent.state.messages = advisorMessages;
           const beforeMessageCount = advisorAgent.state.messages.length;
+          const usageId = randomUUID();
 
           try {
             await advisorAgent.prompt(requestMessage);
@@ -321,6 +326,7 @@ export function createAdvisorTool(context: AdvisorToolRuntimeContext) {
           const newAdvisorMessages =
             advisorAgent.state.messages.slice(beforeMessageCount);
           const outputMessages = newAdvisorMessages.filter(isAssistantMessage);
+          const usage = extractGenAiUsageSummary(...newAdvisorMessages);
           const outputMessagesAttribute = serializeGenAiAttribute(
             conversationPrivacy !== "public"
               ? outputMessages.map(toGenAiMessageMetadata)
@@ -331,8 +337,27 @@ export function createAdvisorTool(context: AdvisorToolRuntimeContext) {
               ? { "gen_ai.output.messages": outputMessagesAttribute }
               : {}),
             ...toGenAiMessagesTraceAttributes("app.ai.output", outputMessages),
-            ...extractGenAiUsageAttributes(...newAdvisorMessages),
+            ...extractGenAiUsageAttributes(usage),
           });
+
+          if (hasAgentTurnUsage(usage)) {
+            try {
+              await persistWithRetry(async () => {
+                await conversationStore().recordUsage({
+                  conversationId,
+                  id: usageId,
+                  usage,
+                });
+              });
+            } catch {
+              setSpanStatus("error");
+              await endSubagent("error", "session_unavailable");
+              return failure(
+                "session_unavailable",
+                "Advisor guidance is unavailable because advisor usage could not be saved. Retry the advisor call or continue without assuming advisor history.",
+              );
+            }
+          }
 
           if (
             !assistant ||

--- a/packages/junior/src/chat/tools/index.ts
+++ b/packages/junior/src/chat/tools/index.ts
@@ -118,6 +118,7 @@ export function createTools(
   if (hooks.writeGeneratedArtifacts) {
     tools.imageGenerate = createImageGenerateTool(
       {
+        recordUsage: hooks.recordUsage,
         writeGeneratedArtifacts: hooks.writeGeneratedArtifacts,
       },
       {

--- a/packages/junior/src/chat/tools/types.ts
+++ b/packages/junior/src/chat/tools/types.ts
@@ -17,6 +17,7 @@ import type { LoadSkillMetadata } from "@/chat/tools/skill/load-skill";
 import type { AdvisorToolRuntimeContext } from "@/chat/tools/advisor/tool";
 import type { JuniorToolResult } from "@/chat/tool-support/structured-result";
 import type { LocalActor, Actor, SlackActor } from "@/chat/actor";
+import type { AgentTurnUsage } from "@/chat/usage";
 
 export interface ImageGenerateToolDeps {
   fetch?: typeof fetch;
@@ -45,6 +46,8 @@ export interface GeneratedArtifactFileRef {
 }
 
 export interface ToolHooks {
+  /** Persist model usage produced inside a tool under the active conversation. */
+  recordUsage?: (usage: AgentTurnUsage) => void | Promise<void>;
   /**
    * Materialize generated files and return sandbox paths that exist before the
    * generating tool reports success.

--- a/packages/junior/src/chat/tools/web/image-generate.ts
+++ b/packages/junior/src/chat/tools/web/image-generate.ts
@@ -10,6 +10,7 @@ import {
 } from "@/chat/pi/client";
 import { JUNIOR_PERSONALITY } from "@/chat/prompt";
 import { logInfo, logWarn } from "@/chat/logging";
+import type { AgentTurnUsage } from "@/chat/usage";
 
 const DEFAULT_IMAGE_MODEL = "google/gemini-3-pro-image";
 
@@ -42,9 +43,12 @@ ${JUNIOR_PERSONALITY}
 
 Rewrite the user's image request into a detailed image generation prompt that encodes this personality's visual aesthetic. Output ONLY the rewritten prompt text — no explanation, no wrapper.`;
 
-async function enrichImagePrompt(rawPrompt: string): Promise<string> {
+async function enrichImagePrompt(rawPrompt: string): Promise<{
+  prompt: string;
+  usage?: AgentTurnUsage;
+}> {
   try {
-    const { text } = await completeText({
+    const { text, usage } = await completeText({
       modelId: botConfig.fastModelId,
       system: ENRICHMENT_SYSTEM_PROMPT,
       messages: [{ role: "user", content: rawPrompt, timestamp: Date.now() }],
@@ -57,9 +61,9 @@ async function enrichImagePrompt(rawPrompt: string): Promise<string> {
         { "app.image.enriched_prompt_length": text.trim().length },
         "Image prompt enriched with persona",
       );
-      return text.trim();
+      return { prompt: text.trim(), usage };
     }
-    return rawPrompt;
+    return { prompt: rawPrompt, usage };
   } catch (error) {
     logWarn(
       "image_prompt_enrichment_failed",
@@ -67,7 +71,7 @@ async function enrichImagePrompt(rawPrompt: string): Promise<string> {
       { "exception.message": String(error) },
       "Image prompt enrichment failed, using raw prompt",
     );
-    return rawPrompt;
+    return { prompt: rawPrompt };
   }
 }
 
@@ -101,7 +105,8 @@ function parseImageGenerationError(
 
 /** Create the image tool with sandbox artifact guidance matched to file-send capability. */
 export function createImageGenerateTool(
-  hooks: Required<Pick<ToolHooks, "writeGeneratedArtifacts">>,
+  hooks: Required<Pick<ToolHooks, "writeGeneratedArtifacts">> &
+    Pick<ToolHooks, "recordUsage">,
   options: { canSendFilesToActiveConversation?: boolean } = {},
   deps: ImageGenerateToolDeps = {},
 ) {
@@ -121,7 +126,11 @@ export function createImageGenerateTool(
         throw new Error(MISSING_GATEWAY_CREDENTIALS_ERROR);
       }
       const model = process.env.AI_IMAGE_MODEL ?? DEFAULT_IMAGE_MODEL;
-      const enrichedPrompt = await enrichImagePrompt(prompt);
+      const enrichment = await enrichImagePrompt(prompt);
+      if (enrichment.usage) {
+        await hooks.recordUsage?.(enrichment.usage);
+      }
+      const enrichedPrompt = enrichment.prompt;
       const response = await fetchImpl(
         "https://ai-gateway.vercel.sh/v1/chat/completions",
         {

--- a/packages/junior/src/chat/usage.ts
+++ b/packages/junior/src/chat/usage.ts
@@ -91,10 +91,16 @@ export function addAgentTurnUsage(
       reasoningTokens = (reasoningTokens ?? 0) + reasoning;
     }
     if (usage.cost) {
-      for (const field of [...COST_COMPONENT_FIELDS, "total"] as const) {
+      let componentCostTotal: number | undefined;
+      for (const field of COST_COMPONENT_FIELDS) {
         const value = getFiniteCost(usage.cost[field]);
         if (value === undefined) continue;
         cost[field] = addCost(cost[field], value);
+        componentCostTotal = addCost(componentCostTotal, value);
+      }
+      const total = getFiniteCost(usage.cost.total) ?? componentCostTotal;
+      if (total !== undefined) {
+        cost.total = addCost(cost.total, total);
       }
     }
     const usageComponentTotal = getComponentTotal(usage);

--- a/packages/junior/src/db/schema.ts
+++ b/packages/junior/src/db/schema.ts
@@ -1,5 +1,6 @@
 import { juniorAgentSteps } from "./schema/agent-steps";
 import { juniorConversationMessages } from "./schema/conversation-messages";
+import { juniorConversationUsageEvents } from "./schema/conversation-usage-events";
 import { juniorConversations } from "./schema/conversations";
 import { juniorDestinations } from "./schema/destinations";
 import { juniorIdentities } from "./schema/identities";
@@ -8,6 +9,7 @@ import { juniorUsers } from "./schema/users";
 export {
   juniorAgentSteps,
   juniorConversationMessages,
+  juniorConversationUsageEvents,
   juniorConversations,
   juniorDestinations,
   juniorIdentities,
@@ -17,6 +19,7 @@ export {
 export const juniorSqlSchema = {
   juniorAgentSteps,
   juniorConversationMessages,
+  juniorConversationUsageEvents,
   juniorConversations,
   juniorDestinations,
   juniorIdentities,

--- a/packages/junior/src/db/schema/conversation-usage-events.ts
+++ b/packages/junior/src/db/schema/conversation-usage-events.ts
@@ -1,0 +1,18 @@
+import { jsonb, pgTable, text } from "drizzle-orm/pg-core";
+import type { AgentTurnUsage } from "@/chat/usage";
+import { juniorConversations } from "./conversations";
+import { timestamptz } from "./timestamps";
+
+export const juniorConversationUsageEvents = pgTable(
+  "junior_conversation_usage_events",
+  {
+    id: text("id").primaryKey(),
+    conversationId: text("conversation_id")
+      .notNull()
+      .references(() => juniorConversations.conversationId, {
+        onDelete: "cascade",
+      }),
+    usage: jsonb("usage_json").$type<AgentTurnUsage>().notNull(),
+    createdAt: timestamptz("created_at").notNull(),
+  },
+);

--- a/packages/junior/tests/component/cli/upgrade-cli.test.ts
+++ b/packages/junior/tests/component/cli/upgrade-cli.test.ts
@@ -43,6 +43,7 @@ const stateOnlyConversationStore: ConversationStore = {
   get: async () => undefined,
   getDestinationVisibility: async () => undefined,
   recordActivity: async () => {},
+  recordUsage: async () => {},
   ensureChildConversation: async () => {},
   recordExecution: async () => {},
   listByActivity: async () => [],

--- a/packages/junior/tests/component/conversation-sql-store.test.ts
+++ b/packages/junior/tests/component/conversation-sql-store.test.ts
@@ -672,6 +672,74 @@ WHERE conversation_id = $1
     }
   });
 
+  it("adds auxiliary usage once and preserves it across execution replacement", async () => {
+    const fixture = await createLocalJuniorSqlFixture();
+
+    try {
+      const store = createSqlStore(fixture.sql);
+      await migrateSchema(fixture.sql);
+      await store.recordExecution({
+        conversationId: CONVERSATION_ID,
+        createdAtMs: 1_000,
+        execution: {
+          runId: "run-main",
+          status: "running",
+          updatedAtMs: 2_000,
+        },
+        metrics: {
+          durationMs: 100,
+          usage: { totalTokens: 10, cost: { total: 0.01 } },
+        },
+        lastActivityAtMs: 2_000,
+        updatedAtMs: 2_000,
+      });
+      await store.recordUsage({
+        conversationId: CONVERSATION_ID,
+        id: "aux-call-1",
+        usage: { totalTokens: 5, cost: { total: 0.02 } },
+        createdAtMs: 2_500,
+      });
+      await store.recordUsage({
+        conversationId: CONVERSATION_ID,
+        id: "aux-call-1",
+        usage: { totalTokens: 5, cost: { total: 0.02 } },
+        createdAtMs: 2_500,
+      });
+      await store.recordExecution({
+        conversationId: CONVERSATION_ID,
+        createdAtMs: 1_000,
+        execution: {
+          runId: "run-main",
+          status: "idle",
+          updatedAtMs: 3_000,
+        },
+        metrics: {
+          durationMs: 150,
+          usage: { totalTokens: 12, cost: { total: 0.015 } },
+        },
+        lastActivityAtMs: 3_000,
+        updatedAtMs: 3_000,
+      });
+
+      const [metrics] = await fixture.sql.query<{
+        usage: { cost?: { total?: number }; totalTokens?: number } | null;
+      }>(
+        `SELECT usage_json AS usage FROM junior_conversations WHERE conversation_id = $1`,
+        [CONVERSATION_ID],
+      );
+      const [events] = await fixture.sql.query<{ count: number }>(
+        `SELECT count(*)::integer AS count FROM junior_conversation_usage_events`,
+      );
+      expect(metrics?.usage).toEqual({
+        totalTokens: 17,
+        cost: { total: 0.035 },
+      });
+      expect(events?.count).toBe(1);
+    } finally {
+      await fixture.close();
+    }
+  });
+
   it("keeps SQL execution timestamps when a fresh summary omits them", async () => {
     const fixture = await createLocalJuniorSqlFixture();
 

--- a/packages/junior/tests/component/conversation-transcripts-sql.test.ts
+++ b/packages/junior/tests/component/conversation-transcripts-sql.test.ts
@@ -86,7 +86,7 @@ describe("conversation transcript SQL stores", () => {
       const [applied] = await fixture.sql.query<{ count: number }>(
         "SELECT count(*)::integer AS count FROM drizzle.__drizzle_junior_core",
       );
-      expect(applied?.count).toBe(2);
+      expect(applied?.count).toBe(3);
     } finally {
       await fixture.close();
     }

--- a/packages/junior/tests/component/services/turn-session-record.test.ts
+++ b/packages/junior/tests/component/services/turn-session-record.test.ts
@@ -36,6 +36,7 @@ function failingConversationStore(): ConversationStore {
     recordActivity: vi.fn(async () => {
       throw new Error("conversation metadata unavailable");
     }),
+    recordUsage: vi.fn(),
     recordExecution: vi.fn(),
     listByActivity: vi.fn(),
   };

--- a/packages/junior/tests/component/task-execution/conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/conversation-work.test.ts
@@ -66,6 +66,7 @@ function failingMetadataStore(): ConversationStore {
     getDestinationVisibility: vi.fn(async () => undefined),
     ensureChildConversation: vi.fn(async () => undefined),
     recordActivity: vi.fn(),
+    recordUsage: vi.fn(),
     recordExecution: vi.fn(async () => {
       throw new Error("metadata unavailable");
     }),
@@ -79,6 +80,7 @@ function metadataEventsStore(events: string[]): ConversationStore {
     getDestinationVisibility: vi.fn(async () => undefined),
     ensureChildConversation: vi.fn(async () => undefined),
     recordActivity: vi.fn(),
+    recordUsage: vi.fn(),
     recordExecution: vi.fn(async () => {
       events.push("metadata");
     }),

--- a/packages/junior/tests/component/tools/advisor-tool.test.ts
+++ b/packages/junior/tests/component/tools/advisor-tool.test.ts
@@ -12,7 +12,20 @@ const mocks = vi.hoisted(() => ({
         role: "assistant",
         content: [{ type: "text", text: "private advisor memo" }],
         stopReason: "stop",
-        usage: { input: 5, output: 6, totalTokens: 11 },
+        usage: {
+          input: 5,
+          output: 6,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 11,
+          cost: {
+            input: 0.001,
+            output: 0.002,
+            cacheRead: 0,
+            cacheWrite: 0,
+            total: 0.003,
+          },
+        },
       });
     });
   }),
@@ -51,6 +64,7 @@ vi.mock("@/chat/pi/client", () => ({
 describe("createAdvisorTool", () => {
   it("records privacy-safe advisor invoke-agent attributes", async () => {
     const { createAdvisorTool } = await import("@/chat/tools/advisor/tool");
+    const recordUsage = vi.fn(async () => undefined);
     const advisor = createAdvisorTool({
       config: {
         modelId: "openai/gpt-5.4",
@@ -61,6 +75,7 @@ describe("createAdvisorTool", () => {
       getTools: () => [],
       conversationStore: {
         ensureChildConversation: async () => undefined,
+        recordUsage,
       } as unknown as import("@/chat/conversations/store").ConversationStore,
     });
 
@@ -104,5 +119,12 @@ describe("createAdvisorTool", () => {
     expect(endAttributes["gen_ai.output.messages"]).not.toContain(
       "private advisor memo",
     );
+    expect(recordUsage).toHaveBeenCalledWith({
+      conversationId: "slack:D1:123",
+      id: expect.any(String),
+      usage: expect.objectContaining({
+        cost: expect.objectContaining({ total: 0.003 }),
+      }),
+    });
   }, 20_000);
 });

--- a/packages/junior/tests/integration/auxiliary-usage-reporting.test.ts
+++ b/packages/junior/tests/integration/auxiliary-usage-reporting.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test, vi } from "vitest";
+import { readConversationStatsFromSql } from "@/api/conversations/stats.query";
+import { createJuniorRuntimeServices } from "@/chat/app/services";
+import { migrateSchema } from "@/chat/conversations/sql/migrations";
+import { createSqlStore } from "@/chat/conversations/sql/store";
+import { commitMessages } from "@/chat/conversations/projection";
+import type { PiMessage } from "@/chat/pi/messages";
+import { coerceThreadConversationState } from "@/chat/state/conversation";
+import { juniorConversationUsageEvents } from "@/db/schema";
+import { createConfiguredJuniorSqlFixture } from "../fixtures/sql";
+
+describe("auxiliary model usage reporting", () => {
+  test("includes compaction and classifier cost in the root conversation", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-11T12:00:00.000Z"));
+    const fixture = createConfiguredJuniorSqlFixture();
+    const conversationId = "slack:C123:1752235200.000000";
+    try {
+      await migrateSchema(fixture.sql);
+      const store = createSqlStore(fixture.sql);
+      await store.recordActivity({
+        conversationId,
+        source: "slack",
+        nowMs: Date.now(),
+      });
+      const piMessages = [
+        {
+          role: "user",
+          content: [{ type: "text", text: `compact ${"x".repeat(10_000)}` }],
+          timestamp: Date.now(),
+        },
+      ] as PiMessage[];
+      await commitMessages({ conversationId, messages: piMessages });
+
+      const services = createJuniorRuntimeServices({
+        contextCompactor: {
+          autoCompactionTriggerTokens: 0,
+          completeText: async () =>
+            ({
+              text: "Compacted context.",
+              usage: {
+                totalTokens: 20,
+                cost: { total: 0.02 },
+              },
+            }) as never,
+        },
+        subscribedReplyPolicy: {
+          completeObject: (async () => ({
+            object: {
+              should_reply: true,
+              should_unsubscribe: false,
+              confidence: 0.95,
+              reason: "direct question",
+            },
+            usage: {
+              totalTokens: 30,
+              cost: { total: 0.03 },
+            },
+          })) as never,
+        },
+      });
+
+      await services.contextCompactor.maybeCompact({
+        conversation: coerceThreadConversationState({}),
+        conversationId,
+        piMessages,
+        metadata: { threadId: conversationId },
+      });
+      await services.subscribedReplyPolicy({
+        rawText: "some new text",
+        text: "some new text",
+        context: { conversationId, threadId: conversationId },
+      });
+
+      const report = await readConversationStatsFromSql();
+      const events = await fixture.sql
+        .db()
+        .select()
+        .from(juniorConversationUsageEvents);
+      expect(events).toHaveLength(2);
+      expect(report).toMatchObject({
+        conversations: 1,
+        costUsd: 0.05,
+        tokens: 50,
+      });
+    } finally {
+      vi.useRealTimers();
+      await fixture.close();
+    }
+  });
+});

--- a/packages/junior/tests/integration/conversation-sql.test.ts
+++ b/packages/junior/tests/integration/conversation-sql.test.ts
@@ -140,7 +140,7 @@ VALUES ('host-migration', 9999999999999)
         "SELECT count(*)::integer AS count FROM drizzle.__drizzle_junior_core",
       );
       expect(host?.count).toBe(1);
-      expect(core?.count).toBe(2);
+      expect(core?.count).toBe(3);
     } finally {
       await fixture.close();
     }
@@ -173,6 +173,9 @@ VALUES
   ('0005_conversation_transcripts', 'legacy-checksum-5')
 `);
         await fixture.sql.execute("DROP TABLE drizzle.__drizzle_junior_core");
+        await fixture.sql.execute(
+          "DROP TABLE junior_conversation_usage_events",
+        );
         await fixture.sql.execute(`
 ALTER TABLE junior_conversations
   DROP COLUMN duration_ms,
@@ -189,7 +192,7 @@ ALTER TABLE junior_conversations
         const [journal] = await fixture.sql.query<{ count: number }>(
           "SELECT count(*)::integer AS count FROM drizzle.__drizzle_junior_core",
         );
-        expect(journal?.count).toBe(2);
+        expect(journal?.count).toBe(3);
       } finally {
         await second.close();
         await fixture.close();
@@ -257,7 +260,7 @@ WHERE conversation_id = $1
         "SELECT count(*)::integer AS count FROM drizzle.__drizzle_junior_core",
       );
 
-      expect(migrationRows?.count).toBe(2);
+      expect(migrationRows?.count).toBe(3);
       expect(rows).toHaveLength(1);
       expect(rows[0]).toMatchObject({
         conversation_id: "slack:C123:1718123456.000000",
@@ -303,6 +306,7 @@ VALUES
   ('0005_conversation_transcripts', 'legacy-checksum-5')
 `);
       await fixture.sql.execute("DROP SCHEMA drizzle CASCADE");
+      await fixture.sql.execute("DROP TABLE junior_conversation_usage_events");
       await fixture.sql.execute(`
 ALTER TABLE junior_conversations
   DROP COLUMN duration_ms,
@@ -336,7 +340,7 @@ ORDER BY column_name
         "execution_usage_json",
         "usage_json",
       ]);
-      expect(migrationRows?.count).toBe(2);
+      expect(migrationRows?.count).toBe(3);
     } finally {
       await fixture.close();
     }
@@ -365,6 +369,7 @@ VALUES
   ('0006_conversation_metrics', 'legacy-checksum-6')
 `);
       await fixture.sql.execute("DROP SCHEMA drizzle CASCADE");
+      await fixture.sql.execute("DROP TABLE junior_conversation_usage_events");
 
       await migrateSchema(fixture.sql);
 
@@ -384,7 +389,7 @@ WHERE table_schema = 'public'
   )
 ORDER BY column_name
 `);
-      expect(migrationRows?.count).toBe(1);
+      expect(migrationRows?.count).toBe(2);
       expect(metricColumns.map((row) => row.column_name)).toEqual([
         "duration_ms",
         "execution_duration_ms",

--- a/packages/junior/tests/unit/pi/client.test.ts
+++ b/packages/junior/tests/unit/pi/client.test.ts
@@ -2,6 +2,16 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
 const mocks = vi.hoisted(() => ({
+  calculateCost: vi.fn((_model, usage) => {
+    usage.cost = {
+      input: 0.001,
+      output: 0.002,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 0.003,
+    };
+    return usage.cost;
+  }),
   completeSimple: vi.fn(),
   createGatewayProvider: vi.fn(() => ({
     chat: vi.fn((modelId: string) => ({ modelId })),
@@ -27,6 +37,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/chat/pi/sdk", () => ({
+  calculateCost: mocks.calculateCost,
   completeSimple: mocks.completeSimple,
   getEnvApiKey: mocks.getEnvApiKey,
   getModels: mocks.getModels,
@@ -247,7 +258,23 @@ describe("completeText", () => {
       system: "structured only",
     });
 
-    expect(result).toEqual({ object: { ok: true } });
+    expect(result).toEqual({
+      object: { ok: true },
+      usage: {
+        inputTokens: 10,
+        outputTokens: 3,
+        cachedInputTokens: 0,
+        cacheCreationTokens: 0,
+        totalTokens: 13,
+        cost: {
+          input: 0.001,
+          output: 0.002,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0.003,
+        },
+      },
+    });
     expect(mocks.generateObject).toHaveBeenCalledWith(
       expect.objectContaining({
         model: { modelId: "openai/gpt-4o-mini" },

--- a/packages/junior/tests/unit/slack/assistant-thread-title.test.ts
+++ b/packages/junior/tests/unit/slack/assistant-thread-title.test.ts
@@ -84,7 +84,9 @@ describe("maybeUpdateAssistantTitle", () => {
         sourceMessageId: USER_MESSAGE_ID,
         title: GENERATED_TITLE,
       });
-      expect(args.generateThreadTitle).toHaveBeenCalledWith(USER_MESSAGE_TEXT);
+      expect(args.generateThreadTitle).toHaveBeenCalledWith(USER_MESSAGE_TEXT, {
+        conversationId: `slack:${CHANNEL_ID}:${THREAD_TS}`,
+      });
     });
 
     it("does NOT call setAssistantTitle for a public channel", async () => {

--- a/packages/junior/tests/unit/usage.test.ts
+++ b/packages/junior/tests/unit/usage.test.ts
@@ -60,6 +60,17 @@ describe("addAgentTurnUsage", () => {
     expect(hasAgentTurnUsage({ cost: { total: 0.01 } })).toBe(true);
   });
 
+  it("derives missing slice totals from cost components", () => {
+    expect(
+      addAgentTurnUsage(
+        { cost: { total: 0.01 } },
+        { cost: { input: 0.02, output: 0.03 } },
+      ),
+    ).toEqual({
+      cost: { input: 0.02, output: 0.03, total: 0.06 },
+    });
+  });
+
   it("uses provider totals only for slices without component counters", () => {
     expect(
       addAgentTurnUsage(

--- a/packages/junior/tests/unit/web/image-generate.test.ts
+++ b/packages/junior/tests/unit/web/image-generate.test.ts
@@ -214,17 +214,21 @@ describe("createImageGenerateTool", () => {
 
   it("forwards enriched prompt to image API when enrichment succeeds", async () => {
     process.env.AI_GATEWAY_API_KEY = "test-key";
+    const usage = { totalTokens: 12, cost: { total: 0.004 } };
     mockCompleteText.mockResolvedValueOnce({
       text: "a dark, high-contrast dog with glowing eyes",
+      usage,
     } as any);
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(createJsonResponse(imagePayload()));
     vi.stubGlobal("fetch", fetchMock);
 
+    const recordUsage = vi.fn();
     const tool = createImageGenerateTool({
+      recordUsage,
       writeGeneratedArtifacts,
-    } as any);
+    });
     const result = await tool.execute!({ prompt: "draw a dog" }, {} as any);
 
     const body = getRequestBody(fetchMock);
@@ -235,6 +239,7 @@ describe("createImageGenerateTool", () => {
       prompt: "draw a dog",
       enrichedPrompt: "a dark, high-contrast dog with glowing eyes",
     });
+    expect(recordUsage).toHaveBeenCalledWith(usage);
   });
 
   it("falls back to raw prompt when enrichment returns empty text", async () => {

--- a/specs/advisor-tool.md
+++ b/specs/advisor-tool.md
@@ -58,7 +58,9 @@ The tool description is the executor-facing trigger policy. It must say the advi
 6. Assign the loaded messages to `advisorAgent.state.messages`.
 7. Run `advisorAgent.prompt(requestMessage)`.
 8. On success, append the new advisor steps under the child conversation's own `conversation_id`.
-9. Return the advisor's text exactly as produced in the tool result.
+9. Add the advisor run's normalized model usage to the parent conversation
+   under an idempotent auxiliary usage event.
+10. Return the advisor's text exactly as produced in the tool result.
 
 If `conversationId` is unavailable, return `missing_conversation_id`; do not create an orphan advisor conversation.
 
@@ -118,6 +120,10 @@ The advisor runtime emits a nested `ai.invoke_advisor` span with:
 - `gen_ai.request.model`
 - native span status
 - standard usage attributes when provider usage is available
+
+The same normalized usage is persisted against the parent conversation for
+dashboard cost reporting. The child conversation does not carry an independent
+reporting total.
 
 Do not add custom outcome/result attributes when native span status or standard usage attributes already represent the fact.
 

--- a/specs/conversation-storage.md
+++ b/specs/conversation-storage.md
@@ -27,6 +27,7 @@ terms as defined there.
 - Visible conversation messages (`junior_conversation_messages`).
 - Model execution history as agent steps (`junior_agent_steps`), including context
   epochs, compaction/rollback markers, and subagent child conversations.
+- Idempotent auxiliary model usage (`junior_conversation_usage_events`).
 - Execution status summaries and run/checkpoint timestamps.
 - Conversation display details such as title, channel, source, destination, and
   actor.
@@ -150,6 +151,9 @@ the state-backed task execution store.
   - `(conversation_id, seq)` primary key, `context_epoch` integer, `type`
     discriminant, `role` (nullable, denormalized for `pi_message` rows),
     `payload` jsonb, `created_at`
+- `junior_conversation_usage_events`
+  - `id` primary key, `conversation_id` FK, normalized `usage_json`, and
+    `created_at`; each row contributes once to the root conversation usage
 
 Identities model provider-scoped principals, not just actors. A Slack user turn
 may use the same identity row for multiple roles. Scheduled work uses a system
@@ -241,6 +245,10 @@ polymorphic `transcriptRef {type, key}` reference and the ad-hoc
 - Reading a subagent transcript uses the same query path as any conversation.
 - Top-level listings filter `parent_conversation_id IS NULL`; children are
   excluded from dashboard/reporting lists and purge with their root.
+- Model usage produced by a child or auxiliary model call is added to the root
+  conversation's cumulative usage. `junior_conversation_usage_events` stores a
+  unique call id and usage contribution so persistence retries are idempotent;
+  the conversation row remains the reporting read model.
 
 ### Destination Visibility
 

--- a/specs/dashboard.md
+++ b/specs/dashboard.md
@@ -314,6 +314,12 @@ usage from durable conversation records. Estimated cost and reasoning-token
 usage, when available, are also cumulative conversation fields rather than
 execution-row joins. Per-execution metrics are not part of the dashboard contract;
 feed, detail, stats, and People views expose persisted per-conversation totals.
+The root conversation's cumulative usage includes model calls made on its
+behalf outside the main agent loop, including advisor children, context and
+visible-history compaction, vision summaries, title generation, image-prompt
+enrichment, and structured reply classification. Child conversations remain
+excluded from top-level aggregates; their model usage is attributed to the root
+instead of counted as a separate conversation.
 
 People list and profile APIs must read durable actor identities from the
 SQL conversation index with Drizzle. They must not use plugin reporting hooks


### PR DESCRIPTION
Conversation cost reports now include model calls made on behalf of the root conversation outside the main agent loop: advisor runs, compaction, vision summaries, title generation, image-prompt enrichment, and structured reply classification. Child conversations remain excluded from top-level reporting while their model usage rolls into the parent.

Auxiliary contributions are stored in `junior_conversation_usage_events` with a unique call ID, making persistence retries idempotent while the conversation row remains the reporting read model. Legacy Drizzle adoption now distinguishes baseline, metrics-only, and usage-event schemas so older deployments apply only the missing migrations. Image-generation media charges remain outside this text-model estimate because the raw image endpoint does not expose normalized model cost; prompt enrichment is included.
