### PR TITLE
fix(dashboard): tidy system plugin reporting views

### DIFF
--- a/packages/junior-dashboard/e2e/system.spec.ts
+++ b/packages/junior-dashboard/e2e/system.spec.ts
@@ -143,6 +143,26 @@ test("navigates plugin information and activity on mobile", async ({
   expect(
     await page.evaluate(() => document.documentElement.scrollWidth),
   ).toBeLessThanOrEqual(390);
+  await expect(page.getByLabel("System view").locator("option")).toHaveText([
+    "Overview",
+    "Scheduler",
+  ]);
+  await page
+    .getByRole("region", { name: "Plugins" })
+    .getByRole("link", { name: /GitHub/ })
+    .click();
+  await expect(page.getByLabel("System view")).toHaveValue(
+    "/system/plugins/github",
+  );
+  await expect(
+    page.getByLabel("System view").locator("option:checked"),
+  ).toHaveText("GitHub");
+  await expect(
+    page
+      .getByLabel("System view")
+      .locator('option[value="/system/plugins/github"]'),
+  ).toHaveAttribute("disabled", "");
+  await page.getByLabel("System view").selectOption("/system");
   await page
     .getByLabel("System view")
     .selectOption("/system/plugins/scheduler");

--- a/packages/junior-dashboard/e2e/system.spec.ts
+++ b/packages/junior-dashboard/e2e/system.spec.ts
@@ -39,10 +39,31 @@ test("shows system usage and plugin details", async ({ page }) => {
     });
   expect(headerBounds).toEqual({ left: 160, width: 1280 });
 
-  await page
-    .getByLabel("System navigation")
-    .getByRole("link", { name: "GitHub", exact: true })
-    .click();
+  const systemNavigation = page.getByLabel("System navigation");
+  await expect(
+    systemNavigation.getByRole("link", { name: "GitHub", exact: true }),
+  ).toHaveCount(0);
+  await expect(
+    systemNavigation.getByRole("link", { name: "Scheduler", exact: true }),
+  ).toHaveCount(0);
+
+  const pluginPanels = page.getByRole("region", { name: "Plugins" });
+  const githubPanel = pluginPanels.getByRole("link", {
+    name: /GitHub/,
+  });
+  const schedulerPanel = pluginPanels.getByRole("link", {
+    name: /Scheduler/,
+  });
+  const [githubBounds, schedulerBounds] = await Promise.all([
+    githubPanel.boundingBox(),
+    schedulerPanel.boundingBox(),
+  ]);
+  expect(githubBounds?.x).toBe(schedulerBounds?.x);
+  expect(schedulerBounds?.y).toBeGreaterThan(
+    (githubBounds?.y ?? 0) + (githubBounds?.height ?? 0),
+  );
+
+  await githubPanel.click();
   await expect(page).toHaveURL(`${server.baseURL}/system/plugins/github`);
   await expect(
     page.getByRole("heading", { name: "GitHub", exact: true }),
@@ -51,6 +72,11 @@ test("shows system usage and plugin details", async ({ page }) => {
     page.getByText("This plugin does not expose operational activity yet."),
   ).toBeVisible();
   await expect(page.getByText("github.organization")).toBeVisible();
+  expect(
+    await page
+      .getByRole("heading", { level: 2, name: "System", exact: true })
+      .evaluate((element) => element.getBoundingClientRect().top),
+  ).toBeLessThan(180);
 
   await page.goto(`${server.baseURL}/system/plugins/github/`);
   await expect(page).toHaveURL(`${server.baseURL}/system/plugins/github/`);

--- a/packages/junior-dashboard/src/client/pages/system/PluginPanels.tsx
+++ b/packages/junior-dashboard/src/client/pages/system/PluginPanels.tsx
@@ -20,7 +20,7 @@ export function PluginPanels(props: { plugins: SystemPlugin[] }) {
         </h2>
       </div>
       {props.plugins.length ? (
-        <div className="grid gap-3 xl:grid-cols-2">
+        <div className="grid gap-3">
           {props.plugins.map((plugin) => (
             <PluginPanel key={plugin.name} plugin={plugin} />
           ))}

--- a/packages/junior-dashboard/src/client/pages/system/SystemNavigation.tsx
+++ b/packages/junior-dashboard/src/client/pages/system/SystemNavigation.tsx
@@ -9,9 +9,16 @@ import {
 } from "./SystemPlugins";
 
 /** Render route-backed navigation for the System overview and loaded plugins. */
-export function SystemNavigation(props: { plugins: SystemPlugin[] }) {
+export function SystemNavigation(props: {
+  plugins: SystemPlugin[];
+  reportingPlugins: SystemPlugin[];
+}) {
   const location = useLocation();
   const navigate = useNavigate();
+  const currentPlugin = findSystemPlugin(location.pathname, props.plugins);
+  const currentPluginHasReporting = props.reportingPlugins.some(
+    (plugin) => plugin.name === currentPlugin?.name,
+  );
   const linkClass = ({ isActive }: { isActive: boolean }) =>
     cn(
       "flex min-w-fit items-center gap-2.5 rounded-md border px-3 py-2 font-display text-sm font-medium no-underline transition-colors lg:min-w-0",
@@ -34,11 +41,16 @@ export function SystemNavigation(props: { plugins: SystemPlugin[] }) {
             value={systemNavigationValue(location.pathname, props.plugins)}
           >
             <option value="/system">Overview</option>
-            {props.plugins.map((plugin) => (
+            {props.reportingPlugins.map((plugin) => (
               <option key={plugin.name} value={systemPluginPath(plugin.name)}>
                 {plugin.displayName}
               </option>
             ))}
+            {currentPlugin && !currentPluginHasReporting ? (
+              <option disabled value={systemPluginPath(currentPlugin.name)}>
+                {currentPlugin.displayName}
+              </option>
+            ) : null}
           </select>
           <ChevronDown
             aria-hidden="true"
@@ -56,12 +68,12 @@ export function SystemNavigation(props: { plugins: SystemPlugin[] }) {
             <Gauge aria-hidden="true" size={15} strokeWidth={1.8} />
             Overview
           </NavLink>
-          {props.plugins.length ? (
+          {props.reportingPlugins.length ? (
             <>
               <div className="px-3 pt-4 pb-1.5 font-mono text-[0.56rem] font-medium uppercase tracking-[0.16em] text-white/25">
                 Plugins
               </div>
-              {props.plugins.map((plugin) => (
+              {props.reportingPlugins.map((plugin) => (
                 <NavLink
                   className={linkClass}
                   key={plugin.name}
@@ -83,9 +95,16 @@ function systemNavigationValue(
   pathname: string,
   plugins: SystemPlugin[],
 ): string {
+  const plugin = findSystemPlugin(pathname, plugins);
+  return plugin ? systemPluginPath(plugin.name) : "/system";
+}
+
+function findSystemPlugin(
+  pathname: string,
+  plugins: SystemPlugin[],
+): SystemPlugin | undefined {
   const normalizedPath = normalizeSystemPath(pathname);
-  const plugin = plugins.find(
+  return plugins.find(
     (candidate) => systemPluginPath(candidate.name) === normalizedPath,
   );
-  return plugin ? systemPluginPath(plugin.name) : "/system";
 }

--- a/packages/junior-dashboard/src/client/pages/system/SystemPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/system/SystemPage.tsx
@@ -37,7 +37,9 @@ export function SystemPage(props: { data: SystemData }) {
     reports,
     skills: props.data.skills,
   });
-  const reportingPlugins = plugins.filter((plugin) => plugin.reports.length);
+  const reportingPlugins = props.data.pluginReportsLoading
+    ? plugins
+    : plugins.filter((plugin) => plugin.reports.length);
   const pathname = normalizeSystemPath(location.pathname);
   const plugin = plugins.find(
     (candidate) => systemPluginPath(candidate.name) === pathname,

--- a/packages/junior-dashboard/src/client/pages/system/SystemPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/system/SystemPage.tsx
@@ -37,6 +37,7 @@ export function SystemPage(props: { data: SystemData }) {
     reports,
     skills: props.data.skills,
   });
+  const reportingPlugins = plugins.filter((plugin) => plugin.reports.length);
   const pathname = normalizeSystemPath(location.pathname);
   const plugin = plugins.find(
     (candidate) => systemPluginPath(candidate.name) === pathname,
@@ -56,7 +57,7 @@ export function SystemPage(props: { data: SystemData }) {
     <div
       className={cn(
         dashboardContainerClass,
-        "grid min-w-0 gap-4 px-4 py-4 sm:gap-6 sm:px-8 sm:py-8",
+        "grid min-w-0 content-start gap-4 px-4 py-4 sm:gap-6 sm:px-8 sm:py-8",
       )}
     >
       <PageHeader
@@ -71,7 +72,7 @@ export function SystemPage(props: { data: SystemData }) {
       />
 
       <div className="grid min-w-0 items-start gap-4 sm:gap-6 lg:grid-cols-[13rem_minmax(0,1fr)]">
-        <SystemNavigation plugins={plugins} />
+        <SystemNavigation plugins={reportingPlugins} />
         <div className="grid min-w-0 gap-4 sm:gap-6">
           {plugin ? (
             <PluginSystemPage data={props.data} plugin={plugin} range={range} />

--- a/packages/junior-dashboard/src/client/pages/system/SystemPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/system/SystemPage.tsx
@@ -72,7 +72,10 @@ export function SystemPage(props: { data: SystemData }) {
       />
 
       <div className="grid min-w-0 items-start gap-4 sm:gap-6 lg:grid-cols-[13rem_minmax(0,1fr)]">
-        <SystemNavigation plugins={reportingPlugins} />
+        <SystemNavigation
+          plugins={plugins}
+          reportingPlugins={reportingPlugins}
+        />
         <div className="grid min-w-0 gap-4 sm:gap-6">
           {plugin ? (
             <PluginSystemPage data={props.data} plugin={plugin} range={range} />

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -1125,6 +1125,7 @@ describe("dashboard canonical-event components", () => {
     );
     expect(loadingHtml).not.toContain("Loading plugin stats.");
     expect(loadingHtml).toContain(">GitHub<");
+    expect(loadingHtml).toContain('href="/system/plugins/github"');
     expect(loadingHtml).not.toContain(
       "This plugin does not expose operational activity yet.",
     );
@@ -1223,7 +1224,7 @@ describe("dashboard canonical-event components", () => {
     );
 
     expect(html).toContain('aria-label="System navigation"');
-    expect(html).toContain('href="/system/plugins/github"');
+    expect(html).not.toContain('href="/system/plugins/github"');
     expect(html).toContain('href="/system/plugins/scheduler"');
     expect(html).toContain(">Scheduler<");
     expect(html).toContain(">active tasks<");


### PR DESCRIPTION
System navigation now lists only plugins that returned operational reports, while the overview continues to show the full plugin inventory in single-column cards. Short System plugin pages are top-aligned instead of stretching their content across the viewport.

Browser coverage verifies that plugins without reports are absent from navigation, overview cards stay one per row, and short plugin pages remain near the top of the screen. The dashboard typecheck, build, focused Playwright tests, and desktop/mobile visual QA all pass.
