### PR TITLE
fix(slack): Cancel resource watches on thread stop

### DIFF
--- a/packages/docs/src/content/docs/start-here/using-junior.md
+++ b/packages/docs/src/content/docs/start-here/using-junior.md
@@ -67,6 +67,8 @@ Junior reads every message in the thread, so you can course-correct at any point
 - **Narrow scope:** `@jr skip the frontend, just fix the query`
 - **Verbosity:** `@jr tl;dr` or `@jr more detail on the error handling`
 
+When Junior acknowledges a stop, it leaves the thread and cancels active resource watches for that conversation. A later `@jr` mention invites Junior back, but you must ask it to create those watches again.
+
 Junior cannot undo side effects that have already landed — a pushed commit, a filed issue, a sent Slack message. Redirect before the action, not after.
 
 ## Verify important output

--- a/packages/junior/src/chat/app/factory.ts
+++ b/packages/junior/src/chat/app/factory.ts
@@ -42,7 +42,7 @@ import {
 import type { SubscribedReplyDecision } from "@/chat/services/subscribed-reply-policy";
 import { botConfig } from "@/chat/config";
 import { standardModelId } from "@/chat/model-profile";
-import { cancelConversationResourceEventSubscriptions } from "@/chat/resource-events/store";
+import { cancelSubscriptions as cancelEventSubscriptions } from "@/chat/resource-events/store";
 
 export interface CreateSlackRuntimeOptions {
   getSlackAdapter: () => SlackAdapter;
@@ -118,9 +118,7 @@ export function createSlackRuntime(
 
   return createSlackTurnRuntime<PreparedTurnState, AssistantLifecycleEvent>({
     assistantUserName: botConfig.userName,
-    cancelResourceEventSubscriptions: async (conversationId) => {
-      await cancelConversationResourceEventSubscriptions({ conversationId });
-    },
+    cancelEventSubscriptions,
     modelId: standardModelId(botConfig),
     now: options.now ?? (() => Date.now()),
     getThreadId,

--- a/packages/junior/src/chat/app/factory.ts
+++ b/packages/junior/src/chat/app/factory.ts
@@ -42,6 +42,7 @@ import {
 import type { SubscribedReplyDecision } from "@/chat/services/subscribed-reply-policy";
 import { botConfig } from "@/chat/config";
 import { standardModelId } from "@/chat/model-profile";
+import { cancelConversationResourceEventSubscriptions } from "@/chat/resource-events/store";
 
 export interface CreateSlackRuntimeOptions {
   getSlackAdapter: () => SlackAdapter;
@@ -117,6 +118,9 @@ export function createSlackRuntime(
 
   return createSlackTurnRuntime<PreparedTurnState, AssistantLifecycleEvent>({
     assistantUserName: botConfig.userName,
+    cancelResourceEventSubscriptions: async (conversationId) => {
+      await cancelConversationResourceEventSubscriptions({ conversationId });
+    },
     modelId: standardModelId(botConfig),
     now: options.now ?? (() => Date.now()),
     getThreadId,

--- a/packages/junior/src/chat/resource-events/README.md
+++ b/packages/junior/src/chat/resource-events/README.md
@@ -9,6 +9,8 @@ conversation.
   operation.
 - Core owns subscription creation, cancellation, expiry, deduplication, and the
   conversation association.
+- A thread opt-out cancels every active subscription for that conversation
+  before the Slack thread is marked unsubscribed.
 - Provider route code validates and normalizes incoming events before calling
   the ingestion boundary.
 - Plugin-owned provider routes publish normalized events through the route-hook

--- a/packages/junior/src/chat/resource-events/store.ts
+++ b/packages/junior/src/chat/resource-events/store.ts
@@ -411,6 +411,28 @@ export async function cancelResourceEventSubscription(input: {
   });
 }
 
+/** Cancel every active resource event subscription bound to one conversation. */
+export async function cancelConversationResourceEventSubscriptions(input: {
+  conversationId: string;
+  nowMs?: number;
+  state?: StateAdapter;
+}): Promise<ResourceEventSubscription[]> {
+  const subscriptions = await listResourceEventSubscriptions(input);
+  const cancelled: ResourceEventSubscription[] = [];
+  for (const subscription of subscriptions) {
+    const result = await cancelResourceEventSubscription({
+      conversationId: input.conversationId,
+      id: subscription.id,
+      nowMs: input.nowMs,
+      state: input.state,
+    });
+    if (result) {
+      cancelled.push(result);
+    }
+  }
+  return cancelled;
+}
+
 /** Find active subscriptions interested in a normalized provider event. */
 export async function findMatchingResourceEventSubscriptions(input: {
   eventType: string;

--- a/packages/junior/src/chat/resource-events/store.ts
+++ b/packages/junior/src/chat/resource-events/store.ts
@@ -412,25 +412,20 @@ export async function cancelResourceEventSubscription(input: {
 }
 
 /** Cancel every active resource event subscription bound to one conversation. */
-export async function cancelConversationResourceEventSubscriptions(input: {
+export async function cancelSubscriptions(input: {
   conversationId: string;
   nowMs?: number;
   state?: StateAdapter;
-}): Promise<ResourceEventSubscription[]> {
+}): Promise<void> {
   const subscriptions = await listResourceEventSubscriptions(input);
-  const cancelled: ResourceEventSubscription[] = [];
   for (const subscription of subscriptions) {
-    const result = await cancelResourceEventSubscription({
+    await cancelResourceEventSubscription({
       conversationId: input.conversationId,
       id: subscription.id,
       nowMs: input.nowMs,
       state: input.state,
     });
-    if (result) {
-      cancelled.push(result);
-    }
   }
-  return cancelled;
 }
 
 /** Find active subscriptions interested in a normalized provider event. */

--- a/packages/junior/src/chat/runtime/slack-runtime.ts
+++ b/packages/junior/src/chat/runtime/slack-runtime.ts
@@ -103,6 +103,7 @@ function shouldRethrowTurnControlError(error: unknown): boolean {
 /** Apply a subscribed-thread opt-out decision before any agent work runs. */
 async function maybeHandleThreadOptOutDecision(args: {
   beforeFirstResponsePost?: () => Promise<void>;
+  cancelResourceEventSubscriptions: (conversationId: string) => Promise<void>;
   decision?: { shouldUnsubscribe?: boolean };
   thread: Thread;
 }): Promise<boolean> {
@@ -110,6 +111,7 @@ async function maybeHandleThreadOptOutDecision(args: {
     return false;
   }
 
+  await args.cancelResourceEventSubscriptions(args.thread.id);
   await args.thread.unsubscribe();
   await args.beforeFirstResponsePost?.();
   await args.thread.post(THREAD_OPTOUT_ACK);
@@ -129,6 +131,7 @@ type RuntimeLogContext = Record<string, unknown> & {
 
 export interface SlackTurnRuntimeDependencies<TPreparedState> {
   assistantUserName: string;
+  cancelResourceEventSubscriptions: (conversationId: string) => Promise<void>;
   getChannelId: (thread: Thread, message: Message) => string | undefined;
   getPreparedConversationContext: (
     preparedState: TPreparedState,
@@ -674,6 +677,7 @@ export function createSlackTurnRuntime<
         thread: args.thread,
         decision: skipped.decision,
         beforeFirstResponsePost: args.beforeFirstResponsePost,
+        cancelResourceEventSubscriptions: deps.cancelResourceEventSubscriptions,
       });
       logSkippedSubscribedDecision(skipped);
       await deps.recordSkippedSteeringMessage({
@@ -1041,6 +1045,8 @@ export function createSlackTurnRuntime<
               thread,
               decision,
               beforeFirstResponsePost: hooks.beforeFirstResponsePost,
+              cancelResourceEventSubscriptions:
+                deps.cancelResourceEventSubscriptions,
             })
           ) {
             await skipSubscribedMessage({

--- a/packages/junior/src/chat/runtime/slack-runtime.ts
+++ b/packages/junior/src/chat/runtime/slack-runtime.ts
@@ -100,24 +100,6 @@ function shouldRethrowTurnControlError(error: unknown): boolean {
   );
 }
 
-/** Apply a subscribed-thread opt-out decision before any agent work runs. */
-async function maybeHandleThreadOptOutDecision(args: {
-  beforeFirstResponsePost?: () => Promise<void>;
-  cancelResourceEventSubscriptions: (conversationId: string) => Promise<void>;
-  decision?: { shouldUnsubscribe?: boolean };
-  thread: Thread;
-}): Promise<boolean> {
-  if (!args.decision?.shouldUnsubscribe) {
-    return false;
-  }
-
-  await args.cancelResourceEventSubscriptions(args.thread.id);
-  await args.thread.unsubscribe();
-  await args.beforeFirstResponsePost?.();
-  await args.thread.post(THREAD_OPTOUT_ACK);
-  return true;
-}
-
 type RuntimeLogContext = Record<string, unknown> & {
   assistantUserName: string;
   conversationId?: string;
@@ -131,7 +113,9 @@ type RuntimeLogContext = Record<string, unknown> & {
 
 export interface SlackTurnRuntimeDependencies<TPreparedState> {
   assistantUserName: string;
-  cancelResourceEventSubscriptions: (conversationId: string) => Promise<void>;
+  cancelEventSubscriptions: (input: {
+    conversationId: string;
+  }) => Promise<void>;
   getChannelId: (thread: Thread, message: Message) => string | undefined;
   getPreparedConversationContext: (
     preparedState: TPreparedState,
@@ -402,6 +386,23 @@ export function createSlackTurnRuntime<
     threadId?: string;
     runId?: string;
   }): RuntimeLogContext => buildLogContext(deps, args);
+
+  /** Apply a subscribed-thread opt-out decision before any agent work runs. */
+  const maybeHandleThreadOptOutDecision = async (args: {
+    beforeFirstResponsePost?: () => Promise<void>;
+    decision?: { shouldUnsubscribe?: boolean };
+    thread: Thread;
+  }): Promise<boolean> => {
+    if (!args.decision?.shouldUnsubscribe) {
+      return false;
+    }
+
+    await deps.cancelEventSubscriptions({ conversationId: args.thread.id });
+    await args.thread.unsubscribe();
+    await args.beforeFirstResponsePost?.();
+    await args.thread.post(THREAD_OPTOUT_ACK);
+    return true;
+  };
 
   const failConversationTurn = async (args: {
     eventId: string;
@@ -677,7 +678,6 @@ export function createSlackTurnRuntime<
         thread: args.thread,
         decision: skipped.decision,
         beforeFirstResponsePost: args.beforeFirstResponsePost,
-        cancelResourceEventSubscriptions: deps.cancelResourceEventSubscriptions,
       });
       logSkippedSubscribedDecision(skipped);
       await deps.recordSkippedSteeringMessage({
@@ -1045,8 +1045,6 @@ export function createSlackTurnRuntime<
               thread,
               decision,
               beforeFirstResponsePost: hooks.beforeFirstResponsePost,
-              cancelResourceEventSubscriptions:
-                deps.cancelResourceEventSubscriptions,
             })
           ) {
             await skipSubscribedMessage({

--- a/packages/junior/tests/component/resource-events/resource-events.test.ts
+++ b/packages/junior/tests/component/resource-events/resource-events.test.ts
@@ -17,6 +17,7 @@ import { JUNIOR_THREAD_STATE_TTL_MS } from "@/chat/state/ttl";
 import { getConversationWorkState } from "@/chat/task-execution/store";
 import { ingestResourceEvent } from "@/chat/resource-events/ingest";
 import {
+  cancelConversationResourceEventSubscriptions,
   cancelResourceEventSubscription,
   createResourceEventSubscription,
   deliverResourceEventSubscription,
@@ -322,6 +323,31 @@ describe("resource event subscriptions", () => {
       ),
     ).resolves.toEqual({ enqueued: 0 });
     expect(queue.sentRecords()).toEqual([]);
+  });
+
+  it("cancels every active subscription for a conversation", async () => {
+    const first = await createGithubPrSubscription({
+      events: ["checks.failed"],
+    });
+    const second = await createGithubPrSubscription({
+      events: ["pull_request.merged"],
+    });
+
+    await expect(
+      cancelConversationResourceEventSubscriptions({
+        conversationId: CONVERSATION_ID,
+        nowMs: 1_200,
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({ id: first.id, status: "cancelled" }),
+      expect.objectContaining({ id: second.id, status: "cancelled" }),
+    ]);
+    await expect(
+      listResourceEventSubscriptions({
+        conversationId: CONVERSATION_ID,
+        nowMs: 1_300,
+      }),
+    ).resolves.toEqual([]);
   });
 
   it("does not deliver from a stale match after cancellation", async () => {

--- a/packages/junior/tests/component/resource-events/resource-events.test.ts
+++ b/packages/junior/tests/component/resource-events/resource-events.test.ts
@@ -17,8 +17,8 @@ import { JUNIOR_THREAD_STATE_TTL_MS } from "@/chat/state/ttl";
 import { getConversationWorkState } from "@/chat/task-execution/store";
 import { ingestResourceEvent } from "@/chat/resource-events/ingest";
 import {
-  cancelConversationResourceEventSubscriptions,
   cancelResourceEventSubscription,
+  cancelSubscriptions,
   createResourceEventSubscription,
   deliverResourceEventSubscription,
   findMatchingResourceEventSubscriptions,
@@ -326,22 +326,17 @@ describe("resource event subscriptions", () => {
   });
 
   it("cancels every active subscription for a conversation", async () => {
-    const first = await createGithubPrSubscription({
+    await createGithubPrSubscription({
       events: ["checks.failed"],
     });
-    const second = await createGithubPrSubscription({
+    await createGithubPrSubscription({
       events: ["pull_request.merged"],
     });
 
-    await expect(
-      cancelConversationResourceEventSubscriptions({
-        conversationId: CONVERSATION_ID,
-        nowMs: 1_200,
-      }),
-    ).resolves.toEqual([
-      expect.objectContaining({ id: first.id, status: "cancelled" }),
-      expect.objectContaining({ id: second.id, status: "cancelled" }),
-    ]);
+    await cancelSubscriptions({
+      conversationId: CONVERSATION_ID,
+      nowMs: 1_200,
+    });
     await expect(
       listResourceEventSubscriptions({
         conversationId: CONVERSATION_ID,

--- a/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { StateAdapter } from "chat";
 import {
   SLACK_BOT_USER_ID,
+  SLACK_DESTINATION,
   SLACK_SIGNING_SECRET,
   createConversationWorkQueueTestAdapter,
   deferred,
@@ -27,6 +28,10 @@ import {
 } from "@/chat/task-execution/store";
 import { processConversationQueueMessage } from "@/chat/task-execution/vercel-callback";
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
+import {
+  createResourceEventSubscription,
+  listResourceEventSubscriptions,
+} from "@/chat/resource-events/store";
 import {
   deliverAssistantMessagesForTest,
   flattenAgentRunRequestForTest,
@@ -584,6 +589,20 @@ describe("Slack behavior: durable turn steering", () => {
       agentRunner: { run: executeAgentRun },
       state,
     });
+    await createResourceEventSubscription(
+      {
+        conversationId,
+        destination: SLACK_DESTINATION,
+        events: ["checks.failed"],
+        expiresAtMs: Date.now() + 60_000,
+        intent: "Watch CI while this turn is active.",
+        label: "Pull request checks",
+        provider: "github",
+        resourceRef: "github:pull_request:getsentry/junior#steering",
+        resourceType: "pull_request",
+      },
+      { state },
+    );
 
     await expect(
       handleSlackWebhookAndFlush({
@@ -629,6 +648,9 @@ describe("Slack behavior: durable turn steering", () => {
     releaseAgent.resolve();
     await expect(activeTurn).resolves.toEqual({ status: "completed" });
     expect(await state.isSubscribed(conversationId)).toBe(false);
+    await expect(
+      listResourceEventSubscriptions({ conversationId, state }),
+    ).resolves.toEqual([]);
     expect(drainedTexts).toEqual([]);
 
     expect(reactionTargetsByName("eyes")).toEqual([

--- a/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
@@ -13,6 +13,10 @@ import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { hydrateConversationMessages } from "@/chat/conversations/messages";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
 import {
+  createResourceEventSubscription,
+  listResourceEventSubscriptions,
+} from "@/chat/resource-events/store";
+import {
   deliverAssistantMessagesForTest,
   flattenAgentRunRequestForTest,
 } from "../../fixtures/agent-runner";
@@ -535,6 +539,31 @@ describe("Slack behavior: subscribed messages", () => {
 
     expect(thread.subscribed).toBe(true);
 
+    const subscriptionDestination = createTestDestination(thread);
+    const expiresAtMs = Date.now() + 60_000;
+    await createResourceEventSubscription({
+      conversationId: thread.id,
+      destination: subscriptionDestination,
+      events: ["checks.failed"],
+      expiresAtMs,
+      intent: "Watch CI for this thread.",
+      label: "Pull request checks",
+      provider: "github",
+      resourceRef: "github:pull_request:getsentry/junior#100",
+      resourceType: "pull_request",
+    });
+    await createResourceEventSubscription({
+      conversationId: thread.id,
+      destination: subscriptionDestination,
+      events: ["issue.updated"],
+      expiresAtMs,
+      intent: "Watch the issue for this thread.",
+      label: "Tracking issue",
+      provider: "github",
+      resourceRef: "github:issue:getsentry/junior#101",
+      resourceType: "issue",
+    });
+
     await slackRuntime.handleSubscribedMessage(
       thread,
       createTestMessage({
@@ -550,6 +579,9 @@ describe("Slack behavior: subscribed messages", () => {
     expect(classifierCalled).toBe(false);
     expect(replyCalls).toHaveLength(1);
     expect(thread.subscribed).toBe(false);
+    await expect(
+      listResourceEventSubscriptions({ conversationId: thread.id }),
+    ).resolves.toEqual([]);
     expect(toPostedText(thread.posts[1])).toContain(
       "I'll stay out of this thread unless someone @mentions me again.",
     );

--- a/packages/junior/tests/unit/slack/slack-runtime.test.ts
+++ b/packages/junior/tests/unit/slack/slack-runtime.test.ts
@@ -19,6 +19,7 @@ function createMockDeps(
 ): SlackTurnRuntimeDependencies<TestState> {
   return {
     assistantUserName: "test-bot",
+    cancelResourceEventSubscriptions: vi.fn().mockResolvedValue(undefined),
     modelId: "test-model",
     now: () => 1700000000000,
     getChannelId: (_thread, message) => message.threadId?.split(":")[1],
@@ -117,6 +118,39 @@ describe("createSlackTurnRuntime", () => {
   });
 
   describe("handleSubscribedMessage", () => {
+    it("does not unsubscribe the thread when resource cleanup fails", async () => {
+      const cleanupError = new Error("resource cleanup failed");
+      const deps = createMockDeps({
+        cancelResourceEventSubscriptions: vi
+          .fn()
+          .mockRejectedValue(cleanupError),
+        decideSubscribedReply: vi.fn().mockResolvedValue({
+          shouldReply: false,
+          shouldUnsubscribe: true,
+          reason: "explicit stop",
+        }),
+      });
+      const runtime = createSlackTurnRuntime<TestState>(deps);
+      const thread = createTestThread({});
+      const message = createTestMessage({});
+      await thread.subscribe();
+
+      await expect(
+        runtime.handleSubscribedMessage(thread, message, {
+          destination: createTestDestination(thread),
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(deps.cancelResourceEventSubscriptions).toHaveBeenCalledWith(
+        thread.id,
+      );
+      expect(thread.subscribed).toBe(true);
+      expect(thread.posts).toHaveLength(1);
+      expect(thread.posts).not.toContain(
+        "Understood. I'll stay out of this thread unless someone @mentions me again.",
+      );
+    });
+
     it("passes stripped text via stripLeadingBotMention to prepareTurnState", async () => {
       const deps = createMockDeps({
         stripLeadingBotMention: vi.fn(() => "stripped text"),

--- a/packages/junior/tests/unit/slack/slack-runtime.test.ts
+++ b/packages/junior/tests/unit/slack/slack-runtime.test.ts
@@ -19,7 +19,7 @@ function createMockDeps(
 ): SlackTurnRuntimeDependencies<TestState> {
   return {
     assistantUserName: "test-bot",
-    cancelResourceEventSubscriptions: vi.fn().mockResolvedValue(undefined),
+    cancelEventSubscriptions: vi.fn().mockResolvedValue(undefined),
     modelId: "test-model",
     now: () => 1700000000000,
     getChannelId: (_thread, message) => message.threadId?.split(":")[1],
@@ -121,9 +121,7 @@ describe("createSlackTurnRuntime", () => {
     it("does not unsubscribe the thread when resource cleanup fails", async () => {
       const cleanupError = new Error("resource cleanup failed");
       const deps = createMockDeps({
-        cancelResourceEventSubscriptions: vi
-          .fn()
-          .mockRejectedValue(cleanupError),
+        cancelEventSubscriptions: vi.fn().mockRejectedValue(cleanupError),
         decideSubscribedReply: vi.fn().mockResolvedValue({
           shouldReply: false,
           shouldUnsubscribe: true,
@@ -141,9 +139,9 @@ describe("createSlackTurnRuntime", () => {
         }),
       ).resolves.toBeUndefined();
 
-      expect(deps.cancelResourceEventSubscriptions).toHaveBeenCalledWith(
-        thread.id,
-      );
+      expect(deps.cancelEventSubscriptions).toHaveBeenCalledWith({
+        conversationId: thread.id,
+      });
       expect(thread.subscribed).toBe(true);
       expect(thread.posts).toHaveLength(1);
       expect(thread.posts).not.toContain(


### PR DESCRIPTION
Explicit Slack stop requests now cancel every active resource-event subscription for the conversation before Junior unsubscribes from the thread. This prevents provider events from waking a thread after Junior has acknowledged the opt-out; a later direct mention can still re-engage Junior, but its watches must be recreated.

The cleanup applies to both ordinary subscribed messages and stop decisions drained during an active turn. If resource cleanup fails, Junior keeps the thread subscribed and uses the existing failure response instead of confirming an incomplete opt-out.
