### PR TITLE
fix(tools): bound readFile output

### DIFF
--- a/packages/junior/src/chat/tool-support/text-range-result.ts
+++ b/packages/junior/src/chat/tool-support/text-range-result.ts
@@ -1,6 +1,7 @@
 import { makeStructuredToolResult } from "@/chat/tool-support/structured-result";
 
 const DEFAULT_READ_LIMIT = 1000;
+const MAX_READ_CHARS = 60_000;
 
 interface TextRangeResult {
   content: [{ type: "text"; text: string }];
@@ -14,8 +15,11 @@ interface TextRangeResult {
       path: string;
       start_line: number;
       total_lines: number;
+      truncation_reasons?: string[];
     };
     truncated: boolean;
+    character_limit_reached?: number;
+    line_truncated?: boolean;
     continuation?: {
       arguments: {
         offset: number;
@@ -51,6 +55,7 @@ interface LegacyTextRangeResult {
   path: string;
   start_line: number;
   total_lines: number;
+  truncation_reasons?: string[];
   truncated: boolean;
 }
 
@@ -82,19 +87,53 @@ export function sliceFileContent(params: {
   const maxLines = requestedLimit ?? DEFAULT_READ_LIMIT;
   const startIndex = Math.min(lines.length, startLine - 1);
   const selected = lines.slice(startIndex, startIndex + maxLines);
+  const returnedLines: string[] = [];
+  let returnedCharacters = 0;
+  let characterLimitReached = false;
+  let lineTruncated = false;
+
+  for (const line of selected) {
+    const separatorLength = returnedLines.length > 0 ? 1 : 0;
+    if (returnedCharacters + separatorLength + line.length <= MAX_READ_CHARS) {
+      returnedLines.push(line);
+      returnedCharacters += separatorLength + line.length;
+      continue;
+    }
+
+    characterLimitReached = true;
+    if (returnedLines.length === 0) {
+      returnedLines.push(line.slice(0, MAX_READ_CHARS));
+      lineTruncated = true;
+    }
+    break;
+  }
+
   const endLine =
-    selected.length > 0 ? startLine + selected.length - 1 : startLine - 1;
-  const truncated = startIndex > 0 || endLine < lines.length;
+    returnedLines.length > 0
+      ? startLine + returnedLines.length - 1
+      : startLine - 1;
+  const truncated =
+    startIndex > 0 || endLine < lines.length || characterLimitReached;
   const rangeRequested =
     requestedOffset !== undefined || requestedLimit !== undefined;
   const returnedContent =
-    !rangeRequested && !truncated ? params.content : selected.join("\n");
+    !rangeRequested && !truncated ? params.content : returnedLines.join("\n");
+  const truncationReasons: string[] = [];
+  if (characterLimitReached) {
+    truncationReasons.push(`${MAX_READ_CHARS} character output limit reached.`);
+  }
+  if (lineTruncated) {
+    truncationReasons.push(`Line ${startLine} was truncated.`);
+  }
   const range: LegacyTextRangeResult = {
     content: returnedContent,
     end_line: selected.length > 0 ? endLine : undefined,
     path: params.path,
     start_line: startLine,
     total_lines: lines.length,
+    ...(truncationReasons.length > 0
+      ? { truncation_reasons: truncationReasons }
+      : {}),
     truncated,
   };
 
@@ -104,6 +143,10 @@ export function sliceFileContent(params: {
     target: params.path,
     data: range,
     truncated,
+    ...(characterLimitReached
+      ? { character_limit_reached: MAX_READ_CHARS }
+      : {}),
+    ...(lineTruncated ? { line_truncated: true } : {}),
     ...(endLine < lines.length
       ? {
           continuation: {
@@ -112,7 +155,9 @@ export function sliceFileContent(params: {
               offset: endLine + 1,
               limit: maxLines,
             },
-            reason: "file has more lines",
+            reason: characterLimitReached
+              ? "character output limit reached; file has more lines"
+              : "file has more lines",
           },
         }
       : {}),

--- a/packages/junior/tests/unit/tools/sandbox/file-tools.test.ts
+++ b/packages/junior/tests/unit/tools/sandbox/file-tools.test.ts
@@ -108,6 +108,57 @@ describe("sandbox file tools", () => {
     expect(JSON.parse(result.content[0].text)).toEqual(result.details);
   });
 
+  it("continues readFile at the first whole line excluded by the character limit", () => {
+    const line = "a".repeat(30_000);
+    const result = sliceFileContent({
+      content: `${line}\n${line}\nthree`,
+      path: "generated.txt",
+    });
+
+    expect(result.details).toMatchObject({
+      truncated: true,
+      character_limit_reached: 60_000,
+      data: {
+        content: line,
+        end_line: 1,
+        truncation_reasons: ["60000 character output limit reached."],
+      },
+      continuation: {
+        arguments: {
+          path: "generated.txt",
+          offset: 2,
+          limit: 1000,
+        },
+        reason: "character output limit reached; file has more lines",
+      },
+    });
+    expect(result.details).not.toHaveProperty("line_truncated");
+    expect(result.content[0].text.length).toBeLessThan(61_000);
+  });
+
+  it("bounds and reports an individually oversized readFile line", () => {
+    const result = sliceFileContent({
+      content: "a".repeat(100_000),
+      path: "generated.json",
+    });
+
+    expect(result.details).toMatchObject({
+      truncated: true,
+      character_limit_reached: 60_000,
+      line_truncated: true,
+      data: {
+        end_line: 1,
+        truncation_reasons: [
+          "60000 character output limit reached.",
+          "Line 1 was truncated.",
+        ],
+      },
+    });
+    expect(result.details.data.content).toHaveLength(60_000);
+    expect(result.details).not.toHaveProperty("continuation");
+    expect(result.content[0].text.length).toBeLessThan(61_000);
+  });
+
   it("applies exact edits and preserves line endings", async () => {
     const memory = createMemoryFs({
       "src/app.ts": "one\r\ntwo\r\nthree\r\n",


### PR DESCRIPTION
`readFile` now caps returned file content at 60,000 characters, preventing minified files, source maps, and other oversized lines from flooding the model context. Complete lines remain resumable through continuation metadata at the first excluded line, while an individually oversized line is explicitly marked as clipped without claiming its omitted suffix can be resumed.

The focused sandbox file-tool coverage exercises both whole-line continuation and single-line clipping. Existing line-limit behavior and ordinary file reads remain unchanged.
