### PR TITLE
feat(plugins): add structured turn context

### DIFF
--- a/packages/junior-dashboard/src/client/components/ConversationTranscript.tsx
+++ b/packages/junior-dashboard/src/client/components/ConversationTranscript.tsx
@@ -45,6 +45,7 @@ import {
 import { TranscriptText } from "./TranscriptText";
 import { TranscriptSubagentView } from "./TranscriptSubagentView";
 import { TranscriptContextEventView } from "./TranscriptContextEventView";
+import { TranscriptTurnContextView } from "./TranscriptTurnContextView";
 import { TranscriptToolRun } from "./TranscriptToolRun";
 import { TranscriptToolView } from "./TranscriptToolView";
 import { shouldCopyRawTranscript } from "./transcriptCopy";
@@ -793,6 +794,11 @@ function TranscriptMessageView(props: {
           })}
         </div>
       )}
+      {props.view === "rich" &&
+      props.message.role === "user" &&
+      props.message.contexts?.length ? (
+        <TranscriptTurnContextView contexts={props.message.contexts} />
+      ) : null}
     </TranscriptMessageShell>
   );
 }

--- a/packages/junior-dashboard/src/client/components/TranscriptTurnContextView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptTurnContextView.tsx
@@ -1,4 +1,5 @@
-import { Brain } from "lucide-react";
+import { Brain, Braces, X } from "lucide-react";
+import { useEffect, useId, useRef, useState } from "react";
 
 import type { TranscriptViewTurnContext } from "../types";
 import { formatMessageTimestamp } from "../format";
@@ -6,49 +7,167 @@ import {
   memoryRecallContent,
   type MemoryRecallContent,
 } from "../conversations/turnContext";
+import { cn } from "../styles";
 import { HighlightText } from "./transcriptSearch";
 
-/** Render structured context attached to one transcript user message. */
+/** Show structured context attached to one transcript user message. */
 export function TranscriptTurnContextView(props: {
   contexts: TranscriptViewTurnContext[];
 }) {
+  const [open, setOpen] = useState(false);
+  const panelId = useId();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function closeOnEscape(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    }
+
+    document.addEventListener("keydown", closeOnEscape);
+    return () => document.removeEventListener("keydown", closeOnEscape);
+  }, [open]);
+
   return (
-    <div className="grid gap-2">
-      {props.contexts.map((context, index) => (
-        <TurnContext
-          context={context}
-          key={`${context.pluginName}:${context.kind}:${context.version}:${index}`}
+    <>
+      <div className="group/context relative flex justify-end">
+        <button
+          aria-controls={panelId}
+          aria-expanded={open}
+          aria-label="View turn context"
+          className={cn(
+            "grid size-7 cursor-pointer place-items-center rounded-md border border-transparent bg-transparent text-white/35 transition-colors hover:border-white/10 hover:bg-white/[0.06] hover:text-white/75 focus-visible:outline focus-visible:outline-2 focus-visible:outline-cyan-200/60",
+            open && "border-white/10 bg-white/[0.06] text-cyan-100/80",
+          )}
+          onClick={() => setOpen(true)}
+          ref={triggerRef}
+          title="View turn context"
+          type="button"
+        >
+          <Braces aria-hidden="true" size={15} strokeWidth={1.8} />
+        </button>
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute right-0 bottom-[calc(100%+0.35rem)] z-10 whitespace-nowrap rounded border border-white/10 bg-[#111] px-2 py-1 text-[0.68rem] font-medium text-white/70 opacity-0 shadow-lg transition-opacity group-hover/context:opacity-100 group-focus-within/context:opacity-100"
+        >
+          View turn context
+        </span>
+      </div>
+
+      {open ? (
+        <TurnContextPanel
+          contexts={props.contexts}
+          id={panelId}
+          onClose={() => {
+            setOpen(false);
+            triggerRef.current?.focus();
+          }}
         />
-      ))}
+      ) : null}
+    </>
+  );
+}
+
+function TurnContextPanel(props: {
+  contexts: TranscriptViewTurnContext[];
+  id: string;
+  onClose(): void;
+}) {
+  return (
+    <div className="fixed inset-0 z-50">
+      <button
+        aria-label="Close turn context"
+        className="absolute inset-0 cursor-default border-0 bg-black/55 backdrop-blur-[1px]"
+        onClick={props.onClose}
+        type="button"
+      />
+      <section
+        aria-label="Turn context"
+        aria-modal="true"
+        className="absolute inset-y-0 right-0 flex w-full max-w-[34rem] flex-col border-l border-white/15 bg-[#0b0b0b] shadow-2xl shadow-black/70"
+        id={props.id}
+        role="dialog"
+      >
+        <header className="flex min-h-16 items-center justify-between gap-4 border-b border-white/10 px-5">
+          <div className="flex min-w-0 items-center gap-3">
+            <span className="grid size-8 shrink-0 place-items-center rounded-lg bg-cyan-200/10 text-cyan-100/80">
+              <Braces aria-hidden="true" size={17} strokeWidth={1.8} />
+            </span>
+            <div className="min-w-0">
+              <h2 className="m-0 text-sm font-semibold text-white">
+                Turn context
+              </h2>
+              <p className="m-0 mt-0.5 text-xs text-white/40">
+                Structured context supplied with this message
+              </p>
+            </div>
+          </div>
+          <button
+            aria-label="Close turn context"
+            autoFocus
+            className="grid size-8 shrink-0 cursor-pointer place-items-center rounded-md border-0 bg-transparent text-white/45 transition-colors hover:bg-white/10 hover:text-white"
+            onClick={props.onClose}
+            type="button"
+          >
+            <X aria-hidden="true" size={17} />
+          </button>
+        </header>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-2">
+          {props.contexts.map((context, index) => (
+            <TurnContext
+              context={context}
+              key={`${context.pluginName}:${context.kind}:${context.version}:${index}`}
+            />
+          ))}
+        </div>
+      </section>
     </div>
   );
 }
 
 function TurnContext(props: { context: TranscriptViewTurnContext }) {
   const memory = memoryRecallContent(props.context);
-  const count = memory?.memories.length;
 
   return (
-    <details className="rounded-lg border border-cyan-300/15 bg-cyan-300/[0.035] px-3 py-2">
-      <summary className="flex cursor-pointer list-none items-center gap-2 text-[0.78rem] font-medium text-cyan-100/75 [&::-webkit-details-marker]:hidden">
-        <Brain aria-hidden="true" className="size-3.5" />
-        <span>
-          {count === undefined
-            ? `${props.context.pluginName} context`
-            : `${count} recalled ${count === 1 ? "memory" : "memories"}`}
+    <section className="border-b border-white/10 py-5 last:border-b-0">
+      <div className="mb-4 flex items-start justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-2.5">
+          {memory ? (
+            <Brain
+              aria-hidden="true"
+              className="shrink-0 text-cyan-100/60"
+              size={15}
+            />
+          ) : (
+            <Braces
+              aria-hidden="true"
+              className="shrink-0 text-cyan-100/60"
+              size={15}
+            />
+          )}
+          <h3 className="m-0 truncate text-[0.82rem] font-semibold text-white/85">
+            {memory ? "Recalled memories" : props.context.pluginName}
+          </h3>
+        </div>
+        <span className="shrink-0 text-[0.7rem] text-white/35">
+          {props.context.kind} · v{props.context.version}
         </span>
-      </summary>
-      <div className="mt-3">
-        {memory ? (
-          <MemoryRecall
-            loadedAt={props.context.loadedAt}
-            memories={memory.memories}
-          />
-        ) : (
-          <GenericContext context={props.context} />
-        )}
       </div>
-    </details>
+
+      {memory ? (
+        <MemoryRecall
+          loadedAt={props.context.loadedAt}
+          memories={memory.memories}
+        />
+      ) : (
+        <GenericContext context={props.context} />
+      )}
+    </section>
   );
 }
 
