### PR TITLE
fix(memory): Reuse semantic preference duplicates

### DIFF
--- a/packages/junior-evals/evals/memory/helpers.ts
+++ b/packages/junior-evals/evals/memory/helpers.ts
@@ -76,6 +76,7 @@ export const evalMemoryModel: PluginModel = {
             input.prompt,
             "",
             "Return only raw JSON in exactly one of these shapes:",
+            '{"decision":"duplicate","duplicateId":"existing-memory-id"}',
             '{"decision":"supersedes_old","supersededIds":["existing-memory-id"]}',
             '{"decision":"distinct"}',
             '{"decision":"uncertain"}',
@@ -112,6 +113,20 @@ export async function readMemories(thread: MemoryThread) {
     .from(juniorMemoryMemories)
     .orderBy(juniorMemoryMemories.createdAtMs, juniorMemoryMemories.id);
   return rows.filter((memory) => memory.sourceKey === memorySourceKey(thread));
+}
+
+/** Read the durable memories currently eligible for recall in one eval thread. */
+export async function readActiveMemories(
+  thread: MemoryThread,
+  nowMs = Date.now(),
+) {
+  return (await readMemories(thread)).filter(
+    (memory) =>
+      memory.archivedAtMs === null &&
+      memory.supersededAtMs === null &&
+      memory.supersededById === null &&
+      (memory.expiresAtMs === null || memory.expiresAtMs > nowMs),
+  );
 }
 
 export async function clearMemories() {

--- a/packages/junior-evals/evals/memory/helpers.ts
+++ b/packages/junior-evals/evals/memory/helpers.ts
@@ -80,7 +80,7 @@ export const evalMemoryModel: PluginModel = {
             '{"decision":"supersedes_old","supersededIds":["existing-memory-id"]}',
             '{"decision":"distinct"}',
             '{"decision":"uncertain"}',
-            'Use camelCase keys exactly, including "supersededIds". Do not wrap it in markdown.',
+            'Use camelCase keys exactly, including "duplicateId" and "supersededIds". Do not wrap it in markdown.',
           ].join("\n"),
           timestamp: Date.now(),
         },
@@ -88,6 +88,17 @@ export const evalMemoryModel: PluginModel = {
       temperature: 0,
     });
     const parsed = JSON.parse(text) as unknown;
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      "duplicate_id" in parsed &&
+      !("duplicateId" in parsed)
+    ) {
+      (parsed as Record<string, unknown>).duplicateId = (
+        parsed as Record<string, unknown>
+      ).duplicate_id;
+      delete (parsed as Record<string, unknown>).duplicate_id;
+    }
     if (
       parsed &&
       typeof parsed === "object" &&

--- a/packages/junior-evals/evals/memory/management.eval.ts
+++ b/packages/junior-evals/evals/memory/management.eval.ts
@@ -4,6 +4,7 @@ import { mention, rubric, slackEvals } from "../../src/helpers";
 import {
   clearMemories,
   memoryPluginOverrides,
+  readActiveMemories,
   readMemories,
   seedMemory,
 } from "./helpers";
@@ -79,17 +80,16 @@ describeEval("Memory Management", slackEvals, (it) => {
       ],
       criteria: rubric({
         pass: [
-          "The assistant acknowledges the preference naturally without creating a second remembered copy.",
+          "The assistant acknowledges that PR summaries should continue to put risks first.",
           "The assistant does not mention hidden storage fields, scope keys, or Slack ids.",
         ],
         fail: [
-          "Do not claim a new duplicate memory was saved.",
           "Do not ask the user for Slack ids, actor ids, scope names, or subject ids.",
         ],
       }),
     });
 
-    const rows = await readMemories(passiveDedupeThread);
+    const rows = await readActiveMemories(passiveDedupeThread);
     expect(rows).toEqual([
       expect.objectContaining({
         archivedAtMs: null,

--- a/packages/junior-evals/evals/memory/personal.eval.ts
+++ b/packages/junior-evals/evals/memory/personal.eval.ts
@@ -6,7 +6,9 @@ import {
   evalMemoryModel,
   expectActorMemorySemantics,
   memoryPluginOverrides,
+  readActiveMemories,
   readMemories,
+  seedMemory,
   visibleAssistantText,
 } from "./helpers";
 import { createMemoryAgent } from "../../../junior-memory/src/agent";
@@ -135,6 +137,50 @@ describeEval("Personal Memory", slackEvals, (it) => {
     });
   });
 
+  const explicitDuplicateThread = {
+    id: "thread-memory-explicit-duplicate",
+    channel_id: "CMEMORYEXPLICITDUPLICATE",
+    thread_ts: "17000000.000004",
+  };
+
+  it("when explicitly asked to remember an existing preference, acknowledge the existing memory", async ({
+    run,
+  }) => {
+    await clearMemories();
+    await seedMemory({
+      content: "Prefers PR summaries with risks first.",
+      idempotencyKey: "eval-memory-explicit-duplicate",
+      thread: explicitDuplicateThread,
+    });
+
+    await run({
+      overrides: memoryPluginOverrides,
+      initialEvents: [
+        mention(
+          "Please remember that I want risk notes at the start of PR summaries.",
+          { thread: explicitDuplicateThread },
+        ),
+      ],
+      criteria: rubric({
+        pass: [
+          "The assistant confirms that the preference is already remembered or remains remembered.",
+          "The assistant does not imply that a second or additional memory was created.",
+        ],
+        fail: [
+          "Do not claim that a new or additional memory was created when the preference was already remembered.",
+          "Do not expose hidden memory ids, scope keys, actor ids, or Slack ids.",
+        ],
+      }),
+    });
+
+    await expect(readActiveMemories(explicitDuplicateThread)).resolves.toEqual([
+      expect.objectContaining({
+        content: "Prefers PR summaries with risks first.",
+        scope: "personal",
+      }),
+    ]);
+  });
+
   it("when adjudicating preferences, distinguish duplicates, replacements, and additive preferences", async () => {
     const agent = createMemoryAgent(evalMemoryModel);
     const runtimeContext = {
@@ -204,5 +250,20 @@ describeEval("Personal Memory", slackEvals, (it) => {
       runtimeContext,
     });
     expect(additive).toEqual({ decision: "distinct" });
+
+    const sameTopicAdditive = await agent.adjudicateSupersession({
+      candidate: {
+        content: "Prefers PR summaries to name an owner for every risk.",
+        kind: "preference",
+      },
+      existingMemories: [
+        {
+          content: "Prefers PR summaries with risks first.",
+          id: "memory-existing-summary-order",
+        },
+      ],
+      runtimeContext,
+    });
+    expect(sameTopicAdditive).toEqual({ decision: "distinct" });
   }, 120_000);
 });

--- a/packages/junior-evals/evals/memory/personal.eval.ts
+++ b/packages/junior-evals/evals/memory/personal.eval.ts
@@ -135,7 +135,7 @@ describeEval("Personal Memory", slackEvals, (it) => {
     });
   });
 
