### PR TITLE
fix(agent): Hide tool-call narration from replies

### DIFF
--- a/packages/junior-evals/evals/conversation/delivery.eval.ts
+++ b/packages/junior-evals/evals/conversation/delivery.eval.ts
@@ -2,7 +2,6 @@ import { describeEval, toolCalls } from "vitest-evals";
 import { beforeAll, expect } from "vitest";
 import { NO_REPLY_MARKER } from "@/chat/no-reply";
 import {
-  assistantTextContent,
   hasImageAttachment,
   mention,
   rubric,
@@ -61,67 +60,65 @@ describeEval("Slack Message Delivery", slackEvals, (it) => {
     expect(visibleThreadReplies(result.session)).toHaveLength(1);
   });
 
-  it("when a task needs a progress update, post complete messages rather than partial revisions", async ({
+  it("when a task needs a progress update, use status before one completed reply", async ({
     run,
   }) => {
     const result = await run({
       initialEvents: [
         mention(
-          "Tell me the current UTC time. Send a short update before you check, then give me the answer separately when you're done.",
+          "Tell me the current UTC time, and keep me posted while you check.",
         ),
       ],
       requireSandboxReady: false,
       criteria: rubric({
         pass: [
-          "The assistant sends a distinct progress update before a separate completed summary.",
-          "Each visible assistant message reads as a complete message at that point in the work.",
+          "The assistant returns the requested UTC time in one concise completed reply.",
         ],
         fail: [
-          "Do not expose token-by-token fragments, cumulative drafts, or repeated copies of the same reply.",
+          "Do not post intermediate process narration, cumulative drafts, or repeated copies of the reply.",
         ],
       }),
     });
 
-    expect(
-      toolCalls(result.session).some((call) => call.name === "systemTime"),
-    ).toBe(true);
-    const replies = visibleThreadReplies(result.session);
-    expect(replies.length).toBeGreaterThanOrEqual(2);
-    const replyTexts = replies.map((reply) =>
-      assistantTextContent(reply.content).trim(),
-    );
-    expect(new Set(replyTexts).size).toBe(replyTexts.length);
+    const callNames = toolCalls(result.session).map((call) => call.name);
+    expect(callNames).toContain("reportProgress");
+    expect(callNames).toContain("systemTime");
+    expect(visibleThreadReplies(result.session)).toHaveLength(1);
   });
 
-  it("when a generated image should be shared here, send it to the thread", async ({
+  it("when asked to show an image, attach it without process chatter", async ({
     run,
   }) => {
     const result = await run({
       overrides: { mock_image_generation: true },
-      initialEvents: [
-        mention("make a small image of a launch checklist and share it here"),
-      ],
+      initialEvents: [mention("show me an image of a red panda")],
+      criteria: rubric({
+        pass: [
+          "Any visible text is limited to at most one concise acknowledgement that the requested image was delivered.",
+        ],
+        fail: [
+          "Do not narrate image generation, file lookup, attachment paths, permission checks, retries, or other internal process steps.",
+          "Do not post multiple progress or troubleshooting messages before the image.",
+        ],
+      }),
     });
 
-    expect(toolCalls(result.session)).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ name: "imageGenerate" }),
-        expect.objectContaining({
-          name: "sendFiles",
-        }),
-      ]),
+    const imageGenerateCalls = toolCalls(result.session).filter(
+      (call) => call.name === "imageGenerate",
     );
-    expect(toolCalls(result.session)).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: "sendFiles",
-          status: "ok",
-          result: expect.objectContaining({ ok: true, status: "success" }),
-        }),
-      ]),
+    const sendFilesCalls = toolCalls(result.session).filter(
+      (call) => call.name === "sendFiles",
     );
+
+    expect(imageGenerateCalls).toHaveLength(1);
+    expect(sendFilesCalls).toEqual([
+      expect.objectContaining({
+        status: "ok",
+        result: expect.objectContaining({ ok: true, status: "success" }),
+      }),
+    ]);
     expect(hasImageAttachment(result.session)).toBe(true);
     expect(visibleAssistantText(result.session)).not.toContain(NO_REPLY_MARKER);
-    expect(visibleThreadReplies(result.session).length).toBeGreaterThan(0);
+    expect(visibleThreadReplies(result.session).length).toBeLessThanOrEqual(1);
   });
 });

--- a/packages/junior/src/chat/README.md
+++ b/packages/junior/src/chat/README.md
@@ -15,8 +15,9 @@ file.
 4. `runtime/` prepares and orchestrates the run; `agent/` owns Pi execution.
 5. Tools, plugins, credentials, sandbox, and MCP operate within harness-owned
    actor and destination context.
-6. `agent/` emits every completed visible assistant message through one awaited
-   delivery port; provider adapters deliver and record each message in order.
+6. `agent/` emits every completed, tool-free visible assistant message through
+   one awaited delivery port; provider adapters deliver and record each message
+   in order. Tool-bearing assistant text remains internal to the agent loop.
 7. The completed run result supplies diagnostics and artifacts; successful
    delivery or intentional no-reply completion commits the durable turn outcome.
 
