### PR TITLE
fix(telemetry): Align GenAI spans with OTel

### DIFF
--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -17,6 +17,7 @@ import {
   logException,
   logInfo,
   logWarn,
+  normalizeGenAiFinishReason,
   serializeGenAiAttribute,
   setSpanAttributes,
   setTags,
@@ -47,8 +48,6 @@ import {
 import type { Actor } from "@/chat/actor";
 import {
   GEN_AI_PROVIDER_NAME,
-  GEN_AI_SERVER_ADDRESS,
-  GEN_AI_SERVER_PORT,
   completeObject,
   completeText,
   getPiGatewayApiKey,
@@ -83,7 +82,6 @@ import {
   resolveConversationPrivacy,
   runWithConversationPrivacy,
   toCanonicalOutputMessage,
-  toGenAiMessageMetadata,
   toGenAiMessagesTraceAttributes,
   type ConversationPrivacy,
 } from "@/chat/conversation-privacy";
@@ -452,16 +450,6 @@ async function executeAgentRunInPrivacyContext(
       fastModelId: botConfig.fastModelId,
       messageText: userInput,
     });
-    setSpanAttributes({
-      "gen_ai.request.model": activeModelId,
-      "gen_ai.request.reasoning.level": reasoningSelection.reasoningLevel,
-      "app.ai.reasoning_level_reason": reasoningSelection.reason,
-      ...(reasoningSelection.confidence !== undefined
-        ? {
-            "app.ai.reasoning_level_confidence": reasoningSelection.confidence,
-          }
-        : {}),
-    });
 
     // ── Mutable turn state ───────────────────────────────────────────
     const generatedFiles: FileUpload[] = [];
@@ -761,10 +749,9 @@ async function executeAgentRunInPrivacyContext(
           runResume.setTurnStartMessageIndex(0);
           runResume.adoptCommittedBoundary(replacement);
           setSpanAttributes({
-            "gen_ai.request.model": activeModelId,
-            "gen_ai.request.reasoning.level":
-              reasoningSelection!.reasoningLevel,
-            "app.ai.model_profile": activeModelProfile,
+            "gen_ai.agent.model": activeModelId,
+            "gen_ai.agent.model_profile": activeModelProfile,
+            "gen_ai.agent.reasoning.level": reasoningSelection!.reasoningLevel,
           });
           update = {
             context: {
@@ -855,7 +842,7 @@ async function executeAgentRunInPrivacyContext(
       }
 
       await withSpan(
-        `invoke_agent ${activeModelId}`,
+        `invoke_agent ${botConfig.userName}`,
         "gen_ai.invoke_agent",
         spanContext,
         async () => {
@@ -994,10 +981,11 @@ async function executeAgentRunInPrivacyContext(
             );
             const outputMessages = newMessages.filter(isAssistantMessage);
             const outputMessagesAttribute = serializeGenAiAttribute(
-              conversationPrivacy !== "public"
-                ? outputMessages.map(toGenAiMessageMetadata)
-                : outputMessages.map(toCanonicalOutputMessage),
+              conversationPrivacy === "public"
+                ? outputMessages.map(toCanonicalOutputMessage)
+                : undefined,
             );
+            const lastAssistant = outputMessages.at(-1);
             const usageSummary = extractGenAiUsageSummary(...outputMessages);
             const currentUsage = hasAgentTurnUsage(usageSummary)
               ? usageSummary
@@ -1012,9 +1000,16 @@ async function executeAgentRunInPrivacyContext(
                 ? { "gen_ai.output.messages": outputMessagesAttribute }
                 : {}),
               ...toGenAiMessagesTraceAttributes(
-                "app.ai.output",
+                "gen_ai.output",
                 outputMessages,
               ),
+              ...(lastAssistant
+                ? {
+                    "gen_ai.response.finish_reasons": [
+                      normalizeGenAiFinishReason(lastAssistant.stopReason),
+                    ],
+                  }
+                : {}),
               ...extractGenAiUsageAttributes(usageSummary),
             });
             if (getPendingAuthPause()) {
@@ -1024,7 +1019,6 @@ async function executeAgentRunInPrivacyContext(
               throw getPendingAuthPause()!;
             }
 
-            const lastAssistant = outputMessages.at(-1);
             const providerRetry = nextProviderRetry({
               attempt,
               lastAssistant,
@@ -1049,12 +1043,18 @@ async function executeAgentRunInPrivacyContext(
           }
         },
         {
-          "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
           "gen_ai.operation.name": "invoke_agent",
-          "gen_ai.request.model": activeModelId,
+          "gen_ai.agent.model": activeModelId,
+          "gen_ai.agent.model_profile": activeModelProfile,
+          "gen_ai.agent.reasoning.level": reasoningSelection.reasoningLevel,
+          "gen_ai.agent.reasoning.level_reason": reasoningSelection.reason,
+          ...(reasoningSelection.confidence !== undefined
+            ? {
+                "gen_ai.agent.reasoning.level_confidence":
+                  reasoningSelection.confidence,
+              }
+            : {}),
           "gen_ai.output.type": "text",
-          "server.address": GEN_AI_SERVER_ADDRESS,
-          "server.port": GEN_AI_SERVER_PORT,
           ...(conversationPrivacy
             ? { "app.conversation.privacy": conversationPrivacy }
             : {}),
@@ -1063,8 +1063,7 @@ async function executeAgentRunInPrivacyContext(
             : {}),
           ...(sessionId ? { "app.ai.turn.session_id": sessionId } : {}),
           ...(currentSliceId ? { "app.ai.turn.slice_id": currentSliceId } : {}),
-          "gen_ai.request.reasoning.level": reasoningSelection.reasoningLevel,
-          ...toGenAiMessagesTraceAttributes("app.ai.input", inputMessages),
+          ...toGenAiMessagesTraceAttributes("gen_ai.input", inputMessages),
           ...(inputMessagesAttribute
             ? { "gen_ai.input.messages": inputMessagesAttribute }
             : {}),

--- a/packages/junior/src/chat/agent/prompt.ts
+++ b/packages/junior/src/chat/agent/prompt.ts
@@ -4,7 +4,7 @@
  * Builds the user-turn content parts (text, attachments, omitted-image
  * notices) and the full prompt for one run slice: system instructions, plugin
  * contributions, bootstrap turn context, resume-safe history trimming, and
- * the redacted telemetry view of the input messages.
+ * the optional canonical telemetry view of public input messages.
  */
 import { isDeepStrictEqual } from "node:util";
 import { renderCurrentInstruction } from "@/chat/current-instruction";
@@ -23,10 +23,7 @@ import {
   stripRuntimeTurnContext,
 } from "@/chat/pi/transcript";
 import { serializeGenAiAttribute, type LogContext } from "@/chat/logging";
-import {
-  toGenAiMessageMetadata,
-  type ConversationPrivacy,
-} from "@/chat/conversation-privacy";
+import type { ConversationPrivacy } from "@/chat/conversation-privacy";
 import type { SkillInvocation, SkillMetadata } from "@/chat/skills";
 import type { ActiveMcpCatalogSummary } from "@/chat/tool-support/skill/mcp-tool-summary";
 import type { ToolRuntimeContext } from "@/chat/tools/types";
@@ -436,9 +433,22 @@ export async function assemblePrompt(args: {
     },
   ];
   const inputMessagesAttribute = serializeGenAiAttribute(
-    args.conversationPrivacy !== "public"
-      ? inputMessages.map(toGenAiMessageMetadata)
-      : inputMessages,
+    args.conversationPrivacy === "public"
+      ? [
+          {
+            role: "system",
+            parts: [{ type: "text", content: baseInstructions }],
+          },
+          {
+            role: "user",
+            parts: promptContentParts.flatMap((part) =>
+              part.type === "text"
+                ? [{ type: "text", content: part.text }]
+                : [],
+            ),
+          },
+        ]
+      : undefined,
   );
 
   return {

--- a/packages/junior/src/chat/conversation-privacy.ts
+++ b/packages/junior/src/chat/conversation-privacy.ts
@@ -90,60 +90,6 @@ export function runWithConversationPrivacy<T>(
   return conversationPrivacyStorage.run(privacy, callback);
 }
 
-function contentMetadata(content: unknown): unknown {
-  if (typeof content === "string") {
-    return [{ type: "text", chars: content.length }];
-  }
-  if (!Array.isArray(content)) {
-    return { type: typeof content };
-  }
-  return content.map((part) => {
-    if (!part || typeof part !== "object") {
-      return { type: typeof part };
-    }
-    const record = part as Record<string, unknown>;
-    const type = canonicalContentPartType(
-      typeof record.type === "string" ? record.type : "unknown",
-    );
-    return {
-      type,
-      ...(typeof record.text === "string"
-        ? { chars: record.text.length }
-        : typeof record.thinking === "string" && record.thinking.length > 0
-          ? { chars: record.thinking.length }
-          : {}),
-      ...(typeof record.mimeType === "string"
-        ? { mimeType: record.mimeType }
-        : {}),
-      ...(typeof record.mediaType === "string"
-        ? { mediaType: record.mediaType }
-        : {}),
-      ...(typeof record.data === "string"
-        ? { dataChars: record.data.length }
-        : {}),
-    };
-  });
-}
-
-/** Convert a GenAI message into safe metadata for private trace contexts. */
-export function toGenAiMessageMetadata(
-  message: unknown,
-): Record<string, unknown> {
-  const record =
-    message && typeof message === "object"
-      ? (message as Record<string, unknown>)
-      : {};
-  return {
-    role: record.role,
-    content: contentMetadata(record.content),
-  };
-}
-
-/** Convert raw text into size-only metadata for private trace contexts. */
-export function toGenAiTextMetadata(text: string): Record<string, unknown> {
-  return { type: "text", chars: text.length };
-}
-
 function payloadType(payload: unknown): string {
   return Array.isArray(payload) ? "array" : typeof payload;
 }
@@ -185,7 +131,7 @@ export function toGenAiPayloadMetadata(
 
 /** Convert an arbitrary payload into safe flattened trace attributes. */
 export function toGenAiPayloadTraceAttributes(
-  prefix: string,
+  prefix: "gen_ai.tool.call.arguments" | "gen_ai.tool.call.result",
   payload: unknown,
 ): Record<string, TraceAttributeValue> {
   const attributes: Record<string, TraceAttributeValue> = {
@@ -244,7 +190,7 @@ function summarizeContent(content: unknown): {
 // ---------------------------------------------------------------------------
 
 function normalizeFinishReason(reason: string): string {
-  return reason === "toolUse" ? "tool_use" : reason;
+  return reason === "toolUse" ? "tool_call" : reason;
 }
 
 function canonicalContentPartType(type: string): string {
@@ -255,13 +201,13 @@ function canonicalContentPartType(type: string): string {
 
 function toCanonicalPart(
   part: TextContent | ThinkingContent | ImageContent | ToolCall,
-): Record<string, unknown> {
+): Record<string, unknown> | undefined {
   if (part.type === "text") {
     return { type: "text", content: part.text };
   }
   if (part.type === "thinking") {
     if (part.redacted) {
-      return { type: "reasoning", redacted: true };
+      return undefined;
     }
     return { type: "reasoning", content: part.thinking };
   }
@@ -273,8 +219,15 @@ function toCanonicalPart(
       arguments: part.arguments,
     };
   }
-  // image — omit raw base64 data, keep type and mimeType only
-  return { type: "image", mimeType: (part as ImageContent).mimeType };
+  return undefined;
+}
+
+function toCanonicalParts(
+  parts: Array<TextContent | ThinkingContent | ImageContent | ToolCall>,
+): Record<string, unknown>[] {
+  return parts
+    .map(toCanonicalPart)
+    .filter((part): part is Record<string, unknown> => part !== undefined);
 }
 
 /**
@@ -286,7 +239,7 @@ export function toCanonicalOutputMessage(
 ): Record<string, unknown> {
   return {
     role: "assistant",
-    parts: message.content.map(toCanonicalPart),
+    parts: toCanonicalParts(message.content),
     finish_reason: normalizeFinishReason(message.stopReason),
   };
 }
@@ -302,15 +255,19 @@ export function toCanonicalInputMessage(
     const parts =
       typeof message.content === "string"
         ? [{ type: "text", content: message.content }]
-        : message.content.map(toCanonicalPart);
+        : toCanonicalParts(message.content);
     return { role: "user", parts };
   }
   if (message.role === "toolResult") {
     return {
       role: "tool",
-      id: message.toolCallId,
-      name: message.toolName,
-      parts: message.content.map(toCanonicalPart),
+      parts: [
+        {
+          type: "tool_call_response",
+          id: message.toolCallId,
+          response: toCanonicalParts(message.content),
+        },
+      ],
     };
   }
   // AssistantMessage appearing as a prior turn in input context
@@ -319,7 +276,7 @@ export function toCanonicalInputMessage(
 
 /** Summarize a message list without exposing raw message content. */
 export function toGenAiMessagesTraceAttributes(
-  prefix: string,
+  prefix: "gen_ai.input" | "gen_ai.output",
   messages: unknown[],
 ): Record<string, TraceAttributeValue> {
   let contentChars = 0;

--- a/packages/junior/src/chat/logging.ts
+++ b/packages/junior/src/chat/logging.ts
@@ -115,7 +115,7 @@ const LEGACY_KEY_MAP: Record<string, string> = {
 
 /** Normalize runtime finish reasons to the telemetry spelling we emit. */
 export function normalizeGenAiFinishReason(reason: string): string {
-  return reason === "toolUse" ? "tool_use" : reason;
+  return reason === "toolUse" ? "tool_call" : reason;
 }
 
 /** Truncate message text for log attributes. */
@@ -1412,6 +1412,23 @@ export function getLogContextAttributes(): LogAttributes {
   return contextStorage.getStore() ?? {};
 }
 
+/** Return inherited log context filtered to attributes valid for the span operation. */
+export function getLogContextAttributesForSpan(op: string): LogAttributes {
+  const attributes = { ...getLogContextAttributes() };
+  if (op === "gen_ai.invoke_agent" || op === "gen_ai.execute_tool") {
+    delete attributes["gen_ai.request.model"];
+    return attributes;
+  }
+  if (op === "gen_ai.chat" || op === "gen_ai.embeddings") {
+    delete attributes["gen_ai.agent.name"];
+    delete attributes["gen_ai.request.model"];
+    return attributes;
+  }
+  delete attributes["gen_ai.agent.name"];
+  delete attributes["gen_ai.request.model"];
+  return attributes;
+}
+
 export function registerLogRecordSink(
   sink: (record: EmittedLogRecord) => void,
 ): () => void {
@@ -1668,7 +1685,7 @@ export async function withSpan<T>(
     // Child spans inherit the active log context so nested GenAI spans keep
     // conversation/session correlation even when callers pass only delta
     // context such as modelId or tool metadata.
-    const inheritedAttributes = getLogContextAttributes();
+    const inheritedAttributes = getLogContextAttributesForSpan(op);
     return Sentry.startSpan(
       {
         name,
@@ -1678,7 +1695,18 @@ export async function withSpan<T>(
           ...normalizedAttributes,
         },
       },
-      (span) => callback((attributes) => setAttributesOnSpan(span, attributes)),
+      async (span: Sentry.Span) => {
+        try {
+          return await callback((attributes) =>
+            setAttributesOnSpan(span, attributes),
+          );
+        } catch (error) {
+          setAttributesOnSpan(span, {
+            "error.type": error instanceof Error ? error.name : typeof error,
+          });
+          throw error;
+        }
+      },
     );
   });
 }
@@ -1801,7 +1829,7 @@ const GEN_AI_MAX_ARRAY_ITEMS = 50;
 const GEN_AI_MAX_OBJECT_KEYS = 50;
 
 function truncateGenAiString(value: string, maxChars: number): string {
-  return value.length > maxChars ? `${value.slice(0, maxChars)}...` : value;
+  return value.length > maxChars ? "" : value;
 }
 
 function sanitizeGenAiValue(
@@ -1868,7 +1896,7 @@ function sanitizeGenAiValue(
   return out;
 }
 
-/** Serialize an AI model response value into a truncated log attribute. */
+/** Serialize a bounded AI value, omitting it when valid JSON cannot fit. */
 export function serializeGenAiAttribute(
   value: unknown,
   maxChars = GEN_AI_DEFAULT_MAX_ATTRIBUTE_CHARS,
@@ -1884,7 +1912,7 @@ export function serializeGenAiAttribute(
     return undefined;
   }
 
-  return truncateGenAiString(redactSecrets(serialized), maxChars);
+  return truncateGenAiString(redactSecrets(serialized), maxChars) || undefined;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
@@ -2022,19 +2050,18 @@ export function extractGenAiUsageAttributes(
   Record<
     | "gen_ai.usage.input_tokens"
     | "gen_ai.usage.output_tokens"
-    | "gen_ai.usage.input_tokens.cached"
-    | "gen_ai.usage.input_tokens.cache_write"
-    | "gen_ai.usage.total_tokens",
+    | "gen_ai.usage.cache_read.input_tokens"
+    | "gen_ai.usage.cache_creation.input_tokens"
+    | "gen_ai.usage.reasoning.output_tokens",
     number
   > &
     Partial<
       Record<
-        | "app.ai.cost.input_usd"
-        | "app.ai.cost.output_usd"
-        | "app.ai.cost.cache_read_usd"
-        | "app.ai.cost.cache_write_usd"
-        | "app.ai.cost.total_usd"
-        | "app.ai.reasoning_tokens",
+        | "app.cost.input_usd"
+        | "app.cost.output_usd"
+        | "app.cost.cache_read_usd"
+        | "app.cost.cache_write_usd"
+        | "app.cost.total_usd",
         number
       >
     >
@@ -2045,7 +2072,6 @@ export function extractGenAiUsageAttributes(
     cachedInputTokens,
     cacheCreationTokens,
     reasoningTokens,
-    totalTokens,
     cost,
   } = extractGenAiUsageSummary(...sources);
   const semanticInputTokens = sumTokenCounts(
@@ -2054,9 +2080,6 @@ export function extractGenAiUsageAttributes(
     cacheCreationTokens,
   );
 
-  const semanticTotalTokens =
-    totalTokens ?? sumTokenCounts(semanticInputTokens, outputTokens);
-
   return {
     ...(semanticInputTokens !== undefined
       ? { "gen_ai.usage.input_tokens": semanticInputTokens }
@@ -2064,32 +2087,26 @@ export function extractGenAiUsageAttributes(
     ...(outputTokens !== undefined
       ? { "gen_ai.usage.output_tokens": outputTokens }
       : {}),
-    ...(semanticTotalTokens !== undefined
-      ? { "gen_ai.usage.total_tokens": semanticTotalTokens }
-      : {}),
+    // OTel has no monetary cost attributes, so report accounting generically.
     ...(cachedInputTokens !== undefined
-      ? { "gen_ai.usage.input_tokens.cached": cachedInputTokens }
+      ? { "gen_ai.usage.cache_read.input_tokens": cachedInputTokens }
       : {}),
     ...(cacheCreationTokens !== undefined
-      ? { "gen_ai.usage.input_tokens.cache_write": cacheCreationTokens }
+      ? { "gen_ai.usage.cache_creation.input_tokens": cacheCreationTokens }
       : {}),
     ...(reasoningTokens !== undefined
-      ? { "app.ai.reasoning_tokens": reasoningTokens }
+      ? { "gen_ai.usage.reasoning.output_tokens": reasoningTokens }
       : {}),
-    ...(cost?.input !== undefined
-      ? { "app.ai.cost.input_usd": cost.input }
-      : {}),
+    ...(cost?.input !== undefined ? { "app.cost.input_usd": cost.input } : {}),
     ...(cost?.output !== undefined
-      ? { "app.ai.cost.output_usd": cost.output }
+      ? { "app.cost.output_usd": cost.output }
       : {}),
     ...(cost?.cacheRead !== undefined
-      ? { "app.ai.cost.cache_read_usd": cost.cacheRead }
+      ? { "app.cost.cache_read_usd": cost.cacheRead }
       : {}),
     ...(cost?.cacheWrite !== undefined
-      ? { "app.ai.cost.cache_write_usd": cost.cacheWrite }
+      ? { "app.cost.cache_write_usd": cost.cacheWrite }
       : {}),
-    ...(cost?.total !== undefined
-      ? { "app.ai.cost.total_usd": cost.total }
-      : {}),
+    ...(cost?.total !== undefined ? { "app.cost.total_usd": cost.total } : {}),
   };
 }

--- a/packages/junior/src/chat/mcp/tool-manager.ts
+++ b/packages/junior/src/chat/mcp/tool-manager.ts
@@ -14,10 +14,8 @@ import {
   setSpanAttributes,
   withSpan,
 } from "@/chat/logging";
-import {
-  toGenAiPayloadMetadata,
-  type ConversationPrivacy,
-} from "@/chat/conversation-privacy";
+import type { ConversationPrivacy } from "@/chat/conversation-privacy";
+import { toGenAiPayloadMetadata } from "@/chat/conversation-privacy";
 import type { SkillMetadata } from "@/chat/skills";
 import type { PluginDefinition } from "@/chat/plugins/types";
 import {
@@ -129,7 +127,11 @@ function utf8Bytes(value: string): number {
   return Buffer.byteLength(value, "utf8");
 }
 
-function prefixWithin(value: string, maxChars: number, maxBytes: number): string {
+function prefixWithin(
+  value: string,
+  maxChars: number,
+  maxBytes: number,
+): string {
   let low = 0;
   let high = Math.min(value.length, maxChars);
   while (low < high) {
@@ -146,7 +148,11 @@ function prefixWithin(value: string, maxChars: number, maxBytes: number): string
   return value.slice(0, low);
 }
 
-function suffixWithin(value: string, maxChars: number, maxBytes: number): string {
+function suffixWithin(
+  value: string,
+  maxChars: number,
+  maxBytes: number,
+): string {
   let low = Math.max(0, value.length - maxChars);
   let high = value.length;
   while (low < high) {
@@ -495,15 +501,18 @@ export class McpToolManager {
             plugin.manifest.name,
             tool,
           ),
-          "gen_ai.tool.type": "extension",
+          "gen_ai.tool.type": "function",
           "app.plugin.name": plugin.manifest.name,
           ...(options?.toolCallId
             ? { "gen_ai.tool.call.id": options.toolCallId }
             : {}),
         };
+        // Intentional OTel deviation: private traces put Junior's safe metadata
+        // projection here because it is more useful than omitting the attribute.
         const argumentAttribute = serializeMcpPayload(
           resolvedArgs,
           conversationPrivacy,
+          { privateMetadata: true },
         );
 
         return await withSpan(
@@ -520,6 +529,7 @@ export class McpToolManager {
               const resultAttribute = serializeMcpPayload(
                 result,
                 conversationPrivacy,
+                { privateMetadata: true },
               );
               if (resultAttribute) {
                 setSpanAttributes({
@@ -641,8 +651,12 @@ function toOptionalRecord(value: unknown): Record<string, unknown> | undefined {
 function serializeMcpPayload(
   payload: unknown,
   privacy: ConversationPrivacy,
+  options: { privateMetadata?: boolean } = {},
 ): string | undefined {
-  return serializeGenAiAttribute(
-    privacy === "private" ? toGenAiPayloadMetadata(payload) : payload,
-  );
+  if (privacy !== "private") {
+    return serializeGenAiAttribute(payload);
+  }
+  return options.privateMetadata
+    ? serializeGenAiAttribute(toGenAiPayloadMetadata(payload))
+    : undefined;
 }

--- a/packages/junior/src/chat/pi/client.ts
+++ b/packages/junior/src/chat/pi/client.ts
@@ -24,12 +24,12 @@ registerApiProvider({
 import type { ZodTypeAny, z } from "zod";
 import {
   extractGenAiUsageAttributes,
+  normalizeGenAiFinishReason,
   serializeGenAiAttribute,
 } from "@/chat/logging";
 import {
   logException,
   logWarn,
-  setSpanAttributes,
   withSpan,
   type LogContext,
 } from "@/chat/logging";
@@ -39,14 +39,13 @@ import {
   resolveConversationPrivacy,
   toCanonicalInputMessage,
   toCanonicalOutputMessage,
-  toGenAiMessageMetadata,
   toGenAiMessagesTraceAttributes,
-  toGenAiTextMetadata,
 } from "@/chat/conversation-privacy";
 import {
   createProviderError,
   isProviderRetryError,
 } from "@/chat/services/provider-retry";
+import { hasCompactedConversationContext } from "@/chat/services/context-compaction-marker";
 
 const GATEWAY_PROVIDER = "vercel-ai-gateway" as const;
 export const GEN_AI_PROVIDER_NAME = GATEWAY_PROVIDER;
@@ -136,18 +135,14 @@ export async function completeText(params: {
   const messageAttributeMode =
     params.messageAttributeMode ??
     (effectivePrivacy === "public" ? "content" : "metadata");
-  const requestMessagesAttribute = serializeGenAiAttribute(
-    messageAttributeMode === "metadata"
-      ? params.messages.map(toGenAiMessageMetadata)
-      : params.messages.map(toCanonicalInputMessage),
-  );
-  const systemInstructionsAttribute = params.system
-    ? serializeGenAiAttribute(
-        messageAttributeMode === "metadata"
-          ? [toGenAiTextMetadata(params.system)]
-          : [{ type: "text", content: params.system }],
-      )
-    : undefined;
+  const requestMessagesAttribute =
+    messageAttributeMode === "content"
+      ? serializeGenAiAttribute(params.messages.map(toCanonicalInputMessage))
+      : undefined;
+  const systemInstructionsAttribute =
+    params.system && messageAttributeMode === "content"
+      ? serializeGenAiAttribute([{ type: "text", content: params.system }])
+      : undefined;
   const baseAttributes = {
     "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
     "gen_ai.operation.name": GEN_AI_OPERATION_CHAT,
@@ -155,16 +150,25 @@ export async function completeText(params: {
     "gen_ai.output.type": "text",
     "server.address": GEN_AI_SERVER_ADDRESS,
     "server.port": GEN_AI_SERVER_PORT,
+    ...(hasCompactedConversationContext(params.messages)
+      ? { "gen_ai.conversation.compacted": true }
+      : {}),
     "app.conversation.privacy": effectivePrivacy,
     ...(params.thinkingLevel
       ? { "gen_ai.request.reasoning.level": params.thinkingLevel }
       : {}),
+    ...(params.temperature !== undefined
+      ? { "gen_ai.request.temperature": params.temperature }
+      : {}),
+    ...(params.maxTokens !== undefined
+      ? { "gen_ai.request.max_tokens": params.maxTokens }
+      : {}),
   };
   const startAttributes = {
     ...baseAttributes,
-    ...toGenAiMessagesTraceAttributes("app.ai.input", params.messages),
+    ...toGenAiMessagesTraceAttributes("gen_ai.input", params.messages),
     ...(params.system
-      ? { "app.ai.system_instructions.content_chars": params.system.length }
+      ? { "gen_ai.system_instructions.content_chars": params.system.length }
       : {}),
     ...(systemInstructionsAttribute
       ? { "gen_ai.system_instructions": systemInstructionsAttribute }
@@ -172,13 +176,13 @@ export async function completeText(params: {
     ...(requestMessagesAttribute
       ? { "gen_ai.input.messages": requestMessagesAttribute }
       : {}),
-    "app.ai.auth_mode": authMode,
+    "gen_ai.provider.auth_mode": authMode,
   };
   return withSpan(
     `${GEN_AI_OPERATION_CHAT} ${params.modelId}`,
     "gen_ai.chat",
     logContextFromMetadata(params.modelId, params.metadata),
-    async () => {
+    async (setSpanAttributes) => {
       let message: Awaited<ReturnType<typeof completeSimple>>;
       try {
         message = await completeSimple(
@@ -201,19 +205,14 @@ export async function completeText(params: {
       }
       const outputText = extractText(message);
       const outputMessagesAttribute = serializeGenAiAttribute(
-        messageAttributeMode === "metadata"
-          ? [
-              {
-                role: "assistant",
-                content: outputText ? [toGenAiTextMetadata(outputText)] : [],
-              },
-            ]
-          : [toCanonicalOutputMessage(message)],
+        messageAttributeMode === "content"
+          ? [toCanonicalOutputMessage(message)]
+          : undefined,
       );
       const usageAttributes = extractGenAiUsageAttributes(message);
       const endAttributes = {
         ...baseAttributes,
-        ...toGenAiMessagesTraceAttributes("app.ai.output", [
+        ...toGenAiMessagesTraceAttributes("gen_ai.output", [
           {
             role: "assistant",
             content: outputText ? [{ type: "text", text: outputText }] : [],
@@ -224,8 +223,13 @@ export async function completeText(params: {
           : {}),
         ...usageAttributes,
         ...(message.stopReason
-          ? { "gen_ai.response.finish_reasons": [message.stopReason] }
+          ? {
+              "gen_ai.response.finish_reasons": [
+                normalizeGenAiFinishReason(message.stopReason),
+              ],
+            }
           : {}),
+        ...(message.model ? { "gen_ai.response.model": message.model } : {}),
       };
       setSpanAttributes(endAttributes);
       if (message.stopReason === "error") {
@@ -297,8 +301,8 @@ export async function completeObject<TSchema extends ZodTypeAny>(params: {
       `${GEN_AI_OPERATION_CHAT} ${params.modelId}`,
       "gen_ai.chat",
       logContextFromMetadata(params.modelId, params.metadata),
-      async () =>
-        await generateObject({
+      async (setSpanAttributes) => {
+        const result = await generateObject({
           model: provider.chat(params.modelId),
           schema: params.schema,
           prompt: params.prompt,
@@ -312,7 +316,13 @@ export async function completeObject<TSchema extends ZodTypeAny>(params: {
           ...(params.signal !== undefined
             ? { abortSignal: params.signal }
             : {}),
-        }),
+        });
+        setSpanAttributes({
+          "gen_ai.response.finish_reasons": [result.finishReason],
+          ...extractGenAiUsageAttributes(result.usage),
+        });
+        return result;
+      },
       {
         "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
         "gen_ai.operation.name": GEN_AI_OPERATION_CHAT,
@@ -323,18 +333,14 @@ export async function completeObject<TSchema extends ZodTypeAny>(params: {
         ...(params.thinkingLevel
           ? { "gen_ai.request.reasoning.level": params.thinkingLevel }
           : {}),
+        ...(params.temperature !== undefined
+          ? { "gen_ai.request.temperature": params.temperature }
+          : {}),
+        ...(params.maxTokens !== undefined
+          ? { "gen_ai.request.max_tokens": params.maxTokens }
+          : {}),
       },
     );
-    setSpanAttributes({
-      "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
-      "gen_ai.operation.name": GEN_AI_OPERATION_CHAT,
-      "gen_ai.request.model": params.modelId,
-      "gen_ai.output.type": "json",
-      "server.address": GEN_AI_SERVER_ADDRESS,
-      "server.port": GEN_AI_SERVER_PORT,
-      "gen_ai.response.finish_reasons": [result.finishReason],
-      ...extractGenAiUsageAttributes(result.usage),
-    });
     return { object: result.object as z.infer<TSchema> };
   } catch (error) {
     const providerError = createProviderError(error);
@@ -380,45 +386,43 @@ export async function embedTexts(params: {
       `${GEN_AI_OPERATION_EMBEDDINGS} ${params.modelId}`,
       "gen_ai.embeddings",
       logContextFromMetadata(params.modelId, params.metadata),
-      async () =>
-        await embedMany({
+      async (setSpanAttributes) => {
+        const result = await embedMany({
           model: provider.embeddingModel(params.modelId),
           values: texts,
           ...(params.signal !== undefined
             ? { abortSignal: params.signal }
             : {}),
-        }),
+        });
+        const dimensions = result.embeddings[0]?.length;
+        if (
+          result.embeddings.length !== texts.length ||
+          !dimensions ||
+          !result.embeddings.every(
+            (embedding) => embedding.length === dimensions,
+          )
+        ) {
+          throw new Error("Embedding provider returned invalid vectors.");
+        }
+        setSpanAttributes({
+          "gen_ai.embeddings.dimension.count": dimensions,
+          ...extractGenAiUsageAttributes(result.usage),
+        });
+        return { dimensions, result };
+      },
       {
         "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
         "gen_ai.operation.name": GEN_AI_OPERATION_EMBEDDINGS,
         "gen_ai.request.model": params.modelId,
-        "gen_ai.output.type": "embedding",
         "server.address": GEN_AI_SERVER_ADDRESS,
         "server.port": GEN_AI_SERVER_PORT,
       },
     );
-    const dimensions = result.embeddings[0]?.length;
-    if (
-      result.embeddings.length !== texts.length ||
-      !dimensions ||
-      !result.embeddings.every((embedding) => embedding.length === dimensions)
-    ) {
-      throw new Error("Embedding provider returned invalid vectors.");
-    }
-    setSpanAttributes({
-      "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
-      "gen_ai.operation.name": GEN_AI_OPERATION_EMBEDDINGS,
-      "gen_ai.request.model": params.modelId,
-      "gen_ai.output.type": "embedding",
-      "server.address": GEN_AI_SERVER_ADDRESS,
-      "server.port": GEN_AI_SERVER_PORT,
-      ...extractGenAiUsageAttributes(result.usage),
-    });
     return {
-      dimensions,
+      dimensions: result.dimensions,
       model: params.modelId,
       provider: GEN_AI_PROVIDER_NAME,
-      vectors: result.embeddings,
+      vectors: result.result.embeddings,
     };
   } catch (error) {
     const providerError = createProviderError(error);

--- a/packages/junior/src/chat/pi/traced-stream.ts
+++ b/packages/junior/src/chat/pi/traced-stream.ts
@@ -9,7 +9,7 @@ import {
 import * as Sentry from "@/chat/sentry";
 import {
   extractGenAiUsageAttributes,
-  getLogContextAttributes,
+  getLogContextAttributesForSpan,
   normalizeGenAiFinishReason,
   serializeGenAiAttribute,
 } from "@/chat/logging";
@@ -22,10 +22,9 @@ import {
   type ConversationPrivacy,
   toCanonicalInputMessage,
   toCanonicalOutputMessage,
-  toGenAiMessageMetadata,
   toGenAiMessagesTraceAttributes,
-  toGenAiTextMetadata,
 } from "@/chat/conversation-privacy";
+import { hasCompactedConversationContext } from "@/chat/services/context-compaction-marker";
 
 type GenAiAttributeMode = "content" | "metadata";
 type TraceAttributeValue = string | number | boolean | string[];
@@ -42,6 +41,7 @@ function attributeModeForPrivacy(
 function buildChatStartAttributes(
   model: Model<Api>,
   context: Context,
+  options: Parameters<StreamFn>[2],
   mode: GenAiAttributeMode,
   conversationPrivacy: ConversationPrivacy | undefined,
 ): Record<string, TraceAttributeValue> {
@@ -53,31 +53,43 @@ function buildChatStartAttributes(
     "gen_ai.output.type": "text",
     "server.address": GEN_AI_SERVER_ADDRESS,
     "server.port": GEN_AI_SERVER_PORT,
+    ...(options?.temperature !== undefined
+      ? { "gen_ai.request.temperature": options.temperature }
+      : {}),
+    ...(options?.maxTokens !== undefined
+      ? { "gen_ai.request.max_tokens": options.maxTokens }
+      : {}),
+    ...(options?.reasoning
+      ? { "gen_ai.request.reasoning.level": options.reasoning }
+      : {}),
+    ...(hasCompactedConversationContext(context.messages)
+      ? { "gen_ai.conversation.compacted": true }
+      : {}),
     ...(conversationPrivacy
       ? { "app.conversation.privacy": conversationPrivacy }
       : {}),
-    ...toGenAiMessagesTraceAttributes("app.ai.input", context.messages),
+    ...toGenAiMessagesTraceAttributes("gen_ai.input", context.messages),
   };
 
-  const inputMessages = serializeGenAiAttribute(
-    mode === "metadata"
-      ? context.messages.map(toGenAiMessageMetadata)
-      : context.messages.map(toCanonicalInputMessage),
-  );
-  if (inputMessages) {
-    attributes["gen_ai.input.messages"] = inputMessages;
+  if (mode === "content") {
+    const inputMessages = serializeGenAiAttribute(
+      context.messages.map(toCanonicalInputMessage),
+    );
+    if (inputMessages) {
+      attributes["gen_ai.input.messages"] = inputMessages;
+    }
   }
 
   if (context.systemPrompt) {
-    const systemInstructions = serializeGenAiAttribute([
-      mode === "metadata"
-        ? toGenAiTextMetadata(context.systemPrompt)
-        : { type: "text", content: context.systemPrompt },
-    ]);
-    if (systemInstructions) {
-      attributes["gen_ai.system_instructions"] = systemInstructions;
+    if (mode === "content") {
+      const systemInstructions = serializeGenAiAttribute([
+        { type: "text", content: context.systemPrompt },
+      ]);
+      if (systemInstructions) {
+        attributes["gen_ai.system_instructions"] = systemInstructions;
+      }
     }
-    attributes["app.ai.system_instructions.content_chars"] =
+    attributes["gen_ai.system_instructions.content_chars"] =
       context.systemPrompt.length;
   }
 
@@ -90,16 +102,16 @@ function buildChatEndAttributes(
   mode: GenAiAttributeMode,
 ): Record<string, TraceAttributeValue> {
   const attributes: Record<string, TraceAttributeValue> = {
-    ...toGenAiMessagesTraceAttributes("app.ai.output", [message]),
+    ...toGenAiMessagesTraceAttributes("gen_ai.output", [message]),
   };
 
-  const outputMessages = serializeGenAiAttribute(
-    mode === "metadata"
-      ? [toGenAiMessageMetadata(message)]
-      : [toCanonicalOutputMessage(message)],
-  );
-  if (outputMessages) {
-    attributes["gen_ai.output.messages"] = outputMessages;
+  if (mode === "content") {
+    const outputMessages = serializeGenAiAttribute([
+      toCanonicalOutputMessage(message),
+    ]);
+    if (outputMessages) {
+      attributes["gen_ai.output.messages"] = outputMessages;
+    }
   }
 
   Object.assign(attributes, extractGenAiUsageAttributes(message));
@@ -151,8 +163,14 @@ export function createTracedStreamFn(
       name: `chat ${model.id}`,
       op: "gen_ai.chat",
       attributes: {
-        ...getLogContextAttributes(),
-        ...buildChatStartAttributes(model, context, mode, effectivePrivacy),
+        ...getLogContextAttributesForSpan("gen_ai.chat"),
+        ...buildChatStartAttributes(
+          model,
+          context,
+          options,
+          mode,
+          effectivePrivacy,
+        ),
       },
     });
 
@@ -164,18 +182,26 @@ export function createTracedStreamFn(
       stream
         .result()
         .then(
-          (finalMessage) => {
+          (finalMessage: AssistantMessage) => {
             try {
               for (const [key, value] of Object.entries(
                 buildChatEndAttributes(finalMessage, mode),
               )) {
                 span.setAttribute(key, value);
               }
+              if (finalMessage.stopReason === "error") {
+                span.setAttribute("error.type", "provider_error");
+                span.setStatus({ code: 2, message: "LLM stream failed" });
+              }
             } finally {
               span.end();
             }
           },
-          () => {
+          (error: unknown) => {
+            span.setAttribute(
+              "error.type",
+              error instanceof Error ? error.name : typeof error,
+            );
             span.setStatus({ code: 2, message: "LLM stream failed" });
             span.end();
           },
@@ -187,6 +213,10 @@ export function createTracedStreamFn(
 
       return stream;
     } catch (error) {
+      span.setAttribute(
+        "error.type",
+        error instanceof Error ? error.name : typeof error,
+      );
       span.setStatus({ code: 2, message: "LLM call failed" });
       span.end();
       throw error;

--- a/packages/junior/src/chat/services/context-compaction-marker.ts
+++ b/packages/junior/src/chat/services/context-compaction-marker.ts
@@ -1,0 +1,44 @@
+import type { PiMessage } from "@/chat/pi/messages";
+import { unwrapCurrentInstruction } from "@/chat/current-instruction";
+
+export const COMPACTION_SUMMARY_PREFIX =
+  "Context compaction summary for future Junior turns:";
+// TODO(v0.97.0): Remove support for the deployed "Context handoff summary"
+// prefix after pre-rename rows pass the conversation-history retention horizon.
+export const LEGACY_COMPACTION_SUMMARY_PREFIX =
+  "Context handoff summary for future Junior turns:";
+export const MODEL_HANDOFF_SUMMARY_PREFIX =
+  "Model handoff checkpoint. Continue the outstanding request now using this summary as the complete prior context:";
+
+/** Return whether text is one of Junior's durable compacted-context markers. */
+export function isCompactionSummaryText(text: string): boolean {
+  const normalized = (unwrapCurrentInstruction(text) ?? text).trimStart();
+  return (
+    normalized.startsWith(COMPACTION_SUMMARY_PREFIX) ||
+    normalized.startsWith(LEGACY_COMPACTION_SUMMARY_PREFIX) ||
+    normalized.startsWith(MODEL_HANDOFF_SUMMARY_PREFIX)
+  );
+}
+
+/** Return whether model-visible history contains a durable compacted context marker. */
+export function hasCompactedConversationContext(
+  messages: PiMessage[],
+): boolean {
+  return messages.some((message) => {
+    const content = (message as { content?: unknown }).content;
+    if (typeof content === "string") {
+      return isCompactionSummaryText(content);
+    }
+    if (!Array.isArray(content)) {
+      return false;
+    }
+    return content.some(
+      (part) =>
+        part &&
+        typeof part === "object" &&
+        (part as { type?: unknown }).type === "text" &&
+        typeof (part as { text?: unknown }).text === "string" &&
+        isCompactionSummaryText((part as { text: string }).text),
+    );
+  });
+}

--- a/packages/junior/src/chat/services/context-compaction.ts
+++ b/packages/junior/src/chat/services/context-compaction.ts
@@ -36,20 +36,17 @@ import {
 } from "@/chat/pi/transcript";
 import { updateConversationStats } from "@/chat/services/conversation-memory";
 import { modelIdForProfile, type ModelProfile } from "@/chat/model-profile";
+import {
+  COMPACTION_SUMMARY_PREFIX,
+  isCompactionSummaryText,
+  MODEL_HANDOFF_SUMMARY_PREFIX,
+} from "@/chat/services/context-compaction-marker";
 
 const RETAINED_USER_MESSAGE_TOKENS = 20_000;
 const MAX_SUMMARY_INPUT_CHARS = 80_000;
 const MAX_VISIBLE_CONTEXT_CHARS = 20_000;
 const MAX_SUMMARY_CHARS = 6_000;
 const MAX_RENDERED_MESSAGE_CHARS = 4_000;
-const COMPACTION_SUMMARY_PREFIX =
-  "Context compaction summary for future Junior turns:";
-// TODO(v0.97.0): Remove support for the deployed "Context handoff summary"
-// prefix after pre-rename rows pass the conversation-history retention horizon.
-const LEGACY_COMPACTION_SUMMARY_PREFIX =
-  "Context handoff summary for future Junior turns:";
-const MODEL_HANDOFF_SUMMARY_PREFIX =
-  "Model handoff checkpoint. Continue the outstanding request now using this summary as the complete prior context:";
 const OMITTED_OLDER_CONTEXT_NOTICE = "[older context omitted]";
 
 export interface ContextCompactorDeps {
@@ -147,12 +144,7 @@ function truncateToTokenBudget(text: string, maxTokens: number): string {
 }
 
 function isCompactionSummary(text: string): boolean {
-  const normalized = text.trimStart();
-  return (
-    normalized.startsWith(COMPACTION_SUMMARY_PREFIX) ||
-    normalized.startsWith(LEGACY_COMPACTION_SUMMARY_PREFIX) ||
-    normalized.startsWith(MODEL_HANDOFF_SUMMARY_PREFIX)
-  );
+  return isCompactionSummaryText(text);
 }
 
 function isPayloadHeavy(text: string): boolean {

--- a/packages/junior/src/chat/services/turn-failure-response.ts
+++ b/packages/junior/src/chat/services/turn-failure-response.ts
@@ -1,7 +1,6 @@
 import type { LogContext } from "@/chat/logging";
 import { buildTurnFailureResponse } from "@/chat/logging";
 import { getInterruptionMarker } from "@/chat/interruption-marker";
-import { GEN_AI_PROVIDER_NAME } from "@/chat/pi/client";
 import type { AgentRunResult } from "@/chat/services/turn-result";
 
 type LogException = (
@@ -79,8 +78,6 @@ export function getAgentTurnDiagnosticsAttributes(
   reply: AgentRunResult,
 ): Record<string, unknown> {
   return {
-    "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
-    "gen_ai.operation.name": "invoke_agent",
     "app.ai.outcome": reply.diagnostics.outcome,
     "app.ai.assistant_messages": reply.diagnostics.assistantMessageCount,
     "app.ai.tool_results": reply.diagnostics.toolResultCount,

--- a/packages/junior/src/chat/services/turn-reasoning-level.ts
+++ b/packages/junior/src/chat/services/turn-reasoning-level.ts
@@ -229,11 +229,11 @@ export async function selectTurnReasoningLevel(args: {
       });
 
       setSpanAttributes({
-        "app.ai.reasoning_level": normalizedSelection.reasoningLevel,
-        "app.ai.reasoning_level_reason": normalizedSelection.reason,
+        "gen_ai.request.reasoning.level": normalizedSelection.reasoningLevel,
+        "gen_ai.request.reasoning.level_reason": normalizedSelection.reason,
         ...(normalizedSelection.confidence !== undefined
           ? {
-              "app.ai.reasoning_level_confidence":
+              "gen_ai.request.reasoning.level_confidence":
                 normalizedSelection.confidence,
             }
           : {}),

--- a/packages/junior/src/chat/tool-support/pi-tool-adapter.ts
+++ b/packages/junior/src/chat/tool-support/pi-tool-adapter.ts
@@ -11,7 +11,6 @@ import {
   type LogContext,
   type SetSpanAttributes,
 } from "@/chat/logging";
-import { GEN_AI_PROVIDER_NAME } from "@/chat/pi/client";
 import { shouldEmitDevAgentTrace } from "@/chat/runtime/dev-agent-trace";
 import {
   AuthorizationFlowDisabledError,
@@ -76,13 +75,13 @@ export function createPiAgentTools(
   const effectiveConversationPrivacy = conversationPrivacy ?? "private";
   const serializeToolPayload = (
     payload: unknown,
-    options: { exposePrivate?: boolean } = {},
+    options: { exposePrivate?: boolean; privateMetadata?: boolean } = {},
   ) =>
-    serializeGenAiAttribute(
-      effectiveConversationPrivacy === "private" && !options.exposePrivate
-        ? toGenAiPayloadMetadata(payload)
-        : payload,
-    );
+    effectiveConversationPrivacy === "private" && !options.exposePrivate
+      ? options.privateMetadata
+        ? serializeGenAiAttribute(toGenAiPayloadMetadata(payload))
+        : undefined
+      : serializeGenAiAttribute(payload);
   const notifyToolResult = async (report: ToolExecutionReport) => {
     try {
       await onToolResult?.(report);
@@ -214,14 +213,17 @@ export function createPiAgentTools(
             hasProjectedPrivateResult
               ? projectedPrivateResult
               : resultAttributeValue,
-            { exposePrivate: hasProjectedPrivateResult },
+            {
+              exposePrivate: hasProjectedPrivateResult,
+              privateMetadata: true,
+            },
           );
     if (toolResultAttribute) {
       setSpanAttributes({
         "gen_ai.tool.call.result": toolResultAttribute,
         ...(hasProjectedPrivateResult ? privateTraceResultAttributes() : {}),
         ...toGenAiPayloadTraceAttributes(
-          "app.ai.tool.call.result",
+          "gen_ai.tool.call.result",
           resultAttributeValue,
         ),
       });
@@ -262,9 +264,13 @@ export function createPiAgentTools(
         typeof toolCallId === "string" && toolCallId.length > 0
           ? toolCallId
           : undefined;
-      const toolArgumentsAttribute = serializeToolPayload(params);
+      // Intentional OTel deviation: private traces put Junior's safe metadata
+      // here, with flattened gen_ai.tool.call.arguments.* extension attributes.
+      const toolArgumentsAttribute = serializeToolPayload(params, {
+        privateMetadata: true,
+      });
       const toolArgumentsMetadata = toGenAiPayloadTraceAttributes(
-        "app.ai.tool.call.arguments",
+        "gen_ai.tool.call.arguments",
         params,
       );
       return withSpan(
@@ -285,7 +291,7 @@ export function createPiAgentTools(
               executionToolName = resolvedCatalogCall.toolName;
               executionParams = resolvedCatalogCall.arguments;
               setSpanAttributes({
-                "app.ai.tool.dispatcher.name": EXECUTE_TOOL_NAME,
+                "gen_ai.tool.dispatcher.name": EXECUTE_TOOL_NAME,
                 "gen_ai.tool.description":
                   resolvedCatalogCall.definition.description,
                 "gen_ai.tool.name": resolvedCatalogCall.toolName,
@@ -337,11 +343,10 @@ export function createPiAgentTools(
           }
         },
         {
-          "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
           "gen_ai.operation.name": "execute_tool",
           "gen_ai.tool.name": toolName,
           "gen_ai.tool.description": toolDef.description,
-          "gen_ai.tool.type": "extension",
+          "gen_ai.tool.type": "function",
           ...toolArgumentsMetadata,
           ...(normalizedToolCallId
             ? { "gen_ai.tool.call.id": normalizedToolCallId }

--- a/packages/junior/src/chat/tool-support/private-trace-result.ts
+++ b/packages/junior/src/chat/tool-support/private-trace-result.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-const PRIVATE_TRACE_RESULT_ATTRIBUTE = "app.ai.tool.call.result.exposure";
+const PRIVATE_TRACE_RESULT_ATTRIBUTE = "gen_ai.tool.call.result.exposure";
 const privateTraceResultToken = randomUUID();
 
 /** Mark one tool result as an adapter-approved private trace projection. */

--- a/packages/junior/src/chat/tools/execution/tool-error-handler.ts
+++ b/packages/junior/src/chat/tools/execution/tool-error-handler.ts
@@ -7,7 +7,6 @@ import {
   type SetSpanAttributes,
 } from "@/chat/logging";
 import { PluginToolInputError } from "@sentry/junior-plugin-api";
-import { GEN_AI_PROVIDER_NAME } from "@/chat/pi/client";
 import type { ConversationPrivacy } from "@/chat/conversation-privacy";
 import { getMcpAwareTelemetryMessage, McpToolError } from "@/chat/mcp/errors";
 import { PluginCredentialFailureError } from "@/chat/services/plugin-auth-orchestration";
@@ -79,7 +78,6 @@ export function handleToolExecutionError(
         traceContext,
         {
           "app.credential.provider": error.provider,
-          "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
           "gen_ai.operation.name": "execute_tool",
           "gen_ai.tool.name": toolName,
           ...(toolCallId ? { "gen_ai.tool.call.id": toolCallId } : {}),
@@ -96,7 +94,6 @@ export function handleToolExecutionError(
       "agent_tool_call_failed",
       traceContext,
       {
-        "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
         "gen_ai.operation.name": "execute_tool",
         "gen_ai.tool.name": toolName,
         ...(toolCallId ? { "gen_ai.tool.call.id": toolCallId } : {}),
@@ -118,7 +115,6 @@ export function handleToolExecutionError(
       "agent_tool_call_failed",
       {},
       {
-        "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
         "gen_ai.operation.name": "execute_tool",
         "gen_ai.tool.name": toolName,
         ...(toolCallId ? { "gen_ai.tool.call.id": toolCallId } : {}),

--- a/packages/junior/tests/unit/chat/pi/traced-stream.test.ts
+++ b/packages/junior/tests/unit/chat/pi/traced-stream.test.ts
@@ -87,7 +87,7 @@ describe("createTracedStreamFn", () => {
     expect(opts.name).toBe("chat openai/gpt-5.4");
   });
 
-  it("sets metadata-only input messages and system instructions when privacy is unknown", async () => {
+  it("omits opt-in semantic content when privacy is unknown", async () => {
     const { createTracedStreamFn } = await import("@/chat/pi/traced-stream");
     const stream = createAssistantMessageEventStream();
     const base = vi.fn(() => stream);
@@ -110,26 +110,20 @@ describe("createTracedStreamFn", () => {
     expect(opts.attributes["server.port"]).toBe(443);
     expect(opts.attributes["gen_ai.request.stream"]).toBe(true);
     expect(opts.attributes["gen_ai.output.type"]).toBe("text");
-    expect(opts.attributes["app.ai.input.message_count"]).toBe(1);
-    expect(opts.attributes["app.ai.input.content_chars"]).toBe(5);
-    expect(opts.attributes["app.ai.input.roles"]).toEqual(["user"]);
-    expect(opts.attributes["app.ai.system_instructions.content_chars"]).toBe(
+    expect(opts.attributes["gen_ai.input.message_count"]).toBe(1);
+    expect(opts.attributes["gen_ai.input.content_chars"]).toBe(5);
+    expect(opts.attributes["gen_ai.input.roles"]).toEqual(["user"]);
+    expect(opts.attributes["gen_ai.system_instructions.content_chars"]).toBe(
       14,
     );
-    expect(typeof opts.attributes["gen_ai.input.messages"]).toBe("string");
     expect(opts.attributes["app.conversation.privacy"]).toBe("private");
-    expect(opts.attributes["gen_ai.input.messages"]).toContain('"chars"');
-    expect(opts.attributes["gen_ai.input.messages"]).not.toContain("hello");
-    expect(typeof opts.attributes["gen_ai.system_instructions"]).toBe("string");
-    expect(opts.attributes["gen_ai.system_instructions"]).toContain('"chars"');
-    expect(opts.attributes["gen_ai.system_instructions"]).not.toContain(
-      "you are junior",
-    );
+    expect(opts.attributes["gen_ai.input.messages"]).toBeUndefined();
+    expect(opts.attributes["gen_ai.system_instructions"]).toBeUndefined();
     expect(opts.attributes["gen_ai.operation.name"]).toBe("chat");
     expect(opts.attributes["gen_ai.request.model"]).toBe("openai/gpt-5.4");
   });
 
-  it("uses message metadata for private conversation chat spans", async () => {
+  it("keeps private conversation content out of semantic attributes", async () => {
     const { createTracedStreamFn } = await import("@/chat/pi/traced-stream");
     const stream = createAssistantMessageEventStream();
     const base = vi.fn(() => stream);
@@ -153,24 +147,12 @@ describe("createTracedStreamFn", () => {
       attributes: Record<string, unknown>;
     };
     expect(opts.attributes["app.conversation.privacy"]).toBe("private");
-    expect(opts.attributes["app.ai.input.message_count"]).toBe(1);
-    expect(opts.attributes["app.ai.input.content_chars"]).toBe(
+    expect(opts.attributes["gen_ai.input.message_count"]).toBe(1);
+    expect(opts.attributes["gen_ai.input.content_chars"]).toBe(
       privatePrompt.length,
     );
-    expect(opts.attributes["gen_ai.input.messages"]).toContain('"chars"');
-    expect(opts.attributes["gen_ai.input.messages"]).not.toContain(
-      "private prompt",
-    );
-    expect(opts.attributes["gen_ai.input.messages"]).not.toContain(
-      "slack.conversation.name",
-    );
-    expect(opts.attributes["gen_ai.input.messages"]).not.toContain(
-      "#private-roadmap",
-    );
-    expect(opts.attributes["gen_ai.system_instructions"]).toContain('"chars"');
-    expect(opts.attributes["gen_ai.system_instructions"]).not.toContain(
-      "private system",
-    );
+    expect(opts.attributes["gen_ai.input.messages"]).toBeUndefined();
+    expect(opts.attributes["gen_ai.system_instructions"]).toBeUndefined();
 
     stream.end({
       ...fakeMessage(),
@@ -183,10 +165,9 @@ describe("createTracedStreamFn", () => {
     const endAttributes = Object.fromEntries(
       span.setAttribute.mock.calls.map((c) => [c[0], c[1]]),
     );
-    expect(endAttributes["app.ai.output.message_count"]).toBe(1);
-    expect(endAttributes["app.ai.output.content_chars"]).toBe(6);
-    expect(endAttributes["gen_ai.output.messages"]).toContain('"chars"');
-    expect(endAttributes["gen_ai.output.messages"]).not.toContain("secret");
+    expect(endAttributes["gen_ai.output.message_count"]).toBe(1);
+    expect(endAttributes["gen_ai.output.content_chars"]).toBe(6);
+    expect(endAttributes["gen_ai.output.messages"]).toBeUndefined();
   });
 
   it("sets output.messages, usage tokens, finish_reasons, response.model after stream completion", async () => {
@@ -194,7 +175,10 @@ describe("createTracedStreamFn", () => {
     const stream = createAssistantMessageEventStream();
     const base = vi.fn(() => stream);
 
-    const traced = createTracedStreamFn(base as unknown as StreamFn);
+    const traced = createTracedStreamFn({
+      base: base as unknown as StreamFn,
+      conversationPrivacy: "public",
+    });
     const returned = await traced(
       fakeModel("openai/gpt-5.4"),
       { messages: [{ role: "user", content: "hi", timestamp: 0 }] },
@@ -266,10 +250,9 @@ describe("createTracedStreamFn", () => {
     expect(outputMessages).toHaveLength(1);
     const msg = outputMessages[0];
     expect(msg.role).toBe("assistant");
-    expect(msg.finish_reason).toBe("tool_use");
+    expect(msg.finish_reason).toBe("tool_call");
     expect(msg.parts).toEqual([
       { type: "reasoning", content: "I should use the search tool." },
-      { type: "reasoning", redacted: true },
       { type: "text", content: "The answer is 42." },
       {
         type: "tool_call",
@@ -318,7 +301,7 @@ describe("createTracedStreamFn", () => {
       span.setAttribute.mock.calls.map((c) => [c[0], c[1]]),
     );
     expect(endAttributes["gen_ai.response.finish_reasons"]).toEqual([
-      "tool_use",
+      "tool_call",
     ]);
   });
 
@@ -350,6 +333,37 @@ describe("createTracedStreamFn", () => {
     expect(opts.attributes["gen_ai.request.model"]).toBe("openai/gpt-5.4");
   });
 
+  it("marks inference spans that use compacted conversation context", async () => {
+    const { createTracedStreamFn } = await import("@/chat/pi/traced-stream");
+    const stream = createAssistantMessageEventStream();
+    const base = vi.fn(() => stream);
+    const traced = createTracedStreamFn(base as unknown as StreamFn);
+
+    await traced(
+      fakeModel("openai/gpt-5.4"),
+      {
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: "Context compaction summary for future Junior turns:\nsummary",
+              },
+            ],
+            timestamp: 0,
+          },
+        ],
+      },
+      undefined,
+    );
+
+    const opts = startInactiveSpan.mock.calls[0]?.[0] as {
+      attributes: Record<string, unknown>;
+    };
+    expect(opts.attributes["gen_ai.conversation.compacted"]).toBe(true);
+  });
+
   it("ends the span when the stream errors", async () => {
     const { createTracedStreamFn } = await import("@/chat/pi/traced-stream");
     const stream = createAssistantMessageEventStream();
@@ -373,9 +387,12 @@ describe("createTracedStreamFn", () => {
 
     const span = getSpan();
     expect(span.end).toHaveBeenCalledTimes(1);
-    // End attributes are still populated because the success arm runs.
+    expect(span.setStatus).toHaveBeenCalledWith({
+      code: 2,
+      message: "LLM stream failed",
+    });
     const endAttributeKeys = span.setAttribute.mock.calls.map((c) => c[0]);
-    expect(endAttributeKeys).toContain("gen_ai.output.messages");
+    expect(endAttributeKeys).toContain("error.type");
   });
 
   it("sets error status and ends the span when base() throws", async () => {

--- a/packages/junior/tests/unit/logging/extract-gen-ai-usage-summary.test.ts
+++ b/packages/junior/tests/unit/logging/extract-gen-ai-usage-summary.test.ts
@@ -135,15 +135,14 @@ describe("extractGenAiUsageSummary", () => {
     ).toEqual({
       "gen_ai.usage.input_tokens": 15,
       "gen_ai.usage.output_tokens": 2,
-      "gen_ai.usage.total_tokens": 17,
-      "gen_ai.usage.input_tokens.cached": 4,
-      "gen_ai.usage.input_tokens.cache_write": 1,
-      "app.ai.reasoning_tokens": 1,
-      "app.ai.cost.input_usd": 0.001,
-      "app.ai.cost.output_usd": 0.002,
-      "app.ai.cost.cache_read_usd": 0.0003,
-      "app.ai.cost.cache_write_usd": 0.0004,
-      "app.ai.cost.total_usd": 0.0037,
+      "gen_ai.usage.cache_read.input_tokens": 4,
+      "gen_ai.usage.cache_creation.input_tokens": 1,
+      "gen_ai.usage.reasoning.output_tokens": 1,
+      "app.cost.input_usd": 0.001,
+      "app.cost.output_usd": 0.002,
+      "app.cost.cache_read_usd": 0.0003,
+      "app.cost.cache_write_usd": 0.0004,
+      "app.cost.total_usd": 0.0037,
     });
   });
 });

--- a/packages/junior/tests/unit/logging/serialize-gen-ai-attribute.test.ts
+++ b/packages/junior/tests/unit/logging/serialize-gen-ai-attribute.test.ts
@@ -28,4 +28,8 @@ describe("serializeGenAiAttribute", () => {
     expect(serialized).not.toContain("abcdefghijklmnopqrstuvwxyz1234567890");
     expect(serialized).not.toContain("super-secret-material");
   });
+
+  it("omits oversized values instead of emitting invalid JSON", () => {
+    expect(serializeGenAiAttribute({ value: "abcdef" }, 5)).toBeUndefined();
+  });
 });

--- a/packages/junior/tests/unit/logging/with-span.test.ts
+++ b/packages/junior/tests/unit/logging/with-span.test.ts
@@ -7,7 +7,10 @@ const { activeSpan, getTraceData, startSpan } = vi.hoisted(() => ({
   },
   getTraceData: vi.fn(),
   startSpan: vi.fn(
-    async (_options: unknown, callback: () => Promise<unknown>) => callback(),
+    async (
+      _options: unknown,
+      callback: (span: typeof activeSpan) => Promise<unknown>,
+    ) => callback(activeSpan),
   ),
 }));
 
@@ -62,9 +65,7 @@ describe("withSpan", () => {
       "thread_123",
     );
     expect(innerSpanOptions.attributes["app.run.id"]).toBe("run_123");
-    expect(innerSpanOptions.attributes["gen_ai.request.model"]).toBe(
-      "openai/gpt-4o-mini",
-    );
+    expect(innerSpanOptions.attributes["gen_ai.request.model"]).toBeUndefined();
   });
 
   it("normalizes Pi toolUse finish reasons on span attributes", async () => {
@@ -79,11 +80,26 @@ describe("withSpan", () => {
       attributes: Record<string, unknown>;
     };
     expect(spanOptions.attributes["gen_ai.response.finish_reasons"]).toEqual([
-      "tool_use",
+      "tool_call",
     ]);
     expect(activeSpan.setAttribute).toHaveBeenCalledWith(
       "gen_ai.response.finish_reasons",
-      ["tool_use"],
+      ["tool_call"],
+    );
+  });
+
+  it("sets error.type on the span that throws", async () => {
+    const { withSpan } = await import("@/chat/logging");
+
+    await expect(
+      withSpan("chat model", "gen_ai.chat", {}, async () => {
+        throw new TypeError("bad response");
+      }),
+    ).rejects.toThrow("bad response");
+
+    expect(activeSpan.setAttribute).toHaveBeenCalledWith(
+      "error.type",
+      "TypeError",
     );
   });
 

--- a/packages/junior/tests/unit/mcp/tool-manager-telemetry.test.ts
+++ b/packages/junior/tests/unit/mcp/tool-manager-telemetry.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginDefinition } from "@/chat/plugins/types";
+
+const { endAttributes, resultMock, startAttributes } = vi.hoisted(() => ({
+  endAttributes: { value: {} as Record<string, unknown> },
+  resultMock: vi.fn(),
+  startAttributes: { value: {} as Record<string, unknown> },
+}));
+
+vi.mock("@/chat/logging", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/chat/logging")>();
+  return {
+    ...actual,
+    setSpanAttributes: vi.fn((attributes: Record<string, unknown>) => {
+      Object.assign(endAttributes.value, attributes);
+    }),
+    withSpan: vi.fn(
+      async (
+        _name: string,
+        _op: string,
+        _context: unknown,
+        callback: () => Promise<unknown>,
+        attributes: Record<string, unknown>,
+      ) => {
+        startAttributes.value = { ...attributes };
+        return await callback();
+      },
+    ),
+  };
+});
+
+vi.mock("@/chat/mcp/client", () => ({
+  McpAuthorizationRequiredError: class McpAuthorizationRequiredError extends Error {},
+  PluginMcpClient: class PluginMcpClient {
+    async listTools() {
+      return [
+        {
+          name: "inspect",
+          description: "Inspect a private value.",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ];
+    }
+
+    async callTool() {
+      return await resultMock();
+    }
+
+    async close() {}
+  },
+}));
+
+import { McpToolManager } from "@/chat/mcp/tool-manager";
+
+function buildPlugin(): PluginDefinition {
+  return {
+    dir: "/tmp/plugins/demo",
+    skillsDir: "/tmp/plugins/demo/skills",
+    manifest: {
+      name: "demo",
+      displayName: "Demo",
+      description: "Demo MCP plugin",
+      capabilities: [],
+      configKeys: [],
+      mcp: {
+        transport: "http",
+        url: "https://mcp.example.com",
+      },
+    },
+  };
+}
+
+describe("McpToolManager telemetry", () => {
+  beforeEach(() => {
+    startAttributes.value = {};
+    endAttributes.value = {};
+    resultMock.mockReset();
+    resultMock.mockResolvedValue({
+      content: [{ type: "text", text: "private result" }],
+      isError: false,
+    });
+  });
+
+  it("reports metadata for private MCP results without exposing content", async () => {
+    const manager = new McpToolManager([buildPlugin()]);
+    await manager.activateProvider("demo");
+    const [tool] = manager.getResolvedActiveTools();
+
+    await tool!.execute({}, { conversationPrivacy: "private" });
+
+    expect(endAttributes.value["gen_ai.tool.call.result"]).toContain(
+      '"type":"object"',
+    );
+    expect(endAttributes.value["gen_ai.tool.call.result"]).not.toContain(
+      "private result",
+    );
+  });
+});

--- a/packages/junior/tests/unit/pi/client.test.ts
+++ b/packages/junior/tests/unit/pi/client.test.ts
@@ -5,7 +5,9 @@ const mocks = vi.hoisted(() => ({
   completeSimple: vi.fn(),
   createGatewayProvider: vi.fn(() => ({
     chat: vi.fn((modelId: string) => ({ modelId })),
+    embeddingModel: vi.fn((modelId: string) => ({ modelId })),
   })),
+  embedMany: vi.fn(),
   generateObject: vi.fn(),
   getEnvApiKey: vi.fn(),
   getModels: vi.fn(() => [{ id: "openai/gpt-4o-mini" }]),
@@ -20,9 +22,11 @@ const mocks = vi.hoisted(() => ({
       _name: string,
       _op: string,
       _context: Record<string, unknown>,
-      callback: () => Promise<unknown>,
+      callback: (
+        setSpanAttributes: (attributes: Record<string, unknown>) => void,
+      ) => Promise<unknown>,
       _attributes?: Record<string, unknown>,
-    ) => callback(),
+    ) => callback(mocks.setSpanAttributes),
   ),
 }));
 
@@ -40,6 +44,7 @@ vi.mock("@ai-sdk/gateway", () => ({
 }));
 
 vi.mock("ai", () => ({
+  embedMany: mocks.embedMany,
   generateObject: mocks.generateObject,
 }));
 
@@ -76,6 +81,7 @@ describe("completeText", () => {
       system: "Be concise.",
       messages: [{ role: "user", content: "hi", timestamp: 1 }] as any,
       thinkingLevel: "low",
+      messageAttributeMode: "content",
     });
 
     expect(result.text).toBe("hello world");
@@ -109,19 +115,13 @@ describe("completeText", () => {
 
     expect(mocks.setSpanAttributes).toHaveBeenCalledWith(
       expect.objectContaining({
-        "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
-        "gen_ai.operation.name": "chat",
-        "gen_ai.request.model": "openai/gpt-4o-mini",
-        "gen_ai.output.type": "text",
-        "server.address": "ai-gateway.vercel.sh",
-        "server.port": 443,
         "gen_ai.output.messages": expect.any(String),
         "gen_ai.response.finish_reasons": ["stop"],
       }),
     );
   });
 
-  it("uses message metadata for non-public conversation traces", async () => {
+  it("omits opt-in semantic content for non-public conversation traces", async () => {
     mocks.completeSimple.mockResolvedValue({
       content: [{ type: "text", text: "private answer" }],
       stopReason: "stop",
@@ -159,27 +159,18 @@ describe("completeText", () => {
     expect(attributes["server.address"]).toBe("ai-gateway.vercel.sh");
     expect(attributes["server.port"]).toBe(443);
     expect(attributes["gen_ai.output.type"]).toBe("text");
-    expect(attributes["app.ai.input.message_count"]).toBe(1);
-    expect(attributes["app.ai.input.content_chars"]).toBe(16);
-    expect(attributes["gen_ai.system_instructions"]).toContain('"chars"');
-    expect(attributes["gen_ai.system_instructions"]).not.toContain(
-      "private system",
-    );
-    expect(attributes["gen_ai.input.messages"]).toContain('"chars"');
-    expect(attributes["gen_ai.input.messages"]).not.toContain(
-      "private question",
-    );
+    expect(attributes["gen_ai.input.message_count"]).toBe(1);
+    expect(attributes["gen_ai.input.content_chars"]).toBe(16);
+    expect(attributes["gen_ai.system_instructions"]).toBeUndefined();
+    expect(attributes["gen_ai.input.messages"]).toBeUndefined();
 
     const endAttributes = mocks.setSpanAttributes.mock.calls[0]?.[0] as Record<
       string,
       unknown
     >;
-    expect(endAttributes["app.ai.output.message_count"]).toBe(1);
-    expect(endAttributes["app.ai.output.content_chars"]).toBe(14);
-    expect(endAttributes["gen_ai.output.messages"]).toContain('"chars"');
-    expect(endAttributes["gen_ai.output.messages"]).not.toContain(
-      "private answer",
-    );
+    expect(endAttributes["gen_ai.output.message_count"]).toBe(1);
+    expect(endAttributes["gen_ai.output.content_chars"]).toBe(14);
+    expect(endAttributes["gen_ai.output.messages"]).toBeUndefined();
   });
 
   it("scrubs C-prefixed channel traces unless the turn confirmed the channel public", async () => {
@@ -207,9 +198,7 @@ describe("completeText", () => {
       unknown
     >;
     expect(noSignal["app.conversation.privacy"]).toBe("private");
-    expect(noSignal["gen_ai.input.messages"]).not.toContain(
-      "possibly private question",
-    );
+    expect(noSignal["gen_ai.input.messages"]).toBeUndefined();
 
     // The turn-scoped privacy context carries the source-confirmed signal.
     await runWithConversationPrivacy("public", () =>
@@ -236,8 +225,7 @@ describe("completeText", () => {
       usage: { inputTokens: 10, outputTokens: 3, totalTokens: 13 },
     });
 
-    const { completeObject, GEN_AI_PROVIDER_NAME } =
-      await import("@/chat/pi/client");
+    const { completeObject } = await import("@/chat/pi/client");
     const schema = z.object({ ok: z.boolean() });
 
     const result = await completeObject({
@@ -258,10 +246,6 @@ describe("completeText", () => {
     );
     expect(mocks.setSpanAttributes).toHaveBeenCalledWith(
       expect.objectContaining({
-        "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
-        "gen_ai.operation.name": "chat",
-        "gen_ai.request.model": "openai/gpt-4o-mini",
-        "gen_ai.output.type": "json",
         "gen_ai.response.finish_reasons": ["stop"],
       }),
     );
@@ -285,5 +269,50 @@ describe("completeText", () => {
     );
     expect(mocks.logWarn).not.toHaveBeenCalled();
     expect(mocks.logException).not.toHaveBeenCalled();
+  });
+
+  it("records embedding usage and dimensions on the embedding span", async () => {
+    mocks.embedMany.mockResolvedValue({
+      embeddings: [
+        [0.1, 0.2, 0.3],
+        [0.4, 0.5, 0.6],
+      ],
+      usage: { inputTokens: 8 },
+    });
+
+    const { embedTexts } = await import("@/chat/pi/client");
+    const result = await embedTexts({
+      modelId: "openai/text-embedding-3-small",
+      texts: ["one", "two"],
+    });
+
+    expect(result.dimensions).toBe(3);
+    const startAttributes = mocks.withSpan.mock.calls[0]?.[4] as Record<
+      string,
+      unknown
+    >;
+    expect(startAttributes["gen_ai.operation.name"]).toBe("embeddings");
+    expect(startAttributes["gen_ai.output.type"]).toBeUndefined();
+    expect(mocks.setSpanAttributes).toHaveBeenCalledWith({
+      "gen_ai.embeddings.dimension.count": 3,
+      "gen_ai.usage.input_tokens": 8,
+    });
+  });
+
+  it("validates embedding output before the embedding span ends", async () => {
+    mocks.embedMany.mockResolvedValue({
+      embeddings: [[0.1], [0.2, 0.3]],
+      usage: { inputTokens: 8 },
+    });
+
+    const { embedTexts } = await import("@/chat/pi/client");
+
+    await expect(
+      embedTexts({
+        modelId: "openai/text-embedding-3-small",
+        texts: ["one", "two"],
+      }),
+    ).rejects.toThrow("Embedding provider returned invalid vectors");
+    expect(mocks.setSpanAttributes).not.toHaveBeenCalled();
   });
 });

--- a/packages/junior/tests/unit/privacy/conversation-privacy.test.ts
+++ b/packages/junior/tests/unit/privacy/conversation-privacy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   canExposeConversationPayload,
   resolveConversationPrivacy,
+  toCanonicalInputMessage,
   toGenAiPayloadMetadata,
   toGenAiPayloadTraceAttributes,
 } from "@/chat/conversation-privacy";
@@ -60,20 +61,43 @@ describe("conversation privacy metadata", () => {
 
     const metadata = toGenAiPayloadMetadata(payload);
     const attributes = toGenAiPayloadTraceAttributes(
-      "app.ai.tool.call.arguments",
+      "gen_ai.tool.call.arguments",
       payload,
     );
 
     expect(metadata.keys).toHaveLength(20);
     expect(metadata.keys).toContain("privateKey0");
     expect(metadata.keys).not.toContain("privateKey20");
-    expect(attributes["app.ai.tool.call.arguments.keys"]).toHaveLength(20);
-    expect(attributes["app.ai.tool.call.arguments.keys"]).toContain(
+    expect(attributes["gen_ai.tool.call.arguments.keys"]).toHaveLength(20);
+    expect(attributes["gen_ai.tool.call.arguments.keys"]).toContain(
       "privateKey0",
     );
-    expect(attributes["app.ai.tool.call.arguments.keys"]).not.toContain(
+    expect(attributes["gen_ai.tool.call.arguments.keys"]).not.toContain(
       "privateKey20",
     );
     expect(JSON.stringify(metadata)).not.toContain("private value");
+  });
+});
+
+describe("canonical GenAI messages", () => {
+  it("represents tool results as tool_call_response parts", () => {
+    expect(
+      toCanonicalInputMessage({
+        role: "toolResult",
+        toolCallId: "call_123",
+        toolName: "weather",
+        content: [{ type: "text", text: "sunny" }],
+        timestamp: 0,
+      } as any),
+    ).toEqual({
+      role: "tool",
+      parts: [
+        {
+          type: "tool_call_response",
+          id: "call_123",
+          response: [{ type: "text", content: "sunny" }],
+        },
+      ],
+    });
   });
 });

--- a/packages/junior/tests/unit/sentry-payload-filter.test.ts
+++ b/packages/junior/tests/unit/sentry-payload-filter.test.ts
@@ -108,7 +108,7 @@ describe("Sentry private payload filtering", () => {
     expect(span.attributes?.["gen_ai.tool.call.result"]).toBe(projectedResult);
     expect(span.attributes?.["app.conversation.payload_redacted"]).toBe(true);
     expect(span.attributes).not.toHaveProperty(
-      "app.ai.tool.call.result.exposure",
+      "gen_ai.tool.call.result.exposure",
     );
   });
 
@@ -116,7 +116,7 @@ describe("Sentry private payload filtering", () => {
     const span = {
       attributes: {
         "gen_ai.tool.call.result": JSON.stringify({ secret: "private" }),
-        "app.ai.tool.call.result.exposure": "projected",
+        "gen_ai.tool.call.result.exposure": "projected",
       },
       end_timestamp: 2,
       is_segment: false,
@@ -131,7 +131,7 @@ describe("Sentry private payload filtering", () => {
 
     expect(span.attributes?.["gen_ai.tool.call.result"]).toBeUndefined();
     expect(span.attributes).not.toHaveProperty(
-      "app.ai.tool.call.result.exposure",
+      "gen_ai.tool.call.result.exposure",
     );
   });
 

--- a/packages/junior/tests/unit/services/context-compaction-marker.test.ts
+++ b/packages/junior/tests/unit/services/context-compaction-marker.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { renderCurrentInstruction } from "@/chat/current-instruction";
+import {
+  hasCompactedConversationContext,
+  MODEL_HANDOFF_SUMMARY_PREFIX,
+} from "@/chat/services/context-compaction-marker";
+
+describe("hasCompactedConversationContext", () => {
+  it("detects a handoff summary wrapped as the current instruction", () => {
+    expect(
+      hasCompactedConversationContext([
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: renderCurrentInstruction(
+                `${MODEL_HANDOFF_SUMMARY_PREFIX}\nContinue the task.`,
+              ),
+            },
+          ],
+          timestamp: Date.now(),
+        },
+      ]),
+    ).toBe(true);
+  });
+});

--- a/packages/junior/tests/unit/tool-support/pi-tool-adapter-telemetry.test.ts
+++ b/packages/junior/tests/unit/tool-support/pi-tool-adapter-telemetry.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AnyToolDefinition } from "@/chat/tools/definition";
+
+const { endAttributes, startAttributes } = vi.hoisted(() => ({
+  endAttributes: { value: {} as Record<string, unknown> },
+  startAttributes: { value: {} as Record<string, unknown> },
+}));
+
+vi.mock("@/chat/logging", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/chat/logging")>();
+  return {
+    ...actual,
+    logWarn: vi.fn(),
+    withSpan: vi.fn(
+      async (
+        _name: string,
+        _op: string,
+        _context: unknown,
+        callback: (
+          setSpanAttributes: (attributes: Record<string, unknown>) => void,
+        ) => Promise<unknown>,
+        attributes: Record<string, unknown>,
+      ) => {
+        startAttributes.value = { ...attributes };
+        return await callback((nextAttributes) => {
+          Object.assign(endAttributes.value, nextAttributes);
+        });
+      },
+    ),
+  };
+});
+
+import { createPiAgentTools } from "@/chat/tool-support/pi-tool-adapter";
+
+describe("createPiAgentTools telemetry", () => {
+  beforeEach(() => {
+    startAttributes.value = {};
+    endAttributes.value = {};
+  });
+
+  it("reports metadata for private tool results without exposing content", async () => {
+    const tools: Record<string, AnyToolDefinition> = {
+      inspect: {
+        description: "Inspect a private value.",
+        inputSchema: { type: "object", properties: {} },
+        execute: async () => ({
+          ok: true,
+          status: "success",
+          secret: "private result",
+        }),
+      },
+    };
+    const [tool] = createPiAgentTools(
+      tools,
+      {} as never,
+      {},
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "private",
+    );
+
+    await tool!.execute!("call-1", {});
+
+    expect(endAttributes.value["gen_ai.tool.call.result"]).toContain(
+      '"type":"object"',
+    );
+    expect(endAttributes.value["gen_ai.tool.call.result"]).not.toContain(
+      "private result",
+    );
+    expect(endAttributes.value["gen_ai.tool.call.result.keys"]).toContain(
+      "secret",
+    );
+  });
+});


### PR DESCRIPTION
Junior's GenAI telemetry now follows the current OpenTelemetry span taxonomy and attribute ownership. Agent runs use an internal `invoke_agent` parent, provider calls use `chat` children, and locally executed tools use `execute_tool` children. Model handoffs remain tool executions followed by a new target-model `chat` span whose effective compacted context is explicitly reported.

Standard OTel attributes are used wherever they exist, including `gen_ai.request.model`, request reasoning settings, finish reasons, embeddings dimensions, and input/cache/output/reasoning token usage. Junior-specific GenAI metadata stays in the closest `gen_ai.*` namespace rather than `app.ai.*`; examples include safe flattened message/tool metadata, agent model-profile state, and provider auth mode. Monetary accounting is provider-independent and uses generic `app.cost.*` attributes.

Private tool calls intentionally populate `gen_ai.tool.call.arguments` with Junior's privacy-safe metadata projection and add flattened `gen_ai.tool.call.arguments.*` extension attributes. This is a documented, deliberate deviation because it provides more operational value than omitting the standard attribute entirely.