### PR TITLE
fix(agent): prevent duplicate replies after cooperative yield

### DIFF
--- a/packages/junior/src/chat/README.md
+++ b/packages/junior/src/chat/README.md
@@ -67,6 +67,9 @@ delegation without becoming the execution actor or a general task owner.
 - Tool failures remain internal agent-loop data unless the final result exposes
   an appropriate diagnostic.
 - Durable state is committed before acknowledging queue work or yielding.
+- Cooperative yield preserves the exact agent history and occurs only at a user
+  or tool-result tail. Unlike timeout or auth recovery, it never rolls history
+  back past delivered assistant output.
 - Unexpected failures propagate to the boundary that owns capture and fallback
   delivery.
 - Actor, destination, conversation, and credential context remain explicit

--- a/packages/junior/src/chat/agent/resume.ts
+++ b/packages/junior/src/chat/agent/resume.ts
@@ -31,7 +31,10 @@ import {
 } from "@/chat/services/auth-pause";
 import { hasAgentTurnUsage, type AgentTurnUsage } from "@/chat/usage";
 import { extractGenAiUsageSummary } from "@/chat/logging";
-import { isAssistantMessage } from "@/chat/pi/transcript";
+import {
+  isAssistantMessage,
+  isContinuablePiBoundary,
+} from "@/chat/pi/transcript";
 import {
   RetryableDeliveryError,
   type AgentRunDurability,
@@ -185,7 +188,11 @@ export function createResumeState(args: ResumeStateArgs) {
         return undefined;
       }
 
-      resumeMessages = this.getResumeSnapshot(currentMessages);
+      const nextResumeMessages = this.getResumeSnapshot(currentMessages);
+      if (!isContinuablePiBoundary(nextResumeMessages)) {
+        return undefined;
+      }
+      resumeMessages = nextResumeMessages;
       return new CooperativeTurnYieldError(
         `Agent turn yielded at a safe boundary after ${currentDurationMs()}ms`,
       );

--- a/packages/junior/src/chat/pi/transcript.ts
+++ b/packages/junior/src/chat/pi/transcript.ts
@@ -100,6 +100,14 @@ export function getPiMessageRole(value: unknown): string | undefined {
   return typeof role === "string" ? role : undefined;
 }
 
+/** Return whether Pi can continue directly from the current history tail. */
+export function isContinuablePiBoundary(
+  messages: readonly PiMessage[],
+): boolean {
+  const lastRole = getPiMessageRole(messages.at(-1));
+  return lastRole === "user" || lastRole === "toolResult";
+}
+
 /** Concatenate text content parts from an assistant message. */
 export function extractAssistantText(message: AssistantMessage): string {
   const content =

--- a/packages/junior/src/chat/services/turn-session-record.ts
+++ b/packages/junior/src/chat/services/turn-session-record.ts
@@ -11,7 +11,7 @@ import { getActiveTraceId, logException } from "@/chat/logging";
 import type { PiMessage } from "@/chat/pi/messages";
 import type { ConversationMessageProvenance } from "@/chat/conversations/provenance";
 import {
-  getPiMessageRole,
+  isContinuablePiBoundary,
   trimTrailingAssistantMessages,
 } from "@/chat/pi/transcript";
 import { addAgentTurnUsage, type AgentTurnUsage } from "@/chat/usage";
@@ -83,11 +83,6 @@ function addDurationMs(
   return total;
 }
 
-function isContinuableBoundary(messages: PiMessage[]): boolean {
-  const lastRole = getPiMessageRole(messages.at(-1));
-  return lastRole === "user" || lastRole === "toolResult";
-}
-
 /**
  * Choose the latest Pi boundary that can be continued safely after auth pause
  * or timeout, falling back to the last durable record when the current slice
@@ -98,7 +93,7 @@ function resumableBoundary(
   fallbackMessages: PiMessage[] | undefined,
 ): PiMessage[] {
   const current = trimTrailingAssistantMessages(messages);
-  if (current.length > 0 && isContinuableBoundary(current)) {
+  if (current.length > 0 && isContinuablePiBoundary(current)) {
     return current;
   }
   return trimTrailingAssistantMessages(fallbackMessages ?? []);
@@ -143,7 +138,7 @@ export async function persistRunningSessionRecord(args: {
   surface?: AgentTurnSurface;
   turnStartMessageIndex?: number;
 }): Promise<boolean> {
-  if (args.messages.length === 0 || !isContinuableBoundary(args.messages)) {
+  if (args.messages.length === 0 || !isContinuablePiBoundary(args.messages)) {
     return false;
   }
 
@@ -385,7 +380,7 @@ export async function persistAuthPauseSessionRecord(args: {
       args.messages,
       latestSessionRecord?.piMessages,
     );
-    if (piMessages.length > 0 && !isContinuableBoundary(piMessages)) {
+    if (piMessages.length > 0 && !isContinuablePiBoundary(piMessages)) {
       return undefined;
     }
     return await upsertAgentTurnSessionRecord({
@@ -485,7 +480,7 @@ export async function persistContinuationSessionRecord(
       args.messages,
       latestSessionRecord?.piMessages,
     );
-    if (piMessages.length === 0 || !isContinuableBoundary(piMessages)) {
+    if (piMessages.length === 0 || !isContinuablePiBoundary(piMessages)) {
       return undefined;
     }
     const cumulativeDurationMs = addDurationMs(
@@ -621,17 +616,16 @@ export async function persistYieldSessionRecord(args: {
   surface?: AgentTurnSurface;
 }): Promise<AgentTurnSessionRecord | undefined> {
   try {
+    // Cooperative yield must preserve the exact history boundary. Trimming a
+    // delivered assistant message would regenerate and redeliver that reply.
+    const piMessages = [...args.messages];
+    if (piMessages.length === 0 || !isContinuablePiBoundary(piMessages)) {
+      return undefined;
+    }
     const latestSessionRecord = await getAgentTurnSessionRecord(
       args.conversationId,
       args.sessionId,
     );
-    const piMessages = resumableBoundary(
-      args.messages,
-      latestSessionRecord?.piMessages,
-    );
-    if (piMessages.length === 0 || !isContinuableBoundary(piMessages)) {
-      return undefined;
-    }
     return await upsertAgentTurnSessionRecord({
       ...((args.channelName ?? latestSessionRecord?.channelName)
         ? { channelName: args.channelName ?? latestSessionRecord?.channelName }

--- a/packages/junior/tests/integration/runtime/agent-run-provider-retry.test.ts
+++ b/packages/junior/tests/integration/runtime/agent-run-provider-retry.test.ts
@@ -12,6 +12,7 @@ const { agentMode, counters, sessionLogState } = vi.hoisted(() => ({
       | "providerRetry"
       | "pendingProviderCall"
       | "cooperativeYield"
+      | "terminalDelivery"
       | "steering"
       | "steeringDelivery"
       | "steeringSteerThrows"
@@ -179,6 +180,35 @@ vi.mock("@earendil-works/pi-agent-core", () => {
             output: 2,
           },
         });
+        return {};
+      }
+      if (agentMode.value === "terminalDelivery") {
+        const finalMessage = {
+          role: "assistant",
+          content: [{ type: "text", text: "Final answer." }],
+          stopReason: "stop",
+          usage: { input: 2, output: 2 },
+        };
+        this.state.messages.push(finalMessage);
+        await Promise.all(
+          this.subscribers.map((subscriber) =>
+            subscriber({ type: "message_end", message: finalMessage }),
+          ),
+        );
+        await Promise.all(
+          this.subscribers.map((subscriber) =>
+            subscriber({
+              type: "turn_end",
+              message: finalMessage,
+              toolResults: [],
+            }),
+          ),
+        );
+        try {
+          await this.prepareNextTurn?.();
+        } catch (error) {
+          this.recordRunFailure(error);
+        }
         return {};
       }
       if (
@@ -663,6 +693,78 @@ describe("executeAgentRun provider retry", () => {
     expect(delivered).toEqual([
       { text: "Initial answer." },
       { text: "Steered." },
+    ]);
+  });
+
+  it("does not suspend after delivering a terminal response", async () => {
+    agentMode.value = "terminalDelivery";
+    const delivered: Array<{ text: string }> = [];
+
+    const outcome = await executeAgentRun({
+      conversationId: "conversation-terminal-delivery-yield",
+      turnId: "turn-terminal-delivery-yield",
+      input: { messageText: "help me" },
+      routing: {
+        destination: TEST_DESTINATION,
+        source: TEST_SOURCE,
+        actor: { platform: "slack", teamId: "T123", userId: "U123" },
+      },
+      delivery: {
+        onAssistantMessage: (message) => {
+          delivered.push(message);
+        },
+      },
+      durability: { shouldYield: () => true },
+    });
+
+    expect(delivered).toEqual([{ text: "Final answer." }]);
+    expect(outcome.status).toBe("completed");
+  });
+
+  it("can suspend after delivery when steering creates a continuable boundary", async () => {
+    agentMode.value = "steeringDelivery";
+    const delivered: Array<{ text: string }> = [];
+
+    const outcome = await executeAgentRun({
+      conversationId: "conversation-delivery-steering-yield",
+      turnId: "turn-delivery-steering-yield",
+      input: { messageText: "help me" },
+      routing: {
+        destination: TEST_DESTINATION,
+        source: TEST_SOURCE,
+        actor: { platform: "slack", teamId: "T123", userId: "U123" },
+      },
+      delivery: {
+        onAssistantMessage: (message) => {
+          delivered.push(message);
+        },
+      },
+      durability: {
+        drainSteeringMessages: async (inject) => {
+          const messages = [
+            {
+              text: "actually do the other thing",
+              timestampMs: 2_000,
+              provenance: { authority: "instruction" as const },
+            },
+          ];
+          await inject(messages);
+          return messages;
+        },
+        shouldYield: () => true,
+      },
+    });
+
+    expect(outcome.status).toBe("suspended");
+    expect(delivered).toEqual([{ text: "Initial answer." }]);
+    const sessionRecord = await turnSessionState.getAgentTurnSessionRecord(
+      "conversation-delivery-steering-yield",
+      "turn-delivery-steering-yield",
+    );
+    expect(sessionRecord?.piMessages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
     ]);
   });
 


### PR DESCRIPTION
Cooperative yields now suspend only when the exact Pi history can be resumed directly. After a terminal assistant reply is delivered, the run completes instead of trimming that assistant message and regenerating it in a continuation. If steering arrives after an intermediate reply, the preserved user tail remains yieldable.

Timeout and authorization recovery keep their existing rollback behavior; the stricter exact-history rule applies only to cooperative yield. Regression coverage exercises both terminal delivery and post-delivery steering.

Fixes #1041
