### PR TITLE
fix(dashboard): Expand model handoff messages

### DIFF
--- a/packages/junior-dashboard/src/client/components/TranscriptContextEventView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptContextEventView.tsx
@@ -23,8 +23,83 @@ export function TranscriptContextEventView(props: {
   timestamp?: number;
 }) {
   const event = props.part.event;
-  const handoff = event.type === "model_handoff";
-  const summary = event.summary;
+  if (event.type === "model_handoff") {
+    return <ModelHandoffView event={event} timestamp={props.timestamp} />;
+  }
+  return <ContextCompactedView event={event} timestamp={props.timestamp} />;
+}
+
+function ModelHandoffView(props: {
+  event: Extract<
+    TranscriptViewContextEventPart["event"],
+    { type: "model_handoff" }
+  >;
+  timestamp?: number;
+}) {
+  const { active: searchActive } = useTranscriptSearch();
+  const header = (
+    <>
+      <div
+        aria-hidden="true"
+        className="grid size-8 place-items-center rounded-md border border-[#beaaff]/25 bg-[#beaaff]/10 text-violet-200"
+      >
+        <Send size={15} />
+      </div>
+      <div className="min-w-0">
+        <div className="flex min-w-0 flex-wrap items-center justify-between gap-x-3 gap-y-1">
+          <strong className="text-[0.88rem] font-bold text-[#e8e3f8]">
+            Model handoff
+          </strong>
+          {typeof props.timestamp === "number" ? (
+            <span className="text-[0.76rem] text-[#777]">
+              {formatMessageTimestamp(props.timestamp)}
+            </span>
+          ) : null}
+        </div>
+        <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-2 text-[0.8rem] text-[#888]">
+          {props.event.fromModelId ? (
+            <ModelLabel modelId={props.event.fromModelId} />
+          ) : (
+            <span>Previous model</span>
+          )}
+          <ArrowRight aria-hidden="true" size={13} />
+          <ModelLabel modelId={props.event.toModelId} />
+        </div>
+      </div>
+    </>
+  );
+  const className =
+    "min-w-0 border-y border-[#beaaff]/15 bg-[#beaaff]/[0.045] first:mt-1";
+
+  if (!props.event.message) {
+    return (
+      <article
+        className={`${className} grid grid-cols-[2rem_minmax(0,1fr)] gap-3 px-3 py-3`}
+      >
+        {header}
+      </article>
+    );
+  }
+
+  return (
+    <details className={className} open={searchActive || undefined}>
+      <summary className="grid cursor-pointer list-none grid-cols-[2rem_minmax(0,1fr)] gap-3 px-3 py-3 transition-colors hover:bg-white/[0.025] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[#beaaff]/55 [&::-webkit-details-marker]:hidden">
+        {header}
+      </summary>
+      <pre className="min-w-0 whitespace-pre-wrap break-words border-t border-[#beaaff]/15 px-3 py-3 font-mono text-[0.82rem] leading-relaxed text-[#c8c8c8]">
+        <HighlightText text={props.event.message} />
+      </pre>
+    </details>
+  );
+}
+
+function ContextCompactedView(props: {
+  event: Extract<
+    TranscriptViewContextEventPart["event"],
+    { type: "context_compacted" }
+  >;
+  timestamp?: number;
+}) {
   const { active: searchActive } = useTranscriptSearch();
 
   return (
@@ -33,12 +108,12 @@ export function TranscriptContextEventView(props: {
         aria-hidden="true"
         className="grid size-8 place-items-center rounded-md border border-[#beaaff]/25 bg-[#beaaff]/10 text-violet-200"
       >
-        {handoff ? <Send size={15} /> : <Minimize2 size={15} />}
+        <Minimize2 size={15} />
       </div>
       <div className="min-w-0">
         <div className="flex min-w-0 flex-wrap items-center justify-between gap-x-3 gap-y-1">
           <strong className="text-[0.88rem] font-bold text-[#e8e3f8]">
-            {handoff ? "Model handoff" : "Context compacted"}
+            Context compacted
           </strong>
           {typeof props.timestamp === "number" ? (
             <span className="text-[0.76rem] text-[#777]">
@@ -47,19 +122,9 @@ export function TranscriptContextEventView(props: {
           ) : null}
         </div>
 
-        {handoff ? (
-          <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-2 text-[0.8rem] text-[#888]">
-            {event.fromModelId ? (
-              <ModelLabel modelId={event.fromModelId} />
-            ) : (
-              <span>Previous model</span>
-            )}
-            <ArrowRight aria-hidden="true" size={13} />
-            <ModelLabel modelId={event.toModelId} />
-          </div>
-        ) : event.modelId ? (
+        {props.event.modelId ? (
           <div className="mt-1.5 text-[0.8rem] text-[#888]">
-            Continuing with <ModelLabel modelId={event.modelId} />
+            Continuing with <ModelLabel modelId={props.event.modelId} />
           </div>
         ) : (
           <div className="mt-1.5 text-[0.8rem] text-[#888]">
@@ -67,7 +132,7 @@ export function TranscriptContextEventView(props: {
           </div>
         )}
 
-        {summary ? (
+        {props.event.summary ? (
           <details
             className="mt-2 text-[0.82rem] leading-relaxed text-[#b8b8b8]"
             open={searchActive || undefined}
@@ -77,9 +142,9 @@ export function TranscriptContextEventView(props: {
             </summary>
             <div className="mt-2 border-l-2 border-[#beaaff]/25 pl-3 text-[#c8c8c8]">
               {searchActive ? (
-                <HighlightText text={summary} />
+                <HighlightText text={props.event.summary} />
               ) : (
-                <TranscriptMarkdown text={summary} />
+                <TranscriptMarkdown text={props.event.summary} />
               )}
             </div>
           </details>

--- a/packages/junior-dashboard/src/client/components/transcriptRenderModel.ts
+++ b/packages/junior-dashboard/src/client/components/transcriptRenderModel.ts
@@ -296,7 +296,7 @@ export function messageRawText(message: TranscriptViewMessage): string {
       if (part.type === "context_event") {
         const event = part.event;
         return event.type === "model_handoff"
-          ? ["model handoff", event.fromModelId, event.toModelId, event.summary]
+          ? ["model handoff", event.fromModelId, event.toModelId, event.message]
               .filter(isString)
               .join("\n")
           : ["context compacted", event.modelId, event.summary]

--- a/packages/junior-dashboard/src/client/components/transcriptSearch.tsx
+++ b/packages/junior-dashboard/src/client/components/transcriptSearch.tsx
@@ -163,7 +163,7 @@ export function entryMatchesSearch(
       ? textContains("model handoff", normalizedQuery) ||
           textContains(event.fromModelId, normalizedQuery) ||
           textContains(event.toModelId, normalizedQuery) ||
-          textContains(event.summary, normalizedQuery)
+          textContains(event.message, normalizedQuery)
       : textContains("context compacted", normalizedQuery) ||
           textContains(event.modelId, normalizedQuery) ||
           textContains(event.summary, normalizedQuery);

--- a/packages/junior-dashboard/src/client/markdownExport.ts
+++ b/packages/junior-dashboard/src/client/markdownExport.ts
@@ -194,7 +194,8 @@ function appendContextEvent(
   } else {
     addMetaLine(lines, "Model", event.modelId);
   }
-  if (event.summary) lines.push("", event.summary);
+  const body = event.type === "model_handoff" ? event.message : event.summary;
+  if (body) lines.push("", body);
 }
 
 function appendMessage(

--- a/packages/junior-dashboard/src/mock-release-conversation.ts
+++ b/packages/junior-dashboard/src/mock-release-conversation.ts
@@ -580,8 +580,8 @@ export function longReleaseConversation(
         createdAt: iso(Date.parse(secondStartedAt), 129_000),
         fromModelId: "openai/gpt-5.4",
         toModelId: "openai/gpt-5.6-sol",
-        summary:
-          "Finish the self-update change after the build failed only because CACHE_URL is unavailable in the sandbox. Check and typecheck passed; commit package.json and pnpm-lock.yaml, push the branch, and open a draft PR that records the build limitation.",
+        message:
+          "Model handoff checkpoint. Continue the outstanding request now using this summary as the complete prior context:\nFinish the self-update change after the build failed only because CACHE_URL is unavailable in the sandbox. Check and typecheck passed; commit package.json and pnpm-lock.yaml, push the branch, and open a draft PR that records the build limitation.",
         transcriptIndex: handoffTranscriptIndex,
       },
     ],

--- a/packages/junior-dashboard/tests/markdownExport.test.ts
+++ b/packages/junior-dashboard/tests/markdownExport.test.ts
@@ -80,7 +80,7 @@ describe("dashboard markdown export", () => {
           createdAt: "2026-01-01T00:00:04.000Z",
           fromModelId: "openai/gpt-5.4",
           toModelId: "openai/gpt-5.6-sol",
-          summary: "Continue with the implementation evidence.",
+          message: "Continue with the implementation evidence.",
           transcriptIndex: 3,
         },
       ],

--- a/packages/junior-dashboard/tests/transcriptContextEvent.test.tsx
+++ b/packages/junior-dashboard/tests/transcriptContextEvent.test.tsx
@@ -40,7 +40,7 @@ describe("transcript context events", () => {
     expect(html).toContain("Earlier release checks passed.");
   });
 
-  it("renders a model handoff with source, destination, and markdown summary", () => {
+  it("renders a model handoff as an expandable raw user message", () => {
     const html = renderToStaticMarkup(
       withQueryClient(
         <TranscriptContextEventView
@@ -51,7 +51,8 @@ describe("transcript context events", () => {
               createdAt: "2026-01-01T00:00:04.000Z",
               fromModelId: "openai/gpt-5.4",
               toModelId: "openai/gpt-5.6-sol",
-              summary: "**Next:** Continue with the migration fix.",
+              message:
+                "Model handoff checkpoint. Continue the outstanding request now using this summary as the complete prior context:\n**Next:** Continue with the migration fix.",
               transcriptIndex: 0,
             },
           }}
@@ -62,8 +63,9 @@ describe("transcript context events", () => {
     expect(html).toContain("Model handoff");
     expect(html).toContain("gpt-5.4");
     expect(html).toContain("gpt-5.6-sol");
+    expect(html).toContain("<details");
     expect(html).toContain("**Next:**");
-    expect(html).toContain("Next:");
+    expect(html).not.toContain("<strong>Next:</strong>");
     expect(html).toContain("Continue with the migration fix.");
   });
 

--- a/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
+++ b/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
@@ -297,7 +297,7 @@ describe("transcript render model", () => {
           createdAt: "2026-01-01T00:00:04.000Z",
           fromModelId: "openai/gpt-5.4",
           toModelId: "openai/gpt-5.6-sol",
-          summary: "Continue with the coding fix.",
+          message: "Continue with the coding fix.",
           transcriptIndex: 2,
         },
       ],

--- a/packages/junior/src/api/conversations/detail-projection.ts
+++ b/packages/junior/src/api/conversations/detail-projection.ts
@@ -143,13 +143,15 @@ function historyContent(args: {
             ])
           : -1;
     const summary =
-      replacementSummaryIndex >= 0
+      marker?.entry.reason === "compaction" && replacementSummaryIndex >= 0
         ? summaryAfterPrefix(
             projected[replacementSummaryIndex]!,
-            marker?.entry.reason === "handoff"
-              ? [MODEL_HANDOFF_SUMMARY_PREFIX]
-              : COMPACTION_SUMMARY_PREFIXES,
+            COMPACTION_SUMMARY_PREFIXES,
           )
+        : undefined;
+    const handoffMessage =
+      marker?.entry.reason === "handoff" && replacementSummaryIndex >= 0
+        ? messageText(projected[replacementSummaryIndex]!) || undefined
         : undefined;
 
     if (marker?.entry.reason === "compaction") {
@@ -166,7 +168,9 @@ function historyContent(args: {
         createdAt: new Date(marker.createdAtMs).toISOString(),
         ...(previousModelId ? { fromModelId: previousModelId } : {}),
         toModelId: marker.entry.modelId,
-        ...(args.canExposePayload && summary ? { summary } : {}),
+        ...(args.canExposePayload && handoffMessage
+          ? { message: handoffMessage }
+          : {}),
         transcriptIndex: messages.length,
       });
     }

--- a/packages/junior/src/api/conversations/schema.ts
+++ b/packages/junior/src/api/conversations/schema.ts
@@ -158,7 +158,7 @@ export const conversationContextEventSchema = z.discriminatedUnion("type", [
       type: z.literal("model_handoff"),
       createdAt: z.string(),
       fromModelId: z.string().optional(),
-      summary: z.string().optional(),
+      message: z.string().optional(),
       toModelId: z.string(),
       transcriptIndex: z.number().int().nonnegative(),
     })

--- a/packages/junior/tests/integration/dashboard-reporting.test.ts
+++ b/packages/junior/tests/integration/dashboard-reporting.test.ts
@@ -1619,8 +1619,8 @@ describe("dashboard reporting", () => {
         type: "model_handoff",
         fromModelId: "openai/gpt-5.4",
         toModelId: "openai/gpt-5.6-sol",
-        summary:
-          "The release migration fails because its constraint is created too late.",
+        message:
+          "Model handoff checkpoint. Continue the outstanding request now using this summary as the complete prior context:\nThe release migration fails because its constraint is created too late.",
       }),
     ]);
     expect(JSON.stringify(report.transcript)).toContain(
@@ -1805,7 +1805,8 @@ describe("dashboard reporting", () => {
         type: "model_handoff",
         fromModelId: "openai/gpt-5.4",
         toModelId: "openai/gpt-5.6-sol",
-        summary: "Implement the prepared release plan.",
+        message:
+          "Model handoff checkpoint. Continue the outstanding request now using this summary as the complete prior context:\nImplement the prepared release plan.",
       }),
     ]);
     expect(report.contextEvents?.[0]?.transcriptIndex).toBeLessThanOrEqual(


### PR DESCRIPTION
Model handoff events now behave like other transcript disclosures: clicking the handoff row expands the exact synthetic user message sent to the target model. The expanded payload is shown as plain pre-wrapped text instead of a separately rendered markdown summary.

The conversation detail contract now exposes this payload as `message` for `model_handoff` events while retaining `summary` for `context_compacted` events. Conversations whose payloads cannot be exposed continue to show the model transition without expandable message content.