### PR TITLE
fix(agent): Stop resource watches when users ask

### DIFF
--- a/packages/junior-evals/evals/agent/subscriptions.eval.ts
+++ b/packages/junior-evals/evals/agent/subscriptions.eval.ts
@@ -60,6 +60,12 @@ describeEval("Resource Event Subscriptions", slackEvals, (it) => {
               "state.closed_unmerged",
             ]),
           }),
+          result: expect.objectContaining({
+            stop_watching: {
+              tool_name: "stopWatchingResources",
+              arguments: {},
+            },
+          }),
         }),
       ]),
     );

--- a/packages/junior-evals/evals/agent/subscriptions.eval.ts
+++ b/packages/junior-evals/evals/agent/subscriptions.eval.ts
@@ -68,6 +68,49 @@ describeEval("Resource Event Subscriptions", slackEvals, (it) => {
     );
   });
 
+  it("when a follow-up stops monitoring, cancel the conversation's subscriptions before confirming", async ({
+    run,
+  }) => {
+    const thread = {
+      id: "thread-resource-event-stop",
+      channel_id: "CRESOURCEEVENTSTOP",
+      thread_ts: "17000000.7301",
+    };
+    const result = await run({
+      overrides: {
+        plugin_dirs: ["fixtures/resource-event-plugins"],
+      },
+      initialEvents: [
+        mention(
+          "/eval-resource-events Create a pull request titled 'Stop resource monitoring', watch its checks and review feedback, and keep me posted here.",
+          { thread },
+        ),
+      ],
+      events: [mention("stop", { thread })],
+      criteria: rubric({
+        pass: [
+          "Junior understands from the conversation that the terse follow-up asks it to stop monitoring the pull request.",
+          "Junior briefly confirms that monitoring stopped.",
+        ],
+        fail: [
+          "Do not require the user to repeat a special unsubscribe phrase.",
+          "Do not ask which resource the user meant when the active monitoring target is clear from the conversation.",
+        ],
+      }),
+    });
+
+    expect(toolCalls(result.session)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "subscribeToResourceEvents",
+        }),
+        expect.objectContaining({
+          name: "stopWatchingResources",
+        }),
+      ]),
+    );
+  });
+
   it("when a subscribed PR check fails, summarize the failure and suggest next steps", async ({
     run,
   }) => {

--- a/packages/junior-evals/evals/agent/subscriptions.eval.ts
+++ b/packages/junior-evals/evals/agent/subscriptions.eval.ts
@@ -62,8 +62,11 @@ describeEval("Resource Event Subscriptions", slackEvals, (it) => {
           }),
           result: expect.objectContaining({
             stop_watching: {
-              tool_name: "stopWatchingResources",
-              arguments: {},
+              execution_tool: "executeTool",
+              execution_example: {
+                tool_name: "stopWatchingResources",
+                arguments: {},
+              },
             },
           }),
         }),

--- a/packages/junior/src/chat/resource-events/README.md
+++ b/packages/junior/src/chat/resource-events/README.md
@@ -9,6 +9,8 @@ conversation.
   operation.
 - Core owns subscription creation, cancellation, expiry, deduplication, and the
   conversation association.
+- A successful subscription result identifies the no-argument action that stops
+  every resource watch for the conversation.
 - A thread opt-out cancels every active subscription for that conversation
   before the Slack thread is marked unsubscribed.
 - Provider route code validates and normalizes incoming events before calling

--- a/packages/junior/src/chat/resource-events/README.md
+++ b/packages/junior/src/chat/resource-events/README.md
@@ -9,7 +9,8 @@ conversation.
   operation.
 - Core owns subscription creation, cancellation, expiry, deduplication, and the
   conversation association.
-- A successful subscription result identifies the no-argument action that stops
+- Inspection and stop actions stay in the tool catalog. A successful
+  subscription result identifies the exact no-argument catalog call that stops
   every resource watch for the conversation.
 - A thread opt-out cancels every active subscription for that conversation
   before the Slack thread is marked unsubscribed.

