### PR TITLE
ref(sandbox): simplify snapshot dependency resolution

### DIFF
--- a/packages/docs/src/content/docs/extend/build-a-plugin.md
+++ b/packages/docs/src/content/docs/extend/build-a-plugin.md
@@ -97,6 +97,7 @@ runtime-postinstall:
 ```
 
 Junior merges runtime dependency declarations from all loaded plugins and prepares them with `junior snapshot create`.
+Identical declarations are deduplicated. Plugins that declare different versions of the same npm package cannot share a snapshot, so snapshot creation fails until their versions agree.
 
 ## Register the package
 

--- a/packages/junior-evals/src/snapshot-warmup.ts
+++ b/packages/junior-evals/src/snapshot-warmup.ts
@@ -1,4 +1,4 @@
-import { runSnapshotCreate } from "@/cli/snapshot-warmup";
+import { runSnapshotCreate } from "@/cli/snapshot-create";
 import { pluginCatalogRuntime } from "@/chat/plugins/catalog-runtime";
 
 /** Warm one plugin dependency profile and restore the eval catalog afterward. */

--- a/packages/junior/src/chat/plugins/types.ts
+++ b/packages/junior/src/chat/plugins/types.ts
@@ -1,4 +1,16 @@
+import type {
+  PluginRuntimeDependency,
+  PluginRuntimePostinstallCommand,
+} from "@sentry/junior-plugin-api";
 import type { UserTokenStore } from "@/chat/credentials/user-token-store";
+
+export type {
+  PluginNpmRuntimeDependency,
+  PluginRuntimeDependency,
+  PluginRuntimePostinstallCommand,
+  PluginSystemRuntimeDependency,
+  PluginSystemRuntimeDependencyFromUrl,
+} from "@sentry/junior-plugin-api";
 
 export interface PluginOAuthConfig {
   clientIdEnv: string;
@@ -32,34 +44,6 @@ export interface OAuthBearerCredentials {
 }
 
 export type PluginCredentials = OAuthBearerCredentials;
-
-export interface PluginNpmRuntimeDependency {
-  type: "npm";
-  package: string;
-  version: string;
-}
-
-export interface PluginSystemRuntimeDependency {
-  type: "system";
-  package: string;
-}
-
-export interface PluginSystemRuntimeDependencyFromUrl {
-  type: "system";
-  url: string;
-  sha256: string;
-}
-
-export type PluginRuntimeDependency =
-  | PluginNpmRuntimeDependency
-  | PluginSystemRuntimeDependency
-  | PluginSystemRuntimeDependencyFromUrl;
-
-export interface PluginRuntimePostinstallCommand {
-  cmd: string;
-  args?: string[];
-  sudo?: boolean;
-}
 
 export interface PluginMcpHttpConfig {
   transport: "http";

--- a/packages/junior/src/chat/sandbox/snapshot/profile.ts
+++ b/packages/junior/src/chat/sandbox/snapshot/profile.ts
@@ -9,13 +9,13 @@ import { GLOBAL_RUNTIME_DEPENDENCIES } from "@/chat/sandbox/runtime-dependencies
 const VERSION = 1;
 const DEFAULT_FLOATING_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
-export interface Profile {
+export type Profile = {
   hash: string;
   dependencyCount: number;
   floating: boolean;
   dependencies: PluginRuntimeDependency[];
   postinstall: PluginRuntimePostinstallCommand[];
-}
+};
 
 function isExactNpmVersion(version: string): boolean {
   return /^\d+\.\d+\.\d+(?:[-+][a-z0-9.]+)?$/i.test(version.trim());
@@ -23,6 +23,44 @@ function isExactNpmVersion(version: string): boolean {
 
 function isFloating(dep: PluginRuntimeDependency): boolean {
   return dep.type === "npm" && !isExactNpmVersion(dep.version);
+}
+
+/**
+ * Merge dependencies for one global install, rejecting competing npm versions.
+ */
+function mergeDependencies(
+  dependencies: PluginRuntimeDependency[],
+): PluginRuntimeDependency[] {
+  const seen = new Set<string>();
+  const npmVersions = new Map<string, string>();
+  const merged: PluginRuntimeDependency[] = [];
+
+  for (const dependency of dependencies) {
+    const key =
+      dependency.type === "npm"
+        ? `${dependency.type}:${dependency.package}:${dependency.version}`
+        : "package" in dependency
+          ? `${dependency.type}:package:${dependency.package}`
+          : `${dependency.type}:url:${dependency.url}:${dependency.sha256}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+
+    if (dependency.type === "npm") {
+      const version = npmVersions.get(dependency.package);
+      if (version !== undefined && version !== dependency.version) {
+        throw new Error(
+          `Conflicting runtime dependency versions for ${dependency.package}: ${version} and ${dependency.version}`,
+        );
+      }
+      npmVersions.set(dependency.package, dependency.version);
+    }
+
+    merged.push(dependency);
+  }
+
+  return merged;
 }
 
 function floatingMaxAgeMs(): number {
@@ -38,10 +76,10 @@ function floatingMaxAgeMs(): number {
 
 /** Build the dependency profile that selects a reusable sandbox snapshot. */
 export function create(runtime: string): Profile | null {
-  const dependencies = [
+  const dependencies = mergeDependencies([
     ...GLOBAL_RUNTIME_DEPENDENCIES,
     ...pluginCatalogRuntime.getRuntimeDependencies(),
-  ];
+  ]);
   const postinstall = pluginCatalogRuntime.getRuntimePostinstall();
   if (dependencies.length === 0 && postinstall.length === 0) {
     return null;

--- a/packages/junior/src/chat/sandbox/snapshot/resolve.ts
+++ b/packages/junior/src/chat/sandbox/snapshot/resolve.ts
@@ -1,4 +1,5 @@
 import { Sandbox } from "@vercel/sandbox";
+import { z } from "zod";
 import { getVercelSandboxCredentials } from "@/chat/sandbox/credentials";
 import { getSandboxResources } from "@/chat/sandbox/resources";
 import * as install from "@/chat/sandbox/snapshot/install";
@@ -13,16 +14,20 @@ import { getStateAdapter } from "@/chat/state/adapter";
 const SNAPSHOT_CACHE_PREFIX = "junior:sandbox_snapshot_profile";
 const SNAPSHOT_LOCK_PREFIX = "junior:sandbox_snapshot_lock";
 const SNAPSHOT_CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
-const SNAPSHOT_BUILD_LOCK_TTL_MS = 10 * 60 * 1000;
-const SNAPSHOT_WAIT_FOR_LOCK_MS = SNAPSHOT_BUILD_LOCK_TTL_MS + 30 * 1000;
+const SNAPSHOT_BUILD_LOCK_BUFFER_MS = 30 * 1000;
+const SNAPSHOT_WAIT_FOR_LOCK_BUFFER_MS = 30 * 1000;
 
-interface CachedSnapshotEntry {
-  profileHash: string;
-  snapshotId: string;
-  runtime: string;
-  createdAtMs: number;
-  dependencyCount: number;
-}
+const cachedSnapshotSchema = z
+  .object({
+    profileHash: z.string(),
+    snapshotId: z.string(),
+    runtime: z.string(),
+    createdAtMs: z.number(),
+    dependencyCount: z.number(),
+  })
+  .strict();
+
+type CachedSnapshot = z.output<typeof cachedSnapshotSchema>;
 
 export type ResolveOutcome =
   | "no_profile"
@@ -54,11 +59,10 @@ export type ProgressPhase =
   | "building_snapshot"
   | "build_complete";
 
-interface BuildLockResult {
+type LockResult = {
   snapshotId: string;
-  source: "wait_cache" | "callback_cache" | "built";
-  waitedForLock: boolean;
-}
+  source: "cache_hit" | "cache_hit_after_lock_wait" | "built";
+};
 
 function profileCacheKey(profileHash: string): string {
   return `${SNAPSHOT_CACHE_PREFIX}:${profileHash}`;
@@ -68,35 +72,31 @@ function profileLockKey(profileHash: string): string {
   return `${SNAPSHOT_LOCK_PREFIX}:${profileHash}`;
 }
 
+/** Read one cached snapshot pointer; only a missing key is a cache miss. */
 async function getCachedSnapshot(
   profileHash: string,
-): Promise<CachedSnapshotEntry | null> {
-  try {
-    const state = getStateAdapter();
-    await state.connect();
-    const raw = await state.get(profileCacheKey(profileHash));
-    if (typeof raw !== "string") {
-      return null;
-    }
-    const parsed = JSON.parse(raw) as CachedSnapshotEntry;
-    if (
-      !parsed ||
-      typeof parsed !== "object" ||
-      typeof parsed.profileHash !== "string" ||
-      typeof parsed.snapshotId !== "string" ||
-      typeof parsed.runtime !== "string" ||
-      typeof parsed.createdAtMs !== "number" ||
-      typeof parsed.dependencyCount !== "number"
-    ) {
-      return null;
-    }
-    return parsed;
-  } catch {
+): Promise<CachedSnapshot | null> {
+  const state = getStateAdapter();
+  await state.connect();
+  const raw = await state.get(profileCacheKey(profileHash));
+  if (typeof raw !== "string") {
     return null;
   }
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    throw new Error(`Invalid cached sandbox snapshot for ${profileHash}`);
+  }
+  const parsed = cachedSnapshotSchema.safeParse(value);
+  if (!parsed.success || parsed.data.profileHash !== profileHash) {
+    throw new Error(`Invalid cached sandbox snapshot for ${profileHash}`);
+  }
+  return parsed.data;
 }
 
-async function setCachedSnapshot(entry: CachedSnapshotEntry): Promise<void> {
+/** Persist one dependency profile's reusable snapshot pointer. */
+async function setCachedSnapshot(entry: CachedSnapshot): Promise<void> {
   const state = getStateAdapter();
   await state.connect();
   await state.set(
@@ -155,32 +155,28 @@ async function build(
   );
 }
 
+/** Run one profile build under a timeout-buffered lock or reuse its result. */
 async function withBuildLock(
   profileHash: string,
+  timeoutMs: number,
   callback: () => Promise<{
     snapshotId: string;
-    source: "callback_cache" | "built";
+    source: "cache_hit" | "built";
   }>,
-  canUseCachedSnapshot: (cached: CachedSnapshotEntry) => boolean,
-  hooks?: {
-    onWaitingForLock?: () => void | Promise<void>;
-  },
-): Promise<BuildLockResult> {
+  canUseCachedSnapshot: (cached: CachedSnapshot) => boolean,
+  onWaitingForLock?: () => void | Promise<void>,
+): Promise<LockResult> {
   const state = getStateAdapter();
   await state.connect();
   const lockKey = profileLockKey(profileHash);
+  const lockTtlMs = timeoutMs + SNAPSHOT_BUILD_LOCK_BUFFER_MS;
   const tryAcquireLock = async () =>
-    await state.acquireLock(lockKey, SNAPSHOT_BUILD_LOCK_TTL_MS);
+    await state.acquireLock(lockKey, lockTtlMs);
 
   let lock = await tryAcquireLock();
   if (lock) {
     try {
-      const result = await callback();
-      return {
-        snapshotId: result.snapshotId,
-        source: result.source,
-        waitedForLock: false,
-      };
+      return await callback();
     } finally {
       await state.releaseLock(lock);
     }
@@ -193,15 +189,15 @@ async function withBuildLock(
       "app.sandbox.snapshot.profile_hash": profileHash,
     },
     async () => {
-      await hooks?.onWaitingForLock?.();
-      const waitUntil = Date.now() + SNAPSHOT_WAIT_FOR_LOCK_MS;
+      await onWaitingForLock?.();
+      const waitUntil =
+        Date.now() + lockTtlMs + SNAPSHOT_WAIT_FOR_LOCK_BUFFER_MS;
       while (Date.now() < waitUntil) {
         const cached = await getCachedSnapshot(profileHash);
         if (cached?.snapshotId && canUseCachedSnapshot(cached)) {
           return {
             snapshotId: cached.snapshotId,
-            source: "wait_cache" as const,
-            waitedForLock: true,
+            source: "cache_hit_after_lock_wait",
           };
         }
 
@@ -211,8 +207,10 @@ async function withBuildLock(
             const result = await callback();
             return {
               snapshotId: result.snapshotId,
-              source: result.source,
-              waitedForLock: true,
+              source:
+                result.source === "built"
+                  ? "built"
+                  : "cache_hit_after_lock_wait",
             };
           } finally {
             await state.releaseLock(lock);
@@ -226,8 +224,7 @@ async function withBuildLock(
       if (cached?.snapshotId && canUseCachedSnapshot(cached)) {
         return {
           snapshotId: cached.snapshotId,
-          source: "wait_cache" as const,
-          waitedForLock: true,
+          source: "cache_hit_after_lock_wait",
         };
       }
 
@@ -238,22 +235,18 @@ async function withBuildLock(
 
 function toResolveOutcome(
   forceRebuild: boolean,
-  source: BuildLockResult["source"],
-  waitedForLock: boolean,
+  source: LockResult["source"],
 ): ResolveOutcome {
   if (source === "built") {
     return forceRebuild ? "forced_rebuild" : "rebuilt";
   }
-  if (waitedForLock || source === "wait_cache") {
-    return "cache_hit_after_lock_wait";
-  }
-  return "cache_hit";
+  return source;
 }
 
 function getRebuildReason(params: {
   forceRebuild?: boolean;
   staleSnapshotId?: string;
-  cached?: CachedSnapshotEntry | null;
+  cached?: CachedSnapshot | null;
   shouldRebuildCached: boolean;
 }): RebuildReason | undefined {
   if (params.forceRebuild) {
@@ -285,7 +278,6 @@ export async function resolve(params: {
     },
     async () => {
       await params.onProgress?.("resolve_start");
-      const resolveStartedAtMs = Date.now();
       const currentProfile = profile.create(params.runtime);
       if (!currentProfile) {
         return {
@@ -319,29 +311,28 @@ export async function resolve(params: {
         shouldRebuildCached: cachedNeedsRebuild,
       });
 
-      const canUseCachedSnapshot = (
-        candidate: CachedSnapshotEntry,
-      ): boolean => {
+      const canUseCachedSnapshot = (candidate: CachedSnapshot): boolean => {
         if (params.forceRebuild) {
           if (params.staleSnapshotId) {
             return candidate.snapshotId !== params.staleSnapshotId;
           }
           // Force rebuild requests should ignore snapshots that existed before this
           // call but can reuse a fresh snapshot produced by a concurrent builder.
-          return candidate.createdAtMs > resolveStartedAtMs;
+          return candidate.snapshotId !== cached?.snapshotId;
         }
         return !profile.isStale(currentProfile, candidate.createdAtMs);
       };
 
       const lockResult = await withBuildLock(
         currentProfile.hash,
+        params.timeoutMs,
         async () => {
           const latest = await getCachedSnapshot(currentProfile.hash);
           if (latest?.snapshotId && canUseCachedSnapshot(latest)) {
             await params.onProgress?.("cache_hit");
             return {
               snapshotId: latest.snapshotId,
-              source: "callback_cache" as const,
+              source: "cache_hit",
             };
           }
 
@@ -359,13 +350,11 @@ export async function resolve(params: {
             dependencyCount: currentProfile.dependencyCount,
           });
           await params.onProgress?.("build_complete");
-          return { snapshotId: nextSnapshotId, source: "built" as const };
+          return { snapshotId: nextSnapshotId, source: "built" };
         },
         canUseCachedSnapshot,
-        {
-          onWaitingForLock: async () => {
-            await params.onProgress?.("waiting_for_lock");
-          },
+        async () => {
+          await params.onProgress?.("waiting_for_lock");
         },
       );
 
@@ -377,7 +366,6 @@ export async function resolve(params: {
         resolveOutcome: toResolveOutcome(
           Boolean(params.forceRebuild),
           lockResult.source,
-          lockResult.waitedForLock,
         ),
         ...(rebuildReason ? { rebuildReason } : {}),
       };

--- a/packages/junior/src/cli/main.ts
+++ b/packages/junior/src/cli/main.ts
@@ -21,7 +21,7 @@ async function runInit(dir: string): Promise<void> {
 }
 
 async function runSnapshotCreate(): Promise<void> {
-  const mod = await import("./snapshot-warmup");
+  const mod = await import("./snapshot-create");
   await mod.runSnapshotCreate();
 }
 

--- a/packages/junior/src/cli/snapshot-create.ts
+++ b/packages/junior/src/cli/snapshot-create.ts
@@ -3,7 +3,7 @@ import {
   resolve as resolveSnapshot,
   type ProgressPhase,
 } from "@/chat/sandbox/snapshot/resolve";
-import { GLOBAL_RUNTIME_DEPENDENCIES } from "@/chat/sandbox/runtime-dependencies";
+import * as profile from "@/chat/sandbox/snapshot/profile";
 import { disconnectStateAdapter } from "@/chat/state/adapter";
 
 const DEFAULT_RUNTIME = "node22";
@@ -29,8 +29,12 @@ function formatList(values: string[]): string {
   return values.length > 0 ? values.join(", ") : "none";
 }
 
-function logSnapshotProfile(log: (line: string) => void): void {
+function logSnapshotProfile(
+  runtime: string,
+  log: (line: string) => void,
+): void {
   const providers = pluginCatalogRuntime.getProviders();
+  const currentProfile = profile.create(runtime);
   const pluginNames = providers.map((plugin) => plugin.manifest.name).sort();
   const snapshotPluginNames = providers
     .filter(
@@ -42,10 +46,7 @@ function logSnapshotProfile(log: (line: string) => void): void {
     .sort();
   const systemDependencies: string[] = [];
   const npmDependencies: string[] = [];
-  for (const dep of [
-    ...GLOBAL_RUNTIME_DEPENDENCIES,
-    ...pluginCatalogRuntime.getRuntimeDependencies(),
-  ]) {
+  for (const dep of currentProfile?.dependencies ?? []) {
     if (dep.type === "npm") {
       npmDependencies.push(`${dep.package}@${dep.version}`);
       continue;
@@ -53,11 +54,10 @@ function logSnapshotProfile(log: (line: string) => void): void {
 
     systemDependencies.push("package" in dep ? dep.package : dep.url);
   }
-  const postinstallCommands = pluginCatalogRuntime
-    .getRuntimePostinstall()
-    .map(({ cmd, args }) =>
+  const postinstallCommands = (currentProfile?.postinstall ?? []).map(
+    ({ cmd, args }) =>
       [cmd, ...(args ?? [])].filter((part) => part.trim().length > 0).join(" "),
-    );
+  );
 
   log(`Loaded plugins (${pluginNames.length}): ${formatList(pluginNames)}`);
   log(
@@ -102,6 +102,7 @@ function logSnapshotProfile(log: (line: string) => void): void {
   }
 }
 
+/** Resolve or create the default sandbox snapshot and report its progress. */
 export async function runSnapshotCreate(
   log: (line: string) => void = console.log,
 ): Promise<void> {
@@ -114,7 +115,7 @@ export async function runSnapshotCreate(
   const timeoutMs = DEFAULT_TIMEOUT_MS;
 
   try {
-    logSnapshotProfile(log);
+    logSnapshotProfile(runtime, log);
     const emitted = new Set<ProgressPhase>();
     const snapshot = await resolveSnapshot({
       runtime,

--- a/packages/junior/tests/component/sandbox/snapshot/resolve.test.ts
+++ b/packages/junior/tests/component/sandbox/snapshot/resolve.test.ts
@@ -42,15 +42,23 @@ vi.mock("@/chat/logging", () => ({
 
 const store = new Map<string, string>();
 let lockHeld = false;
+let getError: Error | undefined;
+const acquiredLockTtls: number[] = [];
 
 vi.mock("@/chat/state/adapter", () => ({
   getStateAdapter: () => ({
     connect: vi.fn(async () => {}),
-    get: vi.fn(async (key: string) => store.get(key)),
+    get: vi.fn(async (key: string) => {
+      if (getError) {
+        throw getError;
+      }
+      return store.get(key);
+    }),
     set: vi.fn(async (key: string, value: string) => {
       store.set(key, value);
     }),
-    acquireLock: vi.fn(async () => {
+    acquireLock: vi.fn(async (_key: string, ttlMs: number) => {
+      acquiredLockTtls.push(ttlMs);
       if (lockHeld) {
         return null;
       }
@@ -91,6 +99,8 @@ describe("snapshot resolution", () => {
   beforeEach(() => {
     store.clear();
     lockHeld = false;
+    getError = undefined;
+    acquiredLockTtls.length = 0;
     sandboxCreateMock.mockReset();
     withSpanMock.mockReset();
     withSpanMock.mockImplementation(
@@ -154,6 +164,59 @@ describe("snapshot resolution", () => {
     });
     expect(snapshot.snapshotId).toBe("snap_stopped");
     expect(sandbox.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets cache failures reach the caller", async () => {
+    getRuntimeDependenciesMock.mockReturnValue([
+      { type: "npm", package: "sentry", version: "latest" },
+    ]);
+    getError = new Error("state unavailable");
+
+    await expect(
+      resolveSnapshot({
+        runtime: "node22",
+        timeoutMs: 60_000,
+      }),
+    ).rejects.toThrow("state unavailable");
+    expect(sandboxCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed cache values without exposing their contents", async () => {
+    getRuntimeDependenciesMock.mockReturnValue([
+      { type: "npm", package: "sentry", version: "latest" },
+    ]);
+    sandboxCreateMock.mockResolvedValueOnce(makeSandbox("snap_new"));
+
+    const first = await resolveSnapshot({
+      runtime: "node22",
+      timeoutMs: 60_000,
+    });
+    const [cacheKey] = [...store.keys()];
+    store.set(cacheKey, "private-token-abc");
+
+    await expect(
+      resolveSnapshot({
+        runtime: "node22",
+        timeoutMs: 60_000,
+      }),
+    ).rejects.toEqual(
+      new Error(`Invalid cached sandbox snapshot for ${first.profileHash}`),
+    );
+    expect(sandboxCreateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the build lock beyond the sandbox timeout", async () => {
+    getRuntimeDependenciesMock.mockReturnValue([
+      { type: "npm", package: "sentry", version: "latest" },
+    ]);
+    sandboxCreateMock.mockResolvedValueOnce(makeSandbox("snap_new"));
+
+    await resolveSnapshot({
+      runtime: "node22",
+      timeoutMs: 60_000,
+    });
+
+    expect(acquiredLockTtls).toEqual([90_000]);
   });
 
   it("does not return stale cached snapshot while waiting on force rebuild lock", async () => {
@@ -237,11 +300,8 @@ describe("snapshot resolution", () => {
 
     const [cacheKey] = [...store.keys()];
     const initialCached = JSON.parse(store.get(cacheKey) ?? "") as {
-      profileHash: string;
       snapshotId: string;
-      runtime: string;
       createdAtMs: number;
-      dependencyCount: number;
     };
 
     lockHeld = true;
@@ -251,7 +311,6 @@ describe("snapshot resolution", () => {
         JSON.stringify({
           ...initialCached,
           snapshotId: "snap_from_other_worker",
-          createdAtMs: Date.now(),
         }),
       );
     }, 100);

--- a/packages/junior/tests/unit/cli/snapshot-create-cli.test.ts
+++ b/packages/junior/tests/unit/cli/snapshot-create-cli.test.ts
@@ -28,7 +28,7 @@ vi.mock("@/chat/sandbox/runtime-dependencies", () => ({
   GLOBAL_RUNTIME_DEPENDENCIES: [],
 }));
 
-import { runSnapshotCreate } from "@/cli/snapshot-warmup";
+import { runSnapshotCreate } from "@/cli/snapshot-create";
 
 describe("snapshot create cli", () => {
   beforeEach(() => {

--- a/packages/junior/tests/unit/sandbox/snapshot/profile.test.ts
+++ b/packages/junior/tests/unit/sandbox/snapshot/profile.test.ts
@@ -73,4 +73,26 @@ describe("snapshot dependency profile", () => {
 
     expect(first?.hash).not.toBe(second?.hash);
   });
+
+  it("rejects conflicting npm versions", () => {
+    dependenciesMock.mockReturnValue([
+      { type: "npm", package: "example", version: "1.2.3" },
+      { type: "npm", package: "example", version: "2.0.0" },
+    ]);
+
+    expect(() => create("node22")).toThrow(
+      "Conflicting runtime dependency versions for example: 1.2.3 and 2.0.0",
+    );
+  });
+
+  it("deduplicates identical dependencies", () => {
+    dependenciesMock.mockReturnValue([
+      { type: "npm", package: "example", version: "1.2.3" },
+      { type: "npm", package: "example", version: "1.2.3" },
+    ]);
+
+    expect(create("node22")?.dependencies).toEqual([
+      { type: "npm", package: "example", version: "1.2.3" },
+    ]);
+  });
 });

--- a/packages/junior/tsup.config.ts
+++ b/packages/junior/tsup.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     "cli/chat": "src/cli/chat.ts",
     "cli/check": "src/cli/check.ts",
     "cli/upgrade": "src/cli/upgrade.ts",
-    "cli/snapshot-warmup": "src/cli/snapshot-warmup.ts",
+    "cli/snapshot-create": "src/cli/snapshot-create.ts",
     api: "src/api.ts",
     "api/schema": "src/api/schema.ts",
     instrumentation: "src/instrumentation.ts",


### PR DESCRIPTION
Snapshot creation now uses the resolved dependency profile as its single source of truth: identical declarations are deduplicated, conflicting npm versions fail before the global install, and CLI reporting reflects the normalized inputs.

Snapshot cache reads now validate their durable shape, propagate state failures, and avoid exposing malformed cache contents. Build locks follow the requested sandbox timeout, while forced rebuilds recognize concurrent replacements by snapshot ID instead of timestamps. The change also reuses the plugin API dependency types and renames the internal CLI module to match `junior snapshot create`; the public command is unchanged.

Focused profile, installation, resolution, and CLI tests cover the dependency conflicts, cache failures, lock lifetime, and concurrent rebuild behavior.
