### PR TITLE
fix(dashboard): Show model settings in conversation details

### DIFF
--- a/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
@@ -5,6 +5,7 @@ import type { ConversationDetailReport } from "@sentry/junior/api/schema";
 import { useConversationData } from "../api";
 import { buildConversationMarkdown } from "../markdownExport";
 import { CopyMarkdownButton } from "../components/CopyMarkdownButton";
+import { ExecutionSignature } from "../components/ExecutionSignature";
 import { StatusBadge } from "../components/StatusBadge";
 import {
   buildConversations,
@@ -68,6 +69,10 @@ export function ConversationPage(props: { data?: DashboardData }) {
                 {conversationDisplayTitle(conversation)}
               </h2>
               <StatusBadge status={visualStatus} />
+              <ExecutionSignature
+                modelId={conversationDetail?.modelId}
+                reasoningLevel={conversationDetail?.reasoningLevel}
+              />
             </div>
             <div className="mt-1 break-words text-[0.86rem] leading-snug text-[#b8b8b8]">
               <ConversationIdentity

--- a/packages/junior-dashboard/src/mock-conversations.ts
+++ b/packages/junior-dashboard/src/mock-conversations.ts
@@ -924,7 +924,11 @@ function mockConversations(nowMs: number): ConversationDetailReport[] {
     failedConversation(nowMs),
     hungConversation(nowMs),
     schedulerConversation(nowMs),
-  ];
+  ].map((conversation) => ({
+    modelId: "openai/gpt-5.6-sol",
+    reasoningLevel: "high",
+    ...conversation,
+  }));
 }
 
 function mockConversationMap(

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -707,6 +707,36 @@ describe("dashboard telemetry components", () => {
     expect(html).not.toContain("tool call");
   });
 
+  it("shows the conversation model and thinking level in the detail header", () => {
+    const session = {
+      conversationId: "conversation-1",
+      cumulativeDurationMs: 0,
+      lastProgressAt: "2026-01-01T00:00:00.000Z",
+      lastSeenAt: "2026-01-01T00:00:00.000Z",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      status: "completed",
+      surface: "internal",
+      displayTitle: "Conversation",
+    } satisfies ConversationSummaryReport;
+    const detail = {
+      ...session,
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      modelId: "openai/gpt-5.6-sol",
+      reasoningLevel: "high",
+      transcript: [],
+      transcriptAvailable: true,
+    } satisfies ConversationDetailReport;
+    client.setQueryData(["conversation", "conversation-1"], detail);
+
+    const html = renderConversationPage(dashboardData([session]));
+
+    expect(html).toContain(
+      'aria-label="Execution settings: openai/gpt-5.6-sol, high"',
+    );
+    expect(html).toContain("gpt-5.6-sol");
+    expect(html).toContain("(high)");
+  });
+
   it("renders execution activity inside the transcript", () => {
     const session = {
       conversationId: "conversation-1",

--- a/packages/junior/src/api/conversations/detail.query.ts
+++ b/packages/junior/src/api/conversations/detail.query.ts
@@ -1,7 +1,26 @@
-import { listAgentTurnSessionSummariesForConversation } from "@/chat/state/turn-session";
+import { logException } from "@/chat/logging";
+import {
+  listAgentTurnSessionSummariesForConversation,
+  type AgentTurnSessionSummary,
+} from "@/chat/state/turn-session";
 import { buildConversationDetail } from "./detail-projection";
 import { readConversationRecordFromSql } from "./list.query";
 import type { ConversationDetailReport } from "./schema";
+
+async function readLatestRun(
+  conversationId: string,
+): Promise<AgentTurnSessionSummary | undefined> {
+  try {
+    return (
+      await listAgentTurnSessionSummariesForConversation(conversationId)
+    )[0];
+  } catch (error) {
+    logException(error, "conversation_execution_settings_read_failed", {
+      conversationId,
+    });
+    return undefined;
+  }
+}
 
 /** Read one SQL conversation with its latest operational run settings. */
 export async function readConversationDetailFromSql(
@@ -10,13 +29,13 @@ export async function readConversationDetailFromSql(
   const record = await readConversationRecordFromSql(conversationId);
   if (!record) return undefined;
 
-  const latestRun = (
-    await listAgentTurnSessionSummariesForConversation(conversationId)
-  )[0];
-  const report = await buildConversationDetail({
-    ...record,
-    usage: record.usage ?? undefined,
-  });
+  const [report, latestRun] = await Promise.all([
+    buildConversationDetail({
+      ...record,
+      usage: record.usage ?? undefined,
+    }),
+    readLatestRun(conversationId),
+  ]);
   return {
     ...report,
     ...(latestRun?.modelId ? { modelId: latestRun.modelId } : {}),

--- a/packages/junior/src/api/conversations/detail.query.ts
+++ b/packages/junior/src/api/conversations/detail.query.ts
@@ -1,6 +1,6 @@
 import { logException } from "@/chat/logging";
 import {
-  listAgentTurnSessionSummariesForConversation,
+  listBoundedAgentTurnSessionSummariesForConversation,
   type AgentTurnSessionSummary,
 } from "@/chat/state/turn-session";
 import { buildConversationDetail } from "./detail-projection";
@@ -12,8 +12,8 @@ async function readLatestRun(
 ): Promise<AgentTurnSessionSummary | undefined> {
   try {
     return (
-      await listAgentTurnSessionSummariesForConversation(conversationId)
-    )[0];
+      await listBoundedAgentTurnSessionSummariesForConversation(conversationId)
+    ).find((summary) => summary.modelId || summary.reasoningLevel);
   } catch (error) {
     logException(error, "conversation_execution_settings_read_failed", {
       conversationId,

--- a/packages/junior/src/api/conversations/detail.query.ts
+++ b/packages/junior/src/api/conversations/detail.query.ts
@@ -1,16 +1,27 @@
+import { listAgentTurnSessionSummariesForConversation } from "@/chat/state/turn-session";
 import { buildConversationDetail } from "./detail-projection";
 import { readConversationRecordFromSql } from "./list.query";
 import type { ConversationDetailReport } from "./schema";
 
-/** Read one conversation and its cumulative metrics from durable SQL. */
+/** Read one SQL conversation with its latest operational run settings. */
 export async function readConversationDetailFromSql(
   conversationId: string,
 ): Promise<ConversationDetailReport | undefined> {
   const record = await readConversationRecordFromSql(conversationId);
-  return record
-    ? buildConversationDetail({
-        ...record,
-        usage: record.usage ?? undefined,
-      })
-    : undefined;
+  if (!record) return undefined;
+
+  const latestRun = (
+    await listAgentTurnSessionSummariesForConversation(conversationId)
+  )[0];
+  const report = await buildConversationDetail({
+    ...record,
+    usage: record.usage ?? undefined,
+  });
+  return {
+    ...report,
+    ...(latestRun?.modelId ? { modelId: latestRun.modelId } : {}),
+    ...(latestRun?.reasoningLevel
+      ? { reasoningLevel: latestRun.reasoningLevel }
+      : {}),
+  };
 }

--- a/packages/junior/src/api/conversations/detail.ts
+++ b/packages/junior/src/api/conversations/detail.ts
@@ -2,7 +2,7 @@ import { readConversationDetailFromSql } from "./detail.query";
 import { conversationDetailReportSchema } from "./schema";
 import type { ConversationDetailReport } from "./schema";
 
-/** Load one conversation directly from durable SQL records. */
+/** Load one conversation with durable content and recent run diagnostics. */
 export async function readConversationDetail(
   conversationId: string,
 ): Promise<ConversationDetailReport | undefined> {

--- a/packages/junior/src/api/conversations/schema.ts
+++ b/packages/junior/src/api/conversations/schema.ts
@@ -146,6 +146,8 @@ export const conversationActivityReportSchema = z.discriminatedUnion("type", [
 export const conversationDetailReportSchema = conversationSummaryReportSchema
   .extend({
     activity: z.array(conversationActivityReportSchema).optional(),
+    modelId: z.string().optional(),
+    reasoningLevel: z.string().optional(),
     transcriptAvailable: z.boolean(),
     transcriptMetadata: z.array(transcriptMessageSchema).optional(),
     transcriptMessageCount: z.number().optional(),

--- a/packages/junior/src/chat/state/turn-session.ts
+++ b/packages/junior/src/chat/state/turn-session.ts
@@ -802,10 +802,8 @@ export async function listAgentTurnSessionSummariesForConversation(
   conversationId: string,
 ): Promise<AgentTurnSessionSummary[]> {
   const stateAdapter = getStateAdapter();
-  const summaries = await readAgentTurnSessionSummariesFromIndex(
-    agentTurnSessionConversationIndexKey(conversationId),
-    stateAdapter,
-  );
+  const summaries =
+    await listBoundedAgentTurnSessionSummariesForConversation(conversationId);
   if (summaries.length > 0) {
     return summaries;
   }
@@ -816,6 +814,16 @@ export async function listAgentTurnSessionSummariesForConversation(
       stateAdapter,
     )
   ).filter((summary) => summary.conversationId === conversationId);
+}
+
+/** List retained run summaries without falling back to global history. */
+export async function listBoundedAgentTurnSessionSummariesForConversation(
+  conversationId: string,
+): Promise<AgentTurnSessionSummary[]> {
+  return readAgentTurnSessionSummariesFromIndex(
+    agentTurnSessionConversationIndexKey(conversationId),
+    getStateAdapter(),
+  );
 }
 
 /** Read complete per-conversation summary indexes with bounded backend load. */

--- a/packages/junior/tests/component/services/turn-session-record.test.ts
+++ b/packages/junior/tests/component/services/turn-session-record.test.ts
@@ -238,6 +238,22 @@ describe("persistAuthPauseSessionRecord", () => {
     ).resolves.toEqual([]);
   });
 
+  it("reads the bounded conversation summary index without scanning globally", async () => {
+    const { getStateAdapter } = await import("@/chat/state/adapter");
+    const { listBoundedAgentTurnSessionSummariesForConversation } =
+      await import("@/chat/state/turn-session");
+    const getList = vi.spyOn(getStateAdapter(), "getList");
+
+    await expect(
+      listBoundedAgentTurnSessionSummariesForConversation(
+        "slack:C123:bounded-summary",
+      ),
+    ).resolves.toEqual([]);
+    expect(getList).toHaveBeenCalledExactlyOnceWith(
+      "junior:agent_turn_session:conversation:slack:C123:bounded-summary:index",
+    );
+  });
+
   it("materializes auth completion events appended after the pause record", async () => {
     const { getAgentTurnSessionRecord, upsertAgentTurnSessionRecord } =
       await import("@/chat/state/turn-session");

--- a/packages/junior/tests/integration/dashboard-reporting.test.ts
+++ b/packages/junior/tests/integration/dashboard-reporting.test.ts
@@ -974,6 +974,55 @@ describe("dashboard reporting", () => {
     ]);
   });
 
+  it("keeps SQL detail available when optional execution settings fail", async () => {
+    const { getAgentStepStore, getConversationStore } =
+      await import("@/chat/db");
+    const { getStateAdapter } = await import("@/chat/state/adapter");
+    const conversationId = "slack:C1:settings-unavailable";
+    await getConversationStore().recordActivity({
+      conversationId,
+      destination: {
+        platform: "slack",
+        teamId: "T1",
+        channelId: "C1",
+      },
+      source: "slack",
+      visibility: "public",
+    });
+    await getAgentStepStore().append(conversationId, [
+      {
+        entry: {
+          type: "pi_message",
+          message: {
+            role: "user",
+            content: [{ type: "text", text: "available transcript" }],
+            timestamp: 1,
+          } as PiMessage,
+        },
+        createdAtMs: 1,
+      },
+    ]);
+    vi.spyOn(getStateAdapter(), "getList").mockRejectedValueOnce(
+      new Error("execution settings unavailable"),
+    );
+
+    const report = await readConversationDetailReport(conversationId);
+
+    expect(report).toMatchObject({
+      conversationId,
+      transcriptAvailable: true,
+      transcript: [
+        {
+          role: "user",
+          timestamp: 1,
+          parts: [{ type: "text", text: "available transcript" }],
+        },
+      ],
+    });
+    expect(report).not.toHaveProperty("modelId");
+    expect(report).not.toHaveProperty("reasoningLevel");
+  });
+
   it("reports multiple message exchanges as one complete SQL transcript", async () => {
     const { upsertAgentTurnSessionRecord } =
       await import("@/chat/state/turn-session");

--- a/packages/junior/tests/integration/dashboard-reporting.test.ts
+++ b/packages/junior/tests/integration/dashboard-reporting.test.ts
@@ -322,7 +322,7 @@ describe("dashboard reporting", () => {
   });
 
   it("reports the complete SQL conversation transcript", async () => {
-    const { upsertAgentTurnSessionRecord } =
+    const { recordAgentTurnSessionSummary, upsertAgentTurnSessionRecord } =
       await import("@/chat/state/turn-session");
     const { readConversationDetailFromSql } =
       await import("@/api/conversations/detail.query");
@@ -392,6 +392,12 @@ describe("dashboard reporting", () => {
           timestamp: 6,
         },
       ] as PiMessage[],
+    });
+    await recordAgentTurnSessionSummary({
+      conversationId: "slack:C1:222",
+      sessionId: "turn-running",
+      sliceId: 1,
+      state: "running",
     });
 
     const report = await readConversationDetailFromSql("slack:C1:222");

--- a/packages/junior/tests/integration/dashboard-reporting.test.ts
+++ b/packages/junior/tests/integration/dashboard-reporting.test.ts
@@ -398,6 +398,8 @@ describe("dashboard reporting", () => {
     expect(report).toMatchObject({
       cumulativeDurationMs: 1_200,
       cumulativeUsage: { totalTokens: 120 },
+      modelId: "openai/gpt-5.5",
+      reasoningLevel: "high",
       transcriptMessageCount: 4,
     });
     expect(report?.transcript).toEqual([

--- a/specs/dashboard.md
+++ b/specs/dashboard.md
@@ -178,6 +178,9 @@ when the exposed transcript begins at a model run boundary. Follow-up run
 transcripts that are scoped to the current user message must not repeat the
 system prompt.
 
+Conversation detail responses expose the latest retained turn session's
+`modelId` and `reasoningLevel` when those operational settings are available.
+
 The current public diagnostics surfaces must move behind dashboard auth:
 
 - The HTML diagnostics page stays at `/` when the dashboard package is mounted, but requires dashboard auth.


### PR DESCRIPTION
Conversation details now expose the latest retained run's model and reasoning level and show them beside the status in the dashboard header. Operators can identify the execution settings without opening subagent activity or external telemetry.

The response fields remain optional for conversations without retained run diagnostics. Regression coverage verifies both the API projection and the rendered header.