### PR TITLE
ref(runtime): Simplify resumed turn commits

### DIFF
--- a/packages/junior/src/chat/agent-dispatch/runner.ts
+++ b/packages/junior/src/chat/agent-dispatch/runner.ts
@@ -543,12 +543,6 @@ export async function runAgentDispatchSlice(
         source: dispatch.source,
         actor: dispatch.actor,
         surface: "api",
-        logContext: {
-          threadId: conversationId,
-          channelId: dispatch.destination.channelId,
-          runId: dispatch.id,
-          assistantUserName: botConfig.userName,
-        },
       });
     }
     if (statePersisted) {

--- a/packages/junior/src/chat/local/runner.ts
+++ b/packages/junior/src/chat/local/runner.ts
@@ -442,7 +442,6 @@ export async function runLocalAgentTurn(
         source,
         actor: localActor,
         surface: "internal",
-        logContext: {},
       });
     }
   } catch (error) {

--- a/packages/junior/src/chat/runtime/agent-continue-runner.ts
+++ b/packages/junior/src/chat/runtime/agent-continue-runner.ts
@@ -439,7 +439,7 @@ export async function continueSlackAgentRun(
               },
             },
           },
-          onSuccess: async (reply: AgentRunResult) => {
+          commitResult: async (reply: AgentRunResult) => {
             await persistCompletedReplyState({
               sessionRecord: activeSessionRecord,
               reply,

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -1505,13 +1505,6 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                 sliceId: 1,
                 messages: reply.piMessages,
                 modelId: reply.diagnostics.modelId,
-                logContext: {
-                  threadId,
-                  actorId: slackActorId,
-                  channelId,
-                  runId,
-                  assistantUserName: botConfig.userName,
-                },
                 actor: executionActor,
                 surface: "slack",
               });

--- a/packages/junior/src/chat/runtime/slack-resume.ts
+++ b/packages/junior/src/chat/runtime/slack-resume.ts
@@ -165,7 +165,7 @@ interface ResumeSlackTurnArgs {
     conversationId: string;
     sessionId: string;
   }) => Promise<void>;
-  onSuccess?: (reply: AgentRunResult) => Promise<void>;
+  commitResult?: (result: AgentRunResult) => Promise<void>;
   onFailure?: (error: unknown) => Promise<void>;
   onAuthPause?: (pause: { providerDisplayName: string }) => Promise<void>;
   onSuspend?: (resumeVersion: number) => Promise<void>;
@@ -189,7 +189,7 @@ interface ResumePreparedTurn {
   inputMessageIds?: string[];
   initialStatus?: AssistantStatusSpec;
   replyContext: ResumeReplyContext;
-  onSuccess?: (reply: AgentRunResult) => Promise<void>;
+  commitResult?: (result: AgentRunResult) => Promise<void>;
   onFailure?: (error: unknown) => Promise<void>;
   onAuthPause?: (pause: { providerDisplayName: string }) => Promise<void>;
   onSuspend?: (resumeVersion: number) => Promise<void>;
@@ -687,17 +687,9 @@ export async function resumeSlackTurn(
           source: replyContext.routing.source,
           actor: resumeActor,
           surface: "slack",
-          logContext: {
-            threadId: runArgs.conversationId,
-            actorId: isUserActor(replyContext.routing.actor)
-              ? replyContext.routing.actor.userId
-              : undefined,
-            channelId: runArgs.channelId,
-            assistantUserName: botConfig.userName,
-          },
         });
       }
