### PR TITLE
fix(dashboard): Show cumulative session runtime

### DIFF
--- a/packages/junior-dashboard/src/client/format.ts
+++ b/packages/junior-dashboard/src/client/format.ts
@@ -551,33 +551,16 @@ export function formatCostTotal(usage: ConversationUsage | undefined): string {
   return formatCostSummary(summarizeCost(usage));
 }
 
-/** Keep conversation duration displays aligned on elapsed transcript time. */
-export function transcriptElapsedDurationMs(
-  conversation: Pick<ConversationTranscript, "lastSeenAt" | "startedAt">,
-): number | undefined {
-  const start = parseTime(conversation.startedAt);
-  const end = parseTime(conversation.lastSeenAt);
-  if (start == null || end == null || end < start) return undefined;
-  return Math.max(0, end - start);
-}
-
-/** Format elapsed conversation time for chart dots and transcript metadata. */
+/** Format the execution time accumulated across a conversation's runs. */
 export function formatTranscriptDuration(
-  conversation: Pick<ConversationTranscript, "lastSeenAt" | "startedAt">,
+  conversation: Pick<ConversationTranscript, "cumulativeDurationMs">,
 ): string {
-  return formatMs(transcriptElapsedDurationMs(conversation));
+  return formatRuntime(conversation.cumulativeDurationMs) || "none";
 }
 
-/** Format a conversation span from its start to latest activity. */
+/** Format the execution time accumulated across a conversation's runs. */
 export function formatConversationDuration(conversation: Conversation): string {
-  const start = parseTime(conversation.startedAt);
-  const end = parseTime(conversation.lastSeenAt);
-  if (start == null || end == null || end < start) return "none";
-  const seconds = Math.max(1, Math.round((end - start) / 1000));
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.round(seconds / 60);
-  if (minutes < 60) return `${minutes}m`;
-  return `${Math.round(minutes / 60)}h`;
+  return formatRuntime(conversation.cumulativeDurationMs) || "none";
 }
 
 /** Return the persisted cumulative conversation runtime. */

--- a/packages/junior-dashboard/tests/format.test.ts
+++ b/packages/junior-dashboard/tests/format.test.ts
@@ -96,13 +96,12 @@ describe("dashboard token formatting", () => {
     expect(formatDurationTick(9 * 60_000 + 59_900)).toBe("10m");
   });
 
-  it("formats conversation duration from start to last activity", () => {
+  it("formats transcript duration from cumulative execution time", () => {
     expect(
       formatTranscriptDuration({
-        lastSeenAt: "2026-01-01T00:02:00.000Z",
-        startedAt: "2026-01-01T00:00:00.000Z",
+        cumulativeDurationMs: 7_000,
       }),
-    ).toBe("2m 0s");
+    ).toBe("7.0s");
   });
 
   it("counts conversational transcript messages instead of tool events", () => {
@@ -501,11 +500,11 @@ describe("dashboard token formatting", () => {
     ).toEqual([]);
   });
 
-  it("formats conversation spans with the compact conversation duration rules", () => {
+  it("formats cumulative runtime instead of the conversation wall time", () => {
     const [conversation] = buildConversations([
       {
         conversationId: "slack:C1:123",
-        cumulativeDurationMs: 0,
+        cumulativeDurationMs: 7_000,
         displayTitle: "Conversation",
         lastProgressAt: "2026-06-01T10:02:29.000Z",
         lastSeenAt: "2026-06-01T10:02:29.000Z",
@@ -515,10 +514,10 @@ describe("dashboard token formatting", () => {
       },
     ]);
 
-    expect(formatConversationDuration(conversation!)).toBe("2m");
+    expect(formatConversationDuration(conversation!)).toBe("7.0s");
   });
 
-  it("does not invent conversation spans without a valid end time", () => {
+  it("omits conversation runtime when no execution time is recorded", () => {
     const [conversation] = buildConversations([
       {
         conversationId: "slack:C1:123",


### PR DESCRIPTION
Conversation and transcript details now show persisted cumulative execution time instead of the wall-clock span between first and latest activity. This excludes idle gaps between user turns and aligns detail views with the conversation feed, aggregate stats, and duration chart.\n\nThe formatter regression coverage uses a multi-minute conversation span with only seven seconds of recorded execution time.