### PR TITLE
feat(tools): declare approval modes

### DIFF
--- a/packages/junior-plugin-api/src/tools.ts
+++ b/packages/junior-plugin-api/src/tools.ts
@@ -129,7 +129,17 @@ export type PluginToolExecute<TInput = unknown, TOutput = unknown> = {
   ): Promise<TOutput> | TOutput;
 }["bivarianceHack"];
 
+export const toolApprovalBehaviorSchema = z.enum([
+  "none",
+  "guardian",
+  "always_ask",
+]);
+
+export type ToolApprovalBehavior = z.output<typeof toolApprovalBehaviorSchema>;
+
 export interface PluginToolDefinition<TInput = unknown, TOutput = unknown> {
+  /** Declares the core action-review behavior for this tool. */
+  approval?: ToolApprovalBehavior;
   annotations?: unknown;
   description: string;
   executionMode?: unknown;

--- a/packages/junior-plugin-api/src/tools.ts
+++ b/packages/junior-plugin-api/src/tools.ts
@@ -132,14 +132,14 @@ export type PluginToolExecute<TInput = unknown, TOutput = unknown> = {
 /**
  * Tool-declared approval mode.
  *
- * `auto` delegates to core policy, `prompt` enters approval review, and
+ * `auto` delegates to core policy, `review` enters approval review, and
  * `approve` permits execution without review. Omission delegates to core
  * defaults. These values do not select the reviewer.
  *
  * This is declaration metadata only; current tool execution is unchanged.
  * TODO(#1053): Enforce effective approval modes before tool execution.
  */
-export const toolApprovalModeSchema = z.enum(["auto", "prompt", "approve"]);
+export const toolApprovalModeSchema = z.enum(["auto", "review", "approve"]);
 
 export type ToolApprovalMode = z.output<typeof toolApprovalModeSchema>;
 

--- a/packages/junior-plugin-api/src/tools.ts
+++ b/packages/junior-plugin-api/src/tools.ts
@@ -129,17 +129,13 @@ export type PluginToolExecute<TInput = unknown, TOutput = unknown> = {
   ): Promise<TOutput> | TOutput;
 }["bivarianceHack"];
 
-export const toolApprovalBehaviorSchema = z.enum([
-  "none",
-  "guardian",
-  "always_ask",
-]);
+export const toolApprovalModeSchema = z.enum(["auto", "prompt", "approve"]);
 
-export type ToolApprovalBehavior = z.output<typeof toolApprovalBehaviorSchema>;
+export type ToolApprovalMode = z.output<typeof toolApprovalModeSchema>;
 
 export interface PluginToolDefinition<TInput = unknown, TOutput = unknown> {
-  /** Declares the core action-review behavior for this tool. */
-  approval?: ToolApprovalBehavior;
+  /** Declares when this tool requires approval before execution. */
+  approvalMode?: ToolApprovalMode;
   annotations?: unknown;
   description: string;
   executionMode?: unknown;

--- a/packages/junior-plugin-api/src/tools.ts
+++ b/packages/junior-plugin-api/src/tools.ts
@@ -135,6 +135,9 @@ export type PluginToolExecute<TInput = unknown, TOutput = unknown> = {
  * `auto` delegates to core policy, `prompt` enters approval review, and
  * `approve` permits execution without review. Omission delegates to core
  * defaults. These values do not select the reviewer.
+ *
+ * This is declaration metadata only; current tool execution is unchanged.
+ * TODO(#1053): Enforce effective approval modes before tool execution.
  */
 export const toolApprovalModeSchema = z.enum(["auto", "prompt", "approve"]);
 

--- a/packages/junior-plugin-api/src/tools.ts
+++ b/packages/junior-plugin-api/src/tools.ts
@@ -129,12 +129,19 @@ export type PluginToolExecute<TInput = unknown, TOutput = unknown> = {
   ): Promise<TOutput> | TOutput;
 }["bivarianceHack"];
 
+/**
+ * Tool-declared approval mode.
+ *
+ * `auto` delegates to core policy, `prompt` enters approval review, and
+ * `approve` permits execution without review. Omission delegates to core
+ * defaults. These values do not select the reviewer.
+ */
 export const toolApprovalModeSchema = z.enum(["auto", "prompt", "approve"]);
 
 export type ToolApprovalMode = z.output<typeof toolApprovalModeSchema>;
 
 export interface PluginToolDefinition<TInput = unknown, TOutput = unknown> {
-  /** Declares when this tool requires approval before execution. */
+  /** Optional declared approval mode; omission delegates to core defaults. */
   approvalMode?: ToolApprovalMode;
   annotations?: unknown;
   description: string;

--- a/packages/junior/src/chat/tool-support/zod-tool.ts
+++ b/packages/junior/src/chat/tool-support/zod-tool.ts
@@ -13,6 +13,7 @@ import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 
 type ZodToolDefinitionBase<TInputSchema extends ZodTypeAny> = Pick<
   AnyToolDefinition,
+  | "approval"
   | "identity"
   | "source"
   | "description"

--- a/packages/junior/src/chat/tool-support/zod-tool.ts
+++ b/packages/junior/src/chat/tool-support/zod-tool.ts
@@ -13,7 +13,7 @@ import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 
 type ZodToolDefinitionBase<TInputSchema extends ZodTypeAny> = Pick<
   AnyToolDefinition,
-  | "approval"
+  | "approvalMode"
   | "identity"
   | "source"
   | "description"

--- a/packages/junior/src/chat/tools/definition.ts
+++ b/packages/junior/src/chat/tools/definition.ts
@@ -1,7 +1,7 @@
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import { Kind, type Static, type TSchema } from "@sinclair/typebox";
 import type { ToolExecutionMode } from "@earendil-works/pi-agent-core";
-import type { ToolApprovalBehavior } from "@sentry/junior-plugin-api";
+import type { ToolApprovalMode } from "@sentry/junior-plugin-api";
 import type { ConversationPrivacy } from "@/chat/conversation-privacy";
 
 /**
@@ -22,8 +22,8 @@ export interface ToolExecuteOptions {
 }
 
 interface BaseToolDefinition<TInput, TInputSchema extends ToolInputSchema> {
-  /** Declares the core action-review behavior for this tool. */
-  approval?: ToolApprovalBehavior;
+  /** Declares when this tool requires approval before execution. */
+  approvalMode?: ToolApprovalMode;
   /** Stable internal owner-qualified identity for plugin-contributed tools. */
   identity?: {
     id: string;
@@ -69,8 +69,8 @@ export interface ToolDefinition<
  * Schema-erased view for heterogeneous registries after Pi validates tool input.
  */
 export interface AnyToolDefinition {
-  /** Declares the core action-review behavior for this tool. */
-  approval?: ToolApprovalBehavior;
+  /** Declares when this tool requires approval before execution. */
+  approvalMode?: ToolApprovalMode;
   /** Stable internal owner-qualified identity for plugin-contributed tools. */
   identity?: {
     id: string;

--- a/packages/junior/src/chat/tools/definition.ts
+++ b/packages/junior/src/chat/tools/definition.ts
@@ -22,7 +22,7 @@ export interface ToolExecuteOptions {
 }
 
 interface BaseToolDefinition<TInput, TInputSchema extends ToolInputSchema> {
-  /** Declares when this tool requires approval before execution. */
+  /** Optional declared approval mode; omission delegates to core defaults. */
   approvalMode?: ToolApprovalMode;
   /** Stable internal owner-qualified identity for plugin-contributed tools. */
   identity?: {
@@ -69,7 +69,7 @@ export interface ToolDefinition<
  * Schema-erased view for heterogeneous registries after Pi validates tool input.
  */
 export interface AnyToolDefinition {
-  /** Declares when this tool requires approval before execution. */
+  /** Optional declared approval mode; omission delegates to core defaults. */
   approvalMode?: ToolApprovalMode;
   /** Stable internal owner-qualified identity for plugin-contributed tools. */
   identity?: {

--- a/packages/junior/src/chat/tools/definition.ts
+++ b/packages/junior/src/chat/tools/definition.ts
@@ -1,6 +1,7 @@
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import { Kind, type Static, type TSchema } from "@sinclair/typebox";
 import type { ToolExecutionMode } from "@earendil-works/pi-agent-core";
+import type { ToolApprovalBehavior } from "@sentry/junior-plugin-api";
 import type { ConversationPrivacy } from "@/chat/conversation-privacy";
 
 /**
@@ -21,6 +22,8 @@ export interface ToolExecuteOptions {
 }
 
 interface BaseToolDefinition<TInput, TInputSchema extends ToolInputSchema> {
+  /** Declares the core action-review behavior for this tool. */
+  approval?: ToolApprovalBehavior;
   /** Stable internal owner-qualified identity for plugin-contributed tools. */
   identity?: {
     id: string;
@@ -66,6 +69,8 @@ export interface ToolDefinition<
  * Schema-erased view for heterogeneous registries after Pi validates tool input.
  */
 export interface AnyToolDefinition {
+  /** Declares the core action-review behavior for this tool. */
+  approval?: ToolApprovalBehavior;
   /** Stable internal owner-qualified identity for plugin-contributed tools. */
   identity?: {
     id: string;

--- a/packages/junior/tests/unit/plugins/agent-hooks.test.ts
+++ b/packages/junior/tests/unit/plugins/agent-hooks.test.ts
@@ -30,10 +30,10 @@ const demoToolResultSchema = pluginToolResultSchema.extend({
 
 function demoPluginTool(
   description = "Demo tool",
-  approval?: "none" | "guardian" | "always_ask",
+  approvalMode?: "auto" | "prompt" | "approve",
 ) {
   return definePluginTool({
-    approval,
+    approvalMode,
     description,
     inputSchema: z.object({}),
     outputSchema: demoToolResultSchema,
@@ -416,7 +416,7 @@ describe("agent plugin hooks", () => {
           tools(ctx) {
             expect(ctx.actor).toEqual(TEST_ACTOR);
             return {
-              demoTool: demoPluginTool("Demo tool", "guardian"),
+              demoTool: demoPluginTool("Demo tool", "prompt"),
             };
           },
         },
@@ -442,7 +442,7 @@ describe("agent plugin hooks", () => {
         id: "agent-demo",
         description: "Agent demo",
       });
-      expect(tools.agentDemo_demoTool?.approval).toBe("guardian");
+      expect(tools.agentDemo_demoTool?.approvalMode).toBe("prompt");
     } finally {
       setPlugins(previous);
     }

--- a/packages/junior/tests/unit/plugins/agent-hooks.test.ts
+++ b/packages/junior/tests/unit/plugins/agent-hooks.test.ts
@@ -28,8 +28,12 @@ const demoToolResultSchema = pluginToolResultSchema.extend({
   status: z.literal("success"),
 });
 
-function demoPluginTool(description = "Demo tool") {
+function demoPluginTool(
+  description = "Demo tool",
+  approval?: "none" | "guardian" | "always_ask",
+) {
   return definePluginTool({
+    approval,
     description,
     inputSchema: z.object({}),
     outputSchema: demoToolResultSchema,
@@ -412,7 +416,7 @@ describe("agent plugin hooks", () => {
           tools(ctx) {
             expect(ctx.actor).toEqual(TEST_ACTOR);
             return {
-              demoTool: demoPluginTool(),
+              demoTool: demoPluginTool("Demo tool", "guardian"),
             };
           },
         },
@@ -438,6 +442,7 @@ describe("agent plugin hooks", () => {
         id: "agent-demo",
         description: "Agent demo",
       });
+      expect(tools.agentDemo_demoTool?.approval).toBe("guardian");
     } finally {
       setPlugins(previous);
     }

--- a/packages/junior/tests/unit/plugins/agent-hooks.test.ts
+++ b/packages/junior/tests/unit/plugins/agent-hooks.test.ts
@@ -30,7 +30,7 @@ const demoToolResultSchema = pluginToolResultSchema.extend({
 
 function demoPluginTool(
   description = "Demo tool",
-  approvalMode?: "auto" | "prompt" | "approve",
+  approvalMode?: "auto" | "review" | "approve",
 ) {
   return definePluginTool({
     approvalMode,
@@ -416,7 +416,7 @@ describe("agent plugin hooks", () => {
           tools(ctx) {
             expect(ctx.actor).toEqual(TEST_ACTOR);
             return {
-              demoTool: demoPluginTool("Demo tool", "prompt"),
+              demoTool: demoPluginTool("Demo tool", "review"),
             };
           },
         },
@@ -442,7 +442,7 @@ describe("agent plugin hooks", () => {
         id: "agent-demo",
         description: "Agent demo",
       });
-      expect(tools.agentDemo_demoTool?.approvalMode).toBe("prompt");
+      expect(tools.agentDemo_demoTool?.approvalMode).toBe("review");
     } finally {
       setPlugins(previous);
     }

--- a/packages/junior/tests/unit/plugins/define-plugin-tool.test.ts
+++ b/packages/junior/tests/unit/plugins/define-plugin-tool.test.ts
@@ -18,7 +18,7 @@ const countResultSchema = pluginToolResultSchema.extend({
 describe("definePluginTool", () => {
   it("preserves the declared approval mode", () => {
     const tool = definePluginTool({
-      approvalMode: "prompt",
+      approvalMode: "review",
       description: "Schedule a meeting.",
       inputSchema: z.object({}),
       outputSchema: countResultSchema,
@@ -31,7 +31,7 @@ describe("definePluginTool", () => {
         }) as const,
     });
 
-    expect(tool.approvalMode).toBe("prompt");
+    expect(tool.approvalMode).toBe("review");
     expect(toolApprovalModeSchema.safeParse("unexpected").success).toBe(false);
   });
 

--- a/packages/junior/tests/unit/plugins/define-plugin-tool.test.ts
+++ b/packages/junior/tests/unit/plugins/define-plugin-tool.test.ts
@@ -3,7 +3,7 @@ import {
   definePluginTool,
   PluginToolInputError,
   pluginToolResultSchema,
-  toolApprovalBehaviorSchema,
+  toolApprovalModeSchema,
   zodTool,
 } from "@sentry/junior-plugin-api";
 import { z } from "zod";
@@ -16,9 +16,9 @@ const countResultSchema = pluginToolResultSchema.extend({
 });
 
 describe("definePluginTool", () => {
-  it("preserves the declared approval behavior", () => {
+  it("preserves the declared approval mode", () => {
     const tool = definePluginTool({
-      approval: "guardian",
+      approvalMode: "prompt",
       description: "Schedule a meeting.",
       inputSchema: z.object({}),
       outputSchema: countResultSchema,
@@ -31,10 +31,8 @@ describe("definePluginTool", () => {
         }) as const,
     });
 
-    expect(tool.approval).toBe("guardian");
-    expect(toolApprovalBehaviorSchema.safeParse("unexpected").success).toBe(
-      false,
-    );
+    expect(tool.approvalMode).toBe("prompt");
+    expect(toolApprovalModeSchema.safeParse("unexpected").success).toBe(false);
   });
 
   it("projects Zod input schemas to JSON Schema and parses tool arguments", async () => {

--- a/packages/junior/tests/unit/plugins/define-plugin-tool.test.ts
+++ b/packages/junior/tests/unit/plugins/define-plugin-tool.test.ts
@@ -3,6 +3,7 @@ import {
   definePluginTool,
   PluginToolInputError,
   pluginToolResultSchema,
+  toolApprovalBehaviorSchema,
   zodTool,
 } from "@sentry/junior-plugin-api";
 import { z } from "zod";
@@ -15,6 +16,27 @@ const countResultSchema = pluginToolResultSchema.extend({
 });
 
 describe("definePluginTool", () => {
+  it("preserves the declared approval behavior", () => {
+    const tool = definePluginTool({
+      approval: "guardian",
+      description: "Schedule a meeting.",
+      inputSchema: z.object({}),
+      outputSchema: countResultSchema,
+      execute: async () =>
+        ({
+          ok: true,
+          status: "success",
+          data: { count: 1 },
+          count: 1,
+        }) as const,
+    });
+
+    expect(tool.approval).toBe("guardian");
+    expect(toolApprovalBehaviorSchema.safeParse("unexpected").success).toBe(
+      false,
+    );
+  });
+
   it("projects Zod input schemas to JSON Schema and parses tool arguments", async () => {
     const execute = vi.fn(
       async (input: { count: number }) =>

--- a/packages/junior/tests/unit/tool-support/zod-tool.test.ts
+++ b/packages/junior/tests/unit/tool-support/zod-tool.test.ts
@@ -5,16 +5,16 @@ import { zodTool } from "@/chat/tool-support/zod-tool";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 
 describe("zodTool", () => {
-  it("preserves the declared approval behavior", () => {
+  it("preserves the declared approval mode", () => {
     const tool = zodTool({
-      approval: "always_ask",
+      approvalMode: "approve",
       description: "Delete a record.",
       inputSchema: z.object({}),
       outputSchema: juniorToolResultSchema,
       execute: async () => ({ ok: true, status: "success" as const }),
     });
 
-    expect(tool.approval).toBe("always_ask");
+    expect(tool.approvalMode).toBe("approve");
   });
 
   it("projects Zod input schemas to JSON Schema and parses tool arguments", async () => {

--- a/packages/junior/tests/unit/tool-support/zod-tool.test.ts
+++ b/packages/junior/tests/unit/tool-support/zod-tool.test.ts
@@ -5,6 +5,18 @@ import { zodTool } from "@/chat/tool-support/zod-tool";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 
 describe("zodTool", () => {
+  it("preserves the declared approval behavior", () => {
+    const tool = zodTool({
+      approval: "always_ask",
+      description: "Delete a record.",
+      inputSchema: z.object({}),
+      outputSchema: juniorToolResultSchema,
+      execute: async () => ({ ok: true, status: "success" as const }),
+    });
+
+    expect(tool.approval).toBe("always_ask");
+  });
+
   it("projects Zod input schemas to JSON Schema and parses tool arguments", async () => {
     const execute = vi.fn(
       async (input: { count: number }, _options: unknown) => input.count,


### PR DESCRIPTION
Core and plugin tool definitions can now declare `auto`, `review`, or `approve` through an `approvalMode` field. Both Zod tool helpers preserve the declaration, and plugin registration carries it into Junior’s canonical tool registry alongside the tool identity and source.

Approval mode determines whether an invocation enters the approval system; it does not select the reviewer. Guardian remains a runtime actor that reviews eligible requests and may approve, escalate to the user, or deny them.

The field remains optional, so unclassified tools execute exactly as before. This is the metadata-only first increment of #1050; exact-action proposal descriptions, MCP adaptation, effective mode resolution, and Guardian enforcement remain separate follow-up work.

Refs #874.
Refs #1050.
