### PR TITLE
ref(runtime): Continue paused work in the same worker

### DIFF
--- a/packages/junior/src/chat/app/production.ts
+++ b/packages/junior/src/chat/app/production.ts
@@ -118,12 +118,16 @@ export function createProductionConversationWorkOptions(options: {
     run: createSlackConversationWorker({
       getSlackAdapter: getProductionSlackAdapter,
       conversationStore,
-      resumeAwaitingContinuation: async (conversationId) =>
-        await resumeAwaitingSlackContinuation(conversationId, {
-          agentRunner,
-          scheduleSessionCompletedPluginTasks:
-            services.replyExecutor?.scheduleSessionCompletedPluginTasks,
-        }),
+      resumeAwaitingContinuation: async (conversationId, runOptions) =>
+        await resumeAwaitingSlackContinuation(
+          conversationId,
+          {
+            agentRunner,
+            scheduleSessionCompletedPluginTasks:
+              services.replyExecutor?.scheduleSessionCompletedPluginTasks,
+          },
+          runOptions,
+        ),
       runtime,
     }),
   };

--- a/packages/junior/src/chat/runtime/agent-continue-runner.ts
+++ b/packages/junior/src/chat/runtime/agent-continue-runner.ts
@@ -89,6 +89,11 @@ export interface AgentContinueRunnerOptions {
   }) => Promise<void>;
 }
 
