### PR TITLE
fix(dashboard): Forward the avatar asset route

### DIFF
--- a/packages/junior/src/app.ts
+++ b/packages/junior/src/app.ts
@@ -374,6 +374,7 @@ function dashboardHostRoutePaths(dashboard: JuniorDashboardOptions): string[] {
   return [
     ...pagePaths,
     "/favicon.ico",
+    "/_junior/dashboard/avatar.png",
     "/_junior/dashboard/client.js",
     loginPath,
     "/api/health",

--- a/packages/junior/tests/unit/app-config.test.ts
+++ b/packages/junior/tests/unit/app-config.test.ts
@@ -807,6 +807,12 @@ describe("createApp plugin config", () => {
     expect(systemPage.status).toBe(200);
     await expect(systemPage.text()).resolves.toBe("dashboard");
 
+    const dashboardAvatar = await app.fetch(
+      new Request("http://localhost/_junior/dashboard/avatar.png"),
+    );
+    expect(dashboardAvatar.status).toBe(200);
+    await expect(dashboardAvatar.text()).resolves.toBe("dashboard");
+
     const pluginsPage = await app.fetch(
       new Request("http://localhost/plugins"),
     );


### PR DESCRIPTION
The production Junior host now forwards the dashboard avatar asset route, allowing the header logo to render after deployment.

The dashboard already served the image, but its path was absent from the host's explicit dashboard route list, so the request returned 404 before reaching the asset handler. Regression coverage now exercises that host boundary.