### PR TITLE
fix(slack): Resume turns after transient reply failures

### DIFF
--- a/packages/junior/src/chat/agent-dispatch/runner.ts
+++ b/packages/junior/src/chat/agent-dispatch/runner.ts
@@ -8,6 +8,7 @@
  */
 import { botConfig } from "@/chat/config";
 import { standardModelId } from "@/chat/model-profile";
+import { RetryableDeliveryError } from "@/chat/agent/request";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { logException } from "@/chat/logging";
 import {
@@ -55,6 +56,7 @@ import { persistWithRetry } from "@/chat/services/persist-retry";
 import { getAgentTurnSessionRecord } from "@/chat/state/turn-session";
 import { AuthorizationFlowDisabledError } from "@/chat/services/auth-pause";
 import { PluginCredentialFailureError } from "@/chat/services/plugin-auth-orchestration";
+import { isRetryableSlackPostError } from "@/chat/slack/errors";
 import { scheduleSessionCompletedPluginTasks } from "@/chat/plugins/task-runner";
 import { scheduleDispatchCallback } from "./signing";
 import {
@@ -323,10 +325,17 @@ export async function runAgentDispatchSlice(
         return;
       }
       failureCode = "delivery_failed";
-      resultMessageTs = await postSlackApiReplyPosts({
-        channelId: dispatch.destination.channelId,
-        posts,
-      });
+      try {
+        resultMessageTs = await postSlackApiReplyPosts({
+          channelId: dispatch.destination.channelId,
+          posts,
+        });
+      } catch (error) {
+        if (isRetryableSlackPostError(error)) {
+          throw new RetryableDeliveryError(error);
+        }
+        throw error;
+      }
       assistantMessageDelivered = true;
       const recordedMessageId = recordDeliveredAssistantMessage({
         conversation,

--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -94,6 +94,7 @@ import {
   type ConversationPrivacy,
 } from "@/chat/conversation-privacy";
 import {
+  RetryableDeliveryError,
   assertRunRoutingConsistency,
   actorFromRouting,
   surfaceFromRouting,
@@ -1146,6 +1147,12 @@ async function executeAgentRunInPrivacyContext(
       result,
     };
   } catch (error) {
+    if (
+      error instanceof AssistantMessageDeliveryError &&
+      !(error.originalError instanceof RetryableDeliveryError)
+    ) {
+      throw error.originalError;
+    }
     const runError =
       error instanceof AssistantMessageDeliveryError
         ? error.originalError

--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -1146,17 +1146,22 @@ async function executeAgentRunInPrivacyContext(
       result,
     };
   } catch (error) {
-    if (error instanceof AssistantMessageDeliveryError) {
-      throw error.originalError;
-    }
+    const runError =
+      error instanceof AssistantMessageDeliveryError
+        ? error.originalError
+        : error;
     if (resume) {
       const { outcome } = await resume.translateExpectedEnding({
         currentUsage: turnUsage,
-        error,
+        error: runError,
       });
       if (outcome) {
         return outcome;
       }
+    }
+
+    if (error instanceof AssistantMessageDeliveryError) {
+      throw error.originalError;
     }
 
     if (error instanceof ModelProfileNotConfiguredError) {

--- a/packages/junior/src/chat/agent/request.ts
+++ b/packages/junior/src/chat/agent/request.ts
@@ -150,10 +150,10 @@ export interface AgentRunDelivery {
   onAssistantMessage: (message: AgentAssistantMessage) => void | Promise<void>;
 }
 
-/** Ask the agent runtime to resume from its last durable boundary and retry delivery. */
+/** Resume the agent turn after a transient or ambiguous delivery failure. */
 export class RetryableDeliveryError extends Error {
   constructor(cause: unknown) {
-    super("Assistant delivery should retry", { cause });
+    super("Assistant delivery was transient or ambiguous", { cause });
     this.name = "RetryableDeliveryError";
   }
 }

--- a/packages/junior/src/chat/agent/request.ts
+++ b/packages/junior/src/chat/agent/request.ts
@@ -150,6 +150,14 @@ export interface AgentRunDelivery {
   onAssistantMessage: (message: AgentAssistantMessage) => void | Promise<void>;
 }
 
+/** Ask the agent runtime to resume from its last durable boundary and retry delivery. */
+export class RetryableDeliveryError extends Error {
+  constructor(cause: unknown) {
+    super("Assistant delivery should retry", { cause });
+    this.name = "RetryableDeliveryError";
+  }
+}
+
 /** Carries durable-worker ports that commit or update resumable run state. */
 export interface AgentRunDurability {
   onInputCommitted?: () => void | Promise<void>;

--- a/packages/junior/src/chat/agent/resume.ts
+++ b/packages/junior/src/chat/agent/resume.ts
@@ -204,8 +204,8 @@ export function createResumeState(args: ResumeStateArgs) {
       const retryingDelivery = error instanceof RetryableDeliveryError;
       if (retryingDelivery || timedOut) {
         if (retryingDelivery) {
-          // The failed assistant message was never committed. Regenerate it
-          // from the last safe transcript; an ambiguous provider write may
+          // The failed assistant message was never saved. Regenerate it from
+          // the latest saved agent history; an ambiguous provider write may
           // therefore produce a duplicate reply.
           resumeMessages = [...latestSafeBoundaryMessages];
         }

--- a/packages/junior/src/chat/agent/resume.ts
+++ b/packages/junior/src/chat/agent/resume.ts
@@ -204,6 +204,9 @@ export function createResumeState(args: ResumeStateArgs) {
       const retryingDelivery = error instanceof RetryableDeliveryError;
       if (retryingDelivery || timedOut) {
         if (retryingDelivery) {
+          // The failed assistant message was never committed. Regenerate it
+          // from the last safe transcript; an ambiguous provider write may
+          // therefore produce a duplicate reply.
           resumeMessages = [...latestSafeBoundaryMessages];
         }
         const usage =

--- a/packages/junior/src/chat/agent/resume.ts
+++ b/packages/junior/src/chat/agent/resume.ts
@@ -21,15 +21,18 @@ import type { Actor } from "@/chat/actor";
 import {
   loadTurnSessionRecord,
   persistAuthPauseSessionRecord,
+  persistContinuationSessionRecord,
   persistRunningSessionRecord,
-  persistTimeoutSessionRecord,
   persistYieldSessionRecord,
 } from "@/chat/services/turn-session-record";
 import { AuthorizationPauseError } from "@/chat/services/auth-pause";
 import { hasAgentTurnUsage, type AgentTurnUsage } from "@/chat/usage";
 import { extractGenAiUsageSummary } from "@/chat/logging";
 import { isAssistantMessage } from "@/chat/pi/transcript";
-import type { AgentRunDurability } from "@/chat/agent/request";
+import {
+  RetryableDeliveryError,
+  type AgentRunDurability,
+} from "@/chat/agent/request";
 import { TurnSliceLimitExceededError } from "@/chat/services/turn-limit";
 
 type LoadedSessionRecordState = Awaited<
@@ -198,6 +201,41 @@ export function createResumeState(args: ResumeStateArgs) {
       error: unknown;
     }): Promise<ExpectedEndingTranslation> {
       const { error } = args2;
+      const retryingDelivery = error instanceof RetryableDeliveryError;
+      if (retryingDelivery || timedOut) {
+        if (retryingDelivery) {
+          resumeMessages = [...latestSafeBoundaryMessages];
+        }
+        const usage =
+          args2.currentUsage ??
+          extractSliceUsage(resumeMessages, beforeMessageCount);
+        await args.recordActiveMcpProviders();
+        const sessionRecord = await persistContinuationSessionRecord({
+          ...sessionRecordBase(),
+          currentSliceId,
+          currentDurationMs: currentDurationMs(),
+          currentUsage: usage,
+          messages: resumeMessages,
+          errorMessage: error instanceof Error ? error.message : String(error),
+          resumeReason: retryingDelivery ? "retry" : "timeout",
+        });
+        if (!sessionRecord) {
+          throw new Error(
+            `Failed to persist continuation for conversation=${args.conversationId} turn=${args.turnId}`,
+          );
+        }
+        if (sessionRecord.state === "awaiting_resume") {
+          return {
+            outcome: {
+              status: "suspended",
+              resumeVersion: sessionRecord.version,
+              ...(usage ? { usage } : {}),
+            },
+          };
+        }
+        throw new TurnSliceLimitExceededError(botConfig.maxSlicesPerTurn);
+      }
+
       if (cooperativeYieldError && error instanceof CooperativeTurnYieldError) {
         const usage =
           args2.currentUsage ??
@@ -223,36 +261,6 @@ export function createResumeState(args: ResumeStateArgs) {
             ...(usage ? { usage } : {}),
           },
         };
-      }
-
-      if (timedOut) {
-        const usage =
-          args2.currentUsage ??
-          extractSliceUsage(resumeMessages, beforeMessageCount);
-        await args.recordActiveMcpProviders();
-        const sessionRecord = await persistTimeoutSessionRecord({
-          ...sessionRecordBase(),
-          currentSliceId,
-          currentDurationMs: currentDurationMs(),
-          currentUsage: usage,
-          messages: resumeMessages,
-          errorMessage: error instanceof Error ? error.message : String(error),
-        });
-        if (!sessionRecord) {
-          throw new Error(
-            `Failed to persist timeout continuation for conversation=${args.conversationId} turn=${args.turnId}`,
-          );
-        }
-        if (sessionRecord.state === "awaiting_resume") {
-          return {
-            outcome: {
-              status: "suspended",
-              resumeVersion: sessionRecord.version,
-              ...(usage ? { usage } : {}),
-            },
-          };
-        }
-        throw new TurnSliceLimitExceededError(botConfig.maxSlicesPerTurn);
       }
 
       if (error instanceof AuthorizationPauseError) {

--- a/packages/junior/src/chat/agent/resume.ts
+++ b/packages/junior/src/chat/agent/resume.ts
@@ -201,44 +201,6 @@ export function createResumeState(args: ResumeStateArgs) {
       error: unknown;
     }): Promise<ExpectedEndingTranslation> {
       const { error } = args2;
-      const retryingDelivery = error instanceof RetryableDeliveryError;
-      if (retryingDelivery || timedOut) {
-        if (retryingDelivery) {
-          // The failed assistant message was never saved. Regenerate it from
-          // the latest saved agent history; an ambiguous provider write may
-          // therefore produce a duplicate reply.
-          resumeMessages = [...latestSafeBoundaryMessages];
-        }
-        const usage =
-          args2.currentUsage ??
-          extractSliceUsage(resumeMessages, beforeMessageCount);
-        await args.recordActiveMcpProviders();
-        const sessionRecord = await persistContinuationSessionRecord({
-          ...sessionRecordBase(),
-          currentSliceId,
-          currentDurationMs: currentDurationMs(),
-          currentUsage: usage,
-          messages: resumeMessages,
-          errorMessage: error instanceof Error ? error.message : String(error),
-          resumeReason: retryingDelivery ? "retry" : "timeout",
-        });
-        if (!sessionRecord) {
-          throw new Error(
-            `Failed to persist continuation for conversation=${args.conversationId} turn=${args.turnId}`,
-          );
-        }
-        if (sessionRecord.state === "awaiting_resume") {
-          return {
-            outcome: {
-              status: "suspended",
-              resumeVersion: sessionRecord.version,
-              ...(usage ? { usage } : {}),
-            },
-          };
-        }
-        throw new TurnSliceLimitExceededError(botConfig.maxSlicesPerTurn);
-      }
-
       if (cooperativeYieldError && error instanceof CooperativeTurnYieldError) {
         const usage =
           args2.currentUsage ??
@@ -264,6 +226,49 @@ export function createResumeState(args: ResumeStateArgs) {
             ...(usage ? { usage } : {}),
           },
         };
+      }
+
+      const resumeReason =
+        error instanceof RetryableDeliveryError
+          ? "retry"
+          : timedOut
+            ? "timeout"
+            : undefined;
+      if (resumeReason) {
+        if (resumeReason === "retry") {
+          // The failed assistant message was never saved. Regenerate it from
+          // the latest saved agent history; an ambiguous provider write may
+          // therefore produce a duplicate reply.
+          resumeMessages = [...latestSafeBoundaryMessages];
+        }
+        const usage =
+          args2.currentUsage ??
+          extractSliceUsage(resumeMessages, beforeMessageCount);
+        await args.recordActiveMcpProviders();
+        const sessionRecord = await persistContinuationSessionRecord({
+          ...sessionRecordBase(),
+          currentSliceId,
+          currentDurationMs: currentDurationMs(),
+          currentUsage: usage,
+          messages: resumeMessages,
+          errorMessage: error instanceof Error ? error.message : String(error),
+          resumeReason,
+        });
+        if (!sessionRecord) {
+          throw new Error(
+            `Failed to persist continuation for conversation=${args.conversationId} turn=${args.turnId}`,
+          );
+        }
+        if (sessionRecord.state === "awaiting_resume") {
+          return {
+            outcome: {
+              status: "suspended",
+              resumeVersion: sessionRecord.version,
+              ...(usage ? { usage } : {}),
+            },
+          };
+        }
+        throw new TurnSliceLimitExceededError(botConfig.maxSlicesPerTurn);
       }
 
       if (error instanceof AuthorizationPauseError) {

--- a/packages/junior/src/chat/agent/tools.ts
+++ b/packages/junior/src/chat/agent/tools.ts
@@ -212,7 +212,6 @@ export async function wireAgentTools(
         ? args.routing.source.threadTs
         : undefined,
     userMessage: args.userInput,
-    channelConfiguration: args.policy.channelConfiguration,
     pendingAuth: args.state.pendingAuth,
     recordPendingAuth: args.durability.recordPendingAuth,
     authorizationFlowMode: args.policy.authorizationFlowMode,

--- a/packages/junior/src/chat/agent/tools.ts
+++ b/packages/junior/src/chat/agent/tools.ts
@@ -211,7 +211,6 @@ export async function wireAgentTools(
       args.routing.source.platform === "slack"
         ? args.routing.source.threadTs
         : undefined,
-    userMessage: args.userInput,
     pendingAuth: args.state.pendingAuth,
     recordPendingAuth: args.durability.recordPendingAuth,
     authorizationFlowMode: args.policy.authorizationFlowMode,

--- a/packages/junior/src/chat/oauth-flow.ts
+++ b/packages/junior/src/chat/oauth-flow.ts
@@ -4,7 +4,6 @@ import {
   type Destination,
   type Source,
 } from "@sentry/junior-plugin-api";
-import type { ChannelConfigurationService } from "@/chat/configuration/types";
 import { parseDestination } from "@/chat/destination";
 import { logInfo, logWarn } from "@/chat/logging";
 import { pluginCatalogRuntime } from "@/chat/plugins/catalog-runtime";
@@ -31,7 +30,6 @@ export type OAuthStatePayload = {
   source?: Source;
   threadTs?: string;
   pendingMessage?: string;
-  configuration?: Record<string, unknown>;
   resumeConversationId?: string;
   resumeSessionId?: string;
   scope?: string;
@@ -44,7 +42,6 @@ type OAuthFlowInput = {
   source?: Source;
   threadTs?: string;
   userMessage?: string;
-  channelConfiguration?: ChannelConfigurationService;
   activeSkillName?: string;
   resumeConversationId?: string;
   resumeSessionId?: string;
@@ -94,9 +91,6 @@ export function parseOAuthStatePayload(
       ? { threadTs: optionalString(value.threadTs) }
       : {}),
     ...(pendingMessage ? { pendingMessage } : {}),
-    ...(isRecord(value.configuration)
-      ? { configuration: value.configuration }
-      : {}),
     ...(optionalString(value.resumeConversationId)
       ? { resumeConversationId: optionalString(value.resumeConversationId) }
       : {}),
@@ -252,10 +246,6 @@ export async function startOAuthFlow(
     };
   }
 
-  const configuration =
-    input.userMessage && input.channelConfiguration
-      ? await input.channelConfiguration.resolveValues()
-      : undefined;
   const state = randomBytes(32).toString("hex");
   const requestedScope = input.scope ?? providerConfig.scope;
 
@@ -269,9 +259,6 @@ export async function startOAuthFlow(
       ...(input.source ? { source: input.source } : {}),
       ...(input.threadTs ? { threadTs: input.threadTs } : {}),
       ...(input.userMessage ? { pendingMessage: input.userMessage } : {}),
-      ...(configuration && Object.keys(configuration).length > 0
-        ? { configuration }
-        : {}),
       ...(input.resumeConversationId
         ? { resumeConversationId: input.resumeConversationId }
         : {}),

--- a/packages/junior/src/chat/oauth-flow.ts
+++ b/packages/junior/src/chat/oauth-flow.ts
@@ -29,7 +29,6 @@ export type OAuthStatePayload = {
   destination?: Destination;
   source?: Source;
   threadTs?: string;
-  pendingMessage?: string;
   resumeConversationId?: string;
   resumeSessionId?: string;
   scope?: string;
@@ -41,7 +40,6 @@ type OAuthFlowInput = {
   destination?: Destination;
   source?: Source;
   threadTs?: string;
-  userMessage?: string;
   activeSkillName?: string;
   resumeConversationId?: string;
   resumeSessionId?: string;
@@ -75,10 +73,6 @@ export function parseOAuthStatePayload(
   if (value.source !== undefined && (!source || !source.success)) {
     return undefined;
   }
-  const pendingMessage = optionalString(value.pendingMessage);
-  if (pendingMessage && !source?.success) {
-    return undefined;
-  }
   return {
     userId: value.userId,
     provider: value.provider,
@@ -90,7 +84,6 @@ export function parseOAuthStatePayload(
     ...(optionalString(value.threadTs)
       ? { threadTs: optionalString(value.threadTs) }
       : {}),
-    ...(pendingMessage ? { pendingMessage } : {}),
     ...(optionalString(value.resumeConversationId)
       ? { resumeConversationId: optionalString(value.resumeConversationId) }
       : {}),
@@ -258,7 +251,6 @@ export async function startOAuthFlow(
       ...(input.destination ? { destination: input.destination } : {}),
       ...(input.source ? { source: input.source } : {}),
       ...(input.threadTs ? { threadTs: input.threadTs } : {}),
-      ...(input.userMessage ? { pendingMessage: input.userMessage } : {}),
       ...(input.resumeConversationId
         ? { resumeConversationId: input.resumeConversationId }
         : {}),

--- a/packages/junior/src/chat/runtime/README.md
+++ b/packages/junior/src/chat/runtime/README.md
@@ -1,76 +1,51 @@
-# Agent Runtime
+# Chat Runtime
 
-The runtime prepares turns, advances durable agent state, handles continuation,
-and coordinates provider delivery. `../agent/` owns the Pi execution loop; this
-directory owns product orchestration around it.
+This folder coordinates a chat turn. It loads conversation state, calls the
+agent, delivers replies, saves the result, and schedules more work when a turn
+must continue later. `../agent/` owns the model and tool loop.
 
-## Turn Handling
+## Replies
 
-- A turn may reply, intentionally remain silent, pause for authorization,
-  cooperatively yield, or fail.
-- Silence is explicit; absence of model text is not automatically a successful
-  silent outcome.
-- Every completed tool-free assistant message with visible text is delivered as
-  its own destination reply. Thinking, tool calls, and text emitted alongside
-  tool calls remain internal.
-- Assistant delivery is awaited before the run advances. Explicit progress uses
-  the runtime status surface rather than tool-bearing assistant text.
-- The runtime records each assistant message only after delivery succeeds.
-- Resumed runs continue the same durable turn and must not repeat already
-  committed side effects. An ambiguous external delivery may be repeated when
-  the provider accepted it before the worker lost confirmation.
+- A completed assistant message without tool calls is sent as a reply.
+- Thinking, tool calls, and text attached to tool calls stay internal.
+- Progress is shown through the status UI, not as an assistant reply.
+- An assistant message is saved only after delivery succeeds.
+- A turn that intentionally has no reply records `no_reply`. Missing text alone
+  does not count as intentional silence.
 
-## Durable Continuation
+## Recovery
 
-- Conversation events append at safe boundaries with monotonic sequence numbers.
-- Restoration reduces the current history version into Pi messages and derived
-  runtime state.
-- A timeout or soft execution limit yields only at a boundary where tool results
-  and state updates are durable.
-- Auth pauses persist the pending authorization state and end the live run;
-  callbacks append new work and start a later run.
-- Transient or ambiguous reply-delivery failures resume from the last safe
-  transcript boundary and share the normal bounded continuation limit.
-- Explicit provider rejections fail the turn instead of retrying.
-- Canonical turn lifecycle uses stable conversation and turn IDs: input is
-  durable before `turn_started`, and completion/failure is appended only at the
-  owning delivery-and-persistence boundary. Competing terminal writes share
-  one idempotency key, so the first committed outcome wins.
-- Intentional silence is a `turn_completed` `no_reply` outcome and does not
-  create a synthetic visible assistant message.
-- Stable lifecycle keys make internal terminal writes idempotent. External
-  delivery remains best-effort: process death after a provider accepts a reply
-  can produce a duplicate when the turn recovers.
+A turn can outlive one worker. The runtime saves agent history after input and
+after completed tool work, then resumes from the latest saved checkpoint.
 
-## Prompt Ownership
+- Timeouts, worker yields, authorization pauses, and retryable delivery failures
+  can continue the same turn in a later run.
+- Timeouts and delivery retries share the turn's normal execution limit.
+- Work already present in saved agent history is not repeated.
+- The same conversation ID and turn ID are used throughout recovery. If two
+  workers try to finish the turn, only the first saved result wins.
 
-- Core prompt text contains stable Junior behavior, not provider-specific setup.
-- Runtime context supplies the active source, actor, destination, capabilities,
-  artifacts, attachments, and execution constraints.
-- Plugins contribute bounded prompt messages and tool descriptions through
-  registered hooks.
-- Skills provide task guidance after activation; they do not own runtime setup
-  or credentials.
-- Avoid repeating schemas, tool catalogs, policy prose, or implementation
-  details already visible through structured surfaces.
+Reply delivery is best effort. An explicit provider rejection fails the turn.
+A transient failure, or a failure where the provider may have accepted the
+reply, resumes from the latest checkpoint and generates the reply again. This
+can produce a duplicate reply if the first one actually reached the provider.
 
-## Compaction And Handoff
+## Prompt Context
 
-- The host profile registry maps stable names to models and may force a
-  reasoning level. Only `standard` uses the turn router; named profiles start
-  directly and can use `handoff` to switch to another named profile.
-- Compaction replaces agent history. Its replacement history contains the
-  retained user messages followed by a summary; later messages append normally.
-  Visible conversation history remains unchanged.
-- The replacement must retain unresolved work, durable facts, active artifacts,
-  tool outcomes needed for continuation, and relevant actor/destination context.
-- Model handoff is a permanent in-place transition recorded at a safe boundary.
-  It does not fork the conversation or replay completed side effects.
-- Restoration uses the model profile recorded by durable history, not
-  process-local assumptions.
-- Normal turn-record reads stay pinned to their checkpoint. Agent execution
-  follows a newer committed compaction or handoff replacement and discards
-  volatile context from the superseded history.
+The core prompt contains stable Junior behavior. The runtime adds the current
+source, actor, destination, tools, files, and execution limits. Plugins and
+skills may add their own focused instructions, but they do not own runtime
+state or credentials.
 
-Representative integration coverage lives under
-`packages/junior/tests/integration/runtime/`.
+## Compaction And Model Handoff
+
+Compaction replaces old agent history with retained user messages and a
+summary. A model handoff replaces that history and switches models. Both are
+saved changes to the same conversation; neither creates a new conversation or
+changes the visible message history.
+
+The replacement must keep anything needed to continue the work: unfinished
+tasks, important facts, files, completed tool results, and the active actor and
+destination.
+
+Integration coverage lives under `packages/junior/tests/integration/runtime/`.

--- a/packages/junior/src/chat/runtime/README.md
+++ b/packages/junior/src/chat/runtime/README.md
@@ -17,7 +17,8 @@ directory owns product orchestration around it.
   the runtime status surface rather than tool-bearing assistant text.
 - The runtime records each assistant message only after delivery succeeds.
 - Resumed runs continue the same durable turn and must not repeat already
-  committed side effects.
+  committed side effects. An ambiguous external delivery may be repeated when
+  the provider accepted it before the worker lost confirmation.
 
 ## Durable Continuation
 
@@ -28,17 +29,18 @@ directory owns product orchestration around it.
   and state updates are durable.
 - Auth pauses persist the pending authorization state and end the live run;
   callbacks append new work and start a later run.
-- Completion and delivery markers make retries idempotent.
+- Transient or ambiguous reply-delivery failures resume from the last safe
+  transcript boundary and share the normal bounded continuation limit.
+- Explicit provider rejections fail the turn instead of retrying.
 - Canonical turn lifecycle uses stable conversation and turn IDs: input is
   durable before `turn_started`, and completion/failure is appended only at the
   owning delivery-and-persistence boundary. Competing terminal writes share
   one idempotency key, so the first committed outcome wins.
 - Intentional silence is a `turn_completed` `no_reply` outcome and does not
   create a synthetic visible assistant message.
-- Stable lifecycle keys make explicit retries idempotent; they do not cover
-  process death between external delivery and persistence. Slack needs a
-  durable delivery outbox/receipt reconciler before terminal events are
-  crash-safe across that boundary.
+- Stable lifecycle keys make internal terminal writes idempotent. External
+  delivery remains best-effort: process death after a provider accepts a reply
+  can produce a duplicate when the turn recovers.
 
 ## Prompt Ownership
 

--- a/packages/junior/src/chat/runtime/agent-continue-runner.ts
+++ b/packages/junior/src/chat/runtime/agent-continue-runner.ts
@@ -472,7 +472,7 @@ export async function continueSlackAgentRun(
               "Continued agent run parked for auth",
             );
           },
-          onTimeoutPause: async ({ resumeVersion }) => {
+          onSuspend: async (resumeVersion) => {
             await scheduleAgentContinue({
               conversationId: payload.conversationId,
               destination: payload.destination,

--- a/packages/junior/src/chat/runtime/agent-continue-runner.ts
+++ b/packages/junior/src/chat/runtime/agent-continue-runner.ts
@@ -254,7 +254,9 @@ async function resolveContinuationActor(args: {
 function isContinuationResume(summary: AgentTurnSessionSummary): boolean {
   return (
     summary.state === "awaiting_resume" &&
-    (summary.resumeReason === "timeout" || summary.resumeReason === "yield")
+    (summary.resumeReason === "timeout" ||
+      summary.resumeReason === "yield" ||
+      summary.resumeReason === "retry")
   );
 }
 
@@ -312,7 +314,8 @@ export async function continueSlackAgentRun(
           !sessionRecord ||
           sessionRecord.state !== "awaiting_resume" ||
           (sessionRecord.resumeReason !== "timeout" &&
-            sessionRecord.resumeReason !== "yield") ||
+            sessionRecord.resumeReason !== "yield" &&
+            sessionRecord.resumeReason !== "retry") ||
           sessionRecord.version !== payload.expectedVersion
         ) {
           return false;

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -29,9 +29,15 @@ import {
   type PlannedSlackReplyStage,
 } from "@/chat/slack/reply";
 import { buildSlackOutputMessage } from "@/chat/slack/output";
-import { getSlackErrorObservabilityAttributes } from "@/chat/slack/errors";
+import {
+  getSlackErrorObservabilityAttributes,
+  isRetryableSlackPostError,
+} from "@/chat/slack/errors";
 import { buildSteeringPiMessage } from "@/chat/agent/prompt";
-import type { AgentRunSteeringMessage } from "@/chat/agent/request";
+import {
+  RetryableDeliveryError,
+  type AgentRunSteeringMessage,
+} from "@/chat/agent/request";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import type { CredentialContext } from "@/chat/credentials/context";
 import { shouldEmitDevAgentTrace } from "@/chat/runtime/dev-agent-trace";
@@ -1008,6 +1014,9 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               },
               "Failed to post Slack thread reply",
             );
+            if (isRetryableSlackPostError(error)) {
+              throw new RetryableDeliveryError(error);
+            }
             throw new ConversationTurnBoundaryError({
               cause: error,
               ...(eventId ? { eventId } : {}),

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -1003,6 +1003,9 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
           try {
             return await thread.post(payload);
           } catch (error) {
+            if (isRetryableSlackPostError(error)) {
+              throw new RetryableDeliveryError(error);
+            }
             const eventId = logException(
               error,
               "slack_thread_post_failed",
@@ -1014,9 +1017,6 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
               },
               "Failed to post Slack thread reply",
             );
-            if (isRetryableSlackPostError(error)) {
-              throw new RetryableDeliveryError(error);
-            }
             throw new ConversationTurnBoundaryError({
               cause: error,
               ...(eventId ? { eventId } : {}),

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -8,7 +8,10 @@
 import { botConfig } from "@/chat/config";
 import { standardModelId } from "@/chat/model-profile";
 import type { ChannelConfigurationService } from "@/chat/configuration/types";
-import type { AgentRunRequest } from "@/chat/agent/request";
+import {
+  RetryableDeliveryError,
+  type AgentRunRequest,
+} from "@/chat/agent/request";
 import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { scheduleSessionCompletedPluginTasks } from "@/chat/plugins/task-runner";
@@ -72,6 +75,7 @@ import {
   turnHasReply,
 } from "@/chat/services/conversation-memory";
 import { persistWithRetry } from "@/chat/services/persist-retry";
+import { isRetryableSlackPostError } from "@/chat/slack/errors";
 
 function resolveReplyTimeoutMs(explicitTimeoutMs?: number): number | undefined {
   if (typeof explicitTimeoutMs === "number" && explicitTimeoutMs > 0) {
@@ -552,11 +556,19 @@ export async function resumeSlackTurn(
       }
       failureCode = "delivery_failed";
       const deliveryState = await getDeliveryConversation();
-      const messageTs = await postSlackApiReplyPosts({
-        channelId: runArgs.channelId,
-        threadTs: runArgs.threadTs,
-        posts,
-      });
+      let messageTs: string | undefined;
+      try {
+        messageTs = await postSlackApiReplyPosts({
+          channelId: runArgs.channelId,
+          threadTs: runArgs.threadTs,
+          posts,
+        });
+      } catch (error) {
+        if (isRetryableSlackPostError(error)) {
+          throw new RetryableDeliveryError(error);
+        }
+        throw error;
+      }
       assistantMessageDelivered = true;
       const recordedMessageId = recordDeliveredAssistantMessage({
         conversation: deliveryState.conversation,

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -180,7 +180,7 @@ interface ResumeSlackTurnArgs {
   onSuccess?: (reply: AgentRunResult) => Promise<void>;
   onFailure?: (error: unknown) => Promise<void>;
   onAuthPause?: (pause: { providerDisplayName: string }) => Promise<void>;
-  onTimeoutPause?: (resume: { resumeVersion: number }) => Promise<void>;
+  onSuspend?: (resumeVersion: number) => Promise<void>;
   onPostDeliveryCommitFailure?: (error: unknown) => Promise<void>;
   beforeStart?: () => Promise<ResumePreparedTurn | false | void>;
   replyTimeoutMs?: number;
@@ -204,7 +204,7 @@ interface ResumePreparedTurn {
   onSuccess?: (reply: AgentRunResult) => Promise<void>;
   onFailure?: (error: unknown) => Promise<void>;
   onAuthPause?: (pause: { providerDisplayName: string }) => Promise<void>;
-  onTimeoutPause?: (resume: { resumeVersion: number }) => Promise<void>;
+  onSuspend?: (resumeVersion: number) => Promise<void>;
   onPostDeliveryCommitFailure?: (error: unknown) => Promise<void>;
 }
 
@@ -438,7 +438,6 @@ export async function resumeSlackTurn(
     threadTs: args.threadTs,
   });
   let processingReaction: ProcessingReactionSession | undefined;
-  let deferredPauseKind: "auth" | "timeout" | undefined;
   let deferredAuthInfo:
     | { providerDisplayName: string; actorId: string | undefined }
     | undefined;
@@ -640,9 +639,8 @@ export async function resumeSlackTurn(
       // mirroring the failure path below.
       await status.clear();
       const onAuthPause = runArgs.onAuthPause;
-      const onTimeoutPause = runArgs.onTimeoutPause;
+      const onSuspend = runArgs.onSuspend;
       if (outcome.status === "awaiting_auth" && onAuthPause) {
-        deferredPauseKind = "auth";
         deferredAuthInfo = {
           providerDisplayName: outcome.providerDisplayName,
           actorId: isUserActor(resumeActor) ? resumeActor.userId : undefined,
@@ -652,10 +650,9 @@ export async function resumeSlackTurn(
             providerDisplayName: outcome.providerDisplayName,
           });
         };
-      } else if (outcome.status === "suspended" && onTimeoutPause) {
-        deferredPauseKind = "timeout";
+      } else if (outcome.status === "suspended" && onSuspend) {
         deferredPauseHandler = async () => {
-          await onTimeoutPause({ resumeVersion: outcome.resumeVersion });
+          await onSuspend(outcome.resumeVersion);
         };
       } else {
         deferredFailureHandler = async () => {
@@ -810,7 +807,7 @@ export async function resumeSlackTurn(
   if (deferredPauseHandler) {
     try {
       await deferredPauseHandler();
-      if (deferredPauseKind === "auth" && deferredAuthInfo) {
+      if (deferredAuthInfo) {
         const footer = buildSlackReplyFooter({
           conversationId: runArgs.conversationId,
         });

--- a/packages/junior/src/chat/services/agent-continue.ts
+++ b/packages/junior/src/chat/services/agent-continue.ts
@@ -40,7 +40,8 @@ export async function getAwaitingAgentContinueRequest(args: {
     !sessionRecord ||
     sessionRecord.state !== "awaiting_resume" ||
     (sessionRecord.resumeReason !== "timeout" &&
-      sessionRecord.resumeReason !== "yield") ||
+      sessionRecord.resumeReason !== "yield" &&
+      sessionRecord.resumeReason !== "retry") ||
     (sessionRecord.resumeReason === "timeout" && sessionRecord.sliceId < 2)
   ) {
     return undefined;

--- a/packages/junior/src/chat/services/plugin-auth-orchestration.ts
+++ b/packages/junior/src/chat/services/plugin-auth-orchestration.ts
@@ -11,7 +11,6 @@
  * stdout patterns, or exit codes.
  */
 import type { Destination, Source } from "@sentry/junior-plugin-api";
-import type { ChannelConfigurationService } from "@/chat/configuration/types";
 import type { UserTokenStore } from "@/chat/credentials/user-token-store";
 import { formatProviderLabel, startOAuthFlow } from "@/chat/oauth-flow";
 import {
@@ -58,7 +57,6 @@ export interface PluginAuthOrchestrationInput {
   source?: Source;
   threadTs?: string;
   userMessage: string;
-  channelConfiguration?: ChannelConfigurationService;
   pendingAuth?: ConversationPendingAuthState;
   recordPendingAuth?: (
     pendingAuth: ConversationPendingAuthState,
@@ -175,7 +173,6 @@ export function createPluginAuthOrchestration(
         source: input.source,
         threadTs: input.threadTs,
         userMessage: input.userMessage,
-        channelConfiguration: input.channelConfiguration,
         ...(options?.scope ? { scope: options.scope } : {}),
         resumeConversationId: input.conversationId,
         resumeSessionId: input.sessionId,

--- a/packages/junior/src/chat/services/plugin-auth-orchestration.ts
+++ b/packages/junior/src/chat/services/plugin-auth-orchestration.ts
@@ -56,7 +56,6 @@ export interface PluginAuthOrchestrationInput {
   destination?: Destination;
   source?: Source;
   threadTs?: string;
-  userMessage: string;
   pendingAuth?: ConversationPendingAuthState;
   recordPendingAuth?: (
     pendingAuth: ConversationPendingAuthState,
@@ -172,7 +171,6 @@ export function createPluginAuthOrchestration(
         destination: input.destination,
         source: input.source,
         threadTs: input.threadTs,
-        userMessage: input.userMessage,
         ...(options?.scope ? { scope: options.scope } : {}),
         resumeConversationId: input.conversationId,
         resumeSessionId: input.sessionId,

--- a/packages/junior/src/chat/services/turn-session-record.ts
+++ b/packages/junior/src/chat/services/turn-session-record.ts
@@ -471,7 +471,7 @@ interface ContinuationRecordInput {
   surface?: AgentTurnSurface;
 }
 
-/** Persist a timeout or delivery-retry continuation at the last safe boundary. */
+/** Persist a timeout or delivery retry under the turn's shared slice limit. */
 export async function persistContinuationSessionRecord(
   args: ContinuationRecordInput & {
     resumeReason: "retry" | "timeout";

--- a/packages/junior/src/chat/services/turn-session-record.ts
+++ b/packages/junior/src/chat/services/turn-session-record.ts
@@ -452,11 +452,7 @@ export async function persistAuthPauseSessionRecord(args: {
   return undefined;
 }
 
-/**
- * Persist a timeout session record at the last safe boundary. Returns the durable
- * record so callers can distinguish scheduled continuations from terminal caps.
- */
-export async function persistTimeoutSessionRecord(args: {
+interface ContinuationRecordInput {
   channelName?: string;
   conversationId: string;
   sessionId: string;
@@ -473,7 +469,14 @@ export async function persistTimeoutSessionRecord(args: {
   actor?: Actor;
   reasoningLevel?: string;
   surface?: AgentTurnSurface;
-}): Promise<AgentTurnSessionRecord | undefined> {
+}
+
+/** Persist a timeout or delivery-retry continuation at the last safe boundary. */
+export async function persistContinuationSessionRecord(
+  args: ContinuationRecordInput & {
+    resumeReason: "retry" | "timeout";
+  },
+): Promise<AgentTurnSessionRecord | undefined> {
   const nextSliceId = args.currentSliceId + 1;
 
   try {
@@ -531,7 +534,7 @@ export async function persistTimeoutSessionRecord(args: {
                 args.reasoningLevel ?? latestSessionRecord?.reasoningLevel,
             }
           : {}),
-        resumeReason: "timeout",
+        resumeReason: args.resumeReason,
         resumedFromSliceId: latestSessionRecord?.resumedFromSliceId,
         errorMessage: new TurnSliceLimitExceededError(
           botConfig.maxSlicesPerTurn,
@@ -574,7 +577,7 @@ export async function persistTimeoutSessionRecord(args: {
               args.reasoningLevel ?? latestSessionRecord?.reasoningLevel,
           }
         : {}),
-      resumeReason: "timeout",
+      resumeReason: args.resumeReason,
       resumedFromSliceId: args.currentSliceId,
       errorMessage: args.errorMessage,
       ...((args.actor ?? latestSessionRecord?.actor)

--- a/packages/junior/src/chat/slack/README.md
+++ b/packages/junior/src/chat/slack/README.md
@@ -27,10 +27,13 @@ runtime orchestration.
 - Reactions and status messages are progress UI, not assistant-message delivery
   contracts.
 - OAuth links and other private authorization material use private delivery.
+- Explicit Slack API rejections fail delivery. Transient or ambiguous failures
+  resume the agent from its last safe transcript boundary; a reply may be
+  duplicated if Slack accepted it before the failure became visible.
 
-`outbound.ts` owns Slack API calls and retry classification. `mrkdwn.ts` owns
-format conversion. `assistant-thread/` owns assistant-thread lifecycle and
-status rendering.
+`outbound.ts` owns Slack API calls and immediate transport retries. `errors.ts`
+owns reply-failure classification. `mrkdwn.ts` owns format conversion.
+`assistant-thread/` owns assistant-thread lifecycle and status rendering.
 
 ## Boundaries
 

--- a/packages/junior/src/chat/slack/README.md
+++ b/packages/junior/src/chat/slack/README.md
@@ -28,7 +28,7 @@ runtime orchestration.
   contracts.
 - OAuth links and other private authorization material use private delivery.
 - Explicit Slack API rejections fail delivery. Transient or ambiguous failures
-  resume the agent from its last safe transcript boundary; a reply may be
+  resume the agent from its latest saved history; a reply may be
   duplicated if Slack accepted it before the failure became visible.
 
 `outbound.ts` owns Slack API calls and immediate transport retries. `errors.ts`

--- a/packages/junior/src/chat/slack/errors.ts
+++ b/packages/junior/src/chat/slack/errors.ts
@@ -70,7 +70,7 @@ const TRANSIENT_SLACK_API_ERRORS = new Set([
   "service_unavailable",
 ]);
 
-/** Retry transport failures and transient Slack responses, but not explicit rejections. */
+/** Recover transient or ambiguous Slack failures, but stop on explicit rejection. */
 export function isRetryableSlackPostError(error: unknown): boolean {
   if (!error || typeof error !== "object") {
     return true;

--- a/packages/junior/src/chat/slack/errors.ts
+++ b/packages/junior/src/chat/slack/errors.ts
@@ -66,6 +66,9 @@ export function getSlackErrorObservabilityAttributes(
 const TRANSIENT_SLACK_API_ERRORS = new Set([
   "fatal_error",
   "internal_error",
+  // chat.postMessage documents both spellings.
+  "rate_limited",
+  "ratelimited",
   "request_timeout",
   "service_unavailable",
 ]);

--- a/packages/junior/src/chat/slack/errors.ts
+++ b/packages/junior/src/chat/slack/errors.ts
@@ -1,4 +1,4 @@
-import { getHeaderString } from "@/chat/slack/client";
+import { getHeaderString, SlackActionError } from "@/chat/slack/client";
 
 /** Extract Slack's stable API error code from Web API errors. */
 export function getSlackApiErrorCode(error: unknown): string | undefined {
@@ -61,6 +61,51 @@ export function getSlackErrorObservabilityAttributes(
   }
 
   return attributes;
+}
+
+const TRANSIENT_SLACK_API_ERRORS = new Set([
+  "fatal_error",
+  "internal_error",
+  "request_timeout",
+  "service_unavailable",
+]);
+
+/** Retry transport failures and transient Slack responses, but not explicit rejections. */
+export function isRetryableSlackPostError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return true;
+  }
+
+  const candidate = error as {
+    data?: { error?: unknown };
+    statusCode?: unknown;
+  };
+  if (typeof candidate.statusCode === "number") {
+    if (candidate.statusCode === 429 || candidate.statusCode >= 500) {
+      return true;
+    }
+    if (candidate.statusCode >= 400) {
+      return false;
+    }
+  }
+
+  const apiError =
+    error instanceof SlackActionError
+      ? error.apiError
+      : typeof candidate.data?.error === "string"
+        ? candidate.data.error
+        : undefined;
+  if (apiError) {
+    return TRANSIENT_SLACK_API_ERRORS.has(apiError);
+  }
+
+  if (error instanceof SlackActionError) {
+    return error.code === "rate_limited" || error.code === "internal_error";
+  }
+
+  // Without an API response, delivery is ambiguous. Recover the turn and
+  // accept the narrow possibility that Slack already accepted the message.
+  return true;
 }
 
 /** Report whether Slack rejected assistant title updates for stable auth reasons. */

--- a/packages/junior/src/chat/state/turn-session.ts
+++ b/packages/junior/src/chat/state/turn-session.ts
@@ -61,7 +61,7 @@ export type AgentTurnSessionStatus =
 
 export type AgentTurnSurface = "slack" | "api" | "scheduler" | "internal";
 
-export type AgentTurnResumeReason = "timeout" | "auth" | "yield";
+export type AgentTurnResumeReason = "timeout" | "auth" | "yield" | "retry";
 
 interface ConversationMessageProjection {
   messages: PiMessage[];
@@ -154,6 +154,7 @@ const agentTurnResumeReasonSchema = z.enum([
   "timeout",
   "auth",
   "yield",
+  "retry",
 ]) satisfies z.ZodType<AgentTurnResumeReason>;
 
 const nonNegativeNumberSchema = z.number().finite().nonnegative();

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -454,7 +454,7 @@ async function resumeAuthorizedMcpTurn(args: {
             "Resumed MCP turn requested another authorization flow",
           );
         },
-        onTimeoutPause: async ({ resumeVersion }) => {
+        onSuspend: async (resumeVersion) => {
           await scheduleAgentContinue({
             conversationId: authSession.conversationId,
             destination,

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -39,15 +39,10 @@ import {
   getTurnUserSlackMessageTs,
   getTurnUserReplyAttachmentContext,
 } from "@/chat/runtime/turn-user-message";
-import {
-  buildDeterministicTurnId,
-  markTurnFailed,
-  startActiveTurn,
-} from "@/chat/runtime/turn";
+import { markTurnFailed } from "@/chat/runtime/turn";
 import { publishAppHomeView } from "@/chat/slack/app-home";
 import { getSlackClient } from "@/chat/slack/client";
 import { createSlackResumeActor, isUserActor, type Actor } from "@/chat/actor";
-import { lookupSlackActor } from "@/chat/slack/user";
 import { getStateAdapter } from "@/chat/state/adapter";
 import { coerceThreadArtifactsState } from "@/chat/state/artifacts";
 import {
@@ -186,7 +181,7 @@ async function persistFailedOAuthReplyState(args: {
 async function resumeOAuthSessionRecordTurn(
   stored: OAuthStatePayload,
   options: OAuthCallbackOptions,
-): Promise<boolean> {
+): Promise<void> {
   if (
     !stored.resumeConversationId ||
     !stored.resumeSessionId ||
@@ -195,7 +190,7 @@ async function resumeOAuthSessionRecordTurn(
     !stored.source ||
     !stored.threadTs
   ) {
-    return false;
+    return;
   }
   const destination = requireSlackDestination(
     stored.destination,
@@ -234,7 +229,7 @@ async function resumeOAuthSessionRecordTurn(
         errorMessage:
           "Auth completed after a newer thread message abandoned this blocked request.",
       });
-      return true;
+      return;
     }
   }
 
@@ -243,31 +238,30 @@ async function resumeOAuthSessionRecordTurn(
     resolvedSessionId,
   );
   if (!sessionRecord) {
-    return false;
+    return;
   }
-  // Terminal session record states are already handled; do not fall through to
-  // the pending-message resume which would re-post the original request.
+  // Terminal session record states are already handled.
   if (
     sessionRecord.state === "completed" ||
     sessionRecord.state === "failed" ||
     sessionRecord.state === "abandoned"
   ) {
-    return true;
+    return;
   }
   if (
     sessionRecord.state !== "awaiting_resume" ||
     sessionRecord.resumeReason !== "auth"
   ) {
-    return true;
+    return;
   }
   if (!userMessage?.author?.userId) {
-    return false;
+    return;
   }
   if (
     !pendingAuth &&
     conversation.processing.activeTurnId !== stored.resumeSessionId
   ) {
-    return true;
+    return;
   }
 
   await resumeSlackTurn({
@@ -490,104 +484,6 @@ async function resumeOAuthSessionRecordTurn(
       };
     },
   });
-
-  return true;
-}
-
-async function resumePendingOAuthMessage(
-  stored: OAuthStatePayload,
-  options: OAuthCallbackOptions,
-): Promise<void> {
-  const source = stored.source;
-  if (
-    !stored.pendingMessage ||
-    !stored.channelId ||
-    !stored.destination ||
-    !source ||
-    !stored.threadTs
-  ) {
-    return;
-  }
-
-  const threadId = `slack:${stored.channelId}:${stored.threadTs}`;
-  const conversation = coerceThreadConversationState(
-    await getPersistedThreadState(threadId),
-  );
-  await hydrateConversationMessages({ conversation, conversationId: threadId });
-  const latestUserMessage = [...conversation.messages]
-    .reverse()
-    .find((message) => message.role === "user");
-  const conversationContext = buildConversationContext(conversation, {
-    excludeMessageId: latestUserMessage?.id,
-  });
-  const destination = requireSlackDestination(
-    stored.destination,
-    "OAuth pending message resume",
-  );
-  const actor = await lookupSlackActor(destination.teamId, stored.userId);
-  const messageTs = getTurnUserSlackMessageTs(latestUserMessage);
-  const turnId =
-    stored.resumeSessionId ??
-    (latestUserMessage
-      ? buildDeterministicTurnId(latestUserMessage.id)
-      : undefined);
-  if (!turnId) {
-    return;
-  }
-  await resumeSlackTurn({
-    messageText: stored.pendingMessage,
-    conversationId: threadId,
-    turnId,
-    channelId: stored.channelId,
-    threadTs: stored.threadTs,
-    messageTs,
-    initialText: "",
-    agentRunner: options.agentRunner,
-    replyContext: {
-      input: {
-        conversationContext,
-        // Pi history is SQL-authoritative via the event-store projection.
-        piMessages: await loadProjection({ conversationId: threadId }),
-      },
-      routing: {
-        credentialContext: {
-          actor: { type: "user", userId: stored.userId },
-        },
-        actor,
-        destination: stored.destination,
-        source,
-      },
-      policy: {
-        configuration: stored.configuration,
-      },
-    },
-    onSuccess: async (reply) => {
-      logInfo(
-        "oauth_callback_resume_complete",
-        {},
-        {
-          "app.credential.provider": stored.provider,
-          "app.ai.outcome": reply.diagnostics.outcome,
-          "app.ai.tool_calls": reply.diagnostics.toolCalls.length,
-        },
-        "OAuth callback auto-resumed pending message finished replying",
-      );
-    },
-    onSuspend: async (resumeVersion) => {
-      startActiveTurn({
-        conversation,
-        nextTurnId: turnId,
-        updateConversationStats,
-      });
-      await persistThreadStateById(threadId, { conversation });
-      await scheduleAgentContinue({
-        conversationId: threadId,
-        destination,
-        sessionId: turnId,
-        expectedVersion: resumeVersion,
-      });
-    },
-  });
 }
 
 export async function GET(
@@ -768,10 +664,9 @@ export async function GET(
   if (stored.pendingMessage && stored.channelId && stored.threadTs) {
     waitUntil(async () => {
       try {
-        const resumed = await resumeOAuthSessionRecordTurn(stored, options);
-        if (!resumed) {
-          await resumePendingOAuthMessage(stored, options);
-        }
+        // Agent OAuth links resume their durable session record. Do not rebuild
+        // a turn from pending message text when that record is missing.
+        await resumeOAuthSessionRecordTurn(stored, options);
       } catch (error) {
         if (error instanceof ResumeTurnBusyError) {
           logWarn(

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -265,9 +265,7 @@ async function resumeOAuthSessionRecordTurn(
   }
 
   await resumeSlackTurn({
-    messageText: pendingAuth
-      ? userMessage.text
-      : (stored.pendingMessage ?? userMessage.text),
+    messageText: userMessage.text,
     conversationId: stored.resumeConversationId,
     turnId: resolvedSessionId,
     channelId: stored.channelId,
@@ -389,9 +387,7 @@ async function resumeOAuthSessionRecordTurn(
 
       const lockedMessageTs = getTurnUserSlackMessageTs(lockedUserMessage);
       return {
-        messageText: lockedPendingAuth
-          ? lockedUserMessage.text
-          : (stored.pendingMessage ?? lockedUserMessage.text),
+        messageText: lockedUserMessage.text,
         messageTs: lockedMessageTs,
         inputMessageIds: [lockedUserMessage.id],
         replyContext: {
@@ -661,7 +657,10 @@ export async function GET(
     }
   });
 
-  if (stored.pendingMessage && stored.channelId && stored.threadTs) {
+  const resumesAgentTurn = Boolean(
+    stored.resumeConversationId && stored.resumeSessionId,
+  );
+  if (resumesAgentTurn) {
     waitUntil(async () => {
       try {
         // Agent OAuth links resume their durable session record. Do not rebuild
@@ -702,7 +701,7 @@ export async function GET(
     );
   }
 
-  const statusMessage = stored.pendingMessage
+  const statusMessage = resumesAgentTurn
     ? "Your request is being processed in Slack."
     : "You can close this tab and return to Slack.";
   const html = `<!DOCTYPE html>

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -475,7 +475,7 @@ async function resumeOAuthSessionRecordTurn(
             threadStateId: stored.resumeConversationId!,
           });
         },
-        onTimeoutPause: async ({ resumeVersion }) => {
+        onSuspend: async (resumeVersion) => {
           await scheduleAgentContinue({
             conversationId: stored.resumeConversationId!,
             destination,

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -569,6 +569,14 @@ async function resumePendingOAuthMessage(
         "OAuth callback auto-resumed pending message finished replying",
       );
     },
+    onSuspend: async (resumeVersion) => {
+      await scheduleAgentContinue({
+        conversationId: threadId,
+        destination,
+        sessionId: turnId,
+        expectedVersion: resumeVersion,
+      });
+    },
   });
 }
 

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -39,7 +39,11 @@ import {
   getTurnUserSlackMessageTs,
   getTurnUserReplyAttachmentContext,
 } from "@/chat/runtime/turn-user-message";
-import { buildDeterministicTurnId, markTurnFailed } from "@/chat/runtime/turn";
+import {
+  buildDeterministicTurnId,
+  markTurnFailed,
+  startActiveTurn,
+} from "@/chat/runtime/turn";
 import { publishAppHomeView } from "@/chat/slack/app-home";
 import { getSlackClient } from "@/chat/slack/client";
 import { createSlackResumeActor, isUserActor, type Actor } from "@/chat/actor";
@@ -570,6 +574,12 @@ async function resumePendingOAuthMessage(
       );
     },
     onSuspend: async (resumeVersion) => {
+      startActiveTurn({
+        conversation,
+        nextTurnId: turnId,
+        updateConversationStats,
+      });
+      await persistThreadStateById(threadId, { conversation });
       await scheduleAgentContinue({
         conversationId: threadId,
         destination,

--- a/packages/junior/tests/component/runtime/agent-continue.test.ts
+++ b/packages/junior/tests/component/runtime/agent-continue.test.ts
@@ -188,7 +188,7 @@ describe("agent continuation scheduling", () => {
       sliceId: 2,
       state: "awaiting_resume",
       destination: SLACK_DESTINATION,
-      resumeReason: "timeout",
+      resumeReason: "retry",
       piMessages: [],
     });
 

--- a/packages/junior/tests/component/runtime/agent-continue.test.ts
+++ b/packages/junior/tests/component/runtime/agent-continue.test.ts
@@ -174,7 +174,7 @@ describe("agent continuation scheduling", () => {
     });
   });
 
-  it("passes runner options into awaiting continuations", async () => {
+  it("resumes delivery retries with the supplied runner", async () => {
     const { resumeAwaitingSlackContinuation } =
       await import("@/chat/runtime/agent-continue-runner");
     const conversationId = "slack:C123:1712345.0005";

--- a/packages/junior/tests/component/services/turn-session-record.test.ts
+++ b/packages/junior/tests/component/services/turn-session-record.test.ts
@@ -599,7 +599,7 @@ describe("persistAuthPauseSessionRecord", () => {
   });
 
   it("carries cumulative diagnostics across pause records", async () => {
-    const { persistTimeoutSessionRecord } =
+    const { persistContinuationSessionRecord } =
       await import("@/chat/services/turn-session-record");
     const { getAgentTurnSessionRecord, upsertAgentTurnSessionRecord } =
       await import("@/chat/state/turn-session");
@@ -627,7 +627,8 @@ describe("persistAuthPauseSessionRecord", () => {
       },
     });
 
-    await persistTimeoutSessionRecord({
+    await persistContinuationSessionRecord({
+      resumeReason: "timeout",
       modelId: "test/model",
       conversationId: "conversation-1",
       sessionId: "turn-1",
@@ -671,7 +672,7 @@ describe("persistAuthPauseSessionRecord", () => {
   });
 
   it("fails timeout sessions instead of scheduling beyond the execution limit", async () => {
-    const { persistTimeoutSessionRecord } =
+    const { persistContinuationSessionRecord } =
       await import("@/chat/services/turn-session-record");
     const { botConfig } = await import("@/chat/config");
     const { getAgentTurnSessionRecord, upsertAgentTurnSessionRecord } =
@@ -697,7 +698,8 @@ describe("persistAuthPauseSessionRecord", () => {
     });
 
     await expect(
-      persistTimeoutSessionRecord({
+      persistContinuationSessionRecord({
+        resumeReason: "timeout",
         modelId: "test-model",
         conversationId: "conversation-timeout-cap",
         sessionId: "turn-timeout-cap",
@@ -802,7 +804,7 @@ describe("persistAuthPauseSessionRecord", () => {
     const {
       loadTurnSessionRecord,
       persistAuthPauseSessionRecord,
-      persistTimeoutSessionRecord,
+      persistContinuationSessionRecord,
     } = await import("@/chat/services/turn-session-record");
     const { getAgentTurnSessionRecord } =
       await import("@/chat/state/turn-session");
@@ -838,7 +840,8 @@ describe("persistAuthPauseSessionRecord", () => {
     });
 
     await expect(
-      persistTimeoutSessionRecord({
+      persistContinuationSessionRecord({
+        resumeReason: "timeout",
         modelId: "test-model",
         conversationId: "conversation-timeout-empty",
         sessionId: "turn-timeout-empty",
@@ -1099,7 +1102,7 @@ describe("persistAuthPauseSessionRecord", () => {
   });
 
   it("promotes the latest running record when timeout capture has no messages", async () => {
-    const { persistTimeoutSessionRecord, persistRunningSessionRecord } =
+    const { persistContinuationSessionRecord, persistRunningSessionRecord } =
       await import("@/chat/services/turn-session-record");
     const { getAgentTurnSessionRecord } =
       await import("@/chat/state/turn-session");
@@ -1120,7 +1123,8 @@ describe("persistAuthPauseSessionRecord", () => {
       logContext: {},
     });
 
-    await persistTimeoutSessionRecord({
+    await persistContinuationSessionRecord({
+      resumeReason: "timeout",
       modelId: "test-model",
       conversationId: "conversation-1",
       sessionId: "turn-1",

--- a/packages/junior/tests/integration/agent-dispatch-runner.test.ts
+++ b/packages/junior/tests/integration/agent-dispatch-runner.test.ts
@@ -22,6 +22,7 @@ import { disconnectStateAdapter, getStateAdapter } from "@/chat/state/adapter";
 import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { PiMessage } from "@/chat/pi/messages";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
+import { RetryableDeliveryError } from "@/chat/agent/request";
 import {
   bindScheduledTaskCredentialSubject,
   bindSlackDirectCredentialSubject,
@@ -33,6 +34,7 @@ import { createAgentRunner } from "@/chat/runtime/agent-runner";
 import { chatPostMessageOk } from "../fixtures/slack/factories/api";
 import {
   getCapturedSlackApiCalls,
+  queueSlackApiError,
   queueSlackApiResponse,
 } from "../msw/handlers/slack-api";
 import {
@@ -524,6 +526,12 @@ describe("agent dispatch runner", () => {
   });
 
   it("preserves task-scoped creator credentials across dispatch slices", async () => {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      queueSlackApiError("chat.postMessage", {
+        error: "internal_error",
+        status: 503,
+      });
+    }
     const created = await createOrGetDispatch({
       plugin: "scheduler",
       nowMs: Date.parse("2026-05-26T12:00:00.000Z"),
@@ -539,7 +547,12 @@ describe("agent dispatch runner", () => {
     const scheduleCallback = vi.fn(async () => undefined);
     const executeAgentRun = vi
       .fn<AgentRunner["run"]>()
-      .mockResolvedValueOnce({ status: "suspended", resumeVersion: 7 })
+      .mockImplementationOnce(async (request) => {
+        await expect(deliverCompletedReply(request)).rejects.toBeInstanceOf(
+          RetryableDeliveryError,
+        );
+        return { status: "suspended", resumeVersion: 7 };
+      })
       .mockImplementationOnce(async (request) => {
         expect(
           flattenAgentRunRequestForTest(request).credentialContext,

--- a/packages/junior/tests/integration/oauth-callback-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-callback-slack.test.ts
@@ -267,7 +267,9 @@ describe("oauth callback slack integration", () => {
 
   it("schedules a continuation when a pending OAuth resume suspends", async () => {
     const threadTs = "1700000000.002";
+    const conversationId = `slack:C123:${threadTs}`;
     const turnId = "turn_user-retry";
+    const storedSource = slackSource(threadTs);
     await stateAdapterModule
       .getStateAdapter()
       .set("oauth-state:eval-oauth-retry-state", {
@@ -275,14 +277,42 @@ describe("oauth callback slack integration", () => {
         provider: "eval-oauth",
         channelId: "C123",
         destination: SLACK_DESTINATION,
-        source: slackSource(threadTs),
+        source: storedSource,
         threadTs,
         pendingMessage: "list my sentry issues",
-        resumeSessionId: turnId,
       });
-    executeAgentRunMock.mockResolvedValueOnce({
-      status: "suspended",
-      resumeVersion: 3,
+    await stateAdapterModule
+      .getStateAdapter()
+      .set(`thread-state:${conversationId}`, {
+        conversation: {
+          messages: [
+            {
+              id: "user-retry",
+              role: "user",
+              text: "list my sentry issues",
+              createdAtMs: 1,
+              author: { userId: "U123", userName: "dcramer" },
+            },
+          ],
+        },
+      });
+    await seedVisibleTranscriptFromThreadState(
+      stateAdapterModule.getStateAdapter(),
+      conversationId,
+    );
+    executeAgentRunMock.mockImplementationOnce(async () => {
+      const record = await turnSessionStoreModule.upsertAgentTurnSessionRecord({
+        modelId: "test/model",
+        conversationId,
+        sessionId: turnId,
+        sliceId: 2,
+        state: "awaiting_resume",
+        destination: SLACK_DESTINATION,
+        source: storedSource,
+        piMessages: [],
+        resumeReason: "retry",
+      });
+      return { status: "suspended", resumeVersion: record.version } as const;
     });
 
     const response = await oauthCallbackHarnessModule.runOauthCallbackRoute({
@@ -293,6 +323,12 @@ describe("oauth callback slack integration", () => {
     });
 
     expect(response.status).toBe(200);
+    const persistedState = await stateAdapterModule
+      .getStateAdapter()
+      .get<{
+        conversation?: { processing?: { activeTurnId?: string } };
+      }>(`thread-state:${conversationId}`);
+    expect(persistedState?.conversation?.processing?.activeTurnId).toBe(turnId);
     expect(queueSendMock).toHaveBeenCalledOnce();
     expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([]);
   }, 20_000);

--- a/packages/junior/tests/integration/oauth-callback-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-callback-slack.test.ts
@@ -20,13 +20,6 @@ import {
   type ConversationMessage,
 } from "@/chat/state/conversation";
 
-const queueSendMock = vi.hoisted(() =>
-  vi.fn(async () => ({ messageId: "oauth-resume-wake" })),
-);
-
-vi.mock("@/chat/vercel-queue-client", () => ({
-  createVercelQueueClient: () => ({ send: queueSendMock }),
-}));
 /**
  * Mirror a just-seeded thread-state transcript into SQL, the durable transcript
  * authority the resume handlers now read from. Takes the connected adapter so it
@@ -99,7 +92,6 @@ let pluginApp: PluginAppFixture | undefined;
 describe("oauth callback slack integration", () => {
   beforeEach(async () => {
     executeAgentRunMock.mockReset();
-    queueSendMock.mockClear();
     executeAgentRunMock.mockImplementation(async (request) => {
       await deliverAssistantMessagesForTest(request, [
         { text: "Here are your Sentry issues." },
@@ -166,171 +158,6 @@ describe("oauth callback slack integration", () => {
         }),
       }),
     ]);
-  }, 20_000);
-
-  it("resumes a pending OAuth request with persisted thread context", async () => {
-    const storedSource = createSlackSource({
-      teamId: "T123",
-      channelId: "C123",
-      messageTs: "1700000000.oauth-source",
-      threadTs: "1700000000.001",
-
-      type: "priv",
-    });
-    await stateAdapterModule
-      .getStateAdapter()
-      .set("oauth-state:eval-oauth-resume-state", {
-        userId: "U123",
-        provider: "eval-oauth",
-        channelId: "C123",
-        destination: SLACK_DESTINATION,
-        source: storedSource,
-        threadTs: "1700000000.001",
-        pendingMessage: "list my sentry issues",
-      });
-    await stateAdapterModule
-      .getStateAdapter()
-      .set("thread-state:slack:C123:1700000000.001", {
-        conversation: {
-          messages: [
-            {
-              id: "assistant-1",
-              role: "assistant",
-              text: "You need the budget by Friday.",
-              createdAtMs: 1,
-              author: {
-                userName: "junior",
-                isBot: true,
-              },
-            },
-            {
-              id: "user-1",
-              role: "user",
-              text: "list my sentry issues",
-              createdAtMs: 2,
-              author: {
-                userId: "U123",
-                userName: "dcramer",
-              },
-            },
-          ],
-        },
-      });
-    await seedVisibleTranscriptFromThreadState(
-      stateAdapterModule.getStateAdapter(),
-      "slack:C123:1700000000.001",
-    );
-
-    const response = await oauthCallbackHarnessModule.runOauthCallbackRoute({
-      provider: "eval-oauth",
-      state: "eval-oauth-resume-state",
-      code: "eval-oauth-code",
-      agentRunner: testAgentRunner,
-    });
-
-    expect(response.status).toBe(200);
-    expect(executeAgentRunMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        conversationId: "slack:C123:1700000000.001",
-        turnId: "turn_user-1",
-        input: expect.objectContaining({
-          messageText: "list my sentry issues",
-          conversationContext: expect.stringContaining(
-            "You need the budget by Friday.",
-          ),
-        }),
-        routing: expect.objectContaining({
-          destination: SLACK_DESTINATION,
-          source: storedSource,
-        }),
-      }),
-    );
-    const resumeContext = executeAgentRunMock.mock.calls[0]?.[0] as {
-      input?: { conversationContext?: string };
-    };
-    expect(resumeContext.input?.conversationContext).not.toContain(
-      "list my sentry issues",
-    );
-
-    expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          params: expect.objectContaining({
-            channel: "C123",
-            thread_ts: "1700000000.001",
-            text: "Here are your Sentry issues.",
-          }),
-        }),
-      ]),
-    );
-  }, 20_000);
-
-  it("schedules a continuation when a pending OAuth resume suspends", async () => {
-    const threadTs = "1700000000.002";
-    const conversationId = `slack:C123:${threadTs}`;
-    const turnId = "turn_user-retry";
-    const storedSource = slackSource(threadTs);
-    await stateAdapterModule
-      .getStateAdapter()
-      .set("oauth-state:eval-oauth-retry-state", {
-        userId: "U123",
-        provider: "eval-oauth",
-        channelId: "C123",
-        destination: SLACK_DESTINATION,
-        source: storedSource,
-        threadTs,
-        pendingMessage: "list my sentry issues",
-      });
-    await stateAdapterModule
-      .getStateAdapter()
-      .set(`thread-state:${conversationId}`, {
-        conversation: {
-          messages: [
-            {
-              id: "user-retry",
-              role: "user",
-              text: "list my sentry issues",
-              createdAtMs: 1,
-              author: { userId: "U123", userName: "dcramer" },
-            },
-          ],
-        },
-      });
-    await seedVisibleTranscriptFromThreadState(
-      stateAdapterModule.getStateAdapter(),
-      conversationId,
-    );
-    executeAgentRunMock.mockImplementationOnce(async () => {
-      const record = await turnSessionStoreModule.upsertAgentTurnSessionRecord({
-        modelId: "test/model",
-        conversationId,
-        sessionId: turnId,
-        sliceId: 2,
-        state: "awaiting_resume",
-        destination: SLACK_DESTINATION,
-        source: storedSource,
-        piMessages: [],
-        resumeReason: "retry",
-      });
-      return { status: "suspended", resumeVersion: record.version } as const;
-    });
-
-    const response = await oauthCallbackHarnessModule.runOauthCallbackRoute({
-      provider: "eval-oauth",
-      state: "eval-oauth-retry-state",
-      code: "eval-oauth-code",
-      agentRunner: testAgentRunner,
-    });
-
-    expect(response.status).toBe(200);
-    const persistedState = await stateAdapterModule
-      .getStateAdapter()
-      .get<{
-        conversation?: { processing?: { activeTurnId?: string } };
-      }>(`thread-state:${conversationId}`);
-    expect(persistedState?.conversation?.processing?.activeTurnId).toBe(turnId);
-    expect(queueSendMock).toHaveBeenCalledOnce();
-    expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([]);
   }, 20_000);
 
   it("resumes a session-recorded OAuth turn with persisted thread state", async () => {

--- a/packages/junior/tests/integration/oauth-callback-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-callback-slack.test.ts
@@ -208,7 +208,6 @@ describe("oauth callback slack integration", () => {
         destination: SLACK_DESTINATION,
         source: slackSource("1700000000.009"),
         threadTs: "1700000000.009",
-        pendingMessage: "list my sentry issues",
         resumeConversationId: conversationId,
         resumeSessionId: sessionId,
         scope: "read",
@@ -442,7 +441,6 @@ describe("oauth callback slack integration", () => {
         destination: SLACK_DESTINATION,
         source: slackSource("1700000000.012"),
         threadTs: "1700000000.012",
-        pendingMessage: "list my sentry issues",
         resumeConversationId: conversationId,
         resumeSessionId: sessionId,
         scope: "read",
@@ -609,7 +607,6 @@ describe("oauth callback slack integration", () => {
         destination: SLACK_DESTINATION,
         source: slackSource("1700000000.011"),
         threadTs: "1700000000.011",
-        pendingMessage: "list my sentry issues",
         resumeConversationId: conversationId,
         resumeSessionId: sessionId,
       });
@@ -732,7 +729,6 @@ describe("oauth callback slack integration", () => {
         destination: SLACK_DESTINATION,
         source: slackSource("1700000000.012"),
         threadTs: "1700000000.012",
-        pendingMessage: "old request",
         resumeConversationId: conversationId,
         resumeSessionId: oldSessionId,
       });
@@ -837,7 +833,6 @@ describe("oauth callback slack integration", () => {
         destination: SLACK_DESTINATION,
         source: slackSource("1700000000.010"),
         threadTs: "1700000000.010",
-        pendingMessage: "list my sentry issues",
         resumeConversationId: conversationId,
         resumeSessionId: sessionId,
       });

--- a/packages/junior/tests/integration/oauth-callback-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-callback-slack.test.ts
@@ -19,6 +19,14 @@ import {
   coerceThreadConversationState,
   type ConversationMessage,
 } from "@/chat/state/conversation";
+
+const queueSendMock = vi.hoisted(() =>
+  vi.fn(async () => ({ messageId: "oauth-resume-wake" })),
+);
+
+vi.mock("@/chat/vercel-queue-client", () => ({
+  createVercelQueueClient: () => ({ send: queueSendMock }),
+}));
 /**
  * Mirror a just-seeded thread-state transcript into SQL, the durable transcript
  * authority the resume handlers now read from. Takes the connected adapter so it
@@ -91,6 +99,7 @@ let pluginApp: PluginAppFixture | undefined;
 describe("oauth callback slack integration", () => {
   beforeEach(async () => {
     executeAgentRunMock.mockReset();
+    queueSendMock.mockClear();
     executeAgentRunMock.mockImplementation(async (request) => {
       await deliverAssistantMessagesForTest(request, [
         { text: "Here are your Sentry issues." },
@@ -254,6 +263,38 @@ describe("oauth callback slack integration", () => {
         }),
       ]),
     );
+  }, 20_000);
+
+  it("schedules a continuation when a pending OAuth resume suspends", async () => {
+    const threadTs = "1700000000.002";
+    const turnId = "turn_user-retry";
+    await stateAdapterModule
+      .getStateAdapter()
+      .set("oauth-state:eval-oauth-retry-state", {
+        userId: "U123",
+        provider: "eval-oauth",
+        channelId: "C123",
+        destination: SLACK_DESTINATION,
+        source: slackSource(threadTs),
+        threadTs,
+        pendingMessage: "list my sentry issues",
+        resumeSessionId: turnId,
+      });
+    executeAgentRunMock.mockResolvedValueOnce({
+      status: "suspended",
+      resumeVersion: 3,
+    });
+
+    const response = await oauthCallbackHarnessModule.runOauthCallbackRoute({
+      provider: "eval-oauth",
+      state: "eval-oauth-retry-state",
+      code: "eval-oauth-code",
+      agentRunner: testAgentRunner,
+    });
+
+    expect(response.status).toBe(200);
+    expect(queueSendMock).toHaveBeenCalledOnce();
+    expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([]);
   }, 20_000);
 
   it("resumes a session-recorded OAuth turn with persisted thread state", async () => {

--- a/packages/junior/tests/integration/runtime/agent-run-model-handoff.test.ts
+++ b/packages/junior/tests/integration/runtime/agent-run-model-handoff.test.ts
@@ -187,6 +187,8 @@ vi.mock("@/chat/skills", async (importOriginal) => ({
 }));
 
 import { executeAgentRun } from "@/chat/agent";
+import { RetryableDeliveryError } from "@/chat/agent/request";
+import { getAwaitingAgentContinueRequest } from "@/chat/services/agent-continue";
 import {
   loadConversationProjection,
   loadProjection,
@@ -478,6 +480,65 @@ describe("executeAgentRun model handoff", () => {
     ).rejects.toBe(deliveryError);
     expect(observations.providerCalls).toBe(2);
     expect(observations.statuses).toContain("Checking details");
+  });
+
+  it("resumes from the last safe boundary after a retryable delivery failure", async () => {
+    observations.progressTool = true;
+    const conversationId = "local:test:assistant-message-delivery-retry";
+    const turnId = "turn-assistant-message-delivery-retry";
+    const delivered: Array<{ text: string }> = [];
+    let deliveryAttempts = 0;
+    const request = {
+      conversationId,
+      turnId,
+      input: { messageText: "Check the details." },
+      routing: {
+        destination: { platform: "local" as const, conversationId },
+        source: createLocalSource(conversationId),
+      },
+      delivery: {
+        onAssistantMessage: (message: { text: string }) => {
+          deliveryAttempts += 1;
+          if (deliveryAttempts === 1) {
+            throw new RetryableDeliveryError(new Error("Slack unavailable"));
+          }
+          delivered.push(message);
+        },
+      },
+    };
+
+    const suspended = await executeAgentRun(request);
+
+    expect(suspended).toMatchObject({
+      status: "suspended",
+      resumeVersion: expect.any(Number),
+    });
+    const suspendedRecord = await getAgentTurnSessionRecord(
+      conversationId,
+      turnId,
+    );
+    expect(suspendedRecord).toMatchObject({
+      state: "awaiting_resume",
+      resumeReason: "retry",
+      sliceId: 2,
+    });
+    expect(JSON.stringify(suspendedRecord?.piMessages)).not.toContain(
+      "Handoff model completed it.",
+    );
+    await expect(
+      getAwaitingAgentContinueRequest({ conversationId, sessionId: turnId }),
+    ).resolves.toMatchObject({
+      conversationId,
+      sessionId: turnId,
+      expectedVersion: suspendedRecord?.version,
+    });
+
+    const completed = await executeAgentRun(request);
+
+    expect(completed.status).toBe("completed");
+    expect(delivered).toEqual([{ text: "Handoff model completed it." }]);
+    expect(deliveryAttempts).toBe(2);
+    expect(observations.providerCalls).toBe(3);
   });
 
   it("preserves explicit agent reasoning across handoff", async () => {

--- a/packages/junior/tests/unit/handlers/oauth-callback.test.ts
+++ b/packages/junior/tests/unit/handlers/oauth-callback.test.ts
@@ -672,7 +672,7 @@ describe("oauth callback handler", () => {
     expect(body).toContain("&lt;img");
   });
 
-  it("shows pending-message status in success page", async () => {
+  it("shows resumable-turn status in success page", async () => {
     const stateKey = "oauth-state:pending-test";
     await putStoredState(stateKey, {
       userId: "U111",
@@ -686,7 +686,8 @@ describe("oauth callback handler", () => {
         type: "priv",
       }),
       threadTs: "123.789",
-      pendingMessage: "list my sentry issues",
+      resumeConversationId: "slack:C123:123.789",
+      resumeSessionId: "turn-123",
     });
 
     configureSentryOAuthEnv();

--- a/packages/junior/tests/unit/handlers/oauth-resume.test.ts
+++ b/packages/junior/tests/unit/handlers/oauth-resume.test.ts
@@ -291,8 +291,8 @@ describe("resumeSlackTurn", () => {
     });
   });
 
-  it("releases the thread lock before scheduling another timeout slice", async () => {
-    const onTimeoutPause = vi.fn(async () => {
+  it("releases the thread lock before scheduling a continuation", async () => {
+    const onSuspend = vi.fn(async () => {
       const stateAdapter = getStateAdapter();
       await stateAdapter.connect();
       const lock = await stateAdapter.acquireLock(
@@ -327,14 +327,15 @@ describe("resumeSlackTurn", () => {
           resumeVersion: 3,
         }),
       },
-      onTimeoutPause,
+      onSuspend,
     });
 
-    expect(onTimeoutPause).toHaveBeenCalledTimes(1);
+    expect(onSuspend).toHaveBeenCalledOnce();
+    expect(onSuspend).toHaveBeenCalledWith(3);
     expect(postMessageMock).not.toHaveBeenCalled();
   });
 
-  it("runs failure handling when timeout pause handling throws", async () => {
+  it("runs failure handling when suspension handling throws", async () => {
     const onFailure = vi.fn(async () => undefined);
 
     await resumeSlackTurn({
@@ -359,7 +360,7 @@ describe("resumeSlackTurn", () => {
           resumeVersion: 3,
         }),
       },
-      onTimeoutPause: async () => {
+      onSuspend: async () => {
         throw new Error("continuation scheduling failed");
       },
       onFailure,

--- a/packages/junior/tests/unit/services/plugin-auth-orchestration.test.ts
+++ b/packages/junior/tests/unit/services/plugin-auth-orchestration.test.ts
@@ -109,7 +109,6 @@ describe("createPluginAuthOrchestration", () => {
       abortAgent: vi.fn(),
       actorId: "U123",
       source: slackSource,
-      userMessage: "check Sentry",
       userTokenStore: tokens,
     });
 
@@ -126,7 +125,6 @@ describe("createPluginAuthOrchestration", () => {
       expect.objectContaining({
         actorId: "U123",
         source: slackSource,
-        userMessage: "check Sentry",
       }),
     );
     expect(unlinkProvider).not.toHaveBeenCalled();
@@ -144,7 +142,6 @@ describe("createPluginAuthOrchestration", () => {
     const orchestration = createPluginAuthOrchestration({
       abortAgent: vi.fn(),
       actorId: "U123",
-      userMessage: "check Sentry",
       userTokenStore: tokens,
     });
 
@@ -165,7 +162,6 @@ describe("createPluginAuthOrchestration", () => {
     const orchestration = createPluginAuthOrchestration({
       abortAgent,
       actorId: "U123",
-      userMessage: "check Sentry",
       userTokenStore: tokenStore(),
       authorizationFlowMode: "disabled",
     });
@@ -181,7 +177,6 @@ describe("createPluginAuthOrchestration", () => {
   it("returns AuthorizationFlowDisabledError when no actor and flow is disabled", async () => {
     const orchestration = createPluginAuthOrchestration({
       abortAgent: vi.fn(),
-      userMessage: "<scheduled-task-run />",
       authorizationFlowMode: "disabled",
     });
 
@@ -205,7 +200,6 @@ describe("createPluginAuthOrchestration", () => {
     const orchestration = createPluginAuthOrchestration({
       abortAgent,
       actorId: "U123",
-      userMessage: "check Sentry",
       userTokenStore: tokens,
     });
 
@@ -229,7 +223,6 @@ describe("createPluginAuthOrchestration", () => {
       conversationId: "slack:C123:1700000000.000000",
       sessionId: "run_new",
       actorId: "U123",
-      userMessage: "check Sentry",
       userTokenStore: tokenStore(),
     });
 
@@ -250,7 +243,6 @@ describe("createPluginAuthOrchestration", () => {
     const orchestration = createPluginAuthOrchestration({
       abortAgent: vi.fn(),
       actorId: "U123",
-      userMessage: "check Sentry",
       userTokenStore: tokenStore(),
     });
 
@@ -271,7 +263,6 @@ describe("createPluginAuthOrchestration", () => {
     const orchestration = createPluginAuthOrchestration({
       abortAgent: vi.fn(),
       actorId: "U123",
-      userMessage: "push the branch",
       userTokenStore: tokens,
     });
 
@@ -287,7 +278,6 @@ describe("createPluginAuthOrchestration", () => {
       "github",
       expect.objectContaining({
         actorId: "U123",
-        userMessage: "push the branch",
       }),
     );
     expect(unlinkProvider).not.toHaveBeenCalled();
@@ -305,7 +295,6 @@ describe("createPluginAuthOrchestration", () => {
       conversationId: "slack:C123:1700000000.000000",
       sessionId: "run_new",
       actorId: "U123",
-      userMessage: "check Sentry",
       userTokenStore: tokenStore(),
       pendingAuth: {
         kind: "plugin",
@@ -348,7 +337,6 @@ describe("createPluginAuthOrchestration", () => {
     const orchestration = createPluginAuthOrchestration({
       abortAgent: vi.fn(),
       actorId: "U123",
-      userMessage: "inspect a repo",
       userTokenStore: tokenStore(),
     });
 
@@ -375,7 +363,6 @@ describe("createPluginAuthOrchestration", () => {
     const orchestration = createPluginAuthOrchestration({
       abortAgent: vi.fn(),
       actorId: "U123",
-      userMessage: "inspect a repo",
       userTokenStore: tokenStore(),
     });
 
@@ -398,7 +385,6 @@ describe("createPluginAuthOrchestration", () => {
     const orchestration = createPluginAuthOrchestration({
       abortAgent: vi.fn(),
       actorId: "U123",
-      userMessage: "inspect a repo",
       userTokenStore: tokenStore(),
     });
 
@@ -421,7 +407,6 @@ describe("createPluginAuthOrchestration", () => {
   it("preserves no-oauth auth signal messages when authorization flow is disabled", async () => {
     const orchestration = createPluginAuthOrchestration({
       abortAgent: vi.fn(),
-      userMessage: "<scheduled-task-run />",
       authorizationFlowMode: "disabled",
     });
 
@@ -444,7 +429,6 @@ describe("createPluginAuthOrchestration", () => {
     const orchestration = createPluginAuthOrchestration({
       abortAgent: vi.fn(),
       actorId: "U123",
-      userMessage: "check GitHub",
       userTokenStore: tokenStore(),
     });
 
@@ -462,7 +446,6 @@ describe("createPluginAuthOrchestration", () => {
   it("no-ops when result is empty", async () => {
     const orchestration = createPluginAuthOrchestration({
       abortAgent: vi.fn(),
-      userMessage: "check Sentry",
     });
 
     await expect(
@@ -495,7 +478,6 @@ describe("createPluginAuthOrchestration", () => {
       const orchestration = createPluginAuthOrchestration({
         abortAgent: vi.fn(),
         actorId: "U123",
-        userMessage: "do something",
         userTokenStore: tokenStore(),
       });
 

--- a/packages/junior/tests/unit/slack/slack-errors.test.ts
+++ b/packages/junior/tests/unit/slack/slack-errors.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { SlackActionError } from "@/chat/slack/client";
+import { isRetryableSlackPostError } from "@/chat/slack/errors";
+
+describe("isRetryableSlackPostError", () => {
+  it.each([
+    [
+      "an ambiguous network failure",
+      Object.assign(new Error(), { code: "ECONNRESET" }),
+      true,
+    ],
+    [
+      "a mapped transient failure",
+      new SlackActionError("failed", "internal_error"),
+      true,
+    ],
+    [
+      "an explicit API rejection",
+      { data: { error: "channel_not_found" } },
+      false,
+    ],
+    [
+      "an unfamiliar mapped API rejection",
+      new SlackActionError("failed", "internal_error", {
+        apiError: "account_inactive",
+      }),
+      false,
+    ],
+    [
+      "a mapped permanent failure",
+      new SlackActionError("failed", "missing_scope"),
+      false,
+    ],
+  ])("classifies %s", (_name, error, retryable) => {
+    expect(isRetryableSlackPostError(error)).toBe(retryable);
+  });
+});

--- a/packages/junior/tests/unit/slack/slack-errors.test.ts
+++ b/packages/junior/tests/unit/slack/slack-errors.test.ts
@@ -15,6 +15,13 @@ describe("isRetryableSlackPostError", () => {
       true,
     ],
     [
+      "a documented rate limit",
+      new SlackActionError("failed", "internal_error", {
+        apiError: "ratelimited",
+      }),
+      true,
+    ],
+    [
       "an explicit API rejection",
       { data: { error: "channel_not_found" } },
       false,


### PR DESCRIPTION
Slack reply delivery failures that are transient or do not include an explicit
provider rejection now suspend the active agent turn. The existing continuation
worker resumes the same turn from its latest saved agent history, preserving
completed tool work and applying the normal turn execution limit to initial
replies, continued turns, and authorization resumes. Explicit Slack API
rejections still fail the turn.

Recovery is intentionally best effort. Because the failed assistant message was
not saved, the agent regenerates it on resume. If Slack accepted a reply before
the worker lost confirmation, recovery can post a duplicate.
