### PR TITLE
feat(dashboard): Move model details into transcript header

### DIFF
--- a/packages/junior-dashboard/src/client/components/ConversationTranscript.tsx
+++ b/packages/junior-dashboard/src/client/components/ConversationTranscript.tsx
@@ -31,6 +31,7 @@ import type {
   TranscriptViewPart,
   TranscriptViewSubagentPart,
 } from "../types";
+import { ExecutionSignature } from "./ExecutionSignature";
 import { StatusBadge } from "./StatusBadge";
 import { ToolFrame, toolFrameClass } from "./ToolFrame";
 import {
@@ -617,6 +618,18 @@ function transcriptMeta(
   const toolSummary = summarizeToolCalls(conversation);
   const messageSummary = transcriptMessageSummary(conversation);
   const items: Array<MetricListItem | undefined> = [
+    conversation.modelId || conversation.reasoningLevel
+      ? {
+          content: (
+            <ExecutionSignature
+              className="text-violet-200"
+              modelId={conversation.modelId}
+              reasoningLevel={conversation.reasoningLevel}
+            />
+          ),
+          key: "execution",
+        }
+      : undefined,
     duration !== "none"
       ? {
           content: (

--- a/packages/junior-dashboard/src/client/components/ExecutionSignature.tsx
+++ b/packages/junior-dashboard/src/client/components/ExecutionSignature.tsx
@@ -19,7 +19,7 @@ export function ExecutionSignature(props: {
           : `Execution reasoning: ${reasoningLevel}`
       }
       className={cn(
-        "font-mono text-[0.76rem] leading-snug text-[#aaa]",
+        "break-all font-mono text-[0.76rem] leading-snug text-[#aaa]",
         props.className,
       )}
       title={modelId}

--- a/packages/junior-dashboard/src/client/components/Transcript.tsx
+++ b/packages/junior-dashboard/src/client/components/Transcript.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { ArrowDownToLine, Search } from "lucide-react";
 
 import type {
@@ -15,10 +15,7 @@ import {
 } from "./transcriptBottomPinning";
 import type { TranscriptViewMode } from "./transcriptRenderModel";
 import { transcriptEmptyClass } from "./transcriptStyles";
-import {
-  TranscriptSearchProvider,
-  conversationHasMatch,
-} from "./transcriptSearch";
+import { TranscriptSearchProvider } from "./transcriptSearch";
 
 /** Render one conversation transcript as ordered message and tool events. */
 export function Transcript(props: {
@@ -33,22 +30,11 @@ export function Transcript(props: {
   const [view, setView] = useState<TranscriptViewMode>("rich");
   const [search, setSearch] = useState("");
 
-  const normalizedSearch = search.trim().toLowerCase();
   const redacted = Boolean(props.transcript?.transcriptRedacted);
   const bottomPinning = usePinnedTranscriptBottom({
     enabled: props.live ?? false,
     version: transcriptBottomVersion(props.transcript),
   });
-
-  const visibleTurn = useMemo(
-    () =>
-      normalizedSearch && props.transcript
-        ? conversationHasMatch(props.transcript, normalizedSearch)
-          ? props.transcript
-          : undefined
-        : props.transcript,
-    [props.transcript, normalizedSearch],
-  );
 
   if (!props.transcript) {
     return (
@@ -86,17 +72,11 @@ export function Transcript(props: {
             onChange={(event) => setSearch(event.currentTarget.value)}
           />
         </div>
-        {visibleTurn ? (
-          <ConversationTranscriptView
-            onOpenSubagentTranscript={props.onOpenSubagentTranscript}
-            conversation={visibleTurn}
-            view={view}
-          />
-        ) : normalizedSearch ? (
-          <div className={transcriptEmptyClass()}>
-            No events match your search.
-          </div>
-        ) : null}
+        <ConversationTranscriptView
+          onOpenSubagentTranscript={props.onOpenSubagentTranscript}
+          conversation={props.transcript}
+          view={view}
+        />
         <div
           aria-hidden="true"
           className="h-px"

--- a/packages/junior-dashboard/src/client/components/transcriptSearch.tsx
+++ b/packages/junior-dashboard/src/client/components/transcriptSearch.tsx
@@ -2,10 +2,7 @@ import { type ReactNode, createContext, useContext } from "react";
 import type { DecorationItem } from "shiki/bundle/web";
 
 import { stringifyPartValue } from "../format";
-import { conversationTranscriptMessages } from "../transcriptActivity";
-import type { ConversationTranscript } from "../types";
 import {
-  groupTranscriptMessages,
   messageRawText,
   type RenderedTranscriptEntry,
 } from "./transcriptRenderModel";
@@ -170,17 +167,6 @@ export function entryMatchesSearch(
   }
 
   return false;
-}
-
-/** Returns true if the conversation has at least one entry matching the normalised query. */
-export function conversationHasMatch(
-  conversation: ConversationTranscript,
-  normalizedQuery: string,
-): boolean {
-  if (!normalizedQuery) return true;
-  return groupTranscriptMessages(
-    conversationTranscriptMessages(conversation),
-  ).some((entry) => entryMatchesSearch(entry, normalizedQuery));
 }
 
 function textContains(text: string | undefined, query: string): boolean {

--- a/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
@@ -6,7 +6,6 @@ import type { ConversationFeed } from "@sentry/junior/api/schema";
 import { useConversationData } from "../api";
 import { buildConversationMarkdown } from "../markdownExport";
 import { CopyMarkdownButton } from "../components/CopyMarkdownButton";
-import { ExecutionSignature } from "../components/ExecutionSignature";
 import { StatusBadge } from "../components/StatusBadge";
 import {
   buildConversations,
@@ -70,10 +69,6 @@ export function ConversationPage(props: {
                 {conversationDisplayTitle(conversation)}
               </h2>
               <StatusBadge status={visualStatus} />
-              <ExecutionSignature
-                modelId={conversationDetail?.modelId}
-                reasoningLevel={conversationDetail?.reasoningLevel}
-              />
             </div>
             <div className="mt-1 break-words text-[0.86rem] leading-snug text-[#b8b8b8]">
               <ConversationIdentity

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -1680,6 +1680,40 @@ describe("dashboard telemetry components", () => {
     expect(html).toContain(">deploy<");
   });
 
+  it("keeps execution settings visible when transcript search has no matches", () => {
+    const turn = {
+      conversationId: "conversation-1",
+      lastProgressAt: "2026-01-01T00:00:10.000Z",
+      lastSeenAt: "2026-01-01T00:00:10.000Z",
+      modelId: "openai/gpt-5.6-sol",
+      reasoningLevel: "high",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      status: "completed",
+      surface: "internal",
+      displayTitle: "Conversation",
+      transcript: [
+        {
+          role: "assistant",
+          parts: [{ type: "text", text: "A visible response" }],
+        },
+      ],
+      transcriptAvailable: true,
+    } as ConversationTranscript;
+
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={client}>
+        <TranscriptSearchProvider query="not-present">
+          <ConversationTranscriptView conversation={turn} view="rich" />
+        </TranscriptSearchProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(html).toContain("gpt-5.6-sol");
+    expect(html).toContain("(high)");
+    expect(html).toContain("No events match your search.");
+    expect(html).not.toContain("A visible response");
+  });
+
   it("consolidates mixed tool-and-thinking run at threshold behind a reveal", () => {
     // 2 tool calls + 2 thinking entries = 4 total = at threshold
     const turn = {

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -653,7 +653,7 @@ describe("dashboard telemetry components", () => {
     expect(html).not.toContain("tool call");
   });
 
-  it("shows the conversation model and thinking level in the detail header", () => {
+  it("shows the conversation model and thinking level in the transcript header", () => {
     const session = {
       conversationId: "conversation-1",
       cumulativeDurationMs: 0,
@@ -675,12 +675,17 @@ describe("dashboard telemetry components", () => {
     client.setQueryData(["conversation", "conversation-1"], detail);
 
     const html = renderConversationPage(dashboardData([session]));
+    const transcriptStart = html.indexOf('aria-label="Transcript view"');
+    const detailHeader = html.slice(0, transcriptStart);
+    const transcript = html.slice(transcriptStart);
 
-    expect(html).toContain(
+    expect(detailHeader).not.toContain("gpt-5.6-sol");
+    expect(transcript).toContain(
       'aria-label="Execution settings: openai/gpt-5.6-sol, high"',
     );
-    expect(html).toContain("gpt-5.6-sol");
-    expect(html).toContain("(high)");
+    expect(transcript).toContain("break-all font-mono");
+    expect(transcript).toContain("gpt-5.6-sol");
+    expect(transcript).toContain("(high)");
   });
 
   it("renders execution activity inside the transcript", () => {

--- a/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
+++ b/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
@@ -5,7 +5,7 @@ import {
   groupTranscriptMessages,
   groupTranscriptParts,
 } from "../src/client/components/transcriptRenderModel";
-import { conversationHasMatch } from "../src/client/components/transcriptSearch";
+import { entryMatchesSearch } from "../src/client/components/transcriptSearch";
 import { conversationTranscriptMessages } from "../src/client/transcriptActivity";
 import type { ConversationTranscript } from "../src/client/types";
 
@@ -328,8 +328,14 @@ describe("transcript render model", () => {
       "context",
       "message",
     ]);
-    expect(conversationHasMatch(turn, "gpt-5.6-sol")).toBe(true);
-    expect(conversationHasMatch(turn, "earlier investigation")).toBe(true);
+    expect(
+      entries.some((entry) => entryMatchesSearch(entry, "gpt-5.6-sol")),
+    ).toBe(true);
+    expect(
+      entries.some((entry) =>
+        entryMatchesSearch(entry, "earlier investigation"),
+      ),
+    ).toBe(true);
   });
 
   it("does not duplicate subagents from repeated activity snapshots", () => {
@@ -641,9 +647,19 @@ describe("transcript render model", () => {
       transcriptAvailable: true,
     });
 
-    expect(conversationHasMatch(turn, "advisor")).toBe(true);
-    expect(conversationHasMatch(turn, "running")).toBe(true);
-    expect(conversationHasMatch(turn, "not-present")).toBe(false);
+    const entries = groupTranscriptMessages(
+      conversationTranscriptMessages(turn),
+    );
+
+    expect(entries.some((entry) => entryMatchesSearch(entry, "advisor"))).toBe(
+      true,
+    );
+    expect(entries.some((entry) => entryMatchesSearch(entry, "running"))).toBe(
+      true,
+    );
+    expect(
+      entries.some((entry) => entryMatchesSearch(entry, "not-present")),
+    ).toBe(false);
   });
 
   it("matches tool activity status in transcript search", () => {
@@ -663,6 +679,12 @@ describe("transcript render model", () => {
       transcriptAvailable: true,
     });
 
-    expect(conversationHasMatch(turn, "running")).toBe(true);
+    const entries = groupTranscriptMessages(
+      conversationTranscriptMessages(turn),
+    );
+
+    expect(entries.some((entry) => entryMatchesSearch(entry, "running"))).toBe(
+      true,
+    );
   });
 });


### PR DESCRIPTION
Conversation model and reasoning settings now render with transcript metrics instead of beside the conversation title, keeping execution context near the content it produced. Long model identifiers wrap safely on narrow screens.