### PR TITLE
fix(state): Discover retained turn-session indexes

### DIFF
--- a/packages/junior/src/cli/upgrade/migrations/agent-turn-session-actor.ts
+++ b/packages/junior/src/cli/upgrade/migrations/agent-turn-session-actor.ts
@@ -1,5 +1,7 @@
+import type { RedisStateAdapter } from "@chat-adapter/state-redis";
 import { THREAD_STATE_TTL_MS, type StateAdapter } from "chat";
 import { isRecord, toOptionalString } from "@/chat/coerce";
+import { getChatConfig } from "@/chat/config";
 import type {
   MigrationContext,
   MigrationResult,
@@ -9,6 +11,11 @@ import type {
 const AGENT_TURN_SESSION_PREFIX = "junior:agent_turn_session";
 const AGENT_TURN_SESSION_INDEX_KEY = `${AGENT_TURN_SESSION_PREFIX}:index`;
 const AGENT_TURN_SESSION_INDEX_MAX_LENGTH = 5_000;
+const REDIS_SCAN_COUNT = 500;
+
+type RedisCommandClient = {
+  sendCommand<T = unknown>(args: readonly string[]): Promise<T>;
+};
 
 interface MigratedValue {
   changed: boolean;
@@ -21,6 +28,72 @@ function conversationIndexKey(conversationId: string): string {
 
 function sessionRecordKey(conversationId: string, sessionId: string): string {
   return `${AGENT_TURN_SESSION_PREFIX}:${conversationId}:${sessionId}`;
+}
+
+function logicalConversationIndexPrefix(): string {
+  const prefix = getChatConfig().state.keyPrefix;
+  return [
+    ...(prefix ? [prefix] : []),
+    `${AGENT_TURN_SESSION_PREFIX}:conversation:`,
+  ].join(":");
+}
+
+function conversationIdFromRedisListKey(key: string): string | undefined {
+  const marker = `:list:${logicalConversationIndexPrefix()}`;
+  const markerIndex = key.indexOf(marker);
+  if (markerIndex < 0 || !key.endsWith(":index")) {
+    return undefined;
+  }
+  return toOptionalString(
+    key.slice(markerIndex + marker.length, -":index".length),
+  );
+}
+
+async function discoverRedisConversationIds(
+  redisStateAdapter: RedisStateAdapter | undefined,
+): Promise<string[]> {
+  const client = redisStateAdapter?.getClient() as
+    | RedisCommandClient
+    | undefined;
+  if (!client) {
+    return [];
+  }
+
+  const conversationIds = new Set<string>();
+  const match = `*:list:${logicalConversationIndexPrefix()}*:index`;
+  let cursor = "0";
+  do {
+    const reply = await client.sendCommand<unknown>([
+      "SCAN",
+      cursor,
+      "MATCH",
+      match,
+      "COUNT",
+      String(REDIS_SCAN_COUNT),
+    ]);
+    if (
+      !Array.isArray(reply) ||
+      reply.length !== 2 ||
+      (typeof reply[0] !== "string" && typeof reply[0] !== "number") ||
+      !Array.isArray(reply[1])
+    ) {
+      throw new Error(
+        "Unexpected Redis SCAN response while migrating turn sessions",
+      );
+    }
+    cursor = String(reply[0]);
+    for (const key of reply[1]) {
+      if (typeof key !== "string") {
+        continue;
+      }
+      const conversationId = conversationIdFromRedisListKey(key);
+      if (conversationId) {
+        conversationIds.add(conversationId);
+      }
+    }
+  } while (cursor !== "0");
+
+  return [...conversationIds];
 }
 
 function migrateRequesterToActor(value: unknown): MigratedValue {
@@ -97,6 +170,11 @@ async function migrateAgentTurnSessionActor(
 
   const conversations = new Set<string>();
   const sessions = new Set<string>();
+  for (const conversationId of await discoverRedisConversationIds(
+    context.redisStateAdapter,
+  )) {
+    conversations.add(conversationId);
+  }
   for (const value of global.values) {
     if (!isRecord(value)) {
       continue;
@@ -119,6 +197,15 @@ async function migrateAgentTurnSessionActor(
     });
     result.scanned += conversation.values.length;
     result.migrated += conversation.migrated;
+    for (const value of conversation.values) {
+      if (!isRecord(value)) {
+        continue;
+      }
+      const sessionId = toOptionalString(value.sessionId);
+      if (sessionId) {
+        sessions.add(`${conversationId}\u0000${sessionId}`);
+      }
+    }
   }
 
   for (const session of sessions) {

--- a/packages/junior/tests/component/cli/upgrade-cli.test.ts
+++ b/packages/junior/tests/component/cli/upgrade-cli.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import type { RedisStateAdapter } from "@chat-adapter/state-redis";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import {
@@ -201,6 +202,82 @@ export const plugins = {
       missing: 0,
       scanned: 3,
     });
+  });
+
+  it("discovers legacy turn sessions outside the bounded global index", async () => {
+    const stateAdapter = getStateAdapter();
+    await stateAdapter.connect();
+    const conversationId = "slack:C123:older-legacy-actor";
+    const sessionId = "turn-older-legacy-actor";
+    const requester = {
+      platform: "slack",
+      teamId: "T123",
+      userId: "U123",
+    };
+    const summary = {
+      version: 1,
+      conversationId,
+      cumulativeDurationMs: 0,
+      lastProgressAtMs: 2,
+      requester,
+      sessionId,
+      sliceId: 1,
+      startedAtMs: 1,
+      state: "completed",
+      updatedAtMs: 3,
+    };
+
+    await stateAdapter.appendToList(
+      `junior:agent_turn_session:conversation:${conversationId}:index`,
+      summary,
+      { ttlMs: 60_000 },
+    );
+    await stateAdapter.set(
+      `junior:agent_turn_session:${conversationId}:${sessionId}`,
+      { ...summary, committedSeq: -1 },
+      60_000,
+    );
+
+    const redisStateAdapter = {
+      getClient: () => ({
+        sendCommand: async (args: readonly string[]) => {
+          const match = args[3];
+          if (!match) {
+            throw new Error("Expected Redis SCAN match pattern");
+          }
+          return [
+            "0",
+            [match.replace("*", "chat-sdk").replace("*", conversationId)],
+          ];
+        },
+      }),
+    } as unknown as RedisStateAdapter;
+
+    await expect(
+      agentTurnSessionActorMigration.run({
+        io: { info: () => {} },
+        redisStateAdapter,
+        stateAdapter,
+      }),
+    ).resolves.toEqual({
+      existing: 0,
+      migrated: 2,
+      missing: 0,
+      scanned: 2,
+    });
+
+    const { listBoundedAgentTurnSessionSummariesForConversation } =
+      await import("@/chat/state/turn-session");
+    await expect(
+      listBoundedAgentTurnSessionSummariesForConversation(conversationId),
+    ).resolves.toEqual([
+      expect.objectContaining({ actor: requester, sessionId }),
+    ]);
+    await expect(
+      stateAdapter.get(
+        `junior:agent_turn_session:${conversationId}:${sessionId}`,
+      ),
+    ).resolves.toEqual(expect.objectContaining({ actor: requester }));
   });
 
   it("migrates legacy conversation work before SQL conversation backfill", async () => {

--- a/packages/junior/tests/component/cli/upgrade-cli.test.ts
+++ b/packages/junior/tests/component/cli/upgrade-cli.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import type { RedisStateAdapter } from "@chat-adapter/state-redis";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getChatConfig } from "@/chat/config";
 import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import {
   appendInboundMessage,
@@ -238,17 +239,24 @@ export const plugins = {
       60_000,
     );
 
+    const statePrefix = getChatConfig().state.keyPrefix;
+    const redisConversationIndexKey = [
+      "chat-sdk:list",
+      ...(statePrefix ? [statePrefix] : []),
+      `junior:agent_turn_session:conversation:${conversationId}:index`,
+    ].join(":");
     const redisStateAdapter = {
       getClient: () => ({
         sendCommand: async (args: readonly string[]) => {
-          const match = args[3];
-          if (!match) {
-            throw new Error("Expected Redis SCAN match pattern");
-          }
-          return [
+          expect(args).toEqual([
+            "SCAN",
             "0",
-            [match.replace("*", "chat-sdk").replace("*", conversationId)],
-          ];
+            "MATCH",
+            `*:list:${statePrefix ? `${statePrefix}:` : ""}junior:agent_turn_session:conversation:*:index`,
+            "COUNT",
+            "500",
+          ]);
+          return ["0", [redisConversationIndexKey]];
         },
       }),
     } as unknown as RedisStateAdapter;


### PR DESCRIPTION
The legacy turn-session actor migration now scans Redis for retained per-conversation indexes instead of discovering conversations only through the bounded global index. Sessions that have fallen out of the global feed still have their summaries and session records migrated from `requester` to `actor`.

The existing state adapter remains responsible for rewriting values, while Redis is used only to discover the logical conversation indexes. Regression coverage exercises a retained conversation whose global index entry is already absent.

Follow-up to #891.