### PR TITLE
feat(tools): back sandbox search with ripgrep

### DIFF
--- a/packages/junior/src/chat/sandbox/runtime-dependencies.ts
+++ b/packages/junior/src/chat/sandbox/runtime-dependencies.ts
@@ -2,4 +2,5 @@ import type { PluginRuntimeDependency } from "@/chat/plugins/types";
 
 export const GLOBAL_RUNTIME_DEPENDENCIES: PluginRuntimeDependency[] = [
   { type: "system", package: "docker" },
+  { type: "system", package: "ripgrep" },
 ];

--- a/packages/junior/src/chat/sandbox/sandbox.ts
+++ b/packages/junior/src/chat/sandbox/sandbox.ts
@@ -47,6 +47,7 @@ import {
   isMissingPathError,
   positiveInteger,
   resolveWorkspacePath,
+  type SandboxCommandRunner,
 } from "@/chat/tools/sandbox/file-utils";
 import { grepFiles } from "@/chat/tools/sandbox/grep";
 import { listDir } from "@/chat/tools/sandbox/list-dir";
@@ -92,6 +93,7 @@ export interface SandboxOptions {
 interface SandboxToolCallContext {
   readonly signal?: AbortSignal;
   fileSystem(): Promise<SandboxFileSystem>;
+  commandRunner(): Promise<SandboxCommandRunner>;
 }
 
 /** Create the safe expected tool error for an unavailable sandbox operation. */
@@ -213,6 +215,7 @@ export function createSandbox(options: SandboxOptions): SandboxAccess {
     signal?: AbortSignal,
   ): SandboxToolCallContext => {
     let fileSystemPromise: Promise<SandboxFileSystem> | undefined;
+    let commandRunnerPromise: Promise<SandboxCommandRunner> | undefined;
 
     return {
       signal,
@@ -222,6 +225,19 @@ export function createSandbox(options: SandboxOptions): SandboxAccess {
           signal?.throwIfAborted();
           return bindSandboxFileSystem(fs, signal);
         }));
+      },
+      commandRunner() {
+        signal?.throwIfAborted();
+        return (commandRunnerPromise ??= runtime
+          .tools()
+          .then(({ runCommand }) => {
+            signal?.throwIfAborted();
+            return async (input) =>
+              await runCommand({
+                ...input,
+                ...(signal ? { signal } : {}),
+              });
+          }));
       },
     };
   };
