### PR TITLE
fix(skills): load dollar-prefixed skill references

### DIFF
--- a/packages/junior-evals/evals/agent/oauth.eval.ts
+++ b/packages/junior-evals/evals/agent/oauth.eval.ts
@@ -182,7 +182,7 @@ describeEval("OAuth Workflows", slackEvals, (it) => {
     ]);
     expect(
       matchingToolCalls(result, "loadSkill", { skill_name: "eval-oauth" }),
-    ).not.toHaveLength(0);
+    ).toHaveLength(0);
     expect(evalOauthIdentityCalls(result)).not.toHaveLength(0);
     expect(evalOauthIdentityCalls(result).length).toBeGreaterThanOrEqual(3);
     expect(
@@ -273,7 +273,7 @@ describeEval("OAuth Workflows", slackEvals, (it) => {
     ]);
     expect(
       matchingToolCalls(result, "loadSkill", { skill_name: "eval-oauth" }),
-    ).not.toHaveLength(0);
+    ).toHaveLength(0);
     expect(evalOauthIdentityCalls(result)).not.toHaveLength(0);
     expect(
       matchingThreadReplies(result, oauthConnectThread, /\S/),

--- a/packages/junior-evals/evals/agent/oauth.eval.ts
+++ b/packages/junior-evals/evals/agent/oauth.eval.ts
@@ -273,7 +273,7 @@ describeEval("OAuth Workflows", slackEvals, (it) => {
     ]);
     expect(
       matchingToolCalls(result, "loadSkill", { skill_name: "eval-oauth" }),
-    ).toHaveLength(0);
+    ).not.toHaveLength(0);
     expect(evalOauthIdentityCalls(result)).not.toHaveLength(0);
     expect(
       matchingThreadReplies(result, oauthConnectThread, /\S/),

--- a/packages/junior-evals/evals/agent/providers.eval.ts
+++ b/packages/junior-evals/evals/agent/providers.eval.ts
@@ -63,12 +63,6 @@ describeEval("Skill Providers", slackEvals, (it) => {
     expect(toolCalls(result.session)).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          name: "loadSkill",
-          arguments: expect.objectContaining({
-            skill_name: "eval-mcp",
-          }),
-        }),
-        expect.objectContaining({
           name: "callMcpTool",
           arguments: expect.objectContaining({
             tool_name: "mcp__eval-mcp__handbook-search",
@@ -76,6 +70,14 @@ describeEval("Skill Providers", slackEvals, (it) => {
               query: expect.stringMatching(/US holidays/i),
             }),
           }),
+        }),
+      ]),
+    );
+    expect(toolCalls(result.session)).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "loadSkill",
+          arguments: expect.objectContaining({ skill_name: "eval-mcp" }),
         }),
       ]),
     );

