### PR TITLE
fix(mcp): Skip credentialless provider restoration

### DIFF
--- a/packages/junior/src/chat/agent/tools.ts
+++ b/packages/junior/src/chat/agent/tools.ts
@@ -117,7 +117,7 @@ export async function wireAgentTools(
   args: ToolWiringArgs,
 ): Promise<ToolWiring> {
   const runSource = args.routing.source;
-  const authActorId = args.routing.credentialContext
+  const credentialUserId = args.routing.credentialContext
     ? credentialUserSubjectId(args.routing.credentialContext)
     : undefined;
   const userTokenStore = createUserTokenStore();
@@ -177,7 +177,7 @@ export async function wireAgentTools(
     abortAgent: args.abortAgent,
     conversationId: args.conversationId,
     sessionId: args.turnId,
-    actorId: authActorId,
+    actorId: credentialUserId,
     channelId: slackChannelId,
     destination: args.routing.destination,
     source: runSource,
@@ -202,7 +202,7 @@ export async function wireAgentTools(
     abortAgent: args.abortAgent,
     conversationId: args.conversationId,
     sessionId: args.turnId,
-    actorId: authActorId,
+    actorId: credentialUserId,
     channelId: slackChannelId,
     destination: args.routing.destination,
     source: runSource,
@@ -372,13 +372,16 @@ export async function wireAgentTools(
   // Conversation history records prior capability use, not authority for the
   // current turn. Credentialless system turns must not reconnect user-owned
   // MCP providers merely because an earlier user turn activated them.
-  if (authActorId) {
+  if (credentialUserId) {
     // Restore providers visible in durable Pi session history. In serverless
     // runtimes, later slices and follow-up turns usually run in a fresh
     // process, so in-memory MCP clients cannot be reused.
     const providersToRestore = new Set([
       ...args.connectedMcpProviders,
       ...inferActiveMcpProvidersFromPiMessages(args.priorPiMessages),
+      ...args.activeSkills.flatMap((skill) =>
+        skill.pluginProvider ? [skill.pluginProvider] : [],
+      ),
     ]);
     for (const provider of providersToRestore) {
       if (provider === pendingMcpProvider) {
@@ -386,19 +389,6 @@ export async function wireAgentTools(
       }
       if (await mcpToolManager.activateProvider(provider)) {
         await args.recordConnectedMcpProvider(provider);
-      }
-      if (mcpAuth.getPendingPause()) {
-        args.resume.captureResumeSnapshot(args.preAgentPromptMessages());
-        throw mcpAuth.getPendingPause()!;
-      }
-    }
-    // Activate MCP for skills recovered from durable Pi history.
-    for (const skill of args.activeSkills) {
-      if (skill.pluginProvider === pendingMcpProvider) {
-        continue; // awaiting user authorization — skip to avoid aborting unrelated turns
-      }
-      if (await mcpToolManager.activateForSkill(skill)) {
-        await args.recordConnectedMcpProvider(skill.pluginProvider!);
       }
       if (mcpAuth.getPendingPause()) {
         args.resume.captureResumeSnapshot(args.preAgentPromptMessages());

--- a/packages/junior/src/chat/agent/tools.ts
+++ b/packages/junior/src/chat/agent/tools.ts
@@ -58,6 +58,7 @@ import { createLazySandboxWorkspace } from "@/chat/agent/sandbox";
 import { upsertActiveSkill } from "@/chat/agent/skills";
 import type { ResumeState } from "@/chat/agent/resume";
 import { writeSandboxGeneratedArtifacts } from "@/chat/runtime/generated-artifacts";
+import { credentialUserSubjectId } from "@/chat/credentials/context";
 
 interface ToolWiringArgs {
   abortAgent: () => void;
@@ -116,11 +117,9 @@ export async function wireAgentTools(
   args: ToolWiringArgs,
 ): Promise<ToolWiring> {
   const runSource = args.routing.source;
-  const authActorId =
-    args.routing.credentialContext &&
-    "type" in args.routing.credentialContext.actor
-      ? args.routing.credentialContext.actor.userId
-      : undefined;
+  const authActorId = args.routing.credentialContext
+    ? credentialUserSubjectId(args.routing.credentialContext)
+    : undefined;
   const userTokenStore = createUserTokenStore();
   const pluginHooks = createPluginHookRunner({
     actor: args.currentActor,
@@ -370,36 +369,41 @@ export async function wireAgentTools(
       ? args.state.pendingAuth.provider
       : undefined;
 
-  // Restore providers visible in durable Pi session history. In serverless
-  // runtimes, later slices and follow-up turns usually run in a fresh
-  // process, so in-memory MCP clients cannot be reused.
-  const providersToRestore = new Set([
-    ...args.connectedMcpProviders,
-    ...inferActiveMcpProvidersFromPiMessages(args.priorPiMessages),
-  ]);
-  for (const provider of providersToRestore) {
-    if (provider === pendingMcpProvider) {
-      continue; // awaiting user authorization — skip to avoid aborting unrelated turns
+  // Conversation history records prior capability use, not authority for the
+  // current turn. Credentialless system turns must not reconnect user-owned
+  // MCP providers merely because an earlier user turn activated them.
+  if (authActorId) {
+    // Restore providers visible in durable Pi session history. In serverless
+    // runtimes, later slices and follow-up turns usually run in a fresh
+    // process, so in-memory MCP clients cannot be reused.
+    const providersToRestore = new Set([
+      ...args.connectedMcpProviders,
+      ...inferActiveMcpProvidersFromPiMessages(args.priorPiMessages),
+    ]);
+    for (const provider of providersToRestore) {
+      if (provider === pendingMcpProvider) {
+        continue; // awaiting user authorization — skip to avoid aborting unrelated turns
+      }
+      if (await mcpToolManager.activateProvider(provider)) {
+        await args.recordConnectedMcpProvider(provider);
+      }
+      if (mcpAuth.getPendingPause()) {
+        args.resume.captureResumeSnapshot(args.preAgentPromptMessages());
+        throw mcpAuth.getPendingPause()!;
+      }
     }
-    if (await mcpToolManager.activateProvider(provider)) {
-      await args.recordConnectedMcpProvider(provider);
-    }
-    if (mcpAuth.getPendingPause()) {
-      args.resume.captureResumeSnapshot(args.preAgentPromptMessages());
-      throw mcpAuth.getPendingPause()!;
-    }
-  }
-  // Activate MCP for skills recovered from durable Pi history.
-  for (const skill of args.activeSkills) {
-    if (skill.pluginProvider === pendingMcpProvider) {
-      continue; // awaiting user authorization — skip to avoid aborting unrelated turns
-    }
-    if (await mcpToolManager.activateForSkill(skill)) {
-      await args.recordConnectedMcpProvider(skill.pluginProvider!);
-    }
-    if (mcpAuth.getPendingPause()) {
-      args.resume.captureResumeSnapshot(args.preAgentPromptMessages());
-      throw mcpAuth.getPendingPause()!;
+    // Activate MCP for skills recovered from durable Pi history.
+    for (const skill of args.activeSkills) {
+      if (skill.pluginProvider === pendingMcpProvider) {
+        continue; // awaiting user authorization — skip to avoid aborting unrelated turns
+      }
+      if (await mcpToolManager.activateForSkill(skill)) {
+        await args.recordConnectedMcpProvider(skill.pluginProvider!);
+      }
+      if (mcpAuth.getPendingPause()) {
+        args.resume.captureResumeSnapshot(args.preAgentPromptMessages());
+        throw mcpAuth.getPendingPause()!;
+      }
     }
   }
 

--- a/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
+++ b/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
@@ -22,6 +22,8 @@ import {
   hydrateConversationMessages,
   persistConversationMessages,
 } from "@/chat/conversations/messages";
+import { getConversationEventStore } from "@/chat/db";
+import type { PiMessage } from "@/chat/pi/messages";
 import {
   coerceThreadConversationState,
   type ConversationMessage,
@@ -877,6 +879,79 @@ describe("mcp auth runtime slack integration", () => {
       },
     });
     expect(getCapturedSlackApiCalls("chat.postMessage")).toEqual([]);
+  });
+
+  it("does not restore prior user MCP providers for credentialless resource events", async () => {
+    agentProbe.shouldBypassSkill = true;
+    const threadId = "slack:C130:1700000000.011";
+    const { createTestChatRuntime } = chatRuntimeModule;
+    const { slackRuntime } = createTestChatRuntime({
+      services: {
+        visionContext: {
+          listThreadReplies: async () => [],
+        },
+      },
+    });
+    const destination = {
+      platform: "slack" as const,
+      teamId: "T123",
+      channelId: "C130",
+    };
+    const thread = createTestThread({ id: threadId });
+    await mirrorThreadStateToAdapter(thread);
+    await getConversationEventStore().append(threadId, [
+      {
+        createdAtMs: 1,
+        data: {
+          type: "agent_step",
+          message: {
+            role: "toolResult",
+            toolCallId: "prior-linear-call",
+            toolName: "callMcpTool",
+            isError: false,
+            content: [{ type: "text", text: "prior result" }],
+            timestamp: 1,
+            input: {
+              tool_name: MCP_TOOL_NAME,
+              arguments: { query: "prior request" },
+            },
+          } as PiMessage,
+        },
+      },
+    ]);
+
+    await slackRuntime.handleSubscribedMessage(
+      thread,
+      createTestMessage({
+        id: "resource-event-resub-1-check-suite-1",
+        threadId,
+        text: "[event notification]\n\nA subscribed GitHub check changed.",
+        isMention: false,
+        author: {
+          userId: "UJRNEVENT",
+          userName: "junior-event",
+          fullName: "Junior event",
+          isBot: true,
+        },
+        raw: {
+          channel: "C130",
+          event_type: "resource_event",
+          thread_ts: "1700000000.011",
+          ts: "resource-event-resub-1-check-suite-1",
+          type: "message",
+          user: "UJRNEVENT",
+        },
+      }),
+      { destination },
+    );
+
+    expect(agentProbe.promptCallCount).toBe(1);
+    expect(getCapturedSlackApiCalls("chat.postEphemeral")).toEqual([]);
+    expect(thread.posts.at(-1)).toEqual(
+      expect.objectContaining({
+        markdown: unrelatedAuthPendingReply,
+      }),
+    );
   });
 
   it("parks and resumes an MCP auth challenge from direct provider activation", async () => {

--- a/packages/junior/tests/unit/runtime/agent-run-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/unit/runtime/agent-run-mcp-progressive-loading.test.ts
@@ -840,6 +840,61 @@ describe("executeAgentRun progressive MCP loading", () => {
     expect(listToolsMock).toHaveBeenCalledTimes(1);
   });
 
+  it("restores prior MCP providers for a system actor with a delegated credential subject", async () => {
+    listToolsMock.mockReset();
+    listToolsMock.mockResolvedValue(makeDemoMcpTools());
+
+    await executeAgentRun(
+      makeAgentRunRequest(
+        "run the scheduled task",
+        {
+          conversationId: "conversation-delegated-provider",
+          threadTs: "1712345.0092",
+          turnId: "turn-delegated-provider",
+        },
+        {
+          input: {
+            piMessages: [
+              {
+                role: "toolResult",
+                toolName: "callMcpTool",
+                isError: false,
+                content: [{ type: "text", text: "pong" }],
+                input: {
+                  tool_name: "mcp__demo__ping",
+                  arguments: { query: "prior" },
+                },
+              },
+            ] as unknown as PiMessage[],
+          },
+          routing: {
+            actor: { platform: "system", name: "scheduler" },
+            credentialContext: {
+              actor: { platform: "system", name: "scheduler" },
+              subject: {
+                type: "user",
+                userId: "U123",
+                allowedWhen: "scheduled-task",
+                taskId: "scheduled-task-1",
+                binding: {
+                  type: "scheduled-task",
+                  plugin: "scheduler",
+                  taskId: "scheduled-task-1",
+                  signature: "v1=test",
+                },
+              },
+            },
+          },
+        },
+      ),
+    );
+
+    expect(turnContextInputs[0]?.activeMcpCatalogs).toEqual([
+      { provider: "demo", available_tool_count: 1 },
+    ]);
+    expect(listToolsMock).toHaveBeenCalledTimes(1);
+  });
+
   it("adds missing bootstrap context when inferred provider restore pauses before prompt", async () => {
     const priorMessages = [
       {


### PR DESCRIPTION
Credentialless system turns, including resource events, no longer eagerly
reconnect MCP providers inferred from durable conversation history. This keeps
an earlier user's provider activity from being treated as authority for the
current turn and prevents the turn from failing before model invocation.

Current-user turns and system turns with an explicitly delegated credential
subject retain provider restoration. Regression coverage exercises both the
Slack resource-event failure and the delegated scheduled-task path.

Fixes #965
