### PR TITLE
fix(agent): Preserve generated artifact paths

### DIFF
--- a/packages/junior-evals/evals/conversation/delivery.eval.ts
+++ b/packages/junior-evals/evals/conversation/delivery.eval.ts
@@ -111,13 +111,15 @@ describeEval("Slack Message Delivery", slackEvals, (it) => {
         }),
       ]),
     );
-    const sendFilesCall = toolCalls(result.session).find(
-      (call) => call.name === "sendFiles",
+    expect(toolCalls(result.session)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "sendFiles",
+          status: "ok",
+          result: expect.objectContaining({ ok: true, status: "success" }),
+        }),
+      ]),
     );
-    expect(sendFilesCall).toMatchObject({
-      status: "ok",
-      result: { ok: true, status: "success" },
-    });
     expect(hasImageAttachment(result.session)).toBe(true);
     expect(visibleAssistantText(result.session)).not.toContain(NO_REPLY_MARKER);
     expect(visibleThreadReplies(result.session).length).toBeGreaterThan(0);

--- a/packages/junior/src/chat/runtime/generated-artifacts.ts
+++ b/packages/junior/src/chat/runtime/generated-artifacts.ts
@@ -2,8 +2,8 @@ import type { FileUpload } from "chat";
 import {
   SANDBOX_ARTIFACTS_DIR,
   sandboxArtifactPath,
+  type GeneratedArtifactFileRef,
 } from "@/chat/tools/sandbox/file-uploads";
-import type { GeneratedArtifactFileRef } from "@/chat/tools/types";
 import type { SandboxCommandResult } from "@/chat/sandbox/workspace";
 
 /** Sandbox operations needed to make generated artifacts visible to later tools. */

--- a/packages/junior/src/chat/slack/tools/send-files.ts
+++ b/packages/junior/src/chat/slack/tools/send-files.ts
@@ -5,45 +5,19 @@ import { z } from "zod";
 import { zodTool } from "@/chat/tool-support/zod-tool";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 import { createOperationKey } from "@/chat/tools/idempotency";
-import type { SandboxFileUpload } from "@/chat/tools/sandbox/file-uploads";
+import {
+  sandboxFileReferenceSchema,
+  type SandboxFileMaterializationInput,
+  type SandboxFileReferenceInput,
+  type SandboxFileUpload,
+} from "@/chat/tools/sandbox/file-uploads";
 import type { ToolState } from "@/chat/tools/types";
 import { juniorToolResultSchema } from "@/chat/tool-support/structured-result";
 
 /** Convert a model-supplied sandbox file path into bytes safe for Slack upload. */