@@ -542,6 +558,7 @@ export function createSandbox(options: SandboxOptions): SandboxAccess {
       async () => {
         const response = await grepFiles({
           fs: fileSystem,
+          runCommand: await context.commandRunner(),
           pattern,
           ...(typeof rawInput.path === "string" ? { path: rawInput.path } : {}),
           ...(typeof rawInput.glob === "string" ? { glob: rawInput.glob } : {}),
@@ -583,6 +600,7 @@ export function createSandbox(options: SandboxOptions): SandboxAccess {
       async () => {
         const response = await findFiles({
           fs: fileSystem,
+          runCommand: await context.commandRunner(),
           pattern,
           ...(typeof rawInput.path === "string" ? { path: rawInput.path } : {}),
           ...(limit ? { limit } : {}),

--- a/packages/junior/src/chat/sandbox/session.ts
+++ b/packages/junior/src/chat/sandbox/session.ts
@@ -68,6 +68,7 @@ interface SandboxToolExecutors {
     timedOut?: boolean;
   }>;
   fs: SandboxFileSystem;
+  runCommand: SandboxSession["runCommand"];
 }
 
 interface SandboxRuntime {
@@ -768,6 +769,7 @@ export function createSandboxRuntime(
         }
       },
       fs: sandboxInstance.fs as SandboxFileSystem,
+      runCommand: async (input) => await sandboxInstance.runCommand(input),
     };
   };
 

--- a/packages/junior/src/chat/tools/sandbox/file-utils.ts
+++ b/packages/junior/src/chat/tools/sandbox/file-utils.ts
@@ -1,10 +1,17 @@
 import path from "node:path";
 import { SANDBOX_WORKSPACE_ROOT } from "@/chat/sandbox/paths";
-import type { SandboxFileSystem } from "@/chat/sandbox/workspace";
+import type {
+  SandboxCommandInput,
+  SandboxCommandResult,
+  SandboxFileSystem,
+} from "@/chat/sandbox/workspace";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 import { makeStructuredToolResult } from "@/chat/tool-support/structured-result";
 
 export type { SandboxFileSystem };
+export type SandboxCommandRunner = (
+  input: SandboxCommandInput,
+) => Promise<SandboxCommandResult>;
 
 export const MAX_TEXT_CHARS = 60_000;
 const SKIPPED_DIRECTORIES = new Set([".git", "node_modules"]);

--- a/packages/junior/src/chat/tools/sandbox/file-utils.ts
+++ b/packages/junior/src/chat/tools/sandbox/file-utils.ts
@@ -183,6 +183,20 @@ export function resolveWorkspacePath(
   return normalized;
 }
 
+/** Anchor ripgrep paths and globs to the requested search root. */
+export function getRipgrepSearchLocation(
+  root: string,
+  rootIsDirectory: boolean,
+): { cwd: string; target: string } {
+  if (rootIsDirectory) {
+    return { cwd: root, target: "." };
+  }
+  return {
+    cwd: path.posix.dirname(root),
+    target: path.posix.basename(root),
+  };
+}
+
 /** Share bounded workspace traversal across search tools so their skip rules stay aligned. */
 export async function collectFiles(params: {
   fs: SandboxFileSystem;

--- a/packages/junior/src/chat/tools/sandbox/file-utils.ts
+++ b/packages/junior/src/chat/tools/sandbox/file-utils.ts
@@ -14,6 +14,10 @@ export type SandboxCommandRunner = (
 ) => Promise<SandboxCommandResult>;
 
 export const MAX_TEXT_CHARS = 60_000;
+export const RIPGREP_EXCLUDED_GLOBS = [
+  "!**/.git/**",
+  "!**/node_modules/**",
+] as const;
 const SKIPPED_DIRECTORIES = new Set([".git", "node_modules"]);
 
 export type TextSearchResultDetails =

--- a/packages/junior/src/chat/tools/sandbox/find-files.ts
+++ b/packages/junior/src/chat/tools/sandbox/find-files.ts
@@ -1,11 +1,14 @@
 import path from "node:path";
+import { SANDBOX_WORKSPACE_ROOT } from "@/chat/sandbox/paths";
 import {
   MAX_TEXT_CHARS,
   collectFiles,
+  isMissingPathError,
   missingPathSearchResult,
   positiveInteger,
   resolveWorkspacePath,
   truncateText,
+  type SandboxCommandRunner,
   type SandboxFileSystem,
   type TextSearchResultDetails,
   type TextSearchToolResult,
@@ -41,6 +44,7 @@ export async function findFiles(params: {
   limit?: unknown;
   path?: string;
   pattern: string;
+  runCommand?: SandboxCommandRunner;
 }): Promise<FindFilesResult> {
   if (!params.pattern.trim()) {
     throw new Error("pattern is required");
@@ -48,6 +52,16 @@ export async function findFiles(params: {
 
   const root = resolveWorkspacePath(params.path);
   const limit = positiveInteger(params.limit) ?? DEFAULT_FIND_LIMIT;
+  if (params.runCommand) {
+    return await findFilesWithRipgrep({
+      fs: params.fs,
+      limit,
+      path: params.path,
+      pattern: params.pattern,
+      root,
+      runCommand: params.runCommand,
+    });
+  }
   const { files, limitReached, missingPath, missingRoot } = await collectFiles({
     fs: params.fs,
     root,
@@ -97,6 +111,104 @@ export async function findFiles(params: {
         ...(notices.length > 0 ? { truncation_reasons: notices } : {}),
       },
       ...(limitReached ? { result_limit_reached: limit } : {}),
+    },
+    { content: [{ type: "text", text }] },
+  ) as FindFilesResult;
+}
+
+async function findFilesWithRipgrep(params: {
+  fs: SandboxFileSystem;
+  limit: number;
+  path?: string;
+  pattern: string;
+  root: string;
+  runCommand: SandboxCommandRunner;
+}): Promise<FindFilesResult> {
+  let rootIsDirectory: boolean;
+  try {
+    rootIsDirectory = (await params.fs.stat(params.root)).isDirectory();
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return missingPathSearchResult({
+        path: params.path ?? ".",
+        displayPath: params.path ?? ".",
+      });
+    }
+    throw error;
+  }
+
+  const target =
+    path.posix.relative(SANDBOX_WORKSPACE_ROOT, params.root) || ".";
+  const result = await params.runCommand({
+    cmd: "rg",
+    args: [
+      "--files",
+      "--null",
+      "--hidden",
+      "--sort=path",
+      "--glob",
+      "!.git/**",
+      "--glob",
+      "!node_modules/**",
+      "--glob",
+      params.pattern,
+      "--",
+      target,
+    ],
+    cwd: SANDBOX_WORKSPACE_ROOT,
+  });
+  if (result.exitCode !== 0 && result.exitCode !== 1) {
+    const detail =
+      result.stderr.trim() || result.stdout.trim() || "command failed";
+    throw new Error(`ripgrep file search failed: ${detail}`);
+  }
+
+  const allPaths = result.stdout
+    .split("\0")
+    .filter(Boolean)
+    .map((filePath) => {
+      const absolute = filePath.startsWith("/")
+        ? path.posix.normalize(filePath)
+        : path.posix.resolve(SANDBOX_WORKSPACE_ROOT, filePath);
+      return rootIsDirectory
+        ? path.posix.relative(params.root, absolute)
+        : path.posix.basename(absolute);
+    });
+  const limitReached = allPaths.length > params.limit;
+  const relativePaths = allPaths.slice(0, params.limit);
+  const bounded = truncateText(
+    relativePaths.length > 0
+      ? relativePaths.join("\n")
+      : "No files found matching pattern",
+  );
+  const notices: string[] = [];
+  if (limitReached) {
+    notices.push(
+      `${params.limit} results limit reached. Refine pattern or raise limit.`,
+    );
+  }
+  if (bounded.truncated) {
+    notices.push(`${MAX_TEXT_CHARS} character output limit reached.`);
+  }
+  const text =
+    notices.length > 0
+      ? `${bounded.content}\n\n[${notices.join(" ")}]`
+      : bounded.content;
+
+  return makeStructuredToolResult(
+    {
+      ok: true,
+      status: "success",
+      target: params.path ?? ".",
+      path: params.path ?? ".",
+      truncated: limitReached || bounded.truncated,
+      data: {
+        files: relativePaths,
+        file_count: relativePaths.length,
+        path: params.path ?? ".",
+        ...(notices.length > 0 ? { truncation_reasons: notices } : {}),
+      },
+      ...(limitReached ? { result_limit_reached: params.limit } : {}),
     },
     { content: [{ type: "text", text }] },
   ) as FindFilesResult;

--- a/packages/junior/src/chat/tools/sandbox/find-files.ts
+++ b/packages/junior/src/chat/tools/sandbox/find-files.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import {
   MAX_TEXT_CHARS,
+  RIPGREP_EXCLUDED_GLOBS,
   collectFiles,
   getRipgrepSearchLocation,
   isMissingPathError,
@@ -138,22 +139,21 @@ async function findFilesWithRipgrep(params: {
   }
 
   const location = getRipgrepSearchLocation(params.root, rootIsDirectory);
+  const args = [
+    "--files",
+    "--null",
+    "--hidden",
+    "--sort=path",
+    "--glob",
+    params.pattern,
+  ];
+  for (const excludedGlob of RIPGREP_EXCLUDED_GLOBS) {
+    args.push("--glob", excludedGlob);
+  }
+  args.push("--", location.target);
   const result = await params.runCommand({
     cmd: "rg",
-    args: [
-      "--files",
-      "--null",
-      "--hidden",
-      "--sort=path",
-      "--glob",
-      "!.git/**",
-      "--glob",
-      "!node_modules/**",
-      "--glob",
-      params.pattern,
-      "--",
-      location.target,
-    ],
+    args,
     cwd: location.cwd,
   });
   if (result.exitCode !== 0 && result.exitCode !== 1) {

--- a/packages/junior/src/chat/tools/sandbox/find-files.ts
+++ b/packages/junior/src/chat/tools/sandbox/find-files.ts
@@ -1,8 +1,8 @@
 import path from "node:path";
-import { SANDBOX_WORKSPACE_ROOT } from "@/chat/sandbox/paths";
 import {
   MAX_TEXT_CHARS,
   collectFiles,
+  getRipgrepSearchLocation,
   isMissingPathError,
   missingPathSearchResult,
   positiveInteger,
@@ -137,8 +137,7 @@ async function findFilesWithRipgrep(params: {
     throw error;
   }
 
-  const target =
-    path.posix.relative(SANDBOX_WORKSPACE_ROOT, params.root) || ".";
+  const location = getRipgrepSearchLocation(params.root, rootIsDirectory);
   const result = await params.runCommand({
     cmd: "rg",
     args: [
@@ -153,9 +152,9 @@ async function findFilesWithRipgrep(params: {
       "--glob",
       params.pattern,
       "--",
-      target,
+      location.target,
     ],
-    cwd: SANDBOX_WORKSPACE_ROOT,
+    cwd: location.cwd,
   });
   if (result.exitCode !== 0 && result.exitCode !== 1) {
     const detail =
@@ -169,7 +168,7 @@ async function findFilesWithRipgrep(params: {
     .map((filePath) => {
       const absolute = filePath.startsWith("/")
         ? path.posix.normalize(filePath)
-        : path.posix.resolve(SANDBOX_WORKSPACE_ROOT, filePath);
+        : path.posix.resolve(location.cwd, filePath);
       return rootIsDirectory
         ? path.posix.relative(params.root, absolute)
         : path.posix.basename(absolute);

--- a/packages/junior/src/chat/tools/sandbox/grep.ts
+++ b/packages/junior/src/chat/tools/sandbox/grep.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { SANDBOX_WORKSPACE_ROOT } from "@/chat/sandbox/paths";
 import {
   MAX_TEXT_CHARS,
   collectFiles,
@@ -8,6 +9,7 @@ import {
   positiveInteger,
   resolveWorkspacePath,
   truncateText,
+  type SandboxCommandRunner,
   type SandboxFileSystem,
   type TextSearchResultDetails,
   type TextSearchToolResult,
@@ -90,6 +92,7 @@ export async function grepFiles(params: {
   literal?: boolean;
   path?: string;
   pattern: string;
+  runCommand?: SandboxCommandRunner;
 }): Promise<GrepResult> {
   if (!params.pattern) {
     throw new Error("pattern is required");
@@ -98,6 +101,20 @@ export async function grepFiles(params: {
   const root = resolveWorkspacePath(params.path);
   const limit = positiveInteger(params.limit) ?? DEFAULT_GREP_LIMIT;
   const context = positiveInteger(params.context) ?? 0;
+  if (params.runCommand) {
+    return await grepFilesWithRipgrep({
+      context,
+      fs: params.fs,
+      glob: params.glob,
+      ignoreCase: params.ignoreCase,
+      limit,
+      literal: params.literal,
+      path: params.path,
+      pattern: params.pattern,
+      root,
+      runCommand: params.runCommand,
+    });
+  }
   let regex: RegExp | undefined;
   if (!params.literal) {
     try {
@@ -226,6 +243,225 @@ export async function grepFiles(params: {
       ...(notices.length > 0 ? { truncation_reasons: notices } : {}),
     },
     ...(matchLimitReached ? { match_limit_reached: limit } : {}),
+    ...(lineTruncated ? { line_truncated: true } : {}),
+  });
+}
+
+interface RipgrepText {
+  bytes?: string;
+  text?: string;
+}
+
+interface RipgrepRecord {
+  type?: string;
+  data?: {
+    line_number?: number;
+    lines?: RipgrepText;
+    path?: RipgrepText;
+  };
+}
+
+function decodeRipgrepText(value: RipgrepText | undefined): string {
+  if (typeof value?.text === "string") {
+    return value.text;
+  }
+  if (typeof value?.bytes === "string") {
+    return Buffer.from(value.bytes, "base64").toString("utf8");
+  }
+  return "";
+}
+
+async function grepFilesWithRipgrep(params: {
+  context: number;
+  fs: SandboxFileSystem;
+  glob?: string;
+  ignoreCase?: boolean;
+  limit: number;
+  literal?: boolean;
+  path?: string;
+  pattern: string;
+  root: string;
+  runCommand: SandboxCommandRunner;
+}): Promise<GrepResult> {
+  let rootIsDirectory: boolean;
+  try {
+    rootIsDirectory = (await params.fs.stat(params.root)).isDirectory();
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return missingPathSearchResult({
+        path: params.path ?? ".",
+        displayPath: params.path ?? ".",
+      });
+    }
+    throw error;
+  }
+
+  const target =
+    path.posix.relative(SANDBOX_WORKSPACE_ROOT, params.root) || ".";
+  const args = [
+    "--json",
+    "--line-number",
+    "--hidden",
+    "--sort=path",
+    "--glob",
+    "!.git/**",
+    "--glob",
+    "!node_modules/**",
+  ];
+  if (params.ignoreCase) {
+    args.push("--ignore-case");
+  }
+  if (params.literal) {
+    args.push("--fixed-strings");
+  }
+  if (params.glob) {
+    args.push("--glob", params.glob);
+  }
+  if (params.context > 0) {
+    args.push("--context", String(params.context));
+  }
+  args.push("--", params.pattern, target);
+
+  const result = await params.runCommand({
+    cmd: "rg",
+    args,
+    cwd: SANDBOX_WORKSPACE_ROOT,
+  });
+  if (result.exitCode !== 0 && result.exitCode !== 1) {
+    const detail =
+      result.stderr.trim() || result.stdout.trim() || "command failed";
+    if (/regex parse error|error parsing regex/i.test(detail)) {
+      throw new ToolInputError(`Invalid regex pattern: ${params.pattern}`, {
+        cause: new Error(detail),
+      });
+    }
+    throw new Error(`ripgrep search failed: ${detail}`);
+  }
+
+  const recordsByPath = new Map<
+    string,
+    Array<{ line: number; matched: boolean; text: string }>
+  >();
+  const pathOrder: string[] = [];
+  let totalMatches = 0;
+  for (const rawLine of normalizeToLf(result.stdout).split("\n")) {
+    if (!rawLine) {
+      continue;
+    }
+    let record: RipgrepRecord;
+    try {
+      record = JSON.parse(rawLine) as RipgrepRecord;
+    } catch (error) {
+      throw new Error("ripgrep returned invalid JSON output", { cause: error });
+    }
+    if (record.type !== "match" && record.type !== "context") {
+      continue;
+    }
+    const line = record.data?.line_number;
+    const rawPath = decodeRipgrepText(record.data?.path);
+    if (!line || !rawPath) {
+      continue;
+    }
+    const absolutePath = rawPath.startsWith("/")
+      ? path.posix.normalize(rawPath)
+      : path.posix.resolve(SANDBOX_WORKSPACE_ROOT, rawPath);
+    const displayPath = rootIsDirectory
+      ? path.posix.relative(params.root, absolutePath)
+      : path.posix.basename(absolutePath);
+    let records = recordsByPath.get(displayPath);
+    if (!records) {
+      records = [];
+      recordsByPath.set(displayPath, records);
+      pathOrder.push(displayPath);
+    }
+    const matched = record.type === "match";
+    if (matched) {
+      totalMatches += 1;
+    }
+    records.push({
+      line,
+      matched,
+      text: decodeRipgrepText(record.data?.lines).replace(/\r?\n$/, ""),
+    });
+  }
+
+  let remainingMatches = params.limit;
+  const output: string[] = [];
+  let lineTruncated = false;
+  for (const displayPath of pathOrder) {
+    const records = recordsByPath.get(displayPath) ?? [];
+    const selectedMatchLines: number[] = [];
+    for (const record of records) {
+      if (record.matched && remainingMatches > 0) {
+        selectedMatchLines.push(record.line);
+        remainingMatches -= 1;
+      }
+    }
+    if (selectedMatchLines.length === 0) {
+      continue;
+    }
+    const selectedMatchSet = new Set(selectedMatchLines);
+    const emittedLines = new Set<number>();
+    for (const record of records) {
+      if (emittedLines.has(record.line)) {
+        continue;
+      }
+      const include = selectedMatchLines.some(
+        (matchLine) => Math.abs(record.line - matchLine) <= params.context,
+      );
+      if (!include) {
+        continue;
+      }
+      emittedLines.add(record.line);
+      const truncated = truncateGrepLine(record.text);
+      lineTruncated ||= truncated.truncated;
+      const separator = selectedMatchSet.has(record.line) ? ":" : "-";
+      output.push(
+        `${displayPath}${separator}${record.line}${separator} ${truncated.line}`,
+      );
+    }
+  }
+
+  const matchCount = Math.min(totalMatches, params.limit);
+  const matchLimitReached = totalMatches > params.limit;
+  const bounded = truncateText(
+    output.length > 0 ? output.join("\n") : "No matches found",
+  );
+  const notices: string[] = [];
+  if (matchLimitReached) {
+    notices.push(
+      `${params.limit} matches limit reached. Refine pattern or raise limit.`,
+    );
+  }
+  if (lineTruncated) {
+    notices.push(
+      `Some lines were truncated to ${MAX_GREP_LINE_CHARS} characters.`,
+    );
+  }
+  if (bounded.truncated) {
+    notices.push(`${MAX_TEXT_CHARS} character output limit reached.`);
+  }
+
+  return makeStructuredToolResult({
+    ok: true,
+    status: "success",
+    target: params.path ?? ".",
+    path: params.path ?? ".",
+    truncated: matchLimitReached || lineTruncated || bounded.truncated,
+    data: {
+      context: params.context,
+      ...(params.glob ? { glob: params.glob } : {}),
+      line_count: output.length,
+      lines:
+        bounded.content === "No matches found"
+          ? []
+          : bounded.content.split("\n"),
+      match_count: matchCount,
+      pattern: params.pattern,
+      path: params.path ?? ".",
+      ...(notices.length > 0 ? { truncation_reasons: notices } : {}),
+    },
+    ...(matchLimitReached ? { match_limit_reached: params.limit } : {}),
     ...(lineTruncated ? { line_truncated: true } : {}),
   });
 }

--- a/packages/junior/src/chat/tools/sandbox/grep.ts
+++ b/packages/junior/src/chat/tools/sandbox/grep.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import {
   MAX_TEXT_CHARS,
+  RIPGREP_EXCLUDED_GLOBS,
   collectFiles,
   getRipgrepSearchLocation,
   isMissingPathError,
@@ -297,16 +298,7 @@ async function grepFilesWithRipgrep(params: {
   }
 
   const location = getRipgrepSearchLocation(params.root, rootIsDirectory);
-  const args = [
-    "--json",
-    "--line-number",
-    "--hidden",
-    "--sort=path",
-    "--glob",
-    "!.git/**",
-    "--glob",
-    "!node_modules/**",
-  ];
+  const args = ["--json", "--line-number", "--hidden", "--sort=path"];
   if (params.ignoreCase) {
     args.push("--ignore-case");
   }
@@ -315,6 +307,9 @@ async function grepFilesWithRipgrep(params: {
   }
   if (params.glob) {
     args.push("--glob", params.glob);
+  }
+  for (const excludedGlob of RIPGREP_EXCLUDED_GLOBS) {
+    args.push("--glob", excludedGlob);
   }
   if (params.context > 0) {
     args.push("--context", String(params.context));

--- a/packages/junior/src/chat/tools/sandbox/grep.ts
+++ b/packages/junior/src/chat/tools/sandbox/grep.ts
@@ -1,8 +1,8 @@
 import path from "node:path";
-import { SANDBOX_WORKSPACE_ROOT } from "@/chat/sandbox/paths";
 import {
   MAX_TEXT_CHARS,
   collectFiles,
+  getRipgrepSearchLocation,
   isMissingPathError,
   missingPathSearchResult,
   normalizeToLf,
@@ -296,8 +296,7 @@ async function grepFilesWithRipgrep(params: {
     throw error;
   }
 
-  const target =
-    path.posix.relative(SANDBOX_WORKSPACE_ROOT, params.root) || ".";
+  const location = getRipgrepSearchLocation(params.root, rootIsDirectory);
   const args = [
     "--json",
     "--line-number",
@@ -320,12 +319,12 @@ async function grepFilesWithRipgrep(params: {
   if (params.context > 0) {
     args.push("--context", String(params.context));
   }
-  args.push("--", params.pattern, target);
+  args.push("--", params.pattern, location.target);
 
   const result = await params.runCommand({
     cmd: "rg",
     args,
-    cwd: SANDBOX_WORKSPACE_ROOT,
+    cwd: location.cwd,
   });
   if (result.exitCode !== 0 && result.exitCode !== 1) {
     const detail =
@@ -364,7 +363,7 @@ async function grepFilesWithRipgrep(params: {
     }
     const absolutePath = rawPath.startsWith("/")
       ? path.posix.normalize(rawPath)
-      : path.posix.resolve(SANDBOX_WORKSPACE_ROOT, rawPath);
+      : path.posix.resolve(location.cwd, rawPath);
     const displayPath = rootIsDirectory
       ? path.posix.relative(params.root, absolutePath)
       : path.posix.basename(absolutePath);

--- a/packages/junior/tests/component/misc/sandbox-executor.test.ts
+++ b/packages/junior/tests/component/misc/sandbox-executor.test.ts
@@ -1605,34 +1605,32 @@ describe("createTestSandbox", () => {
     });
   });
 
-  it("preserves turn cancellation when file traversal reports an interrupted stream", async () => {
+  it("preserves turn cancellation when ripgrep reports an interrupted stream", async () => {
     const sandbox = makeSandbox("sbx_aborted_find_files");
     const abortReason = new Error("agent turn cancelled");
-    let markEntryStatStarted: () => void = () => {};
-    const entryStatStarted = new Promise<void>((resolve) => {
-      markEntryStatStarted = resolve;
+    let markCommandStarted: () => void = () => {};
+    const commandStarted = new Promise<void>((resolve) => {
+      markCommandStarted = resolve;
     });
-    sandbox.fs.stat
-      .mockResolvedValueOnce({ isDirectory: () => true })
-      .mockImplementationOnce(
-        async (_filePath: string, options?: { signal?: AbortSignal }) =>
-          await new Promise<{ isDirectory(): boolean }>((_resolve, reject) => {
-            markEntryStatStarted();
-            const missingSignalTimeout = setTimeout(
-              () => reject(new Error("abort signal was not propagated")),
-              100,
-            );
-            options?.signal?.addEventListener(
-              "abort",
-              () => {
-                clearTimeout(missingSignalTimeout);
-                reject(createStreamInterruptedError());
-              },
-              { once: true },
-            );
-          }),
-      );
-    sandbox.fs.readdir.mockResolvedValueOnce(["first.ts", "second.ts"]);
+    sandbox.fs.stat.mockResolvedValueOnce({ isDirectory: () => true });
+    sandbox.runCommand.mockImplementationOnce(
+      async (input: { signal?: AbortSignal }) =>
+        await new Promise<never>((_resolve, reject) => {
+          markCommandStarted();
+          const missingSignalTimeout = setTimeout(
+            () => reject(new Error("abort signal was not propagated")),
+            100,
+          );
+          input.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(missingSignalTimeout);
+              reject(createStreamInterruptedError());
+            },
+            { once: true },
+          );
+        }),
+    );
     sandboxGetMock.mockResolvedValueOnce(sandbox);
 
     const executor = createTestSandbox({
@@ -1645,12 +1643,13 @@ describe("createTestSandbox", () => {
       input: { pattern: "*.ts" },
       signal: controller.signal,
     });
-    await entryStatStarted;
+    await commandStarted;
 
     controller.abort(abortReason);
 
     await expect(operation).rejects.toBe(abortReason);
-    expect(sandbox.fs.stat).toHaveBeenCalledTimes(2);
+    expect(sandbox.fs.stat).toHaveBeenCalledTimes(1);
+    expect(sandbox.runCommand).toHaveBeenCalledTimes(1);
   });
 
   it("invalidates an unavailable sandbox and lets a later tool call recover", async () => {

--- a/packages/junior/tests/unit/sandbox/runtime-dependencies.test.ts
+++ b/packages/junior/tests/unit/sandbox/runtime-dependencies.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { GLOBAL_RUNTIME_DEPENDENCIES } from "@/chat/sandbox/runtime-dependencies";
+
+describe("global sandbox runtime dependencies", () => {
+  it("provisions the command-line tools used by core sandbox tools", () => {
+    expect(GLOBAL_RUNTIME_DEPENDENCIES).toEqual(
+      expect.arrayContaining([
+        { type: "system", package: "docker" },
+        { type: "system", package: "ripgrep" },
+      ]),
+    );
+  });
+});

--- a/packages/junior/tests/unit/tools/sandbox/file-tools.test.ts
+++ b/packages/junior/tests/unit/tools/sandbox/file-tools.test.ts
@@ -10,6 +10,7 @@ import { createGrepTool, grepFiles } from "@/chat/tools/sandbox/grep";
 import { listDir } from "@/chat/tools/sandbox/list-dir";
 import { sliceFileContent } from "@/chat/tools/sandbox/read-file";
 import type { SandboxFileSystem } from "@/chat/tools/sandbox/file-utils";
+import type { SandboxCommandRunner } from "@/chat/tools/sandbox/file-utils";
 import { ToolInputError } from "@/chat/tools/execution/tool-input-error";
 
 function workspacePath(filePath: string): string {
@@ -283,6 +284,140 @@ describe("sandbox file tools", () => {
         },
       },
     });
+  });
+
+  it("runs findFiles through ripgrep with ignore-aware argv", async () => {
+    const memory = createMemoryFs({
+      "src/app.ts": "content\n",
+      "src/nested/test.ts": "content\n",
+    });
+    const calls: Parameters<SandboxCommandRunner>[0][] = [];
+    const runCommand: SandboxCommandRunner = async (input) => {
+      calls.push(input);
+      return {
+        exitCode: 0,
+        stderr: "",
+        stdout: "src/app.ts\0src/nested/test.ts\0",
+      };
+    };
+
+    const result = await findFiles({
+      fs: memory.fs,
+      path: "src",
+      pattern: "*.ts",
+      runCommand,
+    });
+
+    expect(calls).toEqual([
+      {
+        cmd: "rg",
+        args: [
+          "--files",
+          "--null",
+          "--hidden",
+          "--sort=path",
+          "--glob",
+          "!.git/**",
+          "--glob",
+          "!node_modules/**",
+          "--glob",
+          "*.ts",
+          "--",
+          "src",
+        ],
+        cwd: SANDBOX_WORKSPACE_ROOT,
+      },
+    ]);
+    expect(result.details).toMatchObject({
+      ok: true,
+      data: {
+        files: ["app.ts", "nested/test.ts"],
+        file_count: 2,
+      },
+    });
+  });
+
+  it("parses bounded ripgrep JSON without shell interpolation", async () => {
+    const memory = createMemoryFs({
+      "src/app.ts": "before\nneedle\nafter\n",
+    });
+    const calls: Parameters<SandboxCommandRunner>[0][] = [];
+    const event = (type: "context" | "match", line: number, text: string) =>
+      JSON.stringify({
+        type,
+        data: {
+          path: { text: "src/app.ts" },
+          lines: { text: `${text}\n` },
+          line_number: line,
+        },
+      });
+    const runCommand: SandboxCommandRunner = async (input) => {
+      calls.push(input);
+      return {
+        exitCode: 0,
+        stderr: "",
+        stdout: [
+          event("context", 1, "before"),
+          event("match", 2, "needle"),
+          event("context", 3, "after"),
+        ].join("\n"),
+      };
+    };
+
+    const result = await grepFiles({
+      context: 1,
+      fs: memory.fs,
+      literal: true,
+      path: "src",
+      pattern: "needle'; exit 9; '",
+      runCommand,
+    });
+
+    expect(calls[0]).toMatchObject({
+      cmd: "rg",
+      cwd: SANDBOX_WORKSPACE_ROOT,
+    });
+    expect(calls[0]?.args).toContain("--fixed-strings");
+    expect(calls[0]?.args).toContain("needle'; exit 9; '");
+    expect(result.details).toMatchObject({
+      ok: true,
+      data: {
+        lines: ["app.ts-1- before", "app.ts:2: needle", "app.ts-3- after"],
+        match_count: 1,
+      },
+    });
+  });
+
+  it("preserves ripgrep input and sandbox lifecycle failures", async () => {
+    const memory = createMemoryFs({
+      "src/app.ts": "content\n",
+    });
+    const invalidRegex: SandboxCommandRunner = async () => ({
+      exitCode: 2,
+      stderr: "regex parse error: unclosed character class",
+      stdout: "",
+    });
+
+    await expect(
+      grepFiles({
+        fs: memory.fs,
+        path: "src",
+        pattern: "[invalid",
+        runCommand: invalidRegex,
+      }),
+    ).rejects.toThrow(ToolInputError);
+
+    const lifecycleFailure = new Error("sandbox_stopped");
+    await expect(
+      findFiles({
+        fs: memory.fs,
+        path: "src",
+        pattern: "*.ts",
+        runCommand: async () => {
+          throw lifecycleFailure;
+        },
+      }),
+    ).rejects.toBe(lifecycleFailure);
   });
 
   it("prepares grep string booleans like the previous TypeBox schema", () => {

--- a/packages/junior/tests/unit/tools/sandbox/file-tools.test.ts
+++ b/packages/junior/tests/unit/tools/sandbox/file-tools.test.ts
@@ -317,11 +317,11 @@ describe("sandbox file tools", () => {
           "--hidden",
           "--sort=path",
           "--glob",
-          "!.git/**",
-          "--glob",
-          "!node_modules/**",
-          "--glob",
           "nested/*.ts",
+          "--glob",
+          "!**/.git/**",
+          "--glob",
+          "!**/node_modules/**",
           "--",
           ".",
         ],
@@ -378,9 +378,16 @@ describe("sandbox file tools", () => {
       cmd: "rg",
       cwd: workspacePath("src"),
     });
-    expect(calls[0]?.args).toContain("--fixed-strings");
-    expect(calls[0]?.args).toContain("nested/*.ts");
-    expect(calls[0]?.args).toContain("needle'; exit 9; '");
+    const args = calls[0]?.args ?? [];
+    expect(args).toContain("--fixed-strings");
+    expect(args).toContain("nested/*.ts");
+    expect(args).toContain("needle'; exit 9; '");
+    expect(args.indexOf("nested/*.ts")).toBeLessThan(
+      args.indexOf("!**/.git/**"),
+    );
+    expect(args.indexOf("nested/*.ts")).toBeLessThan(
+      args.indexOf("!**/node_modules/**"),
+    );
     expect(result.details).toMatchObject({
       ok: true,
       data: {

--- a/packages/junior/tests/unit/tools/sandbox/file-tools.test.ts
+++ b/packages/junior/tests/unit/tools/sandbox/file-tools.test.ts
@@ -297,14 +297,14 @@ describe("sandbox file tools", () => {
       return {
         exitCode: 0,
         stderr: "",
-        stdout: "src/app.ts\0src/nested/test.ts\0",
+        stdout: "nested/test.ts\0",
       };
     };
 
     const result = await findFiles({
       fs: memory.fs,
       path: "src",
-      pattern: "*.ts",
+      pattern: "nested/*.ts",
       runCommand,
     });
 
@@ -321,32 +321,32 @@ describe("sandbox file tools", () => {
           "--glob",
           "!node_modules/**",
           "--glob",
-          "*.ts",
+          "nested/*.ts",
           "--",
-          "src",
+          ".",
         ],
-        cwd: SANDBOX_WORKSPACE_ROOT,
+        cwd: workspacePath("src"),
       },
     ]);
     expect(result.details).toMatchObject({
       ok: true,
       data: {
-        files: ["app.ts", "nested/test.ts"],
-        file_count: 2,
+        files: ["nested/test.ts"],
+        file_count: 1,
       },
     });
   });
 
   it("parses bounded ripgrep JSON without shell interpolation", async () => {
     const memory = createMemoryFs({
-      "src/app.ts": "before\nneedle\nafter\n",
+      "src/nested/app.ts": "before\nneedle\nafter\n",
     });
     const calls: Parameters<SandboxCommandRunner>[0][] = [];
     const event = (type: "context" | "match", line: number, text: string) =>
       JSON.stringify({
         type,
         data: {
-          path: { text: "src/app.ts" },
+          path: { text: "nested/app.ts" },
           lines: { text: `${text}\n` },
           line_number: line,
         },
@@ -367,6 +367,7 @@ describe("sandbox file tools", () => {
     const result = await grepFiles({
       context: 1,
       fs: memory.fs,
+      glob: "nested/*.ts",
       literal: true,
       path: "src",
       pattern: "needle'; exit 9; '",
@@ -375,14 +376,19 @@ describe("sandbox file tools", () => {
 
     expect(calls[0]).toMatchObject({
       cmd: "rg",
-      cwd: SANDBOX_WORKSPACE_ROOT,
+      cwd: workspacePath("src"),
     });
     expect(calls[0]?.args).toContain("--fixed-strings");
+    expect(calls[0]?.args).toContain("nested/*.ts");
     expect(calls[0]?.args).toContain("needle'; exit 9; '");
     expect(result.details).toMatchObject({
       ok: true,
       data: {
-        lines: ["app.ts-1- before", "app.ts:2: needle", "app.ts-3- after"],
+        lines: [
+          "nested/app.ts-1- before",
+          "nested/app.ts:2: needle",
+          "nested/app.ts-3- after",
+        ],
         match_count: 1,
       },
     });


### PR DESCRIPTION
Sandbox `grep` and `findFiles` now use ripgrep for repository traversal and matching while preserving Junior's bounded, structured tool results. Ripgrep is installed in the cached sandbox runtime snapshot, commands receive model input as argv rather than interpolated shell text, and results retain existing match limits, context formatting, line truncation, and missing-path behavior.

Search now honors `.gitignore`, `.ignore`, and `.rgignore` while still searching hidden files and unconditionally excluding `.git` and `node_modules`. Regex patterns consequently use ripgrep's regex syntax instead of JavaScript `RegExp`; invalid patterns remain structured tool-input failures, and sandbox lifecycle failures continue to propagate to the owning recovery boundary.
