### PR TITLE
fix(agent): enforce context window compaction

### DIFF
--- a/packages/junior-dashboard/src/client/components/TranscriptContextEventView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptContextEventView.tsx
@@ -1,4 +1,4 @@
-import { formatMessageTimestamp } from "../format";
+import { formatCompactNumber, formatMessageTimestamp } from "../format";
 import type { TranscriptViewContextEventPart } from "../types";
 
 /** Render a structural context change from the privacy-safe event API. */
@@ -8,6 +8,14 @@ export function TranscriptContextEventView(props: {
 }) {
   const event = props.part.event;
   const handoff = event.type === "handoff";
+  const compactionDetail =
+    event.type === "compaction" && event.details
+      ? ` at approximately ${formatCompactNumber(event.details.estimatedInputTokens)} estimated tokens`
+      : "";
+  const compactionModel =
+    event.type === "compaction" && event.modelProfile && event.modelId
+      ? ` using the ${event.modelProfile} profile (${event.modelId})`
+      : "";
   return (
     <article
       className={`min-w-0 rounded-lg border px-3 py-3 first:mt-1 ${
@@ -33,7 +41,7 @@ export function TranscriptContextEventView(props: {
       <div className="mt-1.5 text-[0.8rem] text-white/45">
         {handoff
           ? `Execution continued with the ${event.modelProfile} profile (${event.modelId}${event.reasoningLevel ? `, ${event.reasoningLevel}` : ""}).`
-          : "Earlier context was summarized for the next turn."}
+          : `Earlier context was summarized${compactionDetail}${compactionModel} before execution continued.`}
       </div>
     </article>
   );

--- a/packages/junior-dashboard/src/client/conversations/eventTranscript.ts
+++ b/packages/junior-dashboard/src/client/conversations/eventTranscript.ts
@@ -180,7 +180,15 @@ export function conversationTranscriptMessages(
                       ? { reasoningLevel: data.reasoningLevel }
                       : {}),
                   }
-                : { type: data.type, createdAt: event.createdAt },
+                : {
+                    type: data.type,
+                    createdAt: event.createdAt,
+                    ...(data.modelId ? { modelId: data.modelId } : {}),
+                    ...(data.modelProfile
+                      ? { modelProfile: data.modelProfile }
+                      : {}),
+                    ...(data.details ? { details: data.details } : {}),
+                  },
           },
         ]),
       );

--- a/packages/junior-dashboard/src/client/markdownExport.ts
+++ b/packages/junior-dashboard/src/client/markdownExport.ts
@@ -180,6 +180,44 @@ function appendContextEvent(
     addMetaLine(lines, "Profile", event.modelProfile);
     addMetaLine(lines, "Model", event.modelId);
     addMetaLine(lines, "Reasoning", event.reasoningLevel);
+  } else {
+    addMetaLine(lines, "Profile", event.modelProfile);
+    addMetaLine(lines, "Model", event.modelId);
+    if (event.details) {
+      addMetaLine(
+        lines,
+        "Estimated input tokens",
+        String(event.details.estimatedInputTokens),
+      );
+      if (event.details.replacementInputTokens !== undefined) {
+        addMetaLine(
+          lines,
+          "Replacement input tokens",
+          String(event.details.replacementInputTokens),
+        );
+      }
+      addMetaLine(
+        lines,
+        "Compaction trigger",
+        String(event.details.triggerTokens),
+      );
+      addMetaLine(lines, "Input limit", String(event.details.inputLimitTokens));
+      addMetaLine(
+        lines,
+        "Input messages",
+        String(event.details.inputMessageCount),
+      );
+      addMetaLine(
+        lines,
+        "Retained messages",
+        String(event.details.retainedMessageCount),
+      );
+      addMetaLine(
+        lines,
+        "Summary characters",
+        String(event.details.summaryChars),
+      );
+    }
   }
 }
 

--- a/packages/junior-dashboard/src/client/types.ts
+++ b/packages/junior-dashboard/src/client/types.ts
@@ -35,7 +35,22 @@ export type TranscriptViewSubagentPart = {
 
 export type TranscriptViewContextEventPart = {
   event:
-    | { createdAt: string; type: "compaction" }
+    | {
+        createdAt: string;
+        type: "compaction";
+        modelId?: string;
+        modelProfile?: string;
+        details?: {
+          reason: "capacity";
+          estimatedInputTokens: number;
+          replacementInputTokens?: number;
+          triggerTokens: number;
+          inputLimitTokens: number;
+          inputMessageCount: number;
+          retainedMessageCount: number;
+          summaryChars: number;
+        };
+      }
     | {
         createdAt: string;
         modelId: string;

--- a/packages/junior-dashboard/src/mock-reporting/fixtures.ts
+++ b/packages/junior-dashboard/src/mock-reporting/fixtures.ts
@@ -243,6 +243,18 @@ function dashboardQaConversation(nowMs: number): ConversationDetailReport {
       }),
       reportEvent(8, iso(Date.parse(startedAt), 50_000), {
         type: "compaction",
+        modelProfile: "standard",
+        modelId: "openai/gpt-5.4",
+        details: {
+          reason: "capacity",
+          estimatedInputTokens: 361_000,
+          replacementInputTokens: 2_400,
+          triggerTokens: 360_000,
+          inputLimitTokens: 380_000,
+          inputMessageCount: 42,
+          retainedMessageCount: 2,
+          summaryChars: 1_200,
+        },
       }),
       reportEvent(9, iso(Date.parse(startedAt), 55_000), {
         type: "message",
@@ -319,6 +331,18 @@ function longConversation(nowMs: number): ConversationDetailReport {
   events.push(
     reportEvent(14, iso(Date.parse(startedAt), 53_000), {
       type: "compaction",
+      modelProfile: "standard",
+      modelId: "openai/gpt-5.4",
+      details: {
+        reason: "capacity",
+        estimatedInputTokens: 364_200,
+        replacementInputTokens: 2_750,
+        triggerTokens: 360_000,
+        inputLimitTokens: 380_000,
+        inputMessageCount: 28,
+        retainedMessageCount: 1,
+        summaryChars: 980,
+      },
     }),
     reportEvent(15, iso(Date.parse(startedAt), 90_000), {
       type: "handoff",

--- a/packages/junior-dashboard/tests/markdownExport.test.ts
+++ b/packages/junior-dashboard/tests/markdownExport.test.ts
@@ -138,7 +138,21 @@ describe("dashboard canonical-event Markdown export", () => {
           subagentKind: "advisor",
           status: "running",
         }),
-        event(4, { type: "compaction" }),
+        event(4, {
+          type: "compaction",
+          modelProfile: "standard",
+          modelId: "openai/gpt-5.4",
+          details: {
+            reason: "capacity",
+            estimatedInputTokens: 361_000,
+            replacementInputTokens: 2_400,
+            triggerTokens: 360_000,
+            inputLimitTokens: 380_000,
+            inputMessageCount: 42,
+            retainedMessageCount: 2,
+            summaryChars: 1_200,
+          },
+        }),
         event(5, {
           type: "handoff",
           modelProfile: "fast",
@@ -161,6 +175,9 @@ describe("dashboard canonical-event Markdown export", () => {
     expect(markdown).toContain('"matches": 3');
     expect(markdown).toContain("### Subagent: advisor");
     expect(markdown).toContain("### Context compacted");
+    expect(markdown).toContain("- Estimated input tokens: 361000");
+    expect(markdown).toContain("- Compaction trigger: 360000");
+    expect(markdown).toContain("- Input limit: 380000");
     expect(markdown).toContain("### Model handoff");
     expect(markdown).toContain("- Profile: fast");
     expect(markdown).toContain("- Model: openai/gpt-5-mini");

--- a/packages/junior-dashboard/tests/transcriptContextEvent.test.tsx
+++ b/packages/junior-dashboard/tests/transcriptContextEvent.test.tsx
@@ -23,6 +23,18 @@ describe("transcript context events", () => {
             event: {
               type: "compaction",
               createdAt: "2026-01-01T00:00:02.000Z",
+              modelProfile: "standard",
+              modelId: "openai/gpt-5.4",
+              details: {
+                reason: "capacity",
+                estimatedInputTokens: 361_000,
+                replacementInputTokens: 2_400,
+                triggerTokens: 360_000,
+                inputLimitTokens: 380_000,
+                inputMessageCount: 42,
+                retainedMessageCount: 2,
+                summaryChars: 1_200,
+              },
             },
           }}
           timestamp={Date.parse("2026-01-01T00:00:02.000Z")}
@@ -31,7 +43,8 @@ describe("transcript context events", () => {
     );
 
     expect(html).toContain("Context compacted");
-    expect(html).toContain("Earlier context was summarized");
+    expect(html).toContain("approximately 361k estimated tokens");
+    expect(html).toContain("standard profile (openai/gpt-5.4)");
   });
 
   it("renders a model handoff as a structural event", () => {

--- a/packages/junior/src/api/conversations/events.ts
+++ b/packages/junior/src/api/conversations/events.ts
@@ -247,7 +247,12 @@ function reportEventData(args: {
           data.failureCode === "delivery_failed" ? "delivery" : "agent",
       };
     case "compaction":
-      return { type: "compaction" };
+      return {
+        type: "compaction",
+        modelProfile: data.modelProfile,
+        modelId: data.modelId,
+        ...(data.details ? { details: data.details } : {}),
+      };
     default:
       // Unsupported and host-only facts do not affect this observational view.
       return undefined;

--- a/packages/junior/src/api/schema/conversation.ts
+++ b/packages/junior/src/api/schema/conversation.ts
@@ -173,7 +173,24 @@ const conversationReportTurnRoutedEventDataSchema = z
   .strict();
 
 const conversationReportCompactionEventDataSchema = z
-  .object({ type: z.literal("compaction") })
+  .object({
+    type: z.literal("compaction"),
+    modelProfile: z.string().min(1).optional(),
+    modelId: z.string().min(1).optional(),
+    details: z
+      .object({
+        reason: z.literal("capacity"),
+        estimatedInputTokens: z.number().int().nonnegative(),
+        replacementInputTokens: z.number().int().nonnegative().optional(),
+        triggerTokens: z.number().int().nonnegative(),
+        inputLimitTokens: z.number().int().positive(),
+        inputMessageCount: z.number().int().nonnegative(),
+        retainedMessageCount: z.number().int().nonnegative(),
+        summaryChars: z.number().int().nonnegative(),
+      })
+      .strict()
+      .optional(),
+  })
   .strict();
 
 const conversationReportHandoffEventDataSchema = z

--- a/packages/junior/src/chat/README.md
+++ b/packages/junior/src/chat/README.md
@@ -67,6 +67,12 @@ delegation without becoming the execution actor or a general task owner.
 - Tool failures remain internal agent-loop data unless the final result exposes
   an appropriate diagnostic.
 - Durable state is committed before acknowledging queue work or yielding.
+- Model input stays below the configured bot context cap and the active model's
+  advertised window. The agent checks before its first provider request and
+  after each tool batch; an in-turn compaction commits its history replacement
+  and resumable boundary before execution continues. Compaction events retain
+  the active model plus privacy-safe capacity and replacement metrics for
+  reporting without exposing the summary or replaced history.
 - Cooperative yield preserves the exact agent history and occurs only at a user
   or tool-result tail. Unlike timeout or auth recovery, it never rolls history
   back past delivered assistant output.

--- a/packages/junior/src/chat/README.md
+++ b/packages/junior/src/chat/README.md
@@ -70,9 +70,11 @@ delegation without becoming the execution actor or a general task owner.
 - Model input stays below the configured bot context cap and the active model's
   advertised window. The agent checks before its first provider request and
   after each tool batch; an in-turn compaction commits its history replacement
-  and resumable boundary before execution continues. Compaction events retain
-  the active model plus privacy-safe capacity and replacement metrics for
-  reporting without exposing the summary or replaced history.
+  and resumable boundary before execution continues. A handoff changes the
+  active model and history, then passes through the same capacity check rather
+  than bypassing it. Compaction events retain the active model plus privacy-safe
+  capacity and replacement metrics for reporting without exposing the summary
+  or replaced history.
 - Cooperative yield preserves the exact agent history and occurs only at a user
   or tool-result tail. Unlike timeout or auth recovery, it never rolls history
   back past delivered assistant output.

--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -66,10 +66,7 @@ import {
 } from "@/chat/pi/transcript";
 import { createTracedStreamFn } from "@/chat/pi/traced-stream";
 import { shouldEmitDevAgentTrace } from "@/chat/runtime/dev-agent-trace";
-import {
-  isTurnInputCommitLostError,
-  type CooperativeTurnYieldError,
-} from "@/chat/runtime/turn";
+import { isTurnInputCommitLostError } from "@/chat/runtime/turn";
 import type { AgentRunOutcome } from "@/chat/runtime/agent-run-outcome";
 import {
   buildTurnResult,
@@ -127,7 +124,10 @@ import {
   profileConfig,
   type ModelProfile,
 } from "@/chat/model-profile";
-import { compactContextForHandoff } from "@/chat/services/context-compaction";
+import {
+  compactActiveContextIfNeeded,
+  compactContextForHandoff,
+} from "@/chat/services/context-compaction";
 import { HANDOFF_TOOL_NAME } from "@/chat/tools/handoff/tool";
 
 const AGENT_ABORT_SETTLE_GRACE_MS = 5_000;
@@ -647,7 +647,9 @@ async function executeAgentRunInPrivacyContext(
             runId,
           },
         },
-        { completeText },
+        {
+          completeText: (args) => completeText(args),
+        },
       );
       durableModelProfile = args.profile;
       if (handoffReasoningLevel !== turnRoute!.reasoningLevel) {
@@ -781,6 +783,59 @@ async function executeAgentRunInPrivacyContext(
         thinkingLevel,
       };
     };
+    /** Commit and adopt an active capacity replacement before another model call. */
+    const applyActiveContextCompaction = async (
+      messages: PiMessage[],
+      hookSignal?: AbortSignal,
+      pendingMessages?: Array<{
+        message: PiMessage;
+        provenance: ConversationMessageProvenance;
+      }>,
+      clearSteeringQueueOnCommit = false,
+    ): Promise<AgentLoopTurnUpdate | undefined> => {
+      const compaction = await compactActiveContextIfNeeded(
+        {
+          conversationContext: input.conversationContext,
+          conversationId,
+          metadata: {
+            threadId: conversationId,
+            channelId: slackDestination?.channelId,
+            actorId: slackActor?.userId,
+            runId,
+          },
+          modelId: activeModelId,
+          modelProfile: activeModelProfile,
+          onCompactionStart: () =>
+            observers.onStatus?.({ text: "Compacting context" }),
+          pendingMessages,
+          piMessages: messages,
+          signal: hookSignal,
+        },
+        {
+          completeText: (args) => completeText(args),
+        },
+      );
+      if (!compaction.compacted || !compaction.piMessages) {
+        return undefined;
+      }
+
+      const replacement = [...compaction.piMessages];
+      await runResume.requireDurableInputCheckpoint(replacement);
+      agent!.state.messages = replacement;
+      runResume.setBeforeMessageCount(replacement.length);
+      runResume.setTurnStartMessageIndex(0);
+      runResume.adoptCommittedBoundary(replacement);
+      if (clearSteeringQueueOnCommit && pendingMessages?.length) {
+        agent!.clearSteeringQueue();
+      }
+      return {
+        context: {
+          systemPrompt: baseInstructions,
+          messages: replacement,
+          tools: agent!.state.tools,
+        },
+      };
+    };
     // ── Agent execution ──────────────────────────────────────────────
     let assistantMessageDeliveryError:
       | AssistantMessageDeliveryError
@@ -802,11 +857,20 @@ async function executeAgentRunInPrivacyContext(
         throw assistantMessageDeliveryError;
       }
     };
-    const drainSteeringMessages = async (): Promise<void> => {
+    const drainSteeringMessages = async (): Promise<
+      Array<{
+        message: PiMessage;
+        provenance: ConversationMessageProvenance;
+      }>
+    > => {
       if (!durability.drainSteeringMessages) {
-        return;
+        return [];
       }
 
+      const acceptedMessages: Array<{
+        message: PiMessage;
+        provenance: ConversationMessageProvenance;
+      }> = [];
       try {
         let steeredMessageCount = 0;
         await durability.drainSteeringMessages(async (messages) => {
@@ -824,6 +888,12 @@ async function executeAgentRunInPrivacyContext(
           for (const message of piMessages) {
             agent!.steer(message);
           }
+          acceptedMessages.push(
+            ...piMessages.map((message, index) => ({
+              message,
+              provenance: messages[index]!.provenance,
+            })),
+          );
           steeredMessageCount += piMessages.length;
         });
         if (steeredMessageCount > 0) {
@@ -850,13 +920,14 @@ async function executeAgentRunInPrivacyContext(
           "Agent turn steering message drain failed",
         );
       }
+      return acceptedMessages;
     };
 
     const apiKeyOverride = getPiGatewayApiKey();
     // Pi converts prepareNextTurn exceptions into error turns instead of
     // rejecting. Preserve Junior's yield so runAgentStep can restore it after
     // the Pi run settles without leaking Pi mechanics into the resume API.
-    let pendingPiHookError: CooperativeTurnYieldError | undefined;
+    let pendingPiHookError: Error | undefined;
     agent = new Agent({
       ...(apiKeyOverride ? { getApiKey: () => apiKeyOverride } : {}),
       streamFn: createTracedStreamFn({ conversationPrivacy }),
@@ -881,15 +952,30 @@ async function executeAgentRunInPrivacyContext(
         runResume.timedOut && signal?.aborted
           ? annotateTurnDeadlineToolResult(result)
           : undefined,
-      prepareNextTurn: async () => {
-        const update = applyPendingHandoff();
-        await drainSteeringMessages();
-        const yieldError = runResume.prepareYieldIfDue(currentAgentMessages());
-        if (yieldError) {
-          pendingPiHookError = yieldError;
-          throw yieldError;
+      prepareNextTurnWithContext: async (nextTurn, hookSignal) => {
+        try {
+          const handoffUpdate = applyPendingHandoff();
+          const pendingMessages = await drainSteeringMessages();
+          const capacityUpdate = handoffUpdate
+            ? undefined
+            : await applyActiveContextCompaction(
+                nextTurn.context.messages as PiMessage[],
+                hookSignal,
+                pendingMessages,
+                true,
+              );
+          const yieldError = runResume.prepareYieldIfDue(
+            currentAgentMessages(),
+          );
+          if (yieldError) {
+            throw yieldError;
+          }
+          return capacityUpdate ?? handoffUpdate;
+        } catch (error) {
+          pendingPiHookError =
+            error instanceof Error ? error : new Error(String(error));
+          throw error;
         }
-        return update;
       },
       initialState: {
         systemPrompt: baseInstructions,
@@ -1079,9 +1165,56 @@ async function executeAgentRunInPrivacyContext(
             return result;
           };
 
-          let run: Promise<unknown> = shouldPromptAgent
-            ? agent!.prompt(freshPromptMessage)
-            : agent!.continue();
+          const requestedProfile =
+            activeModelProfile === STANDARD_MODEL_PROFILE
+              ? turnRoute!.profile
+              : undefined;
+          let run: Promise<unknown>;
+          if (requestedProfile && requestedProfile !== STANDARD_MODEL_PROFILE) {
+            const handoffAbortController = new AbortController();
+            await runAgentStep(
+              scheduleHandoff({
+                profile: requestedProfile,
+                runtimeContextSourceMessages: shouldPromptAgent
+                  ? [freshPromptMessage]
+                  : undefined,
+                signal: handoffAbortController.signal,
+                sourceMessages: [...agent!.state.messages],
+              }),
+              () => handoffAbortController.abort(),
+            );
+            applyPendingHandoff();
+            if (shouldPromptAgent) {
+              await runResume.requireDurableInputCheckpoint([
+                ...agent!.state.messages,
+                freshPromptMessage,
+              ]);
+              run = agent!.prompt(freshPromptMessage);
+            } else {
+              run = agent!.continue();
+            }
+          } else {
+            const compactionAbortController = new AbortController();
+            const capacityUpdate = await runAgentStep(
+              applyActiveContextCompaction(
+                [...agent!.state.messages],
+                compactionAbortController.signal,
+                shouldPromptAgent
+                  ? [
+                      {
+                        message: freshPromptMessage,
+                        provenance: instructionProvenanceFor(actor),
+                      },
+                    ]
+                  : undefined,
+              ),
+              () => compactionAbortController.abort(),
+            );
+            run =
+              shouldPromptAgent && !capacityUpdate
+                ? agent!.prompt(freshPromptMessage)
+                : agent!.continue();
+          }
           let retryUsage: AgentTurnUsage | undefined;
           try {
             for (let attempt = 0; ; attempt += 1) {

--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -963,21 +963,23 @@ async function executeAgentRunInPrivacyContext(
         try {
           const handoffUpdate = applyPendingHandoff();
           const pendingMessages = await drainSteeringMessages();
-          const capacityUpdate = handoffUpdate
-            ? undefined
-            : await applyActiveContextCompaction(
-                nextTurn.context.messages as PiMessage[],
-                hookSignal,
-                pendingMessages,
-                true,
-              );
+          const capacityUpdate = await applyActiveContextCompaction(
+            handoffUpdate
+              ? currentAgentMessages()
+              : (nextTurn.context.messages as PiMessage[]),
+            hookSignal,
+            pendingMessages,
+            true,
+          );
           const yieldError = runResume.prepareYieldIfDue(
             currentAgentMessages(),
           );
           if (yieldError) {
             throw yieldError;
           }
-          return capacityUpdate ?? handoffUpdate;
+          return capacityUpdate && handoffUpdate
+            ? { ...handoffUpdate, ...capacityUpdate }
+            : (capacityUpdate ?? handoffUpdate);
         } catch (error) {
           pendingPiHookError =
             error instanceof Error ? error : new Error(String(error));
@@ -1177,6 +1179,7 @@ async function executeAgentRunInPrivacyContext(
               ? turnRoute!.profile
               : undefined;
           let run: Promise<unknown>;
+          let handoffApplied = false;
           if (requestedProfile && requestedProfile !== STANDARD_MODEL_PROFILE) {
             const handoffAbortController = new AbortController();
             await runAgentStep(
@@ -1190,38 +1193,34 @@ async function executeAgentRunInPrivacyContext(
               }),
               () => handoffAbortController.abort(),
             );
-            applyPendingHandoff();
-            if (shouldPromptAgent) {
-              await runResume.requireDurableInputCheckpoint([
-                ...agent!.state.messages,
-                freshPromptMessage,
-              ]);
-              run = agent!.prompt(freshPromptMessage);
-            } else {
-              run = agent!.continue();
-            }
-          } else {
-            const compactionAbortController = new AbortController();
-            const capacityUpdate = await runAgentStep(
-              applyActiveContextCompaction(
-                [...agent!.state.messages],
-                compactionAbortController.signal,
-                shouldPromptAgent
-                  ? [
-                      {
-                        message: freshPromptMessage,
-                        provenance: instructionProvenanceFor(actor),
-                      },
-                    ]
-                  : undefined,
-              ),
-              () => compactionAbortController.abort(),
-            );
-            run =
-              shouldPromptAgent && !capacityUpdate
-                ? agent!.prompt(freshPromptMessage)
-                : agent!.continue();
+            handoffApplied = Boolean(applyPendingHandoff());
           }
+          const compactionAbortController = new AbortController();
+          const capacityUpdate = await runAgentStep(
+            applyActiveContextCompaction(
+              [...agent!.state.messages],
+              compactionAbortController.signal,
+              shouldPromptAgent
+                ? [
+                    {
+                      message: freshPromptMessage,
+                      provenance: instructionProvenanceFor(actor),
+                    },
+                  ]
+                : undefined,
+            ),
+            () => compactionAbortController.abort(),
+          );
+          if (shouldPromptAgent && handoffApplied && !capacityUpdate) {
+            await runResume.requireDurableInputCheckpoint([
+              ...agent!.state.messages,
+              freshPromptMessage,
+            ]);
+          }
+          run =
+            shouldPromptAgent && !capacityUpdate
+              ? agent!.prompt(freshPromptMessage)
+              : agent!.continue();
           let retryUsage: AgentTurnUsage | undefined;
           try {
             for (let attempt = 0; ; attempt += 1) {

--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -269,7 +269,7 @@ async function executeAgentRunInPrivacyContext(
   let mcpToolManager: McpToolManager | undefined;
   let connectedMcpProviders = new Set<string>();
   let turnUsage: AgentTurnUsage | undefined;
-  let handoffPhaseUsage: AgentTurnUsage | undefined;
+  let priorPhaseUsage: AgentTurnUsage | undefined;
   const configuredReasoningLevel =
     policy.reasoningLevel ?? botConfig.reasoningLevel;
   let turnRoute: TurnRoute | undefined = configuredReasoningLevel
@@ -586,6 +586,16 @@ async function executeAgentRunInPrivacyContext(
         )
         .sort(),
     ];
+    const usageSinceCurrentBoundary = (
+      messages: PiMessage[],
+    ): AgentTurnUsage | undefined => {
+      const usage = extractGenAiUsageSummary(
+        ...messages
+          .slice(runResume.beforeMessageCount)
+          .filter(isAssistantMessage),
+      );
+      return hasAgentTurnUsage(usage) ? usage : undefined;
+    };
     /** Commit the durable handoff epoch before staging its in-memory model swap. */
     const scheduleHandoff = async (args: {
       profile: ModelProfile;
@@ -600,14 +610,7 @@ async function executeAgentRunInPrivacyContext(
       const runtimeContext = retainRuntimeTurnContext(
         args.runtimeContextSourceMessages ?? args.sourceMessages,
       );
-      const standardPhaseUsage = extractGenAiUsageSummary(
-        ...args.sourceMessages
-          .slice(runResume.beforeMessageCount)
-          .filter(isAssistantMessage),
-      );
-      const phaseUsage = hasAgentTurnUsage(standardPhaseUsage)
-        ? standardPhaseUsage
-        : undefined;
+      const phaseUsage = usageSinceCurrentBoundary(args.sourceMessages);
       const selectedProfile = profileConfig(botConfig, args.profile);
       const handoffReasoningLevel =
         selectedProfile.reasoningLevel ?? turnRoute!.reasoningLevel;
@@ -659,7 +662,7 @@ async function executeAgentRunInPrivacyContext(
           reason: `profile_reasoning_override:${args.profile}:${turnRoute!.reason}`,
         };
       }
-      handoffPhaseUsage = phaseUsage;
+      priorPhaseUsage = addAgentTurnUsage(priorPhaseUsage, phaseUsage);
       pendingHandoff = {
         messages: handoffMessages,
         model: handoffModel,
@@ -819,6 +822,10 @@ async function executeAgentRunInPrivacyContext(
         return undefined;
       }
 
+      priorPhaseUsage = addAgentTurnUsage(
+        priorPhaseUsage,
+        usageSinceCurrentBoundary(messages),
+      );
       const replacement = [...compaction.piMessages];
       await runResume.requireDurableInputCheckpoint(replacement);
       agent!.state.messages = replacement;
@@ -1242,10 +1249,7 @@ async function executeAgentRunInPrivacyContext(
                 retryUsage,
                 currentUsage,
               );
-              turnUsage = addAgentTurnUsage(
-                handoffPhaseUsage,
-                currentPhaseUsage,
-              );
+              turnUsage = addAgentTurnUsage(priorPhaseUsage, currentPhaseUsage);
               setSpanAttributes({
                 ...(outputMessagesAttribute
                   ? { "gen_ai.output.messages": outputMessagesAttribute }

--- a/packages/junior/src/chat/config.ts
+++ b/packages/junior/src/chat/config.ts
@@ -20,6 +20,7 @@ const DEFAULT_FUNCTION_MAX_DURATION_SECONDS = 300;
 const DEFAULT_SLACK_SLASH_COMMAND = "/jr";
 const DEFAULT_PROCESSING_REACTION_EMOJI = "eyes";
 const DEFAULT_COMPLETED_REACTION_EMOJI = "white_check_mark";
+const DEFAULT_MODEL_CONTEXT_WINDOW_TOKENS = 400_000;
 /**
  * Buffer between the Vercel function timeout and the agent turn timeout so
  * Junior can abort, persist, and schedule continuation before host teardown.
@@ -43,13 +44,13 @@ const DEFAULT_ASSISTANT_LOADING_MESSAGES = [
 ] as const;
 
 export interface BotConfig {
+  contextWindowTokens: number;
   embeddingModelId: string;
   fastModelId: string;
   imageGenerationModelId: string;
   loadingMessages: string[];
   profiles: Readonly<Record<string, ExecutionProfileConfig>>;
   reasoningLevel?: TurnReasoningLevel;
-  modelContextWindowTokens?: number;
   visionModelId?: string;
   maxSlicesPerTurn: number;
   turnTimeoutMs: number;
@@ -283,10 +284,11 @@ function readBotConfig(
   return {
     userName: toOptionalTrimmed(env.JUNIOR_BOT_NAME) ?? "junior",
     profiles: parseProfiles(env.AI_MODEL_PROFILES, modelId, handoffModelId),
-    modelContextWindowTokens: parseOptionalPositiveInteger(
-      "AI_MODEL_CONTEXT_WINDOW_TOKENS",
-      env.AI_MODEL_CONTEXT_WINDOW_TOKENS,
-    ),
+    contextWindowTokens:
+      parseOptionalPositiveInteger(
+        "AI_MODEL_CONTEXT_WINDOW_TOKENS",
+        env.AI_MODEL_CONTEXT_WINDOW_TOKENS,
+      ) ?? DEFAULT_MODEL_CONTEXT_WINDOW_TOKENS,
     reasoningLevel:
       reasoningLevel === undefined
         ? undefined

--- a/packages/junior/src/chat/conversations/history.ts
+++ b/packages/junior/src/chat/conversations/history.ts
@@ -53,6 +53,19 @@ const replacementHistoryMessageSchema = conversationMessageDataSchema.extend({
  */
 const replacementHistorySchema = z.array(replacementHistoryMessageSchema);
 
+const compactionDetailsSchema = z
+  .object({
+    reason: z.literal("capacity"),
+    estimatedInputTokens: z.number().int().nonnegative(),
+    replacementInputTokens: z.number().int().nonnegative().optional(),
+    triggerTokens: z.number().int().nonnegative(),
+    inputLimitTokens: z.number().int().positive(),
+    inputMessageCount: z.number().int().nonnegative(),
+    retainedMessageCount: z.number().int().nonnegative(),
+    summaryChars: z.number().int().nonnegative(),
+  })
+  .strict();
+
 const historyReplacementEventDataSchema = z.discriminatedUnion("type", [
   z
     .object({
@@ -69,6 +82,7 @@ const historyReplacementEventDataSchema = z.discriminatedUnion("type", [
       type: z.literal("compaction"),
       modelProfile: modelProfileSchema,
       modelId: z.string().min(1),
+      details: compactionDetailsSchema.optional(),
       replacementHistory: replacementHistorySchema,
     })
     .strict(),

--- a/packages/junior/src/chat/runtime/reply-executor.ts
+++ b/packages/junior/src/chat/runtime/reply-executor.ts
@@ -10,7 +10,12 @@ import type { Message, Thread } from "chat";
 import type { SlackAdapter } from "@chat-adapter/slack";
 import { createSlackSource, type Destination } from "@sentry/junior-plugin-api";
 import { botConfig } from "@/chat/config";
-import { standardModelId } from "@/chat/model-profile";
+import {
+  modelIdForProfile,
+  STANDARD_MODEL_PROFILE,
+  standardModelId,
+  type ModelProfile,
+} from "@/chat/model-profile";
 import { getSlackMessageTs } from "@/chat/slack/message";
 import { readSlackActionToken } from "@/chat/slack/action-token";
 import {
@@ -128,7 +133,6 @@ import {
 } from "@/chat/conversations/provenance";
 import {
   commitMessages,
-  loadProjection,
   loadConversationProjection,
 } from "@/chat/conversations/projection";
 import { getStateAdapter } from "@/chat/state/adapter";
@@ -337,6 +341,7 @@ function collectTurnAttachments(
 
 interface LoadedPiMessagesForTurn {
   canCompact?: boolean;
+  modelProfile?: ModelProfile;
   piMessages?: PiMessage[];
 }
 
@@ -367,13 +372,14 @@ async function loadPiMessagesForTurn(args: {
     }
   }
 
-  const projection = await loadProjection({
+  const projection = await loadConversationProjection({
     conversationId: args.conversationId,
   });
-  if (projection.length > 0) {
+  if (projection.messages.length > 0) {
     return {
       canCompact: true,
-      piMessages: projection,
+      modelProfile: projection.modelProfile,
+      piMessages: projection.messages,
     };
   }
 
@@ -1115,6 +1121,10 @@ export function createReplyToThread(deps: ReplyExecutorDeps) {
                 },
                 onCompactionStart: () => status.update(compactingStatus),
                 piMessages,
+                modelId: modelIdForProfile(
+                  botConfig,
+                  loadedPiMessages.modelProfile ?? STANDARD_MODEL_PROFILE,
+                ),
               });
             if (compaction.compacted) {
               piMessages = compaction.piMessages;

--- a/packages/junior/src/chat/services/context-budget.ts
+++ b/packages/junior/src/chat/services/context-budget.ts
@@ -1,16 +1,13 @@
 import { botConfig } from "@/chat/config";
-import { standardModelId } from "@/chat/model-profile";
 import { resolveGatewayModel } from "@/chat/pi/client";
 
-const COMPACTION_TRIGGER_INPUT_RATIO = 0.75;
-const COMPACTION_OUTPUT_RESERVE_RATIO = 0.25;
+const COMPACTION_TRIGGER_RATIO = 0.9;
+const CONTEXT_INPUT_LIMIT_RATIO = 0.95;
 const COMPACTION_TARGET_RATIO = 0.8;
 const FALLBACK_CONTEXT_WINDOW_TOKENS = 400_000;
-const FALLBACK_MAX_OUTPUT_TOKENS = 128_000;
 
 export interface ModelContextBudget {
   contextWindow: number;
-  maxTokens: number;
 }
 
 function positiveInteger(value: number, fallback: number): number {
@@ -30,19 +27,18 @@ export function calculateContextCompactionTriggerTokens(
     model.contextWindow,
     FALLBACK_CONTEXT_WINDOW_TOKENS,
   );
-  const maxTokens = positiveInteger(
-    model.maxTokens,
-    FALLBACK_MAX_OUTPUT_TOKENS,
+  return Math.max(1, Math.floor(contextWindow * COMPACTION_TRIGGER_RATIO));
+}
+
+/** Derive the maximum estimated input size with room for uncounted request overhead. */
+export function calculateContextInputLimitTokens(
+  model: ModelContextBudget,
+): number {
+  const contextWindow = positiveInteger(
+    model.contextWindow,
+    FALLBACK_CONTEXT_WINDOW_TOKENS,
   );
-  const outputReserve = Math.min(
-    maxTokens,
-    Math.floor(contextWindow * COMPACTION_OUTPUT_RESERVE_RATIO),
-  );
-  const usableInputTokens = Math.max(1, contextWindow - outputReserve);
-  return Math.max(
-    1,
-    Math.floor(usableInputTokens * COMPACTION_TRIGGER_INPUT_RATIO),
-  );
+  return Math.max(1, Math.floor(contextWindow * CONTEXT_INPUT_LIMIT_RATIO));
 }
 
 /** Derive the post-compaction target from the automatic trigger threshold. */
@@ -52,20 +48,38 @@ export function calculateContextCompactionTargetTokens(
   return Math.max(1, Math.floor(triggerTokens * COMPACTION_TARGET_RATIO));
 }
 
+/** Cap one model's advertised context capacity with the host bot configuration. */
+export function getModelContextBudget(modelId: string): ModelContextBudget {
+  const model = resolveGatewayModel(modelId);
+  const advertisedContextWindow = positiveInteger(
+    model.contextWindow,
+    FALLBACK_CONTEXT_WINDOW_TOKENS,
+  );
+  return {
+    contextWindow: Math.min(
+      botConfig.contextWindowTokens,
+      advertisedContextWindow,
+    ),
+  };
+}
+
 /** Resolve the automatic compaction threshold for the active agent model. */
-export function getAgentContextCompactionTriggerTokens(): number {
-  const model = resolveGatewayModel(standardModelId(botConfig));
-  return calculateContextCompactionTriggerTokens({
-    contextWindow: botConfig.modelContextWindowTokens ?? model.contextWindow,
-    maxTokens: model.maxTokens,
-  });
+export function getAgentContextCompactionTriggerTokens(
+  modelId: string,
+): number {
+  return calculateContextCompactionTriggerTokens(
+    getModelContextBudget(modelId),
+  );
+}
+
+/** Resolve the hard input ceiling for the active agent model. */
+export function getAgentContextInputLimitTokens(modelId: string): number {
+  return calculateContextInputLimitTokens(getModelContextBudget(modelId));
 }
 
 /** Resolve the visible conversation compaction threshold for the auxiliary model. */
 export function getConversationContextCompactionTriggerTokens(): number {
-  const model = resolveGatewayModel(botConfig.fastModelId);
-  return calculateContextCompactionTriggerTokens({
-    contextWindow: model.contextWindow,
-    maxTokens: model.maxTokens,
-  });
+  return calculateContextCompactionTriggerTokens(
+    getModelContextBudget(botConfig.fastModelId),
+  );
 }

--- a/packages/junior/src/chat/services/context-compaction.ts
+++ b/packages/junior/src/chat/services/context-compaction.ts
@@ -7,10 +7,6 @@
  * handoff starts a profile-bound epoch with only its summary. Normal checkpoints
  * may later append the current bootstrap; future replacement strips it again.
  */
-import {
-  estimateContextTokens,
-  estimateTokens,
-} from "@earendil-works/pi-agent-core";
 import { botConfig } from "@/chat/config";
 import {
   renderCurrentInstruction,
@@ -21,6 +17,7 @@ import type { PiMessage } from "@/chat/pi/messages";
 import {
   estimateTextTokens,
   getAgentContextCompactionTriggerTokens,
+  getAgentContextInputLimitTokens,
 } from "@/chat/services/context-budget";
 import {
   contextProvenance,
@@ -31,6 +28,7 @@ import { getConversationEventStore } from "@/chat/db";
 import type { ThreadConversationState } from "@/chat/state/conversation";
 import { logWarn, setSpanAttributes } from "@/chat/logging";
 import {
+  retainRuntimeTurnContext,
   stripRuntimeTurnContext,
   trimTrailingAssistantMessages,
 } from "@/chat/pi/transcript";
@@ -62,7 +60,7 @@ export interface CompactContextArgs {
   conversation: ThreadConversationState;
   conversationContext?: string;
   conversationId: string;
-  onCompactionStart?: () => void;
+  onCompactionStart?: () => void | Promise<void>;
   piMessages: PiMessage[];
   metadata?: {
     channelId?: string;
@@ -70,6 +68,7 @@ export interface CompactContextArgs {
     runId?: string;
     threadId?: string;
   };
+  modelId: string;
 }
 
 export interface CompactContextResult {
@@ -91,6 +90,34 @@ interface HandoffContextArgs {
     modelProfile: ModelProfile;
     reasoningLevel?: string;
   };
+}
+
+interface ActiveContextCompactionArgs {
+  conversationContext?: string;
+  conversationId: string;
+  metadata?: CompactContextArgs["metadata"];
+  modelId: string;
+  modelProfile: ModelProfile;
+  onCompactionStart?: () => void | Promise<void>;
+  pendingMessages?: Array<{
+    message: PiMessage;
+    provenance: ConversationMessageProvenance;
+  }>;
+  piMessages: PiMessage[];
+  signal?: AbortSignal;
+}
+
+/** Raised when Junior cannot compact history below the active model's hard ceiling. */
+export class ContextInputLimitExceededError extends Error {
+  constructor(
+    readonly estimatedTokens: number,
+    readonly inputLimitTokens: number,
+  ) {
+    super(
+      `Agent context is ${estimatedTokens} estimated input tokens, above the ${inputLimitTokens} token limit`,
+    );
+    this.name = "ContextInputLimitExceededError";
+  }
 }
 
 function textPart(value: unknown): string | undefined {
@@ -335,12 +362,11 @@ async function summarizeContext(
 
 function estimateHistoryTokens(messages: PiMessage[]): number {
   const stripped = stripRuntimeTurnContext(messages);
-  const usageEstimate = estimateContextTokens(stripped).tokens;
-  const structuralEstimate = stripped.reduce(
-    (total, message) => total + estimateTokens(message),
+  return stripped.reduce(
+    (total, message) =>
+      total + estimateTextTokens(JSON.stringify(message) ?? ""),
     0,
   );
-  return Math.max(usageEstimate, structuralEstimate);
 }
 
 /**
@@ -391,12 +417,12 @@ async function maybeCompactWithDeps(
 
   const triggerTokens =
     deps.autoCompactionTriggerTokens ??
-    getAgentContextCompactionTriggerTokens();
+    getAgentContextCompactionTriggerTokens(args.modelId);
   if (source.estimatedTokens <= triggerTokens) {
     return { compacted: false, reason: "below_threshold" };
   }
 
-  args.onCompactionStart?.();
+  await args.onCompactionStart?.();
 
   let summary: string;
   try {
@@ -431,6 +457,7 @@ async function maybeCompactWithDeps(
   return await writeCompactedThreadContext(args, source.messages, summary, {
     estimatedTokens: source.estimatedTokens,
     triggerTokens,
+    inputLimitTokens: getAgentContextInputLimitTokens(args.modelId),
   });
 }
 
@@ -445,6 +472,7 @@ async function writeCompactedThreadContext(
   context: {
     estimatedTokens: number;
     triggerTokens?: number;
+    inputLimitTokens: number;
   },
 ): Promise<CompactContextResult> {
   const eventStore = getConversationEventStore();
@@ -458,6 +486,7 @@ async function writeCompactedThreadContext(
     ...retained.map((entry) => entry.message),
     userMessage(`${COMPACTION_SUMMARY_PREFIX}\n${summary}`),
   ];
+  const replacementInputTokens = estimateHistoryTokens(replacement);
   // Provenance comes from the committed projection so retained user asks keep
   // their original instruction author across the compaction epoch.
   const replacementProvenance = buildReplacementProvenance({
@@ -470,6 +499,18 @@ async function writeCompactedThreadContext(
       type: "compaction",
       modelProfile: sourceProjection.modelProfile,
       modelId: modelIdForProfile(botConfig, sourceProjection.modelProfile),
+      details: {
+        reason: "capacity",
+        estimatedInputTokens: context.estimatedTokens,
+        replacementInputTokens,
+        triggerTokens:
+          context.triggerTokens ??
+          getAgentContextCompactionTriggerTokens(args.modelId),
+        inputLimitTokens: context.inputLimitTokens,
+        inputMessageCount: sourceMessages.length,
+        retainedMessageCount: replacement.length - 1,
+        summaryChars: summary.length,
+      },
       replacementHistory: replacement.map((message, index) => {
         const sourceEventSeq =
           index < retained.length
@@ -551,4 +592,130 @@ export async function compactContextForHandoff(
     },
   });
   return messages;
+}
+
+/**
+ * Replace oversized active history at Pi's next-turn boundary before another
+ * provider request can observe it.
+ */
+export async function compactActiveContextIfNeeded(
+  args: ActiveContextCompactionArgs,
+  deps: Pick<ContextCompactorDeps, "completeText">,
+): Promise<CompactContextResult> {
+  const pendingMessages = args.pendingMessages ?? [];
+  const source = loadCompactionSource([
+    ...args.piMessages,
+    ...pendingMessages.map((entry) => entry.message),
+  ]);
+  if ("reason" in source) {
+    return { compacted: false, reason: source.reason };
+  }
+  const triggerTokens = getAgentContextCompactionTriggerTokens(args.modelId);
+  if (source.estimatedTokens <= triggerTokens) {
+    return { compacted: false, reason: "below_threshold" };
+  }
+
+  await args.onCompactionStart?.();
+
+  const inputLimitTokens = getAgentContextInputLimitTokens(args.modelId);
+  let summary: string;
+  try {
+    summary = await summarizeContext(
+      {
+        ...args,
+        piMessages: args.piMessages,
+      },
+      deps,
+    );
+  } catch (error) {
+    if (source.estimatedTokens >= inputLimitTokens) {
+      throw new ContextInputLimitExceededError(
+        source.estimatedTokens,
+        inputLimitTokens,
+      );
+    }
+    logWarn(
+      "active_context_compaction_summary_failed",
+      {
+        messageConversationId: args.metadata?.threadId,
+        userId: args.metadata?.actorId,
+        destinationName: args.metadata?.channelId,
+        runId: args.metadata?.runId,
+        assistantUserName: botConfig.userName,
+        modelId: args.modelId,
+      },
+      {
+        "app.context_input_limit_tokens": inputLimitTokens,
+        "app.context_tokens_estimated": source.estimatedTokens,
+        "exception.message":
+          error instanceof Error ? error.message : String(error),
+      },
+      "Active context compaction failed below the hard input limit",
+    );
+    return { compacted: false, reason: "summary_failed" };
+  }
+
+  const summaryText = `${COMPACTION_SUMMARY_PREFIX}\n${summary}`;
+  const runtimeMessage = retainRuntimeTurnContext(args.piMessages).at(-1) as
+    | { content: unknown[] }
+    | undefined;
+  const summaryMessages = runtimeMessage
+    ? [
+        {
+          ...runtimeMessage,
+          content: [
+            ...runtimeMessage.content,
+            { type: "text", text: renderCurrentInstruction(summaryText) },
+          ],
+        } as PiMessage,
+      ]
+    : [userMessage(renderCurrentInstruction(summaryText))];
+  const messages = [
+    ...summaryMessages,
+    ...pendingMessages.map((entry) => entry.message),
+  ];
+  const replacementInputTokens = estimateHistoryTokens(messages);
+  if (replacementInputTokens >= inputLimitTokens) {
+    throw new ContextInputLimitExceededError(
+      replacementInputTokens,
+      inputLimitTokens,
+    );
+  }
+  const replacementMessages = stripRuntimeTurnContext(messages);
+  args.signal?.throwIfAborted();
+  await getConversationEventStore().replaceHistory(args.conversationId, {
+    createdAtMs: Date.now(),
+    data: {
+      type: "compaction",
+      modelProfile: args.modelProfile,
+      modelId: args.modelId,
+      details: {
+        reason: "capacity",
+        estimatedInputTokens: source.estimatedTokens,
+        replacementInputTokens,
+        triggerTokens,
+        inputLimitTokens,
+        inputMessageCount: source.messages.length,
+        retainedMessageCount: pendingMessages.length,
+        summaryChars: summary.length,
+      },
+      replacementHistory: replacementMessages.map((message, index) => ({
+        message,
+        provenance:
+          index === 0
+            ? contextProvenance
+            : (pendingMessages[index - 1]?.provenance ?? contextProvenance),
+      })),
+    },
+  });
+  setSpanAttributes({
+    "app.compaction.input_messages": source.messages.length,
+    "app.compaction.replacement_tokens": replacementInputTokens,
+    "app.compaction.retained_messages": pendingMessages.length,
+    "app.compaction.summary_chars": summary.length,
+    "app.compaction.trigger_tokens": triggerTokens,
+    "app.context_input_limit_tokens": inputLimitTokens,
+    "app.context_tokens_estimated": source.estimatedTokens,
+  });
+  return { compacted: true, piMessages: messages };
 }

--- a/packages/junior/src/chat/services/context-compaction.ts
+++ b/packages/junior/src/chat/services/context-compaction.ts
@@ -361,8 +361,9 @@ async function summarizeContext(
 }
 
 function estimateHistoryTokens(messages: PiMessage[]): number {
-  const stripped = stripRuntimeTurnContext(messages);
-  return stripped.reduce(
+  // Capacity checks must measure the live provider input. Runtime turn context
+  // is stripped only when the replacement is persisted for later turns.
+  return messages.reduce(
     (total, message) =>
       total + estimateTextTokens(JSON.stringify(message) ?? ""),
     0,

--- a/packages/junior/src/chat/tools/sandbox/edit-file.ts
+++ b/packages/junior/src/chat/tools/sandbox/edit-file.ts
@@ -35,7 +35,6 @@ interface EditFileResult {
   details:
     | {
         data: {
-          diff: string;
           first_changed_line?: number;
           path: string;
           replacements: number;
@@ -47,6 +46,7 @@ interface EditFileResult {
         replacements: number;
         status: "success";
         target: string;
+        truncated: boolean;
       }
     | {
         data: {
@@ -171,7 +171,6 @@ export async function editFile(params: {
     status: "success",
     target: params.path,
     data: {
-      diff: diff.diff,
       first_changed_line: diff.firstChangedLine,
       path: params.path,
       replacements: params.edits.length,
@@ -180,6 +179,7 @@ export async function editFile(params: {
     first_changed_line: diff.firstChangedLine,
     path: params.path,
     replacements: params.edits.length,
+    truncated: diff.truncated,
   });
 }
 

--- a/packages/junior/src/chat/tools/sandbox/text-edits.ts
+++ b/packages/junior/src/chat/tools/sandbox/text-edits.ts
@@ -1,4 +1,8 @@
-import { normalizeToLf } from "@/chat/tools/sandbox/file-utils";
+import {
+  MAX_TEXT_CHARS,
+  normalizeToLf,
+  truncateText,
+} from "@/chat/tools/sandbox/file-utils";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 
 export interface TextReplacement {
@@ -15,6 +19,21 @@ interface MatchedEdit {
   matchIndex: number;
   matchLength: number;
   newText: string;
+}
+
+const MAX_DIFF_LINE_CHARS = 4_000;
+
+function truncateDiffLine(value: string): {
+  line: string;
+  truncated: boolean;
+} {
+  if (value.length <= MAX_DIFF_LINE_CHARS) {
+    return { line: value, truncated: false };
+  }
+  return {
+    line: `${value.slice(0, MAX_DIFF_LINE_CHARS)}... [line truncated]`,
+    truncated: true,
+  };
 }
 
 /** Preserve a text artifact's dominant line-ending style across rewrites. */
@@ -117,6 +136,7 @@ export function buildCompactDiff(
 ): {
   diff: string;
   firstChangedLine?: number;
+  truncated: boolean;
 } {
   const oldLines = oldContent.split("\n");
   const newLines = newContent.split("\n");
@@ -145,32 +165,40 @@ export function buildCompactDiff(
   const oldContextEnd = Math.min(oldLines.length - 1, oldSuffix + 3);
   const width = String(Math.max(oldLines.length, newLines.length)).length;
   const output: string[] = [];
+  let lineTruncated = false;
+  const pushLine = (value: string): void => {
+    const bounded = truncateDiffLine(value);
+    output.push(bounded.line);
+    lineTruncated ||= bounded.truncated;
+  };
 
   if (contextStart > 0) {
-    output.push(` ${"".padStart(width)} ...`);
+    pushLine(` ${"".padStart(width)} ...`);
   }
   for (let index = contextStart; index < prefix; index += 1) {
-    output.push(` ${String(index + 1).padStart(width)} ${oldLines[index]}`);
+    pushLine(` ${String(index + 1).padStart(width)} ${oldLines[index]}`);
   }
   for (let index = prefix; index <= oldSuffix; index += 1) {
-    output.push(`-${String(index + 1).padStart(width)} ${oldLines[index]}`);
+    pushLine(`-${String(index + 1).padStart(width)} ${oldLines[index]}`);
   }
   for (let index = prefix; index <= newSuffix; index += 1) {
-    output.push(`+${String(index + 1).padStart(width)} ${newLines[index]}`);
+    pushLine(`+${String(index + 1).padStart(width)} ${newLines[index]}`);
   }
   for (let index = newSuffix + 1; index <= newContextEnd; index += 1) {
-    output.push(` ${String(index + 1).padStart(width)} ${newLines[index]}`);
+    pushLine(` ${String(index + 1).padStart(width)} ${newLines[index]}`);
   }
   if (
     newContextEnd < newLines.length - 1 ||
     oldContextEnd < oldLines.length - 1
   ) {
-    output.push(` ${"".padStart(width)} ...`);
+    pushLine(` ${"".padStart(width)} ...`);
   }
 
+  const bounded = truncateText(output.join("\n"), MAX_TEXT_CHARS);
   return {
-    diff: output.join("\n"),
+    diff: bounded.content,
     firstChangedLine: firstChangedLine(oldContent, newContent),
+    truncated: lineTruncated || bounded.truncated,
   };
 }
 

--- a/packages/junior/tests/component/config/chat-config.test.ts
+++ b/packages/junior/tests/component/config/chat-config.test.ts
@@ -293,11 +293,18 @@ describe("chat config", () => {
     expect(botConfig.visionModelId).toBe("openai/gpt-5.4");
   });
 
-  it("reads optional model context window overrides", async () => {
+  it("uses a 400k model context window cap by default", async () => {
+    delete process.env.AI_MODEL_CONTEXT_WINDOW_TOKENS;
+
+    const { botConfig } = await loadConfig();
+    expect(botConfig.contextWindowTokens).toBe(400_000);
+  });
+
+  it("reads model context window cap overrides", async () => {
     process.env.AI_MODEL_CONTEXT_WINDOW_TOKENS = "200000";
 
     const { botConfig } = await loadConfig();
-    expect(botConfig.modelContextWindowTokens).toBe(200000);
+    expect(botConfig.contextWindowTokens).toBe(200000);
   });
 
   it("throws when model context window overrides are invalid", async () => {

--- a/packages/junior/tests/component/services/context-compaction.test.ts
+++ b/packages/junior/tests/component/services/context-compaction.test.ts
@@ -32,20 +32,22 @@ describe("context compaction retained messages", () => {
     const {
       calculateContextCompactionTargetTokens,
       calculateContextCompactionTriggerTokens,
+      calculateContextInputLimitTokens,
     } = await import("@/chat/services/context-budget");
 
     const miniTrigger = calculateContextCompactionTriggerTokens({
       contextWindow: 400_000,
-      maxTokens: 128_000,
     });
-    expect(miniTrigger).toBe(225_000);
-    expect(calculateContextCompactionTargetTokens(miniTrigger)).toBe(180_000);
+    expect(miniTrigger).toBe(360_000);
+    expect(calculateContextInputLimitTokens({ contextWindow: 400_000 })).toBe(
+      380_000,
+    );
+    expect(calculateContextCompactionTargetTokens(miniTrigger)).toBe(288_000);
     expect(
       calculateContextCompactionTriggerTokens({
         contextWindow: 1_050_000,
-        maxTokens: 128_000,
       }),
-    ).toBe(691_500);
+    ).toBe(945_000);
   });
 
   it("uses configured model context windows for runtime thresholds", async () => {
@@ -61,14 +63,42 @@ describe("context compaction retained messages", () => {
         calculateContextCompactionTriggerTokens,
         getAgentContextCompactionTriggerTokens,
         getConversationContextCompactionTriggerTokens,
+        getModelContextBudget,
       } = await import("@/chat/services/context-budget");
       const { resolveGatewayModel } = await import("@/chat/pi/client");
 
-      expect(getAgentContextCompactionTriggerTokens()).toBe(112_500);
+      expect(getAgentContextCompactionTriggerTokens("openai/gpt-5.4")).toBe(
+        180_000,
+      );
+      expect(getModelContextBudget("openai/gpt-5.4")).toMatchObject({
+        contextWindow: 200_000,
+      });
       expect(getConversationContextCompactionTriggerTokens()).toBe(
-        calculateContextCompactionTriggerTokens(
-          resolveGatewayModel("openai/gpt-5.4-mini"),
-        ),
+        calculateContextCompactionTriggerTokens({
+          ...resolveGatewayModel("openai/gpt-5.4-mini"),
+          contextWindow: 200_000,
+        }),
+      );
+    } finally {
+      process.env = { ...ORIGINAL_ENV };
+      vi.resetModules();
+    }
+  });
+
+  it("never raises an active model's advertised context window", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      AI_MODEL_CONTEXT_WINDOW_TOKENS: "900000",
+    };
+    vi.resetModules();
+    try {
+      const { getModelContextBudget } =
+        await import("@/chat/services/context-budget");
+      const { resolveGatewayModel } = await import("@/chat/pi/client");
+      const model = resolveGatewayModel("anthropic/claude-haiku-4.5");
+
+      expect(getModelContextBudget(model.id).contextWindow).toBe(
+        model.contextWindow,
       );
     } finally {
       process.env = { ...ORIGINAL_ENV };
@@ -239,6 +269,7 @@ describe("context compaction projection reset", () => {
     const result = await compactor.maybeCompact({
       conversation,
       conversationId: "conversation-1",
+      modelId: "openai/gpt-5.4",
       piMessages: priorMessages,
     });
 
@@ -269,6 +300,187 @@ describe("context compaction projection reset", () => {
       fullName: "Alice Example",
       email: "alice@sentry.io",
     });
+  });
+
+  it("compacts active tool history before the next provider request", async () => {
+    const { compactActiveContextIfNeeded } =
+      await import("@/chat/services/context-compaction");
+    const { commitMessages, loadConversationProjection, loadProjection } =
+      await import("@/chat/conversations/projection");
+    const { getConversationEventStore } = await import("@/chat/db");
+    const conversationId = "conversation-active-capacity";
+    await commitMessages({
+      conversationId,
+      messages: [user("Make the requested edit.", 1)],
+    });
+    const activeMessages = [
+      user(
+        "<runtime-turn-context>\nFresh runtime context\n</runtime-turn-context>",
+        2,
+      ),
+      user("Make the requested edit.", 3),
+      {
+        role: "toolResult",
+        toolCallId: "edit-1",
+        toolName: "editFile",
+        content: [{ type: "text", text: "x".repeat(1_600_000) }],
+        isError: false,
+        timestamp: 4,
+      } as PiMessage,
+    ];
+
+    const result = await compactActiveContextIfNeeded(
+      {
+        conversationId,
+        modelId: "openai/gpt-5.4",
+        modelProfile: "standard",
+        pendingMessages: [
+          {
+            message: user("Also run the focused test.", 5),
+            provenance: {
+              authority: "instruction",
+              actor: {
+                platform: "slack",
+                teamId: "T123",
+                userId: "U_STEER",
+                userName: "steering-user",
+              },
+            },
+          },
+        ],
+        piMessages: activeMessages,
+      },
+      {
+        completeText: async () =>
+          ({ text: "The edit completed; verify the result." }) as never,
+      },
+    );
+
+    expect(result.compacted).toBe(true);
+    expect(result.piMessages).toHaveLength(2);
+    expect(textOf(result.piMessages![0]!)).toContain(
+      "<runtime-turn-context>\nFresh runtime context\n</runtime-turn-context>",
+    );
+    expect(textOf(result.piMessages![0]!)).toContain(
+      "The edit completed; verify the result.",
+    );
+    expect(textOf(result.piMessages![1]!)).toBe("Also run the focused test.");
+    const durable = await loadProjection({ conversationId });
+    expect(textOf(durable[0]!)).not.toContain("<runtime-turn-context>");
+    expect(textOf(durable[0]!)).toContain(
+      "The edit completed; verify the result.",
+    );
+    expect(textOf(durable[1]!)).toBe("Also run the focused test.");
+    const projection = await loadConversationProjection({ conversationId });
+    expect(projection.modelProfile).toBe("standard");
+    expect(projection.provenance[1]).toMatchObject({
+      authority: "instruction",
+      actor: { userId: "U_STEER" },
+    });
+    const compactionEvent = (
+      await getConversationEventStore().loadHistory(conversationId)
+    ).find((event) => event.data.type === "compaction");
+    expect(compactionEvent?.data).toMatchObject({
+      type: "compaction",
+      modelProfile: "standard",
+      modelId: "openai/gpt-5.4",
+      details: {
+        reason: "capacity",
+        triggerTokens: 360_000,
+        inputLimitTokens: 380_000,
+        inputMessageCount: 4,
+        retainedMessageCount: 1,
+        summaryChars: 38,
+      },
+    });
+    expect(
+      compactionEvent?.data.type === "compaction"
+        ? compactionEvent.data.details?.estimatedInputTokens
+        : undefined,
+    ).toBeGreaterThan(360_000);
+    expect(
+      compactionEvent?.data.type === "compaction"
+        ? compactionEvent.data.details?.replacementInputTokens
+        : undefined,
+    ).toBeLessThan(380_000);
+  });
+
+  it("blocks when retained pending input leaves the replacement above the hard limit", async () => {
+    const { compactActiveContextIfNeeded, ContextInputLimitExceededError } =
+      await import("@/chat/services/context-compaction");
+    const { commitMessages, loadProjection } =
+      await import("@/chat/conversations/projection");
+    const conversationId = "conversation-active-pending-hard-limit";
+    const original = [user("Keep this committed history.", 1)];
+    await commitMessages({ conversationId, messages: original });
+
+    await expect(
+      compactActiveContextIfNeeded(
+        {
+          conversationId,
+          modelId: "openai/gpt-5.4",
+          modelProfile: "standard",
+          pendingMessages: [
+            {
+              message: user(`Retain exactly: ${"y".repeat(1_600_000)}`, 3),
+              provenance: { authority: "instruction" },
+            },
+          ],
+          piMessages: [
+            ...original,
+            {
+              role: "toolResult",
+              toolCallId: "tool-1",
+              toolName: "oversized",
+              content: [{ type: "text", text: "x".repeat(1_600_000) }],
+              isError: false,
+              timestamp: 2,
+            } as PiMessage,
+          ],
+        },
+        {
+          completeText: async () => ({ text: "Short summary." }) as never,
+        },
+      ),
+    ).rejects.toBeInstanceOf(ContextInputLimitExceededError);
+    await expect(loadProjection({ conversationId })).resolves.toEqual(original);
+  });
+
+  it("blocks the next provider request when hard-limit compaction fails", async () => {
+    const { compactActiveContextIfNeeded, ContextInputLimitExceededError } =
+      await import("@/chat/services/context-compaction");
+    const { commitMessages, loadProjection } =
+      await import("@/chat/conversations/projection");
+    const conversationId = "conversation-active-hard-limit";
+    const original = [user("Keep this committed history.", 1)];
+    await commitMessages({ conversationId, messages: original });
+
+    await expect(
+      compactActiveContextIfNeeded(
+        {
+          conversationId,
+          modelId: "openai/gpt-5.4",
+          modelProfile: "standard",
+          piMessages: [
+            ...original,
+            {
+              role: "toolResult",
+              toolCallId: "tool-1",
+              toolName: "oversized",
+              content: [{ type: "text", text: "x".repeat(1_600_000) }],
+              isError: false,
+              timestamp: 2,
+            } as PiMessage,
+          ],
+        },
+        {
+          completeText: async () => {
+            throw new Error("summary provider unavailable");
+          },
+        },
+      ),
+    ).rejects.toBeInstanceOf(ContextInputLimitExceededError);
+    await expect(loadProjection({ conversationId })).resolves.toEqual(original);
   });
 
   it("handoff binds its named profile and later projection replacements inherit it", async () => {
@@ -364,6 +576,7 @@ describe("context compaction projection reset", () => {
     const compacted = await compactor.maybeCompact({
       conversation: coerceThreadConversationState({}),
       conversationId,
+      modelId: botConfig.profiles.handoff!.modelId,
       piMessages: handoffMessages,
     });
     expect(compacted.compacted).toBe(true);
@@ -580,6 +793,7 @@ describe("context compaction projection reset", () => {
     const result = await compactor.maybeCompact({
       conversation: coerceThreadConversationState({}),
       conversationId: "conversation-identical-retained-text",
+      modelId: "openai/gpt-5.4",
       piMessages: priorMessages,
     });
 
@@ -640,6 +854,7 @@ describe("context compaction projection reset", () => {
     await compactor.maybeCompact({
       conversation,
       conversationId: "conversation-large",
+      modelId: "openai/gpt-5.4",
       piMessages: priorMessages,
     });
 
@@ -707,6 +922,7 @@ describe("context compaction projection reset", () => {
     const result = await compactor.maybeCompact({
       conversation,
       conversationId: "conversation-tool-context",
+      modelId: "openai/gpt-5.4",
       piMessages: priorMessages,
     });
 
@@ -730,6 +946,7 @@ describe("context compaction projection reset", () => {
       compactor.maybeCompact({
         conversation,
         conversationId: "conversation-missing",
+        modelId: "openai/gpt-5.4",
         piMessages: [],
       }),
     ).resolves.toEqual({ compacted: false, reason: "missing_context" });

--- a/packages/junior/tests/component/services/context-compaction.test.ts
+++ b/packages/junior/tests/component/services/context-compaction.test.ts
@@ -405,7 +405,7 @@ describe("context compaction projection reset", () => {
     ).toBeLessThan(380_000);
   });
 
-  it("blocks when retained pending input leaves the replacement above the hard limit", async () => {
+  it("counts retained runtime context in the replacement hard limit", async () => {
     const { compactActiveContextIfNeeded, ContextInputLimitExceededError } =
       await import("@/chat/services/context-compaction");
     const { commitMessages, loadProjection } =
@@ -422,7 +422,20 @@ describe("context compaction projection reset", () => {
           modelProfile: "standard",
           pendingMessages: [
             {
-              message: user(`Retain exactly: ${"y".repeat(1_600_000)}`, 3),
+              message: {
+                role: "user",
+                content: [
+                  {
+                    type: "text",
+                    text: `<runtime-turn-context>\n${"y".repeat(1_600_000)}\n</runtime-turn-context>`,
+                  },
+                  {
+                    type: "text",
+                    text: "<current-instruction>\nRetain exactly.\n</current-instruction>",
+                  },
+                ],
+                timestamp: 3,
+              } as PiMessage,
               provenance: { authority: "instruction" },
             },
           ],

--- a/packages/junior/tests/integration/dashboard-reporting.test.ts
+++ b/packages/junior/tests/integration/dashboard-reporting.test.ts
@@ -394,7 +394,11 @@ describe("dashboard canonical event reporting", () => {
         subagentKind: "review",
         status: "completed",
       },
-      { type: "compaction" },
+      {
+        type: "compaction",
+        modelProfile: "standard",
+        modelId: "private-model-id",
+      },
       {
         type: "handoff",
         modelProfile: "fast",
@@ -408,7 +412,7 @@ describe("dashboard canonical event reporting", () => {
     expect(JSON.stringify(detail)).not.toContain(
       "private model-only duplicate",
     );
-    expect(JSON.stringify(detail)).not.toContain("private-model-id");
+    expect(JSON.stringify(detail)).toContain("private-model-id");
     expect(JSON.stringify(detail)).toContain("private-handoff-model-id");
     for (const removed of [
       "activity",

--- a/packages/junior/tests/integration/plugin-prompt-hooks.test.ts
+++ b/packages/junior/tests/integration/plugin-prompt-hooks.test.ts
@@ -29,10 +29,13 @@ vi.mock("@earendil-works/pi-agent-core", () => {
       systemPrompt: string;
       tools: unknown[];
     };
-    private prepareNextTurn?: () => Promise<unknown> | unknown;
+    private prepareNextTurn?: (context?: unknown) => Promise<unknown> | unknown;
 
     constructor(input: {
       prepareNextTurn?: () => Promise<unknown> | unknown;
+      prepareNextTurnWithContext?: (
+        context: unknown,
+      ) => Promise<unknown> | unknown;
       initialState: {
         model: unknown;
         systemPrompt: string;
@@ -46,7 +49,8 @@ vi.mock("@earendil-works/pi-agent-core", () => {
         systemPrompt: input.initialState.systemPrompt,
         tools: input.initialState.tools,
       };
-      this.prepareNextTurn = input.prepareNextTurn;
+      this.prepareNextTurn =
+        input.prepareNextTurnWithContext ?? input.prepareNextTurn;
     }
 
     subscribe() {
@@ -67,7 +71,9 @@ vi.mock("@earendil-works/pi-agent-core", () => {
     async prompt(message: unknown) {
       captured.promptMessages.push(message);
       this.state.messages.push(message);
-      await this.prepareNextTurn?.();
+      await this.prepareNextTurn?.({
+        context: { messages: this.state.messages },
+      });
       this.state.messages.push({
         role: "assistant",
         content: [{ type: "text", text: "Done." }],

--- a/packages/junior/tests/integration/plugin-run-actors.test.ts
+++ b/packages/junior/tests/integration/plugin-run-actors.test.ts
@@ -27,10 +27,13 @@ vi.mock("@earendil-works/pi-agent-core", () => {
       systemPrompt: string;
       tools: unknown[];
     };
-    private prepareNextTurn?: () => Promise<unknown> | unknown;
+    private prepareNextTurn?: (context?: unknown) => Promise<unknown> | unknown;
 
     constructor(input: {
       prepareNextTurn?: () => Promise<unknown> | unknown;
+      prepareNextTurnWithContext?: (
+        context: unknown,
+      ) => Promise<unknown> | unknown;
       initialState: {
         model: unknown;
         systemPrompt: string;
@@ -43,7 +46,8 @@ vi.mock("@earendil-works/pi-agent-core", () => {
         systemPrompt: input.initialState.systemPrompt,
         tools: input.initialState.tools,
       };
-      this.prepareNextTurn = input.prepareNextTurn;
+      this.prepareNextTurn =
+        input.prepareNextTurnWithContext ?? input.prepareNextTurn;
     }
 
     subscribe() {
@@ -63,7 +67,9 @@ vi.mock("@earendil-works/pi-agent-core", () => {
 
     async prompt(message: unknown) {
       this.state.messages.push(message);
-      await this.prepareNextTurn?.();
+      await this.prepareNextTurn?.({
+        context: { messages: this.state.messages },
+      });
       this.state.messages.push({
         role: "assistant",
         content: [{ type: "text", text: "Done." }],

--- a/packages/junior/tests/integration/runtime/agent-run-agent-continue.test.ts
+++ b/packages/junior/tests/integration/runtime/agent-run-agent-continue.test.ts
@@ -329,6 +329,7 @@ describe("executeAgentRun agent continuation", () => {
       },
     });
 
+    await waitForPromptCall(1);
     await vi.advanceTimersByTimeAsync(10_000);
     const outcome = await replyPromise;
 
@@ -420,6 +421,7 @@ describe("executeAgentRun agent continuation", () => {
       policy: { turnDeadlineAtMs: startedAtMs + 2_500 },
     });
 
+    await waitForPromptCall(1);
     await vi.advanceTimersByTimeAsync(2_500);
     const outcome = await replyPromise;
 

--- a/packages/junior/tests/integration/runtime/agent-run-model-handoff.test.ts
+++ b/packages/junior/tests/integration/runtime/agent-run-model-handoff.test.ts
@@ -201,6 +201,7 @@ import {
 import { disconnectStateAdapter } from "@/chat/state/adapter";
 import { getAgentTurnSessionRecord } from "@/chat/state/turn-session";
 import { getConversationEventStore } from "@/chat/db";
+import { ContextInputLimitExceededError } from "@/chat/services/context-compaction";
 
 const ORIGINAL_STATE_ADAPTER = process.env.JUNIOR_STATE_ADAPTER;
 
@@ -317,6 +318,29 @@ describe("executeAgentRun model handoff", () => {
         source: "router",
       },
     ]);
+  });
+
+  it("blocks oversized current input after a router handoff before the first provider request", async () => {
+    observations.routedModelProfile = "handoff";
+    const conversationId = "local:test:router-handoff-input-limit";
+    const outcome = await executeAgentRun({
+      conversationId,
+      runId: "run-router-handoff-input-limit",
+      turnId: "turn-router-handoff-input-limit",
+      input: { messageText: "x".repeat(1_600_000) },
+      routing: {
+        destination: { platform: "local", conversationId },
+        source: createLocalSource(conversationId),
+      },
+    });
+
+    expect(outcome.status).toBe("completed");
+    if (outcome.status !== "completed") return;
+    expect(outcome.result.diagnostics.outcome).toBe("provider_error");
+    expect(outcome.result.diagnostics.providerError).toBeInstanceOf(
+      ContextInputLimitExceededError,
+    );
+    expect(observations.providerCalls).toBe(0);
   });
 
   it("does not compact context while applying a router-selected profile", async () => {
@@ -494,6 +518,47 @@ describe("executeAgentRun model handoff", () => {
     expect(observations.afterHandoffToolNames).toContain("handoff");
     expect(observations.reasoningLevels).toEqual(["high", "high", "high"]);
     expect(observations.summaryCalls).toBe(1);
+  });
+
+  it("blocks oversized steering after a tool handoff before the next provider request", async () => {
+    observations.requestedProfile = "handoff";
+    const conversationId = "local:test:tool-handoff-input-limit";
+    let drained = false;
+    const outcome = await executeAgentRun({
+      conversationId,
+      runId: "run-tool-handoff-input-limit",
+      turnId: "turn-tool-handoff-input-limit",
+      input: { messageText: "Start the implementation." },
+      routing: {
+        destination: { platform: "local", conversationId },
+        source: createLocalSource(conversationId),
+      },
+      durability: {
+        drainSteeringMessages: async (inject) => {
+          if (drained) {
+            return [];
+          }
+          drained = true;
+          const messages = [
+            {
+              text: "y".repeat(1_600_000),
+              timestampMs: 2_000,
+              provenance: { authority: "instruction" as const },
+            },
+          ];
+          await inject(messages);
+          return messages;
+        },
+      },
+    });
+
+    expect(outcome.status).toBe("completed");
+    if (outcome.status !== "completed") return;
+    expect(outcome.result.diagnostics.outcome).toBe("provider_error");
+    expect(outcome.result.diagnostics.providerError).toBeInstanceOf(
+      ContextInputLimitExceededError,
+    );
+    expect(observations.providerCalls).toBe(1);
   });
 
   it("delivers only the tool-free assistant message after tool use", async () => {

--- a/packages/junior/tests/integration/runtime/agent-run-provider-retry.test.ts
+++ b/packages/junior/tests/integration/runtime/agent-run-provider-retry.test.ts
@@ -566,6 +566,10 @@ describe("executeAgentRun provider retry", () => {
     expect(statuses).toContain("Compacting context");
     expect(compactionState.summaryCalls).toBe(1);
     expect(compactionState.nextProviderContextChars).toBeLessThan(20_000);
+    expect(result.diagnostics.usage).toMatchObject({
+      inputTokens: 4,
+      outputTokens: 4,
+    });
     const history = await (await import("@/chat/db"))
       .getConversationEventStore()
       .loadHistory("conversation-active-compaction");

--- a/packages/junior/tests/integration/runtime/agent-run-provider-retry.test.ts
+++ b/packages/junior/tests/integration/runtime/agent-run-provider-retry.test.ts
@@ -6,28 +6,37 @@ import { renderCurrentInstruction } from "@/chat/current-instruction";
 import type { PiMessage } from "@/chat/pi/messages";
 import { readConversationDetail } from "@/api/conversations/detail";
 
-const { agentMode, counters, sessionLogState } = vi.hoisted(() => ({
-  agentMode: {
-    value: "providerRetry" as
-      | "providerRetry"
-      | "pendingProviderCall"
-      | "cooperativeYield"
-      | "terminalDelivery"
-      | "steering"
-      | "steeringDelivery"
-      | "steeringSteerThrows"
-      | "toolActivity",
-  },
-  counters: {
-    abortCalls: 0,
-    continueCalls: 0,
-    promptCalls: 0,
-  },
-  sessionLogState: {
-    failToolExecutionAppend: false,
-    toolExecutionAppendCalls: 0,
-  },
-}));
+const { agentMode, compactionState, counters, sessionLogState } = vi.hoisted(
+  () => ({
+    agentMode: {
+      value: "providerRetry" as
+        | "providerRetry"
+        | "activeCompaction"
+        | "preflightCompaction"
+        | "pendingProviderCall"
+        | "cooperativeYield"
+        | "terminalDelivery"
+        | "steering"
+        | "steeringDelivery"
+        | "steeringSteerThrows"
+        | "toolActivity",
+    },
+    compactionState: {
+      nextProviderContextChars: 0,
+      preflightContextText: "",
+      summaryCalls: 0,
+    },
+    counters: {
+      abortCalls: 0,
+      continueCalls: 0,
+      promptCalls: 0,
+    },
+    sessionLogState: {
+      failToolExecutionAppend: false,
+      toolExecutionAppendCalls: 0,
+    },
+  }),
+);
 
 async function realSleep(ms: number): Promise<void> {
   await new Promise<void>((resolve) => realSetTimeout(resolve, ms));
@@ -82,7 +91,7 @@ vi.mock("@earendil-works/pi-agent-core", () => {
       systemPrompt: string;
       tools: unknown[];
     };
-    private prepareNextTurn?: () => Promise<unknown> | unknown;
+    private prepareNextTurn?: (context?: unknown) => Promise<unknown> | unknown;
     private finishPendingRun?: () => void;
     private steeringMessages: unknown[] = [];
     private subscribers: Array<(event: unknown) => unknown> = [];
@@ -94,6 +103,9 @@ vi.mock("@earendil-works/pi-agent-core", () => {
         tools: unknown[];
       };
       prepareNextTurn?: () => Promise<unknown> | unknown;
+      prepareNextTurnWithContext?: (
+        context: unknown,
+      ) => Promise<unknown> | unknown;
     }) {
       this.state = {
         messages: [],
@@ -101,7 +113,8 @@ vi.mock("@earendil-works/pi-agent-core", () => {
         systemPrompt: input.initialState.systemPrompt,
         tools: input.initialState.tools,
       };
-      this.prepareNextTurn = input.prepareNextTurn;
+      this.prepareNextTurn =
+        input.prepareNextTurnWithContext ?? input.prepareNextTurn;
     }
 
     subscribe(subscriber: (event: unknown) => unknown) {
@@ -141,6 +154,51 @@ vi.mock("@earendil-works/pi-agent-core", () => {
     async prompt(message: unknown) {
       counters.promptCalls += 1;
       this.state.messages.push(message);
+      if (agentMode.value === "activeCompaction") {
+        const toolResult = {
+          role: "toolResult",
+          toolCallId: "call_oversized",
+          toolName: "editFile",
+          isError: false,
+          content: [{ type: "text", text: "x".repeat(1_600_000) }],
+        };
+        this.state.messages.push({
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call_oversized",
+              name: "editFile",
+              arguments: {},
+            },
+          ],
+          stopReason: "toolUse",
+          usage: { input: 2, output: 2 },
+        });
+        this.state.messages.push(toolResult);
+        await Promise.all(
+          this.subscribers.map((subscriber) =>
+            subscriber({
+              type: "turn_end",
+              message: this.state.messages.at(-2),
+              toolResults: [toolResult],
+            }),
+          ),
+        );
+        await this.prepareNextTurn?.({
+          context: { messages: this.state.messages },
+        });
+        compactionState.nextProviderContextChars = JSON.stringify(
+          this.state.messages,
+        ).length;
+        this.state.messages.push({
+          role: "assistant",
+          content: [{ type: "text", text: "Verified after compaction." }],
+          stopReason: "stop",
+          usage: { input: 2, output: 2 },
+        });
+        return {};
+      }
       if (agentMode.value === "pendingProviderCall") {
         await new Promise<void>((resolve) => {
           this.finishPendingRun = resolve;
@@ -205,7 +263,9 @@ vi.mock("@earendil-works/pi-agent-core", () => {
           ),
         );
         try {
-          await this.prepareNextTurn?.();
+          await this.prepareNextTurn?.({
+            context: { messages: this.state.messages },
+          });
         } catch (error) {
           this.recordRunFailure(error);
         }
@@ -232,7 +292,9 @@ vi.mock("@earendil-works/pi-agent-core", () => {
           );
         }
         try {
-          await this.prepareNextTurn?.();
+          await this.prepareNextTurn?.({
+            context: { messages: this.state.messages },
+          });
         } catch (error) {
           this.recordRunFailure(error);
           return {};
@@ -285,6 +347,35 @@ vi.mock("@earendil-works/pi-agent-core", () => {
 
     async continue() {
       counters.continueCalls += 1;
+      if (agentMode.value === "preflightCompaction") {
+        compactionState.preflightContextText = this.state.messages
+          .flatMap((message) => {
+            const content = (message as { content?: unknown }).content;
+            return Array.isArray(content)
+              ? content.map((part) =>
+                  part &&
+                  typeof part === "object" &&
+                  "text" in part &&
+                  typeof part.text === "string"
+                    ? part.text
+                    : "",
+                )
+              : [];
+          })
+          .join("\n");
+        this.state.messages.push({
+          role: "assistant",
+          content: [
+            { type: "text", text: "Preserved after preflight compaction." },
+          ],
+          stopReason: "stop",
+          usage: {
+            input: 2,
+            output: 2,
+          },
+        });
+        return {};
+      }
       this.state.messages.push({
         role: "assistant",
         content: [{ type: "text", text: "Recovered." }],
@@ -345,6 +436,10 @@ vi.mock("@/chat/pi/client", () => ({
       reason: "test-router",
     },
   }),
+  completeText: async () => {
+    compactionState.summaryCalls += 1;
+    return { text: "The edit completed; verify the changed file." };
+  },
   getPiGatewayApiKey: () => "test-gateway-key",
   resolveGatewayModel: (modelId: string) => modelId,
 }));
@@ -428,6 +523,9 @@ describe("executeAgentRun provider retry", () => {
     counters.abortCalls = 0;
     counters.continueCalls = 0;
     counters.promptCalls = 0;
+    compactionState.nextProviderContextChars = 0;
+    compactionState.preflightContextText = "";
+    compactionState.summaryCalls = 0;
     sessionLogState.failToolExecutionAppend = false;
     sessionLogState.toolExecutionAppendCalls = 0;
     process.env.JUNIOR_STATE_ADAPTER = "memory";
@@ -439,6 +537,79 @@ describe("executeAgentRun provider retry", () => {
     vi.useRealTimers();
     await disconnectStateAdapter();
     delete process.env.JUNIOR_STATE_ADAPTER;
+  });
+
+  it("compacts oversized tool history before the next provider request", async () => {
+    agentMode.value = "activeCompaction";
+    const statuses: string[] = [];
+
+    const result = finalReply(
+      await executeAgentRun({
+        input: {
+          messageText: "Make a large generated-file edit.",
+        },
+        routing: {
+          source: TEST_SOURCE,
+          destination: TEST_DESTINATION,
+        },
+        conversationId: "conversation-active-compaction",
+        turnId: "turn-active-compaction",
+        observers: {
+          onStatus: (status) => {
+            statuses.push(status.text);
+          },
+        },
+      }),
+    );
+
+    expect(result.text).toBe("Verified after compaction.");
+    expect(statuses).toContain("Compacting context");
+    expect(compactionState.summaryCalls).toBe(1);
+    expect(compactionState.nextProviderContextChars).toBeLessThan(20_000);
+    const history = await (await import("@/chat/db"))
+      .getConversationEventStore()
+      .loadHistory("conversation-active-compaction");
+    expect(history.some((event) => event.data.type === "compaction")).toBe(
+      true,
+    );
+  });
+
+  it("retains the complete current instruction across preflight compaction", async () => {
+    agentMode.value = "preflightCompaction";
+    const currentInstruction = `PRESERVE_THIS_START:${"z".repeat(12_000)}:PRESERVE_THIS_END`;
+    const priorMessages = [
+      {
+        role: "toolResult",
+        toolCallId: "call_prior_oversized",
+        toolName: "editFile",
+        isError: false,
+        content: [{ type: "text", text: "x".repeat(1_600_000) }],
+        timestamp: 1,
+      } as PiMessage,
+    ];
+
+    const result = finalReply(
+      await executeAgentRun({
+        input: {
+          messageText: currentInstruction,
+          piMessages: priorMessages,
+        },
+        routing: {
+          source: TEST_SOURCE,
+          destination: TEST_DESTINATION,
+          actor: { platform: "slack", teamId: "T123", userId: "U123" },
+        },
+        conversationId: "conversation-preflight-compaction",
+        turnId: "turn-preflight-compaction",
+      }),
+    );
+
+    expect(result.text).toBe("Preserved after preflight compaction.");
+    expect(compactionState.summaryCalls).toBe(1);
+    expect(compactionState.preflightContextText).toContain(currentInstruction);
+    expect(
+      compactionState.preflightContextText.match(/PRESERVE_THIS_START/g),
+    ).toHaveLength(1);
   });
 
   it("continues from the last safe boundary after an HTTP request timeout", async () => {

--- a/packages/junior/tests/integration/slack/message-content-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/message-content-behavior.test.ts
@@ -10,6 +10,7 @@ import { disconnectStateAdapter } from "@/chat/state/adapter";
 import { commitMessages } from "@/chat/conversations/projection";
 import { upsertAgentTurnSessionRecord } from "@/chat/state/turn-session";
 import { getConversationEventStore } from "@/chat/db";
+import { botConfig } from "@/chat/config";
 import { createTestChatRuntime } from "../../fixtures/chat-runtime";
 import {
   createTestMessage,
@@ -433,6 +434,63 @@ describe("Slack behavior: message content", () => {
     expect(JSON.stringify(calls[0]?.piMessages)).not.toContain(
       "<runtime-turn-context>",
     );
+  });
+
+  it("uses the projected handoff model for turn-start context limits", async () => {
+    const modelIds: string[] = [];
+    const priorMessages = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "Continue after handoff." }],
+        timestamp: 1,
+      },
+    ] as PiMessage[];
+    const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700005005.500" });
+    await getConversationEventStore().replaceHistory(thread.id, {
+      createdAtMs: 1,
+      data: {
+        type: "handoff",
+        modelProfile: "handoff",
+        modelId: botConfig.profiles.handoff!.modelId,
+        replacementHistory: priorMessages.map((message) => ({
+          message,
+          provenance: { authority: "context" },
+        })),
+      },
+    });
+    await persistThreadState(thread, {
+      conversation: coerceThreadConversationState({}),
+    });
+
+    const { slackRuntime } = createTestChatRuntime({
+      services: {
+        replyExecutor: {
+          contextCompactor: {
+            maybeCompact: async (args) => {
+              modelIds.push(args.modelId);
+              return { compacted: false, reason: "below_threshold" };
+            },
+          },
+          agentRunner: {
+            run: async () => completedReply("Done."),
+          },
+        },
+      },
+    });
+
+    await slackRuntime.handleNewMention(
+      thread,
+      createTestMessage({
+        id: "m-content-handoff-model",
+        text: "<@U0APP> continue",
+        isMention: true,
+        threadId: thread.id,
+        author: { userId: "U0TESTER" },
+      }),
+      { destination: createTestDestination(thread) },
+    );
+
+    expect(modelIds).toEqual([botConfig.profiles.handoff!.modelId]);
   });
 
   it("keeps active-turn Pi history instead of compacting older completed history", async () => {

--- a/packages/junior/tests/unit/api/conversation-events.test.ts
+++ b/packages/junior/tests/unit/api/conversation-events.test.ts
@@ -491,6 +491,15 @@ describe("conversation report event projection", () => {
           type: "compaction",
           modelProfile: "standard",
           modelId: "private-model-id",
+          details: {
+            reason: "capacity",
+            estimatedInputTokens: 361_000,
+            triggerTokens: 360_000,
+            inputLimitTokens: 380_000,
+            inputMessageCount: 42,
+            retainedMessageCount: 2,
+            summaryChars: 1_200,
+          },
           replacementHistory: [],
         }),
         event(4, {
@@ -565,7 +574,20 @@ describe("conversation report event projection", () => {
         confidence: 0.93,
         source: "router",
       },
-      { type: "compaction" },
+      {
+        type: "compaction",
+        modelProfile: "standard",
+        modelId: "private-model-id",
+        details: {
+          reason: "capacity",
+          estimatedInputTokens: 361_000,
+          triggerTokens: 360_000,
+          inputLimitTokens: 380_000,
+          inputMessageCount: 42,
+          retainedMessageCount: 2,
+          summaryChars: 1_200,
+        },
+      },
       {
         type: "tool_calls",
         calls: [
@@ -634,7 +656,6 @@ describe("conversation report event projection", () => {
     const serialized = JSON.stringify(projected);
     for (const forbidden of [
       "private-input-id",
-      "private-model-id",
       "subagent-invocation-1",
       "private-child-model-id",
       "private-reasoning-level",

--- a/packages/junior/tests/unit/tools/sandbox/file-tools.test.ts
+++ b/packages/junior/tests/unit/tools/sandbox/file-tools.test.ts
@@ -129,6 +129,34 @@ describe("sandbox file tools", () => {
       throw new Error("editFile should have succeeded");
     }
     expect(result.details.diff).toContain("+2 TWO");
+    expect(result.details.data).not.toHaveProperty("diff");
+    expect(JSON.parse(result.content[0].text)).toEqual(result.details);
+  });
+
+  it("bounds huge single-line edit diffs without duplicating them", async () => {
+    const memory = createMemoryFs({
+      "generated.js": `const data = "${"a".repeat(100_000)}";\n`,
+    });
+
+    const result = await editFile({
+      fs: memory.fs,
+      path: "generated.js",
+      edits: [
+        {
+          oldText: "a".repeat(100_000),
+          newText: "b".repeat(100_000),
+        },
+      ],
+    });
+
+    if (!result.details.ok) {
+      throw new Error("editFile should have succeeded");
+    }
+    expect(result.details.truncated).toBe(true);
+    expect(result.details.diff.length).toBeLessThan(10_000);
+    expect(result.details.diff).toContain("[line truncated]");
+    expect(result.details.data).not.toHaveProperty("diff");
+    expect(result.content[0].text.length).toBeLessThan(20_000);
   });
 
   it("prepares common edit argument variants", () => {


### PR DESCRIPTION
## Summary

- cap effective context at `min(botConfig.contextWindowTokens, model.contextWindow)` with a configurable 400k default
- compact before the first provider request and after tool batches at 90% of the effective window, then block before a provider call if the exact replacement remains above the 95% input ceiling
- preserve the current instruction and queued steering input verbatim across compaction, and use the active handoff profile for thresholds and diagnostics
- bound large `editFile` diff output and expose privacy-safe compaction metadata in conversation reports, dashboard events, and Markdown exports

## Root cause

Junior only compacted reusable history before starting a turn. A tool result—especially an unbounded generated-file diff—could expand the active Pi transcript past the provider limit between model calls. The next provider request was therefore allowed without another capacity check.

The first active-compaction implementation also treated fresh and queued instructions as summary input. That could truncate the current ask, and it did not re-estimate the actual summary-plus-retained replacement before continuing.

## Compatibility

- Existing compaction events remain readable; the new replacement estimate is optional on historical rows.
- The configured cap defaults to 400k and can be overridden through `botConfig` / `AI_MODEL_CONTEXT_WINDOW_TOKENS`.
- Model-advertised limits always win when they are smaller than the configured cap.

## Validation

- 2,160 Junior tests across 281 files
- 133 dashboard tests across 14 files
- focused boundary coverage for preflight compaction, between-call tool growth, oversized retained input, exact current-instruction preservation, and post-handoff model selection
- Junior and dashboard typechecks and builds
- Junior lint/dependency checks, ast-grep, formatting, diff checks, and release alignment

Closes #431
