### PR TITLE
fix(runtime): Validate durable state boundaries

### DIFF
--- a/packages/junior-scheduler/src/store.ts
+++ b/packages/junior-scheduler/src/store.ts
@@ -236,6 +236,13 @@ function unique(values: string[]): string[] {
   return [...new Set(values.filter(Boolean))];
 }
 
+const schedulerTaskIndexSchema = z.array(z.string().min(1));
+
+/** Parse the persisted scheduler task index without repairing malformed state. */
+function parseStringIndex(value: unknown): string[] {
+  return value === undefined ? [] : schedulerTaskIndexSchema.parse(value);
+}
+
 async function withLock<T>(
   state: PluginState,
   key: string,
@@ -250,9 +257,7 @@ async function addToIndex(
   taskId: string,
 ): Promise<void> {
   await withLock(state, indexLockKey(key), async () => {
-    const current = ((await state.get<string[]>(key)) ?? []).filter(
-      (value): value is string => typeof value === "string",
-    );
+    const current = unique(parseStringIndex(await state.get(key)));
     await state.set(key, unique([...current, taskId]), SCHEDULER_RECORD_TTL_MS);
   });
 }
@@ -263,11 +268,7 @@ async function removeFromIndex(
   taskId: string,
 ): Promise<void> {
   await withLock(state, indexLockKey(key), async () => {
-    const current = unique(
-      ((await state.get<string[]>(key)) ?? []).filter(
-        (value): value is string => typeof value === "string",
-      ),
-    );
+    const current = unique(parseStringIndex(await state.get(key)));
     const next = current.filter((value) => value !== taskId);
     if (next.length === current.length) {
       return;
@@ -284,10 +285,7 @@ async function getIndex(
   state: PluginReadState,
   key: string,
 ): Promise<string[]> {
-  const values = (await state.get<string[]>(key)) ?? [];
-  return unique(
-    values.filter((value): value is string => typeof value === "string"),
-  );
+  return unique(parseStringIndex(await state.get(key)));
 }
 
 async function clearActiveRun(

--- a/packages/junior/src/chat/agent-dispatch/store.ts
+++ b/packages/junior/src/chat/agent-dispatch/store.ts
@@ -32,6 +32,7 @@ const nonEmptyExactStringSchema = z
   .refine(
     (value) => value === value.trim() && value.toLowerCase() !== "unknown",
   );
+const incompleteDispatchIndexSchema = z.array(nonEmptyExactStringSchema);
 const dispatchStatusSchema = z.enum([
   "pending",
   "running",
@@ -130,6 +131,13 @@ function incompleteDispatchIndexKey(): string {
 
 function incompleteDispatchIndexLockKey(): string {
   return `${DISPATCH_PREFIX}:incomplete:lock`;
+}
+
+/** Parse the persisted recovery index without hiding malformed state. */
+function parseIncompleteDispatchIndex(value: unknown): string[] {
+  return value === undefined || value === null
+    ? []
+    : incompleteDispatchIndexSchema.parse(value);
 }
 
 function dispatchLockKey(id: string): string {
@@ -248,10 +256,12 @@ async function syncIncompleteDispatchIndex(
   record: DispatchRecord,
 ): Promise<void> {
   await withIncompleteDispatchIndexLock(state, async () => {
-    const existing =
-      (await state.get<string[]>(incompleteDispatchIndexKey())) ?? [];
     const ids = [
-      ...new Set(existing.filter((id): id is string => typeof id === "string")),
+      ...new Set(
+        parseIncompleteDispatchIndex(
+          await state.get(incompleteDispatchIndexKey()),
+        ),
+      ),
     ];
     const next = isTerminalDispatchStatus(record.status)
       ? ids.filter((id) => id !== record.id)
@@ -363,8 +373,13 @@ export async function updateDispatchRecord(
 export async function listIncompleteDispatchIds(): Promise<string[]> {
   const state = getStateAdapter();
   await state.connect();
-  const ids = (await state.get<string[]>(incompleteDispatchIndexKey())) ?? [];
-  return [...new Set(ids.filter((id): id is string => typeof id === "string"))];
+  return [
+    ...new Set(
+      parseIncompleteDispatchIndex(
+        await state.get(incompleteDispatchIndexKey()),
+      ),
+    ),
+  ];
 }
 
 /** Return a plugin-scoped dispatch projection without exposing raw runtime state. */

--- a/packages/junior/src/chat/task-execution/slack-work.ts
+++ b/packages/junior/src/chat/task-execution/slack-work.ts
@@ -7,6 +7,7 @@ import {
   type SerializedThread,
   type StateAdapter,
 } from "chat";
+import { z } from "zod";
 import type {
   SlackTurnOptions,
   SteeringCandidateMessage,
@@ -38,16 +39,372 @@ import {
   requireSlackDestination,
 } from "@/chat/destination";
 
-export type SlackConversationRoute = "mention" | "subscribed";
+const slackConversationRouteSchema = z.enum(["mention", "subscribed"]);
+export type SlackConversationRoute = z.output<
+  typeof slackConversationRouteSchema
+>;
 
-export interface SlackConversationMessageMetadata {
-  [key: string]: unknown;
-  installation?: SlackInstallationContext;
-  message: SerializedMessage;
-  platform: "slack";
-  route: SlackConversationRoute;
-  thread: SerializedThread;
+const serializedDateSchema = z.iso.datetime();
+const mdastPointSchema = z
+  .object({
+    column: z.number().int().positive(),
+    line: z.number().int().positive(),
+    offset: z.number().int().nonnegative().optional(),
+  })
+  .strict();
+const mdastPositionSchema = z
+  .object({
+    end: mdastPointSchema,
+    start: mdastPointSchema,
+  })
+  .strict();
+
+function isOptionalNullableString(value: unknown): boolean {
+  return value === undefined || value === null || typeof value === "string";
 }
+
+function isOptionalNullableBoolean(value: unknown): boolean {
+  return value === undefined || value === null || typeof value === "boolean";
+}
+
+function hasValidMdastBase(
+  node: Record<string, unknown>,
+  fields: readonly string[],
+): boolean {
+  const allowed = new Set(["data", "position", "type", ...fields]);
+  return (
+    Object.keys(node).every((key) => allowed.has(key)) &&
+    (node.data === undefined ||
+      (typeof node.data === "object" &&
+        node.data !== null &&
+        !Array.isArray(node.data))) &&
+    (node.position === undefined ||
+      mdastPositionSchema.safeParse(node.position).success)
+  );
+}
+
+const mdastPhrasingTypes = new Set([
+  "break",
+  "delete",
+  "emphasis",
+  "footnoteReference",
+  "html",
+  "image",
+  "imageReference",
+  "inlineCode",
+  "link",
+  "linkReference",
+  "strong",
+  "text",
+]);
+const mdastBlockOrDefinitionTypes = new Set([
+  "blockquote",
+  "code",
+  "definition",
+  "footnoteDefinition",
+  "heading",
+  "html",
+  "list",
+  "paragraph",
+  "table",
+  "thematicBreak",
+]);
+const mdastListItemTypes = new Set(["listItem"]);
+const mdastTableCellTypes = new Set(["tableCell"]);
+const mdastTableRowTypes = new Set(["tableRow"]);
+
+function hasMdastChildren(
+  node: Record<string, unknown>,
+  allowedTypes?: ReadonlySet<string>,
+): boolean {
+  return (
+    Array.isArray(node.children) &&
+    node.children.every(
+      (child) =>
+        isFormattedContentNode(child) &&
+        (!allowedTypes ||
+          (typeof child === "object" &&
+            child !== null &&
+            !Array.isArray(child) &&
+            allowedTypes.has(String((child as { type?: unknown }).type)))),
+    )
+  );
+}
+
+/** Validate every supported mdast node before restoring a serialized message. */
+function isFormattedContentNode(value: unknown): boolean {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const node = value as Record<string, unknown>;
+  switch (node.type) {
+    case "break":
+    case "thematicBreak":
+      return hasValidMdastBase(node, []);
+    case "html":
+    case "inlineCode":
+    case "text":
+    case "yaml":
+      return (
+        hasValidMdastBase(node, ["value"]) && typeof node.value === "string"
+      );
+    case "code":
+      return (
+        hasValidMdastBase(node, ["lang", "meta", "value"]) &&
+        typeof node.value === "string" &&
+        isOptionalNullableString(node.lang) &&
+        isOptionalNullableString(node.meta)
+      );
+    case "delete":
+    case "emphasis":
+    case "paragraph":
+    case "strong":
+    case "tableCell":
+      return (
+        hasValidMdastBase(node, ["children"]) &&
+        hasMdastChildren(node, mdastPhrasingTypes)
+      );
+    case "blockquote":
+      return (
+        hasValidMdastBase(node, ["children"]) &&
+        hasMdastChildren(node, mdastBlockOrDefinitionTypes)
+      );
+    case "tableRow":
+      return (
+        hasValidMdastBase(node, ["children"]) &&
+        hasMdastChildren(node, mdastTableCellTypes)
+      );
+    case "heading":
+      return (
+        hasValidMdastBase(node, ["children", "depth"]) &&
+        hasMdastChildren(node, mdastPhrasingTypes) &&
+        Number.isInteger(node.depth) &&
+        Number(node.depth) >= 1 &&
+        Number(node.depth) <= 6
+      );
+    case "list":
+      return (
+        hasValidMdastBase(node, ["children", "ordered", "spread", "start"]) &&
+        hasMdastChildren(node, mdastListItemTypes) &&
+        isOptionalNullableBoolean(node.ordered) &&
+        isOptionalNullableBoolean(node.spread) &&
+        (node.start === undefined ||
+          node.start === null ||
+          (typeof node.start === "number" && Number.isFinite(node.start)))
+      );
+    case "listItem":
+      return (
+        hasValidMdastBase(node, ["checked", "children", "spread"]) &&
+        hasMdastChildren(node, mdastBlockOrDefinitionTypes) &&
+        isOptionalNullableBoolean(node.checked) &&
+        isOptionalNullableBoolean(node.spread)
+      );
+    case "table":
+      return (
+        hasValidMdastBase(node, ["align", "children"]) &&
+        hasMdastChildren(node, mdastTableRowTypes) &&
+        (node.align === undefined ||
+          node.align === null ||
+          (Array.isArray(node.align) &&
+            node.align.every(
+              (align) =>
+                align === null ||
+                align === "center" ||
+                align === "left" ||
+                align === "right",
+            )))
+      );
+    case "definition":
+      return (
+        hasValidMdastBase(node, ["identifier", "label", "title", "url"]) &&
+        typeof node.identifier === "string" &&
+        typeof node.url === "string" &&
+        isOptionalNullableString(node.label) &&
+        isOptionalNullableString(node.title)
+      );
+    case "footnoteDefinition":
+      return (
+        hasValidMdastBase(node, ["children", "identifier", "label"]) &&
+        hasMdastChildren(node, mdastBlockOrDefinitionTypes) &&
+        typeof node.identifier === "string" &&
+        isOptionalNullableString(node.label)
+      );
+    case "footnoteReference":
+      return (
+        hasValidMdastBase(node, ["identifier", "label"]) &&
+        typeof node.identifier === "string" &&
+        isOptionalNullableString(node.label)
+      );
+    case "image":
+      return (
+        hasValidMdastBase(node, ["alt", "title", "url"]) &&
+        typeof node.url === "string" &&
+        isOptionalNullableString(node.alt) &&
+        isOptionalNullableString(node.title)
+      );
+    case "imageReference":
+      return (
+        hasValidMdastBase(node, [
+          "alt",
+          "identifier",
+          "label",
+          "referenceType",
+        ]) &&
+        typeof node.identifier === "string" &&
+        isOptionalNullableString(node.alt) &&
+        isOptionalNullableString(node.label) &&
+        (node.referenceType === "collapsed" ||
+          node.referenceType === "full" ||
+          node.referenceType === "shortcut")
+      );
+    case "link":
+      return (
+        hasValidMdastBase(node, ["children", "title", "url"]) &&
+        hasMdastChildren(node, mdastPhrasingTypes) &&
+        typeof node.url === "string" &&
+        isOptionalNullableString(node.title)
+      );
+    case "linkReference":
+      return (
+        hasValidMdastBase(node, [
+          "children",
+          "identifier",
+          "label",
+          "referenceType",
+        ]) &&
+        hasMdastChildren(node, mdastPhrasingTypes) &&
+        typeof node.identifier === "string" &&
+        isOptionalNullableString(node.label) &&
+        (node.referenceType === "collapsed" ||
+          node.referenceType === "full" ||
+          node.referenceType === "shortcut")
+      );
+    default:
+      return false;
+  }
+}
+
+const formattedContentSchema = z.custom<SerializedMessage["formatted"]>(
+  (value) => {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      return false;
+    }
+    const root = value as Record<string, unknown>;
+    return (
+      root.type === "root" &&
+      hasValidMdastBase(root, ["children"]) &&
+      hasMdastChildren(root)
+    );
+  },
+  "must be a valid formatted-content root",
+);
+
+const serializedMessageSchema = z
+  .object({
+    _type: z.literal("chat:Message"),
+    attachments: z.array(
+      z
+        .object({
+          type: z.enum(["image", "file", "video", "audio"]),
+          url: z.string().optional(),
+          name: z.string().optional(),
+          mimeType: z.string().optional(),
+          size: z.number().finite().optional(),
+          width: z.number().finite().optional(),
+          height: z.number().finite().optional(),
+          fetchMetadata: z.record(z.string(), z.string()).optional(),
+        })
+        .strict(),
+    ),
+    author: z
+      .object({
+        userId: z.string(),
+        userName: z.string(),
+        fullName: z.string(),
+        isBot: z.union([z.boolean(), z.literal("unknown")]),
+        isMe: z.boolean(),
+      })
+      .strict(),
+    formatted: formattedContentSchema,
+    id: z.string().min(1),
+    isMention: z.boolean().optional(),
+    links: z
+      .array(
+        z
+          .object({
+            url: z.string(),
+            title: z.string().optional(),
+            description: z.string().optional(),
+            imageUrl: z.string().optional(),
+            siteName: z.string().optional(),
+          })
+          .strict(),
+      )
+      .optional(),
+    metadata: z
+      .object({
+        dateSent: serializedDateSchema,
+        edited: z.boolean(),
+        editedAt: serializedDateSchema.optional(),
+      })
+      .strict(),
+    raw: z.unknown(),
+    text: z.string(),
+    threadId: z.string().min(1),
+  })
+  .strict() satisfies z.ZodType<SerializedMessage>;
+
+const serializedThreadSchema = z
+  .object({
+    _type: z.literal("chat:Thread"),
+    adapterName: z.literal("slack"),
+    channelId: z.string().min(1),
+    channelVisibility: z
+      .enum(["private", "workspace", "external", "unknown"])
+      .optional(),
+    currentMessage: serializedMessageSchema.optional(),
+    id: z.string().min(1),
+    isDM: z.boolean(),
+  })
+  .strict() satisfies z.ZodType<SerializedThread>;
+
+const slackInstallationSchema = z
+  .object({
+    enterpriseId: z.string().optional(),
+    isEnterpriseInstall: z.boolean().optional(),
+    teamId: z.string().optional(),
+  })
+  .strict() satisfies z.ZodType<SlackInstallationContext>;
+
+const slackConversationMessageMetadataBaseSchema = z.object({
+  installation: slackInstallationSchema.optional(),
+  message: serializedMessageSchema,
+  platform: z.literal("slack"),
+  route: slackConversationRouteSchema,
+  thread: serializedThreadSchema,
+});
+
+const slackConversationMessageMetadataSchema = z.union([
+  slackConversationMessageMetadataBaseSchema.strict(),
+  slackConversationMessageMetadataBaseSchema
+    .extend({
+      kind: z.literal("resource_event"),
+      resourceEvent: z
+        .object({
+          eventKey: z.string(),
+          eventType: z.string(),
+          provider: z.string(),
+          resourceRef: z.string(),
+          subscriptionId: z.string(),
+        })
+        .strict(),
+    })
+    .strict(),
+]);
+
+export type SlackConversationMessageMetadata = z.output<
+  typeof slackConversationMessageMetadataSchema
+>;
 
 type SlackInboxTurnOptions = SlackTurnOptions & {
   ack: () => Promise<void>;
@@ -121,7 +478,7 @@ function slackSerializedThread(input: {
   channelId: string;
   message: SerializedMessage;
   threadTs: string;
-}): SerializedThread {
+}): z.output<typeof serializedThreadSchema> {
   return {
     _type: "chat:Thread",
     adapterName: "slack",
@@ -227,10 +584,7 @@ export function createSlackResourceEventInboundMessage(
           resourceRef: input.event.resourceRef,
           subscriptionId: input.subscription.id,
         },
-      } satisfies SlackConversationMessageMetadata & {
-        kind: "resource_event";
-        resourceEvent: Record<string, string>;
-      },
+      } satisfies SlackConversationMessageMetadata,
     },
   };
 }
@@ -239,17 +593,12 @@ function getConnectedState(stateAdapter?: StateAdapter): StateAdapter {
   return stateAdapter ?? getStateAdapter();
 }
 
-/** Validate the serialized Slack message/thread envelope stored in the mailbox. */
-function isSlackMetadata(
+/** Parse the serialized Slack message/thread envelope stored in the mailbox. */
+function parseSlackMetadata(
   value: AgentInput["metadata"],
-): value is SlackConversationMessageMetadata {
-  return (
-    Boolean(value) &&
-    value?.platform === "slack" &&
-    (value.route === "mention" || value.route === "subscribed") &&
-    Boolean(value.thread) &&
-    Boolean(value.message)
-  );
+): SlackConversationMessageMetadata | undefined {
+  const parsed = slackConversationMessageMetadataSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
 }
 
 function compareInboundMessages(
@@ -265,8 +614,8 @@ function compareInboundMessages(
 
 function routeForRecords(records: InboundMessage[]): SlackConversationRoute {
   return records.some((record) => {
-    const metadata = record.input.metadata;
-    if (!isSlackMetadata(metadata)) {
+    const metadata = parseSlackMetadata(record.input.metadata);
+    if (!metadata) {
       throw new Error("Conversation mailbox record is not Slack metadata");
     }
     return metadata.route === "mention";
@@ -300,8 +649,8 @@ function restoreMessage(args: {
   adapter: SlackAdapter;
   record: InboundMessage;
 }): Message {
-  const metadata = args.record.input.metadata;
-  if (!isSlackMetadata(metadata)) {
+  const metadata = parseSlackMetadata(args.record.input.metadata);
+  if (!metadata) {
     throw new Error("Conversation mailbox record is not a Slack message");
   }
 
@@ -375,8 +724,8 @@ function restoreThread(args: {
 
 function getInstallation(records: InboundMessage[]): SlackInstallationContext {
   for (let index = records.length - 1; index >= 0; index -= 1) {
-    const metadata = records[index]?.input.metadata;
-    if (isSlackMetadata(metadata) && metadata.installation) {
+    const metadata = parseSlackMetadata(records[index]?.input.metadata);
+    if (metadata?.installation) {
       return metadata.installation;
     }
   }
@@ -426,8 +775,8 @@ export function createSlackConversationWorker(
       return { status: "completed" };
     }
 
-    const latestMetadata = latestRecord.input.metadata;
-    if (!isSlackMetadata(latestMetadata)) {
+    const latestMetadata = parseSlackMetadata(latestRecord.input.metadata);
+    if (!latestMetadata) {
       throw new Error(
         "Latest conversation mailbox record is not Slack metadata",
       );
@@ -494,8 +843,8 @@ export function createSlackConversationWorker(
         ): Promise<void> => {
           await context.attempt.drain(async (pendingRecords) => {
             const messages = pendingRecords.map((record) => {
-              const metadata = record.input.metadata;
-              if (!isSlackMetadata(metadata)) {
+              const metadata = parseSlackMetadata(record.input.metadata);
+              if (!metadata) {
                 throw new Error(
                   "Conversation mailbox record is not Slack metadata",
                 );
@@ -597,7 +946,7 @@ export function buildSlackInboundMessage(args: {
         platform: "slack",
         route: args.route,
         installation: args.installation,
-        thread: args.thread.toJSON(),
+        thread: serializedThreadSchema.parse(args.thread.toJSON()),
         message: args.message.toJSON(),
       } satisfies SlackConversationMessageMetadata,
     },

--- a/packages/junior/src/chat/task-execution/state.ts
+++ b/packages/junior/src/chat/task-execution/state.ts
@@ -310,16 +310,17 @@ function normalizeInput(value: unknown): AgentInput | undefined {
   if (!isRecord(value)) {
     return undefined;
   }
-  const text = toOptionalString(value.text);
-  if (!text) {
+  const text = typeof value.text === "string" ? value.text : undefined;
+  const attachments = Array.isArray(value.attachments)
+    ? [...value.attachments]
+    : undefined;
+  if (text === undefined || (!text.trim() && !attachments?.length)) {
     return undefined;
   }
   return {
     text,
     authorId: toOptionalString(value.authorId),
-    attachments: Array.isArray(value.attachments)
-      ? [...value.attachments]
-      : undefined,
+    attachments,
     metadata: normalizeMetadata(value.metadata),
   };
 }

--- a/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
@@ -8,6 +8,7 @@ import {
 import { getSlackClient } from "@/chat/slack/client";
 import { recoverConversationWork } from "@/chat/task-execution/heartbeat";
 import {
+  appendAndEnqueueInboundMessage,
   appendInboundMessage,
   CONVERSATION_WORK_LEASE_TTL_MS,
   CONVERSATION_WORK_MAX_DELIVERY_ATTEMPTS,
@@ -150,6 +151,209 @@ describe("Slack conversation work execution", () => {
         }),
       }),
     ]);
+  });
+
+  it("delivers attachment-only Slack messages through the durable mailbox", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    const state = getStateAdapter();
+    await state.connect();
+    const slackAdapter = createSlackAdapterFixture();
+    const message = new Message({
+      id: "1712345.0002",
+      threadId: CONVERSATION_ID,
+      text: "",
+      attachments: [
+        {
+          type: "image",
+          url: "https://example.com/attachment-only.png",
+        },
+      ],
+      metadata: { dateSent: new Date(1_000), edited: false },
+      formatted: {
+        type: "root",
+        children: [
+          {
+            type: "paragraph",
+            children: [
+              {
+                type: "link",
+                url: "https://example.com",
+                children: [{ type: "text", value: "attachment" }],
+              },
+            ],
+          },
+          {
+            type: "list",
+            children: [
+              {
+                type: "listItem",
+                children: [
+                  {
+                    type: "paragraph",
+                    children: [{ type: "text", value: "image" }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      raw: {
+        channel: "C123",
+        thread_ts: "1712345.0001",
+        ts: "1712345.0002",
+        user: "U123",
+      },
+      author: {
+        userId: "U123",
+        userName: "dcramer",
+        fullName: "David Cramer",
+        isBot: false,
+        isMe: false,
+      },
+    });
+    const thread = new ThreadImpl({
+      adapter: slackAdapter,
+      stateAdapter: state,
+      id: CONVERSATION_ID,
+      channelId: "C123",
+      currentMessage: message,
+      initialMessage: message,
+      isDM: false,
+    });
+    const handleNewMention = vi.fn(async (_thread, restored, hooks) => {
+      expect(restored.text).toBe("");
+      expect(restored.attachments).toHaveLength(1);
+      expect(restored.formatted.children).toHaveLength(2);
+      await hooks.ack?.();
+    });
+
+    await appendAndEnqueueInboundMessage({
+      message: buildSlackInboundMessage({
+        conversationId: CONVERSATION_ID,
+        installation: { teamId: "T123" },
+        message,
+        receivedAtMs: 1_100,
+        route: "mention",
+        thread,
+      }),
+      nowMs: 1_100,
+      queue,
+      state,
+    });
+
+    await expect(
+      processNextQueuedSlackWork({
+        getSlackAdapter: () => slackAdapter,
+        lookupSlackUser: async () => ({
+          email: "david@example.com",
+          fullName: "David Cramer",
+          userName: "dcramer",
+        }),
+        queue,
+        runtime: {
+          handleNewMention,
+          handleSubscribedMessage: async () => {
+            throw new Error("unexpected subscribed route");
+          },
+        },
+        state,
+      }),
+    ).resolves.toEqual({ status: "completed" });
+    expect(handleNewMention).toHaveBeenCalledOnce();
+  });
+
+  it("rejects malformed serialized Slack mailbox metadata", async () => {
+    const state = getStateAdapter();
+    await state.connect();
+    const slackAdapter = createSlackAdapterFixture();
+    const malformed = {
+      ...conversationQueueMessage(),
+      inboundMessageId: "malformed-slack-metadata",
+      source: "slack" as const,
+      createdAtMs: 1_000,
+      receivedAtMs: 1_100,
+      input: {
+        text: "hello",
+        authorId: "U123",
+        metadata: {
+          platform: "slack",
+          route: "mention",
+          message: {
+            _type: "chat:Message",
+            attachments: [],
+            author: {
+              userId: "U123",
+              userName: "dcramer",
+              fullName: "David Cramer",
+              isBot: false,
+              isMe: false,
+            },
+            formatted: {
+              type: "root",
+              children: [
+                {
+                  type: "paragraph",
+                  children: [
+                    {
+                      type: "table",
+                      children: [],
+                    },
+                  ],
+                },
+              ],
+            },
+            id: "1712345.0002",
+            metadata: {
+              dateSent: "2026-07-22T12:00:00.000Z",
+              edited: false,
+            },
+            raw: {},
+            text: "hello",
+            threadId: CONVERSATION_ID,
+          },
+          thread: {
+            _type: "chat:Thread",
+            adapterName: "slack",
+            channelId: "C123",
+            id: CONVERSATION_ID,
+            isDM: false,
+          },
+        },
+      },
+    };
+    const worker = createSlackConversationWorker({
+      getSlackAdapter: () => slackAdapter,
+      resumeAwaitingContinuation: async () => false,
+      runtime: {
+        handleNewMention: async () => {
+          throw new Error("malformed metadata must not reach the runtime");
+        },
+        handleSubscribedMessage: async () => {
+          throw new Error("malformed metadata must not reach the runtime");
+        },
+      },
+      state,
+    });
+
+    await expect(
+      worker({
+        attempt: {
+          ack: async () => {},
+          conversationId: CONVERSATION_ID,
+          destination: SLACK_DESTINATION,
+          drain: async () => [],
+          isFinalAttempt: false,
+          messages: [malformed],
+        },
+        checkIn: async () => true,
+        conversationId: CONVERSATION_ID,
+        destination: SLACK_DESTINATION,
+        shouldYield: () => false,
+      }),
+    ).rejects.toThrow(
+      "Latest conversation mailbox record is not Slack metadata",
+    );
   });
 
   it("routes resource-event mailbox records without Slack actor lookup", async () => {

--- a/packages/junior/tests/fixtures/slack-harness.ts
+++ b/packages/junior/tests/fixtures/slack-harness.ts
@@ -99,6 +99,8 @@ export function createTestMessage(args: {
 // ── Fake Slack Adapter ───────────────────────────────────────────────
 
 export class FakeSlackAdapter {
+  readonly name = "slack";
+
   // Providing a bot user id opts this fixture into single-workspace install
   // mode: runWithSlackInstallation requires defaultBotTokenProvider (and a
   // resolved bot user id) before it runs worker-claimed Slack turns. Leaving

--- a/packages/junior/tests/integration/heartbeat.test.ts
+++ b/packages/junior/tests/integration/heartbeat.test.ts
@@ -781,6 +781,14 @@ describe("plugin heartbeat", () => {
     );
   });
 
+  it("rejects a malformed persisted dispatch recovery index", async () => {
+    const state = getStateAdapter();
+    await state.connect();
+    await state.set("junior:agent_dispatch:incomplete", { invalid: true });
+
+    await expect(listIncompleteDispatchIds()).rejects.toThrow("expected array");
+  });
+
   it("does not fail an active leased dispatch that reached max attempts", async () => {
     const created = await createOrGetDispatch({
       plugin: "scheduler",

--- a/packages/junior/tests/unit/scheduler-state-index.test.ts
+++ b/packages/junior/tests/unit/scheduler-state-index.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { createSchedulerStore } from "../../../junior-scheduler/src/store";
+import { createPluginState } from "@/chat/plugins/state";
+
+describe("scheduler plugin-state indexes", () => {
+  it("rejects a malformed persisted task index", async () => {
+    const stateAdapter = createMemoryState();
+    const state = createPluginState("scheduler", stateAdapter);
+    await state.set("junior:scheduler:tasks", { invalid: true });
+    const store = createSchedulerStore(state);
+
+    try {
+      await expect(store.listTasks()).rejects.toThrow("expected array");
+    } finally {
+      await stateAdapter.disconnect();
+    }
+  });
+});

--- a/packages/junior/tests/unit/slack/slack-harness.test.ts
+++ b/packages/junior/tests/unit/slack/slack-harness.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { createTestThread } from "../../fixtures/slack-harness";
+import {
+  createTestThread,
+  FakeSlackAdapter,
+} from "../../fixtures/slack-harness";
 
 describe("slack harness fixture", () => {
+  it("identifies its fake adapter as Slack", () => {
+    expect(new FakeSlackAdapter().name).toBe("slack");
+  });
+
   it("uses explicit channelId when provided", () => {
     const thread = createTestThread({ id: "thread-3", channelId: "C-3" });
 


### PR DESCRIPTION
Durable Slack mailbox records now preserve attachment-only messages and validate the complete serialized Slack envelope before restoration. Malformed scheduler and dispatch indexes now fail at their storage boundaries instead of being treated as empty, preventing corrupted state from silently hiding work.

The boundary schemas own the types they return and distinguish legitimate missing-state sentinels from malformed persisted values. Focused regression coverage exercises attachment-only delivery, rich and malformed formatted content, and corrupted index reads.
