### PR TITLE
ref(chat)!: store native agent history events

### DIFF
--- a/TERMINOLOGY.md
+++ b/TERMINOLOGY.md
@@ -25,9 +25,9 @@ Canonical words used across Junior's code and documentation.
 - **Run**: one bounded attempt to advance a turn. A later run may resume the
   same turn after a pause, yield, or recoverable failure.
 - **Execution slice**: one serverless invocation segment of a run.
-- **Agent step**: one replayable entry in agent history, stored as an
-  `agent_step` event. Tool calls belong to the assistant step that requested
-  them; each tool result is a separate step.
+- **Agent history item**: one replayable model input or output, stored as a
+  `user_message`, `assistant_message`, or `tool_result` event. Tool calls remain
+  ordered content inside the assistant message that requested them.
 - **History replacement**: an explicit compaction or handoff that supplies the
   agent history used by later turns. It is stored as the corresponding event,
   not as a generic context-start marker.
@@ -42,7 +42,7 @@ Canonical words used across Junior's code and documentation.
 - **Message update**: later delivery or hydration state for an existing
   message, stored as a `message_updated` event without creating another message.
 - **Transcript**: a reporting view rendered from stored messages and agent
-  steps. It is not the stored data itself.
+  history items. It is not the stored data itself.
 - **Session record**: the persisted read model for one resumable turn.
 - **Conversation execution**: mutable operational state for a conversation,
   such as mailbox state, worker lease, checkpoints, and activity status.
@@ -53,9 +53,11 @@ Canonical words used across Junior's code and documentation.
 
 ## Naming Guidance
 
-- Use `turn`, `run`, `slice`, and `step` only with the meanings above.
-- Use `message` for chat content and `agent_step` for replayable agent history;
-  do not use `model_item` or `model_message` as Junior-owned terms.
+- Use `turn`, `run`, and `slice` only with the meanings above.
+- Use `message` for platform chat content. Use `user_message`,
+  `assistant_message`, and `tool_result` for replayable agent history.
+- Use `agent history item` when referring to those three native event types as
+  a group; do not use `model_item` or `model_message`.
 - Use `turnId` for new identifiers representing a turn.
 - Use `reply` only for destination-visible messages; execution code should use
   `turn`, `run`, `result`, `outcome`, or `delivery` as appropriate.

--- a/packages/docs/src/content/docs/cli/upgrade.md
+++ b/packages/docs/src/content/docs/cli/upgrade.md
@@ -42,6 +42,14 @@ release is ready. If Junior reports this unsupported database state:
 
 Fresh databases without Junior tables do not require the bridge release.
 
+## Native agent-history migration
+
+When upgrading from a release that writes `agent_step` conversation events,
+block new ingress, drain active and resumable work, and stop all old workers
+before running `junior upgrade`. Deploy the new runtime before restarting
+workers or reopening ingress. The migration rewrites existing history once, so
+an old worker that remains active could append a legacy event after the rewrite.
+
 ## Example output
 
 An already-current database reports its migrations as existing:

--- a/packages/junior/migrations/0010_native_conversation_history.sql
+++ b/packages/junior/migrations/0010_native_conversation_history.sql
@@ -1,0 +1,142 @@
+DO $$
+BEGIN
+	IF EXISTS (
+		SELECT 1
+		FROM "junior_conversation_events"
+		WHERE "schema_version" = 1
+			AND "type" = 'agent_step'
+			AND (
+				jsonb_typeof("payload") IS DISTINCT FROM 'object'
+				OR jsonb_typeof("payload"->'message') IS DISTINCT FROM 'object'
+				OR "payload"->'message'->>'role' IS NULL
+				OR "payload"->'message'->>'role' NOT IN ('user', 'assistant', 'toolResult')
+			)
+	) THEN
+		RAISE EXCEPTION 'Cannot migrate malformed agent_step conversation events';
+	END IF;
+
+	IF EXISTS (
+		SELECT 1
+		FROM "junior_conversation_events" AS "event"
+		WHERE "event"."schema_version" = 1
+			AND "event"."type" IN ('compaction', 'handoff', 'rollback')
+			AND (
+				jsonb_typeof("event"."payload") IS DISTINCT FROM 'object'
+				OR jsonb_typeof("event"."payload"->'replacementHistory') IS DISTINCT FROM 'array'
+			)
+	) THEN
+		RAISE EXCEPTION 'Cannot migrate malformed conversation history replacements';
+	END IF;
+
+	IF EXISTS (
+		SELECT 1
+		FROM "junior_conversation_events" AS "event"
+		CROSS JOIN LATERAL jsonb_array_elements(
+			"event"."payload"->'replacementHistory'
+		) AS "replacement"("item")
+		WHERE "event"."schema_version" = 1
+			AND "event"."type" IN ('compaction', 'handoff', 'rollback')
+			AND (
+				jsonb_typeof("replacement"."item") IS DISTINCT FROM 'object'
+				OR (
+					"replacement"."item" ? 'message'
+					AND (
+						jsonb_typeof("replacement"."item"->'message') IS DISTINCT FROM 'object'
+						OR "replacement"."item"->'message'->>'role' IS NULL
+						OR "replacement"."item"->'message'->>'role' NOT IN ('user', 'assistant', 'toolResult')
+					)
+				)
+				OR (
+					NOT ("replacement"."item" ? 'message')
+					AND (
+						jsonb_typeof("replacement"."item"->'item') IS DISTINCT FROM 'object'
+						OR "replacement"."item"->'item'->>'type' IS NULL
+						OR "replacement"."item"->'item'->>'type' NOT IN ('user_message', 'assistant_message', 'tool_result')
+						OR "replacement"."item"->'item' ? 'role'
+						OR (
+							"replacement"."item"->'item'->>'type' = 'user_message'
+							AND jsonb_typeof("replacement"."item"->'item'->'provenance') IS DISTINCT FROM 'object'
+						)
+					)
+				)
+			)
+	) THEN
+		RAISE EXCEPTION 'Cannot migrate malformed replacement history items';
+	END IF;
+END $$;
+--> statement-breakpoint
+UPDATE "junior_conversation_events"
+SET
+	"type" = CASE "payload"->'message'->>'role'
+		WHEN 'user' THEN 'user_message'
+		WHEN 'assistant' THEN 'assistant_message'
+		WHEN 'toolResult' THEN 'tool_result'
+	END,
+	"payload" = CASE "payload"->'message'->>'role'
+		WHEN 'user' THEN
+			(("payload"->'message') - 'role')
+			|| jsonb_build_object(
+				'provenance',
+				coalesce("payload"->'provenance', '{"authority":"context"}'::jsonb)
+			)
+		ELSE ("payload"->'message') - 'role'
+	END
+WHERE "schema_version" = 1
+	AND "type" = 'agent_step';
+--> statement-breakpoint
+UPDATE "junior_conversation_events" AS "event"
+SET "payload" = jsonb_set(
+	"event"."payload",
+	'{replacementHistory}',
+	(
+		SELECT coalesce(
+			jsonb_agg(
+				CASE
+					WHEN "replacement"."item" ? 'message' THEN
+						(("replacement"."item" - 'message') - 'provenance')
+						|| jsonb_build_object(
+							'item',
+							CASE "replacement"."item"->'message'->>'role'
+								WHEN 'user' THEN
+									(("replacement"."item"->'message') - 'role')
+									|| jsonb_build_object('type', 'user_message')
+									|| jsonb_build_object(
+										'provenance',
+										coalesce(
+											"replacement"."item"->'provenance',
+											'{"authority":"context"}'::jsonb
+										)
+									)
+								WHEN 'assistant' THEN
+									(("replacement"."item"->'message') - 'role')
+									|| jsonb_build_object('type', 'assistant_message')
+								WHEN 'toolResult' THEN
+									(("replacement"."item"->'message') - 'role')
+									|| jsonb_build_object('type', 'tool_result')
+							END
+						)
+					ELSE "replacement"."item"
+				END
+				ORDER BY "replacement"."position"
+			),
+			'[]'::jsonb
+		)
+		FROM jsonb_array_elements(
+			"event"."payload"->'replacementHistory'
+		) WITH ORDINALITY AS "replacement"("item", "position")
+	)
+)
+WHERE "event"."schema_version" = 1
+	AND "event"."type" IN ('compaction', 'handoff', 'rollback')
+	AND EXISTS (
+		SELECT 1
+		FROM jsonb_array_elements(
+			"event"."payload"->'replacementHistory'
+		) AS "replacement"("item")
+		WHERE "replacement"."item" ? 'message'
+	);
+--> statement-breakpoint
+UPDATE "junior_conversation_events"
+SET "type" = 'compaction'
+WHERE "schema_version" = 1
+	AND "type" = 'rollback';

