### PR TITLE
fix(github): Simplify dashboard activity reporting

### DIFF
--- a/packages/docs/src/content/docs/extend/github-plugin.md
+++ b/packages/docs/src/content/docs/extend/github-plugin.md
@@ -154,20 +154,20 @@ The GitHub plugin classifies a pull request or issue as Junior-owned on its
 signed `opened` event when the author matches the bot login derived from
 `GITHUB_APP_BOT_EMAIL` and the opening body contains Junior's session footer.
 It keeps tracking that projection through later lifecycle events even if the
-body changes. The `/system` dashboard reports pull request creation, merge,
-closure, merge-rate, and time-to-merge summaries alongside issue creation,
-closure, open-count, and time-to-close summaries for 7-, 30-, and 90-day
-windows. This reporting is independent of conversation subscriptions and never
-stores pull request or issue bodies.
+body changes. The `/system` dashboard charts daily pull request and issue
+creation for 7-, 30-, and 90-day windows. It also reports pull request and
+issue closure summaries with 30-day repository breakdowns. This reporting is
+independent of conversation subscriptions and never stores pull request or
+issue bodies.
 
 When a tracked pull request merges, Junior reads its commit list with the
 GitHub App installation credential. A merged pull request is `Junior-only` when
 every commit's Git author matches the configured bot login or bot email. If any
 commit has another author, the report classifies the pull request as `mixed`.
 Older records, empty commit lists, and lookups that fail remain `unknown`; the
-pull request outcome is still recorded. The headline Junior-only merge rate
-excludes unknown records. Junior stores only that classification, not commit
-SHAs, author identities, or email addresses.
+pull request outcome is still recorded. The repository breakdown exposes only
+the count of Junior-only merges. Junior stores the full classification, not
+commit SHAs, author identities, or email addresses.
 
 The pull request projection also keeps the native Junior conversation ids from
 bot-written session footers in a deduplicated `text[]`. These are opaque
@@ -194,7 +194,7 @@ Then confirm:
 2. The author is the GitHub App bot, and the body includes `Requested by` attribution for the verified runtime actor.
 3. A follow-up GitHub request can update or comment on the same issue without asking the user to authorize GitHub or handle tokens manually.
 4. A pushed branch can be turned into a draft PR with `github_createPullRequest` using explicit `repo`, `head`, and `base` values.
-5. After that PR merges, `/system` reports it as a Junior-only or mixed merge.
+5. After that PR merges, `/system` includes it in the repository's Junior-only merge count when every commit belongs to Junior.
 
 For code changes, a local `git commit` does not call GitHub. The GitHub write happens when Junior pushes the branch. The App installation requires `Contents: write`; grant it `Workflows: write` when Junior may change files under `.github/workflows`. Creating the PR after the branch exists is a separate pull-request write operation, but it uses the same repository-scoped write credential.
 

--- a/packages/junior-dashboard/src/client/components/PluginBarChart.tsx
+++ b/packages/junior-dashboard/src/client/components/PluginBarChart.tsx
@@ -53,24 +53,26 @@ export function PluginBarChart(props: {
             {widget.description}
           </p>
         ) : null}
