### PR TITLE
feat(dashboard): show continuation summaries

### DIFF
--- a/packages/junior-dashboard/src/client/components/TranscriptContextEventView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptContextEventView.tsx
@@ -1,5 +1,6 @@
 import { formatCompactNumber, formatMessageTimestamp } from "../format";
 import type { TranscriptViewContextEventPart } from "../types";
+import { TranscriptText } from "./TranscriptText";
 
 /** Render a structural context change from the privacy-safe event API. */
 export function TranscriptContextEventView(props: {
@@ -43,6 +44,21 @@ export function TranscriptContextEventView(props: {
           ? `Execution continued with the ${event.modelProfile} profile (${event.modelId}${event.reasoningLevel ? `, ${event.reasoningLevel}` : ""}).`
           : `Earlier context was summarized${compactionDetail}${compactionModel} before execution continued.`}
       </div>
+      {event.summary ? (
+        <details className="mt-2 border-t border-white/[0.06] pt-2">
+          <summary className="cursor-pointer select-none text-[0.78rem] font-medium text-white/55">
+            Continuation summary
+          </summary>
+          <div className="mt-2 text-[0.8rem] leading-relaxed text-white/60">
+            <TranscriptText
+              firstChildIndex={0}
+              lastChildIndex={0}
+              role="system"
+              text={event.summary}
+            />
+          </div>
+        </details>
+      ) : null}
     </article>
   );
 }

--- a/packages/junior-dashboard/src/client/components/transcriptRenderModel.ts
+++ b/packages/junior-dashboard/src/client/components/transcriptRenderModel.ts
@@ -125,11 +125,16 @@ export function messageRawText(message: TranscriptViewMessage): string {
       if (part.type === "subagent") {
         return `subagent ${part.subagentKind}\nstatus ${part.status}`;
       }
-      if (part.event.type !== "handoff") return "context compacted";
+      if (part.event.type !== "handoff") {
+        return ["context compacted", part.event.summary]
+          .filter((line): line is string => line !== undefined)
+          .join("\n");
+      }
       return [
         "model handoff",
         `profile ${part.event.modelProfile}`,
         `model ${part.event.modelId}`,
+        part.event.summary,
         part.event.reasoningLevel
           ? `reasoning ${part.event.reasoningLevel}`
           : undefined,

--- a/packages/junior-dashboard/src/client/components/transcriptSearch.tsx
+++ b/packages/junior-dashboard/src/client/components/transcriptSearch.tsx
@@ -162,8 +162,11 @@ export function entryMatchesSearch(
           event.modelProfile,
           event.modelId,
           event.reasoningLevel,
+          event.summary,
         ].some((value) => textContains(value, normalizedQuery))
-      : textContains("context compacted", normalizedQuery);
+      : ["context compacted", event.summary].some((value) =>
+          textContains(value, normalizedQuery),
+        );
   }
 
   return false;

--- a/packages/junior-dashboard/src/client/conversations/eventTranscript.ts
+++ b/packages/junior-dashboard/src/client/conversations/eventTranscript.ts
@@ -176,6 +176,7 @@ export function conversationTranscriptMessages(
                     createdAt: event.createdAt,
                     modelId: data.modelId,
                     modelProfile: data.modelProfile,
+                    ...(data.summary ? { summary: data.summary } : {}),
                     ...(data.reasoningLevel
                       ? { reasoningLevel: data.reasoningLevel }
                       : {}),
@@ -187,6 +188,7 @@ export function conversationTranscriptMessages(
                     ...(data.modelProfile
                       ? { modelProfile: data.modelProfile }
                       : {}),
+                    ...(data.summary ? { summary: data.summary } : {}),
                     ...(data.details ? { details: data.details } : {}),
                   },
           },

--- a/packages/junior-dashboard/src/client/markdownExport.ts
+++ b/packages/junior-dashboard/src/client/markdownExport.ts
@@ -219,6 +219,9 @@ function appendContextEvent(
       );
     }
   }
