### PR TITLE
fix(dashboard): Render tool results in transcripts

### DIFF
--- a/packages/junior-dashboard/README.md
+++ b/packages/junior-dashboard/README.md
@@ -14,6 +14,9 @@ state.
 - Conversation detail exposes one ordered, privacy-safe event log. The
   dashboard owns the event-to-view reduction and never merges a duplicate
   transcript, activity stream, or provider runtime state.
+- Reporting projects only tool calls and model-visible results from agent
+  steps. The dashboard correlates their start, call, and result facts by tool
+  call id into one row without exposing the rest of model history.
 - Private conversation access requires authenticated authorization at the
   server boundary. Client-side route hiding is not authorization.
 - The package remains stateless apart from normal auth/session infrastructure;

--- a/packages/junior-dashboard/src/client/components/ConversationTranscript.tsx
+++ b/packages/junior-dashboard/src/client/components/ConversationTranscript.tsx
@@ -335,6 +335,7 @@ function VisibleTranscriptEntries(props: {
           key={`${props.conversation.conversationId}:${index}`}
           part={entry.part}
           timestamp={entry.timestamp}
+          view={props.view}
         />
       )}
     />

--- a/packages/junior-dashboard/src/client/components/TranscriptToolRun.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptToolRun.tsx
@@ -5,7 +5,7 @@ import { useTranscriptSearch } from "./transcriptSearch";
 
 const TOOL_RUN_REVEAL_THRESHOLD = 4;
 