@@ -59,8 +60,10 @@ delegation without becoming the execution actor or a general task owner.
 
 ## Invariants
 
-- Each completed visible assistant message is delivered before the run advances;
-  assistant output handling settles before the turn is finalized.
+- Each completed tool-free visible assistant message is delivered before the
+  run advances; assistant output handling settles before the turn is finalized.
+- Tool-bearing assistant text stays in agent history but is not destination
+  output; explicit progress uses the runtime status surface.
 - Tool failures remain internal agent-loop data unless the final result exposes
   an appropriate diagnostic.
 - Durable state is committed before acknowledging queue work or yielding.

--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -5,9 +5,10 @@
  * runtime/ingress code has parsed and routed the request. Wires the phase
  * modules (session restore, skills, tools, prompt, resume), runs the Pi
  * agent with the inline provider retry loop, and translates expected run
- * endings into `AgentRunOutcome` values. It emits every completed visible
- * assistant message through the delivery port; the result carries diagnostics,
- * artifacts, and transcript state for destination-owned completion.
+ * endings into `AgentRunOutcome` values. It emits every completed, tool-free
+ * visible assistant message through the delivery port; the result carries
+ * diagnostics, artifacts, and transcript state for destination-owned
+ * completion.
  */
 import { Agent, type AgentLoopTurnUpdate } from "@earendil-works/pi-agent-core";
 import { isRetryableAssistantError } from "@earendil-works/pi-ai";