+/** Per-worker controls for one continued run. */
+export interface AgentContinueRunOptions {
+  shouldYield?: () => boolean;
+}
+
 /** Persist a delivered continuation reply as the terminal thread state. */
 async function persistCompletedReplyState(args: {
   sessionRecord: AgentTurnSessionRecord;
@@ -282,6 +287,7 @@ async function failUnresumableContinuation(args: {
 export async function continueSlackAgentRun(
   payload: AgentContinueRequest,
   options: AgentContinueRunnerOptions,
+  runOptions: AgentContinueRunOptions = {},
 ): Promise<boolean> {
   const thread = parseSlackThreadId(payload.conversationId);
   if (!thread) {
@@ -431,6 +437,7 @@ export async function continueSlackAgentRun(
               sandboxRef,
             },
             durability: {
+              shouldYield: runOptions.shouldYield,
               recordPendingAuth: async (nextPendingAuth) => {
                 conversation.processing.pendingAuth = nextPendingAuth;
                 await persistThreadStateById(payload.conversationId, {
@@ -558,6 +565,7 @@ async function failStrandedSessionWithFallback(args: {
 async function recoverStrandedRunningSession(args: {
   conversationId: string;
   options: AgentContinueRunnerOptions;
+  runOptions: AgentContinueRunOptions;
   summary: AgentTurnSessionSummary;
 }): Promise<boolean> {
   // A live resume outside the mailbox lease (OAuth/timeout continuation)
@@ -623,7 +631,13 @@ async function recoverStrandedRunningSession(args: {
     return false;
   }
 
-  if (await continueSlackAgentRunWithLockRetry(request, args.options)) {
+  if (
+    await continueSlackAgentRunWithLockRetry(
+      request,
+      args.options,
+      args.runOptions,
+    )
+  ) {
     return true;
   }
   await failUnresumableContinuation({
@@ -639,6 +653,7 @@ async function recoverStrandedRunningSession(args: {
 export async function resumeAwaitingSlackContinuation(
   conversationId: string,
   options: AgentContinueRunnerOptions,
+  runOptions: AgentContinueRunOptions = {},
 ): Promise<boolean> {
   const summaries =
     await listAgentTurnSessionSummariesForConversation(conversationId);
@@ -651,6 +666,7 @@ export async function resumeAwaitingSlackContinuation(
     return await recoverStrandedRunningSession({
       conversationId,
       options,
+      runOptions,
       summary: newest,
     });
   }
@@ -674,7 +690,9 @@ export async function resumeAwaitingSlackContinuation(
       continue;
     }
 
-    if (await continueSlackAgentRunWithLockRetry(request, options)) {
+    if (
+      await continueSlackAgentRunWithLockRetry(request, options, runOptions)
+    ) {
       return true;
     }
 
@@ -699,6 +717,7 @@ export async function resumeAwaitingSlackContinuation(
 export async function continueSlackAgentRunWithLockRetry(
   payload: AgentContinueRequest,
   options: AgentContinueRunnerOptions,
+  runOptions: AgentContinueRunOptions = {},
 ): Promise<boolean> {
   const scheduleAgentContinue =
     options.scheduleAgentContinue ?? defaultScheduleAgentContinue;
@@ -707,7 +726,7 @@ export async function continueSlackAgentRunWithLockRetry(
     undefined,
   ].entries()) {
     try {
-      return await continueSlackAgentRun(payload, options);
+      return await continueSlackAgentRun(payload, options, runOptions);
     } catch (error) {
       if (!(error instanceof ResumeTurnBusyError)) {
         throw error;

--- a/packages/junior/src/chat/task-execution/README.md
+++ b/packages/junior/src/chat/task-execution/README.md
@@ -24,14 +24,20 @@ require a valid delivery value and reject invalid pending work.
 
 1. Ingress appends mailbox work before sending a queue nudge.
 2. The worker validates the queue callback and acquires the conversation lease.
-3. It drains available mailbox messages into durable agent history.
+3. While it owns the lease, the worker reloads durable state and runs the next
+   work: `interrupt` mailbox delivery first, then a paused turn, then `defer`
+   mailbox delivery. Each iteration gets a fresh mailbox delivery attempt.
 4. Runtime advances the turn until completion, auth pause, cooperative yield,
    or terminal failure, delivering and recording completed tool-free assistant
-   messages as it advances. Tool-bearing assistant text remains agent history;
-   explicit progress uses the status surface.
-5. Before yielding, the worker commits a safe history boundary, sends another
+   messages as it advances. A requested turn resume is durable state, not an
+   in-memory callback; the same worker observes it on the next loop iteration.
+   Tool-bearing assistant text remains agent history; explicit progress uses
+   the status surface.
+5. Work appended under a healthy lease does not send another queue nudge. The
+   current worker observes it on its next state reload.
+6. Before yielding, the worker commits a safe history boundary, sends another
    nudge, and releases the lease.
-6. Terminal delivery or intentional no-reply completion records the delivered
+7. Terminal delivery or intentional no-reply completion records the delivered
    turn before acknowledging work.
 
 New messages that arrive during a run remain durable. `interrupt` work is
@@ -41,8 +47,8 @@ and waits for the next turn.
 Slack `@` mentions use `interrupt` delivery; all other inbound messages use
 `defer`.
 
-An active turn drains only `interrupt` messages. When a new turn starts,
-interrupt messages are handled before queued deferred work.
+An active turn drains only messages with `interrupt` mailbox delivery. When a
+new turn starts, `interrupt` delivery is handled before queued `defer` delivery.
 
 ## Queue And Lease Rules
 

--- a/packages/junior/src/chat/task-execution/slack-work.ts
+++ b/packages/junior/src/chat/task-execution/slack-work.ts
@@ -450,7 +450,10 @@ export interface CreateSlackConversationWorkerOptions {
     teamId: string,
     userId: string,
   ) => Promise<SlackActorProfile | null | undefined>;
-  resumeAwaitingContinuation: (conversationId: string) => Promise<boolean>;
+  resumeAwaitingContinuation: (
+    conversationId: string,
+    options: { shouldYield: () => boolean },
+  ) => Promise<boolean>;
   conversationStore?: ConversationStore;
   runtime: SlackInboxTurnRuntime;
   state?: StateAdapter;
@@ -756,7 +759,9 @@ export function createSlackConversationWorker(
         installation: { teamId: destination.teamId },
         state,
         task: async () => {
-          await options.resumeAwaitingContinuation(context.conversationId);
+          await options.resumeAwaitingContinuation(context.conversationId, {
+            shouldYield: context.shouldYield,
+          });
         },
       });
       return { status: "completed" };
@@ -842,7 +847,6 @@ export function createSlackConversationWorker(
             );
           });
         };
-
         try {
           if (route === "mention") {
             await options.runtime.handleNewMention(thread, latestMessage, {
@@ -853,17 +857,20 @@ export function createSlackConversationWorker(
               isFinalAttempt: context.attempt.isFinalAttempt,
               shouldYield: context.shouldYield,
             });
-            return;
+          } else {
+            await options.runtime.handleSubscribedMessage(
+              thread,
+              latestMessage,
+              {
+                destination: context.destination,
+                messageContext,
+                drainSteeringMessages,
+                ack,
+                isFinalAttempt: context.attempt.isFinalAttempt,
+                shouldYield: context.shouldYield,
+              },
+            );
           }
-
-          await options.runtime.handleSubscribedMessage(thread, latestMessage, {
-            destination: context.destination,
-            messageContext,
-            drainSteeringMessages,
-            ack,
-            isFinalAttempt: context.attempt.isFinalAttempt,
-            shouldYield: context.shouldYield,
-          });
         } catch (error) {
           if (isTurnInputDeferredError(error)) {
             return { status: "deferred" } satisfies ConversationWorkerResult;

--- a/packages/junior/src/chat/task-execution/state.ts
+++ b/packages/junior/src/chat/task-execution/state.ts
@@ -1428,7 +1428,10 @@ export async function startConversationWork(args: {
         {
           ...current.execution,
           lease,
-          status: "running",
+          status:
+            current.execution.status === "awaiting_resume"
+              ? "awaiting_resume"
+              : "running",
           runId: current.execution.runId ?? randomUUID(),
           lastEnqueuedAtMs: undefined,
         },
@@ -1634,6 +1637,39 @@ export async function requestConversationContinuation(args: {
   });
 }
 
+/** Begin a requested turn resume under the worker's existing lease. */
+export async function beginConversationResume(args: {
+  conversationId: string;
+  leaseToken: string;
+  nowMs?: number;
+  state?: StateAdapter;
+}): Promise<boolean> {
+  const nowMs = args.nowMs ?? now();
+  return await withConversationMutation(args, async (state, lock) => {
+    const current = await readConversation(state, args.conversationId);
+    if (
+      !current ||
+      current.execution.lease?.token !== args.leaseToken ||
+      current.execution.status !== "awaiting_resume"
+    ) {
+      return false;
+    }
+    await writeConversation(
+      state,
+      lock,
+      withExecutionUpdate(
+        current,
+        {
+          ...current.execution,
+          status: "running",
+        },
+        nowMs,
+      ),
+    );
+    return true;
+  });
+}
+
 /** Release the durable execution lease without changing completion state. */
 export async function releaseConversationWork(args: {
   conversationId: string;
@@ -1691,7 +1727,11 @@ export async function completeConversationWork(args: {
         {
           ...current.execution,
           lease: undefined,
-          status: runnable ? "pending" : "idle",
+          status: needsRun
+            ? "awaiting_resume"
+            : hasPending
+              ? "pending"
+              : "idle",
           runId: runnable ? current.execution.runId : undefined,
         },
         nowMs,
@@ -1844,7 +1884,7 @@ export async function clearExpiredConversationLease(args: {
         {
           ...current.execution,
           lease: undefined,
-          status: "pending",
+          status: "awaiting_resume",
         },
         nowMs,
       ),

--- a/packages/junior/src/chat/task-execution/store.ts
+++ b/packages/junior/src/chat/task-execution/store.ts
@@ -49,7 +49,7 @@ export type EnsureConversationWakeResult =
       status: "enqueued";
     }
   | {
-      status: "already_enqueued" | "no_work";
+      status: "already_enqueued" | "lease_active" | "no_work";
     };
 
 function metadataStore(options: MetadataOptions): ConversationStore {
@@ -170,6 +170,13 @@ export async function ensureConversationWake(args: {
   }
   if (!conversation.destination) {
     return { status: "no_work" };
+  }
+  if (
+    args.replaceExistingWake !== true &&
+    conversation.execution.lease &&
+    conversation.execution.lease.expiresAtMs > nowMs
+  ) {
+    return { status: "lease_active" };
   }
   if (
     args.replaceExistingWake !== true &&
@@ -402,6 +409,21 @@ export async function requestConversationContinuation(args: {
 }) {
   const result = await workState.requestConversationContinuation(args);
   await recordExecutionMetadata(args);
+  return result;
+}
+
+/** Begin a requested turn resume without releasing the current lease. */
+export async function beginConversationResume(args: {
+  conversationId: string;
+  leaseToken: string;
+  conversationStore?: ConversationStore;
+  nowMs?: number;
+  state?: StateAdapter;
+}) {
+  const result = await workState.beginConversationResume(args);
+  if (result) {
+    await recordExecutionMetadata(args);
+  }
   return result;
 }
 

--- a/packages/junior/src/chat/task-execution/worker.ts
+++ b/packages/junior/src/chat/task-execution/worker.ts
@@ -11,6 +11,7 @@ import {
 } from "./queue";
 import {
   ackMessages,
+  beginConversationResume,
   checkInConversationWork,
   clearConsumedConversationWake,
   completeConversationWork,
@@ -82,11 +83,15 @@ function now(options: ProcessConversationWorkOptions): number {
 }
 
 /** Prioritize the interrupt batch; otherwise process the deferred batch. */
-function selectAttemptMessages(messages: InboundMessage[]): InboundMessage[] {
+function selectAttemptMessages(work: ConversationWorkState): InboundMessage[] {
+  const messages = work.messages;
   const interrupts = messages.filter(
     (message) => message.delivery === "interrupt",
   );
-  return interrupts.length > 0 ? interrupts : messages;
+  if (interrupts.length > 0) {
+    return interrupts;
+  }
+  return work.execution.status === "awaiting_resume" ? [] : messages;
 }
 
 function nudgeIdempotencyKey(
@@ -104,7 +109,7 @@ async function requestLostLeaseRecovery(args: {
   nowMs: number;
   options: ProcessConversationWorkOptions;
 }): Promise<void> {
-  const continuationMarked = await requestConversationContinuation({
+  const resumeRequested = await requestConversationContinuation({
     conversationId: args.conversationId,
     destination: args.destination,
     leaseToken: args.leaseToken,
@@ -112,7 +117,7 @@ async function requestLostLeaseRecovery(args: {
     nowMs: args.nowMs,
     state: args.options.state,
   });
-  if (!continuationMarked) {
+  if (!resumeRequested) {
     return;
   }
   const released = await releaseConversationWork({
@@ -319,16 +324,7 @@ export async function processConversationWork(
     startedAtMs +
     (options.softYieldAfterMs ??
       getChatConfig().conversationWorkSoftYieldAfterMs);
-  const leasedWork = await getConversationWorkState({
-    conversationId,
-    state: options.state,
-  });
-  const attemptMessages = selectAttemptMessages(
-    leasedWork?.messages ?? initial.messages,
-  );
-  const attemptMessageIds = attemptMessages.map(
-    (message) => message.inboundMessageId,
-  );
+  let attemptMessageIds: string[] = [];
   let leaseLost = false;
   const markLeaseLost = (): void => {
     leaseLost = true;
@@ -372,167 +368,251 @@ export async function processConversationWork(
       state: options.state,
     });
 
-  const ack = async (): Promise<void> => {
-    const acknowledged = await ackMessages({
+  const shouldYield = (): boolean =>
+    leaseLost || now(options) >= softYieldDeadlineMs;
+  const checkIn = async (): Promise<boolean> => {
+    const checkedIn = await checkInConversationWork({
       conversationId,
-      inboundMessageIds: attemptMessageIds,
       leaseToken: lease.leaseToken,
       conversationStore: options.conversationStore,
       nowMs: now(options),
       state: options.state,
     });
-    if (!acknowledged) {
+    if (!checkedIn) {
       markLeaseLost();
-      throw new Error(
-        `Conversation work lease lost before inbox ack for ${conversationId}`,
-      );
     }
+    return checkedIn;
   };
-
-  const workerContext: ConversationWorkerContext = {
-    attempt: {
-      ack,
+  const yieldWork = async (): Promise<ConversationWorkProcessResult> => {
+    const yieldNowMs = now(options);
+    await ensureConversationWake({
       conversationId,
-      destination,
-      drain,
-      isFinalAttempt: attemptMessages.some((message) =>
-        isFinalAttempt(message),
-      ),
-      messages: attemptMessages,
-    },
-    conversationId,
-    destination,
-    shouldYield: () => leaseLost || now(options) >= softYieldDeadlineMs,
-    checkIn: async () => {
-      const checkedIn = await checkInConversationWork({
-        conversationId,
-        leaseToken: lease.leaseToken,
-        conversationStore: options.conversationStore,
-        nowMs: now(options),
-        state: options.state,
-      });
-      if (!checkedIn) {
-        markLeaseLost();
-      }
-      return checkedIn;
-    },
+      conversationStore: options.conversationStore,
+      idempotencyKey: nudgeIdempotencyKey("yield", conversationId, yieldNowMs),
+      nowMs: yieldNowMs,
+      queue: options.queue,
+      replaceExistingWake: true,
+      state: options.state,
+    });
+    const released = await releaseConversationWork({
+      conversationId,
+      leaseToken: lease.leaseToken,
+      conversationStore: options.conversationStore,
+      nowMs: yieldNowMs,
+      state: options.state,
+    });
+    if (!released) {
+      return { status: "lost_lease" };
+    }
+    logInfo(
+      "conversation_work_cooperative_yield",
+      { conversationId },
+      {
+        "app.worker.elapsed_ms": now(options) - startedAtMs,
+        "app.worker.soft_yield_deadline_ms": softYieldDeadlineMs,
+      },
+      "Conversation work yielded cooperatively",
+    );
+    return { status: "yielded" };
   };
 
   try {
-    const result = await options.run(workerContext);
-    if (result.status === "lost_lease") {
-      await requestLostLeaseRecovery({
+    let hasRun = false;
+    while (true) {
+      attemptMessageIds = [];
+      const leasedWork = await getConversationWorkState({
         conversationId,
-        destination,
-        leaseToken: lease.leaseToken,
-        nowMs: now(options),
-        options,
-      });
-      return { status: "lost_lease" };
-    }
-    if (leaseLost) {
-      await requestLostLeaseRecovery({
-        conversationId,
-        destination,
-        leaseToken: lease.leaseToken,
-        nowMs: now(options),
-        options,
-      });
-      return { status: "lost_lease" };
-    }
-    if (result.status === "yielded") {
-      const yieldNowMs = now(options);
-      const continuationMarked = await requestConversationContinuation({
-        conversationId,
-        destination,
-        leaseToken: lease.leaseToken,
-        conversationStore: options.conversationStore,
-        nowMs: yieldNowMs,
         state: options.state,
       });
-      if (!continuationMarked) {
+      if (
+        !leasedWork ||
+        leasedWork.lease?.leaseToken !== lease.leaseToken ||
+        leaseLost
+      ) {
+        markLeaseLost();
+        await requestLostLeaseRecovery({
+          conversationId,
+          destination,
+          leaseToken: lease.leaseToken,
+          nowMs: now(options),
+          options,
+        });
         return { status: "lost_lease" };
       }
-      await ensureConversationWake({
-        conversationId,
-        conversationStore: options.conversationStore,
-        idempotencyKey: nudgeIdempotencyKey(
-          "yield",
-          conversationId,
-          yieldNowMs,
-        ),
-        nowMs: yieldNowMs,
-        queue: options.queue,
-        state: options.state,
-      });
-      await releaseConversationWork({
-        conversationId,
-        leaseToken: lease.leaseToken,
-        conversationStore: options.conversationStore,
-        nowMs: yieldNowMs,
-        state: options.state,
-      });
-      logInfo(
-        "conversation_work_cooperative_yield",
-        { conversationId },
-        {
-          "app.worker.elapsed_ms": now(options) - startedAtMs,
-          "app.worker.soft_yield_deadline_ms": softYieldDeadlineMs,
-        },
-        "Conversation work yielded cooperatively",
-      );
-      return { status: "yielded" };
-    }
 
-    if (result.status === "deferred") {
-      const deferredNowMs = now(options);
-      const released = await releaseConversationWork({
-        conversationId,
-        leaseToken: lease.leaseToken,
-        conversationStore: options.conversationStore,
-        nowMs: deferredNowMs,
-        state: options.state,
-      });
-      if (!released) {
-        return { status: "lost_lease" };
+      const resumePending = leasedWork.execution.status === "awaiting_resume";
+      const attemptMessages = selectAttemptMessages(leasedWork);
+
+      if (hasRun && shouldYield()) {
+        if (resumePending) {
+          return await yieldWork();
+        }
+        break;
       }
-      const wake = await ensureConversationWake({
-        conversationId,
-        conversationStore: options.conversationStore,
-        idempotencyKey: nudgeIdempotencyKey(
-          "deferred",
-          conversationId,
-          deferredNowMs,
-        ),
-        nowMs: deferredNowMs,
-        queue: options.queue,
-        state: options.state,
-      });
-      return wake.status === "enqueued"
-        ? { status: "pending_requeued" }
-        : { status: "completed" };
-    }
 
-    // A run that returns without durably handling any attempted message is a
-    // failed delivery attempt, even when the runner swallowed its error:
-    // completing would requeue the untouched mailbox forever.
-    if (attemptMessageIds.length > 0) {
-      const failure = await recordFailedDeliveryAttempt({
-        conversationId,
-        leaseToken: lease.leaseToken,
-        nowMs: now(options),
-        messageIds: attemptMessageIds,
-        options,
-      });
-      if (isTerminalFailure(failure)) {
-        await deadLetterAttempt({
+      if (resumePending && attemptMessages.length === 0) {
+        const resumeStarted = await beginConversationResume({
           conversationId,
           leaseToken: lease.leaseToken,
           conversationStore: options.conversationStore,
           nowMs: now(options),
           state: options.state,
         });
-        return { status: "failed" };
+        if (!resumeStarted) {
+          markLeaseLost();
+          await requestLostLeaseRecovery({
+            conversationId,
+            destination,
+            leaseToken: lease.leaseToken,
+            nowMs: now(options),
+            options,
+          });
+          return { status: "lost_lease" };
+        }
+      }
+
+      attemptMessageIds = attemptMessages.map(
+        (message) => message.inboundMessageId,
+      );
+      const ack = async (): Promise<void> => {
+        const acknowledged = await ackMessages({
+          conversationId,
+          inboundMessageIds: attemptMessageIds,
+          leaseToken: lease.leaseToken,
+          conversationStore: options.conversationStore,
+          nowMs: now(options),
+          state: options.state,
+        });
+        if (!acknowledged) {
+          markLeaseLost();
+          throw new Error(
+            `Conversation work lease lost before inbox ack for ${conversationId}`,
+          );
+        }
+      };
+      const workerContext: ConversationWorkerContext = {
+        attempt: {
+          ack,
+          conversationId,
+          destination,
+          drain,
+          isFinalAttempt: attemptMessages.some((message) =>
+            isFinalAttempt(message),
+          ),
+          messages: attemptMessages,
+        },
+        conversationId,
+        destination,
+        shouldYield,
+        checkIn,
+      };
+
+      const result = await options.run(workerContext);
+      hasRun = true;
+      if (result.status === "lost_lease") {
+        await requestLostLeaseRecovery({
+          conversationId,
+          destination,
+          leaseToken: lease.leaseToken,
+          nowMs: now(options),
+          options,
+        });
+        return { status: "lost_lease" };
+      }
+      if (leaseLost) {
+        await requestLostLeaseRecovery({
+          conversationId,
+          destination,
+          leaseToken: lease.leaseToken,
+          nowMs: now(options),
+          options,
+        });
+        return { status: "lost_lease" };
+      }
+      if (result.status === "yielded") {
+        const resumeRequested = await requestConversationContinuation({
+          conversationId,
+          destination,
+          leaseToken: lease.leaseToken,
+          conversationStore: options.conversationStore,
+          nowMs: now(options),
+          state: options.state,
+        });
+        if (!resumeRequested) {
+          return { status: "lost_lease" };
+        }
+        return await yieldWork();
+      }
+
+      if (result.status === "deferred") {
+        const deferredNowMs = now(options);
+        const released = await releaseConversationWork({
+          conversationId,
+          leaseToken: lease.leaseToken,
+          conversationStore: options.conversationStore,
+          nowMs: deferredNowMs,
+          state: options.state,
+        });
+        if (!released) {
+          return { status: "lost_lease" };
+        }
+        const wake = await ensureConversationWake({
+          conversationId,
+          conversationStore: options.conversationStore,
+          idempotencyKey: nudgeIdempotencyKey(
+            "deferred",
+            conversationId,
+            deferredNowMs,
+          ),
+          nowMs: deferredNowMs,
+          queue: options.queue,
+          state: options.state,
+        });
+        return wake.status === "enqueued"
+          ? { status: "pending_requeued" }
+          : { status: "completed" };
+      }
+
+      // A run that returns without durably handling any attempted message is a
+      // failed delivery attempt, even when the runner swallowed its error.
+      if (attemptMessageIds.length > 0) {
+        const failure = await recordFailedDeliveryAttempt({
+          conversationId,
+          leaseToken: lease.leaseToken,
+          nowMs: now(options),
+          messageIds: attemptMessageIds,
+          options,
+        });
+        if (isTerminalFailure(failure)) {
+          await deadLetterAttempt({
+            conversationId,
+            leaseToken: lease.leaseToken,
+            conversationStore: options.conversationStore,
+            nowMs: now(options),
+            state: options.state,
+          });
+          return { status: "failed" };
+        }
+        if (failure.status === "lost_lease") {
+          return { status: "lost_lease" };
+        }
+        if (failure.status === "recorded") {
+          break;
+        }
+      }
+
+      const next = await getConversationWorkState({
+        conversationId,
+        state: options.state,
+      });
+      if (!next || next.lease?.leaseToken !== lease.leaseToken) {
+        return { status: "lost_lease" };
+      }
+      if (
+        next.execution.status !== "awaiting_resume" &&
+        countPendingConversationMessages(next) === 0
+      ) {
+        break;
       }
     }
 
@@ -601,7 +681,7 @@ export async function processConversationWork(
           state: options.state,
         });
       } else {
-        const continuationMarked = await requestConversationContinuation({
+        const resumeRequested = await requestConversationContinuation({
           conversationId,
           destination,
           leaseToken: lease.leaseToken,
@@ -609,7 +689,7 @@ export async function processConversationWork(
           nowMs: errorNowMs,
           state: options.state,
         });
-        if (continuationMarked) {
+        if (resumeRequested) {
           await ensureConversationWake({
             conversationId,
             conversationStore: options.conversationStore,
@@ -620,6 +700,7 @@ export async function processConversationWork(
             ),
             nowMs: errorNowMs,
             queue: options.queue,
+            replaceExistingWake: true,
             state: options.state,
           });
         }

--- a/packages/junior/tests/component/task-execution/conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/conversation-work.test.ts
@@ -842,45 +842,49 @@ describe("conversation work execution", () => {
     });
   });
 
-  it("requeues work requested while a lease is running", async () => {
-    const queue = createConversationWorkQueueTestAdapter();
-    let currentNowMs = 1_000;
-    await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
+  it("preserves a requested turn resume when completion races with new work", async () => {
+    await requestConversationWork({
+      conversationId: CONVERSATION_ID,
+      destination: SLACK_DESTINATION,
+      nowMs: 1_000,
+    });
+    const lease = await startConversationWork({
+      conversationId: CONVERSATION_ID,
+      nowMs: 2_000,
+    });
+    expect(lease.status).toBe("acquired");
+    if (lease.status !== "acquired") {
+      return;
+    }
+    await requestConversationContinuation({
+      conversationId: CONVERSATION_ID,
+      destination: SLACK_DESTINATION,
+      leaseToken: lease.leaseToken,
+      nowMs: 3_000,
+    });
 
     await expect(
-      processConversationWork(conversationQueueMessage(), {
-        nowMs: () => currentNowMs,
-        queue,
-        run: async (context) => {
-          await context.attempt.drain(async () => {});
-          currentNowMs = 2_000;
-          await requestConversationWork({
-            conversationId: context.conversationId,
-            destination: context.destination,
-            nowMs: currentNowMs,
-          });
-          return { status: "completed" };
-        },
+      completeConversationWork({
+        conversationId: CONVERSATION_ID,
+        leaseToken: lease.leaseToken,
+        nowMs: 4_000,
       }),
-    ).resolves.toEqual({ status: "pending_requeued" });
-
-    const state = await getConversationWorkState({
+    ).resolves.toBe("pending");
+    const work = await getConversationWorkState({
       conversationId: CONVERSATION_ID,
     });
-    expect(state?.lease).toBeUndefined();
-    expect(state?.needsRun).toBe(true);
-    expect(state ? countPendingConversationMessages(state) : 0).toBe(0);
-    expect(queue.sentRecords()).toMatchObject([
-      {
-        conversationId: CONVERSATION_ID,
-        idempotencyKey: `pending:${CONVERSATION_ID}:2000`,
+    expect(work).toMatchObject({
+      execution: {
+        status: "awaiting_resume",
       },
-    ]);
+    });
+    expect(work?.lease).toBeUndefined();
   });
 
-  it("does not send a second nudge when a continuation wake was already queued during the lease", async () => {
+  it("continues work requested while the lease is running", async () => {
     const queue = createConversationWorkQueueTestAdapter();
     let currentNowMs = 1_000;
+    let runs = 0;
     await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
 
     await expect(
@@ -888,22 +892,16 @@ describe("conversation work execution", () => {
         nowMs: () => currentNowMs,
         queue,
         run: async (context) => {
+          runs += 1;
           await context.attempt.drain(async () => {});
-          currentNowMs = 2_000;
-          await requestConversationWork({
-            conversationId: context.conversationId,
-            destination: context.destination,
-            nowMs: currentNowMs,
-          });
-          await scheduleAgentContinue(
-            {
+          if (runs === 1) {
+            currentNowMs = 2_000;
+            await requestConversationWork({
               conversationId: context.conversationId,
               destination: context.destination,
-              expectedVersion: 2,
-              sessionId: "turn-1",
-            },
-            { queue, nowMs: currentNowMs },
-          );
+              nowMs: currentNowMs,
+            });
+          }
           return { status: "completed" };
         },
       }),
@@ -912,20 +910,17 @@ describe("conversation work execution", () => {
     const state = await getConversationWorkState({
       conversationId: CONVERSATION_ID,
     });
+    expect(runs).toBe(2);
     expect(state?.lease).toBeUndefined();
-    expect(state?.needsRun).toBe(true);
-    expect(state?.lastEnqueuedAtMs).toBe(2_000);
-    expect(queue.sentRecords()).toEqual([
-      {
-        conversationId: CONVERSATION_ID,
-        idempotencyKey: `agent-continue:${CONVERSATION_ID}:turn-1:2:2000`,
-      },
-    ]);
+    expect(state?.needsRun).toBe(false);
+    expect(state ? countPendingConversationMessages(state) : 0).toBe(0);
+    expect(queue.sentRecords()).toEqual([]);
   });
 
-  it("uses an existing conversation wake for pending mailbox and continuation work", async () => {
+  it("does not enqueue a turn resume owned by the active lease", async () => {
     const queue = createConversationWorkQueueTestAdapter();
     let currentNowMs = 1_000;
+    let runs = 0;
     await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
 
     await expect(
@@ -933,13 +928,99 @@ describe("conversation work execution", () => {
         nowMs: () => currentNowMs,
         queue,
         run: async (context) => {
+          runs += 1;
           await context.attempt.drain(async () => {});
+          if (runs === 1) {
+            currentNowMs = 2_000;
+            await scheduleAgentContinue(
+              {
+                conversationId: context.conversationId,
+                destination: context.destination,
+                expectedVersion: 2,
+                sessionId: "turn-1",
+              },
+              { queue, nowMs: currentNowMs },
+            );
+          }
+          return { status: "completed" };
+        },
+      }),
+    ).resolves.toEqual({ status: "completed" });
+
+    const state = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+    });
+    expect(runs).toBe(2);
+    expect(state?.lease).toBeUndefined();
+    expect(state?.needsRun).toBe(false);
+    expect(state?.lastEnqueuedAtMs).toBeUndefined();
+    expect(queue.sentRecords()).toEqual([]);
+  });
+
+  it("runs a resumed turn and mailbox delivery under the same lease", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    let currentNowMs = 1_000;
+    let runs = 0;
+    await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
+
+    await expect(
+      processConversationWork(conversationQueueMessage(), {
+        nowMs: () => currentNowMs,
+        queue,
+        run: async (context) => {
+          runs += 1;
+          await context.attempt.drain(async () => {});
+          if (runs === 1) {
+            currentNowMs = 2_000;
+            await scheduleAgentContinue(
+              {
+                conversationId: context.conversationId,
+                destination: context.destination,
+                expectedVersion: 2,
+                sessionId: "turn-1",
+              },
+              { queue, nowMs: currentNowMs },
+            );
+            await appendInboundMessage({
+              message: inboundMessage("m2", {
+                createdAtMs: 2_100,
+                receivedAtMs: 2_100,
+              }),
+              nowMs: 2_100,
+            });
+          }
+          return { status: "completed" };
+        },
+      }),
+    ).resolves.toEqual({ status: "completed" });
+
+    const state = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+    });
+    expect(runs).toBe(3);
+    expect(state?.lease).toBeUndefined();
+    expect(state?.needsRun).toBe(false);
+    expect(state?.messages).toEqual([]);
+    expect(queue.sentRecords()).toEqual([]);
+  });
+
+  it("resumes a paused turn before defer delivery after requeue", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    let currentNowMs = 1_000;
+    const attempts: string[][] = [];
+    await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
+
+    await expect(
+      processConversationWork(conversationQueueMessage(), {
+        nowMs: () => currentNowMs,
+        queue,
+        softYieldAfterMs: 1_000,
+        run: async (context) => {
+          attempts.push(
+            context.attempt.messages.map((message) => message.inboundMessageId),
+          );
+          await context.attempt.ack();
           currentNowMs = 2_000;
-          await requestConversationWork({
-            conversationId: context.conversationId,
-            destination: context.destination,
-            nowMs: currentNowMs,
-          });
           await scheduleAgentContinue(
             {
               conversationId: context.conversationId,
@@ -951,30 +1032,33 @@ describe("conversation work execution", () => {
           );
           await appendInboundMessage({
             message: inboundMessage("m2", {
-              createdAtMs: 2_100,
-              receivedAtMs: 2_100,
+              createdAtMs: 2_000,
+              delivery: "defer",
+              receivedAtMs: 2_000,
             }),
-            nowMs: 2_100,
+            nowMs: currentNowMs,
           });
+          return { status: "completed" };
+        },
+      }),
+    ).resolves.toEqual({ status: "yielded" });
+
+    currentNowMs = 3_000;
+    await expect(
+      processConversationWork(queue.takeMessage(), {
+        nowMs: () => currentNowMs,
+        queue,
+        run: async (context) => {
+          attempts.push(
+            context.attempt.messages.map((message) => message.inboundMessageId),
+          );
+          await context.attempt.ack();
           return { status: "completed" };
         },
       }),
     ).resolves.toEqual({ status: "completed" });
 
-    const state = await getConversationWorkState({
-      conversationId: CONVERSATION_ID,
-    });
-    expect(state?.lease).toBeUndefined();
-    expect(state?.needsRun).toBe(true);
-    expect(state?.messages.map((message) => message.inboundMessageId)).toEqual([
-      "m2",
-    ]);
-    expect(queue.sentRecords()).toEqual([
-      {
-        conversationId: CONVERSATION_ID,
-        idempotencyKey: `agent-continue:${CONVERSATION_ID}:turn-1:2:2000`,
-      },
-    ]);
+    expect(attempts).toEqual([["m1"], [], ["m2"]]);
   });
 
   it("uses fresh queue idempotency keys for repeated worker requeues", async () => {
@@ -992,24 +1076,17 @@ describe("conversation work execution", () => {
         processConversationWork(conversationQueueMessage(), {
           nowMs: () => currentNowMs,
           queue,
-          run: async (context) => {
-            await requestConversationWork({
-              conversationId: context.conversationId,
-              destination: context.destination,
-              nowMs: currentNowMs,
-            });
-            return { status: "completed" };
-          },
+          run: async () => ({ status: "yielded" }),
         }),
-      ).resolves.toEqual({ status: "pending_requeued" });
+      ).resolves.toEqual({ status: "yielded" });
     }
 
     await runSlice(2_000);
     await runSlice(63_000);
 
     expect(queue.sentRecords().map((send) => send.idempotencyKey)).toEqual([
-      `pending:${CONVERSATION_ID}:2000`,
-      `pending:${CONVERSATION_ID}:63000`,
+      `yield:${CONVERSATION_ID}:2000`,
+      `yield:${CONVERSATION_ID}:63000`,
     ]);
   });
 
@@ -1047,7 +1124,7 @@ describe("conversation work execution", () => {
     ]);
   });
 
-  it("does not send a second error nudge when a continuation wake already exists", async () => {
+  it("queues recovery when a resumed run fails", async () => {
     const queue = createConversationWorkQueueTestAdapter();
     let currentNowMs = 1_000;
     await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
@@ -1082,7 +1159,7 @@ describe("conversation work execution", () => {
     expect(queue.sentRecords()).toEqual([
       {
         conversationId: CONVERSATION_ID,
-        idempotencyKey: `agent-continue:${CONVERSATION_ID}:turn-1:2:2000`,
+        idempotencyKey: `error:${CONVERSATION_ID}:2000`,
       },
     ]);
   });
@@ -1236,6 +1313,7 @@ describe("conversation work execution", () => {
 
   it("keeps unacknowledged drained messages pending for a later slice", async () => {
     const queue = createConversationWorkQueueTestAdapter();
+    let currentNowMs = 1_000;
     await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
     await appendInboundMessage({
       message: inboundMessage("m2", {
@@ -1248,12 +1326,15 @@ describe("conversation work execution", () => {
 
     await expect(
       processConversationWork(conversationQueueMessage(), {
+        nowMs: () => currentNowMs,
         queue,
+        softYieldAfterMs: 1_000,
         run: async (context) => {
           await context.attempt.drain(async (messages) => {
             injected.push(messages.map((message) => message.inboundMessageId));
             return ["m1"];
           });
+          currentNowMs = 2_001;
           return { status: "completed" };
         },
       }),
@@ -1269,7 +1350,7 @@ describe("conversation work execution", () => {
     ]);
   });
 
-  it("drains interrupts while deferred messages stay queued", async () => {
+  it("drains interrupt delivery while defer delivery stays queued", async () => {
     const queue = createConversationWorkQueueTestAdapter();
     await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
     await appendInboundMessage({
@@ -1397,6 +1478,7 @@ describe("conversation work execution", () => {
 
   it("does not block new mailbox appends while injection is in progress", async () => {
     const queue = createConversationWorkQueueTestAdapter();
+    let currentNowMs = 1_000;
     const observed = observeConversationMutationLock({
       conversationId: CONVERSATION_ID,
       state: getStateAdapter(),
@@ -1411,7 +1493,9 @@ describe("conversation work execution", () => {
 
     await expect(
       processConversationWork(conversationQueueMessage(), {
+        nowMs: () => currentNowMs,
         queue,
+        softYieldAfterMs: 1_000,
         state: observed.state,
         run: async (context) => {
           const drain = context.attempt.drain(async () => {
@@ -1433,6 +1517,7 @@ describe("conversation work execution", () => {
           finishInjection.resolve();
           await drain;
           await append;
+          currentNowMs = 2_001;
           return { status: "completed" };
         },
       }),
@@ -1556,7 +1641,7 @@ describe("conversation work execution", () => {
     ]);
   });
 
-  it("keeps an expired injected-message lease runnable for continuation recovery", async () => {
+  it("prioritizes turn recovery after an execution lease expires", async () => {
     const queue = createConversationWorkQueueTestAdapter();
     await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
     const lease = await startConversationWork({
@@ -1580,6 +1665,13 @@ describe("conversation work execution", () => {
         queue,
       }),
     ).resolves.toEqual({ expiredLeaseCount: 1, pendingCount: 0 });
+    await expect(
+      getConversationWorkState({ conversationId: CONVERSATION_ID }),
+    ).resolves.toMatchObject({
+      execution: {
+        status: "awaiting_resume",
+      },
+    });
     await expect(
       processConversationWork(conversationQueueMessage(), {
         queue,
@@ -1796,6 +1888,7 @@ describe("conversation work execution", () => {
       processConversationWork(conversationQueueMessage(), {
         nowMs: () => currentNowMs,
         queue,
+        softYieldAfterMs: 1_000,
         run: async (context) => {
           await context.attempt.drain(async () => {});
           currentNowMs = 2_100;
@@ -1848,6 +1941,54 @@ describe("conversation work execution", () => {
         idempotencyKey: `yield:${CONVERSATION_ID}:242000`,
       },
     ]);
+  });
+
+  it("does not count unattempted interrupt delivery when soft yield fails", async () => {
+    const queue = createConversationWorkQueueTestAdapter();
+    let currentNowMs = 1_000;
+    await appendInboundMessage({ message: inboundMessage("m1"), nowMs: 1_000 });
+
+    await expect(
+      processConversationWork(conversationQueueMessage(), {
+        nowMs: () => currentNowMs,
+        queue,
+        softYieldAfterMs: 1_000,
+        run: async (context) => {
+          await context.attempt.ack();
+          await scheduleAgentContinue(
+            {
+              conversationId: context.conversationId,
+              destination: context.destination,
+              expectedVersion: 2,
+              sessionId: "turn-1",
+            },
+            { queue, nowMs: currentNowMs },
+          );
+          await appendInboundMessage({
+            message: inboundMessage("m2", {
+              createdAtMs: 2_000,
+              receivedAtMs: 2_000,
+            }),
+            nowMs: 2_000,
+          });
+          currentNowMs = 2_000;
+          queue.rejectSends();
+          return { status: "completed" };
+        },
+      }),
+    ).rejects.toThrow("queue unavailable");
+
+    const work = await getConversationWorkState({
+      conversationId: CONVERSATION_ID,
+    });
+    expect(work).toMatchObject({
+      messages: [
+        expect.objectContaining({
+          inboundMessageId: "m2",
+        }),
+      ],
+    });
+    expect(work?.messages[0]?.attemptCount).toBeUndefined();
   });
 
   it("keeps lease mutations token-bound", async () => {

--- a/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
+++ b/packages/junior/tests/component/task-execution/slack-conversation-work.test.ts
@@ -754,22 +754,11 @@ describe("Slack conversation work execution", () => {
         runtime,
         state,
       }),
-    ).resolves.toEqual({ status: "pending_requeued" });
+    ).resolves.toEqual({ status: "completed" });
 
-    expect(calls).toHaveLength(1);
+    expect(calls).toHaveLength(2);
     expect(calls[0]?.message.id).toBe("1712345.0001");
     expect(calls[0]?.skipped).toEqual([]);
-    expect(subscribedValues).toEqual([false]);
-
-    await expect(
-      processNextQueuedSlackWork({
-        getSlackAdapter: () => slackAdapter,
-        queue,
-        runtime,
-        state,
-      }),
-    ).resolves.toEqual({ status: "completed" });
-    expect(calls).toHaveLength(2);
     expect(calls[1]?.message.id).toBe("1712345.0002");
     expect(calls[1]?.skipped).toEqual([]);
     expect(subscribedValues).toEqual([false, true]);
@@ -832,13 +821,22 @@ describe("Slack conversation work execution", () => {
     expect(work ? countPendingConversationMessages(work) : 0).toBe(0);
   });
 
-  it("routes pending Slack follow-ups before awaiting continuations", async () => {
+  it("resumes a paused Slack turn after committing pending input", async () => {
     const queue = createConversationWorkQueueTestAdapter();
     const state = getStateAdapter();
     await state.connect();
     const slackAdapter = createSlackAdapterFixture();
-    const resumeAwaitingContinuation = vi.fn(async () => true);
     const calls: string[] = [];
+    const resumeAwaitingContinuation = vi.fn(
+      async (
+        _conversationId: string,
+        options: { shouldYield: () => boolean },
+      ) => {
+        expect(options.shouldYield()).toBe(false);
+        calls.push("resume");
+        return true;
+      },
+    );
 
     await handleSlackWebhookAndFlush({
       request: slackWebhookRequest(
@@ -867,6 +865,13 @@ describe("Slack conversation work execution", () => {
           handleNewMention: async (_thread, message, hooks) => {
             await hooks.ack?.();
             calls.push(message.text);
+            await requestConversationWork({
+              conversationId: CONVERSATION_ID,
+              destination: SLACK_DESTINATION,
+              nowMs: 3_500,
+              state,
+            });
+            calls.push("runtime returned");
           },
           handleSubscribedMessage: async () => {
             throw new Error("unexpected subscribed route");
@@ -876,8 +881,15 @@ describe("Slack conversation work execution", () => {
       }),
     ).resolves.toEqual({ status: "completed" });
 
-    expect(resumeAwaitingContinuation).not.toHaveBeenCalled();
-    expect(calls).toEqual([expect.stringContaining("follow-up")]);
+    expect(resumeAwaitingContinuation).toHaveBeenCalledOnce();
+    expect(resumeAwaitingContinuation).toHaveBeenCalledWith(CONVERSATION_ID, {
+      shouldYield: expect.any(Function),
+    });
+    expect(calls).toEqual([
+      expect.stringContaining("follow-up"),
+      "runtime returned",
+      "resume",
+    ]);
     expect(queue.sentRecords()).toEqual([]);
     const work = await getConversationWorkState({
       conversationId: CONVERSATION_ID,
@@ -962,6 +974,7 @@ describe("Slack conversation work execution", () => {
 
   it("leaves resource events deferred during an active turn", async () => {
     const queue = createConversationWorkQueueTestAdapter();
+    let currentNowMs = 1_000;
     const state = getStateAdapter();
     await state.connect();
     const slackAdapter = createSlackAdapterFixture();
@@ -1007,6 +1020,7 @@ describe("Slack conversation work execution", () => {
           observed.push(steering.map((candidate) => candidate.message.id));
           return steering.map((candidate) => candidate.inboundMessageId);
         });
+        currentNowMs = 2_001;
       },
       handleSubscribedMessage: async () => {
         throw new Error("resource event should remain queued for follow-up");
@@ -1016,8 +1030,10 @@ describe("Slack conversation work execution", () => {
     await expect(
       processNextQueuedSlackWork({
         getSlackAdapter: () => slackAdapter,
+        nowMs: () => currentNowMs,
         queue,
         runtime,
+        softYieldAfterMs: 1_000,
         state,
       }),
     ).resolves.toEqual({ status: "pending_requeued" });
@@ -1063,6 +1079,7 @@ describe("Slack conversation work execution", () => {
     });
 
     const observed: string[][] = [];
+    let currentNowMs = 1_000;
     const runtime: SlackWorkerOptions["runtime"] = {
       handleNewMention: async (_thread, _message, hooks) => {
         await hooks.ack?.();
@@ -1113,6 +1130,7 @@ describe("Slack conversation work execution", () => {
           observed.push(steering.map((candidate) => candidate.message.id));
           return steering.map((candidate) => candidate.inboundMessageId);
         });
+        currentNowMs = 2_001;
       },
       handleSubscribedMessage: async () => {
         throw new Error("unexpected subscribed route");
@@ -1122,8 +1140,10 @@ describe("Slack conversation work execution", () => {
     await expect(
       processNextQueuedSlackWork({
         getSlackAdapter: () => slackAdapter,
+        nowMs: () => currentNowMs,
         queue,
         runtime,
+        softYieldAfterMs: 1_000,
         state,
       }),
     ).resolves.toEqual({ status: "pending_requeued" });

--- a/packages/junior/tests/integration/agent-continue-slack.test.ts
+++ b/packages/junior/tests/integration/agent-continue-slack.test.ts
@@ -1284,6 +1284,7 @@ describe("agent continuation Slack integration", () => {
       },
     });
 
+    const shouldYield = vi.fn(() => false);
     const resumed = await requestDeadlineModule.runWithTurnRequestDeadline(() =>
       agentContinueRunnerModule.resumeAwaitingSlackContinuation(
         conversationId,
@@ -1294,6 +1295,7 @@ describe("agent continuation Slack integration", () => {
               queue,
             }),
         },
+        { shouldYield },
       ),
     );
 
@@ -1304,6 +1306,7 @@ describe("agent continuation Slack integration", () => {
         routing: expect.objectContaining({
           destination: SLACK_DESTINATION,
         }),
+        durability: expect.objectContaining({ shouldYield }),
       }),
     );
     // Exactly one visible reply for the interrupted request.

--- a/packages/junior/tests/integration/slack/bot-handlers.test.ts
+++ b/packages/junior/tests/integration/slack/bot-handlers.test.ts
@@ -1328,12 +1328,12 @@ describe("bot handlers (integration)", () => {
     expect(conversation?.processing?.activeTurnId).toBeUndefined();
   });
 
-  it("appends a parked-conversation follow-up to the event log before consuming it", async () => {
+  it("commits follow-up input before requesting a turn resume", async () => {
     const conversationId = "slack:C9PARKEDLOG:1700000000.000";
     const destination = slackDestination("C9PARKEDLOG");
     const activeSessionId = "turn_msg-original";
     const storedSource = createSlackSourceForTest("C9PARKEDLOG");
-    const parkedRecord = await upsertAgentTurnSessionRecord({
+    await upsertAgentTurnSessionRecord({
       modelId: "test/model",
       conversationId,
       sessionId: activeSessionId,
@@ -1345,14 +1345,17 @@ describe("bot handlers (integration)", () => {
       piMessages: turnPiMessages("please keep working"),
       turnStartMessageIndex: 0,
     });
-    const projectionAtScheduleTime: string[] = [];
+    const order: string[] = [];
     const scheduleAgentContinue = vi.fn(async () => {
-      projectionAtScheduleTime.push(
+      expect(
         JSON.stringify(await loadProjection({ conversationId })),
-      );
+      ).toContain("also check the logs");
+      order.push("schedule");
+    });
+    const ack = vi.fn(async () => {
+      order.push("ack");
     });
     const executeAgentRun = vi.fn();
-    const ack = vi.fn();
     const { slackRuntime } = createRuntime({
       services: {
         replyExecutor: {
@@ -1381,15 +1384,11 @@ describe("bot handlers (integration)", () => {
     expect(executeAgentRun).not.toHaveBeenCalled();
     expect(thread.posts).toEqual([]);
     expect(ack).toHaveBeenCalledOnce();
-    expect(scheduleAgentContinue).toHaveBeenCalledWith({
-      conversationId,
-      destination,
-      sessionId: activeSessionId,
-      // The append is a log-only write: the resume request stays valid.
-      expectedVersion: parkedRecord.version,
-    });
-    // The durable append happened before the continuation was scheduled.
-    expect(projectionAtScheduleTime[0]).toContain("also check the logs");
+    expect(order).toEqual(["schedule", "ack"]);
+    expect(scheduleAgentContinue).toHaveBeenCalledOnce();
+    expect(JSON.stringify(await loadProjection({ conversationId }))).toContain(
+      "also check the logs",
+    );
 
     // The resumed continue() replays the record's Pi history, which must now
     // end with the follow-up at a continuable user boundary.

--- a/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/conversation-turn-steering-behavior.test.ts
@@ -241,7 +241,7 @@ describe("Slack behavior: durable turn steering", () => {
     expect(work ? countPendingConversationMessages(work) : 0).toBe(1);
   });
 
-  it("interrupts explicit follow-ups and queues deferred follow-ups", async () => {
+  it("steers with explicit mentions and then processes follow-up messages", async () => {
     const agentEntered = deferred();
     const releaseAgent = deferred();
     let blockingCallReleased = false;
@@ -357,18 +357,6 @@ describe("Slack behavior: durable turn steering", () => {
         conversationId,
         idempotencyKey: `slack:T123:${conversationId}:${THREAD_TS}`,
       }),
-      expect.objectContaining({
-        conversationId,
-        idempotencyKey: `slack:T123:${conversationId}:1712345.000200`,
-      }),
-    ]);
-
-    expect(agentCalls).toEqual([
-      {
-        context: undefined,
-        prompt: "start the incident summary",
-        steeringTexts: ["include the rollback owner"],
-      },
     ]);
 
     // The steered follow-up keeps its own Slack author as an instruction,
@@ -384,23 +372,13 @@ describe("Slack behavior: durable turn steering", () => {
       },
     ]);
 
-    const postCalls = slackApiOutbox.messages();
-    expect(postCalls).toHaveLength(1);
-    expect(postCalls[0]?.params).toEqual(
-      expect.objectContaining({
-        channel: CHANNEL_ID,
-        thread_ts: THREAD_TS,
-        text: expect.stringContaining("Steered: include the rollback owner"),
-      }),
-    );
-
     const queuedResults: string[] = [];
     while (queue.hasQueuedMessages()) {
       queuedResults.push((await runNextQueuedWork()).status);
     }
     expect(
       queuedResults.filter((status) => status === "completed"),
-    ).toHaveLength(1);
+    ).toHaveLength(0);
 
     expect(agentCalls).toEqual([
       {
@@ -526,7 +504,7 @@ describe("Slack behavior: durable turn steering", () => {
     expect(replyCalls).toEqual(["start the incident summary"]);
   });
 
-  it("applies queued opt-out decisions on the next turn", async () => {
+  it("applies follow-up opt-out decisions after the active turn", async () => {
     const agentEntered = deferred();
     const releaseAgent = deferred();
     const drainedTexts: string[] = [];
@@ -626,7 +604,7 @@ describe("Slack behavior: durable turn steering", () => {
 
     releaseAgent.resolve();
     await expect(activeTurn).resolves.toEqual({ status: "completed" });
-    expect(await state.isSubscribed(conversationId)).toBe(true);
+    expect(await state.isSubscribed(conversationId)).toBe(false);
     while (queue.hasQueuedMessages()) {
       await runNextQueuedWork();
     }


### PR DESCRIPTION
When Junior receives another Slack message for paused work, it now saves the
message and continues the work in the same worker.

Previously, Junior saved the message, asked the queue to wake the conversation
again, and ended the current worker. That created an extra serverless request
before the work could continue.

This removes that extra hop without changing how Slack messages are saved or
how replies are delivered. Code outside the conversation worker keeps the old
queue fallback.

Refs #876