-  it("when adjudicating preference supersession, distinguish replacement from additive preferences", async () => {
+  it("when adjudicating preferences, distinguish duplicates, replacements, and additive preferences", async () => {
     const agent = createMemoryAgent(evalMemoryModel);
     const runtimeContext = {
       conversationId: "slack:CMEMORYSUPERSESSION:17000000.000003",
@@ -172,6 +172,24 @@ describeEval("Personal Memory", slackEvals, (it) => {
       supersededIds: ["memory-old-language"],
     });
 
+    const duplicate = await agent.adjudicateSupersession({
+      candidate: {
+        content: "Wants meeting reminders 24 hours in advance.",
+        kind: "preference",
+      },
+      existingMemories: [
+        {
+          content: "Prefers calendar reminders one day before meetings.",
+          id: "memory-existing-reminder-timing",
+        },
+      ],
+      runtimeContext,
+    });
+    expect(duplicate).toEqual({
+      decision: "duplicate",
+      duplicateId: "memory-existing-reminder-timing",
+    });
+
     const additive = await agent.adjudicateSupersession({
       candidate: {
         content: "Prefers Slack updates in the morning.",
@@ -185,6 +203,6 @@ describeEval("Personal Memory", slackEvals, (it) => {
       ],
       runtimeContext,
     });
-    expect(additive.decision).not.toBe("supersedes_old");
+    expect(additive).toEqual({ decision: "distinct" });
   }, 120_000);
 });

--- a/packages/junior-memory/src/agent.ts
+++ b/packages/junior-memory/src/agent.ts
@@ -1,8 +1,10 @@
 import { actorSchema, type PluginModel } from "@sentry/junior-plugin-api";
 import { z } from "zod";
-import type {
-  MemorySupersessionDecision,
-  MemorySupersessionInput,
+import {
+  memorySupersessionDecisionSchema,
+  memorySupersessionInputSchema,
+  type MemorySupersessionDecision,
+  type MemorySupersessionInput,
 } from "./store";
 import {
   MEMORY_KINDS,
@@ -84,29 +86,6 @@ const extractSessionRequestSchema = z
       .min(1),
   })
   .strict();
-const supersessionRequestSchema = z
-  .object({
-    candidate: z
-      .object({
-        content: z.string().min(1),
-        kind: z.literal("preference"),
-      })
-      .strict(),
-    existingMemories: z
-      .array(
-        z
-          .object({
-            content: z.string().min(1),
-            id: z.string().min(1),
-          })
-          .strict(),
-      )
-      .min(1)
-      .max(10),
-    runtimeContext: memoryRuntimeContextSchema,
-  })
-  .strict();
-
 const expiresAtMsSchema = z
   .number()
   .finite()
@@ -186,20 +165,6 @@ const extractMemoriesResponseSchema = z
       ),
   })
   .strict();
-const supersessionDecisionResponseSchema = z.discriminatedUnion("decision", [
-  z
-    .object({
-      decision: z.literal("supersedes_old"),
-      supersededIds: z.array(z.string().min(1)).min(1).max(10),
-    })
-    .strict(),
-  z
-    .object({
-      decision: z.enum(["distinct", "uncertain"]),
-    })
-    .strict(),
-]);
-
 type MemoryReviewResponse = z.output<typeof memoryReviewResponseSchema>;
 type ExtractMemoriesResponse = z.output<typeof extractMemoriesResponseSchema>;
 
