### PR TITLE
fix(conversations): Project compacted history consistently

### DIFF
--- a/packages/junior/src/chat/conversations/history.ts
+++ b/packages/junior/src/chat/conversations/history.ts
@@ -362,6 +362,21 @@ export const conversationEventSchema = z.union([
 /** One versioned event read from the durable conversation log. */
 export type ConversationEvent = z.output<typeof conversationEventSchema>;
 
+/** A decoded message-summary event and its readable history boundary. */
+export type MessagesSummarizedEvent = Omit<
+  Extract<ConversationEvent, { schemaVersion: 1 }>,
+  "data"
+> & {
+  data: Extract<ConversationEventData, { type: "messages_summarized" }>;
+};
+
+/** Projection-ready message events paired with their authoritative boundary. */
+export interface MessageHistory {
+  events: ConversationEvent[];
+  compaction: MessagesSummarizedEvent | undefined;
+  historyFromSeq: number;
+}
+
 const storedConversationEventSchema = conversationEventEnvelopeSchema.extend({
   type: z.string().min(1),
   payload: z.unknown(),
@@ -421,11 +436,8 @@ export interface ConversationEventStore {
     seq: number,
     throughSeq?: number,
   ): Promise<ConversationEvent[] | undefined>;
-  /** Current source/destination messages and their latest summary snapshot. */
-  loadMessageHistory(conversationId: string): Promise<{
-    events: ConversationEvent[];
-    compaction: ConversationEvent | undefined;
-  }>;
+  /** Projection-ready message suffix, summary snapshot, and readable boundary. */
+  loadMessageHistory(conversationId: string): Promise<MessageHistory>;
   /** All events across every history version in `seq` order. */
   loadHistory(conversationId: string): Promise<ConversationEvent[]>;
 }

--- a/packages/junior/src/chat/conversations/message-projection.ts
+++ b/packages/junior/src/chat/conversations/message-projection.ts
@@ -1,4 +1,4 @@
-import type { ConversationEvent } from "./history";
+import type { ConversationEvent, MessageHistory } from "./history";
 import type {
   ConversationAuthor,
   ConversationMessage,
@@ -48,14 +48,13 @@ function missingBaselineError(event: MessageEvent): Error {
   );
 }
 
-/** Reduce canonical message facts into destination-facing history. */
+/** Reduce a boundary-bearing message-history suffix into destination history. */
 export function projectConversationMessages(
-  events: ConversationEvent[],
-  options: { historyFromSeq?: number } = {},
+  history: Pick<MessageHistory, "events" | "historyFromSeq">,
 ): ConversationMessage[] {
   const byId = new Map<string, ProjectedMessage>();
 
-  for (const event of events) {
+  for (const event of history.events) {
     if (!isMessageEvent(event)) continue;
     const data = event.data;
     const current = byId.get(data.messageId);
@@ -73,7 +72,7 @@ export function projectConversationMessages(
           `Duplicate message event for ${data.messageId} at seq ${event.seq}`,
         );
       if (data.type === "message_updated" && !current) {
-        if ((options.historyFromSeq ?? 0) > 0) continue;
+        if (history.historyFromSeq > 0) continue;
         throw missingBaselineError(event);
       }
       byId.set(data.messageId, {
@@ -89,7 +88,7 @@ export function projectConversationMessages(
     }
 
     if (!current) {
-      if ((options.historyFromSeq ?? 0) > 0) continue;
+      if (history.historyFromSeq > 0) continue;
       throw missingBaselineError(event);
     }
     current.repliedAtMs ??= event.createdAtMs;

--- a/packages/junior/src/chat/conversations/message-summaries.ts
+++ b/packages/junior/src/chat/conversations/message-summaries.ts
@@ -41,12 +41,7 @@ export async function persistConversationMessageSummaries(args: {
   )?.seq;
   const nextHistoryFromSeq =
     historyFromSeq ??
-    Math.max(
-      history.compaction?.data.type === "messages_summarized"
-        ? history.compaction.data.historyFromSeq
-        : 0,
-      (history.events.at(-1)?.seq ?? -1) + 1,
-    );
+    Math.max(history.historyFromSeq, (history.events.at(-1)?.seq ?? -1) + 1);
   await eventStore.append(args.conversationId, [
     {
       data: {

--- a/packages/junior/src/chat/conversations/messages.ts
+++ b/packages/junior/src/chat/conversations/messages.ts
@@ -76,13 +76,7 @@ export async function hydrateConversationMessages(args: {
   args.conversation.compactions = history.compaction
     ? projectConversationMessageSummaries([history.compaction])
     : [];
-  const historyFromSeq =
-    history.compaction?.data.type === "messages_summarized"
-      ? history.compaction.data.historyFromSeq
-      : 0;
-  args.conversation.messages = projectConversationMessages(history.events, {
-    historyFromSeq,
-  });
+  args.conversation.messages = projectConversationMessages(history);
   updateConversationStats(args.conversation);
 }
 
@@ -98,7 +92,7 @@ export async function persistConversationMessages(args: {
     args.conversationId,
   );
   const existingMessages = new Map(
-    projectConversationMessages(history.events).map((message) => [
+    projectConversationMessages(history).map((message) => [
       message.id,
       message,
     ]),

--- a/packages/junior/src/chat/conversations/sql/history.ts
+++ b/packages/junior/src/chat/conversations/sql/history.ts
@@ -19,6 +19,8 @@ import {
   type ConversationEventStore,
   type ConversationEventData,
   type HistoryReplacement,
+  type MessageHistory,
+  type MessagesSummarizedEvent,
   type NewConversationEvent,
 } from "../history";
 import { ensureConversationRow } from "./conversation-row";
@@ -71,6 +73,19 @@ function eventFromRow(row: ConversationEventRow): ConversationEvent {
     type: row.type,
     payload: row.payload,
   });
+}
+
+/** Decode the summary row that defines a readable message-history suffix. */
+function messagesSummarizedEventFromRow(
+  row: ConversationEventRow,
+): MessagesSummarizedEvent {
+  const event = eventFromRow(row);
+  if (event.schemaVersion !== 1 || event.data.type !== "messages_summarized") {
+    throw new Error(
+      "Message compaction row did not decode as messages_summarized",
+    );
+  }
+  return { ...event, schemaVersion: 1, data: event.data };
 }
 
 class SqlConversationEventStore implements ConversationEventStore {
@@ -240,10 +255,7 @@ class SqlConversationEventStore implements ConversationEventStore {
     return rows.map(eventFromRow);
   }
 
-  async loadMessageHistory(conversationId: string): Promise<{
-    events: ConversationEvent[];
-    compaction: ConversationEvent | undefined;
-  }> {
+  async loadMessageHistory(conversationId: string): Promise<MessageHistory> {
     const [compactionRow] = await this.executor
       .db()
       .select()
@@ -256,11 +268,10 @@ class SqlConversationEventStore implements ConversationEventStore {
       )
       .orderBy(desc(juniorConversationEvents.seq))
       .limit(1);
-    const compaction = compactionRow ? eventFromRow(compactionRow) : undefined;
-    const historyFromSeq =
-      compaction?.data.type === "messages_summarized"
-        ? compaction.data.historyFromSeq
-        : 0;
+    const compaction = compactionRow
+      ? messagesSummarizedEventFromRow(compactionRow)
+      : undefined;
+    const historyFromSeq = compaction?.data.historyFromSeq ?? 0;
     const rows = await this.executor
       .db()
       .select()
@@ -273,7 +284,7 @@ class SqlConversationEventStore implements ConversationEventStore {
         ),
       )
       .orderBy(asc(juniorConversationEvents.seq));
-    return { events: rows.map(eventFromRow), compaction };
+    return { events: rows.map(eventFromRow), compaction, historyFromSeq };
   }
 
   async loadHistory(conversationId: string): Promise<ConversationEvent[]> {

--- a/packages/junior/tests/component/cli/conversation-event-migration.test.ts
+++ b/packages/junior/tests/component/cli/conversation-event-migration.test.ts
@@ -270,9 +270,7 @@ describe("conversation event migration", () => {
       });
       expect(visible.events.map((event) => event.seq)).toEqual([502]);
       expect(
-        projectConversationMessages(visible.events, {
-          historyFromSeq: 502,
-        }).map((message) => message.id),
+        projectConversationMessages(visible).map((message) => message.id),
       ).toEqual(["live"]);
       expect(
         JSON.stringify(await store.loadHistory(conversationId)),

--- a/packages/junior/tests/component/conversation-storage-sql.test.ts
+++ b/packages/junior/tests/component/conversation-storage-sql.test.ts
@@ -757,6 +757,7 @@ INSERT INTO junior_conversation_events (
             compactions: [],
           },
         }),
+        historyFromSeq: 2,
       });
     } finally {
       await fixture.close();
@@ -828,9 +829,7 @@ WHERE conversation_id = $1 AND seq = 0
       expect(visible.events[0]?.seq).toBe(historyFromSeq);
       expect(visible.events).toHaveLength(conversation.messages.length);
       expect(
-        projectConversationMessages(visible.events).map(
-          (message) => message.id,
-        ),
+        projectConversationMessages(visible).map((message) => message.id),
       ).toEqual(conversation.messages.map((message) => message.id));
     } finally {
       await fixture.close();
@@ -1084,7 +1083,7 @@ INSERT INTO junior_conversation_events (
         },
       ]);
       const history = await store.loadMessageHistory(CONVERSATION_ID);
-      expect(projectConversationMessages(history.events)).toEqual([
+      expect(projectConversationMessages(history)).toEqual([
         {
           id: "m1",
           role: "user",

--- a/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
@@ -11,6 +11,7 @@ import {
 import { completedAgentRun } from "@/chat/runtime/agent-run-outcome";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
 import { hydrateConversationMessages } from "@/chat/conversations/messages";
+import { getConversationEventStore, getConversationStore } from "@/chat/db";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
 import {
   deliverAssistantMessagesForTest,
@@ -226,6 +227,116 @@ describe("Slack behavior: subscribed messages", () => {
       }),
     ]);
     expect(thread.posts).toHaveLength(1);
+  });
+
+  it("processes resource events when compacted history retains a handled marker without its message", async () => {
+    const agentRunner = vi.fn<AgentRunner["run"]>(async (request) =>
+      completedReply(request, "I processed the recovered check event."),
+    );
+    const { slackRuntime } = createRuntime({
+      services: {
+        replyExecutor: { agentRunner: { run: agentRunner } },
+      },
+    });
+    const thread = createTestThread({
+      id: "slack:C0BEHAVIOR:1700002000.0025",
+    });
+    const destination = createTestDestination(thread);
+    await getConversationStore().recordActivity({
+      conversationId: thread.id,
+      destination,
+      nowMs: 1_000,
+      source: "resource_event",
+      visibility: "private",
+    });
+    // Late delivery state remains valid after its covered message falls before
+    // the readable compaction boundary.
+    await getConversationEventStore().append(thread.id, [
+      {
+        data: {
+          type: "message",
+          messageId: "compacted-user-message",
+          role: "user",
+          text: "Old request that has already been summarized.",
+        },
+        createdAtMs: 1_000,
+      },
+      {
+        data: {
+          type: "messages_summarized",
+          historyFromSeq: 2,
+          compactions: [
+            {
+              id: "compaction-1",
+              summary: "The old request was completed.",
+              coveredMessageCount: 1,
+              createdAtMs: 2_000,
+            },
+          ],
+        },
+        createdAtMs: 2_000,
+      },
+      {
+        data: {
+          type: "message_handled",
+          messageId: "compacted-user-message",
+        },
+        createdAtMs: 3_000,
+      },
+    ]);
+
+    const message = createTestMessage({
+      id: "resource-event-resub-checks-recovered",
+      text: "[event notification]\n\nThe subscribed check recovered.",
+      isMention: false,
+      threadId: thread.id,
+      author: {
+        userId: "UJRNEVENT",
+        userName: "junior-event",
+        fullName: "Junior event",
+        isBot: true,
+      },
+      raw: {
+        channel: "C0BEHAVIOR",
+        event_type: "resource_event",
+        thread_ts: "1700002000.0025",
+        ts: "resource-event-resub-checks-recovered",
+        type: "message",
+        user: "UJRNEVENT",
+      },
+    });
+
+    await slackRuntime.handleSubscribedMessage(thread, message, {
+      destination,
+    });
+
+    expect(agentRunner).toHaveBeenCalledOnce();
+    expect(thread.posts).toHaveLength(1);
+    expect(toPostedText(thread.posts[0])).toContain(
+      "I processed the recovered check event.",
+    );
+    const conversation = coerceThreadConversationState(
+      (await thread.state) ?? {},
+    );
+    await hydrateConversationMessages({
+      conversation,
+      conversationId: thread.id,
+    });
+    expect(conversation.messages).not.toContainEqual(
+      expect.objectContaining({ id: "compacted-user-message" }),
+    );
+    expect(conversation.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "resource-event-resub-checks-recovered",
+          role: "user",
+        }),
+        expect.objectContaining({
+          role: "assistant",
+          text: "I processed the recovered check event.",
+        }),
+      ]),
+    );
   });
 
   it("posts an auth-needed reply when a resource-event turn needs user auth", async () => {

--- a/packages/junior/tests/unit/conversations/message-projection.test.ts
+++ b/packages/junior/tests/unit/conversations/message-projection.test.ts
@@ -23,26 +23,29 @@ function event(
 describe("message projection", () => {
   it("preserves message metadata and marks a handled message", () => {
     expect(
-      projectConversationMessages([
-        event(0, 1_000, {
-          type: "message",
-          messageId: "m1",
-          role: "user",
-          text: "hello",
-          meta: {
-            author: { userId: "U1", userName: "alice" },
-            explicitMention: true,
-          },
-        }),
-        event(1, 3_000, {
-          type: "message_handled",
-          messageId: "m1",
-        }),
-        event(2, 4_000, {
-          type: "message_handled",
-          messageId: "m1",
-        }),
-      ]),
+      projectConversationMessages({
+        historyFromSeq: 0,
+        events: [
+          event(0, 1_000, {
+            type: "message",
+            messageId: "m1",
+            role: "user",
+            text: "hello",
+            meta: {
+              author: { userId: "U1", userName: "alice" },
+              explicitMention: true,
+            },
+          }),
+          event(1, 3_000, {
+            type: "message_handled",
+            messageId: "m1",
+          }),
+          event(2, 4_000, {
+            type: "message_handled",
+            messageId: "m1",
+          }),
+        ],
+      }),
     ).toEqual([
       {
         id: "m1",
@@ -60,11 +63,15 @@ describe("message projection", () => {
 
   it("rejects a handled marker without an uncompacted baseline", () => {
     const data = { type: "message_handled" as const, messageId: "missing" };
-    expect(() => projectConversationMessages([event(0, 1_000, data)])).toThrow(
-      "before message",
-    );
+    expect(() =>
+      projectConversationMessages({
+        events: [event(0, 1_000, data)],
+        historyFromSeq: 0,
+      }),
+    ).toThrow("before message");
     expect(
-      projectConversationMessages([event(10, 1_000, data)], {
+      projectConversationMessages({
+        events: [event(10, 1_000, data)],
         historyFromSeq: 10,
       }),
     ).toEqual([]);
@@ -72,22 +79,25 @@ describe("message projection", () => {
 
   it("applies the latest message state without changing its original position", () => {
     expect(
-      projectConversationMessages([
-        event(0, 1_000, {
-          type: "message",
-          messageId: "m1",
-          role: "user",
-          text: "hello",
-          meta: { imagesHydrated: false },
-        }),
-        event(1, 2_000, {
-          type: "message_updated",
-          messageId: "m1",
-          role: "user",
-          text: "hello",
-          meta: { imagesHydrated: true, imageFileIds: ["F1"] },
-        }),
-      ]),
+      projectConversationMessages({
+        historyFromSeq: 0,
+        events: [
+          event(0, 1_000, {
+            type: "message",
+            messageId: "m1",
+            role: "user",
+            text: "hello",
+            meta: { imagesHydrated: false },
+          }),
+          event(1, 2_000, {
+            type: "message_updated",
+            messageId: "m1",
+            role: "user",
+            text: "hello",
+            meta: { imagesHydrated: true, imageFileIds: ["F1"] },
+          }),
+        ],
+      }),
     ).toEqual([
       {
         id: "m1",
@@ -101,45 +111,51 @@ describe("message projection", () => {
 
   it("rejects duplicate recorded baselines", () => {
     expect(() =>
-      projectConversationMessages([
-        event(0, 1_000, {
-          type: "message",
-          messageId: "m1",
-          role: "user",
-          text: "first",
-        }),
-        event(1, 1_000, {
-          type: "message",
-          messageId: "m1",
-          role: "user",
-          text: "conflict",
-        }),
-      ]),
+      projectConversationMessages({
+        historyFromSeq: 0,
+        events: [
+          event(0, 1_000, {
+            type: "message",
+            messageId: "m1",
+            role: "user",
+            text: "first",
+          }),
+          event(1, 1_000, {
+            type: "message",
+            messageId: "m1",
+            role: "user",
+            text: "conflict",
+          }),
+        ],
+      }),
     ).toThrow("Duplicate message");
   });
 
   it("preserves canonical event order rather than source timestamps", () => {
     expect(
-      projectConversationMessages([
-        event(0, 2_000, {
-          type: "message",
-          messageId: "later",
-          role: "assistant",
-          text: "later",
-        }),
-        event(1, 1_000, {
-          type: "message",
-          messageId: "b",
-          role: "user",
-          text: "b",
-        }),
-        event(2, 1_000, {
-          type: "message",
-          messageId: "a",
-          role: "user",
-          text: "a",
-        }),
-      ]).map((message) => message.id),
+      projectConversationMessages({
+        historyFromSeq: 0,
+        events: [
+          event(0, 2_000, {
+            type: "message",
+            messageId: "later",
+            role: "assistant",
+            text: "later",
+          }),
+          event(1, 1_000, {
+            type: "message",
+            messageId: "b",
+            role: "user",
+            text: "b",
+          }),
+          event(2, 1_000, {
+            type: "message",
+            messageId: "a",
+            role: "user",
+            text: "a",
+          }),
+        ],
+      }).map((message) => message.id),
     ).toEqual(["later", "b", "a"]);
   });
 });

--- a/packages/junior/tests/unit/conversations/turn-lifecycle.test.ts
+++ b/packages/junior/tests/unit/conversations/turn-lifecycle.test.ts
@@ -3,6 +3,7 @@ import type {
   ConversationEvent,
   ConversationEventStore,
   HistoryReplacement,
+  MessageHistory,
   NewConversationEvent,
 } from "@/chat/conversations/history";
 import { ConversationTurnLifecycleService } from "@/chat/conversations/turn-lifecycle";
@@ -53,11 +54,8 @@ class MemoryConversationEventStore implements ConversationEventStore {
     return this.history;
   }
 
-  async loadMessageHistory(): Promise<{
-    events: ConversationEvent[];
-    compaction: ConversationEvent | undefined;
-  }> {
-    return { events: this.history, compaction: undefined };
+  async loadMessageHistory(): Promise<MessageHistory> {
+    return { events: this.history, compaction: undefined, historyFromSeq: 0 };
   }
 
   async loadHistory(): Promise<ConversationEvent[]> {


### PR DESCRIPTION
Compacted conversations can retain delivery-state events whose baseline message is intentionally outside the readable history suffix. Message-history loads now return that suffix with its authoritative boundary, and projection requires the boundary-bearing result, so persistence cannot accidentally drop the compaction context and fail later subscribed resource events.

The internal hard cutover makes the boundary compiler-required across runtime, storage, migration, and test consumers. The regression coverage exercises the real Slack runtime and SQL event store with the production history shape, then verifies the event reaches the agent, posts successfully, and persists the new messages without restoring the compacted baseline.

Fixes JUNIOR-5X
