### PR TITLE
fix(sandbox): Avoid command log lookup races

### DIFF
--- a/packages/junior/package.json
+++ b/packages/junior/package.json
@@ -75,7 +75,7 @@
     "@slack/web-api": "^7.16.0",
     "@vercel/functions": "^3.6.0",
     "@vercel/queue": "^0.2.0",
-    "@vercel/sandbox": "2.0.0",
+    "@vercel/sandbox": "2.8.0",
     "ai": "^6.0.190",
     "bash-tool": "^1.3.16",
     "chat": "4.29.0",

--- a/packages/junior/src/chat/sandbox/egress/policy.ts
+++ b/packages/junior/src/chat/sandbox/egress/policy.ts
@@ -109,7 +109,8 @@ export function buildSandboxEgressNetworkPolicy(input?: {
     : undefined;
   const domains = new Map<string, { forward: boolean }>();
   // Provider domains are proxied for credentials; configured trace-only domains
-  // get transform-only rules so wildcard trace configs are not limited to plugins.
+  // get transform rules so wildcard trace configs are not limited to plugins.
+  // Vercel policy rules make forwarding and transforms mutually exclusive.
   if (forwardURL) {
     for (const entry of entries) {
       for (const domain of entry.domains) {
@@ -130,14 +131,11 @@ export function buildSandboxEgressNetworkPolicy(input?: {
       domain,
       input?.traceConfig,
     );
-    allow[domain] = [
-      {
-        ...(shouldPropagateTrace && hasTraceHeaders
-          ? { transform: [{ headers: traceHeaders }] }
-          : {}),
-        ...(policy.forward && forwardURL ? { forwardURL } : {}),
-      },
-    ];
+    if (policy.forward && forwardURL) {
+      allow[domain] = [{ forwardURL }];
+    } else if (shouldPropagateTrace && hasTraceHeaders) {
+      allow[domain] = [{ transform: [{ headers: traceHeaders }] }];
+    }
   }
 
   return { allow };

--- a/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/integration/sandbox-egress-proxy.test.ts
@@ -419,7 +419,7 @@ describe("sandbox egress proxy integration", () => {
     });
   });
 
-  it("propagates configured trace headers through real plugin egress wiring", async () => {
+  it("preserves configured trace headers at the real plugin egress proxy", async () => {
     await registerManagedEgressPlugin({
       egressTracePropagationDomains: ["*.managed-egress.example.test"],
     });
@@ -437,11 +437,9 @@ describe("sandbox egress proxy integration", () => {
         traceparent: "00-trace-span-01",
       },
     });
-    expect(traceHeadersFor(networkPolicy, MANAGED_PROVIDER_SUBDOMAIN)).toEqual({
-      "sentry-trace": "trace-span-1",
-      baggage: "sentry-release=abc",
-      traceparent: "00-trace-span-01",
-    });
+    expect(
+      traceHeadersFor(networkPolicy, MANAGED_PROVIDER_SUBDOMAIN),
+    ).toBeUndefined();
     const forwardURL = forwardUrlFor(networkPolicy, MANAGED_PROVIDER_SUBDOMAIN);
     const upstreamFetch = vi.fn(
       async (_url: URL | string, init?: RequestInit) => {

--- a/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
+++ b/packages/junior/tests/unit/handlers/sandbox-egress-proxy.test.ts
@@ -320,19 +320,11 @@ describe("sandbox egress proxy", () => {
           traceparent: "00-trace-span-01",
         },
       }),
-    ).toMatchObject({
+    ).toEqual({
       allow: {
+        "*": [],
         "sentry.io": [
           {
-            transform: [
-              {
-                headers: {
-                  "sentry-trace": "trace-span-1",
-                  baggage: "sentry-release=abc",
-                  traceparent: "00-trace-span-01",
-                },
-              },
-            ],
             forwardURL: `https://junior.example.com/api/internal/sandbox-egress/${token}`,
           },
         ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,14 +188,14 @@ importers:
         specifier: ^0.2.0
         version: 0.2.0
       '@vercel/sandbox':
-        specifier: 2.0.0
-        version: 2.0.0
+        specifier: 2.8.0
+        version: 2.8.0
       ai:
         specifier: 6.0.190
         version: 6.0.190(zod@4.4.3)
       bash-tool:
         specifier: ^1.3.16
-        version: 1.3.16(@vercel/sandbox@2.0.0)(ai@6.0.190(zod@4.4.3))(just-bash@3.0.1)
+        version: 1.3.16(@vercel/sandbox@2.8.0)(ai@6.0.190(zod@4.4.3))(just-bash@3.0.1)
       chat:
         specifier: 4.29.0
         version: 4.29.0(ai@6.0.190(zod@4.4.3))(zod@4.4.3)
@@ -3695,8 +3695,8 @@ packages:
   '@vercel/sandbox@1.9.0':
     resolution: {integrity: sha512-zgr1ad0tkT1xZn/8Vxo60wOUOLqMAVGo4WqJQ8/UDcUtWynNJsBjI2tiMdWZrAo9EKH1MIqEzJNkcclF0UT1EQ==}
 
-  '@vercel/sandbox@2.0.0':
-    resolution: {integrity: sha512-fmg6lNfDJdhQ43Njc0jUIXTQP2wKPY6tJszeVq5C25v1XsDK3wwnlFBQfSKzZfkMkh1N269pPgOopjTEqJJamA==}
+  '@vercel/sandbox@2.8.0':
+    resolution: {integrity: sha512-1gmIXWgueeBBwBitVl1xqOsYmVv7xr7qX1qXeqwLGZTKGG1SkkpYkDzpWZ8LIDN0PmPGCqE6lvYao3zP8iz5uw==}
 
   '@vercel/static-build@2.9.30':
     resolution: {integrity: sha512-0tJU+7cW4FEMMshmoU7bybfOHGIRe+EiQOYFVrG/lSiSeCr3laIUCYn/xa9vBCFOeHcw8o/PQtLSV9d46cz3Uw==}
@@ -7182,6 +7182,10 @@ packages:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
+
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
@@ -10277,9 +10281,9 @@ snapshots:
       '@slack/web-api': 7.16.0
       '@vercel/functions': 3.6.0
       '@vercel/queue': 0.2.0
-      '@vercel/sandbox': 2.0.0
+      '@vercel/sandbox': 2.8.0
       ai: 6.0.190(zod@4.4.3)
-      bash-tool: 1.3.16(@vercel/sandbox@2.0.0)(ai@6.0.190(zod@4.4.3))(just-bash@3.0.1)
+      bash-tool: 1.3.16(@vercel/sandbox@2.8.0)(ai@6.0.190(zod@4.4.3))(just-bash@3.0.1)
       chat: 4.29.0(ai@6.0.190(zod@4.4.3))(zod@4.4.3)
       commander: 14.0.3
       drizzle-orm: 0.45.2(@neondatabase/serverless@1.1.0)(pg@8.21.0)
@@ -11088,7 +11092,7 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  '@vercel/sandbox@2.0.0':
+  '@vercel/sandbox@2.8.0':
     dependencies:
       '@vercel/oidc': 3.2.0
       '@workflow/serde': 4.1.0-beta.2
@@ -11098,9 +11102,9 @@ snapshots:
       ms: 2.1.3
       picocolors: 1.1.1
       tar-stream: 3.1.7
-      undici: 7.25.0
+      undici: 7.28.0
       xdg-app-paths: 5.1.0
-      zod: 3.24.4
+      zod: 4.4.3
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
@@ -11499,14 +11503,14 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  bash-tool@1.3.16(@vercel/sandbox@2.0.0)(ai@6.0.190(zod@4.4.3))(just-bash@3.0.1):
+  bash-tool@1.3.16(@vercel/sandbox@2.8.0)(ai@6.0.190(zod@4.4.3))(just-bash@3.0.1):
     dependencies:
       ai: 6.0.190(zod@4.4.3)
       fast-glob: 3.3.3
       yaml: 2.9.0
       zod: 3.25.76
     optionalDependencies:
-      '@vercel/sandbox': 2.0.0
+      '@vercel/sandbox': 2.8.0
       just-bash: 3.0.1
 
   basic-ftp@5.3.1: {}
@@ -15488,6 +15492,8 @@ snapshots:
   undici@6.25.0: {}
 
   undici@7.25.0: {}
+
+  undici@7.28.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:


### PR DESCRIPTION
Sandbox file tools no longer depend on a follow-up command-logs request that
can race command cleanup and return 404. This upgrades `@vercel/sandbox` to
2.8.0, which reads command output from the execution response used by
`listDir`, `findFiles`, and `grep`.

Sandbox 2.8 also makes request forwarding and header transforms mutually
exclusive. Provider domains continue through the credential proxy, while
trace-only domains retain header transforms, matching the service's existing
effective behavior where forwarding took precedence.

Fixes JUNIOR-5Y
Fixes JUNIOR-2B
Fixes JUNIOR-2E
