### PR TITLE
fix(migrations): Preserve history without compaction summary

### DIFF
--- a/packages/junior/src/cli/upgrade/migrations/conversation-context-checkpoints.ts
+++ b/packages/junior/src/cli/upgrade/migrations/conversation-context-checkpoints.ts
@@ -207,12 +207,11 @@ async function normalizeConversation(args: {
               replacementCount = matchingMessagePrefix(previous, current);
             } else {
               const end = checkpointEnd(current);
-              if (end < 0) {
-                throw new Error(
-                  `Cannot find ${reason} summary at event ${marker.seq} during upgrade`,
-                );
-              }
-              replacementCount = end + 1;
+              // TODO(v0.108.0): Remove the full-epoch fallback after deployed
+              // checkpoint rows without a recognizable summary are upgraded.
+              // The epoch's final row set is still an exact history snapshot,
+              // so folding its appended suffix into the replacement is lossless.
+              replacementCount = end < 0 ? current.length : end + 1;
             }
             const replacementRows = current.slice(0, replacementCount);
             replacementHistory = replacementRows.map((row, index) =>

--- a/packages/junior/tests/component/cli/conversation-event-migration.test.ts
+++ b/packages/junior/tests/component/cli/conversation-event-migration.test.ts
@@ -1145,4 +1145,100 @@ ORDER BY indexname
       await fixture.close();
     }
   }, 20_000);
+
+  it("preserves active history when a deployed compaction summary is missing", async () => {
+    const fixture = await createLocalJuniorSqlFixture();
+    const conversationId = "conversation-compaction-without-summary";
+    const retainedUser = {
+      role: "user",
+      content: [{ type: "text", text: "retain this request" }],
+    };
+    const liveAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "retain this response too" }],
+    };
+    const bot = {
+      embeddingModelId: "test/embedding",
+      fastModelId: "test/fast",
+      loadingMessages: [],
+      profiles: {
+        standard: { modelId: "test/standard" },
+        handoff: { modelId: "test/handoff", reasoningLevel: "xhigh" as const },
+      },
+      maxSlicesPerTurn: 1,
+      turnTimeoutMs: 1,
+      userName: "Junior",
+    };
+
+    try {
+      await executeStatements(
+        (statement) => fixture.sql.execute(statement),
+        historicalPreDrizzleEventDdl,
+      );
+      await executeStatements(
+        (statement) => fixture.sql.execute(statement),
+        migrationStatements("0004_useful_magus.sql"),
+      );
+      await fixture.sql.execute(
+        `INSERT INTO junior_conversations (
+          conversation_id, created_at, last_activity_at, updated_at,
+          execution_status
+        ) VALUES ($1, $2, $2, $2, 'idle')`,
+        [conversationId, new Date("2026-07-14T10:00:00.000Z")],
+      );
+      await executeStatements(
+        (statement) => fixture.sql.execute(statement),
+        migrationStatements("0005_conversation_events.sql"),
+      );
+      await fixture.sql.execute(
+        `INSERT INTO junior_conversation_events (
+          conversation_id, seq, history_version, schema_version, type,
+          payload, created_at
+        ) VALUES
+          ($1, 10, 1, 1, 'context_epoch_started', $2::jsonb, $5),
+          ($1, 11, 1, 1, 'agent_step', $3::jsonb, $5),
+          ($1, 12, 1, 1, 'agent_step', $4::jsonb, $5)`,
+        [
+          conversationId,
+          JSON.stringify({ reason: "compaction" }),
+          JSON.stringify({ message: retainedUser }),
+          JSON.stringify({ message: liveAssistant }),
+          new Date("2026-07-14T10:01:00.000Z"),
+        ],
+      );
+
+      const context = {
+        io: { info: () => {} },
+        stateAdapter: getStateAdapter(),
+      };
+      await expect(
+        normalizeConversationContextCheckpoints(context, {
+          executor: fixture.sql,
+          bot,
+        }),
+      ).resolves.toMatchObject({ migrated: 1, scanned: 1 });
+
+      const history = await createSqlConversationEventStore(
+        fixture.sql,
+      ).loadCurrentHistory(conversationId);
+      expect(history).toHaveLength(1);
+      expect(history[0]?.data).toEqual({
+        type: "compaction",
+        modelProfile: "standard",
+        modelId: "test/standard",
+        replacementHistory: [
+          { message: retainedUser },
+          { message: liveAssistant },
+        ],
+      });
+      await expect(
+        normalizeConversationContextCheckpoints(context, {
+          executor: fixture.sql,
+          bot,
+        }),
+      ).resolves.toMatchObject({ migrated: 0, scanned: 0 });
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
 });


### PR DESCRIPTION
Checkpoint normalization now preserves legacy compaction epochs that do not
contain a recognizable summary delimiter. Instead of aborting after the SQL
schema cutover, the upgrade folds the epoch's complete agent-step history into
the canonical replacement event, allowing partially completed upgrades to be
rerun without losing active model history.

The recognized-summary path remains unchanged and still retains post-summary
events individually. Regression coverage exercises the missing-summary shape
and verifies that a second migration run is a no-op.
