### PR TITLE
fix(scheduler): Compute next runs from structured intent

### DIFF
--- a/packages/junior-evals/evals/scheduler/README.md
+++ b/packages/junior-evals/evals/scheduler/README.md
@@ -3,6 +3,7 @@
 Scheduler evals cover agent-facing scheduled task behavior:
 
 - creating clear one-off reminders without confirmation
+- emitting structured schedule intent while the scheduler owns exact timestamps
 - preserving executable future work in scheduled task text
 - creating clear recurring work without confirmation
 - enabling creator credentials only after explicit authorization

--- a/packages/junior-evals/evals/scheduler/creation.eval.ts
+++ b/packages/junior-evals/evals/scheduler/creation.eval.ts
@@ -1,7 +1,7 @@
 import { describeEval } from "vitest-evals";
 import { expect } from "vitest";
 import { mention, rubric, slackEvals } from "../../src/helpers";
-import { scheduledTaskCreateCall } from "./helpers";
+import { scheduledTaskCreateCalls } from "./helpers";
 
 describeEval("Schedule Creation", slackEvals, (it) => {
   it("when asked for a simple one-off reminder, create it without asking for confirmation", async ({
@@ -21,9 +21,16 @@ describeEval("Schedule Creation", slackEvals, (it) => {
         ],
       }),
     });
-    const createCall = scheduledTaskCreateCall(result.session);
-    expect(createCall.arguments).toMatchObject({ schedule_kind: "one_off" });
-    expect(createCall.arguments).not.toHaveProperty("recurrence");
+    const createCalls = scheduledTaskCreateCalls(result.session);
+    expect(createCalls).toHaveLength(1);
+    const createCall = createCalls[0]!;
+    expect(createCall.arguments).toMatchObject({
+      schedule: {
+        kind: "one_off",
+        timing: { type: "after", value: 1, unit: "minute" },
+      },
+    });
+    expect(createCall.arguments).not.toHaveProperty("next_run_at");
   });
 
   it("when asked for a terse one-off reminder, create it without recurrence", async ({
@@ -43,9 +50,16 @@ describeEval("Schedule Creation", slackEvals, (it) => {
         ],
       }),
     });
-    const createCall = scheduledTaskCreateCall(result.session);
-    expect(createCall.arguments).toMatchObject({ schedule_kind: "one_off" });
-    expect(createCall.arguments).not.toHaveProperty("recurrence");
+    const createCalls = scheduledTaskCreateCalls(result.session);
+    expect(createCalls).toHaveLength(1);
+    const createCall = createCalls[0]!;
+    expect(createCall.arguments).toMatchObject({
+      schedule: {
+        kind: "one_off",
+        timing: { type: "after", value: 1, unit: "minute" },
+      },
+    });
+    expect(createCall.arguments).not.toHaveProperty("next_run_at");
   });
 
   it("when asked for a specific one-off reminder, preserve the future work in the schedule", async ({
@@ -59,17 +73,25 @@ describeEval("Schedule Creation", slackEvals, (it) => {
       ],
       criteria: rubric({
         pass: [
-          "The observed scheduler_slackScheduleCreateTask task is the reminder work to perform later, not instructions for how to create or manage a schedule.",
+          "The reply confirms that the channel reminder was scheduled for two minutes from now.",
         ],
         fail: [
-          "Do not store task text that tells Junior to schedule a reminder later.",
           "Do not ask the user to confirm before creating this clear reminder.",
         ],
       }),
     });
-    const createCall = scheduledTaskCreateCall(result.session);
-    expect(createCall.arguments).toMatchObject({ schedule_kind: "one_off" });
-    expect(createCall.arguments).not.toHaveProperty("recurrence");
+    const createCalls = scheduledTaskCreateCalls(result.session);
+    expect(createCalls).toHaveLength(1);
+    const createCall = createCalls[0]!;
+    expect(createCall.arguments).toMatchObject({
+      schedule: {
+        kind: "one_off",
+        timing: { type: "after", value: 2, unit: "minute" },
+      },
+    });
+    expect(createCall.arguments).not.toHaveProperty("next_run_at");
+    expect(createCall.arguments?.task).toMatch(/standup moved/i);
+    expect(createCall.arguments?.task).not.toMatch(/\bschedul(?:e|ing)\b/i);
   });
 
   it("when asked to schedule clear recurring work, create it without confirmation", async ({
@@ -93,9 +115,15 @@ describeEval("Schedule Creation", slackEvals, (it) => {
         ],
       }),
     });
-    expect(scheduledTaskCreateCall(result.session).arguments).toMatchObject({
-      schedule_kind: "recurring",
-      recurrence: "weekly",
+    const createCalls = scheduledTaskCreateCalls(result.session);
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0]!.arguments).toMatchObject({
+      schedule: {
+        kind: "recurring",
+        frequency: "weekly",
+        time: "09:00",
+        weekdays: ["monday"],
+      },
     });
   });
 });

--- a/packages/junior-evals/evals/scheduler/credentials.eval.ts
+++ b/packages/junior-evals/evals/scheduler/credentials.eval.ts
@@ -2,7 +2,7 @@ import { describeEval } from "vitest-evals";
 import { expect } from "vitest";
 import { toolCalls } from "vitest-evals";
 import { mention, rubric, slackEvals, threadMessage } from "../../src/helpers";
-import { expectNoToolCalls, scheduledTaskCreateCall } from "./helpers";
+import { expectNoToolCalls, scheduledTaskCreateCalls } from "./helpers";
 
 describeEval("Scheduled Credentials", slackEvals, (it) => {
   it("when the creator explicitly authorizes connected credentials, enable creator mode", async ({
@@ -25,9 +25,11 @@ describeEval("Scheduled Credentials", slackEvals, (it) => {
       }),
     });
 
-    expect(scheduledTaskCreateCall(result.session).arguments).toMatchObject({
+    const createCalls = scheduledTaskCreateCalls(result.session);
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0]!.arguments).toMatchObject({
       credential_mode: "creator",
-      schedule_kind: "recurring",
+      schedule: { kind: "recurring", frequency: "weekly" },
     });
   });
 
@@ -75,12 +77,15 @@ describeEval("Scheduled Credentials", slackEvals, (it) => {
       }),
     });
 
-    const createCall = scheduledTaskCreateCall(result.session);
+    const createCalls = scheduledTaskCreateCalls(result.session);
+    expect(createCalls).toHaveLength(1);
+    const createCall = createCalls[0]!;
     expect(createCall.arguments?.credential_mode).not.toBe("creator");
     expect(
       toolCalls(result.session).filter(
         (call) =>
           call.name === "scheduler_slackScheduleUpdateTask" &&
+          call.status === "ok" &&
           call.arguments?.credential_mode === "creator",
       ),
     ).toEqual([]);
@@ -134,12 +139,15 @@ describeEval("Scheduled Credentials", slackEvals, (it) => {
       }),
     });
 
-    const createCall = scheduledTaskCreateCall(result.session);
+    const createCalls = scheduledTaskCreateCalls(result.session);
+    expect(createCalls).toHaveLength(1);
+    const createCall = createCalls[0]!;
     expect(createCall.arguments?.credential_mode).not.toBe("creator");
     expect(
       toolCalls(result.session).filter(
         (call) =>
           call.name === "scheduler_slackScheduleUpdateTask" &&
+          call.status === "ok" &&
           call.arguments?.credential_mode === "creator",
       ),
     ).toEqual([]);

--- a/packages/junior-evals/evals/scheduler/helpers.ts
+++ b/packages/junior-evals/evals/scheduler/helpers.ts
@@ -16,17 +16,26 @@ export const REMINDER_ONLY_FORBIDDEN_TOOLS = [
   "slackChannelListMessages",
 ] as const;
 