--- a/packages/junior/src/chat/tools/execute-tool.ts
+++ b/packages/junior/src/chat/tools/execute-tool.ts
@@ -9,14 +9,16 @@ export const EXECUTE_TOOL_NAME = "executeTool";
 export function createExecuteToolTool() {
   return zodTool({
     description:
-      "Execute any catalog tool by exact tool_name from searchTools. Put tool-specific parameters inside arguments.",
+      "Execute any catalog tool by exact tool_name from searchTools or a tool-result execution hint. Put tool-specific parameters inside arguments.",
     executionMode: "sequential",
     inputSchema: z
       .object({
         tool_name: z
           .string()
           .min(1)
-          .describe("Exact catalog tool_name returned by searchTools."),
+          .describe(
+            "Exact catalog tool_name returned by searchTools or a tool-result execution hint.",
+          ),
         arguments: z
           .record(z.string(), z.unknown())
           .describe(

--- a/packages/junior/src/chat/tools/index.ts
+++ b/packages/junior/src/chat/tools/index.ts
@@ -13,12 +13,7 @@ import { createLoadSkillTool } from "@/chat/tools/skill/load-skill";
 import { createSearchMcpToolsTool } from "@/chat/tools/skill/search-mcp-tools";
 import { createReadFileTool } from "@/chat/tools/sandbox/read-file";
 import { createReportProgressTool } from "@/chat/tools/runtime/report-progress";
-import {
-  canUseResourceEventSubscriptionTools,
-  createListResourceEventSubscriptionsTool,
-  createStopWatchingResourcesTool,
-  createSubscribeToResourceEventsTool,
-} from "@/chat/tools/resource-events";
+import { createResourceEventTools } from "@/chat/tools/resource-events";
 import { createSlackChannelListMessagesTool } from "@/chat/slack/tools/channel-list-messages";
 import { createSlackConversationSearchTool } from "@/chat/slack/tools/conversation-search";
 import { createSlackPublicSearchTool } from "@/chat/slack/tools/public-search";
@@ -120,6 +115,7 @@ export function createTools(
     webFetch: createWebFetchTool(hooks, {
       canSendFilesToActiveConversation,
     }),
+    ...createResourceEventTools(context),
   };
   if (hooks.writeGeneratedArtifacts) {
     tools.imageGenerate = createImageGenerateTool(
@@ -136,14 +132,6 @@ export function createTools(
 
   if (context.handoff) {
     tools.handoff = createHandoffTool(context.handoff);
-  }
-
-  if (canUseResourceEventSubscriptionTools(context)) {
-    tools.subscribeToResourceEvents =
-      createSubscribeToResourceEventsTool(context);
-    tools.listResourceEventSubscriptions =
-      createListResourceEventSubscriptionsTool(context);
-    tools.stopWatchingResources = createStopWatchingResourcesTool(context);
   }
 
   if (context.mcpToolManager) {

--- a/packages/junior/src/chat/tools/index.ts
+++ b/packages/junior/src/chat/tools/index.ts
@@ -15,8 +15,8 @@ import { createReadFileTool } from "@/chat/tools/sandbox/read-file";
 import { createReportProgressTool } from "@/chat/tools/runtime/report-progress";
 import {
   canUseResourceEventSubscriptionTools,
-  createCancelResourceEventSubscriptionTool,
   createListResourceEventSubscriptionsTool,
+  createStopWatchingResourcesTool,
   createSubscribeToResourceEventsTool,
 } from "@/chat/tools/resource-events";
 import { createSlackChannelListMessagesTool } from "@/chat/slack/tools/channel-list-messages";
@@ -143,8 +143,7 @@ export function createTools(
       createSubscribeToResourceEventsTool(context);
     tools.listResourceEventSubscriptions =
       createListResourceEventSubscriptionsTool(context);
-    tools.cancelResourceEventSubscription =
-      createCancelResourceEventSubscriptionTool(context);
+    tools.stopWatchingResources = createStopWatchingResourcesTool(context);
   }
 
   if (context.mcpToolManager) {

--- a/packages/junior/src/chat/tools/resource-events.ts
+++ b/packages/junior/src/chat/tools/resource-events.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { juniorToolResultSchema } from "@/chat/tool-support/structured-result";
 import { zodTool } from "@/chat/tool-support/zod-tool";
+import type { ToolRegistry } from "@/chat/tools/definition";
 import type { ToolRuntimeContext } from "@/chat/tools/types";
 import {
   cancelResourceEventSubscription,
@@ -72,7 +73,7 @@ function requireConversationContext(context: ToolRuntimeContext): string {
 }
 
 /** Return whether the current runtime can safely manage conversation subscriptions. */
-export function canUseResourceEventSubscriptionTools(
+function canUseResourceEventSubscriptionTools(
   context: ToolRuntimeContext,
 ): boolean {
   return (
@@ -109,9 +110,7 @@ function ttlMs(input: SubscribeInput): number {
 }
 
 /** Create the tool that subscribes the current conversation to resource events. */
-export function createSubscribeToResourceEventsTool(
-  context: ToolRuntimeContext,
-) {
+function createSubscribeToResourceEventsTool(context: ToolRuntimeContext) {
   return zodTool({
     description:
       "Subscribe the current conversation to high-signal events for a resource returned by a subscribable tool result. Matching events are queued as normal conversation messages; they do not interrupt active work.",
@@ -154,9 +153,7 @@ export function createSubscribeToResourceEventsTool(
 }
 
 /** Create the tool that lists active resource subscriptions for this conversation. */
-export function createListResourceEventSubscriptionsTool(
-  context: ToolRuntimeContext,
-) {
+function createListResourceEventSubscriptionsTool(context: ToolRuntimeContext) {
   return zodTool({
     description:
       "List active resource event subscriptions for the current conversation.",
@@ -190,7 +187,7 @@ export function createListResourceEventSubscriptionsTool(
 }
 
 /** Create the tool that stops resource watches for this conversation. */
-export function createStopWatchingResourcesTool(context: ToolRuntimeContext) {
+function createStopWatchingResourcesTool(context: ToolRuntimeContext) {
   return zodTool({
     description:
       "Stop watching resources for the current conversation. Infer the user's intent from context instead of requiring a special command. Pass resource refs when they identify specific watches; omit them only when they mean all active watches or one watch is unambiguous. Call this tool before confirming that watching stopped.",
@@ -247,4 +244,20 @@ export function createStopWatchingResourcesTool(context: ToolRuntimeContext) {
       };
     },
   });
+}
+
+/** Build the complete resource-watch tool set allowed by this runtime context. */
+export function createResourceEventTools(
+  context: ToolRuntimeContext,
+): ToolRegistry {
+  if (!canUseResourceEventSubscriptionTools(context)) {
+    return {};
+  }
+
+  return {
+    subscribeToResourceEvents: createSubscribeToResourceEventsTool(context),
+    listResourceEventSubscriptions:
+      createListResourceEventSubscriptionsTool(context),
+    stopWatchingResources: createStopWatchingResourcesTool(context),
+  };
 }

--- a/packages/junior/src/chat/tools/resource-events.ts
+++ b/packages/junior/src/chat/tools/resource-events.ts
@@ -41,16 +41,18 @@ const subscribeInputSchema = z.object({
     .optional(),
 });
 
-const cancelInputSchema = z.object({
-  subscriptionId: z
-    .string()
+const stopWatchingInputSchema = z.object({
+  resourceRefs: z
+    .array(z.string())
+    .min(1)
+    .optional()
     .describe(
-      "Subscription id returned by subscribeToResourceEvents or listResourceEventSubscriptions.",
+      "Resource refs to stop watching when the user identifies specific resources. Omit only when they want every active watch stopped or the conversation has one unambiguous watch.",
     ),
 });
 
 type SubscribeInput = z.output<typeof subscribeInputSchema>;
-type CancelInput = z.output<typeof cancelInputSchema>;
+type StopWatchingInput = z.output<typeof stopWatchingInputSchema>;
 
 function requireConversationContext(context: ToolRuntimeContext): string {
   if (!context.conversationId) {
@@ -187,27 +189,55 @@ export function createListResourceEventSubscriptionsTool(
   });
 }
 
-/** Create the tool that cancels a current-conversation resource subscription. */
-export function createCancelResourceEventSubscriptionTool(
-  context: ToolRuntimeContext,
-) {
+/** Create the tool that stops resource watches for this conversation. */
+export function createStopWatchingResourcesTool(context: ToolRuntimeContext) {
   return zodTool({
     description:
-      "Cancel a resource event subscription for the current conversation.",
-    inputSchema: cancelInputSchema,
+      "Stop watching resources for the current conversation. Infer the user's intent from context instead of requiring a special command. Pass resource refs when they identify specific watches; omit them only when they mean all active watches or one watch is unambiguous. Call this tool before confirming that watching stopped.",
+    inputSchema: stopWatchingInputSchema,
     outputSchema: juniorToolResultSchema,
-    async execute(input: CancelInput) {
+    async execute(input: StopWatchingInput) {
       const conversationId = requireConversationContext(context);
-      const subscription = await cancelResourceEventSubscription({
+      const subscriptions = await listResourceEventSubscriptions({
         conversationId,
-        id: input.subscriptionId,
       });
-      if (!subscription) {
-        throw new Error("Resource event subscription was not found");
+      const requestedRefs = input.resourceRefs
+        ? new Set(cleanStrings(input.resourceRefs))
+        : undefined;
+      const targets = requestedRefs
+        ? subscriptions.filter((subscription) =>
+            requestedRefs.has(subscription.resourceRef),
+          )
+        : subscriptions;
+      const matchedRefs = new Set(
+        targets.map((subscription) => subscription.resourceRef),
+      );
+      const missingRefs = requestedRefs
+        ? [...requestedRefs].filter(
+            (resourceRef) => !matchedRefs.has(resourceRef),
+          )
+        : [];
+      if (missingRefs.length > 0) {
+        throw new Error(
+          `No active resource watches matched: ${missingRefs.join(", ")}`,
+        );
       }
+      await Promise.all(
+        targets.map((subscription) =>
+          cancelResourceEventSubscription({
+            conversationId,
+            id: subscription.id,
+          }),
+        ),
+      );
       const details = {
-        id: subscription.id,
-        subscription_status: subscription.status,
+        stopped_count: targets.length,
+        subscriptions: targets.map((subscription) => ({
+          id: subscription.id,
+          label: subscription.label,
+          resourceRef: subscription.resourceRef,
+          subscription_status: "cancelled" as const,
+        })),
       };
       return {
         ok: true,

--- a/packages/junior/src/chat/tools/resource-events.ts
+++ b/packages/junior/src/chat/tools/resource-events.ts
@@ -12,6 +12,10 @@ import {
 const DEFAULT_TTL_MS = 14 * 24 * 60 * 60 * 1000;
 const MAX_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const STOP_WATCHING_TOOL_NAME = "stopWatchingResources";
+const RESOURCE_WATCH_TOOL_SOURCE = {
+  id: "resource-watches",
+  description: "Inspect or stop resource watches for the current conversation.",
+};
 
 const subscribeInputSchema = z.object({
   resourceRef: z
@@ -132,8 +136,11 @@ function createSubscribeToResourceEventsTool(context: ToolRuntimeContext) {
         events: subscription.events,
         expiresAtMs: subscription.expiresAtMs,
         stop_watching: {
-          tool_name: STOP_WATCHING_TOOL_NAME,
-          arguments: {},
+          execution_tool: "executeTool",
+          execution_example: {
+            tool_name: STOP_WATCHING_TOOL_NAME,
+            arguments: {},
+          },
         },
       };
       return {
@@ -151,6 +158,8 @@ function createListResourceEventSubscriptionsTool(context: ToolRuntimeContext) {
   return zodTool({
     description:
       "List active resource event subscriptions for the current conversation.",
+    exposure: "deferred",
+    source: RESOURCE_WATCH_TOOL_SOURCE,
     inputSchema: z.object({}),
     outputSchema: juniorToolResultSchema,
     async execute() {
@@ -185,6 +194,8 @@ function createStopWatchingResourcesTool(context: ToolRuntimeContext) {
   return zodTool({
     description:
       "Stop every resource watch for the current conversation. Infer the user's intent from context instead of requiring a special command, and call this tool before confirming that watching stopped.",
+    exposure: "deferred",
+    source: RESOURCE_WATCH_TOOL_SOURCE,
     inputSchema: z.object({}),
     outputSchema: juniorToolResultSchema,
     async execute() {

--- a/packages/junior/src/chat/tools/resource-events.ts
+++ b/packages/junior/src/chat/tools/resource-events.ts
@@ -4,13 +4,14 @@ import { zodTool } from "@/chat/tool-support/zod-tool";
 import type { ToolRegistry } from "@/chat/tools/definition";
 import type { ToolRuntimeContext } from "@/chat/tools/types";
 import {
-  cancelResourceEventSubscription,
+  cancelSubscriptions,
   createResourceEventSubscription,
   listResourceEventSubscriptions,
 } from "@/chat/resource-events/store";
 
 const DEFAULT_TTL_MS = 14 * 24 * 60 * 60 * 1000;
 const MAX_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const STOP_WATCHING_TOOL_NAME = "stopWatchingResources";
 
 const subscribeInputSchema = z.object({
   resourceRef: z
@@ -42,18 +43,7 @@ const subscribeInputSchema = z.object({
     .optional(),
 });
 
-const stopWatchingInputSchema = z.object({
-  resourceRefs: z
-    .array(z.string())
-    .min(1)
-    .optional()
-    .describe(
-      "Resource refs to stop watching when the user identifies specific resources. Omit only when they want every active watch stopped or the conversation has one unambiguous watch.",
-    ),
-});
-
 type SubscribeInput = z.output<typeof subscribeInputSchema>;
-type StopWatchingInput = z.output<typeof stopWatchingInputSchema>;
 
 function requireConversationContext(context: ToolRuntimeContext): string {
   if (!context.conversationId) {
@@ -141,6 +131,10 @@ function createSubscribeToResourceEventsTool(context: ToolRuntimeContext) {
         resourceRef: subscription.resourceRef,
         events: subscription.events,
         expiresAtMs: subscription.expiresAtMs,
+        stop_watching: {
+          tool_name: STOP_WATCHING_TOOL_NAME,
+          arguments: {},
+        },
       };
       return {
         ok: true,
@@ -190,51 +184,14 @@ function createListResourceEventSubscriptionsTool(context: ToolRuntimeContext) {
 function createStopWatchingResourcesTool(context: ToolRuntimeContext) {
   return zodTool({
     description:
-      "Stop watching resources for the current conversation. Infer the user's intent from context instead of requiring a special command. Pass resource refs when they identify specific watches; omit them only when they mean all active watches or one watch is unambiguous. Call this tool before confirming that watching stopped.",
-    inputSchema: stopWatchingInputSchema,
+      "Stop every resource watch for the current conversation. Infer the user's intent from context instead of requiring a special command, and call this tool before confirming that watching stopped.",
+    inputSchema: z.object({}),
     outputSchema: juniorToolResultSchema,
-    async execute(input: StopWatchingInput) {
+    async execute() {
       const conversationId = requireConversationContext(context);
-      const subscriptions = await listResourceEventSubscriptions({
-        conversationId,
-      });
-      const requestedRefs = input.resourceRefs
-        ? new Set(cleanStrings(input.resourceRefs))
-        : undefined;
-      const targets = requestedRefs
-        ? subscriptions.filter((subscription) =>
-            requestedRefs.has(subscription.resourceRef),
-          )
-        : subscriptions;
-      const matchedRefs = new Set(
-        targets.map((subscription) => subscription.resourceRef),
-      );
-      const missingRefs = requestedRefs
-        ? [...requestedRefs].filter(
-            (resourceRef) => !matchedRefs.has(resourceRef),
-          )
-        : [];
-      if (missingRefs.length > 0) {
-        throw new Error(
-          `No active resource watches matched: ${missingRefs.join(", ")}`,
-        );
-      }
-      await Promise.all(
-        targets.map((subscription) =>
-          cancelResourceEventSubscription({
-            conversationId,
-            id: subscription.id,
-          }),
-        ),
-      );
+      await cancelSubscriptions({ conversationId });
       const details = {
-        stopped_count: targets.length,
-        subscriptions: targets.map((subscription) => ({
-          id: subscription.id,
-          label: subscription.label,
-          resourceRef: subscription.resourceRef,
-          subscription_status: "cancelled" as const,
-        })),
+        watching_status: "stopped",
       };
       return {
         ok: true,
@@ -258,6 +215,6 @@ export function createResourceEventTools(
     subscribeToResourceEvents: createSubscribeToResourceEventsTool(context),
     listResourceEventSubscriptions:
       createListResourceEventSubscriptionsTool(context),
-    stopWatchingResources: createStopWatchingResourcesTool(context),
+    [STOP_WATCHING_TOOL_NAME]: createStopWatchingResourcesTool(context),
   };
 }

--- a/packages/junior/tests/unit/slack/tool-registration.test.ts
+++ b/packages/junior/tests/unit/slack/tool-registration.test.ts
@@ -99,6 +99,7 @@ describe("Slack tool registration", () => {
     expect(tools).toHaveProperty("addReaction");
     expect(tools).toHaveProperty("slackCanvasCreate");
     expect(tools).toHaveProperty("searchConversationHistory");
+    expect(tools).toHaveProperty("stopWatchingResources");
     expect(tools.searchConversationHistory?.exposure).toBe("deferred");
     expect(tools.searchConversationHistory?.source?.id).toBe(
       "conversation-history",
@@ -236,6 +237,7 @@ describe("Slack tool registration", () => {
       Object.keys(tools).filter((name) => name.startsWith("slack")),
     ).toEqual([]);
     expect(tools).not.toHaveProperty("attachFile");
+    expect(tools).not.toHaveProperty("stopWatchingResources");
   });
 
   it("registers image generation only when artifact persistence is available", () => {

--- a/packages/junior/tests/unit/slack/tool-registration.test.ts
+++ b/packages/junior/tests/unit/slack/tool-registration.test.ts
@@ -100,10 +100,13 @@ describe("Slack tool registration", () => {
     expect(tools).toHaveProperty("slackCanvasCreate");
     expect(tools).toHaveProperty("searchConversationHistory");
     expect(tools).toHaveProperty("stopWatchingResources");
+    expect(tools).toHaveProperty("listResourceEventSubscriptions");
     expect(tools.searchConversationHistory?.exposure).toBe("deferred");
     expect(tools.searchConversationHistory?.source?.id).toBe(
       "conversation-history",
     );
+    expect(tools.stopWatchingResources?.exposure).toBe("deferred");
+    expect(tools.listResourceEventSubscriptions?.exposure).toBe("deferred");
   });
 
   it("does not register public search without an action token", () => {

--- a/packages/junior/tests/unit/tools/resource-events.test.ts
+++ b/packages/junior/tests/unit/tools/resource-events.test.ts
@@ -1,0 +1,105 @@
+import { createSlackSource } from "@sentry/junior-plugin-api";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ToolRuntimeContext } from "@/chat/tools/types";
+
+const { cancelSubscription, listSubscriptions } = vi.hoisted(() => ({
+  cancelSubscription: vi.fn(),
+  listSubscriptions: vi.fn(),
+}));
+
+vi.mock("@/chat/resource-events/store", () => ({
+  cancelResourceEventSubscription: cancelSubscription,
+  createResourceEventSubscription: vi.fn(),
+  listResourceEventSubscriptions: listSubscriptions,
+}));
+
+import { createStopWatchingResourcesTool } from "@/chat/tools/resource-events";
+
+const context: ToolRuntimeContext = {
+  conversationId: "slack:C123:1712345.0001",
+  destination: {
+    platform: "slack",
+    teamId: "T123",
+    channelId: "C123",
+  },
+  source: createSlackSource({
+    teamId: "T123",
+    channelId: "C123",
+    threadTs: "1712345.0001",
+    type: "pub",
+  }),
+  egress: {
+    async fetch() {
+      return new Response("ok");
+    },
+  },
+  workspace: {} as ToolRuntimeContext["workspace"],
+};
+
+const subscriptions = [
+  {
+    id: "subscription-1",
+    label: "GitHub PR #1",
+    resourceRef: "github:pull_request:getsentry/junior#1",
+  },
+  {
+    id: "subscription-2",
+    label: "GitHub PR #2",
+    resourceRef: "github:pull_request:getsentry/junior#2",
+  },
+];
+
+describe("resource event tools", () => {
+  beforeEach(() => {
+    cancelSubscription.mockReset();
+    cancelSubscription.mockImplementation(async ({ id }) => ({
+      id,
+      status: "cancelled",
+    }));
+    listSubscriptions.mockReset();
+    listSubscriptions.mockResolvedValue(subscriptions);
+  });
+
+  it("stops only the resource watches selected from conversation context", async () => {
+    const tool = createStopWatchingResourcesTool(context);
+
+    await expect(
+      tool.execute!(
+        {
+          resourceRefs: ["github:pull_request:getsentry/junior#2"],
+        },
+        {},
+      ),
+    ).resolves.toMatchObject({
+      stopped_count: 1,
+      subscriptions: [
+        {
+          id: "subscription-2",
+          resourceRef: "github:pull_request:getsentry/junior#2",
+          subscription_status: "cancelled",
+        },
+      ],
+    });
+    expect(cancelSubscription).toHaveBeenCalledTimes(1);
+    expect(cancelSubscription).toHaveBeenCalledWith({
+      conversationId: "slack:C123:1712345.0001",
+      id: "subscription-2",
+    });
+  });
+
+  it("does not stop other watches when a requested resource is not active", async () => {
+    const tool = createStopWatchingResourcesTool(context);
+
+    await expect(
+      tool.execute!(
+        {
+          resourceRefs: ["github:pull_request:getsentry/junior#404"],
+        },
+        {},
+      ),
+    ).rejects.toThrow(
+      "No active resource watches matched: github:pull_request:getsentry/junior#404",
+    );
+    expect(cancelSubscription).not.toHaveBeenCalled();
+  });
+});

--- a/packages/junior/tests/unit/tools/resource-events.test.ts
+++ b/packages/junior/tests/unit/tools/resource-events.test.ts
@@ -1,5 +1,6 @@
 import { createSlackSource } from "@sentry/junior-plugin-api";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { planToolExposure } from "@/chat/tool-exposure";
 import type { ToolRuntimeContext } from "@/chat/tools/types";
 
 const { cancelSubscriptions, createSubscription, listSubscriptions } =
@@ -85,9 +86,29 @@ describe("resource event tools", () => {
     ).resolves.toMatchObject({
       subscription_status: "active",
       stop_watching: {
-        tool_name: "stopWatchingResources",
-        arguments: {},
+        execution_tool: "executeTool",
+        execution_example: {
+          tool_name: "stopWatchingResources",
+          arguments: {},
+        },
       },
+    });
+  });
+
+  it("keeps inspection and stopping in the resource-watch catalog", () => {
+    const tools = createResourceEventTools(context);
+    const exposure = planToolExposure(tools);
+
+    expect(exposure.directTools).toHaveProperty("subscribeToResourceEvents");
+    expect(exposure.directTools).not.toHaveProperty(
+      "listResourceEventSubscriptions",
+    );
+    expect(exposure.directTools).not.toHaveProperty("stopWatchingResources");
+    expect(exposure.catalogTools).toHaveProperty(
+      "listResourceEventSubscriptions",
+    );
+    expect(exposure.catalogTools.stopWatchingResources).toMatchObject({
+      source: { id: "resource-watches" },
     });
   });
 

--- a/packages/junior/tests/unit/tools/resource-events.test.ts
+++ b/packages/junior/tests/unit/tools/resource-events.test.ts
@@ -13,7 +13,7 @@ vi.mock("@/chat/resource-events/store", () => ({
   listResourceEventSubscriptions: listSubscriptions,
 }));
 
-import { createStopWatchingResourcesTool } from "@/chat/tools/resource-events";
+import { createResourceEventTools } from "@/chat/tools/resource-events";
 
 const context: ToolRuntimeContext = {
   conversationId: "slack:C123:1712345.0001",
@@ -61,7 +61,7 @@ describe("resource event tools", () => {
   });
 
   it("stops only the resource watches selected from conversation context", async () => {
-    const tool = createStopWatchingResourcesTool(context);
+    const tool = createResourceEventTools(context).stopWatchingResources!;
 
     await expect(
       tool.execute!(
@@ -88,7 +88,7 @@ describe("resource event tools", () => {
   });
 
   it("does not stop other watches when a requested resource is not active", async () => {
-    const tool = createStopWatchingResourcesTool(context);
+    const tool = createResourceEventTools(context).stopWatchingResources!;
 
     await expect(
       tool.execute!(

--- a/packages/junior/tests/unit/tools/resource-events.test.ts
+++ b/packages/junior/tests/unit/tools/resource-events.test.ts
@@ -2,14 +2,16 @@ import { createSlackSource } from "@sentry/junior-plugin-api";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ToolRuntimeContext } from "@/chat/tools/types";
 
-const { cancelSubscription, listSubscriptions } = vi.hoisted(() => ({
-  cancelSubscription: vi.fn(),
-  listSubscriptions: vi.fn(),
-}));
+const { cancelSubscriptions, createSubscription, listSubscriptions } =
+  vi.hoisted(() => ({
+    cancelSubscriptions: vi.fn(),
+    createSubscription: vi.fn(),
+    listSubscriptions: vi.fn(),
+  }));
 
 vi.mock("@/chat/resource-events/store", () => ({
-  cancelResourceEventSubscription: cancelSubscription,
-  createResourceEventSubscription: vi.fn(),
+  cancelSubscriptions,
+  createResourceEventSubscription: createSubscription,
   listResourceEventSubscriptions: listSubscriptions,
 }));
 
@@ -51,55 +53,54 @@ const subscriptions = [
 
 describe("resource event tools", () => {
   beforeEach(() => {
-    cancelSubscription.mockReset();
-    cancelSubscription.mockImplementation(async ({ id }) => ({
-      id,
-      status: "cancelled",
-    }));
+    cancelSubscriptions.mockReset();
+    cancelSubscriptions.mockResolvedValue(undefined);
+    createSubscription.mockReset();
+    createSubscription.mockResolvedValue({
+      id: "subscription-1",
+      status: "active",
+      resourceRef: "github:pull_request:getsentry/junior#1",
+      events: ["checks.failed", "review.changes_requested"],
+      expiresAtMs: 1_800_000_000_000,
+    });
     listSubscriptions.mockReset();
     listSubscriptions.mockResolvedValue(subscriptions);
   });
 
-  it("stops only the resource watches selected from conversation context", async () => {
-    const tool = createResourceEventTools(context).stopWatchingResources!;
+  it("returns the inverse action after creating a resource watch", async () => {
+    const tool = createResourceEventTools(context).subscribeToResourceEvents!;
 
     await expect(
       tool.execute!(
         {
-          resourceRefs: ["github:pull_request:getsentry/junior#2"],
+          resourceRef: "github:pull_request:getsentry/junior#1",
+          provider: "github",
+          resourceType: "pull_request",
+          label: "GitHub PR #1",
+          events: ["checks.failed", "review.changes_requested"],
+          intent: "Report failed checks and requested changes.",
         },
         {},
       ),
     ).resolves.toMatchObject({
-      stopped_count: 1,
-      subscriptions: [
-        {
-          id: "subscription-2",
-          resourceRef: "github:pull_request:getsentry/junior#2",
-          subscription_status: "cancelled",
-        },
-      ],
-    });
-    expect(cancelSubscription).toHaveBeenCalledTimes(1);
-    expect(cancelSubscription).toHaveBeenCalledWith({
-      conversationId: "slack:C123:1712345.0001",
-      id: "subscription-2",
+      subscription_status: "active",
+      stop_watching: {
+        tool_name: "stopWatchingResources",
+        arguments: {},
+      },
     });
   });
 
-  it("does not stop other watches when a requested resource is not active", async () => {
+  it("stops every resource watch for the current conversation", async () => {
     const tool = createResourceEventTools(context).stopWatchingResources!;
 
-    await expect(
-      tool.execute!(
-        {
-          resourceRefs: ["github:pull_request:getsentry/junior#404"],
-        },
-        {},
-      ),
-    ).rejects.toThrow(
-      "No active resource watches matched: github:pull_request:getsentry/junior#404",
-    );
-    expect(cancelSubscription).not.toHaveBeenCalled();
+    await expect(tool.execute!({}, {})).resolves.toMatchObject({
+      watching_status: "stopped",
+    });
+    expect(cancelSubscriptions).toHaveBeenCalledTimes(1);
+    expect(cancelSubscriptions).toHaveBeenCalledWith({
+      conversationId: "slack:C123:1712345.0001",
+    });
+    expect(listSubscriptions).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
When Junior starts watching a pull request, it stores a resource subscription
for the current Slack conversation. The bug was that a later message such as
`stop` could be handled as ordinary chat: Junior would say monitoring stopped,
but the stored subscription could remain active. The existing cancellation tool
also required an internal subscription ID that users never see.

This replaces that model-facing contract with a no-argument
`stopWatchingResources` action. It cancels every resource watch owned by the
current conversation through the existing bulk-cancellation boundary, and
Junior only confirms after that call succeeds. Stopping everything is
intentional: resource watches are conversation-owned, and the existing Slack
thread opt-out path already uses the same scope.

Creating a watch now returns the exact inverse catalog call, so a later turn can
understand natural requests such as `stop` without relying on a magic phrase or
rediscovering subscription IDs. Creating subscriptions stays directly
available; the less-common list and stop actions live in the deferred tool
catalog. A regression eval creates a pull-request watch, follows it with
`stop`, and requires the cancellation action before the confirmation.
