### PR TITLE
ref(queue): Use conversation IDs in callbacks

### DIFF
--- a/packages/junior/src/chat/task-execution/README.md
+++ b/packages/junior/src/chat/task-execution/README.md
@@ -7,8 +7,8 @@ source of truth.
 ## State Model
 
 - A conversation mailbox contains normalized pending user work.
-- A queue payload identifies the conversation and destination needed to resume
-  processing; it does not carry authoritative conversation content.
+- A queue payload identifies the conversation to wake; persisted conversation
+  work owns destination and routing.
 - A lease grants one worker temporary execution ownership.
 - Check-ins extend active ownership and allow heartbeat recovery to distinguish
   slow work from abandoned work.

--- a/packages/junior/src/chat/task-execution/queue-signing.ts
+++ b/packages/junior/src/chat/task-execution/queue-signing.ts
@@ -1,17 +1,26 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
-import { destinationKey, parseDestination } from "@/chat/destination";
-import type { ConversationQueueMessage } from "./queue";
+import { z } from "zod";
+import {
+  conversationQueueMessageSchema,
+  type ConversationQueueMessage,
+} from "./queue";
 
 const CONVERSATION_WORK_QUEUE_SIGNATURE_CONTEXT =
-  "junior.conversation_work_queue.v1";
-const CONVERSATION_WORK_QUEUE_SIGNATURE_VERSION = "v1";
+  "junior.conversation_work_queue.v2";
+const CONVERSATION_WORK_QUEUE_SIGNATURE_VERSION = "v2";
 export const CONVERSATION_WORK_QUEUE_SIGNATURE_MAX_SKEW_MS = 60 * 60 * 1000;
 
