### PR TITLE
fix(conversations): Preserve transcript formatting

### DIFF
--- a/packages/junior-dashboard/e2e/dashboard.spec.ts
+++ b/packages/junior-dashboard/e2e/dashboard.spec.ts
@@ -337,10 +337,13 @@ test("loads earlier transcript events without dropping the current page", async 
   await expect(
     page.getByRole("heading", { name: "Package release and self-update" }),
   ).toBeVisible();
-  const currentEvent = page.getByText(
-    "Released the package and opened the update pull request.",
-  );
+  const currentEvent = page
+    .locator("p")
+    .filter({ hasText: "Released the package." })
+    .filter({ hasText: "Opened the update pull request." })
+    .filter({ hasText: "Deployment is ready." });
   await expect(currentEvent).toBeVisible();
+  await expect(currentEvent.locator("br")).toHaveCount(2);
 
   const toolRun = page.locator("details").filter({ hasText: /12 tool calls/ });
   await toolRun.locator("summary").click();

--- a/packages/junior-dashboard/src/mock-reporting/fixtures.ts
+++ b/packages/junior-dashboard/src/mock-reporting/fixtures.ts
@@ -321,7 +321,7 @@ function longConversation(nowMs: number): ConversationDetailReport {
       type: "message",
       messageId: "release-assistant",
       role: "assistant",
-      text: "Released the package and opened the update pull request.",
+      text: "Released the package.\nOpened the update pull request.\nDeployment is ready.",
     }),
   );
   return detail(nowMs, {

--- a/packages/junior-dashboard/tests/markdownExport.test.ts
+++ b/packages/junior-dashboard/tests/markdownExport.test.ts
@@ -64,7 +64,7 @@ describe("dashboard canonical-event Markdown export", () => {
           type: "message",
           messageId: "assistant-1",
           role: "assistant",
-          text: "investigation complete",
+          text: "investigation complete\nfollow-up deployed",
         }),
       ]),
     );