-        <div className="mt-3 flex flex-wrap gap-3">
-          {widget.series.map((series, index) => (
-            <span
-              className="flex items-center gap-1.5 font-mono text-[0.58rem] text-white/40"
-              key={series.key}
-            >
-              <i
-                className="size-2 rounded-sm"
-                style={{
-                  backgroundColor: series.tone
-                    ? toneColors[series.tone]
-                    : colors[index % colors.length],
-                }}
-              />
-              {series.label}
-            </span>
-          ))}
-        </div>
+        {widget.series.length > 1 ? (
+          <div aria-label="Chart legend" className="mt-3 flex flex-wrap gap-3">
+            {widget.series.map((series, index) => (
+              <span
+                className="flex items-center gap-1.5 font-mono text-[0.58rem] text-white/40"
+                key={series.key}
+              >
+                <i
+                  className="size-2 rounded-sm"
+                  style={{
+                    backgroundColor: series.tone
+                      ? toneColors[series.tone]
+                      : colors[index % colors.length],
+                  }}
+                />
+                {series.label}
+              </span>
+            ))}
+          </div>
+        ) : null}
       </div>
       {categories.length === 0 ? (
         <p className="m-0 p-4 font-mono text-[0.68rem] text-white/30">

--- a/packages/junior-dashboard/src/client/components/PluginReports.tsx
+++ b/packages/junior-dashboard/src/client/components/PluginReports.tsx
@@ -72,12 +72,12 @@ function PluginReportView(props: {
           <h3 className="m-0 truncate font-display text-lg font-medium text-white">
             {title}
           </h3>
-          <div className="mt-1 font-mono text-[0.62rem] text-white/30">
+          <div className="mt-1 hidden font-mono text-[0.62rem] text-white/30 sm:block">
             {props.report.pluginName}
           </div>
         </div>
         {props.report.generatedAt ? (
-          <div className="shrink-0 font-mono text-[0.62rem] text-white/30">
+          <div className="hidden shrink-0 font-mono text-[0.62rem] text-white/30 sm:block">
             updated {formatTime(props.report.generatedAt)}
           </div>
         ) : null}
@@ -91,10 +91,11 @@ function PluginReportView(props: {
               : "lg:grid-cols-4",
           )}
         >
-          {props.report.metrics.map((metric) => (
+          {props.report.metrics.map((metric, index) => (
             <div
               className={cn(
                 "min-w-0 bg-[#09090b] px-4 py-4",
+                index > 0 && "hidden sm:block",
                 summaryToneClass(metric.tone),
               )}
               key={metric.label}
@@ -145,7 +146,7 @@ function PluginReportRecordSet(props: {
         <div className="font-mono text-[0.62rem] uppercase tracking-[0.12em] text-white/45">
           {props.recordSet.title}
         </div>
-        <div className="font-mono text-[0.58rem] text-white/25">
+        <div className="hidden font-mono text-[0.58rem] text-white/25 sm:block">
           {records.length} records
         </div>
       </div>
@@ -158,13 +159,17 @@ function PluginReportRecordSet(props: {
           Report records are unavailable because no fields were declared.
         </div>
       ) : (
-        <div className="overflow-x-auto border-t border-white/[0.05]">
-          <table className="w-full min-w-[36rem] border-collapse text-left">
+        <div className="overflow-x-hidden border-t border-white/[0.05] sm:overflow-x-auto">
+          <table className="w-full table-fixed border-collapse text-left sm:min-w-[36rem] sm:table-auto">
             <thead className="bg-black/15 font-mono text-[0.58rem] uppercase tracking-[0.1em] text-white/25">
               <tr>
-                {fields.map((field) => (
+                {fields.map((field, index) => (
                   <th
-                    className="border-b border-white/[0.055] px-5 py-2.5 font-medium"
+                    className={cn(
+                      "border-b border-white/[0.055] px-3 py-2.5 font-medium sm:w-auto sm:px-5",
+                      index === 0 ? "w-1/2" : index === 1 ? "w-1/6" : "w-1/3",
+                      index > 2 && "hidden sm:table-cell",
+                    )}
                     key={field.key}
                     scope="col"
                   >
@@ -182,9 +187,12 @@ function PluginReportRecordSet(props: {
                   )}
                   key={record.id}
                 >
-                  {fields.map((field) => (
+                  {fields.map((field, index) => (
                     <td
-                      className="max-w-72 truncate border-b border-white/[0.05] px-5 py-3 font-mono text-[0.7rem] text-white/55"
+                      className={cn(
+                        "max-w-72 truncate border-b border-white/[0.05] px-3 py-3 font-mono text-[0.7rem] text-white/55 sm:px-5",
+                        index > 2 && "hidden sm:table-cell",
+                      )}
                       key={field.key}
                     >
                       {record.values[field.key] ?? ""}

--- a/packages/junior-dashboard/src/client/components/PluginReports.tsx
+++ b/packages/junior-dashboard/src/client/components/PluginReports.tsx
@@ -83,7 +83,14 @@ function PluginReportView(props: {
         ) : null}
       </div>
       {props.report.metrics?.length ? (
-        <div className="grid gap-px bg-white/[0.055] sm:grid-cols-2 lg:grid-cols-4">
+        <div
+          className={cn(
+            "grid gap-px bg-white/[0.055] sm:grid-cols-2",
+            props.report.metrics.length === 3
+              ? "lg:grid-cols-3"
+              : "lg:grid-cols-4",
+          )}
+        >
           {props.report.metrics.map((metric) => (
             <div
               className={cn(

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -952,6 +952,60 @@ describe("dashboard canonical-event components", () => {
     expect(html).toContain('aria-label="30d, Merged: -1.25"');
   });
 
+  it("prioritizes plugin report content at mobile widths", () => {
+    const html = renderToStaticMarkup(
+      <PluginReports
+        reports={[
+          {
+            generatedAt: "2026-07-24T21:15:00.000Z",
+            metrics: [
+              { label: "Primary", value: "1" },
+              { label: "Secondary", value: "2" },
+            ],
+            pluginName: "github",
+            recordSets: [
+              {
+                fields: [
+                  { key: "repository", label: "Repository" },
+                  { key: "created", label: "Created" },
+                  { key: "juniorOnly", label: "Junior-only merges" },
+                  { key: "merged", label: "Merged" },
+                ],
+                records: [
+                  {
+                    id: "getsentry/junior",
+                    values: {
+                      created: "2",
+                      juniorOnly: "1",
+                      merged: "1",
+                      repository: "getsentry/junior",
+                    },
+                  },
+                ],
+                title: "Pull request repositories · 30d",
+              },
+            ],
+            title: "GitHub activity",
+          },
+        ]}
+      />,
+    );
+
+    expect(html).toContain(
+      'class="mt-1 hidden font-mono text-[0.62rem] text-white/30 sm:block"',
+    );
+    expect(html).toContain(
+      'class="hidden shrink-0 font-mono text-[0.62rem] text-white/30 sm:block"',
+    );
+    expect(html).toContain(
+      'class="min-w-0 bg-[#09090b] px-4 py-4 hidden sm:block"',
+    );
+    expect(html).toContain(
+      'class="w-full table-fixed border-collapse text-left sm:min-w-[36rem] sm:table-auto"',
+    );
+    expect(html.match(/hidden sm:table-cell/g) ?? []).toHaveLength(2);
+  });
+
   it("formats fractional chart ticks without floating-point noise", () => {
     const html = renderToStaticMarkup(
       <PluginReports

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -947,6 +947,7 @@ describe("dashboard canonical-event components", () => {
       />,
     );
     expect(html).toContain("Pull request outcomes");
+    expect(html).toContain('aria-label="Chart legend"');
     expect(html).toContain('aria-label="30d, Created: 4.5"');
     expect(html).toContain('aria-label="30d, Merged: -1.25"');
   });
@@ -975,6 +976,7 @@ describe("dashboard canonical-event components", () => {
     );
     expect(html).toContain(">0.1</text>");
     expect(html).not.toContain("0.10000000000000002");
+    expect(html).not.toContain('aria-label="Chart legend"');
   });
 
   it("keeps dense chart bars within their allocated slots", () => {

--- a/packages/junior-github/src/outcomes/report.ts
+++ b/packages/junior-github/src/outcomes/report.ts
@@ -471,9 +471,9 @@ export async function buildGitHubOutcomeReport(args: {
         fields: [
           { key: "repository", label: "Repository" },
           { key: "created", label: "Created" },
+          { key: "juniorOnly", label: "Junior-only merges" },
           { key: "merged", label: "Merged" },
           { key: "closed", label: "Closed unmerged" },
-          { key: "juniorOnly", label: "Junior-only merges" },
           { key: "mergeRate", label: "Closure merge rate" },
         ],
         records: repositories.map(({ repository, ...stats }) => ({

--- a/packages/junior-github/src/outcomes/report.ts
+++ b/packages/junior-github/src/outcomes/report.ts
@@ -10,34 +10,27 @@ const WINDOWS = [7, 30, 90] as const;
 const pullRequestStatsSchema = z
   .object({
     closed: z.number().int().nonnegative(),
-    compositionUnknown: z.number().int().nonnegative(),
     created: z.number().int().nonnegative(),
     days: z.number().int().positive(),
-    juniorOnly: z.number().int().nonnegative(),
     medianMergeTimeMs: z.number().nonnegative().nullable(),
     merged: z.number().int().nonnegative(),
-    mixed: z.number().int().nonnegative(),
   })
   .strict()
   .transform((row) => {
     const terminal = row.merged + row.closed;
-    const classified = row.juniorOnly + row.mixed;
     return {
       ...row,
       medianMergeTimeMs: row.medianMergeTimeMs ?? undefined,
       mergeRate: terminal > 0 ? row.merged / terminal : undefined,
-      juniorOnlyRate: classified > 0 ? row.juniorOnly / classified : undefined,
     };
   });
 
 const pullRequestRepositoryStatsSchema = z
   .object({
     closed: z.number().int().nonnegative(),
-    compositionUnknown: z.number().int().nonnegative(),
     created: z.number().int().nonnegative(),
     juniorOnly: z.number().int().nonnegative(),
     merged: z.number().int().nonnegative(),
-    mixed: z.number().int().nonnegative(),
     repository: z.string().min(1),
   })
   .strict()
@@ -67,19 +60,13 @@ const issueStatsSchema = z
 
 const pullRequestDaySchema = z
   .object({
-    closed: z.number().int().nonnegative(),
     created: z.number().int().nonnegative(),
     date: z.string().date(),
-    merged: z.number().int().nonnegative(),
   })
   .strict();
 
 const issueDaySchema = z
   .object({
-    closedCompleted: z.number().int().nonnegative(),
-    closedDuplicate: z.number().int().nonnegative(),
-    closedNotPlanned: z.number().int().nonnegative(),
-    closedUnknown: z.number().int().nonnegative(),
     created: z.number().int().nonnegative(),
     date: z.string().date(),
   })
@@ -136,7 +123,6 @@ async function aggregatePullRequestWindows(args: {
       SELECT
         ${table.pullRequestId},
         ${table.state},
-        ${table.commitComposition},
         ${table.openedAt},
         ${table.mergedAt},
         ${table.closedAt}
@@ -160,24 +146,6 @@ async function aggregatePullRequestWindows(args: {
           WHERE recent_pull_requests.state = 'closed_unmerged'
             AND recent_pull_requests.closed_at >= windows.start_at
         )::integer AS "closed",
-      count(recent_pull_requests.pull_request_id)
-        FILTER (
-          WHERE recent_pull_requests.state = 'merged'
-            AND recent_pull_requests.merged_at >= windows.start_at
-            AND recent_pull_requests.commit_composition = 'junior_only'
-        )::integer AS "juniorOnly",
-      count(recent_pull_requests.pull_request_id)
-        FILTER (
-          WHERE recent_pull_requests.state = 'merged'
-            AND recent_pull_requests.merged_at >= windows.start_at
-            AND recent_pull_requests.commit_composition = 'mixed'
-        )::integer AS "mixed",
-      count(recent_pull_requests.pull_request_id)
-        FILTER (
-          WHERE recent_pull_requests.state = 'merged'
-            AND recent_pull_requests.merged_at >= windows.start_at
-            AND recent_pull_requests.commit_composition IS NULL
-        )::integer AS "compositionUnknown",
       (
         percentile_cont(0.5) WITHIN GROUP (
           ORDER BY extract(
@@ -212,38 +180,17 @@ async function aggregatePullRequestDays(args: {
         date_trunc('day', ${end}::timestamptz AT TIME ZONE 'UTC'),
         interval '1 day'
       ) AS day
-    ), events AS (
-      SELECT
-        date_trunc('day', ${table.openedAt} AT TIME ZONE 'UTC') AS day,
-        'created' AS kind
-      FROM ${table}
-      WHERE ${table.openedAt} >= ${start}
-      UNION ALL
-      SELECT
-        date_trunc('day', ${table.mergedAt} AT TIME ZONE 'UTC') AS day,
-        'merged' AS kind
-      FROM ${table}
-      WHERE ${table.state} = 'merged' AND ${table.mergedAt} >= ${start}
-      UNION ALL
-      SELECT
-        date_trunc('day', ${table.closedAt} AT TIME ZONE 'UTC') AS day,
-        'closed' AS kind
-      FROM ${table}
-      WHERE ${table.state} = 'closed_unmerged' AND ${table.closedAt} >= ${start}
     ), daily AS (
       SELECT
-        events.day,
-        count(*) FILTER (WHERE events.kind = 'created')::integer AS created,
-        count(*) FILTER (WHERE events.kind = 'merged')::integer AS merged,
-        count(*) FILTER (WHERE events.kind = 'closed')::integer AS closed
-      FROM events
-      GROUP BY events.day
+        date_trunc('day', ${table.openedAt} AT TIME ZONE 'UTC') AS day,
+        count(*)::integer AS created
+      FROM ${table}
+      WHERE ${table.openedAt} >= ${start}
+      GROUP BY date_trunc('day', ${table.openedAt} AT TIME ZONE 'UTC')
     )
     SELECT
       to_char(days.day, 'YYYY-MM-DD') AS "date",
-      coalesce(daily.created, 0)::integer AS "created",
-      coalesce(daily.merged, 0)::integer AS "merged",
-      coalesce(daily.closed, 0)::integer AS "closed"
+      coalesce(daily.created, 0)::integer AS "created"
     FROM days
     LEFT JOIN daily ON daily.day = days.day
     ORDER BY days.day
@@ -273,17 +220,7 @@ async function aggregatePullRequestRepositories(args: {
         WHERE ${table.state} = 'merged'
           AND ${table.mergedAt} >= ${start}
           AND ${table.commitComposition} = 'junior_only'
-      )::integer AS "juniorOnly",
-      count(*) FILTER (
-        WHERE ${table.state} = 'merged'
-          AND ${table.mergedAt} >= ${start}
-          AND ${table.commitComposition} = 'mixed'
-      )::integer AS "mixed",
-      count(*) FILTER (
-        WHERE ${table.state} = 'merged'
-          AND ${table.mergedAt} >= ${start}
-          AND ${table.commitComposition} IS NULL
-      )::integer AS "compositionUnknown"
+      )::integer AS "juniorOnly"
     FROM ${table}
     WHERE ${table.openedAt} >= ${start}
       OR ${table.mergedAt} >= ${start}
@@ -382,40 +319,17 @@ async function aggregateIssueDays(args: {
         date_trunc('day', ${end}::timestamptz AT TIME ZONE 'UTC'),
         interval '1 day'
       ) AS day
-    ), events AS (
-      SELECT
-        date_trunc('day', ${table.openedAt} AT TIME ZONE 'UTC') AS day,
-        'created' AS kind
-      FROM ${table}
-      WHERE ${table.openedAt} >= ${start}
-      UNION ALL
-      SELECT
-        date_trunc('day', ${table.closedAt} AT TIME ZONE 'UTC') AS day,
-        coalesce(${table.stateReason}, 'unknown') AS kind
-      FROM ${table}
-      WHERE ${table.state} = 'closed' AND ${table.closedAt} >= ${start}
     ), daily AS (
       SELECT
-        events.day,
-        count(*) FILTER (WHERE events.kind = 'created')::integer AS created,
-        count(*) FILTER (WHERE events.kind = 'completed')::integer
-          AS closed_completed,
-        count(*) FILTER (WHERE events.kind = 'duplicate')::integer
-          AS closed_duplicate,
-        count(*) FILTER (WHERE events.kind = 'not_planned')::integer
-          AS closed_not_planned,
-        count(*) FILTER (WHERE events.kind = 'unknown')::integer
-          AS closed_unknown
-      FROM events
-      GROUP BY events.day
+        date_trunc('day', ${table.openedAt} AT TIME ZONE 'UTC') AS day,
+        count(*)::integer AS created
+      FROM ${table}
+      WHERE ${table.openedAt} >= ${start}
+      GROUP BY date_trunc('day', ${table.openedAt} AT TIME ZONE 'UTC')
     )
     SELECT
       to_char(days.day, 'YYYY-MM-DD') AS "date",
-      coalesce(daily.created, 0)::integer AS "created",
-      coalesce(daily.closed_completed, 0)::integer AS "closedCompleted",
-      coalesce(daily.closed_duplicate, 0)::integer AS "closedDuplicate",
-      coalesce(daily.closed_not_planned, 0)::integer AS "closedNotPlanned",
-      coalesce(daily.closed_unknown, 0)::integer AS "closedUnknown"
+      coalesce(daily.created, 0)::integer AS "created"
     FROM days
     LEFT JOIN daily ON daily.day = days.day
     ORDER BY days.day
@@ -476,14 +390,6 @@ function formatDuration(value: number | undefined): string {
   return `${Math.round((hours / 24) * 10) / 10}d`;
 }
 
-function formatCommitComposition(stats: {
-  compositionUnknown: number;
-  juniorOnly: number;
-  mixed: number;
-}): string {
-  return `${stats.juniorOnly} Junior-only · ${stats.mixed} mixed · ${stats.compositionUnknown} unknown`;
-}
-
 function startOfUtcDay(timestampMs: number): Date {
   const date = new Date(timestampMs);
   date.setUTCHours(0, 0, 0, 0);
@@ -515,70 +421,46 @@ export async function buildGitHubOutcomeReport(args: {
 
   return {
     generatedAt: new Date(args.nowMs).toISOString(),
-    title: "GitHub work delivered",
+    title: "GitHub activity",
     metrics: [
       {
-        label: "Junior-only merge rate · 30d",
-        value: formatPercent(thirtyDays.juniorOnlyRate),
-      },
-      {
-        label: "PR merge rate · 30d",
+        label: "PR closure merge rate · 30d",
         value: formatPercent(thirtyDays.mergeRate),
       },
       {
-        label: "median PR merge time · 30d",
+        label: "Median PR merge time · merged in 30d",
         value: formatDuration(thirtyDays.medianMergeTimeMs),
       },
       {
-        label: "median issue close time · 30d",
+        label: "Median issue close time · closed in 30d",
         value: formatDuration(issueThirtyDays.medianCloseTimeMs),
       },
     ],
     widgets: [
       {
-        id: "pull-request-outcomes",
+        id: "pull-requests-created",
         type: "bar_chart",
-        title: "Pull request outcomes",
-        description: "Daily outcomes",
+        title: "Pull requests created",
+        description: "Junior-owned pull requests opened per day",
         timeRangeDays: [...WINDOWS],
-        series: [
-          { key: "created", label: "Created" },
-          { key: "merged", label: "Merged", tone: "good" },
-          { key: "closed", label: "Closed unmerged", tone: "danger" },
-        ],
+        series: [{ key: "created", label: "Created" }],
         categories: pullRequestDays.map((stats) => ({
           id: stats.date,
           label: stats.date,
-          values: {
-            created: stats.created,
-            merged: stats.merged,
-            closed: stats.closed,
-          },
+          values: { created: stats.created },
         })),
       },
       {
-        id: "issue-outcomes",
+        id: "issues-created",
         type: "bar_chart",
-        title: "Issue outcomes",
-        description: "Daily outcomes",
+        title: "Issues created",
+        description: "Junior-owned issues opened per day",
         timeRangeDays: [...WINDOWS],
-        series: [
-          { key: "created", label: "Created" },
-          { key: "completed", label: "Completed", tone: "good" },
-          { key: "duplicate", label: "Duplicate", tone: "warning" },
-          { key: "notPlanned", label: "Not planned", tone: "danger" },
-          { key: "unknown", label: "Unknown" },
-        ],
+        series: [{ key: "created", label: "Created" }],
         categories: issueDays.map((stats) => ({
           id: stats.date,
           label: stats.date,
-          values: {
-            created: stats.created,
-            completed: stats.closedCompleted,
-            duplicate: stats.closedDuplicate,
-            notPlanned: stats.closedNotPlanned,
-            unknown: stats.closedUnknown,
-          },
+          values: { created: stats.created },
         })),
       },
     ],
@@ -591,8 +473,8 @@ export async function buildGitHubOutcomeReport(args: {
           { key: "created", label: "Created" },
           { key: "merged", label: "Merged" },
           { key: "closed", label: "Closed unmerged" },
-          { key: "commitComposition", label: "Merged commit composition" },
-          { key: "mergeRate", label: "Merge rate" },
+          { key: "juniorOnly", label: "Junior-only merges" },
+          { key: "mergeRate", label: "Closure merge rate" },
         ],
         records: repositories.map(({ repository, ...stats }) => ({
           id: repository,
@@ -601,7 +483,7 @@ export async function buildGitHubOutcomeReport(args: {
             created: String(stats.created),
             merged: String(stats.merged),
             closed: String(stats.closed),
-            commitComposition: formatCommitComposition(stats),
+            juniorOnly: String(stats.juniorOnly),
             mergeRate: formatPercent(stats.mergeRate),
           },
         })),

--- a/packages/junior-github/tests/webhook-outcomes.test.ts
+++ b/packages/junior-github/tests/webhook-outcomes.test.ts
@@ -973,7 +973,7 @@ describe("GitHub-owned pull request outcomes", () => {
     }
   });
 
-  it("reports daily outcomes with 7/30/90-day chart ranges", async () => {
+  it("reports daily creation with 7/30/90-day chart ranges", async () => {
     const fixture = await createGitHubFixture();
     try {
       const route = webhookRoute(
@@ -1111,45 +1111,61 @@ describe("GitHub-owned pull request outcomes", () => {
         db: fixture.db(),
         nowMs: Date.parse("2026-07-31T12:00:00.000Z"),
       });
-      expect(report.title).toBe("GitHub work delivered");
+      expect(report.title).toBe("GitHub activity");
       expect(report.metrics).toEqual([
-        { label: "Junior-only merge rate · 30d", value: "100%" },
-        { label: "PR merge rate · 30d", value: "50%" },
-        { label: "median PR merge time · 30d", value: "90d" },
-        { label: "median issue close time · 30d", value: "71d" },
+        { label: "PR closure merge rate · 30d", value: "50%" },
+        {
+          label: "Median PR merge time · merged in 30d",
+          value: "90d",
+        },
+        {
+          label: "Median issue close time · closed in 30d",
+          value: "71d",
+        },
       ]);
       expect(report.widgets?.[0]?.timeRangeDays).toEqual([7, 30, 90]);
+      expect(report.widgets?.[0]?.title).toBe("Pull requests created");
+      expect(report.widgets?.[0]?.series).toEqual([
+        { key: "created", label: "Created" },
+      ]);
       expect(report.widgets?.[0]?.categories).toHaveLength(90);
       expect(report.widgets?.[0]?.categories.at(-3)).toEqual({
         id: "2026-07-29",
         label: "2026-07-29",
-        values: { closed: 0, created: 1, merged: 0 },
+        values: { created: 1 },
       });
       expect(report.widgets?.[0]?.categories.at(-2)).toEqual({
         id: "2026-07-30",
         label: "2026-07-30",
-        values: { closed: 0, created: 0, merged: 1 },
+        values: { created: 0 },
       });
       expect(report.recordSets?.[0]?.records?.[0]?.values).toEqual({
         closed: "1",
-        commitComposition: "1 Junior-only · 0 mixed · 0 unknown",
         created: "2",
+        juniorOnly: "1",
         merged: "1",
         mergeRate: "50%",
         repository: "getsentry/junior",
       });
+      expect(report.recordSets?.[0]?.fields).toContainEqual({
+        key: "juniorOnly",
+        label: "Junior-only merges",
+      });
       expect(report.widgets?.[1]?.timeRangeDays).toEqual([7, 30, 90]);
+      expect(report.widgets?.[1]?.title).toBe("Issues created");
+      expect(report.widgets?.[1]?.series).toEqual([
+        { key: "created", label: "Created" },
+      ]);
       expect(report.widgets?.[1]?.categories).toHaveLength(90);
+      expect(report.widgets?.[1]?.categories.at(-3)).toEqual({
+        id: "2026-07-29",
+        label: "2026-07-29",
+        values: { created: 1 },
+      });
       expect(report.widgets?.[1]?.categories.at(-12)).toEqual({
         id: "2026-07-20",
         label: "2026-07-20",
-        values: {
-          completed: 0,
-          created: 0,
-          duplicate: 0,
-          notPlanned: 1,
-          unknown: 0,
-        },
+        values: { created: 0 },
       });
       expect(report.recordSets?.[1]?.records?.[0]?.values).toEqual({
         completed: "0",
@@ -1164,7 +1180,7 @@ describe("GitHub-owned pull request outcomes", () => {
     }
   });
 
-  it("excludes unknown compositions from the Junior-only merge rate", async () => {
+  it("reports only the Junior-only merge count", async () => {
     const fixture = await createGitHubFixture();
     const openedAt = new Date("2026-07-10T12:00:00.000Z");
     const mergedAt = new Date("2026-07-11T12:00:00.000Z");
@@ -1211,17 +1227,17 @@ describe("GitHub-owned pull request outcomes", () => {
         db: fixture.db(),
         nowMs: Date.parse("2026-07-31T12:00:00.000Z"),
       });
-      expect(
-        report.metrics.find(
-          (metric) => metric.label === "Junior-only merge rate · 30d",
-        ),
-      ).toEqual({
-        label: "Junior-only merge rate · 30d",
-        value: "50%",
+      expect(report.metrics).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ label: expect.stringMatching(/Junior/i) }),
+        ]),
+      );
+      expect(report.recordSets?.[0]?.records?.[0]?.values).toMatchObject({
+        juniorOnly: "1",
       });
-      expect(
-        report.recordSets?.[0]?.records?.[0]?.values.commitComposition,
-      ).toBe("1 Junior-only · 1 mixed · 1 unknown");
+      expect(report.recordSets?.[0]?.records?.[0]?.values).not.toHaveProperty(
+        "commitComposition",
+      );
     } finally {
       await fixture.close();
     }
@@ -1236,10 +1252,15 @@ describe("GitHub-owned pull request outcomes", () => {
       });
 
       expect(report.metrics).toEqual([
-        { label: "Junior-only merge rate · 30d", value: "—" },
-        { label: "PR merge rate · 30d", value: "—" },
-        { label: "median PR merge time · 30d", value: "—" },
-        { label: "median issue close time · 30d", value: "—" },
+        { label: "PR closure merge rate · 30d", value: "—" },
+        {
+          label: "Median PR merge time · merged in 30d",
+          value: "—",
+        },
+        {
+          label: "Median issue close time · closed in 30d",
+          value: "—",
+        },
       ]);
       expect(report.recordSets?.[0]?.records).toEqual([]);
       expect(report.recordSets?.[1]?.records).toEqual([]);

--- a/packages/junior-github/tests/webhook-outcomes.test.ts
+++ b/packages/junior-github/tests/webhook-outcomes.test.ts
@@ -1147,10 +1147,11 @@ describe("GitHub-owned pull request outcomes", () => {
         mergeRate: "50%",
         repository: "getsentry/junior",
       });
-      expect(report.recordSets?.[0]?.fields).toContainEqual({
-        key: "juniorOnly",
-        label: "Junior-only merges",
-      });
+      expect(report.recordSets?.[0]?.fields?.slice(0, 3)).toEqual([
+        { key: "repository", label: "Repository" },
+        { key: "created", label: "Created" },
+        { key: "juniorOnly", label: "Junior-only merges" },
+      ]);
       expect(report.widgets?.[1]?.timeRangeDays).toEqual([7, 30, 90]);
       expect(report.widgets?.[1]?.title).toBe("Issues created");
       expect(report.widgets?.[1]?.series).toEqual([


### PR DESCRIPTION
GitHub operational reporting now charts only daily Junior-owned pull request
and issue creation, avoiding grouped terminal-event bars that represented
different cohorts.

The report replaces commit-composition prose and its summary card with a
per-repository Junior-only merge count, clarifies the remaining outcome metric
labels, and removes redundant legends from single-series charts.

On narrow viewports, plugin reports now keep the first metric and first three
repository fields. GitHub orders repository, created, and Junior-only merges as
those priority fields; desktop retains the complete metrics and tables. Stored
outcome and commit-composition projections remain unchanged.
