### PR TITLE
fix(ai): handle invalid structured responses

### DIFF
--- a/packages/junior/src/chat/pi/client.ts
+++ b/packages/junior/src/chat/pi/client.ts
@@ -10,7 +10,7 @@ import {
   type ThinkingLevel,
 } from "@/chat/pi/sdk";
 import { createGatewayProvider } from "@ai-sdk/gateway";
-import { embedMany, generateObject } from "ai";
+import { embedMany, generateObject, NoObjectGeneratedError } from "ai";
 
 // Directly register the anthropic provider at import time. pi-ai's built-in
 // registration relies on opaque dynamic import() calls that break under
@@ -344,23 +344,11 @@ export async function completeObject<TSchema extends ZodTypeAny>(params: {
     return { object: result.object as z.infer<TSchema> };
   } catch (error) {
     const providerError = createProviderError(error, {
+      ...(NoObjectGeneratedError.isInstance(error)
+        ? { kind: "invalid_response" }
+        : {}),
       modelId: params.modelId,
     });
-    if (isProviderRetryError(providerError)) {
-      throw providerError;
-    }
-
-    logException(
-      providerError,
-      "ai_completion_failed",
-      {},
-      {
-        "gen_ai.provider.name": GEN_AI_PROVIDER_NAME,
-        "gen_ai.operation.name": GEN_AI_OPERATION_CHAT,
-        "gen_ai.request.model": params.modelId,
-      },
-      "AI object completion failed",
-    );
     throw providerError;
   }
 }

