### PR TITLE
feat(dashboard): Archive conversations from sidebar

### DIFF
--- a/packages/junior-dashboard/e2e/dashboard.spec.ts
+++ b/packages/junior-dashboard/e2e/dashboard.spec.ts
@@ -457,7 +457,7 @@ test("inspects and copies an advisor transcript", async ({ context, page }) => {
   await expect(drawer).toBeVisible();
 });
 
-test("archives a conversation from the sidebar without navigating", async ({
+test("archives and restores a conversation from the sidebar", async ({
   page,
 }) => {
   await page.setViewportSize({ height: 900, width: 1600 });
@@ -486,5 +486,29 @@ test("archives a conversation from the sidebar without navigating", async ({
   const archiveRequest = await archiveRequestPromise;
 
   expect(archiveRequest.postDataJSON()).toMatchObject({ archived: true });
+  expect(page.url()).toBe(currentUrl);
+  await expect(
+    page.getByRole("status").filter({
+      hasText: "Dashboard QA edge cases archived",
+    }),
+  ).toBeVisible();
+
+  const restoreRequestPromise = page.waitForRequest(
+    (request) =>
+      request.method() === "PATCH" && request.url().endsWith("/archive"),
+  );
+  await page
+    .getByRole("button", {
+      name: "Undo archive for Dashboard QA edge cases",
+    })
+    .click();
+  const restoreRequest = await restoreRequestPromise;
+
+  expect(restoreRequest.postDataJSON()).toMatchObject({ archived: false });
+  await expect(
+    page.getByRole("status").filter({
+      hasText: "Dashboard QA edge cases archived",
+    }),
+  ).toHaveCount(0);
   expect(page.url()).toBe(currentUrl);
 });

--- a/packages/junior-dashboard/e2e/dashboard.spec.ts
+++ b/packages/junior-dashboard/e2e/dashboard.spec.ts
@@ -456,3 +456,35 @@ test("inspects and copies an advisor transcript", async ({ context, page }) => {
   await page.setViewportSize({ height: 844, width: 390 });
   await expect(drawer).toBeVisible();
 });
+
+test("archives a conversation from the sidebar without navigating", async ({
+  page,
+}) => {
+  await page.setViewportSize({ height: 900, width: 1600 });
+  await page.route("**/api/conversations/*/archive", async (route) => {
+    await route.fulfill({ json: { archived: true } });
+  });
+  await page.goto(baseURL);
+  await expect(
+    page.getByRole("heading", { name: "Investigate checkout latency" }),
+  ).toBeVisible();
+
+  const conversationLink = page.getByRole("link", {
+    name: /Dashboard QA edge cases/,
+  });
+  const archiveButton = page.getByRole("button", {
+    name: "Archive Dashboard QA edge cases",
+  });
+  await conversationLink.hover();
+
+  const currentUrl = page.url();
+  const archiveRequestPromise = page.waitForRequest(
+    (request) =>
+      request.method() === "PATCH" && request.url().endsWith("/archive"),
+  );
+  await archiveButton.click();
+  const archiveRequest = await archiveRequestPromise;
+
+  expect(archiveRequest.postDataJSON()).toMatchObject({ archived: true });
+  expect(page.url()).toBe(currentUrl);
+});

--- a/packages/junior-dashboard/src/client/components/ConversationSidebar.tsx
+++ b/packages/junior-dashboard/src/client/components/ConversationSidebar.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Archive, MessageSquareText, Search } from "lucide-react";
 import { Link } from "react-router";
 
@@ -22,8 +23,10 @@ export function ConversationSidebar(props: {
   selectedId?: string;
   onQueryChange(value: string): void;
 }) {
+  const [archivedConversation, setArchivedConversation] =
+    useState<Conversation>();
   return (
-    <aside className="grid h-full min-h-0 min-w-0 grid-rows-[auto_auto_minmax(0,1fr)] overflow-hidden border-r border-white/[0.07] bg-white/[0.02]">
+    <aside className="relative grid h-full min-h-0 min-w-0 grid-rows-[auto_auto_minmax(0,1fr)] overflow-hidden border-r border-white/[0.07] bg-white/[0.02]">
       <div className="px-5 pb-3 pt-5">
         <div className="mb-2 flex items-center gap-2 font-mono text-[0.62rem] uppercase tracking-[0.16em] text-cyan-200/65">
           <MessageSquareText aria-hidden="true" size={13} />
@@ -70,18 +73,26 @@ export function ConversationSidebar(props: {
               <ConversationSidebarRow
                 conversation={conversation}
                 key={conversation.id}
+                onArchived={setArchivedConversation}
                 selected={conversation.id === props.selectedId}
               />
             ))}
           </nav>
         )}
       </div>
+      {archivedConversation ? (
+        <ArchivedConversationNotice
+          conversation={archivedConversation}
+          onRestored={() => setArchivedConversation(undefined)}
+        />
+      ) : null}
     </aside>
   );
 }
 
 function ConversationSidebarRow(props: {
   conversation: Conversation;
+  onArchived(conversation: Conversation): void;
   selected: boolean;
 }) {
   const archive = useArchiveConversation(props.conversation.id);
@@ -135,10 +146,15 @@ function ConversationSidebarRow(props: {
         )}
         disabled={archive.isPending}
         onClick={() =>
-          archive.mutate({
-            archived: true,
-            lastSeenAt: props.conversation.lastSeenAt,
-          })
+          archive.mutate(
+            {
+              archived: true,
+              lastSeenAt: props.conversation.lastSeenAt,
+            },
+            {
+              onSuccess: () => props.onArchived(props.conversation),
+            },
+          )
         }
         title={
           archive.error ? `Could not archive ${title}` : `Archive ${title}`
@@ -147,6 +163,51 @@ function ConversationSidebarRow(props: {
       >
         <Archive aria-hidden="true" size={15} />
       </button>
+    </div>
+  );
+}
+
+function ArchivedConversationNotice(props: {
+  conversation: Conversation;
+  onRestored(): void;
+}) {
+  const restore = useArchiveConversation(props.conversation.id);
+  const title = conversationDisplayTitle(props.conversation);
+  return (
+    <div className="absolute bottom-3 left-3 right-3 z-20 rounded-lg border border-white/15 bg-[#111719] px-3 py-2.5 shadow-[0_12px_32px_rgba(0,0,0,0.45)]">
+      <div className="flex min-w-0 items-center gap-3">
+        <div
+          className="min-w-0 flex-1 truncate font-mono text-[0.68rem] text-white/65"
+          role="status"
+        >
+          {title} archived
+        </div>
+        <button
+          aria-label={`Undo archive for ${title}`}
+          className="shrink-0 rounded border border-white/15 px-2 py-1 font-mono text-[0.65rem] text-cyan-100/75 transition hover:border-white/30 hover:text-cyan-50 focus:outline-none focus:ring-2 focus:ring-cyan-300/35 disabled:opacity-40"
+          disabled={restore.isPending}
+          onClick={() =>
+            restore.mutate(
+              {
+                archived: false,
+                lastSeenAt: props.conversation.lastSeenAt,
+              },
+              { onSuccess: props.onRestored },
+            )
+          }
+          type="button"
+        >
+          {restore.isPending ? "Restoring…" : "Undo"}
+        </button>
+      </div>
+      {restore.error ? (
+        <div
+          className="mt-1 font-mono text-[0.62rem] text-rose-200/80"
+          role="alert"
+        >
+          Could not restore the conversation.
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/packages/junior-dashboard/src/client/components/ConversationSidebar.tsx
+++ b/packages/junior-dashboard/src/client/components/ConversationSidebar.tsx
@@ -1,6 +1,7 @@
-import { MessageSquareText, Search } from "lucide-react";
+import { Archive, MessageSquareText, Search } from "lucide-react";
 import { Link } from "react-router";
 
+import { useArchiveConversation } from "../api";
 import {
   conversationDisplayTitle,
   conversationPath,
@@ -83,45 +84,69 @@ function ConversationSidebarRow(props: {
   conversation: Conversation;
   selected: boolean;
 }) {
+  const archive = useArchiveConversation(props.conversation.id);
   const status = visualStatusForConversation(props.conversation);
   const location = slackLocationLabel(props.conversation, {
     includeId: false,
   });
+  const title = conversationDisplayTitle(props.conversation);
   return (
-    <Link
-      aria-current={props.selected ? "page" : undefined}
-      className={cn(
-        "relative block min-w-0 rounded-lg border border-transparent px-3 py-3 text-inherit no-underline transition-all hover:border-white/[0.07] hover:bg-white/[0.035]",
-        props.selected && "border-cyan-300/20 bg-cyan-300/[0.07]",
-      )}
-      to={conversationPath(props.conversation.id)}
-    >
-      <div className="flex min-w-0 items-center gap-2">
-        <span
-          aria-hidden="true"
-          className={cn(
-            "size-1.5 shrink-0 rounded-full",
-            status === "active" &&
-              "bg-emerald-300 shadow-[0_0_10px_rgba(110,231,183,0.55)]",
-            status === "failed" && "bg-rose-300",
-            status === "idle" && "bg-white/25",
-          )}
-        />
-        <div className="truncate font-display text-[0.92rem] font-medium leading-tight text-white/90">
-          {conversationDisplayTitle(props.conversation)}
+    <div className="group relative min-w-0">
+      <Link
+        aria-current={props.selected ? "page" : undefined}
+        className={cn(
+          "block min-w-0 rounded-lg border border-transparent px-3 py-3 text-inherit no-underline transition-all hover:border-white/[0.07] hover:bg-white/[0.035]",
+          props.selected && "border-cyan-300/20 bg-cyan-300/[0.07]",
+        )}
+        to={conversationPath(props.conversation.id)}
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          <span
+            aria-hidden="true"
+            className={cn(
+              "size-1.5 shrink-0 rounded-full",
+              status === "active" &&
+                "bg-emerald-300 shadow-[0_0_10px_rgba(110,231,183,0.55)]",
+              status === "failed" && "bg-rose-300",
+              status === "idle" && "bg-white/25",
+            )}
+          />
+          <div className="truncate font-display text-[0.92rem] font-medium leading-tight text-white/90">
+            {title}
+          </div>
         </div>
-      </div>
-      <div className="ml-3.5 mt-1.5 flex min-w-0 items-center gap-1.5 font-mono text-[0.62rem] leading-tight text-white/30">
-        <span className="shrink-0">
-          {formatRelativeTime(props.conversation.lastSeenAt)}
-        </span>
-        {location ? (
-          <>
-            <span aria-hidden="true">·</span>
-            <span className="truncate">{location}</span>
-          </>
-        ) : null}
-      </div>
-    </Link>
+        <div className="ml-3.5 mt-1.5 flex min-w-0 items-center gap-1.5 font-mono text-[0.62rem] leading-tight text-white/30">
+          <span className="shrink-0">
+            {formatRelativeTime(props.conversation.lastSeenAt)}
+          </span>
+          {location ? (
+            <>
+              <span aria-hidden="true">·</span>
+              <span className="truncate">{location}</span>
+            </>
+          ) : null}
+        </div>
+      </Link>
+      <button
+        aria-label={`Archive ${title}`}
+        className={cn(
+          "pointer-events-none absolute right-2 top-1/2 z-10 grid size-8 -translate-y-1/2 place-items-center rounded-md border border-white/15 bg-[#111719] text-white/60 opacity-0 shadow-[-8px_0_12px_rgba(9,12,14,0.8)] transition hover:border-white/30 hover:text-white focus:pointer-events-auto focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-cyan-300/35 group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100",
+          archive.error && "border-rose-300/30 text-rose-200/80",
+        )}
+        disabled={archive.isPending}
+        onClick={() =>
+          archive.mutate({
+            archived: true,
+            lastSeenAt: props.conversation.lastSeenAt,
+          })
+        }
+        title={
+          archive.error ? `Could not archive ${title}` : `Archive ${title}`
+        }
+        type="button"
+      >
+        <Archive aria-hidden="true" size={15} />
+      </button>
+    </div>
   );
 }


### PR DESCRIPTION
Conversation rows in the dashboard sidebar now reveal a vertically centered
archive button on hover or keyboard focus. The opaque, raised control masks
underlying text and calls the existing archive mutation without navigating away
from the selected conversation.

After the row leaves the active feed, the sidebar keeps a persistent Undo notice
that restores the conversation through the same mutation. The conversation link
and archive button remain separate interactive elements, and browser coverage
exercises the complete archive and restore flow.