@@ -620,7 +621,7 @@ async function executeAgentRunInPrivacyContext(
     let assistantMessageDeliveryError:
       | AssistantMessageDeliveryError
       | undefined;
-    /** Deliver one completed visible message before the agent advances. */
+    /** Deliver one completed tool-free visible message before the agent advances. */
     const deliverAssistantMessage = async (
       message: Parameters<typeof extractAssistantText>[0],
     ): Promise<void> => {

--- a/packages/junior/src/chat/agent/request.ts
+++ b/packages/junior/src/chat/agent/request.ts
@@ -140,12 +140,12 @@ export interface AgentRunObservers {
   onStatus?: (status: AssistantStatusSpec) => void | Promise<void>;
 }
 
-/** One completed assistant message ready for destination delivery. */
+/** One completed tool-free assistant message ready for destination delivery. */
 export interface AgentAssistantMessage {
   text: string;
 }
 
-/** Delivers completed assistant messages in model order. */
+/** Delivers completed tool-free assistant messages in model order. */
 export interface AgentRunDelivery {
   onAssistantMessage: (message: AgentAssistantMessage) => void | Promise<void>;
 }

--- a/packages/junior/src/chat/local/README.md
+++ b/packages/junior/src/chat/local/README.md
@@ -10,10 +10,10 @@ provider mailbox worker.
 - Conversation IDs use `local:<workspace-key>:<conversation-slug>`.
 - Source context is local, the credential actor is the `local-cli` system actor,
   and Slack-only authorization or delivery surfaces are disabled.
-- User input is persisted before execution; each completed assistant message is
-  written to stdout and recorded in conversation order. Post-delivery state is
-  attempted immediately without blocking later tools, then persisted again at
-  turn completion.
+- User input is persisted before execution; each completed tool-free assistant
+  message is written to stdout and recorded in conversation order. Text emitted
+  alongside tool calls remains internal. Post-delivery state is attempted
+  immediately, then persisted again at turn completion.
 - Each invocation uses a collision-resistant turn ID independent of transcript
   length. It records `turn_started` after durable input, then a terminal
   success, no-reply, or privacy-safe failure after the owning boundary.

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -4,7 +4,7 @@
  * This module owns the Slack-free execution boundary for CLI-originated turns:
  * it persists local conversation state, invokes the shared agent runner with
  * a local destination, and only commits assistant delivery after the CLI sink
- * accepts each completed assistant message.
+ * accepts each completed tool-free assistant message.
  */
 import type { AgentRunResult } from "@/chat/services/turn-result";
 import { randomUUID } from "node:crypto";

--- a/packages/junior/src/chat/runtime/README.md
+++ b/packages/junior/src/chat/runtime/README.md
@@ -10,10 +10,11 @@ directory owns product orchestration around it.
   cooperatively yield, or fail.
 - Silence is explicit; absence of model text is not automatically a successful
   silent outcome.
-- Every completed assistant message with visible text is delivered as its own
-  destination reply. Thinking and raw tool-call parts remain internal.
-- Assistant delivery is awaited before the run advances; tool-bearing messages
-  are delivered before their tool batch executes.
+- Every completed tool-free assistant message with visible text is delivered as
+  its own destination reply. Thinking, tool calls, and text emitted alongside
+  tool calls remain internal.
+- Assistant delivery is awaited before the run advances. Explicit progress uses
+  the runtime status surface rather than tool-bearing assistant text.
 - The runtime records each assistant message only after delivery succeeds.
 - Resumed runs continue the same durable turn and must not repeat already
   committed side effects.

--- a/packages/junior/src/chat/services/turn-result.ts
+++ b/packages/junior/src/chat/services/turn-result.ts
@@ -168,16 +168,18 @@ function getVisibleAssistantText(rawText: string): string | undefined {
   return text;
 }
 
-/** Return the destination-visible text from one completed assistant message. */
+/** Return destination-visible text from one completed tool-free assistant message. */
 export function getAssistantMessageText(
   message: Parameters<typeof extractAssistantText>[0],
 ): string | undefined {
+  if (message.content.some((part) => part.type === "toolCall")) {
+    return undefined;
+  }
   const text = getVisibleAssistantText(extractAssistantText(message));
   if (!text) {
     return undefined;
   }
-  const hasToolCall = message.content.some((part) => part.type === "toolCall");
-  return !hasToolCall && isExecutionEscapeResponse(text) ? undefined : text;
+  return isExecutionEscapeResponse(text) ? undefined : text;
 }
 
 /** Process raw agent messages into a structured AgentRunResult. */

--- a/packages/junior/src/chat/slack/README.md
+++ b/packages/junior/src/chat/slack/README.md
@@ -15,8 +15,10 @@ runtime orchestration.
 
 ## Delivery
 
-- Post each completed assistant message in the originating conversation
-  context, preserving model message boundaries.
+- Post each completed tool-free assistant message in the originating
+  conversation context, preserving destination-visible model message
+  boundaries. Tool-bearing assistant text remains agent history; explicit
+  progress uses the status surface.
 - Translate Junior Markdown to Slack `mrkdwn` only at the outbound boundary.
 - Continue oversized replies without splitting code fences into invalid
   fragments.

--- a/packages/junior/src/chat/task-execution/README.md
+++ b/packages/junior/src/chat/task-execution/README.md
@@ -22,8 +22,9 @@ source of truth.
 2. The worker validates the queue callback and acquires the conversation lease.
 3. It drains available mailbox messages into durable agent history.
 4. Runtime advances the turn until completion, auth pause, cooperative yield,
-   or terminal failure, delivering and recording completed assistant messages
-   as it advances.
+   or terminal failure, delivering and recording completed tool-free assistant
+   messages as it advances. Tool-bearing assistant text remains agent history;
+   explicit progress uses the status surface.
 5. Before yielding, the worker commits a safe history boundary, sends another
    nudge, and releases the lease.
 6. Terminal delivery or intentional no-reply completion records the delivered

--- a/packages/junior/tests/integration/runtime/agent-run-model-handoff.test.ts
+++ b/packages/junior/tests/integration/runtime/agent-run-model-handoff.test.ts
@@ -303,7 +303,7 @@ describe("executeAgentRun model handoff", () => {
     expect(observations.summaryCalls).toBe(1);
   });
 
-  it("delivers completed assistant messages in model order", async () => {
+  it("delivers only the tool-free assistant message after tool use", async () => {
     observations.progressTool = true;
     const delivered: Array<{ text: string }> = [];
     const conversationId = "local:test:assistant-message-delivery";
@@ -324,13 +324,10 @@ describe("executeAgentRun model handoff", () => {
     });
 
     expect(outcome.status).toBe("completed");
-    expect(delivered).toEqual([
-      { text: "Let me do that now." },
-      { text: "Handoff model completed it." },
-    ]);
+    expect(delivered).toEqual([{ text: "Handoff model completed it." }]);
   });
 
-  it("propagates delivery failure before the agent executes the tool", async () => {
+  it("executes tools before a terminal assistant delivery failure", async () => {
     observations.progressTool = true;
     const deliveryError = new Error("destination unavailable");
     const conversationId = "local:test:assistant-message-delivery-failure";
@@ -356,8 +353,8 @@ describe("executeAgentRun model handoff", () => {
         },
       }),
     ).rejects.toBe(deliveryError);
-    expect(observations.providerCalls).toBe(1);
-    expect(observations.statuses).not.toContain("Checking details");
+    expect(observations.providerCalls).toBe(2);
+    expect(observations.statuses).toContain("Checking details");
   });
 
   it("preserves explicit agent reasoning across handoff without routing", async () => {

--- a/packages/junior/tests/unit/turn-result.test.ts
+++ b/packages/junior/tests/unit/turn-result.test.ts
@@ -86,10 +86,10 @@ describe("getAssistantMessageText", () => {
     ).toBeUndefined();
   });
 
-  it("keeps progress text attached to a tool call", () => {
+  it("suppresses text attached to a tool call", () => {
     expect(
       getAssistantMessageText(assistantMessage("Let me do that now.", true)),
-    ).toBe("Let me do that now.");
+    ).toBeUndefined();
   });
 
   it("keeps prose that quotes a tool payload fragment", () => {


### PR DESCRIPTION
Assistant text emitted in the same model message as a tool call now stays in the Pi transcript instead of being posted to Slack or stdout. Tool-free completed replies are still delivered normally, and explicit progress continues through the status surface.

This prevents routine tool loops and retries from producing a chain of process messages. The Slack delivery eval now covers a generated-image request end to end, including a single successful generation/upload and at most one visible acknowledgement.
