### PR TITLE
fix(state): Migrate legacy turn-session actors

### DIFF
--- a/packages/junior/src/cli/upgrade.ts
+++ b/packages/junior/src/cli/upgrade.ts
@@ -11,6 +11,7 @@ import { pluginStorageMigration } from "./upgrade/migrations/plugin-storage";
 import { sqlPluginMigration } from "./upgrade/migrations/plugin-sql";
 import { resolveUpgradePlugins } from "./upgrade/migrations/upgrade-plugins";
 import { redisConversationStateMigration } from "./upgrade/migrations/redis-conversation-state";
+import { agentTurnSessionActorMigration } from "./upgrade/migrations/agent-turn-session-actor";
 import type {
   MigrationContext,
   MigrationResult,
@@ -25,6 +26,7 @@ const DEFAULT_IO: UpgradeIo = {
 const localPluginLoader = createJiti(import.meta.url, { moduleCache: false });
 
 const MIGRATIONS: UpgradeMigration[] = [
+  agentTurnSessionActorMigration,
   redisConversationStateMigration,
   coreSqlSchemaMigration,
   sqlConversationMigration,

--- a/packages/junior/src/cli/upgrade/migrations/agent-turn-session-actor.ts
+++ b/packages/junior/src/cli/upgrade/migrations/agent-turn-session-actor.ts
@@ -1,0 +1,149 @@
+import { THREAD_STATE_TTL_MS, type StateAdapter } from "chat";
+import { isRecord, toOptionalString } from "@/chat/coerce";
+import type {
+  MigrationContext,
+  MigrationResult,
+  UpgradeMigration,
+} from "../types";
+
+const AGENT_TURN_SESSION_PREFIX = "junior:agent_turn_session";
+const AGENT_TURN_SESSION_INDEX_KEY = `${AGENT_TURN_SESSION_PREFIX}:index`;
+const AGENT_TURN_SESSION_INDEX_MAX_LENGTH = 5_000;
+
+interface MigratedValue {
+  changed: boolean;
+  value: unknown;
+}
+
+function conversationIndexKey(conversationId: string): string {
+  return `${AGENT_TURN_SESSION_PREFIX}:conversation:${conversationId}:index`;
+}
+
+function sessionRecordKey(conversationId: string, sessionId: string): string {
+  return `${AGENT_TURN_SESSION_PREFIX}:${conversationId}:${sessionId}`;
+}
+
+function migrateRequesterToActor(value: unknown): MigratedValue {
+  if (!isRecord(value) || value.requester === undefined) {
+    return { changed: false, value };
+  }
+
+  const { requester, ...record } = value;
+  return {
+    changed: true,
+    value: {
+      ...record,
+      ...(record.actor === undefined ? { actor: requester } : {}),
+    },
+  };
+}
+
+async function rewriteList(args: {
+  key: string;
+  maxLength?: number;
+  stateAdapter: StateAdapter;
+}): Promise<{ migrated: number; values: unknown[] }> {
+  const values = await args.stateAdapter.getList(args.key);
+  const migrated = values.map(migrateRequesterToActor);
+  const changed = migrated.filter((entry) => entry.changed).length;
+  if (changed === 0) {
+    return { migrated: 0, values };
+  }
+
+  await args.stateAdapter.delete(args.key);
+  for (const entry of migrated) {
+    await args.stateAdapter.appendToList(args.key, entry.value, {
+      ...(args.maxLength !== undefined ? { maxLength: args.maxLength } : {}),
+      ttlMs: THREAD_STATE_TTL_MS,
+    });
+  }
+  return { migrated: changed, values: migrated.map((entry) => entry.value) };
+}
+
+async function migrateSessionRecord(args: {
+  conversationId: string;
+  sessionId: string;
+  stateAdapter: StateAdapter;
+}): Promise<"existing" | "migrated" | "missing"> {
+  const key = sessionRecordKey(args.conversationId, args.sessionId);
+  const existing = await args.stateAdapter.get<unknown>(key);
+  if (existing === undefined) {
+    return "missing";
+  }
+  const migrated = migrateRequesterToActor(existing);
+  if (!migrated.changed) {
+    return "existing";
+  }
+  await args.stateAdapter.set(key, migrated.value, THREAD_STATE_TTL_MS);
+  return "migrated";
+}
+
+async function migrateAgentTurnSessionActor(
+  context: MigrationContext,
+): Promise<MigrationResult> {
+  const result: MigrationResult = {
+    existing: 0,
+    migrated: 0,
+    missing: 0,
+    scanned: 0,
+  };
+  const global = await rewriteList({
+    key: AGENT_TURN_SESSION_INDEX_KEY,
+    maxLength: AGENT_TURN_SESSION_INDEX_MAX_LENGTH,
+    stateAdapter: context.stateAdapter,
+  });
+  result.scanned += global.values.length;
+  result.migrated += global.migrated;
+
+  const conversations = new Set<string>();
+  const sessions = new Set<string>();
+  for (const value of global.values) {
+    if (!isRecord(value)) {
+      continue;
+    }
+    const conversationId = toOptionalString(value.conversationId);
+    const sessionId = toOptionalString(value.sessionId);
+    if (!conversationId) {
+      continue;
+    }
+    conversations.add(conversationId);
+    if (sessionId) {
+      sessions.add(`${conversationId}\u0000${sessionId}`);
+    }
+  }
+
+  for (const conversationId of conversations) {
+    const conversation = await rewriteList({
+      key: conversationIndexKey(conversationId),
+      stateAdapter: context.stateAdapter,
+    });
+    result.scanned += conversation.values.length;
+    result.migrated += conversation.migrated;
+  }
+
+  for (const session of sessions) {
+    const separator = session.indexOf("\u0000");
+    const conversationId = session.slice(0, separator);
+    const sessionId = session.slice(separator + 1);
+    result.scanned += 1;
+    const status = await migrateSessionRecord({
+      conversationId,
+      sessionId,
+      stateAdapter: context.stateAdapter,
+    });
+    if (status === "migrated") {
+      result.migrated += 1;
+    } else if (status === "existing") {
+      result.existing += 1;
+    } else {
+      result.missing += 1;
+    }
+  }
+
+  return result;
+}
+
+export const agentTurnSessionActorMigration: UpgradeMigration = {
+  name: "migrate-agent-turn-session-requester-to-actor",
+  run: migrateAgentTurnSessionActor,
+};

--- a/packages/junior/tests/component/cli/upgrade-cli.test.ts
+++ b/packages/junior/tests/component/cli/upgrade-cli.test.ts
@@ -15,6 +15,7 @@ import type { ConversationStore } from "@/chat/conversations/store";
 import { persistThreadStateById } from "@/chat/runtime/thread-state";
 import { recordAgentTurnSessionSummary } from "@/chat/state/turn-session";
 import { resolveUpgradePluginSet } from "@/cli/upgrade";
+import { agentTurnSessionActorMigration } from "@/cli/upgrade/migrations/agent-turn-session-actor";
 import { migrateConversationsToSql } from "@/cli/upgrade/migrations/conversations-sql";
 import { redisConversationStateMigration } from "@/cli/upgrade/migrations/redis-conversation-state";
 import {
@@ -120,6 +121,86 @@ export const plugins = {
       process.chdir(ORIGINAL_CWD);
       rmSync(tempDir, { force: true, recursive: true });
     }
+  });
+
+  it("migrates legacy requester fields in turn-session state", async () => {
+    const stateAdapter = getStateAdapter();
+    await stateAdapter.connect();
+    const conversationId = "slack:C123:legacy-actor";
+    const sessionId = "turn-legacy-actor";
+    const requester = {
+      platform: "slack",
+      teamId: "T123",
+      userId: "U123",
+      userName: "alice",
+    };
+    const summary = {
+      version: 1,
+      conversationId,
+      cumulativeDurationMs: 0,
+      lastProgressAtMs: 2,
+      requester,
+      sessionId,
+      sliceId: 1,
+      startedAtMs: 1,
+      state: "completed",
+      updatedAtMs: 3,
+    };
+
+    await stateAdapter.appendToList(
+      "junior:agent_turn_session:index",
+      summary,
+      { ttlMs: 60_000 },
+    );
+    await stateAdapter.appendToList(
+      `junior:agent_turn_session:conversation:${conversationId}:index`,
+      summary,
+      { ttlMs: 60_000 },
+    );
+    await stateAdapter.set(
+      `junior:agent_turn_session:${conversationId}:${sessionId}`,
+      { ...summary, committedSeq: -1 },
+      60_000,
+    );
+
+    await expect(
+      agentTurnSessionActorMigration.run({
+        io: { info: () => {} },
+        stateAdapter,
+      }),
+    ).resolves.toEqual({
+      existing: 0,
+      migrated: 3,
+      missing: 0,
+      scanned: 3,
+    });
+
+    const { listBoundedAgentTurnSessionSummariesForConversation } =
+      await import("@/chat/state/turn-session");
+    await expect(
+      listBoundedAgentTurnSessionSummariesForConversation(conversationId),
+    ).resolves.toEqual([
+      expect.objectContaining({ actor: requester, sessionId }),
+    ]);
+    const migratedRecord = await stateAdapter.get(
+      `junior:agent_turn_session:${conversationId}:${sessionId}`,
+    );
+    expect(migratedRecord).toEqual(
+      expect.objectContaining({ actor: requester }),
+    );
+    expect(migratedRecord).not.toHaveProperty("requester");
+
+    await expect(
+      agentTurnSessionActorMigration.run({
+        io: { info: () => {} },
+        stateAdapter,
+      }),
+    ).resolves.toEqual({
+      existing: 1,
+      migrated: 0,
+      missing: 0,
+      scanned: 3,
+    });
   });
 
   it("migrates legacy conversation work before SQL conversation backfill", async () => {


### PR DESCRIPTION
Strict turn-session readers no longer fail when retained state still uses the legacy `requester` field. A new `junior upgrade` migration rewrites the global summary index, per-conversation indexes, and session records to `actor` before the runtime starts, preventing one stale global entry from breaking continuation lookup for both existing and new conversations.

The migration is idempotent and preserves an existing `actor` when both fields are present. Regression coverage exercises the strict reader after migration and verifies safe reruns.