+  if (event.summary) {
+    lines.push("", "#### Continuation summary", "", event.summary);
+  }
 }
 
 function appendResourceEvent(

--- a/packages/junior-dashboard/src/client/types.ts
+++ b/packages/junior-dashboard/src/client/types.ts
@@ -40,6 +40,7 @@ export type TranscriptViewContextEventPart = {
         type: "compaction";
         modelId?: string;
         modelProfile?: string;
+        summary?: string;
         details?: {
           reason: "capacity";
           estimatedInputTokens: number;
@@ -56,6 +57,7 @@ export type TranscriptViewContextEventPart = {
         modelId: string;
         modelProfile: string;
         reasoningLevel?: string;
+        summary?: string;
         type: "handoff";
       };
   type: "context_event";

--- a/packages/junior-dashboard/src/mock-reporting/fixtures.ts
+++ b/packages/junior-dashboard/src/mock-reporting/fixtures.ts
@@ -375,6 +375,8 @@ function longConversation(nowMs: number): ConversationDetailReport {
       type: "compaction",
       modelProfile: "standard",
       modelId: "openai/gpt-5.4",
+      summary:
+        "The release is complete. Preserve the published version and continue by checking the update pull request.",
       details: {
         reason: "capacity",
         estimatedInputTokens: 364_200,
@@ -391,6 +393,8 @@ function longConversation(nowMs: number): ConversationDetailReport {
       modelProfile: "fast",
       modelId: "openai/gpt-5-mini",
       reasoningLevel: "medium",
+      summary:
+        "Investigate the remaining deployment checks and report any actionable failure.",
     }),
     reportEvent(16, iso(Date.parse(startedAt), 166_000), {
       type: "message",

--- a/packages/junior-dashboard/tests/markdownExport.test.ts
+++ b/packages/junior-dashboard/tests/markdownExport.test.ts
@@ -142,6 +142,7 @@ describe("dashboard canonical-event Markdown export", () => {
           type: "compaction",
           modelProfile: "standard",
           modelId: "openai/gpt-5.4",
+          summary: "Keep the release state and continue monitoring CI.",
           details: {
             reason: "capacity",
             estimatedInputTokens: 361_000,
@@ -158,6 +159,7 @@ describe("dashboard canonical-event Markdown export", () => {
           modelProfile: "fast",
           modelId: "openai/gpt-5-mini",
           reasoningLevel: "medium",
+          summary: "Investigate the remaining deployment failure.",
         }),
         event(6, {
           type: "turn_lifecycle",
@@ -178,10 +180,15 @@ describe("dashboard canonical-event Markdown export", () => {
     expect(markdown).toContain("- Estimated input tokens: 361000");
     expect(markdown).toContain("- Compaction trigger: 360000");
     expect(markdown).toContain("- Input limit: 380000");
+    expect(markdown).toContain("#### Continuation summary");
+    expect(markdown).toContain(
+      "Keep the release state and continue monitoring CI.",
+    );
     expect(markdown).toContain("### Model handoff");
     expect(markdown).toContain("- Profile: fast");
     expect(markdown).toContain("- Model: openai/gpt-5-mini");
     expect(markdown).toContain("- Reasoning: medium");
+    expect(markdown).toContain("Investigate the remaining deployment failure.");
     expect(markdown).toContain("### Agent response failed");
     expect(markdown).not.toContain("missing");
     expect(markdown).not.toContain("Result: running");

--- a/packages/junior-dashboard/tests/transcriptContextEvent.test.tsx
+++ b/packages/junior-dashboard/tests/transcriptContextEvent.test.tsx
@@ -25,6 +25,7 @@ describe("transcript context events", () => {
               createdAt: "2026-01-01T00:00:02.000Z",
               modelProfile: "standard",
               modelId: "openai/gpt-5.4",
+              summary: "Preserve the release state and monitor **CI**.",
               details: {
                 reason: "capacity",
                 estimatedInputTokens: 361_000,
@@ -45,6 +46,9 @@ describe("transcript context events", () => {
     expect(html).toContain("Context compacted");
     expect(html).toContain("approximately 361k estimated tokens");
     expect(html).toContain("standard profile (openai/gpt-5.4)");
+    expect(html).toContain("Continuation summary");
+    expect(html).toContain("Preserve the release state and monitor");
+    expect(html).toContain("CI");
   });
 
   it("renders a model handoff as a structural event", () => {
@@ -59,6 +63,7 @@ describe("transcript context events", () => {
               modelId: "openai/gpt-5.4",
               modelProfile: "coding",
               reasoningLevel: "high",
+              summary: "Continue the implementation from the failing test.",
             },
           }}
         />,
@@ -68,6 +73,10 @@ describe("transcript context events", () => {
     expect(html).toContain("Model handoff");
     expect(html).toContain(
       "Execution continued with the coding profile (openai/gpt-5.4, high).",
+    );
+    expect(html).toContain("Continuation summary");
+    expect(html).toContain(
+      "Continue the implementation from the failing test.",
     );
   });
 });

--- a/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
+++ b/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
@@ -4,7 +4,10 @@ import type {
   ConversationReportEventData,
 } from "@sentry/junior/api/schema";
 
-import { groupTranscriptMessages } from "../src/client/components/transcriptRenderModel";
+import {
+  groupTranscriptMessages,
+  messageRawText,
+} from "../src/client/components/transcriptRenderModel";
 import { entryMatchesSearch } from "../src/client/components/transcriptSearch";
 import { conversationTranscriptMessages } from "../src/client/conversations/eventTranscript";
 import type {
@@ -127,6 +130,7 @@ describe("canonical event transcript reduction", () => {
           modelProfile: "review",
           modelId: "openai/gpt-5.6-review",
           triggeringToolCallId: "handoff-1",
+          summary: "Continue with the regression review.",
         }),
       ]),
     );
@@ -154,9 +158,14 @@ describe("canonical event transcript reduction", () => {
           type: "handoff",
           modelProfile: "review",
           modelId: "openai/gpt-5.6-review",
+          summary: "Continue with the regression review.",
         },
       },
     });
+    expect(entryMatchesSearch(entries[1]!, "regression review")).toBe(true);
+    expect(messageRawText(messages[1]!)).toContain(
+      "Continue with the regression review.",
+    );
   });
 
   it("preserves resource event type for special rendering", () => {
@@ -376,6 +385,7 @@ describe("canonical event transcript reduction", () => {
       conversation([
         event(0, "2026-01-01T00:00:00.000Z", {
           type: "compaction",
+          summary: "Preserve the release checklist.",
         }),
         event(1, "2026-01-01T00:00:01.000Z", {
           type: "handoff",
@@ -420,6 +430,10 @@ describe("canonical event transcript reduction", () => {
         status: "completed",
       },
     });
+    expect(entryMatchesSearch(entries[0]!, "release checklist")).toBe(true);
+    expect(messageRawText(messages[0]!)).toContain(
+      "Preserve the release checklist.",
+    );
   });
 
   it("correlates repeated child outcomes by start sequence", () => {

--- a/packages/junior/src/api/conversations/README.md
+++ b/packages/junior/src/api/conversations/README.md
@@ -22,7 +22,9 @@ resource events:
 - `subagent` carries a stable child reference, canonical start position, and
   current status.
 - message, turn lifecycle, compaction, and handoff events expose only the
-  fields owned by the reporting API.
+  fields owned by the reporting API. Authorized compaction and handoff events
+  include the generated continuation summary, but never the full replacement
+  history.
 
 The projection is append-only: later canonical facts produce new observations
 instead of changing previously returned events. Clients reduce observations by

--- a/packages/junior/src/api/conversations/events.ts
+++ b/packages/junior/src/api/conversations/events.ts
@@ -251,6 +251,9 @@ function reportEventData(args: {
         type: "compaction",
         modelProfile: data.modelProfile,
         modelId: data.modelId,
+        ...(args.canExposePayload && data.summary
+          ? { summary: data.summary }
+          : {}),
         ...(data.details ? { details: data.details } : {}),
       };
     default:
@@ -387,6 +390,9 @@ export function projectConversationReportEventPage(args: {
           : {}),
         ...(event.data.triggeringToolCallId
           ? { triggeringToolCallId: event.data.triggeringToolCallId }
+          : {}),
+        ...(args.canExposePayload && event.data.summary
+          ? { summary: event.data.summary }
           : {}),
       };
     } else {

--- a/packages/junior/src/api/schema/conversation.ts
+++ b/packages/junior/src/api/schema/conversation.ts
@@ -177,6 +177,7 @@ const conversationReportCompactionEventDataSchema = z
     type: z.literal("compaction"),
     modelProfile: z.string().min(1).optional(),
     modelId: z.string().min(1).optional(),
+    summary: z.string().min(1).optional(),
     details: z
       .object({
         reason: z.literal("capacity"),
@@ -200,6 +201,7 @@ const conversationReportHandoffEventDataSchema = z
     modelId: z.string().min(1),
     reasoningLevel: z.string().min(1).optional(),
     triggeringToolCallId: z.string().min(1).optional(),
+    summary: z.string().min(1).optional(),
   })
   .strict();
 

--- a/packages/junior/src/chat/conversations/history.ts
+++ b/packages/junior/src/chat/conversations/history.ts
@@ -74,6 +74,7 @@ const historyReplacementEventDataSchema = z.discriminatedUnion("type", [
       modelId: z.string().min(1),
       reasoningLevel: z.string().min(1).optional(),
       triggeringToolCallId: z.string().min(1).optional(),
+      summary: z.string().min(1).optional(),
       replacementHistory: replacementHistorySchema,
     })
     .strict(),
@@ -83,6 +84,7 @@ const historyReplacementEventDataSchema = z.discriminatedUnion("type", [
       modelProfile: modelProfileSchema,
       modelId: z.string().min(1),
       details: compactionDetailsSchema.optional(),
+      summary: z.string().min(1).optional(),
       replacementHistory: replacementHistorySchema,
     })
     .strict(),

--- a/packages/junior/src/chat/services/context-compaction.ts
+++ b/packages/junior/src/chat/services/context-compaction.ts
@@ -512,6 +512,7 @@ async function writeCompactedThreadContext(
         retainedMessageCount: replacement.length - 1,
         summaryChars: summary.length,
       },
+      summary,
       replacementHistory: replacement.map((message, index) => {
         const sourceEventSeq =
           index < retained.length
@@ -563,7 +564,8 @@ export async function compactContextForHandoff(
   if (!runtimeMessage) {
     throw new Error("Handoff requires the current runtime turn context");
   }
-  const summary = `${MODEL_HANDOFF_SUMMARY_PREFIX}\n${await summarizeContext(args, deps)}`;
+  const generatedSummary = await summarizeContext(args, deps);
+  const summary = `${MODEL_HANDOFF_SUMMARY_PREFIX}\n${generatedSummary}`;
   const message = {
     ...runtimeMessage,
     content: [
@@ -586,6 +588,7 @@ export async function compactContextForHandoff(
       ...(args.triggeringToolCallId
         ? { triggeringToolCallId: args.triggeringToolCallId }
         : {}),
+      summary: generatedSummary,
       replacementHistory: replacementMessages.map((replacementMessage) => ({
         message: replacementMessage,
         provenance: contextProvenance,
@@ -700,6 +703,7 @@ export async function compactActiveContextIfNeeded(
         retainedMessageCount: pendingMessages.length,
         summaryChars: summary.length,
       },
+      summary,
       replacementHistory: replacementMessages.map((message, index) => ({
         message,
         provenance:

--- a/packages/junior/tests/component/services/context-compaction.test.ts
+++ b/packages/junior/tests/component/services/context-compaction.test.ts
@@ -384,6 +384,7 @@ describe("context compaction projection reset", () => {
       type: "compaction",
       modelProfile: "standard",
       modelId: "openai/gpt-5.4",
+      summary: "The edit completed; verify the result.",
       details: {
         reason: "capacity",
         triggerTokens: 360_000,
@@ -573,6 +574,7 @@ describe("context compaction projection reset", () => {
       modelProfile: "handoff",
       modelId: botConfig.profiles.handoff!.modelId,
       triggeringToolCallId: "handoff-call-1",
+      summary: "Continue the multi-file implementation.",
       replacementHistory: [
         {
           message: durableHandoffMessages[0],
@@ -614,21 +616,24 @@ describe("context compaction projection reset", () => {
         (entry) => entry.type === "handoff" || entry.type === "compaction",
       );
     expect(
-      replacements.map(({ type, modelProfile, modelId }) => ({
+      replacements.map(({ type, modelProfile, modelId, summary }) => ({
         type,
         modelProfile,
         modelId,
+        summary,
       })),
     ).toEqual([
       {
         type: "handoff",
         modelProfile: "handoff",
         modelId: botConfig.profiles.handoff!.modelId,
+        summary: "Continue the multi-file implementation.",
       },
       {
         type: "compaction",
         modelProfile: "handoff",
         modelId: botConfig.profiles.handoff!.modelId,
+        summary: "Continue the handed-off implementation.",
       },
     ]);
   });

--- a/packages/junior/tests/integration/dashboard-reporting.test.ts
+++ b/packages/junior/tests/integration/dashboard-reporting.test.ts
@@ -190,7 +190,17 @@ async function appendVisibleHistory(
       type: "compaction",
       modelProfile: "standard",
       modelId: "private-model-id",
-      replacementHistory: [{ message: modelMessage }],
+      summary: "Continue monitoring CI.",
+      replacementHistory: [
+        { message: modelMessage },
+        {
+          message: {
+            role: "user",
+            content: "Private replacement context.",
+            timestamp: 15,
+          } as PiMessage,
+        },
+      ],
     },
   });
   await getConversationEventStore().replaceHistory(conversationId, {
@@ -201,7 +211,21 @@ async function appendVisibleHistory(
       modelId: "private-handoff-model-id",
       reasoningLevel: "high",
       triggeringToolCallId: `${conversationId}:handoff-tool-call`,
-      replacementHistory: [],
+      summary: "Fix the remaining test.",
+      replacementHistory: [
+        {
+          message: {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: "More private replacement context.",
+              },
+            ],
+            timestamp: 16,
+          } as PiMessage,
+        },
+      ],
     },
   });
 }
@@ -398,6 +422,7 @@ describe("dashboard canonical event reporting", () => {
         type: "compaction",
         modelProfile: "standard",
         modelId: "private-model-id",
+        summary: "Continue monitoring CI.",
       },
       {
         type: "handoff",
@@ -405,12 +430,19 @@ describe("dashboard canonical event reporting", () => {
         modelId: "private-handoff-model-id",
         reasoningLevel: "high",
         triggeringToolCallId: `${conversationId}:handoff-tool-call`,
+        summary: "Fix the remaining test.",
       },
     ]);
     const eventSeqs = detail.events.map((event) => event.seq);
     expect(eventSeqs).toEqual(eventSeqs.slice().sort((a, b) => a - b));
     expect(JSON.stringify(detail)).not.toContain(
       "private model-only duplicate",
+    );
+    expect(JSON.stringify(detail)).not.toContain(
+      "Private replacement context.",
+    );
+    expect(JSON.stringify(detail)).not.toContain(
+      "More private replacement context.",
     );
     expect(JSON.stringify(detail)).toContain("private-model-id");
     expect(JSON.stringify(detail)).toContain("private-handoff-model-id");

--- a/packages/junior/tests/integration/runtime/agent-run-model-handoff.test.ts
+++ b/packages/junior/tests/integration/runtime/agent-run-model-handoff.test.ts
@@ -398,6 +398,7 @@ describe("executeAgentRun model handoff", () => {
         modelId: "openai/gpt-5.6-sol",
         reasoningLevel: "high",
         triggeringToolCallId: "handoff-call-1",
+        summary: "Implement the requested change and verify it.",
         replacementHistory: expectedHandoffReplacementHistory(),
       },
     ]);
@@ -456,6 +457,7 @@ describe("executeAgentRun model handoff", () => {
         modelId: "openai/gpt-5.6-sol",
         reasoningLevel: "high",
         triggeringToolCallId: "handoff-call-1",
+        summary: "Implement the requested change and verify it.",
         replacementHistory: expectedHandoffReplacementHistory(),
       },
     ]);
@@ -768,6 +770,7 @@ describe("executeAgentRun model handoff", () => {
         modelId: "openai/gpt-5.4",
         reasoningLevel: "high",
         triggeringToolCallId: "handoff-call-1",
+        summary: "Implement the requested change and verify it.",
         replacementHistory: expectedHandoffReplacementHistory(),
       },
     ]);
@@ -847,6 +850,7 @@ describe("executeAgentRun model handoff", () => {
         modelId: "openai/gpt-5.6-sol",
         reasoningLevel: "high",
         triggeringToolCallId: "handoff-call-1",
+        summary: "Implement the requested change and verify it.",
         replacementHistory: expectedHandoffReplacementHistory(),
       },
     ]);

--- a/packages/junior/tests/unit/api/conversation-events.test.ts
+++ b/packages/junior/tests/unit/api/conversation-events.test.ts
@@ -468,6 +468,83 @@ describe("conversation report event projection", () => {
     }
   });
 
+  it("exposes only generated continuation summaries to authorized viewers", () => {
+    const events = [
+      event(1, {
+        type: "compaction",
+        modelProfile: "standard",
+        modelId: "openai/gpt-5.4",
+        summary: "Continue monitoring CI.",
+        replacementHistory: [
+          {
+            message: {
+              role: "user",
+              content: "Private retained user message.",
+              timestamp: 1,
+            } as ConversationAgentStepPayload,
+          },
+          {
+            message: {
+              role: "user",
+              content: "Other private replacement context.",
+              timestamp: 1,
+            } as ConversationAgentStepPayload,
+          },
+        ],
+      }),
+      event(2, {
+        type: "handoff",
+        modelProfile: "handoff",
+        modelId: "openai/gpt-5.6-sol",
+        summary: "Fix the remaining test.",
+        replacementHistory: [
+          {
+            message: {
+              role: "user",
+              content: [
+                {
+                  type: "text",
+                  text: "More private replacement context.",
+                },
+              ],
+              timestamp: 2,
+            } as ConversationAgentStepPayload,
+          },
+        ],
+      }),
+    ];
+
+    expect(
+      projectConversationReportEventPage({
+        canExposePayload: true,
+        events,
+      }).map((entry) => entry.data),
+    ).toEqual([
+      {
+        type: "compaction",
+        modelProfile: "standard",
+        modelId: "openai/gpt-5.4",
+        summary: "Continue monitoring CI.",
+      },
+      {
+        type: "handoff",
+        modelProfile: "handoff",
+        modelId: "openai/gpt-5.6-sol",
+        summary: "Fix the remaining test.",
+      },
+    ]);
+
+    const redacted = JSON.stringify(
+      projectConversationReportEventPage({
+        canExposePayload: false,
+        events,
+      }),
+    );
+    expect(redacted).not.toContain("Private retained user message.");
+    expect(redacted).not.toContain("Continue monitoring CI.");
+    expect(redacted).not.toContain("Fix the remaining test.");
+  });
+
   it("emits only safe structural lifecycle, context, and child references", () => {
     const projected = projectConversationReportEventPage({
       canExposePayload: true,


### PR DESCRIPTION
Compaction and model-handoff transcript cards now expose the generated continuation summary in an expandable section. The summary is also searchable and included in raw and Markdown exports, so operators can inspect the context execution continued from.

History replacement events now persist the generated summary as a narrow top-level field. Reporting exposes it only when the viewer can access transcript payloads; full replacement history remains stripped. Existing events without the field remain compatible and render as before.

Regression coverage spans all three summary writers, SQL reporting and redaction, transcript reduction, search, copy and export behavior, and component rendering. The full Junior and dashboard suites pass.
