### PR TITLE
fix(github): Use sandbox-provided curl

### DIFF
--- a/packages/junior-github/src/index.ts
+++ b/packages/junior-github/src/index.ts
@@ -1734,10 +1734,6 @@ export function githubPlugin(
       runtimeDependencies: [
         {
           type: "system",
-          package: "curl",
-        },
-        {
-          type: "system",
           package: "gh",
         },
         {

--- a/packages/junior-github/tests/github-plugin.test.ts
+++ b/packages/junior-github/tests/github-plugin.test.ts
@@ -449,6 +449,13 @@ describe("github plugin", () => {
     process.env = { ...ORIGINAL_ENV };
   });
 
+  it("uses the sandbox-provided curl implementation", () => {
+    expect(githubPlugin().manifest?.runtimeDependencies).toEqual([
+      { type: "system", package: "gh" },
+      { type: "system", package: "jq" },
+    ]);
+  });
+
   it("defaults GitHub App permissions and user OAuth scopes to all available app access", () => {
     const plugin = githubPlugin();
 


### PR DESCRIPTION
The GitHub plugin now uses the curl implementation already provided by the Amazon Linux sandbox instead of requesting the conflicting full curl package. This allows runtime dependency snapshots to build so the pending production release can deploy.

The manifest regression coverage keeps the system dependency list limited to gh and jq.

Fixes JUNIOR-4R