### PR TITLE
feat(dashboard): Add profile menu to header

### DIFF
--- a/packages/junior-dashboard/e2e/dashboard.spec.ts
+++ b/packages/junior-dashboard/e2e/dashboard.spec.ts
@@ -46,7 +46,25 @@ async function writeResponse(res: ServerResponse, response: Response) {
 
 test.beforeAll(async () => {
   const app = createDashboardApp({
-    authRequired: false,
+    allowedEmails: ["dashboard-user@sentry.io"],
+    auth: {
+      async getSession() {
+        return {
+          user: {
+            email: "dashboard-user@sentry.io",
+            emailVerified: true,
+            hostedDomain: "sentry.io",
+            name: "Dashboard User",
+          },
+        };
+      },
+      async handler() {
+        return Response.json({ ok: true });
+      },
+      async signInWithGoogle() {
+        return Response.redirect("https://accounts.google.com", 302);
+      },
+    },
     mockConversations: true,
   });
 
@@ -113,6 +131,39 @@ test("hydrates the built dashboard client in a real browser", async ({
   ).toBeVisible();
   await expect(page.getByText("0ms runtime")).toHaveCount(0);
   expect(browserErrors).toEqual([]);
+});
+
+test("groups the signed-in profile and session actions in the header", async ({
+  page,
+}) => {
+  await page.goto(baseURL);
+
+  const trigger = page.getByRole("button", {
+    name: "Open profile menu for Dashboard User",
+  });
+  await expect(trigger).toBeVisible();
+  await expect(trigger).toHaveAttribute("aria-expanded", "false");
+  await trigger.click();
+
+  const popover = page.locator("#profile-popover");
+  await expect(popover.getByText("dashboard-user@sentry.io")).toBeVisible();
+  await expect(
+    popover.getByRole("link", { name: "My profile" }),
+  ).toHaveAttribute("href", "/people/dashboard-user%40sentry.io");
+  await expect(popover.getByRole("button", { name: "Log out" })).toBeVisible();
+
+  await page.keyboard.press("Escape");
+  await expect(popover).toHaveCount(0);
+  await expect(trigger).toBeFocused();
+
+  await trigger.click();
+  const signOutRequest = page.waitForRequest(
+    (request) =>
+      request.url().endsWith("/api/auth/sign-out") &&
+      request.method() === "POST",
+  );
+  await page.getByRole("button", { name: "Log out" }).click();
+  await signOutRequest;
 });
 
 test("inspects and copies an advisor transcript", async ({ context, page }) => {

--- a/packages/junior-dashboard/src/client/App.tsx
+++ b/packages/junior-dashboard/src/client/App.tsx
@@ -1,10 +1,9 @@
-import { LogOut } from "lucide-react";
 import type { ReactElement } from "react";
 import { Link, Navigate, NavLink, Route, Routes } from "react-router";
 
 import { useDashboardCoreData, useDashboardData } from "./api";
-import { Button } from "./components/Button";
 import { LoadingView } from "./components/LoadingView";
+import { ProfileMenu } from "./components/ProfileMenu";
 import { setDashboardTimeZone } from "./format";
 import { CommandCenter } from "./pages/CommandCenter";
 import { ConversationPage } from "./pages/ConversationPage";
@@ -43,7 +42,7 @@ export function DashboardShell() {
   return (
     <main className="grid min-h-screen grid-rows-[auto_1fr] bg-black font-sans text-white">
       <header className="sticky top-0 z-10 border-b border-white/10 bg-[#050505]/95 backdrop-blur">
-        <div className="mx-auto grid w-full max-w-screen-xl grid-cols-[minmax(0,1fr)_auto] items-center gap-4 px-4 py-3 md:px-8 max-md:grid-cols-1">
+        <div className="mx-auto grid w-full max-w-screen-xl grid-cols-[minmax(0,1fr)_auto] items-center gap-x-4 gap-y-2 px-4 py-3 md:grid-cols-[auto_minmax(0,1fr)_auto] md:px-8">
           <Link
             className="flex min-w-0 max-w-full justify-self-start text-inherit no-underline"
             to="/"
@@ -54,32 +53,25 @@ export function DashboardShell() {
               </h1>
             </div>
           </Link>
-          <div className="flex min-w-0 items-center gap-x-6 gap-y-2 max-md:flex-wrap max-md:justify-between">
-            <nav className="flex min-w-0 items-center gap-5">
-              <NavLink className={navLinkClass} end to="/">
-                Command
-              </NavLink>
-              <NavLink className={navLinkClass} to="/conversations">
-                Conversations
-              </NavLink>
-              <NavLink className={navLinkClass} to="/people">
-                People
-              </NavLink>
-              <NavLink className={navLinkClass} to="/plugins">
-                Plugins
-              </NavLink>
-            </nav>
-            {loggedIn ? (
-              <Button
-                aria-label="Log out"
-                onClick={() => void signOut()}
-                size="icon"
-                title="Log out"
-              >
-                <LogOut aria-hidden="true" size={16} strokeWidth={2} />
-              </Button>
-            ) : null}
-          </div>
+          <nav className="col-span-2 row-start-2 flex min-w-0 items-center gap-5 overflow-x-auto md:col-span-1 md:col-start-2 md:row-start-1 md:justify-self-end md:overflow-visible">
+            <NavLink className={navLinkClass} end to="/">
+              Command
+            </NavLink>
+            <NavLink className={navLinkClass} to="/conversations">
+              Conversations
+            </NavLink>
+            <NavLink className={navLinkClass} to="/people">
+              People
+            </NavLink>
+            <NavLink className={navLinkClass} to="/plugins">
+              Plugins
+            </NavLink>
+          </nav>
+          {loggedIn ? (
+            <div className="col-start-2 row-start-1 justify-self-end md:col-start-3">
+              <ProfileMenu identity={data!.me} onSignOut={signOut} />
+            </div>
+          ) : null}
         </div>
       </header>
 

--- a/packages/junior-dashboard/src/client/components/ProfileMenu.tsx
+++ b/packages/junior-dashboard/src/client/components/ProfileMenu.tsx
@@ -2,6 +2,7 @@ import { ChevronDown, LogOut, UserRound } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router";
 
+import { peoplePath } from "../format";
 import { cn } from "../styles";
 import type { Identity } from "../types";
 
@@ -101,7 +102,7 @@ export function ProfileMenu({ identity, onSignOut }: ProfileMenuProps) {
           <Link
             className="mt-1 flex items-center gap-2.5 px-2.5 py-2 text-[0.82rem] font-semibold text-[#d6d6d6] no-underline transition-colors hover:bg-white/10 hover:text-white focus-visible:bg-white/10 focus-visible:text-white focus-visible:outline-none"
             onClick={() => setOpen(false)}
-            to={`/people/${encodeURIComponent(email)}`}
+            to={peoplePath(email)}
           >
             <UserRound aria-hidden="true" size={16} strokeWidth={2} />
             My profile

--- a/packages/junior-dashboard/src/client/components/ProfileMenu.tsx
+++ b/packages/junior-dashboard/src/client/components/ProfileMenu.tsx
@@ -1,0 +1,124 @@
+import { ChevronDown, LogOut, UserRound } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Link } from "react-router";
+
+import { cn } from "../styles";
+import type { Identity } from "../types";
+
+type ProfileMenuProps = {
+  identity: Identity;
+  onSignOut(): Promise<void>;
+};
+
+function initials(name: string | null | undefined, email: string): string {
+  const words = name?.trim().split(/\s+/).filter(Boolean) ?? [];
+  if (words.length > 0) {
+    return words
+      .slice(0, 2)
+      .map((word) => word[0])
+      .join("")
+      .toUpperCase();
+  }
+  return email.slice(0, 1).toUpperCase();
+}
+
+/** Group the signed-in identity, personal profile, and session actions. */
+export function ProfileMenu({ identity, onSignOut }: ProfileMenuProps) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const email = identity.user.email!;
+  const name = identity.user.name?.trim() || email;
+
+  useEffect(() => {
+    if (!open) return;
+
+    function closeOnOutsideClick(event: PointerEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+
+    function closeOnEscape(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    }
+
+    document.addEventListener("pointerdown", closeOnOutsideClick);
+    document.addEventListener("keydown", closeOnEscape);
+    return () => {
+      document.removeEventListener("pointerdown", closeOnOutsideClick);
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [open]);
+
+  return (
+    <div className="relative" ref={rootRef}>
+      <button
+        aria-controls="profile-popover"
+        aria-expanded={open}
+        aria-label={`Open profile menu for ${name}`}
+        className={cn(
+          "flex h-9 cursor-pointer items-center gap-2 border border-white/15 bg-[#0b0b0b] px-1.5 text-[#d6d6d6] transition-colors hover:border-white/30 hover:bg-[#151515] hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#beaaff]/70",
+          open && "border-white/30 bg-[#151515] text-white",
+        )}
+        onClick={() => setOpen((value) => !value)}
+        ref={triggerRef}
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          className="grid size-6 place-items-center rounded-full bg-[#beaaff] text-[0.68rem] font-bold tracking-wide text-black"
+        >
+          {initials(identity.user.name, email)}
+        </span>
+        <span className="max-w-32 truncate text-[0.8rem] font-semibold max-sm:hidden">
+          {identity.user.name?.trim() || "My profile"}
+        </span>
+        <ChevronDown
+          aria-hidden="true"
+          className={cn("transition-transform", open && "rotate-180")}
+          size={14}
+          strokeWidth={2}
+        />
+      </button>
+
+      {open ? (
+        <div
+          className="absolute right-0 top-[calc(100%+0.5rem)] z-20 w-64 border border-white/15 bg-[#0b0b0b] p-1.5 shadow-2xl shadow-black/60"
+          id="profile-popover"
+        >
+          <div className="border-b border-white/10 px-2.5 py-2.5">
+            <p className="m-0 truncate text-sm font-semibold text-white">
+              {name}
+            </p>
+            {name !== email ? (
+              <p className="mt-1 mb-0 truncate text-xs text-[#888]">{email}</p>
+            ) : null}
+          </div>
+          <Link
+            className="mt-1 flex items-center gap-2.5 px-2.5 py-2 text-[0.82rem] font-semibold text-[#d6d6d6] no-underline transition-colors hover:bg-white/10 hover:text-white focus-visible:bg-white/10 focus-visible:text-white focus-visible:outline-none"
+            onClick={() => setOpen(false)}
+            to={`/people/${encodeURIComponent(email)}`}
+          >
+            <UserRound aria-hidden="true" size={16} strokeWidth={2} />
+            My profile
+          </Link>
+          <button
+            className="flex w-full cursor-pointer items-center gap-2.5 border-0 bg-transparent px-2.5 py-2 text-left text-[0.82rem] font-semibold text-[#d6d6d6] transition-colors hover:bg-white/10 hover:text-white focus-visible:bg-white/10 focus-visible:text-white focus-visible:outline-none"
+            onClick={() => {
+              setOpen(false);
+              void onSignOut();
+            }}
+            type="button"
+          >
+            <LogOut aria-hidden="true" size={16} strokeWidth={2} />
+            Log out
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
The dashboard header now presents the signed-in identity through a responsive avatar popover with a direct personal profile link and logout action, replacing the standalone logout icon. Product navigation stays on one row at desktop widths and moves to a dedicated row on smaller screens.

The popover keeps native link and button semantics, closes on outside click or Escape, and restores focus to its trigger. Authenticated browser coverage exercises the profile destination and sign-out request.
