### PR TITLE
feat(conversations): Search prior public transcripts

### DIFF
--- a/packages/junior-evals/evals/core/conversation-storage.eval.ts
+++ b/packages/junior-evals/evals/core/conversation-storage.eval.ts
@@ -1,4 +1,4 @@
-import { describeEval } from "vitest-evals";
+import { describeEval, toolCalls } from "vitest-evals";
 import { expect } from "vitest";
 import {
   agentSteps,
@@ -10,6 +10,58 @@ import {
 } from "../../src/helpers";
 
 describeEval("Conversation Storage", slackEvals, (it) => {
+  it("when asked about an earlier public thread in the same workspace, search stored conversation history", async ({
+    run,
+  }) => {
+    const priorThread = {
+      id: "thread-conversation-search-prior",
+      channel_id: "CCONVERSATIONSEARCHPRIOR",
+      channel_type: "channel" as const,
+      thread_ts: "17000000.688001",
+    };
+    const currentThread = {
+      id: "thread-conversation-search-current",
+      channel_id: "CCONVERSATIONSEARCHCURRENT",
+      channel_type: "channel" as const,
+      thread_ts: "17000000.688002",
+    };
+    const result = await run({
+      initialEvents: [
+        mention(
+          "Record this decision for our launch: the rollback owner is Priya.",
+          { thread: priorThread },
+        ),
+      ],
+      events: [
+        mention(
+          "Who did we name as the rollback owner in the earlier thread?",
+          {
+            thread: currentThread,
+          },
+        ),
+      ],
+      requireSandboxReady: false,
+      criteria: rubric({
+        pass: [
+          "The assistant answers that Priya was named as the rollback owner.",
+          "The answer is based on a search of the earlier public Junior conversation in the same Slack workspace.",
+        ],
+        fail: [
+          "Do not claim the earlier decision is unavailable.",
+          "Do not ask the user to paste the earlier thread.",
+        ],
+      }),
+    });
+
+    expect(toolCalls(result.session)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "searchConversationHistory",
+        }),
+      ]),
+    );
+  });
+
   it("when a user asks a simple question, the turn's messages persist to the SQL stores", async ({
     run,
   }) => {

--- a/packages/junior-evals/evals/core/conversation-storage.eval.ts
+++ b/packages/junior-evals/evals/core/conversation-storage.eval.ts
@@ -56,6 +56,12 @@ describeEval("Conversation Storage", slackEvals, (it) => {
     expect(toolCalls(result.session)).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
+          name: "searchTools",
+          arguments: expect.objectContaining({
+            source: "conversation-history",
+          }),
+        }),
+        expect.objectContaining({
           name: "searchConversationHistory",
         }),
       ]),

--- a/packages/junior/migrations/0002_conversation_message_search.sql
+++ b/packages/junior/migrations/0002_conversation_message_search.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "junior_conversation_messages_search_idx" ON "junior_conversation_messages" USING gin (to_tsvector('english', "text"));

