### PR TITLE
fix(dashboard): Align workspace header gutters

### DIFF
--- a/packages/junior-dashboard/src/client/App.tsx
+++ b/packages/junior-dashboard/src/client/App.tsx
@@ -61,7 +61,11 @@ export function DashboardShell() {
         <div
           className={cn(
             dashboardContainerClass,
-            "grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-4 gap-y-2 px-4 py-3 md:grid-cols-[auto_minmax(0,1fr)_auto] md:px-8",
+            "grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-4 gap-y-2 px-4 py-4",
+            loggedIn
+              ? "md:grid-cols-[auto_minmax(0,1fr)_auto]"
+              : "md:grid-cols-[auto_minmax(0,1fr)]",
+            workspace ? "md:px-4" : "md:px-8",
           )}
         >
           <Link


### PR DESCRIPTION
The dashboard header now uses the same horizontal gutter as the conversation workspace, keeping the Junior wordmark and right-side controls aligned with the content below. Non-workspace pages retain their wider page padding, and logged-out headers no longer reserve an empty profile column.

The header also gains a small amount of vertical padding to create clearer separation from the workspace content.