-      await runArgs.onSuccess?.(reply);
+      await runArgs.commitResult?.(reply);
       if (reply.diagnostics.outcome === "success") {
         await turnLifecycle.complete({
           conversationId: runArgs.conversationId,

--- a/packages/junior/src/chat/services/turn-session-record.ts
+++ b/packages/junior/src/chat/services/turn-session-record.ts
@@ -233,7 +233,6 @@ export async function persistCompletedSessionRecord(args: {
   sliceId?: number;
   allMessages: PiMessage[];
   loadedSkillNames?: string[];
-  logContext: SessionRecordLogContext;
   modelId: string;
   actor?: Actor;
   reasoningLevel?: string;
@@ -323,7 +322,6 @@ export async function completeDeliveredTurn(args: {
   destinationVisibility?: ConversationPrivacy;
   durationMs?: number;
   loadedSkillNames?: string[];
-  logContext: SessionRecordLogContext;
   messages: PiMessage[];
   modelId: string;
   actor?: Actor;
@@ -347,7 +345,6 @@ export async function completeDeliveredTurn(args: {
     sliceId: args.sliceId,
     allMessages: args.messages,
     loadedSkillNames: args.loadedSkillNames,
-    logContext: args.logContext,
     modelId: args.modelId,
     actor: args.actor,
     reasoningLevel: args.reasoningLevel,

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -407,7 +407,7 @@ async function resumeAuthorizedMcpTurn(args: {
             },
           },
         },
-        onSuccess: async (reply: AgentRunResult) => {
+        commitResult: async (reply: AgentRunResult) => {
           await persistCompletedReplyState(
             authSession.channelId!,
             authSession.threadTs!,

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -430,7 +430,7 @@ async function resumeOAuthSessionRecordTurn(
             },
           },
         },
-        onSuccess: async (reply: AgentRunResult) => {
+        commitResult: async (reply: AgentRunResult) => {
           logInfo(
             "oauth_callback_resume_complete",
             {},

--- a/packages/junior/tests/component/services/turn-session-record.test.ts
+++ b/packages/junior/tests/component/services/turn-session-record.test.ts
@@ -884,11 +884,6 @@ describe("persistAuthPauseSessionRecord", () => {
             timestamp: 1,
           },
         ],
-        logContext: {
-          channelId: "C123",
-          actorId: "U123",
-          threadId: "slack:C123:1",
-        },
       }),
     ).rejects.toThrow("state adapter unavailable");
     expect(getAgentTurnSessionRecord).toHaveBeenCalledTimes(3);
@@ -924,7 +919,6 @@ describe("persistAuthPauseSessionRecord", () => {
       currentDurationMs: 500,
       currentUsage: { inputTokens: 5 },
       allMessages: [userMessage("done")],
-      logContext: {},
     });
 
     expect(getAgentTurnSessionRecord).toHaveBeenCalledTimes(1);
@@ -966,7 +960,6 @@ describe("persistAuthPauseSessionRecord", () => {
           timestamp: 2,
         } as PiMessage,
       ],
-      logContext: {},
       reasoningLevel: "high",
     });
 

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -108,9 +108,6 @@ async function persistCompletedSessionForFakeReply(
     sessionId,
     sliceId: 1,
     allMessages: piMessages,
-    logContext: {
-      runId: context.runId,
-    },
     surface: context.surface,
     turnStartMessageIndex: context.piMessages?.length ?? 0,
   });

--- a/packages/junior/tests/integration/oauth-resume-slack.test.ts
+++ b/packages/junior/tests/integration/oauth-resume-slack.test.ts
@@ -95,6 +95,12 @@ describe("oauth resume slack integration", () => {
           }),
         },
       }),
+      commitResult: async () => {
+        expect(
+          getCapturedSlackApiCalls("assistant.threads.setStatus").at(-1)
+            ?.params,
+        ).toEqual(expect.objectContaining({ status: "" }));
+      },
     });
 
     expect(getCapturedSlackApiCalls("assistant.threads.setStatus")).toEqual([
@@ -132,6 +138,51 @@ describe("oauth resume slack integration", () => {
       }),
     ]);
   }, 10_000);
+
+  it("validates credentials before starting Slack resume UX", async () => {
+    const { resumeSlackTurn } = await import("@/chat/runtime/slack-resume");
+    const agentRunner = {
+      run: vi.fn(async () =>
+        completedAgentRun({
+          text: "should not run",
+          diagnostics: makeDiagnostics(),
+        }),
+      ),
+    };
+
+    await resumeSlackTurn({
+      messageText: "Continue the original request",
+      conversationId: "slack:C123:1700000000.011",
+      turnId: "turn-invalid-resume-actor",
+      channelId: "C123",
+      threadTs: "1700000000.011",
+      initialText: "Connected. Continuing...",
+      initialStatus: { text: "Continuing request" },
+      replyContext: {
+        routing: {
+          credentialContext: {
+            actor: { type: "user", userId: "U456" },
+          },
+          destination: TEST_SLACK_DESTINATION,
+          source: testSlackSource("1700000000.011"),
+          actor: { platform: "slack", teamId: "T123", userId: "U123" },
+        },
+      },
+      agentRunner,
+    });
+
+    expect(agentRunner.run).not.toHaveBeenCalled();
+    expect(getCapturedSlackApiCalls("assistant.threads.setStatus")).toEqual([]);
+    expect(
+      getCapturedSlackApiCalls("chat.postMessage").map(
+        (call) => call.params.text,
+      ),
+    ).toEqual([
+      expect.stringContaining(
+        "I ran into an internal error while processing that. Reference: `event_id=",
+      ),
+    ]);
+  });
 
   it("posts a failure reply when resumed generation times out", async () => {
     const { resumeSlackTurn } = await import("@/chat/runtime/slack-resume");

--- a/packages/junior/tests/integration/runtime/agent-run-provider-retry.test.ts
+++ b/packages/junior/tests/integration/runtime/agent-run-provider-retry.test.ts
@@ -604,7 +604,6 @@ describe("executeAgentRun provider retry", () => {
       allMessages: reply.piMessages ?? [],
       destination: TEST_DESTINATION,
       source: TEST_SOURCE,
-      logContext: {},
     });
 
     const sessionRecord = await turnSessionState.getAgentTurnSessionRecord(

--- a/packages/junior/tests/unit/handlers/oauth-resume.test.ts
+++ b/packages/junior/tests/unit/handlers/oauth-resume.test.ts
@@ -217,7 +217,7 @@ describe("resumeSlackTurn", () => {
             });
           },
         },
-        onSuccess: async () => {
+        commitResult: async () => {
           throw new Error("state write failed");
         },
         onFailure,


### PR DESCRIPTION
Resumed Slack turns now call their post-output hook `commitResult`, which makes
its job clear: save provider-specific state after output has been handled.
Session persistence also drops an unused `logContext` argument.

Integration coverage protects the important ordering: validate credentials
before starting Slack UX, and clear status before committing the result. This
does not add a new runtime abstraction.