@@ -57,31 +176,45 @@ function MemoryRecall(props: {
   memories: MemoryRecallContent["memories"];
 }) {
   return (
-    <div className="grid gap-3">
-      <div className="text-[0.72rem] text-white/35">
-        Loaded {formatMessageTimestamp(Date.parse(props.loadedAt))}
-      </div>
-      {props.memories.map((memory) => (
-        <div
-          className="grid gap-2 border-t border-white/8 pt-3 first:border-t-0 first:pt-0"
+    <div>
+      {props.memories.map((memory, index) => (
+        <article
+          className="border-t border-white/8 py-4 first:border-t-0 first:pt-0 last:pb-0"
           key={memory.id}
         >
-          <div className="whitespace-pre-wrap text-[0.82rem] leading-relaxed text-white/70">
+          <div className="whitespace-pre-wrap text-[0.88rem] leading-6 text-white/80">
             <HighlightText text={memory.content} />
           </div>
-          <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 text-[0.7rem]">
-            <dt className="text-white/30">ID</dt>
-            <dd className="truncate font-mono text-white/50">{memory.id}</dd>
-            <dt className="text-white/30">Observed</dt>
-            <dd className="text-white/50">
-              {formatMessageTimestamp(memory.observedAtMs)}
-            </dd>
-            <dt className="text-white/30">Scope</dt>
-            <dd className="text-white/50">{memory.scope}</dd>
-            <dt className="text-white/30">Kind</dt>
-            <dd className="text-white/50">{memory.kind}</dd>
+
+          <dl className="mt-4 grid gap-2 text-xs">
+            <div className="grid grid-cols-[5rem_minmax(0,1fr)] items-start gap-3">
+              <dt className="text-white/35">Memory ID</dt>
+              <dd className="m-0 break-all font-mono text-white/60">
+                <HighlightText text={memory.id} />
+              </dd>
+            </div>
+            <div className="grid grid-cols-[5rem_minmax(0,1fr)] items-start gap-3">
+              <dt className="text-white/35">Observed</dt>
+              <dd className="m-0 text-white/60">
+                {formatMessageTimestamp(memory.observedAtMs)}
+              </dd>
+            </div>
+            <div className="grid grid-cols-[5rem_minmax(0,1fr)] items-start gap-3">
+              <dt className="text-white/35">Scope</dt>
+              <dd className="m-0 text-white/60">{memory.scope}</dd>
+            </div>
+            <div className="grid grid-cols-[5rem_minmax(0,1fr)] items-start gap-3">
+              <dt className="text-white/35">Kind</dt>
+              <dd className="m-0 text-white/60">{memory.kind}</dd>
+            </div>
           </dl>
-        </div>
+
+          {index === props.memories.length - 1 ? (
+            <p className="m-0 mt-4 text-[0.7rem] text-white/30">
+              Loaded {formatMessageTimestamp(Date.parse(props.loadedAt))}
+            </p>
+          ) : null}
+        </article>
       ))}
     </div>
   );
@@ -89,14 +222,13 @@ function MemoryRecall(props: {
 
 function GenericContext(props: { context: TranscriptViewTurnContext }) {
   return (
-    <div className="grid gap-2">
-      <div className="text-[0.72rem] text-white/35">
-        {props.context.kind} v{props.context.version} · Loaded{" "}
-        {formatMessageTimestamp(Date.parse(props.context.loadedAt))}
-      </div>
-      <pre className="overflow-x-auto whitespace-pre-wrap break-words text-[0.72rem] leading-relaxed text-white/55">
+    <div>
+      <pre className="m-0 overflow-x-auto whitespace-pre-wrap break-words rounded-lg bg-white/[0.04] p-3 text-[0.75rem] leading-relaxed text-white/60">
         <HighlightText text={JSON.stringify(props.context.content, null, 2)} />
       </pre>
+      <p className="m-0 mt-3 text-[0.7rem] text-white/30">
+        Loaded {formatMessageTimestamp(Date.parse(props.context.loadedAt))}
+      </p>
     </div>
   );
 }

--- a/packages/junior-dashboard/src/client/components/TranscriptTurnContextView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptTurnContextView.tsx
@@ -1,4 +1,4 @@
-import { Brain, Braces, X } from "lucide-react";
+import { Brain, Braces, ChevronRight, X } from "lucide-react";
 import { useEffect, useId, useRef, useState } from "react";
 
 import type { TranscriptViewTurnContext } from "../types";
@@ -176,46 +176,68 @@ function MemoryRecall(props: {
   memories: MemoryRecallContent["memories"];
 }) {
   return (
-    <div>
+    <div className="overflow-hidden rounded-lg border border-white/10">
       {props.memories.map((memory, index) => (
-        <article
-          className="border-t border-white/8 py-4 first:border-t-0 first:pt-0 last:pb-0"
+        <details
+          className="group/memory border-t border-white/10 first:border-t-0"
           key={memory.id}
         >
-          <div className="whitespace-pre-wrap text-[0.88rem] leading-6 text-white/80">
-            <HighlightText text={memory.content} />
+          <summary className="flex cursor-pointer list-none items-start gap-2.5 px-3 py-3 transition-colors hover:bg-white/[0.04] [&::-webkit-details-marker]:hidden">
+            <ChevronRight
+              aria-hidden="true"
+              className="mt-0.5 shrink-0 text-white/35 transition-transform group-open/memory:rotate-90"
+              size={15}
+            />
+            <span className="min-w-0 flex-1">
+              <span className="flex items-center justify-between gap-3">
+                <span className="text-[0.72rem] font-medium text-white/45">
+                  Memory {index + 1}
+                </span>
+                <span className="shrink-0 text-[0.68rem] text-white/30">
+                  {memory.kind} · {memory.scope}
+                </span>
+              </span>
+              <span className="mt-1 block truncate text-[0.8rem] text-white/75">
+                <HighlightText text={memory.content} />
+              </span>
+            </span>
+          </summary>
+
+          <div className="border-t border-white/8 bg-white/[0.025] px-4 py-4">
+            <div className="whitespace-pre-wrap text-[0.88rem] leading-6 text-white/80">
+              <HighlightText text={memory.content} />
+            </div>
+
+            <dl className="mt-4 grid gap-2 text-xs">
+              <div className="grid grid-cols-[5rem_minmax(0,1fr)] items-start gap-3">
+                <dt className="text-white/35">Memory ID</dt>
+                <dd className="m-0 break-all font-mono text-white/60">
+                  <HighlightText text={memory.id} />
+                </dd>
+              </div>
+              <div className="grid grid-cols-[5rem_minmax(0,1fr)] items-start gap-3">
+                <dt className="text-white/35">Observed</dt>
+                <dd className="m-0 text-white/60">
+                  {formatMessageTimestamp(memory.observedAtMs)}
+                </dd>
+              </div>
+              <div className="grid grid-cols-[5rem_minmax(0,1fr)] items-start gap-3">
+                <dt className="text-white/35">Scope</dt>
+                <dd className="m-0 text-white/60">{memory.scope}</dd>
+              </div>
+              <div className="grid grid-cols-[5rem_minmax(0,1fr)] items-start gap-3">
+                <dt className="text-white/35">Kind</dt>
+                <dd className="m-0 text-white/60">{memory.kind}</dd>
+              </div>
+            </dl>
           </div>
-
-          <dl className="mt-4 grid gap-2 text-xs">
-            <div className="grid grid-cols-[5rem_minmax(0,1fr)] items-start gap-3">
-              <dt className="text-white/35">Memory ID</dt>
-              <dd className="m-0 break-all font-mono text-white/60">
-                <HighlightText text={memory.id} />
-              </dd>
-            </div>
-            <div className="grid grid-cols-[5rem_minmax(0,1fr)] items-start gap-3">
-              <dt className="text-white/35">Observed</dt>
-              <dd className="m-0 text-white/60">
-                {formatMessageTimestamp(memory.observedAtMs)}
-              </dd>
-            </div>
-            <div className="grid grid-cols-[5rem_minmax(0,1fr)] items-start gap-3">
-              <dt className="text-white/35">Scope</dt>
-              <dd className="m-0 text-white/60">{memory.scope}</dd>
-            </div>
-            <div className="grid grid-cols-[5rem_minmax(0,1fr)] items-start gap-3">
-              <dt className="text-white/35">Kind</dt>
-              <dd className="m-0 text-white/60">{memory.kind}</dd>
-            </div>
-          </dl>
-
-          {index === props.memories.length - 1 ? (
-            <p className="m-0 mt-4 text-[0.7rem] text-white/30">
-              Loaded {formatMessageTimestamp(Date.parse(props.loadedAt))}
-            </p>
-          ) : null}
-        </article>
+        </details>
       ))}
+      <p className="m-0 border-t border-white/10 px-3 py-2 text-[0.68rem] text-white/30">
+        {props.memories.length}{" "}
+        {props.memories.length === 1 ? "memory" : "memories"} · Loaded{" "}
+        {formatMessageTimestamp(Date.parse(props.loadedAt))}
+      </p>
     </div>
   );
 }

--- a/packages/junior-dashboard/src/client/components/TranscriptTurnContextView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptTurnContextView.tsx
@@ -1,0 +1,102 @@
+import { Brain } from "lucide-react";
+
+import type { TranscriptViewTurnContext } from "../types";
+import { formatMessageTimestamp } from "../format";
+import {
+  memoryRecallContent,
+  type MemoryRecallContent,
+} from "../conversations/turnContext";
+import { HighlightText } from "./transcriptSearch";
+
+/** Render structured context attached to one transcript user message. */
+export function TranscriptTurnContextView(props: {
+  contexts: TranscriptViewTurnContext[];
+}) {
+  return (
+    <div className="grid gap-2">
+      {props.contexts.map((context, index) => (
+        <TurnContext
+          context={context}
+          key={`${context.pluginName}:${context.kind}:${context.version}:${index}`}
+        />
+      ))}
+    </div>
+  );
+}
+
+function TurnContext(props: { context: TranscriptViewTurnContext }) {
+  const memory = memoryRecallContent(props.context);
+  const count = memory?.memories.length;
+
+  return (
+    <details className="rounded-lg border border-cyan-300/15 bg-cyan-300/[0.035] px-3 py-2">
+      <summary className="flex cursor-pointer list-none items-center gap-2 text-[0.78rem] font-medium text-cyan-100/75 [&::-webkit-details-marker]:hidden">
+        <Brain aria-hidden="true" className="size-3.5" />
+        <span>
+          {count === undefined
+            ? `${props.context.pluginName} context`
+            : `${count} recalled ${count === 1 ? "memory" : "memories"}`}
+        </span>
+      </summary>
+      <div className="mt-3">
+        {memory ? (
+          <MemoryRecall
+            loadedAt={props.context.loadedAt}
+            memories={memory.memories}
+          />
+        ) : (
+          <GenericContext context={props.context} />
+        )}
+      </div>
+    </details>
+  );
+}
+
+function MemoryRecall(props: {
+  loadedAt: string;
+  memories: MemoryRecallContent["memories"];
+}) {
+  return (
+    <div className="grid gap-3">
+      <div className="text-[0.72rem] text-white/35">
+        Loaded {formatMessageTimestamp(Date.parse(props.loadedAt))}
+      </div>
+      {props.memories.map((memory) => (
+        <div
+          className="grid gap-2 border-t border-white/8 pt-3 first:border-t-0 first:pt-0"
+          key={memory.id}
+        >
+          <div className="whitespace-pre-wrap text-[0.82rem] leading-relaxed text-white/70">
+            <HighlightText text={memory.content} />
+          </div>
+          <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 text-[0.7rem]">
+            <dt className="text-white/30">ID</dt>
+            <dd className="truncate font-mono text-white/50">{memory.id}</dd>
+            <dt className="text-white/30">Observed</dt>
+            <dd className="text-white/50">
+              {formatMessageTimestamp(memory.observedAtMs)}
+            </dd>
+            <dt className="text-white/30">Scope</dt>
+            <dd className="text-white/50">{memory.scope}</dd>
+            <dt className="text-white/30">Kind</dt>
+            <dd className="text-white/50">{memory.kind}</dd>
+          </dl>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function GenericContext(props: { context: TranscriptViewTurnContext }) {
+  return (
+    <div className="grid gap-2">
+      <div className="text-[0.72rem] text-white/35">
+        {props.context.kind} v{props.context.version} · Loaded{" "}
+        {formatMessageTimestamp(Date.parse(props.context.loadedAt))}
+      </div>
+      <pre className="overflow-x-auto whitespace-pre-wrap break-words text-[0.72rem] leading-relaxed text-white/55">
+        <HighlightText text={JSON.stringify(props.context.content, null, 2)} />
+      </pre>
+    </div>
+  );
+}

--- a/packages/junior-dashboard/src/client/components/TranscriptTurnContextView.tsx
+++ b/packages/junior-dashboard/src/client/components/TranscriptTurnContextView.tsx
@@ -2,7 +2,7 @@ import { Brain, Braces, ChevronRight, X } from "lucide-react";
 import { useEffect, useId, useRef, useState } from "react";
 
 import type { TranscriptViewTurnContext } from "../types";
-import { formatMessageTimestamp } from "../format";
+import { formatMessageTimestamp, formatTime } from "../format";
 import {
   memoryRecallContent,
   type MemoryRecallContent,
@@ -218,7 +218,7 @@ function MemoryRecall(props: {
               <div className="grid grid-cols-[5rem_minmax(0,1fr)] items-start gap-3">
                 <dt className="text-white/35">Observed</dt>
                 <dd className="m-0 text-white/60">
-                  {formatMessageTimestamp(memory.observedAtMs)}
+                  {formatTime(new Date(memory.observedAtMs).toISOString())}
                 </dd>
               </div>
               <div className="grid grid-cols-[5rem_minmax(0,1fr)] items-start gap-3">

--- a/packages/junior-dashboard/src/client/components/transcriptSearch.tsx
+++ b/packages/junior-dashboard/src/client/components/transcriptSearch.tsx
@@ -5,7 +5,6 @@ import {
   messageRawText,
   type RenderedTranscriptEntry,
 } from "./transcriptRenderModel";
-import { turnContextSearchText } from "../conversations/turnContext";
 import { stringifyPartValue } from "../format";
 
 // ─── Context ────────────────────────────────────────────────────────────────
@@ -126,10 +125,7 @@ export function entryMatchesSearch(
   if (entry.kind === "message") {
     return (
       textContains(entry.message.eventType, normalizedQuery) ||
-      textContains(messageRawText(entry.message), normalizedQuery) ||
-      entry.message.contexts?.some((context) =>
-        textContains(turnContextSearchText(context), normalizedQuery),
-      ) === true
+      textContains(messageRawText(entry.message), normalizedQuery)
     );
   }
 

--- a/packages/junior-dashboard/src/client/components/transcriptSearch.tsx
+++ b/packages/junior-dashboard/src/client/components/transcriptSearch.tsx
@@ -5,6 +5,7 @@ import {
   messageRawText,
   type RenderedTranscriptEntry,
 } from "./transcriptRenderModel";
+import { turnContextSearchText } from "../conversations/turnContext";
 import { stringifyPartValue } from "../format";
 
 // ─── Context ────────────────────────────────────────────────────────────────
@@ -125,7 +126,10 @@ export function entryMatchesSearch(
   if (entry.kind === "message") {
     return (
       textContains(entry.message.eventType, normalizedQuery) ||
-      textContains(messageRawText(entry.message), normalizedQuery)
+      textContains(messageRawText(entry.message), normalizedQuery) ||
+      entry.message.contexts?.some((context) =>
+        textContains(turnContextSearchText(context), normalizedQuery),
+      ) === true
     );
   }
 

--- a/packages/junior-dashboard/src/client/conversations/eventTranscript.ts
+++ b/packages/junior-dashboard/src/client/conversations/eventTranscript.ts
@@ -136,6 +136,21 @@ export function conversationTranscriptMessages(
       continue;
     }
 
+    if (data.type === "turn_context") {
+      const message = latestUserMessageByTurn.get(data.turnId);
+      if (message) {
+        message.contexts ??= [];
+        message.contexts.push({
+          content: data.content,
+          kind: data.kind,
+          loadedAt: event.createdAt,
+          pluginName: data.pluginName,
+          version: data.version,
+        });
+      }
+      continue;
+    }
+
     if (data.type === "tool_calls") {
       for (const call of data.calls) ensureTool(event, call);
       continue;

--- a/packages/junior-dashboard/src/client/conversations/turnContext.ts
+++ b/packages/junior-dashboard/src/client/conversations/turnContext.ts
@@ -33,15 +33,3 @@ export function memoryRecallContent(context: TranscriptViewTurnContext) {
   const parsed = memoryRecallContentSchema.safeParse(context.content);
   return parsed.success ? parsed.data : undefined;
 }
-
-/** Flatten authorized context content for transcript-local search. */
-export function turnContextSearchText(
-  context: TranscriptViewTurnContext,
-): string {
-  return [
-    context.pluginName,
-    context.kind,
-    String(context.version),
-    JSON.stringify(context.content),
-  ].join(" ");
-}

--- a/packages/junior-dashboard/src/client/conversations/turnContext.ts
+++ b/packages/junior-dashboard/src/client/conversations/turnContext.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+import type { TranscriptViewTurnContext } from "../types";
+
+/** Dashboard parser for the first persisted memory recall context version. */
+export const memoryRecallContentSchema = z
+  .object({
+    memories: z.array(
+      z
+        .object({
+          id: z.string(),
+          content: z.string(),
+          observedAtMs: z.number(),
+          scope: z.enum(["personal", "conversation"]),
+          kind: z.enum(["preference", "procedure", "knowledge"]),
+        })
+        .strict(),
+    ),
+  })
+  .strict();
+
+export type MemoryRecallContent = z.output<typeof memoryRecallContentSchema>;
+
+/** Parse the first native memory recall context version. */
+export function memoryRecallContent(context: TranscriptViewTurnContext) {
+  if (
+    context.pluginName !== "memory" ||
+    context.kind !== "recall" ||
+    context.version !== 1
+  ) {
+    return undefined;
+  }
+  const parsed = memoryRecallContentSchema.safeParse(context.content);
+  return parsed.success ? parsed.data : undefined;
+}
+
+/** Flatten authorized context content for transcript-local search. */
+export function turnContextSearchText(
+  context: TranscriptViewTurnContext,
+): string {
+  return [
+    context.pluginName,
+    context.kind,
+    String(context.version),
+    JSON.stringify(context.content),
+  ].join(" ");
+}

--- a/packages/junior-dashboard/src/client/markdownExport.ts
+++ b/packages/junior-dashboard/src/client/markdownExport.ts
@@ -22,7 +22,9 @@ import type {
   TranscriptViewContextEventPart,
   TranscriptViewSubagentPart,
   TranscriptViewToolCallPart,
+  TranscriptViewTurnContext,
 } from "./types";
+import { memoryRecallContent } from "./conversations/turnContext";
 
 /** Build a clipboard Markdown transcript from the already-authorized dashboard report. */
 export function buildConversationMarkdown(
@@ -258,6 +260,43 @@ function appendMessage(
 
   const rawText = messageRawText(message);
   lines.push("", rawText.trim().length ? rawText : "_No content._");
+  appendTurnContexts(lines, message.contexts);
+}
+
+function appendTurnContexts(
+  lines: string[],
+  contexts: TranscriptViewTurnContext[] | undefined,
+): void {
+  for (const context of contexts ?? []) {
+    const memory = memoryRecallContent(context);
+    lines.push(
+      "",
+      memory
+        ? "#### Recalled memories"
+        : `#### ${headingText(context.kind)} context`,
+    );
+    addMetaLine(lines, "Plugin", context.pluginName);
+    addMetaLine(lines, "Loaded", context.loadedAt);
+    if (!memory) {
+      lines.push(
+        "",
+        "```json",
+        JSON.stringify(context.content, null, 2),
+        "```",
+      );
+      continue;
+    }
+    for (const item of memory.memories) {
+      lines.push(
+        "",
+        `- ${item.content}`,
+        `  - ID: ${inlineCode(item.id)}`,
+        `  - Observed: ${new Date(item.observedAtMs).toISOString()}`,
+        `  - Scope: ${item.scope}`,
+        `  - Kind: ${item.kind}`,
+      );
+    }
+  }
 }
 
 function appendSubagent(

--- a/packages/junior-dashboard/src/client/types.ts
+++ b/packages/junior-dashboard/src/client/types.ts
@@ -69,7 +69,16 @@ export type TranscriptViewPart =
   | TranscriptViewTextPart
   | TranscriptViewToolCallPart;
 
+export type TranscriptViewTurnContext = {
+  content: Record<string, unknown>;
+  kind: string;
+  loadedAt: string;
+  pluginName: string;
+  version: number;
+};
+
 export type TranscriptViewMessage = {
+  contexts?: TranscriptViewTurnContext[];
   eventType?: string;
   route?: {
     confidence?: number;

--- a/packages/junior-dashboard/src/mock-reporting/fixtures.ts
+++ b/packages/junior-dashboard/src/mock-reporting/fixtures.ts
@@ -132,6 +132,25 @@ function activeConversation(nowMs: number): ConversationDetailReport {
         state: "started",
       }),
       reportEvent(2, iso(Date.parse(startedAt), 8_000), {
+        type: "turn_context",
+        turnId: "active-turn",
+        pluginName: "memory",
+        kind: "recall",
+        version: 1,
+        content: {
+          memories: [
+            {
+              id: "memory-checkout-runbook",
+              content:
+                "Checkout latency investigations start with the deployment comparison dashboard.",
+              observedAtMs: Date.parse(startedAt) - 86_400_000,
+              scope: "conversation",
+              kind: "procedure",
+            },
+          ],
+        },
+      }),
+      reportEvent(3, iso(Date.parse(startedAt), 9_000), {
         type: "turn_routed",
         turnId: "active-turn",
         modelProfile: "handoff",
@@ -140,7 +159,7 @@ function activeConversation(nowMs: number): ConversationDetailReport {
         confidence: 0.93,
         source: "router",
       }),
-      reportEvent(3, iso(Date.parse(startedAt), 10_000), {
+      reportEvent(4, iso(Date.parse(startedAt), 10_000), {
         type: "tool_calls",
         calls: [
           {

--- a/packages/junior-dashboard/tests/markdownExport.test.ts
+++ b/packages/junior-dashboard/tests/markdownExport.test.ts
@@ -77,6 +77,47 @@ describe("dashboard canonical-event Markdown export", () => {
     expect(markdown).toContain("investigation complete\nfollow-up deployed");
   });
 
+  it("exports recalled memory context with its user message", () => {
+    const markdown = buildConversationMarkdown(
+      conversation([
+        event(0, {
+          type: "message",
+          messageId: "user-1",
+          role: "user",
+          text: "Prepare the release.",
+        }),
+        event(1, {
+          type: "turn_lifecycle",
+          turnId: "turn-1",
+          state: "started",
+        }),
+        event(2, {
+          type: "turn_context",
+          turnId: "turn-1",
+          pluginName: "memory",
+          kind: "recall",
+          version: 1,
+          content: {
+            memories: [
+              {
+                id: "memory-1",
+                content: "Release notes live in Notion.",
+                observedAtMs: Date.parse("2026-01-01T00:00:00.000Z"),
+                scope: "conversation",
+                kind: "knowledge",
+              },
+            ],
+          },
+        }),
+      ]),
+    );
+
+    expect(markdown).toContain("#### Recalled memories");
+    expect(markdown).toContain("Release notes live in Notion.");
+    expect(markdown).toContain("`memory-1`");
+    expect(markdown).toContain("Scope: conversation");
+  });
+
   it("exports resource events without attributing them to the actor", () => {
     const markdown = buildConversationMarkdown(
       conversation([

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -450,7 +450,7 @@ describe("dashboard canonical-event components", () => {
     expect(html).toContain("Agent response failed");
   });
 
-  it("renders recalled memory context on its user message", () => {
+  it("keeps recalled memory context collapsed on its user message", () => {
     const html = renderTranscript(
       conversation([
         event(0, {
@@ -485,11 +485,10 @@ describe("dashboard canonical-event components", () => {
       ]),
     );
 
-    expect(html).toContain("1 recalled memory");
-    expect(html).toContain("Release notes live in Notion.");
-    expect(html).toContain("memory-1");
-    expect(html).toContain("conversation");
-    expect(html).toContain("knowledge");
+    expect(html).toContain('aria-label="View turn context"');
+    expect(html).toContain('aria-expanded="false"');
+    expect(html).not.toContain("Release notes live in Notion.");
+    expect(html).not.toContain("memory-1");
   });
 
   it("renders a delivery terminal failure without treating it as an agent failure", () => {

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -450,6 +450,48 @@ describe("dashboard canonical-event components", () => {
     expect(html).toContain("Agent response failed");
   });
 
+  it("renders recalled memory context on its user message", () => {
+    const html = renderTranscript(
+      conversation([
+        event(0, {
+          type: "message",
+          messageId: "user-1",
+          role: "user",
+          text: "Prepare the release.",
+        }),
+        event(1, {
+          type: "turn_lifecycle",
+          turnId: "turn-1",
+          state: "started",
+        }),
+        event(2, {
+          type: "turn_context",
+          turnId: "turn-1",
+          pluginName: "memory",
+          kind: "recall",
+          version: 1,
+          content: {
+            memories: [
+              {
+                id: "memory-1",
+                content: "Release notes live in Notion.",
+                observedAtMs: Date.parse("2026-01-01T00:00:00.000Z"),
+                scope: "conversation",
+                kind: "knowledge",
+              },
+            ],
+          },
+        }),
+      ]),
+    );
+
+    expect(html).toContain("1 recalled memory");
+    expect(html).toContain("Release notes live in Notion.");
+    expect(html).toContain("memory-1");
+    expect(html).toContain("conversation");
+    expect(html).toContain("knowledge");
+  });
+
   it("renders a delivery terminal failure without treating it as an agent failure", () => {
     const html = renderTranscript(
       conversation([

--- a/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
+++ b/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
@@ -436,7 +436,7 @@ describe("canonical event transcript reduction", () => {
     );
   });
 
-  it("attaches turn context to the user message and searches its content", () => {
+  it("attaches turn context without matching its hidden content", () => {
     const messages = conversationTranscriptMessages(
       conversation([
         event(0, "2026-01-01T00:00:00.000Z", {
@@ -473,8 +473,8 @@ describe("canonical event transcript reduction", () => {
     const entries = groupTranscriptMessages(messages);
 
     expect(messages[0]?.contexts).toHaveLength(1);
-    expect(entryMatchesSearch(entries[0]!, "release notes")).toBe(true);
-    expect(entryMatchesSearch(entries[0]!, "memory-1")).toBe(true);
+    expect(entryMatchesSearch(entries[0]!, "release notes")).toBe(false);
+    expect(entryMatchesSearch(entries[0]!, "memory-1")).toBe(false);
   });
 
   it("correlates repeated child outcomes by start sequence", () => {

--- a/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
+++ b/packages/junior-dashboard/tests/transcriptRenderModel.test.ts
@@ -436,6 +436,47 @@ describe("canonical event transcript reduction", () => {
     );
   });
 
+  it("attaches turn context to the user message and searches its content", () => {
+    const messages = conversationTranscriptMessages(
+      conversation([
+        event(0, "2026-01-01T00:00:00.000Z", {
+          type: "message",
+          messageId: "user-1",
+          role: "user",
+          text: "Prepare the release.",
+        }),
+        event(1, "2026-01-01T00:00:01.000Z", {
+          type: "turn_lifecycle",
+          turnId: "turn-1",
+          state: "started",
+        }),
+        event(2, "2026-01-01T00:00:02.000Z", {
+          type: "turn_context",
+          turnId: "turn-1",
+          pluginName: "memory",
+          kind: "recall",
+          version: 1,
+          content: {
+            memories: [
+              {
+                id: "memory-1",
+                content: "Release notes live in Notion.",
+                observedAtMs: 1_750_000_000_000,
+                scope: "conversation",
+                kind: "knowledge",
+              },
+            ],
+          },
+        }),
+      ]),
+    );
+    const entries = groupTranscriptMessages(messages);
+
+    expect(messages[0]?.contexts).toHaveLength(1);
+    expect(entryMatchesSearch(entries[0]!, "release notes")).toBe(true);
+    expect(entryMatchesSearch(entries[0]!, "memory-1")).toBe(true);
+  });
+
   it("correlates repeated child outcomes by start sequence", () => {
     const messages = conversationTranscriptMessages(
       conversation([

--- a/packages/junior-memory/src/plugin.ts
+++ b/packages/junior-memory/src/plugin.ts
@@ -11,7 +11,7 @@ import {
   type MemoryToolContext,
 } from "./tools";
 import { processMemorySession } from "./process-session";
-import { createMemoryPromptMessages } from "./recall";
+import { createMemoryPromptContributions } from "./recall";
 import type { MemoryDb } from "./store";
 
 const MEMORY_MODEL_ENV = "AI_MEMORY_MODEL";
@@ -132,7 +132,7 @@ export function createMemoryPlugin(options: MemoryPluginOptions = {}) {
         };
       },
       async userPrompt(ctx) {
-        return await createMemoryPromptMessages({
+        return await createMemoryPromptContributions({
           ...(ctx.conversationId ? { conversationId: ctx.conversationId } : {}),
           ...(ctx.actor ? { actor: ctx.actor } : {}),
           db: ctx.db as MemoryDb,

--- a/packages/junior-memory/src/recall.ts
+++ b/packages/junior-memory/src/recall.ts
@@ -1,4 +1,10 @@
-import type { PromptMessage, Actor, Source } from "@sentry/junior-plugin-api";
+import {
+  definePromptContext,
+  type UserPromptContribution,
+  type Actor,
+  type Source,
+} from "@sentry/junior-plugin-api";
+import { z } from "zod";
 import {
   createMemoryStore,
   type MemoryDb,
@@ -34,35 +40,78 @@ function formatObservedDate(observedAtMs: number): string {
   return new Date(observedAtMs).toISOString().slice(0, 10);
 }
 
-function renderMemoryPrompt(memories: MemoryRecord[]): string | undefined {
+const recalledMemorySchema = z
+  .object({
+    id: z.string().min(1),
+    content: z.string().min(1).max(MAX_MEMORY_LINE_CHARS),
+    observedAtMs: z.number().finite(),
+    scope: z.enum(["personal", "conversation"]),
+    kind: z.enum(["preference", "procedure", "knowledge"]),
+  })
+  .strict();
+
+/** Structured snapshot retained for one automatic memory recall. */
+export const memoryRecallContextSchema = z
+  .object({
+    memories: z.array(recalledMemorySchema).min(1).max(DEFAULT_RECALL_LIMIT),
+  })
+  .strict();
+
+type RecalledMemory = z.output<typeof recalledMemorySchema>;
+
+function selectPromptMemories(memories: MemoryRecord[]): RecalledMemory[] {
   const header = "Relevant memories for this request:";
   const footer =
     "Treat these as possibly stale context. Current user instructions and repository evidence take priority.";
-  const lines: string[] = [];
+  const selected: RecalledMemory[] = [];
   let totalChars = header.length + footer.length + 2;
 
   for (const memory of memories) {
-    const line = `- Observed ${formatObservedDate(memory.observedAtMs)}: ${trimContent(
-      memory.content,
-      MAX_MEMORY_LINE_CHARS,
-    )}`;
+    const content = trimContent(memory.content, MAX_MEMORY_LINE_CHARS);
+    const line = `- Observed ${formatObservedDate(memory.observedAtMs)}: ${content}`;
     if (totalChars + line.length + 1 > MAX_PROMPT_CHARS) {
       break;
     }
-    lines.push(line);
+    selected.push({
+      id: memory.id,
+      content,
+      observedAtMs: memory.observedAtMs,
+      scope: memory.scope,
+      kind: memory.kind,
+    });
     totalChars += line.length + 1;
   }
-
-  if (lines.length === 0) {
-    return undefined;
-  }
-  return `${header}\n${lines.join("\n")}\n\n${footer}`;
+  return selected;
 }
 
-/** Build the memory prompt contribution for active visible recall. */
-export async function createMemoryPromptMessages(
+function renderMemoryPrompt(memories: RecalledMemory[]): string {
+  return [
+    "Relevant memories for this request:",
+    ...memories.map(
+      (memory) =>
+        `- Observed ${formatObservedDate(memory.observedAtMs)}: ${memory.content}`,
+    ),
+    "",
+    "Treat these as possibly stale context. Current user instructions and repository evidence take priority.",
+  ].join("\n");
+}
+
+const memoryRecallContext = definePromptContext({
+  kind: "recall",
+  version: 1,
+  schema: memoryRecallContextSchema,
+  renderPrompt: (content) => renderMemoryPrompt(content.memories),
+});
+
+/**
+ * Build active memory recall contributions.
+ *
+ * Personal recall remains prompt-only so conversation reporting cannot widen
+ * actor-scoped memory visibility.
+ */
+export async function createMemoryPromptContributions(
   context: MemoryRecallContext,
-): Promise<PromptMessage[] | undefined> {
+): Promise<UserPromptContribution[] | undefined> {
   if (!context.text.trim()) {
     return undefined;
   }
@@ -82,6 +131,12 @@ export async function createMemoryPromptMessages(
     query: context.text,
     limit: DEFAULT_RECALL_LIMIT,
   });
-  const text = renderMemoryPrompt(memories);
-  return text ? [{ text }] : undefined;
+  const selected = selectPromptMemories(memories);
+  if (selected.length === 0) {
+    return undefined;
+  }
+  if (selected.some((memory) => memory.scope === "personal")) {
+    return [{ text: renderMemoryPrompt(selected) }];
+  }
+  return [memoryRecallContext({ memories: selected })];
 }

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -2919,7 +2919,7 @@ WHERE id = '${superseded.memory.id}'
     }
   }, 15_000);
 
-  it("injects visible active memories into user prompt context", async () => {
+  it("keeps personal memory recall out of durable prompt context", async () => {
     const fixture = await createMemoryFixture();
 
     try {
@@ -2969,18 +2969,71 @@ WHERE id = '${superseded.memory.id}'
         text: "Draft a PR summary and mention release notes.",
       });
 
-      expect(result).toEqual([
-        {
-          text: expect.stringContaining(personal.memory.content),
-        },
-      ]);
-      const text = result?.[0]?.text ?? "";
+      const contribution = result?.[0];
+      expect(contribution && "text" in contribution).toBe(true);
+      if (!contribution || !("text" in contribution)) {
+        throw new Error("Memory recall did not return prompt text");
+      }
+      const text = contribution.text;
       expect(text).toContain(`Observed 2026-06-19: ${personal.memory.content}`);
       expect(text).toContain(conversation.memory.content);
       expect(text).not.toContain(personal.memory.id);
       expect(text).not.toContain(conversation.memory.id);
       expect(text).not.toContain("obsolete wording");
       expect(text).not.toContain("unrelated owner");
+    } finally {
+      await fixture.close();
+    }
+  }, 15_000);
+
+  it("retains conversation memory recall as structured prompt context", async () => {
+    const fixture = await createMemoryFixture();
+
+    try {
+      const context = slackContext();
+      const conversation = await createMemoryStore(memoryDb(fixture), context, {
+        now: () => TEST_NOW_MS,
+      }).createConversationMemory({
+        content: "Release notes live in Notion.",
+        kind: "knowledge",
+        idempotencyKey: "memory-test:recall-conversation-context",
+      });
+
+      const plugin = createMemoryPlugin();
+      const result = await plugin.hooks?.userPrompt?.({
+        ...context,
+        destination: slackDestination(context),
+        db: memoryDb(fixture),
+        embedder: createTestEmbedder(),
+        log: noopLogger,
+        plugin: { name: "memory" },
+        state: memoryState,
+        text: "Where do release notes live?",
+      });
+
+      const contribution = result?.[0];
+      expect(contribution && "context" in contribution).toBe(true);
+      if (!contribution || !("context" in contribution)) {
+        throw new Error("Memory recall did not return structured context");
+      }
+      expect(contribution.context).toEqual({
+        kind: "recall",
+        version: 1,
+        content: {
+          memories: [
+            {
+              id: conversation.memory.id,
+              content: conversation.memory.content,
+              kind: conversation.memory.kind,
+              observedAtMs: conversation.memory.observedAtMs,
+              scope: "conversation",
+            },
+          ],
+        },
+      });
+      expect(contribution.renderPrompt()).toContain(
+        conversation.memory.content,
+      );
     } finally {
       await fixture.close();
     }
@@ -3036,22 +3089,22 @@ WHERE id = '${superseded.memory.id}'
       });
 
       const plugin = createMemoryPlugin();
-      await expect(
-        plugin.hooks?.userPrompt?.({
-          ...context,
-          destination: slackDestination(context),
-          db: memoryDb(fixture),
-          embedder,
-          log: noopLogger,
-          plugin: { name: "memory" },
-          state: memoryState,
-          text: query,
-        }),
-      ).resolves.toEqual([
-        {
-          text: expect.stringContaining(memory),
-        },
-      ]);
+      const result = await plugin.hooks?.userPrompt?.({
+        ...context,
+        destination: slackDestination(context),
+        db: memoryDb(fixture),
+        embedder,
+        log: noopLogger,
+        plugin: { name: "memory" },
+        state: memoryState,
+        text: query,
+      });
+      const contribution = result?.[0];
+      expect(contribution && "text" in contribution).toBe(true);
+      if (!contribution || !("text" in contribution)) {
+        throw new Error("Memory recall did not return prompt text");
+      }
+      expect(contribution.text).toContain(memory);
     } finally {
       await fixture.close();
     }

--- a/packages/junior-memory/tests/storage.test.ts
+++ b/packages/junior-memory/tests/storage.test.ts
@@ -3031,8 +3031,13 @@ WHERE id = '${superseded.memory.id}'
           ],
         },
       });
-      expect(contribution.renderPrompt()).toContain(
-        conversation.memory.content,
+      expect(contribution.renderPrompt()).toBe(
+        [
+          "Relevant memories for this request:",
+          "- Observed 2026-06-19: Release notes live in Notion.",
+          "",
+          "Treat these as possibly stale context. Current user instructions and repository evidence take priority.",
+        ].join("\n"),
       );
     } finally {
       await fixture.close();

--- a/packages/junior-plugin-api/src/hooks.ts
+++ b/packages/junior-plugin-api/src/hooks.ts
@@ -29,6 +29,7 @@ import type {
   PromptMessage,
   SystemPromptContext,
   UserPromptContext,
+  UserPromptContribution,
 } from "./prompt";
 
 export interface PluginHooks {
@@ -37,7 +38,10 @@ export interface PluginHooks {
   ): Promise<PromptMessage[]> | PromptMessage[];
   userPrompt?(
     ctx: UserPromptContext,
-  ): Promise<PromptMessage[] | undefined> | PromptMessage[] | undefined;
+  ):
+    | Promise<UserPromptContribution[] | undefined>
+    | UserPromptContribution[]
+    | undefined;
   beforeToolExecute?(ctx: BeforeToolExecuteHookContext): Promise<void> | void;
   grantForEgress?(
     ctx: EgressHookContext,

--- a/packages/junior-plugin-api/src/index.ts
+++ b/packages/junior-plugin-api/src/index.ts
@@ -3,9 +3,14 @@ export * from "./schemas";
 export * from "./context";
 export * from "./state";
 export {
+  definePromptContext,
+  promptContextSchema,
   promptMessageSchema,
+  type PromptContext,
+  type PromptContextContribution,
   type PromptMessage,
   type SystemPromptContext,
+  type UserPromptContribution,
   type UserPromptContext,
 } from "./prompt";
 export * from "./dispatch";

--- a/packages/junior-plugin-api/src/prompt.ts
+++ b/packages/junior-plugin-api/src/prompt.ts
@@ -9,6 +9,13 @@ import type {
 } from "./context";
 import type { PluginState } from "./state";
 
+const promptContextKindSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(64)
+  .regex(/^[a-z][a-z0-9_-]*$/);
+
 export const promptMessageSchema = z
   .object({
     text: z.string().trim().min(1).max(8_000),
@@ -17,6 +24,47 @@ export const promptMessageSchema = z
 
 /** Small plugin-owned prompt text block rendered by Junior core. */
 export type PromptMessage = z.output<typeof promptMessageSchema>;
+
+export const promptContextSchema = z
+  .object({
+    kind: promptContextKindSchema,
+    version: z.number().int().positive(),
+    content: z.record(z.string(), z.unknown()),
+  })
+  .strict();
+
+/** Structured plugin context retained alongside its model-visible rendering. */
+export type PromptContext = z.output<typeof promptContextSchema>;
+
+/** Runtime contribution produced from one validated plugin context value. */
+export interface PromptContextContribution {
+  context: PromptContext;
+  renderPrompt(): string;
+}
+
+/** Define one typed, versioned plugin context contribution. */
+export function definePromptContext<
+  TSchema extends z.ZodType<Record<string, unknown>>,
+>(definition: {
+  kind: string;
+  version: number;
+  schema: TSchema;
+  renderPrompt(content: z.output<TSchema>): string;
+}): (content: z.input<TSchema>) => PromptContextContribution {
+  const identity = promptContextSchema
+    .pick({ kind: true, version: true })
+    .parse({ kind: definition.kind, version: definition.version });
+  return (content) => {
+    const parsed = definition.schema.parse(content);
+    return {
+      context: { ...identity, content: parsed },
+      renderPrompt: () => definition.renderPrompt(parsed),
+    };
+  };
+}
+
+/** One request-scoped plugin contribution to the model-visible user prompt. */
+export type UserPromptContribution = PromptMessage | PromptContextContribution;
 
 /** Stable platform context for plugin system prompt guidance. */
 export type SystemPromptContext = Pick<

--- a/packages/junior/src/api/conversations/events.ts
+++ b/packages/junior/src/api/conversations/events.ts
@@ -14,6 +14,7 @@ export const conversationReportSourceEventTypes = [
   "tool_result",
   "tool_execution_started",
   "turn_started",
+  "turn_context",
   "turn_routed",
   "turn_completed",
   "turn_failed",
@@ -217,6 +218,18 @@ function reportEventData(args: {
         type: "turn_lifecycle",
         turnId: data.turnId,
         state: "started",
+      };
+    case "turn_context":
+      if (!args.canExposePayload) {
+        return undefined;
+      }
+      return {
+        type: "turn_context",
+        turnId: data.turnId,
+        pluginName: data.pluginName,
+        kind: data.kind,
+        version: data.version,
+        content: data.content,
       };
     case "turn_routed":
       return {

--- a/packages/junior/src/api/schema/conversation.ts
+++ b/packages/junior/src/api/schema/conversation.ts
@@ -173,6 +173,17 @@ const conversationReportTurnRoutedEventDataSchema = z
   })
   .strict();
 
+const conversationReportTurnContextEventDataSchema = z
+  .object({
+    type: z.literal("turn_context"),
+    turnId: z.string().min(1),
+    pluginName: z.string().min(1),
+    kind: z.string().min(1),
+    version: z.number().int().positive(),
+    content: z.record(z.string(), z.unknown()),
+  })
+  .strict();
+
 const conversationReportCompactionEventDataSchema = z
   .object({
     type: z.literal("compaction"),
@@ -224,6 +235,7 @@ export const conversationReportEventDataSchema = z.discriminatedUnion("type", [
   conversationReportMessageHandledEventDataSchema,
   conversationReportToolCallsEventDataSchema,
   conversationReportTurnLifecycleEventDataSchema,
+  conversationReportTurnContextEventDataSchema,
   conversationReportTurnRoutedEventDataSchema,
   conversationReportCompactionEventDataSchema,
   conversationReportHandoffEventDataSchema,

--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -742,6 +742,7 @@ async function executeAgentRunInPrivacyContext(
       promptContentParts,
       promptHistoryMessages,
       shouldPromptAgent,
+      turnContexts,
     } = await assemblePrompt({
       activeMcpCatalogs: wiring.activeMcpCatalogs,
       currentActor: actor,
@@ -761,6 +762,7 @@ async function executeAgentRunInPrivacyContext(
       toolRuntimeContext: wiring.toolRuntimeContext,
       userContentParts,
     });
+    runResume.setTurnContexts(turnContexts);
     /** Apply a committed handoff to Pi and reset its durable resume baseline. */
     const applyPendingHandoff = (): AgentLoopTurnUpdate | undefined => {
       if (!pendingHandoff) {

--- a/packages/junior/src/chat/agent/prompt.ts
+++ b/packages/junior/src/chat/agent/prompt.ts
@@ -30,6 +30,7 @@ import type { ToolRuntimeContext } from "@/chat/tools/types";
 import type { AnyToolDefinition } from "@/chat/tools/definition";
 import { isUserActor, type Actor } from "@/chat/actor";
 import type { ThreadArtifactsState } from "@/chat/state/artifacts";
+import type { PluginTurnContext } from "@/chat/plugins/prompt";
 import type {
   AgentRunInput,
   AgentRunInstructionActor,
@@ -63,6 +64,7 @@ export interface PromptAssembly {
   promptContentParts: UserContentPart[];
   promptHistoryMessages: PiMessage[];
   shouldPromptAgent: boolean;
+  turnContexts: PluginTurnContext[];
 }
 
 function isStructuredThreadContext(context: string): boolean {
@@ -458,5 +460,8 @@ export async function assemblePrompt(args: {
     promptContentParts,
     promptHistoryMessages,
     shouldPromptAgent,
+    turnContexts: pluginUserPromptContributions.flatMap((contribution) =>
+      contribution.context ? [contribution.context] : [],
+    ),
   };
 }

--- a/packages/junior/src/chat/agent/prompt.ts
+++ b/packages/junior/src/chat/agent/prompt.ts
@@ -340,6 +340,57 @@ function userPromptContentMatches(
   return isDeepStrictEqual(storedContent, currentContent);
 }
 
+function isUserContentPart(value: unknown): value is UserContentPart {
+  if (typeof value !== "object" || value === null || !("type" in value)) {
+    return false;
+  }
+  if (value.type === "text") {
+    return "text" in value && typeof value.text === "string";
+  }
+  return (
+    value.type === "image" &&
+    "data" in value &&
+    typeof value.data === "string" &&
+    "mimeType" in value &&
+    typeof value.mimeType === "string"
+  );
+}
+
+// A failed input acknowledgement redelivers the same running checkpoint.
+// Reuse its exact prompt so plugin context cannot diverge from its durable event.
+function checkpointedPromptContent(args: {
+  messages: PiMessage[] | undefined;
+  turnStartMessageIndex: number | undefined;
+  userContentParts: UserContentPart[];
+}): UserContentPart[] | undefined {
+  if (
+    !args.messages ||
+    args.turnStartMessageIndex === undefined ||
+    args.turnStartMessageIndex !== args.messages.length - 1
+  ) {
+    return undefined;
+  }
+  const message = args.messages[args.turnStartMessageIndex] as
+    | { content?: unknown; role?: unknown }
+    | undefined;
+  if (message?.role !== "user" || !Array.isArray(message.content)) {
+    return undefined;
+  }
+  const durableMessage = stripRuntimeTurnContext([message as PiMessage])[0] as
+    | { content?: unknown }
+    | undefined;
+  if (
+    !userPromptContentMatches(durableMessage?.content, args.userContentParts)
+  ) {
+    return undefined;
+  }
+  const content = message.content;
+  if (!content.every(isUserContentPart)) {
+    return undefined;
+  }
+  return content;
+}
+
 /** Assemble prompt history, instructions, and telemetry input for one slice. */
 export async function assemblePrompt(args: {
   activeMcpCatalogs: ActiveMcpCatalogSummary[];
@@ -379,8 +430,18 @@ export async function assemblePrompt(args: {
         args.userContentParts,
       )
     : args.existingSessionPiMessages!;
+  const replayedPromptContent =
+    shouldPromptAgent && !args.resumedFromSessionRecord
+      ? checkpointedPromptContent({
+          messages: args.existingSessionPiMessages,
+          turnStartMessageIndex: args.existingTurnStartMessageIndex,
+          userContentParts: args.userContentParts,
+        })
+      : undefined;
   const needsBootstrapContextForPrompt =
-    shouldPromptAgent && !hasRuntimeTurnContext(promptHistoryMessages);
+    shouldPromptAgent &&
+    !replayedPromptContent &&
+    !hasRuntimeTurnContext(promptHistoryMessages);
   const systemPromptContributions =
     await getPluginSystemPromptContributions(source);
   const pluginSystemPrompt = buildPluginSystemPromptContributions(
@@ -389,11 +450,12 @@ export async function assemblePrompt(args: {
   const baseInstructions = [buildSystemPrompt({ source }), pluginSystemPrompt]
     .filter((section): section is string => Boolean(section))
     .join("\n\n");
-  const pluginUserPromptContributions = !shouldPromptAgent
-    ? []
-    : await getPluginUserPromptContributions({
-        context: args.toolRuntimeContext,
-      });
+  const pluginUserPromptContributions =
+    !shouldPromptAgent || replayedPromptContent
+      ? []
+      : await getPluginUserPromptContributions({
+          context: args.toolRuntimeContext,
+        });
   const turnContextPrompt =
     needsBootstrapContextForPrompt || pluginUserPromptContributions.length > 0
       ? buildTurnContextPrompt({
@@ -422,7 +484,10 @@ export async function assemblePrompt(args: {
   const turnContextParts: UserContentPart[] = turnContextPrompt
     ? [{ type: "text", text: turnContextPrompt }]
     : [];
-  const promptContentParts = [...turnContextParts, ...args.userContentParts];
+  const promptContentParts = replayedPromptContent ?? [
+    ...turnContextParts,
+    ...args.userContentParts,
+  ];
 
   const inputMessages = [
     {

--- a/packages/junior/src/chat/agent/resume.ts
+++ b/packages/junior/src/chat/agent/resume.ts
@@ -40,6 +40,7 @@ import {
   type AgentRunDurability,
 } from "@/chat/agent/request";
 import { TurnSliceLimitExceededError } from "@/chat/services/turn-limit";
+import type { PluginTurnContext } from "@/chat/plugins/prompt";
 
 type LoadedSessionRecordState = Awaited<
   ReturnType<typeof loadTurnSessionRecord>
@@ -86,6 +87,7 @@ export function createResumeState(args: ResumeStateArgs) {
   let latestSafeBoundaryMessages: PiMessage[] = [];
   let timedOut = false;
   let resumeMessages: PiMessage[] = [];
+  let turnContexts: PluginTurnContext[] = [];
   let turnStartMessageIndex: number | undefined;
 
   const currentSliceId = args.sessionRecordState.currentSliceId;
@@ -124,6 +126,9 @@ export function createResumeState(args: ResumeStateArgs) {
     setBeforeMessageCount(count: number): void {
       beforeMessageCount = count;
     },
+    setTurnContexts(contexts: PluginTurnContext[]): void {
+      turnContexts = contexts;
+    },
     /** Adopt an already committed epoch replacement as every resume baseline. */
     adoptCommittedBoundary(messages: PiMessage[]): void {
       latestSafeBoundaryMessages = [...messages];
@@ -156,6 +161,7 @@ export function createResumeState(args: ResumeStateArgs) {
         sliceId: currentSliceId,
         messages,
         ...(trailingMessageProvenance ? { trailingMessageProvenance } : {}),
+        ...(turnContexts.length > 0 ? { turnContexts } : {}),
         ...(turnStartMessageIndex !== undefined
           ? { turnStartMessageIndex }
           : {}),

--- a/packages/junior/src/chat/conversations/history.ts
+++ b/packages/junior/src/chat/conversations/history.ts
@@ -257,6 +257,17 @@ const turnRoutedEventDataSchema = z
   })
   .strict();
 
+const turnContextEventDataSchema = z
+  .object({
+    type: z.literal("turn_context"),
+    turnId: z.string().min(1),
+    pluginName: z.string().min(1),
+    kind: z.string().min(1).max(64),
+    version: z.number().int().positive(),
+    content: z.record(z.string(), z.unknown()),
+  })
+  .strict();
+
 const turnCompletedEventDataSchema = z
   .object({
     type: z.literal("turn_completed"),
@@ -316,6 +327,7 @@ const appendableConversationEventDataSchema = z.union([
   messageHandledEventDataSchema,
   messagesSummarizedEventDataSchema,
   turnStartedEventDataSchema,
+  turnContextEventDataSchema,
   turnRoutedEventDataSchema,
   turnCompletedEventDataSchema,
   turnFailedEventDataSchema,
@@ -350,6 +362,7 @@ export const KNOWN_CONVERSATION_EVENT_TYPES = [
   "message_handled",
   "messages_summarized",
   "turn_started",
+  "turn_context",
   "turn_routed",
   "turn_completed",
   "turn_failed",

--- a/packages/junior/src/chat/conversations/projection.ts
+++ b/packages/junior/src/chat/conversations/projection.ts
@@ -29,6 +29,7 @@ import { stripRuntimeTurnContext } from "@/chat/pi/transcript";
 import { sanitizePostgresJson } from "@/db/postgres-json";
 import type { ModelProfile } from "@/chat/model-profile";
 import type { TurnReasoningLevel } from "@/chat/reasoning-level";
+import type { PluginTurnContext } from "@/chat/plugins/prompt";
 
 /** Distinct MCP providers durably connected in the given events, sorted. */
 function connectedMcpProvidersFromEvents(
@@ -225,6 +226,11 @@ export async function commitMessages(args: {
   trailingMessageProvenance?: ConversationMessageProvenance[];
   /** Default applied to the last new user message when no explicit array. */
   newMessageProvenance?: ConversationMessageProvenance;
+  /** Structured plugin context committed atomically with this turn's input. */
+  turnContext?: {
+    contexts: PluginTurnContext[];
+    turnId: string;
+  };
   /** SQL authority for the atomic commit; defaults to the process executor. */
   executor?: JuniorSqlDatabase;
 }): Promise<{
@@ -280,16 +286,32 @@ async function commitMessagesLocked(
   });
   if (matchingPrefix === current.messages.length) {
     const newMessages = nextLocalMessages.slice(matchingPrefix);
-    await eventStore.append(
-      args.conversationId,
-      newMessages.map((message, index) => ({
+    const turnContext = args.turnContext;
+    const turnContextEvents =
+      turnContext?.contexts.map((context, index) => ({
+        idempotencyKey:
+          `turn:${turnContext.turnId}:context:` +
+          `${context.pluginName}:${index}`,
+        createdAtMs: context.loadedAtMs,
+        data: {
+          type: "turn_context" as const,
+          turnId: turnContext.turnId,
+          pluginName: context.pluginName,
+          kind: context.kind,
+          version: context.version,
+          content: context.content,
+        },
+      })) ?? [];
+    await eventStore.append(args.conversationId, [
+      ...newMessages.map((message, index) => ({
         data: historyItemFromPiMessage(
           message,
           nextLocalProvenance[matchingPrefix + index]!,
         ),
         createdAtMs: messageTimestamp(message),
       })),
-    );
+      ...turnContextEvents,
+    ]);
   } else {
     throw new Error(
       `Agent history for ${args.conversationId} changed before its committed boundary`,

--- a/packages/junior/src/chat/plugins/agent-hooks.ts
+++ b/packages/junior/src/chat/plugins/agent-hooks.ts
@@ -1,4 +1,5 @@
 import {
+  promptContextSchema,
   promptMessageSchema,
   resourceEventSchema,
 } from "@sentry/junior-plugin-api";
@@ -94,8 +95,9 @@ const PLUGIN_ROUTE_METHODS = new Set<PluginRouteMethod>([
   "ALL",
 ]);
 const PLUGIN_PROMPT_CONTRIBUTION_TOTAL_MAX_CHARS = 16_000;
+const PLUGIN_PROMPT_CONTEXT_MAX_BYTES = 8_000;
+const PLUGIN_PROMPT_CONTEXT_TOTAL_MAX_BYTES = 16_000;
 const systemPromptMessageArraySchema = z.array(promptMessageSchema);
-const userPromptMessageArraySchema = z.array(promptMessageSchema);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
@@ -179,6 +181,62 @@ function toPromptContributionContext(args: {
     id: `${args.hookName}:${args.index}`,
     pluginName: args.pluginName,
     text: args.message.text,
+  };
+}
+
+function normalizePromptContext(value: unknown): Record<string, unknown> {
+  const serialized = JSON.stringify(value);
+  if (
+    serialized === undefined ||
+    Buffer.byteLength(serialized, "utf8") > PLUGIN_PROMPT_CONTEXT_MAX_BYTES
+  ) {
+    throw new TypeError("Plugin prompt context exceeded its serialized budget");
+  }
+  const parsed = JSON.parse(serialized);
+  if (!isRecord(parsed)) {
+    throw new TypeError("Plugin prompt context must be a JSON object");
+  }
+  return parsed;
+}
+
+function toUserPromptContributionContext(args: {
+  index: number;
+  pluginName: string;
+  value: unknown;
+}): PluginPromptContributionContext | undefined {
+  const message = promptMessageSchema.safeParse(args.value);
+  if (message.success) {
+    return toPromptContributionContext({
+      hookName: "userPrompt",
+      index: args.index,
+      message: message.data,
+      pluginName: args.pluginName,
+    });
+  }
+  if (!isRecord(args.value) || typeof args.value.renderPrompt !== "function") {
+    return undefined;
+  }
+  const context = promptContextSchema.safeParse(args.value.context);
+  if (!context.success) {
+    return undefined;
+  }
+  const text = promptMessageSchema.safeParse({
+    text: args.value.renderPrompt(),
+  });
+  if (!text.success) {
+    return undefined;
+  }
+  return {
+    id: `userPrompt:${args.index}`,
+    pluginName: args.pluginName,
+    text: text.data.text,
+    context: {
+      content: normalizePromptContext(context.data.content),
+      kind: context.data.kind,
+      loadedAtMs: Date.now(),
+      pluginName: args.pluginName,
+      version: context.data.version,
+    },
   };
 }
 
@@ -322,6 +380,7 @@ export async function getPluginUserPromptContributions(args: {
 }): Promise<PluginPromptContributionContext[]> {
   const contributions: PluginPromptContributionContext[] = [];
   let totalChars = 0;
+  let totalContextBytes = 0;
   for (const plugin of getPlugins()) {
     const pluginName = plugin.manifest.name;
     const hook = plugin.hooks?.userPrompt;
@@ -335,8 +394,7 @@ export async function getPluginUserPromptContributions(args: {
       if (rawResult === undefined) {
         continue;
       }
-      const result = userPromptMessageArraySchema.safeParse(rawResult);
-      if (!result.success) {
+      if (!Array.isArray(rawResult)) {
         logInvalidPromptContributions({
           hookName: "userPrompt",
           pluginName,
@@ -344,21 +402,40 @@ export async function getPluginUserPromptContributions(args: {
         continue;
       }
 
-      const acceptedContributions = result.data.map((message, index) =>
-        toPromptContributionContext({
-          hookName: "userPrompt",
-          index,
-          message,
-          pluginName,
-        }),
+      const acceptedContributions = rawResult.map((value, index) =>
+        toUserPromptContributionContext({ index, pluginName, value }),
       );
-      const pluginContributionChars = acceptedContributions.reduce(
+      if (acceptedContributions.some((contribution) => !contribution)) {
+        logInvalidPromptContributions({
+          hookName: "userPrompt",
+          pluginName,
+        });
+        continue;
+      }
+      const validContributions = acceptedContributions.filter(
+        (contribution): contribution is PluginPromptContributionContext =>
+          contribution !== undefined,
+      );
+      const pluginContributionChars = validContributions.reduce(
         (sum, contribution) => sum + contribution.text.length,
+        0,
+      );
+      const pluginContextBytes = validContributions.reduce(
+        (sum, contribution) =>
+          sum +
+          (contribution.context
+            ? Buffer.byteLength(
+                JSON.stringify(contribution.context.content),
+                "utf8",
+              )
+            : 0),
         0,
       );
       if (
         totalChars + pluginContributionChars >
-        PLUGIN_PROMPT_CONTRIBUTION_TOTAL_MAX_CHARS
+          PLUGIN_PROMPT_CONTRIBUTION_TOTAL_MAX_CHARS ||
+        totalContextBytes + pluginContextBytes >
+          PLUGIN_PROMPT_CONTEXT_TOTAL_MAX_BYTES
       ) {
         logWarn(
           "plugin_user_prompt_contribution_budget_exceeded",
@@ -371,7 +448,8 @@ export async function getPluginUserPromptContributions(args: {
         continue;
       }
       totalChars += pluginContributionChars;
-      contributions.push(...acceptedContributions);
+      totalContextBytes += pluginContextBytes;
+      contributions.push(...validContributions);
     } catch (error) {
       logWarn(
         "plugin_user_prompt_hook_failed",

--- a/packages/junior/src/chat/plugins/prompt.ts
+++ b/packages/junior/src/chat/plugins/prompt.ts
@@ -1,4 +1,14 @@
+/** Validated plugin context retained for the current turn. */
+export interface PluginTurnContext {
+  content: Record<string, unknown>;
+  kind: string;
+  loadedAtMs: number;
+  pluginName: string;
+  version: number;
+}
+
 export interface PluginPromptContributionContext {
+  context?: PluginTurnContext;
   id: string;
   pluginName: string;
   text: string;

--- a/packages/junior/src/chat/services/turn-session-record.ts
+++ b/packages/junior/src/chat/services/turn-session-record.ts
@@ -19,6 +19,7 @@ import { addAgentTurnUsage, type AgentTurnUsage } from "@/chat/usage";
 import { persistWithRetry } from "@/chat/services/persist-retry";
 import { TurnSliceLimitExceededError } from "@/chat/services/turn-limit";
 import { botConfig } from "@/chat/config";
+import type { PluginTurnContext } from "@/chat/plugins/prompt";
 
 export interface TurnSessionContext {
   conversationId: string;
@@ -138,6 +139,7 @@ export async function persistRunningSessionRecord(args: {
   actor?: Actor;
   reasoningLevel?: string;
   surface?: AgentTurnSurface;
+  turnContexts?: PluginTurnContext[];
   turnStartMessageIndex?: number;
 }): Promise<boolean> {
   if (args.messages.length === 0 || !isContinuablePiBoundary(args.messages)) {
@@ -180,6 +182,7 @@ export async function persistRunningSessionRecord(args: {
         : {}),
       modelId: args.modelId,
       ...(args.reasoningLevel ? { reasoningLevel: args.reasoningLevel } : {}),
+      ...(args.turnContexts ? { turnContexts: args.turnContexts } : {}),
       ...((args.actor ?? latestSessionRecord?.actor)
         ? { actor: args.actor ?? latestSessionRecord?.actor }
         : {}),

--- a/packages/junior/src/chat/state/turn-session.ts
+++ b/packages/junior/src/chat/state/turn-session.ts
@@ -27,6 +27,7 @@ import {
   commitMessages,
   loadTurnProjection,
 } from "@/chat/conversations/projection";
+import type { PluginTurnContext } from "@/chat/plugins/prompt";
 import { projectConversationEvents } from "@/chat/pi/conversation-events";
 import { agentTurnUsageSchema, type AgentTurnUsage } from "@/chat/usage";
 import { getStateAdapter } from "./adapter";
@@ -708,6 +709,7 @@ export async function upsertAgentTurnSessionRecord(args: {
   errorMessage?: string;
   resumedFromSliceId?: number;
   traceId?: string;
+  turnContexts?: PluginTurnContext[];
   turnStartMessageIndex?: number;
   ttlMs?: number;
 }): Promise<AgentTurnSessionRecord> {
@@ -742,6 +744,14 @@ export async function upsertAgentTurnSessionRecord(args: {
       : {}),
     ...(args.trailingMessageProvenance
       ? { trailingMessageProvenance: args.trailingMessageProvenance }
+      : {}),
+    ...(args.turnContexts && args.turnContexts.length > 0
+      ? {
+          turnContext: {
+            contexts: args.turnContexts,
+            turnId: args.sessionId,
+          },
+        }
       : {}),
   });
   const durableTurnStartMessageIndex =

--- a/packages/junior/tests/integration/plugin-prompt-hooks.test.ts
+++ b/packages/junior/tests/integration/plugin-prompt-hooks.test.ts
@@ -117,6 +117,7 @@ import { setPlugins } from "@/chat/plugins/agent-hooks";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
 import { upsertAgentTurnSessionRecord } from "@/chat/state/turn-session";
 import { getConversationEventStore } from "@/chat/db";
+import { TurnInputCommitLostError } from "@/chat/runtime/turn";
 
 const LOCAL_DESTINATION = {
   platform: "local",
@@ -252,6 +253,83 @@ describe("plugin prompt hooks", () => {
         ),
       ),
     ).not.toContain("Use pnpm.");
+  });
+
+  it("replays checkpointed structured context after input acknowledgement fails", async () => {
+    const recall = definePromptContext({
+      kind: "recall",
+      version: 1,
+      schema: z.object({
+        memories: z.array(z.object({ id: z.string(), content: z.string() })),
+      }),
+      renderPrompt: ({ memories }) => memories[0]!.content,
+    });
+    let recallCount = 0;
+    setPlugins([
+      defineJuniorPlugin({
+        manifest: {
+          name: "memory",
+          displayName: "Memory",
+          description: "Memory test plugin",
+        },
+        hooks: {
+          userPrompt() {
+            recallCount += 1;
+            return [
+              recall({
+                memories: [
+                  {
+                    id: `memory-${recallCount}`,
+                    content: `Use pnpm snapshot ${recallCount}.`,
+                  },
+                ],
+              }),
+            ];
+          },
+        },
+      }),
+    ]);
+
+    const turnId = "turn-plugin-context-input-redelivery";
+    const request = {
+      conversationId: LOCAL_DESTINATION.conversationId,
+      turnId,
+      input: { messageText: "hello" },
+      routing: {
+        destination: LOCAL_DESTINATION,
+        source: LOCAL_SOURCE,
+      },
+    };
+    await expect(
+      executeAgentRun({
+        ...request,
+        durability: {
+          onInputCommitted() {
+            throw new TurnInputCommitLostError();
+          },
+        },
+      }),
+    ).rejects.toBeInstanceOf(TurnInputCommitLostError);
+
+    await executeAgentRun(request);
+
+    expect(recallCount).toBe(1);
+    expect(JSON.stringify(captured.promptMessages[0])).toContain(
+      "Use pnpm snapshot 1.",
+    );
+    expect(JSON.stringify(captured.promptMessages[0])).not.toContain(
+      "Use pnpm snapshot 2.",
+    );
+    const stored = await getConversationEventStore().loadByIdempotencyKey(
+      LOCAL_DESTINATION.conversationId,
+      `turn:${turnId}:context:memory:0`,
+    );
+    expect(stored?.data).toMatchObject({
+      type: "turn_context",
+      content: {
+        memories: [{ id: "memory-1", content: "Use pnpm snapshot 1." }],
+      },
+    });
   });
 
   it("runs user prompt hooks for non-bootstrap follow-up prompts", async () => {

--- a/packages/junior/tests/integration/plugin-prompt-hooks.test.ts
+++ b/packages/junior/tests/integration/plugin-prompt-hooks.test.ts
@@ -107,11 +107,16 @@ vi.mock("@/chat/pi/client", () => ({
   resolveGatewayModel: (modelId: string) => modelId,
 }));
 
-import { defineJuniorPlugin } from "@sentry/junior-plugin-api";
+import {
+  defineJuniorPlugin,
+  definePromptContext,
+} from "@sentry/junior-plugin-api";
+import { z } from "zod";
 import { executeAgentRun } from "@/chat/agent";
 import { setPlugins } from "@/chat/plugins/agent-hooks";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
 import { upsertAgentTurnSessionRecord } from "@/chat/state/turn-session";
+import { getConversationEventStore } from "@/chat/db";
 
 const LOCAL_DESTINATION = {
   platform: "local",
@@ -179,6 +184,74 @@ describe("plugin prompt hooks", () => {
     expect(JSON.stringify(captured.promptMessages[0])).toContain(
       "User memory guidance for hello.",
     );
+  });
+
+  it("persists structured context used by the prompt", async () => {
+    const recall = definePromptContext({
+      kind: "recall",
+      version: 1,
+      schema: z.object({
+        memories: z.array(z.object({ id: z.string(), content: z.string() })),
+      }),
+      renderPrompt: ({ memories }) => memories[0]!.content,
+    });
+    setPlugins([
+      defineJuniorPlugin({
+        manifest: {
+          name: "memory",
+          displayName: "Memory",
+          description: "Memory test plugin",
+        },
+        hooks: {
+          userPrompt() {
+            return [
+              recall({
+                memories: [{ id: "memory-1", content: "Use pnpm." }],
+              }),
+            ];
+          },
+        },
+      }),
+    ]);
+
+    const turnId = "turn-plugin-structured-context";
+    await executeAgentRun({
+      conversationId: LOCAL_DESTINATION.conversationId,
+      turnId,
+      input: { messageText: "hello" },
+      routing: {
+        destination: LOCAL_DESTINATION,
+        source: LOCAL_SOURCE,
+      },
+    });
+
+    expect(JSON.stringify(captured.promptMessages[0])).toContain("Use pnpm.");
+    const stored = await getConversationEventStore().loadByIdempotencyKey(
+      LOCAL_DESTINATION.conversationId,
+      `turn:${turnId}:context:memory:0`,
+    );
+    expect(stored?.data).toEqual({
+      type: "turn_context",
+      turnId,
+      pluginName: "memory",
+      kind: "recall",
+      version: 1,
+      content: {
+        memories: [{ id: "memory-1", content: "Use pnpm." }],
+      },
+    });
+    const history = await getConversationEventStore().loadCurrentHistory(
+      LOCAL_DESTINATION.conversationId,
+    );
+    expect(
+      JSON.stringify(
+        history.filter((event) =>
+          ["user_message", "assistant_message", "tool_result"].includes(
+            event.data.type,
+          ),
+        ),
+      ),
+    ).not.toContain("Use pnpm.");
   });
 
   it("runs user prompt hooks for non-bootstrap follow-up prompts", async () => {

--- a/packages/junior/tests/unit/api/conversation-events.test.ts
+++ b/packages/junior/tests/unit/api/conversation-events.test.ts
@@ -61,6 +61,47 @@ describe("conversation report event projection", () => {
     ).toEqual([]);
   });
 
+  it("projects turn context only across the authorized payload boundary", () => {
+    const context = event(1, {
+      type: "turn_context",
+      turnId: "turn-1",
+      pluginName: "memory",
+      kind: "recall",
+      version: 1,
+      content: {
+        memories: [{ id: "memory-1", content: "Use pnpm." }],
+      },
+    });
+
+    expect(
+      projectConversationReportEventPage({
+        canExposePayload: true,
+        events: [context],
+      }),
+    ).toEqual([
+      {
+        seq: 1,
+        createdAt: new Date(1_000).toISOString(),
+        data: {
+          type: "turn_context",
+          turnId: "turn-1",
+          pluginName: "memory",
+          kind: "recall",
+          version: 1,
+          content: {
+            memories: [{ id: "memory-1", content: "Use pnpm." }],
+          },
+        },
+      },
+    ]);
+    expect(
+      projectConversationReportEventPage({
+        canExposePayload: false,
+        events: [context],
+      }),
+    ).toEqual([]);
+  });
+
   it("keeps canonical sequence order and projects tool facts from agent history", () => {
     const events = [
       event(

--- a/packages/junior/tests/unit/plugins/agent-hooks.test.ts
+++ b/packages/junior/tests/unit/plugins/agent-hooks.test.ts
@@ -1,6 +1,7 @@
 import {
   createLocalSource,
   createSlackSource,
+  definePromptContext,
   definePluginTool,
   defineJuniorPlugin,
   pluginToolResultSchema,
@@ -282,6 +283,65 @@ describe("agent plugin hooks", () => {
           id: "userPrompt:0",
           pluginName: "agent-demo",
           text: "remembered context",
+        },
+      ]);
+    } finally {
+      setPlugins(previous);
+    }
+  });
+
+  it("renders and retains typed user prompt context", async () => {
+    const recall = definePromptContext({
+      kind: "recall",
+      version: 1,
+      schema: z.object({
+        memories: z.array(z.object({ id: z.string(), content: z.string() })),
+      }),
+      renderPrompt: ({ memories }) =>
+        memories.map((memory) => memory.content).join("\n"),
+    });
+    const previous = setPlugins([
+      defineJuniorPlugin({
+        manifest: {
+          name: "memory",
+          displayName: "Memory",
+          description: "Memory",
+        },
+        hooks: {
+          userPrompt() {
+            return [
+              recall({
+                memories: [{ id: "memory-1", content: "Use pnpm." }],
+              }),
+            ];
+          },
+        },
+      }),
+    ]);
+    try {
+      await expect(
+        getPluginUserPromptContributions({
+          context: {
+            conversationId: "conversation-1",
+            source: LOCAL_SOURCE,
+            destination: LOCAL_DESTINATION,
+            userText: "hello",
+          },
+        }),
+      ).resolves.toEqual([
+        {
+          id: "userPrompt:0",
+          pluginName: "memory",
+          text: "Use pnpm.",
+          context: {
+            content: {
+              memories: [{ id: "memory-1", content: "Use pnpm." }],
+            },
+            kind: "recall",
+            loadedAtMs: expect.any(Number),
+            pluginName: "memory",
+            version: 1,
+          },
         },
       ]);
     } finally {


### PR DESCRIPTION
Plugin user-prompt hooks can now return typed, versioned structured context with a plugin-owned prompt renderer. Junior validates and budgets the JSON content, renders it into the volatile user prompt, and atomically records the normalized `turn_context` alongside the native agent input without retaining the rendered labels in conversation history.

Memory recall uses this contract for conversation-scoped memories. Personal or mixed recall remains prompt-only so actor-scoped memory cannot be widened through conversation reporting. Existing text prompt contributions remain supported.

The dashboard attaches authorized context to its originating user turn, with native memory rendering, a generic versioned fallback, transcript search, and Markdown export. Regression coverage exercises prompt rendering, atomic persistence, reporting redaction, memory scoping, transcript projection, search, export, and the context popout.

Refs #1074
