### PR TITLE
fix(mcp): Isolate OAuth authorization attempts

### DIFF
--- a/packages/junior/src/chat/agent/request.ts
+++ b/packages/junior/src/chat/agent/request.ts
@@ -154,7 +154,7 @@ export interface AgentRunDurability {
     accept: (messages: AgentRunSteeringMessage[]) => Promise<void>,
   ) => Promise<AgentRunSteeringMessage[]>;
   recordPendingAuth?: (
-    pendingAuth: ConversationPendingAuthState,
+    pendingAuth: ConversationPendingAuthState | undefined,
   ) => void | Promise<void>;
   onSandboxAcquired?: (sandbox: SandboxAcquiredState) => void | Promise<void>;
   onArtifactStateUpdated?: (

--- a/packages/junior/src/chat/agent/request.ts
+++ b/packages/junior/src/chat/agent/request.ts
@@ -19,7 +19,6 @@ import { createActor, isUserActor, type Actor } from "@/chat/actor";
 import type { SandboxAcquiredState } from "@/chat/sandbox/sandbox";
 import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress/tracing";
 import type { AuthorizationFlowMode } from "@/chat/services/auth-pause";
-import type { PendingAuthUpdateOptions } from "@/chat/services/pending-auth";
 import type { AssistantStatusSpec } from "@/chat/slack/assistant-thread/status";
 import type { SlackConversationContext } from "@/chat/slack/conversation-context";
 import { parseSlackThreadId } from "@/chat/slack/context";
@@ -156,7 +155,6 @@ export interface AgentRunDurability {
   ) => Promise<AgentRunSteeringMessage[]>;
   recordPendingAuth?: (
     pendingAuth: ConversationPendingAuthState | undefined,
-    options?: PendingAuthUpdateOptions,
   ) => void | Promise<void>;
   onSandboxAcquired?: (sandbox: SandboxAcquiredState) => void | Promise<void>;
   onArtifactStateUpdated?: (

--- a/packages/junior/src/chat/agent/request.ts
+++ b/packages/junior/src/chat/agent/request.ts
@@ -19,6 +19,7 @@ import { createActor, isUserActor, type Actor } from "@/chat/actor";
 import type { SandboxAcquiredState } from "@/chat/sandbox/sandbox";
 import type { SandboxEgressTracePropagationConfig } from "@/chat/sandbox/egress/tracing";
 import type { AuthorizationFlowMode } from "@/chat/services/auth-pause";
+import type { PendingAuthUpdateOptions } from "@/chat/services/pending-auth";
 import type { AssistantStatusSpec } from "@/chat/slack/assistant-thread/status";
 import type { SlackConversationContext } from "@/chat/slack/conversation-context";
 import { parseSlackThreadId } from "@/chat/slack/context";
@@ -155,6 +156,7 @@ export interface AgentRunDurability {
   ) => Promise<AgentRunSteeringMessage[]>;
   recordPendingAuth?: (
     pendingAuth: ConversationPendingAuthState | undefined,
+    options?: PendingAuthUpdateOptions,
   ) => void | Promise<void>;
   onSandboxAcquired?: (sandbox: SandboxAcquiredState) => void | Promise<void>;
   onArtifactStateUpdated?: (

--- a/packages/junior/src/chat/credentials/README.md
+++ b/packages/junior/src/chat/credentials/README.md
@@ -37,7 +37,8 @@ sandbox.
 - Every authorization start creates a fresh v2 attempt id. Its PKCE verifier
   and authorization URL are persisted independently and remain write-once.
 - Thread-local MCP pending auth includes the exact attempt id before the private
-  link is delivered. Failed delivery deletes the new attempt and clears it.
+  link is delivered. Failed delivery deletes the new attempt and restores the
+  prior pending authorization without abandoning its blocked turn.
 - Before each shared user/provider credential mutation, the callback acquires
   the thread lock and verifies that the attempt still owns pending auth.
 - Pre-v2 attempts and legacy MCP pending-auth records without an attempt id are

--- a/packages/junior/src/chat/credentials/README.md
+++ b/packages/junior/src/chat/credentials/README.md
@@ -32,5 +32,16 @@ sandbox.
 5. Replayed, expired, mismatched, or already-consumed callbacks fail without
    altering conversation authority.
 
+### MCP Authorization Attempts
+
+- Every authorization start creates a fresh v2 attempt id. Its PKCE verifier
+  and authorization URL are persisted independently and remain write-once.
+- Thread-local MCP pending auth includes the exact attempt id before the private
+  link is delivered. Failed delivery deletes the new attempt and clears it.
+- Before each shared user/provider credential mutation, the callback acquires
+  the thread lock and verifies that the attempt still owns pending auth.
+- Pre-v2 attempts and legacy MCP pending-auth records without an attempt id are
+  invalid after the cutover. Existing completed credentials remain valid.
+
 Follow `../../../../../policies/security.md` and
 `../../../../../policies/context-bound-systems.md`.

--- a/packages/junior/src/chat/mcp/auth-store.ts
+++ b/packages/junior/src/chat/mcp/auth-store.ts
@@ -13,15 +13,16 @@ import type { ThreadArtifactsState } from "@/chat/state/artifacts";
 import { isRecord } from "@/chat/coerce";
 import { getStateAdapter } from "@/chat/state/adapter";
 
-const MCP_AUTH_SESSION_PREFIX = "junior:mcp_auth_session";
+const MCP_AUTH_SESSION_PREFIX = "junior:mcp_oauth_attempt:v2";
 const MCP_AUTH_CREDENTIALS_PREFIX = "junior:mcp_auth_credentials";
-const MCP_AUTH_SESSION_INDEX_PREFIX = "junior:mcp_auth_session_index";
+const MCP_AUTH_SESSION_INDEX_PREFIX = "junior:mcp_oauth_attempt_index:v2";
 const MCP_SERVER_SESSION_PREFIX = "junior:mcp_server_session";
 const MCP_AUTH_SESSION_TTL_MS = 24 * 60 * 60 * 1000;
 const MCP_AUTH_CREDENTIALS_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const MCP_SERVER_SESSION_TTL_MS = 24 * 60 * 60 * 1000;
 
 export interface McpAuthSessionState {
+  schemaVersion: 2;
   authSessionId: string;
   provider: string;
   userId: string;
@@ -98,6 +99,7 @@ function parseMcpAuthSession(value: unknown): McpAuthSessionState | undefined {
     }
 
     if (
+      parsed.schemaVersion !== 2 ||
       typeof parsed.authSessionId !== "string" ||
       typeof parsed.provider !== "string" ||
       typeof parsed.userId !== "string" ||
@@ -126,6 +128,7 @@ function parseMcpAuthSession(value: unknown): McpAuthSessionState | undefined {
     }
 
     return {
+      schemaVersion: 2,
       authSessionId: parsed.authSessionId,
       provider: parsed.provider,
       userId: parsed.userId,
@@ -270,6 +273,7 @@ export async function patchMcpAuthSession(
   const next: McpAuthSessionState = {
     ...current,
     ...patch,
+    schemaVersion: 2,
     authSessionId: current.authSessionId,
     provider: current.provider,
     userId: current.userId,

--- a/packages/junior/src/chat/mcp/client.ts
+++ b/packages/junior/src/chat/mcp/client.ts
@@ -65,6 +65,7 @@ type HostManagedSessionProvider = OAuthClientProvider & {
 
 export class PluginMcpClient {
   private client?: Client;
+  private clientPromise?: Promise<Client>;
   private lastAttemptedTransportSessionId?: string;
   private transport?: StreamableHTTPClientTransport;
   private listedTools?: ListedTool[];
@@ -164,7 +165,22 @@ export class PluginMcpClient {
     if (this.client) {
       return this.client;
     }
+    if (this.clientPromise) {
+      return await this.clientPromise;
+    }
 
+    const clientPromise = this.connectClient();
+    this.clientPromise = clientPromise;
+    try {
+      return await clientPromise;
+    } finally {
+      if (this.clientPromise === clientPromise) {
+        this.clientPromise = undefined;
+      }
+    }
+  }
+
+  private async connectClient(): Promise<Client> {
     const mcp = this.plugin.manifest.mcp;
     if (!mcp) {
       throw new Error(
@@ -244,6 +260,7 @@ export class PluginMcpClient {
     this.listedTools = undefined;
     this.transport = undefined;
     this.client = undefined;
+    this.clientPromise = undefined;
 
     if (transport) {
       await transport.close();

--- a/packages/junior/src/chat/mcp/oauth-provider.ts
+++ b/packages/junior/src/chat/mcp/oauth-provider.ts
@@ -49,12 +49,16 @@ export class StateBackedMcpOAuthClientProvider implements OAuthClientProvider {
     private readonly callbackUrl: string,
     private readonly sessionContext?: Omit<
       McpAuthSessionState,
+      | "schemaVersion"
       | "authSessionId"
       | "authorizationUrl"
       | "codeVerifier"
       | "createdAtMs"
       | "updatedAtMs"
     >,
+    private readonly runCredentialMutation?: <T>(
+      mutation: () => Promise<T>,
+    ) => Promise<T>,
   ) {
     this.clientMetadata = createClientMetadata(callbackUrl);
   }
@@ -86,13 +90,17 @@ export class StateBackedMcpOAuthClientProvider implements OAuthClientProvider {
   async saveClientInformation(
     clientInformation: OAuthClientInformationMixed,
   ): Promise<void> {
-    const session = await this.getCredentialContext();
-    const credentials =
-      (await getMcpStoredOAuthCredentials(session.userId, session.provider)) ??
-      {};
-    await putMcpStoredOAuthCredentials(session.userId, session.provider, {
-      ...credentials,
-      clientInformation,
+    await this.mutateCredentials(async () => {
+      const session = await this.getCredentialContext();
+      const credentials =
+        (await getMcpStoredOAuthCredentials(
+          session.userId,
+          session.provider,
+        )) ?? {};
+      await putMcpStoredOAuthCredentials(session.userId, session.provider, {
+        ...credentials,
+        clientInformation,
+      });
     });
   }
 
@@ -106,23 +114,38 @@ export class StateBackedMcpOAuthClientProvider implements OAuthClientProvider {
   }
 
   async saveTokens(tokens: OAuthTokens): Promise<void> {
-    const session = await this.getCredentialContext();
-    const credentials =
-      (await getMcpStoredOAuthCredentials(session.userId, session.provider)) ??
-      {};
-    await putMcpStoredOAuthCredentials(session.userId, session.provider, {
-      ...credentials,
-      tokens,
+    await this.mutateCredentials(async () => {
+      const session = await this.getCredentialContext();
+      const credentials =
+        (await getMcpStoredOAuthCredentials(
+          session.userId,
+          session.provider,
+        )) ?? {};
+      await putMcpStoredOAuthCredentials(session.userId, session.provider, {
+        ...credentials,
+        tokens,
+      });
     });
   }
 
   async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
+    const existing = await getMcpAuthSession(this.authSessionId);
+    if (
+      existing?.authorizationUrl &&
+      existing.authorizationUrl !== authorizationUrl.toString()
+    ) {
+      throw new Error("MCP OAuth authorization attempt is already initialized");
+    }
     await this.ensureSession({
       authorizationUrl: authorizationUrl.toString(),
     });
   }
 
   async saveCodeVerifier(codeVerifier: string): Promise<void> {
+    const existing = await getMcpAuthSession(this.authSessionId);
+    if (existing?.codeVerifier && existing.codeVerifier !== codeVerifier) {
+      throw new Error("MCP OAuth authorization attempt is already initialized");
+    }
     await this.ensureSession({ codeVerifier });
   }
 
@@ -135,13 +158,17 @@ export class StateBackedMcpOAuthClientProvider implements OAuthClientProvider {
   }
 
   async saveDiscoveryState(state: OAuthDiscoveryState): Promise<void> {
-    const session = await this.getCredentialContext();
-    const credentials =
-      (await getMcpStoredOAuthCredentials(session.userId, session.provider)) ??
-      {};
-    await putMcpStoredOAuthCredentials(session.userId, session.provider, {
-      ...credentials,
-      discoveryState: state,
+    await this.mutateCredentials(async () => {
+      const session = await this.getCredentialContext();
+      const credentials =
+        (await getMcpStoredOAuthCredentials(
+          session.userId,
+          session.provider,
+        )) ?? {};
+      await putMcpStoredOAuthCredentials(session.userId, session.provider, {
+        ...credentials,
+        discoveryState: state,
+      });
     });
   }
 
@@ -157,38 +184,32 @@ export class StateBackedMcpOAuthClientProvider implements OAuthClientProvider {
   async invalidateCredentials(
     scope: "all" | "client" | "tokens" | "verifier" | "discovery",
   ): Promise<void> {
-    const session = await this.getCredentialContext();
-    const credentials =
-      (await getMcpStoredOAuthCredentials(session.userId, session.provider)) ??
-      {};
+    await this.mutateCredentials(async () => {
+      const session = await this.getCredentialContext();
+      const credentials =
+        (await getMcpStoredOAuthCredentials(
+          session.userId,
+          session.provider,
+        )) ?? {};
 
-    await putMcpStoredOAuthCredentials(session.userId, session.provider, {
-      ...(scope === "tokens" || scope === "all"
-        ? {}
-        : credentials.tokens
-          ? { tokens: credentials.tokens }
-          : {}),
-      ...(scope === "client" || scope === "all"
-        ? {}
-        : credentials.clientInformation
-          ? { clientInformation: credentials.clientInformation }
-          : {}),
-      ...(scope === "discovery" || scope === "all"
-        ? {}
-        : credentials.discoveryState
-          ? { discoveryState: credentials.discoveryState }
-          : {}),
+      await putMcpStoredOAuthCredentials(session.userId, session.provider, {
+        ...(scope === "tokens" || scope === "all"
+          ? {}
+          : credentials.tokens
+            ? { tokens: credentials.tokens }
+            : {}),
+        ...(scope === "client" || scope === "all"
+          ? {}
+          : credentials.clientInformation
+            ? { clientInformation: credentials.clientInformation }
+            : {}),
+        ...(scope === "discovery" || scope === "all"
+          ? {}
+          : credentials.discoveryState
+            ? { discoveryState: credentials.discoveryState }
+            : {}),
+      });
     });
-
-    if (scope === "verifier" || scope === "all") {
-      const authSession = await getMcpAuthSession(this.authSessionId);
-      if (authSession) {
-        await patchMcpAuthSession(this.authSessionId, {
-          codeVerifier: undefined,
-          ...(scope === "all" ? { authorizationUrl: undefined } : {}),
-        });
-      }
-    }
   }
 
   async getMcpServerSessionId(): Promise<string | undefined> {
@@ -197,13 +218,22 @@ export class StateBackedMcpOAuthClientProvider implements OAuthClientProvider {
   }
 
   async saveMcpServerSessionId(sessionId: string | undefined): Promise<void> {
-    const session = await this.getCredentialContext();
-    if (!sessionId) {
-      await deleteMcpServerSessionId(session.userId, session.provider);
-      return;
-    }
+    await this.mutateCredentials(async () => {
+      const session = await this.getCredentialContext();
+      if (!sessionId) {
+        await deleteMcpServerSessionId(session.userId, session.provider);
+        return;
+      }
 
-    await putMcpServerSessionId(session.userId, session.provider, sessionId);
+      await putMcpServerSessionId(session.userId, session.provider, sessionId);
+    });
+  }
+
+  /** Route shared credential writes through callback-owned freshness control. */
+  private async mutateCredentials<T>(mutation: () => Promise<T>): Promise<T> {
+    return this.runCredentialMutation
+      ? await this.runCredentialMutation(mutation)
+      : await mutation();
   }
 
   private async getCredentialContext() {
@@ -221,6 +251,7 @@ export class StateBackedMcpOAuthClientProvider implements OAuthClientProvider {
 
     const now = Date.now();
     const nextSession: McpAuthSessionState = {
+      schemaVersion: 2,
       authSessionId: this.authSessionId,
       ...this.sessionContext,
       ...patch,

--- a/packages/junior/src/chat/mcp/oauth.ts
+++ b/packages/junior/src/chat/mcp/oauth.ts
@@ -5,12 +5,7 @@ import { resolveBaseUrl } from "@/chat/oauth-flow";
 import { pluginCatalogRuntime } from "@/chat/plugins/catalog-runtime";
 import type { PluginDefinition } from "@/chat/plugins/types";
 import type { ThreadArtifactsState } from "@/chat/state/artifacts";
-import {
-  getLatestMcpAuthSessionForUserProvider,
-  getMcpAuthSession,
-  putMcpAuthSession,
-  type McpAuthSessionState,
-} from "./auth-store";
+import { getMcpAuthSession, type McpAuthSessionState } from "./auth-store";
 import { StateBackedMcpOAuthClientProvider } from "./oauth-provider";
 
 export function getMcpOAuthCallbackPath(provider: string): string {
@@ -25,6 +20,7 @@ function requirePluginWithMcp(provider: string): PluginDefinition {
   return plugin;
 }
 
+/** Create one immutable provider authorization attempt for the active turn. */
 export async function createMcpOAuthClientProvider(input: {
   provider: string;
   conversationId: string;
@@ -48,42 +44,7 @@ export async function createMcpOAuthClientProvider(input: {
     );
   }
 
-  const existingSession = await getLatestMcpAuthSessionForUserProvider(
-    input.userId,
-    input.provider,
-  );
-  const reusableSession =
-    existingSession &&
-    existingSession.conversationId === input.conversationId &&
-    existingSession.sessionId === input.sessionId
-      ? existingSession
-      : undefined;
-  const now = Date.now();
-  const authSessionId = reusableSession?.authSessionId ?? randomUUID();
-
-  await putMcpAuthSession({
-    authSessionId,
-    provider: input.provider,
-    userId: input.userId,
-    conversationId: input.conversationId,
-    ...(input.destination ? { destination: input.destination } : {}),
-    ...(input.source ? { source: input.source } : {}),
-    sessionId: input.sessionId,
-    userMessage: input.userMessage,
-    ...(input.channelId ? { channelId: input.channelId } : {}),
-    ...(input.threadTs ? { threadTs: input.threadTs } : {}),
-    ...(input.toolChannelId ? { toolChannelId: input.toolChannelId } : {}),
-    ...(input.configuration ? { configuration: input.configuration } : {}),
-    ...(input.artifactState ? { artifactState: input.artifactState } : {}),
-    ...(reusableSession?.authorizationUrl
-      ? { authorizationUrl: reusableSession.authorizationUrl }
-      : {}),
-    ...(reusableSession?.codeVerifier
-      ? { codeVerifier: reusableSession.codeVerifier }
-      : {}),
-    createdAtMs: reusableSession?.createdAtMs ?? now,
-    updatedAtMs: now,
-  });
+  const authSessionId = randomUUID();
 
   return new StateBackedMcpOAuthClientProvider(
     authSessionId,
@@ -93,6 +54,7 @@ export async function createMcpOAuthClientProvider(input: {
       userId: input.userId,
       conversationId: input.conversationId,
       ...(input.destination ? { destination: input.destination } : {}),
+      ...(input.source ? { source: input.source } : {}),
       sessionId: input.sessionId,
       userMessage: input.userMessage,
       ...(input.channelId ? { channelId: input.channelId } : {}),
@@ -104,10 +66,12 @@ export async function createMcpOAuthClientProvider(input: {
   );
 }
 
+/** Exchange a callback code while guarding every shared credential mutation. */
 export async function finalizeMcpAuthorization(
   provider: string,
   authSessionId: string,
   authorizationCode: string,
+  runCredentialMutation?: <T>(mutation: () => Promise<T>) => Promise<T>,
 ): Promise<McpAuthSessionState> {
   const plugin = requirePluginWithMcp(provider);
   const mcp = plugin.manifest.mcp;
@@ -135,6 +99,8 @@ export async function finalizeMcpAuthorization(
   const authProvider = new StateBackedMcpOAuthClientProvider(
     authSessionId,
     callbackUrl,
+    undefined,
+    runCredentialMutation,
   );
   const requestInit: RequestInit = {};
   if (mcp.headers && Object.keys(mcp.headers).length > 0) {

--- a/packages/junior/src/chat/mcp/tool-manager.ts
+++ b/packages/junior/src/chat/mcp/tool-manager.ts
@@ -292,6 +292,10 @@ export class McpToolManager {
   private readonly activeProviders = new Set<string>();
   private readonly authorizationPendingProviders = new Set<string>();
   private readonly clientsByProvider = new Map<string, PluginMcpClient>();
+  private readonly clientPromisesByProvider = new Map<
+    string,
+    Promise<PluginMcpClient>
+  >();
   private readonly toolsByProvider = new Map<string, ManagedMcpTool[]>();
 
   constructor(
@@ -426,6 +430,28 @@ export class McpToolManager {
       return existing;
     }
 
+    const pending = this.clientPromisesByProvider.get(plugin.manifest.name);
+    if (pending) {
+      return await pending;
+    }
+
+    const clientPromise = this.createClient(plugin);
+    this.clientPromisesByProvider.set(plugin.manifest.name, clientPromise);
+    try {
+      return await clientPromise;
+    } finally {
+      if (
+        this.clientPromisesByProvider.get(plugin.manifest.name) ===
+        clientPromise
+      ) {
+        this.clientPromisesByProvider.delete(plugin.manifest.name);
+      }
+    }
+  }
+
+  private async createClient(
+    plugin: PluginDefinition,
+  ): Promise<PluginMcpClient> {
     const authProvider = this.options.authProviderFactory
       ? await this.options.authProviderFactory(plugin)
       : undefined;

--- a/packages/junior/src/chat/runtime/agent-continue-runner.ts
+++ b/packages/junior/src/chat/runtime/agent-continue-runner.ts
@@ -68,10 +68,7 @@ import { getConversationWorkState } from "@/chat/task-execution/store";
 import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { persistAuthPauseTurnState } from "@/chat/runtime/auth-pause-state";
-import {
-  applyPendingAuthUpdate,
-  clearPendingAuth,
-} from "@/chat/services/pending-auth";
+import { clearPendingAuth } from "@/chat/services/pending-auth";
 import { requireSlackDestination } from "@/chat/destination";
 import type { CredentialContext } from "@/chat/credentials/context";
 import { sleep } from "@/chat/sleep";
@@ -441,17 +438,8 @@ export async function continueSlackAgentRun(
               sandbox,
             },
             durability: {
-              recordPendingAuth: async (nextPendingAuth, options) => {
-                if (nextPendingAuth) {
-                  await applyPendingAuthUpdate({
-                    conversation,
-                    conversationId: payload.conversationId,
-                    nextPendingAuth,
-                    options,
-                  });
-                } else {
-                  clearPendingAuth(conversation);
-                }
+              recordPendingAuth: async (nextPendingAuth) => {
+                conversation.processing.pendingAuth = nextPendingAuth;
                 await persistThreadStateById(payload.conversationId, {
                   conversation,
                 });

--- a/packages/junior/src/chat/runtime/agent-continue-runner.ts
+++ b/packages/junior/src/chat/runtime/agent-continue-runner.ts
@@ -442,11 +442,15 @@ export async function continueSlackAgentRun(
             },
             durability: {
               recordPendingAuth: async (nextPendingAuth) => {
-                await applyPendingAuthUpdate({
-                  conversation,
-                  conversationId: payload.conversationId,
-                  nextPendingAuth,
-                });
+                if (nextPendingAuth) {
+                  await applyPendingAuthUpdate({
+                    conversation,
+                    conversationId: payload.conversationId,
+                    nextPendingAuth,
+                  });
+                } else {
+                  clearPendingAuth(conversation);
+                }
                 await persistThreadStateById(payload.conversationId, {
                   conversation,
                 });

--- a/packages/junior/src/chat/runtime/agent-continue-runner.ts
+++ b/packages/junior/src/chat/runtime/agent-continue-runner.ts
@@ -441,12 +441,13 @@ export async function continueSlackAgentRun(
               sandbox,
             },
             durability: {
-              recordPendingAuth: async (nextPendingAuth) => {
+              recordPendingAuth: async (nextPendingAuth, options) => {
                 if (nextPendingAuth) {
                   await applyPendingAuthUpdate({
                     conversation,
                     conversationId: payload.conversationId,
                     nextPendingAuth,
+                    options,
                   });
                 } else {
                   clearPendingAuth(conversation);

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -65,7 +65,10 @@ import {
   updateConversationStats,
 } from "@/chat/services/conversation-memory";
 import type { ContextCompactor } from "@/chat/services/context-compaction";
-import { applyPendingAuthUpdate } from "@/chat/services/pending-auth";
+import {
+  applyPendingAuthUpdate,
+  clearPendingAuth,
+} from "@/chat/services/pending-auth";
 import {
   countPotentialImageAttachments,
   hasPotentialImageAttachment,
@@ -1258,11 +1261,15 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                 });
               },
               recordPendingAuth: async (pendingAuth) => {
-                await applyPendingAuthUpdate({
-                  conversation: preparedState.conversation,
-                  conversationId,
-                  nextPendingAuth: pendingAuth,
-                });
+                if (pendingAuth) {
+                  await applyPendingAuthUpdate({
+                    conversation: preparedState.conversation,
+                    conversationId,
+                    nextPendingAuth: pendingAuth,
+                  });
+                } else {
+                  clearPendingAuth(preparedState.conversation);
+                }
                 await persistThreadState(thread, {
                   conversation: preparedState.conversation,
                 });

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -66,10 +66,6 @@ import {
 } from "@/chat/services/conversation-memory";
 import type { ContextCompactor } from "@/chat/services/context-compaction";
 import {
-  applyPendingAuthUpdate,
-  clearPendingAuth,
-} from "@/chat/services/pending-auth";
-import {
   countPotentialImageAttachments,
   hasPotentialImageAttachment,
   isVisionEnabled,
@@ -1260,17 +1256,8 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                   artifacts: latestArtifacts,
                 });
               },
-              recordPendingAuth: async (pendingAuth, options) => {
-                if (pendingAuth) {
-                  await applyPendingAuthUpdate({
-                    conversation: preparedState.conversation,
-                    conversationId,
-                    nextPendingAuth: pendingAuth,
-                    options,
-                  });
-                } else {
-                  clearPendingAuth(preparedState.conversation);
-                }
+              recordPendingAuth: async (pendingAuth) => {
+                preparedState.conversation.processing.pendingAuth = pendingAuth;
                 await persistThreadState(thread, {
                   conversation: preparedState.conversation,
                 });

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -1260,12 +1260,13 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                   artifacts: latestArtifacts,
                 });
               },
-              recordPendingAuth: async (pendingAuth) => {
+              recordPendingAuth: async (pendingAuth, options) => {
                 if (pendingAuth) {
                   await applyPendingAuthUpdate({
                     conversation: preparedState.conversation,
                     conversationId,
                     nextPendingAuth: pendingAuth,
+                    options,
                   });
                 } else {
                   clearPendingAuth(preparedState.conversation);

--- a/packages/junior/src/chat/services/mcp-auth-orchestration.ts
+++ b/packages/junior/src/chat/services/mcp-auth-orchestration.ts
@@ -53,7 +53,7 @@ export interface McpAuthOrchestrationInput {
   getArtifactState: () => ThreadArtifactsState | undefined;
   getMergedArtifactState: () => ThreadArtifactsState;
   recordPendingAuth?: (
-    pendingAuth: ConversationPendingAuthState,
+    pendingAuth: ConversationPendingAuthState | undefined,
   ) => void | Promise<void>;
   authorizationFlowMode?: AuthorizationFlowMode;
 }
@@ -164,8 +164,24 @@ export function createMcpAuthOrchestration(
       sessionId,
     });
     const providerLabel = formatProviderLabel(provider);
+    const reusedAuthSessionId =
+      reusingPendingLink && input.pendingAuth?.kind === "mcp"
+        ? input.pendingAuth.authSessionId
+        : undefined;
+
+    const nextPendingAuth: ConversationPendingAuthState = {
+      authSessionId: reusedAuthSessionId ?? authSessionId,
+      kind: "mcp",
+      provider,
+      actorId,
+      sessionId,
+      linkSentAtMs: reusingPendingLink
+        ? input.pendingAuth!.linkSentAtMs
+        : Date.now(),
+    };
 
     if (!reusingPendingLink) {
+      await recordPendingAuth(nextPendingAuth);
       const delivery = await deliverPrivateMessage({
         channelId: authSession.channelId,
         threadTs: authSession.threadTs,
@@ -178,6 +194,8 @@ export function createMcpAuthOrchestration(
         }),
       });
       if (!delivery) {
+        await deleteMcpAuthSession(authSessionId);
+        await recordPendingAuth(undefined);
         throw new Error(
           `Unable to deliver MCP authorization link for plugin "${provider}"`,
         );
@@ -186,15 +204,9 @@ export function createMcpAuthOrchestration(
       await deleteMcpAuthSession(authSessionId);
     }
 
-    await recordPendingAuth({
-      kind: "mcp",
-      provider,
-      actorId,
-      sessionId,
-      linkSentAtMs: reusingPendingLink
-        ? input.pendingAuth!.linkSentAtMs
-        : Date.now(),
-    });
+    if (reusingPendingLink) {
+      await recordPendingAuth(nextPendingAuth);
+    }
     await recordAuthorizationRequested({
       conversationId,
       kind: "mcp",

--- a/packages/junior/src/chat/services/mcp-auth-orchestration.ts
+++ b/packages/junior/src/chat/services/mcp-auth-orchestration.ts
@@ -17,8 +17,8 @@ import {
 import { formatOAuthAuthorizationMessage } from "@/chat/oauth-authorization-message";
 import { deliverPrivateMessage, formatProviderLabel } from "@/chat/oauth-flow";
 import {
+  abandonReplacedPendingAuth,
   canReusePendingAuthLink,
-  type PendingAuthUpdateOptions,
 } from "@/chat/services/pending-auth";
 import {
   AuthorizationFlowDisabledError,
@@ -57,7 +57,6 @@ export interface McpAuthOrchestrationInput {
   getMergedArtifactState: () => ThreadArtifactsState;
   recordPendingAuth?: (
     pendingAuth: ConversationPendingAuthState | undefined,
-    options?: PendingAuthUpdateOptions,
   ) => void | Promise<void>;
   authorizationFlowMode?: AuthorizationFlowMode;
 }
@@ -185,7 +184,7 @@ export function createMcpAuthOrchestration(
     };
 
     if (!reusingPendingLink) {
-      await recordPendingAuth(nextPendingAuth, { skipAbandonment: true });
+      await recordPendingAuth(nextPendingAuth);
       const delivery = await deliverPrivateMessage({
         channelId: authSession.channelId,
         threadTs: authSession.threadTs,
@@ -199,19 +198,18 @@ export function createMcpAuthOrchestration(
       });
       if (!delivery) {
         await deleteMcpAuthSession(authSessionId);
-        await recordPendingAuth(input.pendingAuth, { skipAbandonment: true });
+        await recordPendingAuth(input.pendingAuth);
         throw new Error(
           `Unable to deliver MCP authorization link for plugin "${provider}"`,
         );
       }
-      await recordPendingAuth(nextPendingAuth, {
-        replacedPendingAuth: input.pendingAuth,
+      await abandonReplacedPendingAuth({
+        conversationId,
+        previousPendingAuth: input.pendingAuth,
+        nextPendingAuth,
       });
     } else {
       await deleteMcpAuthSession(authSessionId);
-    }
-
-    if (reusingPendingLink) {
       await recordPendingAuth(nextPendingAuth);
     }
     await recordAuthorizationRequested({

--- a/packages/junior/src/chat/services/mcp-auth-orchestration.ts
+++ b/packages/junior/src/chat/services/mcp-auth-orchestration.ts
@@ -144,8 +144,20 @@ export function createMcpAuthOrchestration(
       );
     }
 
+    const reusingPendingLink = canReusePendingAuthLink({
+      pendingAuth: input.pendingAuth,
+      kind: "mcp",
+      provider,
+      actorId,
+      sessionId,
+    });
+    const reusedAuthSessionId =
+      reusingPendingLink && input.pendingAuth?.kind === "mcp"
+        ? input.pendingAuth.authSessionId
+        : undefined;
+    const activeAuthSessionId = reusedAuthSessionId ?? authSessionId;
     const latestArtifactState = input.getMergedArtifactState();
-    await patchMcpAuthSession(authSessionId, {
+    await patchMcpAuthSession(activeAuthSessionId, {
       configuration: { ...input.getConfiguration() },
       artifactState: latestArtifactState,
       toolChannelId:
@@ -154,26 +166,10 @@ export function createMcpAuthOrchestration(
         input.channelId,
     });
 
-    const authSession = await getMcpAuthSession(authSessionId);
-    if (!authSession?.authorizationUrl) {
-      throw new Error(`Missing MCP authorization URL for plugin "${provider}"`);
-    }
-
-    const reusingPendingLink = canReusePendingAuthLink({
-      pendingAuth: input.pendingAuth,
-      kind: "mcp",
-      provider,
-      actorId,
-      sessionId,
-    });
     const providerLabel = formatProviderLabel(provider);
-    const reusedAuthSessionId =
-      reusingPendingLink && input.pendingAuth?.kind === "mcp"
-        ? input.pendingAuth.authSessionId
-        : undefined;
 
     const nextPendingAuth: ConversationPendingAuthState = {
-      authSessionId: reusedAuthSessionId ?? authSessionId,
+      authSessionId: activeAuthSessionId,
       kind: "mcp",
       provider,
       actorId,
@@ -184,6 +180,12 @@ export function createMcpAuthOrchestration(
     };
 
     if (!reusingPendingLink) {
+      const authSession = await getMcpAuthSession(authSessionId);
+      if (!authSession?.authorizationUrl) {
+        throw new Error(
+          `Missing MCP authorization URL for plugin "${provider}"`,
+        );
+      }
       await recordPendingAuth(nextPendingAuth);
       const delivery = await deliverPrivateMessage({
         channelId: authSession.channelId,

--- a/packages/junior/src/chat/services/mcp-auth-orchestration.ts
+++ b/packages/junior/src/chat/services/mcp-auth-orchestration.ts
@@ -16,7 +16,10 @@ import {
 } from "@/chat/mcp/auth-store";
 import { formatOAuthAuthorizationMessage } from "@/chat/oauth-authorization-message";
 import { deliverPrivateMessage, formatProviderLabel } from "@/chat/oauth-flow";
-import { canReusePendingAuthLink } from "@/chat/services/pending-auth";
+import {
+  canReusePendingAuthLink,
+  type PendingAuthUpdateOptions,
+} from "@/chat/services/pending-auth";
 import {
   AuthorizationFlowDisabledError,
   AuthorizationPauseError,
@@ -54,6 +57,7 @@ export interface McpAuthOrchestrationInput {
   getMergedArtifactState: () => ThreadArtifactsState;
   recordPendingAuth?: (
     pendingAuth: ConversationPendingAuthState | undefined,
+    options?: PendingAuthUpdateOptions,
   ) => void | Promise<void>;
   authorizationFlowMode?: AuthorizationFlowMode;
 }
@@ -181,7 +185,7 @@ export function createMcpAuthOrchestration(
     };
 
     if (!reusingPendingLink) {
-      await recordPendingAuth(nextPendingAuth);
+      await recordPendingAuth(nextPendingAuth, { skipAbandonment: true });
       const delivery = await deliverPrivateMessage({
         channelId: authSession.channelId,
         threadTs: authSession.threadTs,
@@ -195,11 +199,14 @@ export function createMcpAuthOrchestration(
       });
       if (!delivery) {
         await deleteMcpAuthSession(authSessionId);
-        await recordPendingAuth(undefined);
+        await recordPendingAuth(input.pendingAuth, { skipAbandonment: true });
         throw new Error(
           `Unable to deliver MCP authorization link for plugin "${provider}"`,
         );
       }
+      await recordPendingAuth(nextPendingAuth, {
+        replacedPendingAuth: input.pendingAuth,
+      });
     } else {
       await deleteMcpAuthSession(authSessionId);
     }

--- a/packages/junior/src/chat/services/pending-auth.ts
+++ b/packages/junior/src/chat/services/pending-auth.ts
@@ -6,6 +6,11 @@ import type {
 import { buildDeterministicTurnId } from "@/chat/state/turn-id";
 import { abandonAgentTurnSessionRecord } from "@/chat/state/turn-session";
 
+export interface PendingAuthUpdateOptions {
+  replacedPendingAuth?: ConversationPendingAuthState;
+  skipAbandonment?: boolean;
+}
+
 // A fresh private auth link is worth reissuing after ~10 minutes: long enough
 // to cover normal back-and-forth (read the prompt, check a password manager),
 // short enough that a link the user has clearly abandoned doesn't keep
@@ -111,8 +116,12 @@ export async function applyPendingAuthUpdate(args: {
   conversation: ThreadConversationState;
   conversationId: string | undefined;
   nextPendingAuth: ConversationPendingAuthState;
+  options?: PendingAuthUpdateOptions;
 }): Promise<void> {
-  const previousPendingAuth = args.conversation.processing.pendingAuth;
+  const currentPendingAuth = args.conversation.processing.pendingAuth;
+  const previousPendingAuth = args.options?.skipAbandonment
+    ? undefined
+    : (args.options?.replacedPendingAuth ?? currentPendingAuth);
   args.conversation.processing.pendingAuth = args.nextPendingAuth;
   if (
     previousPendingAuth &&

--- a/packages/junior/src/chat/services/pending-auth.ts
+++ b/packages/junior/src/chat/services/pending-auth.ts
@@ -49,6 +49,21 @@ export function canReusePendingAuthLink(args: {
   );
 }
 
+/** Return the exact pending authorization target for one actor and provider. */
+export function getConversationPendingAuth(args: {
+  conversation: ThreadConversationState;
+  kind: "mcp";
+  provider: string;
+  actorId: string;
+  scope?: string;
+}): Extract<ConversationPendingAuthState, { kind: "mcp" }> | undefined;
+export function getConversationPendingAuth(args: {
+  conversation: ThreadConversationState;
+  kind: "plugin";
+  provider: string;
+  actorId: string;
+  scope?: string;
+}): Extract<ConversationPendingAuthState, { kind: "plugin" }> | undefined;
 export function getConversationPendingAuth(args: {
   conversation: ThreadConversationState;
   kind: AuthorizationPauseKind;

--- a/packages/junior/src/chat/services/pending-auth.ts
+++ b/packages/junior/src/chat/services/pending-auth.ts
@@ -6,11 +6,6 @@ import type {
 import { buildDeterministicTurnId } from "@/chat/state/turn-id";
 import { abandonAgentTurnSessionRecord } from "@/chat/state/turn-session";
 
-export interface PendingAuthUpdateOptions {
-  replacedPendingAuth?: ConversationPendingAuthState;
-  skipAbandonment?: boolean;
-}
-
 // A fresh private auth link is worth reissuing after ~10 minutes: long enough
 // to cover normal back-and-forth (read the prompt, check a password manager),
 // short enough that a link the user has clearly abandoned doesn't keep
@@ -107,30 +102,20 @@ export function clearPendingAuth(
   conversation.processing.pendingAuth = undefined;
 }
 
-/**
- * Apply a new pending-auth record to the conversation and, when replacing a
- * different session's pending-auth, mark the prior session record as abandoned.
- * Callers are responsible for persisting the mutated conversation afterwards.
- */
-export async function applyPendingAuthUpdate(args: {
-  conversation: ThreadConversationState;
+/** Mark the prior blocked turn abandoned after a new auth attempt replaces it. */
+export async function abandonReplacedPendingAuth(args: {
   conversationId: string | undefined;
+  previousPendingAuth: ConversationPendingAuthState | undefined;
   nextPendingAuth: ConversationPendingAuthState;
-  options?: PendingAuthUpdateOptions;
 }): Promise<void> {
-  const currentPendingAuth = args.conversation.processing.pendingAuth;
-  const previousPendingAuth = args.options?.skipAbandonment
-    ? undefined
-    : (args.options?.replacedPendingAuth ?? currentPendingAuth);
-  args.conversation.processing.pendingAuth = args.nextPendingAuth;
   if (
-    previousPendingAuth &&
-    previousPendingAuth.sessionId !== args.nextPendingAuth.sessionId &&
+    args.previousPendingAuth &&
+    args.previousPendingAuth.sessionId !== args.nextPendingAuth.sessionId &&
     args.conversationId
   ) {
     await abandonAgentTurnSessionRecord({
       conversationId: args.conversationId,
-      sessionId: previousPendingAuth.sessionId,
+      sessionId: args.previousPendingAuth.sessionId,
       errorMessage:
         "Abandoned by a newer auth-blocked request in the same conversation.",
     });

--- a/packages/junior/src/chat/services/plugin-auth-orchestration.ts
+++ b/packages/junior/src/chat/services/plugin-auth-orchestration.ts
@@ -14,7 +14,10 @@ import type { Destination, Source } from "@sentry/junior-plugin-api";
 import type { ChannelConfigurationService } from "@/chat/configuration/types";
 import type { UserTokenStore } from "@/chat/credentials/user-token-store";
 import { formatProviderLabel, startOAuthFlow } from "@/chat/oauth-flow";
-import { canReusePendingAuthLink } from "@/chat/services/pending-auth";
+import {
+  abandonReplacedPendingAuth,
+  canReusePendingAuthLink,
+} from "@/chat/services/pending-auth";
 import {
   AuthorizationFlowDisabledError,
   AuthorizationPauseError,
@@ -189,7 +192,7 @@ export function createPluginAuthOrchestration(
     }
 
     if (input.sessionId && recordPendingAuth) {
-      await recordPendingAuth({
+      const nextPendingAuth: ConversationPendingAuthState = {
         kind: "plugin",
         provider,
         actorId: input.actorId,
@@ -198,6 +201,12 @@ export function createPluginAuthOrchestration(
         linkSentAtMs: reusingPendingLink
           ? input.pendingAuth!.linkSentAtMs
           : Date.now(),
+      };
+      await recordPendingAuth(nextPendingAuth);
+      await abandonReplacedPendingAuth({
+        conversationId: input.conversationId,
+        previousPendingAuth: input.pendingAuth,
+        nextPendingAuth,
       });
     }
     if (input.conversationId && input.sessionId) {

--- a/packages/junior/src/chat/state/conversation.ts
+++ b/packages/junior/src/chat/state/conversation.ts
@@ -1,5 +1,4 @@
 import { isRecord, toOptionalNumber, toOptionalString } from "@/chat/coerce";
-import type { AuthorizationPauseKind } from "@/chat/services/auth-pause";
 
 type ConversationRole = "assistant" | "system" | "user";
 
@@ -48,14 +47,22 @@ export interface ConversationProcessingState {
   pendingAuth?: ConversationPendingAuthState;
 }
 
-export interface ConversationPendingAuthState {
-  kind: AuthorizationPauseKind;
+interface ConversationPendingAuthBase {
   linkSentAtMs: number;
   provider: string;
   actorId: string;
   scope?: string;
   sessionId: string;
 }
+
+export type ConversationPendingAuthState =
+  | (ConversationPendingAuthBase & {
+      authSessionId: string;
+      kind: "mcp";
+    })
+  | (ConversationPendingAuthBase & {
+      kind: "plugin";
+    });
 
 export interface ConversationStats {
   compactedMessageCount: number;
@@ -114,6 +121,7 @@ function coercePendingAuthState(
   const kind = value.kind;
   const provider = toOptionalString(value.provider);
   const actorId = toOptionalString(value.actorId);
+  const authSessionId = toOptionalString(value.authSessionId);
   const scope = toOptionalString(value.scope);
   const sessionId = toOptionalString(value.sessionId);
   const linkSentAtMs = toOptionalNumber(value.linkSentAtMs);
@@ -121,20 +129,23 @@ function coercePendingAuthState(
     (kind !== "mcp" && kind !== "plugin") ||
     !provider ||
     !actorId ||
+    (kind === "mcp" && !authSessionId) ||
     !sessionId ||
     typeof linkSentAtMs !== "number"
   ) {
     return undefined;
   }
 
-  return {
-    kind,
+  const base = {
     provider,
     actorId,
     ...(scope ? { scope } : {}),
     sessionId,
     linkSentAtMs,
   };
+  return kind === "mcp"
+    ? { ...base, authSessionId: authSessionId!, kind }
+    : { ...base, kind };
 }
 
 /** Safely coerce an unknown persisted value into a ThreadConversationState. */

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -6,10 +6,13 @@
  * must not resume newer thread work after another user message has superseded
  * the paused request.
  */
+import { getStateAdapter } from "@/chat/state/adapter";
+import { acquireActiveLock } from "@/chat/state/locks";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
 import { hydrateConversationMessages } from "@/chat/conversations/visible-messages";
 import {
   deleteMcpAuthSession,
+  getMcpAuthSession,
   type McpAuthSessionState,
 } from "@/chat/mcp/auth-store";
 import { finalizeMcpAuthorization } from "@/chat/mcp/oauth";
@@ -75,6 +78,12 @@ const CALLBACK_PAGES = {
     message: "Missing code parameter.",
     status: 400,
   },
+  expired: {
+    title: "Authorization expired",
+    message:
+      "This authorization link is no longer active. Return to Slack and retry the original request.",
+    status: 400,
+  },
   success: {
     title: "Authorization complete",
     message:
@@ -91,6 +100,13 @@ const CALLBACK_PAGES = {
 
 interface McpOAuthCallbackOptions {
   agentRunner: AgentRunner;
+}
+
+class McpOAuthAttemptExpiredError extends Error {
+  constructor() {
+    super("MCP OAuth authorization attempt is no longer current");
+    this.name = "McpOAuthAttemptExpiredError";
+  }
 }
 
 function mcpAuthorizationId(args: {
@@ -217,21 +233,20 @@ async function resumeAuthorizedMcpTurn(args: {
     provider,
     actorId: authSession.userId,
   });
-  const resolvedSessionId = pendingAuth?.sessionId ?? authSession.sessionId;
+  if (pendingAuth?.authSessionId !== authSession.authSessionId) {
+    return;
+  }
+  const resolvedSessionId = pendingAuth.sessionId;
   const userMessage = getTurnUserMessage(conversation, resolvedSessionId);
-  if (pendingAuth) {
-    if (!isPendingAuthLatestRequest(conversation, pendingAuth)) {
-      clearPendingAuth(conversation, pendingAuth.sessionId);
-      await persistThreadStateById(threadId, { conversation });
-      await abandonAgentTurnSessionRecord({
-        conversationId: authSession.conversationId,
-        sessionId: pendingAuth.sessionId,
-        errorMessage:
-          "Auth completed after a newer thread message abandoned this blocked request.",
-      });
-      return;
-    }
-  } else if (conversation.processing.activeTurnId !== authSession.sessionId) {
+  if (!isPendingAuthLatestRequest(conversation, pendingAuth)) {
+    clearPendingAuth(conversation, pendingAuth.sessionId);
+    await persistThreadStateById(threadId, { conversation });
+    await abandonAgentTurnSessionRecord({
+      conversationId: authSession.conversationId,
+      sessionId: pendingAuth.sessionId,
+      errorMessage:
+        "Auth completed after a newer thread message abandoned this blocked request.",
+    });
     return;
   }
   if (!userMessage) {
@@ -260,30 +275,24 @@ async function resumeAuthorizedMcpTurn(args: {
         provider,
         actorId: authSession.userId,
       });
-      const lockedSessionId =
-        lockedPendingAuth?.sessionId ?? authSession.sessionId;
+      if (lockedPendingAuth?.authSessionId !== authSession.authSessionId) {
+        return false;
+      }
+      const lockedSessionId = lockedPendingAuth.sessionId;
       if (lockedSessionId !== resolvedSessionId) {
         return false;
       }
-      if (lockedPendingAuth) {
-        if (
-          !isPendingAuthLatestRequest(lockedConversation, lockedPendingAuth)
-        ) {
-          clearPendingAuth(lockedConversation, lockedPendingAuth.sessionId);
-          await persistThreadStateById(threadId, {
-            conversation: lockedConversation,
-          });
-          await abandonAgentTurnSessionRecord({
-            conversationId: authSession.conversationId,
-            sessionId: lockedPendingAuth.sessionId,
-            errorMessage:
-              "Auth completed after a newer thread message abandoned this blocked request.",
-          });
-          return false;
-        }
-      } else if (
-        lockedConversation.processing.activeTurnId !== authSession.sessionId
-      ) {
+      if (!isPendingAuthLatestRequest(lockedConversation, lockedPendingAuth)) {
+        clearPendingAuth(lockedConversation, lockedPendingAuth.sessionId);
+        await persistThreadStateById(threadId, {
+          conversation: lockedConversation,
+        });
+        await abandonAgentTurnSessionRecord({
+          conversationId: authSession.conversationId,
+          sessionId: lockedPendingAuth.sessionId,
+          errorMessage:
+            "Auth completed after a newer thread message abandoned this blocked request.",
+        });
         return false;
       }
 
@@ -396,11 +405,15 @@ async function resumeAuthorizedMcpTurn(args: {
           },
           durability: {
             recordPendingAuth: async (nextPendingAuth) => {
-              await applyPendingAuthUpdate({
-                conversation: lockedConversation,
-                conversationId: authSession.conversationId,
-                nextPendingAuth,
-              });
+              if (nextPendingAuth) {
+                await applyPendingAuthUpdate({
+                  conversation: lockedConversation,
+                  conversationId: authSession.conversationId,
+                  nextPendingAuth,
+                });
+              } else {
+                clearPendingAuth(lockedConversation);
+              }
               await persistThreadStateById(threadId, {
                 conversation: lockedConversation,
               });
@@ -467,6 +480,59 @@ async function resumeAuthorizedMcpTurn(args: {
   });
 }
 
+async function isCurrentMcpAuthorizationAttempt(
+  authSession: McpAuthSessionState,
+  provider: string,
+): Promise<boolean> {
+  if (!authSession.channelId || !authSession.threadTs) {
+    return false;
+  }
+
+  const threadId = `slack:${authSession.channelId}:${authSession.threadTs}`;
+  const currentState = await getPersistedThreadState(threadId);
+  const conversation = coerceThreadConversationState(currentState);
+  const pendingAuth = getConversationPendingAuth({
+    conversation,
+    kind: "mcp",
+    provider,
+    actorId: authSession.userId,
+  });
+
+  return (
+    pendingAuth?.authSessionId === authSession.authSessionId &&
+    pendingAuth.sessionId === authSession.sessionId
+  );
+}
+
+/** Commit one shared credential mutation only while this attempt owns the thread. */
+async function runCurrentMcpCredentialMutation<T>(
+  authSession: McpAuthSessionState,
+  provider: string,
+  mutation: () => Promise<T>,
+): Promise<T> {
+  if (!authSession.channelId || !authSession.threadTs) {
+    throw new McpOAuthAttemptExpiredError();
+  }
+
+  const threadId = `slack:${authSession.channelId}:${authSession.threadTs}`;
+  const stateAdapter = getStateAdapter();
+  await stateAdapter.connect();
+  const lock = await acquireActiveLock(stateAdapter, threadId);
+  if (!lock) {
+    throw new Error(
+      `Could not acquire MCP OAuth callback lock for ${threadId}`,
+    );
+  }
+  try {
+    if (!(await isCurrentMcpAuthorizationAttempt(authSession, provider))) {
+      throw new McpOAuthAttemptExpiredError();
+    }
+    return await mutation();
+  } finally {
+    await stateAdapter.releaseLock(lock);
+  }
+}
+
 export async function GET(
   request: Request,
   provider: string,
@@ -489,7 +555,29 @@ export async function GET(
   }
 
   try {
-    const authSession = await finalizeMcpAuthorization(provider, state, code);
+    const pendingSession = await getMcpAuthSession(state);
+    if (
+      !pendingSession ||
+      pendingSession.provider !== provider ||
+      !(await isCurrentMcpAuthorizationAttempt(pendingSession, provider))
+    ) {
+      if (pendingSession) {
+        await deleteMcpAuthSession(pendingSession.authSessionId);
+      }
+      return htmlResponse("expired");
+    }
+
+    const authSession = await finalizeMcpAuthorization(
+      provider,
+      state,
+      code,
+      async (mutation) =>
+        await runCurrentMcpCredentialMutation(
+          pendingSession,
+          provider,
+          mutation,
+        ),
+    );
     try {
       await deleteMcpAuthSession(authSession.authSessionId);
     } catch (cleanupError) {
@@ -512,6 +600,10 @@ export async function GET(
 
     return htmlResponse("success");
   } catch (callbackError) {
+    if (callbackError instanceof McpOAuthAttemptExpiredError) {
+      await deleteMcpAuthSession(state);
+      return htmlResponse("expired");
+    }
     logException(
       callbackError,
       "mcp_oauth_callback_failed",

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -41,7 +41,6 @@ import { coerceThreadArtifactsState } from "@/chat/state/artifacts";
 import { resumeAuthorizedRequest } from "@/chat/runtime/slack-resume";
 import { persistAuthPauseTurnState } from "@/chat/runtime/auth-pause-state";
 import {
-  applyPendingAuthUpdate,
   clearPendingAuth,
   getConversationPendingAuth,
   isPendingAuthLatestRequest,
@@ -404,17 +403,8 @@ async function resumeAuthorizedMcpTurn(args: {
             sandbox: getPersistedSandboxState(lockedState),
           },
           durability: {
-            recordPendingAuth: async (nextPendingAuth, options) => {
-              if (nextPendingAuth) {
-                await applyPendingAuthUpdate({
-                  conversation: lockedConversation,
-                  conversationId: authSession.conversationId,
-                  nextPendingAuth,
-                  options,
-                });
-              } else {
-                clearPendingAuth(lockedConversation);
-              }
+            recordPendingAuth: async (nextPendingAuth) => {
+              lockedConversation.processing.pendingAuth = nextPendingAuth;
               await persistThreadStateById(threadId, {
                 conversation: lockedConversation,
               });

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -404,12 +404,13 @@ async function resumeAuthorizedMcpTurn(args: {
             sandbox: getPersistedSandboxState(lockedState),
           },
           durability: {
-            recordPendingAuth: async (nextPendingAuth) => {
+            recordPendingAuth: async (nextPendingAuth, options) => {
               if (nextPendingAuth) {
                 await applyPendingAuthUpdate({
                   conversation: lockedConversation,
                   conversationId: authSession.conversationId,
                   nextPendingAuth,
+                  options,
                 });
               } else {
                 clearPendingAuth(lockedConversation);

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -57,7 +57,6 @@ import {
   recordAuthorizationCompleted,
 } from "@/chat/conversations/projection";
 import {
-  applyPendingAuthUpdate,
   clearPendingAuth,
   getConversationPendingAuth,
   isPendingAuthLatestRequest,
@@ -434,17 +433,8 @@ async function resumeOAuthSessionRecordTurn(
             sandbox: getPersistedSandboxState(lockedState),
           },
           durability: {
-            recordPendingAuth: async (nextPendingAuth, options) => {
-              if (nextPendingAuth) {
-                await applyPendingAuthUpdate({
-                  conversation: lockedConversation,
-                  conversationId: stored.resumeConversationId!,
-                  nextPendingAuth,
-                  options,
-                });
-              } else {
-                clearPendingAuth(lockedConversation);
-              }
+            recordPendingAuth: async (nextPendingAuth) => {
+              lockedConversation.processing.pendingAuth = nextPendingAuth;
               await persistThreadStateById(stored.resumeConversationId!, {
                 conversation: lockedConversation,
               });

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -434,12 +434,13 @@ async function resumeOAuthSessionRecordTurn(
             sandbox: getPersistedSandboxState(lockedState),
           },
           durability: {
-            recordPendingAuth: async (nextPendingAuth) => {
+            recordPendingAuth: async (nextPendingAuth, options) => {
               if (nextPendingAuth) {
                 await applyPendingAuthUpdate({
                   conversation: lockedConversation,
                   conversationId: stored.resumeConversationId!,
                   nextPendingAuth,
+                  options,
                 });
               } else {
                 clearPendingAuth(lockedConversation);

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -435,11 +435,15 @@ async function resumeOAuthSessionRecordTurn(
           },
           durability: {
             recordPendingAuth: async (nextPendingAuth) => {
-              await applyPendingAuthUpdate({
-                conversation: lockedConversation,
-                conversationId: stored.resumeConversationId!,
-                nextPendingAuth,
-              });
+              if (nextPendingAuth) {
+                await applyPendingAuthUpdate({
+                  conversation: lockedConversation,
+                  conversationId: stored.resumeConversationId!,
+                  nextPendingAuth,
+                });
+              } else {
+                clearPendingAuth(lockedConversation);
+              }
               await persistThreadStateById(stored.resumeConversationId!, {
                 conversation: lockedConversation,
               });

--- a/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
+++ b/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
@@ -559,21 +559,15 @@ describe("mcp auth runtime slack integration", () => {
     expect(agentProbe.continueCallCount).toBe(1);
     expect(agentProbe.searchToolNames).toEqual([[MCP_TOOL_NAME]]);
 
-    const latestReusableSession =
-      await mcpAuthStoreModule.getLatestMcpAuthSessionForUserProvider(
+    await expect(
+      mcpAuthStoreModule.getMcpAuthSession(parkedAuthSessionId),
+    ).resolves.toBeUndefined();
+    await expect(
+      mcpAuthStoreModule.getLatestMcpAuthSessionForUserProvider(
         "U123",
         EVAL_MCP_AUTH_PROVIDER,
-      );
-    expect(latestReusableSession).toMatchObject({
-      provider: EVAL_MCP_AUTH_PROVIDER,
-      conversationId: threadId,
-      sessionId: turnId,
-      userId: "U123",
-      userMessage: "what did i say about the budget?",
-    });
-    expect(latestReusableSession?.authSessionId).not.toBe(parkedAuthSessionId);
-    expect(latestReusableSession?.authorizationUrl).toBeUndefined();
-    expect(latestReusableSession?.codeVerifier).toBeUndefined();
+      ),
+    ).resolves.toBeUndefined();
     expect(
       await mcpAuthStoreModule.getMcpStoredOAuthCredentials(
         "U123",

--- a/packages/junior/tests/integration/mcp-oauth-callback-slack.test.ts
+++ b/packages/junior/tests/integration/mcp-oauth-callback-slack.test.ts
@@ -103,6 +103,26 @@ let stateAdapterModule: StateAdapterModule;
 let turnSessionStoreModule: TurnSessionStoreModule;
 let pluginApp: PluginAppFixture | undefined;
 
+async function bindPendingAuthAttempt(args: {
+  authSessionId: string;
+  channelId: string;
+  threadTs: string;
+}) {
+  const key = `thread-state:slack:${args.channelId}:${args.threadTs}`;
+  const state = await stateAdapterModule
+    .getStateAdapter()
+    .get<Record<string, unknown>>(key);
+  const conversation = state?.conversation as
+    | { processing?: { pendingAuth?: Record<string, unknown> } }
+    | undefined;
+  const pendingAuth = conversation?.processing?.pendingAuth;
+  if (!state || !pendingAuth) {
+    return;
+  }
+  pendingAuth.authSessionId = args.authSessionId;
+  await stateAdapterModule.getStateAdapter().set(key, state);
+}
+
 async function createPendingAuthSession(args: {
   conversationId: string;
   sessionId: string;
@@ -134,6 +154,11 @@ async function createPendingAuthSession(args: {
     mcpClientModule.McpAuthorizationRequiredError,
   );
   await client.close();
+  await bindPendingAuthAttempt({
+    authSessionId: authProvider.authSessionId,
+    channelId: args.channelId,
+    threadTs: args.threadTs,
+  });
 
   return authProvider;
 }
@@ -343,6 +368,11 @@ describe("mcp oauth callback slack integration", () => {
       mcpClientModule.McpAuthorizationRequiredError,
     );
     await client.close();
+    await bindPendingAuthAttempt({
+      authSessionId: authProvider.authSessionId,
+      channelId: "C123",
+      threadTs: "1700000000.001",
+    });
 
     const pendingSession = await mcpAuthStoreModule.getMcpAuthSession(
       authProvider.authSessionId,
@@ -371,6 +401,36 @@ describe("mcp oauth callback slack integration", () => {
       ),
       codeVerifier: expect.any(String),
     });
+
+    const repeatedProvider = await mcpOauthModule.createMcpOAuthClientProvider({
+      provider: EVAL_MCP_AUTH_PROVIDER,
+      conversationId: "conversation-1",
+      destination: SLACK_DESTINATION,
+      sessionId,
+      userId: "U123",
+      userMessage: "what did i say about the budget?",
+      channelId: "C123",
+      threadTs: "1700000000.001",
+      source: storedSource,
+    });
+    const repeatedClient = new mcpClientModule.PluginMcpClient(plugin!, {
+      authProvider: repeatedProvider,
+    });
+    await expect(repeatedClient.listTools()).rejects.toBeInstanceOf(
+      mcpClientModule.McpAuthorizationRequiredError,
+    );
+    await repeatedClient.close();
+
+    expect(repeatedProvider.authSessionId).not.toBe(authProvider.authSessionId);
+    await expect(
+      mcpAuthStoreModule.getMcpAuthSession(authProvider.authSessionId),
+    ).resolves.toMatchObject({
+      codeVerifier: pendingSession?.codeVerifier,
+      authorizationUrl: pendingSession?.authorizationUrl,
+    });
+    await mcpAuthStoreModule.deleteMcpAuthSession(
+      repeatedProvider.authSessionId,
+    );
 
     const response =
       await mcpOauthCallbackHarnessModule.runMcpOauthCallbackRoute({
@@ -602,6 +662,7 @@ describe("mcp oauth callback slack integration", () => {
         processing: {
           activeTurnId: undefined,
           pendingAuth: {
+            authSessionId: "pending-auth-session",
             kind: "mcp",
             provider: EVAL_MCP_AUTH_PROVIDER,
             actorId: "U123",
@@ -644,6 +705,7 @@ describe("mcp oauth callback slack integration", () => {
         processing: {
           activeTurnId: undefined,
           pendingAuth: {
+            authSessionId: "pending-auth-session",
             kind: "mcp",
             provider: EVAL_MCP_AUTH_PROVIDER,
             actorId: "U123",
@@ -664,6 +726,10 @@ describe("mcp oauth callback slack integration", () => {
       channelId: "C123",
       threadTs: "1700000000.005",
     });
+    staleState.conversation.processing.pendingAuth.authSessionId =
+      authProvider.authSessionId;
+    freshState.conversation.processing.pendingAuth.authSessionId =
+      authProvider.authSessionId;
     await createAwaitingMcpTurnRecord({
       conversationId: threadId,
       sessionId,

--- a/packages/junior/tests/unit/handlers/mcp-oauth-callback.test.ts
+++ b/packages/junior/tests/unit/handlers/mcp-oauth-callback.test.ts
@@ -1,11 +1,30 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { finalizeMcpAuthorizationMock } = vi.hoisted(() => ({
+const {
+  deleteMcpAuthSessionMock,
+  finalizeMcpAuthorizationMock,
+  getMcpAuthSessionMock,
+  getPersistedThreadStateMock,
+} = vi.hoisted(() => ({
+  deleteMcpAuthSessionMock: vi.fn(),
   finalizeMcpAuthorizationMock: vi.fn(),
+  getMcpAuthSessionMock: vi.fn(),
+  getPersistedThreadStateMock: vi.fn(),
 }));
 
 vi.mock("@/chat/mcp/oauth", () => ({
   finalizeMcpAuthorization: finalizeMcpAuthorizationMock,
+}));
+
+vi.mock("@/chat/mcp/auth-store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/chat/mcp/auth-store")>()),
+  deleteMcpAuthSession: deleteMcpAuthSessionMock,
+  getMcpAuthSession: getMcpAuthSessionMock,
+}));
+
+vi.mock("@/chat/runtime/thread-state", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/chat/runtime/thread-state")>()),
+  getPersistedThreadState: getPersistedThreadStateMock,
 }));
 
 import { GET } from "@/handlers/mcp-oauth-callback";
@@ -25,7 +44,37 @@ const testAgentRunner = neverRunAgentRunner();
 
 describe("mcp oauth callback handler", () => {
   beforeEach(() => {
+    deleteMcpAuthSessionMock.mockReset();
     finalizeMcpAuthorizationMock.mockReset();
+    getMcpAuthSessionMock.mockReset();
+    getPersistedThreadStateMock.mockReset();
+    getMcpAuthSessionMock.mockResolvedValue({
+      schemaVersion: 2,
+      authSessionId: "state-123",
+      provider: "demo",
+      userId: "U123",
+      conversationId: "slack:C123:1700000000.001",
+      sessionId: "turn-1",
+      userMessage: "use MCP",
+      channelId: "C123",
+      threadTs: "1700000000.001",
+      createdAtMs: 1,
+      updatedAtMs: 1,
+    });
+    getPersistedThreadStateMock.mockResolvedValue({
+      conversation: {
+        processing: {
+          pendingAuth: {
+            authSessionId: "state-123",
+            kind: "mcp",
+            provider: "demo",
+            actorId: "U123",
+            sessionId: "turn-1",
+            linkSentAtMs: 1,
+          },
+        },
+      },
+    });
     waitUntil = createWaitUntilCollector();
   });
 
@@ -85,5 +134,89 @@ describe("mcp oauth callback handler", () => {
     );
     expect(body).not.toContain("<img src=x onerror=alert(1)>");
     expect(waitUntil.pendingCount()).toBe(0);
+  });
+
+  it("expires callbacks that do not match the current pending attempt", async () => {
+    getPersistedThreadStateMock.mockResolvedValue({
+      conversation: {
+        processing: {
+          pendingAuth: {
+            authSessionId: "newer-state",
+            kind: "mcp",
+            provider: "demo",
+            actorId: "U123",
+            sessionId: "turn-1",
+            linkSentAtMs: 1,
+          },
+        },
+      },
+    });
+
+    const response = await GET(
+      makeRequest(
+        "https://example.com/api/oauth/callback/mcp/demo?code=auth-code&state=state-123",
+      ),
+      "demo",
+      waitUntil.fn,
+      { agentRunner: testAgentRunner },
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain(
+      "This authorization link is no longer active.",
+    );
+    expect(finalizeMcpAuthorizationMock).not.toHaveBeenCalled();
+    expect(deleteMcpAuthSessionMock).toHaveBeenCalledWith("state-123");
+  });
+
+  it("rechecks the exact attempt inside shared credential mutations", async () => {
+    const mutation = vi.fn();
+    getPersistedThreadStateMock
+      .mockResolvedValueOnce({
+        conversation: {
+          processing: {
+            pendingAuth: {
+              authSessionId: "state-123",
+              kind: "mcp",
+              provider: "demo",
+              actorId: "U123",
+              sessionId: "turn-1",
+              linkSentAtMs: 1,
+            },
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        conversation: {
+          processing: {
+            pendingAuth: {
+              authSessionId: "newer-state",
+              kind: "mcp",
+              provider: "demo",
+              actorId: "U123",
+              sessionId: "turn-1",
+              linkSentAtMs: 2,
+            },
+          },
+        },
+      });
+    finalizeMcpAuthorizationMock.mockImplementationOnce(
+      async (_provider, _state, _code, runCredentialMutation) => {
+        await runCredentialMutation(mutation);
+      },
+    );
+
+    const response = await GET(
+      makeRequest(
+        "https://example.com/api/oauth/callback/mcp/demo?code=auth-code&state=state-123",
+      ),
+      "demo",
+      waitUntil.fn,
+      { agentRunner: testAgentRunner },
+    );
+
+    expect(response.status).toBe(400);
+    expect(mutation).not.toHaveBeenCalled();
+    expect(deleteMcpAuthSessionMock).toHaveBeenCalledWith("state-123");
   });
 });

--- a/packages/junior/tests/unit/mcp/auth-store.test.ts
+++ b/packages/junior/tests/unit/mcp/auth-store.test.ts
@@ -19,6 +19,7 @@ function buildSession(
   }> = {},
 ) {
   return {
+    schemaVersion: 2 as const,
     authSessionId,
     provider: overrides.provider ?? "notion",
     userId: overrides.userId ?? "U123",
@@ -71,6 +72,22 @@ describe("MCP auth session store", () => {
     await expect(getMcpAuthSession("auth-4")).resolves.toEqual(
       expect.objectContaining({ authSessionId: "auth-4" }),
     );
+  });
+
+  it("ignores legacy attempt payloads stored under the v2 key", async () => {
+    const { getMcpAuthSession } = await import("@/chat/mcp/auth-store");
+    const { getStateAdapter } = await import("@/chat/state/adapter");
+    const state = getStateAdapter();
+    await state.connect();
+    await state.set(
+      "junior:mcp_oauth_attempt:v2:legacy-auth",
+      JSON.stringify({
+        ...buildSession("legacy-auth"),
+        schemaVersion: 1,
+      }),
+    );
+
+    await expect(getMcpAuthSession("legacy-auth")).resolves.toBeUndefined();
   });
 
   it("keeps bulk deletion working after one sibling session is removed directly", async () => {

--- a/packages/junior/tests/unit/mcp/client.test.ts
+++ b/packages/junior/tests/unit/mcp/client.test.ts
@@ -154,6 +154,29 @@ describe("PluginMcpClient", () => {
     transportOptions.length = 0;
   });
 
+  it("shares one connection across concurrent operations", async () => {
+    const authProvider = buildAuthProvider();
+    authProvider.getMcpServerSessionId.mockResolvedValue(undefined);
+    authProvider.saveMcpServerSessionId.mockResolvedValue(undefined);
+    let finishConnect: (() => void) | undefined;
+    connectMock.mockImplementation(
+      async () =>
+        await new Promise<void>((resolve) => {
+          finishConnect = resolve;
+        }),
+    );
+    listToolsMock.mockResolvedValue({ tools: [], nextCursor: undefined });
+
+    const client = new PluginMcpClient(buildPlugin(), { authProvider });
+    const first = client.listTools();
+    const second = client.listTools();
+
+    await vi.waitFor(() => expect(connectMock).toHaveBeenCalledTimes(1));
+    finishConnect?.();
+    await expect(Promise.all([first, second])).resolves.toEqual([[], []]);
+    expect(transportOptions).toHaveLength(1);
+  });
+
   it("reuses and refreshes host-managed MCP server session ids", async () => {
     const authProvider = buildAuthProvider();
     authProvider.getMcpServerSessionId.mockResolvedValue("stored-session");

--- a/packages/junior/tests/unit/mcp/oauth-provider.test.ts
+++ b/packages/junior/tests/unit/mcp/oauth-provider.test.ts
@@ -72,7 +72,7 @@ describe("StateBackedMcpOAuthClientProvider.invalidateCredentials", () => {
     patchMcpAuthSessionMock.mockResolvedValue(undefined);
   });
 
-  it("preserves the authorization URL when only clearing the verifier", async () => {
+  it("preserves immutable attempt state when invalidating the verifier", async () => {
     const provider = new StateBackedMcpOAuthClientProvider(
       "auth-session-1",
       "https://junior.example.com/callback",
@@ -92,12 +92,10 @@ describe("StateBackedMcpOAuthClientProvider.invalidateCredentials", () => {
         },
       },
     );
-    expect(patchMcpAuthSessionMock).toHaveBeenCalledWith("auth-session-1", {
-      codeVerifier: undefined,
-    });
+    expect(patchMcpAuthSessionMock).not.toHaveBeenCalled();
   });
 
-  it("clears the authorization URL when invalidating all credentials", async () => {
+  it("preserves immutable attempt state when invalidating credentials", async () => {
     const provider = new StateBackedMcpOAuthClientProvider(
       "auth-session-1",
       "https://junior.example.com/callback",
@@ -110,10 +108,7 @@ describe("StateBackedMcpOAuthClientProvider.invalidateCredentials", () => {
       "demo",
       {},
     );
-    expect(patchMcpAuthSessionMock).toHaveBeenCalledWith("auth-session-1", {
-      codeVerifier: undefined,
-      authorizationUrl: undefined,
-    });
+    expect(patchMcpAuthSessionMock).not.toHaveBeenCalled();
   });
 
   it("reads stored credentials without requiring a persisted auth session", async () => {
@@ -174,6 +169,48 @@ describe("StateBackedMcpOAuthClientProvider.invalidateCredentials", () => {
       }),
     );
     expect(patchMcpAuthSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects replacing the verifier for an initialized attempt", async () => {
+    getMcpAuthSessionMock.mockResolvedValue({
+      schemaVersion: 2,
+      authSessionId: "auth-session-1",
+      provider: "demo",
+      userId: "U123",
+      conversationId: "conversation-1",
+      sessionId: "turn-1",
+      userMessage: "/demo",
+      codeVerifier: "original-verifier",
+      createdAtMs: 1,
+      updatedAtMs: 1,
+    });
+    const provider = new StateBackedMcpOAuthClientProvider(
+      "auth-session-1",
+      "https://junior.example.com/callback",
+    );
+
+    await expect(
+      provider.saveCodeVerifier("replacement-verifier"),
+    ).rejects.toThrow("MCP OAuth authorization attempt is already initialized");
+    expect(patchMcpAuthSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("guards shared credential mutations before writing", async () => {
+    const runCredentialMutation = vi
+      .fn()
+      .mockRejectedValue(new Error("expired"));
+    const provider = new StateBackedMcpOAuthClientProvider(
+      "auth-session-1",
+      "https://junior.example.com/callback",
+      undefined,
+      runCredentialMutation,
+    );
+
+    await expect(
+      provider.saveDiscoveryState({ authorizationServerUrl: "https://auth" }),
+    ).rejects.toThrow("expired");
+    expect(runCredentialMutation).toHaveBeenCalledTimes(1);
+    expect(putMcpStoredOAuthCredentialsMock).not.toHaveBeenCalled();
   });
 
   it("stores the opaque MCP server session outside agent-visible state", async () => {

--- a/packages/junior/tests/unit/mcp/oauth.test.ts
+++ b/packages/junior/tests/unit/mcp/oauth.test.ts
@@ -52,9 +52,8 @@ describe("createMcpOAuthClientProvider", () => {
     process.env = { ...ORIGINAL_ENV };
   });
 
-  it("persists and reuses the pending auth session for the same turn", async () => {
-    const { getMcpAuthSession, patchMcpAuthSession } =
-      await import("@/chat/mcp/auth-store");
+  it("creates isolated lazy authorization attempts for the same turn", async () => {
+    const { getMcpAuthSession } = await import("@/chat/mcp/auth-store");
     const { createMcpOAuthClientProvider } = await import("@/chat/mcp/oauth");
 
     const firstProvider = await createMcpOAuthClientProvider({
@@ -69,8 +68,37 @@ describe("createMcpOAuthClientProvider", () => {
       configuration: { region: "us" },
     });
 
-    const initialSession = await getMcpAuthSession(firstProvider.authSessionId);
-    expect(initialSession).toMatchObject({
+    const secondProvider = await createMcpOAuthClientProvider({
+      provider: "demo",
+      conversationId: "conversation-1",
+      destination: SLACK_DESTINATION,
+      sessionId: "turn-1",
+      userId: "U123",
+      userMessage: "use /demo",
+      channelId: "C123",
+      threadTs: "1712345.0001",
+      toolChannelId: "C999",
+      configuration: { region: "eu" },
+      artifactState: { assistantContextChannelId: "C999" },
+    });
+
+    expect(secondProvider.authSessionId).not.toBe(firstProvider.authSessionId);
+    await expect(
+      getMcpAuthSession(firstProvider.authSessionId),
+    ).resolves.toBeUndefined();
+    await expect(
+      getMcpAuthSession(secondProvider.authSessionId),
+    ).resolves.toBeUndefined();
+
+    await firstProvider.saveCodeVerifier("code-verifier");
+    await firstProvider.redirectToAuthorization(
+      new URL("https://auth.example.com/start"),
+    );
+
+    await expect(
+      getMcpAuthSession(firstProvider.authSessionId),
+    ).resolves.toMatchObject({
+      schemaVersion: 2,
       authSessionId: firstProvider.authSessionId,
       provider: "demo",
       userId: "U123",
@@ -81,49 +109,11 @@ describe("createMcpOAuthClientProvider", () => {
       channelId: "C123",
       threadTs: "1712345.0001",
       configuration: { region: "us" },
-    });
-
-    await patchMcpAuthSession(firstProvider.authSessionId, {
       authorizationUrl: "https://auth.example.com/start",
       codeVerifier: "code-verifier",
     });
-
-    const reusedProvider = await createMcpOAuthClientProvider({
-      provider: "demo",
-      conversationId: "conversation-1",
-      destination: SLACK_DESTINATION,
-      sessionId: "turn-1",
-      userId: "U123",
-      userMessage: "use /demo",
-      channelId: "C123",
-      threadTs: "1712345.0001",
-      toolChannelId: "C999",
-      configuration: { region: "eu" },
-      artifactState: { assistantContextChannelId: "C999" },
-    });
-
-    expect(reusedProvider.authSessionId).toBe(firstProvider.authSessionId);
-
-    const reusedSession = await getMcpAuthSession(reusedProvider.authSessionId);
-    expect(reusedSession).toMatchObject({
-      authSessionId: firstProvider.authSessionId,
-      provider: "demo",
-      userId: "U123",
-      conversationId: "conversation-1",
-      destination: SLACK_DESTINATION,
-      sessionId: "turn-1",
-      userMessage: "use /demo",
-      channelId: "C123",
-      threadTs: "1712345.0001",
-      toolChannelId: "C999",
-      configuration: { region: "eu" },
-      artifactState: { assistantContextChannelId: "C999" },
-      authorizationUrl: "https://auth.example.com/start",
-      codeVerifier: "code-verifier",
-    });
-    expect(reusedSession?.createdAtMs).toBe(initialSession?.createdAtMs);
-    expect(reusedSession?.updatedAtMs).toBeGreaterThanOrEqual(
-      initialSession?.updatedAtMs ?? 0,
-    );
+    await expect(
+      getMcpAuthSession(secondProvider.authSessionId),
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/junior/tests/unit/mcp/tool-manager.test.ts
+++ b/packages/junior/tests/unit/mcp/tool-manager.test.ts
@@ -155,6 +155,29 @@ describe("McpToolManager", () => {
     expect(manager.getActiveToolCatalog()).toEqual([]);
   });
 
+  it("creates one provider client across concurrent activations", async () => {
+    let finishProvider: (() => void) | undefined;
+    const authProviderFactory = vi.fn(
+      async () =>
+        await new Promise<undefined>((resolve) => {
+          finishProvider = () => resolve(undefined);
+        }),
+    );
+    const manager = new McpToolManager([buildPlugin()], {
+      authProviderFactory,
+    });
+
+    const first = manager.activateProvider("demo");
+    const second = manager.activateProvider("demo");
+
+    await vi.waitFor(() =>
+      expect(authProviderFactory).toHaveBeenCalledTimes(1),
+    );
+    finishProvider?.();
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+    expect(clientOptions).toHaveLength(1);
+  });
+
   it("throws expected MCP tool errors", async () => {
     const plugin = buildPlugin();
     const manager = new McpToolManager([plugin]);

--- a/packages/junior/tests/unit/runtime/agent-run-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/unit/runtime/agent-run-mcp-progressive-loading.test.ts
@@ -337,6 +337,7 @@ vi.mock("@/chat/mcp/oauth", () => ({
       await import("@/chat/mcp/auth-store");
     const authSessionId = `${input.provider}-auth-session`;
     await putMcpAuthSession({
+      schemaVersion: 2,
       authSessionId,
       provider: input.provider,
       userId: input.userId,
@@ -626,8 +627,10 @@ function makeAgentRunRequest(
     ...(overrides.state ? { state: overrides.state } : {}),
     ...(overrides.observers ? { observers: overrides.observers } : {}),
     durability: {
-      recordPendingAuth: async (pendingAuth: ConversationPendingAuthState) => {
-        pendingAuthRecords.push(pendingAuth);
+      recordPendingAuth: async (pendingAuth) => {
+        if (pendingAuth) {
+          pendingAuthRecords.push(pendingAuth);
+        }
       },
       ...(overrides.durability ?? {}),
     },

--- a/packages/junior/tests/unit/runtime/agent-run-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/unit/runtime/agent-run-mcp-progressive-loading.test.ts
@@ -741,14 +741,15 @@ describe("executeAgentRun progressive MCP loading", () => {
       toolName: "loadSkill",
     });
     expect(deliverPrivateMessageMock).toHaveBeenCalledTimes(1);
-    expect(pendingAuthRecords).toEqual([
+    expect(pendingAuthRecords).toHaveLength(2);
+    expect(pendingAuthRecords.at(-1)).toEqual(
       expect.objectContaining({
         kind: "mcp",
         provider: "demo",
         actorId: "U123",
         sessionId: "turn-1",
       }),
-    ]);
+    );
     expect(loadSkillExecutionErrorCount.value).toBe(0);
 
     const reply = finalReply(await executeAgentRun(context));

--- a/packages/junior/tests/unit/runtime/agent-run-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/unit/runtime/agent-run-mcp-progressive-loading.test.ts
@@ -741,7 +741,7 @@ describe("executeAgentRun progressive MCP loading", () => {
       toolName: "loadSkill",
     });
     expect(deliverPrivateMessageMock).toHaveBeenCalledTimes(1);
-    expect(pendingAuthRecords).toHaveLength(2);
+    expect(pendingAuthRecords).toHaveLength(1);
     expect(pendingAuthRecords.at(-1)).toEqual(
       expect.objectContaining({
         kind: "mcp",

--- a/packages/junior/tests/unit/services/mcp-auth-orchestration.test.ts
+++ b/packages/junior/tests/unit/services/mcp-auth-orchestration.test.ts
@@ -152,6 +152,7 @@ describe("createMcpAuthOrchestration", () => {
       threadTs: "1700000000.000000",
       userMessage: "use MCP",
       pendingAuth: {
+        authSessionId: "github-auth-session",
         kind: "mcp",
         provider: "github",
         actorId: "U123",
@@ -185,5 +186,47 @@ describe("createMcpAuthOrchestration", () => {
       }),
     );
     expect(abortAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the pending attempt when private link delivery fails", async () => {
+    const abortAgent = vi.fn();
+    const recordPendingAuth = vi.fn();
+    getMcpAuthSession.mockResolvedValue({
+      authorizationUrl: "https://mcp.example/authorize",
+      channelId: "C123",
+      threadTs: "1700000000.000000",
+      userId: "U123",
+    });
+    deliverPrivateMessage.mockResolvedValue(false);
+
+    const orchestration = createMcpAuthOrchestration({
+      abortAgent,
+      conversationId: "slack:C123:1700000000.000000",
+      sessionId: "run_new",
+      actorId: "U123",
+      channelId: "C123",
+      threadTs: "1700000000.000000",
+      userMessage: "use MCP",
+      getConfiguration: () => ({}),
+      getArtifactState: () => undefined,
+      getMergedArtifactState: () => ({}),
+      recordPendingAuth,
+    });
+
+    await orchestration.authProviderFactory(plugin("github"));
+
+    await expect(
+      orchestration.onAuthorizationRequired("github"),
+    ).rejects.toThrow(
+      'Unable to deliver MCP authorization link for plugin "github"',
+    );
+
+    expect(recordPendingAuth).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ authSessionId: "auth_1" }),
+    );
+    expect(deleteMcpAuthSession).toHaveBeenCalledWith("auth_1");
+    expect(recordPendingAuth).toHaveBeenNthCalledWith(2, undefined);
+    expect(abortAgent).not.toHaveBeenCalled();
   });
 });

--- a/packages/junior/tests/unit/services/mcp-auth-orchestration.test.ts
+++ b/packages/junior/tests/unit/services/mcp-auth-orchestration.test.ts
@@ -11,6 +11,7 @@ const {
   formatProviderLabel,
   getMcpAuthSession,
   patchMcpAuthSession,
+  abandonAgentTurnSessionRecord,
 } = vi.hoisted(() => ({
   createMcpOAuthClientProvider: vi.fn(),
   deleteMcpAuthSession: vi.fn(),
@@ -18,6 +19,7 @@ const {
   formatProviderLabel: vi.fn((provider: string) => provider),
   getMcpAuthSession: vi.fn(),
   patchMcpAuthSession: vi.fn(),
+  abandonAgentTurnSessionRecord: vi.fn(),
 }));
 
 vi.mock("@/chat/mcp/oauth", () => ({
@@ -33,6 +35,10 @@ vi.mock("@/chat/mcp/auth-store", () => ({
 vi.mock("@/chat/oauth-flow", () => ({
   deliverPrivateMessage,
   formatProviderLabel,
+}));
+
+vi.mock("@/chat/state/turn-session", () => ({
+  abandonAgentTurnSessionRecord,
 }));
 
 function plugin(name: string): PluginDefinition {
@@ -67,6 +73,7 @@ describe("createMcpAuthOrchestration", () => {
     formatProviderLabel.mockClear();
     getMcpAuthSession.mockReset();
     patchMcpAuthSession.mockReset();
+    abandonAgentTurnSessionRecord.mockReset();
   });
 
   it("returns a deterministic error instead of delivering auth links when authorization is disabled", async () => {
@@ -185,22 +192,19 @@ describe("createMcpAuthOrchestration", () => {
         actorId: "U123",
         sessionId: "run_new",
       }),
-      { skipAbandonment: true },
     );
-    expect(recordPendingAuth).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        kind: "mcp",
-        provider: "github",
-        actorId: "U123",
-        sessionId: "run_new",
-      }),
-      {
-        replacedPendingAuth: expect.objectContaining({
-          authSessionId: "github-auth-session",
-          sessionId: "run_old",
-        }),
-      },
+    expect(recordPendingAuth).toHaveBeenCalledTimes(1);
+    expect(abandonAgentTurnSessionRecord).toHaveBeenCalledWith({
+      conversationId: "slack:C123:1700000000.000000",
+      sessionId: "run_old",
+      errorMessage:
+        "Abandoned by a newer auth-blocked request in the same conversation.",
+    });
+    expect(recordPendingAuth.mock.invocationCallOrder[0]).toBeLessThan(
+      deliverPrivateMessage.mock.invocationCallOrder[0]!,
+    );
+    expect(deliverPrivateMessage.mock.invocationCallOrder[0]).toBeLessThan(
+      abandonAgentTurnSessionRecord.mock.invocationCallOrder[0]!,
     );
     expect(abortAgent).toHaveBeenCalledTimes(1);
   });
@@ -250,12 +254,10 @@ describe("createMcpAuthOrchestration", () => {
     expect(recordPendingAuth).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({ authSessionId: "auth_1" }),
-      { skipAbandonment: true },
     );
     expect(deleteMcpAuthSession).toHaveBeenCalledWith("auth_1");
-    expect(recordPendingAuth).toHaveBeenNthCalledWith(2, previousPendingAuth, {
-      skipAbandonment: true,
-    });
+    expect(recordPendingAuth).toHaveBeenNthCalledWith(2, previousPendingAuth);
+    expect(abandonAgentTurnSessionRecord).not.toHaveBeenCalled();
     expect(abortAgent).not.toHaveBeenCalled();
   });
 });

--- a/packages/junior/tests/unit/services/mcp-auth-orchestration.test.ts
+++ b/packages/junior/tests/unit/services/mcp-auth-orchestration.test.ts
@@ -183,6 +183,12 @@ describe("createMcpAuthOrchestration", () => {
         userId: "U123",
       }),
     );
+    expect(patchMcpAuthSession).toHaveBeenCalledWith("auth_1", {
+      configuration: {},
+      artifactState: {},
+      toolChannelId: "C123",
+    });
+    expect(getMcpAuthSession).toHaveBeenCalledWith("auth_1");
     expect(deleteMcpAuthSession).not.toHaveBeenCalled();
     expect(recordPendingAuth).toHaveBeenNthCalledWith(
       1,
@@ -203,9 +209,63 @@ describe("createMcpAuthOrchestration", () => {
     expect(recordPendingAuth.mock.invocationCallOrder[0]).toBeLessThan(
       deliverPrivateMessage.mock.invocationCallOrder[0]!,
     );
+    expect(patchMcpAuthSession.mock.invocationCallOrder[0]).toBeLessThan(
+      getMcpAuthSession.mock.invocationCallOrder[0]!,
+    );
+    expect(getMcpAuthSession.mock.invocationCallOrder[0]).toBeLessThan(
+      recordPendingAuth.mock.invocationCallOrder[0]!,
+    );
     expect(deliverPrivateMessage.mock.invocationCallOrder[0]).toBeLessThan(
       abandonAgentTurnSessionRecord.mock.invocationCallOrder[0]!,
     );
+    expect(abortAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("updates the surviving attempt when reusing a pending link", async () => {
+    const abortAgent = vi.fn();
+    const recordPendingAuth = vi.fn();
+    const pendingAuth = {
+      authSessionId: "auth_existing",
+      kind: "mcp" as const,
+      provider: "github",
+      actorId: "U123",
+      sessionId: "run_1",
+      linkSentAtMs: Date.now(),
+    };
+
+    const orchestration = createMcpAuthOrchestration({
+      abortAgent,
+      conversationId: "slack:C123:1700000000.000000",
+      sessionId: "run_1",
+      actorId: "U123",
+      channelId: "C123",
+      threadTs: "1700000000.000000",
+      userMessage: "use MCP",
+      pendingAuth,
+      getConfiguration: () => ({ region: "us" }),
+      getArtifactState: () => undefined,
+      getMergedArtifactState: () => ({
+        assistantContextChannelId: "C-tools",
+      }),
+      recordPendingAuth,
+    });
+
+    await orchestration.authProviderFactory(plugin("github"));
+
+    await expect(orchestration.onAuthorizationRequired("github")).resolves.toBe(
+      true,
+    );
+
+    expect(patchMcpAuthSession).toHaveBeenCalledWith("auth_existing", {
+      configuration: { region: "us" },
+      artifactState: { assistantContextChannelId: "C-tools" },
+      toolChannelId: "C-tools",
+    });
+    expect(deleteMcpAuthSession).toHaveBeenCalledWith("auth_1");
+    expect(getMcpAuthSession).not.toHaveBeenCalled();
+    expect(deliverPrivateMessage).not.toHaveBeenCalled();
+    expect(recordPendingAuth).toHaveBeenCalledWith(pendingAuth);
+    expect(abandonAgentTurnSessionRecord).not.toHaveBeenCalled();
     expect(abortAgent).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/junior/tests/unit/services/mcp-auth-orchestration.test.ts
+++ b/packages/junior/tests/unit/services/mcp-auth-orchestration.test.ts
@@ -177,20 +177,45 @@ describe("createMcpAuthOrchestration", () => {
       }),
     );
     expect(deleteMcpAuthSession).not.toHaveBeenCalled();
-    expect(recordPendingAuth).toHaveBeenCalledWith(
+    expect(recordPendingAuth).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         kind: "mcp",
         provider: "github",
         actorId: "U123",
         sessionId: "run_new",
       }),
+      { skipAbandonment: true },
+    );
+    expect(recordPendingAuth).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        kind: "mcp",
+        provider: "github",
+        actorId: "U123",
+        sessionId: "run_new",
+      }),
+      {
+        replacedPendingAuth: expect.objectContaining({
+          authSessionId: "github-auth-session",
+          sessionId: "run_old",
+        }),
+      },
     );
     expect(abortAgent).toHaveBeenCalledTimes(1);
   });
 
-  it("clears the pending attempt when private link delivery fails", async () => {
+  it("restores the prior pending attempt when private link delivery fails", async () => {
     const abortAgent = vi.fn();
     const recordPendingAuth = vi.fn();
+    const previousPendingAuth = {
+      authSessionId: "auth_old",
+      kind: "mcp" as const,
+      provider: "github",
+      actorId: "U123",
+      sessionId: "run_old",
+      linkSentAtMs: 1,
+    };
     getMcpAuthSession.mockResolvedValue({
       authorizationUrl: "https://mcp.example/authorize",
       channelId: "C123",
@@ -207,6 +232,7 @@ describe("createMcpAuthOrchestration", () => {
       channelId: "C123",
       threadTs: "1700000000.000000",
       userMessage: "use MCP",
+      pendingAuth: previousPendingAuth,
       getConfiguration: () => ({}),
       getArtifactState: () => undefined,
       getMergedArtifactState: () => ({}),
@@ -224,9 +250,12 @@ describe("createMcpAuthOrchestration", () => {
     expect(recordPendingAuth).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({ authSessionId: "auth_1" }),
+      { skipAbandonment: true },
     );
     expect(deleteMcpAuthSession).toHaveBeenCalledWith("auth_1");
-    expect(recordPendingAuth).toHaveBeenNthCalledWith(2, undefined);
+    expect(recordPendingAuth).toHaveBeenNthCalledWith(2, previousPendingAuth, {
+      skipAbandonment: true,
+    });
     expect(abortAgent).not.toHaveBeenCalled();
   });
 });

--- a/packages/junior/tests/unit/services/pending-auth.test.ts
+++ b/packages/junior/tests/unit/services/pending-auth.test.ts
@@ -19,15 +19,18 @@ function pendingAuth(
     sessionId: string;
     linkSentAtMs: number;
   }> = {},
-) {
-  return {
-    kind: "mcp" as const,
+): ConversationPendingAuthState {
+  const { kind = "mcp", ...rest } = overrides;
+  const value = {
     provider: "eval-auth",
     actorId: "U123",
     sessionId: "run_1",
     linkSentAtMs: NOW - 60_000,
-    ...overrides,
+    ...rest,
   };
+  return kind === "mcp"
+    ? { ...value, authSessionId: "auth-session-1", kind }
+    : { ...value, kind };
 }
 
 function conversationWithMessages(

--- a/packages/junior/tests/unit/services/pending-auth.test.ts
+++ b/packages/junior/tests/unit/services/pending-auth.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+const { abandonAgentTurnSessionRecord } = vi.hoisted(() => ({
+  abandonAgentTurnSessionRecord: vi.fn(),
+}));
+
+vi.mock("@/chat/state/turn-session", () => ({
+  abandonAgentTurnSessionRecord,
+}));
+
 import {
+  applyPendingAuthUpdate,
   canReusePendingAuthLink,
   isPendingAuthLatestRequest,
 } from "@/chat/services/pending-auth";
@@ -10,6 +19,10 @@ import type {
 
 const NOW = 1_700_000_000_000;
 const REUSE_WINDOW_MS = 10 * 60 * 1000;
+
+beforeEach(() => {
+  abandonAgentTurnSessionRecord.mockReset();
+});
 
 function pendingAuth(
   overrides: Partial<{
@@ -166,6 +179,45 @@ describe("canReusePendingAuthLink", () => {
         nowMs: NOW,
       }),
     ).toBe(false);
+  });
+});
+
+describe("applyPendingAuthUpdate", () => {
+  it("stages a replacement without abandoning the current session", async () => {
+    const conversation = conversationWithMessages([]);
+    conversation.processing.pendingAuth = pendingAuthState("run_old");
+    const nextPendingAuth = pendingAuthState("run_new");
+
+    await applyPendingAuthUpdate({
+      conversation,
+      conversationId: "conversation-1",
+      nextPendingAuth,
+      options: { skipAbandonment: true },
+    });
+
+    expect(conversation.processing.pendingAuth).toBe(nextPendingAuth);
+    expect(abandonAgentTurnSessionRecord).not.toHaveBeenCalled();
+  });
+
+  it("abandons the explicitly replaced session after staging succeeds", async () => {
+    const conversation = conversationWithMessages([]);
+    const previousPendingAuth = pendingAuthState("run_old");
+    const nextPendingAuth = pendingAuthState("run_new");
+    conversation.processing.pendingAuth = nextPendingAuth;
+
+    await applyPendingAuthUpdate({
+      conversation,
+      conversationId: "conversation-1",
+      nextPendingAuth,
+      options: { replacedPendingAuth: previousPendingAuth },
+    });
+
+    expect(abandonAgentTurnSessionRecord).toHaveBeenCalledWith({
+      conversationId: "conversation-1",
+      sessionId: "run_old",
+      errorMessage:
+        "Abandoned by a newer auth-blocked request in the same conversation.",
+    });
   });
 });
 

--- a/packages/junior/tests/unit/services/pending-auth.test.ts
+++ b/packages/junior/tests/unit/services/pending-auth.test.ts
@@ -8,7 +8,7 @@ vi.mock("@/chat/state/turn-session", () => ({
 }));
 
 import {
-  applyPendingAuthUpdate,
+  abandonReplacedPendingAuth,
   canReusePendingAuthLink,
   isPendingAuthLatestRequest,
 } from "@/chat/services/pending-auth";
@@ -182,34 +182,15 @@ describe("canReusePendingAuthLink", () => {
   });
 });
 
-describe("applyPendingAuthUpdate", () => {
-  it("stages a replacement without abandoning the current session", async () => {
-    const conversation = conversationWithMessages([]);
-    conversation.processing.pendingAuth = pendingAuthState("run_old");
-    const nextPendingAuth = pendingAuthState("run_new");
-
-    await applyPendingAuthUpdate({
-      conversation,
-      conversationId: "conversation-1",
-      nextPendingAuth,
-      options: { skipAbandonment: true },
-    });
-
-    expect(conversation.processing.pendingAuth).toBe(nextPendingAuth);
-    expect(abandonAgentTurnSessionRecord).not.toHaveBeenCalled();
-  });
-
-  it("abandons the explicitly replaced session after staging succeeds", async () => {
-    const conversation = conversationWithMessages([]);
+describe("abandonReplacedPendingAuth", () => {
+  it("abandons a prior blocked session after replacement succeeds", async () => {
     const previousPendingAuth = pendingAuthState("run_old");
     const nextPendingAuth = pendingAuthState("run_new");
-    conversation.processing.pendingAuth = nextPendingAuth;
 
-    await applyPendingAuthUpdate({
-      conversation,
+    await abandonReplacedPendingAuth({
       conversationId: "conversation-1",
+      previousPendingAuth,
       nextPendingAuth,
-      options: { replacedPendingAuth: previousPendingAuth },
     });
 
     expect(abandonAgentTurnSessionRecord).toHaveBeenCalledWith({

--- a/packages/junior/tests/unit/services/plugin-auth-orchestration.test.ts
+++ b/packages/junior/tests/unit/services/plugin-auth-orchestration.test.ts
@@ -13,11 +13,13 @@ const {
   getOAuthConfigMock,
   startOAuthFlow,
   unlinkProvider,
+  abandonAgentTurnSessionRecord,
 } = vi.hoisted(() => ({
   formatProviderLabel: vi.fn((provider: string) => provider),
   getOAuthConfigMock: vi.fn(),
   startOAuthFlow: vi.fn(),
   unlinkProvider: vi.fn(),
+  abandonAgentTurnSessionRecord: vi.fn(),
 }));
 
 vi.mock("@/chat/oauth-flow", () => ({
@@ -33,6 +35,10 @@ vi.mock("@/chat/plugins/catalog-runtime", () => ({
 
 vi.mock("@/chat/credentials/unlink-provider", () => ({
   unlinkProvider,
+}));
+
+vi.mock("@/chat/state/turn-session", () => ({
+  abandonAgentTurnSessionRecord,
 }));
 
 function tokenStore(): UserTokenStore {
@@ -75,6 +81,7 @@ describe("createPluginAuthOrchestration", () => {
     );
     startOAuthFlow.mockReset();
     unlinkProvider.mockReset();
+    abandonAgentTurnSessionRecord.mockReset();
   });
 
   async function expectPluginCredentialFailure(
@@ -328,6 +335,12 @@ describe("createPluginAuthOrchestration", () => {
         sessionId: "run_new",
       }),
     );
+    expect(abandonAgentTurnSessionRecord).toHaveBeenCalledWith({
+      conversationId: "slack:C123:1700000000.000000",
+      sessionId: "run_old",
+      errorMessage:
+        "Abandoned by a newer auth-blocked request in the same conversation.",
+    });
   });
 
   it("throws PluginCredentialFailureError for signals without oauth authorization", async () => {

--- a/packages/junior/tests/unit/state/conversation-state.test.ts
+++ b/packages/junior/tests/unit/state/conversation-state.test.ts
@@ -55,6 +55,62 @@ describe("conversation state", () => {
     });
   });
 
+  it("ignores legacy MCP pending auth without an attempt id", () => {
+    const conversation = coerceThreadConversationState({
+      conversation: {
+        processing: {
+          pendingAuth: {
+            kind: "mcp",
+            provider: "notion",
+            actorId: "U123",
+            sessionId: "turn-1",
+            linkSentAtMs: 1,
+          },
+        },
+      },
+    });
+
+    expect(conversation.processing.pendingAuth).toBeUndefined();
+  });
+
+  it("coerces message image file ids and vision summaries", () => {
+    const conversation = coerceThreadConversationState({
+      conversation: {
+        messages: [
+          {
+            id: "1700000000.100",
+            role: "user",
+            text: "candidate info",
+            createdAtMs: 1700000000100,
+            meta: { slackTs: "1700000000.100" },
+          },
+        ],
+        vision: {
+          byFileId: {
+            F123: {
+              summary: "Candidate name appears as Jane Doe.",
+              analyzedAtMs: 1700000000500,
+            },
+            bad: {
+              summary: "",
+              analyzedAtMs: 10,
+            },
+          },
+        },
+      },
+    });
+
+    // The visible transcript lives in SQL now; a legacy transcript mirror in a
+    // persisted payload is dropped on read.
+    expect(conversation.messages).toEqual([]);
+    expect(conversation.vision.byFileId).toEqual({
+      F123: {
+        summary: "Candidate name appears as Jane Doe.",
+        analyzedAtMs: 1700000000500,
+      },
+    });
+  });
+
   it("includes vision cache in state patch payload", () => {
     const state: ThreadConversationState = coerceThreadConversationState({
       conversation: {


### PR DESCRIPTION
MCP OAuth authorization links now own immutable attempt IDs and PKCE material. Repeated or concurrent transport initialization no longer reuses per-turn authorization state, and callbacks only mutate shared credentials while the exact attempt remains pending under the thread lock.

This intentionally makes a clean break for pending authorization state: pre-v2 MCP attempt keys and persisted MCP pending-auth records without `authSessionId` are ignored. Existing completed user/provider credentials remain valid.

Private-link delivery persists the new exact attempt before sending the link so a fast callback can validate it. Failed delivery deletes the new attempt and restores the prior pending state; successful delivery leaves the staged attempt in place and explicitly abandons the replaced blocked turn. The generic pending-auth durability port remains a plain state setter rather than exposing transition-specific options.

Client and provider construction are single-flight to prevent duplicate challenge starts. Regression coverage exercises verifier immutability, concurrent authorization starts, stale callback races, delivery rollback, transition ordering, legacy-state invalidation, and successful Slack continuation.