--- a/packages/junior/migrations/meta/0002_snapshot.json
+++ b/packages/junior/migrations/meta/0002_snapshot.json
@@ -1,0 +1,987 @@
+{
+  "id": "df0fd278-b0ca-43c5-8d4c-f3881004516b",
+  "prevId": "787c677c-20a2-48b4-8222-8bbb6aa5f45c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.junior_agent_steps": {
+      "name": "junior_agent_steps",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_epoch": {
+          "name": "context_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_agent_steps_epoch_idx": {
+          "name": "junior_agent_steps_epoch_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_epoch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_agent_steps_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_agent_steps_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_agent_steps",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_agent_steps_conversation_id_seq_pk": {
+          "name": "junior_agent_steps_conversation_id_seq_pk",
+          "columns": ["conversation_id", "seq"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversation_messages": {
+      "name": "junior_conversation_messages",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_identity_id": {
+          "name": "author_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replied_at": {
+          "name": "replied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_conversation_messages_activity_idx": {
+          "name": "junior_conversation_messages_activity_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversation_messages_search_idx": {
+          "name": "junior_conversation_messages_search_idx",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"text\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_conversation_messages_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversation_messages_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversation_messages",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversation_messages_author_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversation_messages_author_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversation_messages",
+          "tableTo": "junior_identities",
+          "columnsFrom": ["author_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_conversation_messages_conversation_id_message_id_pk": {
+          "name": "junior_conversation_messages_conversation_id_message_id_pk",
+          "columns": ["conversation_id", "message_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversations": {
+      "name": "junior_conversations",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_type": {
+          "name": "origin_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_id": {
+          "name": "origin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_run_id": {
+          "name": "origin_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_json": {
+          "name": "destination_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity_id": {
+          "name": "actor_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_identity_id": {
+          "name": "creator_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_subject_identity_id": {
+          "name": "credential_subject_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_json": {
+          "name": "actor_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_updated_at": {
+          "name": "execution_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_status": {
+          "name": "execution_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_checkpoint_at": {
+          "name": "last_checkpoint_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_enqueued_at": {
+          "name": "last_enqueued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_conversation_id": {
+          "name": "parent_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_purged_at": {
+          "name": "transcript_purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "usage_json": {
+          "name": "usage_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_duration_ms": {
+          "name": "execution_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "execution_usage_json": {
+          "name": "execution_usage_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_conversations_last_activity_idx": {
+          "name": "junior_conversations_last_activity_idx",
+          "columns": [
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_active_idx": {
+          "name": "junior_conversations_active_idx",
+          "columns": [
+            {
+              "expression": "coalesce(\"execution_updated_at\", \"updated_at\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_conversations\".\"execution_status\" <> 'idle'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_destination_activity_idx": {
+          "name": "junior_conversations_destination_activity_idx",
+          "columns": [
+            {
+              "expression": "destination_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_actor_activity_idx": {
+          "name": "junior_conversations_actor_activity_idx",
+          "columns": [
+            {
+              "expression": "actor_identity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_origin_idx": {
+          "name": "junior_conversations_origin_idx",
+          "columns": [
+            {
+              "expression": "origin_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "origin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_parent_idx": {
+          "name": "junior_conversations_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_conversations_destination_id_junior_destinations_id_fk": {
+          "name": "junior_conversations_destination_id_junior_destinations_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_destinations",
+          "columnsFrom": ["destination_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_actor_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversations_actor_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_identities",
+          "columnsFrom": ["actor_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_creator_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversations_creator_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_identities",
+          "columnsFrom": ["creator_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_credential_subject_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversations_credential_subject_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_identities",
+          "columnsFrom": ["credential_subject_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_parent_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversations_parent_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["parent_conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_destinations": {
+      "name": "junior_destinations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_tenant_id": {
+          "name": "provider_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "provider_destination_id": {
+          "name": "provider_destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_destination_id": {
+          "name": "parent_destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_destinations_provider_destination_uidx": {
+          "name": "junior_destinations_provider_destination_uidx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_destination_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_destinations_provider_kind_idx": {
+          "name": "junior_destinations_provider_kind_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_identities": {
+      "name": "junior_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_tenant_id": {
+          "name": "provider_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "provider_subject_id": {
+          "name": "provider_subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_normalized": {
+          "name": "email_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "junior_identities_provider_subject_uidx": {
+          "name": "junior_identities_provider_subject_uidx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_identities_user_idx": {
+          "name": "junior_identities_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_identities_verified_email_idx": {
+          "name": "junior_identities_verified_email_idx",
+          "columns": [
+            {
+              "expression": "email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_identities\".\"email_verified\" = true AND \"junior_identities\".\"email_normalized\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_identities_kind_provider_idx": {
+          "name": "junior_identities_kind_provider_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_identities_user_id_junior_users_id_fk": {
+          "name": "junior_identities_user_id_junior_users_id_fk",
+          "tableFrom": "junior_identities",
+          "tableTo": "junior_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_users": {
+      "name": "junior_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "primary_email": {
+          "name": "primary_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_email_normalized": {
+          "name": "primary_email_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_users_primary_email_normalized_uidx": {
+          "name": "junior_users_primary_email_normalized_uidx",
+          "columns": [
+            {
+              "expression": "primary_email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/junior/migrations/meta/_journal.json
+++ b/packages/junior/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1783781940092,
       "tag": "0001_conversation_metrics",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1783870609225,
+      "tag": "0002_conversation_message_search",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/junior/src/chat/conversations/search.ts
+++ b/packages/junior/src/chat/conversations/search.ts
@@ -1,0 +1,26 @@
+/** One relevant visible-message match from a prior conversation. */
+export interface ConversationSearchResult {
+  conversationId: string;
+  excerpt: string;
+  messageCreatedAtMs: number;
+  messageId: string;
+  providerDestinationId: string;
+  role: "assistant" | "user";
+}
+
+/** Runtime-derived public workspace scope for cross-conversation search. */
+export interface ConversationSearchScope {
+  kind: "public_provider_tenant";
+  provider: "slack";
+  providerTenantId: string;
+}
+
+/** Search retained public visible messages within an authorized workspace. */
+export interface ConversationSearchStore {
+  search(args: {
+    currentConversationId: string;
+    limit: number;
+    query: string;
+    scope: ConversationSearchScope;
+  }): Promise<ConversationSearchResult[]>;
+}

--- a/packages/junior/src/chat/conversations/sql/migrations.ts
+++ b/packages/junior/src/chat/conversations/sql/migrations.ts
@@ -75,7 +75,7 @@ WHERE table_schema = 'public'
     );
   }
 
-  const migration = metrics?.complete ? migrations.at(-1) : migrations[0];
+  const migration = metrics?.complete ? migrations[1] : migrations[0];
   if (!migration) {
     throw new Error("No core Drizzle migrations were packaged");
   }

--- a/packages/junior/src/chat/conversations/sql/search.ts
+++ b/packages/junior/src/chat/conversations/sql/search.ts
@@ -1,0 +1,99 @@
+import { and, desc, eq, inArray, isNull, ne, sql } from "drizzle-orm";
+import type { JuniorSqlDatabase } from "@/db/db";
+import {
+  juniorConversationMessages,
+  juniorConversations,
+  juniorDestinations,
+} from "@/db/schema";
+import type {
+  ConversationSearchResult,
+  ConversationSearchScope,
+  ConversationSearchStore,
+} from "../search";
+
+class SqlConversationSearchStore implements ConversationSearchStore {
+  constructor(private readonly executor: JuniorSqlDatabase) {}
+
+  async search(args: {
+    currentConversationId: string;
+    limit: number;
+    query: string;
+    scope: ConversationSearchScope;
+  }): Promise<ConversationSearchResult[]> {
+    const db = this.executor.db();
+    const tsquery = sql`websearch_to_tsquery('english', ${args.query})`;
+    const rank = sql<number>`ts_rank_cd(to_tsvector('english', ${juniorConversationMessages.text}), ${tsquery})`;
+    const excerpt = sql<string>`ts_headline('english', ${juniorConversationMessages.text}, ${tsquery}, 'MaxFragments=2, MinWords=8, MaxWords=40, FragmentDelimiter=" … ", StartSel=**, StopSel=**')`;
+    const role = sql<
+      ConversationSearchResult["role"]
+    >`${juniorConversationMessages.role}`;
+
+    const bestPerConversation = db
+      .selectDistinctOn([juniorConversations.conversationId], {
+        conversationId: juniorConversations.conversationId,
+        excerpt: excerpt.as("excerpt"),
+        lastActivityAt: juniorConversations.lastActivityAt,
+        messageCreatedAt: juniorConversationMessages.createdAt,
+        messageId: juniorConversationMessages.messageId,
+        providerDestinationId: juniorDestinations.providerDestinationId,
+        rank: rank.as("rank"),
+        role: role.as("role"),
+      })
+      .from(juniorConversationMessages)
+      .innerJoin(
+        juniorConversations,
+        eq(
+          juniorConversations.conversationId,
+          juniorConversationMessages.conversationId,
+        ),
+      )
+      .innerJoin(
+        juniorDestinations,
+        eq(juniorDestinations.id, juniorConversations.destinationId),
+      )
+      .where(
+        and(
+          eq(juniorConversations.source, "slack"),
+          isNull(juniorConversations.parentConversationId),
+          isNull(juniorConversations.transcriptPurgedAt),
+          ne(juniorConversations.conversationId, args.currentConversationId),
+          eq(juniorDestinations.provider, args.scope.provider),
+          eq(juniorDestinations.providerTenantId, args.scope.providerTenantId),
+          eq(juniorDestinations.visibility, "public"),
+          inArray(juniorConversationMessages.role, ["user", "assistant"]),
+          sql`to_tsvector('english', ${juniorConversationMessages.text}) @@ ${tsquery}`,
+        ),
+      )
+      .orderBy(
+        juniorConversations.conversationId,
+        desc(rank),
+        desc(juniorConversationMessages.createdAt),
+      )
+      .as("best_conversation_matches");
+
+    const rows = await db
+      .select()
+      .from(bestPerConversation)
+      .orderBy(
+        desc(bestPerConversation.rank),
+        desc(bestPerConversation.lastActivityAt),
+      )
+      .limit(args.limit);
+
+    return rows.map((row) => ({
+      conversationId: row.conversationId,
+      excerpt: row.excerpt,
+      messageCreatedAtMs: row.messageCreatedAt.getTime(),
+      messageId: row.messageId,
+      providerDestinationId: row.providerDestinationId,
+      role: row.role,
+    }));
+  }
+}
+
+/** Create a SQL-backed public workspace conversation search store. */
+export function createSqlConversationSearchStore(
+  executor: JuniorSqlDatabase,
+): ConversationSearchStore {
+  return new SqlConversationSearchStore(executor);
+}

--- a/packages/junior/src/chat/db.ts
+++ b/packages/junior/src/chat/db.ts
@@ -5,6 +5,8 @@ import { createSqlAgentStepStore } from "@/chat/conversations/sql/history";
 import type { AgentStepStore } from "@/chat/conversations/history";
 import { createSqlConversationMessageStore } from "@/chat/conversations/sql/messages";
 import type { ConversationMessageStore } from "@/chat/conversations/messages";
+import { createSqlConversationSearchStore } from "@/chat/conversations/sql/search";
+import type { ConversationSearchStore } from "@/chat/conversations/search";
 import type { JuniorDatabase, JuniorSqlExecutor } from "@/db/db";
 import { createJuniorSqlExecutor } from "@/db/executor";
 
@@ -16,6 +18,7 @@ let current:
       store: ConversationStore;
       stepStore: AgentStepStore;
       messageStore: ConversationMessageStore;
+      searchStore: ConversationSearchStore;
     }
   | undefined;
 
@@ -55,6 +58,7 @@ export function getSqlExecutor(): JuniorSqlExecutor {
       store: createSqlStore(db),
       stepStore: createSqlAgentStepStore(db),
       messageStore: createSqlConversationMessageStore(db),
+      searchStore: createSqlConversationSearchStore(db),
     };
   }
   return current.db;
@@ -81,6 +85,12 @@ export function getAgentStepStore(): AgentStepStore {
 export function getConversationMessageStore(): ConversationMessageStore {
   getSqlExecutor();
   return current!.messageStore;
+}
+
+/** Return the SQL-backed public provider-tenant conversation search store. */
+export function getConversationSearchStore(): ConversationSearchStore {
+  getSqlExecutor();
+  return current!.searchStore;
 }
 
 /** Close the process SQL database when it has been opened. */

--- a/packages/junior/src/chat/slack/outbound.ts
+++ b/packages/junior/src/chat/slack/outbound.ts
@@ -56,7 +56,8 @@ function requireSlackMessageText(text: string, action: string): string {
   return text;
 }
 
-async function getPermalinkBestEffort(args: {
+/** Resolve a Slack message permalink without making read-only workflows fail on lookup errors. */
+export async function getSlackMessagePermalink(args: {
   channelId: SlackChannelId;
   messageTs: SlackMessageTs;
 }): Promise<string | undefined> {
@@ -134,7 +135,7 @@ export async function postSlackMessage(input: {
     ts: messageTs,
     ...(input.includePermalink
       ? {
-          permalink: await getPermalinkBestEffort({
+          permalink: await getSlackMessagePermalink({
             channelId,
             messageTs,
           }),

--- a/packages/junior/src/chat/slack/tools/conversation-search.ts
+++ b/packages/junior/src/chat/slack/tools/conversation-search.ts
@@ -43,6 +43,12 @@ export function createSlackConversationSearchTool(
   return zodTool({
     description:
       "Search prior public Junior conversation threads across the current Slack workspace. Use when the user refers to an earlier public discussion, decision, or answer that is not in the current thread. Searches retained visible user and assistant messages only.",
+    exposure: "deferred",
+    source: {
+      id: "conversation-history",
+      description:
+        "Search retained public Junior conversation threads in the current Slack workspace.",
+    },
     annotations: { readOnlyHint: true, destructiveHint: false },
     inputSchema: z.object({
       query: z

--- a/packages/junior/src/chat/slack/tools/conversation-search.ts
+++ b/packages/junior/src/chat/slack/tools/conversation-search.ts
@@ -1,0 +1,109 @@
+import { z } from "zod";
+import type {
+  ConversationSearchScope,
+  ConversationSearchStore,
+} from "@/chat/conversations/search";
+import { getConversationSearchStore } from "@/chat/db";
+import { parseSlackThreadId } from "@/chat/slack/context";
+import { getSlackMessagePermalink } from "@/chat/slack/outbound";
+import { juniorToolResultSchema } from "@/chat/tool-support/structured-result";
+import { zodTool } from "@/chat/tool-support/zod-tool";
+
+const DEFAULT_LIMIT = 5;
+
+const conversationSearchOutputSchema = juniorToolResultSchema.extend({
+  query: z.string(),
+  count: z.number().int().nonnegative(),
+  threads: z.array(
+    z
+      .object({
+        conversation_id: z.string().min(1),
+        thread_ts: z.string().min(1),
+        message_id: z.string().min(1),
+        message_role: z.enum(["assistant", "user"]),
+        message_timestamp: z.string().datetime(),
+        excerpt: z.string(),
+        permalink: z.string().url().optional(),
+      })
+      .strict(),
+  ),
+});
+
+interface ConversationSearchToolDeps {
+  getPermalink?: typeof getSlackMessagePermalink;
+  store?: ConversationSearchStore;
+}
+
+/** Create a tool that searches retained public Junior threads across an authorized Slack workspace. */
+export function createSlackConversationSearchTool(
+  scope: ConversationSearchScope,
+  currentConversationId: string,
+  deps: ConversationSearchToolDeps = {},
+) {
+  return zodTool({
+    description:
+      "Search prior public Junior conversation threads across the current Slack workspace. Use when the user refers to an earlier public discussion, decision, or answer that is not in the current thread. Searches retained visible user and assistant messages only.",
+    annotations: { readOnlyHint: true, destructiveHint: false },
+    inputSchema: z.object({
+      query: z
+        .string()
+        .trim()
+        .min(1)
+        .max(200)
+        .describe("Words or a short phrase to find in prior conversations."),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(10)
+        .describe("Maximum number of prior conversation threads to return.")
+        .nullable()
+        .optional(),
+    }),
+    outputSchema: conversationSearchOutputSchema,
+    execute: async ({ query, limit }) => {
+      const store = deps.store ?? getConversationSearchStore();
+      const matches = await store.search({
+        currentConversationId,
+        limit: limit ?? DEFAULT_LIMIT,
+        query,
+        scope,
+      });
+      const getPermalink = deps.getPermalink ?? getSlackMessagePermalink;
+      const threads = await Promise.all(
+        matches.map(async (match) => {
+          const reference = parseSlackThreadId(match.conversationId);
+          if (
+            !reference ||
+            reference.channelId !== match.providerDestinationId
+          ) {
+            throw new Error(
+              "Stored Slack conversation search returned an invalid destination",
+            );
+          }
+          const permalink = await getPermalink({
+            channelId: reference.channelId,
+            messageTs: reference.threadTs,
+          });
+          return {
+            conversation_id: match.conversationId,
+            thread_ts: reference.threadTs,
+            message_id: match.messageId,
+            message_role: match.role,
+            message_timestamp: new Date(match.messageCreatedAtMs).toISOString(),
+            excerpt: match.excerpt,
+            ...(permalink ? { permalink } : {}),
+          };
+        }),
+      );
+
+      return {
+        ok: true,
+        status: "success" as const,
+        query,
+        count: threads.length,
+        threads,
+      };
+    },
+  });
+}

--- a/packages/junior/src/chat/tool-support/zod-tool.ts
+++ b/packages/junior/src/chat/tool-support/zod-tool.ts
@@ -14,6 +14,7 @@ import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 type ZodToolDefinitionBase<TInputSchema extends ZodTypeAny> = Pick<
   AnyToolDefinition,
   | "identity"
+  | "source"
   | "description"
   | "exposure"
   | "annotations"

--- a/packages/junior/src/chat/tools/index.ts
+++ b/packages/junior/src/chat/tools/index.ts
@@ -19,6 +19,7 @@ import {
   createSubscribeToResourceEventsTool,
 } from "@/chat/tools/resource-events";
 import { createSlackChannelListMessagesTool } from "@/chat/slack/tools/channel-list-messages";
+import { createSlackConversationSearchTool } from "@/chat/slack/tools/conversation-search";
 import { getSlackToolContext } from "@/chat/slack/tools/context";
 import { createSlackMessageAddReactionTool } from "@/chat/slack/tools/message-add-reaction";
 import { createSendMessageTool } from "@/chat/slack/tools/send-message";
@@ -150,6 +151,16 @@ export function createTools(
     tools.slackCanvasEdit = createSlackCanvasEditTool(state);
     tools.slackCanvasWrite = createSlackCanvasWriteTool(state);
     tools.slackThreadRead = createSlackThreadReadTool(slackContext);
+    if (context.conversationId && slackContext.source.type === "pub") {
+      tools.searchConversationHistory = createSlackConversationSearchTool(
+        {
+          kind: "public_provider_tenant",
+          provider: "slack",
+          providerTenantId: slackContext.teamId,
+        },
+        context.conversationId,
+      );
+    }
     tools.slackUserLookup = createSlackUserLookupTool();
     tools.slackListCreate = createSlackListCreateTool(state);
     tools.slackListAddItems = createSlackListAddItemsTool(state);

--- a/packages/junior/src/db/schema/conversation-messages.ts
+++ b/packages/junior/src/db/schema/conversation-messages.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { index, jsonb, pgTable, primaryKey, text } from "drizzle-orm/pg-core";
 import { juniorConversations } from "./conversations";
 import { juniorIdentities } from "./identities";
@@ -30,6 +31,10 @@ export const juniorConversationMessages = pgTable(
     index("junior_conversation_messages_activity_idx").on(
       table.conversationId,
       table.createdAt,
+    ),
+    index("junior_conversation_messages_search_idx").using(
+      "gin",
+      sql`to_tsvector('english', ${table.text})`,
     ),
   ],
 );

--- a/packages/junior/tests/component/conversation-search.test.ts
+++ b/packages/junior/tests/component/conversation-search.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { migrateSchema } from "@/chat/conversations/sql/migrations";
+import type { ConversationMessageRole } from "@/chat/conversations/messages";
+import { createSqlConversationMessageStore } from "@/chat/conversations/sql/messages";
+import { createSqlConversationSearchStore } from "@/chat/conversations/sql/search";
+import { createSqlStore } from "@/chat/conversations/sql/store";
+import type { ConversationPrivacy } from "@/chat/conversation-privacy";
+import { createLocalJuniorSqlFixture } from "../fixtures/sql";
+
+describe("conversation search", () => {
+  it("returns only public user and assistant messages from the authorized workspace", async () => {
+    const fixture = await createLocalJuniorSqlFixture();
+
+    try {
+      await migrateSchema(fixture.sql);
+      const conversations = createSqlStore(fixture.sql);
+      const messages = createSqlConversationMessageStore(fixture.sql);
+      const search = createSqlConversationSearchStore(fixture.sql);
+
+      const seed = async (args: {
+        channelId: string;
+        conversationId: string;
+        message: string;
+        role?: ConversationMessageRole;
+        teamId?: string;
+        visibility: ConversationPrivacy;
+      }) => {
+        await conversations.recordActivity({
+          conversationId: args.conversationId,
+          destination: {
+            platform: "slack",
+            teamId: args.teamId ?? "T123",
+            channelId: args.channelId,
+          },
+          nowMs: 1_750_000_000_000,
+          source: "slack",
+          visibility: args.visibility,
+        });
+        await messages.record(args.conversationId, [
+          {
+            messageId: `${args.conversationId}:message`,
+            role: args.role ?? "user",
+            text: args.message,
+            createdAtMs: 1_750_000_000_000,
+          },
+        ]);
+      };
+
+      await seed({
+        channelId: "CREQUEST",
+        conversationId: "slack:CREQUEST:1700000000.100000",
+        message: "The current launch checklist thread must be excluded.",
+        visibility: "public",
+      });
+      await seed({
+        channelId: "CREQUEST",
+        conversationId: "slack:CREQUEST:1700000000.200000",
+        message: "The launch checklist needs a rollback owner.",
+        visibility: "public",
+      });
+      await seed({
+        channelId: "CARCHIVE",
+        conversationId: "slack:CARCHIVE:1700000000.300000",
+        message: "The launch checklist also needs a database backup step.",
+        role: "assistant",
+        visibility: "public",
+      });
+      await seed({
+        channelId: "CPRIVATE",
+        conversationId: "slack:CPRIVATE:1700000000.400000",
+        message: "A private launch checklist secret.",
+        visibility: "private",
+      });
+      await seed({
+        channelId: "COTHERWORKSPACE",
+        conversationId: "slack:COTHERWORKSPACE:1700000000.500000",
+        message: "Another workspace launch checklist secret.",
+        teamId: "TOTHER",
+        visibility: "public",
+      });
+      await seed({
+        channelId: "CSYSTEM",
+        conversationId: "slack:CSYSTEM:1700000000.600000",
+        message: "A system launch checklist instruction.",
+        role: "system",
+        visibility: "public",
+      });
+
+      const results = await search.search({
+        currentConversationId: "slack:CREQUEST:1700000000.100000",
+        limit: 10,
+        query: "launch checklist",
+        scope: {
+          kind: "public_provider_tenant",
+          provider: "slack",
+          providerTenantId: "T123",
+        },
+      });
+
+      expect(results).toHaveLength(2);
+      expect(results).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            conversationId: "slack:CREQUEST:1700000000.200000",
+            providerDestinationId: "CREQUEST",
+            role: "user",
+          }),
+          expect.objectContaining({
+            conversationId: "slack:CARCHIVE:1700000000.300000",
+            providerDestinationId: "CARCHIVE",
+            role: "assistant",
+          }),
+        ]),
+      );
+      expect(results.map((result) => result.excerpt).join(" ")).not.toMatch(
+        /private|system|other workspace/i,
+      );
+    } finally {
+      await fixture.close();
+    }
+  });
+});

--- a/packages/junior/tests/component/conversation-transcripts-sql.test.ts
+++ b/packages/junior/tests/component/conversation-transcripts-sql.test.ts
@@ -229,7 +229,7 @@ describe("conversation transcript SQL stores", () => {
       const [applied] = await fixture.sql.query<{ count: number }>(
         "SELECT count(*)::integer AS count FROM drizzle.__drizzle_junior_core",
       );
-      expect(applied?.count).toBe(2);
+      expect(applied?.count).toBe(3);
     } finally {
       await fixture.close();
     }

--- a/packages/junior/tests/integration/conversation-sql.test.ts
+++ b/packages/junior/tests/integration/conversation-sql.test.ts
@@ -70,6 +70,7 @@ ORDER BY indexname ASC
           "junior_conversations_origin_idx",
           "junior_conversations_pkey",
           "junior_conversations_actor_activity_idx",
+          "junior_conversation_messages_search_idx",
           "junior_destinations_pkey",
           "junior_destinations_provider_destination_uidx",
           "junior_identities_kind_provider_idx",
@@ -140,7 +141,7 @@ VALUES ('host-migration', 9999999999999)
         "SELECT count(*)::integer AS count FROM drizzle.__drizzle_junior_core",
       );
       expect(host?.count).toBe(1);
-      expect(core?.count).toBe(2);
+      expect(core?.count).toBe(3);
     } finally {
       await fixture.close();
     }
@@ -173,6 +174,9 @@ VALUES
   ('0005_conversation_transcripts', 'legacy-checksum-5')
 `);
         await fixture.sql.execute("DROP TABLE drizzle.__drizzle_junior_core");
+        await fixture.sql.execute(
+          "DROP INDEX junior_conversation_messages_search_idx",
+        );
         await fixture.sql.execute(`
 ALTER TABLE junior_conversations
   DROP COLUMN duration_ms,
@@ -189,7 +193,7 @@ ALTER TABLE junior_conversations
         const [journal] = await fixture.sql.query<{ count: number }>(
           "SELECT count(*)::integer AS count FROM drizzle.__drizzle_junior_core",
         );
-        expect(journal?.count).toBe(2);
+        expect(journal?.count).toBe(3);
       } finally {
         await second.close();
         await fixture.close();
@@ -257,7 +261,7 @@ WHERE conversation_id = $1
         "SELECT count(*)::integer AS count FROM drizzle.__drizzle_junior_core",
       );
 
-      expect(migrationRows?.count).toBe(2);
+      expect(migrationRows?.count).toBe(3);
       expect(rows).toHaveLength(1);
       expect(rows[0]).toMatchObject({
         conversation_id: "slack:C123:1718123456.000000",
@@ -303,6 +307,9 @@ VALUES
   ('0005_conversation_transcripts', 'legacy-checksum-5')
 `);
       await fixture.sql.execute("DROP SCHEMA drizzle CASCADE");
+      await fixture.sql.execute(
+        "DROP INDEX junior_conversation_messages_search_idx",
+      );
       await fixture.sql.execute(`
 ALTER TABLE junior_conversations
   DROP COLUMN duration_ms,
@@ -336,7 +343,7 @@ ORDER BY column_name
         "execution_usage_json",
         "usage_json",
       ]);
-      expect(migrationRows?.count).toBe(2);
+      expect(migrationRows?.count).toBe(3);
     } finally {
       await fixture.close();
     }
@@ -365,12 +372,18 @@ VALUES
   ('0006_conversation_metrics', 'legacy-checksum-6')
 `);
       await fixture.sql.execute("DROP SCHEMA drizzle CASCADE");
+      await fixture.sql.execute(
+        "DROP INDEX junior_conversation_messages_search_idx",
+      );
 
       await migrateSchema(fixture.sql);
 
       const [migrationRows] = await fixture.sql.query<{ count: number }>(
         "SELECT count(*)::integer AS count FROM drizzle.__drizzle_junior_core",
       );
+      const [searchIndex] = await fixture.sql.query<{ exists: boolean }>(`
+SELECT to_regclass('public.junior_conversation_messages_search_idx') IS NOT NULL AS exists
+`);
       const metricColumns = await fixture.sql.query<{ column_name: string }>(`
 SELECT column_name
 FROM information_schema.columns
@@ -384,7 +397,8 @@ WHERE table_schema = 'public'
   )
 ORDER BY column_name
 `);
-      expect(migrationRows?.count).toBe(1);
+      expect(migrationRows?.count).toBe(2);
+      expect(searchIndex?.exists).toBe(true);
       expect(metricColumns.map((row) => row.column_name)).toEqual([
         "duration_ms",
         "execution_duration_ms",

--- a/packages/junior/tests/integration/slack-conversation-search.test.ts
+++ b/packages/junior/tests/integration/slack-conversation-search.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ConversationSearchScope } from "@/chat/conversations/search";
+import { migrateSchema } from "@/chat/conversations/sql/migrations";
+import { createSqlConversationMessageStore } from "@/chat/conversations/sql/messages";
+import { createSqlConversationSearchStore } from "@/chat/conversations/sql/search";
+import { createSqlStore } from "@/chat/conversations/sql/store";
+import { createSlackConversationSearchTool } from "@/chat/slack/tools/conversation-search";
+import { createLocalJuniorSqlFixture } from "../fixtures/sql";
+
+const scope: ConversationSearchScope = {
+  kind: "public_provider_tenant",
+  provider: "slack",
+  providerTenantId: "T123",
+};
+
+async function executeTool<TInput>(tool: any, input: TInput) {
+  if (typeof tool?.execute !== "function") {
+    throw new Error("tool execute function missing");
+  }
+  return await tool.execute(input, {} as any);
+}
+
+describe("searchConversationHistory", () => {
+  it("searches the authorized public workspace and returns cross-channel permalinks", async () => {
+    const fixture = await createLocalJuniorSqlFixture();
+
+    try {
+      await migrateSchema(fixture.sql);
+      const conversations = createSqlStore(fixture.sql);
+      const messages = createSqlConversationMessageStore(fixture.sql);
+      const search = createSqlConversationSearchStore(fixture.sql);
+      await conversations.recordActivity({
+        conversationId: "slack:CARCHIVE:1700000000.100000",
+        destination: {
+          platform: "slack",
+          teamId: "T123",
+          channelId: "CARCHIVE",
+        },
+        nowMs: Date.parse("2026-07-01T12:00:00.000Z"),
+        source: "slack",
+        visibility: "public",
+      });
+      await messages.record("slack:CARCHIVE:1700000000.100000", [
+        {
+          messageId: "1700000000.100001",
+          role: "user",
+          text: "We decided the launch checklist needs a rollback owner.",
+          createdAtMs: Date.parse("2026-07-01T12:00:00.000Z"),
+        },
+      ]);
+      const getPermalink = vi.fn(async () =>
+        Promise.resolve(
+          "https://example.slack.com/archives/CARCHIVE/p1700000000100000",
+        ),
+      );
+      const tool = createSlackConversationSearchTool(
+        scope,
+        "slack:CREQUEST:1700000000.900000",
+        {
+          store: search,
+          getPermalink,
+        },
+      );
+
+      const result = await executeTool(tool, {
+        query: "launch checklist",
+        limit: null,
+      });
+
+      expect(getPermalink).toHaveBeenCalledWith({
+        channelId: "CARCHIVE",
+        messageTs: "1700000000.100000",
+      });
+      expect(result).toEqual({
+        ok: true,
+        status: "success",
+        query: "launch checklist",
+        count: 1,
+        threads: [
+          {
+            conversation_id: "slack:CARCHIVE:1700000000.100000",
+            thread_ts: "1700000000.100000",
+            message_id: "1700000000.100001",
+            message_role: "user",
+            message_timestamp: "2026-07-01T12:00:00.000Z",
+            excerpt: expect.stringContaining("rollback owner"),
+            permalink:
+              "https://example.slack.com/archives/CARCHIVE/p1700000000100000",
+          },
+        ],
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+});

--- a/packages/junior/tests/unit/slack/tool-registration.test.ts
+++ b/packages/junior/tests/unit/slack/tool-registration.test.ts
@@ -17,8 +17,12 @@ const noopEgress = {
 function ctx(): Extract<ToolRuntimeContext, { source: { platform: "local" } }>;
 function ctx(
   channelId: string,
+  sourceType?: "priv" | "pub",
 ): Extract<ToolRuntimeContext, { source: { platform: "slack" } }>;
-function ctx(channelId?: string): ToolRuntimeContext {
+function ctx(
+  channelId?: string,
+  sourceType?: "priv" | "pub",
+): ToolRuntimeContext {
   if (!channelId) {
     return {
       destination: {
@@ -32,6 +36,7 @@ function ctx(channelId?: string): ToolRuntimeContext {
   }
 
   return {
+    conversationId: `slack:${channelId}:1700000000.100000`,
     destination: {
       platform: "slack" as const,
       teamId: "T123",
@@ -40,8 +45,7 @@ function ctx(channelId?: string): ToolRuntimeContext {
     source: createSlackSource({
       teamId: "T123",
       channelId,
-
-      type: "priv",
+      type: sourceType ?? (channelId.startsWith("C") ? "pub" : "priv"),
     }),
     egress: noopEgress,
     sandbox: noopSandbox,
@@ -71,6 +75,7 @@ describe("Slack tool registration", () => {
     expect(tools).not.toHaveProperty("slackChannelListMessages");
     expect(tools).toHaveProperty("addReaction");
     expect(tools).toHaveProperty("slackCanvasCreate");
+    expect(tools).not.toHaveProperty("searchConversationHistory");
   });
 
   it("registers channel-scope tools in shared channel context", () => {
@@ -81,6 +86,13 @@ describe("Slack tool registration", () => {
     expect(tools).toHaveProperty("slackChannelListMessages");
     expect(tools).toHaveProperty("addReaction");
     expect(tools).toHaveProperty("slackCanvasCreate");
+    expect(tools).toHaveProperty("searchConversationHistory");
+  });
+
+  it("does not register conversation search for a source-confirmed private C channel", () => {
+    const tools = createTools([], {}, ctx("C12345", "priv"));
+
+    expect(tools).not.toHaveProperty("searchConversationHistory");
   });
 
   it("registers tools when runtime channel ids are Junior Slack references", () => {

--- a/packages/junior/tests/unit/slack/tool-registration.test.ts
+++ b/packages/junior/tests/unit/slack/tool-registration.test.ts
@@ -87,6 +87,10 @@ describe("Slack tool registration", () => {
     expect(tools).toHaveProperty("addReaction");
     expect(tools).toHaveProperty("slackCanvasCreate");
     expect(tools).toHaveProperty("searchConversationHistory");
+    expect(tools.searchConversationHistory?.exposure).toBe("deferred");
+    expect(tools.searchConversationHistory?.source?.id).toBe(
+      "conversation-history",
+    );
   });
 
   it("does not register conversation search for a source-confirmed private C channel", () => {

--- a/specs/conversation-storage.md
+++ b/specs/conversation-storage.md
@@ -3,7 +3,7 @@
 ## Metadata
 
 - Created: 2026-06-11
-- Last Edited: 2026-07-11
+- Last Edited: 2026-07-12
 
 ## Purpose
 
@@ -109,6 +109,9 @@ The feature ports are:
   reads (children excluded).
 - `ConversationMessageStore` — record and read visible messages; set the
   `replied_at` delivery mark.
+- `ConversationSearchStore` — search retained public visible messages within
+  one runtime-authorized provider tenant, excluding the active conversation;
+  results are bounded to one relevant excerpt per prior conversation.
 - `AgentStepStore` — append agent steps under the conversation lease, read a
   conversation's steps in `seq` order, and read the current context-epoch Pi
   projection.
@@ -185,6 +188,11 @@ conversation key and `message_id` is the source-scoped message identity (Slack
 - Reply policy, channel-context assembly, and reporting read visible messages
   through `ConversationMessageStore`; no transcript data is read from
   `thread-state`.
+- Model-facing prior-conversation search reads only visible messages through
+  `ConversationSearchStore`. It uses PostgreSQL full-text search, accepts one
+  runtime-derived public provider-tenant scope instead of caller-supplied
+  destination selectors, requires persisted public visibility, searches only
+  user and assistant roles, and never searches raw agent-step/tool payloads.
 
 ### Agent Step History
 

--- a/specs/data-redaction-policy.md
+++ b/specs/data-redaction-policy.md
@@ -80,11 +80,15 @@ are an exposure surface governed by the same visibility classification.
 
 - A conversation's transcript is always readable from that conversation's own
   context.
-- Cross-conversation reads require persisted destination visibility of
-  `public` and the same provider tenant (Slack workspace) as the requesting
-  context.
-- Conversations with missing destinations or non-public visibility are not
-  readable across contexts.
+- Cross-conversation search is available only from a source-confirmed public
+  Slack context. It may read conversations with persisted `public` visibility
+  in the same provider tenant (Slack workspace), including other public
+  channels in that workspace.
+- Private channels, group DMs, and DMs cannot read other conversations,
+  including earlier threads in the same destination. Their current
+  conversation remains readable from its own context.
+- Conversations with missing destinations, missing/unknown visibility, or
+  non-public visibility are not readable across contexts.
 - Local and Slack contexts must not read each other's transcripts.
 
 ## Dashboard Reporting
@@ -161,8 +165,8 @@ aged out. They are distinct and must present distinctly.
 - Unknown conversation ids are treated as private.
 - Conversations Slack reports as private (`channel_type: group` or
   `is_private: true`) are classified private regardless of a `C` id prefix.
-- Cross-context transcript reads are denied unless the destination has
-  persisted public visibility.
+- Cross-context transcript reads are denied unless both the requesting source
+  and stored destination are public and belong to the same provider tenant.
 
 ## Related Specs
 


### PR DESCRIPTION
Junior can now search retained public conversation transcripts across public channels in the active Slack workspace when users refer to an earlier discussion. Results return one bounded relevant excerpt per prior thread with timestamps and Slack permalinks.

The tool is exposed only from source-confirmed public contexts, and SQL independently requires persisted-public target visibility and a matching workspace. Private channels and DMs remain isolated. PostgreSQL full-text search backs lexical retrieval while respecting message roles and retention purges.

Fixes #688