### PR TITLE
fix(dashboard): Improve analytics views and conversation details

### DIFF
--- a/packages/junior-dashboard/e2e/dashboard.spec.ts
+++ b/packages/junior-dashboard/e2e/dashboard.spec.ts
@@ -201,23 +201,37 @@ test("hydrates the built dashboard client in a real browser", async ({
   ).toBeVisible();
   expect(await containerBounds()).toEqual(headerBounds);
 
-  const activityPoints = page
-    .getByRole("img", { name: "Active people per day" })
-    .locator("circle");
-  await expect(activityPoints).toHaveCount(30);
+  await expect(
+    page.getByRole("img", { name: "Active people per day" }),
+  ).toBeVisible();
+  await expect(page.getByRole("button", { name: "90d" })).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  await expect(page.getByRole("combobox", { name: "Sort people" })).toHaveValue(
+    "conversations",
+  );
   await page.getByRole("button", { name: "7d" }).click();
   await expect(page.getByRole("button", { name: "7d" })).toHaveAttribute(
     "aria-pressed",
     "true",
   );
-  await expect(activityPoints).toHaveCount(7);
   await page.getByRole("button", { name: "90d" }).click();
-  await expect(activityPoints).toHaveCount(90);
+  await expect(page.getByRole("button", { name: "90d" })).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
 
   await page.goto(`${baseURL}/locations`);
   await expect(
     page.locator("main > div").getByText("Locations", { exact: true }),
   ).toBeVisible();
+  await expect(
+    page.getByRole("img", { name: "Public and private conversations per day" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("combobox", { name: "Sort locations" }),
+  ).toHaveValue("conversations");
   expect(await containerBounds()).toEqual(headerBounds);
   expect(browserErrors).toEqual([]);
 });

--- a/packages/junior-dashboard/src/client/components/ContributionGrid.tsx
+++ b/packages/junior-dashboard/src/client/components/ContributionGrid.tsx
@@ -48,12 +48,12 @@ export function ContributionGrid(props: { days: ContributionDay[] }) {
 
   return (
     <div className="overflow-x-auto px-4 py-4">
-      <div className="w-max">
+      <div className="min-w-[36rem]">
         <div
           aria-hidden="true"
           className="mb-1 grid gap-1 text-[0.64rem] font-semibold leading-none text-[#666]"
           style={{
-            gridTemplateColumns: `repeat(${weeks.length}, 0.75rem)`,
+            gridTemplateColumns: `repeat(${weeks.length}, minmax(0.75rem, 1fr))`,
           }}
         >
           {monthLabels.map((label, index) => (
@@ -64,10 +64,10 @@ export function ContributionGrid(props: { days: ContributionDay[] }) {
         </div>
         <div
           aria-label="Daily Junior conversation activity"
-          className="grid w-max grid-flow-col grid-rows-7 gap-1"
+          className="grid w-full grid-flow-col grid-rows-7 gap-1"
           role="list"
           style={{
-            gridTemplateColumns: `repeat(${weeks.length}, 0.75rem)`,
+            gridTemplateColumns: `repeat(${weeks.length}, minmax(0.75rem, 1fr))`,
           }}
         >
           {weeks.flatMap((week, weekIndex) =>

--- a/packages/junior-dashboard/src/client/components/ConversationTranscript.tsx
+++ b/packages/junior-dashboard/src/client/components/ConversationTranscript.tsx
@@ -16,10 +16,9 @@ import {
   formatTranscriptDuration,
   actorLabel,
   summarizeCost,
-  summarizeMessages,
+  summarizeTurns,
   summarizeToolCalls,
   summarizeUsage,
-  conversationMessageCount,
   stringifyPartValue,
   unavailableTranscriptLabel,
   visualStatusForSummary,
@@ -44,7 +43,7 @@ import { MetricList, type MetricListItem } from "./Metric";
 import {
   CostMetric,
   DurationMetric,
-  MessagesMetric,
+  TurnsMetric,
   TokenMetric,
   ToolCallsMetric,
 } from "./TelemetryMetrics";
@@ -673,13 +672,6 @@ function transcriptActorLabel(conversation: ConversationTranscript): string {
   return actorLabel(conversation.actorIdentity) ?? "User";
 }
 
-function transcriptMessageSummary(conversation: ConversationTranscript) {
-  const summary = summarizeMessages(conversation);
-  if (summary.total > 0) return summary;
-  const total = conversationMessageCount(conversation);
-  return total > 0 ? { items: [], total } : undefined;
-}
-
 function transcriptMeta(
   conversation: ConversationTranscript,
 ): MetricListItem[] {
@@ -687,7 +679,7 @@ function transcriptMeta(
   const tokenSummary = summarizeUsage(conversation.cumulativeUsage);
   const costSummary = summarizeCost(conversation.cumulativeUsage);
   const toolSummary = summarizeToolCalls(conversation);
-  const messageSummary = transcriptMessageSummary(conversation);
+  const turnSummary = summarizeTurns(conversation);
   const items: Array<MetricListItem | undefined> = [
     conversation.modelId || conversation.reasoningLevel
       ? {
@@ -725,10 +717,10 @@ function transcriptMeta(
           key: "cost",
         }
       : undefined,
-    messageSummary
+    turnSummary
       ? {
-          content: <MessagesMetric summary={messageSummary} />,
-          key: "messages",
+          content: <TurnsMetric summary={turnSummary} />,
+          key: "turns",
         }
       : undefined,
     toolSummary.total > 0

--- a/packages/junior-dashboard/src/client/components/DirectoryRowsSkeleton.tsx
+++ b/packages/junior-dashboard/src/client/components/DirectoryRowsSkeleton.tsx
@@ -1,0 +1,33 @@
+/** Preserve directory table geometry while a new client-side order renders. */
+export function DirectoryRowsSkeleton() {
+  return (
+    <div
+      aria-label="Loading sorted results"
+      className="min-w-0 animate-pulse"
+      role="status"
+    >
+      {Array.from({ length: 5 }, (_, index) => (
+        <div
+          aria-hidden="true"
+          className="grid min-w-0 grid-cols-[minmax(14rem,1fr)_repeat(3,minmax(5rem,auto))] items-center gap-4 border-b border-white/[0.055] px-4 py-3.5 last:border-b-0 max-md:grid-cols-3 max-md:gap-x-3 max-md:gap-y-4"
+          key={index}
+        >
+          <div className="flex min-w-0 items-center gap-3 max-md:col-span-3">
+            <span className="size-9 shrink-0 rounded bg-white/[0.07]" />
+            <div className="grid min-w-0 flex-1 gap-2">
+              <span className="h-3.5 w-2/5 rounded bg-white/[0.08]" />
+              <span className="h-2.5 w-3/5 rounded bg-white/[0.045]" />
+            </div>
+          </div>
+          {[0, 1, 2].map((metric) => (
+            <span
+              className="h-4 w-10 justify-self-end rounded bg-white/[0.06]"
+              key={metric}
+            />
+          ))}
+        </div>
+      ))}
+      <span className="sr-only">Loading sorted results</span>
+    </div>
+  );
+}

--- a/packages/junior-dashboard/src/client/components/TelemetryMetrics.tsx
+++ b/packages/junior-dashboard/src/client/components/TelemetryMetrics.tsx
@@ -170,3 +170,13 @@ export function MessagesMetric(props: {
   if (!props.summary) return null;
   return <MetricValue>{plural("message", props.summary.total)}</MetricValue>;
 }
+
+/** Render an actor-initiated conversation turn count. */
+export function TurnsMetric(props: {
+  loading?: boolean;
+  summary: MessageSummary | undefined;
+}) {
+  if (props.loading) return <span>turns loading</span>;
+  if (!props.summary) return null;
+  return <MetricValue>{plural("turn", props.summary.total)}</MetricValue>;
+}

--- a/packages/junior-dashboard/src/client/components/TranscriptMarkdown.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptMarkdown.tsx
@@ -7,6 +7,7 @@ import {
   HighlightedCodeHtml,
   type ShikiHtml,
 } from "../code";
+import { cn } from "../styles";
 import {
   buildTranscriptMarkdownDecorations,
   findTranscriptMarkdownLinks,
@@ -20,7 +21,7 @@ import {
 const TRANSCRIPT_MARKDOWN_CACHE_KEY = "transcript-markdown";
 
 /** Render transcript markdown source with Shiki highlighting and safe links. */
-export function TranscriptMarkdown(props: { text: string }) {
+export function TranscriptMarkdown(props: { compact?: boolean; text: string }) {
   const search = useTranscriptSearch();
   const links = findTranscriptMarkdownLinks(props.text);
   const decorations = [
@@ -48,13 +49,27 @@ export function TranscriptMarkdown(props: { text: string }) {
 
   if (!highlighted.data) {
     return (
-      <HighlightedCodeFallback variant="prose">
-        {renderMarkdownInline(props.text, links)}
-      </HighlightedCodeFallback>
+      <div
+        className={cn(
+          props.compact && "[&_pre]:!text-[0.9rem] [&_pre]:!leading-[1.6rem]",
+        )}
+      >
+        <HighlightedCodeFallback variant="prose">
+          {renderMarkdownInline(props.text, links)}
+        </HighlightedCodeFallback>
+      </div>
     );
   }
 
-  return <HighlightedCodeHtml html={highlighted.data} variant="prose" />;
+  return (
+    <div
+      className={cn(
+        props.compact && "[&_pre]:!text-[0.9rem] [&_pre]:!leading-[1.6rem]",
+      )}
+    >
+      <HighlightedCodeHtml html={highlighted.data} variant="prose" />
+    </div>
+  );
 }
 
 function renderMarkdownInline(

--- a/packages/junior-dashboard/src/client/components/TranscriptText.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptText.tsx
@@ -17,8 +17,9 @@ export function TranscriptText(props: {
   role?: string;
   text: string;
 }) {
+  const roleKind = transcriptRoleKind(props.role ?? "");
   const blocks = parseMarkdownBlocks(props.text, {
-    outputOnly: transcriptRoleKind(props.role ?? "") === "assistant",
+    outputOnly: roleKind === "assistant",
   });
   let seenChildren = props.firstChildIndex;
 
@@ -30,7 +31,13 @@ export function TranscriptText(props: {
         seenChildren += childCount;
 
         if (block.language === "markdown" && !block.fenced) {
-          return <TranscriptMarkdown key={index} text={block.code} />;
+          return (
+            <TranscriptMarkdown
+              compact={roleKind === "assistant" || roleKind === "user"}
+              key={index}
+              text={block.code}
+            />
+          );
         }
 
         if (!canRenderStructuredMarkup(block)) {

--- a/packages/junior-dashboard/src/client/components/controls/DirectorySortSelect.tsx
+++ b/packages/junior-dashboard/src/client/components/controls/DirectorySortSelect.tsx
@@ -1,0 +1,36 @@
+export type DirectorySortOption = {
+  label: string;
+  value: string;
+};
+
+/** Render a native directory sort control with an explicit dark color scheme. */
+export function DirectorySortSelect(props: {
+  ariaLabel: string;
+  onChange(value: string): void;
+  options: readonly DirectorySortOption[];
+  value: string;
+}) {
+  return (
+    <label className="grid h-9 min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center overflow-hidden rounded-lg border border-white/10 bg-white/[0.025] transition-colors hover:border-white/20 focus-within:border-amber-500/35 focus-within:ring-1 focus-within:ring-amber-500/15">
+      <span className="flex h-full items-center border-r border-white/[0.07] px-2 font-mono text-[0.62rem] uppercase tracking-[0.12em] text-white/30">
+        Sort
+      </span>
+      <select
+        aria-label={props.ariaLabel}
+        className="h-full min-w-0 bg-[#111114] px-2 font-mono text-[0.72rem] text-white/70 outline-none [color-scheme:dark]"
+        value={props.value}
+        onChange={(event) => props.onChange(event.currentTarget.value)}
+      >
+        {props.options.map((option) => (
+          <option
+            className="bg-[#111114] text-white/80"
+            key={option.value}
+            value={option.value}
+          >
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/packages/junior-dashboard/src/client/format.ts
+++ b/packages/junior-dashboard/src/client/format.ts
@@ -390,6 +390,33 @@ export function summarizeMessages(
   return { items, total: items.length };
 }
 
+/** Count actor-initiated exchanges rather than individual transcript messages. */
+export function summarizeTurns(
+  conversation: ConversationTranscript,
+): MessageSummary | undefined {
+  const messages = transcriptSource(conversation);
+  const userMessages = messages.filter(
+    (message) =>
+      transcriptRoleKind(message.role) === "user" &&
+      isConversationMessage(message),
+  );
+  if (userMessages.length > 0) {
+    return {
+      items: userMessages.map((message) => ({
+        author: transcriptMessageAuthor(conversation, message),
+        bytes: message.parts.reduce(
+          (sum, part) => sum + transcriptPartBytes(part),
+          0,
+        ),
+      })),
+      total: userMessages.length,
+    };
+  }
+
+  const messageCount = conversationMessageCount(conversation);
+  return messageCount > 0 ? { items: [], total: 1 } : undefined;
+}
+
 /** Format raw counts with the dashboard's compact number rules. */
 export function formatCompactNumber(value: number | undefined): string {
   return formatNumber(value);

--- a/packages/junior-dashboard/src/client/format.ts
+++ b/packages/junior-dashboard/src/client/format.ts
@@ -413,8 +413,7 @@ export function summarizeTurns(
     };
   }
 
-  const messageCount = conversationMessageCount(conversation);
-  return messageCount > 0 ? { items: [], total: 1 } : undefined;
+  return undefined;
 }
 
 /** Format raw counts with the dashboard's compact number rules. */

--- a/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
@@ -14,11 +14,10 @@ import {
   conversationActorLabel,
   formatConversationDuration,
   formatRelativeTime,
-  formatTime,
   peoplePath,
   slackLocationLabel,
   summarizeCost,
-  summarizeMessages,
+  summarizeTurns,
   summarizeToolCalls,
   summarizeUsage,
   visualStatusForConversation,
@@ -27,7 +26,7 @@ import { MetricList, type MetricListItem } from "../components/Metric";
 import {
   CostMetric,
   DurationMetric,
-  MessagesMetric,
+  TurnsMetric,
   TokenMetric,
   ToolCallsMetric,
 } from "../components/TelemetryMetrics";
@@ -188,9 +187,7 @@ function ConversationStats(props: {
   detail?: ConversationDetailReport;
 }) {
   if (!props.conversation) return null;
-  const messageSummary = props.detail
-    ? summarizeMessages(props.detail)
-    : undefined;
+  const turnSummary = props.detail ? summarizeTurns(props.detail) : undefined;
   const toolSummary = props.detail
     ? summarizeToolCalls(props.detail)
     : undefined;
@@ -210,10 +207,8 @@ function ConversationStats(props: {
         }
       : undefined,
     {
-      content: (
-        <MessagesMetric loading={!props.detail} summary={messageSummary} />
-      ),
-      key: "messages",
+      content: <TurnsMetric loading={!props.detail} summary={turnSummary} />,
+      key: "turns",
     },
     !props.detail || (toolSummary && toolSummary.total > 0)
       ? {
@@ -247,10 +242,6 @@ function ConversationStats(props: {
           key: "duration",
         }
       : undefined,
-    {
-      content: `started ${formatTime(props.conversation.startedAt)}`,
-      key: "started",
-    },
   ];
   const stats = rawStats.filter(
     (item): item is MetricListItem => item !== undefined,

--- a/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
@@ -206,10 +206,14 @@ function ConversationStats(props: {
           key: "location",
         }
       : undefined,
-    {
-      content: <TurnsMetric loading={!props.detail} summary={turnSummary} />,
-      key: "turns",
-    },
+    !props.detail || turnSummary
+      ? {
+          content: (
+            <TurnsMetric loading={!props.detail} summary={turnSummary} />
+          ),
+          key: "turns",
+        }
+      : undefined,
     !props.detail || (toolSummary && toolSummary.total > 0)
       ? {
           content: (

--- a/packages/junior-dashboard/src/client/pages/locations/LocationActivityChart.tsx
+++ b/packages/junior-dashboard/src/client/pages/locations/LocationActivityChart.tsx
@@ -46,7 +46,7 @@ export function LocationActivityChart(props: {
         </div>
         <div className="flex items-center gap-2 font-mono text-[0.64rem] text-white/35">
           <span className="size-2 rounded-full bg-cyan-400 shadow-[0_0_12px_rgba(34,211,238,0.5)]" />
-          30 days
+          90 days
         </div>
       </div>
       <div className="px-2 py-3 sm:px-4 sm:py-4">

--- a/packages/junior-dashboard/src/client/pages/locations/LocationDirectory.tsx
+++ b/packages/junior-dashboard/src/client/pages/locations/LocationDirectory.tsx
@@ -3,7 +3,9 @@ import { Link } from "react-router";
 import type { LocationSummaryReport } from "@sentry/junior/api/schema";
 
 import { ConversationSearchInput } from "../../components/ConversationListControls";
+import { DirectoryRowsSkeleton } from "../../components/DirectoryRowsSkeleton";
 import { EmptyTelemetry } from "../../components/EmptyTelemetry";
+import { DirectorySortSelect } from "../../components/controls/DirectorySortSelect";
 import { Card } from "../../components/layout/Card";
 import { DirectoryMetric } from "../../components/metrics/DirectoryMetric";
 import {
@@ -21,6 +23,7 @@ export function LocationDirectory(props: {
   query: string;
   sort: LocationSort;
   totalLocations: number;
+  loading?: boolean;
   onQueryChange(value: string): void;
   onSortChange(value: LocationSort): void;
 }) {
@@ -41,26 +44,21 @@ export function LocationDirectory(props: {
           value={props.query}
           onChange={props.onQueryChange}
         />
-        <label className="grid h-9 min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center overflow-hidden rounded-lg border border-white/[0.08] bg-black/25 focus-within:border-amber-500/30 focus-within:ring-1 focus-within:ring-amber-500/15">
-          <span className="flex h-full items-center border-r border-white/[0.07] px-2 font-mono text-[0.62rem] uppercase tracking-[0.12em] text-white/30">
-            Sort
-          </span>
-          <select
-            aria-label="Sort locations"
-            className="h-full min-w-0 bg-transparent px-2 font-mono text-[0.72rem] text-white/70 outline-none"
-            value={props.sort}
-            onChange={(event) =>
-              props.onSortChange(event.currentTarget.value as LocationSort)
-            }
-          >
-            <option value="recent">Recently active</option>
-            <option value="conversations">Most conversations</option>
-            <option value="tokens">Most tokens</option>
-            <option value="runtime">Most runtime</option>
-          </select>
-        </label>
+        <DirectorySortSelect
+          ariaLabel="Sort locations"
+          onChange={(value) => props.onSortChange(value as LocationSort)}
+          options={[
+            { label: "Most conversations", value: "conversations" },
+            { label: "Recently active", value: "recent" },
+            { label: "Most tokens", value: "tokens" },
+            { label: "Most runtime", value: "runtime" },
+          ]}
+          value={props.sort}
+        />
       </div>
-      {props.locations.length ? (
+      {props.loading ? (
+        <DirectoryRowsSkeleton />
+      ) : props.locations.length ? (
         <div className="min-w-0" role="table">
           <div className="grid grid-cols-[minmax(14rem,1fr)_repeat(3,minmax(5rem,auto))] items-center gap-4 border-b border-white/[0.06] bg-black/20 px-4 py-2.5 font-mono text-[0.62rem] uppercase tracking-[0.1em] text-white/30 max-md:hidden">
             <div>Location</div>

--- a/packages/junior-dashboard/src/client/pages/locations/LocationDirectoryActivityChart.tsx
+++ b/packages/junior-dashboard/src/client/pages/locations/LocationDirectoryActivityChart.tsx
@@ -1,0 +1,158 @@
+import type { LocationActivityDayReport } from "@sentry/junior/api/schema";
+
+import { Card } from "../../components/layout/Card";
+
+function shortDate(date: string): string {
+  return new Date(`${date}T00:00:00.000Z`).toLocaleDateString(undefined, {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+  });
+}
+
+/** Compare public and privacy-preserving private conversation volume by day. */
+export function LocationDirectoryActivityChart(props: {
+  days: LocationActivityDayReport[];
+}) {
+  const width = 960;
+  const height = 260;
+  const left = 42;
+  const right = 18;
+  const top = 24;
+  const bottom = 36;
+  const plotWidth = width - left - right;
+  const plotHeight = height - top - bottom;
+  const maximum = Math.max(
+    1,
+    ...props.days.flatMap((day) => [
+      day.privateConversations,
+      day.publicConversations,
+    ]),
+  );
+  const step = plotWidth / Math.max(1, props.days.length);
+  const groupWidth = Math.max(3, Math.min(18, step * 0.8));
+  const gap = Math.min(2, groupWidth * 0.15);
+  const barWidth = Math.max(1.5, (groupWidth - gap) / 2);
+  const labelIndexes = [
+    ...new Set([
+      0,
+      Math.floor((props.days.length - 1) / 2),
+      props.days.length - 1,
+    ]),
+  ].filter((index) => index >= 0);
+
+  return (
+    <Card>
+      <div className="flex flex-wrap items-start justify-between gap-4 border-b border-white/[0.06] px-4 py-4 sm:px-5">
+        <div>
+          <h3 className="m-0 font-mono text-[0.68rem] font-medium uppercase tracking-[0.14em] text-white/60">
+            Conversations per day
+          </h3>
+          <p className="mt-1 mb-0 font-mono text-[0.68rem] leading-relaxed text-white/30">
+            Daily public volume compared with private activity in aggregate.
+          </p>
+        </div>
+        <div className="flex items-center gap-4 font-mono text-[0.64rem] text-white/35">
+          <span className="flex items-center gap-2">
+            <span className="size-2 rounded-sm bg-cyan-400" /> public
+          </span>
+          <span className="flex items-center gap-2">
+            <span className="size-2 rounded-sm bg-amber-400" /> private
+          </span>
+        </div>
+      </div>
+      <div className="px-2 py-3 sm:px-4 sm:py-4">
+        <svg
+          aria-label="Public and private conversations per day"
+          className="block h-auto min-h-56 w-full overflow-visible"
+          role="img"
+          viewBox={`0 0 ${width} ${height}`}
+        >
+          {[0, 0.5, 1].map((ratio) => {
+            const y = top + ratio * plotHeight;
+            return (
+              <g key={ratio}>
+                <line
+                  stroke="rgba(255,255,255,0.07)"
+                  strokeDasharray="3 5"
+                  x1={left}
+                  x2={width - right}
+                  y1={y}
+                  y2={y}
+                />
+                <text
+                  fill="rgba(255,255,255,0.3)"
+                  fontFamily="ui-monospace, monospace"
+                  fontSize="10"
+                  textAnchor="end"
+                  x={left - 8}
+                  y={y + 3}
+                >
+                  {Math.round(maximum * (1 - ratio))}
+                </text>
+              </g>
+            );
+          })}
+          {props.days.flatMap((day, index) => {
+            const groupX = left + index * step + (step - groupWidth) / 2;
+            return (
+              [
+                {
+                  count: day.publicConversations,
+                  fill: "#22d3ee",
+                  key: "public",
+                  x: groupX,
+                },
+                {
+                  count: day.privateConversations,
+                  fill: "#fbbf24",
+                  key: "private",
+                  x: groupX + barWidth + gap,
+                },
+              ] as const
+            ).map((bar) => {
+              const barHeight = (bar.count / maximum) * plotHeight;
+              return (
+                <rect
+                  fill={bar.fill}
+                  height={Math.max(bar.count ? 2 : 0, barHeight)}
+                  key={`${day.date}-${bar.key}`}
+                  opacity={bar.count ? 0.85 : 0.12}
+                  rx="1.5"
+                  width={barWidth}
+                  x={bar.x}
+                  y={top + plotHeight - barHeight}
+                >
+                  <title>{`${shortDate(day.date)}: ${bar.count} ${bar.key} conversations`}</title>
+                </rect>
+              );
+            });
+          })}
+          {labelIndexes.map((index) => {
+            const day = props.days[index];
+            if (!day) return null;
+            return (
+              <text
+                fill="rgba(255,255,255,0.3)"
+                fontFamily="ui-monospace, monospace"
+                fontSize="10"
+                key={day.date}
+                textAnchor={
+                  index === 0
+                    ? "start"
+                    : index === props.days.length - 1
+                      ? "end"
+                      : "middle"
+                }
+                x={left + index * step + step / 2}
+                y={height - 8}
+              >
+                {shortDate(day.date)}
+              </text>
+            );
+          })}
+        </svg>
+      </div>
+    </Card>
+  );
+}

--- a/packages/junior-dashboard/src/client/pages/locations/LocationsPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/locations/LocationsPage.tsx
@@ -1,5 +1,5 @@
 import { Clock3, LockKeyhole, MapPinned, MessageSquare } from "lucide-react";
-import { useState } from "react";
+import { useDeferredValue, useState } from "react";
 import { useSearchParams } from "react-router";
 import type {
   LocationDirectoryReport,
@@ -14,6 +14,7 @@ import { PageHeader } from "../../components/layout/PageHeader";
 import { StatCard } from "../../components/metrics/StatCard";
 import { formatCompactNumber, formatMs } from "../../format";
 import { cn, dashboardContainerClass } from "../../styles";
+import { LocationDirectoryActivityChart } from "./LocationDirectoryActivityChart";
 import { LocationDirectory, type LocationSort } from "./LocationDirectory";
 import { PrivateActivityCard } from "./PrivateActivityCard";
 
@@ -29,13 +30,18 @@ export function LocationsPageContent(props: {
   error: unknown;
 }) {
   const [params, setParams] = useSearchParams();
-  const [sort, setSort] = useState<LocationSort>("recent");
+  const [sort, setSort] = useState<LocationSort>("conversations");
+  const deferredSort = useDeferredValue(sort);
   const search = params.get("q") ?? "";
   if (!props.data && !props.error) {
     return <LoadingView label="Loading locations" />;
   }
 
-  const locations = filterLocations(props.data?.locations ?? [], search, sort);
+  const locations = filterLocations(
+    props.data?.locations ?? [],
+    search,
+    deferredSort,
+  );
   const publicConversations =
     props.data?.locations.reduce(
       (total, location) => total + location.conversations,
@@ -109,7 +115,9 @@ export function LocationsPageContent(props: {
               )}
             />
           </div>
+          <LocationDirectoryActivityChart days={props.data.activityDays} />
           <LocationDirectory
+            loading={sort !== deferredSort}
             locations={locations}
             onQueryChange={setSearch}
             onSortChange={setSort}

--- a/packages/junior-dashboard/src/client/pages/people/PeopleDirectory.tsx
+++ b/packages/junior-dashboard/src/client/pages/people/PeopleDirectory.tsx
@@ -3,15 +3,12 @@ import { UserRound } from "lucide-react";
 import type { ActorSummaryReport } from "@sentry/junior/api/schema";
 
 import { ConversationSearchInput } from "../../components/ConversationListControls";
+import { DirectoryRowsSkeleton } from "../../components/DirectoryRowsSkeleton";
 import { EmptyTelemetry } from "../../components/EmptyTelemetry";
+import { DirectorySortSelect } from "../../components/controls/DirectorySortSelect";
 import { Card } from "../../components/layout/Card";
 import { DirectoryMetric } from "../../components/metrics/DirectoryMetric";
-import {
-  formatCompactNumber,
-  formatMs,
-  formatRelativeTime,
-  peoplePath,
-} from "../../format";
+import { formatCompactNumber, formatMs, peoplePath } from "../../format";
 
 export type PeopleSort = "activeDays" | "conversations" | "recent" | "runtime";
 
@@ -21,13 +18,10 @@ function actorName(person: Pick<ActorSummaryReport, "actor">): string {
   );
 }
 
-function personMeta(person: ActorSummaryReport): string {
-  const pieces = [
-    person.actor.email,
-    person.actor.slackUserName ? `@${person.actor.slackUserName}` : undefined,
-    `last ${formatRelativeTime(person.lastSeenAt)}`,
-  ];
-  return pieces.filter(Boolean).join(" / ");
+function personMeta(person: ActorSummaryReport): string | undefined {
+  return actorName(person) === person.actor.email
+    ? undefined
+    : person.actor.email;
 }
 
 function runtimeLabel(durationMs: number, conversations: number): string {
@@ -69,6 +63,7 @@ export function filterPeople(
 export function PeopleDirectory(props: {
   onQueryChange(value: string): void;
   onSortChange(value: PeopleSort): void;
+  loading?: boolean;
   people: ActorSummaryReport[];
   query: string;
   sort: PeopleSort;
@@ -93,26 +88,21 @@ export function PeopleDirectory(props: {
           value={props.query}
           onChange={props.onQueryChange}
         />
-        <label className="grid h-9 min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center overflow-hidden rounded-lg border border-white/10 bg-white/[0.025] transition-colors hover:border-white/20 focus-within:border-amber-500/35 focus-within:ring-1 focus-within:ring-amber-500/15">
-          <span className="flex h-full items-center border-r border-white/[0.07] px-2 font-mono text-[0.62rem] uppercase tracking-[0.12em] text-white/30">
-            Sort
-          </span>
-          <select
-            aria-label="Sort people"
-            className="h-full min-w-0 bg-transparent px-2 font-mono text-[0.72rem] text-white/70 outline-none"
-            value={props.sort}
-            onChange={(event) =>
-              props.onSortChange(event.currentTarget.value as PeopleSort)
-            }
-          >
-            <option value="recent">Recently active</option>
-            <option value="conversations">Most conversations</option>
-            <option value="activeDays">Most active days</option>
-            <option value="runtime">Most runtime</option>
-          </select>
-        </label>
+        <DirectorySortSelect
+          ariaLabel="Sort people"
+          onChange={(value) => props.onSortChange(value as PeopleSort)}
+          options={[
+            { label: "Most conversations", value: "conversations" },
+            { label: "Recently active", value: "recent" },
+            { label: "Most active days", value: "activeDays" },
+            { label: "Most runtime", value: "runtime" },
+          ]}
+          value={props.sort}
+        />
       </div>
-      {props.people.length === 0 ? (
+      {props.loading ? (
+        <DirectoryRowsSkeleton />
+      ) : props.people.length === 0 ? (
         <div className="p-4">
           <EmptyTelemetry>No people match this search.</EmptyTelemetry>
         </div>
@@ -141,9 +131,11 @@ export function PeopleDirectory(props: {
                   <div className="truncate font-display text-[1rem] font-medium leading-tight text-white/90">
                     {actorName(person)}
                   </div>
-                  <div className="mt-1 truncate font-mono text-[0.68rem] leading-tight text-white/35">
-                    {personMeta(person)}
-                  </div>
+                  {personMeta(person) ? (
+                    <div className="mt-1 truncate font-mono text-[0.68rem] leading-tight text-white/35">
+                      {personMeta(person)}
+                    </div>
+                  ) : null}
                 </div>
               </div>
               <DirectoryMetric

--- a/packages/junior-dashboard/src/client/pages/people/PeoplePage.tsx
+++ b/packages/junior-dashboard/src/client/pages/people/PeoplePage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useDeferredValue, useState } from "react";
 import { Activity, Clock3, MessageSquare, Users } from "lucide-react";
 import type { ActorDirectoryReport } from "@sentry/junior/api/schema";
 
@@ -33,15 +33,18 @@ export function PeoplePageContent(props: {
   error: unknown;
 }) {
   const [peopleSearch, setPeopleSearch] = useState("");
-  const [range, setRange] = useState<TimeRangeDays>(30);
-  const [sort, setSort] = useState<PeopleSort>("recent");
+  const [range, setRange] = useState<TimeRangeDays>(90);
+  const [sort, setSort] = useState<PeopleSort>("conversations");
+  const deferredSort = useDeferredValue(sort);
   if (!props.data && !props.error) {
     return <LoadingView label="Loading people" />;
   }
 
   const data = props.data;
   const visibleActivity = data?.activityDays.slice(-range) ?? [];
-  const people = data ? filterPeople(data.people, peopleSearch, sort) : [];
+  const people = data
+    ? filterPeople(data.people, peopleSearch, deferredSort)
+    : [];
   const indexedConversations =
     data?.people.reduce((total, person) => total + person.conversations, 0) ??
     0;
@@ -108,6 +111,7 @@ export function PeoplePageContent(props: {
           </div>
           <PeopleActivityChart days={visibleActivity} />
           <PeopleDirectory
+            loading={sort !== deferredSort}
             onQueryChange={setPeopleSearch}
             onSortChange={setSort}
             people={people}

--- a/packages/junior-dashboard/src/client/pages/people/PersonProfilePage.tsx
+++ b/packages/junior-dashboard/src/client/pages/people/PersonProfilePage.tsx
@@ -82,77 +82,80 @@ export function Profile(props: { profile: ActorProfileReport }) {
         title={displayName}
       />
 
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-        <StatCard
-          detail="Across the complete conversation index"
-          icon={MessageSquare}
-          label="Conversations"
-          value={formatCompactNumber(profile.totals.conversations)}
-        />
-        <StatCard
-          detail="Cumulative persisted conversation runtime"
-          icon={Clock3}
-          label="Runtime"
-          value={formatMs(profile.totals.durationMs)}
-        />
-        <StatCard
-          detail="Persisted model token usage"
-          icon={Coins}
-          label="Tokens"
-          value={formatCompactNumber(profile.totals.tokens ?? 0)}
-        />
-      </div>
-
-      <Section className="mb-0">
-        <SectionHeader
-          actions={
-            <div className="font-mono text-[0.66rem] uppercase tracking-[0.12em] text-white/30">
-              12 months
-            </div>
-          }
-        >
-          <SectionTitle>Activity</SectionTitle>
-        </SectionHeader>
-        <ContributionGrid days={profile.activityDays} />
-      </Section>
-
-      <div className="grid min-w-0 gap-4 lg:grid-cols-2">
-        <LeaderboardSection items={profile.locations} title="Places" />
-        <LeaderboardSection items={profile.surfaces} title="Surfaces" />
-      </div>
-
-      <Section className="mb-0">
-        <SectionHeader>
-          <div>
-            <SectionTitle>Recent</SectionTitle>
-            <div className="mt-1 font-mono text-[0.68rem] leading-relaxed text-white/35">
-              {formatCompactNumber(visibleConversations.length)} of{" "}
-              {formatCompactNumber(profile.recentConversations.length)}{" "}
-              conversations / generated {formatTime(profile.generatedAt)}
-            </div>
+      <div className="grid min-w-0 gap-5 lg:grid-cols-[minmax(0,1fr)_19rem] lg:items-start">
+        <aside className="grid min-w-0 gap-4 lg:order-2">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3 lg:grid-cols-1">
+            <StatCard
+              detail="Across the complete conversation index"
+              icon={MessageSquare}
+              label="Conversations"
+              value={formatCompactNumber(profile.totals.conversations)}
+            />
+            <StatCard
+              detail="Cumulative persisted conversation runtime"
+              icon={Clock3}
+              label="Runtime"
+              value={formatMs(profile.totals.durationMs)}
+            />
+            <StatCard
+              detail="Persisted model token usage"
+              icon={Coins}
+              label="Tokens"
+              value={formatCompactNumber(profile.totals.tokens ?? 0)}
+            />
           </div>
-        </SectionHeader>
-        <div className="grid gap-2 border-b border-white/[0.06] bg-black/15 px-3 py-3 md:grid-cols-[minmax(12rem,36rem)_auto]">
-          <ConversationSearchInput
-            label="Search recent conversations"
-            placeholder="Search title, email, channel, id..."
-            value={recentSearch}
-            onChange={setRecentSearch}
-          />
-          {recentSearch.trim() ? (
-            <Button
-              className="h-9 justify-center"
-              onClick={() => setRecentSearch("")}
+          <LeaderboardSection items={profile.locations} title="Places" />
+          <LeaderboardSection items={profile.surfaces} title="Surfaces" />
+        </aside>
+
+        <div className="grid min-w-0 gap-5 lg:order-1">
+          <Section className="mb-0">
+            <SectionHeader
+              actions={
+                <div className="font-mono text-[0.66rem] uppercase tracking-[0.12em] text-white/30">
+                  90 days
+                </div>
+              }
             >
-              Clear
-            </Button>
-          ) : null}
+              <SectionTitle>Activity</SectionTitle>
+            </SectionHeader>
+            <ContributionGrid days={profile.activityDays} />
+          </Section>
+
+          <Section className="mb-0">
+            <SectionHeader>
+              <div>
+                <SectionTitle>Recent</SectionTitle>
+                <div className="mt-1 font-mono text-[0.68rem] leading-relaxed text-white/35">
+                  {formatCompactNumber(visibleConversations.length)} of{" "}
+                  {formatCompactNumber(profile.recentConversations.length)}{" "}
+                  conversations / generated {formatTime(profile.generatedAt)}
+                </div>
+              </div>
+            </SectionHeader>
+            <div className="grid gap-2 border-b border-white/[0.06] bg-black/15 px-3 py-3 md:grid-cols-[minmax(12rem,36rem)_auto]">
+              <ConversationSearchInput
+                label="Search recent conversations"
+                placeholder="Search title, email, channel, id..."
+                value={recentSearch}
+                onChange={setRecentSearch}
+              />
+              {recentSearch.trim() ? (
+                <Button
+                  className="h-9 justify-center"
+                  onClick={() => setRecentSearch("")}
+                >
+                  Clear
+                </Button>
+              ) : null}
+            </div>
+            <ConversationList
+              conversations={visibleConversations}
+              emptyLabel="No recent conversations match this search."
+            />
+          </Section>
         </div>
-        <ConversationList
-          conversations={visibleConversations}
-          emptyLabel="No recent conversations match this search."
-        />
-      </Section>
+      </div>
     </div>
   );
 }

--- a/packages/junior-dashboard/src/client/pages/system/SystemActivity.tsx
+++ b/packages/junior-dashboard/src/client/pages/system/SystemActivity.tsx
@@ -18,7 +18,7 @@ import {
 } from "../../format";
 import { cn } from "../../styles";
 
-/** Present seven-day runtime health as the primary System analytics surface. */
+/** Present 90-day runtime health as the primary System analytics surface. */
 export function SystemActivity(props: {
   error: boolean;
   loading: boolean;
@@ -60,7 +60,7 @@ export function SystemActivity(props: {
       <div className="flex items-start justify-between gap-4 border-b border-white/[0.06] px-5 py-4 max-sm:flex-col">
         <div>
           <div className="font-mono text-[0.62rem] uppercase tracking-[0.16em] text-cyan-200/65">
-            Seven-day pulse
+            90-day pulse
           </div>
           <h2 className="mt-1 mb-0 font-display text-xl font-medium tracking-[-0.02em] text-white">
             Runtime health

--- a/packages/junior-dashboard/src/mock-conversations.ts
+++ b/packages/junior-dashboard/src/mock-conversations.ts
@@ -20,6 +20,7 @@ import type {
 import type {
   DailyConversationActivity,
   LocationActorSummaryReport,
+  LocationActivityDayReport,
   LocationDetailReport,
   LocationDirectoryReport,
   LocationSummaryReport,
@@ -45,9 +46,9 @@ const FAILED_CONVERSATION_ID = "slack:CQA777:1770014400.000500";
 const SCHEDULER_CONVERSATION_ID = "scheduler:daily-ops-digest";
 export const DASHBOARD_QA_CONVERSATION_ID = "internal:dashboard-qa";
 const DASHBOARD_QA_ADVISOR_CONVERSATION_ID = `junior:${DASHBOARD_QA_CONVERSATION_ID}:advisor_session`;
-const RECENT_CONVERSATION_STATS_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+const RECENT_CONVERSATION_STATS_WINDOW_MS = 90 * 24 * 60 * 60 * 1000;
 const PEOPLE_ACTIVITY_DAYS = 90;
-const PEOPLE_PROFILE_ACTIVITY_DAYS = 366;
+const PEOPLE_PROFILE_ACTIVITY_DAYS = 90;
 const PUBLIC_MOCK_CHANNEL_IDS = new Set([
   "CQA123",
   "CQA456",
@@ -1271,9 +1272,19 @@ function mockLocationDirectory(nowMs: number): LocationDirectoryReport {
   const summaries = mockConversationFeed(nowMs).conversations;
   const locations = new Map<string, LocationSummaryReport>();
   const privateActivity = emptyStatsItem("Private activity");
+  const sparseActivity = new Map<string, LocationActivityDayReport>();
 
   for (const conversation of summaries) {
     const initial = publicMockLocation(conversation);
+    const date = conversation.lastSeenAt.slice(0, 10);
+    const day = sparseActivity.get(date) ?? {
+      date,
+      privateConversations: 0,
+      publicConversations: 0,
+    };
+    if (initial) day.publicConversations += 1;
+    else day.privateConversations += 1;
+    sparseActivity.set(date, day);
     if (!initial) {
       addConversationStats(privateActivity, conversation);
       continue;
@@ -1289,7 +1300,24 @@ function mockLocationDirectory(nowMs: number): LocationDirectoryReport {
     locations.set(location.id, location);
   }
 
+  const activityDays: LocationActivityDayReport[] = [];
+  const end = new Date(nowMs);
+  end.setUTCHours(0, 0, 0, 0);
+  for (let offset = 89; offset >= 0; offset -= 1) {
+    const cursor = new Date(end);
+    cursor.setUTCDate(cursor.getUTCDate() - offset);
+    const date = cursor.toISOString().slice(0, 10);
+    activityDays.push(
+      sparseActivity.get(date) ?? {
+        date,
+        privateConversations: 0,
+        publicConversations: 0,
+      },
+    );
+  }
+
   return {
+    activityDays,
     generatedAt: iso(nowMs),
     locations: [...locations.values()].sort(
       (left, right) =>
@@ -1297,10 +1325,12 @@ function mockLocationDirectory(nowMs: number): LocationDirectoryReport {
     ),
     privateActivity,
     source: "conversation_index",
+    windowEnd: `${activityDays.at(-1)!.date}T00:00:00.000Z`,
+    windowStart: `${activityDays[0]!.date}T00:00:00.000Z`,
   };
 }
 
-/** Fill the fixed 30-day activity series used by mock location detail. */
+/** Fill the fixed 90-day activity series used by mock location detail. */
 function mockLocationActivityDays(
   nowMs: number,
   conversations: ConversationSummaryReport[],
@@ -1326,7 +1356,7 @@ function mockLocationActivityDays(
   const result: DailyConversationActivity[] = [];
   const end = new Date(nowMs);
   end.setUTCHours(0, 0, 0, 0);
-  for (let offset = 29; offset >= 0; offset -= 1) {
+  for (let offset = 89; offset >= 0; offset -= 1) {
     const cursor = new Date(end);
     cursor.setUTCDate(cursor.getUTCDate() - offset);
     const date = cursor.toISOString().slice(0, 10);

--- a/packages/junior-dashboard/src/mock-conversations.ts
+++ b/packages/junior-dashboard/src/mock-conversations.ts
@@ -1235,7 +1235,7 @@ function conversationStatsReportFromSummaries(
     ...(costUsd !== undefined ? { costUsd } : {}),
     ...(tokens !== undefined ? { tokens } : {}),
     windowEnd: iso(nowMs),
-    windowStart: iso(nowMs, -7 * 24 * 60 * 60 * 1000),
+    windowStart: iso(windowStartMs),
   };
 }
 

--- a/packages/junior-dashboard/tests/dashboard-mock-routes.test.ts
+++ b/packages/junior-dashboard/tests/dashboard-mock-routes.test.ts
@@ -14,7 +14,7 @@ describe("dashboard mock conversation routes", () => {
 
   it("overlays mock conversations for local dashboard visual QA", async () => {
     // Pin time to match the hardcoded conversation dates in the mock reporting fixture.
-    // Without this, recentConversationGroups filters out conversations older than 7 days.
+    // Without this, recentConversationGroups filters out conversations older than 90 days.
     vi.useFakeTimers({ now: new Date("2026-05-30T00:00:00.000Z") });
     const app = createDashboardApp({
       authRequired: false,
@@ -79,6 +79,8 @@ describe("dashboard mock conversation routes", () => {
       conversations: number;
       costUsd?: number;
       durationMs: number;
+      windowEnd: string;
+      windowStart: string;
     };
     expect(statsBody).toMatchObject({
       conversations: new Set(
@@ -93,6 +95,9 @@ describe("dashboard mock conversation routes", () => {
     );
     expect(statsBody.durationMs).toBe(rawDurationMs);
     expect(statsBody.costUsd).toBeGreaterThan(0);
+    expect(
+      Date.parse(statsBody.windowEnd) - Date.parse(statsBody.windowStart),
+    ).toBe(90 * 24 * 60 * 60 * 1000);
 
     const locations = await app.fetch(
       new Request("http://localhost/api/locations"),

--- a/packages/junior-dashboard/tests/format.test.ts
+++ b/packages/junior-dashboard/tests/format.test.ts
@@ -182,6 +182,19 @@ describe("dashboard token formatting", () => {
     });
   });
 
+  it("does not count assistant-only transcripts as actor turns", () => {
+    const conversation = transcript({
+      transcript: [
+        {
+          role: "assistant",
+          parts: [{ type: "text", text: "proactive update" }],
+        },
+      ],
+    });
+
+    expect(summarizeTurns(conversation)).toBeUndefined();
+  });
+
   it("counts activity-only tool calls in tool summaries", () => {
     const conversation = {
       conversationId: "conversation-activity",

--- a/packages/junior-dashboard/tests/format.test.ts
+++ b/packages/junior-dashboard/tests/format.test.ts
@@ -19,6 +19,7 @@ import {
   actorLabel,
   slackLocationLabel,
   summarizeMessages,
+  summarizeTurns,
   summarizeCost,
   summarizeToolCalls,
   summarizeUsage,
@@ -160,6 +161,10 @@ describe("dashboard token formatting", () => {
         { author: "Junior", bytes: 4 },
       ],
       total: 2,
+    });
+    expect(summarizeTurns(conversation)).toEqual({
+      items: [{ author: "alice", bytes: 10 }],
+      total: 1,
     });
     expect(
       summarizeUsage({

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -804,10 +804,13 @@ describe("dashboard telemetry components", () => {
 
     const html = renderConversationPage(dashboardData([session]));
     const header = html.slice(0, html.indexOf('aria-label="Transcript view"'));
+    const transcript = html.slice(html.indexOf('aria-label="Transcript view"'));
 
     expect(header).toContain("2 turns");
     expect(header).not.toContain("4 messages");
     expect(header).not.toContain("started Jan");
+    expect(transcript).toContain("2 turns");
+    expect(transcript).not.toContain("4 messages");
   });
 
   it("shows the conversation model and thinking level in the transcript header", () => {

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -34,6 +34,7 @@ import { ContributionGrid } from "../src/client/components/ContributionGrid";
 import { ConversationPage } from "../src/client/pages/ConversationPage";
 import { ConversationWorkspace } from "../src/client/pages/ConversationWorkspace";
 import { PeoplePageContent } from "../src/client/pages/people/PeoplePage";
+import { PeopleDirectory } from "../src/client/pages/people/PeopleDirectory";
 import { Profile } from "../src/client/pages/people/PersonProfilePage";
 import {
   LocationDetailPage,
@@ -453,6 +454,7 @@ describe("dashboard telemetry components", () => {
     expect(html).toContain("Activity");
     expect(html).toContain("Incident triage");
     expect(html).toContain("Daily Junior conversation activity");
+    expect(html).toContain("90 days");
     expect(html).toContain(">Jan<");
     expect(html).toContain(">Less<");
     expect(html).toContain(">More<");
@@ -510,6 +512,7 @@ describe("dashboard telemetry components", () => {
           actor: {
             email: "avery@example.com",
             fullName: "Avery Example",
+            slackUserName: "avery",
           },
         },
       ],
@@ -528,9 +531,29 @@ describe("dashboard telemetry components", () => {
     expect(html).toContain("Active people per day");
     expect(html).toContain('aria-label="Reporting period"');
     expect(html).toContain('aria-pressed="true"');
-    expect(html).toContain(">30d</button>");
+    expect(html).toContain(">90d</button>");
     expect(html).toContain("Peak daily active");
     expect(html).toContain("Avery Example");
+    expect(html).not.toContain("@avery");
+    expect(html).not.toContain("last 1 day ago");
+  });
+
+  it("renders a stable skeleton while directory sorting catches up", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <PeopleDirectory
+          loading
+          onQueryChange={() => {}}
+          onSortChange={() => {}}
+          people={[]}
+          query=""
+          sort="runtime"
+          totalPeople={2}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(html).toContain('aria-label="Loading sorted results"');
   });
 
   it("keeps completed status badges quiet unless explicitly requested", () => {
@@ -753,6 +776,38 @@ describe("dashboard telemetry components", () => {
 
     expect(html).not.toContain("turn");
     expect(html).not.toContain("tool call");
+  });
+
+  it("counts actor turns and omits the redundant started header item", () => {
+    const session = {
+      conversationId: "conversation-1",
+      cumulativeDurationMs: 60_000,
+      lastProgressAt: "2026-01-01T00:01:00.000Z",
+      lastSeenAt: "2026-01-01T00:01:00.000Z",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      status: "completed",
+      surface: "internal",
+      displayTitle: "Conversation",
+    } satisfies ConversationSummaryReport;
+    const detail = {
+      ...session,
+      generatedAt: "2026-01-01T00:01:00.000Z",
+      transcript: [
+        { role: "user", parts: [{ type: "text", text: "first" }] },
+        { role: "assistant", parts: [{ type: "text", text: "done" }] },
+        { role: "user", parts: [{ type: "text", text: "second" }] },
+        { role: "assistant", parts: [{ type: "text", text: "done" }] },
+      ],
+      transcriptAvailable: true,
+    } satisfies ConversationDetailReport;
+    client.setQueryData(["conversation", "conversation-1"], detail);
+
+    const html = renderConversationPage(dashboardData([session]));
+    const header = html.slice(0, html.indexOf('aria-label="Transcript view"'));
+
+    expect(header).toContain("2 turns");
+    expect(header).not.toContain("4 messages");
+    expect(header).not.toContain("started Jan");
   });
 
   it("shows the conversation model and thinking level in the transcript header", () => {
@@ -1072,6 +1127,13 @@ describe("dashboard telemetry components", () => {
 
   it("renders public locations as primary rows and collapses private activity", () => {
     const data: LocationDirectoryReport = {
+      activityDays: [
+        {
+          date: "2026-01-05",
+          privateConversations: 3,
+          publicConversations: 6,
+        },
+      ],
       generatedAt: "2026-01-05T00:00:00.000Z",
       locations: [
         {
@@ -1112,6 +1174,8 @@ describe("dashboard telemetry components", () => {
         label: "Private activity",
       },
       source: "conversation_index",
+      windowEnd: "2026-01-05T00:00:00.000Z",
+      windowStart: "2025-10-08T00:00:00.000Z",
     };
     const html = renderToStaticMarkup(
       <MemoryRouter initialEntries={["/locations?q=proj-alpha"]}>
@@ -1127,10 +1191,12 @@ describe("dashboard telemetry components", () => {
     expect(html).not.toContain(">Active<");
     expect(html).toContain("Private activity");
     expect(html).toContain("DMs, private channels, and unknown visibility");
+    expect(html).toContain("Public and private conversations per day");
   });
 
   it("keeps cached location rows visible after a refresh failure", () => {
     const data: LocationDirectoryReport = {
+      activityDays: [],
       generatedAt: "2026-01-05T00:00:00.000Z",
       locations: [
         {
@@ -1156,6 +1222,8 @@ describe("dashboard telemetry components", () => {
         label: "Private activity",
       },
       source: "conversation_index",
+      windowEnd: "2026-01-05T00:00:00.000Z",
+      windowStart: "2025-10-08T00:00:00.000Z",
     };
 
     const html = renderToStaticMarkup(
@@ -1295,7 +1363,7 @@ describe("dashboard telemetry components", () => {
     expect(html).toContain(
       "Conversation metrics refresh failed. Showing cached data.",
     );
-    expect(html).toContain("Seven-day pulse");
+    expect(html).toContain("90-day pulse");
   });
 
   it("does not report a completion rate before any conversation finishes", () => {

--- a/packages/junior/src/api/conversations/stats.query.ts
+++ b/packages/junior/src/api/conversations/stats.query.ts
@@ -10,7 +10,7 @@ import {
 import { conversationAggregateColumns } from "./aggregate";
 import type { ConversationStatsItem, ConversationStatsReport } from "./schema";
 
-const WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+const WINDOW_MS = 90 * 24 * 60 * 60 * 1000;
 
 function emptyStatsItem(label: string): ConversationStatsItem {
   return {
@@ -180,7 +180,7 @@ async function aggregateStats(db: JuniorDatabase, start: Date, end: Date) {
   return { actorRows, locationRows, totals: totalsRows[0] };
 }
 
-/** Build complete seven-day dashboard stats from normalized durable SQL records. */
+/** Build complete 90-day dashboard stats from normalized durable SQL records. */
 export async function readConversationStatsFromSql(): Promise<ConversationStatsReport> {
   const nowMs = Date.now();
   const windowStartMs = nowMs - WINDOW_MS;

--- a/packages/junior/src/api/locations/query.ts
+++ b/packages/junior/src/api/locations/query.ts
@@ -16,13 +16,14 @@ import type { ActorIdentity } from "../conversations/schema";
 import { summaryFromRow } from "../conversations/reporting";
 import type {
   LocationActorSummaryReport,
+  LocationActivityDayReport,
   LocationDetailReport,
   LocationDirectoryReport,
   LocationSummaryReport,
 } from "./schema";
 
 const RECENT_LIMIT = 25;
-const ACTIVITY_DAYS = 30;
+const ACTIVITY_DAYS = 90;
 
 type AggregateMetrics = Pick<
   LocationSummaryReport,
@@ -181,10 +182,82 @@ async function directoryRows(db: JuniorDatabase) {
     .groupBy(...locationGroupBy());
 }
 
+async function directoryActivityRows(db: JuniorDatabase, start: Date) {
+  const date = sql<string>`TO_CHAR(
+    ${juniorConversations.lastActivityAt} AT TIME ZONE 'UTC',
+    'YYYY-MM-DD'
+  )`;
+  return db
+    .select({
+      conversations: sql<number>`COUNT(*)::integer`,
+      date,
+      visibility: juniorDestinations.visibility,
+    })
+    .from(juniorConversations)
+    .leftJoin(
+      juniorDestinations,
+      eq(juniorDestinations.id, juniorConversations.destinationId),
+    )
+    .where(and(topLevelWhere(), gte(juniorConversations.lastActivityAt, start)))
+    .groupBy(date, juniorDestinations.visibility);
+}
+
+function directoryActivityDays(
+  rows: Array<{
+    conversations: number;
+    date: string;
+    visibility: (typeof juniorDestinations.$inferSelect)["visibility"] | null;
+  }>,
+  nowMs: number,
+): LocationActivityDayReport[] {
+  const days = new Map<string, LocationActivityDayReport>();
+  for (const row of rows) {
+    const day = days.get(row.date) ?? {
+      date: row.date,
+      privateConversations: 0,
+      publicConversations: 0,
+    };
+    if (row.visibility === "public") {
+      day.publicConversations += row.conversations;
+    } else {
+      day.privateConversations += row.conversations;
+    }
+    days.set(row.date, day);
+  }
+
+  const end = new Date(nowMs);
+  end.setUTCHours(0, 0, 0, 0);
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - (ACTIVITY_DAYS - 1));
+  const activity: LocationActivityDayReport[] = [];
+  for (
+    const cursor = new Date(start);
+    cursor.getTime() <= end.getTime();
+    cursor.setUTCDate(cursor.getUTCDate() + 1)
+  ) {
+    const date = cursor.toISOString().slice(0, 10);
+    activity.push(
+      days.get(date) ?? {
+        date,
+        privateConversations: 0,
+        publicConversations: 0,
+      },
+    );
+  }
+  return activity;
+}
+
 /** Load public locations plus one complete privacy-safe aggregate for non-public activity. */
 export async function readLocationDirectoryFromSql(): Promise<LocationDirectoryReport> {
   const nowMs = Date.now();
-  const rows = await directoryRows(getDb());
+  const end = new Date(nowMs);
+  end.setUTCHours(0, 0, 0, 0);
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - (ACTIVITY_DAYS - 1));
+  const [rows, activityRows] = await Promise.all([
+    directoryRows(getDb()),
+    directoryActivityRows(getDb(), start),
+  ]);
   const locations: LocationSummaryReport[] = [];
   const privateActivity = {
     ...emptyMetrics(),
@@ -198,6 +271,7 @@ export async function readLocationDirectoryFromSql(): Promise<LocationDirectoryR
   }
 
   return {
+    activityDays: directoryActivityDays(activityRows, nowMs),
     generatedAt: new Date(nowMs).toISOString(),
     locations: locations.sort(
       (left, right) =>
@@ -207,6 +281,8 @@ export async function readLocationDirectoryFromSql(): Promise<LocationDirectoryR
     ),
     privateActivity,
     source: "conversation_index",
+    windowEnd: end.toISOString(),
+    windowStart: start.toISOString(),
   };
 }
 

--- a/packages/junior/src/api/locations/schema.ts
+++ b/packages/junior/src/api/locations/schema.ts
@@ -23,12 +23,23 @@ export const locationActorSummaryReportSchema = conversationStatsItemSchema
   .extend({ actor: actorIdentitySchema })
   .strict();
 
+export const locationActivityDayReportSchema = z
+  .object({
+    date: z.string(),
+    privateConversations: z.number(),
+    publicConversations: z.number(),
+  })
+  .strict();
+
 export const locationDirectoryReportSchema = z
   .object({
+    activityDays: z.array(locationActivityDayReportSchema),
     generatedAt: z.string(),
     locations: z.array(locationSummaryReportSchema),
     privateActivity: conversationStatsItemSchema,
     source: z.literal("conversation_index"),
+    windowEnd: z.string(),
+    windowStart: z.string(),
   })
   .strict();
 
@@ -47,6 +58,9 @@ export const locationDetailReportSchema = locationSummaryReportSchema
 export type LocationSummaryReport = z.infer<typeof locationSummaryReportSchema>;
 export type LocationActorSummaryReport = z.infer<
   typeof locationActorSummaryReportSchema
+>;
+export type LocationActivityDayReport = z.infer<
+  typeof locationActivityDayReportSchema
 >;
 export type LocationDirectoryReport = z.infer<
   typeof locationDirectoryReportSchema

--- a/packages/junior/src/api/people/shared.ts
+++ b/packages/junior/src/api/people/shared.ts
@@ -13,7 +13,7 @@ import type {
 } from "./schema";
 
 export const RECENT_LIMIT = 25;
-export const ACTIVITY_DAYS = 366;
+export const ACTIVITY_DAYS = 90;
 
 /** Normalize emails before matching people API rows. */
 export function normalizeEmail(email: string | undefined): string | undefined {

--- a/packages/junior/src/api/schema.ts
+++ b/packages/junior/src/api/schema.ts
@@ -33,11 +33,13 @@ export {
   actorProfileReportSchema,
 } from "./people/schema";
 export {
+  locationActivityDayReportSchema,
   locationDetailReportSchema,
   locationDirectoryReportSchema,
 } from "./locations/schema";
 export type {
   LocationActorSummaryReport,
+  LocationActivityDayReport,
   LocationDetailReport,
   LocationDirectoryReport,
   LocationSummaryReport,

--- a/packages/junior/tests/integration/api/conversations/stats.test.ts
+++ b/packages/junior/tests/integration/api/conversations/stats.test.ts
@@ -118,7 +118,7 @@ describe("conversation stats API", () => {
         },
         source: "slack",
         visibility: "public",
-        nowMs: Date.parse("2026-06-01T10:00:00.000Z"),
+        nowMs: Date.parse("2026-02-01T10:00:00.000Z"),
       });
       await store.ensureChildConversation({
         conversationId: "advisor:child",

--- a/packages/junior/tests/integration/api/locations.test.ts
+++ b/packages/junior/tests/integration/api/locations.test.ts
@@ -80,6 +80,16 @@ describe("locations API", () => {
         tokens: 15_000,
       });
       expect(directory.privateActivity.conversations).toBe(1);
+      expect(directory.activityDays).toHaveLength(90);
+      expect(
+        directory.activityDays.find((day) => day.date === "2026-06-15"),
+      ).toEqual({
+        date: "2026-06-15",
+        privateConversations: 1,
+        publicConversations: 5_001,
+      });
+      expect(directory.windowStart).toBe("2026-03-18T00:00:00.000Z");
+      expect(directory.windowEnd).toBe("2026-06-15T00:00:00.000Z");
 
       const detail = await readLocationDetailFromSql(destination?.id ?? "");
       expect(detail).toMatchObject({
@@ -88,6 +98,7 @@ describe("locations API", () => {
         tokens: 15_000,
       });
       expect(detail?.recentConversations).toHaveLength(25);
+      expect(detail?.activityDays).toHaveLength(90);
       expect(
         detail?.activityDays.find((day) => day.date === "2026-06-15"),
       ).toMatchObject({

--- a/packages/junior/tests/integration/api/people/profile.test.ts
+++ b/packages/junior/tests/integration/api/people/profile.test.ts
@@ -50,7 +50,7 @@ describe("people profile API", () => {
           }),
         ],
       });
-      expect(report.activityDays).toHaveLength(366);
+      expect(report.activityDays).toHaveLength(90);
       expect(
         report.activityDays.find((day) => day.date === "2026-06-12"),
       ).toMatchObject({

--- a/policies/testing.md
+++ b/policies/testing.md
@@ -34,6 +34,9 @@ routine refactors do not churn brittle unit tests.
 - Assert user-visible outcomes and external contracts before implementation
   details. Logs, spans, and status telemetry are not behavior contracts unless
   the test is explicitly about instrumentation.
+- Do not assert CSS utility strings, raw DOM tag counts, or generated markup to
+  prove visual styling. Test semantic state and interaction behavior with
+  component or browser coverage, and validate styling-only changes visually.
 
 ## Exceptions
 


### PR DESCRIPTION
Dashboard analytics now use consistent 90-day windows, default People and Locations to conversation volume, and show loading feedback while client-side sort order changes. Locations also expose and visualize a privacy-safe daily public/private activity series, while profiles use a two-column layout that gives activity and recent conversations more room.

Conversation details now label actor exchanges as turns, remove the redundant started item, and use slightly smaller body text for user and assistant messages. The location directory response adds activityDays, windowStart, and windowEnd; dashboard-owned consumers and mock reporting data move with the contract.