### PR TITLE
fix(agent): Retry transient provider failures

### DIFF
--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -9,6 +9,7 @@
  * stay outside this module.
  */
 import { Agent, type AgentLoopTurnUpdate } from "@earendil-works/pi-agent-core";
+import { isRetryableAssistantError } from "@earendil-works/pi-ai";
 import type { FileUpload } from "chat";
 import { botConfig } from "@/chat/config";
 import {
@@ -1021,8 +1022,10 @@ async function executeAgentRunInPrivacyContext(
 
             const providerRetry = nextProviderRetry({
               attempt,
-              lastAssistant,
               messages: agent!.state.messages,
+              retryableFailure:
+                lastAssistant !== undefined &&
+                isRetryableAssistantError(lastAssistant),
             });
             if (!providerRetry) {
               break;

--- a/packages/junior/src/chat/services/provider-retry.ts
+++ b/packages/junior/src/chat/services/provider-retry.ts
@@ -1,4 +1,3 @@
-import type { AssistantMessage } from "@earendil-works/pi-ai";
 import type { PiMessage } from "@/chat/pi/messages";
 import {
   getPiMessageRole,
@@ -9,7 +8,7 @@ const PROVIDER_RETRY_DELAYS_MS = [2_000, 4_000, 8_000] as const;
 const PROVIDER_ERROR_PREFIX = "AI provider error:";
 const PROVIDER_RETRY_ERROR_NAME = "ProviderRetryError";
 const NON_RETRYABLE_PROVIDER_ERROR_PATTERNS = [
-  /invalid.?api.?key|no api key|authentication|authorization|permission|forbidden|credential/i,
+  /invalid.?api.?key|no api key|authentication|authorization|permission|forbidden|(?:invalid|missing|expired|revoked).{0,24}\bcredentials?\b|\bcredentials?\b.{0,24}(?:invalid|missing|expired|revoked)|\bno\b.{0,16}\bcredentials?\b/i,
   /context.?length|context.?window/i,
   /content.?policy|validation|bad request|\b(?:400|401|403)\b/i,
   /unsupported model|invalid model|unknown ai gateway model|unknown model|mismatched api/i,
@@ -46,19 +45,11 @@ function isRetryableProviderFailure(errorMessage: string): boolean {
 /** Build the next provider retry step from Pi history, if the turn can resume. */
 export function nextProviderRetry(args: {
   attempt: number;
-  lastAssistant:
-    | Pick<AssistantMessage, "stopReason" | "errorMessage">
-    | undefined;
   messages: PiMessage[];
+  retryableFailure: boolean;
 }): { delayMs: number; messages: PiMessage[] } | undefined {
   const delayMs = PROVIDER_RETRY_DELAYS_MS[args.attempt];
-  const errorMessage = args.lastAssistant?.errorMessage?.trim();
-  if (
-    delayMs === undefined ||
-    args.lastAssistant?.stopReason !== "error" ||
-    !errorMessage ||
-    !isRetryableProviderFailure(errorMessage)
-  ) {
+  if (delayMs === undefined || !args.retryableFailure) {
     return undefined;
   }
 

--- a/packages/junior/tests/unit/services/provider-retry.test.ts
+++ b/packages/junior/tests/unit/services/provider-retry.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import type { AssistantMessage } from "@earendil-works/pi-ai";
+import {
+  isRetryableAssistantError,
+  type AssistantMessage,
+} from "@earendil-works/pi-ai";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai/providers/faux";
 import type { PiMessage } from "@/chat/pi/messages";
 import {
   nextProviderRetry,
@@ -7,14 +11,15 @@ import {
   isProviderRetryError,
 } from "@/chat/services/provider-retry";
 
-function assistantError(
-  errorMessage: string | undefined,
-): Pick<AssistantMessage, "stopReason" | "errorMessage"> {
-  return {
+function assistantError(errorMessage: string | undefined): AssistantMessage {
+  return fauxAssistantMessage([], {
     stopReason: "error",
-    errorMessage,
-  };
+    ...(errorMessage ? { errorMessage } : {}),
+  });
 }
+
+const XAI_SERVICE_UNAVAILABLE =
+  '503 {"error":{"message":"Service temporarily unavailable. Please try again shortly.","type":"service_unavailable_error","param":{"error":"Service temporarily unavailable. Please try again shortly.","type":"service_unavailable_error","statusCode":503}},"providerMetadata":{"gateway":{"routing":{"originalModelId":"xai/grok-4.5","resolvedProvider":"xai","fallbacksAvailable":[],"canonicalSlug":"xai/grok-4.5","modelAttemptCount":1,"modelAttempts":[{"canonicalSlug":"xai/grok-4.5","success":false,"providerAttemptCount":1,"providerAttempts":[{"provider":"xai","credentialType":"system","success":false,"error":"Service temporarily unavailable","startTime":1784041443272,"endTime":1784041443386,"statusCode":503,"inferenceEndpoint":{"slug":"global","scope":"global"}}]}],"totalProviderAttemptCount":1},"generationId":"gen_01KXGJG3XC3MJ511VVF87ZSBTC"}}}';
 
 describe("provider retry helpers", () => {
   it("marks retryable provider-boundary exceptions", () => {
@@ -38,21 +43,48 @@ describe("provider retry helpers", () => {
       role: "user",
       content: [{ type: "text", text: "help" }],
     } as PiMessage;
-    const failedAssistant = {
-      role: "assistant",
-      content: [],
-      stopReason: "error",
-    } as unknown as PiMessage;
+    const failedAssistant = assistantError(
+      "Anthropic stream ended before message_stop",
+    );
 
     expect(
       nextProviderRetry({
         attempt: 0,
-        lastAssistant: assistantError(
-          "Anthropic stream ended before message_stop",
-        ),
         messages: [user, failedAssistant],
+        retryableFailure: isRetryableAssistantError(failedAssistant),
       }),
     ).toEqual({ delayMs: 2_000, messages: [user] });
+  });
+
+  it("retries a structured xAI 503 despite gateway credential metadata", () => {
+    const user = {
+      role: "user",
+      content: [{ type: "text", text: "help" }],
+    } as PiMessage;
+    const failedAssistant = assistantError(XAI_SERVICE_UNAVAILABLE);
+
+    expect(
+      isProviderRetryError(createProviderError(XAI_SERVICE_UNAVAILABLE)),
+    ).toBe(true);
+
+    expect(
+      nextProviderRetry({
+        attempt: 0,
+        messages: [user, failedAssistant],
+        retryableFailure: isRetryableAssistantError(failedAssistant),
+      }),
+    ).toEqual({ delayMs: 2_000, messages: [user] });
+  });
+
+  it("does not retry explicit credential failures", () => {
+    for (const message of [
+      "Missing AI gateway credentials (AI_GATEWAY_API_KEY or VERCEL_OIDC_TOKEN)",
+      '401 {"error":{"message":"The provided credentials are invalid","type":"authentication_error","statusCode":401}}',
+      "Provider credentials have expired",
+      "Provider credentials were revoked",
+    ]) {
+      expect(isProviderRetryError(createProviderError(message))).toBe(false);
+    }
   });
 
   it("does not retry permanent, exhausted, or unresumable Pi failures", () => {
@@ -60,36 +92,32 @@ describe("provider retry helpers", () => {
       role: "user",
       content: [{ type: "text", text: "help" }],
     } as PiMessage;
-    const failedAssistant = {
-      role: "assistant",
-      content: [],
-      stopReason: "error",
-    } as unknown as PiMessage;
+    const failedAssistant = assistantError("Anthropic overloaded");
     const retry = (
       overrides: {
         attempt?: number;
-        lastAssistant?: Pick<AssistantMessage, "stopReason" | "errorMessage">;
         messages?: PiMessage[];
+        retryableFailure?: boolean;
       } = {},
     ) =>
       nextProviderRetry({
         attempt: 0,
-        lastAssistant: assistantError("Anthropic overloaded"),
         messages: [user, failedAssistant],
+        retryableFailure: true,
         ...overrides,
       });
 
-    expect(
-      retry({
-        lastAssistant: assistantError("400 bad request"),
-      }),
-    ).toBeUndefined();
-    expect(
-      retry({
-        lastAssistant: assistantError(undefined),
-      }),
-    ).toBeUndefined();
-    expect(retry({ lastAssistant: { stopReason: "stop" } })).toBeUndefined();
+    for (const message of [
+      assistantError("400 bad request"),
+      assistantError(undefined),
+      fauxAssistantMessage("done"),
+      assistantError(
+        '429 {"error":{"message":"Quota exceeded","type":"insufficient_quota"}}',
+      ),
+    ]) {
+      expect(isRetryableAssistantError(message)).toBe(false);
+    }
+    expect(retry({ retryableFailure: false })).toBeUndefined();
     expect(retry({ attempt: 3 })).toBeUndefined();
     expect(retry({ messages: [failedAssistant] })).toBeUndefined();
   });


### PR DESCRIPTION
Transient provider outages now retry from the last safe Pi boundary instead of immediately ending with the generic internal-error response.

The retry classifier previously scanned serialized gateway metadata and treated credentialType: system as a permanent credential failure, so xAI 503 responses skipped the existing 2/4/8-second backoff. Assistant failures are now classified by Pi at the agent boundary while Junior retains backoff and safe-history resumption; direct-provider credential checks only match explicit missing, invalid, expired, or revoked credentials. Regression coverage uses the production-shaped 503 payload and preserves permanent quota and credential failures.

Fixes JUNIOR-53