-export type MaterializeFile = (input: {
-  path: string;
-  filename?: string;
-  mimeType?: string;
-}) => Promise<SandboxFileUpload>;
-
-type FileInput = {
-  path: string;
-  filename?: string | null;
-  mimeType?: string | null;
-};
-
-const fileInputSchema = z.object({
-  path: z
-    .string()
-    .min(1)
-    .describe(
-      "Sandbox file path to include in the message. Absolute paths and workspace-relative paths are supported.",
-    ),
-  filename: z
-    .string()
-    .min(1)
-    .nullable()
-    .optional()
-    .describe(
-      "Optional filename override shown in Slack. Null is treated as omitted.",
-    ),
-  mimeType: z
-    .string()
-    .min(1)
-    .nullable()
-    .optional()
-    .describe("Optional MIME type override. Null is treated as omitted."),
-});
+export type MaterializeFile = (
+  input: SandboxFileMaterializationInput,
+) => Promise<SandboxFileUpload>;
 
 const sendFilesDataSchema = z.object({
   channel_id: z.string().min(1),
@@ -63,8 +37,8 @@ const sendFilesResultSchema = juniorToolResultSchema.extend({
 type SendFilesResult = z.output<typeof sendFilesResultSchema>;
 
 function normalizeFiles(
-  files: FileInput[],
-): Array<{ path: string; filename?: string; mimeType?: string }> {
+  files: SandboxFileReferenceInput[],
+): SandboxFileMaterializationInput[] {
   return files.map((file) => ({
     path: file.path,
     ...(file.filename ? { filename: file.filename } : {}),
@@ -98,9 +72,11 @@ export function createSendFilesTool(
       "Send one or more sandbox files into the active Slack conversation. Use when the user asks to attach, send, or share files here, in this conversation, or in this thread. Do not use for ordinary assistant text, top-level channel posts, other named channels, inline @mentions, or pinging mentioned users.",
     inputSchema: z.object({
       files: z
-        .array(fileInputSchema)
+        .array(sandboxFileReferenceSchema)
         .min(1)
-        .describe("One or more sandbox files to include in the message."),
+        .describe(
+          "One or more existing sandbox files. Objects returned by imageGenerate or webFetch can be passed unchanged.",
+        ),
     }),
     outputSchema: sendFilesResultSchema,
     execute: async ({ files }) => {

--- a/packages/junior/src/chat/tools/sandbox/file-uploads.ts
+++ b/packages/junior/src/chat/tools/sandbox/file-uploads.ts
@@ -3,11 +3,72 @@ import { runNonInteractiveCommand } from "@/chat/sandbox/noninteractive-command"
 import { SANDBOX_WORKSPACE_ROOT } from "@/chat/sandbox/paths";
 import type { SandboxWorkspace } from "@/chat/sandbox/workspace";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
+import { z } from "zod";
 
 /** Maximum single file size accepted by model-facing upload tools. */
 export const MAX_SANDBOX_FILE_UPLOAD_BYTES = 10 * 1024 * 1024;
 /** Sandbox directory for generated files that later tools can consume. */
 export const SANDBOX_ARTIFACTS_DIR = "/tmp/junior/artifacts";
+
+/** Canonical model-facing reference to a file that already exists in the sandbox. */
+export const sandboxFileReferenceSchema = z.object({
+  path: z
+    .string()
+    .min(1)
+    .describe(
+      "Exact source path of an existing sandbox file. Preserve paths returned by other tools unchanged; do not move or rewrite them before sending.",
+    ),
+  filename: z
+    .string()
+    .min(1)
+    .nullable()
+    .optional()
+    .describe(
+      "Optional filename override shown to the recipient. Null is treated as omitted.",
+    ),
+  mimeType: z
+    .string()
+    .min(1)
+    .nullable()
+    .optional()
+    .describe("Optional MIME type override. Null is treated as omitted."),
+  bytes: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .describe(
+      "Optional known file size returned by a producing tool. Sending tools validate the file contents directly.",
+    ),
+});
+
+/** Model input accepted anywhere an existing sandbox file can be referenced. */
+export type SandboxFileReferenceInput = z.input<
+  typeof sandboxFileReferenceSchema
+>;
+
+type WithoutNull<T> = {
+  [Key in keyof T]: Exclude<T[Key], null>;
+};
+
+/** Normalized projection consumed when materializing a sandbox file. */
+export type SandboxFileMaterializationInput = WithoutNull<
+  Omit<z.output<typeof sandboxFileReferenceSchema>, "bytes">
+>;
+
+/** Generated file reference whose path and metadata can be passed directly to sendFiles. */
+export const generatedArtifactFileRefSchema = sandboxFileReferenceSchema
+  .extend({
+    filename: z.string().min(1),
+    mimeType: z.string().min(1).optional(),
+    bytes: z.number().int().nonnegative(),
+  })
+  .strict();
+
+/** Fully materialized generated artifact returned to model-facing tools. */
+export type GeneratedArtifactFileRef = z.output<
+  typeof generatedArtifactFileRefSchema
+>;
 
 const MIME_BY_EXTENSION: Record<string, string> = {
   ".png": "image/png",
@@ -118,11 +179,7 @@ async function detectMimeType(
 /** Read and validate one sandbox file for Slack/file reply upload. */
 export async function readSandboxFileUpload(
   sandbox: SandboxWorkspace,
-  input: {
-    path: string;
-    filename?: string;
-    mimeType?: string;
-  },
+  input: SandboxFileMaterializationInput,
 ): Promise<SandboxFileUpload> {
   const targetPath = normalizeSandboxPath(input.path);
   const fileBuffer = await sandbox.readFileToBuffer({ path: targetPath });

--- a/packages/junior/src/chat/tools/sandbox/file-uploads.ts
+++ b/packages/junior/src/chat/tools/sandbox/file-uploads.ts
@@ -36,9 +36,10 @@ export const sandboxFileReferenceSchema = z.object({
     .number()
     .int()
     .nonnegative()
+    .nullable()
     .optional()
     .describe(
-      "Optional known file size returned by a producing tool. Sending tools validate the file contents directly.",
+      "Optional known file size returned by a producing tool. Null is treated as omitted; sending tools validate the file contents directly.",
     ),
 });
 

--- a/packages/junior/src/chat/tools/types.ts
+++ b/packages/junior/src/chat/tools/types.ts
@@ -18,6 +18,7 @@ import type { JuniorToolResult } from "@/chat/tool-support/structured-result";
 import type { LocalActor, Actor, SlackActor } from "@/chat/actor";
 import type { SlackActionToken } from "@/chat/slack/action-token";
 import type { ModelProfile } from "@/chat/model-profile";
+import type { GeneratedArtifactFileRef } from "@/chat/tools/sandbox/file-uploads";
 
 interface HandoffControl {
   /** Non-empty catalog with the default target first. */
@@ -44,14 +45,6 @@ export interface WebSearchToolDeps {
     query: string;
     max_results?: number;
   }) => Promise<JuniorToolResult> | JuniorToolResult;
-}
-
-/** Sandbox file handle returned to the model after a generated artifact is written. */
-export interface GeneratedArtifactFileRef {
-  bytes: number;
-  filename: string;
-  mimeType?: string;
-  path: string;
 }
 
 export interface ToolHooks {

--- a/packages/junior/src/chat/tools/web/fetch-tool.ts
+++ b/packages/junior/src/chat/tools/web/fetch-tool.ts
@@ -106,17 +106,11 @@ export function createWebFetchTool(
             url: safeUrl.toString(),
             media_type: contentType,
             bytes: bytes.byteLength,
-            images: artifactRefs.map((artifact) => ({
-              filename: artifact.filename,
-              path: artifact.path,
-              attachment_path: artifact.path,
-              media_type: artifact.mimeType,
-              bytes: artifact.bytes,
-            })),
+            images: artifactRefs,
             delivery:
               artifactRefs.length > 0
                 ? options.canSendFilesToActiveConversation
-                  ? "Fetched image was written to a sandbox path. Use sendFiles to share or attach the image in the active conversation."
+                  ? "Fetched images were written to sandbox paths. To share them, pass the returned image objects unchanged as sendFiles files."
                   : "Fetched image was written to a sandbox path, but this runtime has no file-send tool for the active conversation."
                 : "Fetched image bytes are available only in this tool result; this runtime has no file-send tool for the active conversation.",
           };

--- a/packages/junior/src/chat/tools/web/image-generate.ts
+++ b/packages/junior/src/chat/tools/web/image-generate.ts
@@ -10,6 +10,7 @@ import {
 } from "@/chat/pi/client";
 import { JUNIOR_PERSONALITY } from "@/chat/prompt";
 import { logInfo, logWarn } from "@/chat/logging";
+import { generatedArtifactFileRefSchema } from "@/chat/tools/sandbox/file-uploads";
 
 const DEFAULT_IMAGE_MODEL = "google/gemini-3-pro-image";
 
@@ -19,21 +20,7 @@ const imageGenerateOutputSchema = juniorToolResultSchema
     prompt: z.string(),
     enrichedPrompt: z.string(),
     image_count: z.number().int().nonnegative(),
-    images: z.array(
-      z
-        .object({
-          filename: z.string(),
-          path: z.string(),
-          attachment_path: z
-            .string()
-            .describe(
-              "Exact sandbox path to pass unchanged as sendFiles files[].path.",
-            ),
-          media_type: z.string().optional(),
-          bytes: z.number().int().nonnegative(),
-        })
-        .strict(),
-    ),
+    images: z.array(generatedArtifactFileRefSchema),
     delivery: z.string(),
   })
   .strict();
@@ -202,15 +189,9 @@ export function createImageGenerateTool(
           prompt,
           enrichedPrompt,
           image_count: artifactRefs.length,
-          images: artifactRefs.map((artifact) => ({
-            filename: artifact.filename,
-            path: artifact.path,
-            attachment_path: artifact.path,
-            media_type: artifact.mimeType,
-            bytes: artifact.bytes,
-          })),
+          images: artifactRefs,
           delivery: options.canSendFilesToActiveConversation
-            ? "Generated images were written to sandbox paths. To share one, pass its exact attachment_path unchanged as sendFiles files[].path."
+            ? "Generated images were written to sandbox paths. To share them, pass the returned image objects unchanged as sendFiles files."
             : "Generated images were written to sandbox paths, but this runtime has no file-send tool for the active conversation.",
         };
       }

--- a/packages/junior/tests/integration/slack-channel-tools.test.ts
+++ b/packages/junior/tests/integration/slack-channel-tools.test.ts
@@ -479,7 +479,14 @@ describe("slack channel tools", () => {
     );
 
     const result = await executeTool(tool, {
-      files: [{ path: "/tmp/report.txt", filename: null, mimeType: null }],
+      files: [
+        {
+          path: "/tmp/report.txt",
+          filename: null,
+          mimeType: null,
+          bytes: null,
+        },
+      ],
     });
 
     expect(result).toMatchObject({

--- a/packages/junior/tests/integration/slack-channel-tools.test.ts
+++ b/packages/junior/tests/integration/slack-channel-tools.test.ts
@@ -370,6 +370,35 @@ describe("slack channel tools", () => {
     ).not.toHaveProperty("initial_comment");
   });
 
+  it("accepts a generated artifact reference without translating its path", async () => {
+    const imageBytes = Buffer.from("image bytes");
+    const generatedArtifact = {
+      bytes: imageBytes.byteLength,
+      filename: "generated.png",
+      mimeType: "image/png",
+      path: "/tmp/junior/artifacts/generated.png",
+    };
+    const tool = createSendFilesTool(
+      createContext("share the generated image"),
+      createToolState(),
+      createMaterializeFile({ [generatedArtifact.path]: imageBytes }),
+    );
+
+    const result = await executeTool(tool, { files: [generatedArtifact] });
+
+    expect(
+      getCapturedSlackApiCalls("files.getUploadURLExternal")[0]?.params,
+    ).toMatchObject({
+      filename: generatedArtifact.filename,
+      length: String(imageBytes.byteLength),
+    });
+    expect(result).toMatchObject({
+      ok: true,
+      status: "success",
+      data: { file_count: 1 },
+    });
+  });
+
   it("uses source thread coordinates for thread delivery in assistant-context turns", async () => {
     const context = createContext("attach this here", {
       sourceChannelId: "D123",

--- a/packages/junior/tests/unit/web-fetch-tool.test.ts
+++ b/packages/junior/tests/unit/web-fetch-tool.test.ts
@@ -113,10 +113,10 @@ describe("web fetch tool", () => {
       media_type: "image/png",
       images: [
         {
+          bytes: Buffer.from("png-bytes").byteLength,
           filename: "logo.png",
+          mimeType: "image/png",
           path: "/tmp/junior/artifacts/logo.png",
-          attachment_path: "/tmp/junior/artifacts/logo.png",
-          media_type: "image/png",
         },
       ],
     });

--- a/packages/junior/tests/unit/web/image-generate.test.ts
+++ b/packages/junior/tests/unit/web/image-generate.test.ts
@@ -118,16 +118,25 @@ describe("createImageGenerateTool", () => {
     });
     expect(JSON.stringify(result)).not.toContain("sendFiles");
     const generated = result as {
-      images: Array<{ attachment_path: string }>;
+      images: Array<{
+        bytes: number;
+        filename: string;
+        mimeType: string;
+        path: string;
+      }>;
     };
     expect(generated).toMatchObject({
       images: [
-        expect.objectContaining({
-          attachment_path:
-            "/tmp/junior/artifacts/generated-image-1737000000000-1.png",
-        }),
+        {
+          bytes: 3,
+          filename: "generated-image-1737000000000-1.png",
+          mimeType: "image/png",
+          path: "/tmp/junior/artifacts/generated-image-1737000000000-1.png",
+        },
       ],
     });
+    expect(JSON.stringify(generated)).not.toContain("attachment_path");
+    expect(JSON.stringify(generated)).not.toContain("media_type");
     expect(uploads[0]?.filename).toContain("generated-image-1737000000000-1");
     expect(uploads[0]?.data).toEqual(Buffer.from("img"));
   });
@@ -152,7 +161,9 @@ describe("createImageGenerateTool", () => {
     expect(result).toMatchObject({
       ok: true,
       image_count: 1,
-      delivery: expect.stringContaining("sendFiles"),
+      delivery: expect.stringContaining(
+        "pass the returned image objects unchanged",
+      ),
     });
   });
 


### PR DESCRIPTION
Generated image and fetched-image results now expose the same canonical file
object accepted by `sendFiles`: `path`, `filename`, `mimeType`, and `bytes`.
This lets the agent pass the literal existing sandbox path through without
translating it into an invented upload-staging path. `sendFiles` treats the
reported size as advisory and still materializes and validates the real file
before uploading it.

This is an intentional hard cutover from the producer-only `attachment_path`
and per-image `media_type` aliases. Existing nullable `sendFiles` metadata and
active-conversation targeting remain unchanged. The delivery eval also accepts
a later successful upload when the agent repairs an earlier tool call, and the
regression coverage exercises the canonical object through real sandbox
materialization and the Slack upload boundary.