--- a/packages/junior/src/chat/services/provider-error.ts
+++ b/packages/junior/src/chat/services/provider-error.ts
@@ -27,6 +27,7 @@ interface ProviderErrorOptions {
 }
 
 interface ProviderErrorDetails {
+  cause?: unknown;
   kind: ProviderErrorKind;
   modelId?: string;
   retryable: boolean;
@@ -44,7 +45,10 @@ export class ProviderError extends Error {
   readonly status?: number;
 
   constructor(details: ProviderErrorDetails) {
-    super(`AI provider error: ${details.kind}`);
+    super(
+      `AI provider error: ${details.kind}`,
+      details.cause !== undefined ? { cause: details.cause } : {},
+    );
     this.name = "ProviderError";
     this.kind = details.kind;
     this.modelId = details.modelId;
@@ -214,6 +218,7 @@ export function createProviderError(
     !TERMINAL_KINDS.has(kind) &&
     (options.retryable ?? RETRYABLE_KINDS.has(kind));
   return new ProviderError({
+    cause: error,
     kind,
     modelId: options.modelId,
     retryable,

--- a/packages/junior/src/chat/services/turn-router.ts
+++ b/packages/junior/src/chat/services/turn-router.ts
@@ -12,7 +12,12 @@ import {
   STANDARD_MODEL_PROFILE,
 } from "@/chat/model-profile";
 import { renderCurrentInstruction } from "@/chat/current-instruction";
-import { setSpanAttributes, withSpan, type LogContext } from "@/chat/logging";
+import {
+  logWarn,
+  setSpanAttributes,
+  withSpan,
+  type LogContext,
+} from "@/chat/logging";
 
 const CLASSIFIER_CONFIDENCE_THRESHOLD = 0.75;
 const MAX_ROUTER_CONTEXT_CHARS = 8_000;
@@ -345,7 +350,22 @@ async function classifyTurn(args: {
       reasoningLevel: parsed.reasoning_level,
       reason,
     };
-  } catch {
+  } catch (error) {
+    logWarn(
+      "turn_router_classifier_failed",
+      {
+        messageConversationId: args.metadata.threadId,
+        destinationName: args.metadata.channelId,
+        userId: args.metadata.actorId,
+        runId: args.metadata.runId,
+        modelId: args.fastModelId,
+      },
+      {
+        "exception.message":
+          error instanceof Error ? error.message : String(error),
+      },
+      "Turn router classifier failed; using the default route",
+    );
     return {
       profile: STANDARD_MODEL_PROFILE,
       reasoningLevel: CLASSIFIER_FALLBACK_REASONING_LEVEL,

--- a/packages/junior/tests/unit/pi/client.test.ts
+++ b/packages/junior/tests/unit/pi/client.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   getModels: vi.fn(() => [{ id: "openai/gpt-4o-mini" }]),
   logException: vi.fn(),
   logWarn: vi.fn(),
+  noObjectGeneratedErrorIsInstance: vi.fn(),
   registerApiProvider: vi.fn(),
   setSpanAttributes: vi.fn(),
   streamAnthropic: vi.fn(),
@@ -46,6 +47,9 @@ vi.mock("@ai-sdk/gateway", () => ({
 vi.mock("ai", () => ({
   embedMany: mocks.embedMany,
   generateObject: mocks.generateObject,
+  NoObjectGeneratedError: {
+    isInstance: mocks.noObjectGeneratedErrorIsInstance,
+  },
 }));
 
 vi.mock("@/chat/logging", async (importOriginal) => ({
@@ -265,6 +269,29 @@ describe("completeText", () => {
         prompt: "return json",
       }),
     ).rejects.toThrow("AI provider error: network");
+    expect(mocks.logWarn).not.toHaveBeenCalled();
+    expect(mocks.logException).not.toHaveBeenCalled();
+  });
+
+  it("classifies invalid structured output without capturing it", async () => {
+    const sdkError = new Error("No object generated.");
+    mocks.generateObject.mockRejectedValue(sdkError);
+    mocks.noObjectGeneratedErrorIsInstance.mockReturnValueOnce(true);
+
+    const { completeObject } = await import("@/chat/pi/client");
+
+    await expect(
+      completeObject({
+        modelId: "anthropic/claude-haiku-4.5",
+        schema: z.object({ ok: z.boolean() }),
+        prompt: "return json",
+      }),
+    ).rejects.toMatchObject({
+      cause: sdkError,
+      kind: "invalid_response",
+      message: "AI provider error: invalid_response",
+      retryable: false,
+    });
     expect(mocks.logWarn).not.toHaveBeenCalled();
     expect(mocks.logException).not.toHaveBeenCalled();
   });

--- a/packages/junior/tests/unit/services/provider-retry.test.ts
+++ b/packages/junior/tests/unit/services/provider-retry.test.ts
@@ -22,11 +22,11 @@ const XAI_SERVICE_UNAVAILABLE =
 
 describe("provider retry helpers", () => {
   it("marks retryable provider-boundary exceptions", () => {
-    const error = createProviderError(
-      new Error("Anthropic stream ended before message_stop"),
-    );
+    const cause = new Error("Anthropic stream ended before message_stop");
+    const error = createProviderError(cause);
 
     expect(error.message).toBe("AI provider error: network");
+    expect(error.cause).toBe(cause);
     expect(error).toBeInstanceOf(ProviderError);
     expect(error).toMatchObject({
       code: "provider_error",

--- a/packages/junior/tests/unit/services/turn-router.test.ts
+++ b/packages/junior/tests/unit/services/turn-router.test.ts
@@ -1,9 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   configuredTurnRoute,
   selectTurnRoute,
   toPiReasoningLevel,
 } from "@/chat/services/turn-router";
+
+const mocks = vi.hoisted(() => ({
+  logWarn: vi.fn(),
+}));
+
+vi.mock("@/chat/logging", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/chat/logging")>()),
+  logWarn: mocks.logWarn,
+}));
 
 const profiles = {
   standard: { modelId: "xai/grok-4.5" },
@@ -14,6 +23,10 @@ const routeTurn = (
 ) => selectTurnRoute({ ...args, profiles });
 
 describe("selectTurnRoute", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("keeps configured reasoning independent from model routing", () => {
     expect(configuredTurnRoute("standard", "xhigh", "agent_config")).toEqual({
       profile: "standard",
@@ -200,6 +213,16 @@ describe("selectTurnRoute", () => {
       reasoningLevel: "medium",
       reason: "classifier_error_default",
     });
+    expect(mocks.logWarn).toHaveBeenCalledWith(
+      "turn_router_classifier_failed",
+      expect.objectContaining({
+        modelId: "openai/gpt-5.4-mini",
+      }),
+      {
+        "exception.message": "router failed",
+      },
+      "Turn router classifier failed; using the default route",
+    );
   });
 
   it("preserves high-confidence low classifications for deterministic simple work", async () => {


### PR DESCRIPTION
Structured AI completions that return unparseable or schema-invalid output now normalize the AI SDK's `NoObjectGeneratedError` as `invalid_response` while preserving the original cause. The provider client no longer captures terminal structured-output failures before rethrowing; the recovering turn router emits a warning and continues with its existing default route.

This prevents an expected classifier fallback from creating an alert-level Sentry issue while retaining the diagnostic chain for failures that reach an owning boundary. Focused regression coverage verifies normalization, cause preservation, fallback logging, and the absence of duplicate exception capture.
