### PR TITLE
feat(tools): describe approval proposals

### DIFF
--- a/packages/junior-plugin-api/src/tools.ts
+++ b/packages/junior-plugin-api/src/tools.ts
@@ -143,10 +143,46 @@ export const toolApprovalModeSchema = z.enum(["auto", "review", "approve"]);
 
 export type ToolApprovalMode = z.output<typeof toolApprovalModeSchema>;
 
-export interface PluginToolDefinition<TInput = unknown, TOutput = unknown> {
+/**
+ * Reviewer signals describing a tool's side-effect behavior.
+ *
+ * These hints follow the MCP tool annotation contract. Approval review may use
+ * them as signals, but they never grant authority or override deterministic
+ * authorization.
+ */
+export interface ToolAnnotations {
+  [key: string]: unknown;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+  readOnlyHint?: boolean;
+  title?: string;
+}
+
+/**
+ * Canonical approval metadata declared by core and plugin tools.
+ *
+ * This metadata is declaration-only until #1053 adds approval enforcement.
+ * Current tool execution is unchanged.
+ */
+export interface ToolApprovalMetadata<TInput = unknown> {
   /** Optional declared approval mode; omission delegates to core defaults. */
   approvalMode?: ToolApprovalMode;
-  annotations?: unknown;
+  annotations?: ToolAnnotations;
+  /**
+   * Describe the exact validated invocation for future approval presentation.
+   *
+   * Core owns authoritative tool, actor, source, destination, conversation,
+   * credential, and input data. This description adds domain-specific context
+   * only and is never an authorization grant.
+   */
+  describeProposal?(input: TInput): string;
+}
+
+export interface PluginToolDefinition<
+  TInput = unknown,
+  TOutput = unknown,
+> extends ToolApprovalMetadata<TInput> {
   description: string;
   executionMode?: unknown;
   inputSchema: unknown;
@@ -156,7 +192,7 @@ export interface PluginToolDefinition<TInput = unknown, TOutput = unknown> {
    * Returning `undefined` suppresses private result capture.
    */
   privateTraceResult?(result: TOutput): unknown;
-  prepareArguments?: (args: unknown) => unknown;
+  prepareArguments?: (args: unknown) => TInput;
   /**
    * @deprecated Put tool-selection and usage guidance directly in `description`
    * and parameter descriptions. Retained for compatibility; may be removed in a

--- a/packages/junior/src/chat/mcp/tool-manager.ts
+++ b/packages/junior/src/chat/mcp/tool-manager.ts
@@ -8,6 +8,7 @@
  */
 import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import type { ToolAnnotations } from "@sentry/junior-plugin-api";
 import {
   logWarn,
   serializeGenAiAttribute,
@@ -277,7 +278,7 @@ export interface ManagedMcpToolDescriptor {
   description: string;
   parameters: Record<string, unknown>;
   outputSchema?: Record<string, unknown>;
-  annotations?: Record<string, unknown>;
+  annotations?: ToolAnnotations;
   provider: string;
 }
 
@@ -475,7 +476,7 @@ export class McpToolManager {
     tool: PluginMcpListedTool,
   ): ManagedMcpTool {
     const outputSchema = toOptionalRecord(tool.outputSchema);
-    const annotations = toOptionalRecord(tool.annotations);
+    const annotations = tool.annotations;
     return {
       name: normalizeMcpToolName(plugin.manifest.name, tool.name),
       description: describeMcpTool(plugin.manifest.name, tool),

--- a/packages/junior/src/chat/tool-support/zod-tool.ts
+++ b/packages/junior/src/chat/tool-support/zod-tool.ts
@@ -23,6 +23,7 @@ type ZodToolDefinitionBase<TInputSchema extends ZodTypeAny> = Pick<
   | "promptGuidelines"
   | "executionMode"
 > & {
+  describeProposal?(input: z.output<TInputSchema>): string;
   inputSchema: TInputSchema;
   prepareArguments?: (args: unknown) => z.input<TInputSchema>;
 };

--- a/packages/junior/src/chat/tools/definition.ts
+++ b/packages/junior/src/chat/tools/definition.ts
@@ -1,7 +1,6 @@
-import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import { Kind, type Static, type TSchema } from "@sinclair/typebox";
 import type { ToolExecutionMode } from "@earendil-works/pi-agent-core";
-import type { ToolApprovalMode } from "@sentry/junior-plugin-api";
+import type { ToolApprovalMetadata } from "@sentry/junior-plugin-api";
 import type { ConversationPrivacy } from "@/chat/conversation-privacy";
 
 /**
@@ -21,9 +20,10 @@ export interface ToolExecuteOptions {
   toolCallId?: string;
 }
 
-interface BaseToolDefinition<TInput, TInputSchema extends ToolInputSchema> {
-  /** Optional declared approval mode; omission delegates to core defaults. */
-  approvalMode?: ToolApprovalMode;
+interface BaseToolDefinition<
+  TInput,
+  TInputSchema extends ToolInputSchema,
+> extends ToolApprovalMetadata<TInput> {
   /** Stable internal owner-qualified identity for plugin-contributed tools. */
   identity?: {
     id: string;
@@ -40,7 +40,6 @@ interface BaseToolDefinition<TInput, TInputSchema extends ToolInputSchema> {
   inputSchema: TInputSchema;
   outputSchema?: ToolInputSchema;
   privateTraceResult?(result: unknown): unknown;
-  annotations?: ToolAnnotations;
   /**
    * @deprecated Put tool-selection and usage guidance directly in `description`
    * and parameter descriptions. Retained for plugin compatibility; may be
@@ -68,9 +67,7 @@ export interface ToolDefinition<
 /**
  * Schema-erased view for heterogeneous registries after Pi validates tool input.
  */
-export interface AnyToolDefinition {
-  /** Optional declared approval mode; omission delegates to core defaults. */
-  approvalMode?: ToolApprovalMode;
+export interface AnyToolDefinition extends ToolApprovalMetadata {
   /** Stable internal owner-qualified identity for plugin-contributed tools. */
   identity?: {
     id: string;
@@ -87,7 +84,6 @@ export interface AnyToolDefinition {
   inputSchema: ToolInputSchema;
   outputSchema?: ToolInputSchema;
   privateTraceResult?(result: unknown): unknown;
-  annotations?: ToolAnnotations;
   /**
    * @deprecated Put tool-selection and usage guidance directly in `description`
    * and parameter descriptions. Retained for plugin compatibility; may be

--- a/packages/junior/tests/unit/mcp/tool-manager.test.ts
+++ b/packages/junior/tests/unit/mcp/tool-manager.test.ts
@@ -103,6 +103,11 @@ describe("McpToolManager", () => {
             query: { type: "string" },
           },
         },
+        annotations: {
+          destructiveHint: false,
+          openWorldHint: true,
+          readOnlyHint: true,
+        },
       },
     ]);
     callToolMock.mockResolvedValue({
@@ -137,6 +142,11 @@ describe("McpToolManager", () => {
     expect(tools[0]?.name).toBe("mcp__demo__ping");
     expect(tools[0]?.rawName).toBe("ping");
     expect(tools[0]?.description).toBe("[demo] Ping the remote MCP server");
+    expect(tools[0]?.annotations).toEqual({
+      destructiveHint: false,
+      openWorldHint: true,
+      readOnlyHint: true,
+    });
 
     const resolvedTools = manager.getResolvedActiveTools();
     expect(resolvedTools).toHaveLength(1);

--- a/packages/junior/tests/unit/plugins/agent-hooks.test.ts
+++ b/packages/junior/tests/unit/plugins/agent-hooks.test.ts
@@ -34,6 +34,7 @@ function demoPluginTool(
 ) {
   return definePluginTool({
     approvalMode,
+    describeProposal: () => `${description} proposal`,
     description,
     inputSchema: z.object({}),
     outputSchema: demoToolResultSchema,
@@ -443,6 +444,9 @@ describe("agent plugin hooks", () => {
         description: "Agent demo",
       });
       expect(tools.agentDemo_demoTool?.approvalMode).toBe("review");
+      expect(tools.agentDemo_demoTool?.describeProposal?.({})).toBe(
+        "Demo tool proposal",
+      );
     } finally {
       setPlugins(previous);
     }

--- a/packages/junior/tests/unit/plugins/define-plugin-tool.test.ts
+++ b/packages/junior/tests/unit/plugins/define-plugin-tool.test.ts
@@ -16,11 +16,17 @@ const countResultSchema = pluginToolResultSchema.extend({
 });
 
 describe("definePluginTool", () => {
-  it("preserves the declared approval mode", () => {
+  it("preserves approval metadata", () => {
     const tool = definePluginTool({
       approvalMode: "review",
+      annotations: {
+        destructiveHint: false,
+        openWorldHint: true,
+        readOnlyHint: true,
+      },
+      describeProposal: ({ query }) => `Search for ${query}.`,
       description: "Schedule a meeting.",
-      inputSchema: z.object({}),
+      inputSchema: z.object({ query: z.string() }),
       outputSchema: countResultSchema,
       execute: async () =>
         ({
@@ -32,6 +38,13 @@ describe("definePluginTool", () => {
     });
 
     expect(tool.approvalMode).toBe("review");
+    expect(tool.annotations).toEqual({
+      destructiveHint: false,
+      openWorldHint: true,
+      readOnlyHint: true,
+    });
+    const input = tool.prepareArguments?.({ query: "errors" });
+    expect(tool.describeProposal?.(input!)).toBe("Search for errors.");
     expect(toolApprovalModeSchema.safeParse("unexpected").success).toBe(false);
   });
 

--- a/packages/junior/tests/unit/tool-support/zod-tool.test.ts
+++ b/packages/junior/tests/unit/tool-support/zod-tool.test.ts
@@ -5,16 +5,24 @@ import { zodTool } from "@/chat/tool-support/zod-tool";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 
 describe("zodTool", () => {
-  it("preserves the declared approval mode", () => {
+  it("preserves approval metadata", () => {
     const tool = zodTool({
       approvalMode: "approve",
+      annotations: { destructiveHint: true, readOnlyHint: false },
+      describeProposal: ({ recordId }) => `Delete record ${recordId}.`,
       description: "Delete a record.",
-      inputSchema: z.object({}),
+      inputSchema: z.object({ recordId: z.coerce.string() }),
       outputSchema: juniorToolResultSchema,
       execute: async () => ({ ok: true, status: "success" as const }),
     });
 
     expect(tool.approvalMode).toBe("approve");
+    expect(tool.annotations).toEqual({
+      destructiveHint: true,
+      readOnlyHint: false,
+    });
+    const input = tool.prepareArguments!({ recordId: 42 });
+    expect(tool.describeProposal?.(input)).toBe("Delete record 42.");
   });
 
   it("projects Zod input schemas to JSON Schema and parses tool arguments", async () => {


### PR DESCRIPTION
Tool definitions now expose one canonical approval-metadata contract across Junior-owned and plugin tools. Proposal descriptions receive the schema-validated input type, while MCP-compatible annotations retain their reviewer hints through plugin registration and MCP discovery.

The metadata remains declaration-only, so existing tool execution is unchanged. #1053 will resolve approval modes and enforce Guardian review at runtime.

Validated with the focused tool metadata suites, the full workspace type check, and the plugin API build.

Fixes #1050.
