### PR TITLE
fix(oauth): harden provider errors and callbacks

### DIFF
--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -36,6 +36,10 @@ import {
   type Skill,
 } from "@/chat/skills";
 import { McpToolManager } from "@/chat/mcp/tool-manager";
+import {
+  getMcpAwareTelemetryMessage,
+  getMcpProviderErrorAttributes,
+} from "@/chat/mcp/errors";
 import type { ThreadArtifactsState } from "@/chat/state/artifacts";
 import {
   loadConnectedMcpProviders,
@@ -1458,10 +1462,11 @@ async function executeAgentRunInPrivacyContext(
         "mcp_tool_manager_close_failed",
         {},
         {
-          "exception.message":
-            closeError instanceof Error
-              ? closeError.message
-              : String(closeError),
+          ...getMcpProviderErrorAttributes(closeError),
+          "exception.message": getMcpAwareTelemetryMessage(
+            closeError,
+            undefined,
+          ),
         },
         "Failed to close MCP tool manager",
       );

--- a/packages/junior/src/chat/agent/tools.ts
+++ b/packages/junior/src/chat/agent/tools.ts
@@ -19,6 +19,10 @@ import {
 } from "@/chat/plugins/agent-hooks";
 import { pluginCatalogRuntime } from "@/chat/plugins/catalog-runtime";
 import { McpToolManager } from "@/chat/mcp/tool-manager";
+import {
+  getMcpAwareTelemetryMessage,
+  getMcpProviderErrorAttributes,
+} from "@/chat/mcp/errors";
 import { inferActiveMcpProvidersFromPiMessages } from "@/chat/pi/derived-state";
 import { createTools } from "@/chat/tools";
 import type { AnyToolDefinition } from "@/chat/tools/definition";
@@ -428,10 +432,11 @@ export async function wireAgentTools(
           "mcp_tool_manager_close_failed",
           {},
           {
-            "exception.message":
-              closeError instanceof Error
-                ? closeError.message
-                : String(closeError),
+            ...getMcpProviderErrorAttributes(closeError),
+            "exception.message": getMcpAwareTelemetryMessage(
+              closeError,
+              args.conversationPrivacy,
+            ),
           },
           "Failed to close MCP tool manager",
         );

--- a/packages/junior/src/chat/mcp/client.ts
+++ b/packages/junior/src/chat/mcp/client.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { Client } from "@modelcontextprotocol/sdk/client";
 import {
   UnauthorizedError,
@@ -80,7 +81,9 @@ export class PluginMcpClient {
   private client?: Client;
   private clientPromise?: Promise<Client>;
   private lastAttemptedTransportSessionId?: string;
-  private lastProviderStatus?: number;
+  private readonly providerStatusStore = new AsyncLocalStorage<{
+    status?: number;
+  }>();
   private transport?: StreamableHTTPClientTransport;
   private listedTools?: ListedTool[];
   private readonly resourceHost?: string;
@@ -106,7 +109,7 @@ export class PluginMcpClient {
 
       do {
         const result = await this.wrapAuth(
-          client.listTools(cursor ? { cursor } : undefined),
+          () => client.listTools(cursor ? { cursor } : undefined),
           "list_tools",
         );
         await this.syncTransportSessionId();
@@ -149,10 +152,11 @@ export class PluginMcpClient {
         });
       }
       const result = await this.wrapAuth(
-        client.callTool({
-          name,
-          arguments: args ?? {},
-        }),
+        () =>
+          client.callTool({
+            name,
+            arguments: args ?? {},
+          }),
         "call_tool",
       );
       await this.syncTransportSessionId();
@@ -218,7 +222,10 @@ export class PluginMcpClient {
     const transport = new StreamableHTTPClientTransport(new URL(mcp.url), {
       ...(Object.keys(requestInit).length > 0 ? { requestInit } : {}),
       fetch: fetchWithBoundedOAuthErrorBodies(this.options.fetch, (status) => {
-        this.lastProviderStatus = status;
+        const store = this.providerStatusStore.getStore();
+        if (store) {
+          store.status = status;
+        }
       }),
       ...(this.options.authProvider
         ? { authProvider: this.options.authProvider }
@@ -232,7 +239,7 @@ export class PluginMcpClient {
     this.transport = transport;
 
     try {
-      await this.wrapAuth(client.connect(transport), "connect");
+      await this.wrapAuth(() => client.connect(transport), "connect");
       this.client = client;
       await this.syncTransportSessionId();
       return client;
@@ -244,30 +251,32 @@ export class PluginMcpClient {
   }
 
   private async wrapAuth<T>(
-    promise: Promise<T>,
+    operation: () => Promise<T>,
     phase: McpProviderErrorPhase,
   ): Promise<T> {
-    this.lastProviderStatus = undefined;
-    try {
-      return await promise;
-    } catch (error) {
-      if (error instanceof McpAuthorizationRequiredError) {
-        throw error;
+    const store: { status?: number } = {};
+    return await this.providerStatusStore.run(store, async () => {
+      try {
+        return await operation();
+      } catch (error) {
+        if (error instanceof McpAuthorizationRequiredError) {
+          throw error;
+        }
+        if (error instanceof UnauthorizedError) {
+          throw new McpAuthorizationRequiredError(
+            this.plugin.manifest.name,
+            `MCP authorization required for plugin "${this.plugin.manifest.name}"`,
+          );
+        }
+        throw toMcpProviderError(error, {
+          phase,
+          provider: this.plugin.manifest.name,
+          missingSession: isMissingSessionError(error) || undefined,
+          resourceHost: this.resourceHost,
+          status: store.status,
+        });
       }
-      if (error instanceof UnauthorizedError) {
-        throw new McpAuthorizationRequiredError(
-          this.plugin.manifest.name,
-          `MCP authorization required for plugin "${this.plugin.manifest.name}"`,
-        );
-      }
-      throw toMcpProviderError(error, {
-        phase,
-        provider: this.plugin.manifest.name,
-        missingSession: isMissingSessionError(error) || undefined,
-        resourceHost: this.resourceHost,
-        status: this.lastProviderStatus,
-      });
-    }
+    });
   }
 
   private async shouldResetMissingSession(error: unknown): Promise<boolean> {

--- a/packages/junior/src/chat/mcp/client.ts
+++ b/packages/junior/src/chat/mcp/client.ts
@@ -176,7 +176,7 @@ export class PluginMcpClient {
       }
 
       await this.clearStoredTransportSessionId();
-      await this.disposeClient({ throwOnError: false });
+      await this.cleanupClientAfterFailure();
       return await operation();
     }
   }
@@ -238,7 +238,7 @@ export class PluginMcpClient {
       return client;
     } catch (error) {
       await this.syncTransportSessionId();
-      await this.disposeClient({ throwOnError: false });
+      await this.cleanupClientAfterFailure();
       throw error;
     }
   }
@@ -287,26 +287,37 @@ export class PluginMcpClient {
     );
   }
 
-  private async disposeClient({
-    throwOnError = true,
-  }: { throwOnError?: boolean } = {}): Promise<void> {
+  private resetClientState(): StreamableHTTPClientTransport | undefined {
     const transport = this.transport;
     this.listedTools = undefined;
     this.transport = undefined;
     this.client = undefined;
     this.clientPromise = undefined;
+    return transport;
+  }
+
+  private async cleanupClientAfterFailure(): Promise<void> {
+    const transport = this.resetClientState();
+    if (!transport) {
+      return;
+    }
+    try {
+      await transport.close();
+    } catch {}
+  }
+
+  private async disposeClient(): Promise<void> {
+    const transport = this.resetClientState();
 
     if (transport) {
       try {
         await transport.close();
       } catch (error) {
-        if (throwOnError) {
-          throw toMcpProviderError(error, {
-            phase: "close",
-            provider: this.plugin.manifest.name,
-            resourceHost: this.resourceHost,
-          });
-        }
+        throw toMcpProviderError(error, {
+          phase: "close",
+          provider: this.plugin.manifest.name,
+          resourceHost: this.resourceHost,
+        });
       }
     }
   }

--- a/packages/junior/src/chat/mcp/client.ts
+++ b/packages/junior/src/chat/mcp/client.ts
@@ -8,7 +8,13 @@ import {
   StreamableHTTPError,
 } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { setSpanAttributes } from "@/chat/logging";
+import { fetchWithBoundedOAuthErrorBodies } from "@/chat/oauth-response";
 import type { PluginDefinition } from "@/chat/plugins/types";
+import {
+  McpProviderError,
+  type McpProviderErrorPhase,
+  toMcpProviderError,
+} from "./errors";
 
 type ListedTool = Awaited<ReturnType<Client["listTools"]>>["tools"][number];
 type ToolCallResult = Awaited<ReturnType<Client["callTool"]>>;
@@ -63,17 +69,28 @@ type HostManagedSessionProvider = OAuthClientProvider & {
   saveMcpServerSessionId?: (sessionId: string | undefined) => Promise<void>;
 };
 
+function isMissingSessionError(error: unknown): boolean {
+  return (
+    error instanceof StreamableHTTPError &&
+    (error.code === 404 || /Session not found/i.test(error.message))
+  );
+}
+
 export class PluginMcpClient {
   private client?: Client;
   private clientPromise?: Promise<Client>;
   private lastAttemptedTransportSessionId?: string;
   private transport?: StreamableHTTPClientTransport;
   private listedTools?: ListedTool[];
+  private readonly resourceHost?: string;
 
   constructor(
     private readonly plugin: PluginDefinition,
     private readonly options: PluginMcpClientOptions = {},
-  ) {}
+  ) {
+    const url = plugin.manifest.mcp?.url;
+    this.resourceHost = url ? new URL(url).hostname : undefined;
+  }
 
   async listTools(): Promise<ListedTool[]> {
     if (this.listedTools) {
@@ -89,6 +106,7 @@ export class PluginMcpClient {
       do {
         const result = await this.wrapAuth(
           client.listTools(cursor ? { cursor } : undefined),
+          "list_tools",
         );
         await this.syncTransportSessionId();
         for (const tool of result.tools) {
@@ -134,6 +152,7 @@ export class PluginMcpClient {
           name,
           arguments: args ?? {},
         }),
+        "call_tool",
       );
       await this.syncTransportSessionId();
       return result;
@@ -197,7 +216,7 @@ export class PluginMcpClient {
     this.lastAttemptedTransportSessionId = sessionId;
     const transport = new StreamableHTTPClientTransport(new URL(mcp.url), {
       ...(Object.keys(requestInit).length > 0 ? { requestInit } : {}),
-      ...(this.options.fetch ? { fetch: this.options.fetch } : {}),
+      fetch: fetchWithBoundedOAuthErrorBodies(this.options.fetch),
       ...(this.options.authProvider
         ? { authProvider: this.options.authProvider }
         : {}),
@@ -210,7 +229,7 @@ export class PluginMcpClient {
     this.transport = transport;
 
     try {
-      await this.wrapAuth(client.connect(transport));
+      await this.wrapAuth(client.connect(transport), "connect");
       this.client = client;
       await this.syncTransportSessionId();
       return client;
@@ -221,7 +240,10 @@ export class PluginMcpClient {
     }
   }
 
-  private async wrapAuth<T>(promise: Promise<T>): Promise<T> {
+  private async wrapAuth<T>(
+    promise: Promise<T>,
+    phase: McpProviderErrorPhase,
+  ): Promise<T> {
     try {
       return await promise;
     } catch (error) {
@@ -234,15 +256,20 @@ export class PluginMcpClient {
           `MCP authorization required for plugin "${this.plugin.manifest.name}"`,
         );
       }
-      throw error;
+      throw toMcpProviderError(error, {
+        phase,
+        provider: this.plugin.manifest.name,
+        missingSession: isMissingSessionError(error) || undefined,
+        resourceHost: this.resourceHost,
+      });
     }
   }
 
   private async shouldResetMissingSession(error: unknown): Promise<boolean> {
     if (
       !(
-        error instanceof StreamableHTTPError &&
-        (error.code === 404 || /Session not found/i.test(error.message))
+        (error instanceof McpProviderError && error.missingSession) ||
+        isMissingSessionError(error)
       )
     ) {
       return false;
@@ -263,7 +290,15 @@ export class PluginMcpClient {
     this.clientPromise = undefined;
 
     if (transport) {
-      await transport.close();
+      try {
+        await transport.close();
+      } catch (error) {
+        throw toMcpProviderError(error, {
+          phase: "close",
+          provider: this.plugin.manifest.name,
+          resourceHost: this.resourceHost,
+        });
+      }
     }
   }
 

--- a/packages/junior/src/chat/mcp/client.ts
+++ b/packages/junior/src/chat/mcp/client.ts
@@ -176,7 +176,7 @@ export class PluginMcpClient {
       }
 
       await this.clearStoredTransportSessionId();
-      await this.disposeClient();
+      await this.disposeClient({ throwOnError: false });
       return await operation();
     }
   }
@@ -238,7 +238,7 @@ export class PluginMcpClient {
       return client;
     } catch (error) {
       await this.syncTransportSessionId();
-      await this.disposeClient();
+      await this.disposeClient({ throwOnError: false });
       throw error;
     }
   }
@@ -287,7 +287,9 @@ export class PluginMcpClient {
     );
   }
 
-  private async disposeClient(): Promise<void> {
+  private async disposeClient({
+    throwOnError = true,
+  }: { throwOnError?: boolean } = {}): Promise<void> {
     const transport = this.transport;
     this.listedTools = undefined;
     this.transport = undefined;
@@ -298,11 +300,13 @@ export class PluginMcpClient {
       try {
         await transport.close();
       } catch (error) {
-        throw toMcpProviderError(error, {
-          phase: "close",
-          provider: this.plugin.manifest.name,
-          resourceHost: this.resourceHost,
-        });
+        if (throwOnError) {
+          throw toMcpProviderError(error, {
+            phase: "close",
+            provider: this.plugin.manifest.name,
+            resourceHost: this.resourceHost,
+          });
+        }
       }
     }
   }

--- a/packages/junior/src/chat/mcp/client.ts
+++ b/packages/junior/src/chat/mcp/client.ts
@@ -80,6 +80,7 @@ export class PluginMcpClient {
   private client?: Client;
   private clientPromise?: Promise<Client>;
   private lastAttemptedTransportSessionId?: string;
+  private lastProviderStatus?: number;
   private transport?: StreamableHTTPClientTransport;
   private listedTools?: ListedTool[];
   private readonly resourceHost?: string;
@@ -216,7 +217,9 @@ export class PluginMcpClient {
     this.lastAttemptedTransportSessionId = sessionId;
     const transport = new StreamableHTTPClientTransport(new URL(mcp.url), {
       ...(Object.keys(requestInit).length > 0 ? { requestInit } : {}),
-      fetch: fetchWithBoundedOAuthErrorBodies(this.options.fetch),
+      fetch: fetchWithBoundedOAuthErrorBodies(this.options.fetch, (status) => {
+        this.lastProviderStatus = status;
+      }),
       ...(this.options.authProvider
         ? { authProvider: this.options.authProvider }
         : {}),
@@ -244,6 +247,7 @@ export class PluginMcpClient {
     promise: Promise<T>,
     phase: McpProviderErrorPhase,
   ): Promise<T> {
+    this.lastProviderStatus = undefined;
     try {
       return await promise;
     } catch (error) {
@@ -261,6 +265,7 @@ export class PluginMcpClient {
         provider: this.plugin.manifest.name,
         missingSession: isMissingSessionError(error) || undefined,
         resourceHost: this.resourceHost,
+        status: this.lastProviderStatus,
       });
     }
   }

--- a/packages/junior/src/chat/mcp/errors.ts
+++ b/packages/junior/src/chat/mcp/errors.ts
@@ -1,5 +1,86 @@
 import type { ConversationPrivacy } from "@/chat/conversation-privacy";
 
+export type McpProviderErrorPhase =
+  | "connect"
+  | "list_tools"
+  | "call_tool"
+  | "close"
+  | "oauth_callback";
+
+export interface McpProviderErrorDetails {
+  phase: McpProviderErrorPhase;
+  provider: string;
+  missingSession?: boolean;
+  resourceHost?: string;
+  status?: number;
+}
+
+/** Safe failure at an MCP network or OAuth boundary. */
+export class McpProviderError extends Error {
+  readonly phase: McpProviderErrorPhase;
+  readonly provider: string;
+  readonly missingSession?: boolean;
+  readonly resourceHost?: string;
+  readonly status?: number;
+
+  constructor(details: McpProviderErrorDetails) {
+    super(`MCP provider ${details.phase.replace("_", " ")} failed`);
+    this.name = "McpProviderError";
+    this.phase = details.phase;
+    this.provider = details.provider;
+    this.missingSession = details.missingSession;
+    this.resourceHost = details.resourceHost;
+    this.status = details.status;
+  }
+}
+
+function providerStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+  const value = error as { code?: unknown; status?: unknown };
+  const status =
+    typeof value.status === "number"
+      ? value.status
+      : typeof value.code === "number"
+        ? value.code
+        : undefined;
+  return status !== undefined && status >= 100 && status <= 599
+    ? status
+    : undefined;
+}
+
+/** Replace an external MCP failure without retaining its provider-controlled cause. */
+export function toMcpProviderError(
+  error: unknown,
+  details: McpProviderErrorDetails,
+): McpProviderError {
+  if (error instanceof McpProviderError) {
+    return error;
+  }
+  return new McpProviderError({
+    ...details,
+    status: details.status ?? providerStatus(error),
+  });
+}
+
+/** Return safe MCP provider fields for logs and spans. */
+export function getMcpProviderErrorAttributes(
+  error: unknown,
+): Record<string, string | number> {
+  if (!(error instanceof McpProviderError)) {
+    return {};
+  }
+  return {
+    "app.credential.provider": error.provider,
+    "app.mcp.error.phase": error.phase,
+    ...(error.status !== undefined
+      ? { "http.response.status_code": error.status }
+      : {}),
+    ...(error.resourceHost ? { "server.address": error.resourceHost } : {}),
+  };
+}
+
 /** Thrown when an MCP failure should be returned as a model-visible tool error. */
 export class McpToolError extends Error {
   constructor(message: string) {
@@ -13,6 +94,9 @@ export function getMcpAwareErrorType(error: unknown, fallback: string): string {
   if (error instanceof McpToolError) {
     return "tool_error";
   }
+  if (error instanceof McpProviderError) {
+    return "mcp_provider_error";
+  }
   return error instanceof Error ? error.name : fallback;
 }
 
@@ -24,10 +108,13 @@ export function getMcpAwareErrorMessage(error: unknown): string {
 /** Return an error message safe for logs and span attributes. */
 export function getMcpAwareTelemetryMessage(
   error: unknown,
-  privacy: ConversationPrivacy | undefined,
+  _privacy: ConversationPrivacy | undefined,
 ): string {
-  if (privacy === "private" && error instanceof McpToolError) {
+  if (error instanceof McpToolError) {
     return "MCP tool call failed";
+  }
+  if (error instanceof McpProviderError) {
+    return error.message;
   }
   return getMcpAwareErrorMessage(error);
 }

--- a/packages/junior/src/chat/mcp/oauth.ts
+++ b/packages/junior/src/chat/mcp/oauth.ts
@@ -2,11 +2,13 @@ import { randomUUID } from "node:crypto";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { Destination, Source } from "@sentry/junior-plugin-api";
 import { resolveBaseUrl } from "@/chat/oauth-flow";
+import { fetchWithBoundedOAuthErrorBodies } from "@/chat/oauth-response";
 import { pluginCatalogRuntime } from "@/chat/plugins/catalog-runtime";
 import type { PluginDefinition } from "@/chat/plugins/types";
 import type { ThreadArtifactsState } from "@/chat/state/artifacts";
 import { getMcpAuthSession, type McpAuthSessionState } from "./auth-store";
 import { StateBackedMcpOAuthClientProvider } from "./oauth-provider";
+import { toMcpProviderError } from "./errors";
 
 export function getMcpOAuthCallbackPath(provider: string): string {
   return `/api/oauth/callback/mcp/${provider}`;
@@ -112,12 +114,30 @@ export async function finalizeMcpAuthorization(
   const transport = new StreamableHTTPClientTransport(new URL(mcp.url), {
     ...(Object.keys(requestInit).length > 0 ? { requestInit } : {}),
     authProvider,
+    fetch: fetchWithBoundedOAuthErrorBodies(),
   });
 
+  let failure: unknown;
   try {
     await transport.finishAuth(authorizationCode);
-  } finally {
+  } catch (error) {
+    failure = toMcpProviderError(error, {
+      phase: "oauth_callback",
+      provider,
+      resourceHost: new URL(mcp.url).hostname,
+    });
+  }
+  try {
     await transport.close();
+  } catch (error) {
+    failure ??= toMcpProviderError(error, {
+      phase: "oauth_callback",
+      provider,
+      resourceHost: new URL(mcp.url).hostname,
+    });
+  }
+  if (failure) {
+    throw failure;
   }
 
   const nextSession = await getMcpAuthSession(authSessionId);

--- a/packages/junior/src/chat/mcp/oauth.ts
+++ b/packages/junior/src/chat/mcp/oauth.ts
@@ -111,10 +111,13 @@ export async function finalizeMcpAuthorization(
   if (mcp.headers && Object.keys(mcp.headers).length > 0) {
     requestInit.headers = new Headers(mcp.headers);
   }
+  let providerStatus: number | undefined;
   const transport = new StreamableHTTPClientTransport(new URL(mcp.url), {
     ...(Object.keys(requestInit).length > 0 ? { requestInit } : {}),
     authProvider,
-    fetch: fetchWithBoundedOAuthErrorBodies(),
+    fetch: fetchWithBoundedOAuthErrorBodies(undefined, (status) => {
+      providerStatus = status;
+    }),
   });
 
   let failure: unknown;
@@ -125,6 +128,7 @@ export async function finalizeMcpAuthorization(
       phase: "oauth_callback",
       provider,
       resourceHost: new URL(mcp.url).hostname,
+      status: providerStatus,
     });
   }
   try {

--- a/packages/junior/src/chat/mcp/tool-manager.ts
+++ b/packages/junior/src/chat/mcp/tool-manager.ts
@@ -28,6 +28,7 @@ import {
 import {
   getMcpAwareTelemetryMessage,
   getMcpAwareErrorType,
+  getMcpProviderErrorAttributes,
   McpToolError,
 } from "./errors";
 
@@ -562,6 +563,7 @@ export class McpToolManager {
               }
               const errorAttributes = {
                 ...baseAttributes,
+                ...getMcpProviderErrorAttributes(error),
                 "error.type": getMcpAwareErrorType(error, "mcp_tool_error"),
                 "exception.message": getMcpAwareTelemetryMessage(
                   error,

--- a/packages/junior/src/chat/oauth-response.ts
+++ b/packages/junior/src/chat/oauth-response.ts
@@ -91,7 +91,13 @@ export function fetchWithBoundedOAuthErrorBodies(
       return response;
     }
 
-    const body = await readBoundedOAuthErrorBody(response);
+    let body = "";
+    try {
+      body = await readBoundedOAuthErrorBody(response);
+    } catch {
+      // Preserve status handling without exposing an unreadable provider body.
+      await response.body.cancel().catch(() => undefined);
+    }
     return new Response(body, {
       headers: response.headers,
       status: response.status,

--- a/packages/junior/src/chat/oauth-response.ts
+++ b/packages/junior/src/chat/oauth-response.ts
@@ -1,4 +1,5 @@
 const MAX_OAUTH_ERROR_BODY_BYTES = 16 * 1024;
+const MAX_OAUTH_ERROR_BODY_READS = MAX_OAUTH_ERROR_BODY_BYTES;
 
 export type OAuthProviderErrorPhase = "token_exchange" | "token_refresh";
 
@@ -54,10 +55,15 @@ export async function readBoundedOAuthErrorBody(
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
   let bytesRead = 0;
+  let reads = 0;
   let text = "";
 
   try {
-    while (bytesRead < MAX_OAUTH_ERROR_BODY_BYTES) {
+    while (
+      bytesRead < MAX_OAUTH_ERROR_BODY_BYTES &&
+      reads < MAX_OAUTH_ERROR_BODY_READS
+    ) {
+      reads += 1;
       const { done, value } = await reader.read();
       if (done) {
         return text + decoder.decode();

--- a/packages/junior/src/chat/oauth-response.ts
+++ b/packages/junior/src/chat/oauth-response.ts
@@ -1,0 +1,101 @@
+const MAX_OAUTH_ERROR_BODY_BYTES = 16 * 1024;
+
+export type OAuthProviderErrorPhase = "token_exchange" | "token_refresh";
+
+export interface OAuthProviderErrorDetails {
+  phase: OAuthProviderErrorPhase;
+  provider: string;
+  resourceHost: string;
+  status?: number;
+}
+
+/** Safe failure at a generic OAuth provider boundary. */
+export class OAuthProviderError extends Error {
+  readonly phase: OAuthProviderErrorPhase;
+  readonly provider: string;
+  readonly resourceHost: string;
+  readonly status?: number;
+
+  constructor(details: OAuthProviderErrorDetails) {
+    super(`OAuth provider ${details.phase.replace("_", " ")} failed`);
+    this.name = "OAuthProviderError";
+    this.phase = details.phase;
+    this.provider = details.provider;
+    this.resourceHost = details.resourceHost;
+    this.status = details.status;
+  }
+}
+
+/** Return safe generic OAuth provider fields for logs and spans. */
+export function getOAuthProviderErrorAttributes(
+  error: unknown,
+): Record<string, string | number> {
+  if (!(error instanceof OAuthProviderError)) {
+    return {};
+  }
+  return {
+    "app.credential.provider": error.provider,
+    "app.oauth.error.phase": error.phase,
+    "server.address": error.resourceHost,
+    ...(error.status !== undefined
+      ? { "http.response.status_code": error.status }
+      : {}),
+  };
+}
+
+/** Read only the bounded prefix needed to classify an OAuth error response. */
+export async function readBoundedOAuthErrorBody(
+  response: Response,
+): Promise<string> {
+  if (!response.body) {
+    return "";
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let bytesRead = 0;
+  let text = "";
+
+  try {
+    while (bytesRead < MAX_OAUTH_ERROR_BODY_BYTES) {
+      const { done, value } = await reader.read();
+      if (done) {
+        return text + decoder.decode();
+      }
+
+      const remaining = MAX_OAUTH_ERROR_BODY_BYTES - bytesRead;
+      const chunk = value.subarray(0, remaining);
+      bytesRead += chunk.byteLength;
+      text += decoder.decode(chunk, { stream: true });
+
+      if (chunk.byteLength < value.byteLength) {
+        await reader.cancel();
+        return text + decoder.decode();
+      }
+    }
+
+    await reader.cancel();
+    return text + decoder.decode();
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/** Preserve small OAuth error responses while bounding bodies before SDK parsing. */
+export function fetchWithBoundedOAuthErrorBodies(
+  fetchFn: typeof fetch = globalThis.fetch,
+): typeof fetch {
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const response = await fetchFn(input, init);
+    if (response.ok || !response.body) {
+      return response;
+    }
+
+    const body = await readBoundedOAuthErrorBody(response);
+    return new Response(body, {
+      headers: response.headers,
+      status: response.status,
+      statusText: response.statusText,
+    });
+  }) as typeof fetch;
+}

--- a/packages/junior/src/chat/oauth-response.ts
+++ b/packages/junior/src/chat/oauth-response.ts
@@ -84,10 +84,17 @@ export async function readBoundedOAuthErrorBody(
 /** Preserve small OAuth error responses while bounding bodies before SDK parsing. */
 export function fetchWithBoundedOAuthErrorBodies(
   fetchFn: typeof fetch = globalThis.fetch,
+  onResponseStatus?: (status: number | undefined) => void,
 ): typeof fetch {
   return (async (input: RequestInfo | URL, init?: RequestInit) => {
     const response = await fetchFn(input, init);
-    if (response.ok || !response.body) {
+    if (response.ok) {
+      onResponseStatus?.(undefined);
+      return response;
+    }
+
+    onResponseStatus?.(response.status);
+    if (!response.body) {
       return response;
     }
 

--- a/packages/junior/src/chat/oauth-response.ts
+++ b/packages/junior/src/chat/oauth-response.ts
@@ -1,5 +1,34 @@
 const MAX_OAUTH_ERROR_BODY_BYTES = 16 * 1024;
 const MAX_OAUTH_ERROR_BODY_READS = MAX_OAUTH_ERROR_BODY_BYTES;
+const MAX_OAUTH_ERROR_BODY_READ_MS = 5_000;
+const OAUTH_ERROR_BODY_READ_TIMEOUT = Symbol("oauth-error-body-read-timeout");
+
+async function readOAuthErrorBodyChunk(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<ReadableStreamReadResult<Uint8Array>> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutResult = new Promise<typeof OAUTH_ERROR_BODY_READ_TIMEOUT>(
+    (resolve) => {
+      timeout = setTimeout(
+        resolve,
+        MAX_OAUTH_ERROR_BODY_READ_MS,
+        OAUTH_ERROR_BODY_READ_TIMEOUT,
+      );
+    },
+  );
+  try {
+    const result = await Promise.race([reader.read(), timeoutResult]);
+    if (result === OAUTH_ERROR_BODY_READ_TIMEOUT) {
+      await reader.cancel();
+      throw new Error("OAuth error body read timed out");
+    }
+    return result;
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
 
 export type OAuthProviderErrorPhase = "token_exchange" | "token_refresh";
 
@@ -64,7 +93,7 @@ export async function readBoundedOAuthErrorBody(
       reads < MAX_OAUTH_ERROR_BODY_READS
     ) {
       reads += 1;
-      const { done, value } = await reader.read();
+      const { done, value } = await readOAuthErrorBodyChunk(reader);
       if (done) {
         return text + decoder.decode();
       }
@@ -90,16 +119,15 @@ export async function readBoundedOAuthErrorBody(
 /** Preserve small OAuth error responses while bounding bodies before SDK parsing. */
 export function fetchWithBoundedOAuthErrorBodies(
   fetchFn: typeof fetch = globalThis.fetch,
-  onResponseStatus?: (status: number | undefined) => void,
+  onErrorResponseStatus?: (status: number) => void,
 ): typeof fetch {
   return (async (input: RequestInfo | URL, init?: RequestInit) => {
     const response = await fetchFn(input, init);
     if (response.ok) {
-      onResponseStatus?.(undefined);
       return response;
     }
 
-    onResponseStatus?.(response.status);
+    onErrorResponseStatus?.(response.status);
     if (!response.body) {
       return response;
     }

--- a/packages/junior/src/chat/plugins/auth/oauth-bearer-broker.ts
+++ b/packages/junior/src/chat/plugins/auth/oauth-bearer-broker.ts
@@ -7,6 +7,10 @@ import { CredentialUnavailableError } from "@/chat/credentials/broker";
 import { credentialUserSubjectId } from "@/chat/credentials/context";
 import { mergeHeaderTransforms } from "@/chat/credentials/header-transforms";
 import { hasRequiredOAuthScope } from "@/chat/credentials/oauth-scope";
+import {
+  OAuthProviderError,
+  readBoundedOAuthErrorBody,
+} from "@/chat/oauth-response";
 import type {
   StoredTokens,
   UserTokenStore,
@@ -49,6 +53,7 @@ function parseRefreshError(text: string): string | undefined {
 }
 
 async function refreshAccessToken(
+  provider: string,
   refreshToken: string,
   oauth: NonNullable<PluginManifest["oauth"]>,
   requestedScope?: string,
@@ -77,30 +82,51 @@ async function refreshAccessToken(
     tokenAuthMethod: oauth.tokenAuthMethod,
     tokenExtraHeaders: oauth.tokenExtraHeaders,
   });
-  const response = await fetch(oauth.tokenEndpoint, {
-    method: "POST",
-    headers: request.headers,
-    body: request.body,
-    signal: AbortSignal.timeout(TOKEN_REFRESH_TIMEOUT_MS),
-  });
-
-  if (!response.ok) {
-    const errorCode = parseRefreshError(await response.text());
-    if (errorCode === "invalid_grant" || errorCode === "bad_refresh_token") {
-      throw new OAuthRefreshRejectedError(
-        `Token refresh rejected: ${errorCode}`,
-      );
-    }
-    throw new Error(
-      `Token refresh failed: ${response.status}${errorCode ? ` ${errorCode}` : ""}`,
-    );
+  const errorDetails = {
+    phase: "token_refresh" as const,
+    provider,
+    resourceHost: new URL(oauth.tokenEndpoint).hostname,
+  };
+  let response: Response;
+  try {
+    response = await fetch(oauth.tokenEndpoint, {
+      method: "POST",
+      headers: request.headers,
+      body: request.body,
+      signal: AbortSignal.timeout(TOKEN_REFRESH_TIMEOUT_MS),
+    });
+  } catch {
+    throw new OAuthProviderError(errorDetails);
   }
 
-  const data = (await response.json()) as Record<string, unknown>;
-  return parseOAuthTokenResponse(data, requestedScope, {
-    treatEmptyScopeAsUnreported: oauth.treatEmptyScopeAsUnreported,
-    refreshToken,
-  });
+  if (!response.ok) {
+    let errorCode: string | undefined;
+    try {
+      errorCode = parseRefreshError(await readBoundedOAuthErrorBody(response));
+    } catch {
+      throw new OAuthProviderError({
+        ...errorDetails,
+        status: response.status,
+      });
+    }
+    if (errorCode === "invalid_grant" || errorCode === "bad_refresh_token") {
+      throw new OAuthRefreshRejectedError("Token refresh was rejected");
+    }
+    throw new OAuthProviderError({
+      ...errorDetails,
+      status: response.status,
+    });
+  }
+
+  try {
+    const data = (await response.json()) as Record<string, unknown>;
+    return parseOAuthTokenResponse(data, requestedScope, {
+      treatEmptyScopeAsUnreported: oauth.treatEmptyScopeAsUnreported,
+      refreshToken,
+    });
+  } catch {
+    throw new OAuthProviderError(errorDetails);
+  }
 }
 
 function getLeaseExpiry(expiresAt?: number): number {
@@ -223,6 +249,7 @@ export function createOAuthBearerBroker(
                   }
 
                   const refreshed = await refreshAccessToken(
+                    provider,
                     latest.refreshToken,
                     oauth,
                     latest.scope ?? oauth.scope,

--- a/packages/junior/src/chat/tools/execution/tool-error-handler.ts
+++ b/packages/junior/src/chat/tools/execution/tool-error-handler.ts
@@ -8,7 +8,16 @@ import {
 } from "@/chat/logging";
 import { PluginToolInputError } from "@sentry/junior-plugin-api";
 import type { ConversationPrivacy } from "@/chat/conversation-privacy";
-import { getMcpAwareTelemetryMessage, McpToolError } from "@/chat/mcp/errors";
+import {
+  getOAuthProviderErrorAttributes,
+  OAuthProviderError,
+} from "@/chat/oauth-response";
+import {
+  getMcpAwareTelemetryMessage,
+  getMcpProviderErrorAttributes,
+  McpProviderError,
+  McpToolError,
+} from "@/chat/mcp/errors";
 import { PluginCredentialFailureError } from "@/chat/services/plugin-auth-orchestration";
 import { SlackActionError } from "@/chat/slack/client";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
@@ -23,6 +32,8 @@ function isPluginToolInputError(error: unknown): boolean {
 /** Classify tool errors into stable observability types. */
 function getToolErrorType(error: unknown): string {
   if (error instanceof McpToolError) return "tool_error";
+  if (error instanceof McpProviderError) return "mcp_provider_error";
+  if (error instanceof OAuthProviderError) return "oauth_provider_error";
   if (error instanceof ToolInputError || isPluginToolInputError(error)) {
     return "tool_input_error";
   }
@@ -61,6 +72,8 @@ export function handleToolExecutionError(
   const errorMessage = getMcpAwareTelemetryMessage(error, conversationPrivacy);
   const errorAttributes = {
     "error.type": errorType,
+    ...getMcpProviderErrorAttributes(error),
+    ...getOAuthProviderErrorAttributes(error),
     ...(error instanceof PluginCredentialFailureError
       ? { "app.credential.provider": error.provider }
       : {}),
@@ -97,7 +110,7 @@ export function handleToolExecutionError(
         "gen_ai.operation.name": "execute_tool",
         "gen_ai.tool.name": toolName,
         ...(toolCallId ? { "gen_ai.tool.call.id": toolCallId } : {}),
-        "error.type": errorType,
+        ...errorAttributes,
         "exception.message": errorMessage,
       },
       "Agent tool call failed",
@@ -118,6 +131,7 @@ export function handleToolExecutionError(
         "gen_ai.operation.name": "execute_tool",
         "gen_ai.tool.name": toolName,
         ...(toolCallId ? { "gen_ai.tool.call.id": toolCallId } : {}),
+        ...errorAttributes,
         ...getToolErrorAttributes(error),
       },
       "Agent tool call failed",

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -130,7 +130,13 @@ function htmlResponse(
             "Your MCP access is connected. Junior will continue the paused request in the local client.",
         }
       : CALLBACK_PAGES[kind];
-  return htmlCallbackResponse(page.title, page.message, page.status);
+  const footerMessage =
+    kind === "success" && !options?.local
+      ? "You can close this tab and return to Slack."
+      : undefined;
+  return htmlCallbackResponse(page.title, page.message, page.status, {
+    footerMessage,
+  });
 }
 
 async function persistCompletedReplyState(

--- a/packages/junior/src/handlers/mcp-oauth-callback.ts
+++ b/packages/junior/src/handlers/mcp-oauth-callback.ts
@@ -17,6 +17,7 @@ import {
   type McpAuthSessionState,
 } from "@/chat/mcp/auth-store";
 import { finalizeMcpAuthorization } from "@/chat/mcp/oauth";
+import { getMcpProviderErrorAttributes } from "@/chat/mcp/errors";
 import { logException, logWarn } from "@/chat/logging";
 import type { AgentRunResult } from "@/chat/services/turn-result";
 import type { AgentRunner } from "@/chat/runtime/agent-runner";
@@ -628,7 +629,10 @@ export async function GET(
       callbackError,
       "mcp_oauth_callback_failed",
       {},
-      { "app.credential.provider": provider },
+      {
+        "app.credential.provider": provider,
+        ...getMcpProviderErrorAttributes(callbackError),
+      },
       "Failed to process MCP OAuth callback",
     );
     return htmlResponse("failure");

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -761,10 +761,15 @@ export async function GET(
       ? "Your request is continuing in the local Junior client."
       : resumesAgentTurn
         ? "Your request is being processed in Slack."
-        : "You can close this tab and return to Slack.";
+        : `Your ${providerLabel} account is connected.`;
+  const footerMessage =
+    stored.destination?.platform === "local"
+      ? "You can close this tab and return to Junior."
+      : "You can close this tab and return to Slack.";
   return htmlCallbackResponse(
     escapeXml(`${providerLabel} account connected`),
     escapeXml(statusMessage),
     200,
+    { footerMessage: escapeXml(footerMessage) },
   );
 }

--- a/packages/junior/src/handlers/oauth-callback.ts
+++ b/packages/junior/src/handlers/oauth-callback.ts
@@ -88,6 +88,19 @@ function htmlErrorResponse(
   return htmlCallbackResponse(escapeXml(title), escapeXml(message), status);
 }
 
+function oauthTokenErrorAttributes(
+  provider: string,
+  endpoint: string,
+  status?: number,
+): Record<string, string | number> {
+  return {
+    "app.credential.provider": provider,
+    "app.oauth.error.phase": "token_exchange",
+    "server.address": new URL(endpoint).hostname,
+    ...(status !== undefined ? { "http.response.status_code": status } : {}),
+  };
+}
+
 async function persistCompletedOAuthReplyState(args: {
   conversationId: string;
   sessionId: string;
@@ -601,6 +614,12 @@ export async function GET(
       body: tokenRequest.body,
     });
   } catch {
+    logWarn(
+      "oauth_token_exchange_failed",
+      {},
+      oauthTokenErrorAttributes(provider, providerConfig.tokenEndpoint),
+      "OAuth token exchange request failed",
+    );
     return htmlErrorResponse(
       "Connection failed",
       "Failed to exchange the authorization code. Please try again.",
@@ -609,6 +628,16 @@ export async function GET(
   }
 
   if (!tokenResponse.ok) {
+    logWarn(
+      "oauth_token_exchange_failed",
+      {},
+      oauthTokenErrorAttributes(
+        provider,
+        providerConfig.tokenEndpoint,
+        tokenResponse.status,
+      ),
+      "OAuth token exchange was rejected",
+    );
     return htmlErrorResponse(
       "Connection failed",
       "The token exchange with the provider failed. Please try again.",
@@ -623,6 +652,16 @@ export async function GET(
       treatEmptyScopeAsUnreported: providerConfig.treatEmptyScopeAsUnreported,
     });
   } catch {
+    logWarn(
+      "oauth_token_exchange_failed",
+      {},
+      oauthTokenErrorAttributes(
+        provider,
+        providerConfig.tokenEndpoint,
+        tokenResponse.status,
+      ),
+      "OAuth token exchange returned an invalid response",
+    );
     return htmlErrorResponse(
       "Connection failed",
       "The provider returned an incomplete token response. Please try again.",
@@ -723,19 +762,9 @@ export async function GET(
       : resumesAgentTurn
         ? "Your request is being processed in Slack."
         : "You can close this tab and return to Slack.";
-  const html = `<!DOCTYPE html>
-<html>
-<head><title>${providerLabel} Connected</title></head>
-<body style="font-family: system-ui, sans-serif; display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0;">
-  <div style="text-align: center;">
-    <h1>${providerLabel} account connected</h1>
-    <p>${statusMessage}</p>
-  </div>
-</body>
-</html>`;
-
-  return new Response(html, {
-    status: 200,
-    headers: { "Content-Type": "text/html; charset=utf-8" },
-  });
+  return htmlCallbackResponse(
+    escapeXml(`${providerLabel} account connected`),
+    escapeXml(statusMessage),
+    200,
+  );
 }

--- a/packages/junior/src/handlers/oauth-html.ts
+++ b/packages/junior/src/handlers/oauth-html.ts
@@ -1,4 +1,4 @@
-/** Build a simple centered HTML callback page. Callers must pre-escape dynamic strings. */
+/** Build pre-escaped callback HTML with the shared response security policy. */
 export function htmlCallbackResponse(
   title: string,
   message: string,
@@ -17,6 +17,13 @@ export function htmlCallbackResponse(
 </html>`;
   return new Response(html, {
     status,
-    headers: { "Content-Type": "text/html; charset=utf-8" },
+    headers: {
+      "Cache-Control": "no-store",
+      "Content-Security-Policy":
+        "default-src 'none'; style-src 'unsafe-inline'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'",
+      "Content-Type": "text/html; charset=utf-8",
+      "Referrer-Policy": "no-referrer",
+      "X-Content-Type-Options": "nosniff",
+    },
   });
 }

--- a/packages/junior/src/handlers/oauth-html.ts
+++ b/packages/junior/src/handlers/oauth-html.ts
@@ -3,7 +3,10 @@ export function htmlCallbackResponse(
   title: string,
   message: string,
   status: number,
+  options: { footerMessage?: string } = {},
 ): Response {
+  const footerMessage =
+    options.footerMessage ?? "You can close this tab and return to Junior.";
   const html = `<!DOCTYPE html>
 <html>
 <head><title>${title}</title></head>
@@ -11,7 +14,7 @@ export function htmlCallbackResponse(
   <div style="text-align: center; max-width: 480px;">
     <h1>${title}</h1>
     <p>${message}</p>
-    <p style="margin-top: 2rem; color: #666; font-size: 0.9em;">You can close this tab and return to Junior.</p>
+    <p style="margin-top: 2rem; color: #666; font-size: 0.9em;">${footerMessage}</p>
   </div>
 </body>
 </html>`;

--- a/packages/junior/tests/unit/handlers/mcp-oauth-callback.test.ts
+++ b/packages/junior/tests/unit/handlers/mcp-oauth-callback.test.ts
@@ -250,4 +250,37 @@ describe("mcp oauth callback handler", () => {
     expect(mutation).not.toHaveBeenCalled();
     expect(deleteMcpAuthSessionMock).toHaveBeenCalledWith("state-123");
   });
+
+  it("returns local close guidance after successful local MCP authorization", async () => {
+    const localSession = {
+      schemaVersion: 2,
+      authSessionId: "state-123",
+      provider: "demo",
+      userId: "U123",
+      conversationId: "local:thread",
+      destination: { platform: "local", threadId: "local:thread" },
+      sessionId: "turn-1",
+      userMessage: "use MCP",
+      createdAtMs: 1,
+      updatedAtMs: 1,
+    };
+    getMcpAuthSessionMock.mockResolvedValue(localSession);
+    finalizeMcpAuthorizationMock.mockResolvedValueOnce(localSession);
+
+    const response = await GET(
+      makeRequest(
+        "https://example.com/api/oauth/callback/mcp/demo?code=auth-code&state=state-123",
+      ),
+      "demo",
+      waitUntil.fn,
+      { agentRunner: testAgentRunner },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("Your MCP access is connected");
+    expect(body).toContain("You can close this tab and return to Junior.");
+    expect(body).not.toContain("You can close this tab and return to Slack.");
+    expect(waitUntil.pendingCount()).toBe(0);
+  });
 });

--- a/packages/junior/tests/unit/handlers/mcp-oauth-callback.test.ts
+++ b/packages/junior/tests/unit/handlers/mcp-oauth-callback.test.ts
@@ -5,11 +5,18 @@ const {
   finalizeMcpAuthorizationMock,
   getMcpAuthSessionMock,
   getPersistedThreadStateMock,
+  logExceptionMock,
 } = vi.hoisted(() => ({
   deleteMcpAuthSessionMock: vi.fn(),
   finalizeMcpAuthorizationMock: vi.fn(),
   getMcpAuthSessionMock: vi.fn(),
   getPersistedThreadStateMock: vi.fn(),
+  logExceptionMock: vi.fn(),
+}));
+
+vi.mock("@/chat/logging", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/chat/logging")>()),
+  logException: logExceptionMock,
 }));
 
 vi.mock("@/chat/mcp/oauth", () => ({
@@ -28,6 +35,7 @@ vi.mock("@/chat/runtime/thread-state", async (importOriginal) => ({
 }));
 
 import { GET } from "@/handlers/mcp-oauth-callback";
+import { McpProviderError } from "@/chat/mcp/errors";
 import {
   createWaitUntilCollector,
   type WaitUntilCollector,
@@ -48,6 +56,7 @@ describe("mcp oauth callback handler", () => {
     finalizeMcpAuthorizationMock.mockReset();
     getMcpAuthSessionMock.mockReset();
     getPersistedThreadStateMock.mockReset();
+    logExceptionMock.mockReset();
     getMcpAuthSessionMock.mockResolvedValue({
       schemaVersion: 2,
       authSessionId: "state-123",
@@ -91,6 +100,12 @@ describe("mcp oauth callback handler", () => {
     );
 
     expect(response.status).toBe(400);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(response.headers.get("content-security-policy")).toContain(
+      "frame-ancestors 'none'",
+    );
     expect(await response.text()).toContain("Missing state parameter");
     expect(finalizeMcpAuthorizationMock).not.toHaveBeenCalled();
     expect(waitUntil.pendingCount()).toBe(0);
@@ -113,9 +128,14 @@ describe("mcp oauth callback handler", () => {
     expect(waitUntil.pendingCount()).toBe(0);
   });
 
-  it("does not reflect callback exception text in the HTML response", async () => {
+  it("logs safe metadata for callback provider failures", async () => {
     finalizeMcpAuthorizationMock.mockRejectedValueOnce(
-      new Error("<img src=x onerror=alert(1)>"),
+      new McpProviderError({
+        phase: "oauth_callback",
+        provider: "demo",
+        resourceHost: "mcp.example.com",
+        status: 502,
+      }),
     );
 
     const response = await GET(
@@ -132,7 +152,18 @@ describe("mcp oauth callback handler", () => {
     expect(body).toContain(
       "Junior could not finish the authorization callback. Return to Junior and retry the original request.",
     );
-    expect(body).not.toContain("<img src=x onerror=alert(1)>");
+    expect(logExceptionMock).toHaveBeenCalledWith(
+      expect.any(McpProviderError),
+      "mcp_oauth_callback_failed",
+      {},
+      expect.objectContaining({
+        "app.credential.provider": "demo",
+        "app.mcp.error.phase": "oauth_callback",
+        "http.response.status_code": 502,
+        "server.address": "mcp.example.com",
+      }),
+      "Failed to process MCP OAuth callback",
+    );
     expect(waitUntil.pendingCount()).toBe(0);
   });
 

--- a/packages/junior/tests/unit/handlers/oauth-callback.test.ts
+++ b/packages/junior/tests/unit/handlers/oauth-callback.test.ts
@@ -432,6 +432,8 @@ describe("oauth callback handler", () => {
     const body = await response.text();
     expect(body).toContain("<!DOCTYPE html>");
     expect(body).toContain("Sentry account connected");
+    expect(body).toContain("You can close this tab and return to Slack.");
+    expect(body).not.toContain("You can close this tab and return to Junior.");
 
     const stored = (await getStoredTokens("U456", "sentry")) as {
       accessToken: string;
@@ -746,5 +748,7 @@ describe("oauth callback handler", () => {
     expect(response.status).toBe(200);
     const body = await response.text();
     expect(body).toContain("being processed in Slack");
+    expect(body).toContain("You can close this tab and return to Slack.");
+    expect(body).not.toContain("You can close this tab and return to Junior.");
   });
 });

--- a/packages/junior/tests/unit/handlers/oauth-callback.test.ts
+++ b/packages/junior/tests/unit/handlers/oauth-callback.test.ts
@@ -423,6 +423,12 @@ describe("oauth callback handler", () => {
     );
 
     expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(response.headers.get("content-security-policy")).toContain(
+      "frame-ancestors 'none'",
+    );
     const body = await response.text();
     expect(body).toContain("<!DOCTYPE html>");
     expect(body).toContain("Sentry account connected");

--- a/packages/junior/tests/unit/mcp/client.test.ts
+++ b/packages/junior/tests/unit/mcp/client.test.ts
@@ -239,9 +239,11 @@ describe("PluginMcpClient", () => {
     authProvider.getMcpServerSessionId.mockResolvedValue(undefined);
     authProvider.saveMcpServerSessionId.mockResolvedValue(undefined);
     const providerText = "SENSITIVE_CANARY";
+    const closeProviderText = "SENSITIVE_CLOSE_CANARY";
     connectMock.mockRejectedValueOnce(
       new StreamableHTTPError(401, providerText),
     );
+    closeMock.mockRejectedValueOnce(new Error(closeProviderText));
 
     const client = new PluginMcpClient(buildPlugin(), { authProvider });
     const error = await client.listTools().catch((caught: unknown) => caught);
@@ -255,7 +257,9 @@ describe("PluginMcpClient", () => {
     });
     expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
     expect(JSON.stringify(error)).not.toContain(providerText);
+    expect(JSON.stringify(error)).not.toContain(closeProviderText);
     expect((error as Error).message).not.toContain(providerText);
+    expect((error as Error).message).not.toContain(closeProviderText);
   });
 
   it("sanitizes transport close failures before cleanup telemetry", async () => {
@@ -324,6 +328,7 @@ describe("PluginMcpClient", () => {
       .mockResolvedValueOnce("stale-session")
       .mockResolvedValue(undefined);
     authProvider.saveMcpServerSessionId.mockResolvedValue(undefined);
+    closeMock.mockRejectedValueOnce(new Error("SENSITIVE_CLOSE_CANARY"));
     connectMock
       .mockRejectedValueOnce(new StreamableHTTPError(400, "Session not found"))
       .mockImplementationOnce(async (transport: { sessionId?: string }) => {
@@ -343,6 +348,7 @@ describe("PluginMcpClient", () => {
     const client = new PluginMcpClient(buildPlugin(), { authProvider });
 
     await expect(client.listTools()).resolves.toHaveLength(1);
+    expect(closeMock).toHaveBeenCalledTimes(1);
     expect(authProvider.saveMcpServerSessionId).toHaveBeenCalledWith(undefined);
     expect(transportOptions).toEqual([
       expect.objectContaining({

--- a/packages/junior/tests/unit/mcp/client.test.ts
+++ b/packages/junior/tests/unit/mcp/client.test.ts
@@ -42,15 +42,18 @@ vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => {
   }
 
   class StreamableHTTPClientTransport {
+    fetch?: typeof fetch;
     protocolVersion?: string;
     sessionId?: string;
 
     constructor(
       _url: URL,
       options?: {
+        fetch?: typeof fetch;
         sessionId?: string;
       },
     ) {
+      this.fetch = options?.fetch;
       this.sessionId = options?.sessionId;
       transportOptions.push({ ...(options ?? {}) });
     }
@@ -260,6 +263,68 @@ describe("PluginMcpClient", () => {
     expect(JSON.stringify(error)).not.toContain(closeProviderText);
     expect((error as Error).message).not.toContain(providerText);
     expect((error as Error).message).not.toContain(closeProviderText);
+  });
+
+  it("keeps MCP provider status scoped to each concurrent operation", async () => {
+    const authProvider = buildAuthProvider();
+    authProvider.getMcpServerSessionId.mockResolvedValue(undefined);
+    authProvider.saveMcpServerSessionId.mockResolvedValue(undefined);
+    connectMock.mockResolvedValue(undefined);
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      return new Response("provider failed", {
+        status: url.includes("first") ? 503 : 429,
+      });
+    });
+    let firstFetched: (() => void) | undefined;
+    const firstFetchDone = new Promise<void>((resolve) => {
+      firstFetched = resolve;
+    });
+    let releaseFirst: (() => void) | undefined;
+    const releaseFirstError = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    callToolMock.mockImplementation(
+      async (
+        transport: { fetch?: typeof fetch } | undefined,
+        args: { name: string },
+      ) => {
+        if (!transport?.fetch) {
+          throw new Error("missing fetch");
+        }
+        if (args.name === "first") {
+          await transport.fetch("https://mcp.notion.com/first");
+          firstFetched?.();
+          await releaseFirstError;
+          throw new Error("first failed");
+        }
+
+        await firstFetchDone;
+        await transport.fetch("https://mcp.notion.com/second");
+        releaseFirst?.();
+        throw new Error("second failed");
+      },
+    );
+
+    const client = new PluginMcpClient(buildPlugin(), {
+      authProvider,
+      fetch: fetchMock,
+    });
+
+    const [first, second] = await Promise.allSettled([
+      client.callTool("first", undefined),
+      client.callTool("second", undefined),
+    ]);
+
+    expect(first).toMatchObject({
+      status: "rejected",
+      reason: expect.objectContaining({ status: 503 }),
+    });
+    expect(second).toMatchObject({
+      status: "rejected",
+      reason: expect.objectContaining({ status: 429 }),
+    });
   });
 
   it("sanitizes transport close failures before cleanup telemetry", async () => {

--- a/packages/junior/tests/unit/mcp/client.test.ts
+++ b/packages/junior/tests/unit/mcp/client.test.ts
@@ -3,12 +3,14 @@ import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.
 
 const {
   callToolMock,
+  closeMock,
   connectMock,
   listToolsMock,
   setSpanAttributesMock,
   transportOptions,
 } = vi.hoisted(() => ({
   callToolMock: vi.fn(),
+  closeMock: vi.fn(),
   connectMock: vi.fn(),
   listToolsMock: vi.fn(),
   setSpanAttributesMock: vi.fn(),
@@ -53,7 +55,9 @@ vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => {
       transportOptions.push({ ...(options ?? {}) });
     }
 
-    async close() {}
+    async close() {
+      return await closeMock();
+    }
 
     setProtocolVersion(version: string) {
       this.protocolVersion = version;
@@ -97,6 +101,7 @@ import {
   McpAuthorizationRequiredError,
   PluginMcpClient,
 } from "@/chat/mcp/client";
+import { McpProviderError } from "@/chat/mcp/errors";
 
 function buildPlugin() {
   return {
@@ -148,6 +153,8 @@ function buildAuthProvider() {
 describe("PluginMcpClient", () => {
   beforeEach(() => {
     callToolMock.mockReset();
+    closeMock.mockReset();
+    closeMock.mockResolvedValue(undefined);
     connectMock.mockReset();
     listToolsMock.mockReset();
     setSpanAttributesMock.mockReset();
@@ -227,22 +234,52 @@ describe("PluginMcpClient", () => {
     );
   });
 
-  it("does not relabel raw 401 transport failures as auth challenges", async () => {
+  it("sanitizes raw 401 transport failures without treating them as auth challenges", async () => {
     const authProvider = buildAuthProvider();
     authProvider.getMcpServerSessionId.mockResolvedValue(undefined);
     authProvider.saveMcpServerSessionId.mockResolvedValue(undefined);
+    const providerText = "SENSITIVE_CANARY";
     connectMock.mockRejectedValueOnce(
-      new StreamableHTTPError(
-        401,
-        "Server returned 401 after successful authentication",
-      ),
+      new StreamableHTTPError(401, providerText),
     );
 
     const client = new PluginMcpClient(buildPlugin(), { authProvider });
+    const error = await client.listTools().catch((caught: unknown) => caught);
 
-    await expect(client.listTools()).rejects.toBeInstanceOf(
-      StreamableHTTPError,
-    );
+    expect(error).toBeInstanceOf(McpProviderError);
+    expect(error).toMatchObject({
+      phase: "connect",
+      provider: "notion",
+      resourceHost: "mcp.notion.com",
+      status: 401,
+    });
+    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
+    expect(JSON.stringify(error)).not.toContain(providerText);
+    expect((error as Error).message).not.toContain(providerText);
+  });
+
+  it("sanitizes transport close failures before cleanup telemetry", async () => {
+    const authProvider = buildAuthProvider();
+    authProvider.getMcpServerSessionId.mockResolvedValue(undefined);
+    authProvider.saveMcpServerSessionId.mockResolvedValue(undefined);
+    connectMock.mockResolvedValue(undefined);
+    listToolsMock.mockResolvedValue({ tools: [], nextCursor: undefined });
+    const providerText = "SENSITIVE_CLOSE_CANARY";
+    closeMock.mockRejectedValueOnce(new Error(providerText));
+
+    const client = new PluginMcpClient(buildPlugin(), { authProvider });
+    await client.listTools();
+    const error = await client.close().catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(McpProviderError);
+    expect(error).toMatchObject({
+      phase: "close",
+      provider: "notion",
+      resourceHost: "mcp.notion.com",
+    });
+    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
+    expect(JSON.stringify(error)).not.toContain(providerText);
+    expect((error as Error).message).not.toContain(providerText);
   });
 
   it("sends an empty arguments object for no-argument MCP tool calls", async () => {
@@ -288,7 +325,7 @@ describe("PluginMcpClient", () => {
       .mockResolvedValue(undefined);
     authProvider.saveMcpServerSessionId.mockResolvedValue(undefined);
     connectMock
-      .mockRejectedValueOnce(new StreamableHTTPError(404, "Session not found"))
+      .mockRejectedValueOnce(new StreamableHTTPError(400, "Session not found"))
       .mockImplementationOnce(async (transport: { sessionId?: string }) => {
         transport.sessionId = "fresh-session";
       });
@@ -308,8 +345,15 @@ describe("PluginMcpClient", () => {
     await expect(client.listTools()).resolves.toHaveLength(1);
     expect(authProvider.saveMcpServerSessionId).toHaveBeenCalledWith(undefined);
     expect(transportOptions).toEqual([
-      { authProvider, sessionId: "stale-session" },
-      { authProvider },
+      expect.objectContaining({
+        authProvider,
+        fetch: expect.any(Function),
+        sessionId: "stale-session",
+      }),
+      expect.objectContaining({
+        authProvider,
+        fetch: expect.any(Function),
+      }),
     ]);
   });
 

--- a/packages/junior/tests/unit/mcp/oauth.test.ts
+++ b/packages/junior/tests/unit/mcp/oauth.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const ORIGINAL_ENV = { ...process.env };
+const ORIGINAL_FETCH = globalThis.fetch;
+const closeMock = vi.fn();
+const finishAuthMock = vi.fn();
+const transportOptions: Array<{ fetch?: typeof fetch }> = [];
 const SLACK_DESTINATION = {
   platform: "slack",
   teamId: "T123",
@@ -39,6 +43,25 @@ describe("createMcpOAuthClientProvider", () => {
           provider === "demo" ? buildPlugin() : undefined,
       },
     }));
+    vi.doMock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+      StreamableHTTPClientTransport: class StreamableHTTPClientTransport {
+        constructor(_url: URL, options: { fetch?: typeof fetch } = {}) {
+          transportOptions.push(options);
+        }
+
+        async finishAuth(code: string) {
+          return await finishAuthMock(code, transportOptions.at(-1));
+        }
+
+        async close() {
+          return await closeMock();
+        }
+      },
+    }));
+    closeMock.mockReset();
+    closeMock.mockResolvedValue(undefined);
+    finishAuthMock.mockReset();
+    transportOptions.length = 0;
 
     const { disconnectStateAdapter } = await import("@/chat/state/adapter");
     await disconnectStateAdapter();
@@ -48,7 +71,9 @@ describe("createMcpOAuthClientProvider", () => {
     const { disconnectStateAdapter } = await import("@/chat/state/adapter");
     await disconnectStateAdapter();
     vi.doUnmock("@/chat/plugins/catalog-runtime");
+    vi.doUnmock("@modelcontextprotocol/sdk/client/streamableHttp.js");
     vi.resetModules();
+    globalThis.fetch = ORIGINAL_FETCH;
     process.env = { ...ORIGINAL_ENV };
   });
 
@@ -115,5 +140,68 @@ describe("createMcpOAuthClientProvider", () => {
     await expect(
       getMcpAuthSession(secondProvider.authSessionId),
     ).resolves.toBeUndefined();
+  });
+
+  it("sanitizes and bounds provider errors from the callback exchange", async () => {
+    const secrets = [
+      "https://auth.example.com/authorize?code=authorization-code",
+      "access-token-value",
+      "client-secret-value",
+      "<script>alert('provider')</script>",
+    ];
+    let cancelled = false;
+    const prefix = new TextEncoder().encode(secrets.join(" "));
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(prefix);
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    globalThis.fetch = vi.fn(
+      async () => new Response(body, { status: 502 }),
+    ) as unknown as typeof fetch;
+    finishAuthMock.mockImplementation(
+      async (_code: string, options: { fetch?: typeof fetch } | undefined) => {
+        const response = await options?.fetch?.("https://mcp.example.com/token");
+        const error = new Error(await response?.text());
+        Object.assign(error, { status: response?.status });
+        throw error;
+      },
+    );
+
+    const { createMcpOAuthClientProvider, finalizeMcpAuthorization } =
+      await import("@/chat/mcp/oauth");
+    const { McpProviderError } = await import("@/chat/mcp/errors");
+    const authProvider = await createMcpOAuthClientProvider({
+      provider: "demo",
+      conversationId: "conversation-1",
+      sessionId: "turn-1",
+      userId: "U123",
+      userMessage: "use /demo",
+    });
+    await authProvider.saveCodeVerifier("code-verifier");
+
+    const error = await finalizeMcpAuthorization(
+      "demo",
+      authProvider.authSessionId,
+      "authorization-code",
+    ).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(McpProviderError);
+    expect(error).toMatchObject({
+      phase: "oauth_callback",
+      provider: "demo",
+      resourceHost: "mcp.example.com",
+      status: 502,
+    });
+    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
+    for (const secret of secrets) {
+      expect((error as Error).message).not.toContain(secret);
+      expect(JSON.stringify(error)).not.toContain(secret);
+    }
+    expect(cancelled).toBe(true);
+    expect(closeMock).toHaveBeenCalledOnce();
   });
 });

--- a/packages/junior/tests/unit/mcp/oauth.test.ts
+++ b/packages/junior/tests/unit/mcp/oauth.test.ts
@@ -164,10 +164,10 @@ describe("createMcpOAuthClientProvider", () => {
     ) as unknown as typeof fetch;
     finishAuthMock.mockImplementation(
       async (_code: string, options: { fetch?: typeof fetch } | undefined) => {
-        const response = await options?.fetch?.("https://mcp.example.com/token");
-        const error = new Error(await response?.text());
-        Object.assign(error, { status: response?.status });
-        throw error;
+        const response = await options?.fetch?.(
+          "https://mcp.example.com/token",
+        );
+        throw new Error(await response?.text());
       },
     );
 

--- a/packages/junior/tests/unit/mcp/tool-manager-telemetry.test.ts
+++ b/packages/junior/tests/unit/mcp/tool-manager-telemetry.test.ts
@@ -95,4 +95,27 @@ describe("McpToolManager telemetry", () => {
       "private result",
     );
   });
+
+  it.each(["private", "public"] as const)(
+    "keeps provider tool error text out of %s telemetry",
+    async (conversationPrivacy) => {
+      const providerText = "SENSITIVE_CANARY";
+      resultMock.mockResolvedValue({
+        content: [{ type: "text", text: providerText }],
+        isError: true,
+      });
+      const manager = new McpToolManager([buildPlugin()]);
+      await manager.activateProvider("demo");
+      const [tool] = manager.getResolvedActiveTools();
+
+      await expect(tool!.execute({}, { conversationPrivacy })).rejects.toThrow(
+        providerText,
+      );
+
+      expect(endAttributes.value["exception.message"]).toBe(
+        "MCP tool call failed",
+      );
+      expect(JSON.stringify(endAttributes.value)).not.toContain(providerText);
+    },
+  );
 });

--- a/packages/junior/tests/unit/oauth-response.test.ts
+++ b/packages/junior/tests/unit/oauth-response.test.ts
@@ -27,6 +27,28 @@ describe("OAuth error responses", () => {
     expect(pulls).toBeLessThan(100);
   });
 
+  it("bounds provider streams that keep yielding empty chunks", async () => {
+    let cancelled = false;
+    let pulls = 0;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulls += 1;
+        controller.enqueue(new Uint8Array());
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+
+    const text = await readBoundedOAuthErrorBody(
+      new Response(body, { status: 500 }),
+    );
+
+    expect(text).toBe("");
+    expect(cancelled).toBe(true);
+    expect(pulls).toBe(16 * 1024);
+  });
+
   it("preserves the HTTP status when the provider body stream fails", async () => {
     const body = new ReadableStream<Uint8Array>({
       pull(controller) {

--- a/packages/junior/tests/unit/oauth-response.test.ts
+++ b/packages/junior/tests/unit/oauth-response.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "vitest";
-import { readBoundedOAuthErrorBody } from "@/chat/oauth-response";
+import { describe, expect, it, vi } from "vitest";
+import {
+  fetchWithBoundedOAuthErrorBodies,
+  readBoundedOAuthErrorBody,
+} from "@/chat/oauth-response";
 
 describe("OAuth error responses", () => {
   it("bounds provider-controlled bodies and cancels the remaining stream", async () => {
@@ -22,5 +25,27 @@ describe("OAuth error responses", () => {
     expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(16 * 1024);
     expect(cancelled).toBe(true);
     expect(pulls).toBeLessThan(100);
+  });
+
+  it("preserves the HTTP status when the provider body stream fails", async () => {
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.error(new Error("provider stream failed"));
+      },
+    });
+    const wrappedFetch = fetchWithBoundedOAuthErrorBodies(
+      vi.fn(async () =>
+        new Response(body, {
+          headers: { "www-authenticate": 'Bearer realm="mcp"' },
+          status: 401,
+        }),
+      ) as typeof fetch,
+    );
+
+    const response = await wrappedFetch("https://mcp.example.com/token");
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("www-authenticate")).toBe('Bearer realm="mcp"');
+    await expect(response.text()).resolves.toBe("");
   });
 });

--- a/packages/junior/tests/unit/oauth-response.test.ts
+++ b/packages/junior/tests/unit/oauth-response.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { readBoundedOAuthErrorBody } from "@/chat/oauth-response";
+
+describe("OAuth error responses", () => {
+  it("bounds provider-controlled bodies and cancels the remaining stream", async () => {
+    let cancelled = false;
+    let pulls = 0;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulls += 1;
+        controller.enqueue(new Uint8Array(1024).fill(65));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+
+    const text = await readBoundedOAuthErrorBody(
+      new Response(body, { status: 500 }),
+    );
+
+    expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(16 * 1024);
+    expect(cancelled).toBe(true);
+    expect(pulls).toBeLessThan(100);
+  });
+});

--- a/packages/junior/tests/unit/oauth-response.test.ts
+++ b/packages/junior/tests/unit/oauth-response.test.ts
@@ -34,11 +34,12 @@ describe("OAuth error responses", () => {
       },
     });
     const wrappedFetch = fetchWithBoundedOAuthErrorBodies(
-      vi.fn(async () =>
-        new Response(body, {
-          headers: { "www-authenticate": 'Bearer realm="mcp"' },
-          status: 401,
-        }),
+      vi.fn(
+        async () =>
+          new Response(body, {
+            headers: { "www-authenticate": 'Bearer realm="mcp"' },
+            status: 401,
+          }),
       ) as typeof fetch,
     );
 
@@ -47,5 +48,20 @@ describe("OAuth error responses", () => {
     expect(response.status).toBe(401);
     expect(response.headers.get("www-authenticate")).toBe('Bearer realm="mcp"');
     await expect(response.text()).resolves.toBe("");
+  });
+
+  it("reports safe status metadata before returning an error response", async () => {
+    let observedStatus: number | undefined;
+    const wrappedFetch = fetchWithBoundedOAuthErrorBodies(
+      vi.fn(async () => new Response("provider detail", { status: 503 })),
+      (status) => {
+        observedStatus = status;
+      },
+    );
+
+    const response = await wrappedFetch("https://mcp.example.com/token");
+
+    expect(response.status).toBe(503);
+    expect(observedStatus).toBe(503);
   });
 });

--- a/packages/junior/tests/unit/oauth-response.test.ts
+++ b/packages/junior/tests/unit/oauth-response.test.ts
@@ -46,7 +46,7 @@ describe("OAuth error responses", () => {
 
     expect(text).toBe("");
     expect(cancelled).toBe(true);
-    expect(pulls).toBe(16 * 1024);
+    expect(pulls).toBeLessThanOrEqual(16 * 1024 + 1);
   });
 
   it("preserves the HTTP status when the provider body stream fails", async () => {
@@ -70,6 +70,34 @@ describe("OAuth error responses", () => {
     expect(response.status).toBe(401);
     expect(response.headers.get("www-authenticate")).toBe('Bearer realm="mcp"');
     await expect(response.text()).resolves.toBe("");
+  });
+
+  it("preserves the HTTP status when the provider body never yields", async () => {
+    vi.useFakeTimers();
+    try {
+      let cancelled = false;
+      const body = new ReadableStream<Uint8Array>({
+        pull() {
+          return new Promise(() => undefined);
+        },
+        cancel() {
+          cancelled = true;
+        },
+      });
+      const wrappedFetch = fetchWithBoundedOAuthErrorBodies(
+        vi.fn(async () => new Response(body, { status: 504 })) as typeof fetch,
+      );
+
+      const responsePromise = wrappedFetch("https://mcp.example.com/token");
+      await vi.advanceTimersByTimeAsync(5_000);
+      const response = await responsePromise;
+
+      expect(response.status).toBe(504);
+      expect(cancelled).toBe(true);
+      await expect(response.text()).resolves.toBe("");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("reports safe status metadata before returning an error response", async () => {

--- a/packages/junior/tests/unit/plugins/sentry-broker.test.ts
+++ b/packages/junior/tests/unit/plugins/sentry-broker.test.ts
@@ -5,6 +5,7 @@ import type {
   PluginManifest,
 } from "@/chat/plugins/types";
 import { CredentialUnavailableError } from "@/chat/credentials/broker";
+import { OAuthProviderError } from "@/chat/oauth-response";
 import type {
   StoredTokens,
   UserTokenStore,
@@ -367,20 +368,112 @@ describe("sentry credential broker (oauth-bearer plugin)", () => {
       },
     });
 
+    const providerText = "SENSITIVE_CANARY";
     globalThis.fetch = vi.fn(
       async () =>
-        new Response(JSON.stringify({ error: "server_error" }), {
+        new Response(JSON.stringify({ error: providerText }), {
           status: 500,
         }),
+    ) as unknown as typeof fetch;
+
+    const broker = createBroker(tokenStore);
+    const error = await broker
+      .issue({
+        context: USER_CREDENTIAL_CONTEXT,
+        reason: "test:refresh-failure",
+      })
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(OAuthProviderError);
+    expect(error).toMatchObject({
+      phase: "token_refresh",
+      provider: "sentry",
+      resourceHost: "sentry.io",
+      status: 500,
+    });
+    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
+    expect((error as Error).message).not.toContain(providerText);
+    expect(JSON.stringify(error)).not.toContain(providerText);
+  });
+
+  it("bounds oversized token refresh error bodies", async () => {
+    process.env.SENTRY_CLIENT_ID = "client-id";
+    process.env.SENTRY_CLIENT_SECRET = "client-secret";
+
+    const tokenStore = createMockTokenStore({
+      "U123:sentry": {
+        accessToken: "old-access-token",
+        refreshToken: "old-refresh-token",
+        expiresAt: Date.now() + 2 * 60 * 1000,
+        scope: SENTRY_SCOPE,
+      },
+    });
+    let cancelled = false;
+    let pulls = 0;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulls += 1;
+        controller.enqueue(new Uint8Array(1024).fill(65));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    globalThis.fetch = vi.fn(
+      async () => new Response(body, { status: 500 }),
     ) as unknown as typeof fetch;
 
     const broker = createBroker(tokenStore);
     await expect(
       broker.issue({
         context: USER_CREDENTIAL_CONTEXT,
-        reason: "test:refresh-failure",
+        reason: "test:oversized-refresh-failure",
       }),
-    ).rejects.toThrow("Token refresh failed: 500 server_error");
+    ).rejects.toThrow("OAuth provider token refresh failed");
+    expect(cancelled).toBe(true);
+    expect(pulls).toBeLessThan(100);
+  });
+
+  it("sanitizes provider failures while reading refresh error bodies", async () => {
+    process.env.SENTRY_CLIENT_ID = "client-id";
+    process.env.SENTRY_CLIENT_SECRET = "client-secret";
+
+    const tokenStore = createMockTokenStore({
+      "U123:sentry": {
+        accessToken: "old-access-token",
+        refreshToken: "old-refresh-token",
+        expiresAt: Date.now() + 2 * 60 * 1000,
+        scope: SENTRY_SCOPE,
+      },
+    });
+    const providerText = "SENSITIVE_STREAM_CANARY";
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(new Error(providerText));
+      },
+    });
+    globalThis.fetch = vi.fn(
+      async () => new Response(body, { status: 500 }),
+    ) as unknown as typeof fetch;
+
+    const broker = createBroker(tokenStore);
+    const error = await broker
+      .issue({
+        context: USER_CREDENTIAL_CONTEXT,
+        reason: "test:refresh-read-failure",
+      })
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(OAuthProviderError);
+    expect(error).toMatchObject({
+      phase: "token_refresh",
+      provider: "sentry",
+      resourceHost: "sentry.io",
+      status: 500,
+    });
+    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
+    expect((error as Error).message).not.toContain(providerText);
+    expect(JSON.stringify(error)).not.toContain(providerText);
   });
 
   it("requires stored tokens to include the configured OAuth scope", async () => {

--- a/packages/junior/tests/unit/tools/tool-error-handler.test.ts
+++ b/packages/junior/tests/unit/tools/tool-error-handler.test.ts
@@ -16,6 +16,7 @@ vi.mock("@/chat/logging", () => ({
 }));
 
 import { McpToolError } from "@/chat/mcp/errors";
+import { OAuthProviderError } from "@/chat/oauth-response";
 import { PluginCredentialFailureError } from "@/chat/services/plugin-auth-orchestration";
 import { handleToolExecutionError } from "@/chat/tools/execution/tool-error-handler";
 
@@ -60,6 +61,45 @@ describe("handleToolExecutionError", () => {
       "remote tool failed",
     );
     expect(logExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it("reports only safe OAuth provider diagnostics", () => {
+    const error = new OAuthProviderError({
+      phase: "token_refresh",
+      provider: "sentry",
+      resourceHost: "sentry.io",
+      status: 503,
+    });
+
+    expect(() =>
+      handleToolExecutionError(error, "bash", "tool-call-id", true, {}),
+    ).toThrow(error);
+
+    expect(logWarnMock).toHaveBeenCalledWith(
+      "agent_tool_call_failed",
+      {},
+      expect.objectContaining({
+        "app.credential.provider": "sentry",
+        "app.oauth.error.phase": "token_refresh",
+        "error.type": "oauth_provider_error",
+        "exception.message": "OAuth provider token refresh failed",
+        "http.response.status_code": 503,
+        "server.address": "sentry.io",
+      }),
+      "Agent tool call failed",
+    );
+    expect(logExceptionMock).toHaveBeenCalledWith(
+      error,
+      "agent_tool_call_failed",
+      {},
+      expect.objectContaining({
+        "app.credential.provider": "sentry",
+        "app.oauth.error.phase": "token_refresh",
+        "http.response.status_code": 503,
+        "server.address": "sentry.io",
+      }),
+      "Agent tool call failed",
+    );
   });
 
   it("logs plugin credential failures as credential events", () => {


### PR DESCRIPTION
## Summary

OAuth and MCP provider failures can include raw response bodies in SDK error
messages. Those errors reach Junior's tool, cleanup, and callback telemetry,
which can expose provider-controlled text or secrets. OAuth callback pages also
lack explicit browser response protections.

## Changes

This change translates provider failures into phase-specific Junior errors
before they reach telemetry. The safe errors retain only the provider, phase,
HTTP status, and resource host, and deliberately do not retain the original
error as a cause. Non-success response bodies read by the MCP SDK or generic
OAuth refresh path are limited to 16 KiB, oversized streams are canceled, and
unreadable streams preserve the original status and auth headers with an empty
body.

Generic and MCP callback pages now share `Cache-Control: no-store`,
`Referrer-Policy: no-referrer`, a default-deny CSP, and
`X-Content-Type-Options: nosniff`. Existing authorization challenges, refresh
reauthorization signals, and stale MCP session recovery remain unchanged.

## Verification

```bash
pnpm --filter @sentry/junior exec vitest run tests/unit/oauth-response.test.ts tests/unit/mcp/client.test.ts tests/unit/mcp/oauth.test.ts tests/unit/plugins/sentry-broker.test.ts tests/unit/handlers/mcp-oauth-callback.test.ts tests/unit/handlers/oauth-callback.test.ts tests/unit/mcp/tool-manager-telemetry.test.ts tests/unit/tools/tool-error-handler.test.ts
pnpm --filter @sentry/junior test
pnpm --filter @sentry/junior typecheck
pnpm --filter @sentry/junior lint
pnpm file-length:check
```

The focused safety suite passes 54 tests across 8 files. The full Junior
package passes 2235 tests across 297 files, along with typecheck, lint,
dependency-boundary, and file-length checks.

Fixes #842
