### PR TITLE
fix(storage): Sanitize NUL characters in agent step JSON

### DIFF
--- a/packages/junior/src/chat/conversations/sql/history.ts
+++ b/packages/junior/src/chat/conversations/sql/history.ts
@@ -13,6 +13,7 @@ import {
 } from "../history";
 import { ensureConversationRow } from "./conversation-row";
 import { juniorAgentSteps } from "@/db/schema";
+import { sanitizePostgresJson } from "@/db/postgres-json";
 
 type AgentStepRow = typeof juniorAgentSteps.$inferSelect;
 type AgentStepInsert = typeof juniorAgentSteps.$inferInsert;
@@ -43,7 +44,7 @@ function insertFromStep(
     contextEpoch,
     type,
     role: messageRole(step.entry),
-    payload,
+    payload: sanitizePostgresJson(payload),
     createdAt: new Date(step.createdAtMs),
   };
 }

--- a/packages/junior/src/chat/conversations/sql/legacy-history-import.ts
+++ b/packages/junior/src/chat/conversations/sql/legacy-history-import.ts
@@ -12,6 +12,7 @@
  */
 import { eq, sql } from "drizzle-orm";
 import type { JuniorSqlDatabase } from "@/db/db";
+import { sanitizePostgresJson } from "@/db/postgres-json";
 import type { PiMessage } from "@/chat/pi/messages";
 import { unescapeXml } from "@/chat/xml";
 import type { NewConversationMessage } from "../messages";
@@ -333,7 +334,7 @@ function insertRow(
     contextEpoch: step.contextEpoch,
     type,
     role: messageRole(step.entry),
-    payload,
+    payload: sanitizePostgresJson(payload),
     createdAt: new Date(step.createdAtMs),
   };
 }

--- a/packages/junior/src/db/postgres-json.ts
+++ b/packages/junior/src/db/postgres-json.ts
@@ -1,0 +1,27 @@
+/**
+ * Replace actual NUL characters that PostgreSQL cannot store in JSONB.
+ * Literal `\\u0000` text is preserved because it contains no NUL character.
+ */
+export function sanitizePostgresJson<T>(value: T): T {
+  if (typeof value === "string") {
+    return value.replaceAll("\u0000", " ") as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizePostgresJson(item)) as T;
+  }
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, item]) => [
+      key,
+      sanitizePostgresJson(item),
+    ]),
+  ) as T;
+}

--- a/packages/junior/tests/component/conversation-transcripts-sql.test.ts
+++ b/packages/junior/tests/component/conversation-transcripts-sql.test.ts
@@ -288,6 +288,37 @@ describe("conversation transcript SQL stores", () => {
     }
   });
 
+  it("replaces NUL characters before persisting agent steps", async () => {
+    const fixture = await createLocalJuniorSqlFixture();
+
+    try {
+      await migrateSchema(fixture.sql);
+      await seedConversation(fixture, CONVERSATION_ID);
+      const store = createSqlAgentStepStore(fixture.sql);
+
+      await store.append(CONVERSATION_ID, [
+        {
+          entry: {
+            type: "pi_message",
+            message: userMessage("before\u0000after and literal \\u0000"),
+          },
+          createdAtMs: 1_000,
+        },
+      ]);
+
+      expect(
+        (await store.loadHistory(CONVERSATION_ID))[0]?.entry,
+      ).toMatchObject({
+        type: "pi_message",
+        message: {
+          content: [{ text: "before after and literal \\u0000", type: "text" }],
+        },
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+
   it("returns only the highest epoch from loadCurrentEpoch", async () => {
     const fixture = await createLocalJuniorSqlFixture();
 

--- a/packages/junior/tests/component/conversations/legacy-import.test.ts
+++ b/packages/junior/tests/component/conversations/legacy-import.test.ts
@@ -680,6 +680,44 @@ describe("legacy conversation import", () => {
     }
   }, 20_000);
 
+  it("replaces NUL characters in imported agent steps", async () => {
+    const fixture = await createLocalJuniorSqlFixture();
+    await migrateSchema(fixture.sql);
+    const stepStore = createSqlAgentStepStore(fixture.sql);
+    const messageStore = createSqlConversationMessageStore(fixture.sql);
+
+    try {
+      await importConversationFromLegacy(CONVERSATION_ID, {
+        executor: fixture.sql,
+        messageStore,
+        conversationRecord: conversationRecord(),
+        sessionLogStore: staticSessionLogStore([
+          {
+            schemaVersion: 2,
+            type: "pi_message",
+            sessionId: "session_0",
+            message: assistantMessage(
+              "before\u0000after and literal \\u0000",
+              10,
+            ),
+          } as SessionLogEntry,
+        ]),
+        loadVisibleMessages: async () => [],
+      });
+
+      expect(
+        (await stepStore.loadHistory(CONVERSATION_ID))[0]?.entry,
+      ).toMatchObject({
+        type: "pi_message",
+        message: {
+          content: [{ text: "before after and literal \\u0000", type: "text" }],
+        },
+      });
+    } finally {
+      await fixture.close();
+    }
+  }, 20_000);
+
   it("reads legacy visible messages from a real thread-state payload", async () => {
     const fixture = await createLocalJuniorSqlFixture();
     await migrateSchema(fixture.sql);


### PR DESCRIPTION
Agent-step persistence now replaces actual NUL characters before passing JSON payloads to PostgreSQL. PostgreSQL rejects `U+0000` in JSONB, which previously caused normal history writes and legacy conversation imports to fail.

The normalization stays at the two SQL write paths and preserves literal escaped text rather than treating it as a NUL character. Regression coverage exercises both paths against PostgreSQL.

Fixes JUNIOR-51