### PR TITLE
fix(state): connect adapter lazily before operations

### DIFF
--- a/packages/junior/src/chat/state/adapter.ts
+++ b/packages/junior/src/chat/state/adapter.ts
@@ -10,6 +10,40 @@ const ACTIVE_LOCK_HEARTBEAT_MS = 30_000;
 let stateAdapter: StateAdapter | undefined;
 let redisStateAdapter: RedisStateAdapter | undefined;
 
+/** Lazily connect state operations, including queued-adapter lock heartbeats. */
+function createConnectingStateAdapter(base: StateAdapter): StateAdapter {
+  const connected = async <T>(operation: () => Promise<T>): Promise<T> => {
+    await base.connect();
+    return await operation();
+  };
+
+  return {
+    appendToList: (key, value, options) =>
+      connected(() => base.appendToList(key, value, options)),
+    connect: () => base.connect(),
+    disconnect: () => base.disconnect(),
+    subscribe: (threadId) => connected(() => base.subscribe(threadId)),
+    unsubscribe: (threadId) => connected(() => base.unsubscribe(threadId)),
+    isSubscribed: (threadId) => connected(() => base.isSubscribed(threadId)),
+    acquireLock: (threadId, ttlMs) =>
+      connected(() => base.acquireLock(threadId, ttlMs)),
+    releaseLock: (lock) => connected(() => base.releaseLock(lock)),
+    extendLock: (lock, ttlMs) => connected(() => base.extendLock(lock, ttlMs)),
+    forceReleaseLock: (threadId) =>
+      connected(() => base.forceReleaseLock(threadId)),
+    enqueue: (threadId, entry, maxSize) =>
+      connected(() => base.enqueue(threadId, entry, maxSize)),
+    dequeue: (threadId) => connected(() => base.dequeue(threadId)),
+    queueDepth: (threadId) => connected(() => base.queueDepth(threadId)),
+    get: (key) => connected(() => base.get(key)),
+    getList: (key) => connected(() => base.getList(key)),
+    set: (key, value, ttlMs) => connected(() => base.set(key, value, ttlMs)),
+    setIfNotExists: (key, value, ttlMs) =>
+      connected(() => base.setIfNotExists(key, value, ttlMs)),
+    delete: (key) => connected(() => base.delete(key)),
+  };
+}
+
 function createPrefixedStateAdapter(
   base: StateAdapter,
   prefix: string,
@@ -228,7 +262,9 @@ function createStateAdapter(): StateAdapter {
   if (config.state.adapter === "memory") {
     redisStateAdapter = undefined;
     return createQueuedStateAdapter(
-      withOptionalPrefix(createMemoryState(), config.state.keyPrefix),
+      createConnectingStateAdapter(
+        withOptionalPrefix(createMemoryState(), config.state.keyPrefix),
+      ),
       { activeLockMaxAgeMs },
     );
   }
@@ -242,7 +278,9 @@ function createStateAdapter(): StateAdapter {
   });
   redisStateAdapter = redisState;
   return createQueuedStateAdapter(
-    withOptionalPrefix(redisState, config.state.keyPrefix),
+    createConnectingStateAdapter(
+      withOptionalPrefix(redisState, config.state.keyPrefix),
+    ),
     { activeLockMaxAgeMs },
   );
 }

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -503,10 +503,12 @@ export async function GET(
   const code = url.searchParams.get("code");
   const state = url.searchParams.get("state");
 
+  const stateAdapter = getStateAdapter();
+  await stateAdapter.connect();
+
   if (errorParam) {
     if (state) {
-      const cleanupAdapter = getStateAdapter();
-      await cleanupAdapter.delete(`oauth-state:${state}`);
+      await stateAdapter.delete(`oauth-state:${state}`);
     }
 
     if (errorParam === "access_denied") {
@@ -531,7 +533,6 @@ export async function GET(
     );
   }
 
-  const stateAdapter = getStateAdapter();
   const stateKey = `oauth-state:${state}`;
   const stored = parseOAuthStatePayload(await stateAdapter.get(stateKey));
   if (!stored) {

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -503,12 +503,10 @@ export async function GET(
   const code = url.searchParams.get("code");
   const state = url.searchParams.get("state");
 
-  const stateAdapter = getStateAdapter();
-  await stateAdapter.connect();
-
   if (errorParam) {
     if (state) {
-      await stateAdapter.delete(`oauth-state:${state}`);
+      const cleanupAdapter = getStateAdapter();
+      await cleanupAdapter.delete(`oauth-state:${state}`);
     }
 
     if (errorParam === "access_denied") {
@@ -533,6 +531,7 @@ export async function GET(
     );
   }
 
+  const stateAdapter = getStateAdapter();
   const stateKey = `oauth-state:${state}`;
   const stored = parseOAuthStatePayload(await stateAdapter.get(stateKey));
   if (!stored) {

--- a/packages/junior/tests/component/state/state-adapter-lock.test.ts
+++ b/packages/junior/tests/component/state/state-adapter-lock.test.ts
@@ -21,7 +21,7 @@ async function loadMemoryStateAdapter(
   return stateAdapterModule;
 }
 
-describe("state adapter lock lease", () => {
+describe("state adapter lifecycle and lock lease", () => {
   afterEach(async () => {
     await stateAdapterModule?.disconnectStateAdapter();
     stateAdapterModule = undefined;
@@ -30,13 +30,25 @@ describe("state adapter lock lease", () => {
     vi.resetModules();
   });
 
+  it("supports concurrent operations from a cold adapter", async () => {
+    const { getStateAdapter } = await loadMemoryStateAdapter();
+    const adapter = getStateAdapter();
+
+    await Promise.all([
+      adapter.set("cold-key-1", "first"),
+      adapter.set("cold-key-2", "second"),
+    ]);
+
+    await expect(adapter.get("cold-key-1")).resolves.toBe("first");
+    await expect(adapter.get("cold-key-2")).resolves.toBe("second");
+  });
+
   it("lets short locks expire at their requested ttl", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(0));
 
     const { getStateAdapter } = await loadMemoryStateAdapter();
     const adapter = getStateAdapter();
-    await adapter.connect();
 
     const lock = await adapter.acquireLock("thread-1", 30_000);
     expect(lock).not.toBeNull();
@@ -60,7 +72,6 @@ describe("state adapter lock lease", () => {
 
     const { getStateAdapter } = await loadMemoryStateAdapter();
     const adapter = getStateAdapter();
-    await adapter.connect();
 
     const lock = await adapter.acquireLock("thread-1", ACTIVE_LOCK_TTL_MS);
     expect(lock).not.toBeNull();
@@ -79,7 +90,6 @@ describe("state adapter lock lease", () => {
 
     const { getStateAdapter } = await loadMemoryStateAdapter();
     const adapter = getStateAdapter();
-    await adapter.connect();
 
     const lock = await adapter.acquireLock("thread-1", ACTIVE_LOCK_TTL_MS);
     expect(lock).not.toBeNull();
@@ -104,7 +114,6 @@ describe("state adapter lock lease", () => {
       AGENT_TURN_TIMEOUT_MS: "10000",
     });
     const adapter = getStateAdapter();
-    await adapter.connect();
 
     const lock = await adapter.acquireLock("thread-1", ACTIVE_LOCK_TTL_MS);
     expect(lock).not.toBeNull();
@@ -127,7 +136,6 @@ describe("state adapter lock lease", () => {
 
     const { getStateAdapter } = await loadMemoryStateAdapter();
     const adapter = getStateAdapter();
-    await adapter.connect();
 
     const lock = await adapter.acquireLock("snapshot-lock", 10 * 60 * 1000);
     expect(lock).not.toBeNull();
@@ -143,7 +151,6 @@ describe("state adapter lock lease", () => {
       JUNIOR_STATE_KEY_PREFIX: "junior:test:state-adapter-lock",
     });
     const adapter = getStateAdapter();
-    await adapter.connect();
 
     await adapter.set("logical-key", "stored");
     await expect(adapter.get("logical-key")).resolves.toBe("stored");

--- a/packages/junior/tests/unit/handlers/oauth-callback.test.ts
+++ b/packages/junior/tests/unit/handlers/oauth-callback.test.ts
@@ -342,6 +342,37 @@ describe("oauth callback handler", () => {
     expect(await getStoredState(stateKey)).toBeFalsy();
   });
 
+  it("handles callbacks when the state adapter starts disconnected", async () => {
+    const stateKey = "oauth-state:cold-start";
+    await putStoredState(stateKey, {
+      userId: "U123",
+      provider: "sentry",
+    });
+
+    configureSentryOAuthEnv();
+    mockJsonFetch({
+      access_token: "new-access",
+      refresh_token: "new-refresh",
+      expires_in: 3600,
+    });
+
+    await getStateAdapter().disconnect();
+
+    const response = await GET(
+      makeRequest(
+        "https://example.com/api/oauth/callback/sentry?code=auth-code&state=cold-start",
+      ),
+      "sentry",
+      testWaitUntil,
+      { agentRunner: testAgentRunner },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await getStoredTokens("U123", "sentry")).toMatchObject({
+      accessToken: "new-access",
+    });
+  });
+
   it("returns styled HTML 500 when client credentials are missing", async () => {
     const stateKey = "oauth-state:test-state-789";
     await putStoredState(stateKey, {

--- a/packages/junior/tests/unit/handlers/oauth-callback.test.ts
+++ b/packages/junior/tests/unit/handlers/oauth-callback.test.ts
@@ -342,41 +342,6 @@ describe("oauth callback handler", () => {
     expect(await getStoredState(stateKey)).toBeFalsy();
   });
 
-  it("connects the state adapter before reading oauth state", async () => {
-    const stateKey = "oauth-state:connect-before-get";
-    await putStoredState(stateKey, {
-      userId: "U123",
-      provider: "sentry",
-    });
-
-    const adapter = getStateAdapter();
-    const connectSpy = vi.spyOn(adapter, "connect");
-    const getSpy = vi.spyOn(adapter, "get");
-
-    configureSentryOAuthEnv();
-    mockJsonFetch({
-      access_token: "new-access",
-      refresh_token: "new-refresh",
-      expires_in: 3600,
-    });
-
-    const response = await GET(
-      makeRequest(
-        "https://example.com/api/oauth/callback/sentry?code=auth-code&state=connect-before-get",
-      ),
-      "sentry",
-      testWaitUntil,
-      { agentRunner: testAgentRunner },
-    );
-
-    expect(response.status).toBe(200);
-    expect(connectSpy).toHaveBeenCalled();
-    expect(getSpy).toHaveBeenCalled();
-    expect(connectSpy.mock.invocationCallOrder[0]).toBeLessThan(
-      getSpy.mock.invocationCallOrder[0],
-    );
-  });
-
   it("returns styled HTML 500 when client credentials are missing", async () => {
     const stateKey = "oauth-state:test-state-789";
     await putStoredState(stateKey, {

--- a/packages/junior/tests/unit/handlers/oauth-callback.test.ts
+++ b/packages/junior/tests/unit/handlers/oauth-callback.test.ts
@@ -342,6 +342,41 @@ describe("oauth callback handler", () => {
     expect(await getStoredState(stateKey)).toBeFalsy();
   });
 
+  it("connects the state adapter before reading oauth state", async () => {
+    const stateKey = "oauth-state:connect-before-get";
+    await putStoredState(stateKey, {
+      userId: "U123",
+      provider: "sentry",
+    });
+
+    const adapter = getStateAdapter();
+    const connectSpy = vi.spyOn(adapter, "connect");
+    const getSpy = vi.spyOn(adapter, "get");
+
+    configureSentryOAuthEnv();
+    mockJsonFetch({
+      access_token: "new-access",
+      refresh_token: "new-refresh",
+      expires_in: 3600,
+    });
+
+    const response = await GET(
+      makeRequest(
+        "https://example.com/api/oauth/callback/sentry?code=auth-code&state=connect-before-get",
+      ),
+      "sentry",
+      testWaitUntil,
+      { agentRunner: testAgentRunner },
+    );
+
+    expect(response.status).toBe(200);
+    expect(connectSpy).toHaveBeenCalled();
+    expect(getSpy).toHaveBeenCalled();
+    expect(connectSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      getSpy.mock.invocationCallOrder[0],
+    );
+  });
+
   it("returns styled HTML 500 when client credentials are missing", async () => {
     const stateKey = "oauth-state:test-state-789";
     await putStoredState(stateKey, {


### PR DESCRIPTION
State-backed operations now establish the default adapter connection lazily
before each operation, so cold callbacks and other state consumers no longer
depend on an unrelated request having initialized Redis. The decorator sits
beneath queued state handling so lock heartbeats receive the same behavior;
existing explicit connection calls, key prefixing, and the adapter API remain
unchanged.

This fixes generic OAuth callbacks on fresh instances and adds regression
coverage for disconnected callbacks and concurrent cold state operations.

Fixes #979