--- a/packages/junior-evals/evals/agent/skill-routing.eval.ts
+++ b/packages/junior-evals/evals/agent/skill-routing.eval.ts
@@ -31,9 +31,7 @@ describeEval("Skill Invocation Control", slackEvals, (it) => {
     await run({
       overrides: { skill_dirs: skillDirs },
       initialEvents: [
-        mention(
-          "Use the weather-lookup skill to check the weather in San Francisco.",
-        ),
+        mention("$weather-lookup check the weather in San Francisco."),
       ],
       criteria: rubric({
         pass: [

--- a/packages/junior-evals/evals/agent/skill-routing.eval.ts
+++ b/packages/junior-evals/evals/agent/skill-routing.eval.ts
@@ -25,10 +25,10 @@ describeEval("Skill Invocation Control", slackEvals, (it) => {
     });
   });
 
-  it("loads a user-callable skill when the user explicitly names it", async ({
+  it("injects a user-callable skill when the user explicitly names it", async ({
     run,
   }) => {
-    await run({
+    const result = await run({
       overrides: { skill_dirs: skillDirs },
       initialEvents: [
         mention("$weather-lookup check the weather in San Francisco."),
@@ -43,6 +43,17 @@ describeEval("Skill Invocation Control", slackEvals, (it) => {
         ],
       }),
     });
+
+    expect(toolCalls(result.session)).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "loadSkill",
+          arguments: expect.objectContaining({
+            skill_name: "weather-lookup",
+          }),
+        }),
+      ]),
+    );
   });
 
   it("auto-selects an available skill when contextually relevant", async ({

--- a/packages/junior/src/chat/agent/index.ts
+++ b/packages/junior/src/chat/agent/index.ts
@@ -462,6 +462,9 @@ async function executeAgentRunInPrivacyContext(
       skillSandbox,
       syncLoadedSkillNamesForResume,
     });
+    const explicitSkill = invokedSkill
+      ? (activeSkills.find((skill) => skill.name === invokedSkill.name) ?? null)
+      : null;
 
     // ── Prompt input ─────────────────────────────────────────────────
     const { routerBlocks, userContentParts } = buildPromptInput(input);
@@ -753,7 +756,7 @@ async function executeAgentRunInPrivacyContext(
       existingSessionPiMessages: existingSessionRecord?.piMessages,
       existingTurnStartMessageIndex:
         existingSessionRecord?.turnStartMessageIndex,
-      invocation: skillInvocation,
+      explicitSkill,
       priorPiMessages,
       resumedFromSessionRecord,
       routing,

--- a/packages/junior/src/chat/agent/prompt.ts
+++ b/packages/junior/src/chat/agent/prompt.ts
@@ -8,6 +8,7 @@
  */
 import { isDeepStrictEqual } from "node:util";
 import { renderCurrentInstruction } from "@/chat/current-instruction";
+import { sandboxSkillFile } from "@/chat/sandbox/paths";
 import {
   buildPluginSystemPromptContributions,
   buildSystemPrompt,
@@ -24,13 +25,14 @@ import {
 } from "@/chat/pi/transcript";
 import { serializeGenAiAttribute, type LogContext } from "@/chat/logging";
 import type { ConversationPrivacy } from "@/chat/conversation-privacy";
-import type { SkillInvocation, SkillMetadata } from "@/chat/skills";
+import type { Skill, SkillMetadata } from "@/chat/skills";
 import type { ActiveMcpCatalogSummary } from "@/chat/tool-support/skill/mcp-tool-summary";
 import type { ToolRuntimeContext } from "@/chat/tools/types";
 import type { AnyToolDefinition } from "@/chat/tools/definition";
 import { isUserActor, type Actor } from "@/chat/actor";
 import type { ThreadArtifactsState } from "@/chat/state/artifacts";
 import type { PluginTurnContext } from "@/chat/plugins/prompt";
+import { escapeXml } from "@/chat/xml";
 import type {
   AgentRunInput,
   AgentRunInstructionActor,
@@ -99,6 +101,17 @@ export function buildUserTurnText(
     renderThreadContextForPrompt(trimmedContext),
     "",
     currentInstruction,
+  ].join("\n");
+}
+
+/** Render an explicitly selected skill as instructions for the current turn. */
+export function renderExplicitSkillInstructions(skill: Skill): string {
+  return [
+    "<skill>",
+    `<name>${escapeXml(skill.name)}</name>`,
+    `<path>${escapeXml(sandboxSkillFile(skill.name))}</path>`,
+    skill.body,
+    "</skill>",
   ].join("\n");
 }
 
@@ -401,7 +414,7 @@ export async function assemblePrompt(args: {
   conversationPrivacy?: ConversationPrivacy;
   existingSessionPiMessages?: PiMessage[];
   existingTurnStartMessageIndex?: number;
-  invocation: SkillInvocation | null;
+  explicitSkill: Skill | null;
   priorPiMessages?: PiMessage[];
   resumedFromSessionRecord: boolean;
   routing: AgentRunRouting;
@@ -420,6 +433,17 @@ export async function assemblePrompt(args: {
     args.existingTurnStartMessageIndex !== undefined;
   const shouldPromptAgent =
     !args.resumedFromSessionRecord || !hasPromptCheckpoint;
+  const requestContentParts: UserContentPart[] = [
+    ...(args.explicitSkill
+      ? [
+          {
+            type: "text" as const,
+            text: renderExplicitSkillInstructions(args.explicitSkill),
+          },
+        ]
+      : []),
+    ...args.userContentParts,
+  ];
   // Every re-prompt shape must trim a trailing checkpointed copy of the same
   // user prompt, including redelivery of the same inbound message after a
   // lost input commit against a still-`running` record; otherwise the prompt
@@ -427,7 +451,7 @@ export async function assemblePrompt(args: {
   const promptHistoryMessages = shouldPromptAgent
     ? withoutTrailingUncheckpointedUserPrompt(
         args.priorPiMessages,
-        args.userContentParts,
+        requestContentParts,
       )
     : args.existingSessionPiMessages!;
   const replayedPromptContent =
@@ -435,7 +459,7 @@ export async function assemblePrompt(args: {
       ? checkpointedPromptContent({
           messages: args.existingSessionPiMessages,
           turnStartMessageIndex: args.existingTurnStartMessageIndex,
-          userContentParts: args.userContentParts,
+          userContentParts: requestContentParts,
         })
       : undefined;
   const needsBootstrapContextForPrompt =
@@ -475,7 +499,6 @@ export async function assemblePrompt(args: {
                 source,
               }
             : undefined,
-          invocation: args.invocation,
           actor: isUserActor(args.currentActor) ? args.currentActor : undefined,
           artifactState: args.artifactState,
           configuration: args.configurationValues,
@@ -486,7 +509,7 @@ export async function assemblePrompt(args: {
     : [];
   const promptContentParts = replayedPromptContent ?? [
     ...turnContextParts,
-    ...args.userContentParts,
+    ...requestContentParts,
   ];
 
   const inputMessages = [

--- a/packages/junior/src/chat/agent/prompt.ts
+++ b/packages/junior/src/chat/agent/prompt.ts
@@ -8,7 +8,11 @@
  */
 import { isDeepStrictEqual } from "node:util";
 import { renderCurrentInstruction } from "@/chat/current-instruction";
-import { sandboxSkillFile } from "@/chat/sandbox/paths";
+import {
+  sandboxSkillDir,
+  sandboxSkillFile,
+  sandboxSkillPathResolution,
+} from "@/chat/sandbox/paths";
 import {
   buildPluginSystemPromptContributions,
   buildSystemPrompt,
@@ -110,6 +114,8 @@ export function renderExplicitSkillInstructions(skill: Skill): string {
     "<skill>",
     `<name>${escapeXml(skill.name)}</name>`,
     `<path>${escapeXml(sandboxSkillFile(skill.name))}</path>`,
+    `<working_directory>${escapeXml(sandboxSkillDir(skill.name))}</working_directory>`,
+    `<path_resolution>${escapeXml(sandboxSkillPathResolution(skill.name))}</path_resolution>`,
     skill.body,
     "</skill>",
   ].join("\n");

--- a/packages/junior/src/chat/agent/tools.ts
+++ b/packages/junior/src/chat/agent/tools.ts
@@ -202,6 +202,10 @@ export async function wireAgentTools(
       skill.disableModelInvocation !== true ||
       skill.name === args.invokedSkill?.name,
   );
+  const explicitSkillLoaded = Boolean(
+    args.invokedSkill &&
+    args.activeSkills.some((skill) => skill.name === args.invokedSkill?.name),
+  );
   const commonToolRuntimeContext = {
     conversationId: args.conversationId,
     userText: args.userInput,
@@ -310,6 +314,7 @@ export async function wireAgentTools(
       },
     },
     toolRuntimeContext,
+    { includeLoadSkill: !explicitSkillLoaded },
   );
 
   const plannedToolExposure = planToolExposure(

--- a/packages/junior/src/chat/prompt.ts
+++ b/packages/junior/src/chat/prompt.ts
@@ -25,7 +25,7 @@ import {
 } from "@/chat/sandbox/paths";
 import type { SlackConversationContext } from "@/chat/slack/conversation-context";
 import type { ThreadArtifactsState } from "@/chat/state/artifacts";
-import type { SkillMetadata, SkillInvocation } from "@/chat/skills";
+import type { SkillMetadata } from "@/chat/skills";
 import type { ActiveMcpCatalogSummary } from "@/chat/tool-support/skill/mcp-tool-summary";
 import { escapeXml } from "@/chat/xml";
 import type { PluginPromptContributionContext } from "@/chat/plugins/prompt";
@@ -183,17 +183,10 @@ function formatSkillEntry(skill: SkillMetadata): string[] {
 
 function formatAvailableSkillsForPrompt(
   skills: SkillMetadata[],
-  invocation: SkillInvocation | null,
 ): string | null {
   const autoSelectable = skills.filter(
     (s) => s.disableModelInvocation !== true,
   );
-  const invokedExplicitOnly = invocation
-    ? skills.filter(
-        (s) =>
-          s.disableModelInvocation === true && s.name === invocation.skillName,
-      )
-    : [];
 
   const sections: string[] = [];
 
@@ -208,19 +201,6 @@ function formatAvailableSkillsForPrompt(
     }
     available.push("</available-skills>");
     sections.push(available.join("\n"));
-  }
-
-  // User-callable skills: model must not auto-select these.
-  if (invokedExplicitOnly.length > 0) {
-    const userCallable = [
-      "<user-callable-skills>",
-      "The user's current message explicitly references this skill by name. Load it when relevant to the request.",
-    ];
-    for (const skill of invokedExplicitOnly) {
-      userCallable.push(...formatSkillEntry(skill));
-    }
-    userCallable.push("</user-callable-skills>");
-    sections.push(userCallable.join("\n"));
   }
 
   return sections.length > 0 ? sections.join("\n") : null;
@@ -370,7 +350,8 @@ const TOOL_CALL_STYLE_RULES = [
 ];
 
 const SKILL_POLICY_RULES = [
-  "- Only load skills listed in `<available-skills>`, `<user-callable-skills>`, or named by `<explicit-skill-trigger>`. Never guess or invent a skill name.",
+  "- A `<skill>` block in the current user turn is already loaded. Follow its instructions directly and do not call `loadSkill` for that skill.",
+  "- Otherwise, only load skills listed in `<available-skills>`. Never guess or invent a skill name.",
   "- Load one skill at a time. After `loadSkill`, follow the instructions returned by that tool result.",
 ];
 
@@ -586,7 +567,6 @@ function buildContextSection(params: {
     plugin?: string;
     source: Source;
   };
-  invocation: SkillInvocation | null;
 }): string | null {
   const blocks: string[][] = [];
 
@@ -629,15 +609,6 @@ function buildContextSection(params: {
     );
   }
 
-  if (params.invocation) {
-    blocks.push(
-      renderTag("explicit-skill-trigger", [
-        "Treat this skill as selected. Load it unless the tool says it is unavailable.",
-        `/${escapeXml(params.invocation.skillName)}`,
-      ]),
-    );
-  }
-
   const body = blocks.map((block) => block.join("\n")).join("\n\n");
   if (!body) {
     return null;
@@ -649,13 +620,11 @@ function buildContextSection(params: {
 function buildCapabilitiesSection(params: {
   availableSkills: SkillMetadata[];
   activeMcpCatalogs: ActiveMcpCatalogSummary[];
-  invocation: SkillInvocation | null;
   toolGuidance?: ToolPromptContext[];
 }): string | null {
   const blocks: string[] = [];
   const availableSkills = formatAvailableSkillsForPrompt(
     params.availableSkills,
-    params.invocation,
   );
   if (availableSkills) {
     blocks.push(availableSkills);
@@ -738,7 +707,6 @@ type TurnContextPromptInput = {
     plugin?: string;
     source: Source;
   };
-  invocation: SkillInvocation | null;
   actor?: {
     userName?: string;
     fullName?: string;
@@ -795,7 +763,6 @@ export function buildTurnContextPrompt(
       ? buildCapabilitiesSection({
           availableSkills: params.availableSkills,
           activeMcpCatalogs: params.activeMcpCatalogs ?? [],
-          invocation: params.invocation,
           toolGuidance: params.toolGuidance ?? [],
         })
       : null,
@@ -806,7 +773,6 @@ export function buildTurnContextPrompt(
           artifactState: params.artifactState,
           configuration: params.configuration,
           dispatch: params.dispatch,
-          invocation: params.invocation,
         })
       : null,
     includeSessionContext ? buildRuntimeSection(params.runtime ?? {}) : null,

--- a/packages/junior/src/chat/sandbox/paths.ts
+++ b/packages/junior/src/chat/sandbox/paths.ts
@@ -21,3 +21,9 @@ export function sandboxSkillDir(skillName: string): string {
 export function sandboxSkillFile(skillName: string): string {
   return `${sandboxSkillDir(skillName)}/SKILL.md`;
 }
+
+/** Explain how the agent should resolve files and commands owned by a skill. */
+export function sandboxSkillPathResolution(skillName: string): string {
+  const skillDir = sandboxSkillDir(skillName);
+  return `Resolve relative paths in this skill against ${skillDir}. For bash commands from this skill, cd to ${skillDir} first or use absolute paths.`;
+}

--- a/packages/junior/src/chat/skills.ts
+++ b/packages/junior/src/chat/skills.ts
@@ -427,7 +427,7 @@ export async function discoverSkills(
   return sorted;
 }
 
-/** Extract a skill invocation (name + args) from a user message, or return null if none matches. */
+/** Extract an explicit skill invocation (name + args) from a user message. */
 export function parseSkillInvocation(
   messageText: string,
   availableSkills: SkillMetadata[],
@@ -435,17 +435,19 @@ export function parseSkillInvocation(
   const trimmed = messageText.trim();
   const escapePattern = (value: string) =>
     value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const slashMatch =
-    /(?:^|\s)\/([a-z0-9]+(?:-[a-z0-9]+)*)(?:\s+([\s\S]*))?/i.exec(trimmed);
-  if (slashMatch) {
-    const skillName = slashMatch[1].toLowerCase();
+  const referenceMatch =
+    /(?:^|\s)(?:\/|\$)([a-z0-9]+(?:-[a-z0-9]+)*)(?:\s+([\s\S]*))?/i.exec(
+      trimmed,
+    );
+  if (referenceMatch) {
+    const skillName = referenceMatch[1].toLowerCase();
     if (!availableSkills.some((skill) => skill.name === skillName)) {
       return null;
     }
 
     return {
       skillName,
-      args: (slashMatch[2] ?? "").trim(),
+      args: (referenceMatch[2] ?? "").trim(),
     };
   }
 

--- a/packages/junior/src/chat/skills.ts
+++ b/packages/junior/src/chat/skills.ts
@@ -426,6 +426,22 @@ export async function discoverSkills(
   return sorted;
 }
 
+function isCommonEnvironmentVariable(name: string): boolean {
+  return [
+    "HOME",
+    "LANG",
+    "PATH",
+    "PWD",
+    "SHELL",
+    "TEMP",
+    "TERM",
+    "TMP",
+    "TMPDIR",
+    "USER",
+    "XDG_CONFIG_HOME",
+  ].includes(name.toUpperCase());
+}
+
 /** Extract an explicit skill invocation from a user message. */
 export function parseSkillInvocation(
   messageText: string,
@@ -434,16 +450,25 @@ export function parseSkillInvocation(
   const trimmed = messageText.trim();
   const escapePattern = (value: string) =>
     value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const referenceMatch = /(?:^|\s)(?:\/|\$)([a-z0-9]+(?:-[a-z0-9]+)*)/i.exec(
-    trimmed,
-  );
-  if (referenceMatch) {
-    const skillName = referenceMatch[1].toLowerCase();
+  const slashMatch = /(?:^|\s)\/([a-z0-9]+(?:-[a-z0-9]+)*)/i.exec(trimmed);
+  if (slashMatch) {
+    const skillName = slashMatch[1].toLowerCase();
     if (!availableSkills.some((skill) => skill.name === skillName)) {
       return null;
     }
 
     return { skillName };
+  }
+
+  const dollarPattern = /(?:^|\s)\$([a-z0-9]+(?:-[a-z0-9]+)*)/gi;
+  for (const match of trimmed.matchAll(dollarPattern)) {
+    const skillName = match[1].toLowerCase();
+    if (isCommonEnvironmentVariable(skillName)) {
+      continue;
+    }
+    if (availableSkills.some((skill) => skill.name === skillName)) {
+      return { skillName };
+    }
   }
 
   const namedSkill = availableSkills.find((skill) => {

--- a/packages/junior/src/chat/skills.ts
+++ b/packages/junior/src/chat/skills.ts
@@ -235,7 +235,6 @@ export interface Skill extends SkillMetadata {
 
 export interface SkillInvocation {
   skillName: string;
-  args: string;
 }
 
 export interface DiscoverSkillsOptions {
@@ -427,7 +426,7 @@ export async function discoverSkills(
   return sorted;
 }
 
-/** Extract an explicit skill invocation (name + args) from a user message. */
+/** Extract an explicit skill invocation from a user message. */
 export function parseSkillInvocation(
   messageText: string,
   availableSkills: SkillMetadata[],
@@ -435,20 +434,16 @@ export function parseSkillInvocation(
   const trimmed = messageText.trim();
   const escapePattern = (value: string) =>
     value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const referenceMatch =
-    /(?:^|\s)(?:\/|\$)([a-z0-9]+(?:-[a-z0-9]+)*)(?:\s+([\s\S]*))?/i.exec(
-      trimmed,
-    );
+  const referenceMatch = /(?:^|\s)(?:\/|\$)([a-z0-9]+(?:-[a-z0-9]+)*)/i.exec(
+    trimmed,
+  );
   if (referenceMatch) {
     const skillName = referenceMatch[1].toLowerCase();
     if (!availableSkills.some((skill) => skill.name === skillName)) {
       return null;
     }
 
-    return {
-      skillName,
-      args: (referenceMatch[2] ?? "").trim(),
-    };
+    return { skillName };
   }
 
   const namedSkill = availableSkills.find((skill) => {
@@ -472,7 +467,6 @@ export function parseSkillInvocation(
 
   return {
     skillName: namedSkill.name,
-    args: trimmed,
   };
 }
 

--- a/packages/junior/src/chat/tools/index.ts
+++ b/packages/junior/src/chat/tools/index.ts
@@ -82,11 +82,16 @@ function createToolState(
 
 export type { ToolHooks, ToolRuntimeContext };
 
+export interface CreateToolsOptions {
+  includeLoadSkill?: boolean;
+}
+
 /** Build the model-facing tool registry from runtime-owned context and capabilities. */
 export function createTools(
   availableSkills: SkillMetadata[],
   hooks: ToolHooks = {},
   context: ToolRuntimeContext,
+  options: CreateToolsOptions = {},
 ) {
   const state = createToolState(hooks, context);
   const slackContext = getSlackToolContext(context);
@@ -97,9 +102,13 @@ export function createTools(
     slackContext && slackSourceCapabilities?.canSendFiles,
   );
   const tools: ToolRegistry = {
-    loadSkill: createLoadSkillTool(availableSkills, {
-      onSkillLoaded: hooks.onSkillLoaded,
-    }),
+    ...(options.includeLoadSkill === false
+      ? {}
+      : {
+          loadSkill: createLoadSkillTool(availableSkills, {
+            onSkillLoaded: hooks.onSkillLoaded,
+          }),
+        }),
     reportProgress: createReportProgressTool(),
     systemTime: createSystemTimeTool(),
     bash: createBashTool(),

--- a/packages/junior/src/chat/tools/skill/load-skill.ts
+++ b/packages/junior/src/chat/tools/skill/load-skill.ts
@@ -1,7 +1,11 @@
 import { z } from "zod";
 import { juniorToolResultSchema } from "@/chat/tool-support/structured-result";
 import { zodTool } from "@/chat/tool-support/zod-tool";
-import { sandboxSkillDir, sandboxSkillFile } from "@/chat/sandbox/paths";
+import {
+  sandboxSkillDir,
+  sandboxSkillFile,
+  sandboxSkillPathResolution,
+} from "@/chat/sandbox/paths";
 import {
   loadSkillsByName,
   type Skill,
@@ -90,7 +94,7 @@ async function loadSkillFromHost(
     skill_dir: skillDir,
     working_directory: skillDir,
     location: skillFilePath,
-    path_resolution: `Resolve relative paths in this skill against ${skillDir}. For bash commands from this skill, cd to ${skillDir} first or use absolute paths.`,
+    path_resolution: sandboxSkillPathResolution(skill.name),
     instructions: loaded.body,
   };
 }

--- a/packages/junior/tests/unit/agent/prompt-user-turn.test.ts
+++ b/packages/junior/tests/unit/agent/prompt-user-turn.test.ts
@@ -19,7 +19,9 @@ describe("buildUserTurnText", () => {
       [
         "<skill>",
         "<name>weather-lookup</name>",
-        "<path>/vercel/sandbox/.junior/skills/weather-lookup/SKILL.md</path>",
+        "<path>/vercel/sandbox/skills/weather-lookup/SKILL.md</path>",
+        "<working_directory>/vercel/sandbox/skills/weather-lookup</working_directory>",
+        "<path_resolution>Resolve relative paths in this skill against /vercel/sandbox/skills/weather-lookup. For bash commands from this skill, cd to /vercel/sandbox/skills/weather-lookup first or use absolute paths.</path_resolution>",
         "Use the weather source.",
         "</skill>",
       ].join("\n"),

--- a/packages/junior/tests/unit/agent/prompt-user-turn.test.ts
+++ b/packages/junior/tests/unit/agent/prompt-user-turn.test.ts
@@ -1,8 +1,31 @@
 import { describe, expect, it } from "vitest";
-import { buildPromptInput, buildUserTurnText } from "@/chat/agent/prompt";
+import {
+  buildPromptInput,
+  buildUserTurnText,
+  renderExplicitSkillInstructions,
+} from "@/chat/agent/prompt";
 import { unwrapCurrentInstruction } from "@/chat/current-instruction";
 
 describe("buildUserTurnText", () => {
+  it("renders an explicitly selected skill as loaded instructions", () => {
+    expect(
+      renderExplicitSkillInstructions({
+        name: "weather-lookup",
+        description: "Weather lookup",
+        skillPath: "/host/skills/weather-lookup/SKILL.md",
+        body: "Use the weather source.",
+      }),
+    ).toBe(
+      [
+        "<skill>",
+        "<name>weather-lookup</name>",
+        "<path>/vercel/sandbox/.junior/skills/weather-lookup/SKILL.md</path>",
+        "Use the weather source.",
+        "</skill>",
+      ].join("\n"),
+    );
+  });
+
   it("wraps input in the current instruction boundary without context", () => {
     expect(buildUserTurnText("hello")).toBe(
       ["<current-instruction>", "hello", "</current-instruction>"].join("\n"),

--- a/packages/junior/tests/unit/prompt.test.ts
+++ b/packages/junior/tests/unit/prompt.test.ts
@@ -58,7 +58,6 @@ describe("prompt builders", () => {
     const prompt = buildTurnContextPrompt({
       availableSkills: [],
       activeMcpCatalogs: [],
-      invocation: null,
     });
 
     expect(prompt).toContain("- sandbox.workspace_root: /vercel/sandbox");
@@ -68,7 +67,6 @@ describe("prompt builders", () => {
     const prompt = buildTurnContextPrompt({
       availableSkills: [],
       activeMcpCatalogs: [],
-      invocation: null,
       runtime: {
         conversationId: "slack:C123:1712345.000001",
         slackConversation: {
@@ -111,7 +109,6 @@ describe("prompt builders", () => {
           taskId: "sched_plugin_1",
         },
       },
-      invocation: null,
     });
 
     expect(prompt).toContain("<dispatch>");
@@ -153,7 +150,6 @@ describe("prompt builders", () => {
           sentry_project: "junior",
         },
         includeSessionContext: false,
-        invocation: null,
         actor: {
           userId: "U0BETA",
           userName: "dcramer",
@@ -184,7 +180,6 @@ describe("prompt builders", () => {
         { provider: "alpha-provider", available_tool_count: 2 },
       ],
       includeSessionContext: false,
-      invocation: null,
       pluginPromptContributions: [
         {
           id: "memory",

--- a/packages/junior/tests/unit/skills/skills.test.ts
+++ b/packages/junior/tests/unit/skills/skills.test.ts
@@ -138,6 +138,31 @@ describe("skills", () => {
     });
   });
 
+  it("ignores environment variables and keeps scanning for a skill", () => {
+    expect(
+      parseSkillInvocation("use $HOME then $brief github: octocat", stubSkills),
+    ).toEqual({
+      skillName: "brief",
+    });
+    expect(
+      parseSkillInvocation(
+        "For $10, use the weather-lookup skill for San Francisco.",
+        stubSkills,
+      ),
+    ).toEqual({
+      skillName: "weather-lookup",
+    });
+  });
+
+  it("does not treat common environment variables as skill references", () => {
+    expect(
+      parseSkillInvocation("echo $HOME", [
+        ...stubSkills,
+        { name: "home", description: "Home", skillPath: "/tmp/home" },
+      ]),
+    ).toBeNull();
+  });
+
   it("returns null for an unregistered skill reference", () => {
     expect(parseSkillInvocation("/jr link sentry", stubSkills)).toBeNull();
     expect(parseSkillInvocation("$jr link sentry", stubSkills)).toBeNull();

--- a/packages/junior/tests/unit/skills/skills.test.ts
+++ b/packages/junior/tests/unit/skills/skills.test.ts
@@ -82,7 +82,7 @@ describe("skills", () => {
     }
   });
 
-  it("does not parse invocation without slash command", () => {
+  it("does not parse invocation without an explicit skill reference", () => {
     expect(
       parseSkillInvocation("please summarize this candidate", stubSkills),
     ).toBeNull();
@@ -124,17 +124,27 @@ describe("skills", () => {
     });
   });
 
-  it("parses /skill invocation", () => {
+  it("parses $skill tokens anywhere in the message", () => {
     expect(
-      parseSkillInvocation("hey /brief github: octocat", stubSkills),
+      parseSkillInvocation("hey $brief github: octocat", stubSkills),
     ).toEqual({
       skillName: "brief",
       args: "github: octocat",
     });
   });
 
-  it("returns null for unregistered slash command", () => {
+  it("parses $skill for user-callable skills", () => {
+    expect(
+      parseSkillInvocation("$weather-lookup San Francisco", stubSkills),
+    ).toEqual({
+      skillName: "weather-lookup",
+      args: "San Francisco",
+    });
+  });
+
+  it("returns null for an unregistered skill reference", () => {
     expect(parseSkillInvocation("/jr link sentry", stubSkills)).toBeNull();
+    expect(parseSkillInvocation("$jr link sentry", stubSkills)).toBeNull();
   });
 
   it("returns null when no skills are available", () => {

--- a/packages/junior/tests/unit/skills/skills.test.ts
+++ b/packages/junior/tests/unit/skills/skills.test.ts
@@ -96,7 +96,6 @@ describe("skills", () => {
       ),
     ).toEqual({
       skillName: "weather-lookup",
-      args: "Use the weather-lookup skill for San Francisco.",
     });
   });
 
@@ -120,7 +119,6 @@ describe("skills", () => {
       parseSkillInvocation("hey /brief github: octocat", stubSkills),
     ).toEqual({
       skillName: "brief",
-      args: "github: octocat",
     });
   });
 
@@ -129,7 +127,6 @@ describe("skills", () => {
       parseSkillInvocation("hey $brief github: octocat", stubSkills),
     ).toEqual({
       skillName: "brief",
-      args: "github: octocat",
     });
   });
 
@@ -138,7 +135,6 @@ describe("skills", () => {
       parseSkillInvocation("$weather-lookup San Francisco", stubSkills),
     ).toEqual({
       skillName: "weather-lookup",
-      args: "San Francisco",
     });
   });
 

--- a/packages/junior/tests/unit/slack/tool-registration.test.ts
+++ b/packages/junior/tests/unit/slack/tool-registration.test.ts
@@ -70,6 +70,14 @@ describe("Slack tool registration", () => {
     vi.restoreAllMocks();
   });
 
+  it("omits loadSkill when an explicit skill is already loaded", () => {
+    const tools = createTools([], {}, ctx("D12345"), {
+      includeLoadSkill: false,
+    });
+
+    expect(tools).not.toHaveProperty("loadSkill");
+  });
+
   it("registers thread sendFiles but not channel-only tools in DM context", () => {
     const tools = createTools([], {}, ctx("D12345"));
 


### PR DESCRIPTION
Explicit `$skill` references now resolve and load the selected skill before the model runs. Junior injects the full `SKILL.md` instructions, sandbox working directory, and relative-path guidance alongside the unchanged user request, then omits `loadSkill` from that turn so loading is deterministic and does not require another model/tool round trip. Existing `/skill` references keep the same explicit behavior, while natural-language skill selection continues to use `loadSkill`.

Dollar-reference scanning ignores common environment variables and unmatched tokens instead of suppressing later skill matching. This keeps inputs such as `$HOME` or `$10` from interfering with a valid skill request.