### PR TITLE
feat(reporting): record daily skill usage

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -178,7 +178,7 @@ A skill/tool is missing, plugin discovery failed, or capability activation looks
 
 Events: `startup_discovery_summary`, `plugin_loaded`,
 `capability_catalog_loaded`, `skill_directory_read_failed`,
-`skill_frontmatter_invalid`, `plugin_root_read_failed`
+`skill_frontmatter_invalid`, `skill_load_stat_failed`, `plugin_root_read_failed`
 
 Spans: active turn spans carry plugin/skill attributes
 

--- a/packages/junior/migrations/0011_sour_golden_guardian.sql
+++ b/packages/junior/migrations/0011_sour_golden_guardian.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "junior_stats" (
+	"date" date NOT NULL,
+	"namespace" text NOT NULL,
+	"metric" text NOT NULL,
+	"name" text NOT NULL,
+	"count" integer DEFAULT 0 NOT NULL,
+	CONSTRAINT "junior_stats_date_namespace_metric_name_pk" PRIMARY KEY("date","namespace","metric","name")
+);

--- a/packages/junior/migrations/meta/0011_snapshot.json
+++ b/packages/junior/migrations/meta/0011_snapshot.json
@@ -1,0 +1,1195 @@
+{
+  "id": "d68ca73e-2d45-4adf-a955-7226d68dddcf",
+  "prevId": "c0925d95-c4c3-4647-8bae-a365dcf2920d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.junior_api_tokens": {
+      "name": "junior_api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_email_normalized": {
+          "name": "owner_email_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_suffix": {
+          "name": "token_suffix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_api_tokens_token_hash_uidx": {
+          "name": "junior_api_tokens_token_hash_uidx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_api_tokens_owner_email_idx": {
+          "name": "junior_api_tokens_owner_email_idx",
+          "columns": [
+            {
+              "expression": "owner_email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversation_annotations": {
+      "name": "junior_conversation_annotations",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin": {
+          "name": "plugin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "annotation_json": {
+          "name": "annotation_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "junior_conversation_annotations_conversation_id_fk": {
+          "name": "junior_conversation_annotations_conversation_id_fk",
+          "tableFrom": "junior_conversation_annotations",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_conversation_annotations_pk": {
+          "name": "junior_conversation_annotations_pk",
+          "columns": ["conversation_id", "plugin", "kind", "key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversation_events": {
+      "name": "junior_conversation_events",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "history_version": {
+          "name": "history_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_conversation_events_history_version_idx": {
+          "name": "junior_conversation_events_history_version_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "history_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversation_events_type_idx": {
+          "name": "junior_conversation_events_type_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversation_events_message_search_idx": {
+          "name": "junior_conversation_events_message_search_idx",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"payload\"->>'text')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_conversation_events\".\"type\" = 'message'",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "junior_conversation_events_idempotency_idx": {
+          "name": "junior_conversation_events_idempotency_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_conversation_events_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversation_events_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversation_events",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "junior_conversation_events_conversation_id_seq_pk": {
+          "name": "junior_conversation_events_conversation_id_seq_pk",
+          "columns": ["conversation_id", "seq"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_conversations": {
+      "name": "junior_conversations",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_type": {
+          "name": "origin_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_id": {
+          "name": "origin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_run_id": {
+          "name": "origin_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_json": {
+          "name": "destination_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity_id": {
+          "name": "actor_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_identity_id": {
+          "name": "creator_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_subject_identity_id": {
+          "name": "credential_subject_identity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_json": {
+          "name": "actor_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_updated_at": {
+          "name": "execution_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_status": {
+          "name": "execution_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_checkpoint_at": {
+          "name": "last_checkpoint_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_enqueued_at": {
+          "name": "last_enqueued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_conversation_id": {
+          "name": "parent_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_conversation_id": {
+          "name": "root_conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript_purged_at": {
+          "name": "transcript_purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "usage_json": {
+          "name": "usage_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_duration_ms": {
+          "name": "execution_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "execution_usage_json": {
+          "name": "execution_usage_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metric_run_id": {
+          "name": "metric_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "junior_conversations_last_activity_idx": {
+          "name": "junior_conversations_last_activity_idx",
+          "columns": [
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_active_idx": {
+          "name": "junior_conversations_active_idx",
+          "columns": [
+            {
+              "expression": "coalesce(\"execution_updated_at\", \"updated_at\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_conversations\".\"execution_status\" <> 'idle'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_destination_activity_idx": {
+          "name": "junior_conversations_destination_activity_idx",
+          "columns": [
+            {
+              "expression": "destination_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_actor_activity_idx": {
+          "name": "junior_conversations_actor_activity_idx",
+          "columns": [
+            {
+              "expression": "actor_identity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_origin_idx": {
+          "name": "junior_conversations_origin_idx",
+          "columns": [
+            {
+              "expression": "origin_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "origin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_parent_idx": {
+          "name": "junior_conversations_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_conversations_root_idx": {
+          "name": "junior_conversations_root_idx",
+          "columns": [
+            {
+              "expression": "root_conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_conversations_destination_id_junior_destinations_id_fk": {
+          "name": "junior_conversations_destination_id_junior_destinations_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_destinations",
+          "columnsFrom": ["destination_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_actor_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversations_actor_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_identities",
+          "columnsFrom": ["actor_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_creator_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversations_creator_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_identities",
+          "columnsFrom": ["creator_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_credential_subject_identity_id_junior_identities_id_fk": {
+          "name": "junior_conversations_credential_subject_identity_id_junior_identities_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_identities",
+          "columnsFrom": ["credential_subject_identity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_parent_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversations_parent_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["parent_conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "junior_conversations_root_conversation_id_junior_conversations_conversation_id_fk": {
+          "name": "junior_conversations_root_conversation_id_junior_conversations_conversation_id_fk",
+          "tableFrom": "junior_conversations",
+          "tableTo": "junior_conversations",
+          "columnsFrom": ["root_conversation_id"],
+          "columnsTo": ["conversation_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_destinations": {
+      "name": "junior_destinations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_tenant_id": {
+          "name": "provider_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "provider_destination_id": {
+          "name": "provider_destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_destination_id": {
+          "name": "parent_destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_destinations_provider_destination_uidx": {
+          "name": "junior_destinations_provider_destination_uidx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_destination_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_destinations_provider_kind_idx": {
+          "name": "junior_destinations_provider_kind_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_identities": {
+      "name": "junior_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_tenant_id": {
+          "name": "provider_tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "provider_subject_id": {
+          "name": "provider_subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_normalized": {
+          "name": "email_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "junior_identities_provider_subject_uidx": {
+          "name": "junior_identities_provider_subject_uidx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_subject_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_identities_user_idx": {
+          "name": "junior_identities_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_identities_verified_email_idx": {
+          "name": "junior_identities_verified_email_idx",
+          "columns": [
+            {
+              "expression": "email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"junior_identities\".\"email_verified\" = true AND \"junior_identities\".\"email_normalized\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "junior_identities_kind_provider_idx": {
+          "name": "junior_identities_kind_provider_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "junior_identities_user_id_junior_users_id_fk": {
+          "name": "junior_identities_user_id_junior_users_id_fk",
+          "tableFrom": "junior_identities",
+          "tableTo": "junior_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_stats": {
+      "name": "junior_stats",
+      "schema": "",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "junior_stats_date_namespace_metric_name_pk": {
+          "name": "junior_stats_date_namespace_metric_name_pk",
+          "columns": ["date", "namespace", "metric", "name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.junior_users": {
+      "name": "junior_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "primary_email": {
+          "name": "primary_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_email_normalized": {
+          "name": "primary_email_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "junior_users_primary_email_normalized_uidx": {
+          "name": "junior_users_primary_email_normalized_uidx",
+          "columns": [
+            {
+              "expression": "primary_email_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/junior/migrations/meta/_journal.json
+++ b/packages/junior/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1785211716838,
       "tag": "0010_native_conversation_history",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1785271740428,
+      "tag": "0011_sour_golden_guardian",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/junior/src/api.ts
+++ b/packages/junior/src/api.ts
@@ -16,6 +16,7 @@ import {
 import runtimeRoute from "./api/runtime";
 import { apiErrorSchema } from "./api/schema/common";
 import skillsRoute from "./api/skills";
+import statsRoute from "./api/stats";
 
 export { authenticatePersonalToken } from "./personal-tokens/store";
 export type { JuniorApiVariables };
@@ -27,6 +28,7 @@ const routes = [
   pluginsRoute,
   skillsRoute,
   pluginReportsRoute,
+  statsRoute,
 ] satisfies readonly ApiRoute[];
 
 /** Create Junior's production REST API for authenticated dashboard consumers. */

--- a/packages/junior/src/api/schema.ts
+++ b/packages/junior/src/api/schema.ts
@@ -76,6 +76,8 @@ export {
   revokePersonalTokenResponseSchema,
 } from "./schema/personal-token";
 export type { PersonalTokenMetadata } from "./schema/personal-token";
+export { statSchema, statsReportSchema } from "./schema/stats";
+export type { StatReport, StatsReport } from "./schema/stats";
 export {
   healthReportSchema,
   pluginOperationalReportFeedSchema,

--- a/packages/junior/src/api/schema/stats.ts
+++ b/packages/junior/src/api/schema/stats.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+export const statSchema = z
+  .object({
+    count: z.number().int().nonnegative(),
+    date: z.string(),
+    metric: z.string().min(1),
+    name: z.string().min(1),
+    namespace: z.string().min(1),
+  })
+  .strict();
+
+export const statsReportSchema = z
+  .object({
+    generatedAt: z.string().datetime(),
+    stats: z.array(statSchema),
+    windowEnd: z.string(),
+    windowStart: z.string(),
+  })
+  .strict();
+
+export type StatReport = z.infer<typeof statSchema>;
+export type StatsReport = z.infer<typeof statsReportSchema>;

--- a/packages/junior/src/api/stats.ts
+++ b/packages/junior/src/api/stats.ts
@@ -1,0 +1,29 @@
+import { readStats } from "@/stats";
+import { defineApiRoute } from "./route";
+import { statsReportSchema, type StatsReport } from "./schema/stats";
+
+const WINDOW_DAYS = 90;
+
+/** Read the last 90 days of named daily counters. */
+export async function readStatsReport(): Promise<StatsReport> {
+  const now = new Date();
+  const end = now.toISOString().slice(0, 10);
+  const startDate = new Date(now);
+  startDate.setUTCHours(0, 0, 0, 0);
+  startDate.setUTCDate(startDate.getUTCDate() - (WINDOW_DAYS - 1));
+  const start = startDate.toISOString().slice(0, 10);
+
+  return statsReportSchema.parse({
+    generatedAt: now.toISOString(),
+    stats: await readStats(start, end),
+    windowEnd: end,
+    windowStart: start,
+  });
+}
+
+export default defineApiRoute({
+  method: "get",
+  path: "/api/stats",
+  responseSchema: statsReportSchema,
+  handler: readStatsReport,
+});

--- a/packages/junior/src/chat/agent/tools.ts
+++ b/packages/junior/src/chat/agent/tools.ts
@@ -54,6 +54,7 @@ import {
 import { upsertActiveSkill } from "@/chat/agent/skills";
 import type { ResumeState } from "@/chat/agent/resume";
 import { credentialUserSubjectId } from "@/chat/credentials/context";
+import { incrementStat } from "@/stats";
 
 interface ToolWiringArgs {
   abortAgent: () => void;
@@ -88,6 +89,30 @@ interface ToolWiringArgs {
   syncLoadedSkillNamesForResume: () => void;
   toolCalls: string[];
   userInput: string;
+}
+
+/** Record optional reporting without changing the loadSkill outcome. */
+async function tryRecordSkillLoadStat(skill: Skill, spanContext: LogContext) {
+  if (!process.env.DATABASE_URL) return;
+  try {
+    await incrementStat({
+      namespace: skill.pluginProvider ?? "junior",
+      metric: "skill_load",
+      name: skill.name,
+    });
+  } catch (error) {
+    logWarn(
+      "skill_load_stat_failed",
+      spanContext,
+      {
+        "app.skill.name": skill.name,
+        "app.plugin.name": skill.pluginProvider,
+        "exception.message":
+          error instanceof Error ? error.message : String(error),
+      },
+      "Failed to record skill load stat",
+    );
+  }
 }
 
 export interface ToolWiring {
@@ -285,6 +310,7 @@ export async function wireAgentTools(
         if (await mcpToolManager.activateForSkill(effective)) {
           await args.recordConnectedMcpProvider(effective.pluginProvider!);
         }
+        await tryRecordSkillLoadStat(effective, args.spanContext);
         if (mcpAuth.getPendingPause()) {
           // Auth pause requested — suppress loadSkill failure and let the
           // aborted run park cleanly.

--- a/packages/junior/src/db/schema.ts
+++ b/packages/junior/src/db/schema.ts
@@ -4,6 +4,7 @@ import { juniorConversationEvents } from "./schema/conversation-events";
 import { juniorConversations } from "./schema/conversations";
 import { juniorDestinations } from "./schema/destinations";
 import { juniorIdentities } from "./schema/identities";
+import { juniorStats } from "./schema/stats";
 import { juniorUsers } from "./schema/users";
 
 export {
@@ -13,6 +14,7 @@ export {
   juniorConversations,
   juniorDestinations,
   juniorIdentities,
+  juniorStats,
   juniorUsers,
 };
 
@@ -23,5 +25,6 @@ export const juniorSqlSchema = {
   juniorConversations,
   juniorDestinations,
   juniorIdentities,
+  juniorStats,
   juniorUsers,
 };

--- a/packages/junior/src/db/schema/stats.ts
+++ b/packages/junior/src/db/schema/stats.ts
@@ -1,0 +1,19 @@
+import { date, integer, pgTable, primaryKey, text } from "drizzle-orm/pg-core";
+
+/** Daily named counters used by Junior and loaded plugins. */
+export const juniorStats = pgTable(
+  "junior_stats",
+  {
+    date: date("date", { mode: "string" }).notNull(),
+    namespace: text("namespace").notNull(),
+    metric: text("metric").notNull(),
+    name: text("name").notNull(),
+    count: integer("count").notNull().default(0),
+  },
+  (table) => [
+    primaryKey({
+      name: "junior_stats_date_namespace_metric_name_pk",
+      columns: [table.date, table.namespace, table.metric, table.name],
+    }),
+  ],
+);

--- a/packages/junior/src/stats.ts
+++ b/packages/junior/src/stats.ts
@@ -1,0 +1,55 @@
+import { and, asc, gte, lte, sql } from "drizzle-orm";
+import { getDb } from "@/chat/db";
+import { juniorStats } from "@/db/schema";
+
+export interface Stat {
+  count: number;
+  date: string;
+  metric: string;
+  name: string;
+  namespace: string;
+}
+
+export interface StatKey {
+  metric: string;
+  name: string;
+  namespace: string;
+}
+
+function utcDate(nowMs: number): string {
+  return new Date(nowMs).toISOString().slice(0, 10);
+}
+
+/** Increment one daily named counter. */
+export async function incrementStat(
+  key: StatKey,
+  options: { nowMs?: number } = {},
+): Promise<void> {
+  const date = utcDate(options.nowMs ?? Date.now());
+  await getDb()
+    .insert(juniorStats)
+    .values({ ...key, date, count: 1 })
+    .onConflictDoUpdate({
+      target: [
+        juniorStats.date,
+        juniorStats.namespace,
+        juniorStats.metric,
+        juniorStats.name,
+      ],
+      set: { count: sql`${juniorStats.count} + 1` },
+    });
+}
+
+/** Read daily counters inside an inclusive UTC date range. */
+export async function readStats(start: string, end: string): Promise<Stat[]> {
+  return await getDb()
+    .select()
+    .from(juniorStats)
+    .where(and(gte(juniorStats.date, start), lte(juniorStats.date, end)))
+    .orderBy(
+      asc(juniorStats.date),
+      asc(juniorStats.namespace),
+      asc(juniorStats.metric),
+      asc(juniorStats.name),
+    );
+}

--- a/packages/junior/tests/component/runtime/agent-run-mcp-progressive-loading.test.ts
+++ b/packages/junior/tests/component/runtime/agent-run-mcp-progressive-loading.test.ts
@@ -17,6 +17,7 @@ const {
   listToolsMock,
   loadSkillExecutionErrorCount,
   loadSkillsByNameMock,
+  incrementStatMock,
   pendingAuthRecords,
   promptCallCount,
   promptMessages,
@@ -43,6 +44,7 @@ const {
   listToolsMock: vi.fn(),
   loadSkillExecutionErrorCount: { value: 0 },
   loadSkillsByNameMock: vi.fn(),
+  incrementStatMock: vi.fn(),
   pendingAuthRecords: [] as ConversationPendingAuthState[],
   promptCallCount: { value: 0 },
   promptMessages: [] as unknown[],
@@ -504,6 +506,10 @@ vi.mock("@/chat/skills", async (importOriginal) => {
   };
 });
 
+vi.mock("@/stats", () => ({
+  incrementStat: incrementStatMock,
+}));
+
 vi.mock("@/chat/mcp/client", () => {
   class MockMcpAuthorizationRequiredError extends Error {
     readonly provider: string;
@@ -632,6 +638,7 @@ describe("executeAgentRun progressive MCP loading", () => {
     searchMcpToolNames.length = 0;
     loadSkillExecutionErrorCount.value = 0;
     loadSkillsByNameMock.mockReset();
+    incrementStatMock.mockReset();
     pendingAuthRecords.length = 0;
     promptCallCount.value = 0;
     promptMessages.length = 0;
@@ -727,6 +734,11 @@ describe("executeAgentRun progressive MCP loading", () => {
       }),
     );
     expect(loadSkillExecutionErrorCount.value).toBe(0);
+    expect(incrementStatMock).toHaveBeenCalledWith({
+      namespace: "demo",
+      metric: "skill_load",
+      name: "demo-skill",
+    });
 
     const reply = finalReply(await executeAgentRun(context));
 

--- a/packages/junior/tests/integration/api/stats.test.ts
+++ b/packages/junior/tests/integration/api/stats.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { createJuniorApi } from "@/api";
+import { statsReportSchema } from "@/api/schema";
+import { migrateSchema } from "@/chat/conversations/sql/migrations";
+import { incrementStat } from "@/stats";
+import { createConfiguredJuniorSqlFixture } from "../../fixtures/sql";
+
+describe("stats API", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("increments and serves daily namespaced counters", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-28T12:00:00.000Z"));
+    const fixture = createConfiguredJuniorSqlFixture();
+    try {
+      await migrateSchema(fixture.sql);
+      await incrementStat({
+        namespace: "junior",
+        metric: "skill_load",
+        name: "junior-qa",
+      });
+      await incrementStat({
+        namespace: "junior",
+        metric: "skill_load",
+        name: "junior-qa",
+      });
+      await incrementStat(
+        {
+          namespace: "github",
+          metric: "skill_load",
+          name: "review-pr",
+        },
+        { nowMs: Date.parse("2026-07-27T23:00:00.000Z") },
+      );
+
+      const response = await createJuniorApi().request(
+        "http://localhost/api/stats",
+      );
+      expect(response.status).toBe(200);
+      const report = statsReportSchema.parse(await response.json());
+
+      expect(report).toMatchObject({
+        windowEnd: "2026-07-28",
+        windowStart: "2026-04-30",
+        stats: [
+          {
+            count: 1,
+            date: "2026-07-27",
+            metric: "skill_load",
+            name: "review-pr",
+            namespace: "github",
+          },
+          {
+            count: 2,
+            date: "2026-07-28",
+            metric: "skill_load",
+            name: "junior-qa",
+            namespace: "junior",
+          },
+        ],
+      });
+    } finally {
+      await fixture.close();
+    }
+  });
+});


### PR DESCRIPTION
Junior now records successful `loadSkill` calls as atomic daily counters keyed by date, namespace, metric, and name. Core skills use the `junior` namespace, plugin-owned skills use the plugin name, and `GET /api/stats` exposes the latest 90 days for future dashboard rendering.

The new counter write is explicitly best-effort so reporting failures cannot break skill loading. The migration, API boundary, atomic increment behavior, and plugin namespace are covered by focused integration and runtime tests.
