### PR TITLE
fix(dashboard): stringify tool argument strings

### DIFF
--- a/packages/junior-dashboard/src/client/components/toolCallPreview.ts
+++ b/packages/junior-dashboard/src/client/components/toolCallPreview.ts
@@ -63,7 +63,7 @@ function objectPreview(value: unknown): string | null {
 }
 
 function formatValue(value: unknown): string {
-  if (typeof value === "string") return value;
+  if (typeof value === "string") return JSON.stringify(value);
   return stringifyPartValue(value).replace(/\s+/g, " ").trim();
 }
 

--- a/packages/junior-dashboard/tests/telemetry-components.test.tsx
+++ b/packages/junior-dashboard/tests/telemetry-components.test.tsx
@@ -209,7 +209,9 @@ describe("dashboard canonical-event components", () => {
     );
 
     expect(html).toContain("webSearch");
-    expect(html).toContain("github_search, query: is:pr is:open, limit: 25");
+    expect(html).toContain(
+      "github_search, query: &quot;is:pr is:open&quot;, limit: 25",
+    );
     expect(html).toContain("jr-rpc config get github.repo");
     expect(html).toContain("junior-qa");
     expect(html).toContain('aria-label="Tool failed"');

--- a/packages/junior-dashboard/tests/toolCallPreview.test.ts
+++ b/packages/junior-dashboard/tests/toolCallPreview.test.ts
@@ -11,8 +11,18 @@ describe("toolCallPreview", () => {
         options: { archived: false },
       }),
     ).toBe(
-      'query: release regression, limit: 10, options: { "archived": false }',
+      'query: "release regression", limit: 10, options: { "archived": false }',
     );
+  });
+
+  it("JSON stringifies string argument values", () => {
+    expect(
+      toolCallPreview("searchTools", {
+        query: "",
+        source: "memory",
+        note: 'say "hello"',
+      }),
+    ).toBe('query: "", source: "memory", note: "say \\"hello\\""');
   });
 
   it("shows only the bash command", () => {
@@ -30,7 +40,7 @@ describe("toolCallPreview", () => {
         tool_name: "github_search",
         arguments: { query: "is:pr is:open", limit: 25 },
       }),
-    ).toBe("github_search, query: is:pr is:open, limit: 25");
+    ).toBe('github_search, query: "is:pr is:open", limit: 25');
   });
 
   it("shows only the skill name for loadSkill", () => {


### PR DESCRIPTION
Tool-call previews now JSON-encode string argument values, making empty strings visible and quoted or escaped content unambiguous. Specialized previews for Bash commands, skills, and dispatched tool names remain compact.

Focused preview and component rendering tests cover empty strings, escaped quotes, and nested `executeTool` arguments.