-/** Collapse dense consecutive tool-start rows while keeping search results open. */
+/** Collapse dense consecutive tool rows while keeping search results open. */
 export function TranscriptToolRun(props: {
   autoCollapse: boolean;
   entries: RenderedToolEntry[];

--- a/packages/junior-dashboard/src/client/components/TranscriptToolView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptToolView.tsx
@@ -2,8 +2,8 @@ import type { ReactNode } from "react";
 
 import { HighlightedCode } from "../code";
 import {
+  formatElapsedDuration,
   formatMessageTimestamp,
-  formatMs,
   stringifyPartValue,
 } from "../format";
 import type { TranscriptViewToolCallPart } from "../types";
@@ -17,7 +17,10 @@ export function TranscriptToolView(props: {
   view?: "raw" | "rich";
 }) {
   const timestamp = formatMessageTimestamp(props.timestamp);
-  const duration = toolDuration(props.timestamp, props.part.resultTimestamp);
+  const duration = formatElapsedDuration(
+    props.timestamp,
+    props.part.resultTimestamp,
+  );
   const hasDetails =
     props.part.input !== undefined || props.part.output !== undefined;
   const meta = [duration, timestamp].filter(isString);
@@ -126,20 +129,6 @@ function ToolBody(props: { children: ReactNode; label?: string }) {
       {props.children}
     </div>
   );
-}
-
-function toolDuration(
-  startedAt: number | undefined,
-  endedAt: number | undefined,
-): string | undefined {
-  if (
-    typeof startedAt !== "number" ||
-    typeof endedAt !== "number" ||
-    endedAt < startedAt
-  ) {
-    return undefined;
-  }
-  return formatMs(endedAt - startedAt);
 }
 
 function isString(value: string | undefined): value is string {

--- a/packages/junior-dashboard/src/client/components/TranscriptToolView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptToolView.tsx
@@ -1,26 +1,145 @@
-import { formatMessageTimestamp } from "../format";
+import type { ReactNode } from "react";
+
+import { HighlightedCode } from "../code";
+import {
+  formatMessageTimestamp,
+  formatMs,
+  stringifyPartValue,
+} from "../format";
 import type { TranscriptViewToolCallPart } from "../types";
 import { ToolFrame } from "./ToolFrame";
 import { HighlightText } from "./transcriptSearch";
 
-/** Render the structural start of one tool execution. */
+/** Render one tool invocation as it advances from running to a terminal result. */
 export function TranscriptToolView(props: {
   part: TranscriptViewToolCallPart;
   timestamp?: number;
+  view?: "raw" | "rich";
 }) {
   const timestamp = formatMessageTimestamp(props.timestamp);
+  const duration = toolDuration(props.timestamp, props.part.resultTimestamp);
+  const hasDetails =
+    props.part.input !== undefined || props.part.output !== undefined;
+  const meta = [duration, timestamp].filter(isString);
+  const status =
+    props.part.status === "completed" ? null : (
+      <ToolStatus status={props.part.status} />
+    );
+  const mobileSummary = duration;
+
+  if (props.view === "raw" && hasDetails) {
+    return (
+      <ToolFrame
+        meta={meta}
+        mobileSummaryMeta={mobileSummary}
+        raw
+        signature={<ToolSignature name={props.part.name} status={status} />}
+      >
+        <ToolBody>
+          <HighlightedCode
+            code={stringifyPartValue({
+              call: {
+                id: props.part.id,
+                input: props.part.input,
+                name: props.part.name,
+              },
+              result:
+                props.part.status === "running"
+                  ? undefined
+                  : {
+                      outcome: props.part.status,
+                      output: props.part.output,
+                    },
+            })}
+            language="json"
+          />
+        </ToolBody>
+      </ToolFrame>
+    );
+  }
+
   return (
     <ToolFrame
-      meta={["started", timestamp].filter(isString)}
-      mobileSummaryMeta="started"
-      raw
-      signature={
-        <strong className="min-w-0 break-words font-bold text-[#d6d6d6]">
-          <HighlightText text={props.part.name} />
-        </strong>
-      }
-    />
+      expandable={hasDetails}
+      meta={meta}
+      mobileSummaryMeta={mobileSummary}
+      signature={<ToolSignature name={props.part.name} status={status} />}
+    >
+      {props.part.input !== undefined ? (
+        <ToolBody label="arguments">
+          <HighlightedCode
+            code={stringifyPartValue(props.part.input)}
+            language="json"
+          />
+        </ToolBody>
+      ) : null}
+      {props.part.output !== undefined ? (
+        <ToolBody label="result">
+          <HighlightedCode
+            code={stringifyPartValue(props.part.output)}
+            language="json"
+          />
+        </ToolBody>
+      ) : null}
+    </ToolFrame>
   );
+}
+
+function ToolSignature(props: { name: string; status: ReactNode }) {
+  return (
+    <>
+      <strong className="min-w-0 break-words font-bold text-[#d6d6d6]">
+        <HighlightText text={props.name} />
+      </strong>
+      {props.status ? (
+        <>
+          <span className="text-[#777]">·</span>
+          {props.status}
+        </>
+      ) : null}
+    </>
+  );
+}
+
+function ToolStatus(props: { status: "error" | "running" }) {
+  if (props.status === "running") {
+    return (
+      <span
+        aria-label="running"
+        className="animate-pulse text-cyan-200/70 motion-reduce:animate-none"
+      >
+        running
+      </span>
+    );
+  }
+  return <span className="text-rose-300">error</span>;
+}
+
+function ToolBody(props: { children: ReactNode; label?: string }) {
+  return (
+    <div className="min-w-0 max-w-full overflow-hidden border-t border-white/10 py-2">
+      {props.label ? (
+        <div className="pb-2 font-mono text-[0.68rem] font-bold uppercase leading-none text-[#9a8fd0]">
+          {props.label}
+        </div>
+      ) : null}
+      {props.children}
+    </div>
+  );
+}
+
+function toolDuration(
+  startedAt: number | undefined,
+  endedAt: number | undefined,
+): string | undefined {
+  if (
+    typeof startedAt !== "number" ||
+    typeof endedAt !== "number" ||
+    endedAt < startedAt
+  ) {
+    return undefined;
+  }
+  return formatMs(endedAt - startedAt);
 }
 
 function isString(value: string | undefined): value is string {

--- a/packages/junior-dashboard/src/client/components/transcriptBottomPinning.ts
+++ b/packages/junior-dashboard/src/client/components/transcriptBottomPinning.ts
@@ -268,11 +268,9 @@ function transcriptPartVersion(part: TranscriptViewPart | undefined): string {
     return [
       part.type,
       part.id,
-      part.name,
       part.status,
       part.input === undefined ? "" : "input",
       part.output === undefined ? "" : "output",
-      part.resultTimestamp ?? "",
     ].join(":");
   }
   if (part.type === "subagent") {

--- a/packages/junior-dashboard/src/client/components/transcriptBottomPinning.ts
+++ b/packages/junior-dashboard/src/client/components/transcriptBottomPinning.ts
@@ -264,7 +264,17 @@ function transcriptPartVersion(part: TranscriptViewPart | undefined): string {
       part.redacted ? "redacted" : "",
     ].join(":");
   }
-  if (part.type === "tool_call") return `${part.type}:${part.name}`;
+  if (part.type === "tool_call") {
+    return [
+      part.type,
+      part.id,
+      part.name,
+      part.status,
+      part.input === undefined ? "" : "input",
+      part.output === undefined ? "" : "output",
+      part.resultTimestamp ?? "",
+    ].join(":");
+  }
   if (part.type === "subagent") {
     return [
       part.type,

--- a/packages/junior-dashboard/src/client/components/transcriptRenderModel.ts
+++ b/packages/junior-dashboard/src/client/components/transcriptRenderModel.ts
@@ -97,16 +97,7 @@ export function messageRawText(message: TranscriptViewMessage): string {
   return message.parts
     .map((part) => {
       if (part.type === "text") return part.text ?? "";
-      if (part.type === "tool_call") {
-        return [
-          `tool_call ${part.name}`,
-          `status ${part.status}`,
-          part.input === undefined ? "" : JSON.stringify(part.input, null, 2),
-          part.output === undefined ? "" : JSON.stringify(part.output, null, 2),
-        ]
-          .filter((value) => value.length > 0)
-          .join("\n");
-      }
+      if (part.type === "tool_call") return `tool_call ${part.name}`;
       if (part.type === "subagent") {
         return `subagent ${part.subagentKind}\nstatus ${part.status}`;
       }

--- a/packages/junior-dashboard/src/client/components/transcriptRenderModel.ts
+++ b/packages/junior-dashboard/src/client/components/transcriptRenderModel.ts
@@ -97,7 +97,16 @@ export function messageRawText(message: TranscriptViewMessage): string {
   return message.parts
     .map((part) => {
       if (part.type === "text") return part.text ?? "";
-      if (part.type === "tool_call") return `tool_call ${part.name}`;
+      if (part.type === "tool_call") {
+        return [
+          `tool_call ${part.name}`,
+          `status ${part.status}`,
+          part.input === undefined ? "" : JSON.stringify(part.input, null, 2),
+          part.output === undefined ? "" : JSON.stringify(part.output, null, 2),
+        ]
+          .filter((value) => value.length > 0)
+          .join("\n");
+      }
       if (part.type === "subagent") {
         return `subagent ${part.subagentKind}\nstatus ${part.status}`;
       }

--- a/packages/junior-dashboard/src/client/components/transcriptSearch.tsx
+++ b/packages/junior-dashboard/src/client/components/transcriptSearch.tsx
@@ -5,6 +5,7 @@ import {
   messageRawText,
   type RenderedTranscriptEntry,
 } from "./transcriptRenderModel";
+import { stringifyPartValue } from "../format";
 
 // ─── Context ────────────────────────────────────────────────────────────────
 
@@ -135,7 +136,12 @@ export function entryMatchesSearch(
   }
 
   if (entry.kind === "tool") {
-    return textContains(entry.part.name, normalizedQuery);
+    return [
+      entry.part.name,
+      entry.part.status,
+      stringifyPartValue(entry.part.input),
+      stringifyPartValue(entry.part.output),
+    ].some((value) => textContains(value, normalizedQuery));
   }
 
   if (entry.kind === "subagent") {

--- a/packages/junior-dashboard/src/client/eventTranscript.ts
+++ b/packages/junior-dashboard/src/client/eventTranscript.ts
@@ -43,18 +43,26 @@ function subagentOutcomes(
   return outcomes;
 }
 
-function specialToolStarts(events: ConversationReportEvent[]): Set<number> {
-  const starts = new Set<number>();
+function specialToolIds(events: ConversationReportEvent[]): Set<string> {
+  const startsBySeq = new Map<number, string>();
+  for (const event of events) {
+    if (event.data.type === "tool_started") {
+      startsBySeq.set(event.seq, event.data.toolCallId);
+    }
+  }
+
+  const ids = new Set<string>();
   for (const event of events) {
     const data = event.data;
     if (
       (data.type === "handoff" || data.type === "subagent_started") &&
       data.toolStartedSeq !== undefined
     ) {
-      starts.add(data.toolStartedSeq);
+      const id = startsBySeq.get(data.toolStartedSeq);
+      if (id) ids.add(id);
     }
   }
-  return starts;
+  return ids;
 }
 
 function subagentPart(
@@ -80,8 +88,31 @@ export function conversationTranscriptMessages(
   conversation: ConversationTranscript,
 ): TranscriptViewMessage[] {
   const outcomes = subagentOutcomes(conversation.events);
-  const replacedToolStarts = specialToolStarts(conversation.events);
+  const replacedToolIds = specialToolIds(conversation.events);
+  const tools = new Map<
+    string,
+    Extract<TranscriptViewPart, { type: "tool_call" }>
+  >();
   const messages: TranscriptViewMessage[] = [];
+
+  const ensureTool = (
+    event: ConversationReportEvent,
+    toolCallId: string,
+    name: string,
+  ): Extract<TranscriptViewPart, { type: "tool_call" }> | undefined => {
+    if (replacedToolIds.has(toolCallId)) return undefined;
+    const existing = tools.get(toolCallId);
+    if (existing) return existing;
+    const part = {
+      type: "tool_call" as const,
+      id: toolCallId,
+      name,
+      status: "running" as const,
+    };
+    tools.set(toolCallId, part);
+    messages.push(eventMessage(event, "tool", [part]));
+    return part;
+  };
 
   // API sequence is the only ordering authority. Do not sort by timestamps:
   // producers may preserve ingestion order while clocks are skewed.
@@ -99,14 +130,25 @@ export function conversationTranscriptMessages(
     }
 
     if (data.type === "tool_started") {
-      if (replacedToolStarts.has(event.seq)) continue;
-      messages.push(
-        eventMessage(event, "tool", [
-          // Reporting intentionally has no completion state. This is a neutral
-          // structural start row, not a claim that the tool is still running.
-          { type: "tool_call", name: data.name },
-        ]),
-      );
+      ensureTool(event, data.toolCallId, data.name);
+      continue;
+    }
+
+    if (data.type === "tool_calls") {
+      for (const call of data.calls) {
+        const part = ensureTool(event, call.toolCallId, call.name);
+        if (part && call.input !== undefined) part.input = call.input;
+      }
+      continue;
+    }
+
+    if (data.type === "tool_result") {
+      const part = tools.get(data.toolCallId);
+      if (part) {
+        part.status = data.outcome;
+        part.resultTimestamp = eventTimestamp(event);
+        if (data.output !== undefined) part.output = data.output;
+      }
       continue;
     }
 

--- a/packages/junior-dashboard/src/client/eventTranscript.ts
+++ b/packages/junior-dashboard/src/client/eventTranscript.ts
@@ -44,22 +44,14 @@ function subagentOutcomes(
 }
 
 function specialToolIds(events: ConversationReportEvent[]): Set<string> {
-  const startsBySeq = new Map<number, string>();
-  for (const event of events) {
-    if (event.data.type === "tool_started") {
-      startsBySeq.set(event.seq, event.data.toolCallId);
-    }
-  }
-
   const ids = new Set<string>();
   for (const event of events) {
     const data = event.data;
-    if (
-      (data.type === "handoff" || data.type === "subagent_started") &&
-      data.toolStartedSeq !== undefined
-    ) {
-      const id = startsBySeq.get(data.toolStartedSeq);
-      if (id) ids.add(id);
+    if (data.type === "handoff" && data.triggeringToolCallId) {
+      ids.add(data.triggeringToolCallId);
+    }
+    if (data.type === "subagent_started" && data.parentToolCallId) {
+      ids.add(data.parentToolCallId);
     }
   }
   return ids;

--- a/packages/junior-dashboard/src/client/format.ts
+++ b/packages/junior-dashboard/src/client/format.ts
@@ -103,6 +103,21 @@ export function formatMs(value: number | undefined): string {
   return `${minutes}m ${remainingSeconds}s`;
 }
 
+/** Format the elapsed duration between two transcript event timestamps. */
+export function formatElapsedDuration(
+  startedAt: number | undefined,
+  endedAt: number | undefined,
+): string | undefined {
+  if (
+    typeof startedAt !== "number" ||
+    typeof endedAt !== "number" ||
+    endedAt < startedAt
+  ) {
+    return undefined;
+  }
+  return formatMs(endedAt - startedAt);
+}
+
 /** Format a persisted conversation runtime when duration data exists. */
 export function formatRuntime(durationMs: number | undefined): string {
   if (typeof durationMs !== "number" || !Number.isFinite(durationMs)) return "";

--- a/packages/junior-dashboard/src/client/markdownExport.ts
+++ b/packages/junior-dashboard/src/client/markdownExport.ts
@@ -204,7 +204,6 @@ function appendTool(
   lines.push("", `### Tool: ${headingText(part.name)}`);
   addEventMeta(lines, conversationTranscript, timestamp);
   addMetaLine(lines, "Status", part.status);
-  addMetaLine(lines, "Result timestamp", eventTimestamp(part.resultTimestamp));
   addMetaLine(
     lines,
     "Duration",

--- a/packages/junior-dashboard/src/client/markdownExport.ts
+++ b/packages/junior-dashboard/src/client/markdownExport.ts
@@ -5,6 +5,7 @@ import {
   formatUsageTotal,
   actorLabel,
   slackLocationLabel,
+  stringifyPartValue,
   transcriptRoleKind,
   unavailableTranscriptLabel,
 } from "./format";
@@ -201,7 +202,39 @@ function appendTool(
 ): void {
   lines.push("", `### Tool: ${headingText(part.name)}`);
   addEventMeta(lines, conversationTranscript, timestamp);
-  addMetaLine(lines, "Status", "started");
+  addMetaLine(lines, "Status", part.status);
+  addMetaLine(lines, "Result timestamp", eventTimestamp(part.resultTimestamp));
+  addMetaLine(lines, "Duration", toolDuration(timestamp, part.resultTimestamp));
+  if (part.input !== undefined) {
+    lines.push(
+      "",
+      "#### Arguments",
+      "",
+      fencedBlock(stringifyPartValue(part.input), "json"),
+    );
+  }
+  if (part.output !== undefined) {
+    lines.push(
+      "",
+      "#### Result",
+      "",
+      fencedBlock(stringifyPartValue(part.output), "json"),
+    );
+  }
+}
+
+function toolDuration(
+  startedAt: number | undefined,
+  endedAt: number | undefined,
+): string | undefined {
+  if (
+    typeof startedAt !== "number" ||
+    typeof endedAt !== "number" ||
+    endedAt < startedAt
+  ) {
+    return undefined;
+  }
+  return formatMs(endedAt - startedAt);
 }
 
 function addEventMeta(
@@ -293,6 +326,15 @@ function headingText(value: string): string {
 function inlineCode(value: string): string {
   const fence = value.includes("`") ? "``" : "`";
   return `${fence}${value}${fence}`;
+}
+
+function fencedBlock(value: string, language: string): string {
+  const longestBacktickRun = [...value.matchAll(/`+/g)].reduce(
+    (longest, match) => Math.max(longest, match[0].length),
+    0,
+  );
+  const fence = "`".repeat(Math.max(3, longestBacktickRun + 1));
+  return `${fence}${language}\n${value}\n${fence}`;
 }
 
 function finishMarkdown(lines: string[]): string {

--- a/packages/junior-dashboard/src/client/markdownExport.ts
+++ b/packages/junior-dashboard/src/client/markdownExport.ts
@@ -1,6 +1,7 @@
 import {
   conversationDisplayTitle,
   formatCostTotal,
+  formatElapsedDuration,
   formatMs,
   formatUsageTotal,
   actorLabel,
@@ -204,7 +205,11 @@ function appendTool(
   addEventMeta(lines, conversationTranscript, timestamp);
   addMetaLine(lines, "Status", part.status);
   addMetaLine(lines, "Result timestamp", eventTimestamp(part.resultTimestamp));
-  addMetaLine(lines, "Duration", toolDuration(timestamp, part.resultTimestamp));
+  addMetaLine(
+    lines,
+    "Duration",
+    formatElapsedDuration(timestamp, part.resultTimestamp),
+  );
   if (part.input !== undefined) {
     lines.push(
       "",
@@ -221,20 +226,6 @@ function appendTool(
       fencedBlock(stringifyPartValue(part.output), "json"),
     );
   }
-}
-
-function toolDuration(
-  startedAt: number | undefined,
-  endedAt: number | undefined,
-): string | undefined {
-  if (
-    typeof startedAt !== "number" ||
-    typeof endedAt !== "number" ||
-    endedAt < startedAt
-  ) {
-    return undefined;
-  }
-  return formatMs(endedAt - startedAt);
 }
 
 function addEventMeta(

--- a/packages/junior-dashboard/src/client/types.ts
+++ b/packages/junior-dashboard/src/client/types.ts
@@ -16,7 +16,12 @@ export type TranscriptViewTextPart =
   | { redacted: true; text?: never; type: "text" };
 
 export type TranscriptViewToolCallPart = {
+  id: string;
+  input?: unknown;
   name: string;
+  output?: unknown;
+  resultTimestamp?: number;
+  status: "completed" | "error" | "running";
   type: "tool_call";
 };
 

--- a/packages/junior-dashboard/src/mock-reporting/fixtures.ts
+++ b/packages/junior-dashboard/src/mock-reporting/fixtures.ts
@@ -182,7 +182,6 @@ function dashboardQaConversation(nowMs: number): ConversationDetailReport {
       reportEvent(5, iso(Date.parse(startedAt), 21_000), {
         type: "tool_result",
         toolCallId: "qa-advisor",
-        name: "advisor",
         outcome: "completed",
         output: { ok: true, status: "success" },
       }),
@@ -355,7 +354,6 @@ function incidentConversation(nowMs: number): ConversationDetailReport {
       reportEvent(3, iso(Date.parse(startedAt), 28_000), {
         type: "tool_result",
         toolCallId: "incident-issue",
-        name: "sentry.get_issue",
         outcome: "completed",
         output: {
           ok: true,
@@ -407,7 +405,6 @@ function privateConversation(nowMs: number): ConversationDetailReport {
       reportEvent(3, iso(Date.parse(startedAt), 25_000), {
         type: "tool_result",
         toolCallId: "private-search",
-        name: "sentry.search",
         outcome: "completed",
       }),
       reportEvent(4, iso(Date.parse(startedAt), 30_000), {

--- a/packages/junior-dashboard/src/mock-reporting/fixtures.ts
+++ b/packages/junior-dashboard/src/mock-reporting/fixtures.ts
@@ -129,6 +129,7 @@ function activeConversation(nowMs: number): ConversationDetailReport {
       }),
       reportEvent(2, iso(Date.parse(startedAt), 8_000), {
         type: "tool_started",
+        toolCallId: "active-search",
         name: "datacat.search_logs",
       }),
     ],
@@ -154,33 +155,51 @@ function dashboardQaConversation(nowMs: number): ConversationDetailReport {
       }),
       reportEvent(1, iso(Date.parse(startedAt), 2_000), {
         type: "tool_started",
+        toolCallId: "qa-advisor",
         name: "advisor",
       }),
       reportEvent(2, iso(Date.parse(startedAt), 3_000), {
+        type: "tool_calls",
+        calls: [
+          {
+            toolCallId: "qa-advisor",
+            name: "advisor",
+            input: { task: "Review the dashboard plan" },
+          },
+        ],
+      }),
+      reportEvent(3, iso(Date.parse(startedAt), 4_000), {
         type: "subagent_started",
         childConversationId: DASHBOARD_QA_PLAN_ID,
         subagentKind: "advisor",
         toolStartedSeq: 1,
       }),
-      reportEvent(3, iso(Date.parse(startedAt), 20_000), {
+      reportEvent(4, iso(Date.parse(startedAt), 20_000), {
         type: "subagent_ended",
-        startedSeq: 2,
+        startedSeq: 3,
         outcome: "success",
       }),
-      reportEvent(4, iso(Date.parse(startedAt), 25_000), {
+      reportEvent(5, iso(Date.parse(startedAt), 21_000), {
+        type: "tool_result",
+        toolCallId: "qa-advisor",
+        name: "advisor",
+        outcome: "completed",
+        output: { ok: true, status: "success" },
+      }),
+      reportEvent(6, iso(Date.parse(startedAt), 25_000), {
         type: "subagent_started",
         childConversationId: DASHBOARD_QA_REVIEW_ID,
         subagentKind: "advisor",
       }),
-      reportEvent(5, iso(Date.parse(startedAt), 44_000), {
+      reportEvent(7, iso(Date.parse(startedAt), 44_000), {
         type: "subagent_ended",
-        startedSeq: 4,
+        startedSeq: 6,
         outcome: "success",
       }),
-      reportEvent(6, iso(Date.parse(startedAt), 50_000), {
+      reportEvent(8, iso(Date.parse(startedAt), 50_000), {
         type: "compaction",
       }),
-      reportEvent(7, iso(Date.parse(startedAt), 55_000), {
+      reportEvent(9, iso(Date.parse(startedAt), 55_000), {
         type: "message",
         messageId: "qa-assistant",
         role: "assistant",
@@ -241,6 +260,7 @@ function longConversation(nowMs: number): ConversationDetailReport {
         iso(Date.parse(startedAt), 2_000 + index * 4_000),
         {
           type: "tool_started",
+          toolCallId: `release-bash-${index}`,
           name: "bash",
         },
       ),
@@ -319,9 +339,31 @@ function incidentConversation(nowMs: number): ConversationDetailReport {
       }),
       reportEvent(1, iso(Date.parse(startedAt), 12_000), {
         type: "tool_started",
+        toolCallId: "incident-issue",
         name: "sentry.get_issue",
       }),
-      reportEvent(2, iso(Date.parse(startedAt), 35_000), {
+      reportEvent(2, iso(Date.parse(startedAt), 13_000), {
+        type: "tool_calls",
+        calls: [
+          {
+            toolCallId: "incident-issue",
+            name: "sentry.get_issue",
+            input: { issueId: "PAYMENTS-42" },
+          },
+        ],
+      }),
+      reportEvent(3, iso(Date.parse(startedAt), 28_000), {
+        type: "tool_result",
+        toolCallId: "incident-issue",
+        name: "sentry.get_issue",
+        outcome: "completed",
+        output: {
+          ok: true,
+          status: "success",
+          data: { culprit: "payments-v42", eventCount: 418 },
+        },
+      }),
+      reportEvent(4, iso(Date.parse(startedAt), 35_000), {
         type: "message",
         messageId: "incident-assistant",
         role: "assistant",
@@ -355,9 +397,20 @@ function privateConversation(nowMs: number): ConversationDetailReport {
       }),
       reportEvent(1, iso(Date.parse(startedAt), 10_000), {
         type: "tool_started",
+        toolCallId: "private-search",
         name: "sentry.search",
       }),
-      reportEvent(2, iso(Date.parse(startedAt), 30_000), {
+      reportEvent(2, iso(Date.parse(startedAt), 11_000), {
+        type: "tool_calls",
+        calls: [{ toolCallId: "private-search", name: "sentry.search" }],
+      }),
+      reportEvent(3, iso(Date.parse(startedAt), 25_000), {
+        type: "tool_result",
+        toolCallId: "private-search",
+        name: "sentry.search",
+        outcome: "completed",
+      }),
+      reportEvent(4, iso(Date.parse(startedAt), 30_000), {
         type: "message",
         messageId: "private-assistant",
         role: "assistant",

--- a/packages/junior-dashboard/src/mock-reporting/fixtures.ts
+++ b/packages/junior-dashboard/src/mock-reporting/fixtures.ts
@@ -172,7 +172,7 @@ function dashboardQaConversation(nowMs: number): ConversationDetailReport {
         type: "subagent_started",
         childConversationId: DASHBOARD_QA_PLAN_ID,
         subagentKind: "advisor",
-        toolStartedSeq: 1,
+        parentToolCallId: "qa-advisor",
       }),
       reportEvent(4, iso(Date.parse(startedAt), 20_000), {
         type: "subagent_ended",

--- a/packages/junior-dashboard/tests/format.test.ts
+++ b/packages/junior-dashboard/tests/format.test.ts
@@ -18,6 +18,7 @@ import {
   formatCompactNumber,
   formatConversationDuration,
   formatCostTotal,
+  formatElapsedDuration,
   formatRuntime,
   formatTranscriptDuration,
   formatUsageTotal,
@@ -97,6 +98,12 @@ describe("dashboard conversation formatting", () => {
     expect(formatTranscriptDuration({ cumulativeDurationMs: 7_000 })).toBe(
       "7.0s",
     );
+  });
+
+  it("formats elapsed transcript event durations", () => {
+    expect(formatElapsedDuration(1_000, 4_500)).toBe("3.5s");
+    expect(formatElapsedDuration(undefined, 4_500)).toBeUndefined();
+    expect(formatElapsedDuration(4_500, 1_000)).toBeUndefined();
   });
 
   it("formats conversation duration from cumulative execution time", () => {

--- a/packages/junior-dashboard/tests/format.test.ts
+++ b/packages/junior-dashboard/tests/format.test.ts
@@ -158,7 +158,7 @@ describe("dashboard conversation formatting", () => {
           type: "subagent_started",
           childConversationId: "child-1",
           subagentKind: "advisor",
-          toolStartedSeq: 1,
+          parentToolCallId: "search-1",
         }),
         event(3, {
           type: "message",

--- a/packages/junior-dashboard/tests/format.test.ts
+++ b/packages/junior-dashboard/tests/format.test.ts
@@ -142,7 +142,11 @@ describe("dashboard conversation formatting", () => {
           role: "user",
           text: "run search",
         }),
-        event(1, { type: "tool_started", name: "search" }),
+        event(1, {
+          type: "tool_started",
+          toolCallId: "search-1",
+          name: "search",
+        }),
         event(2, {
           type: "subagent_started",
           childConversationId: "child-1",

--- a/packages/junior-dashboard/tests/markdownExport.test.ts
+++ b/packages/junior-dashboard/tests/markdownExport.test.ts
@@ -88,7 +88,6 @@ describe("dashboard canonical-event Markdown export", () => {
         event(2, {
           type: "tool_result",
           toolCallId: "search-1",
-          name: "search",
           outcome: "completed",
           output: { matches: 3 },
         }),

--- a/packages/junior-dashboard/tests/markdownExport.test.ts
+++ b/packages/junior-dashboard/tests/markdownExport.test.ts
@@ -70,14 +70,35 @@ describe("dashboard canonical-event Markdown export", () => {
   it("exports structural tool, context, subagent, and failure rows", () => {
     const markdown = buildConversationMarkdown(
       conversation([
-        event(0, { type: "tool_started", name: "search" }),
+        event(0, {
+          type: "tool_started",
+          toolCallId: "search-1",
+          name: "search",
+        }),
         event(1, {
+          type: "tool_calls",
+          calls: [
+            {
+              toolCallId: "search-1",
+              name: "search",
+              input: { query: "release regression" },
+            },
+          ],
+        }),
+        event(2, {
+          type: "tool_result",
+          toolCallId: "search-1",
+          name: "search",
+          outcome: "completed",
+          output: { matches: 3 },
+        }),
+        event(3, {
           type: "subagent_started",
           childConversationId: "child-1",
           subagentKind: "advisor",
         }),
-        event(2, { type: "compaction" }),
-        event(3, {
+        event(4, { type: "compaction" }),
+        event(5, {
           type: "turn_lifecycle",
           turnId: "turn-1",
           state: "failed",
@@ -87,7 +108,10 @@ describe("dashboard canonical-event Markdown export", () => {
     );
 
     expect(markdown).toContain("### Tool: search");
-    expect(markdown).toContain("- Status: started");
+    expect(markdown).toContain("- Status: completed");
+    expect(markdown.match(/### Tool: search/g)).toHaveLength(1);
+    expect(markdown).toContain("release regression");
+    expect(markdown).toContain('"matches": 3');
     expect(markdown).toContain("### Subagent: advisor");
     expect(markdown).toContain("### Context compacted");
     expect(markdown).toContain("### Agent response failed");
@@ -115,18 +139,27 @@ describe("dashboard canonical-event Markdown export", () => {
     expect(markdown).not.toContain("Agent response failed");
   });
 
-  it("labels redacted structural tool starts neutrally", () => {
+  it("labels redacted in-progress tools without inventing a completion", () => {
     const markdown = buildConversationMarkdown(
-      conversation([event(0, { type: "tool_started", name: "search" })], {
-        eventHistory: {
-          status: "redacted",
-          reason: "non_public_conversation",
+      conversation(
+        [
+          event(0, {
+            type: "tool_started",
+            toolCallId: "search-1",
+            name: "search",
+          }),
+        ],
+        {
+          eventHistory: {
+            status: "redacted",
+            reason: "non_public_conversation",
+          },
         },
-      }),
+      ),
     );
 
     expect(markdown).toContain("### Tool: search");
-    expect(markdown).toContain("- Status: started");
+    expect(markdown).toContain("- Status: running");
     expect(markdown).not.toContain("missing result");
   });
 

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -335,7 +335,6 @@ describe("dashboard canonical-event components", () => {
         event(2, {
           type: "tool_result",
           toolCallId: "search-1",
-          name: "search",
           outcome: "completed",
           output: { matches: 2 },
         }),
@@ -361,7 +360,6 @@ describe("dashboard canonical-event components", () => {
         event(1, {
           type: "tool_result",
           toolCallId: "search-1",
-          name: "search",
           outcome: "error",
           output: { error: "timed out" },
         }),

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -290,19 +290,89 @@ describe("dashboard canonical-event components", () => {
     expect(html).not.toContain("Agent response failed");
   });
 
-  it("renders redacted tool starts as started rather than missing", () => {
+  it("renders one in-progress row for a tool start", () => {
     const html = renderTranscript(
-      conversation([event(0, { type: "tool_started", name: "search" })], {
-        eventHistory: {
-          status: "redacted",
-          reason: "non_public_conversation",
+      conversation(
+        [
+          event(0, {
+            type: "tool_started",
+            toolCallId: "search-1",
+            name: "search",
+          }),
+        ],
+        {
+          eventHistory: {
+            status: "redacted",
+            reason: "non_public_conversation",
+          },
         },
-      }),
+      ),
     );
     expect(html).toContain("search");
-    expect(html).toContain("started");
-    expect(html).not.toContain("running");
+    expect(html).toContain("running");
+    expect(html).not.toContain("started");
     expect(html).not.toContain("missing result");
+  });
+
+  it("replaces the running treatment with details on the same completed row", () => {
+    const html = renderTranscript(
+      conversation([
+        event(0, {
+          type: "tool_started",
+          toolCallId: "search-1",
+          name: "search",
+        }),
+        event(1, {
+          type: "tool_calls",
+          calls: [
+            {
+              toolCallId: "search-1",
+              name: "search",
+              input: { query: "regression" },
+            },
+          ],
+        }),
+        event(2, {
+          type: "tool_result",
+          toolCallId: "search-1",
+          name: "search",
+          outcome: "completed",
+          output: { matches: 2 },
+        }),
+      ]),
+    );
+
+    expect(html).toContain("arguments");
+    expect(html).toContain("result");
+    expect(html).toContain("regression");
+    expect(html).toContain("matches");
+    expect(html).not.toContain("running");
+    expect(html).not.toContain("completed");
+  });
+
+  it("renders a terminal tool error with its result details", () => {
+    const html = renderTranscript(
+      conversation([
+        event(0, {
+          type: "tool_started",
+          toolCallId: "search-1",
+          name: "search",
+        }),
+        event(1, {
+          type: "tool_result",
+          toolCallId: "search-1",
+          name: "search",
+          outcome: "error",
+          output: { error: "timed out" },
+        }),
+      ]),
+    );
+
+    expect(html).toContain("search");
+    expect(html).toContain("error");
+    expect(html).toContain("result");
+    expect(html).toContain("timed out");
+    expect(html).not.toContain("running");
   });
 
   it.each([

--- a/packages/junior-dashboard/tests/transcriptBottomPinning.test.ts
+++ b/packages/junior-dashboard/tests/transcriptBottomPinning.test.ts
@@ -100,7 +100,6 @@ describe("transcript bottom pinning", () => {
             data: {
               type: "tool_result",
               toolCallId: "search-1",
-              name: "search",
               outcome: "completed",
               output: { matches: 2 },
             },

--- a/packages/junior-dashboard/tests/transcriptBottomPinning.test.ts
+++ b/packages/junior-dashboard/tests/transcriptBottomPinning.test.ts
@@ -79,6 +79,39 @@ describe("transcript bottom pinning", () => {
     expect(after).not.toBe(before);
   });
 
+  it("changes the tail version when a running tool receives its result", () => {
+    const started = {
+      seq: 0,
+      createdAt: "2026-01-01T00:00:01.000Z",
+      data: {
+        type: "tool_started" as const,
+        toolCallId: "search-1",
+        name: "search",
+      },
+    };
+    const before = transcriptBottomVersion(activeTurn({ events: [started] }));
+    const after = transcriptBottomVersion(
+      activeTurn({
+        events: [
+          started,
+          {
+            seq: 1,
+            createdAt: "2026-01-01T00:00:02.000Z",
+            data: {
+              type: "tool_result",
+              toolCallId: "search-1",
+              name: "search",
+              outcome: "completed",
+              output: { matches: 2 },
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(after).not.toBe(before);
+  });
+
   it("keeps the tail version stable when only polling timestamps change", () => {
     const before = transcriptBottomVersion(activeTurn());
     const after = transcriptBottomVersion(

--- a/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
+++ b/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
@@ -88,18 +88,67 @@ describe("canonical event transcript reduction", () => {
     expect(messages[1]?.parts).toEqual([{ type: "text", redacted: true }]);
   });
 
-  it("renders tool starts as neutral structural events", () => {
+  it("renders a tool start as one running invocation", () => {
     const [message] = conversationTranscriptMessages(
       conversation([
         event(0, "2026-01-01T00:00:00.000Z", {
           type: "tool_started",
+          toolCallId: "search-1",
           name: "search",
         }),
       ]),
     );
 
-    expect(message?.parts).toEqual([{ type: "tool_call", name: "search" }]);
-    expect(message?.parts[0]).not.toHaveProperty("status");
+    expect(message?.parts).toEqual([
+      {
+        type: "tool_call",
+        id: "search-1",
+        name: "search",
+        status: "running",
+      },
+    ]);
+  });
+
+  it("enriches one tool row in place when call details and a result arrive", () => {
+    const messages = conversationTranscriptMessages(
+      conversation([
+        event(0, "2026-01-01T00:00:00.000Z", {
+          type: "tool_started",
+          toolCallId: "search-1",
+          name: "search",
+        }),
+        event(1, "2026-01-01T00:00:01.000Z", {
+          type: "tool_calls",
+          calls: [
+            {
+              toolCallId: "search-1",
+              name: "search",
+              input: { query: "regression" },
+            },
+          ],
+        }),
+        event(2, "2026-01-01T00:00:03.000Z", {
+          type: "tool_result",
+          toolCallId: "search-1",
+          name: "search",
+          outcome: "completed",
+          output: { matches: 2 },
+        }),
+      ]),
+    );
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.parts).toEqual([
+      {
+        type: "tool_call",
+        id: "search-1",
+        input: { query: "regression" },
+        name: "search",
+        output: { matches: 2 },
+        resultTimestamp: Date.parse("2026-01-01T00:00:03.000Z"),
+        status: "completed",
+      },
+    ]);
   });
 
   it("replaces only correlated tool starts with special lifecycle rows", () => {
@@ -108,6 +157,7 @@ describe("canonical event transcript reduction", () => {
         conversation([
           event(0, "2026-01-01T00:00:00.000Z", {
             type: "tool_started",
+            toolCallId: "advisor-correlated",
             name: "advisor",
           }),
           event(1, "2026-01-01T00:00:01.000Z", {
@@ -123,10 +173,12 @@ describe("canonical event transcript reduction", () => {
           }),
           event(3, "2026-01-01T00:00:03.000Z", {
             type: "tool_started",
+            toolCallId: "advisor-visible",
             name: "advisor",
           }),
           event(4, "2026-01-01T00:00:04.000Z", {
             type: "tool_started",
+            toolCallId: "handoff-correlated",
             name: "handoff",
           }),
           event(5, "2026-01-01T00:00:05.000Z", {
@@ -140,6 +192,35 @@ describe("canonical event transcript reduction", () => {
           }),
           event(7, "2026-01-01T00:00:07.000Z", {
             type: "handoff",
+          }),
+          event(8, "2026-01-01T00:00:08.000Z", {
+            type: "tool_calls",
+            calls: [
+              {
+                toolCallId: "advisor-correlated",
+                name: "advisor",
+                input: { task: "review" },
+              },
+              {
+                toolCallId: "handoff-correlated",
+                name: "handoff",
+                input: { profile: "fast" },
+              },
+            ],
+          }),
+          event(9, "2026-01-01T00:00:09.000Z", {
+            type: "tool_result",
+            toolCallId: "advisor-correlated",
+            name: "advisor",
+            outcome: "completed",
+            output: { ok: true },
+          }),
+          event(10, "2026-01-01T00:00:10.000Z", {
+            type: "tool_result",
+            toolCallId: "handoff-correlated",
+            name: "handoff",
+            outcome: "completed",
+            output: { ok: true },
           }),
         ]),
       ),
@@ -241,23 +322,41 @@ describe("canonical event transcript reduction", () => {
         conversation([
           event(0, "2026-01-01T00:00:00.000Z", {
             type: "tool_started",
+            toolCallId: "search-1",
             name: "sentry.search",
           }),
           event(1, "2026-01-01T00:00:01.000Z", {
+            type: "tool_calls",
+            calls: [
+              {
+                toolCallId: "search-1",
+                name: "sentry.search",
+                input: { project: "checkout-project" },
+              },
+            ],
+          }),
+          event(2, "2026-01-01T00:00:02.000Z", {
+            type: "tool_result",
+            toolCallId: "search-1",
+            name: "sentry.search",
+            outcome: "completed",
+            output: { culprit: "payments-v42" },
+          }),
+          event(3, "2026-01-01T00:00:03.000Z", {
             type: "subagent_started",
             childConversationId: "child-1",
             subagentKind: "advisor",
           }),
-          event(2, "2026-01-01T00:00:02.000Z", {
+          event(4, "2026-01-01T00:00:04.000Z", {
             type: "compaction",
           }),
-          event(3, "2026-01-01T00:00:03.000Z", {
+          event(5, "2026-01-01T00:00:05.000Z", {
             type: "turn_lifecycle",
             turnId: "turn-1",
             state: "failed",
             failureKind: "agent",
           }),
-          event(4, "2026-01-01T00:00:04.000Z", {
+          event(6, "2026-01-01T00:00:06.000Z", {
             type: "turn_lifecycle",
             turnId: "turn-2",
             state: "failed",
@@ -269,8 +368,10 @@ describe("canonical event transcript reduction", () => {
 
     for (const query of [
       "sentry.search",
+      "checkout-project",
+      "payments-v42",
       "advisor",
-      "running",
+      "completed",
       "compacted",
       "failed",
       "delivery failed",

--- a/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
+++ b/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
@@ -130,7 +130,6 @@ describe("canonical event transcript reduction", () => {
         event(2, "2026-01-01T00:00:03.000Z", {
           type: "tool_result",
           toolCallId: "search-1",
-          name: "search",
           outcome: "completed",
           output: { matches: 2 },
         }),
@@ -201,14 +200,12 @@ describe("canonical event transcript reduction", () => {
           event(9, "2026-01-01T00:00:09.000Z", {
             type: "tool_result",
             toolCallId: "advisor-correlated",
-            name: "advisor",
             outcome: "completed",
             output: { ok: true },
           }),
           event(10, "2026-01-01T00:00:10.000Z", {
             type: "tool_result",
             toolCallId: "handoff-correlated",
-            name: "handoff",
             outcome: "completed",
             output: { ok: true },
           }),
@@ -328,7 +325,6 @@ describe("canonical event transcript reduction", () => {
           event(2, "2026-01-01T00:00:02.000Z", {
             type: "tool_result",
             toolCallId: "search-1",
-            name: "sentry.search",
             outcome: "completed",
             output: { culprit: "payments-v42" },
           }),

--- a/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
+++ b/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
@@ -151,20 +151,15 @@ describe("canonical event transcript reduction", () => {
     ]);
   });
 
-  it("replaces only correlated tool starts with special lifecycle rows", () => {
+  it("replaces correlated tool facts with special lifecycle rows", () => {
     const entries = groupTranscriptMessages(
       conversationTranscriptMessages(
         conversation([
-          event(0, "2026-01-01T00:00:00.000Z", {
-            type: "tool_started",
-            toolCallId: "advisor-correlated",
-            name: "advisor",
-          }),
           event(1, "2026-01-01T00:00:01.000Z", {
             type: "subagent_started",
             childConversationId: "child-correlated",
             subagentKind: "advisor",
-            toolStartedSeq: 0,
+            parentToolCallId: "advisor-correlated",
           }),
           event(2, "2026-01-01T00:00:02.000Z", {
             type: "subagent_ended",
@@ -176,14 +171,9 @@ describe("canonical event transcript reduction", () => {
             toolCallId: "advisor-visible",
             name: "advisor",
           }),
-          event(4, "2026-01-01T00:00:04.000Z", {
-            type: "tool_started",
-            toolCallId: "handoff-correlated",
-            name: "handoff",
-          }),
           event(5, "2026-01-01T00:00:05.000Z", {
             type: "handoff",
-            toolStartedSeq: 4,
+            triggeringToolCallId: "handoff-correlated",
           }),
           event(6, "2026-01-01T00:00:06.000Z", {
             type: "subagent_started",

--- a/packages/junior/src/api/conversations/events.ts
+++ b/packages/junior/src/api/conversations/events.ts
@@ -1,4 +1,5 @@
 import type { ConversationEvent } from "@/chat/conversations/history";
+import { z } from "zod";
 import {
   conversationReportEventSchema,
   type ConversationReportEvent,
@@ -9,6 +10,7 @@ import {
 export const conversationReportSourceEventTypes = [
   "message",
   "message_handled",
+  "agent_step",
   "tool_execution_started",
   "turn_started",
   "turn_completed",
@@ -18,6 +20,133 @@ export const conversationReportSourceEventTypes = [
   "subagent_started",
   "subagent_ended",
 ] as const;
+
+const reportingAssistantMessageSchema = z
+  .object({
+    role: z.literal("assistant"),
+    content: z.array(z.unknown()),
+  })
+  .passthrough();
+
+const reportingToolCallPartSchema = z
+  .object({
+    type: z.literal("toolCall"),
+    id: z.string().min(1),
+    name: z.string().min(1),
+    arguments: z.unknown(),
+  })
+  .passthrough();
+
+const reportingToolResultMessageSchema = z
+  .object({
+    role: z.literal("toolResult"),
+    toolCallId: z.string().min(1),
+    toolName: z.string().min(1),
+    content: z.array(z.unknown()),
+    details: z.unknown().optional(),
+    isError: z.boolean().optional(),
+  })
+  .passthrough();
+
+const reportingToolResultDetailsSchema = z
+  .object({
+    ok: z.boolean().optional(),
+    status: z.string().optional(),
+  })
+  .passthrough();
+
+const reportingTextPartSchema = z
+  .object({ type: z.literal("text"), text: z.string() })
+  .passthrough();
+
+const reportingMediaPartSchema = z
+  .object({
+    type: z.enum(["image", "audio"]),
+    mimeType: z.string().min(1).optional(),
+  })
+  .passthrough();
+
+type ReportingModelContentPart =
+  | { type: "text"; text: string }
+  | { type: "image" | "audio"; mimeType?: string };
+
+/** Retain model-visible text and media descriptors, dropping all opaque fields. */
+function sanitizeModelContentPart(
+  value: unknown,
+): ReportingModelContentPart | undefined {
+  const text = reportingTextPartSchema.safeParse(value);
+  if (text.success) return { type: "text", text: text.data.text };
+
+  const media = reportingMediaPartSchema.safeParse(value);
+  if (!media.success) return undefined;
+  return {
+    type: media.data.type,
+    ...(media.data.mimeType ? { mimeType: media.data.mimeType } : {}),
+  };
+}
+
+/** Convert allowlisted Pi content parts into the reporting result value. */
+function modelVisibleToolOutput(content: unknown[]): unknown {
+  const sanitized = content
+    .map(sanitizeModelContentPart)
+    .filter((part) => part !== undefined);
+  if (sanitized.length === 0) return undefined;
+  if (sanitized.length !== 1) return sanitized;
+
+  const only = sanitized[0]!;
+  return only.type === "text" ? only.text : only;
+}
+
+/** Project canonical Pi tool calls into the narrow reporting contract. */
+function reportToolCalls(args: {
+  canExposePayload: boolean;
+  message: unknown;
+}): ConversationReportEventData | undefined {
+  const message = reportingAssistantMessageSchema.safeParse(args.message);
+  if (!message.success) return undefined;
+
+  const calls = message.data.content.flatMap((part) => {
+    const call = reportingToolCallPartSchema.safeParse(part);
+    if (!call.success) return [];
+    return [
+      {
+        toolCallId: call.data.id,
+        name: call.data.name,
+        ...(args.canExposePayload && call.data.arguments !== undefined
+          ? { input: call.data.arguments }
+          : {}),
+      },
+    ];
+  });
+  return calls.length > 0 ? { type: "tool_calls", calls } : undefined;
+}
+
+/** Project a Pi tool result without exposing host-only result details. */
+function reportToolResult(args: {
+  canExposePayload: boolean;
+  message: unknown;
+}): ConversationReportEventData | undefined {
+  const message = reportingToolResultMessageSchema.safeParse(args.message);
+  if (!message.success) return undefined;
+
+  const details = reportingToolResultDetailsSchema.safeParse(
+    message.data.details,
+  );
+  const outcome =
+    message.data.isError === true ||
+    (details.success &&
+      (details.data.ok === false || details.data.status === "error"))
+      ? "error"
+      : "completed";
+  const output = modelVisibleToolOutput(message.data.content);
+  return {
+    type: "tool_result",
+    toolCallId: message.data.toolCallId,
+    name: message.data.toolName,
+    outcome,
+    ...(args.canExposePayload && output !== undefined ? { output } : {}),
+  };
+}
 
 function reportEventData(args: {
   canExposePayload: boolean;
@@ -83,9 +212,19 @@ export function projectConversationReportEvents(args: {
 
   for (const event of args.events) {
     let data: ConversationReportEventData | undefined;
-    if (event.data.type === "tool_execution_started") {
+    if (event.data.type === "agent_step") {
+      const reportArgs = {
+        canExposePayload: args.canExposePayload,
+        message: event.data.message,
+      };
+      data = reportToolCalls(reportArgs) ?? reportToolResult(reportArgs);
+    } else if (event.data.type === "tool_execution_started") {
       toolStarts.set(event.data.toolCallId, event.seq);
-      data = { type: "tool_started", name: event.data.toolName };
+      data = {
+        type: "tool_started",
+        toolCallId: event.data.toolCallId,
+        name: event.data.toolName,
+      };
     } else if (event.data.type === "subagent_started") {
       subagentStarts.set(event.data.subagentInvocationId, event.seq);
       const toolStartedSeq = event.data.parentToolCallId

--- a/packages/junior/src/api/conversations/events.ts
+++ b/packages/junior/src/api/conversations/events.ts
@@ -207,7 +207,6 @@ export function projectConversationReportEvents(args: {
   events: ConversationEvent[];
 }): ConversationReportEvent[] {
   const subagentStarts = new Map<string, number>();
-  const toolStarts = new Map<string, number>();
   const projected: ConversationReportEvent[] = [];
 
   for (const event of args.events) {
@@ -219,7 +218,6 @@ export function projectConversationReportEvents(args: {
       };
       data = reportToolCalls(reportArgs) ?? reportToolResult(reportArgs);
     } else if (event.data.type === "tool_execution_started") {
-      toolStarts.set(event.data.toolCallId, event.seq);
       data = {
         type: "tool_started",
         toolCallId: event.data.toolCallId,
@@ -227,14 +225,13 @@ export function projectConversationReportEvents(args: {
       };
     } else if (event.data.type === "subagent_started") {
       subagentStarts.set(event.data.subagentInvocationId, event.seq);
-      const toolStartedSeq = event.data.parentToolCallId
-        ? toolStarts.get(event.data.parentToolCallId)
-        : undefined;
       data = {
         type: "subagent_started",
         childConversationId: event.data.childConversationId,
         subagentKind: event.data.subagentKind,
-        ...(toolStartedSeq === undefined ? {} : { toolStartedSeq }),
+        ...(event.data.parentToolCallId
+          ? { parentToolCallId: event.data.parentToolCallId }
+          : {}),
       };
     } else if (event.data.type === "subagent_ended") {
       const startedSeq = subagentStarts.get(event.data.subagentInvocationId);
@@ -246,12 +243,11 @@ export function projectConversationReportEvents(args: {
         };
       }
     } else if (event.data.type === "handoff") {
-      const toolStartedSeq = event.data.triggeringToolCallId
-        ? toolStarts.get(event.data.triggeringToolCallId)
-        : undefined;
       data = {
         type: "handoff",
-        ...(toolStartedSeq === undefined ? {} : { toolStartedSeq }),
+        ...(event.data.triggeringToolCallId
+          ? { triggeringToolCallId: event.data.triggeringToolCallId }
+          : {}),
       };
     } else {
       data = reportEventData({

--- a/packages/junior/src/api/conversations/events.ts
+++ b/packages/junior/src/api/conversations/events.ts
@@ -41,7 +41,6 @@ const reportingToolResultMessageSchema = z
   .object({
     role: z.literal("toolResult"),
     toolCallId: z.string().min(1),
-    toolName: z.string().min(1),
     content: z.array(z.unknown()),
     details: z.unknown().optional(),
     isError: z.boolean().optional(),
@@ -142,7 +141,6 @@ function reportToolResult(args: {
   return {
     type: "tool_result",
     toolCallId: message.data.toolCallId,
-    name: message.data.toolName,
     outcome,
     ...(args.canExposePayload && output !== undefined ? { output } : {}),
   };

--- a/packages/junior/src/api/conversations/schema.ts
+++ b/packages/junior/src/api/conversations/schema.ts
@@ -77,7 +77,33 @@ const conversationReportMessageHandledEventDataSchema = z
 const conversationReportToolStartedEventDataSchema = z
   .object({
     type: z.literal("tool_started"),
+    toolCallId: z.string().min(1),
     name: z.string().min(1),
+  })
+  .strict();
+
+const conversationReportToolCallSchema = z
+  .object({
+    toolCallId: z.string().min(1),
+    name: z.string().min(1),
+    input: z.unknown().optional(),
+  })
+  .strict();
+
+const conversationReportToolCallsEventDataSchema = z
+  .object({
+    type: z.literal("tool_calls"),
+    calls: z.array(conversationReportToolCallSchema).min(1),
+  })
+  .strict();
+
+const conversationReportToolResultEventDataSchema = z
+  .object({
+    type: z.literal("tool_result"),
+    toolCallId: z.string().min(1),
+    name: z.string().min(1),
+    outcome: z.enum(["completed", "error"]),
+    output: z.unknown().optional(),
   })
   .strict();
 
@@ -135,6 +161,8 @@ export const conversationReportEventDataSchema = z.discriminatedUnion("type", [
   conversationReportMessageEventDataSchema,
   conversationReportMessageHandledEventDataSchema,
   conversationReportToolStartedEventDataSchema,
+  conversationReportToolCallsEventDataSchema,
+  conversationReportToolResultEventDataSchema,
   conversationReportTurnLifecycleEventDataSchema,
   conversationReportCompactionEventDataSchema,
   conversationReportHandoffEventDataSchema,
@@ -202,25 +230,48 @@ export const conversationDetailReportSchema = conversationSummaryReportSchema
       }
     }
     for (const [index, event] of report.events.entries()) {
-      if (event.data.type !== "message") continue;
+      if (event.data.type === "message") {
+        if (
+          report.eventHistory.status === "redacted" &&
+          event.data.redacted !== true
+        ) {
+          context.addIssue({
+            code: "custom",
+            path: ["events", index, "data"],
+            message: "redacted event history must redact messages",
+          });
+        }
+        if (
+          report.eventHistory.status === "available" &&
+          event.data.redacted === true
+        ) {
+          context.addIssue({
+            code: "custom",
+            path: ["events", index, "data"],
+            message: "available event history must expose messages",
+          });
+        }
+      }
       if (
         report.eventHistory.status === "redacted" &&
-        event.data.redacted !== true
+        event.data.type === "tool_calls" &&
+        event.data.calls.some((call) => call.input !== undefined)
       ) {
         context.addIssue({
           code: "custom",
           path: ["events", index, "data"],
-          message: "redacted event history must redact messages",
+          message: "redacted event history must redact tool inputs",
         });
       }
       if (
-        report.eventHistory.status === "available" &&
-        event.data.redacted === true
+        report.eventHistory.status === "redacted" &&
+        event.data.type === "tool_result" &&
+        event.data.output !== undefined
       ) {
         context.addIssue({
           code: "custom",
           path: ["events", index, "data"],
-          message: "available event history must expose messages",
+          message: "redacted event history must redact tool outputs",
         });
       }
     }

--- a/packages/junior/src/api/conversations/schema.ts
+++ b/packages/junior/src/api/conversations/schema.ts
@@ -101,7 +101,6 @@ const conversationReportToolResultEventDataSchema = z
   .object({
     type: z.literal("tool_result"),
     toolCallId: z.string().min(1),
-    name: z.string().min(1),
     outcome: z.enum(["completed", "error"]),
     output: z.unknown().optional(),
   })

--- a/packages/junior/src/api/conversations/schema.ts
+++ b/packages/junior/src/api/conversations/schema.ts
@@ -135,7 +135,7 @@ const conversationReportCompactionEventDataSchema = z
 const conversationReportHandoffEventDataSchema = z
   .object({
     type: z.literal("handoff"),
-    toolStartedSeq: z.number().int().nonnegative().optional(),
+    triggeringToolCallId: z.string().min(1).optional(),
   })
   .strict();
 
@@ -144,7 +144,7 @@ const conversationReportSubagentStartedEventDataSchema = z
     type: z.literal("subagent_started"),
     childConversationId: z.string().min(1),
     subagentKind: z.string().min(1),
-    toolStartedSeq: z.number().int().nonnegative().optional(),
+    parentToolCallId: z.string().min(1).optional(),
   })
   .strict();
 

--- a/packages/junior/tests/integration/dashboard-reporting.test.ts
+++ b/packages/junior/tests/integration/dashboard-reporting.test.ts
@@ -334,7 +334,6 @@ describe("dashboard canonical event reporting", () => {
       {
         type: "tool_result",
         toolCallId: `${conversationId}:tool-call`,
-        name: "search",
         outcome: "completed",
         output: "model-visible result",
       },

--- a/packages/junior/tests/integration/dashboard-reporting.test.ts
+++ b/packages/junior/tests/integration/dashboard-reporting.test.ts
@@ -89,6 +89,61 @@ async function appendVisibleHistory(
     },
     {
       data: {
+        type: "agent_step",
+        message: {
+          role: "assistant",
+          api: "responses",
+          provider: "openai",
+          model: "gpt-5",
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            cost: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              total: 0,
+            },
+          },
+          stopReason: "toolUse",
+          content: [
+            {
+              type: "toolCall",
+              id: `${conversationId}:tool-call`,
+              name: "search",
+              arguments: { query: "visible tool query" },
+            },
+          ],
+          timestamp: 12,
+        } as PiMessage,
+      },
+      createdAtMs: 12,
+    },
+    {
+      data: {
+        type: "agent_step",
+        message: {
+          role: "toolResult",
+          toolCallId: `${conversationId}:tool-call`,
+          toolName: "search",
+          content: [{ type: "text", text: "model-visible result" }],
+          details: {
+            ok: true,
+            status: "success",
+            data: { matches: 2 },
+          },
+          isError: false,
+          timestamp: 13,
+        } as PiMessage,
+      },
+      createdAtMs: 13,
+    },
+    {
+      data: {
         type: "turn_started",
         turnId: `${conversationId}:turn`,
         inputMessageIds: [`${conversationId}:visible`],
@@ -261,7 +316,28 @@ describe("dashboard canonical event reporting", () => {
         role: "assistant",
         text: "Visible answer",
       },
-      { type: "tool_started", name: "search" },
+      {
+        type: "tool_started",
+        toolCallId: `${conversationId}:tool-call`,
+        name: "search",
+      },
+      {
+        type: "tool_calls",
+        calls: [
+          {
+            toolCallId: `${conversationId}:tool-call`,
+            name: "search",
+            input: { query: "visible tool query" },
+          },
+        ],
+      },
+      {
+        type: "tool_result",
+        toolCallId: `${conversationId}:tool-call`,
+        name: "search",
+        outcome: "completed",
+        output: "model-visible result",
+      },
       {
         type: "turn_lifecycle",
         turnId: `${conversationId}:turn`,
@@ -279,7 +355,7 @@ describe("dashboard canonical event reporting", () => {
       },
       {
         type: "subagent_ended",
-        startedSeq: 5,
+        startedSeq: 7,
         outcome: "success",
       },
       { type: "compaction" },
@@ -371,9 +447,14 @@ describe("dashboard canonical event reporting", () => {
     });
     expect(detail.events[1]?.data).toEqual({
       type: "tool_started",
+      toolCallId: `${conversationId}:tool-call`,
       name: "search",
     });
-    expect(JSON.stringify(detail)).not.toContain("Visible answer");
+    const serialized = JSON.stringify(detail);
+    expect(serialized).not.toContain("Visible answer");
+    expect(serialized).not.toContain("visible tool query");
+    expect(serialized).not.toContain("model-visible result");
+    expect(serialized).not.toContain('"matches":2');
   });
 
   it("authorizes children from their persisted root and rejects forged or malformed lineage", async () => {

--- a/packages/junior/tests/integration/dashboard-reporting.test.ts
+++ b/packages/junior/tests/integration/dashboard-reporting.test.ts
@@ -359,7 +359,10 @@ describe("dashboard canonical event reporting", () => {
         outcome: "success",
       },
       { type: "compaction" },
-      { type: "handoff" },
+      {
+        type: "handoff",
+        triggeringToolCallId: `${conversationId}:handoff-tool-call`,
+      },
     ]);
     const eventSeqs = detail.events.map((event) => event.seq);
     expect(eventSeqs).toEqual(eventSeqs.slice().sort((a, b) => a - b));

--- a/packages/junior/tests/unit/api/conversation-events.test.ts
+++ b/packages/junior/tests/unit/api/conversation-events.test.ts
@@ -473,7 +473,10 @@ describe("conversation report event projection", () => {
         toolCallId: "private-handoff-tool-call-id",
         name: "handoff",
       },
-      { type: "handoff", toolStartedSeq: 3 },
+      {
+        type: "handoff",
+        triggeringToolCallId: "private-handoff-tool-call-id",
+      },
       {
         type: "turn_lifecycle",
         turnId: "turn-1",
@@ -489,7 +492,7 @@ describe("conversation report event projection", () => {
         type: "subagent_started",
         childConversationId: "child-conversation-1",
         subagentKind: "advisor",
-        toolStartedSeq: 8,
+        parentToolCallId: "private-parent-tool-id",
       },
       {
         type: "subagent_ended",

--- a/packages/junior/tests/unit/api/conversation-events.test.ts
+++ b/packages/junior/tests/unit/api/conversation-events.test.ts
@@ -46,7 +46,7 @@ describe("conversation report event projection", () => {
     ).toEqual([]);
   });
 
-  it("keeps canonical sequence order and sources display text only from visible messages", () => {
+  it("keeps canonical sequence order and projects only tool facts from agent steps", () => {
     const events = [
       event(
         10,
@@ -69,6 +69,7 @@ describe("conversation report event projection", () => {
               { type: "thinking", thinking: "private chain of thought" },
               {
                 type: "toolCall",
+                id: "private-tool-call-id",
                 name: "search",
                 arguments: { query: "private query" },
               },
@@ -105,9 +106,27 @@ describe("conversation report event projection", () => {
         },
       },
       {
+        seq: 11,
+        createdAt: "1970-01-01T00:00:10.000Z",
+        data: {
+          type: "tool_calls",
+          calls: [
+            {
+              toolCallId: "private-tool-call-id",
+              name: "search",
+              input: { query: "private query" },
+            },
+          ],
+        },
+      },
+      {
         seq: 12,
         createdAt: "1970-01-01T00:00:05.000Z",
-        data: { type: "tool_started", name: "search" },
+        data: {
+          type: "tool_started",
+          toolCallId: "private-tool-call-id",
+          name: "search",
+        },
       },
       {
         seq: 13,
@@ -118,10 +137,109 @@ describe("conversation report event projection", () => {
         },
       },
     ]);
-    expect(projected.map(({ seq }) => seq)).toEqual([10, 12, 13]);
+    expect(projected.map(({ seq }) => seq)).toEqual([10, 11, 12, 13]);
     expect(
       JSON.stringify(projected).match(/one user-facing answer/g),
     ).toHaveLength(1);
+    expect(JSON.stringify(projected)).not.toContain("private chain of thought");
+  });
+
+  it("projects parallel calls, structured outcomes, and safe native content", () => {
+    const projected = projectConversationReportEvents({
+      canExposePayload: true,
+      events: [
+        event(1, {
+          type: "agent_step",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "toolCall",
+                id: "call-1",
+                name: "search",
+                arguments: { query: "first" },
+              },
+              {
+                type: "toolCall",
+                id: "call-2",
+                name: "fetch",
+                arguments: { url: "https://example.com" },
+              },
+            ],
+          } as ConversationAgentStepPayload,
+        }),
+        event(2, {
+          type: "agent_step",
+          message: {
+            role: "toolResult",
+            toolCallId: "call-1",
+            toolName: "search",
+            content: [{ type: "text", text: "model-visible error summary" }],
+            details: {
+              ok: false,
+              status: "error",
+              error: { kind: "not_found", message: "No matches" },
+              providerSecret: "must stay host-only",
+            },
+            isError: false,
+          } as ConversationAgentStepPayload,
+        }),
+        event(3, {
+          type: "agent_step",
+          message: {
+            role: "toolResult",
+            toolCallId: "call-2",
+            toolName: "fetch",
+            content: [
+              { type: "text", text: "native result" },
+              { type: "image", mimeType: "image/png", data: "AAAA" },
+            ],
+            details: { ok: true, status: "success" },
+            rawProviderResponse: "must not escape",
+            isError: false,
+          } as ConversationAgentStepPayload,
+        }),
+      ],
+    });
+
+    expect(projected.map(({ data }) => data)).toEqual([
+      {
+        type: "tool_calls",
+        calls: [
+          {
+            toolCallId: "call-1",
+            name: "search",
+            input: { query: "first" },
+          },
+          {
+            toolCallId: "call-2",
+            name: "fetch",
+            input: { url: "https://example.com" },
+          },
+        ],
+      },
+      {
+        type: "tool_result",
+        toolCallId: "call-1",
+        name: "search",
+        outcome: "error",
+        output: "model-visible error summary",
+      },
+      {
+        type: "tool_result",
+        toolCallId: "call-2",
+        name: "fetch",
+        outcome: "completed",
+        output: [
+          { type: "text", text: "native result" },
+          { type: "image", mimeType: "image/png" },
+        ],
+      },
+    ]);
+    expect(JSON.stringify(projected)).not.toContain("must not escape");
+    expect(JSON.stringify(projected)).not.toContain("must stay host-only");
+    expect(JSON.stringify(projected)).not.toContain("No matches");
+    expect(JSON.stringify(projected)).not.toContain("AAAA");
   });
 
   it("keeps projected prefixes byte-equivalent when later facts arrive", () => {
@@ -169,7 +287,7 @@ describe("conversation report event projection", () => {
           type: "agent_step",
           message: {
             role: "toolResult",
-            name: "private-tool-name",
+            toolName: "safe_tool_name",
             toolCallId: "private-tool-call-id",
             isError: true,
             content: [{ type: "text", text: "private tool result" }],
@@ -217,16 +335,23 @@ describe("conversation report event projection", () => {
       redacted: true,
     });
     expect(projected[1]?.data).toEqual({
-      type: "tool_started",
+      type: "tool_result",
+      toolCallId: "private-tool-call-id",
       name: "safe_tool_name",
+      outcome: "error",
     });
     expect(projected[2]?.data).toEqual({
+      type: "tool_started",
+      toolCallId: "private-tool-call-id",
+      name: "safe_tool_name",
+    });
+    expect(projected[3]?.data).toEqual({
       type: "turn_lifecycle",
       turnId: "turn-1",
       state: "failed",
       failureKind: "agent",
     });
-    expect(projected[3]?.data).toEqual({
+    expect(projected[4]?.data).toEqual({
       type: "turn_lifecycle",
       turnId: "turn-delivery-1",
       state: "failed",
@@ -241,8 +366,6 @@ describe("conversation report event projection", () => {
       "private-actor-id",
       "private arbitrary metadata",
       "private-authorization-id",
-      "private-tool-name",
-      "private-tool-call-id",
       "private tool result",
       "private provider error",
       "model_execution_failed",
@@ -345,7 +468,11 @@ describe("conversation report event projection", () => {
     expect(projected.map(({ data }) => data)).toEqual([
       { type: "turn_lifecycle", turnId: "turn-1", state: "started" },
       { type: "compaction" },
-      { type: "tool_started", name: "handoff" },
+      {
+        type: "tool_started",
+        toolCallId: "private-handoff-tool-call-id",
+        name: "handoff",
+      },
       { type: "handoff", toolStartedSeq: 3 },
       {
         type: "turn_lifecycle",
@@ -353,7 +480,11 @@ describe("conversation report event projection", () => {
         state: "failed",
         failureKind: "delivery",
       },
-      { type: "tool_started", name: "advisor" },
+      {
+        type: "tool_started",
+        toolCallId: "private-parent-tool-id",
+        name: "advisor",
+      },
       {
         type: "subagent_started",
         childConversationId: "child-conversation-1",
@@ -377,11 +508,9 @@ describe("conversation report event projection", () => {
       "private-input-id",
       "private-model-id",
       "private-handoff-model-id",
-      "private-handoff-tool-call-id",
       "private-rollback-model-id",
       "subagent-invocation-1",
       "private-child-model-id",
-      "private-parent-tool-id",
       "private-reasoning-level",
       "private-child-error-code",
       "legacy-subagent-invocation",
@@ -579,6 +708,53 @@ describe("conversation report event projection", () => {
     expect(
       conversationDetailReportSchema.safeParse({
         ...summary,
+        eventHistory: {
+          status: "redacted",
+          reason: "non_public_conversation",
+        },
+        events: [
+          {
+            seq: 1,
+            createdAt: summary.generatedAt,
+            data: {
+              type: "tool_calls",
+              calls: [
+                {
+                  toolCallId: "private-call",
+                  name: "search",
+                  input: { query: "must not be exposed" },
+                },
+              ],
+            },
+          },
+        ],
+      }).success,
+    ).toBe(false);
+    expect(
+      conversationDetailReportSchema.safeParse({
+        ...summary,
+        eventHistory: {
+          status: "redacted",
+          reason: "non_public_conversation",
+        },
+        events: [
+          {
+            seq: 1,
+            createdAt: summary.generatedAt,
+            data: {
+              type: "tool_result",
+              toolCallId: "private-call",
+              name: "search",
+              outcome: "completed",
+              output: { matches: "must not be exposed" },
+            },
+          },
+        ],
+      }).success,
+    ).toBe(false);
+    expect(
+      conversationDetailReportSchema.safeParse({
+        ...summary,
         eventHistory: { status: "available" },
         events: [visibleEvent({ redacted: true })],
       }).success,
@@ -599,6 +775,35 @@ describe("conversation report event projection", () => {
           reason: "non_public_conversation",
         },
         events: [visibleEvent({ redacted: true })],
+      }).success,
+    ).toBe(true);
+    expect(
+      conversationDetailReportSchema.safeParse({
+        ...summary,
+        eventHistory: {
+          status: "redacted",
+          reason: "non_public_conversation",
+        },
+        events: [
+          {
+            seq: 1,
+            createdAt: summary.generatedAt,
+            data: {
+              type: "tool_calls",
+              calls: [{ toolCallId: "private-call", name: "search" }],
+            },
+          },
+          {
+            seq: 2,
+            createdAt: summary.generatedAt,
+            data: {
+              type: "tool_result",
+              toolCallId: "private-call",
+              name: "search",
+              outcome: "completed",
+            },
+          },
+        ],
       }).success,
     ).toBe(true);
     expect(

--- a/packages/junior/tests/unit/api/conversation-events.test.ts
+++ b/packages/junior/tests/unit/api/conversation-events.test.ts
@@ -221,14 +221,12 @@ describe("conversation report event projection", () => {
       {
         type: "tool_result",
         toolCallId: "call-1",
-        name: "search",
         outcome: "error",
         output: "model-visible error summary",
       },
       {
         type: "tool_result",
         toolCallId: "call-2",
-        name: "fetch",
         outcome: "completed",
         output: [
           { type: "text", text: "native result" },
@@ -337,7 +335,6 @@ describe("conversation report event projection", () => {
     expect(projected[1]?.data).toEqual({
       type: "tool_result",
       toolCallId: "private-tool-call-id",
-      name: "safe_tool_name",
       outcome: "error",
     });
     expect(projected[2]?.data).toEqual({
@@ -747,7 +744,6 @@ describe("conversation report event projection", () => {
             data: {
               type: "tool_result",
               toolCallId: "private-call",
-              name: "search",
               outcome: "completed",
               output: { matches: "must not be exposed" },
             },
@@ -802,7 +798,6 @@ describe("conversation report event projection", () => {
             data: {
               type: "tool_result",
               toolCallId: "private-call",
-              name: "search",
               outcome: "completed",
             },
           },


### PR DESCRIPTION
Conversation reports now project canonical tool calls and allowlisted model-visible results from existing agent history. The dashboard correlates start, call, and result facts by tool-call ID into one row: it pulses while running, then the same row becomes completed or errored with expandable arguments and results. Transcript search, Markdown export, and live bottom-following use that correlated state.

The reporting boundary excludes host-only result details, provider extension fields, and media bytes. Private conversations retain structural tool events without payloads, while advisor and handoff lifecycle rows continue to replace their generic tool events. Existing history is projected at read time, so this requires no migration.