-export function scheduledTaskCreateCall(
+export function scheduledTaskCreateCalls(
   session: Parameters<typeof toolCalls>[0],
 ) {
-  const calls = toolCalls(session).filter(
+  return toolCalls(session).filter(
     (call) =>
       call.name === "scheduler_slackScheduleCreateTask" &&
       call.status === "ok" &&
       call.result !== undefined,
   );
-  expect(calls).toHaveLength(1);
-  return calls[0]!;
+}
+
+export function scheduledTaskUpdateCalls(
+  session: Parameters<typeof toolCalls>[0],
+) {
+  return toolCalls(session).filter(
+    (call) =>
+      call.name === "scheduler_slackScheduleUpdateTask" &&
+      call.status === "ok" &&
+      call.result !== undefined,
+  );
 }
 
 export function expectNoToolCalls(

--- a/packages/junior-evals/evals/scheduler/management.eval.ts
+++ b/packages/junior-evals/evals/scheduler/management.eval.ts
@@ -1,0 +1,57 @@
+import { describeEval } from "vitest-evals";
+import { expect } from "vitest";
+import { mention, rubric, slackEvals, threadMessage } from "../../src/helpers";
+import { scheduledTaskCreateCalls, scheduledTaskUpdateCalls } from "./helpers";
+
+describeEval("Schedule Management", slackEvals, (it) => {
+  it("when asked to reschedule an existing task, replace its cadence", async ({
+    run,
+  }) => {
+    const thread = {
+      channel_type: "channel" as const,
+      channel_id: "CSCHEDMANAGE",
+      id: "thread-scheduler-reschedule",
+      thread_ts: "1700000000.877000",
+    };
+    const author = {
+      user_id: "UALICE",
+      user_name: "alice",
+      full_name: "Alice Example",
+    };
+    const result = await run({
+      initialEvents: [
+        mention(
+          "@bot every Monday at 9am Pacific post a planning reminder here.",
+          { thread, author },
+        ),
+      ],
+      events: [
+        threadMessage(
+          "@bot change that scheduled task to Tuesdays at 10am Pacific.",
+          { thread, is_mention: true, author },
+        ),
+      ],
+      criteria: rubric({
+        pass: [
+          "The reply confirms that the scheduled task now runs every Tuesday at 10am Pacific.",
+        ],
+        fail: ["Do not claim the task still runs on Monday at 9am."],
+      }),
+    });
+
+    const createCalls = scheduledTaskCreateCalls(result.session);
+    const updateCalls = scheduledTaskUpdateCalls(result.session);
+    expect(createCalls).toHaveLength(1);
+    expect(updateCalls).toHaveLength(1);
+    const updateCall = updateCalls[0]!;
+    expect(updateCall.arguments).toMatchObject({
+      schedule: {
+        kind: "recurring",
+        frequency: "weekly",
+        time: "10:00",
+        weekdays: ["tuesday"],
+      },
+    });
+    expect(updateCall.arguments).not.toHaveProperty("next_run_at");
+  });
+});

--- a/packages/junior-evals/evals/scheduler/management.eval.ts
+++ b/packages/junior-evals/evals/scheduler/management.eval.ts
@@ -42,9 +42,10 @@ describeEval("Schedule Management", slackEvals, (it) => {
     const createCalls = scheduledTaskCreateCalls(result.session);
     const updateCalls = scheduledTaskUpdateCalls(result.session);
     expect(createCalls).toHaveLength(1);
-    expect(updateCalls).toHaveLength(1);
-    const updateCall = updateCalls[0]!;
-    expect(updateCall.arguments).toMatchObject({
+    const scheduleUpdate = updateCalls.find(
+      (call) => call.arguments?.schedule !== undefined,
+    );
+    expect(scheduleUpdate?.arguments).toMatchObject({
       schedule: {
         kind: "recurring",
         frequency: "weekly",
@@ -52,6 +53,8 @@ describeEval("Schedule Management", slackEvals, (it) => {
         weekdays: ["tuesday"],
       },
     });
-    expect(updateCall.arguments).not.toHaveProperty("next_run_at");
+    for (const updateCall of updateCalls) {
+      expect(updateCall.arguments).not.toHaveProperty("next_run_at");
+    }
   });
 });

--- a/packages/junior-evals/src/behavior-harness.ts
+++ b/packages/junior-evals/src/behavior-harness.ts
@@ -524,22 +524,6 @@ function toEvalToolInvocation(input: {
     ...(input.toolCallId ? { toolCallId: input.toolCallId } : {}),
   };
 
-  if (input.toolName.startsWith("slackSchedule")) {
-    invocation.arguments = Object.fromEntries(
-      [
-        "task_id",
-        "task",
-        "schedule",
-        "timezone",
-        "next_run_at",
-        "recurrence",
-        "status",
-      ]
-        .filter((key) => key in input.params)
-        .map((key) => [key, input.params[key]]),
-    );
-  }
-
   if (input.toolName === "bash" && typeof input.params.command === "string") {
     invocation.bash_command = input.params.command.trim();
   }

--- a/packages/junior-scheduler/README.md
+++ b/packages/junior-scheduler/README.md
@@ -20,8 +20,6 @@ Junior's durable agent runtime.
   lower bound and its containing week is the first active week.
 - Create tool-call identities produce stable task ids so retrying one committed
   tool invocation returns the existing task instead of duplicating it.
-- Update tool-call identities retain their committed task snapshot so replaying
-  an older mutation cannot recompute relative time or overwrite a later edit.
 - Updates and deletion invalidate obsolete pending run times.
 
 ## Dispatch

--- a/packages/junior-scheduler/README.md
+++ b/packages/junior-scheduler/README.md
@@ -9,8 +9,17 @@ Junior's durable agent runtime.
   prompt text, timezone-aware schedule, recurrence, credential mode, status, and
   next-run state.
 - SQL schemas and migrations are authoritative for persistence.
-- Schedule parsing normalizes calendar intent before storage; execution does not
+- Model-facing tools accept structured schedule intent. The scheduler resolves
+  relative delays and calendar fields against its server clock and timezone,
+  computes `nextRunAtMs`, and stores the canonical schedule. Execution does not
   reinterpret the original natural-language request.
+- Relative delays are elapsed durations. Calendar schedules use local wall-clock
+  time: nonexistent recurring times are skipped, nonexistent one-off times are
+  rejected, and repeated times use their first instant.
+- Create tool-call identities produce stable task ids so retrying one committed
+  tool invocation returns the existing task instead of duplicating it.
+- Update tool-call identities retain their committed task snapshot so replaying
+  an older mutation cannot recompute relative time or overwrite a later edit.
 - Updates and deletion invalidate obsolete pending run times.
 
 ## Dispatch

--- a/packages/junior-scheduler/README.md
+++ b/packages/junior-scheduler/README.md
@@ -16,6 +16,8 @@ Junior's durable agent runtime.
 - Relative delays are elapsed durations. Calendar schedules use local wall-clock
   time: nonexistent recurring times are skipped, nonexistent one-off times are
   rejected, and repeated times use their first instant.
+- Multi-week recurrences use Monday-based calendar weeks; `startDate` is the
+  lower bound and its containing week is the first active week.
 - Create tool-call identities produce stable task ids so retrying one committed
   tool invocation returns the existing task instead of duplicating it.
 - Update tool-call identities retain their committed task snapshot so replaying

--- a/packages/junior-scheduler/src/cadence.ts
+++ b/packages/junior-scheduler/src/cadence.ts
@@ -50,6 +50,10 @@ function getLocalDateWeekday(date: LocalDate): number {
   return new Date(Date.UTC(date.year, date.month - 1, date.day)).getUTCDay();
 }
 
+function getWeekStart(date: LocalDate): LocalDate {
+  return addDays(date, -((getLocalDateWeekday(date) + 6) % 7));
+}
+
 /** Resolve a UTC timestamp into calendar parts for a named time zone. */
 export function getZonedDateTimeParts(
   timestampMs: number,
@@ -174,7 +178,10 @@ function weeklyRecurrenceMatchesDate(
   return (
     normalizeWeekdays(recurrence.weekdays).includes(
       getLocalDateWeekday(date),
-    ) && Math.floor(daysBetween(start, date) / 7) % recurrence.interval === 0
+    ) &&
+    Math.floor(daysBetween(getWeekStart(start), getWeekStart(date)) / 7) %
+      recurrence.interval ===
+      0
   );
 }
 

--- a/packages/junior-scheduler/src/cadence.ts
+++ b/packages/junior-scheduler/src/cadence.ts
@@ -1,51 +1,8 @@
 import type {
-  ScheduledCalendarFrequency,
   ScheduledLocalTime,
   ScheduledTask,
   ScheduledTaskRecurrence,
 } from "./types";
-
-/** Parse an ISO timestamp into a finite Unix timestamp in milliseconds. */
-export function parseScheduleTimestamp(value: string): number | undefined {
-  const trimmed = value.trim();
-  const match =
-    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(?:\.\d{1,9})?)?(Z|[+-]\d{2}:\d{2})$/.exec(
-      trimmed,
-    );
-  if (!match) {
-    return undefined;
-  }
-
-  const year = Number(match[1]);
-  const month = Number(match[2]);
-  const day = Number(match[3]);
-  const hour = Number(match[4]);
-  const minute = Number(match[5]);
-  const second = match[6] ? Number(match[6]) : 0;
-  if (
-    !Number.isInteger(year) ||
-    !Number.isInteger(month) ||
-    !Number.isInteger(day) ||
-    !Number.isInteger(hour) ||
-    !Number.isInteger(minute) ||
-    !Number.isInteger(second) ||
-    month < 1 ||
-    month > 12 ||
-    day < 1 ||
-    day > daysInMonth(year, month) ||
-    hour < 0 ||
-    hour > 23 ||
-    minute < 0 ||
-    minute > 59 ||
-    second < 0 ||
-    second > 59
-  ) {
-    return undefined;
-  }
-
-  const parsed = Date.parse(trimmed);
-  return Number.isFinite(parsed) ? parsed : undefined;
-}
 
 export interface ZonedDateTimeParts {
   day: number;
@@ -136,7 +93,7 @@ function localDateTimeToTimestampMs(args: {
   date: LocalDate;
   time: ScheduledLocalTime;
   timezone: string;
-}): number {
+}): number | undefined {
   const localAsUtcMs = Date.UTC(
     args.date.year,
     args.date.month - 1,
@@ -145,18 +102,219 @@ function localDateTimeToTimestampMs(args: {
     args.time.minute,
     0,
   );
-  let timestampMs =
-    localAsUtcMs - getTimeZoneOffsetMs(localAsUtcMs, args.timezone);
-
-  for (let index = 0; index < 3; index += 1) {
-    const next = localAsUtcMs - getTimeZoneOffsetMs(timestampMs, args.timezone);
-    if (next === timestampMs) {
-      break;
-    }
-    timestampMs = next;
+  const offsets = new Set<number>();
+  for (const probeDeltaMs of [
+    -36 * 60 * 60 * 1000,
+    -12 * 60 * 60 * 1000,
+    0,
+    12 * 60 * 60 * 1000,
+    36 * 60 * 60 * 1000,
+  ]) {
+    offsets.add(
+      getTimeZoneOffsetMs(localAsUtcMs + probeDeltaMs, args.timezone),
+    );
   }
 
-  return timestampMs;
+  const matches = [...offsets]
+    .map((offsetMs) => localAsUtcMs - offsetMs)
+    .filter((timestampMs) => {
+      const parts = getZonedDateTimeParts(timestampMs, args.timezone);
+      return (
+        parts.year === args.date.year &&
+        parts.month === args.date.month &&
+        parts.day === args.date.day &&
+        parts.hour === args.time.hour &&
+        parts.minute === args.time.minute
+      );
+    });
+
+  if (matches.length === 0) {
+    return undefined;
+  }
+  return Math.min(...matches);
+}
+
+/** Resolve local time, rejecting DST gaps and choosing the earlier instant in a fold. */
+export function resolveLocalScheduleAtMs(args: {
+  date: string;
+  time: ScheduledLocalTime;
+  timezone: string;
+}): number | undefined {
+  const date = parseLocalDate(args.date);
+  if (!date) {
+    return undefined;
+  }
+  return localDateTimeToTimestampMs({
+    date,
+    time: args.time,
+    timezone: args.timezone,
+  });
+}
+
+function daysBetween(left: LocalDate, right: LocalDate): number {
+  return Math.floor(
+    (Date.UTC(right.year, right.month - 1, right.day) -
+      Date.UTC(left.year, left.month - 1, left.day)) /
+      (24 * 60 * 60 * 1000),
+  );
+}
+
+function monthsBetween(left: LocalDate, right: LocalDate): number {
+  return right.year * 12 + right.month - (left.year * 12 + left.month);
+}
+
+function weeklyRecurrenceMatchesDate(
+  date: LocalDate,
+  start: LocalDate,
+  recurrence: ScheduledTaskRecurrence,
+): boolean {
+  if (compareDate(date, start) < 0) {
+    return false;
+  }
+  return (
+    normalizeWeekdays(recurrence.weekdays).includes(
+      getLocalDateWeekday(date),
+    ) && Math.floor(daysBetween(start, date) / 7) % recurrence.interval === 0
+  );
+}
+
+function greatestCommonDivisor(left: number, right: number): number {
+  let a = Math.abs(left);
+  let b = Math.abs(right);
+  while (b !== 0) {
+    [a, b] = [b, a % b];
+  }
+  return a;
+}
+
+function findNextRunAtMs(args: {
+  afterMs: number;
+  recurrence: ScheduledTaskRecurrence;
+  searchFrom: LocalDate;
+  timezone: string;
+}): number | undefined {
+  const start = parseLocalDate(args.recurrence.startDate);
+  const interval = args.recurrence.interval;
+  if (!start || !Number.isInteger(interval) || interval <= 0) {
+    return undefined;
+  }
+
+  const searchFrom =
+    compareDate(args.searchFrom, start) < 0 ? start : args.searchFrom;
+  if (args.recurrence.frequency === "daily") {
+    const offsetDays = daysBetween(start, searchFrom);
+    let candidateDate = addDays(
+      start,
+      Math.ceil(offsetDays / interval) * interval,
+    );
+    const gregorianCycleDays = 146_097;
+    const candidateCount =
+      gregorianCycleDays / greatestCommonDivisor(gregorianCycleDays, interval);
+    for (let attempts = 0; attempts < candidateCount; attempts += 1) {
+      const candidate = buildCandidate({
+        date: candidateDate,
+        recurrence: args.recurrence,
+        timezone: args.timezone,
+      });
+      if (candidate !== undefined && candidate > args.afterMs) {
+        return candidate;
+      }
+      candidateDate = addDays(candidateDate, interval);
+    }
+    return undefined;
+  }
+
+  if (args.recurrence.frequency === "weekly") {
+    if (normalizeWeekdays(args.recurrence.weekdays).length === 0) {
+      return undefined;
+    }
+    let candidateDate = searchFrom;
+    const gregorianCycleDays = 146_097;
+    const cadenceDays = interval * 7;
+    const searchDays =
+      (gregorianCycleDays * cadenceDays) /
+      greatestCommonDivisor(gregorianCycleDays, cadenceDays);
+    for (let attempts = 0; attempts < searchDays; attempts += 1) {
+      if (weeklyRecurrenceMatchesDate(candidateDate, start, args.recurrence)) {
+        const candidate = buildCandidate({
+          date: candidateDate,
+          recurrence: args.recurrence,
+          timezone: args.timezone,
+        });
+        if (candidate !== undefined && candidate > args.afterMs) {
+          return candidate;
+        }
+      }
+      candidateDate = addDays(candidateDate, 1);
+    }
+    return undefined;
+  }
+
+  if (args.recurrence.frequency === "monthly") {
+    const startMonth = start.year * 12 + start.month - 1;
+    const searchMonth = searchFrom.year * 12 + searchFrom.month - 1;
+    let candidateMonth =
+      startMonth + Math.ceil((searchMonth - startMonth) / interval) * interval;
+    const gregorianCycleMonths = 4_800;
+    const candidateCount =
+      gregorianCycleMonths /
+      greatestCommonDivisor(gregorianCycleMonths, interval);
+    for (let attempts = 0; attempts < candidateCount; attempts += 1) {
+      const candidateDate = {
+        year: Math.floor(candidateMonth / 12),
+        month: (candidateMonth % 12) + 1,
+        day: args.recurrence.dayOfMonth ?? 0,
+      };
+      if (compareDate(candidateDate, searchFrom) >= 0) {
+        const candidate = buildCandidate({
+          date: candidateDate,
+          recurrence: args.recurrence,
+          timezone: args.timezone,
+        });
+        if (candidate !== undefined && candidate > args.afterMs) {
+          return candidate;
+        }
+      }
+      candidateMonth += interval;
+    }
+    return undefined;
+  }
+
+  let candidateYear =
+    start.year +
+    Math.ceil((searchFrom.year - start.year) / interval) * interval;
+  const candidateCount = 400 / greatestCommonDivisor(400, interval);
+  for (let attempts = 0; attempts < candidateCount; attempts += 1) {
+    const candidateDate = {
+      year: candidateYear,
+      month: args.recurrence.month ?? 0,
+      day: args.recurrence.dayOfMonth ?? 0,
+    };
+    if (compareDate(candidateDate, searchFrom) >= 0) {
+      const candidate = buildCandidate({
+        date: candidateDate,
+        recurrence: args.recurrence,
+        timezone: args.timezone,
+      });
+      if (candidate !== undefined && candidate > args.afterMs) {
+        return candidate;
+      }
+    }
+    candidateYear += interval;
+  }
+  return undefined;
+}
+
+/** Compute the first recurring calendar occurrence strictly after a timestamp. */
+export function getFirstRunAtMs(args: {
+  afterMs: number;
+  recurrence: ScheduledTaskRecurrence;
+  timezone: string;
+}): number | undefined {
+  return findNextRunAtMs({
+    ...args,
+    searchFrom: getLocalDate(args.afterMs, args.timezone),
+  });
 }
 
 function compareDate(left: LocalDate, right: LocalDate): number {
@@ -203,14 +361,6 @@ function parseLocalDate(value: string): LocalDate | undefined {
   return { year, month, day };
 }
 
-function formatLocalDate(date: LocalDate): string {
-  return [
-    String(date.year).padStart(4, "0"),
-    String(date.month).padStart(2, "0"),
-    String(date.day).padStart(2, "0"),
-  ].join("-");
-}
-
 function getLocalDate(timestampMs: number, timezone: string): LocalDate {
   const parts = getZonedDateTimeParts(timestampMs, timezone);
   return { year: parts.year, month: parts.month, day: parts.day };
@@ -226,224 +376,12 @@ function buildCandidate(args: {
   date: LocalDate;
   recurrence: ScheduledTaskRecurrence;
   timezone: string;
-}): number {
+}): number | undefined {
   return localDateTimeToTimestampMs({
     date: args.date,
     time: args.recurrence.time,
     timezone: args.timezone,
   });
-}
-
-function getDailyNextRunAtMs(args: {
-  afterMs: number;
-  recurrence: ScheduledTaskRecurrence;
-  scheduledForMs: number;
-  timezone: string;
-}): number | undefined {
-  const start = parseLocalDate(args.recurrence.startDate);
-  if (!start) {
-    return undefined;
-  }
-
-  let candidateDate = addDays(
-    getLocalDate(args.scheduledForMs, args.timezone),
-    args.recurrence.interval,
-  );
-  if (compareDate(candidateDate, start) < 0) {
-    candidateDate = start;
-  }
-
-  let candidate = buildCandidate({
-    date: candidateDate,
-    recurrence: args.recurrence,
-    timezone: args.timezone,
-  });
-  while (candidate <= args.afterMs) {
-    candidateDate = addDays(candidateDate, args.recurrence.interval);
-    candidate = buildCandidate({
-      date: candidateDate,
-      recurrence: args.recurrence,
-      timezone: args.timezone,
-    });
-  }
-  return candidate;
-}
-
-function getWeeklyNextRunAtMs(args: {
-  afterMs: number;
-  recurrence: ScheduledTaskRecurrence;
-  scheduledForMs: number;
-  timezone: string;
-}): number | undefined {
-  const start = parseLocalDate(args.recurrence.startDate);
-  if (!start) {
-    return undefined;
-  }
-
-  const weekdays = normalizeWeekdays(args.recurrence.weekdays);
-  if (weekdays.length === 0) {
-    return undefined;
-  }
-
-  let candidateDate = addDays(
-    getLocalDate(args.scheduledForMs, args.timezone),
-    1,
-  );
-  for (let attempts = 0; attempts < 3660; attempts += 1) {
-    const weeksSinceStart = Math.floor(
-      (Date.UTC(
-        candidateDate.year,
-        candidateDate.month - 1,
-        candidateDate.day,
-      ) -
-        Date.UTC(start.year, start.month - 1, start.day)) /
-        (7 * 24 * 60 * 60 * 1000),
-    );
-    const isInCycle =
-      weeksSinceStart >= 0 && weeksSinceStart % args.recurrence.interval === 0;
-    if (isInCycle && weekdays.includes(getLocalDateWeekday(candidateDate))) {
-      const candidate = buildCandidate({
-        date: candidateDate,
-        recurrence: args.recurrence,
-        timezone: args.timezone,
-      });
-      if (candidate > args.afterMs) {
-        return candidate;
-      }
-    }
-    candidateDate = addDays(candidateDate, 1);
-  }
-
-  return undefined;
-}
-
-function getMonthlyNextRunAtMs(args: {
-  afterMs: number;
-  recurrence: ScheduledTaskRecurrence;
-  scheduledForMs: number;
-  timezone: string;
-}): number | undefined {
-  const start = parseLocalDate(args.recurrence.startDate);
-  const dayOfMonth = args.recurrence.dayOfMonth;
-  if (!start || !dayOfMonth) {
-    return undefined;
-  }
-
-  const scheduledDate = getLocalDate(args.scheduledForMs, args.timezone);
-  let monthIndex = scheduledDate.year * 12 + scheduledDate.month - 1;
-  const startMonthIndex = start.year * 12 + start.month - 1;
-
-  for (let attempts = 0; attempts < 1200; attempts += 1) {
-    monthIndex += args.recurrence.interval;
-    if (monthIndex < startMonthIndex) {
-      monthIndex = startMonthIndex;
-    }
-    const year = Math.floor(monthIndex / 12);
-    const month = (monthIndex % 12) + 1;
-    if (dayOfMonth > daysInMonth(year, month)) {
-      continue;
-    }
-    const candidate = buildCandidate({
-      date: { year, month, day: dayOfMonth },
-      recurrence: args.recurrence,
-      timezone: args.timezone,
-    });
-    if (candidate > args.afterMs) {
-      return candidate;
-    }
-  }
-
-  return undefined;
-}
-
-function getYearlyNextRunAtMs(args: {
-  afterMs: number;
-  recurrence: ScheduledTaskRecurrence;
-  scheduledForMs: number;
-  timezone: string;
-}): number | undefined {
-  const start = parseLocalDate(args.recurrence.startDate);
-  const month = args.recurrence.month;
-  const dayOfMonth = args.recurrence.dayOfMonth;
-  if (!start || !month || !dayOfMonth) {
-    return undefined;
-  }
-
-  const scheduledDate = getLocalDate(args.scheduledForMs, args.timezone);
-  let year = scheduledDate.year;
-
-  for (let attempts = 0; attempts < 100; attempts += 1) {
-    year += args.recurrence.interval;
-    if (year < start.year) {
-      year = start.year;
-    }
-    if (dayOfMonth > daysInMonth(year, month)) {
-      continue;
-    }
-    const candidate = buildCandidate({
-      date: { year, month, day: dayOfMonth },
-      recurrence: args.recurrence,
-      timezone: args.timezone,
-    });
-    if (candidate > args.afterMs) {
-      return candidate;
-    }
-  }
-
-  return undefined;
-}
-
-/** Build a calendar recurrence anchored to an exact first run timestamp. */
-export function buildCalendarRecurrence(args: {
-  frequency: ScheduledCalendarFrequency;
-  interval?: number;
-  nextRunAtMs: number;
-  timezone: string;
-  weekdays?: number[];
-}): ScheduledTaskRecurrence {
-  const interval = args.interval && args.interval > 0 ? args.interval : 1;
-  const parts = getZonedDateTimeParts(args.nextRunAtMs, args.timezone);
-  const time = { hour: parts.hour, minute: parts.minute };
-  const startDate = formatLocalDate(parts);
-
-  if (args.frequency === "weekly") {
-    const weekdays = normalizeWeekdays(args.weekdays);
-    return {
-      frequency: args.frequency,
-      interval,
-      startDate,
-      time,
-      weekdays: weekdays.length > 0 ? weekdays : [parts.weekday],
-    };
-  }
-
-  if (args.frequency === "monthly") {
-    return {
-      dayOfMonth: parts.day,
-      frequency: args.frequency,
-      interval,
-      startDate,
-      time,
-    };
-  }
-
-  if (args.frequency === "yearly") {
-    return {
-      dayOfMonth: parts.day,
-      frequency: args.frequency,
-      interval,
-      month: parts.month,
-      startDate,
-      time,
-    };
-  }
-
-  return {
-    frequency: args.frequency,
-    interval,
-    startDate,
-    time,
-  };
 }
 
 /** Return the next fire time after a completed run, when the task recurs. */
@@ -465,37 +403,16 @@ export function getNextRunAtMs(
     return undefined;
   }
 
-  if (recurrence.frequency === "daily") {
-    return getDailyNextRunAtMs({
-      recurrence,
-      timezone: task.schedule.timezone,
-      scheduledForMs,
-      afterMs,
-    });
-  }
-
-  if (recurrence.frequency === "weekly") {
-    return getWeeklyNextRunAtMs({
-      recurrence,
-      timezone: task.schedule.timezone,
-      scheduledForMs,
-      afterMs,
-    });
-  }
-
-  if (recurrence.frequency === "monthly") {
-    return getMonthlyNextRunAtMs({
-      recurrence,
-      timezone: task.schedule.timezone,
-      scheduledForMs,
-      afterMs,
-    });
-  }
-
-  return getYearlyNextRunAtMs({
-    recurrence,
-    timezone: task.schedule.timezone,
-    scheduledForMs,
+  const timezone = task.schedule.timezone;
+  const afterDate = getLocalDate(afterMs, timezone);
+  const nextScheduledDate = addDays(getLocalDate(scheduledForMs, timezone), 1);
+  return findNextRunAtMs({
     afterMs,
+    recurrence,
+    searchFrom:
+      compareDate(afterDate, nextScheduledDate) < 0
+        ? nextScheduledDate
+        : afterDate,
+    timezone,
   });
 }

--- a/packages/junior-scheduler/src/schedule-intent.ts
+++ b/packages/junior-scheduler/src/schedule-intent.ts
@@ -1,0 +1,372 @@
+/**
+ * Owns model-facing schedule intent and materializes it against the trusted
+ * server clock into the canonical schedule persisted by the scheduler.
+ */
+import { z } from "zod";
+import {
+  getFirstRunAtMs,
+  getZonedDateTimeParts,
+  resolveLocalScheduleAtMs,
+} from "./cadence";
+import type {
+  ScheduledLocalTime,
+  ScheduledTaskRecurrence,
+  ScheduledTaskSchedule,
+} from "./types";
+
+const localDateSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, "Use a local date in YYYY-MM-DD format.");
+const localTimeSchema = z
+  .string()
+  .regex(/^([01]\d|2[0-3]):[0-5]\d$/, "Use local time in HH:MM format.");
+const timezoneSchema = z
+  .string()
+  .min(1)
+  .max(80)
+  .describe(
+    "IANA timezone, for example America/Los_Angeles. Omit or use null for the scheduler default.",
+  )
+  .nullable()
+  .optional();
+const weekdaySchema = z.enum([
+  "sunday",
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+]);
+
+const oneOffScheduleIntentSchema = z
+  .object({
+    kind: z.literal("one_off").describe("A schedule that runs once."),
+    timezone: timezoneSchema,
+    timing: z
+      .discriminatedUnion("type", [
+        z
+          .object({
+            type: z
+              .literal("after")
+              .describe("Run after a relative delay from the server clock."),
+            value: z.number().int().positive().max(100_000),
+            unit: z.enum(["second", "minute", "hour", "day", "week"]),
+          })
+          .strict(),
+        z
+          .object({
+            type: z
+              .literal("at")
+              .describe("Run at an explicit local calendar date and time."),
+            date: localDateSchema.describe(
+              "Requested local calendar date in YYYY-MM-DD format.",
+            ),
+            time: localTimeSchema.describe(
+              "Requested local wall-clock time in HH:MM format.",
+            ),
+          })
+          .strict(),
+      ])
+      .describe("Relative delay or explicit local time for the one-off run."),
+  })
+  .strict();
+
+const recurringScheduleIntentSchema = z
+  .object({
+    kind: z.literal("recurring").describe("A repeating calendar schedule."),
+    frequency: z
+      .enum(["daily", "weekly", "monthly", "yearly"])
+      .describe("Recurring tasks can run at most once per day."),
+    interval: z
+      .number()
+      .int()
+      .positive()
+      .max(365)
+      .describe("Repeat every N frequency units. Defaults to 1.")
+      .nullable()
+      .optional(),
+    time: localTimeSchema.describe(
+      "Local wall-clock time for each occurrence in HH:MM format.",
+    ),
+    weekdays: z
+      .array(weekdaySchema)
+      .min(1)
+      .max(7)
+      .describe("Required for weekly schedules.")
+      .nullable()
+      .optional(),
+    day_of_month: z
+      .number()
+      .int()
+      .min(1)
+      .max(31)
+      .describe("Required for monthly and yearly schedules.")
+      .nullable()
+      .optional(),
+    month: z
+      .number()
+      .int()
+      .min(1)
+      .max(12)
+      .describe("Required for yearly schedules, where January is 1.")
+      .nullable()
+      .optional(),
+    start_date: localDateSchema
+      .describe(
+        "Optional local calendar date that anchors the recurrence. Omit to start with the next matching occurrence.",
+      )
+      .nullable()
+      .optional(),
+    timezone: timezoneSchema,
+  })
+  .strict()
+  .superRefine((schedule, context) => {
+    if (schedule.frequency === "weekly" && schedule.weekdays == null) {
+      context.addIssue({
+        code: "custom",
+        message: "Weekly schedules require weekdays.",
+        path: ["weekdays"],
+      });
+    }
+    if (
+      (schedule.frequency === "monthly" || schedule.frequency === "yearly") &&
+      schedule.day_of_month == null
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: `${schedule.frequency} schedules require day_of_month.`,
+        path: ["day_of_month"],
+      });
+    }
+    if (schedule.frequency === "yearly" && schedule.month == null) {
+      context.addIssue({
+        code: "custom",
+        message: "Yearly schedules require month.",
+        path: ["month"],
+      });
+    }
+    if (schedule.frequency !== "weekly" && schedule.weekdays != null) {
+      context.addIssue({
+        code: "custom",
+        message: "weekdays applies only to weekly schedules.",
+        path: ["weekdays"],
+      });
+    }
+    if (
+      schedule.frequency !== "monthly" &&
+      schedule.frequency !== "yearly" &&
+      schedule.day_of_month != null
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "day_of_month applies only to monthly or yearly schedules.",
+        path: ["day_of_month"],
+      });
+    }
+    if (schedule.frequency !== "yearly" && schedule.month != null) {
+      context.addIssue({
+        code: "custom",
+        message: "month applies only to yearly schedules.",
+        path: ["month"],
+      });
+    }
+  });
+
+export const scheduleIntentSchema = z.union([
+  oneOffScheduleIntentSchema,
+  recurringScheduleIntentSchema,
+]);
+export type ScheduleIntent = z.infer<typeof scheduleIntentSchema>;
+
+const WEEKDAY_INDEX = {
+  sunday: 0,
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6,
+} as const;
+
+const DURATION_MS = {
+  second: 1000,
+  minute: 60 * 1000,
+  hour: 60 * 60 * 1000,
+  day: 24 * 60 * 60 * 1000,
+  week: 7 * 24 * 60 * 60 * 1000,
+} as const;
+
+function parseLocalTime(value: string): ScheduledLocalTime {
+  const [hour, minute] = value.split(":").map(Number);
+  return { hour: hour!, minute: minute! };
+}
+
+function localDateAt(timestampMs: number, timezone: string): string {
+  const parts = getZonedDateTimeParts(timestampMs, timezone);
+  return [parts.year, parts.month, parts.day]
+    .map((value, index) =>
+      index === 0
+        ? String(value).padStart(4, "0")
+        : String(value).padStart(2, "0"),
+    )
+    .join("-");
+}
+
+function isValidTimeZone(timezone: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: timezone }).format();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function plural(value: number, unit: string): string {
+  return value === 1 ? unit : `${unit}s`;
+}
+
+function formatWeekdays(weekdays: readonly string[]): string {
+  const labels = weekdays.map(
+    (weekday) => `${weekday[0]!.toUpperCase()}${weekday.slice(1)}`,
+  );
+  if (labels.length < 2) {
+    return labels[0] ?? "";
+  }
+  return `${labels.slice(0, -1).join(", ")} and ${labels.at(-1)}`;
+}
+
+function recurringDescription(
+  schedule: z.infer<typeof recurringScheduleIntentSchema>,
+  timezone: string,
+): string {
+  const interval = schedule.interval ?? 1;
+  const cadenceUnit = {
+    daily: "day",
+    weekly: "week",
+    monthly: "month",
+    yearly: "year",
+  }[schedule.frequency];
+  const cadence = interval === 1 ? cadenceUnit : `${interval} ${cadenceUnit}s`;
+  let detail = "";
+  if (schedule.frequency === "weekly") {
+    detail = ` on ${formatWeekdays(schedule.weekdays!)}`;
+  } else if (schedule.frequency === "monthly") {
+    detail = ` on day ${schedule.day_of_month}`;
+  } else if (schedule.frequency === "yearly") {
+    detail = ` on ${String(schedule.month).padStart(2, "0")}-${String(
+      schedule.day_of_month,
+    ).padStart(2, "0")}`;
+  }
+  return `Every ${cadence}${detail} at ${schedule.time} (${timezone})`;
+}
+
+export interface CompiledScheduleIntent {
+  nextRunAtMs: number;
+  schedule: ScheduledTaskSchedule;
+}
+
+export class ScheduleIntentError extends Error {}
+
+/** Materialize model-interpreted schedule intent against the trusted server clock. */
+export function compileScheduleIntent(args: {
+  defaultTimezone: string;
+  intent: ScheduleIntent;
+  nowMs: number;
+}): CompiledScheduleIntent {
+  const timezone = args.intent.timezone ?? args.defaultTimezone;
+  if (!isValidTimeZone(timezone)) {
+    throw new ScheduleIntentError("timezone must be a valid IANA time zone.");
+  }
+
+  if (args.intent.kind === "one_off") {
+    if (args.intent.timing.type === "after") {
+      const nextRunAtMs =
+        args.nowMs +
+        args.intent.timing.value * DURATION_MS[args.intent.timing.unit];
+      return {
+        nextRunAtMs,
+        schedule: {
+          description: `In ${args.intent.timing.value} ${plural(
+            args.intent.timing.value,
+            args.intent.timing.unit,
+          )}`,
+          kind: "one_off",
+          timezone,
+        },
+      };
+    }
+
+    const nextRunAtMs = resolveLocalScheduleAtMs({
+      date: args.intent.timing.date,
+      time: parseLocalTime(args.intent.timing.time),
+      timezone,
+    });
+    if (nextRunAtMs === undefined) {
+      throw new ScheduleIntentError(
+        "The requested local date or time does not exist in that timezone.",
+      );
+    }
+    if (nextRunAtMs <= args.nowMs) {
+      throw new ScheduleIntentError(
+        "The requested one-off schedule must be in the future.",
+      );
+    }
+    return {
+      nextRunAtMs,
+      schedule: {
+        description: `Once on ${args.intent.timing.date} at ${args.intent.timing.time} (${timezone})`,
+        kind: "one_off",
+        timezone,
+      },
+    };
+  }
+
+  const recurrence: ScheduledTaskRecurrence = {
+    frequency: args.intent.frequency,
+    interval: args.intent.interval ?? 1,
+    startDate: args.intent.start_date ?? localDateAt(args.nowMs, timezone),
+    time: parseLocalTime(args.intent.time),
+    ...(args.intent.frequency === "weekly"
+      ? {
+          weekdays: [
+            ...new Set(
+              args.intent.weekdays!.map((weekday) => WEEKDAY_INDEX[weekday]),
+            ),
+          ].sort((left, right) => left - right),
+        }
+      : {}),
+    ...(args.intent.frequency === "monthly" ||
+    args.intent.frequency === "yearly"
+      ? { dayOfMonth: args.intent.day_of_month ?? undefined }
+      : {}),
+    ...(args.intent.frequency === "yearly"
+      ? { month: args.intent.month ?? undefined }
+      : {}),
+  };
+  const searchRecurrence = args.intent.start_date
+    ? recurrence
+    : { ...recurrence, interval: 1 };
+  const nextRunAtMs = getFirstRunAtMs({
+    afterMs: args.nowMs,
+    recurrence: searchRecurrence,
+    timezone,
+  });
+  if (nextRunAtMs === undefined) {
+    throw new ScheduleIntentError(
+      "The recurring schedule has no valid future occurrence.",
+    );
+  }
+  const materializedRecurrence = args.intent.start_date
+    ? recurrence
+    : { ...recurrence, startDate: localDateAt(nextRunAtMs, timezone) };
+  return {
+    nextRunAtMs,
+    schedule: {
+      description: recurringDescription(args.intent, timezone),
+      kind: "recurring",
+      recurrence: materializedRecurrence,
+      timezone,
+    },
+  };
+}

--- a/packages/junior-scheduler/src/store.ts
+++ b/packages/junior-scheduler/src/store.ts
@@ -78,22 +78,8 @@ const taskSpecSchema = z
     text: z.string(),
   })
   .strict();
-const taskMutationSnapshotSchema = z
-  .object({
-    credentialMode: scheduledTaskCredentialModeSchema,
-    lastRunAtMs: z.number().optional(),
-    nextRunAtMs: z.number().optional(),
-    runNowAtMs: z.number().optional(),
-    schedule: taskScheduleSchema,
-    status: z.enum(["active", "paused", "blocked", "deleted"]),
-    statusReason: z.string().optional(),
-    task: taskSpecSchema,
-    updatedAtMs: z.number(),
-  })
-  .strict();
 const taskRecordFields = {
   id: z.string(),
-  creationFingerprint: z.string().optional(),
   conversationAccess: z
     .object({
       audience: z.enum(["direct", "group", "channel"]),
@@ -112,17 +98,6 @@ const taskRecordFields = {
     .strict()
     .optional(),
   lastRunAtMs: z.number().optional(),
-  mutationLedger: z
-    .record(
-      z.string(),
-      z
-        .object({
-          fingerprint: z.string(),
-          result: taskMutationSnapshotSchema,
-        })
-        .strict(),
-    )
-    .optional(),
   nextRunAtMs: z.number().optional(),
   originalRequest: z.string().optional(),
   runNowAtMs: z.number().optional(),
@@ -172,12 +147,6 @@ const runRecordSchema = z
   .strict();
 
 export interface SchedulerStore {
-  applyTaskMutation(args: {
-    fingerprint: string;
-    operationId: string;
-    taskId: string;
-    update: (task: ScheduledTask | undefined) => ScheduledTask;
-  }): Promise<ScheduledTask>;
   claimDueRun(args: { nowMs: number }): Promise<ScheduledRun | undefined>;
   createTask(task: ScheduledTask): Promise<ScheduledTask>;
   getRun(runId: string): Promise<ScheduledRun | undefined>;
@@ -226,22 +195,6 @@ export interface SchedulerStore {
 export interface SchedulerOperationalStore {
   listIncompleteRunsForTasks(tasks: ScheduledTask[]): Promise<ScheduledRun[]>;
   listTasks(): Promise<ScheduledTask[]>;
-}
-
-export class SchedulerOperationConflictError extends Error {}
-
-function taskMutationSnapshot(task: ScheduledTask) {
-  return taskMutationSnapshotSchema.parse({
-    credentialMode: task.credentialMode,
-    lastRunAtMs: task.lastRunAtMs,
-    nextRunAtMs: task.nextRunAtMs,
-    runNowAtMs: task.runNowAtMs,
-    schedule: task.schedule,
-    status: task.status,
-    statusReason: task.statusReason,
-    task: task.task,
-    updatedAtMs: task.updatedAtMs,
-  });
 }
 
 function taskKey(taskId: string): string {
@@ -680,37 +633,6 @@ class PluginStateSchedulerStore implements SchedulerStore {
 
   constructor(state: PluginState) {
     this.state = state;
-  }
-
-  async applyTaskMutation(args: {
-    fingerprint: string;
-    operationId: string;
-    taskId: string;
-    update: (task: ScheduledTask | undefined) => ScheduledTask;
-  }): Promise<ScheduledTask> {
-    return await withLock(this.state, taskLockKey(args.taskId), async () => {
-      const current = await getTaskFromState(this.state, args.taskId);
-      const recorded = current?.mutationLedger?.[args.operationId];
-      if (current && recorded) {
-        if (recorded.fingerprint !== args.fingerprint) {
-          throw new SchedulerOperationConflictError();
-        }
-        return { ...current, ...recorded.result };
-      }
-      const updated = args.update(current);
-      const next = requireStoredTask({
-        ...updated,
-        mutationLedger: {
-          ...current?.mutationLedger,
-          [args.operationId]: {
-            fingerprint: args.fingerprint,
-            result: taskMutationSnapshot(updated),
-          },
-        },
-      });
-      await this.saveTaskRecord(next, current);
-      return next;
-    });
   }
 
   async createTask(task: ScheduledTask): Promise<ScheduledTask> {
@@ -1345,37 +1267,6 @@ async function listIncompleteRunsForTasksFromSql(
 
 class SqlSchedulerStore implements SchedulerStore, SchedulerOperationalStore {
   constructor(private readonly db: SchedulerDb) {}
-
-  async applyTaskMutation(args: {
-    fingerprint: string;
-    operationId: string;
-    taskId: string;
-    update: (task: ScheduledTask | undefined) => ScheduledTask;
-  }): Promise<ScheduledTask> {
-    return await withSqlLock(this.db, taskLockKey(args.taskId), async (db) => {
-      const current = await getTaskFromSql(db, args.taskId);
-      const recorded = current?.mutationLedger?.[args.operationId];
-      if (current && recorded) {
-        if (recorded.fingerprint !== args.fingerprint) {
-          throw new SchedulerOperationConflictError();
-        }
-        return { ...current, ...recorded.result };
-      }
-      const updated = args.update(current);
-      const next = requireStoredTask({
-        ...updated,
-        mutationLedger: {
-          ...current?.mutationLedger,
-          [args.operationId]: {
-            fingerprint: args.fingerprint,
-            result: taskMutationSnapshot(updated),
-          },
-        },
-      });
-      await this.saveTaskRecord(db, next, current);
-      return next;
-    });
-  }
 
   async createTask(task: ScheduledTask): Promise<ScheduledTask> {
     const next = requireStoredTask(task);

--- a/packages/junior-scheduler/src/store.ts
+++ b/packages/junior-scheduler/src/store.ts
@@ -78,8 +78,22 @@ const taskSpecSchema = z
     text: z.string(),
   })
   .strict();
+const taskMutationSnapshotSchema = z
+  .object({
+    credentialMode: scheduledTaskCredentialModeSchema,
+    lastRunAtMs: z.number().optional(),
+    nextRunAtMs: z.number().optional(),
+    runNowAtMs: z.number().optional(),
+    schedule: taskScheduleSchema,
+    status: z.enum(["active", "paused", "blocked", "deleted"]),
+    statusReason: z.string().optional(),
+    task: taskSpecSchema,
+    updatedAtMs: z.number(),
+  })
+  .strict();
 const taskRecordFields = {
   id: z.string(),
+  creationFingerprint: z.string().optional(),
   conversationAccess: z
     .object({
       audience: z.enum(["direct", "group", "channel"]),
@@ -98,6 +112,17 @@ const taskRecordFields = {
     .strict()
     .optional(),
   lastRunAtMs: z.number().optional(),
+  mutationLedger: z
+    .record(
+      z.string(),
+      z
+        .object({
+          fingerprint: z.string(),
+          result: taskMutationSnapshotSchema,
+        })
+        .strict(),
+    )
+    .optional(),
   nextRunAtMs: z.number().optional(),
   originalRequest: z.string().optional(),
   runNowAtMs: z.number().optional(),
@@ -147,7 +172,14 @@ const runRecordSchema = z
   .strict();
 
 export interface SchedulerStore {
+  applyTaskMutation(args: {
+    fingerprint: string;
+    operationId: string;
+    taskId: string;
+    update: (task: ScheduledTask | undefined) => ScheduledTask;
+  }): Promise<ScheduledTask>;
   claimDueRun(args: { nowMs: number }): Promise<ScheduledRun | undefined>;
+  createTask(task: ScheduledTask): Promise<ScheduledTask>;
   getRun(runId: string): Promise<ScheduledRun | undefined>;
   getTask(taskId: string): Promise<ScheduledTask | undefined>;
   listIncompleteRuns(): Promise<ScheduledRun[]>;
@@ -194,6 +226,22 @@ export interface SchedulerStore {
 export interface SchedulerOperationalStore {
   listIncompleteRunsForTasks(tasks: ScheduledTask[]): Promise<ScheduledRun[]>;
   listTasks(): Promise<ScheduledTask[]>;
+}
+
+export class SchedulerOperationConflictError extends Error {}
+
+function taskMutationSnapshot(task: ScheduledTask) {
+  return taskMutationSnapshotSchema.parse({
+    credentialMode: task.credentialMode,
+    lastRunAtMs: task.lastRunAtMs,
+    nextRunAtMs: task.nextRunAtMs,
+    runNowAtMs: task.runNowAtMs,
+    schedule: task.schedule,
+    status: task.status,
+    statusReason: task.statusReason,
+    task: task.task,
+    updatedAtMs: task.updatedAtMs,
+  });
 }
 
 function taskKey(taskId: string): string {
@@ -632,6 +680,49 @@ class PluginStateSchedulerStore implements SchedulerStore {
 
   constructor(state: PluginState) {
     this.state = state;
+  }
+
+  async applyTaskMutation(args: {
+    fingerprint: string;
+    operationId: string;
+    taskId: string;
+    update: (task: ScheduledTask | undefined) => ScheduledTask;
+  }): Promise<ScheduledTask> {
+    return await withLock(this.state, taskLockKey(args.taskId), async () => {
+      const current = await getTaskFromState(this.state, args.taskId);
+      const recorded = current?.mutationLedger?.[args.operationId];
+      if (current && recorded) {
+        if (recorded.fingerprint !== args.fingerprint) {
+          throw new SchedulerOperationConflictError();
+        }
+        return { ...current, ...recorded.result };
+      }
+      const updated = args.update(current);
+      const next = requireStoredTask({
+        ...updated,
+        mutationLedger: {
+          ...current?.mutationLedger,
+          [args.operationId]: {
+            fingerprint: args.fingerprint,
+            result: taskMutationSnapshot(updated),
+          },
+        },
+      });
+      await this.saveTaskRecord(next, current);
+      return next;
+    });
+  }
+
+  async createTask(task: ScheduledTask): Promise<ScheduledTask> {
+    const next = requireStoredTask(task);
+    return await withLock(this.state, taskLockKey(task.id), async () => {
+      const current = await getTaskFromState(this.state, task.id);
+      if (current) {
+        return current;
+      }
+      await this.saveTaskRecord(next, undefined);
+      return next;
+    });
   }
 
   async saveTask(task: ScheduledTask): Promise<void> {
@@ -1254,6 +1345,49 @@ async function listIncompleteRunsForTasksFromSql(
 
 class SqlSchedulerStore implements SchedulerStore, SchedulerOperationalStore {
   constructor(private readonly db: SchedulerDb) {}
+
+  async applyTaskMutation(args: {
+    fingerprint: string;
+    operationId: string;
+    taskId: string;
+    update: (task: ScheduledTask | undefined) => ScheduledTask;
+  }): Promise<ScheduledTask> {
+    return await withSqlLock(this.db, taskLockKey(args.taskId), async (db) => {
+      const current = await getTaskFromSql(db, args.taskId);
+      const recorded = current?.mutationLedger?.[args.operationId];
+      if (current && recorded) {
+        if (recorded.fingerprint !== args.fingerprint) {
+          throw new SchedulerOperationConflictError();
+        }
+        return { ...current, ...recorded.result };
+      }
+      const updated = args.update(current);
+      const next = requireStoredTask({
+        ...updated,
+        mutationLedger: {
+          ...current?.mutationLedger,
+          [args.operationId]: {
+            fingerprint: args.fingerprint,
+            result: taskMutationSnapshot(updated),
+          },
+        },
+      });
+      await this.saveTaskRecord(db, next, current);
+      return next;
+    });
+  }
+
+  async createTask(task: ScheduledTask): Promise<ScheduledTask> {
+    const next = requireStoredTask(task);
+    return await withSqlLock(this.db, taskLockKey(task.id), async (db) => {
+      const current = await getTaskFromSql(db, task.id);
+      if (current) {
+        return current;
+      }
+      await this.saveTaskRecord(db, next, undefined);
+      return next;
+    });
+  }
 
   async saveTask(task: ScheduledTask): Promise<void> {
     const next = requireStoredTask(task);

--- a/packages/junior-scheduler/src/tool-support.ts
+++ b/packages/junior-scheduler/src/tool-support.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash } from "node:crypto";
 import {
   PluginToolInputError,
   pluginToolResultSchema,
@@ -8,20 +8,18 @@ import {
   type SlackSource,
 } from "@sentry/junior-plugin-api";
 import { z } from "zod";
-import { buildCalendarRecurrence, parseScheduleTimestamp } from "./cadence";
 import { sanitizeScheduledTaskPrincipal } from "./identity";
 import { type SchedulerStore } from "./store";
 import type {
-  ScheduledCalendarFrequency,
   ScheduledTask,
   ScheduledTaskConversationAccess,
   ScheduledTaskPrincipal,
-  ScheduledTaskRecurrence,
   ScheduledTaskStatus,
 } from "./types";
 
 export interface SchedulerToolContext {
   actor?: SlackActor;
+  now?: () => number;
   source?: SlackSource;
   store: SchedulerStore;
   userText?: string;
@@ -30,6 +28,37 @@ export interface SchedulerToolContext {
 const TASK_ID_PREFIX = "sched";
 export const MAX_LISTED_TASKS = 50;
 const DEFAULT_SCHEDULE_TIMEZONE = "America/Los_Angeles";
+
+function canonicalFingerprintValue(value: unknown, key?: string): unknown {
+  if (value == null) {
+    return undefined;
+  }
+  if (Array.isArray(value)) {
+    const items = value.map((item) => canonicalFingerprintValue(item));
+    return key === "weekdays"
+      ? [...new Set(items)].sort((left, right) =>
+          String(left).localeCompare(String(right)),
+        )
+      : items;
+  }
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .flatMap(([childKey, childValue]) => {
+          const canonical = canonicalFingerprintValue(childValue, childKey);
+          return canonical === undefined ? [] : [[childKey, canonical]];
+        }),
+    );
+  }
+  return value;
+}
+
+function fingerprint(value: unknown): string {
+  return createHash("sha256")
+    .update(JSON.stringify(canonicalFingerprintValue(value)))
+    .digest("hex");
+}
 
 const compactTaskResultSchema = z
   .object({
@@ -277,9 +306,63 @@ export function scheduleListToolResult(args: {
   } as const;
 }
 
-/** Prefix generated scheduler ids so tool results are distinguishable from provider ids. */
-export function buildTaskId(): string {
-  return `${TASK_ID_PREFIX}_${randomUUID()}`;
+/** Build a retry-stable scheduler id scoped to the creating actor and destination. */
+export function buildTaskId(args: {
+  actor: ScheduledTaskPrincipal;
+  destination: SlackDestination;
+  toolCallId: string | undefined;
+}): string {
+  const toolCallId = args.toolCallId?.trim();
+  if (!toolCallId) {
+    throw new Error("Scheduler task creation requires a tool-call identity.");
+  }
+  const digest = createHash("sha256")
+    .update(
+      JSON.stringify({
+        actor: args.actor.slackUserId,
+        channel: args.destination.channelId,
+        operation: toolCallId,
+        platform: args.destination.platform,
+        team: args.destination.teamId,
+      }),
+    )
+    .digest("hex")
+    .slice(0, 32);
+  return `${TASK_ID_PREFIX}_${digest}`;
+}
+
+/** Fingerprint canonical create arguments so an operation id cannot change meaning. */
+export function buildTaskCreationFingerprint(input: unknown): string {
+  return fingerprint(input);
+}
+
+/** Bind a retryable task mutation to its task, tool call, and canonical input. */
+export function buildTaskMutationIdentity(args: {
+  actor: ScheduledTaskPrincipal;
+  destination: SlackDestination;
+  input: unknown;
+  taskId: string;
+  toolCallId: string | undefined;
+}): { fingerprint: string; operationId: string } {
+  const toolCallId = args.toolCallId?.trim();
+  if (!toolCallId) {
+    throw new Error("Scheduler task updates require a tool-call identity.");
+  }
+  return {
+    fingerprint: fingerprint(args.input),
+    operationId: createHash("sha256")
+      .update(
+        JSON.stringify({
+          actor: args.actor.slackUserId,
+          channel: args.destination.channelId,
+          operation: toolCallId,
+          platform: args.destination.platform,
+          task: args.taskId,
+          team: args.destination.teamId,
+        }),
+      )
+      .digest("hex"),
+  };
 }
 
 /** Keep concrete scheduler tools coupled to the injected store, not global state. */
@@ -297,143 +380,7 @@ export function normalizeStatus(
   return undefined;
 }
 
-function normalizeFrequency(
-  value: unknown,
-): ScheduledCalendarFrequency | undefined {
-  if (
-    value === "daily" ||
-    value === "weekly" ||
-    value === "monthly" ||
-    value === "yearly"
-  ) {
-    return value;
-  }
-  return undefined;
-}
-
-/** Rebuild recurrence only from validated daily-or-slower schedule requests. */
-export function buildRecurrence(args: {
-  existing?: ScheduledTaskRecurrence;
-  input: {
-    recurrence?: unknown;
-  };
-  nextRunAtMs: number | undefined;
-  timezone: string;
-}): ScheduledTaskRecurrence | undefined {
-  if (args.input.recurrence === null) {
-    return undefined;
-  }
-
-  const frequency =
-    normalizeFrequency(args.input.recurrence) ?? args.existing?.frequency;
-  if (!frequency) {
-    return undefined;
-  }
-  if (!args.nextRunAtMs) {
-    throwToolInputError("Recurring scheduled tasks require next_run_at.");
-  }
-
-  try {
-    return buildCalendarRecurrence({
-      frequency,
-      interval: args.existing?.interval,
-      nextRunAtMs: args.nextRunAtMs,
-      timezone: args.timezone,
-      weekdays: frequency === "weekly" ? args.existing?.weekdays : undefined,
-    });
-  } catch (error) {
-    throwToolInputError(
-      error instanceof RangeError
-        ? "timezone must be a valid IANA time zone."
-        : error instanceof Error
-          ? error.message
-          : String(error),
-    );
-  }
-}
-
-/** Reject recurrence values that would exceed the scheduler cadence policy. */
-export function validateRecurringFrequencyLimit(input: {
-  recurrence?: unknown;
-}) {
-  if (
-    input.recurrence !== undefined &&
-    input.recurrence !== null &&
-    !normalizeFrequency(input.recurrence)
-  ) {
-    throwToolInputError(
-      "Recurring scheduled tasks can run at most once per day.",
-    );
-  }
-}
-
-/** Force create-tool callers to explicitly choose one-off versus recurring semantics. */
-export function validateCreateScheduleKind(input: {
-  recurrence?: unknown;
-  schedule_kind?: unknown;
-}) {
-  if (input.schedule_kind === undefined) {
-    throwToolInputError("Provide schedule_kind as one_off or recurring.");
-  }
-  if (
-    input.schedule_kind !== "one_off" &&
-    input.schedule_kind !== "recurring"
-  ) {
-    throwToolInputError("schedule_kind must be one_off or recurring.");
-  }
-  if (
-    input.schedule_kind === "one_off" &&
-    input.recurrence !== undefined &&
-    input.recurrence !== null
-  ) {
-    throwToolInputError("Omit recurrence when schedule_kind is one_off.");
-  }
-  if (
-    input.schedule_kind === "recurring" &&
-    (input.recurrence === undefined || input.recurrence === null)
-  ) {
-    throwToolInputError("Provide recurrence when schedule_kind is recurring.");
-  }
-}
-
-/** Detect update inputs that affect calendar recurrence materialization. */
-export function shouldRebuildRecurrence(input: {
-  next_run_at?: string;
-  recurrence?: unknown;
-  timezone?: string;
-}): boolean {
-  return (
-    input.next_run_at !== undefined ||
-    input.recurrence !== undefined ||
-    input.timezone !== undefined
-  );
-}
-
 /** Centralize scheduler timezone defaulting for all concrete tool entry points. */
 export function getDefaultScheduleTimezone(): string {
   return process.env.JUNIOR_TIMEZONE?.trim() || DEFAULT_SCHEDULE_TIMEZONE;
-}
-
-/** Validate IANA timezone names before persisting scheduler cadence state. */
-export function isValidTimeZone(timezone: string): boolean {
-  try {
-    new Intl.DateTimeFormat("en-US", { timeZone: timezone }).format();
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/** Parse model-supplied timestamps without leaking date parser details to tools. */
-export function parseNextRunAtMs(
-  nextRunAtIso: string | undefined,
-): number | undefined {
-  try {
-    if (nextRunAtIso) {
-      return parseScheduleTimestamp(nextRunAtIso);
-    }
-  } catch {
-    return undefined;
-  }
-  return undefined;
 }

--- a/packages/junior-scheduler/src/tool-support.ts
+++ b/packages/junior-scheduler/src/tool-support.ts
@@ -29,37 +29,6 @@ const TASK_ID_PREFIX = "sched";
 export const MAX_LISTED_TASKS = 50;
 const DEFAULT_SCHEDULE_TIMEZONE = "America/Los_Angeles";
 
-function canonicalFingerprintValue(value: unknown, key?: string): unknown {
-  if (value == null) {
-    return undefined;
-  }
-  if (Array.isArray(value)) {
-    const items = value.map((item) => canonicalFingerprintValue(item));
-    return key === "weekdays"
-      ? [...new Set(items)].sort((left, right) =>
-          String(left).localeCompare(String(right)),
-        )
-      : items;
-  }
-  if (typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value)
-        .sort(([left], [right]) => left.localeCompare(right))
-        .flatMap(([childKey, childValue]) => {
-          const canonical = canonicalFingerprintValue(childValue, childKey);
-          return canonical === undefined ? [] : [[childKey, canonical]];
-        }),
-    );
-  }
-  return value;
-}
-
-function fingerprint(value: unknown): string {
-  return createHash("sha256")
-    .update(JSON.stringify(canonicalFingerprintValue(value)))
-    .digest("hex");
-}
-
 const compactTaskResultSchema = z
   .object({
     id: z.string(),
@@ -329,40 +298,6 @@ export function buildTaskId(args: {
     .digest("hex")
     .slice(0, 32);
   return `${TASK_ID_PREFIX}_${digest}`;
-}
-
-/** Fingerprint canonical create arguments so an operation id cannot change meaning. */
-export function buildTaskCreationFingerprint(input: unknown): string {
-  return fingerprint(input);
-}
-
-/** Bind a retryable task mutation to its task, tool call, and canonical input. */
-export function buildTaskMutationIdentity(args: {
-  actor: ScheduledTaskPrincipal;
-  destination: SlackDestination;
-  input: unknown;
-  taskId: string;
-  toolCallId: string | undefined;
-}): { fingerprint: string; operationId: string } {
-  const toolCallId = args.toolCallId?.trim();
-  if (!toolCallId) {
-    throw new Error("Scheduler task updates require a tool-call identity.");
-  }
-  return {
-    fingerprint: fingerprint(args.input),
-    operationId: createHash("sha256")
-      .update(
-        JSON.stringify({
-          actor: args.actor.slackUserId,
-          channel: args.destination.channelId,
-          operation: toolCallId,
-          platform: args.destination.platform,
-          task: args.taskId,
-          team: args.destination.teamId,
-        }),
-      )
-      .digest("hex"),
-  };
 }
 
 /** Keep concrete scheduler tools coupled to the injected store, not global state. */

--- a/packages/junior-scheduler/src/tools/create-task.ts
+++ b/packages/junior-scheduler/src/tools/create-task.ts
@@ -1,23 +1,25 @@
 import { definePluginTool } from "@sentry/junior-plugin-api";
 import { z } from "zod";
+import {
+  compileScheduleIntent,
+  ScheduleIntentError,
+  scheduleIntentSchema,
+} from "../schedule-intent";
 import { SCHEDULED_TASK_SYSTEM_ACTOR } from "../types";
 import type { ScheduledTask } from "../types";
 import {
-  buildRecurrence,
   buildTaskId,
+  buildTaskCreationFingerprint,
   compactTask,
   getConversationAccess,
   getDefaultScheduleTimezone,
-  isValidTimeZone,
-  parseNextRunAtMs,
   requireActiveConversation,
   requireActor,
+  sameDestination,
   scheduleTaskToolResult,
   scheduleTaskToolResultSchema,
   schedulerStore,
   throwToolInputError,
-  validateCreateScheduleKind,
-  validateRecurringFrequencyLimit,
   type SchedulerToolContext,
 } from "../tool-support";
 
@@ -27,74 +29,72 @@ export function createSlackScheduleCreateTaskTool(
 ) {
   return definePluginTool({
     description:
-      "Create a one-time or recurring Junior task in the active Slack conversation. For one-time reminders or one-time scheduled work, omit recurrence entirely; never choose a default recurrence. Use only when the user explicitly asks Junior to do work later or on a recurring cadence. Do not create scheduled polling tasks to watch provider resources when a subscribable tool result can deliver the requested events. Only manage tasks for the active Slack DM or channel; never target threads, other channels, or another user's DM. Set credential_mode to creator only when the current user explicitly authorizes future scheduled use of their connected credentials. If connected-credential use is needed but authorization is ambiguous, ask before creating the task. Otherwise omit credential_mode and use system credentials. When the task, schedule, destination, and credential mode are clear, create it without another confirmation.",
+      "Create a one-time or recurring Junior task in the active Slack conversation when the user asks Junior to do work later or repeatedly.",
     executionMode: "sequential",
-    inputSchema: z.object({
-      task: z.string().min(1).max(4000),
-      schedule: z.string().min(1).max(300),
-      schedule_kind: z
-        .enum(["one_off", "recurring"])
-        .describe(
-          "Required schedule classification. Use one_off for one-time reminders or one-time scheduled work. Use recurring only when the user explicitly asks for a repeating schedule.",
+    inputSchema: z
+      .object({
+        task: z.string().min(1).max(4000),
+        schedule: scheduleIntentSchema.describe(
+          "When the task runs. The scheduler computes the exact next run from this intent and the server clock.",
         ),
-      timezone: z
-        .string()
-        .min(1)
-        .max(80)
-        .describe(
-          "IANA timezone, e.g. 'America/Los_Angeles'. Defaults to the channel's configured timezone.",
-        )
-        .optional(),
-      next_run_at: z
-        .string()
-        .min(1)
-        .describe(
-          "Exact next run time as an ISO timestamp, computed from the user's requested schedule.",
-        )
-        .optional(),
-      recurrence: z
-        .enum(["daily", "weekly", "monthly", "yearly"])
-        .nullable()
-        .describe(
-          "Required when schedule_kind is recurring. Omit when schedule_kind is one_off. Recurring tasks run at most once per day: use daily, weekly, monthly, or yearly only.",
-        )
-        .optional(),
-      credential_mode: z
-        .enum(["system", "creator"])
-        .nullable()
-        .describe(
-          "Use creator only when the current user explicitly authorizes future scheduled use of their connected credentials. Omit or use system otherwise.",
-        )
-        .optional(),
-    }),
+        credential_mode: z
+          .enum(["system", "creator"])
+          .nullable()
+          .describe(
+            "Use creator only when the current user explicitly authorizes future scheduled use of their connected credentials. Omit or use system otherwise.",
+          )
+          .optional(),
+      })
+      .strict(),
     outputSchema: scheduleTaskToolResultSchema,
-    execute: async (input) => {
+    execute: async (input, options) => {
       const destination = requireActiveConversation(context);
       const actor = requireActor(context, destination);
-
-      const nowMs = Date.now();
-      const timezone = input.timezone ?? getDefaultScheduleTimezone();
-      validateCreateScheduleKind(input);
-      validateRecurringFrequencyLimit(input);
-      if (!isValidTimeZone(timezone)) {
-        throwToolInputError("timezone must be a valid IANA time zone.");
-      }
-      const nextRunAtMs = parseNextRunAtMs(input.next_run_at);
-      if (!nextRunAtMs) {
-        throwToolInputError("Provide next_run_at as a valid ISO timestamp.");
-      }
-      const recurrence = buildRecurrence({
-        input,
-        nextRunAtMs,
-        timezone,
+      const store = schedulerStore(context);
+      const id = buildTaskId({
+        actor,
+        destination,
+        toolCallId: options.toolCallId,
       });
+      const creationFingerprint = buildTaskCreationFingerprint(input);
+      // Replaying a durable tool call returns its original task instead of duplicating it.
+      const existing = await store.getTask(id);
+      if (existing) {
+        if (
+          !sameDestination(existing, destination) ||
+          existing.createdBy.slackUserId !== actor.slackUserId ||
+          existing.creationFingerprint !== creationFingerprint
+        ) {
+          throwToolInputError("Scheduled task operation identity is invalid.");
+        }
+        return scheduleTaskToolResult(
+          "slackScheduleCreateTask",
+          compactTask(existing),
+        );
+      }
+
+      const nowMs = context.now?.() ?? Date.now();
+      let compiled;
+      try {
+        compiled = compileScheduleIntent({
+          defaultTimezone: getDefaultScheduleTimezone(),
+          intent: input.schedule,
+          nowMs,
+        });
+      } catch (error) {
+        if (error instanceof ScheduleIntentError) {
+          throwToolInputError(error.message);
+        }
+        throw error;
+      }
       const conversationAccess = getConversationAccess(
         destination,
         context.source,
       );
 
       const task: ScheduledTask = {
-        id: buildTaskId(),
+        id,
+        creationFingerprint,
         createdAtMs: nowMs,
         updatedAtMs: nowMs,
         createdBy: actor,
@@ -102,24 +102,26 @@ export function createSlackScheduleCreateTaskTool(
         credentialMode: input.credential_mode ?? "system",
         destination,
         executionActor: SCHEDULED_TASK_SYSTEM_ACTOR,
-        nextRunAtMs,
+        nextRunAtMs: compiled.nextRunAtMs,
         originalRequest: context.userText,
-        schedule: {
-          description: input.schedule,
-          timezone,
-          kind: recurrence ? "recurring" : "one_off",
-          recurrence,
-        },
+        schedule: compiled.schedule,
         status: "active",
         task: {
           text: input.task,
         },
       };
 
-      await schedulerStore(context).saveTask(task);
+      const committed = await store.createTask(task);
+      if (
+        !sameDestination(committed, destination) ||
+        committed.createdBy.slackUserId !== actor.slackUserId ||
+        committed.creationFingerprint !== creationFingerprint
+      ) {
+        throwToolInputError("Scheduled task operation identity is invalid.");
+      }
       return scheduleTaskToolResult(
         "slackScheduleCreateTask",
-        compactTask(task),
+        compactTask(committed),
       );
     },
   });

--- a/packages/junior-scheduler/src/tools/create-task.ts
+++ b/packages/junior-scheduler/src/tools/create-task.ts
@@ -9,7 +9,6 @@ import { SCHEDULED_TASK_SYSTEM_ACTOR } from "../types";
 import type { ScheduledTask } from "../types";
 import {
   buildTaskId,
-  buildTaskCreationFingerprint,
   compactTask,
   getConversationAccess,
   getDefaultScheduleTimezone,
@@ -56,14 +55,12 @@ export function createSlackScheduleCreateTaskTool(
         destination,
         toolCallId: options.toolCallId,
       });
-      const creationFingerprint = buildTaskCreationFingerprint(input);
       // Replaying a durable tool call returns its original task instead of duplicating it.
       const existing = await store.getTask(id);
       if (existing) {
         if (
           !sameDestination(existing, destination) ||
-          existing.createdBy.slackUserId !== actor.slackUserId ||
-          existing.creationFingerprint !== creationFingerprint
+          existing.createdBy.slackUserId !== actor.slackUserId
         ) {
           throwToolInputError("Scheduled task operation identity is invalid.");
         }
@@ -94,7 +91,6 @@ export function createSlackScheduleCreateTaskTool(
 
       const task: ScheduledTask = {
         id,
-        creationFingerprint,
         createdAtMs: nowMs,
         updatedAtMs: nowMs,
         createdBy: actor,
@@ -114,8 +110,7 @@ export function createSlackScheduleCreateTaskTool(
       const committed = await store.createTask(task);
       if (
         !sameDestination(committed, destination) ||
-        committed.createdBy.slackUserId !== actor.slackUserId ||
-        committed.creationFingerprint !== creationFingerprint
+        committed.createdBy.slackUserId !== actor.slackUserId
       ) {
         throwToolInputError("Scheduled task operation identity is invalid.");
       }

--- a/packages/junior-scheduler/src/tools/update-task.ts
+++ b/packages/junior-scheduler/src/tools/update-task.ts
@@ -6,15 +6,12 @@ import {
   scheduleIntentSchema,
 } from "../schedule-intent";
 import type { ScheduledTask } from "../types";
-import { SchedulerOperationConflictError } from "../store";
 import {
-  buildTaskMutationIdentity,
   compactTask,
   getDefaultScheduleTimezone,
+  getWritableTask,
   normalizeStatus,
-  requireActiveConversation,
   requireActor,
-  sameDestination,
   scheduleTaskToolResult,
   scheduleTaskToolResultSchema,
   schedulerStore,
@@ -61,99 +58,74 @@ export function createSlackScheduleUpdateTaskTool(
       })
       .strict(),
     outputSchema: scheduleTaskToolResultSchema,
-    execute: async (input, options) => {
-      const destination = requireActiveConversation(context);
-      const actor = requireActor(context, destination);
-      const mutation = buildTaskMutationIdentity({
-        actor,
-        destination,
-        input,
+    execute: async (input) => {
+      const lookup = await getWritableTask({
+        context,
         taskId: input.task_id,
-        toolCallId: options.toolCallId,
       });
-      const nowMs = context.now?.() ?? Date.now();
-      let committed: ScheduledTask;
-      try {
-        committed = await schedulerStore(context).applyTaskMutation({
-          ...mutation,
-          taskId: input.task_id,
-          update: (lookup) => {
-            if (!lookup || lookup.status === "deleted") {
-              throwToolInputError(
-                "Scheduled task was not found in the active Slack conversation.",
-              );
-            }
-            if (!sameDestination(lookup, destination)) {
-              throwToolInputError(
-                "Scheduled task can only be managed from the Slack destination where it was created.",
-              );
-            }
-            const isCreator =
-              actor.slackUserId === lookup.createdBy.slackUserId;
-            if (input.credential_mode === "creator" && !isCreator) {
-              throwToolInputError(
-                "Only the scheduled task creator can enable creator credential use.",
-              );
-            }
-
-            const compiled = input.schedule
-              ? compileScheduleIntent({
-                  defaultTimezone:
-                    lookup.schedule.timezone || getDefaultScheduleTimezone(),
-                  intent: input.schedule,
-                  nowMs,
-                })
-              : undefined;
-            const nextRunAtMs = compiled?.nextRunAtMs ?? lookup.nextRunAtMs;
-
-            const status = normalizeStatus(input.status);
-            if (input.status && !status) {
-              throwToolInputError("status must be active, paused, or blocked.");
-            }
-            if (status === "active" && !nextRunAtMs) {
-              throwToolInputError(
-                "Active scheduled tasks require a schedule with a future occurrence.",
-              );
-            }
-            const nextStatus = status ?? lookup.status;
-            // Another actor changing executable text revokes creator delegation.
-            const credentialMode =
-              input.task !== undefined &&
-              input.task !== lookup.task.text &&
-              !isCreator
-                ? "system"
-                : (input.credential_mode ?? lookup.credentialMode);
-
-            return {
-              ...lookup,
-              credentialMode,
-              updatedAtMs: nowMs,
-              nextRunAtMs,
-              runNowAtMs:
-                nextStatus === "active" && !compiled
-                  ? lookup.runNowAtMs
-                  : undefined,
-              status: nextStatus,
-              statusReason:
-                nextStatus === "blocked" ? lookup.statusReason : undefined,
-              schedule: compiled?.schedule ?? lookup.schedule,
-              task: input.task ? { text: input.task } : lookup.task,
-            };
-          },
-        });
-      } catch (error) {
-        if (error instanceof ScheduleIntentError) {
-          throwToolInputError(error.message);
-        }
-        if (error instanceof SchedulerOperationConflictError) {
-          throwToolInputError("Scheduled task operation identity is invalid.");
-        }
-        throw error;
+      const actor = requireActor(context, lookup.destination);
+      const isCreator = actor.slackUserId === lookup.createdBy.slackUserId;
+      if (input.credential_mode === "creator" && !isCreator) {
+        throwToolInputError(
+          "Only the scheduled task creator can enable creator credential use.",
+        );
       }
 
+      const nowMs = context.now?.() ?? Date.now();
+      let compiled;
+      if (input.schedule) {
+        try {
+          compiled = compileScheduleIntent({
+            defaultTimezone:
+              lookup.schedule.timezone || getDefaultScheduleTimezone(),
+            intent: input.schedule,
+            nowMs,
+          });
+        } catch (error) {
+          if (error instanceof ScheduleIntentError) {
+            throwToolInputError(error.message);
+          }
+          throw error;
+        }
+      }
+      const nextRunAtMs = compiled?.nextRunAtMs ?? lookup.nextRunAtMs;
+
+      const status = normalizeStatus(input.status);
+      if (input.status && !status) {
+        throwToolInputError("status must be active, paused, or blocked.");
+      }
+      if (status === "active" && !nextRunAtMs) {
+        throwToolInputError(
+          "Active scheduled tasks require a schedule with a future occurrence.",
+        );
+      }
+      const nextStatus = status ?? lookup.status;
+      // Another actor changing executable text revokes creator delegation.
+      const credentialMode =
+        input.task !== undefined &&
+        input.task !== lookup.task.text &&
+        !isCreator
+          ? "system"
+          : (input.credential_mode ?? lookup.credentialMode);
+
+      const next: ScheduledTask = {
+        ...lookup,
+        credentialMode,
+        updatedAtMs: nowMs,
+        nextRunAtMs,
+        runNowAtMs:
+          nextStatus === "active" && !compiled ? lookup.runNowAtMs : undefined,
+        status: nextStatus,
+        statusReason:
+          nextStatus === "blocked" ? lookup.statusReason : undefined,
+        schedule: compiled?.schedule ?? lookup.schedule,
+        task: input.task ? { text: input.task } : lookup.task,
+      };
+
+      await schedulerStore(context).saveTask(next);
       return scheduleTaskToolResult(
         "slackScheduleUpdateTask",
-        compactTask(committed),
+        compactTask(next),
       );
     },
   });

--- a/packages/junior-scheduler/src/tools/update-task.ts
+++ b/packages/junior-scheduler/src/tools/update-task.ts
@@ -1,20 +1,24 @@
 import { definePluginTool } from "@sentry/junior-plugin-api";
 import { z } from "zod";
-import type { ScheduledTask } from "../types";
 import {
-  buildRecurrence,
+  compileScheduleIntent,
+  ScheduleIntentError,
+  scheduleIntentSchema,
+} from "../schedule-intent";
+import type { ScheduledTask } from "../types";
+import { SchedulerOperationConflictError } from "../store";
+import {
+  buildTaskMutationIdentity,
   compactTask,
-  getWritableTask,
-  isValidTimeZone,
+  getDefaultScheduleTimezone,
   normalizeStatus,
-  parseNextRunAtMs,
+  requireActiveConversation,
   requireActor,
+  sameDestination,
   scheduleTaskToolResult,
   scheduleTaskToolResultSchema,
   schedulerStore,
-  shouldRebuildRecurrence,
   throwToolInputError,
-  validateRecurringFrequencyLimit,
   type SchedulerToolContext,
 } from "../tool-support";
 
@@ -24,120 +28,132 @@ export function createSlackScheduleUpdateTaskTool(
 ) {
   return definePluginTool({
     description:
-      "Edit, pause, resume, reschedule, or change credential use for an existing Junior scheduled task in the active Slack conversation. Use only task IDs returned for this conversation. Do not move scheduled tasks across conversations. Set credential_mode to creator only when the task creator explicitly authorizes future scheduled use of their connected credentials. If creator credential use is requested but authorization is ambiguous, ask before enabling it. If another user changes the executable task text, creator credential use is cleared automatically.",
+      "Edit, pause, resume, reschedule, or change credential use for an existing Junior scheduled task in the active Slack conversation.",
     executionMode: "sequential",
-    inputSchema: z.object({
-      task_id: z
-        .string()
-        .min(1)
-        .describe(
-          "ID of the task to update. Must be from this active Slack conversation.",
-        ),
-      task: z.string().min(1).max(4000).optional(),
-      schedule: z.string().min(1).max(300).optional(),
-      timezone: z.string().min(1).max(80).optional(),
-      next_run_at: z
-        .string()
-        .min(1)
-        .describe("Exact ISO timestamp when changing the next run time.")
-        .optional(),
-      recurrence: z
-        .enum(["daily", "weekly", "monthly", "yearly"])
-        .nullable()
-        .describe(
-          "Provide only for repeating schedules. Omit for one-time requests. Set to null to convert a recurring task to one-time.",
-        )
-        .optional(),
-      status: z
-        .enum(["active", "paused", "blocked"])
-        .describe(
-          "Set to active, paused, or blocked to resume, pause, or block the task.",
-        )
-        .optional(),
-      credential_mode: z
-        .enum(["system", "creator"])
-        .nullable()
-        .describe(
-          "Set creator only when the current actor is the task creator and explicitly authorizes future scheduled credential use. Set system to disable delegation.",
-        )
-        .optional(),
-    }),
+    inputSchema: z
+      .object({
+        task_id: z
+          .string()
+          .min(1)
+          .describe(
+            "ID of the task to update. Must be from this active Slack conversation.",
+          ),
+        task: z.string().min(1).max(4000).optional(),
+        schedule: scheduleIntentSchema
+          .describe(
+            "Complete replacement schedule when rescheduling. Omit for task, status, or credential-only changes; the scheduler computes the next run.",
+          )
+          .nullable()
+          .optional(),
+        status: z
+          .enum(["active", "paused", "blocked"])
+          .describe(
+            "Set to active, paused, or blocked to resume, pause, or block the task.",
+          )
+          .optional(),
+        credential_mode: z
+          .enum(["system", "creator"])
+          .nullable()
+          .describe(
+            "Set creator only when the current actor is the task creator and explicitly authorizes future scheduled credential use. Set system to disable delegation.",
+          )
+          .optional(),
+      })
+      .strict(),
     outputSchema: scheduleTaskToolResultSchema,
-    execute: async (input) => {
-      const lookup = await getWritableTask({
-        context,
+    execute: async (input, options) => {
+      const destination = requireActiveConversation(context);
+      const actor = requireActor(context, destination);
+      const mutation = buildTaskMutationIdentity({
+        actor,
+        destination,
+        input,
         taskId: input.task_id,
+        toolCallId: options.toolCallId,
       });
-      const actor = requireActor(context, lookup.destination);
-      const isCreator = actor.slackUserId === lookup.createdBy.slackUserId;
-      if (input.credential_mode === "creator" && !isCreator) {
-        throwToolInputError(
-          "Only the scheduled task creator can enable creator credential use.",
-        );
+      const nowMs = context.now?.() ?? Date.now();
+      let committed: ScheduledTask;
+      try {
+        committed = await schedulerStore(context).applyTaskMutation({
+          ...mutation,
+          taskId: input.task_id,
+          update: (lookup) => {
+            if (!lookup || lookup.status === "deleted") {
+              throwToolInputError(
+                "Scheduled task was not found in the active Slack conversation.",
+              );
+            }
+            if (!sameDestination(lookup, destination)) {
+              throwToolInputError(
+                "Scheduled task can only be managed from the Slack destination where it was created.",
+              );
+            }
+            const isCreator =
+              actor.slackUserId === lookup.createdBy.slackUserId;
+            if (input.credential_mode === "creator" && !isCreator) {
+              throwToolInputError(
+                "Only the scheduled task creator can enable creator credential use.",
+              );
+            }
+
+            const compiled = input.schedule
+              ? compileScheduleIntent({
+                  defaultTimezone:
+                    lookup.schedule.timezone || getDefaultScheduleTimezone(),
+                  intent: input.schedule,
+                  nowMs,
+                })
+              : undefined;
+            const nextRunAtMs = compiled?.nextRunAtMs ?? lookup.nextRunAtMs;
+
+            const status = normalizeStatus(input.status);
+            if (input.status && !status) {
+              throwToolInputError("status must be active, paused, or blocked.");
+            }
+            if (status === "active" && !nextRunAtMs) {
+              throwToolInputError(
+                "Active scheduled tasks require a schedule with a future occurrence.",
+              );
+            }
+            const nextStatus = status ?? lookup.status;
+            // Another actor changing executable text revokes creator delegation.
+            const credentialMode =
+              input.task !== undefined &&
+              input.task !== lookup.task.text &&
+              !isCreator
+                ? "system"
+                : (input.credential_mode ?? lookup.credentialMode);
+
+            return {
+              ...lookup,
+              credentialMode,
+              updatedAtMs: nowMs,
+              nextRunAtMs,
+              runNowAtMs:
+                nextStatus === "active" && !compiled
+                  ? lookup.runNowAtMs
+                  : undefined,
+              status: nextStatus,
+              statusReason:
+                nextStatus === "blocked" ? lookup.statusReason : undefined,
+              schedule: compiled?.schedule ?? lookup.schedule,
+              task: input.task ? { text: input.task } : lookup.task,
+            };
+          },
+        });
+      } catch (error) {
+        if (error instanceof ScheduleIntentError) {
+          throwToolInputError(error.message);
+        }
+        if (error instanceof SchedulerOperationConflictError) {
+          throwToolInputError("Scheduled task operation identity is invalid.");
+        }
+        throw error;
       }
 
-      const timezone = input.timezone ?? lookup.schedule.timezone;
-      validateRecurringFrequencyLimit(input);
-      if (!isValidTimeZone(timezone)) {
-        throwToolInputError("timezone must be a valid IANA time zone.");
-      }
-      const parsedNextRunAtMs = parseNextRunAtMs(input.next_run_at);
-      const nextRunAtMs = input.next_run_at
-        ? parsedNextRunAtMs
-        : lookup.nextRunAtMs;
-      if (input.next_run_at && !nextRunAtMs) {
-        throwToolInputError("Provide next_run_at as a valid ISO timestamp.");
-      }
-
-      const status = normalizeStatus(input.status);
-      if (input.status && !status) {
-        throwToolInputError("status must be active, paused, or blocked.");
-      }
-      if (status === "active" && !nextRunAtMs) {
-        throwToolInputError(
-          "Active scheduled tasks require next_run_at when no next run is stored.",
-        );
-      }
-      const recurrence = shouldRebuildRecurrence(input)
-        ? buildRecurrence({
-            existing: lookup.schedule.recurrence,
-            input,
-            nextRunAtMs,
-            timezone,
-          })
-        : lookup.schedule.recurrence;
-      const nextStatus = status ?? lookup.status;
-      // Another actor changing executable text revokes creator delegation.
-      const credentialMode =
-        input.task !== undefined &&
-        input.task !== lookup.task.text &&
-        !isCreator
-          ? "system"
-          : (input.credential_mode ?? lookup.credentialMode);
-
-      const next: ScheduledTask = {
-        ...lookup,
-        credentialMode,
-        updatedAtMs: Date.now(),
-        nextRunAtMs,
-        runNowAtMs: nextStatus === "active" ? lookup.runNowAtMs : undefined,
-        status: nextStatus,
-        statusReason:
-          nextStatus === "blocked" ? lookup.statusReason : undefined,
-        schedule: {
-          ...lookup.schedule,
-          description: input.schedule ?? lookup.schedule.description,
-          timezone,
-          kind: recurrence ? "recurring" : "one_off",
-          recurrence,
-        },
-        task: input.task ? { text: input.task } : lookup.task,
-      };
-
-      await schedulerStore(context).saveTask(next);
       return scheduleTaskToolResult(
         "slackScheduleUpdateTask",
-        compactTask(next),
+        compactTask(committed),
       );
     },
   });

--- a/packages/junior-scheduler/src/types.ts
+++ b/packages/junior-scheduler/src/types.ts
@@ -65,8 +65,26 @@ export interface ScheduledTaskSpec {
   text: string;
 }
 
+export interface ScheduledTaskMutationSnapshot {
+  credentialMode: ScheduledTaskCredentialMode;
+  lastRunAtMs?: number;
+  nextRunAtMs?: number;
+  runNowAtMs?: number;
+  schedule: ScheduledTaskSchedule;
+  status: ScheduledTaskStatus;
+  statusReason?: string;
+  task: ScheduledTaskSpec;
+  updatedAtMs: number;
+}
+
+export interface ScheduledTaskMutationRecord {
+  fingerprint: string;
+  result: ScheduledTaskMutationSnapshot;
+}
+
 export interface ScheduledTask {
   id: string;
+  creationFingerprint?: string;
   createdAtMs: number;
   createdBy: ScheduledTaskPrincipal;
   conversationAccess?: ScheduledTaskConversationAccess;
@@ -75,6 +93,7 @@ export interface ScheduledTask {
   destination: SlackDestination;
   executionActor?: ScheduledTaskExecutionActor;
   lastRunAtMs?: number;
+  mutationLedger?: Record<string, ScheduledTaskMutationRecord>;
   nextRunAtMs?: number;
   originalRequest?: string;
   runNowAtMs?: number;

--- a/packages/junior-scheduler/src/types.ts
+++ b/packages/junior-scheduler/src/types.ts
@@ -65,26 +65,8 @@ export interface ScheduledTaskSpec {
   text: string;
 }
 
-export interface ScheduledTaskMutationSnapshot {
-  credentialMode: ScheduledTaskCredentialMode;
-  lastRunAtMs?: number;
-  nextRunAtMs?: number;
-  runNowAtMs?: number;
-  schedule: ScheduledTaskSchedule;
-  status: ScheduledTaskStatus;
-  statusReason?: string;
-  task: ScheduledTaskSpec;
-  updatedAtMs: number;
-}
-
-export interface ScheduledTaskMutationRecord {
-  fingerprint: string;
-  result: ScheduledTaskMutationSnapshot;
-}
-
 export interface ScheduledTask {
   id: string;
-  creationFingerprint?: string;
   createdAtMs: number;
   createdBy: ScheduledTaskPrincipal;
   conversationAccess?: ScheduledTaskConversationAccess;
@@ -93,7 +75,6 @@ export interface ScheduledTask {
   destination: SlackDestination;
   executionActor?: ScheduledTaskExecutionActor;
   lastRunAtMs?: number;
-  mutationLedger?: Record<string, ScheduledTaskMutationRecord>;
   nextRunAtMs?: number;
   originalRequest?: string;
   runNowAtMs?: number;

--- a/packages/junior/tests/integration/slack-schedule-tools.test.ts
+++ b/packages/junior/tests/integration/slack-schedule-tools.test.ts
@@ -317,36 +317,31 @@ describe("Slack schedule tools", () => {
     ).resolves.toHaveLength(1);
   });
 
-  it("rejects reuse of a create operation id with different arguments", async () => {
+  it("allows separate create calls to make equivalent tasks", async () => {
     const tool = createSlackScheduleCreateTaskTool(createContext());
-    await executeTool(
-      tool,
-      {
-        task: "Post the first reminder.",
-        schedule: {
-          kind: "one_off",
-          timing: { type: "after", value: 1, unit: "minute" },
+    const input = {
+      task: "Post the reminder.",
+      schedule: {
+        kind: "one_off" as const,
+        timing: {
+          type: "after" as const,
+          value: 1,
+          unit: "minute" as const,
         },
       },
-      { toolCallId: "call-create-conflict" },
-    );
+    };
 
-    await expect(
-      executeTool(
-        tool,
-        {
-          task: "Post a different reminder.",
-          schedule: {
-            kind: "one_off",
-            timing: { type: "after", value: 2, unit: "minute" },
-          },
-        },
-        { toolCallId: "call-create-conflict" },
-      ),
-    ).rejects.toThrow("Scheduled task operation identity is invalid.");
+    const first = await executeTool(tool, input, {
+      toolCallId: "call-create-first",
+    });
+    const second = await executeTool(tool, input, {
+      toolCallId: "call-create-second",
+    });
+
+    expect(second.task.id).not.toBe(first.task.id);
     await expect(
       schedulerStore().listTasksForTeam(TEST_TEAM_ID),
-    ).resolves.toHaveLength(1);
+    ).resolves.toHaveLength(2);
   });
 
   it("does not store Slack ids as creator display identity", async () => {
@@ -690,67 +685,6 @@ describe("Slack schedule tools", () => {
         status: "paused",
       },
     });
-  });
-
-  it("deduplicates relative update replays across intervening edits", async () => {
-    let nowCalls = 0;
-    const context = createContext({
-      now: () => Date.parse("2026-05-24T12:00:00.000Z") + nowCalls++ * 1_000,
-    });
-    const created = (await createTask(context)) as { task: { id: string } };
-    const tool = createSlackScheduleUpdateTaskTool(context);
-    const input = {
-      task_id: created.task.id,
-      schedule: {
-        kind: "one_off" as const,
-        timing: {
-          type: "after" as const,
-          value: 5,
-          unit: "minute" as const,
-        },
-      },
-    };
-
-    const [first, replay] = await Promise.all([
-      executeTool(tool, input, { toolCallId: "call-update-relative" }),
-      executeTool(tool, input, { toolCallId: "call-update-relative" }),
-    ]);
-
-    expect(replay.task.next_run_at).toBe(first.task.next_run_at);
-    const second = await executeTool(
-      tool,
-      {
-        task_id: created.task.id,
-        schedule: {
-          kind: "one_off",
-          timing: { type: "after", value: 10, unit: "minute" },
-        },
-      },
-      { toolCallId: "call-update-later" },
-    );
-    const historicalReplay = await executeTool(tool, input, {
-      toolCallId: "call-update-relative",
-    });
-    expect(historicalReplay.task.next_run_at).toBe(first.task.next_run_at);
-    await expect(
-      schedulerStore().getTask(created.task.id),
-    ).resolves.toMatchObject({
-      nextRunAtMs: Date.parse(second.task.next_run_at!),
-    });
-
-    await expect(
-      executeTool(
-        tool,
-        {
-          task_id: created.task.id,
-          schedule: {
-            kind: "one_off",
-            timing: { type: "after", value: 15, unit: "minute" },
-          },
-        },
-        { toolCallId: "call-update-relative" },
-      ),
-    ).rejects.toThrow("Scheduled task operation identity is invalid.");
   });
 
   it("rejects removed top-level rescheduling fields", async () => {

--- a/packages/junior/tests/integration/slack-schedule-tools.test.ts
+++ b/packages/junior/tests/integration/slack-schedule-tools.test.ts
@@ -4,6 +4,7 @@ import { createSlackSource } from "@sentry/junior-plugin-api";
 import {
   PluginToolInputError,
   type PluginToolDefinition,
+  type PluginToolExecuteOptions,
   type PluginToolResult,
 } from "@sentry/junior-plugin-api";
 import {
@@ -34,6 +35,7 @@ vi.hoisted(() => {
 const TEST_TEAM_ID = `TSCHEDULE${Date.now()}`;
 let currentFixture: LocalJuniorSqlFixture | undefined;
 let currentSchedulerStore: SchedulerToolContext["store"] | undefined;
+let toolCallSequence = 0;
 
 function schedulerMigrationsDir(): string {
   return path.resolve(process.cwd(), "../junior-scheduler/migrations");
@@ -80,6 +82,7 @@ function createContext(
       userName: "dcramer",
       fullName: "David Cramer",
     },
+    now: () => Date.parse("2026-05-24T12:00:00.000Z"),
     userText: "schedule this weekly",
     store: schedulerStore(),
     ...contextOverrides,
@@ -90,23 +93,31 @@ function createContext(
 async function executeTool<TInput, TOutput extends PluginToolResult>(
   tool: PluginToolDefinition<TInput, TOutput>,
   input: TInput,
+  options: PluginToolExecuteOptions = {},
 ): Promise<TOutput> {
   if (typeof tool?.execute !== "function") {
     throw new Error("tool execute function missing");
   }
-  return await tool.execute(input, {});
+  const prepared = tool.prepareArguments?.(input) ?? input;
+  return await tool.execute(prepared as TInput, {
+    toolCallId: `test-scheduler-call-${toolCallSequence++}`,
+    ...options,
+  });
 }
 
 async function executeRegisteredTool<TDetails>(
   tool: {
     execute?: (input: unknown, options: {}) => Promise<unknown> | unknown;
+    prepareArguments?: (input: unknown) => unknown;
   },
   input: unknown,
 ): Promise<TDetails> {
   if (typeof tool?.execute !== "function") {
     throw new Error("tool execute function missing");
   }
-  return (await tool.execute(input, {})) as TDetails;
+  return (await tool.execute(tool.prepareArguments?.(input) ?? input, {
+    toolCallId: `test-scheduler-call-${toolCallSequence++}`,
+  })) as TDetails;
 }
 
 function schedulerStore() {
@@ -135,11 +146,13 @@ async function createTask(
   const tool = createSlackScheduleCreateTaskTool(context);
   return await executeTool(tool, {
     task: "Weekly issue digest: Summarize open scheduler issues and post a concise summary.",
-    schedule: "Every Monday at 9am",
-    schedule_kind: "recurring",
-    timezone: "America/Los_Angeles",
-    next_run_at: "2026-05-25T16:00:00.000Z",
-    recurrence: "weekly",
+    schedule: {
+      kind: "recurring",
+      frequency: "weekly",
+      time: "09:00",
+      weekdays: ["monday"],
+      timezone: "America/Los_Angeles",
+    },
     ...overrides,
   });
 }
@@ -158,40 +171,36 @@ describe("Slack schedule tools", () => {
     await disconnectStateAdapter();
   });
 
-  it("exposes schedule kind as a required create schema field", async () => {
+  it("exposes a required structured schedule without model-computed timestamps", async () => {
     const schema = createSlackScheduleCreateTaskTool(createContext())
       .inputSchema as {
-      properties?: Record<
-        string,
-        {
-          enum?: unknown[];
-          oneOf?: Array<{ const?: unknown }>;
-        }
-      >;
+      properties?: Record<string, unknown>;
       required?: string[];
     };
-    const scheduleKind = schema.properties?.schedule_kind;
-    const options = (scheduleKind?.enum ??
-      scheduleKind?.oneOf?.map((option) => option.const) ??
-      []) as unknown[];
 
-    expect(schema.required).toContain("schedule_kind");
-    expect([...options].sort()).toEqual(["one_off", "recurring"]);
+    expect(schema.required).toContain("schedule");
+    expect(schema.properties).not.toHaveProperty("next_run_at");
+    expect(schema.properties).not.toHaveProperty("schedule_kind");
   });
 
-  it("accepts null recurrence in the create schema", async () => {
+  it("accepts a structured relative one-off schedule", async () => {
     const tool = createSlackScheduleCreateTaskTool(createContext());
 
     expect(
       tool.prepareArguments?.({
         task: "Remind Greg to drink water.",
-        schedule: "In 1 minute",
-        schedule_kind: "one_off",
-        next_run_at: "2026-05-28T02:18:48.005Z",
-        recurrence: null,
+        schedule: {
+          kind: "one_off",
+          timezone: null,
+          timing: { type: "after", value: 1, unit: "minute" },
+        },
       }),
     ).toMatchObject({
-      recurrence: null,
+      schedule: {
+        kind: "one_off",
+        timezone: null,
+        timing: { type: "after" },
+      },
     });
   });
 
@@ -225,7 +234,7 @@ describe("Slack schedule tools", () => {
       tasks: [
         {
           task: "Weekly issue digest: Summarize open scheduler issues and post a concise summary.",
-          schedule: "Every Monday at 9am",
+          schedule: "Every week on Monday at 09:00 (America/Los_Angeles)",
         },
       ],
     });
@@ -239,7 +248,7 @@ describe("Slack schedule tools", () => {
       tasks: [
         {
           task: "Weekly issue digest: Summarize open scheduler issues and post a concise summary.",
-          schedule: "Every Monday at 9am",
+          schedule: "Every week on Monday at 09:00 (America/Los_Angeles)",
         },
       ],
     });
@@ -250,18 +259,20 @@ describe("Slack schedule tools", () => {
       createSlackScheduleCreateTaskTool(createContext()),
       {
         task: "Weekly issue digest: Summarize open scheduler issues and post a concise summary.",
-        schedule: "Every Monday at 9am",
-        schedule_kind: "recurring",
-        timezone: "America/Los_Angeles",
-        next_run_at: "2026-05-25T16:00:00.000Z",
-        recurrence: "weekly",
+        schedule: {
+          kind: "recurring",
+          frequency: "weekly",
+          time: "09:00",
+          weekdays: ["monday"],
+          timezone: "America/Los_Angeles",
+        },
       },
     );
 
     expect(result).toMatchObject({
       ok: true,
       task: {
-        schedule: "Every Monday at 9am",
+        schedule: "Every week on Monday at 09:00 (America/Los_Angeles)",
         status: "active",
         task: "Weekly issue digest: Summarize open scheduler issues and post a concise summary.",
       },
@@ -274,6 +285,68 @@ describe("Slack schedule tools", () => {
         status: "active",
       },
     ]);
+  });
+
+  it("returns the existing task when a create tool call is replayed", async () => {
+    let nowCalls = 0;
+    const context = createContext({
+      now: () => Date.parse("2026-05-24T12:00:00.000Z") + nowCalls++ * 1_000,
+    });
+    const tool = createSlackScheduleCreateTaskTool(context);
+    const input = {
+      task: "Post the scheduler reminder.",
+      schedule: {
+        kind: "one_off" as const,
+        timing: {
+          type: "after" as const,
+          value: 1,
+          unit: "minute" as const,
+        },
+      },
+    };
+
+    const [first, replay] = await Promise.all([
+      executeTool(tool, input, { toolCallId: "call-create-1" }),
+      executeTool(tool, input, { toolCallId: "call-create-1" }),
+    ]);
+
+    expect(replay.task.id).toBe(first.task.id);
+    expect(replay.task.next_run_at).toBe(first.task.next_run_at);
+    await expect(
+      schedulerStore().listTasksForTeam(TEST_TEAM_ID),
+    ).resolves.toHaveLength(1);
+  });
+
+  it("rejects reuse of a create operation id with different arguments", async () => {
+    const tool = createSlackScheduleCreateTaskTool(createContext());
+    await executeTool(
+      tool,
+      {
+        task: "Post the first reminder.",
+        schedule: {
+          kind: "one_off",
+          timing: { type: "after", value: 1, unit: "minute" },
+        },
+      },
+      { toolCallId: "call-create-conflict" },
+    );
+
+    await expect(
+      executeTool(
+        tool,
+        {
+          task: "Post a different reminder.",
+          schedule: {
+            kind: "one_off",
+            timing: { type: "after", value: 2, unit: "minute" },
+          },
+        },
+        { toolCallId: "call-create-conflict" },
+      ),
+    ).rejects.toThrow("Scheduled task operation identity is invalid.");
+    await expect(
+      schedulerStore().listTasksForTeam(TEST_TEAM_ID),
+    ).resolves.toHaveLength(1);
   });
 
   it("does not store Slack ids as creator display identity", async () => {
@@ -325,9 +398,10 @@ describe("Slack schedule tools", () => {
       createSlackScheduleCreateTaskTool(createContext({ teamId: "D123" })),
       {
         task: "Reminder: Remind David to wash his hands.",
-        schedule: "In 1 minute",
-        schedule_kind: "one_off",
-        next_run_at: "2026-05-27T00:25:23.000Z",
+        schedule: {
+          kind: "one_off",
+          timing: { type: "after", value: 1, unit: "minute" },
+        },
       },
     );
 
@@ -408,7 +482,7 @@ describe("Slack schedule tools", () => {
     );
   });
 
-  it("creates explicit one-off reminders without a second confirmation", async () => {
+  it("computes relative one-off runs from the trusted clock", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-27T00:24:23.000Z"));
 
@@ -416,14 +490,16 @@ describe("Slack schedule tools", () => {
       createSlackScheduleCreateTaskTool(
         createContext({
           channelId: "D123",
+          now: () => Date.now(),
           userText: "remind me in 1 minute to wash my hands",
         }),
       ),
       {
         task: "Wash hands reminder: Remind David to wash his hands.",
-        schedule: "In 1 minute",
-        schedule_kind: "one_off",
-        next_run_at: "2026-05-27T00:25:23.000Z",
+        schedule: {
+          kind: "one_off",
+          timing: { type: "after", value: 1, unit: "minute" },
+        },
         credential_mode: null,
       },
     );
@@ -453,206 +529,83 @@ describe("Slack schedule tools", () => {
     ]);
   });
 
-  it("creates short imperative one-off reminders without channel confirmation", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-05-27T00:24:23.000Z"));
-
-    const result = await executeTool(
-      createSlackScheduleCreateTaskTool(
-        createContext({
-          userText: "drink water in 1 minute in this conversation",
-        }),
-      ),
-      {
-        task: "Drink water reminder: Remind David to drink water.",
-        schedule: "In 1 minute",
-        schedule_kind: "one_off",
-        next_run_at: "2026-05-27T00:25:23.000Z",
-      },
-    );
-
-    expect(result).toMatchObject({
-      ok: true,
-      task: {
-        next_run_at: "2026-05-27T00:25:23.000Z",
-        schedule: "In 1 minute",
-        status: "active",
-        task: "Drink water reminder: Remind David to drink water.",
-      },
-    });
+  it("rejects malformed local dates", async () => {
     await expect(
-      schedulerStore().listTasksForTeam(TEST_TEAM_ID),
-    ).resolves.toMatchObject([
-      {
-        destination: { channelId: "C123" },
-        nextRunAtMs: Date.parse("2026-05-27T00:25:23.000Z"),
-        status: "active",
-      },
-    ]);
-  });
-
-  it("creates one-off reminders by omitting recurrence", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-05-28T02:17:48.005Z"));
-
-    const result = await executeTool(
-      createSlackScheduleCreateTaskTool(
-        createContext({
-          userText: "remind greg to drink water in 1m",
-        }),
-      ),
-      {
-        task: "Remind Greg to drink water.",
-        schedule: "In 1 minute",
-        schedule_kind: "one_off",
-        next_run_at: "2026-05-28T02:18:48.005Z",
-      },
-    );
-
-    expect(result).toMatchObject({
-      ok: true,
-      task: {
-        next_run_at: "2026-05-28T02:18:48.005Z",
-        recurrence: null,
-        schedule: "In 1 minute",
-        status: "active",
-        task: "Remind Greg to drink water.",
-      },
-    });
-    await expect(
-      schedulerStore().listTasksForTeam(TEST_TEAM_ID),
-    ).resolves.toMatchObject([
-      {
-        nextRunAtMs: Date.parse("2026-05-28T02:18:48.005Z"),
+      createTask(createContext(), {
         schedule: {
           kind: "one_off",
+          timing: { type: "at", date: "05/25/2026", time: "09:00" },
         },
-        status: "active",
-      },
-    ]);
-  });
-
-  it("creates one-off reminders with null recurrence", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-05-28T02:17:48.005Z"));
-
-    const result = await executeTool(
-      createSlackScheduleCreateTaskTool(
-        createContext({
-          userText: "remind greg to drink water in 1m",
-        }),
-      ),
-      {
-        task: "Remind Greg to drink water.",
-        schedule: "In 1 minute",
-        schedule_kind: "one_off",
-        next_run_at: "2026-05-28T02:18:48.005Z",
-        recurrence: null,
-      },
-    );
-
-    expect(result).toMatchObject({
-      ok: true,
-      task: {
-        next_run_at: "2026-05-28T02:18:48.005Z",
-        recurrence: null,
-        schedule: "In 1 minute",
-        status: "active",
-        task: "Remind Greg to drink water.",
-      },
-    });
+      }),
+    ).rejects.toThrow("Use a local date in YYYY-MM-DD format.");
     await expect(
       schedulerStore().listTasksForTeam(TEST_TEAM_ID),
-    ).resolves.toMatchObject([
-      {
-        nextRunAtMs: Date.parse("2026-05-28T02:18:48.005Z"),
+    ).resolves.toEqual([]);
+  });
+
+  it("rejects missing structured schedules with a tool error", async () => {
+    await expect(
+      createTask(createContext(), {
+        schedule: undefined,
+      }),
+    ).rejects.toThrow("schedule");
+    await expect(
+      schedulerStore().listTasksForTeam(TEST_TEAM_ID),
+    ).resolves.toEqual([]);
+  });
+
+  it("rejects unsupported recurring frequencies", async () => {
+    await expect(
+      createTask(createContext(), {
         schedule: {
-          kind: "one_off",
+          kind: "recurring",
+          frequency: "hourly",
+          time: "09:00",
         },
-        status: "active",
-      },
-    ]);
-  });
-
-  it("rejects parseable non-ISO next run timestamps", async () => {
-    await expect(
-      createTask(createContext(), {
-        next_run_at: "05/25/2026 09:00",
       }),
-    ).rejects.toThrow("Provide next_run_at as a valid ISO timestamp.");
+    ).rejects.toThrow("Invalid tool arguments: schedule");
     await expect(
       schedulerStore().listTasksForTeam(TEST_TEAM_ID),
     ).resolves.toEqual([]);
   });
 
-  it("rejects missing next run timestamps with a tool error", async () => {
+  it("rejects removed top-level scheduling fields", async () => {
     await expect(
       createTask(createContext(), {
-        next_run_at: undefined,
+        next_run_at: "2026-05-25T16:00:00.000Z",
       }),
-    ).rejects.toThrow("Provide next_run_at as a valid ISO timestamp.");
+    ).rejects.toThrow("Unrecognized key");
     await expect(
       schedulerStore().listTasksForTeam(TEST_TEAM_ID),
     ).resolves.toEqual([]);
   });
 
-  it("rejects recurring schedules that can run more than once per day", async () => {
+  it("rejects weekly schedules without weekdays", async () => {
     await expect(
       createTask(createContext(), {
-        schedule: "Every hour",
-        recurrence: "hourly",
+        schedule: {
+          kind: "recurring",
+          frequency: "weekly",
+          time: "09:00",
+        },
       }),
-    ).rejects.toThrow(
-      "Recurring scheduled tasks can run at most once per day.",
-    );
+    ).rejects.toThrow("Weekly schedules require weekdays.");
     await expect(
       schedulerStore().listTasksForTeam(TEST_TEAM_ID),
     ).resolves.toEqual([]);
   });
 
-  it("rejects create calls that omit schedule kind", async () => {
+  it("rejects recurring fields that contradict the selected frequency", async () => {
     await expect(
       createTask(createContext(), {
-        schedule_kind: undefined,
+        schedule: {
+          kind: "recurring",
+          frequency: "daily",
+          time: "09:00",
+          weekdays: ["monday"],
+        },
       }),
-    ).rejects.toThrow("Provide schedule_kind as one_off or recurring.");
-    await expect(
-      schedulerStore().listTasksForTeam(TEST_TEAM_ID),
-    ).resolves.toEqual([]);
-  });
-
-  it("rejects one-off create calls that include recurrence", async () => {
-    await expect(
-      createTask(createContext(), {
-        schedule: "In 30 seconds",
-        schedule_kind: "one_off",
-        recurrence: "daily",
-      }),
-    ).rejects.toThrow("Omit recurrence when schedule_kind is one_off.");
-    await expect(
-      schedulerStore().listTasksForTeam(TEST_TEAM_ID),
-    ).resolves.toEqual([]);
-  });
-
-  it("rejects recurring create calls that omit recurrence", async () => {
-    await expect(
-      createTask(createContext(), {
-        schedule_kind: "recurring",
-        recurrence: undefined,
-      }),
-    ).rejects.toThrow("Provide recurrence when schedule_kind is recurring.");
-    await expect(
-      schedulerStore().listTasksForTeam(TEST_TEAM_ID),
-    ).resolves.toEqual([]);
-  });
-
-  it("rejects recurring create calls with null recurrence", async () => {
-    await expect(
-      createTask(createContext(), {
-        schedule_kind: "recurring",
-        recurrence: null,
-      }),
-    ).rejects.toThrow("Provide recurrence when schedule_kind is recurring.");
+    ).rejects.toThrow("weekdays applies only to weekly schedules.");
     await expect(
       schedulerStore().listTasksForTeam(TEST_TEAM_ID),
     ).resolves.toEqual([]);
@@ -669,17 +622,32 @@ describe("Slack schedule tools", () => {
       createSlackScheduleUpdateTaskTool(context),
       {
         task_id: taskId,
-        task: "Daily scheduler digest: Summarize open scheduler issues.",
-        schedule: "Every day at 9am",
-        recurrence: "daily",
+        task: "Tuesday scheduler digest: Summarize open scheduler issues.",
+        schedule: {
+          kind: "recurring",
+          frequency: "weekly",
+          time: "10:00",
+          weekdays: ["tuesday"],
+        },
       },
     );
     expect(updated).toMatchObject({
       ok: true,
       task: {
         id: taskId,
-        task: "Daily scheduler digest: Summarize open scheduler issues.",
-        schedule: "Every day at 9am",
+        next_run_at: "2026-05-26T17:00:00.000Z",
+        task: "Tuesday scheduler digest: Summarize open scheduler issues.",
+        schedule: "Every week on Tuesday at 10:00 (America/Los_Angeles)",
+      },
+    });
+    await expect(schedulerStore().getTask(taskId)).resolves.toMatchObject({
+      nextRunAtMs: Date.parse("2026-05-26T17:00:00.000Z"),
+      schedule: {
+        recurrence: {
+          frequency: "weekly",
+          time: { hour: 10, minute: 0 },
+          weekdays: [2],
+        },
       },
     });
 
@@ -704,7 +672,106 @@ describe("Slack schedule tools", () => {
     expect(listed).toMatchObject({ ok: true, tasks: [] });
   });
 
-  it("rejects edits that make a recurring task run more than once per day", async () => {
+  it("treats a null update schedule as omitted", async () => {
+    const context = createContext();
+    const created = (await createTask(context)) as {
+      task: { id: string; next_run_at: string };
+    };
+
+    const updated = await executeTool(
+      createSlackScheduleUpdateTaskTool(context),
+      { task_id: created.task.id, schedule: null, status: "paused" },
+    );
+
+    expect(updated).toMatchObject({
+      task: {
+        id: created.task.id,
+        next_run_at: created.task.next_run_at,
+        status: "paused",
+      },
+    });
+  });
+
+  it("deduplicates relative update replays across intervening edits", async () => {
+    let nowCalls = 0;
+    const context = createContext({
+      now: () => Date.parse("2026-05-24T12:00:00.000Z") + nowCalls++ * 1_000,
+    });
+    const created = (await createTask(context)) as { task: { id: string } };
+    const tool = createSlackScheduleUpdateTaskTool(context);
+    const input = {
+      task_id: created.task.id,
+      schedule: {
+        kind: "one_off" as const,
+        timing: {
+          type: "after" as const,
+          value: 5,
+          unit: "minute" as const,
+        },
+      },
+    };
+
+    const [first, replay] = await Promise.all([
+      executeTool(tool, input, { toolCallId: "call-update-relative" }),
+      executeTool(tool, input, { toolCallId: "call-update-relative" }),
+    ]);
+
+    expect(replay.task.next_run_at).toBe(first.task.next_run_at);
+    const second = await executeTool(
+      tool,
+      {
+        task_id: created.task.id,
+        schedule: {
+          kind: "one_off",
+          timing: { type: "after", value: 10, unit: "minute" },
+        },
+      },
+      { toolCallId: "call-update-later" },
+    );
+    const historicalReplay = await executeTool(tool, input, {
+      toolCallId: "call-update-relative",
+    });
+    expect(historicalReplay.task.next_run_at).toBe(first.task.next_run_at);
+    await expect(
+      schedulerStore().getTask(created.task.id),
+    ).resolves.toMatchObject({
+      nextRunAtMs: Date.parse(second.task.next_run_at!),
+    });
+
+    await expect(
+      executeTool(
+        tool,
+        {
+          task_id: created.task.id,
+          schedule: {
+            kind: "one_off",
+            timing: { type: "after", value: 15, unit: "minute" },
+          },
+        },
+        { toolCallId: "call-update-relative" },
+      ),
+    ).rejects.toThrow("Scheduled task operation identity is invalid.");
+  });
+
+  it("rejects removed top-level rescheduling fields", async () => {
+    const context = createContext();
+    const created = (await createTask(context)) as { task: { id: string } };
+    const tool = createSlackScheduleUpdateTaskTool(context);
+
+    await expect(
+      executeTool(tool, {
+        task_id: created.task.id,
+        next_run_at: "2026-06-01T16:00:00.000Z",
+      } as unknown as Parameters<NonNullable<typeof tool.execute>>[0]),
+    ).rejects.toThrow("Unrecognized key");
+    await expect(
+      schedulerStore().getTask(created.task.id),
+    ).resolves.toMatchObject({
+      nextRunAtMs: Date.parse("2026-05-25T16:00:00.000Z"),
+    });
+  });
+
+  it("rejects edits with an unsupported recurring frequency", async () => {
     const context = createContext();
     const created = (await createTask(context)) as {
       task: { id: string };
@@ -714,22 +781,23 @@ describe("Slack schedule tools", () => {
     await expect(
       executeTool(updateTool, {
         task_id: created.task.id,
-        schedule: "Every hour",
-        recurrence: "hourly",
+        schedule: {
+          kind: "recurring",
+          frequency: "hourly",
+          time: "09:00",
+        },
       } as unknown as Parameters<NonNullable<typeof updateTool.execute>>[0]),
-    ).rejects.toThrow(
-      "Recurring scheduled tasks can run at most once per day.",
-    );
+    ).rejects.toThrow("Invalid tool arguments: schedule");
     await expect(
       schedulerStore().getTask(created.task.id),
     ).resolves.toMatchObject({
       schedule: {
-        description: "Every Monday at 9am",
+        description: "Every week on Monday at 09:00 (America/Los_Angeles)",
       },
     });
   });
 
-  it("converts recurring tasks to one-off tasks with recurrence null", async () => {
+  it("converts recurring tasks to one-off tasks with a full schedule replacement", async () => {
     const context = createContext();
     const created = (await createTask(context)) as {
       task: { id: string };
@@ -739,9 +807,10 @@ describe("Slack schedule tools", () => {
       createSlackScheduleUpdateTaskTool(context),
       {
         task_id: created.task.id,
-        schedule: "On June 1 at 9am",
-        next_run_at: "2026-06-01T16:00:00.000Z",
-        recurrence: null,
+        schedule: {
+          kind: "one_off",
+          timing: { type: "at", date: "2026-06-01", time: "09:00" },
+        },
       },
     );
 
@@ -751,7 +820,7 @@ describe("Slack schedule tools", () => {
         id: created.task.id,
         next_run_at: "2026-06-01T16:00:00.000Z",
         recurrence: null,
-        schedule: "On June 1 at 9am",
+        schedule: "Once on 2026-06-01 at 09:00 (America/Los_Angeles)",
       },
     });
     await expect(
@@ -927,7 +996,13 @@ describe("Slack schedule tools", () => {
 
     await executeTool(createSlackScheduleUpdateTaskTool(otherActor), {
       task_id: created.task.id,
-      schedule: "Every Tuesday at 9am",
+      schedule: {
+        kind: "recurring",
+        frequency: "weekly",
+        time: "09:00",
+        weekdays: ["tuesday"],
+        timezone: "America/Los_Angeles",
+      },
       credential_mode: null,
     });
     await expect(
@@ -1046,10 +1121,10 @@ describe("Slack schedule tools", () => {
           },
         },
         {
-          schedule: "In 1 minute",
-          schedule_kind: "one_off",
-          next_run_at: "2026-05-27T00:25:23.000Z",
-          recurrence: undefined,
+          schedule: {
+            kind: "one_off",
+            timing: { type: "after", value: 1, unit: "minute" },
+          },
         },
       ),
     ).rejects.toThrow("Active Slack conversation channel is invalid.");
@@ -1060,10 +1135,10 @@ describe("Slack schedule tools", () => {
 
   it("stores canonical Slack destinations directly", async () => {
     const result = await createTask(createContext({ channelId: "D123" }), {
-      schedule: "In 1 minute",
-      schedule_kind: "one_off",
-      next_run_at: "2026-05-27T00:25:23.000Z",
-      recurrence: undefined,
+      schedule: {
+        kind: "one_off",
+        timing: { type: "after", value: 1, unit: "minute" },
+      },
     });
 
     expect(result).toMatchObject({
@@ -1084,16 +1159,15 @@ describe("Slack schedule tools", () => {
     ]);
   });
 
-  it("creates one-off tasks with an exact timestamp using the default Pacific timezone", async () => {
+  it("computes one-off timestamps from local time in the default Pacific timezone", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-25T12:00:00.000Z"));
 
     const created = await createTask(createContext(), {
-      schedule: "On May 26 at 9am",
-      schedule_kind: "one_off",
-      next_run_at: "2026-05-26T16:00:00.000Z",
-      recurrence: undefined,
-      timezone: undefined,
+      schedule: {
+        kind: "one_off",
+        timing: { type: "at", date: "2026-05-26", time: "09:00" },
+      },
     });
 
     expect(created).toMatchObject({
@@ -1112,11 +1186,10 @@ describe("Slack schedule tools", () => {
     vi.setSystemTime(new Date("2026-05-25T12:00:00.000Z"));
 
     const created = await createTask(createContext(), {
-      schedule: "On May 26 at 9am",
-      schedule_kind: "one_off",
-      next_run_at: "2026-05-26T13:00:00.000Z",
-      recurrence: undefined,
-      timezone: undefined,
+      schedule: {
+        kind: "one_off",
+        timing: { type: "at", date: "2026-05-26", time: "09:00" },
+      },
     });
 
     expect(created).toMatchObject({
@@ -1134,7 +1207,10 @@ describe("Slack schedule tools", () => {
 
     await expect(
       createTask(createContext(), {
-        timezone: undefined,
+        schedule: {
+          kind: "one_off",
+          timing: { type: "after", value: 1, unit: "minute" },
+        },
       }),
     ).rejects.toThrow("timezone must be a valid IANA time zone.");
     await expect(
@@ -1144,9 +1220,7 @@ describe("Slack schedule tools", () => {
 
   it("preserves a recurring task calendar anchor on content-only edits", async () => {
     const context = createContext();
-    const created = (await createTask(context, {
-      recurrence: "weekly",
-    })) as {
+    const created = (await createTask(context)) as {
       task: { id: string };
     };
     const store = schedulerStore();
@@ -1403,11 +1477,14 @@ describe("Slack schedule tool wiring via getPluginTools", () => {
         task: { id: string };
       }>(tools.scheduler_slackScheduleCreateTask, {
         task: "Wiring test: post a weekly digest.",
-        schedule: "Every Monday at 9am",
-        schedule_kind: "recurring",
-        timezone: "America/Los_Angeles",
-        next_run_at: "2026-06-09T16:00:00.000Z",
-        recurrence: "weekly",
+        schedule: {
+          kind: "recurring",
+          frequency: "weekly",
+          time: "09:00",
+          weekdays: ["monday"],
+          start_date: "2026-06-09",
+          timezone: "America/Los_Angeles",
+        },
       });
 
       expect(result).toMatchObject({ ok: true });

--- a/packages/junior/tests/unit/scheduler/schedule-intent.test.ts
+++ b/packages/junior/tests/unit/scheduler/schedule-intent.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vitest";
+import { type ScheduledTask } from "@sentry/junior-scheduler";
+import { getNextRunAtMs } from "../../../../junior-scheduler/src/cadence";
+import { compileScheduleIntent } from "../../../../junior-scheduler/src/schedule-intent";
+
+const DEFAULT_TIMEZONE = "America/Los_Angeles";
+
+describe("schedule intent compiler", () => {
+  it("resolves relative one-offs from the trusted server clock", () => {
+    const nowMs = Date.parse("2026-05-28T02:17:48.005Z");
+
+    expect(
+      compileScheduleIntent({
+        defaultTimezone: DEFAULT_TIMEZONE,
+        intent: {
+          kind: "one_off",
+          timing: { type: "after", value: 1, unit: "minute" },
+        },
+        nowMs,
+      }),
+    ).toMatchObject({
+      nextRunAtMs: Date.parse("2026-05-28T02:18:48.005Z"),
+      schedule: {
+        description: "In 1 minute",
+        kind: "one_off",
+        timezone: DEFAULT_TIMEZONE,
+      },
+    });
+  });
+
+  it("materializes the next matching local recurring occurrence", () => {
+    const compiled = compileScheduleIntent({
+      defaultTimezone: DEFAULT_TIMEZONE,
+      intent: {
+        kind: "recurring",
+        frequency: "weekly",
+        time: "09:00",
+        weekdays: ["monday"],
+      },
+      nowMs: Date.parse("2026-05-24T12:00:00.000Z"),
+    });
+
+    expect(compiled).toMatchObject({
+      nextRunAtMs: Date.parse("2026-05-25T16:00:00.000Z"),
+      schedule: {
+        kind: "recurring",
+        recurrence: {
+          frequency: "weekly",
+          interval: 1,
+          startDate: "2026-05-25",
+          time: { hour: 9, minute: 0 },
+          weekdays: [1],
+        },
+      },
+    });
+  });
+
+  it("skips a nonexistent spring-forward recurring time", () => {
+    const compiled = compileScheduleIntent({
+      defaultTimezone: DEFAULT_TIMEZONE,
+      intent: {
+        kind: "recurring",
+        frequency: "daily",
+        time: "02:30",
+        start_date: "2026-03-08",
+      },
+      nowMs: Date.parse("2026-03-08T08:00:00.000Z"),
+    });
+
+    expect(compiled.nextRunAtMs).toBe(Date.parse("2026-03-09T09:30:00.000Z"));
+  });
+
+  it("uses the first instant when a fall-back local time repeats", () => {
+    const compiled = compileScheduleIntent({
+      defaultTimezone: DEFAULT_TIMEZONE,
+      intent: {
+        kind: "recurring",
+        frequency: "daily",
+        time: "01:30",
+        start_date: "2026-11-01",
+      },
+      nowMs: Date.parse("2026-11-01T07:00:00.000Z"),
+    });
+
+    expect(compiled.nextRunAtMs).toBe(Date.parse("2026-11-01T08:30:00.000Z"));
+  });
+
+  it("finds the next valid monthly and leap-year occurrences", () => {
+    const monthly = compileScheduleIntent({
+      defaultTimezone: DEFAULT_TIMEZONE,
+      intent: {
+        kind: "recurring",
+        frequency: "monthly",
+        day_of_month: 31,
+        time: "09:00",
+      },
+      nowMs: Date.parse("2026-04-30T12:00:00.000Z"),
+    });
+    const yearly = compileScheduleIntent({
+      defaultTimezone: DEFAULT_TIMEZONE,
+      intent: {
+        kind: "recurring",
+        frequency: "yearly",
+        month: 2,
+        day_of_month: 29,
+        time: "09:00",
+      },
+      nowMs: Date.parse("2026-03-01T12:00:00.000Z"),
+    });
+
+    expect(monthly.nextRunAtMs).toBe(Date.parse("2026-05-31T16:00:00.000Z"));
+    expect(yearly.nextRunAtMs).toBe(Date.parse("2028-02-29T17:00:00.000Z"));
+  });
+
+  it("supports yearly intervals beyond the old search horizon", () => {
+    const compiled = compileScheduleIntent({
+      defaultTimezone: DEFAULT_TIMEZONE,
+      intent: {
+        kind: "recurring",
+        frequency: "yearly",
+        interval: 365,
+        month: 1,
+        day_of_month: 1,
+        start_date: "2026-01-01",
+        time: "09:00",
+      },
+      nowMs: Date.parse("2026-03-01T12:00:00.000Z"),
+    });
+
+    expect(compiled.nextRunAtMs).toBe(Date.parse("2391-01-01T17:00:00.000Z"));
+  });
+
+  it("skips a nonexistent local time when advancing an existing task", () => {
+    const compiled = compileScheduleIntent({
+      defaultTimezone: DEFAULT_TIMEZONE,
+      intent: {
+        kind: "recurring",
+        frequency: "daily",
+        time: "02:30",
+        start_date: "2026-03-07",
+      },
+      nowMs: Date.parse("2026-03-07T08:00:00.000Z"),
+    });
+    const task: ScheduledTask = {
+      id: "sched_dst",
+      createdAtMs: Date.parse("2026-03-07T08:00:00.000Z"),
+      createdBy: { slackUserId: "U123" },
+      credentialMode: "system",
+      destination: {
+        platform: "slack",
+        teamId: "T123",
+        channelId: "C123",
+      },
+      nextRunAtMs: compiled.nextRunAtMs,
+      schedule: compiled.schedule,
+      status: "active",
+      task: { text: "Post the daily reminder." },
+      updatedAtMs: Date.parse("2026-03-07T08:00:00.000Z"),
+    };
+
+    expect(getNextRunAtMs(task, compiled.nextRunAtMs)).toBe(
+      Date.parse("2026-03-09T09:30:00.000Z"),
+    );
+  });
+
+  it("anchors an unanchored interval at the next matching occurrence", () => {
+    const compiled = compileScheduleIntent({
+      defaultTimezone: DEFAULT_TIMEZONE,
+      intent: {
+        kind: "recurring",
+        frequency: "yearly",
+        interval: 4,
+        month: 2,
+        day_of_month: 29,
+        time: "09:00",
+      },
+      nowMs: Date.parse("2025-03-01T12:00:00.000Z"),
+    });
+
+    expect(compiled.nextRunAtMs).toBe(Date.parse("2028-02-29T17:00:00.000Z"));
+    expect(compiled.schedule.recurrence).toMatchObject({
+      interval: 4,
+      startDate: "2028-02-29",
+    });
+  });
+
+  it("does not schedule before a future recurrence start date", () => {
+    const monthly = compileScheduleIntent({
+      defaultTimezone: DEFAULT_TIMEZONE,
+      intent: {
+        kind: "recurring",
+        frequency: "monthly",
+        day_of_month: 1,
+        start_date: "2027-06-15",
+        time: "09:00",
+      },
+      nowMs: Date.parse("2026-03-01T12:00:00.000Z"),
+    });
+    const yearly = compileScheduleIntent({
+      defaultTimezone: DEFAULT_TIMEZONE,
+      intent: {
+        kind: "recurring",
+        frequency: "yearly",
+        month: 1,
+        day_of_month: 1,
+        start_date: "2027-06-15",
+        time: "09:00",
+      },
+      nowMs: Date.parse("2026-03-01T12:00:00.000Z"),
+    });
+
+    expect(monthly.nextRunAtMs).toBe(Date.parse("2027-07-01T16:00:00.000Z"));
+    expect(yearly.nextRunAtMs).toBe(Date.parse("2028-01-01T17:00:00.000Z"));
+  });
+
+  it("rejects a nonexistent one-off local time", () => {
+    expect(() =>
+      compileScheduleIntent({
+        defaultTimezone: DEFAULT_TIMEZONE,
+        intent: {
+          kind: "one_off",
+          timing: { type: "at", date: "2026-03-08", time: "02:30" },
+        },
+        nowMs: Date.parse("2026-03-08T08:00:00.000Z"),
+      }),
+    ).toThrow("does not exist in that timezone");
+  });
+});

--- a/packages/junior/tests/unit/scheduler/schedule-intent.test.ts
+++ b/packages/junior/tests/unit/scheduler/schedule-intent.test.ts
@@ -5,6 +5,28 @@ import { compileScheduleIntent } from "../../../../junior-scheduler/src/schedule
 
 const DEFAULT_TIMEZONE = "America/Los_Angeles";
 
+function scheduledTask(
+  compiled: ReturnType<typeof compileScheduleIntent>,
+  nowMs: number,
+): ScheduledTask {
+  return {
+    id: "sched_test",
+    createdAtMs: nowMs,
+    createdBy: { slackUserId: "U123" },
+    credentialMode: "system",
+    destination: {
+      platform: "slack",
+      teamId: "T123",
+      channelId: "C123",
+    },
+    nextRunAtMs: compiled.nextRunAtMs,
+    schedule: compiled.schedule,
+    status: "active",
+    task: { text: "Post the reminder." },
+    updatedAtMs: nowMs,
+  };
+}
+
 describe("schedule intent compiler", () => {
   it("resolves relative one-offs from the trusted server clock", () => {
     const nowMs = Date.parse("2026-05-28T02:17:48.005Z");
@@ -182,6 +204,52 @@ describe("schedule intent compiler", () => {
       interval: 4,
       startDate: "2028-02-29",
     });
+  });
+
+  it("starts an unanchored daily interval at the next occurrence", () => {
+    const nowMs = Date.parse("2026-05-24T18:00:00.000Z");
+    const compiled = compileScheduleIntent({
+      defaultTimezone: DEFAULT_TIMEZONE,
+      intent: {
+        kind: "recurring",
+        frequency: "daily",
+        interval: 2,
+        time: "09:00",
+      },
+      nowMs,
+    });
+
+    expect(compiled.nextRunAtMs).toBe(Date.parse("2026-05-25T16:00:00.000Z"));
+    expect(compiled.schedule.recurrence).toMatchObject({
+      interval: 2,
+      startDate: "2026-05-25",
+    });
+    expect(
+      getNextRunAtMs(scheduledTask(compiled, nowMs), compiled.nextRunAtMs),
+    ).toBe(Date.parse("2026-05-27T16:00:00.000Z"));
+  });
+
+  it("anchors multi-week schedules to calendar weeks", () => {
+    const nowMs = Date.parse("2026-05-26T18:00:00.000Z");
+    const compiled = compileScheduleIntent({
+      defaultTimezone: DEFAULT_TIMEZONE,
+      intent: {
+        kind: "recurring",
+        frequency: "weekly",
+        interval: 2,
+        time: "09:00",
+        weekdays: ["monday", "friday"],
+      },
+      nowMs,
+    });
+    const task = scheduledTask(compiled, nowMs);
+    const secondRunAtMs = getNextRunAtMs(task, compiled.nextRunAtMs);
+
+    expect(compiled.nextRunAtMs).toBe(Date.parse("2026-05-29T16:00:00.000Z"));
+    expect(secondRunAtMs).toBe(Date.parse("2026-06-08T16:00:00.000Z"));
+    expect(getNextRunAtMs(task, secondRunAtMs!)).toBe(
+      Date.parse("2026-06-12T16:00:00.000Z"),
+    );
   });
 
   it("does not schedule before a future recurrence start date", () => {


### PR DESCRIPTION
Scheduler create and update tools now accept structured one-off or recurring
intent instead of model-computed timestamps. The scheduler materializes
`next_run_at` from its trusted clock and timezone rules, including explicit DST
gap/fold behavior and recurrence anchoring. Existing one-off and recurring user
features remain available, while the legacy top-level `next_run_at`,
`schedule_kind`, and `recurrence` inputs are intentionally removed without a
compatibility shim.

Create tool-call identities derive stable task ids and use atomic
create-if-absent storage, so concurrent retries of the same call return one
committed task. Separate create calls remain independent and may intentionally
produce equivalent tasks. The persisted task shape is unchanged and no SQL
migration is needed.

The main review surface is the structured intent compiler and cadence logic;
the Slack integration tests and scheduler evals cover the model-facing hard cut,
rescheduling, create retry recovery, DST transitions, and calendar edge cases,
including multi-week schedules.
