### PR TITLE
fix(agent): Route complex turns through execution profiles

### DIFF
--- a/packages/junior-evals/evals/agent/files.eval.ts
+++ b/packages/junior-evals/evals/agent/files.eval.ts
@@ -74,7 +74,7 @@ describeEval("Coding File Tools", slackEvals, (it) => {
         ],
       }),
     });
-    expect(toolCalls(result.session)[0]).toMatchObject({ name: "handoff" });
+    expect(result.usage.model).toBe("openai/gpt-5.6-sol");
   });
 
   it("hands a coding task off once and keeps its workspace on the next turn", async ({

--- a/packages/junior-evals/evals/agent/files.eval.ts
+++ b/packages/junior-evals/evals/agent/files.eval.ts
@@ -75,9 +75,12 @@ describeEval("Coding File Tools", slackEvals, (it) => {
       }),
     });
     expect(result.usage.model).toBe("openai/gpt-5.6-sol");
+    expect(
+      toolCalls(result.session).filter((call) => call.name === "handoff"),
+    ).toHaveLength(0);
   });
 
-  it("hands a coding task off once and keeps its workspace on the next turn", async ({
+  it("routes a coding task to the handoff model and keeps its workspace on the next turn", async ({
     run,
   }) => {
     const thread = {
@@ -112,11 +115,7 @@ describeEval("Coding File Tools", slackEvals, (it) => {
     });
 
     const calls = toolCalls(result.session);
-    expect(calls[0]).toMatchObject({
-      name: "handoff",
-      arguments: { profile: "coding" },
-    });
-    expect(calls.filter((call) => call.name === "handoff")).toHaveLength(1);
+    expect(result.usage.model).toBe("openai/gpt-5.6-sol");
     expect(
       calls.some((call) => {
         const args = JSON.stringify(call.arguments) ?? "";

--- a/packages/junior/src/api/conversations/events.ts
+++ b/packages/junior/src/api/conversations/events.ts
@@ -107,7 +107,9 @@ export function projectConversationReportEvents(args: {
         };
       }
     } else if (event.data.type === "handoff") {
-      const toolStartedSeq = toolStarts.get(event.data.triggeringToolCallId);
+      const toolStartedSeq = event.data.triggeringToolCallId
+        ? toolStarts.get(event.data.triggeringToolCallId)
+        : undefined;
       data = {
         type: "handoff",
         ...(toolStartedSeq === undefined ? {} : { toolStartedSeq }),

--- a/packages/junior/src/chat/agent-dispatch/runner.ts
+++ b/packages/junior/src/chat/agent-dispatch/runner.ts
@@ -7,6 +7,7 @@
  * state, and schedules follow-up slices when a turn needs to continue.
  */
 import { botConfig } from "@/chat/config";
+import { standardModelId } from "@/chat/model-profile";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { logException } from "@/chat/logging";
 import {
@@ -625,7 +626,7 @@ export async function runAgentDispatchSlice(
       "agent_dispatch_run_failed",
       {
         ...logContext,
-        modelId: botConfig.modelId,
+        modelId: standardModelId(botConfig),
       },
       {},
       "Agent dispatch failed",

--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -466,13 +466,17 @@ async function executeAgentRunInPrivacyContext(
         .filter((profile) => profile !== DEFAULT_HANDOFF_MODEL_PROFILE)
         .sort(),
     ];
+    /** Commit the durable handoff epoch before staging its in-memory model swap. */
     const scheduleHandoff = async (args: {
       profile: ModelProfile;
+      runtimeContextSourceMessages?: PiMessage[];
       signal?: AbortSignal;
       sourceMessages: PiMessage[];
       triggeringToolCallId?: string;
     }) => {
-      const runtimeContext = retainRuntimeTurnContext(args.sourceMessages);
+      const runtimeContext = retainRuntimeTurnContext(
+        args.runtimeContextSourceMessages ?? args.sourceMessages,
+      );
       const standardPhaseUsage = extractGenAiUsageSummary(
         ...args.sourceMessages
           .slice(runResume.beforeMessageCount)
@@ -628,6 +632,7 @@ async function executeAgentRunInPrivacyContext(
       toolRuntimeContext: wiring.toolRuntimeContext,
       userContentParts,
     });
+    /** Apply a committed handoff to Pi and reset its durable resume baseline. */
     const applyPendingHandoff = (): AgentLoopTurnUpdate | undefined => {
       if (!pendingHandoff) {
         return undefined;
@@ -830,15 +835,17 @@ async function executeAgentRunInPrivacyContext(
             }
           }
 
+          /** Race one provider operation against the turn deadline and abort its owner. */
           const runAgentStep = async (
             run: Promise<unknown>,
+            abortRun: () => void = () => agent!.abort(),
           ): Promise<unknown> => {
             let timeoutId: ReturnType<typeof setTimeout> | undefined;
             let removeAbortListener: (() => void) | undefined;
             const timeoutPromise = new Promise<never>((_, reject) => {
               const rejectWithTimeout = () => {
                 runResume.markTimedOut();
-                agent!.abort();
+                abortRun();
                 reject(
                   new Error(
                     `Agent turn timed out after ${turnTimeoutBudgetMs}ms`,
@@ -855,7 +862,7 @@ async function executeAgentRunInPrivacyContext(
             const abortPromise = signal
               ? new Promise<never>((_, reject) => {
                   const rejectWithAbort = () => {
-                    agent!.abort();
+                    abortRun();
                     reject(signal.reason);
                   };
                   if (signal.aborted) {
@@ -939,15 +946,28 @@ async function executeAgentRunInPrivacyContext(
               : undefined;
           let run: Promise<unknown>;
           if (requestedModelProfile) {
-            await scheduleHandoff({
-              profile: requestedModelProfile,
-              signal,
-              sourceMessages: shouldPromptAgent
-                ? [...agent!.state.messages, freshPromptMessage]
-                : [...agent!.state.messages],
-            });
+            const handoffAbortController = new AbortController();
+            await runAgentStep(
+              scheduleHandoff({
+                profile: requestedModelProfile,
+                runtimeContextSourceMessages: shouldPromptAgent
+                  ? [freshPromptMessage]
+                  : undefined,
+                signal: handoffAbortController.signal,
+                sourceMessages: [...agent!.state.messages],
+              }),
+              () => handoffAbortController.abort(),
+            );
             applyPendingHandoff();
-            run = agent!.continue();
+            if (shouldPromptAgent) {
+              await runResume.requireDurableInputCheckpoint([
+                ...agent!.state.messages,
+                freshPromptMessage,
+              ]);
+              run = agent!.prompt(freshPromptMessage);
+            } else {
+              run = agent!.continue();
+            }
           } else {
             run = shouldPromptAgent
               ? agent!.prompt(freshPromptMessage)

--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -75,10 +75,11 @@ import {
   nextProviderRetry,
 } from "@/chat/services/provider-retry";
 import {
-  configuredTurnExecutionProfile,
-  selectTurnExecutionProfile,
+  configuredTurnRoute,
+  selectTurnRoute,
   toPiReasoningLevel,
-} from "@/chat/services/turn-execution-profile";
+  type TurnRoute,
+} from "@/chat/services/turn-router";
 import {
   addAgentTurnUsage,
   hasAgentTurnUsage,
@@ -113,6 +114,7 @@ import {
   modelIdForProfile,
   ModelProfileNotConfiguredError,
   STANDARD_MODEL_PROFILE,
+  profileConfig,
   type ModelProfile,
 } from "@/chat/model-profile";
 import { compactContextForHandoff } from "@/chat/services/context-compaction";
@@ -225,12 +227,7 @@ async function executeAgentRunInPrivacyContext(
   let handoffPhaseUsage: AgentTurnUsage | undefined;
   const configuredReasoningLevel =
     policy.reasoningLevel ?? botConfig.reasoningLevel;
-  let executionProfile = configuredReasoningLevel
-    ? configuredTurnExecutionProfile(
-        configuredReasoningLevel,
-        policy.reasoningLevel ? "agent_config" : "default",
-      )
-    : undefined;
+  let turnRoute: TurnRoute | undefined;
   let activeModelProfile: ModelProfile = STANDARD_MODEL_PROFILE;
   let activeModelId = modelIdForProfile(botConfig, activeModelProfile);
   const actor = actorFromRouting(routing);
@@ -360,7 +357,7 @@ async function executeAgentRunInPrivacyContext(
       destination: routing.destination,
       durability,
       getLoadedSkillNames: () => loadedSkillNamesForResume,
-      getReasoningLevel: () => executionProfile?.reasoningLevel,
+      getReasoningLevel: () => turnRoute?.reasoningLevel,
       logContext: sessionRecordLogContext,
       getModelId: () => activeModelId,
       recordActiveMcpProviders,
@@ -430,19 +427,43 @@ async function executeAgentRunInPrivacyContext(
     const preAgentPromptMessages = (): PiMessage[] =>
       existingSessionRecord?.piMessages ?? [...(input.piMessages ?? [])];
 
-    executionProfile ??= await selectTurnExecutionProfile({
-      completeObject,
-      conversationContext: input.conversationContext,
-      context: {
-        threadId: conversationId,
-        channelId: slackDestination?.channelId,
-        actorId: slackActor?.userId,
-        runId,
-      },
-      currentTurnBlocks: routerBlocks,
-      fastModelId: botConfig.fastModelId,
-      messageText: userInput,
-    });
+    if (activeModelProfile === STANDARD_MODEL_PROFILE) {
+      turnRoute = await selectTurnRoute({
+        completeObject,
+        conversationContext: input.conversationContext,
+        context: {
+          threadId: conversationId,
+          channelId: slackDestination?.channelId,
+          actorId: slackActor?.userId,
+          runId,
+        },
+        currentTurnBlocks: routerBlocks,
+        fastModelId: botConfig.fastModelId,
+        messageText: userInput,
+        profiles: botConfig.profiles,
+      });
+      if (configuredReasoningLevel) {
+        turnRoute = {
+          ...turnRoute,
+          reasoningLevel: configuredReasoningLevel,
+          reason: `configured:${policy.reasoningLevel ? "agent_config" : "default"}:${turnRoute.reason}`,
+        };
+      }
+    } else {
+      const activeProfileConfig = profileConfig(botConfig, activeModelProfile);
+      turnRoute = configuredTurnRoute(
+        activeModelProfile,
+        policy.reasoningLevel ??
+          activeProfileConfig.reasoningLevel ??
+          botConfig.reasoningLevel ??
+          "medium",
+        policy.reasoningLevel
+          ? "agent_config"
+          : activeProfileConfig.reasoningLevel
+            ? "profile"
+            : "default",
+      );
+    }
 
     // ── Mutable turn state ───────────────────────────────────────────
     const generatedFiles: FileUpload[] = [];
@@ -462,8 +483,12 @@ async function executeAgentRunInPrivacyContext(
       agent ? [...agent.state.messages] : [];
     const handoffProfiles: [ModelProfile, ...ModelProfile[]] = [
       DEFAULT_HANDOFF_MODEL_PROFILE,
-      ...Object.keys(botConfig.modelProfiles)
-        .filter((profile) => profile !== DEFAULT_HANDOFF_MODEL_PROFILE)
+      ...Object.keys(botConfig.profiles)
+        .filter(
+          (profile) =>
+            profile !== STANDARD_MODEL_PROFILE &&
+            profile !== DEFAULT_HANDOFF_MODEL_PROFILE,
+        )
         .sort(),
     ];
     /** Commit the durable handoff epoch before staging its in-memory model swap. */
@@ -485,14 +510,15 @@ async function executeAgentRunInPrivacyContext(
       const phaseUsage = hasAgentTurnUsage(standardPhaseUsage)
         ? standardPhaseUsage
         : undefined;
+      const selectedProfile = profileConfig(botConfig, args.profile);
       const target = {
-        modelId: modelIdForProfile(botConfig, args.profile),
+        modelId: selectedProfile.modelId,
         modelProfile: args.profile,
       };
       const handoffModel = resolveGatewayModel(target.modelId);
-      const handoffThinkingLevel = toPiReasoningLevel(
-        executionProfile!.reasoningLevel,
-      );
+      const handoffReasoningLevel =
+        selectedProfile.reasoningLevel ?? turnRoute!.reasoningLevel;
+      const handoffThinkingLevel = toPiReasoningLevel(handoffReasoningLevel);
       void (async () => {
         await observers.onStatus?.({ text: "Switching models" });
       })().catch((error) => {
@@ -524,6 +550,13 @@ async function executeAgentRunInPrivacyContext(
         },
         { completeText },
       );
+      if (handoffReasoningLevel !== turnRoute!.reasoningLevel) {
+        turnRoute = {
+          ...turnRoute!,
+          reasoningLevel: handoffReasoningLevel,
+          reason: `profile_reasoning_override:${args.profile}:${turnRoute!.reason}`,
+        };
+      }
       handoffPhaseUsage = phaseUsage;
       pendingHandoff = {
         messages: handoffMessages,
@@ -533,22 +566,19 @@ async function executeAgentRunInPrivacyContext(
       activeModelProfile = args.profile;
       activeModelId = target.modelId;
     };
-    const requestHandoff =
-      activeModelProfile === STANDARD_MODEL_PROFILE
-        ? {
-            profiles: handoffProfiles,
-            execute: async (
-              profile: ModelProfile,
-              options: { signal?: AbortSignal; toolCallId: string },
-            ) =>
-              await scheduleHandoff({
-                profile,
-                signal: options.signal,
-                sourceMessages: [...agent!.state.messages],
-                triggeringToolCallId: options.toolCallId,
-              }),
-          }
-        : undefined;
+    const requestHandoff = {
+      profiles: handoffProfiles,
+      execute: async (
+        profile: ModelProfile,
+        options: { signal?: AbortSignal; toolCallId: string },
+      ) =>
+        await scheduleHandoff({
+          profile,
+          signal: options.signal,
+          sourceMessages: [...agent!.state.messages],
+          triggeringToolCallId: options.toolCallId,
+        }),
+    };
 
     setTags({
       conversationId: spanContext.conversationId,
@@ -601,9 +631,7 @@ async function executeAgentRunInPrivacyContext(
     mcpToolManager = wiring.mcpToolManager;
     const sandboxExecutor = wiring.sandboxExecutor;
     const getPendingAuthPause = wiring.getPendingAuthPause;
-    const toolsAfterHandoff = wiring.agentTools.filter(
-      (tool) => tool.name !== HANDOFF_TOOL_NAME,
-    );
+    const toolsAfterHandoff = wiring.agentTools;
 
     // ── Prompt context ───────────────────────────────────────────────
     const {
@@ -650,7 +678,7 @@ async function executeAgentRunInPrivacyContext(
       setSpanAttributes({
         "gen_ai.agent.model": activeModelId,
         "gen_ai.agent.model_profile": activeModelProfile,
-        "gen_ai.agent.reasoning.level": executionProfile!.reasoningLevel,
+        "gen_ai.agent.reasoning.level": turnRoute!.reasoningLevel,
       });
       return {
         context: {
@@ -763,7 +791,7 @@ async function executeAgentRunInPrivacyContext(
       initialState: {
         systemPrompt: baseInstructions,
         model: resolveGatewayModel(activeModelId),
-        thinkingLevel: toPiReasoningLevel(executionProfile.reasoningLevel),
+        thinkingLevel: toPiReasoningLevel(turnRoute.reasoningLevel),
         tools: wiring.agentTools,
       },
     });
@@ -892,10 +920,10 @@ async function executeAgentRunInPrivacyContext(
                     "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
                     "gen_ai.operation.name": "invoke_agent",
                     "gen_ai.request.model": activeModelId,
-                    ...(executionProfile
+                    ...(turnRoute
                       ? {
                           "gen_ai.request.reasoning.level":
-                            executionProfile.reasoningLevel,
+                            turnRoute.reasoningLevel,
                         }
                       : {}),
                     "app.ai.turn_timeout_ms": turnTimeoutBudgetMs,
@@ -940,16 +968,16 @@ async function executeAgentRunInPrivacyContext(
             }
           };
 
-          const requestedModelProfile =
+          const requestedProfile =
             activeModelProfile === STANDARD_MODEL_PROFILE
-              ? executionProfile!.requestedModelProfile
+              ? turnRoute!.profile
               : undefined;
           let run: Promise<unknown>;
-          if (requestedModelProfile) {
+          if (requestedProfile && requestedProfile !== STANDARD_MODEL_PROFILE) {
             const handoffAbortController = new AbortController();
             await runAgentStep(
               scheduleHandoff({
-                profile: requestedModelProfile,
+                profile: requestedProfile,
                 runtimeContextSourceMessages: shouldPromptAgent
                   ? [freshPromptMessage]
                   : undefined,
@@ -1056,12 +1084,11 @@ async function executeAgentRunInPrivacyContext(
           "gen_ai.operation.name": "invoke_agent",
           "gen_ai.agent.model": activeModelId,
           "gen_ai.agent.model_profile": activeModelProfile,
-          "gen_ai.agent.reasoning.level": executionProfile.reasoningLevel,
-          "gen_ai.agent.reasoning.level_reason": executionProfile.reason,
-          ...(executionProfile.confidence !== undefined
+          "gen_ai.agent.reasoning.level": turnRoute.reasoningLevel,
+          "gen_ai.agent.reasoning.level_reason": turnRoute.reason,
+          ...(turnRoute.confidence !== undefined
             ? {
-                "gen_ai.agent.reasoning.level_confidence":
-                  executionProfile.confidence,
+                "gen_ai.agent.reasoning.level_confidence": turnRoute.confidence,
               }
             : {}),
           "gen_ai.output.type": "text",
@@ -1101,7 +1128,7 @@ async function executeAgentRunInPrivacyContext(
       shouldTrace,
       spanContext,
       usage: turnUsage,
-      executionProfile,
+      executionProfile: turnRoute,
       assistantUserName: botConfig.userName,
       modelId: activeModelId,
     });
@@ -1168,9 +1195,9 @@ async function executeAgentRunInPrivacyContext(
           outcome: "provider_error",
           modelId: activeModelId,
           assistantMessageCount: 0,
-          ...(executionProfile
+          ...(turnRoute
             ? {
-                reasoningLevel: executionProfile.reasoningLevel,
+                reasoningLevel: turnRoute.reasoningLevel,
               }
             : {}),
           toolCalls: [],

--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -505,6 +505,9 @@ async function executeAgentRunInPrivacyContext(
       sourceMessages: PiMessage[];
       triggeringToolCallId?: string;
     }) => {
+      if (args.profile === activeModelProfile) {
+        return;
+      }
       const runtimeContext = retainRuntimeTurnContext(
         args.runtimeContextSourceMessages ?? args.sourceMessages,
       );

--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -75,10 +75,10 @@ import {
   nextProviderRetry,
 } from "@/chat/services/provider-retry";
 import {
-  configuredTurnReasoningLevel,
-  selectTurnReasoningLevel,
+  configuredTurnExecutionProfile,
+  selectTurnExecutionProfile,
   toPiReasoningLevel,
-} from "@/chat/services/turn-reasoning-level";
+} from "@/chat/services/turn-execution-profile";
 import {
   addAgentTurnUsage,
   hasAgentTurnUsage,
@@ -225,8 +225,8 @@ async function executeAgentRunInPrivacyContext(
   let handoffPhaseUsage: AgentTurnUsage | undefined;
   const configuredReasoningLevel =
     policy.reasoningLevel ?? botConfig.reasoningLevel;
-  let reasoningSelection = configuredReasoningLevel
-    ? configuredTurnReasoningLevel(
+  let executionProfile = configuredReasoningLevel
+    ? configuredTurnExecutionProfile(
         configuredReasoningLevel,
         policy.reasoningLevel ? "agent_config" : "default",
       )
@@ -360,7 +360,7 @@ async function executeAgentRunInPrivacyContext(
       destination: routing.destination,
       durability,
       getLoadedSkillNames: () => loadedSkillNamesForResume,
-      getReasoningLevel: () => reasoningSelection?.reasoningLevel,
+      getReasoningLevel: () => executionProfile?.reasoningLevel,
       logContext: sessionRecordLogContext,
       getModelId: () => activeModelId,
       recordActiveMcpProviders,
@@ -430,7 +430,7 @@ async function executeAgentRunInPrivacyContext(
     const preAgentPromptMessages = (): PiMessage[] =>
       existingSessionRecord?.piMessages ?? [...(input.piMessages ?? [])];
 
-    reasoningSelection ??= await selectTurnReasoningLevel({
+    executionProfile ??= await selectTurnExecutionProfile({
       completeObject,
       conversationContext: input.conversationContext,
       context: {
@@ -466,6 +466,69 @@ async function executeAgentRunInPrivacyContext(
         .filter((profile) => profile !== DEFAULT_HANDOFF_MODEL_PROFILE)
         .sort(),
     ];
+    const scheduleHandoff = async (args: {
+      profile: ModelProfile;
+      signal?: AbortSignal;
+      sourceMessages: PiMessage[];
+      triggeringToolCallId?: string;
+    }) => {
+      const runtimeContext = retainRuntimeTurnContext(args.sourceMessages);
+      const standardPhaseUsage = extractGenAiUsageSummary(
+        ...args.sourceMessages
+          .slice(runResume.beforeMessageCount)
+          .filter(isAssistantMessage),
+      );
+      const phaseUsage = hasAgentTurnUsage(standardPhaseUsage)
+        ? standardPhaseUsage
+        : undefined;
+      const target = {
+        modelId: modelIdForProfile(botConfig, args.profile),
+        modelProfile: args.profile,
+      };
+      const handoffModel = resolveGatewayModel(target.modelId);
+      const handoffThinkingLevel = toPiReasoningLevel(
+        executionProfile!.reasoningLevel,
+      );
+      void (async () => {
+        await observers.onStatus?.({ text: "Switching models" });
+      })().catch((error) => {
+        logWarn(
+          "assistant_status_observer_failed",
+          {},
+          {
+            "exception.message":
+              error instanceof Error ? error.message : String(error),
+          },
+          "Failed to report assistant status",
+        );
+      });
+      const handoffMessages = await compactContextForHandoff(
+        {
+          conversationContext: input.conversationContext,
+          conversationId,
+          piMessages: args.sourceMessages,
+          runtimeContext,
+          signal: args.signal,
+          triggeringToolCallId: args.triggeringToolCallId,
+          target,
+          metadata: {
+            threadId: conversationId,
+            channelId: slackDestination?.channelId,
+            actorId: slackActor?.userId,
+            runId,
+          },
+        },
+        { completeText },
+      );
+      handoffPhaseUsage = phaseUsage;
+      pendingHandoff = {
+        messages: handoffMessages,
+        model: handoffModel,
+        thinkingLevel: handoffThinkingLevel,
+      };
+      activeModelProfile = args.profile;
+      activeModelId = target.modelId;
+    };
     const requestHandoff =
       activeModelProfile === STANDARD_MODEL_PROFILE
         ? {
@@ -473,65 +536,13 @@ async function executeAgentRunInPrivacyContext(
             execute: async (
               profile: ModelProfile,
               options: { signal?: AbortSignal; toolCallId: string },
-            ) => {
-              const sourceMessages = [...agent!.state.messages];
-              const runtimeContext = retainRuntimeTurnContext(sourceMessages);
-              const standardPhaseUsage = extractGenAiUsageSummary(
-                ...sourceMessages
-                  .slice(runResume.beforeMessageCount)
-                  .filter(isAssistantMessage),
-              );
-              const phaseUsage = hasAgentTurnUsage(standardPhaseUsage)
-                ? standardPhaseUsage
-                : undefined;
-              const target = {
-                modelId: modelIdForProfile(botConfig, profile),
-                modelProfile: profile,
-              };
-              const handoffModel = resolveGatewayModel(target.modelId);
-              const handoffThinkingLevel = toPiReasoningLevel(
-                reasoningSelection!.reasoningLevel,
-              );
-              void (async () => {
-                await observers.onStatus?.({ text: "Switching models" });
-              })().catch((error) => {
-                logWarn(
-                  "assistant_status_observer_failed",
-                  {},
-                  {
-                    "exception.message":
-                      error instanceof Error ? error.message : String(error),
-                  },
-                  "Failed to report assistant status",
-                );
-              });
-              const handoffMessages = await compactContextForHandoff(
-                {
-                  conversationContext: input.conversationContext,
-                  conversationId,
-                  piMessages: sourceMessages,
-                  runtimeContext,
-                  signal: options.signal,
-                  triggeringToolCallId: options.toolCallId,
-                  target,
-                  metadata: {
-                    threadId: conversationId,
-                    channelId: slackDestination?.channelId,
-                    actorId: slackActor?.userId,
-                    runId,
-                  },
-                },
-                { completeText },
-              );
-              handoffPhaseUsage = phaseUsage;
-              pendingHandoff = {
-                messages: handoffMessages,
-                model: handoffModel,
-                thinkingLevel: handoffThinkingLevel,
-              };
-              activeModelProfile = profile;
-              activeModelId = target.modelId;
-            },
+            ) =>
+              await scheduleHandoff({
+                profile,
+                signal: options.signal,
+                sourceMessages: [...agent!.state.messages],
+                triggeringToolCallId: options.toolCallId,
+              }),
           }
         : undefined;
 
@@ -617,6 +628,35 @@ async function executeAgentRunInPrivacyContext(
       toolRuntimeContext: wiring.toolRuntimeContext,
       userContentParts,
     });
+    const applyPendingHandoff = (): AgentLoopTurnUpdate | undefined => {
+      if (!pendingHandoff) {
+        return undefined;
+      }
+      const { messages, model, thinkingLevel } = pendingHandoff;
+      const replacement = [...messages];
+      pendingHandoff = undefined;
+      agent!.state.messages = replacement;
+      agent!.state.model = model;
+      agent!.state.thinkingLevel = thinkingLevel;
+      agent!.state.tools = toolsAfterHandoff;
+      runResume.setBeforeMessageCount(replacement.length);
+      runResume.setTurnStartMessageIndex(0);
+      runResume.adoptCommittedBoundary(replacement);
+      setSpanAttributes({
+        "gen_ai.agent.model": activeModelId,
+        "gen_ai.agent.model_profile": activeModelProfile,
+        "gen_ai.agent.reasoning.level": executionProfile!.reasoningLevel,
+      });
+      return {
+        context: {
+          systemPrompt: baseInstructions,
+          messages: replacement,
+          tools: toolsAfterHandoff,
+        },
+        model,
+        thinkingLevel,
+      };
+    };
     // ── Agent execution ──────────────────────────────────────────────
     let assistantMessageDeliveryError:
       | AssistantMessageDeliveryError
@@ -710,33 +750,7 @@ async function executeAgentRunInPrivacyContext(
         return undefined;
       },
       prepareNextTurn: async () => {
-        let update: AgentLoopTurnUpdate | undefined;
-        if (pendingHandoff) {
-          const { messages, model, thinkingLevel } = pendingHandoff;
-          const replacement = [...messages];
-          pendingHandoff = undefined;
-          agent!.state.messages = replacement;
-          agent!.state.model = model;
-          agent!.state.thinkingLevel = thinkingLevel;
-          agent!.state.tools = toolsAfterHandoff;
-          runResume.setBeforeMessageCount(replacement.length);
-          runResume.setTurnStartMessageIndex(0);
-          runResume.adoptCommittedBoundary(replacement);
-          setSpanAttributes({
-            "gen_ai.agent.model": activeModelId,
-            "gen_ai.agent.model_profile": activeModelProfile,
-            "gen_ai.agent.reasoning.level": reasoningSelection!.reasoningLevel,
-          });
-          update = {
-            context: {
-              systemPrompt: baseInstructions,
-              messages: replacement,
-              tools: toolsAfterHandoff,
-            },
-            model,
-            thinkingLevel,
-          };
-        }
+        const update = applyPendingHandoff();
         await drainSteeringMessages();
         runResume.yieldAtSafeBoundaryIfDue(currentAgentMessages());
         return update;
@@ -744,7 +758,7 @@ async function executeAgentRunInPrivacyContext(
       initialState: {
         systemPrompt: baseInstructions,
         model: resolveGatewayModel(activeModelId),
-        thinkingLevel: toPiReasoningLevel(reasoningSelection.reasoningLevel),
+        thinkingLevel: toPiReasoningLevel(executionProfile.reasoningLevel),
         tools: wiring.agentTools,
       },
     });
@@ -871,10 +885,10 @@ async function executeAgentRunInPrivacyContext(
                     "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
                     "gen_ai.operation.name": "invoke_agent",
                     "gen_ai.request.model": activeModelId,
-                    ...(reasoningSelection
+                    ...(executionProfile
                       ? {
                           "gen_ai.request.reasoning.level":
-                            reasoningSelection.reasoningLevel,
+                            executionProfile.reasoningLevel,
                         }
                       : {}),
                     "app.ai.turn_timeout_ms": turnTimeoutBudgetMs,
@@ -919,9 +933,26 @@ async function executeAgentRunInPrivacyContext(
             }
           };
 
-          let run = shouldPromptAgent
-            ? agent!.prompt(freshPromptMessage)
-            : agent!.continue();
+          const requestedModelProfile =
+            activeModelProfile === STANDARD_MODEL_PROFILE
+              ? executionProfile!.requestedModelProfile
+              : undefined;
+          let run: Promise<unknown>;
+          if (requestedModelProfile) {
+            await scheduleHandoff({
+              profile: requestedModelProfile,
+              signal,
+              sourceMessages: shouldPromptAgent
+                ? [...agent!.state.messages, freshPromptMessage]
+                : [...agent!.state.messages],
+            });
+            applyPendingHandoff();
+            run = agent!.continue();
+          } else {
+            run = shouldPromptAgent
+              ? agent!.prompt(freshPromptMessage)
+              : agent!.continue();
+          }
           let retryUsage: AgentTurnUsage | undefined;
           for (let attempt = 0; ; attempt += 1) {
             await runAgentStep(run);
@@ -1005,12 +1036,12 @@ async function executeAgentRunInPrivacyContext(
           "gen_ai.operation.name": "invoke_agent",
           "gen_ai.agent.model": activeModelId,
           "gen_ai.agent.model_profile": activeModelProfile,
-          "gen_ai.agent.reasoning.level": reasoningSelection.reasoningLevel,
-          "gen_ai.agent.reasoning.level_reason": reasoningSelection.reason,
-          ...(reasoningSelection.confidence !== undefined
+          "gen_ai.agent.reasoning.level": executionProfile.reasoningLevel,
+          "gen_ai.agent.reasoning.level_reason": executionProfile.reason,
+          ...(executionProfile.confidence !== undefined
             ? {
                 "gen_ai.agent.reasoning.level_confidence":
-                  reasoningSelection.confidence,
+                  executionProfile.confidence,
               }
             : {}),
           "gen_ai.output.type": "text",
@@ -1050,7 +1081,7 @@ async function executeAgentRunInPrivacyContext(
       shouldTrace,
       spanContext,
       usage: turnUsage,
-      reasoningSelection,
+      executionProfile,
       assistantUserName: botConfig.userName,
       modelId: activeModelId,
     });
@@ -1117,9 +1148,9 @@ async function executeAgentRunInPrivacyContext(
           outcome: "provider_error",
           modelId: activeModelId,
           assistantMessageCount: 0,
-          ...(reasoningSelection
+          ...(executionProfile
             ? {
-                reasoningLevel: reasoningSelection.reasoningLevel,
+                reasoningLevel: executionProfile.reasoningLevel,
               }
             : {}),
           toolCalls: [],

--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -227,7 +227,13 @@ async function executeAgentRunInPrivacyContext(
   let handoffPhaseUsage: AgentTurnUsage | undefined;
   const configuredReasoningLevel =
     policy.reasoningLevel ?? botConfig.reasoningLevel;
-  let turnRoute: TurnRoute | undefined;
+  let turnRoute: TurnRoute | undefined = configuredReasoningLevel
+    ? configuredTurnRoute(
+        STANDARD_MODEL_PROFILE,
+        configuredReasoningLevel,
+        policy.reasoningLevel ? "agent_config" : "default",
+      )
+    : undefined;
   let activeModelProfile: ModelProfile = STANDARD_MODEL_PROFILE;
   let activeModelId = modelIdForProfile(botConfig, activeModelProfile);
   const actor = actorFromRouting(routing);

--- a/packages/junior/src/chat/app/factory.ts
+++ b/packages/junior/src/chat/app/factory.ts
@@ -41,6 +41,7 @@ import {
 } from "@/chat/services/conversation-memory";
 import type { SubscribedReplyDecision } from "@/chat/services/subscribed-reply-policy";
 import { botConfig } from "@/chat/config";
+import { standardModelId } from "@/chat/model-profile";
 
 export interface CreateSlackRuntimeOptions {
   getSlackAdapter: () => SlackAdapter;
@@ -116,7 +117,7 @@ export function createSlackRuntime(
 
   return createSlackTurnRuntime<PreparedTurnState, AssistantLifecycleEvent>({
     assistantUserName: botConfig.userName,
-    modelId: botConfig.modelId,
+    modelId: standardModelId(botConfig),
     now: options.now ?? (() => Date.now()),
     getThreadId,
     getChannelId,

--- a/packages/junior/src/chat/config.ts
+++ b/packages/junior/src/chat/config.ts
@@ -8,6 +8,7 @@ import {
 } from "@/chat/reasoning-level";
 import {
   DEFAULT_HANDOFF_MODEL_PROFILE,
+  type ExecutionProfileConfig,
   modelProfileSchema,
   STANDARD_MODEL_PROFILE,
 } from "@/chat/model-profile";
@@ -43,8 +44,7 @@ export interface BotConfig {
   embeddingModelId: string;
   fastModelId: string;
   loadingMessages: string[];
-  modelId: string;
-  modelProfiles: Readonly<Record<string, string>>;
+  profiles: Readonly<Record<string, ExecutionProfileConfig>>;
   reasoningLevel?: TurnReasoningLevel;
   modelContextWindowTokens?: number;
   visionModelId?: string;
@@ -184,12 +184,17 @@ function validateEmbeddingModelId(raw: string | undefined): string | undefined {
   return toOptionalTrimmed(raw);
 }
 
-function parseModelProfiles(
+function parseProfiles(
   rawValue: string | undefined,
+  standardModelId: string,
   handoffModelId: string,
-): Readonly<Record<string, string>> {
-  const profiles: Record<string, string> = {
-    [DEFAULT_HANDOFF_MODEL_PROFILE]: handoffModelId,
+): Readonly<Record<string, ExecutionProfileConfig>> {
+  const profiles: Record<string, ExecutionProfileConfig> = {
+    [STANDARD_MODEL_PROFILE]: { modelId: standardModelId },
+    [DEFAULT_HANDOFF_MODEL_PROFILE]: {
+      modelId: handoffModelId,
+      reasoningLevel: "xhigh",
+    },
   };
   const trimmed = toOptionalTrimmed(rawValue);
   if (trimmed === undefined) {
@@ -224,7 +229,7 @@ function parseModelProfiles(
     if (!modelId) {
       throw new Error(`AI_MODEL_PROFILES.${profile} must not be empty`);
     }
-    profiles[profile] = modelId;
+    profiles[profile] = { modelId };
   }
   return profiles;
 }
@@ -260,8 +265,7 @@ function readBotConfig(env: NodeJS.ProcessEnv): BotConfig {
 
   return {
     userName: toOptionalTrimmed(env.JUNIOR_BOT_NAME) ?? "junior",
-    modelId,
-    modelProfiles: parseModelProfiles(env.AI_MODEL_PROFILES, handoffModelId),
+    profiles: parseProfiles(env.AI_MODEL_PROFILES, modelId, handoffModelId),
     modelContextWindowTokens: parseOptionalPositiveInteger(
       "AI_MODEL_CONTEXT_WINDOW_TOKENS",
       env.AI_MODEL_CONTEXT_WINDOW_TOKENS,

--- a/packages/junior/src/chat/conversations/history.ts
+++ b/packages/junior/src/chat/conversations/history.ts
@@ -58,7 +58,7 @@ const historyReplacementEventDataSchema = z.discriminatedUnion("type", [
       type: z.literal("handoff"),
       modelProfile: handoffModelProfileSchema,
       modelId: z.string().min(1),
-      triggeringToolCallId: z.string().min(1),
+      triggeringToolCallId: z.string().min(1).optional(),
       replacementHistory: replacementHistorySchema,
     })
     .strict(),

--- a/packages/junior/src/chat/model-profile.ts
+++ b/packages/junior/src/chat/model-profile.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { BotConfig } from "@/chat/config";
+import type { TurnReasoningLevel } from "@/chat/reasoning-level";
 
 export const STANDARD_MODEL_PROFILE = "standard";
 export const DEFAULT_HANDOFF_MODEL_PROFILE = "handoff";
@@ -9,6 +10,12 @@ export const modelProfileSchema = z.string().regex(/^[a-z][a-z0-9_-]*$/);
 
 /** A configured model role rather than a provider-specific model id. */
 export type ModelProfile = z.output<typeof modelProfileSchema>;
+
+/** Runtime configuration for one named execution profile. */
+export interface ExecutionProfileConfig {
+  modelId: string;
+  reasoningLevel?: TurnReasoningLevel;
+}
 
 /** Identify durable profile bindings that the current host cannot resolve. */
 export class ModelProfileNotConfiguredError extends Error {
@@ -23,14 +30,24 @@ export function modelIdForProfile(
   config: BotConfig,
   profile: ModelProfile,
 ): string {
-  if (profile === STANDARD_MODEL_PROFILE) {
-    return config.modelId;
-  }
-  const modelId = Object.hasOwn(config.modelProfiles, profile)
-    ? config.modelProfiles[profile]
+  return profileConfig(config, profile).modelId;
+}
+
+/** Resolve the standard execution profile's model. */
+export function standardModelId(config: BotConfig): string {
+  return modelIdForProfile(config, STANDARD_MODEL_PROFILE);
+}
+
+/** Resolve a stable model profile through the host-owned profile catalog. */
+export function profileConfig(
+  config: BotConfig,
+  profile: ModelProfile,
+): ExecutionProfileConfig {
+  const profileConfig = Object.hasOwn(config.profiles, profile)
+    ? config.profiles[profile]
     : undefined;
-  if (!modelId) {
+  if (!profileConfig) {
     throw new ModelProfileNotConfiguredError(profile);
   }
-  return modelId;
+  return profileConfig;
 }

--- a/packages/junior/src/chat/plugins/model.ts
+++ b/packages/junior/src/chat/plugins/model.ts
@@ -4,6 +4,7 @@ import type {
   PluginModelConfig,
 } from "@sentry/junior-plugin-api";
 import { botConfig } from "@/chat/config";
+import { standardModelId } from "@/chat/model-profile";
 import { completeObject, embedTexts } from "@/chat/pi/client";
 
 /** Create the host-owned structured model capability exposed to plugins. */
@@ -17,7 +18,7 @@ export function createPluginModel(
       const modelId =
         options.structuredModelId ??
         (options.structuredModel === "default"
-          ? botConfig.modelId
+          ? standardModelId(botConfig)
           : botConfig.fastModelId);
       const result = await completeObject({
         modelId,

--- a/packages/junior/src/chat/prompt.ts
+++ b/packages/junior/src/chat/prompt.ts
@@ -349,7 +349,6 @@ const TURN_CONTEXT_HEADER =
 
 const TOOL_POLICY_RULES = [
   "- Tool schemas are the source of truth for parameters; tool names are case-sensitive, so call tools exactly by their exposed names and do not invent arguments.",
-  "- Model upgrade: when `handoff` is available, call it immediately and as the only tool before handling any request to write, edit, review, debug, or substantially reason about code; make a multi-file change; perform architecture or root-cause analysis; do research-heavy synthesis or complex planning; or complete another task where a more capable model materially improves reliability. Choose the configured profile whose name best fits the task, or omit `profile` to use the default. Do not inspect or modify files first. After handoff, continue the same task normally.",
   "- Use tools for actionable work and for facts that are mutable, external, repository-backed, provider-backed, or requested as verified/current. Stable general knowledge and already-provided context may be answered directly.",
   "- Resolve provider action targets before calls: explicit target wins; ambient `<configuration>` fills omitted targets. Treat non-target links/references as context.",
   "- Verification source order: conversation/thread context; user-provided attachments, links, and reference files; local/sandbox files when present; loaded skill references; repository/provider tools; public web. Use the nearest authoritative available source before weaker sources.",

--- a/packages/junior/src/chat/runtime/README.md
+++ b/packages/junior/src/chat/runtime/README.md
@@ -54,6 +54,9 @@ directory owns product orchestration around it.
 
 ## Compaction And Handoff
 
+- The host profile registry maps stable names to models and may force a
+  reasoning level. Only `standard` uses the turn router; named profiles start
+  directly and can use `handoff` to switch to another named profile.
 - Compaction replaces agent history. Its replacement history contains the
   retained user messages followed by a summary; later messages append normally.
   Visible conversation history remains unchanged.

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -10,6 +10,7 @@ import type { Message, SentMessage, Thread } from "chat";
 import type { SlackAdapter } from "@chat-adapter/slack";
 import { createSlackSource, type Destination } from "@sentry/junior-plugin-api";
 import { botConfig } from "@/chat/config";
+import { standardModelId } from "@/chat/model-profile";
 import { getSlackMessageTs } from "@/chat/slack/message";
 import { readSlackActionToken } from "@/chat/slack/action-token";
 import {
@@ -489,7 +490,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
         slackChannelId: channelId,
         runId,
         assistantUserName: botConfig.userName,
-        modelId: botConfig.modelId,
+        modelId: standardModelId(botConfig),
       },
       async () => {
         const strippedUserText = stripLeadingBotMention(message.text, {
@@ -560,7 +561,7 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           slackChannelId: channelId,
           runId,
           assistantUserName: botConfig.userName,
-          modelId: botConfig.modelId,
+          modelId: standardModelId(botConfig),
         };
         let beforeFirstResponsePostCalled = false;
         const beforeFirstResponsePost = async (): Promise<void> => {

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -6,6 +6,7 @@
  * reuse the shared Slack reply footer path when they are user-visible.
  */
 import { botConfig } from "@/chat/config";
+import { standardModelId } from "@/chat/model-profile";
 import type { ChannelConfigurationService } from "@/chat/configuration/types";
 import type { AgentRunRequest } from "@/chat/agent/request";
 import type { AgentRunResult } from "@/chat/services/turn-result";
@@ -220,7 +221,7 @@ function getResumeLogContext(
     slackUserName: isUserActor(actor) ? actor.userName : undefined,
     slackChannelId: args.channelId,
     assistantUserName: botConfig.userName,
-    modelId: botConfig.modelId,
+    modelId: standardModelId(botConfig),
   };
 }
 

--- a/packages/junior/src/chat/services/context-budget.ts
+++ b/packages/junior/src/chat/services/context-budget.ts
@@ -1,4 +1,5 @@
 import { botConfig } from "@/chat/config";
+import { standardModelId } from "@/chat/model-profile";
 import { resolveGatewayModel } from "@/chat/pi/client";
 
 const COMPACTION_TRIGGER_INPUT_RATIO = 0.75;
@@ -53,7 +54,7 @@ export function calculateContextCompactionTargetTokens(
 
 /** Resolve the automatic compaction threshold for the active agent model. */
 export function getAgentContextCompactionTriggerTokens(): number {
-  const model = resolveGatewayModel(botConfig.modelId);
+  const model = resolveGatewayModel(standardModelId(botConfig));
   return calculateContextCompactionTriggerTokens({
     contextWindow: botConfig.modelContextWindowTokens ?? model.contextWindow,
     maxTokens: model.maxTokens,

--- a/packages/junior/src/chat/services/context-compaction.ts
+++ b/packages/junior/src/chat/services/context-compaction.ts
@@ -85,7 +85,7 @@ interface HandoffContextArgs {
   piMessages: PiMessage[];
   runtimeContext: PiMessage[];
   signal?: AbortSignal;
-  triggeringToolCallId: string;
+  triggeringToolCallId?: string;
   target: {
     modelId: string;
     modelProfile: ModelProfile;
@@ -537,7 +537,9 @@ export async function compactContextForHandoff(
       type: "handoff",
       modelProfile: args.target.modelProfile,
       modelId: args.target.modelId,
-      triggeringToolCallId: args.triggeringToolCallId,
+      ...(args.triggeringToolCallId
+        ? { triggeringToolCallId: args.triggeringToolCallId }
+        : {}),
       replacementHistory: replacementMessages.map((replacementMessage) => ({
         message: replacementMessage,
         provenance: contextProvenance,

--- a/packages/junior/src/chat/services/turn-execution-profile.ts
+++ b/packages/junior/src/chat/services/turn-execution-profile.ts
@@ -5,6 +5,11 @@ import {
   TURN_REASONING_LEVELS,
   type TurnReasoningLevel,
 } from "@/chat/reasoning-level";
+import {
+  DEFAULT_HANDOFF_MODEL_PROFILE,
+  STANDARD_MODEL_PROFILE,
+  type ModelProfile,
+} from "@/chat/model-profile";
 import { renderCurrentInstruction } from "@/chat/current-instruction";
 import { setSpanAttributes, withSpan, type LogContext } from "@/chat/logging";
 
@@ -39,6 +44,10 @@ function coerceClassifierConfidence(value: unknown): unknown {
 
 const turnExecutionProfileSchema = z.object({
   reasoning_level: z.enum(TURN_REASONING_LEVELS),
+  model_profile: z.enum([
+    STANDARD_MODEL_PROFILE,
+    DEFAULT_HANDOFF_MODEL_PROFILE,
+  ]),
   confidence: z.preprocess(
     coerceClassifierConfidence,
     z.number().min(0).max(1),
@@ -46,13 +55,14 @@ const turnExecutionProfileSchema = z.object({
   reason: z.string().min(1),
 });
 
-export interface TurnReasoningSelection {
+export interface TurnExecutionProfile {
   confidence?: number;
   reasoningLevel: TurnReasoningLevel;
+  requestedModelProfile?: ModelProfile;
   reason: string;
 }
 
-const CLASSIFIER_FALLBACK_REASONING_LEVEL: TurnReasoningSelection["reasoningLevel"] =
+const CLASSIFIER_FALLBACK_REASONING_LEVEL: TurnExecutionProfile["reasoningLevel"] =
   "medium";
 const REASONING_LEVEL_RANK: Record<TurnReasoningLevel, number> = {
   none: 0,
@@ -94,8 +104,9 @@ function trimContextForRouter(text: string | undefined): TrimmedContext | null {
 
 function buildClassifierSystemPrompt(): string {
   return [
-    "You route assistant turns to the reasoning level most likely to produce a complete, source-grounded answer.",
+    "You choose the execution profile most likely to produce a complete, source-grounded answer.",
     "Choose exactly one bucket: none, low, medium, high, or xhigh.",
+    "Choose model_profile standard or handoff independently from the reasoning bucket.",
     "",
     "Use none only for greetings, acknowledgments, and turns that need no substantive assistant work.",
     "Use low rarely: only for deterministic one-step answers or transformations with no tools, no current/external facts, no prior thread-context interpretation, and no source verification.",
@@ -103,10 +114,12 @@ function buildClassifierSystemPrompt(): string {
     "Use high for research-heavy work, non-trivial drafting, or explicit requests to be thorough.",
     "Use xhigh for the most complex tasks: code changes, debugging/root-cause analysis, broad refactors, architecture decisions, multi-file implementation, or any task where deep reasoning across multiple systems or files is required.",
     "When unsure between two non-none buckets, choose the higher bucket. Do not use low as the default.",
+    "Use model_profile handoff for writing, editing, reviewing, debugging, or substantially reasoning about code; multi-file changes; architecture or root-cause analysis; research-heavy synthesis or complex planning; or another task where a more capable model materially improves reliability. Otherwise use standard.",
+    "Code architecture includes advice about dependency injection, module boundaries, configuration ownership, API design, and test strategy, even when the user requests advice only or says repository inspection is unnecessary.",
     "",
     "Classify based on the substance of the task, not the length of the current message. When the current instruction is a short affirmation (for example: 'go', 'do it', 'yes please', 'proceed') and prior thread context contains a pending task, classify the pending task — not the affirmation.",
     "",
-    "Return JSON only with reasoning_level, confidence, and reason.",
+    "Return JSON only with reasoning_level, model_profile, confidence, and reason.",
     "confidence must be a number from 0 to 1, not a word label.",
   ].join("\n");
 }
@@ -146,18 +159,18 @@ function buildClassifierPrompt(args: {
 }
 
 /** Preserve an explicitly configured reasoning level without invoking the router. */
-export function configuredTurnReasoningLevel(
+export function configuredTurnExecutionProfile(
   reasoningLevel: TurnReasoningLevel,
   source: "agent_config" | "default",
-): TurnReasoningSelection {
+): TurnExecutionProfile {
   return {
     reasoningLevel,
     reason: `configured:${source}`,
   };
 }
 
-/** Choose the reasoning level for the upcoming assistant turn when none is configured. */
-export async function selectTurnReasoningLevel(args: {
+/** Route the upcoming assistant turn to its reasoning and model profiles. */
+export async function selectTurnExecutionProfile(args: {
   completeObject: (args: {
     modelId: string;
     schema: typeof turnExecutionProfileSchema;
@@ -178,7 +191,7 @@ export async function selectTurnReasoningLevel(args: {
   currentTurnBlocks?: string[];
   fastModelId: string;
   messageText: string;
-}): Promise<TurnReasoningSelection> {
+}): Promise<TurnExecutionProfile> {
   const trimmedContext = trimContextForRouter(args.conversationContext);
   const instructionLength = args.messageText.trim().length;
   const turnBlockCount = (args.currentTurnBlocks ?? []).filter(
@@ -199,8 +212,8 @@ export async function selectTurnReasoningLevel(args: {
   };
 
   return withSpan(
-    "chat.route_reasoning",
-    "chat.route_reasoning",
+    "chat.route_execution_profile",
+    "chat.route_execution_profile",
     logContext,
     async () => {
       setSpanAttributes({
@@ -245,9 +258,9 @@ export async function selectTurnReasoningLevel(args: {
 }
 
 function applyReasoningFloor(
-  selection: TurnReasoningSelection,
+  selection: TurnExecutionProfile,
   args: { minimum?: TurnReasoningLevel },
-): TurnReasoningSelection {
+): TurnExecutionProfile {
   const minimum = args.minimum;
   if (
     !minimum ||
@@ -267,17 +280,17 @@ function applyReasoningFloor(
 
 async function classifyTurn(args: {
   completeObject: Parameters<
-    typeof selectTurnReasoningLevel
+    typeof selectTurnExecutionProfile
   >[0]["completeObject"];
   fastModelId: string;
   metadata: Record<string, string>;
   prompt: string;
-}): Promise<TurnReasoningSelection> {
+}): Promise<TurnExecutionProfile> {
   try {
     const result = await args.completeObject({
       modelId: args.fastModelId,
       schema: turnExecutionProfileSchema,
-      maxTokens: 120,
+      maxTokens: 140,
       metadata: args.metadata,
       prompt: args.prompt,
       thinkingLevel: "low",
@@ -299,6 +312,9 @@ async function classifyTurn(args: {
     return {
       confidence: parsed.confidence,
       reasoningLevel: parsed.reasoning_level,
+      ...(parsed.model_profile === DEFAULT_HANDOFF_MODEL_PROFILE
+        ? { requestedModelProfile: parsed.model_profile }
+        : {}),
       reason,
     };
   } catch {
@@ -311,7 +327,7 @@ async function classifyTurn(args: {
 
 /** Convert a routing bucket into the Pi Agent reasoning setting for a main turn. */
 export function toPiReasoningLevel(
-  level: TurnReasoningSelection["reasoningLevel"],
+  level: TurnExecutionProfile["reasoningLevel"],
 ): AgentThinkingLevel | "off" {
   switch (level) {
     case "none":

--- a/packages/junior/src/chat/services/turn-execution-profile.ts
+++ b/packages/junior/src/chat/services/turn-execution-profile.ts
@@ -8,7 +8,6 @@ import {
 import {
   DEFAULT_HANDOFF_MODEL_PROFILE,
   STANDARD_MODEL_PROFILE,
-  type ModelProfile,
 } from "@/chat/model-profile";
 import { renderCurrentInstruction } from "@/chat/current-instruction";
 import { setSpanAttributes, withSpan, type LogContext } from "@/chat/logging";
@@ -58,7 +57,7 @@ const turnExecutionProfileSchema = z.object({
 export interface TurnExecutionProfile {
   confidence?: number;
   reasoningLevel: TurnReasoningLevel;
-  requestedModelProfile?: ModelProfile;
+  requestedModelProfile?: typeof DEFAULT_HANDOFF_MODEL_PROFILE;
   reason: string;
 }
 
@@ -114,8 +113,8 @@ function buildClassifierSystemPrompt(): string {
     "Use high for research-heavy work, non-trivial drafting, or explicit requests to be thorough.",
     "Use xhigh for the most complex tasks: code changes, debugging/root-cause analysis, broad refactors, architecture decisions, multi-file implementation, or any task where deep reasoning across multiple systems or files is required.",
     "When unsure between two non-none buckets, choose the higher bucket. Do not use low as the default.",
-    "Use model_profile handoff for writing, editing, reviewing, debugging, or substantially reasoning about code; multi-file changes; architecture or root-cause analysis; research-heavy synthesis or complex planning; or another task where a more capable model materially improves reliability. Otherwise use standard.",
-    "Code architecture includes advice about dependency injection, module boundaries, configuration ownership, API design, and test strategy, even when the user requests advice only or says repository inspection is unnecessary.",
+    "Use model_profile handoff for writing, editing, reviewing, debugging, or substantially reasoning about code; multi-file changes; root-cause analysis; research-heavy synthesis or complex planning; or another task where a more capable model materially improves reliability. Otherwise use standard.",
+    "Any request for a software architecture or component-design decision must use handoff, including advice-only requests with no implementation.",
     "",
     "Classify based on the substance of the task, not the length of the current message. When the current instruction is a short affirmation (for example: 'go', 'do it', 'yes please', 'proceed') and prior thread context contains a pending task, classify the pending task — not the affirmation.",
     "",

--- a/packages/junior/src/chat/services/turn-result.ts
+++ b/packages/junior/src/chat/services/turn-result.ts
@@ -2,7 +2,7 @@ import { logInfo, logWarn, summarizeMessageText } from "@/chat/logging";
 import type { LogContext } from "@/chat/logging";
 import { containsNoReplyMarker, isNoReplyMarker } from "@/chat/no-reply";
 import type { PiMessage } from "@/chat/pi/messages";
-import type { TurnReasoningSelection } from "@/chat/services/turn-reasoning-level";
+import type { TurnExecutionProfile } from "@/chat/services/turn-execution-profile";
 import type { AgentTurnUsage } from "@/chat/usage";
 import type { ThreadArtifactsState } from "@/chat/state/artifacts";
 import {
@@ -100,7 +100,7 @@ export interface AgentTurnDiagnostics {
   providerError?: unknown;
   modelId: string;
   outcome: "success" | "execution_failure" | "provider_error";
-  reasoningLevel?: TurnReasoningSelection["reasoningLevel"];
+  reasoningLevel?: TurnExecutionProfile["reasoningLevel"];
   stopReason?: string;
   toolCalls: string[];
   toolErrorCount: number;
@@ -132,7 +132,7 @@ export interface TurnResultInput {
   shouldTrace: boolean;
   spanContext: LogContext;
   usage?: AgentTurnUsage;
-  reasoningSelection: TurnReasoningSelection;
+  executionProfile: TurnExecutionProfile;
   assistantUserName?: string;
   modelId: string;
 }
@@ -194,7 +194,7 @@ export function buildTurnResult(input: TurnResultInput): AgentRunResult {
     shouldTrace,
     spanContext,
     usage,
-    reasoningSelection,
+    executionProfile,
     assistantUserName,
     modelId,
   } = input;
@@ -324,7 +324,7 @@ export function buildTurnResult(input: TurnResultInput): AgentRunResult {
     outcome: resolvedOutcome,
     modelId,
     assistantMessageCount: assistantMessages.length,
-    reasoningLevel: reasoningSelection.reasoningLevel,
+    reasoningLevel: executionProfile.reasoningLevel,
     toolCalls,
     toolResultCount: toolResults.length,
     toolErrorCount,

--- a/packages/junior/src/chat/services/turn-result.ts
+++ b/packages/junior/src/chat/services/turn-result.ts
@@ -2,7 +2,7 @@ import { logInfo, logWarn, summarizeMessageText } from "@/chat/logging";
 import type { LogContext } from "@/chat/logging";
 import { containsNoReplyMarker, isNoReplyMarker } from "@/chat/no-reply";
 import type { PiMessage } from "@/chat/pi/messages";
-import type { TurnExecutionProfile } from "@/chat/services/turn-execution-profile";
+import type { TurnRoute } from "@/chat/services/turn-router";
 import type { AgentTurnUsage } from "@/chat/usage";
 import type { ThreadArtifactsState } from "@/chat/state/artifacts";
 import {
@@ -100,7 +100,7 @@ export interface AgentTurnDiagnostics {
   providerError?: unknown;
   modelId: string;
   outcome: "success" | "execution_failure" | "provider_error";
-  reasoningLevel?: TurnExecutionProfile["reasoningLevel"];
+  reasoningLevel?: TurnRoute["reasoningLevel"];
   stopReason?: string;
   toolCalls: string[];
   toolErrorCount: number;
@@ -132,7 +132,7 @@ export interface TurnResultInput {
   shouldTrace: boolean;
   spanContext: LogContext;
   usage?: AgentTurnUsage;
-  executionProfile: TurnExecutionProfile;
+  executionProfile: TurnRoute;
   assistantUserName?: string;
   modelId: string;
 }

--- a/packages/junior/src/chat/services/turn-router.ts
+++ b/packages/junior/src/chat/services/turn-router.ts
@@ -6,7 +6,9 @@ import {
   type TurnReasoningLevel,
 } from "@/chat/reasoning-level";
 import {
-  DEFAULT_HANDOFF_MODEL_PROFILE,
+  type ModelProfile,
+  type ExecutionProfileConfig,
+  modelProfileSchema,
   STANDARD_MODEL_PROFILE,
 } from "@/chat/model-profile";
 import { renderCurrentInstruction } from "@/chat/current-instruction";
@@ -41,27 +43,31 @@ function coerceClassifierConfidence(value: unknown): unknown {
   return CONFIDENCE_LABELS[trimmed] ?? value;
 }
 
-const turnExecutionProfileSchema = z.object({
-  reasoning_level: z.enum(TURN_REASONING_LEVELS),
-  model_profile: z.enum([
-    STANDARD_MODEL_PROFILE,
-    DEFAULT_HANDOFF_MODEL_PROFILE,
-  ]),
-  confidence: z.preprocess(
-    coerceClassifierConfidence,
-    z.number().min(0).max(1),
-  ),
-  reason: z.string().min(1),
-});
+function createTurnRouteSchema(
+  profiles: Readonly<Record<string, ExecutionProfileConfig>>,
+) {
+  return z.object({
+    reasoning_level: z.enum(TURN_REASONING_LEVELS),
+    profile: modelProfileSchema.refine(
+      (profile) => Object.hasOwn(profiles, profile),
+      "Profile is not configured",
+    ),
+    confidence: z.preprocess(
+      coerceClassifierConfidence,
+      z.number().min(0).max(1),
+    ),
+    reason: z.string().min(1),
+  });
+}
 
-export interface TurnExecutionProfile {
+export interface TurnRoute {
   confidence?: number;
+  profile: ModelProfile;
   reasoningLevel: TurnReasoningLevel;
-  requestedModelProfile?: typeof DEFAULT_HANDOFF_MODEL_PROFILE;
   reason: string;
 }
 
-const CLASSIFIER_FALLBACK_REASONING_LEVEL: TurnExecutionProfile["reasoningLevel"] =
+const CLASSIFIER_FALLBACK_REASONING_LEVEL: TurnRoute["reasoningLevel"] =
   "medium";
 const REASONING_LEVEL_RANK: Record<TurnReasoningLevel, number> = {
   none: 0,
@@ -101,11 +107,12 @@ function trimContextForRouter(text: string | undefined): TrimmedContext | null {
   };
 }
 
-function buildClassifierSystemPrompt(): string {
+function buildClassifierSystemPrompt(profileNames: string[]): string {
   return [
     "You choose the execution profile most likely to produce a complete, source-grounded answer.",
     "Choose exactly one bucket: none, low, medium, high, or xhigh.",
-    "Choose model_profile standard or handoff independently from the reasoning bucket.",
+    `Choose profile from the configured profiles: ${profileNames.join(", ")}.`,
+    "Choose profile independently from the reasoning bucket.",
     "",
     "Use none only for greetings, acknowledgments, and turns that need no substantive assistant work.",
     "Use low rarely: only for deterministic one-step answers or transformations with no tools, no current/external facts, no prior thread-context interpretation, and no source verification.",
@@ -113,12 +120,12 @@ function buildClassifierSystemPrompt(): string {
     "Use high for research-heavy work, non-trivial drafting, or explicit requests to be thorough.",
     "Use xhigh for the most complex tasks: code changes, debugging/root-cause analysis, broad refactors, architecture decisions, multi-file implementation, or any task where deep reasoning across multiple systems or files is required.",
     "When unsure between two non-none buckets, choose the higher bucket. Do not use low as the default.",
-    "Use model_profile handoff for writing, editing, reviewing, debugging, or substantially reasoning about code; multi-file changes; root-cause analysis; research-heavy synthesis or complex planning; or another task where a more capable model materially improves reliability. Otherwise use standard.",
+    "Use profile handoff for writing, editing, reviewing, debugging, or substantially reasoning about code; multi-file changes; root-cause analysis; research-heavy synthesis or complex planning; or another task where a more capable model materially improves reliability. Otherwise use standard.",
     "Any request for a software architecture or component-design decision must use handoff, including advice-only requests with no implementation.",
     "",
     "Classify based on the substance of the task, not the length of the current message. When the current instruction is a short affirmation (for example: 'go', 'do it', 'yes please', 'proceed') and prior thread context contains a pending task, classify the pending task — not the affirmation.",
     "",
-    "Return JSON only with reasoning_level, model_profile, confidence, and reason.",
+    "Return JSON only with reasoning_level, profile, confidence, and reason.",
     "confidence must be a number from 0 to 1, not a word label.",
   ].join("\n");
 }
@@ -158,21 +165,23 @@ function buildClassifierPrompt(args: {
 }
 
 /** Preserve an explicitly configured reasoning level without invoking the router. */
-export function configuredTurnExecutionProfile(
+export function configuredTurnRoute(
+  profile: ModelProfile,
   reasoningLevel: TurnReasoningLevel,
-  source: "agent_config" | "default",
-): TurnExecutionProfile {
+  source: "agent_config" | "default" | "profile",
+): TurnRoute {
   return {
+    profile,
     reasoningLevel,
     reason: `configured:${source}`,
   };
 }
 
 /** Route the upcoming assistant turn to its reasoning and model profiles. */
-export async function selectTurnExecutionProfile(args: {
+export async function selectTurnRoute(args: {
   completeObject: (args: {
     modelId: string;
-    schema: typeof turnExecutionProfileSchema;
+    schema: ReturnType<typeof createTurnRouteSchema>;
     maxTokens: number;
     metadata: Record<string, string>;
     prompt: string;
@@ -190,7 +199,8 @@ export async function selectTurnExecutionProfile(args: {
   currentTurnBlocks?: string[];
   fastModelId: string;
   messageText: string;
-}): Promise<TurnExecutionProfile> {
+  profiles: Readonly<Record<string, ExecutionProfileConfig>>;
+}): Promise<TurnRoute> {
   const trimmedContext = trimContextForRouter(args.conversationContext);
   const instructionLength = args.messageText.trim().length;
   const turnBlockCount = (args.currentTurnBlocks ?? []).filter(
@@ -234,11 +244,16 @@ export async function selectTurnExecutionProfile(args: {
           actorId: args.context?.actorId ?? "",
           runId: args.context?.runId ?? "",
         },
+        profiles: args.profiles,
         prompt,
       });
-      const normalizedSelection = applyReasoningFloor(selection, {
+      const flooredSelection = applyReasoningFloor(selection, {
         minimum: trimmedContext || turnBlockCount > 0 ? "medium" : undefined,
       });
+      const normalizedSelection = applyProfileReasoningOverride(
+        flooredSelection,
+        args.profiles,
+      );
 
       setSpanAttributes({
         "gen_ai.request.reasoning.level": normalizedSelection.reasoningLevel,
@@ -257,9 +272,9 @@ export async function selectTurnExecutionProfile(args: {
 }
 
 function applyReasoningFloor(
-  selection: TurnExecutionProfile,
+  selection: TurnRoute,
   args: { minimum?: TurnReasoningLevel },
-): TurnExecutionProfile {
+): TurnRoute {
   const minimum = args.minimum;
   if (
     !minimum ||
@@ -277,32 +292,48 @@ function applyReasoningFloor(
   };
 }
 
+function applyProfileReasoningOverride(
+  route: TurnRoute,
+  profiles: Readonly<Record<string, ExecutionProfileConfig>>,
+): TurnRoute {
+  const reasoningLevel = profiles[route.profile]?.reasoningLevel;
+  if (!reasoningLevel || reasoningLevel === route.reasoningLevel) {
+    return route;
+  }
+  return {
+    ...route,
+    reasoningLevel,
+    reason: `profile_reasoning_override:${route.profile}:${route.reason}`,
+  };
+}
+
 async function classifyTurn(args: {
-  completeObject: Parameters<
-    typeof selectTurnExecutionProfile
-  >[0]["completeObject"];
+  completeObject: Parameters<typeof selectTurnRoute>[0]["completeObject"];
   fastModelId: string;
   metadata: Record<string, string>;
+  profiles: Readonly<Record<string, ExecutionProfileConfig>>;
   prompt: string;
-}): Promise<TurnExecutionProfile> {
+}): Promise<TurnRoute> {
   try {
+    const schema = createTurnRouteSchema(args.profiles);
     const result = await args.completeObject({
       modelId: args.fastModelId,
-      schema: turnExecutionProfileSchema,
+      schema,
       maxTokens: 140,
       metadata: args.metadata,
       prompt: args.prompt,
       thinkingLevel: "low",
-      system: buildClassifierSystemPrompt(),
+      system: buildClassifierSystemPrompt(Object.keys(args.profiles)),
       temperature: 0,
     });
 
-    const parsed = turnExecutionProfileSchema.parse(result.object);
+    const parsed = schema.parse(result.object);
     const reason = parsed.reason.trim();
 
     if (parsed.confidence < CLASSIFIER_CONFIDENCE_THRESHOLD) {
       return {
         confidence: parsed.confidence,
+        profile: STANDARD_MODEL_PROFILE,
         reasoningLevel: CLASSIFIER_FALLBACK_REASONING_LEVEL,
         reason: `low_confidence_medium_default:${reason}`,
       };
@@ -310,14 +341,13 @@ async function classifyTurn(args: {
 
     return {
       confidence: parsed.confidence,
+      profile: parsed.profile,
       reasoningLevel: parsed.reasoning_level,
-      ...(parsed.model_profile === DEFAULT_HANDOFF_MODEL_PROFILE
-        ? { requestedModelProfile: parsed.model_profile }
-        : {}),
       reason,
     };
   } catch {
     return {
+      profile: STANDARD_MODEL_PROFILE,
       reasoningLevel: CLASSIFIER_FALLBACK_REASONING_LEVEL,
       reason: "classifier_error_default",
     };
@@ -326,7 +356,7 @@ async function classifyTurn(args: {
 
 /** Convert a routing bucket into the Pi Agent reasoning setting for a main turn. */
 export function toPiReasoningLevel(
-  level: TurnExecutionProfile["reasoningLevel"],
+  level: TurnRoute["reasoningLevel"],
 ): AgentThinkingLevel | "off" {
   switch (level) {
     case "none":

--- a/packages/junior/src/chat/slack/vision-context.ts
+++ b/packages/junior/src/chat/slack/vision-context.ts
@@ -1,5 +1,6 @@
 import type { Attachment } from "chat";
 import { botConfig } from "@/chat/config";
+import { standardModelId } from "@/chat/model-profile";
 import type { completeText } from "@/chat/pi/client";
 import type { ThreadConversationState } from "@/chat/state/conversation";
 import { toOptionalString } from "@/chat/coerce";
@@ -318,7 +319,7 @@ async function resolveUserAttachmentsWithDeps(
             slackChannelId: context.channelId,
             runId: context.runId,
             assistantUserName: botConfig.userName,
-            modelId: botConfig.modelId,
+            modelId: standardModelId(botConfig),
           },
           {
             "file.size": data.byteLength,
@@ -347,7 +348,7 @@ async function resolveUserAttachmentsWithDeps(
             slackChannelId: context.channelId,
             runId: context.runId,
             assistantUserName: botConfig.userName,
-            modelId: botConfig.visionModelId ?? botConfig.modelId,
+            modelId: botConfig.visionModelId ?? standardModelId(botConfig),
           },
           {
             "exception.message":
@@ -368,7 +369,7 @@ async function resolveUserAttachmentsWithDeps(
           slackChannelId: context.channelId,
           runId: context.runId,
           assistantUserName: botConfig.userName,
-          modelId: botConfig.modelId,
+          modelId: standardModelId(botConfig),
         },
         {
           "exception.message":
@@ -509,7 +510,7 @@ async function hydrateConversationVisionContextWithDeps(
         slackChannelId: context.channelId,
         runId: context.runId,
         assistantUserName: botConfig.userName,
-        modelId: botConfig.modelId,
+        modelId: standardModelId(botConfig),
       },
       {
         "exception.message":
@@ -593,7 +594,7 @@ async function hydrateConversationVisionContextWithDeps(
             slackChannelId: context.channelId,
             runId: context.runId,
             assistantUserName: botConfig.userName,
-            modelId: botConfig.modelId,
+            modelId: standardModelId(botConfig),
           },
           {
             "app.file.id": fileId,
@@ -624,7 +625,7 @@ async function hydrateConversationVisionContextWithDeps(
             slackChannelId: context.channelId,
             runId: context.runId,
             assistantUserName: botConfig.userName,
-            modelId: botConfig.modelId,
+            modelId: standardModelId(botConfig),
           },
           {
             "exception.message":
@@ -646,7 +647,7 @@ async function hydrateConversationVisionContextWithDeps(
             slackChannelId: context.channelId,
             runId: context.runId,
             assistantUserName: botConfig.userName,
-            modelId: botConfig.modelId,
+            modelId: standardModelId(botConfig),
           },
           {
             "app.file.id": fileId,
@@ -698,7 +699,7 @@ async function hydrateConversationVisionContextWithDeps(
         slackChannelId: context.channelId,
         runId: context.runId,
         assistantUserName: botConfig.userName,
-        modelId: botConfig.modelId,
+        modelId: standardModelId(botConfig),
       },
       {
         "app.conversation_image.cache_hits": cacheHits,

--- a/packages/junior/src/chat/tools/handoff/tool.ts
+++ b/packages/junior/src/chat/tools/handoff/tool.ts
@@ -6,12 +6,11 @@ import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 
 export const HANDOFF_TOOL_NAME = "handoff";
 
-/** Create the terminal standard-agent control for an in-place model upgrade. */
+/** Create the runtime control for an in-place execution-profile switch. */
 export function createHandoffTool(
   handoff: NonNullable<ToolRuntimeContext["handoff"]>,
 ) {
   const profileSchema = z.enum(handoff.profiles);
-  const defaultProfile = handoff.profiles[0];
   const handoffResultSchema = juniorToolResultSchema.extend({
     model_profile: profileSchema,
   });
@@ -19,20 +18,16 @@ export function createHandoffTool(
     .map((profile) => `\`${profile}\``)
     .join(", ");
   return zodTool({
-    description: `Permanently switch this conversation to a more capable model profile, replace prior context with a continuation summary, and continue the same task with the same workspace and all other normal tools. Available profiles: ${profileNames}. Omit profile to use \`${defaultProfile}\`. Call it as the only tool in the assistant message when the system tool policy requires a model upgrade.`,
+    description: `Switch execution profiles and continue the same task with the same workspace and tools. Available profiles: ${profileNames}. Call this as the only tool in the assistant message.`,
     executionMode: "sequential",
     inputSchema: z
       .object({
-        profile: profileSchema
-          .nullish()
-          .describe(
-            "Named model profile to use for the rest of the conversation; omit or pass null for the default",
-          ),
+        profile: profileSchema.describe("Execution profile to switch to"),
       })
       .strict(),
     outputSchema: handoffResultSchema,
     execute: async (input, options) => {
-      const profile = input.profile ?? defaultProfile;
+      const profile = input.profile;
       if (!options.toolCallId) {
         throw new ToolInputError("Handoff requires an active tool call ID");
       }

--- a/packages/junior/src/chat/tools/handoff/tool.ts
+++ b/packages/junior/src/chat/tools/handoff/tool.ts
@@ -18,11 +18,11 @@ export function createHandoffTool(
     .map((profile) => `\`${profile}\``)
     .join(", ");
   return zodTool({
-    description: `Switch execution profiles and continue the same task with the same workspace and tools. Available profiles: ${profileNames}. Call this as the only tool in the assistant message.`,
+    description: `Switch to another execution profile and continue the same task. Profiles: ${profileNames}. Call this as the only tool.`,
     executionMode: "sequential",
     inputSchema: z
       .object({
-        profile: profileSchema.describe("Execution profile to switch to"),
+        profile: profileSchema.describe("Target execution profile"),
       })
       .strict(),
     outputSchema: handoffResultSchema,

--- a/packages/junior/src/chat/tools/types.ts
+++ b/packages/junior/src/chat/tools/types.ts
@@ -21,7 +21,7 @@ import type { ModelProfile } from "@/chat/model-profile";
 import type { GeneratedArtifactFileRef } from "@/chat/tools/sandbox/file-uploads";
 
 interface HandoffControl {
-  /** Non-empty catalog with the default target first. */
+  /** Non-empty catalog of configured targets. */
   profiles: readonly [ModelProfile, ...ModelProfile[]];
   execute: (
     profile: ModelProfile,

--- a/packages/junior/src/cli/upgrade/migrations/conversations-history-sql.ts
+++ b/packages/junior/src/cli/upgrade/migrations/conversations-history-sql.ts
@@ -1,4 +1,5 @@
 import { getChatConfig } from "@/chat/config";
+import { standardModelId } from "@/chat/model-profile";
 import { importConversationFromLegacy } from "./conversation-history/import";
 import { createStateConversationStore } from "./conversation-history/state-conversation-store";
 import type { LegacyAdvisorSessionReader } from "./conversation-history/advisor-session";
@@ -62,7 +63,7 @@ export async function migrateConversationHistoryToSql(
           conversation.conversationId,
           {
             executor,
-            modelId: chatConfig.bot.modelId,
+            modelId: standardModelId(chatConfig.bot),
             conversationRecord: conversation,
             ...(options.sessionLogStore
               ? { sessionLogStore: options.sessionLogStore }

--- a/packages/junior/tests/component/cli/conversation-event-migration.test.ts
+++ b/packages/junior/tests/component/cli/conversation-event-migration.test.ts
@@ -904,8 +904,10 @@ ORDER BY indexname
       embeddingModelId: "test/embedding",
       fastModelId: "test/fast",
       loadingMessages: [],
-      modelId: "test/standard",
-      modelProfiles: { handoff: "test/handoff" },
+      profiles: {
+        standard: { modelId: "test/standard" },
+        handoff: { modelId: "test/handoff", reasoningLevel: "xhigh" as const },
+      },
       maxSlicesPerTurn: 1,
       turnTimeoutMs: 1,
       userName: "Junior",

--- a/packages/junior/tests/component/config/chat-config.test.ts
+++ b/packages/junior/tests/component/config/chat-config.test.ts
@@ -24,7 +24,9 @@ describe("chat config", () => {
     delete process.env.AI_FAST_MODEL;
 
     const { botConfig } = await loadConfig();
-    expect(botConfig.modelId).toBe("anthropic/claude-opus-4.6");
+    expect(botConfig.profiles.standard).toEqual({
+      modelId: "anthropic/claude-opus-4.6",
+    });
     expect(botConfig.fastModelId).toBe("anthropic/claude-opus-4.6");
   });
 
@@ -48,7 +50,9 @@ describe("chat config", () => {
     delete process.env.AI_MODEL;
 
     const { botConfig } = await loadConfig();
-    expect(botConfig.modelId).toBe("xai/grok-4.5");
+    expect(botConfig.profiles.standard).toEqual({
+      modelId: "xai/grok-4.5",
+    });
   });
 
   it("leaves reasoning unset by default", async () => {
@@ -83,8 +87,12 @@ describe("chat config", () => {
     delete process.env.AI_MODEL_PROFILES;
 
     const { botConfig } = await loadConfig();
-    expect(botConfig.modelProfiles).toEqual({
-      handoff: "openai/gpt-5.6-sol",
+    expect(botConfig.profiles).toEqual({
+      standard: { modelId: "xai/grok-4.5" },
+      handoff: {
+        modelId: "openai/gpt-5.6-sol",
+        reasoningLevel: "xhigh",
+      },
     });
   });
 
@@ -92,7 +100,10 @@ describe("chat config", () => {
     process.env.AI_HANDOFF_MODEL = "openai/gpt-5.4";
 
     const { botConfig } = await loadConfig();
-    expect(botConfig.modelProfiles.handoff).toBe("openai/gpt-5.4");
+    expect(botConfig.profiles.handoff).toEqual({
+      modelId: "openai/gpt-5.4",
+      reasoningLevel: "xhigh",
+    });
   });
 
   it("adds named profiles from AI_MODEL_PROFILES", async () => {
@@ -102,10 +113,14 @@ describe("chat config", () => {
     });
 
     const { botConfig } = await loadConfig();
-    expect(botConfig.modelProfiles).toEqual({
-      handoff: "openai/gpt-5.6-sol",
-      coding: "openai/gpt-5.4",
-      research: "anthropic/claude-opus-4.6",
+    expect(botConfig.profiles).toEqual({
+      standard: { modelId: "xai/grok-4.5" },
+      handoff: {
+        modelId: "openai/gpt-5.6-sol",
+        reasoningLevel: "xhigh",
+      },
+      coding: { modelId: "openai/gpt-5.4" },
+      research: { modelId: "anthropic/claude-opus-4.6" },
     });
   });
 
@@ -238,7 +253,9 @@ describe("chat config", () => {
     process.env.AI_VISION_MODEL = "openai/gpt-5.4";
 
     const { botConfig } = await loadConfig();
-    expect(botConfig.modelId).toBe("anthropic/claude-opus-4.6");
+    expect(botConfig.profiles.standard).toEqual({
+      modelId: "anthropic/claude-opus-4.6",
+    });
     expect(botConfig.visionModelId).toBe("openai/gpt-5.4");
   });
 

--- a/packages/junior/tests/component/conversation-storage-sql.test.ts
+++ b/packages/junior/tests/component/conversation-storage-sql.test.ts
@@ -51,6 +51,14 @@ it("accepts compaction and handoff as the only live history replacements", () =>
       type: "handoff",
       modelProfile: "handoff",
       modelId: "openai/gpt-5.6-sol",
+      replacementHistory: [],
+    }).success,
+  ).toBe(true);
+  expect(
+    conversationEventDataSchema.safeParse({
+      type: "handoff",
+      modelProfile: "handoff",
+      modelId: "openai/gpt-5.6-sol",
       triggeringToolCallId: "handoff-call-1",
       replacementHistory: [],
     }).success,
@@ -61,7 +69,6 @@ it("accepts compaction and handoff as the only live history replacements", () =>
     {
       type: "handoff",
       modelProfile: "handoff",
-      modelId: "openai/gpt-5.6-sol",
       replacementHistory: [],
     },
   ]) {
@@ -208,7 +215,6 @@ it("rejects incomplete handoffs through the replacement boundary", async () => {
       data: {
         type: "handoff",
         modelProfile: "handoff",
-        modelId: "openai/gpt-5.6-sol",
         replacementHistory: [],
       },
     } as never),

--- a/packages/junior/tests/component/services/context-compaction.test.ts
+++ b/packages/junior/tests/component/services/context-compaction.test.ts
@@ -303,7 +303,7 @@ describe("context compaction projection reset", () => {
         runtimeContext,
         triggeringToolCallId: "handoff-call-1",
         target: {
-          modelId: botConfig.modelProfiles.handoff,
+          modelId: botConfig.profiles.handoff!.modelId,
           modelProfile: "handoff",
         },
       },
@@ -346,7 +346,7 @@ describe("context compaction projection reset", () => {
     expect(marker).toEqual({
       type: "handoff",
       modelProfile: "handoff",
-      modelId: botConfig.modelProfiles.handoff,
+      modelId: botConfig.profiles.handoff!.modelId,
       triggeringToolCallId: "handoff-call-1",
       replacementHistory: [
         {
@@ -397,12 +397,12 @@ describe("context compaction projection reset", () => {
       {
         type: "handoff",
         modelProfile: "handoff",
-        modelId: botConfig.modelProfiles.handoff,
+        modelId: botConfig.profiles.handoff!.modelId,
       },
       {
         type: "compaction",
         modelProfile: "handoff",
-        modelId: botConfig.modelProfiles.handoff,
+        modelId: botConfig.profiles.handoff!.modelId,
       },
     ]);
   });

--- a/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
+++ b/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
@@ -98,15 +98,15 @@ function expectBlocksIncludeConversationId(
   expect(JSON.stringify(params.blocks)).toContain(conversationId);
 }
 
-vi.mock("@/chat/services/turn-reasoning-level", async () => {
+vi.mock("@/chat/services/turn-execution-profile", async () => {
   const actual = await vi.importActual<
-    typeof import("@/chat/services/turn-reasoning-level")
-  >("@/chat/services/turn-reasoning-level");
+    typeof import("@/chat/services/turn-execution-profile")
+  >("@/chat/services/turn-execution-profile");
   return {
     ...actual,
     // Bypass the classifier to keep this an agent-boundary test with no
     // model traffic.
-    selectTurnReasoningLevel: async () => ({
+    selectTurnExecutionProfile: async () => ({
       reasoningLevel: "medium" as const,
       reason: "test_default",
     }),

--- a/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
+++ b/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
@@ -98,15 +98,16 @@ function expectBlocksIncludeConversationId(
   expect(JSON.stringify(params.blocks)).toContain(conversationId);
 }
 
-vi.mock("@/chat/services/turn-execution-profile", async () => {
+vi.mock("@/chat/services/turn-router", async () => {
   const actual = await vi.importActual<
-    typeof import("@/chat/services/turn-execution-profile")
-  >("@/chat/services/turn-execution-profile");
+    typeof import("@/chat/services/turn-router")
+  >("@/chat/services/turn-router");
   return {
     ...actual,
     // Bypass the classifier to keep this an agent-boundary test with no
     // model traffic.
-    selectTurnExecutionProfile: async () => ({
+    selectTurnRoute: async () => ({
+      profile: "standard" as const,
       reasoningLevel: "medium" as const,
       reason: "test_default",
     }),

--- a/packages/junior/tests/integration/plugin-auth-runtime-slack.test.ts
+++ b/packages/junior/tests/integration/plugin-auth-runtime-slack.test.ts
@@ -17,13 +17,13 @@ import {
 import { hydrateConversationMessages } from "@/chat/conversations/messages";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
 
-vi.mock("@/chat/services/turn-reasoning-level", async () => {
+vi.mock("@/chat/services/turn-execution-profile", async () => {
   const actual = await vi.importActual<
-    typeof import("@/chat/services/turn-reasoning-level")
-  >("@/chat/services/turn-reasoning-level");
+    typeof import("@/chat/services/turn-execution-profile")
+  >("@/chat/services/turn-execution-profile");
   return {
     ...actual,
-    selectTurnReasoningLevel: async () => ({
+    selectTurnExecutionProfile: async () => ({
       reasoningLevel: "medium" as const,
       reason: "test_default",
     }),

--- a/packages/junior/tests/integration/plugin-auth-runtime-slack.test.ts
+++ b/packages/junior/tests/integration/plugin-auth-runtime-slack.test.ts
@@ -17,13 +17,14 @@ import {
 import { hydrateConversationMessages } from "@/chat/conversations/messages";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
 
-vi.mock("@/chat/services/turn-execution-profile", async () => {
+vi.mock("@/chat/services/turn-router", async () => {
   const actual = await vi.importActual<
-    typeof import("@/chat/services/turn-execution-profile")
-  >("@/chat/services/turn-execution-profile");
+    typeof import("@/chat/services/turn-router")
+  >("@/chat/services/turn-router");
   return {
     ...actual,
-    selectTurnExecutionProfile: async () => ({
+    selectTurnRoute: async () => ({
+      profile: "standard" as const,
       reasoningLevel: "medium" as const,
       reason: "test_default",
     }),

--- a/packages/junior/tests/integration/plugin-prompt-hooks.test.ts
+++ b/packages/junior/tests/integration/plugin-prompt-hooks.test.ts
@@ -92,6 +92,7 @@ vi.mock("@/chat/pi/client", () => ({
   completeObject: async () => ({
     object: {
       reasoning_level: "medium",
+      model_profile: "standard",
       confidence: 1,
       reason: "test-router",
     },

--- a/packages/junior/tests/integration/plugin-prompt-hooks.test.ts
+++ b/packages/junior/tests/integration/plugin-prompt-hooks.test.ts
@@ -92,7 +92,7 @@ vi.mock("@/chat/pi/client", () => ({
   completeObject: async () => ({
     object: {
       reasoning_level: "medium",
-      model_profile: "standard",
+      profile: "standard",
       confidence: 1,
       reason: "test-router",
     },

--- a/packages/junior/tests/integration/plugin-run-actors.test.ts
+++ b/packages/junior/tests/integration/plugin-run-actors.test.ts
@@ -87,7 +87,7 @@ vi.mock("@/chat/pi/client", () => ({
   completeObject: async () => ({
     object: {
       reasoning_level: "medium",
-      model_profile: "standard",
+      profile: "standard",
       confidence: 1,
       reason: "test-router",
     },

--- a/packages/junior/tests/integration/plugin-run-actors.test.ts
+++ b/packages/junior/tests/integration/plugin-run-actors.test.ts
@@ -87,6 +87,7 @@ vi.mock("@/chat/pi/client", () => ({
   completeObject: async () => ({
     object: {
       reasoning_level: "medium",
+      model_profile: "standard",
       confidence: 1,
       reason: "test-router",
     },

--- a/packages/junior/tests/integration/runtime/agent-run-agent-continue.test.ts
+++ b/packages/junior/tests/integration/runtime/agent-run-agent-continue.test.ts
@@ -203,7 +203,7 @@ vi.mock("@/chat/pi/client", () => ({
   completeObject: async () => ({
     object: {
       reasoning_level: "medium",
-      model_profile: "standard",
+      profile: "standard",
       confidence: 1,
       reason: "test-router",
     },

--- a/packages/junior/tests/integration/runtime/agent-run-agent-continue.test.ts
+++ b/packages/junior/tests/integration/runtime/agent-run-agent-continue.test.ts
@@ -203,6 +203,7 @@ vi.mock("@/chat/pi/client", () => ({
   completeObject: async () => ({
     object: {
       reasoning_level: "medium",
+      model_profile: "standard",
       confidence: 1,
       reason: "test-router",
     },

--- a/packages/junior/tests/integration/runtime/agent-run-model-handoff.test.ts
+++ b/packages/junior/tests/integration/runtime/agent-run-model-handoff.test.ts
@@ -14,6 +14,7 @@ const observations = vi.hoisted(() => ({
   progressTool: false,
   providerCalls: 0,
   requestedProfile: undefined as string | null | undefined,
+  routedModelProfile: "standard",
   routedReasoningLevel: "high",
   reasoningLevels: [] as string[],
   summaryCalls: 0,
@@ -38,6 +39,7 @@ vi.mock("@/chat/pi/client", async (importOriginal) => {
     completeObject: async () => ({
       object: {
         reasoning_level: observations.routedReasoningLevel,
+        model_profile: observations.routedModelProfile,
         confidence: 0.99,
         reason: "complex implementation",
       },
@@ -57,6 +59,8 @@ vi.mock("@/chat/pi/traced-stream", () => ({
       observations.providerCalls += 1;
       observations.reasoningLevels.push(options?.reasoning ?? "unset");
       const call = observations.providerCalls;
+      const routerForcedHandoff =
+        call === 1 && observations.routedModelProfile === "handoff";
       if (call === 1) {
         observations.initialModelId = model.id;
         observations.initialToolNames = (context.tools ?? []).map(
@@ -70,8 +74,9 @@ vi.mock("@/chat/pi/traced-stream", () => ({
         );
       }
 
-      const text =
-        call === 1
+      const text = routerForcedHandoff
+        ? "Handoff model completed it."
+        : call === 1
           ? observations.progressTool
             ? "Let me do that now."
             : "The standard model started an answer that must be hidden."
@@ -79,7 +84,7 @@ vi.mock("@/chat/pi/traced-stream", () => ({
             ? "Standard model recovered safely."
             : "Handoff model completed it.";
       const content: Array<Record<string, unknown>> = [{ type: "text", text }];
-      if (call === 1) {
+      if (call === 1 && !routerForcedHandoff) {
         content.push({
           type: "toolCall",
           id: observations.progressTool ? "progress-call-1" : "handoff-call-1",
@@ -102,7 +107,7 @@ vi.mock("@/chat/pi/traced-stream", () => ({
       const message = {
         role: "assistant",
         content,
-        stopReason: call === 1 ? "toolUse" : "stop",
+        stopReason: call === 1 && !routerForcedHandoff ? "toolUse" : "stop",
         api: "test",
         provider: "test",
         model: model.id,
@@ -188,6 +193,7 @@ describe("executeAgentRun model handoff", () => {
     observations.progressTool = false;
     observations.providerCalls = 0;
     observations.requestedProfile = undefined;
+    observations.routedModelProfile = "standard";
     observations.routedReasoningLevel = "high";
     observations.reasoningLevels = [];
     observations.summaryCalls = 0;
@@ -203,6 +209,46 @@ describe("executeAgentRun model handoff", () => {
     } else {
       process.env.JUNIOR_STATE_ADAPTER = ORIGINAL_STATE_ADAPTER;
     }
+  });
+
+  it("routes requested execution profiles through handoff before the first provider request", async () => {
+    observations.routedModelProfile = "handoff";
+    const conversationId = "local:test:router-model-handoff";
+    const outcome = await executeAgentRun({
+      conversationId,
+      runId: "run-router-model-handoff",
+      turnId: "turn-router-model-handoff",
+      input: { messageText: "Recommend the architecture and test strategy." },
+      routing: {
+        destination: { platform: "local", conversationId },
+        source: createLocalSource(conversationId),
+      },
+    });
+
+    expect(outcome.status).toBe("completed");
+    if (outcome.status !== "completed") return;
+    expect(outcome.result.text).toBe("Handoff model completed it.");
+    expect(outcome.result.diagnostics.modelId).toBe("openai/gpt-5.6-sol");
+    expect(observations.providerCalls).toBe(1);
+    expect(observations.initialModelId).toBe("openai/gpt-5.6-sol");
+    expect(observations.initialToolNames).not.toContain("handoff");
+    expect(observations.reasoningLevels).toEqual(["high"]);
+    expect(observations.summaryCalls).toBe(1);
+    expect(
+      (await loadConversationProjection({ conversationId })).modelProfile,
+    ).toBe("handoff");
+    expect(
+      (await getConversationEventStore().loadHistory(conversationId))
+        .map((event) => event.data)
+        .filter((entry) => entry.type === "handoff"),
+    ).toEqual([
+      {
+        type: "handoff",
+        modelProfile: "handoff",
+        modelId: "openai/gpt-5.6-sol",
+        replacementHistory: expectedHandoffReplacementHistory(),
+      },
+    ]);
   });
 
   it("compacts and upgrades the same conversation before continuing the turn", async () => {
@@ -375,6 +421,7 @@ describe("executeAgentRun model handoff", () => {
     expect(outcome.status).toBe("completed");
     if (outcome.status !== "completed") return;
     expect(outcome.result.diagnostics.reasoningLevel).toBe("xhigh");
+    expect(observations.providerCalls).toBe(2);
     expect(observations.reasoningLevels).toEqual(["xhigh", "xhigh"]);
   });
 

--- a/packages/junior/tests/integration/runtime/agent-run-model-handoff.test.ts
+++ b/packages/junior/tests/integration/runtime/agent-run-model-handoff.test.ts
@@ -17,7 +17,8 @@ const observations = vi.hoisted(() => ({
   mixedBatch: false,
   progressTool: false,
   providerCalls: 0,
-  requestedProfile: undefined as string | null | undefined,
+  routerCalls: 0,
+  requestedProfile: "handoff" as string | null | undefined,
   routedModelProfile: "standard",
   routedReasoningLevel: "high",
   reasoningLevels: [] as string[],
@@ -42,14 +43,17 @@ vi.mock("@/chat/pi/client", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/chat/pi/client")>();
   return {
     ...actual,
-    completeObject: async () => ({
-      object: {
-        reasoning_level: observations.routedReasoningLevel,
-        model_profile: observations.routedModelProfile,
-        confidence: 0.99,
-        reason: "complex implementation",
-      },
-    }),
+    completeObject: async () => {
+      observations.routerCalls += 1;
+      return {
+        object: {
+          reasoning_level: observations.routedReasoningLevel,
+          profile: observations.routedModelProfile,
+          confidence: 0.99,
+          reason: "complex implementation",
+        },
+      };
+    },
     completeText: async (args: { signal?: AbortSignal }) => {
       observations.handoffStatusBeforeSummary =
         observations.statuses.includes("Switching models");
@@ -225,7 +229,8 @@ describe("executeAgentRun model handoff", () => {
     observations.mixedBatch = false;
     observations.progressTool = false;
     observations.providerCalls = 0;
-    observations.requestedProfile = undefined;
+    observations.routerCalls = 0;
+    observations.requestedProfile = "handoff";
     observations.routedModelProfile = "standard";
     observations.routedReasoningLevel = "high";
     observations.reasoningLevels = [];
@@ -274,14 +279,15 @@ describe("executeAgentRun model handoff", () => {
     expect(outcome.result.text).toBe("Handoff model completed it.");
     expect(outcome.result.diagnostics.modelId).toBe("openai/gpt-5.6-sol");
     expect(observations.providerCalls).toBe(1);
+    expect(observations.routerCalls).toBe(1);
     expect(observations.initialModelId).toBe("openai/gpt-5.6-sol");
-    expect(observations.initialToolNames).not.toContain("handoff");
+    expect(observations.initialToolNames).toContain("handoff");
     expect(observations.initialImagePart).toEqual({
       type: "image",
       data: Buffer.from("architecture-diagram").toString("base64"),
       mimeType: "image/png",
     });
-    expect(observations.reasoningLevels).toEqual(["high"]);
+    expect(observations.reasoningLevels).toEqual(["xhigh"]);
     expect(observations.summaryCalls).toBe(1);
     expect(
       (await loadConversationProjection({ conversationId })).modelProfile,
@@ -322,7 +328,7 @@ describe("executeAgentRun model handoff", () => {
   });
 
   it("compacts and upgrades the same conversation before continuing the turn", async () => {
-    observations.requestedProfile = null;
+    observations.requestedProfile = "handoff";
     const conversationId = "local:test:model-handoff";
     const outcome = await executeAgentRun({
       conversationId,
@@ -352,10 +358,10 @@ describe("executeAgentRun model handoff", () => {
       observations.afterHandoffModelId,
     );
     expect(observations.afterHandoffModelId).toBe("openai/gpt-5.6-sol");
-    expect(observations.reasoningLevels.slice(0, 2)).toEqual(["high", "high"]);
-    expect(observations.afterHandoffToolNames).not.toContain("handoff");
+    expect(observations.reasoningLevels.slice(0, 2)).toEqual(["high", "xhigh"]);
+    expect(observations.afterHandoffToolNames).toContain("handoff");
     expect(observations.afterHandoffToolNames).toEqual(
-      observations.initialToolNames.filter((name) => name !== "handoff"),
+      observations.initialToolNames,
     );
     expect(observations.summaryCalls).toBe(1);
     expect(observations.handoffStatusBeforeSummary).toBe(true);
@@ -414,8 +420,9 @@ describe("executeAgentRun model handoff", () => {
     if (followUp.status !== "completed") return;
     expect(followUp.result.diagnostics.modelId).toBe("openai/gpt-5.6-sol");
     expect(observations.providerCalls).toBe(3);
+    expect(observations.routerCalls).toBe(1);
     expect(observations.afterHandoffModelId).toBe("openai/gpt-5.6-sol");
-    expect(observations.afterHandoffToolNames).not.toContain("handoff");
+    expect(observations.afterHandoffToolNames).toContain("handoff");
     expect(observations.summaryCalls).toBe(1);
   });
 
@@ -473,8 +480,8 @@ describe("executeAgentRun model handoff", () => {
     expect(observations.statuses).toContain("Checking details");
   });
 
-  it("preserves explicit agent reasoning across handoff without routing", async () => {
-    observations.requestedProfile = null;
+  it("preserves explicit agent reasoning across handoff", async () => {
+    observations.requestedProfile = "handoff";
     observations.routedReasoningLevel = "low";
     const conversationId = "local:test:model-handoff-explicit-reasoning";
     const outcome = await executeAgentRun({
@@ -496,7 +503,7 @@ describe("executeAgentRun model handoff", () => {
   });
 
   it("keeps handoff independent from status observer failures", async () => {
-    observations.requestedProfile = null;
+    observations.requestedProfile = "handoff";
     const conversationId = "local:test:model-handoff-status-failure";
     const outcome = await executeAgentRun({
       conversationId,
@@ -566,7 +573,8 @@ describe("executeAgentRun model handoff", () => {
     expect(followUp.status).toBe("completed");
     if (followUp.status !== "completed") return;
     expect(followUp.result.diagnostics.modelId).toBe("openai/gpt-5.4");
-    expect(observations.afterHandoffToolNames).not.toContain("handoff");
+    expect(observations.routerCalls).toBe(1);
+    expect(observations.afterHandoffToolNames).toContain("handoff");
     expect(observations.summaryCalls).toBe(1);
   });
 
@@ -612,7 +620,7 @@ describe("executeAgentRun model handoff", () => {
     expect(outcome.status).toBe("completed");
     if (outcome.status !== "completed") return;
     expect(outcome.result.diagnostics.modelId).toBe("openai/gpt-5.6-sol");
-    expect(observations.afterHandoffToolNames).not.toContain("handoff");
+    expect(observations.afterHandoffToolNames).toContain("handoff");
     expect(
       (await loadConversationProjection({ conversationId })).modelProfile,
     ).toBe("handoff");

--- a/packages/junior/tests/integration/runtime/agent-run-model-handoff.test.ts
+++ b/packages/junior/tests/integration/runtime/agent-run-model-handoff.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createLocalSource } from "@sentry/junior-plugin-api";
 
@@ -9,6 +10,9 @@ const observations = vi.hoisted(() => ({
   }>,
   afterHandoffToolNames: [] as string[],
   initialModelId: "",
+  initialImagePart: undefined as
+    | { type: unknown; data: unknown; mimeType: unknown }
+    | undefined,
   initialToolNames: [] as string[],
   mixedBatch: false,
   progressTool: false,
@@ -18,6 +22,8 @@ const observations = vi.hoisted(() => ({
   routedReasoningLevel: "high",
   reasoningLevels: [] as string[],
   summaryCalls: 0,
+  summaryAborted: false,
+  summaryPending: false,
   handoffStatusBeforeSummary: false,
   statuses: [] as string[],
 }));
@@ -44,10 +50,23 @@ vi.mock("@/chat/pi/client", async (importOriginal) => {
         reason: "complex implementation",
       },
     }),
-    completeText: async () => {
+    completeText: async (args: { signal?: AbortSignal }) => {
       observations.handoffStatusBeforeSummary =
         observations.statuses.includes("Switching models");
       observations.summaryCalls += 1;
+      if (observations.summaryPending) {
+        return await new Promise<never>((_resolve, reject) => {
+          const abort = () => {
+            observations.summaryAborted = true;
+            reject(args.signal?.reason);
+          };
+          if (args.signal?.aborted) {
+            abort();
+            return;
+          }
+          args.signal?.addEventListener("abort", abort, { once: true });
+        });
+      }
       return { text: "Implement the requested change and verify it." };
     },
   };
@@ -63,6 +82,19 @@ vi.mock("@/chat/pi/traced-stream", () => ({
         call === 1 && observations.routedModelProfile === "handoff";
       if (call === 1) {
         observations.initialModelId = model.id;
+        observations.initialImagePart = (
+          (context.messages ?? []) as Array<{
+            content?: Array<{
+              type?: unknown;
+              data?: unknown;
+              mimeType?: unknown;
+            }>;
+          }>
+        )
+          .flatMap((message) => message.content ?? [])
+          .find((part) => part.type === "image") as
+          | { type: unknown; data: unknown; mimeType: unknown }
+          | undefined;
         observations.initialToolNames = (context.tools ?? []).map(
           (tool: { name: string }) => tool.name,
         );
@@ -188,6 +220,7 @@ describe("executeAgentRun model handoff", () => {
     observations.afterHandoffMessages = [];
     observations.afterHandoffToolNames = [];
     observations.initialModelId = "";
+    observations.initialImagePart = undefined;
     observations.initialToolNames = [];
     observations.mixedBatch = false;
     observations.progressTool = false;
@@ -197,6 +230,8 @@ describe("executeAgentRun model handoff", () => {
     observations.routedReasoningLevel = "high";
     observations.reasoningLevels = [];
     observations.summaryCalls = 0;
+    observations.summaryAborted = false;
+    observations.summaryPending = false;
     observations.handoffStatusBeforeSummary = false;
     observations.statuses = [];
     await disconnectStateAdapter();
@@ -218,7 +253,16 @@ describe("executeAgentRun model handoff", () => {
       conversationId,
       runId: "run-router-model-handoff",
       turnId: "turn-router-model-handoff",
-      input: { messageText: "Recommend the architecture and test strategy." },
+      input: {
+        messageText: "Recommend the architecture and test strategy.",
+        userAttachments: [
+          {
+            data: Buffer.from("architecture-diagram"),
+            filename: "architecture.png",
+            mediaType: "image/png",
+          },
+        ],
+      },
       routing: {
         destination: { platform: "local", conversationId },
         source: createLocalSource(conversationId),
@@ -232,6 +276,11 @@ describe("executeAgentRun model handoff", () => {
     expect(observations.providerCalls).toBe(1);
     expect(observations.initialModelId).toBe("openai/gpt-5.6-sol");
     expect(observations.initialToolNames).not.toContain("handoff");
+    expect(observations.initialImagePart).toEqual({
+      type: "image",
+      data: Buffer.from("architecture-diagram").toString("base64"),
+      mimeType: "image/png",
+    });
     expect(observations.reasoningLevels).toEqual(["high"]);
     expect(observations.summaryCalls).toBe(1);
     expect(
@@ -249,6 +298,27 @@ describe("executeAgentRun model handoff", () => {
         replacementHistory: expectedHandoffReplacementHistory(),
       },
     ]);
+  });
+
+  it("applies the turn deadline while preparing a router-requested handoff", async () => {
+    observations.routedModelProfile = "handoff";
+    observations.summaryPending = true;
+    const conversationId = "local:test:router-model-handoff-timeout";
+    const outcome = await executeAgentRun({
+      conversationId,
+      runId: "run-router-model-handoff-timeout",
+      turnId: "turn-router-model-handoff-timeout",
+      input: { messageText: "Recommend the architecture." },
+      policy: { turnDeadlineAtMs: Date.now() + 50 },
+      routing: {
+        destination: { platform: "local", conversationId },
+        source: createLocalSource(conversationId),
+      },
+    });
+
+    expect(outcome.status).toBe("suspended");
+    expect(observations.summaryAborted).toBe(true);
+    expect(observations.providerCalls).toBe(0);
   });
 
   it("compacts and upgrades the same conversation before continuing the turn", async () => {

--- a/packages/junior/tests/integration/runtime/agent-run-provider-retry.test.ts
+++ b/packages/junior/tests/integration/runtime/agent-run-provider-retry.test.ts
@@ -311,7 +311,7 @@ vi.mock("@/chat/pi/client", () => ({
   completeObject: async () => ({
     object: {
       reasoning_level: "medium",
-      model_profile: "standard",
+      profile: "standard",
       confidence: 1,
       reason: "test-router",
     },

--- a/packages/junior/tests/integration/runtime/agent-run-provider-retry.test.ts
+++ b/packages/junior/tests/integration/runtime/agent-run-provider-retry.test.ts
@@ -311,6 +311,7 @@ vi.mock("@/chat/pi/client", () => ({
   completeObject: async () => ({
     object: {
       reasoning_level: "medium",
+      model_profile: "standard",
       confidence: 1,
       reason: "test-router",
     },

--- a/packages/junior/tests/unit/logging/with-span.test.ts
+++ b/packages/junior/tests/unit/logging/with-span.test.ts
@@ -39,8 +39,8 @@ describe("withSpan", () => {
       },
       async () => {
         await withSpan(
-          "chat.route_reasoning",
-          "chat.route_reasoning",
+          "chat.route_execution_profile",
+          "chat.route_execution_profile",
           {
             modelId: "openai/gpt-4o-mini",
           },

--- a/packages/junior/tests/unit/plugins/plugin-model.test.ts
+++ b/packages/junior/tests/unit/plugins/plugin-model.test.ts
@@ -12,7 +12,9 @@ vi.mock("@/chat/config", () => ({
   botConfig: {
     embeddingModelId: "test-embedding-model",
     fastModelId: "openai/gpt-5.4-mini",
-    modelId: "openai/gpt-5.5",
+    profiles: {
+      standard: { modelId: "openai/gpt-5.5" },
+    },
   },
 }));
 

--- a/packages/junior/tests/unit/runtime/agent-run-lazy-sandbox.test.ts
+++ b/packages/junior/tests/unit/runtime/agent-run-lazy-sandbox.test.ts
@@ -132,6 +132,7 @@ vi.mock("@/chat/pi/client", () => ({
       return {
         object: {
           reasoning_level: "high",
+          model_profile: "standard",
           confidence: 1,
           reason: "attachment stack trace",
         },
@@ -141,6 +142,7 @@ vi.mock("@/chat/pi/client", () => ({
       return {
         object: {
           reasoning_level: "none",
+          model_profile: "standard",
           confidence: 1,
           reason: "ack",
         },
@@ -150,6 +152,7 @@ vi.mock("@/chat/pi/client", () => ({
       return {
         object: {
           reasoning_level: "high",
+          model_profile: "standard",
           confidence: 1,
           reason: "code change request",
         },
@@ -158,6 +161,7 @@ vi.mock("@/chat/pi/client", () => ({
     return {
       object: {
         reasoning_level: "medium",
+        model_profile: "standard",
         confidence: 1,
         reason: "test-router",
       },

--- a/packages/junior/tests/unit/runtime/agent-run-lazy-sandbox.test.ts
+++ b/packages/junior/tests/unit/runtime/agent-run-lazy-sandbox.test.ts
@@ -111,7 +111,10 @@ vi.mock("@/chat/config", () => ({
   botConfig: {
     fastModelId: "test-fast-model",
     modelId: "test-model",
-    modelProfiles: { handoff: "test-handoff-model" },
+    profiles: {
+      standard: { modelId: "test-model" },
+      handoff: { modelId: "test-handoff-model", reasoningLevel: "xhigh" },
+    },
     turnTimeoutMs: 1000,
     userName: "junior",
   },
@@ -132,7 +135,7 @@ vi.mock("@/chat/pi/client", () => ({
       return {
         object: {
           reasoning_level: "high",
-          model_profile: "standard",
+          profile: "standard",
           confidence: 1,
           reason: "attachment stack trace",
         },
@@ -142,7 +145,7 @@ vi.mock("@/chat/pi/client", () => ({
       return {
         object: {
           reasoning_level: "none",
-          model_profile: "standard",
+          profile: "standard",
           confidence: 1,
           reason: "ack",
         },
@@ -152,7 +155,7 @@ vi.mock("@/chat/pi/client", () => ({
       return {
         object: {
           reasoning_level: "high",
-          model_profile: "standard",
+          profile: "standard",
           confidence: 1,
           reason: "code change request",
         },
@@ -161,7 +164,7 @@ vi.mock("@/chat/pi/client", () => ({
     return {
       object: {
         reasoning_level: "medium",
-        model_profile: "standard",
+        profile: "standard",
         confidence: 1,
         reason: "test-router",
       },

--- a/packages/junior/tests/unit/runtime/agent-run-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/unit/runtime/agent-run-mcp-progressive-loading.test.ts
@@ -359,7 +359,7 @@ vi.mock("@/chat/pi/client", () => ({
   completeObject: async () => ({
     object: {
       reasoning_level: "medium",
-      model_profile: "standard",
+      profile: "standard",
       confidence: 1,
       reason: "test-router",
     },

--- a/packages/junior/tests/unit/runtime/agent-run-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/unit/runtime/agent-run-mcp-progressive-loading.test.ts
@@ -359,6 +359,7 @@ vi.mock("@/chat/pi/client", () => ({
   completeObject: async () => ({
     object: {
       reasoning_level: "medium",
+      model_profile: "standard",
       confidence: 1,
       reason: "test-router",
     },

--- a/packages/junior/tests/unit/services/turn-execution-profile.test.ts
+++ b/packages/junior/tests/unit/services/turn-execution-profile.test.ts
@@ -1,20 +1,29 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-  selectTurnReasoningLevel,
+  configuredTurnExecutionProfile,
+  selectTurnExecutionProfile,
   toPiReasoningLevel,
-} from "@/chat/services/turn-reasoning-level";
+} from "@/chat/services/turn-execution-profile";
 
-describe("selectTurnReasoningLevel", () => {
+describe("selectTurnExecutionProfile", () => {
+  it("keeps configured reasoning independent from model routing", () => {
+    expect(configuredTurnExecutionProfile("xhigh", "agent_config")).toEqual({
+      reasoningLevel: "xhigh",
+      reason: "configured:agent_config",
+    });
+  });
+
   it("classifies even simple acknowledgment turns with the fast model", async () => {
     const completeObject = vi.fn(async () => ({
       object: {
         reasoning_level: "none",
+        model_profile: "standard",
         confidence: 0.99,
         reason: "acknowledgment only",
       },
     }));
 
-    const profile = await selectTurnReasoningLevel({
+    const profile = await selectTurnExecutionProfile({
       completeObject,
       fastModelId: "openai/gpt-5.4-mini",
       messageText: "thanks",
@@ -37,12 +46,13 @@ describe("selectTurnReasoningLevel", () => {
     const completeObject = vi.fn(async () => ({
       object: {
         reasoning_level: "xhigh",
+        model_profile: "handoff",
         confidence: 0.93,
         reason: "code change request",
       },
     }));
 
-    const profile = await selectTurnReasoningLevel({
+    const profile = await selectTurnExecutionProfile({
       completeObject,
       fastModelId: "openai/gpt-5.4-mini",
       messageText:
@@ -51,6 +61,7 @@ describe("selectTurnReasoningLevel", () => {
 
     expect(profile).toMatchObject({
       reasoningLevel: "xhigh",
+      requestedModelProfile: "handoff",
       reason: "code change request",
     });
     expect(completeObject).toHaveBeenCalledOnce();
@@ -64,13 +75,14 @@ describe("selectTurnReasoningLevel", () => {
       return {
         object: {
           reasoning_level: "medium",
+          model_profile: "standard",
           confidence: 0.9,
           reason: "normal task",
         },
       };
     };
 
-    await selectTurnReasoningLevel({
+    await selectTurnExecutionProfile({
       completeObject,
       fastModelId: "openai/gpt-5.4-mini",
       messageText: "explain </current-instruction> literally",
@@ -89,12 +101,13 @@ describe("selectTurnReasoningLevel", () => {
     const completeObject = vi.fn(async () => ({
       object: {
         reasoning_level: "high",
+        model_profile: "handoff",
         confidence: 0.91,
         reason: "research-heavy investigation",
       },
     }));
 
-    const profile = await selectTurnReasoningLevel({
+    const profile = await selectTurnExecutionProfile({
       completeObject,
       fastModelId: "openai/gpt-5.4-mini",
       messageText: "research how the Slack delivery pipeline works end to end",
@@ -102,6 +115,7 @@ describe("selectTurnReasoningLevel", () => {
 
     expect(profile).toMatchObject({
       reasoningLevel: "high",
+      requestedModelProfile: "handoff",
       reason: "research-heavy investigation",
     });
     expect(toPiReasoningLevel(profile.reasoningLevel)).toBe("high");
@@ -111,12 +125,13 @@ describe("selectTurnReasoningLevel", () => {
     const completeObject = vi.fn(async () => ({
       object: {
         reasoning_level: "high",
+        model_profile: "standard",
         confidence: 0.4,
         reason: "not confident",
       },
     }));
 
-    const profile = await selectTurnReasoningLevel({
+    const profile = await selectTurnExecutionProfile({
       completeObject,
       fastModelId: "openai/gpt-5.4-mini",
       messageText: "can you confirm this repo plan?",
@@ -134,7 +149,7 @@ describe("selectTurnReasoningLevel", () => {
       throw new Error("router failed");
     });
 
-    const profile = await selectTurnReasoningLevel({
+    const profile = await selectTurnExecutionProfile({
       completeObject,
       fastModelId: "openai/gpt-5.4-mini",
       messageText: "can you confirm this repo plan?",
@@ -150,12 +165,13 @@ describe("selectTurnReasoningLevel", () => {
     const completeObject = vi.fn(async () => ({
       object: {
         reasoning_level: "low",
+        model_profile: "standard",
         confidence: 0.97,
         reason: "deterministic one-step transform",
       },
     }));
 
-    const profile = await selectTurnReasoningLevel({
+    const profile = await selectTurnExecutionProfile({
       completeObject,
       fastModelId: "openai/gpt-5.4-mini",
       messageText: "alphabetize these words: beta, alpha",
@@ -172,12 +188,13 @@ describe("selectTurnReasoningLevel", () => {
     const completeObject = vi.fn(async () => ({
       object: {
         reasoning_level: "low",
+        model_profile: "standard",
         confidence: "high",
         reason: "deterministic single-step command",
       },
     }));
 
-    const profile = await selectTurnReasoningLevel({
+    const profile = await selectTurnExecutionProfile({
       completeObject,
       fastModelId: "anthropic/claude-haiku-4.5",
       messageText: "can you clone getsentry/test-internal-repo",
@@ -194,12 +211,13 @@ describe("selectTurnReasoningLevel", () => {
     const completeObject = vi.fn(async () => ({
       object: {
         reasoning_level: "low",
+        model_profile: "standard",
         confidence: 0.92,
         reason: "simple follow-up",
       },
     }));
 
-    const profile = await selectTurnReasoningLevel({
+    const profile = await selectTurnExecutionProfile({
       completeObject,
       conversationContext: "Earlier task: double-check the repo evidence.",
       fastModelId: "openai/gpt-5.4-mini",
@@ -216,12 +234,13 @@ describe("selectTurnReasoningLevel", () => {
     const completeObject = vi.fn(async () => ({
       object: {
         reasoning_level: "none",
+        model_profile: "standard",
         confidence: 0.96,
         reason: "thanks only",
       },
     }));
 
-    const profile = await selectTurnReasoningLevel({
+    const profile = await selectTurnExecutionProfile({
       completeObject,
       conversationContext: "Earlier answer already resolved the task.",
       fastModelId: "openai/gpt-5.4-mini",
@@ -241,6 +260,7 @@ describe("selectTurnReasoningLevel", () => {
       return {
         object: {
           reasoning_level: "medium",
+          model_profile: "standard",
           confidence: 0.9,
           reason: "ok",
         },
@@ -252,7 +272,7 @@ describe("selectTurnReasoningLevel", () => {
     const filler = "filler text. ".repeat(2_000);
     const longContext = `${headMarker} ${filler} ${tailMarker}`;
 
-    await selectTurnReasoningLevel({
+    await selectTurnExecutionProfile({
       completeObject,
       fastModelId: "openai/gpt-5.4-mini",
       messageText: "go",
@@ -268,12 +288,13 @@ describe("selectTurnReasoningLevel", () => {
     const completeObject = vi.fn(async () => ({
       object: {
         reasoning_level: "xhigh",
+        model_profile: "handoff",
         confidence: 0.95,
         reason: "multi-file refactor with architecture implications",
       },
     }));
 
-    const profile = await selectTurnReasoningLevel({
+    const profile = await selectTurnExecutionProfile({
       completeObject,
       conversationContext: "Prior task context about a large refactor.",
       fastModelId: "openai/gpt-5.4-mini",
@@ -282,6 +303,7 @@ describe("selectTurnReasoningLevel", () => {
 
     expect(profile).toMatchObject({
       reasoningLevel: "xhigh",
+      requestedModelProfile: "handoff",
       reason: "multi-file refactor with architecture implications",
     });
     expect(toPiReasoningLevel(profile.reasoningLevel)).toBe("xhigh");

--- a/packages/junior/tests/unit/services/turn-router.test.ts
+++ b/packages/junior/tests/unit/services/turn-router.test.ts
@@ -1,13 +1,22 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-  configuredTurnExecutionProfile,
-  selectTurnExecutionProfile,
+  configuredTurnRoute,
+  selectTurnRoute,
   toPiReasoningLevel,
-} from "@/chat/services/turn-execution-profile";
+} from "@/chat/services/turn-router";
 
-describe("selectTurnExecutionProfile", () => {
+const profiles = {
+  standard: { modelId: "xai/grok-4.5" },
+  handoff: { modelId: "openai/gpt-5.6-sol" },
+};
+const routeTurn = (
+  args: Omit<Parameters<typeof selectTurnRoute>[0], "profiles">,
+) => selectTurnRoute({ ...args, profiles });
+
+describe("selectTurnRoute", () => {
   it("keeps configured reasoning independent from model routing", () => {
-    expect(configuredTurnExecutionProfile("xhigh", "agent_config")).toEqual({
+    expect(configuredTurnRoute("standard", "xhigh", "agent_config")).toEqual({
+      profile: "standard",
       reasoningLevel: "xhigh",
       reason: "configured:agent_config",
     });
@@ -17,13 +26,13 @@ describe("selectTurnExecutionProfile", () => {
     const completeObject = vi.fn(async () => ({
       object: {
         reasoning_level: "none",
-        model_profile: "standard",
+        profile: "standard",
         confidence: 0.99,
         reason: "acknowledgment only",
       },
     }));
 
-    const profile = await selectTurnExecutionProfile({
+    const profile = await routeTurn({
       completeObject,
       fastModelId: "openai/gpt-5.4-mini",
       messageText: "thanks",
@@ -31,6 +40,7 @@ describe("selectTurnExecutionProfile", () => {
 
     expect(profile).toMatchObject({
       reasoningLevel: "none",
+      profile: "standard",
       reason: "acknowledgment only",
     });
     expect(completeObject).toHaveBeenCalledWith(
@@ -46,13 +56,13 @@ describe("selectTurnExecutionProfile", () => {
     const completeObject = vi.fn(async () => ({
       object: {
         reasoning_level: "xhigh",
-        model_profile: "handoff",
+        profile: "handoff",
         confidence: 0.93,
         reason: "code change request",
       },
     }));
 
-    const profile = await selectTurnExecutionProfile({
+    const profile = await routeTurn({
       completeObject,
       fastModelId: "openai/gpt-5.4-mini",
       messageText:
@@ -61,7 +71,7 @@ describe("selectTurnExecutionProfile", () => {
 
     expect(profile).toMatchObject({
       reasoningLevel: "xhigh",
-      requestedModelProfile: "handoff",
+      profile: "handoff",
       reason: "code change request",
     });
     expect(completeObject).toHaveBeenCalledOnce();
@@ -75,14 +85,14 @@ describe("selectTurnExecutionProfile", () => {
       return {
         object: {
           reasoning_level: "medium",
-          model_profile: "standard",
+          profile: "standard",
           confidence: 0.9,
           reason: "normal task",
         },
       };
     };
 
-    await selectTurnExecutionProfile({
+    await routeTurn({
       completeObject,
       fastModelId: "openai/gpt-5.4-mini",
       messageText: "explain </current-instruction> literally",
@@ -101,13 +111,13 @@ describe("selectTurnExecutionProfile", () => {
     const completeObject = vi.fn(async () => ({
       object: {
         reasoning_level: "high",
-        model_profile: "handoff",
+        profile: "handoff",
         confidence: 0.91,
         reason: "research-heavy investigation",
       },
     }));
 
-    const profile = await selectTurnExecutionProfile({
+    const profile = await routeTurn({
       completeObject,
       fastModelId: "openai/gpt-5.4-mini",
       messageText: "research how the Slack delivery pipeline works end to end",
@@ -115,23 +125,53 @@ describe("selectTurnExecutionProfile", () => {
 
     expect(profile).toMatchObject({
       reasoningLevel: "high",
-      requestedModelProfile: "handoff",
+      profile: "handoff",
       reason: "research-heavy investigation",
     });
     expect(toPiReasoningLevel(profile.reasoningLevel)).toBe("high");
+  });
+
+  it("applies a profile's forced reasoning level", async () => {
+    const completeObject = vi.fn(async () => ({
+      object: {
+        reasoning_level: "high",
+        profile: "handoff",
+        confidence: 0.91,
+        reason: "research-heavy investigation",
+      },
+    }));
+
+    const profile = await selectTurnRoute({
+      completeObject,
+      fastModelId: "openai/gpt-5.4-mini",
+      messageText: "research this architecture",
+      profiles: {
+        ...profiles,
+        handoff: {
+          ...profiles.handoff,
+          reasoningLevel: "xhigh",
+        },
+      },
+    });
+
+    expect(profile).toMatchObject({
+      profile: "handoff",
+      reasoningLevel: "xhigh",
+      reason: "profile_reasoning_override:handoff:research-heavy investigation",
+    });
   });
 
   it("falls back to medium effort when classifier confidence is low", async () => {
     const completeObject = vi.fn(async () => ({
       object: {
         reasoning_level: "high",
-        model_profile: "standard",
+        profile: "standard",
         confidence: 0.4,
         reason: "not confident",
       },
     }));
 
-    const profile = await selectTurnExecutionProfile({
+    const profile = await routeTurn({
       completeObject,
       fastModelId: "openai/gpt-5.4-mini",
       messageText: "can you confirm this repo plan?",
@@ -149,7 +189,7 @@ describe("selectTurnExecutionProfile", () => {
       throw new Error("router failed");
     });
 
-    const profile = await selectTurnExecutionProfile({
+    const profile = await routeTurn({
       completeObject,
       fastModelId: "openai/gpt-5.4-mini",
       messageText: "can you confirm this repo plan?",
@@ -165,13 +205,13 @@ describe("selectTurnExecutionProfile", () => {
     const completeObject = vi.fn(async () => ({
       object: {
         reasoning_level: "low",
-        model_profile: "standard",
+        profile: "standard",
         confidence: 0.97,
         reason: "deterministic one-step transform",
       },
     }));
 
-    const profile = await selectTurnExecutionProfile({
+    const profile = await routeTurn({
       completeObject,
       fastModelId: "openai/gpt-5.4-mini",
       messageText: "alphabetize these words: beta, alpha",
@@ -188,13 +228,13 @@ describe("selectTurnExecutionProfile", () => {
     const completeObject = vi.fn(async () => ({
       object: {
         reasoning_level: "low",
-        model_profile: "standard",
+        profile: "standard",
         confidence: "high",
         reason: "deterministic single-step command",
       },
     }));
 
-    const profile = await selectTurnExecutionProfile({
+    const profile = await routeTurn({
       completeObject,
       fastModelId: "anthropic/claude-haiku-4.5",
       messageText: "can you clone getsentry/test-internal-repo",
@@ -211,13 +251,13 @@ describe("selectTurnExecutionProfile", () => {
     const completeObject = vi.fn(async () => ({
       object: {
         reasoning_level: "low",
-        model_profile: "standard",
+        profile: "standard",
         confidence: 0.92,
         reason: "simple follow-up",
       },
     }));
 
-    const profile = await selectTurnExecutionProfile({
+    const profile = await routeTurn({
       completeObject,
       conversationContext: "Earlier task: double-check the repo evidence.",
       fastModelId: "openai/gpt-5.4-mini",
@@ -234,13 +274,13 @@ describe("selectTurnExecutionProfile", () => {
     const completeObject = vi.fn(async () => ({
       object: {
         reasoning_level: "none",
-        model_profile: "standard",
+        profile: "standard",
         confidence: 0.96,
         reason: "thanks only",
       },
     }));
 
-    const profile = await selectTurnExecutionProfile({
+    const profile = await routeTurn({
       completeObject,
       conversationContext: "Earlier answer already resolved the task.",
       fastModelId: "openai/gpt-5.4-mini",
@@ -260,7 +300,7 @@ describe("selectTurnExecutionProfile", () => {
       return {
         object: {
           reasoning_level: "medium",
-          model_profile: "standard",
+          profile: "standard",
           confidence: 0.9,
           reason: "ok",
         },
@@ -272,7 +312,7 @@ describe("selectTurnExecutionProfile", () => {
     const filler = "filler text. ".repeat(2_000);
     const longContext = `${headMarker} ${filler} ${tailMarker}`;
 
-    await selectTurnExecutionProfile({
+    await routeTurn({
       completeObject,
       fastModelId: "openai/gpt-5.4-mini",
       messageText: "go",
@@ -288,13 +328,13 @@ describe("selectTurnExecutionProfile", () => {
     const completeObject = vi.fn(async () => ({
       object: {
         reasoning_level: "xhigh",
-        model_profile: "handoff",
+        profile: "handoff",
         confidence: 0.95,
         reason: "multi-file refactor with architecture implications",
       },
     }));
 
-    const profile = await selectTurnExecutionProfile({
+    const profile = await routeTurn({
       completeObject,
       conversationContext: "Prior task context about a large refactor.",
       fastModelId: "openai/gpt-5.4-mini",
@@ -303,7 +343,7 @@ describe("selectTurnExecutionProfile", () => {
 
     expect(profile).toMatchObject({
       reasoningLevel: "xhigh",
-      requestedModelProfile: "handoff",
+      profile: "handoff",
       reason: "multi-file refactor with architecture implications",
     });
     expect(toPiReasoningLevel(profile.reasoningLevel)).toBe("xhigh");

--- a/packages/junior/tests/unit/turn-result.test.ts
+++ b/packages/junior/tests/unit/turn-result.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@/chat/services/turn-result";
 
 const executionProfile = {
+  profile: "standard",
   reasoningLevel: "medium" as const,
   reason: "test",
 };

--- a/packages/junior/tests/unit/turn-result.test.ts
+++ b/packages/junior/tests/unit/turn-result.test.ts
@@ -7,7 +7,7 @@ import {
   getAssistantMessageText,
 } from "@/chat/services/turn-result";
 
-const reasoningSelection = {
+const executionProfile = {
   reasoningLevel: "medium" as const,
   reason: "test",
 };
@@ -127,7 +127,7 @@ describe("buildTurnResult", () => {
       shouldTrace: false,
       spanContext: {},
       modelId: "test-model",
-      reasoningSelection,
+      executionProfile,
     });
 
     expect(reply.text).toBe("");
@@ -160,7 +160,7 @@ describe("buildTurnResult", () => {
       shouldTrace: false,
       spanContext: {},
       modelId: "test-model",
-      reasoningSelection,
+      executionProfile,
     });
 
     expect(reply.text).toBe("");
@@ -197,7 +197,7 @@ describe("buildTurnResult", () => {
       shouldTrace: false,
       spanContext: {},
       modelId: "test-model",
-      reasoningSelection,
+      executionProfile,
     });
 
     expect(reply.text).toBe("");
@@ -231,7 +231,7 @@ describe("buildTurnResult", () => {
       shouldTrace: false,
       spanContext: {},
       modelId: "test-model",
-      reasoningSelection,
+      executionProfile,
     });
 
     expect(reply.text).toBe("Here is the actual summary.");
@@ -268,7 +268,7 @@ describe("buildTurnResult", () => {
       shouldTrace: false,
       spanContext: {},
       modelId: "test-model",
-      reasoningSelection,
+      executionProfile,
     });
 
     expect(reply.text).toBe("Updated answer.");
@@ -307,7 +307,7 @@ describe("buildTurnResult", () => {
       shouldTrace: false,
       spanContext: {},
       modelId: "test-model",
-      reasoningSelection,
+      executionProfile,
     });
 
     expect(reply.text).toBe(
@@ -346,7 +346,7 @@ describe("buildTurnResult", () => {
       shouldTrace: false,
       spanContext: {},
       modelId: "test-model",
-      reasoningSelection,
+      executionProfile,
     });
 
     expect(reply.text).toBe("");
@@ -379,7 +379,7 @@ describe("buildTurnResult", () => {
       shouldTrace: false,
       spanContext: {},
       modelId: "test-model",
-      reasoningSelection,
+      executionProfile,
     });
 
     expect(reply.text).toBe("Handled it.");
@@ -418,7 +418,7 @@ describe("buildTurnResult", () => {
       shouldTrace: false,
       spanContext: {},
       modelId: "test-model",
-      reasoningSelection,
+      executionProfile,
     });
 
     expect(reply.text).toBe("");
@@ -442,7 +442,7 @@ describe("buildTurnResult", () => {
       shouldTrace: false,
       spanContext: {},
       modelId: "test-model",
-      reasoningSelection,
+      executionProfile,
     });
 
     expect(reply.text).toBe("");
@@ -466,7 +466,7 @@ describe("buildTurnResult", () => {
       shouldTrace: false,
       spanContext: {},
       modelId: "test-model",
-      reasoningSelection,
+      executionProfile,
     });
 
     expect(reply.text).toBe("");
@@ -495,7 +495,7 @@ describe("buildTurnResult", () => {
       shouldTrace: false,
       spanContext: {},
       modelId: "test-model",
-      reasoningSelection,
+      executionProfile,
     });
 
     expect(reply.text).toBe("");
@@ -531,7 +531,7 @@ describe("buildTurnResult", () => {
       shouldTrace: false,
       spanContext: {},
       modelId: "test-model",
-      reasoningSelection,
+      executionProfile,
     });
 
     expect(reply.text).toBe("Here's the image.");
@@ -555,7 +555,7 @@ describe("buildTurnResult", () => {
       shouldTrace: false,
       spanContext: {},
       modelId: "test-model",
-      reasoningSelection,
+      executionProfile,
       usage: {
         inputTokens: 321,
         outputTokens: 144,


### PR DESCRIPTION
Complex coding, architecture, and root-cause-analysis turns can now switch execution profiles before the standard model begins generating. The router selects a profile and reasoning level only while a conversation is on `standard`; conversations already on another profile start there directly.

`botConfig.profiles` is the single registry for profile model IDs and optional forced reasoning levels. Router validation, model resolution, and handoff targets all consume that registry, which preserves the existing environment-based profile configuration while leaving room for a future user-managed source.

Handoff remains available after a profile switch so a conversation can move between configured profiles. The tool requires an explicit target, never offers `standard`, and uses the same durable context transition for router- and tool-requested switches. The static prompt no longer forces coding turns through the tool, and selecting the active profile is an idempotent no-op.