-interface SignedConversationQueueMessage extends ConversationQueueMessage {
-  signature: string;
-  signatureVersion: typeof CONVERSATION_WORK_QUEUE_SIGNATURE_VERSION;
-  signedAtMs: number;
-}
+const signedConversationQueueMessageSchema = conversationQueueMessageSchema
+  .extend({
+    signature: z.string().trim().min(1),
+    signatureVersion: z.literal(CONVERSATION_WORK_QUEUE_SIGNATURE_VERSION),
+    signedAtMs: z.number().finite(),
+  })
+  .strict();
+
+type SignedConversationQueueMessage = z.output<
+  typeof signedConversationQueueMessageSchema
+>;
 
 export type ConversationQueueMessageVerificationResult =
   | {
@@ -31,26 +40,20 @@ function getConversationWorkQueueSecret(): string | undefined {
   return process.env.JUNIOR_SECRET?.trim() || undefined;
 }
 
+/** Build the canonical signature input for one conversation wake. */
 function buildSignedPayload(
   message: ConversationQueueMessage,
   signedAtMs: number,
-) {
+): string {
   return [
     CONVERSATION_WORK_QUEUE_SIGNATURE_CONTEXT,
     signedAtMs,
     message.conversationId,
-    destinationKey(message.destination),
   ].join(":");
 }
 
-function signPayload(
-  message: ConversationQueueMessage,
-  signedAtMs: number,
-  secret: string,
-): string {
-  return createHmac("sha256", secret)
-    .update(buildSignedPayload(message, signedAtMs))
-    .digest("hex");
+function signPayload(payload: string, secret: string): string {
+  return createHmac("sha256", secret).update(payload).digest("hex");
 }
 
 function timingSafeMatch(expected: string, actual: string): boolean {
@@ -62,34 +65,12 @@ function timingSafeMatch(expected: string, actual: string): boolean {
   return timingSafeEqual(expectedBuffer, actualBuffer);
 }
 
+/** Parse only the signed conversation queue wire format owned by this module. */
 function parseSignedConversationQueueMessage(
   value: unknown,
 ): SignedConversationQueueMessage | undefined {
-  if (!value || typeof value !== "object") {
-    return undefined;
-  }
-  const record = value as Record<string, unknown>;
-  const destination = parseDestination(record.destination);
-  if (
-    typeof record.conversationId !== "string" ||
-    !record.conversationId.trim() ||
-    !destination ||
-    record.signatureVersion !== CONVERSATION_WORK_QUEUE_SIGNATURE_VERSION ||
-    typeof record.signedAtMs !== "number" ||
-    !Number.isFinite(record.signedAtMs) ||
-    typeof record.signature !== "string" ||
-    !record.signature.trim()
-  ) {
-    return undefined;
-  }
-
-  return {
-    conversationId: record.conversationId,
-    destination,
-    signature: record.signature,
-    signatureVersion: CONVERSATION_WORK_QUEUE_SIGNATURE_VERSION,
-    signedAtMs: record.signedAtMs,
-  };
+  const parsed = signedConversationQueueMessageSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
 }
 
 /** Sign a conversation queue payload before it crosses the public callback route. */
@@ -107,11 +88,11 @@ export function signConversationQueueMessage(
     ...message,
     signedAtMs: nowMs,
     signatureVersion: CONVERSATION_WORK_QUEUE_SIGNATURE_VERSION,
-    signature: signPayload(message, nowMs, secret),
+    signature: signPayload(buildSignedPayload(message, nowMs), secret),
   };
 }
 
-/** Explain whether a queue payload is verified, rejected, or temporarily unverifiable. */
+/** Explain whether a queue payload is verified, rejected, or unavailable. */
 export function verifyConversationQueueMessage(
   value: unknown,
   nowMs = Date.now(),
@@ -134,17 +115,17 @@ export function verifyConversationQueueMessage(
     return { status: "rejected", reason: "expired" };
   }
 
-  const expected = signPayload(message, message.signedAtMs, secret);
+  const expected = signPayload(
+    buildSignedPayload(message, message.signedAtMs),
+    secret,
+  );
   if (!timingSafeMatch(expected, message.signature)) {
     return { status: "rejected", reason: "signature_mismatch" };
   }
 
   return {
     status: "verified",
-    message: {
-      conversationId: message.conversationId,
-      destination: message.destination,
-    },
+    message: { conversationId: message.conversationId },
   };
 }
 

--- a/packages/junior/src/chat/task-execution/queue.ts
+++ b/packages/junior/src/chat/task-execution/queue.ts
@@ -1,12 +1,18 @@
-import type { Destination } from "@sentry/junior-plugin-api";
+import { z } from "zod";
 
-export interface ConversationQueueMessage {
-  conversationId: string;
-  destination: Destination;
-}
+/** Validate the conversation work hint sent through Vercel Queue. */
+export const conversationQueueMessageSchema = z
+  .object({
+    conversationId: z.string().trim().min(1),
+  })
+  .strict();
+
+/** Conversation work hint accepted by the queue callback and worker. */
+export type ConversationQueueMessage = z.output<
+  typeof conversationQueueMessageSchema
+>;
 
 export type ConversationQueueMessageRejectReason =
-  | "destination_mismatch"
   | "expired"
   | "invalid_record"
   | "malformed"
@@ -28,7 +34,7 @@ export class ConversationQueueMessageRejectedError extends Error {
   }
 }
 
-/** Return whether a queue payload was permanently rejected at the message boundary. */
+/** Return whether an error means the queue message was permanently rejected. */
 export function isConversationQueueMessageRejectedError(
   error: unknown,
 ): error is ConversationQueueMessageRejectedError {

--- a/packages/junior/src/chat/task-execution/store.ts
+++ b/packages/junior/src/chat/task-execution/store.ts
@@ -180,7 +180,6 @@ export async function ensureConversationWake(args: {
   const queueResult = await args.queue.send(
     {
       conversationId: args.conversationId,
-      destination: conversation.destination,
     },
     {
       delayMs: args.delayMs,

--- a/packages/junior/src/chat/task-execution/vercel-callback.ts
+++ b/packages/junior/src/chat/task-execution/vercel-callback.ts
@@ -6,12 +6,12 @@ import {
 } from "@vercel/queue";
 import type { StateAdapter } from "chat";
 import { getChatConfig } from "@/chat/config";
-import { parseDestination } from "@/chat/destination";
 import { logWarn } from "@/chat/logging";
 import { createVercelQueueClient } from "@/chat/vercel-queue-client";
 import type { ConversationStore } from "@/chat/conversations/store";
 import { runWithTurnRequestDeadline } from "@/chat/runtime/request-deadline";
 import {
+  conversationQueueMessageSchema,
   ConversationQueueMessageRejectedError,
   isConversationQueueMessageRejectedError,
   type ConversationQueueMessage,
@@ -48,28 +48,15 @@ export interface VercelConversationWorkCallbackOptions extends ProcessConversati
   visibilityTimeoutSeconds?: number;
 }
 
+/** Parse the signed callback body before conversation work reaches the worker. */
 function parseConversationQueueMessage(
   message: unknown,
 ): ConversationQueueMessage {
-  const destination = parseDestination(
-    (message as { destination?: unknown } | undefined)?.destination,
-  );
-  if (
-    !message ||
-    typeof message !== "object" ||
-    typeof (message as { conversationId?: unknown }).conversationId !==
-      "string" ||
-    !(message as { conversationId: string }).conversationId.trim() ||
-    !destination
-  ) {
-    throw new Error(
-      "Conversation queue message is missing destination context",
-    );
+  const parsed = conversationQueueMessageSchema.safeParse(message);
+  if (!parsed.success) {
+    throw new Error("Conversation queue message is malformed");
   }
-  return {
-    conversationId: (message as { conversationId: string }).conversationId,
-    destination,
-  };
+  return parsed.data;
 }
 
 /** Resolve queue visibility so redelivery waits past the host timeout boundary. */

--- a/packages/junior/src/chat/task-execution/worker.ts
+++ b/packages/junior/src/chat/task-execution/worker.ts
@@ -1,6 +1,5 @@
 import type { StateAdapter } from "chat";
 import type { Destination } from "@sentry/junior-plugin-api";
-import { sameDestination } from "@/chat/destination";
 import { logException, logInfo, logWarn } from "@/chat/logging";
 import type { ConversationStore } from "@/chat/conversations/store";
 import { isProviderRetryError } from "@/chat/services/provider-retry";
@@ -260,13 +259,10 @@ export async function processConversationWork(
     }
     return { status: "no_work" };
   }
-  if (
-    !initial.destination ||
-    !sameDestination(initial.destination, message.destination)
-  ) {
+  if (!initial.destination) {
     throw new ConversationQueueMessageRejectedError(
-      "destination_mismatch",
-      `Conversation work queue destination changed for ${conversationId}`,
+      "invalid_record",
+      `Conversation work is missing destination context for ${conversationId}`,
       { conversationId },
     );
   }

--- a/packages/junior/tests/component/resource-events/resource-events.test.ts
+++ b/packages/junior/tests/component/resource-events/resource-events.test.ts
@@ -111,7 +111,6 @@ describe("resource event subscriptions", () => {
     expect(queue.sentRecords()).toEqual([
       {
         conversationId: CONVERSATION_ID,
-        destination: SLACK_DESTINATION,
         idempotencyKey: `resource-event:${subscription.id}:delivery-1:check-suite-1`,
       },
     ]);
@@ -209,7 +208,6 @@ describe("resource event subscriptions", () => {
       expect(queue.sentRecords()).toEqual([
         {
           conversationId: CONVERSATION_ID,
-          destination: SLACK_DESTINATION,
           idempotencyKey: `resource-event:${subscription.id}:github:delivery-bridge:comment.created`,
         },
       ]);
@@ -287,7 +285,6 @@ describe("resource event subscriptions", () => {
     expect(queue.sentRecords()).toEqual([
       {
         conversationId: CONVERSATION_ID,
-        destination: SLACK_DESTINATION,
         idempotencyKey: `resource-event:${subscription.id}:delivery-3:check-suite-1`,
       },
     ]);

--- a/packages/junior/tests/component/runtime/agent-continue.test.ts
+++ b/packages/junior/tests/component/runtime/agent-continue.test.ts
@@ -61,7 +61,6 @@ describe("agent continuation scheduling", () => {
     expect(queue.sentRecords()).toEqual([
       {
         conversationId,
-        destination: SLACK_DESTINATION,
         idempotencyKey: `agent-continue:${conversationId}:turn_msg_1:3:1000`,
       },
     ]);

--- a/packages/junior/tests/component/task-execution/conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/conversation-work.test.ts
@@ -172,7 +172,6 @@ describe("conversation work execution", () => {
     expect(queue.sentRecords()).toEqual([
       {
         conversationId: CONVERSATION_ID,
-        destination: SLACK_DESTINATION,
         idempotencyKey: "m1",
       },
     ]);
@@ -250,7 +249,6 @@ describe("conversation work execution", () => {
     expect(queue.sendAttempts()).toEqual([
       {
         conversationId: CONVERSATION_ID,
-        destination: SLACK_DESTINATION,
         idempotencyKey: `duplicate:${CONVERSATION_ID}:m1:62000`,
       },
     ]);
@@ -417,7 +415,6 @@ describe("conversation work execution", () => {
     expect(queue.sentRecords()).toEqual([
       {
         conversationId: CONVERSATION_ID,
-        destination: SLACK_DESTINATION,
         idempotencyKey: `heartbeat:pending:${CONVERSATION_ID}:62000`,
       },
     ]);
@@ -662,28 +659,25 @@ describe("conversation work execution", () => {
     expect(queue.sentRecords()).toEqual([
       {
         conversationId: CONVERSATION_ID,
-        destination: SLACK_DESTINATION,
         idempotencyKey: "m2",
       },
     ]);
   });
 
-  it("rejects queue messages whose destination does not match persisted work", async () => {
+  it("loads queue routing from persisted conversation work", async () => {
     const queue = createConversationWorkQueueTestAdapter();
-    const run = vi.fn(async () => ({ status: "completed" as const }));
+    const run = vi.fn(async (context) => {
+      expect(context.destination).toEqual(SLACK_DESTINATION);
+      await context.attempt.ack();
+      return { status: "completed" as const };
+    });
     await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
 
     await expect(
-      processConversationWork(
-        conversationQueueMessage({ destination: OTHER_SLACK_DESTINATION }),
-        {
-          queue,
-          run,
-        },
-      ),
-    ).rejects.toThrow("Conversation work queue destination changed");
+      processConversationWork(conversationQueueMessage(), { queue, run }),
+    ).resolves.toEqual({ status: "completed" });
 
-    expect(run).not.toHaveBeenCalled();
+    expect(run).toHaveBeenCalledOnce();
     const work = await getConversationWorkState({
       conversationId: CONVERSATION_ID,
     });
@@ -797,7 +791,6 @@ describe("conversation work execution", () => {
     expect(queue.sentRecords()).toEqual([
       {
         conversationId: CONVERSATION_ID,
-        destination: SLACK_DESTINATION,
         idempotencyKey: `agent-continue:${CONVERSATION_ID}:turn-1:2:2000`,
       },
     ]);
@@ -852,7 +845,6 @@ describe("conversation work execution", () => {
     expect(queue.sentRecords()).toEqual([
       {
         conversationId: CONVERSATION_ID,
-        destination: SLACK_DESTINATION,
         idempotencyKey: `agent-continue:${CONVERSATION_ID}:turn-1:2:2000`,
       },
     ]);
@@ -963,7 +955,6 @@ describe("conversation work execution", () => {
     expect(queue.sentRecords()).toEqual([
       {
         conversationId: CONVERSATION_ID,
-        destination: SLACK_DESTINATION,
         idempotencyKey: `agent-continue:${CONVERSATION_ID}:turn-1:2:2000`,
       },
     ]);
@@ -1085,7 +1076,6 @@ describe("conversation work execution", () => {
     expect(queue.sentRecords()).toEqual([
       {
         conversationId: CONVERSATION_ID,
-        destination: SLACK_DESTINATION,
         idempotencyKey: `lost_lease:${CONVERSATION_ID}:2000`,
       },
     ]);
@@ -1516,7 +1506,6 @@ describe("conversation work execution", () => {
     expect(queue.sentRecords()).toEqual([
       {
         conversationId: CONVERSATION_ID,
-        destination: SLACK_DESTINATION,
         idempotencyKey: `heartbeat:pending:${CONVERSATION_ID}:62000`,
       },
     ]);
@@ -1697,19 +1686,16 @@ describe("conversation work execution", () => {
     expect(queue.sendAttempts()).toEqual([
       {
         conversationId: CONVERSATION_ID,
-        destination: SLACK_DESTINATION,
         idempotencyKey: "m1",
       },
       {
         conversationId: CONVERSATION_ID,
-        destination: SLACK_DESTINATION,
         idempotencyKey: "m1",
       },
     ]);
     expect(queue.sentRecords()).toEqual([
       {
         conversationId: CONVERSATION_ID,
-        destination: SLACK_DESTINATION,
         idempotencyKey: "m1",
       },
     ]);
@@ -1746,7 +1732,7 @@ describe("conversation work execution", () => {
         message: expect.objectContaining({
           conversationId: CONVERSATION_ID,
           signature: expect.any(String),
-          signatureVersion: "v1",
+          signatureVersion: "v2",
           signedAtMs: expect.any(Number),
         }),
         options: {
@@ -1769,7 +1755,6 @@ describe("conversation work execution", () => {
 
     expect(verifySignedConversationQueueMessage(signed, signedAtMs)).toEqual({
       conversationId: CONVERSATION_ID,
-      destination: SLACK_DESTINATION,
     });
     expect(
       verifySignedConversationQueueMessage(
@@ -1797,27 +1782,6 @@ describe("conversation work execution", () => {
     ).toBeUndefined();
   });
 
-  it("signs queue destinations by identity rather than object key order", () => {
-    process.env.JUNIOR_SECRET = "conversation-work-secret";
-    const signedAtMs = 12_345;
-    const signed = signConversationQueueMessage(
-      {
-        conversationId: CONVERSATION_ID,
-        destination: {
-          channelId: "C123",
-          platform: "slack",
-          teamId: "T123",
-        },
-      },
-      signedAtMs,
-    );
-
-    expect(verifySignedConversationQueueMessage(signed, signedAtMs)).toEqual({
-      conversationId: CONVERSATION_ID,
-      destination: SLACK_DESTINATION,
-    });
-  });
-
   it("keeps queue signatures valid across default visibility redelivery", () => {
     process.env.JUNIOR_SECRET = "conversation-work-secret";
     const signedAtMs = 12_345;
@@ -1830,7 +1794,6 @@ describe("conversation work execution", () => {
       verifySignedConversationQueueMessage(signed, signedAtMs + 330_000),
     ).toEqual({
       conversationId: CONVERSATION_ID,
-      destination: SLACK_DESTINATION,
     });
   });
 
@@ -1864,6 +1827,6 @@ describe("conversation work execution", () => {
           run: async () => ({ status: "completed" }),
         },
       ),
-    ).rejects.toThrow("missing destination context");
+    ).rejects.toThrow("Conversation queue message is malformed");
   });
 });

--- a/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
@@ -269,6 +269,7 @@ describe("Slack conversation work execution", () => {
     const slackAdapter = createSlackAdapterFixture();
     const malformed = {
       ...conversationQueueMessage(),
+      destination: SLACK_DESTINATION,
       inboundMessageId: "malformed-slack-metadata",
       source: "slack" as const,
       createdAtMs: 1_000,

--- a/packages/junior/tests/component/vercel-queue-dev.test.ts
+++ b/packages/junior/tests/component/vercel-queue-dev.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ConversationWorkerContext } from "@/chat/task-execution/worker";
 
 const originalNodeEnv = process.env.NODE_ENV;
 const originalQueueTopic = process.env.JUNIOR_CONVERSATION_WORK_QUEUE_TOPIC;
@@ -203,7 +204,7 @@ describe("registerVercelConversationWorkDevConsumer", () => {
     });
   });
 
-  it("absorbs rejected conversation queue messages before retry", async () => {
+  it("handles rejected and versioned conversation queue messages", async () => {
     const routeHandler = vi.fn();
     const handleCallback = vi.fn(() => routeHandler);
 
@@ -216,7 +217,10 @@ describe("registerVercelConversationWorkDevConsumer", () => {
     const { createVercelConversationWorkCallback } =
       await import("@/chat/task-execution/vercel-callback");
 
-    const run = vi.fn(async () => ({ status: "completed" as const }));
+    const run = vi.fn(async (context: ConversationWorkerContext) => {
+      await context.attempt.ack();
+      return { status: "completed" as const };
+    });
     expect(
       createVercelConversationWorkCallback({
         run,
@@ -298,25 +302,28 @@ describe("registerVercelConversationWorkDevConsumer", () => {
       handler(
         signConversationQueueMessage({
           conversationId: "slack:C123:1712345.0001",
-          destination: {
-            channelId: "C456",
-            platform: "slack",
-            teamId: "T123",
-          },
         }),
         metadata,
       ),
     ).resolves.toBeUndefined();
-    expect(run).not.toHaveBeenCalled();
+    expect(run).toHaveBeenCalledOnce();
+    expect(run).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        destination: {
+          channelId: "C123",
+          platform: "slack",
+          teamId: "T123",
+        },
+      }),
+    );
 
     delete process.env.JUNIOR_SECRET;
     let missingSecretError: unknown;
     await handler(
       {
         conversationId: "slack:C123:1712345.0001",
-        destination: { channelId: "C123", platform: "slack", teamId: "T123" },
         signature: "signature",
-        signatureVersion: "v1",
+        signatureVersion: "v2",
         signedAtMs: 1_000,
       },
       metadata,

--- a/packages/junior/tests/fixtures/conversation-work.ts
+++ b/packages/junior/tests/fixtures/conversation-work.ts
@@ -25,7 +25,6 @@ export const SLACK_SIGNING_SECRET = "slack-signature-fixture";
 
 export interface ConversationQueueSendRecord {
   conversationId: string;
-  destination: Destination;
   delayMs?: number;
   idempotencyKey?: string;
 }
@@ -95,7 +94,6 @@ export class ConversationWorkQueueTestAdapter implements ConversationWorkQueue {
     }
     const record: ConversationQueueSendRecord = {
       conversationId: message.conversationId,
-      destination: message.destination,
     };
     if (options?.delayMs !== undefined) {
       record.delayMs = options.delayMs;
@@ -216,7 +214,6 @@ export function conversationQueueMessage(
 ): ConversationQueueMessage {
   return {
     conversationId: CONVERSATION_ID,
-    destination: SLACK_DESTINATION,
     ...overrides,
   };
 }

--- a/packages/junior/tests/integration/agent-continue-slack.test.ts
+++ b/packages/junior/tests/integration/agent-continue-slack.test.ts
@@ -731,7 +731,6 @@ describe("agent continuation Slack integration", () => {
     expect(queue.sentRecords()).toEqual([
       {
         conversationId,
-        destination: SLACK_DESTINATION,
         idempotencyKey: expect.stringContaining(
           `agent-continue:${conversationId}:${sessionId}:`,
         ),
@@ -1194,7 +1193,6 @@ describe("agent continuation Slack integration", () => {
     expect(queue.sentRecords()).toEqual([
       {
         conversationId,
-        destination: SLACK_DESTINATION,
         idempotencyKey: expect.stringContaining(
           `agent-continue:${conversationId}:${sessionId}:`,
         ),

--- a/packages/junior/tests/integration/heartbeat.test.ts
+++ b/packages/junior/tests/integration/heartbeat.test.ts
@@ -295,7 +295,6 @@ describe("plugin heartbeat", () => {
     expect(queue.sentRecords()).toEqual([
       {
         conversationId,
-        destination: SLACK_DESTINATION,
         idempotencyKey: `heartbeat:pending:${conversationId}:${TEST_NOW_MS}`,
       },
     ]);
@@ -356,7 +355,6 @@ describe("plugin heartbeat", () => {
     expect(queue.sentRecords()).toEqual([
       {
         conversationId,
-        destination: SLACK_DESTINATION,
         idempotencyKey: `heartbeat:pending:${conversationId}:${TEST_NOW_MS}`,
       },
     ]);

--- a/packages/junior/tests/integration/slack/app-home-webhook.test.ts
+++ b/packages/junior/tests/integration/slack/app-home-webhook.test.ts
@@ -157,7 +157,6 @@ describe("Slack webhook: App Home events", () => {
     expect(queue.queuedMessages()).toEqual([
       {
         conversationId: "slack:C123:1712345.0001",
-        destination: { platform: "slack", teamId: "T123", channelId: "C123" },
       },
     ]);
     expect(waitUntil.pendingCount()).toBe(0);
@@ -205,7 +204,6 @@ describe("Slack webhook: App Home events", () => {
     expect(queue.queuedMessages()).toEqual([
       {
         conversationId: "slack:C123:1712345.0002",
-        destination: { platform: "slack", teamId: "T123", channelId: "C123" },
       },
     ]);
   });

--- a/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
@@ -218,22 +218,15 @@ describe("Slack behavior: durable turn steering", () => {
     ).resolves.toMatchObject({ status: 200 });
 
     const inboundMessageId = `slack:T123:${conversationId}:${THREAD_TS}`;
-    const destination = {
-      platform: "slack",
-      teamId: "T123",
-      channelId: CHANNEL_ID,
-    };
     expect(queue.sendAttempts()).toEqual([
       {
         conversationId,
-        destination,
         idempotencyKey: inboundMessageId,
       },
     ]);
     expect(queue.sentRecords()).toEqual([
       {
         conversationId,
-        destination,
         idempotencyKey: inboundMessageId,
       },
     ]);


### PR DESCRIPTION
Conversation queue messages previously repeated the conversation destination.
That destination is already stored with the conversation, so this PR changes
queue producers, signatures, callbacks, and workers to pass only
`conversationId`.

The queue message is now only a wake-up hint:

```text
{ conversationId }
```

After signature verification, the worker loads destination and routing from
persisted conversation work. Queue callbacks can no longer provide or override
that routing data.

The writer and reader switch together in this PR. Vercel push queues are
partitioned by deployment and deliver messages to the same deployment that
published them, so the new payload does not need a cross-deployment
compatibility reader. Old deployments continue processing their own queued
messages with their existing code.

This PR does not change turn execution, Slack behavior, or subagent behavior.
Review should start with `task-execution/queue.ts` and
`task-execution/queue-signing.ts`, followed by the producer change in
`task-execution/store.ts` and the worker routing change. Tests cover signature
tampering, the real callback path, persisted routing, steering, and heartbeat
recovery.

Refs #876