--- a/packages/junior/migrations/meta/0010_snapshot.json
+++ b/packages/junior/migrations/meta/0010_snapshot.json
@@ -1,0 +1,1190 @@
+{
+  "id": "c0925d95-c4c3-4647-8bae-a365dcf2920d",
+  "prevId": "a28495fc-55ba-423b-b4ab-a5e16a85444f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.junior_api_tokens": {
+      "name": "junior_api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email_normalized": {
+          "name": "owner_email_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_suffix": {
+          "name": "token_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_api_tokens_token_hash_uidx": {
+          "name": "junior_api_tokens_token_hash_uidx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_api_tokens_owner_email_idx": {
+          "name": "junior_api_tokens_owner_email_idx",
+          "columns": [
+            {
+              "expression": "owner_email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversation_annotations": {
+      "name": "junior_conversation_annotations",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin": {
+          "name": "plugin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "annotation_json": {
+          "name": "annotation_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "junior_conversation_annotations_conversation_id_fk": {
+          "name": "junior_conversation_annotations_conversation_id_fk",
+          "tableFrom": "junior_conversation_annotations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "tableTo": "junior_conversations",
+          "columnsTo": [
+            "conversation_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_conversation_annotations_pk": {
+          "name": "junior_conversation_annotations_pk",
+          "columns": [
+            "conversation_id",
+            "plugin",
+            "kind",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversation_events": {
+      "name": "junior_conversation_events",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "history_version": {
+          "name": "history_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_conversation_events_history_version_idx": {
+          "name": "junior_conversation_events_history_version_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "history_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_conversation_events_type_idx": {
+          "name": "junior_conversation_events_type_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_conversation_events_message_search_idx": {
+          "name": "junior_conversation_events_message_search_idx",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"payload\"->>'text')",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "where": "\"junior_conversation_events\".\"type\" = 'message'",
+          "concurrently": false
+        },
+        "junior_conversation_events_idempotency_idx": {
+          "name": "junior_conversation_events_idempotency_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "junior_conversation_events_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversation_events_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversation_events",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "tableTo": "junior_conversations",
+          "columnsTo": [
+            "conversation_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_conversation_events_conversation_id_seq_pk": {
+          "name": "junior_conversation_events_conversation_id_seq_pk",
+          "columns": [
+            "conversation_id",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversations": {
+      "name": "junior_conversations",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_type": {
+          "name": "origin_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_id": {
+          "name": "origin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_run_id": {
+          "name": "origin_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_json": {
+          "name": "destination_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity_id": {
+          "name": "actor_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_identity_id": {
+          "name": "creator_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_subject_identity_id": {
+          "name": "credential_subject_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_json": {
+          "name": "actor_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_updated_at": {
+          "name": "execution_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_status": {
+          "name": "execution_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_checkpoint_at": {
+          "name": "last_checkpoint_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_enqueued_at": {
+          "name": "last_enqueued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_conversation_id": {
+          "name": "parent_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_conversation_id": {
+          "name": "root_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_purged_at": {
+          "name": "transcript_purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "usage_json": {
+          "name": "usage_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_duration_ms": {
+          "name": "execution_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "execution_usage_json": {
+          "name": "execution_usage_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metric_run_id": {
+          "name": "metric_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_conversations_last_activity_idx": {
+          "name": "junior_conversations_last_activity_idx",
+          "columns": [
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_conversations_active_idx": {
+          "name": "junior_conversations_active_idx",
+          "columns": [
+            {
+              "expression": "coalesce(\"execution_updated_at\", \"updated_at\")",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"junior_conversations\".\"execution_status\" <> 'idle'",
+          "concurrently": false
+        },
+        "junior_conversations_destination_activity_idx": {
+          "name": "junior_conversations_destination_activity_idx",
+          "columns": [
+            {
+              "expression": "destination_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_conversations_actor_activity_idx": {
+          "name": "junior_conversations_actor_activity_idx",
+          "columns": [
+            {
+              "expression": "actor_identity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_conversations_origin_idx": {
+          "name": "junior_conversations_origin_idx",
+          "columns": [
+            {
+              "expression": "origin_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "origin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_conversations_parent_idx": {
+          "name": "junior_conversations_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_conversations_root_idx": {
+          "name": "junior_conversations_root_idx",
+          "columns": [
+            {
+              "expression": "root_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "junior_conversations_destination_id_junior_destinations_id_fk": {
+          "name": "junior_conversations_destination_id_junior_destinations_id_fk",
+          "tableFrom": "junior_conversations",
+          "columnsFrom": [
+            "destination_id"
+          ],
+          "tableTo": "junior_destinations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "junior_conversations_actor_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversations_actor_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversations",
+          "columnsFrom": [
+            "actor_identity_id"
+          ],
+          "tableTo": "junior_identities",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "junior_conversations_creator_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversations_creator_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversations",
+          "columnsFrom": [
+            "creator_identity_id"
+          ],
+          "tableTo": "junior_identities",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "junior_conversations_credential_subject_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversations_credential_subject_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversations",
+          "columnsFrom": [
+            "credential_subject_identity_id"
+          ],
+          "tableTo": "junior_identities",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "junior_conversations_parent_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversations_parent_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversations",
+          "columnsFrom": [
+            "parent_conversation_id"
+          ],
+          "tableTo": "junior_conversations",
+          "columnsTo": [
+            "conversation_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "junior_conversations_root_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversations_root_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversations",
+          "columnsFrom": [
+            "root_conversation_id"
+          ],
+          "tableTo": "junior_conversations",
+          "columnsTo": [
+            "conversation_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_destinations": {
+      "name": "junior_destinations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_tenant_id": {
+          "name": "provider_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "provider_destination_id": {
+          "name": "provider_destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_destination_id": {
+          "name": "parent_destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_destinations_provider_destination_uidx": {
+          "name": "junior_destinations_provider_destination_uidx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_destination_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_destinations_provider_kind_idx": {
+          "name": "junior_destinations_provider_kind_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_identities": {
+      "name": "junior_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_tenant_id": {
+          "name": "provider_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "provider_subject_id": {
+          "name": "provider_subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_normalized": {
+          "name": "email_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "junior_identities_provider_subject_uidx": {
+          "name": "junior_identities_provider_subject_uidx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_identities_user_idx": {
+          "name": "junior_identities_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "junior_identities_verified_email_idx": {
+          "name": "junior_identities_verified_email_idx",
+          "columns": [
+            {
+              "expression": "email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"junior_identities\".\"email_verified\" = true AND \"junior_identities\".\"email_normalized\" IS NOT NULL",
+          "concurrently": false
+        },
+        "junior_identities_kind_provider_idx": {
+          "name": "junior_identities_kind_provider_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "junior_identities_user_id_junior_users_id_fk": {
+          "name": "junior_identities_user_id_junior_users_id_fk",
+          "tableFrom": "junior_identities",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "junior_users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_users": {
+      "name": "junior_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "primary_email": {
+          "name": "primary_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_email_normalized": {
+          "name": "primary_email_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_users_primary_email_normalized_uidx": {
+          "name": "junior_users_primary_email_normalized_uidx",
+          "columns": [
+            {
+              "expression": "primary_email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/junior/migrations/meta/_journal.json
+++ b/packages/junior/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1785209518342,
       "tag": "0009_slippery_harrier",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1785211716838,
+      "tag": "0010_native_conversation_history",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/junior/src/api/conversations/event-page.ts
+++ b/packages/junior/src/api/conversations/event-page.ts
@@ -159,7 +159,7 @@ async function projectConversationEventRows(
  *
  * Source rows are scanned in bounded chunks until the requested projected page
  * and one older event are known. This keeps ordinary pages bounded without
- * assuming every canonical agent step produces a reporting event.
+ * assuming every agent history event produces a reporting event.
  */
 export async function readConversationEventPage(
   executor: JuniorSqlDatabase,

--- a/packages/junior/src/api/conversations/events.ts
+++ b/packages/junior/src/api/conversations/events.ts
@@ -10,7 +10,8 @@ import {
 export const conversationReportSourceEventTypes = [
   "message",
   "message_handled",
-  "agent_step",
+  "assistant_message",
+  "tool_result",
   "tool_execution_started",
   "turn_started",
   "turn_routed",
@@ -24,7 +25,7 @@ export const conversationReportSourceEventTypes = [
 
 const reportingAssistantMessageSchema = z
   .object({
-    role: z.literal("assistant"),
+    type: z.literal("assistant_message"),
     content: z.array(z.unknown()),
   })
   .passthrough();
@@ -40,7 +41,7 @@ const reportingToolCallPartSchema = z
 
 const reportingToolResultMessageSchema = z
   .object({
-    role: z.literal("toolResult"),
+    type: z.literal("tool_result"),
     toolCallId: z.string().min(1),
     toolName: z.string().min(1).optional(),
     name: z.string().min(1).optional(),
@@ -105,7 +106,7 @@ function modelVisibleToolOutput(content: unknown[]): unknown {
   return only.type === "text" ? only.text : only;
 }
 
-/** Project canonical Pi tool calls into the narrow reporting contract. */
+/** Project native assistant tool calls into the narrow reporting contract. */
 function reportToolCalls(args: {
   canExposePayload: boolean;
   createdAtMs: number;
@@ -134,7 +135,7 @@ function reportToolCalls(args: {
   return calls.length > 0 ? { type: "tool_calls", calls } : undefined;
 }
 
-/** Project a Pi tool result without exposing host-only result details. */
+/** Project a native tool result without exposing host-only result details. */
 function reportToolResult(args: {
   canExposePayload: boolean;
   message: unknown;
@@ -181,10 +182,7 @@ export function conversationReportToolResultIds(
   return [
     ...new Set(
       events.flatMap((event) => {
-        if (event.data.type !== "agent_step") return [];
-        const result = reportingToolResultMessageSchema.safeParse(
-          event.data.message,
-        );
+        const result = reportingToolResultMessageSchema.safeParse(event.data);
         return result.success ? [result.data.toolCallId] : [];
       }),
     ),
@@ -308,16 +306,17 @@ export function projectConversationReportEventPage(args: {
 
   for (const event of args.events) {
     let data: ConversationReportEventData | undefined;
-    if (event.data.type === "agent_step") {
+    if (
+      event.data.type === "assistant_message" ||
+      event.data.type === "tool_result"
+    ) {
       const reportArgs = {
         canExposePayload: args.canExposePayload,
         createdAtMs: event.createdAtMs,
-        message: event.data.message,
+        message: event.data,
         seq: event.seq,
       };
-      const result = reportingToolResultMessageSchema.safeParse(
-        event.data.message,
-      );
+      const result = reportingToolResultMessageSchema.safeParse(event.data);
       const start = result.success
         ? toolStarts.get(result.data.toolCallId)
         : undefined;
@@ -325,7 +324,7 @@ export function projectConversationReportEventPage(args: {
         reportToolCalls(reportArgs) ??
         reportToolResult({
           canExposePayload: args.canExposePayload,
-          message: event.data.message,
+          message: event.data,
           ...(start && start.seq < event.seq ? { start } : {}),
         });
     } else if (event.data.type === "tool_execution_started") {

--- a/packages/junior/src/chat/README.md
+++ b/packages/junior/src/chat/README.md
@@ -48,7 +48,7 @@ the production singleton.
 - **Conversation**: durable identity shared by messages and agent state.
 - **Turn**: one response-producing execution for accumulated user input.
 - **Run**: one bounded attempt to advance a turn; a turn may span resumed runs.
-- **Step**: one persisted agent-history entry.
+- **Agent history item**: one persisted replayable model input or output.
 - **History replacement**: explicit agent-history reset after compaction or handoff.
 - **Reply**: one destination-visible assistant message owned by delivery code.
 - **Actor**: human or system principal associated with current work.

--- a/packages/junior/src/chat/conversations/README.md
+++ b/packages/junior/src/chat/conversations/README.md
@@ -8,37 +8,43 @@ This module owns Junior's durable conversation record, search, and retention.
 has a stable `(conversation_id, seq)` identity, an event type, a versioned JSON
 payload, and a timestamp.
 
-Two primary event types intentionally describe different facts:
+Platform transcript and agent-history events intentionally describe different
+facts:
 
 - `message` records exact source or destination chat content. It is the
   authority for transcript display, delivery handling, privacy, and search.
-- `agent_step` records one replayable Pi history entry. It is the authority for
-  the next agent request and may contain transformed input, assistant tool
-  calls, or tool results that were never chat messages.
+- `user_message`, `assistant_message`, and `tool_result` record native,
+  replayable agent-history items. They are the authority for the next model
+  request and may contain transformed input, assistant tool calls, or tool
+  results that were never platform chat messages.
+
+`user_message` provenance distinguishes user instructions from ambient context.
+Tool calls remain ordered content inside the `assistant_message` that produced
+them; the corresponding results are separate `tool_result` events.
 
 `message_updated` records later delivery or hydration state for an existing
 message. It updates that message's projection without pretending the same chat
 message arrived twice. `message_handled` remains the compact lifecycle fact
 used to prevent redelivery.
 
-A chat message and an agent step can correspond to the same turn, but they are
-not interchangeable. For example, delivered fallback text is a `message` even
-when it is not part of Pi history, while a tool result is an `agent_step` even
-though it is never delivered as a chat message. Keeping both facts in the same
-ordered event stream avoids a second transcript authority without conflating
-product history with agent history.
+A platform message and an agent-history item can correspond to the same turn,
+but they are not interchangeable. For example, delivered fallback text is a
+`message` even when it is not part of Pi history, while a `tool_result` is never
+delivered as a platform message. Keeping both facts in the same ordered event
+stream avoids a second transcript authority without conflating product history
+with agent history.
 
 Search queries `message` payloads directly through the partial GIN index on the
 event table. There is no message projection table.
 
 ## Agent History Replacement
 
-Normal execution appends `agent_step` events. `compaction` and `handoff` are
-the only live events that replace active agent history. Each stores the exact
-replacement history; later `agent_step` events append to it. The internal
-`history_version` column makes loading that active history efficient. There is
-no initial-history event. Rollback events written by the required `0.107.1`
-bridge remain read-compatible but are never written by the current runtime.
+Normal execution appends native agent-history events. `compaction` and
+`handoff` are the only live events that replace active agent history. Each
+stores the exact replacement history in the same native shapes; later native
+events append to it. The internal `history_version` column makes loading that
+active history efficient. There is no initial-history event. Database migrations
+normalize older history shapes before the runtime reads them.
 
 Volatile `<runtime-turn-context>` bootstrap is kept only in an unfinished turn's
 session record. It is removed before SQL history is written and restored for an
@@ -52,7 +58,7 @@ older source-thread context; it does not replace Pi history.
 
 - Persist inbound `message` events before agent execution.
 - Persist assistant `message` events only after destination acceptance.
-- Append stable `agent_step` events in sequence order.
+- Append stable native agent-history events in sequence order.
 - Reject attempts to mutate an already committed agent-history prefix.
 - Replace agent history only through explicit compaction or handoff.
 - Restore transcripts and agent history directly from conversation events.
@@ -80,9 +86,10 @@ to `unknown`.
 
 ## Visibility And Retention
 
-Destination visibility is the privacy authority. Messages, agent steps, child
-conversations, and plugin projections inherit it. Retention distinguishes
-expired content from redacted content and purges the complete child tree.
+Destination visibility is the privacy authority. Messages, agent-history
+items, child conversations, and plugin projections inherit it. Retention
+distinguishes expired content from redacted content and purges the complete
+child tree.
 
 Every conversation row carries its owning `root_conversation_id`. Roots
 self-reference; descendants copy the root from their immediate parent when
@@ -113,6 +120,10 @@ Follow `../../../../../policies/data-redaction.md` and
   complete the `0.107.1` bridge upgrade before installing a later release.
 - Keep old workers stopped between the bridge upgrade and the later deployment
   so they cannot write legacy state after it has been imported.
+- Upgrades from releases that write `agent_step` events must also block ingress,
+  drain active and resumable work, and stop old workers before running the
+  native agent-history migration. Deploy the new runtime before restarting
+  workers so legacy rows cannot be appended after the one-time rewrite.
 - Current `junior upgrade` runs only core and enabled-plugin Drizzle SQL
   migrations. Live workers restore history exclusively from conversation
   events.

--- a/packages/junior/src/chat/conversations/history.ts
+++ b/packages/junior/src/chat/conversations/history.ts
@@ -18,40 +18,57 @@ const handoffModelProfileSchema = modelProfileSchema.refine(
   "handoff profile must not be standard",
 );
 
-/** Store one opaque agent-step payload while Pi owns provider validation. */
-export const conversationAgentStepPayloadSchema = z
-  .object({ role: z.string() })
-  .passthrough()
-  .transform((value) => value as { role: string });
-
-/** The opaque Pi history entry carried by an `agent_step` event. */
-export type ConversationAgentStepPayload = z.output<
-  typeof conversationAgentStepPayloadSchema
->;
-
-const conversationMessageDataSchema = z
+const userMessageEventDataSchema = z
   .object({
-    message: conversationAgentStepPayloadSchema,
-    provenance: conversationMessageProvenanceSchema.optional(),
+    type: z.literal("user_message"),
+    role: z.never().optional(),
+    provenance: conversationMessageProvenanceSchema,
+  })
+  .passthrough();
+
+const assistantMessageEventDataSchema = z
+  .object({
+    type: z.literal("assistant_message"),
+    role: z.never().optional(),
+  })
+  .passthrough();
+
+const toolResultEventDataSchema = z
+  .object({
+    type: z.literal("tool_result"),
+    role: z.never().optional(),
+  })
+  .passthrough();
+
+/**
+ * One replayable agent-history item. Junior owns `type` and user provenance,
+ * forbids the provider `role` discriminator, and leaves preserved message
+ * fields for the Pi adapter to validate when restoring model context.
+ */
+export const agentHistoryItemSchema = z.discriminatedUnion("type", [
+  userMessageEventDataSchema,
+  assistantMessageEventDataSchema,
+  toolResultEventDataSchema,
+]);
+
+/** A native replayable agent-history item. */
+export type AgentHistoryItem = z.output<typeof agentHistoryItemSchema>;
+
+const nativeReplacementHistoryItemSchema = z
+  .object({
+    item: agentHistoryItemSchema,
+    // Preserve the copied item's position when a turn resumes. Synthetic
+    // summary and handoff items have no source event.
+    sourceEventSeq: z.number().int().nonnegative().optional(),
   })
   .strict();
 
-const agentStepEventDataSchema = conversationMessageDataSchema.extend({
-  type: z.literal("agent_step"),
-});
-
-const replacementHistoryMessageSchema = conversationMessageDataSchema.extend({
-  // Preserve the copied message's position when a turn resumes. Synthetic
-  // summary and handoff messages have no source event.
-  sourceEventSeq: z.number().int().nonnegative().optional(),
-});
-
 /**
  * The complete agent history used immediately after a replacement. Later
- * `agent_step` events append to it. These entries are replayed model input, not
- * new conversation activity.
+ * native history events append to it. Replacement entries are replayed model
+ * history, not new conversation activity.
  */
-const replacementHistorySchema = z.array(replacementHistoryMessageSchema);
+const replacementHistorySchema = z.array(nativeReplacementHistoryItemSchema);
 
 const compactionDetailsSchema = z
   .object({
@@ -89,17 +106,6 @@ const historyReplacementEventDataSchema = z.discriminatedUnion("type", [
     })
     .strict(),
 ]);
-
-// Read-only compatibility for rollback histories persisted by the 0.107.1
-// bridge. Live writers cannot create this event through replaceHistory().
-const legacyRollbackEventDataSchema = z
-  .object({
-    type: z.literal("rollback"),
-    modelProfile: modelProfileSchema,
-    modelId: z.string().min(1),
-    replacementHistory: replacementHistorySchema,
-  })
-  .strict();
 
 /** Validate an event that intentionally replaces active model history. */
 export const historyReplacementSchema = z
@@ -302,7 +308,7 @@ const subagentEndedEventDataSchema = z
 const appendableConversationEventDataSchema = z.union([
   messageEventDataSchema,
   messageUpdatedEventDataSchema,
-  agentStepEventDataSchema,
+  agentHistoryItemSchema,
   mcpProviderConnectedEventDataSchema,
   authorizationRequestedEventDataSchema,
   authorizationCompletedEventDataSchema,
@@ -321,7 +327,6 @@ const appendableConversationEventDataSchema = z.union([
 export const conversationEventDataSchema = z.union([
   appendableConversationEventDataSchema,
   historyReplacementEventDataSchema,
-  legacyRollbackEventDataSchema,
 ]);
 
 /** One durable conversation event's validated data. */
@@ -331,11 +336,13 @@ export type ConversationEventData = z.output<
 
 // This list distinguishes unsupported rows from corrupt known rows. Add every
 // canonical event type here with its data schema.
-/** Canonical event type names accepted by live writers and observational queries. */
+/** Event type names recognized by current readers and observational queries. */
 export const KNOWN_CONVERSATION_EVENT_TYPES = [
   "message",
   "message_updated",
-  "agent_step",
+  "user_message",
+  "assistant_message",
+  "tool_result",
   "mcp_provider_connected",
   "authorization_requested",
   "authorization_completed",
@@ -350,7 +357,6 @@ export const KNOWN_CONVERSATION_EVENT_TYPES = [
   "subagent_ended",
   "handoff",
   "compaction",
-  "rollback",
 ] as const;
 
 /** One known durable conversation event type name. */
@@ -491,8 +497,8 @@ export interface ConversationEventStore {
     conversationId: string,
     idempotencyKey: string,
   ): Promise<ConversationEvent | undefined>;
-  /** Latest durable user instruction across history versions. */
-  loadLatestInstructionStep(
+  /** Latest durable instruction across history versions. */
+  loadLatestInstruction(
     conversationId: string,
   ): Promise<ConversationEvent | undefined>;
   /** Events of the current history version in `seq` order. */

--- a/packages/junior/src/chat/conversations/projection.ts
+++ b/packages/junior/src/chat/conversations/projection.ts
@@ -20,6 +20,7 @@ import type { JuniorSqlDatabase } from "@/db/db";
 import { createSqlConversationEventStore } from "@/chat/conversations/sql/history";
 import { withConversationEventLock } from "@/chat/conversations/sql/event-lock";
 import {
+  historyItemFromPiMessage,
   projectConversationEvents,
   type PiConversationEventProjection,
   type PiConversationProjection,
@@ -85,10 +86,13 @@ function resolveCommitProvenance(args: {
     }
     return args.explicitProvenance;
   }
+  if (args.existing.provenance.length !== args.existing.messages.length) {
+    throw new Error("committed provenance must align one-to-one with messages");
+  }
   const matchingPrefix = args.matchingPrefix;
   const provenance = args.nextMessages.map((_, index) =>
     index < matchingPrefix
-      ? (args.existing.provenance[index] ?? contextProvenance)
+      ? args.existing.provenance[index]!
       : contextProvenance,
   );
   if (args.newMessageProvenance) {
@@ -208,7 +212,7 @@ function messageTimestamp(message: PiMessage): number {
 }
 
 /**
- * Append newly stable agent steps. A shorter or changed prefix indicates
+ * Append newly stable native history items. A shorter or changed prefix indicates
  * that a caller persisted volatile Pi state; only compaction and handoff may
  * intentionally replace active model history.
  */
@@ -226,7 +230,7 @@ export async function commitMessages(args: {
 }): Promise<{
   committedSeq: number;
   historyVersion: number;
-  /** Event sequence for every projected agent step. */
+  /** Event sequence for every projected agent history item. */
   messageSeqs: number[];
   /** Normalized durable messages after volatile runtime context is removed. */
   messages: PiMessage[];
@@ -279,11 +283,10 @@ async function commitMessagesLocked(
     await eventStore.append(
       args.conversationId,
       newMessages.map((message, index) => ({
-        data: {
-          type: "agent_step" as const,
+        data: historyItemFromPiMessage(
           message,
-          provenance: nextLocalProvenance[matchingPrefix + index]!,
-        },
+          nextLocalProvenance[matchingPrefix + index]!,
+        ),
         createdAtMs: messageTimestamp(message),
       })),
     );

--- a/packages/junior/src/chat/conversations/sql/history.ts
+++ b/packages/junior/src/chat/conversations/sql/history.ts
@@ -277,7 +277,7 @@ class SqlConversationEventStore implements ConversationEventStore {
     return rows.map(eventFromRow);
   }
 
-  async loadLatestInstructionStep(
+  async loadLatestInstruction(
     conversationId: string,
   ): Promise<ConversationEvent | undefined> {
     const [row] = await this.executor
@@ -287,8 +287,7 @@ class SqlConversationEventStore implements ConversationEventStore {
       .where(
         and(
           eq(juniorConversationEvents.conversationId, conversationId),
-          eq(juniorConversationEvents.type, "agent_step"),
-          sql`${juniorConversationEvents.payload}->'message'->>'role' = 'user'`,
+          eq(juniorConversationEvents.type, "user_message"),
           sql`${juniorConversationEvents.payload}->'provenance'->>'authority' = 'instruction'`,
         ),
       )

--- a/packages/junior/src/chat/pi/conversation-events.ts
+++ b/packages/junior/src/chat/pi/conversation-events.ts
@@ -8,18 +8,13 @@ import type { ModelProfile } from "@/chat/model-profile";
 import type {
   ConversationEvent,
   ConversationEventData,
+  AgentHistoryItem,
 } from "@/chat/conversations/history";
+import { agentHistoryItemSchema } from "@/chat/conversations/history";
 import { piMessageSchema, type PiMessage } from "@/chat/pi/messages";
 import { stripRuntimeTurnContext } from "@/chat/pi/transcript";
-import {
-  contextProvenance,
-  type ConversationMessageProvenance,
-} from "@/chat/conversations/provenance";
-
-type AgentStepEventData = Extract<
-  ConversationEventData,
-  { type: "agent_step" }
->;
+import { type ConversationMessageProvenance } from "@/chat/conversations/provenance";
+import { contextProvenance } from "@/chat/conversations/provenance";
 type AuthorizationCompletedEventData = Extract<
   ConversationEventData,
   { type: "authorization_completed" }
@@ -55,20 +50,65 @@ function authorizationObservationMessage(
   });
 }
 
-function messageEventProvenance(
-  data: AgentStepEventData,
-): ConversationMessageProvenance {
-  return data.provenance ?? contextProvenance;
+function durableMessages(message: PiMessage): PiMessage[] {
+  return stripRuntimeTurnContext([message]);
 }
 
-function durableMessages(message: unknown): PiMessage[] {
-  return stripRuntimeTurnContext([piMessageSchema.parse(message)]);
+/** Translate one Pi message into Junior's native durable history item. */
+export function historyItemFromPiMessage(
+  message: PiMessage,
+  provenance: ConversationMessageProvenance,
+): AgentHistoryItem {
+  const parsed = piMessageSchema.parse(message) as PiMessage & {
+    role: string;
+  };
+  const { role, ...fields } = parsed;
+  if (role === "user") {
+    return agentHistoryItemSchema.parse({
+      ...fields,
+      type: "user_message",
+      provenance,
+    });
+  }
+  if (role === "assistant") {
+    return agentHistoryItemSchema.parse({
+      ...fields,
+      type: "assistant_message",
+    });
+  }
+  if (role === "toolResult") {
+    return agentHistoryItemSchema.parse({
+      ...fields,
+      type: "tool_result",
+    });
+  }
+  throw new Error(`Unsupported durable agent message role "${role}"`);
+}
+
+/** Translate one Junior-native history item into the Pi message it represents. */
+export function piMessageFromHistoryItem(data: AgentHistoryItem): PiMessage {
+  if (data.type === "user_message") {
+    const { type: _, provenance: __, ...fields } = data;
+    return piMessageSchema.parse({ ...fields, role: "user" });
+  }
+  if (data.type === "assistant_message") {
+    const { type: _, ...fields } = data;
+    return piMessageSchema.parse({ ...fields, role: "assistant" });
+  }
+  const { type: _, ...fields } = data;
+  return piMessageSchema.parse({ ...fields, role: "toolResult" });
+}
+
+function historyItemProvenance(
+  data: AgentHistoryItem,
+): ConversationMessageProvenance {
+  return data.type === "user_message" ? data.provenance : contextProvenance;
 }
 
 /**
  * Project ordered Junior events into Pi context.
  *
- * Compaction and handoff start with replacement history. Later agent-step
+ * Compaction and handoff start with replacement history. Later native history
  * events append after it.
  *
  * Host-only events are filtered, completed authorization becomes a synthetic
@@ -93,26 +133,30 @@ export function projectConversationEvents(
         `Unsupported conversation event "${event.data.originalType}" at seq ${event.seq} (schema version ${event.schemaVersion})`,
       );
     }
-    if (
-      event.data.type === "compaction" ||
-      event.data.type === "handoff" ||
-      event.data.type === "rollback"
-    ) {
+    if (event.data.type === "compaction" || event.data.type === "handoff") {
       modelProfile = event.data.modelProfile;
       modelId = event.data.modelId;
       for (const replacement of event.data.replacementHistory) {
-        for (const message of durableMessages(replacement.message)) {
+        for (const message of durableMessages(
+          piMessageFromHistoryItem(replacement.item),
+        )) {
           messages.push(message);
-          provenance.push(replacement.provenance ?? contextProvenance);
+          provenance.push(historyItemProvenance(replacement.item));
           seqs.push(replacement.sourceEventSeq ?? event.seq);
         }
       }
       continue;
     }
-    if (event.data.type === "agent_step") {
-      for (const message of durableMessages(event.data.message)) {
+    if (
+      event.data.type === "user_message" ||
+      event.data.type === "assistant_message" ||
+      event.data.type === "tool_result"
+    ) {
+      for (const message of durableMessages(
+        piMessageFromHistoryItem(event.data),
+      )) {
         messages.push(message);
-        provenance.push(messageEventProvenance(event.data));
+        provenance.push(historyItemProvenance(event.data));
         seqs.push(event.seq);
       }
       continue;

--- a/packages/junior/src/chat/pi/sql-model-usage.ts
+++ b/packages/junior/src/chat/pi/sql-model-usage.ts
@@ -1,4 +1,4 @@
-/** SQL reporting adapter for usage stored on assistant agent steps. */
+/** SQL reporting adapter for usage stored on assistant history events. */
 import { and, eq, sql, type SQL } from "drizzle-orm";
 import type { JuniorSqlDatabase } from "@/db/db";
 import { juniorConversationEvents, juniorConversations } from "@/db/schema";
@@ -9,7 +9,7 @@ import {
   type AgentTurnUsage,
 } from "@/chat/usage";
 
-const message = sql`${juniorConversationEvents.payload}->'message'`;
+const message = sql`${juniorConversationEvents.payload}`;
 const usage = sql`${message}->'usage'`;
 const cost = sql`${usage}->'cost'`;
 
@@ -163,8 +163,7 @@ export async function readConversationModelUsageFromSql(
         options.includeDescendants
           ? eq(juniorConversations.rootConversationId, options.conversationId)
           : eq(juniorConversationEvents.conversationId, options.conversationId),
-        eq(juniorConversationEvents.type, "agent_step"),
-        sql`${message}->>'role' = 'assistant'`,
+        eq(juniorConversationEvents.type, "assistant_message"),
         sql`jsonb_typeof(${message}->'provider') = 'string'`,
         sql`jsonb_typeof(${message}->'model') = 'string'`,
         sql`coalesce(${message}->>'provider', '') <> ''`,

--- a/packages/junior/src/chat/services/context-compaction.ts
+++ b/packages/junior/src/chat/services/context-compaction.ts
@@ -32,6 +32,10 @@ import {
   stripRuntimeTurnContext,
   trimTrailingAssistantMessages,
 } from "@/chat/pi/transcript";
+import {
+  historyItemFromPiMessage,
+  piMessageFromHistoryItem,
+} from "@/chat/pi/conversation-events";
 import { updateConversationStats } from "@/chat/services/conversation-memory";
 import { modelIdForProfile, type ModelProfile } from "@/chat/model-profile";
 import {
@@ -380,22 +384,30 @@ function buildReplacementProvenance(args: {
   sourceProvenance: ConversationMessageProvenance[];
 }): ConversationMessageProvenance[] {
   return [
-    ...args.retained.map(
-      (entry) => args.sourceProvenance[entry.sourceIndex] ?? contextProvenance,
-    ),
+    ...args.retained.map((entry) => {
+      const provenance = args.sourceProvenance[entry.sourceIndex];
+      if (!provenance) {
+        throw new Error("retained message provenance is missing");
+      }
+      return provenance;
+    }),
     contextProvenance,
   ];
 }
 
 async function loadLastInstruction(conversationId: string) {
   const event =
-    await getConversationEventStore().loadLatestInstructionStep(conversationId);
-  if (event?.data.type !== "agent_step") return undefined;
-  return {
-    message: event.data.message as PiMessage,
-    provenance: event.data.provenance,
-    sourceEventSeq: event.seq,
-  };
+    await getConversationEventStore().loadLatestInstruction(conversationId);
+  if (!event) return undefined;
+  if (event.data.type === "user_message") {
+    if (event.data.provenance.authority !== "instruction") return undefined;
+    return {
+      message: piMessageFromHistoryItem(event.data),
+      provenance: event.data.provenance,
+      sourceEventSeq: event.seq,
+    };
+  }
+  return undefined;
 }
 
 type CompactionSource =
@@ -530,8 +542,10 @@ async function writeCompactedThreadContext(
             ? sourceProjection.seqs[retained[index]!.sourceIndex]
             : undefined;
         return {
-          message,
-          provenance: replacementProvenance[index]!,
+          item: historyItemFromPiMessage(
+            message,
+            replacementProvenance[index]!,
+          ),
           ...(sourceEventSeq === undefined ? {} : { sourceEventSeq }),
         };
       }),
@@ -601,8 +615,7 @@ export async function compactContextForHandoff(
         : {}),
       summary: generatedSummary,
       replacementHistory: replacementMessages.map((replacementMessage) => ({
-        message: replacementMessage,
-        provenance: contextProvenance,
+        item: historyItemFromPiMessage(replacementMessage, contextProvenance),
       })),
     },
   });
@@ -704,6 +717,11 @@ export async function compactActiveContextIfNeeded(
     );
   }
   const replacementMessages = stripRuntimeTurnContext(messages);
+  if (replacementMessages.length !== 1 + instructionProvenance.length) {
+    throw new Error(
+      "persisted instruction provenance must align one-to-one with messages",
+    );
+  }
   args.signal?.throwIfAborted();
   await getConversationEventStore().replaceHistory(args.conversationId, {
     createdAtMs: Date.now(),
@@ -722,16 +740,16 @@ export async function compactActiveContextIfNeeded(
         summaryChars: summary.length,
       },
       summary,
-      replacementHistory: replacementMessages.map((message, index) => ({
-        message,
-        provenance:
-          index === 0
-            ? contextProvenance
-            : (instructionProvenance[index - 1] ?? contextProvenance),
-        ...(index === 1 && retainedInstruction
-          ? { sourceEventSeq: retainedInstruction.sourceEventSeq }
-          : {}),
-      })),
+      replacementHistory: replacementMessages.map((message, index) => {
+        const provenance =
+          index === 0 ? contextProvenance : instructionProvenance[index - 1]!;
+        return {
+          item: historyItemFromPiMessage(message, provenance),
+          ...(index === 1 && retainedInstruction
+            ? { sourceEventSeq: retainedInstruction.sourceEventSeq }
+            : {}),
+        };
+      }),
     },
   });
   setSpanAttributes({

--- a/packages/junior/src/chat/tools/query-conversation-events.ts
+++ b/packages/junior/src/chat/tools/query-conversation-events.ts
@@ -362,11 +362,7 @@ function stripReplacementHistory(
       payload: stripReplacementHistoryField(data.payload),
     };
   }
-  if (
-    data.type === "compaction" ||
-    data.type === "handoff" ||
-    data.type === "rollback"
-  ) {
+  if (data.type === "compaction" || data.type === "handoff") {
     return stripReplacementHistoryField(data) as Record<string, unknown>;
   }
   return data;

--- a/packages/junior/tests/component/conversation-storage-sql.test.ts
+++ b/packages/junior/tests/component/conversation-storage-sql.test.ts
@@ -6,6 +6,7 @@ import { createSqlConversationEventStore } from "@/chat/conversations/sql/histor
 import {
   conversationEventDataSchema,
   conversationEventSchema,
+  newConversationEventSchema,
 } from "@/chat/conversations/history";
 import { getConversationEventStore } from "@/chat/db";
 import { purgeConversation } from "@/chat/conversations/retention";
@@ -76,7 +77,7 @@ it("accepts compaction and handoff as the only live history replacements", () =>
   }
 });
 
-it("rejects unknown Junior event fields while retaining opaque message fields", () => {
+it("rejects unknown fields and legacy agent-step writes", () => {
   expect(
     conversationEventDataSchema.safeParse({
       type: "message",
@@ -124,9 +125,20 @@ it("rejects unknown Junior event fields while retaining opaque message fields", 
     }).success,
   ).toBe(false);
   expect(
+    newConversationEventSchema.safeParse({
+      data: {
+        type: "agent_step",
+        message: { role: "", providerOwnedField: true },
+      },
+      createdAtMs: 1,
+    }).success,
+  ).toBe(false);
+  expect(
     conversationEventDataSchema.safeParse({
-      type: "agent_step",
-      message: { role: "", providerOwnedField: true },
+      type: "user_message",
+      content: [{ type: "provider_owned", value: true }],
+      timestamp: 1,
+      provenance: { authority: "context" },
     }).success,
   ).toBe(true);
 });
@@ -294,6 +306,19 @@ function userMessage(text: string) {
   };
 }
 
+function userMessageEvent(
+  text: string,
+  authority: "instruction" | "context" = "context",
+) {
+  const { content, timestamp } = userMessage(text);
+  return {
+    type: "user_message" as const,
+    content,
+    timestamp,
+    provenance: { authority },
+  };
+}
+
 describe("SQL conversation storage", () => {
   it("persists visible-context compaction snapshots in conversation history", async () => {
     const events = getConversationEventStore();
@@ -349,11 +374,11 @@ describe("SQL conversation storage", () => {
 
       await store.append(CONVERSATION_ID, [
         {
-          data: { type: "agent_step", message: userMessage("one") },
+          data: userMessageEvent("one"),
           createdAtMs: 1_000,
         },
         {
-          data: { type: "agent_step", message: userMessage("two") },
+          data: userMessageEvent("two"),
           createdAtMs: 2_000,
         },
       ]);
@@ -368,8 +393,8 @@ describe("SQL conversation storage", () => {
       expect(history.map((event) => event.seq)).toEqual([0, 1, 2]);
       expect(history.map((event) => event.schemaVersion)).toEqual([1, 1, 1]);
       expect(history.map((event) => event.data.type)).toEqual([
-        "agent_step",
-        "agent_step",
+        "user_message",
+        "user_message",
         "mcp_provider_connected",
       ]);
 
@@ -393,7 +418,7 @@ describe("SQL conversation storage", () => {
     }
   });
 
-  it("loads the latest user instruction step", async () => {
+  it("loads the latest user instruction", async () => {
     const fixture = await createLocalJuniorSqlFixture();
 
     try {
@@ -403,44 +428,28 @@ describe("SQL conversation storage", () => {
 
       await store.append(CONVERSATION_ID, [
         {
-          data: {
-            type: "agent_step",
-            message: userMessage("first instruction"),
-            provenance: { authority: "instruction" },
-          },
+          data: userMessageEvent("first instruction", "instruction"),
           createdAtMs: 1_000,
         },
         {
-          data: {
-            type: "agent_step",
-            message: userMessage("ambient context"),
-            provenance: { authority: "context" },
-          },
+          data: userMessageEvent("ambient context"),
           createdAtMs: 2_000,
         },
         {
-          data: {
-            type: "agent_step",
-            message: { role: "assistant" },
-            provenance: { authority: "instruction" },
-          },
+          data: { type: "mcp_provider_connected", provider: "github" },
           createdAtMs: 3_000,
         },
         {
-          data: {
-            type: "agent_step",
-            message: userMessage("latest instruction"),
-            provenance: { authority: "instruction" },
-          },
+          data: userMessageEvent("latest instruction", "instruction"),
           createdAtMs: 4_000,
         },
       ]);
 
-      const event = await store.loadLatestInstructionStep(CONVERSATION_ID);
+      const event = await store.loadLatestInstruction(CONVERSATION_ID);
       expect(event?.seq).toBe(3);
       expect(event?.data).toMatchObject({
-        type: "agent_step",
-        message: userMessage("latest instruction"),
+        type: "user_message",
+        content: userMessage("latest instruction").content,
         provenance: { authority: "instruction" },
       });
     } finally {
@@ -455,7 +464,7 @@ describe("SQL conversation storage", () => {
       await migrateSchema(fixture.sql);
       const store = createSqlConversationEventStore(fixture.sql);
       const firstEvent = {
-        data: { type: "agent_step" as const, message: userMessage("first") },
+        data: userMessageEvent("first"),
         idempotencyKey: "event:first",
         createdAtMs: 1_000,
       };
@@ -494,7 +503,7 @@ describe("SQL conversation storage", () => {
       await store.append(CONVERSATION_ID, [
         { ...firstEvent, createdAtMs: 10_000 },
         {
-          data: { type: "agent_step", message: userMessage("second") },
+          data: userMessageEvent("second"),
           idempotencyKey: "event:second",
           createdAtMs: 8_000,
         },
@@ -616,22 +625,15 @@ describe("SQL conversation storage", () => {
 
       await store.append(CONVERSATION_ID, [
         {
-          data: {
-            type: "agent_step",
-            message: userMessage("before\u0000after and literal \\u0000"),
-          },
+          data: userMessageEvent("before\u0000after and literal \\u0000"),
           createdAtMs: 1_000,
         },
       ]);
 
       expect((await store.loadHistory(CONVERSATION_ID))[0]?.data).toMatchObject(
         {
-          type: "agent_step",
-          message: {
-            content: [
-              { text: "before after and literal \\u0000", type: "text" },
-            ],
-          },
+          type: "user_message",
+          content: [{ text: "before after and literal \\u0000", type: "text" }],
         },
       );
     } finally {
@@ -649,11 +651,11 @@ describe("SQL conversation storage", () => {
 
       await store.append(CONVERSATION_ID, [
         {
-          data: { type: "agent_step", message: userMessage("epoch0-a") },
+          data: userMessageEvent("epoch0-a"),
           createdAtMs: 1_000,
         },
         {
-          data: { type: "agent_step", message: userMessage("epoch0-b") },
+          data: userMessageEvent("epoch0-b"),
           createdAtMs: 2_000,
         },
       ]);
@@ -663,7 +665,7 @@ describe("SQL conversation storage", () => {
           type: "compaction",
           modelProfile: "standard",
           modelId: "test/model",
-          replacementHistory: [{ message: userMessage("epoch1-summary") }],
+          replacementHistory: [{ item: userMessageEvent("epoch1-summary") }],
         },
       });
 
@@ -689,11 +691,11 @@ describe("SQL conversation storage", () => {
 
       await store.append(CONVERSATION_ID, [
         {
-          data: { type: "agent_step", message: userMessage("epoch0-a") },
+          data: userMessageEvent("epoch0-a"),
           createdAtMs: 1_000,
         },
         {
-          data: { type: "agent_step", message: userMessage("epoch0-b") },
+          data: userMessageEvent("epoch0-b"),
           createdAtMs: 2_000,
         },
       ]);
@@ -703,7 +705,7 @@ describe("SQL conversation storage", () => {
           type: "compaction",
           modelProfile: "standard",
           modelId: "test/model",
-          replacementHistory: [{ message: userMessage("epoch1-summary") }],
+          replacementHistory: [{ item: userMessageEvent("epoch1-summary") }],
         },
       });
       await store.append(CONVERSATION_ID, [
@@ -718,7 +720,7 @@ describe("SQL conversation storage", () => {
           type: "compaction",
           modelId: "test/model",
           modelProfile: "standard",
-          replacementHistory: [{ message: userMessage("epoch2-message") }],
+          replacementHistory: [{ item: userMessageEvent("epoch2-message") }],
         },
       });
 
@@ -757,7 +759,7 @@ describe("SQL conversation storage", () => {
       const store = createSqlConversationEventStore(fixture.sql);
       await store.append(CONVERSATION_ID, [
         {
-          data: { type: "agent_step", message: userMessage("committed") },
+          data: userMessageEvent("committed"),
           createdAtMs: 1_000,
         },
         {
@@ -942,7 +944,7 @@ WHERE conversation_id = $1 AND seq = 0
       const store = createSqlConversationEventStore(fixture.sql);
       await store.append(CONVERSATION_ID, [
         {
-          data: { type: "agent_step", message: userMessage("epoch0") },
+          data: userMessageEvent("epoch0"),
           createdAtMs: 1_000,
         },
       ]);
@@ -966,7 +968,7 @@ WHERE conversation_id = $1 AND seq = 0
             type: "compaction",
             modelId: "test/model",
             modelProfile: "standard",
-            replacementHistory: [{ message: userMessage("never") }],
+            replacementHistory: [{ item: userMessageEvent("never") }],
           },
         }),
       ).rejects.toThrow("epoch write failed");
@@ -1240,14 +1242,14 @@ INSERT INTO junior_conversation_events (
       // Event appends advance the clock too, and also never regress it.
       await events.append(CONVERSATION_ID, [
         {
-          data: { type: "agent_step", message: userMessage("newest") },
+          data: userMessageEvent("newest"),
           createdAtMs: 8_000,
         },
       ]);
       expect(await lastActivityMs()).toBe(8_000);
       await events.append(CONVERSATION_ID, [
         {
-          data: { type: "agent_step", message: userMessage("backdated") },
+          data: userMessageEvent("backdated"),
           createdAtMs: 3_000,
         },
       ]);
@@ -1269,7 +1271,7 @@ INSERT INTO junior_conversation_events (
       for (const conversationId of [CONVERSATION_ID, CHILD_CONVERSATION_ID]) {
         await events.append(conversationId, [
           {
-            data: { type: "agent_step", message: userMessage("hi") },
+            data: userMessageEvent("hi"),
             createdAtMs: 1_000,
           },
           {
@@ -1305,7 +1307,7 @@ INSERT INTO junior_conversation_events (
 
       await events.append(CONVERSATION_ID, [
         {
-          data: { type: "agent_step", message: userMessage("new history") },
+          data: userMessageEvent("new history"),
           createdAtMs: 6_000,
         },
         {

--- a/packages/junior/tests/component/plugins/plugin-tasks.test.ts
+++ b/packages/junior/tests/component/plugins/plugin-tasks.test.ts
@@ -18,6 +18,39 @@ const destination = {
   conversationId,
 } as const;
 
+function testPiMessages(messages: Array<Record<string, unknown>>): PiMessage[] {
+  return messages.map((message, index) => {
+    const timestamp = index + 1;
+    if (message.role === "assistant") {
+      return {
+        api: "openai-responses",
+        provider: "openai",
+        model: "test-model",
+        usage: {},
+        stopReason: "stop",
+        timestamp,
+        ...message,
+        content:
+          typeof message.content === "string"
+            ? [{ type: "text", text: message.content }]
+            : message.content,
+      } as PiMessage;
+    }
+    if (message.role === "toolResult") {
+      return {
+        toolCallId: `test-call-${index}`,
+        timestamp,
+        ...message,
+        content:
+          typeof message.content === "string"
+            ? [{ type: "text", text: message.content }]
+            : (message.content ?? []),
+      } as PiMessage;
+    }
+    return { timestamp, ...message } as PiMessage;
+  });
+}
+
 class PluginTaskQueueTestAdapter {
   #messages: PluginTaskQueueMessage[] = [];
 
@@ -49,7 +82,7 @@ async function recordCompletedSession(args: {
       userId: "local-cli",
       userName: "local",
     },
-    piMessages: [
+    piMessages: testPiMessages([
       {
         role: "user",
         content: "Run a completed session task.",
@@ -58,7 +91,7 @@ async function recordCompletedSession(args: {
         role: "assistant",
         content: "Done.",
       },
-    ] as PiMessage[],
+    ]),
     sessionId: args.sessionId,
     sliceId: 1,
     source: createLocalSource(args.conversationId),
@@ -140,7 +173,7 @@ describe("plugin background tasks", () => {
       modelId: "test/model",
       conversationId: runConversationId,
       destination: runDestination,
-      piMessages: [
+      piMessages: testPiMessages([
         {
           role: "user",
           content: "Remember that stale prior turn data must not leak.",
@@ -174,7 +207,7 @@ describe("plugin background tasks", () => {
           role: "assistant",
           content: "Understood.",
         },
-      ] as PiMessage[],
+      ]),
       sessionId: runSessionId,
       sliceId: 1,
       source: runSource,
@@ -303,13 +336,13 @@ describe("plugin background tasks", () => {
       modelId: "test/model",
       conversationId: runConversationId,
       destination: { ...destination, conversationId: runConversationId },
-      piMessages: [
+      piMessages: testPiMessages([
         {
           role: "user",
           content: [{ type: "text", text: embeddedUserText }],
         },
         { role: "assistant", content: "Here are the takeaways." },
-      ] as PiMessage[],
+      ]),
       sessionId: runSessionId,
       sliceId: 1,
       source: runSource,
@@ -428,10 +461,10 @@ describe("plugin background tasks", () => {
       modelId: "test/model",
       conversationId: slackConversationId,
       destination: { platform: "slack", teamId, channelId },
-      piMessages: [
+      piMessages: testPiMessages([
         { role: "user", content: "Deploy the release now." },
         { role: "assistant", content: "On it." },
-      ] as PiMessage[],
+      ]),
       sessionId: slackSessionId,
       sliceId: 1,
       source,
@@ -524,10 +557,10 @@ describe("plugin background tasks", () => {
       modelId: "test/model",
       conversationId: slackConversationId,
       destination: { platform: "slack", teamId, channelId },
-      piMessages: [
+      piMessages: testPiMessages([
         { role: "user", content: "Summarize the thread context." },
         { role: "assistant", content: "On it." },
-      ] as PiMessage[],
+      ]),
       sessionId: slackSessionId,
       sliceId: 1,
       source,
@@ -619,10 +652,10 @@ describe("plugin background tasks", () => {
       modelId: "test/model",
       conversationId: runConversationId,
       destination: { ...destination, conversationId: runConversationId },
-      piMessages: [
+      piMessages: testPiMessages([
         { role: "user", content: "Run a legacy system task." },
         { role: "assistant", content: "Done." },
-      ] as PiMessage[],
+      ]),
       sessionId: runSessionId,
       sliceId: 1,
       source: runSource,
@@ -726,10 +759,10 @@ describe("plugin background tasks", () => {
       modelId: "test/model",
       conversationId: slackConversationId,
       destination: { platform: "slack", teamId, channelId },
-      piMessages: [
+      piMessages: testPiMessages([
         { role: "user", content: "Handle this direct message." },
         { role: "assistant", content: "Sure." },
-      ] as PiMessage[],
+      ]),
       sessionId: slackSessionId,
       sliceId: 1,
       source,

--- a/packages/junior/tests/component/runtime/agent-run-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/component/runtime/agent-run-mcp-progressive-loading.test.ts
@@ -93,6 +93,32 @@ const TEST_ACTOR = {
 } as const;
 
 vi.mock("@earendil-works/pi-agent-core", () => {
+  function assistantMessage(text: string) {
+    return {
+      role: "assistant",
+      content: [{ type: "text", text }],
+      api: "openai-responses",
+      provider: "openai",
+      model: "test-model",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+        },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    };
+  }
+
   class MockAgent {
     state: {
       messages: unknown[];
@@ -166,10 +192,7 @@ vi.mock("@earendil-works/pi-agent-core", () => {
         };
       } catch (error) {
         loadSkillExecutionErrorCount.value += 1;
-        this.state.messages.push({
-          role: "assistant",
-          content: [{ type: "text", text: "loading demo skill" }],
-        });
+        this.state.messages.push(assistantMessage("loading demo skill"));
         throw error;
       }
       this.state.messages.push({
@@ -179,22 +202,14 @@ vi.mock("@earendil-works/pi-agent-core", () => {
         isError: false,
         details: loadSkillResult.details,
         content: [{ type: "text", text: "loaded" }],
+        timestamp: Date.now(),
       });
       if (this.aborted) {
-        this.state.messages.push({
-          role: "assistant",
-          content: [
-            {
-              type: "text",
-              text: completeEmptyAssistantOnAbort.value
-                ? ""
-                : "loading demo skill",
-            },
-          ],
-          ...(completeEmptyAssistantOnAbort.value
-            ? { stopReason: "stop" }
-            : {}),
-        });
+        this.state.messages.push(
+          assistantMessage(
+            completeEmptyAssistantOnAbort.value ? "" : "loading demo skill",
+          ),
+        );
         return {};
       }
       if (loadSkillResult.details?.mcp_provider) {
@@ -225,11 +240,7 @@ vi.mock("@earendil-works/pi-agent-core", () => {
         tool_name: "mcp__demo__ping",
         arguments: { query: "hello" },
       });
-      this.state.messages.push({
-        role: "assistant",
-        content: [{ type: "text", text: "resumed reply" }],
-        stopReason: "stop",
-      });
+      this.state.messages.push(assistantMessage("resumed reply"));
       return {};
     }
 
@@ -272,11 +283,7 @@ vi.mock("@earendil-works/pi-agent-core", () => {
       if (this.aborted && continueStopsOnAbort.value) {
         return {};
       }
-      this.state.messages.push({
-        role: "assistant",
-        content: [{ type: "text", text: "resumed reply" }],
-        stopReason: "stop",
-      });
+      this.state.messages.push(assistantMessage("resumed reply"));
       return {};
     }
   }
@@ -824,9 +831,11 @@ describe("executeAgentRun progressive MCP loading", () => {
             piMessages: [
               {
                 role: "toolResult",
+                toolCallId: "prior-call",
                 toolName: "callMcpTool",
                 isError: false,
                 content: [{ type: "text", text: "pong" }],
+                timestamp: 1,
                 input: {
                   tool_name: "mcp__demo__ping",
                   arguments: { query: "prior" },
@@ -861,9 +870,11 @@ describe("executeAgentRun progressive MCP loading", () => {
             piMessages: [
               {
                 role: "toolResult",
+                toolCallId: "prior-call",
                 toolName: "callMcpTool",
                 isError: false,
                 content: [{ type: "text", text: "pong" }],
+                timestamp: 1,
                 input: {
                   tool_name: "mcp__demo__ping",
                   arguments: { query: "prior" },
@@ -908,9 +919,11 @@ describe("executeAgentRun progressive MCP loading", () => {
       },
       {
         role: "toolResult",
+        toolCallId: "prior-call",
         toolName: "callMcpTool",
         isError: false,
         content: [{ type: "text", text: "pong" }],
+        timestamp: 2,
         input: {
           tool_name: "mcp__demo__ping",
           arguments: { query: "prior" },

--- a/packages/junior/tests/component/services/context-compaction.test.ts
+++ b/packages/junior/tests/component/services/context-compaction.test.ts
@@ -15,6 +15,11 @@ function assistant(text: string, timestamp = 1): PiMessage {
   return {
     role: "assistant",
     content: [{ type: "text", text }],
+    api: "openai-responses",
+    provider: "openai",
+    model: "test-model",
+    usage: {},
+    stopReason: "stop",
     timestamp,
   } as PiMessage;
 }
@@ -206,7 +211,7 @@ describe("context compaction projection reset", () => {
       user("Run the lookup.", 1),
       {
         ...assistant("Lookup complete.", 2),
-        provider: undefined,
+        responseId: undefined,
         usage: { input: 5, cached: undefined },
       } as unknown as PiMessage,
     ];
@@ -583,8 +588,16 @@ describe("context compaction projection reset", () => {
       summary: "Continue the multi-file implementation.",
       replacementHistory: [
         {
-          message: durableHandoffMessages[0],
-          provenance: { authority: "context" },
+          item: {
+            type: "user_message",
+            content: (
+              durableHandoffMessages[0] as {
+                content: unknown[];
+              }
+            ).content,
+            timestamp: 3,
+            provenance: { authority: "context" },
+          },
         },
       ],
     });

--- a/packages/junior/tests/component/services/turn-session-record.test.ts
+++ b/packages/junior/tests/component/services/turn-session-record.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@sentry/junior-plugin-api";
 import type { ConversationStore } from "@/chat/conversations/store";
 import type { PiMessage } from "@/chat/pi/messages";
+import { historyItemFromPiMessage } from "@/chat/pi/conversation-events";
 
 const ORIGINAL_ENV = { ...process.env };
 const SLACK_DESTINATION = {
@@ -26,6 +27,32 @@ function userMessage(text: string): PiMessage {
     content: [{ type: "text", text }],
     timestamp: Date.now(),
   };
+}
+
+function assistantMessage(text: string, timestamp: number): PiMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "openai-responses",
+    provider: "openai",
+    model: "test-model",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+      },
+    },
+    stopReason: "stop",
+    timestamp,
+  } as PiMessage;
 }
 
 function failingConversationStore(): ConversationStore {
@@ -491,11 +518,7 @@ describe("persistAuthPauseSessionRecord", () => {
       content: [{ type: "text", text: "current question" }],
       timestamp: 2,
     } as PiMessage;
-    const answer: PiMessage = {
-      role: "assistant",
-      content: [{ type: "text", text: "answer" }],
-      timestamp: 3,
-    } as PiMessage;
+    const answer = assistantMessage("answer", 3);
 
     await upsertAgentTurnSessionRecord({
       modelId: "test/model",
@@ -977,11 +1000,7 @@ describe("persistAuthPauseSessionRecord", () => {
           ],
           timestamp: 1,
         } as PiMessage,
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "done" }],
-          timestamp: 2,
-        } as PiMessage,
+        assistantMessage("done", 2),
       ],
       reasoningLevel: "high",
     });
@@ -1053,11 +1072,7 @@ describe("persistAuthPauseSessionRecord", () => {
     ];
     const unsafeAssistantBoundary: PiMessage[] = [
       ...userBoundary,
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "working" }],
-        timestamp: 2,
-      } as PiMessage,
+      assistantMessage("working", 2),
     ];
     const toolResultBoundary: PiMessage[] = [
       ...unsafeAssistantBoundary,
@@ -1066,6 +1081,7 @@ describe("persistAuthPauseSessionRecord", () => {
         toolCallId: "call-1",
         toolName: "bash",
         content: [{ type: "text", text: "ok" }],
+        isError: false,
         timestamp: 3,
       } as PiMessage,
     ];
@@ -1204,11 +1220,7 @@ describe("persistAuthPauseSessionRecord", () => {
       content: [{ type: "text", text: "help me" }],
       timestamp: 1,
     };
-    const unsafeAssistant = {
-      role: "assistant",
-      content: [{ type: "text", text: "not committed" }],
-      timestamp: 2,
-    } as PiMessage;
+    const unsafeAssistant = assistantMessage("not committed", 2);
     await upsertAgentTurnSessionRecord({
       modelId: "test/model",
       conversationId: "conversation-branch",
@@ -1294,11 +1306,7 @@ describe("persistAuthPauseSessionRecord", () => {
       content: [{ type: "text", text: "new request" }],
       timestamp: 2,
     };
-    const newFollowup: PiMessage = {
-      role: "assistant",
-      content: [{ type: "text", text: "new followup" }],
-      timestamp: 3,
-    } as PiMessage;
+    const newFollowup = assistantMessage("new followup", 3);
 
     const oldRecord = await upsertAgentTurnSessionRecord({
       modelId: "test/model",
@@ -1317,7 +1325,13 @@ describe("persistAuthPauseSessionRecord", () => {
           type: "compaction",
           modelProfile: "standard",
           modelId: "test/model",
-          replacementHistory: [{ message: newRequest }],
+          replacementHistory: [
+            {
+              item: historyItemFromPiMessage(newRequest, {
+                authority: "context",
+              }),
+            },
+          ],
         },
       },
     );
@@ -1390,7 +1404,13 @@ describe("persistAuthPauseSessionRecord", () => {
         modelProfile: "handoff",
         modelId: "openai/gpt-5.6-sol",
         triggeringToolCallId: "handoff-call",
-        replacementHistory: [{ message: handoffSummary }],
+        replacementHistory: [
+          {
+            item: historyItemFromPiMessage(handoffSummary, {
+              authority: "context",
+            }),
+          },
+        ],
       },
     });
 

--- a/packages/junior/tests/integration/agent-continue-slack.test.ts
+++ b/packages/junior/tests/integration/agent-continue-slack.test.ts
@@ -15,6 +15,7 @@ import type { SandboxWorkspace } from "@/chat/sandbox/workspace";
 import { createTools } from "@/chat/tools";
 import type { ToolRuntimeContext } from "@/chat/tools/types";
 import { deliverAssistantMessagesForTest } from "../fixtures/agent-runner";
+import { historyItemFromPiMessage } from "@/chat/pi/conversation-events";
 
 const executeAgentRunMock = vi.fn();
 
@@ -53,6 +54,19 @@ function makeDiagnostics() {
     toolErrorCount: 0,
     toolResultCount: 0,
     usedPrimaryText: true,
+  };
+}
+
+function assistantPiMessage(text: string, timestamp: number) {
+  return {
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text }],
+    api: "openai-responses" as const,
+    provider: "openai",
+    model: "fake-agent-model",
+    usage: TEST_USAGE,
+    stopReason: "stop" as const,
+    timestamp,
   };
 }
 
@@ -1217,9 +1231,7 @@ describe("agent continuation Slack integration", () => {
             timestamp: 1,
           },
           {
-            role: "assistant",
-            content: [{ type: "text", text: "Final resumed answer" }],
-            timestamp: 2,
+            ...assistantPiMessage("Final resumed answer", 2),
           },
         ] as any,
         diagnostics: makeDiagnostics(),
@@ -1379,7 +1391,13 @@ describe("agent continuation Slack integration", () => {
         modelId: "test/model",
         modelProfile: "handoff",
         triggeringToolCallId: "recovered-handoff-call",
-        replacementHistory: [{ message: summaryMessage }],
+        replacementHistory: [
+          {
+            item: historyItemFromPiMessage(summaryMessage, {
+              authority: "context",
+            }),
+          },
+        ],
       },
     });
     // A prior recovery can park runtime context in the handoff epoch before
@@ -1387,12 +1405,10 @@ describe("agent continuation Slack integration", () => {
     await getConversationEventStore().append(conversationId, [
       {
         data: {
-          type: "agent_step",
-          message: {
-            role: "user",
-            content: [{ type: "text", text: previousRuntimeContext }],
-            timestamp: 1,
-          } as any,
+          type: "user_message",
+          content: [{ type: "text", text: previousRuntimeContext }],
+          timestamp: 1,
+          provenance: { authority: "context" },
         },
         createdAtMs: 1,
       },
@@ -1440,11 +1456,7 @@ describe("agent continuation Slack integration", () => {
         text: "Handoff recovery completed.",
         piMessages: [
           summaryMessage,
-          {
-            role: "assistant",
-            content: [{ type: "text", text: "Handoff recovery completed." }],
-            timestamp: 6,
-          },
+          assistantPiMessage("Handoff recovery completed.", 6),
         ] as any,
         diagnostics: {
           ...makeDiagnostics(),

--- a/packages/junior/tests/integration/api/conversations/event-list.test.ts
+++ b/packages/junior/tests/integration/api/conversations/event-list.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { Hono } from "hono";
-import type { PiMessage } from "@/chat/pi/messages";
 import { createJuniorApi, type JuniorApiVariables } from "@/api";
 import {
   apiErrorSchema,
@@ -37,33 +36,30 @@ function message(messageId: string, createdAtMs: number) {
   };
 }
 
-function textAgentStep(createdAtMs: number, inputTokens = 0) {
+function assistantMessage(createdAtMs: number, inputTokens = 0) {
   return {
     data: {
-      type: "agent_step" as const,
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "not a reporting event" }],
-        api: "responses",
-        provider: "openai",
-        model: "gpt-5",
-        stopReason: "stop",
-        timestamp: createdAtMs,
-        usage: {
-          input: inputTokens,
+      type: "assistant_message" as const,
+      content: [{ type: "text", text: "not a reporting event" }],
+      api: "responses",
+      provider: "openai",
+      model: "gpt-5",
+      stopReason: "stop",
+      timestamp: createdAtMs,
+      usage: {
+        input: inputTokens,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: inputTokens,
+        cost: {
+          input: inputTokens / 1_000,
           output: 0,
           cacheRead: 0,
           cacheWrite: 0,
-          totalTokens: inputTokens,
-          cost: {
-            input: inputTokens / 1_000,
-            output: 0,
-            cacheRead: 0,
-            cacheWrite: 0,
-            total: inputTokens / 1_000,
-          },
+          total: inputTokens / 1_000,
         },
-      } as PiMessage,
+      },
     },
     createdAtMs,
   };
@@ -79,7 +75,7 @@ describe("conversation event list API", () => {
     await recordConversation(conversationId);
     await getConversationEventStore().append(conversationId, [
       message("message-1", 1),
-      textAgentStep(2),
+      assistantMessage(2),
       message("message-2", 3),
       message("message-3", 4),
       {
@@ -216,13 +212,12 @@ describe("conversation event list API", () => {
       },
       {
         data: {
-          type: "agent_step",
-          message: {
-            role: "toolResult",
-            toolCallId: "search-before-page",
-            content: [{ type: "text", text: "two matches" }],
-            isError: false,
-          } as PiMessage,
+          type: "tool_result",
+          toolCallId: "search-before-page",
+          toolName: "search",
+          content: [{ type: "text", text: "two matches" }],
+          isError: false,
+          timestamp: 3,
         },
         createdAtMs: 3,
       },
@@ -421,7 +416,7 @@ describe("conversation event list API", () => {
     await recordConversation(conversationId);
     await getConversationEventStore().append(conversationId, [
       message("expired-message-1", 1),
-      textAgentStep(2, 5),
+      assistantMessage(2, 5),
       message("expired-message-2", 3),
     ]);
 

--- a/packages/junior/tests/integration/conversation-sql.test.ts
+++ b/packages/junior/tests/integration/conversation-sql.test.ts
@@ -1,11 +1,15 @@
 import { fileURLToPath } from "node:url";
-import { getTableColumns, getTableName } from "drizzle-orm";
+import { eq, getTableColumns, getTableName } from "drizzle-orm";
 import { readMigrationFiles } from "drizzle-orm/migrator";
 import { describe, expect, it, vi } from "vitest";
 import { migrateSchema } from "@/chat/conversations/sql/migrations";
 import type { JuniorSqlMigrationExecutor } from "@/db/db";
 import { createPostgresJuniorSqlExecutor } from "@/db/postgres";
-import { juniorSqlSchema as schema } from "@/db/schema";
+import {
+  juniorConversationEvents,
+  juniorConversations,
+  juniorSqlSchema as schema,
+} from "@/db/schema";
 import { createSqlStore } from "@/chat/conversations/sql/store";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
 import { recordAgentTurnSessionSummary } from "@/chat/state/turn-session";
@@ -36,6 +40,266 @@ SELECT EXISTS (
 }
 
 describe("conversation SQL local mode", () => {
+  it("migrates legacy agent history to native event types", async () => {
+    const fixture = await createLocalJuniorSqlFixture();
+    const nativeHistoryMigrationIndex = coreMigrations.findIndex((migration) =>
+      migration.sql.some((statement) =>
+        statement.includes(
+          "Cannot migrate malformed agent_step conversation events",
+        ),
+      ),
+    );
+    const nativeHistoryMigration = coreMigrations[nativeHistoryMigrationIndex];
+    if (!nativeHistoryMigration) {
+      throw new Error("Native conversation history migration not found");
+    }
+
+    try {
+      for (const migration of coreMigrations.slice(
+        0,
+        nativeHistoryMigrationIndex,
+      )) {
+        for (const statement of migration.sql) {
+          await fixture.sql.execute(statement);
+        }
+      }
+
+      const conversationId = "internal:native-history-migration";
+      await fixture.sql
+        .db()
+        .insert(juniorConversations)
+        .values(buildJuniorSqlConversation({ conversationId }));
+      await fixture.sql
+        .db()
+        .insert(juniorConversationEvents)
+        .values([
+          {
+            conversationId,
+            seq: 0,
+            historyVersion: 0,
+            schemaVersion: 1,
+            type: "agent_step",
+            payload: {
+              message: {
+                role: "user",
+                content: "Investigate the failure",
+                timestamp: 1_000,
+              },
+            },
+            createdAt: new Date(1_000),
+          },
+          {
+            conversationId,
+            seq: 1,
+            historyVersion: 0,
+            schemaVersion: 1,
+            type: "agent_step",
+            payload: {
+              message: {
+                role: "assistant",
+                content: [],
+                api: "responses",
+                provider: "openai",
+                model: "gpt-5.4",
+                usage: {},
+                stopReason: "toolUse",
+                timestamp: 1_001,
+              },
+            },
+            createdAt: new Date(1_001),
+          },
+          {
+            conversationId,
+            seq: 2,
+            historyVersion: 0,
+            schemaVersion: 1,
+            type: "agent_step",
+            payload: {
+              message: {
+                role: "toolResult",
+                toolCallId: "call-1",
+                toolName: "search",
+                content: [],
+                isError: false,
+                timestamp: 1_002,
+              },
+            },
+            createdAt: new Date(1_002),
+          },
+          {
+            conversationId,
+            seq: 3,
+            historyVersion: 1,
+            schemaVersion: 1,
+            type: "rollback",
+            payload: {
+              modelProfile: "coding",
+              modelId: "openai/gpt-5.4",
+              replacementHistory: [
+                {
+                  message: {
+                    role: "user",
+                    type: "tool_result",
+                    content: "Retained instruction",
+                    timestamp: 1_000,
+                  },
+                  provenance: { authority: "instruction" },
+                  sourceEventSeq: 0,
+                },
+              ],
+            },
+            createdAt: new Date(1_003),
+          },
+        ]);
+
+      for (const statement of nativeHistoryMigration.sql) {
+        await fixture.sql.execute(statement);
+      }
+      // The transformation is safe if an operator reruns its SQL manually.
+      for (const statement of nativeHistoryMigration.sql) {
+        await fixture.sql.execute(statement);
+      }
+
+      const rows = await fixture.sql
+        .db()
+        .select({
+          type: juniorConversationEvents.type,
+          payload: juniorConversationEvents.payload,
+        })
+        .from(juniorConversationEvents)
+        .orderBy(juniorConversationEvents.seq);
+
+      expect(rows).toEqual([
+        {
+          type: "user_message",
+          payload: {
+            content: "Investigate the failure",
+            provenance: { authority: "context" },
+            timestamp: 1_000,
+          },
+        },
+        {
+          type: "assistant_message",
+          payload: {
+            api: "responses",
+            content: [],
+            model: "gpt-5.4",
+            provider: "openai",
+            stopReason: "toolUse",
+            timestamp: 1_001,
+            usage: {},
+          },
+        },
+        {
+          type: "tool_result",
+          payload: {
+            content: [],
+            isError: false,
+            timestamp: 1_002,
+            toolCallId: "call-1",
+            toolName: "search",
+          },
+        },
+        {
+          type: "compaction",
+          payload: {
+            modelId: "openai/gpt-5.4",
+            modelProfile: "coding",
+            replacementHistory: [
+              {
+                item: {
+                  content: "Retained instruction",
+                  provenance: { authority: "instruction" },
+                  timestamp: 1_000,
+                  type: "user_message",
+                },
+                sourceEventSeq: 0,
+              },
+            ],
+          },
+        },
+      ]);
+
+      await fixture.sql
+        .db()
+        .insert(juniorConversationEvents)
+        .values({
+          conversationId,
+          seq: 4,
+          historyVersion: 1,
+          schemaVersion: 1,
+          type: "agent_step",
+          payload: { message: { role: "system" } },
+          createdAt: new Date(1_004),
+        });
+      await expect(
+        (async () => {
+          for (const statement of nativeHistoryMigration.sql) {
+            await fixture.sql.execute(statement);
+          }
+        })(),
+      ).rejects.toThrow("Cannot migrate malformed agent_step");
+      const [malformed] = await fixture.sql
+        .db()
+        .select({
+          type: juniorConversationEvents.type,
+          payload: juniorConversationEvents.payload,
+        })
+        .from(juniorConversationEvents)
+        .where(eq(juniorConversationEvents.seq, 4));
+      expect(malformed).toEqual({
+        type: "agent_step",
+        payload: { message: { role: "system" } },
+      });
+
+      await fixture.sql
+        .db()
+        .delete(juniorConversationEvents)
+        .where(eq(juniorConversationEvents.seq, 4));
+      await fixture.sql
+        .db()
+        .insert(juniorConversationEvents)
+        .values({
+          conversationId,
+          seq: 4,
+          historyVersion: 1,
+          schemaVersion: 1,
+          type: "compaction",
+          payload: {
+            modelProfile: "standard",
+            modelId: "openai/gpt-5.4",
+            replacementHistory: [{}],
+          },
+          createdAt: new Date(1_004),
+        });
+      await expect(
+        (async () => {
+          for (const statement of nativeHistoryMigration.sql) {
+            await fixture.sql.execute(statement);
+          }
+        })(),
+      ).rejects.toThrow("Cannot migrate malformed replacement history items");
+      const [malformedReplacement] = await fixture.sql
+        .db()
+        .select({
+          type: juniorConversationEvents.type,
+          payload: juniorConversationEvents.payload,
+        })
+        .from(juniorConversationEvents)
+        .where(eq(juniorConversationEvents.seq, 4));
+      expect(malformedReplacement).toEqual({
+        type: "compaction",
+        payload: {
+          modelProfile: "standard",
+          modelId: "openai/gpt-5.4",
+          replacementHistory: [{}],
+        },
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+
   it("creates migrated tables matching the Drizzle schema", async () => {
     const fixture = await createLocalJuniorSqlFixture();
 

--- a/packages/junior/tests/integration/dashboard-reporting.test.ts
+++ b/packages/junior/tests/integration/dashboard-reporting.test.ts
@@ -4,6 +4,7 @@ import { readConversationDetail } from "@/api/conversations/detail";
 import { readConversationFeedFromSql } from "@/api/conversations/list";
 import { createSqlConversationEventStore } from "@/chat/conversations/sql/history";
 import { purgeConversation } from "@/chat/conversations/retention";
+import { historyItemFromPiMessage } from "@/chat/pi/conversation-events";
 import type { PiMessage } from "@/chat/pi/messages";
 import { createPostgresJuniorSqlExecutor } from "@/db/postgres";
 import {
@@ -15,6 +16,12 @@ import {
 
 const ORIGINAL_ENV = { ...process.env };
 const TEST_DATABASE_URL = ORIGINAL_ENV.DATABASE_URL;
+
+function replacement(message: PiMessage) {
+  return {
+    item: historyItemFromPiMessage(message, { authority: "context" }),
+  };
+}
 
 if (!TEST_DATABASE_URL) {
   throw new Error(
@@ -80,10 +87,7 @@ async function appendVisibleHistory(
       createdAtMs: 10,
     },
     {
-      data: {
-        type: "agent_step",
-        message: modelMessage,
-      },
+      data: historyItemFromPiMessage(modelMessage, { authority: "context" }),
       createdAtMs: 11,
     },
     {
@@ -95,9 +99,8 @@ async function appendVisibleHistory(
       createdAtMs: 12,
     },
     {
-      data: {
-        type: "agent_step",
-        message: {
+      data: historyItemFromPiMessage(
+        {
           role: "assistant",
           api: "responses",
           provider: "openai",
@@ -127,13 +130,13 @@ async function appendVisibleHistory(
           ],
           timestamp: 12,
         } as PiMessage,
-      },
+        { authority: "context" },
+      ),
       createdAtMs: 12,
     },
     {
-      data: {
-        type: "agent_step",
-        message: {
+      data: historyItemFromPiMessage(
+        {
           role: "toolResult",
           toolCallId: `${conversationId}:tool-call`,
           toolName: "search",
@@ -146,7 +149,8 @@ async function appendVisibleHistory(
           isError: false,
           timestamp: 13,
         } as PiMessage,
-      },
+        { authority: "context" },
+      ),
       createdAtMs: 13,
     },
     {
@@ -192,14 +196,12 @@ async function appendVisibleHistory(
       modelId: "private-model-id",
       summary: "Continue monitoring CI.",
       replacementHistory: [
-        { message: modelMessage },
-        {
-          message: {
-            role: "user",
-            content: "Private replacement context.",
-            timestamp: 15,
-          } as PiMessage,
-        },
+        replacement(modelMessage),
+        replacement({
+          role: "user",
+          content: "Private replacement context.",
+          timestamp: 15,
+        } as PiMessage),
       ],
     },
   });
@@ -213,18 +215,16 @@ async function appendVisibleHistory(
       triggeringToolCallId: `${conversationId}:handoff-tool-call`,
       summary: "Fix the remaining test.",
       replacementHistory: [
-        {
-          message: {
-            role: "user",
-            content: [
-              {
-                type: "text",
-                text: "More private replacement context.",
-              },
-            ],
-            timestamp: 16,
-          } as PiMessage,
-        },
+        replacement({
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "More private replacement context.",
+            },
+          ],
+          timestamp: 16,
+        } as PiMessage),
       ],
     },
   });
@@ -465,8 +465,12 @@ describe("dashboard canonical event reporting", () => {
     await recordRoot(conversationId, "public");
     const componentUsageMessage = {
       role: "assistant",
+      api: "responses",
       provider: "openai",
       model: "gpt-5",
+      content: [],
+      stopReason: "stop",
+      timestamp: 10,
       usage: {
         input: 10,
         cost: {
@@ -477,21 +481,29 @@ describe("dashboard canonical event reporting", () => {
           total: 0.037,
         },
       },
-    };
+    } as unknown as PiMessage;
     const totalOnlyUsageMessage = {
       role: "assistant",
+      api: "responses",
       provider: "openai",
       model: "gpt-5",
+      content: [],
+      stopReason: "stop",
+      timestamp: 11,
       usage: { totalTokens: 7, cost: { total: 0.005 } },
-    };
+    } as unknown as PiMessage;
     const { getConversationEventStore } = await import("@/chat/db");
     await getConversationEventStore().append(conversationId, [
       {
-        data: { type: "agent_step", message: componentUsageMessage },
+        data: historyItemFromPiMessage(componentUsageMessage, {
+          authority: "context",
+        }),
         createdAtMs: 10,
       },
       {
-        data: { type: "agent_step", message: totalOnlyUsageMessage },
+        data: historyItemFromPiMessage(totalOnlyUsageMessage, {
+          authority: "context",
+        }),
         createdAtMs: 11,
       },
     ]);
@@ -502,8 +514,8 @@ describe("dashboard canonical event reporting", () => {
         modelProfile: "standard",
         modelId: "openai/gpt-5",
         replacementHistory: [
-          { message: componentUsageMessage },
-          { message: totalOnlyUsageMessage },
+          replacement(componentUsageMessage),
+          replacement(totalOnlyUsageMessage),
         ],
       },
     });

--- a/packages/junior/tests/integration/local-agent-runner.test.ts
+++ b/packages/junior/tests/integration/local-agent-runner.test.ts
@@ -35,6 +35,40 @@ import {
 } from "../fixtures/agent-runner";
 import { getConversationEventStore } from "@/chat/db";
 
+function userPiMessage(text: string, timestamp = 1): PiMessage {
+  return {
+    role: "user",
+    content: [{ type: "text", text }],
+    timestamp,
+  } as PiMessage;
+}
+
+function assistantPiMessage(text: string, timestamp = 1): PiMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "openai-responses",
+    provider: "openai",
+    model: "fake-local-agent",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+      },
+    },
+    stopReason: "stop",
+    timestamp,
+  } as PiMessage;
+}
+
 function successReply(
   text: string,
   options: Partial<
@@ -314,12 +348,7 @@ describe("local agent runner", () => {
             await deliverAssistantText(request, "uploaded");
             return completedAgentRun(
               successReply("uploaded", {
-                piMessages: [
-                  {
-                    role: "assistant",
-                    content: [{ type: "text", text: "uploaded" }],
-                  },
-                ] as PiMessage[],
+                piMessages: [assistantPiMessage("uploaded")],
               }),
             );
           },
@@ -587,12 +616,7 @@ describe("local agent runner", () => {
     const capture = vi.fn().mockReturnValue(eventId);
     const rawError = "raw-session-persistence-error-sentinel";
     const reply = successReply("delivered", {
-      piMessages: [
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "delivered" }],
-        } as PiMessage,
-      ],
+      piMessages: [assistantPiMessage("delivered")],
     });
 
     await expect(
@@ -775,15 +799,9 @@ describe("local agent runner", () => {
               const context = flattenAgentRunRequestForTest(request);
 
               const piMessages = [
-                {
-                  role: "user",
-                  content: "capture this local turn",
-                },
-                {
-                  role: "assistant",
-                  content: "captured",
-                },
-              ] as PiMessage[];
+                userPiMessage("capture this local turn"),
+                assistantPiMessage("captured", 2),
+              ];
               await persistCompletedSessionForFakeReply(context, piMessages);
               await deliverAssistantText(request, "captured");
               return completedAgentRun(
@@ -997,10 +1015,7 @@ describe("local agent runner", () => {
       cwd: "/tmp/local-agent-runner-four",
     });
     expect(conversationId).toBeDefined();
-    const projectedMessage = {
-      role: "user",
-      content: [{ type: "text", text: "projected history" }],
-    } as PiMessage;
+    const projectedMessage = userPiMessage("projected history");
     await commitMessages({
       conversationId: conversationId!,
       messages: [projectedMessage],
@@ -1036,15 +1051,9 @@ describe("local agent runner", () => {
     expect(conversationId).toBeDefined();
 
     const generatedMessages = [
-      {
-        role: "user",
-        content: [{ type: "text", text: "hello" }],
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "persisted pi output" }],
-      },
-    ] as PiMessage[];
+      userPiMessage("hello"),
+      assistantPiMessage("persisted pi output", 2),
+    ];
     const generateReply = vi.fn<AgentRunner["run"]>(async (request) => {
       await deliverAssistantText(request, "persisted visible output");
       return completedAgentRun(
@@ -1099,15 +1108,9 @@ describe("local agent runner", () => {
     expect(conversationId).toBeDefined();
 
     const generatedMessages = [
-      {
-        role: "user",
-        content: [{ type: "text", text: "hello" }],
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "visible reply" }],
-      },
-    ] as PiMessage[];
+      userPiMessage("hello"),
+      assistantPiMessage("visible reply", 2),
+    ];
     const delivered: LocalAgentReply[] = [];
     let taskRuns = 0;
     setPlugins([
@@ -1177,19 +1180,10 @@ describe("local agent runner", () => {
     expect(conversationId).toBeDefined();
 
     const projectedMessages = [
-      {
-        role: "user",
-        content: [{ type: "text", text: "projected question" }],
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "projected answer" }],
-      },
-      {
-        role: "user",
-        content: [{ type: "text", text: "projected follow-up" }],
-      },
-    ] as PiMessage[];
+      userPiMessage("projected question"),
+      assistantPiMessage("projected answer", 2),
+      userPiMessage("projected follow-up", 3),
+    ];
     await commitMessages({
       conversationId: conversationId!,
       messages: projectedMessages,

--- a/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
+++ b/packages/junior/tests/integration/mcp-auth-runtime-slack.test.ts
@@ -20,7 +20,6 @@ import {
   persistConversationMessages,
 } from "@/chat/conversations/messages";
 import { getConversationEventStore } from "@/chat/db";
-import type { PiMessage } from "@/chat/pi/messages";
 import {
   coerceThreadConversationState,
   type ConversationMessage,
@@ -155,10 +154,31 @@ vi.mock("@earendil-works/pi-agent-core", () => {
     }
 
     private async appendAssistantMessage(message: unknown) {
-      this.state.messages.push(message);
+      const durableMessage = {
+        api: "openai-responses",
+        provider: "openai",
+        model: "fake-agent-model",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            total: 0,
+          },
+        },
+        timestamp: Date.now(),
+        ...(message as Record<string, unknown>),
+      };
+      this.state.messages.push(durableMessage);
       await Promise.all(
         this.subscribers.map((subscriber) =>
-          subscriber({ type: "message_end", message }),
+          subscriber({ type: "message_end", message: durableMessage }),
         ),
       );
     }
@@ -220,6 +240,8 @@ vi.mock("@earendil-works/pi-agent-core", () => {
         ok: loadSkillResult.ok,
         details: loadSkillResult,
         isError: false,
+        content: [],
+        timestamp: Date.now(),
       });
 
       if (this.aborted) {
@@ -899,19 +921,12 @@ describe("mcp auth runtime slack integration", () => {
       {
         createdAtMs: 1,
         data: {
-          type: "agent_step",
-          message: {
-            role: "toolResult",
-            toolCallId: "prior-linear-call",
-            toolName: "callMcpTool",
-            isError: false,
-            content: [{ type: "text", text: "prior result" }],
-            timestamp: 1,
-            input: {
-              tool_name: MCP_TOOL_NAME,
-              arguments: { query: "prior request" },
-            },
-          } as PiMessage,
+          type: "tool_result",
+          toolCallId: "prior-linear-call",
+          toolName: "callMcpTool",
+          isError: false,
+          content: [{ type: "text", text: "prior result" }],
+          timestamp: 1,
         },
       },
     ]);

--- a/packages/junior/tests/integration/oauth-callback.test.ts
+++ b/packages/junior/tests/integration/oauth-callback.test.ts
@@ -224,6 +224,12 @@ describe("oauth callback integration", () => {
             {
               role: "assistant",
               content: [{ type: "text", text: "uploaded" }],
+              api: "openai-responses",
+              provider: "openai",
+              model: "test-model",
+              usage: {},
+              stopReason: "stop",
+              timestamp: Date.now(),
             },
           ] as NonNullable<AgentRunResult["piMessages"]>,
           diagnostics: makeDiagnostics(),

--- a/packages/junior/tests/integration/query-conversation-events.test.ts
+++ b/packages/junior/tests/integration/query-conversation-events.test.ts
@@ -103,7 +103,16 @@ describe("queryConversationEvents", () => {
         type: "handoff",
         modelProfile: "handoff",
         modelId: "test/model",
-        replacementHistory: [{ message: { role: "user" } }],
+        replacementHistory: [
+          {
+            item: {
+              type: "user_message",
+              content: [],
+              timestamp: 3,
+              provenance: { authority: "context" },
+            },
+          },
+        ],
       },
     });
 

--- a/packages/junior/tests/integration/runtime/agent-run-model-handoff.test.ts
+++ b/packages/junior/tests/integration/runtime/agent-run-model-handoff.test.ts
@@ -208,8 +208,8 @@ const ORIGINAL_STATE_ADAPTER = process.env.JUNIOR_STATE_ADAPTER;
 function expectedHandoffReplacementHistory() {
   return [
     {
-      message: {
-        role: "user",
+      item: {
+        type: "user_message",
         timestamp: expect.any(Number),
         content: [
           expect.objectContaining({
@@ -219,8 +219,8 @@ function expectedHandoffReplacementHistory() {
             ),
           }),
         ],
+        provenance: { authority: "context" },
       },
-      provenance: { authority: "context" },
     },
   ];
 }

--- a/packages/junior/tests/integration/runtime/agent-run-provider-retry.test.ts
+++ b/packages/junior/tests/integration/runtime/agent-run-provider-retry.test.ts
@@ -85,6 +85,32 @@ vi.mock("@/chat/conversations/projection", async (importOriginal) => {
 });
 
 vi.mock("@earendil-works/pi-agent-core", () => {
+  function durableTestMessage(message: unknown) {
+    const data = message as Record<string, unknown>;
+    if (data.role === "assistant") {
+      return {
+        api: "openai-responses",
+        provider: "openai",
+        model: "test-model",
+        usage: {},
+        stopReason: "stop",
+        timestamp: Date.now(),
+        ...data,
+      };
+    }
+    if (data.role === "toolResult") {
+      return {
+        toolCallId: "test-tool-call",
+        timestamp: Date.now(),
+        ...data,
+      };
+    }
+    if (data.role === "user") {
+      return { timestamp: Date.now(), ...data };
+    }
+    return message;
+  }
+
   class MockAgent {
     state: {
       messages: unknown[];
@@ -139,8 +165,12 @@ vi.mock("@earendil-works/pi-agent-core", () => {
       this.finishPendingRun?.();
     }
 
+    private pushMessages(...messages: unknown[]) {
+      this.state.messages.push(...messages.map(durableTestMessage));
+    }
+
     private recordRunFailure(error: unknown) {
-      this.state.messages.push({
+      this.pushMessages({
         role: "assistant",
         content: [{ type: "text", text: "" }],
         stopReason: "error",
@@ -154,7 +184,7 @@ vi.mock("@earendil-works/pi-agent-core", () => {
 
     async prompt(message: unknown) {
       counters.promptCalls += 1;
-      this.state.messages.push(message);
+      this.pushMessages(message);
       if (agentMode.value === "activeCompaction") {
         const toolResult = {
           role: "toolResult",
@@ -163,7 +193,7 @@ vi.mock("@earendil-works/pi-agent-core", () => {
           isError: false,
           content: [{ type: "text", text: "x".repeat(1_600_000) }],
         };
-        this.state.messages.push({
+        this.pushMessages({
           role: "assistant",
           content: [
             {
@@ -176,7 +206,7 @@ vi.mock("@earendil-works/pi-agent-core", () => {
           stopReason: "toolUse",
           usage: { input: 2, output: 2 },
         });
-        this.state.messages.push(toolResult);
+        this.pushMessages(toolResult);
         await Promise.all(
           this.subscribers.map((subscriber) =>
             subscriber({
@@ -197,7 +227,7 @@ vi.mock("@earendil-works/pi-agent-core", () => {
         const keptRequest = compactionState.nextProviderContextText.includes(
           "Make a large generated-file edit.",
         );
-        this.state.messages.push({
+        this.pushMessages({
           role: "assistant",
           content: [
             {
@@ -236,13 +266,13 @@ vi.mock("@earendil-works/pi-agent-core", () => {
           this.recordRunFailure(error);
           return {};
         }
-        this.state.messages.push({
+        this.pushMessages({
           role: "toolResult",
           toolName: "bash",
           isError: false,
           content: [{ type: "text", text: "ok" }],
         });
-        this.state.messages.push({
+        this.pushMessages({
           role: "assistant",
           content: [{ type: "text", text: "Tool done." }],
           stopReason: "stop",
@@ -260,7 +290,7 @@ vi.mock("@earendil-works/pi-agent-core", () => {
           stopReason: "stop",
           usage: { input: 2, output: 2 },
         };
-        this.state.messages.push(finalMessage);
+        this.pushMessages(finalMessage);
         await Promise.all(
           this.subscribers.map((subscriber) =>
             subscriber({ type: "message_end", message: finalMessage }),
@@ -297,7 +327,7 @@ vi.mock("@earendil-works/pi-agent-core", () => {
             stopReason: "stop",
             usage: { input: 2, output: 2 },
           };
-          this.state.messages.push(firstMessage);
+          this.pushMessages(firstMessage);
           await Promise.all(
             this.subscribers.map((subscriber) =>
               subscriber({ type: "message_end", message: firstMessage }),
@@ -319,7 +349,7 @@ vi.mock("@earendil-works/pi-agent-core", () => {
             ),
           );
         }
-        this.state.messages.push(...this.steeringMessages);
+        this.pushMessages(...this.steeringMessages);
         const finalMessage = {
           role: "assistant",
           content: [{ type: "text", text: "Steered." }],
@@ -329,7 +359,7 @@ vi.mock("@earendil-works/pi-agent-core", () => {
             output: 2,
           },
         };
-        this.state.messages.push(finalMessage);
+        this.pushMessages(finalMessage);
         if (agentMode.value === "steeringDelivery") {
           await Promise.all(
             this.subscribers.map((subscriber) =>
@@ -339,13 +369,13 @@ vi.mock("@earendil-works/pi-agent-core", () => {
         }
         return {};
       }
-      this.state.messages.push({
+      this.pushMessages({
         role: "toolResult",
         toolName: "bash",
         isError: false,
         content: [{ type: "text", text: "ok" }],
       });
-      this.state.messages.push({
+      this.pushMessages({
         role: "assistant",
         content: [],
         stopReason: "error",
@@ -376,7 +406,7 @@ vi.mock("@earendil-works/pi-agent-core", () => {
               : [];
           })
           .join("\n");
-        this.state.messages.push({
+        this.pushMessages({
           role: "assistant",
           content: [
             { type: "text", text: "Preserved after preflight compaction." },
@@ -389,7 +419,7 @@ vi.mock("@earendil-works/pi-agent-core", () => {
         });
         return {};
       }
-      this.state.messages.push({
+      this.pushMessages({
         role: "assistant",
         content: [{ type: "text", text: "Recovered." }],
         stopReason: "stop",

--- a/packages/junior/tests/integration/slack/message-content-behavior.test.ts
+++ b/packages/junior/tests/integration/slack/message-content-behavior.test.ts
@@ -8,6 +8,7 @@ import {
 import { coerceThreadConversationState } from "@/chat/state/conversation";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
 import { commitMessages } from "@/chat/conversations/projection";
+import { historyItemFromPiMessage } from "@/chat/pi/conversation-events";
 import { upsertAgentTurnSessionRecord } from "@/chat/state/turn-session";
 import { getConversationEventStore } from "@/chat/db";
 import { botConfig } from "@/chat/config";
@@ -39,6 +40,19 @@ function completedReply(text: string) {
       usedPrimaryText: true,
     },
   });
+}
+
+function assistantPiMessage(text: string, timestamp: number): PiMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "openai-responses",
+    provider: "openai",
+    model: "test-model",
+    usage: {},
+    stopReason: "stop",
+    timestamp,
+  } as PiMessage;
 }
 
 describe("Slack behavior: message content", () => {
@@ -241,11 +255,7 @@ describe("Slack behavior: message content", () => {
         ],
         timestamp: 1,
       },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "First response." }],
-        timestamp: 2,
-      },
+      assistantPiMessage("First response.", 2),
     ] as PiMessage[];
     const durableFirstTurnHistory: PiMessage[] = [
       {
@@ -353,11 +363,7 @@ describe("Slack behavior: message content", () => {
         ],
         timestamp: 1,
       },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "old answer ".repeat(1_000) }],
-        timestamp: 2,
-      },
+      assistantPiMessage("old answer ".repeat(1_000), 2),
     ] as PiMessage[];
     const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700005005.000" });
     await commitMessages({
@@ -453,8 +459,7 @@ describe("Slack behavior: message content", () => {
         modelProfile: "handoff",
         modelId: botConfig.profiles.handoff!.modelId,
         replacementHistory: priorMessages.map((message) => ({
-          message,
-          provenance: { authority: "context" },
+          item: historyItemFromPiMessage(message, { authority: "context" }),
         })),
       },
     });
@@ -521,11 +526,7 @@ describe("Slack behavior: message content", () => {
         content: [{ type: "text", text: "older context ".repeat(5_000) }],
         timestamp: 1,
       },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "older answer ".repeat(1_000) }],
-        timestamp: 2,
-      },
+      assistantPiMessage("older answer ".repeat(1_000), 2),
     ] as PiMessage[];
     const thread = createTestThread({ id: "slack:C0BEHAVIOR:1700005006.000" });
     await commitMessages({
@@ -546,7 +547,9 @@ describe("Slack behavior: message content", () => {
         type: "compaction",
         modelProfile: "standard",
         modelId: "test/model",
-        replacementHistory: priorMessages.map((message) => ({ message })),
+        replacementHistory: priorMessages.map((message) => ({
+          item: historyItemFromPiMessage(message, { authority: "context" }),
+        })),
       },
     });
     const conversation = coerceThreadConversationState({});

--- a/packages/junior/tests/unit/api/conversation-events.test.ts
+++ b/packages/junior/tests/unit/api/conversation-events.test.ts
@@ -9,7 +9,6 @@ import {
   decodeStoredConversationEvent,
   type ConversationEvent,
   type ConversationEventData,
-  type ConversationAgentStepPayload,
 } from "@/chat/conversations/history";
 
 function event(
@@ -25,6 +24,22 @@ function event(
     createdAtMs,
     data,
   });
+}
+
+function assistantMessage(
+  content: unknown[],
+  timestamp = 0,
+): ConversationEventData {
+  return {
+    type: "assistant_message",
+    content,
+    api: "responses",
+    provider: "openai",
+    model: "gpt-5",
+    usage: {},
+    stopReason: "stop",
+    timestamp,
+  };
 }
 
 describe("conversation report event projection", () => {
@@ -46,7 +61,7 @@ describe("conversation report event projection", () => {
     ).toEqual([]);
   });
 
-  it("keeps canonical sequence order and projects only tool facts from agent steps", () => {
+  it("keeps canonical sequence order and projects tool facts from agent history", () => {
     const events = [
       event(
         10,
@@ -60,22 +75,19 @@ describe("conversation report event projection", () => {
       ),
       event(
         11,
-        {
-          type: "agent_step",
-          message: {
-            role: "assistant",
-            content: [
-              { type: "text", text: "one user-facing answer" },
-              { type: "thinking", thinking: "private chain of thought" },
-              {
-                type: "toolCall",
-                id: "private-tool-call-id",
-                name: "search",
-                arguments: { query: "private query" },
-              },
-            ],
-          } as ConversationAgentStepPayload,
-        },
+        assistantMessage(
+          [
+            { type: "text", text: "one user-facing answer" },
+            { type: "thinking", thinking: "private chain of thought" },
+            {
+              type: "toolCall",
+              id: "private-tool-call-id",
+              name: "search",
+              arguments: { query: "private query" },
+            },
+          ],
+          10_000,
+        ),
         10_000,
       ),
       event(
@@ -158,56 +170,48 @@ describe("conversation report event projection", () => {
     const projected = projectConversationReportEventPage({
       canExposePayload: true,
       events: [
-        event(1, {
-          type: "agent_step",
-          message: {
-            role: "assistant",
-            content: [
-              {
-                type: "toolCall",
-                id: "call-1",
-                name: "search",
-                arguments: { query: "first" },
-              },
-              {
-                type: "toolCall",
-                id: "call-2",
-                name: "fetch",
-                arguments: { url: "https://example.com" },
-              },
-            ],
-          } as ConversationAgentStepPayload,
-        }),
-        event(2, {
-          type: "agent_step",
-          message: {
-            role: "toolResult",
-            toolCallId: "call-1",
-            toolName: "search",
-            content: [{ type: "text", text: "model-visible error summary" }],
-            details: {
-              ok: false,
-              status: "error",
-              error: { kind: "not_found", message: "No matches" },
-              providerSecret: "must stay host-only",
+        event(
+          1,
+          assistantMessage([
+            {
+              type: "toolCall",
+              id: "call-1",
+              name: "search",
+              arguments: { query: "first" },
             },
-            isError: false,
-          } as ConversationAgentStepPayload,
+            {
+              type: "toolCall",
+              id: "call-2",
+              name: "fetch",
+              arguments: { url: "https://example.com" },
+            },
+          ]),
+        ),
+        event(2, {
+          type: "tool_result",
+          toolCallId: "call-1",
+          toolName: "search",
+          content: [{ type: "text", text: "model-visible error summary" }],
+          details: {
+            ok: false,
+            status: "error",
+            error: { kind: "not_found", message: "No matches" },
+            providerSecret: "must stay host-only",
+          },
+          isError: false,
+          timestamp: 2_000,
         }),
         event(3, {
-          type: "agent_step",
-          message: {
-            role: "toolResult",
-            toolCallId: "call-2",
-            toolName: "fetch",
-            content: [
-              { type: "text", text: "native result" },
-              { type: "image", mimeType: "image/png", data: "AAAA" },
-            ],
-            details: { ok: true, status: "success" },
-            rawProviderResponse: "must not escape",
-            isError: false,
-          } as ConversationAgentStepPayload,
+          type: "tool_result",
+          toolCallId: "call-2",
+          toolName: "fetch",
+          content: [
+            { type: "text", text: "native result" },
+            { type: "image", mimeType: "image/png", data: "AAAA" },
+          ],
+          details: { ok: true, status: "success" },
+          isError: false,
+          timestamp: 3_000,
         }),
       ],
     });
@@ -317,14 +321,14 @@ describe("conversation report event projection", () => {
     expect(JSON.stringify(prefix)).toBe(JSON.stringify(complete.slice(0, 1)));
   });
 
-  it("does not use future start context to rewrite an earlier tool result", () => {
+  it("does not use future start context to rewrite a native tool result", () => {
     const result = event(1, {
-      type: "agent_step",
-      message: {
-        role: "toolResult",
-        toolCallId: "call-1",
-        content: [{ type: "text", text: "result" }],
-      } as ConversationAgentStepPayload,
+      type: "tool_result",
+      toolCallId: "call-1",
+      toolName: "result_tool",
+      content: [{ type: "text", text: "result" }],
+      isError: false,
+      timestamp: 1_000,
     });
     const futureStart = event(2, {
       type: "tool_execution_started",
@@ -338,7 +342,23 @@ describe("conversation report event projection", () => {
         events: [result],
         toolStartEvents: [futureStart],
       }),
-    ).toEqual([]);
+    ).toEqual([
+      {
+        seq: 1,
+        createdAt: "1970-01-01T00:00:01.000Z",
+        data: {
+          type: "tool_calls",
+          calls: [
+            {
+              toolCallId: "call-1",
+              name: "result_tool",
+              status: "completed",
+              output: "result",
+            },
+          ],
+        },
+      },
+    ]);
   });
 
   it("redacts private content and strips every internal persistence or payload field", () => {
@@ -358,15 +378,13 @@ describe("conversation report event projection", () => {
           },
         }),
         event(2, {
-          type: "agent_step",
-          message: {
-            role: "toolResult",
-            toolName: "safe_tool_name",
-            toolCallId: "private-tool-call-id",
-            isError: true,
-            content: [{ type: "text", text: "private tool result" }],
-            errorMessage: "private provider error",
-          } as ConversationAgentStepPayload,
+          type: "tool_result",
+          toolName: "safe_tool_name",
+          toolCallId: "private-tool-call-id",
+          isError: true,
+          content: [{ type: "text", text: "private tool result" }],
+          errorMessage: "private provider error",
+          timestamp: 2,
         }),
         event(3, {
           type: "tool_execution_started",
@@ -477,18 +495,20 @@ describe("conversation report event projection", () => {
         summary: "Continue monitoring CI.",
         replacementHistory: [
           {
-            message: {
-              role: "user",
+            item: {
+              type: "user_message",
               content: "Private retained user message.",
               timestamp: 1,
-            } as ConversationAgentStepPayload,
+              provenance: { authority: "context" },
+            },
           },
           {
-            message: {
-              role: "user",
+            item: {
+              type: "user_message",
               content: "Other private replacement context.",
               timestamp: 1,
-            } as ConversationAgentStepPayload,
+              provenance: { authority: "context" },
+            },
           },
         ],
       }),
@@ -499,8 +519,8 @@ describe("conversation report event projection", () => {
         summary: "Fix the remaining test.",
         replacementHistory: [
           {
-            message: {
-              role: "user",
+            item: {
+              type: "user_message",
               content: [
                 {
                   type: "text",
@@ -508,7 +528,8 @@ describe("conversation report event projection", () => {
                 },
               ],
               timestamp: 2,
-            } as ConversationAgentStepPayload,
+              provenance: { authority: "context" },
+            },
           },
         ],
       }),

--- a/packages/junior/tests/unit/chat/pi/conversation-events.test.ts
+++ b/packages/junior/tests/unit/chat/pi/conversation-events.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from "vitest";
 import {
+  agentHistoryItemSchema,
   conversationEventSchema,
   decodeStoredConversationEvent,
   type ConversationEvent,
   type ConversationEventData,
 } from "@/chat/conversations/history";
-import { projectConversationEvents } from "@/chat/pi/conversation-events";
-import type { PiMessage } from "@/chat/pi/messages";
+import {
+  historyItemFromPiMessage,
+  piMessageFromHistoryItem,
+  projectConversationEvents,
+} from "@/chat/pi/conversation-events";
 
 function event(
   seq: number,
@@ -51,8 +55,9 @@ describe("projectConversationEvents", () => {
     }),
     event(1, { type: "mcp_provider_connected", provider: "github" }),
     event(2, {
-      type: "agent_step",
-      message: firstMessage,
+      type: "user_message",
+      content: firstMessage.content,
+      timestamp: firstMessage.timestamp,
       provenance: instructionProvenance,
     }),
     event(3, {
@@ -75,7 +80,12 @@ describe("projectConversationEvents", () => {
       authorizationId: "auth-2",
       delivery: "private_link_sent",
     }),
-    event(6, { type: "agent_step", message: lastMessage }),
+    event(6, {
+      type: "user_message",
+      content: lastMessage.content,
+      timestamp: lastMessage.timestamp,
+      provenance: { authority: "context" },
+    }),
     event(7, {
       type: "turn_started",
       turnId: "turn-1",
@@ -159,57 +169,68 @@ describe("projectConversationEvents", () => {
         modelId: "openai/gpt-5.4",
         replacementHistory: [
           {
-            message: retained,
-            provenance: instructionProvenance,
+            item: {
+              type: "user_message",
+              content: retained.content,
+              timestamp: retained.timestamp,
+              provenance: instructionProvenance,
+            },
             sourceEventSeq: 4,
           },
-          { message: summary },
+          {
+            item: {
+              type: "user_message",
+              content: summary.content,
+              timestamp: summary.timestamp,
+              provenance: { authority: "context" },
+            },
+          },
         ],
       }),
-      event(11, { type: "agent_step", message: later }),
+      event(11, {
+        type: "user_message",
+        content: later.content,
+        timestamp: later.timestamp,
+        provenance: { authority: "context" },
+      }),
     ]);
 
     expect(projection.messages).toEqual([retained, summary, later]);
     expect(projection.seqs).toEqual([4, 10, 11]);
   });
 
-  it("projects rollback history persisted by the bridge release", () => {
-    const retained = {
-      role: "user",
-      content: [{ type: "text", text: "Retained bridge history" }],
-      timestamp: 2_000,
-    };
-    const rollback = decodeStoredConversationEvent({
-      schemaVersion: 1,
-      seq: 12,
-      historyVersion: 2,
-      createdAtMs: 1_012,
-      type: "rollback",
-      payload: {
-        modelProfile: "coding",
-        modelId: "openai/gpt-5.4",
-        replacementHistory: [{ message: retained, sourceEventSeq: 4 }],
-      },
-    });
+  it("round-trips native Pi message roles without leaking provenance", () => {
+    const native = historyItemFromPiMessage(
+      firstMessage,
+      instructionProvenance,
+    );
 
-    expect(projectConversationEvents([rollback])).toMatchObject({
-      messages: [retained],
-      modelId: "openai/gpt-5.4",
-      modelProfile: "coding",
-      seqs: [4],
+    expect(native).toEqual({
+      type: "user_message",
+      content: firstMessage.content,
+      timestamp: firstMessage.timestamp,
+      provenance: instructionProvenance,
     });
+    expect(piMessageFromHistoryItem(native)).toEqual(firstMessage);
   });
 
-  it("validates opaque durable messages only at the Pi boundary", () => {
-    const invalid = {
-      schemaVersion: 1,
-      seq: 1,
-      historyVersion: 2,
-      createdAtMs: 1_001,
-      data: { type: "agent_step", message: {} },
-    } as ConversationEvent;
+  it("keeps Junior-owned history discriminants authoritative", () => {
+    const native = historyItemFromPiMessage(
+      {
+        ...firstMessage,
+        type: "tool_result",
+      } as Parameters<typeof historyItemFromPiMessage>[0],
+      instructionProvenance,
+    );
 
-    expect(() => projectConversationEvents([invalid])).toThrow(/role/);
+    expect(native.type).toBe("user_message");
+    expect(piMessageFromHistoryItem(native)).toMatchObject({ role: "user" });
+    expect(
+      agentHistoryItemSchema.safeParse({
+        type: "assistant_message",
+        role: "user",
+      }).success,
+    ).toBe(false);
   });
 
   it("rejects unsupported stored events at the model-history boundary", () => {
@@ -230,17 +251,16 @@ describe("projectConversationEvents", () => {
   it("omits volatile runtime bootstrap from durable agent history", () => {
     const projection = projectConversationEvents([
       event(20, {
-        type: "agent_step",
-        message: {
-          role: "user",
-          content: [
-            {
-              type: "text",
-              text: "<runtime-turn-context>\nvolatile\n</runtime-turn-context>",
-            },
-            { type: "text", text: "Keep this instruction." },
-          ],
-        } as PiMessage,
+        type: "user_message",
+        content: [
+          {
+            type: "text",
+            text: "<runtime-turn-context>\nvolatile\n</runtime-turn-context>",
+          },
+          { type: "text", text: "Keep this instruction." },
+        ],
+        timestamp: 2_000,
+        provenance: { authority: "instruction" },
       }),
     ]);
 
@@ -248,6 +268,7 @@ describe("projectConversationEvents", () => {
       {
         role: "user",
         content: [{ type: "text", text: "Keep this instruction." }],
+        timestamp: 2_000,
       },
     ]);
     expect(projection.seqs).toEqual([20]);

--- a/packages/junior/tests/unit/conversations/turn-lifecycle.test.ts
+++ b/packages/junior/tests/unit/conversations/turn-lifecycle.test.ts
@@ -48,7 +48,7 @@ class MemoryConversationEventStore implements ConversationEventStore {
     throw new Error("not implemented");
   }
 
-  async loadLatestInstructionStep(): Promise<ConversationEvent | undefined> {
+  async loadLatestInstruction(): Promise<ConversationEvent | undefined> {
     return undefined;
   }
 


### PR DESCRIPTION
Today, every model-history entry looks the same to the database: it is an `agent_step`, and you have to open its payload to learn whether it contains a user message, assistant message, or tool result.

This PR stores that meaning directly in the event type.

Before:

```json
{
  "type": "agent_step",
  "payload": {
    "message": {
      "role": "user",
      "content": "Investigate the failure",
      "timestamp": 1000
    },
    "provenance": { "authority": "context" }
  }
}
```

After:

```json
{
  "type": "user_message",
  "payload": {
    "content": "Investigate the failure",
    "timestamp": 1000,
    "provenance": { "authority": "context" }
  }
}
```

Assistant messages use `assistant_message`, and tool results use `tool_result`. Compaction and handoff history follows the same idea: each replacement entry contains an `item` with one of those native types instead of a nested Pi message with a `role`.

This makes the event log useful without understanding Pi's message wrapper. Reporting, usage aggregation, event queries, and instruction lookup can switch on the stored event type directly. Pi-specific fields remain opaque in storage and are validated when the Pi adapter rebuilds model context.
cords the migration but contains no table or column change.

### Upgrade note

This is a hard worker cutover. When upgrading from a release that writes `agent_step`, operators must block ingress, drain active and resumable work, stop old workers, run `junior upgrade`, and deploy the new runtime before restarting workers. Otherwise an old worker could append a legacy event after the one-time rewrite.
