### PR TITLE
feat(github): link issues to conversations

### DIFF
--- a/packages/junior-dashboard/e2e/conversations.spec.ts
+++ b/packages/junior-dashboard/e2e/conversations.spec.ts
@@ -325,7 +325,7 @@ test("inspects and copies an advisor transcript", async ({ context, page }) => {
   ).toBeVisible();
   await expect(
     page.getByRole("link", {
-      name: "Open pull request getsentry/junior #1081: Show conversation pull requests",
+      name: "Open getsentry/junior#1081",
     }),
   ).toHaveAttribute("href", "https://github.com/getsentry/junior/pull/1081");
   const subagentRow = page

--- a/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
+++ b/packages/junior-dashboard/src/client/pages/ConversationPage.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
 import {
+  CircleDashed,
+  CircleDot,
+  CircleX,
   GitMerge,
-  GitPullRequest,
-  GitPullRequestClosed,
   TriangleAlert,
 } from "lucide-react";
 import { Link } from "react-router";
@@ -186,10 +187,7 @@ function ConversationAnnotations(props: {
   );
   if (!links?.length) return null;
   return (
-    <div className="border-t border-white/[0.07] pt-4 md:col-span-2">
-      <div className="mb-2 font-mono text-[0.62rem] uppercase tracking-[0.16em] text-cyan-200/65">
-        Pull requests
-      </div>
+    <div className="md:col-span-2">
       <div className="flex flex-wrap gap-2">
         {links.map((link) => (
           <a
@@ -199,7 +197,7 @@ function ConversationAnnotations(props: {
             rel="noreferrer"
             target="_blank"
           >
-            {link.status ? <PullRequestStatus status={link.status} /> : null}
+            {link.status ? <ResourceStatus status={link.status} /> : null}
             <span>{link.label}</span>
           </a>
         ))}
@@ -208,34 +206,34 @@ function ConversationAnnotations(props: {
   );
 }
 
-function PullRequestStatus(props: {
+function ResourceStatus(props: {
   status: "open" | "draft" | "closed" | "merged" | "warning";
 }) {
   const status = {
     open: {
       className: "text-[#3fb950]",
-      Icon: GitPullRequest,
-      label: "Open pull request",
+      Icon: CircleDot,
+      label: "Open",
     },
     draft: {
       className: "text-[#8c959f]",
-      Icon: GitPullRequest,
-      label: "Draft pull request",
+      Icon: CircleDashed,
+      label: "Draft",
     },
     closed: {
       className: "text-[#f85149]",
-      Icon: GitPullRequestClosed,
-      label: "Closed pull request",
+      Icon: CircleX,
+      label: "Closed",
     },
     merged: {
       className: "text-[#a371f7]",
       Icon: GitMerge,
-      label: "Merged pull request",
+      label: "Merged",
     },
     warning: {
       className: "text-[#d29922]",
       Icon: TriangleAlert,
-      label: "Pull request needs attention",
+      label: "Needs attention",
     },
   }[props.status];
 

--- a/packages/junior-dashboard/src/mock-reporting/fixtures.ts
+++ b/packages/junior-dashboard/src/mock-reporting/fixtures.ts
@@ -186,7 +186,7 @@ function dashboardQaConversation(nowMs: number): ConversationDetailReport {
       {
         kind: "resource_link",
         key: "getsentry/junior#1081",
-        label: "getsentry/junior #1081: Show conversation pull requests",
+        label: "getsentry/junior#1081",
         plugin: "github",
         status: "open",
         url: "https://github.com/getsentry/junior/pull/1081",

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -343,6 +343,35 @@ describe("dashboard canonical-event components", () => {
     expect(failedHtml).not.toContain(">error</span>");
   });
 
+  it("renders conversation resource links without pull request assumptions", () => {
+    const queryClient = conversationQueryClient();
+    queryClient.setQueryData(
+      conversationDetailQueryKey("conversation-1"),
+      conversation([], {
+        annotations: [
+          {
+            kind: "resource_link",
+            key: "getsentry/junior#1081",
+            label: "getsentry/junior#1081",
+            plugin: "github",
+            status: "open",
+            url: "https://github.com/getsentry/junior/issues/1081",
+            createdAt: "2026-01-01T00:00:00.000Z",
+            updatedAt: "2026-01-01T00:00:01.000Z",
+          },
+        ],
+      }),
+    );
+
+    const html = renderConversationPageWithClient(queryClient);
+
+    expect(html).toContain("getsentry/junior#1081");
+    expect(html).toContain('title="Open"');
+    expect(html).not.toContain("Linked resources");
+    expect(html).not.toContain("Pull requests");
+    expect(html).not.toContain("Open pull request");
+  });
+
   it("distinguishes initial detail failures from stale refresh failures", () => {
     const initialClient = conversationQueryClient();
     const initialError = new Error("initial detail failed");

--- a/packages/junior-github/src/tools/create-issue.ts
+++ b/packages/junior-github/src/tools/create-issue.ts
@@ -67,6 +67,7 @@ const createIssueStateSchema = Type.Union([
   Type.Object(
     {
       createdAtMs: Type.Number(),
+      input: Type.Optional(createIssueInputSchema),
       number: Type.Number(),
       status: Type.Literal("completed"),
       url: Type.String(),
@@ -76,6 +77,7 @@ const createIssueStateSchema = Type.Union([
   Type.Object(
     {
       createdAtMs: Type.Number(),
+      input: Type.Optional(createIssueInputSchema),
       status: Type.Literal("pending"),
     },
     { additionalProperties: false },
@@ -273,6 +275,21 @@ async function createGitHubIssue(
   };
 }
 
+async function annotateIssue(
+  ctx: ToolRegistrationHookContext,
+  input: CreateGitHubIssueInput,
+  result: GitHubIssueResult,
+): Promise<void> {
+  const repo = parseRepo(input.repo);
+  await ctx.annotations?.upsert({
+    kind: "resource_link",
+    key: `${repo.owner.toLowerCase()}/${repo.name.toLowerCase()}#${result.number}`,
+    label: `${repo.owner}/${repo.name}#${result.number}`,
+    url: result.url,
+    status: "open",
+  });
+}
+
 /** Own issue creation so provider writes use host egress and the footer stays deterministic. */
 export function createGitHubIssueTool(ctx: ToolRegistrationHookContext) {
   return definePluginTool({
@@ -297,10 +314,13 @@ export function createGitHubIssueTool(ctx: ToolRegistrationHookContext) {
         async () => {
           const state = createIssueState(await ctx.state.get(key));
           if (state?.status === "completed") {
-            return gitHubIssueToolResult({
+            const completedInput = state.input ?? parsedInput;
+            const completedResult = {
               number: state.number,
               url: state.url,
-            });
+            };
+            await annotateIssue(ctx, completedInput, completedResult);
+            return gitHubIssueToolResult(completedResult);
           }
           if (state?.status === "pending") {
             throw new Error(
@@ -315,6 +335,7 @@ export function createGitHubIssueTool(ctx: ToolRegistrationHookContext) {
           const pendingState: CreateIssueState = {
             status: "pending",
             createdAtMs: Date.now(),
+            input: parsedInput,
           };
           await ctx.state.set(
             key,
@@ -336,6 +357,7 @@ export function createGitHubIssueTool(ctx: ToolRegistrationHookContext) {
                 { cause: error },
               );
             }
+            await annotateIssue(ctx, parsedInput, result);
             return gitHubIssueToolResult(result);
           } catch (error) {
             if (

--- a/packages/junior-github/src/tools/create-pull-request.ts
+++ b/packages/junior-github/src/tools/create-pull-request.ts
@@ -17,7 +17,6 @@ import { gitHubPullRequestSubscribable } from "../resource-events/pull-request.j
 import { appendGitHubRequesterAttribution } from "../tool-support/attribution.js";
 const GITHUB_PULL_REQUEST_CREATE_IDEMPOTENCY_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const GITHUB_PULL_REQUEST_CREATE_LOCK_TTL_MS = 60_000;
-const RESOURCE_LINK_LABEL_MAX_LENGTH = 256;
 
 class GitHubPullRequestCreateRejectedError extends Error {
   status: number;
@@ -339,15 +338,10 @@ async function annotatePullRequest(
   result: GitHubPullRequestResult,
 ): Promise<void> {
   const repo = parseRepo(input.repo);
-  const label =
-    `${repo.owner}/${repo.name} #${result.number}: ${nonEmptyString(input.title, "title")}`.slice(
-      0,
-      RESOURCE_LINK_LABEL_MAX_LENGTH,
-    );
   await ctx.annotations?.upsert({
     kind: "resource_link",
     key: `${repo.owner.toLowerCase()}/${repo.name.toLowerCase()}#${result.number}`,
-    label,
+    label: `${repo.owner}/${repo.name}#${result.number}`,
     url: result.url,
     status: input.draft ? "draft" : "open",
   });

--- a/packages/junior-github/tests/github-plugin.test.ts
+++ b/packages/junior-github/tests/github-plugin.test.ts
@@ -702,6 +702,32 @@ describe("github plugin", () => {
       body: "Issue body\n\n<!-- junior-request-attribution:start -->\nRequested by **David Cramer** via Junior.\n<!-- junior-request-attribution:end -->",
       labels: ["bug", "high-priority"],
     });
+    expect(ctx.annotationInputs()).toEqual([
+      {
+        kind: "resource_link",
+        key: "getsentry/junior#660",
+        label: "getsentry/junior#660",
+        status: "open",
+        url: "https://github.com/getsentry/junior/issues/660",
+      },
+    ]);
+  });
+
+  it("keeps issue annotation labels compact for long titles", async () => {
+    const ctx = githubToolsContext();
+    const tool = githubPlugin().hooks?.tools?.(ctx as any)?.createIssue;
+
+    await expect(
+      tool?.execute?.(
+        {
+          repo: "getsentry/junior",
+          title: "x".repeat(256),
+        },
+        { toolCallId: "call-create-issue-long-title" },
+      ),
+    ).resolves.toMatchObject({ number: 660 });
+
+    expect(ctx.annotationInputs()[0]?.label).toBe("getsentry/junior#660");
   });
 
   it("adds a Sentry session link to issue footers when configured", async () => {
@@ -783,7 +809,14 @@ Conversation: \`local:test:old-conversation\`
       url: "https://github.com/getsentry/junior/issues/660",
     });
     await expect(
-      tool?.execute?.(input, { toolCallId: "call-idempotent-create" }),
+      tool?.execute?.(
+        {
+          ...input,
+          repo: "getsentry/other",
+          title: "Different issue",
+        },
+        { toolCallId: "call-idempotent-create" },
+      ),
     ).resolves.toMatchObject({
       ok: true,
       status: "success",
@@ -793,6 +826,22 @@ Conversation: \`local:test:old-conversation\`
     });
 
     expect(ctx.egressRequests()).toHaveLength(1);
+    expect(ctx.annotationInputs()).toEqual([
+      {
+        kind: "resource_link",
+        key: "getsentry/junior#660",
+        label: "getsentry/junior#660",
+        status: "open",
+        url: "https://github.com/getsentry/junior/issues/660",
+      },
+      {
+        kind: "resource_link",
+        key: "getsentry/junior#660",
+        label: "getsentry/junior#660",
+        status: "open",
+        url: "https://github.com/getsentry/junior/issues/660",
+      },
+    ]);
   });
 
   it("refuses to duplicate issue creation after an uncertain pending attempt", async () => {
@@ -1106,14 +1155,14 @@ Conversation: \`local:test:old-conversation\`
       {
         kind: "resource_link",
         key: "getsentry/junior#691",
-        label: "getsentry/junior #691: Typed PR",
+        label: "getsentry/junior#691",
         status: "draft",
         url: "https://github.com/getsentry/junior/pull/691",
       },
     ]);
   });
 
-  it("bounds pull request annotation labels for maximum-length titles", async () => {
+  it("keeps pull request annotation labels compact for long titles", async () => {
     const ctx = githubToolsContext({
       egressFetch: async () =>
         new Response(
@@ -1138,10 +1187,7 @@ Conversation: \`local:test:old-conversation\`
       ),
     ).resolves.toMatchObject({ number: 691 });
 
-    expect(ctx.annotationInputs()[0]?.label).toHaveLength(256);
-    expect(ctx.annotationInputs()[0]?.label).toMatch(
-      /^getsentry\/junior #691: x+$/,
-    );
+    expect(ctx.annotationInputs()[0]?.label).toBe("getsentry/junior#691");
   });
 
   it("omits pull request subscription hints when GitHub webhooks are not configured", async () => {


### PR DESCRIPTION
GitHub issue creation now adds the same conversation resource annotation as pull request creation. Issue and pull request links use the compact `owner/repo#number` label, while the dashboard renders them as generic resource links without pull-request-only wording or an extra section heading.

Retry handling preserves the original repository association, and focused GitHub and dashboard coverage protects creation, replay, accessibility, and the compact label format. Desktop and mobile visual QA confirmed the smaller layout.
