### PR TITLE
fix(dashboard): Surface agent failures in conversation history

### DIFF
--- a/packages/junior-dashboard/src/client/components/ConversationTranscript.tsx
+++ b/packages/junior-dashboard/src/client/components/ConversationTranscript.tsx
@@ -4,7 +4,13 @@ import {
   type ClipboardEventHandler,
   type ReactNode,
 } from "react";
-import { Bot, Minimize2, Send, type LucideIcon } from "lucide-react";
+import {
+  Bot,
+  CircleAlert,
+  Minimize2,
+  Send,
+  type LucideIcon,
+} from "lucide-react";
 
 import { HighlightedCode } from "../code";
 import {
@@ -72,6 +78,7 @@ import { entryMatchesSearch, useTranscriptSearch } from "./transcriptSearch";
 
 type TranscriptEntry = ReturnType<typeof groupTranscriptMessages>[number];
 type TranscriptContextEntry = Extract<TranscriptEntry, { kind: "context" }>;
+type TranscriptFailureEntry = Extract<TranscriptEntry, { kind: "failure" }>;
 type TranscriptMessageEntry = Extract<TranscriptEntry, { kind: "message" }>;
 type TranscriptSubagentEntry = Extract<TranscriptEntry, { kind: "subagent" }>;
 type TranscriptThinkingEntry = Extract<TranscriptEntry, { kind: "thinking" }>;
@@ -295,6 +302,13 @@ function VisibleTranscriptEntries(props: {
           />
         </TranscriptRailEvent>
       )}
+      renderFailure={(entry, index) => (
+        <TranscriptFailureView
+          key={`${props.conversation.conversationId}:failure:${index}`}
+          outcome={entry.outcome}
+          timestamp={entry.timestamp}
+        />
+      )}
       renderMessage={(entry, index) => (
         <TranscriptMessageView
           key={`${props.conversation.conversationId}:${index}`}
@@ -345,6 +359,7 @@ function TranscriptEntryList(props: {
   entries: TranscriptEntry[];
   keyPrefix: string;
   renderContext: (entry: TranscriptContextEntry, index: number) => ReactNode;
+  renderFailure: (entry: TranscriptFailureEntry, index: number) => ReactNode;
   renderMessage: (entry: TranscriptMessageEntry, index: number) => ReactNode;
   renderSubagent: (entry: TranscriptSubagentEntry, index: number) => ReactNode;
   renderThinking: (entry: TranscriptThinkingEntry, index: number) => ReactNode;
@@ -394,7 +409,9 @@ function TranscriptEntryList(props: {
             ? props.renderSubagent(entry, index)
             : entry.kind === "context"
               ? props.renderContext(entry, index)
-              : props.renderMessage(entry, index)}
+              : entry.kind === "failure"
+                ? props.renderFailure(entry, index)
+                : props.renderMessage(entry, index)}
         </Fragment>,
       );
     }
@@ -408,6 +425,58 @@ function TranscriptEntryList(props: {
   }
 
   return <>{rows}</>;
+}
+
+function TranscriptFailureView(props: {
+  outcome: "error" | "aborted";
+  timestamp?: number;
+}) {
+  const timestamp = formatMessageTimestamp(props.timestamp);
+  const isError = props.outcome === "error";
+
+  return (
+    <div
+      className={cn(
+        "grid min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-3 rounded-lg border px-4 py-3 max-md:grid-cols-[auto_minmax(0,1fr)]",
+        isError
+          ? "border-rose-300/25 bg-rose-300/[0.07] text-rose-100"
+          : "border-amber-300/25 bg-amber-300/[0.07] text-amber-100",
+      )}
+      data-transcript-failure={props.outcome}
+      role={isError ? "alert" : "status"}
+    >
+      <CircleAlert
+        aria-hidden="true"
+        className={cn("mt-0.5", isError ? "text-rose-300" : "text-amber-300")}
+        size={16}
+      />
+      <div className="min-w-0">
+        <div className="font-display text-[0.95rem] font-semibold leading-tight">
+          {isError ? "Agent response failed" : "Agent response stopped"}
+        </div>
+        <div
+          className={cn(
+            "mt-1 text-[0.84rem] leading-relaxed",
+            isError ? "text-rose-100/70" : "text-amber-100/70",
+          )}
+        >
+          {isError
+            ? "The model response ended before Junior could complete this turn."
+            : "The model response was stopped before Junior could complete this turn."}
+        </div>
+      </div>
+      {timestamp ? (
+        <span
+          className={cn(
+            "font-mono text-[0.78rem] leading-none max-md:col-start-2",
+            isError ? "text-rose-100/55" : "text-amber-100/55",
+          )}
+        >
+          {timestamp}
+        </span>
+      ) : null}
+    </div>
+  );
 }
 
 type TranscriptRailEventKind = "compaction" | "handoff" | "subagent";
@@ -483,6 +552,13 @@ function RedactedTranscriptView(props: {
             timestamp={entry.timestamp}
           />
         </TranscriptRailEvent>
+      )}
+      renderFailure={(entry, index) => (
+        <TranscriptFailureView
+          key={`${props.conversation.conversationId}:redacted:failure:${index}`}
+          outcome={entry.outcome}
+          timestamp={entry.timestamp}
+        />
       )}
       renderMessage={(entry, index) => (
         <RedactedMessageView

--- a/packages/junior-dashboard/src/client/components/transcriptBottomPinning.ts
+++ b/packages/junior-dashboard/src/client/components/transcriptBottomPinning.ts
@@ -62,6 +62,7 @@ export function transcriptBottomVersion(
     conversation.status,
     messages.length,
     lastMessage?.role ?? "",
+    lastMessage?.outcome ?? "",
     lastMessage?.timestamp ?? "",
     lastMessage?.parts.length ?? 0,
     transcriptPartVersion(lastPart),

--- a/packages/junior-dashboard/src/client/components/transcriptRenderModel.ts
+++ b/packages/junior-dashboard/src/client/components/transcriptRenderModel.ts
@@ -22,6 +22,7 @@ export type RenderedTranscriptPart =
 
 export type RenderedTranscriptEntry =
   | RenderedContextEventEntry
+  | RenderedFailureEntry
   | { kind: "message"; message: TranscriptViewMessage }
   | RenderedSubagentEntry
   | RenderedThinkingEntry
@@ -30,6 +31,12 @@ export type RenderedTranscriptEntry =
 export type RenderedThinkingEntry = {
   kind: "thinking";
   part: TranscriptViewPart;
+  timestamp?: number;
+};
+
+export type RenderedFailureEntry = {
+  kind: "failure";
+  outcome: "error" | "aborted";
   timestamp?: number;
 };
 
@@ -253,6 +260,13 @@ export function groupTranscriptMessages(
     }
 
     flushMessage();
+    if (message.outcome) {
+      entries.push({
+        kind: "failure",
+        outcome: message.outcome,
+        timestamp: message.timestamp,
+      });
+    }
   }
 
   return entries;

--- a/packages/junior-dashboard/src/client/components/transcriptSearch.tsx
+++ b/packages/junior-dashboard/src/client/components/transcriptSearch.tsx
@@ -126,6 +126,15 @@ export function entryMatchesSearch(
     return textContains(messageRawText(entry.message), normalizedQuery);
   }
 
+  if (entry.kind === "failure") {
+    return textContains(
+      entry.outcome === "error"
+        ? "agent response failed error"
+        : "agent response stopped aborted",
+      normalizedQuery,
+    );
+  }
+
   if (entry.kind === "tool") {
     const visibleCallStatus =
       entry.call?.status === "running" && !entry.result

--- a/packages/junior-dashboard/src/client/markdownExport.ts
+++ b/packages/junior-dashboard/src/client/markdownExport.ts
@@ -120,6 +120,16 @@ function appendTranscriptMessages(
       continue;
     }
 
+    if (entry.kind === "failure") {
+      appendFailure(
+        lines,
+        conversationTranscript,
+        entry.outcome,
+        entry.timestamp,
+      );
+      continue;
+    }
+
     if (entry.kind === "thinking") {
       appendThinking(
         lines,
@@ -172,6 +182,27 @@ function appendTranscriptMessages(
       entry.resultTimestamp,
     );
   }
+}
+
+function appendFailure(
+  lines: string[],
+  conversationTranscript: ConversationTranscript,
+  outcome: "error" | "aborted",
+  timestamp: number | undefined,
+): void {
+  lines.push(
+    "",
+    outcome === "error"
+      ? "### Agent response failed"
+      : "### Agent response stopped",
+  );
+  addEventMeta(lines, conversationTranscript, timestamp);
+  lines.push(
+    "",
+    outcome === "error"
+      ? "The model response ended before Junior could complete this turn."
+      : "The model response was stopped before Junior could complete this turn.",
+  );
 }
 
 function appendContextEvent(

--- a/packages/junior-dashboard/src/mock-conversations.ts
+++ b/packages/junior-dashboard/src/mock-conversations.ts
@@ -507,6 +507,12 @@ function failedConversation(nowMs: number): ConversationDetailReport {
           },
         ],
       },
+      {
+        role: "assistant",
+        outcome: "error",
+        timestamp: Date.parse(startedAt) + 72_000,
+        parts: [],
+      },
     ],
   };
 }

--- a/packages/junior-dashboard/tests/dashboard-mock-routes.test.ts
+++ b/packages/junior-dashboard/tests/dashboard-mock-routes.test.ts
@@ -158,6 +158,29 @@ describe("dashboard mock conversation routes", () => {
         .filter(Boolean),
     ).toContain("datacat.search_logs");
 
+    const failedConversation = await app.fetch(
+      new Request(
+        "http://localhost/api/conversations/slack%3ACQA777%3A1770014400.000500",
+      ),
+    );
+    expect(failedConversation.status).toBe(200);
+    const failedConversationBody = (await failedConversation.json()) as {
+      transcript: Array<{
+        outcome?: string;
+        parts: unknown[];
+        role: string;
+      }>;
+      transcriptMessageCount?: number;
+    };
+    expect(failedConversationBody.transcript.at(-1)).toEqual(
+      expect.objectContaining({
+        role: "assistant",
+        outcome: "error",
+        parts: [],
+      }),
+    );
+    expect(failedConversationBody.transcriptMessageCount).toBe(3);
+
     const qaConversation = await app.fetch(
       new Request(
         `http://localhost/api/conversations/${encodeURIComponent(

--- a/packages/junior-dashboard/tests/markdownExport.test.ts
+++ b/packages/junior-dashboard/tests/markdownExport.test.ts
@@ -166,6 +166,47 @@ describe("dashboard markdown export", () => {
     expect(markdown).toContain("## Done\n\n\n\nCopied as Markdown.");
   });
 
+  it("exports terminal assistant outcomes with safe copy", () => {
+    const startedAt = "2026-01-01T00:00:00.000Z";
+    const detail = {
+      conversationId: "slack:C1:failed",
+      cumulativeDurationMs: 0,
+      displayTitle: "Failed responses",
+      generatedAt: "2026-01-01T00:00:03.000Z",
+      lastProgressAt: "2026-01-01T00:00:02.000Z",
+      lastSeenAt: "2026-01-01T00:00:02.000Z",
+      startedAt,
+      status: "completed",
+      surface: "slack",
+      transcriptAvailable: true,
+      transcript: [
+        {
+          role: "assistant",
+          outcome: "error",
+          timestamp: Date.parse(startedAt) + 1_000,
+          parts: [],
+        },
+        {
+          role: "assistant",
+          outcome: "aborted",
+          timestamp: Date.parse(startedAt) + 2_000,
+          parts: [],
+        },
+      ],
+    } satisfies ConversationDetailReport;
+
+    const markdown = buildConversationMarkdown(detail);
+
+    expect(markdown).toContain("### Agent response failed");
+    expect(markdown).toContain(
+      "The model response ended before Junior could complete this turn.",
+    );
+    expect(markdown).toContain("### Agent response stopped");
+    expect(markdown).toContain(
+      "The model response was stopped before Junior could complete this turn.",
+    );
+  });
+
   it("prefers the freshly loaded detail title over a stale list row title", () => {
     const generatedAt = "2026-01-01T00:00:08.000Z";
     const detail = {

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -592,6 +592,75 @@ describe("dashboard telemetry components", () => {
     expect(html).toContain("https://sentry.example/trace/abc");
   });
 
+  it("renders terminal assistant outcomes as distinct safe callouts", () => {
+    const turn = {
+      conversationId: "conversation-1",
+      cumulativeDurationMs: 0,
+      lastProgressAt: "2026-01-01T00:00:02.000Z",
+      lastSeenAt: "2026-01-01T00:00:02.000Z",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      status: "completed",
+      surface: "slack",
+      displayTitle: "Conversation",
+      transcript: [
+        {
+          role: "assistant",
+          outcome: "error",
+          timestamp: 1_000,
+          parts: [],
+        },
+        {
+          role: "assistant",
+          outcome: "aborted",
+          timestamp: 2_000,
+          parts: [],
+        },
+      ],
+      transcriptAvailable: true,
+    } as ConversationTranscript;
+
+    const html = renderToStaticMarkup(
+      <ConversationTranscriptView conversation={turn} view="rich" />,
+    );
+
+    expect(html).toContain('data-transcript-failure="error"');
+    expect(html).toContain('data-transcript-failure="aborted"');
+    expect(html).toContain("Agent response failed");
+    expect(html).toContain("Agent response stopped");
+  });
+
+  it("renders terminal assistant outcomes from redacted transcript metadata", () => {
+    const turn = {
+      conversationId: "conversation-private",
+      cumulativeDurationMs: 0,
+      lastProgressAt: "2026-01-01T00:00:01.000Z",
+      lastSeenAt: "2026-01-01T00:00:01.000Z",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      status: "completed",
+      surface: "slack",
+      displayTitle: "Private conversation",
+      transcript: [],
+      transcriptAvailable: false,
+      transcriptMetadata: [
+        {
+          role: "assistant",
+          outcome: "error",
+          timestamp: 1_000,
+          parts: [],
+        },
+      ],
+      transcriptRedacted: true,
+      transcriptRedactionReason: "non_public_conversation",
+    } as ConversationTranscript;
+
+    const html = renderToStaticMarkup(
+      <ConversationTranscriptView conversation={turn} view="rich" />,
+    );
+
+    expect(html).toContain('data-transcript-failure="error"');
+    expect(html).toContain("Agent response failed");
+  });
+
   it("removes residual grid row gap from collapsed system prompts", () => {
     const turn = {
       conversationId: "conversation-1",

--- a/packages/junior-dashboard/tests/transcriptBottomPinning.test.ts
+++ b/packages/junior-dashboard/tests/transcriptBottomPinning.test.ts
@@ -91,6 +91,24 @@ describe("transcript bottom pinning", () => {
     expect(after).not.toBe(before);
   });
 
+  it("changes the tail version when an empty response gains a terminal outcome", () => {
+    const emptyResponse = {
+      role: "assistant" as const,
+      timestamp: 1_000,
+      parts: [],
+    };
+    const before = transcriptBottomVersion(
+      activeTurn({ transcript: [emptyResponse] }),
+    );
+    const after = transcriptBottomVersion(
+      activeTurn({
+        transcript: [{ ...emptyResponse, outcome: "error" }],
+      }),
+    );
+
+    expect(after).not.toBe(before);
+  });
+
   it("does not auto-pin after live mode turns off", () => {
     expect(
       shouldAutoPinTranscriptBottom({ enabled: true, following: true }),

--- a/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
+++ b/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
@@ -28,6 +28,41 @@ function conversationTurn(
 }
 
 describe("transcript render model", () => {
+  it("promotes terminal assistant outcomes to standalone failure entries", () => {
+    const messages = [
+      {
+        role: "assistant",
+        outcome: "error",
+        timestamp: 1_000,
+        parts: [],
+      },
+      {
+        role: "assistant",
+        outcome: "aborted",
+        timestamp: 2_000,
+        parts: [{ type: "text", text: "Partial response" }],
+      },
+    ] as TranscriptMessage[];
+
+    const entries = groupTranscriptMessages(messages);
+
+    expect(entries).toEqual([
+      { kind: "failure", outcome: "error", timestamp: 1_000 },
+      {
+        kind: "message",
+        message: {
+          role: "assistant",
+          outcome: "aborted",
+          timestamp: 2_000,
+          parts: [{ type: "text", text: "Partial response" }],
+        },
+      },
+      { kind: "failure", outcome: "aborted", timestamp: 2_000 },
+    ]);
+    expect(entryMatchesSearch(entries[0]!, "failed")).toBe(true);
+    expect(entryMatchesSearch(entries[2]!, "aborted")).toBe(true);
+  });
+
   it("promotes thinking parts to standalone transcript events", () => {
     const messages = [
       {

--- a/packages/junior/src/api/conversations/schema.ts
+++ b/packages/junior/src/api/conversations/schema.ts
@@ -90,6 +90,7 @@ export const transcriptRoleSchema = z.enum([
 
 export const transcriptMessageSchema = z
   .object({
+    outcome: z.enum(["error", "aborted"]).optional(),
     parts: z.array(transcriptPartSchema),
     role: transcriptRoleSchema,
     timestamp: z.number().optional(),

--- a/packages/junior/src/api/conversations/transcript.ts
+++ b/packages/junior/src/api/conversations/transcript.ts
@@ -187,6 +187,10 @@ function normalizeMessage(
   const role = transcriptRole(record.role);
   return {
     role,
+    ...(role === "assistant" &&
+    (record.stopReason === "error" || record.stopReason === "aborted")
+      ? { outcome: record.stopReason }
+      : {}),
     ...(typeof record.timestamp === "number"
       ? { timestamp: record.timestamp }
       : {}),
@@ -310,6 +314,7 @@ export function redactTranscriptMessage(
 ): TranscriptMessage {
   return {
     role: message.role,
+    ...(message.outcome ? { outcome: message.outcome } : {}),
     ...(typeof message.timestamp === "number"
       ? { timestamp: message.timestamp }
       : {}),

--- a/packages/junior/tests/integration/dashboard-reporting.test.ts
+++ b/packages/junior/tests/integration/dashboard-reporting.test.ts
@@ -1009,6 +1009,126 @@ describe("dashboard reporting", () => {
     ]);
   });
 
+  it("reports terminal assistant outcomes without exposing provider errors", async () => {
+    const { getAgentStepStore, getConversationStore } =
+      await import("@/chat/db");
+    const errorConversationId = "slack:C1:terminal-error";
+    const abortedConversationId = "slack:D1:terminal-aborted";
+    const sensitiveError =
+      "xAI 503 credential=secret-provider-token upstream payload";
+
+    await confirmPublicSlackConversation(errorConversationId);
+    await getAgentStepStore().append(errorConversationId, [
+      {
+        entry: {
+          type: "pi_message",
+          message: {
+            role: "assistant",
+            api: "openai-responses",
+            content: [],
+            model: "grok-4.5",
+            provider: "xai",
+            stopReason: "error",
+            errorMessage: sensitiveError,
+            timestamp: 2,
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: {
+                input: 0,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+                total: 0,
+              },
+            },
+          } as PiMessage,
+        },
+        createdAtMs: 2,
+      },
+    ]);
+
+    await getConversationStore().recordActivity({
+      conversationId: abortedConversationId,
+      destination: {
+        platform: "slack",
+        teamId: "T1",
+        channelId: "D1",
+      },
+      source: "slack",
+      visibility: "private",
+    });
+    await getAgentStepStore().append(abortedConversationId, [
+      {
+        entry: {
+          type: "pi_message",
+          message: {
+            role: "assistant",
+            api: "openai-responses",
+            content: [],
+            model: "grok-4.5",
+            provider: "xai",
+            stopReason: "aborted",
+            errorMessage: sensitiveError,
+            timestamp: 3,
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: {
+                input: 0,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+                total: 0,
+              },
+            },
+          } as PiMessage,
+        },
+        createdAtMs: 3,
+      },
+    ]);
+
+    const errorReport = await readConversationDetailReport(errorConversationId);
+    const abortedReport = await readConversationDetailReport(
+      abortedConversationId,
+    );
+
+    expect(errorReport.transcript).toEqual([
+      {
+        role: "assistant",
+        outcome: "error",
+        parts: [],
+        timestamp: 2,
+      },
+    ]);
+    expect(errorReport.transcriptMessageCount).toBe(0);
+    expect(abortedReport).toMatchObject({
+      transcript: [],
+      transcriptAvailable: false,
+      transcriptMetadata: [
+        {
+          role: "assistant",
+          outcome: "aborted",
+          parts: [],
+          timestamp: 3,
+        },
+      ],
+      transcriptRedacted: true,
+    });
+    expect(JSON.stringify({ errorReport, abortedReport })).not.toContain(
+      sensitiveError,
+    );
+    expect(JSON.stringify({ errorReport, abortedReport })).not.toContain(
+      '"provider":"xai"',
+    );
+  });
+
   it("keeps SQL detail available when optional execution settings fail", async () => {
     const { getAgentStepStore, getConversationStore } =
       await import("@/chat/db");


### PR DESCRIPTION
Terminal Pi assistant messages ending in error or aborted could disappear from operator history when they contained no displayable text. The reporting projection now carries a safe terminal outcome, preserves it through private-conversation redaction, and the dashboard renders distinct failure and stopped events in visible and redacted transcripts.

Search, Markdown export, live bottom-pinning, and the failed-conversation mock understand these events. The projection deliberately excludes raw provider diagnostics and does not alter Pi replay, persistence, Slack delivery, conversation status, or transcript message counts. Regression coverage includes reporting privacy and count behavior plus public and redacted dashboard rendering.