### PR TITLE
feat(dashboard): improve collapsed tool call rendering

### DIFF
--- a/apps/example/dashboard.ts
+++ b/apps/example/dashboard.ts
@@ -27,3 +27,8 @@ export function exampleDashboardAuthRequired(): boolean {
 export function exampleDashboardMockConversations(): boolean {
   return process.env.JUNIOR_DASHBOARD_MOCK_CONVERSATIONS === "true";
 }
+
+/** Return whether the example dashboard should expose its local component gallery. */
+export function exampleDashboardComponentGallery(): boolean {
+  return process.env.JUNIOR_DASHBOARD_COMPONENT_GALLERY === "true";
+}

--- a/apps/example/nitro.config.ts
+++ b/apps/example/nitro.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "nitro";
 import { juniorNitro } from "@sentry/junior/nitro";
 import {
   exampleDashboardAuthRequired,
+  exampleDashboardComponentGallery,
   exampleDashboardMockConversations,
 } from "./dashboard.ts";
 
@@ -12,6 +13,7 @@ export default defineConfig({
       dashboard: {
         authRequired: exampleDashboardAuthRequired(),
         allowedGoogleDomains: ["sentry.io"],
+        componentGallery: exampleDashboardComponentGallery(),
         mockConversations: exampleDashboardMockConversations(),
       },
       plugins: "./plugins",

--- a/apps/example/server.ts
+++ b/apps/example/server.ts
@@ -2,6 +2,7 @@ import { createApp } from "@sentry/junior";
 import { initSentry } from "@sentry/junior/instrumentation";
 import {
   exampleDashboardAuthRequired,
+  exampleDashboardComponentGallery,
   exampleDashboardMockConversations,
 } from "./dashboard.ts";
 import { plugins } from "./plugins.ts";
@@ -12,6 +13,7 @@ const app = await createApp({
   dashboard: {
     authRequired: exampleDashboardAuthRequired(),
     allowedGoogleDomains: ["sentry.io"],
+    componentGallery: exampleDashboardComponentGallery(),
     mockConversations: exampleDashboardMockConversations(),
   },
   plugins,

--- a/packages/junior-dashboard/README.md
+++ b/packages/junior-dashboard/README.md
@@ -26,6 +26,9 @@ state.
 Mock reporting data exists for local UI development only and must not be
 reachable as a production fallback.
 
+Run `JUNIOR_DASHBOARD_COMPONENT_GALLERY=true pnpm dev` from the repository root
+and open `/dev` to inspect the typed component fixtures.
+
 User-facing setup lives in
 `packages/docs/src/content/docs/operate/dashboard.md`. Follow
 `../../policies/data-redaction.md` and `../../policies/frontend-components.md`.

--- a/packages/junior-dashboard/src/client/components/ToolFrame.tsx
+++ b/packages/junior-dashboard/src/client/components/ToolFrame.tsx
@@ -30,7 +30,7 @@ export function ToolFrame(props: {
               <span
                 className={cn(
                   "hidden text-[#777] max-md:inline",
-                  !staticFrame && "group-open:hidden",
+                  !staticFrame && "max-md:group-open:hidden",
                 )}
               >
                 ·
@@ -38,7 +38,7 @@ export function ToolFrame(props: {
               <span
                 className={cn(
                   "hidden shrink-0 whitespace-nowrap text-[#888] max-md:inline",
-                  !staticFrame && "group-open:hidden",
+                  !staticFrame && "max-md:group-open:hidden",
                 )}
               >
                 {props.mobileSummaryMeta}
@@ -90,7 +90,7 @@ export function ToolFrame(props: {
 
 /** Provide the shared transcript tool-frame shell for nonstandard part views. */
 export function toolFrameClass(): string {
-  return "ml-6 min-w-0 max-w-full overflow-hidden px-[1.0625rem]";
+  return "min-w-0 max-w-full overflow-hidden";
 }
 
 function toolHeaderClass(interactive: boolean): string {

--- a/packages/junior-dashboard/src/client/components/ToolFrame.tsx
+++ b/packages/junior-dashboard/src/client/components/ToolFrame.tsx
@@ -14,6 +14,7 @@ export function ToolFrame(props: {
   expandable?: boolean;
   meta: string[];
   mobileSummaryMeta?: string;
+  plain?: boolean;
   raw?: boolean;
   signature: ReactNode;
 }) {
@@ -68,7 +69,7 @@ export function ToolFrame(props: {
   // Force-expand tool details during search so highlighted matches are visible.
   if (searchActive || props.raw || !interactive) {
     return (
-      <div className={toolFrameClass()}>
+      <div className={toolFrameClass(props.plain)}>
         <div className={toolHeaderClass(false)}>{header}</div>
         {mobileMeta}
         {props.children}
@@ -78,7 +79,7 @@ export function ToolFrame(props: {
 
   return (
     <details
-      className={toolFrameClass()}
+      className={toolFrameClass(props.plain)}
       onToggle={(event) => {
         if (event.currentTarget !== event.target) return;
         setOpen(event.currentTarget.open);
@@ -92,8 +93,11 @@ export function ToolFrame(props: {
 }
 
 /** Provide the shared transcript tool-frame shell for nonstandard part views. */
-export function toolFrameClass(): string {
-  return "min-w-0 max-w-full overflow-hidden";
+export function toolFrameClass(plain = false): string {
+  return cn(
+    "min-w-0 max-w-full overflow-hidden",
+    !plain && "rounded-lg border border-white/[0.055] bg-black/15 px-3",
+  );
 }
 
 function toolHeaderClass(interactive: boolean): string {

--- a/packages/junior-dashboard/src/client/components/ToolFrame.tsx
+++ b/packages/junior-dashboard/src/client/components/ToolFrame.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from "react";
+import type { ReactNode } from "react";
 
 import { cn } from "../styles";
 import {
@@ -10,41 +10,38 @@ import { useTranscriptSearch } from "./transcriptSearch";
 /** Render the shared expandable/non-expandable frame for transcript tools. */
 export function ToolFrame(props: {
   children?: ReactNode;
-  collapsedSignature?: ReactNode;
   expandable?: boolean;
   meta: string[];
   mobileSummaryMeta?: string;
   raw?: boolean;
   signature: ReactNode;
 }) {
-  const [open, setOpen] = useState(false);
   const { active: searchActive } = useTranscriptSearch();
-
-  // Search replaces the native details element, so discard its expansion state.
-  useEffect(() => {
-    if (searchActive) setOpen(false);
-  }, [searchActive]);
-
   const metaText = props.meta.join(" · ");
   const interactive = props.expandable ?? Boolean(props.children);
-  const mobileSummaryMeta =
-    props.mobileSummaryMeta && (!interactive || !open)
-      ? props.mobileSummaryMeta
-      : undefined;
-  const signature =
-    props.collapsedSignature && !searchActive && !props.raw && !open
-      ? props.collapsedSignature
-      : props.signature;
+  const staticFrame = searchActive || props.raw || !interactive;
   const header = (
     <TranscriptHeadingRow
       left={
         <>
-          {signature}
-          {mobileSummaryMeta ? (
+          {props.signature}
+          {props.mobileSummaryMeta ? (
             <>
-              <span className="hidden text-[#777] max-md:inline">·</span>
-              <span className="hidden shrink-0 whitespace-nowrap text-[#888] max-md:inline">
-                {mobileSummaryMeta}
+              <span
+                className={cn(
+                  "hidden text-[#777] max-md:inline",
+                  !staticFrame && "group-open:hidden",
+                )}
+              >
+                ·
+              </span>
+              <span
+                className={cn(
+                  "hidden shrink-0 whitespace-nowrap text-[#888] max-md:inline",
+                  !staticFrame && "group-open:hidden",
+                )}
+              >
+                {props.mobileSummaryMeta}
               </span>
             </>
           ) : null}
@@ -52,7 +49,7 @@ export function ToolFrame(props: {
       }
       leftClassName={cn(
         "gap-x-1 gap-y-0.5",
-        interactive && !open ? "flex-nowrap" : "flex-wrap",
+        staticFrame ? "flex-wrap" : "flex-nowrap group-open:flex-wrap",
       )}
       right={
         metaText ? (
@@ -72,7 +69,7 @@ export function ToolFrame(props: {
     ) : null;
 
   // Force-expand tool details during search so highlighted matches are visible.
-  if (searchActive || props.raw || !interactive) {
+  if (staticFrame) {
     return (
       <div className={toolFrameClass()}>
         <div className={toolHeaderClass(false)}>{header}</div>
@@ -83,13 +80,7 @@ export function ToolFrame(props: {
   }
 
   return (
-    <details
-      className={toolFrameClass()}
-      onToggle={(event) => {
-        if (event.currentTarget !== event.target) return;
-        setOpen(event.currentTarget.open);
-      }}
-    >
+    <details className={cn("group", toolFrameClass())}>
       <summary className={toolHeaderClass(true)}>{header}</summary>
       {mobileMeta}
       {props.children}

--- a/packages/junior-dashboard/src/client/components/ToolFrame.tsx
+++ b/packages/junior-dashboard/src/client/components/ToolFrame.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 
 import { cn } from "../styles";
 import {
@@ -19,6 +19,12 @@ export function ToolFrame(props: {
 }) {
   const [open, setOpen] = useState(false);
   const { active: searchActive } = useTranscriptSearch();
+
+  // Search replaces the native details element, so discard its expansion state.
+  useEffect(() => {
+    if (searchActive) setOpen(false);
+  }, [searchActive]);
+
   const metaText = props.meta.join(" · ");
   const interactive = props.expandable ?? Boolean(props.children);
   const mobileSummaryMeta =

--- a/packages/junior-dashboard/src/client/components/ToolFrame.tsx
+++ b/packages/junior-dashboard/src/client/components/ToolFrame.tsx
@@ -14,7 +14,6 @@ export function ToolFrame(props: {
   expandable?: boolean;
   meta: string[];
   mobileSummaryMeta?: string;
-  plain?: boolean;
   raw?: boolean;
   signature: ReactNode;
 }) {
@@ -69,7 +68,7 @@ export function ToolFrame(props: {
   // Force-expand tool details during search so highlighted matches are visible.
   if (searchActive || props.raw || !interactive) {
     return (
-      <div className={toolFrameClass(props.plain)}>
+      <div className={toolFrameClass()}>
         <div className={toolHeaderClass(false)}>{header}</div>
         {mobileMeta}
         {props.children}
@@ -79,7 +78,7 @@ export function ToolFrame(props: {
 
   return (
     <details
-      className={toolFrameClass(props.plain)}
+      className={toolFrameClass()}
       onToggle={(event) => {
         if (event.currentTarget !== event.target) return;
         setOpen(event.currentTarget.open);
@@ -93,11 +92,8 @@ export function ToolFrame(props: {
 }
 
 /** Provide the shared transcript tool-frame shell for nonstandard part views. */
-export function toolFrameClass(plain = false): string {
-  return cn(
-    "min-w-0 max-w-full overflow-hidden",
-    !plain && "rounded-lg border border-white/[0.055] bg-black/15 px-3",
-  );
+export function toolFrameClass(): string {
+  return "min-w-0 max-w-full overflow-hidden";
 }
 
 function toolHeaderClass(interactive: boolean): string {

--- a/packages/junior-dashboard/src/client/components/ToolFrame.tsx
+++ b/packages/junior-dashboard/src/client/components/ToolFrame.tsx
@@ -10,6 +10,7 @@ import { useTranscriptSearch } from "./transcriptSearch";
 /** Render the shared expandable/non-expandable frame for transcript tools. */
 export function ToolFrame(props: {
   children?: ReactNode;
+  collapsedSignature?: ReactNode;
   expandable?: boolean;
   meta: string[];
   mobileSummaryMeta?: string;
@@ -24,15 +25,19 @@ export function ToolFrame(props: {
     props.mobileSummaryMeta && (!interactive || !open)
       ? props.mobileSummaryMeta
       : undefined;
+  const signature =
+    props.collapsedSignature && !searchActive && !props.raw && !open
+      ? props.collapsedSignature
+      : props.signature;
   const header = (
     <TranscriptHeadingRow
       left={
         <>
-          {props.signature}
+          {signature}
           {mobileSummaryMeta ? (
             <>
               <span className="hidden text-[#777] max-md:inline">·</span>
-              <span className="hidden min-w-0 break-words text-[#888] max-md:inline">
+              <span className="hidden shrink-0 whitespace-nowrap text-[#888] max-md:inline">
                 {mobileSummaryMeta}
               </span>
             </>
@@ -88,7 +93,7 @@ export function ToolFrame(props: {
 
 /** Provide the shared transcript tool-frame shell for nonstandard part views. */
 export function toolFrameClass(): string {
-  return "min-w-0 max-w-full overflow-hidden rounded-lg border border-white/[0.055] bg-black/15 px-3";
+  return "min-w-0 max-w-full overflow-hidden";
 }
 
 function toolHeaderClass(interactive: boolean): string {

--- a/packages/junior-dashboard/src/client/components/ToolFrame.tsx
+++ b/packages/junior-dashboard/src/client/components/ToolFrame.tsx
@@ -99,7 +99,7 @@ export function ToolFrame(props: {
 
 /** Provide the shared transcript tool-frame shell for nonstandard part views. */
 export function toolFrameClass(): string {
-  return "min-w-0 max-w-full overflow-hidden";
+  return "ml-6 min-w-0 max-w-full overflow-hidden px-[1.0625rem]";
 }
 
 function toolHeaderClass(interactive: boolean): string {

--- a/packages/junior-dashboard/src/client/components/TranscriptToolView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptToolView.tsx
@@ -39,7 +39,6 @@ export function TranscriptToolView(props: {
       <ToolFrame
         meta={meta}
         mobileSummaryMeta={mobileSummary}
-        plain
         raw
         signature={signature}
       >
@@ -77,7 +76,6 @@ export function TranscriptToolView(props: {
         expandable={hasDetails}
         meta={meta}
         mobileSummaryMeta={mobileSummary}
-        plain
         signature={signature}
       >
         {props.part.input !== undefined ? (

--- a/packages/junior-dashboard/src/client/components/TranscriptToolView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptToolView.tsx
@@ -137,7 +137,7 @@ function ToolErrorMarker(props: {
   return (
     <span
       aria-label="Tool failed"
-      className="absolute -left-[1.95rem] top-1 z-[1] grid size-6 place-items-center rounded border border-rose-300/40 bg-[#071012] text-rose-200 shadow-[0_0_0_3px_#050507,0_8px_20px_rgba(0,0,0,0.3)]"
+      className="absolute -left-[1.95rem] top-0.5 z-[1] grid size-6 place-items-center rounded border border-rose-300/40 bg-[#071012] text-rose-200 shadow-[0_0_0_3px_#050507,0_8px_20px_rgba(0,0,0,0.3)]"
       role="img"
     >
       <TriangleAlert size={12} strokeWidth={2.2} />

--- a/packages/junior-dashboard/src/client/components/TranscriptToolView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptToolView.tsx
@@ -32,6 +32,7 @@ export function TranscriptToolView(props: {
   const signature = (
     <ToolSignature
       name={props.part.name}
+      preview={props.view === "raw" ? null : preview}
       running={props.part.status === "running"}
     />
   );
@@ -65,15 +66,6 @@ export function TranscriptToolView(props: {
       </ToolFrame>
     ) : (
       <ToolFrame
-        collapsedSignature={
-          preview ? (
-            <ToolSignature
-              name={props.part.name}
-              preview={preview}
-              running={props.part.status === "running"}
-            />
-          ) : undefined
-        }
         expandable={hasDetails}
         meta={meta}
         mobileSummaryMeta={mobileSummary}
@@ -108,7 +100,7 @@ export function TranscriptToolView(props: {
 
 function ToolSignature(props: {
   name: string;
-  preview?: string;
+  preview: string | null;
   running: boolean;
 }) {
   const { active: searchActive } = useTranscriptSearch();
@@ -126,8 +118,8 @@ function ToolSignature(props: {
       >
         <HighlightText text={props.name} />
       </strong>
-      {props.preview ? (
-        <code className="min-w-0 truncate font-[inherit] text-[#b8b8b8]">
+      {props.preview && !searchActive ? (
+        <code className="min-w-0 truncate font-[inherit] text-[#b8b8b8] group-open:hidden">
           (<HighlightText text={props.preview} />)
         </code>
       ) : null}

--- a/packages/junior-dashboard/src/client/components/TranscriptToolView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptToolView.tsx
@@ -39,6 +39,7 @@ export function TranscriptToolView(props: {
       <ToolFrame
         meta={meta}
         mobileSummaryMeta={mobileSummary}
+        plain
         raw
         signature={signature}
       >
@@ -76,6 +77,7 @@ export function TranscriptToolView(props: {
         expandable={hasDetails}
         meta={meta}
         mobileSummaryMeta={mobileSummary}
+        plain
         signature={signature}
       >
         {props.part.input !== undefined ? (

--- a/packages/junior-dashboard/src/client/components/TranscriptToolView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptToolView.tsx
@@ -8,9 +8,10 @@ import {
   stringifyPartValue,
 } from "../format";
 import type { TranscriptViewToolCallPart } from "../types";
+import { cn } from "../styles";
 import { ToolFrame } from "./ToolFrame";
 import { toolCallPreview } from "./toolCallPreview";
-import { HighlightText } from "./transcriptSearch";
+import { HighlightText, useTranscriptSearch } from "./transcriptSearch";
 
 /** Render one tool invocation as it advances from running to a terminal result. */
 export function TranscriptToolView(props: {
@@ -110,14 +111,18 @@ function ToolSignature(props: {
   preview?: string;
   running: boolean;
 }) {
+  const { active: searchActive } = useTranscriptSearch();
+
   return (
     <>
       <strong
-        className={
-          props.running
-            ? "shrink-0 animate-[junior-tool-shimmer_1.6s_linear_infinite] bg-[linear-gradient(90deg,#777_0%,#d6d6d6_40%,#fff_50%,#d6d6d6_60%,#777_100%)] bg-[length:200%_100%] bg-clip-text font-bold text-transparent motion-reduce:animate-none motion-reduce:bg-none motion-reduce:text-[#d6d6d6]"
-            : "shrink-0 font-bold text-[#d6d6d6]"
-        }
+        aria-label={props.running ? `${props.name} (running)` : undefined}
+        className={cn(
+          "shrink-0 font-bold text-[#d6d6d6]",
+          props.running &&
+            !searchActive &&
+            "animate-[junior-tool-shimmer_1.6s_linear_infinite] bg-[linear-gradient(90deg,#777_0%,#d6d6d6_40%,#fff_50%,#d6d6d6_60%,#777_100%)] bg-[length:200%_100%] bg-clip-text text-transparent motion-reduce:animate-none",
+        )}
       >
         <HighlightText text={props.name} />
       </strong>

--- a/packages/junior-dashboard/src/client/components/TranscriptToolView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptToolView.tsx
@@ -110,10 +110,10 @@ function ToolSignature(props: {
       <strong
         aria-label={props.running ? `${props.name} (running)` : undefined}
         className={cn(
-          "shrink-0 font-bold text-[#d6d6d6]",
-          props.running &&
-            !searchActive &&
-            "animate-[junior-tool-shimmer_1.6s_linear_infinite] bg-[linear-gradient(90deg,#777_0%,#d6d6d6_40%,#fff_50%,#d6d6d6_60%,#777_100%)] bg-[length:200%_100%] bg-clip-text text-transparent motion-reduce:animate-none",
+          "shrink-0 font-bold",
+          props.running && !searchActive
+            ? "animate-[junior-tool-shimmer_1.6s_linear_infinite] bg-[linear-gradient(90deg,#777_0%,#d6d6d6_40%,#fff_50%,#d6d6d6_60%,#777_100%)] bg-[length:200%_100%] bg-clip-text text-transparent motion-reduce:animate-none"
+            : "text-[#d6d6d6]",
         )}
       >
         <HighlightText text={props.name} />

--- a/packages/junior-dashboard/src/client/components/TranscriptToolView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptToolView.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { TriangleAlert } from "lucide-react";
 
 import { HighlightedCode } from "../code";
 import {
@@ -8,6 +9,7 @@ import {
 } from "../format";
 import type { TranscriptViewToolCallPart } from "../types";
 import { ToolFrame } from "./ToolFrame";
+import { toolCallPreview } from "./toolCallPreview";
 import { HighlightText } from "./transcriptSearch";
 
 /** Render one tool invocation as it advances from running to a terminal result. */
@@ -24,19 +26,21 @@ export function TranscriptToolView(props: {
   const hasDetails =
     props.part.input !== undefined || props.part.output !== undefined;
   const meta = [duration, timestamp].filter(isString);
-  const status =
-    props.part.status === "completed" ? null : (
-      <ToolStatus status={props.part.status} />
-    );
   const mobileSummary = duration;
-
-  if (props.view === "raw" && hasDetails) {
-    return (
+  const preview = toolCallPreview(props.part.name, props.part.input);
+  const signature = (
+    <ToolSignature
+      name={props.part.name}
+      running={props.part.status === "running"}
+    />
+  );
+  const frame =
+    props.view === "raw" && hasDetails ? (
       <ToolFrame
         meta={meta}
         mobileSummaryMeta={mobileSummary}
         raw
-        signature={<ToolSignature name={props.part.name} status={status} />}
+        signature={signature}
       >
         <ToolBody>
           <HighlightedCode
@@ -58,64 +62,87 @@ export function TranscriptToolView(props: {
           />
         </ToolBody>
       </ToolFrame>
+    ) : (
+      <ToolFrame
+        collapsedSignature={
+          preview ? (
+            <ToolSignature
+              name={props.part.name}
+              preview={preview}
+              running={props.part.status === "running"}
+            />
+          ) : undefined
+        }
+        expandable={hasDetails}
+        meta={meta}
+        mobileSummaryMeta={mobileSummary}
+        signature={signature}
+      >
+        {props.part.input !== undefined ? (
+          <ToolBody label="arguments">
+            <HighlightedCode
+              code={stringifyPartValue(props.part.input)}
+              language="json"
+            />
+          </ToolBody>
+        ) : null}
+        {props.part.output !== undefined ? (
+          <ToolBody label="result">
+            <HighlightedCode
+              code={stringifyPartValue(props.part.output)}
+              language="json"
+            />
+          </ToolBody>
+        ) : null}
+      </ToolFrame>
     );
-  }
 
   return (
-    <ToolFrame
-      expandable={hasDetails}
-      meta={meta}
-      mobileSummaryMeta={mobileSummary}
-      signature={<ToolSignature name={props.part.name} status={status} />}
-    >
-      {props.part.input !== undefined ? (
-        <ToolBody label="arguments">
-          <HighlightedCode
-            code={stringifyPartValue(props.part.input)}
-            language="json"
-          />
-        </ToolBody>
-      ) : null}
-      {props.part.output !== undefined ? (
-        <ToolBody label="result">
-          <HighlightedCode
-            code={stringifyPartValue(props.part.output)}
-            language="json"
-          />
-        </ToolBody>
-      ) : null}
-    </ToolFrame>
+    <div className="relative min-w-0">
+      <ToolErrorMarker status={props.part.status} />
+      {frame}
+    </div>
   );
 }
 
-function ToolSignature(props: { name: string; status: ReactNode }) {
+function ToolSignature(props: {
+  name: string;
+  preview?: string;
+  running: boolean;
+}) {
   return (
     <>
-      <strong className="min-w-0 break-words font-bold text-[#d6d6d6]">
+      <strong
+        className={
+          props.running
+            ? "shrink-0 animate-[junior-tool-shimmer_1.6s_linear_infinite] bg-[linear-gradient(90deg,#777_0%,#d6d6d6_40%,#fff_50%,#d6d6d6_60%,#777_100%)] bg-[length:200%_100%] bg-clip-text font-bold text-transparent motion-reduce:animate-none motion-reduce:bg-none motion-reduce:text-[#d6d6d6]"
+            : "shrink-0 font-bold text-[#d6d6d6]"
+        }
+      >
         <HighlightText text={props.name} />
       </strong>
-      {props.status ? (
-        <>
-          <span className="text-[#777]">·</span>
-          {props.status}
-        </>
+      {props.preview ? (
+        <code className="min-w-0 truncate font-[inherit] text-[#b8b8b8]">
+          (<HighlightText text={props.preview} />)
+        </code>
       ) : null}
     </>
   );
 }
 
-function ToolStatus(props: { status: "error" | "running" }) {
-  if (props.status === "running") {
-    return (
-      <span
-        aria-label="running"
-        className="animate-pulse text-cyan-200/70 motion-reduce:animate-none"
-      >
-        running
-      </span>
-    );
-  }
-  return <span className="text-rose-300">error</span>;
+function ToolErrorMarker(props: {
+  status: TranscriptViewToolCallPart["status"];
+}) {
+  if (props.status !== "error") return null;
+  return (
+    <span
+      aria-label="Tool failed"
+      className="absolute -left-[1.95rem] top-1 z-[1] grid size-6 place-items-center rounded border border-rose-300/40 bg-[#071012] text-rose-200 shadow-[0_0_0_3px_#050507,0_8px_20px_rgba(0,0,0,0.3)]"
+      role="img"
+    >
+      <TriangleAlert size={12} strokeWidth={2.2} />
+    </span>
+  );
 }
 
 function ToolBody(props: { children: ReactNode; label?: string }) {

--- a/packages/junior-dashboard/src/client/components/toolCallPreview.ts
+++ b/packages/junior-dashboard/src/client/components/toolCallPreview.ts
@@ -1,0 +1,86 @@
+import { stringifyPartValue } from "../format";
+
+const MAX_VALUE_LENGTH = 48;
+const MAX_PREVIEW_LENGTH = 120;
+const MAX_OBJECT_ENTRIES = 4;
+
+/** Format the useful arguments from a tool call for its collapsed transcript row. */
+export function toolCallPreview(name: string, input: unknown): string | null {
+  if (name === "bash") {
+    return fieldValue(input, "command");
+  }
+
+  if (name === "loadSkill") {
+    return fieldValue(input, "skill_name");
+  }
+
+  if (name === "webSearch") {
+    return fieldValue(input, "query");
+  }
+
+  if (name === "executeTool") {
+    const toolName = fieldValue(input, "tool_name");
+    const argumentsPreview = objectFieldPreview(input, "arguments");
+    return joinPreview(toolName, argumentsPreview);
+  }
+
+  return valuePreview(input, MAX_PREVIEW_LENGTH);
+}
+
+function objectFieldPreview(input: unknown, key: string): string | null {
+  if (!isRecord(input)) return null;
+  return objectPreview(input[key]);
+}
+
+function fieldValue(input: unknown, key: string): string | null {
+  if (!isRecord(input)) return null;
+  const value = input[key];
+  if (typeof value !== "string") return null;
+  return compactText(value, MAX_PREVIEW_LENGTH);
+}
+
+function valuePreview(value: unknown, maxLength: number): string | null {
+  if (value == null || value === "") return null;
+  if (isRecord(value)) return objectPreview(value);
+  return compactText(formatValue(value), maxLength);
+}
+
+function objectPreview(value: unknown): string | null {
+  if (!isRecord(value)) return null;
+  const entries = Object.entries(value);
+  if (entries.length === 0) return null;
+
+  const preview = entries
+    .slice(0, MAX_OBJECT_ENTRIES)
+    .map(
+      ([key, entryValue]) =>
+        `${key}: ${compactText(formatValue(entryValue), MAX_VALUE_LENGTH)}`,
+    )
+    .join(", ");
+  const withOmission =
+    entries.length > MAX_OBJECT_ENTRIES ? `${preview}, …` : preview;
+  return compactText(withOmission, MAX_PREVIEW_LENGTH);
+}
+
+function formatValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  return stringifyPartValue(value).replace(/\s+/g, " ").trim();
+}
+
+function compactText(value: string, maxLength: number): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  return normalized.length > maxLength
+    ? `${normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`
+    : normalized;
+}
+
+function joinPreview(...parts: Array<string | null>): string | null {
+  const present = parts.filter((part): part is string => Boolean(part));
+  return present.length > 0
+    ? compactText(present.join(", "), MAX_PREVIEW_LENGTH)
+    : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/junior-dashboard/src/client/pages/dev/ComponentsPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/dev/ComponentsPage.tsx
@@ -23,7 +23,9 @@ import { MetricList, MetricValue } from "../../components/Metric";
 import { StatCard } from "../../components/metrics/StatCard";
 import { TranscriptMarkdown } from "../../components/TranscriptMarkdown";
 import { TranscriptText } from "../../components/TranscriptText";
+import { TranscriptToolView } from "../../components/TranscriptToolView";
 import { cn, dashboardContainerClass } from "../../styles";
+import type { TranscriptViewToolCallPart } from "../../types";
 
 const EVENT_NOTIFICATION = `[event notification]
 
@@ -97,6 +99,123 @@ const CONTRIBUTION_DAYS = fixtureDates(70).map((date, index) => ({
   durationMs: index % 9 === 0 ? 0 : 45_000 + ((index * 13) % 20) * 18_000,
 }));
 
+type ToolCallFixture = {
+  description: string;
+  part: TranscriptViewToolCallPart;
+  timestamp: number;
+};
+
+const TOOL_CALL_TIMESTAMP = Date.UTC(2026, 4, 1, 16);
+
+const TOOL_CALL_FIXTURES = [
+  {
+    description: "Default completed tool with normalized arguments",
+    part: {
+      id: "gallery-search",
+      input: {
+        query: "release regression",
+        limit: 25,
+        options: { includeArchived: false },
+      },
+      name: "searchIssues",
+      output: { matches: 3 },
+      resultTimestamp: TOOL_CALL_TIMESTAMP + 1_842,
+      status: "completed",
+      type: "tool_call",
+    },
+    timestamp: TOOL_CALL_TIMESTAMP,
+  },
+  {
+    description: "Running webSearch with name-only shimmer",
+    part: {
+      id: "gallery-running",
+      input: {
+        query: "service:checkout status:error",
+        max_results: 50,
+      },
+      name: "webSearch",
+      status: "running",
+      type: "tool_call",
+    },
+    timestamp: TOOL_CALL_TIMESTAMP + 3_000,
+  },
+  {
+    description: "Failed tool with warning rail marker",
+    part: {
+      id: "gallery-error",
+      input: {
+        command: "jr-rpc config get github.repo",
+        timeout_ms: 10_000,
+      },
+      name: "bash",
+      output: { error: "configuration unavailable" },
+      resultTimestamp: TOOL_CALL_TIMESTAMP + 6_416,
+      status: "error",
+      type: "tool_call",
+    },
+    timestamp: TOOL_CALL_TIMESTAMP + 6_000,
+  },
+  {
+    description: "Known loadSkill signature",
+    part: {
+      id: "gallery-load-skill",
+      input: { skill_name: "junior-qa" },
+      name: "loadSkill",
+      output: { ok: true },
+      resultTimestamp: TOOL_CALL_TIMESTAMP + 8_105,
+      status: "completed",
+      type: "tool_call",
+    },
+    timestamp: TOOL_CALL_TIMESTAMP + 8_000,
+  },
+  {
+    description: "Known executeTool signature with nested arguments",
+    part: {
+      id: "gallery-execute-tool",
+      input: {
+        tool_name: "github_search",
+        arguments: { query: "is:pr is:open", limit: 25 },
+      },
+      name: "executeTool",
+      output: { matches: 3, ok: true },
+      resultTimestamp: TOOL_CALL_TIMESTAMP + 10_723,
+      status: "completed",
+      type: "tool_call",
+    },
+    timestamp: TOOL_CALL_TIMESTAMP + 10_000,
+  },
+  {
+    description: "Long generic arguments exercise both truncation limits",
+    part: {
+      id: "gallery-long",
+      input: {
+        project: "payments-checkout-platform",
+        query:
+          "Find every regression associated with the most recent production deployment and include the complete evidence trail",
+        environment: "production",
+        includeResolved: false,
+        ignoredAfterFourEntries: "not shown in the collapsed preview",
+      },
+      name: "investigateDeploy",
+      output: { ok: true },
+      resultTimestamp: TOOL_CALL_TIMESTAMP + 13_250,
+      status: "completed",
+      type: "tool_call",
+    },
+    timestamp: TOOL_CALL_TIMESTAMP + 12_000,
+  },
+  {
+    description: "Completed tool without argument or result payloads",
+    part: {
+      id: "gallery-empty",
+      name: "systemTime",
+      status: "completed",
+      type: "tool_call",
+    },
+    timestamp: TOOL_CALL_TIMESTAMP + 15_000,
+  },
+] as const satisfies readonly ToolCallFixture[];
+
 /** Config-gated visual fixtures for reusable dashboard components. */
 export function ComponentsPage() {
   const [range, setRange] = useState<TimeRangeDays>(30);
@@ -121,30 +240,81 @@ export function ComponentsPage() {
       >
         <Fixture title="Buttons and controls">
           <div className="flex flex-wrap items-center gap-3">
-            <Button><Copy aria-hidden="true" size={14} />Copy</Button>
+            <Button>
+              <Copy aria-hidden="true" size={14} />
+              Copy
+            </Button>
             <Button disabled>Disabled</Button>
-            <Button aria-label="Bot action" size="icon"><Bot aria-hidden="true" size={16} /></Button>
-            <ToggleButton pressed={pressed} variant="pill" onClick={() => setPressed((value) => !value)}>Toggle</ToggleButton>
-            <ToggleButton pressed={!pressed} variant="text" onClick={() => setPressed((value) => !value)}>Alternate</ToggleButton>
+            <Button aria-label="Bot action" size="icon">
+              <Bot aria-hidden="true" size={16} />
+            </Button>
+            <ToggleButton
+              pressed={pressed}
+              variant="pill"
+              onClick={() => setPressed((value) => !value)}
+            >
+              Toggle
+            </ToggleButton>
+            <ToggleButton
+              pressed={!pressed}
+              variant="text"
+              onClick={() => setPressed((value) => !value)}
+            >
+              Alternate
+            </ToggleButton>
             <TimeRangeSelector onChange={setRange} value={range} />
           </div>
         </Fixture>
         <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-          <StatCard detail="Across the selected period" icon={MessageSquare} label="Conversations" value="1,284" />
-          <StatCard detail="94% completed successfully" icon={Activity} label="Completed" value="1,207" />
-          <StatCard detail="Cumulative agent runtime" icon={Timer} label="Runtime" value="18.4h" />
-          <StatCard detail="Model and tool workers" icon={Bot} label="Active agents" value="7" />
+          <StatCard
+            detail="Across the selected period"
+            icon={MessageSquare}
+            label="Conversations"
+            value="1,284"
+          />
+          <StatCard
+            detail="94% completed successfully"
+            icon={Activity}
+            label="Completed"
+            value="1,207"
+          />
+          <StatCard
+            detail="Cumulative agent runtime"
+            icon={Timer}
+            label="Runtime"
+            value="18.4h"
+          />
+          <StatCard
+            detail="Model and tool workers"
+            icon={Bot}
+            label="Active agents"
+            value="7"
+          />
         </div>
         <Fixture title="Metadata and empty state">
           <div className="grid gap-4">
             <MetricList
               items={[
-                { content: <MetricValue tooltip={[{ label: "input", value: "12.4k" }, { label: "output", value: "3.1k" }]}>15.5k tokens</MetricValue>, key: "tokens" },
+                {
+                  content: (
+                    <MetricValue
+                      tooltip={[
+                        { label: "input", value: "12.4k" },
+                        { label: "output", value: "3.1k" },
+                      ]}
+                    >
+                      15.5k tokens
+                    </MetricValue>
+                  ),
+                  key: "tokens",
+                },
                 { content: <MetricValue>$0.42</MetricValue>, key: "cost" },
                 { content: <MetricValue>38s</MetricValue>, key: "duration" },
               ]}
             />
-            <EmptyTelemetry>No activity was recorded for this period.</EmptyTelemetry>
+            <EmptyTelemetry>
+              No activity was recorded for this period.
+            </EmptyTelemetry>
           </div>
         </Fixture>
       </GallerySection>
@@ -157,7 +327,10 @@ export function ComponentsPage() {
         <PeopleActivityChart days={PEOPLE_DAYS} />
         <LocationDirectoryActivityChart days={LOCATION_DAYS} />
         <Card>
-          <CardHeader description="Daily conversation intensity over ten weeks." title="Contribution activity" />
+          <CardHeader
+            description="Daily conversation intensity over ten weeks."
+            title="Contribution activity"
+          />
           <ContributionGrid days={CONTRIBUTION_DAYS} />
         </Card>
       </GallerySection>
@@ -173,12 +346,53 @@ export function ComponentsPage() {
           <TranscriptMarkdown text={GFM_SAMPLE} />
         </Fixture>
         <Fixture title="TranscriptText assistant">
-          <TranscriptText firstChildIndex={0} lastChildIndex={0} role="assistant" text={MIXED_ASSISTANT} />
+          <TranscriptText
+            firstChildIndex={0}
+            lastChildIndex={0}
+            role="assistant"
+            text={MIXED_ASSISTANT}
+          />
         </Fixture>
         <Fixture title="TranscriptText user">
-          <TranscriptText firstChildIndex={0} lastChildIndex={0} role="user" text={EVENT_NOTIFICATION} />
+          <TranscriptText
+            firstChildIndex={0}
+            lastChildIndex={0}
+            role="user"
+            text={EVENT_NOTIFICATION}
+          />
+        </Fixture>
+        <Fixture title="Tool calls">
+          <ToolCallGallery />
         </Fixture>
       </GallerySection>
+    </div>
+  );
+}
+
+/** Render typed transcript tool states for visual regression and interaction checks. */
+export function ToolCallGallery() {
+  return (
+    <div className="grid min-w-0 grid-cols-[0.875rem_minmax(0,1fr)] gap-3">
+      <div aria-hidden="true" className="flex justify-center">
+        <span className="w-px bg-cyan-300/15" />
+      </div>
+      <div className="grid min-w-0 gap-3">
+        <p className="m-0 text-[0.78rem] leading-relaxed text-white/45">
+          Click any row to compare its collapsed signature with the full
+          arguments and result.
+        </p>
+        {TOOL_CALL_FIXTURES.map((fixture) => (
+          <div className="grid min-w-0 gap-1" key={fixture.part.id}>
+            <div className="font-mono text-[0.65rem] uppercase tracking-[0.08em] text-white/30">
+              {fixture.description}
+            </div>
+            <TranscriptToolView
+              part={fixture.part}
+              timestamp={fixture.timestamp}
+            />
+          </div>
+        ))}
+      </div>
     </div>
   );
 }
@@ -191,7 +405,9 @@ function GallerySection(props: {
   return (
     <section className="grid min-w-0 gap-4">
       <div>
-        <h2 className="m-0 font-display text-xl font-medium text-white">{props.title}</h2>
+        <h2 className="m-0 font-display text-xl font-medium text-white">
+          {props.title}
+        </h2>
         <p className="mt-1 mb-0 text-sm text-white/45">{props.description}</p>
       </div>
       {props.children}

--- a/packages/junior-dashboard/src/mock-reporting/fixtures.ts
+++ b/packages/junior-dashboard/src/mock-reporting/fixtures.ts
@@ -145,7 +145,7 @@ function activeConversation(nowMs: number): ConversationDetailReport {
         calls: [
           {
             toolCallId: "active-search",
-            name: "datacat.search_logs",
+            name: "webSearch",
             status: "running",
           },
         ],
@@ -242,6 +242,48 @@ function dashboardQaConversation(nowMs: number): ConversationDetailReport {
         status: "completed",
       }),
       reportEvent(8, iso(Date.parse(startedAt), 50_000), {
+        type: "tool_calls",
+        calls: [
+          {
+            toolCallId: "qa-load-skill",
+            name: "loadSkill",
+            status: "completed",
+            input: { skill_name: "junior-qa" },
+            output: { ok: true },
+          },
+        ],
+      }),
+      reportEvent(9, iso(Date.parse(startedAt), 52_000), {
+        type: "tool_calls",
+        calls: [
+          {
+            toolCallId: "qa-execute-tool",
+            name: "executeTool",
+            status: "completed",
+            input: {
+              tool_name: "github_search",
+              arguments: { query: "is:pr is:open", limit: 25 },
+            },
+            output: { ok: true, matches: 3 },
+          },
+        ],
+      }),
+      reportEvent(10, iso(Date.parse(startedAt), 54_000), {
+        type: "tool_calls",
+        calls: [
+          {
+            toolCallId: "qa-bash",
+            name: "bash",
+            status: "error",
+            input: {
+              command: "jr-rpc config get github.repo",
+              timeout_ms: 10_000,
+            },
+            output: { error: "configuration unavailable" },
+          },
+        ],
+      }),
+      reportEvent(11, iso(Date.parse(startedAt), 56_000), {
         type: "compaction",
         modelProfile: "standard",
         modelId: "openai/gpt-5.4",
@@ -256,7 +298,7 @@ function dashboardQaConversation(nowMs: number): ConversationDetailReport {
           summaryChars: 1_200,
         },
       }),
-      reportEvent(9, iso(Date.parse(startedAt), 55_000), {
+      reportEvent(12, iso(Date.parse(startedAt), 58_000), {
         type: "message",
         messageId: "qa-assistant",
         role: "assistant",

--- a/packages/junior-dashboard/src/tailwind.css
+++ b/packages/junior-dashboard/src/tailwind.css
@@ -50,3 +50,13 @@
     background-position: 200% 50%;
   }
 }
+
+@keyframes junior-tool-shimmer {
+  0% {
+    background-position: 200% 50%;
+  }
+
+  100% {
+    background-position: -200% 50%;
+  }
+}

--- a/packages/junior-dashboard/tests/dashboard-mock-routes.test.ts
+++ b/packages/junior-dashboard/tests/dashboard-mock-routes.test.ts
@@ -222,7 +222,7 @@ describe("dashboard canonical-event mock routes", () => {
           ? event.data.calls.map((call) => call.name)
           : [],
       ),
-    ).toContain("datacat.search_logs");
+    ).toContain("webSearch");
 
     const failed = await readDetail("slack:CQA777:1770014400.000500");
     expect(failed.events.at(-1)?.data).toMatchObject({

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -24,6 +24,8 @@ import {
 import { Transcript } from "../src/client/components/Transcript";
 import { TranscriptHeader } from "../src/client/components/TranscriptHeader";
 import { TranscriptMarkdown } from "../src/client/components/TranscriptMarkdown";
+import { TranscriptSubagentView } from "../src/client/components/TranscriptSubagentView";
+import { TranscriptToolView } from "../src/client/components/TranscriptToolView";
 import { TranscriptSearchProvider } from "../src/client/components/transcriptSearch";
 import { ConversationPage } from "../src/client/pages/ConversationPage";
 import { ToolCallGallery } from "../src/client/pages/dev/ComponentsPage";
@@ -202,6 +204,44 @@ describe("dashboard canonical-event components", () => {
     expect(html).not.toContain('aria-label="Tool running"');
     expect(html).toContain('aria-label="Tool failed"');
     expect(html.match(/<details/g)).toHaveLength(6);
+  });
+
+  it("keeps card chrome on subagents but not tool calls", () => {
+    const toolHtml = renderToStaticMarkup(
+      <QueryClientProvider client={client}>
+        <TranscriptSearchProvider query="">
+          <TranscriptToolView
+            part={{
+              id: "tool-1",
+              input: { query: "regression" },
+              name: "search",
+              status: "running",
+              type: "tool_call",
+            }}
+          />
+        </TranscriptSearchProvider>
+      </QueryClientProvider>,
+    );
+    const subagentHtml = renderToStaticMarkup(
+      <QueryClientProvider client={client}>
+        <TranscriptSearchProvider query="">
+          <TranscriptSubagentView
+            part={{
+              childConversationId: "child-1",
+              id: "subagent-1",
+              status: "running",
+              subagentKind: "advisor",
+              type: "subagent",
+            }}
+          />
+        </TranscriptSearchProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(toolHtml).not.toContain("border-white/[0.055]");
+    expect(toolHtml).not.toContain("bg-black/15");
+    expect(subagentHtml).toContain("border-white/[0.055]");
+    expect(subagentHtml).toContain("bg-black/15");
   });
 
   it("exposes pressed state for transcript view controls", () => {

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -206,7 +206,7 @@ describe("dashboard canonical-event components", () => {
     expect(html.match(/<details/g)).toHaveLength(6);
   });
 
-  it("keeps card chrome on subagents but not tool calls", () => {
+  it("keeps tool and subagent transcript rows borderless", () => {
     const toolHtml = renderToStaticMarkup(
       <QueryClientProvider client={client}>
         <TranscriptSearchProvider query="">
@@ -240,8 +240,8 @@ describe("dashboard canonical-event components", () => {
 
     expect(toolHtml).not.toContain("border-white/[0.055]");
     expect(toolHtml).not.toContain("bg-black/15");
-    expect(subagentHtml).toContain("border-white/[0.055]");
-    expect(subagentHtml).toContain("bg-black/15");
+    expect(subagentHtml).not.toContain("border-white/[0.055]");
+    expect(subagentHtml).not.toContain("bg-black/15");
   });
 
   it("exposes pressed state for transcript view controls", () => {

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -248,6 +248,52 @@ describe("dashboard canonical-event components", () => {
     expect(subagentHtml).toContain("px-[1.0625rem]");
   });
 
+  it("keeps a running tool name searchable and accessible", () => {
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={client}>
+        <TranscriptSearchProvider query="search">
+          <TranscriptToolView
+            part={{
+              id: "tool-1",
+              input: { query: "regression" },
+              name: "webSearch",
+              status: "running",
+              type: "tool_call",
+            }}
+          />
+        </TranscriptSearchProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(html).toContain('aria-label="webSearch (running)"');
+    expect(html).toContain("<mark");
+    expect(html).not.toContain("junior-tool-shimmer");
+    expect(html).not.toContain("text-transparent");
+  });
+
+  it("keeps a static running-name treatment when motion is reduced", () => {
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={client}>
+        <TranscriptSearchProvider query="">
+          <TranscriptToolView
+            part={{
+              id: "tool-1",
+              name: "webSearch",
+              status: "running",
+              type: "tool_call",
+            }}
+          />
+        </TranscriptSearchProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(html).toContain('aria-label="webSearch (running)"');
+    expect(html).toContain("motion-reduce:animate-none");
+    expect(html).toContain("bg-clip-text");
+    expect(html).not.toContain("motion-reduce:bg-none");
+    expect(html).not.toContain("motion-reduce:text-[#d6d6d6]");
+  });
+
   it("exposes pressed state for transcript view controls", () => {
     const html = renderToStaticMarkup(
       <TranscriptHeader redacted={false} value="raw" onChange={() => {}} />,

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -24,7 +24,6 @@ import {
 import { Transcript } from "../src/client/components/Transcript";
 import { TranscriptHeader } from "../src/client/components/TranscriptHeader";
 import { TranscriptMarkdown } from "../src/client/components/TranscriptMarkdown";
-import { TranscriptSubagentView } from "../src/client/components/TranscriptSubagentView";
 import { TranscriptToolView } from "../src/client/components/TranscriptToolView";
 import { TranscriptSearchProvider } from "../src/client/components/transcriptSearch";
 import { ConversationPage } from "../src/client/pages/ConversationPage";
@@ -201,51 +200,7 @@ describe("dashboard canonical-event components", () => {
     expect(html).toContain("github_search, query: is:pr is:open, limit: 25");
     expect(html).toContain("jr-rpc config get github.repo");
     expect(html).toContain("junior-qa");
-    expect(html).not.toContain('aria-label="Tool running"');
     expect(html).toContain('aria-label="Tool failed"');
-    expect(html.match(/<details/g)).toHaveLength(6);
-  });
-
-  it("keeps tool and subagent transcript rows borderless", () => {
-    const toolHtml = renderToStaticMarkup(
-      <QueryClientProvider client={client}>
-        <TranscriptSearchProvider query="">
-          <TranscriptToolView
-            part={{
-              id: "tool-1",
-              input: { query: "regression" },
-              name: "search",
-              status: "running",
-              type: "tool_call",
-            }}
-          />
-        </TranscriptSearchProvider>
-      </QueryClientProvider>,
-    );
-    const subagentHtml = renderToStaticMarkup(
-      <QueryClientProvider client={client}>
-        <TranscriptSearchProvider query="">
-          <TranscriptSubagentView
-            part={{
-              childConversationId: "child-1",
-              id: "subagent-1",
-              status: "running",
-              subagentKind: "advisor",
-              type: "subagent",
-            }}
-          />
-        </TranscriptSearchProvider>
-      </QueryClientProvider>,
-    );
-
-    expect(toolHtml).not.toContain("border-white/[0.055]");
-    expect(toolHtml).not.toContain("bg-black/15");
-    expect(toolHtml).toContain("ml-6");
-    expect(toolHtml).toContain("px-[1.0625rem]");
-    expect(subagentHtml).not.toContain("border-white/[0.055]");
-    expect(subagentHtml).not.toContain("bg-black/15");
-    expect(subagentHtml).toContain("ml-6");
-    expect(subagentHtml).toContain("px-[1.0625rem]");
   });
 
   it("keeps a running tool name searchable and accessible", () => {
@@ -267,31 +222,6 @@ describe("dashboard canonical-event components", () => {
 
     expect(html).toContain('aria-label="webSearch (running)"');
     expect(html).toContain("<mark");
-    expect(html).not.toContain("junior-tool-shimmer");
-    expect(html).not.toContain("text-transparent");
-  });
-
-  it("keeps a static running-name treatment when motion is reduced", () => {
-    const html = renderToStaticMarkup(
-      <QueryClientProvider client={client}>
-        <TranscriptSearchProvider query="">
-          <TranscriptToolView
-            part={{
-              id: "tool-1",
-              name: "webSearch",
-              status: "running",
-              type: "tool_call",
-            }}
-          />
-        </TranscriptSearchProvider>
-      </QueryClientProvider>,
-    );
-
-    expect(html).toContain('aria-label="webSearch (running)"');
-    expect(html).toContain("motion-reduce:animate-none");
-    expect(html).toContain("bg-clip-text");
-    expect(html).not.toContain("motion-reduce:bg-none");
-    expect(html).not.toContain("motion-reduce:text-[#d6d6d6]");
   });
 
   it("exposes pressed state for transcript view controls", () => {
@@ -526,7 +456,7 @@ describe("dashboard canonical-event components", () => {
       ),
     );
     expect(html).toContain("search");
-    expect(html).toContain("junior-tool-shimmer");
+    expect(html).toContain('aria-label="search (running)"');
     expect(html).not.toContain(">running<");
     expect(html).not.toContain("started");
     expect(html).not.toContain("missing result");

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -26,6 +26,7 @@ import { TranscriptHeader } from "../src/client/components/TranscriptHeader";
 import { TranscriptMarkdown } from "../src/client/components/TranscriptMarkdown";
 import { TranscriptSearchProvider } from "../src/client/components/transcriptSearch";
 import { ConversationPage } from "../src/client/pages/ConversationPage";
+import { ToolCallGallery } from "../src/client/pages/dev/ComponentsPage";
 import { LocationDetailPageContent } from "../src/client/pages/locations/LocationDetailPage";
 import { LocationsPageContent } from "../src/client/pages/locations/LocationsPage";
 import { Profile } from "../src/client/pages/people/PersonProfilePage";
@@ -185,6 +186,22 @@ describe("dashboard canonical-event components", () => {
     expect(renderToStaticMarkup(<Button>Copy</Button>)).toContain(
       'type="button"',
     );
+  });
+
+  it("renders typed tool states in the component gallery", () => {
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={client}>
+        <ToolCallGallery />
+      </QueryClientProvider>,
+    );
+
+    expect(html).toContain("webSearch");
+    expect(html).toContain("github_search, query: is:pr is:open, limit: 25");
+    expect(html).toContain("jr-rpc config get github.repo");
+    expect(html).toContain("junior-qa");
+    expect(html).not.toContain('aria-label="Tool running"');
+    expect(html).toContain('aria-label="Tool failed"');
+    expect(html.match(/<details/g)).toHaveLength(6);
   });
 
   it("exposes pressed state for transcript view controls", () => {
@@ -419,7 +436,8 @@ describe("dashboard canonical-event components", () => {
       ),
     );
     expect(html).toContain("search");
-    expect(html).toContain("running");
+    expect(html).toContain("junior-tool-shimmer");
+    expect(html).not.toContain(">running<");
     expect(html).not.toContain("started");
     expect(html).not.toContain("missing result");
   });

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -240,8 +240,12 @@ describe("dashboard canonical-event components", () => {
 
     expect(toolHtml).not.toContain("border-white/[0.055]");
     expect(toolHtml).not.toContain("bg-black/15");
+    expect(toolHtml).toContain("ml-6");
+    expect(toolHtml).toContain("px-[1.0625rem]");
     expect(subagentHtml).not.toContain("border-white/[0.055]");
     expect(subagentHtml).not.toContain("bg-black/15");
+    expect(subagentHtml).toContain("ml-6");
+    expect(subagentHtml).toContain("px-[1.0625rem]");
   });
 
   it("exposes pressed state for transcript view controls", () => {

--- a/packages/junior-dashboard/tests/toolCallPreview.test.ts
+++ b/packages/junior-dashboard/tests/toolCallPreview.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { toolCallPreview } from "../src/client/components/toolCallPreview";
+
+describe("toolCallPreview", () => {
+  it("normalizes generic tool arguments", () => {
+    expect(
+      toolCallPreview("search", {
+        query: "release   regression",
+        limit: 10,
+        options: { archived: false },
+      }),
+    ).toBe(
+      'query: release regression, limit: 10, options: { "archived": false }',
+    );
+  });
+
+  it("shows only the bash command", () => {
+    expect(
+      toolCallPreview("bash", {
+        command: "jr-rpc   config get github.repo",
+        timeout_ms: 10_000,
+      }),
+    ).toBe("jr-rpc config get github.repo");
+  });
+
+  it("shows the dispatched tool and its arguments for executeTool", () => {
+    expect(
+      toolCallPreview("executeTool", {
+        tool_name: "github_search",
+        arguments: { query: "is:pr is:open", limit: 25 },
+      }),
+    ).toBe("github_search, query: is:pr is:open, limit: 25");
+  });
+
+  it("shows only the skill name for loadSkill", () => {
+    expect(
+      toolCallPreview("loadSkill", {
+        skill_name: "github",
+        ignored: "value",
+      }),
+    ).toBe("github");
+  });
+
+  it("shows only the query for webSearch", () => {
+    expect(
+      toolCallPreview("webSearch", {
+        query: "service:checkout status:error",
+        max_results: 50,
+      }),
+    ).toBe("service:checkout status:error");
+  });
+
+  it("bounds long values and long argument lists", () => {
+    const preview = toolCallPreview("demo", {
+      first: "x".repeat(100),
+      second: 2,
+      third: 3,
+      fourth: 4,
+      fifth: 5,
+    });
+
+    expect(preview?.length).toBeLessThanOrEqual(120);
+    expect(preview).toContain("…");
+    expect(preview).not.toContain("fifth");
+  });
+});

--- a/packages/junior/src/app.ts
+++ b/packages/junior/src/app.ts
@@ -119,6 +119,8 @@ export interface JuniorDashboardOptions {
   basePath?: string;
   /** Public deployment origin used for auth callbacks and external links. */
   baseURL?: string;
+  /** Expose the config-gated component gallery for local visual QA. */
+  componentGallery?: boolean;
   /** Disable dashboard route mounting while preserving serializable config shape. */
   disabled?: boolean;
   /** Replace conversation API responses with dashboard visual-QA fixtures. */
@@ -377,6 +379,9 @@ function dashboardHostRoutePaths(dashboard: JuniorDashboardOptions): string[] {
     `${peoplePath}/*`,
     pagePath("system"),
   ];
+  if (dashboard.componentGallery) {
+    pagePaths.push(pagePath("dev"), `${pagePath("dev")}/*`);
+  }
   const loginPath = basePath === "/" ? "/auth/login" : `${basePath}/auth/login`;
 
   return [

--- a/packages/junior/tests/integration/example-build-discovery.test.ts
+++ b/packages/junior/tests/integration/example-build-discovery.test.ts
@@ -102,6 +102,7 @@ async function importExampleDashboardConfig() {
   const href = `${pathToFileURL(exampleDashboardConfig).href}?t=${Date.now()}`;
   return (await import(href)) as {
     exampleDashboardAuthRequired: () => boolean;
+    exampleDashboardComponentGallery: () => boolean;
   };
 }
 
@@ -178,6 +179,20 @@ describe.sequential("example build discovery integration", () => {
     delete process.env.NODE_ENV;
     clearVercelEnv();
     expect(config.exampleDashboardAuthRequired()).toBe(true);
+  });
+
+  it("enables the component gallery only through its explicit flag", async () => {
+    const config = await importExampleDashboardConfig();
+
+    process.env = { ...originalEnv };
+    delete process.env.JUNIOR_DASHBOARD_COMPONENT_GALLERY;
+    expect(config.exampleDashboardComponentGallery()).toBe(false);
+
+    process.env.JUNIOR_DASHBOARD_COMPONENT_GALLERY = "true";
+    expect(config.exampleDashboardComponentGallery()).toBe(true);
+
+    process.env.JUNIOR_DASHBOARD_COMPONENT_GALLERY = "false";
+    expect(config.exampleDashboardComponentGallery()).toBe(false);
   });
 
   it("does not include top-level Vercel api source files", () => {

--- a/packages/junior/tests/unit/app-config.test.ts
+++ b/packages/junior/tests/unit/app-config.test.ts
@@ -786,6 +786,7 @@ describe("createApp plugin config", () => {
       dashboard: {
         authRequired: false,
         allowedGoogleDomains: ["sentry.io"],
+        componentGallery: true,
       },
       pluginSet: defineJuniorPlugins([
         defineJuniorPlugin({
@@ -821,6 +822,15 @@ describe("createApp plugin config", () => {
     const systemPage = await app.fetch(new Request("http://localhost/system"));
     expect(systemPage.status).toBe(200);
     await expect(systemPage.text()).resolves.toBe("dashboard");
+
+    const componentGallery = await app.fetch(
+      new Request("http://localhost/dev"),
+    );
+    expect(componentGallery.status).toBe(200);
+    await expect(componentGallery.text()).resolves.toBe("dashboard");
+    expect(createDashboardApp).toHaveBeenCalledWith(
+      expect.objectContaining({ componentGallery: true }),
+    );
 
     const dashboardAvatar = await app.fetch(
       new Request("http://localhost/_junior/dashboard/avatar.png"),

--- a/packages/junior/tests/unit/cli/init-cli.test.ts
+++ b/packages/junior/tests/unit/cli/init-cli.test.ts
@@ -32,7 +32,7 @@ function removeExampleDashboardServerConfig(source: string): string {
   return normalizeText(
     source
       .replace(
-        /import \{\n  exampleDashboardAuthRequired,\n  exampleDashboardMockConversations,\n\} from "\.\/dashboard\.ts";\n/,
+        /import \{\n  exampleDashboardAuthRequired,\n  exampleDashboardComponentGallery,\n  exampleDashboardMockConversations,\n\} from "\.\/dashboard\.ts";\n/,
         "",
       )
       .replace(/  dashboard: \{[\s\S]*?  \},\n  plugins,/, "  plugins,")
@@ -44,7 +44,7 @@ function removeExampleDashboardNitroConfig(source: string): string {
   return normalizeText(
     source
       .replace(
-        /import \{\n  exampleDashboardAuthRequired,\n  exampleDashboardMockConversations,\n\} from "\.\/dashboard\.ts";\n/,
+        /import \{\n  exampleDashboardAuthRequired,\n  exampleDashboardComponentGallery,\n  exampleDashboardMockConversations,\n\} from "\.\/dashboard\.ts";\n/,
         "",
       )
       .replace(


### PR DESCRIPTION
Collapsed transcript tool calls now show compact, normalized argument previews, with focused summaries for `bash`, `executeTool`, `loadSkill`, and `webSearch`. Running calls shimmer only the tool name, failed calls place their warning marker on the transcript rail, and the rows no longer add their own border or background; expanded arguments and results retain the existing behavior.

A config-gated, strongly typed component gallery now covers completed, running, failed, specialized, generic, truncated, and empty tool states for repeatable visual review. The gallery was checked at desktop and 390px widths, including expansion, with no horizontal overflow or browser errors.
