### PR TITLE
fix(identity): Use canonical user names in conversations

### DIFF
--- a/packages/junior/src/api/conversations/list.ts
+++ b/packages/junior/src/api/conversations/list.ts
@@ -6,6 +6,7 @@ import {
   juniorConversations,
   juniorDestinations,
   juniorIdentities,
+  juniorUsers,
 } from "@/db/schema";
 import { conversationSummaryFromStoredConversation } from "./projection";
 import { conversationFeedSchema } from "./schema";
@@ -32,6 +33,7 @@ async function conversationRows(
       identityProvider: juniorIdentities.provider,
       identitySubjectId: juniorIdentities.providerSubjectId,
       identityTenantId: juniorIdentities.providerTenantId,
+      userDisplayName: juniorUsers.displayName,
     })
     .from(juniorConversations)
     .leftJoin(
@@ -42,6 +44,7 @@ async function conversationRows(
       juniorIdentities,
       eq(juniorIdentities.id, juniorConversations.actorIdentityId),
     )
+    .leftJoin(juniorUsers, eq(juniorUsers.id, juniorIdentities.userId))
     .where(
       and(
         isNull(juniorConversations.parentConversationId),
@@ -63,16 +66,16 @@ async function conversationRows(
 
 type ConversationRow = Awaited<ReturnType<typeof conversationRows>>[number];
 
+/** Decode a conversation row with the linked user name and identity-scoped provider fields. */
 function conversationFromRow(row: ConversationRow): Conversation {
   const value = row.conversation;
+  const actorFullName = row.userDisplayName ?? row.identityDisplayName;
   const actor =
     row.identityProvider === "slack"
       ? {
           platform: "slack" as const,
           ...(row.identityEmail ? { email: row.identityEmail } : {}),
-          ...(row.identityDisplayName
-            ? { fullName: row.identityDisplayName }
-            : {}),
+          ...(actorFullName ? { fullName: actorFullName } : {}),
           ...(row.identitySubjectId
             ? { slackUserId: row.identitySubjectId }
             : {}),
@@ -134,6 +137,7 @@ export async function readConversationRecordFromSql(
       identityProvider: juniorIdentities.provider,
       identitySubjectId: juniorIdentities.providerSubjectId,
       identityTenantId: juniorIdentities.providerTenantId,
+      userDisplayName: juniorUsers.displayName,
     })
     .from(juniorConversations)
     .leftJoin(
@@ -144,6 +148,7 @@ export async function readConversationRecordFromSql(
       juniorIdentities,
       eq(juniorIdentities.id, juniorConversations.actorIdentityId),
     )
+    .leftJoin(juniorUsers, eq(juniorUsers.id, juniorIdentities.userId))
     .where(eq(juniorConversations.conversationId, conversationId))
     .limit(1);
   const row = rows[0];

--- a/packages/junior/src/api/conversations/list.ts
+++ b/packages/junior/src/api/conversations/list.ts
@@ -69,7 +69,9 @@ type ConversationRow = Awaited<ReturnType<typeof conversationRows>>[number];
 /** Decode a conversation row with the linked user name and identity-scoped provider fields. */
 function conversationFromRow(row: ConversationRow): Conversation {
   const value = row.conversation;
-  const actorFullName = row.userDisplayName ?? row.identityDisplayName;
+  const actorFullName = row.userDisplayName?.trim()
+    ? row.userDisplayName
+    : row.identityDisplayName;
   const actor =
     row.identityProvider === "slack"
       ? {

--- a/packages/junior/src/chat/conversations/sql/store.ts
+++ b/packages/junior/src/chat/conversations/sql/store.ts
@@ -18,6 +18,7 @@ import {
   juniorConversations,
   juniorDestinations,
   juniorIdentities,
+  juniorUsers,
 } from "@/db/schema";
 import type { AgentTurnCost, AgentTurnUsage } from "@/chat/usage";
 import type {
@@ -33,6 +34,7 @@ interface ConversationReadRow {
   conversation: ConversationRow;
   destination: DestinationRow | null;
   actorIdentity: IdentityRow | null;
+  actorUserDisplayName: string | null;
 }
 
 interface DestinationUpsert {
@@ -227,8 +229,10 @@ function privacyFromRow(
   return row.destination.visibility === "public" ? "public" : "private";
 }
 
+/** Reconstruct a Slack actor with the linked user name and identity-scoped provider fields. */
 function actorFromIdentityRow(
   identity: IdentityRow | null,
+  userDisplayName: string | null,
 ): StoredSlackActor | undefined {
   if (!identity) {
     return undefined;
@@ -236,13 +240,14 @@ function actorFromIdentityRow(
   if (identity.provider !== "slack") {
     return undefined;
   }
+  const fullName = userDisplayName ?? identity.displayName;
   return {
     ...(identity.emailNormalized
       ? { email: identity.emailNormalized }
       : identity.email
         ? { email: identity.email }
         : {}),
-    ...(identity.displayName ? { fullName: identity.displayName } : {}),
+    ...(fullName ? { fullName } : {}),
     platform: "slack",
     slackUserId: identity.providerSubjectId,
     ...(identity.handle ? { slackUserName: identity.handle } : {}),
@@ -283,7 +288,10 @@ function conversationFromRow(readRow: ConversationReadRow): Conversation {
     throw new Error("Conversation legacy actor is not migrated");
   }
   const destination = destinationFromRow(readRow.destination);
-  const actor = actorFromIdentityRow(readRow.actorIdentity);
+  const actor = actorFromIdentityRow(
+    readRow.actorIdentity,
+    readRow.actorUserDisplayName,
+  );
   if (readRow.destination !== null && !destination) {
     throw new Error("Conversation record destination is invalid");
   }
@@ -710,6 +718,7 @@ export class SqlStore implements ConversationStore {
         conversation: juniorConversations,
         destination: juniorDestinations,
         actorIdentity: juniorIdentities,
+        actorUserDisplayName: juniorUsers.displayName,
       })
       .from(juniorConversations)
       .leftJoin(
@@ -720,6 +729,7 @@ export class SqlStore implements ConversationStore {
         juniorIdentities,
         eq(juniorIdentities.id, juniorConversations.actorIdentityId),
       )
+      .leftJoin(juniorUsers, eq(juniorUsers.id, juniorIdentities.userId))
       // Subagent child conversations are excluded from top-level listings and
       // purge with their root on the root's visibility window.
       .where(isNull(juniorConversations.parentConversationId))
@@ -787,6 +797,7 @@ export class SqlStore implements ConversationStore {
         conversation: juniorConversations,
         destination: juniorDestinations,
         actorIdentity: juniorIdentities,
+        actorUserDisplayName: juniorUsers.displayName,
       })
       .from(juniorConversations)
       .leftJoin(
@@ -797,6 +808,7 @@ export class SqlStore implements ConversationStore {
         juniorIdentities,
         eq(juniorIdentities.id, juniorConversations.actorIdentityId),
       )
+      .leftJoin(juniorUsers, eq(juniorUsers.id, juniorIdentities.userId))
       .where(eq(juniorConversations.conversationId, conversationId));
     return rows[0];
   }

--- a/packages/junior/src/chat/conversations/sql/store.ts
+++ b/packages/junior/src/chat/conversations/sql/store.ts
@@ -240,7 +240,9 @@ function actorFromIdentityRow(
   if (identity.provider !== "slack") {
     return undefined;
   }
-  const fullName = userDisplayName ?? identity.displayName;
+  const fullName = userDisplayName?.trim()
+    ? userDisplayName
+    : identity.displayName;
   return {
     ...(identity.emailNormalized
       ? { email: identity.emailNormalized }

--- a/packages/junior/src/chat/identities/README.md
+++ b/packages/junior/src/chat/identities/README.md
@@ -1,0 +1,14 @@
+# SQL Identities
+
+`junior_users` stores person-level data. Provider accounts live in
+`junior_identities` and link to a user only through a verified normalized email.
+
+`junior_users.display_name` is the canonical name for a linked person. The first
+non-empty name observed while creating or linking the user is retained; later
+provider-specific names do not replace it. Conversation actors use that user
+name when present and otherwise fall back to
+`junior_identities.display_name`.
+
+Provider handles and subject IDs always remain identity-scoped. Display names
+are presentation data and must never be used to link identities or grant
+authority.

--- a/packages/junior/tests/component/conversation-sql-store.test.ts
+++ b/packages/junior/tests/component/conversation-sql-store.test.ts
@@ -186,19 +186,6 @@ describe("conversation SQL store", () => {
         1_000,
       );
 
-      await upsertIdentity(
-        fixture.sql,
-        {
-          kind: "user",
-          provider: "slack",
-          providerTenantId: "T123",
-          providerSubjectId: "U123",
-          email: "alice@example.com",
-          emailVerified: true,
-          displayName: "Changed Name",
-        },
-        2_000,
-      );
       const secondIdentity = await upsertIdentity(
         fixture.sql,
         {
@@ -209,6 +196,7 @@ describe("conversation SQL store", () => {
           email: "ALICE@example.com",
           emailVerified: true,
           displayName: "Alice Other Device",
+          handle: "alice-other",
         },
         2_500,
       );
@@ -218,7 +206,7 @@ describe("conversation SQL store", () => {
         destination: inboundMessage("identity").destination,
         actor: {
           platform: "slack",
-          slackUserId: "U123",
+          slackUserId: "U456",
           teamId: "T123",
         },
         source: "slack",
@@ -251,11 +239,58 @@ describe("conversation SQL store", () => {
           actor: {
             email: "alice@example.com",
             fullName: "Alice Example",
-            slackUserId: "U123",
-            slackUserName: "alice",
+            slackUserId: "U456",
+            slackUserName: "alice-other",
           },
         },
       ]);
+      await expect(
+        store.get({ conversationId: CONVERSATION_ID }),
+      ).resolves.toMatchObject({
+        actor: {
+          email: "alice@example.com",
+          fullName: "Alice Example",
+          slackUserId: "U456",
+          slackUserName: "alice-other",
+        },
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  it("falls back to the provider name when an actor has no linked user", async () => {
+    const fixture = await createLocalJuniorSqlFixture();
+
+    try {
+      const store = createSqlStore(fixture.sql);
+      await migrateSchema(fixture.sql);
+
+      await store.recordActivity({
+        conversationId: CONVERSATION_ID,
+        actor: {
+          fullName: "Unlinked User",
+          platform: "slack",
+          slackUserId: "U123",
+          slackUserName: "unlinked",
+          teamId: "T123",
+        },
+        source: "slack",
+        nowMs: 1_000,
+      });
+
+      await expect(
+        store.get({ conversationId: CONVERSATION_ID }),
+      ).resolves.toMatchObject({
+        actor: {
+          fullName: "Unlinked User",
+          slackUserId: "U123",
+          slackUserName: "unlinked",
+        },
+      });
+      await expect(
+        fixture.sql.db().select().from(juniorUsers),
+      ).resolves.toEqual([]);
     } finally {
       await fixture.close();
     }

--- a/packages/junior/tests/component/conversation-sql-store.test.ts
+++ b/packages/junior/tests/component/conversation-sql-store.test.ts
@@ -254,6 +254,20 @@ describe("conversation SQL store", () => {
           slackUserName: "alice-other",
         },
       });
+      await fixture.sql
+        .db()
+        .update(juniorUsers)
+        .set({ displayName: "" })
+        .where(eq(juniorUsers.primaryEmailNormalized, "alice@example.com"));
+      await expect(
+        store.get({ conversationId: CONVERSATION_ID }),
+      ).resolves.toMatchObject({
+        actor: {
+          fullName: "Alice Other Device",
+          slackUserId: "U456",
+          slackUserName: "alice-other",
+        },
+      });
     } finally {
       await fixture.close();
     }

--- a/packages/junior/tests/integration/api/conversations/list.test.ts
+++ b/packages/junior/tests/integration/api/conversations/list.test.ts
@@ -1,12 +1,98 @@
 import { describe, expect, test } from "vitest";
 import { eq } from "drizzle-orm";
-import { readConversationFeedFromSql } from "@/api/conversations/list";
+import {
+  readConversationFeedFromSql,
+  readConversationRecordFromSql,
+} from "@/api/conversations/list";
 import { migrateSchema } from "@/chat/conversations/sql/migrations";
 import { createSqlStore } from "@/chat/conversations/sql/store";
 import { juniorConversations, juniorIdentities } from "@/db/schema";
 import { createConfiguredJuniorSqlFixture } from "../../../fixtures/sql";
 
 describe("conversation list API", () => {
+  test("uses canonical and fallback actor names with provider identity fields", async () => {
+    const fixture = createConfiguredJuniorSqlFixture();
+    const store = createSqlStore(fixture.sql);
+    try {
+      await migrateSchema(fixture.sql);
+      await store.recordActivity({
+        actor: {
+          email: "alice@example.com",
+          fullName: "Alice Example",
+          platform: "slack",
+          slackUserId: "U1",
+          slackUserName: "alice",
+          teamId: "T1",
+        },
+        conversationId: "slack:C1:canonical-name",
+        nowMs: 1_000,
+        source: "slack",
+      });
+      await store.recordActivity({
+        actor: {
+          email: "ALICE@example.com",
+          fullName: "Workspace Alice",
+          platform: "slack",
+          slackUserId: "U2",
+          slackUserName: "workspace-alice",
+          teamId: "T1",
+        },
+        conversationId: "slack:C1:provider-name",
+        nowMs: 2_000,
+        source: "slack",
+      });
+      await store.recordActivity({
+        actor: {
+          fullName: "Unlinked User",
+          platform: "slack",
+          slackUserId: "U3",
+          slackUserName: "unlinked",
+          teamId: "T1",
+        },
+        conversationId: "slack:C1:unlinked-name",
+        nowMs: 3_000,
+        source: "slack",
+      });
+
+      const feed = await readConversationFeedFromSql();
+
+      expect(feed.conversations).toContainEqual(
+        expect.objectContaining({
+          actorIdentity: {
+            email: "ALICE@example.com",
+            fullName: "Alice Example",
+            slackUserId: "U2",
+            slackUserName: "workspace-alice",
+          },
+          conversationId: "slack:C1:provider-name",
+        }),
+      );
+      expect(feed.conversations).toContainEqual(
+        expect.objectContaining({
+          actorIdentity: {
+            fullName: "Unlinked User",
+            slackUserId: "U3",
+            slackUserName: "unlinked",
+          },
+          conversationId: "slack:C1:unlinked-name",
+        }),
+      );
+      await expect(
+        readConversationRecordFromSql("slack:C1:provider-name"),
+      ).resolves.toMatchObject({
+        conversation: {
+          actor: {
+            fullName: "Alice Example",
+            slackUserId: "U2",
+            slackUserName: "workspace-alice",
+          },
+        },
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+
   test("filters by verified actor email before applying the feed limit", async () => {
     const fixture = createConfiguredJuniorSqlFixture();
     const store = createSqlStore(fixture.sql);

--- a/packages/junior/tests/integration/api/conversations/list.test.ts
+++ b/packages/junior/tests/integration/api/conversations/list.test.ts
@@ -6,7 +6,11 @@ import {
 } from "@/api/conversations/list";
 import { migrateSchema } from "@/chat/conversations/sql/migrations";
 import { createSqlStore } from "@/chat/conversations/sql/store";
-import { juniorConversations, juniorIdentities } from "@/db/schema";
+import {
+  juniorConversations,
+  juniorIdentities,
+  juniorUsers,
+} from "@/db/schema";
 import { createConfiguredJuniorSqlFixture } from "../../../fixtures/sql";
 
 describe("conversation list API", () => {
@@ -87,6 +91,23 @@ describe("conversation list API", () => {
             slackUserName: "workspace-alice",
           },
         },
+      });
+      await fixture.sql
+        .db()
+        .update(juniorUsers)
+        .set({ displayName: "" })
+        .where(eq(juniorUsers.primaryEmailNormalized, "alice@example.com"));
+      await expect(readConversationFeedFromSql()).resolves.toMatchObject({
+        conversations: expect.arrayContaining([
+          expect.objectContaining({
+            actorIdentity: expect.objectContaining({
+              fullName: "Workspace Alice",
+              slackUserId: "U2",
+              slackUserName: "workspace-alice",
+            }),
+            conversationId: "slack:C1:provider-name",
+          }),
+        ]),
       });
     } finally {
       await fixture.close();


### PR DESCRIPTION
Conversation reads now treat the linked SQL user's display name as canonical,
so provider identities connected by verified email present one consistent
person name across runtime storage and reporting. Provider-specific handles and
identifiers remain attached to the originating identity, while actors without a
canonical user name fall back to the identity display name.

This intentionally keeps the existing first-non-empty write behavior; it does
not refresh renamed users or introduce provider precedence.

Fixes #927
