### PR TITLE
fix(dashboard): Round costs to two decimal places

### DIFF
--- a/packages/junior-dashboard/src/client/format.ts
+++ b/packages/junior-dashboard/src/client/format.ts
@@ -533,7 +533,7 @@ export function summarizeCost(
   return total !== undefined || componentTotal > 0 ? summary : undefined;
 }
 
-/** Format estimated model cost in USD with useful sub-cent precision. */
+/** Format estimated model cost in USD for consistent dashboard display. */
 export function formatCostSummary(
   summary: CostUsageSummary | undefined,
 ): string {
@@ -542,7 +542,7 @@ export function formatCostSummary(
     style: "currency",
     currency: "USD",
     minimumFractionDigits: 2,
-    maximumFractionDigits: 6,
+    maximumFractionDigits: 2,
   }).format(summary.total);
 }
 

--- a/packages/junior-dashboard/tests/format.test.ts
+++ b/packages/junior-dashboard/tests/format.test.ts
@@ -82,7 +82,8 @@ describe("dashboard token formatting", () => {
       cacheWrite: undefined,
       total: 0.0121,
     });
-    expect(formatCostTotal(usage)).toBe("$0.0121");
+    expect(formatCostTotal(usage)).toBe("$0.01");
+    expect(formatCostTotal({ cost: { total: 1.999 } })).toBe("$2.00");
   });
 
   it("formats cumulative conversation runtime", () => {


### PR DESCRIPTION
Dashboard cost values now consistently render as USD with exactly two decimal places across list rows, conversation details, charts, tooltips, stats, and exports. The shared formatter test covers both sub-cent values and rounding up to the next dollar.