@@ -74,6 +74,7 @@ describe("dashboard canonical-event Markdown export", () => {
     expect(markdown).toContain("please investigate");
     expect(markdown).toContain("### Junior");
     expect(markdown.match(/investigation complete/g)).toHaveLength(1);
+    expect(markdown).toContain("investigation complete\nfollow-up deployed");
   });
 
   it("exports resource events without attributing them to the actor", () => {

--- a/packages/junior/src/chat/services/conversation-memory.ts
+++ b/packages/junior/src/chat/services/conversation-memory.ts
@@ -46,8 +46,9 @@ export function generateConversationId(
   return `${prefix}_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
 }
 
+/** Normalize message boundaries without changing transcript formatting. */
 export function normalizeConversationText(text: string): string {
-  return text.trim().replace(/\s+/g, " ").slice(0, CONTEXT_MAX_MESSAGE_CHARS);
+  return text.replace(/\r\n?/g, "\n").trim();
 }
 
 function buildImageContextSuffix(
@@ -75,6 +76,9 @@ function renderConversationMessageLine(
   conversation?: ThreadConversationState,
 ): string {
   const displayName = conversationAuthorDisplayName(message);
+  const text = message.text
+    .replace(/\s+/g, " ")
+    .slice(0, CONTEXT_MAX_MESSAGE_CHARS);
 
   const markers: string[] = [];
   if (message.meta?.replied === false) {
@@ -88,7 +92,7 @@ function renderConversationMessageLine(
 
   const markerSuffix = markers.length > 0 ? ` (${markers.join("; ")})` : "";
   const imageContext = buildImageContextSuffix(message, conversation);
-  return `[${message.role}] ${displayName}: ${message.text}${imageContext}${markerSuffix}`;
+  return `[${message.role}] ${displayName}: ${text}${imageContext}${markerSuffix}`;
 }
 
 function conversationAuthorDisplayName(message: ConversationMessage): string {

--- a/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/subscribed-message-behavior.test.ts
@@ -185,7 +185,7 @@ describe("Slack behavior: subscribed messages", () => {
               replyContexts.push(context);
               return await completedReply(
                 request,
-                "I checked the subscribed PR event.",
+                "I checked the subscribed PR event.\nThe PR is merged.",
               );
             },
           },
@@ -196,7 +196,7 @@ describe("Slack behavior: subscribed messages", () => {
     const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700002000.002" });
     const message = createTestMessage({
       id: "resource-event-resub-1-check-suite-1",
-      text: "[event notification]\n\nA subscribed resource changed.",
+      text: "[event notification]\n\nA subscribed resource changed.\n\nHandling:\n- Stay concise.",
       isMention: false,
       threadId: thread.id,
       author: {
@@ -231,6 +231,25 @@ describe("Slack behavior: subscribed messages", () => {
       }),
     ]);
     expect(thread.posts).toHaveLength(1);
+    const conversation = coerceThreadConversationState(
+      (await thread.state) ?? {},
+    );
+    await hydrateConversationMessages({
+      conversation,
+      conversationId: thread.id,
+    });
+    expect(conversation.messages).toContainEqual(
+      expect.objectContaining({
+        id: "resource-event-resub-1-check-suite-1",
+        text: "[event notification]\n\nA subscribed resource changed.\n\nHandling:\n- Stay concise.",
+      }),
+    );
+    expect(conversation.messages).toContainEqual(
+      expect.objectContaining({
+        role: "assistant",
+        text: "I checked the subscribed PR event.\nThe PR is merged.",
+      }),
+    );
   });
 
   it("processes resource events when compacted history retains a handled marker without its message", async () => {

--- a/packages/junior/tests/unit/services/conversation-memory.test.ts
+++ b/packages/junior/tests/unit/services/conversation-memory.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildConversationContext,
   getThreadTitleSourceMessage,
+  normalizeConversationText,
   turnHasReply,
 } from "@/chat/services/conversation-memory";
 import { coerceThreadConversationState } from "@/chat/state/conversation";
@@ -61,6 +62,19 @@ describe("conversation memory title source", () => {
     expect(getThreadTitleSourceMessage(conversation)?.text).toBe(
       "Real user request",
     );
+  });
+});
+
+describe("normalizeConversationText", () => {
+  it("preserves message line breaks while normalizing line endings", () => {
+    expect(normalizeConversationText("  first\r\nsecond\rthird  ")).toBe(
+      "first\nsecond\nthird",
+    );
+  });
+
+  it("does not truncate durable message text to the model context budget", () => {
+    const text = "x".repeat(4_000);
+    expect(normalizeConversationText(text)).toBe(text);
   });
 });
 
@@ -163,6 +177,38 @@ describe("buildConversationContext", () => {
     expect(context).toContain('actor_id="U039RR91S"');
     expect(context).toContain("[user] user: hello");
     expect(context).not.toContain("@U039RR91S");
+  });
+
+  it("keeps multiline messages compact in model context", () => {
+    const conversation = coerceThreadConversationState({});
+    conversation.messages = [
+      {
+        id: "msg-1",
+        role: "assistant",
+        text: "first line\nsecond line",
+        createdAtMs: 1000,
+      },
+    ];
+
+    const context = buildConversationContext(conversation);
+    expect(context).toContain("first line second line");
+    expect(context).not.toContain("first line\nsecond line");
+  });
+
+  it("applies the message character budget only to model context", () => {
+    const conversation = coerceThreadConversationState({});
+    conversation.messages = [
+      {
+        id: "msg-1",
+        role: "assistant",
+        text: "x".repeat(4_000),
+        createdAtMs: 1000,
+      },
+    ];
+
+    const context = buildConversationContext(conversation);
+    const renderedText = /\[assistant\][^\n]*: (x+)/.exec(context ?? "")?.[1];
+    expect(renderedText).toHaveLength(3_200);
   });
 });
 


### PR DESCRIPTION
Canonical conversation messages now preserve their accepted formatting and full text instead of collapsing whitespace and truncating at the model-context budget. This restores single-newline rendering in dashboard transcripts, raw views, and Markdown exports for newly recorded inbound events and assistant replies.

The root cause was a model-context normalization helper being reused at the durable message-storage boundary. Whitespace compaction and the 3,200-character cap now apply only when rendering conversation context for the model; stored messages normalize line endings but otherwise retain their content. Existing already-flattened history cannot be reconstructed.

Regression coverage follows multiline inbound and assistant messages through persistence and hydration, protects long-message storage versus context truncation, and keeps a deterministic multiline dashboard fixture for browser QA. The full Junior and dashboard suites, both typechecks, lint, and dependency-boundary checks pass.