@@ -212,7 +177,7 @@ export type ExtractSessionRequest = z.output<
 export type ExtractedMemory = z.output<typeof extractedMemoryResultSchema>;
 
 export interface MemoryAgent {
-  /** Decide whether a new preference safely replaces active old preferences. */
+  /** Classify a new preference against related active preferences. */
   adjudicateSupersession(
     request: MemorySupersessionInput,
   ): Promise<MemorySupersessionDecision> | MemorySupersessionDecision;
@@ -238,11 +203,12 @@ const MEMORY_EXTRACTION_SYSTEM = [
   "Reject secrets, credentials, private or sensitive personal details, gossip, speculative claims about other people, assistant/system implementation details, vague references, and low-durability chatter.",
   "If no public, durable, self-contained memory remains after rewriting, return an empty memories array.",
 ].join("\n");
-const MEMORY_SUPERSESSION_SYSTEM = [
-  "You are Junior's memory supersession agent.",
-  "Decide whether a new actor preference clearly replaces existing active actor preferences.",
-  "Return supersedes_old only for obvious changed preferences about the same mutable slot.",
-  "If the facts are additive, different topics, duplicate, broader/narrower without direct replacement, or uncertain, do not supersede.",
+const MEMORY_PREFERENCE_ADJUDICATION_SYSTEM = [
+  "You are Junior's memory preference adjudication agent.",
+  "Classify how one new actor preference relates to existing active actor preferences.",
+  "Return duplicate when the same durable preference is merely phrased differently.",
+  "Return supersedes_old only for an obvious changed value in the same mutable preference slot.",
+  "Return distinct for additive preferences or different topics, and uncertain when the relationship is unclear.",
 ].join("\n");
 const CANONICAL_CONTENT_RULES = [
   "- Stored memory text must be a rewritten fact, not copied user wording or a sentence about who said it.",
@@ -478,10 +444,12 @@ function sessionExtractionPrompt(request: ExtractSessionRequest): string {
   ].join("\n");
 }
 
-function supersessionPrompt(request: MemorySupersessionInput): string {
+function preferenceAdjudicationPrompt(
+  request: MemorySupersessionInput,
+): string {
   return [
-    "<memory-supersession-input>",
-    "Decide whether the candidate preference clearly replaces one or more existing active preferences.",
+    "<memory-preference-adjudication-input>",
+    "Classify the candidate preference against the related active preferences.",
     "",
     runtimeDescription({
       runtimeContext: request.runtimeContext,
@@ -496,14 +464,16 @@ function supersessionPrompt(request: MemorySupersessionInput): string {
     "</existing-memories>",
     "",
     "<rules>",
+    "- Return duplicate when the candidate and one existing memory express the same durable preference or value with different wording.",
     "- Return supersedes_old only when the candidate and old memory describe the same mutable preference slot and the candidate is the newer value.",
     "- Examples of same mutable slot: preferred programming language, preferred review style, preferred notification cadence, preferred tool for a task.",
-    "- Do not supersede when the candidate is just more specific, an additional preference, a different task/context, or the same value phrased differently.",
+    "- Return distinct when the candidate is an additional preference or belongs to a different task or topic.",
+    "- Return uncertain when broader or narrower wording makes equivalence or replacement unclear.",
     "- Do not supersede memories from different topics even if they are both preferences.",
-    "- Only return ids that appear in existing-memories.",
+    "- duplicateId and supersededIds may contain only ids from existing-memories.",
     "- If unsure, return uncertain.",
     "</rules>",
-    "</memory-supersession-input>",
+    "</memory-preference-adjudication-input>",
   ].join("\n");
 }
 
@@ -511,18 +481,14 @@ function supersessionPrompt(request: MemorySupersessionInput): string {
 export function createMemoryAgent(model: PluginModel): MemoryAgent {
   return {
     async adjudicateSupersession(rawRequest) {
-      const request = supersessionRequestSchema.parse(
-        rawRequest,
-      ) as MemorySupersessionInput;
+      const request = memorySupersessionInputSchema.parse(rawRequest);
       const result = await model.completeObject({
-        schema: supersessionDecisionResponseSchema,
-        system: MEMORY_SUPERSESSION_SYSTEM,
-        prompt: supersessionPrompt(request),
+        schema: memorySupersessionDecisionSchema,
+        system: MEMORY_PREFERENCE_ADJUDICATION_SYSTEM,
+        prompt: preferenceAdjudicationPrompt(request),
         maxTokens: 400,
       });
-      return supersessionDecisionResponseSchema.parse(
-        result.object,
-      ) as MemorySupersessionDecision;
+      return memorySupersessionDecisionSchema.parse(result.object);
     },
     async extractSessionMemories(rawRequest) {
       const request = extractSessionRequestSchema.parse(rawRequest);

--- a/packages/junior-memory/src/store.ts
+++ b/packages/junior-memory/src/store.ts
@@ -50,14 +50,14 @@ const DEFAULT_LIST_LIMIT = 50;
 const DEFAULT_SEARCH_LIMIT = 10;
 const DEFAULT_EXPIRED_ARCHIVE_LIMIT = 100;
 const HIGH_CONFIDENCE_DUPLICATE_DISTANCE = 0.015;
-const SUPERSESSION_CANDIDATE_LIMIT = 10;
+const PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT = 10;
 const VECTOR_SEARCH_OVERFETCH = 4;
 const MAX_MEMORY_CONTENT_CHARS = 4_000;
 const EMBEDDING_METRIC = "cosine";
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const RELEVANCE_NEAR_TIE_DELTA = 0.01;
 const SOURCE_CHANNEL_BOOST = 0.05;
-const SUPERSESSION_STOP_TERMS = new Set([
+const PREFERENCE_ADJUDICATION_STOP_TERMS = new Set([
   "and",
   "for",
   "prefer",
@@ -206,6 +206,65 @@ const embeddingResultSchema = z
     vectors: z.array(embeddingVectorSchema),
   })
   .strict();
+const memorySupersessionCandidateSchema = z
+  .object({
+    content: z.string().min(1),
+    id: z.string().min(1),
+  })
+  .strict();
+const memorySupersessionCandidatesSchema = z
+  .tuple([memorySupersessionCandidateSchema], memorySupersessionCandidateSchema)
+  .refine(
+    (candidates) =>
+      candidates.length <= PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT,
+    { message: "Too many preference candidates." },
+  );
+const supersededIdsSchema = z
+  .tuple([z.string().min(1)], z.string().min(1))
+  .refine((ids) => ids.length <= PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT, {
+    message: "Too many superseded memory ids.",
+  });
+
+/** Validated preference comparison input supplied to a supersession decider. */
+export const memorySupersessionInputSchema = z
+  .object({
+    candidate: z
+      .object({
+        content: z.string().min(1),
+        kind: z.literal("preference"),
+      })
+      .strict(),
+    existingMemories: memorySupersessionCandidatesSchema,
+    runtimeContext: memoryRuntimeContextSchema,
+  })
+  .strict();
+
+/**
+ * Validated preference decision whose referenced ids must come from the
+ * supplied existing memories.
+ */
+export const memorySupersessionDecisionSchema = z.discriminatedUnion(
+  "decision",
+  [
+    z
+      .object({
+        decision: z.literal("duplicate"),
+        duplicateId: z.string().min(1),
+      })
+      .strict(),
+    z
+      .object({
+        decision: z.literal("supersedes_old"),
+        supersededIds: supersededIdsSchema,
+      })
+      .strict(),
+    z
+      .object({
+        decision: z.enum(["distinct", "uncertain"]),
+      })
+      .strict(),
+  ],
+);
 
 export type MemoryRecord = z.output<typeof memoryRecordSchema>;
 export type CreateMemoryInput = z.output<typeof createMemoryInputSchema>;
@@ -240,35 +299,16 @@ export interface MemoryEmbeddingProvider {
   }>;
 }
 
-export interface MemorySupersessionInput {
-  candidate: {
-    content: string;
-    kind: "preference";
-  };
-  existingMemories: [
-    {
-      content: string;
-      id: string;
-    },
-    ...Array<{
-      content: string;
-      id: string;
-    }>,
-  ];
-  runtimeContext: MemoryRuntimeContext;
-}
+export type MemorySupersessionInput = z.output<
+  typeof memorySupersessionInputSchema
+>;
 
-export type MemorySupersessionDecision =
-  | {
-      decision: "supersedes_old";
-      supersededIds: [string, ...string[]];
-    }
-  | {
-      decision: "distinct" | "uncertain";
-    };
+export type MemorySupersessionDecision = z.output<
+  typeof memorySupersessionDecisionSchema
+>;
 
 export interface MemorySupersessionDecider {
-  /** Decide whether a new preference clearly replaces active old preferences. */
+  /** Classify a new preference against related active preferences. */
   adjudicateSupersession(
     input: MemorySupersessionInput,
   ): Promise<MemorySupersessionDecision> | MemorySupersessionDecision;
@@ -792,7 +832,11 @@ async function rememberDuplicateIdempotency(args: {
     .onConflictDoNothing();
 }
 
-async function listSupersessionCandidates(args: {
+/**
+ * Prefer lexical and vector matches, then fill the bounded model input with
+ * recent active preferences so text shape cannot veto semantic adjudication.
+ */
+async function listPreferenceAdjudicationCandidates(args: {
   content: string;
   db: MemoryDb;
   embedding?: MemoryEmbedding;
@@ -803,7 +847,7 @@ async function listSupersessionCandidates(args: {
 }): Promise<MemoryRecord[]> {
   const predicate = activeScopedSubjectPredicate(args);
   const terms = searchTerms(args.content).filter(
-    (term) => !SUPERSESSION_STOP_TERMS.has(term),
+    (term) => !PREFERENCE_ADJUDICATION_STOP_TERMS.has(term),
   );
   const lexicalRows =
     terms.length > 0
@@ -837,7 +881,7 @@ async function listSupersessionCandidates(args: {
     .map((candidate) => candidate.memory);
 
   const vectorCandidates = args.embedding
-    ? await listVectorSupersessionCandidates({
+    ? await listVectorPreferenceAdjudicationCandidates({
         db: args.db,
         embedding: args.embedding,
         kind: args.kind,
@@ -848,15 +892,32 @@ async function listSupersessionCandidates(args: {
     : [];
   const byId = new Map<string, MemoryRecord>();
   for (const memory of [...lexicalCandidates, ...vectorCandidates]) {
-    if (byId.size >= SUPERSESSION_CANDIDATE_LIMIT) {
+    if (byId.size >= PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT) {
       break;
     }
     byId.set(memory.id, memory);
   }
+  if (byId.size < PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT) {
+    const fallbackRows = await args.db
+      .select()
+      .from(juniorMemoryMemories)
+      .where(predicate)
+      .orderBy(
+        desc(juniorMemoryMemories.createdAtMs),
+        asc(juniorMemoryMemories.id),
+      )
+      .limit(PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT);
+    for (const memory of fallbackRows.map(parseMemoryRow)) {
+      byId.set(memory.id, memory);
+      if (byId.size >= PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT) {
+        break;
+      }
+    }
+  }
   return [...byId.values()];
 }
 
-async function listVectorSupersessionCandidates(args: {
+async function listVectorPreferenceAdjudicationCandidates(args: {
   db: MemoryDb;
   embedding: MemoryEmbedding;
   kind: MemoryRecord["kind"];
@@ -893,7 +954,7 @@ async function listVectorSupersessionCandidates(args: {
       desc(juniorMemoryMemories.createdAtMs),
       asc(juniorMemoryMemories.id),
     )
-    .limit(SUPERSESSION_CANDIDATE_LIMIT);
+    .limit(PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT);
   return rows.flatMap((row) => {
     if (hashEmbeddedContent(row.memory.content) !== row.contentHash) {
       return [];
@@ -902,26 +963,28 @@ async function listVectorSupersessionCandidates(args: {
   });
 }
 
-async function decideSupersededIds(args: {
+/**
+ * Normalize a preference decision to known duplicate or supersession targets.
+ * Uncertainty, invalid ids, and model failure leave existing memories active.
+ */
+async function adjudicatePreferenceCandidate(args: {
   candidates: MemoryRecord[];
   content: string;
   decider: MemorySupersessionDecider | undefined;
   kind: MemoryRecord["kind"];
   runtimeContext: MemoryRuntimeContext;
-}): Promise<string[]> {
-  // Supersession is conservative: model uncertainty or decider failure leaves
-  // both memories active rather than hiding a possibly valid old preference.
-  if (
-    args.kind !== "preference" ||
-    !args.decider ||
-    args.candidates.length === 0
-  ) {
-    return [];
+}): Promise<{ duplicate?: MemoryRecord; supersededIds: string[] }> {
+  const [firstCandidate, ...remainingCandidates] = args.candidates;
+  if (args.kind !== "preference" || !args.decider || !firstCandidate) {
+    return { supersededIds: [] };
   }
-  const existingMemories = args.candidates.map((memory) => ({
-    content: memory.content,
-    id: memory.id,
-  })) as MemorySupersessionInput["existingMemories"];
+  const existingMemories: MemorySupersessionInput["existingMemories"] = [
+    { content: firstCandidate.content, id: firstCandidate.id },
+    ...remainingCandidates.map((memory) => ({
+      content: memory.content,
+      id: memory.id,
+    })),
+  ];
   const candidateIds = new Set(args.candidates.map((memory) => memory.id));
   try {
     const decision = await args.decider.adjudicateSupersession({
@@ -932,12 +995,24 @@ async function decideSupersededIds(args: {
       existingMemories,
       runtimeContext: args.runtimeContext,
     });
-    if (decision.decision !== "supersedes_old") {
-      return [];
+    if (decision.decision === "duplicate") {
+      return {
+        duplicate: args.candidates.find(
+          (memory) => memory.id === decision.duplicateId,
+        ),
+        supersededIds: [],
+      };
     }
-    return decision.supersededIds.filter((id) => candidateIds.has(id));
+    if (decision.decision === "supersedes_old") {
+      return {
+        supersededIds: decision.supersededIds.filter((id) =>
+          candidateIds.has(id),
+        ),
+      };
+    }
+    return { supersededIds: [] };
   } catch {
-    return [];
+    return { supersededIds: [] };
   }
 }
 
@@ -1295,7 +1370,7 @@ export function createMemoryStore(
       supersessionDecider &&
       (input.expiresAtMs === undefined || input.expiresAtMs > nowMs)
     ) {
-      const supersessionCandidates = await listSupersessionCandidates({
+      const preferenceCandidates = await listPreferenceAdjudicationCandidates({
         content,
         db,
         ...(candidateEmbedding ? { embedding: candidateEmbedding } : {}),
@@ -1304,13 +1379,34 @@ export function createMemoryStore(
         scope,
         subject,
       });
-      supersededIds = await decideSupersededIds({
-        candidates: supersessionCandidates,
+      const adjudication = await adjudicatePreferenceCandidate({
+        candidates: preferenceCandidates,
         content,
         decider: supersessionDecider,
         kind: input.kind,
         runtimeContext,
       });
+      if (adjudication.duplicate) {
+        await rememberDuplicateIdempotency({
+          content,
+          db,
+          duplicate: adjudication.duplicate,
+          idempotencyKey: input.idempotencyKey,
+          nowMs,
+          runtimeContext,
+          scope,
+          subject,
+        });
+        await storeEmbedding({
+          content: adjudication.duplicate.content,
+          db,
+          embedder,
+          memoryId: adjudication.duplicate.id,
+          nowMs,
+        });
+        return { created: false, memory: adjudication.duplicate };
+      }
+      supersededIds = adjudication.supersededIds;
     }
 
     const id = randomUUID();

--- a/packages/junior-memory/src/store.ts
+++ b/packages/junior-memory/src/store.ts
@@ -51,6 +51,7 @@ const DEFAULT_SEARCH_LIMIT = 10;
 const DEFAULT_EXPIRED_ARCHIVE_LIMIT = 100;
 const HIGH_CONFIDENCE_DUPLICATE_DISTANCE = 0.015;
 const PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT = 10;
+const PREFERENCE_ADJUDICATION_VECTOR_LIMIT = 5;
 const VECTOR_SEARCH_OVERFETCH = 4;
 const MAX_MEMORY_CONTENT_CHARS = 4_000;
 const EMBEDDING_METRIC = "cosine";
@@ -817,7 +818,7 @@ async function rememberDuplicateIdempotency(args: {
     .onConflictDoNothing();
 }
 
-/** Select semantic preference candidates, falling back to recency without embeddings. */
+/** Select semantic preferences, then fill the window by recency for unembedded records. */
 async function listPreferenceAdjudicationCandidates(args: {
   db: MemoryDb;
   embedding?: MemoryEmbedding;
@@ -825,30 +826,39 @@ async function listPreferenceAdjudicationCandidates(args: {
   scope: ResolvedMemoryScope;
   subject: ResolvedMemorySubject;
 }): Promise<MemoryRecord[]> {
-  if (args.embedding) {
-    return await listVectorPreferenceAdjudicationCandidates({
-      db: args.db,
-      embedding: args.embedding,
-      nowMs: args.nowMs,
-      scope: args.scope,
-      subject: args.subject,
-    });
-  }
-  const rows = await args.db
-    .select()
-    .from(juniorMemoryMemories)
-    .where(
-      activeScopedSubjectPredicate({
-        ...args,
-        kind: "preference",
-      }),
-    )
-    .orderBy(
-      desc(juniorMemoryMemories.createdAtMs),
-      asc(juniorMemoryMemories.id),
-    )
-    .limit(PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT);
-  return rows.map(parseMemoryRow);
+  const vectorCandidates = args.embedding
+    ? await listVectorPreferenceAdjudicationCandidates({
+        db: args.db,
+        embedding: args.embedding,
+        nowMs: args.nowMs,
+        scope: args.scope,
+        subject: args.subject,
+      })
+    : [];
+  const recentCandidates = (
+    await args.db
+      .select()
+      .from(juniorMemoryMemories)
+      .where(
+        activeScopedSubjectPredicate({
+          ...args,
+          kind: "preference",
+        }),
+      )
+      .orderBy(
+        desc(juniorMemoryMemories.createdAtMs),
+        asc(juniorMemoryMemories.id),
+      )
+      .limit(PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT)
+  ).map(parseMemoryRow);
+  return [
+    ...new Map(
+      [...vectorCandidates, ...recentCandidates].map((memory) => [
+        memory.id,
+        memory,
+      ]),
+    ).values(),
+  ].slice(0, PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT);
 }
 
 async function listVectorPreferenceAdjudicationCandidates(args: {
@@ -887,7 +897,7 @@ async function listVectorPreferenceAdjudicationCandidates(args: {
       desc(juniorMemoryMemories.createdAtMs),
       asc(juniorMemoryMemories.id),
     )
-    .limit(PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT);
+    .limit(PREFERENCE_ADJUDICATION_VECTOR_LIMIT);
   return rows.flatMap((row) => {
     if (hashEmbeddedContent(row.memory.content) !== row.contentHash) {
       return [];

--- a/packages/junior-memory/src/store.ts
+++ b/packages/junior-memory/src/store.ts
@@ -57,17 +57,6 @@ const EMBEDDING_METRIC = "cosine";
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const RELEVANCE_NEAR_TIE_DELTA = 0.01;
 const SOURCE_CHANNEL_BOOST = 0.05;
-const PREFERENCE_ADJUDICATION_STOP_TERMS = new Set([
-  "and",
-  "for",
-  "prefer",
-  "prefers",
-  "preference",
-  "the",
-  "use",
-  "uses",
-  "with",
-]);
 
 export type MemoryDb = PgDatabase<PgQueryResultHKT, typeof memorySqlSchema>;
 
@@ -828,103 +817,43 @@ async function rememberDuplicateIdempotency(args: {
     .onConflictDoNothing();
 }
 
-/**
- * Reserve the best lexical, vector, and recent matches, then fill the bounded
- * model input so one retrieval strategy cannot veto semantic adjudication.
- */
+/** Select semantic preference candidates, falling back to recency without embeddings. */
 async function listPreferenceAdjudicationCandidates(args: {
-  content: string;
   db: MemoryDb;
   embedding?: MemoryEmbedding;
-  kind: MemoryRecord["kind"];
   nowMs: number;
   scope: ResolvedMemoryScope;
   subject: ResolvedMemorySubject;
 }): Promise<MemoryRecord[]> {
-  const predicate = activeScopedSubjectPredicate(args);
-  const terms = searchTerms(args.content).filter(
-    (term) => !PREFERENCE_ADJUDICATION_STOP_TERMS.has(term),
-  );
-  const lexicalRows =
-    terms.length > 0
-      ? await args.db
-          .select()
-          .from(juniorMemoryMemories)
-          .where(
-            and(
-              predicate,
-              or(
-                ...terms.map((term) =>
-                  ilike(juniorMemoryMemories.content, `%${term}%`),
-                ),
-              ),
-            ),
-          )
-      : [];
-  const lexicalCandidates = lexicalRows
-    .map(parseMemoryRow)
-    .map((memory) => ({
-      memory,
-      score: searchScore(memory, terms),
-    }))
-    .filter((candidate) => candidate.score > 1)
-    .sort(
-      (left, right) =>
-        right.score - left.score ||
-        right.memory.createdAtMs - left.memory.createdAtMs ||
-        left.memory.id.localeCompare(right.memory.id),
+  if (args.embedding) {
+    return await listVectorPreferenceAdjudicationCandidates({
+      db: args.db,
+      embedding: args.embedding,
+      nowMs: args.nowMs,
+      scope: args.scope,
+      subject: args.subject,
+    });
+  }
+  const rows = await args.db
+    .select()
+    .from(juniorMemoryMemories)
+    .where(
+      activeScopedSubjectPredicate({
+        ...args,
+        kind: "preference",
+      }),
     )
-    .map((candidate) => candidate.memory);
-
-  const vectorCandidates = args.embedding
-    ? await listVectorPreferenceAdjudicationCandidates({
-        db: args.db,
-        embedding: args.embedding,
-        kind: args.kind,
-        nowMs: args.nowMs,
-        scope: args.scope,
-        subject: args.subject,
-      })
-    : [];
-  const recentCandidates = (
-    await args.db
-      .select()
-      .from(juniorMemoryMemories)
-      .where(predicate)
-      .orderBy(
-        desc(juniorMemoryMemories.createdAtMs),
-        asc(juniorMemoryMemories.id),
-      )
-      .limit(PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT)
-  ).map(parseMemoryRow);
-  const byId = new Map<string, MemoryRecord>();
-  for (const candidates of [
-    lexicalCandidates,
-    vectorCandidates,
-    recentCandidates,
-  ]) {
-    const first = candidates[0];
-    if (first) {
-      byId.set(first.id, first);
-    }
-  }
-  for (const memory of [
-    ...lexicalCandidates.slice(1),
-    ...vectorCandidates.slice(1),
-    ...recentCandidates.slice(1),
-  ]) {
-    if (byId.size >= PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT) {
-      break;
-    }
-    byId.set(memory.id, memory);
-  }
-  return [...byId.values()];
+    .orderBy(
+      desc(juniorMemoryMemories.createdAtMs),
+      asc(juniorMemoryMemories.id),
+    )
+    .limit(PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT);
+  return rows.map(parseMemoryRow);
 }
 
 async function listVectorPreferenceAdjudicationCandidates(args: {
   db: MemoryDb;
   embedding: MemoryEmbedding;
-  kind: MemoryRecord["kind"];
   nowMs: number;
   scope: ResolvedMemoryScope;
   subject: ResolvedMemorySubject;
@@ -946,7 +875,7 @@ async function listVectorPreferenceAdjudicationCandidates(args: {
     )
     .where(
       and(
-        activeScopedSubjectPredicate(args),
+        activeScopedSubjectPredicate({ ...args, kind: "preference" }),
         eq(juniorMemoryEmbeddings.provider, args.embedding.provider),
         eq(juniorMemoryEmbeddings.model, args.embedding.model),
         eq(juniorMemoryEmbeddings.dimensions, MEMORY_EMBEDDING_DIMENSIONS),
@@ -967,6 +896,11 @@ async function listVectorPreferenceAdjudicationCandidates(args: {
   });
 }
 
+type PreferenceAdjudicationResult =
+  | { decision: "create" }
+  | { decision: "duplicate"; memory: MemoryRecord }
+  | { decision: "supersede"; ids: [string, ...string[]] };
+
 /**
  * Normalize a preference decision to known duplicate or supersession targets.
  * Uncertainty, invalid ids, and model failure leave existing memories active.
@@ -974,13 +908,12 @@ async function listVectorPreferenceAdjudicationCandidates(args: {
 async function adjudicatePreferenceCandidate(args: {
   candidates: MemoryRecord[];
   content: string;
-  decider: MemorySupersessionDecider | undefined;
-  kind: MemoryRecord["kind"];
+  decider: MemorySupersessionDecider;
   runtimeContext: MemoryRuntimeContext;
-}): Promise<{ duplicate?: MemoryRecord; supersededIds: string[] }> {
+}): Promise<PreferenceAdjudicationResult> {
   const [firstCandidate, ...remainingCandidates] = args.candidates;
-  if (args.kind !== "preference" || !args.decider || !firstCandidate) {
-    return { supersededIds: [] };
+  if (!firstCandidate) {
+    return { decision: "create" };
   }
   const existingMemories = [
     { content: firstCandidate.content, id: firstCandidate.id },
@@ -1000,23 +933,23 @@ async function adjudicatePreferenceCandidate(args: {
       runtimeContext: args.runtimeContext,
     });
     if (decision.decision === "duplicate") {
-      return {
-        duplicate: args.candidates.find(
-          (memory) => memory.id === decision.duplicateId,
-        ),
-        supersededIds: [],
-      };
+      const memory = args.candidates.find(
+        (candidate) => candidate.id === decision.duplicateId,
+      );
+      return memory
+        ? { decision: "duplicate", memory }
+        : { decision: "create" };
     }
     if (decision.decision === "supersedes_old") {
-      return {
-        supersededIds: decision.supersededIds.filter((id) =>
-          candidateIds.has(id),
-        ),
-      };
+      const ids = decision.supersededIds.filter((id) => candidateIds.has(id));
+      const [firstId, ...remainingIds] = ids;
+      return firstId
+        ? { decision: "supersede", ids: [firstId, ...remainingIds] }
+        : { decision: "create" };
     }
-    return { supersededIds: [] };
+    return { decision: "create" };
   } catch {
-    return { supersededIds: [] };
+    return { decision: "create" };
   }
 }
 
@@ -1255,6 +1188,29 @@ export function createMemoryStore(
     });
   }
 
+  async function reuseDuplicateMemory(args: {
+    content: string;
+    duplicate: MemoryRecord;
+    idempotencyKey?: string;
+    nowMs: number;
+    scope: ResolvedMemoryScope;
+    subject: ResolvedMemorySubject;
+  }): Promise<CreateMemoryResult> {
+    await rememberDuplicateIdempotency({
+      ...args,
+      db,
+      runtimeContext,
+    });
+    await storeEmbedding({
+      content: args.duplicate.content,
+      db,
+      embedder,
+      memoryId: args.duplicate.id,
+      nowMs: args.nowMs,
+    });
+    return { created: false, memory: args.duplicate };
+  }
+
   /** Persist a memory under the plugin-derived scope and subject. */
   async function createScopedMemory(
     rawInput: CreateMemoryInput,
@@ -1308,24 +1264,14 @@ export function createMemoryStore(
       subject,
     });
     if (exactDuplicate) {
-      await rememberDuplicateIdempotency({
+      return await reuseDuplicateMemory({
         content,
-        db,
         duplicate: exactDuplicate,
         idempotencyKey: input.idempotencyKey,
         nowMs,
-        runtimeContext,
         scope,
         subject,
       });
-      await storeEmbedding({
-        content: exactDuplicate.content,
-        db,
-        embedder,
-        memoryId: exactDuplicate.id,
-        nowMs,
-      });
-      return { created: false, memory: exactDuplicate };
     }
 
     let candidateEmbedding: MemoryEmbedding | undefined;
@@ -1347,24 +1293,14 @@ export function createMemoryStore(
         })
       : undefined;
     if (vectorDuplicate) {
-      await rememberDuplicateIdempotency({
+      return await reuseDuplicateMemory({
         content,
-        db,
         duplicate: vectorDuplicate,
         idempotencyKey: input.idempotencyKey,
         nowMs,
-        runtimeContext,
         scope,
         subject,
       });
-      await storeEmbedding({
-        content: vectorDuplicate.content,
-        db,
-        embedder,
-        memoryId: vectorDuplicate.id,
-        nowMs,
-      });
-      return { created: false, memory: vectorDuplicate };
     }
 
     let supersededIds: string[] = [];
@@ -1375,10 +1311,8 @@ export function createMemoryStore(
       (input.expiresAtMs === undefined || input.expiresAtMs > nowMs)
     ) {
       const preferenceCandidates = await listPreferenceAdjudicationCandidates({
-        content,
         db,
         ...(candidateEmbedding ? { embedding: candidateEmbedding } : {}),
-        kind: input.kind,
         nowMs,
         scope,
         subject,
@@ -1387,30 +1321,21 @@ export function createMemoryStore(
         candidates: preferenceCandidates,
         content,
         decider: supersessionDecider,
-        kind: input.kind,
         runtimeContext,
       });
-      if (adjudication.duplicate) {
-        await rememberDuplicateIdempotency({
+      if (adjudication.decision === "duplicate") {
+        return await reuseDuplicateMemory({
           content,
-          db,
-          duplicate: adjudication.duplicate,
+          duplicate: adjudication.memory,
           idempotencyKey: input.idempotencyKey,
           nowMs,
-          runtimeContext,
           scope,
           subject,
         });
-        await storeEmbedding({
-          content: adjudication.duplicate.content,
-          db,
-          embedder,
-          memoryId: adjudication.duplicate.id,
-          nowMs,
-        });
-        return { created: false, memory: adjudication.duplicate };
       }
-      supersededIds = adjudication.supersededIds;
+      if (adjudication.decision === "supersede") {
+        supersededIds = adjudication.ids;
+      }
     }
 
     const id = randomUUID();

--- a/packages/junior-memory/src/store.ts
+++ b/packages/junior-memory/src/store.ts
@@ -213,17 +213,13 @@ const memorySupersessionCandidateSchema = z
   })
   .strict();
 const memorySupersessionCandidatesSchema = z
-  .tuple([memorySupersessionCandidateSchema], memorySupersessionCandidateSchema)
-  .refine(
-    (candidates) =>
-      candidates.length <= PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT,
-    { message: "Too many preference candidates." },
-  );
+  .array(memorySupersessionCandidateSchema)
+  .min(1)
+  .max(PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT);
 const supersededIdsSchema = z
-  .tuple([z.string().min(1)], z.string().min(1))
-  .refine((ids) => ids.length <= PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT, {
-    message: "Too many superseded memory ids.",
-  });
+  .array(z.string().min(1))
+  .min(1)
+  .max(PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT);
 
 /** Validated preference comparison input supplied to a supersession decider. */
 export const memorySupersessionInputSchema = z
@@ -833,8 +829,9 @@ async function rememberDuplicateIdempotency(args: {
 }
 
 /**
- * Prefer lexical and vector matches, then fill the bounded model input with
- * recent active preferences so text shape cannot veto semantic adjudication.
+ * Reserve the best lexical and vector matches, then fill the bounded model
+ * input with ranked and recent active preferences so one retrieval strategy
+ * cannot veto semantic adjudication.
  */
 async function listPreferenceAdjudicationCandidates(args: {
   content: string;
@@ -891,7 +888,16 @@ async function listPreferenceAdjudicationCandidates(args: {
       })
     : [];
   const byId = new Map<string, MemoryRecord>();
-  for (const memory of [...lexicalCandidates, ...vectorCandidates]) {
+  for (const candidates of [lexicalCandidates, vectorCandidates]) {
+    const first = candidates[0];
+    if (first) {
+      byId.set(first.id, first);
+    }
+  }
+  for (const memory of [
+    ...lexicalCandidates.slice(1),
+    ...vectorCandidates.slice(1),
+  ]) {
     if (byId.size >= PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT) {
       break;
     }
@@ -978,7 +984,7 @@ async function adjudicatePreferenceCandidate(args: {
   if (args.kind !== "preference" || !args.decider || !firstCandidate) {
     return { supersededIds: [] };
   }
-  const existingMemories: MemorySupersessionInput["existingMemories"] = [
+  const existingMemories = [
     { content: firstCandidate.content, id: firstCandidate.id },
     ...remainingCandidates.map((memory) => ({
       content: memory.content,

--- a/packages/junior-memory/src/store.ts
+++ b/packages/junior-memory/src/store.ts
@@ -829,9 +829,8 @@ async function rememberDuplicateIdempotency(args: {
 }
 
 /**
- * Reserve the best lexical and vector matches, then fill the bounded model
- * input with ranked and recent active preferences so one retrieval strategy
- * cannot veto semantic adjudication.
+ * Reserve the best lexical, vector, and recent matches, then fill the bounded
+ * model input so one retrieval strategy cannot veto semantic adjudication.
  */
 async function listPreferenceAdjudicationCandidates(args: {
   content: string;
@@ -887,8 +886,23 @@ async function listPreferenceAdjudicationCandidates(args: {
         subject: args.subject,
       })
     : [];
+  const recentCandidates = (
+    await args.db
+      .select()
+      .from(juniorMemoryMemories)
+      .where(predicate)
+      .orderBy(
+        desc(juniorMemoryMemories.createdAtMs),
+        asc(juniorMemoryMemories.id),
+      )
+      .limit(PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT)
+  ).map(parseMemoryRow);
   const byId = new Map<string, MemoryRecord>();
-  for (const candidates of [lexicalCandidates, vectorCandidates]) {
+  for (const candidates of [
+    lexicalCandidates,
+    vectorCandidates,
+    recentCandidates,
+  ]) {
     const first = candidates[0];
     if (first) {
       byId.set(first.id, first);
@@ -897,28 +911,12 @@ async function listPreferenceAdjudicationCandidates(args: {
   for (const memory of [
     ...lexicalCandidates.slice(1),
     ...vectorCandidates.slice(1),
+    ...recentCandidates.slice(1),
   ]) {
     if (byId.size >= PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT) {
       break;
     }
     byId.set(memory.id, memory);
-  }
-  if (byId.size < PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT) {
-    const fallbackRows = await args.db
-      .select()
-      .from(juniorMemoryMemories)
-      .where(predicate)
-      .orderBy(
-        desc(juniorMemoryMemories.createdAtMs),
-        asc(juniorMemoryMemories.id),
-      )
-      .limit(PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT);
-    for (const memory of fallbackRows.map(parseMemoryRow)) {
-      byId.set(memory.id, memory);
-      if (byId.size >= PREFERENCE_ADJUDICATION_CANDIDATE_LIMIT) {
-        break;
-      }
-    }
   }
   return [...byId.values()];
 }

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -3342,6 +3342,67 @@ INSERT INTO junior_memory_memories (
     }
   }, 15_000);
 
+  it("keeps the most recent preference when lexical candidates fill the limit without embeddings", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      let nowMs = TEST_NOW_MS;
+      const existingContent =
+        "Prefers deployment summaries to lead with risks.";
+      const duplicateContent =
+        "Wants concise release notes with warnings first.";
+      const distractorContents = Array.from(
+        { length: 12 },
+        (_, index) => `Wants release notes for workflow detail ${index}.`,
+      );
+      let duplicateId: string | undefined;
+      const store = createMemoryStore(memoryDb(fixture), slackContext(), {
+        now: () => nowMs,
+        supersessionDecider: {
+          adjudicateSupersession(input) {
+            if (input.candidate.content !== duplicateContent || !duplicateId) {
+              return { decision: "distinct" };
+            }
+            return input.existingMemories.some(
+              (memory) => memory.id === duplicateId,
+            )
+              ? { decision: "duplicate", duplicateId }
+              : { decision: "distinct" };
+          },
+        },
+      });
+      for (const [index, content] of distractorContents.entries()) {
+        nowMs = TEST_NOW_MS + index;
+        await store.createMemory({
+          content,
+          kind: "preference",
+          idempotencyKey: `memory-test:recent-candidate-distractor-${index}`,
+        });
+      }
+      nowMs = TEST_NOW_MS + 20;
+      const existing = await store.createMemory({
+        content: existingContent,
+        kind: "preference",
+        idempotencyKey: "memory-test:recent-candidate-existing",
+      });
+      duplicateId = existing.memory.id;
+
+      nowMs = TEST_NOW_MS + 21;
+      await expect(
+        store.createMemory({
+          content: duplicateContent,
+          kind: "preference",
+          idempotencyKey: "memory-test:recent-candidate-duplicate",
+        }),
+      ).resolves.toMatchObject({
+        created: false,
+        memory: { id: existing.memory.id },
+      });
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
   it("supersedes old actor preferences when adjudication is confident", async () => {
     const fixture = await createMemoryFixture();
 

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -769,18 +769,11 @@ describe("memory plugin storage", () => {
     const fixture = await createMemoryFixture();
 
     try {
-      const oldContent = "Prefers Python for automation scripts.";
-      const newContent = "Prefers TypeScript for automation scripts.";
-      const embedder = createTestEmbedder({
-        [oldContent]: unitEmbedding(0),
-        [newContent]: cosineEmbedding(0.98),
-      });
       const store = createMemoryStore(memoryDb(fixture), localContext(), {
-        embedder,
         now: () => TEST_NOW_MS,
       });
       const oldMemory = await store.createMemory({
-        content: oldContent,
+        content: "Prefers Python for automation scripts.",
         kind: "preference",
         idempotencyKey: "memory-test:passive-supersession-old",
       });
@@ -801,7 +794,7 @@ describe("memory plugin storage", () => {
             object: {
               memories: [
                 {
-                  canonicalFact: newContent,
+                  canonicalFact: "Prefers TypeScript for automation scripts.",
                   expiresAtMs: null,
                   kind: "preference",
                   evidenceMessageIndices: [0],
@@ -815,7 +808,6 @@ describe("memory plugin storage", () => {
       await processMemorySession(
         processSessionContext({
           db: memoryDb(fixture),
-          embedder,
           model,
           run: {
             async load() {

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -781,7 +781,7 @@ describe("memory plugin storage", () => {
         async completeObject(input) {
           if (
             typeof input.prompt === "string" &&
-            input.prompt.includes("<memory-supersession-input>")
+            input.prompt.includes("<memory-preference-adjudication-input>")
           ) {
             return {
               object: {
@@ -3228,6 +3228,55 @@ INSERT INTO junior_memory_memories (
     }
   }, 15_000);
 
+  it("reuses a semantic duplicate selected by preference adjudication without embeddings", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      let duplicateId: string | undefined;
+      const model: PluginModel = {
+        async completeObject(input) {
+          expect(input.prompt).toContain(
+            "<memory-preference-adjudication-input>",
+          );
+          return {
+            object: duplicateId
+              ? { decision: "duplicate", duplicateId }
+              : { decision: "distinct" },
+          };
+        },
+      };
+      const store = createMemoryStore(memoryDb(fixture), slackContext(), {
+        now: () => TEST_NOW_MS,
+        supersessionDecider: createMemoryAgent(model),
+      });
+      const existing = await store.createMemory({
+        content: "Prefers PR summaries with risks first.",
+        kind: "preference",
+        idempotencyKey: "memory-test:adjudicated-duplicate-original",
+      });
+      duplicateId = existing.memory.id;
+
+      await expect(
+        store.createMemory({
+          content: "Wants danger notes at the beginning of code review recaps.",
+          kind: "preference",
+          idempotencyKey: "memory-test:adjudicated-duplicate-repeat",
+        }),
+      ).resolves.toMatchObject({
+        created: false,
+        memory: {
+          content: existing.memory.content,
+          id: existing.memory.id,
+        },
+      });
+      await expect(store.listMemories({})).resolves.toEqual([
+        expect.objectContaining({ id: existing.memory.id }),
+      ]);
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
   it("supersedes old actor preferences when adjudication is confident", async () => {
     const fixture = await createMemoryFixture();
 
@@ -3239,13 +3288,13 @@ INSERT INTO junior_memory_memories (
         [oldContent]: unitEmbedding(1),
         [newContent]: unitEmbedding(2),
       });
-      const supersessionCalls: MemorySupersessionInput[] = [];
+      const preferenceAdjudicationCalls: MemorySupersessionInput[] = [];
       const store = createMemoryStore(memoryDb(fixture), slackContext(), {
         embedder,
         now: () => nowMs,
         supersessionDecider: {
           adjudicateSupersession(input) {
-            supersessionCalls.push(input);
+            preferenceAdjudicationCalls.push(input);
             if (input.candidate.content !== newContent) {
               return { decision: "distinct" };
             }
@@ -3272,7 +3321,7 @@ INSERT INTO junior_memory_memories (
         });
       }
 
-      supersessionCalls.length = 0;
+      preferenceAdjudicationCalls.length = 0;
       nowMs = TEST_NOW_MS + 20;
       const newMemory = await store.createMemory({
         content: newContent,
@@ -3280,7 +3329,7 @@ INSERT INTO junior_memory_memories (
         idempotencyKey: "memory-test:supersession-new",
       });
 
-      expect(supersessionCalls).toEqual([
+      expect(preferenceAdjudicationCalls).toEqual([
         expect.objectContaining({
           candidate: { content: newContent, kind: "preference" },
           existingMemories: expect.arrayContaining([
@@ -3288,7 +3337,7 @@ INSERT INTO junior_memory_memories (
           ]),
         }),
       ]);
-      expect(supersessionCalls[0]?.existingMemories[0]).toEqual({
+      expect(preferenceAdjudicationCalls[0]?.existingMemories[0]).toEqual({
         content: oldContent,
         id: oldMemory.memory.id,
       });
@@ -3395,14 +3444,14 @@ INSERT INTO junior_memory_memories (
 
     try {
       let nowMs = TEST_NOW_MS;
-      const decider: MemorySupersessionDecider = {
+      const adjudicator: MemorySupersessionDecider = {
         adjudicateSupersession() {
           throw new Error("expired replacement should not use supersession");
         },
       };
       const store = createMemoryStore(memoryDb(fixture), slackContext(), {
         now: () => nowMs,
-        supersessionDecider: decider,
+        supersessionDecider: adjudicator,
       });
 
       const oldMemory = await store.createMemory({

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -769,11 +769,18 @@ describe("memory plugin storage", () => {
     const fixture = await createMemoryFixture();
 
     try {
+      const oldContent = "Prefers Python for automation scripts.";
+      const newContent = "Prefers TypeScript for automation scripts.";
+      const embedder = createTestEmbedder({
+        [oldContent]: unitEmbedding(0),
+        [newContent]: cosineEmbedding(0.98),
+      });
       const store = createMemoryStore(memoryDb(fixture), localContext(), {
+        embedder,
         now: () => TEST_NOW_MS,
       });
       const oldMemory = await store.createMemory({
-        content: "Prefers Python for automation scripts.",
+        content: oldContent,
         kind: "preference",
         idempotencyKey: "memory-test:passive-supersession-old",
       });
@@ -794,7 +801,7 @@ describe("memory plugin storage", () => {
             object: {
               memories: [
                 {
-                  canonicalFact: "Prefers TypeScript for automation scripts.",
+                  canonicalFact: newContent,
                   expiresAtMs: null,
                   kind: "preference",
                   evidenceMessageIndices: [0],
@@ -808,6 +815,7 @@ describe("memory plugin storage", () => {
       await processMemorySession(
         processSessionContext({
           db: memoryDb(fixture),
+          embedder,
           model,
           run: {
             async load() {
@@ -3277,72 +3285,7 @@ INSERT INTO junior_memory_memories (
     }
   }, 15_000);
 
-  it("keeps the closest vector match when lexical candidates fill the adjudication limit", async () => {
-    const fixture = await createMemoryFixture();
-
-    try {
-      const existingContent =
-        "Prefers deployment summaries to lead with risks.";
-      const duplicateContent =
-        "Wants concise release notes with warnings first.";
-      const vectors: Record<string, number[]> = {
-        [existingContent]: unitEmbedding(0),
-        [duplicateContent]: cosineEmbedding(0.98),
-      };
-      const distractorContents = Array.from(
-        { length: 12 },
-        (_, index) => `Wants release notes for workflow detail ${index}.`,
-      );
-      for (const [index, content] of distractorContents.entries()) {
-        vectors[content] = unitEmbedding(index + 2);
-      }
-      let duplicateId: string | undefined;
-      const store = createMemoryStore(memoryDb(fixture), slackContext(), {
-        embedder: createTestEmbedder(vectors),
-        now: () => TEST_NOW_MS,
-        supersessionDecider: {
-          adjudicateSupersession(input) {
-            if (input.candidate.content !== duplicateContent || !duplicateId) {
-              return { decision: "distinct" };
-            }
-            return input.existingMemories.some(
-              (memory) => memory.id === duplicateId,
-            )
-              ? { decision: "duplicate", duplicateId }
-              : { decision: "distinct" };
-          },
-        },
-      });
-      const existing = await store.createMemory({
-        content: existingContent,
-        kind: "preference",
-        idempotencyKey: "memory-test:vector-candidate-existing",
-      });
-      duplicateId = existing.memory.id;
-      for (const [index, content] of distractorContents.entries()) {
-        await store.createMemory({
-          content,
-          kind: "preference",
-          idempotencyKey: `memory-test:vector-candidate-distractor-${index}`,
-        });
-      }
-
-      await expect(
-        store.createMemory({
-          content: duplicateContent,
-          kind: "preference",
-          idempotencyKey: "memory-test:vector-candidate-duplicate",
-        }),
-      ).resolves.toMatchObject({
-        created: false,
-        memory: { id: existing.memory.id },
-      });
-    } finally {
-      await fixture.close();
-    }
-  }, 15_000);
-
-  it("keeps the most recent preference when lexical candidates fill the limit without embeddings", async () => {
+  it("uses recent preferences for adjudication without embeddings", async () => {
     const fixture = await createMemoryFixture();
 
     try {
@@ -3410,10 +3353,18 @@ INSERT INTO junior_memory_memories (
       let nowMs = TEST_NOW_MS;
       const oldContent = "Prefers Python for automation scripts.";
       const newContent = "Prefers TypeScript for automation scripts.";
-      const embedder = createTestEmbedder({
-        [oldContent]: unitEmbedding(1),
-        [newContent]: unitEmbedding(2),
-      });
+      const vectors: Record<string, number[]> = {
+        [oldContent]: unitEmbedding(0),
+        [newContent]: cosineEmbedding(0.98),
+      };
+      const unrelatedContents = Array.from(
+        { length: 12 },
+        (_, index) => `Prefers unrelated workflow detail ${index}.`,
+      );
+      for (const [index, content] of unrelatedContents.entries()) {
+        vectors[content] = unitEmbedding(index + 2);
+      }
+      const embedder = createTestEmbedder(vectors);
       const preferenceAdjudicationCalls: MemorySupersessionInput[] = [];
       const store = createMemoryStore(memoryDb(fixture), slackContext(), {
         embedder,
@@ -3438,10 +3389,10 @@ INSERT INTO junior_memory_memories (
         idempotencyKey: "memory-test:supersession-old",
       });
 
-      for (let index = 0; index < 12; index += 1) {
+      for (const [index, content] of unrelatedContents.entries()) {
         nowMs = TEST_NOW_MS + index + 1;
         await store.createMemory({
-          content: `Prefers unrelated workflow detail ${index}.`,
+          content,
           kind: "preference",
           idempotencyKey: `memory-test:supersession-unrelated-${index}`,
         });

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -3277,6 +3277,71 @@ INSERT INTO junior_memory_memories (
     }
   }, 15_000);
 
+  it("keeps the closest vector match when lexical candidates fill the adjudication limit", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      const existingContent =
+        "Prefers deployment summaries to lead with risks.";
+      const duplicateContent =
+        "Wants concise release notes with warnings first.";
+      const vectors: Record<string, number[]> = {
+        [existingContent]: unitEmbedding(0),
+        [duplicateContent]: cosineEmbedding(0.98),
+      };
+      const distractorContents = Array.from(
+        { length: 12 },
+        (_, index) => `Wants release notes for workflow detail ${index}.`,
+      );
+      for (const [index, content] of distractorContents.entries()) {
+        vectors[content] = unitEmbedding(index + 2);
+      }
+      let duplicateId: string | undefined;
+      const store = createMemoryStore(memoryDb(fixture), slackContext(), {
+        embedder: createTestEmbedder(vectors),
+        now: () => TEST_NOW_MS,
+        supersessionDecider: {
+          adjudicateSupersession(input) {
+            if (input.candidate.content !== duplicateContent || !duplicateId) {
+              return { decision: "distinct" };
+            }
+            return input.existingMemories.some(
+              (memory) => memory.id === duplicateId,
+            )
+              ? { decision: "duplicate", duplicateId }
+              : { decision: "distinct" };
+          },
+        },
+      });
+      const existing = await store.createMemory({
+        content: existingContent,
+        kind: "preference",
+        idempotencyKey: "memory-test:vector-candidate-existing",
+      });
+      duplicateId = existing.memory.id;
+      for (const [index, content] of distractorContents.entries()) {
+        await store.createMemory({
+          content,
+          kind: "preference",
+          idempotencyKey: `memory-test:vector-candidate-distractor-${index}`,
+        });
+      }
+
+      await expect(
+        store.createMemory({
+          content: duplicateContent,
+          kind: "preference",
+          idempotencyKey: "memory-test:vector-candidate-duplicate",
+        }),
+      ).resolves.toMatchObject({
+        created: false,
+        memory: { id: existing.memory.id },
+      });
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
   it("supersedes old actor preferences when adjudication is confident", async () => {
     const fixture = await createMemoryFixture();
 


### PR DESCRIPTION
Personal preference candidates that restate an active memory now reuse the
existing record instead of creating another recallable copy. Preference
adjudication distinguishes duplicates, replacements, additive preferences,
and uncertainty. Its bounded comparison window reserves space for the nearest
semantic memories and fills by recency, keeping records with missing
best-effort embeddings eligible.

Duplicate reuse preserves idempotent retries and the existing supersession
lifecycle. The memory evals separately assert the user-facing acknowledgement
and active durable state across explicit and passive memory paths. The public
supersession API names remain unchanged.
